### PR TITLE
Enhance usability for waitForElementToBePresent method

### DIFF
--- a/src/main/java/com/shaft/gui/element/ElementActions.java
+++ b/src/main/java/com/shaft/gui/element/ElementActions.java
@@ -598,6 +598,8 @@ public class ElementActions {
     }
 
     /**
+     * @deprecated use {@link #waitForElementToBeReady(WebDriver, By)} or {@link #waitForElementToBeInvisible(WebDriver, By)} instead.
+     *
      * Waits dynamically for a specific element to achieve the desired
      * stateOfPresence on the current page. Waits for a specific number of retries
      * multiplied by the default element identification timeout (in the POM.xml
@@ -617,25 +619,25 @@ public class ElementActions {
     }
 
     /**
-     * Waits dynamically for a specific element to be present on the current page.
+     * Waits dynamically for a specific element to be present in DOM, and ready to interact with, on the current page.
      *
      * @param driver          the current instance of Selenium webdriver
      * @param elementLocator  the locator of the webElement under test (By xpath,
      *                        id, selector, name ...etc)
      */
-    public static void waitForElementToBePresent(WebDriver driver, By elementLocator) {
-        waitForElementToBePresent(driver, elementLocator, 1, true);
+    public static void waitForElementToBeReady(WebDriver driver, By elementLocator) {
+        WebDriverElementActions.waitForElementToBePresent(driver, elementLocator, 1, true);
     }
 
     /**
-     * Waits dynamically for a specific element to be absent on the current page.
+     * Waits dynamically for a specific element to be detached from DOM, or hidden, on the current page.
      *
      * @param driver          the current instance of Selenium webdriver
      * @param elementLocator  the locator of the webElement under test (By xpath,
      *                        id, selector, name ...etc)
      */
-    public static void waitForElementToBeAbsent(WebDriver driver, By elementLocator) {
-        waitForElementToBePresent(driver, elementLocator, 1, false);
+    public static void waitForElementToBeInvisible(WebDriver driver, By elementLocator) {
+        WebDriverElementActions.waitForElementToBePresent(driver, elementLocator, 1, false);
     }
 
     public WebDriverElementActions performWebDriverElementAction() {
@@ -1047,6 +1049,8 @@ public class ElementActions {
     }
 
     /**
+     * @deprecated use {@link #waitToBeReady(By)} or {@link #waitToBeInvisible(By)} instead.
+     *
      * Waits dynamically for a specific element to achieve the desired
      * stateOfPresence on the current page. Waits for a specific number of retries
      * multiplied by the default element identification timeout (in the POM.xml
@@ -1060,6 +1064,7 @@ public class ElementActions {
      *                        is not present, and true is present
      * @return a self-reference to be used to chain actions
      */
+    @Deprecated
     public ElementActions waitForElementToBePresent(By elementLocator, int numberOfTries, boolean stateOfPresence) {
         waitForElementToBePresent(DriverFactoryHelper.getDriver().get(), elementLocator, numberOfTries,
                 stateOfPresence);
@@ -1067,26 +1072,26 @@ public class ElementActions {
     }
 
     /**
-     * Waits dynamically for a specific element to be present on the current page.
+     * Waits dynamically for a specific element to be present in DOM, and ready to interact with, on the current page.
      *
      * @param elementLocator  the locator of the webElement under test (By xpath,
      *                        id, selector, name ...etc)
      * @return a self-reference to be used to chain actions
      */
-    public ElementActions waitForElementToBePresent(By elementLocator) {
-        waitForElementToBePresent(DriverFactoryHelper.getDriver().get(), elementLocator, 1, true);
+    public ElementActions waitToBeReady(By elementLocator) {
+        WebDriverElementActions.waitForElementToBePresent(DriverFactoryHelper.getDriver().get(), elementLocator, 1, true);
         return this;
     }
 
     /**
-     * Waits dynamically for a specific element to be absent on the current page.
+     * Waits dynamically for a specific element to be detached from DOM, or hidden, on the current page.
      *
      * @param elementLocator  the locator of the webElement under test (By xpath,
      *                        id, selector, name ...etc)
      * @return a self-reference to be used to chain actions
      */
-    public ElementActions waitForElementToBeAbsent(By elementLocator) {
-        waitForElementToBePresent(DriverFactoryHelper.getDriver().get(), elementLocator, 1, false);
+    public ElementActions waitToBeInvisible(By elementLocator) {
+        WebDriverElementActions.waitForElementToBePresent(DriverFactoryHelper.getDriver().get(), elementLocator, 1, false);
         return this;
     }
 

--- a/src/main/java/com/shaft/gui/element/ElementActions.java
+++ b/src/main/java/com/shaft/gui/element/ElementActions.java
@@ -616,6 +616,28 @@ public class ElementActions {
         WebDriverElementActions.waitForElementToBePresent(driver, elementLocator, numberOfTries, stateOfPresence);
     }
 
+    /**
+     * Waits dynamically for a specific element to be present on the current page.
+     *
+     * @param driver          the current instance of Selenium webdriver
+     * @param elementLocator  the locator of the webElement under test (By xpath,
+     *                        id, selector, name ...etc)
+     */
+    public static void waitForElementToBePresent(WebDriver driver, By elementLocator) {
+        waitForElementToBePresent(driver, elementLocator, 1, true);
+    }
+
+    /**
+     * Waits dynamically for a specific element to be absent on the current page.
+     *
+     * @param driver          the current instance of Selenium webdriver
+     * @param elementLocator  the locator of the webElement under test (By xpath,
+     *                        id, selector, name ...etc)
+     */
+    public static void waitForElementToBeAbsent(WebDriver driver, By elementLocator) {
+        waitForElementToBePresent(driver, elementLocator, 1, false);
+    }
+
     public WebDriverElementActions performWebDriverElementAction() {
         return new WebDriverElementActions(DriverFactoryHelper.getDriver().get());
     }
@@ -1041,6 +1063,30 @@ public class ElementActions {
     public ElementActions waitForElementToBePresent(By elementLocator, int numberOfTries, boolean stateOfPresence) {
         waitForElementToBePresent(DriverFactoryHelper.getDriver().get(), elementLocator, numberOfTries,
                 stateOfPresence);
+        return this;
+    }
+
+    /**
+     * Waits dynamically for a specific element to be present on the current page.
+     *
+     * @param elementLocator  the locator of the webElement under test (By xpath,
+     *                        id, selector, name ...etc)
+     * @return a self-reference to be used to chain actions
+     */
+    public ElementActions waitForElementToBePresent(By elementLocator) {
+        waitForElementToBePresent(DriverFactoryHelper.getDriver().get(), elementLocator, 1, true);
+        return this;
+    }
+
+    /**
+     * Waits dynamically for a specific element to be absent on the current page.
+     *
+     * @param elementLocator  the locator of the webElement under test (By xpath,
+     *                        id, selector, name ...etc)
+     * @return a self-reference to be used to chain actions
+     */
+    public ElementActions waitForElementToBeAbsent(By elementLocator) {
+        waitForElementToBePresent(DriverFactoryHelper.getDriver().get(), elementLocator, 1, false);
         return this;
     }
 


### PR DESCRIPTION
Enhance usability for waitForElementToBePresent method by creating overloaded methods **waitForElementToBeReady**  & **waitForElementToBeInvisible** that support both static and wizard implementations.
Also deprecated the public waitForElementToBePresent method to use the new ones. 