### PR TITLE
Cover bearer token authorization on the XRay integration

### DIFF
--- a/src/main/java/com/shaft/tools/tms/XrayIntegrationHelper.java
+++ b/src/main/java/com/shaft/tools/tms/XrayIntegrationHelper.java
@@ -27,13 +27,15 @@ import static io.restassured.config.EncoderConfig.encoderConfig;
 
 public class XrayIntegrationHelper {
 
-    private static final String _JiraAuthorization =
-            Base64.getEncoder().encodeToString(System.getProperty("authorization").trim().getBytes());
+    private static String _JiraAuthorization =System.getProperty("authorization").trim();
+    private static final String authType= System.getProperty("authType").trim()+" ";
     private static final String _ProjectKey = System.getProperty("projectKey").trim();
     private static String _TestExecutionID = null;
 
     private static void setup() {
         baseURI = System.getProperty("jiraUrl");
+        if(authType.equals("Basic "))
+            _JiraAuthorization=Base64.getEncoder().encodeToString(_JiraAuthorization.getBytes());
         given()
                 .config(RestAssuredConfig.config().sslConfig(SSLConfig.sslConfig().allowAllHostnames()))
                 .relaxedHTTPSValidation();
@@ -58,7 +60,7 @@ public class XrayIntegrationHelper {
         try {
             Response response = given()
                     .contentType("application/json")
-                    .header("Authorization", "Basic " + _JiraAuthorization)
+                    .header("Authorization", authType + _JiraAuthorization)
                     .body(prettyJsonString)
                     .expect().statusCode(200)
                     .when()
@@ -91,7 +93,7 @@ public class XrayIntegrationHelper {
         try {
             given()
                     .contentType("application/json")
-                    .header("Authorization", "Basic " + _JiraAuthorization)
+                    .header("Authorization", authType + _JiraAuthorization)
                     .body(body)
                     .expect().statusCode(204)
                     .when()
@@ -116,7 +118,7 @@ public class XrayIntegrationHelper {
             Response response = given()
                     .config(config().encoderConfig(encoderConfig().encodeContentTypeAs("multipart/form-data", ContentType.TEXT)))
                     .relaxedHTTPSValidation().contentType("multipart/form-data")
-                    .header("Authorization", "Basic " + _JiraAuthorization)
+                    .header("Authorization", authType + _JiraAuthorization)
                     .multiPart(new File(reportPath))
                     .when()
                     .post("/rest/raven/1.0/import/execution/testng?projectKey=" + _ProjectKey)
@@ -144,7 +146,7 @@ public class XrayIntegrationHelper {
             Response response = given()
                     .config(config().encoderConfig(encoderConfig().encodeContentTypeAs("application/json", ContentType.JSON)))
                     .relaxedHTTPSValidation().contentType("application/json")
-                    .header("Authorization", "Basic " + _JiraAuthorization)
+                    .header("Authorization", authType + _JiraAuthorization)
                     .when()
                     .body(getCreateIssueRequestBody()
                             .replace("${PROJECT_KEY}", _ProjectKey)
@@ -181,7 +183,7 @@ public class XrayIntegrationHelper {
         try {
             RequestSpecification req = given()
                     .relaxedHTTPSValidation().contentType(ContentType.MULTIPART)
-                    .header("Authorization", "Basic " + _JiraAuthorization)
+                    .header("Authorization", authType + _JiraAuthorization)
                     .header("X-Atlassian-Token", "nocheck");
             for (String file : files)
                 req.multiPart("file", new File(file));
@@ -207,7 +209,7 @@ public class XrayIntegrationHelper {
             given()
                     .config(config().encoderConfig(encoderConfig().encodeContentTypeAs("application/json", ContentType.JSON)))
                     .relaxedHTTPSValidation().contentType("application/json")
-                    .header("Authorization", "Basic " + _JiraAuthorization)
+                    .header("Authorization", authType + _JiraAuthorization)
                     .when()
                     .body(getLinkJIRATicketRequestBody()
                             .replace("${TICKET_ID}", linkedToID)

--- a/src/main/javadoc/index.html
+++ b/src/main/javadoc/index.html
@@ -2349,6 +2349,27 @@
                                         </div>
                                     </div>
 
+                                    <div class="form-group">
+                                        <label class="col-md-4 control-label"
+                                               for="authType">Authorization Type:*</label>
+                                        <div class="col-md-4" id="authType">
+                                            <div class="radio-inline">
+                                                <label for="authType-0">
+                                                    <input id="authType-0"
+                                                           name="authType" type="radio"
+                                                           value="Basic"> Username and Password
+                                                </label>
+                                            </div>
+                                            <div class="radio-inline">
+                                                <label for="authType-1">
+                                                    <input  id="authType-1"
+                                                           name="authType"
+                                                           type="radio" value="Bearer"> Token
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div>
+
                                     <!-- Text input-->
                                     <div class="form-group">
                                         <label class="col-md-4 control-label" for="username">Authorized username:*
@@ -2363,13 +2384,25 @@
 
                                     <!-- Text input-->
                                     <div class="form-group">
-                                        <label class="col-md-4 control-label" for="password">Password/APIToken:*
+                                        <label class="col-md-4 control-label" for="password">Password:*
                                         </label>
                                         <div class="col-md-4">
                                             <input class="form-control input-md"
                                                    id="password"
                                                    name="password"
                                                    type="password">
+                                        </div>
+                                    </div>
+
+                                    <!-- Text input-->
+                                    <div class="form-group">
+                                        <label class="col-md-4 control-label" for="token">JIRA Token:*
+                                        </label>
+                                        <div class="col-md-4">
+                                            <input class="form-control input-md"
+                                                   id="token"
+                                                   name="token"
+                                                   type="token">
                                         </div>
                                     </div>
 
@@ -2866,6 +2899,20 @@ for (i = 0; i < close.length; i++) {
     });
 
 </script>
+<script type="text/javascript">
+    // XRay authorization setup
+    $("input[name=authType]").click(function () {
+        if ($("input[name=authType]:checked").val() == "Basic") {
+            $("#token").attr("disabled", true).val("");
+            $("#username").attr("disabled", false);
+            $("#password").attr("disabled", false);
+        } else {
+            $("#token").attr("disabled", false);
+            $("#username").attr("disabled", true).val("");
+            $("#password").attr("disabled", true).val("");
+        }
+    });
+</script>
 <script>
     function downloadFile(data, fileName) {
         data =
@@ -3139,7 +3186,7 @@ for (i = 0; i < close.length; i++) {
         const reportBugs = $("input[name=ReportBugs]:checked").val();
         const jiraUrl = 'https://'+$("input[name=jiraUrl]").val();
         const projectKey = $("input[name=projectKey]").val();
-        const authorization = $("input[name=username]").val()+':'+$("input[name=password]").val();
+        const authType = $("input[name=authType]:checked").val();
         const reportTestCasesExecution = $("input[name=reportTestCasesExecution]:checked").val();
         const reportPath = $("select[name=reportPath]").val();
         const ExecutionName = $("input[name=ExecutionName]").val();
@@ -3147,11 +3194,20 @@ for (i = 0; i < close.length; i++) {
         const ExecutionDescription = $("input[name=ExecutionDescription]").val();
         const allureLinkTmsPattern='https://'+ $("input[name=allureLinkTmsPattern]").val();
 
+
+        var authorization;
+        if ($("input[name=authType]:checked").val() == "Basic") {
+            authorization = $("input[name=username]").val()+':'+$("input[name=password]").val();
+        } else {
+            authorization = $("input[name=token]").val();
+        }
+
         // This variable stores all the data.
         let data =
             'jiraInteraction=' + jiraInteraction + '\r\n' +
             'jiraUrl=' + jiraUrl + '\r\n' +
             'projectKey=' + projectKey + '\r\n' +
+            'authType=' + authType + '\r\n' +
             'authorization=' + authorization + '\r\n' +
             'reportTestCasesExecution=' + reportTestCasesExecution + '\r\n' +
             'reportPath=' + reportPath + '\r\n' +


### PR DESCRIPTION
- Update the Xray helper class to handle _bearer token_ auth instead of supporting _Basic_ only.  
- Enhance the Xray tab on the configuration manager to cover the changes.