### PR TITLE
fixing issue with native app browserstack

### DIFF
--- a/src/main/java/com/shaft/api/BrowserStack.java
+++ b/src/main/java/com/shaft/api/BrowserStack.java
@@ -1,6 +1,7 @@
 package com.shaft.api;
 
 import com.shaft.cli.FileActions;
+import com.shaft.driver.SHAFT;
 import com.shaft.tools.io.ReportManager;
 import io.github.shafthq.shaft.tools.io.helpers.ReportManagerHelper;
 import org.openqa.selenium.MutableCapabilities;
@@ -125,10 +126,10 @@ public class BrowserStack {
     }
 
     private static MutableCapabilities setBrowserStackProperties(String username, String password, String deviceName, String osVersion, String appUrl) {
-        System.setProperty("executionAddress", username + ":" + password + "@" + hubUrl);
-        System.setProperty("mobile_deviceName", deviceName);
-        System.setProperty("mobile_platformVersion", osVersion);
-        System.setProperty("mobile_app", appUrl);
+        SHAFT.Properties.platform.set().executionAddress(username + ":" + password + "@" + hubUrl);
+        SHAFT.Properties.mobile.set().deviceName(deviceName);
+        SHAFT.Properties.mobile.set().platformVersion(osVersion);
+        SHAFT.Properties.mobile.set().app(appUrl);
         MutableCapabilities browserStackCapabilities = new MutableCapabilities();
         HashMap<String, Object> browserstackOptions = new HashMap<>();
         browserstackOptions.put("appiumVersion", System.getProperty("browserStack.appiumVersion"));

--- a/src/main/java/io/github/shafthq/shaft/driver/DriverFactoryHelper.java
+++ b/src/main/java/io/github/shafthq/shaft/driver/DriverFactoryHelper.java
@@ -57,7 +57,7 @@ public class DriverFactoryHelper {
     @Getter(AccessLevel.PUBLIC)
     private static String targetOperatingSystem;
     @Getter(AccessLevel.PUBLIC)
-    private static String targetBrowserName;
+    private static String targetBrowserName = "";
     @Getter(AccessLevel.PUBLIC)
     private static final ThreadLocal<WebDriver> driver = new ThreadLocal<>();
     private static final ThreadLocal<WebDriverManager> webDriverManager = new ThreadLocal<>();
@@ -556,7 +556,11 @@ public class DriverFactoryHelper {
             default ->
                     failAction("Unsupported Driver Type \"" + JavaHelper.convertToSentenceCase(driverType.getValue()) + "\".");
         }
-        ReportManager.log("Successfully Opened \"" + driverType.getValue() + "\".");
+        var driverName = driverType.getValue();
+        if (driverName.contains("MobileApp")) {
+            driverName = driverName.replace("Mobile", targetOperatingSystem);
+        }
+        ReportManager.log("Successfully Opened \"" + JavaHelper.convertToSentenceCase(driverName) + "\".");
     }
 
     private static Platform getDesiredOperatingSystem() {

--- a/src/main/java/io/github/shafthq/shaft/listeners/helpers/TestNGListenerHelper.java
+++ b/src/main/java/io/github/shafthq/shaft/listeners/helpers/TestNGListenerHelper.java
@@ -109,23 +109,25 @@ public class TestNGListenerHelper {
                     System.setProperty("screenshotParams_screenshotType", "Regular");
                 }
             });
-        } else {
-            //if not cross browser mode, still aff some properties as parameters to the test suites for better reporting
-            var parameters = new java.util.HashMap<>(Map.of(
-                    "executionAddress", Properties.platform.executionAddress(),
-                    "targetOperatingSystem", Properties.platform.targetOperatingSystem()
-            ));
+//        } else {
+            // IMPORTANT: the below code block introduced the following issue:
 
-            if (DriverFactoryHelper.isWebExecution()) {
-                parameters.put("targetBrowserName", Properties.web.targetBrowserName());
-            } else {
-                parameters.put("automationName", Properties.mobile.automationName());
-            }
-            suites.forEach(suite -> {
-                var params = suite.getParameters();
-                params.putAll(parameters);
-                suite.setParameters(params);
-            });
+            //if not cross browser mode, still add some properties as parameters to the test suites for better reporting
+//            var parameters = new java.util.HashMap<>(Map.of(
+//                    "executionAddress", Properties.platform.executionAddress(),
+//                    "targetOperatingSystem", Properties.platform.targetOperatingSystem()
+//            ));
+//
+//            if (DriverFactoryHelper.isWebExecution()) {
+//                parameters.put("targetBrowserName", Properties.web.targetBrowserName());
+//            } else {
+//                parameters.put("automationName", Properties.mobile.automationName());
+//            }
+//            suites.forEach(suite -> {
+//                var params = suite.getParameters();
+//                params.putAll(parameters);
+//                suite.setParameters(params);
+//            });
         }
     }
 


### PR DESCRIPTION
- upgrading browserstack class to use shaft properties manager
- initializing target browser name with empty string to avoid null exception (while attempting to get current element name for enhanced logging) closes #836
- enhancing log message to show successfully opened native android/ios app instead of the generic log message.
- commented cosmetic enhanced reporting feature which overrides certain properties. Closes #839

Signed-off-by: Mohab Mohie <Mohab.MohieElDeen@outlook.com>