### PR TITLE
Fix the issue of the report on mac Bug#858

### DIFF
--- a/src/main/java/io/github/shafthq/shaft/tools/io/helpers/ReportManagerHelper.java
+++ b/src/main/java/io/github/shafthq/shaft/tools/io/helpers/ReportManagerHelper.java
@@ -823,9 +823,9 @@ public class ReportManagerHelper {
         } else {
             // create Unix-based sh file
             commandsToServeAllureReport = Arrays
-                    .asList("#!/bin/bash", "parent_path=$( cd '$(dirname '${BASH_SOURCE[0]}')' ; pwd -P )",
+                    .asList("#!/bin/bash", "parent_path=$('$(dirname:- '${BASH_SOURCE[0]}')' ; pwd -P )",
                             "cd '" + allureExtractionLocation + "allure-" + allureVersion + "/bin/'",
-                            "bash allure serve '$parent_path/"
+                            "bash allure serve $parent_path'/"
                                     + allureResultsFolderPath.substring(0, allureResultsFolderPath.length() - 1) + "'",
                             "exit"
 

--- a/src/main/java/io/github/shafthq/shaft/tools/io/helpers/ReportManagerHelper.java
+++ b/src/main/java/io/github/shafthq/shaft/tools/io/helpers/ReportManagerHelper.java
@@ -823,7 +823,7 @@ public class ReportManagerHelper {
         } else {
             // create Unix-based sh file
             commandsToServeAllureReport = Arrays
-                    .asList("#!/bin/bash", "parent_path=$('$(dirname:- '${BASH_SOURCE[0]}')' ; pwd -P )",
+                    .asList("#!/bin/bash", "parent_path=$( cd \"$(dirname \"${BASH_SOURCE[0]}\")\" ; pwd -P )",
                             "cd '" + allureExtractionLocation + "allure-" + allureVersion + "/bin/'",
                             "bash allure serve $parent_path'/"
                                     + allureResultsFolderPath.substring(0, allureResultsFolderPath.length() - 1) + "'",


### PR DESCRIPTION
Fix the issue of the report on mac

There were actually two things :- 
1- First of all it was CD'ing to generate_allure_report.sh which is No such file or directory so I changed the '' to "" 
<img width="1472" alt="Screenshot 2023-02-13 at 10 50 44 PM" src="https://user-images.githubusercontent.com/38945724/218571738-0ed928cb-9918-49f5-8ea2-bcb9f0b70e0d.png">

After the Fix 

<img width="1459" alt="Screenshot 2023-02-13 at 10 51 33 PM" src="https://user-images.githubusercontent.com/38945724/218571895-fd767e54-8fda-4740-bd4a-c13fbdc7abe2.png">

2- The other thing and the one that caused the issue is $parent_path this variable was read as String so it couldn't be appended the variable value well
<img width="1511" alt="Screenshot 2023-02-13 at 10 22 16 PM" src="https://user-images.githubusercontent.com/38945724/218569008-5fd54bcb-419f-4e20-b77b-ad989622eb19.png">

And here is the generate_allure_report.sh After generation
<img width="534" alt="Screenshot 2023-02-13 at 10 57 49 PM" src="https://user-images.githubusercontent.com/38945724/218573001-530789f8-fb88-44b2-9abe-b24c5fd761e1.png">
