### PR TITLE
Migrate static methods to FluentElementActions & Handle scrollToElement exception on Firefox

### DIFF
--- a/src/main/java/io/github/shafthq/shaft/gui/element/ElementActionsHelper.java
+++ b/src/main/java/io/github/shafthq/shaft/gui/element/ElementActionsHelper.java
@@ -107,6 +107,10 @@ public class ElementActionsHelper {
         return DriverFactoryHelper.getTargetBrowserName().toLowerCase().contains("safari");
     }
 
+    private static boolean isFirefoxBrowser() {
+        return DriverFactoryHelper.getTargetBrowserName().toLowerCase().contains("firefox");
+    }
+
     public static ArrayList<Class<? extends Exception>> getExpectedExceptions(boolean isValidToCheckForVisibility) {
         ArrayList<Class<? extends Exception>> expectedExceptions = new ArrayList<>();
         expectedExceptions.add(org.openqa.selenium.NoSuchElementException.class);
@@ -140,7 +144,7 @@ public class ElementActionsHelper {
                         WebElement targetElement = nestedDriver.findElement(elementLocator);
                         if (isValidToCheckForVisibility) {
                             if (!isMobileExecution) {
-                                if (isSafariBrowser() || attemptedToUseActionsToScrollToElement.get()) {
+                                if (isSafariBrowser() || isFirefoxBrowser() || attemptedToUseActionsToScrollToElement.get()) {
                                     ((Locatable) targetElement).getCoordinates().inViewPort();
                                 } else {
                                     attemptedToUseActionsToScrollToElement.set(true);

--- a/src/main/java/io/github/shafthq/shaft/gui/element/FluentElementActions.java
+++ b/src/main/java/io/github/shafthq/shaft/gui/element/FluentElementActions.java
@@ -562,4 +562,29 @@ public class FluentElementActions {
         ElementActions.waitForTextToChange(DriverFactoryHelper.getDriver().get(), elementLocator, initialValue);
         return this;
     }
+
+    /**
+     * Checks to see if an element is displayed
+     *
+     * @param elementLocator the locator of the webElement under test (By xpath, id,
+     *                       selector, name ...etc)
+     * @return boolean value, true if the element is displayed, and false if the
+     * element is not displayed
+     */
+    public boolean isElementDisplayed(By elementLocator) {
+        return ElementActions.isElementDisplayed(DriverFactoryHelper.getDriver().get(), elementLocator);
+    }
+
+    /**
+     * Checks to see if an element is clickable
+     *
+     * @param elementLocator the locator of the webElement under test (By xpath, id,
+     *                       selector, name ...etc)
+     * @return boolean value, true if the element is clickable, and false if the
+     * element is not clickable
+     */
+    public boolean isElementClickable(By elementLocator) {
+        return ElementActions.isElementClickable(DriverFactoryHelper.getDriver().get(), elementLocator);
+    }
+
 }


### PR DESCRIPTION
- Add isElementDisplayed & isElementClickable to FluentElementActions
- Handle scrollToElement InvalidArgumentException exception on Firefox