### PR TITLE
fix issue with the least changes possible

### DIFF
--- a/src/main/java/com/shaft/driver/DriverFactory.java
+++ b/src/main/java/com/shaft/driver/DriverFactory.java
@@ -10,6 +10,7 @@ import io.github.shafthq.shaft.driver.helpers.DriverFactoryHelper;
 import io.github.shafthq.shaft.listeners.TestNGListener;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.Browser;
 import org.sikuli.script.App;
 
 public class DriverFactory {
@@ -183,8 +184,8 @@ public class DriverFactory {
      * List of the supported driver types for execution
      */
     public enum DriverType {
-        SIKULI("SikuliActions"), BROWSERSTACK("BrowserStack"), DATABASE("DatabaseActions"), TERMINAL("TerminalActions"), API("RestActions"), DESKTOP_FIREFOX("MozillaFirefox"), DESKTOP_CHROME("GoogleChrome"), DESKTOP_SAFARI("Safari"),
-        DESKTOP_INTERNET_EXPLORER("MicrosoftInternetExplorer"), DESKTOP_EDGE("MicrosoftEdge"), DESKTOP_CHROMIUM("Chromium"), DESKTOP_WEBKIT("Webkit"), APPIUM_CHROME("chrome"),
+        SIKULI("SikuliActions"), BROWSERSTACK("BrowserStack"), DATABASE("DatabaseActions"), TERMINAL("TerminalActions"), API("RestActions"), FIREFOX(Browser.FIREFOX.browserName()), CHROME(Browser.CHROME.browserName()), SAFARI(Browser.SAFARI.browserName()),
+        IE(Browser.IE.browserName()), EDGE(Browser.EDGE.browserName()), CHROMIUM("Chromium"), WEBKIT("Webkit"), APPIUM_CHROME("chrome"),
         APPIUM_CHROMIUM("Chromium"), APPIUM_BROWSER("Browser"), APPIUM_SAMSUNG_BROWSER("samsung"), APPIUM_MOBILE_NATIVE("NativeMobileApp");
 
         private final String value;

--- a/src/main/java/io/github/shafthq/shaft/driver/helpers/DriverFactoryHelper.java
+++ b/src/main/java/io/github/shafthq/shaft/driver/helpers/DriverFactoryHelper.java
@@ -31,6 +31,7 @@ import org.openqa.selenium.*;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.chromium.ChromiumOptions;
 import org.openqa.selenium.edge.EdgeOptions;
+import org.openqa.selenium.firefox.FirefoxDriverLogLevel;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.ie.InternetExplorerOptions;
@@ -162,12 +163,12 @@ public class DriverFactoryHelper {
     private static DriverType getDriverTypeFromName(String driverName) {
         int values = DriverType.values().length;
         for (var i = 0; i < values; i++) {
-            if (Arrays.asList(DriverType.values()).get(i).getValue().equalsIgnoreCase(driverName.trim())) {
+            if (driverName.trim().toLowerCase().contains(Arrays.asList(DriverType.values()).get(i).getValue().toLowerCase())) {
                 return Arrays.asList(DriverType.values()).get(i);
             }
         }
         failAction("Unsupported Driver Type \"" + driverName + "\".");
-        return DriverType.DESKTOP_CHROME;
+        return DriverType.CHROME;
     }
     private static void setDriverOptions(DriverType driverType, MutableCapabilities customDriverOptions) {
         String downloadsFolderPath = FileActions.getInstance().getAbsolutePath(System.getProperty("downloadsFolderPath"));
@@ -178,7 +179,7 @@ public class DriverFactoryHelper {
 
         //https://github.com/GoogleChrome/chrome-launcher/blob/master/docs/chrome-flags-for-tools.md#--enable-automation
         switch (driverType) {
-            case DESKTOP_FIREFOX -> {
+            case FIREFOX -> {
                 // https://wiki.mozilla.org/Firefox/CommandLineOptions
                 // https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities/firefoxOptions
                 ffOptions = new FirefoxOptions();
@@ -192,8 +193,8 @@ public class DriverFactoryHelper {
                 if (Boolean.TRUE.equals(HEADLESS_EXECUTION)) {
                     ffOptions.addArguments("-headless");
                 }
-                ffOptions.addArguments("-foreground");
-                ffOptions.setPageLoadStrategy(PageLoadStrategy.NORMAL);
+                ffOptions.setLogLevel(FirefoxDriverLogLevel.WARN);
+                ffOptions.setPageLoadStrategy(PageLoadStrategy.EAGER);
                 ffOptions.setPageLoadTimeout(Duration.ofSeconds(PAGE_LOAD_TIMEOUT));
                 ffOptions.setScriptTimeout(Duration.ofSeconds(SCRIPT_TIMEOUT));
                 //Add Proxy Setting if found
@@ -204,7 +205,7 @@ public class DriverFactoryHelper {
                     ffOptions.setProxy(proxy);
                 }
                 // Enable BiDi
-//                ffOptions.setCapability("webSocketUrl", true);
+                ffOptions.setCapability("webSocketUrl", true);
                 //merge customWebdriverCapabilities.properties
                 ffOptions = ffOptions.merge(PropertyFileManager.getCustomWebdriverDesiredCapabilities());
                 //merge hardcoded custom options
@@ -212,7 +213,7 @@ public class DriverFactoryHelper {
                     ffOptions = ffOptions.merge(customDriverOptions);
                 }
             }
-            case DESKTOP_INTERNET_EXPLORER -> {
+            case IE -> {
                 ieOptions = new InternetExplorerOptions();
                 ieOptions.setCapability(CapabilityType.PLATFORM_NAME, Properties.platform.targetPlatform());
                 ieOptions.setPageLoadStrategy(PageLoadStrategy.NORMAL);
@@ -232,14 +233,14 @@ public class DriverFactoryHelper {
                     ieOptions = ieOptions.merge(customDriverOptions);
                 }
             }
-            case DESKTOP_CHROME, DESKTOP_EDGE, DESKTOP_CHROMIUM -> {
-                if (driverType.equals(DriverType.DESKTOP_EDGE)) {
+            case CHROME, EDGE, CHROMIUM -> {
+                if (driverType.equals(DriverType.EDGE)) {
                     edOptions = (EdgeOptions) setupChromiumOptions(new EdgeOptions(), customDriverOptions);
                 } else {
                     chOptions = (ChromeOptions) setupChromiumOptions(new ChromeOptions(), customDriverOptions);
                 }
             }
-            case DESKTOP_SAFARI, DESKTOP_WEBKIT -> {
+            case SAFARI, WEBKIT -> {
                 sfOptions = new SafariOptions();
                 sfOptions.setCapability(CapabilityType.PLATFORM_NAME, Properties.platform.targetPlatform());
                 sfOptions.setCapability(CapabilityType.UNHANDLED_PROMPT_BEHAVIOUR, UnhandledPromptBehavior.ACCEPT_AND_NOTIFY);
@@ -404,27 +405,27 @@ public class DriverFactoryHelper {
 
         try {
             switch (driverType) {
-                case DESKTOP_FIREFOX -> {
+                case FIREFOX -> {
                     ReportManager.logDiscrete(WEBDRIVERMANAGER_MESSAGE);
 //                    driver.set(ThreadGuard.protect(WebDriverManager.firefoxdriver().proxy(proxy).capabilities(ffOptions).create()));
                     driver.set(WebDriverManager.firefoxdriver().proxy(proxy).capabilities(ffOptions).create());
                 }
-                case DESKTOP_INTERNET_EXPLORER -> {
+                case IE -> {
                     ReportManager.logDiscrete(WEBDRIVERMANAGER_MESSAGE);
 //                    driver.set(ThreadGuard.protect(WebDriverManager.iedriver().proxy(proxy).capabilities(ieOptions).create()));
                     driver.set(WebDriverManager.iedriver().proxy(proxy).capabilities(ieOptions).create());
                 }
-                case DESKTOP_CHROME -> {
+                case CHROME -> {
                     ReportManager.logDiscrete(WEBDRIVERMANAGER_MESSAGE);
 //                    driver.set(ThreadGuard.protect(WebDriverManager.chromedriver().proxy(proxy).capabilities(chOptions).create()));
                     driver.set(WebDriverManager.chromedriver().proxy(proxy).capabilities(chOptions).create());
                 }
-                case DESKTOP_EDGE -> {
+                case EDGE -> {
                     ReportManager.logDiscrete(WEBDRIVERMANAGER_MESSAGE);
 //                    driver.set(ThreadGuard.protect(WebDriverManager.edgedriver().proxy(proxy).capabilities(edOptions).create()));
                     driver.set(WebDriverManager.edgedriver().proxy(proxy).capabilities(edOptions).create());
                 }
-                case DESKTOP_SAFARI -> {
+                case SAFARI -> {
                     ReportManager.logDiscrete(WEBDRIVERMANAGER_MESSAGE);
 //                    driver.set(ThreadGuard.protect(WebDriverManager.safaridriver().proxy(proxy).capabilities(sfOptions).create()));
                     driver.set(WebDriverManager.safaridriver().proxy(proxy).capabilities(sfOptions).create());
@@ -448,22 +449,22 @@ public class DriverFactoryHelper {
 
         try {
             switch (driverType) {
-                case DESKTOP_FIREFOX -> {
+                case FIREFOX -> {
                     ReportManager.logDiscrete(ffOptions.toString());
                     ReportManager.logDiscrete(WEBDRIVERMANAGER_DOCKERIZED_MESSAGE);
                     webDriverManager.set(WebDriverManager.firefoxdriver().capabilities(ffOptions));
                 }
-                case DESKTOP_CHROME -> {
+                case CHROME -> {
                     ReportManager.logDiscrete(chOptions.toString());
                     ReportManager.logDiscrete(WEBDRIVERMANAGER_DOCKERIZED_MESSAGE);
                     webDriverManager.set(WebDriverManager.chromedriver().capabilities(chOptions));
                 }
-                case DESKTOP_EDGE -> {
+                case EDGE -> {
                     ReportManager.logDiscrete(edOptions.toString());
                     ReportManager.logDiscrete(WEBDRIVERMANAGER_DOCKERIZED_MESSAGE);
                     webDriverManager.set(WebDriverManager.edgedriver().capabilities(edOptions));
                 }
-                case DESKTOP_SAFARI -> {
+                case SAFARI -> {
                     ReportManager.logDiscrete(sfOptions.toString());
                     ReportManager.logDiscrete(WEBDRIVERMANAGER_DOCKERIZED_MESSAGE);
                     webDriverManager.set(WebDriverManager.safaridriver().capabilities(sfOptions));
@@ -661,11 +662,11 @@ public class DriverFactoryHelper {
 
     private static void configureRemoteDriverInstance(DriverType driverType, DesiredCapabilities appiumDesiredCapabilities) throws MalformedURLException {
         switch (driverType) {
-            case DESKTOP_FIREFOX -> setRemoteDriverInstance(ffOptions);
-            case DESKTOP_INTERNET_EXPLORER -> setRemoteDriverInstance(ieOptions);
-            case DESKTOP_CHROME, DESKTOP_CHROMIUM -> setRemoteDriverInstance(chOptions);
-            case DESKTOP_EDGE -> setRemoteDriverInstance(edOptions);
-            case DESKTOP_SAFARI, DESKTOP_WEBKIT -> {
+            case FIREFOX -> setRemoteDriverInstance(ffOptions);
+            case IE -> setRemoteDriverInstance(ieOptions);
+            case CHROME, CHROMIUM -> setRemoteDriverInstance(chOptions);
+            case EDGE -> setRemoteDriverInstance(edOptions);
+            case SAFARI, WEBKIT -> {
                 if (!Platform.ANDROID.toString().equalsIgnoreCase(SHAFT.Properties.platform.targetPlatform())
                         && !Platform.IOS.toString().equalsIgnoreCase(SHAFT.Properties.platform.targetPlatform())) {
                     setRemoteDriverInstance(sfOptions);
@@ -830,10 +831,11 @@ public class DriverFactoryHelper {
             }
 
             if (!isMobileExecution) {
+                var targetBrowserName = SHAFT.Properties.web.targetBrowserName().toLowerCase();
                 if (Boolean.TRUE.equals(AUTO_MAXIMIZE)
                         && (
-                        "Safari".equalsIgnoreCase(targetBrowserName) || "MozillaFirefox".equalsIgnoreCase(targetBrowserName)
-                )) {
+                        targetBrowserName.contains(Browser.SAFARI.browserName().toLowerCase())
+                                || targetBrowserName.contains(Browser.FIREFOX.browserName().toLowerCase()))) {
                     new BrowserActions().maximizeWindow();
                 }
             }

--- a/src/main/java/io/github/shafthq/shaft/driver/helpers/DriverFactoryHelper.java
+++ b/src/main/java/io/github/shafthq/shaft/driver/helpers/DriverFactoryHelper.java
@@ -207,7 +207,7 @@ public class DriverFactoryHelper {
                 // Enable BiDi
                 ffOptions.setCapability("webSocketUrl", true);
                 //merge customWebdriverCapabilities.properties
-                ffOptions = ffOptions.merge(PropertyFileManager.getCustomWebdriverDesiredCapabilities());
+                ffOptions = ffOptions.merge(PropertyFileManager.getCustomWebDriverDesiredCapabilities());
                 //merge hardcoded custom options
                 if (customDriverOptions != null) {
                     ffOptions = ffOptions.merge(customDriverOptions);
@@ -227,7 +227,7 @@ public class DriverFactoryHelper {
                     ieOptions.setProxy(proxy);
                 }
                 //merge customWebdriverCapabilities.properties
-                ieOptions = ieOptions.merge(PropertyFileManager.getCustomWebdriverDesiredCapabilities());
+                ieOptions = ieOptions.merge(PropertyFileManager.getCustomWebDriverDesiredCapabilities());
                 //merge hardcoded custom options
                 if (customDriverOptions != null) {
                     ieOptions = ieOptions.merge(customDriverOptions);
@@ -255,14 +255,14 @@ public class DriverFactoryHelper {
                     sfOptions.setProxy(proxy);
                 }
                 //merge customWebdriverCapabilities.properties
-                sfOptions = sfOptions.merge(PropertyFileManager.getCustomWebdriverDesiredCapabilities());
+                sfOptions = sfOptions.merge(PropertyFileManager.getCustomWebDriverDesiredCapabilities());
                 //merge hardcoded custom options
                 if (customDriverOptions != null) {
                     sfOptions = sfOptions.merge(customDriverOptions);
                 }
             }
             case APPIUM_MOBILE_NATIVE, APPIUM_SAMSUNG_BROWSER, APPIUM_CHROME, APPIUM_CHROMIUM ->
-                    appiumCapabilities = new DesiredCapabilities(PropertyFileManager.getCustomWebdriverDesiredCapabilities().merge(customDriverOptions));
+                    appiumCapabilities = new DesiredCapabilities(PropertyFileManager.getCustomWebDriverDesiredCapabilities().merge(customDriverOptions));
             default ->
                     failAction("Unsupported Driver Type \"" + JavaHelper.convertToSentenceCase(driverType.getValue()) + "\".");
         }
@@ -373,7 +373,7 @@ public class DriverFactoryHelper {
             options.setExperimentalOption("mobileEmulation", mobileEmulation);
         }
         //merge customWebdriverCapabilities.properties
-        options = (ChromiumOptions<?>) options.merge(PropertyFileManager.getCustomWebdriverDesiredCapabilities());
+        options = (ChromiumOptions<?>) options.merge(PropertyFileManager.getCustomWebDriverDesiredCapabilities());
         //merge hardcoded custom options
         if (customDriverOptions != null) {
             options = (ChromiumOptions<?>) options.merge(customDriverOptions);

--- a/src/main/java/io/github/shafthq/shaft/properties/PropertyFileManager.java
+++ b/src/main/java/io/github/shafthq/shaft/properties/PropertyFileManager.java
@@ -187,7 +187,8 @@ public class PropertyFileManager {
                 System.setProperty("debugMode", String.valueOf(false));
                 System.setProperty("captureClickedElementText", String.valueOf(false));
                 System.setProperty("headlessExecution", String.valueOf(false));
-                if (maximumPerformanceMode.equals("2") && !DriverFactory.DriverType.DESKTOP_SAFARI.getValue().equals(System.getProperty("targetBrowserName"))) System.setProperty("headlessExecution", String.valueOf(true));
+                if (maximumPerformanceMode.equals("2") && !DriverFactory.DriverType.SAFARI.getValue().equals(SHAFT.Properties.web.targetBrowserName()))
+                    System.setProperty("headlessExecution", String.valueOf(true));
             }
             case "false", "0" -> {
             }

--- a/src/main/java/io/github/shafthq/shaft/properties/PropertyFileManager.java
+++ b/src/main/java/io/github/shafthq/shaft/properties/PropertyFileManager.java
@@ -169,8 +169,8 @@ public final class PropertyFileManager {
      */
     private static void manageMaximumPerformanceMode() {
         String maximumPerformanceMode = System.getProperty("maximumPerformanceMode");
-        switch (maximumPerformanceMode) {
-            case "true", "1", "2" -> {
+        /*~~(null)~~>*/switch (maximumPerformanceMode) {
+            /*~~(null)~~>*/case "true":, "1", "2" -> {
                 System.setProperty("aiPoweredSelfHealingElementIdentification", String.valueOf(false));
                 System.setProperty("autoMaximizeBrowserWindow", String.valueOf(true));
                 System.setProperty("screenshotParams_whenToTakeAScreenshot", "ValidationPointsOnly");
@@ -187,7 +187,7 @@ public final class PropertyFileManager {
                     System.setProperty("headlessExecution", String.valueOf(true));
                 }
             }
-            case "false", "0" -> {
+            case "false":, "0" -> {
                 // do nothing
             }
         }

--- a/src/main/java/io/github/shafthq/shaft/properties/PropertyFileManager.java
+++ b/src/main/java/io/github/shafthq/shaft/properties/PropertyFileManager.java
@@ -169,8 +169,8 @@ public final class PropertyFileManager {
      */
     private static void manageMaximumPerformanceMode() {
         String maximumPerformanceMode = System.getProperty("maximumPerformanceMode");
-        /*~~(null)~~>*/switch (maximumPerformanceMode) {
-            /*~~(null)~~>*/case "true":, "1", "2" -> {
+        switch (maximumPerformanceMode) {
+            case "true", "1", "2" -> {
                 System.setProperty("aiPoweredSelfHealingElementIdentification", String.valueOf(false));
                 System.setProperty("autoMaximizeBrowserWindow", String.valueOf(true));
                 System.setProperty("screenshotParams_whenToTakeAScreenshot", "ValidationPointsOnly");
@@ -187,7 +187,7 @@ public final class PropertyFileManager {
                     System.setProperty("headlessExecution", String.valueOf(true));
                 }
             }
-            case "false":, "0" -> {
+            case "false", "0" -> {
                 // do nothing
             }
         }

--- a/src/main/java/io/github/shafthq/shaft/properties/PropertyFileManager.java
+++ b/src/main/java/io/github/shafthq/shaft/properties/PropertyFileManager.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-public class PropertyFileManager {
+public final class PropertyFileManager {
     //    private static final String OS_WINDOWS = "Windows";
 //    private static final String OS_LINUX = "Linux";
 //    private static final String OS_MAC = "Mac";
@@ -56,7 +56,7 @@ public class PropertyFileManager {
                 String propertyKey = ((String) (props.keySet().toArray())[i]).trim();
                 if (propertyKey.contains(CUSTOM_PROPERTIES_FOLDER_PROPERTY_NAME)
                         && !propertyKey.equals(CUSTOM_PROPERTIES_FOLDER_PROPERTY_NAME)
-                        && !props.getProperty(propertyKey).trim().equals("")) {
+                        && !"".equals(props.getProperty(propertyKey).trim())) {
                     readPropertyFiles(props.getProperty(propertyKey));
                 }
             }
@@ -173,8 +173,8 @@ public class PropertyFileManager {
      */
     private static void manageMaximumPerformanceMode() {
         String maximumPerformanceMode = System.getProperty("maximumPerformanceMode");
-        switch (maximumPerformanceMode) {
-            case "true", "1", "2" -> {
+        /*~~(null)~~>*/switch (maximumPerformanceMode) {
+            case "true":, "1", "2" -> {
                 System.setProperty("aiPoweredSelfHealingElementIdentification", String.valueOf(false));
                 System.setProperty("autoMaximizeBrowserWindow", String.valueOf(true));
                 System.setProperty("screenshotParams_whenToTakeAScreenshot", "ValidationPointsOnly");
@@ -187,10 +187,11 @@ public class PropertyFileManager {
                 System.setProperty("debugMode", String.valueOf(false));
                 System.setProperty("captureClickedElementText", String.valueOf(false));
                 System.setProperty("headlessExecution", String.valueOf(false));
-                if (maximumPerformanceMode.equals("2") && !DriverFactory.DriverType.SAFARI.getValue().equals(SHAFT.Properties.web.targetBrowserName()))
+                if ("2".equals(maximumPerformanceMode) && !DriverFactory.DriverType.SAFARI.getValue().equals(SHAFT.Properties.web.targetBrowserName())) {
                     System.setProperty("headlessExecution", String.valueOf(true));
+                }break;
             }
-            case "false", "0" -> {
+            case "false":, "0" -> {
             }
         }
     }

--- a/src/main/java/io/github/shafthq/shaft/properties/PropertyFileManager.java
+++ b/src/main/java/io/github/shafthq/shaft/properties/PropertyFileManager.java
@@ -8,9 +8,7 @@ import io.github.shafthq.shaft.enums.Browsers;
 import io.github.shafthq.shaft.tools.io.helpers.ReportManagerHelper;
 import lombok.Getter;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.SystemUtils;
 import org.openqa.selenium.MutableCapabilities;
-import org.openqa.selenium.Platform;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -22,9 +20,7 @@ import java.util.Map;
 import java.util.Objects;
 
 public final class PropertyFileManager {
-    //    private static final String OS_WINDOWS = "Windows";
-//    private static final String OS_LINUX = "Linux";
-//    private static final String OS_MAC = "Mac";
+
     private static final String DEFAULT_PROPERTIES_FOLDER_PATH = "src/main/resources/properties/default";
     @Getter
     private static final String CUSTOM_PROPERTIES_FOLDER_PATH = "src/main/resources/properties";
@@ -98,7 +94,7 @@ public final class PropertyFileManager {
         return appiumDesiredCapabilities;
     }
 
-    public static MutableCapabilities getCustomWebdriverDesiredCapabilities() {
+    public static MutableCapabilities getCustomWebDriverDesiredCapabilities() {
         MutableCapabilities customDriverOptions = new MutableCapabilities();
         java.util.Properties props = System.getProperties();
         props.forEach((key, value) -> {
@@ -173,8 +169,8 @@ public final class PropertyFileManager {
      */
     private static void manageMaximumPerformanceMode() {
         String maximumPerformanceMode = System.getProperty("maximumPerformanceMode");
-        /*~~(null)~~>*/switch (maximumPerformanceMode) {
-            case "true":, "1", "2" -> {
+        switch (maximumPerformanceMode) {
+            case "true", "1", "2" -> {
                 System.setProperty("aiPoweredSelfHealingElementIdentification", String.valueOf(false));
                 System.setProperty("autoMaximizeBrowserWindow", String.valueOf(true));
                 System.setProperty("screenshotParams_whenToTakeAScreenshot", "ValidationPointsOnly");
@@ -189,9 +185,10 @@ public final class PropertyFileManager {
                 System.setProperty("headlessExecution", String.valueOf(false));
                 if ("2".equals(maximumPerformanceMode) && !DriverFactory.DriverType.SAFARI.getValue().equals(SHAFT.Properties.web.targetBrowserName())) {
                     System.setProperty("headlessExecution", String.valueOf(true));
-                }break;
+                }
             }
-            case "false":, "0" -> {
+            case "false", "0" -> {
+                // do nothing
             }
         }
     }
@@ -206,18 +203,6 @@ public final class PropertyFileManager {
             // reset system properties
         } catch (IOException e) {
             ReportManagerHelper.logDiscrete(e);
-        }
-    }
-
-    private static void overrideTargetOperatingSystemForLocalExecution() {
-        if ("local".equals(SHAFT.Properties.platform.executionAddress())) {
-            if (SystemUtils.IS_OS_WINDOWS) {
-                SHAFT.Properties.platform.set().targetPlatform(Platform.WINDOWS.toString());
-            } else if (SystemUtils.IS_OS_LINUX) {
-                SHAFT.Properties.platform.set().targetPlatform(Platform.LINUX.toString());
-            } else if (SystemUtils.IS_OS_MAC) {
-                SHAFT.Properties.platform.set().targetPlatform(Platform.MAC.toString());
-            }
         }
     }
 }

--- a/src/test/java/testPackage/Test_hover.java
+++ b/src/test/java/testPackage/Test_hover.java
@@ -1,7 +1,6 @@
 package testPackage;
 
 import com.shaft.driver.DriverFactory;
-import com.shaft.driver.DriverFactory.DriverType;
 import com.shaft.gui.browser.BrowserActions;
 import com.shaft.gui.element.ElementActions;
 import org.openqa.selenium.By;
@@ -22,7 +21,7 @@ public class Test_hover {
 
     @BeforeClass // Set-up method, to be run once before the first test
     public void beforeClass() {
-        driver = DriverFactory.getDriver(DriverType.DESKTOP_CHROME);
+        driver = DriverFactory.getDriver();
     }
 
     @AfterClass

--- a/src/test/java/testPackage/Test_hover.java
+++ b/src/test/java/testPackage/Test_hover.java
@@ -1,4 +1,4 @@
-package testPackage;
+package testpackage;
 
 import com.shaft.driver.DriverFactory;
 import com.shaft.gui.browser.BrowserActions;


### PR DESCRIPTION
- migrate to standard browser naming for firefox, chrome, safari, ie, and edge
- remove unsupported argument "-foreground" for firefox
- enable BiDi use with firefox
- fix auto-maximize condition to work for both Browser.FIREFOX.getName(); and "MozillaFirefox"