### PR TITLE
Fix the issue of GIF on firefox

### DIFF
--- a/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -143,14 +143,8 @@ public class BrowserActions extends FluentBrowserActions {
      */
     @Deprecated
     public static String getWindowHeight(WebDriver driver) {
-        var windowSize = "";
-        try {
-            windowSize = String.valueOf(driver.manage().window().getSize().getHeight());
-            passAction(driver, windowSize);
-        } catch (Exception rootCauseException) {
-            failAction(driver, windowSize, rootCauseException);
-        }
-        return windowSize;
+        return FluentBrowserActions.getInstance().getWindowHeight();
+
     }
     /**
      * Gets the current window size and returns it as a string
@@ -160,24 +154,17 @@ public class BrowserActions extends FluentBrowserActions {
      */
     @Deprecated
     public static String getWindowWidth(WebDriver driver) {
-        var windowSize = "";
-        try {
-            windowSize = String.valueOf(driver.manage().window().getSize().getWidth());
-            passAction(driver, windowSize);
-        } catch (Exception rootCauseException) {
-            failAction(driver, windowSize, rootCauseException);
-        }
-        return windowSize;
+        return FluentBrowserActions.getInstance().getWindowWidth();
     }
 
-    /**
-     * Navigates to targetUrl in case the current URL is different, else refreshes
-     * the current page
-     *
-     * @param driver    the current instance of Selenium WebDriver
-     * @param targetUrl a string that represents the URL that you wish to navigate
-     *                  to
-     */
+        /**
+         * Navigates to targetUrl in case the current URL is different, else refreshes
+         * the current page
+         *
+         * @param driver    the current instance of Selenium WebDriver
+         * @param targetUrl a string that represents the URL that you wish to navigate
+         *                  to
+         */
     @Deprecated
     public static void navigateToURL(WebDriver driver, String targetUrl) {
         FluentBrowserActions.getInstance().navigateToURL(targetUrl);

--- a/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -135,6 +135,40 @@ public class BrowserActions extends FluentBrowserActions {
     public static String getWindowSize(WebDriver driver) {
         return FluentBrowserActions.getInstance().getWindowSize();
     }
+    /**
+     * Gets the current window size and returns it as a string
+     *
+     * @param driver the current instance of Selenium WebDriver
+     * @return the Height of the current window
+     */
+    @Deprecated
+    public static String getWindowHeight(WebDriver driver) {
+        var windowSize = "";
+        try {
+            windowSize = String.valueOf(driver.manage().window().getSize().getHeight());
+            passAction(driver, windowSize);
+        } catch (Exception rootCauseException) {
+            failAction(driver, windowSize, rootCauseException);
+        }
+        return windowSize;
+    }
+    /**
+     * Gets the current window size and returns it as a string
+     *
+     * @param driver the current instance of Selenium WebDriver
+     * @return the Width of the current window
+     */
+    @Deprecated
+    public static String getWindowWidth(WebDriver driver) {
+        var windowSize = "";
+        try {
+            windowSize = String.valueOf(driver.manage().window().getSize().getWidth());
+            passAction(driver, windowSize);
+        } catch (Exception rootCauseException) {
+            failAction(driver, windowSize, rootCauseException);
+        }
+        return windowSize;
+    }
 
     /**
      * Navigates to targetUrl in case the current URL is different, else refreshes

--- a/src/main/java/io/github/shafthq/shaft/gui/browser/BrowserActionsHelpers.java
+++ b/src/main/java/io/github/shafthq/shaft/gui/browser/BrowserActionsHelpers.java
@@ -98,8 +98,6 @@ public class BrowserActionsHelpers {
         message = message + ".";
 
         message = message.replace("Browser Action: ", "");
-        if (Properties.web.targetBrowserName().equals("MozillaFirefox")){
-        }else {
         if (driver != null && !message.equals("Capture page snapshot.")) {
             attachments.add(ScreenshotManager.captureScreenShot(driver, actionName, passFailStatus));
             ReportManagerHelper.log(message, attachments);
@@ -107,7 +105,6 @@ public class BrowserActionsHelpers {
             ReportManagerHelper.log(message, attachments);
         } else {
             ReportManager.log(message);
-        }
         }
         return message;
     }

--- a/src/main/java/io/github/shafthq/shaft/gui/browser/BrowserActionsHelpers.java
+++ b/src/main/java/io/github/shafthq/shaft/gui/browser/BrowserActionsHelpers.java
@@ -4,7 +4,6 @@ import com.google.common.net.InternetDomainName;
 import com.shaft.driver.SHAFT;
 import com.shaft.tools.io.ReportManager;
 import io.github.shafthq.shaft.gui.image.ScreenshotManager;
-import io.github.shafthq.shaft.properties.Properties;
 import io.github.shafthq.shaft.tools.io.ReportManagerHelper;
 import io.github.shafthq.shaft.tools.support.JavaHelper;
 import io.github.shafthq.shaft.tools.support.JavaScriptHelper;

--- a/src/main/java/io/github/shafthq/shaft/gui/browser/BrowserActionsHelpers.java
+++ b/src/main/java/io/github/shafthq/shaft/gui/browser/BrowserActionsHelpers.java
@@ -4,6 +4,7 @@ import com.google.common.net.InternetDomainName;
 import com.shaft.driver.SHAFT;
 import com.shaft.tools.io.ReportManager;
 import io.github.shafthq.shaft.gui.image.ScreenshotManager;
+import io.github.shafthq.shaft.properties.Properties;
 import io.github.shafthq.shaft.tools.io.ReportManagerHelper;
 import io.github.shafthq.shaft.tools.support.JavaHelper;
 import io.github.shafthq.shaft.tools.support.JavaScriptHelper;
@@ -97,6 +98,8 @@ public class BrowserActionsHelpers {
         message = message + ".";
 
         message = message.replace("Browser Action: ", "");
+        if (Properties.web.targetBrowserName().equals("MozillaFirefox")){
+        }else {
         if (driver != null && !message.equals("Capture page snapshot.")) {
             attachments.add(ScreenshotManager.captureScreenShot(driver, actionName, passFailStatus));
             ReportManagerHelper.log(message, attachments);
@@ -104,6 +107,7 @@ public class BrowserActionsHelpers {
             ReportManagerHelper.log(message, attachments);
         } else {
             ReportManager.log(message);
+        }
         }
         return message;
     }

--- a/src/main/java/io/github/shafthq/shaft/gui/browser/FluentBrowserActions.java
+++ b/src/main/java/io/github/shafthq/shaft/gui/browser/FluentBrowserActions.java
@@ -191,6 +191,24 @@ public class FluentBrowserActions {
     }
 
     /**
+     * Gets the current window size and returns it as a string
+     *
+     * @return the height of the current window
+     */
+    public String getWindowHeight() {
+        return BrowserActions.getWindowHeight(DriverFactoryHelper.getDriver().get());
+    }
+
+    /**
+     * Gets the current window size and returns it as a string
+     *
+     * @return the height of the current window
+     */
+    public String getWindowWidth() {
+        return BrowserActions.getWindowWidth(DriverFactoryHelper.getDriver().get());
+    }
+
+    /**
      * Navigates to targetUrl in case the current URL is different, else refreshes
      * the current page
      *

--- a/src/main/java/io/github/shafthq/shaft/gui/browser/FluentBrowserActions.java
+++ b/src/main/java/io/github/shafthq/shaft/gui/browser/FluentBrowserActions.java
@@ -196,16 +196,30 @@ public class FluentBrowserActions {
      * @return the height of the current window
      */
     public String getWindowHeight() {
-        return BrowserActions.getWindowHeight(DriverFactoryHelper.getDriver().get());
+        var windowHeight = "";
+        try {
+            windowHeight = String.valueOf(DriverFactoryHelper.getDriver().get().manage().window().getSize().getHeight());
+            passAction(DriverFactoryHelper.getDriver().get(), windowHeight);
+        } catch (Exception rootCauseException) {
+            failAction(DriverFactoryHelper.getDriver().get(), windowHeight, rootCauseException);
+        }
+        return windowHeight;
     }
 
     /**
      * Gets the current window size and returns it as a string
      *
-     * @return the height of the current window
+     * @return the width of the current window
      */
     public String getWindowWidth() {
-        return BrowserActions.getWindowWidth(DriverFactoryHelper.getDriver().get());
+        var windowWidth = "";
+        try {
+            windowWidth = String.valueOf(DriverFactoryHelper.getDriver().get().manage().window().getSize().getWidth());
+            passAction(DriverFactoryHelper.getDriver().get(), windowWidth);
+        } catch (Exception rootCauseException) {
+            failAction(DriverFactoryHelper.getDriver().get(), windowWidth, rootCauseException);
+        }
+        return windowWidth;
     }
 
     /**

--- a/src/main/java/io/github/shafthq/shaft/gui/image/ScreenshotManager.java
+++ b/src/main/java/io/github/shafthq/shaft/gui/image/ScreenshotManager.java
@@ -2,6 +2,7 @@ package io.github.shafthq.shaft.gui.image;
 
 import com.epam.healenium.SelfHealingDriver;
 import com.shaft.cli.FileActions;
+import com.shaft.gui.browser.BrowserActions;
 import com.shaft.tools.io.ReportManager;
 import io.github.shafthq.shaft.driver.DriverFactoryHelper;
 import io.github.shafthq.shaft.enums.Screenshots;
@@ -10,6 +11,7 @@ import io.github.shafthq.shaft.gui.element.ElementActionsHelper;
 import io.github.shafthq.shaft.properties.Properties;
 import io.github.shafthq.shaft.properties.PropertyFileManager;
 import io.github.shafthq.shaft.tools.io.ReportManagerHelper;
+import io.github.shafthq.shaft.gui.browser.FluentBrowserActions;
 import org.imgscalr.Scalr;
 import org.opencv.core.Mat;
 import org.opencv.core.MatOfByte;
@@ -562,6 +564,10 @@ public class ScreenshotManager {
                         + testCaseName + ".gif";
                 gifRelativePathWithFileName = SCREENSHOT_FOLDER_PATH + SCREENSHOT_FOLDER_NAME + gifFileName;
 
+                // get the width and height of the current window of the browser
+                var height = Integer.valueOf(new BrowserActions().getWindowHeight());
+                var width = Integer.valueOf(new BrowserActions().getWindowWidth());
+
                 // grab the output image type from the first image in the sequence
                 BufferedImage firstImage = ImageIO.read(new ByteArrayInputStream(screenshot));
 
@@ -578,11 +584,10 @@ public class ScreenshotManager {
                         new AnimatedGifManager(gifOutputStream.get(), firstImage.getType(), GIF_FRAME_DELAY));
 
                 // draw initial blank image to set the size of the GIF...
-                BufferedImage initialImage = new BufferedImage(firstImage.getWidth(), firstImage.getHeight(),
-                        firstImage.getType());
+                BufferedImage initialImage = new BufferedImage(width, height,firstImage.getType());
                 Graphics2D initialImageGraphics = initialImage.createGraphics();
                 initialImageGraphics.setBackground(Color.WHITE);
-                initialImageGraphics.clearRect(0, 0, firstImage.getWidth(), firstImage.getHeight());
+                initialImageGraphics.clearRect(0, 0, width, height);
 
                 // write out initialImage to the sequence...
                 gifWriter.get().writeToSequence(overlayShaftEngineLogo(initialImage));

--- a/src/main/java/io/github/shafthq/shaft/gui/image/ScreenshotManager.java
+++ b/src/main/java/io/github/shafthq/shaft/gui/image/ScreenshotManager.java
@@ -11,7 +11,6 @@ import io.github.shafthq.shaft.gui.element.ElementActionsHelper;
 import io.github.shafthq.shaft.properties.Properties;
 import io.github.shafthq.shaft.properties.PropertyFileManager;
 import io.github.shafthq.shaft.tools.io.ReportManagerHelper;
-import io.github.shafthq.shaft.gui.browser.FluentBrowserActions;
 import org.imgscalr.Scalr;
 import org.opencv.core.Mat;
 import org.opencv.core.MatOfByte;


### PR DESCRIPTION
So Basically the issue is on MozillaFirefox specifically , the issue was regarding the height of captured firstImage screenshot 
for some reason - may be update from firefox , I didn't try it on previous versions - after navigation and on pass action method while capturing the first screenshot 
the height appears :- (16) and after scaling (7) then appear at Allure report as described below 
<img width="1512" alt="Screenshot 2023-03-11 at 3 19 10 PM" src="https://user-images.githubusercontent.com/38945724/224487753-0f5ff501-1264-4a74-ad00-a86b68643067.png">
<img width="1512" alt="Screenshot 2023-03-11 at 3 19 28 PM" src="https://user-images.githubusercontent.com/38945724/224487760-07964acc-1708-49e3-8128-dcc73e71bf1c.png">
<img width="1512" alt="Screenshot 2023-03-11 at 3 20 00 PM" src="https://user-images.githubusercontent.com/38945724/224487763-ee9890e6-bdbd-4623-ba6a-85bcee3a5482.png">
<img width="1512" alt="Screenshot 2023-03-11 at 3 20 07 PM" src="https://user-images.githubusercontent.com/38945724/224487771-cee644ea-64ad-4649-b3a8-87a5aeceb3a3.png">


So I first fixed it by setting the height from ScreenShotManager method but I didn't like the fix 
so what I did is I escaped the first screenshot to be taken after the first element action not after the redirection and that fixed the issue as described --> Height at firstImage --> 1560 and after scaling --> 660 then appear at Allure report as described below  
<img width="1512" alt="Screenshot 2023-03-11 at 3 25 28 PM" src="https://user-images.githubusercontent.com/38945724/224487897-5db3debb-bec5-4b18-b939-c5f995428797.png">
<img width="1512" alt="Screenshot 2023-03-11 at 3 25 36 PM" src="https://user-images.githubusercontent.com/38945724/224487905-bddb187a-fadc-4c18-ba00-c9ec5fc23832.png">
<img width="1512" alt="Screenshot 2023-03-11 at 3 27 40 PM" src="https://user-images.githubusercontent.com/38945724/224487927-dd4ed2c4-df86-495d-9f5a-0a57dc9198b5.png">
<img width="1512" alt="Screenshot 2023-03-11 at 3 27 31 PM" src="https://user-images.githubusercontent.com/38945724/224487917-e82d7faf-5c1e-42f8-906a-185833836486.png"> 



Also Tested Chrome and working as expected 

<img width="1512" alt="Screenshot 2023-03-11 at 3 30 18 PM" src="https://user-images.githubusercontent.com/38945724/224488096-76523a87-e857-4d89-b47a-cec9b930f0d1.png">

** Added Features :- while trying to find the root cause I noticed we didn't have methods to get the height and width for the screen and I needed them so I added them 
If they are not important I can remove them 

** Last Note we should add an enhancement ticket to improve the performance of GIF and adding after each screenshot at it at firefox