### PR TITLE
Enhance Feature #902

### DIFF
--- a/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -5,6 +5,7 @@ import com.shaft.gui.element.AlertActions;
 import com.shaft.gui.element.SikuliActions;
 import com.shaft.gui.element.TouchActions;
 import com.shaft.gui.element.internal.FluentElementActions;
+import org.openqa.selenium.By;
 import org.openqa.selenium.Cookie;
 import org.openqa.selenium.WebDriver;
 import org.sikuli.script.App;
@@ -300,6 +301,43 @@ public class BrowserActions extends FluentBrowserActions {
     @Deprecated
     public static void switchToWindow(WebDriver driver, String nameOrHandle) {
         FluentBrowserActions.getInstance().switchToWindow(nameOrHandle);
+    }
+
+    /**
+     * Switches focus to default content, is mainly used in coordination with
+     * {@link #switchToIframe(WebDriver, By)} to exit any iFrame layer and go back
+     * to the main page
+     *
+     * @param driver the current instance of Selenium WebDriver
+     */
+    @Deprecated
+    public static void switchToDefaultContent(WebDriver driver) {
+        FluentBrowserActions.getInstance().switchToDefaultContent();
+    }
+
+    /**
+     * Switches focus to parent frame, is mainly used in coordination with
+     * {@link #switchToIframe(WebDriver, By)} to exit any iFrame layer and go back
+     * to the main page
+     *
+     * @param driver the current instance of Selenium WebDriver
+     */
+    @Deprecated
+    public static void switchToParentFrame(WebDriver driver) {
+        FluentBrowserActions.getInstance().switchToParentFrame();
+    }
+
+    /**
+     * Switches focus to a certain iFrame, is mainly used to navigate inside any iFrame
+     * layer and go back to the main page
+     *
+     * @param driver         the current instance of Selenium WebDriver
+     * @param elementLocator the locator of the iFrame webElement under test (By
+     *                       xpath, id, selector, name ...etc)
+     */
+    @Deprecated
+    public static void switchToIframe(WebDriver driver, By elementLocator) {
+        FluentBrowserActions.getInstance().switchToIframe(elementLocator);
     }
 
     @Deprecated

--- a/src/main/java/com/shaft/gui/browser/internal/FluentBrowserActions.java
+++ b/src/main/java/com/shaft/gui/browser/internal/FluentBrowserActions.java
@@ -1,5 +1,6 @@
 package com.shaft.gui.browser.internal;
 
+import com.google.common.base.Throwables;
 import com.shaft.driver.DriverFactory;
 import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactoryHelper;
@@ -740,6 +741,97 @@ public class FluentBrowserActions {
 
     public void generateLightHouseReport() {
         new LightHouseGenerateReport(DriverFactoryHelper.getDriver().get()).generateLightHouseReport();
+    }
+
+    /**
+     * Switches focus to a certain iFrame, is mainly used in coordination with
+     * {@link #switchToDefaultContent()} to navigate inside any iFrame
+     * layer and go back to the main page
+     *
+     * @param elementLocator the locator of the iFrame webElement under test (By
+     *                       xpath, id, selector, name ...etc)
+     * @return a self-reference to be used to chain actions
+     */
+    public FluentBrowserActions switchToIframe(By elementLocator) {
+        try {
+            DriverFactoryHelper.getDriver().get().switchTo().frame(((WebElement) ElementActionsHelper.identifyUniqueElement(DriverFactoryHelper.getDriver().get(), elementLocator).get(1)));
+            // note to self: remove elementLocator in case of bug in screenshot manager
+            boolean discreetLoggingState = ReportManagerHelper.getDiscreteLogging();
+            ReportManagerHelper.setDiscreteLogging(true);
+            ElementActionsHelper.passAction(DriverFactoryHelper.getDriver().get(), null, Thread.currentThread().getStackTrace()[1].getMethodName(), String.valueOf(elementLocator), null, null);
+            ReportManagerHelper.setDiscreteLogging(discreetLoggingState);
+        } catch (Throwable throwable) {
+            // has to be throwable to catch assertion errors in case element was not found
+            if (Throwables.getRootCause(throwable).getClass().getName().equals(org.openqa.selenium.NoSuchElementException.class.getName())) {
+                ElementActionsHelper.failAction(DriverFactoryHelper.getDriver().get(), null, throwable);
+            } else {
+                ElementActionsHelper.failAction(DriverFactoryHelper.getDriver().get(), elementLocator, throwable);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Switches focus to default content, is mainly used in coordination with
+     * {@link #switchToIframe(By)} to exit any iFrame layer and go back
+     * to the main page
+     *
+     * @return a self-reference to be used to chain actions
+     */
+    public FluentBrowserActions switchToDefaultContent() {
+        try {
+            DriverFactoryHelper.getDriver().get().switchTo().defaultContent();
+            boolean discreetLoggingState = ReportManagerHelper.getDiscreteLogging();
+            ReportManagerHelper.setDiscreteLogging(true);
+            ElementActionsHelper.passAction(DriverFactoryHelper.getDriver().get(), null, Thread.currentThread().getStackTrace()[1].getMethodName(), null, null, null);
+            ReportManagerHelper.setDiscreteLogging(discreetLoggingState);
+        } catch (Exception rootCauseException) {
+//            failAction(DriverFactoryHelper.getDriver().get(), null, rootCauseException);
+        }
+        // if there is no last used driver or no drivers in the drivers list, do
+        // nothing...
+//        return new FluentElementActions(Objects.requireNonNull(DriverFactoryHelper.getDriver()).get());
+        return this;
+    }
+
+    /**
+     * Switches focus to parent frame, is mainly used in coordination with
+     * {@link #switchToIframe(By)} to exit any iFrame layer and go back
+     * to the main page
+     *
+     * @return a self-reference to be used to chain actions
+     */
+    public FluentBrowserActions switchToParentFrame() {
+        try {
+            DriverFactoryHelper.getDriver().get().switchTo().parentFrame();
+            boolean discreetLoggingState = ReportManagerHelper.getDiscreteLogging();
+            ReportManagerHelper.setDiscreteLogging(true);
+            ElementActionsHelper.passAction(DriverFactoryHelper.getDriver().get(), null, Thread.currentThread().getStackTrace()[1].getMethodName(), null, null, null);
+            ReportManagerHelper.setDiscreteLogging(discreetLoggingState);
+        } catch (Exception rootCauseException) {
+//            failAction(DriverFactoryHelper.getDriver().get(), null, rootCauseException);
+        }
+        // if there is no last used driver or no drivers in the drivers list, do
+        // nothing...
+//        return new FluentElementActions(Objects.requireNonNull(DriverFactoryHelper.getDriver()).get());
+        return this;
+    }
+
+    /**
+     * gets the current frame
+     *
+     * @return currentFrame the current frame name
+     */
+    public String getCurrentFrame() {
+        String currentFrame = null;
+        try {
+            JavascriptExecutor jsExecutor = (JavascriptExecutor) DriverFactoryHelper.getDriver().get();
+            currentFrame = (String) jsExecutor.executeScript("return self.name");
+            ReportManager.logDiscrete("The current frame is :- " + currentFrame);
+        } catch (Exception rootCauseException) {
+            ReportManager.logDiscrete(String.valueOf(rootCauseException));
+        }
+        return currentFrame;
     }
 
 }

--- a/src/main/java/com/shaft/gui/element/ElementActions.java
+++ b/src/main/java/com/shaft/gui/element/ElementActions.java
@@ -546,31 +546,6 @@ public class ElementActions extends FluentElementActions {
     }
 
     /**
-     * Switches focus to default content, is mainly used in coordination with
-     * {@link #switchToIframe(WebDriver, By)} to exit any iFrame layer and go back
-     * to the main page
-     *
-     * @param driver the current instance of Selenium WebDriver
-     */
-    @Deprecated
-    public static void switchToDefaultContent(WebDriver driver) {
-        FluentElementActions.getInstance().switchToDefaultContent();
-    }
-
-    /**
-     * Switches focus to a certain iFrame, is mainly used to navigate inside any iFrame
-     * layer and go back to the main page
-     *
-     * @param driver         the current instance of Selenium WebDriver
-     * @param elementLocator the locator of the iFrame webElement under test (By
-     *                       xpath, id, selector, name ...etc)
-     */
-    @Deprecated
-    public static void switchToIframe(WebDriver driver, By elementLocator) {
-        FluentElementActions.getInstance().switchToIframe(elementLocator);
-    }
-
-    /**
      * Checks if there is any text in an element, clears it, then types the required
      * string into the target element.
      *

--- a/src/main/java/com/shaft/gui/element/internal/FluentElementActions.java
+++ b/src/main/java/com/shaft/gui/element/internal/FluentElementActions.java
@@ -822,58 +822,6 @@ public class FluentElementActions {
     }
 
     /**
-     * Switches focus to a certain iFrame, is mainly used in coordination with
-     * {@link #switchToDefaultContent()} to navigate inside any iFrame
-     * layer and go back to the main page
-     *
-     * @param elementLocator the locator of the iFrame webElement under test (By
-     *                       xpath, id, selector, name ...etc)
-     * @return a self-reference to be used to chain actions
-     */
-    public FluentElementActions switchToIframe(By elementLocator) {
-        try {
-            DriverFactoryHelper.getDriver().get().switchTo().frame(((WebElement) ElementActionsHelper.identifyUniqueElement(DriverFactoryHelper.getDriver().get(), elementLocator).get(1)));
-            // note to self: remove elementLocator in case of bug in screenshot manager
-            boolean discreetLoggingState = ReportManagerHelper.getDiscreteLogging();
-            ReportManagerHelper.setDiscreteLogging(true);
-            ElementActionsHelper.passAction(DriverFactoryHelper.getDriver().get(), null, Thread.currentThread().getStackTrace()[1].getMethodName(), String.valueOf(elementLocator), null, null);
-            ReportManagerHelper.setDiscreteLogging(discreetLoggingState);
-        } catch (Throwable throwable) {
-            // has to be throwable to catch assertion errors in case element was not found
-            if (Throwables.getRootCause(throwable).getClass().getName().equals(org.openqa.selenium.NoSuchElementException.class.getName())) {
-                ElementActionsHelper.failAction(DriverFactoryHelper.getDriver().get(), null, throwable);
-            } else {
-                ElementActionsHelper.failAction(DriverFactoryHelper.getDriver().get(), elementLocator, throwable);
-            }
-        }
-        return this;
-    }
-
-    /**
-     * Switches focus to default content, is mainly used in coordination with
-     * {@link #switchToIframe(By)} to exit any iFrame layer and go back
-     * to the main page
-     *
-     * @return a self-reference to be used to chain actions
-     */
-    @SuppressWarnings("UnusedReturnValue")
-    public FluentElementActions switchToDefaultContent() {
-        try {
-            DriverFactoryHelper.getDriver().get().switchTo().defaultContent();
-            boolean discreetLoggingState = ReportManagerHelper.getDiscreteLogging();
-            ReportManagerHelper.setDiscreteLogging(true);
-            ElementActionsHelper.passAction(DriverFactoryHelper.getDriver().get(), null, Thread.currentThread().getStackTrace()[1].getMethodName(), null, null, null);
-            ReportManagerHelper.setDiscreteLogging(discreetLoggingState);
-        } catch (Exception rootCauseException) {
-//            failAction(DriverFactoryHelper.getDriver().get(), null, rootCauseException);
-        }
-        // if there is no last used driver or no drivers in the drivers list, do
-        // nothing...
-//        return new FluentElementActions(Objects.requireNonNull(DriverFactoryHelper.getDriver()).get());
-        return this;
-    }
-
-    /**
      * Checks if there is any text in an element, clears it, then types the required
      * string into the target element.
      *

--- a/src/test/java/testPackage/iFrameTest.java
+++ b/src/test/java/testPackage/iFrameTest.java
@@ -1,51 +1,54 @@
 package testPackage;
 
-import com.shaft.driver.DriverFactory;
-import com.shaft.gui.browser.BrowserActions;
-import com.shaft.gui.element.ElementActions;
-import com.shaft.validation.Validations;
+import com.shaft.driver.SHAFT;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 public class iFrameTest {
-    // Declaring webdriver and excelreader instances
-    WebDriver driver;
+    SHAFT.GUI.WebDriver driver;
+    By iframe_1 = By.name("iframe1");
+    By iframe_2 = By.name("iframe2");
+    String testPage = "data:text/html,<script>var result;</script><button alt='Google' onclick='result=\"Clicked\"'>Go</button>\n" +
+            "<html>\n" +
+            "  <head>\n" +
+            "    <title>Nested iFrames Example</title>\n" +
+            "  </head>\n" +
+            "  <body>\n" +
+            "    <h1>Parent Frame</h1>\n" +
+            "    <iframe src=\"data:text/html;base64,PCFET0NUWVBFIGh0bWw+DQo8aHRtbD4NCiAgPGhlYWQ+DQogICAgPHRpdGxlPkNoaWxkIGlGcmFtZSAoRnJhbWUgQSk8L3RpdGxlPg0KICA8L2hlYWQ+DQogIDxib2R5Pg0KICAgIDxoMj5DaGlsZCBpRnJhbWUgKEZyYW1lIEEpPC9oMj4NCiAgICAgIDxpZnJhbWUgc3JjPSJQQ0ZFVDBOVVdWQkZJR2gwYld3K0RRbzhhSFJ0YkQ0TkNpQWdQR2hsWVdRK0RRb2dJQ0FnUEhScGRHeGxQa05vYVd4a0lHbEdjbUZ0WlNBb1JuSmhiV1VnUWlrOEwzUnBkR3hsUGcwS0lDQThMMmhsWVdRK0RRb2dJRHhpYjJSNVBnMEtJQ0FnSUR4b016NURhR2xzWkNCcFJuSmhiV1VnS0VaeVlXMWxJRUlwUEM5b016NE5DaUFnSUNBOGNENVVhR2x6SUdseklIUm9aU0JwYm01bGNtMXZjM1FnYVdaeVlXMWxMand2Y0Q0TkNpQWdQQzlpYjJSNVBnMEtQQzlvZEcxc1BnPT0iIG5hbWU9ImlmcmFtZTIiPjwvaWZyYW1lPg0KICA8L2JvZHk+DQo8L2h0bWw+\" name=\"iframe1\"></iframe>\n" +
+            "  </body>\n" +
+            "</html>";
 
-    //@Test(priority = 0, description = "TC001 - Navigate to URL and assert element exists inside iframe")
-    public void navigateToURLandAssertElementExists() {
-        BrowserActions.getInstance().navigateToURL("https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe");
-        // directly find elmeent - expected to fail
-        By goButton = By.id("goButton");
-        // Verifications.verifyElementExists(driver, goButton, true);
-        // switch to frame manually, then find element, then switch out - expected to
-        // pass
-        By elementInMainPage = By.id("Result");
-        By iframe_1 = By.id("frame_Example1");
-        By iframe_2 = By.xpath("//iframe[@title='iframe example 1']");
-        ElementActions.getInstance().switchToIframe(iframe_1);
-        ElementActions.getInstance().switchToIframe(iframe_2);
-        Validations.verifyThat().element(driver, goButton).exists().perform();
-        ElementActions.getInstance().switchToDefaultContent();
-        Validations.verifyThat().element(driver, elementInMainPage).exists().perform();
+    @Test()
+    public void switchToIframeAndParentFrame() {
+        driver.browser().navigateToURL(testPage);
+        driver.browser().switchToIframe(iframe_1);
+        var currentFrame = driver.browser().getCurrentFrame();
+        driver.browser().switchToDefaultContent();
+        var currentFrameAfterSwitchingBackToParentFrame = driver.browser().getCurrentFrame();
+        SHAFT.Validations.assertThat().object(currentFrameAfterSwitchingBackToParentFrame).doesNotEqual(currentFrame);
+    }
 
-        // attempt to switch out while already out
-        ElementActions.getInstance().switchToDefaultContent();
-
-        // identify iframe dynamically, then switch in and out??
-        // goButton = By.xpath("//iframe[@title='iframe example
-        // 1']//button[@id='goButton']");
-        // Verifications.verifyElementExists(driver, goButton, true);
+    @Test()
+    public void switchToIframeAndParentFrame2() {
+        driver.browser().navigateToURL(testPage);
+        driver.browser().switchToIframe(iframe_1);
+        driver.browser().switchToIframe(iframe_2);
+        var currentFrame = driver.browser().getCurrentFrame();
+        driver.browser().switchToParentFrame();
+        var currentFrameAfterSwitchingBackToParentFrame = driver.browser().getCurrentFrame();
+        SHAFT.Validations.assertThat().object(currentFrameAfterSwitchingBackToParentFrame).doesNotEqual(currentFrame);
     }
 
     @BeforeClass // Set-up method, to be run once before the first test
     public void beforeClass() {
-        driver = DriverFactory.getDriver();
+        driver = new SHAFT.GUI.WebDriver();
     }
 
     @AfterClass(alwaysRun = true)
     public void afterClass() {
-        BrowserActions.getInstance().closeCurrentWindow();
+        driver.quit();
     }
 }

--- a/src/test/java/testPackage/iFrameTest.java
+++ b/src/test/java/testPackage/iFrameTest.java
@@ -28,7 +28,7 @@ public class iFrameTest {
         var currentFrame = driver.browser().getCurrentFrame();
         driver.browser().switchToDefaultContent();
         var currentFrameAfterSwitchingBackToParentFrame = driver.browser().getCurrentFrame();
-        SHAFT.Validations.assertThat().object(currentFrameAfterSwitchingBackToParentFrame).doesNotEqual(currentFrame);
+        SHAFT.Validations.assertThat().object(currentFrameAfterSwitchingBackToParentFrame).doesNotEqual(currentFrame).perform();
     }
 
     @Test()
@@ -39,7 +39,7 @@ public class iFrameTest {
         var currentFrame = driver.browser().getCurrentFrame();
         driver.browser().switchToParentFrame();
         var currentFrameAfterSwitchingBackToParentFrame = driver.browser().getCurrentFrame();
-        SHAFT.Validations.assertThat().object(currentFrameAfterSwitchingBackToParentFrame).doesNotEqual(currentFrame);
+        SHAFT.Validations.assertThat().object(currentFrameAfterSwitchingBackToParentFrame).doesNotEqual(currentFrame).perform();
     }
 
     @BeforeClass // Set-up method, to be run once before the first test


### PR DESCRIPTION
- switch to iframe should be a browser action not an element action
- Implemented `SwitchToParentFrame()` as it is added as of selenium 4
- Implemented a method to get the current frame name
- Added a test class with the new way by using dummy html so I created an html page that contain parent and 2 children frames to test `switchToParentFrame()` it was great btw enjoyed it :D 
- Refactored this test class as it was outdated and commented `iFrameTest`