### PR TITLE
testng/junit logic switching enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ debug.log
 /lighthouse-reports
 GenerateLHScript.js
 OpenLHReport.js
-/src/test/resources/META-INF/services/org.testng.ITestNGListener

--- a/pom.xml
+++ b/pom.xml
@@ -778,6 +778,7 @@
                     <encoding>UTF-8</encoding>
                     <maxmem>10240m</maxmem>
                     <meminitial>1024m</meminitial>
+                    <optimize>true</optimize>
                 </configuration>
             </plugin>
             <plugin>
@@ -793,8 +794,7 @@
                     </archive>
                     <includes>
                         <include>com/**/*</include>
-			<include>resources/**/*</include>
-
+                        <include>resources/**/*</include>
                     </includes>
                 </configuration>
             </plugin>

--- a/src/main/java/com/shaft/driver/DriverFactory.java
+++ b/src/main/java/com/shaft/driver/DriverFactory.java
@@ -90,7 +90,7 @@ public class DriverFactory {
         if (SHAFT.Properties.platform == null) {
             System.out.println("Execution Listeners are not loaded properly... Self-Healing... Initializing minimalistic test run...");
             TestNGListener.engineSetup();
-            if (!TestNGListener.isTestNGRun()) {
+            if (TestNGListener.isJunitRun()) {
                 ProjectStructureManager.initialize(ProjectStructureManager.Mode.JUNIT);
             } else {
                 ProjectStructureManager.initialize(ProjectStructureManager.Mode.TESTNG);

--- a/src/test/resources/META-INF/services/org.testng.ITestNGListener
+++ b/src/test/resources/META-INF/services/org.testng.ITestNGListener
@@ -1,0 +1,1 @@
+com.shaft.listeners.TestNGListener


### PR DESCRIPTION
- now that the listener file is already in place, this should enable this project to run cleanly.
- other projects using cucumber should also copy the org.testng.ITestNGListener so that their test runner can pick it up.
- tetsng projects will run correctly from the first run.
- junit5 projects will do a minimalistic run, self-heal, then run correctly the second time.
- cucumber feature files will run corretly but the first run (compilation run) must be done via the test runner class. OR you can just configure the plugin.