### PR TITLE
adding autoclose driver instance

### DIFF
--- a/src/main/java/com/shaft/driver/internal/DriverFactoryHelper.java
+++ b/src/main/java/com/shaft/driver/internal/DriverFactoryHelper.java
@@ -293,6 +293,8 @@ public class DriverFactoryHelper {
         } else {
             options.addArguments("--window-position=0,0", "--window-size=" + TARGET_WINDOW_SIZE.getWidth() + "," + TARGET_WINDOW_SIZE.getHeight());
         }
+        if (!SHAFT.Properties.flags.autoCloseDriverInstance())
+            options.setExperimentalOption("detach", true);
 
 //         https://github.com/GoogleChrome/chrome-launcher/blob/main/docs/chrome-flags-for-tools.md
 //         https://docs.google.com/spreadsheets/d/1n-vw_PCPS45jX3Jt9jQaAhFqBY6Ge1vWF_Pa0k7dCk4/edit#gid=1265672696

--- a/src/main/java/com/shaft/listeners/internal/ConfigurationHelper.java
+++ b/src/main/java/com/shaft/listeners/internal/ConfigurationHelper.java
@@ -1,6 +1,7 @@
 package com.shaft.listeners.internal;
 
 import com.shaft.driver.DriverFactory;
+import com.shaft.driver.SHAFT;
 import com.shaft.tools.io.internal.CheckpointCounter;
 import com.shaft.tools.io.internal.ReportHelper;
 import org.testng.ITestContext;
@@ -19,7 +20,8 @@ public class ConfigurationHelper {
     //TODO: this method is not being executed in case there's another after class method
     @AfterClass(description = "Cleaning up orphaned drivers", alwaysRun = true)
     public void classTeardown() {
-        DriverFactory.closeAllDrivers();
+        if (SHAFT.Properties.flags.autoCloseDriverInstance())
+            DriverFactory.closeAllDrivers();
     }
 
     @AfterSuite(description = "Attaching Reports", alwaysRun = true)

--- a/src/main/java/com/shaft/listeners/internal/CucumberHelper.java
+++ b/src/main/java/com/shaft/listeners/internal/CucumberHelper.java
@@ -41,7 +41,8 @@ public class CucumberHelper {
     public static void shaftTeardown() {
         if (Reporter.getCurrentTestResult() == null) {
             // running in native Cucumber mode
-            DriverFactory.closeAllDrivers();
+            if (SHAFT.Properties.flags.autoCloseDriverInstance())
+                DriverFactory.closeAllDrivers();
 
             ReportHelper.attachEngineLog();
             ReportHelper.attachExtentReport();

--- a/src/main/java/com/shaft/properties/internal/Flags.java
+++ b/src/main/java/com/shaft/properties/internal/Flags.java
@@ -57,6 +57,10 @@ public interface Flags extends EngineProperties {
     @DefaultValue("false")
     boolean clickUsingJavascriptWhenWebDriverClickFails();
 
+    @Key("autoCloseDriverInstance")
+    @DefaultValue("true")
+    boolean autoCloseDriverInstance();
+
     @Key("automaticallyAssertResponseStatusCode")
     @DefaultValue("true")
     boolean automaticallyAssertResponseStatusCode();
@@ -112,6 +116,10 @@ public interface Flags extends EngineProperties {
 
         public void clickUsingJavascriptWhenWebDriverClickFails(boolean value) {
             setProperty("clickUsingJavascriptWhenWebDriverClickFails", String.valueOf(value));
+        }
+
+        public void autoCloseDriverInstance(boolean value) {
+            setProperty("autoCloseDriverInstance", String.valueOf(value));
         }
 
         public void automaticallyAssertResponseStatusCode(boolean value) {


### PR DESCRIPTION
SHAFT.Properties.flags.set().autoCloseDriverInstance(false);

not working on windows due to a chromedriver bug