### PR TITLE
remove the broken feature

### DIFF
--- a/src/main/java/com/shaft/properties/internal/Reporting.java
+++ b/src/main/java/com/shaft/properties/internal/Reporting.java
@@ -108,16 +108,6 @@ public interface Reporting extends EngineProperties {
             return this;
         }
 
-        public SetProperty cleanAllureResultsDirectoryBeforeExecution(boolean value) {
-            setProperty("cleanAllureResultsDirectoryBeforeExecution", String.valueOf(value));
-            return this;
-        }
-
-        public SetProperty cleanSummaryReportsDirectoryBeforeExecution(boolean value) {
-            setProperty("cleanSummaryReportsDirectoryBeforeExecution", String.valueOf(value));
-            return this;
-        }
-
         public SetProperty generateAllureReportArchive(boolean value) {
             setProperty("generateAllureReportArchive", String.valueOf(value));
             return this;
@@ -130,11 +120,6 @@ public interface Reporting extends EngineProperties {
 
         public SetProperty generateExtentReports(boolean value) {
             setProperty("generateExtentReports", String.valueOf(value));
-            return this;
-        }
-
-        public SetProperty cleanExtentReportsDirectoryBeforeExecution(boolean value) {
-            setProperty("cleanExtentReportsDirectoryBeforeExecution", String.valueOf(value));
             return this;
         }
 

--- a/src/test/java/testPackage/properties/ReportingTests.java
+++ b/src/test/java/testPackage/properties/ReportingTests.java
@@ -43,11 +43,9 @@ public class ReportingTests {
         SHAFT.Properties.reporting.set().captureWebDriverLogs(captureWebDriverLogs);
         SHAFT.Properties.reporting.set().alwaysLogDiscreetly(alwaysLogDiscreetly);
         SHAFT.Properties.reporting.set().debugMode(debugMode);
-        SHAFT.Properties.reporting.set().cleanAllureResultsDirectoryBeforeExecution(cleanAllureResultsDirectoryBeforeExecution);
         SHAFT.Properties.reporting.set().generateAllureReportArchive(generateAllureReportArchive);
         SHAFT.Properties.reporting.set().openAllureReportAfterExecution(openAllureReportAfterExecution);
         SHAFT.Properties.reporting.set().generateExtentReports(generateExtentReports);
-        SHAFT.Properties.reporting.set().cleanExtentReportsDirectoryBeforeExecution(cleanExtentReportsDirectoryBeforeExecution);
         SHAFT.Properties.reporting.set().attachExtentReportsToAllureReport(attachExtentReportsToAllureReport);
         SHAFT.Properties.reporting.set().openLighthouseReportWhileExecution(openLighthouseReportWhileExecution);
         SHAFT.Properties.reporting.set().openExecutionSummaryReportAfterExecution(openExecutionSummaryReportAfterExecution);


### PR DESCRIPTION
- it is not possible to clean the directory before execution, while being inside the execution. therefore it makes no sense to have the ability to set these three properties programatically.