### PR TITLE
New feature to disable cache on Firefox, Microsoft Edge and Google chrome browsers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <!-- Dependencies and Plug-ins Version Numbers Parameters -->
-        <selenium.version>4.11.0</selenium.version>
+        <selenium.version>4.11.0</selenium.version>  <!-- MAKE SURE TO UPDATE devtools.v113.network.Network TO LATEST VERSION WITH UPDATING SELENIUM-->
         <appium-java-client.version>8.5.1</appium-java-client.version>
         <webdrivermanager.version>5.4.1</webdrivermanager.version>
         <allure.version>2.23.0</allure.version> <!-- 2.21.0 DO NOT UPDATE || internal.properties -->

--- a/src/main/java/com/shaft/properties/internal/Flags.java
+++ b/src/main/java/com/shaft/properties/internal/Flags.java
@@ -77,6 +77,10 @@ public interface Flags extends EngineProperties {
     @DefaultValue("false")
     boolean attemptToClickBeforeTyping();
 
+    @Key("disableCache")
+    @DefaultValue("false")
+    boolean disableCache();
+
     default SetProperty set() {
         return new SetProperty();
     }
@@ -154,6 +158,10 @@ public interface Flags extends EngineProperties {
 
         public SetProperty skipTestsWithLinkedIssues(boolean value) {
             setProperty("skipTestsWithLinkedIssues", String.valueOf(value));
+            return this;
+        }
+        public SetProperty disableCache(boolean value) {
+            setProperty("disableCache", String.valueOf(value));
             return this;
         }
     }

--- a/src/test/java/testPackage/properties/FlagsTests.java
+++ b/src/test/java/testPackage/properties/FlagsTests.java
@@ -20,6 +20,7 @@ public class FlagsTests {
     int maximumPerformanceMode;
     boolean skipTestsWithLinkedIssues;
     boolean attemptToClickBeforeTyping ;
+    boolean disableCache ;
 
     @BeforeClass
     public void beforeClass() {
@@ -37,6 +38,7 @@ public class FlagsTests {
         maximumPerformanceMode = SHAFT.Properties.flags.maximumPerformanceMode();
         skipTestsWithLinkedIssues = SHAFT.Properties.flags.skipTestsWithLinkedIssues();
         attemptToClickBeforeTyping = SHAFT.Properties.flags.attemptToClickBeforeTyping();
+        disableCache = SHAFT.Properties.flags.disableCache();
     }
 
     @Test
@@ -55,5 +57,6 @@ public class FlagsTests {
         SHAFT.Properties.flags.set().maximumPerformanceMode(maximumPerformanceMode);
         SHAFT.Properties.flags.set().skipTestsWithLinkedIssues(skipTestsWithLinkedIssues);
         SHAFT.Properties.flags.set().attemptToClickBeforeTyping(attemptToClickBeforeTyping);
+        SHAFT.Properties.flags.set().disableCache(disableCache);
     }
 }


### PR DESCRIPTION
Added a feature to disable cache using flag (disableCache) on the following browsers:

1. Google chrome 
2. Microsoft Edge
3. Firefox
4. Safari

**Note: I could not find a valid website to make a test case for this feature however, this feature was tested locally, and it works fine on mentioned browsers except Safari due to the macOS availability.**
@MahmoudElSharkawy 