### PR TITLE
Added a class to get a unique locator from a generic locator

### DIFF
--- a/src/main/java/com/shaft/gui/internal/locator/MultiLocatorHandler.java
+++ b/src/main/java/com/shaft/gui/internal/locator/MultiLocatorHandler.java
@@ -1,0 +1,95 @@
+package com.shaft.gui.internal.locator;
+
+import com.shaft.driver.internal.DriverFactoryHelper;
+import com.shaft.gui.element.internal.ElementActionsHelper;
+import com.shaft.tools.io.ReportManager;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.Wait;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
+import java.util.List;
+
+public class MultiLocatorHandler {
+    private static int uniqueNumber = 1;
+
+    /**
+     * Get a unique By locator for an element within a list of multiple elements based on exact text match.
+     *
+     * @param multipleElementsLocator The locator for the list of elements.
+     * @param visibleTextOfExactElement The exact text content to match.
+     * @return A unique By locator for the specific element found, or null if not found.
+     * in case multiple options found, returns the first one
+     */
+    public static By getLocatorByText(By multipleElementsLocator, String visibleTextOfExactElement) {
+        waitAndHandleExceptions(multipleElementsLocator);
+
+        List<WebElement> elements = DriverFactoryHelper.getDriver().get().findElements(multipleElementsLocator);
+        for (WebElement element : elements) {
+            if (element.getText().equals(visibleTextOfExactElement)) {
+                String className = injectUniqueClassName(element);
+                return By.className(className);
+            }
+        }
+        ReportManager.logDiscrete("element with text \"" + visibleTextOfExactElement + "\" was not found");
+        return null;
+    }
+    /**
+     * Get a unique By locator for an element within a list of multiple elements based on partial text match.
+     *
+     * @param multipleElementsLocator The locator for the list of elements.
+     * @param partialTextOfExactElement The partial text content to match.
+     * @return A unique By locator for the specific element found, or null if not found.
+     * in case multiple options found, returns the first one
+     */
+    public static By getLocatorContainingText(By multipleElementsLocator, String partialTextOfExactElement) {
+        waitAndHandleExceptions(multipleElementsLocator);
+
+        List<WebElement> elements = DriverFactoryHelper.getDriver().get().findElements(multipleElementsLocator);
+        for (WebElement element : elements) {
+            if (element.getText().contains(partialTextOfExactElement)) {
+                String className = injectUniqueClassName(element);
+                return By.className(className);
+            }
+        }
+        ReportManager.logDiscrete("element containing \"" + partialTextOfExactElement + "\" was not found");
+        return null;
+    }
+    /**
+     * Get a unique By locator for an element within a list of multiple elements based on its index.
+     * starting from 0
+     * @param multipleElementsLocator The locator for the list of elements.
+     * @param index The index of the element to retrieve.
+     * @return A unique By locator for the element at the specified index, or null if not found.
+     */
+    public static By getLocatorByIndex(By multipleElementsLocator, int index) {
+        waitAndHandleExceptions(multipleElementsLocator);
+
+        List<WebElement> elements = DriverFactoryHelper.getDriver().get().findElements(multipleElementsLocator);
+        if (elements.size() <= index) {
+            ReportManager.logDiscrete("element with locator " + multipleElementsLocator
+                    + " with index '" + index + "' was not found");
+            return null;
+        }
+
+        String className = injectUniqueClassName(elements.get(index));
+        return By.className(className);
+    }
+    private static void waitAndHandleExceptions(By multipleElementsLocator) {
+        Wait wait = new WebDriverWait(DriverFactoryHelper.getDriver().get(), Duration.ofSeconds(10));
+        try {
+            wait.until(ExpectedConditions.presenceOfAllElementsLocatedBy(multipleElementsLocator));
+        } catch (Exception throwable) {
+            ElementActionsHelper.failAction(DriverFactoryHelper.getDriver().get(), multipleElementsLocator, throwable);
+        }
+    }
+    private static String injectUniqueClassName(WebElement element) {
+        JavascriptExecutor jsExecutor = (JavascriptExecutor) DriverFactoryHelper.getDriver().get();
+        String className = "shaft-unique-identifier-" + (uniqueNumber++);
+        jsExecutor.executeScript("arguments[0].classList.add('" + className + "');", element);
+        return className;
+    }
+}

--- a/src/test/java/testPackage/MultiLocatorHandlerTests.java
+++ b/src/test/java/testPackage/MultiLocatorHandlerTests.java
@@ -1,0 +1,58 @@
+package testPackage;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.gui.internal.locator.MultiLocatorHandler;
+import org.openqa.selenium.By;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class MultiLocatorHandlerTests {
+    SHAFT.GUI.WebDriver driver;
+    By genericElement = By.cssSelector(".routing a");
+
+
+    @Test
+    public void testGetLocatorByText(){
+        By uniqueLocator = MultiLocatorHandler.getLocatorByText(genericElement, "Dojo");
+        driver.element().click(uniqueLocator);
+        Assert.assertEquals(driver.browser().getCurrentURL(), "https://todomvc.com/examples/dojo/");
+    }
+    @Test
+    public void testGetLocatorContainingText(){
+        By uniqueLocator = MultiLocatorHandler.getLocatorContainingText(genericElement, "Angular");
+        driver.element().click(uniqueLocator);
+        Assert.assertEquals(driver.browser().getCurrentURL(), "https://todomvc.com/examples/angularjs/#/");
+    }
+    @Test
+    public void testGetLocatorByIndex(){
+        By uniqueLocator = MultiLocatorHandler.getLocatorByIndex(genericElement, 3);
+        driver.element().click(uniqueLocator);
+        Assert.assertEquals(driver.browser().getCurrentURL(), "https://todomvc.com/examples/knockoutjs/");
+    }
+    @Test(description = "Verify that the using the method more than once doesn't override the results")
+    public void testLocatorUniqueness(){
+        //one locator before
+        MultiLocatorHandler.getLocatorContainingText(genericElement, "Angular");
+        //target locator
+        By uniqueLocator = MultiLocatorHandler.getLocatorContainingText(genericElement, "Dojo");
+        //one locator after
+        MultiLocatorHandler.getLocatorContainingText(genericElement, "React");
+        driver.element().click(uniqueLocator);
+        Assert.assertEquals(driver.browser().getCurrentURL(), "https://todomvc.com/examples/dojo/");
+
+    }
+
+
+    @BeforeMethod(description = "Setup Browser instance.")
+    public void beforeMethod() {
+        driver = new SHAFT.GUI.WebDriver();
+        driver.browser().navigateToURL("https://todomvc.com/");
+    }
+
+    @AfterMethod(description = "Teardown Browser instance.")
+    public void afterMethod() {
+        driver.quit();
+    }
+}


### PR DESCRIPTION
**Problem:** Making actions (click, select, type,...) on a locator that may have multiple values is not supported
**Use Case:** You have a menu page and you can create an items in that menu. you created the item and you need to click on it to edit it. the newly created item does not have a unique identifier and you will not be able to add the item locator in the page since the items are dynamic.
**Proposed Solution:** Create a class that can handle the generic locators and returns a unique locator by adding a unique class name into the element using JavaScript. and you can get this element by:
1. full text
2. partial text
3. index

**Limitation:** Since it's adding a class name by scripting, refreshing the page or navigating to another page will make the class name get removed so the method will need to be called again.