### PR TITLE
Enhance Cucumber/TestNG user experience:

### DIFF
--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -698,7 +698,7 @@ jobs:
       - name: Run tests on Linux/MacOS
         if: runner.os != 'Windows'
         continue-on-error: true
-        run: mvn -e test "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DmaximumPerformanceMode=2" "-DgenerateAllureReportArchive=true" "-Dtest=.*CucumberTestRunner.*"
+        run: mvn -e test "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DmaximumPerformanceMode=2" "-DgenerateAllureReportArchive=true" "-Dtest=.*CucumberTests.*"
       - name: Upload coverage to Codecov
         uses:  codecov/codecov-action@v3
         with:
@@ -738,7 +738,7 @@ jobs:
       - name: Run tests on Windows
         if: runner.os == 'Windows'
         continue-on-error: true
-        run: mvn -e test "-DretryMaximumNumberOfAttempts=2" -DexecutionAddress="local" -DtargetOperatingSystem="WINDOWS" -DmaximumPerformanceMode="2" -DtargetBrowserName="MicrosoftEdge" -DgenerateAllureReportArchive="true" -Dtest=".*CucumberTestRunner.*"
+        run: mvn -e test "-DretryMaximumNumberOfAttempts=2" -DexecutionAddress="local" -DtargetOperatingSystem="WINDOWS" -DmaximumPerformanceMode="2" -DtargetBrowserName="MicrosoftEdge" -DgenerateAllureReportArchive="true" -Dtest=".*CucumberTests.*"
       - name: Upload coverage to Codecov
         uses:  codecov/codecov-action@v3
         with:
@@ -777,7 +777,7 @@ jobs:
           check-latest: true
       - name: Run tests
         continue-on-error: true
-        run: mvn -e test "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=Safari" "-DmaximumPerformanceMode=1" "-DbrowserStack.os=OS X" "-DbrowserStack.osVersion=Monterey" "-DbrowserStack.browserVersion=15.3" -DgenerateAllureReportArchive="true" -Dtest=".*CucumberTestRunner.*"
+        run: mvn -e test "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=Safari" "-DmaximumPerformanceMode=1" "-DbrowserStack.os=OS X" "-DbrowserStack.osVersion=Monterey" "-DbrowserStack.browserVersion=15.3" -DgenerateAllureReportArchive="true" -Dtest=".*CucumberTests.*"
       - name: Upload coverage to Codecov
         uses:  codecov/codecov-action@v3
         with:

--- a/src/main/java/com/shaft/driver/DriverFactory.java
+++ b/src/main/java/com/shaft/driver/DriverFactory.java
@@ -98,12 +98,13 @@ public class DriverFactory {
     public static void reloadProperties() {
         if (SHAFT.Properties.platform == null) {
             System.out.println("Execution Listeners are not loaded properly... Self-Healing... Initializing minimalistic test run...");
-            TestNGListener.engineSetup();
-            if (TestNGListener.isJunitRun()) {
-                ProjectStructureManager.initialize(ProjectStructureManager.Mode.JUNIT);
-            } else {
-                ProjectStructureManager.initialize(ProjectStructureManager.Mode.TESTNG);
+            var runType = TestNGListener.identifyRunType();
+            if (runType.equals(ProjectStructureManager.RunType.CUCUMBER)) {
+                // stuck on minimalistic test run in case of native cucumber execution without manual plugin configuration
+                System.out.println("To unlock the full capabilities of SHAFT kindly follow these steps to configure SHAFT's Cucumber plugin:");
+                System.out.println("https://github.com/ShaftHQ/SHAFT_ENGINE#stop-reinventing-the-wheel-start-using-shaft");
             }
+            TestNGListener.engineSetup(runType);
         }
     }
 

--- a/src/main/java/com/shaft/listeners/JunitListener.java
+++ b/src/main/java/com/shaft/listeners/JunitListener.java
@@ -76,7 +76,7 @@ public class JunitListener implements LauncherSessionListener {
         SHAFT.Properties.reporting.set().disableLogging(true);
         Allure.getLifecycle();
         Reporter.setEscapeHtml(false);
-        ProjectStructureManager.initialize(ProjectStructureManager.Mode.JUNIT);
+        ProjectStructureManager.initialize(ProjectStructureManager.RunType.JUNIT);
         TestNGListenerHelper.configureJVMProxy();
         GoogleTink.initialize();
         GoogleTink.decrypt();

--- a/src/main/java/com/shaft/listeners/TestNGListener.java
+++ b/src/main/java/com/shaft/listeners/TestNGListener.java
@@ -2,6 +2,7 @@ package com.shaft.listeners;
 
 import com.shaft.driver.SHAFT;
 import com.shaft.gui.internal.image.ImageProcessingActions;
+import com.shaft.listeners.internal.CucumberHelper;
 import com.shaft.listeners.internal.JiraHelper;
 import com.shaft.listeners.internal.RetryAnalyzer;
 import com.shaft.listeners.internal.TestNGListenerHelper;
@@ -38,50 +39,33 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
     @Getter
     private static XmlTest xmlTest;
 
-    private static boolean isJunitRunBool = false;
-    private static boolean isTestNGRunBool = false;
-
-    public static boolean isTestNGRun() {
-        if (!isTestNGRunBool && !isJunitRunBool) {
-            identifyRunType();
-        }
-        return isTestNGRunBool;
-    }
-
-    public static boolean isJunitRun() {
-        if (!isTestNGRunBool && !isJunitRunBool) {
-            identifyRunType();
-        }
-        return isJunitRunBool;
-    }
-
-    private static void identifyRunType() {
+    public static ProjectStructureManager.RunType identifyRunType() {
         Supplier<Stream<?>> stacktraceSupplier = () -> Arrays.stream((new Throwable()).getStackTrace()).map(StackTraceElement::getClassName);
         var isUsingJunitDiscovery = stacktraceSupplier.get().anyMatch(org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.class.getCanonicalName()::equals);
         var isUsingTestNG = stacktraceSupplier.get().anyMatch(TestNG.class.getCanonicalName()::equals);
         var isUsingCucumber = stacktraceSupplier.get().anyMatch(io.cucumber.core.runner.Runner.class.getCanonicalName()::equals);
         if (isUsingJunitDiscovery || isUsingTestNG) {
             System.out.println("TestNG run detected...");
-            isTestNGRunBool = true;
+            return ProjectStructureManager.RunType.TESTNG;
         } else if (isUsingCucumber) {
             System.out.println("Cucumber run detected...");
-            isTestNGRunBool = true;
+            return ProjectStructureManager.RunType.CUCUMBER;
         } else {
             System.out.println("JUnit5 run detected...");
-            isJunitRunBool = true;
+            return ProjectStructureManager.RunType.JUNIT;
         }
     }
 
-    public static void engineSetup() {
+    public static void engineSetup(ProjectStructureManager.RunType runType) {
         ReportManagerHelper.setDiscreteLogging(true);
         PropertiesHelper.initialize();
         SHAFT.Properties.reporting.set().disableLogging(true);
         Allure.getLifecycle();
         Reporter.setEscapeHtml(false);
-        if (isTestNGRun()) {
-            ProjectStructureManager.initialize(ProjectStructureManager.Mode.TESTNG);
-        } else {
-            ProjectStructureManager.initialize(ProjectStructureManager.Mode.JUNIT);
+        switch (runType) {
+            case TESTNG -> ProjectStructureManager.initialize(ProjectStructureManager.RunType.TESTNG);
+            case CUCUMBER -> ProjectStructureManager.initialize(ProjectStructureManager.RunType.CUCUMBER);
+            case JUNIT -> ProjectStructureManager.initialize(ProjectStructureManager.RunType.JUNIT);
         }
         TestNGListenerHelper.configureJVMProxy();
         GoogleTink.initialize();
@@ -104,7 +88,7 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
      */
     @Override
     public void onExecutionStart() {
-        engineSetup();
+        engineSetup(ProjectStructureManager.RunType.TESTNG);
     }
 
     /**
@@ -115,14 +99,14 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
      */
     @Override
     public void alter(List<XmlSuite> suites) {
-        if (isTestNGRun()) {
-            TestNGListenerHelper.configureTestNGProperties(suites);
-            TestNGListenerHelper.updateDefaultSuiteAndTestNames(suites);
-            TestNGListenerHelper.attachConfigurationHelperClass(suites);
-            //All alterations should be finalized before duplicating the
-            //test suites for cross browser execution
-            TestNGListenerHelper.configureCrossBrowserExecution(suites);
+        switch (TestNGListener.identifyRunType()) {
+            case TESTNG -> TestNGListenerHelper.configureTestNGProperties(suites);
+            case CUCUMBER -> CucumberHelper.configureCucumberProperties(suites);
         }
+        TestNGListenerHelper.attachConfigurationHelperClass(suites);
+        //All alterations should be finalized before duplicating the
+        //test suites for cross browser execution
+        TestNGListenerHelper.configureCrossBrowserExecution(suites);
     }
 
     /**
@@ -132,10 +116,10 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
      */
     @Override
     public void onStart(ISuite suite) {
-        if (isTestNGRun()) {
+//        if (isTestNGRun()) {
             TestNGListenerHelper.setTotalNumberOfTests(suite);
             executionStartTime = System.currentTimeMillis();
-        }
+//        }
     }
 
     /**
@@ -156,9 +140,9 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
      */
     @Override
     public void transform(ITestAnnotation annotation, Class testClass, Constructor testConstructor, Method testMethod) {
-        if (isTestNGRun()) {
+//        if (isTestNGRun()) {
             annotation.setRetryAnalyzer(RetryAnalyzer.class);
-        }
+//        }
     }
 
     /**
@@ -175,14 +159,14 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
      */
     @Override
     public void beforeInvocation(IInvokedMethod method, ITestResult iTestResult, ITestContext iTestContext) {
-        if (isTestNGRun()) {
+//        if (isTestNGRun()) {
             xmlTest = method.getTestMethod().getXmlTest();
             JiraHelper.prepareTestResultAttributes(method, iTestResult);
             TestNGListenerHelper.setTestName(iTestContext);
             TestNGListenerHelper.logTestInformation(iTestResult);
             TestNGListenerHelper.failFast(iTestResult);
             TestNGListenerHelper.skipTestsWithLinkedIssues(iTestResult);
-        }
+//        }
     }
 
     /**
@@ -199,13 +183,13 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
      */
     @Override
     public void afterInvocation(IInvokedMethod iInvokedMethod, ITestResult iTestResult, ITestContext iTestContext) {
-        if (isTestNGRun()) {
+//        if (isTestNGRun()) {
             IssueReporter.updateTestStatusInCaseOfVerificationFailure(iTestResult);
             IssueReporter.updateIssuesLog(iTestResult);
             TestNGListenerHelper.updateConfigurationMethodLogs(iTestResult);
             TestNGListenerHelper.logFinishedTestInformation(iTestResult);
             ReportManagerHelper.setDiscreteLogging(SHAFT.Properties.reporting.alwaysLogDiscreetly());
-        }
+//        }
     }
 
     /**
@@ -213,7 +197,7 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
      */
     @Override
     public void onExecutionFinish() {
-        if (isTestNGRun()) {
+//        if (isTestNGRun()) {
             ReportManagerHelper.setDiscreteLogging(true);
             JiraHelper.reportExecutionStatusToJira();
             GoogleTink.encrypt();
@@ -223,36 +207,36 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
             long executionEndTime = System.currentTimeMillis();
             ExecutionSummaryReport.generateExecutionSummaryReport(passedTests.size(), failedTests.size(), skippedTests.size(), executionStartTime, executionEndTime);
             ReportManagerHelper.logEngineClosure();
-        }
+//        }
     }
 
     @Override
     public void onTestSuccess(ITestResult result) {
-        if (isTestNGRun()) {
+//        if (isTestNGRun()) {
             passedTests.add(result.getMethod());
             ExecutionSummaryReport.casesDetailsIncrement(result.getMethod().getQualifiedName().replace("." + result.getMethod().getMethodName(), ""),
                     result.getMethod().getMethodName(), result.getMethod().getDescription(), "",
                     ExecutionSummaryReport.StatusIcon.PASSED.getValue() + ExecutionSummaryReport.Status.PASSED.name(), TestNGListenerHelper.testHasIssueAnnotation(result));
-        }
+//        }
     }
 
     @Override
     public void onTestFailure(ITestResult result) {
-        if (isTestNGRun()) {
+//        if (isTestNGRun()) {
             failedTests.add(result.getMethod());
             ExecutionSummaryReport.casesDetailsIncrement(result.getMethod().getQualifiedName().replace("." + result.getMethod().getMethodName(), ""),
                     result.getMethod().getMethodName(), result.getMethod().getDescription(), result.getThrowable().getMessage(),
                     ExecutionSummaryReport.StatusIcon.FAILED.getValue() + ExecutionSummaryReport.Status.FAILED.name(), TestNGListenerHelper.testHasIssueAnnotation(result));
-        }
+//        }
     }
 
     @Override
     public void onTestSkipped(ITestResult result) {
-        if (isTestNGRun()) {
+//        if (isTestNGRun()) {
             skippedTests.add(result.getMethod());
             ExecutionSummaryReport.casesDetailsIncrement(result.getMethod().getQualifiedName().replace("." + result.getMethod().getMethodName(), ""),
                     result.getMethod().getMethodName(), result.getMethod().getDescription(), result.getThrowable().getMessage(),
                     ExecutionSummaryReport.StatusIcon.SKIPPED.getValue() + ExecutionSummaryReport.Status.SKIPPED.name(), TestNGListenerHelper.testHasIssueAnnotation(result));
-        }
+//        }
     }
 }

--- a/src/main/java/com/shaft/listeners/internal/CucumberHelper.java
+++ b/src/main/java/com/shaft/listeners/internal/CucumberHelper.java
@@ -10,32 +10,63 @@ import com.shaft.tools.io.internal.ProjectStructureManager;
 import com.shaft.tools.io.internal.ReportHelper;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import org.testng.Reporter;
+import org.testng.xml.XmlSuite;
+
+import java.util.List;
 
 public class CucumberHelper {
 
+    public static void configureCucumberProperties(List<XmlSuite> suites) {
+        suites.forEach(suite -> {
+            // override test suite parameters adding cucumber options
+            var params = suite.getParameters();
+            params.put("cucumber.ansi-colors.disabled", String.valueOf(SHAFT.Properties.cucumber.cucumberAnsiColorsDisabled()));
+            params.put("cucumber.execution.dry-run", String.valueOf(SHAFT.Properties.cucumber.cucumberExecutionDryRun()));
+            params.put("cucumber.execution.limit", SHAFT.Properties.cucumber.cucumberExecutionLimit());
+            params.put("cucumber.execution.order", SHAFT.Properties.cucumber.cucumberExecutionOrder());
+            params.put("cucumber.execution.wip", String.valueOf(SHAFT.Properties.cucumber.cucumberExecutionWip()));
+            params.put("cucumber.features", SHAFT.Properties.cucumber.cucumberFeatures());
+            params.put("cucumber.filter.name", SHAFT.Properties.cucumber.cucumberFilterName());
+            params.put("cucumber.filter.tags", SHAFT.Properties.cucumber.cucumberFilterTags());
+            params.put("cucumber.glue", SHAFT.Properties.cucumber.cucumberGlue());
+            params.put("cucumber.plugin", SHAFT.Properties.cucumber.cucumberPlugin());
+            params.put("cucumber.object-factory", SHAFT.Properties.cucumber.cucumberObjectFactory());
+            params.put("cucumber.snippet-type", SHAFT.Properties.cucumber.cucumberSnippetType());
+            suite.setParameters(params);
+        });
+    }
+
     public static void shaftSetup() {
-        if (Reporter.getCurrentTestResult() == null) {
-            // running in native Cucumber mode
-            PropertiesHelper.initialize();
-            SHAFT.Properties.reporting.set().disableLogging(true);
-            ProjectStructureManager.initialize(ProjectStructureManager.Mode.TESTNG);
-            TestNGListenerHelper.configureJVMProxy();
-            GoogleTink.initialize();
-            GoogleTink.decrypt();
-            SHAFT.Properties.reporting.set().disableLogging(false);
+        PropertiesHelper.initialize();
+        SHAFT.Properties.reporting.set().disableLogging(true);
+        ProjectStructureManager.initialize(ProjectStructureManager.RunType.CUCUMBER);
+        TestNGListenerHelper.configureJVMProxy();
+        GoogleTink.initialize();
+        GoogleTink.decrypt();
+        SHAFT.Properties.reporting.set().disableLogging(false);
 
-            ReportManagerHelper.logEngineVersion();
-            ImageProcessingActions.loadOpenCV();
+        ReportManagerHelper.logEngineVersion();
+        ImageProcessingActions.loadOpenCV();
 
-            ReportManagerHelper.initializeAllureReportingEnvironment();
-            ReportManagerHelper.initializeExtentReportingEnvironment();
+        ReportManagerHelper.initializeAllureReportingEnvironment();
+        ReportManagerHelper.initializeExtentReportingEnvironment();
 
-            ReportHelper.attachImportantLinks();
-            ReportHelper.attachPropertyFiles();
+        ReportHelper.attachImportantLinks();
+        ReportHelper.attachPropertyFiles();
 
-            ReportManagerHelper.setDiscreteLogging(SHAFT.Properties.reporting.alwaysLogDiscreetly());
-            ReportManagerHelper.setDebugMode(SHAFT.Properties.reporting.debugMode());
-        }
+        ReportManagerHelper.setDiscreteLogging(SHAFT.Properties.reporting.alwaysLogDiscreetly());
+        ReportManagerHelper.setDebugMode(SHAFT.Properties.reporting.debugMode());
+        //set cucumber options
+        System.setProperty("cucumber.options",
+                " --dry-run " + SHAFT.Properties.cucumber.cucumberExecutionDryRun() +
+                        " --features " + SHAFT.Properties.cucumber.cucumberFeatures() +
+                        " --name " + SHAFT.Properties.cucumber.cucumberFilterName() +
+                        " --tags " + SHAFT.Properties.cucumber.cucumberFilterTags() +
+                        " --glue " + SHAFT.Properties.cucumber.cucumberGlue() +
+                        " --plugin " + SHAFT.Properties.cucumber.cucumberPlugin() +
+                        " --quiet " + SHAFT.Properties.cucumber.cucumberPublishQuiet() +
+                        " --publish " + !SHAFT.Properties.cucumber.cucumberPublishQuiet()
+        );
     }
 
     public static void shaftTeardown() {

--- a/src/main/java/com/shaft/tools/io/internal/ProjectStructureManager.java
+++ b/src/main/java/com/shaft/tools/io/internal/ProjectStructureManager.java
@@ -8,7 +8,7 @@ import com.shaft.tools.io.ReportManager;
 import java.nio.file.Paths;
 
 public class ProjectStructureManager {
-    public static void initialize(Mode mode) {
+    public static void initialize(RunType runType) {
         ReportManager.logDiscrete("Initializing Project Structure...");
         SHAFT.Properties.reporting.set().disableLogging(true);
         if (Properties.platform.executionAddress().equals("local")
@@ -21,7 +21,7 @@ public class ProjectStructureManager {
         // manually override listeners configuration
         if (Properties.platform.executionAddress().equals("local")) {
             FileActions.getInstance().deleteFolder(Properties.paths.services());
-            switch (mode) {
+            switch (runType) {
                 case JUNIT -> {
                     FileActions.getInstance().createFolder(Properties.paths.services());
                     FileActions.getInstance().writeToFile(Properties.paths.services(), "org.junit.platform.launcher.LauncherSessionListener", "com.shaft.listeners.JunitListener");
@@ -30,6 +30,10 @@ public class ProjectStructureManager {
                     FileActions.getInstance().createFolder(Properties.paths.services());
                     FileActions.getInstance().writeToFile(Properties.paths.services(), "org.testng.ITestNGListener", "com.shaft.listeners.TestNGListener");
                 }
+                case CUCUMBER -> {
+                    FileActions.getInstance().createFolder(Properties.paths.services());
+                    FileActions.getInstance().writeToFile(Properties.paths.services(), "io.cucumber.plugin.ConcurrentEventListener", "com.shaft.listeners.CucumberFeatureListener");
+                }
             }
         }
         // delete previous run execution log
@@ -37,5 +41,5 @@ public class ProjectStructureManager {
         SHAFT.Properties.reporting.set().disableLogging(false);
     }
 
-    public enum Mode {TESTNG, JUNIT}
+    public enum RunType {TESTNG, JUNIT, CUCUMBER}
 }

--- a/src/test/java/cucumberTestRunner/CucumberTestRunner.java
+++ b/src/test/java/cucumberTestRunner/CucumberTestRunner.java
@@ -1,6 +1,0 @@
-package cucumberTestRunner;
-
-import io.cucumber.testng.AbstractTestNGCucumberTests;
-
-public class CucumberTestRunner extends AbstractTestNGCucumberTests {
-}

--- a/src/test/java/cucumberTestRunner/CucumberTests.java
+++ b/src/test/java/cucumberTestRunner/CucumberTests.java
@@ -1,0 +1,8 @@
+package cucumberTestRunner;
+
+import io.cucumber.testng.AbstractTestNGCucumberTests;
+import org.testng.annotations.Listeners;
+
+@Listeners({com.shaft.listeners.TestNGListener.class})
+public class CucumberTests extends AbstractTestNGCucumberTests {
+}

--- a/src/test/resources/TestSuites/cucumber_testSuite.xml
+++ b/src/test/resources/TestSuites/cucumber_testSuite.xml
@@ -3,7 +3,7 @@
 <suite name="Suite01" verbose="10">
     <test name="Test01">
         <classes>
-            <class name="cucumberTestRunner.CucumberTestRunner">
+            <class name="cucumberTestRunner.CucumberTests">
             </class>
         </classes>
     </test>


### PR DESCRIPTION
- If a user wants to run from their testng test runner or command-line argument sometimes they will get NaN on their allure report. They now need to configure their test runner like this file `src/test/java/cucumberTestRunner/CucumberTests.java`
```java
package cucumberTestRunner;

import io.cucumber.testng.AbstractTestNGCucumberTests;
import org.testng.annotations.Listeners;

@Listeners({com.shaft.listeners.TestNGListener.class})
public class CucumberTests extends AbstractTestNGCucumberTests {
}
```
- If a user wants to run a feature file or scenario directly they will now get a log message instructing them to follow the cucumber plugin configuration in this link `https://github.com/ShaftHQ/SHAFT_ENGINE#stop-reinventing-the-wheel-start-using-shaft`
- In all cases