### PR TITLE
Selenium Webdriver Explicit waits wrapping

### DIFF
--- a/src/main/java/com/shaft/driver/SHAFT.java
+++ b/src/main/java/com/shaft/driver/SHAFT.java
@@ -77,7 +77,7 @@ public class SHAFT {
                 return new AlertActions();
             }
 
-            public WaitActions SeleniumExplicitWaits(Function<? super org.openqa.selenium.WebDriver, ?> conditions) {
+            public WaitActions CustomExplicitWaits(Function<? super org.openqa.selenium.WebDriver, ?> conditions) {
                 return new WaitActions().CustomExplicitWaits(conditions);
             }
 

--- a/src/main/java/com/shaft/driver/SHAFT.java
+++ b/src/main/java/com/shaft/driver/SHAFT.java
@@ -77,8 +77,8 @@ public class SHAFT {
                 return new AlertActions();
             }
 
-            public WaitActions CustomExplicitWaits(Function<? super org.openqa.selenium.WebDriver, ?> conditions) {
-                return new WaitActions().CustomExplicitWaits(conditions);
+            public WaitActions waitUntil(Function<? super org.openqa.selenium.WebDriver, ?> conditions) {
+                return new WaitActions().waitUntil(conditions);
             }
 
             public WizardHelpers.WebDriverAssertions assertThat() {

--- a/src/main/java/com/shaft/driver/SHAFT.java
+++ b/src/main/java/com/shaft/driver/SHAFT.java
@@ -27,6 +27,7 @@ import org.sikuli.script.App;
 import java.io.InputStream;
 import java.sql.ResultSet;
 import java.util.List;
+import java.util.function.Function;
 
 @SuppressWarnings("unused")
 public class SHAFT {
@@ -76,8 +77,8 @@ public class SHAFT {
                 return new AlertActions();
             }
 
-            public WaitActions waits() {
-                return new WaitActions();
+            public WaitActions SeleniumExplicitWaits(Function<? super org.openqa.selenium.WebDriver, ?> conditions) {
+                return new WaitActions().CustomExplicitWaits(conditions);
             }
 
             public WizardHelpers.WebDriverAssertions assertThat() {

--- a/src/main/java/com/shaft/driver/SHAFT.java
+++ b/src/main/java/com/shaft/driver/SHAFT.java
@@ -9,6 +9,7 @@ import com.shaft.driver.internal.DriverFactoryHelper;
 import com.shaft.driver.internal.WizardHelpers;
 import com.shaft.gui.browser.BrowserActions;
 import com.shaft.gui.element.*;
+import com.shaft.gui.waits.WaitActions;
 import com.shaft.listeners.internal.WebDriverListener;
 import com.shaft.tools.io.ExcelFileManager;
 import com.shaft.tools.io.JSONFileManager;
@@ -73,6 +74,10 @@ public class SHAFT {
 
             public AlertActions alert() {
                 return new AlertActions();
+            }
+
+            public WaitActions waits() {
+                return new WaitActions();
             }
 
             public WizardHelpers.WebDriverAssertions assertThat() {

--- a/src/main/java/com/shaft/driver/SHAFT.java
+++ b/src/main/java/com/shaft/driver/SHAFT.java
@@ -77,6 +77,13 @@ public class SHAFT {
                 return new AlertActions();
             }
 
+            /**
+             * Use this method to do any selenium explicit wait if needed. <br>
+             * Please note that most of the used wait methods are implemented in the related classes (browser & element)
+             *
+             * @param conditions Any Selenium explicit wait, also supports <a href="http://appium.io/docs/en/commands/mobile-command/">expected conditions</a>
+             * @return wait actions reference to be used to chain actions
+             */
             public WaitActions waitUntil(Function<? super org.openqa.selenium.WebDriver, ?> conditions) {
                 return new WaitActions().waitUntil(conditions);
             }

--- a/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -32,6 +32,7 @@ import org.openqa.selenium.remote.Augmenter;
 import org.openqa.selenium.remote.http.HttpRequest;
 import org.openqa.selenium.remote.http.HttpResponse;
 import org.openqa.selenium.remote.http.Route;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.io.ByteArrayInputStream;
 import java.net.URI;
@@ -40,6 +41,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 @SuppressWarnings("unused")
@@ -85,8 +87,8 @@ public class BrowserActions {
         return ElementActions.getInstance();
     }
 
-    public WaitActions waits() {
-        return new WaitActions();
+    public WaitActions CustomExplicitWaits(Function<? super WebDriver, ?> conditions) {
+        return new WaitActions().CustomExplicitWaits(conditions);
     }
 
     public BrowserActions and() {
@@ -816,4 +818,55 @@ public class BrowserActions {
     public void generateLightHouseReport() {
         new LightHouseGenerateReport(DriverFactoryHelper.getDriver()).generateLightHouseReport();
     }
+
+    public BrowserActions waitForLazyLoading() {
+        JavaScriptWaitManager.waitForLazyLoading();
+        return this;
+    }
+
+    public BrowserActions waitUntilTitleIs(String title) {
+        WaitActions.explicitWaits(ExpectedConditions.titleIs(title), BrowserActionsHelper.NAVIGATION_TIMEOUT_INTEGER);
+        return this;
+    }
+    
+    public BrowserActions waitUntilTitleContains(String title) {
+        WaitActions.explicitWaits(ExpectedConditions.titleContains(title), BrowserActionsHelper.NAVIGATION_TIMEOUT_INTEGER);
+        return this;
+    }
+    
+    public BrowserActions waitUntilTitleNotContains(String title) {
+        WaitActions.explicitWaits(ExpectedConditions.not(ExpectedConditions.titleContains(title)), BrowserActionsHelper.NAVIGATION_TIMEOUT_INTEGER);
+        return this;
+    }
+
+    public BrowserActions waitUntilUrlContains(String url) {
+        WaitActions.explicitWaits(ExpectedConditions.urlContains(url), BrowserActionsHelper.NAVIGATION_TIMEOUT_INTEGER);
+        return this;
+    }
+
+    public BrowserActions waitUntilUrlNotContains(String url) {
+        WaitActions.explicitWaits(ExpectedConditions.not(ExpectedConditions.urlContains(url)), BrowserActionsHelper.NAVIGATION_TIMEOUT_INTEGER);
+        return this;
+    }
+
+    public BrowserActions waitUntilUrlToBe(String url) {
+        WaitActions.explicitWaits(ExpectedConditions.urlToBe(url), BrowserActionsHelper.NAVIGATION_TIMEOUT_INTEGER);
+        return this;
+    }
+
+    public BrowserActions waitUntilUrlNotToBe(String url) {
+        WaitActions.explicitWaits(ExpectedConditions.not(ExpectedConditions.urlToBe(url)), BrowserActionsHelper.NAVIGATION_TIMEOUT_INTEGER);
+        return this;
+    }
+
+    public BrowserActions waitUntilUrlMatches(String urlRegex) {
+        WaitActions.explicitWaits(ExpectedConditions.urlMatches(urlRegex), BrowserActionsHelper.NAVIGATION_TIMEOUT_INTEGER);
+        return this;
+    }
+
+    public BrowserActions waitUntilNumberOfWindowsToBe(int numberOfWindows) {
+        WaitActions.explicitWaits(ExpectedConditions.numberOfWindowsToBe(numberOfWindows), BrowserActionsHelper.NAVIGATION_TIMEOUT_INTEGER);
+        return this;
+    }
+
 }

--- a/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -14,6 +14,7 @@ import com.shaft.gui.element.TouchActions;
 import com.shaft.gui.internal.image.ScreenshotManager;
 import com.shaft.gui.internal.locator.LocatorBuilder;
 import com.shaft.gui.internal.locator.ShadowLocatorBuilder;
+import com.shaft.gui.waits.WaitActions;
 import com.shaft.performance.internal.LightHouseGenerateReport;
 import com.shaft.tools.internal.support.JavaScriptHelper;
 import com.shaft.tools.io.ReportManager;
@@ -82,6 +83,10 @@ public class BrowserActions {
 
     public ElementActions element() {
         return ElementActions.getInstance();
+    }
+
+    public WaitActions waits() {
+        return new WaitActions();
     }
 
     public BrowserActions and() {

--- a/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -87,8 +87,8 @@ public class BrowserActions {
         return ElementActions.getInstance();
     }
 
-    public WaitActions CustomExplicitWaits(Function<? super WebDriver, ?> conditions) {
-        return new WaitActions().CustomExplicitWaits(conditions);
+    public WaitActions waitUntil(Function<? super WebDriver, ?> conditions) {
+        return new WaitActions().waitUntil(conditions);
     }
 
     public BrowserActions and() {

--- a/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -87,6 +87,13 @@ public class BrowserActions {
         return ElementActions.getInstance();
     }
 
+    /**
+     * Use this method to do any selenium explicit wait if needed. <br>
+     * Please note that most of the used wait methods are implemented in the related classes (browser & element)
+     *
+     * @param conditions Any Selenium explicit wait, also supports <a href="http://appium.io/docs/en/commands/mobile-command/">expected conditions</a>
+     * @return wait actions reference to be used to chain actions
+     */
     public WaitActions waitUntil(Function<? super WebDriver, ?> conditions) {
         return new WaitActions().waitUntil(conditions);
     }

--- a/src/main/java/com/shaft/gui/browser/internal/BrowserActionsHelper.java
+++ b/src/main/java/com/shaft/gui/browser/internal/BrowserActionsHelper.java
@@ -33,7 +33,7 @@ import java.util.*;
 
 public class BrowserActionsHelper {
     private static final Boolean HEADLESS_EXECUTION = SHAFT.Properties.web.headlessExecution();
-    private static final int NAVIGATION_TIMEOUT_INTEGER = SHAFT.Properties.timeouts.browserNavigationTimeout();
+    public static final int NAVIGATION_TIMEOUT_INTEGER = SHAFT.Properties.timeouts.browserNavigationTimeout();
 
     public static void passAction(String testData) {
         String actionName = Thread.currentThread().getStackTrace()[2].getMethodName();

--- a/src/main/java/com/shaft/gui/element/AlertActions.java
+++ b/src/main/java/com/shaft/gui/element/AlertActions.java
@@ -4,6 +4,7 @@ import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactoryHelper;
 import com.shaft.gui.browser.BrowserActions;
 import com.shaft.gui.element.internal.ElementActionsHelper;
+import com.shaft.gui.waits.WaitActions;
 import com.shaft.tools.io.ReportManager;
 import org.openqa.selenium.NoAlertPresentException;
 import org.openqa.selenium.WebDriver;
@@ -11,6 +12,7 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.time.Duration;
+import java.util.function.Function;
 
 @SuppressWarnings("unused")
 public class AlertActions {
@@ -36,6 +38,10 @@ public class AlertActions {
 
     public AlertActions and() {
         return this;
+    }
+
+    public WaitActions CustomExplicitWaits(Function<? super WebDriver, ?> conditions) {
+        return new WaitActions().CustomExplicitWaits(conditions);
     }
 
     private static void waitForAlertToBePresent() {

--- a/src/main/java/com/shaft/gui/element/AlertActions.java
+++ b/src/main/java/com/shaft/gui/element/AlertActions.java
@@ -40,6 +40,13 @@ public class AlertActions {
         return this;
     }
 
+    /**
+     * Use this method to do any selenium explicit wait if needed. <br>
+     * Please note that most of the used wait methods are implemented in the related classes (browser & element)
+     *
+     * @param conditions Any Selenium explicit wait, also supports <a href="http://appium.io/docs/en/commands/mobile-command/">expected conditions</a>
+     * @return wait actions reference to be used to chain actions
+     */
     public WaitActions waitUntil(Function<? super WebDriver, ?> conditions) {
         return new WaitActions().waitUntil(conditions);
     }

--- a/src/main/java/com/shaft/gui/element/AlertActions.java
+++ b/src/main/java/com/shaft/gui/element/AlertActions.java
@@ -40,8 +40,8 @@ public class AlertActions {
         return this;
     }
 
-    public WaitActions CustomExplicitWaits(Function<? super WebDriver, ?> conditions) {
-        return new WaitActions().CustomExplicitWaits(conditions);
+    public WaitActions waitUntil(Function<? super WebDriver, ?> conditions) {
+        return new WaitActions().waitUntil(conditions);
     }
 
     private static void waitForAlertToBePresent() {

--- a/src/main/java/com/shaft/gui/element/ElementActions.java
+++ b/src/main/java/com/shaft/gui/element/ElementActions.java
@@ -31,6 +31,7 @@ import org.sikuli.script.App;
 import java.nio.file.FileSystems;
 import java.time.Duration;
 import java.util.*;
+import java.util.function.Function;
 
 @SuppressWarnings("unused")
 public class ElementActions {
@@ -102,8 +103,8 @@ public class ElementActions {
         return new SikuliActions(applicationWindow);
     }
 
-    public WaitActions waits() {
-        return new WaitActions();
+    public WaitActions CustomExplicitWaits(Function<? super WebDriver, ?> conditions) {
+        return new WaitActions().CustomExplicitWaits(conditions);
     }
 
     public ElementActions and() {
@@ -1254,4 +1255,40 @@ public class ElementActions {
         ReportManagerHelper.log("Capture element screenshot", Collections.singletonList(ScreenshotManager.prepareImageForReport(ScreenshotManager.takeElementScreenshot(DriverFactoryHelper.getDriver(), elementLocator), "captureScreenshot")));
         return this;
     }
+
+    public ElementActions waitUntilNumberOfElementsToBe(By elementLocator, int numberOfElements) {
+        WaitActions.explicitWaits(ExpectedConditions.numberOfElementsToBe(elementLocator, numberOfElements), ElementActionsHelper.ELEMENT_IDENTIFICATION_TIMEOUT_INTEGER);
+        return this;
+    }
+
+    public ElementActions waitUntilNumberOfElementsToBeLessThan(By elementLocator, int numberOfElements) {
+        WaitActions.explicitWaits(ExpectedConditions.numberOfElementsToBeLessThan(elementLocator, numberOfElements), ElementActionsHelper.ELEMENT_IDENTIFICATION_TIMEOUT_INTEGER);
+        return this;
+    }
+
+    public ElementActions waitUntilNumberOfElementsToBeMoreThan(By elementLocator, int numberOfElements) {
+        WaitActions.explicitWaits(ExpectedConditions.numberOfElementsToBeMoreThan(elementLocator, numberOfElements), ElementActionsHelper.ELEMENT_IDENTIFICATION_TIMEOUT_INTEGER);
+        return this;
+    }
+
+    public ElementActions waitUntilAttributeContains(By elementLocator, String attribute, String attributeContainsValue) {
+        WaitActions.explicitWaits(ExpectedConditions.attributeContains(elementLocator,attribute, attributeContainsValue), ElementActionsHelper.ELEMENT_IDENTIFICATION_TIMEOUT_INTEGER);
+        return this;
+    }
+
+    public ElementActions waitUntilElementTextToBe(By elementLocator, String text) {
+        WaitActions.explicitWaits(ExpectedConditions.textToBe(elementLocator, text), ElementActionsHelper.ELEMENT_IDENTIFICATION_TIMEOUT_INTEGER);
+        return this;
+    }
+
+    public ElementActions waitUntilElementToBeSelected(By elementLocator) {
+        WaitActions.explicitWaits(ExpectedConditions.elementToBeSelected(elementLocator), ElementActionsHelper.ELEMENT_IDENTIFICATION_TIMEOUT_INTEGER);
+        return this;
+    }
+
+    public ElementActions waitUntilPresenceOfAllElementsLocatedBy(By elementLocator) {
+        WaitActions.explicitWaits(ExpectedConditions.presenceOfAllElementsLocatedBy(elementLocator), ElementActionsHelper.ELEMENT_IDENTIFICATION_TIMEOUT_INTEGER);
+        return this;
+    }
+
 }

--- a/src/main/java/com/shaft/gui/element/ElementActions.java
+++ b/src/main/java/com/shaft/gui/element/ElementActions.java
@@ -12,6 +12,7 @@ import com.shaft.gui.element.internal.ElementActionsHelper;
 import com.shaft.gui.element.internal.ElementInformation;
 import com.shaft.gui.internal.image.ScreenshotManager;
 import com.shaft.gui.internal.locator.LocatorBuilder;
+import com.shaft.gui.waits.WaitActions;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import com.shaft.validation.internal.WebDriverElementValidationsBuilder;
@@ -99,6 +100,10 @@ public class ElementActions {
 
     public SikuliActions sikulix(App applicationWindow) {
         return new SikuliActions(applicationWindow);
+    }
+
+    public WaitActions waits() {
+        return new WaitActions();
     }
 
     public ElementActions and() {

--- a/src/main/java/com/shaft/gui/element/ElementActions.java
+++ b/src/main/java/com/shaft/gui/element/ElementActions.java
@@ -103,6 +103,13 @@ public class ElementActions {
         return new SikuliActions(applicationWindow);
     }
 
+    /**
+     * Use this method to do any selenium explicit wait if needed. <br>
+     * Please note that most of the used wait methods are implemented in the related classes (browser & element)
+     *
+     * @param conditions Any Selenium explicit wait, also supports <a href="http://appium.io/docs/en/commands/mobile-command/">expected conditions</a>
+     * @return wait actions reference to be used to chain actions
+     */
     public WaitActions waitUntil(Function<? super WebDriver, ?> conditions) {
         return new WaitActions().waitUntil(conditions);
     }

--- a/src/main/java/com/shaft/gui/element/ElementActions.java
+++ b/src/main/java/com/shaft/gui/element/ElementActions.java
@@ -103,8 +103,8 @@ public class ElementActions {
         return new SikuliActions(applicationWindow);
     }
 
-    public WaitActions CustomExplicitWaits(Function<? super WebDriver, ?> conditions) {
-        return new WaitActions().CustomExplicitWaits(conditions);
+    public WaitActions waitUntil(Function<? super WebDriver, ?> conditions) {
+        return new WaitActions().waitUntil(conditions);
     }
 
     public ElementActions and() {

--- a/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java
+++ b/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java
@@ -50,6 +50,7 @@ public class ElementActionsHelper {
     private static final boolean FORCE_CHECK_FOR_ELEMENT_VISIBILITY = SHAFT.Properties.flags.forceCheckForElementVisibility();
     private static final int ELEMENT_IDENTIFICATION_POLLING_DELAY = 100; // milliseconds
     private static final String WHEN_TO_TAKE_PAGE_SOURCE_SNAPSHOT = SHAFT.Properties.visuals.whenToTakePageSourceSnapshot();
+    public static final int ELEMENT_IDENTIFICATION_TIMEOUT_INTEGER = (int)SHAFT.Properties.timeouts.defaultElementIdentificationTimeout();
 
     private ElementActionsHelper() {
         throw new IllegalStateException("Utility class");

--- a/src/main/java/com/shaft/gui/waits/WaitActions.java
+++ b/src/main/java/com/shaft/gui/waits/WaitActions.java
@@ -3,16 +3,13 @@ package com.shaft.gui.waits;
 import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactoryHelper;
 import com.shaft.gui.browser.BrowserActions;
-import com.shaft.gui.browser.internal.JavaScriptWaitManager;
 import com.shaft.gui.element.AlertActions;
 import com.shaft.gui.element.ElementActions;
 import com.shaft.gui.element.TouchActions;
 import com.shaft.tools.io.ReportManager;
-import org.apache.poi.ss.formula.functions.T;
+import com.shaft.tools.io.internal.FailureReporter;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.Wait;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.Assert;
 
@@ -41,22 +38,19 @@ public class WaitActions {
         return this;
     }
 
-    public WaitActions seleniumExplicitWaits(Function<? super WebDriver, ?> conditions) {
-        try {
-            new WebDriverWait(DriverFactoryHelper.getDriver(), Duration.ofSeconds(SHAFT.Properties.timeouts.webDriverTimeout()))
-                    .until(conditions);
-            ReportManager.log("Selenium Explicit wait \"" + conditions + "\".");
-        } catch (TimeoutException toe) {
-            ReportManager.logDiscrete(toe.getMessage());
-            Assert.fail(toe.getMessage());
-        }
-
+    public WaitActions CustomExplicitWaits(Function<? super WebDriver, ?> conditions) {
+        explicitWaits(conditions, SHAFT.Properties.timeouts.customExplicitWaitsTimeout());
         return this;
     }
 
-    public WaitActions waitForLazyLoading() {
-        JavaScriptWaitManager.waitForLazyLoading();
-        return this;
+    public static void explicitWaits(Function<? super WebDriver, ?> conditions, int timeoutWithSeconds) {
+        try {
+            new WebDriverWait(DriverFactoryHelper.getDriver(), Duration.ofSeconds(timeoutWithSeconds))
+                    .until(conditions);
+            ReportManager.log("Explicit wait until: \"" + conditions + "\".");
+        } catch (TimeoutException toe) {
+            FailureReporter.fail(toe.getMessage().split("\n")[0]);
+        }
     }
 
 }

--- a/src/main/java/com/shaft/gui/waits/WaitActions.java
+++ b/src/main/java/com/shaft/gui/waits/WaitActions.java
@@ -1,0 +1,62 @@
+package com.shaft.gui.waits;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.driver.internal.DriverFactoryHelper;
+import com.shaft.gui.browser.BrowserActions;
+import com.shaft.gui.browser.internal.JavaScriptWaitManager;
+import com.shaft.gui.element.AlertActions;
+import com.shaft.gui.element.ElementActions;
+import com.shaft.gui.element.TouchActions;
+import com.shaft.tools.io.ReportManager;
+import org.apache.poi.ss.formula.functions.T;
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.Wait;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.testng.Assert;
+
+import java.time.Duration;
+import java.util.function.Function;
+
+public class WaitActions {
+
+    public TouchActions touch() {
+        return new TouchActions();
+    }
+
+    public AlertActions alert() {
+        return new AlertActions();
+    }
+
+    public BrowserActions browser() {
+        return BrowserActions.getInstance();
+    }
+
+    public ElementActions element() {
+        return ElementActions.getInstance();
+    }
+
+    public WaitActions and() {
+        return this;
+    }
+
+    public WaitActions seleniumExplicitWaits(Function<? super WebDriver, ?> conditions) {
+        try {
+            new WebDriverWait(DriverFactoryHelper.getDriver(), Duration.ofSeconds(SHAFT.Properties.timeouts.webDriverTimeout()))
+                    .until(conditions);
+            ReportManager.log("Selenium Explicit wait \"" + conditions + "\".");
+        } catch (TimeoutException toe) {
+            ReportManager.logDiscrete(toe.getMessage());
+            Assert.fail(toe.getMessage());
+        }
+
+        return this;
+    }
+
+    public WaitActions waitForLazyLoading() {
+        JavaScriptWaitManager.waitForLazyLoading();
+        return this;
+    }
+
+}

--- a/src/main/java/com/shaft/gui/waits/WaitActions.java
+++ b/src/main/java/com/shaft/gui/waits/WaitActions.java
@@ -11,7 +11,6 @@ import com.shaft.tools.io.internal.FailureReporter;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.WebDriverWait;
-import org.testng.Assert;
 
 import java.time.Duration;
 import java.util.function.Function;
@@ -38,8 +37,8 @@ public class WaitActions {
         return this;
     }
 
-    public WaitActions CustomExplicitWaits(Function<? super WebDriver, ?> conditions) {
-        explicitWaits(conditions, SHAFT.Properties.timeouts.customExplicitWaitsTimeout());
+    public WaitActions waitUntil(Function<? super WebDriver, ?> conditions) {
+        explicitWaits(conditions, SHAFT.Properties.timeouts.waitUntilTimeout());
         return this;
     }
 

--- a/src/main/java/com/shaft/properties/internal/Timeouts.java
+++ b/src/main/java/com/shaft/properties/internal/Timeouts.java
@@ -84,9 +84,9 @@ public interface Timeouts extends EngineProperties {
     @DefaultValue("10")
     int remoteServerInstanceCreationTimeout();
 
-    @Key("customExplicitWaitsTimeout")
+    @Key("waitUntilTimeout")
     @DefaultValue("60")
-    int customExplicitWaitsTimeout();
+    int waitUntilTimeout();
 
     default SetProperty set() {
         return new SetProperty();
@@ -178,8 +178,8 @@ public interface Timeouts extends EngineProperties {
             return this;
         }
 
-        public SetProperty customExplicitWaitsTimeout(int value) {
-            setProperty("customExplicitWaitsTimeout", String.valueOf(value));
+        public SetProperty waitUntilTimeout(int value) {
+            setProperty("waitUntilTimeout", String.valueOf(value));
             return this;
         }
 

--- a/src/main/java/com/shaft/properties/internal/Timeouts.java
+++ b/src/main/java/com/shaft/properties/internal/Timeouts.java
@@ -84,9 +84,9 @@ public interface Timeouts extends EngineProperties {
     @DefaultValue("10")
     int remoteServerInstanceCreationTimeout();
 
-    @Key("webDriverTimeout")
+    @Key("customExplicitWaitsTimeout")
     @DefaultValue("60")
-    int webDriverTimeout();
+    int customExplicitWaitsTimeout();
 
     default SetProperty set() {
         return new SetProperty();
@@ -178,8 +178,8 @@ public interface Timeouts extends EngineProperties {
             return this;
         }
 
-        public SetProperty webDriverTimeout(int value) {
-            setProperty("webDriverTimeout", String.valueOf(value));
+        public SetProperty customExplicitWaitsTimeout(int value) {
+            setProperty("customExplicitWaitsTimeout", String.valueOf(value));
             return this;
         }
 

--- a/src/main/java/com/shaft/properties/internal/Timeouts.java
+++ b/src/main/java/com/shaft/properties/internal/Timeouts.java
@@ -84,6 +84,10 @@ public interface Timeouts extends EngineProperties {
     @DefaultValue("10")
     int remoteServerInstanceCreationTimeout();
 
+    @Key("webDriverTimeout")
+    @DefaultValue("60")
+    int webDriverTimeout();
+
     default SetProperty set() {
         return new SetProperty();
     }
@@ -171,6 +175,11 @@ public interface Timeouts extends EngineProperties {
 
         public SetProperty remoteServerInstanceCreationTimeout(int value) {
             setProperty("remoteServerInstanceCreationTimeout", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty webDriverTimeout(int value) {
+            setProperty("webDriverTimeout", String.valueOf(value));
             return this;
         }
 


### PR DESCRIPTION
Added some on the most important waits in to the browser and element actions (supporting the fluency wizard) and added a custom method to be used anytime to have the flexibility for creating any custom waits including and & or methods if/when needed by the users.
Usage should be something like this:
![image](https://github.com/ShaftHQ/SHAFT_ENGINE/assets/46620378/0b81cf3e-35ef-4967-8200-376768e55476)
