### PR TITLE
Bump com.fasterxml.jackson.datatype:jackson-datatype-jdk8 from 2.15.3…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -413,7 +413,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>2.15.3</version>
+            <version>2.16.0</version>
         </dependency>
 
         <!-- VISUAL VALIDATIONS & ELEMENT IDENTIFICATION -->


### PR DESCRIPTION
… to 2.16.0 (#1365)

Bump com.fasterxml.jackson.datatype:jackson-datatype-jdk8

Bumps com.fasterxml.jackson.datatype:jackson-datatype-jdk8 from 2.15.3 to 2.16.0.

---
updated-dependencies:
- dependency-name: com.fasterxml.jackson.datatype:jackson-datatype-jdk8 dependency-type: direct:production update-type: version-update:semver-minor ...