### PR TITLE
moving engine teardown logic

### DIFF
--- a/src/main/java/com/shaft/listeners/JunitListener.java
+++ b/src/main/java/com/shaft/listeners/JunitListener.java
@@ -38,6 +38,11 @@ public class JunitListener implements LauncherSessionListener {
                 }
 
                 @Override
+                public void testPlanExecutionFinished(TestPlan testPlan) {
+                    engineTeardown();
+                }
+
+                @Override
                 public void executionSkipped(TestIdentifier testIdentifier, String reason) {
                     afterInvocation();
                     onTestSkipped(testIdentifier, reason);
@@ -65,12 +70,6 @@ public class JunitListener implements LauncherSessionListener {
             });
         }
     }
-
-    @Override
-    public void launcherSessionClosed(LauncherSession session) {
-        engineTeardown();
-    }
-
     private void engineSetup() {
         ReportManagerHelper.setDiscreteLogging(true);
         PropertiesHelper.initialize();


### PR DESCRIPTION
- teardown logic was implemented inside the launcherSessionClosed action of JUNit's LauncherSessionListener. This caused several activities to happen multiple times in case of executing several classes.
- moved it to testPlanExecutionFinished trigger in the TestExecutionListener implementation to ensure it runs only once.