### PR TITLE
Fix Lambdatest issues in iOS

### DIFF
--- a/src/test/java/testPackage/LambdaTest/Test_LTMobIPAAppURL.java
+++ b/src/test/java/testPackage/LambdaTest/Test_LTMobIPAAppURL.java
@@ -30,10 +30,11 @@ public class Test_LTMobIPAAppURL {
         SHAFT.Properties.platform.set().executionAddress("lambdatest");
         SHAFT.Properties.lambdaTest.set().platformVersion("15");
         SHAFT.Properties.lambdaTest.set().deviceName("iPhone 13");
-        SHAFT.Properties.lambdaTest.set().appUrl("lt://APP10160631101690360659784171");
+        SHAFT.Properties.lambdaTest.set().appUrl("lt://APP10160612541701952809945764");
         SHAFT.Properties.mobile.set().browserName("");
         SHAFT.Properties.lambdaTest.set().username(testData.getTestData("LambdaTestUserName"));
         SHAFT.Properties.lambdaTest.set().accessKey(testData.getTestData("LambdaTestAccessKey"));
+        SHAFT.Properties.flags.set().attemptClearBeforeTyping(false);
         driver = new SHAFT.GUI.WebDriver();
 
     }

--- a/src/test/java/testPackage/LambdaTest/Test_LTMobIPARelativePath.java
+++ b/src/test/java/testPackage/LambdaTest/Test_LTMobIPARelativePath.java
@@ -43,6 +43,7 @@ public class Test_LTMobIPARelativePath {
         SHAFT.Properties.lambdaTest.set().isRealMobile(true);
         SHAFT.Properties.lambdaTest.set().username(testData.getTestData("LambdaTestUserName"));
         SHAFT.Properties.lambdaTest.set().accessKey(testData.getTestData("LambdaTestAccessKey"));
+        SHAFT.Properties.flags.set().attemptClearBeforeTyping(false);
         driver = DriverFactory.getDriver();
 
     }


### PR DESCRIPTION
- Simply they deleted the old app url so the app was not found 
- added the flag to disable the clearing before typing in Mobile element till it's fixed