### PR TITLE
flagging bidi enablement

### DIFF
--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  GLOBAL_TESTING_SCOPE: "!%regex[.*Tests_Api.*], !%regex[.*NetworkInterceptionTest.*], !%regex[.*DatabaseTests.*], !%regex[.*MobileEmulation.*], !%regex[.*Healenium.*], !%regex[.*Release.*], !%regex[.*checksum.*], !%regex[.*cucumber.*], !%regex[.*ikuli.*], !%regex[.*Comparison.*], !%regex[.*FileActions.*], !%regex[.*TerminalActions.*], !%regex[.*Shell.*], !%regex[.*fullPageScreenshotWithHeader.*], !%regex[.*dbConnection.*], !%regex[.*appium.*], !%regex[.*ndroid.*],!%regex[.*obile.*], !%regex[.*ios.*], !%regex[.*IOS.*], !%regex[.*BasicAuthentication.*], !%regex[.*Test_LT*.*], !%regex[.*Tests_Api.*], !%regex[.*tests_restActions.*], !%regex[.*Test_AssertApiResponseEquals.*], !%regex[.*MatchJsonSchemaTests.*]"
+  GLOBAL_TESTING_SCOPE: "!%regex[.*MultipleBrowserInstancesTest.*], !%regex[.*Tests_Api.*], !%regex[.*NetworkInterceptionTest.*], !%regex[.*DatabaseTests.*], !%regex[.*MobileEmulation.*], !%regex[.*Healenium.*], !%regex[.*Release.*], !%regex[.*checksum.*], !%regex[.*cucumber.*], !%regex[.*ikuli.*], !%regex[.*Comparison.*], !%regex[.*FileActions.*], !%regex[.*TerminalActions.*], !%regex[.*Shell.*], !%regex[.*fullPageScreenshotWithHeader.*], !%regex[.*dbConnection.*], !%regex[.*appium.*], !%regex[.*ndroid.*],!%regex[.*obile.*], !%regex[.*ios.*], !%regex[.*IOS.*], !%regex[.*BasicAuthentication.*], !%regex[.*Test_LT*.*], !%regex[.*Tests_Api.*], !%regex[.*tests_restActions.*], !%regex[.*Test_AssertApiResponseEquals.*], !%regex[.*MatchJsonSchemaTests.*]"
 
 jobs:
   #  Ubuntu_Database:

--- a/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -383,8 +383,8 @@ public class DriverFactoryHelper {
     }
 
     @SneakyThrows({java.net.MalformedURLException.class, InterruptedException.class})
-    private static RemoteWebDriver attemptRemoteServerConnection(Capabilities capabilities) {
-        RemoteWebDriver driver = null;
+    private static WebDriver attemptRemoteServerConnection(Capabilities capabilities) {
+        WebDriver driver = null;
         boolean isRemoteConnectionEstablished = false;
         var startTime = System.currentTimeMillis();
         var exception = "";
@@ -416,7 +416,7 @@ public class DriverFactoryHelper {
         return driver;
     }
 
-    private static RemoteWebDriver connectToRemoteServer(Capabilities capabilities, boolean isLegacy) throws MalformedURLException, URISyntaxException {
+    private static WebDriver connectToRemoteServer(Capabilities capabilities, boolean isLegacy) throws MalformedURLException, URISyntaxException {
         var targetHubUrl = isLegacy ? TARGET_HUB_URL + "wd/hub" : TARGET_HUB_URL;
         var targetLambdaTestHubURL = targetHubUrl.replace("http", "https");
         var targetPlatform = Properties.platform.targetPlatform();
@@ -444,9 +444,15 @@ public class DriverFactoryHelper {
             }
         } else {
             if (SHAFT.Properties.platform.executionAddress().contains("lambdatest")) {
-                return new RemoteWebDriver(new URI(targetLambdaTestHubURL).toURL(), capabilities);
+                return new RemoteWebDriver(new URI(targetLambdaTestHubURL).toURL(), capabilities, false);
             } else {
-                return new RemoteWebDriver(new URI(targetHubUrl).toURL(), capabilities);
+                // ToDo: Upgrade to using Augmenter and RemoteWebDriver builder instead of old native implementation
+//                return RemoteWebDriver.builder().address(new URI(targetHubUrl).toURL())
+//                        .augmentUsing(new Augmenter())
+//                        .addAlternative(capabilities)
+//                        .config(ClientConfig.defaultConfig())
+//                        .build();
+                return new RemoteWebDriver(new URI(targetHubUrl).toURL(), capabilities, false);
             }
         }
     }
@@ -533,7 +539,6 @@ public class DriverFactoryHelper {
         initializeSystemProperties();
         try {
             var isMobileExecution = Platform.ANDROID.toString().equalsIgnoreCase(SHAFT.Properties.platform.targetPlatform()) || Platform.IOS.toString().equalsIgnoreCase(SHAFT.Properties.platform.targetPlatform());
-
             if (isMobileExecution) {
                 //mobile execution
                 if (isMobileWebExecution()) {

--- a/src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java
+++ b/src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java
@@ -85,7 +85,7 @@ public class OptionsManager {
                     ffOptions.setProxy(proxy);
                 }
                 // Enable BiDi
-                ffOptions.setCapability("webSocketUrl", true);
+                ffOptions.setCapability("webSocketUrl", SHAFT.Properties.platform.enableBiDi());
                 //merge customWebDriverCapabilities.properties
                 ffOptions = ffOptions.merge(PropertyFileManager.getCustomWebDriverDesiredCapabilities());
                 //merge hardcoded custom options
@@ -237,7 +237,8 @@ public class OptionsManager {
 
     @SuppressWarnings("SpellCheckingInspection")
     private ChromiumOptions<?> setupChromiumOptions(ChromiumOptions<?> options, MutableCapabilities customDriverOptions) {
-        if (!SHAFT.Properties.platform.executionAddress().equalsIgnoreCase("local"))
+        String executionAddress = SHAFT.Properties.platform.executionAddress().toLowerCase();
+        if (!executionAddress.equalsIgnoreCase("local"))
             options.setCapability(CapabilityType.PLATFORM_NAME, Properties.platform.targetPlatform());
         if (SHAFT.Properties.web.headlessExecution()) {
             options.addArguments("--headless=new");
@@ -305,7 +306,7 @@ public class OptionsManager {
             options.setExperimentalOption("mobileEmulation", mobileEmulation);
         }
         // Enable BiDi
-        options.setCapability("webSocketUrl", true);
+        options.setCapability("webSocketUrl", SHAFT.Properties.platform.enableBiDi());
         //merge customWebdriverCapabilities.properties
         options = (ChromiumOptions<?>) options.merge(PropertyFileManager.getCustomWebDriverDesiredCapabilities());
         //merge hardcoded custom options

--- a/src/main/java/com/shaft/properties/internal/Platform.java
+++ b/src/main/java/com/shaft/properties/internal/Platform.java
@@ -34,6 +34,10 @@ public interface Platform extends EngineProperties {
     @DefaultValue("true")
     boolean jvmProxySettings();
 
+    @Key("enableBiDi")
+    @DefaultValue("true")
+    boolean enableBiDi();
+
     private static void setProperty(String key, String value) {
         var updatedProps = new java.util.Properties();
         updatedProps.setProperty(key, value);
@@ -79,6 +83,11 @@ public interface Platform extends EngineProperties {
 
         public SetProperty jvmProxySettings(boolean value) {
             setProperty("jvmProxySettings", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty enableBiDi(boolean value) {
+            setProperty("enableBiDi", String.valueOf(value));
             return this;
         }
     }

--- a/src/test/java/junitTestPackage/MoonTests.java
+++ b/src/test/java/junitTestPackage/MoonTests.java
@@ -1,0 +1,79 @@
+package junitTestPackage;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.tools.io.ReportManager;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.devtools.DevTools;
+import org.openqa.selenium.devtools.HasDevTools;
+import org.openqa.selenium.remote.Augmenter;
+import poms.GoogleSearch;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static com.shaft.driver.DriverFactory.DriverType.CHROME;
+
+public class MoonTests {
+    private SHAFT.GUI.WebDriver driver;
+
+    //    @BeforeAll
+    public static void beforeAll() {
+        SHAFT.Properties.platform.set().executionAddress("http://moon.aerokube.local/wd/hub");
+        SHAFT.Properties.web.set().headlessExecution(true);
+        SHAFT.Properties.timeouts.set().remoteServerInstanceCreationTimeout(1);
+        SHAFT.Properties.platform.set().enableBiDi(false);
+    }
+
+    private static ChromeOptions getMoonCapabilities(String testName) {
+        var options = new ChromeOptions();
+        options.setCapability("moon:options", new HashMap<String, Object>() {{
+            /* How to add test badge */
+            put("name", testName);
+
+            /* How to set session timeout */
+            put("sessionTimeout", "15m");
+
+            /* How to set timezone */
+            put("env", new ArrayList<String>() {{
+                add("TZ=UTC");
+            }});
+
+            /* How to add "trash" button */
+            put("labels", new HashMap<String, Object>() {{
+                put("manual", "true");
+            }});
+
+            /* How to enable video recording */
+            put("enableVideo", true);
+        }});
+        return options;
+    }
+
+    //    @Test
+    public void regularDriver() {
+        var searchPage = new GoogleSearch(driver.getDriver());
+        searchPage.navigateToURL();
+        searchPage.assertPageIsOpen();
+    }
+
+    //    @Test
+    public void augmentedDriver() {
+        var nativeDriver = driver.getDriver();
+        nativeDriver = new Augmenter().augment(driver.getDriver());
+        DevTools devTools = ((HasDevTools) nativeDriver).getDevTools();
+        ReportManager.logDiscrete(devTools.getDomains().toString());
+        var searchPage = new GoogleSearch(nativeDriver);
+        searchPage.navigateToURL();
+        searchPage.assertPageIsOpen();
+    }
+
+    //    @BeforeEach
+    public void beforeMethod() {
+        driver = new SHAFT.GUI.WebDriver(CHROME, getMoonCapabilities("test"));
+    }
+
+    //    @AfterEach
+    public void afterMethod() {
+        driver.quit();
+    }
+}

--- a/src/test/java/testPackage/mockedTests/MultipleBrowserInstancesTest.java
+++ b/src/test/java/testPackage/mockedTests/MultipleBrowserInstancesTest.java
@@ -1,0 +1,35 @@
+package testPackage.mockedTests;
+
+import com.shaft.driver.SHAFT;
+import org.openqa.selenium.By;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+
+public class MultipleBrowserInstancesTest {
+    ArrayList<SHAFT.GUI.WebDriver> drivers = new ArrayList<>();
+    String testElement = "data:text/html,<input type=\"text\"/><br><br>";
+    By locator = SHAFT.GUI.Locator.hasTagName("input").build();
+
+    @Test
+    public void multipleInstancesSwitching() {
+        drivers.add(new SHAFT.GUI.WebDriver());
+        drivers.get(0).browser().navigateToURL(testElement)
+                .and().element().type(locator, "first string");
+
+        drivers.add(new SHAFT.GUI.WebDriver());
+        drivers.get(1).browser().navigateToURL(testElement)
+                .and().element().type(locator, "second string");
+
+        drivers.get(0).element().assertThat(locator).text().isEqualTo("first string")
+                .perform();
+        drivers.get(1).element().assertThat(locator).text().isEqualTo("second string")
+                .perform();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void afterMethod() {
+        drivers.forEach(SHAFT.GUI.WebDriver::quit);
+    }
+}

--- a/src/test/java/testPackage/properties/PlatformTests.java
+++ b/src/test/java/testPackage/properties/PlatformTests.java
@@ -11,6 +11,7 @@ public class PlatformTests {
     String proxy;
     Boolean driverProxy;
     Boolean jvmProxy;
+    Boolean enableBiDi;
 
     @BeforeClass
     public void beforeClass() {
@@ -20,6 +21,7 @@ public class PlatformTests {
         proxy = SHAFT.Properties.platform.proxy();
         driverProxy = SHAFT.Properties.platform.driverProxySettings();
         jvmProxy = SHAFT.Properties.platform.jvmProxySettings();
+        enableBiDi = SHAFT.Properties.platform.enableBiDi();
     }
 
     @Test
@@ -30,5 +32,6 @@ public class PlatformTests {
         SHAFT.Properties.platform.set().proxySettings(proxy);
         SHAFT.Properties.platform.set().driverProxySettings(driverProxy);
         SHAFT.Properties.platform.set().jvmProxySettings(jvmProxy);
+        SHAFT.Properties.platform.set().enableBiDi(enableBiDi);
     }
 }


### PR DESCRIPTION
user can now disable BiDi as it conflicts with certain non-standard grid implementations like moon and selenoid

Code: `SHAFT.Properties.platform.set().enableBiDi(false);`
Property file: `enableBiDi=false`
CommandLine: `-DenableBiDi=false`