### PR TITLE
Execution summary report fixes #1680

### DIFF
--- a/src/main/java/com/shaft/validation/internal/ValidationsHelper2.java
+++ b/src/main/java/com/shaft/validation/internal/ValidationsHelper2.java
@@ -263,15 +263,18 @@ public class ValidationsHelper2 {
         if (!validationState) {
             String failureMessage = this.validationCategoryString.replace("erify", "erificat") + "ion failed; expected " + expected + ", but found " + actual;
             if (this.validationCategory.equals(ValidationEnums.ValidationCategory.HARD_ASSERT)) {
+                ReportManagerHelper.logNestedSteps(failureMessage, null ,null);
                 Allure.getLifecycle().updateStep(stepResult -> FailureReporter.fail(failureMessage));
             } else {
                 // soft assert
                 ValidationsHelper.verificationFailuresList.add(failureMessage);
                 ValidationsHelper.verificationError = new AssertionError(String.join("\nAND ", ValidationsHelper.verificationFailuresList));
                 Allure.getLifecycle().updateStep(stepResult -> ReportManager.log(failureMessage));
+                ReportManagerHelper.logNestedSteps(failureMessage, null ,null);
             }
         } else {
             Allure.getLifecycle().updateStep(stepResult -> ReportManager.log(this.validationCategoryString.replace("erify", "erificat") + "ion passed"));
+            ReportManagerHelper.logNestedSteps(validationCategoryString.replace("erify", "erificat") + "ion passed" , null ,null);
         }
     }
 }


### PR DESCRIPTION
Fix validations section in Execution summary report to show correct number of validations instead of zeroes
<img width="1031" alt="Screen Shot 2024-08-12 at 5 24 51 AM" src="https://github.com/user-attachments/assets/65b99dd0-8a81-428d-9e55-5334f32c4976">
<img width="1280" alt="Screen Shot 2024-08-12 at 5 10 27 AM" src="https://github.com/user-attachments/assets/473bb2f0-8544-4b48-8838-1f8873875479">
[New Reports.zip](https://github.com/user-attachments/files/16576897/New.Reports.zip)
