### PR TITLE
Fix: Ensure Content-Type is set based on header value if not explicit…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
 
     <dependencyManagement>
         <dependencies>
+
             <!-- JUNIT5 BOM -->
             <!-- https://mvnrepository.com/artifact/org.junit/junit-bom -->
             <dependency>

--- a/src/main/java/com/shaft/api/RestActions.java
+++ b/src/main/java/com/shaft/api/RestActions.java
@@ -933,8 +933,18 @@ public class RestActions {
                                                        Object body, ContentType contentType, Map<String, Object> sessionCookies, Map<String, String> sessionHeaders, RestAssuredConfig sessionConfig, boolean appendDefaultContentCharsetToContentTypeIfUndefined, boolean urlEncodingEnabled) {
         RequestSpecBuilder builder = initializeBuilder(sessionCookies, sessionHeaders, sessionConfig, appendDefaultContentCharsetToContentTypeIfUndefined);
 
-        // set the default content type as part of the specs
-        builder.setContentType(contentType);
+        // Check if contentType is still ANY and use the Content-Type header value directly
+        if (contentType == ContentType.ANY) {
+            String contentTypeHeader = sessionHeaders.get("Content-Type");
+            if (contentTypeHeader != null) {
+                // Set the content type to the exact header value
+                builder.setContentType(contentTypeHeader);
+            }
+        } else {
+            // If contentType is explicitly set, use it
+            builder.setContentType(contentType);
+        }
+
         builder.setUrlEncodingEnabled(urlEncodingEnabled);
 
         if (body != null && contentType != null && !body.toString().isEmpty()) {

--- a/src/test/java/com/shaft/api/testss.java
+++ b/src/test/java/com/shaft/api/testss.java
@@ -1,0 +1,95 @@
+package com.shaft.api;
+
+import com.shaft.driver.SHAFT;
+import io.qameta.allure.TmsLinks;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * @author Kyrillos Nageh
+ */
+public class testss {
+    SHAFT.API api;
+
+
+    @BeforeClass
+    public void setUp() {
+       // api = new SHAFT.API("http://www.dneonline.com");
+    }
+
+    @Test
+    public void testCreateUser() {
+
+
+    String requestBody= "    {\n" +
+            "        \"name\": \"Test user1\",\n" +
+            "        \"job\": \"leader\"\n" +
+            "    }";
+
+        api = new SHAFT.API("https://reqres.in/api/");
+       //api.addHeader("Content-Type", "application/json");
+        Response response = api.post("users")
+                .setContentType("application/json")
+                        .setRequestBody(requestBody)
+                                .performRequest();
+        System.out.println("Response Body: " + response.getBody().asString());
+    }
+    @Test
+    public void testAddOperation() {
+        /*
+        AddRequest request = AddRequest.builder()
+                .intA(5)
+                .intB(10)
+                .build();
+
+        AddResponse response = calculatorService.add(request);
+        Assert.assertEquals(response.getAddResult(), 15);
+
+         */
+
+        String requestXml = "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">\n" +
+                "   <soapenv:Body>\n" +
+                "      <tem:Multiply xmlns:tem=\"http://tempuri.org/\">\n" +
+                "         <tem:intA>10</tem:intA>\n" +
+                "         <tem:intB>2</tem:intB>\n" +
+                "      </tem:Multiply>\n" +
+                "   </soapenv:Body>\n" +
+                "</soapenv:Envelope>";
+
+        api = new SHAFT.API("");
+       api.addHeader("Content-Type", "text/xml; charset=UTF-8");
+        api.addHeader("SOAPAction", "http://tempuri.org/" + "Multiply");
+
+        System.out.println("Request Body: " + requestXml);
+
+        Response response = api.post("http://www.dneonline.com/calculator.asmx")
+                .setRequestBody(requestXml)
+                .performRequest();
+
+        String Result =RestActions.getResponseXMLValue(response, "AddResponse/AddResult");
+
+        SHAFT.Report.log(">>>>>>>>>>>> Test result >>>> " + Result);
+
+/*
+        Response response = given()
+                .header("Content-Type", "text/xml")
+                .contentType(ContentType.XML)
+                .header("SOAPAction", "http://tempuri.org/" + "Multiply")
+                .body(requestXml)
+                .when()
+                .post("http://www.dneonline.com/calculator.asmx")
+                .then()
+                .statusCode(200)  // Validate status code directly
+                .extract().response();
+
+        String Result =RestActions.getResponseXMLValue(response, "AddResponse/AddResult");
+
+        SHAFT.Report.log(">>>>>>>>>>>> Test result >>>> " + Result);
+*/
+    }
+
+}
+

--- a/src/test/resources/META-INF/services/io.qameta.allure.listener.ContainerLifecycleListener
+++ b/src/test/resources/META-INF/services/io.qameta.allure.listener.ContainerLifecycleListener
@@ -1,0 +1,1 @@
+com.shaft.listeners.AllureListener

--- a/src/test/resources/META-INF/services/io.qameta.allure.listener.FixtureLifecycleListener
+++ b/src/test/resources/META-INF/services/io.qameta.allure.listener.FixtureLifecycleListener
@@ -1,0 +1,1 @@
+com.shaft.listeners.AllureListener

--- a/src/test/resources/META-INF/services/io.qameta.allure.listener.StepLifecycleListener
+++ b/src/test/resources/META-INF/services/io.qameta.allure.listener.StepLifecycleListener
@@ -1,0 +1,1 @@
+com.shaft.listeners.AllureListener

--- a/src/test/resources/META-INF/services/io.qameta.allure.listener.TestLifecycleListener
+++ b/src/test/resources/META-INF/services/io.qameta.allure.listener.TestLifecycleListener
@@ -1,0 +1,1 @@
+com.shaft.listeners.AllureListener

--- a/src/test/resources/META-INF/services/org.testng.ITestNGListener
+++ b/src/test/resources/META-INF/services/org.testng.ITestNGListener
@@ -1,0 +1,1 @@
+com.shaft.listeners.TestNGListener


### PR DESCRIPTION
Fixes [#1697](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/1697)

This PR ensures that the `Content-Type` is set based on the header value if it is not explicitly set by the user.
- Modified the `prepareRequestSpecs` method to check if `contentType` is still `ContentType.ANY`.
- If `ContentType` is not explicitly set by the user, it now retrieves the `Content-Type` from `sessionHeaders` and applies it directly to the `RequestSpecBuilder`.
- This change ensures that the request uses the exact `Content-Type` provided in the headers, preventing encoding and serialization issues.
