### PR TITLE
add clearBeforeTypingMode flag and deprecating old flags 

### DIFF
--- a/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -152,15 +152,20 @@ public class Actions extends ElementActions {
                         }
                     }
                     case TYPE -> {
-                        if (SHAFT.Properties.flags.attemptClearBeforeTyping())
-                            foundElements.get().getFirst().clear();
+                        String clearMode = SHAFT.Properties.flags.clearMode();
+                        switch(clearMode){
+                            case "native":
+                                foundElements.get().getFirst().clear();
+                                break ;
+                            case "backspace":
+                                String text = parseElementText(foundElements.get().getFirst());
+                                if (!text.isEmpty())
+                                    foundElements.get().getFirst().sendKeys(String.valueOf(Keys.BACK_SPACE).repeat(text.length()));
+                                break ;
+                            case"off":
+                                break;
 
-                        if (SHAFT.Properties.flags.attemptClearBeforeTypingUsingBackspace()){
-                            String text = parseElementText(foundElements.get().getFirst());
-                            if (!text.isEmpty())
-                                foundElements.get().getFirst().sendKeys(String.valueOf(Keys.BACK_SPACE).repeat(text.length()));
                         }
-
                         foundElements.get().getFirst().sendKeys((CharSequence) data);
                     }
                     case GET_NAME -> output.set(foundElements.get().getFirst().getAccessibleName());

--- a/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -152,7 +152,7 @@ public class Actions extends ElementActions {
                         }
                     }
                     case TYPE -> {
-                        String clearMode = SHAFT.Properties.flags.clearMode();
+                        String clearMode = SHAFT.Properties.flags.clearBeforeTypingMode();
                         switch(clearMode){
                             case "native":
                                 foundElements.get().getFirst().clear();

--- a/src/main/java/com/shaft/properties/internal/Flags.java
+++ b/src/main/java/com/shaft/properties/internal/Flags.java
@@ -45,6 +45,11 @@ public interface Flags extends EngineProperties<Flags> {
     @DefaultValue("true")
     boolean attemptClearBeforeTyping();
 
+    @Key("clearMode")
+    @DefaultValue("native")
+    String clearMode();
+
+
     @Key("forceCheckNavigationWasSuccessful")
     @DefaultValue("false")
     boolean forceCheckNavigationWasSuccessful();
@@ -132,6 +137,11 @@ public interface Flags extends EngineProperties<Flags> {
             return this;
         }
 
+
+        public SetProperty clearMode (String value) {
+            setProperty("clearMode", value);
+            return this;
+        }
         public SetProperty attemptClearBeforeTypingUsingBackspace(boolean value) {
             setProperty("attemptClearBeforeTypingUsingBackspace", String.valueOf(value));
             return this;

--- a/src/main/java/com/shaft/properties/internal/Flags.java
+++ b/src/main/java/com/shaft/properties/internal/Flags.java
@@ -45,9 +45,9 @@ public interface Flags extends EngineProperties<Flags> {
     @DefaultValue("true")
     boolean attemptClearBeforeTyping();
 
-    @Key("clearMode")
+    @Key("clearBeforeTypingMode")
     @DefaultValue("native")
-    String clearMode();
+    String clearBeforeTypingMode();
 
 
     @Key("forceCheckNavigationWasSuccessful")
@@ -131,19 +131,35 @@ public interface Flags extends EngineProperties<Flags> {
             setProperty("forceCheckTextWasTypedCorrectly", String.valueOf(value));
             return this;
         }
-
+        /**
+         Please use {@link #clearBeforeTypingMode(String value)} instead.
+              */
+       @Deprecated()
         public SetProperty attemptClearBeforeTyping(boolean value) {
             setProperty("attemptClearBeforeTyping", String.valueOf(value));
             return this;
         }
 
-
-        public SetProperty clearMode (String value) {
-            setProperty("clearMode", value);
-            return this;
-        }
+        /**
+         Please use {@link #clearBeforeTypingMode(String value)} instead.
+         */
+        @Deprecated
         public SetProperty attemptClearBeforeTypingUsingBackspace(boolean value) {
             setProperty("attemptClearBeforeTypingUsingBackspace", String.valueOf(value));
+            return this;
+        }
+
+        /**
+         *
+         * @param value
+         *   <ul>
+         *          <li><b>native</b> = clear using native Selenium method</li>
+         *          <li><b>backspace</b> = clear by deleting letter by letter</li>
+         *           <li><b>off</b> = no clearing</li>
+         *          </ul>
+         */
+        public SetProperty clearBeforeTypingMode(String value) {
+            setProperty("clearBeforeTypingMode", value);
             return this;
         }
 

--- a/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
+++ b/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
@@ -69,21 +69,20 @@ public class PropertiesHelper {
         overrideScreenshotTypeForSafariBrowser();
         overrideScreenshotTypeForParallelExecution();
         setExtraAllureProperties();
-        setClearMode();
+        setClearBeforeTypingMode();
     }
 
-    private static void setClearMode(){
-       if (Properties.flags.attemptClearBeforeTyping()){
-           SHAFT.Properties.flags.set().clearMode("native");
-       }
-       if (Properties.flags.attemptClearBeforeTypingUsingBackspace()) {
-           SHAFT.Properties.flags.set().clearMode("backspace");
-       }
-       else {
-           SHAFT.Properties.flags.set().clearMode("off");
+    private static void setClearBeforeTypingMode(){
+        if (!Properties.flags.attemptClearBeforeTyping() || SHAFT.Properties.flags.clearBeforeTypingMode().equals("off")) {
+            SHAFT.Properties.flags.set().clearBeforeTypingMode("off");
+            return ;
         }
-    }
 
+        if (Properties.flags.attemptClearBeforeTypingUsingBackspace() || SHAFT.Properties.flags.clearBeforeTypingMode().equals("backspace")) {
+            SHAFT.Properties.flags.set().clearBeforeTypingMode("backspace");
+          }
+    }
+    
     private static void overrideScreenshotTypeForParallelExecution() {
         if (!Properties.testNG.parallel().equals("NONE"))
             SHAFT.Properties.visuals.set().screenshotParamsScreenshotType(String.valueOf(Screenshots.VIEWPORT));

--- a/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
+++ b/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
@@ -10,6 +10,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.openqa.selenium.remote.Browser;
 
+import java.awt.*;
 import java.io.File;
 import java.net.URL;
 import java.util.Arrays;
@@ -68,6 +69,19 @@ public class PropertiesHelper {
         overrideScreenshotTypeForSafariBrowser();
         overrideScreenshotTypeForParallelExecution();
         setExtraAllureProperties();
+        setClearMode();
+    }
+
+    private static void setClearMode(){
+       if (Properties.flags.attemptClearBeforeTyping()){
+           SHAFT.Properties.flags.set().clearMode("native");
+       }
+       if (Properties.flags.attemptClearBeforeTypingUsingBackspace()) {
+           SHAFT.Properties.flags.set().clearMode("backspace");
+       }
+       else {
+           SHAFT.Properties.flags.set().clearMode("off");
+        }
     }
 
     private static void overrideScreenshotTypeForParallelExecution() {
@@ -77,7 +91,7 @@ public class PropertiesHelper {
 
     private static void overrideScreenScalingFactorForWindows() {
         if (Properties.platform.targetPlatform().equalsIgnoreCase(org.openqa.selenium.Platform.WINDOWS.toString())) {
-            int res = java.awt.Toolkit.getDefaultToolkit().getScreenResolution();
+            int res = Toolkit.getDefaultToolkit().getScreenResolution();
             double scale = (double)res/96;
             Properties.visuals.set().screenshotParamsScalingFactor(scale);
         }


### PR DESCRIPTION
- new flag added to control clear before typing 
 key **clearBeforeTypingMode**
possible values : 
native ( to clear using native selenium clear ) 
backspace ( to delete letter by letter ) 
off ( no clear before typing ) 
 - deprecating old flags 
 attemptClearBeforeTyping , attemptClearBeforeTypingUsingBackspace

