### PR TITLE
new Type compatibility with old clear before typing flags during runtime  

### DIFF
--- a/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -12,6 +12,7 @@ import com.shaft.gui.internal.image.ImageProcessingActions;
 import com.shaft.gui.internal.image.ScreenshotHelper;
 import com.shaft.gui.internal.locator.LocatorBuilder;
 import com.shaft.gui.internal.locator.ShadowLocatorBuilder;
+import com.shaft.properties.internal.PropertiesHelper;
 import com.shaft.tools.internal.support.JavaHelper;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.FailureReporter;
@@ -160,19 +161,20 @@ public class Actions extends ElementActions {
                         }
                     }
                     case TYPE -> {
+                        PropertiesHelper.setClearBeforeTypingMode();
                         String clearMode = SHAFT.Properties.flags.clearBeforeTypingMode();
-                        switch(clearMode){
+
+                        switch (clearMode) {
                             case "native":
                                 foundElements.get().getFirst().clear();
-                                break ;
+                                break;
                             case "backspace":
                                 String text = parseElementText(foundElements.get().getFirst());
                                 if (!text.isEmpty())
                                     foundElements.get().getFirst().sendKeys(String.valueOf(Keys.BACK_SPACE).repeat(text.length()));
-                                break ;
-                            case"off":
                                 break;
-
+                            case "off":
+                                break;
                         }
                         foundElements.get().getFirst().sendKeys((CharSequence) data);
                     }

--- a/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
+++ b/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
@@ -72,7 +72,7 @@ public class PropertiesHelper {
         setClearBeforeTypingMode();
     }
 
-    private static void setClearBeforeTypingMode(){
+    public static void setClearBeforeTypingMode(){
         if (!Properties.flags.attemptClearBeforeTyping() || SHAFT.Properties.flags.clearBeforeTypingMode().equals("off")) {
             SHAFT.Properties.flags.set().clearBeforeTypingMode("off");
             return ;

--- a/src/test/java/testPackage/mockedTests/MultipleTypeCyclesTest.java
+++ b/src/test/java/testPackage/mockedTests/MultipleTypeCyclesTest.java
@@ -22,20 +22,18 @@ public class MultipleTypeCyclesTest {
     }
 
 
-
-@Test
-    public void _02clearUsingBackSpace(){
-    SHAFT.Properties.flags.set().attemptClearBeforeTyping(false);
-    SHAFT.Properties.flags.set().attemptClearBeforeTypingUsingBackspace(true);
+    @Test(dependsOnMethods = "_01typeClearTypeTypeAppend")
+    public void _02clearUsingBackSpace() {
+        SHAFT.Properties.flags.set().attemptClearBeforeTypingUsingBackspace(true);
         driver.get().browser().navigateToURL(testElement);
         driver.get().element().type(locator, "first string")
-                              .type(locator, "Second string")
-            .and().assertThat(locator).text().isEqualTo("Second string")
-                  .perform();
+                .type(locator, "Second string")
+                .and().assertThat(locator).text().isEqualTo("Second string")
+                .perform();
     }
 
-    @Test
-    public void _03NoClearBeforeTypingTest(){
+    @Test(dependsOnMethods = "_02clearUsingBackSpace")
+    public void _03NoClearBeforeTypingTest() {
         SHAFT.Properties.flags.set().attemptClearBeforeTyping(false);
         driver.get().browser().navigateToURL(testElement);
         driver.get().element().type(locator, "first string")
@@ -43,6 +41,38 @@ public class MultipleTypeCyclesTest {
                 .and().assertThat(locator).text().isEqualTo("first string + Second string")
                 .perform();
     }
+
+    @Test(dependsOnMethods = "_03NoClearBeforeTypingTest")
+    public void _04typeClearNewFlagTypeTypeAppend() {
+        driver.get().browser().navigateToURL(testElement);
+        driver.get().element().type(locator, "first string")
+                .type(locator, "second ")
+                .typeAppend(locator, "string")
+                .and().assertThat(locator).text().isEqualTo("second string")
+                .perform();
+    }
+
+
+    @Test(dependsOnMethods = "_04typeClearNewFlagTypeTypeAppend")
+    public void _05clearUsingNewFlagBackSpace() {
+        SHAFT.Properties.flags.set().clearBeforeTypingMode("backspace");
+        driver.get().browser().navigateToURL(testElement);
+        driver.get().element().type(locator, "first string")
+                .type(locator, "Second string")
+                .and().assertThat(locator).text().isEqualTo("Second string")
+                .perform();
+    }
+
+    @Test(dependsOnMethods = "_05clearUsingNewFlagBackSpace")
+    public void _06NoClearBeforeTypingNewFlagTest() {
+        SHAFT.Properties.flags.set().clearBeforeTypingMode("off");
+        driver.get().browser().navigateToURL(testElement);
+        driver.get().element().type(locator, "first string")
+                .type(locator, " + Second string")
+                .and().assertThat(locator).text().isEqualTo("first string + Second string")
+                .perform();
+    }
+
 
     @BeforeMethod
     public void beforeMethod() {
@@ -55,6 +85,7 @@ public class MultipleTypeCyclesTest {
         driver.get().quit();
         driver.remove();
         //Resetting flags to default values after each method
+        SHAFT.Properties.flags.set().clearBeforeTypingMode("native");
         SHAFT.Properties.flags.set().attemptClearBeforeTyping(true);
         SHAFT.Properties.flags.set().attemptClearBeforeTypingUsingBackspace(false);
     }


### PR DESCRIPTION
- new type was checking old flags only at the start of the test 
now checking also done during runtime till old flags are permanent removed 
- fixing multitype broken test 