### PR TITLE
Geolocation caps for Real Device on LambdaTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 <a href="https://www.browserstack.com/" target="_blank"><img src="https://ml.globenewswire.com/Resource/Download/745e80b7-4736-424e-b44b-850d2dc41940" alt="BrowserStack" height="50px"></a>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://applitools.com/" target="_blank"><img src="https://www.selenium.dev/images/sponsors/applitools.png" alt="Applitools" height="50px"></a>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://jb.gg/OpenSourceSupport" target="_blank"><img src="https://resources.jetbrains.com/storage/products/company/brand/logos/jb_beam.png" alt="JetBrains" height="50px"></a>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://www.lambdatest.com" target="_blank"><img src="https://www.lambdatest.com/blog/wp-content/uploads/2024/10/LambdaTest-Logo.png" alt="LambdaTest" height="50px"></a>
 <br/><br/>
 
 ### Trusted solution of choice for: [^4]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 <a href="https://www.browserstack.com/" target="_blank"><img src="https://ml.globenewswire.com/Resource/Download/745e80b7-4736-424e-b44b-850d2dc41940" alt="BrowserStack" height="50px"></a>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://applitools.com/" target="_blank"><img src="https://www.selenium.dev/images/sponsors/applitools.png" alt="Applitools" height="50px"></a>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://jb.gg/OpenSourceSupport" target="_blank"><img src="https://resources.jetbrains.com/storage/products/company/brand/logos/jb_beam.png" alt="JetBrains" height="50px"></a>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://www.lambdatest.com" target="_blank"><img src="https://www.lambdatest.com/blog/wp-content/uploads/2024/10/LambdaTest-Logo.png" alt="LambdaTest" height="50px"></a>
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://www.lambdatest.com" target="_blank"><img src="https://www.lambdatest.com/blog/wp-content/uploads/2024/10/LambdaTest-Logo.png" alt="LambdaTest" width="250px" height="50px"></a>
 <br/><br/>
 
 ### Trusted solution of choice for: [^4]

--- a/src/main/java/com/shaft/driver/internal/DriverFactory/LambdaTestHelper.java
+++ b/src/main/java/com/shaft/driver/internal/DriverFactory/LambdaTestHelper.java
@@ -108,7 +108,10 @@ public class LambdaTestHelper {
         lambdaTestOptions.put("isRealMobile", SHAFT.Properties.lambdaTest.isRealMobile());
         lambdaTestOptions.put("appProfiling", SHAFT.Properties.lambdaTest.appProfiling());
         lambdaTestOptions.put("app", appUrl);
-        
+        String geoLocation = SHAFT.Properties.lambdaTest.geoLocation();
+        if (geoLocation != null && !Objects.equals(geoLocation, "")) {
+            lambdaTestOptions.put("geoLocation", SHAFT.Properties.lambdaTest.geoLocation());
+        }
         lambdaTestCapabilities.setCapability("lt:options", lambdaTestOptions);
         return lambdaTestCapabilities;
     }

--- a/src/main/java/com/shaft/properties/internal/LambdaTest.java
+++ b/src/main/java/com/shaft/properties/internal/LambdaTest.java
@@ -123,7 +123,7 @@ public interface LambdaTest extends EngineProperties<LambdaTest> {
 
     //Optional extra settings
     @Key("LambdaTest.geoLocation")
-    @DefaultValue("EG")
+    @DefaultValue("")
     String geoLocation();
 
     @Key("LambdaTest.debug")


### PR DESCRIPTION
With this change, Shaft users executing Real-Device tests on LambdaTest will be able to select devices as per the specified geoLocation capability.

Verification was done by checking the Input Config (with capabilities passed via SHAFT) on the LambdaTest dashboard.