### PR TITLE
fix allure history and trends generation

### DIFF
--- a/src/main/java/com/shaft/properties/internal/Allure.java
+++ b/src/main/java/com/shaft/properties/internal/Allure.java
@@ -22,12 +22,16 @@ public interface Allure extends EngineProperties<Allure> {
     boolean automaticallyOpen(); //automaticallyOpen (used to be: openAllureReportAfterExecution)
 
     @Key("allure.accumulateHistory")
-    @DefaultValue("false")
+    @DefaultValue("true")
     boolean accumulateHistory(); //accumulateHistory (used to be: cleanAllureResultsDirectoryBeforeExecution)
 
     @Key("allure.accumulateReports")
     @DefaultValue("true")
     boolean accumulateReports(); //allows html files to accumulate in the allure report directory
+
+    @Key("allure.cleanResultsDirectory")
+    @DefaultValue("true")
+    boolean cleanResultsDirectory();
 
     @Key("allure.generateArchive")
     @DefaultValue("false")
@@ -59,6 +63,11 @@ public interface Allure extends EngineProperties<Allure> {
 
         public SetProperty accumulateReports(boolean value) {
             setProperty("allure.accumulateReports", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty cleanResultsDirectory(boolean value) {
+            setProperty("allure.cleanResultsDirectory", String.valueOf(value));
             return this;
         }
 

--- a/src/main/java/com/shaft/tools/io/internal/AllureManager.java
+++ b/src/main/java/com/shaft/tools/io/internal/AllureManager.java
@@ -138,12 +138,14 @@ public class AllureManager {
     }
 
     private static void cleanAllureResultsDirectory() {
-        // clean allure-results directory before execution
-        var allureResultsPath = allureResultsFolderPath.substring(0, allureResultsFolderPath.length() - 1);
-        try {
-            internalFileSession.deleteFolder(allureResultsPath);
-        } catch (Exception t) {
-            ReportManager.log("Failed to delete '" + allureResultsPath + "' as it is currently open. Kindly restart your device to unlock the directory.");
+        if (SHAFT.Properties.allure.cleanResultsDirectory()) {
+            // clean allure-results directory before execution
+            var allureResultsPath = allureResultsFolderPath.substring(0, allureResultsFolderPath.length() - 1);
+            try {
+                internalFileSession.deleteFolder(allureResultsPath);
+            } catch (Exception t) {
+                ReportManager.log("Failed to delete '" + allureResultsPath + "' as it is currently open. Kindly restart your device to unlock the directory.");
+            }
         }
     }
 

--- a/src/main/java/com/shaft/tools/io/internal/AllureManager.java
+++ b/src/main/java/com/shaft/tools/io/internal/AllureManager.java
@@ -48,6 +48,7 @@ public class AllureManager {
     private static void copyAndOpenAllure() {
         internalFileSession.copyFolder(allureOutPutDirectory, allureReportPath);
         internalFileSession.deleteFile(allureOutPutDirectory);
+        internalFileSession.deleteFile(System.getProperty("user.dir") + File.separator + "target" + File.separator + "allure-report-history");
         String newFileName = renameAllureReport();
         openAllureReport(newFileName);
     }
@@ -138,13 +139,11 @@ public class AllureManager {
 
     private static void cleanAllureResultsDirectory() {
         // clean allure-results directory before execution
-        if (!SHAFT.Properties.allure.accumulateHistory()) {
-            var allureResultsPath = allureResultsFolderPath.substring(0, allureResultsFolderPath.length() - 1);
-            try {
-                internalFileSession.deleteFolder(allureResultsPath);
-            } catch (Exception t) {
-                ReportManager.log("Failed to delete '" + allureResultsPath + "' as it is currently open. Kindly restart your device to unlock the directory.");
-            }
+        var allureResultsPath = allureResultsFolderPath.substring(0, allureResultsFolderPath.length() - 1);
+        try {
+            internalFileSession.deleteFolder(allureResultsPath);
+        } catch (Exception t) {
+            ReportManager.log("Failed to delete '" + allureResultsPath + "' as it is currently open. Kindly restart your device to unlock the directory.");
         }
     }
 
@@ -177,22 +176,55 @@ public class AllureManager {
     }
 
     private static void writeAllureReport() {
-        String commandToCreateAllureReport;
         allureBinaryPath = allureExtractionLocation + "allure-" + SHAFT.Properties.internal.allureVersion()
                 + "/bin/allure";
         allureOutPutDirectory = System.getProperty("user.dir") + File.separator + "target" + File.separator + allureReportPath;
         var customReportName = SHAFT.Properties.allure.customTitle();
-        if (SystemUtils.IS_OS_WINDOWS) {
-            commandToCreateAllureReport = allureBinaryPath + ".bat" + " generate --single-file --clean '"
-                    + allureResultsFolderPath.substring(0, allureResultsFolderPath.length() - 1)
-                    + "' -o '" + allureOutPutDirectory + "' --report-name '"+customReportName+"'";
-        } else {
-            commandToCreateAllureReport = allureBinaryPath + " generate --single-file --clean "
-                    + allureResultsFolderPath.substring(0, allureResultsFolderPath.length() - 1)
-                    + " -o " + allureOutPutDirectory + " --report-name "+customReportName;
-        }
         internalFileSession.createFolder(allureOutPutDirectory);
-        internalTerminalSession.performTerminalCommand(commandToCreateAllureReport);
+
+        String pathToLastHistoryDirectory = System.getProperty("user.dir") + File.separator + "target" + File.separator + "last-history";
+        if (SHAFT.Properties.allure.accumulateHistory()) {
+            // move existing history to the correct folder
+            if (internalFileSession.doesFileExist(pathToLastHistoryDirectory)) {//if not the first test run and history already exists
+                internalFileSession.copyFolder(pathToLastHistoryDirectory, allureResultsFolderPath + File.separator + "history");
+            } else {
+                internalFileSession.createFolder(pathToLastHistoryDirectory);
+            }
+
+            internalTerminalSession.performTerminalCommand(getCommandToCreateAllureReport(customReportName, true));
+            internalTerminalSession.performTerminalCommand(getCommandToCreateAllureReport(customReportName, false));
+            internalFileSession.copyFolder(System.getProperty("user.dir") + File.separator + "target" + File.separator + "allure-report-history" + File.separator + "history"
+                    , pathToLastHistoryDirectory);
+        } else {
+            internalFileSession.deleteFolder(pathToLastHistoryDirectory);
+            internalTerminalSession.performTerminalCommand(getCommandToCreateAllureReport(customReportName, false));
+        }
+    }
+
+    private static String getCommandToCreateAllureReport(String customReportName, boolean isHistory) {
+        String commandToCreateAllureReport;
+        if (isHistory) {
+            if (SystemUtils.IS_OS_WINDOWS) {
+                commandToCreateAllureReport = allureBinaryPath + ".bat" + " generate '"
+                        + allureResultsFolderPath.substring(0, allureResultsFolderPath.length() - 1)
+                        + "' -o '" + allureOutPutDirectory + "-history' --report-name '" + customReportName + "'";
+            } else {
+                commandToCreateAllureReport = allureBinaryPath + " generate "
+                        + allureResultsFolderPath.substring(0, allureResultsFolderPath.length() - 1)
+                        + " -o " + allureOutPutDirectory + "-history --report-name " + customReportName;
+            }
+        } else {
+            if (SystemUtils.IS_OS_WINDOWS) {
+                commandToCreateAllureReport = allureBinaryPath + ".bat" + " generate --single-file --clean '"
+                        + allureResultsFolderPath.substring(0, allureResultsFolderPath.length() - 1)
+                        + "' -o '" + allureOutPutDirectory + "' --report-name '" + customReportName + "'";
+            } else {
+                commandToCreateAllureReport = allureBinaryPath + " generate --single-file --clean "
+                        + allureResultsFolderPath.substring(0, allureResultsFolderPath.length() - 1)
+                        + " -o " + allureOutPutDirectory + " --report-name " + customReportName;
+            }
+        }
+        return commandToCreateAllureReport;
     }
 
     private static void createAllureReportArchive() {


### PR DESCRIPTION
-allure.accumulateHistory=true
will now behave as expected, saving execution history and showing relevant trends to help identify flaky tests.

-allure.accumulateReports=true
will now be more relevant, as the report will hold details of the current test run only; previous run details will no longer show in the retries tab.