### PR TITLE
Allure results dynamic path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1720,4 +1720,3 @@ OpenLHReport.js
 /src/main/resources/docker-compose/data/storage/prj-users/thumbnail-default
 /src/main/resources/docker-compose/data/storage/prj-users/thumbnail-superadmin
 /src/test/resources/testDataFiles/allure-results/environment.xml
-/src/test/resources/allure.properties

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ debug.log
 /generateJdk.bat
 /generateJdk.sh
 /src/main/resources/docker-compose/android-emulator/*
-/src/main/resources/properties/*
+#/src/main/resources/properties/*
 /lighthouse-reports/*
 /lighthouse-reports
 GenerateLHScript.js
@@ -1720,3 +1720,4 @@ OpenLHReport.js
 /src/main/resources/docker-compose/data/storage/prj-users/thumbnail-default
 /src/main/resources/docker-compose/data/storage/prj-users/thumbnail-superadmin
 /src/test/resources/testDataFiles/allure-results/environment.xml
+/src/test/resources/allure.properties

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ debug.log
 /generateJdk.bat
 /generateJdk.sh
 /src/main/resources/docker-compose/android-emulator/*
-#/src/main/resources/properties/*
+/src/main/resources/properties/*
 /lighthouse-reports/*
 /lighthouse-reports
 GenerateLHScript.js

--- a/src/main/java/com/shaft/properties/internal/AllureResults.java
+++ b/src/main/java/com/shaft/properties/internal/AllureResults.java
@@ -1,0 +1,34 @@
+package com.shaft.properties.internal;
+
+import com.shaft.tools.io.ReportManager;
+import org.aeonbits.owner.Config.Sources;
+import org.aeonbits.owner.ConfigFactory;
+
+@SuppressWarnings("unused")
+@Sources({"system:properties", "file:src/test/resources/allure.properties", "file:src/main/resources/properties/default/allure.properties", "classpath:allure.properties",})
+public interface AllureResults extends EngineProperties<AllureResults> {
+    private static void setProperty(String key, String value) {
+        var updatedProps = new java.util.Properties();
+        updatedProps.setProperty(key, value);
+        Properties.allureResults = ConfigFactory.create(AllureResults.class, updatedProps);
+        // temporarily set the system property to support hybrid read/write mode
+        System.setProperty(key, value);
+        ReportManager.logDiscrete("Setting \"" + key + "\" property with \"" + value + "\".");
+    }
+
+    @Key("allure.results.directory")
+    @DefaultValue("allure-results")
+    String allureResultsDirectory();
+
+    default SetProperty set() {
+        return new SetProperty();
+    }
+
+    class SetProperty implements EngineProperties.SetProperty {
+        public AllureResults.SetProperty allureResultsDirectory(String value) {
+            setProperty("allure.results.directory", value);
+            return this;
+        }
+    }
+
+}

--- a/src/main/java/com/shaft/properties/internal/AllureResults.java
+++ b/src/main/java/com/shaft/properties/internal/AllureResults.java
@@ -4,7 +4,7 @@ import com.shaft.tools.io.ReportManager;
 import org.aeonbits.owner.Config.Sources;
 import org.aeonbits.owner.ConfigFactory;
 
-@SuppressWarnings("unused")
+@SuppressWarnings({"SameParameterValue", "unused"})
 @Sources({"system:properties", "file:src/test/resources/allure.properties", "file:src/main/resources/properties/default/allure.properties", "classpath:allure.properties",})
 public interface AllureResults extends EngineProperties<AllureResults> {
     private static void setProperty(String key, String value) {
@@ -25,7 +25,7 @@ public interface AllureResults extends EngineProperties<AllureResults> {
     }
 
     class SetProperty implements EngineProperties.SetProperty {
-        public AllureResults.SetProperty allureResultsDirectory(String value) {
+        public SetProperty allureResultsDirectory(String value) {
             setProperty("allure.results.directory", value);
             return this;
         }

--- a/src/main/java/com/shaft/properties/internal/Properties.java
+++ b/src/main/java/com/shaft/properties/internal/Properties.java
@@ -2,7 +2,6 @@ package com.shaft.properties.internal;
 
 public class Properties {
     //    private static final boolean reloadProperties = DriverFactory.reloadProperties();
-    public static AllureResults allureResults;
     public static BrowserStack browserStack;
     public static Cucumber cucumber;
     public static Platform platform;
@@ -23,5 +22,6 @@ public class Properties {
     public static Web web;
     public static Performance performance;
     public static LambdaTest lambdaTest;
+    public static AllureResults allureResults;
 
 }

--- a/src/main/java/com/shaft/properties/internal/Properties.java
+++ b/src/main/java/com/shaft/properties/internal/Properties.java
@@ -2,6 +2,7 @@ package com.shaft.properties.internal;
 
 public class Properties {
     //    private static final boolean reloadProperties = DriverFactory.reloadProperties();
+    public static AllureResults allureResults;
     public static BrowserStack browserStack;
     public static Cucumber cucumber;
     public static Platform platform;

--- a/src/main/java/com/shaft/tools/io/internal/AllureManager.java
+++ b/src/main/java/com/shaft/tools/io/internal/AllureManager.java
@@ -31,7 +31,7 @@ public class AllureManager {
          * Force screenshot link to be shown in the results as a link not text
          */
         System.setProperty("org.uncommons.reportng.escape-output", "false");
-        allureResultsFolderPath = SHAFT.Properties.paths.allureResults();
+        allureResultsFolderPath = SHAFT.Properties.allureResults.allureResultsDirectory() + "/";
         cleanAllureReportDirectory();
         cleanAllureResultsDirectory();
         downloadAndExtractAllureBinaries();
@@ -264,7 +264,7 @@ public class AllureManager {
             }
         }
         propertiesFileBuilder.append("</environment>");
-        internalFileSession.writeToFile(SHAFT.Properties.paths.allureResults(), "environment.xml",
+        internalFileSession.writeToFile(SHAFT.Properties.allureResults.allureResultsDirectory(), "environment.xml",
                 RestActions.formatXML(propertiesFileBuilder.toString()));
     }
 }

--- a/src/main/java/com/shaft/tools/io/internal/AllureManager.java
+++ b/src/main/java/com/shaft/tools/io/internal/AllureManager.java
@@ -264,7 +264,7 @@ public class AllureManager {
             }
         }
         propertiesFileBuilder.append("</environment>");
-        internalFileSession.writeToFile(SHAFT.Properties.allureResults.allureResultsDirectory(), "environment.xml",
+        internalFileSession.writeToFile(SHAFT.Properties.allureResults.allureResultsDirectory() + "/", "environment.xml",
                 RestActions.formatXML(propertiesFileBuilder.toString()));
     }
 }

--- a/src/main/java/com/shaft/tools/io/internal/ReportHelper.java
+++ b/src/main/java/com/shaft/tools/io/internal/ReportHelper.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Stream;
 
 public class ReportHelper {
     public static void attachEngineLog() {
@@ -35,8 +36,12 @@ public class ReportHelper {
         disableLogging();
         if (FileActions.getInstance(true).doesFileExist(SHAFT.Properties.paths.properties())) {
             List<List<Object>> attachments = new ArrayList<>();
-            var propertyFiles = Arrays.asList(FileActions.getInstance(true).listFilesInDirectory(SHAFT.Properties.paths.properties(), null).replaceAll("default" + System.lineSeparator(), "").trim().split(System.lineSeparator()));
+            var propertyFiles = new ArrayList<>(Arrays.asList(FileActions.getInstance(true).listFilesInDirectory(SHAFT.Properties.paths.properties(), null).replaceAll("default" + System.lineSeparator(), "").trim().split(System.lineSeparator())));
+            String fileListString = FileActions.getInstance(true).listFilesInDirectory("src/test/resources/");
+            String allureProperties = Stream.of(fileListString.split("\\R")).filter("allure.properties"::equals).findFirst().orElse(null);
             propertyFiles.forEach(file -> attachments.add(Arrays.asList("Properties", file.replace(".properties", ""), FileActions.getInstance(true).readFile(SHAFT.Properties.paths.properties() + File.separator + file))));
+            propertyFiles.add(allureProperties);
+            attachments.add(Arrays.asList("Properties", propertyFiles.getLast().replace(".properties", ""), FileActions.getInstance(true).readFile("src/test/resources" + File.separator + allureProperties)));
             ReportManagerHelper.logNestedSteps("Property Files", attachments);
         }
         enableLogging();

--- a/src/main/resources/properties/default/allure.properties
+++ b/src/main/resources/properties/default/allure.properties
@@ -1,0 +1,1 @@
+allure.results.directory=allure-results

--- a/src/test/java/testPackage/properties/AllureResultsTests.java
+++ b/src/test/java/testPackage/properties/AllureResultsTests.java
@@ -1,0 +1,19 @@
+package testPackage.properties;
+
+import com.shaft.driver.SHAFT;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class AllureResultsTests {
+    String allureResultsDirectory;
+
+    @BeforeClass
+    public void beforeClass() {
+        allureResultsDirectory = SHAFT.Properties.allureResults.allureResultsDirectory();
+    }
+
+    @Test
+    public void test() {
+        SHAFT.Properties.allureResults.set().allureResultsDirectory(allureResultsDirectory);
+    }
+}


### PR DESCRIPTION
Added Logic to make Allure-Results path Dynamic via Properties file 

You can find more info in the following link
https://allurereport.org/docs/testng/#specifying-allure-results-location


What's done in that PR:
- Create `"AllureResults"` Interface that contains the property value that will be in the `"allure.properties"` file
- Create `"allure.properties"` file with the `"allure.results.directory"` property in the same directory as the `default properties`
- Create the method that will copy `"allure.propeties"` in the `"initializeAllureProperties"` method at `"PropertiesHelper"` class following the same approach of  `"initializeDefaultProperties`" method
- Fix the paths of allureresults in `"AllureManager"` to instead of `"SHAFT.Properties.paths.allureResults()"` to `"SHAFT.Properties.allureResults.allureResultsDirectory()"`
- Added the logic to `"ReportHelper"` class in order to attach the `"allure.properties"` at `"src/test/resources"` directory to be attached to the allure report
- Created `"AllureResultsTests"` to cover the newly added Property


**The logic will do the following, when running the project for the first time and allure.properties doesn't exist it will create it under test/resources after that when the user can change the allure-results path**