### PR TITLE
reorganize engineSetup

### DIFF
--- a/src/main/java/com/shaft/listeners/TestNGListener.java
+++ b/src/main/java/com/shaft/listeners/TestNGListener.java
@@ -68,6 +68,7 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
     }
 
     public static void engineSetup(ProjectStructureManager.RunType runType) {
+        PropertiesHelper.setKeySystemProperties();
         Allure.getLifecycle();
         Reporter.setEscapeHtml(false);
         ReportManagerHelper.setDiscreteLogging(true);


### PR DESCRIPTION
- support early system properties setup needed for reporting and other key integrations via `PropertiesHelper.setKeySystemProperties();`
- reorganizing some actions inside the properties helper to ensure they are called in the right location.