### PR TITLE
Add Headers and Add Cookies Features

### DIFF
--- a/src/main/java/com/shaft/api/RequestBuilder.java
+++ b/src/main/java/com/shaft/api/RequestBuilder.java
@@ -290,7 +290,7 @@ public class RequestBuilder {
     }
 
     /**
-     * Append headers to the current session to be used in the current and all the following requests.
+     * Append headers to the current session to be used in the current and all the following requests. This feature is commonly used for authentication tokens.
      *
      * @param headers a map of headers that you want to add
      * @return a self-reference to be used to continue building your API request

--- a/src/main/java/com/shaft/api/RequestBuilder.java
+++ b/src/main/java/com/shaft/api/RequestBuilder.java
@@ -289,6 +289,16 @@ public class RequestBuilder {
         return this;
     }
 
+    /**
+     * Append headers to the current session to be used in the current and all the following requests.
+     *
+     * @param headers a map of headers that you want to add
+     * @return a self-reference to be used to continue building your API request
+     */
+    public RequestBuilder addHeaders(Map<String, String> headers) {
+        this.sessionHeaders.putAll(headers);
+        return this;
+    }
 
     /**
      * Append a cookie to the current session to be used in the current and all the following requests. This feature is commonly used for authentication cookies.
@@ -299,6 +309,17 @@ public class RequestBuilder {
      */
     public RequestBuilder addCookie(String key, Object value) {
         this.sessionCookies.put(key, value);
+        return this;
+    }
+
+    /**
+     * Append cookies to the current session to be used in the current and all the following requests. This feature is commonly used for authentication cookies.
+     *
+     * @param cookies a map of cookies that you want to add
+     * @return a self-reference to be used to continue building your API request
+     */
+    public RequestBuilder addCookies(Map<String, String> cookies) {
+        this.sessionCookies.putAll(cookies);
         return this;
     }
 

--- a/src/test/java/testPackage/legacy/BasicAPITests.java
+++ b/src/test/java/testPackage/legacy/BasicAPITests.java
@@ -68,11 +68,14 @@ public class BasicAPITests {
     }
 
     @Test(description = "This test is used to Test add headers to the request")
-    public void apiTest5() {
+    public void addHeadersMethodTest() {
         Map<String, String> headers = Map.of("Firstheader", "FirstHeaderValue",
                 "Secondheader", "SecondHeaderValue");
         api = new SHAFT.API("https://httpbin.org/");
-        api.get("get").addHeaders(headers).perform();
+        api.get("get")
+                .addHeaders(headers)
+                .setTargetStatusCode(200)
+                .perform();
         api.assertThatResponse().extractedJsonValue("headers.Firstheader")
                 .isEqualTo("FirstHeaderValue")
                 .perform();
@@ -81,17 +84,40 @@ public class BasicAPITests {
                 .perform();
     }
 
+    @Test(description = "This test is used to Test add headers to the request")
+    public void addEmptyHeadersMethodTest() {
+        Map<String, String> headers = Map.of();
+        api = new SHAFT.API("https://httpbin.org/");
+        api.get("get")
+                .addHeaders(headers)
+                .setTargetStatusCode(200)
+                .perform();
+    }
+
     @Test(description = "This test is used to Test add cookies to the request")
-    public void apiTest6() {
+    public void addCookiesMethodTest() {
         Map<String, String> cookies = Map.of("FirstCookie", "FirstCookieValue",
                 "SecondCookie", "SecondCookieValue");
         api = new SHAFT.API("https://httpbin.org/");
-        api.get("get").addCookies(cookies).perform();
+        api.get("get")
+                .addCookies(cookies)
+                .setTargetStatusCode(200)
+                .perform();
         api.assertThatResponse().extractedJsonValue("headers.Cookie")
                 .contains("FirstCookie=FirstCookieValue")
                 .perform();
         api.assertThatResponse().extractedJsonValue("headers.Cookie")
                 .contains("SecondCookie=SecondCookieValue")
+                .perform();
+    }
+
+    @Test(description = "This test is used to Test add cookies to the request")
+    public void addEmptyCookiesMethodTest() {
+        Map<String, String> cookies = Map.of();
+        api = new SHAFT.API("https://httpbin.org/");
+        api.get("get")
+                .addCookies(cookies)
+                .setTargetStatusCode(200)
                 .perform();
     }
 

--- a/src/test/java/testPackage/legacy/BasicAPITests.java
+++ b/src/test/java/testPackage/legacy/BasicAPITests.java
@@ -37,7 +37,7 @@ public class BasicAPITests {
 
     @Test
     public void apiTest3() {
-        Map <String, Object> queryParameters = Map.of("FirstName", "Abdelrahman",
+        Map<String, Object> queryParameters = Map.of("FirstName", "Abdelrahman",
                 "LastName", "Fahd");
         String body = "{\n" +
                 "\"Body1\": \"Abdelrahman\",\n" +
@@ -57,8 +57,8 @@ public class BasicAPITests {
 
     @Test
     public void apiTest4() {
-        Map <String, Object> formParameters = Map.of("name", "SHAFT",
-                                                     "job", "Automation Engineer");
+        Map<String, Object> formParameters = Map.of("name", "SHAFT",
+                "job", "Automation Engineer");
         api = new SHAFT.API("https://reqres.in/api");
 
         api.post("users")
@@ -66,4 +66,33 @@ public class BasicAPITests {
                 .setTargetStatusCode(200)
                 .perform();
     }
+
+    @Test(description = "This test is used to Test add headers to the request")
+    public void apiTest5() {
+        Map<String, String> headers = Map.of("Firstheader", "FirstHeaderValue",
+                "Secondheader", "SecondHeaderValue");
+        api = new SHAFT.API("https://httpbin.org/");
+        api.get("get").addHeaders(headers).perform();
+        api.assertThatResponse().extractedJsonValue("headers.Firstheader")
+                .isEqualTo("FirstHeaderValue")
+                .perform();
+        api.assertThatResponse().extractedJsonValue("headers.Secondheader")
+                .isEqualTo("SecondHeaderValue")
+                .perform();
+    }
+
+    @Test(description = "This test is used to Test add cookies to the request")
+    public void apiTest6() {
+        Map<String, String> cookies = Map.of("FirstCookie", "FirstCookieValue",
+                "SecondCookie", "SecondCookieValue");
+        api = new SHAFT.API("https://httpbin.org/");
+        api.get("get").addCookies(cookies).perform();
+        api.assertThatResponse().extractedJsonValue("headers.Cookie")
+                .contains("FirstCookie=FirstCookieValue")
+                .perform();
+        api.assertThatResponse().extractedJsonValue("headers.Cookie")
+                .contains("SecondCookie=SecondCookieValue")
+                .perform();
+    }
+
 }

--- a/src/test/java/testPackage/legacy/BasicAPITests.java
+++ b/src/test/java/testPackage/legacy/BasicAPITests.java
@@ -85,6 +85,19 @@ public class BasicAPITests {
     }
 
     @Test(description = "This test is used to Test add headers to the request")
+    public void addSingleHeadersMethodTest() {
+        Map<String, String> headers = Map.of("Firstheader", "FirstHeaderValue");
+        api = new SHAFT.API("https://httpbin.org/");
+        api.get("get")
+                .addHeaders(headers)
+                .setTargetStatusCode(200)
+                .perform();
+        api.assertThatResponse().extractedJsonValue("headers.Firstheader")
+                .isEqualTo("FirstHeaderValue")
+                .perform();
+    }
+
+    @Test(description = "This test is used to Test add headers to the request")
     public void addEmptyHeadersMethodTest() {
         Map<String, String> headers = Map.of();
         api = new SHAFT.API("https://httpbin.org/");
@@ -108,6 +121,19 @@ public class BasicAPITests {
                 .perform();
         api.assertThatResponse().extractedJsonValue("headers.Cookie")
                 .contains("SecondCookie=SecondCookieValue")
+                .perform();
+    }
+
+    @Test(description = "This test is used to Test add cookies to the request")
+    public void addSingleCookiesMethodTest() {
+        Map<String, String> cookies = Map.of("FirstCookie", "FirstCookieValue");
+        api = new SHAFT.API("https://httpbin.org/");
+        api.get("get")
+                .addCookies(cookies)
+                .setTargetStatusCode(200)
+                .perform();
+        api.assertThatResponse().extractedJsonValue("headers.Cookie")
+                .contains("FirstCookie=FirstCookieValue")
                 .perform();
     }
 

--- a/src/test/java/testPackage/legacy/BasicAPITests.java
+++ b/src/test/java/testPackage/legacy/BasicAPITests.java
@@ -59,11 +59,11 @@ public class BasicAPITests {
     public void apiTest4() {
         Map<String, Object> formParameters = Map.of("name", "SHAFT",
                 "job", "Automation Engineer");
-        api = new SHAFT.API("https://reqres.in/api");
+        api = new SHAFT.API("https://reqres.in/api/");
 
         api.post("users")
                 .setParameters(formParameters, RestActions.ParametersType.FORM)
-                .setTargetStatusCode(200)
+                .setTargetStatusCode(201)
                 .perform();
     }
 


### PR DESCRIPTION
This PR adds "addHeaders" and "addCookies" methods to the API

Linked Issue
#1925 

You can try it out by doing this:
```
Map<String, String> headers = Map.of("Content-Type", "application/json", "Authorization", "Bearer token");
Map<String, String> cookies = Map.of("cookie_key", "cookie_value", "cookie_Key2", "cookie_value2");
        restActions
                .buildNewRequest(APIEndPoint, requestType)
                .setHeaders(headers)
                .setCookies(cookies)
                .perform();
```