### PR TITLE
Enable WebDriverListener Attachment via getDriver(WebDriverListener) for Non-Appium Drivers

### DIFF
--- a/src/test/java/testPackage/SHAFTWizard/GUIWizardTests.java
+++ b/src/test/java/testPackage/SHAFTWizard/GUIWizardTests.java
@@ -1,15 +1,21 @@
 package testPackage.SHAFTWizard;
 
 import com.shaft.driver.SHAFT;
+import org.mockito.Mockito;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.events.WebDriverListener;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.testng.asserts.SoftAssert;
 import poms.GoogleSearch;
+
+import java.lang.reflect.Method;
+
+import static org.mockito.ArgumentMatchers.any;
 
 public class GUIWizardTests {
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
@@ -78,7 +84,16 @@ public class GUIWizardTests {
         driver.get().element().captureScreenshot(By.id("dropdown"));
 
     }
-
+    
+    @Test
+    public void test_GetWebDriverWithCustomListener() {
+        var mockListener = Mockito.mock(CustomWebDriverListener.class);
+        
+        var nativeDriver = driver.get().getDriver(mockListener);
+        nativeDriver.get("https://www.google.com/");
+        
+        Mockito.verify(mockListener).shouldBeCalled();
+    }
 
     @BeforeMethod
     public void beforeMethod() {
@@ -89,5 +104,18 @@ public class GUIWizardTests {
     @AfterMethod(alwaysRun = true)
     public void afterMethod() {
         driver.get().quit();
+    }
+    
+    public static class CustomWebDriverListener implements WebDriverListener {
+        @Override
+        public void beforeAnyCall(Object target, Method method, Object[] args) {
+            WebDriverListener.super.beforeAnyCall(target, method, args);
+            
+            shouldBeCalled();
+        }
+        
+        private void shouldBeCalled() {
+            // Used to check that the listener is being called
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature to the `getDriver(WebDriverListener)` method, allowing users to attach a `WebDriverListener` to Selenium WebDriver instances. This enhances the driver's functionality by enabling custom event handling and logging.

**Changes Made:**

- Implemented the `getDriver(WebDriverListener)` method to wrap non-Appium drivers (excluding `AndroidDriver` and `IOSDriver`) with `EventFiringDecorator`.
- Added logic to bypass `EventFiringDecorator` for Appium drivers due to compatibility issues.
- Included a unit test to verify the correct application of the listener for non-Appium drivers.

**Rationale:**

- Provides users with the ability to attach custom listeners for advanced WebDriver interactions.
- Improves flexibility and enables better debugging and logging.
- Maintains compatibility with Appium drivers by avoiding `EventFiringDecorator`.
- Adheres to the recommendation of using SHAFT's `WebDriverListener` for optimal usage.

**Testing:**

- Added a unit test to ensure that the listener is correctly applied to non-Appium drivers.

This feature adds significant value by allowing users to extend the WebDriver's behavior through custom listeners, while ensuring compatibility with various driver types.