### PR TITLE
1986 bug video recording not working as expected in junit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -541,12 +541,25 @@
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.testng</groupId>
                     <artifactId>testng</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.automation-remarks/video-recorder-junit5 -->
+        <dependency>
+            <groupId>com.automation-remarks</groupId>
+            <artifactId>video-recorder-junit5</artifactId>
+            <version>2.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/src/main/java/com/shaft/gui/internal/image/AnimatedGifManager.java
+++ b/src/main/java/com/shaft/gui/internal/image/AnimatedGifManager.java
@@ -47,7 +47,7 @@ public class AnimatedGifManager {
 
     public static String attachAnimatedGif() {
         // stop and attach
-        if (Boolean.TRUE.equals(SHAFT.Properties.visuals.createAnimatedGif()) && !"".equals(gifRelativePathWithFileName)) {
+        if (SHAFT.Properties.visuals.createAnimatedGif() && !"".equals(gifRelativePathWithFileName)) {
             try {
                 ReportManagerHelper.attach("Animated Gif", String.valueOf(System.currentTimeMillis()), new FileInputStream(gifRelativePathWithFileName));
                 if (!gifWriter.equals(new ThreadLocal<>())) {
@@ -74,7 +74,7 @@ public class AnimatedGifManager {
 
     public static void startOrAppendToAnimatedGif(byte[] screenshot) {
         // ensure that animatedGif is started, else force start it
-        if (Boolean.TRUE.equals(SHAFT.Properties.visuals.createAnimatedGif())) {
+        if (SHAFT.Properties.visuals.createAnimatedGif()) {
             if (gifRelativePathWithFileName.isEmpty()) {
                 startAnimatedGif(screenshot);
             } else {
@@ -104,7 +104,7 @@ public class AnimatedGifManager {
     }
 
     protected static void startAnimatedGif(byte[] screenshot) {
-        if (Boolean.TRUE.equals(SHAFT.Properties.visuals.createAnimatedGif()) && screenshot != null) {
+        if (SHAFT.Properties.visuals.createAnimatedGif() && screenshot != null) {
             try {
                 String gifFileName = FileSystems.getDefault().getSeparator() + System.currentTimeMillis() + ".gif";
                 gifRelativePathWithFileName = SHAFT.Properties.paths.allureResults() + "/screenshots/" + new SimpleDateFormat("yyyyMMdd-HHmmss").format(new Date()) + gifFileName;

--- a/src/main/java/com/shaft/gui/internal/video/RecordManager.java
+++ b/src/main/java/com/shaft/gui/internal/video/RecordManager.java
@@ -1,8 +1,10 @@
 package com.shaft.gui.internal.video;
 
 import com.automation.remarks.video.RecorderFactory;
+import com.automation.remarks.video.RecordingUtils;
+import com.automation.remarks.video.enums.RecorderType;
+import com.automation.remarks.video.enums.VideoSaveMode;
 import com.automation.remarks.video.recorder.IVideoRecorder;
-import com.automation.remarks.video.recorder.VideoRecorder;
 import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.tools.io.ReportManager;
@@ -12,6 +14,7 @@ import io.appium.java_client.android.AndroidStartScreenRecordingOptions;
 import io.appium.java_client.ios.IOSDriver;
 import io.appium.java_client.ios.IOSStartScreenRecordingOptions;
 import org.apache.commons.io.FileUtils;
+import org.apache.log4j.BasicConfigurator;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import ws.schild.jave.Encoder;
@@ -25,8 +28,6 @@ import java.io.*;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Base64;
-
-import static com.automation.remarks.video.RecordingUtils.doVideoProcessing;
 
 public class RecordManager {
     private static final ThreadLocal<IVideoRecorder> recorder = new ThreadLocal<>();
@@ -66,7 +67,10 @@ public class RecordManager {
                 && SHAFT.Properties.platform.executionAddress().equals("local")
                 && !SHAFT.Properties.web.headlessExecution()
                 && recorder.get() == null) {
-            recorder.set(RecorderFactory.getRecorder(VideoRecorder.conf().recorderType()));
+            BasicConfigurator.configure();
+            System.setProperty("video.save.mode", VideoSaveMode.ALL.name());
+            recorder.set(RecorderFactory.getRecorder(RecorderType.MONTE));
+//            recorder.set(RecorderFactory.getRecorder(VideoRecorder.conf().recorderType()));
             recorder.get().start();
         }
     }
@@ -104,7 +108,7 @@ public class RecordManager {
         String testMethodName = ReportManagerHelper.getTestMethodName();
 
         if (Boolean.TRUE.equals(SHAFT.Properties.visuals.videoParamsRecordVideo()) && recorder.get() != null) {
-            pathToRecording = doVideoProcessing(ReportManagerHelper.isCurrentTestPassed(), recorder.get().stopAndSave(System.currentTimeMillis() + "_" + testMethodName));
+            pathToRecording = RecordingUtils.doVideoProcessing(ReportManagerHelper.isCurrentTestPassed(), recorder.get().stopAndSave(System.currentTimeMillis() + "_" + testMethodName));
             try {
                 inputStream = new FileInputStream(encodeRecording(pathToRecording));
             } catch (FileNotFoundException e) {

--- a/src/main/java/com/shaft/gui/internal/video/RecordManager.java
+++ b/src/main/java/com/shaft/gui/internal/video/RecordManager.java
@@ -41,7 +41,7 @@ public class RecordManager {
     //TODO: the animated GIF should follow the same path as the video
     @SuppressWarnings("SpellCheckingInspection")
     public static void startVideoRecording(WebDriver driver) {
-        if (Boolean.TRUE.equals(SHAFT.Properties.visuals.videoParamsRecordVideo())
+        if (SHAFT.Properties.visuals.videoParamsRecordVideo()
                 && !isRecordingStarted
                 && driver != null
                 && DriverFactoryHelper.isMobileNativeExecution()) {
@@ -63,12 +63,13 @@ public class RecordManager {
     }
 
     public static void startVideoRecording() {
-        if (Boolean.TRUE.equals(SHAFT.Properties.visuals.videoParamsRecordVideo())
+        if (SHAFT.Properties.visuals.videoParamsRecordVideo()
                 && SHAFT.Properties.platform.executionAddress().equals("local")
                 && !SHAFT.Properties.web.headlessExecution()
                 && recorder.get() == null) {
             BasicConfigurator.configure();
             System.setProperty("video.save.mode", VideoSaveMode.ALL.name());
+            System.setProperty("video.folder", "target/video");
             recorder.set(RecorderFactory.getRecorder(RecorderType.MONTE));
 //            recorder.set(RecorderFactory.getRecorder(VideoRecorder.conf().recorderType()));
             recorder.get().start();
@@ -107,7 +108,7 @@ public class RecordManager {
         String pathToRecording;
         String testMethodName = ReportManagerHelper.getTestMethodName();
 
-        if (Boolean.TRUE.equals(SHAFT.Properties.visuals.videoParamsRecordVideo()) && recorder.get() != null) {
+        if (SHAFT.Properties.visuals.videoParamsRecordVideo() && recorder.get() != null) {
             pathToRecording = RecordingUtils.doVideoProcessing(ReportManagerHelper.isCurrentTestPassed(), recorder.get().stopAndSave(System.currentTimeMillis() + "_" + testMethodName));
             try {
                 inputStream = new FileInputStream(encodeRecording(pathToRecording));
@@ -117,7 +118,7 @@ public class RecordManager {
             }
             recorder.remove();
 
-        } else if (Boolean.TRUE.equals(SHAFT.Properties.visuals.videoParamsRecordVideo()) && videoDriver.get() != null) {
+        } else if (SHAFT.Properties.visuals.videoParamsRecordVideo() && videoDriver.get() != null) {
             String base64EncodedRecording = "";
             if (videoDriver.get() instanceof AndroidDriver androidDriver) {
                 base64EncodedRecording = androidDriver.stopRecordingScreen();

--- a/src/main/java/com/shaft/listeners/JunitListener.java
+++ b/src/main/java/com/shaft/listeners/JunitListener.java
@@ -6,6 +6,7 @@ import com.shaft.listeners.internal.JiraHelper;
 import com.shaft.listeners.internal.JunitListenerHelper;
 import com.shaft.tools.internal.security.GoogleTink;
 import com.shaft.tools.io.internal.*;
+import lombok.Getter;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.launcher.*;
 
@@ -19,6 +20,8 @@ public class JunitListener implements LauncherSessionListener {
     private static final List<TestIdentifier> skippedTests = new ArrayList<>();
     private static long executionStartTime;
     private static boolean isEngineReady = false;
+    @Getter
+    private static Boolean isLastFinishedTestOK = true;
 
     @Override
     public void launcherSessionOpened(LauncherSession session) {
@@ -89,16 +92,19 @@ public class JunitListener implements LauncherSessionListener {
 
     private void onTestSuccess(TestIdentifier testIdentifier) {
         passedTests.add(testIdentifier);
+        isLastFinishedTestOK = true;
         appendToExecutionSummaryReport(testIdentifier, "", ExecutionSummaryReport.StatusIcon.PASSED, ExecutionSummaryReport.Status.PASSED);
     }
 
     private void onTestFailure(TestIdentifier testIdentifier, Throwable throwable) {
         failedTests.add(testIdentifier);
+        isLastFinishedTestOK = false;
         appendToExecutionSummaryReport(testIdentifier, throwable.getMessage(), ExecutionSummaryReport.StatusIcon.FAILED, ExecutionSummaryReport.Status.FAILED);
     }
 
     private void onTestSkipped(TestIdentifier testIdentifier, String reason) {
         skippedTests.add(testIdentifier);
+        isLastFinishedTestOK = false;
         appendToExecutionSummaryReport(testIdentifier, reason, ExecutionSummaryReport.StatusIcon.SKIPPED, ExecutionSummaryReport.Status.SKIPPED);
     }
 

--- a/src/main/java/com/shaft/listeners/JunitListener.java
+++ b/src/main/java/com/shaft/listeners/JunitListener.java
@@ -2,6 +2,8 @@ package com.shaft.listeners;
 
 import com.shaft.api.RequestBuilder;
 import com.shaft.driver.SHAFT;
+import com.shaft.gui.internal.image.AnimatedGifManager;
+import com.shaft.gui.internal.video.RecordManager;
 import com.shaft.listeners.internal.JiraHelper;
 import com.shaft.listeners.internal.JunitListenerHelper;
 import com.shaft.tools.internal.security.GoogleTink;
@@ -41,7 +43,7 @@ public class JunitListener implements LauncherSessionListener {
 
                 @Override
                 public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-                    afterInvocation();
+                    afterInvocation(testIdentifier, null);
                     onTestSkipped(testIdentifier, reason);
                 }
 
@@ -53,7 +55,7 @@ public class JunitListener implements LauncherSessionListener {
 
                 @Override
                 public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
-                    afterInvocation();
+                    afterInvocation(testIdentifier, testExecutionResult);
                     if (testIdentifier.isTest()) {
                         switch (testExecutionResult.getStatus()) {
                             case SUCCESSFUL -> onTestSuccess(testIdentifier);
@@ -86,8 +88,12 @@ public class JunitListener implements LauncherSessionListener {
         ReportManagerHelper.logEngineClosure();
     }
 
-    private void afterInvocation() {
+    private void afterInvocation(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
         ReportManagerHelper.setDiscreteLogging(SHAFT.Properties.reporting.alwaysLogDiscreetly());
+        if (SHAFT.Properties.visuals.videoParamsScope().equals("TestMethod")) {
+            RecordManager.attachVideoRecording();
+        }
+        AnimatedGifManager.attachAnimatedGif();
     }
 
     private void onTestSuccess(TestIdentifier testIdentifier) {

--- a/src/main/java/com/shaft/listeners/internal/JunitListenerHelper.java
+++ b/src/main/java/com/shaft/listeners/internal/JunitListenerHelper.java
@@ -1,9 +1,11 @@
 package com.shaft.listeners.internal;
 
 import com.shaft.tools.io.internal.ReportManagerHelper;
+import lombok.Getter;
 import org.junit.platform.launcher.TestIdentifier;
 
 public class JunitListenerHelper {
+    @Getter
     private static final ThreadLocal<String> testName = new ThreadLocal<>();
 
     public static void setTestName(TestIdentifier testIdentifier) {

--- a/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
+++ b/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
@@ -4,6 +4,8 @@ import com.shaft.cli.FileActions;
 import com.shaft.cli.TerminalActions;
 import com.shaft.driver.SHAFT;
 import com.shaft.listeners.CucumberFeatureListener;
+import com.shaft.listeners.JunitListener;
+import com.shaft.listeners.internal.JunitListenerHelper;
 import com.shaft.properties.internal.PropertyFileManager;
 import com.shaft.tools.internal.support.JavaHelper;
 import com.shaft.tools.io.ReportManager;
@@ -365,9 +367,12 @@ public class ReportManagerHelper {
     public static String getTestMethodName() {
         if (Reporter.getCurrentTestResult() != null) {
             return Reporter.getCurrentTestResult().getMethod().getMethodName();
-        } else {
-            // this happens when running a cucumber feature file directly because there is no testNG Reporter instance
+        } else if (CucumberFeatureListener.getLastStartedScenarioName() != null){
+            // this happens in case of native cucumber execution without TestNG Test Runner
             return JavaHelper.removeSpecialCharacters(CucumberFeatureListener.getLastStartedScenarioName());
+        } else {
+            // this happens in case of JUnit Test Runner
+            return JunitListenerHelper.getTestName().get();
         }
     }
 
@@ -388,10 +393,14 @@ public class ReportManagerHelper {
 
     public static Boolean isCurrentTestPassed() {
         if (Reporter.getCurrentTestResult() != null) {
+            // this happens in case of TestNG Test Runner
             return Reporter.getCurrentTestResult().isSuccess();
-        } else {
+        } else if (CucumberFeatureListener.getIsLastFinishedStepOK() != null){
             // this happens in case of native cucumber execution without TestNG Test Runner
             return CucumberFeatureListener.getIsLastFinishedStepOK();
+        } else {
+            // this happens in case of JUnit Test Runner
+            return JunitListener.getIsLastFinishedTestOK();
         }
     }
 

--- a/src/main/resources/properties/default/junit-platform.properties
+++ b/src/main/resources/properties/default/junit-platform.properties
@@ -6,3 +6,4 @@ junit.jupiter.execution.parallel.mode.classes.default=same_thread
 junit.jupiter.execution.parallel.config.strategy=dynamic
 junit.jupiter.execution.parallel.config.dynamic.factor=1.0
 #junit.jupiter.execution.parallel.config.dynamic.max-pool-size-factor=10.0
+junit.jupiter.extensions.autodetection.enabled=true


### PR DESCRIPTION
Issue fixed, and support for video recording should now work as expected for junit5 using the property

```properties
videoParams_recordVideo=true
```

<img width="1277" alt="image" src="https://github.com/user-attachments/assets/f69dc9fd-4418-46ed-b701-0170a7aa0deb" />

same for the animated gif (which is extremely slow and highly not recommended unless you really have to)

```properties
createAnimatedGif=true
```

<img width="1267" alt="image" src="https://github.com/user-attachments/assets/7c3907b8-7ba1-48cd-8c91-562a68aead7b" />
