### PR TITLE
API: Robust multipart (UTF-8) with Map parameters — fixes #2051 

### DIFF
--- a/src/test/java/com/shaft/api/TestUpload.java
+++ b/src/test/java/com/shaft/api/TestUpload.java
@@ -1,0 +1,68 @@
+package com.shaft.api;
+
+import com.shaft.driver.SHAFT;
+import io.restassured.RestAssured;
+import io.restassured.builder.MultiPartSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import io.restassured.specification.MultiPartSpecification;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class TestUpload {
+   SHAFT.API api;
+    @Test
+    public void testUploadWithList() {
+        api = new SHAFT.API("http://localhost:3000/");
+        SHAFT.Properties.api.set().swaggerValidationEnabled(false);
+
+        List<List<Object>> parameters = Arrays.asList(
+                Arrays.asList("image", new File("src/test/resources/search.PNG")),
+                Arrays.asList("arabicText", "تست اوتوميشن")
+        );
+
+        api.post("upload")
+                .setContentType("multipart/form-data; charset=UTF-8") // Ensure UTF-8 encoding
+                .setParameters(parameters, RestActions.ParametersType.MULTIPART)
+                .setTargetStatusCode(200)
+                .perform();
+
+        api.assertThatResponse()
+                .extractedJsonValue("arabicText").isEqualTo("تست اوتوميشن");
+        SHAFT.Report.log("Shaft API Response:" + api.getResponseBody());
+    }
+
+    @Test
+    public void testUploadWithMap() {
+        api = new SHAFT.API("http://localhost:3000/");
+        SHAFT.Properties.api.set().swaggerValidationEnabled(false);
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("image", new File("src/test/resources/search.PNG"));
+        parameters.put("arabicText", "تست أوتوميشن");
+
+        api.post("upload")
+                .setContentType("multipart/form-data; charset=UTF-8") // Ensure UTF-8 encoding
+                .setParameters(parameters, RestActions.ParametersType.MULTIPART)
+                .setTargetStatusCode(200)
+                .perform();
+
+        api.assertThatResponse()
+                .extractedJsonValue("arabicText").isEqualTo("تست أوتوميشن");
+        SHAFT.Report.log("Shaft API Response:" + api.getResponseBody());
+    }
+
+
+}


### PR DESCRIPTION
## Summary
This PR resolves [#2051](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/2051) where SHAFT was unable to handle multipart file uploads when using Map-based parameters, and failed to preserve Arabic text.

## Changes
- Added `ParametersType.MULTIPART` to explicitly handle multipart form-data.
- Implemented UTF-8 charset for text parts in multipart uploads.
- Added Map→List parameter normalization to share the same request-building path for both APIs.
- Added RestActions overloads to support Map parameters without breaking the deprecated List-based API.
- Updated multipart detection to auto-trigger for File parameters.

## Testing
- Verified uploads work with both `List<List<Object>>` and `Map<String, Object>` parameter formats.
- Confirmed Arabic text and other UTF-8 characters are preserved correctly in responses.

## Impact
Backwards-compatible; deprecated List API still works.

```java
public class TestUpload {
   SHAFT.API api;
    @Test
    public void testUploadWithList() {
        api = new SHAFT.API("http://localhost:3000/");
        SHAFT.Properties.api.set().swaggerValidationEnabled(false);

        List<List<Object>> parameters = Arrays.asList(
                Arrays.asList("image", new File("src/test/resources/search.PNG")),
                Arrays.asList("arabicText", "تست اوتوميشن")
        );

        api.post("upload")
                .setContentType("multipart/form-data; charset=UTF-8") // Ensure UTF-8 encoding
                .setParameters(parameters, RestActions.ParametersType.MULTIPART)
                .setTargetStatusCode(200)
                .perform();

        api.assertThatResponse()
                .extractedJsonValue("arabicText").isEqualTo("تست اوتوميشن");
        SHAFT.Report.log("Shaft API Response:" + api.getResponseBody());
    }

    @Test
    public void testUploadWithMap() {
        api = new SHAFT.API("http://localhost:3000/");
        SHAFT.Properties.api.set().swaggerValidationEnabled(false);

        Map<String, Object> parameters = new HashMap<>();
        parameters.put("image", new File("src/test/resources/search.PNG"));
        parameters.put("arabicText", "تست أوتوميشن");

        api.post("upload")
                .setContentType("multipart/form-data; charset=UTF-8") // Ensure UTF-8 encoding
                .setParameters(parameters, RestActions.ParametersType.MULTIPART)
                .setTargetStatusCode(200)
                .perform();

        api.assertThatResponse()
                .extractedJsonValue("arabicText").isEqualTo("تست أوتوميشن");
        SHAFT.Report.log("Shaft API Response:" + api.getResponseBody());
    }
}