### PR TITLE
Fix the Key of the userName property for BrowserStack Configurations:

### DIFF
--- a/src/main/java/com/shaft/driver/internal/DriverFactory/BrowserStackHelper.java
+++ b/src/main/java/com/shaft/driver/internal/DriverFactory/BrowserStackHelper.java
@@ -44,13 +44,13 @@ public class BrowserStackHelper {
                 helper.initializeDriver(browserStackOptions);
             } else {
                 // this is the new native app scenario
-                browserStackOptions = setupNativeAppExecution(SHAFT.Properties.browserStack.username(), SHAFT.Properties.browserStack.accessKey(),
+                browserStackOptions = setupNativeAppExecution(SHAFT.Properties.browserStack.userName(), SHAFT.Properties.browserStack.accessKey(),
                         SHAFT.Properties.browserStack.deviceName(), SHAFT.Properties.browserStack.platformVersion(), SHAFT.Properties.browserStack.appRelativeFilePath(), SHAFT.Properties.browserStack.appName()).merge(browserStackOptions);
                 helper.initializeDriver(DriverFactory.DriverType.APPIUM_MOBILE_NATIVE, browserStackOptions);
             }
         } else {
             // this is the existing version from a native app scenario
-            browserStackOptions = setupNativeAppExecution(SHAFT.Properties.browserStack.username(), SHAFT.Properties.browserStack.accessKey(),
+            browserStackOptions = setupNativeAppExecution(SHAFT.Properties.browserStack.userName(), SHAFT.Properties.browserStack.accessKey(),
                     SHAFT.Properties.browserStack.deviceName(), SHAFT.Properties.browserStack.platformVersion(), appUrl).merge(browserStackOptions);
             helper.initializeDriver(DriverFactory.DriverType.APPIUM_MOBILE_NATIVE, browserStackOptions);
         }
@@ -135,7 +135,7 @@ public class BrowserStackHelper {
 
     private static MutableCapabilities setupMobileWebExecution() {
         ReportManager.logDiscrete("Setting up BrowserStack configuration for mobile web execution...");
-        String username = SHAFT.Properties.browserStack.username();
+        String username = SHAFT.Properties.browserStack.userName();
         String password = SHAFT.Properties.browserStack.accessKey();
         String os = SHAFT.Properties.platform.targetPlatform();
         String osVersion = SHAFT.Properties.browserStack.osVersion();
@@ -168,7 +168,7 @@ public class BrowserStackHelper {
 
     private static MutableCapabilities setupDesktopWebExecution() {
         ReportManager.logDiscrete("Setting up BrowserStack configuration for desktop web execution...");
-        String username = SHAFT.Properties.browserStack.username();
+        String username = SHAFT.Properties.browserStack.userName();
         String password = SHAFT.Properties.browserStack.accessKey();
         String os = SHAFT.Properties.platform.targetPlatform();
         String osVersion = SHAFT.Properties.browserStack.osVersion();

--- a/src/main/java/com/shaft/properties/internal/BrowserStack.java
+++ b/src/main/java/com/shaft/properties/internal/BrowserStack.java
@@ -29,9 +29,9 @@ public interface BrowserStack extends EngineProperties<BrowserStack> {
     }
 
     //Below properties are all required
-    @Key("browserStack.username")
+    @Key("browserStack.userName")
     @DefaultValue("mohabmohie1")
-    String username();
+    String userName();
 
     @Key("browserStack.accessKey")
     @DefaultValue("")
@@ -120,8 +120,8 @@ public interface BrowserStack extends EngineProperties<BrowserStack> {
     }
 
     class SetProperty implements EngineProperties.SetProperty {
-        public SetProperty username(String value) {
-            setProperty("browserStack.username", value);
+        public SetProperty userName(String value) {
+            setProperty("browserStack.userName", value);
             return this;
         }
 

--- a/src/main/java/com/shaft/properties/internal/PropertyFileManager.java
+++ b/src/main/java/com/shaft/properties/internal/PropertyFileManager.java
@@ -12,10 +12,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 public final class PropertyFileManager {
 
@@ -59,8 +56,13 @@ public final class PropertyFileManager {
         java.util.Properties props = System.getProperties();
         props.forEach((key, value) -> {
             if (String.valueOf(key).startsWith("browserStack.") && !String.valueOf(value).isBlank()) {
+                Set<String> excludedKeys = Set.of(
+                        "appName",
+                        "appUrl",
+                        "appRelativeFilePath"
+                );
                 var parsedKey = String.valueOf(key).split("browserStack.")[1];
-                if (!Objects.equals(parsedKey, "appName") && !Objects.equals(parsedKey, "appUrl") && !Objects.equals(parsedKey, "appRelativeFilePath"))
+                if (!excludedKeys.contains(parsedKey))
                     browserstackOptions.put(parsedKey, String.valueOf(value));
             }
         });

--- a/src/test/java/testPackage/properties/BrowserStackTests.java
+++ b/src/test/java/testPackage/properties/BrowserStackTests.java
@@ -19,7 +19,7 @@ public class BrowserStackTests {
 
     @BeforeClass
     public void beforeClass() {
-        username = SHAFT.Properties.browserStack.username();
+        username = SHAFT.Properties.browserStack.userName();
         accessKey = SHAFT.Properties.browserStack.accessKey();
         platformVersion = SHAFT.Properties.browserStack.platformVersion();
         deviceName = SHAFT.Properties.browserStack.deviceName();
@@ -34,7 +34,7 @@ public class BrowserStackTests {
 
     @Test
     public void test() {
-        SHAFT.Properties.browserStack.set().username(username);
+        SHAFT.Properties.browserStack.set().userName(username);
         SHAFT.Properties.browserStack.set().accessKey(accessKey);
         SHAFT.Properties.browserStack.set().platformVersion(platformVersion);
         SHAFT.Properties.browserStack.set().deviceName(deviceName);


### PR DESCRIPTION
     - Refactor the Key of username property at BrowserStack.java to be UserName as this is how it's required from BrowserStack side (The variable name is also changed to match the key for removing any unnecessary confusion)
     - convert if logic at PropertyFileManager.java "getCustomBrowserstackCapabilities" method to be using set instead for better reusability and ease of extension