### PR TITLE
Fix relative path resolution failing on Linux CI (#2347)

### DIFF
--- a/src/main/java/com/shaft/tools/internal/support/JavaHelper.java
+++ b/src/main/java/com/shaft/tools/internal/support/JavaHelper.java
@@ -250,13 +250,13 @@ public class JavaHelper {
             //file path is valid
             return relativePath;
         } else {
-            // Do not prepend testData path to absolute OS paths
-            if (new java.io.File(relativePath).isAbsolute()) {
-                return relativePath;
-            }
             if (relativePath.startsWith("/")) {
                 //remove extra slash at the beginning if applicable
                 relativePath = relativePath.substring(1);
+            }
+            // Do not prepend testData path to absolute OS paths
+            if (new java.io.File(relativePath).isAbsolute()) {
+                return relativePath;
             }
             var testDataFolderPath = SHAFT.Properties.paths.testData();
             if (relativePath.contains(testDataFolderPath)) {


### PR DESCRIPTION
On Linux, java.io.File.isAbsolute() returns true for any path starting with "/", causing paths like "/Accounting/TestData/CreateAccount.json" to be returned unchanged instead of being resolved against the testData folder. On Windows isAbsolute() requires a drive letter so the same paths were correctly processed.

Fix: strip the leading "/" before the isAbsolute() check so both OSes follow the same code path and the testData folder is always prepended.

Closes #2347