### PR TITLE
Refactor allure generation and opening shell scripts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.20</version>
+                <version>2.21</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/src/main/java/com/shaft/cli/TerminalActions.java
@@ -399,9 +399,9 @@ public class TerminalActions {
         // https://stackoverflow.com/a/10954450/12912100
         if (isWindows) {
             if (asynchronous && verbose) {
-                pb.command("powershell.exe", "Start-Process powershell.exe '-NoExit -WindowStyle Minimized \"[Console]::Title = ''SHAFT_Engine''; " + command + "\"'");
+                pb.command("powershell.exe", "-ExecutionPolicy", "Bypass", "Start-Process powershell.exe '-NoExit -WindowStyle Minimized \"[Console]::Title = ''SHAFT_Engine''; " + command + "\"'");
             } else {
-                pb.command("powershell.exe", "-Command", command);
+                pb.command("powershell.exe", "-ExecutionPolicy", "Bypass", "-Command", command);
             }
         } else {
             pb.command("sh", "-c", command);

--- a/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/src/main/java/com/shaft/cli/TerminalActions.java
@@ -399,7 +399,10 @@ public class TerminalActions {
         // https://stackoverflow.com/a/10954450/12912100
         if (isWindows) {
             if (asynchronous && verbose) {
-                pb.command("powershell.exe", "-ExecutionPolicy", "Bypass", "Start-Process powershell.exe '-NoExit -WindowStyle Minimized \"[Console]::Title = ''SHAFT_Engine''; " + command + "\"'");
+                // Apply the execution policy to the spawned child PowerShell as well,
+                // because Start-Process launches a separate process that does not inherit
+                // the outer shell's command-line arguments.
+                pb.command("powershell.exe", "-ExecutionPolicy", "Bypass", "Start-Process powershell.exe '-ExecutionPolicy Bypass -NoExit -WindowStyle Minimized -Command \"[Console]::Title = ''SHAFT_Engine''; " + command + "\"'");
             } else {
                 pb.command("powershell.exe", "-ExecutionPolicy", "Bypass", "-Command", command);
             }

--- a/src/main/java/com/shaft/tools/io/internal/AllureManager.java
+++ b/src/main/java/com/shaft/tools/io/internal/AllureManager.java
@@ -123,7 +123,7 @@ public class AllureManager {
         internalFileSession.deleteFile(allureOutPutDirectory);
         String newFileName = renameAllureReport();
         if (newFileName != null) {
-            openAllureReport();
+            openAllureReport(newFileName);
         }
     }
 
@@ -148,19 +148,13 @@ public class AllureManager {
         return newFileName;
     }
 
-    private static void openAllureReport() {
+    private static void openAllureReport(String newFileName) {
         if (SHAFT.Properties.allure.automaticallyOpen()) {
-            String prefix = resolveAllureCommandPrefix();
-            if (prefix == null) return;
-            String configPath = System.getProperty("user.dir") + File.separator + allureConfigFileName;
-            String resultsPath = getResultsPath();
-            // Use `allure open` to regenerate and serve the report via HTTP on a random port.
-            // This avoids opening via file:// URL, which causes JavaScript console errors
-            // in the Allure 3 awesome SPA (broken base-URL setup and History-API restrictions).
-            String openCommand = prefix + " open --config \"" + configPath + "\" \"" + resultsPath + "\"";
-            // Run asynchronously so the HTTP server stays alive while the user views the report
-            // without blocking SHAFT's main thread or preventing JVM shutdown.
-            TerminalActions.getInstance(true, false, true).performTerminalCommand(openCommand);
+            if (SystemUtils.IS_OS_WINDOWS) {
+                internalTerminalSession.performTerminalCommand(".\\" + allureReportPath + File.separator + newFileName);
+            } else {
+                internalTerminalSession.performTerminalCommand("open ./" + allureReportPath + File.separator + newFileName);
+            }
         }
     }
 

--- a/src/main/java/com/shaft/tools/io/internal/AllureManager.java
+++ b/src/main/java/com/shaft/tools/io/internal/AllureManager.java
@@ -149,12 +149,16 @@ public class AllureManager {
     }
 
     private static void openAllureReport(String newFileName) {
-        if (SHAFT.Properties.allure.automaticallyOpen()) {
-            if (SystemUtils.IS_OS_WINDOWS) {
-                internalTerminalSession.performTerminalCommand(".\\" + allureReportPath + File.separator + newFileName);
-            } else {
-                internalTerminalSession.performTerminalCommand("open ./" + allureReportPath + File.separator + newFileName);
-            }
+        String reportPath = new File(allureReportPath, newFileName).getAbsolutePath();
+        if (SystemUtils.IS_OS_WINDOWS) {
+            reportPath = reportPath.replace("'", "''");
+            internalTerminalSession.performTerminalCommand(
+                    "powershell -NoProfile -Command \"Start-Process -FilePath '" + reportPath + "'\""
+            );
+        } else if (SystemUtils.IS_OS_MAC) {
+            internalTerminalSession.performTerminalCommand("open \"" + reportPath + "\"");
+        } else {
+            internalTerminalSession.performTerminalCommand("xdg-open \"" + reportPath + "\"");
         }
     }
 


### PR DESCRIPTION
Refactor getProcessBuilder at TerminalActions.java to use "-ExecutionPolicy", "Bypass", as it was getting "cannot be loaded because running scripts is disabled" error when trying to execute the powershell command

- Revert the logic of opening the Generated Allure Report at openAllureReport at AllureManager.java to open the html file as the newly introduced logic with "Allure open" only accept the full directory path