### PR TITLE
Fix for Equals on incomparable types

### DIFF
--- a/src/test/java/testPackage/legacy/ChecksumTests.java
+++ b/src/test/java/testPackage/legacy/ChecksumTests.java
@@ -15,7 +15,7 @@ public class ChecksumTests {
         TerminalActions terminalSession = new TerminalActions();
         String actualHash = FileActions.getInstance().getFileChecksum(terminalSession, targetFileFolderPath, targetFileName);
 
-        Validations.assertThat().object(actualHash).equals(expectedHash);
+        Validations.assertThat().object(actualHash).isEqualTo(expectedHash);
     }
 
     @Test(enabled = false)
@@ -34,7 +34,7 @@ public class ChecksumTests {
                 sshKeyFileFolderName, sshKeyFileName);
         String actualHash = FileActions.getInstance().getFileChecksum(terminalSession, targetFileFolderPath, targetFileName);
 
-        Validations.assertThat().object(actualHash).equals(expectedHash);
+        Validations.assertThat().object(actualHash).isEqualTo(expectedHash);
     }
 
     @Test(enabled = false)
@@ -57,6 +57,6 @@ public class ChecksumTests {
         String actualHash = FileActions.getInstance().getFileChecksum(terminalSession, targetFileFolderPath, targetFileName,
                 pathToTempDirectoryOnRemoteMachine);
 
-        Validations.assertThat().object(actualHash).equals(expectedHash);
+        Validations.assertThat().object(actualHash).isEqualTo(expectedHash);
     }
 }


### PR DESCRIPTION
Use the validation API’s explicit equality assertion method instead of Java `equals` on the builder.  
The safest fix (without changing functionality) is to replace `.equals(expectedHash)` with `.isEqualTo(expectedHash)` on all matching assertions in this file, including line 37 and the identical patterns on lines 18 and 60. This preserves intent (assert that actual hash matches expected hash) while avoiding incomparable-type `equals` calls.

Edits needed in `src/test/java/testPackage/legacy/ChecksumTests.java`:
- Replace:
  - `Validations.assertThat().object(actualHash).equals(expectedHash);`
- With:
  - `Validations.assertThat().object(actualHash).isEqualTo(expectedHash);`

No imports, helper methods, or new definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._