### PR TITLE
Fix for Equals on incomparable types

### DIFF
--- a/src/test/java/testPackage/legacy/BasicAuthenticationTests.java
+++ b/src/test/java/testPackage/legacy/BasicAuthenticationTests.java
@@ -69,7 +69,7 @@ public class BasicAuthenticationTests extends Tests {
         ((HasAuthentication) driver).register(UsernameAndPassword.of("admin", "admin"));
         driver.get("https://the-internet.herokuapp.com/basic_auth");
         var text = driver.findElement(By.tagName("p")).getText();
-        SHAFT.Validations.assertThat().object(text).equals("Congratulations! You must have the proper credentials.");
+        SHAFT.Validations.assertThat().object(text).isEqualTo("Congratulations! You must have the proper credentials.");
     }
 
 }


### PR DESCRIPTION
The fix is to use the SHAFT validation chain correctly so the expected string is compared to the actual `text` value, instead of calling `equals` on the builder object itself.

Best single fix without changing intended functionality:
- In `src/test/java/testPackage/legacy/BasicAuthenticationTests.java`, line 72 region, replace the incorrect builder `.equals(...)` call with the assertion terminal intended by the API, e.g. `.isEqualTo(...)`.
- Keep the same expected message string and surrounding test flow unchanged.

No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._