### PR TITLE
fix(reporting): close attachment streams and ReportPortal temp cleanup

### DIFF
--- a/src/main/java/com/shaft/gui/internal/image/AnimatedGifManager.java
+++ b/src/main/java/com/shaft/gui/internal/image/AnimatedGifManager.java
@@ -84,7 +84,8 @@ public class AnimatedGifManager {
         // stop and attach
         if (SHAFT.Properties.visuals.createAnimatedGif() && !gifRelativePathWithFileName.get().isEmpty()) {
             try {
-                ReportManagerHelper.attach("Animated Gif", String.valueOf(System.currentTimeMillis()), new FileInputStream(gifRelativePathWithFileName.get()));
+                byte[] gifBytes = java.nio.file.Files.readAllBytes(java.nio.file.Paths.get(gifRelativePathWithFileName.get()));
+                ReportManagerHelper.attach("Animated Gif", String.valueOf(System.currentTimeMillis()), new ByteArrayInputStream(gifBytes));
                 if (gifWriter.get() != null) {
                     gifManager.get().close();
                 }
@@ -100,9 +101,6 @@ public class AnimatedGifManager {
                 String gifRelativePath = gifRelativePathWithFileName.get();
                 gifRelativePathWithFileName.remove();
                 return gifRelativePath;
-            } catch (FileNotFoundException e) {
-                // this happens when the gif fails to start, maybe the browser window was
-                // already closed
             } catch (IOException | NullPointerException | IllegalStateException e) {
                 ReportManagerHelper.logDiscrete(e);
             }

--- a/src/main/java/com/shaft/gui/internal/image/AnimatedGifManager.java
+++ b/src/main/java/com/shaft/gui/internal/image/AnimatedGifManager.java
@@ -17,6 +17,8 @@ import java.awt.image.BufferedImage;
 import java.awt.image.RenderedImage;
 import java.io.*;
 import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
@@ -83,9 +85,8 @@ public class AnimatedGifManager {
     public static String attachAnimatedGif() {
         // stop and attach
         if (SHAFT.Properties.visuals.createAnimatedGif() && !gifRelativePathWithFileName.get().isEmpty()) {
-            try {
-                byte[] gifBytes = java.nio.file.Files.readAllBytes(java.nio.file.Paths.get(gifRelativePathWithFileName.get()));
-                ReportManagerHelper.attach("Animated Gif", String.valueOf(System.currentTimeMillis()), new ByteArrayInputStream(gifBytes));
+            try (InputStream in = Files.newInputStream(Paths.get(gifRelativePathWithFileName.get()))) {
+                ReportManagerHelper.attach("Animated Gif", String.valueOf(System.currentTimeMillis()), in);
                 if (gifWriter.get() != null) {
                     gifManager.get().close();
                 }

--- a/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
+++ b/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
@@ -34,12 +34,14 @@ import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -534,15 +536,23 @@ public class ImageProcessingActions {
             // fetch the related reference screenshot file name using the current file
             // name/number as index
             String relatedReferenceFileName = referenceFiles[Integer.parseInt(screenshot.getName()) - 1].getName();
-
-            List<Object> referenceScreenshotAttachment = Arrays.asList("Reference Screenshot", relatedReferenceFileName,
-                    new FileInputStream(referenceProcessingFolder + FileSystems.getDefault().getSeparator()
-                            + screenshot.getName()));
-
             String relatedTestFileName = testFiles[Integer.parseInt(screenshot.getName()) - 1].getName();
 
-            List<Object> testScreenshotAttachment = Arrays.asList("Test Screenshot", relatedTestFileName,
-                    new FileInputStream(screenshot));
+            List<Object> referenceScreenshotAttachment;
+            List<Object> testScreenshotAttachment;
+            try {
+                byte[] refBytes = Files.readAllBytes(Paths.get(
+                        referenceProcessingFolder + FileSystems.getDefault().getSeparator()
+                                + screenshot.getName()));
+                byte[] testBytes = Files.readAllBytes(screenshot.toPath());
+                referenceScreenshotAttachment = Arrays.asList("Reference Screenshot", relatedReferenceFileName,
+                        new ByteArrayInputStream(refBytes));
+                testScreenshotAttachment = Arrays.asList("Test Screenshot", relatedTestFileName,
+                        new ByteArrayInputStream(testBytes));
+            } catch (IOException ioEx) {
+                ReportManagerHelper.logDiscrete(ioEx);
+                continue;
+            }
 
             ReportManagerHelper.log(
                     "Test Screenshot [" + relatedTestFileName + "] and related Reference Image ["

--- a/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
+++ b/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
@@ -38,9 +38,11 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.List;
@@ -538,26 +540,22 @@ public class ImageProcessingActions {
             String relatedReferenceFileName = referenceFiles[Integer.parseInt(screenshot.getName()) - 1].getName();
             String relatedTestFileName = testFiles[Integer.parseInt(screenshot.getName()) - 1].getName();
 
-            List<Object> referenceScreenshotAttachment;
-            List<Object> testScreenshotAttachment;
-            try {
-                byte[] refBytes = Files.readAllBytes(Paths.get(
-                        referenceProcessingFolder + FileSystems.getDefault().getSeparator()
-                                + screenshot.getName()));
-                byte[] testBytes = Files.readAllBytes(screenshot.toPath());
-                referenceScreenshotAttachment = Arrays.asList("Reference Screenshot", relatedReferenceFileName,
-                        new ByteArrayInputStream(refBytes));
-                testScreenshotAttachment = Arrays.asList("Test Screenshot", relatedTestFileName,
-                        new ByteArrayInputStream(testBytes));
+            Path referenceImagePath = Paths.get(
+                    referenceProcessingFolder + FileSystems.getDefault().getSeparator() + screenshot.getName());
+            try (InputStream refIn = Files.newInputStream(referenceImagePath);
+                 InputStream testIn = Files.newInputStream(screenshot.toPath())) {
+                List<Object> referenceScreenshotAttachment = Arrays.asList(
+                        "Reference Screenshot", relatedReferenceFileName, refIn);
+                List<Object> testScreenshotAttachment = Arrays.asList(
+                        "Test Screenshot", relatedTestFileName, testIn);
+                ReportManagerHelper.log(
+                        "Test Screenshot [" + relatedTestFileName + "] and related Reference Image ["
+                                + relatedReferenceFileName + "] match by [" + percentage + "] percent.",
+                        Arrays.asList(referenceScreenshotAttachment, testScreenshotAttachment));
             } catch (IOException ioEx) {
                 ReportManagerHelper.logDiscrete(ioEx);
                 continue;
             }
-
-            ReportManagerHelper.log(
-                    "Test Screenshot [" + relatedTestFileName + "] and related Reference Image ["
-                            + relatedReferenceFileName + "] match by [" + percentage + "] percent.",
-                    Arrays.asList(referenceScreenshotAttachment, testScreenshotAttachment));
 
             boolean discreetLoggingState = ReportManagerHelper.getDiscreteLogging();
             try {

--- a/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
+++ b/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
@@ -34,7 +34,6 @@ import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/com/shaft/gui/internal/video/RecordManager.java
+++ b/src/main/java/com/shaft/gui/internal/video/RecordManager.java
@@ -26,6 +26,7 @@ import ws.schild.jave.encode.EncodingAttributes;
 import ws.schild.jave.encode.VideoAttributes;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Base64;
@@ -81,9 +82,9 @@ public class RecordManager {
         if (pathToRecording != null) {
             String testMethodName = ReportManagerHelper.getTestMethodName();
             try {
-                ReportManagerHelper.attach("Video Recording", testMethodName,
-                        new FileInputStream(pathToRecording.toString()));
-            } catch (FileNotFoundException e) {
+                byte[] bytes = Files.readAllBytes(pathToRecording);
+                ReportManagerHelper.attach("Video Recording", testMethodName, new ByteArrayInputStream(bytes));
+            } catch (IOException e) {
                 ReportManagerHelper.logDiscrete(e);
             }
         }
@@ -112,10 +113,10 @@ public class RecordManager {
         if (SHAFT.Properties.visuals.videoParamsRecordVideo() && recorder.get() != null) {
             pathToRecording = RecordingUtils.doVideoProcessing(ReportManagerHelper.isCurrentTestPassed(), recorder.get().stopAndSave(System.currentTimeMillis() + "_" + testMethodName));
             try {
-                inputStream = new FileInputStream(encodeRecording(pathToRecording));
-            } catch (FileNotFoundException e) {
+                File encoded = encodeRecording(pathToRecording);
+                inputStream = new ByteArrayInputStream(Files.readAllBytes(encoded.toPath()));
+            } catch (IOException e) {
                 ReportManagerHelper.logDiscrete(e);
-//                inputStream = new ByteArrayInputStream(new byte[0]);
             }
             recorder.remove();
 

--- a/src/main/java/com/shaft/gui/internal/video/RecordManager.java
+++ b/src/main/java/com/shaft/gui/internal/video/RecordManager.java
@@ -81,9 +81,8 @@ public class RecordManager {
     public static void attachVideoRecording(Path pathToRecording) {
         if (pathToRecording != null) {
             String testMethodName = ReportManagerHelper.getTestMethodName();
-            try {
-                byte[] bytes = Files.readAllBytes(pathToRecording);
-                ReportManagerHelper.attach("Video Recording", testMethodName, new ByteArrayInputStream(bytes));
+            try (InputStream in = Files.newInputStream(pathToRecording)) {
+                ReportManagerHelper.attach("Video Recording", testMethodName, in);
             } catch (IOException e) {
                 ReportManagerHelper.logDiscrete(e);
             }
@@ -114,7 +113,7 @@ public class RecordManager {
             pathToRecording = RecordingUtils.doVideoProcessing(ReportManagerHelper.isCurrentTestPassed(), recorder.get().stopAndSave(System.currentTimeMillis() + "_" + testMethodName));
             try {
                 File encoded = encodeRecording(pathToRecording);
-                inputStream = new ByteArrayInputStream(Files.readAllBytes(encoded.toPath()));
+                inputStream = new FileInputStream(encoded);
             } catch (IOException e) {
                 ReportManagerHelper.logDiscrete(e);
             }

--- a/src/main/java/com/shaft/tools/io/ExcelFileManager.java
+++ b/src/main/java/com/shaft/tools/io/ExcelFileManager.java
@@ -13,9 +13,11 @@ import org.apache.poi.xssf.usermodel.XSSFRow;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
+import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -72,10 +74,10 @@ public class ExcelFileManager {
         List<List<Object>> attachments = new ArrayList<>();
         List<Object> testDataFileAttachment = null;
         try {
-            testDataFileAttachment = Arrays.asList("Test Data", "Excel",
-                    new FileInputStream(excelFilePath));
-        } catch (FileNotFoundException e) {
-            //unreachable code because if the file was not found then the reader would have failed at a previous step
+            byte[] raw = Files.readAllBytes(Paths.get(excelFilePath));
+            testDataFileAttachment = Arrays.asList("Test Data", "Excel", new ByteArrayInputStream(raw));
+        } catch (IOException e) {
+            ReportManagerHelper.logDiscrete(e);
         }
         attachments.add(testDataFileAttachment);
         ReportManagerHelper.log("Loaded Test Data: \"" + excelFilePath + "\".", attachments);

--- a/src/main/java/com/shaft/tools/io/JSONFileManager.java
+++ b/src/main/java/com/shaft/tools/io/JSONFileManager.java
@@ -8,11 +8,13 @@ import com.shaft.tools.io.internal.ReportManagerHelper;
 import io.restassured.path.json.JsonPath;
 import io.restassured.path.json.exception.JsonPathException;
 
-import java.io.FileInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -55,10 +57,10 @@ public class JSONFileManager {
         List<List<Object>> attachments = new ArrayList<>();
         List<Object> testDataFileAttachment = null;
         try {
-            testDataFileAttachment = Arrays.asList("Test Data", "JSON",
-                    new FileInputStream(jsonFilePath));
-        } catch (FileNotFoundException e) {
-            //unreachable code because if the file was not found then the reader would have failed at a previous step
+            byte[] raw = Files.readAllBytes(Paths.get(jsonFilePath));
+            testDataFileAttachment = Arrays.asList("Test Data", "JSON", new ByteArrayInputStream(raw));
+        } catch (IOException e) {
+            ReportManagerHelper.logDiscrete(e);
         }
         attachments.add(testDataFileAttachment);
         ReportManagerHelper.log("Loaded Test Data: \"" + jsonFilePath + "\".", attachments);

--- a/src/main/java/com/shaft/tools/io/YAMLFileManager.java
+++ b/src/main/java/com/shaft/tools/io/YAMLFileManager.java
@@ -6,9 +6,12 @@ import com.shaft.tools.io.internal.FailureReporter;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import org.yaml.snakeyaml.Yaml;
 
+import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -56,15 +59,13 @@ public class YAMLFileManager {
         this.filePath = JavaHelper.appendTestDataToRelativePath(filePath);
         this.data = getData();
 
-        List<Object> testDataFileAttachment = new ArrayList<>();
+        List<Object> testDataFileAttachment;
         try {
-            testDataFileAttachment = List.of(
-                    "Test Data",
-                    "YAML",
-                    new FileInputStream(filePath)
-            );
-        } catch (FileNotFoundException ignore) {
-            // unreachable code because if the file was not found then the get data method will fail while loading the file
+            byte[] raw = Files.readAllBytes(Paths.get(filePath));
+            testDataFileAttachment = List.of("Test Data", "YAML", new ByteArrayInputStream(raw));
+        } catch (IOException e) {
+            ReportManagerHelper.logDiscrete(e);
+            testDataFileAttachment = List.of();
         }
 
         ReportManagerHelper.log(

--- a/src/main/java/com/shaft/tools/io/YAMLFileManager.java
+++ b/src/main/java/com/shaft/tools/io/YAMLFileManager.java
@@ -61,7 +61,7 @@ public class YAMLFileManager {
 
         List<Object> testDataFileAttachment;
         try {
-            byte[] raw = Files.readAllBytes(Paths.get(filePath));
+            byte[] raw = Files.readAllBytes(Paths.get(this.filePath));
             testDataFileAttachment = List.of("Test Data", "YAML", new ByteArrayInputStream(raw));
         } catch (IOException e) {
             ReportManagerHelper.logDiscrete(e);
@@ -69,7 +69,7 @@ public class YAMLFileManager {
         }
 
         ReportManagerHelper.log(
-                "Loaded Test Data: \"" + filePath + "\".",
+                "Loaded Test Data: \"" + this.filePath + "\".",
                 List.of(testDataFileAttachment)
         );
     }

--- a/src/main/java/com/shaft/tools/io/internal/AttachmentReporter.java
+++ b/src/main/java/com/shaft/tools/io/internal/AttachmentReporter.java
@@ -8,7 +8,6 @@ import io.qameta.allure.Allure;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.IOException;
 import java.util.Calendar;
 import java.util.LinkedHashMap;
 import java.util.function.BiConsumer;
@@ -113,7 +112,7 @@ public class AttachmentReporter {
                 file = File.createTempFile("rp-test", fileExtension);
                 Files.write(content.toByteArray(), file);
                 ReportPortal.emitLog(attachmentDescription, "INFO", Calendar.getInstance().getTime(), file);
-            } catch (IOException e) {
+            } catch (Exception e) {
                 ReportManagerHelper.logDiscrete(e);
             } finally {
                 if (file != null) {

--- a/src/main/java/com/shaft/tools/io/internal/AttachmentReporter.java
+++ b/src/main/java/com/shaft/tools/io/internal/AttachmentReporter.java
@@ -108,12 +108,19 @@ public class AttachmentReporter {
     private static void attachFileBased(String attachmentDescription, String contentType, ByteArrayOutputStream content, String fileExtension) {
         Allure.addAttachment(attachmentDescription, contentType, new ByteArrayInputStream(content.toByteArray()), fileExtension);
         if (TestNGListener.isReportPortalEnabled()) {
+            File file = null;
             try {
-                File file = File.createTempFile("rp-test", fileExtension);
+                file = File.createTempFile("rp-test", fileExtension);
                 Files.write(content.toByteArray(), file);
                 ReportPortal.emitLog(attachmentDescription, "INFO", Calendar.getInstance().getTime(), file);
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                ReportManagerHelper.logDiscrete(e);
+            } finally {
+                if (file != null) {
+                    if (!file.delete()) {
+                        file.deleteOnExit();
+                    }
+                }
             }
         }
     }

--- a/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
+++ b/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
@@ -859,23 +859,25 @@ public class ReportManagerHelper {
     }
 
     private static void createAttachment(String attachmentType, String attachmentName, InputStream attachmentContent) {
-        if (attachmentContent != null) {
-            var byteArrayOutputStream = new ByteArrayOutputStream();
-            try {
-                attachmentContent.transferTo(byteArrayOutputStream);
-            } catch (IOException e) {
-                var error = "Error while creating Attachment";
-                if (logger == null) {
-                    initializeLogger();
-                }
-                logger.error(error, e);
-                Reporter.log(error, false);
-            }
-            String attachmentDescription = attachmentType + " - " + attachmentName;
-            AttachmentReporter.attachBasedOnFileType(attachmentType, attachmentName, byteArrayOutputStream, attachmentDescription);
-            logAttachmentAction(attachmentType, attachmentName, byteArrayOutputStream);
-            forwardAttachmentToRealtimeReporter(attachmentType, attachmentName, byteArrayOutputStream);
+        if (attachmentContent == null) {
+            return;
         }
+        var byteArrayOutputStream = new ByteArrayOutputStream();
+        try (InputStream in = attachmentContent) {
+            in.transferTo(byteArrayOutputStream);
+        } catch (IOException e) {
+            var error = "Error while creating Attachment";
+            if (logger == null) {
+                initializeLogger();
+            }
+            logger.error(error, e);
+            Reporter.log(error, false);
+            return;
+        }
+        String attachmentDescription = attachmentType + " - " + attachmentName;
+        AttachmentReporter.attachBasedOnFileType(attachmentType, attachmentName, byteArrayOutputStream, attachmentDescription);
+        logAttachmentAction(attachmentType, attachmentName, byteArrayOutputStream);
+        forwardAttachmentToRealtimeReporter(attachmentType, attachmentName, byteArrayOutputStream);
     }
 
     private static void logAttachmentAction(String attachmentType, String attachmentName, ByteArrayOutputStream attachmentContent) {
@@ -890,10 +892,13 @@ public class ReportManagerHelper {
                 && !attachmentType.toLowerCase().contains("engine logs")) {
             String timestamp = TIMESTAMP_FORMATTER.format(ZonedDateTime.now());
 
-            String theString;
-            var br = new BufferedReader(
-                    new InputStreamReader(new ByteArrayInputStream(attachmentContent.toByteArray()), StandardCharsets.UTF_8));
-            theString = br.lines().collect(Collectors.joining(System.lineSeparator()));
+            String theString = "";
+            try (var br = new BufferedReader(
+                    new InputStreamReader(new ByteArrayInputStream(attachmentContent.toByteArray()), StandardCharsets.UTF_8))) {
+                theString = br.lines().collect(Collectors.joining(System.lineSeparator()));
+            } catch (IOException e) {
+                logDiscrete(e);
+            }
             if (!theString.isEmpty()) {
                 String logEntry = REPORT_MANAGER_PREFIX + "Debugging Attachment Entry" + " @" + timestamp
                         + System.lineSeparator() + theString + System.lineSeparator();

--- a/src/test/java/testPackage/unitTests/ReportManagerHelperAttachmentIoUnitTest.java
+++ b/src/test/java/testPackage/unitTests/ReportManagerHelperAttachmentIoUnitTest.java
@@ -32,6 +32,7 @@ import static org.testng.Assert.assertTrue;
  *
  * @see <a href="https://shafthq.github.io/">SHAFT User Guide</a>
  */
+@Test(singleThreaded = true)
 public class ReportManagerHelperAttachmentIoUnitTest {
 
     private static final class CloseTrackingInputStream extends InputStream {

--- a/src/test/java/testPackage/unitTests/ReportManagerHelperAttachmentIoUnitTest.java
+++ b/src/test/java/testPackage/unitTests/ReportManagerHelperAttachmentIoUnitTest.java
@@ -16,6 +16,7 @@ import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.stream.Stream;
 
@@ -57,16 +58,18 @@ public class ReportManagerHelperAttachmentIoUnitTest {
         }
     }
 
-    private static long countRpTestFilesInTempDir() throws IOException {
-        Path tmp = Path.of(System.getProperty("java.io.tmpdir"));
-        if (!Files.isDirectory(tmp)) {
-            return 0L;
+    private static void deleteRecursively(Path root) throws IOException {
+        if (root == null || Files.notExists(root)) {
+            return;
         }
-        try (Stream<Path> stream = Files.list(tmp)) {
-            return stream
-                    .map(p -> p.getFileName().toString())
-                    .filter(name -> name.startsWith("rp-test"))
-                    .count();
+        try (Stream<Path> walk = Files.walk(root)) {
+            walk.sorted(Comparator.reverseOrder()).forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (IOException ignored) {
+                    // best-effort teardown of isolated tmpdir
+                }
+            });
         }
     }
 
@@ -94,23 +97,39 @@ public class ReportManagerHelperAttachmentIoUnitTest {
      */
     @Test
     public void shouldNotLeaveReportPortalTempFilesBehindWhenEmitSucceeds() throws Exception {
-        long before = countRpTestFilesInTempDir();
+        Path isolated = Files.createTempDirectory("rpmgr-attachment-io-");
+        String originalTmpdir = System.getProperty("java.io.tmpdir");
 
-        ByteArrayOutputStream content = new ByteArrayOutputStream();
-        content.write("sample".getBytes(StandardCharsets.UTF_8));
+        System.setProperty("java.io.tmpdir", isolated.toAbsolutePath().toString());
+        try {
+            ByteArrayOutputStream content = new ByteArrayOutputStream();
+            content.write("sample".getBytes(StandardCharsets.UTF_8));
 
-        try (MockedStatic<TestNGListener> tl = mockStatic(TestNGListener.class);
-             MockedStatic<ReportPortal> rp = mockStatic(ReportPortal.class)) {
-            tl.when(TestNGListener::isReportPortalEnabled).thenReturn(true);
-            rp.when(() -> ReportPortal.emitLog(anyString(), anyString(), any(Date.class), any(File.class)))
-                    .thenAnswer(invocation -> null);
+            try (MockedStatic<TestNGListener> tl = mockStatic(TestNGListener.class);
+                 MockedStatic<ReportPortal> rp = mockStatic(ReportPortal.class)) {
+                tl.when(TestNGListener::isReportPortalEnabled).thenReturn(true);
+                rp.when(() -> ReportPortal.emitLog(anyString(), anyString(), any(Date.class), any(File.class)))
+                        .thenAnswer(invocation -> null);
 
-            AttachmentReporter.attachBasedOnFileType(
-                    "screenshot", "s.png", content, "screenshot - s.png");
+                AttachmentReporter.attachBasedOnFileType(
+                        "screenshot", "s.png", content, "screenshot - s.png");
+            }
+
+            try (Stream<Path> listed = Files.list(isolated)) {
+                long leftover = listed
+                        .map(p -> p.getFileName().toString())
+                        .filter(name -> name.startsWith("rp-test"))
+                        .count();
+                assertEquals(leftover, 0L,
+                        "rp-test* temp files for ReportPortal should be removed under isolated tmpdir");
+            }
+        } finally {
+            if (originalTmpdir != null) {
+                System.setProperty("java.io.tmpdir", originalTmpdir);
+            } else {
+                System.clearProperty("java.io.tmpdir");
+            }
+            deleteRecursively(isolated);
         }
-
-        long after = countRpTestFilesInTempDir();
-        assertEquals(after, before,
-                "rp-test* temp file count should not increase after ReportPortal attachment");
     }
 }

--- a/src/test/java/testPackage/unitTests/ReportManagerHelperAttachmentIoUnitTest.java
+++ b/src/test/java/testPackage/unitTests/ReportManagerHelperAttachmentIoUnitTest.java
@@ -1,0 +1,116 @@
+package testPackage.unitTests;
+
+import com.epam.reportportal.service.ReportPortal;
+import com.shaft.listeners.TestNGListener;
+import com.shaft.tools.io.internal.AttachmentReporter;
+import com.shaft.tools.io.internal.ReportManagerHelper;
+import org.mockito.MockedStatic;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Date;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Verifies that attachment-related IO paths close {@link InputStream}s and that
+ * ReportPortal temp files are deleted after emit (no cumulative {@code rp-test*} leaks).
+ *
+ * @see <a href="https://shafthq.github.io/">SHAFT User Guide</a>
+ */
+public class ReportManagerHelperAttachmentIoUnitTest {
+
+    private static final class CloseTrackingInputStream extends InputStream {
+        private final InputStream delegate;
+        private volatile boolean closed;
+
+        CloseTrackingInputStream(InputStream delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public int read() throws IOException {
+            return delegate.read();
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            delegate.close();
+        }
+
+        boolean isClosed() {
+            return closed;
+        }
+    }
+
+    private static long countRpTestFilesInTempDir() throws IOException {
+        Path tmp = Path.of(System.getProperty("java.io.tmpdir"));
+        if (!Files.isDirectory(tmp)) {
+            return 0L;
+        }
+        try (Stream<Path> stream = Files.list(tmp)) {
+            return stream
+                    .map(p -> p.getFileName().toString())
+                    .filter(name -> name.startsWith("rp-test"))
+                    .count();
+        }
+    }
+
+    /**
+     * {@link ReportManagerHelper} must close attachment streams after copying bytes so
+     * parallel suites do not leak file descriptors from {@link java.io.FileInputStream}.
+     */
+    @Test
+    public void shouldCloseInputStreamAfterCreateAttachment() throws Exception {
+        CloseTrackingInputStream tracking = new CloseTrackingInputStream(
+                new ByteArrayInputStream("attachment-payload".getBytes(StandardCharsets.UTF_8)));
+
+        Method m = ReportManagerHelper.class.getDeclaredMethod(
+                "createAttachment", String.class, String.class, InputStream.class);
+        m.setAccessible(true);
+        m.invoke(null, "Unit Test Attachment", "stream-closure.txt", tracking);
+
+        assertTrue(tracking.isClosed(), "createAttachment must close the supplied InputStream");
+    }
+
+    /**
+     * When ReportPortal is enabled, {@link AttachmentReporter} writes a temp file for
+     * {@code emitLog}; it must be deleted (or scheduled for delete) so CI agents do not
+     * accumulate garbage under {@code java.io.tmpdir}.
+     */
+    @Test
+    public void shouldNotLeaveReportPortalTempFilesBehindWhenEmitSucceeds() throws Exception {
+        long before = countRpTestFilesInTempDir();
+
+        ByteArrayOutputStream content = new ByteArrayOutputStream();
+        content.write("sample".getBytes(StandardCharsets.UTF_8));
+
+        try (MockedStatic<TestNGListener> tl = mockStatic(TestNGListener.class);
+             MockedStatic<ReportPortal> rp = mockStatic(ReportPortal.class)) {
+            tl.when(TestNGListener::isReportPortalEnabled).thenReturn(true);
+            rp.when(() -> ReportPortal.emitLog(anyString(), anyString(), any(Date.class), any(File.class)))
+                    .thenAnswer(invocation -> null);
+
+            AttachmentReporter.attachBasedOnFileType(
+                    "screenshot", "s.png", content, "screenshot - s.png");
+        }
+
+        long after = countRpTestFilesInTempDir();
+        assertEquals(after, before,
+                "rp-test* temp file count should not increase after ReportPortal attachment");
+    }
+}


### PR DESCRIPTION
### Summary
- Close InputStream in ReportManagerHelper#createAttachment after copying bytes (reduces FD leaks under parallel runs).
- AttachmentReporter: delete rp-test* temp files after ReportPortal.emitLog; on failure, log and continue instead of throwing.
- Test-data and media attach paths use in-memory bytes where the report path previously opened an extra FileInputStream.

### Tests
- ReportManagerHelperAttachmentIoUnitTest --> stream closure + no extra rp-test* files when ReportPortal is mocked.
- Verify it through this-->  mvn -Dtest=ReportManagerHelperAttachmentIoUnitTest test