### PR TITLE
Upgrade CLAUDE.md with environment requirements, CI workflow map, and cross-agent learnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 # CLAUDE.md
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+It is a living document — update it at the end of every non-trivial session with new patterns, constraints, and learnings.
 
 ## Commands
 
@@ -19,12 +20,53 @@ mvn javadoc:javadoc
 
 # Check for outdated dependencies before a release
 mvn versions:display-dependency-updates versions:display-plugin-updates versions:display-property-updates -DgenerateBackupPoms=false
+
+# Side-by-side comparison (before/after a focused change)
+BEFORE=<before_commit> AFTER=<after_commit> TESTS='testPackage.ClassA,testPackage.ClassB'
+for C in "$BEFORE" "$AFTER"; do
+  git checkout -q "$C"
+  START=$(date +%s)
+  mvn test -Dtest="$TESTS" -Dgpg.skip > "/tmp/compare_${C}.log" 2>&1
+  END=$(date +%s)
+  echo "${C},$((END-START))s"
+  grep -E "Tests run:|BUILD SUCCESS|BUILD FAILURE" "/tmp/compare_${C}.log" | tail -10
+done
 ```
 
 **Mandatory pre-commit sequence** (no exceptions):
 1. `mvn clean install -DskipTests -Dgpg.skip` must succeed.
 2. Write tests for every new or changed feature.
 3. `mvn test -Dtest=<YourTestClass>` must pass.
+
+---
+
+## Environment Requirements
+
+> **Critical — read before attempting any build or test run.**
+
+| Requirement | Version | Notes |
+|---|---|---|
+| **JDK** | **25** (exact) | Maven enforcer rejects any other JDK. The enforcer rule is `[25,26)`. |
+| **Maven** | 3.9+ | Verified with 3.9.11 |
+| **Node.js** | 25 (CI default) or `lts/*` (Cucumber jobs) | Used for Allure 3 CLI resolution. Not required for non-Allure local runs. |
+| **Docker** | Any recent version | Required for Selenium Grid jobs (`selenium4.yml` compose). Not needed for pure unit tests. |
+| **GPG** | Any | Only needed for Maven Central releases. Skip with `-Dgpg.skip` in dev. |
+
+**⚠️ JDK 25 is strictly enforced.** If you only have JDK 21 available (e.g., in an automated agent environment):
+- `mvn clean install` will fail at the enforcer step.
+- Attempting `-Denforcer.skip=true` bypasses the enforcer but then fails at the compiler (`release version 25 not supported`).
+- There is **no workaround** — JDK 25 must be installed to build or run tests.
+- As a consequence, **fresh JaCoCo coverage numbers cannot be generated** in a JDK 21 environment; coverage data must come from CI runs.
+
+**⚠️ Stale copilot-instructions.md**: `.github/copilot-instructions.md` says "Language: Java 21" in its overview section — this is **incorrect**. The project has been on Java 25 since at least 2026. Always trust `pom.xml` `<jdk.version>` over prose documentation.
+
+**UTF-8 enforcement**: The CI `setup-test-env` action sets these JVM flags globally:
+```
+JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8
+```
+They are also declared in `.mvn/jvm.config` for local runs. Do not remove them — Unicode text renders incorrectly without them on non-UTF-8 hosts.
+
+---
 
 ## Architecture
 
@@ -58,6 +100,8 @@ SHAFT never requires pre-installed binaries. New tool dependencies must follow t
 
 ### Allure 3 (Current)
 Use `AllureManager.resolveAllureCommandPrefix()` — never invoke `allure` directly. `allure generate` has **no `--clean` flag** in v3; summary JSON is at `<report>/summary.json` (not `widgets/`); config file is `allurerc.yaml`.
+
+---
 
 ## Code Patterns
 
@@ -110,6 +154,18 @@ int timeout = 30;
 System.getProperty("targetBrowserName");
 ```
 
+### ThreadLocal teardown (always remove to prevent pool-reuse leaks)
+```java
+@AfterMethod(alwaysRun = true)
+public void tear() {
+    driver.get().quit();
+    driver.remove();              // prevents stale reference when thread pool reuses threads
+    Properties.clearForCurrentThread();
+}
+```
+
+---
+
 ## Source Layout
 
 ```
@@ -129,20 +185,101 @@ src/main/java/com/shaft/
 
 src/test/java/
   testPackage/           Main integration/feature tests
-  com/shaft/             Framework unit tests (mirrors main package structure)
-  junitTestPackage/      JUnit5 examples
+    unitTests/           Pure unit tests (no browser/device required)
+    mockedTests/         Tests using Mockito mocks (no browser/device required)
+    properties/          Property accessor tests (no browser/device required)
+    coverage/            Race-condition and file-action tests
+    legacy/              Full browser integration tests (require Selenium Grid/local browser)
+    locator/             Locator builder tests (require browser)
+    validationsWizard/   Validation API tests (require browser)
+    SHAFTWizard/         Wizard-pattern demo tests (some require browser)
+    appium/              Mobile tests (require Appium server + device/emulator)
+    LambdaTest/          LambdaTest cloud tests (require LambdaTest credentials)
+  com/shaft/             Framework unit tests (mirrors main package structure, no browser needed)
+  junitTestPackage/      JUnit5 examples (no browser needed)
   cucumberTestRunner/    Cucumber runner + customCucumberSteps/
 
 src/main/resources/
   properties/            Default .properties files read by OWNER
   examples/              Seven sample pom.xml files (TestNG, JUnit, Cucumber variants)
+  docker-compose/        Selenium Grid + Postgres compose files
 ```
+
+---
+
+## CI Workflow Coverage Map
+
+The four active CI workflows use Maven `-Dtest=` regex patterns to select test classes. Understanding this map prevents "why isn't my test running in CI?" surprises.
+
+### `e2eTests.yml` (triggers on push to `main`, nightly, `workflow_dispatch`)
+
+| Job | Test pattern | Infrastructure needed |
+|---|---|---|
+| `Ubuntu_Database` | `.*DatabaseActions.*`, `.*DB.*`, `.*Db.*`, `.*db.*` | PostgreSQL container |
+| `Ubuntu_APIs` | `.*API.*`, `.*Api.*`, `.*uestBuilder.*`, `.*Rest.*`, `.*Json.*`, `.*JSON.*`, `.*json.*`, `.*YAML.*`, `.*Yaml.*`, `.*yaml.*`, `.*CLIWizard.*`, `.*TerminalActions.*`, `.*properties.Mobile.*`, `.*CSVFileManagerUnitTest.*`, `.*PdfFileManager.*`, `.*ExcelFileManager.*` | None (pure unit/API) |
+| `Ubuntu_Firefox_Grid` | **GLOBAL_TESTING_SCOPE** (see below) | Docker Selenium Grid, 10 Firefox nodes |
+| `Ubuntu_Chrome_Grid` | **GLOBAL_TESTING_SCOPE** | Docker Selenium Grid, 10 Chrome nodes |
+| `Ubuntu_MicrosoftEdge_Grid` | **GLOBAL_TESTING_SCOPE** | Docker Selenium Grid, 10 Edge nodes |
+| `Android_Native_BrowserStack` | `.*ndroid.*`, `.*BrowserStackPropertiesUnitTest.*`, `.*BrowserStackHelperUnitTest.*`, `.*BrowserStackSdkHelperCoverageUnitTest.*` | BrowserStack credentials |
+| `iOS_Web_SAFARI_BrowserStack` | `.*MobileWebTest.*` | BrowserStack credentials |
+| `Android_Web_Chrome_BrowserStack` | `.*MobileWebTest.*` | BrowserStack credentials |
+| `MacOSX_Safari_BrowserStack` | `.*BrowserActionsTests.*`, `.*BigPageActionsTest.*`, `.*BrowserStackPropertiesUnitTest.*`, `.*BrowserStackHelperUnitTest.*`, `.*BrowserStackSdkHelperCoverageUnitTest.*` | BrowserStack credentials |
+| `Ubuntu_Chrome_Cucumber_Grid` | `.*CucumberTests.*`, `.*CucumberFeatureListenerUnitTest.*`, `.*CucumberTestRunnerListenerUnitTest.*` | Docker Selenium Grid |
+| `MacOSX_Safari_Cucumber_BrowserStack` | `.*CucumberTests.*` | BrowserStack credentials |
+
+### `e2eLocalTests.yml` (nightly, `workflow_dispatch`)
+
+Runs **GLOBAL_TESTING_SCOPE** on Windows Edge, Windows Chrome, macOS Safari, macOS Chrome (local browser, no Grid).
+Also runs `.*CucumberTests.*` on Windows Edge Cucumber.
+MacOS Safari excludes additionally: `.*MobileEmulation.*`
+
+### `e2eLambdaTestTests.yml` (`workflow_dispatch`, nightly)
+
+| Job | Test pattern |
+|---|---|
+| `LambdaTest_NativeAndroid` | `.*Test_LTMobAPK.*` |
+| `LambdaTest_NativeIOS` | `.*Test_LTMobIPA.*` |
+| `LambdaTest_WebApp` | `.*Test_LTWebApp.*` |
+| `LambdaTest_DesktopWeb` | `.*Test_LTDesktopWeb.*`, `.*LambdaTestHelperUnitTest.*`, `.*LambdaTestSetPropertyCoverageUnitTest.*` |
+
+### GLOBAL_TESTING_SCOPE (exclusion-based)
+
+Everything **except** these patterns:
+```
+!.*DatabaseActions.*, !.*CLI.*, !.*DB.*, !.*Db.*, !.*db.*,
+!.*API.*, !.*Api.*, !.*api.*, !.*uestBuilder.*, !.*Rest.*,
+!.*Json.*, !.*JSON.*, !.*json.*, !.*ndroid.*, !.*IOS.*,
+!.*MobileWeb.*, !.*appium.Mobile.*, !.*properties.Mobile.*,
+!.*CucumberTests.*, !.*LT.*, !.*Flutter.*
+```
+
+**Important subtleties:**
+- `YAML`/`Yaml`/`yaml` are NOT excluded from GLOBAL_TESTING_SCOPE, so YAML unit tests run in both `Ubuntu_APIs` AND browser grid jobs (double execution — harmless for unit tests).
+- `.*LT.*` is matched literally, so "LambdaTest" (no adjacent L+T) passes through. Only `Test_LT*` class names are excluded.
+- `.*CucumberTests.*` excludes `testPackage.properties.CucumberTests` from GLOBAL_TESTING_SCOPE; it runs in Cucumber grid jobs instead.
+- `CucumberFeatureListenerUnitTest` and `CucumberTestRunnerListenerUnitTest` do NOT contain "CucumberTests" as a substring, so they run in BOTH Cucumber grid jobs AND GLOBAL_TESTING_SCOPE browser grid jobs.
+
+---
+
+## Known Workflow Coverage Gaps
+
+| Test class | Status | Reason | Resolution |
+|---|---|---|---|
+| `testPackage.appium.IOSBasicInteractionsTest` | ❌ **Not covered by any workflow** | Excluded from GLOBAL_TESTING_SCOPE via `!.*IOS.*`; iOS BrowserStack job only runs `MobileWebTest` | Needs a dedicated native iOS BrowserStack job, or explicit inclusion in the iOS web job |
+| `testPackage.appium.FlutterTest` | ⚠️ Intentionally not run | Excluded via `!.*Flutter.*`; all `@Test` methods have `groups = {"flutter"}` which no workflow enables | Intentional — no Flutter CI infrastructure configured |
+| `testPackage.appium.FileUploadDownloadTest` | ⚠️ Intentionally not run | All `@Test` methods have `enabled = false` | Intentional — tests are scaffolded but disabled |
+| `testPackage.appium.MobileTest` | N/A | Abstract base class | Cannot be instantiated directly |
+
+---
 
 ## Logging Rules
 - Every SHAFT action emits **exactly one** `INFO` log describing the outcome.
 - Every SHAFT action emits **at least one** `DEBUG` log with diagnostic context.
 - Route logs through SHAFT reporting helpers — never `System.out.println` or raw logger calls from action classes.
 - Default: root level `INFO`, console enabled, file logging disabled (enabled only on retry, then deleted and attached to Allure).
+- Do not add duplicate `INFO` logs through separate loggers for the same action.
+
+---
 
 ## Release Versioning
 Format: `{major}.{quarter}.{YYYYMMDD}` — e.g., `10.2.20260506`.
@@ -152,7 +289,25 @@ Three files must always be updated together:
 2. `Internal.java` `@DefaultValue` for `shaftEngineVersion` (and check `allure3Version`, `nodeLtsVersion`)
 3. All 7 example pom.xml files under `src/main/resources/examples/` (use bulk `sed`)
 
+Also sync these properties across all 7 sample pom.xml files:
+`jdk.version`, `aspectjweaver.version`, `maven-compiler-plugin.version`, `maven-resources-plugin.version`, `maven-surefire-plugin.version`, `surefire-testng.version`
+
 Merging to `main` auto-triggers Maven Central CD, JavaDocs publishing, and sample-project sync workflows.
+
+### Required Secrets for Release
+| Secret | Purpose |
+|---|---|
+| `GPG_KEYNAME`, `GPG_PASSPHRASE`, `GPG_PRIVATE_KEY` | Maven Central artifact signing |
+| `OSSRH_USERNAME`, `OSSRH_PASSWORD` | Maven Central credentials |
+| `BOT_TOKEN` | PAT with `repo` scope on `ShaftHQ/shafthq.github.io` for cross-repo dispatch |
+| `CODECOV_TOKEN` | JaCoCo coverage upload in `post-test-report` action |
+
+### Cross-Repo Dispatch Contract
+The CD pipeline dispatches to `ShaftHQ/shafthq.github.io` for automated blog post creation.
+**Always include `tag_name`** in the dispatch payload — the blog workflow reads `client_payload.tag_name`.
+Do NOT use `stefanzweifel/git-auto-commit-action` in the blog workflow; use `peter-evans/create-pull-request` instead (protected branch requires PR).
+
+---
 
 ## Key Anti-Patterns
 - Do **not** call `System.getProperty()` or `System.setProperty()` in framework or test code — use `SHAFT.Properties.*` / `ThreadLocalPropertiesManager`.
@@ -161,10 +316,129 @@ Merging to `main` auto-triggers Maven Central CD, JavaDocs publishing, and sampl
 - Do **not** add intentionally broken/failing tests; Allure `BROKEN` status fails CI.
 - Do **not** add new external binary dependencies without the three-tier resolution pattern.
 - Do **not** modify unrelated code while fixing a bug.
+- Do **not** use `Thread.sleep()` — use SHAFT's built-in wait mechanisms.
+- Do **not** skip `ThreadLocal.remove()` in teardown — stale references cause failures on thread-pool reuse.
+- Do **not** modify `SHAFT.Properties.flags` in parallel tests without `@Test(singleThreaded = true)` + teardown reset.
+- Do **not** read CI workflow job names from copilot-instructions.md for Java version — always check `pom.xml`.
+- Do **not** add `## What's Changed` placeholder in `RELEASE_BODY_TEMPLATE.md` — it is appended automatically.
+
+---
+
+## Mobile & Remote Testing Constraints
+
+### BrowserStack
+- `TouchActions.pushFile()`/`pullFile()` may return corrupted content on BrowserStack virtual devices — validate thoroughly before writing integration tests.
+- `nativeKeyboardKeyPress()` relies on `mobile: isKeyboardShown` which may not return `true` on BrowserStack after typing.
+- BrowserStack SDK integration is optional; it is excluded from the default surefire classpath (`classpathDependencyExcludes`) to avoid AspectJ instrumentation noise.
+
+### API Tests with External Services
+- Tests hitting external services (e.g., `restful-booker.herokuapp.com`) should use `.setTargetStatusCode(0)` to skip status code validation when the test is about functionality (performance, request building) rather than the API contract.
+
+### iOS Native Tests
+- `IOSBasicInteractionsTest` is the only test class with no CI workflow coverage (see Known Gaps above). It requires a BrowserStack native iOS session.
+
+---
 
 ## Path-Scoped Instruction Files
 More detailed rules are in `.github/instructions/`:
 - `java-tests.instructions.md` — applies to `src/test/java/**/*.java`
 - `framework-source.instructions.md` — applies to `src/main/java/**/*.java`
 
-Full development methodology (PDCA cycle, bug-fix process, PR checklist) is in `.github/copilot-instructions.md`.
+Full development methodology (PDCA cycle, bug-fix process, PR checklist, release process) is in `.github/copilot-instructions.md`.
+
+---
+
+## Agent Knowledge Repository
+
+Other AI agents are also configured for this repo. Their skills inform patterns usable here too:
+
+| Agent | Files | Key skills |
+|---|---|---|
+| GitHub Copilot | `.github/copilot-instructions.md`, `.github/copilot-memory.md`, `.github/instructions/` | PDCA methodology, bug-fix process, release process, self-improvement ledger |
+| Copilot skills | `.github/skills/github-copilot/` | CI failure investigator, flaky-test stabilizer, release-dependency guard |
+| Google Gemma | `.github/skills/google-gemma/` | SHAFT expert triage, code analysis, confidence-scored diagnosis |
+| DeepSeek | `.github/skills/deepseek/README.md` | Code analysis + debugging (no skills yet) |
+| Qwen | `.github/skills/qwen/README.md` | Multilingual code generation (no skills yet) |
+| Claude Code | `.github/skills/claude-code/README.md` | This file is Claude's primary context |
+
+**Adopt from copilot-instructions.md:**
+- PDCA: Plan → Do → Check → Act, minimum 3 iterations for non-trivial work.
+- Bug-fix: write a failing test first, fix root cause (not symptoms), run regression tests.
+- Validation checklist before every PR (see `.github/pull_request_template.md`).
+
+**Adopt from Gemma code-analysis-and-optimization.md:**
+- Root-cause-first diagnosis: distinguish symptom, trigger, and root cause.
+- Confidence scoring: High (direct match) / Medium (partial) / Low (insufficient evidence).
+- Fix ordering by impact and blast radius.
+
+**Adopt from flaky-test-stabilizer.md:**
+- `ThreadLocal` requires both `.quit()` AND `.remove()` in teardown.
+- Global `SHAFT.Properties.flags` mutations need `@Test(singleThreaded = true)` + teardown reset.
+- Assertions on external services need mocking or `.setTargetStatusCode(0)`.
+
+---
+
+## Self-Improvement Cycle
+
+> Claude Code **must** update this file after every non-trivial session. This is how the agent gets smarter over time.
+
+### What to capture
+1. **Environment constraints discovered** — version mismatches, missing tools, JDK requirements.
+2. **New patterns or idioms** — if you found a better way, note it in the relevant section.
+3. **Anti-patterns encountered** — add to the anti-patterns list to prevent future repetition.
+4. **CI/workflow behavior** — if a workflow behaved unexpectedly, document the root cause and fix.
+5. **Coverage/test gaps** — any test class not covered by a workflow.
+6. **Cross-agent learnings** — if another agent's skill file had useful patterns, migrate them here.
+
+### Format for session learnings
+Add entries to the **Session Learnings Log** section below. Keep each entry compact:
+```
+- Date: YYYY-MM-DD
+- Area: (Environment / CI / Coverage / Pattern / Anti-pattern / Release)
+- Lesson: one-sentence summary
+- Evidence: (file path, class, workflow, issue/PR)
+```
+
+### When NOT to update
+- Trivial fixes (typo, renaming a variable) — skip.
+- Changes already documented in `.github/copilot-instructions.md` — reference that file instead of duplicating.
+- Temporary workarounds — document the root cause and the intended fix, not the workaround.
+
+---
+
+## Session Learnings Log
+
+- Date: 2026-05-08
+- Area: Environment
+- Lesson: JDK 25 is strictly enforced by the Maven enforcer plugin (`[25,26)` range); JDK 21 is the only version available in automated agent environments (Claude Code on Web) and cannot build or run tests — no workaround exists.
+- Evidence: `pom.xml` line 39 (`<jdk.version>25</jdk.version>`), `pom.xml` lines 1122-1135 (enforcer rule), `setup-test-env/action.yml` line 6 (`default: '25'`)
+
+- Date: 2026-05-08
+- Area: CI / Coverage
+- Lesson: `testPackage.appium.IOSBasicInteractionsTest` is the only test class in the repo with zero CI workflow coverage — it is excluded from GLOBAL_TESTING_SCOPE via `!.*IOS.*` and the iOS BrowserStack job only runs `MobileWebTest`.
+- Evidence: `.github/workflows/e2eTests.yml` lines 14-15 (GLOBAL_TESTING_SCOPE), issue #2503 comment 2026-05-08
+
+- Date: 2026-05-08
+- Area: CI / Coverage
+- Lesson: The regex `!%regex[.*LT.*]` in GLOBAL_TESTING_SCOPE only excludes class names containing a literal "LT" substring — "LambdaTest" does not contain adjacent L+T, so `LambdaTestHelperUnitTest` and `LambdaTestSetPropertyCoverageUnitTest` run in GLOBAL_TESTING_SCOPE in addition to the LambdaTest workflow.
+- Evidence: `.github/workflows/e2eTests.yml` line 15
+
+- Date: 2026-05-08
+- Area: CI / Coverage
+- Lesson: `testPackage.properties.CucumberTests` matches `!%regex[.*CucumberTests.*]` and is therefore excluded from GLOBAL_TESTING_SCOPE, running only in Cucumber grid jobs — this is a property test, not a Cucumber runner, but it co-locates correctly.
+- Evidence: `.github/workflows/e2eTests.yml` lines 347-348
+
+- Date: 2026-05-08
+- Area: Coverage / JaCoCo
+- Lesson: All 60 classes in issue #2503 coverage backlog now have dedicated unit tests wired into at least one CI workflow; 34 of those classes have confirmed post-PR coverage percentages from commit messages, the remainder need a full CI run to measure.
+- Evidence: git log since 2026-05-07, issue #2503 comment 2026-05-08
+
+- Date: 2026-05-08
+- Area: Environment / Agent
+- Lesson: `.github/copilot-instructions.md` states "Language: Java 21" — this is outdated and incorrect; always derive the canonical Java version from `pom.xml` `<jdk.version>`.
+- Evidence: `.github/copilot-instructions.md` line 8 vs `pom.xml` line 39
+
+- Date: 2026-05-07
+- Area: Encoding / Unicode
+- Lesson: Enforce UTF-8 at all runtime layers (Maven JVM, Surefire forked JVMs, and CI environment) — do not rely on host defaults.
+- Evidence: `pom.xml`, `.mvn/jvm.config`, `setup-test-env/action.yml`, `testPackage/properties/Log4jTests.java` (from copilot-memory.md)


### PR DESCRIPTION
Key additions:
- Environment Requirements section: JDK 25 strictly enforced, Maven 3.9+, Node.js, Docker; explicit warning that JDK 21 (the only version in automated agent environments) cannot build the project
- CI Workflow Coverage Map: full regex-pattern-to-job mapping for all four active workflows (e2eTests, e2eLocalTests, e2eLambdaTestTests), including GLOBAL_TESTING_SCOPE subtleties (LT regex, CucumberTests exclusion, YAML double-run)
- Known Workflow Coverage Gaps: IOSBasicInteractionsTest has zero CI coverage; FlutterTest and FileUploadDownloadTest are intentionally excluded
- ThreadLocal teardown pattern: add .remove() after .quit() to prevent thread-pool reuse leaks
- Release secrets table and cross-repo dispatch contract
- Mobile/Remote testing constraints: BrowserStack pushFile/pullFile reliability, nativeKeyboardKeyPress limitation
- Agent Knowledge Repository: inventory of all AI agent skill files with cross-pollination notes from Copilot (PDCA, bug-fix), Gemma (confidence scoring, root-cause diagnosis), and Flaky-test stabilizer
- Self-Improvement Cycle section: directive and format for updating this file after every non-trivial session
- Session Learnings Log: six documented learnings from the 2026-05-08 coverage audit session

https://claude.ai/code/session_01PLvyvs8JLRdd9fNDFwH6DL