### PR TITLE
fix(coverage): restore testFailureIgnore=true so JaCoCo runs even when tests fail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,6 +438,16 @@ Add entries to the **Session Learnings Log** section below. Keep each entry comp
 - Lesson: `.github/copilot-instructions.md` states "Language: Java 21" — this is outdated and incorrect; always derive the canonical Java version from `pom.xml` `<jdk.version>`.
 - Evidence: `.github/copilot-instructions.md` line 8 vs `pom.xml` line 39
 
+- Date: 2026-05-08
+- Area: CI / Coverage / Anti-pattern
+- Lesson: `<testFailureIgnore>false</testFailureIgnore>` in Surefire causes Maven to exit (code 1) during the `test` phase when tests fail, before JaCoCo's `report` goal (also bound to `test` phase) runs — coverage is never generated. Always keep `testFailureIgnore=true` and delegate pass/fail enforcement to the `post-test-report` composite action, which reads Allure summary.json or Surefire XML and exits 1 on failures.
+- Evidence: `pom.xml` surefire config (lines 1484/1549), `.github/actions/post-test-report/action.yml` lines 141-154, issue #2642, PR for `claude/coverage-on-maven-failure-dbdnG`
+
+- Date: 2026-05-08
+- Area: Pattern / New PR workflow
+- Lesson: When working on a new scope of work: always create a new branch, self-assign the GitHub issue, implement the fix, commit, push, and open a draft PR assigning the user as reviewer.
+- Evidence: User instructions in session 2026-05-08
+
 - Date: 2026-05-07
 - Area: Encoding / Unicode
 - Lesson: Enforce UTF-8 at all runtime layers (Maven JVM, Surefire forked JVMs, and CI environment) — do not rely on host defaults.

--- a/pom.xml
+++ b/pom.xml
@@ -1477,10 +1477,13 @@
                                 <alwaysLogDiscreetly>true</alwaysLogDiscreetly>
                                 <log4j2.disableAnsi>true</log4j2.disableAnsi>
                             </systemPropertyVariables>
-                            <!-- Enforce strict failure behavior -->
-                            <testFailureIgnore>false</testFailureIgnore>
-                            <failIfNoSpecifiedTests>true</failIfNoSpecifiedTests>
-                            <failIfNoTests>true</failIfNoTests>
+                            <!-- testFailureIgnore=true lets Maven complete the test phase even when tests fail,
+                                 which allows JaCoCo to generate its coverage report afterward.
+                                 Actual pass/fail is enforced by the post-test-report composite action
+                                 (reads Allure summary.json or Surefire XML and exits 1 on failures). -->
+                            <testFailureIgnore>true</testFailureIgnore>
+                            <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+                            <failIfNoTests>false</failIfNoTests>
                             <trimStackTrace>false</trimStackTrace>
                             <useFile>true</useFile>
                             <argLine>
@@ -1539,10 +1542,13 @@
                                 <alwaysLogDiscreetly>true</alwaysLogDiscreetly>
                                 <log4j2.disableAnsi>true</log4j2.disableAnsi>
                             </systemPropertyVariables>
-                            <!-- Enforce strict failure behavior -->
-                            <testFailureIgnore>false</testFailureIgnore>
-                            <failIfNoSpecifiedTests>true</failIfNoSpecifiedTests>
-                            <failIfNoTests>true</failIfNoTests>
+                            <!-- testFailureIgnore=true lets Maven complete the test phase even when tests fail,
+                                 which allows JaCoCo to generate its coverage report afterward.
+                                 Actual pass/fail is enforced by the post-test-report composite action
+                                 (reads Allure summary.json or Surefire XML and exits 1 on failures). -->
+                            <testFailureIgnore>true</testFailureIgnore>
+                            <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+                            <failIfNoTests>false</failIfNoTests>
                             <trimStackTrace>false</trimStackTrace>
                             <useFile>true</useFile>
                             <argLine>


### PR DESCRIPTION
## Summary

- Reverts `<testFailureIgnore>false</testFailureIgnore>` introduced in #2634 back to `true` in both Surefire configurations (TestNG and JUnit listeners)
- Reverts `failIfNoSpecifiedTests` and `failIfNoTests` back to `false`
- Adds an explanatory comment in `pom.xml` documenting *why* `testFailureIgnore=true` must be kept

## Root cause

`testFailureIgnore=false` causes Maven to exit with code 1 during the `test` phase as soon as Surefire detects a failure. Because JaCoCo's `report` goal is also bound to the `test` phase (and declared after Surefire), it never executes — so `target/jacoco/jacoco.xml` is never written and the Codecov upload in `post-test-report` has nothing to send.

## Why the pipeline stays RED on failure

CI pass/fail is **not** determined by Maven's exit code. All test steps use `continue-on-error: true`, and the `post-test-report` composite action is responsible for the final verdict: it reads Allure `summary.json` (or falls back to Surefire XML) and calls `exit 1` when any tests are `failed` or `broken`. This was already in place before #2634, so reverting `testFailureIgnore` does not re-introduce the original green-pipeline issue.

## Test plan

- [ ] Verify CI runs produce a non-empty `target/jacoco/jacoco.xml` and a successful Codecov upload
- [ ] Verify a job with real test failures still marks the pipeline RED (via `post-test-report` exit 1)
- [ ] Confirm no regression in jobs that run with targeted `-Dtest=` patterns (e.g. `Ubuntu_APIs`, `Ubuntu_Database`)

Closes #2642

https://claude.ai/code/session_01KzcDiXTSdmT9znono7a9XW