### PR TITLE
Add Agent Knowledge Migration runbook and integrate with agent instructions and memory

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1120,6 +1120,13 @@ These guidelines apply to GitHub Copilot coding agent sessions working on this r
 3. **Edge cases** — if a test revealed an unexpected edge case, document it near the relevant SHAFT API section.
 4. **Workflow improvements** — if a CI/CD workflow behaved unexpectedly, note the root cause and the correct fix.
 
+### Repository Knowledge Migration Protocol
+- When asked to scan, migrate, consolidate, or preserve agent knowledge, follow `docs/AGENT_KNOWLEDGE_MIGRATION.md`.
+- Create or link a task ticket before implementation; if authenticated GitHub Issues access is unavailable, create a local ticket under `docs/tickets/` and note that maintainers should mirror it.
+- Create a dedicated task branch before editing files, then keep migration/documentation changes isolated from unrelated code.
+- Discover `AGENTS.md`, instruction, memory, skill, and tool files first; reconcile conflicts by favoring direct session instructions, scoped instructions, and executable configuration over stale prose.
+- Open a PR when the initial implementation is complete so humans can collaborate before the migration is finalized; if GitHub publication access is unavailable, explicitly report the limitation and provide a PR handoff.
+
 ### Persistent Memory Ledger (Mandatory for Non-Trivial Sessions)
 - Store high-value learnings in `.github/copilot-memory.md` using a compact append-only format.
 - Add entries only for reusable lessons (root-cause patterns, CI traps, tooling constraints, flaky-test signatures).

--- a/.github/copilot-memory.md
+++ b/.github/copilot-memory.md
@@ -18,3 +18,9 @@ Purpose: keep high-signal, reusable learnings from implementation sessions in on
 - Evidence: `pom.xml`, `.mvn/jvm.config`, `.github/actions/setup-test-env/action.yml`, `src/test/java/testPackage/properties/Log4jTests.java`
 - Action taken: Added explicit UTF-8 JVM flags and coverage assertions to prevent regressions.
 
+- Date: 2026-05-08
+- Area: Agent knowledge migration / instruction hygiene
+- Trigger: Request to scan repository skills, tools, instructions, and memory for a smooth AI-agent migration without knowledge loss.
+- Lesson: Use `docs/AGENT_KNOWLEDGE_MIGRATION.md` for future migration tasks: create or link a ticket, branch before editing, progressively scan instruction/memory/skill files, favor executable configuration over stale prose, update the memory ledger, commit, and open a PR; if GitHub publication access is missing, explicitly report the limitation and provide a PR handoff.
+- Evidence: `docs/AGENT_KNOWLEDGE_MIGRATION.md`, `docs/tickets/2026-05-08-agent-knowledge-migration.md`, `.github/copilot-instructions.md`, `CLAUDE.md`
+- Action taken: Added a migration runbook, local ticket, global instruction reference, Claude guidance, and this memory entry.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,10 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 It is a living document — update it at the end of every non-trivial session with new patterns, constraints, and learnings.
 
+## Repository Knowledge Migration
+
+When a session asks to scan, consolidate, migrate, or preserve repository knowledge, use `docs/AGENT_KNOWLEDGE_MIGRATION.md` as the canonical runbook. Create or link a task ticket first, create a dedicated task branch before editing, scan instruction/memory/skill/tool files with progressive disclosure, reconcile conflicts in favor of scoped instructions and executable config, update `.github/copilot-memory.md` with reusable lessons, commit the work, and open a PR for human collaboration; if GitHub publication access is unavailable, report the limitation and provide a PR handoff.
+
 ## Commands
 
 ```bash

--- a/docs/AGENT_KNOWLEDGE_MIGRATION.md
+++ b/docs/AGENT_KNOWLEDGE_MIGRATION.md
@@ -56,7 +56,7 @@ Perform a focused repository scan:
 
 ```bash
 find .. -name AGENTS.md -print
-rg --files -g '*instruction*' -g '*memory*' -g 'CLAUDE.md' -g '.github/skills/**'
+rg --files -g '*instruction*' -g '*memory*' -g 'CLAUDE.md' -g '.github/skills/**' .github CLAUDE.md
 ```
 
 Then read only the files required to understand the task. Prefer progressive disclosure over loading the entire repository into context.

--- a/docs/AGENT_KNOWLEDGE_MIGRATION.md
+++ b/docs/AGENT_KNOWLEDGE_MIGRATION.md
@@ -1,0 +1,128 @@
+# Agent Knowledge Migration Runbook
+
+Use this runbook when an AI-agent session is asked to scan the repository, migrate between agents, consolidate instructions, or preserve repository knowledge for future work.
+
+## Goals
+
+- Preserve repository-specific knowledge without relying on transient chat context.
+- Keep global instructions, scoped instructions, skills, and memory ledgers aligned.
+- Make migration work traceable through a ticket, branch, commit, and PR.
+- Avoid knowledge loss by recording durable lessons in the canonical memory ledger.
+
+## Canonical Knowledge Sources
+
+Start with these repository sources before making implementation decisions:
+
+| Source | Purpose |
+|---|---|
+| `.github/copilot-instructions.md` | Global AI-agent policy, PDCA workflow, validation requirements, and self-improvement rules. |
+| `.github/copilot-memory.md` | Append-only ledger for reusable lessons and decision context. |
+| `.github/instructions/*.instructions.md` | Path-scoped rules for framework source and Java test files. |
+| `.github/skills/` | Agent/model-specific skills and task playbooks. |
+| `CLAUDE.md` | Claude Code operating notes, environment requirements, architecture notes, and command reference. |
+| `README.md` and `docs/` | User-facing framework overview, architecture, features, quick start, and technical context. |
+| Executable config (`pom.xml`, `.mvn/jvm.config`, workflow files) | Source of truth for versions, build constraints, and CI behavior when prose conflicts. |
+
+## Migration Workflow
+
+Follow this sequence for every non-trivial knowledge migration or instruction consolidation task.
+
+### 1. Create a ticket
+
+Create or link a ticket before implementation. If authenticated GitHub access is unavailable, create a local ticket under `docs/tickets/` using the date and a short slug, then state that it should be mirrored to GitHub Issues by maintainers.
+
+A good ticket includes:
+
+- Problem statement.
+- Proposed solution.
+- Scope and non-goals.
+- Acceptance criteria.
+- Branch name.
+- Notes about environment limitations.
+
+### 2. Create a task branch
+
+Use a descriptive branch name before editing files, for example:
+
+```bash
+git switch -c task/agent-memory-migration-runbook
+```
+
+Do not mix migration/documentation work with unrelated code changes.
+
+### 3. Discover instructions, skills, and memory
+
+Perform a focused repository scan:
+
+```bash
+find .. -name AGENTS.md -print
+rg --files -g '*instruction*' -g '*memory*' -g 'CLAUDE.md' -g '.github/skills/**'
+```
+
+Then read only the files required to understand the task. Prefer progressive disclosure over loading the entire repository into context.
+
+### 4. Reconcile conflicts
+
+When guidance conflicts, apply this precedence order:
+
+1. Direct user/developer/system instructions for the current session.
+2. `AGENTS.md` files that scope to the changed files, if present.
+3. Path-scoped repository instructions in `.github/instructions/`.
+4. Global repository instructions in `.github/copilot-instructions.md` and `CLAUDE.md`.
+5. Agent/model-specific skills in `.github/skills/`.
+6. General docs and README prose.
+
+Executable configuration wins over stale prose for build versions and runtime constraints. For example, prefer `pom.xml` and enforcer rules over a prose language-version summary if they disagree.
+
+### 5. Consolidate without duplication
+
+- Keep stable policy in `.github/copilot-instructions.md` or `CLAUDE.md`.
+- Keep path-specific coding/test rules in `.github/instructions/`.
+- Keep task-specific playbooks in `.github/skills/`.
+- Keep reusable lessons and rationale in `.github/copilot-memory.md`.
+- Move long explanatory workflows to `docs/` and link to them from instruction files.
+
+### 6. Validate and commit
+
+For documentation-only changes, run lightweight checks that prove the edited files are present and traceable. For code changes, follow the mandatory Maven compile/test sequence from the repository instructions.
+
+Suggested documentation checks:
+
+```bash
+git status --short
+rg -n "Agent Knowledge Migration|knowledge migration|docs/tickets" docs .github CLAUDE.md
+```
+
+Commit the final changes on the task branch with a concise message.
+
+### 7. Open a PR
+
+Open a PR when the initial implementation is ready for collaboration and merge review. Prefer a draft PR while the implementation is intentionally incomplete; otherwise open a ready-for-review PR. The PR body should include:
+
+- Summary of files changed.
+- Validation commands and outcomes.
+- Any environment limitations.
+- Follow-up actions, such as mirroring a local ticket into GitHub Issues.
+
+If a session cannot publish to GitHub, it must explicitly report the missing access instead of implying that a GitHub PR exists. Before claiming that a PR is visible on GitHub, verify all of the following:
+
+```bash
+git remote -v
+command -v gh
+gh auth status
+```
+
+When any of those checks are unavailable or unauthenticated, create the local PR/handoff artifact required by the execution environment, include the intended PR title/body in the final response, and ask a maintainer to push the branch and open the GitHub PR.
+
+## Session Memory Checklist
+
+Before finishing a migration task, update `.github/copilot-memory.md` with:
+
+- Date.
+- Area.
+- Trigger.
+- Lesson.
+- Evidence.
+- Action taken.
+
+Keep the memory entry compact and reusable. Do not paste long transcripts or duplicate the runbook.

--- a/docs/tickets/2026-05-08-agent-knowledge-migration.md
+++ b/docs/tickets/2026-05-08-agent-knowledge-migration.md
@@ -1,0 +1,39 @@
+# Ticket: Agent Knowledge Migration and Instruction Consolidation
+
+- **Date created:** 2026-05-08
+- **Branch:** `task/agent-memory-migration-runbook`
+- **Type:** Documentation / AI-agent enablement
+- **Status:** Initial implementation committed; GitHub PR publication blocked by missing remote/GitHub CLI access in this environment
+
+## Problem Statement
+
+Agent knowledge for SHAFT_ENGINE is distributed across repository-level instructions, memory ledgers, scoped source/test guidance, agent-specific skills, and general project documentation. New AI-agent sessions need a repeatable way to discover, reconcile, and preserve this knowledge without losing local constraints during migration or handoff.
+
+## Proposed Solution
+
+Create a repository knowledge migration runbook and add durable instruction/memory entries that require future agents to:
+
+1. Discover repository instruction, memory, skill, and tool files before changing code.
+2. Reconcile conflicts by favoring executable configuration and path-scoped instructions over stale prose.
+3. Record reusable learnings in the canonical memory ledger.
+4. Create a task ticket, isolate work on a task branch, and open a PR for collaborative review when a migration/consolidation task is requested; if GitHub publication access is unavailable, provide a PR handoff and say so clearly.
+
+## Scope
+
+- Add a durable runbook under `docs/` for future agent migrations.
+- Update global agent instructions to reference the runbook.
+- Update Claude guidance so Claude Code sessions follow the same migration workflow.
+- Append a compact memory ledger entry preserving the decision context.
+
+## Acceptance Criteria
+
+- [x] Ticket exists in the repository.
+- [x] Dedicated implementation branch exists: `task/agent-memory-migration-runbook`.
+- [x] Migration runbook documents discovery, consolidation, ticket, branch, and PR workflow.
+- [x] Agent instructions and memory ledger reference the process for future reuse.
+- [x] Initial implementation is committed and a PR handoff is prepared for human collaboration.
+- [x] Missing GitHub publication access is explicitly documented so maintainers know why no PR appears in GitHub.
+
+## Notes for Reviewers
+
+This ticket was created locally because this execution environment does not expose an authenticated GitHub CLI or Git remote. The agent can record PR metadata through the local `make_pr` tool, but cannot publish a visible GitHub PR from this checkout. Maintainers should push `task/agent-memory-migration-runbook`, open the GitHub PR, and mirror/link this ticket in GitHub Issues if desired.


### PR DESCRIPTION
### Motivation
- Provide a repeatable runbook for scanning, migrating, and consolidating AI-agent knowledge across the repository.
- Ensure migration work is traceable via a ticket, task branch, and PR and that durable lessons are recorded in the memory ledger.
- Reduce knowledge-loss risk by favoring executable configuration and scoped instructions over stale prose during reconciliations.

### Description
- Add `docs/AGENT_KNOWLEDGE_MIGRATION.md` containing a step-by-step migration workflow, canonical sources, conflict-precedence rules, and validation guidance.
- Update `.github/copilot-instructions.md` to reference the new Repository Knowledge Migration Protocol and add concise procedural bullets.
- Append a memory entry to `.github/copilot-memory.md` capturing the migration lesson and evidence. 
- Update `CLAUDE.md` with repository migration guidance and add a local ticket file at `docs/tickets/2026-05-08-agent-knowledge-migration.md` documenting the task, branch, scope, and the environment limitation that blocked PR publication. 

### Testing
- No unit or integration tests were required for documentation-only changes. 
- Per the runbook, lightweight validation was performed to confirm files are present using commands like `git status --short` and `rg -n "Agent Knowledge Migration|docs/tickets"`, and these checks succeeded. 
- PR publication could not be completed from this environment due to missing Git remote/GitHub CLI authentication, which is documented in the ticket and should be completed by a maintainer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe4909867083209b22c4040be74063)