### PR TITLE
Enable alerts/search/checksum tests, add local fixtures, and SHA-256 helper

### DIFF
--- a/src/test/java/testPackage/legacy/ChecksumTests.java
+++ b/src/test/java/testPackage/legacy/ChecksumTests.java
@@ -5,14 +5,17 @@ import com.shaft.cli.TerminalActions;
 import com.shaft.validation.Validations;
 import org.testng.annotations.Test;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+
 public class ChecksumTests {
-    @Test(enabled = false)
-    public void readLocalFileChecksum() {
+    @Test
+    public void readLocalFileChecksum() throws Exception {
         String targetFileFolderPath = "";
         String targetFileName = "pom.xml";
-        // Expected SHA-256 checksum for the current contents of pom.xml in targetFileFolderPath.
-        // Regenerate/verify when pom.xml changes (for example: `sha256sum pom.xml`).
-        String expectedHash = "f31105c8059fb10caba965b489fa97a88212ed529916bf3d8841e5ca7d076eb8";
+        String expectedHash = calculateSha256(Path.of(targetFileFolderPath, targetFileName));
 
         TerminalActions terminalSession = new TerminalActions();
         String actualHash = FileActions.getInstance().getFileChecksum(terminalSession, targetFileFolderPath, targetFileName);
@@ -64,5 +67,10 @@ public class ChecksumTests {
                 pathToTempDirectoryOnRemoteMachine);
 
         Validations.assertThat().object(actualHash).isEqualTo(expectedHash);
+    }
+
+    private String calculateSha256(Path targetFilePath) throws Exception {
+        byte[] digest = MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(targetFilePath));
+        return HexFormat.of().formatHex(digest);
     }
 }

--- a/src/test/java/testPackage/mockedTests/CoverageTests.java
+++ b/src/test/java/testPackage/mockedTests/CoverageTests.java
@@ -39,13 +39,14 @@ public class CoverageTests {
             driver.get().browser().navigateToURLWithBasicAuthentication("https://authenticationtest.com/HTTPAuth/", "user", "pass", "https://authenticationtest.com/loginSuccess/");
     }
 
-    @Test(enabled = false)
+    @Test
     public void alerts_getText_and_accept() {
-        driver.get().browser().navigateToURL("https://kitchen.applitools.com/ingredients/alert");
+        driver.get().browser().navigateToURL(SHAFT.Properties.paths.testData() + "alertFixture.html");
         var alert = driver.get().element().click(By.id("alert-button"))
                 .and().alert();
         alert.getAlertText();
         alert.acceptAlert();
+        driver.get().element().assertThat(By.id("alert-result")).text().isEqualTo("accepted").perform();
     }
 
     @Test(expectedExceptions = {RuntimeException.class})
@@ -91,18 +92,20 @@ public class CoverageTests {
         }
     }
 
-    @Test(enabled = false)
+    @Test
     public void alerts_dismiss() {
-        driver.get().browser().navigateToURL("https://kitchen.applitools.com/ingredients/alert");
+        driver.get().browser().navigateToURL(SHAFT.Properties.paths.testData() + "alertFixture.html");
         driver.get().element().click(By.id("confirm-button"))
                 .and().alert().dismissAlert();
+        driver.get().element().assertThat(By.id("confirm-result")).text().isEqualTo("false").perform();
     }
 
-    @Test(enabled = false)
+    @Test
     public void alerts_type() {
-        driver.get().browser().navigateToURL("https://kitchen.applitools.com/ingredients/alert");
+        driver.get().browser().navigateToURL(SHAFT.Properties.paths.testData() + "alertFixture.html");
         driver.get().element().click(By.id("prompt-button"))
                 .and().alert().typeIntoPromptAlert("nachos").acceptAlert();
+        driver.get().element().assertThat(By.id("prompt-result")).text().isEqualTo("nachos").perform();
     }
 
     @Test(enabled = false)

--- a/src/test/java/testPackage/unitTests/CucumberFeatureListenerUnitTest.java
+++ b/src/test/java/testPackage/unitTests/CucumberFeatureListenerUnitTest.java
@@ -93,7 +93,7 @@ public class CucumberFeatureListenerUnitTest {
         Mockito.verify(lifecycle, Mockito.times(1)).updateTestCase(Mockito.anyString(), Mockito.any());
     }
 
-    @Test(enabled = false)
+    @Test
     public void examplesAsParametersShouldReturnEmptyWhenRowsNotMatching() throws Exception {
         CucumberFeatureListener listener = new CucumberFeatureListener(Mockito.mock(AllureLifecycle.class));
         Method method = CucumberFeatureListener.class.getDeclaredMethod("getExamplesAsParameters", io.cucumber.messages.types.Scenario.class, TestCase.class);

--- a/src/test/java/testPackage/unitTests/TestClass.java
+++ b/src/test/java/testPackage/unitTests/TestClass.java
@@ -3,7 +3,6 @@ package testPackage.unitTests;
 import com.shaft.driver.SHAFT;
 import com.shaft.gui.internal.locator.Locator;
 import org.openqa.selenium.By;
-import org.openqa.selenium.Keys;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import testPackage.Tests;
@@ -11,28 +10,27 @@ import testPackage.Tests;
 public class TestClass extends Tests {
     SHAFT.TestData.JSON testData;
 
-    String targetUrl = "https://duckduckgo.com/";
+    String targetUrl = SHAFT.Properties.paths.testData() + "searchFixture.html";
 
-    By searchBox = Locator.hasAnyTagName().hasAttribute("id", "searchbox_input").build(); // DuckDuckGo search box (id changed from legacy 'search_form_input_homepage')
-    By firstSearchResult = Locator.hasTagName("article").isFirst().build(); // synonym to By.xpath("(//article)[1]");
+    By searchBox = Locator.hasAnyTagName().hasAttribute("id", "searchbox_input").build();
+    By firstSearchResult = Locator.hasTagName("article").isFirst().build();
 
-    @Test(enabled = false)
-    public void navigateToDuckDuckGoAndAssertBrowserTitleIsDisplayedCorrectly() {
+    @Test
+    public void navigateToSearchFixtureAndAssertBrowserTitleIsDisplayedCorrectly() {
         driver.get().browser().navigateToURL(targetUrl)
-                .and().assertThat().title().contains(testData.getTestData("expectedTitle"));
+                .and().assertThat().title().isEqualTo("SHAFT Search Fixture");
     }
 
-    @Test(enabled = false)
-    public void navigateToDuckDuckGoAndAssertSearchBoxIsVisible() {
+    @Test
+    public void navigateToSearchFixtureAndAssertSearchBoxIsVisible() {
         driver.get().browser().navigateToURL(targetUrl)
                 .and().element().assertThat(searchBox).isVisible();
     }
 
-    @Test(enabled = false)
+    @Test
     public void searchForQueryAndAssert() {
-        // this test will fail when duckduckgo detects that a bot is using it and shows a captcha instead of search results
         driver.get().browser().navigateToURL(targetUrl)
-                .and().element().type(searchBox, testData.getTestData("searchQuery") + Keys.ENTER)
+                .and().element().type(searchBox, testData.getTestData("searchQuery"))
                 .and().assertThat(firstSearchResult).text().doesNotEqual(testData.getTestData("unexpectedInFirstResult"));
     }
 

--- a/src/test/resources/testDataFiles/alertFixture.html
+++ b/src/test/resources/testDataFiles/alertFixture.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Alert Fixture</title>
+    <script>
+        function showAlert() {
+            alert('Hello from fixture');
+            document.getElementById('alert-result').textContent = 'accepted';
+        }
+
+        function showConfirm() {
+            document.getElementById('confirm-result').textContent = String(confirm('Continue?'));
+        }
+
+        function showPrompt() {
+            document.getElementById('prompt-result').textContent = prompt('Favorite food?');
+        }
+    </script>
+</head>
+<body>
+<button id="alert-button" onclick="showAlert()">Alert</button>
+<span id="alert-result"></span>
+
+<button id="confirm-button" onclick="showConfirm()">Confirm</button>
+<span id="confirm-result"></span>
+
+<button id="prompt-button" onclick="showPrompt()">Prompt</button>
+<span id="prompt-result"></span>
+</body>
+</html>

--- a/src/test/resources/testDataFiles/searchFixture.html
+++ b/src/test/resources/testDataFiles/searchFixture.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SHAFT Search Fixture</title>
+</head>
+<body>
+<label for="searchbox_input">Search</label>
+<input id="searchbox_input" name="q" type="search" aria-label="Search query">
+<article>SHAFT Engine documentation</article>
+</body>
+</html>


### PR DESCRIPTION
### Motivation

- Replace flaky external dependencies in UI tests and enable previously-disabled checks to improve reliability by using local test fixtures instead of remote sites.
- Provide a programmatic way to compute local file SHA-256 checksums to avoid hardcoding values that drift as files change.
- Enable/adjust unit tests to validate behavior previously skipped.

### Description

- Enabled several tests that were previously annotated `@Test(enabled = false)` and updated them to use local fixtures instead of external URLs, including `CoverageTests` alert tests and `TestClass` search tests.
- Added two test fixture HTML files: `src/test/resources/testDataFiles/alertFixture.html` and `src/test/resources/testDataFiles/searchFixture.html` and switched tests to navigate to `SHAFT.Properties.paths.testData()` paths for those fixtures.
- Reworked `ChecksumTests.readLocalFileChecksum` to compute the expected SHA-256 at runtime by adding `calculateSha256(Path)` and required imports (`Files`, `Path`, `MessageDigest`, `HexFormat`) and marked the test to throw `Exception`.
- Small test adjustments: removed external `Keys` usage from `TestClass`, updated title/assertion to `SHAFT Search Fixture`, and added DOM assertions after alert interactions in `CoverageTests`; also enabled `CucumberFeatureListenerUnitTest.examplesAsParametersShouldReturnEmptyWhenRowsNotMatching`.

### Testing

- Ran the modified test suite for the changed tests including `ChecksumTests.readLocalFileChecksum`, `CoverageTests` alert tests, `TestClass` tests, and the enabled `CucumberFeatureListenerUnitTest` case via the project's test runner; these tests completed successfully.
- No automated test failures were observed for the modified files after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe406bd668832082cfe8db5915c144)