### PR TITLE
Add Allure failure extractor and surface failed tests in post-test-report action

### DIFF
--- a/.github/actions/post-test-report/action.yml
+++ b/.github/actions/post-test-report/action.yml
@@ -139,6 +139,13 @@ runs:
             echo "::warning::No tests were executed. Check test configuration."
           fi
           if [ "$FAILED" -gt 0 ] || [ "$BROKEN" -gt 0 ]; then
+            if [ -d "allure-results" ] && command -v python3 >/dev/null 2>&1; then
+              {
+                echo ""
+                echo "### ❌ Failed and broken test methods"
+                python3 scripts/ci/extract_allure_failures.py allure-results || true
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
             echo "::error::Allure report shows $FAILED failed and $BROKEN broken test(s) out of $TOTAL total. Check the Allure report artifact for details."
             exit 1
           fi

--- a/docs/tickets/2026-05-08-actions-run-25572054507.md
+++ b/docs/tickets/2026-05-08-actions-run-25572054507.md
@@ -1,0 +1,50 @@
+# Investigate E2E test failures from GitHub Actions run 25572054507
+
+GitHub Actions run: <https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/25572054507>
+
+## Run details
+
+- Workflow: `E2E Tests`
+- Trigger: push on May 8, 2026 at 18:19 UTC
+- Branch: `main`
+- Commit: `e5c2da1`
+- Status: failure
+- Duration: 23m 51s
+- Artifacts: 11 Allure HTML artifacts were produced, including browser/grid/mobile/API/database reports.
+
+## Public findings
+
+Public GitHub Actions metadata shows these failing jobs:
+
+| Job | Result from public annotation |
+|---|---:|
+| `Ubuntu_Firefox_Grid` | 4 failed, 4 broken out of 1029 tests |
+| `Ubuntu_Chrome_Grid` | 4 failed, 4 broken out of 1030 tests |
+| `Ubuntu_MicrosoftEdge_Grid` | 4 failed, 4 broken out of 1032 tests |
+| `Android_Native_BrowserStack` | 2 failed, 0 broken out of 61 tests |
+| `MacOSX_Safari_BrowserStack` | 1 failed, 0 broken out of 36 tests |
+
+The failing jobs failed in the `Post-Test Report and Check` step after Allure summary enforcement detected failed or broken tests. Maven test execution was allowed to finish so coverage/reporting artifacts could still be generated.
+
+## Access limitation
+
+The exact failing test method names and stack traces are hidden behind authenticated GitHub Actions logs/artifacts. Public metadata exposes only aggregate Allure counts. An unauthenticated artifact ZIP request returned `401 Unauthorized`, and an unauthenticated job-log request returned `403 Forbidden`.
+
+## Implementation started
+
+This branch adds `scripts/ci/extract_allure_failures.py`, which parses Allure JSON result/report folders, JSON files, or ZIP archives and emits a Markdown or JSON list of every `failed` or `broken` test with the method name, failure reason, top stack-trace frame, and source JSON file.
+
+The `post-test-report` action now appends a `Failed and broken test methods` section to the GitHub job summary whenever Allure summary counts show failed or broken tests and raw `allure-results` are available. This makes future runs self-triaging without requiring a manual Allure HTML download just to identify failing methods.
+
+## Plan
+
+1. Download the five failing Allure artifacts from run `25572054507` with an authenticated GitHub session.
+2. Run `scripts/ci/extract_allure_failures.py` against the downloaded artifacts or raw `allure-results` folders.
+3. Group repeated grid failures across Chrome, Firefox, and Edge.
+4. Triage Android native BrowserStack failures separately.
+5. Triage the isolated macOS Safari BrowserStack failure separately.
+6. Fix shared grid failures first.
+7. Fix mobile/Safari-specific failures next.
+8. Rerun the affected CI jobs.
+9. Confirm Allure reports show `failed = 0` and `broken = 0`.
+10. Confirm JaCoCo coverage is still generated and uploaded.

--- a/scripts/ci/extract_allure_failures.py
+++ b/scripts/ci/extract_allure_failures.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Extract failed and broken test cases from Allure result/report artifacts.
+
+The script accepts one or more Allure result directories, generated report
+folders, JSON files, or ZIP archives. It prints a Markdown table by default so
+CI jobs and issue triage notes can include exact failing methods and reasons.
+"""
+
+import argparse
+import json
+import textwrap
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator
+
+FAILING_STATUSES = {"failed", "broken"}
+
+
+@dataclass(frozen=True)
+class AllureFailure:
+    source: str
+    status: str
+    method: str
+    reason: str
+    trace_top: str
+
+
+def _iter_json_payloads(path: Path) -> Iterator[tuple[str, dict]]:
+    if path.is_dir():
+        for json_path in sorted(path.rglob("*.json")):
+            yield from _iter_json_payloads(json_path)
+        return
+
+    if zipfile.is_zipfile(path):
+        with zipfile.ZipFile(path) as archive:
+            for member in sorted(archive.namelist()):
+                if member.endswith(".json"):
+                    try:
+                        yield member, json.loads(archive.read(member).decode("utf-8"))
+                    except (UnicodeDecodeError, json.JSONDecodeError):
+                        continue
+        return
+
+    if path.suffix == ".json":
+        try:
+            yield str(path), json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return
+
+
+def _clean_cell(value: str) -> str:
+    value = " ".join(str(value or "").split())
+    return value.replace("|", "\\|")
+
+
+def _first_trace_line(trace: str) -> str:
+    for line in str(trace or "").splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def _status_details(payload: dict) -> tuple[str, str]:
+    details = payload.get("statusDetails") or {}
+    message = details.get("message") or details.get("known") or ""
+    trace = details.get("trace") or ""
+    reason = str(message).strip() or _first_trace_line(trace) or "No failure message recorded"
+    return reason, _first_trace_line(trace)
+
+
+def _method_name(payload: dict) -> str:
+    labels = payload.get("labels") or []
+    label_map = {label.get("name"): label.get("value") for label in labels if isinstance(label, dict)}
+    package = label_map.get("package")
+    test_class = label_map.get("testClass") or label_map.get("suite")
+    method = label_map.get("testMethod")
+    if package and test_class and method and not str(test_class).startswith(str(package)):
+        return f"{package}.{test_class}.{method}"
+    if test_class and method:
+        return f"{test_class}.{method}"
+    return payload.get("fullName") or payload.get("name") or payload.get("uid") or payload.get("uuid") or "<unknown>"
+
+
+def extract_failures(paths: Iterable[Path]) -> list[AllureFailure]:
+    failures: list[AllureFailure] = []
+    seen: set[tuple[str, str, str, str]] = set()
+    for path in paths:
+        for source, payload in _iter_json_payloads(path):
+            status = str(payload.get("status") or "").lower()
+            if status not in FAILING_STATUSES:
+                continue
+            method = _method_name(payload)
+            reason, trace_top = _status_details(payload)
+            key = (source, status, method, reason)
+            if key in seen:
+                continue
+            seen.add(key)
+            failures.append(AllureFailure(source, status, method, reason, trace_top))
+    return failures
+
+
+def to_markdown(failures: list[AllureFailure]) -> str:
+    if not failures:
+        return "No failed or broken Allure test cases were found."
+
+    rows = [
+        "| Status | Test method | Failure reason | Top trace frame | Source |",
+        "|---|---|---|---|---|",
+    ]
+    for failure in failures:
+        rows.append(
+            "| {status} | `{method}` | {reason} | `{trace}` | `{source}` |".format(
+                status=_clean_cell(failure.status),
+                method=_clean_cell(failure.method),
+                reason=_clean_cell(failure.reason),
+                trace=_clean_cell(failure.trace_top or "n/a"),
+                source=_clean_cell(failure.source),
+            )
+        )
+    return "\n".join(rows)
+
+
+def to_json(failures: list[AllureFailure]) -> str:
+    return json.dumps([failure.__dict__ for failure in failures], indent=2, sort_keys=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Extract failed and broken test methods from Allure JSON artifacts.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent(
+            """
+            Examples:
+              scripts/ci/extract_allure_failures.py allure-results
+              scripts/ci/extract_allure_failures.py artifacts/*.zip --format json
+            """
+        ),
+    )
+    parser.add_argument("paths", nargs="+", type=Path, help="Allure result/report path, JSON file, or ZIP archive")
+    parser.add_argument("--format", choices=("markdown", "json"), default="markdown", help="Output format")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    failures = extract_failures(args.paths)
+    print(to_json(failures) if args.format == "json" else to_markdown(failures))
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_extract_allure_failures.py
+++ b/tests/scripts/test_extract_allure_failures.py
@@ -1,0 +1,72 @@
+import json
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from scripts.ci.extract_allure_failures import extract_failures, to_markdown
+
+
+class ExtractAllureFailuresTests(unittest.TestCase):
+    def test_extracts_failed_and_broken_results_from_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "passed-result.json").write_text(json.dumps({"status": "passed", "name": "passes"}), encoding="utf-8")
+            (root / "failed-result.json").write_text(
+                json.dumps(
+                    {
+                        "status": "failed",
+                        "name": "fallbackName",
+                        "labels": [
+                            {"name": "testClass", "value": "ExampleTest"},
+                            {"name": "testMethod", "value": "fails"},
+                        ],
+                        "statusDetails": {"message": "expected true but was false", "trace": "AssertionError\n at ExampleTest.fails"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (root / "broken-result.json").write_text(
+                json.dumps(
+                    {
+                        "status": "broken",
+                        "fullName": "pkg.ExampleTest.breaks",
+                        "statusDetails": {"trace": "RuntimeException: browser died\n at Driver.start"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            failures = extract_failures([root])
+
+        self.assertEqual([failure.status for failure in failures], ["broken", "failed"])
+        self.assertEqual(failures[0].method, "pkg.ExampleTest.breaks")
+        self.assertEqual(failures[0].reason, "RuntimeException: browser died")
+        self.assertEqual(failures[1].method, "ExampleTest.fails")
+        self.assertEqual(failures[1].reason, "expected true but was false")
+
+    def test_extracts_results_from_zip_archive_and_renders_markdown(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            archive_path = Path(temp_dir) / "allure.zip"
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr(
+                    "allure-results/test-result.json",
+                    json.dumps(
+                        {
+                            "status": "failed",
+                            "fullName": "pkg.ZipTest.fails",
+                            "statusDetails": {"message": "value | was invalid"},
+                        }
+                    ),
+                )
+
+            failures = extract_failures([archive_path])
+            markdown = to_markdown(failures)
+
+        self.assertIn("`pkg.ZipTest.fails`", markdown)
+        self.assertIn("value \\| was invalid", markdown)
+        self.assertIn("`allure-results/test-result.json`", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Make failing/broken test method names and top-stack frames visible in the GitHub job summary so triage can start without downloading authenticated Allure HTML artifacts.
- Capture and report raw Allure JSON details automatically when `Allure` counts show failures, improving CI self-triage for cross-browser/mobile runs.

### Description

- Add `scripts/ci/extract_allure_failures.py`, a small CLI that parses Allure JSON files, result directories, and ZIP archives and emits a deduplicated Markdown or JSON table of `failed`/`broken` tests with method, reason, top trace frame, and source.
- Update `.github/actions/post-test-report/action.yml` to append a `Failed and broken test methods` section to the GitHub step summary and run `python3 scripts/ci/extract_allure_failures.py allure-results` when `allure-results` exists and `python3` is available if Allure counts show failures/broken.
- Add unit tests `tests/scripts/test_extract_allure_failures.py` that validate directory and ZIP parsing, method name resolution, reason/trace extraction, and Markdown escaping.
- Add investigation notes `docs/tickets/2026-05-08-actions-run-25572054507.md` documenting the failing run details and planned triage steps.

### Testing

- Added unit tests in `tests/scripts/test_extract_allure_failures.py` and executed them with `python -m unittest tests/scripts/test_extract_allure_failures.py`, which passed.
- The CI `post-test-report` step was modified to only attempt running the extractor when `allure-results` exists and `python3` is on the PATH to avoid breaking environments without Python.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe521260a88320a22696ef227cd814)