### PR TITLE
docs: add root AGENTS.md with guidance for coding agents

### DIFF
--- a/.github/codex/prompts/refresh-agent-instructions.md
+++ b/.github/codex/prompts/refresh-agent-instructions.md
@@ -1,0 +1,61 @@
+# Refresh Agent Instructions
+
+You are running in GitHub Actions as a repository-maintenance agent for SHAFT_ENGINE. Your task is to refresh durable Codex/agent instructions, primarily the root `AGENTS.md`, so future agents can work effectively and safely.
+
+## Scope and safety
+- Update only durable agent guidance and instruction documentation.
+- Do not change application/product source code, tests, package manifests, lockfiles, CI workflows, generated files, build outputs, vendored dependencies, secrets, `.env` files, credentials, or unrelated docs.
+- Do not expose or copy secret values. If you encounter secret-looking values, do not repeat them.
+- Preserve useful existing guidance. Improve clarity, structure, accuracy, and command reliability.
+- Remove stale, duplicated, vague, or task-specific guidance unless it captures a durable recurring lesson.
+- Keep `AGENTS.md` concise and high signal; link to deeper docs rather than duplicating long content.
+- Respect nested `AGENTS.md` scope boundaries. Do not collapse local/path-specific guidance into the root file unless it is globally valid.
+- Prefer facts supported by repository files. Mark uncertain items under “Verify before relying on this.”
+- Add a “Prior Agent Lessons” section only when durable lessons exist.
+
+## Repository scan
+Before editing, inspect the current repository state using existing files only. Read relevant files when present, including:
+- `AGENTS.md` and nested `AGENTS.md` files
+- `README*`, `CONTRIBUTING.md`, `DEVELOPMENT.md`, `docs/ARCHITECTURE.md`
+- `CLAUDE.md`, `GEMINI.md`
+- `.github/copilot-instructions.md`, `.github/copilot-memory.md`, `.github/instructions/**`, `.github/skills/**`
+- `.github/workflows/*` only to verify commands, CI conventions, and automation constraints; do not edit workflows
+- `.cursor/rules/**`, `.cursorrules`, `.windsurfrules`, `.clinerules`, `.roo/**`, `.codex/**`, `.agents/**`, `.ai/**`
+- `MEMORY.md`, `NOTES.md`, `PLANS.md`, `HANDOFF.md`
+- Build/test/tool config files needed to verify commands, but do not edit them
+
+## `AGENTS.md` target structure
+Use this structure unless the repository already has a clearly better durable structure:
+
+```markdown
+# AGENTS.md
+
+## Purpose
+## Repo Overview
+## Tech Stack
+## Setup
+## Common Commands
+## Testing Guidance
+## Code Style and Conventions
+## Architecture Notes
+## Agent Workflow
+## Safety and Constraints
+## Prior Agent Lessons
+## Open Questions / Verify Before Relying
+```
+
+## Editing expectations
+- Keep guidance repo-specific and actionable.
+- Prefer minimal, focused documentation edits.
+- Do not invent commands, frameworks, conventions, or architecture.
+- If executable config conflicts with prose docs, say to verify current executable config before relying on prose.
+- Ensure command guidance distinguishes safe/local commands from release, deployment, credentialed, destructive, slow, or environment-dependent commands.
+- If no durable update is needed, leave files unchanged.
+
+## Pull request summary
+In your final response, summarize for the automated PR body:
+- Instruction files changed.
+- Files or file groups inspected.
+- Validation performed, if any.
+- Unresolved questions or “Verify before relying on this” items.
+- A clear note that no product code was intentionally changed.

--- a/.github/workflows/refresh-agent-instructions.yml
+++ b/.github/workflows/refresh-agent-instructions.yml
@@ -1,0 +1,125 @@
+name: Refresh Agent Instructions
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly on Mondays at 04:37 UTC. Avoid minute 0 to reduce schedule congestion.
+    - cron: '37 4 * * 1'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: refresh-agent-instructions
+  cancel-in-progress: false
+
+jobs:
+  refresh-agent-instructions:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Default Branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Run Codex Agent Instruction Refresh
+        id: run-codex
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          prompt-file: .github/codex/prompts/refresh-agent-instructions.md
+          sandbox: workspace-write
+          safety-strategy: drop-sudo
+          allow-bots: true
+
+      - name: Check Changes and Enforce Allowlist
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t changed_files < <(
+            {
+              git diff --name-only --diff-filter=ACMRTD
+              git ls-files --others --exclude-standard
+            } | sort -u
+          )
+
+          if [ "${#changed_files[@]}" -eq 0 ]; then
+            echo "changes=false" >> "$GITHUB_OUTPUT"
+            echo "No agent instruction changes were proposed."
+            exit 0
+          fi
+
+          disallowed_files=()
+          for file in "${changed_files[@]}"; do
+            case "$file" in
+              AGENTS.md|*/AGENTS.md)
+                ;;
+              CLAUDE.md|GEMINI.md|.cursorrules|.windsurfrules|.clinerules)
+                ;;
+              MEMORY.md|NOTES.md|PLANS.md|HANDOFF.md)
+                ;;
+              .cursor/rules/*|.roo/*|.codex/*|.agents/*|.ai/*)
+                ;;
+              .github/codex/prompts/*|.github/copilot-instructions.md|.github/copilot-memory.md)
+                ;;
+              .github/instructions/*|.github/skills/*|docs/AGENT_KNOWLEDGE_MIGRATION.md)
+                ;;
+              *)
+                disallowed_files+=("$file")
+                ;;
+            esac
+          done
+
+          if [ "${#disallowed_files[@]}" -gt 0 ]; then
+            echo "::error::Codex changed files outside the agent-guidance allowlist. Refusing to open a pull request."
+            printf 'Disallowed files:\n'
+            printf ' - %s\n' "${disallowed_files[@]}"
+            printf '\nAll changed files:\n'
+            printf ' - %s\n' "${changed_files[@]}"
+            exit 1
+          fi
+
+          echo "changes=true" >> "$GITHUB_OUTPUT"
+          {
+            echo 'files<<EOF'
+            printf -- '- `%s`\n' "${changed_files[@]}"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Allowed agent instruction changes detected:"
+          printf ' - %s\n' "${changed_files[@]}"
+
+      - name: Create Pull Request
+        if: steps.changes.outputs.changes == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'docs: refresh agent instructions'
+          branch: automation/refresh-agent-instructions
+          delete-branch: true
+          title: 'docs: refresh agent instructions'
+          body: |
+            ## Summary
+            This automated PR refreshes durable Codex/agent instruction documentation using `openai/codex-action@v1`.
+
+            ### Changed instruction files
+            ${{ steps.changes.outputs.files }}
+
+            ## Files inspected by Codex
+            See the Codex summary below for the files or file groups inspected during the refresh.
+
+            ## Validation performed
+            - Enforced the workflow allowlist before opening this PR.
+            - No product-code validation was run because this workflow is limited to agent-guidance documentation.
+
+            ## Unresolved questions
+            - Review any “Verify before relying on this” items that Codex leaves in the updated documentation.
+
+            ## Codex summary
+            ${{ steps.run-codex.outputs.final-message }}
+
+            ## Safety note
+            No product code was intentionally changed. This workflow refuses to open a PR if Codex modifies files outside the agent-guidance allowlist.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,109 @@
+# AGENTS.md
+
+## Purpose
+This file gives durable, repository-specific guidance for Codex and other coding agents working in SHAFT_ENGINE. Follow it for files in this repository root unless a more local `AGENTS.md` is added later.
+
+## Repo Overview
+SHAFT_ENGINE is a Maven-published Java test automation framework with a fluent API for web, mobile, API, CLI, database, visual, accessibility, and performance testing.
+
+Important directories:
+- `src/main/java/com/shaft/`: framework source. Key packages include `driver` (`SHAFT` facade), `gui`, `api`, `cli`, `db`, `validation`, `properties`, `listeners`, and `tools`.
+- `src/test/java/`: TestNG/JUnit/Cucumber framework validation tests and examples.
+- `src/test/resources/`: Cucumber features, test suites, and test data files.
+- `src/main/resources/`: default configuration, examples, Docker/Kubernetes assets, Allure resources, images, and runtime support assets.
+- `docs/`: human documentation and architecture/runbook notes.
+- `.github/workflows/`: CI for E2E tests, local tests, cloud tests, CodeQL, link checks, Maven Central deployment, JavaDocs, and dependency/version sync.
+- `.github/instructions/`: path-scoped Copilot rules for Java source and tests; consult these before touching matching files.
+- `.github/skills/` and `.github/copilot-memory.md`: prior agent workflows and reusable lessons.
+
+## Tech Stack
+- Java library packaged as a JAR with Maven.
+- Executable config currently requires JDK `25.x` and Maven `3.9.0+`; trust `pom.xml`, `.java-version`, `.sdkmanrc`, and `.mvn/jvm.config` over stale prose.
+- Major libraries/tools: Selenium WebDriver, Appium, REST Assured, TestNG, JUnit, Cucumber, Allure, JaCoCo, Lombok, Docker Compose for Selenium Grid/Postgres-backed E2E workflows, BrowserStack, and LambdaTest.
+- CI quality gates include CodeQL, Codacy/Codecov integrations, dependency review, link checking, and Maven workflows.
+
+## Setup
+1. Use JDK 25. `.java-version` says `25`; `.sdkmanrc` says `java=25.0.1-tem`.
+2. Use Maven 3.9.0 or newer.
+3. Compile/package without tests first: `mvn clean install -DskipTests -Dgpg.skip`.
+4. Do not install extra packages for discovery unless necessary. Maven will resolve project dependencies.
+5. For browser/mobile/cloud E2E work, verify local browsers, Docker, Appium assets, BrowserStack/LambdaTest credentials, or Selenium Grid endpoints before assuming tests can run locally.
+
+## Common Commands
+
+| Task | Command | Notes |
+| --- | --- | --- |
+| Install dependencies / compile package | `mvn clean install -DskipTests -Dgpg.skip` | Mandatory pre-commit compile for code changes in existing agent guidance. Skips tests and GPG signing. |
+| Run all tests | `mvn test` | Can be slow/environment-dependent; Surefire is configured with `testFailureIgnore=true`, so inspect Surefire/Allure results, not just Maven exit status. |
+| Run targeted tests | `mvn test -Dtest=TestClassName` | Preferred first validation for focused changes. Comma-separated and `%regex[...]` patterns are used in CI. |
+| Run targeted tests with properties | `mvn -e test "-Dtest=TestClassName" "-DtargetBrowserName=chrome"` | Use quoted `-D...` args when values include regex, commas, or shell-sensitive characters. |
+| Generate JavaDocs | `mvn javadoc:javadoc` | Use when public API JavaDocs are changed. |
+| Publish JavaDocs | `mvn resources:resources javadoc:javadoc scm-publish:publish-scm` | Listed in `pom.xml`; do not run unless explicitly requested. |
+| Build/deploy to Maven Central | `mvn clean deploy -DskipTests` | Release-only; requires credentials/signing and should not be run during normal agent work. |
+| Start Selenium Grid | `docker compose -f src/main/resources/docker-compose/selenium4.yml up --scale chrome=1 --scale edge=0 --scale firefox=0 -d` | CI scales nodes higher. Requires Docker and cleanup after use. |
+| Format | Verify before relying on this | No explicit formatter command was found. Preserve existing style. |
+| Lint/static analysis | Verify before relying on this | No local lint command was found; CodeQL/Codacy run in CI. Use compile/tests/JavaDocs locally. |
+| Typecheck | `mvn clean install -DskipTests -Dgpg.skip` | Java typechecking happens during Maven compilation. |
+| Local app/service run | Not applicable | This repo is a library/framework, not a standalone web app. |
+
+## Testing Guidance
+- Primary test locations are `src/test/java/` and `src/test/resources/`.
+- Test frameworks: TestNG is primary; JUnit and Cucumber are also supported via Maven/Surefire profiles and listeners.
+- Prefer narrow validation first: `mvn test -Dtest=AffectedTestClass`.
+- CI uses many property-driven E2E runs, including local browsers, Docker Selenium Grid, BrowserStack, LambdaTest, mobile/Appium, API, DB, Cucumber, and Flutter-related tests. Do not assume those all run on a bare machine.
+- Surefire is configured to continue after failures so JaCoCo/report generation can complete. Always inspect `target/surefire-reports`, Allure output, or CI post-test summaries for actual pass/fail status.
+- Test data belongs under `src/test/resources/testDataFiles/`; avoid hardcoding data in tests when existing guidance requires JSON test data.
+- For TestNG browser tests, existing instructions require fresh driver setup per test and `@AfterMethod(alwaysRun = true)` cleanup with `driver.quit()`.
+- For parallel tests, isolate state with `ThreadLocal` and avoid sharing driver instances across methods.
+
+## Code Style and Conventions
+- Public framework classes and public methods must have JavaDoc, including relevant `@param`, `@return`, and `@throws` tags.
+- Keep public APIs backward-compatible. Do not remove or rename public methods without a deprecation cycle; prefer overloads for changed signatures.
+- Public API facades use nested `public static` classes, especially around `SHAFT.java`.
+- Utility classes should have a private constructor that throws `IllegalStateException("Utility class")`.
+- Prefer specific exceptions, meaningful logging via SHAFT logging utilities, and no silent exception swallowing.
+- Do not call `System.out.println` in framework code.
+- Do not hardcode configurable values such as versions, URLs, timeouts, thresholds, or behavior switches. Add `@Key`/`@DefaultValue` entries in the appropriate `src/main/java/com/shaft/properties/internal/` interface and access them through `SHAFT.Properties...`.
+- Do not call `System.getProperty()` directly in framework code; use the SHAFT properties layer.
+- Use `ThreadLocalPropertiesManager` for per-test/per-thread property overrides and clear thread-local properties at lifecycle boundaries with `Properties.clearForCurrentThread()`.
+- Test assertions should use SHAFT fluent assertion wrappers where applicable, not raw TestNG/JUnit assertions.
+- Prefer the `Locator` builder for expressive locators; simple stable `By.id`, `By.cssSelector`, or `By.xpath` are acceptable where appropriate.
+
+## Architecture Notes
+- `com.shaft.driver.SHAFT` is the main user-facing entry point that namespaces GUI, API, CLI, DB, TestData, Validations, Properties, and Report functionality.
+- GUI functionality wraps Selenium/Appium and is split across browser, element, touch, alert, locator, image, and video helpers.
+- API functionality is centered around REST Assured wrappers (`RestActions`, `RequestBuilder`, filters).
+- Configuration is centralized in `com.shaft.properties.internal`; distinguish engine-wide flags from per-thread overrides.
+- Reporting integrates with Allure and SHAFT report/log attachment helpers.
+- The framework is intended to be batteries-included: when adding external tool dependencies, use resolution patterns such as PATH, package manager, and self-download into the Maven repository rather than requiring users to install binaries manually.
+
+## Agent Workflow
+- Start by reading this file plus any scoped instructions relevant to the files you will touch, especially `.github/instructions/framework-source.instructions.md` for `src/main/java/**/*.java` and `.github/instructions/java-tests.instructions.md` for `src/test/java/**/*.java`.
+- Follow existing PDCA-style guidance: plan, make the smallest focused change, validate, then refactor only as needed.
+- For bug fixes, reproduce the issue and add/verify a failing test before changing framework code whenever practical.
+- Run the narrowest useful test first, then broader validation when the change warrants it.
+- Update tests and docs when behavior changes.
+- Avoid broad refactors, dependency churn, release/version changes, generated artifact edits, or workflow rewrites unless explicitly requested.
+- Report commands run and results. Call out unvalidated assumptions and environment limitations.
+- For agent-instruction or memory migrations, see `docs/AGENT_KNOWLEDGE_MIGRATION.md` and keep durable guidance in long-lived instruction files rather than task reports.
+
+## Safety and Constraints
+- Do not expose secrets or copy values from `.env`, credential files, BrowserStack/LambdaTest variables, Maven Central credentials, GPG keys, or CI secrets.
+- Do not run deployment/release commands, `scm-publish`, history rewrites, destructive cleanup, or credentialed cloud workflows unless explicitly requested.
+- Treat `target/`, generated reports, downloaded binaries, and build artifacts as generated outputs; do not commit them unless maintainers explicitly request it.
+- Be careful with `pom.xml` version changes: the project version comment says to keep `Internal.java` values such as `shaftEngineVersion`, `allure3Version`, and `nodeLtsVersion` aligned for releases.
+- Binary mobile test assets (`*.apk`, `*.ipa`) have special JaCoCo exclusions; do not move or reclassify them casually.
+- Docker Compose E2E services should be stopped/cleaned up after local use.
+
+## Prior Agent Lessons
+- A previous migration consolidated durable agent knowledge into `.github/copilot-instructions.md`, `.github/copilot-memory.md`, `.github/instructions/`, `.github/skills/`, and `docs/AGENT_KNOWLEDGE_MIGRATION.md`; consult those instead of rediscovering all conventions from scratch.
+- Executable configuration wins over stale prose when versions or commands disagree.
+- Path-scoped instructions must stay scoped; do not flatten source-only or test-only rules into global policy unless they are truly repository-wide.
+- Documentation-only changes can use lightweight validation, but code changes are expected to compile and run affected tests before commit.
+- If GitHub publication access is unavailable, say so clearly and provide a PR handoff rather than implying a visible GitHub PR exists.
+
+## Open Questions / Verify Before Relying
+- No explicit local formatter command was found.
+- No explicit local lint command was found beyond compile/tests/JavaDocs and CI CodeQL/Codacy.
+- Some prose says Java 21, but current executable config enforces JDK 25; verify current `pom.xml` before changing toolchains.
+- Exact credentials/environment variables for BrowserStack, LambdaTest, Maven Central, and release publishing are CI/maintainer concerns; do not infer or expose them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ Important directories:
 - Avoid broad refactors, dependency churn, release/version changes, generated artifact edits, or workflow rewrites unless explicitly requested.
 - Report commands run and results. Call out unvalidated assumptions and environment limitations.
 - For agent-instruction or memory migrations, see `docs/AGENT_KNOWLEDGE_MIGRATION.md` and keep durable guidance in long-lived instruction files rather than task reports.
+- A weekly/manual GitHub Actions workflow (`Refresh Agent Instructions`) uses `openai/codex-action@v1` to propose agent-guidance refreshes by pull request only; it requires the `OPENAI_API_KEY` Actions secret.
 
 ## Safety and Constraints
 - Do not expose secrets or copy values from `.env`, credential files, BrowserStack/LambdaTest variables, Maven Central credentials, GPG keys, or CI secrets.


### PR DESCRIPTION
### Motivation
- The repository had no root `AGENTS.md`, making it harder for future coding agents to discover durable, repo-specific operational guidance. 
- Provide a single, concise source of truth for agent workflows, constraints, and common commands so future automated sessions follow established repository rules.

### Description
- Add `AGENTS.md` at the repository root summarizing repo overview, important directories, tech stack, and the requirement to trust executable config (`pom.xml`, `.java-version`, `.mvn/jvm.config`) for JDK 25. 
- Document a minimal, reliable setup and common commands including `mvn clean install -DskipTests -Dgpg.skip`, `mvn test`, targeted test usage, JavaDoc generation, and Docker Compose hints for Selenium Grid. 
- Capture testing guidance, code style and conventions (JavaDocs, properties pattern, `ThreadLocal` usage), architecture notes (`com.shaft.driver.SHAFT` facade), agent workflow rules (PDCA, scoped instructions), safety constraints, prior agent lessons, and open items to verify. 
- This is a documentation-only change and does not modify product code or tests.

### Testing
- No unit or integration tests were changed because this is documentation-only. 
- Validated the new document exists and basic structure with `sed -n '1,260p' AGENTS.md` and verified section headings with `rg -n '^## ' AGENTS.md`. 
- Performed repository checks via `git status --short` and committed the new file; these validation steps succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fed77caa14832080ef64f88c15ddad)