### PR TITLE
Add class coverage metric to readiness gate

### DIFF
--- a/.github/workflows/coverage-readiness.yml
+++ b/.github/workflows/coverage-readiness.yml
@@ -16,6 +16,7 @@ on:
           - branch
           - instruction
           - method
+          - class
         default: line
       coverage-minimum:
         description: 'Minimum coverage percentage for the selected metric'

--- a/scripts/ci/jacoco_coverage_gate.py
+++ b/scripts/ci/jacoco_coverage_gate.py
@@ -7,7 +7,8 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
-METRICS = ("INSTRUCTION", "BRANCH", "LINE", "METHOD")
+COUNTER_METRICS = ("INSTRUCTION", "BRANCH", "LINE", "METHOD")
+METRICS = (*COUNTER_METRICS, "CLASS")
 
 
 @dataclass(frozen=True)
@@ -35,12 +36,15 @@ def load_metrics(csv_path: Path) -> list[CoverageMetric]:
         rows = list(csv.DictReader(report))
 
     metrics: list[CoverageMetric] = []
-    for metric in METRICS:
+    for metric in COUNTER_METRICS:
         missed_column = f"{metric}_MISSED"
         covered_column = f"{metric}_COVERED"
         missed = sum(int(row[missed_column]) for row in rows)
         covered = sum(int(row[covered_column]) for row in rows)
         metrics.append(CoverageMetric(metric.lower(), missed, covered))
+
+    covered_classes = sum(1 for row in rows if int(row["METHOD_COVERED"]) > 0)
+    metrics.append(CoverageMetric("class", len(rows) - covered_classes, covered_classes))
     return metrics
 
 

--- a/tests/scripts/test_jacoco_coverage_gate.py
+++ b/tests/scripts/test_jacoco_coverage_gate.py
@@ -22,6 +22,8 @@ class JacocoCoverageGateTests(unittest.TestCase):
         self.assertEqual(metrics["instruction"].total, 20)
         self.assertEqual(metrics["line"].missed, 5)
         self.assertAlmostEqual(metrics["line"].percent, 75.0)
+        self.assertEqual(metrics["class"].covered, 2)
+        self.assertEqual(metrics["class"].total, 2)
 
     def test_renders_markdown_with_gate_marker(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -35,6 +37,24 @@ class JacocoCoverageGateTests(unittest.TestCase):
             markdown = to_markdown(load_metrics(report), "line", 80.0)
 
         self.assertIn("| line | 10 | 10 | 100.00% | minimum 80.00% |", markdown)
+
+
+class JacocoCoverageClassMetricTests(unittest.TestCase):
+    def test_marks_classes_without_covered_methods_as_missed(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report = Path(temp_dir) / "jacoco.csv"
+            report.write_text(
+                "GROUP,PACKAGE,CLASS,INSTRUCTION_MISSED,INSTRUCTION_COVERED,BRANCH_MISSED,BRANCH_COVERED,LINE_MISSED,LINE_COVERED,COMPLEXITY_MISSED,COMPLEXITY_COVERED,METHOD_MISSED,METHOD_COVERED\n"
+                "bundle,pkg,Covered,1,9,0,0,1,9,0,0,1,1\n"
+                "bundle,pkg,Missed,10,0,0,0,5,0,0,0,2,0\n",
+                encoding="utf-8",
+            )
+
+            metrics = {metric.name: metric for metric in load_metrics(report)}
+
+        self.assertEqual(metrics["class"].missed, 1)
+        self.assertEqual(metrics["class"].covered, 1)
+        self.assertAlmostEqual(metrics["class"].percent, 50.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Provide a class-level JaCoCo coverage metric so the coverage-readiness helper can report or gate on class coverage in addition to line/branch/instruction/method metrics.
- Make it possible to run focused readiness checks for class coverage from the `coverage-readiness` workflow without ad-hoc local inspection.

### Description
- Compute a derived `class` metric in `scripts/ci/jacoco_coverage_gate.py` by treating a JaCoCo CSV row as a covered class when `METHOD_COVERED > 0`, and expose it alongside the existing counters. (`scripts/ci/jacoco_coverage_gate.py`)
- Add `class` as a `coverage-metric` option in the `coverage-readiness` workflow dispatch inputs so maintainers can select `class` when running the workflow. (`.github/workflows/coverage-readiness.yml`)
- Add and update unit tests that assert the new `class` metric behaviour and that classes with zero covered methods count as missed. (`tests/scripts/test_jacoco_coverage_gate.py`)

### Testing
- Ran the targeted unit tests with `python -m unittest tests/scripts/test_jacoco_coverage_gate.py` and they passed. (OK)
- Ran the full script test suite with `python -m unittest discover -s tests/scripts -p 'test_*.py'` and all tests passed. (OK)
- Executed the CLI helper against a synthetic `jacoco.csv` using `scripts/ci/jacoco_coverage_gate.py "$tmp/jacoco.csv" --metric class --minimum 80` and confirmed the markdown summary includes the `class` metric and gate line. (OK)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff2668369c8320a3764109eb97d694)