### PR TITLE
Stabilize API/unit CI artifacts, add local API fixture, harden Allure extractor, and guard heavy E2E tests

### DIFF
--- a/scripts/ci/extract_allure_failures.py
+++ b/scripts/ci/extract_allure_failures.py
@@ -12,7 +12,7 @@ import textwrap
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Iterator
+from typing import Any, Iterable, Iterator
 
 FAILING_STATUSES = {"failed", "broken"}
 
@@ -26,7 +26,7 @@ class AllureFailure:
     trace_top: str
 
 
-def _iter_json_payloads(path: Path) -> Iterator[tuple[str, dict]]:
+def _iter_json_payloads(path: Path) -> Iterator[tuple[str, dict[str, Any]]]:
     if path.is_dir():
         for json_path in sorted(path.rglob("*.json")):
             yield from _iter_json_payloads(json_path)
@@ -37,14 +37,18 @@ def _iter_json_payloads(path: Path) -> Iterator[tuple[str, dict]]:
             for member in sorted(archive.namelist()):
                 if member.endswith(".json"):
                     try:
-                        yield member, json.loads(archive.read(member).decode("utf-8"))
+                        payload = json.loads(archive.read(member).decode("utf-8"))
                     except (UnicodeDecodeError, json.JSONDecodeError):
                         continue
+                    if isinstance(payload, dict):
+                        yield member, payload
         return
 
     if path.suffix == ".json":
         try:
-            yield str(path), json.loads(path.read_text(encoding="utf-8"))
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(payload, dict):
+                yield str(path), payload
         except json.JSONDecodeError:
             return
 

--- a/src/test/java/testPackage/appium/FlutterTest.java
+++ b/src/test/java/testPackage/appium/FlutterTest.java
@@ -8,6 +8,7 @@ import io.github.ashwith.flutter.FlutterFinder;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -20,6 +21,7 @@ import org.testng.annotations.Test;
  * with Flutter widgets.
  */
 public class FlutterTest {
+    private static final String ENABLE_FLUTTER_E2E_PROPERTY = "shaft.enableFlutterE2E";
     public static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
     private FlutterFinder finder;
 
@@ -29,6 +31,10 @@ public class FlutterTest {
      */
     @BeforeMethod(onlyForGroups = {"flutter"})
     public void setupFlutterDriver() {
+        if (!Boolean.getBoolean(ENABLE_FLUTTER_E2E_PROPERTY)) {
+            throw new SkipException("Flutter BrowserStack E2E is disabled. Set -D"
+                    + ENABLE_FLUTTER_E2E_PROPERTY + "=true after validating the Flutter driver/app on the target cloud.");
+        }
         // Common mobile attributes
         SHAFT.Properties.platform.set().targetPlatform(Platform.ANDROID.name());
         // Set automation name to FlutterIntegration - this automatically enables Flutter driver

--- a/src/test/java/testPackage/appium/IOSBasicInteractionsTest.java
+++ b/src/test/java/testPackage/appium/IOSBasicInteractionsTest.java
@@ -6,11 +6,13 @@ import com.shaft.properties.internal.Properties;
 import com.shaft.validation.Validations;
 import io.appium.java_client.AppiumBy;
 import org.openqa.selenium.Platform;
+import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class IOSBasicInteractionsTest {
+    private static final String ENABLE_NATIVE_IOS_E2E_PROPERTY = "shaft.enableNativeIosE2E";
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
 
     @Test
@@ -27,6 +29,10 @@ public class IOSBasicInteractionsTest {
     @SuppressWarnings("CommentedOutCode")
     @BeforeMethod
     public void setup() {
+        if (!Boolean.getBoolean(ENABLE_NATIVE_IOS_E2E_PROPERTY)) {
+            throw new SkipException("Native iOS BrowserStack E2E is disabled for the web Safari matrix. Set -D"
+                    + ENABLE_NATIVE_IOS_E2E_PROPERTY + "=true in a native iOS job after validating the app upload.");
+        }
         // common attributes
         SHAFT.Properties.platform.set().targetPlatform(Platform.IOS.toString());
         SHAFT.Properties.mobile.set().automationName("XCUITest");

--- a/src/test/java/testPackage/unitTests/Allure3ReportValidationTests.java
+++ b/src/test/java/testPackage/unitTests/Allure3ReportValidationTests.java
@@ -24,12 +24,13 @@ import java.io.ByteArrayOutputStream;
  * be excluded from CI using {@code -Dgroups=!allure3-visual-demo}.  To run <em>all four</em> tests
  * (for local visual validation of the Allure 3 report), execute:
  * <pre>
- *   mvn test -Dtest=Allure3ReportValidationTests -DgenerateAllureReportArchive=true
+ *   mvn test -Dtest=Allure3ReportValidationTests -Dshaft.enableAllure3VisualDemo=true -DgenerateAllureReportArchive=true
  * </pre>
  */
 @Epic("Allure 3 Migration")
 @Feature("Report Validation")
 public class Allure3ReportValidationTests {
+    private static final String ENABLE_VISUAL_DEMO_PROPERTY = "shaft.enableAllure3VisualDemo";
 
     /**
      * PASSED — verifies that basic Java arithmetic works and attaches a
@@ -60,6 +61,7 @@ public class Allure3ReportValidationTests {
     @Story("FAILED result")
     @Severity(SeverityLevel.NORMAL)
     public void testFails() {
+        skipUnlessVisualDemoIsEnabled();
         Allure.step("Assert that 1 equals 2 (this step will fail)", () ->
                 SHAFT.Validations.assertThat().number(1).isEqualTo(2).perform());
     }
@@ -86,10 +88,21 @@ public class Allure3ReportValidationTests {
     @Story("BROKEN result")
     @Severity(SeverityLevel.MINOR)
     public void testIsBroken() {
+        skipUnlessVisualDemoIsEnabled();
         throw new RuntimeException("Intentional broken state for Allure 3 visual validation");
     }
 
     // ─── helpers ─────────────────────────────────────────────────────────────
+
+    /**
+     * Keeps the intentional failed/broken Allure visual-demo scenarios out of CI unless explicitly requested.
+     */
+    private static void skipUnlessVisualDemoIsEnabled() {
+        if (!Boolean.getBoolean(ENABLE_VISUAL_DEMO_PROPERTY)) {
+            throw new SkipException("Intentional Allure visual-demo failure is disabled. Set -D"
+                    + ENABLE_VISUAL_DEMO_PROPERTY + "=true to generate FAILED/BROKEN demo results.");
+        }
+    }
 
     /**
      * Generates a simple 400×100 PNG image as a byte array for use as an Allure attachment.

--- a/tests/scripts/test_extract_allure_failures.py
+++ b/tests/scripts/test_extract_allure_failures.py
@@ -67,6 +67,20 @@ class ExtractAllureFailuresTests(unittest.TestCase):
         self.assertIn("value \\| was invalid", markdown)
         self.assertIn("`allure-results/test-result.json`", markdown)
 
+    def test_ignores_non_result_json_payloads(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "array-attachment.json").write_text(json.dumps([{"id": 1}]), encoding="utf-8")
+            (root / "object-attachment.json").write_text(json.dumps({"id": 1}), encoding="utf-8")
+            archive_path = root / "allure.zip"
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr("allure-results/array-attachment.json", json.dumps([{"id": 1}]))
+                archive.writestr("allure-results/failed-result.json", json.dumps({"status": "failed", "name": "real failure"}))
+
+            failures = extract_failures([root, archive_path])
+
+        self.assertEqual([failure.method for failure in failures], ["real failure"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation

- Make API tests deterministic in CI by isolating network-dependent tests and avoid noisy failures from external services. 
- Improve post-test triage by fixing the Allure failure extractor to handle non-dict JSON payloads and archive inputs. 
- Prevent heavy/cloud mobile/visual demo tests from running by default in the main CI matrix to avoid spurious failures and resource usage. 

### Description

- Added a lightweight local HTTP fixture `src/test/java/com/shaft/api/LocalApiTestServer.java` and updated API tests `PathParamTest` and `SwaggerContractTest` to use the local server and to clear thread-local properties during teardown. 
- Hard-gated visual/demo and cloud mobile tests behind boolean properties by adding skip guards: `shaft.enableAllure3VisualDemo`, `shaft.enableFlutterE2E`, and `shaft.enableNativeIosE2E`, and updated `Allure3ReportValidationTests`, `FlutterTest`, and `IOSBasicInteractionsTest` to throw `SkipException` when not enabled. 
- Fixed `scripts/ci/extract_allure_failures.py` to ignore non-object JSON payloads (arrays/attachments) when scanning Allure artifacts and adjusted typing/robustness for zipped JSON entries. 
- Added/updated tests for the extractor (`tests/scripts/test_extract_allure_failures.py`) and small test changes to ensure CI workflows select the right test classes (workflow selector adjustments were included in related changes). 

### Testing

- Ran the script unit tests: `python3 -m unittest tests/scripts/test_extract_allure_failures.py` and `tests/scripts/test_e2e_test_inventory.py`, both completed OK. 
- Ran targeted API tests: `mvn -Dtest=PathParamTest,SwaggerContractTest test` and verified all tests in that selector passed (Exit 0). 
- Exercised the gated visual/mobile tests: `mvn -Dtest=Allure3ReportValidationTests,FlutterTest,IOSBasicInteractionsTest test` and observed 1 passed + 6 skipped (skips are intentional by default), no failures. 
- Verified build compiles and packages: `mvn clean install -DskipTests -Dgpg.skip` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff49320af083209f92d44801e0b56a)