### PR TITLE
Add GitHub auth normalization script and document GH_TOKEN usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,11 @@ Important directories:
 - Reporting integrates with Allure and SHAFT report/log attachment helpers.
 - The framework is intended to be batteries-included: when adding external tool dependencies, use resolution patterns such as PATH, package manager, and self-download into the Maven repository rather than requiring users to install binaries manually.
 
+## GitHub API and CLI Authentication
+- Before using GitHub APIs, Actions artifacts/logs, or `gh`, normalize the token environment with `source scripts/ci/github-auth-env.sh`. This maps `GITHUB_TOKEN` to `GH_TOKEN` and `GH_TOKEN` to `GITHUB_TOKEN` without printing secret values.
+- If `gh` is missing and GitHub access is needed, install it in the current environment, then run `GH_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}" gh auth status -h github.com` to verify authentication without exposing the token.
+- Prefer authenticated `gh` commands for GitHub Actions artifacts, logs, issues, and PRs; anonymous REST calls can list some public metadata but cannot reliably download artifacts, read logs, or create issues.
+
 ## Agent Workflow
 - Start by reading this file plus any scoped instructions relevant to the files you will touch, especially `.github/instructions/framework-source.instructions.md` for `src/main/java/**/*.java` and `.github/instructions/java-tests.instructions.md` for `src/test/java/**/*.java`.
 - Follow existing PDCA-style guidance: plan, make the smallest focused change, validate, then refactor only as needed.

--- a/scripts/ci/github-auth-env.sh
+++ b/scripts/ci/github-auth-env.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Normalize GitHub authentication environment variables for local agents and CI.
+#
+# Source this file before using `gh`, `curl`, or other GitHub API clients:
+#   source scripts/ci/github-auth-env.sh
+#
+# GitHub CLI prefers GH_TOKEN, while many CI/agent environments expose
+# GITHUB_TOKEN. Keep both names populated when either one is already available.
+# This script never prints token values.
+
+if [ -z "${GH_TOKEN:-}" ] && [ -n "${GITHUB_TOKEN:-}" ]; then
+  export GH_TOKEN="${GITHUB_TOKEN}"
+fi
+
+if [ -z "${GITHUB_TOKEN:-}" ] && [ -n "${GH_TOKEN:-}" ]; then
+  export GITHUB_TOKEN="${GH_TOKEN}"
+fi
+
+# Make gh fail fast in non-interactive environments instead of prompting for
+# browser/device authentication when no usable token is present.
+export GH_PROMPT_DISABLED="${GH_PROMPT_DISABLED:-1}"


### PR DESCRIPTION
### Motivation
- Ensure CI/agent workflows and local shells have consistent GitHub authentication by mapping `GITHUB_TOKEN` and `GH_TOKEN` transparently. 
- Prevent interactive `gh` authentication prompts in non-interactive CI/agent environments by disabling prompting by default. 
- Provide guidance for agents on how to authenticate when working with GitHub APIs, Actions artifacts, and the `gh` CLI. 

### Description
- Added `scripts/ci/github-auth-env.sh`, a small shell script that sets `GH_TOKEN` from `GITHUB_TOKEN` and vice versa when one is present and disables `gh` prompts via `GH_PROMPT_DISABLED=1`. 
- Updated `AGENTS.md` to include a new "GitHub API and CLI Authentication" section documenting how and why to source `scripts/ci/github-auth-env.sh` and recommending authenticated `gh` usage for artifacts/logs/PRs. 
- The script file is added as an executable (`100755`) to be sourceable in shells and CI jobs. 

### Testing
- No automated tests were run for this documentation and small utility script change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff6fa4fcf08320815d9ac6bd432c41)