### PR TITLE
Stabilize DriverFactoryHelper close-driver test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ Important directories:
 - Test data belongs under `src/test/resources/testDataFiles/`; avoid hardcoding data in tests when existing guidance requires JSON test data.
 - For TestNG browser tests, existing instructions require fresh driver setup per test and `@AfterMethod(alwaysRun = true)` cleanup with `driver.quit()`.
 - For parallel tests, isolate state with `ThreadLocal` and avoid sharing driver instances across methods.
+- `@Test(singleThreaded = true)` serializes methods inside one TestNG class only; it does not isolate static SHAFT property setters from other classes in a parallel suite. Tests that assert behavior depending on global properties such as `executionAddress` must set those prerequisites inside the test (and rely on `@AfterMethod(alwaysRun = true)` cleanup) to avoid E2E flakes from cross-class property mutation.
 
 ## Code Style and Conventions
 - Public framework classes and public methods must have JavaDoc, including relevant `@param`, `@return`, and `@throws` tags.

--- a/src/test/java/testPackage/unitTests/DriverFactoryHelperAdditionalUnitTest.java
+++ b/src/test/java/testPackage/unitTests/DriverFactoryHelperAdditionalUnitTest.java
@@ -134,6 +134,7 @@ public class DriverFactoryHelperAdditionalUnitTest {
 
     @Test
     public void closeDriverShouldHandleNullAndDriverExceptions() {
+        SHAFT.Properties.platform.set().executionAddress("local");
         DriverFactoryHelper helper = new DriverFactoryHelper();
         helper.closeDriver(null);
 


### PR DESCRIPTION
## Summary
- Fixes #2660 by forcing the driver-close exception test onto the local close/quit branch before verifying mock `close()` and `quit()` calls.
- Documents the E2E stabilization lesson that TestNG `singleThreaded` does not isolate static SHAFT property setters from other classes in a parallel suite.

## Root cause
The E2E Allure artifact showed `closeDriverShouldHandleNullAndDriverExceptions` failing because `executionAddress` was `dockerized`, so `DriverFactoryHelper.closeDriver(WebDriver)` took the dockerized cleanup path and never called the mocked driver's `close()`/`quit()` methods. This can happen when another parallel test class mutates the static SHAFT platform properties.

## Testing
- `mvn test -Dtest=DriverFactoryHelperAdditionalUnitTest#closeDriverShouldHandleNullAndDriverExceptions -Dgpg.skip`
- `mvn test -Dtest=DriverFactoryHelperAdditionalUnitTest -Dgpg.skip`
- `mvn test -Dtest=DriverFactoryHelperAdditionalUnitTest#closeDriverShouldHandleNullAndDriverExceptions -DexecutionAddress=dockerized -Dgpg.skip`
- `mvn clean install -DskipTests -Dgpg.skip`
