### PR TITLE
Fix ElementActions coverage test session isolation

### DIFF
--- a/.github/copilot-memory.md
+++ b/.github/copilot-memory.md
@@ -24,3 +24,10 @@ Purpose: keep high-signal, reusable learnings from implementation sessions in on
 - Lesson: Use `docs/AGENT_KNOWLEDGE_MIGRATION.md` for future migration tasks: create or link a ticket, branch before editing, progressively scan instruction/memory/skill files, favor executable configuration over stale prose, update the memory ledger, commit, and open a PR; if GitHub publication access is missing, explicitly report the limitation and provide a PR handoff.
 - Evidence: `docs/AGENT_KNOWLEDGE_MIGRATION.md`, `docs/tickets/2026-05-08-agent-knowledge-migration.md`, `.github/copilot-instructions.md`, `CLAUDE.md`
 - Action taken: Added a migration runbook, local ticket, global instruction reference, Claude guidance, and this memory entry.
+
+- Date: 2026-05-09
+- Area: WebDriver lifecycle / coverage tests
+- Trigger: Grid E2E failures in `ElementActionsCoverageUnitTest.shouldCoverBasicFluentAndActionWrappers`.
+- Lesson: Coverage-only unit tests must not call GUI facade default constructors such as `ElementActions::new`; those constructors create real browser sessions through the driver factory and can produce Selenium Grid failures even when the test otherwise uses mocks. Prefer explicit mock-driver constructors for unit coverage and keep all driver-factory/session paths in focused integration tests.
+- Evidence: `src/test/java/testPackage/unitTests/ElementActionsCoverageUnitTest.java`
+- Action taken: Removed the default-constructor coverage invocation so the test remains fully mock-backed and session-isolated.

--- a/src/test/java/testPackage/unitTests/ElementActionsCoverageUnitTest.java
+++ b/src/test/java/testPackage/unitTests/ElementActionsCoverageUnitTest.java
@@ -83,7 +83,6 @@ public class ElementActionsCoverageUnitTest {
     public void shouldCoverBasicFluentAndActionWrappers() {
         By locator = By.id("sample");
 
-        invokeAndIgnoreFailures(ElementActions::new);
         Assert.assertNotNull(elementActions.and());
         Assert.assertNotNull(elementActions.assertThat(locator));
         Assert.assertNotNull(elementActions.verifyThat(locator));


### PR DESCRIPTION
### Motivation
- Prevent a coverage-only invocation from creating a real browser session in `ElementActionsCoverageUnitTest.shouldCoverBasicFluentAndActionWrappers`, which was causing Selenium Grid E2E failures by leaking real driver/session creation into a mock-backed unit test.

### Description
- Removed the coverage-only `invokeAndIgnoreFailures(ElementActions::new)` call from `shouldCoverBasicFluentAndActionWrappers` and added a Copilot memory entry documenting that mock-backed GUI coverage tests must avoid facade default constructors that reach the driver factory.

### Testing
- Ran `mvn -q test -Dtest=ElementActionsCoverageUnitTest#shouldCoverBasicFluentAndActionWrappers` and it passed. 
- Ran `mvn -q test -Dtest=ElementActionsCoverageUnitTest` and the class passed all tests. 
- Verified `mvn clean install -DskipTests -Dgpg.skip` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff82a86ef083208a4626228c2a25bc)