### PR TITLE
Fix custom properties template defaults test

### DIFF
--- a/src/test/java/testPackage/unitTests/PropertiesHelperInitializationUnitTest.java
+++ b/src/test/java/testPackage/unitTests/PropertiesHelperInitializationUnitTest.java
@@ -51,15 +51,15 @@ public class PropertiesHelperInitializationUnitTest {
 
         Assert.assertTrue(customTemplateContent.contains("https://shafthq.github.io/"),
                 "custom.properties template should include a user guide link.");
-        Assert.assertTrue(customTemplateContent.contains("executionAddress=local"));
-        Assert.assertTrue(customTemplateContent.contains("targetOperatingSystem=Linux"));
-        Assert.assertTrue(customTemplateContent.contains("targetBrowserName=chrome"));
-        Assert.assertTrue(customTemplateContent.contains("headlessExecution=false"));
-        Assert.assertTrue(customTemplateContent.contains("setParallel=NONE"));
-        Assert.assertTrue(customTemplateContent.contains("setThreadCount=1"));
-        Assert.assertTrue(customTemplateContent.contains("retryMaximumNumberOfAttempts=0"));
-        Assert.assertTrue(customTemplateContent.contains("maximumPerformanceMode=0"));
-        Assert.assertTrue(customTemplateContent.contains("screenshotParamsWhenToTakeAScreenshot=ValidationPointsOnly"));
+        List.of(
+                "executionAddress=local",
+                "targetOperatingSystem=Linux",
+                "targetBrowserName=chrome",
+                "headlessExecution=false",
+                "retryMaximumNumberOfAttempts=0",
+                "screenshotParamsWhenToTakeAScreenshot=ValidationPointsOnly"
+        ).forEach(expectedDefault -> Assert.assertTrue(customTemplateContent.contains(expectedDefault),
+                "custom.properties template should include default: " + expectedDefault));
     }
 
     private void deleteGeneratedPropertyFile(String fileName) {


### PR DESCRIPTION
### Motivation
- The unit test `PropertiesHelperInitializationUnitTest.defaultCustomPropertiesTemplateShouldContainCommonDefaultsAndDocumentationLink` was failing due to stale expectations that no longer match `src/main/resources/properties/default/custom.properties`, so the test needs to assert only the defaults actually present in the template.

### Description
- Update `src/test/java/testPackage/unitTests/PropertiesHelperInitializationUnitTest.java` to replace multiple individual `Assert.assertTrue(...)` calls with a `List.of(...).forEach(...)` that verifies only the current defaults present in the default `custom.properties` template and remove stale assertions (e.g., TestNG parallel and `maximumPerformanceMode`).

### Testing
- Ran the targeted test: `mvn test -Dtest=PropertiesHelperInitializationUnitTest#defaultCustomPropertiesTemplateShouldContainCommonDefaultsAndDocumentationLink -Dgpg.skip` and it passed. 
- Ran the whole test class: `mvn test -Dtest=PropertiesHelperInitializationUnitTest -Dgpg.skip` and all tests in the class passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff85b0c348832098095040015c5e34)