### PR TITLE
Stabilize next E2E subtasks after run #3570

### DIFF
--- a/src/main/java/com/shaft/tools/io/internal/RealtimeReporter.java
+++ b/src/main/java/com/shaft/tools/io/internal/RealtimeReporter.java
@@ -40,7 +40,7 @@ public class RealtimeReporter {
 
     /** Default port for the real-time dashboard server. */
     private static final int DEFAULT_PORT = 1111;
-    private static final String DASHBOARD_URL = "http://localhost:" + DEFAULT_PORT;
+    private static volatile String DASHBOARD_URL = "http://localhost:" + DEFAULT_PORT;
     private static final Logger logger = LogManager.getLogger(RealtimeReporter.class);
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm").withZone(ZoneId.systemDefault());
     private static final DateTimeFormatter FULL_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss").withZone(ZoneId.systemDefault());
@@ -411,34 +411,57 @@ public class RealtimeReporter {
 
     private static void startServer() {
         try {
-            httpServer = HttpServer.create(new InetSocketAddress("localhost", DEFAULT_PORT), 0);
-            httpServer.createContext("/", RealtimeReporter::handleRoot);
-            httpServer.createContext("/api/state", RealtimeReporter::handleState);
-            httpServer.createContext("/api/events", RealtimeReporter::handleSse);
-            httpServer.createContext("/api/test/", RealtimeReporter::handleTestDetails);
-            httpServer.createContext("/api/attachment/", RealtimeReporter::handleAttachment);
-            httpExecutor = Executors.newCachedThreadPool();
-            httpServer.setExecutor(httpExecutor);
-            httpServer.start();
-            serverRunning.set(true);
-            logger.info("[RealtimeReporter] Dashboard started at {}", DASHBOARD_URL);
+            httpServer = createHttpServer(DEFAULT_PORT);
+            configureAndStartServer();
         } catch (BindException e) {
-            serverRunning.set(false);
-            httpServer = null;
-            if (httpExecutor != null) {
-                httpExecutor.shutdownNow();
-                httpExecutor = null;
+            logger.warn("[RealtimeReporter] Dashboard port {} is already in use. Falling back to an ephemeral port.", DEFAULT_PORT);
+            closeFailedServerResources();
+            try {
+                httpServer = createHttpServer(0);
+                configureAndStartServer();
+            } catch (IOException fallbackException) {
+                closeFailedServerResources();
+                logger.warn("[RealtimeReporter] Could not start dashboard server on fallback port. Reporter disabled for this run. Cause: {}", fallbackException.getMessage());
             }
-            logger.warn("[RealtimeReporter] Could not start dashboard on {} (port may already be in use). Reporter disabled for this run.", DEFAULT_PORT);
         } catch (IOException e) {
-            serverRunning.set(false);
-            httpServer = null;
-            if (httpExecutor != null) {
-                httpExecutor.shutdownNow();
-                httpExecutor = null;
-            }
+            closeFailedServerResources();
             logger.warn("[RealtimeReporter] Could not start dashboard server. Reporter disabled for this run. Cause: {}", e.getMessage());
         }
+    }
+
+    private static HttpServer createHttpServer(int port) throws IOException {
+        return HttpServer.create(new InetSocketAddress("localhost", port), 0);
+    }
+
+    private static void configureAndStartServer() {
+        httpServer.createContext("/", RealtimeReporter::handleRoot);
+        httpServer.createContext("/api/state", RealtimeReporter::handleState);
+        httpServer.createContext("/api/events", RealtimeReporter::handleSse);
+        httpServer.createContext("/api/test/", RealtimeReporter::handleTestDetails);
+        httpServer.createContext("/api/attachment/", RealtimeReporter::handleAttachment);
+        httpExecutor = Executors.newCachedThreadPool();
+        httpServer.setExecutor(httpExecutor);
+        httpServer.start();
+        DASHBOARD_URL = "http://localhost:" + httpServer.getAddress().getPort();
+        serverRunning.set(true);
+        logger.info("[RealtimeReporter] Dashboard started at {}", DASHBOARD_URL);
+    }
+
+    private static void closeFailedServerResources() {
+        serverRunning.set(false);
+        if (httpServer != null) {
+            try {
+                httpServer.stop(0);
+            } catch (Exception e) {
+                logger.debug("[RealtimeReporter] Error stopping failed server: {}", e.getMessage());
+            }
+            httpServer = null;
+        }
+        if (httpExecutor != null) {
+            httpExecutor.shutdownNow();
+            httpExecutor = null;
+        }
+        DASHBOARD_URL = "http://localhost:" + DEFAULT_PORT;
     }
 
     private static void openBrowser() {

--- a/src/test/java/testPackage/unitTests/RealtimeReporterServerUnitTest.java
+++ b/src/test/java/testPackage/unitTests/RealtimeReporterServerUnitTest.java
@@ -13,6 +13,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
+import java.net.ServerSocket;
 import java.net.URLEncoder;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -105,6 +106,23 @@ public class RealtimeReporterServerUnitTest {
         Assert.assertTrue(RealtimeReporter.isRunning());
         RealtimeReporter.onExecutionFinished();
         Assert.assertTrue(RealtimeReporter.isRunning());
+    }
+
+    @Test
+    public void startServerShouldFallbackToEphemeralPortWhenDefaultPortIsBusy() throws Exception {
+        RealtimeReporter.stopServer();
+        try (ServerSocket defaultPortBlocker = new ServerSocket(1111)) {
+            Method startServer = RealtimeReporter.class.getDeclaredMethod("startServer");
+            startServer.setAccessible(true);
+            startServer.invoke(null);
+
+            Assert.assertTrue(RealtimeReporter.isRunning());
+            var dashboardUrlField = RealtimeReporter.class.getDeclaredField("DASHBOARD_URL");
+            dashboardUrlField.setAccessible(true);
+            baseUrl = (String) dashboardUrlField.get(null);
+            Assert.assertFalse(baseUrl.endsWith(":1111"));
+            Assert.assertEquals(request("GET", "/api/state").code, 200);
+        }
     }
 
     private HttpResponse request(String method, String path) throws Exception {

--- a/src/test/java/testPackage/unitTests/ReportManagerHelperUnitTests.java
+++ b/src/test/java/testPackage/unitTests/ReportManagerHelperUnitTests.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+@Test(singleThreaded = true)
 public class ReportManagerHelperUnitTests {
 
     @BeforeMethod(alwaysRun = true)

--- a/src/test/java/testPackage/unitTests/TestClass.java
+++ b/src/test/java/testPackage/unitTests/TestClass.java
@@ -2,15 +2,25 @@ package testPackage.unitTests;
 
 import com.shaft.driver.SHAFT;
 import com.shaft.gui.internal.locator.Locator;
+import com.shaft.properties.internal.Properties;
+import com.shaft.properties.internal.ThreadLocalPropertiesManager;
 import org.openqa.selenium.By;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import testPackage.Tests;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class TestClass extends Tests {
     SHAFT.TestData.JSON testData;
 
-    String targetUrl = SHAFT.Properties.paths.testData() + "searchFixture.html";
+    String targetUrl;
 
     By searchBox = Locator.hasAnyTagName().hasAttribute("id", "searchbox_input").build();
     By firstSearchResult = Locator.hasTagName("article").isFirst().build();
@@ -35,7 +45,37 @@ public class TestClass extends Tests {
     }
 
     @BeforeClass
-    public void beforeClass() {
+    public void beforeClass() throws IOException {
         testData = new SHAFT.TestData.JSON("simpleJSON.json");
+        String fixtureHtml = Files.readString(Path.of(SHAFT.Properties.paths.testData(), "searchFixture.html"));
+        targetUrl = "data:text/html;charset=utf-8," + URLEncoder.encode(fixtureHtml, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    @Override
+    public void init() {
+        Properties.clearForCurrentThread();
+        setThreadLocalPropertyFromSystemProperty("executionAddress");
+        setThreadLocalPropertyFromSystemProperty("targetOperatingSystem");
+        setThreadLocalPropertyFromSystemProperty("targetBrowserName");
+        setThreadLocalPropertyFromSystemProperty("headlessExecution");
+        driver.set(new SHAFT.GUI.WebDriver());
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    public void tear() {
+        if (driver.get() != null) {
+            driver.get().quit();
+            driver.remove();
+        }
+        Properties.clearForCurrentThread();
+    }
+
+    private void setThreadLocalPropertyFromSystemProperty(String propertyName) {
+        String propertyValue = System.getProperty(propertyName);
+        if (propertyValue != null && !propertyValue.isBlank()) {
+            ThreadLocalPropertiesManager.setProperty(propertyName, propertyValue);
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Tests from run #3570 were failing or flaky due to environment-dependent assumptions around the realtime dashboard port, shared static report state, and tests that relied on host filesystem URLs or global property mutation. 
- The goal is to make those unit/E2E coverage tests robust against CI/shared-host variability without broad refactors. 

### Description
- Make `RealtimeReporter` robust to port collisions by falling back to an ephemeral localhost port, tracking the actual bound port in `DASHBOARD_URL`, and moving server setup/cleanup into `createHttpServer`, `configureAndStartServer`, and `closeFailedServerResources` helpers. 
- Add a regression test `startServerShouldFallbackToEphemeralPortWhenDefaultPortIsBusy` to verify blocking port `1111` triggers the fallback and `/api/state` remains served. 
- Reduce intra-class races by marking `ReportManagerHelperUnitTests` `@Test(singleThreaded = true)` so static issue/log state is not corrupted under dynamic parallel TestNG execution. 
- Stabilize browser-based `TestClass` by loading the HTML fixture as a `data:` URL (so it no longer depends on host file paths), encoding whitespace safely, and restoring/setting per-thread properties via `ThreadLocalPropertiesManager` in `@BeforeMethod` while clearing them in teardown before creating the driver. 

### Testing
- Ran targeted tests with `mvn -q test -DgenerateAllureReport=false "-Dtest=RealtimeReporterServerUnitTest,ReportManagerHelperUnitTests#prepareIssuesLogShouldAggregateNewAndOpenIssueEntries" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DheadlessExecution=true"`, and the invoked tests passed. 
- Ran `mvn -q -DskipTests -Dgpg.skip test-compile` to validate test compilation, and it succeeded. 
- Ran `mvn -q clean install -DskipTests -Dgpg.skip` to verify the project builds, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff8af97d4083209ed53d7921327366)