### PR TITLE
Stabilize ReportPortal listener coverage tests

### DIFF
--- a/src/test/java/testPackage/unitTests/TestNGListenerCoverageUnitTest.java
+++ b/src/test/java/testPackage/unitTests/TestNGListenerCoverageUnitTest.java
@@ -12,6 +12,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Field;
+import java.util.List;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
@@ -107,6 +108,7 @@ public class TestNGListenerCoverageUnitTest {
             Mockito.verify(reportPortalService).sendReportPortalMsg(testResult);
             Mockito.verify(reportPortalService).finishTestMethod(ItemStatus.FAILED, testResult);
         } finally {
+            removeTrackedMethod("failedTests", testResult.getMethod());
             setReportPortalEnabled(false);
         }
     }
@@ -123,8 +125,16 @@ public class TestNGListenerCoverageUnitTest {
             listener.onTestSkipped(testResult);
             Mockito.verify(reportPortalService).finishTestMethod(ItemStatus.SKIPPED, testResult);
         } finally {
+            removeTrackedMethod("skippedTests", testResult.getMethod());
             setReportPortalEnabled(false);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void removeTrackedMethod(String fieldName, ITestNGMethod testMethod) throws Exception {
+        Field trackedMethodsField = TestNGListener.class.getDeclaredField(fieldName);
+        trackedMethodsField.setAccessible(true);
+        ((List<ITestNGMethod>) trackedMethodsField.get(null)).remove(testMethod);
     }
 
     private static ITestResult createTestResult(String methodName, Throwable throwable) {


### PR DESCRIPTION
### Motivation

- Prevent synthetic ReportPortal listener invocations in unit tests from polluting SHAFT's execution-summary counts by cleaning up the listener's tracked method lists after coverage assertions.

### Description

- Update `TestNGListenerCoverageUnitTest` to remove the mocked `ITestNGMethod` from `TestNGListener`'s static `failedTests` and `skippedTests` lists after verifying ReportPortal callbacks. 
- Add a small reflection helper `removeTrackedMethod(String, ITestNGMethod)` to remove only the specific mocked method rather than resetting global listener state.
- Add `java.util.List` import required for the helper.

### Testing

- Ran `mvn -q test -Dtest=TestNGListenerCoverageUnitTest` which completed successfully. 
- Ran `mvn -q clean install -DskipTests -Dgpg.skip` to validate compilation and packaging, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff97af23088320a53993aee5e5632e)