### PR TITLE
Add realtime reporter headless checkout demo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefireArgLine>--enable-native-access=ALL-UNNAMED -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8</surefireArgLine>
-        <surefire.excludedGroups>allure3-visual-demo</surefire.excludedGroups>
+        <surefire.excludedGroups>allure3-visual-demo,realtime-reporter-demo</surefire.excludedGroups>
         <jdk.version>25</jdk.version>
         <lombok.version>1.18.46</lombok.version>
         <maven.min.version>3.9.0</maven.min.version>
@@ -1467,8 +1467,8 @@
                             <classpathDependencyExcludes>
                                 <classpathDependencyExclude>com.browserstack:browserstack-java-sdk</classpathDependencyExclude>
                             </classpathDependencyExcludes>
-                            <!-- Exclude intentionally-failing visual-demo tests from default CI runs.
-                                 Run them explicitly with -Dgroups=allure3-visual-demo when needed,
+                            <!-- Exclude intentionally-failing visual-demo and opt-in realtime dashboard demo tests from default CI runs.
+                                 Run them explicitly with -Dgroups=allure3-visual-demo or -Dgroups=realtime-reporter-demo when needed,
                                  or override -Dsurefire.excludedGroups to customize exclusions. -->
                             <excludedGroups>${surefire.excludedGroups}</excludedGroups>
                             <systemPropertyVariables>

--- a/scripts/demos/record-realtime-reporter-headless-checkout.sh
+++ b/scripts/demos/record-realtime-reporter-headless-checkout.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+OUT_DIR="${OUT_DIR:-target/realtime-reporter-demo}"
+if [[ "$OUT_DIR" != /* ]]; then
+  OUT_DIR="$ROOT_DIR/$OUT_DIR"
+fi
+TOOLS_DIR="$OUT_DIR/playwright-tools"
+RAW_VIDEO_DIR="$OUT_DIR/raw-video"
+LOG_FILE="$OUT_DIR/maven-realtime-demo.log"
+OUTPUT_VIDEO="$OUT_DIR/realtime-dashboard-headless-checkout.webm"
+PLAYWRIGHT_VERSION="${PLAYWRIGHT_VERSION:-1.57.0}"
+DASHBOARD_URL=""
+
+rm -rf "$OUT_DIR"
+mkdir -p "$TOOLS_DIR" "$RAW_VIDEO_DIR"
+
+cat > "$TOOLS_DIR/package.json" <<JSON
+{"private":true,"type":"commonjs","dependencies":{"playwright":"$PLAYWRIGHT_VERSION"}}
+JSON
+npm --prefix "$TOOLS_DIR" install --silent
+PLAYWRIGHT_BROWSERS_PATH="$OUT_DIR/ms-playwright" npx --prefix "$TOOLS_DIR" playwright install chromium >/dev/null
+
+mvn -q \
+  -Dtest=RealtimeReporterHeadlessCheckoutDemoTest \
+  -Dgroups=realtime-reporter-demo \
+  -Dsurefire.excludedGroups= \
+  -Dreporting.realtimeReport.enabled=true \
+  -DheadlessExecution=true \
+  -DtargetBrowserName=chrome \
+  -DautomaticallyAddRecommendedChromeOptions=true \
+  test >"$LOG_FILE" 2>&1 &
+MVN_PID=$!
+
+cleanup() {
+  if kill -0 "$MVN_PID" >/dev/null 2>&1; then
+    kill "$MVN_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 120); do
+  if grep -q "Dashboard started at" "$LOG_FILE"; then
+    DASHBOARD_URL="$(grep -oE 'http://localhost:[0-9]+' "$LOG_FILE" | tail -1)"
+    break
+  fi
+  if ! kill -0 "$MVN_PID" >/dev/null 2>&1; then
+    wait "$MVN_PID" || true
+    echo "Maven finished before the realtime dashboard started. See $LOG_FILE" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+if [[ -z "$DASHBOARD_URL" ]]; then
+  echo "Timed out waiting for realtime dashboard. See $LOG_FILE" >&2
+  exit 1
+fi
+
+TOOLS_DIR="$TOOLS_DIR" \
+DASHBOARD_URL="$DASHBOARD_URL" \
+RAW_VIDEO_DIR="$RAW_VIDEO_DIR" \
+OUTPUT_VIDEO="$OUTPUT_VIDEO" \
+PLAYWRIGHT_BROWSERS_PATH="$OUT_DIR/ms-playwright" \
+node <<'NODE'
+const fs = require('fs');
+const path = require('path');
+const { chromium } = require(path.join(process.env.TOOLS_DIR, 'node_modules', 'playwright'));
+
+const terminalStatuses = new Set(['PASSED', 'FAILED', 'SKIPPED']);
+
+async function getState(page, dashboardUrl) {
+  return await page.evaluate(async (url) => {
+    const response = await fetch(`${url}/api/state`, { cache: 'no-store' });
+    return response.json();
+  }, dashboardUrl);
+}
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 1000 },
+    recordVideo: { dir: process.env.RAW_VIDEO_DIR, size: { width: 1440, height: 1000 } },
+  });
+  const page = await context.newPage();
+  await page.goto(process.env.DASHBOARD_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('body');
+
+  const deadline = Date.now() + 180_000;
+  while (Date.now() < deadline) {
+    await page.waitForTimeout(1000);
+    const state = await getState(page, process.env.DASHBOARD_URL);
+    const tests = Array.isArray(state.tests) ? state.tests : [];
+    if (tests.length > 0 && tests.every(test => terminalStatuses.has(test.status))) {
+      await page.waitForTimeout(5000);
+      break;
+    }
+  }
+
+  const video = page.video();
+  if (!video) {
+    throw new Error('Playwright did not create a video for the dashboard page.');
+  }
+  await page.close();
+  const videoPath = await video.path();
+  await context.close();
+  await browser.close();
+  fs.mkdirSync(path.dirname(process.env.OUTPUT_VIDEO), { recursive: true });
+  fs.copyFileSync(videoPath, process.env.OUTPUT_VIDEO);
+  console.log(`Recorded realtime dashboard video: ${process.env.OUTPUT_VIDEO}`);
+})().catch(error => {
+  console.error(error);
+  process.exit(1);
+});
+NODE
+
+wait "$MVN_PID"
+trap - EXIT
+
+if rg -q "failures=\"[1-9]|errors=\"[1-9]" target/surefire-reports/TEST-testPackage.realtime.RealtimeReporterHeadlessCheckoutDemoTest.xml; then
+  echo "The realtime checkout demo test reported failures. See $LOG_FILE" >&2
+  exit 1
+fi
+
+printf 'Realtime dashboard video: %s\nMaven log: %s\n' "$OUTPUT_VIDEO" "$LOG_FILE"

--- a/src/main/java/com/shaft/tools/io/internal/RealtimeReporter.java
+++ b/src/main/java/com/shaft/tools/io/internal/RealtimeReporter.java
@@ -32,6 +32,8 @@ import java.util.stream.Collectors;
  *   <li>The {@code reporting.realtimeReport.enabled} property is {@code true}.</li>
  *   <li>Execution is not inside a CI/CD environment.</li>
  * </ul>
+ * The dashboard server can run while local browser tests execute in headless mode so
+ * external tools can capture the live report without displaying the tested browser.
  *
  * <p>Only one instance of the server runs at a time. Starting a new test run tears down
  * the previous server and starts a fresh one.
@@ -46,8 +48,6 @@ public class RealtimeReporter {
     private static final DateTimeFormatter FULL_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss").withZone(ZoneId.systemDefault());
     private static final int MAX_ATTACHMENT_SIZE_BYTES = 25 * 1024 * 1024; // 25MB per attachment
     private static final long MAX_TOTAL_ATTACHMENT_BYTES = 250L * 1024 * 1024; // 250MB total
-    private static final String EXECUTION_ADDRESS_LOCAL = "local";
-
     // Server state
     private static HttpServer httpServer;
     private static ExecutorService httpExecutor;
@@ -312,18 +312,15 @@ public class RealtimeReporter {
 
     /**
      * Determines whether the real-time report should be launched.
-     * The report launches when the flag is enabled, not running in CI,
-     * and not executing locally in headless mode.
+     * The report launches when the flag is enabled and execution is not running in CI.
+     * Local headless browser execution is allowed so the dashboard can be observed or
+     * recorded separately while the tested browser remains headless.
      *
      * @return {@code true} when launch conditions are satisfied
      */
     public static boolean shouldLaunch() {
         try {
             if (!SHAFT.Properties.reporting.realtimeReport()) return false;
-            if (EXECUTION_ADDRESS_LOCAL.equalsIgnoreCase(SHAFT.Properties.platform.executionAddress())
-                    && SHAFT.Properties.web.headlessExecution()) {
-                return false;
-            }
         } catch (Exception e) {
             return false;
         }

--- a/src/test/java/testPackage/realtime/RealtimeReporterHeadlessCheckoutDemoTest.java
+++ b/src/test/java/testPackage/realtime/RealtimeReporterHeadlessCheckoutDemoTest.java
@@ -1,0 +1,112 @@
+package testPackage.realtime;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.gui.internal.locator.Locator;
+import com.shaft.properties.internal.Properties;
+import org.openqa.selenium.By;
+import org.openqa.selenium.remote.Browser;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class RealtimeReporterHeadlessCheckoutDemoTest {
+    private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
+    private SHAFT.TestData.JSON testData;
+
+    private final By usernameField = Locator.hasTagName("input").hasAttribute("data-test", "username").build();
+    private final By passwordField = Locator.hasTagName("input").hasAttribute("data-test", "password").build();
+    private final By loginButton = Locator.hasTagName("input").hasAttribute("data-test", "login-button").build();
+    private final By backpackAddToCartButton = By.id("add-to-cart-sauce-labs-backpack");
+    private final By bikeLightAddToCartButton = By.id("add-to-cart-sauce-labs-bike-light");
+    private final By cartBadge = By.className("shopping_cart_badge");
+    private final By cartLink = By.className("shopping_cart_link");
+    private final By checkoutButton = By.id("checkout");
+    private final By firstNameField = By.id("first-name");
+    private final By lastNameField = By.id("last-name");
+    private final By postalCodeField = By.id("postal-code");
+    private final By continueButton = By.id("continue");
+    private final By checkoutSummary = By.id("checkout_summary_container");
+    private final By finishButton = By.id("finish");
+    private final By completeHeader = By.className("complete-header");
+    private final By backHomeButton = By.id("back-to-products");
+
+    @BeforeClass(alwaysRun = true)
+    public void loadTestData() {
+        testData = new SHAFT.TestData.JSON("realtimeReporterCheckoutDemo.json");
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void setup() {
+        SHAFT.Properties.reporting.set().realtimeReport(true);
+        SHAFT.Properties.web.set()
+                .targetBrowserName(Browser.CHROME.browserName())
+                .headlessExecution(true);
+        SHAFT.Properties.flags.set().automaticallyAddRecommendedChromeOptions(true);
+        SHAFT.Properties.visuals.set().videoParamsRecordVideo(true);
+        driver.set(new SHAFT.GUI.WebDriver());
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void teardown() {
+        if (driver.get() != null) {
+            driver.get().quit();
+            driver.remove();
+        }
+        Properties.clearForCurrentThread();
+    }
+
+    @Test(groups = "realtime-reporter-demo", description = "Runs a long headless Sauce Demo checkout journey for realtime dashboard recording")
+    public void completeFullShoppingCheckoutCycleInHeadlessMode() {
+        driver.get().browser().navigateToURL(testData.getTestData("baseUrl"));
+        pauseForDashboardRecording();
+
+        driver.get().assertThat().browser().title().contains(testData.getTestData("expectedTitle")).perform();
+        driver.get().element()
+                .type(usernameField, testData.getTestData("username"))
+                .typeSecure(passwordField, testData.getTestData("password"))
+                .click(loginButton);
+        pauseForDashboardRecording();
+
+        driver.get().assertThat().element(By.xpath("//div[text()='Sauce Labs Backpack']")).exists().perform();
+        driver.get().element()
+                .click(backpackAddToCartButton)
+                .click(bikeLightAddToCartButton);
+        pauseForDashboardRecording();
+
+        driver.get().assertThat().element(cartBadge).text().isEqualTo(testData.getTestData("expectedCartCount")).perform();
+        driver.get().element().click(cartLink);
+        pauseForDashboardRecording();
+
+        driver.get().assertThat().element(By.xpath("//div[text()='Sauce Labs Backpack']")).exists().perform();
+        driver.get().assertThat().element(By.xpath("//div[text()='Sauce Labs Bike Light']")).exists().perform();
+        driver.get().element().click(checkoutButton);
+        pauseForDashboardRecording();
+
+        driver.get().element()
+                .type(firstNameField, testData.getTestData("firstName"))
+                .type(lastNameField, testData.getTestData("lastName"))
+                .type(postalCodeField, testData.getTestData("postalCode"))
+                .click(continueButton);
+        pauseForDashboardRecording();
+
+        driver.get().assertThat().element(checkoutSummary).exists().perform();
+        driver.get().assertThat().element(By.xpath("//div[contains(text(),'Payment Information')]")).exists().perform();
+        driver.get().element().click(finishButton);
+        pauseForDashboardRecording();
+
+        driver.get().assertThat().element(completeHeader).text().isEqualTo(testData.getTestData("completionMessage")).perform();
+        driver.get().element().click(backHomeButton);
+        driver.get().assertThat().element(By.xpath("//div[text()='Sauce Labs Backpack']")).exists().perform();
+        pauseForDashboardRecording();
+    }
+
+    private void pauseForDashboardRecording() {
+        try {
+            Thread.sleep(1500);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while pacing realtime dashboard demo", e);
+        }
+    }
+}

--- a/src/test/java/testPackage/unitTests/RealtimeReporterUnitTest.java
+++ b/src/test/java/testPackage/unitTests/RealtimeReporterUnitTest.java
@@ -1,5 +1,7 @@
 package testPackage.unitTests;
 
+import com.shaft.driver.SHAFT;
+import com.shaft.properties.internal.Properties;
 import com.shaft.tools.io.internal.RealtimeReporter;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -29,6 +31,7 @@ public class RealtimeReporterUnitTest {
     @AfterMethod(alwaysRun = true)
     public void cleanup() {
         RealtimeReporter.stopServer();
+        Properties.clearForCurrentThread();
     }
 
     // ─── CI detection ─────────────────────────────────────────────────────
@@ -57,6 +60,17 @@ public class RealtimeReporterUnitTest {
         // regardless of the environment.
         assertFalse(RealtimeReporter.shouldLaunch(),
                 "Real-time report should be disabled by default");
+    }
+
+
+    @Test
+    public void shouldLaunchAllowsExplicitRealtimeDashboardForLocalHeadlessRuns() {
+        SHAFT.Properties.reporting.set().realtimeReport(true);
+        SHAFT.Properties.platform.set().executionAddress("local");
+        SHAFT.Properties.web.set().headlessExecution(true);
+
+        assertEquals(RealtimeReporter.shouldLaunch(), !RealtimeReporter.isRunningInCI(),
+                "Real-time report should be launchable during local headless execution outside CI");
     }
 
     @Test

--- a/src/test/resources/testDataFiles/realtimeReporterCheckoutDemo.json
+++ b/src/test/resources/testDataFiles/realtimeReporterCheckoutDemo.json
@@ -1,0 +1,11 @@
+{
+  "baseUrl": "https://www.saucedemo.com",
+  "username": "standard_user",
+  "password": "secret_sauce",
+  "expectedTitle": "Swag Labs",
+  "expectedCartCount": "2",
+  "firstName": "Realtime",
+  "lastName": "Reporter",
+  "postalCode": "90210",
+  "completionMessage": "Thank you for your order!"
+}


### PR DESCRIPTION
### Motivation
- Make the realtime dashboard usable when a developer explicitly enables it for local headless runs so external tooling can observe/record the live dashboard while the tested browser runs headless.
- Provide an end-to-end demo that exercises the realtime reporter with a realistic long GUI flow (login → add to cart → checkout) and captures the live dashboard as a video for documentation/demos.

### Description
- Relaxed the realtime launch guard so `reporting.realtimeReport` controls launching while CI remains blocked and headless local runs are allowed; updated JavaDoc accordingly (`RealtimeReporter`).
- Added an opt-in TestNG E2E GUI test `RealtimeReporterHeadlessCheckoutDemoTest` that runs headlessly against the Sauce Demo site and paces actions to make realtime dashboard updates observable; test data lives in `src/test/resources/testDataFiles/realtimeReporterCheckoutDemo.json`.
- Added `scripts/demos/record-realtime-reporter-headless-checkout.sh`, a helper that installs Playwright under `target/`, runs the demo test with realtime reporting enabled, opens the dashboard, records the dashboard page to a WebM, and copies the recording to `target/realtime-reporter-demo/realtime-dashboard-headless-checkout.webm`.
- Marked the demo as opt-in by excluding a new test group from default Surefire runs (`realtime-reporter-demo`) and updated `pom.xml` exclusions.
- Added a unit test to cover the changed launch-guard behavior and cleared thread-local properties in the realtime reporter unit tests (`RealtimeReporterUnitTest`).

### Testing
- Ran `mvn clean install -DskipTests -Dgpg.skip` to compile the project; build succeeded.
- Ran `mvn -Dtest=RealtimeReporterUnitTest test`; the unit suite passed (no failures).
- Executed the demo flow and recorder using `./scripts/demos/record-realtime-reporter-headless-checkout.sh`; the demo test completed and the script produced a recorded dashboard video at `target/realtime-reporter-demo/realtime-dashboard-headless-checkout.webm` (created during the run).
- Verified the demo test Surefire XML shows zero failures for the demo class and the Maven log contains the dashboard start message `Dashboard started at http://localhost:1111`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff95bae5b08320a6c1017197d35574)