### PR TITLE
Stabilize ReportPortal listener tests in parallel runs

### DIFF
--- a/src/main/java/com/shaft/listeners/TestNGListener.java
+++ b/src/main/java/com/shaft/listeners/TestNGListener.java
@@ -85,6 +85,7 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
     @Getter
     private static boolean isReportPortalEnabled;
     private ITestNGService reportPortalTestNGService;
+    private boolean isReportPortalEnabledForListener;
 
     public static ProjectStructureManager.RunType identifyRunType() {
         Supplier<Stream<?>> stacktraceSupplier = () -> Arrays.stream((new Throwable()).getStackTrace()).map(StackTraceElement::getClassName);
@@ -153,7 +154,8 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
         }
         String rpEnableValue = ThreadLocalPropertiesManager.getProperty("rp.enable");
         TestNGListener.isReportPortalEnabled = rpEnableValue != null && Boolean.parseBoolean(rpEnableValue.trim());
-        if (TestNGListener.isReportPortalEnabled) {
+        this.isReportPortalEnabledForListener = TestNGListener.isReportPortalEnabled;
+        if (this.isReportPortalEnabledForListener) {
             String info = "Initializing ReportPortal Reporting Environment.";
             ReportManagerHelper.logDiscrete(info, Level.INFO);
             this.reportPortalTestNGService.startLaunch();
@@ -187,7 +189,7 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
     public void onStart(ISuite suite) {
         TestNGListenerHelper.setTotalNumberOfTests(suite);
         executionStartTime = System.currentTimeMillis();
-        if (isReportPortalEnabled) this.reportPortalTestNGService.startTestSuite(suite);
+        if (this.isReportPortalEnabledForListener) this.reportPortalTestNGService.startTestSuite(suite);
         // Populate real-time dashboard with planned tests
         RealtimeReporter.initialize(suite.getName());
         List<RealtimeReporter.TestCard> planned = suite.getAllMethods().stream()
@@ -208,7 +210,7 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
 
     @Override
     public void onFinish(ISuite suite) {
-        if (isReportPortalEnabled) this.reportPortalTestNGService.finishTestSuite(suite);
+        if (this.isReportPortalEnabledForListener) this.reportPortalTestNGService.finishTestSuite(suite);
     }
 
     @Override
@@ -219,17 +221,17 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
         Arrays.stream(testContext.getAllTestMethods())
                 .filter(ITestNGMethod::isTest)
                 .forEach(method -> method.setRetryAnalyzerClass(RetryAnalyzer.class));
-        if (isReportPortalEnabled) this.reportPortalTestNGService.startTest(testContext);
+        if (this.isReportPortalEnabledForListener) this.reportPortalTestNGService.startTest(testContext);
     }
 
     @Override
     public void onFinish(ITestContext testContext) {
-        if (isReportPortalEnabled) this.reportPortalTestNGService.finishTest(testContext);
+        if (this.isReportPortalEnabledForListener) this.reportPortalTestNGService.finishTest(testContext);
     }
 
     @Override
     public void beforeConfiguration(ITestResult testResult) {
-        if (isReportPortalEnabled) this.reportPortalTestNGService.startConfiguration(testResult);
+        if (this.isReportPortalEnabledForListener) this.reportPortalTestNGService.startConfiguration(testResult);
     }
 
     @Override
@@ -237,24 +239,24 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
         if (testResult.getThrowable() != null) {
             TestNGListenerHelper.setPendingConfigFailure(testResult.getThrowable());
         }
-        if (isReportPortalEnabled) this.reportPortalTestNGService.sendReportPortalMsg(testResult);
-        if (isReportPortalEnabled) this.reportPortalTestNGService.finishTestMethod(ItemStatus.FAILED, testResult);
+        if (this.isReportPortalEnabledForListener) this.reportPortalTestNGService.sendReportPortalMsg(testResult);
+        if (this.isReportPortalEnabledForListener) this.reportPortalTestNGService.finishTestMethod(ItemStatus.FAILED, testResult);
     }
 
     @Override
     public void onConfigurationSuccess(ITestResult testResult) {
-        if (isReportPortalEnabled) this.reportPortalTestNGService.finishTestMethod(ItemStatus.PASSED, testResult);
+        if (this.isReportPortalEnabledForListener) this.reportPortalTestNGService.finishTestMethod(ItemStatus.PASSED, testResult);
     }
 
     @Override
     public void onConfigurationSkip(ITestResult testResult) {
-        if (isReportPortalEnabled) this.reportPortalTestNGService.startConfiguration(testResult);
-        if (isReportPortalEnabled) this.reportPortalTestNGService.finishTestMethod(ItemStatus.SKIPPED, testResult);
+        if (this.isReportPortalEnabledForListener) this.reportPortalTestNGService.startConfiguration(testResult);
+        if (this.isReportPortalEnabledForListener) this.reportPortalTestNGService.finishTestMethod(ItemStatus.SKIPPED, testResult);
     }
 
     @Override
     public void onTestFailedButWithinSuccessPercentage(ITestResult result) {
-        if (isReportPortalEnabled) this.reportPortalTestNGService.finishTestMethod(ItemStatus.FAILED, result);
+        if (this.isReportPortalEnabledForListener) this.reportPortalTestNGService.finishTestMethod(ItemStatus.FAILED, result);
     }
 
     /**
@@ -401,12 +403,12 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
         RealtimeReporter.onExecutionFinished();
         AllureManager.openAllureReportAfterExecution();
         AllureManager.generateAllureReportArchive();
-        if (isReportPortalEnabled) this.reportPortalTestNGService.finishLaunch();
+        if (this.isReportPortalEnabledForListener) this.reportPortalTestNGService.finishLaunch();
     }
 
     @Override
     public void onTestStart(ITestResult testResult) {
-        if (isReportPortalEnabled) this.reportPortalTestNGService.startTestMethod(testResult);
+        if (this.isReportPortalEnabledForListener) this.reportPortalTestNGService.startTestMethod(testResult);
         String id = RealtimeReporter.buildTestId(
                 testResult.getTestClass().getName(),
                 testResult.getMethod().getMethodName());
@@ -420,7 +422,7 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
         ExecutionSummaryReport.casesDetailsIncrement(TestNGListenerHelper.getTmsLinkAnnotationValue(testResult), testResult.getMethod().getQualifiedName().replace("." + testResult.getMethod().getMethodName(), ""),
                 testResult.getMethod().getMethodName(), testResult.getMethod().getDescription(), "",
                 ExecutionSummaryReport.StatusIcon.PASSED.getValue() + ExecutionSummaryReport.Status.PASSED.name(), TestNGListenerHelper.getIssueAnnotationValue(testResult));
-        if (isReportPortalEnabled) this.reportPortalTestNGService.finishTestMethod(ItemStatus.PASSED, testResult);
+        if (this.isReportPortalEnabledForListener) this.reportPortalTestNGService.finishTestMethod(ItemStatus.PASSED, testResult);
         String id = RealtimeReporter.buildTestId(
                 testResult.getTestClass().getName(),
                 testResult.getMethod().getMethodName());
@@ -434,8 +436,8 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
         ExecutionSummaryReport.casesDetailsIncrement(TestNGListenerHelper.getTmsLinkAnnotationValue(testResult), testResult.getMethod().getQualifiedName().replace("." + testResult.getMethod().getMethodName(), ""),
                 testResult.getMethod().getMethodName(), testResult.getMethod().getDescription(), testResult.getThrowable().getMessage(),
                 ExecutionSummaryReport.StatusIcon.FAILED.getValue() + ExecutionSummaryReport.Status.FAILED.name(), TestNGListenerHelper.getIssueAnnotationValue(testResult));
-        if (isReportPortalEnabled) this.reportPortalTestNGService.sendReportPortalMsg(testResult);
-        if (isReportPortalEnabled) this.reportPortalTestNGService.finishTestMethod(ItemStatus.FAILED, testResult);
+        if (this.isReportPortalEnabledForListener) this.reportPortalTestNGService.sendReportPortalMsg(testResult);
+        if (this.isReportPortalEnabledForListener) this.reportPortalTestNGService.finishTestMethod(ItemStatus.FAILED, testResult);
         String id = RealtimeReporter.buildTestId(
                 testResult.getTestClass().getName(),
                 testResult.getMethod().getMethodName());
@@ -450,7 +452,7 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
         ExecutionSummaryReport.casesDetailsIncrement(TestNGListenerHelper.getTmsLinkAnnotationValue(testResult), testResult.getMethod().getQualifiedName().replace("." + testResult.getMethod().getMethodName(), ""),
                 testResult.getMethod().getMethodName(), testResult.getMethod().getDescription(), throwableMessage,
                 ExecutionSummaryReport.StatusIcon.SKIPPED.getValue() + ExecutionSummaryReport.Status.SKIPPED.name(), TestNGListenerHelper.getIssueAnnotationValue(testResult));
-        if (isReportPortalEnabled) this.reportPortalTestNGService.finishTestMethod(ItemStatus.SKIPPED, testResult);
+        if (this.isReportPortalEnabledForListener) this.reportPortalTestNGService.finishTestMethod(ItemStatus.SKIPPED, testResult);
         String id = RealtimeReporter.buildTestId(
                 testResult.getTestClass().getName(),
                 testResult.getMethod().getMethodName());

--- a/src/test/java/testPackage/unitTests/TestNGListenerCoverageUnitTest.java
+++ b/src/test/java/testPackage/unitTests/TestNGListenerCoverageUnitTest.java
@@ -48,7 +48,7 @@ public class TestNGListenerCoverageUnitTest {
 
         ITestNGService reportPortalService = Mockito.mock(ITestNGService.class);
         setReportPortalService(listener, reportPortalService);
-        setReportPortalEnabled(true);
+        setReportPortalEnabled(listener, true);
         try {
             listener.onConfigurationFailure(testResult);
             Mockito.verify(reportPortalService).sendReportPortalMsg(testResult);
@@ -65,7 +65,7 @@ public class TestNGListenerCoverageUnitTest {
 
         ITestNGService reportPortalService = Mockito.mock(ITestNGService.class);
         setReportPortalService(listener, reportPortalService);
-        setReportPortalEnabled(true);
+        setReportPortalEnabled(listener, true);
         try {
             listener.onConfigurationSuccess(testResult);
             listener.onConfigurationSkip(testResult);
@@ -85,7 +85,7 @@ public class TestNGListenerCoverageUnitTest {
 
         ITestNGService reportPortalService = Mockito.mock(ITestNGService.class);
         setReportPortalService(listener, reportPortalService);
-        setReportPortalEnabled(true);
+        setReportPortalEnabled(listener, true);
         try {
             listener.onTestFailedButWithinSuccessPercentage(testResult);
             Mockito.verify(reportPortalService).finishTestMethod(ItemStatus.FAILED, testResult);
@@ -102,7 +102,7 @@ public class TestNGListenerCoverageUnitTest {
 
         ITestNGService reportPortalService = Mockito.mock(ITestNGService.class);
         setReportPortalService(listener, reportPortalService);
-        setReportPortalEnabled(true);
+        setReportPortalEnabled(listener, true);
         try {
             listener.onTestFailure(testResult);
             Mockito.verify(reportPortalService).sendReportPortalMsg(testResult);
@@ -120,7 +120,7 @@ public class TestNGListenerCoverageUnitTest {
 
         ITestNGService reportPortalService = Mockito.mock(ITestNGService.class);
         setReportPortalService(listener, reportPortalService);
-        setReportPortalEnabled(true);
+        setReportPortalEnabled(listener, true);
         try {
             listener.onTestSkipped(testResult);
             Mockito.verify(reportPortalService).finishTestMethod(ItemStatus.SKIPPED, testResult);
@@ -157,6 +157,12 @@ public class TestNGListenerCoverageUnitTest {
         Field reportPortalEnabledField = TestNGListener.class.getDeclaredField("isReportPortalEnabled");
         reportPortalEnabledField.setAccessible(true);
         reportPortalEnabledField.set(null, value);
+    }
+
+    private static void setReportPortalEnabled(TestNGListener listener, boolean value) throws Exception {
+        Field reportPortalEnabledField = TestNGListener.class.getDeclaredField("isReportPortalEnabledForListener");
+        reportPortalEnabledField.setAccessible(true);
+        reportPortalEnabledField.set(listener, value);
     }
 
     private static void setReportPortalService(TestNGListener listener, ITestNGService reportPortalService) throws Exception {


### PR DESCRIPTION
### Motivation

- Prevent race conditions where tests enable ReportPortal globally and affect other concurrently-running listener instances.  

### Description

- Added an instance-scoped flag `isReportPortalEnabledForListener` to `TestNGListener` and initialize it from the existing global `rp.enable` value during `onExecutionStart`.  
- Replaced direct checks of the shared static flag with guards that use the per-listener instance flag for all ReportPortal callbacks (suite/test/configuration/test-method lifecycle).  
- Updated `TestNGListenerCoverageUnitTest` to enable ReportPortal on the specific `TestNGListener` instance under test via a new reflection helper `setReportPortalEnabled(listener, true)` instead of mutating the shared static flag.  
- Modified only `src/main/java/com/shaft/listeners/TestNGListener.java` and `src/test/java/testPackage/unitTests/TestNGListenerCoverageUnitTest.java` to implement the change.  

### Testing

- Ran `mvn -q -Dtest=TestNGListenerCoverageUnitTest test` and the test class passed.  
- Ran `mvn -q -Dtest=TestNGListenerCoverageUnitTest "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" test` to validate parallel execution and it passed.  
- Ran `mvn clean install -DskipTests -Dgpg.skip` to verify compilation and packaging and it succeeded.  
- Note: the original full CI run showed many external API tests failing with `Network is unreachable`; those failures are environment/network-related and not caused by this listener-scoping change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffcb9bd63c83209431cd7c41f96570)