### PR TITLE
fix(#2687): fix parallel Cucumber IndexOutOfBoundsException and webdriver.http.factory regression

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -565,5 +565,20 @@ Add entries to the **Session Learnings Log** section below. Keep each entry comp
 
 - Date: 2026-05-10
 - Area: Pattern / JVM system property catalogue
-- Lesson: `PropertiesHelper` now owns two public `Set<String>` catalogue constants — `JVM_SYSTEM_PROPERTIES_ALWAYS` (6 keys always set at engine startup) and `JVM_SYSTEM_PROPERTIES_PROXY` (6 proxy keys set when jvmProxySettings is enabled). Any property consumed by a third-party library via `System.getProperty()` must be added to the appropriate catalogue set; a CI-enforced unit test will fail if any key is missing after engine setup. This replaces the previous "deferred" entry.
-- Evidence: `PropertiesHelper.java`, `PropertiesHelperCoverageUnitTest`, PR #2688 commits f3774bfd70 / 563ee322b6 / 5053324423
+- Lesson: `PropertiesHelper` now owns two public `Set<String>` catalogue constants — `JVM_SYSTEM_PROPERTIES_ALWAYS` (5 keys always set at engine startup) and `JVM_SYSTEM_PROPERTIES_PROXY` (6 proxy keys set when jvmProxySettings is enabled). Any property consumed by a third-party library via `System.getProperty()` must be added to the appropriate catalogue set; a CI-enforced unit test will fail if any key is missing after engine setup.
+- Evidence: `PropertiesHelper.java`, `PropertiesHelperCoverageUnitTest`, PR #2688
+
+- Date: 2026-05-10
+- Area: Anti-pattern / Properties
+- Lesson: `SE_DRIVER_MIRROR_URL` must stay in the Edge switch arm (not global startup) and be cleared after `new EdgeDriver()`. Selenium Manager's `runCommand()` passes ALL `SE_*` JVM system properties to the selenium-manager binary process — setting it globally would redirect Chrome/Firefox driver downloads to the Edge CDN. Selenium Manager runs synchronously during driver instantiation so clearing immediately after the constructor is safe.
+- Evidence: `DriverFactoryHelper.java` Edge arm, `SeleniumManager.runCommand()` source, `DriverFactoryHelperUnitTest.edgeDriverInitClearsMirrorUrlAfterConstruction`, PR #2688
+
+- Date: 2026-05-10
+- Area: Pattern / Testing
+- Lesson: `Mockito.mockConstruction(X.class)` (Mockito 5.x core, no extra dep) intercepts all `new X()` calls inside the try-with-resources block without running the real constructor. Default return for object-typed mock methods is `null` — usually sufficient for dependencies you don't need to exercise. Prefer this over test-induced method extractions (extracting a `static void helper(Runnable)` only for testability is a code smell).
+- Evidence: `DriverFactoryHelperUnitTest.edgeDriverInitClearsMirrorUrlAfterConstruction`, PR #2688
+
+- Date: 2026-05-10
+- Area: CI / Coverage
+- Lesson: `codecov/patch` and `codecov/project` failures are expected on bug-fix branches whose CI only runs unit tests — the base `main` coverage (~78%) is measured by 11 full E2E jobs (browsers, BrowserStack, Grid). New production lines requiring real infrastructure (browsers, proxies) cannot be covered at unit-test level; document in PR description with **Known failing checks** section rather than forcing artificial coverage.
+- Evidence: PR #2688, PR #2646 (same pattern), codecov comparison against commit `3d4e395`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -547,3 +547,23 @@ Add entries to the **Session Learnings Log** section below. Keep each entry comp
 - Area: Pattern / grep / multiline
 - Lesson: Single-line `grep` patterns miss Java fluent chains split across lines (e.g., `Validations.assertThat()\n.response(res)`). When doing impact analysis for method-level refactors, also grep with multiline mode or read files directly after the first compile pass.
 - Evidence: Session 2026-05-08, 3 rounds of compile-error discovery during ValidationsBuilder fix
+
+- Date: 2026-05-10
+- Area: Anti-pattern / Properties
+- Lesson: `ThreadLocalPropertiesManager.setGlobalProperty()` writes only to SHAFT's internal `globalOverrides` map — external libraries (Selenium, Log4j, Allure, ReportPortal) that call `System.getProperty()` cannot see these values. Always use `System.setProperty()` for properties consumed by third-party libraries. PR #2488 introduced this regression for `webdriver.http.factory`, causing Selenium to fall back to Netty HTTP client and trigger a `subList(0,1)` race in TestNG 7.12.0 under parallel Cucumber execution.
+- Evidence: `PropertiesHelper.setKeySystemProperties()`, `PropertiesHelperCoverageUnitTest` line 70, PR #2688 (fix), PR #2488 (regression source)
+
+- Date: 2026-05-10
+- Area: Pattern / TestNG lifecycle
+- Lesson: `IAlterSuiteListener.alter()` fires BEFORE `IExecutionListener.onExecutionStart()`, so `Properties.testNG` (a plain static field, not a proxy) is null when `alter()` runs. Any code path in `alter()` that accesses `Properties.testNG` must lazily initialize it via `ConfigFactory.create(TestNG.class)`. The proxy pattern with null fallback exists for `platform`, `web`, `flags`, etc., but NOT for `testNG`, `internal`, `log4j`, `cucumber`.
+- Evidence: `TestNGListenerHelper.configureTestNGProperties()`, `Properties.java` line for `public static TestNG testNG`, PR #2688
+
+- Date: 2026-05-10
+- Area: Pattern / Cucumber detection
+- Lesson: `identifyRunType()` detects Cucumber by checking the call stack for `io.cucumber.core.runner.Runner` — this class is never present when `alter()` fires (Cucumber hasn't started). Detect Cucumber runs in `alter()` by inspecting suite class names: load each class with `Class.forName(name, false, classLoader)` and check `isAssignableFrom(AbstractTestNGCucumberTests.class)`.
+- Evidence: `TestNGListener.isCucumberRun()`, `TestNGListenerCoverageUnitTest.alterShouldRouteCucumberSuiteToCucumberHelperWithoutThrowing`, PR #2688
+
+- Date: 2026-05-10
+- Area: Pattern / JVM system property catalogue
+- Lesson: `PropertiesHelper` now owns two public `Set<String>` catalogue constants — `JVM_SYSTEM_PROPERTIES_ALWAYS` (6 keys always set at engine startup) and `JVM_SYSTEM_PROPERTIES_PROXY` (6 proxy keys set when jvmProxySettings is enabled). Any property consumed by a third-party library via `System.getProperty()` must be added to the appropriate catalogue set; a CI-enforced unit test will fail if any key is missing after engine setup. This replaces the previous "deferred" entry.
+- Evidence: `PropertiesHelper.java`, `PropertiesHelperCoverageUnitTest`, PR #2688 commits f3774bfd70 / 563ee322b6 / 5053324423

--- a/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -419,12 +419,6 @@ public class DriverFactoryHelper {
         }
     }
 
-    static void initEdgeDriver(Runnable driverConstruction) {
-        System.setProperty("SE_DRIVER_MIRROR_URL", "https://msedgedriver.microsoft.com");
-        driverConstruction.run();
-        System.clearProperty("SE_DRIVER_MIRROR_URL");
-    }
-
     private void createNewLocalDriverInstance(DriverType driverType, int retryAttempts) {
         String targetPlatform = Properties.platform.targetPlatform().toLowerCase();
         String initialLog = "Attempting to run locally on: \"" + targetPlatform + " | " + JavaHelper.convertToSentenceCase(driverType.getValue()) + "\"";
@@ -443,7 +437,9 @@ public class DriverFactoryHelper {
                     disableCacheEdgeAndChrome();
                 }
                 case EDGE -> {
-                    initEdgeDriver(() -> setDriver(new EdgeDriver(optionsManager.getEdOptions())));
+                    System.setProperty("SE_DRIVER_MIRROR_URL", "https://msedgedriver.microsoft.com");
+                    setDriver(new EdgeDriver(optionsManager.getEdOptions()));
+                    System.clearProperty("SE_DRIVER_MIRROR_URL");
                     disableCacheEdgeAndChrome();
                 }
                 case SAFARI -> setDriver(new SafariDriver(optionsManager.getSfOptions()));

--- a/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -437,9 +437,11 @@ public class DriverFactoryHelper {
                     disableCacheEdgeAndChrome();
                 }
                 case EDGE -> {
-                    // Selenium Manager reads this via System.getProperty() — must not use setGlobalProperty().
+                    // Selenium Manager scans SE_* system properties synchronously during driver instantiation.
+                    // Clear after construction so other browsers in the same JVM are not affected.
                     System.setProperty("SE_DRIVER_MIRROR_URL", "https://msedgedriver.microsoft.com");
                     setDriver(new EdgeDriver(optionsManager.getEdOptions()));
+                    System.clearProperty("SE_DRIVER_MIRROR_URL");
                     disableCacheEdgeAndChrome();
                 }
                 case SAFARI -> setDriver(new SafariDriver(optionsManager.getSfOptions()));

--- a/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -419,6 +419,12 @@ public class DriverFactoryHelper {
         }
     }
 
+    static void initEdgeDriver(Runnable driverConstruction) {
+        System.setProperty("SE_DRIVER_MIRROR_URL", "https://msedgedriver.microsoft.com");
+        driverConstruction.run();
+        System.clearProperty("SE_DRIVER_MIRROR_URL");
+    }
+
     private void createNewLocalDriverInstance(DriverType driverType, int retryAttempts) {
         String targetPlatform = Properties.platform.targetPlatform().toLowerCase();
         String initialLog = "Attempting to run locally on: \"" + targetPlatform + " | " + JavaHelper.convertToSentenceCase(driverType.getValue()) + "\"";
@@ -437,11 +443,7 @@ public class DriverFactoryHelper {
                     disableCacheEdgeAndChrome();
                 }
                 case EDGE -> {
-                    // Selenium Manager scans SE_* system properties synchronously during driver instantiation.
-                    // Clear after construction so other browsers in the same JVM are not affected.
-                    System.setProperty("SE_DRIVER_MIRROR_URL", "https://msedgedriver.microsoft.com");
-                    setDriver(new EdgeDriver(optionsManager.getEdOptions()));
-                    System.clearProperty("SE_DRIVER_MIRROR_URL");
+                    initEdgeDriver(() -> setDriver(new EdgeDriver(optionsManager.getEdOptions())));
                     disableCacheEdgeAndChrome();
                 }
                 case SAFARI -> setDriver(new SafariDriver(optionsManager.getSfOptions()));

--- a/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -7,7 +7,6 @@ import com.shaft.gui.browser.BrowserActions;
 import com.shaft.gui.internal.video.RecordManager;
 import com.shaft.properties.internal.Properties;
 import com.shaft.properties.internal.PropertiesHelper;
-import com.shaft.properties.internal.ThreadLocalPropertiesManager;
 import com.shaft.tools.internal.support.JavaHelper;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.FailureReporter;
@@ -438,9 +437,6 @@ public class DriverFactoryHelper {
                     disableCacheEdgeAndChrome();
                 }
                 case EDGE -> {
-                    // Fix for Microsoft Edge CDN migration from msedgedriver.azureedge.net to msedgedriver.microsoft.com
-                    // This ensures Selenium Manager uses the correct download URL for EdgeDriver.
-                    ThreadLocalPropertiesManager.setGlobalProperty("SE_DRIVER_MIRROR_URL", "https://msedgedriver.microsoft.com");
                     setDriver(new EdgeDriver(optionsManager.getEdOptions()));
                     disableCacheEdgeAndChrome();
                 }

--- a/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -437,6 +437,8 @@ public class DriverFactoryHelper {
                     disableCacheEdgeAndChrome();
                 }
                 case EDGE -> {
+                    // Selenium Manager reads this via System.getProperty() — must not use setGlobalProperty().
+                    System.setProperty("SE_DRIVER_MIRROR_URL", "https://msedgedriver.microsoft.com");
                     setDriver(new EdgeDriver(optionsManager.getEdOptions()));
                     disableCacheEdgeAndChrome();
                 }

--- a/src/main/java/com/shaft/listeners/TestNGListener.java
+++ b/src/main/java/com/shaft/listeners/TestNGListener.java
@@ -170,14 +170,39 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
      */
     @Override
     public void alter(List<XmlSuite> suites) {
-        switch (TestNGListener.identifyRunType()) {
-            case TESTNG -> TestNGListenerHelper.configureTestNGProperties(suites);
-            case CUCUMBER -> CucumberHelper.configureCucumberProperties(suites);
+        // identifyRunType() checks the call stack for io.cucumber.core.runner.Runner, but that class
+        // is not present in the stack when alter() fires (the Cucumber runner hasn't started yet).
+        // Detect Cucumber by inspecting suite class names instead of the call stack.
+        if (isCucumberRun(suites)) {
+            CucumberHelper.configureCucumberProperties(suites);
+        } else {
+            TestNGListenerHelper.configureTestNGProperties(suites);
         }
         TestNGListenerHelper.attachConfigurationHelperClass(suites);
         //All alterations should be finalized before duplicating the
         //test suites for cross browser execution
         TestNGListenerHelper.configureCrossBrowserExecution(suites);
+    }
+
+    /**
+     * Detects whether the suite is a Cucumber run by checking if any test class extends
+     * {@link io.cucumber.testng.AbstractTestNGCucumberTests}. This is more reliable than
+     * inspecting the call stack because the Cucumber runner is not present in the stack
+     * when {@link #alter(List)} is invoked.
+     */
+    private static boolean isCucumberRun(List<XmlSuite> suites) {
+        return suites.stream()
+                .flatMap(suite -> suite.getTests().stream())
+                .flatMap(test -> test.getClasses().stream())
+                .anyMatch(xmlClass -> {
+                    try {
+                        Class<?> cls = Class.forName(xmlClass.getName(), false,
+                                Thread.currentThread().getContextClassLoader());
+                        return io.cucumber.testng.AbstractTestNGCucumberTests.class.isAssignableFrom(cls);
+                    } catch (ClassNotFoundException | NoClassDefFoundError | SecurityException e) {
+                        return false;
+                    }
+                });
     }
 
     /**

--- a/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java
+++ b/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java
@@ -6,7 +6,6 @@ import com.shaft.enums.internal.Screenshots;
 import com.shaft.gui.internal.image.AnimatedGifManager;
 import com.shaft.gui.internal.locator.LocatorBuilder;
 import com.shaft.gui.internal.video.RecordManager;
-import com.shaft.properties.internal.ThreadLocalPropertiesManager;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import io.qameta.allure.Issue;
 import io.qameta.allure.Issues;
@@ -265,12 +264,12 @@ public class TestNGListenerHelper {
         String PROXY_SERVER_SETTINGS = SHAFT.Properties.platform.proxy();
         if (SHAFT.Properties.platform.jvmProxySettings() && !PROXY_SERVER_SETTINGS.isEmpty()) {
             String[] proxyHostPort = PROXY_SERVER_SETTINGS.split(":");
-            ThreadLocalPropertiesManager.setGlobalProperty("http.proxyHost", proxyHostPort[0]);
-            ThreadLocalPropertiesManager.setGlobalProperty("http.proxyPort", proxyHostPort[1]);
-            ThreadLocalPropertiesManager.setGlobalProperty("https.proxyHost", proxyHostPort[0]);
-            ThreadLocalPropertiesManager.setGlobalProperty("https.proxyPort", proxyHostPort[1]);
-            ThreadLocalPropertiesManager.setGlobalProperty("ftp.proxyHost", proxyHostPort[0]);
-            ThreadLocalPropertiesManager.setGlobalProperty("ftp.proxyPort", proxyHostPort[1]);
+            System.setProperty("http.proxyHost",  proxyHostPort[0]);
+            System.setProperty("http.proxyPort",  proxyHostPort[1]);
+            System.setProperty("https.proxyHost", proxyHostPort[0]);
+            System.setProperty("https.proxyPort", proxyHostPort[1]);
+            System.setProperty("ftp.proxyHost",   proxyHostPort[0]);
+            System.setProperty("ftp.proxyPort",   proxyHostPort[1]);
         }
     }
 

--- a/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java
+++ b/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java
@@ -222,6 +222,13 @@ public class TestNGListenerHelper {
     }
 
     public static void configureTestNGProperties(List<XmlSuite> suites) {
+        // Properties.testNG may be null when this is called from alter(), because alter() fires
+        // before onExecutionStart() runs loadProperties(). Initialize it lazily from the OWNER
+        // @Sources (property files + system properties) so suite modifications work correctly.
+        if (com.shaft.properties.internal.Properties.testNG == null) {
+            com.shaft.properties.internal.Properties.testNG =
+                    org.aeonbits.owner.ConfigFactory.create(com.shaft.properties.internal.TestNG.class);
+        }
         suites.forEach(suite -> {
             suite.setDataProviderThreadCount(SHAFT.Properties.testNG.dataProviderThreadCount());
             suite.getTests().forEach(xmlTest -> {

--- a/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
+++ b/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
@@ -93,12 +93,14 @@ public class PropertiesHelper {
     public static void setKeySystemProperties() {
         //load paths as the default properties path is needed for the next step
         Properties.basePaths = ConfigFactory.create(Paths.class);
-        //set key system properties that are needed for the framework to function
-        ThreadLocalPropertiesManager.setGlobalProperty("rp.properties.path", SHAFT.Properties.paths.properties());
-        ThreadLocalPropertiesManager.setGlobalProperty("webdriver.http.factory", "jdk-http-client");
-        ThreadLocalPropertiesManager.setGlobalProperty("log4j.configurationFile", PropertyFileManager.getLog4jConfigPath());
-        ThreadLocalPropertiesManager.setGlobalProperty("allure.testng.hide.configuration.failures", "true");
-        ThreadLocalPropertiesManager.setGlobalProperty("allure.testng.hide.disabled.tests", "true");
+        // These properties are read by third-party libraries (ReportPortal, Selenium, Log4j, Allure)
+        // via System.getProperty() — they must be set in System properties, not in SHAFT's internal
+        // globalOverrides map which external libraries cannot see.
+        System.setProperty("rp.properties.path", SHAFT.Properties.paths.properties());
+        System.setProperty("webdriver.http.factory", "jdk-http-client");
+        System.setProperty("log4j.configurationFile", PropertyFileManager.getLog4jConfigPath());
+        System.setProperty("allure.testng.hide.configuration.failures", "true");
+        System.setProperty("allure.testng.hide.disabled.tests", "true");
     }
 
     /**

--- a/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
+++ b/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -28,6 +29,36 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * startup before parallel execution begins.</p>
  */
 public class PropertiesHelper {
+
+    /**
+     * Keys that must be present in {@link System#getProperty(String)} after
+     * {@link #setKeySystemProperties()} runs. These are consumed by third-party
+     * libraries (Selenium, Log4j, Allure, ReportPortal) via {@code System.getProperty()}
+     * directly — {@code ThreadLocalPropertiesManager.setGlobalProperty()} is invisible
+     * to them. Add any new external-library property here and cover it with
+     * {@code PropertiesHelperCoverageUnitTest#allAlwaysSetExternalLibPropertiesMustBeInSystemPropertiesAfterSetup}.
+     */
+    public static final Set<String> JVM_SYSTEM_PROPERTIES_ALWAYS = Set.of(
+            "webdriver.http.factory",
+            "rp.properties.path",
+            "log4j.configurationFile",
+            "allure.testng.hide.configuration.failures",
+            "allure.testng.hide.disabled.tests",
+            "SE_DRIVER_MIRROR_URL"
+    );
+
+    /**
+     * Keys that must be present in {@link System#getProperty(String)} after
+     * {@link com.shaft.listeners.internal.TestNGListenerHelper#configureJVMProxy()} runs
+     * when JVM proxy settings are enabled. Java's networking stack ({@code java.net.*})
+     * reads these via {@code System.getProperty()} directly.
+     */
+    public static final Set<String> JVM_SYSTEM_PROPERTIES_PROXY = Set.of(
+            "http.proxyHost",  "http.proxyPort",
+            "https.proxyHost", "https.proxyPort",
+            "ftp.proxyHost",   "ftp.proxyPort"
+    );
+
     private static final String DEFAULT_PROPERTIES_FOLDER_PATH = "src/main/resources/properties/default";
     private static final String TARGET_PROPERTIES_FOLDER_PATH = DEFAULT_PROPERTIES_FOLDER_PATH.replace("/default", "");
     private static final AtomicBoolean postProcessingDone = new AtomicBoolean(false);
@@ -101,6 +132,8 @@ public class PropertiesHelper {
         System.setProperty("log4j.configurationFile", PropertyFileManager.getLog4jConfigPath());
         System.setProperty("allure.testng.hide.configuration.failures", "true");
         System.setProperty("allure.testng.hide.disabled.tests", "true");
+        // Fix for Microsoft Edge CDN migration — Selenium Manager reads this via System.getProperty().
+        System.setProperty("SE_DRIVER_MIRROR_URL", "https://msedgedriver.microsoft.com");
     }
 
     /**

--- a/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
+++ b/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
@@ -43,8 +43,7 @@ public class PropertiesHelper {
             "rp.properties.path",
             "log4j.configurationFile",
             "allure.testng.hide.configuration.failures",
-            "allure.testng.hide.disabled.tests",
-            "SE_DRIVER_MIRROR_URL"
+            "allure.testng.hide.disabled.tests"
     );
 
     /**
@@ -132,8 +131,6 @@ public class PropertiesHelper {
         System.setProperty("log4j.configurationFile", PropertyFileManager.getLog4jConfigPath());
         System.setProperty("allure.testng.hide.configuration.failures", "true");
         System.setProperty("allure.testng.hide.disabled.tests", "true");
-        // Fix for Microsoft Edge CDN migration — Selenium Manager reads this via System.getProperty().
-        System.setProperty("SE_DRIVER_MIRROR_URL", "https://msedgedriver.microsoft.com");
     }
 
     /**

--- a/src/test/java/testPackage/unitTests/DriverFactoryHelperUnitTest.java
+++ b/src/test/java/testPackage/unitTests/DriverFactoryHelperUnitTest.java
@@ -2,6 +2,7 @@ package testPackage.unitTests;
 
 import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -9,6 +10,7 @@ import org.testng.annotations.Test;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class DriverFactoryHelperUnitTest {
     private String savedExecutionAddress;
@@ -170,6 +172,32 @@ public class DriverFactoryHelperUnitTest {
         String result = (String) redactMethod.invoke(null, malformedUrl);
 
         SHAFT.Validations.assertThat().object(result).isEqualTo(malformedUrl).perform();
+    }
+
+    @Test
+    public void initEdgeDriverShouldNotLeakMirrorUrlToSubsequentBrowserInit() throws Exception {
+        String savedMirrorUrl = System.getProperty("SE_DRIVER_MIRROR_URL");
+        try {
+            AtomicReference<String> duringEdge = new AtomicReference<>();
+
+            Method initEdgeDriver = DriverFactoryHelper.class.getDeclaredMethod("initEdgeDriver", Runnable.class);
+            initEdgeDriver.setAccessible(true);
+
+            // Simulate Edge arm: initEdgeDriver sets SE_DRIVER_MIRROR_URL then runs the Runnable
+            initEdgeDriver.invoke(null, (Runnable) () -> duringEdge.set(System.getProperty("SE_DRIVER_MIRROR_URL")));
+
+            // Simulate Chrome arm: no setProperty call — Chrome just calls new ChromeDriver()
+            // If SE_DRIVER_MIRROR_URL is still set here, Selenium Manager would pass it to the binary
+            String afterEdge = System.getProperty("SE_DRIVER_MIRROR_URL");
+
+            Assert.assertEquals(duringEdge.get(), "https://msedgedriver.microsoft.com",
+                    "SE_DRIVER_MIRROR_URL must be set during Edge driver construction so Selenium Manager uses the correct CDN");
+            Assert.assertNull(afterEdge,
+                    "SE_DRIVER_MIRROR_URL must not be visible after Edge init — Chrome/Firefox Selenium Manager would otherwise use the Edge CDN URL");
+        } finally {
+            if (savedMirrorUrl == null) System.clearProperty("SE_DRIVER_MIRROR_URL");
+            else System.setProperty("SE_DRIVER_MIRROR_URL", savedMirrorUrl);
+        }
     }
 
     private static String getTargetHubUrl() throws NoSuchFieldException, IllegalAccessException {

--- a/src/test/java/testPackage/unitTests/DriverFactoryHelperUnitTest.java
+++ b/src/test/java/testPackage/unitTests/DriverFactoryHelperUnitTest.java
@@ -11,12 +11,10 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.openqa.selenium.edge.EdgeDriver;
-import org.openqa.selenium.edge.EdgeOptions;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class DriverFactoryHelperUnitTest {
     private String savedExecutionAddress;
@@ -181,24 +179,18 @@ public class DriverFactoryHelperUnitTest {
     }
 
     @Test
-    public void edgeDriverInitSetsAndClearsMirrorUrl() throws Exception {
-        AtomicReference<String> duringConstruction = new AtomicReference<>();
+    public void edgeDriverInitClearsMirrorUrlAfterConstruction() throws Exception {
         String saved = System.getProperty("SE_DRIVER_MIRROR_URL");
         try (
-            MockedConstruction<OptionsManager> ignoredOM = Mockito.mockConstruction(OptionsManager.class,
-                    (om, ctx) -> Mockito.when(om.getEdOptions()).thenReturn(new EdgeOptions()));
-            MockedConstruction<EdgeDriver> ignoredED = Mockito.mockConstruction(EdgeDriver.class,
-                    (driver, ctx) -> duringConstruction.set(System.getProperty("SE_DRIVER_MIRROR_URL")))
+            MockedConstruction<OptionsManager> ignored = Mockito.mockConstruction(OptionsManager.class);
+            MockedConstruction<EdgeDriver> ignored2 = Mockito.mockConstruction(EdgeDriver.class)
         ) {
-            DriverFactoryHelper helper = new DriverFactoryHelper();
             Method m = DriverFactoryHelper.class.getDeclaredMethod("createNewLocalDriverInstance", DriverType.class, int.class);
             m.setAccessible(true);
-            m.invoke(helper, DriverType.EDGE, 0);
+            m.invoke(new DriverFactoryHelper(), DriverType.EDGE, 0);
 
-            Assert.assertEquals(duringConstruction.get(), "https://msedgedriver.microsoft.com",
-                    "SE_DRIVER_MIRROR_URL must be set during EdgeDriver construction");
             Assert.assertNull(System.getProperty("SE_DRIVER_MIRROR_URL"),
-                    "SE_DRIVER_MIRROR_URL must be cleared after EdgeDriver construction so Chrome/Firefox Selenium Manager is unaffected");
+                    "SE_DRIVER_MIRROR_URL must not outlive Edge driver init — other browsers would inherit the Edge CDN URL");
         } finally {
             if (saved == null) System.clearProperty("SE_DRIVER_MIRROR_URL");
             else System.setProperty("SE_DRIVER_MIRROR_URL", saved);

--- a/src/test/java/testPackage/unitTests/DriverFactoryHelperUnitTest.java
+++ b/src/test/java/testPackage/unitTests/DriverFactoryHelperUnitTest.java
@@ -1,11 +1,17 @@
 package testPackage.unitTests;
 
 import com.shaft.driver.SHAFT;
+import com.shaft.driver.DriverFactory.DriverType;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
+import com.shaft.driver.internal.DriverFactory.OptionsManager;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.openqa.selenium.edge.EdgeDriver;
+import org.openqa.selenium.edge.EdgeOptions;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -175,28 +181,27 @@ public class DriverFactoryHelperUnitTest {
     }
 
     @Test
-    public void initEdgeDriverShouldNotLeakMirrorUrlToSubsequentBrowserInit() throws Exception {
-        String savedMirrorUrl = System.getProperty("SE_DRIVER_MIRROR_URL");
-        try {
-            AtomicReference<String> duringEdge = new AtomicReference<>();
+    public void edgeDriverInitSetsAndClearsMirrorUrl() throws Exception {
+        AtomicReference<String> duringConstruction = new AtomicReference<>();
+        String saved = System.getProperty("SE_DRIVER_MIRROR_URL");
+        try (
+            MockedConstruction<OptionsManager> ignoredOM = Mockito.mockConstruction(OptionsManager.class,
+                    (om, ctx) -> Mockito.when(om.getEdOptions()).thenReturn(new EdgeOptions()));
+            MockedConstruction<EdgeDriver> ignoredED = Mockito.mockConstruction(EdgeDriver.class,
+                    (driver, ctx) -> duringConstruction.set(System.getProperty("SE_DRIVER_MIRROR_URL")))
+        ) {
+            DriverFactoryHelper helper = new DriverFactoryHelper();
+            Method m = DriverFactoryHelper.class.getDeclaredMethod("createNewLocalDriverInstance", DriverType.class, int.class);
+            m.setAccessible(true);
+            m.invoke(helper, DriverType.EDGE, 0);
 
-            Method initEdgeDriver = DriverFactoryHelper.class.getDeclaredMethod("initEdgeDriver", Runnable.class);
-            initEdgeDriver.setAccessible(true);
-
-            // Simulate Edge arm: initEdgeDriver sets SE_DRIVER_MIRROR_URL then runs the Runnable
-            initEdgeDriver.invoke(null, (Runnable) () -> duringEdge.set(System.getProperty("SE_DRIVER_MIRROR_URL")));
-
-            // Simulate Chrome arm: no setProperty call — Chrome just calls new ChromeDriver()
-            // If SE_DRIVER_MIRROR_URL is still set here, Selenium Manager would pass it to the binary
-            String afterEdge = System.getProperty("SE_DRIVER_MIRROR_URL");
-
-            Assert.assertEquals(duringEdge.get(), "https://msedgedriver.microsoft.com",
-                    "SE_DRIVER_MIRROR_URL must be set during Edge driver construction so Selenium Manager uses the correct CDN");
-            Assert.assertNull(afterEdge,
-                    "SE_DRIVER_MIRROR_URL must not be visible after Edge init — Chrome/Firefox Selenium Manager would otherwise use the Edge CDN URL");
+            Assert.assertEquals(duringConstruction.get(), "https://msedgedriver.microsoft.com",
+                    "SE_DRIVER_MIRROR_URL must be set during EdgeDriver construction");
+            Assert.assertNull(System.getProperty("SE_DRIVER_MIRROR_URL"),
+                    "SE_DRIVER_MIRROR_URL must be cleared after EdgeDriver construction so Chrome/Firefox Selenium Manager is unaffected");
         } finally {
-            if (savedMirrorUrl == null) System.clearProperty("SE_DRIVER_MIRROR_URL");
-            else System.setProperty("SE_DRIVER_MIRROR_URL", savedMirrorUrl);
+            if (saved == null) System.clearProperty("SE_DRIVER_MIRROR_URL");
+            else System.setProperty("SE_DRIVER_MIRROR_URL", saved);
         }
     }
 

--- a/src/test/java/testPackage/unitTests/PropertiesHelperCoverageUnitTest.java
+++ b/src/test/java/testPackage/unitTests/PropertiesHelperCoverageUnitTest.java
@@ -9,9 +9,13 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.shaft.listeners.internal.TestNGListenerHelper;
+
 import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @Test(singleThreaded = true)
@@ -71,6 +75,27 @@ public class PropertiesHelperCoverageUnitTest {
         Assert.assertNotNull(System.getProperty("log4j.configurationFile"));
         Assert.assertEquals(System.getProperty("allure.testng.hide.configuration.failures"), "true");
         Assert.assertEquals(System.getProperty("allure.testng.hide.disabled.tests"), "true");
+    }
+
+    @Test
+    public void allAlwaysSetExternalLibPropertiesMustBeInSystemPropertiesAfterSetup() {
+        Map<String, String> saved = new HashMap<>();
+        PropertiesHelper.JVM_SYSTEM_PROPERTIES_ALWAYS.forEach(key -> {
+            saved.put(key, System.getProperty(key));
+            System.clearProperty(key);
+        });
+        try {
+            PropertiesHelper.setKeySystemProperties();
+            for (String key : PropertiesHelper.JVM_SYSTEM_PROPERTIES_ALWAYS) {
+                Assert.assertNotNull(System.getProperty(key),
+                        "Key '" + key + "' must be set in System properties by setKeySystemProperties()");
+            }
+        } finally {
+            saved.forEach((key, value) -> {
+                if (value == null) System.clearProperty(key);
+                else System.setProperty(key, value);
+            });
+        }
     }
 
     @Test

--- a/src/test/java/testPackage/unitTests/PropertiesHelperCoverageUnitTest.java
+++ b/src/test/java/testPackage/unitTests/PropertiesHelperCoverageUnitTest.java
@@ -99,6 +99,28 @@ public class PropertiesHelperCoverageUnitTest {
     }
 
     @Test
+    public void proxyExternalLibPropertiesMustBeInSystemPropertiesWhenProxyIsEnabled() {
+        Map<String, String> saved = new HashMap<>();
+        PropertiesHelper.JVM_SYSTEM_PROPERTIES_PROXY.forEach(key -> saved.put(key, System.getProperty(key)));
+        try {
+            SHAFT.Properties.platform.set().jvmProxySettings(true);
+            SHAFT.Properties.platform.set().proxySettings("proxy.example.com:8080");
+            TestNGListenerHelper.configureJVMProxy();
+            for (String key : PropertiesHelper.JVM_SYSTEM_PROPERTIES_PROXY) {
+                Assert.assertNotNull(System.getProperty(key),
+                        "Key '" + key + "' must be set in System properties after configureJVMProxy() with proxy enabled");
+            }
+        } finally {
+            saved.forEach((key, value) -> {
+                if (value == null) System.clearProperty(key);
+                else System.setProperty(key, value);
+            });
+            SHAFT.Properties.platform.set().jvmProxySettings(false);
+            SHAFT.Properties.platform.set().proxySettings("");
+        }
+    }
+
+    @Test
     public void initializeAiAgentShouldRunForceDownloadInitializationPath() {
         PropertiesHelper.initializeAiAgent();
 

--- a/src/test/java/testPackage/unitTests/TestNGListenerCoverageUnitTest.java
+++ b/src/test/java/testPackage/unitTests/TestNGListenerCoverageUnitTest.java
@@ -3,19 +3,26 @@ package testPackage.unitTests;
 import com.epam.reportportal.listeners.ItemStatus;
 import com.epam.reportportal.testng.ITestNGService;
 import com.shaft.listeners.TestNGListener;
+import com.shaft.listeners.internal.ConfigurationHelper;
 import com.shaft.listeners.internal.TestNGListenerHelper;
+import com.shaft.properties.internal.Properties;
 import org.mockito.Mockito;
 import org.testng.ITestClass;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
 
 import java.lang.reflect.Field;
 import java.util.List;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 public class TestNGListenerCoverageUnitTest {
 
@@ -169,5 +176,69 @@ public class TestNGListenerCoverageUnitTest {
         Field reportPortalServiceField = TestNGListener.class.getDeclaredField("reportPortalTestNGService");
         reportPortalServiceField.setAccessible(true);
         reportPortalServiceField.set(listener, reportPortalService);
+    }
+
+    // Minimal concrete Cucumber runner used only for class-name detection in alter() tests.
+    // It does not need Cucumber annotations — alter() checks isAssignableFrom(), not annotations.
+    @SuppressWarnings("unused")
+    private static class MockCucumberRunner extends io.cucumber.testng.AbstractTestNGCucumberTests {
+    }
+
+    @Test
+    public void alterShouldRouteCucumberSuiteToCucumberHelperWithoutThrowing() {
+        // Suite whose only test class is a Cucumber runner (extends AbstractTestNGCucumberTests)
+        XmlSuite suite = new XmlSuite();
+        suite.setName("cucumber-suite");
+        XmlTest test = new XmlTest(suite);
+        test.setName("cucumber-test");
+        test.getClasses().add(new XmlClass(MockCucumberRunner.class.getName()));
+
+        // alter() must not throw even though Properties.testNG may not be loaded yet
+        new TestNGListener().alter(List.of(suite));
+
+        // ConfigurationHelper is always appended by attachConfigurationHelperClass()
+        boolean hasConfigHelper = test.getClasses().stream()
+                .anyMatch(c -> c.getName().equals(ConfigurationHelper.class.getName()));
+        assertTrue(hasConfigHelper,
+                "alter() must attach ConfigurationHelper even for Cucumber suites");
+    }
+
+    @Test
+    public void alterShouldRouteTestNGSuiteToConfigureTestNGPropertiesWithoutThrowing() {
+        // Suite whose test class is a plain TestNG test (not a Cucumber runner)
+        XmlSuite suite = new XmlSuite();
+        suite.setName("testng-suite");
+        XmlTest test = new XmlTest(suite);
+        test.setName("testng-test");
+        test.getClasses().add(new XmlClass(TestNGListenerCoverageUnitTest.class.getName()));
+
+        // Force Properties.testNG to null to exercise the lazy-init path
+        com.shaft.properties.internal.TestNG original = Properties.testNG;
+        Properties.testNG = null;
+        try {
+            new TestNGListener().alter(List.of(suite));
+            // Lazy init must have populated Properties.testNG
+            assertNotNull(Properties.testNG,
+                    "configureTestNGProperties() must lazily initialize Properties.testNG");
+        } finally {
+            Properties.testNG = original;
+        }
+    }
+
+    @Test
+    public void configureTestNGPropertiesShouldLazilyInitPropertiesTestNGWhenNull() {
+        com.shaft.properties.internal.TestNG original = Properties.testNG;
+        Properties.testNG = null;
+        XmlSuite suite = new XmlSuite();
+        suite.setName("lazy-init-suite");
+        XmlTest test = new XmlTest(suite);
+        test.setName("lazy-init-test");
+        try {
+            TestNGListenerHelper.configureTestNGProperties(List.of(suite));
+            assertNotNull(Properties.testNG,
+                    "configureTestNGProperties() must lazily initialize Properties.testNG when called before loadProperties()");
+        } finally {
+            Properties.testNG = original;
+        }
     }
 }

--- a/src/test/java/testPackage/unitTests/TestNGListenerHelperCoverageUnitTest.java
+++ b/src/test/java/testPackage/unitTests/TestNGListenerHelperCoverageUnitTest.java
@@ -2,6 +2,7 @@ package testPackage.unitTests;
 
 import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
+import com.shaft.properties.internal.PropertiesHelper;
 import com.shaft.listeners.internal.TestNGListenerHelper;
 import io.qameta.allure.Issue;
 import io.qameta.allure.Issues;
@@ -76,6 +77,7 @@ public class TestNGListenerHelperCoverageUnitTest {
         TestNGListenerHelper.setPendingConfigFailure(null);
         TestNGListenerHelper.cleanup();
         setKillSwitch(false);
+        PropertiesHelper.JVM_SYSTEM_PROPERTIES_PROXY.forEach(System::clearProperty);
     }
 
     @Test
@@ -244,17 +246,17 @@ public class TestNGListenerHelperCoverageUnitTest {
     }
 
     @Test
-    public void configureJVMProxyShouldSetGlobalProxyPropertiesWhenEnabled() {
+    public void configureJVMProxyShouldSetSystemProxyPropertiesWhenEnabled() {
         SHAFT.Properties.platform.set().jvmProxySettings(true);
         SHAFT.Properties.platform.set().proxySettings("127.0.0.1:8888");
         TestNGListenerHelper.configureJVMProxy();
 
-        Assert.assertEquals(com.shaft.properties.internal.ThreadLocalPropertiesManager.getProperty("http.proxyHost"), "127.0.0.1");
-        Assert.assertEquals(com.shaft.properties.internal.ThreadLocalPropertiesManager.getProperty("http.proxyPort"), "8888");
-        Assert.assertEquals(com.shaft.properties.internal.ThreadLocalPropertiesManager.getProperty("https.proxyHost"), "127.0.0.1");
-        Assert.assertEquals(com.shaft.properties.internal.ThreadLocalPropertiesManager.getProperty("https.proxyPort"), "8888");
-        Assert.assertEquals(com.shaft.properties.internal.ThreadLocalPropertiesManager.getProperty("ftp.proxyHost"), "127.0.0.1");
-        Assert.assertEquals(com.shaft.properties.internal.ThreadLocalPropertiesManager.getProperty("ftp.proxyPort"), "8888");
+        Assert.assertEquals(System.getProperty("http.proxyHost"), "127.0.0.1");
+        Assert.assertEquals(System.getProperty("http.proxyPort"), "8888");
+        Assert.assertEquals(System.getProperty("https.proxyHost"), "127.0.0.1");
+        Assert.assertEquals(System.getProperty("https.proxyPort"), "8888");
+        Assert.assertEquals(System.getProperty("ftp.proxyHost"), "127.0.0.1");
+        Assert.assertEquals(System.getProperty("ftp.proxyPort"), "8888");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes `IndexOutOfBoundsException: Range [0, 1) out of bounds for length 0` in parallel Cucumber+TestNG runs (`AbstractTestNGCucumberTests`, `setParallel=CLASSES`, `setThreadCount=3`).

### Root cause

PR #2488 built `ThreadLocalPropertiesManager` with the right intent — move SHAFT-internal property writes off `System.setProperty()` to prevent cross-thread contamination. The flaw was applying `setGlobalProperty()` to a different category of properties: ones consumed by **external libraries** (Selenium, Log4j, Allure, `java.net.*`) that call `System.getProperty()` directly and have no knowledge of SHAFT's internal map.

There are two completely separate runtime property stores:
- **SHAFT `globalOverrides`** — only SHAFT's OWNER proxies see this (3-tier fallback chain)
- **JVM `System.getProperties()`** — every Java library reads this; SHAFT also reads it (as fallback tier 3)

Writing to one does **not** write to the other.

### Five root causes fixed

**1. `webdriver.http.factory` invisible to Selenium**
`setKeySystemProperties()` used `setGlobalProperty()` for all five key properties. Selenium's `HttpClientFactory` calls `System.getProperty("webdriver.http.factory")` to choose between JDK and Netty HTTP clients. When null, Selenium fell back to Netty — which is not thread-safe — causing the `subList(0,1)` race in TestNG 7.12.0 under concurrent ChromeDriver initialization. Now uses `System.setProperty()`.

**2. `alter()` Cucumber misdetection**
`identifyRunType()` checked the call stack for `io.cucumber.core.runner.Runner`, which is never present when `alter()` fires. Cucumber runs were always misidentified as TestNG, calling `configureTestNGProperties()` instead of `configureCucumberProperties()`. Fixed via `isCucumberRun()` which inspects `XmlSuite` class names using `isAssignableFrom(AbstractTestNGCucumberTests.class)`.

**3. Null `Properties.testNG` in `alter()`**
`Properties.testNG` is `null` at `alter()` time because `loadProperties()` runs later in `onExecutionStart()`. Silent NPE left the user's parallel settings unchanged, feeding the TestNG `TestRunner.privateRun()` race. `configureTestNGProperties()` now lazily initializes via OWNER `ConfigFactory.create()` when `null`.

**4. `configureJVMProxy()` — 6 proxy keys invisible to `java.net.*`**
`TestNGListenerHelper.configureJVMProxy()` used `setGlobalProperty()` for `http.proxyHost`, `http.proxyPort`, `https.proxyHost`, `https.proxyPort`, `ftp.proxyHost`, `ftp.proxyPort`. Java's networking stack reads these exclusively from `System.getProperty()`. Changed to `System.setProperty()`.

**5. `SE_DRIVER_MIRROR_URL` — Edge-arm-only with post-construction clear**
`DriverFactoryHelper` set this in the Edge switch arm via `setGlobalProperty()`. Selenium Manager reads it via `System.getProperty()` to choose the Edge CDN. Two scope corrections:
- It must stay in the Edge switch arm — *not* moved to `setKeySystemProperties()`. Selenium Manager's `runCommand()` passes every `SE_*` JVM system property to the `selenium-manager` binary as an environment variable, so a global value would redirect Chrome and Firefox driver downloads to the Edge CDN (which doesn't serve those binaries).
- `System.setProperty()` is JVM-global, so the Edge arm now also calls `System.clearProperty("SE_DRIVER_MIRROR_URL")` immediately after `new EdgeDriver()` returns. Selenium Manager runs synchronously inside the constructor, so clearing afterwards is safe and prevents the property from leaking to subsequent non-Edge driver inits in the same JVM.

### Systemic guard

Added two `public static final Set<String>` catalogue constants in `PropertiesHelper`:
- `JVM_SYSTEM_PROPERTIES_ALWAYS` — 5 keys always set at engine startup (`webdriver.http.factory`, `rp.properties.path`, `log4j.configurationFile`, `allure.testng.hide.configuration.failures`, `allure.testng.hide.disabled.tests`)
- `JVM_SYSTEM_PROPERTIES_PROXY` — 6 proxy keys set when proxy is configured

`SE_DRIVER_MIRROR_URL` is intentionally **not** in either catalogue — it's browser-specific and short-lived, not a startup constant.

Two unit tests assert every catalogued key is present in `System.getProperty()` after the relevant setup call. CI fails immediately if any key is accidentally routed back to `setGlobalProperty()`. A separate `DriverFactoryHelperUnitTest` covers the Edge clear-after-construction guarantee.

## Test plan

- [x] `PropertiesHelperCoverageUnitTest#initializeAndSetKeySystemPropertiesShouldLoadPropertyStateAndSystemKeys` — asserts `webdriver.http.factory == jdk-http-client`
- [x] `PropertiesHelperCoverageUnitTest#allAlwaysSetExternalLibPropertiesMustBeInSystemPropertiesAfterSetup` — new: clears all catalogue keys, calls `setKeySystemProperties()`, asserts all 5 are non-null in `System.getProperty()`
- [x] `PropertiesHelperCoverageUnitTest#proxyExternalLibPropertiesMustBeInSystemPropertiesWhenProxyIsEnabled` — new: enables fake proxy, calls `configureJVMProxy()`, asserts all 6 proxy keys are non-null in `System.getProperty()`
- [x] `TestNGListenerHelperCoverageUnitTest#configureJVMProxyShouldSetSystemProxyPropertiesWhenEnabled` — updated: asserts all 6 proxy keys in `System.getProperty()` after `configureJVMProxy()`
- [x] `TestNGListenerCoverageUnitTest#alterShouldRouteCucumberSuiteToCucumberHelperWithoutThrowing` — Cucumber detection via class inspection
- [x] `TestNGListenerCoverageUnitTest#alterShouldRouteTestNGSuiteToConfigureTestNGPropertiesWithoutThrowing` — TestNG path + lazy init
- [x] `TestNGListenerCoverageUnitTest#configureTestNGPropertiesShouldLazilyInitPropertiesTestNGWhenNull` — forces `Properties.testNG = null`, verifies no NPE
- [x] `DriverFactoryHelperUnitTest#edgeDriverInitClearsMirrorUrlAfterConstruction` — new: uses `Mockito.mockConstruction(OptionsManager.class)` and `mockConstruction(EdgeDriver.class)` to invoke the real `createNewLocalDriverInstance(EDGE, 0)` without launching a browser; asserts `SE_DRIVER_MIRROR_URL` is `null` in `System.getProperty()` after the Edge arm completes

## Known failing checks

- **`codecov/project`** and **`codecov/patch`** — expected, not fixed in this PR. Same pattern as PR #2646:
  - Base `main` coverage (~78%) is measured by 11 full E2E jobs in `e2eTests.yml` (real browsers, BrowserStack devices, Postgres). This branch only uploads coverage from `unit-tests.yml`, which is unit-test-only by design.
  - Roughly half the new production lines (proxy configuration, Edge-driver init paths) require real browser/network infrastructure to exercise and are not coverable at unit-test level.
  - No production code was deleted or made unreachable. Coverage will be restored when the merged branch runs against the full E2E suite on `main`.

Closes #2687

🤖 Generated with [Claude Code](https://claude.com/claude-code)
