### PR TITLE
Docs: use stable user guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ When enabled, SHAFT checks `allure --version` and only uses system `allure` when
 
 | Resource | Description |
 |----------|-------------|
-| 📖 **[User Guide](https://shaftengine.netlify.app/)** | Comprehensive documentation, tutorials, and configuration reference |
+| 📖 **[User Guide](https://ShaftHQ.github.io/)** | Comprehensive documentation, tutorials, and configuration reference |
 | 🏗️ **[Architecture](docs/ARCHITECTURE.md)** | Framework design, module overview, and Mermaid diagrams |
 | 🛠️ **[Tech Stack](docs/TECH_STACK.md)** | Technologies and libraries powering SHAFT |
 | ✨ **[Features](docs/FEATURES.md)** | Full feature list with platform compatibility matrix |

--- a/docs/FLUTTER_TESTING.md
+++ b/docs/FLUTTER_TESTING.md
@@ -467,7 +467,7 @@ public class FlutterAppTestSuite {
 
 - [Appium Flutter Driver Documentation](https://github.com/appium-userland/appium-flutter-driver)
 - [Flutter Testing Guide](https://flutter.dev/docs/testing)
-- [SHAFT Engine Documentation](https://shaftengine.netlify.app/)
+- [SHAFT Engine Documentation](https://ShaftHQ.github.io/)
 - [Flutter Finder Java Library](https://github.com/ashwithpoojary98/javaflutterfinder) - Package: `io.github.ashwithpoojary98`
 
 ## Support
@@ -475,7 +475,7 @@ public class FlutterAppTestSuite {
 For issues or questions:
 - Open an issue on [GitHub](https://github.com/ShaftHQ/SHAFT_ENGINE/issues)
 - Join our [Slack community](https://join.slack.com/t/shaft-engine/shared_invite/zt-oii5i2gg-0ZGnih_Y34NjK7QqDn01Dw)
-- Check our [documentation](https://shaftengine.netlify.app/)
+- Check our [documentation](https://ShaftHQ.github.io/)
 
 ---
 


### PR DESCRIPTION
### Motivation
- Replace flaky/broken root Netlify documentation links with the stable GitHub Pages user-guide entry point to reduce false positives in the link audit and improve reliability for readers.

### Description
- Update root `https://shaftengine.netlify.app/` references to `https://ShaftHQ.github.io/` in `README.md` and `docs/FLUTTER_TESTING.md` while keeping deep Netlify anchors untouched.

### Testing
- Ran `git diff --check` and validated the GitHub Pages entry with `curl -I --max-time 20 https://ShaftHQ.github.io/` and `curl -I -L --max-time 20 https://ShaftHQ.github.io/ | sed -n '1,60p'`, and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0227bc8ed08320894a865104c7ced2)