### PR TITLE
Serialize local WebDriver initialization to prevent parallel race during Chrome init

### DIFF
--- a/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -58,6 +58,7 @@ public class DriverFactoryHelper {
     private static final String WEB_DRIVER_MANAGER_DOCKERIZED_MESSAGE = "Identifying target OS/Browser and setting up the dockerized environment automatically. Please note that if a new docker container will be downloaded it may take some time depending on your connection...";
     private static final String SELENIUM_WEBSOCKET_LISTENER_LOGGER = "org.openqa.selenium.remote.http.WebSocket$Listener";
     private static final ThreadLocal<WebDriverManager> webDriverManager = new ThreadLocal<>();
+    private static final Object LOCAL_DRIVER_INITIALIZATION_LOCK = new Object();
     @Getter(AccessLevel.PUBLIC)
     private static final Dimension TARGET_WINDOW_SIZE = new Dimension(1920, 1080);
     private static final long appiumServerInitializationTimeout = TimeUnit.MINUTES.toSeconds(SHAFT.Properties.timeouts.timeoutForRemoteServerToBeUp()); // seconds
@@ -420,6 +421,12 @@ public class DriverFactoryHelper {
         }
     }
 
+    private static void runWithLocalDriverInitializationLock(Runnable localDriverInitializer) {
+        synchronized (LOCAL_DRIVER_INITIALIZATION_LOCK) {
+            localDriverInitializer.run();
+        }
+    }
+
     private void createNewLocalDriverInstance(DriverType driverType, int retryAttempts) {
         String targetPlatform = Properties.platform.targetPlatform().toLowerCase();
         String initialLog = "Attempting to run locally on: \"" + targetPlatform + " | " + JavaHelper.convertToSentenceCase(driverType.getValue()) + "\"";
@@ -430,24 +437,26 @@ public class DriverFactoryHelper {
         ReportManager.logDiscrete(initialLog + ".");
         try {
             ReportManager.logDiscrete(WEB_DRIVER_MANAGER_MESSAGE);
-            switch (driverType) {
-                case FIREFOX -> setDriver(new FirefoxDriver(optionsManager.getFfOptions()));
-                case IE -> setDriver(new InternetExplorerDriver(optionsManager.getIeOptions()));
-                case CHROME -> {
-                    setDriver(new ChromeDriver(optionsManager.getChOptions()));
-                    disableCacheEdgeAndChrome();
+            runWithLocalDriverInitializationLock(() -> {
+                switch (driverType) {
+                    case FIREFOX -> setDriver(new FirefoxDriver(optionsManager.getFfOptions()));
+                    case IE -> setDriver(new InternetExplorerDriver(optionsManager.getIeOptions()));
+                    case CHROME -> {
+                        setDriver(new ChromeDriver(optionsManager.getChOptions()));
+                        disableCacheEdgeAndChrome();
+                    }
+                    case EDGE -> {
+                        // Fix for Microsoft Edge CDN migration from msedgedriver.azureedge.net to msedgedriver.microsoft.com
+                        // This ensures Selenium Manager uses the correct download URL for EdgeDriver.
+                        ThreadLocalPropertiesManager.setGlobalProperty("SE_DRIVER_MIRROR_URL", "https://msedgedriver.microsoft.com");
+                        setDriver(new EdgeDriver(optionsManager.getEdOptions()));
+                        disableCacheEdgeAndChrome();
+                    }
+                    case SAFARI -> setDriver(new SafariDriver(optionsManager.getSfOptions()));
+                    default ->
+                            failAction("Unsupported Driver Type \"" + JavaHelper.convertToSentenceCase(driverType.getValue()) + "\".");
                 }
-                case EDGE -> {
-                    // Fix for Microsoft Edge CDN migration from msedgedriver.azureedge.net to msedgedriver.microsoft.com
-                    // This ensures Selenium Manager uses the correct download URL for EdgeDriver.
-                    ThreadLocalPropertiesManager.setGlobalProperty("SE_DRIVER_MIRROR_URL", "https://msedgedriver.microsoft.com");
-                    setDriver(new EdgeDriver(optionsManager.getEdOptions()));
-                    disableCacheEdgeAndChrome();
-                }
-                case SAFARI -> setDriver(new SafariDriver(optionsManager.getSfOptions()));
-                default ->
-                        failAction("Unsupported Driver Type \"" + JavaHelper.convertToSentenceCase(driverType.getValue()) + "\".");
-            }
+            });
             String successMessage = initialLog.replace("Attempting to run locally on", "Successfully Opened") + ".";
             List<Object> launchScreenshot = captureLaunchScreenshot();
             if (launchScreenshot != null) {

--- a/src/test/java/testPackage/unitTests/DriverFactoryHelperAdditionalUnitTest.java
+++ b/src/test/java/testPackage/unitTests/DriverFactoryHelperAdditionalUnitTest.java
@@ -41,6 +41,12 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
 @Test(singleThreaded = true)
@@ -435,6 +441,52 @@ public class DriverFactoryHelperAdditionalUnitTest {
             createNewLocalDriverInstance.invoke(helper, com.shaft.driver.DriverFactory.DriverType.IE, 0);
             createNewLocalDriverInstance.invoke(helper, com.shaft.driver.DriverFactory.DriverType.SAFARI, 0);
             SHAFT.Validations.assertThat().object(helper.getDriver()).isNotNull().perform();
+        }
+    }
+
+    @Test
+    public void localDriverInitializationLockShouldSerializeParallelBrowserResolution() throws Exception {
+        Method runWithLocalDriverInitializationLock = DriverFactoryHelper.class.getDeclaredMethod("runWithLocalDriverInitializationLock", Runnable.class);
+        runWithLocalDriverInitializationLock.setAccessible(true);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicInteger activeInitializers = new AtomicInteger(0);
+        AtomicInteger maximumConcurrentInitializers = new AtomicInteger(0);
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+        Future<?> firstInitializer = executorService.submit(() -> invokeLocalDriverInitializationLock(runWithLocalDriverInitializationLock, ready, start, activeInitializers, maximumConcurrentInitializers));
+        Future<?> secondInitializer = executorService.submit(() -> invokeLocalDriverInitializationLock(runWithLocalDriverInitializationLock, ready, start, activeInitializers, maximumConcurrentInitializers));
+        ready.await(5, TimeUnit.SECONDS);
+        start.countDown();
+        firstInitializer.get(5, TimeUnit.SECONDS);
+        secondInitializer.get(5, TimeUnit.SECONDS);
+        executorService.shutdownNow();
+
+        SHAFT.Validations.assertThat().object(maximumConcurrentInitializers.get()).isEqualTo(1).perform();
+    }
+
+    private static void invokeLocalDriverInitializationLock(Method runWithLocalDriverInitializationLock, CountDownLatch ready, CountDownLatch start,
+                                                            AtomicInteger activeInitializers, AtomicInteger maximumConcurrentInitializers) {
+        ready.countDown();
+        try {
+            start.await(5, TimeUnit.SECONDS);
+            runWithLocalDriverInitializationLock.invoke(null, (Runnable) () -> {
+                int active = activeInitializers.incrementAndGet();
+                maximumConcurrentInitializers.updateAndGet(maximum -> Math.max(maximum, active));
+                try {
+                    Thread.sleep(150);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError("Serialized local driver initialization should not be interrupted.", e);
+                } finally {
+                    activeInitializers.decrementAndGet();
+                }
+            });
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Local driver initialization lock test should not be interrupted.", e);
+        } catch (Exception e) {
+            throw new AssertionError("Local driver initialization lock should not fail.", e);
         }
     }
 


### PR DESCRIPTION
### Motivation

- Prevent a race during local ChromeDriver initialization where concurrent threads observe incomplete WebDriverManager state and fail (manifested as empty browser path / IndexOutOfBoundsException) when tests run in parallel.

### Description

- Add a process-wide lock `LOCAL_DRIVER_INITIALIZATION_LOCK` and wrap local driver construction in `runWithLocalDriverInitializationLock(...)` to serialize the critical section that instantiates local WebDriver instances (Chrome/Edge/Firefox/Safari/IE).
- Refactor the driver-creation block in `src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java` to call the new helper and keep behavior identical outside the lock.
- Add a focused concurrency unit test `localDriverInitializationLockShouldSerializeParallelBrowserResolution` and update `DriverFactoryHelperAdditionalUnitTest` to validate serialized execution and to stabilize mocked driver constructions used in parallel test scenarios.

### Testing

- Ran focused unit tests: `mvn test -Dtest=DriverFactoryHelperAdditionalUnitTest` while iterating; initial run surfaced one failing timeout which was fixed by adjusting the test harness and adding the explicit lock helper, after which the test class completed successfully; final targeted runs passed.
- Executed the single new/modified test `mvn test -Dtest=DriverFactoryHelperAdditionalUnitTest#localDriverInitializationLockShouldSerializeParallelBrowserResolution` and it passed.
- Per the mandatory pre-commit step, built the project with `mvn clean install -DskipTests -Dgpg.skip` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0227f899508320af23c372cafd2c95)