### PR TITLE
Fix E2E workflow flake regressions

### DIFF
--- a/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -771,8 +771,8 @@ public class DriverFactoryHelper {
                     driverLogs.get(logType).getAll().forEach(logEntry -> logBuilder.append(logEntry).append(System.lineSeparator()));
                     ReportManagerHelper.attach("Selenium WebDriver Logs", logType, logBuilder.toString());
                 });
-            } catch (WebDriverException e) {
-                // exception when the defined logging is not supported
+            } catch (Exception e) {
+                // exception when the defined logging is not supported or the driver mock/session cannot expose logs
                 ReportManagerHelper.logDiscrete(e, Level.DEBUG);
             }
         }

--- a/src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java
+++ b/src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java
@@ -457,7 +457,17 @@ public class OptionsManager {
         if (SHAFT.Properties.web.isMobileEmulation() && DriverFactoryHelper.isNotMobileExecution()) {
             Map<String, Object> mobileEmulation = new HashMap<>();
             if (!SHAFT.Properties.web.mobileEmulationIsCustomDevice() && (!SHAFT.Properties.web.mobileEmulationDeviceName().isBlank())) {
-                mobileEmulation.put("deviceName", SHAFT.Properties.web.mobileEmulationDeviceName());
+                if (options.getBrowserName().equals(DriverFactory.DriverType.EDGE.getValue())
+                        && SHAFT.Properties.web.mobileEmulationDeviceName().equalsIgnoreCase("Pixel 5")) {
+                    Map<String, Object> deviceMetrics = new HashMap<>();
+                    deviceMetrics.put("width", 393);
+                    deviceMetrics.put("height", 851);
+                    deviceMetrics.put("pixelRatio", 2.75);
+                    mobileEmulation.put("deviceMetrics", deviceMetrics);
+                    mobileEmulation.put("userAgent", "Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Mobile Safari/537.36");
+                } else {
+                    mobileEmulation.put("deviceName", SHAFT.Properties.web.mobileEmulationDeviceName());
+                }
             } else if (SHAFT.Properties.web.mobileEmulationIsCustomDevice()) {
                 if ((SHAFT.Properties.web.mobileEmulationWidth() != 0) && (SHAFT.Properties.web.mobileEmulationHeight() != 0)) {
                     Map<String, Object> deviceMetrics = new HashMap<>();

--- a/src/main/java/com/shaft/gui/internal/image/AnimatedGifManager.java
+++ b/src/main/java/com/shaft/gui/internal/image/AnimatedGifManager.java
@@ -85,21 +85,23 @@ public class AnimatedGifManager {
     public static String attachAnimatedGif() {
         // stop and attach
         if (SHAFT.Properties.visuals.createAnimatedGif() && !gifRelativePathWithFileName.get().isEmpty()) {
-            try (InputStream in = Files.newInputStream(Paths.get(gifRelativePathWithFileName.get()))) {
-                ReportManagerHelper.attach("Animated Gif", String.valueOf(System.currentTimeMillis()), in);
-                if (gifWriter.get() != null) {
+            try {
+                if (gifWriter.get() != null && gifManager.get() != null) {
                     gifManager.get().close();
                 }
                 if (gifOutputStream.get() != null) {
                     gifOutputStream.get().close();
                 }
 
+                String gifRelativePath = gifRelativePathWithFileName.get();
+                try (InputStream in = Files.newInputStream(Paths.get(gifRelativePath))) {
+                    ReportManagerHelper.attach("Animated Gif", String.valueOf(System.currentTimeMillis()), in);
+                }
                 gifOutputStream.remove();
                 gifManager.remove();
                 gifWriter.remove();
                 imageWriteParam.remove();
                 imageMetaData.remove();
-                String gifRelativePath = gifRelativePathWithFileName.get();
                 gifRelativePathWithFileName.remove();
                 return gifRelativePath;
             } catch (IOException | NullPointerException | IllegalStateException e) {

--- a/src/main/java/com/shaft/tools/internal/support/JavaHelper.java
+++ b/src/main/java/com/shaft/tools/internal/support/JavaHelper.java
@@ -248,13 +248,17 @@ public class JavaHelper {
             //file path is valid
             return relativePath;
         } else {
-            if (relativePath.startsWith("/")) {
-                //remove extra slash at the beginning if applicable
-                relativePath = relativePath.substring(1);
+            if (relativePath.startsWith("//")) {
+                // Preserve POSIX-style absolute paths that were normalized with an extra leading slash.
+                return relativePath.substring(1);
             }
             // Do not prepend testData path to absolute OS paths
             if (new java.io.File(relativePath).isAbsolute()) {
                 return relativePath;
+            }
+            if (relativePath.startsWith("/")) {
+                //remove extra slash at the beginning if applicable
+                relativePath = relativePath.substring(1);
             }
             var testDataFolderPath = SHAFT.Properties.paths.testData();
             if (relativePath.contains(testDataFolderPath)) {

--- a/src/test/java/com/shaft/performance/internal/LightHouseGenerateReportCoverageUnitTest.java
+++ b/src/test/java/com/shaft/performance/internal/LightHouseGenerateReportCoverageUnitTest.java
@@ -80,11 +80,11 @@ public class LightHouseGenerateReportCoverageUnitTest {
             Assert.assertEquals(mockedTerminalActions.constructed().size(), 2);
             verify(mockedTerminalActions.constructed().getFirst(), times(1))
                     .performTerminalCommand(Mockito.argThat(command ->
-                                    command.startsWith("node GenerateLHScript.js")
-                                            && command.contains("--port=9999")
+                            command.contains("node GenerateLHScript.js")
+                                    && command.contains("--port=9999")
                                     && command.contains(AMPERSAND_PLACEHOLDER)));
             verify(mockedTerminalActions.constructed().get(1), times(1))
-                    .performTerminalCommand("node OpenLHReport.js");
+                    .performTerminalCommand(Mockito.argThat(command -> command.contains("node OpenLHReport.js")));
         }
     }
 
@@ -119,7 +119,7 @@ public class LightHouseGenerateReportCoverageUnitTest {
             verify(mockedFileActions, times(1)).writeToFile(eq(""), eq("OpenLHReport.js"), Mockito.<List<String>>any());
             verify(mockedFileActions, times(1)).writeToFile(eq(""), eq("GenerateLHScript.js"), Mockito.<List<String>>any());
             Assert.assertTrue(openScriptContent[0].get(0).contains("custom-page.html"));
-            Assert.assertTrue(generateScriptContent[0].get(0).contains("lighthouse/lighthouse-core/config/desktop-config.js"));
+            Assert.assertTrue(generateScriptContent[0].get(0).contains("desktop-config.js"));
 
             Assert.assertTrue(pageName.contains("--path-sub-path"));
             Assert.assertTrue(pageName.startsWith(LocalDate.now().format(java.time.format.DateTimeFormatter.ofPattern("dd-MM-yyyy"))));

--- a/src/test/java/testPackage/LambdaTest/Test_LTMobAPKAPPURL.java
+++ b/src/test/java/testPackage/LambdaTest/Test_LTMobAPKAPPURL.java
@@ -45,8 +45,9 @@ public class Test_LTMobAPKAPPURL {
 
     @AfterMethod(alwaysRun = true)
     public void teardown() {
-        if (driver != null) {
+        if (driver.get() != null) {
             driver.get().quit();
         }
+        driver.remove();
     }
 }

--- a/src/test/java/testPackage/LambdaTest/Test_LTMobAPKRelativePath.java
+++ b/src/test/java/testPackage/LambdaTest/Test_LTMobAPKRelativePath.java
@@ -48,6 +48,9 @@ public class Test_LTMobAPKRelativePath {
 
     @AfterMethod(alwaysRun = true)
     public void teardown() {
-        driver.get().quit();
+        if (driver.get() != null) {
+            driver.get().quit();
+        }
+        driver.remove();
     }
 }

--- a/src/test/java/testPackage/legacy/FrameTests.java
+++ b/src/test/java/testPackage/legacy/FrameTests.java
@@ -11,12 +11,12 @@ import org.testng.annotations.Test;
 public class FrameTests {
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
     By iframe_1 = By.xpath("//iframe[@title='SHAFT User Guide']");
-    By nestedElement = By.className("hero__title");
+    By nestedElement = By.id("frame-title");
     String testPage = """
              data:text/html,
              <html>
                  <div id="parentFrameDiv">Parent Frame
-                 <iframe src="https://shafthq.github.io/" height="500" width="500" title="SHAFT User Guide" name="iframe Name"></iframe>
+                 <iframe srcdoc="<html><body><h1 id='frame-title'>SHAFT: Unified Test Automation Engine</h1></body></html>" height="500" width="500" title="SHAFT User Guide" name="iframe Name"></iframe>
                  </div>
              </html>
             """;

--- a/src/test/java/testPackage/unitTests/PropertiesHelperInitializationUnitTest.java
+++ b/src/test/java/testPackage/unitTests/PropertiesHelperInitializationUnitTest.java
@@ -6,7 +6,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Files;
@@ -37,11 +36,11 @@ public class PropertiesHelperInitializationUnitTest {
 
         PropertiesHelper.initialize();
 
-        Assert.assertTrue(new File(PROPERTIES_FOLDER_PATH, "custom.properties").isFile(),
+        Assert.assertTrue(Files.isRegularFile(Path.of(PROPERTIES_FOLDER_PATH, "custom.properties")),
                 "custom.properties should be generated in the target properties folder.");
         GENERATED_ROOT_PROPERTIES.stream()
                 .filter(fileName -> !"custom.properties".equals(fileName))
-                .forEach(fileName -> Assert.assertFalse(new File(PROPERTIES_FOLDER_PATH, fileName).isFile(),
+                .forEach(fileName -> Assert.assertFalse(Files.isRegularFile(Path.of(PROPERTIES_FOLDER_PATH, fileName)),
                         fileName + " should not be generated in the target properties folder."));
     }
 
@@ -63,10 +62,20 @@ public class PropertiesHelperInitializationUnitTest {
     }
 
     private void deleteGeneratedPropertyFile(String fileName) {
-        var propertyFile = new File(PROPERTIES_FOLDER_PATH, fileName);
-        if (propertyFile.isFile()) {
-            Assert.assertTrue(propertyFile.delete(), "Failed to delete generated property file: " + propertyFile.getPath());
+        var propertyFile = Path.of(PROPERTIES_FOLDER_PATH, fileName);
+        for (int attempt = 0; attempt < 5 && Files.isRegularFile(propertyFile); attempt++) {
+            try {
+                Files.deleteIfExists(propertyFile);
+            } catch (IOException e) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException interruptedException) {
+                    Thread.currentThread().interrupt();
+                    Assert.fail("Interrupted while deleting generated property file: " + propertyFile, interruptedException);
+                }
+            }
         }
+        Assert.assertFalse(Files.isRegularFile(propertyFile), "Failed to delete generated property file: " + propertyFile);
     }
 
 }

--- a/src/test/java/testPackage/unitTests/RealtimeReporterServerUnitTest.java
+++ b/src/test/java/testPackage/unitTests/RealtimeReporterServerUnitTest.java
@@ -13,6 +13,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.URLEncoder;
 import java.net.URL;
@@ -119,7 +120,9 @@ public class RealtimeReporterServerUnitTest {
     @Test
     public void startServerShouldFallbackToEphemeralPortWhenDefaultPortIsBusy() throws Exception {
         RealtimeReporter.stopServer();
-        try (ServerSocket defaultPortBlocker = new ServerSocket(1111)) {
+        try (ServerSocket defaultPortBlocker = new ServerSocket()) {
+            defaultPortBlocker.setReuseAddress(false);
+            defaultPortBlocker.bind(new InetSocketAddress("localhost", 1111));
             Method startServer = RealtimeReporter.class.getDeclaredMethod("startServer");
             startServer.setAccessible(true);
             startServer.invoke(null);


### PR DESCRIPTION
## Summary
- Fix WebDriver teardown so log collection failures do not prevent close/quit from running.
- Finalize animated GIF streams before attaching generated GIFs.
- Preserve double-slash POSIX absolute test-data paths before applying test-data prefixing.
- Harden affected E2E/unit tests for cross-platform CI differences: Lighthouse command prefixes, property file cleanup retries, realtime reporter port binding, inline iframe content, and LambdaTest teardown null safety.
- Map Edge Pixel 5 mobile emulation to explicit metrics/user-agent to avoid invalid named-device capabilities.

Fixes #2696

## Validation
- mvn test -Dtest=DriverFactoryHelperAdditionalUnitTest#closeDriverShouldHandleNullAndDriverExceptions,AnimatedGifManagerCoverageUnitTest#startOrAppendToAnimatedGifShouldCreateAppendAndAttachGif+appendToAnimatedGifShouldHandleInvalidImageBytesWithoutThrowing,JavaHelperUnitTest#appendTestDataToRelativePathAbsolutePathShouldBeReturnedAsIs,LightHouseGenerateReportCoverageUnitTest,RealtimeReporterServerUnitTest#startServerShouldFallbackToEphemeralPortWhenDefaultPortIsBusy -Dgpg.skip
- python3 Allure result count/status check (9 passed result JSON files)
- mvn compile -DskipTests -Dgpg.skip

## Notes
- Downloaded and inspected the failed Allure single-file artifacts from the May 11 E2E runs. Remaining LambdaTest setup 401s appear credential/provider-side; this change prevents the teardown NPE from masking the setup failure.