### PR TITLE
codex: document CI Allure triage lessons

### DIFF
--- a/.github/copilot-memory.md
+++ b/.github/copilot-memory.md
@@ -59,3 +59,9 @@ Purpose: keep high-signal, reusable learnings from implementation sessions in on
 - Lesson: `@Test(singleThreaded = true)` does not protect static server lifecycle shared across different TestNG classes. Unit tests that start/stop `RealtimeReporter` need an explicit cross-class lock plus readiness polling and property restoration.
 - Evidence: `src/test/java/testPackage/unitTests/RealtimeReporterServerUnitTest.java`, `src/test/java/testPackage/unitTests/RealtimeReporterUnitTest.java`, `src/test/java/testPackage/unitTests/RealtimeReporterTestLock.java`
 - Action taken: Serialized realtime reporter unit tests with a package-local lock and added server readiness polling.
+- Date: 2026-05-12
+- Area: CI E2E failure triage / Allure artifact traversal / PR authorship
+- Trigger: Issue #2696 required investigating failing E2E workflow runs from GitHub Actions artifacts, and a follow-up request asked agents to preserve the investigation workflow and make Codex-authored PRs explicit.
+- Lesson: Start E2E triage with authenticated `gh run view`, failed job logs, and artifact metadata; self-contained `*_Allure.html` artifacts can be parsed directly by decoding embedded `data/test-results/*.json` payloads, which is much faster than browser traversal. Always count populated Allure results before trusting statuses, distinguish provider/credential failures from code defects, and label Codex-authored branches/PRs so human token owners are not implied as manual authors.
+- Evidence: `docs/CI_FAILURE_INVESTIGATION.md`, `AGENTS.md`, issue #2696, PR #2699
+- Action taken: Added a CI/Allure investigation runbook, linked it from repository agent guidance, and recorded PR title/body authorship guidance for future Codex-created work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ Important directories:
 - CI uses many property-driven E2E runs, including local browsers, Docker Selenium Grid, BrowserStack, LambdaTest, mobile/Appium, API, DB, Cucumber, and Flutter-related tests. Do not assume those all run on a bare machine.
 - Allure result JSON/report output is the authoritative pass/fail source for SHAFT test runs. Surefire output is useful diagnostics, but do not use it as the final oracle when it disagrees with Allure.
 - Before analyzing Allure statuses, first count the executed tests/result JSON files. If the count is zero or unexpectedly low, treat the report as empty/invalid and fix rerun/report generation before drawing conclusions.
+- For GitHub Actions E2E investigations, use `docs/CI_FAILURE_INVESTIGATION.md` to pull run/job metadata, download job logs, and parse self-contained `*_Allure.html` artifacts directly from embedded `data/test-results/*.json` payloads instead of opening large reports manually.
 - Surefire is configured to continue after failures so JaCoCo/report generation can complete. Use `target/surefire-reports` as supporting evidence only after validating the Allure run is populated.
 - Test data belongs under `src/test/resources/testDataFiles/`; avoid hardcoding data in tests when existing guidance requires JSON test data.
 - For TestNG browser tests, existing instructions require fresh driver setup per test and `@AfterMethod(alwaysRun = true)` cleanup with `driver.quit()`.
@@ -124,6 +125,7 @@ Important directories:
 - Documentation-only changes can use lightweight validation, but code changes are expected to compile and run affected tests before commit.
 - Java 25 plus Mockito inline mocking can fail on some TestNG interfaces with optional dependency types. Prefer extracting list/value-based helper logic for unit coverage over mocking or proxying `org.testng.ISuite`.
 - If GitHub publication access is unavailable, say so clearly and provide a PR handoff rather than implying a visible GitHub PR exists.
+- Agent-created branches/PRs must identify the agent author. Prefer branch names starting with `codex/` and PR titles starting with `codex:` for Codex-authored work. If a human maintainer token creates the PR, state in the PR body that Codex made the changes and that the token owner did not author them manually.
 
 ## Open Questions / Verify Before Relying
 - No explicit local formatter command was found.

--- a/docs/CI_FAILURE_INVESTIGATION.md
+++ b/docs/CI_FAILURE_INVESTIGATION.md
@@ -1,0 +1,122 @@
+# CI Failure and Allure Artifact Investigation Runbook
+
+Use this runbook when an agent is assigned a ticket for failing GitHub Actions E2E, local, cloud, or scheduled workflows.
+
+## 1. Start from authenticated GitHub metadata
+
+Normalize GitHub CLI credentials first so private logs and artifacts are available without exposing tokens:
+
+```bash
+source scripts/ci/github-auth-env.sh
+GH_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}" gh auth status -h github.com
+```
+
+Collect run, job, failed-step, and artifact metadata before changing code:
+
+```bash
+RUN_ID=<run-id>
+GH_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}" gh run view "$RUN_ID" \
+  --repo ShaftHQ/SHAFT_ENGINE \
+  --json name,workflowName,conclusion,status,createdAt,updatedAt,url,jobs \
+  | jq '{name,workflowName,conclusion,status,createdAt,updatedAt,url,jobs:[.jobs[]|{name,conclusion,status,databaseId,failedSteps:[.steps[]|select(.conclusion=="failure")|{name,number,conclusion}]}]}'
+
+GH_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}" gh api \
+  "repos/ShaftHQ/SHAFT_ENGINE/actions/runs/$RUN_ID/artifacts" \
+  --jq '.artifacts[] | [.name,.size_in_bytes,.expired,.archive_download_url] | @tsv'
+```
+
+Download job logs for each failed job and search for post-test summaries, setup failures, and root-cause stack traces:
+
+```bash
+JOB_ID=<job-id>
+mkdir -p /tmp/shaft-ci/logs
+GH_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}" gh api \
+  "repos/ShaftHQ/SHAFT_ENGINE/actions/jobs/$JOB_ID/logs" \
+  > "/tmp/shaft-ci/logs/$JOB_ID.txt"
+rg -n "(Allure Report Summary|::error::|FAILED|BROKEN|AssertionError|Exception|SessionNotCreated|401|TimeoutException)" \
+  "/tmp/shaft-ci/logs/$JOB_ID.txt"
+```
+
+## 2. Traverse SHAFT single-file Allure artifacts quickly
+
+Many SHAFT workflow artifacts named `*_Allure.html` are already self-contained HTML reports, not zip archives. `gh run download` may fail with `zip: not a valid zip file`; in that case, save the artifact API response directly as an HTML file.
+
+```bash
+RUN_ID=<run-id>
+mkdir -p /tmp/shaft-ci/allure-html
+GH_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}" gh api \
+  "repos/ShaftHQ/SHAFT_ENGINE/actions/runs/$RUN_ID/artifacts" \
+  --jq '.artifacts[] | select(.name | endswith("_Allure.html")) | [.name,.archive_download_url] | @tsv' \
+  | while IFS=$'\t' read -r name url; do
+      GH_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}" gh api "$url" > "/tmp/shaft-ci/allure-html/$name"
+    done
+```
+
+The self-contained Allure HTML embeds report files as JavaScript calls like `d("data/test-results/...json","<base64>")`. Parse those embedded JSON payloads instead of opening a browser when you need the failure list fast:
+
+```bash
+python3 - <<'PY'
+import base64
+import json
+import re
+from pathlib import Path
+
+for report in sorted(Path('/tmp/shaft-ci/allure-html').glob('*_Allure.html')):
+    failures = []
+    for match in re.finditer(r'd\("([^"]+)","([A-Za-z0-9+/=]+)"\)', report.read_text(errors='ignore')):
+        path, payload = match.groups()
+        if path.startswith('data/test-results/') and path.endswith('.json'):
+            data = json.loads(base64.b64decode(payload))
+            if data.get('status') in {'failed', 'broken'}:
+                error = data.get('error') or {}
+                failures.append((data.get('status'), data.get('fullName') or data.get('name'), error.get('message', '')))
+    print(f'\n==== {report.name}: {len(failures)} failed/broken ====')
+    for status, name, message in failures:
+        print(f'- {status}: {name}')
+        print('  ' + message.replace('\r', '').replace('\n', ' | ')[:1000])
+PY
+```
+
+Always count populated result JSON files before trusting any Allure status analysis:
+
+```bash
+python3 - <<'PY'
+import base64
+import json
+import re
+from pathlib import Path
+
+for report in sorted(Path('/tmp/shaft-ci/allure-html').glob('*_Allure.html')):
+    total = 0
+    statuses = {}
+    for match in re.finditer(r'd\("([^"]+)","([A-Za-z0-9+/=]+)"\)', report.read_text(errors='ignore')):
+        path, payload = match.groups()
+        if path.startswith('data/test-results/') and path.endswith('.json'):
+            total += 1
+            status = json.loads(base64.b64decode(payload)).get('status', 'unknown')
+            statuses[status] = statuses.get(status, 0) + 1
+    print(report.name, total, statuses)
+PY
+```
+
+If the count is zero or unexpectedly low, treat the report as empty/invalid and investigate report generation before diagnosing tests.
+
+## 3. Separate test defects from environment/provider defects
+
+Document each failed/broken test with:
+
+- workflow/run ID, job ID, and artifact name;
+- Allure `fullName`, status, and concise failure signature;
+- whether the failure is deterministic in local targeted tests;
+- whether the signature points to code, test isolation, CI host behavior, credentials, or an external provider outage.
+
+Do not hide provider or credential failures by changing assertions. For example, a cloud-provider `401` during setup should be reported as credential/provider evidence; only fix framework/test teardown if it adds a secondary `NullPointerException` or masks the real setup failure.
+
+## 4. PR authorship and title hygiene for agent-created work
+
+When an AI agent creates a branch or PR, make that explicit even if the GitHub token belongs to a human maintainer:
+
+- Branch names should be descriptive and preferably start with `codex/` for Codex-authored work.
+- PR titles created by Codex should start with `codex:` unless the user explicitly requests a different prefix.
+- PR bodies must state that Codex/AI authored the branch and PR, for example: `This PR was created by Codex, not manually by the maintainer whose token opened it.`
+- Avoid placeholder titles or bodies. Include summary, validation, limitations, and links to the issue/run evidence.


### PR DESCRIPTION
## Authorship
This PR was created by Codex. It was opened using the available GitHub token, but the documentation changes were authored by Codex, not manually by the maintainer whose token created the PR.

## Summary
- Add a CI failure investigation runbook for authenticated GitHub Actions metadata, job logs, and fast traversal of self-contained Allure HTML artifacts.
- Link the runbook from repository agent guidance so future E2E investigations count populated Allure results and decode embedded test-result JSON before drawing conclusions.
- Record the reusable lesson in the Copilot memory ledger, including Codex branch/PR naming and authorship guidance.

## Validation
- git diff --check
- rg -n "CI Failure|Allure|codex:|Codex|data/test-results|PR titles" docs/CI_FAILURE_INVESTIGATION.md AGENTS.md .github/copilot-memory.md

Addresses follow-up guidance from issue #2696 / PR #2699.