### PR TITLE
codex: guard Allure extraction against Surefire mismatches

### DIFF
--- a/.github/actions/post-test-report/action.yml
+++ b/.github/actions/post-test-report/action.yml
@@ -143,13 +143,27 @@ runs:
               {
                 echo ""
                 echo "### ❌ Failed and broken test methods"
-                python3 scripts/ci/extract_allure_failures.py allure-results || true
+                python3 scripts/ci/extract_allure_failures.py allure-results --surefire-reports target/surefire-reports || true
               } >> "$GITHUB_STEP_SUMMARY"
             fi
             echo "::error::Allure report shows $FAILED failed and $BROKEN broken test(s) out of $TOTAL total. Check the Allure report artifact for details."
             exit 1
           fi
-          echo "All tests passed according to Allure report."
+          if [ -d "allure-results" ] && [ -d "target/surefire-reports" ] && command -v python3 >/dev/null 2>&1; then
+            SUREFIRE_ALLURE_CHECK=$(mktemp)
+            if ! python3 scripts/ci/extract_allure_failures.py allure-results --surefire-reports target/surefire-reports > "$SUREFIRE_ALLURE_CHECK"; then
+              {
+                echo ""
+                echo "### ❌ Surefire / Allure consistency check"
+                cat "$SUREFIRE_ALLURE_CHECK"
+              } >> "$GITHUB_STEP_SUMMARY"
+              echo "::error::Surefire reports include failures that are missing from Allure failed/broken results. Check the job summary for details."
+              rm -f "$SUREFIRE_ALLURE_CHECK"
+              exit 1
+            fi
+            rm -f "$SUREFIRE_ALLURE_CHECK"
+          fi
+          echo "All tests passed according to Allure report and Surefire cross-check."
         else
           echo "::warning::Allure report summary not found. Falling back to surefire reports."
           # Fallback: Check surefire reports if allure data is unavailable.

--- a/.github/workflows/coverage-readiness.yml
+++ b/.github/workflows/coverage-readiness.yml
@@ -78,7 +78,7 @@ jobs:
         continue-on-error: true
         run: |
           if [ -d allure-results ]; then
-            scripts/ci/extract_allure_failures.py allure-results | tee allure-failures.md
+            scripts/ci/extract_allure_failures.py allure-results --surefire-reports target/surefire-reports | tee allure-failures.md
           else
             echo 'No allure-results directory was generated.' | tee allure-failures.md
           fi

--- a/scripts/ci/extract_allure_failures.py
+++ b/scripts/ci/extract_allure_failures.py
@@ -4,11 +4,14 @@
 The script accepts one or more Allure result directories, generated report
 folders, JSON files, or ZIP archives. It prints a Markdown table by default so
 CI jobs and issue triage notes can include exact failing methods and reasons.
+When Surefire XML paths are provided, it also flags Surefire failures
+that do not have a matching failed or broken Allure result.
 """
 
 import argparse
 import json
 import textwrap
+import xml.etree.ElementTree as ET
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -19,6 +22,15 @@ FAILING_STATUSES = {"failed", "broken"}
 
 @dataclass(frozen=True)
 class AllureFailure:
+    source: str
+    status: str
+    method: str
+    reason: str
+    trace_top: str
+
+
+@dataclass(frozen=True)
+class SurefireFailure:
     source: str
     status: str
     method: str
@@ -87,6 +99,73 @@ def _method_name(payload: dict) -> str:
     return payload.get("fullName") or payload.get("name") or payload.get("uid") or payload.get("uuid") or "<unknown>"
 
 
+def _iter_surefire_xml_files(path: Path) -> Iterator[Path]:
+    if path.is_dir():
+        for xml_path in sorted(path.rglob("TEST-*.xml")):
+            yield xml_path
+        return
+    if path.suffix == ".xml":
+        yield path
+
+
+def _surefire_case_method(testcase: ET.Element) -> str:
+    class_name = testcase.get("classname") or ""
+    name = testcase.get("name") or ""
+    if class_name and name and not name.startswith(f"{class_name}."):
+        return f"{class_name}.{name}"
+    return name or class_name or "<unknown>"
+
+
+def _surefire_failure_details(element: ET.Element) -> tuple[str, str]:
+    message = element.get("message") or element.get("type") or ""
+    trace = element.text or ""
+    reason = str(message).strip() or _first_trace_line(trace) or "No failure message recorded"
+    return reason, _first_trace_line(trace)
+
+
+def extract_surefire_failures(paths: Iterable[Path]) -> list[SurefireFailure]:
+    failures: list[SurefireFailure] = []
+    seen: set[tuple[str, str, str, str]] = set()
+    for path in paths:
+        for xml_path in _iter_surefire_xml_files(path):
+            try:
+                root = ET.parse(xml_path).getroot()
+            except ET.ParseError:
+                continue
+            for testcase in root.iter("testcase"):
+                failure_element = testcase.find("failure")
+                error_element = testcase.find("error")
+                result_element = failure_element if failure_element is not None else error_element
+                if result_element is None:
+                    continue
+                status = "failure" if failure_element is not None else "error"
+                method = _surefire_case_method(testcase)
+                reason, trace_top = _surefire_failure_details(result_element)
+                key = (str(xml_path), status, method, reason)
+                if key in seen:
+                    continue
+                seen.add(key)
+                failures.append(SurefireFailure(str(xml_path), status, method, reason, trace_top))
+    return failures
+
+
+def _methods_match(left: str, right: str) -> bool:
+    if left == right:
+        return True
+    return left.endswith(f".{right}") or right.endswith(f".{left}")
+
+
+def missing_surefire_failures(
+    allure_failures: Iterable[AllureFailure], surefire_failures: Iterable[SurefireFailure]
+) -> list[SurefireFailure]:
+    allure_methods = [failure.method for failure in allure_failures]
+    return [
+        failure
+        for failure in surefire_failures
+        if not any(_methods_match(failure.method, allure_method) for allure_method in allure_methods)
+    ]
+
+
 def extract_failures(paths: Iterable[Path]) -> list[AllureFailure]:
     failures: list[AllureFailure] = []
     seen: set[tuple[str, str, str, str]] = set()
@@ -126,8 +205,45 @@ def to_markdown(failures: list[AllureFailure]) -> str:
     return "\n".join(rows)
 
 
+def to_surefire_markdown(failures: list[SurefireFailure]) -> str:
+    if not failures:
+        return "No Surefire failures were missing from Allure results."
+
+    rows = [
+        "| Status | Test method | Failure reason | Top trace frame | Source |",
+        "|---|---|---|---|---|",
+    ]
+    for failure in failures:
+        rows.append(
+            "| {status} | `{method}` | {reason} | `{trace}` | `{source}` |".format(
+                status=_clean_cell(failure.status),
+                method=_clean_cell(failure.method),
+                reason=_clean_cell(failure.reason),
+                trace=_clean_cell(failure.trace_top or "n/a"),
+                source=_clean_cell(failure.source),
+            )
+        )
+    return "\n".join(rows)
+
+
 def to_json(failures: list[AllureFailure]) -> str:
     return json.dumps([failure.__dict__ for failure in failures], indent=2, sort_keys=True)
+
+
+def to_comparison_json(
+    allure_failures: list[AllureFailure],
+    surefire_failures: list[SurefireFailure],
+    missing_failures: list[SurefireFailure],
+) -> str:
+    return json.dumps(
+        {
+            "allureFailures": [failure.__dict__ for failure in allure_failures],
+            "surefireFailures": [failure.__dict__ for failure in surefire_failures],
+            "missingSurefireFailures": [failure.__dict__ for failure in missing_failures],
+        },
+        indent=2,
+        sort_keys=True,
+    )
 
 
 def parse_args() -> argparse.Namespace:
@@ -138,20 +254,47 @@ def parse_args() -> argparse.Namespace:
             """
             Examples:
               scripts/ci/extract_allure_failures.py allure-results
+              scripts/ci/extract_allure_failures.py allure-results --surefire-reports target/surefire-reports
               scripts/ci/extract_allure_failures.py artifacts/*.zip --format json
             """
         ),
     )
     parser.add_argument("paths", nargs="+", type=Path, help="Allure result/report path, JSON file, or ZIP archive")
+    parser.add_argument(
+        "--surefire-reports",
+        nargs="*",
+        type=Path,
+        default=[],
+        help="Optional Surefire XML report path(s) to cross-check against Allure failures",
+    )
     parser.add_argument("--format", choices=("markdown", "json"), default="markdown", help="Output format")
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
-    failures = extract_failures(args.paths)
-    print(to_json(failures) if args.format == "json" else to_markdown(failures))
-    return 1 if failures else 0
+    allure_failures = extract_failures(args.paths)
+    surefire_failures = extract_surefire_failures(args.surefire_reports)
+    missing_failures = missing_surefire_failures(allure_failures, surefire_failures)
+
+    if args.format == "json":
+        output = (
+            to_comparison_json(allure_failures, surefire_failures, missing_failures)
+            if args.surefire_reports
+            else to_json(allure_failures)
+        )
+    else:
+        output = to_markdown(allure_failures)
+        if args.surefire_reports:
+            output = "\n\n".join(
+                [
+                    output,
+                    "## Surefire failures missing from Allure results",
+                    to_surefire_markdown(missing_failures),
+                ]
+            )
+    print(output)
+    return 1 if allure_failures or missing_failures else 0
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_extract_allure_failures.py
+++ b/tests/scripts/test_extract_allure_failures.py
@@ -4,7 +4,14 @@ import unittest
 import zipfile
 from pathlib import Path
 
-from scripts.ci.extract_allure_failures import extract_failures, to_markdown
+from scripts.ci.extract_allure_failures import (
+    extract_failures,
+    extract_surefire_failures,
+    missing_surefire_failures,
+    to_comparison_json,
+    to_markdown,
+    to_surefire_markdown,
+)
 
 
 class ExtractAllureFailuresTests(unittest.TestCase):
@@ -80,6 +87,81 @@ class ExtractAllureFailuresTests(unittest.TestCase):
             failures = extract_failures([root, archive_path])
 
         self.assertEqual([failure.method for failure in failures], ["real failure"])
+
+    def test_extracts_surefire_failures_from_xml(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            reports = Path(temp_dir)
+            (reports / "TEST-TestSuite.xml").write_text(
+                """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite tests="2" failures="1" errors="1" skipped="0">
+  <testcase classname="pkg.ExampleTest" name="fails">
+    <failure message="expected true but was false">java.lang.AssertionError: expected true but was false
+        at pkg.ExampleTest.fails(ExampleTest.java:10)</failure>
+  </testcase>
+  <testcase classname="pkg.ExampleTest" name="breaks">
+    <error type="java.lang.RuntimeException">java.lang.RuntimeException: browser died
+        at pkg.ExampleTest.breaks(ExampleTest.java:20)</error>
+  </testcase>
+</testsuite>
+""",
+                encoding="utf-8",
+            )
+
+            failures = extract_surefire_failures([reports])
+
+        self.assertEqual([failure.status for failure in failures], ["failure", "error"])
+        self.assertEqual(failures[0].method, "pkg.ExampleTest.fails")
+        self.assertEqual(failures[0].reason, "expected true but was false")
+        self.assertEqual(failures[1].method, "pkg.ExampleTest.breaks")
+        self.assertEqual(failures[1].reason, "java.lang.RuntimeException")
+
+    def test_detects_surefire_failures_missing_from_allure_results(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            allure = root / "allure-results"
+            surefire = root / "surefire-reports"
+            allure.mkdir()
+            surefire.mkdir()
+            (allure / "known-result.json").write_text(
+                json.dumps(
+                    {
+                        "status": "failed",
+                        "labels": [
+                            {"name": "testClass", "value": "ExampleTest"},
+                            {"name": "testMethod", "value": "recordedFailure"},
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (surefire / "TEST-TestSuite.xml").write_text(
+                """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite tests="2" failures="2" errors="0" skipped="0">
+  <testcase classname="pkg.ExampleTest" name="recordedFailure">
+    <failure message="recorded failure" />
+  </testcase>
+  <testcase classname="pkg.LightHouseGenerateReportCoverageUnitTest" name="missingFailure">
+    <failure message="lighthouse artifact was not created" />
+  </testcase>
+</testsuite>
+""",
+                encoding="utf-8",
+            )
+
+            allure_failures = extract_failures([allure])
+            surefire_failures = extract_surefire_failures([surefire])
+            missing_failures = missing_surefire_failures(allure_failures, surefire_failures)
+            markdown = to_surefire_markdown(missing_failures)
+            comparison_json = json.loads(to_comparison_json(allure_failures, surefire_failures, missing_failures))
+
+        self.assertEqual(
+            [failure.method for failure in missing_failures], ["pkg.LightHouseGenerateReportCoverageUnitTest.missingFailure"]
+        )
+        self.assertIn("lighthouse artifact was not created", markdown)
+        self.assertEqual(
+            comparison_json["missingSurefireFailures"][0]["method"],
+            "pkg.LightHouseGenerateReportCoverageUnitTest.missingFailure",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- The Allure-based post-test reporting flow could silently omit test failures that Surefire reported, causing CI to appear green while hiding real failures. 
- A reproducible local run showed Surefire reported 5 failures while the existing Allure extraction only listed 3, proving the mismatch risk. 

### Description
- Extend `scripts/ci/extract_allure_failures.py` to parse Surefire `TEST-*.xml` files, normalize test method names, and detect Surefire failures/errors that do not have matching failed/broken Allure results. 
- Add JSON comparison output (`to_comparison_json`) and a Surefire-focused Markdown renderer so the script can emit both Allure-only and Allure-vs-Surefire views. 
- Update the post-test report composite action to run a Surefire/Allure cross-check and fail the job with a clear summary when Surefire reports failures missing from Allure results. 
- Update the `coverage-readiness` workflow to pass `target/surefire-reports` into the extraction script and add regression unit tests for Surefire XML parsing and mismatch detection. 

### Testing
- Ran the script unit tests with `python -m unittest discover -s tests/scripts -p 'test_*.py'` and all tests passed. 
- Executed the updated `scripts/ci/extract_allure_failures.py` against a synthetic fixture (`allure-results` + `surefire-reports`) and verified it reports the Lighthouse-style missing failure and returns a non-zero exit when mismatches are found. 
- Reproduced the original local scenario with `mvn test ... "-Dtest=%regex[.*UnitTest.*]"` to confirm the mismatch condition exists and that the new guard will surface such discrepancies in the post-test summary. 

This PR was authored by Codex on branch `codex/allure-surefire-consistency-guard`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0375bf9e9c832088ed7f54641ca2f4)