### PR TITLE
codex: add start/init workflow guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,6 +52,18 @@ PDCA is the mandatory development methodology.  Each cycle consists of four phas
 - Re-run tests to confirm refactoring did not break anything.
 - Update JavaDocs and inline comments to reflect the final design.
 
+### Start/Init Trigger Protocol
+
+When a maintainer tags `@codex` and asks the agent to begin work, or when the trigger includes the keywords `start` or `init`, treat that as an explicit instruction to initialize the full task workflow before implementation. Complete these steps in order unless a higher-priority instruction or platform limitation prevents them; when blocked, state the limitation and complete the nearest safe equivalent.
+
+1. **Take assignment intentionally.** Assign the GitHub Issue or task to `codex` when that identity is available. If GitHub cannot assign `codex`, assign the task to the requesting maintainer and explain the fallback. Never assign the task to `MohabMohie` or another maintainer unless explicitly requested.
+2. **Create a linked branch.** Create a dedicated branch for the task and link it to the GitHub task for traceability. Prefer branch names and PR metadata that include the issue number or closing keyword relationship, so merging the PR closes the task automatically. If the trigger is not an issue, the issue number is unavailable, or GitHub access is unavailable, document why auto-closing linkage could not be established.
+3. **Open a draft PR before deep implementation.** Push the branch and open a draft PR as early as practical. The draft PR body must state that Codex is the implementation agent and must include a plan detailed enough for a lower-intelligence AI agent to follow, including exact inspection steps, expected files, sample commands, validation expectations, acceptance criteria, assumptions, risks, and fallback guidance.
+4. **Execute with at least three PDCA iterations.** For non-trivial work, iteration 1 should make the smallest working change, iteration 2 should reduce change impact and align with repository/industry best practices, and iteration 3 should optimize clarity, maintainability, documentation, and validation. Each iteration must explicitly cover Plan, Do, Check, and Act.
+5. **Commit at meaningful checkpoints.** After each validated checkpoint, commit the focused changes to the branch. Do not accumulate a large uncommitted implementation when a safe checkpoint exists.
+6. **Validate the task outcome.** Run targeted checks first, then broader checks as appropriate. Confirm that the checks directly prove the requested behavior or fix, and document any environment limitations.
+7. **Finalize and notify.** Push the final branch, update the PR description or add a progress comment with completed iterations and validation evidence, mark the PR ready for review when complete, and notify the requester to review.
+
 ### Minimum 3-Iteration Rule
 
 > **You MUST complete at least three full PDCA cycles for any non-trivial implementation.**
@@ -1123,7 +1135,7 @@ These guidelines apply to GitHub Copilot coding agent sessions working on this r
 4. **Workflow improvements** — if a CI/CD workflow behaved unexpectedly, note the root cause and the correct fix.
 
 ### Repository Knowledge Migration Protocol
-- When asked to scan, migrate, consolidate, or preserve agent knowledge, follow `docs/AGENT_KNOWLEDGE_MIGRATION.md`.
+- When asked to scan, migrate, consolidate, preserve agent knowledge, or update start/init task workflow instructions, follow `docs/AGENT_KNOWLEDGE_MIGRATION.md`.
 - Create or link a task ticket before implementation; if authenticated GitHub Issues access is unavailable, create a local ticket under `docs/tickets/` and note that maintainers should mirror it.
 - Create a dedicated task branch before editing files, then keep migration/documentation changes isolated from unrelated code.
 - Discover `AGENTS.md`, instruction, memory, skill, and tool files first; reconcile conflicts by favoring direct session instructions, scoped instructions, and executable configuration over stale prose.

--- a/.github/copilot-memory.md
+++ b/.github/copilot-memory.md
@@ -65,3 +65,10 @@ Purpose: keep high-signal, reusable learnings from implementation sessions in on
 - Lesson: Start E2E triage with authenticated `gh run view`, failed job logs, and artifact metadata; self-contained `*_Allure.html` artifacts can be parsed directly by decoding embedded `data/test-results/*.json` payloads, which is much faster than browser traversal. Always count populated Allure results before trusting statuses, distinguish provider/credential failures from code defects, and label Codex-authored branches/PRs so human token owners are not implied as manual authors.
 - Evidence: `docs/CI_FAILURE_INVESTIGATION.md`, `AGENTS.md`, issue #2696, PR #2699
 - Action taken: Added a CI/Allure investigation runbook, linked it from repository agent guidance, and recorded PR title/body authorship guidance for future Codex-created work.
+
+- Date: 2026-05-13
+- Area: Agent start/init workflow / PR traceability
+- Trigger: PR follow-up comment asked `@codex init` to make future start/init mentions follow the explicit assignment, linked-branch, draft-PR, checkpoint-commit, and review-notification process.
+- Lesson: Treat maintainer mentions with `start` or `init` as a request to initialize the full task workflow: assign to `codex` when possible (otherwise the requester), create a GitHub-linked branch for auto-close traceability when an issue exists, open an early draft PR with a lower-intelligence-agent-ready plan, execute at least three PDCA iterations for non-trivial work, commit at validated checkpoints, then push final status and notify the requester for review.
+- Evidence: `AGENTS.md`, `.github/copilot-instructions.md`, PR follow-up trigger `@codex init` on 2026-05-13.
+- Action taken: Added explicit start/init protocol guidance to repository agent instructions and recorded this reusable lesson in the memory ledger.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,7 @@ Important directories:
 
 ## Agent Workflow
 - Start by reading this file plus any scoped instructions relevant to the files you will touch, especially `.github/instructions/framework-source.instructions.md` for `src/main/java/**/*.java` and `.github/instructions/java-tests.instructions.md` for `src/test/java/**/*.java`.
+- When the user asks you to start work on a task, mentions `@codex` with `start` or `init`, or otherwise uses those keywords to begin implementation, follow the full start/init protocol below before coding.
 - When the user asks you to work on an issue, create a dedicated branch from that issue and ensure the branch is linked to the issue correctly. Open a draft pull request early with a generic implementation-plan description, continue working locally on that branch, and push changes to the remote branch once you reach a good implementation milestone. When the work is complete, push the latest code, mark the pull request ready for review, and notify the user that the pull request is ready for review.
 - Follow existing PDCA-style guidance: plan, make the smallest focused change, validate, then refactor only as needed.
 - For bug fixes, reproduce the issue and add/verify a failing test before changing framework code whenever practical.
@@ -109,6 +110,17 @@ Important directories:
 - Report commands run and results. Call out unvalidated assumptions and environment limitations.
 - For agent-instruction or memory migrations, see `docs/AGENT_KNOWLEDGE_MIGRATION.md` and keep durable guidance in long-lived instruction files rather than task reports.
 - A weekly/manual GitHub Actions workflow (`Refresh Agent Instructions`) uses `openai/codex-action@v1` to propose agent-guidance refreshes by pull request only; it requires the `OPENAI_API_KEY` Actions secret.
+
+### Start/Init Task Protocol
+Use this protocol whenever a maintainer tags `@codex` to start work, says `start`, says `init`, or otherwise asks the agent to begin a task. If a direct higher-priority instruction or environment limitation prevents a step, state the limitation explicitly and perform the nearest safe equivalent.
+
+1. **Assign ownership.** Assign the task to `codex` where GitHub supports that identity. If `codex` cannot be assigned, assign the task to the requesting maintainer instead and explain why in the PR or status update. Do not assign the task to unrelated maintainers such as `MohabMohie` unless explicitly requested.
+2. **Link traceability before work.** Create a dedicated branch that is linked to the GitHub Issue or task. Prefer branch names that include the issue number or closing keyword relationship where the platform supports it, so merging the branch or PR can automatically close the task. If there is no issue number, no authenticated GitHub access, or the trigger is only a PR comment, document that no auto-closing link could be created.
+3. **Open a draft PR early.** Create a draft PR from the new branch before substantial implementation. The PR body must identify Codex as the implementation agent and include an implementation plan written for a lower-intelligence AI agent: detailed steps, explicit files to inspect or edit, command examples, acceptance criteria, validation commands, rollback/failure handling, and assumptions.
+4. **Use iterative PDCA execution.** Follow at least three development iterations for non-trivial work: iteration 1 makes the smallest working change, iteration 2 refactors toward minimal impact and industry best practices, and iteration 3 optimizes readability, maintainability, validation coverage, and documentation. Each iteration must include Plan, Do, Check, and Act activities.
+5. **Commit at checkpoints.** Commit code to the task branch at every useful checkpoint after validation passes for that checkpoint. Keep commits focused and avoid mixing unrelated changes.
+6. **Validate before claiming done.** Run the narrowest relevant checks first, then broader checks when warranted. For SHAFT test runs, confirm Allure results are populated before using them as the pass/fail oracle.
+7. **Publish final status.** After implementation is done, push the final branch state, update the PR description or add a progress comment summarizing completed iterations, checks run, files changed, and open risks, then notify the requester that the PR is ready for review.
 
 ## Safety and Constraints
 - Do not expose secrets or copy values from `.env`, credential files, BrowserStack/LambdaTest variables, Maven Central credentials, GPG keys, or CI secrets.


### PR DESCRIPTION
### Motivation
- Ensure maintainer triggers like `@codex start` or `@codex init` reliably initialize a full, traceable task workflow rather than starting ad-hoc work. 
- Improve traceability and consistency by enforcing assignment, linked-branch creation, early draft PRs, and a PDCA-based iterative process for non-trivial tasks.

### Description
- Added a `Start/Init Task Protocol` to `AGENTS.md` that defines assignment-to-`codex`, linked-branch traceability, early draft PR requirements, a minimum three-iteration PDCA execution model, checkpoint commits, validation expectations, and final notification. 
- Mirrored the start/init trigger guidance into `.github/copilot-instructions.md` so Copilot/Codex sessions treat `start`/`init` as an explicit initialization trigger with the same detailed workflow requirements. 
- Recorded the change as a reusable memory entry in `.github/copilot-memory.md` with the 2026-05-13 metadata explaining the trigger, lesson, and action taken.

### Testing
- Performed lightweight validation checks: `git diff --check` and `rg -n "Start/Init|start/init|lower-intelligence|MohabMohie|2026-05-13|Repository Knowledge Migration Protocol" AGENTS.md .github/copilot-instructions.md .github/copilot-memory.md`, both of which returned the expected results. 
- This is a documentation-only change so no Maven build or unit tests were required or run as part of this update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03f3bc52f88320af1b1cc77a16d219)