### PR TITLE
Add SHAFT MCP server starter

### DIFF
--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -15,6 +15,7 @@ Each subdirectory contains skill files tailored to a specific AI agent or model.
 | [Qwen](./qwen/) | `qwen/` | Skills for Alibaba's Qwen model integration |
 | [Claude Code](./claude-code/) | `claude-code/` | Skills for Anthropic's Claude Code integration |
 | [Google Gemma](./google-gemma/) | `google-gemma/` | Skills for Google's Gemma model integration |
+| [SHAFT MCP](./shaft-mcp/) | `shaft-mcp/` | Skill for agents connected to the community SHAFT MCP server starter |
 
 ## Skill File Format
 

--- a/.github/skills/shaft-mcp/README.md
+++ b/.github/skills/shaft-mcp/README.md
@@ -1,0 +1,8 @@
+# SHAFT MCP Skill
+
+This directory contains an agent skill for using the community SHAFT MCP server
+starter in `tools/shaft-mcp-server/`.
+
+Use it when an AI agent is connected to a SHAFT MCP server and needs to inspect
+a SHAFT workspace, run safe validation, summarize reports, or prepare
+maintainer-facing findings.

--- a/.github/skills/shaft-mcp/SKILL.md
+++ b/.github/skills/shaft-mcp/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: shaft-mcp
+description: Use SHAFT MCP tools to inspect a SHAFT_ENGINE workspace, run safe validation, summarize Allure/Surefire reports, and prepare maintainer-ready QA findings.
+metadata:
+  homepage: https://github.com/ShaftHQ/SHAFT_ENGINE/tree/main/tools/shaft-mcp-server
+---
+
+# SHAFT MCP Automation Skill
+
+## Purpose
+
+Use this skill when an AI agent has access to the SHAFT MCP server. Prefer it
+for QA automation workflows where the agent needs SHAFT project context,
+validation evidence, and report summaries.
+
+Use Playwright MCP for direct browser exploration. Use SHAFT MCP for framework
+orchestration and report analysis.
+
+## Default Workflow
+
+1. Call `shaft_project_info` first.
+   - Confirm the workspace is SHAFT_ENGINE.
+   - Check Java/Maven metadata and report artifact inventory.
+
+2. Choose the narrowest safe validation.
+   - Use `shaft_run_validation` with `validate` for a cheap setup check.
+   - Use `compile` or `test-compile` before source/test changes.
+   - Use `specific-test` for focused test verification.
+   - Use `unit-tests-regex` only when a broad unit slice is justified.
+
+3. After tests run, call `shaft_extract_allure_failures`.
+   - Count total Allure result JSON files before drawing conclusions.
+   - If the result count is zero or unexpectedly low, treat the run as invalid.
+
+4. Call `shaft_list_report_artifacts` and `shaft_read_report_artifact` when
+   supporting evidence is needed.
+
+5. Prepare findings with:
+   - affected files and lines
+   - exact commands/tools used
+   - expected versus actual behavior
+   - impact
+   - minimal safe fix direction
+   - remaining uncertainty
+
+## Installation Awareness
+
+If the SHAFT MCP server is not available as tools, tell the user to install or
+configure it first. The starter server uses stdio transport and lives at:
+
+```text
+tools/shaft-mcp-server/src/index.js
+```
+
+The MCP client must set:
+
+```text
+SHAFT_WORKSPACE=/absolute/path/to/SHAFT_ENGINE
+```
+
+Useful config examples are in:
+
+- `tools/shaft-mcp-server/examples/codex-config.example.toml`
+- `tools/shaft-mcp-server/examples/claude-desktop-config.example.json`
+- `tools/shaft-mcp-server/examples/mcp-client-config.example.json`
+
+## Safety Rules
+
+- Do not ask the MCP server to expose raw secrets.
+- Do not paste literal credential values into reports or public issues.
+- Do not rely on Maven exit code alone; SHAFT may intentionally continue after
+  failures so reporting can finish.
+- Treat Allure result JSON as the primary SHAFT test oracle only after verifying
+  the result count is populated.
+- Cross-check Surefire reports when Allure and Maven disagree.
+
+## Suggested Prompts
+
+### Failure Triage
+
+```text
+Use SHAFT MCP to inspect the workspace, run the narrowest relevant validation,
+summarize Allure failures, and produce a maintainer-ready issue draft with
+commands, file references, expected behavior, actual behavior, impact, and
+minimal fix direction.
+```
+
+### Release Confidence
+
+```text
+Use SHAFT MCP to run validate, compile, test-compile, and the relevant test
+selector. Then inspect Allure and Surefire artifacts and report whether the
+release evidence is complete, incomplete, or blocked.
+```
+
+### Reporting Consistency
+
+```text
+Use SHAFT MCP to compare Allure result counts and failure summaries against
+Surefire report artifacts. Flag any mismatch where the authoritative report can
+hide a failing test.
+```

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target/
+/tools/shaft-mcp-server/node_modules/
 /allure-results/
 /allure-report/
 /allure-report-check/

--- a/docs/SHAFT_MCP_SERVER.md
+++ b/docs/SHAFT_MCP_SERVER.md
@@ -1,0 +1,140 @@
+# SHAFT MCP Server Community Proposal
+
+## Recommendation
+
+Build SHAFT MCP as a high-level QA automation MCP server, not as a replacement
+for Playwright MCP.
+
+- **Playwright MCP** should remain the preferred tool for direct browser
+  operation: navigate, click, type, inspect accessibility snapshots, and capture
+  screenshots.
+- **SHAFT MCP** should focus on SHAFT workflows: run Maven/TestNG suites,
+  inspect Allure and SHAFT reports, summarize failures, and guide agents through
+  web, API, mobile, database, CLI, and reporting evidence.
+
+In short:
+
+```text
+Playwright MCP = browser control
+SHAFT MCP      = QA framework orchestration and reporting
+```
+
+## MVP
+
+The starter server in `tools/shaft-mcp-server/` exposes:
+
+- `shaft_project_info`
+- `shaft_run_validation`
+- `shaft_extract_allure_failures`
+- `shaft_list_report_artifacts`
+- `shaft_read_report_artifact`
+- `shaft://guidance/agents`
+- `shaft://project/pom`
+
+This is deliberately small. It gives agents enough capability to validate a
+SHAFT checkout and reason over results without taking over the whole framework.
+
+## Full Capability Map
+
+| Capability | MVP Tooling | Requirement Before It Is Truly End-to-End |
+| --- | --- | --- |
+| Workspace onboarding | `shaft_project_info`, `shaft://guidance/agents`, `shaft://project/pom` | Add dependency/workflow inventory and environment diagnostics |
+| Java/Maven setup validation | `shaft_run_validation` with `validate`, `compile`, `test-compile` | Add JDK/Maven discovery and maintainer-approved self-provisioning if desired |
+| Existing unit tests | `shaft_run_validation` with `specific-test` and `unit-tests-regex` | Add suite discovery and safer profile selection |
+| Allure result analysis | `shaft_extract_allure_failures` | Add history/trend comparison and broken-test clustering |
+| Surefire/report artifact reading | `shaft_list_report_artifacts`, `shaft_read_report_artifact` | Add `shaft_compare_surefire_allure` for oracle mismatch detection |
+| Web browser tests | Existing Maven tests can run if browser/grid is already configured | Add Selenium Grid lifecycle tools and structured WebDriver snapshots |
+| API tests | Existing Maven tests can run if the target API is available | Add sanitized request/response summaries and API environment checks |
+| Android tests | Existing Maven tests can run if device/emulator/Appium are ready | Add Android device listing, emulator readiness, and Appium lifecycle tools |
+| iOS tests | Existing Maven tests can run if macOS/device/Appium are ready | Add iOS device listing and Appium lifecycle tools |
+| Database tests | Existing Maven tests can run if DB is available | Add DB readiness checks that never expose credentials |
+| CLI tests | Existing Maven tests can run | Add narrow SHAFT CLI helpers; avoid generic shell execution |
+| Cloud execution | Existing Maven tests can run if credentials are configured | Add BrowserStack/LambdaTest wrappers with strict redaction |
+| Desktop UI | Not a SHAFT MCP responsibility today | Use a dedicated desktop MCP or define an Appium desktop path separately |
+| Maintainer reports | Agent can draft reports from tool output | Add optional GitHub issue/advisory helpers only after redaction policy is accepted |
+
+## Why This Shape
+
+Direct browser-control MCP tools need a strong structured snapshot model. SHAFT
+currently wraps Selenium/Appium and focuses on fluent test automation and rich
+reporting. A browser-control MCP layer would need to design:
+
+- stable element references
+- accessibility or DOM snapshots
+- session lifecycle management
+- screenshot and artifact streaming
+- safe cleanup for WebDriver/Appium sessions
+
+Until that exists, duplicating Playwright MCP's browser surface would likely be
+less reliable than using Playwright MCP directly.
+
+The SHAFT-specific value is higher at the framework/reporting layer:
+
+- run existing SHAFT tests
+- inspect generated Allure result JSON
+- detect Maven/Surefire/Allure mismatches
+- summarize failed tests for maintainers
+- preserve SHAFT's batteries-included workflow
+
+## Security Requirements
+
+SHAFT MCP should never expose secrets through tool output.
+
+Required defaults:
+
+- no generic shell execution tool
+- no raw environment dump
+- no credential printing
+- no unrestricted filesystem read
+- output redaction before returning logs/artifacts to the agent
+- allow-listed report directories
+- explicit workspace root
+
+Security-sensitive future tools, such as GitHub advisory reporting or cloud
+provider debugging, should be added only after the project has a central
+redaction utility and clear maintainer approval.
+
+## Future Tool Candidates
+
+After the MVP stabilizes, useful additions would be:
+
+| Tool | Purpose |
+| --- | --- |
+| `shaft_run_test_class` | Dedicated wrapper for one TestNG/JUnit class |
+| `shaft_compare_surefire_allure` | Detect report-oracle mismatches |
+| `shaft_generate_failure_brief` | Produce a maintainer-ready failure summary |
+| `shaft_start_web_session` | Start a SHAFT WebDriver session |
+| `shaft_snapshot_web_session` | Return a compact structured page snapshot |
+| `shaft_stop_session` | Cleanup WebDriver/Appium sessions |
+| `shaft_api_request_from_config` | Run a safe SHAFT API request from sanitized config |
+
+## Maintainer Handoff
+
+The current starter is a reviewable contribution seed:
+
+1. It is standalone under `tools/shaft-mcp-server/`.
+2. It does not change SHAFT's published Maven artifact.
+3. It uses the official MCP TypeScript SDK.
+4. It includes a smoke test that starts the MCP server, lists tools, and calls
+   `shaft_project_info`.
+5. It can evolve into a separate package or be moved into another repository if
+   maintainers prefer to keep MCP tooling outside the engine repository.
+
+## Client Compatibility
+
+The server uses stdio MCP transport. It should work with any MCP client that can
+launch a local command and pass environment variables.
+
+Confirmed by smoke test:
+
+```bash
+cd tools/shaft-mcp-server
+npm ci
+npm run smoke
+```
+
+Configuration examples are included for:
+
+- Codex: `tools/shaft-mcp-server/examples/codex-config.example.toml`
+- Claude Desktop: `tools/shaft-mcp-server/examples/claude-desktop-config.example.json`
+- Generic MCP clients: `tools/shaft-mcp-server/examples/mcp-client-config.example.json`

--- a/tools/shaft-mcp-server/README.md
+++ b/tools/shaft-mcp-server/README.md
@@ -1,0 +1,240 @@
+# SHAFT MCP Server Starter
+
+This is a community starter for a SHAFT Engine Model Context Protocol (MCP)
+server. It is intentionally separate from the main `SHAFT_ENGINE` Maven
+artifact so maintainers can review and evolve the interface without adding MCP
+runtime dependencies to every SHAFT user.
+
+## Goal
+
+Playwright MCP is excellent for live browser control. This starter focuses on
+the SHAFT layer instead:
+
+- inspect a SHAFT workspace
+- run allow-listed Maven validations
+- summarize Allure result JSON
+- list/read SHAFT report artifacts
+- expose repository guidance as MCP resources
+
+That makes the MCP server useful for AI agents that need to behave like QA
+automation assistants rather than only browser operators.
+
+## Current Status
+
+This starter is a tested MVP.
+
+It can run SHAFT/Maven validation profiles and analyze generated reports. It
+does not yet start Selenium Grid, Appium, emulators, BrowserStack, LambdaTest,
+or desktop UI automation sessions by itself. Those are mapped below as roadmap
+items.
+
+## Tools
+
+| Tool | Purpose |
+| --- | --- |
+| `shaft_project_info` | Read SHAFT project metadata and report inventory without running tests |
+| `shaft_run_validation` | Run allow-listed Maven validation profiles |
+| `shaft_extract_allure_failures` | Summarize Allure result JSON statuses and failures |
+| `shaft_list_report_artifacts` | List generated SHAFT report artifacts |
+| `shaft_read_report_artifact` | Read a text artifact from known report directories |
+
+## Resources
+
+| Resource | Purpose |
+| --- | --- |
+| `shaft://guidance/agents` | Repository-specific agent guidance from `AGENTS.md` |
+| `shaft://project/pom` | Project `pom.xml` for dependency/version context |
+
+## Capability Map
+
+| Area | Works in this MVP | Future end-to-end MCP tools |
+| --- | --- | --- |
+| Project discovery | Yes: `shaft_project_info` | Add richer dependency, workflow, and environment checks |
+| Maven validation | Yes: `shaft_run_validation` allow-listed profiles | Add named suite/profile discovery |
+| Web/Selenium tests | Runs existing Maven tests if the local browser/grid is already configured | `shaft_start_selenium_grid`, `shaft_run_web_suite`, `shaft_stop_selenium_grid` |
+| API tests | Runs existing Maven/API tests | `shaft_run_api_suite`, sanitized request/response report summaries |
+| Android/Appium | Runs existing tests only if device/Appium prerequisites already exist | `shaft_list_android_devices`, `shaft_start_appium`, `shaft_run_android_suite` |
+| iOS/Appium | Runs existing tests only if macOS/device/Appium prerequisites already exist | `shaft_list_ios_devices`, `shaft_run_ios_suite` |
+| Desktop UI | Not direct. SHAFT is not primarily a desktop UI automation framework | Integrate with a dedicated desktop MCP or future Appium Windows/macOS path |
+| CLI tests | Runs existing Maven tests; no generic shell tool is exposed | Add narrow, safe SHAFT CLI workflow helpers |
+| DB tests | Runs existing Maven tests if DB is already available | Add DB service readiness/report helpers without exposing credentials |
+| Cloud providers | Runs existing tests if credentials/config are already present | `shaft_run_browserstack_suite`, `shaft_run_lambdatest_suite` with strict redaction |
+| Reporting | Yes: Allure/Surefire/report artifact inventory and summaries | `shaft_compare_surefire_allure`, `shaft_generate_failure_brief` |
+| GitHub reporting | Not included in the server | Add optional private-safe issue/advisory draft helpers after maintainer approval |
+
+## Install and Run Locally
+
+From this directory:
+
+```bash
+npm install
+npm run smoke
+```
+
+Example MCP client configuration:
+
+```json
+{
+  "mcpServers": {
+    "shaft": {
+      "command": "node",
+      "args": ["/absolute/path/to/SHAFT_ENGINE/tools/shaft-mcp-server/src/index.js"],
+      "env": {
+        "SHAFT_WORKSPACE": "/absolute/path/to/SHAFT_ENGINE"
+      }
+    }
+  }
+}
+```
+
+After configuration, restart the MCP client and ask the agent:
+
+```text
+Use SHAFT MCP to inspect project info.
+```
+
+or:
+
+```text
+Use SHAFT MCP to run validate and summarize report artifacts.
+```
+
+## Install Options
+
+### Option A: Run from a SHAFT checkout
+
+Use this while the server lives inside the SHAFT repository:
+
+```bash
+git clone https://github.com/ShaftHQ/SHAFT_ENGINE.git
+cd SHAFT_ENGINE/tools/shaft-mcp-server
+npm ci
+npm run smoke
+```
+
+Configure your MCP client to run:
+
+```bash
+node /absolute/path/to/SHAFT_ENGINE/tools/shaft-mcp-server/src/index.js
+```
+
+and set:
+
+```bash
+SHAFT_WORKSPACE=/absolute/path/to/SHAFT_ENGINE
+```
+
+### Option B: Install as a local command
+
+From `tools/shaft-mcp-server`:
+
+```bash
+npm install -g .
+shaft-mcp
+```
+
+Then configure your MCP client with command `shaft-mcp` and the
+`SHAFT_WORKSPACE` environment variable.
+
+### Option C: Future npm package
+
+If maintainers publish this package to npm, MCP clients can use:
+
+```json
+{
+  "command": "npx",
+  "args": ["-y", "@shafthq/shaft-mcp-server"],
+  "env": {
+    "SHAFT_WORKSPACE": "/absolute/path/to/SHAFT_ENGINE"
+  }
+}
+```
+
+## Client Configuration
+
+### Codex
+
+Add a server entry to `~/.codex/config.toml`:
+
+```toml
+[features]
+rmcp_client = true
+
+[mcp_servers.shaft]
+command = "node"
+args = ["C:\\Users\\you\\path\\to\\SHAFT_ENGINE\\tools\\shaft-mcp-server\\src\\index.js"]
+startup_timeout_sec = 120
+tool_timeout_sec = 600
+
+[mcp_servers.shaft.env]
+SHAFT_WORKSPACE = "C:\\Users\\you\\path\\to\\SHAFT_ENGINE"
+```
+
+Restart Codex after editing the config.
+
+### Claude Desktop
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "shaft": {
+      "command": "node",
+      "args": [
+        "C:/Users/you/path/to/SHAFT_ENGINE/tools/shaft-mcp-server/src/index.js"
+      ],
+      "env": {
+        "SHAFT_WORKSPACE": "C:/Users/you/path/to/SHAFT_ENGINE"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop after editing the config.
+
+### Claude Code and Other MCP Clients
+
+Use the same stdio launch shape:
+
+```json
+{
+  "mcpServers": {
+    "shaft": {
+      "command": "node",
+      "args": ["/absolute/path/to/SHAFT_ENGINE/tools/shaft-mcp-server/src/index.js"],
+      "env": {
+        "SHAFT_WORKSPACE": "/absolute/path/to/SHAFT_ENGINE"
+      }
+    }
+  }
+}
+```
+
+For clients that support a command-line MCP registration flow, register the
+same command, args, and environment variable. The server uses stdio transport,
+so no port or HTTP endpoint is required.
+
+## Safety Model
+
+The starter deliberately avoids a generic shell tool.
+
+- Maven execution is allow-listed by validation profile.
+- Commands are executed with argument arrays, not shell-string interpolation.
+- Report reading is restricted to known SHAFT report directories.
+- Output is truncated and redacts common secret patterns before returning it to
+  the agent.
+- `SHAFT_WORKSPACE` must point at a checkout whose `pom.xml` contains the
+  `SHAFT_ENGINE` artifact id.
+
+## Recommended Roadmap
+
+1. Keep this server focused on SHAFT-level workflow first: run tests, inspect
+   reports, explain failures.
+2. Add browser/session tools only after a structured snapshot design exists.
+   Otherwise Playwright MCP remains the better browser-control backend.
+3. Add a Java-side adapter only if maintainers want direct access to SHAFT
+   runtime APIs instead of Maven/report orchestration.
+4. Add private-safe GitHub issue/advisory draft helpers only after the project
+   has a central redaction policy.

--- a/tools/shaft-mcp-server/examples/claude-desktop-config.example.json
+++ b/tools/shaft-mcp-server/examples/claude-desktop-config.example.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "shaft": {
+      "command": "node",
+      "args": [
+        "C:/path/to/SHAFT_ENGINE/tools/shaft-mcp-server/src/index.js"
+      ],
+      "env": {
+        "SHAFT_WORKSPACE": "C:/path/to/SHAFT_ENGINE"
+      }
+    }
+  }
+}

--- a/tools/shaft-mcp-server/examples/codex-config.example.toml
+++ b/tools/shaft-mcp-server/examples/codex-config.example.toml
@@ -1,0 +1,11 @@
+[features]
+rmcp_client = true
+
+[mcp_servers.shaft]
+command = "node"
+args = ["C:\\path\\to\\SHAFT_ENGINE\\tools\\shaft-mcp-server\\src\\index.js"]
+startup_timeout_sec = 120
+tool_timeout_sec = 600
+
+[mcp_servers.shaft.env]
+SHAFT_WORKSPACE = "C:\\path\\to\\SHAFT_ENGINE"

--- a/tools/shaft-mcp-server/examples/mcp-client-config.example.json
+++ b/tools/shaft-mcp-server/examples/mcp-client-config.example.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "shaft": {
+      "command": "node",
+      "args": [
+        "/absolute/path/to/SHAFT_ENGINE/tools/shaft-mcp-server/src/index.js"
+      ],
+      "env": {
+        "SHAFT_WORKSPACE": "/absolute/path/to/SHAFT_ENGINE"
+      }
+    }
+  }
+}

--- a/tools/shaft-mcp-server/package-lock.json
+++ b/tools/shaft-mcp-server/package-lock.json
@@ -1,0 +1,1149 @@
+{
+  "name": "@shafthq/shaft-mcp-server",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@shafthq/shaft-mcp-server",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.1.13"
+      },
+      "bin": {
+        "shaft-mcp": "src/index.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/tools/shaft-mcp-server/package.json
+++ b/tools/shaft-mcp-server/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@shafthq/shaft-mcp-server",
+  "version": "0.1.0",
+  "description": "Community starter MCP server for SHAFT Engine automation and reporting workflows.",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "shaft-mcp": "./src/index.js"
+  },
+  "files": [
+    "examples",
+    "scripts",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "check": "node --check src/index.js && node --check scripts/smoke-test.mjs",
+    "smoke": "node scripts/smoke-test.mjs"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.1.13"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/tools/shaft-mcp-server/scripts/smoke-test.mjs
+++ b/tools/shaft-mcp-server/scripts/smoke-test.mjs
@@ -1,0 +1,66 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageRoot = path.resolve(__dirname, "..");
+const repoRoot = path.resolve(packageRoot, "..", "..");
+const serverPath = path.join(packageRoot, "src", "index.js");
+
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: [serverPath],
+  env: {
+    ...process.env,
+    SHAFT_WORKSPACE: repoRoot,
+  },
+});
+
+const client = new Client({
+  name: "shaft-mcp-smoke-test",
+  version: "0.1.0",
+});
+
+try {
+  await client.connect(transport);
+  const tools = await client.listTools();
+  const toolNames = tools.tools.map((tool) => tool.name);
+  const requiredTools = [
+    "shaft_project_info",
+    "shaft_run_validation",
+    "shaft_extract_allure_failures",
+    "shaft_list_report_artifacts",
+    "shaft_read_report_artifact",
+  ];
+  for (const tool of requiredTools) {
+    if (!toolNames.includes(tool)) {
+      throw new Error(`Missing MCP tool: ${tool}`);
+    }
+  }
+
+  const info = await client.callTool({
+    name: "shaft_project_info",
+    arguments: {},
+  });
+  const text = info.content?.[0]?.text || "";
+  if (!text.includes("SHAFT_ENGINE")) {
+    throw new Error("shaft_project_info did not return SHAFT_ENGINE metadata.");
+  }
+
+  await client.callTool({
+    name: "shaft_list_report_artifacts",
+    arguments: {},
+  });
+
+  await client.callTool({
+    name: "shaft_extract_allure_failures",
+    arguments: { resultsDir: "allure-results", limit: 5 },
+  });
+
+  console.log(`Smoke test passed. Tools: ${toolNames.join(", ")}`);
+} finally {
+  await client.close();
+}

--- a/tools/shaft-mcp-server/src/index.js
+++ b/tools/shaft-mcp-server/src/index.js
@@ -1,0 +1,423 @@
+#!/usr/bin/env node
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { spawn } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { z } from "zod";
+
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+const MAX_OUTPUT_CHARS = 24_000;
+const MAX_ARTIFACT_CHARS = 80_000;
+const MAX_FAILURES = 50;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageRoot = path.resolve(__dirname, "..");
+
+const workspaceRoot = await resolveWorkspaceRoot();
+
+const server = new McpServer({
+  name: "shaft-mcp-server",
+  version: "0.1.0",
+});
+
+server.tool(
+  "shaft_project_info",
+  "Use this first in a SHAFT Engine workspace. Returns repository, Maven, Java config, and report-artifact inventory without running tests.",
+  {},
+  async () => withToolErrors(async () => {
+    const pom = await readTextIfExists(path.join(workspaceRoot, "pom.xml"));
+    const packageVersion = firstMatch(pom, /<version>([^<]+)<\/version>/);
+    const artifactId = firstMatch(pom, /<artifactId>([^<]+)<\/artifactId>/);
+    const groupId = firstMatch(pom, /<groupId>([^<]+)<\/groupId>/);
+    const javaVersion = (await readTextIfExists(path.join(workspaceRoot, ".java-version"))).trim();
+    const sdkman = (await readTextIfExists(path.join(workspaceRoot, ".sdkmanrc"))).trim();
+    const git = await runProcess("git", ["rev-parse", "--short=12", "HEAD"], { timeoutMs: 15_000, allowFailure: true });
+    const reports = await collectReportInventory();
+
+    return jsonContent({
+      workspaceRoot,
+      maven: {
+        groupId,
+        artifactId,
+        version: packageVersion,
+      },
+      java: {
+        javaVersionFile: javaVersion || null,
+        sdkman: sdkman || null,
+      },
+      git: {
+        shortHead: git.exitCode === 0 ? git.stdout.trim() : null,
+      },
+      reports,
+    });
+  })
+);
+
+server.tool(
+  "shaft_run_validation",
+  "Run an allow-listed SHAFT Maven validation command. Use this for compile/test evidence; it does not execute arbitrary shell commands.",
+  {
+    profile: z.enum(["validate", "compile", "test-compile", "specific-test", "unit-tests-regex"])
+      .describe("Validation profile to run."),
+    testSelector: z.string().trim().min(1).max(250).optional()
+      .describe("Required for specific-test. Example: testPackage.unitTests.JavaHelperUnitTest"),
+    timeoutMs: z.number().int().min(30_000).max(3_600_000).default(DEFAULT_TIMEOUT_MS)
+      .describe("Maximum runtime in milliseconds."),
+  },
+  async ({ profile, testSelector, timeoutMs }) => withToolErrors(async () => {
+    const args = mavenArgsForProfile(profile, testSelector);
+    const result = await runProcess(mavenCommand(), args, {
+      cwd: workspaceRoot,
+      timeoutMs,
+      allowFailure: true,
+      env: process.env,
+    });
+
+    return jsonContent({
+      command: [mavenCommand(), ...args],
+      exitCode: result.exitCode,
+      timedOut: result.timedOut,
+      stdout: trimAndRedact(result.stdout),
+      stderr: trimAndRedact(result.stderr),
+      reportInventory: await collectReportInventory(),
+    });
+  })
+);
+
+server.tool(
+  "shaft_extract_allure_failures",
+  "Read SHAFT Allure result JSON and summarize failed/broken/skipped/passed counts plus failing test names. Use after running tests.",
+  {
+    resultsDir: z.string().trim().min(1).max(260).default("allure-results")
+      .describe("Path to Allure results, relative to the SHAFT workspace."),
+    limit: z.number().int().min(1).max(200).default(MAX_FAILURES)
+      .describe("Maximum failure records to return."),
+  },
+  async ({ resultsDir, limit }) => withToolErrors(async () => {
+    const resolved = safeWorkspacePath(resultsDir);
+    const files = await listFilesIfExists(resolved, (name) => name.endsWith("-result.json"));
+    const summary = {
+      resultsDir: path.relative(workspaceRoot, resolved) || ".",
+      totalResultFiles: files.length,
+      statuses: {},
+      failures: [],
+    };
+
+    for (const file of files) {
+      const raw = await fs.readFile(file, "utf8");
+      const result = JSON.parse(raw);
+      const status = result.status || "unknown";
+      summary.statuses[status] = (summary.statuses[status] || 0) + 1;
+      if ((status === "failed" || status === "broken") && summary.failures.length < limit) {
+        summary.failures.push({
+          name: result.fullName || result.name || path.basename(file),
+          status,
+          message: trimAndRedact(result.statusDetails?.message || "", 2_000),
+          trace: trimAndRedact(result.statusDetails?.trace || "", 4_000),
+        });
+      }
+    }
+
+    return jsonContent(summary);
+  })
+);
+
+server.tool(
+  "shaft_list_report_artifacts",
+  "List SHAFT-generated report artifacts such as Allure results, Surefire reports, execution summaries, and generated reports.",
+  {},
+  async () => withToolErrors(async () => jsonContent(await collectReportInventory()))
+);
+
+server.tool(
+  "shaft_read_report_artifact",
+  "Read a text report artifact from known SHAFT report directories. Use for Surefire summaries, execution summaries, and small JSON report files.",
+  {
+    artifactPath: z.string().trim().min(1).max(500)
+      .describe("Relative path under a known report directory, for example target/surefire-reports/TestSuite.txt."),
+    maxChars: z.number().int().min(1_000).max(MAX_ARTIFACT_CHARS).default(24_000)
+      .describe("Maximum characters to return."),
+  },
+  async ({ artifactPath, maxChars }) => withToolErrors(async () => {
+    const resolved = safeReportArtifactPath(artifactPath);
+    const stat = await fs.stat(resolved);
+    if (!stat.isFile()) {
+      throw new Error(`Report artifact is not a file: ${artifactPath}`);
+    }
+    const text = await fs.readFile(resolved, "utf8");
+    return textContent(trimAndRedact(text, maxChars));
+  })
+);
+
+server.resource(
+  "shaft-agents-guidance",
+  "shaft://guidance/agents",
+  async (uri) => ({
+    contents: [{
+      uri: uri.href,
+      mimeType: "text/markdown",
+      text: await readTextIfExists(path.join(workspaceRoot, "AGENTS.md")),
+    }],
+  })
+);
+
+server.resource(
+  "shaft-project-pom",
+  "shaft://project/pom",
+  async (uri) => ({
+    contents: [{
+      uri: uri.href,
+      mimeType: "application/xml",
+      text: await readTextIfExists(path.join(workspaceRoot, "pom.xml")),
+    }],
+  })
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+
+async function resolveWorkspaceRoot() {
+  const configured = process.env.SHAFT_WORKSPACE || process.cwd();
+  const resolved = path.resolve(configured);
+  const pomPath = path.join(resolved, "pom.xml");
+  try {
+    const pom = await fs.readFile(pomPath, "utf8");
+    if (!pom.includes("<artifactId>SHAFT_ENGINE</artifactId>")) {
+      throw new Error(`pom.xml at ${pomPath} is not SHAFT_ENGINE`);
+    }
+  } catch (error) {
+    throw new Error(`SHAFT_WORKSPACE must point to a SHAFT_ENGINE checkout. ${error.message}`);
+  }
+  return resolved;
+}
+
+function mavenArgsForProfile(profile, testSelector) {
+  const common = ["-Dgpg.skip=true"];
+  switch (profile) {
+    case "validate":
+      return ["validate", ...common];
+    case "compile":
+      return ["clean", "compile", "-DskipTests", ...common];
+    case "test-compile":
+      return ["test-compile", ...common];
+    case "specific-test":
+      if (!testSelector) {
+        throw new Error("testSelector is required when profile is specific-test.");
+      }
+      return ["test", ...common, `-Dtest=${testSelector}`];
+    case "unit-tests-regex":
+      return [
+        "test",
+        ...common,
+        "-DdefaultElementIdentificationTimeout=5",
+        "-DexecutionAddress=local",
+        "-DtargetOperatingSystem=WINDOWS",
+        "-DheadlessExecution=true",
+        "-Dtest=%regex[.*UnitTest.*]",
+      ];
+    default:
+      throw new Error(`Unsupported validation profile: ${profile}`);
+  }
+}
+
+function mavenCommand() {
+  return process.platform === "win32" ? "mvn.cmd" : "mvn";
+}
+
+async function collectReportInventory() {
+  const knownDirs = [
+    "allure-results",
+    "allure-report",
+    "target/surefire-reports",
+    "execution-summary",
+    "generatedReport",
+    "performanceReport",
+    "lighthouse-reports",
+    "accessibility-reports",
+  ];
+  const inventory = {};
+  for (const relativeDir of knownDirs) {
+    const absoluteDir = path.join(workspaceRoot, relativeDir);
+    const files = await listFilesIfExists(absoluteDir);
+    inventory[relativeDir] = {
+      exists: files.length > 0 || await pathExists(absoluteDir),
+      fileCount: files.length,
+      sampleFiles: files.slice(0, 25).map((file) => normalizePath(path.relative(workspaceRoot, file))),
+    };
+  }
+  return inventory;
+}
+
+async function listFilesIfExists(root, filter = () => true) {
+  if (!await pathExists(root)) {
+    return [];
+  }
+  const files = [];
+  await walk(root, files, filter);
+  files.sort();
+  return files;
+}
+
+async function walk(current, files, filter) {
+  const entries = await fs.readdir(current, { withFileTypes: true });
+  for (const entry of entries) {
+    const absolute = path.join(current, entry.name);
+    if (entry.isDirectory()) {
+      await walk(absolute, files, filter);
+    } else if (entry.isFile() && filter(entry.name, absolute)) {
+      files.push(absolute);
+    }
+  }
+}
+
+async function readTextIfExists(filePath) {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return "";
+    }
+    throw error;
+  }
+}
+
+async function pathExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runProcess(command, args, options = {}) {
+  const {
+    cwd = workspaceRoot,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    allowFailure = false,
+    env = process.env,
+  } = options;
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env,
+      shell: false,
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+    }, timeoutMs);
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+      if (stdout.length > MAX_OUTPUT_CHARS * 2) {
+        stdout = stdout.slice(-MAX_OUTPUT_CHARS);
+      }
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+      if (stderr.length > MAX_OUTPUT_CHARS * 2) {
+        stderr = stderr.slice(-MAX_OUTPUT_CHARS);
+      }
+    });
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      if (allowFailure) {
+        resolve({ exitCode: -1, timedOut, stdout, stderr: error.message });
+      } else {
+        reject(error);
+      }
+    });
+    child.on("close", (exitCode) => {
+      clearTimeout(timeout);
+      const result = { exitCode, timedOut, stdout, stderr };
+      if (!allowFailure && exitCode !== 0) {
+        reject(new Error(`${command} exited ${exitCode}: ${stderr || stdout}`));
+      } else {
+        resolve(result);
+      }
+    });
+  });
+}
+
+function safeWorkspacePath(relativePath) {
+  const resolved = path.resolve(workspaceRoot, relativePath);
+  if (!resolved.startsWith(workspaceRoot + path.sep) && resolved !== workspaceRoot) {
+    throw new Error(`Path escapes SHAFT workspace: ${relativePath}`);
+  }
+  return resolved;
+}
+
+function safeReportArtifactPath(relativePath) {
+  const normalized = normalizePath(relativePath);
+  const allowedRoots = [
+    "allure-results/",
+    "target/surefire-reports/",
+    "execution-summary/",
+    "generatedReport/",
+    "performanceReport/",
+    "lighthouse-reports/",
+    "accessibility-reports/",
+  ];
+  if (!allowedRoots.some((root) => normalized.startsWith(root))) {
+    throw new Error(`Only known SHAFT report artifacts can be read. Rejected: ${relativePath}`);
+  }
+  return safeWorkspacePath(normalized);
+}
+
+function trimAndRedact(value, maxChars = MAX_OUTPUT_CHARS) {
+  const redacted = redactSecrets(String(value ?? ""));
+  if (redacted.length <= maxChars) {
+    return redacted;
+  }
+  return `${redacted.slice(0, maxChars)}\n...[truncated ${redacted.length - maxChars} chars]`;
+}
+
+function redactSecrets(value) {
+  return value
+    .replace(/(authorization\s*[:=]\s*)([^\s,;]+)/gi, "$1[REDACTED]")
+    .replace(/((?:access[_-]?key|api[_-]?key|api[_-]?secret|token|password|passwd|secret|cookie|set-cookie)\s*[:=]\s*)([^\s,;]+)/gi, "$1[REDACTED]")
+    .replace(/(https?:\/\/[^:\s/@]+:)([^@\s/]+)(@)/gi, "$1[REDACTED]$3")
+    .replace(/(measurement_id=[^&\s]+&api_secret=)([^&\s]+)/gi, "$1[REDACTED]");
+}
+
+function firstMatch(value, regex) {
+  return regex.exec(value)?.[1] ?? null;
+}
+
+function normalizePath(value) {
+  return value.replace(/\\/g, "/");
+}
+
+function jsonContent(value) {
+  return {
+    content: [{ type: "text", text: JSON.stringify(value, null, 2) }],
+  };
+}
+
+function textContent(value) {
+  return {
+    content: [{ type: "text", text: value }],
+  };
+}
+
+async function withToolErrors(handler) {
+  try {
+    return await handler();
+  } catch (error) {
+    return {
+      content: [{ type: "text", text: `SHAFT MCP tool failed: ${redactSecrets(error.message)}` }],
+      isError: true,
+    };
+  }
+}


### PR DESCRIPTION
## Description

This PR proposes a community SHAFT MCP server starter so AI agents can interact with SHAFT at the QA-framework layer instead of only controlling a browser.

The goal is not to replace Playwright MCP. Playwright remains better for live browser clicks/snapshots. This starter focuses on SHAFT-specific value: Maven validation, Allure/Surefire/report artifact inspection, and maintainer-ready QA workflow summaries.

Requested by Elhusseiny Ibrahim and prepared with Codex as an open-source contribution seed for maintainer review and opinion.

## What is included

- A standalone stdio MCP server under `tools/shaft-mcp-server/`
- Tool map: `shaft_project_info`, `shaft_run_validation`, `shaft_extract_allure_failures`, `shaft_list_report_artifacts`, `shaft_read_report_artifact`
- MCP resources: `shaft://guidance/agents`, `shaft://project/pom`
- Client install/config examples for Codex, Claude Desktop, and generic MCP clients / Claude Code-style clients
- A full capability roadmap covering Web, API, Android, iOS, DB, CLI, cloud providers, reporting, and desktop boundaries
- A `shaft-mcp` skill under `.github/skills/` for agents connected to the MCP server

## Design choices

- Kept the MCP server outside the main Maven artifact so this does not add MCP/Node dependencies to normal SHAFT users.
- Used stdio transport so it works with MCP clients that can launch a local command.
- Avoided a generic shell tool. Maven execution is allow-listed by validation profile.
- Restricted artifact reading to known SHAFT report directories.
- Added output truncation and common secret redaction before returning logs/artifacts to the agent.
- Documented the current MVP honestly: it runs existing SHAFT/Maven validations and reads reports, but does not yet manage Selenium Grid, Appium, emulators, BrowserStack, LambdaTest, or desktop UI sessions end to end.

## Validation performed

From `tools/shaft-mcp-server`:

```bash
npm ci
npm run check
npm run smoke
npm audit --audit-level=moderate
npm pack --dry-run
```

Results:

- `npm run check` passed
- `npm run smoke` passed and listed all expected MCP tools
- `npm audit --audit-level=moderate` found 0 vulnerabilities
- `npm pack --dry-run` confirmed the npm package includes README, examples, scripts, and source files

## Notes for maintainers

This is intentionally a first reviewable slice, not the final full-platform MCP. If maintainers like the direction, the next useful tools would be:

- `shaft_compare_surefire_allure`
- `shaft_generate_failure_brief`
- `shaft_start_selenium_grid` / `shaft_stop_selenium_grid`
- Android/Appium readiness tools
- BrowserStack/LambdaTest wrappers with strict redaction

I would appreciate maintainer feedback on whether this should live inside this repository under `tools/`, move to a separate repo/package, or be redesigned as a Java-side adapter around SHAFT APIs.