### PR TITLE
codex: Align CI failure logs with Allure results

### DIFF
--- a/.github/workflows/coverage-readiness.yml
+++ b/.github/workflows/coverage-readiness.yml
@@ -78,7 +78,7 @@ jobs:
         continue-on-error: true
         run: |
           if [ -d allure-results ]; then
-            scripts/ci/extract_allure_failures.py allure-results --surefire-reports target/surefire-reports | tee allure-failures.md
+            scripts/ci/extract_allure_failures.py allure-results | tee allure-failures.md
           else
             echo 'No allure-results directory was generated.' | tee allure-failures.md
           fi

--- a/scripts/ci/extract_allure_failures.py
+++ b/scripts/ci/extract_allure_failures.py
@@ -4,8 +4,10 @@
 The script accepts one or more Allure result directories, generated report
 folders, JSON files, or ZIP archives. It prints a Markdown table by default so
 CI jobs and issue triage notes can include exact failing methods and reasons.
-When Surefire XML paths are provided, it also flags Surefire failures
-that do not have a matching failed or broken Allure result.
+Allure failed and broken results are the single source of truth for the
+process exit status and Markdown failure table. Surefire XML can be parsed by
+helper functions for diagnostics, but CLI Markdown output intentionally stays
+limited to Allure failures so CI logs match the Allure summary.
 """
 
 import argparse
@@ -254,7 +256,7 @@ def parse_args() -> argparse.Namespace:
             """
             Examples:
               scripts/ci/extract_allure_failures.py allure-results
-              scripts/ci/extract_allure_failures.py allure-results --surefire-reports target/surefire-reports
+              scripts/ci/extract_allure_failures.py allure-results --surefire-reports target/surefire-reports --format json
               scripts/ci/extract_allure_failures.py artifacts/*.zip --format json
             """
         ),
@@ -265,7 +267,10 @@ def parse_args() -> argparse.Namespace:
         nargs="*",
         type=Path,
         default=[],
-        help="Optional Surefire XML report path(s) to cross-check against Allure failures",
+        help=(
+            "Optional Surefire XML report path(s) for JSON diagnostics only; "
+            "Allure remains the CLI Markdown and exit-code source of truth"
+        ),
     )
     parser.add_argument("--format", choices=("markdown", "json"), default="markdown", help="Output format")
     return parser.parse_args()
@@ -285,16 +290,8 @@ def main() -> int:
         )
     else:
         output = to_markdown(allure_failures)
-        if args.surefire_reports:
-            output = "\n\n".join(
-                [
-                    output,
-                    "## Surefire failures missing from Allure results",
-                    to_surefire_markdown(missing_failures),
-                ]
-            )
     print(output)
-    return 1 if allure_failures or missing_failures else 0
+    return 1 if allure_failures else 0
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_extract_allure_failures.py
+++ b/tests/scripts/test_extract_allure_failures.py
@@ -1,12 +1,16 @@
+import contextlib
+import io
 import json
 import tempfile
 import unittest
 import zipfile
 from pathlib import Path
+from unittest.mock import patch
 
 from scripts.ci.extract_allure_failures import (
     extract_failures,
     extract_surefire_failures,
+    main,
     missing_surefire_failures,
     to_comparison_json,
     to_markdown,
@@ -162,6 +166,43 @@ class ExtractAllureFailuresTests(unittest.TestCase):
             comparison_json["missingSurefireFailures"][0]["method"],
             "pkg.LightHouseGenerateReportCoverageUnitTest.missingFailure",
         )
+
+    def test_cli_markdown_uses_allure_as_single_source_of_truth(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            allure = root / "allure-results"
+            surefire = root / "surefire-reports"
+            allure.mkdir()
+            surefire.mkdir()
+            (allure / "passed-result.json").write_text(
+                json.dumps({"status": "passed", "name": "passes"}), encoding="utf-8"
+            )
+            (surefire / "TEST-TestSuite.xml").write_text(
+                """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite tests="1" failures="1" errors="0" skipped="0">
+  <testcase classname="pkg.ExampleTest" name="surefireOnlyFailure">
+    <failure message="this should not be printed below the Allure summary" />
+  </testcase>
+</testsuite>
+""",
+                encoding="utf-8",
+            )
+            output = io.StringIO()
+            with patch(
+                "sys.argv",
+                [
+                    "extract_allure_failures.py",
+                    str(allure),
+                    "--surefire-reports",
+                    str(surefire),
+                ],
+            ), contextlib.redirect_stdout(output):
+                exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("No failed or broken Allure test cases were found.", output.getvalue())
+        self.assertNotIn("Surefire failures missing from Allure results", output.getvalue())
+        self.assertNotIn("surefireOnlyFailure", output.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Prevent Surefire-only failures from expanding the job summary below the Allure report so the Allure report remains the single source of truth for test failures.

### Description
- Update `scripts/ci/extract_allure_failures.py` to limit CLI Markdown output and exit-code semantics to Allure `failed`/`broken` results while keeping Surefire parsing available for JSON diagnostics and `--format json` use.
- Adjust the `--surefire-reports` argument help text and example usage to emphasize Surefire is for diagnostics only and not included in the default Markdown output.
- Change `.github/workflows/coverage-readiness.yml` so the Extract Allure failures step calls the extractor with only `allure-results` (removing the default Surefire cross-check in the Markdown path).
- Add a regression unit test `test_cli_markdown_uses_allure_as_single_source_of_truth` in `tests/scripts/test_extract_allure_failures.py` to verify Surefire-only failures are not printed in the CLI Markdown output and the script exit code follows Allure results.

### Testing
- Ran `python -m unittest tests.scripts.test_extract_allure_failures -v` and the test suite passed (all tests OK).
- Ran the full script test discovery `python -m unittest discover -s tests/scripts -p 'test_*.py'` and all tests passed (OK).
- Verified the modified Coverage Readiness workflow step now consumes the extractor output produced from `allure-results` without appending Surefire-only failures to the job summary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03fc588a688320b9984e1ef58c7161)