### PR TITLE
codex: fix BrowserStack Android native properties config

### DIFF
--- a/docs/FLUTTER_TESTING.md
+++ b/docs/FLUTTER_TESTING.md
@@ -131,7 +131,7 @@ You can configure Flutter testing using properties file or programmatically:
 #### Properties File (custom.properties)
 ```properties
 # Platform configuration
-targetPlatform=Android
+targetOperatingSystem=Android
 
 # Automation name - setting this to FlutterIntegration automatically enables Flutter driver
 mobile_automationName=FlutterIntegration

--- a/src/main/java/com/shaft/driver/internal/DriverFactory/BrowserStackHelper.java
+++ b/src/main/java/com/shaft/driver/internal/DriverFactory/BrowserStackHelper.java
@@ -42,7 +42,7 @@ public class BrowserStackHelper {
      * @return a new Selenium WebDriver instance using BrowserStack
      */
     public static DriverFactoryHelper getBrowserStackDriver(MutableCapabilities browserStackOptions) {
-        String appUrl = SHAFT.Properties.browserStack.appUrl();
+        String appUrl = resolveBrowserStackAppUrl();
         var helper = new DriverFactoryHelper();
         if ("".equals(appUrl)) {
             // new native app OR web execution
@@ -74,6 +74,22 @@ public class BrowserStackHelper {
             helper.initializeDriver(DriverFactory.DriverType.APPIUM_MOBILE_NATIVE, browserStackOptions);
         }
         return helper;
+    }
+
+    private static String resolveBrowserStackAppUrl() {
+        String browserStackAppUrl = SHAFT.Properties.browserStack.appUrl();
+        if (browserStackAppUrl != null && !browserStackAppUrl.isBlank()) {
+            return browserStackAppUrl;
+        }
+        String mobileApp = SHAFT.Properties.mobile.app();
+        if (mobileApp != null && !mobileApp.isBlank() && isRemoteAppUrl(mobileApp)) {
+            return mobileApp;
+        }
+        return "";
+    }
+
+    private static boolean isRemoteAppUrl(String appUrl) {
+        return appUrl.startsWith("bs://") || appUrl.startsWith("http://") || appUrl.startsWith("https://");
     }
 
     /**

--- a/src/main/java/com/shaft/properties/internal/PropertyFileManager.java
+++ b/src/main/java/com/shaft/properties/internal/PropertyFileManager.java
@@ -217,6 +217,7 @@ public final class PropertyFileManager {
             properties.load(new FileInputStream(propertyFile));
             // merge: effective properties (system + thread-local) override file-based properties
             properties.putAll(ThreadLocalPropertiesManager.getEffectiveProperties());
+            ThreadLocalPropertiesManager.applyCompatibilityAliases(properties);
             // write merged result back to system properties so that ConfigFactory picks them up
             System.getProperties().putAll(properties);
         } catch (IOException e) {

--- a/src/main/java/com/shaft/properties/internal/ThreadLocalPropertiesManager.java
+++ b/src/main/java/com/shaft/properties/internal/ThreadLocalPropertiesManager.java
@@ -107,11 +107,42 @@ public final class ThreadLocalPropertiesManager {
     public static java.util.Properties getEffectiveProperties() {
         java.util.Properties merged = new java.util.Properties();
         merged.putAll(System.getProperties());
+        applyCompatibilityAliases(merged);
         synchronized (globalOverrides) {
             merged.putAll(globalOverrides);
+            applyCompatibilityAliasesFromSource(merged, globalOverrides);
         }
-        merged.putAll(threadLocalOverrides.get());
+        java.util.Properties threadOverrides = threadLocalOverrides.get();
+        merged.putAll(threadOverrides);
+        applyCompatibilityAliasesFromSource(merged, threadOverrides);
         return merged;
+    }
+
+    /**
+     * Copies deprecated compatibility aliases into their canonical property keys when
+     * the canonical key is not already configured. Canonical keys retain precedence so
+     * users can safely migrate incrementally.
+     *
+     * @param properties effective properties to normalize in place
+     */
+    static void applyCompatibilityAliases(java.util.Properties properties) {
+        copyAliasIfCanonicalIsMissing(properties, properties, "targetOperatingSystem", "targetPlatform");
+        copyAliasIfCanonicalIsMissing(properties, properties, "browserStack.userName", "browserStack.user");
+        copyAliasIfCanonicalIsMissing(properties, properties, "browserStack.accessKey", "browserStack.key");
+    }
+
+    private static void applyCompatibilityAliasesFromSource(java.util.Properties target, java.util.Properties source) {
+        copyAliasIfCanonicalIsMissing(target, source, "targetOperatingSystem", "targetPlatform");
+        copyAliasIfCanonicalIsMissing(target, source, "browserStack.userName", "browserStack.user");
+        copyAliasIfCanonicalIsMissing(target, source, "browserStack.accessKey", "browserStack.key");
+    }
+
+    private static void copyAliasIfCanonicalIsMissing(java.util.Properties target, java.util.Properties source, String canonicalKey, String aliasKey) {
+        String canonicalValue = source.getProperty(canonicalKey);
+        String aliasValue = source.getProperty(aliasKey);
+        if ((canonicalValue == null || canonicalValue.isBlank()) && aliasValue != null && !aliasValue.isBlank()) {
+            target.setProperty(canonicalKey, aliasValue);
+        }
     }
 
     /**

--- a/src/test/java/testPackage/unitTests/BrowserStackHelperUnitTest.java
+++ b/src/test/java/testPackage/unitTests/BrowserStackHelperUnitTest.java
@@ -159,6 +159,30 @@ public class BrowserStackHelperUnitTest {
     }
 
     @Test
+    public void getBrowserStackDriverShouldRouteRemoteMobileAppAsNativeExecution() {
+        SHAFT.Properties.browserStack.set().userName("user").accessKey("key").platformVersion("11.0")
+                .deviceName("Samsung Galaxy S21").appUrl("").appRelativeFilePath("").appiumVersion("2.0.0");
+        SHAFT.Properties.platform.set().targetPlatform("ANDROID");
+        SHAFT.Properties.mobile.set().app("bs://existing-mobile-app").browserName("");
+
+        try (MockedConstruction<DriverFactoryHelper> helperConstruction = Mockito.mockConstruction(DriverFactoryHelper.class);
+             MockedStatic<BrowserStackSdkHelper> sdkHelperMock = Mockito.mockStatic(BrowserStackSdkHelper.class)) {
+            sdkHelperMock.when(BrowserStackSdkHelper::generateBrowserStackYml).thenReturn("browserstack.yml");
+
+            MutableCapabilities input = new MutableCapabilities();
+            input.setCapability("custom", "native-mobile-app");
+            DriverFactoryHelper helper = BrowserStackHelper.getBrowserStackDriver(input);
+
+            DriverFactoryHelper constructed = helperConstruction.constructed().getFirst();
+            Assert.assertSame(helper, constructed);
+            ArgumentCaptor<MutableCapabilities> nativeCaptor = ArgumentCaptor.forClass(MutableCapabilities.class);
+            Mockito.verify(constructed).initializeDriver(Mockito.eq(DriverFactory.DriverType.APPIUM_MOBILE_NATIVE), nativeCaptor.capture());
+            Assert.assertEquals(nativeCaptor.getValue().getCapability("custom"), "native-mobile-app");
+            Assert.assertEquals(SHAFT.Properties.mobile.app(), "bs://existing-mobile-app");
+        }
+    }
+
+    @Test
     public void getBrowserStackDriverShouldCoverNewNativeAppUploadBranch() {
         SHAFT.Properties.browserStack.set().userName("user").accessKey("key").platformVersion("13.0")
                 .deviceName("Google Pixel 7").appName("ApiDemos").appRelativeFilePath("src/test/resources/testDataFiles/apps/ApiDemos-debug.apk")

--- a/src/test/java/testPackage/unitTests/ThreadLocalPropertiesTest.java
+++ b/src/test/java/testPackage/unitTests/ThreadLocalPropertiesTest.java
@@ -76,6 +76,35 @@ public class ThreadLocalPropertiesTest {
         }
     }
 
+    @Test(description = "compatibility aliases populate canonical properties only when canonical keys are missing")
+    public void testCompatibilityAliasesPopulateCanonicalKeysWithCanonicalPrecedence() {
+        ThreadLocalPropertiesManager.setProperty("targetPlatform", "ANDROID");
+        ThreadLocalPropertiesManager.setProperty("browserStack.user", "legacyUser");
+        ThreadLocalPropertiesManager.setProperty("browserStack.key", "legacyKey");
+
+        java.util.Properties aliasOnlyProperties = ThreadLocalPropertiesManager.getEffectiveProperties();
+
+        Assert.assertEquals(aliasOnlyProperties.getProperty("targetOperatingSystem"), "ANDROID",
+                "targetPlatform should populate targetOperatingSystem when canonical key is absent");
+        Assert.assertEquals(aliasOnlyProperties.getProperty("browserStack.userName"), "legacyUser",
+                "browserStack.user should populate browserStack.userName when canonical key is absent");
+        Assert.assertEquals(aliasOnlyProperties.getProperty("browserStack.accessKey"), "legacyKey",
+                "browserStack.key should populate browserStack.accessKey when canonical key is absent");
+
+        ThreadLocalPropertiesManager.setProperty("targetOperatingSystem", "IOS");
+        ThreadLocalPropertiesManager.setProperty("browserStack.userName", "canonicalUser");
+        ThreadLocalPropertiesManager.setProperty("browserStack.accessKey", "canonicalKey");
+
+        java.util.Properties canonicalProperties = ThreadLocalPropertiesManager.getEffectiveProperties();
+
+        Assert.assertEquals(canonicalProperties.getProperty("targetOperatingSystem"), "IOS",
+                "Canonical targetOperatingSystem should take precedence over targetPlatform");
+        Assert.assertEquals(canonicalProperties.getProperty("browserStack.userName"), "canonicalUser",
+                "Canonical browserStack.userName should take precedence over browserStack.user");
+        Assert.assertEquals(canonicalProperties.getProperty("browserStack.accessKey"), "canonicalKey",
+                "Canonical browserStack.accessKey should take precedence over browserStack.key");
+    }
+
     @Test(description = "getAppiumDesiredCapabilities picks up thread-local mobile_ properties")
     public void testGetAppiumDesiredCapabilitiesReadsThreadLocal() {
         String testAppUrl = "https://example.com/test-thread-local.apk";


### PR DESCRIPTION
Codex implemented follow-up fixes on top of the original PR.\n\n## Summary\n- Treat remote `mobile_app` values (`bs://`, `http://`, `https://`) as BrowserStack native app signals when `browserStack.appUrl` is not set, preserving `browserStack.appUrl` precedence.\n- Normalize compatibility aliases into canonical property keys in the property layer: `targetPlatform` -> `targetOperatingSystem`, `browserStack.user` -> `browserStack.userName`, and `browserStack.key` -> `browserStack.accessKey`.\n- Add focused regression coverage for remote `mobile_app=bs://...` native routing and alias precedence.\n- Update Flutter properties documentation to use `targetOperatingSystem`.\n\n## Implementation plan for review/continuation\n1. Inspect `BrowserStackHelper.getBrowserStackDriver(...)` and confirm native app routing resolves `browserStack.appUrl` first, then remote `mobile_app` values.\n2. Inspect `ThreadLocalPropertiesManager.getEffectiveProperties()` and `PropertyFileManager.loadPropertiesFileIntoSystemProperties(...)` to verify compatibility aliases are centralized in the property layer.\n3. Run `mvn test -Dtest=ThreadLocalPropertiesTest,BrowserStackHelperUnitTest` and confirm Allure has populated result JSON files.\n4. Run `mvn clean install -DskipTests -Dgpg.skip` for compilation/package validation.\n5. If regressions appear, revert commit `637bbef` or restore BrowserStack routing to the prior direct `browserStack.appUrl` check.\n\n## Validation\n- `mvn test -Dtest=ThreadLocalPropertiesTest,BrowserStackHelperUnitTest` (30 tests passed; Allure result JSON count: 30)\n- `mvn clean install -DskipTests -Dgpg.skip`\n\n## Notes\n- Codex authored these changes. The authenticated token owner did not author them manually.\n- No GitHub issue number was available in the provided PR metadata, so no auto-closing issue link could be added.