### PR TITLE
codex: Align job failure details with generated Allure report

### DIFF
--- a/.github/actions/post-test-report/action.yml
+++ b/.github/actions/post-test-report/action.yml
@@ -139,31 +139,25 @@ runs:
             echo "::warning::No tests were executed. Check test configuration."
           fi
           if [ "$FAILED" -gt 0 ] || [ "$BROKEN" -gt 0 ]; then
-            if [ -d "allure-results" ] && command -v python3 >/dev/null 2>&1; then
-              {
-                echo ""
-                echo "### ❌ Failed and broken test methods"
-                python3 scripts/ci/extract_allure_failures.py allure-results --surefire-reports target/surefire-reports || true
-              } >> "$GITHUB_STEP_SUMMARY"
+            if command -v python3 >/dev/null 2>&1; then
+              ALLURE_FAILURE_SOURCE=""
+              if [ -d "allure-report" ]; then
+                ALLURE_FAILURE_SOURCE="allure-report"
+              elif [ -d "allure-results" ]; then
+                ALLURE_FAILURE_SOURCE="allure-results"
+              fi
+              if [ -n "$ALLURE_FAILURE_SOURCE" ]; then
+                {
+                  echo ""
+                  echo "### ❌ Failed and broken test methods"
+                  python3 scripts/ci/extract_allure_failures.py "$ALLURE_FAILURE_SOURCE" || true
+                } >> "$GITHUB_STEP_SUMMARY"
+              fi
             fi
             echo "::error::Allure report shows $FAILED failed and $BROKEN broken test(s) out of $TOTAL total. Check the Allure report artifact for details."
             exit 1
           fi
-          if [ -d "allure-results" ] && [ -d "target/surefire-reports" ] && command -v python3 >/dev/null 2>&1; then
-            SUREFIRE_ALLURE_CHECK=$(mktemp)
-            if ! python3 scripts/ci/extract_allure_failures.py allure-results --surefire-reports target/surefire-reports > "$SUREFIRE_ALLURE_CHECK"; then
-              {
-                echo ""
-                echo "### ❌ Surefire / Allure consistency check"
-                cat "$SUREFIRE_ALLURE_CHECK"
-              } >> "$GITHUB_STEP_SUMMARY"
-              echo "::error::Surefire reports include failures that are missing from Allure failed/broken results. Check the job summary for details."
-              rm -f "$SUREFIRE_ALLURE_CHECK"
-              exit 1
-            fi
-            rm -f "$SUREFIRE_ALLURE_CHECK"
-          fi
-          echo "All tests passed according to Allure report and Surefire cross-check."
+          echo "All tests passed according to Allure report."
         else
           echo "::warning::Allure report summary not found. Falling back to surefire reports."
           # Fallback: Check surefire reports if allure data is unavailable.

--- a/scripts/ci/extract_allure_failures.py
+++ b/scripts/ci/extract_allure_failures.py
@@ -11,7 +11,9 @@ limited to Allure failures so CI logs match the Allure summary.
 """
 
 import argparse
+import base64
 import json
+import re
 import textwrap
 import xml.etree.ElementTree as ET
 import zipfile
@@ -40,10 +42,30 @@ class SurefireFailure:
     trace_top: str
 
 
+def _iter_embedded_html_payloads(path: Path) -> Iterator[tuple[str, dict[str, Any]]]:
+    try:
+        html = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return
+
+    for match in re.finditer(r'd\("([^"\\]+\.json)","([A-Za-z0-9+/=]+)"\)', html):
+        source, encoded_payload = match.groups()
+        if not source.startswith("data/test-results/"):
+            continue
+        try:
+            payload = json.loads(base64.b64decode(encoded_payload).decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(payload, dict):
+            yield f"{path}!{source}", payload
+
+
 def _iter_json_payloads(path: Path) -> Iterator[tuple[str, dict[str, Any]]]:
     if path.is_dir():
         for json_path in sorted(path.rglob("*.json")):
             yield from _iter_json_payloads(json_path)
+        for html_path in sorted(path.rglob("*.html")):
+            yield from _iter_json_payloads(html_path)
         return
 
     if zipfile.is_zipfile(path):
@@ -65,6 +87,10 @@ def _iter_json_payloads(path: Path) -> Iterator[tuple[str, dict[str, Any]]]:
                 yield str(path), payload
         except json.JSONDecodeError:
             return
+        return
+
+    if path.suffix == ".html":
+        yield from _iter_embedded_html_payloads(path)
 
 
 def _clean_cell(value: str) -> str:
@@ -81,9 +107,9 @@ def _first_trace_line(trace: str) -> str:
 
 
 def _status_details(payload: dict) -> tuple[str, str]:
-    details = payload.get("statusDetails") or {}
-    message = details.get("message") or details.get("known") or ""
-    trace = details.get("trace") or ""
+    details = payload.get("statusDetails") or payload.get("error") or {}
+    message = details.get("message") or details.get("known") or payload.get("statusMessage") or ""
+    trace = details.get("trace") or payload.get("statusTrace") or ""
     reason = str(message).strip() or _first_trace_line(trace) or "No failure message recorded"
     return reason, _first_trace_line(trace)
 
@@ -168,13 +194,22 @@ def missing_surefire_failures(
     ]
 
 
+def _is_generated_report_non_test_result(source: str) -> bool:
+    normalized = source.replace("\\", "/")
+    is_report_data = normalized.startswith("data/") or "/data/" in normalized or "!data/" in normalized
+    is_test_result = "/data/test-results/" in normalized or "!data/test-results/" in normalized
+    return is_report_data and not is_test_result
+
+
 def extract_failures(paths: Iterable[Path]) -> list[AllureFailure]:
     failures: list[AllureFailure] = []
     seen: set[tuple[str, str, str, str]] = set()
     for path in paths:
         for source, payload in _iter_json_payloads(path):
+            if _is_generated_report_non_test_result(source):
+                continue
             status = str(payload.get("status") or "").lower()
-            if status not in FAILING_STATUSES:
+            if status not in FAILING_STATUSES or payload.get("hidden") is True:
                 continue
             method = _method_name(payload)
             reason, trace_top = _status_details(payload)

--- a/tests/scripts/test_extract_allure_failures.py
+++ b/tests/scripts/test_extract_allure_failures.py
@@ -1,3 +1,4 @@
+import base64
 import contextlib
 import io
 import json
@@ -203,6 +204,65 @@ class ExtractAllureFailuresTests(unittest.TestCase):
         self.assertIn("No failed or broken Allure test cases were found.", output.getvalue())
         self.assertNotIn("Surefire failures missing from Allure results", output.getvalue())
         self.assertNotIn("surefireOnlyFailure", output.getvalue())
+
+    def test_extracts_visible_failures_from_single_file_allure_report(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report = Path(temp_dir) / "AllureReport.html"
+            visible_failed = {
+                "status": "failed",
+                "hidden": False,
+                "fullName": "pkg.VisibleTest.fails",
+                "error": {"message": "visible assertion", "trace": "AssertionError: visible assertion\n at pkg.VisibleTest.fails"},
+            }
+            visible_broken = {
+                "status": "broken",
+                "hidden": False,
+                "fullName": "pkg.VisibleTest.breaks",
+                "error": {"message": "visible exception", "trace": "RuntimeException: visible exception"},
+            }
+            hidden_broken = {
+                "status": "broken",
+                "hidden": True,
+                "fullName": "pkg.VisibleTest.hiddenFixture",
+                "error": {"message": "hidden fixture should not be counted"},
+            }
+            embedded_files = {
+                "data/test-results/visible-failed.json": visible_failed,
+                "data/test-results/visible-broken.json": visible_broken,
+                "data/test-results/hidden-broken.json": hidden_broken,
+            }
+            report.write_text(
+                "\n".join(
+                    f'd("{name}","{base64.b64encode(json.dumps(payload).encode("utf-8")).decode("ascii")}")'
+                    for name, payload in embedded_files.items()
+                ),
+                encoding="utf-8",
+            )
+
+            failures = extract_failures([report])
+            markdown = to_markdown(failures)
+
+        self.assertEqual([failure.method for failure in failures], ["pkg.VisibleTest.fails", "pkg.VisibleTest.breaks"])
+        self.assertIn("visible assertion", markdown)
+        self.assertIn("visible exception", markdown)
+        self.assertNotIn("hidden fixture should not be counted", markdown)
+
+    def test_ignores_hidden_allure_failures_from_generated_report_json(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report_data = Path(temp_dir) / "data" / "test-results"
+            report_data.mkdir(parents=True)
+            (report_data / "visible-result.json").write_text(
+                json.dumps({"status": "broken", "hidden": False, "fullName": "pkg.ReportTest.visible"}),
+                encoding="utf-8",
+            )
+            (report_data / "hidden-result.json").write_text(
+                json.dumps({"status": "broken", "hidden": True, "fullName": "pkg.ReportTest.hidden"}),
+                encoding="utf-8",
+            )
+
+            failures = extract_failures([Path(temp_dir)])
+
+        self.assertEqual([failure.method for failure in failures], ["pkg.ReportTest.visible"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Follow up on PR #2712 because E2E job summaries could still expand more failed/broken methods than the generated Allure report summary showed.
- Keep Allure as the single source of truth: when the report summary says 1 failed and 2 broken, the job summary details should list those same visible report entries only.

### Description
- Teach scripts/ci/extract_allure_failures.py to read Allure single-file HTML report payloads, generated report JSON payloads, and generated-report error details.
- Ignore generated Allure report entries marked hidden: true and skip non-data/test-results report JSON payloads so fixture/history/group support files do not inflate the detailed failure table.
- Update .github/actions/post-test-report/action.yml to prefer allure-report as the failure-detail source and remove the Surefire/Allure cross-check from the Allure-summary success path.
- Add regression coverage for single-file Allure reports and hidden generated-report failures.

### Testing
- python3 -m unittest tests.scripts.test_extract_allure_failures -v
- python3 -m unittest discover -s tests/scripts -p 'test_*.py'
- python3 scripts/ci/extract_allure_failures.py /tmp/shaft-run-25795438583/artifacts/edge.html || true

Codex made these changes as the implementation agent. This PR is a follow-up on top of PR #2712; no issue auto-closing link was available from the trigger.