### PR TITLE
chore(release): generate SHAFT_ENGINE 10.2.20260513 release

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -772,7 +772,7 @@ Follow these steps in order when preparing a new SHAFT release:
   - change the `@DefaultValue` of `shaftEngineVersion()` to match the new release version.
   - also check and update `allure3Version()` to the latest stable Allure 3 npm package version.
   - also check and update `nodeLtsVersion()` to the latest Node.js LTS patch version.
-- **All example `pom.xml` files** under `src/main/resources/examples/` (7 files — TestNG, JUnit, Cucumber variants): change `<shaft_engine.version>OLD</shaft_engine.version>` to `<shaft_engine.version>NEW</shaft_engine.version>`.  You can do this in bulk with:
+- **All example/demo `pom.xml` files** under `src/main/resources/examples/` (7 files — TestNG, JUnit, Cucumber variants): change `<shaft_engine.version>OLD</shaft_engine.version>` to `<shaft_engine.version>NEW</shaft_engine.version>` in the release PR itself. Do not wait for the post-release sync workflow to correct sample/demo projects after the release. You can do this in bulk with:
   ```bash
   find src/main/resources/examples -name "pom.xml" | xargs sed -i 's|<shaft_engine.version>OLD</shaft_engine.version>|<shaft_engine.version>NEW</shaft_engine.version>|g'
   ```
@@ -835,7 +835,10 @@ mvn clean install -DskipTests -Dgpg.skip    # must succeed
 > skip baseline/full test-suite reruns to keep release preparation lightweight; rely on pre-release validation already completed and CI on merge.
 > If any file under `src/main/java/` or `src/test/java/` is modified, the mandatory pre-commit rules apply in full. In all cases, `mvn clean install -DskipTests -Dgpg.skip` must pass before commit.
 
-### 5. Commit and Merge to `main`
+### 5. Open the Release PR
+Use a PR title that includes the release name/version and clearly says this PR generates/prepares a new release, for example: `chore(release): generate SHAFT_ENGINE 10.2.20260513 release`. Open the PR directly after validation; do not wait for a separate prompt once the release metadata is ready.
+
+### 6. Commit and Merge to `main`
 Merging to `main` automatically triggers the **Maven Central Continuous Delivery** workflow (`mavenCentral_cd.yml`), which:
 1. Substitutes `$RELEASE_VERSION` in `.github/RELEASE_BODY_TEMPLATE.md` and uses it as the release body.
 2. Creates a GitHub Release via `ncipollo/release-action` with `generateReleaseNotes: true` **and** `bodyFile`.
@@ -893,7 +896,7 @@ See: https://github.com/ShaftHQ/shafthq.github.io/issues/468
 - [ ] `Internal.java` `shaftEngineVersion` `@DefaultValue` updated
 - [ ] `Internal.java` `allure3Version` checked/updated to latest stable
 - [ ] `Internal.java` `nodeLtsVersion` checked/updated to latest LTS patch
-- [ ] All 7 example `pom.xml` files under `src/main/resources/examples/` updated — bump `<shaft_engine.version>` manually (use bulk `sed` command above) **or** wait for the **Sync Sample Projects SHAFT Version** workflow to open a PR automatically after the release is published
+- [ ] All 7 example/demo `pom.xml` files under `src/main/resources/examples/` updated in this release PR — bump `<shaft_engine.version>` manually (use the bulk `sed` command above); do **not** wait for the **Sync Sample Projects SHAFT Version** workflow to fix release PR drift
 - [ ] All 7 example `pom.xml` files synced with main `pom.xml` for plugin/dependency versions — the **Sync Sample Projects SHAFT Version** workflow handles `jdk.version`, `aspectjweaver.version`, `maven-compiler-plugin.version`, `maven-resources-plugin.version`, `maven-surefire-plugin.version`, and `surefire-testng.version` automatically; manually verify only if the workflow fails
 - [ ] Dependency currency gate executed: `versions:display-dependency-updates`, `versions:display-plugin-updates`, and `versions:display-property-updates`
 - [ ] No stable dependency/plugin/property updates skipped

--- a/.github/copilot-memory.md
+++ b/.github/copilot-memory.md
@@ -72,3 +72,10 @@ Purpose: keep high-signal, reusable learnings from implementation sessions in on
 - Lesson: Treat maintainer mentions with `start` or `init` as a request to initialize the full task workflow: assign to `codex` when possible (otherwise the requester), create a GitHub-linked branch for auto-close traceability when an issue exists, open an early draft PR with a lower-intelligence-agent-ready plan, execute at least three PDCA iterations for non-trivial work, commit at validated checkpoints, then push final status and notify the requester for review.
 - Evidence: `AGENTS.md`, `.github/copilot-instructions.md`, PR follow-up trigger `@codex init` on 2026-05-13.
 - Action taken: Added explicit start/init protocol guidance to repository agent instructions and recorded this reusable lesson in the memory ledger.
+
+- Date: 2026-05-13
+- Area: Release preparation / version metadata
+- Trigger: First Codex-generated release PR request for `10.2.20260513`.
+- Lesson: Release PRs are metadata-sensitive and must be opened directly once validated. Always inspect recent merged release PRs, compute the version with `{major}.{quarter}.{YYYYMMDD}`, update root `pom.xml`, `Internal.java` `shaftEngineVersion`, verify/update `allure3Version` and `nodeLtsVersion`, and update all seven sample/demo project `<shaft_engine.version>` values before opening the PR. Do not rely on the post-release sample-sync workflow to fix stale sample POMs.
+- Evidence: PRs #2502, #2494, #2439, #2428, #2418; `pom.xml`; `src/main/java/com/shaft/properties/internal/Internal.java`; `src/main/resources/examples/**/pom.xml`; `.github/copilot-instructions.md`; `AGENTS.md`.
+- Action taken: Added release-preparation notes to agent instructions, framework-source instructions, and this memory entry while preparing the release branch.

--- a/.github/instructions/framework-source.instructions.md
+++ b/.github/instructions/framework-source.instructions.md
@@ -114,6 +114,8 @@ When preparing a SHAFT release and editing `src/main/java/com/shaft/properties/i
 - `allure3Version` (latest stable Allure 3 npm package)
 - `nodeLtsVersion` (latest Node.js LTS patch)
 
+Release PRs must also update every sample/demo `<shaft_engine.version>` under `src/main/resources/examples/**/pom.xml` in the same branch before the PR is opened; do not depend on the post-release sample-sync workflow to repair stale demo project versions.
+
 ### ⛔ Mandatory Pre-Commit Rules (No Exceptions)
 > **You MUST NEVER commit untested framework code. There are no exceptions to these rules.**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,11 +122,19 @@ Use this protocol whenever a maintainer tags `@codex` to start work, says `start
 6. **Validate before claiming done.** Run the narrowest relevant checks first, then broader checks when warranted. For SHAFT test runs, confirm Allure results are populated before using them as the pass/fail oracle.
 7. **Publish final status.** After implementation is done, push the final branch state, update the PR description or add a progress comment summarizing completed iterations, checks run, files changed, and open risks, then notify the requester that the PR is ready for review.
 
+
+## Release Preparation Notes
+- Release versions use `{major}.{quarter}.{YYYYMMDD}`; for example, a Q2 release generated on May 13, 2026 is `10.2.20260513`.
+- A release PR title should include the release name/version and clearly say that the PR generates or prepares a new release.
+- Before opening a release PR, inspect recent merged release PRs for changed files and PR-body conventions, then update these locations together: root `pom.xml`, `src/main/java/com/shaft/properties/internal/Internal.java`, and all seven sample/demo project `pom.xml` files under `src/main/resources/examples/`.
+- In `Internal.java`, verify `allure3Version` against the latest stable `allure` npm package and `nodeLtsVersion` against the latest Node.js LTS patch; record when a value is already current.
+- Validate release-only changes with dependency-update checks and `mvn clean install -DskipTests -Dgpg.skip`; merging the PR to `main` starts the Maven Central release pipeline, so do not run deploy/release commands locally.
+
 ## Safety and Constraints
 - Do not expose secrets or copy values from `.env`, credential files, BrowserStack/LambdaTest variables, Maven Central credentials, GPG keys, or CI secrets.
 - Do not run deployment/release commands, `scm-publish`, history rewrites, destructive cleanup, or credentialed cloud workflows unless explicitly requested.
 - Treat `target/`, generated reports, downloaded binaries, and build artifacts as generated outputs; do not commit them unless maintainers explicitly request it.
-- Be careful with `pom.xml` version changes: the project version comment says to keep `Internal.java` values such as `shaftEngineVersion`, `allure3Version`, and `nodeLtsVersion` aligned for releases.
+- Be careful with release `pom.xml` version changes: release PRs must update the root `pom.xml` project version, `Internal.java` `shaftEngineVersion`, `allure3Version`, and `nodeLtsVersion`, and every sample/demo `<shaft_engine.version>` under `src/main/resources/examples/**/pom.xml` in the same branch before opening the PR. Do not rely on the post-release sample-sync workflow to fix release PR drift.
 - Binary mobile test assets (`*.apk`, `*.ipa`) have special JaCoCo exclusions; do not move or reclassify them casually.
 - Docker Compose E2E services should be stopped/cleaned up after local use.
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.shafthq</groupId>
     <artifactId>SHAFT_ENGINE</artifactId>
-    <version>10.2.20260506</version> <!-- UPDATE com.shaft.properties.internal > Internal > shaftEngineVersion, allure3Version, nodeLtsVersion,  -->
+    <version>10.2.20260513</version> <!-- UPDATE com.shaft.properties.internal > Internal > shaftEngineVersion, allure3Version, nodeLtsVersion,  -->
     <name>${project.groupId}:${project.artifactId}</name>
     <description>SHAFT is a unified test automation engine. Powered by best-in-class frameworks, SHAFT provides a
         wizard-like syntax to drive your automation efficiently, maximize your ROI, and minimize your learning curve.

--- a/src/main/java/com/shaft/properties/internal/Internal.java
+++ b/src/main/java/com/shaft/properties/internal/Internal.java
@@ -18,7 +18,7 @@ import org.aeonbits.owner.Config.Sources;
 })
 public interface Internal extends EngineProperties<Internal> {
     @Key("shaftEngineVersion")
-    @DefaultValue("10.2.20260506")
+    @DefaultValue("10.2.20260513")
     String shaftEngineVersion();
 
     @Key("watermarkImagePath")
@@ -32,7 +32,7 @@ public interface Internal extends EngineProperties<Internal> {
      * without changing {@code AllureManager} or any CI script. Use this url for the latest version <a href="https://github.com/allure-framework/allure3/releases">Allure3Releases</a>
      */
     @Key("allure3Version")
-    @DefaultValue("3.7.0")
+    @DefaultValue("3.8.1")
     String allure3Version();
 
     /**

--- a/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
+++ b/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260506</shaft_engine.version>
+        <shaft_engine.version>10.2.20260513</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
+++ b/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260506</shaft_engine.version>
+        <shaft_engine.version>10.2.20260513</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
+++ b/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260506</shaft_engine.version>
+        <shaft_engine.version>10.2.20260513</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
+++ b/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260506</shaft_engine.version>
+        <shaft_engine.version>10.2.20260513</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
+++ b/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260506</shaft_engine.version>
+        <shaft_engine.version>10.2.20260513</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
+++ b/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260506</shaft_engine.version>
+        <shaft_engine.version>10.2.20260513</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
+++ b/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260506</shaft_engine.version>
+        <shaft_engine.version>10.2.20260513</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>


### PR DESCRIPTION
## 📋 Description

This PR generates the new SHAFT_ENGINE release metadata for `10.2.20260513`. After this PR is merged, the existing Maven Central continuous delivery workflow will create the GitHub Release and publish the artifact to Maven Central automatically.

Codex prepared this release branch after reviewing recent merged release PRs (#2502, #2494, #2439, #2428, #2418).

## Version changes

- Root `pom.xml` project version: `10.2.20260506` → `10.2.20260513`.
- `Internal.java` `shaftEngineVersion`: `10.2.20260506` → `10.2.20260513`.
- `Internal.java` `allure3Version`: `3.7.0` → `3.8.1` after checking the latest stable `allure` npm package.
- `Internal.java` `nodeLtsVersion`: verified current at `24.15.0` after checking the latest Node.js LTS patch.
- All 7 sample/demo project POMs under `src/main/resources/examples/**/pom.xml`: `<shaft_engine.version>` → `10.2.20260513`.

## Agent instruction and memory updates

- Added durable release-preparation guidance to `AGENTS.md`.
- Tightened `.github/copilot-instructions.md` release guidance so future release PRs update sample/demo POM versions in the release PR instead of relying on post-release sync.
- Extended `.github/instructions/framework-source.instructions.md` with the same release metadata guardrail.
- Recorded the release-preparation lesson in `.github/copilot-memory.md`.

## Dependency/release checks

- `allure` npm package latest stable: `3.8.1`.
- Latest Node.js LTS patch: `24.15.0` / Krypton.
- Maven Versions Plugin found no newer direct dependencies, all version properties current, and all explicitly versioned plugins current. It reported newer Cucumber transitive dependency-management entries from the imported BOM only; the direct Cucumber BOM remains managed by the project.

## Validation

```text
mvn versions:display-dependency-updates versions:display-plugin-updates versions:display-property-updates -DgenerateBackupPoms=false
[INFO] BUILD SUCCESS

mvn clean install -DskipTests -Dgpg.skip
[INFO] BUILD SUCCESS

mvn test -Dtest=testPackage.properties.InternalTests -Dgpg.skip
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS

! rg -n "10\.2\.20260506" pom.xml src/main/java/com/shaft/properties/internal/Internal.java src/main/resources/examples .github/copilot-instructions.md AGENTS.md .github/instructions/framework-source.instructions.md .github/copilot-memory.md
example_pom_count=7
```

## Notes

- No Maven Central deploy/release command was run locally. The merge-to-`main` pipeline is expected to handle publication.
- No issue auto-close link is included because this release request was made directly in chat rather than from a numbered GitHub issue.
