### PR TITLE
feat(cli): reusable JSch SSH session, Terminal lifecycle, SFTP and tunnels

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -97,7 +97,7 @@ graph TB
 ### Core Testing Modules
 - **🌐 GUI Module**: Selenium and Appium-based web and mobile automation with fluent API
 - **🔌 API Module**: REST API testing powered by REST Assured
-- **💻 CLI Module**: Command-line execution and file system operations
+- **💻 CLI Module**: Shell automation (`TerminalActions`, `SHAFT.CLI.Terminal`), optional reusable remote SSH closed with `quit()`, `RemoteSshClient` for SFTP and port forwards, file operations, and `SHAFT.Properties.ssh`
 - **🗄️ DB Module**: Database connectivity and SQL operations
 
 ### Supporting Modules

--- a/src/main/java/com/shaft/cli/RemoteSshClient.java
+++ b/src/main/java/com/shaft/cli/RemoteSshClient.java
@@ -1,0 +1,369 @@
+package com.shaft.cli;
+
+import com.jcraft.jsch.ChannelExec;
+import com.jcraft.jsch.ChannelSftp;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import com.shaft.cli.internal.JschSessionFactory;
+import com.shaft.cli.internal.RemoteCommandBundler;
+import com.shaft.cli.internal.SshConnectionOptions;
+import com.shaft.cli.internal.SshOutputRedactor;
+import com.shaft.driver.SHAFT;
+import com.shaft.tools.io.ReportManager;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * One JSch {@link Session} (default) with multiple {@code exec} channels. Day-to-day tests usually call
+ * {@link com.shaft.driver.SHAFT.CLI.Terminal} instead; use this when you need the builder, SFTP, or port forwards.
+ *
+ * @see com.shaft.driver.SHAFT.CLI#remoteSsh(String, int, String, String, String)
+ */
+public final class RemoteSshClient implements AutoCloseable {
+
+    private final String sshHostName;
+    private final int sshPortNumber;
+    private final String sshUsername;
+    private final String sshKeyFileFolderName;
+    private final String sshKeyFileName;
+    private final String dockerName;
+    private final String dockerUsername;
+    private final SshSessionPolicy sessionPolicy;
+    private final String password;
+    private final String knownHostsPathOverride;
+    private final String keyPassphrase;
+
+    private final List<Integer> activeLocalForwardPorts = new ArrayList<>();
+    private final List<Integer> activeRemoteForwardPorts = new ArrayList<>();
+
+    private Session session;
+
+    public RemoteSshClient(String sshHostName, int sshPortNumber, String sshUsername,
+                           String sshKeyFileFolderName, String sshKeyFileName) {
+        this(sshHostName, sshPortNumber, sshUsername, sshKeyFileFolderName, sshKeyFileName, "", "", SshSessionPolicy.REUSE_SESSION,
+                null, null, null);
+    }
+
+    public RemoteSshClient(String sshHostName, int sshPortNumber, String sshUsername,
+                           String sshKeyFileFolderName, String sshKeyFileName, SshSessionPolicy sessionPolicy) {
+        this(sshHostName, sshPortNumber, sshUsername, sshKeyFileFolderName, sshKeyFileName, "", "", sessionPolicy, null, null, null);
+    }
+
+    public RemoteSshClient(String sshHostName, int sshPortNumber, String sshUsername,
+                           String sshKeyFileFolderName, String sshKeyFileName,
+                           String dockerName, String dockerUsername) {
+        this(sshHostName, sshPortNumber, sshUsername, sshKeyFileFolderName, sshKeyFileName, dockerName, dockerUsername,
+                SshSessionPolicy.REUSE_SESSION, null, null, null);
+    }
+
+    public RemoteSshClient(String sshHostName, int sshPortNumber, String sshUsername,
+                           String sshKeyFileFolderName, String sshKeyFileName,
+                           String dockerName, String dockerUsername, SshSessionPolicy sessionPolicy) {
+        this(sshHostName, sshPortNumber, sshUsername, sshKeyFileFolderName, sshKeyFileName, dockerName, dockerUsername,
+                sessionPolicy, null, null, null);
+    }
+
+    private RemoteSshClient(String sshHostName, int sshPortNumber, String sshUsername,
+                            String sshKeyFileFolderName, String sshKeyFileName,
+                            String dockerName, String dockerUsername, SshSessionPolicy sessionPolicy,
+                            String password, String knownHostsPathOverride, String keyPassphrase) {
+        this.sshHostName = sshHostName == null ? "" : sshHostName;
+        this.sshPortNumber = sshPortNumber;
+        this.sshUsername = sshUsername;
+        this.sshKeyFileFolderName = sshKeyFileFolderName;
+        this.sshKeyFileName = sshKeyFileName;
+        this.dockerName = dockerName == null ? "" : dockerName;
+        this.dockerUsername = dockerUsername == null ? "" : dockerUsername;
+        this.sessionPolicy = sessionPolicy == null ? SshSessionPolicy.REUSE_SESSION : sessionPolicy;
+        this.password = password;
+        this.knownHostsPathOverride = knownHostsPathOverride;
+        this.keyPassphrase = keyPassphrase;
+    }
+
+    public static Builder builder(String host, int port, String username) {
+        return new Builder(host, port, username);
+    }
+
+    public void connect() throws JSchException {
+        if (session != null && session.isConnected()) {
+            return;
+        }
+        disconnectQuietly();
+        session = JschSessionFactory.connect(buildOptions());
+        ReportManager.logDiscrete("Successfully created SSH Session.");
+    }
+
+    public Session getJschSession() throws JSchException {
+        connect();
+        return session;
+    }
+
+    public SshSftp openSftp() throws JSchException {
+        connect();
+        ChannelSftp ch = (ChannelSftp) session.openChannel("sftp");
+        ch.connect();
+        return new SshSftp(ch);
+    }
+
+    public SshLocalPortForward forwardLocalPort(int localPort, String remoteHost, int remotePort) throws JSchException {
+        connect();
+        int assigned = session.setPortForwardingL(localPort, remoteHost, remotePort);
+        activeLocalForwardPorts.add(assigned);
+        return new SshLocalPortForward(session, assigned, () -> activeLocalForwardPorts.remove(Integer.valueOf(assigned)));
+    }
+
+    public SshRemotePortForward forwardRemotePort(int remotePort, String localHost, int localPort) throws JSchException {
+        connect();
+        session.setPortForwardingR(remotePort, localHost, localPort);
+        activeRemoteForwardPorts.add(remotePort);
+        return new SshRemotePortForward(session, remotePort,
+                () -> activeRemoteForwardPorts.remove(Integer.valueOf(remotePort)));
+    }
+
+    public SshCommandResult performCommand(String command) throws JSchException, IOException {
+        return performCommands(Collections.singletonList(command), null, null);
+    }
+
+    public SshCommandResult performCommand(String command, Map<String, String> environment)
+            throws JSchException, IOException {
+        return performCommands(Collections.singletonList(command), environment, null);
+    }
+
+    public SshCommandResult performCommandStreaming(String command, Consumer<String> stdoutLineConsumer)
+            throws JSchException, IOException {
+        return performCommands(Collections.singletonList(command), null,
+                Objects.requireNonNull(stdoutLineConsumer, "stdoutLineConsumer"));
+    }
+
+    public SshCommandResult performCommands(List<String> commands) throws JSchException, IOException {
+        return performCommands(commands, null, null);
+    }
+
+    public SshCommandResult performCommands(List<String> commands, Map<String, String> environment)
+            throws JSchException, IOException {
+        return performCommands(commands, environment, null);
+    }
+
+    public SshCommandResult performCommandsStreaming(List<String> commands, Consumer<String> stdoutLineConsumer)
+            throws JSchException, IOException {
+        return performCommands(commands, null, Objects.requireNonNull(stdoutLineConsumer, "stdoutLineConsumer"));
+    }
+
+    private SshCommandResult performCommands(List<String> commands, Map<String, String> environment,
+                                             Consumer<String> stdoutStreamConsumer) throws JSchException, IOException {
+        if (sshHostName.isEmpty()) {
+            throw new IllegalStateException("RemoteSshClient requires a non-empty SSH host.");
+        }
+        List<String> internalCommands = new ArrayList<>(commands);
+        String longCommand = RemoteCommandBundler.buildLongCommand(internalCommands, isDockerized(),
+                dockerName, dockerUsername, SHAFT.Properties.timeouts.dockerCommandTimeout());
+
+        if (sessionPolicy == SshSessionPolicy.NEW_SESSION_PER_COMMAND) {
+            disconnectQuietly();
+        }
+        connect();
+        int sessionTimeoutMs = Integer.parseInt(String.valueOf(SHAFT.Properties.timeouts.shellSessionTimeout() * 1000L));
+        session.setTimeout(sessionTimeoutMs);
+
+        ReportManager.logDiscrete("Attempting to perform the following command remotely. Command: \"" + longCommand + "\"");
+        ChannelExec channel = (ChannelExec) session.openChannel("exec");
+        channel.setCommand(longCommand);
+        if (environment != null) {
+            for (var entry : environment.entrySet()) {
+                if (entry.getKey() != null && entry.getValue() != null) {
+                    channel.setEnv(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+        channel.connect();
+        String stdout;
+        String stderr;
+        try (BufferedReader outReader = new BufferedReader(
+                new InputStreamReader(channel.getInputStream(), StandardCharsets.UTF_8));
+             BufferedReader errReader = new BufferedReader(
+                     new InputStreamReader(channel.getErrStream(), StandardCharsets.UTF_8))) {
+            if (stdoutStreamConsumer != null) {
+                StringBuilder stdoutAcc = new StringBuilder();
+                String line;
+                while ((line = outReader.readLine()) != null) {
+                    stdoutStreamConsumer.accept(line);
+                    appendLine(stdoutAcc, line);
+                }
+                stdout = stdoutAcc.toString();
+                stderr = readAllLines(errReader);
+            } else {
+                stdout = readAllLines(outReader);
+                stderr = readAllLines(errReader);
+            }
+        }
+        int exit = channel.getExitStatus();
+        channel.disconnect();
+        if (sessionPolicy == SshSessionPolicy.NEW_SESSION_PER_COMMAND) {
+            disconnectQuietly();
+        }
+        SshCommandResult result = new SshCommandResult(stdout, stderr, exit);
+        maybeAttachCommandReport(longCommand, result);
+        return result;
+    }
+
+    @Override
+    public void close() {
+        disconnectQuietly();
+    }
+
+    public boolean isConnected() {
+        return session != null && session.isConnected();
+    }
+
+    public SshSessionPolicy getSessionPolicy() {
+        return sessionPolicy;
+    }
+
+    private void maybeAttachCommandReport(String executedCommand, SshCommandResult result) {
+        if (!SHAFT.Properties.ssh.attachCommandOutputToReport()) {
+            return;
+        }
+        String merged = result.mergedOutput();
+        merged = SshOutputRedactor.apply(merged, SHAFT.Properties.ssh.commandOutputReportRedactRegex());
+        String attachment = "Command: " + executedCommand + System.lineSeparator() + merged;
+        SHAFT.Report.attach("text/plain", "ssh-exec-output.txt", attachment);
+    }
+
+    private boolean isDockerized() {
+        return dockerName != null && !dockerName.isEmpty();
+    }
+
+    private SshConnectionOptions buildOptions() {
+        String identity = null;
+        if (sshKeyFileName != null && !sshKeyFileName.isEmpty()) {
+            identity = FileActions.getInstance(true).getAbsolutePath(sshKeyFileFolderName, sshKeyFileName);
+        }
+        String knownHosts = resolveKnownHostsPath();
+        return new SshConnectionOptions(
+                sshUsername,
+                sshHostName,
+                sshPortNumber,
+                identity,
+                SHAFT.Properties.ssh.strictHostKeyChecking(),
+                SHAFT.Properties.ssh.connectTimeout(),
+                SHAFT.Properties.ssh.serverAliveInterval(),
+                knownHosts,
+                password,
+                keyPassphrase);
+    }
+
+    private String resolveKnownHostsPath() {
+        if (knownHostsPathOverride != null && !knownHostsPathOverride.isBlank()) {
+            return knownHostsPathOverride;
+        }
+        String fromProps = SHAFT.Properties.ssh.knownHostsFile();
+        if (fromProps != null && !fromProps.isBlank()) {
+            return fromProps;
+        }
+        return null;
+    }
+
+    private void disconnectQuietly() {
+        if (session != null && session.isConnected()) {
+            for (Integer p : new ArrayList<>(activeLocalForwardPorts)) {
+                try {
+                    session.delPortForwardingL(p);
+                } catch (JSchException ignored) {
+                }
+            }
+            activeLocalForwardPorts.clear();
+            for (Integer r : new ArrayList<>(activeRemoteForwardPorts)) {
+                try {
+                    session.delPortForwardingR(r);
+                } catch (JSchException ignored) {
+                }
+            }
+            activeRemoteForwardPorts.clear();
+            session.disconnect();
+        }
+        session = null;
+    }
+
+    private static void appendLine(StringBuilder logBuilder, String line) {
+        if (logBuilder.isEmpty()) {
+            logBuilder.append(line);
+        } else {
+            logBuilder.append(System.lineSeparator()).append(line);
+        }
+    }
+
+    private static String readAllLines(BufferedReader reader) throws IOException {
+        StringBuilder logBuilder = new StringBuilder();
+        String line;
+        while ((line = reader.readLine()) != null) {
+            appendLine(logBuilder, line);
+        }
+        return logBuilder.toString();
+    }
+
+    public static final class Builder {
+        private final String host;
+        private final int port;
+        private final String username;
+        private String keyFolder = "";
+        private String keyFile = "";
+        private String dockerName = "";
+        private String dockerUser = "";
+        private SshSessionPolicy sessionPolicy = SshSessionPolicy.REUSE_SESSION;
+        private String password;
+        private String knownHostsPath;
+        private String keyPassphrase;
+
+        private Builder(String host, int port, String username) {
+            this.host = host == null ? "" : host;
+            this.port = port;
+            this.username = username;
+        }
+
+        public Builder identity(String folder, String file) {
+            this.keyFolder = folder == null ? "" : folder;
+            this.keyFile = file == null ? "" : file;
+            return this;
+        }
+
+        public Builder dockerExec(String name, String user) {
+            this.dockerName = name == null ? "" : name;
+            this.dockerUser = user == null ? "" : user;
+            return this;
+        }
+
+        public Builder sessionPolicy(SshSessionPolicy policy) {
+            this.sessionPolicy = policy == null ? SshSessionPolicy.REUSE_SESSION : policy;
+            return this;
+        }
+
+        public Builder password(String value) {
+            this.password = value;
+            return this;
+        }
+
+        public Builder knownHostsPath(String path) {
+            this.knownHostsPath = path;
+            return this;
+        }
+
+        public Builder keyPassphrase(String passphrase) {
+            this.keyPassphrase = passphrase;
+            return this;
+        }
+
+        public RemoteSshClient build() {
+            return new RemoteSshClient(host, port, username, keyFolder, keyFile, dockerName, dockerUser, sessionPolicy,
+                    password, knownHostsPath, keyPassphrase);
+        }
+    }
+}

--- a/src/main/java/com/shaft/cli/RemoteSshInteractiveShell.java
+++ b/src/main/java/com/shaft/cli/RemoteSshInteractiveShell.java
@@ -1,0 +1,50 @@
+package com.shaft.cli;
+
+import com.jcraft.jsch.ChannelShell;
+import com.jcraft.jsch.JSchException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Interactive SSH {@code shell} with PTY (timing- and prompt-sensitive). For scripted checks use
+ * {@link RemoteSshClient#performCommand(String)} instead.
+ */
+public final class RemoteSshInteractiveShell implements AutoCloseable {
+    private final ChannelShell channel;
+
+    private RemoteSshInteractiveShell(ChannelShell channel) {
+        this.channel = channel;
+    }
+
+    /**
+     * Opens a shell channel on the client's session. The client must remain connected for the lifetime of this shell.
+     */
+    public static RemoteSshInteractiveShell open(RemoteSshClient client) throws JSchException {
+        client.connect();
+        ChannelShell ch = (ChannelShell) client.getJschSession().openChannel("shell");
+        ch.setPty(true);
+        ch.connect();
+        return new RemoteSshInteractiveShell(ch);
+    }
+
+    public InputStream getInputStream() throws IOException {
+        return channel.getInputStream();
+    }
+
+    public OutputStream getOutputStream() throws IOException {
+        return channel.getOutputStream();
+    }
+
+    public ChannelShell jschChannel() {
+        return channel;
+    }
+
+    @Override
+    public void close() {
+        if (channel != null && channel.isConnected()) {
+            channel.disconnect();
+        }
+    }
+}

--- a/src/main/java/com/shaft/cli/SshCommandResult.java
+++ b/src/main/java/com/shaft/cli/SshCommandResult.java
@@ -1,0 +1,21 @@
+package com.shaft.cli;
+
+/**
+ * Result of a remote {@code exec} channel: separate stdout/stderr plus exit status
+ * ({@code -1} if not yet available from JSch).
+ */
+public record SshCommandResult(String standardOutput, String standardError, int exitStatus) {
+
+    /**
+     * stdout then stderr, matching the merged logging order used by {@link TerminalActions} for remote runs.
+     */
+    public String mergedOutput() {
+        if (standardOutput == null || standardOutput.isEmpty()) {
+            return standardError == null ? "" : standardError;
+        }
+        if (standardError == null || standardError.isEmpty()) {
+            return standardOutput;
+        }
+        return standardOutput + System.lineSeparator() + standardError;
+    }
+}

--- a/src/main/java/com/shaft/cli/SshLocalPortForward.java
+++ b/src/main/java/com/shaft/cli/SshLocalPortForward.java
@@ -1,0 +1,36 @@
+package com.shaft.cli;
+
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+
+/**
+ * Local port forward created via {@link RemoteSshClient#forwardLocalPort(int, String, int)}.
+ * Closing removes the forward without tearing down the SSH session.
+ */
+public final class SshLocalPortForward implements AutoCloseable {
+    private final Session session;
+    private final int boundLocalPort;
+    private final Runnable unregister;
+
+    SshLocalPortForward(Session session, int boundLocalPort, Runnable unregister) {
+        this.session = session;
+        this.boundLocalPort = boundLocalPort;
+        this.unregister = unregister;
+    }
+
+    public int getBoundLocalPort() {
+        return boundLocalPort;
+    }
+
+    @Override
+    public void close() {
+        try {
+            if (session != null && session.isConnected()) {
+                session.delPortForwardingL(boundLocalPort);
+            }
+        } catch (JSchException ignored) {
+        } finally {
+            unregister.run();
+        }
+    }
+}

--- a/src/main/java/com/shaft/cli/SshRemotePortForward.java
+++ b/src/main/java/com/shaft/cli/SshRemotePortForward.java
@@ -1,0 +1,35 @@
+package com.shaft.cli;
+
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+
+/**
+ * Remote port forward created via {@link RemoteSshClient#forwardRemotePort(int, String, int)}.
+ */
+public final class SshRemotePortForward implements AutoCloseable {
+    private final Session session;
+    private final int remotePort;
+    private final Runnable unregister;
+
+    SshRemotePortForward(Session session, int remotePort, Runnable unregister) {
+        this.session = session;
+        this.remotePort = remotePort;
+        this.unregister = unregister;
+    }
+
+    public int getRemotePort() {
+        return remotePort;
+    }
+
+    @Override
+    public void close() {
+        try {
+            if (session != null && session.isConnected()) {
+                session.delPortForwardingR(remotePort);
+            }
+        } catch (JSchException ignored) {
+        } finally {
+            unregister.run();
+        }
+    }
+}

--- a/src/main/java/com/shaft/cli/SshSessionPolicy.java
+++ b/src/main/java/com/shaft/cli/SshSessionPolicy.java
@@ -1,0 +1,11 @@
+package com.shaft.cli;
+
+/**
+ * How {@link RemoteSshClient} manages the underlying JSch {@link com.jcraft.jsch Session}.
+ */
+public enum SshSessionPolicy {
+    /** One SSH session; multiple {@code exec} channels until {@link RemoteSshClient#close()}. */
+    REUSE_SESSION,
+    /** Disconnect after each remote command (closer to legacy {@link TerminalActions} remote behavior). */
+    NEW_SESSION_PER_COMMAND
+}

--- a/src/main/java/com/shaft/cli/SshSftp.java
+++ b/src/main/java/com/shaft/cli/SshSftp.java
@@ -1,0 +1,46 @@
+package com.shaft.cli;
+
+import com.jcraft.jsch.ChannelSftp;
+import com.jcraft.jsch.SftpException;
+
+/**
+ * SFTP operations on a channel opened from an existing {@link RemoteSshClient} session.
+ */
+public final class SshSftp implements AutoCloseable {
+    private final ChannelSftp channel;
+
+    SshSftp(ChannelSftp channel) {
+        this.channel = channel;
+    }
+
+    public void upload(String localPath, String remotePath) throws SftpException {
+        channel.put(localPath, remotePath);
+    }
+
+    public void download(String remotePath, String localPath) throws SftpException {
+        channel.get(remotePath, localPath);
+    }
+
+    public void mkdir(String path) throws SftpException {
+        channel.mkdir(path);
+    }
+
+    public void rm(String path) throws SftpException {
+        channel.rm(path);
+    }
+
+    /**
+     * Exposes the underlying JSch channel for advanced use. Do not {@link ChannelSftp#disconnect()} while this
+     * wrapper is open unless you also stop using {@link RemoteSshClient} SFTP helpers.
+     */
+    public ChannelSftp channel() {
+        return channel;
+    }
+
+    @Override
+    public void close() {
+        if (channel != null && channel.isConnected()) {
+            channel.disconnect();
+        }
+    }
+}

--- a/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/src/main/java/com/shaft/cli/TerminalActions.java
@@ -1,9 +1,9 @@
 package com.shaft.cli;
 
-import com.jcraft.jsch.ChannelExec;
-import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
+import com.shaft.cli.internal.RemoteCommandBundler;
+import com.shaft.cli.internal.ShellCommandNormalizer;
 import com.shaft.driver.SHAFT;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.FailureReporter;
@@ -23,9 +23,9 @@ import java.util.concurrent.TimeUnit;
 /**
  * Executes shell commands on local or remote terminals.
  *
- * <p>Supports local OS command execution via {@link ProcessBuilder} and
- * remote command execution over SSH using JSch. Commands can be run
- * synchronously or asynchronously with configurable timeouts.
+ * <p>Remote SSH defaults to one new session per {@link #performTerminalCommand(String)} (backward compatible).
+ * Pass {@code reusableRemoteSshSession == true} to keep one session until {@link #quit()} (same idea as
+ * {@link com.shaft.driver.SHAFT.CLI.Terminal} with a remote constructor).
  *
  * <p><b>Usage example:</b>
  * <pre>{@code
@@ -52,94 +52,68 @@ public class TerminalActions {
     @Getter
     private String dockerUsername;
 
+    /**
+     * Last remote command exit status from JSch, or {@code -1} if not applicable / not yet run.
+     */
+    @Getter
+    private int lastRemoteCommandExitStatus = -1;
+
     private boolean asynchronous = false;
     private boolean verbose = false;
     private boolean isInternal = false;
 
+    private final boolean reusableRemoteSshSession;
+    private RemoteSshClient reusableSshClient;
 
-    /**
-     * This constructor is used for local terminal actions.
-     */
     public TerminalActions() {
+        this.reusableRemoteSshSession = false;
     }
 
-    /**
-     * This constructor is used for local terminal actions.
-     *
-     * @param asynchronous true for asynchronous execution of commands in a separate thread
-     */
     public TerminalActions(boolean asynchronous) {
         this.asynchronous = asynchronous;
+        this.reusableRemoteSshSession = false;
     }
 
     private TerminalActions(boolean asynchronous, boolean verbose, boolean isInternal) {
         this.asynchronous = asynchronous;
         this.verbose = verbose;
         this.isInternal = isInternal;
+        this.reusableRemoteSshSession = false;
     }
 
-    /**
-     * This constructor is used for local terminal actions inside a docker.
-     *
-     * @param dockerName     the name of the docker instance that you want to
-     *                       execute the terminal command inside
-     * @param dockerUsername the username which will be used to access the docker
-     *                       instance. Must have the access/privilege to execute the
-     *                       terminal command
-     */
     public TerminalActions(String dockerName, String dockerUsername) {
         this.dockerName = dockerName;
         this.dockerUsername = dockerUsername;
+        this.reusableRemoteSshSession = false;
+    }
+
+    public TerminalActions(String sshHostName, int sshPortNumber, String sshUsername, String sshKeyFileFolderName,
+                           String sshKeyFileName) {
+        this(sshHostName, sshPortNumber, sshUsername, sshKeyFileFolderName, sshKeyFileName, false);
     }
 
     /**
-     * This constructor is used for remote terminal actions.
-     *
-     * @param sshHostName          the IP address or host name for the remote
-     *                             machine you want to execute the terminal command
-     *                             on.
-     * @param sshPortNumber        the port that's used for the SSH service on the
-     *                             target machine. Default is 22.
-     * @param sshUsername          the username which will be used to access the
-     *                             target machine via ssh. Must have the
-     *                             access/privilege to execute the terminal command
-     * @param sshKeyFileFolderName the directory that holds the ssh key file
-     *                             (usually it's somewhere in the test data of the
-     *                             current project)
-     * @param sshKeyFileName       the name of the ssh key file
+     * @param reusableRemoteSshSession when {@code true}, reuse one SSH session until {@link #quit()}.
      */
     public TerminalActions(String sshHostName, int sshPortNumber, String sshUsername, String sshKeyFileFolderName,
-                           String sshKeyFileName) {
+                           String sshKeyFileName, boolean reusableRemoteSshSession) {
         this.sshHostName = sshHostName;
         this.sshPortNumber = sshPortNumber;
         this.sshUsername = sshUsername;
         this.sshKeyFileFolderName = sshKeyFileFolderName;
         this.sshKeyFileName = sshKeyFileName;
+        this.reusableRemoteSshSession = reusableRemoteSshSession;
     }
 
-    /**
-     * This constructor is used for remote terminal actions inside a docker.
-     *
-     * @param sshHostName          the IP address or host name for the remote
-     *                             machine you want to execute the terminal command
-     *                             on.
-     * @param sshPortNumber        the port that's used for the SSH service on the
-     *                             target machine. Default is 22.
-     * @param sshUsername          the username which will be used to access the
-     *                             target machine via ssh. Must have the
-     *                             access/privilege to execute the terminal command
-     * @param sshKeyFileFolderName the directory that holds the ssh key file
-     *                             (usually it's somewhere in the test data of the
-     *                             current project)
-     * @param sshKeyFileName       the name of the ssh key file
-     * @param dockerName           the name of the docker instance that you want to
-     *                             execute the terminal command inside
-     * @param dockerUsername       the username which will be used to access the
-     *                             docker instance. Must have the access/privilege
-     *                             to execute the terminal command
-     */
     public TerminalActions(String sshHostName, int sshPortNumber, String sshUsername, String sshKeyFileFolderName,
                            String sshKeyFileName, String dockerName, String dockerUsername) {
+        this(sshHostName, sshPortNumber, sshUsername, sshKeyFileFolderName, sshKeyFileName, dockerName, dockerUsername,
+                false);
+    }
+
+    public TerminalActions(String sshHostName, int sshPortNumber, String sshUsername, String sshKeyFileFolderName,
+                           String sshKeyFileName, String dockerName, String dockerUsername,
+                           boolean reusableRemoteSshSession) {
         this.sshHostName = sshHostName;
         this.sshPortNumber = sshPortNumber;
         this.sshUsername = sshUsername;
@@ -147,6 +121,7 @@ public class TerminalActions {
         this.sshKeyFileName = sshKeyFileName;
         this.dockerName = dockerName;
         this.dockerUsername = dockerUsername;
+        this.reusableRemoteSshSession = reusableRemoteSshSession;
     }
 
     public static TerminalActions getInstance() {
@@ -163,6 +138,49 @@ public class TerminalActions {
 
     public static TerminalActions getInstance(boolean asynchronous, boolean verbose, boolean isInternal) {
         return new TerminalActions(asynchronous, verbose, isInternal);
+    }
+
+    public boolean isReusableRemoteSshSession() {
+        return reusableRemoteSshSession;
+    }
+
+    /**
+     * Closes a reusable remote SSH client if present. No-op for local-only instances.
+     */
+    public void quit() {
+        synchronized (this) {
+            if (reusableSshClient != null) {
+                reusableSshClient.close();
+                reusableSshClient = null;
+            }
+        }
+    }
+
+    /**
+     * JSch session when {@link #isReusableRemoteSshSession()} is {@code true} and {@link #isRemoteTerminal()}.
+     */
+    public Session getJschSession() throws JSchException {
+        if (!isRemoteTerminal()) {
+            throw new IllegalStateException("getJschSession() applies only to remote SSH TerminalActions.");
+        }
+        if (!reusableRemoteSshSession) {
+            throw new IllegalStateException(
+                    "Use a constructor with reusableRemoteSshSession=true for a stable JSch Session.");
+        }
+        ensureReusableClientConnected();
+        return reusableSshClient.getJschSession();
+    }
+
+    /**
+     * Advanced: {@link RemoteSshClient} when {@link #isReusableRemoteSshSession()} is {@code true}.
+     */
+    public RemoteSshClient getRemoteSshClient() throws JSchException {
+        if (!isRemoteTerminal() || !reusableRemoteSshSession) {
+            throw new IllegalStateException(
+                    "Use a remote constructor with reusableRemoteSshSession=true for getRemoteSshClient().");
+        }
+        ensureReusableClientConnected();
+        return reusableSshClient;
     }
 
     private static String reportActionResult(String actionName, String testData, String log, Boolean passFailStatus, Exception... rootCauseException) {
@@ -211,32 +229,26 @@ public class TerminalActions {
     }
 
     public String performTerminalCommands(List<String> commands) {
-        var internalCommands = commands;
+        List<String> expanded = ShellCommandNormalizer.expandSingleCommandChaining(new ArrayList<>(commands));
+        String longCommand = RemoteCommandBundler.buildLongCommand(expanded, isDockerizedTerminal(), dockerName,
+                dockerUsername);
 
-        // Build long command and refactor for dockerized execution if needed
-        String longCommand = buildLongCommand(internalCommands);
-
-        if (internalCommands.size() == 1) {
-            if (internalCommands.getFirst().contains(" && ")) {
-                internalCommands = List.of(internalCommands.getFirst().split(" && "));
-            } else if (internalCommands.getFirst().contains(" ; ")) {
-                internalCommands = List.of(internalCommands.getFirst().split(" ; "));
-            }
+        if (!isRemoteTerminal()) {
+            lastRemoteCommandExitStatus = -1;
         }
 
-        // Perform command
-        List<String> exitLogs = isRemoteTerminal() ? executeRemoteCommand(internalCommands, longCommand) : executeLocalCommand(internalCommands, longCommand);
+        List<String> exitLogs = isRemoteTerminal() ? executeRemoteCommand(expanded, longCommand)
+                : executeLocalCommand(expanded, longCommand);
         String log = exitLogs.get(0);
         String exitStatus = exitLogs.get(1);
 
-        // Prepare final log message
         StringBuilder reportMessage = new StringBuilder();
         if (!sshHostName.isEmpty()) {
             reportMessage.append("Host Name: \"").append(sshHostName).append("\"");
             reportMessage.append(" | SSH Port Number: \"").append(sshPortNumber).append("\"");
             reportMessage.append(" | SSH Username: \"").append(sshUsername).append("\"");
         } else {
-            reportMessage.append("Host Name: \"" + "localHost" + "\"");
+            reportMessage.append("Host Name: \"").append("localHost").append("\"");
         }
         if (sshKeyFileName != null && !sshKeyFileName.isEmpty()) {
             reportMessage.append(" | Key File: \"").append(sshKeyFileFolderName).append(sshKeyFileName).append("\"");
@@ -245,12 +257,12 @@ public class TerminalActions {
         reportMessage.append(" | Exit Status: \"").append(exitStatus).append("\"");
 
         if (log != null) {
-            if (!isInternal)
+            if (!isInternal) {
                 passAction(reportMessage.toString(), log);
+            }
             return log;
-        } else {
-            return "";
         }
+        return "";
     }
 
     public String performTerminalCommand(String command) {
@@ -276,52 +288,27 @@ public class TerminalActions {
         failAction(actionName, testData, rootCauseException);
     }
 
-    private Session createSSHsession() {
-        Session session = null;
-        String testData = sshHostName + ", " + sshPortNumber + ", " + sshUsername + ", " + sshKeyFileFolderName + ", "
-                + sshKeyFileName;
-        try {
-            Properties config = new Properties();
-            config.put("StrictHostKeyChecking", "no");
-            JSch jsch = new JSch();
-            if (sshKeyFileName != null && !sshKeyFileName.isEmpty()) {
-                jsch.addIdentity(FileActions.getInstance(true).getAbsolutePath(sshKeyFileFolderName, sshKeyFileName));
-            }
-            session = jsch.getSession(sshUsername, sshHostName, sshPortNumber);
-            session.setConfig(config);
-            session.connect();
-            ReportManager.logDiscrete("Successfully created SSH Session.");
-        } catch (JSchException rootCauseException) {
-            failAction(testData, rootCauseException);
+    private RemoteSshClient newRemoteSshClientForPolicy(SshSessionPolicy sessionPolicy) {
+        if (isDockerizedTerminal()) {
+            return new RemoteSshClient(sshHostName, sshPortNumber, sshUsername, sshKeyFileFolderName, sshKeyFileName,
+                    dockerName, dockerUsername, sessionPolicy);
         }
-        return session;
+        return new RemoteSshClient(sshHostName, sshPortNumber, sshUsername, sshKeyFileFolderName, sshKeyFileName,
+                sessionPolicy);
     }
 
-    private String buildLongCommand(List<String> commands) {
-        StringBuilder command = new StringBuilder();
-        // build long command
-        for (Iterator<String> i = commands.iterator(); i.hasNext(); ) {
-            if (command.isEmpty()) {
-                command.append(i.next());
-            } else {
-                command.append(" && ").append(i.next());
+    private void ensureReusableClientConnected() throws JSchException {
+        synchronized (this) {
+            if (reusableSshClient == null) {
+                reusableSshClient = newRemoteSshClientForPolicy(SshSessionPolicy.REUSE_SESSION);
             }
+            reusableSshClient.connect();
         }
-
-        // refactor long command for dockerized execution
-        if (isDockerizedTerminal()) {
-            command.insert(0, "docker exec -u " + dockerUsername + " -i " + dockerName + " timeout "
-                    + SHAFT.Properties.timeouts.dockerCommandTimeout() + " sh -c '");
-            command.append("'");
-        }
-        return command.toString();
     }
 
     private List<String> executeLocalCommand(List<String> commands, String longCommand) {
         StringBuilder logs = new StringBuilder();
         StringBuilder exitStatuses = new StringBuilder();
-        // local execution
-//        ReportManager.logDiscrete("Attempting to execute the following command locally. Command: \"" + longCommand + "\"");
         boolean isWindows = SystemUtils.IS_OS_WINDOWS;
         String directory;
         LinkedList<String> internalCommands;
@@ -336,15 +323,16 @@ public class TerminalActions {
         FileActions.getInstance(true).createFolder(directory.replace("\"", ""));
         String finalDirectory = directory;
         internalCommands.forEach(command -> {
-            command = command.contains(".bat") && !command.contains(".\\") && !command.matches("(^.:\\\\.*$)") ? ".\\" + command : command;
-            ReportManager.logDiscrete("Executing: \"" + command + "\" locally.");
+            String cmd = command.contains(".bat") && !command.contains(".\\") && !command.matches("(^.:\\\\.*$)")
+                    ? ".\\" + command
+                    : command;
+            ReportManager.logDiscrete("Executing: \"" + cmd + "\" locally.");
             try {
-                ProcessBuilder pb = getProcessBuilder(command, finalDirectory, isWindows);
+                ProcessBuilder pb = getProcessBuilder(cmd, finalDirectory, isWindows);
                 pb.environment().put("JAVA_HOME", System.getProperty("java.home"));
                 if (!asynchronous) {
                     pb.redirectErrorStream(true);
                     Process localProcess = pb.start();
-                    // output logs
                     String line;
                     try (InputStreamReader isr = new InputStreamReader(localProcess.getInputStream());
                          BufferedReader rdr = new BufferedReader(isr)) {
@@ -366,9 +354,7 @@ public class TerminalActions {
                             logs.append(line);
                         }
                     }
-                    // Wait for the process to complete
                     localProcess.waitFor(SHAFT.Properties.timeouts.shellSessionTimeout(), TimeUnit.MINUTES);
-                    // Retrieve the exit status of the executed command and destroy open sessions
                     exitStatuses.append(localProcess.exitValue());
                 } else {
                     exitStatuses.append("asynchronous");
@@ -396,12 +382,8 @@ public class TerminalActions {
         ProcessBuilder pb = new ProcessBuilder();
         pb.directory(new File(finalDirectory));
 
-        // https://stackoverflow.com/a/10954450/12912100
         if (isWindows) {
             if (asynchronous && verbose) {
-                // Apply the execution policy to the spawned child PowerShell as well,
-                // because Start-Process launches a separate process that does not inherit
-                // the outer shell's command-line arguments.
                 pb.command("powershell.exe", "-ExecutionPolicy", "Bypass", "Start-Process powershell.exe '-ExecutionPolicy Bypass -NoExit -WindowStyle Minimized -Command \"[Console]::Title = ''SHAFT_Engine''; " + command + "\"'");
             } else {
                 pb.command("powershell.exe", "-ExecutionPolicy", "Bypass", "-Command", command);
@@ -415,47 +397,28 @@ public class TerminalActions {
     private List<String> executeRemoteCommand(List<String> commands, String longCommand) {
         StringBuilder logs = new StringBuilder();
         StringBuilder exitStatuses = new StringBuilder();
-        int sessionTimeout = Integer.parseInt(String.valueOf(SHAFT.Properties.timeouts.shellSessionTimeout() * 1000));
-        // remote execution
+        lastRemoteCommandExitStatus = -1;
         ReportManager.logDiscrete(
                 "Attempting to perform the following command remotely. Command: \"" + longCommand + "\"");
-        Session remoteSession = createSSHsession();
-        if (remoteSession != null) {
-            try {
-                remoteSession.setTimeout(sessionTimeout);
-                ChannelExec remoteChannelExecutor = (ChannelExec) remoteSession.openChannel("exec");
-                remoteChannelExecutor.setCommand(longCommand);
-                remoteChannelExecutor.connect();
-
-                // Capture logs and close readers
-                try (BufferedReader reader = new BufferedReader(new InputStreamReader(remoteChannelExecutor.getInputStream()));
-                     BufferedReader errorReader = new BufferedReader(new InputStreamReader(remoteChannelExecutor.getErrStream()))) {
-                    logs.append(readConsoleLogs(reader));
-                    logs.append(readConsoleLogs(errorReader));
+        try {
+            if (reusableRemoteSshSession) {
+                ensureReusableClientConnected();
+                SshCommandResult result = reusableSshClient.performCommands(commands);
+                logs.append(result.mergedOutput());
+                exitStatuses.append(result.exitStatus());
+                lastRemoteCommandExitStatus = result.exitStatus();
+            } else {
+                try (RemoteSshClient client = newRemoteSshClientForPolicy(SshSessionPolicy.NEW_SESSION_PER_COMMAND)) {
+                    client.connect();
+                    SshCommandResult result = client.performCommands(commands);
+                    logs.append(result.mergedOutput());
+                    exitStatuses.append(result.exitStatus());
+                    lastRemoteCommandExitStatus = result.exitStatus();
                 }
-
-                // Retrieve the exit status of the executed command and destroy open sessions
-                exitStatuses.append(remoteChannelExecutor.getExitStatus());
-                remoteSession.disconnect();
-            } catch (JSchException | IOException exception) {
-                failAction(longCommand, exception);
             }
+        } catch (JSchException | IOException exception) {
+            failAction(longCommand, exception);
         }
         return Arrays.asList(logs.toString(), exitStatuses.toString());
-    }
-
-    private String readConsoleLogs(BufferedReader reader) throws IOException {
-        StringBuilder logBuilder = new StringBuilder();
-        if (reader != null) {
-            String logLine;
-            while ((logLine = reader.readLine()) != null) {
-                if (logBuilder.isEmpty()) {
-                    logBuilder.append(logLine);
-                } else {
-                    logBuilder.append(System.lineSeparator()).append(logLine);
-                }
-            }
-        }
-        return logBuilder.toString();
     }
 }

--- a/src/main/java/com/shaft/cli/internal/JschSessionFactory.java
+++ b/src/main/java/com/shaft/cli/internal/JschSessionFactory.java
@@ -1,0 +1,45 @@
+package com.shaft.cli.internal;
+
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+
+import java.util.Properties;
+
+/**
+ * Opens a connected JSch {@link Session} from {@link SshConnectionOptions}.
+ * Callers set {@link Session#setTimeout(int)} after connect for command-level limits if needed.
+ */
+public final class JschSessionFactory {
+    private JschSessionFactory() {
+    }
+
+    public static Session connect(SshConnectionOptions options) throws JSchException {
+        JSch jsch = new JSch();
+        if (options.identityPath() != null && !options.identityPath().isEmpty()) {
+            jsch.addIdentity(options.identityPath());
+        }
+        if (options.knownHostsPath() != null && !options.knownHostsPath().isBlank()) {
+            jsch.setKnownHosts(options.knownHostsPath());
+        }
+        Session session = jsch.getSession(options.username(), options.host(), options.port());
+        Properties config = new Properties();
+        config.put("StrictHostKeyChecking", options.strictHostKeyChecking());
+        session.setConfig(config);
+        if (options.serverAliveIntervalMs() > 0) {
+            session.setServerAliveInterval(options.serverAliveIntervalMs());
+        }
+
+        boolean hasPassword = options.password() != null && !options.password().isEmpty();
+        boolean hasPassphrase = options.keyPassphrase() != null && !options.keyPassphrase().isEmpty();
+        if (hasPassword || hasPassphrase) {
+            session.setUserInfo(new SshUserInfoBridge(options.password(), options.keyPassphrase()));
+        }
+        if (hasPassword) {
+            session.setPassword(options.password());
+        }
+
+        session.connect(options.connectTimeoutMs());
+        return session;
+    }
+}

--- a/src/main/java/com/shaft/cli/internal/RemoteCommandBundler.java
+++ b/src/main/java/com/shaft/cli/internal/RemoteCommandBundler.java
@@ -1,0 +1,38 @@
+package com.shaft.cli.internal;
+
+import com.shaft.driver.SHAFT;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Builds the single remote shell line from command parts (and optional Docker {@code exec} wrap).
+ */
+public final class RemoteCommandBundler {
+    private RemoteCommandBundler() {
+    }
+
+    public static String buildLongCommand(List<String> commands, boolean dockerized, String dockerName,
+                                          String dockerUsername, int dockerCommandTimeoutSeconds) {
+        StringBuilder command = new StringBuilder();
+        for (Iterator<String> i = commands.iterator(); i.hasNext(); ) {
+            if (command.isEmpty()) {
+                command.append(i.next());
+            } else {
+                command.append(" && ").append(i.next());
+            }
+        }
+        if (dockerized) {
+            command.insert(0, "docker exec -u " + dockerUsername + " -i " + dockerName + " timeout "
+                    + dockerCommandTimeoutSeconds + " sh -c '");
+            command.append("'");
+        }
+        return command.toString();
+    }
+
+    public static String buildLongCommand(List<String> commands, boolean dockerized, String dockerName,
+                                          String dockerUsername) {
+        return buildLongCommand(commands, dockerized, dockerName, dockerUsername,
+                SHAFT.Properties.timeouts.dockerCommandTimeout());
+    }
+}

--- a/src/main/java/com/shaft/cli/internal/ShellCommandNormalizer.java
+++ b/src/main/java/com/shaft/cli/internal/ShellCommandNormalizer.java
@@ -1,0 +1,30 @@
+package com.shaft.cli.internal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Expands single-string command chaining ({@code &&}, {@code ;}) into separate command tokens.
+ */
+public final class ShellCommandNormalizer {
+    private ShellCommandNormalizer() {
+    }
+
+    public static List<String> expandSingleCommandChaining(List<String> commands) {
+        if (commands == null || commands.isEmpty()) {
+            return Collections.emptyList();
+        }
+        if (commands.size() != 1) {
+            return new ArrayList<>(commands);
+        }
+        String single = commands.getFirst();
+        if (single.contains(" && ")) {
+            return List.of(single.split(" \\&\\& "));
+        }
+        if (single.contains(" ; ")) {
+            return List.of(single.split(" ; "));
+        }
+        return new ArrayList<>(commands);
+    }
+}

--- a/src/main/java/com/shaft/cli/internal/SshConnectionOptions.java
+++ b/src/main/java/com/shaft/cli/internal/SshConnectionOptions.java
@@ -1,0 +1,17 @@
+package com.shaft.cli.internal;
+
+/**
+ * Parameters for establishing a JSch SSH session (identity, password, and known_hosts optional).
+ */
+public record SshConnectionOptions(
+        String username,
+        String host,
+        int port,
+        String identityPath,
+        String strictHostKeyChecking,
+        int connectTimeoutMs,
+        int serverAliveIntervalMs,
+        String knownHostsPath,
+        String password,
+        String keyPassphrase) {
+}

--- a/src/main/java/com/shaft/cli/internal/SshOutputRedactor.java
+++ b/src/main/java/com/shaft/cli/internal/SshOutputRedactor.java
@@ -1,0 +1,25 @@
+package com.shaft.cli.internal;
+
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * Applies optional regex-based redaction before attaching SSH transcripts to reports.
+ */
+public final class SshOutputRedactor {
+    private SshOutputRedactor() {
+    }
+
+    public static String apply(String text, String javaRegexReplacement) {
+        if (text == null) {
+            return null;
+        }
+        if (javaRegexReplacement == null || javaRegexReplacement.isBlank()) {
+            return text;
+        }
+        try {
+            return text.replaceAll(javaRegexReplacement, "[REDACTED]");
+        } catch (PatternSyntaxException ex) {
+            return text;
+        }
+    }
+}

--- a/src/main/java/com/shaft/cli/internal/SshUserInfoBridge.java
+++ b/src/main/java/com/shaft/cli/internal/SshUserInfoBridge.java
@@ -1,0 +1,64 @@
+package com.shaft.cli.internal;
+
+import com.jcraft.jsch.UIKeyboardInteractive;
+import com.jcraft.jsch.UserInfo;
+
+/**
+ * Minimal {@link UserInfo} + {@link UIKeyboardInteractive} for password-based and keyboard-interactive auth.
+ */
+public final class SshUserInfoBridge implements UserInfo, UIKeyboardInteractive {
+    private final String password;
+    private final String keyPassphrase;
+
+    public SshUserInfoBridge(String password, String keyPassphrase) {
+        this.password = password;
+        this.keyPassphrase = keyPassphrase;
+    }
+
+    @Override
+    public String getPassphrase() {
+        return emptyToNull(keyPassphrase);
+    }
+
+    @Override
+    public String getPassword() {
+        return emptyToNull(password);
+    }
+
+    @Override
+    public boolean promptPassword(String message) {
+        return password != null && !password.isEmpty();
+    }
+
+    @Override
+    public boolean promptPassphrase(String message) {
+        return keyPassphrase != null && !keyPassphrase.isEmpty();
+    }
+
+    @Override
+    public boolean promptYesNo(String message) {
+        return false;
+    }
+
+    @Override
+    public void showMessage(String message) {
+        // Non-interactive run; we do not surface server banners here.
+    }
+
+    @Override
+    public String[] promptKeyboardInteractive(String destination, String name, String instruction, String[] prompt,
+                                              boolean[] echo) {
+        if (password == null || password.isEmpty() || prompt == null || prompt.length == 0) {
+            return null;
+        }
+        String[] response = new String[prompt.length];
+        for (int i = 0; i < prompt.length; i++) {
+            response[i] = password;
+        }
+        return response;
+    }
+
+    private static String emptyToNull(String s) {
+        return s == null || s.isEmpty() ? null : s;
+    }
+}

--- a/src/main/java/com/shaft/driver/DriverFactory.java
+++ b/src/main/java/com/shaft/driver/DriverFactory.java
@@ -98,6 +98,27 @@ public class DriverFactory {
     }
 
     /**
+     * Remote terminal driver: same session when {@code reusableRemoteSsh} is {@code true} until {@link TerminalActions#quit()}.
+     */
+    public static TerminalActions getTerminalDriver(String sshHostName, int sshPortNumber, String sshUsername,
+                                                    String sshKeyFileFolderName, String sshKeyFileName,
+                                                    boolean reusableRemoteSsh) {
+        return new TerminalActions(sshHostName, sshPortNumber, sshUsername, sshKeyFileFolderName, sshKeyFileName,
+                reusableRemoteSsh);
+    }
+
+    /**
+     * Remote terminal with Docker exec wrapper and optional reusable SSH session.
+     */
+    public static TerminalActions getTerminalDriver(String sshHostName, int sshPortNumber, String sshUsername,
+                                                    String sshKeyFileFolderName, String sshKeyFileName,
+                                                    String dockerName, String dockerUsername,
+                                                    boolean reusableRemoteSsh) {
+        return new TerminalActions(sshHostName, sshPortNumber, sshUsername, sshKeyFileFolderName, sshKeyFileName,
+                dockerName, dockerUsername, reusableRemoteSsh);
+    }
+
+    /**
      * Creates a new local Terminal instance to facilitate using the Terminal Actions Library
      *
      * @return local terminal driver instance

--- a/src/main/java/com/shaft/driver/SHAFT.java
+++ b/src/main/java/com/shaft/driver/SHAFT.java
@@ -2,7 +2,11 @@ package com.shaft.driver;
 
 import com.shaft.api.RequestBuilder;
 import com.shaft.api.RestActions;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
 import com.shaft.cli.FileActions;
+import com.shaft.cli.RemoteSshClient;
+import com.shaft.cli.SshSessionPolicy;
 import com.shaft.cli.TerminalActions;
 import com.shaft.db.DatabaseActions;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
@@ -493,6 +497,9 @@ public class SHAFT {
      * <pre>{@code
      * SHAFT.CLI.terminal().performTerminalCommand("echo hello");
      * SHAFT.CLI.file().readFile("path/to/file.txt");
+     * var cli = new SHAFT.CLI.Terminal("host", 22, "user", "keys/", "id_rsa", true);
+     * String out = cli.performTerminalCommand("uname -a");
+     * cli.quit();
      * }</pre>
      */
     public static class CLI {
@@ -507,6 +514,100 @@ public class SHAFT {
          */
         public static TerminalActions terminal() {
             return new TerminalActions();
+        }
+
+        /**
+         * Terminal with an explicit {@link #quit()} (same lifecycle idea as {@link GUI.WebDriver}). Remote SSH needs
+         * {@code reusableRemoteSshSession == true} in the constructor to reuse one session.
+         */
+        public static class Terminal {
+
+            private final TerminalActions actions;
+
+            /** Local shell (same as {@link #terminal()}). */
+            public Terminal() {
+                this.actions = new TerminalActions();
+            }
+
+            public Terminal(boolean asynchronous) {
+                this.actions = new TerminalActions(asynchronous);
+            }
+
+            public Terminal(String dockerName, String dockerUsername) {
+                this.actions = new TerminalActions(dockerName, dockerUsername);
+            }
+
+            public Terminal(String sshHostName, int sshPortNumber, String sshUsername,
+                            String sshKeyFileFolderName, String sshKeyFileName, boolean reusableRemoteSshSession) {
+                this.actions = new TerminalActions(sshHostName, sshPortNumber, sshUsername, sshKeyFileFolderName,
+                        sshKeyFileName, reusableRemoteSshSession);
+            }
+
+            public Terminal(String sshHostName, int sshPortNumber, String sshUsername,
+                            String sshKeyFileFolderName, String sshKeyFileName, String dockerName, String dockerUsername,
+                            boolean reusableRemoteSshSession) {
+                this.actions = new TerminalActions(sshHostName, sshPortNumber, sshUsername, sshKeyFileFolderName,
+                        sshKeyFileName, dockerName, dockerUsername, reusableRemoteSshSession);
+            }
+
+            public String performTerminalCommand(String command) {
+                return actions.performTerminalCommand(command);
+            }
+
+            public String performTerminalCommands(List<String> commands) {
+                return actions.performTerminalCommands(commands);
+            }
+
+            /** Underlying {@link TerminalActions} for verbose/async/internal flags. */
+            public TerminalActions unwrap() {
+                return actions;
+            }
+
+            public Session getJschSession() throws JSchException {
+                return actions.getJschSession();
+            }
+
+            public RemoteSshClient getRemoteSshClient() throws JSchException {
+                return actions.getRemoteSshClient();
+            }
+
+            public void quit() {
+                actions.quit();
+            }
+        }
+
+        /**
+         * Direct {@link RemoteSshClient} entry point: builder options (password, known hosts, etc.), SFTP, forwards.
+         * String-first command flow stays on {@link Terminal}.
+         */
+        public static RemoteSshClient remoteSsh(String sshHostName, int sshPortNumber, String sshUsername,
+                                                String sshKeyFileFolderName, String sshKeyFileName) {
+            return new RemoteSshClient(sshHostName, sshPortNumber, sshUsername, sshKeyFileFolderName, sshKeyFileName);
+        }
+
+        public static RemoteSshClient remoteSsh(String sshHostName, int sshPortNumber, String sshUsername,
+                                                String sshKeyFileFolderName, String sshKeyFileName,
+                                                SshSessionPolicy sessionPolicy) {
+            return new RemoteSshClient(sshHostName, sshPortNumber, sshUsername, sshKeyFileFolderName, sshKeyFileName,
+                    sessionPolicy);
+        }
+
+        public static RemoteSshClient remoteSsh(String sshHostName, int sshPortNumber, String sshUsername,
+                                                String sshKeyFileFolderName, String sshKeyFileName,
+                                                String dockerName, String dockerUsername) {
+            return new RemoteSshClient(sshHostName, sshPortNumber, sshUsername, sshKeyFileFolderName, sshKeyFileName,
+                    dockerName, dockerUsername);
+        }
+
+        public static RemoteSshClient remoteSsh(String sshHostName, int sshPortNumber, String sshUsername,
+                                                String sshKeyFileFolderName, String sshKeyFileName,
+                                                String dockerName, String dockerUsername, SshSessionPolicy sessionPolicy) {
+            return new RemoteSshClient(sshHostName, sshPortNumber, sshUsername, sshKeyFileFolderName, sshKeyFileName,
+                    dockerName, dockerUsername, sessionPolicy);
+        }
+
+        public static RemoteSshClient.Builder remoteSshBuilder(String sshHostName, int sshPortNumber, String sshUsername) {
+            return RemoteSshClient.builder(sshHostName, sshPortNumber, sshUsername);
         }
 
         /**

--- a/src/main/java/com/shaft/properties/internal/Properties.java
+++ b/src/main/java/com/shaft/properties/internal/Properties.java
@@ -47,6 +47,7 @@ public class Properties {
     static Performance basePerformance;
     static LambdaTest baseLambdaTest;
     static API baseApi;
+    static Ssh baseSsh;
 
     // -------------------------------------------------------------------------
     // Thread-local override configs – updated by set() calls on each thread.
@@ -67,6 +68,7 @@ public class Properties {
     static final ThreadLocal<Performance> performanceOverride = new ThreadLocal<>();
     static final ThreadLocal<LambdaTest> lambdaTestOverride = new ThreadLocal<>();
     static final ThreadLocal<API> apiOverride = new ThreadLocal<>();
+    static final ThreadLocal<Ssh> sshOverride = new ThreadLocal<>();
 
     // -------------------------------------------------------------------------
     // Public proxy fields – fully API-compatible with the previous static fields.
@@ -88,6 +90,7 @@ public class Properties {
     public static final Performance performance = createProxy(Performance.class, performanceOverride, () -> basePerformance);
     public static final LambdaTest lambdaTest = createProxy(LambdaTest.class, lambdaTestOverride, () -> baseLambdaTest);
     public static final API api = createProxy(API.class, apiOverride, () -> baseApi);
+    public static final Ssh ssh = createProxy(Ssh.class, sshOverride, () -> baseSsh);
 
     // Read-only properties – not mutable after initialisation, no proxy needed.
     public static Internal internal;
@@ -214,5 +217,6 @@ public class Properties {
         performanceOverride.remove();
         lambdaTestOverride.remove();
         apiOverride.remove();
+        sshOverride.remove();
     }
 }

--- a/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
+++ b/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
@@ -87,6 +87,7 @@ public class PropertiesHelper {
         Properties.basePerformance = ConfigFactory.create(Performance.class);
         Properties.baseLambdaTest = ConfigFactory.create(LambdaTest.class);
         Properties.baseApi = ConfigFactory.create(API.class);
+        Properties.baseSsh = ConfigFactory.create(Ssh.class);
         Properties.initialized = true;
     }
 

--- a/src/main/java/com/shaft/properties/internal/Ssh.java
+++ b/src/main/java/com/shaft/properties/internal/Ssh.java
@@ -1,0 +1,87 @@
+package com.shaft.properties.internal;
+
+import com.shaft.tools.io.ReportManager;
+import org.aeonbits.owner.Config.Sources;
+import org.aeonbits.owner.ConfigFactory;
+
+/**
+ * SSH / JSch client settings for remote CLI operations.
+ *
+ * <p>Use {@link #set()} to override values programmatically:
+ * <pre>{@code
+ * SHAFT.Properties.ssh.set().strictHostKeyChecking("ask");
+ * }</pre>
+ */
+@SuppressWarnings("unused")
+@Sources({"system:properties",
+        "file:src/main/resources/properties/Ssh.properties",
+        "file:src/main/resources/properties/default/Ssh.properties",
+        "classpath:Ssh.properties",
+})
+public interface Ssh extends EngineProperties<Ssh> {
+    private static void setProperty(String key, String value) {
+        ThreadLocalPropertiesManager.setProperty(key, value);
+        Properties.sshOverride.set(ConfigFactory.create(Ssh.class, ThreadLocalPropertiesManager.getOverrides()));
+        ReportManager.logDiscrete("Setting \"" + key + "\" property with \"" + value + "\".");
+    }
+
+    @Key("sshStrictHostKeyChecking")
+    @DefaultValue("no")
+    String strictHostKeyChecking();
+
+    @Key("sshConnectTimeout")
+    @DefaultValue("30000")
+    int connectTimeout();
+
+    @Key("sshServerAliveInterval")
+    @DefaultValue("0")
+    int serverAliveInterval();
+
+    @Key("sshKnownHostsFile")
+    @DefaultValue("")
+    String knownHostsFile();
+
+    @Key("sshAttachCommandOutputToReport")
+    @DefaultValue("false")
+    boolean attachCommandOutputToReport();
+
+    @Key("sshCommandOutputReportRedactRegex")
+    @DefaultValue("")
+    String commandOutputReportRedactRegex();
+
+    default SetProperty set() {
+        return new SetProperty();
+    }
+
+    class SetProperty implements EngineProperties.SetProperty {
+        public SetProperty strictHostKeyChecking(String value) {
+            setProperty("sshStrictHostKeyChecking", value);
+            return this;
+        }
+
+        public SetProperty connectTimeout(int valueMs) {
+            setProperty("sshConnectTimeout", String.valueOf(valueMs));
+            return this;
+        }
+
+        public SetProperty serverAliveInterval(int valueMs) {
+            setProperty("sshServerAliveInterval", String.valueOf(valueMs));
+            return this;
+        }
+
+        public SetProperty knownHostsFile(String path) {
+            setProperty("sshKnownHostsFile", path);
+            return this;
+        }
+
+        public SetProperty attachCommandOutputToReport(boolean value) {
+            setProperty("sshAttachCommandOutputToReport", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty commandOutputReportRedactRegex(String javaRegex) {
+            setProperty("sshCommandOutputReportRedactRegex", javaRegex);
+            return this;
+        }
+    }
+}

--- a/src/test/java/testPackage/unitTests/RemoteCommandBundlerTest.java
+++ b/src/test/java/testPackage/unitTests/RemoteCommandBundlerTest.java
@@ -1,0 +1,36 @@
+package testPackage.unitTests;
+
+import com.shaft.cli.internal.RemoteCommandBundler;
+import com.shaft.cli.internal.ShellCommandNormalizer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+public class RemoteCommandBundlerTest {
+
+    @Test
+    public void buildLongCommandJoinsWithAnd() {
+        String cmd = RemoteCommandBundler.buildLongCommand(List.of("echo a", "echo b"), false, "", "", 60);
+        Assert.assertEquals(cmd, "echo a && echo b");
+    }
+
+    @Test
+    public void buildLongCommandWrapsDockerExec() {
+        String cmd = RemoteCommandBundler.buildLongCommand(List.of("uname"), true, "c1", "root", 99);
+        Assert.assertTrue(cmd.startsWith("docker exec -u root -i c1 timeout 99"));
+        Assert.assertTrue(cmd.contains("uname"));
+    }
+
+    @Test
+    public void expandSingleCommandChainingSplitsAnd() {
+        var expanded = ShellCommandNormalizer.expandSingleCommandChaining(List.of("a && b"));
+        Assert.assertEquals(expanded.size(), 2);
+    }
+
+    @Test
+    public void expandSingleCommandChainingSplitsSemicolon() {
+        var expanded = ShellCommandNormalizer.expandSingleCommandChaining(List.of("a ; b"));
+        Assert.assertEquals(expanded.size(), 2);
+    }
+}

--- a/src/test/java/testPackage/unitTests/RemoteSshClientTest.java
+++ b/src/test/java/testPackage/unitTests/RemoteSshClientTest.java
@@ -1,0 +1,128 @@
+package testPackage.unitTests;
+
+import com.shaft.cli.RemoteSshClient;
+import com.shaft.cli.SshCommandResult;
+import com.shaft.cli.SshSessionPolicy;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link RemoteSshClient} without a live SSH connection.
+ */
+public class RemoteSshClientTest {
+
+    @Test(description = "performCommand must fail fast when SSH host is empty")
+    public void performCommandThrowsWhenHostEmpty() {
+        try (RemoteSshClient client = new RemoteSshClient("", 22, "user", "", "")) {
+            Assert.expectThrows(IllegalStateException.class, () -> client.performCommand("echo test"));
+        }
+    }
+
+    @Test(description = "performCommands must fail fast when SSH host is empty")
+    public void performCommandsThrowsWhenHostEmpty() {
+        try (RemoteSshClient client = new RemoteSshClient("", 2222, "u", "k/", "id_rsa")) {
+            Assert.expectThrows(IllegalStateException.class, () -> client.performCommands(List.of("a", "b")));
+        }
+    }
+
+    @Test(description = "Null host is normalized to empty and performCommand is rejected")
+    public void nullHostNormalizedToEmpty() {
+        try (RemoteSshClient client = new RemoteSshClient(null, 22, "user", "", "")) {
+            Assert.expectThrows(IllegalStateException.class, () -> client.performCommand("x"));
+        }
+    }
+
+    @Test(description = "Default constructor overload uses REUSE_SESSION")
+    public void defaultConstructorUsesReuseSession() {
+        try (RemoteSshClient client = new RemoteSshClient("host", 22, "user", "keys/", "id_rsa")) {
+            Assert.assertEquals(client.getSessionPolicy(), SshSessionPolicy.REUSE_SESSION);
+        }
+    }
+
+    @Test(description = "Explicit session policy is exposed via getter")
+    public void explicitSessionPolicyIsReturned() {
+        try (RemoteSshClient client = new RemoteSshClient(
+                "host", 22, "user", "keys/", "id_rsa", SshSessionPolicy.NEW_SESSION_PER_COMMAND)) {
+            Assert.assertEquals(client.getSessionPolicy(), SshSessionPolicy.NEW_SESSION_PER_COMMAND);
+        }
+    }
+
+    @Test(description = "Null session policy falls back to REUSE_SESSION")
+    public void nullSessionPolicyFallsBackToReuse() {
+        try (RemoteSshClient client = new RemoteSshClient("host", 22, "user", "keys/", "id_rsa", null)) {
+            Assert.assertEquals(client.getSessionPolicy(), SshSessionPolicy.REUSE_SESSION);
+        }
+    }
+
+    @Test(description = "SSH + Docker constructor keeps default reuse policy")
+    public void sshDockerConstructorDefaultPolicy() {
+        try (RemoteSshClient client = new RemoteSshClient(
+                "host", 22, "user", "k/", "key", "c1", "root")) {
+            Assert.assertEquals(client.getSessionPolicy(), SshSessionPolicy.REUSE_SESSION);
+        }
+    }
+
+    @Test(description = "close() without connect should not throw")
+    public void closeWithoutConnectIsSafe() {
+        try (RemoteSshClient client = new RemoteSshClient("localhost", 22, "u", "", "")) {
+            client.close();
+            Assert.assertFalse(client.isConnected());
+        }
+    }
+
+    @Test(description = "isConnected is false before connect()")
+    public void notConnectedBeforeConnect() {
+        try (RemoteSshClient client = new RemoteSshClient("example.com", 22, "user", "", "")) {
+            Assert.assertFalse(client.isConnected());
+        }
+    }
+
+    @Test(description = "performCommandStreaming requires non-null consumer")
+    public void performCommandStreamingRequiresConsumer() {
+        try (RemoteSshClient client = new RemoteSshClient("host", 22, "user", "", "")) {
+            Assert.expectThrows(NullPointerException.class, () -> client.performCommandStreaming("echo", null));
+        }
+    }
+
+    @Test(description = "Builder produces client with expected session policy")
+    public void builderSetsSessionPolicy() {
+        try (RemoteSshClient c = RemoteSshClient.builder("h", 22, "u")
+                .sessionPolicy(SshSessionPolicy.NEW_SESSION_PER_COMMAND)
+                .build()) {
+            Assert.assertEquals(c.getSessionPolicy(), SshSessionPolicy.NEW_SESSION_PER_COMMAND);
+        }
+    }
+
+    @Test(description = "SHAFT.CLI.remoteSshBuilder delegates to RemoteSshClient.builder")
+    public void shaftCliRemoteSshBuilder() {
+        var b = com.shaft.driver.SHAFT.CLI.remoteSshBuilder("h", 22, "u").identity("k/", "id");
+        try (RemoteSshClient c = b.build()) {
+            Assert.assertEquals(c.getSessionPolicy(), SshSessionPolicy.REUSE_SESSION);
+        }
+    }
+
+    @Test(description = "SshCommandResult.mergedOutput joins stdout and stderr")
+    public void mergedOutputJoinsStreams() {
+        var r = new SshCommandResult("line1", "err1", 0);
+        String merged = r.mergedOutput();
+        Assert.assertTrue(merged.contains("line1"));
+        Assert.assertTrue(merged.contains("err1"));
+    }
+
+    @Test(description = "SshCommandResult.mergedOutput with only stdout")
+    public void mergedOutputStdoutOnly() {
+        Assert.assertEquals(new SshCommandResult("out", "", 1).mergedOutput(), "out");
+    }
+
+    @Test(description = "SshCommandResult.mergedOutput with only stderr")
+    public void mergedOutputStderrOnly() {
+        Assert.assertEquals(new SshCommandResult("", "e", -1).mergedOutput(), "e");
+    }
+
+    @Test(description = "SshCommandResult.mergedOutput empty")
+    public void mergedOutputAllEmpty() {
+        Assert.assertEquals(new SshCommandResult("", "", 0).mergedOutput(), "");
+    }
+}

--- a/src/test/java/testPackage/unitTests/SshExtensionsUnitTest.java
+++ b/src/test/java/testPackage/unitTests/SshExtensionsUnitTest.java
@@ -1,0 +1,45 @@
+package testPackage.unitTests;
+
+import com.shaft.cli.internal.SshOutputRedactor;
+import com.shaft.cli.internal.SshUserInfoBridge;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class SshExtensionsUnitTest {
+
+    @Test
+    public void redactorLeavesTextWhenRegexBlank() {
+        Assert.assertEquals(SshOutputRedactor.apply("secret=abc", ""), "secret=abc");
+        Assert.assertEquals(SshOutputRedactor.apply("secret=abc", "   "), "secret=abc");
+    }
+
+    @Test
+    public void redactorReplacesMatches() {
+        String out = SshOutputRedactor.apply("token=xyz", "token=\\w+");
+        Assert.assertTrue(out.contains("[REDACTED]"));
+        Assert.assertFalse(out.contains("xyz"));
+    }
+
+    @Test
+    public void redactorInvalidRegexReturnsOriginal() {
+        String raw = "a[b";
+        Assert.assertSame(SshOutputRedactor.apply(raw, "["), raw);
+    }
+
+    @Test
+    public void keyboardInteractiveReturnsNullWithoutPassword() {
+        var bridge = new SshUserInfoBridge("", null);
+        Assert.assertNull(bridge.promptKeyboardInteractive(null, null, null, new String[] {"Password:"}, new boolean[] {false}));
+    }
+
+    @Test
+    public void keyboardInteractiveSuppliesPasswordForEachPrompt() {
+        var bridge = new SshUserInfoBridge("pw", null);
+        String[] r = bridge.promptKeyboardInteractive(null, null, null, new String[] {"One:", "Two:"},
+                new boolean[] {false, false});
+        Assert.assertNotNull(r);
+        Assert.assertEquals(r.length, 2);
+        Assert.assertEquals(r[0], "pw");
+        Assert.assertEquals(r[1], "pw");
+    }
+}

--- a/src/test/java/testPackage/unitTests/TerminalActionsReusableSshTest.java
+++ b/src/test/java/testPackage/unitTests/TerminalActionsReusableSshTest.java
@@ -1,0 +1,59 @@
+package testPackage.unitTests;
+
+import com.shaft.cli.TerminalActions;
+import com.shaft.driver.SHAFT;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for reusable remote SSH {@link TerminalActions} lifecycle (no live SSH).
+ */
+public class TerminalActionsReusableSshTest {
+
+    @Test(description = "Non-reusable remote terminal rejects getJschSession")
+    public void getJschSessionRequiresReusable() {
+        var t = new TerminalActions("host.example", 22, "user", "keys/", "id_ed25519");
+        Assert.assertFalse(t.isReusableRemoteSshSession());
+        Assert.expectThrows(IllegalStateException.class, () -> t.getJschSession());
+    }
+
+    @Test(description = "Non-reusable remote terminal rejects getRemoteSshClient")
+    public void getRemoteSshClientRequiresReusable() {
+        var t = new TerminalActions("host.example", 22, "user", "keys/", "id_ed25519");
+        Assert.expectThrows(IllegalStateException.class, () -> t.getRemoteSshClient());
+    }
+
+    @Test(description = "Reusable flag is exposed for remote constructors")
+    public void reusableConstructorSetsFlag() {
+        var t = new TerminalActions("h", 22, "u", "k/", "key", true);
+        Assert.assertTrue(t.isReusableRemoteSshSession());
+    }
+
+    @Test(description = "Local terminal rejects getJschSession")
+    public void localTerminalRejectsNativeSession() {
+        var t = new TerminalActions();
+        Assert.expectThrows(IllegalStateException.class, () -> t.getJschSession());
+    }
+
+    @Test(description = "SHAFT.CLI.Terminal.quit is safe on local driver")
+    public void shaftCliTerminalQuitLocal() {
+        var cli = new SHAFT.CLI.Terminal();
+        cli.quit();
+    }
+
+    @Test(description = "SHAFT.CLI.Terminal forwards getJschSession policy to actions")
+    public void shaftCliTerminalThrowsWhenNotReusableRemote() {
+        var cli = new SHAFT.CLI.Terminal("h", 22, "u", "k/", "key", false);
+        try {
+            Assert.expectThrows(IllegalStateException.class, () -> cli.getJschSession());
+        } finally {
+            cli.quit();
+        }
+    }
+
+    @Test(description = "Docker+SSH reusable constructor sets flag")
+    public void dockerSshReusableFlag() {
+        var t = new TerminalActions("h", 22, "u", "k/", "key", "c1", "root", true);
+        Assert.assertTrue(t.isReusableRemoteSshSession());
+    }
+}

--- a/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
+++ b/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
@@ -1,13 +1,15 @@
 package testPackage.unitTests;
 
 import com.shaft.cli.TerminalActions;
+import com.shaft.cli.internal.RemoteCommandBundler;
+import com.shaft.cli.internal.JschSessionFactory;
+import com.shaft.cli.internal.SshConnectionOptions;
 import com.shaft.driver.SHAFT;
+import com.jcraft.jsch.JSchException;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
-import java.io.BufferedReader;
-import java.io.StringReader;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
@@ -236,15 +238,10 @@ public class TerminalActionsUnitTest {
         Assert.assertEquals(log, "", "Asynchronous execution should not capture command output.");
     }
 
-    @Test(description = "buildLongCommand should prepend docker exec wrapper for dockerized terminals")
-    public void buildLongCommandShouldWrapDockerCommand() throws Exception {
-        TerminalActions terminal = new TerminalActions("myContainer", "root");
-        Method buildLongCommand = TerminalActions.class.getDeclaredMethod("buildLongCommand", List.class);
-        buildLongCommand.setAccessible(true);
-
-        String command = (String) buildLongCommand.invoke(terminal, List.of("echo alpha", "echo beta"));
-
-        Assert.assertTrue(command.startsWith("docker exec -u root -i myContainer timeout "),
+    @Test(description = "RemoteCommandBundler should prepend docker exec wrapper for dockerized terminals")
+    public void remoteCommandBundlerShouldWrapDockerCommand() {
+        String command = RemoteCommandBundler.buildLongCommand(List.of("echo alpha", "echo beta"), true, "myContainer", "root", 30);
+        Assert.assertTrue(command.startsWith("docker exec -u root -i myContainer timeout 30"),
                 "Dockerized terminal command should be prefixed with docker exec.");
         Assert.assertTrue(command.contains("echo alpha && echo beta"),
                 "Dockerized command should keep original command chain.");
@@ -270,19 +267,20 @@ public class TerminalActionsUnitTest {
         Assert.assertEquals(linuxBuilder.command(), List.of("sh", "-c", "echo hello"));
     }
 
-    @Test(description = "readConsoleLogs should aggregate lines and handle null readers safely")
-    public void readConsoleLogsShouldHandleContentAndNull() throws Exception {
-        Method readConsoleLogs = TerminalActions.class.getDeclaredMethod("readConsoleLogs", BufferedReader.class);
-        readConsoleLogs.setAccessible(true);
-        TerminalActions terminal = new TerminalActions();
+    @Test(description = "JschSessionFactory should throw when host is unreachable")
+    public void jschSessionFactoryShouldFailOnBadHost() {
+        SshConnectionOptions o = new SshConnectionOptions(
+                "user", "non-existing-host.invalid", 22, null, "no", 5000, 0, null, null, null);
+        Assert.expectThrows(JSchException.class, () -> JschSessionFactory.connect(o));
+    }
 
-        String multiLineLogs = (String) readConsoleLogs.invoke(terminal,
-                new BufferedReader(new StringReader("line1" + System.lineSeparator() + "line2")));
-        Assert.assertTrue(multiLineLogs.contains("line1"));
-        Assert.assertTrue(multiLineLogs.contains("line2"));
-
-        String nullReaderLogs = (String) readConsoleLogs.invoke(terminal, new Object[]{null});
-        Assert.assertEquals(nullReaderLogs, "");
+    @Test(description = "JschSessionFactory should throw when identity file is missing")
+    public void jschSessionFactoryShouldFailOnMissingIdentity() throws Exception {
+        Files.createDirectories(TEMP_DIR);
+        String missingKey = TEMP_DIR.resolve("missing_key").toAbsolutePath().toString();
+        SshConnectionOptions o = new SshConnectionOptions(
+                "user", "127.0.0.1", 22, missingKey, "no", 3000, 0, null, null, null);
+        Assert.expectThrows(JSchException.class, () -> JschSessionFactory.connect(o));
     }
 
     @Test(description = "reportActionResult should format pass and fail messages for different attachment shapes")
@@ -332,28 +330,5 @@ public class TerminalActionsUnitTest {
                 () -> failActionWithoutActionName.invoke(terminal, "input",
                         (Object) new Exception[]{new RuntimeException("forced failure")}));
         Assert.assertTrue(secondFailure.getCause() instanceof RuntimeException);
-    }
-
-    @Test(description = "createSSHsession should surface connection failures for invalid settings")
-    public void createSSHsessionShouldHandleConnectionFailurePath() throws Exception {
-        TerminalActions terminal = new TerminalActions("non-existing-host", 22, "user", "", "");
-        Method createSshSession = TerminalActions.class.getDeclaredMethod("createSSHsession");
-        createSshSession.setAccessible(true);
-
-        InvocationTargetException failure = Assert.expectThrows(InvocationTargetException.class,
-                () -> createSshSession.invoke(terminal));
-        Assert.assertTrue(failure.getCause() instanceof RuntimeException);
-    }
-
-    @Test(description = "createSSHsession should handle invalid key path when identity loading fails")
-    public void createSSHsessionShouldHandleInvalidIdentityPath() throws Exception {
-        TerminalActions terminal = new TerminalActions("127.0.0.1", 22, "user",
-                TEMP_DIR.toAbsolutePath().toString() + "/", "missing_key");
-        Method createSshSession = TerminalActions.class.getDeclaredMethod("createSSHsession");
-        createSshSession.setAccessible(true);
-
-        InvocationTargetException failure = Assert.expectThrows(InvocationTargetException.class,
-                () -> createSshSession.invoke(terminal));
-        Assert.assertTrue(failure.getCause() instanceof RuntimeException);
     }
 }


### PR DESCRIPTION
implements reusable SSH / JSch support for CLI as outlined in #2695 : `SHAFT.CLI.Terminal` with explicit `quit()` (same lifecycle idea as WebDriver), string-first commands there, and `RemoteSshClient` / `remoteSshBuilder` when tests need SFTP, port forwarding, or richer `Builder` options