### PR TITLE
CLI: add reusable SSH session factory and lifecycle (TerminalActions + SHAFT.CLI.remoteTerminal)

### DIFF
--- a/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/src/main/java/com/shaft/cli/TerminalActions.java
@@ -55,6 +55,8 @@ public class TerminalActions {
     private boolean asynchronous = false;
     private boolean verbose = false;
     private boolean isInternal = false;
+    private boolean reuseRemoteSession = false;
+    private Session reusableRemoteSession;
 
 
     /**
@@ -165,6 +167,25 @@ public class TerminalActions {
         return new TerminalActions(asynchronous, verbose, isInternal);
     }
 
+    /**
+     * Creates a remote terminal actions instance that reuses the same SSH session
+     * for multiple command executions until {@link #quit()} is called.
+     *
+     * @param sshHostName          the IP address or host name for the remote machine
+     * @param sshPortNumber        the SSH service port on the target machine
+     * @param sshUsername          the username used to access the target machine
+     * @param sshKeyFileFolderName the directory that holds the SSH key file
+     * @param sshKeyFileName       the SSH key file name
+     * @return a reusable remote {@link TerminalActions} instance
+     */
+    public static TerminalActions getRemoteInstance(String sshHostName, int sshPortNumber, String sshUsername,
+                                                    String sshKeyFileFolderName, String sshKeyFileName) {
+        TerminalActions terminalActions = new TerminalActions(sshHostName, sshPortNumber, sshUsername,
+                sshKeyFileFolderName, sshKeyFileName);
+        terminalActions.reuseRemoteSession = true;
+        return terminalActions;
+    }
+
     private static String reportActionResult(String actionName, String testData, String log, Boolean passFailStatus, Exception... rootCauseException) {
         actionName = actionName.substring(0, 1).toUpperCase() + actionName.substring(1);
         String message;
@@ -257,6 +278,30 @@ public class TerminalActions {
         return performTerminalCommands(Collections.singletonList(command));
     }
 
+    /**
+     * Executes a terminal command and returns this terminal actions instance for fluent chaining.
+     *
+     * @param command the command to execute
+     * @return this {@link TerminalActions} instance
+     */
+    public TerminalActions executeTerminalCommand(String command) {
+        performTerminalCommand(command);
+        return this;
+    }
+
+    /**
+     * Disconnects any reusable SSH session owned by this terminal actions instance.
+     *
+     * <p>This method is safe to call before the first remote command is executed and is a no-op
+     * for local terminals or ephemeral remote terminals.</p>
+     */
+    public void quit() {
+        if (reusableRemoteSession != null && reusableRemoteSession.isConnected()) {
+            reusableRemoteSession.disconnect();
+        }
+        reusableRemoteSession = null;
+    }
+
     private void passAction(String actionName, String testData, String log) {
         reportActionResult(actionName, testData, log, true);
     }
@@ -295,6 +340,22 @@ public class TerminalActions {
             failAction(testData, rootCauseException);
         }
         return session;
+    }
+
+    private Session getRemoteSession() {
+        if (!reuseRemoteSession) {
+            return createSSHsession();
+        }
+        if (reusableRemoteSession == null || !reusableRemoteSession.isConnected()) {
+            reusableRemoteSession = createSSHsession();
+        }
+        return reusableRemoteSession;
+    }
+
+    private void disconnectRemoteSessionIfEphemeral(Session session) {
+        if (!reuseRemoteSession && session != null && session.isConnected()) {
+            session.disconnect();
+        }
     }
 
     private String buildLongCommand(List<String> commands) {
@@ -419,11 +480,12 @@ public class TerminalActions {
         // remote execution
         ReportManager.logDiscrete(
                 "Attempting to perform the following command remotely. Command: \"" + longCommand + "\"");
-        Session remoteSession = createSSHsession();
+        Session remoteSession = getRemoteSession();
+        ChannelExec remoteChannelExecutor = null;
         if (remoteSession != null) {
             try {
                 remoteSession.setTimeout(sessionTimeout);
-                ChannelExec remoteChannelExecutor = (ChannelExec) remoteSession.openChannel("exec");
+                remoteChannelExecutor = (ChannelExec) remoteSession.openChannel("exec");
                 remoteChannelExecutor.setCommand(longCommand);
                 remoteChannelExecutor.connect();
 
@@ -436,9 +498,13 @@ public class TerminalActions {
 
                 // Retrieve the exit status of the executed command and destroy open sessions
                 exitStatuses.append(remoteChannelExecutor.getExitStatus());
-                remoteSession.disconnect();
             } catch (JSchException | IOException exception) {
                 failAction(longCommand, exception);
+            } finally {
+                if (remoteChannelExecutor != null && remoteChannelExecutor.isConnected()) {
+                    remoteChannelExecutor.disconnect();
+                }
+                disconnectRemoteSessionIfEphemeral(remoteSession);
             }
         }
         return Arrays.asList(logs.toString(), exitStatuses.toString());

--- a/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/src/main/java/com/shaft/cli/TerminalActions.java
@@ -19,6 +19,7 @@ import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -298,14 +299,14 @@ public class TerminalActions {
      * <p>This method is safe to call before the first remote command is executed and is a no-op
      * for local terminals or ephemeral remote terminals.</p>
      */
-    public void quit() {
+    public synchronized void quit() {
         cancelReusableSessionTimeoutTask();
         if (reusableRemoteSession != null && reusableRemoteSession.isConnected()) {
             reusableRemoteSession.disconnect();
         }
         reusableRemoteSession = null;
         if (reusableSessionTimeoutScheduler != null) {
-            reusableSessionTimeoutScheduler.shutdownNow();
+            reusableSessionTimeoutScheduler.shutdown();
             reusableSessionTimeoutScheduler = null;
         }
     }
@@ -350,7 +351,7 @@ public class TerminalActions {
         return session;
     }
 
-    private Session getRemoteSession() {
+    private synchronized Session getRemoteSession() {
         if (!reuseRemoteSession) {
             return createSSHsession();
         }
@@ -361,20 +362,28 @@ public class TerminalActions {
         return reusableRemoteSession;
     }
 
-    private void scheduleReusableSessionTimeout() {
+    private synchronized void scheduleReusableSessionTimeout() {
         long sessionTimeoutMinutes = SHAFT.Properties.timeouts.shellSessionTimeout();
         if (sessionTimeoutMinutes <= 0) {
             return;
         }
 
         if (reusableSessionTimeoutScheduler == null || reusableSessionTimeoutScheduler.isShutdown()) {
-            reusableSessionTimeoutScheduler = Executors.newSingleThreadScheduledExecutor();
+            reusableSessionTimeoutScheduler = Executors.newSingleThreadScheduledExecutor(getReusableSessionTimeoutThreadFactory());
         }
         cancelReusableSessionTimeoutTask();
         reusableSessionTimeoutTask = reusableSessionTimeoutScheduler.schedule(this::quit, sessionTimeoutMinutes, TimeUnit.MINUTES);
     }
 
-    private void cancelReusableSessionTimeoutTask() {
+    private ThreadFactory getReusableSessionTimeoutThreadFactory() {
+        return runnable -> {
+            Thread thread = new Thread(runnable, "SHAFT-CLI-Reusable-Session-Timeout");
+            thread.setDaemon(true);
+            return thread;
+        };
+    }
+
+    private synchronized void cancelReusableSessionTimeoutTask() {
         if (reusableSessionTimeoutTask != null) {
             reusableSessionTimeoutTask.cancel(false);
             reusableSessionTimeoutTask = null;

--- a/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/src/main/java/com/shaft/cli/TerminalActions.java
@@ -514,7 +514,7 @@ public class TerminalActions {
     private List<String> executeRemoteCommand(List<String> commands, String longCommand) {
         StringBuilder logs = new StringBuilder();
         StringBuilder exitStatuses = new StringBuilder();
-        int sessionTimeout = Integer.parseInt(String.valueOf(SHAFT.Properties.timeouts.shellSessionTimeout() * 1000));
+        int sessionTimeout = Math.toIntExact(TimeUnit.MINUTES.toMillis(SHAFT.Properties.timeouts.shellSessionTimeout()));
         // remote execution
         ReportManager.logDiscrete(
                 "Attempting to perform the following command remotely. Command: \"" + longCommand + "\"");

--- a/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/src/main/java/com/shaft/cli/TerminalActions.java
@@ -18,6 +18,7 @@ import java.io.InputStreamReader;
 import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -57,6 +58,8 @@ public class TerminalActions {
     private boolean isInternal = false;
     private boolean reuseRemoteSession = false;
     private Session reusableRemoteSession;
+    private ScheduledExecutorService reusableSessionTimeoutScheduler;
+    private ScheduledFuture<?> reusableSessionTimeoutTask;
 
 
     /**
@@ -296,10 +299,15 @@ public class TerminalActions {
      * for local terminals or ephemeral remote terminals.</p>
      */
     public void quit() {
+        cancelReusableSessionTimeoutTask();
         if (reusableRemoteSession != null && reusableRemoteSession.isConnected()) {
             reusableRemoteSession.disconnect();
         }
         reusableRemoteSession = null;
+        if (reusableSessionTimeoutScheduler != null) {
+            reusableSessionTimeoutScheduler.shutdownNow();
+            reusableSessionTimeoutScheduler = null;
+        }
     }
 
     private void passAction(String actionName, String testData, String log) {
@@ -349,7 +357,28 @@ public class TerminalActions {
         if (reusableRemoteSession == null || !reusableRemoteSession.isConnected()) {
             reusableRemoteSession = createSSHsession();
         }
+        scheduleReusableSessionTimeout();
         return reusableRemoteSession;
+    }
+
+    private void scheduleReusableSessionTimeout() {
+        long sessionTimeoutMinutes = SHAFT.Properties.timeouts.shellSessionTimeout();
+        if (sessionTimeoutMinutes <= 0) {
+            return;
+        }
+
+        if (reusableSessionTimeoutScheduler == null || reusableSessionTimeoutScheduler.isShutdown()) {
+            reusableSessionTimeoutScheduler = Executors.newSingleThreadScheduledExecutor();
+        }
+        cancelReusableSessionTimeoutTask();
+        reusableSessionTimeoutTask = reusableSessionTimeoutScheduler.schedule(this::quit, sessionTimeoutMinutes, TimeUnit.MINUTES);
+    }
+
+    private void cancelReusableSessionTimeoutTask() {
+        if (reusableSessionTimeoutTask != null) {
+            reusableSessionTimeoutTask.cancel(false);
+            reusableSessionTimeoutTask = null;
+        }
     }
 
     private void disconnectRemoteSessionIfEphemeral(Session session) {

--- a/src/main/java/com/shaft/driver/SHAFT.java
+++ b/src/main/java/com/shaft/driver/SHAFT.java
@@ -510,6 +510,23 @@ public class SHAFT {
         }
 
         /**
+         * Creates a new remote terminal actions instance that reuses one SSH session
+         * across multiple command executions until {@link TerminalActions#quit()} is called.
+         *
+         * @param sshHostName          the IP address or host name for the remote machine
+         * @param sshPortNumber        the SSH service port on the target machine
+         * @param sshUsername          the username used to access the target machine
+         * @param sshKeyFileFolderName the directory that holds the SSH key file
+         * @param sshKeyFileName       the SSH key file name
+         * @return a reusable remote {@link TerminalActions} instance
+         */
+        public static TerminalActions remoteTerminal(String sshHostName, int sshPortNumber, String sshUsername,
+                                                     String sshKeyFileFolderName, String sshKeyFileName) {
+            return TerminalActions.getRemoteInstance(sshHostName, sshPortNumber, sshUsername,
+                    sshKeyFileFolderName, sshKeyFileName);
+        }
+
+        /**
          * Creates a new file actions instance for file-system operations.
          *
          * @return a {@link FileActions} instance

--- a/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
+++ b/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
@@ -14,6 +14,9 @@ import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Unit tests for {@link TerminalActions}.
@@ -156,6 +159,28 @@ public class TerminalActionsUnitTest {
 
         Assert.assertTrue(terminal.isRemoteTerminal(),
                 "Calling quit before connection should not clear remote terminal configuration");
+    }
+
+    @Test(description = "quit should cancel any scheduled reusable session timeout task")
+    public void quitShouldCancelReusableSessionTimeoutTask() throws Exception {
+        TerminalActions terminal = SHAFT.CLI.remoteTerminal(
+                "host.example.com", 2222, "user", "/keys/", "id_rsa");
+
+        Field schedulerField = TerminalActions.class.getDeclaredField("reusableSessionTimeoutScheduler");
+        schedulerField.setAccessible(true);
+        var scheduler = Executors.newSingleThreadScheduledExecutor();
+        schedulerField.set(terminal, scheduler);
+
+        ScheduledFuture<?> timeoutTask = scheduler.schedule(() -> {
+        }, 10, TimeUnit.MINUTES);
+        Field timeoutTaskField = TerminalActions.class.getDeclaredField("reusableSessionTimeoutTask");
+        timeoutTaskField.setAccessible(true);
+        timeoutTaskField.set(terminal, timeoutTask);
+
+        terminal.quit();
+
+        Assert.assertTrue(timeoutTask.isCancelled(), "Expected reusable session timeout task to be canceled on quit.");
+        Assert.assertTrue(scheduler.isShutdown(), "Expected reusable session timeout scheduler to be shutdown on quit.");
     }
 
     @Test(description = "executeTerminalCommand should return same terminal instance for fluent chaining")

--- a/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
+++ b/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
@@ -8,6 +8,7 @@ import org.testng.annotations.Test;
 
 import java.io.BufferedReader;
 import java.io.StringReader;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
@@ -117,6 +118,54 @@ public class TerminalActionsUnitTest {
     public void getInstanceWithAllFlagsShouldReturnTerminal() {
         TerminalActions terminal = TerminalActions.getInstance(false, false, true);
         Assert.assertNotNull(terminal, "getInstance(false, false, true) should return a non-null instance");
+    }
+
+
+    @Test(description = "remoteTerminal facade should create reusable remote terminal")
+    public void remoteTerminalFacadeShouldCreateReusableRemoteTerminal() throws Exception {
+        TerminalActions terminal = SHAFT.CLI.remoteTerminal(
+                "host.example.com", 2222, "user", "/keys/", "id_rsa");
+
+        Assert.assertNotNull(terminal, "remoteTerminal() should return a non-null instance");
+        Assert.assertTrue(terminal.isRemoteTerminal(),
+                "Facade-created terminal should be remote");
+        Assert.assertEquals(terminal.getSshHostName(), "host.example.com",
+                "SSH host name should match");
+        Assert.assertEquals(terminal.getSshPortNumber(), 2222,
+                "SSH port number should match");
+        Assert.assertEquals(terminal.getSshUsername(), "user",
+                "SSH username should match");
+        Assert.assertEquals(terminal.getSshKeyFileFolderName(), "/keys/",
+                "SSH key folder should match");
+        Assert.assertEquals(terminal.getSshKeyFileName(), "id_rsa",
+                "SSH key file name should match");
+
+        Field reuseRemoteSessionField = TerminalActions.class.getDeclaredField("reuseRemoteSession");
+        reuseRemoteSessionField.setAccessible(true);
+        Assert.assertTrue((Boolean) reuseRemoteSessionField.get(terminal),
+                "Facade-created remote terminal should enable reusable SSH session lifecycle");
+    }
+
+    @Test(description = "quit should be safe before any reusable SSH connection is opened")
+    public void quitShouldBeSafeBeforeReusableRemoteConnection() {
+        TerminalActions terminal = SHAFT.CLI.remoteTerminal(
+                "host.example.com", 2222, "user", "/keys/", "id_rsa");
+
+        terminal.quit();
+        terminal.quit();
+
+        Assert.assertTrue(terminal.isRemoteTerminal(),
+                "Calling quit before connection should not clear remote terminal configuration");
+    }
+
+    @Test(description = "executeTerminalCommand should return same terminal instance for fluent chaining")
+    public void executeTerminalCommandShouldReturnSameInstance() {
+        TerminalActions terminal = TerminalActions.getInstance(false, false, true);
+
+        TerminalActions chainedTerminal = terminal.executeTerminalCommand("echo fluent");
+
+        Assert.assertSame(chainedTerminal, terminal,
+                "Fluent terminal execution should return the same TerminalActions instance");
     }
 
     // --- Default SSH Values ---


### PR DESCRIPTION
### Motivation
- Provide a minimal, backwards-compatible path to reuse a single JSch `Session` across multiple remote commands to reduce connection overhead for multi-step CLI flows while preserving existing ephemeral behavior.

### Description
- Add reusable-session state and lifecycle helpers to `com.shaft.cli.TerminalActions`: `reuseRemoteSession`, `reusableRemoteSession`, `getRemoteSession()`, and `disconnectRemoteSessionIfEphemeral(Session)`, and update remote execution to open a fresh `ChannelExec` per command and only disconnect the `Session` when ephemeral.
- Add a package-public factory `TerminalActions.getRemoteInstance(String,int,String,String,String)` that returns a `TerminalActions` configured to reuse the SSH session, plus `executeTerminalCommand(String)` for fluent chaining and `quit()` to safely disconnect any reusable session.
- Add a new `SHAFT.CLI.remoteTerminal(...)` facade that delegates to `TerminalActions.getRemoteInstance(...)`, and preserve the existing `SHAFT.CLI.terminal()` behavior and all existing public constructors.

### Testing
- Ran the focused unit test class via `mvn -Dtest=TerminalActionsUnitTest test -Dgpg.skip`, which executed 32 tests and reported 32 passed and 0 failed.
- Performed compile validation with `mvn clean install -DskipTests -Dgpg.skip`, which completed successfully (BUILD SUCCESS).
- Allure report generation was attempted during the unit run and exited with code 0, with non-blocking network warnings observed during update/check telemetry calls.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08e79ff7bc832094fc6a9534a84c13)