### PR TITLE
fix: stable property file loading and stream cleanup in PropertyFileManager

### DIFF
--- a/src/main/java/com/shaft/properties/internal/PropertyFileManager.java
+++ b/src/main/java/com/shaft/properties/internal/PropertyFileManager.java
@@ -190,17 +190,16 @@ public final class PropertyFileManager {
                     FileActions.getInstance(true).unpackArchive(url, "target/");
                     propertiesFolderPath = "target/resources/properties/default/";
                 }
-                // reading regular files
-                Collection<File> propertiesFilesList;
                 if (FileActions.getInstance(true).doesFileExist(propertiesFolderPath)) {
-                    propertiesFilesList = FileUtils.listFiles(new File(propertiesFolderPath), new String[]{"properties"},
-                            false);
-                    File propertyFile;
-                    for (int i = 0; i < propertiesFilesList.size(); i++) {
-                        propertyFile = (File) (propertiesFilesList.toArray())[i];
+                    Collection<File> propertyFiles = FileUtils.listFiles(new File(propertiesFolderPath),
+                            new String[]{"properties"}, false);
+                    List<File> sortedPropertyFiles = new ArrayList<>(propertyFiles);
+                    sortedPropertyFiles.sort(Comparator.comparing(file -> file.getAbsolutePath()));
+                    for (File propertyFile : sortedPropertyFiles) {
                         ReportManager.logDiscrete("Loading properties file: " + propertyFile, Level.DEBUG);
-                        loadPropertiesFileIntoSystemProperties(properties, propertyFile);
+                        loadPropertiesFromFile(properties, propertyFile);
                     }
+                    applyLoadedPropertiesToSystem(properties);
                 } else {
                     ReportManager.logDiscrete(
                             "The desired propertiesFolderPath directory doesn't exist. ["
@@ -212,17 +211,28 @@ public final class PropertyFileManager {
         }
     }
 
-    private static void loadPropertiesFileIntoSystemProperties(java.util.Properties properties, File propertyFile) {
-        try {
-            properties.load(new FileInputStream(propertyFile));
-            // merge: effective properties (system + thread-local) override file-based properties
-            properties.putAll(ThreadLocalPropertiesManager.getEffectiveProperties());
-            ThreadLocalPropertiesManager.applyCompatibilityAliases(properties);
-            // write merged result back to system properties so that ConfigFactory picks them up
-            System.getProperties().putAll(properties);
+    /**
+     * Loads entries from a single file into {@code target}. Does not touch {@link System#getProperties()}.
+     *
+     * @return {@code true} when the file was read successfully
+     */
+    private static boolean loadPropertiesFromFile(java.util.Properties target, File propertyFile) {
+        try (FileInputStream inputStream = new FileInputStream(propertyFile)) {
+            target.load(inputStream);
+            return true;
         } catch (IOException e) {
             ReportManagerHelper.logDiscrete(e);
+            return false;
         }
+    }
+
+    /**
+     * Merges file-based properties with effective overrides and publishes once to {@link System#getProperties()}.
+     */
+    private static void applyLoadedPropertiesToSystem(java.util.Properties loadedFromFiles) {
+        loadedFromFiles.putAll(ThreadLocalPropertiesManager.getEffectiveProperties());
+        ThreadLocalPropertiesManager.applyCompatibilityAliases(loadedFromFiles);
+        System.getProperties().putAll(loadedFromFiles);
     }
 
     public static void readCustomPropertyFiles() {

--- a/src/test/java/testPackage/unitTests/PropertyFileManagerUnitTest.java
+++ b/src/test/java/testPackage/unitTests/PropertyFileManagerUnitTest.java
@@ -12,6 +12,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
 public class PropertyFileManagerUnitTest {
@@ -172,10 +173,10 @@ public class PropertyFileManagerUnitTest {
         }
     }
 
-    @Test(description = "loadPropertiesFileIntoSystemProperties should gracefully handle non-readable file input")
-    public void loadPropertiesFileIntoSystemProperties_handlesIOException() throws Exception {
+    @Test(description = "loadPropertiesFromFile should gracefully handle non-readable file input")
+    public void loadPropertiesFromFile_handlesIOException() throws Exception {
         Method loadMethod = PropertyFileManager.class.getDeclaredMethod(
-                "loadPropertiesFileIntoSystemProperties",
+                "loadPropertiesFromFile",
                 java.util.Properties.class,
                 File.class
         );
@@ -188,13 +189,51 @@ public class PropertyFileManagerUnitTest {
         properties.setProperty(key, "from-file-load");
 
         try {
-            loadMethod.invoke(null, properties, directory);
+            boolean loaded = (boolean) loadMethod.invoke(null, properties, directory);
+            SHAFT.Validations.assertThat().object(loaded).isEqualTo(false).perform();
+            SHAFT.Validations.assertThat().object(properties.getProperty(key)).isEqualTo("from-file-load").perform();
         } catch (InvocationTargetException e) {
-            Assert.fail("loadPropertiesFileIntoSystemProperties should handle IO errors internally", e.getCause());
+            Assert.fail("loadPropertiesFromFile should handle IO errors internally", e.getCause());
         } finally {
             Files.deleteIfExists(directory.toPath());
         }
         SHAFT.Validations.assertThat().object(System.getProperty(key)).isEqualTo(previousValue).perform();
         System.clearProperty(key);
+    }
+
+    @Test(description = "readPropertyFiles should load .properties files in deterministic sorted order")
+    public void readPropertyFiles_loadsPropertiesInDeterministicOrder() throws Exception {
+        Method readPropertyFiles = PropertyFileManager.class.getDeclaredMethod("readPropertyFiles", String.class);
+        readPropertyFiles.setAccessible(true);
+        Path propertiesDirectory = Files.createTempDirectory("shaft-property-order");
+        String orderKey = "shaft.property.manager.load.order";
+        String previousValue = System.getProperty(orderKey);
+
+        try {
+            Files.writeString(propertiesDirectory.resolve("z-order.properties"), orderKey + "=from-z\n");
+            Files.writeString(propertiesDirectory.resolve("a-order.properties"), orderKey + "=from-a\n");
+            Files.writeString(propertiesDirectory.resolve("b-order.properties"), orderKey + "=from-b\n");
+
+            readPropertyFiles.invoke(null, propertiesDirectory.toString());
+
+            SHAFT.Validations.assertThat().object(System.getProperty(orderKey)).isEqualTo("from-z").perform();
+        } catch (InvocationTargetException e) {
+            Assert.fail("readPropertyFiles should load sorted property files", e.getCause());
+        } finally {
+            if (previousValue != null) {
+                System.setProperty(orderKey, previousValue);
+            } else {
+                System.clearProperty(orderKey);
+            }
+            Files.walk(propertiesDirectory)
+                    .sorted(java.util.Comparator.reverseOrder())
+                    .forEach(path -> {
+                        try {
+                            Files.deleteIfExists(path);
+                        } catch (Exception ignored) {
+                            // best-effort temp cleanup
+                        }
+                    });
+        }
     }
 }


### PR DESCRIPTION
this small fix in `PropertyFileManager` for how SHAFT reads the `.properties` files in `src/main/resources/properties/` at startup

### Describtion

when tests start, SHAFT loads those files into `System.getProperties()` so the rest of the engine (OWNER / `SHAFT.Properties`) can pick them up, that part is fine but the loader had a few annoying bugs:

**streams not closed**  
we were doing `new FileInputStream(...)` and never closing it, on Windows that can lock the file for a while u will notice it when tests try to delete or overwrite stuff in the properties folder, or when you rerun things in the same JVM

**file order was random**  
`FileUtils.listFiles()` doesn't guarantee order so if u ever had the same key in two files (not the normal SHAFT setup, but it happens), one machine might pick value A and another value B, it will Looks like a flaky test when it's really just load order

**System got updated file by file**  
after each file we pushed into `System.getProperties()` if a later file failed to read, u could still end up half-loaded

### what i changed
nothing public-facing, same flow as before:
- try with resources when reading each file
- sort files by path before loading so order is always the same
- load everything first, then merge overrides and write to `System` once at the end

- for normal SHAFT projects (`custom.properties` + TestNG + log4j etc. with different keys) behavior should be the same, just consistent
- If someone puts the same key in two files, it's now predictable: later file in sorted order wins, then `-D` / `SHAFT.Properties.set()` still win like before

### tests
extended `PropertyFileManagerUnitTest`:
- bad file read doesn't touch System
- new test for sorted load order (a, b, z --> z wins)