### PR TITLE
Normalize single-leading-slash paths in JavaHelper.appendTestDataToRelativePath and update tests

### DIFF
--- a/src/main/java/com/shaft/tools/internal/support/JavaHelper.java
+++ b/src/main/java/com/shaft/tools/internal/support/JavaHelper.java
@@ -252,13 +252,13 @@ public class JavaHelper {
                 // Preserve POSIX-style absolute paths that were normalized with an extra leading slash.
                 return relativePath.substring(1);
             }
+            if (relativePath.startsWith("/")) {
+                // remove extra slash at the beginning if applicable
+                relativePath = relativePath.substring(1);
+            }
             // Do not prepend testData path to absolute OS paths
             if (new java.io.File(relativePath).isAbsolute()) {
                 return relativePath;
-            }
-            if (relativePath.startsWith("/")) {
-                //remove extra slash at the beginning if applicable
-                relativePath = relativePath.substring(1);
             }
             var testDataFolderPath = SHAFT.Properties.paths.testData();
             if (relativePath.contains(testDataFolderPath)) {

--- a/src/test/java/testPackage/unitTests/JavaHelperUnitTest.java
+++ b/src/test/java/testPackage/unitTests/JavaHelperUnitTest.java
@@ -392,12 +392,12 @@ public class JavaHelperUnitTest {
                 "Relative locators should use dedicated formatting");
     }
 
-    @Test(description = "appendTestDataToRelativePath: single-slash absolute path should be returned as-is")
-    public void appendTestDataToRelativePathSingleSlashAbsolutePathShouldBeReturnedAsIs() {
-        String absolutePath = "/javaHelperMissing_" + UUID.randomUUID() + ".json";
-        String result = JavaHelper.appendTestDataToRelativePath(absolutePath);
-        Assert.assertEquals(result, absolutePath,
-                "Absolute OS paths should not be prefixed with the configured test data directory");
+    @Test(description = "appendTestDataToRelativePath: single-slash relative path should be prefixed with test data folder")
+    public void appendTestDataToRelativePathSingleSlashRelativePathShouldBePrefixedWithTestDataFolder() {
+        String slashPrefixedRelativePath = "/javaHelperMissing_" + UUID.randomUUID() + ".json";
+        String result = JavaHelper.appendTestDataToRelativePath(slashPrefixedRelativePath);
+        Assert.assertEquals(result, SHAFT.Properties.paths.testData() + slashPrefixedRelativePath.substring(1),
+                "Slash-prefixed relative paths should be normalized then prefixed with the configured test data directory");
     }
 
     @Test(description = "appendTestDataToRelativePath: absolute path should be returned as-is")


### PR DESCRIPTION
### Motivation
- Fix inconsistent handling of paths that start with a single leading slash so that accidental leading slashes are treated as relative paths to be prefixed with the test data folder rather than treated as absolute paths.
- Preserve prior special-case behavior for POSIX-style normalized absolute paths that start with double slashes (`"//"`).

### Description
- Move single-leading-slash normalization earlier in `JavaHelper.appendTestDataToRelativePath` so the leading `/` is removed before checking `new java.io.File(relativePath).isAbsolute()`.
- Keep the `"//"` prefix case to normalize POSIX absolute paths by returning `relativePath.substring(1)` and avoid altering their absolute semantics.
- Remove the duplicated single-slash trimming and update unit tests in `JavaHelperUnitTest` to expect slash-prefixed relative paths to be normalized and prefixed with `SHAFT.Properties.paths.testData()`.

### Testing
- Updated and executed unit tests in `JavaHelperUnitTest` that cover `appendTestDataToRelativePath` behavior, including the single-slash and double-slash cases, and they passed.
- Ran the full test suite with `mvn test` and observed success for the modified tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a101e37482c83208bca0e83043804b8)