### PR TITLE
codex: prepare release 10.2.20260522

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.shafthq</groupId>
     <artifactId>SHAFT_ENGINE</artifactId>
-    <version>10.2.20260513</version> <!-- UPDATE com.shaft.properties.internal > Internal > shaftEngineVersion, allure3Version, nodeLtsVersion,  -->
+    <version>10.2.20260522</version> <!-- UPDATE com.shaft.properties.internal > Internal > shaftEngineVersion, allure3Version, nodeLtsVersion,  -->
     <name>${project.groupId}:${project.artifactId}</name>
     <description>SHAFT is a unified test automation engine. Powered by best-in-class frameworks, SHAFT provides a
         wizard-like syntax to drive your automation efficiently, maximize your ROI, and minimize your learning curve.

--- a/src/main/java/com/shaft/properties/internal/Internal.java
+++ b/src/main/java/com/shaft/properties/internal/Internal.java
@@ -18,7 +18,7 @@ import org.aeonbits.owner.Config.Sources;
 })
 public interface Internal extends EngineProperties<Internal> {
     @Key("shaftEngineVersion")
-    @DefaultValue("10.2.20260513")
+    @DefaultValue("10.2.20260522")
     String shaftEngineVersion();
 
     @Key("watermarkImagePath")
@@ -32,7 +32,7 @@ public interface Internal extends EngineProperties<Internal> {
      * without changing {@code AllureManager} or any CI script. Use this url for the latest version <a href="https://github.com/allure-framework/allure3/releases">Allure3Releases</a>
      */
     @Key("allure3Version")
-    @DefaultValue("3.8.1")
+    @DefaultValue("3.8.2")
     String allure3Version();
 
     /**

--- a/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
+++ b/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260513</shaft_engine.version>
+        <shaft_engine.version>10.2.20260522</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
+++ b/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260513</shaft_engine.version>
+        <shaft_engine.version>10.2.20260522</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
+++ b/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260513</shaft_engine.version>
+        <shaft_engine.version>10.2.20260522</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
+++ b/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260513</shaft_engine.version>
+        <shaft_engine.version>10.2.20260522</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
+++ b/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260513</shaft_engine.version>
+        <shaft_engine.version>10.2.20260522</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
+++ b/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260513</shaft_engine.version>
+        <shaft_engine.version>10.2.20260522</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
+++ b/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260513</shaft_engine.version>
+        <shaft_engine.version>10.2.20260522</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>


### PR DESCRIPTION
### Motivation
- Prepare and publish a Q2 patch release by updating the project version and internal metadata to the new release date `20260522`.
- Ensure bundled tooling coordinates are current by upgrading the Allure 3 CLI version to the latest stable npm release.
- Keep sample/demo projects aligned with the new engine version so example projects resolve the released artifact.

### Description
- Bumped the root project version to `10.2.20260522` in `pom.xml`.
- Updated `src/main/java/com/shaft/properties/internal/Internal.java` to set `shaftEngineVersion` to `10.2.20260522` and `allure3Version` to `3.8.2` while leaving `nodeLtsVersion` at `24.15.0`.
- Updated all sample/demo POMs under `src/main/resources/examples/**/pom.xml` to use `<shaft_engine.version>10.2.20260522</shaft_engine.version>` so example projects reference the new release.
- Committed the changes with message `codex: prepare release 10.2.20260522` and prepared a release PR body summarizing the change set.

### Testing
- Ran `mvn clean install -DskipTests -Dgpg.skip` to validate the project builds and the installation of the release coordinates, and it completed successfully.
- Queried the npm registry (`https://registry.npmjs.org/allure`) to confirm the latest `allure` dist-tag and used the result (`3.8.2`) to update `Internal.allure3Version`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a01c0b70832091e680c9dc9983a4)