### PR TITLE
codex: improve GitHub automated release notes formatting

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,12 +1,12 @@
 # .github/release.yml
 # Controls how GitHub automatically categorizes pull requests in release notes.
-# Keep release announcements intentionally minimal: only breaking changes, major
-# new features, and GitHub's automatically appended new-contributor section.
+# Goal: produce readable, user-focused release notes with explicit sections and
+# no "everything in one Uncategorized block" output.
 # Reference: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
 
 changelog:
+  # Keep noisy maintenance activity out of release highlights.
   exclude:
-    # Keep bot-authored maintenance out of public release highlights.
     authors:
       - dependabot[bot]
       - dependabot
@@ -14,44 +14,68 @@ changelog:
       - github-actions
       - copilot-swe-agent[bot]
 
-    # Hide routine/non-user-facing changes from the release announcement.
     labels:
-      - bug
-      - bugfix
-      - build
-      - ci
-      - cd
-      - dependencies
-      - dependency
-      - deps
-      - documentation
-      - docs
-      - doc
       - duplicate
-      - github-actions
-      - good first issue
-      - help wanted
-      - infrastructure
       - invalid
-      - maintenance
       - question
-      - regression
-      - test
-      - tests
-      - testing
       - wontfix
+      - skip-release-notes
 
   categories:
-    # Compatibility-impacting changes must be the first thing users see.
     - title: "💥 Breaking Changes"
       labels:
         - breaking-change
         - breaking
         - semver-major
 
-    # Only intentional major feature labels belong in public highlights.
-    - title: "🚀 Major New Features"
+    - title: "🚀 New Features"
       labels:
         - feature
         - new-feature
+        - enhancement
         - semver-minor
+
+    - title: "🐛 Fixes"
+      labels:
+        - fix
+        - bug
+        - bugfix
+        - regression
+
+    - title: "⚡ Performance"
+      labels:
+        - performance
+        - perf
+        - optimization
+
+    - title: "🛡️ Security"
+      labels:
+        - security
+
+    - title: "🧪 Testing & Reliability"
+      labels:
+        - test
+        - tests
+        - testing
+        - flaky-test
+
+    - title: "📚 Documentation"
+      labels:
+        - docs
+        - doc
+        - documentation
+
+    - title: "🔧 CI / Build / Dependencies"
+      labels:
+        - ci
+        - cd
+        - build
+        - dependencies
+        - dependency
+        - deps
+        - github-actions
+
+  uncategorized-title: "📦 Other Changes"
+
+  # Render each PR in a compact, consistent line.
+  change-template: "- $TITLE by @$AUTHOR in #$NUMBER"


### PR DESCRIPTION
### Motivation
- Fix the poor autogenerated release notes presentation by providing explicit categorization, a readable fallback title, and a consistent entry format so release pages are useful without manual edits.
- Reduce maintenance noise while still surfacing user-facing changes by excluding only true-noise authors/labels instead of broadly hiding categories like bug/docs/ci.

### Description
- Updated ` .github/release.yml` to add explicit categories for Breaking Changes, New Features, Fixes, Performance, Security, Testing & Reliability, Documentation, and CI/Build/Dependencies.
- Adjusted the `exclude` section to keep only bot authors and truly noisy labels (`duplicate`, `invalid`, `question`, `wontfix`, `skip-release-notes`).
- Added `uncategorized-title: "📦 Other Changes"` and `change-template: "- $TITLE by @$AUTHOR in #$NUMBER"` to provide a readable fallback and consistent per-PR formatting.
- Improved file header/comments to document intent and GitHub automated-release-notes compatibility.

### Testing
- No automated tests were required or run for this configuration-only change; CI will show the improved formatting on future automated release-note generation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10ae3230dc8320ae95beb8b8e37d69)