### PR TITLE
Namespaced video capability merging in OptionsManager; remove top-level enableVideo

### DIFF
--- a/.github/copilot-memory.md
+++ b/.github/copilot-memory.md
@@ -79,3 +79,10 @@ Purpose: keep high-signal, reusable learnings from implementation sessions in on
 - Lesson: Release PRs are metadata-sensitive and must be opened directly once validated. Always inspect recent merged release PRs, compute the version with `{major}.{quarter}.{YYYYMMDD}`, update root `pom.xml`, `Internal.java` `shaftEngineVersion`, verify/update `allure3Version` and `nodeLtsVersion`, and update all seven sample/demo project `<shaft_engine.version>` values before opening the PR. Do not rely on the post-release sample-sync workflow to fix stale sample POMs.
 - Evidence: PRs #2502, #2494, #2439, #2428, #2418; `pom.xml`; `src/main/java/com/shaft/properties/internal/Internal.java`; `src/main/resources/examples/**/pom.xml`; `.github/copilot-instructions.md`; `AGENTS.md`.
 - Action taken: Added release-preparation notes to agent instructions, framework-source instructions, and this memory entry while preparing the release branch.
+
+- Date: 2026-05-23
+- Area: Remote WebDriver capabilities / Selenium Grid 4 compatibility
+- Trigger: Follow-up PR iterations for Grid warnings about legacy non-W3C `enableVideo` capability handling.
+- Lesson: Never emit top-level `enableVideo`; keep video configuration in namespaced capability payloads only (`selenoid:options`, `moon:options`, `se:recordVideo`). When namespaced maps already exist, merge and preserve existing keys instead of overwriting provider options.
+- Evidence: `src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java`, `src/test/java/com/shaft/driver/internal/DriverFactory/OptionsManagerCoverageUnitTest.java`, `AGENTS.md`.
+- Action taken: Added helper-based namespaced capability merging in `OptionsManager`, kept tests aligned with no top-level `enableVideo`, and added durable guidance to `AGENTS.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ Important directories:
 - Use `ThreadLocalPropertiesManager` for per-test/per-thread property overrides and clear thread-local properties at lifecycle boundaries with `Properties.clearForCurrentThread()`.
 - Test assertions should use SHAFT fluent assertion wrappers where applicable, not raw TestNG/JUnit assertions.
 - Prefer the `Locator` builder for expressive locators; simple stable `By.id`, `By.cssSelector`, or `By.xpath` are acceptable where appropriate.
+- Keep WebDriver capabilities W3C-compliant: do not add legacy non-namespaced top-level capabilities such as `enableVideo`; use namespaced vendor/Grid capabilities (for example `selenoid:options`, `moon:options`, `se:recordVideo`) and merge existing maps instead of overwriting them.
 
 ## Architecture Notes
 - `com.shaft.driver.SHAFT` is the main user-facing entry point that namespaces GUI, API, CLI, DB, TestData, Validations, Properties, and Report functionality.

--- a/src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java
+++ b/src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java
@@ -528,21 +528,57 @@ public class OptionsManager {
             return;
         }
 
-        if (options.getCapability("enableVideo") == null) {
-            options.setCapability("enableVideo", true);
+        if (shouldSetSelenoidVideoCapability(executionAddress)) {
+            setNamespacedVideoCapability(options, "selenoid:options");
         }
-        if (options.getCapability("selenoid:options") == null) {
-            Map<String, Object> selenoidOptions = new HashMap<>();
-            selenoidOptions.put("enableVideo", true);
-            options.setCapability("selenoid:options", selenoidOptions);
+        if (shouldSetMoonVideoCapability(executionAddress)) {
+            setNamespacedVideoCapability(options, "moon:options");
         }
-        if (options.getCapability("moon:options") == null) {
-            Map<String, Object> moonOptions = new HashMap<>();
-            moonOptions.put("enableVideo", true);
-            options.setCapability("moon:options", moonOptions);
-        }
-        if (options.getCapability("se:recordVideo") == null) {
+        if (shouldSetSeleniumVideoCapability(executionAddress) && options.getCapability("se:recordVideo") == null) {
             options.setCapability("se:recordVideo", true);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setNamespacedVideoCapability(MutableCapabilities options, String capabilityName) {
+        Object namespaceCapability = options.getCapability(capabilityName);
+        if (namespaceCapability instanceof Map<?, ?> capabilityMap) {
+            Map<String, Object> mergedCapability = new HashMap<>((Map<String, Object>) capabilityMap);
+            mergedCapability.putIfAbsent("enableVideo", true);
+            options.setCapability(capabilityName, mergedCapability);
+        } else if (namespaceCapability == null) {
+            Map<String, Object> videoOptions = new HashMap<>();
+            videoOptions.put("enableVideo", true);
+            options.setCapability(capabilityName, videoOptions);
+        }
+    }
+
+    private boolean shouldSetSelenoidVideoCapability(String executionAddress) {
+        return executionAddress.contains("selenoid")
+                || executionAddress.contains("selenium")
+                || executionAddress.contains("grid")
+                || executionAddress.contains("wd/hub")
+                || isUnknownRemoteProvider(executionAddress);
+    }
+
+    private boolean shouldSetMoonVideoCapability(String executionAddress) {
+        return executionAddress.contains("moon")
+                || executionAddress.contains("selenium")
+                || executionAddress.contains("grid")
+                || executionAddress.contains("wd/hub")
+                || isUnknownRemoteProvider(executionAddress);
+    }
+
+    private boolean shouldSetSeleniumVideoCapability(String executionAddress) {
+        return executionAddress.contains("selenium") || executionAddress.contains("grid") || executionAddress.contains("wd/hub")
+                || isUnknownRemoteProvider(executionAddress);
+    }
+
+    private boolean isUnknownRemoteProvider(String executionAddress) {
+        return !executionAddress.contains("selenoid")
+                && !executionAddress.contains("moon")
+                && !executionAddress.contains("selenium")
+                && !executionAddress.contains("grid")
+                && !executionAddress.contains("wd/hub");
     }
 }

--- a/src/test/java/com/shaft/driver/internal/DriverFactory/OptionsManagerCoverageUnitTest.java
+++ b/src/test/java/com/shaft/driver/internal/DriverFactory/OptionsManagerCoverageUnitTest.java
@@ -112,7 +112,7 @@ public class OptionsManagerCoverageUnitTest {
         Assert.assertTrue(chromeOptionsAsString.contains("mobileEmulation"));
         Assert.assertTrue(chromeOptionsAsString.contains("detach"));
         Assert.assertNotNull(chromeOptions.getCapability(CapabilityType.PROXY));
-        Assert.assertEquals(chromeOptions.getCapability("enableVideo"), true);
+        Assert.assertNull(chromeOptions.getCapability("enableVideo"));
         Assert.assertEquals(chromeOptions.getCapability("se:recordVideo"), true);
         Assert.assertNotNull(chromeOptions.getCapability("selenoid:options"));
         Assert.assertNotNull(chromeOptions.getCapability("moon:options"));


### PR DESCRIPTION
### Motivation
- Prevent emitting legacy top-level `enableVideo` capability and ensure compatibility with W3C-compliant remote providers and Selenium Grid 4 by keeping video config in vendor/Grid namespaces and preserving existing provider options.
- Add durable guidance for agents and project memory about the correct capability handling to avoid Grid warnings and runtime mismatches.

### Description
- Reworked `applyRemoteVideoCapabilities` in `OptionsManager` to stop setting a top-level `enableVideo` and instead set video flags inside namespaced maps such as `selenoid:options`, `moon:options`, and `se:recordVideo` as appropriate. 
- Added `setNamespacedVideoCapability` helper to merge into existing namespaced capability maps instead of overwriting them and to only add `enableVideo` when absent. 
- Added predicate helpers (`shouldSetSelenoidVideoCapability`, `shouldSetMoonVideoCapability`, `shouldSetSeleniumVideoCapability`, `isUnknownRemoteProvider`) to centralize executionAddress logic for when to add namespaced capabilities. 
- Updated unit test expectations in `OptionsManagerCoverageUnitTest` to assert that top-level `enableVideo` is not present and that namespaced capabilities are present, and updated documentation files (`AGENTS.md`, `.github/copilot-memory.md`) with the new guidance.

### Testing
- Ran the updated unit test `OptionsManagerCoverageUnitTest` via `mvn -Dtest=com.shaft.driver.internal.DriverFactory.OptionsManagerCoverageUnitTest test` and the test assertions passed. 
- Verified the modified `OptionsManager` behavior through the existing OptionsManager unit coverage tests which asserted absence of top-level `enableVideo` and presence/merging of namespaced options, and those tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1147db82308320b37337a5f37bec16)