### PR TITLE
Manage BiDi network interceptors/listeners with BiDiNetworkFoundationManager and integrate cleanup

### DIFF
--- a/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -4,6 +4,7 @@ import com.epam.healenium.SelfHealingDriver;
 import com.shaft.driver.DriverFactory.DriverType;
 import com.shaft.driver.SHAFT;
 import com.shaft.gui.browser.BrowserActions;
+import com.shaft.gui.browser.internal.BiDiNetworkFoundationManager;
 import com.shaft.gui.internal.video.RecordManager;
 import com.shaft.properties.internal.Properties;
 import com.shaft.properties.internal.PropertiesHelper;
@@ -393,6 +394,7 @@ public class DriverFactoryHelper {
             } catch (Exception e) {
                 ReportManagerHelper.logDiscrete(e);
             } finally {
+                BiDiNetworkFoundationManager.cleanupForDriver(driver);
                 seleniumWebSocketLogger.setLevel(previousWebSocketLoggerLevel);
                 webDriverManager.remove();
                 ReportManager.log("Successfully Closed Driver.");

--- a/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -6,6 +6,7 @@ import com.shaft.driver.internal.FluentWebDriverAction;
 import com.shaft.driver.internal.WizardHelpers;
 import com.shaft.enums.internal.NavigationAction;
 import com.shaft.enums.internal.Screenshots;
+import com.shaft.gui.browser.internal.BiDiNetworkFoundationManager;
 import com.shaft.gui.browser.internal.BrowserActionsHelper;
 import com.shaft.gui.browser.internal.JavaScriptWaitManager;
 import com.shaft.gui.internal.image.ScreenshotManager;
@@ -682,14 +683,16 @@ public class BrowserActions extends FluentWebDriverAction {
         ReportManager.logDiscrete("Attempting to configure network interceptor for \"" + requestPredicate + "\", will provide mocked response.");
         ReportManagerHelper.attach("HTTP Response", "Mocked HTTP Response", String.valueOf(mockedResponse));
         try {
-            if (driverFactoryHelper.getDriver() instanceof HasDevTools hasDevTools) {
+            WebDriver activeDriver = driverFactoryHelper.getDriver();
+            if (activeDriver instanceof HasDevTools) {
                 NetworkInterceptor networkInterceptor = new NetworkInterceptor(
-                        driverFactoryHelper.getDriver(),
+                        activeDriver,
                         Route.matching(requestPredicate)
                                 .to(() -> req -> mockedResponse));
-                browserActionsHelper.passAction(driverFactoryHelper.getDriver(), "Successfully configured network interceptor.");
+                BiDiNetworkFoundationManager.registerInterceptor(activeDriver, networkInterceptor);
+                browserActionsHelper.passAction(activeDriver, "Successfully configured network interceptor.");
             } else {
-                browserActionsHelper.failAction(driverFactoryHelper.getDriver(), "Network Interceptor is not supported by the current driver type.");
+                browserActionsHelper.failAction(activeDriver, "Network Interceptor is not supported by the current driver type.");
             }
         } catch (Exception rootCauseException) {
             browserActionsHelper.failAction(rootCauseException);

--- a/src/main/java/com/shaft/gui/browser/internal/BiDiNetworkFoundationManager.java
+++ b/src/main/java/com/shaft/gui/browser/internal/BiDiNetworkFoundationManager.java
@@ -1,0 +1,158 @@
+package com.shaft.gui.browser.internal;
+
+import com.shaft.tools.io.ReportManager;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Internal manager for WebDriver BiDi network artifacts (interceptors/listeners).
+ * Keeps per-thread and per-driver isolation and provides deterministic cleanup.
+ */
+public final class BiDiNetworkFoundationManager {
+    private static final ThreadLocal<Map<String, DriverNetworkState>> DRIVER_STATE =
+            ThreadLocal.withInitial(ConcurrentHashMap::new);
+
+    private BiDiNetworkFoundationManager() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Registers a network interceptor handle for the active driver context.
+     *
+     * @param driver            the active WebDriver session
+     * @param interceptorHandle the interceptor handle to manage
+     * @return generated registration identifier
+     */
+    public static String registerInterceptor(WebDriver driver, AutoCloseable interceptorHandle) {
+        Objects.requireNonNull(driver, "driver cannot be null");
+        Objects.requireNonNull(interceptorHandle, "interceptorHandle cannot be null");
+        String registrationId = UUID.randomUUID().toString();
+        DriverNetworkState state = DRIVER_STATE.get().computeIfAbsent(resolveDriverKey(driver), key -> new DriverNetworkState());
+        state.interceptors.put(registrationId, interceptorHandle);
+        return registrationId;
+    }
+
+    /**
+     * Removes a previously registered interceptor handle and closes it.
+     *
+     * @param driver         the active WebDriver session
+     * @param registrationId the registration identifier returned at registration time
+     * @return {@code true} when a handle was found and removed, otherwise {@code false}
+     */
+    public static boolean removeInterceptor(WebDriver driver, String registrationId) {
+        return removeHandle(driver, registrationId, true);
+    }
+
+    /**
+     * Registers a network listener handle for the active driver context.
+     *
+     * @param driver         the active WebDriver session
+     * @param listenerHandle the listener handle to manage
+     * @return generated registration identifier
+     */
+    public static String registerListener(WebDriver driver, AutoCloseable listenerHandle) {
+        Objects.requireNonNull(driver, "driver cannot be null");
+        Objects.requireNonNull(listenerHandle, "listenerHandle cannot be null");
+        String registrationId = UUID.randomUUID().toString();
+        DriverNetworkState state = DRIVER_STATE.get().computeIfAbsent(resolveDriverKey(driver), key -> new DriverNetworkState());
+        state.listeners.put(registrationId, listenerHandle);
+        return registrationId;
+    }
+
+    /**
+     * Removes a previously registered listener handle and closes it.
+     *
+     * @param driver         the active WebDriver session
+     * @param registrationId the registration identifier returned at registration time
+     * @return {@code true} when a handle was found and removed, otherwise {@code false}
+     */
+    public static boolean removeListener(WebDriver driver, String registrationId) {
+        return removeHandle(driver, registrationId, false);
+    }
+
+    /**
+     * Closes and clears all registered network handles for the supplied driver context only.
+     *
+     * @param driver the active WebDriver session; ignored when {@code null}
+     */
+    public static void cleanupForDriver(WebDriver driver) {
+        if (driver == null) {
+            return;
+        }
+        DriverNetworkState state = DRIVER_STATE.get().remove(resolveDriverKey(driver));
+        if (state == null) {
+            return;
+        }
+        closeAll(state.interceptors);
+        closeAll(state.listeners);
+    }
+
+    /**
+     * Closes and clears all registered network handles tracked in the current thread.
+     */
+    public static void clearCurrentThread() {
+        Map<String, DriverNetworkState> stateByDriver = DRIVER_STATE.get();
+        stateByDriver.values().forEach(state -> {
+            closeAll(state.interceptors);
+            closeAll(state.listeners);
+        });
+        DRIVER_STATE.remove();
+    }
+
+    private static boolean removeHandle(WebDriver driver, String registrationId, boolean isInterceptor) {
+        Objects.requireNonNull(driver, "driver cannot be null");
+        Objects.requireNonNull(registrationId, "registrationId cannot be null");
+        String driverKey = resolveDriverKey(driver);
+        DriverNetworkState state = DRIVER_STATE.get().get(driverKey);
+        if (state == null) {
+            return false;
+        }
+        AutoCloseable handle = isInterceptor ? state.interceptors.remove(registrationId) : state.listeners.remove(registrationId);
+        if (handle == null) {
+            return false;
+        }
+        closeQuietly(handle);
+        removeDriverStateIfEmpty(driverKey, state);
+        return true;
+    }
+
+    private static void closeAll(Map<String, AutoCloseable> handles) {
+        handles.values().forEach(BiDiNetworkFoundationManager::closeQuietly);
+        handles.clear();
+    }
+
+    private static void closeQuietly(AutoCloseable handle) {
+        try {
+            handle.close();
+        } catch (Exception e) {
+            ReportManager.logDiscrete("BiDi network cleanup warning: " + e.getMessage());
+        }
+    }
+
+    private static String resolveDriverKey(WebDriver driver) {
+        if (driver instanceof RemoteWebDriver remoteWebDriver && remoteWebDriver.getSessionId() != null) {
+            return remoteWebDriver.getSessionId().toString();
+        }
+        return String.valueOf(System.identityHashCode(driver));
+    }
+
+    private static void removeDriverStateIfEmpty(String driverKey, DriverNetworkState state) {
+        if (state.isEmpty()) {
+            DRIVER_STATE.get().remove(driverKey);
+        }
+    }
+
+    private static class DriverNetworkState {
+        private final Map<String, AutoCloseable> interceptors = new ConcurrentHashMap<>();
+        private final Map<String, AutoCloseable> listeners = new ConcurrentHashMap<>();
+
+        private boolean isEmpty() {
+            return interceptors.isEmpty() && listeners.isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/shaft/gui/browser/internal/BiDiNetworkFoundationManagerUnitTest.java
+++ b/src/test/java/com/shaft/gui/browser/internal/BiDiNetworkFoundationManagerUnitTest.java
@@ -1,0 +1,101 @@
+package com.shaft.gui.browser.internal;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.SessionId;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BiDiNetworkFoundationManagerUnitTest {
+    @AfterMethod(alwaysRun = true)
+    public void cleanupThreadState() {
+        BiDiNetworkFoundationManager.clearCurrentThread();
+    }
+
+    @Test
+    public void testRemoveInterceptorClosesHandle() {
+        RemoteWebDriver driver = mock(RemoteWebDriver.class);
+        when(driver.getSessionId()).thenReturn(new SessionId("session-1"));
+
+        AtomicInteger closedCounter = new AtomicInteger(0);
+        AutoCloseable handle = closedCounter::incrementAndGet;
+
+        String id = BiDiNetworkFoundationManager.registerInterceptor(driver, handle);
+        boolean removed = BiDiNetworkFoundationManager.removeInterceptor(driver, id);
+
+        Assert.assertTrue(removed);
+        Assert.assertEquals(closedCounter.get(), 1);
+        Assert.assertFalse(BiDiNetworkFoundationManager.removeInterceptor(driver, id));
+    }
+
+    @Test
+    public void testCleanupForDriverClosesInterceptorsAndListeners() {
+        RemoteWebDriver driver = mock(RemoteWebDriver.class);
+        when(driver.getSessionId()).thenReturn(new SessionId("session-2"));
+
+        AtomicInteger interceptorClosedCounter = new AtomicInteger(0);
+        AtomicInteger listenerClosedCounter = new AtomicInteger(0);
+
+        BiDiNetworkFoundationManager.registerInterceptor(driver, interceptorClosedCounter::incrementAndGet);
+        BiDiNetworkFoundationManager.registerListener(driver, listenerClosedCounter::incrementAndGet);
+
+        BiDiNetworkFoundationManager.cleanupForDriver(driver);
+
+        Assert.assertEquals(interceptorClosedCounter.get(), 1);
+        Assert.assertEquals(listenerClosedCounter.get(), 1);
+    }
+
+    @Test
+    public void testCleanupForDriverDoesNotAffectOtherDriversInSameThread() {
+        RemoteWebDriver firstDriver = mock(RemoteWebDriver.class);
+        when(firstDriver.getSessionId()).thenReturn(new SessionId("session-3"));
+        RemoteWebDriver secondDriver = mock(RemoteWebDriver.class);
+        when(secondDriver.getSessionId()).thenReturn(new SessionId("session-4"));
+
+        AtomicInteger firstClosedCounter = new AtomicInteger(0);
+        AtomicInteger secondClosedCounter = new AtomicInteger(0);
+
+        BiDiNetworkFoundationManager.registerInterceptor(firstDriver, firstClosedCounter::incrementAndGet);
+        BiDiNetworkFoundationManager.registerInterceptor(secondDriver, secondClosedCounter::incrementAndGet);
+
+        BiDiNetworkFoundationManager.cleanupForDriver(firstDriver);
+
+        Assert.assertEquals(firstClosedCounter.get(), 1);
+        Assert.assertEquals(secondClosedCounter.get(), 0);
+    }
+
+    @Test
+    public void testClearCurrentThreadClosesEverythingIncludingFailingHandles() {
+        RemoteWebDriver driver = mock(RemoteWebDriver.class);
+        when(driver.getSessionId()).thenReturn(new SessionId("session-5"));
+
+        AtomicInteger closedCounter = new AtomicInteger(0);
+        BiDiNetworkFoundationManager.registerInterceptor(driver, closedCounter::incrementAndGet);
+        BiDiNetworkFoundationManager.registerListener(driver, () -> {
+            throw new Exception("expected");
+        });
+
+        BiDiNetworkFoundationManager.clearCurrentThread();
+
+        Assert.assertEquals(closedCounter.get(), 1);
+        Assert.assertFalse(BiDiNetworkFoundationManager.removeListener(driver, "missing"));
+    }
+
+    @Test
+    public void testCleanupForNullDriverAndIdentityHashFallback() {
+        BiDiNetworkFoundationManager.cleanupForDriver(null);
+
+        WebDriver plainDriver = mock(WebDriver.class);
+        AtomicInteger closedCounter = new AtomicInteger(0);
+        String id = BiDiNetworkFoundationManager.registerListener(plainDriver, closedCounter::incrementAndGet);
+
+        Assert.assertTrue(BiDiNetworkFoundationManager.removeListener(plainDriver, id));
+        Assert.assertEquals(closedCounter.get(), 1);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide deterministic, per-thread and per-driver management of WebDriver BiDi network artifacts (interceptors/listeners) to avoid resource leaks and enable safe cleanup when drivers are closed.

### Description
- Add `com.shaft.gui.browser.internal.BiDiNetworkFoundationManager` that tracks interceptor and listener `AutoCloseable` handles per-driver via a `ThreadLocal` map and exposes `registerInterceptor`, `removeInterceptor`, `registerListener`, `removeListener`, `cleanupForDriver`, and `clearCurrentThread` methods.
- Integrate `BiDiNetworkFoundationManager.cleanupForDriver(driver)` into `DriverFactoryHelper` driver teardown to ensure BiDi resources are closed when a driver session ends.
- Update `BrowserActions.internalIntercept` to obtain a local `activeDriver`, create the `NetworkInterceptor`, and register it with `BiDiNetworkFoundationManager.registerInterceptor`, and adjust success/failure logging to use the local driver reference.
- Add unit tests `BiDiNetworkFoundationManagerUnitTest` to validate registration/removal, per-driver and per-thread cleanup, null handling, and behavior when handles throw on close.

### Testing
- Executed unit tests in `BiDiNetworkFoundationManagerUnitTest` (TestNG) which exercise interceptor/listener registration, removal, `cleanupForDriver`, and `clearCurrentThread`, and all tests passed.
- No integration or UI tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11541c51f48320b2d115b4d9451937)