### PR TITLE
Bump SHAFT engine to 10.2.20260523 and Node LTS to 24.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.shafthq</groupId>
     <artifactId>SHAFT_ENGINE</artifactId>
-    <version>10.2.20260522</version> <!-- UPDATE com.shaft.properties.internal > Internal > shaftEngineVersion, allure3Version, nodeLtsVersion,  -->
+    <version>10.2.20260523</version> <!-- UPDATE com.shaft.properties.internal > Internal > shaftEngineVersion, allure3Version, nodeLtsVersion,  -->
     <name>${project.groupId}:${project.artifactId}</name>
     <description>SHAFT is a unified test automation engine. Powered by best-in-class frameworks, SHAFT provides a
         wizard-like syntax to drive your automation efficiently, maximize your ROI, and minimize your learning curve.

--- a/src/main/java/com/shaft/properties/internal/Internal.java
+++ b/src/main/java/com/shaft/properties/internal/Internal.java
@@ -18,7 +18,7 @@ import org.aeonbits.owner.Config.Sources;
 })
 public interface Internal extends EngineProperties<Internal> {
     @Key("shaftEngineVersion")
-    @DefaultValue("10.2.20260522")
+    @DefaultValue("10.2.20260523")
     String shaftEngineVersion();
 
     @Key("watermarkImagePath")
@@ -43,7 +43,7 @@ public interface Internal extends EngineProperties<Internal> {
      *
      */
     @Key("nodeLtsVersion")
-    @DefaultValue("24.15.0")
+    @DefaultValue("24.16.0")
     String nodeLtsVersion();
 
     /**

--- a/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
+++ b/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260522</shaft_engine.version>
+        <shaft_engine.version>10.2.20260523</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
+++ b/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260522</shaft_engine.version>
+        <shaft_engine.version>10.2.20260523</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
+++ b/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260522</shaft_engine.version>
+        <shaft_engine.version>10.2.20260523</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
+++ b/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260522</shaft_engine.version>
+        <shaft_engine.version>10.2.20260523</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
+++ b/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260522</shaft_engine.version>
+        <shaft_engine.version>10.2.20260523</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
+++ b/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260522</shaft_engine.version>
+        <shaft_engine.version>10.2.20260523</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
+++ b/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260522</shaft_engine.version>
+        <shaft_engine.version>10.2.20260523</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>


### PR DESCRIPTION
### Motivation

- Update the engine release metadata and bundled runtime versions to the new patch release to keep examples and defaults in sync.
- Ensure example projects reference the updated engine version so generated projects and documentation point to the correct release.

### Description

- Bumped the root project `<version>` in `pom.xml` to `10.2.20260523`.
- Updated the default `shaftEngineVersion` in `Internal.java` to `10.2.20260523` and advanced the default `nodeLtsVersion` to `24.16.0`.
- Updated example module POMs under `src/main/resources/examples/` to reference `<shaft_engine.version>` = `10.2.20260523`.

### Testing

- No automated tests were run for this metadata/version bump change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1161f7f8d48320ba84d2941d27cbf5)