### PR TITLE
codex: restore standard release note generation

### DIFF
--- a/.github/RELEASE_BODY_TEMPLATE.md
+++ b/.github/RELEASE_BODY_TEMPLATE.md
@@ -1,4 +1,3 @@
-# 🎉 SHAFT_ENGINE $RELEASE_VERSION
+# SHAFT_ENGINE $RELEASE_VERSION
 
-SHAFT_ENGINE $RELEASE_VERSION is a focused release note for the user-visible highlights in this release: major new capabilities, any compatibility-impacting breaking changes, and first-time contributors. Routine maintenance, dependency bumps, test-only work, documentation edits, and CI/internal cleanup are intentionally omitted here so the announcement stays concise; review the merged pull requests for the exhaustive project history.
-
+Auto-generated release notes for this version are included below.

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,11 +1,9 @@
 # .github/release.yml
-# Controls how GitHub automatically categorizes pull requests in release notes.
-# Goal: produce readable, user-focused release notes with explicit sections and
-# no "everything in one Uncategorized block" output.
+# Keep release notes close to GitHub's default auto-generated format.
+# We only exclude noisy bot authors and explicitly skipped PRs.
 # Reference: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
 
 changelog:
-  # Keep noisy maintenance activity out of release highlights.
   exclude:
     authors:
       - dependabot[bot]
@@ -13,69 +11,5 @@ changelog:
       - github-actions[bot]
       - github-actions
       - copilot-swe-agent[bot]
-
     labels:
-      - duplicate
-      - invalid
-      - question
-      - wontfix
       - skip-release-notes
-
-  categories:
-    - title: "💥 Breaking Changes"
-      labels:
-        - breaking-change
-        - breaking
-        - semver-major
-
-    - title: "🚀 New Features"
-      labels:
-        - feature
-        - new-feature
-        - enhancement
-        - semver-minor
-
-    - title: "🐛 Fixes"
-      labels:
-        - fix
-        - bug
-        - bugfix
-        - regression
-
-    - title: "⚡ Performance"
-      labels:
-        - performance
-        - perf
-        - optimization
-
-    - title: "🛡️ Security"
-      labels:
-        - security
-
-    - title: "🧪 Testing & Reliability"
-      labels:
-        - test
-        - tests
-        - testing
-        - flaky-test
-
-    - title: "📚 Documentation"
-      labels:
-        - docs
-        - doc
-        - documentation
-
-    - title: "🔧 CI / Build / Dependencies"
-      labels:
-        - ci
-        - cd
-        - build
-        - dependencies
-        - dependency
-        - deps
-        - github-actions
-
-  uncategorized-title: "📦 Other Changes"
-
-  # Render each PR in a compact, consistent line.
-  change-template: "- $TITLE by @$AUTHOR in #$NUMBER"


### PR DESCRIPTION
### Motivation
- Release notes were rendered incorrectly due to a large custom template and category overrides; the goal is to restore GitHub's standard autogenerated release-note behavior and remove customizations that produced the messy output.

### Description
- Simplified `.github/release.yml` to keep only a minimal `exclude` list for noisy bot authors and the `skip-release-notes` label, and removed the custom category definitions and formatting overrides, and replaced `.github/RELEASE_BODY_TEMPLATE.md` with a minimal header that defers to GitHub's autogenerated changelog.

### Testing
- Executed repository validation and commit steps: `git status --short`, `git add .github/release.yml .github/RELEASE_BODY_TEMPLATE.md && git commit -m "codex: restore standard release note generation"`, `nl -ba .github/release.yml`, `nl -ba .github/RELEASE_BODY_TEMPLATE.md`, and created the PR via `make_pr`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11744e8d3883208ba47648531dbf32)