### PR TITLE
fix remote webdriver bootstrap and restore jvm system properties

### DIFF
--- a/src/main/java/com/shaft/driver/DriverFactory.java
+++ b/src/main/java/com/shaft/driver/DriverFactory.java
@@ -7,8 +7,8 @@ import com.shaft.db.DatabaseActions.DatabaseType;
 import com.shaft.driver.internal.DriverFactory.BrowserStackHelper;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.driver.internal.DriverFactory.LambdaTestHelper;
-import com.shaft.listeners.TestNGListener;
 import com.shaft.listeners.internal.TestNGListenerHelper;
+import com.shaft.properties.internal.PropertiesHelper;
 import com.shaft.properties.internal.ThreadLocalPropertiesManager;
 import com.shaft.tools.io.internal.ProjectStructureManager;
 import lombok.Getter;
@@ -56,8 +56,8 @@ public class DriverFactory {
     private static void readLastMinuteUpdatedProperties() {
         reloadProperties();
         // it's null in case of Cucumber native feature file execution
-        if (TestNGListener.getXmlTest() != null) {
-            var allParameters = TestNGListener.getXmlTest().getAllParameters();
+        if (TestNGListenerHelper.getXmlTest() != null) {
+            var allParameters = TestNGListenerHelper.getXmlTest().getAllParameters();
             allParameters.forEach(ThreadLocalPropertiesManager::setProperty);
             var testName = TestNGListenerHelper.getTestName().toLowerCase();
             if (testName.contains("firefox")
@@ -76,13 +76,13 @@ public class DriverFactory {
     public static boolean reloadProperties() {
         if (!com.shaft.properties.internal.Properties.isInitialized()) {
             logger.warn("Execution Listeners are not loaded properly... Self-Healing... Initializing minimalistic test run...");
-            var runType = TestNGListener.identifyRunType();
+            var runType = ProjectStructureManager.identifyRunType();
             if (runType.equals(ProjectStructureManager.RunType.CUCUMBER)) {
                 // stuck on minimalistic test run in case of native cucumber execution without manual plugin configuration
                 logger.warn("To unlock the full capabilities of SHAFT kindly follow these steps to configure SHAFT's Cucumber plugin:");
                 logger.warn("https://github.com/ShaftHQ/SHAFT_ENGINE?tab=readme-ov-file#23-cucumber");
             }
-            TestNGListener.engineSetup(runType);
+            PropertiesHelper.bootstrapEngine(runType);
         }
         return true;
     }

--- a/src/main/java/com/shaft/listeners/TestNGListener.java
+++ b/src/main/java/com/shaft/listeners/TestNGListener.java
@@ -81,64 +81,16 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
     private static ITestResult iTestResult;
     private static long executionStartTime;
     @Getter
-    private static XmlTest xmlTest;
-    @Getter
     private static boolean isReportPortalEnabled;
     private ITestNGService reportPortalTestNGService;
     private boolean isReportPortalEnabledForListener;
 
     public static ProjectStructureManager.RunType identifyRunType() {
-        Supplier<Stream<?>> stacktraceSupplier = () -> Arrays.stream((new Throwable()).getStackTrace()).map(StackTraceElement::getClassName);
-        var isUsingJunitDiscovery = stacktraceSupplier.get().anyMatch(org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.class.getCanonicalName()::equals);
-        var isUsingTestNG = stacktraceSupplier.get().anyMatch(TestNG.class.getCanonicalName()::equals);
-        var isUsingCucumber = stacktraceSupplier.get().anyMatch(io.cucumber.core.runner.Runner.class.getCanonicalName()::equals);
-        if (isUsingJunitDiscovery || isUsingTestNG) {
-            logger.info("TestNG run detected...");
-            return ProjectStructureManager.RunType.TESTNG;
-        } else if (isUsingCucumber) {
-            logger.info("Cucumber run detected...");
-            return ProjectStructureManager.RunType.CUCUMBER;
-        } else {
-            logger.info("JUnit5 run detected...");
-            return ProjectStructureManager.RunType.JUNIT;
-        }
+        return ProjectStructureManager.identifyRunType();
     }
 
     public static void engineSetup(ProjectStructureManager.RunType runType) {
-        PropertiesHelper.setKeySystemProperties();
-        Allure.getLifecycle();
-        Reporter.setEscapeHtml(false);
-        ReportManagerHelper.setDiscreteLogging(true);
-        if (runType == ProjectStructureManager.RunType.AI_AGENT) {
-            PropertiesHelper.initializeAiAgent();
-        } else {
-            PropertiesHelper.initialize();
-        }
-        ReportManager.logDiscrete("Initializing Engine Setup...");
-        SHAFT.Properties.reporting.set().disableLogging(true);
-        switch (runType) {
-            case TESTNG ->
-                    Thread.ofVirtual().start(() -> ProjectStructureManager.initialize(ProjectStructureManager.RunType.TESTNG));
-            case CUCUMBER ->
-                    Thread.ofVirtual().start(() -> ProjectStructureManager.initialize(ProjectStructureManager.RunType.CUCUMBER));
-            case JUNIT ->
-                    Thread.ofVirtual().start(() -> ProjectStructureManager.initialize(ProjectStructureManager.RunType.JUNIT));
-            case AI_AGENT ->
-                    ProjectStructureManager.initialize(ProjectStructureManager.RunType.AI_AGENT);
-        }
-        TestNGListenerHelper.configureJVMProxy();
-        Thread.ofVirtual().start(() -> {
-            GoogleTink.initialize();
-            GoogleTink.decrypt();
-        });
-        SHAFT.Properties.reporting.set().disableLogging(false);
-        ReportManagerHelper.logEngineVersion();
-        Thread.ofVirtual().start(UpdateChecker::check);
-        Thread.ofVirtual().start(ImageProcessingActions::loadOpenCV);
-        AllureManager.initializeAllureReportingEnvironment();
-        Thread.ofVirtual().start(ReportManagerHelper::cleanExecutionSummaryReportDirectory);
-        ReportManagerHelper.setDiscreteLogging(SHAFT.Properties.reporting.alwaysLogDiscreetly());
-        ReportManagerHelper.setDebugMode(SHAFT.Properties.reporting.debugMode());
+        PropertiesHelper.bootstrapEngine(runType);
     }
 
     /**
@@ -323,7 +275,7 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
                 activeTestClass.set(incomingClass);
             }
         }
-        xmlTest = method.getTestMethod().getXmlTest();
+        TestNGListenerHelper.setXmlTest(method.getTestMethod().getXmlTest());
         JiraHelper.prepareTestResultAttributes(method, iTestResult);
         TestNGListenerHelper.setTestName(iTestContext);
         TestNGListenerHelper.logTestInformation(iTestResult);

--- a/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java
+++ b/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java
@@ -33,6 +33,26 @@ import java.util.Map;
  */
 public class TestNGListenerHelper {
 
+    private static XmlTest xmlTest;
+
+    /**
+     * Returns the active TestNG XML test definition when available.
+     *
+     * @return current {@link XmlTest}, or {@code null} outside TestNG method execution
+     */
+    public static XmlTest getXmlTest() {
+        return xmlTest;
+    }
+
+    /**
+     * Stores the active TestNG XML test definition for suite parameter lookups.
+     *
+     * @param activeXmlTest current {@link XmlTest}
+     */
+    public static void setXmlTest(XmlTest activeXmlTest) {
+        xmlTest = activeXmlTest;
+    }
+
     private static final List<ITestResult> beforeMethods = Collections.synchronizedList(new ArrayList<>());
     private static final List<ITestResult> afterMethods = Collections.synchronizedList(new ArrayList<>());
     private static final ThreadLocal<String> testName = new ThreadLocal<>();
@@ -259,11 +279,17 @@ public class TestNGListenerHelper {
         if (SHAFT.Properties.platform.jvmProxySettings() && !PROXY_SERVER_SETTINGS.isEmpty()) {
             String[] proxyHostPort = PROXY_SERVER_SETTINGS.split(":");
             ThreadLocalPropertiesManager.setGlobalProperty("http.proxyHost", proxyHostPort[0]);
+            System.setProperty("http.proxyHost", proxyHostPort[0]);
             ThreadLocalPropertiesManager.setGlobalProperty("http.proxyPort", proxyHostPort[1]);
+            System.setProperty("http.proxyPort", proxyHostPort[1]);
             ThreadLocalPropertiesManager.setGlobalProperty("https.proxyHost", proxyHostPort[0]);
+            System.setProperty("https.proxyHost", proxyHostPort[0]);
             ThreadLocalPropertiesManager.setGlobalProperty("https.proxyPort", proxyHostPort[1]);
+            System.setProperty("https.proxyPort", proxyHostPort[1]);
             ThreadLocalPropertiesManager.setGlobalProperty("ftp.proxyHost", proxyHostPort[0]);
+            System.setProperty("ftp.proxyHost", proxyHostPort[0]);
             ThreadLocalPropertiesManager.setGlobalProperty("ftp.proxyPort", proxyHostPort[1]);
+            System.setProperty("ftp.proxyPort", proxyHostPort[1]);
         }
     }
 

--- a/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
+++ b/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
@@ -4,12 +4,20 @@ import com.shaft.cli.FileActions;
 import com.shaft.driver.DriverFactory;
 import com.shaft.driver.SHAFT;
 import com.shaft.enums.internal.Screenshots;
+import com.shaft.gui.internal.image.ImageProcessingActions;
+import com.shaft.listeners.internal.TestNGListenerHelper;
+import com.shaft.listeners.internal.UpdateChecker;
+import com.shaft.tools.internal.security.GoogleTink;
 import com.shaft.tools.io.ReportManager;
+import com.shaft.tools.io.internal.AllureManager;
+import com.shaft.tools.io.internal.ProjectStructureManager;
+import com.shaft.tools.io.internal.ReportManagerHelper;
 import org.aeonbits.owner.ConfigFactory;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.logging.log4j.Level;
 import org.openqa.selenium.remote.Browser;
+import org.testng.Reporter;
 
 import java.awt.*;
 import java.io.File;
@@ -93,12 +101,60 @@ public class PropertiesHelper {
     public static void setKeySystemProperties() {
         //load paths as the default properties path is needed for the next step
         Properties.basePaths = ConfigFactory.create(Paths.class);
-        //set key system properties that are needed for the framework to function
-        ThreadLocalPropertiesManager.setGlobalProperty("rp.properties.path", SHAFT.Properties.paths.properties());
+        // Selenium, Log4j, and ReportPortal read these from System; keep global copy for SHAFT too
+        String propertiesPath = SHAFT.Properties.paths.properties();
+        ThreadLocalPropertiesManager.setGlobalProperty("rp.properties.path", propertiesPath);
+        System.setProperty("rp.properties.path", propertiesPath);
         ThreadLocalPropertiesManager.setGlobalProperty("webdriver.http.factory", "jdk-http-client");
-        ThreadLocalPropertiesManager.setGlobalProperty("log4j.configurationFile", PropertyFileManager.getLog4jConfigPath());
+        System.setProperty("webdriver.http.factory", "jdk-http-client");
+        String log4jConfigPath = PropertyFileManager.getLog4jConfigPath();
+        ThreadLocalPropertiesManager.setGlobalProperty("log4j.configurationFile", log4jConfigPath);
+        System.setProperty("log4j.configurationFile", log4jConfigPath);
         ThreadLocalPropertiesManager.setGlobalProperty("allure.testng.hide.configuration.failures", "true");
+        System.setProperty("allure.testng.hide.configuration.failures", "true");
         ThreadLocalPropertiesManager.setGlobalProperty("allure.testng.hide.disabled.tests", "true");
+        System.setProperty("allure.testng.hide.disabled.tests", "true");
+    }
+
+    /**
+     * Initializes SHAFT engine services without loading TestNG listener types.
+     *
+     * @param runType current execution framework mode
+     */
+    public static void bootstrapEngine(ProjectStructureManager.RunType runType) {
+        setKeySystemProperties();
+        io.qameta.allure.Allure.getLifecycle();
+        Reporter.setEscapeHtml(false);
+        ReportManagerHelper.setDiscreteLogging(true);
+        if (runType == ProjectStructureManager.RunType.AI_AGENT) {
+            initializeAiAgent();
+        } else {
+            initialize();
+        }
+        ReportManager.logDiscrete("Initializing Engine Setup...");
+        SHAFT.Properties.reporting.set().disableLogging(true);
+        switch (runType) {
+            case TESTNG ->
+                    Thread.ofVirtual().start(() -> ProjectStructureManager.initialize(ProjectStructureManager.RunType.TESTNG));
+            case CUCUMBER ->
+                    Thread.ofVirtual().start(() -> ProjectStructureManager.initialize(ProjectStructureManager.RunType.CUCUMBER));
+            case JUNIT ->
+                    Thread.ofVirtual().start(() -> ProjectStructureManager.initialize(ProjectStructureManager.RunType.JUNIT));
+            case AI_AGENT -> ProjectStructureManager.initialize(ProjectStructureManager.RunType.AI_AGENT);
+        }
+        TestNGListenerHelper.configureJVMProxy();
+        Thread.ofVirtual().start(() -> {
+            GoogleTink.initialize();
+            GoogleTink.decrypt();
+        });
+        SHAFT.Properties.reporting.set().disableLogging(false);
+        ReportManagerHelper.logEngineVersion();
+        Thread.ofVirtual().start(UpdateChecker::check);
+        Thread.ofVirtual().start(ImageProcessingActions::loadOpenCV);
+        AllureManager.initializeAllureReportingEnvironment();
+        Thread.ofVirtual().start(ReportManagerHelper::cleanExecutionSummaryReportDirectory);
+        ReportManagerHelper.setDiscreteLogging(SHAFT.Properties.reporting.alwaysLogDiscreetly());
+        ReportManagerHelper.setDebugMode(SHAFT.Properties.reporting.debugMode());
     }
 
     /**

--- a/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
+++ b/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
@@ -141,6 +141,7 @@ public class PropertiesHelper {
             case JUNIT ->
                     Thread.ofVirtual().start(() -> ProjectStructureManager.initialize(ProjectStructureManager.RunType.JUNIT));
             case AI_AGENT -> ProjectStructureManager.initialize(ProjectStructureManager.RunType.AI_AGENT);
+            default -> throw new IllegalStateException("Unsupported run type: " + runType);
         }
         TestNGListenerHelper.configureJVMProxy();
         Thread.ofVirtual().start(() -> {

--- a/src/main/java/com/shaft/tools/io/internal/ProjectStructureManager.java
+++ b/src/main/java/com/shaft/tools/io/internal/ProjectStructureManager.java
@@ -3,14 +3,46 @@ package com.shaft.tools.io.internal;
 import com.shaft.cli.FileActions;
 import com.shaft.properties.internal.Properties;
 import com.shaft.tools.io.ReportManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.testng.TestNG;
 
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 /**
  * Initializes runtime project folders and service provider metadata files.
  */
 public class ProjectStructureManager {
+    private static final Logger logger = LogManager.getLogger(ProjectStructureManager.class);
+
+    /**
+     * Detects the active test runner from the current stack trace.
+     *
+     * @return the inferred execution mode
+     */
+    public static RunType identifyRunType() {
+        Supplier<Stream<String>> stacktraceSupplier = () -> Arrays.stream(new Throwable().getStackTrace())
+                .map(StackTraceElement::getClassName);
+        var isUsingJunitDiscovery = stacktraceSupplier.get()
+                .anyMatch(org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.class.getCanonicalName()::equals);
+        var isUsingTestNG = stacktraceSupplier.get().anyMatch(TestNG.class.getCanonicalName()::equals);
+        var isUsingCucumber = stacktraceSupplier.get()
+                .anyMatch(io.cucumber.core.runner.Runner.class.getCanonicalName()::equals);
+        if (isUsingJunitDiscovery || isUsingTestNG) {
+            logger.info("TestNG run detected...");
+            return RunType.TESTNG;
+        } else if (isUsingCucumber) {
+            logger.info("Cucumber run detected...");
+            return RunType.CUCUMBER;
+        } else {
+            logger.info("JUnit5 run detected...");
+            return RunType.JUNIT;
+        }
+    }
+
     /**
      * Prepares project structure and listener registration files based on run type.
      *

--- a/src/test/java/testPackage/unitTests/DriverFactoryCoverageUnitTest.java
+++ b/src/test/java/testPackage/unitTests/DriverFactoryCoverageUnitTest.java
@@ -6,9 +6,9 @@ import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactory.BrowserStackHelper;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.driver.internal.DriverFactory.LambdaTestHelper;
-import com.shaft.listeners.TestNGListener;
 import com.shaft.listeners.internal.TestNGListenerHelper;
 import com.shaft.properties.internal.Properties;
+import com.shaft.properties.internal.PropertiesHelper;
 import com.shaft.tools.io.internal.ProjectStructureManager;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
@@ -53,13 +53,14 @@ public class DriverFactoryCoverageUnitTest {
         initializedField.setAccessible(true);
         boolean initialValue = initializedField.getBoolean(null);
 
-        try (MockedStatic<TestNGListener> testNGListener = org.mockito.Mockito.mockStatic(TestNGListener.class)) {
+        try (MockedStatic<ProjectStructureManager> projectStructureManager = org.mockito.Mockito.mockStatic(ProjectStructureManager.class);
+             MockedStatic<PropertiesHelper> propertiesHelper = org.mockito.Mockito.mockStatic(PropertiesHelper.class)) {
             initializedField.setBoolean(null, false);
-            testNGListener.when(TestNGListener::identifyRunType).thenReturn(ProjectStructureManager.RunType.TESTNG);
+            projectStructureManager.when(ProjectStructureManager::identifyRunType).thenReturn(ProjectStructureManager.RunType.TESTNG);
 
             SHAFT.Validations.assertThat().object(DriverFactory.reloadProperties()).isEqualTo(true).perform();
-            testNGListener.verify(TestNGListener::identifyRunType);
-            testNGListener.verify(() -> TestNGListener.engineSetup(ProjectStructureManager.RunType.TESTNG));
+            projectStructureManager.verify(ProjectStructureManager::identifyRunType);
+            propertiesHelper.verify(() -> PropertiesHelper.bootstrapEngine(ProjectStructureManager.RunType.TESTNG));
         } finally {
             initializedField.setBoolean(null, initialValue);
         }
@@ -71,11 +72,12 @@ public class DriverFactoryCoverageUnitTest {
         initializedField.setAccessible(true);
         boolean initialValue = initializedField.getBoolean(null);
 
-        try (MockedStatic<TestNGListener> testNGListener = org.mockito.Mockito.mockStatic(TestNGListener.class)) {
+        try (MockedStatic<ProjectStructureManager> projectStructureManager = org.mockito.Mockito.mockStatic(ProjectStructureManager.class);
+             MockedStatic<PropertiesHelper> propertiesHelper = org.mockito.Mockito.mockStatic(PropertiesHelper.class)) {
             initializedField.setBoolean(null, true);
             SHAFT.Validations.assertThat().object(DriverFactory.reloadProperties()).isEqualTo(true).perform();
-            testNGListener.verify(TestNGListener::identifyRunType, org.mockito.Mockito.never());
-            testNGListener.verify(() -> TestNGListener.engineSetup(org.mockito.ArgumentMatchers.any()), org.mockito.Mockito.never());
+            projectStructureManager.verify(ProjectStructureManager::identifyRunType, org.mockito.Mockito.never());
+            propertiesHelper.verify(() -> PropertiesHelper.bootstrapEngine(org.mockito.ArgumentMatchers.any()), org.mockito.Mockito.never());
         } finally {
             initializedField.setBoolean(null, initialValue);
         }
@@ -165,10 +167,9 @@ public class DriverFactoryCoverageUnitTest {
         XmlTest xmlTest = org.mockito.Mockito.mock(XmlTest.class);
         MutableCapabilities customDriverOptions = new MutableCapabilities();
 
-        try (MockedStatic<TestNGListener> testNGListener = org.mockito.Mockito.mockStatic(TestNGListener.class);
-             MockedStatic<TestNGListenerHelper> listenerHelper = org.mockito.Mockito.mockStatic(TestNGListenerHelper.class);
+        try (MockedStatic<TestNGListenerHelper> listenerHelper = org.mockito.Mockito.mockStatic(TestNGListenerHelper.class);
              MockedConstruction<DriverFactoryHelper> helperConstruction = org.mockito.Mockito.mockConstruction(DriverFactoryHelper.class)) {
-            testNGListener.when(TestNGListener::getXmlTest).thenReturn(xmlTest);
+            listenerHelper.when(TestNGListenerHelper::getXmlTest).thenReturn(xmlTest);
             org.mockito.Mockito.when(xmlTest.getAllParameters()).thenReturn(Map.of("targetBrowserName", "firefox"));
             listenerHelper.when(TestNGListenerHelper::getTestName).thenReturn("Smoke_Chrome");
 


### PR DESCRIPTION
Fixes for #2780
### What was wrong

1. After #2488, keys like `webdriver.http.factory` were only written to SHAFT's global property map, selenium still reads `System.getProperty`, so remote sessions often failed with a 500 from the grid

2. `DriverFactory.reloadProperties()` self-heal called `TestNGListener`, which loads ReportPortal types at class init, hat blows up if listeners are not set up yet or ReportPortal is not on the classpath

### What i did

- dual write JVM keys (`webdriver.http.factory`, log4j, rp path, Allure flags, proxy settings) to both `System` and SHAFT global properties
- move `identifyRunType()` to `ProjectStructureManager` and engine startup to `PropertiesHelper.bootstrapEngine()`
- `DriverFactory` uses those paths instead of loading `TestNGListener` during self-heal. `TestNGListener.engineSetup()` still delegates for normal listener runs