### PR TITLE
codex: stabilize native Selenium Grid E2E follow-up — fix flaky test/reporting behavior

### DIFF
--- a/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java
+++ b/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java
@@ -350,7 +350,7 @@ public class TestNGListenerHelper {
                 synchronized (output) {
                     return new ArrayList<>(output);
                 }
-            } catch (ConcurrentModificationException e) {
+            } catch (ConcurrentModificationException | IndexOutOfBoundsException e) {
                 Thread.yield();
             }
         }

--- a/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
+++ b/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
@@ -471,7 +471,7 @@ public class ReportManagerHelper {
                     return;
                 }
                 engineLog = FileActions.getInstance(true).readFileAsByteArray(logFilePath);
-                FileActions.getInstance(true).deleteFile(logFilePath);
+                Files.deleteIfExists(logFile.toPath());
             } catch (Exception throwable) {
                 logDiscrete(throwable);
                 logDebugFileSetupFailure("Could not read engine log attachment: " + logFilePath, throwable);

--- a/src/test/java/com/shaft/cli/FileActionsCoverageUnitTest.java
+++ b/src/test/java/com/shaft/cli/FileActionsCoverageUnitTest.java
@@ -53,10 +53,11 @@ public class FileActionsCoverageUnitTest {
     }
 
     @Test
-    public void instanceCreationAndPathHelpersShouldReturnUsableInstances() {
+    public void instanceCreationAndPathHelpersShouldReturnUsableInstances() throws IOException {
         FileActions publicActions = FileActions.getInstance();
         FileActions internalActions = FileActions.getInstance(true);
         Path target = tempDirectory.resolve("path-helper.txt");
+        Files.writeString(target, "path-helper", StandardCharsets.UTF_8);
 
         String absoluteFromSinglePath = publicActions.getAbsolutePath(target.toString());
         String absoluteFromFolderAndName = internalActions.getAbsolutePath(tempDirectory.toString() + '/', "path-helper.txt");

--- a/src/test/java/com/shaft/tools/io/internal/RealtimeReporterCoverageUnitTest.java
+++ b/src/test/java/com/shaft/tools/io/internal/RealtimeReporterCoverageUnitTest.java
@@ -67,6 +67,7 @@ public class RealtimeReporterCoverageUnitTest {
         RealtimeReporter.onTestsPlanned(List.of(new RealtimeReporter.TestCard("old#test", "old", "test", "old.java")));
         Assert.assertTrue(invokeBuildFullStateJson().contains("old#test"));
 
+        RealtimeReporter.stopServer();
         SHAFT.Properties.reporting.set().realtimeReport(true);
         SHAFT.Properties.platform.set().executionAddress("remote-grid");
         SHAFT.Properties.web.set().headlessExecution(false);


### PR DESCRIPTION
### Motivation
- Address Grid job post-test failures caused by fragile file/delete paths, concurrent reporter log snapshotting, and realtime-reporter startup/port fallback observed in the failing run `26676937329`.
- Make the smallest, targeted code/test adjustments to remove order- and environment-dependent flakes without broad refactors.

### Description
- Improve `TestNGListenerHelper.snapshotReporterOutput` to also tolerate `IndexOutOfBoundsException` during concurrent snapshot retries by catching it alongside `ConcurrentModificationException`.
- Change `ReportManagerHelper.attachEngineLog` to read the engine log bytes and delete the file with `Files.deleteIfExists(logFile.toPath())` instead of routing deletion through `FileActions`, avoiding path/working-directory surprises.
- Harden `FileActionsCoverageUnitTest.instanceCreationAndPathHelpersShouldReturnUsableInstances` by creating the target file (`Files.writeString(...)`) and declaring `throws IOException` so `getAbsolutePath` assertions use a real file path.
- Add a defensive `RealtimeReporter.stopServer()` call before enabling realtime reporting in `RealtimeReporterCoverageUnitTest.initializationAndTeardownPathsRespectLaunchGuardsAndResetState` to ensure predictable server start/stop lifecycle in CI-like environments.
- This PR was created by Codex as an implementation follow-up to the investigation plan for the Grid E2E failures; changes are focused and limited to the files listed above.

### Testing
- Ran the narrow, targeted tests individually with `mvn test -Dtest=ThreadLocalPropertiesTest#testRetryDiagnosticsLoggingLifecycle`, `mvn test -Dtest=FileActionsCoverageUnitTest#instanceCreationAndPathHelpersShouldReturnUsableInstances`, `mvn test -Dtest=RealtimeReporterCoverageUnitTest#initializationAndTeardownPathsRespectLaunchGuardsAndResetState`, and `mvn test -Dtest=CucumberFeatureListenerUnitTest#lifecycleHandlersShouldProcessFeatureCaseStepsAndHooks`, and each test passed locally.
- Ran the combined targeted suite `mvn test -Dtest=ThreadLocalPropertiesTest,FileActionsCoverageUnitTest,RealtimeReporterCoverageUnitTest,CucumberFeatureListenerUnitTest#lifecycleHandlersShouldProcessFeatureCaseStepsAndHooks` and observed all included tests pass.
- Executed the broader `mvn test` subset used during investigation (36 tests in the combined TestSuite) and observed `36` passed / `0` failed; and `mvn clean install -DskipTests -Dgpg.skip` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a9c5e75388320b94b304d8f38b251)