### PR TITLE
codex: prepare release 10.2.20260530

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.shafthq</groupId>
     <artifactId>SHAFT_ENGINE</artifactId>
-    <version>10.2.20260523</version> <!-- UPDATE com.shaft.properties.internal > Internal > shaftEngineVersion, allure3Version, nodeLtsVersion,  -->
+    <version>10.2.20260530</version> <!-- UPDATE com.shaft.properties.internal > Internal > shaftEngineVersion, allure3Version, nodeLtsVersion,  -->
     <name>${project.groupId}:${project.artifactId}</name>
     <description>SHAFT is a unified test automation engine. Powered by best-in-class frameworks, SHAFT provides a
         wizard-like syntax to drive your automation efficiently, maximize your ROI, and minimize your learning curve.

--- a/src/main/java/com/shaft/properties/internal/Internal.java
+++ b/src/main/java/com/shaft/properties/internal/Internal.java
@@ -18,7 +18,7 @@ import org.aeonbits.owner.Config.Sources;
 })
 public interface Internal extends EngineProperties<Internal> {
     @Key("shaftEngineVersion")
-    @DefaultValue("10.2.20260523")
+    @DefaultValue("10.2.20260530")
     String shaftEngineVersion();
 
     @Key("watermarkImagePath")
@@ -32,7 +32,7 @@ public interface Internal extends EngineProperties<Internal> {
      * without changing {@code AllureManager} or any CI script. Use this url for the latest version <a href="https://github.com/allure-framework/allure3/releases">Allure3Releases</a>
      */
     @Key("allure3Version")
-    @DefaultValue("3.8.2")
+    @DefaultValue("3.9.0")
     String allure3Version();
 
     /**

--- a/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
+++ b/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260523</shaft_engine.version>
+        <shaft_engine.version>10.2.20260530</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
+++ b/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260523</shaft_engine.version>
+        <shaft_engine.version>10.2.20260530</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
+++ b/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260523</shaft_engine.version>
+        <shaft_engine.version>10.2.20260530</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
+++ b/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260523</shaft_engine.version>
+        <shaft_engine.version>10.2.20260530</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
+++ b/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260523</shaft_engine.version>
+        <shaft_engine.version>10.2.20260530</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
+++ b/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260523</shaft_engine.version>
+        <shaft_engine.version>10.2.20260530</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
+++ b/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260523</shaft_engine.version>
+        <shaft_engine.version>10.2.20260530</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>


### PR DESCRIPTION
### Motivation

- Bump the engine release metadata to publish the Q2 2026 patch for 2026-05-30.
- Keep framework defaults (Internal metadata) and bundled example projects in sync with the new release version.
- Update the bundled Allure 3 CLI version to the latest stable npm release and verify the Node.js LTS runtime used by the engine.

### Description

- Updated the root Maven project `<version>` in `pom.xml` to `10.2.20260530`.
- Updated `src/main/java/com/shaft/properties/internal/Internal.java` defaults so `shaftEngineVersion` is `10.2.20260530`, `allure3Version` is `3.9.0`, and `nodeLtsVersion` is `24.16.0`.
- Updated all seven example/demo POMs under `src/main/resources/examples/` to use `<shaft_engine.version>10.2.20260530</shaft_engine.version>`.
- Committed changes with the message `codex: prepare release 10.2.20260530`.

### Testing

- Verified latest Allure npm package with `npm view allure version` and found `3.9.0` (succeeded).
- Verified latest Node.js LTS via `https://nodejs.org/dist/index.json` programmatic check and found `24.16.0` (succeeded).
- Ran `mvn clean install -DskipTests -Dgpg.skip` to compile/package and confirmed `BUILD SUCCESS` (succeeded).
- Ran `git diff --check` and `git status` to validate the working tree and staged changes (no issues found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b01b693a083209b9b010ae2b9b09e)