### PR TITLE
Actions: report native click failure when JS fallback disabled (make behavior deterministic)

### DIFF
--- a/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -463,7 +463,10 @@ public class Actions extends ElementActions {
                                 ((JavascriptExecutor) d).executeScript("arguments[0].click();", targetElement);
                                 ReportManager.logDiscrete("Performed Click using JavaScript; If the report is showing that the click passed but you observe that no action was taken, we recommend trying a different element locator.");
                             } else {
-                                throw exception;
+                                // InvalidElementStateException is normally retryable for visibility-aware waits;
+                                // when JavaScript fallback is disabled, report the native click failure immediately
+                                // so the original Selenium exception is not replaced by a FluentWait timeout.
+                                reportBroken(action.name(), accessibleName.get(), screenshot.get(0), exception);
                             }
                         }
                     }

--- a/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
+++ b/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
@@ -227,6 +227,7 @@ public class ActionsCoverageUnitTest {
 
     @Test
     public void performActionShouldFallbackToJavascriptClickWhenWebDriverClickFails() {
+        SHAFT.Properties.flags.set().clickUsingJavascriptWhenWebDriverClickFails(true);
         WebDriver driver = mock(WebDriver.class, org.mockito.Mockito.withSettings().extraInterfaces(JavascriptExecutor.class, TakesScreenshot.class));
         WebElement element = standardElement();
         doThrow(new InvalidElementStateException("native click blocked")).when(element).click();
@@ -252,7 +253,8 @@ public class ActionsCoverageUnitTest {
 
         try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
             RuntimeException exception = Assert.expectThrows(RuntimeException.class, () -> new Actions(helper).click(LOCATOR));
-            Assert.assertNotNull(exception);
+            Assert.assertTrue(hasCause(exception, InvalidElementStateException.class));
+            verify((JavascriptExecutor) driver, org.mockito.Mockito.never()).executeScript(eq("arguments[0].click();"), eq(element));
         }
     }
 
@@ -555,6 +557,17 @@ public class ActionsCoverageUnitTest {
         DriverFactoryHelper helper = mock(DriverFactoryHelper.class);
         when(helper.getDriver()).thenReturn(driver);
         return helper;
+    }
+
+    private boolean hasCause(Throwable throwable, Class<? extends Throwable> expectedCause) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (expectedCause.isInstance(current)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     private WebElement standardElement() {


### PR DESCRIPTION
### Motivation
- Fix a mismatch where a native `InvalidElementStateException` could be lost/converted to a pass or masked by the fluent-wait layer instead of being reported when JavaScript fallback is disabled.
- Ensure the action contract is clear: when `clickUsingJavascriptWhenWebDriverClickFails` is `false`, the original WebDriver click failure should mark the step broken and surface a runtime failure; when `true`, JS click may recover.

### Description
- Change in `src/main/java/com/shaft/gui/element/internal/Actions.java`: in the `case CLICK` `catch (InvalidElementStateException)` branch, call `reportBroken(action.name(), accessibleName.get(), screenshot.get(0), exception)` when JS fallback is disabled instead of re-throwing the raw exception so the original Selenium exception is preserved in the report and propagated consistently.
- Test updates in `src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java`: explicitly set `clickUsingJavascriptWhenWebDriverClickFails` in the affected tests, assert that the thrown `RuntimeException` contains the original `InvalidElementStateException` as a cause when fallback is disabled, verify JS click is not invoked, and add a small `hasCause` helper to inspect exception chains.
- Small test housekeeping: ensure the test toggles the flag inside the test to avoid thread-local/global contamination while relying on existing `@AfterMethod(alwaysRun = true)` cleanup.

### Testing
- Ran the targeted test with `mvn -e test "-Dtest=com.shaft.gui.element.internal.ActionsCoverageUnitTest#performActionShouldReportSeleniumExceptionWhenFallbackIsDisabled" "-DretryMaximumNumberOfAttempts=1"` and it passed.
- Ran the entire test class with `mvn -e test "-Dtest=com.shaft.gui.element.internal.ActionsCoverageUnitTest" "-DretryMaximumNumberOfAttempts=1"` and all tests in the class passed and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c4d00c2208320bb84a5d054b607e1)