### PR TITLE
codex: fix retry diagnostic logging lifecycle synchronization

### DIFF
--- a/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
+++ b/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
@@ -32,6 +32,7 @@ import java.nio.file.StandardOpenOption;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -75,6 +76,8 @@ public class ReportManagerHelper {
     private static final AtomicInteger openIssuesForPassedTestsCounter = new AtomicInteger(0);
     private static final AtomicInteger failedTestsWithoutOpenIssuesCounter = new AtomicInteger(0);
     private static final StackWalker STACK_WALKER = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
+    private static final Object RETRY_DIAGNOSTIC_LOGGING_LOCK = new Object();
+    private static final Set<Long> retryDiagnosticSessionThreads = ConcurrentHashMap.newKeySet();
     private static volatile boolean debugFileLoggingEnabled = false;
     private static volatile Level previousRootLogLevel;
     // TODO: refactor to regular class that can be instantiated within the test
@@ -214,17 +217,20 @@ public class ReportManagerHelper {
      * Enables debug-level file logging for diagnostic retry evidence.
      */
     public static void enableDebugFileLogging() {
-        if (logger == null) {
-            initializeLogger();
+        synchronized (RETRY_DIAGNOSTIC_LOGGING_LOCK) {
+            if (logger == null) {
+                initializeLogger();
+            }
+            if (!ensureLogFileExists()) {
+                return;
+            }
+            if (!debugFileLoggingEnabled) {
+                previousRootLogLevel = getCurrentRootLogLevel();
+            }
+            retryDiagnosticSessionThreads.add(Thread.currentThread().threadId());
+            debugFileLoggingEnabled = true;
+            Configurator.setRootLevel(Level.DEBUG);
         }
-        if (!ensureLogFileExists()) {
-            return;
-        }
-        if (!debugFileLoggingEnabled) {
-            previousRootLogLevel = getCurrentRootLogLevel();
-        }
-        debugFileLoggingEnabled = true;
-        Configurator.setRootLevel(Level.DEBUG);
         logger.debug("Enabled debug-level file logging for retry diagnostics.");
         writeToDebugLogFile("Enabled debug-level file logging for retry diagnostics.", Level.DEBUG);
     }
@@ -242,10 +248,31 @@ public class ReportManagerHelper {
     }
 
     private static void resetRetryDiagnosticLogging() {
-        debugFileLoggingEnabled = false;
-        if (previousRootLogLevel != null) {
-            Configurator.setRootLevel(previousRootLogLevel);
-            previousRootLogLevel = null;
+        synchronized (RETRY_DIAGNOSTIC_LOGGING_LOCK) {
+            retryDiagnosticSessionThreads.clear();
+            debugFileLoggingEnabled = false;
+            if (previousRootLogLevel != null) {
+                Configurator.setRootLevel(previousRootLogLevel);
+                previousRootLogLevel = null;
+            }
+        }
+    }
+
+    private static boolean completeRetryDiagnosticLoggingSession() {
+        synchronized (RETRY_DIAGNOSTIC_LOGGING_LOCK) {
+            if (!debugFileLoggingEnabled) {
+                return false;
+            }
+            retryDiagnosticSessionThreads.remove(Thread.currentThread().threadId());
+            if (!retryDiagnosticSessionThreads.isEmpty()) {
+                return true;
+            }
+            debugFileLoggingEnabled = false;
+            if (previousRootLogLevel != null) {
+                Configurator.setRootLevel(previousRootLogLevel);
+                previousRootLogLevel = null;
+            }
+            return true;
         }
     }
 
@@ -478,7 +505,7 @@ public class ReportManagerHelper {
                 return;
             } finally {
                 if (shouldAttachRetryDiagnostics) {
-                    resetRetryDiagnosticLogging();
+                    completeRetryDiagnosticLoggingSession();
                 }
                 ReportManagerHelper.setDiscreteLogging(initialLoggingState);
             }

--- a/src/test/java/testPackage/unitTests/ThreadLocalPropertiesTest.java
+++ b/src/test/java/testPackage/unitTests/ThreadLocalPropertiesTest.java
@@ -301,7 +301,11 @@ public class ThreadLocalPropertiesTest {
 
         try {
             SHAFT.Properties.flags.set().retryMaximumNumberOfAttempts(1);
+            Assert.assertFalse(isRetryDebugFileLoggingEnabled(),
+                    "Retry diagnostics should start disabled before the retry analyzer runs");
             Assert.assertTrue(new RetryAnalyzer().retry(testResult), "Retry should be scheduled for the first failure");
+            Assert.assertTrue(isRetryDebugFileLoggingEnabled(),
+                    "Retry diagnostics should enable debug file logging while retry evidence is active");
             Assert.assertTrue(logFile.isFile(), "Retry diagnostics should ensure the log file exists");
             Assert.assertTrue(logFile.length() > 0, "Retry diagnostics should write to the log file");
             Assert.assertEquals(getRootLogLevel(), Level.DEBUG,
@@ -310,9 +314,11 @@ public class ThreadLocalPropertiesTest {
             Assert.assertTrue(retryLog.contains("[DEBUG"),
                     "Retry diagnostics should include at least one debug-level entry");
             ReportManagerHelper.attachEngineLog("retry-diagnostics-test");
+            Assert.assertFalse(isRetryDebugFileLoggingEnabled(),
+                    "Retry diagnostics should be disabled after engine log attachment completes");
             Assert.assertFalse(logFile.exists(), "Generated retry diagnostics log should be attached and removed");
             Assert.assertEquals(getRootLogLevel(), originalRootLogLevel,
-                    "Retry diagnostics should restore the root log level after attaching logs");
+                    "Retry diagnostics should restore the exact pre-test root log level after attaching logs");
         } finally {
             SHAFT.Properties.flags.set().retryMaximumNumberOfAttempts(originalRetryCount);
             Files.deleteIfExists(logFile.toPath());
@@ -376,6 +382,16 @@ public class ThreadLocalPropertiesTest {
 
     private Level getRootLogLevel() {
         return ((LoggerContext) LogManager.getContext(false)).getConfiguration().getRootLogger().getLevel();
+    }
+
+    private boolean isRetryDebugFileLoggingEnabled() {
+        try {
+            var field = ReportManagerHelper.class.getDeclaredField("debugFileLoggingEnabled");
+            field.setAccessible(true);
+            return field.getBoolean(null);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Could not inspect retry diagnostics debug logging state", e);
+        }
     }
 
     @Test(description = "Engine log attachment should collapse consecutive duplicate lines")


### PR DESCRIPTION
### Motivation
- Retry diagnostics temporarily set the JVM-global Log4j root level to `DEBUG`, which is racy under TestNG method-level parallel execution and can leave the global logger mutated or restore the wrong value.
- Make retry diagnostic logging deterministic so overlapping retry sessions do not clobber each other's captured root level.
- Improve unit test confidence by asserting the debug-enabled state and exact root-level restoration around the retry lifecycle.

### Description
- Add a lifecycle guard and per-thread active-session tracking via `RETRY_DIAGNOSTIC_LOGGING_LOCK` and `retryDiagnosticSessionThreads` to serialize root-level mutations and track concurrent diagnostic sessions in `ReportManagerHelper`.
- Make `enableDebugFileLogging()` capture the previous root level only once per diagnostic session, register the calling thread as an active session, and set root level to `DEBUG` inside a synchronized block.
- Replace unconditional reset with `completeRetryDiagnosticLoggingSession()` that removes the current thread from active sessions and restores the original root level only when the last session finishes; call this from the `finally` block in `attachEngineLog(...)`.
- Strengthen `ThreadLocalPropertiesTest.testRetryDiagnosticsLoggingLifecycle` to assert that debug diagnostics start disabled, become enabled during retry, and are disabled/restored after `ReportManagerHelper.attachEngineLog(...)`, and add a reflective helper `isRetryDebugFileLoggingEnabled()` used by the test.

### Testing
- Ran targeted test: `mvn -e test "-Dtest=testPackage.unitTests.ThreadLocalPropertiesTest#testRetryDiagnosticsLoggingLifecycle" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=1"`, which initially encountered a transient dependency fetch error from Maven Central (502) but subsequently completed successfully and the test passed.
- Verified that Allure results were produced for the targeted run by checking `find allure-results -maxdepth 1 -name '*-result.json' | wc -l` returned `1`.
- Built the project with `mvn clean install -DskipTests -Dgpg.skip` to ensure compilation; this completed successfully.
- All automated checks listed above succeeded after transient dependency resolution issues were retried.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c4d02f27483209bc23a6264489af1)