### PR TITLE
codex: Make Allure listener unit test parallel-safe

### DIFF
--- a/src/main/java/com/shaft/listeners/AllureListener.java
+++ b/src/main/java/com/shaft/listeners/AllureListener.java
@@ -4,6 +4,7 @@ import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.listeners.internal.TestNGListenerHelper;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import io.qameta.allure.Allure;
+import io.qameta.allure.AllureLifecycle;
 import io.qameta.allure.listener.ContainerLifecycleListener;
 import io.qameta.allure.listener.FixtureLifecycleListener;
 import io.qameta.allure.listener.StepLifecycleListener;
@@ -18,6 +19,7 @@ import org.testng.SkipException;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 /**
  * Allure lifecycle listener that integrates SHAFT's TestNG support with the Allure reporting engine.
@@ -44,12 +46,22 @@ import java.nio.charset.StandardCharsets;
  */
 public class AllureListener implements StepLifecycleListener, FixtureLifecycleListener, TestLifecycleListener,
         ContainerLifecycleListener {
+    private final AllureLifecycle lifecycle;
 
     /**
-     * Creates a new Allure lifecycle listener instance.
+     * Creates a new Allure lifecycle listener instance using the default Allure lifecycle singleton.
      */
     public AllureListener() {
-        super();
+        this(Allure.getLifecycle());
+    }
+
+    /**
+     * Creates a new Allure lifecycle listener instance using the provided Allure lifecycle.
+     *
+     * @param lifecycle the Allure lifecycle instance that receives listener attachments
+     */
+    public AllureListener(AllureLifecycle lifecycle) {
+        this.lifecycle = Objects.requireNonNull(lifecycle, "lifecycle");
     }
 
     //Before each step starts inside the methods
@@ -263,11 +275,11 @@ public class AllureListener implements StepLifecycleListener, FixtureLifecycleLi
                 details.setTrace(trace);
                 result.setStatusDetails(details);
                 // Attach the stacktrace as a readable text file so it appears in the Allure report
-                Allure.addAttachment(
+                lifecycle.addAttachment(
                         "Exception Stacktrace",
                         "text/plain",
-                        new ByteArrayInputStream(trace.getBytes(StandardCharsets.UTF_8)),
-                        ".txt");
+                        ".txt",
+                        new ByteArrayInputStream(trace.getBytes(StandardCharsets.UTF_8)));
             }
         }
         TestLifecycleListener.super.beforeTestStop(result);

--- a/src/test/java/com/shaft/listeners/AllureListenerCoverageUnitTest.java
+++ b/src/test/java/com/shaft/listeners/AllureListenerCoverageUnitTest.java
@@ -2,7 +2,6 @@ package com.shaft.listeners;
 
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.listeners.internal.TestNGListenerHelper;
-import io.qameta.allure.Allure;
 import io.qameta.allure.AllureLifecycle;
 import io.qameta.allure.FileSystemResultsWriter;
 import io.qameta.allure.model.FixtureResult;
@@ -39,13 +38,14 @@ import static org.testng.Assert.assertTrue;
 @Test(singleThreaded = true)
 public class AllureListenerCoverageUnitTest {
     private AllureListener listener;
+    private AllureLifecycle lifecycle;
     private Path allureResultsDirectory;
 
     @BeforeMethod(alwaysRun = true)
     public void beforeMethod() throws Exception {
-        listener = new AllureListener();
         allureResultsDirectory = Files.createTempDirectory("shaft-allure-listener-results");
-        Allure.setLifecycle(new AllureLifecycle(new FileSystemResultsWriter(allureResultsDirectory)));
+        lifecycle = new AllureLifecycle(new FileSystemResultsWriter(allureResultsDirectory));
+        listener = new AllureListener(lifecycle);
         setITestResult(null);
         setKillSwitch(false);
         TestNGListenerHelper.setPendingConfigFailure(null);
@@ -59,7 +59,7 @@ public class AllureListenerCoverageUnitTest {
         TestNGListenerHelper.setPendingConfigFailure(null);
         TestNGListenerHelper.cleanup();
         Reporter.clear();
-        Allure.setLifecycle(new AllureLifecycle());
+        lifecycle = null;
         deleteDirectory(allureResultsDirectory);
     }
 
@@ -204,15 +204,15 @@ public class AllureListenerCoverageUnitTest {
         TestResult result = skippedResult("config skip")
                 .setUuid(UUID.randomUUID().toString())
                 .setName("config failure host");
-        Allure.getLifecycle().scheduleTestCase(result);
-        Allure.getLifecycle().startTestCase(result.getUuid());
+        lifecycle.scheduleTestCase(result);
+        lifecycle.startTestCase(result.getUuid());
 
         try (MockedStatic<DriverFactoryHelper> driverFactoryHelper = Mockito.mockStatic(DriverFactoryHelper.class)) {
             driverFactoryHelper.when(DriverFactoryHelper::isKillSwitch).thenReturn(false);
             listener.beforeTestStop(result);
         } finally {
-            Allure.getLifecycle().stopTestCase(result.getUuid());
-            Allure.getLifecycle().writeTestCase(result.getUuid());
+            lifecycle.stopTestCase(result.getUuid());
+            lifecycle.writeTestCase(result.getUuid());
         }
 
         assertEquals(result.getStatus(), Status.BROKEN);


### PR DESCRIPTION
### Motivation
- Prevent unit tests from replacing the JVM-global Allure lifecycle and eliminate races when TestNG runs methods in parallel by isolating lifecycle writes to a test-local lifecycle instance.

### Description
- Add an injectable `AllureLifecycle` field and a new constructor `AllureListener(AllureLifecycle)` while preserving the default `AllureListener()` that uses `Allure.getLifecycle()` so SPI registration remains unchanged.
- Route stacktrace attachments through the listener's `lifecycle.addAttachment(...)` instead of the global `Allure.addAttachment(...)` so attachments target the injected lifecycle.
- Update `AllureListenerCoverageUnitTest` to create a temporary `AllureLifecycle` backed by `FileSystemResultsWriter`, pass it to `AllureListener`, and schedule/start/stop/write test cases through that `lifecycle` instead of replacing the global lifecycle.
- Scope teardown to test-local state by clearing the local `lifecycle` reference and deleting the temporary results directory only after the injected lifecycle's writes complete.

### Testing
- Ran `mvn -e test "-Dtest=com.shaft.listeners.AllureListenerCoverageUnitTest,com.shaft.test.unitTests.JavaScriptWaitManagerUnitTest" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=1"` and observed the suite produce 24 Allure result JSON files with no failures (23 passed, 1 skipped).
- Searched `allure-results`/report artifacts for `AllureResultsWriteException` and `FileAlreadyExistsException` and found none, confirming no write/race exceptions occurred.
- Also ran `mvn clean install -DskipTests -Dgpg.skip` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c4d054698832083bf592e0965d9d6)