### PR TITLE
codex: enable Moon tests and dedicated workflow

### DIFF
--- a/.github/workflows/e2eLocalTests.yml
+++ b/.github/workflows/e2eLocalTests.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  GLOBAL_TESTING_SCOPE: "!%regex[.*DatabaseActions.*], !%regex[.*CLI.*], !%regex[.*DB.*], !%regex[.*Db.*], !%regex[.*db.*], !%regex[.*API.*], !%regex[.*Api.*], !%regex[.*api.*], !%regex[.*uestBuilder.*], !%regex[.*Rest.*], !%regex[.*Json.*], !%regex[.*JSON.*], !%regex[.*json.*], !%regex[.*ndroid.*], !%regex[.*IOS.*], !%regex[.*MobileWeb.*], !%regex[.*appium.Mobile.*], !%regex[.*properties.Mobile.*], !%regex[.*CucumberTests.*], !%regex[.*LT.*], !%regex[.*Flutter.*]"
+  GLOBAL_TESTING_SCOPE: "!%regex[.*DatabaseActions.*], !%regex[.*CLI.*], !%regex[.*DB.*], !%regex[.*Db.*], !%regex[.*db.*], !%regex[.*API.*], !%regex[.*Api.*], !%regex[.*api.*], !%regex[.*uestBuilder.*], !%regex[.*Rest.*], !%regex[.*Json.*], !%regex[.*JSON.*], !%regex[.*json.*], !%regex[.*ndroid.*], !%regex[.*IOS.*], !%regex[.*MobileWeb.*], !%regex[.*appium.Mobile.*], !%regex[.*properties.Mobile.*], !%regex[.*CucumberTests.*], !%regex[.*LT.*], !%regex[.*Flutter.*], !%regex[.*MoonTests.*]"
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:

--- a/.github/workflows/e2eMoonTests.yml
+++ b/.github/workflows/e2eMoonTests.yml
@@ -1,0 +1,139 @@
+name: E2E Moon Tests
+
+concurrency:
+  group: e2e-moon-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    paths:
+      - '.github/actions/**'
+      - '.github/workflows/e2eMoonTests.yml'
+      - 'pom.xml'
+      - 'src/main/java/com/shaft/driver/**'
+      - 'src/main/java/com/shaft/listeners/**'
+      - 'src/main/java/com/shaft/properties/**'
+      - 'src/test/java/junitTestPackage/MoonTests.java'
+  schedule:
+    - cron: '30 2 * * *'
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  MOON_CHART_VERSION: '2.8.1'
+  MOON_URL: 'http://localhost:4444/wd/hub'
+
+jobs:
+  Ubuntu_Chrome_Moon:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Create Kubernetes Kind Cluster
+        uses: helm/kind-action@v1.14.0
+        with:
+          cluster_name: moon
+          wait: 120s
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4.3.1
+        with:
+          version: v3.18.4
+
+      - name: Install Moon
+        shell: bash
+        run: |
+          helm repo add aerokube https://charts.aerokube.com/
+          helm repo update
+          helm upgrade --install moon aerokube/moon2 \
+            --create-namespace \
+            --namespace moon \
+            --version "${MOON_CHART_VERSION}" \
+            --set deployment.replicas=1 \
+            --set deployment.moonCallbackURL=http://localhost:4444
+          kubectl -n moon rollout status deployment/moon --timeout=5m
+          kubectl -n moon get pods -o wide
+
+      - name: Forward Moon WebDriver Port
+        shell: bash
+        run: |
+          kubectl -n moon port-forward service/moon 4444:4444 > moon-port-forward.log 2>&1 &
+          echo "$!" > moon-port-forward.pid
+
+          for attempt in {1..60}; do
+            if curl -fsS "${MOON_URL%/wd/hub}/status" >/dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+
+          cat moon-port-forward.log || true
+          exit 1
+
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test-env
+        with:
+          node-version: '20'
+
+      - name: Enable JUnit Test Runtime
+        shell: bash
+        run: |
+          mkdir -p src/test/resources/META-INF/services
+          rm -f src/test/resources/META-INF/services/org.testng.ITestNGListener
+          printf 'com.shaft.listeners.JunitListener\n' > src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+
+      - name: Run Moon Tests
+        continue-on-error: true
+        shell: bash
+        run: |
+          mvn -e -Pjunit test \
+            "-DskipTestNG=true" \
+            "-DdefaultElementIdentificationTimeout=5" \
+            "-DretryMaximumNumberOfAttempts=1" \
+            "-DexecutionAddress=${MOON_URL}" \
+            "-DtargetOperatingSystem=LINUX" \
+            "-DtargetBrowserName=chrome" \
+            "-DheadlessExecution=true" \
+            "-DremoteServerInstanceCreationTimeout=10" \
+            "-DgenerateAllureReportArchive=true" \
+            "-Dtest=MoonTests"
+
+      - name: Verify Moon Test Results Exist
+        if: always()
+        shell: bash
+        run: |
+          RESULT_COUNT=$(find allure-results -name '*-result.json' -type f 2>/dev/null | wc -l | tr -d ' ')
+          echo "Allure result files: ${RESULT_COUNT}"
+          if [ "${RESULT_COUNT}" -lt 2 ]; then
+            echo "::error::Expected MoonTests to generate at least 2 Allure result files."
+            exit 1
+          fi
+
+      - name: Collect Moon Diagnostics
+        if: always()
+        shell: bash
+        run: |
+          kubectl -n moon get all || true
+          kubectl -n moon logs deployment/moon -c moon --tail=200 || true
+          kubectl -n moon logs deployment/moon -c moon-conf --tail=200 || true
+          kubectl -n moon logs deployment/moon -c moon-ui --tail=200 || true
+          cat moon-port-forward.log || true
+
+      - name: Stop Moon Port Forward
+        if: always()
+        shell: bash
+        run: |
+          if [ -f moon-port-forward.pid ]; then
+            kill "$(cat moon-port-forward.pid)" || true
+          fi
+
+      - name: Post-Test Report and Check
+        id: post_test_report
+        if: always()
+        uses: ./.github/actions/post-test-report
+        with:
+          job-name: Ubuntu_Chrome_Moon
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  GLOBAL_TESTING_SCOPE: "!%regex[.*DatabaseActions.*], !%regex[.*CLI.*], !%regex[.*DB.*], !%regex[.*Db.*], !%regex[.*db.*], !%regex[.*API.*], !%regex[.*Api.*], !%regex[.*api.*], !%regex[.*uestBuilder.*], !%regex[.*Rest.*], !%regex[.*Json.*], !%regex[.*JSON.*], !%regex[.*json.*], !%regex[.*ndroid.*], !%regex[.*IOS.*], !%regex[.*MobileWeb.*], !%regex[.*appium.Mobile.*], !%regex[.*properties.Mobile.*], !%regex[.*CucumberTests.*], !%regex[.*LT.*], !%regex[.*Flutter.*]"
+  GLOBAL_TESTING_SCOPE: "!%regex[.*DatabaseActions.*], !%regex[.*CLI.*], !%regex[.*DB.*], !%regex[.*Db.*], !%regex[.*db.*], !%regex[.*API.*], !%regex[.*Api.*], !%regex[.*api.*], !%regex[.*uestBuilder.*], !%regex[.*Rest.*], !%regex[.*Json.*], !%regex[.*JSON.*], !%regex[.*json.*], !%regex[.*ndroid.*], !%regex[.*IOS.*], !%regex[.*MobileWeb.*], !%regex[.*appium.Mobile.*], !%regex[.*properties.Mobile.*], !%regex[.*CucumberTests.*], !%regex[.*LT.*], !%regex[.*Flutter.*], !%regex[.*MoonTests.*]"
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   
 jobs:

--- a/scripts/ci/e2e_test_inventory.py
+++ b/scripts/ci/e2e_test_inventory.py
@@ -21,6 +21,7 @@ DEFAULT_WORKFLOWS = (
     Path(".github/workflows/e2eTests.yml"),
     Path(".github/workflows/e2eLocalTests.yml"),
     Path(".github/workflows/e2eLambdaTestTests.yml"),
+    Path(".github/workflows/e2eMoonTests.yml"),
 )
 TEST_CLASS_SUFFIXES = ("Test", "Tests", "UnitTest", "CoverageUnitTest")
 DTEST_PATTERN = re.compile(r"-Dtest=([^\"\s]+|[^\"]*?)(?=\")")

--- a/src/test/java/junitTestPackage/MoonTests.java
+++ b/src/test/java/junitTestPackage/MoonTests.java
@@ -1,79 +1,100 @@
 package junitTestPackage;
 
 import com.shaft.driver.SHAFT;
+import com.shaft.gui.browser.BrowserActions;
+import com.shaft.properties.internal.Properties;
 import com.shaft.tools.io.ReportManager;
+import com.shaft.validation.Validations;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.devtools.DevTools;
 import org.openqa.selenium.devtools.HasDevTools;
 import org.openqa.selenium.remote.Augmenter;
-import poms.GoogleSearch;
 
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static com.shaft.driver.DriverFactory.DriverType.CHROME;
 
 public class MoonTests {
+    private static final String LOCAL_MOON_URL = "http://localhost:4444/wd/hub";
+    private static final String TEST_PAGE_URL = "data:text/html;charset=utf-8,%3Chtml%3E%3Chead%3E%3Ctitle%3EMoon%20Test%20Page%3C%2Ftitle%3E%3C%2Fhead%3E%3Cbody%3E%3Cmain%3E%3Ch1%20id%3D%22moon-ready%22%3EMoon%20is%20running%3C%2Fh1%3E%3C%2Fmain%3E%3C%2Fbody%3E%3C%2Fhtml%3E";
+    private static final By MOON_READY_HEADER = By.id("moon-ready");
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
 
-    //    @BeforeAll
-    public static void beforeAll() {
-        SHAFT.Properties.platform.set().executionAddress("http://moon.aerokube.local/wd/hub");
-        SHAFT.Properties.web.set().headlessExecution(true);
-        SHAFT.Properties.timeouts.set().remoteServerInstanceCreationTimeout(1);
-        SHAFT.Properties.platform.set().enableBiDi(false);
+    @BeforeEach
+    void beforeMethod(TestInfo testInfo) {
+        configureMoonExecution();
+        driver.set(new SHAFT.GUI.WebDriver(CHROME, getMoonCapabilities(testInfo.getDisplayName())));
+    }
+
+    private static void configureMoonExecution() {
+        var executionAddress = SHAFT.Properties.platform.executionAddress();
+        if (executionAddress == null || executionAddress.isBlank() || "local".equalsIgnoreCase(executionAddress)) {
+            executionAddress = LOCAL_MOON_URL;
+        }
+        SHAFT.Properties.platform.set()
+                .executionAddress(executionAddress)
+                .targetPlatform("LINUX")
+                .enableBiDi(false);
+        SHAFT.Properties.web.set()
+                .targetBrowserName("chrome")
+                .headlessExecution(true)
+                .forceBrowserDownload(false);
+        SHAFT.Properties.timeouts.set()
+                .waitForRemoteServerToBeUp(false)
+                .timeoutForRemoteServerToBeUp(2);
     }
 
     private static ChromeOptions getMoonCapabilities(String testName) {
         var options = new ChromeOptions();
-        options.setCapability("moon:options", new HashMap<String, Object>() {{
-            /* How to add test badge */
-            put("name", testName);
-
-            /* How to set session timeout */
-            put("sessionTimeout", "15m");
-
-            /* How to set timezone */
-            put("env", new ArrayList<String>() {{
-                add("TZ=UTC");
-            }});
-
-            /* How to add "trash" button */
-            put("labels", new HashMap<String, Object>() {{
-                put("manual", "true");
-            }});
-
-            /* How to enable video recording */
-            put("enableVideo", true);
-        }});
+        var moonOptions = new HashMap<String, Object>();
+        moonOptions.put("name", testName);
+        moonOptions.put("sessionTimeout", "15m");
+        moonOptions.put("env", List.of("TZ=UTC"));
+        moonOptions.put("labels", Map.of("manual", "true"));
+        options.setCapability("moon:options", moonOptions);
         return options;
     }
 
-    //    @Test
-    public void regularDriver() {
-        var searchPage = new GoogleSearch(driver.get().getDriver());
-        searchPage.navigateToURL();
-        searchPage.assertPageIsOpen();
+    @Test
+    void regularDriverShouldOpenTestPage() {
+        navigateToTestPageAndAssertHeader(driver.get().getDriver());
     }
 
-    //    @Test
-    public void augmentedDriver() {
+    @Test
+    void augmentedDriverShouldOpenTestPageWithDevTools() {
         var nativeDriver = driver.get().getDriver();
         nativeDriver = new Augmenter().augment(driver.get().getDriver());
         DevTools devTools = ((HasDevTools) nativeDriver).getDevTools();
         ReportManager.logDiscrete(devTools.getDomains().toString());
-        var searchPage = new GoogleSearch(nativeDriver);
-        searchPage.navigateToURL();
-        searchPage.assertPageIsOpen();
+        navigateToTestPageAndAssertHeader(nativeDriver);
     }
 
-    //    @BeforeEach
-    public void beforeMethod() {
-        driver.set(new SHAFT.GUI.WebDriver(CHROME, getMoonCapabilities("test")));
+    private static void navigateToTestPageAndAssertHeader(WebDriver nativeDriver) {
+        new BrowserActions(nativeDriver).navigateToURL(TEST_PAGE_URL);
+        Validations.assertThat()
+                .element(nativeDriver, MOON_READY_HEADER)
+                .text()
+                .isEqualTo("Moon is running")
+                .perform();
     }
 
-    //    @AfterEach
-    public void afterMethod() {
-        driver.get().quit();
+    @AfterEach
+    void afterMethod() {
+        try {
+            if (driver.get() != null) {
+                driver.get().quit();
+            }
+        } finally {
+            driver.remove();
+            Properties.clearForCurrentThread();
+        }
     }
 }


### PR DESCRIPTION
Implementation agent: Codex

No linked GitHub issue was provided for this task, so this PR does not include an auto-closing issue reference.

Implementation plan for a lower-intelligence AI agent:
1. Inspect `src/test/java/junitTestPackage/MoonTests.java` and confirm why the existing class does not run. Reactivate it as JUnit 5 tests with `@BeforeEach`, `@Test`, and `@AfterEach`.
2. Replace fragile external page assertions with a deterministic local `data:` URL page so Moon session creation and browser navigation are the behavior under test.
3. Keep Moon-specific capabilities W3C-compliant by nesting custom values under `moon:options` and avoiding legacy top-level video flags.
4. Configure SHAFT properties in test setup for remote Linux Chrome, headless execution, disabled BiDi, and a default local Moon endpoint at `http://localhost:4444/wd/hub`.
5. Add a dedicated GitHub Actions workflow at `.github/workflows/e2eMoonTests.yml` that creates a kind Kubernetes cluster, installs Moon through Aerokube Helm chart `moon2`, port-forwards WebDriver, enables the JUnit runtime listener, runs only `MoonTests`, verifies Allure result population, and uploads the standard SHAFT report artifact.
6. Validate locally with a focused Maven JUnit run against a locally installed Moon server, then confirm Allure contains exactly the expected executed test result files and all are passed.

Acceptance criteria:
- `MoonTests` executes two JUnit 5 tests locally against Moon.
- Both regular and augmented Selenium driver paths create Moon sessions and pass.
- The dedicated workflow is independent from the broader E2E workflows and installs Moon before running the test.
- Allure result JSON files are generated and used as the pass/fail oracle.

Validation commands run:
- `mvn clean install -DskipTests "-Dgpg.skip"`
- `mvn -e -Pjunit test "-DskipTestNG=true" "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=http://localhost:4444/wd/hub" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DremoteServerInstanceCreationTimeout=10" "-DgenerateAllureReportArchive=true" "-Dtest=MoonTests"`
- Allure verification: 2 `*-result.json` files, report status `passed`, 2 passed tests.
- `git diff --cached --check`

Rollback/failure handling:
- Revert this PR to restore the disabled Moon test class and remove the dedicated workflow.
- If CI fails during Moon startup, inspect the workflow's `Collect Moon Diagnostics` output, Moon deployment logs, and port-forward log.
- If browser pods take too long on first image pull, increase the workflow wait loop or pre-pull browser images in the kind cluster.

Assumptions:
- GitHub-hosted Ubuntu runners can run Docker-backed kind clusters.
- The free Moon quota of 4 sessions is sufficient because this workflow runs two tests serially.
- No issue number was provided, so no automatic closing link is possible.