### PR TITLE
codex: fix Edge grid image test isolation

### DIFF
--- a/.github/copilot-memory.md
+++ b/.github/copilot-memory.md
@@ -86,3 +86,10 @@ Purpose: keep high-signal, reusable learnings from implementation sessions in on
 - Lesson: Never emit top-level `enableVideo`; keep video configuration in namespaced capability payloads only (`selenoid:options`, `moon:options`, `se:recordVideo`). When namespaced maps already exist, merge and preserve existing keys instead of overwriting provider options.
 - Evidence: `src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java`, `src/test/java/com/shaft/driver/internal/DriverFactory/OptionsManagerCoverageUnitTest.java`, `AGENTS.md`.
 - Action taken: Added helper-based namespaced capability merging in `OptionsManager`, kept tests aligned with no top-level `enableVideo`, and added durable guidance to `AGENTS.md`.
+
+- Date: 2026-06-05
+- Area: TestNG parallelism / Selenium Grid E2E triage / image test isolation
+- Trigger: E2E run `27004138692` had one `Ubuntu_MicrosoftEdge_Grid` BROKEN result in `ImageProcessingActionsUnitTest.compareImageFoldersShouldPassWhenImagesAreIdentical`.
+- Lesson: In TestNG `setParallel=METHODS`, ordinary instance fields are shared by concurrently running methods in the same class. If `@BeforeMethod` writes a per-method temp path to a shared field and `@AfterMethod` deletes from that field, another method can delete files still being read, surfacing as misleading image IO errors such as `javax.imageio.IIOException: Can't create an ImageInputStream!`. Use `ThreadLocal` for per-method temp paths or serialize classes that intentionally mutate shared/static state. Also inspect retried/skipped Allure result JSON and adjacent job logs, because the final summary can pass after retries while exposing the race.
+- Evidence: `src/test/java/testPackage/unitTests/ImageProcessingActionsUnitTest.java`, `.github/workflows/e2eTests.yml`, run `27004138692`.
+- Action taken: Converted the test temp directory state to `ThreadLocal`, added CI/test instruction guidance, and validated with the Edge Grid workflow properties.

--- a/.github/instructions/java-tests.instructions.md
+++ b/.github/instructions/java-tests.instructions.md
@@ -16,6 +16,8 @@ These examples use **TestNG** (the primary framework). For JUnit5, adapt annotat
 ### Thread Safety for Parallel Execution
 - Wrap driver instances in `ThreadLocal<SHAFT.GUI.WebDriver>` when the class is designed for parallel runs
 - Never share a single driver instance across test methods
+- Do not store per-method temporary paths, files, drivers, mocks, or mutable setup data in ordinary instance fields when `setParallel=METHODS` can run the class in parallel. Use `ThreadLocal`, local variables passed through helper methods, or `@Test(singleThreaded = true)` when the class intentionally mutates static/shared state.
+- For tests that create files in `@BeforeMethod` and delete them in `@AfterMethod(alwaysRun = true)`, make cleanup read the current thread's setup state and clear that state after deletion. A shared field can let one method delete another method's files and surface later as misleading image/file IO failures.
 
 ### Assertions
 - Always use SHAFT's fluent assertion API: `driver.assertThat()...perform()`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,10 @@ Important directories:
 - Test data belongs under `src/test/resources/testDataFiles/`; avoid hardcoding data in tests when existing guidance requires JSON test data.
 - For TestNG browser tests, existing instructions require fresh driver setup per test and `@AfterMethod(alwaysRun = true)` cleanup with `driver.quit()`.
 - For parallel tests, isolate state with `ThreadLocal` and avoid sharing driver instances across methods.
+- Under TestNG `setParallel=METHODS`, ordinary instance fields are shared by concurrently running methods in the same test class. Store per-method temp directories, files, mocks, and setup state in `ThreadLocal` or keep the class `@Test(singleThreaded = true)` when it must mutate static/shared state; otherwise one method's `@AfterMethod` can delete or reset another method's resources.
 - `@Test(singleThreaded = true)` serializes methods inside one TestNG class only; it does not isolate static SHAFT property setters from other classes in a parallel suite. Tests that assert behavior depending on global properties such as `executionAddress` must set those prerequisites inside the test (and rely on `@AfterMethod(alwaysRun = true)` cleanup) to avoid E2E flakes from cross-class property mutation.
 - Tests or setup code that clean Allure results during parallel TestNG execution should preserve the live `allure-results` root directory and delete only its contents. Replacing the root can race with Allure's own file writer on Windows and surface as `FileAlreadyExistsException`/BROKEN results.
+- When a final Allure summary is green but job logs show retry attempts, inspect the non-passed `*-result.json` attempts too. Retried `skipped` results with file/image IO messages often indicate a real parallel-isolation flake that may later become a final BROKEN/FAILED test in CI.
 
 ## Code Style and Conventions
 - Public framework classes and public methods must have JavaDoc, including relevant `@param`, `@return`, and `@throws` tags.
@@ -149,6 +151,7 @@ Use this protocol whenever a maintainer tags `@codex` to start work, says `start
 - If GitHub publication access is unavailable, say so clearly and provide a PR handoff rather than implying a visible GitHub PR exists.
 - Agent-created branches/PRs must identify the agent author. Prefer branch names starting with `codex/` and PR titles starting with `codex:` for Codex-authored work. If a human maintainer token creates the PR, state in the PR body that Codex made the changes and that the token owner did not author them manually.
 - The local `make_pr` tool only records PR metadata for the agent harness; it does **not** publish a visible GitHub pull request or upload the branch. For GitHub-backed tasks, after committing changes, push the `codex/` branch to `origin`, create or update the real GitHub PR with `gh pr create`/`gh pr edit`, include `Closes #<issue>` or an equivalent issue link when an issue exists, and verify with `git ls-remote --heads origin <branch>` plus `gh pr view --json number,url,headRefName,baseRefName,closingIssuesReferences` before telling the user the PR is open.
+- Edge Grid run `27004138692` exposed a TestNG METHOD-parallel race where `ImageProcessingActionsUnitTest` stored its per-method temp directory in an instance field. The final signature was `javax.imageio.IIOException: Can't create an ImageInputStream!`, but job logs showed another method's cleanup deleting `target/temp/imageProcessingUnitTests/.../*.png`. For similar image/file failures, inspect adjacent setup/cleanup lines and convert per-method state to `ThreadLocal` before changing image comparison logic.
 
 ## Open Questions / Verify Before Relying
 - No explicit local formatter command was found.

--- a/docs/CI_FAILURE_INVESTIGATION.md
+++ b/docs/CI_FAILURE_INVESTIGATION.md
@@ -101,6 +101,8 @@ PY
 
 If the count is zero or unexpectedly low, treat the report as empty/invalid and investigate report generation before diagnosing tests.
 
+When a run passes locally or after retries but the logs show transient failures, parse all result JSON files, not only the final summary. Retried attempts can appear as `skipped` in Allure with useful failure messages. In parallel TestNG grid jobs, messages such as `FileNotFoundException`, `Can't create an ImageInputStream`, or missing files under `target/temp/...` often point to test setup/cleanup state shared through instance fields rather than a browser-specific defect.
+
 ## 3. Separate test defects from environment/provider defects
 
 Document each failed/broken test with:
@@ -109,6 +111,7 @@ Document each failed/broken test with:
 - Allure `fullName`, status, and concise failure signature;
 - whether the failure is deterministic in local targeted tests;
 - whether the signature points to code, test isolation, CI host behavior, credentials, or an external provider outage.
+- whether nearby log lines show concurrent methods from the same TestNG class sharing or deleting a resource. Under `setParallel=METHODS`, shared instance fields can race even when every method has `@BeforeMethod` and `@AfterMethod` hooks.
 
 Do not hide provider or credential failures by changing assertions. For example, a cloud-provider `401` during setup should be reported as credential/provider evidence; only fix framework/test teardown if it adds a secondary `NullPointerException` or masks the real setup failure.
 

--- a/src/test/java/testPackage/unitTests/ImageProcessingActionsUnitTest.java
+++ b/src/test/java/testPackage/unitTests/ImageProcessingActionsUnitTest.java
@@ -39,20 +39,23 @@ import java.util.Map;
 public class ImageProcessingActionsUnitTest {
     private static final FileActions testFileActions = FileActions.getInstance(true);
     private static final Path TEMP_ROOT = Path.of("target", "temp", "imageProcessingUnitTests");
-    private Path tempDir;
+    private final ThreadLocal<Path> tempDir = new ThreadLocal<>();
 
     @BeforeMethod(alwaysRun = true)
     public void setup(Method method) throws Exception {
-        tempDir = TEMP_ROOT.resolve(method.getName() + "-" + Thread.currentThread().threadId());
-        testFileActions.deleteFolder(tempDir.toString());
-        testFileActions.createFolder(tempDir.toString());
-        setAiFolderPath(tempDir.toAbsolutePath().toString() + File.separator);
+        Path methodTempDir = TEMP_ROOT.resolve(method.getName() + "-" + Thread.currentThread().threadId());
+        tempDir.set(methodTempDir);
+        testFileActions.deleteFolder(methodTempDir.toString());
+        testFileActions.createFolder(methodTempDir.toString());
+        setAiFolderPath(methodTempDir.toAbsolutePath().toString() + File.separator);
     }
 
     @AfterMethod(alwaysRun = true)
     public void cleanup() throws Exception {
-        if (tempDir != null) {
-            testFileActions.deleteFolder(tempDir.toString());
+        Path methodTempDir = tempDir.get();
+        if (methodTempDir != null) {
+            testFileActions.deleteFolder(methodTempDir.toString());
+            tempDir.remove();
         }
         setAiFolderPath(null);
         Properties.clearForCurrentThread();
@@ -74,7 +77,7 @@ public class ImageProcessingActionsUnitTest {
         By locator = By.id("avatar");
         String hashed = ImageProcessingActions.formatElementLocatorToImagePath(locator);
         byte[] imageBytes = "img".getBytes(StandardCharsets.UTF_8);
-        testFileActions.writeToFile(tempDir.resolve(hashed + ".png").toString(), imageBytes);
+        testFileActions.writeToFile(tempDir().resolve(hashed + ".png").toString(), imageBytes);
 
         Assert.assertEquals(ImageProcessingActions.getReferenceImage(locator), imageBytes);
         Assert.assertEquals(ImageProcessingActions.getShutterbugDifferencesImage(locator), new byte[0]);
@@ -88,11 +91,11 @@ public class ImageProcessingActionsUnitTest {
         String hashed = ImageProcessingActions.formatElementLocatorToImagePath(locator);
         byte[] imageBytes = "img".getBytes(StandardCharsets.UTF_8);
         byte[] shutterbugBytes = "diff".getBytes(StandardCharsets.UTF_8);
-        testFileActions.writeToFile(tempDir.resolve(hashed + ".png").toString(), imageBytes);
-        testFileActions.writeToFile(tempDir.resolve(hashed + "_shutterbug.png").toString(), shutterbugBytes);
+        testFileActions.writeToFile(tempDir().resolve(hashed + ".png").toString(), imageBytes);
+        testFileActions.writeToFile(tempDir().resolve(hashed + "_shutterbug.png").toString(), shutterbugBytes);
 
         try (MockedStatic<ScreenshotHelper> screenshotHelperMock = org.mockito.Mockito.mockStatic(ScreenshotHelper.class)) {
-            screenshotHelperMock.when(ScreenshotHelper::getAiAidedElementIdentificationFolderPath).thenReturn(tempDir.toAbsolutePath().toString() + File.separator);
+            screenshotHelperMock.when(ScreenshotHelper::getAiAidedElementIdentificationFolderPath).thenReturn(tempDir().toAbsolutePath().toString() + File.separator);
             Assert.assertEquals(ImageProcessingActions.getReferenceImage(locator), imageBytes);
             Assert.assertEquals(ImageProcessingActions.getShutterbugDifferencesImage(locator), shutterbugBytes);
         }
@@ -111,7 +114,7 @@ public class ImageProcessingActionsUnitTest {
 
         String hashed = ImageProcessingActions.formatElementLocatorToImagePath(locator);
         Assert.assertTrue(result);
-        Assert.assertTrue(testFileActions.doesFileExist(tempDir.resolve(hashed + ".png").toString()));
+        Assert.assertTrue(testFileActions.doesFileExist(tempDir().resolve(hashed + ".png").toString()));
     }
 
     @Test
@@ -121,8 +124,8 @@ public class ImageProcessingActionsUnitTest {
 
     @Test
     public void compareImageFoldersShouldFailWhenFolderCountsMismatch() {
-        Path reference = tempDir.resolve("reference");
-        Path test = tempDir.resolve("test");
+        Path reference = tempDir().resolve("reference");
+        Path test = tempDir().resolve("test");
         testFileActions.createFolder(reference.toString());
         testFileActions.createFolder(test.toString());
         testFileActions.writeToFile(reference.resolve("one.txt").toString(), "1");
@@ -131,8 +134,8 @@ public class ImageProcessingActionsUnitTest {
 
     @Test
     public void compareImageFoldersShouldPassWhenImagesAreIdentical() {
-        Path reference = tempDir.resolve("reference-pass");
-        Path test = tempDir.resolve("test-pass");
+        Path reference = tempDir().resolve("reference-pass");
+        Path test = tempDir().resolve("test-pass");
         testFileActions.createFolder(reference.toString());
         testFileActions.createFolder(test.toString());
 
@@ -146,7 +149,7 @@ public class ImageProcessingActionsUnitTest {
 
     @Test
     public void findImageWithinCurrentPageShouldReturnCoordinatesWhenImageMatches() {
-        Path referenceImage = tempDir.resolve("reference-image.png");
+        Path referenceImage = tempDir().resolve("reference-image.png");
         byte[] screenshot = createPng(30, 30, Color.GREEN);
         testFileActions.writeToFile(referenceImage.toString(), screenshot);
 
@@ -157,7 +160,7 @@ public class ImageProcessingActionsUnitTest {
     public void compareAgainstBaselineExactOpenCvShouldFailForDifferentImagesWhenReferenceExists() {
         By locator = By.id("differentElement");
         String hashed = ImageProcessingActions.formatElementLocatorToImagePath(locator);
-        testFileActions.writeToFile(tempDir.resolve(hashed + ".png").toString(), createPng(30, 30, Color.YELLOW));
+        testFileActions.writeToFile(tempDir().resolve(hashed + ".png").toString(), createPng(30, 30, Color.YELLOW));
 
         boolean result = ImageProcessingActions.compareAgainstBaseline(
                 org.mockito.Mockito.mock(WebDriver.class),
@@ -184,7 +187,7 @@ public class ImageProcessingActionsUnitTest {
 
         String hashed = ImageProcessingActions.formatElementLocatorToImagePath(locator);
         Assert.assertTrue(result);
-        Assert.assertTrue(testFileActions.doesFileExist(tempDir.resolve(hashed + ".png").toString()));
+        Assert.assertTrue(testFileActions.doesFileExist(tempDir().resolve(hashed + ".png").toString()));
     }
 
     @Test
@@ -223,7 +226,7 @@ public class ImageProcessingActionsUnitTest {
         double originalThreshold = SHAFT.Properties.visuals.visualMatchingThreshold();
         try {
             SHAFT.Properties.visuals.set().visualMatchingThreshold(1.1);
-            Path referenceImage = tempDir.resolve("retry-reference-image.png");
+            Path referenceImage = tempDir().resolve("retry-reference-image.png");
             byte[] screenshot = createPng(25, 25, Color.MAGENTA);
             testFileActions.writeToFile(referenceImage.toString(), screenshot);
 
@@ -238,7 +241,7 @@ public class ImageProcessingActionsUnitTest {
         By locator = By.id("existingShutterbugElement");
         String hashed = ImageProcessingActions.formatElementLocatorToImagePath(locator);
         byte[] screenshot = createPng(20, 20, Color.CYAN);
-        testFileActions.writeToFile(tempDir.resolve(hashed + ".png").toString(), screenshot);
+        testFileActions.writeToFile(tempDir().resolve(hashed + ".png").toString(), screenshot);
 
         ElementSnapshot snapshot = org.mockito.Mockito.mock(ElementSnapshot.class);
         org.mockito.Mockito.when(snapshot.equalsWithDiff(org.mockito.Mockito.anyString(), org.mockito.Mockito.anyString(), org.mockito.Mockito.anyDouble())).thenReturn(true);
@@ -261,7 +264,7 @@ public class ImageProcessingActionsUnitTest {
         By locator = By.id("fallbackShutterbugElement");
         String hashed = ImageProcessingActions.formatElementLocatorToImagePath(locator);
         byte[] screenshot = createPng(20, 20, Color.PINK);
-        testFileActions.writeToFile(tempDir.resolve(hashed + ".png").toString(), screenshot);
+        testFileActions.writeToFile(tempDir().resolve(hashed + ".png").toString(), screenshot);
 
         ElementSnapshot snapshot = org.mockito.Mockito.mock(ElementSnapshot.class);
         org.mockito.Mockito.when(snapshot.equalsWithDiff(org.mockito.Mockito.anyString(), org.mockito.Mockito.anyString(), org.mockito.Mockito.anyDouble()))
@@ -349,6 +352,14 @@ public class ImageProcessingActionsUnitTest {
 
     private static void clearLocatorHashCache() throws Exception {
         getLocatorHashCache().clear();
+    }
+
+    private Path tempDir() {
+        Path methodTempDir = tempDir.get();
+        if (methodTempDir == null) {
+            throw new IllegalStateException("Test temp directory was not initialized for the current thread.");
+        }
+        return methodTempDir;
     }
 
     private static void setAiFolderPath(String value) throws Exception {


### PR DESCRIPTION
This PR was created by Codex, not manually by the maintainer whose token opened it.

## Summary
- Fixes the `Ubuntu_MicrosoftEdge_Grid` BROKEN result from E2E run https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/27004138692.
- Converts `ImageProcessingActionsUnitTest` per-method temp directory state from a shared instance field to `ThreadLocal<Path>` so TestNG `setParallel=METHODS` cannot let one method cleanup delete another method's image files.
- Updates agent/test/CI instructions with the learned parallel TestNG and Allure retry-artifact lessons.

## Root Cause
The failed Allure report had 1019 populated results with one BROKEN test: `testPackage.unitTests.ImageProcessingActionsUnitTest.compareImageFoldersShouldPassWhenImagesAreIdentical`.

The failure was `javax.imageio.IIOException: Can't create an ImageInputStream!`. Adjacent job logs showed concurrent methods in the same TestNG class and `FileNotFoundException` for files under `target/temp/imageProcessingUnitTests/...`. The class stored `tempDir` in a normal instance field, so parallel methods could overwrite it and let one `@AfterMethod` delete another method's image files before `ImageIO.read`.

## Validation
- Parsed `Ubuntu_MicrosoftEdge_Grid_Allure.html` from run `27004138692`: 1019 result JSON files, `passed=1011`, `skipped=7`, `broken=1`; the single broken test matched the image temp-directory race.
- Reproduced the race locally against the workflow grid shape: `docker compose -f src/main/resources/docker-compose/selenium4.yml up --scale chrome=0 --scale edge=10 --scale firefox=0 -d`, then targeted Edge Grid Maven run. Before the fix, Allure had 23 results with 19 passed and 4 skipped retry attempts from the same class.
- After the fix, the same targeted Edge Grid run produced 19 result JSON files, all passed.
- Ran the full local `Ubuntu_MicrosoftEdge_Grid` Maven command with the workflow `GLOBAL_TESTING_SCOPE`; `ImageProcessingActionsUnitTest` had 19/19 passed. The broad local Windows-host run still showed unrelated non-passing results in other classes, so CI on Ubuntu remains the authoritative full-suite check.
- `mvn clean install "-DskipTests" "-Dgpg.skip"` passed.
- `git diff --cached --check` passed before commit.

## Notes
The Selenium Grid stack was stopped with `docker compose -f src/main/resources/docker-compose/selenium4.yml down --remove-orphans` after validation.