### PR TITLE
codex: prepare release 10.2.20260605

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.shafthq</groupId>
     <artifactId>SHAFT_ENGINE</artifactId>
-    <version>10.2.20260530</version> <!-- UPDATE com.shaft.properties.internal > Internal > shaftEngineVersion, allure3Version, nodeLtsVersion,  -->
+    <version>10.2.20260605</version> <!-- UPDATE com.shaft.properties.internal > Internal > shaftEngineVersion, allure3Version, nodeLtsVersion,  -->
     <name>${project.groupId}:${project.artifactId}</name>
     <description>SHAFT is a unified test automation engine. Powered by best-in-class frameworks, SHAFT provides a
         wizard-like syntax to drive your automation efficiently, maximize your ROI, and minimize your learning curve.

--- a/src/main/java/com/shaft/properties/internal/Internal.java
+++ b/src/main/java/com/shaft/properties/internal/Internal.java
@@ -18,7 +18,7 @@ import org.aeonbits.owner.Config.Sources;
 })
 public interface Internal extends EngineProperties<Internal> {
     @Key("shaftEngineVersion")
-    @DefaultValue("10.2.20260530")
+    @DefaultValue("10.2.20260605")
     String shaftEngineVersion();
 
     @Key("watermarkImagePath")

--- a/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
+++ b/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260530</shaft_engine.version>
+        <shaft_engine.version>10.2.20260605</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
+++ b/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260530</shaft_engine.version>
+        <shaft_engine.version>10.2.20260605</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
+++ b/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260530</shaft_engine.version>
+        <shaft_engine.version>10.2.20260605</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
+++ b/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260530</shaft_engine.version>
+        <shaft_engine.version>10.2.20260605</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
+++ b/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260530</shaft_engine.version>
+        <shaft_engine.version>10.2.20260605</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
+++ b/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260530</shaft_engine.version>
+        <shaft_engine.version>10.2.20260605</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
+++ b/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260530</shaft_engine.version>
+        <shaft_engine.version>10.2.20260605</shaft_engine.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>


### PR DESCRIPTION
### Motivation
- Prepare and publish a new SHAFT_ENGINE release by bumping the engine version and keeping internal tooling defaults in sync.
- Ensure sample/demo projects reference the new release so downstream example projects resolve the correct engine artifact.

### Description
- Updated the root Maven project version to `10.2.20260605` in `pom.xml`.
- Updated `@DefaultValue` for `shaftEngineVersion` in `src/main/java/com/shaft/properties/internal/Internal.java` to `10.2.20260605`.
- Updated every sample/demo `shaft_engine.version` under `src/main/resources/examples/**/pom.xml` to `10.2.20260605`.
- Verified `allure3Version` remains `3.9.0` and `nodeLtsVersion` remains `24.16.0` so no changes were required for those internal defaults.

### Testing
- Ran a Python check against the npm registry and Node.js release index and confirmed `allure` dist-tag `latest == 3.9.0` and Node LTS `v24.16.0`, which matched current defaults.
- Ran a repository verification script that confirmed all affected files contain `10.2.20260605` and no `10.2.20260530` references remain.
- Executed `mvn clean install -DskipTests -Dgpg.skip` which completed successfully and produced the JAR, Javadoc, and sources artifacts.
- Note: the Maven build was performed with tests skipped, so no unit tests were executed as part of these steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a230697946c8320bf7c1fd95aff7f16)