### PR TITLE
codex: publish shaft-engine coordinate, BOM, and relocation

### DIFF
--- a/.github/workflows/mavenCentral_cd.yml
+++ b/.github/workflows/mavenCentral_cd.yml
@@ -38,6 +38,8 @@ jobs:
         uses: stCarolas/setup-maven@v5
         with:
           maven-version: 3.9.5
+      - name: Reject divergent SHAFT reactor versions
+        run: python3 scripts/ci/validate_reactor_versions.py
       # Captures the engine version from the pom.xml
       - name: Set Release Version Number
         run: |

--- a/.github/workflows/reactor-version-check.yml
+++ b/.github/workflows/reactor-version-check.yml
@@ -1,0 +1,31 @@
+name: Reactor Version Check
+
+on:
+  pull_request:
+    paths:
+      - 'pom.xml'
+      - '*/pom.xml'
+      - 'scripts/ci/validate_reactor_versions.py'
+      - 'tests/scripts/test_validate_reactor_versions.py'
+  push:
+    branches: [ main ]
+    paths:
+      - 'pom.xml'
+      - '*/pom.xml'
+      - 'scripts/ci/validate_reactor_versions.py'
+      - 'tests/scripts/test_validate_reactor_versions.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-reactor-versions:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+      - name: Reject divergent SHAFT reactor versions
+        run: python3 scripts/ci/validate_reactor_versions.py
+      - name: Test reactor version validator
+        run: python3 -m unittest tests.scripts.test_validate_reactor_versions

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 SHAFT Engine is an open-source **Java test automation framework** built on top of [Selenium](https://www.selenium.dev/), [Appium](https://appium.io/), and [REST Assured](https://rest-assured.io/). It provides a unified, fluent API for **cross-browser testing**, **mobile app testing**, **API testing**, **CLI testing**, and **database testing** — so you can automate anything, from any platform, with zero boilerplate.
 
 [![GitHub Stars](https://img.shields.io/github/stars/ShaftHQ/SHAFT_ENGINE?style=for-the-badge&logo=github&label=Stars&color=gold)](https://github.com/ShaftHQ/SHAFT_ENGINE/stargazers)
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.shafthq/SHAFT_ENGINE?style=for-the-badge&logo=apachemaven&label=Maven%20Central&color=indigo)](https://central.sonatype.com/artifact/io.github.shafthq/SHAFT_ENGINE)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.shafthq/shaft-engine?style=for-the-badge&logo=apachemaven&label=Maven%20Central&color=indigo)](https://central.sonatype.com/artifact/io.github.shafthq/shaft-engine)
 [![License](https://img.shields.io/github/license/ShaftHQ/SHAFT_Engine?color=indigo&style=for-the-badge)](https://github.com/ShaftHQ/SHAFT_ENGINE/blob/master/LICENSE)
 [![E2E Tests](https://img.shields.io/github/actions/workflow/status/SHAFTHQ/SHAFT_Engine/e2eTests.yml?branch=main&color=forestgreen&label=E2E%20Tests&style=for-the-badge)](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/workflows/e2eTests.yml)
 [![Code QL](https://img.shields.io/github/actions/workflow/status/SHAFTHQ/SHAFT_Engine/codeql-analysis.yml?branch=main&label=Security&color=forestgreen&style=for-the-badge)](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/workflows/codeql-analysis.yml)
@@ -178,7 +178,7 @@ mvn archetype:generate \
 ```xml
 <dependency>
     <groupId>io.github.shafthq</groupId>
-    <artifactId>SHAFT_ENGINE</artifactId>
+    <artifactId>shaft-engine</artifactId>
     <!-- Get the latest version from Maven Central ↓ -->
     <version><!-- SEE BADGE BELOW --></version>
 </dependency>
@@ -187,7 +187,7 @@ mvn archetype:generate \
 
 > ℹ️ This repository enforces a Maven-only execution policy for global consistency across local IDE runs and CI/CD pipelines.
 
-> 💡 Check the latest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.shafthq/SHAFT_ENGINE?style=flat-square&label=latest%20version)](https://central.sonatype.com/artifact/io.github.shafthq/SHAFT_ENGINE)
+> 💡 Check the latest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.shafthq/shaft-engine?style=flat-square&label=latest%20version)](https://central.sonatype.com/artifact/io.github.shafthq/shaft-engine)
 
 ### Your First Test
 
@@ -391,7 +391,7 @@ Made with ❤️ by the [SHAFT community](https://github.com/ShaftHQ/SHAFT_ENGIN
   =========================================================
   Project:      SHAFT Engine
   Full name:    SHAFT — Unified Test Automation Engine
-  Maven:        io.github.shafthq:SHAFT_ENGINE
+  Maven:        io.github.shafthq:shaft-engine
   Language:     Java 21
   License:      MIT
   Maintained:   Yes (active, production-ready)

--- a/docs/MAVEN_REACTOR.md
+++ b/docs/MAVEN_REACTOR.md
@@ -1,36 +1,67 @@
 # Maven reactor layout
 
-SHAFT_ENGINE is built as a Maven reactor while the published engine artifact remains
-`io.github.shafthq:SHAFT_ENGINE` for compatibility.
+SHAFT_ENGINE is built as a Maven reactor. The canonical published engine coordinate is
+`io.github.shafthq:shaft-engine`; the former `io.github.shafthq:SHAFT_ENGINE` coordinate is a POM-only
+relocation artifact that points consumers to the canonical JAR.
 
 ## Modules
 
 - The root `pom.xml` is the `io.github.shafthq:shaft-parent` aggregator and build parent. It owns shared version properties, dependency management, and plugin management.
-- `shaft-engine/pom.xml` builds the existing engine JAR. All framework source, resources, tests, examples, and runtime support assets live under `shaft-engine/src/`.
+- `shaft-engine/pom.xml` builds the engine JAR. All framework source, resources, tests, examples, and runtime support assets remain under `shaft-engine/src/`; Java packages remain under `com.shaft`.
+- `shaft-bom/pom.xml` publishes the consumer BOM. Importing it manages the `shaft-engine` version without adding dependencies by itself.
+- `legacy-shaft-engine/pom.xml` publishes the legacy `SHAFT_ENGINE` coordinate as relocation metadata only; it contains no classes.
 
-This layout is intentionally behavior-preserving. API, Appium/mobile, database, BrowserStack, desktop video, OpenCV visual processing, and every other existing capability remain dependencies of the engine module at this stage.
+API, Appium/mobile, database, BrowserStack, desktop video, OpenCV visual processing, and every other retained capability remain dependencies of the engine module.
+
+## Consumer usage
+
+Use the canonical dependency directly:
+
+```xml
+<dependency>
+    <groupId>io.github.shafthq</groupId>
+    <artifactId>shaft-engine</artifactId>
+    <version>${shaft.version}</version>
+</dependency>
+```
+
+Or import the BOM and omit the engine version:
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.github.shafthq</groupId>
+            <artifactId>shaft-bom</artifactId>
+            <version>${shaft.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+<dependencies>
+    <dependency>
+        <groupId>io.github.shafthq</groupId>
+        <artifactId>shaft-engine</artifactId>
+    </dependency>
+</dependencies>
+```
 
 ## Common commands
 
 Run commands from the repository root:
 
 ```bash
-# Build and install the complete reactor without executing tests.
+python3 scripts/ci/validate_reactor_versions.py
 mvn clean install -DskipTests -Dgpg.skip
-
-# Run one engine test class and build required upstream modules.
 mvn -pl shaft-engine -am test -Dtest=TestClassName
-
-# Run the complete engine test suite.
 mvn -pl shaft-engine -am test
-
-# Generate the engine JavaDocs.
 mvn -pl shaft-engine javadoc:javadoc
 ```
 
 Build and test outputs are module-local. Important locations include:
 
-- Engine JAR: `shaft-engine/target/SHAFT_ENGINE-<version>.jar`
+- Engine JAR: `shaft-engine/target/shaft-engine-<version>.jar`
 - Surefire reports: `shaft-engine/target/surefire-reports/`
 - JaCoCo report: `shaft-engine/target/jacoco/`
 - Allure results: `shaft-engine/allure-results/`
@@ -40,11 +71,11 @@ When validating a test run, count `shaft-engine/allure-results/*-result.json` be
 
 ## Dependency baseline fixtures
 
-The cold-cache consumer fixtures continue to resolve the legacy engine coordinate. Build the reactor before measuring them:
+The cold-cache fixtures cover direct canonical dependencies, BOM-managed versionless dependencies, and the legacy relocation path. Build the reactor before measuring them:
 
 ```bash
 mvn clean install -DskipTests -Dgpg.skip
 python3 scripts/ci/measure_consumer_dependencies.py --verify
 ```
 
-The measurement script seeds the engine JAR, the engine module POM, and the reactor parent POM into each isolated Maven repository so the resulting dependency graph matches normal Maven installation.
+The measurement script seeds the canonical engine JAR, the BOM, the legacy relocation POM, and the reactor parent into each isolated Maven repository.

--- a/legacy-shaft-engine/pom.xml
+++ b/legacy-shaft-engine/pom.xml
@@ -1,0 +1,24 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.shafthq</groupId>
+        <artifactId>shaft-parent</artifactId>
+        <version>10.2.20260605</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>SHAFT_ENGINE</artifactId>
+    <packaging>pom</packaging>
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>Legacy SHAFT coordinate retained as a relocation POM.</description>
+
+    <distributionManagement>
+        <relocation>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>shaft-engine</artifactId>
+            <version>${project.version}</version>
+            <message>SHAFT Engine moved to io.github.shafthq:shaft-engine. Update your dependency coordinate.</message>
+        </relocation>
+    </distributionManagement>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,8 @@
 
     <modules>
         <module>shaft-engine</module>
+        <module>shaft-bom</module>
+        <module>legacy-shaft-engine</module>
     </modules>
 
     <properties>

--- a/scripts/ci/measure_consumer_dependencies.py
+++ b/scripts/ci/measure_consumer_dependencies.py
@@ -22,7 +22,12 @@ FIXTURES_ROOT = ROOT / "tools" / "modularization" / "consumer-fixtures"
 BASELINE_ROOT = ROOT / "docs" / "modularization" / "dependency-baseline"
 ENGINE_ROOT = ROOT / "shaft-engine"
 ENGINE_POM = ENGINE_ROOT / "pom.xml"
-PROJECT_COORDINATE = "io.github.shafthq:SHAFT_ENGINE"
+BOM_POM = ROOT / "shaft-bom" / "pom.xml"
+LEGACY_POM = ROOT / "legacy-shaft-engine" / "pom.xml"
+PROJECT_COORDINATES = (
+    "io.github.shafthq:shaft-engine",
+    "io.github.shafthq:SHAFT_ENGINE",
+)
 DEPENDENCY_LINE = re.compile(r"^\s*([^\s].*?):(/.*|[A-Za-z]:\\.*)$")
 
 
@@ -47,15 +52,35 @@ def project_version(pom: Path = ROOT / "pom.xml") -> str:
     return version.strip()
 
 
-def seed_project_artifact(repository: Path, jar: Path, version: str) -> int:
-    destination = repository / "io" / "github" / "shafthq" / "SHAFT_ENGINE" / version
+def seed_pom(repository: Path, artifact_id: str, pom: Path, version: str) -> None:
+    destination = repository / "io" / "github" / "shafthq" / artifact_id / version
     destination.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(jar, destination / f"SHAFT_ENGINE-{version}.jar")
-    shutil.copy2(ENGINE_POM, destination / f"SHAFT_ENGINE-{version}.pom")
-    parent_destination = repository / "io" / "github" / "shafthq" / "shaft-parent" / version
-    parent_destination.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(ROOT / "pom.xml", parent_destination / f"shaft-parent-{version}.pom")
+    shutil.copy2(pom, destination / f"{artifact_id}-{version}.pom")
+
+
+def seed_project_artifact(repository: Path, jar: Path, version: str) -> int:
+    engine_destination = repository / "io" / "github" / "shafthq" / "shaft-engine" / version
+    engine_destination.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(jar, engine_destination / f"shaft-engine-{version}.jar")
+    shutil.copy2(ENGINE_POM, engine_destination / f"shaft-engine-{version}.pom")
+    seed_pom(repository, "shaft-bom", BOM_POM, version)
+    seed_pom(repository, "SHAFT_ENGINE", LEGACY_POM, version)
+    seed_pom(repository, "shaft-parent", ROOT / "pom.xml", version)
     return directory_bytes(repository)
+
+
+
+def fixture_root_coordinate(pom: Path, version: str) -> str:
+    root = ET.parse(pom).getroot()
+    namespace = {"m": "http://maven.apache.org/POM/4.0.0"}
+    dependencies = root.find("m:dependencies", namespace)
+    if dependencies is None:
+        raise ValueError(f"No direct dependencies found in {pom}")
+    for dependency in dependencies.findall("m:dependency", namespace):
+        if dependency.findtext("m:groupId", namespaces=namespace) == "io.github.shafthq":
+            artifact_id = dependency.findtext("m:artifactId", namespaces=namespace)
+            return f"io.github.shafthq:{artifact_id}:{version}"
+    raise ValueError(f"No SHAFT dependency found in {pom}")
 
 
 def parse_dependency_list(text: str, repository: Path) -> list[dict[str, object]]:
@@ -149,7 +174,7 @@ def run_fixture(fixture: Path, jar: Path, keep_repositories: Path | None = None)
     manifest: dict[str, object] = {
         "schemaVersion": 1,
         "fixture": fixture.name,
-        "rootCoordinate": f"{PROJECT_COORDINATE}:{version}",
+        "rootCoordinate": fixture_root_coordinate(fixture / "pom.xml", version),
         "platform": {"system": platform.system(), "machine": platform.machine()},
         "artifactCount": len(artifacts),
         "artifactBytes": sum(int(artifact["compressedBytes"]) for artifact in artifacts),
@@ -173,16 +198,16 @@ def run_fixture(fixture: Path, jar: Path, keep_repositories: Path | None = None)
 def stable_manifest(manifest: dict[str, object]) -> dict[str, object]:
     ignored = {
         "artifactBytes", "elapsedSeconds", "repositoryBytes", "repositoryGrowthBytes",
-        "seededRepositoryBytes", "artifactsRef",
+        "seededRepositoryBytes", "artifactsRef", "rootCoordinate",
     }
     stable = {key: value for key, value in manifest.items() if key not in ignored}
     # The reactor migration rebuilds SHAFT itself; compare the downstream graph byte-for-byte
     # while validating the engine JAR separately by its entry list.
-    project_jar_prefix = f"{PROJECT_COORDINATE}:jar:"
+    project_jar_prefixes = tuple(f"{coordinate}:jar:" for coordinate in PROJECT_COORDINATES)
     if "artifacts" in stable:
         stable["artifacts"] = [
             artifact for artifact in stable["artifacts"]
-            if not str(artifact["coordinate"]).startswith(project_jar_prefix)
+            if not str(artifact["coordinate"]).startswith(project_jar_prefixes)
         ]
     return stable
 
@@ -245,14 +270,14 @@ def write_report(manifests: Iterable[dict[str, object]], destination: Path) -> N
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--fixture", action="append", help="fixture name; repeat to select multiple")
-    parser.add_argument("--jar", type=Path, help="SHAFT JAR; defaults to shaft-engine/target/SHAFT_ENGINE-<version>.jar")
+    parser.add_argument("--jar", type=Path, help="SHAFT JAR; defaults to shaft-engine/target/shaft-engine-<version>.jar")
     parser.add_argument("--record", action="store_true", help="replace committed manifests and report")
     parser.add_argument("--verify", action="store_true", help="compare against committed manifests")
     parser.add_argument("--output", type=Path, help="write generated manifests to this directory")
     parser.add_argument("--keep-repositories", type=Path, help="retain isolated repositories for diagnosis")
     args = parser.parse_args()
     version = project_version()
-    jar = (args.jar or ENGINE_ROOT / "target" / f"SHAFT_ENGINE-{version}.jar").resolve()
+    jar = (args.jar or ENGINE_ROOT / "target" / f"shaft-engine-{version}.jar").resolve()
     if not jar.is_file():
         parser.error(f"SHAFT JAR does not exist: {jar}; run mvn clean install -DskipTests -Dgpg.skip")
     selected = set(args.fixture or [])

--- a/scripts/ci/validate_reactor_versions.py
+++ b/scripts/ci/validate_reactor_versions.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Reject SHAFT reactor modules or BOM entries that diverge from the root version."""
+
+from __future__ import annotations
+
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+NAMESPACE = {"m": "http://maven.apache.org/POM/4.0.0"}
+SHAFT_GROUP = "io.github.shafthq"
+
+
+def text(element: ET.Element, path: str) -> str | None:
+    value = element.findtext(path, namespaces=NAMESPACE)
+    return value.strip() if value else None
+
+
+def validate_reactor_versions(root_pom: Path = ROOT / "pom.xml") -> list[str]:
+    root = ET.parse(root_pom).getroot()
+    root_version = text(root, "m:version")
+    if not root_version:
+        return [f"root project version is missing from {root_pom}"]
+
+    errors: list[str] = []
+    base = root_pom.parent
+    for module_name in root.findall("m:modules/m:module", NAMESPACE):
+        module_pom = base / (module_name.text or "").strip() / "pom.xml"
+        module = ET.parse(module_pom).getroot()
+        parent_group = text(module, "m:parent/m:groupId")
+        parent_version = text(module, "m:parent/m:version")
+        if parent_group != SHAFT_GROUP or parent_version != root_version:
+            errors.append(
+                f"{module_pom}: parent version {parent_version!r} does not match {root_version!r}"
+            )
+
+        shaft_dependencies = [
+            *module.findall("m:dependencies/m:dependency", NAMESPACE),
+            *module.findall("m:dependencyManagement/m:dependencies/m:dependency", NAMESPACE),
+        ]
+        for dependency in shaft_dependencies:
+            if text(dependency, "m:groupId") not in {SHAFT_GROUP, "${project.groupId}"}:
+                continue
+            dependency_version = text(dependency, "m:version")
+            if dependency_version not in {root_version, "${project.version}"}:
+                artifact_id = text(dependency, "m:artifactId")
+                errors.append(
+                    f"{module_pom}: {SHAFT_GROUP}:{artifact_id} version "
+                    f"{dependency_version!r} diverges from {root_version!r}"
+                )
+    return errors
+
+
+def main() -> int:
+    errors = validate_reactor_versions()
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    print("All SHAFT reactor modules and inter-module dependencies use the root project version.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/shaft-bom/pom.xml
+++ b/shaft-bom/pom.xml
@@ -1,0 +1,25 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.shafthq</groupId>
+        <artifactId>shaft-parent</artifactId>
+        <version>10.2.20260605</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>shaft-bom</artifactId>
+    <packaging>pom</packaging>
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>Dependency management BOM for SHAFT consumer artifacts.</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>shaft-engine</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/shaft-engine/pom.xml
+++ b/shaft-engine/pom.xml
@@ -7,7 +7,7 @@
         <version>10.2.20260605</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    <artifactId>SHAFT_ENGINE</artifactId>
+    <artifactId>shaft-engine</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>SHAFT is a unified test automation engine. Powered by best-in-class frameworks, SHAFT provides a
         wizard-like syntax to drive your automation efficiently, maximize your ROI, and minimize your learning curve.

--- a/shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
@@ -21,7 +21,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
-            <artifactId>SHAFT_ENGINE</artifactId>
+            <artifactId>shaft-engine</artifactId>
             <version>${shaft_engine.version}</version>
         </dependency>
         <dependency>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
@@ -20,7 +20,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
-            <artifactId>SHAFT_ENGINE</artifactId>
+            <artifactId>shaft-engine</artifactId>
             <version>${shaft_engine.version}</version>
         </dependency>
         <dependency>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
@@ -20,7 +20,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
-            <artifactId>SHAFT_ENGINE</artifactId>
+            <artifactId>shaft-engine</artifactId>
             <version>${shaft_engine.version}</version>
         </dependency>
         <dependency>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
@@ -20,7 +20,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
-            <artifactId>SHAFT_ENGINE</artifactId>
+            <artifactId>shaft-engine</artifactId>
             <version>${shaft_engine.version}</version>
         </dependency>
         <dependency>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
@@ -21,7 +21,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
-            <artifactId>SHAFT_ENGINE</artifactId>
+            <artifactId>shaft-engine</artifactId>
             <version>${shaft_engine.version}</version>
         </dependency>
         <dependency>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
@@ -21,7 +21,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
-            <artifactId>SHAFT_ENGINE</artifactId>
+            <artifactId>shaft-engine</artifactId>
             <version>${shaft_engine.version}</version>
         </dependency>
         <dependency>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
@@ -21,7 +21,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
-            <artifactId>SHAFT_ENGINE</artifactId>
+            <artifactId>shaft-engine</artifactId>
             <version>${shaft_engine.version}</version>
         </dependency>
         <dependency>

--- a/tests/scripts/test_measure_consumer_dependencies.py
+++ b/tests/scripts/test_measure_consumer_dependencies.py
@@ -8,6 +8,21 @@ import scripts.ci.measure_consumer_dependencies as measure
 
 
 class MeasureConsumerDependenciesTest(unittest.TestCase):
+    def test_fixture_root_coordinate_reads_direct_shaft_dependency(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            pom = Path(temp_dir) / "pom.xml"
+            pom.write_text(
+                """<project xmlns=\"http://maven.apache.org/POM/4.0.0\">
+                <dependencies><dependency><groupId>io.github.shafthq</groupId>
+                <artifactId>shaft-engine</artifactId></dependency></dependencies></project>""",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                measure.fixture_root_coordinate(pom, "1.2.3"),
+                "io.github.shafthq:shaft-engine:1.2.3",
+            )
+
     def test_parse_dependency_list_records_size_and_sha(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             repo = Path(temp_dir) / "repo"
@@ -94,21 +109,38 @@ The following files have been resolved:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             repository = root / "repository"
-            jar = root / "SHAFT_ENGINE.jar"
+            jar = root / "shaft-engine.jar"
             engine_pom = root / "shaft-engine-pom.xml"
+            bom_pom = root / "shaft-bom-pom.xml"
+            legacy_pom = root / "legacy-pom.xml"
             jar.write_bytes(b"jar")
             engine_pom.write_text("<project>engine</project>", encoding="utf-8")
+            bom_pom.write_text("<project>bom</project>", encoding="utf-8")
+            legacy_pom.write_text("<project>legacy</project>", encoding="utf-8")
             (root / "pom.xml").write_text("<project>parent</project>", encoding="utf-8")
 
-            with mock.patch.object(measure, "ENGINE_POM", engine_pom), mock.patch.object(measure, "ROOT", root):
+            with (
+                mock.patch.object(measure, "ENGINE_POM", engine_pom),
+                mock.patch.object(measure, "BOM_POM", bom_pom),
+                mock.patch.object(measure, "LEGACY_POM", legacy_pom),
+                mock.patch.object(measure, "ROOT", root),
+            ):
                 seeded_bytes = measure.seed_project_artifact(repository, jar, "1.2.3")
 
-            engine = repository / "io/github/shafthq/SHAFT_ENGINE/1.2.3"
+            engine = repository / "io/github/shafthq/shaft-engine/1.2.3"
             parent = repository / "io/github/shafthq/shaft-parent/1.2.3"
-            self.assertEqual((engine / "SHAFT_ENGINE-1.2.3.jar").read_bytes(), b"jar")
+            self.assertEqual((engine / "shaft-engine-1.2.3.jar").read_bytes(), b"jar")
             self.assertEqual(
-                (engine / "SHAFT_ENGINE-1.2.3.pom").read_text(encoding="utf-8"),
+                (engine / "shaft-engine-1.2.3.pom").read_text(encoding="utf-8"),
                 "<project>engine</project>",
+            )
+            self.assertEqual(
+                (repository / "io/github/shafthq/shaft-bom/1.2.3/shaft-bom-1.2.3.pom").read_text(encoding="utf-8"),
+                "<project>bom</project>",
+            )
+            self.assertEqual(
+                (repository / "io/github/shafthq/SHAFT_ENGINE/1.2.3/SHAFT_ENGINE-1.2.3.pom").read_text(encoding="utf-8"),
+                "<project>legacy</project>",
             )
             self.assertEqual(
                 (parent / "shaft-parent-1.2.3.pom").read_text(encoding="utf-8"),

--- a/tests/scripts/test_validate_reactor_versions.py
+++ b/tests/scripts/test_validate_reactor_versions.py
@@ -1,0 +1,53 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.ci.validate_reactor_versions import validate_reactor_versions
+
+
+class ValidateReactorVersionsTest(unittest.TestCase):
+    def write_pom(self, path: Path, contents: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents, encoding="utf-8")
+
+    def test_accepts_aligned_parent_and_bom_versions(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            root_pom = root / "pom.xml"
+            self.write_pom(root_pom, ROOT_POM)
+            self.write_pom(root / "module" / "pom.xml", MODULE_POM.replace("VERSION", "1.2.3"))
+
+            self.assertEqual(validate_reactor_versions(root_pom), [])
+
+    def test_rejects_divergent_module_and_managed_versions(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            root_pom = root / "pom.xml"
+            self.write_pom(root_pom, ROOT_POM)
+            self.write_pom(root / "module" / "pom.xml", MODULE_POM.replace("VERSION", "9.9.9"))
+
+            errors = validate_reactor_versions(root_pom)
+
+            self.assertEqual(len(errors), 2)
+            self.assertIn("parent version '9.9.9' does not match '1.2.3'", errors[0])
+            self.assertIn("version '9.9.9' diverges from '1.2.3'", errors[1])
+
+
+ROOT_POM = """<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.github.shafthq</groupId><artifactId>shaft-parent</artifactId><version>1.2.3</version>
+  <modules><module>module</module></modules>
+</project>"""
+
+MODULE_POM = """<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <parent><groupId>io.github.shafthq</groupId><artifactId>shaft-parent</artifactId><version>VERSION</version></parent>
+  <artifactId>shaft-bom</artifactId>
+  <dependencyManagement><dependencies><dependency>
+    <groupId>io.github.shafthq</groupId><artifactId>shaft-engine</artifactId><version>VERSION</version>
+  </dependency></dependencies></dependencyManagement>
+</project>"""
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/modularization/consumer-fixtures/README.md
+++ b/tools/modularization/consumer-fixtures/README.md
@@ -1,8 +1,9 @@
 # Downstream consumer fixtures
 
-These independent Maven projects compile representative downstream usage against the legacy
-`io.github.shafthq:SHAFT_ENGINE` coordinate. They intentionally do not share a parent POM so each can be
-copied and resolved in isolation.
+These independent Maven projects compile representative downstream usage against SHAFT. Most fixtures use the
+canonical `io.github.shafthq:shaft-engine` coordinate, `bom` imports `io.github.shafthq:shaft-bom` and declares a
+versionless engine dependency, and `legacy-coordinate` verifies the POM-only `io.github.shafthq:SHAFT_ENGINE`
+relocation path. They intentionally do not share a parent POM so each can be copied and resolved in isolation.
 
 Run the repository build first, then measure all fixtures with one empty temporary Maven repository each:
 
@@ -15,4 +16,4 @@ python3 scripts/ci/measure_consumer_dependencies.py --verify
 Use `--fixture <name>` for a focused run and `--keep-repositories <directory>` to preserve downloaded
 repositories for diagnosis. Verification compares every downstream artifact coordinate, scope, size, and checksum,
 while excluding the rebuilt SHAFT JAR itself; validate that JAR separately by comparing its sorted entry list. The
-committed baseline is under `docs/modularization/dependency-baseline/`.
+committed pre-modularization baseline is under `docs/modularization/dependency-baseline/`.

--- a/tools/modularization/consumer-fixtures/api/pom.xml
+++ b/tools/modularization/consumer-fixtures/api/pom.xml
@@ -13,7 +13,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
-            <artifactId>SHAFT_ENGINE</artifactId>
+            <artifactId>shaft-engine</artifactId>
             <version>${shaft.version}</version>
         </dependency>
     </dependencies>

--- a/tools/modularization/consumer-fixtures/appium-mobile/pom.xml
+++ b/tools/modularization/consumer-fixtures/appium-mobile/pom.xml
@@ -13,7 +13,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
-            <artifactId>SHAFT_ENGINE</artifactId>
+            <artifactId>shaft-engine</artifactId>
             <version>${shaft.version}</version>
         </dependency>
     </dependencies>

--- a/tools/modularization/consumer-fixtures/bom/pom.xml
+++ b/tools/modularization/consumer-fixtures/bom/pom.xml
@@ -3,18 +3,28 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.shafthq.modularization</groupId>
-    <artifactId>testng-web-consumer-fixture</artifactId>
+    <artifactId>bom-consumer-fixture</artifactId>
     <version>1.0.0</version>
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <shaft.version>10.2.20260605</shaft.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.github.shafthq</groupId>
+                <artifactId>shaft-bom</artifactId>
+                <version>${shaft.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
             <artifactId>shaft-engine</artifactId>
-            <version>${shaft.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/tools/modularization/consumer-fixtures/bom/src/test/java/fixture/BomConsumer.java
+++ b/tools/modularization/consumer-fixtures/bom/src/test/java/fixture/BomConsumer.java
@@ -1,0 +1,9 @@
+package fixture;
+
+import com.shaft.driver.SHAFT;
+
+public class BomConsumer {
+    public String versionlessEngineDependencySmokeTest() {
+        return SHAFT.class.getName();
+    }
+}

--- a/tools/modularization/consumer-fixtures/browserstack-sdk/pom.xml
+++ b/tools/modularization/consumer-fixtures/browserstack-sdk/pom.xml
@@ -13,7 +13,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
-            <artifactId>SHAFT_ENGINE</artifactId>
+            <artifactId>shaft-engine</artifactId>
             <version>${shaft.version}</version>
         </dependency>
     </dependencies>

--- a/tools/modularization/consumer-fixtures/desktop-video/pom.xml
+++ b/tools/modularization/consumer-fixtures/desktop-video/pom.xml
@@ -13,7 +13,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
-            <artifactId>SHAFT_ENGINE</artifactId>
+            <artifactId>shaft-engine</artifactId>
             <version>${shaft.version}</version>
         </dependency>
     </dependencies>

--- a/tools/modularization/consumer-fixtures/junit-web/pom.xml
+++ b/tools/modularization/consumer-fixtures/junit-web/pom.xml
@@ -13,7 +13,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
-            <artifactId>SHAFT_ENGINE</artifactId>
+            <artifactId>shaft-engine</artifactId>
             <version>${shaft.version}</version>
         </dependency>
     </dependencies>

--- a/tools/modularization/consumer-fixtures/opencv-visual/pom.xml
+++ b/tools/modularization/consumer-fixtures/opencv-visual/pom.xml
@@ -13,7 +13,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
-            <artifactId>SHAFT_ENGINE</artifactId>
+            <artifactId>shaft-engine</artifactId>
             <version>${shaft.version}</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Codex is the implementation agent for issue #2812. The authenticated token owner did not author these changes manually.

Closes #2812.

## Summary
- Renamed the engine artifact to the canonical `io.github.shafthq:shaft-engine` coordinate while preserving all `com.shaft` Java packages and retained dependencies.
- Added the POM-only `io.github.shafthq:shaft-bom` consumer BOM.
- Added a POM-only legacy `io.github.shafthq:SHAFT_ENGINE` relocation artifact pointing to `shaft-engine`.
- Added direct, BOM-managed, and legacy relocation consumer fixtures.
- Added a reactor version-alignment validator with pull-request, main-branch, and release gates.
- Updated sample projects and Maven documentation to use the canonical coordinate.

## PDCA execution
### Iteration 1 — smallest working reactor change
- **Plan:** preserve the existing engine module contents and change only published Maven topology.
- **Do:** renamed the engine artifact and added BOM and relocation POM modules.
- **Check:** ran Maven reactor validation and confirmed the four-module build order.
- **Act:** retained the engine directory and all dependencies to avoid Java/API or feature movement.

### Iteration 2 — consumer migration paths
- **Plan:** prove direct, BOM-managed, and legacy consumers compile independently.
- **Do:** migrated retained-surface fixtures to `shaft-engine`, added a versionless BOM fixture, and retained the legacy fixture.
- **Check:** compiled all three paths and confirmed Maven emits the relocation warning.
- **Act:** updated the isolated dependency measurement seeding logic for the canonical JAR, BOM, parent, and relocation POM.

### Iteration 3 — consistency, CI, and documentation
- **Plan:** prevent future reactor version drift and document the supported migration path.
- **Do:** added the version validator, unit tests, PR/main workflow, release gate, sample updates, and Maven reactor documentation.
- **Check:** ran Python tests, the validator, the mandatory Maven install, sample POM validation, XML parsing, and BOM dependency inspection.
- **Act:** made the release workflow fail before release creation when reactor versions diverge.

## Acceptance criteria
- [x] Importing `shaft-bom` downloads no optional feature modules; the BOM has dependency management only and `dependency:list` reports `none`.
- [x] A versionless `shaft-engine` dependency resolves and compiles when `shaft-bom` is imported.
- [x] The legacy coordinate resolves to `shaft-engine` and emits Maven's relocation warning.
- [x] Java package/API compatibility is preserved; no Java source or package names changed.
- [x] CI rejects divergent SHAFT module/inter-module versions.
- [x] API, Appium/mobile, database, and all other retained dependencies remain in `shaft-engine`.

## Validation
- `python3 -m unittest tests.scripts.test_validate_reactor_versions tests.scripts.test_measure_consumer_dependencies`
- `python3 scripts/ci/validate_reactor_versions.py`
- `mvn -q validate -DskipTests -Dgpg.skip`
- `mvn clean install -DskipTests -Dgpg.skip`
- `mvn --batch-mode --no-transfer-progress -f tools/modularization/consumer-fixtures/api/pom.xml -Dshaft.version=10.2.20260605 test-compile`
- `mvn --batch-mode --no-transfer-progress -f tools/modularization/consumer-fixtures/bom/pom.xml -Dshaft.version=10.2.20260605 test-compile`
- `mvn --batch-mode --no-transfer-progress -f tools/modularization/consumer-fixtures/legacy-coordinate/pom.xml -Dshaft.version=10.2.20260605 test-compile`
- `mvn --batch-mode --no-transfer-progress -f shaft-bom/pom.xml dependency:list -DexcludeTransitive=false -DoutputFile=/tmp/shaft-bom-dependencies.txt`
- Validated every sample project with `mvn -q -f <pom> validate`.
- Parsed all repository POMs with Python `xml.etree.ElementTree`.
