### PR TITLE
codex: extract BrowserStack SDK into shaft-browserstack

### DIFF
--- a/.github/workflows/e2eLambdaTestTests.yml
+++ b/.github/workflows/e2eLambdaTestTests.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 'lts/*'
       - name: Run tests
         continue-on-error: true
-        run: mvn -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=lambdatest" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*Test_LTMobAPK*.*]"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=lambdatest" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*Test_LTMobAPK*.*]"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -57,7 +57,7 @@ jobs:
           node-version: 'lts/*'
       - name: Run tests
         continue-on-error: true
-        run: mvn -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=lambdatest" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*Test_LTMobIPA*.*]"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=lambdatest" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*Test_LTMobIPA*.*]"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -86,7 +86,7 @@ jobs:
           node-version: 'lts/*'
       - name: Run tests
         continue-on-error: true
-        run: mvn -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=lambdatest" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*Test_LTWebApp*.*]"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=lambdatest" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*Test_LTWebApp*.*]"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -115,7 +115,7 @@ jobs:
           node-version: 'lts/*'
       - name: Run tests
         continue-on-error: true
-        run: mvn -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=lambdatest" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*Test_LTDesktopWeb.*], %regex[.*LambdaTestHelperUnitTest.*], %regex[.*LambdaTestSetPropertyCoverageUnitTest.*]"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=lambdatest" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*Test_LTDesktopWeb.*], %regex[.*LambdaTestHelperUnitTest.*], %regex[.*LambdaTestSetPropertyCoverageUnitTest.*]"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()

--- a/.github/workflows/e2eLocalTests.yml
+++ b/.github/workflows/e2eLocalTests.yml
@@ -47,7 +47,7 @@ jobs:
         run: (Get-Item (Get-Command msedge).Source).VersionInfo.ProductVersion
       - name: Run tests
         continue-on-error: true
-        run: mvn -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=WINDOWS" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=WINDOWS" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -75,7 +75,7 @@ jobs:
           node-version: '20'
       - name: Run tests
         continue-on-error: true
-        run: mvn -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=safari" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}, !%regex[.*MobileEmulation.*]"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=safari" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}, !%regex[.*MobileEmulation.*]"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -103,7 +103,7 @@ jobs:
           node-version: '20'
       - name: Run tests
         continue-on-error: true
-        run: mvn -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=WINDOWS" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=WINDOWS" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -131,7 +131,7 @@ jobs:
           node-version: '20'
       - name: Run tests
         continue-on-error: true
-        run: mvn -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -162,7 +162,7 @@ jobs:
         run: (Get-Item (Get-Command msedge).Source).VersionInfo.ProductVersion
       - name: Run tests
         continue-on-error: true
-        run: mvn -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=WINDOWS" "-DmaximumPerformanceMode=2" "-DtargetBrowserName=MicrosoftEdge" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*CucumberTests.*]"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=WINDOWS" "-DmaximumPerformanceMode=2" "-DtargetBrowserName=MicrosoftEdge" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*CucumberTests.*]"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()

--- a/.github/workflows/e2eMoonTests.yml
+++ b/.github/workflows/e2eMoonTests.yml
@@ -80,7 +80,7 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          mvn -e -Pjunit test \
+          mvn -e -Pjunit -pl shaft-engine -am test \
             "-DskipTestNG=true" \
             "-DdefaultElementIdentificationTimeout=5" \
             "-DretryMaximumNumberOfAttempts=1" \

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -70,7 +70,7 @@ jobs:
           node-version: '20'
       - name: Run tests
         continue-on-error: true
-        run: mvn -e test "-DretryMaximumNumberOfAttempts=2" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*DatabaseActions.*], %regex[.*DB.*], %regex[.*Db.*], %regex[.*db.*]"
+        run: mvn -pl shaft-engine -am -e test "-DretryMaximumNumberOfAttempts=2" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*DatabaseActions.*], %regex[.*DB.*], %regex[.*Db.*], %regex[.*db.*]"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -98,7 +98,7 @@ jobs:
           node-version: '20'
       - name: Run tests
         continue-on-error: true
-        run: mvn -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*API.*], %regex[.*Api.*], %regex[.*PathParamTest.*], %regex[.*SwaggerContractTest.*], %regex[.*uestBuilder.*], %regex[.*Rest.*], %regex[.*Json.*], %regex[.*JSON.*], %regex[.*json.*], %regex[.*YAML.*], %regex[.*Yaml.*], %regex[.*yaml.*], %regex[.*CLIWizard.*], %regex[.*TerminalActions.*], %regex[.*properties.Mobile.*], %regex[.*CSVFileManagerUnitTest.*], %regex[.*PdfFileManager.*], %regex[.*ExcelFileManager.*]"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*API.*], %regex[.*Api.*], %regex[.*PathParamTest.*], %regex[.*SwaggerContractTest.*], %regex[.*uestBuilder.*], %regex[.*Rest.*], %regex[.*Json.*], %regex[.*JSON.*], %regex[.*json.*], %regex[.*YAML.*], %regex[.*Yaml.*], %regex[.*yaml.*], %regex[.*CLIWizard.*], %regex[.*TerminalActions.*], %regex[.*properties.Mobile.*], %regex[.*CSVFileManagerUnitTest.*], %regex[.*PdfFileManager.*], %regex[.*ExcelFileManager.*]"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -132,7 +132,7 @@ jobs:
         run: docker ps
       - name: Run tests
         continue-on-error: true
-        run: mvn -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=firefox" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=firefox" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -166,7 +166,7 @@ jobs:
         run: docker ps
       - name: Run tests
         continue-on-error: true
-        run: mvn -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -200,7 +200,7 @@ jobs:
         run: docker ps
       - name: Run tests
         continue-on-error: true
-        run: mvn -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -229,7 +229,7 @@ jobs:
       - name: Run tests
         continue-on-error: true
         timeout-minutes: 40
-        run: mvn -e test "-DdefaultElementIdentificationTimeout=60" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=android" "-Dmobile_automationName=UIAutomator2" "-DbrowserStack.platformVersion=13.0" "-DbrowserStack.deviceName=Google Pixel 7" "-DbrowserStack.appUrl=" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*ndroid.*], %regex[.*FlutterTest.*], %regex[.*BrowserStackPropertiesUnitTest.*], %regex[.*BrowserStackHelperUnitTest.*], %regex[.*BrowserStackSdkHelperCoverageUnitTest.*]"
+        run: mvn -pl shaft-browserstack -am -e test "-DdefaultElementIdentificationTimeout=60" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=android" "-Dmobile_automationName=UIAutomator2" "-DbrowserStack.platformVersion=13.0" "-DbrowserStack.deviceName=Google Pixel 7" "-DbrowserStack.appUrl=" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*ndroid.*], %regex[.*FlutterTest.*], %regex[.*BrowserStackPropertiesUnitTest.*], %regex[.*BrowserStackHelperUnitTest.*], %regex[.*BrowserStackSdkHelperCoverageUnitTest.*]"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -257,7 +257,7 @@ jobs:
           node-version: '20'
       - name: Run tests
         continue-on-error: true
-        run: mvn -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=iOS" "-Dmobile_automationName=XCuiTest" "-DbrowserStack.osVersion=16" "-DbrowserStack.deviceName=iPhone 14" "-DbrowserName=safari" "-DbrowserStack.appName=" "-DbrowserStack.appRelativeFilePath=" "-DbrowserStack.appUrl=" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*MobileWebTest.*], %regex[.*IOSBasicInteractionsTest.*]"
+        run: mvn -pl shaft-browserstack -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=iOS" "-Dmobile_automationName=XCuiTest" "-DbrowserStack.osVersion=16" "-DbrowserStack.deviceName=iPhone 14" "-DbrowserName=safari" "-DbrowserStack.appName=" "-DbrowserStack.appRelativeFilePath=" "-DbrowserStack.appUrl=" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*MobileWebTest.*], %regex[.*IOSBasicInteractionsTest.*]"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -285,7 +285,7 @@ jobs:
           node-version: '20'
       - name: Run tests
         continue-on-error: true
-        run: mvn -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=android" "-Dmobile_automationName=UIAutomator2" "-DbrowserStack.osVersion=13.0" "-DbrowserStack.deviceName=Samsung Galaxy S23" "-DbrowserName=chrome" "-DbrowserStack.appName=" "-DbrowserStack.appRelativeFilePath=" "-DbrowserStack.appUrl=" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*MobileWebTest.*]"
+        run: mvn -pl shaft-browserstack -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=android" "-Dmobile_automationName=UIAutomator2" "-DbrowserStack.osVersion=13.0" "-DbrowserStack.deviceName=Samsung Galaxy S23" "-DbrowserName=chrome" "-DbrowserStack.appName=" "-DbrowserStack.appRelativeFilePath=" "-DbrowserStack.appUrl=" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*MobileWebTest.*]"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -313,7 +313,7 @@ jobs:
           node-version: '20'
       - name: Run tests
         continue-on-error: true
-        run: mvn -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=Safari" "-DbrowserStack.os=OS X" "-DbrowserStack.osVersion=Sonoma" "-DbrowserStack.browserVersion=17.0" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*BrowserActionsTests.*], %regex[.*BigPageActionsTest.*], %regex[.*BrowserStackPropertiesUnitTest.*], %regex[.*BrowserStackHelperUnitTest.*], %regex[.*BrowserStackSdkHelperCoverageUnitTest.*]"
+        run: mvn -pl shaft-browserstack -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=Safari" "-DbrowserStack.os=OS X" "-DbrowserStack.osVersion=Sonoma" "-DbrowserStack.browserVersion=17.0" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*BrowserActionsTests.*], %regex[.*BigPageActionsTest.*], %regex[.*BrowserStackPropertiesUnitTest.*], %regex[.*BrowserStackHelperUnitTest.*], %regex[.*BrowserStackSdkHelperCoverageUnitTest.*]"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -345,7 +345,7 @@ jobs:
         run: docker ps
       - name: Run tests
         continue-on-error: true
-        run: mvn -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DmaximumPerformanceMode=2" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*(CucumberTests|CucumberFeatureListenerUnitTest|CucumberTestRunnerListenerUnitTest).*]"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DmaximumPerformanceMode=2" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*(CucumberTests|CucumberFeatureListenerUnitTest|CucumberTestRunnerListenerUnitTest).*]"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -373,7 +373,7 @@ jobs:
           node-version: 'lts/*'
       - name: Run tests
         continue-on-error: true
-        run: mvn -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=Safari" "-DmaximumPerformanceMode=1" "-DbrowserStack.os=OS X" "-DbrowserStack.osVersion=Sonoma" "-DbrowserStack.browserVersion=17.0" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*CucumberTests.*]"
+        run: mvn -pl shaft-browserstack -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=Safari" "-DmaximumPerformanceMode=1" "-DbrowserStack.os=OS X" "-DbrowserStack.osVersion=Sonoma" "-DbrowserStack.browserVersion=17.0" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*CucumberTests.*]"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 
     <modules>
         <module>shaft-engine</module>
+        <module>shaft-browserstack</module>
         <module>shaft-bom</module>
         <module>legacy-shaft-engine</module>
     </modules>
@@ -59,6 +60,7 @@
         <log4j2.version>2.26.0</log4j2.version>
         <testng.version>7.12.0</testng.version>
         <appium.version>10.1.1</appium.version>
+        <browserstack.sdk.version>1.59.8</browserstack.sdk.version>
         <webdrivermanager.version>6.3.4</webdrivermanager.version>
         <aspectj.version>1.9.25.1</aspectj.version>
         <commons.csv.version>1.14.1</commons.csv.version>

--- a/scripts/ci/measure_consumer_dependencies.py
+++ b/scripts/ci/measure_consumer_dependencies.py
@@ -23,9 +23,12 @@ BASELINE_ROOT = ROOT / "docs" / "modularization" / "dependency-baseline"
 ENGINE_ROOT = ROOT / "shaft-engine"
 ENGINE_POM = ENGINE_ROOT / "pom.xml"
 BOM_POM = ROOT / "shaft-bom" / "pom.xml"
+BROWSERSTACK_ROOT = ROOT / "shaft-browserstack"
+BROWSERSTACK_POM = BROWSERSTACK_ROOT / "pom.xml"
 LEGACY_POM = ROOT / "legacy-shaft-engine" / "pom.xml"
 PROJECT_COORDINATES = (
     "io.github.shafthq:shaft-engine",
+    "io.github.shafthq:shaft-browserstack",
     "io.github.shafthq:SHAFT_ENGINE",
 )
 DEPENDENCY_LINE = re.compile(r"^\s*([^\s].*?):(/.*|[A-Za-z]:\\.*)$")
@@ -64,6 +67,13 @@ def seed_project_artifact(repository: Path, jar: Path, version: str) -> int:
     shutil.copy2(jar, engine_destination / f"shaft-engine-{version}.jar")
     shutil.copy2(ENGINE_POM, engine_destination / f"shaft-engine-{version}.pom")
     seed_pom(repository, "shaft-bom", BOM_POM, version)
+    browserstack_destination = repository / "io" / "github" / "shafthq" / "shaft-browserstack" / version
+    browserstack_destination.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(BROWSERSTACK_POM, browserstack_destination / f"shaft-browserstack-{version}.pom")
+    shutil.copy2(
+        BROWSERSTACK_ROOT / "target" / f"shaft-browserstack-{version}.jar",
+        browserstack_destination / f"shaft-browserstack-{version}.jar",
+    )
     seed_pom(repository, "SHAFT_ENGINE", LEGACY_POM, version)
     seed_pom(repository, "shaft-parent", ROOT / "pom.xml", version)
     return directory_bytes(repository)
@@ -130,8 +140,12 @@ def validate_required_artifacts(manifest: dict[str, object]) -> list[str]:
     errors: list[str] = []
     required = {
         "org.openpnp:opencv:jar:4.9.0-0": 109_619_828,
-        "com.browserstack:browserstack-java-sdk:jar:1.59.8": 38_204_017,
     }
+    browserstack_coordinate = "com.browserstack:browserstack-java-sdk:jar:1.59.8"
+    if manifest.get("fixture") == "browserstack-sdk":
+        required[browserstack_coordinate] = 38_204_017
+    elif browserstack_coordinate in artifacts:
+        errors.append(f"forbidden artifact {browserstack_coordinate}")
     for coordinate, expected_bytes in required.items():
         artifact = artifacts.get(coordinate)
         if artifact is None:

--- a/shaft-bom/pom.xml
+++ b/shaft-bom/pom.xml
@@ -20,6 +20,11 @@
                 <artifactId>shaft-engine</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>shaft-browserstack</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/shaft-browserstack/pom.xml
+++ b/shaft-browserstack/pom.xml
@@ -1,0 +1,62 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.shafthq</groupId>
+        <artifactId>shaft-parent</artifactId>
+        <version>10.2.20260605</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>shaft-browserstack</artifactId>
+    <packaging>jar</packaging>
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>Optional BrowserStack SDK integration for SHAFT Engine.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>shaft-engine</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.browserstack</groupId>
+            <artifactId>browserstack-java-sdk</artifactId>
+            <version>${browserstack.sdk.version}</version>
+            <exclusions>
+                <!-- Rely on SHAFT-controlled direct dependencies to avoid old transitive duplicates. -->
+                <exclusion>
+                    <groupId>org.seleniumhq.selenium</groupId>
+                    <artifactId>selenium-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.appium</groupId>
+                    <artifactId>java-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.testng</groupId>
+                    <artifactId>testng</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.aeonbits.owner</groupId>
+                    <artifactId>owner-java8</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jsoup</groupId>
+                    <artifactId>jsoup</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/shaft-browserstack/pom.xml
+++ b/shaft-browserstack/pom.xml
@@ -48,15 +48,8 @@
             </exclusions>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <properties>
+        <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
+    </properties>
+
 </project>

--- a/shaft-engine/pom.xml
+++ b/shaft-engine/pom.xml
@@ -639,37 +639,6 @@
             <version>${snakeyaml.version}</version>
         </dependency>
 
-        <!-- BROWSERSTACK SDK -->
-        <dependency>
-            <groupId>com.browserstack</groupId>
-            <artifactId>browserstack-java-sdk</artifactId>
-            <version>1.59.8</version>
-            <scope>runtime</scope>
-            <exclusions>
-                <!-- Rely on SHAFT-controlled direct dependencies to avoid old transitive duplicates -->
-                <exclusion>
-                    <groupId>org.seleniumhq.selenium</groupId>
-                    <artifactId>selenium-java</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.appium</groupId>
-                    <artifactId>java-client</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.testng</groupId>
-                    <artifactId>testng</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.aeonbits.owner</groupId>
-                    <artifactId>owner-java8</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jsoup</groupId>
-                    <artifactId>jsoup</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <!-- https://mvnrepository.com/artifact/org.aeonbits.owner/owner -->
         <dependency>
             <groupId>org.aeonbits.owner</groupId>
@@ -859,10 +828,6 @@
                         </dependencies>
                         <configuration>
                             <encoding>UTF-8</encoding>
-                            <!-- Exclude optional BrowserStack SDK from default test runtime to avoid AspectJ instrumentation noise in local/CI runs. -->
-                            <classpathDependencyExcludes>
-                                <classpathDependencyExclude>com.browserstack:browserstack-java-sdk</classpathDependencyExclude>
-                            </classpathDependencyExcludes>
                             <!-- Exclude intentionally-failing visual-demo tests from default CI runs.
                                  Run them explicitly with -Dgroups=allure3-visual-demo when needed,
                                  or override -Dsurefire.excludedGroups to customize exclusions. -->
@@ -928,10 +893,6 @@
                         </dependencies>
                         <configuration>
                             <encoding>UTF-8</encoding>
-                            <!-- Exclude optional BrowserStack SDK from default test runtime to avoid AspectJ instrumentation noise in local/CI runs. -->
-                            <classpathDependencyExcludes>
-                                <classpathDependencyExclude>com.browserstack:browserstack-java-sdk</classpathDependencyExclude>
-                            </classpathDependencyExcludes>
                             <systemPropertyVariables>
                                 <testng.dtd.http>true</testng.dtd.http>
                                 <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>

--- a/tests/scripts/test_browserstack_module_boundary.py
+++ b/tests/scripts/test_browserstack_module_boundary.py
@@ -1,0 +1,92 @@
+import json
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+NAMESPACE = {"m": "http://maven.apache.org/POM/4.0.0"}
+BROWSERSTACK_SDK = ("com.browserstack", "browserstack-java-sdk")
+
+
+def dependencies(pom: Path) -> dict[tuple[str, str], ET.Element]:
+    root = ET.parse(pom).getroot()
+    return {
+        (
+            dependency.findtext("m:groupId", namespaces=NAMESPACE),
+            dependency.findtext("m:artifactId", namespaces=NAMESPACE),
+        ): dependency
+        for dependency in root.findall("m:dependencies/m:dependency", NAMESPACE)
+    }
+
+
+class BrowserStackModuleBoundaryTest(unittest.TestCase):
+    def test_engine_is_lean_and_retains_appium(self):
+        engine_dependencies = dependencies(ROOT / "shaft-engine" / "pom.xml")
+
+        self.assertNotIn(BROWSERSTACK_SDK, engine_dependencies)
+        self.assertIn(("io.appium", "java-client"), engine_dependencies)
+
+    def test_optional_module_provides_engine_and_browserstack_sdk(self):
+        module_pom = ROOT / "shaft-browserstack" / "pom.xml"
+        module = ET.parse(module_pom).getroot()
+        module_dependencies = dependencies(module_pom)
+
+        self.assertEqual(module.findtext("m:packaging", namespaces=NAMESPACE), "jar")
+        self.assertIn(("${project.groupId}", "shaft-engine"), module_dependencies)
+        self.assertIn(BROWSERSTACK_SDK, module_dependencies)
+
+    def test_bom_and_consumer_fixture_use_optional_module(self):
+        bom = ET.parse(ROOT / "shaft-bom" / "pom.xml").getroot()
+        managed_artifacts = {
+            dependency.findtext("m:artifactId", namespaces=NAMESPACE)
+            for dependency in bom.findall(
+                "m:dependencyManagement/m:dependencies/m:dependency", NAMESPACE
+            )
+        }
+        fixture_dependencies = dependencies(
+            ROOT / "tools/modularization/consumer-fixtures/browserstack-sdk/pom.xml"
+        )
+
+        self.assertIn("shaft-browserstack", managed_artifacts)
+        self.assertIn(("io.github.shafthq", "shaft-browserstack"), fixture_dependencies)
+
+    def test_workflows_resolve_sdk_only_for_browserstack_jobs(self):
+        workflows = [
+            ROOT / ".github/workflows/e2eTests.yml",
+            ROOT / ".github/workflows/e2eLocalTests.yml",
+            ROOT / ".github/workflows/e2eLambdaTestTests.yml",
+        ]
+        commands = [
+            line.strip()
+            for workflow in workflows
+            for line in workflow.read_text(encoding="utf-8").splitlines()
+            if "run: mvn " in line
+        ]
+
+        self.assertTrue(commands)
+        for command in commands:
+            if "-DexecutionAddress=browserstack" in command:
+                self.assertIn("-pl shaft-browserstack -am", command)
+            else:
+                self.assertIn("-pl shaft-engine -am", command)
+                self.assertNotIn("shaft-browserstack", command)
+
+    def test_direct_cold_cache_saving_meets_issue_threshold(self):
+        baseline = json.loads(
+            (ROOT / "docs/modularization/dependency-baseline/manifests/artifacts.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        browserstack = next(
+            artifact
+            for artifact in baseline["artifacts"]
+            if artifact["coordinate"]
+            == "com.browserstack:browserstack-java-sdk:jar:1.59.8"
+        )
+
+        self.assertGreaterEqual(browserstack["compressedBytes"], 38_204_017)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_browserstack_module_boundary.py
+++ b/tests/scripts/test_browserstack_module_boundary.py
@@ -60,12 +60,13 @@ class BrowserStackModuleBoundaryTest(unittest.TestCase):
             ROOT / ".github/workflows/e2eTests.yml",
             ROOT / ".github/workflows/e2eLocalTests.yml",
             ROOT / ".github/workflows/e2eLambdaTestTests.yml",
+            ROOT / ".github/workflows/e2eMoonTests.yml",
         ]
         commands = [
             line.strip()
             for workflow in workflows
             for line in workflow.read_text(encoding="utf-8").splitlines()
-            if "run: mvn " in line
+            if "mvn " in line
         ]
 
         self.assertTrue(commands)

--- a/tests/scripts/test_browserstack_module_boundary.py
+++ b/tests/scripts/test_browserstack_module_boundary.py
@@ -33,6 +33,10 @@ class BrowserStackModuleBoundaryTest(unittest.TestCase):
         module_dependencies = dependencies(module_pom)
 
         self.assertEqual(module.findtext("m:packaging", namespaces=NAMESPACE), "jar")
+        self.assertEqual(
+            module.findtext("m:properties/m:surefire.failIfNoSpecifiedTests", namespaces=NAMESPACE),
+            "false",
+        )
         self.assertIn(("${project.groupId}", "shaft-engine"), module_dependencies)
         self.assertIn(BROWSERSTACK_SDK, module_dependencies)
 

--- a/tests/scripts/test_measure_consumer_dependencies.py
+++ b/tests/scripts/test_measure_consumer_dependencies.py
@@ -62,6 +62,7 @@ The following files have been resolved:
 
     def test_validate_required_artifacts_checks_key_baseline_sizes(self):
         manifest = {
+            "fixture": "browserstack-sdk",
             "artifacts": [
                 {"coordinate": "org.openpnp:opencv:jar:4.9.0-0", "compressedBytes": 109_619_828},
                 {"coordinate": "com.browserstack:browserstack-java-sdk:jar:1.59.8", "compressedBytes": 38_204_017},
@@ -75,10 +76,29 @@ The following files have been resolved:
         ):
             self.assertEqual(measure.validate_required_artifacts(manifest), [])
 
+    def test_validate_required_artifacts_rejects_browserstack_from_lean_fixture(self):
+        manifest = {
+            "fixture": "testng-web",
+            "artifacts": [
+                {"coordinate": "org.openpnp:opencv:jar:4.9.0-0", "compressedBytes": 109_619_828},
+                {"coordinate": "com.browserstack:browserstack-java-sdk:jar:1.59.8", "compressedBytes": 38_204_017},
+                {"coordinate": "ws.schild:jave-nativebin-linux64:jar:3.5.0", "compressedBytes": 28_201_169},
+            ],
+        }
+        with mock.patch.object(
+            measure,
+            "expected_jave_coordinate",
+            return_value="ws.schild:jave-nativebin-linux64:jar:3.5.0",
+        ):
+            self.assertEqual(
+                measure.validate_required_artifacts(manifest),
+                ["forbidden artifact com.browserstack:browserstack-java-sdk:jar:1.59.8"],
+            )
+
     def test_verify_manifest_ignores_observational_timing_and_repository_growth(self):
         expected = {
             "schemaVersion": 1,
-            "fixture": "sample",
+            "fixture": "browserstack-sdk",
             "artifactCount": 3,
             "artifactBytes": 147_823_045,
             "elapsedSeconds": 1.0,
@@ -112,16 +132,25 @@ The following files have been resolved:
             jar = root / "shaft-engine.jar"
             engine_pom = root / "shaft-engine-pom.xml"
             bom_pom = root / "shaft-bom-pom.xml"
+            browserstack_root = root / "shaft-browserstack"
+            browserstack_pom = browserstack_root / "pom.xml"
+            browserstack_jar = browserstack_root / "target" / "shaft-browserstack-1.2.3.jar"
             legacy_pom = root / "legacy-pom.xml"
             jar.write_bytes(b"jar")
             engine_pom.write_text("<project>engine</project>", encoding="utf-8")
             bom_pom.write_text("<project>bom</project>", encoding="utf-8")
+            browserstack_pom.parent.mkdir(parents=True)
+            browserstack_pom.write_text("<project>browserstack</project>", encoding="utf-8")
+            browserstack_jar.parent.mkdir(parents=True)
+            browserstack_jar.write_bytes(b"browserstack-jar")
             legacy_pom.write_text("<project>legacy</project>", encoding="utf-8")
             (root / "pom.xml").write_text("<project>parent</project>", encoding="utf-8")
 
             with (
                 mock.patch.object(measure, "ENGINE_POM", engine_pom),
                 mock.patch.object(measure, "BOM_POM", bom_pom),
+                mock.patch.object(measure, "BROWSERSTACK_ROOT", browserstack_root),
+                mock.patch.object(measure, "BROWSERSTACK_POM", browserstack_pom),
                 mock.patch.object(measure, "LEGACY_POM", legacy_pom),
                 mock.patch.object(measure, "ROOT", root),
             ):
@@ -137,6 +166,14 @@ The following files have been resolved:
             self.assertEqual(
                 (repository / "io/github/shafthq/shaft-bom/1.2.3/shaft-bom-1.2.3.pom").read_text(encoding="utf-8"),
                 "<project>bom</project>",
+            )
+            self.assertEqual(
+                (repository / "io/github/shafthq/shaft-browserstack/1.2.3/shaft-browserstack-1.2.3.pom").read_text(encoding="utf-8"),
+                "<project>browserstack</project>",
+            )
+            self.assertEqual(
+                (repository / "io/github/shafthq/shaft-browserstack/1.2.3/shaft-browserstack-1.2.3.jar").read_bytes(),
+                b"browserstack-jar",
             )
             self.assertEqual(
                 (repository / "io/github/shafthq/SHAFT_ENGINE/1.2.3/SHAFT_ENGINE-1.2.3.pom").read_text(encoding="utf-8"),

--- a/tools/modularization/consumer-fixtures/README.md
+++ b/tools/modularization/consumer-fixtures/README.md
@@ -2,7 +2,7 @@
 
 These independent Maven projects compile representative downstream usage against SHAFT. Most fixtures use the
 canonical `io.github.shafthq:shaft-engine` coordinate, `bom` imports `io.github.shafthq:shaft-bom` and declares a
-versionless engine dependency, and `legacy-coordinate` verifies the POM-only `io.github.shafthq:SHAFT_ENGINE`
+versionless engine dependency, `browserstack-sdk` uses the optional `io.github.shafthq:shaft-browserstack` integration, and `legacy-coordinate` verifies the POM-only `io.github.shafthq:SHAFT_ENGINE`
 relocation path. They intentionally do not share a parent POM so each can be copied and resolved in isolation.
 
 Run the repository build first, then measure all fixtures with one empty temporary Maven repository each:

--- a/tools/modularization/consumer-fixtures/browserstack-sdk/pom.xml
+++ b/tools/modularization/consumer-fixtures/browserstack-sdk/pom.xml
@@ -13,7 +13,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
-            <artifactId>shaft-engine</artifactId>
+            <artifactId>shaft-browserstack</artifactId>
             <version>${shaft.version}</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Implementation agent
Codex implemented this change. The authenticated token owner did not author these changes manually.

Closes #2813

## Summary
- Added the publishable `io.github.shafthq:shaft-browserstack` dependency-carrier JAR with aligned `shaft-engine` and `browserstack-java-sdk` dependencies.
- Removed `com.browserstack:browserstack-java-sdk` and obsolete Surefire classpath exclusions from `shaft-engine`; Appium, BrowserStack properties, capability construction, and YAML generation remain in the engine.
- Added `shaft-browserstack` to the reactor and `shaft-bom`.
- Moved the SDK-importing downstream consumer fixture to `shaft-browserstack` and taught isolated-repository measurement seeding about the new artifact.
- Updated BrowserStack E2E jobs to select `shaft-browserstack`; local/Grid/LambdaTest/Moon/non-BrowserStack jobs select only `shaft-engine`.
- Added structural tests for the module boundary, BOM/fixture wiring, CI project selection, retained Appium support, and the 38,204,017-byte direct-saving threshold.

## PDCA iterations
### Iteration 1 — minimal extraction
- **Plan:** Prove a dependency-only integration is sufficient because engine source has no BrowserStack SDK bytecode references.
- **Do:** Added the module, removed the engine dependency, updated BOM/fixture/workflows, and added boundary tests.
- **Check:** Dependency trees showed an empty engine BrowserStack tree and the SDK under the optional module.
- **Act:** A consumer probe showed that POM packaging cannot satisfy normal JAR dependency syntax, so the module was refined to an intentionally empty dependency-carrier JAR without bootstrap code.

### Iteration 2 — consumer and test-selection hardening
- **Plan:** Verify direct SDK imports and reactor-selected BrowserStack tests.
- **Do:** Seeded both the optional POM and JAR for cold-cache fixtures and disabled false no-specified-test failures in the empty integration module.
- **Check:** The consumer fixture compiled; 8 focused BrowserStack helper tests passed with 8 populated/passed Allure results.
- **Act:** Replaced plugin-local configuration with the Surefire property to avoid an unversioned-plugin effective-model warning.

### Iteration 3 — graph isolation and maintainability
- **Plan:** Ensure every named non-BrowserStack cloud/local workflow avoids the optional module, including multiline commands.
- **Do:** Scoped Moon to `shaft-engine` and expanded workflow boundary coverage.
- **Check:** Isolated cold-cache measurement resolved 340 artifacts for `testng-web` with no BrowserStack SDK; the BrowserStack fixture resolved the exact 38,204,017-byte SDK JAR.
- **Act:** Kept full-reactor install behavior for publication while making test jobs explicitly module-scoped.

## Validation
- `python3 -m unittest discover -s tests/scripts -p 'test_*.py'` — 47 passed.
- `python3 scripts/ci/validate_reactor_versions.py` — aligned.
- `mvn -pl shaft-browserstack -am test -Dtest=BrowserStackSdkHelperCoverageUnitTest -Dgpg.skip` — 8 passed; 8 Allure results, all passed.
- `mvn clean install -DskipTests -Dgpg.skip` — full five-module reactor build passed.
- `mvn -f tools/modularization/consumer-fixtures/browserstack-sdk/pom.xml clean test` — SDK-importing consumer compiled.
- `python3 scripts/ci/measure_consumer_dependencies.py --fixture browserstack-sdk --output /tmp/shaft-browserstack-measure` — SDK resolved from the optional module at 38,204,017 bytes.
- `python3 scripts/ci/measure_consumer_dependencies.py --fixture testng-web --output /tmp/shaft-lean-measure` — BrowserStack SDK absent.

## Runtime evidence and risk
- Existing BrowserStack jobs previously excluded the SDK from the engine Surefire classpath, while SHAFT's direct URL/capability/YAML behavior remained functional. No engine source imports BrowserStack SDK classes, so no bootstrap/provider or missing-SDK failure path is required.
- Credentialed BrowserStack E2E execution remains a GitHub Actions validation because cloud credentials are not exposed locally.
