### PR TITLE
codex: separate Appium and desktop video recording

### DIFF
--- a/shaft-engine/pom.xml
+++ b/shaft-engine/pom.xml
@@ -710,6 +710,10 @@
                 <targetPath>${project.basedir}/target/classes/resources/properties/default</targetPath>
             </resource>
             <resource>
+                <directory>${project.basedir}/src/main/resources/META-INF</directory>
+                <targetPath>${project.build.outputDirectory}/META-INF</targetPath>
+            </resource>
+            <resource>
                 <directory>${project.basedir}/src/main/javadoc</directory>
                 <targetPath>${project.reporting.outputDirectory}</targetPath>
             </resource>

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/video/AutomationRemarksDesktopVideoRecordingProvider.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/video/AutomationRemarksDesktopVideoRecordingProvider.java
@@ -1,0 +1,103 @@
+package com.shaft.gui.internal.video;
+
+import com.automation.remarks.video.RecorderFactory;
+import com.automation.remarks.video.RecordingUtils;
+import com.automation.remarks.video.enums.RecorderType;
+import com.automation.remarks.video.enums.VideoSaveMode;
+import com.automation.remarks.video.recorder.IVideoRecorder;
+import com.shaft.properties.internal.ThreadLocalPropertiesManager;
+import com.shaft.tools.io.internal.ReportManagerHelper;
+import org.apache.log4j.BasicConfigurator;
+import ws.schild.jave.Encoder;
+import ws.schild.jave.EncoderException;
+import ws.schild.jave.MultimediaObject;
+import ws.schild.jave.encode.AudioAttributes;
+import ws.schild.jave.encode.EncodingAttributes;
+import ws.schild.jave.encode.VideoAttributes;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Desktop video provider backed by Automation Remarks and JAVE.
+ *
+ * <p>This implementation remains in {@code shaft-engine} until the dependency extraction performed by the
+ * {@code shaft-video} module work. Keeping all optional-library types in this class allows engine orchestration and
+ * listeners to depend only on {@link DesktopVideoRecordingProvider}.</p>
+ */
+public class AutomationRemarksDesktopVideoRecordingProvider implements DesktopVideoRecordingProvider {
+    private final ThreadLocal<IVideoRecorder> recorder = new ThreadLocal<>();
+
+    /**
+     * Starts a Monte desktop recording for the current test thread.
+     */
+    @Override
+    public void startRecording() {
+        if (recorder.get() != null) {
+            return;
+        }
+
+        BasicConfigurator.configure();
+        ThreadLocalPropertiesManager.setGlobalProperty("video.save.mode", VideoSaveMode.ALL.name());
+        ThreadLocalPropertiesManager.setGlobalProperty("video.folder", "target/video");
+        recorder.set(RecorderFactory.getRecorder(RecorderType.MONTE));
+        recorder.get().start();
+    }
+
+    /**
+     * Stops, processes, and MP4-encodes the current thread's desktop recording.
+     *
+     * @param testPassed whether the current test passed
+     * @param recordingName unique name to use when saving the recording
+     * @return the encoded recording, or {@code null} when it cannot be read
+     */
+    @Override
+    public InputStream stopRecording(boolean testPassed, String recordingName) {
+        IVideoRecorder activeRecorder = recorder.get();
+        if (activeRecorder == null) {
+            return null;
+        }
+
+        try {
+            String recordingPath = RecordingUtils.doVideoProcessing(testPassed,
+                    activeRecorder.stopAndSave(recordingName));
+            return new FileInputStream(encodeRecording(recordingPath));
+        } catch (IOException exception) {
+            ReportManagerHelper.logDiscrete(exception);
+            return null;
+        } finally {
+            recorder.remove();
+        }
+    }
+
+    /**
+     * Reports whether a desktop recording is active for the current test thread.
+     *
+     * @return {@code true} when recording; otherwise {@code false}
+     */
+    @Override
+    public boolean isRecording() {
+        return recorder.get() != null;
+    }
+
+    @SuppressWarnings("SpellCheckingInspection")
+    private File encodeRecording(String recordingPath) {
+        File source = new File(recordingPath);
+        File target = new File(recordingPath.replace("avi", "mp4"));
+        try {
+            AudioAttributes audio = new AudioAttributes();
+            audio.setCodec("libvorbis");
+            VideoAttributes video = new VideoAttributes();
+            EncodingAttributes attributes = new EncodingAttributes();
+            attributes.setOutputFormat("mp4");
+            attributes.setAudioAttributes(audio);
+            attributes.setVideoAttributes(video);
+            new Encoder().encode(new MultimediaObject(source), target, attributes);
+        } catch (EncoderException exception) {
+            ReportManagerHelper.logDiscrete(exception);
+        }
+        return target;
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/video/DesktopVideoRecordingProvider.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/video/DesktopVideoRecordingProvider.java
@@ -1,0 +1,32 @@
+package com.shaft.gui.internal.video;
+
+import java.io.InputStream;
+
+/**
+ * SHAFT-owned contract for desktop screen-recording implementations.
+ *
+ * <p>Implementations may use optional recording and encoding libraries, but callers in
+ * {@code shaft-engine} interact only with JDK and SHAFT-owned types through this interface.</p>
+ */
+public interface DesktopVideoRecordingProvider {
+    /**
+     * Starts recording the desktop for the current test thread.
+     */
+    void startRecording();
+
+    /**
+     * Stops the active desktop recording and returns its encoded contents.
+     *
+     * @param testPassed whether the current test passed, used by providers that conditionally retain recordings
+     * @param recordingName unique name to use when saving the recording
+     * @return the encoded recording, or {@code null} when no recording is available
+     */
+    InputStream stopRecording(boolean testPassed, String recordingName);
+
+    /**
+     * Reports whether this provider is recording on the current test thread.
+     *
+     * @return {@code true} when a desktop recording is active; otherwise {@code false}
+     */
+    boolean isRecording();
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistry.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistry.java
@@ -1,0 +1,43 @@
+package com.shaft.gui.internal.video;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+final class DesktopVideoRecordingProviderRegistry {
+    private static volatile DesktopVideoRecordingProvider providerOverride;
+
+    private DesktopVideoRecordingProviderRegistry() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static Optional<DesktopVideoRecordingProvider> findProvider() {
+        if (providerOverride != null) {
+            return Optional.of(providerOverride);
+        }
+
+        List<DesktopVideoRecordingProvider> providers = ServiceLoader.load(DesktopVideoRecordingProvider.class)
+                .stream()
+                .map(ServiceLoader.Provider::get)
+                .sorted(Comparator.comparing(provider -> provider.getClass().getName()))
+                .toList();
+        if (providers.size() > 1) {
+            String providerNames = providers.stream()
+                    .map(provider -> provider.getClass().getName())
+                    .sorted()
+                    .reduce((left, right) -> left + ", " + right)
+                    .orElse("");
+            throw new IllegalStateException("Multiple desktop video recording providers were found: " + providerNames);
+        }
+        return providers.stream().findFirst();
+    }
+
+    static void setProviderForTesting(DesktopVideoRecordingProvider provider) {
+        providerOverride = provider;
+    }
+
+    static void resetProviderForTesting() {
+        providerOverride = null;
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistry.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistry.java
@@ -6,15 +6,15 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 
 final class DesktopVideoRecordingProviderRegistry {
-    private static volatile DesktopVideoRecordingProvider providerOverride;
+    private static final ThreadLocal<Optional<DesktopVideoRecordingProvider>> providerOverride = new ThreadLocal<>();
 
     private DesktopVideoRecordingProviderRegistry() {
         throw new IllegalStateException("Utility class");
     }
 
     static Optional<DesktopVideoRecordingProvider> findProvider() {
-        if (providerOverride != null) {
-            return Optional.of(providerOverride);
+        if (providerOverride.get() != null) {
+            return providerOverride.get();
         }
 
         List<DesktopVideoRecordingProvider> providers = ServiceLoader.load(DesktopVideoRecordingProvider.class)
@@ -34,10 +34,10 @@ final class DesktopVideoRecordingProviderRegistry {
     }
 
     static void setProviderForTesting(DesktopVideoRecordingProvider provider) {
-        providerOverride = provider;
+        providerOverride.set(Optional.ofNullable(provider));
     }
 
     static void resetProviderForTesting() {
-        providerOverride = null;
+        providerOverride.remove();
     }
 }

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/video/RecordManager.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/video/RecordManager.java
@@ -39,12 +39,12 @@ public class RecordManager {
     }
 
     //TODO: the animated GIF should follow the same path as the video
-    @SuppressWarnings("SpellCheckingInspection")
     /**
      * Starts Appium-native recording for mobile execution or falls back to desktop recording for local desktop drivers.
      *
      * @param driver the active WebDriver instance, or {@code null} to request desktop recording directly
      */
+    @SuppressWarnings("SpellCheckingInspection")
     public static void startVideoRecording(WebDriver driver) {
         if (SHAFT.Properties.visuals.videoParamsRecordVideo()
                 && !isRecordingStarted

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/video/RecordManager.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/video/RecordManager.java
@@ -1,13 +1,7 @@
 package com.shaft.gui.internal.video;
 
-import com.automation.remarks.video.RecorderFactory;
-import com.automation.remarks.video.RecordingUtils;
-import com.automation.remarks.video.enums.RecorderType;
-import com.automation.remarks.video.enums.VideoSaveMode;
-import com.automation.remarks.video.recorder.IVideoRecorder;
 import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
-import com.shaft.properties.internal.ThreadLocalPropertiesManager;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import io.appium.java_client.android.AndroidDriver;
@@ -15,25 +9,28 @@ import io.appium.java_client.android.AndroidStartScreenRecordingOptions;
 import io.appium.java_client.ios.IOSDriver;
 import io.appium.java_client.ios.IOSStartScreenRecordingOptions;
 import org.apache.commons.io.FileUtils;
-import org.apache.log4j.BasicConfigurator;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
-import ws.schild.jave.Encoder;
-import ws.schild.jave.EncoderException;
-import ws.schild.jave.MultimediaObject;
-import ws.schild.jave.encode.AudioAttributes;
-import ws.schild.jave.encode.EncodingAttributes;
-import ws.schild.jave.encode.VideoAttributes;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Base64;
 
+/**
+ * Orchestrates SHAFT video recording for desktop browsers and Appium native sessions.
+ *
+ * <p>Desktop recording is delegated through {@link DesktopVideoRecordingProvider}; Android and iOS recording remain
+ * driver-native so mobile users do not need the optional desktop video implementation.</p>
+ */
 public class RecordManager {
-    private static final ThreadLocal<IVideoRecorder> recorder = new ThreadLocal<>();
+    private static final String MISSING_DESKTOP_PROVIDER_MESSAGE = "Desktop video recording is enabled, but no provider "
+            + "is available. Add io.github.shafthq:shaft-video to the test runtime dependencies.";
     private static final ThreadLocal<WebDriver> videoDriver = new ThreadLocal<>();
     private static boolean isRecordingStarted = false;
 
@@ -43,6 +40,11 @@ public class RecordManager {
 
     //TODO: the animated GIF should follow the same path as the video
     @SuppressWarnings("SpellCheckingInspection")
+    /**
+     * Starts Appium-native recording for mobile execution or falls back to desktop recording for local desktop drivers.
+     *
+     * @param driver the active WebDriver instance, or {@code null} to request desktop recording directly
+     */
     public static void startVideoRecording(WebDriver driver) {
         if (SHAFT.Properties.visuals.videoParamsRecordVideo()
                 && !isRecordingStarted
@@ -72,20 +74,32 @@ public class RecordManager {
                 && !(driver instanceof RemoteWebDriver);
     }
 
+    /**
+     * Starts desktop screen recording when video recording is enabled for local non-headless execution.
+     *
+     * @throws IllegalStateException when desktop recording is requested but no desktop provider is available
+     */
     public static void startVideoRecording() {
-        if (SHAFT.Properties.visuals.videoParamsRecordVideo()
-                && SHAFT.Properties.platform.executionAddress().equals("local")
-                && !SHAFT.Properties.web.headlessExecution()
-                && recorder.get() == null) {
-            BasicConfigurator.configure();
-            ThreadLocalPropertiesManager.setGlobalProperty("video.save.mode", VideoSaveMode.ALL.name());
-            ThreadLocalPropertiesManager.setGlobalProperty("video.folder", "target/video");
-            recorder.set(RecorderFactory.getRecorder(RecorderType.MONTE));
-//            recorder.set(RecorderFactory.getRecorder(VideoRecorder.conf().recorderType()));
-            recorder.get().start();
+        if (shouldRecordDesktop()) {
+            DesktopVideoRecordingProvider provider = DesktopVideoRecordingProviderRegistry.findProvider()
+                    .orElseThrow(() -> new IllegalStateException(MISSING_DESKTOP_PROVIDER_MESSAGE));
+            if (!provider.isRecording()) {
+                provider.startRecording();
+            }
         }
     }
 
+    private static boolean shouldRecordDesktop() {
+        return SHAFT.Properties.visuals.videoParamsRecordVideo()
+                && SHAFT.Properties.platform.executionAddress().equals("local")
+                && !SHAFT.Properties.web.headlessExecution();
+    }
+
+    /**
+     * Attaches an existing video recording file to the current report.
+     *
+     * @param pathToRecording path to the recording file; {@code null} is ignored
+     */
     public static void attachVideoRecording(Path pathToRecording) {
         if (pathToRecording != null) {
             String testMethodName = ReportManagerHelper.getTestMethodName();
@@ -97,10 +111,18 @@ public class RecordManager {
         }
     }
 
+    /**
+     * Stops the active recording, if any, and attaches it to the current report.
+     */
     public static void attachVideoRecording() {
         ReportManagerHelper.attach("Video Recording", ReportManagerHelper.getTestMethodName(), getVideoRecording());
     }
 
+    /**
+     * Stops the active recording, writes it to SHAFT's temporary video path, and returns that path.
+     *
+     * @return the temporary file path, or an empty string when no recording can be written
+     */
     public static String getVideoRecordingFilePath() {
         try {
             String tempFilePath = "target/tempVideoFile/";
@@ -112,22 +134,19 @@ public class RecordManager {
         }
     }
 
+    /**
+     * Stops the active desktop or Appium-native recording and returns its bytes.
+     *
+     * @return an input stream for the recording, or {@code null} when no recording is active or available
+     */
     public static InputStream getVideoRecording() {
+        InputStream desktopRecording = getDesktopVideoRecording();
+        if (desktopRecording != null) {
+            return desktopRecording;
+        }
+
         InputStream inputStream = null;
-        String pathToRecording;
-        String testMethodName = ReportManagerHelper.getTestMethodName();
-
-        if (SHAFT.Properties.visuals.videoParamsRecordVideo() && recorder.get() != null) {
-            pathToRecording = RecordingUtils.doVideoProcessing(ReportManagerHelper.isCurrentTestPassed(), recorder.get().stopAndSave(System.currentTimeMillis() + "_" + testMethodName));
-            try {
-                File encoded = encodeRecording(pathToRecording);
-                inputStream = new FileInputStream(encoded);
-            } catch (IOException e) {
-                ReportManagerHelper.logDiscrete(e);
-            }
-            recorder.remove();
-
-        } else if (SHAFT.Properties.visuals.videoParamsRecordVideo() && videoDriver.get() != null) {
+        if (SHAFT.Properties.visuals.videoParamsRecordVideo() && videoDriver.get() != null) {
             String base64EncodedRecording = "";
             try {
                 if (videoDriver.get() instanceof AndroidDriver androidDriver) {
@@ -148,24 +167,16 @@ public class RecordManager {
         return inputStream;
     }
 
-    @SuppressWarnings("SpellCheckingInspection")
-    private static File encodeRecording(String pathToRecording) {
-        File source = new File(pathToRecording);
-        File target = new File(pathToRecording.replace("avi", "mp4"));
-        try {
-
-            AudioAttributes audio = new AudioAttributes();
-            audio.setCodec("libvorbis");
-            VideoAttributes video = new VideoAttributes();
-            EncodingAttributes attrs = new EncodingAttributes();
-            attrs.setOutputFormat("mp4");
-            attrs.setAudioAttributes(audio);
-            attrs.setVideoAttributes(video);
-            Encoder encoder = new Encoder();
-            encoder.encode(new MultimediaObject(source), target, attrs);
-        } catch (EncoderException e) {
-            ReportManagerHelper.logDiscrete(e);
+    private static InputStream getDesktopVideoRecording() {
+        if (!SHAFT.Properties.visuals.videoParamsRecordVideo()) {
+            return null;
         }
-        return target;
+
+        return DesktopVideoRecordingProviderRegistry.findProvider()
+                .filter(DesktopVideoRecordingProvider::isRecording)
+                .map(provider -> provider.stopRecording(
+                        ReportManagerHelper.isCurrentTestPassed(),
+                        System.currentTimeMillis() + "_" + ReportManagerHelper.getTestMethodName()))
+                .orElse(null);
     }
 }

--- a/shaft-engine/src/main/resources/META-INF/services/com.shaft.gui.internal.video.DesktopVideoRecordingProvider
+++ b/shaft-engine/src/main/resources/META-INF/services/com.shaft.gui.internal.video.DesktopVideoRecordingProvider
@@ -1,0 +1,1 @@
+com.shaft.gui.internal.video.AutomationRemarksDesktopVideoRecordingProvider

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistryTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistryTest.java
@@ -22,6 +22,20 @@ public class DesktopVideoRecordingProviderRegistryTest {
         Assert.assertSame(DesktopVideoRecordingProviderRegistry.findProvider().orElseThrow(), provider);
     }
 
+
+    @Test
+    public void serviceDiscoveryShouldFindAutomationRemarksProvider() {
+        Assert.assertEquals(DesktopVideoRecordingProviderRegistry.findProvider().orElseThrow().getClass(),
+                AutomationRemarksDesktopVideoRecordingProvider.class);
+    }
+
+    @Test
+    public void explicitEmptyTestProviderShouldOverrideServiceDiscovery() {
+        DesktopVideoRecordingProviderRegistry.setProviderForTesting(null);
+
+        Assert.assertTrue(DesktopVideoRecordingProviderRegistry.findProvider().isEmpty());
+    }
+
     private static final class StubDesktopVideoRecordingProvider implements DesktopVideoRecordingProvider {
         @Override
         public void startRecording() {

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistryTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistryTest.java
@@ -22,7 +22,6 @@ public class DesktopVideoRecordingProviderRegistryTest {
         Assert.assertSame(DesktopVideoRecordingProviderRegistry.findProvider().orElseThrow(), provider);
     }
 
-
     @Test
     public void serviceDiscoveryShouldFindAutomationRemarksProvider() {
         Assert.assertEquals(DesktopVideoRecordingProviderRegistry.findProvider().orElseThrow().getClass(),

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistryTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistryTest.java
@@ -1,0 +1,41 @@
+package com.shaft.gui.internal.video;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+public class DesktopVideoRecordingProviderRegistryTest {
+    @AfterMethod(alwaysRun = true)
+    public void resetProvider() {
+        DesktopVideoRecordingProviderRegistry.resetProviderForTesting();
+    }
+
+    @Test
+    public void registeredTestProviderShouldOverrideServiceDiscovery() {
+        DesktopVideoRecordingProvider provider = new StubDesktopVideoRecordingProvider();
+
+        DesktopVideoRecordingProviderRegistry.setProviderForTesting(provider);
+
+        Assert.assertSame(DesktopVideoRecordingProviderRegistry.findProvider().orElseThrow(), provider);
+    }
+
+    private static final class StubDesktopVideoRecordingProvider implements DesktopVideoRecordingProvider {
+        @Override
+        public void startRecording() {
+            // No-op test provider.
+        }
+
+        @Override
+        public InputStream stopRecording(boolean testPassed, String recordingName) {
+            return new ByteArrayInputStream(new byte[0]);
+        }
+
+        @Override
+        public boolean isRecording() {
+            return false;
+        }
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/video/RecordManagerDesktopProviderTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/video/RecordManagerDesktopProviderTest.java
@@ -1,0 +1,99 @@
+package com.shaft.gui.internal.video;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.properties.internal.Properties;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public class RecordManagerDesktopProviderTest {
+    private boolean videoRecording;
+    private String executionAddress;
+    private boolean headlessExecution;
+
+    @BeforeMethod(alwaysRun = true)
+    public void captureProperties() {
+        videoRecording = SHAFT.Properties.visuals.videoParamsRecordVideo();
+        executionAddress = SHAFT.Properties.platform.executionAddress();
+        headlessExecution = SHAFT.Properties.web.headlessExecution();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void resetState() {
+        DesktopVideoRecordingProviderRegistry.resetProviderForTesting();
+        SHAFT.Properties.visuals.set().videoParamsRecordVideo(videoRecording);
+        SHAFT.Properties.platform.set().executionAddress(executionAddress);
+        SHAFT.Properties.web.set().headlessExecution(headlessExecution);
+        Properties.clearForCurrentThread();
+    }
+
+    @Test
+    public void desktopRecordingShouldDelegateStartAndStopToRegisteredProvider() throws Exception {
+        StubDesktopVideoRecordingProvider provider = new StubDesktopVideoRecordingProvider();
+        DesktopVideoRecordingProviderRegistry.setProviderForTesting(provider);
+        enableDesktopRecording();
+
+        RecordManager.startVideoRecording();
+        try (InputStream recording = RecordManager.getVideoRecording()) {
+            Assert.assertTrue(provider.startCalled);
+            Assert.assertTrue(provider.stopped);
+            Assert.assertEquals(new String(recording.readAllBytes(), StandardCharsets.UTF_8), "desktop-video");
+        }
+    }
+
+    @Test
+    public void missingProviderShouldBeActionableWhenDesktopRecordingIsRequested() {
+        DesktopVideoRecordingProviderRegistry.setProviderForTesting(null);
+        enableDesktopRecording();
+
+        IllegalStateException exception = Assert.expectThrows(IllegalStateException.class,
+                RecordManager::startVideoRecording);
+
+        Assert.assertTrue(exception.getMessage().contains("io.github.shafthq:shaft-video"));
+    }
+
+    @Test
+    public void missingProviderShouldNotFailWhenRecordingIsDisabled() {
+        DesktopVideoRecordingProviderRegistry.setProviderForTesting(null);
+        SHAFT.Properties.visuals.set().videoParamsRecordVideo(false);
+        SHAFT.Properties.platform.set().executionAddress("local");
+        SHAFT.Properties.web.set().headlessExecution(false);
+
+        RecordManager.startVideoRecording();
+    }
+
+    private void enableDesktopRecording() {
+        SHAFT.Properties.visuals.set().videoParamsRecordVideo(true);
+        SHAFT.Properties.platform.set().executionAddress("local");
+        SHAFT.Properties.web.set().headlessExecution(false);
+    }
+
+    private static final class StubDesktopVideoRecordingProvider implements DesktopVideoRecordingProvider {
+        private boolean started;
+        private boolean startCalled;
+        private boolean stopped;
+
+        @Override
+        public void startRecording() {
+            started = true;
+            startCalled = true;
+        }
+
+        @Override
+        public InputStream stopRecording(boolean testPassed, String recordingName) {
+            stopped = true;
+            started = false;
+            return new ByteArrayInputStream("desktop-video".getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public boolean isRecording() {
+            return started;
+        }
+    }
+}

--- a/shaft-engine/src/test/java/testPackage/unitTests/RecordManagerTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/RecordManagerTest.java
@@ -1,9 +1,5 @@
 package testPackage.unitTests;
 
-import com.automation.remarks.video.RecordingUtils;
-import com.automation.remarks.video.RecorderFactory;
-import com.automation.remarks.video.enums.RecorderType;
-import com.automation.remarks.video.recorder.IVideoRecorder;
 import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.gui.internal.video.RecordManager;
@@ -27,8 +23,6 @@ import java.nio.file.Path;
 import java.util.Base64;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
@@ -39,14 +33,11 @@ import static org.mockito.Mockito.when;
  */
 @Test(singleThreaded = true)
 public class RecordManagerTest {
-    private static final Field RECORDER_FIELD;
     private static final Field VIDEO_DRIVER_FIELD;
     private static final Field IS_RECORDING_STARTED_FIELD;
 
     static {
         try {
-            RECORDER_FIELD = RecordManager.class.getDeclaredField("recorder");
-            RECORDER_FIELD.setAccessible(true);
             VIDEO_DRIVER_FIELD = RecordManager.class.getDeclaredField("videoDriver");
             VIDEO_DRIVER_FIELD.setAccessible(true);
             IS_RECORDING_STARTED_FIELD = RecordManager.class.getDeclaredField("isRecordingStarted");
@@ -54,11 +45,6 @@ public class RecordManagerTest {
         } catch (NoSuchFieldException e) {
             throw new ExceptionInInitializerError(e);
         }
-    }
-
-    @SuppressWarnings("unchecked")
-    private ThreadLocal<IVideoRecorder> getRecorderThreadLocal() throws Exception {
-        return (ThreadLocal<IVideoRecorder>) RECORDER_FIELD.get(null);
     }
 
     @SuppressWarnings("unchecked")
@@ -77,7 +63,6 @@ public class RecordManagerTest {
 
     @AfterMethod(alwaysRun = true)
     public void cleanup() throws Exception {
-        getRecorderThreadLocal().remove();
         getVideoDriverThreadLocal().remove();
         IS_RECORDING_STARTED_FIELD.setBoolean(null, false);
         setVideoRecordingEnabled(false);
@@ -141,23 +126,6 @@ public class RecordManagerTest {
         SHAFT.Validations.assertThat().object(IS_RECORDING_STARTED_FIELD.getBoolean(null)).isEqualTo(false).perform();
     }
 
-    @Test(description = "getVideoRecording handles recorder branch and cleans recorder thread local")
-    public void getVideoRecordingCleansRecorderWhenDesktopRecorderExists() throws Exception {
-        setVideoRecordingEnabled(true);
-        IVideoRecorder mockRecorder = mock(IVideoRecorder.class);
-        getRecorderThreadLocal().set(mockRecorder);
-        when(mockRecorder.stopAndSave(anyString())).thenReturn(new File("target/recording-does-not-exist.avi"));
-
-        try (var recordingUtilsMock = mockStatic(RecordingUtils.class)) {
-            recordingUtilsMock.when(() -> RecordingUtils.doVideoProcessing(anyBoolean(), any(File.class)))
-                    .thenReturn("target/recording-does-not-exist.avi");
-            InputStream recording = RecordManager.getVideoRecording();
-            SHAFT.Validations.assertThat().object(recording).isNull().perform();
-            verify(mockRecorder).stopAndSave(anyString());
-            SHAFT.Validations.assertThat().object(getRecorderThreadLocal().get()).isNull().perform();
-        }
-    }
-
     @Test(description = "startVideoRecording starts Android native recording when mobile execution is detected")
     public void startVideoRecordingStartsAndroidNativeRecording() throws Exception {
         setVideoRecordingEnabled(true);
@@ -196,20 +164,6 @@ public class RecordManagerTest {
         SHAFT.Validations.assertThat().object(IS_RECORDING_STARTED_FIELD.getBoolean(null)).isEqualTo(true).perform();
     }
 
-    @Test(description = "startVideoRecording no-args starts desktop recorder under local non-headless execution")
-    public void startVideoRecordingNoArgsStartsDesktopRecorder() throws Exception {
-        setVideoRecordingEnabled(true);
-        SHAFT.Properties.platform.set().executionAddress("local");
-        SHAFT.Properties.web.set().headlessExecution(false);
-        IVideoRecorder mockDesktopRecorder = mock(IVideoRecorder.class);
-        try (var recorderFactoryMock = mockStatic(RecorderFactory.class)) {
-            recorderFactoryMock.when(() -> RecorderFactory.getRecorder(RecorderType.MONTE)).thenReturn(mockDesktopRecorder);
-            RecordManager.startVideoRecording();
-        }
-        verify(mockDesktopRecorder).start();
-        SHAFT.Validations.assertThat().object(getRecorderThreadLocal().get() != null).isEqualTo(true).perform();
-    }
-
     @Test(description = "getVideoRecordingFilePath writes decoded video to temp path")
     public void getVideoRecordingFilePathWritesTempFile() throws Exception {
         setVideoRecordingEnabled(true);
@@ -242,14 +196,6 @@ public class RecordManagerTest {
     @Test(description = "attachVideoRecording no-args overload does not throw when no recording is active")
     public void attachVideoRecordingNoOpWhenNoRecording() {
         RecordManager.attachVideoRecording();
-    }
-
-    @Test(description = "private encodeRecording method returns mp4 target file path")
-    public void encodeRecordingReturnsMp4File() throws Exception {
-        var method = RecordManager.class.getDeclaredMethod("encodeRecording", String.class);
-        method.setAccessible(true);
-        File encoded = (File) method.invoke(null, "target/recording-source.avi");
-        SHAFT.Validations.assertThat().object(encoded.getPath().endsWith(".mp4")).isEqualTo(true).perform();
     }
 
     @Test(description = "startVideoRecording falls back when null driver is provided")


### PR DESCRIPTION
## Agent and traceability

Codex is the implementation agent for this pull request. The authenticated maintainer token is being used only to publish Codex's branch and PR; the token owner did not author these changes manually.

Closes #2814
Parent: #2809
Depends on completed issue: #2813

## Objective

Separate Appium driver-native recording from desktop recording behind a SHAFT-owned provider boundary without changing current user-visible recording, listener, or attachment behavior. This PR prepares the source boundary only; dependency extraction belongs to #2815.

## Implementation plan

Follow these steps in order and keep each checkpoint independently buildable:

1. **Define the provider boundary**
   - Inspect `shaft-engine/src/main/java/com/shaft/gui/internal/video/RecordManager.java` and its unit tests.
   - Add a public SHAFT-owned desktop provider interface under `com.shaft.gui.internal.video` whose method descriptors use only JDK/SHAFT types.
   - Add deterministic service discovery and a test override/reset hook so unit tests do not depend on classpath ordering.
   - Validate with `mvn -pl shaft-engine -am test -Dtest=DesktopVideoRecordingProviderRegistryTest -DfailIfNoTests=false`.

2. **Move optional desktop implementation details out of orchestration**
   - Create a dedicated Automation Remarks/JAVE provider class containing `RecorderFactory`, `RecordingUtils`, `IVideoRecorder`, and JAVE encoding imports and behavior.
   - Register that provider through `META-INF/services` while it remains in `shaft-engine` for this preparatory issue.
   - Refactor `RecordManager` so it orchestrates property checks, Appium Android/iOS recording, attachment creation, and calls through the SHAFT provider contract only.
   - Keep Appium classes and recording behavior in `shaft-engine`.
   - When desktop recording is requested but no provider exists, fail with an actionable message naming `io.github.shafthq:shaft-video`; remain a no-op when recording is disabled or the desktop path is inapplicable.

3. **Harden behavior and tests**
   - Replace RecordManager tests that inspect/mock Automation Remarks internals with a deterministic fake provider.
   - Add provider implementation tests for desktop start/stop/encoding behavior.
   - Add contract/bytecode checks proving `RecordManager`, listeners, and the provider interface do not expose Automation Remarks or JAVE types.
   - Preserve existing attachment name, MIME handling, scope checks, remote-driver behavior, and Appium base64 decoding.

4. **Validation and review**
   - Run narrow tests first: provider registry, RecordManager, listener coverage, and Appium/mobile recording tests.
   - Confirm every SHAFT test run creates the expected non-zero Allure result count and that statuses are passed.
   - Run `mvn clean install -DskipTests -Dgpg.skip` as the mandatory compile/package check.
   - Run JavaDocs if the public provider contract changes documentation-visible APIs.
   - Inspect dependency trees and source/bytecode references; do not remove or move JAVE/Automation Remarks dependencies in this issue.

## Acceptance criteria

- Appium recording tests pass using engine-owned classes.
- Desktop recording remains functional via the in-engine provider before #2815 extraction.
- Provider interfaces expose no JAVE or Automation Remarks types.
- Listeners depend only on `RecordManager` and preserve existing attachment semantics.
- Missing provider behavior is conditional on desktop recording actually being requested and explains how to add `io.github.shafthq:shaft-video`.
- Service discovery is deterministic and tests can register/reset a provider explicitly.
- No dependency extraction is claimed or performed here.

## Rollback and failure handling

- If ServiceLoader discovery changes startup behavior, retain deterministic test registration and narrow provider loading to the desktop-recording path only.
- If desktop tests expose behavior drift, restore the exact existing save-mode, output-folder, filename, encoding, and exception-logging semantics inside the provider before proceeding.
- If Appium tests fail, revert only the orchestration delegation and keep native Android/iOS start/stop logic in `RecordManager`.
- Do not alter Maven dependency scope/profile placement; #2815 owns extraction.

## Assumptions

- `shaft-modularization` is the correct base because #2813 merged there and #2814 is the next ordered ticket.
- A single desktop recording provider is expected; discovering more than one should fail deterministically rather than choosing by classpath order.
- Existing public `RecordManager` method signatures remain backward-compatible.

## Implementation status

- **Iteration 1 — Plan/Do/Check/Act:** introduced the SHAFT-owned `DesktopVideoRecordingProvider` contract and deterministic registry; validated the registry test; committed as `a447b9f`.
- **Iteration 2 — Plan/Do/Check/Act:** moved Automation Remarks/JAVE usage into `AutomationRemarksDesktopVideoRecordingProvider`, registered it with ServiceLoader, and changed `RecordManager` to retain Appium-native recording while delegating desktop behavior; replaced implementation-coupled tests; committed as `282bd88`.
- **Iteration 3 — Plan/Do/Check/Act:** made test overrides thread-local, added property-aware missing-provider coverage, documented public APIs, verified ServiceLoader packaging and public bytecode descriptors, and ran reactor compile plus JavaDocs.

### Validation completed

- `mvn -pl shaft-engine -am test -Dtest=DesktopVideoRecordingProviderRegistryTest,RecordManagerDesktopProviderTest,RecordManagerTest,RecordManagerCoverageUnitTest -DfailIfNoTests=false` — 19 tests passed; 19 populated Allure result JSON files, all `passed`.
- `mvn clean install -DskipTests -Dgpg.skip` — complete five-module reactor build passed.
- `mvn -pl shaft-engine javadoc:javadoc` — passed.
- `javap -classpath shaft-engine/target/classes -public com.shaft.gui.internal.video.DesktopVideoRecordingProvider com.shaft.gui.internal.video.RecordManager` plus optional-type scan — public descriptors contain no Automation Remarks/JAVE types.
- Source scan confirms listeners, `RecordManager`, and the provider contract do not import optional implementation types.

### Scope confirmation and risks

- Appium Android/iOS recording remains in `shaft-engine`.
- Automation Remarks, JAVE, and native binary Maven dependencies remain in `shaft-engine`; #2815 owns their extraction.
- Desktop behavior remains registered by default through the in-engine ServiceLoader provider.
- A future engine-only runtime without the provider receives an actionable `io.github.shafthq:shaft-video` message only when desktop recording is enabled and applicable.
- No local browser/Appium device E2E was run; behavior is covered through focused orchestration and existing native-driver unit tests.
