### PR TITLE
codex: introduce optional visual-processing provider boundary

### DIFF
--- a/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
+++ b/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
@@ -1,37 +1,22 @@
 package com.shaft.gui.internal.image;
 
-import com.applitools.eyes.LogHandler;
-import com.applitools.eyes.MatchLevel;
-import com.applitools.eyes.TestResults;
-import com.applitools.eyes.exceptions.DiffsFoundException;
-import com.applitools.eyes.images.Eyes;
-import com.assertthat.selenium_shutterbug.core.CaptureElement;
-import com.assertthat.selenium_shutterbug.core.Shutterbug;
-import com.assertthat.selenium_shutterbug.utils.image.UnableToCompareImagesException;
 import com.google.common.hash.Hashing;
 import com.shaft.cli.FileActions;
 import com.shaft.driver.SHAFT;
-import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.tools.internal.support.JavaHelper;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.FailureReporter;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import com.shaft.validation.Validations;
-import nu.pattern.OpenCV;
 import org.apache.logging.log4j.Level;
-import org.opencv.core.*;
-import org.opencv.core.Point;
-import org.opencv.highgui.HighGui;
-import org.opencv.imgcodecs.Imgcodecs;
-import org.opencv.imgproc.Imgproc;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Platform;
-import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.Browser;
 
 import javax.imageio.ImageIO;
 import java.awt.*;
+import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
 import java.io.ByteArrayOutputStream;
@@ -51,15 +36,8 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ImageProcessingActions {
     private static final String DIRECTORY_PROCESSING = "/processingDirectory/";
     private static final String DIRECTORY_FAILED = "/failedImagesDirectory/";
-    private static final int
-//            CV_MOP_CLOSE = 3,
-            CV_THRESH_OTSU = 8,
-            CV_THRESH_BINARY = 0;
-//            CV_ADAPTIVE_THRESH_GAUSSIAN_C = 1,
-//            CV_ADAPTIVE_THRESH_MEAN_C = 0,
-//            CV_THRESH_BINARY_INV = 1;
-
     private static final ThreadLocal<String> aiFolderPath = ThreadLocal.withInitial(() -> "");
+    private static final ConcurrentHashMap<String, String> locatorHashMapping = new ConcurrentHashMap<>();
 
     private ImageProcessingActions() {
         throw new IllegalStateException("Utility class");
@@ -145,54 +123,47 @@ public class ImageProcessingActions {
 
     public static byte[] highlightElementInScreenshot(byte[] targetScreenshot,
                                                       org.openqa.selenium.Rectangle elementLocation, Color highlightColor) {
-        Mat img;
+        BufferedImage image;
         try {
-            img = Imgcodecs.imdecode(new MatOfByte(targetScreenshot), Imgcodecs.IMREAD_COLOR);
-        } catch (java.lang.UnsatisfiedLinkError unsatisfiedLinkError) {
-            loadOpenCV();
-            img = Imgcodecs.imdecode(new MatOfByte(targetScreenshot), Imgcodecs.IMREAD_COLOR);
+            image = ImageIO.read(new java.io.ByteArrayInputStream(targetScreenshot));
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Unable to decode screenshot bytes.", e);
         }
 
-        int outlineThickness = 5;
-        double elementHeight = elementLocation.getHeight(),
-                elementWidth = elementLocation.getWidth(),
-                xPos = elementLocation.getX(),
-                yPos = elementLocation.getY();
+        if (image == null) {
+            throw new IllegalArgumentException("Unable to decode screenshot bytes.");
+        }
 
-        // IOS Native | macOS Browser | Linux Browser scaled | -> Repositioning
+        double outlineThickness = 5;
+        double elementHeight = elementLocation.getHeight();
+        double elementWidth = elementLocation.getWidth();
+        double xPos = elementLocation.getX();
+        double yPos = elementLocation.getY();
+
         if (SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.IOS.name())
                 || SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.MAC.name())
-                || (
-                SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.LINUX.name())
-                        && SHAFT.Properties.visuals.screenshotParamsScalingFactor() != Double.parseDouble("1")
-        )
-                || (
-                SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.LINUX.name())
-                        && SHAFT.Properties.visuals.screenshotParamsScalingFactor() != Double.parseDouble("1")
-        )
-        ) {
+                || (SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.LINUX.name())
+                && SHAFT.Properties.visuals.screenshotParamsScalingFactor() != 1)) {
             elementHeight *= 2;
             elementWidth *= 2;
             xPos *= 2;
             yPos *= 2;
         }
 
-        // IOS Browser Repositioning
-        if (SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.IOS.name()) && SHAFT.Properties.mobile.browserName().equalsIgnoreCase(Browser.SAFARI.browserName())) {
+        if (SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.IOS.name())
+                && SHAFT.Properties.mobile.browserName().equalsIgnoreCase(Browser.SAFARI.browserName())) {
             yPos += elementHeight + 2 * outlineThickness;
         }
 
-        // Android Browser Repositioning
-        if (SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.ANDROID.name()) && SHAFT.Properties.mobile.appPackage().equalsIgnoreCase("com.android.chrome")) {
+        if (SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.ANDROID.name())
+                && SHAFT.Properties.mobile.appPackage().equalsIgnoreCase("com.android.chrome")) {
             yPos += 2 * outlineThickness;
         }
 
-        // MacOS Browser Repositioning
         if (SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.MAC.name())) {
             yPos += 2 * outlineThickness;
         }
 
-        // Windows Browser Repositioning
         if (SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.WINDOWS.name())) {
             double scalingFactor = SHAFT.Properties.visuals.screenshotParamsScalingFactor();
             elementHeight *= scalingFactor;
@@ -201,172 +172,35 @@ public class ImageProcessingActions {
             yPos *= scalingFactor;
         }
 
-        Point startPoint = new Point(xPos - outlineThickness, yPos - outlineThickness);
-        Point endPoint = new Point(xPos + elementWidth + outlineThickness, yPos + elementHeight + outlineThickness);
+        BufferedImage highlightedImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = highlightedImage.createGraphics();
+        try {
+            graphics.drawImage(image, 0, 0, null);
+            graphics.setColor(highlightColor);
+            graphics.setStroke(new BasicStroke((float) outlineThickness));
+            graphics.draw(new Rectangle2D.Double(
+                    xPos - outlineThickness,
+                    yPos - outlineThickness,
+                    elementWidth + 2 * outlineThickness,
+                    elementHeight + 2 * outlineThickness));
+        } finally {
+            graphics.dispose();
+        }
 
-        // BGR color
-        Scalar highlightColorScalar = new Scalar(highlightColor.getBlue(), highlightColor.getGreen(),
-                highlightColor.getRed());
-
-        // Outline
-        Imgproc.rectangle(img, startPoint, endPoint, highlightColorScalar, outlineThickness, 8, 0);
-
-        Image tmpImg = HighGui.toBufferedImage(img);
-        BufferedImage image = (BufferedImage) tmpImg;
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try {
-            ImageIO.write(image, "jpg", baos);
+            ImageIO.write(highlightedImage, "jpg", baos);
         } catch (IOException e) {
             ReportManagerHelper.logDiscrete(e);
+            return targetScreenshot;
         }
         return baos.toByteArray();
     }
 
-    private static Mat preprocess(byte[] image) {
-        //https://stackoverflow.com/questions/37302098/image-preprocessing-with-opencv-before-doing-character-recognition-tesseract
-        Mat img;
-        Mat imgGray = new Mat();
-        Mat imgGaussianBlur = new Mat();
-        Mat imgSobel = new Mat();
-        Mat imgThreshold = new Mat();
-
-        img = Imgcodecs.imdecode(new MatOfByte(image), Imgcodecs.IMREAD_COLOR);
-        Imgproc.cvtColor(img, imgGray, Imgproc.COLOR_BGR2GRAY);
-        Imgproc.GaussianBlur(imgGray, imgGaussianBlur, new Size(3, 3), 0);
-        Imgproc.Sobel(imgGaussianBlur, imgSobel, -1, 1, 0);
-        Imgproc.threshold(imgSobel, imgThreshold, 0, 255, CV_THRESH_OTSU + CV_THRESH_BINARY);
-
-        if (SHAFT.Properties.reporting.debugMode()) {
-            FileActions.getInstance(true).createFolder("target/openCV/temp/");
-            String timestamp = String.valueOf(System.currentTimeMillis());
-            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_1_True_Image.png", img);
-            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_2_imgGray.png", imgGray);
-            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_3_imgGaussianBlur.png", imgGaussianBlur);
-            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_4_imgSobel.png", imgSobel);
-            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_5_imgThreshold.png", imgThreshold);
-        }
-        return imgThreshold;
-    }
-
-    private static List<Integer> attemptToFindImageUsingOpenCV(String referenceImagePath, byte[] currentPageScreenshot, int attemptNumber) {
-        if (currentPageScreenshot == null || Arrays.equals(currentPageScreenshot, new byte[]{})) {
-            //target image is empty, force fail comparison
-            ReportManager.log("Failed to identify the element using AI; target screenshot is empty.");
-        } else {
-            Mat img_original = Imgcodecs.imdecode(new MatOfByte(currentPageScreenshot), Imgcodecs.IMREAD_COLOR);
-            Mat templ_original = Imgcodecs.imread(referenceImagePath, Imgcodecs.IMREAD_COLOR);
-
-            Mat img = preprocess(currentPageScreenshot);
-            Mat templ = preprocess(FileActions.getInstance(true).readFileAsByteArray(referenceImagePath));
-
-            // / Create the result matrix
-            int resultCols = img.cols() - templ.cols() + 1;
-            int resultRows = img.rows() - templ.rows() + 1;
-
-            Mat result = new Mat(resultRows, resultCols, CvType.CV_32FC1);
-
-            // / Do the Matching and Normalize
-            try {
-                // matchMethod 1 == Imgproc.TM_SQDIFF_NORMED
-                int matchMethod = Imgproc.TM_CCOEFF_NORMED;
-                double threshold = SHAFT.Properties.visuals.visualMatchingThreshold();
-
-                switch (attemptNumber) {
-                    case 1 -> matchMethod = Imgproc.TM_SQDIFF_NORMED;
-                    case 2 -> matchMethod = Imgproc.TM_CCORR_NORMED;
-                }
-
-                Imgproc.matchTemplate(img, templ, result, matchMethod);
-
-                // Localizing the best match with minMaxLoc
-                Core.MinMaxLocResult mmr = Core.minMaxLoc(result);
-
-                double minMaxVal;
-                double matchAccuracy;
-
-                org.opencv.core.Point matchLoc;
-                //noinspection ConstantValue
-                if (matchMethod == Imgproc.TM_SQDIFF || matchMethod == Imgproc.TM_SQDIFF_NORMED) {
-                    matchLoc = mmr.minLoc;
-                    minMaxVal = mmr.minVal;
-                    matchAccuracy = 1 - minMaxVal;
-                } else {
-                    matchLoc = mmr.maxLoc;
-                    minMaxVal = mmr.maxVal;
-                    matchAccuracy = minMaxVal;
-                }
-
-                var accuracyMessage = "Match accuracy is " + (int) Math.round(matchAccuracy * 100) + "% and threshold is " + (int) Math.round(threshold * 100) + "%. Match Method: " + matchMethod + ".";
-                ReportManager.logDiscrete(accuracyMessage);
-
-                if (SHAFT.Properties.reporting.debugMode()) {
-                    // debugging
-                    try {
-                        FileActions.getInstance(true).createFolder("target/openCV/");
-                        String timestamp = String.valueOf(System.currentTimeMillis());
-
-                        File output = new File("target/openCV/" + timestamp + "_1_templ.png");
-                        ImageIO.write((BufferedImage) HighGui.toBufferedImage(templ_original), "png", output);
-
-                        output = new File("target/openCV/" + timestamp + "_3_img.png");
-                        ImageIO.write((BufferedImage) HighGui.toBufferedImage(img_original), "png", output);
-
-                        Imgproc.rectangle(img_original, matchLoc, new Point(matchLoc.x + templ.cols(), matchLoc.y + templ.rows()),
-                                new Scalar(0, 0, 0), 2, 8, 0);
-                        output = new File("target/openCV/" + timestamp + "_5_output.png");
-                        ImageIO.write((BufferedImage) HighGui.toBufferedImage(img_original), "png", output);
-                    } catch (IOException e) {
-                        ReportManagerHelper.logDiscrete(e);
-                        return Collections.emptyList();
-                    }
-                }
-
-                if (matchAccuracy < threshold) {
-                    return Collections.emptyList();
-                }
-
-                // returning the top left corner +1 pixel
-                int x = Integer.parseInt(String.valueOf(matchLoc.x + 1).split("\\.")[0]);
-                int y = Integer.parseInt(String.valueOf(matchLoc.y + 1).split("\\.")[0]);
-
-                // creating highlighted image to be attached to the report
-                try {
-                    Imgproc.rectangle(img_original, matchLoc, new Point(matchLoc.x + templ.cols(), matchLoc.y + templ.rows()),
-                            new Scalar(67, 176, 42), 2, 8, 0); // selenium-green
-                    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                    ImageIO.write((BufferedImage) HighGui.toBufferedImage(img_original), "png", baos);
-                    var screenshot = new ScreenshotManager().prepareImageForReport(baos.toByteArray(), "AI identified element");
-                    List<List<Object>> attachments = new LinkedList<>();
-                    attachments.add(screenshot);
-                    ReportManagerHelper.log("Successfully identified the element using AI; OpenCV. " + accuracyMessage, attachments);
-                } catch (IOException e) {
-                    ReportManager.log("Successfully identified the element using AI; OpenCV. " + accuracyMessage);
-                }
-                return Arrays.asList(x, y);
-            } catch (org.opencv.core.CvException e) {
-                ReportManagerHelper.logDiscrete(e);
-                ReportManager.log("Failed to identify the element using AI; openCV core exception.");
-            }
-        }
-        return Collections.emptyList();
-    }
-
     public static List<Integer> findImageWithinCurrentPage(String referenceImagePath, byte[] currentPageScreenshot) {
-        int maxNumberOfAttempts = 3;
-        int attempts = 0;
-        List<Integer> foundLocation = Collections.emptyList();
-        do {
-            try {
-                foundLocation = attemptToFindImageUsingOpenCV(referenceImagePath, currentPageScreenshot, attempts);
-            } catch (Exception e) {
-                ReportManagerHelper.logDiscrete(e);
-            }
-            attempts++;
-        } while (Collections.emptyList().equals(foundLocation) && attempts < maxNumberOfAttempts);
-        return foundLocation;
+        return VisualProcessingProviders.requireProvider()
+                .findImageWithinCurrentPage(referenceImagePath, currentPageScreenshot);
     }
-
-    private static final ConcurrentHashMap<String, String> locatorHashMapping = new ConcurrentHashMap<>();
 
     public static String formatElementLocatorToImagePath(By elementLocator) {
         String elementFileName = ReportManagerHelper.getCallingClassFullName() + "_" + JavaHelper.formatLocatorToString(elementLocator);
@@ -400,100 +234,10 @@ public class ImageProcessingActions {
         }
     }
 
-    public static Boolean compareAgainstBaseline(WebDriver driver, By elementLocator, byte[] elementScreenshot, VisualValidationEngine visualValidationEngine) {
-        String hashedLocatorName = ImageProcessingActions.formatElementLocatorToImagePath(elementLocator);
-        String aiAidedElementIdentificationFolderPath = getAiFolderPath();
-
-        if (visualValidationEngine == VisualValidationEngine.EXACT_SHUTTERBUG) {
-            String referenceImagePath = aiAidedElementIdentificationFolderPath + hashedLocatorName + ".png";
-            String resultingImagePath = aiAidedElementIdentificationFolderPath + hashedLocatorName + "_shutterbug";
-
-            if (getReferenceImage(elementLocator) !=null && elementScreenshot != null && elementScreenshot.length > 0) {
-                boolean actualResult = false;
-                try {
-                    var snapshot = Shutterbug.shootElement(driver, elementLocator, CaptureElement.VIEWPORT, true);
-                    actualResult = snapshot.equalsWithDiff(referenceImagePath, resultingImagePath, 0.1);
-                } catch (IOException e) {
-                    ReportManagerHelper.logDiscrete(e);
-                } catch (UnableToCompareImagesException | UnsupportedCommandException exception) {
-                    ReportManager.logDiscrete("Failed to locate element using \"" + VisualValidationEngine.EXACT_SHUTTERBUG + "\", attempting to use \"" + VisualValidationEngine.EXACT_OPENCV + "\".");
-                    // com.assertthat.selenium_shutterbug.utils.image.UnableToCompareImagesException: Images dimensions mismatch
-                    actualResult = compareAgainstBaseline(driver, elementLocator, elementScreenshot, VisualValidationEngine.EXACT_OPENCV);
-                }
-                return actualResult;
-            } else {
-                ReportManager.logDiscrete("Passing the test and saving a reference image");
-                FileActions.getInstance(true).writeToFile(aiAidedElementIdentificationFolderPath, hashedLocatorName + ".png", elementScreenshot);
-                return true;
-            }
-        }
-
-        if (visualValidationEngine == VisualValidationEngine.EXACT_OPENCV) {
-            String referenceImagePath = aiAidedElementIdentificationFolderPath + hashedLocatorName + ".png";
-
-            boolean doesReferenceFileExist = FileActions.getInstance(true).doesFileExist(referenceImagePath);
-            if (!doesReferenceFileExist || !ImageProcessingActions.findImageWithinCurrentPage(referenceImagePath, elementScreenshot).equals(Collections.emptyList())) {
-                //pass: element found and matched || first time element
-                if (!doesReferenceFileExist) {
-                    ReportManager.logDiscrete("Passing the test and saving a reference image");
-                    FileActions.getInstance(true).writeToFile(referenceImagePath, elementScreenshot);
-                }
-                return true;
-            } else {
-                //fail: element doesn't match
-                return false;
-            }
-        }//all the other cases of Eyes
-        Eyes eyes = new Eyes();
-        // Define global settings
-        eyes.setLogHandler(new LogHandler() {
-            @Override
-            public void open() {
-            }
-
-            @Override
-            public void onMessage(boolean b, String s) {
-                ReportManager.logDiscrete(s);
-            }
-
-            @Override
-            public void close() {
-            }
-        });
-        eyes.setApiKey(SHAFT.Properties.paths.applitoolsApiKey());
-        MatchLevel targetMatchLevel = MatchLevel.STRICT;
-        switch (visualValidationEngine) {
-            // https://help.applitools.com/hc/en-us/articles/360007188591-Match-Levels
-            case EXACT_EYES -> targetMatchLevel = MatchLevel.EXACT;
-            case CONTENT_EYES -> targetMatchLevel = MatchLevel.CONTENT;
-            case LAYOUT_EYES -> targetMatchLevel = MatchLevel.LAYOUT;
-            default -> {
-            }
-        }
-        eyes.setMatchLevel(targetMatchLevel);
-        // Define the OS and hosting application to identify the baseline.
-        if (DriverFactoryHelper.isMobileNativeExecution()) {
-            eyes.setHostOS(SHAFT.Properties.mobile.platformName() + "_" + SHAFT.Properties.mobile.platformVersion());
-            eyes.setHostApp("NativeMobileExecution");
-        } else if (DriverFactoryHelper.isMobileWebExecution()) {
-            eyes.setHostOS(SHAFT.Properties.mobile.platformName() + "_" + SHAFT.Properties.mobile.platformVersion());
-            eyes.setHostApp(SHAFT.Properties.mobile.browserName());
-        } else {
-            eyes.setHostOS(SHAFT.Properties.platform.targetPlatform());
-            eyes.setHostApp(SHAFT.Properties.web.targetBrowserName());
-        }
-        try {
-            eyes.open("SHAFT_Engine", ReportManagerHelper.getCallingMethodFullName());
-            eyes.checkImage(elementScreenshot, hashedLocatorName);
-            TestResults eyesValidationResult = eyes.close();
-            ReportManager.logDiscrete("Successfully validated the element using AI; Applitools Eyes.");
-            return eyesValidationResult.isNew() || eyesValidationResult.isPassed();
-        } catch (DiffsFoundException e) {
-            ReportManagerHelper.logDiscrete(e);
-            return false;
-        } finally {
-            eyes.abortIfNotClosed();
-        }
+    public static Boolean compareAgainstBaseline(WebDriver driver, By elementLocator, byte[] elementScreenshot,
+                                                 VisualValidationEngine visualValidationEngine) {
+        return VisualProcessingProviders.requireProvider()
+                .compareAgainstBaseline(driver, elementLocator, elementScreenshot, visualValidationEngine);
     }
 
     private static void compareImageFolders(File[] referenceFiles, File[] testFiles, File[] testProcessingFiles,
@@ -587,24 +331,10 @@ public class ImageProcessingActions {
     }
 
     public static void loadOpenCV() {
-        var libName = "";
-        try {
-            //https://github.com/openpnp/opencv#api
-            libName = org.opencv.core.Core.NATIVE_LIBRARY_NAME;
-            OpenCV.loadLocally();
-            ReportManager.logDiscrete("Loaded OpenCV \"" + libName + "\".");
-        } catch (Throwable throwable) {
-            ReportManagerHelper.logDiscrete(throwable);
-            if (!libName.isEmpty()) {
-                ReportManager.logDiscrete("Failed to load OpenCV \"" + libName + "\". Try installing the binaries manually https://opencv.org/releases/, switching element highlighting to JavaScript...");
-            } else {
-                ReportManager.logDiscrete("Failed to load OpenCV. Try installing the binaries manually https://opencv.org/releases/, switching element highlighting to JavaScript...");
-            }
-            SHAFT.Properties.visuals.set().screenshotParamsHighlightMethod("JavaScript");
-        }
+        VisualProcessingProviders.loadProviderIfPresent();
     }
 
-    private static String getAiFolderPath() {
+    static String getAiFolderPath() {
         String currentAiFolderPath = aiFolderPath.get();
         if (currentAiFolderPath == null || currentAiFolderPath.isEmpty()) {
             currentAiFolderPath = ScreenshotHelper.getAiAidedElementIdentificationFolderPath();

--- a/src/main/java/com/shaft/gui/internal/image/LegacyVisualProcessingProvider.java
+++ b/src/main/java/com/shaft/gui/internal/image/LegacyVisualProcessingProvider.java
@@ -1,0 +1,318 @@
+package com.shaft.gui.internal.image;
+
+import com.applitools.eyes.LogHandler;
+import com.applitools.eyes.MatchLevel;
+import com.applitools.eyes.TestResults;
+import com.applitools.eyes.exceptions.DiffsFoundException;
+import com.applitools.eyes.images.Eyes;
+import com.assertthat.selenium_shutterbug.core.CaptureElement;
+import com.assertthat.selenium_shutterbug.core.Shutterbug;
+import com.assertthat.selenium_shutterbug.utils.image.UnableToCompareImagesException;
+import com.shaft.cli.FileActions;
+import com.shaft.driver.SHAFT;
+import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
+import com.shaft.tools.io.ReportManager;
+import com.shaft.tools.io.internal.ReportManagerHelper;
+import nu.pattern.OpenCV;
+import org.apache.logging.log4j.Level;
+import org.opencv.core.*;
+import org.opencv.highgui.HighGui;
+import org.opencv.imgcodecs.Imgcodecs;
+import org.opencv.imgproc.Imgproc;
+import org.openqa.selenium.By;
+import org.openqa.selenium.UnsupportedCommandException;
+import org.openqa.selenium.WebDriver;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+class LegacyVisualProcessingProvider implements VisualProcessingProvider {
+    private static final int CV_THRESH_OTSU = 8;
+    private static final int CV_THRESH_BINARY = 0;
+
+    @Override
+    public int priority() {
+        return -100;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        try {
+            Class.forName("org.opencv.core.Core", false, getClass().getClassLoader());
+            Class.forName("nu.pattern.OpenCV", false, getClass().getClassLoader());
+            return true;
+        } catch (ClassNotFoundException | LinkageError error) {
+            ReportManagerHelper.logDiscrete(error);
+            return false;
+        }
+    }
+
+    @Override
+    public void initialize() {
+        loadOpenCV();
+    }
+
+    @Override
+    public Boolean compareAgainstBaseline(WebDriver driver, By elementLocator, byte[] elementScreenshot,
+                                          ImageProcessingActions.VisualValidationEngine visualValidationEngine) {
+        String hashedLocatorName = ImageProcessingActions.formatElementLocatorToImagePath(elementLocator);
+        String aiAidedElementIdentificationFolderPath = ImageProcessingActions.getAiFolderPath();
+
+        if (visualValidationEngine == ImageProcessingActions.VisualValidationEngine.EXACT_SHUTTERBUG) {
+            String referenceImagePath = aiAidedElementIdentificationFolderPath + hashedLocatorName + ".png";
+            String resultingImagePath = aiAidedElementIdentificationFolderPath + hashedLocatorName + "_shutterbug";
+
+            if (ImageProcessingActions.getReferenceImage(elementLocator) != null && elementScreenshot != null && elementScreenshot.length > 0) {
+                boolean actualResult = false;
+                try {
+                    var snapshot = Shutterbug.shootElement(driver, elementLocator, CaptureElement.VIEWPORT, true);
+                    actualResult = snapshot.equalsWithDiff(referenceImagePath, resultingImagePath, 0.1);
+                } catch (IOException e) {
+                    ReportManagerHelper.logDiscrete(e);
+                } catch (UnableToCompareImagesException | UnsupportedCommandException exception) {
+                    ReportManager.logDiscrete("Failed to locate element using \"" + ImageProcessingActions.VisualValidationEngine.EXACT_SHUTTERBUG + "\", attempting to use \"" + ImageProcessingActions.VisualValidationEngine.EXACT_OPENCV + "\".");
+                    actualResult = compareAgainstBaseline(driver, elementLocator, elementScreenshot,
+                            ImageProcessingActions.VisualValidationEngine.EXACT_OPENCV);
+                }
+                return actualResult;
+            } else {
+                ReportManager.logDiscrete("Passing the test and saving a reference image");
+                FileActions.getInstance(true).writeToFile(aiAidedElementIdentificationFolderPath, hashedLocatorName + ".png", elementScreenshot);
+                return true;
+            }
+        }
+
+        if (visualValidationEngine == ImageProcessingActions.VisualValidationEngine.EXACT_OPENCV) {
+            String referenceImagePath = aiAidedElementIdentificationFolderPath + hashedLocatorName + ".png";
+
+            boolean doesReferenceFileExist = FileActions.getInstance(true).doesFileExist(referenceImagePath);
+            if (!doesReferenceFileExist || !findImageWithinCurrentPage(referenceImagePath, elementScreenshot).equals(Collections.emptyList())) {
+                if (!doesReferenceFileExist) {
+                    ReportManager.logDiscrete("Passing the test and saving a reference image");
+                    FileActions.getInstance(true).writeToFile(referenceImagePath, elementScreenshot);
+                }
+                return true;
+            } else {
+                return false;
+            }
+        }
+        Eyes eyes = new Eyes();
+        eyes.setLogHandler(new LogHandler() {
+            @Override
+            public void open() {
+            }
+
+            @Override
+            public void onMessage(boolean b, String s) {
+                ReportManager.logDiscrete(s);
+            }
+
+            @Override
+            public void close() {
+            }
+        });
+        eyes.setApiKey(SHAFT.Properties.paths.applitoolsApiKey());
+        MatchLevel targetMatchLevel = MatchLevel.STRICT;
+        switch (visualValidationEngine) {
+            case EXACT_EYES -> targetMatchLevel = MatchLevel.EXACT;
+            case CONTENT_EYES -> targetMatchLevel = MatchLevel.CONTENT;
+            case LAYOUT_EYES -> targetMatchLevel = MatchLevel.LAYOUT;
+            default -> {
+            }
+        }
+        eyes.setMatchLevel(targetMatchLevel);
+        if (DriverFactoryHelper.isMobileNativeExecution()) {
+            eyes.setHostOS(SHAFT.Properties.mobile.platformName() + "_" + SHAFT.Properties.mobile.platformVersion());
+            eyes.setHostApp("NativeMobileExecution");
+        } else if (DriverFactoryHelper.isMobileWebExecution()) {
+            eyes.setHostOS(SHAFT.Properties.mobile.platformName() + "_" + SHAFT.Properties.mobile.platformVersion());
+            eyes.setHostApp(SHAFT.Properties.mobile.browserName());
+        } else {
+            eyes.setHostOS(SHAFT.Properties.platform.targetPlatform());
+            eyes.setHostApp(SHAFT.Properties.web.targetBrowserName());
+        }
+        try {
+            eyes.open("SHAFT_Engine", ReportManagerHelper.getCallingMethodFullName());
+            eyes.checkImage(elementScreenshot, hashedLocatorName);
+            TestResults eyesValidationResult = eyes.close();
+            ReportManager.logDiscrete("Successfully validated the element using AI; Applitools Eyes.");
+            return eyesValidationResult.isNew() || eyesValidationResult.isPassed();
+        } catch (DiffsFoundException e) {
+            ReportManagerHelper.logDiscrete(e);
+            return false;
+        } finally {
+            eyes.abortIfNotClosed();
+        }
+    }
+
+    private static Mat preprocess(byte[] image) {
+        //https://stackoverflow.com/questions/37302098/image-preprocessing-with-opencv-before-doing-character-recognition-tesseract
+        Mat img;
+        Mat imgGray = new Mat();
+        Mat imgGaussianBlur = new Mat();
+        Mat imgSobel = new Mat();
+        Mat imgThreshold = new Mat();
+
+        img = Imgcodecs.imdecode(new MatOfByte(image), Imgcodecs.IMREAD_COLOR);
+        Imgproc.cvtColor(img, imgGray, Imgproc.COLOR_BGR2GRAY);
+        Imgproc.GaussianBlur(imgGray, imgGaussianBlur, new Size(3, 3), 0);
+        Imgproc.Sobel(imgGaussianBlur, imgSobel, -1, 1, 0);
+        Imgproc.threshold(imgSobel, imgThreshold, 0, 255, CV_THRESH_OTSU + CV_THRESH_BINARY);
+
+        if (SHAFT.Properties.reporting.debugMode()) {
+            FileActions.getInstance(true).createFolder("target/openCV/temp/");
+            String timestamp = String.valueOf(System.currentTimeMillis());
+            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_1_True_Image.png", img);
+            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_2_imgGray.png", imgGray);
+            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_3_imgGaussianBlur.png", imgGaussianBlur);
+            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_4_imgSobel.png", imgSobel);
+            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_5_imgThreshold.png", imgThreshold);
+        }
+        return imgThreshold;
+    }
+
+    private static List<Integer> attemptToFindImageUsingOpenCV(String referenceImagePath, byte[] currentPageScreenshot, int attemptNumber) {
+        if (currentPageScreenshot == null || Arrays.equals(currentPageScreenshot, new byte[]{})) {
+            //target image is empty, force fail comparison
+            ReportManager.log("Failed to identify the element using AI; target screenshot is empty.");
+        } else {
+            Mat img_original = Imgcodecs.imdecode(new MatOfByte(currentPageScreenshot), Imgcodecs.IMREAD_COLOR);
+            Mat templ_original = Imgcodecs.imread(referenceImagePath, Imgcodecs.IMREAD_COLOR);
+
+            Mat img = preprocess(currentPageScreenshot);
+            Mat templ = preprocess(FileActions.getInstance(true).readFileAsByteArray(referenceImagePath));
+
+            // / Create the result matrix
+            int resultCols = img.cols() - templ.cols() + 1;
+            int resultRows = img.rows() - templ.rows() + 1;
+
+            Mat result = new Mat(resultRows, resultCols, CvType.CV_32FC1);
+
+            // / Do the Matching and Normalize
+            try {
+                // matchMethod 1 == Imgproc.TM_SQDIFF_NORMED
+                int matchMethod = Imgproc.TM_CCOEFF_NORMED;
+                double threshold = SHAFT.Properties.visuals.visualMatchingThreshold();
+
+                switch (attemptNumber) {
+                    case 1 -> matchMethod = Imgproc.TM_SQDIFF_NORMED;
+                    case 2 -> matchMethod = Imgproc.TM_CCORR_NORMED;
+                }
+
+                Imgproc.matchTemplate(img, templ, result, matchMethod);
+
+                // Localizing the best match with minMaxLoc
+                Core.MinMaxLocResult mmr = Core.minMaxLoc(result);
+
+                double minMaxVal;
+                double matchAccuracy;
+
+                org.opencv.core.Point matchLoc;
+                //noinspection ConstantValue
+                if (matchMethod == Imgproc.TM_SQDIFF || matchMethod == Imgproc.TM_SQDIFF_NORMED) {
+                    matchLoc = mmr.minLoc;
+                    minMaxVal = mmr.minVal;
+                    matchAccuracy = 1 - minMaxVal;
+                } else {
+                    matchLoc = mmr.maxLoc;
+                    minMaxVal = mmr.maxVal;
+                    matchAccuracy = minMaxVal;
+                }
+
+                var accuracyMessage = "Match accuracy is " + (int) Math.round(matchAccuracy * 100) + "% and threshold is " + (int) Math.round(threshold * 100) + "%. Match Method: " + matchMethod + ".";
+                ReportManager.logDiscrete(accuracyMessage);
+
+                if (SHAFT.Properties.reporting.debugMode()) {
+                    // debugging
+                    try {
+                        FileActions.getInstance(true).createFolder("target/openCV/");
+                        String timestamp = String.valueOf(System.currentTimeMillis());
+
+                        File output = new File("target/openCV/" + timestamp + "_1_templ.png");
+                        ImageIO.write((BufferedImage) HighGui.toBufferedImage(templ_original), "png", output);
+
+                        output = new File("target/openCV/" + timestamp + "_3_img.png");
+                        ImageIO.write((BufferedImage) HighGui.toBufferedImage(img_original), "png", output);
+
+                        Imgproc.rectangle(img_original, matchLoc, new Point(matchLoc.x + templ.cols(), matchLoc.y + templ.rows()),
+                                new Scalar(0, 0, 0), 2, 8, 0);
+                        output = new File("target/openCV/" + timestamp + "_5_output.png");
+                        ImageIO.write((BufferedImage) HighGui.toBufferedImage(img_original), "png", output);
+                    } catch (IOException e) {
+                        ReportManagerHelper.logDiscrete(e);
+                        return Collections.emptyList();
+                    }
+                }
+
+                if (matchAccuracy < threshold) {
+                    return Collections.emptyList();
+                }
+
+                // returning the top left corner +1 pixel
+                int x = Integer.parseInt(String.valueOf(matchLoc.x + 1).split("\\.")[0]);
+                int y = Integer.parseInt(String.valueOf(matchLoc.y + 1).split("\\.")[0]);
+
+                // creating highlighted image to be attached to the report
+                try {
+                    Imgproc.rectangle(img_original, matchLoc, new Point(matchLoc.x + templ.cols(), matchLoc.y + templ.rows()),
+                            new Scalar(67, 176, 42), 2, 8, 0); // selenium-green
+                    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                    ImageIO.write((BufferedImage) HighGui.toBufferedImage(img_original), "png", baos);
+                    var screenshot = new ScreenshotManager().prepareImageForReport(baos.toByteArray(), "AI identified element");
+                    List<List<Object>> attachments = new LinkedList<>();
+                    attachments.add(screenshot);
+                    ReportManagerHelper.log("Successfully identified the element using AI; OpenCV. " + accuracyMessage, attachments);
+                } catch (IOException e) {
+                    ReportManager.log("Successfully identified the element using AI; OpenCV. " + accuracyMessage);
+                }
+                return Arrays.asList(x, y);
+            } catch (org.opencv.core.CvException e) {
+                ReportManagerHelper.logDiscrete(e);
+                ReportManager.log("Failed to identify the element using AI; openCV core exception.");
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<Integer> findImageWithinCurrentPage(String referenceImagePath, byte[] currentPageScreenshot) {
+        int maxNumberOfAttempts = 3;
+        int attempts = 0;
+        List<Integer> foundLocation = Collections.emptyList();
+        do {
+            try {
+                foundLocation = attemptToFindImageUsingOpenCV(referenceImagePath, currentPageScreenshot, attempts);
+            } catch (Exception e) {
+                ReportManagerHelper.logDiscrete(e);
+            }
+            attempts++;
+        } while (Collections.emptyList().equals(foundLocation) && attempts < maxNumberOfAttempts);
+        return foundLocation;
+    }
+
+    private static void loadOpenCV() {
+        var libName = "";
+        try {
+            libName = org.opencv.core.Core.NATIVE_LIBRARY_NAME;
+            OpenCV.loadLocally();
+            ReportManager.logDiscrete("Loaded OpenCV \"" + libName + "\".");
+        } catch (Throwable throwable) {
+            ReportManagerHelper.logDiscrete(throwable);
+            if (!libName.isEmpty()) {
+                ReportManager.logDiscrete("Failed to load OpenCV \"" + libName + "\". Add `" + VisualProcessingProviders.SHAFT_VISUAL_COORDINATE + "` when visual matching is extracted, or switch element highlighting to JavaScript.");
+            } else {
+                ReportManager.logDiscrete("Failed to load OpenCV. Add `" + VisualProcessingProviders.SHAFT_VISUAL_COORDINATE + "` when visual matching is extracted, or switch element highlighting to JavaScript.");
+            }
+            SHAFT.Properties.visuals.set().screenshotParamsHighlightMethod("JavaScript");
+        }
+    }
+
+
+}

--- a/src/main/java/com/shaft/gui/internal/image/LegacyVisualProcessingProvider.java
+++ b/src/main/java/com/shaft/gui/internal/image/LegacyVisualProcessingProvider.java
@@ -33,7 +33,14 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-class LegacyVisualProcessingProvider implements VisualProcessingProvider {
+/**
+ * Compatibility provider for visual operations that still depend on OpenCV, Shutterbug, or Applitools.
+ *
+ * <p>The provider is instantiated reflectively so that core image classes do not acquire descriptors for optional
+ * third-party visual libraries before the implementation moves to {@code io.github.shafthq:shaft-visual}.</p>
+ */
+@SuppressWarnings("unused") // Instantiated reflectively by VisualProcessingProviders.
+final class LegacyVisualProcessingProvider implements VisualProcessingProvider {
     private static final int CV_THRESH_OTSU = 8;
     private static final int CV_THRESH_BINARY = 0;
 
@@ -63,71 +70,116 @@ class LegacyVisualProcessingProvider implements VisualProcessingProvider {
     public Boolean compareAgainstBaseline(WebDriver driver, By elementLocator, byte[] elementScreenshot,
                                           ImageProcessingActions.VisualValidationEngine visualValidationEngine) {
         String hashedLocatorName = ImageProcessingActions.formatElementLocatorToImagePath(elementLocator);
-        String aiAidedElementIdentificationFolderPath = ImageProcessingActions.getAiFolderPath();
+        String baselineFolderPath = ImageProcessingActions.getAiFolderPath();
 
-        if (visualValidationEngine == ImageProcessingActions.VisualValidationEngine.EXACT_SHUTTERBUG) {
-            String referenceImagePath = aiAidedElementIdentificationFolderPath + hashedLocatorName + ".png";
-            String resultingImagePath = aiAidedElementIdentificationFolderPath + hashedLocatorName + "_shutterbug";
+        return switch (visualValidationEngine) {
+            case EXACT_SHUTTERBUG -> compareWithShutterbug(driver, elementLocator, elementScreenshot,
+                    hashedLocatorName, baselineFolderPath);
+            case EXACT_OPENCV -> compareWithOpenCv(elementScreenshot, hashedLocatorName, baselineFolderPath);
+            default -> compareWithApplitools(elementScreenshot, hashedLocatorName, visualValidationEngine);
+        };
+    }
 
-            if (ImageProcessingActions.getReferenceImage(elementLocator) != null && elementScreenshot != null && elementScreenshot.length > 0) {
-                boolean actualResult = false;
-                try {
-                    var snapshot = Shutterbug.shootElement(driver, elementLocator, CaptureElement.VIEWPORT, true);
-                    actualResult = snapshot.equalsWithDiff(referenceImagePath, resultingImagePath, 0.1);
-                } catch (IOException e) {
-                    ReportManagerHelper.logDiscrete(e);
-                } catch (UnableToCompareImagesException | UnsupportedCommandException exception) {
-                    ReportManager.logDiscrete("Failed to locate element using \"" + ImageProcessingActions.VisualValidationEngine.EXACT_SHUTTERBUG + "\", attempting to use \"" + ImageProcessingActions.VisualValidationEngine.EXACT_OPENCV + "\".");
-                    actualResult = compareAgainstBaseline(driver, elementLocator, elementScreenshot,
-                            ImageProcessingActions.VisualValidationEngine.EXACT_OPENCV);
-                }
-                return actualResult;
-            } else {
-                ReportManager.logDiscrete("Passing the test and saving a reference image");
-                FileActions.getInstance(true).writeToFile(aiAidedElementIdentificationFolderPath, hashedLocatorName + ".png", elementScreenshot);
-                return true;
-            }
+    private Boolean compareWithShutterbug(WebDriver driver, By elementLocator, byte[] elementScreenshot,
+                                          String hashedLocatorName, String baselineFolderPath) {
+        String referenceImagePath = baselineFolderPath + hashedLocatorName + ".png";
+        String resultingImagePath = baselineFolderPath + hashedLocatorName + "_shutterbug";
+
+        if (ImageProcessingActions.getReferenceImage(elementLocator) == null
+                || elementScreenshot == null
+                || elementScreenshot.length == 0) {
+            saveReferenceImage(baselineFolderPath, hashedLocatorName, elementScreenshot);
+            return true;
         }
 
-        if (visualValidationEngine == ImageProcessingActions.VisualValidationEngine.EXACT_OPENCV) {
-            String referenceImagePath = aiAidedElementIdentificationFolderPath + hashedLocatorName + ".png";
-
-            boolean doesReferenceFileExist = FileActions.getInstance(true).doesFileExist(referenceImagePath);
-            if (!doesReferenceFileExist || !findImageWithinCurrentPage(referenceImagePath, elementScreenshot).equals(Collections.emptyList())) {
-                if (!doesReferenceFileExist) {
-                    ReportManager.logDiscrete("Passing the test and saving a reference image");
-                    FileActions.getInstance(true).writeToFile(referenceImagePath, elementScreenshot);
-                }
-                return true;
-            } else {
-                return false;
-            }
+        try {
+            var snapshot = Shutterbug.shootElement(driver, elementLocator, CaptureElement.VIEWPORT, true);
+            return snapshot.equalsWithDiff(referenceImagePath, resultingImagePath, 0.1);
+        } catch (IOException exception) {
+            ReportManagerHelper.logDiscrete(exception);
+            return false;
+        } catch (UnableToCompareImagesException | UnsupportedCommandException exception) {
+            ReportManager.logDiscrete("Failed to locate element using \""
+                    + ImageProcessingActions.VisualValidationEngine.EXACT_SHUTTERBUG
+                    + "\", attempting to use \"" + ImageProcessingActions.VisualValidationEngine.EXACT_OPENCV
+                    + "\".");
+            return compareWithOpenCv(elementScreenshot, hashedLocatorName, baselineFolderPath);
         }
+    }
+
+    private Boolean compareWithOpenCv(byte[] elementScreenshot, String hashedLocatorName,
+                                      String baselineFolderPath) {
+        String referenceImagePath = baselineFolderPath + hashedLocatorName + ".png";
+        boolean doesReferenceFileExist = FileActions.getInstance(true).doesFileExist(referenceImagePath);
+        if (!doesReferenceFileExist) {
+            saveReferenceImage(referenceImagePath, elementScreenshot);
+            return true;
+        }
+        return !findImageWithinCurrentPage(referenceImagePath, elementScreenshot).isEmpty();
+    }
+
+    private static void saveReferenceImage(String baselineFolderPath, String hashedLocatorName,
+                                           byte[] elementScreenshot) {
+        ReportManager.logDiscrete("Passing the test and saving a reference image");
+        FileActions.getInstance(true).writeToFile(baselineFolderPath, hashedLocatorName + ".png", elementScreenshot);
+    }
+
+    private static void saveReferenceImage(String referenceImagePath, byte[] elementScreenshot) {
+        ReportManager.logDiscrete("Passing the test and saving a reference image");
+        FileActions.getInstance(true).writeToFile(referenceImagePath, elementScreenshot);
+    }
+
+    private static Boolean compareWithApplitools(byte[] elementScreenshot, String hashedLocatorName,
+                                                 ImageProcessingActions.VisualValidationEngine visualValidationEngine) {
         Eyes eyes = new Eyes();
-        eyes.setLogHandler(new LogHandler() {
+        eyes.setLogHandler(createApplitoolsLogHandler());
+        eyes.setApiKey(SHAFT.Properties.paths.applitoolsApiKey());
+        eyes.setMatchLevel(toMatchLevel(visualValidationEngine));
+        configureApplitoolsEnvironment(eyes);
+        try {
+            eyes.open("SHAFT_Engine", ReportManagerHelper.getCallingMethodFullName());
+            eyes.checkImage(elementScreenshot, hashedLocatorName);
+            TestResults eyesValidationResult = eyes.close();
+            ReportManager.logDiscrete("Successfully validated the element using AI; Applitools Eyes.");
+            return eyesValidationResult.isNew() || eyesValidationResult.isPassed();
+        } catch (DiffsFoundException exception) {
+            ReportManagerHelper.logDiscrete(exception);
+            return false;
+        } finally {
+            eyes.abortIfNotClosed();
+        }
+    }
+
+    private static LogHandler createApplitoolsLogHandler() {
+        return new LogHandler() {
             @Override
             public void open() {
+                // No resources need to be opened for SHAFT report logging.
             }
 
             @Override
-            public void onMessage(boolean b, String s) {
-                ReportManager.logDiscrete(s);
+            public void onMessage(boolean verbose, String message) {
+                ReportManager.logDiscrete(message);
             }
 
             @Override
             public void close() {
+                // No resources need to be closed for SHAFT report logging.
             }
-        });
-        eyes.setApiKey(SHAFT.Properties.paths.applitoolsApiKey());
-        MatchLevel targetMatchLevel = MatchLevel.STRICT;
-        switch (visualValidationEngine) {
-            case EXACT_EYES -> targetMatchLevel = MatchLevel.EXACT;
-            case CONTENT_EYES -> targetMatchLevel = MatchLevel.CONTENT;
-            case LAYOUT_EYES -> targetMatchLevel = MatchLevel.LAYOUT;
-            default -> {
-            }
-        }
-        eyes.setMatchLevel(targetMatchLevel);
+        };
+    }
+
+    private static MatchLevel toMatchLevel(
+            ImageProcessingActions.VisualValidationEngine visualValidationEngine) {
+        return switch (visualValidationEngine) {
+            case EXACT_EYES -> MatchLevel.EXACT;
+            case CONTENT_EYES -> MatchLevel.CONTENT;
+            case LAYOUT_EYES -> MatchLevel.LAYOUT;
+            default -> MatchLevel.STRICT;
+        };
+    }
+
+    private static void configureApplitoolsEnvironment(Eyes eyes) {
         if (DriverFactoryHelper.isMobileNativeExecution()) {
             eyes.setHostOS(SHAFT.Properties.mobile.platformName() + "_" + SHAFT.Properties.mobile.platformVersion());
             eyes.setHostApp("NativeMobileExecution");
@@ -137,18 +189,6 @@ class LegacyVisualProcessingProvider implements VisualProcessingProvider {
         } else {
             eyes.setHostOS(SHAFT.Properties.platform.targetPlatform());
             eyes.setHostApp(SHAFT.Properties.web.targetBrowserName());
-        }
-        try {
-            eyes.open("SHAFT_Engine", ReportManagerHelper.getCallingMethodFullName());
-            eyes.checkImage(elementScreenshot, hashedLocatorName);
-            TestResults eyesValidationResult = eyes.close();
-            ReportManager.logDiscrete("Successfully validated the element using AI; Applitools Eyes.");
-            return eyesValidationResult.isNew() || eyesValidationResult.isPassed();
-        } catch (DiffsFoundException e) {
-            ReportManagerHelper.logDiscrete(e);
-            return false;
-        } finally {
-            eyes.abortIfNotClosed();
         }
     }
 
@@ -179,7 +219,7 @@ class LegacyVisualProcessingProvider implements VisualProcessingProvider {
     }
 
     private static List<Integer> attemptToFindImageUsingOpenCV(String referenceImagePath, byte[] currentPageScreenshot, int attemptNumber) {
-        if (currentPageScreenshot == null || Arrays.equals(currentPageScreenshot, new byte[]{})) {
+        if (currentPageScreenshot == null || currentPageScreenshot.length == 0) {
             //target image is empty, force fail comparison
             ReportManager.log("Failed to identify the element using AI; target screenshot is empty.");
         } else {
@@ -211,19 +251,16 @@ class LegacyVisualProcessingProvider implements VisualProcessingProvider {
                 // Localizing the best match with minMaxLoc
                 Core.MinMaxLocResult mmr = Core.minMaxLoc(result);
 
-                double minMaxVal;
                 double matchAccuracy;
 
-                org.opencv.core.Point matchLoc;
+                Point matchLoc;
                 //noinspection ConstantValue
                 if (matchMethod == Imgproc.TM_SQDIFF || matchMethod == Imgproc.TM_SQDIFF_NORMED) {
                     matchLoc = mmr.minLoc;
-                    minMaxVal = mmr.minVal;
-                    matchAccuracy = 1 - minMaxVal;
+                    matchAccuracy = 1 - mmr.minVal;
                 } else {
                     matchLoc = mmr.maxLoc;
-                    minMaxVal = mmr.maxVal;
-                    matchAccuracy = minMaxVal;
+                    matchAccuracy = mmr.maxVal;
                 }
 
                 var accuracyMessage = "Match accuracy is " + (int) Math.round(matchAccuracy * 100) + "% and threshold is " + (int) Math.round(threshold * 100) + "%. Match Method: " + matchMethod + ".";
@@ -300,11 +337,11 @@ class LegacyVisualProcessingProvider implements VisualProcessingProvider {
     private static void loadOpenCV() {
         var libName = "";
         try {
-            libName = org.opencv.core.Core.NATIVE_LIBRARY_NAME;
+            libName = Core.NATIVE_LIBRARY_NAME;
             OpenCV.loadLocally();
             ReportManager.logDiscrete("Loaded OpenCV \"" + libName + "\".");
-        } catch (Throwable throwable) {
-            ReportManagerHelper.logDiscrete(throwable);
+        } catch (LinkageError | RuntimeException exception) {
+            ReportManagerHelper.logDiscrete(exception);
             if (!libName.isEmpty()) {
                 ReportManager.logDiscrete("Failed to load OpenCV \"" + libName + "\". Add `" + VisualProcessingProviders.SHAFT_VISUAL_COORDINATE + "` when visual matching is extracted, or switch element highlighting to JavaScript.");
             } else {
@@ -313,6 +350,4 @@ class LegacyVisualProcessingProvider implements VisualProcessingProvider {
             SHAFT.Properties.visuals.set().screenshotParamsHighlightMethod("JavaScript");
         }
     }
-
-
 }

--- a/src/main/java/com/shaft/gui/internal/image/VisualProcessingProvider.java
+++ b/src/main/java/com/shaft/gui/internal/image/VisualProcessingProvider.java
@@ -1,0 +1,60 @@
+package com.shaft.gui.internal.image;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+import java.util.List;
+
+/**
+ * Contract for optional visual-processing behavior that can be supplied by a SHAFT visual provider.
+ * <p>
+ * Implementations must keep their public descriptors limited to SHAFT-owned, JDK, and retained Selenium types so
+ * core screenshot and assertion classes can load when third-party visual libraries are absent.
+ */
+public interface VisualProcessingProvider {
+    /**
+     * Returns a deterministic provider priority. Higher values are preferred.
+     *
+     * @return the provider priority
+     */
+    default int priority() {
+        return 0;
+    }
+
+    /**
+     * Reports whether this provider can execute in the current classpath and runtime environment.
+     *
+     * @return {@code true} when the provider is available
+     */
+    default boolean isAvailable() {
+        return true;
+    }
+
+    /**
+     * Initializes optional visual dependencies used by this provider.
+     */
+    default void initialize() {
+        // default providers may not need eager initialization
+    }
+
+    /**
+     * Finds a reference image inside the supplied screenshot bytes.
+     *
+     * @param referenceImagePath the path to the reference image
+     * @param currentPageScreenshot the screenshot bytes to search
+     * @return the detected center coordinates, or an empty list when no match is found
+     */
+    List<Integer> findImageWithinCurrentPage(String referenceImagePath, byte[] currentPageScreenshot);
+
+    /**
+     * Compares an element screenshot against its configured visual baseline.
+     *
+     * @param driver the active Selenium driver
+     * @param elementLocator the element locator used to derive baseline identity
+     * @param elementScreenshot the element screenshot bytes
+     * @param visualValidationEngine the requested validation engine
+     * @return {@code true} when the comparison passes
+     */
+    Boolean compareAgainstBaseline(WebDriver driver, By elementLocator, byte[] elementScreenshot,
+                                   ImageProcessingActions.VisualValidationEngine visualValidationEngine);
+}

--- a/src/main/java/com/shaft/gui/internal/image/VisualProcessingProviders.java
+++ b/src/main/java/com/shaft/gui/internal/image/VisualProcessingProviders.java
@@ -11,6 +11,9 @@ import java.util.Optional;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 
+/**
+ * Discovers and caches the visual-processing provider without linking core image classes to optional libraries.
+ */
 final class VisualProcessingProviders {
     static final String SHAFT_VISUAL_COORDINATE = "io.github.shafthq:shaft-visual";
     private static final String BUILT_IN_PROVIDER = "com.shaft.gui.internal.image.LegacyVisualProcessingProvider";

--- a/src/main/java/com/shaft/gui/internal/image/VisualProcessingProviders.java
+++ b/src/main/java/com/shaft/gui/internal/image/VisualProcessingProviders.java
@@ -1,0 +1,106 @@
+package com.shaft.gui.internal.image;
+
+import com.shaft.tools.io.ReportManager;
+import com.shaft.tools.io.internal.ReportManagerHelper;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+
+final class VisualProcessingProviders {
+    static final String SHAFT_VISUAL_COORDINATE = "io.github.shafthq:shaft-visual";
+    private static final String BUILT_IN_PROVIDER = "com.shaft.gui.internal.image.LegacyVisualProcessingProvider";
+    private static final String MISSING_PROVIDER_MESSAGE = "Optional visual processing requires the SHAFT visual "
+            + "provider. Add `" + SHAFT_VISUAL_COORDINATE + "` to enable OpenCV, Shutterbug, or Applitools visual "
+            + "matching.";
+    private static volatile Optional<VisualProcessingProvider> cachedProvider;
+
+    private VisualProcessingProviders() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static VisualProcessingProvider requireProvider() {
+        return getProvider().orElseThrow(() -> new IllegalStateException(MISSING_PROVIDER_MESSAGE));
+    }
+
+    static void loadProviderIfPresent() {
+        Optional<VisualProcessingProvider> provider = getProvider();
+        if (provider.isPresent()) {
+            provider.get().initialize();
+        } else {
+            ReportManager.logDiscrete(MISSING_PROVIDER_MESSAGE);
+        }
+    }
+
+    static Optional<VisualProcessingProvider> getProvider() {
+        Optional<VisualProcessingProvider> provider = cachedProvider;
+        if (provider == null) {
+            synchronized (VisualProcessingProviders.class) {
+                provider = cachedProvider;
+                if (provider == null) {
+                    provider = discover(Thread.currentThread().getContextClassLoader());
+                    cachedProvider = provider;
+                }
+            }
+        }
+        return provider;
+    }
+
+    static Optional<VisualProcessingProvider> discover(ClassLoader classLoader) {
+        ClassLoader discoveryClassLoader = classLoader == null
+                ? VisualProcessingProviders.class.getClassLoader()
+                : classLoader;
+        List<VisualProcessingProvider> providers = new ArrayList<>();
+        addServiceProviders(discoveryClassLoader, providers);
+        addBuiltInProvider(discoveryClassLoader, providers);
+        return selectProvider(providers);
+    }
+
+    static Optional<VisualProcessingProvider> selectProvider(Collection<VisualProcessingProvider> providers) {
+        return providers.stream()
+                .sorted(Comparator.comparingInt(VisualProcessingProvider::priority).reversed()
+                        .thenComparing(provider -> provider.getClass().getName()))
+                .filter(VisualProcessingProviders::isAvailable)
+                .findFirst();
+    }
+
+    static void setProviderForTesting(Optional<VisualProcessingProvider> provider) {
+        cachedProvider = provider;
+    }
+
+    static void resetCacheForTesting() {
+        cachedProvider = null;
+    }
+
+    private static void addServiceProviders(ClassLoader classLoader, List<VisualProcessingProvider> providers) {
+        try {
+            ServiceLoader.load(VisualProcessingProvider.class, classLoader).forEach(providers::add);
+        } catch (ServiceConfigurationError | LinkageError error) {
+            ReportManagerHelper.logDiscrete(error);
+        }
+    }
+
+    private static void addBuiltInProvider(ClassLoader classLoader, List<VisualProcessingProvider> providers) {
+        try {
+            Class<?> providerClass = Class.forName(BUILT_IN_PROVIDER, true, classLoader);
+            if (VisualProcessingProvider.class.isAssignableFrom(providerClass)) {
+                providers.add((VisualProcessingProvider) providerClass.getDeclaredConstructor().newInstance());
+            }
+        } catch (ReflectiveOperationException | LinkageError error) {
+            ReportManagerHelper.logDiscrete(error);
+        }
+    }
+
+    private static boolean isAvailable(VisualProcessingProvider provider) {
+        try {
+            return provider.isAvailable();
+        } catch (LinkageError | RuntimeException error) {
+            ReportManagerHelper.logDiscrete(error);
+            return false;
+        }
+    }
+}

--- a/src/test/java/com/shaft/gui/internal/image/VisualProcessingProvidersUnitTest.java
+++ b/src/test/java/com/shaft/gui/internal/image/VisualProcessingProvidersUnitTest.java
@@ -1,0 +1,164 @@
+package com.shaft.gui.internal.image;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+
+public class VisualProcessingProvidersUnitTest {
+    @AfterMethod(alwaysRun = true)
+    public void resetProviderCache() {
+        VisualProcessingProviders.resetCacheForTesting();
+    }
+
+    @Test
+    public void selectProviderShouldUsePriorityThenClassNameDeterministically() {
+        VisualProcessingProvider lowerPriority = new ZProvider(1);
+        VisualProcessingProvider alphabeticallyFirst = new AProvider(5);
+        VisualProcessingProvider alphabeticallyLast = new ZProvider(5);
+
+        Optional<VisualProcessingProvider> selected = VisualProcessingProviders.selectProvider(
+                List.of(lowerPriority, alphabeticallyLast, alphabeticallyFirst));
+
+        Assert.assertTrue(selected.isPresent());
+        Assert.assertSame(selected.get(), alphabeticallyFirst);
+    }
+
+    @Test
+    public void optionalOperationShouldNameFutureVisualArtifactWhenProviderIsMissing() {
+        VisualProcessingProviders.setProviderForTesting(Optional.empty());
+
+        IllegalStateException exception = Assert.expectThrows(IllegalStateException.class,
+                () -> ImageProcessingActions.findImageWithinCurrentPage("reference.png", new byte[0]));
+
+        Assert.assertTrue(exception.getMessage().contains("io.github.shafthq:shaft-visual"));
+    }
+
+    @Test
+    public void providerContractDescriptorsShouldNotExposeThirdPartyVisualTypes() {
+        for (Method method : VisualProcessingProvider.class.getMethods()) {
+            assertCoreType(method.getReturnType());
+            for (Class<?> parameterType : method.getParameterTypes()) {
+                assertCoreType(parameterType);
+            }
+        }
+    }
+
+    @Test
+    public void coreImageActionsShouldLoadAndHighlightWhenOpenCvIsBlocked() throws Exception {
+        ClassLoader loader = new OpenCvBlockingClassLoader(getClass().getClassLoader());
+        Class<?> imageActions = Class.forName(ImageProcessingActions.class.getName(), true, loader);
+        Method highlight = imageActions.getMethod("highlightElementInScreenshot", byte[].class,
+                org.openqa.selenium.Rectangle.class, Color.class);
+
+        byte[] highlighted = (byte[]) highlight.invoke(null, createPng(),
+                new org.openqa.selenium.Rectangle(5, 5, 10, 10), Color.RED);
+
+        Assert.assertTrue(highlighted.length > 0);
+        Assert.assertNotNull(ImageIO.read(new java.io.ByteArrayInputStream(highlighted)));
+    }
+
+    private static void assertCoreType(Class<?> type) {
+        String typeName = type.isArray() ? type.getComponentType().getName() : type.getName();
+        Assert.assertFalse(typeName.startsWith("org.opencv"), typeName);
+        Assert.assertFalse(typeName.startsWith("com.applitools"), typeName);
+        Assert.assertFalse(typeName.startsWith("com.assertthat"), typeName);
+    }
+
+    private static byte[] createPng() throws IOException {
+        BufferedImage image = new BufferedImage(30, 30, BufferedImage.TYPE_INT_RGB);
+        var graphics = image.createGraphics();
+        graphics.setColor(Color.WHITE);
+        graphics.fillRect(0, 0, image.getWidth(), image.getHeight());
+        graphics.dispose();
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", output);
+        return output.toByteArray();
+    }
+
+    private static class OpenCvBlockingClassLoader extends ClassLoader {
+        private OpenCvBlockingClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (name.startsWith("org.opencv") || name.equals("nu.pattern.OpenCV")) {
+                throw new ClassNotFoundException(name);
+            }
+            if (name.equals(ImageProcessingActions.class.getName())) {
+                synchronized (getClassLoadingLock(name)) {
+                    Class<?> loaded = findLoadedClass(name);
+                    if (loaded == null) {
+                        loaded = defineFromParentResource(name);
+                    }
+                    if (resolve) {
+                        resolveClass(loaded);
+                    }
+                    return loaded;
+                }
+            }
+            return super.loadClass(name, resolve);
+        }
+
+        private Class<?> defineFromParentResource(String name) throws ClassNotFoundException {
+            String resourceName = name.replace('.', '/') + ".class";
+            try (InputStream input = getParent().getResourceAsStream(resourceName)) {
+                if (input == null) {
+                    throw new ClassNotFoundException(name);
+                }
+                byte[] bytes = input.readAllBytes();
+                return defineClass(name, bytes, 0, bytes.length);
+            } catch (IOException e) {
+                throw new ClassNotFoundException(name, e);
+            }
+        }
+    }
+
+    private abstract static class StubProvider implements VisualProcessingProvider {
+        private final int priority;
+
+        private StubProvider(int priority) {
+            this.priority = priority;
+        }
+
+        @Override
+        public int priority() {
+            return priority;
+        }
+
+        @Override
+        public List<Integer> findImageWithinCurrentPage(String referenceImagePath, byte[] currentPageScreenshot) {
+            return List.of();
+        }
+
+        @Override
+        public Boolean compareAgainstBaseline(WebDriver driver, By elementLocator, byte[] elementScreenshot,
+                                              ImageProcessingActions.VisualValidationEngine visualValidationEngine) {
+            return false;
+        }
+    }
+
+    private static final class AProvider extends StubProvider {
+        private AProvider(int priority) {
+            super(priority);
+        }
+    }
+
+    private static final class ZProvider extends StubProvider {
+        private ZProvider(int priority) {
+            super(priority);
+        }
+    }
+}


### PR DESCRIPTION
## Agent
Implemented by Codex. The authenticated maintainer token is used only to publish Codex-authored work; the token owner did not author these changes manually.

Closes #2816

## Summary
- Introduced `VisualProcessingProvider` as the SHAFT-owned optional visual-processing contract using SHAFT/JDK/Selenium descriptors only.
- Added deterministic provider discovery with a clear missing-provider message naming `io.github.shafthq:shaft-visual`.
- Moved OpenCV/Shutterbug/Applitools visual matching into a legacy compatibility provider so current behavior stays available before extraction.
- Kept core screenshot highlighting in `ImageProcessingActions` using JDK image APIs so basic screenshots can load/run without OpenCV.
- Added provider-boundary tests covering deterministic selection, third-party descriptor isolation, absent-provider messaging, and core class loading/highlighting with OpenCV blocked.
- Refined the compatibility provider into focused Shutterbug, OpenCV, and Applitools paths; removed catch-all `Throwable` handling and reflection-related static-analysis noise.

## PDCA execution notes
### Iteration 1 — smallest boundary
- Plan: isolate optional visual matching from core image helpers.
- Do: added the provider contract and routed OpenCV/Shutterbug/Applitools matching through provider discovery.
- Check: compiled and ran focused image tests; fixed compatibility regressions in baseline folder handling.
- Act: retained legacy behavior in a compatibility provider rather than extracting dependencies in this issue.

### Iteration 2 — minimal-impact core behavior
- Plan: keep ordinary screenshots independent from optional OpenCV.
- Do: converted screenshot highlighting to JDK `BufferedImage`/`Graphics2D` while preserving platform/scaling offsets.
- Check: existing image tests continued to validate supported branches and invalid bytes behavior.
- Act: left public method signatures unchanged for backward compatibility.

### Iteration 3 — validation coverage and maintainability
- Plan: make discovery deterministic and absent-provider behavior testable.
- Do: added cache reset/test hooks, deterministic priority/class-name ordering, classpath-blocking load tests, and descriptor checks.
- Check: verified 50 populated Allure result JSON files, all passed; JavaDocs and skipped-test install validation passed.
- Act: documented missing optional behavior with the future `shaft-visual` coordinate.

### Iteration 4 — static-analysis refinement
- Plan: address Codacy's complexity, best-practice, documentation, style, and reflective-unused findings without changing behavior.
- Do: decomposed engine-specific comparisons, documented reflective loading, replaced catch-all error handling, and simplified image-match calculations.
- Check: reran all 50 focused provider/image tests with 50 passed Allure results, JavaDocs, PMD report generation, and the mandatory skipped-test install.
- Act: kept the refinement isolated to provider internals and preserved the public compatibility surface.

## Validation
- `mvn -q test -Dtest=VisualProcessingProvidersUnitTest,ImageProcessingActionsUnitTest,ImageProcessingActionsCoverageUnitTest`
  - Allure result JSON count: 50
  - Allure statuses: `{passed=50}`
- `mvn -q javadoc:javadoc`
- `mvn -q clean install -DskipTests -Dgpg.skip`
- `mvn -q -DskipTests -Dpmd.failOnViolation=false org.apache.maven.plugins:maven-pmd-plugin:3.27.0:pmd`
  - No PMD findings in the changed visual/image classes; existing repository-wide findings remain outside this PR.

## Open risks / follow-ups
- This PR intentionally does not remove OpenCV/Shutterbug/Applitools dependencies; extraction belongs to the future `shaft-visual` issue.
- Healenium was not extracted or redesigned.
