### PR TITLE
Introduce optional VisualProcessingProvider boundary and extract OpenCV implementation

### DIFF
--- a/docs/VISUAL_PROCESSING_PROVIDER_BOUNDARY.md
+++ b/docs/VISUAL_PROCESSING_PROVIDER_BOUNDARY.md
@@ -1,0 +1,25 @@
+# Visual-processing provider boundary
+
+Issue [#2816](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/2816) introduces the boundary needed to move optional computer-vision behavior out of `shaft-engine` without moving screenshot capture or Healenium integration.
+
+## Operation inventory
+
+| `ImageProcessingActions` operation | Classification | Boundary decision |
+| --- | --- | --- |
+| `compareImageFolders` | JDK image/file comparison | Remains in `shaft-engine`; uses `ImageIO` and image data buffers. |
+| `highlightElementInScreenshot` | Core screenshot decoration | Remains in `shaft-engine`; implemented with JDK `BufferedImage`/`Graphics2D`, so ordinary screenshots do not initialize OpenCV. |
+| `findImageWithinCurrentPage` | Optional computer vision | Delegates to the discovered `VisualProcessingProvider`. |
+| `formatElementLocatorToImagePath` | Core baseline naming | Remains in `shaft-engine`. |
+| `getReferenceImage` | Core baseline file access | Remains in `shaft-engine`. |
+| `getShutterbugDifferencesImage` | Core baseline file access | Remains in `shaft-engine` for backward compatibility. |
+| `compareAgainstBaseline` / `EXACT_OPENCV` | Optional computer vision | Reuses `findImageWithinCurrentPage`, and therefore requires a provider. |
+| `compareAgainstBaseline` / Shutterbug and Applitools engines | Third-party visual integrations | Retained unchanged for this preparatory issue; they can move behind the same SHAFT-owned boundary during artifact extraction. |
+| `loadOpenCV` | Backward-compatible OpenCV entry point | Delegates provider loading and no longer embeds OpenCV types in the core class. |
+
+`ScreenshotManager`, Selenium screenshot capture, and Healenium integration remain outside this provider boundary.
+
+## Discovery contract
+
+Providers implement `VisualProcessingProvider` and are discovered with `ServiceLoader`. Discovery sorts implementations by class name and rejects multiple providers with a deterministic error instead of choosing based on classpath order. The current OpenCV implementation is registered as a service so behavior remains available before artifact extraction.
+
+When no provider is installed, provider-dependent operations report the future Maven coordinate `io.github.shafthq:shaft-visual`. Core screenshot capture, JDK highlighting, baseline file handling, and non-OpenCV assertions do not perform provider discovery.

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
@@ -17,13 +17,7 @@ import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.FailureReporter;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import com.shaft.validation.Validations;
-import nu.pattern.OpenCV;
 import org.apache.logging.log4j.Level;
-import org.opencv.core.*;
-import org.opencv.core.Point;
-import org.opencv.highgui.HighGui;
-import org.opencv.imgcodecs.Imgcodecs;
-import org.opencv.imgproc.Imgproc;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.UnsupportedCommandException;
@@ -51,14 +45,6 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ImageProcessingActions {
     private static final String DIRECTORY_PROCESSING = "/processingDirectory/";
     private static final String DIRECTORY_FAILED = "/failedImagesDirectory/";
-    private static final int
-//            CV_MOP_CLOSE = 3,
-            CV_THRESH_OTSU = 8,
-            CV_THRESH_BINARY = 0;
-//            CV_ADAPTIVE_THRESH_GAUSSIAN_C = 1,
-//            CV_ADAPTIVE_THRESH_MEAN_C = 0,
-//            CV_THRESH_BINARY_INV = 1;
-
     private static final ThreadLocal<String> aiFolderPath = ThreadLocal.withInitial(() -> "");
 
     private ImageProcessingActions() {
@@ -145,54 +131,43 @@ public class ImageProcessingActions {
 
     public static byte[] highlightElementInScreenshot(byte[] targetScreenshot,
                                                       org.openqa.selenium.Rectangle elementLocation, Color highlightColor) {
-        Mat img;
-        try {
-            img = Imgcodecs.imdecode(new MatOfByte(targetScreenshot), Imgcodecs.IMREAD_COLOR);
-        } catch (java.lang.UnsatisfiedLinkError unsatisfiedLinkError) {
-            loadOpenCV();
-            img = Imgcodecs.imdecode(new MatOfByte(targetScreenshot), Imgcodecs.IMREAD_COLOR);
+        BufferedImage image;
+        try (var input = new java.io.ByteArrayInputStream(targetScreenshot)) {
+            image = ImageIO.read(input);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to decode screenshot bytes.", e);
+        }
+        if (image == null) {
+            throw new IllegalArgumentException("Failed to decode screenshot bytes.");
         }
 
         int outlineThickness = 5;
-        double elementHeight = elementLocation.getHeight(),
-                elementWidth = elementLocation.getWidth(),
-                xPos = elementLocation.getX(),
-                yPos = elementLocation.getY();
+        double elementHeight = elementLocation.getHeight();
+        double elementWidth = elementLocation.getWidth();
+        double xPos = elementLocation.getX();
+        double yPos = elementLocation.getY();
 
-        // IOS Native | macOS Browser | Linux Browser scaled | -> Repositioning
         if (SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.IOS.name())
                 || SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.MAC.name())
-                || (
-                SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.LINUX.name())
-                        && SHAFT.Properties.visuals.screenshotParamsScalingFactor() != Double.parseDouble("1")
-        )
-                || (
-                SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.LINUX.name())
-                        && SHAFT.Properties.visuals.screenshotParamsScalingFactor() != Double.parseDouble("1")
-        )
-        ) {
+                || (SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.LINUX.name())
+                && SHAFT.Properties.visuals.screenshotParamsScalingFactor() != 1)) {
             elementHeight *= 2;
             elementWidth *= 2;
             xPos *= 2;
             yPos *= 2;
         }
 
-        // IOS Browser Repositioning
-        if (SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.IOS.name()) && SHAFT.Properties.mobile.browserName().equalsIgnoreCase(Browser.SAFARI.browserName())) {
+        if (SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.IOS.name())
+                && SHAFT.Properties.mobile.browserName().equalsIgnoreCase(Browser.SAFARI.browserName())) {
             yPos += elementHeight + 2 * outlineThickness;
         }
-
-        // Android Browser Repositioning
-        if (SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.ANDROID.name()) && SHAFT.Properties.mobile.appPackage().equalsIgnoreCase("com.android.chrome")) {
+        if (SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.ANDROID.name())
+                && SHAFT.Properties.mobile.appPackage().equalsIgnoreCase("com.android.chrome")) {
             yPos += 2 * outlineThickness;
         }
-
-        // MacOS Browser Repositioning
         if (SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.MAC.name())) {
             yPos += 2 * outlineThickness;
         }
-
-        // Windows Browser Repositioning
         if (SHAFT.Properties.platform.targetPlatform().equalsIgnoreCase(Platform.WINDOWS.name())) {
             double scalingFactor = SHAFT.Properties.visuals.screenshotParamsScalingFactor();
             elementHeight *= scalingFactor;
@@ -201,169 +176,30 @@ public class ImageProcessingActions {
             yPos *= scalingFactor;
         }
 
-        Point startPoint = new Point(xPos - outlineThickness, yPos - outlineThickness);
-        Point endPoint = new Point(xPos + elementWidth + outlineThickness, yPos + elementHeight + outlineThickness);
-
-        // BGR color
-        Scalar highlightColorScalar = new Scalar(highlightColor.getBlue(), highlightColor.getGreen(),
-                highlightColor.getRed());
-
-        // Outline
-        Imgproc.rectangle(img, startPoint, endPoint, highlightColorScalar, outlineThickness, 8, 0);
-
-        Image tmpImg = HighGui.toBufferedImage(img);
-        BufferedImage image = (BufferedImage) tmpImg;
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Graphics2D graphics = image.createGraphics();
         try {
-            ImageIO.write(image, "jpg", baos);
+            graphics.setColor(highlightColor);
+            graphics.setStroke(new BasicStroke(outlineThickness));
+            graphics.drawRect((int) Math.round(xPos - outlineThickness),
+                    (int) Math.round(yPos - outlineThickness),
+                    (int) Math.round(elementWidth + 2 * outlineThickness),
+                    (int) Math.round(elementHeight + 2 * outlineThickness));
+        } finally {
+            graphics.dispose();
+        }
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try {
+            ImageIO.write(image, "jpg", output);
         } catch (IOException e) {
             ReportManagerHelper.logDiscrete(e);
         }
-        return baos.toByteArray();
-    }
-
-    private static Mat preprocess(byte[] image) {
-        //https://stackoverflow.com/questions/37302098/image-preprocessing-with-opencv-before-doing-character-recognition-tesseract
-        Mat img;
-        Mat imgGray = new Mat();
-        Mat imgGaussianBlur = new Mat();
-        Mat imgSobel = new Mat();
-        Mat imgThreshold = new Mat();
-
-        img = Imgcodecs.imdecode(new MatOfByte(image), Imgcodecs.IMREAD_COLOR);
-        Imgproc.cvtColor(img, imgGray, Imgproc.COLOR_BGR2GRAY);
-        Imgproc.GaussianBlur(imgGray, imgGaussianBlur, new Size(3, 3), 0);
-        Imgproc.Sobel(imgGaussianBlur, imgSobel, -1, 1, 0);
-        Imgproc.threshold(imgSobel, imgThreshold, 0, 255, CV_THRESH_OTSU + CV_THRESH_BINARY);
-
-        if (SHAFT.Properties.reporting.debugMode()) {
-            FileActions.getInstance(true).createFolder("target/openCV/temp/");
-            String timestamp = String.valueOf(System.currentTimeMillis());
-            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_1_True_Image.png", img);
-            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_2_imgGray.png", imgGray);
-            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_3_imgGaussianBlur.png", imgGaussianBlur);
-            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_4_imgSobel.png", imgSobel);
-            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_5_imgThreshold.png", imgThreshold);
-        }
-        return imgThreshold;
-    }
-
-    private static List<Integer> attemptToFindImageUsingOpenCV(String referenceImagePath, byte[] currentPageScreenshot, int attemptNumber) {
-        if (currentPageScreenshot == null || Arrays.equals(currentPageScreenshot, new byte[]{})) {
-            //target image is empty, force fail comparison
-            ReportManager.log("Failed to identify the element using AI; target screenshot is empty.");
-        } else {
-            Mat img_original = Imgcodecs.imdecode(new MatOfByte(currentPageScreenshot), Imgcodecs.IMREAD_COLOR);
-            Mat templ_original = Imgcodecs.imread(referenceImagePath, Imgcodecs.IMREAD_COLOR);
-
-            Mat img = preprocess(currentPageScreenshot);
-            Mat templ = preprocess(FileActions.getInstance(true).readFileAsByteArray(referenceImagePath));
-
-            // / Create the result matrix
-            int resultCols = img.cols() - templ.cols() + 1;
-            int resultRows = img.rows() - templ.rows() + 1;
-
-            Mat result = new Mat(resultRows, resultCols, CvType.CV_32FC1);
-
-            // / Do the Matching and Normalize
-            try {
-                // matchMethod 1 == Imgproc.TM_SQDIFF_NORMED
-                int matchMethod = Imgproc.TM_CCOEFF_NORMED;
-                double threshold = SHAFT.Properties.visuals.visualMatchingThreshold();
-
-                switch (attemptNumber) {
-                    case 1 -> matchMethod = Imgproc.TM_SQDIFF_NORMED;
-                    case 2 -> matchMethod = Imgproc.TM_CCORR_NORMED;
-                }
-
-                Imgproc.matchTemplate(img, templ, result, matchMethod);
-
-                // Localizing the best match with minMaxLoc
-                Core.MinMaxLocResult mmr = Core.minMaxLoc(result);
-
-                double minMaxVal;
-                double matchAccuracy;
-
-                org.opencv.core.Point matchLoc;
-                //noinspection ConstantValue
-                if (matchMethod == Imgproc.TM_SQDIFF || matchMethod == Imgproc.TM_SQDIFF_NORMED) {
-                    matchLoc = mmr.minLoc;
-                    minMaxVal = mmr.minVal;
-                    matchAccuracy = 1 - minMaxVal;
-                } else {
-                    matchLoc = mmr.maxLoc;
-                    minMaxVal = mmr.maxVal;
-                    matchAccuracy = minMaxVal;
-                }
-
-                var accuracyMessage = "Match accuracy is " + (int) Math.round(matchAccuracy * 100) + "% and threshold is " + (int) Math.round(threshold * 100) + "%. Match Method: " + matchMethod + ".";
-                ReportManager.logDiscrete(accuracyMessage);
-
-                if (SHAFT.Properties.reporting.debugMode()) {
-                    // debugging
-                    try {
-                        FileActions.getInstance(true).createFolder("target/openCV/");
-                        String timestamp = String.valueOf(System.currentTimeMillis());
-
-                        File output = new File("target/openCV/" + timestamp + "_1_templ.png");
-                        ImageIO.write((BufferedImage) HighGui.toBufferedImage(templ_original), "png", output);
-
-                        output = new File("target/openCV/" + timestamp + "_3_img.png");
-                        ImageIO.write((BufferedImage) HighGui.toBufferedImage(img_original), "png", output);
-
-                        Imgproc.rectangle(img_original, matchLoc, new Point(matchLoc.x + templ.cols(), matchLoc.y + templ.rows()),
-                                new Scalar(0, 0, 0), 2, 8, 0);
-                        output = new File("target/openCV/" + timestamp + "_5_output.png");
-                        ImageIO.write((BufferedImage) HighGui.toBufferedImage(img_original), "png", output);
-                    } catch (IOException e) {
-                        ReportManagerHelper.logDiscrete(e);
-                        return Collections.emptyList();
-                    }
-                }
-
-                if (matchAccuracy < threshold) {
-                    return Collections.emptyList();
-                }
-
-                // returning the top left corner +1 pixel
-                int x = Integer.parseInt(String.valueOf(matchLoc.x + 1).split("\\.")[0]);
-                int y = Integer.parseInt(String.valueOf(matchLoc.y + 1).split("\\.")[0]);
-
-                // creating highlighted image to be attached to the report
-                try {
-                    Imgproc.rectangle(img_original, matchLoc, new Point(matchLoc.x + templ.cols(), matchLoc.y + templ.rows()),
-                            new Scalar(67, 176, 42), 2, 8, 0); // selenium-green
-                    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                    ImageIO.write((BufferedImage) HighGui.toBufferedImage(img_original), "png", baos);
-                    var screenshot = new ScreenshotManager().prepareImageForReport(baos.toByteArray(), "AI identified element");
-                    List<List<Object>> attachments = new LinkedList<>();
-                    attachments.add(screenshot);
-                    ReportManagerHelper.log("Successfully identified the element using AI; OpenCV. " + accuracyMessage, attachments);
-                } catch (IOException e) {
-                    ReportManager.log("Successfully identified the element using AI; OpenCV. " + accuracyMessage);
-                }
-                return Arrays.asList(x, y);
-            } catch (org.opencv.core.CvException e) {
-                ReportManagerHelper.logDiscrete(e);
-                ReportManager.log("Failed to identify the element using AI; openCV core exception.");
-            }
-        }
-        return Collections.emptyList();
+        return output.toByteArray();
     }
 
     public static List<Integer> findImageWithinCurrentPage(String referenceImagePath, byte[] currentPageScreenshot) {
-        int maxNumberOfAttempts = 3;
-        int attempts = 0;
-        List<Integer> foundLocation = Collections.emptyList();
-        do {
-            try {
-                foundLocation = attemptToFindImageUsingOpenCV(referenceImagePath, currentPageScreenshot, attempts);
-            } catch (Exception e) {
-                ReportManagerHelper.logDiscrete(e);
-            }
-            attempts++;
-        } while (Collections.emptyList().equals(foundLocation) && attempts < maxNumberOfAttempts);
-        return foundLocation;
+        return VisualProcessingProviderRegistry.requireProvider()
+                .findImageWithinCurrentPage(referenceImagePath, currentPageScreenshot);
     }
 
     private static final ConcurrentHashMap<String, String> locatorHashMapping = new ConcurrentHashMap<>();
@@ -587,21 +423,7 @@ public class ImageProcessingActions {
     }
 
     public static void loadOpenCV() {
-        var libName = "";
-        try {
-            //https://github.com/openpnp/opencv#api
-            libName = org.opencv.core.Core.NATIVE_LIBRARY_NAME;
-            OpenCV.loadLocally();
-            ReportManager.logDiscrete("Loaded OpenCV \"" + libName + "\".");
-        } catch (Throwable throwable) {
-            ReportManagerHelper.logDiscrete(throwable);
-            if (!libName.isEmpty()) {
-                ReportManager.logDiscrete("Failed to load OpenCV \"" + libName + "\". Try installing the binaries manually https://opencv.org/releases/, switching element highlighting to JavaScript...");
-            } else {
-                ReportManager.logDiscrete("Failed to load OpenCV. Try installing the binaries manually https://opencv.org/releases/, switching element highlighting to JavaScript...");
-            }
-            SHAFT.Properties.visuals.set().screenshotParamsHighlightMethod("JavaScript");
-        }
+        VisualProcessingProviderRegistry.requireProvider().load();
     }
 
     private static String getAiFolderPath() {

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java
@@ -1,0 +1,205 @@
+package com.shaft.gui.internal.image;
+
+import com.shaft.cli.FileActions;
+import com.shaft.driver.SHAFT;
+import com.shaft.tools.io.ReportManager;
+import com.shaft.tools.io.internal.ReportManagerHelper;
+import nu.pattern.OpenCV;
+import org.opencv.core.Core;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.MatOfByte;
+import org.opencv.core.Point;
+import org.opencv.core.Scalar;
+import org.opencv.core.Size;
+import org.opencv.highgui.HighGui;
+import org.opencv.imgcodecs.Imgcodecs;
+import org.opencv.imgproc.Imgproc;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Current OpenCV-backed implementation of SHAFT visual processing.
+ *
+ * <p>This provider remains in the engine until it moves to the optional {@code io.github.shafthq:shaft-visual} artifact.</p>
+ */
+public class OpenCvVisualProcessingProvider implements VisualProcessingProvider {
+    private static final int CV_THRESH_OTSU = 8;
+    private static final int CV_THRESH_BINARY = 0;
+
+    private static Mat preprocess(byte[] image) {
+        //https://stackoverflow.com/questions/37302098/image-preprocessing-with-opencv-before-doing-character-recognition-tesseract
+        Mat img;
+        Mat imgGray = new Mat();
+        Mat imgGaussianBlur = new Mat();
+        Mat imgSobel = new Mat();
+        Mat imgThreshold = new Mat();
+
+        img = Imgcodecs.imdecode(new MatOfByte(image), Imgcodecs.IMREAD_COLOR);
+        Imgproc.cvtColor(img, imgGray, Imgproc.COLOR_BGR2GRAY);
+        Imgproc.GaussianBlur(imgGray, imgGaussianBlur, new Size(3, 3), 0);
+        Imgproc.Sobel(imgGaussianBlur, imgSobel, -1, 1, 0);
+        Imgproc.threshold(imgSobel, imgThreshold, 0, 255, CV_THRESH_OTSU + CV_THRESH_BINARY);
+
+        if (SHAFT.Properties.reporting.debugMode()) {
+            FileActions.getInstance(true).createFolder("target/openCV/temp/");
+            String timestamp = String.valueOf(System.currentTimeMillis());
+            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_1_True_Image.png", img);
+            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_2_imgGray.png", imgGray);
+            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_3_imgGaussianBlur.png", imgGaussianBlur);
+            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_4_imgSobel.png", imgSobel);
+            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_5_imgThreshold.png", imgThreshold);
+        }
+        return imgThreshold;
+    }
+
+    private static List<Integer> attemptToFindImageUsingOpenCV(String referenceImagePath, byte[] currentPageScreenshot, int attemptNumber) {
+        if (currentPageScreenshot == null || Arrays.equals(currentPageScreenshot, new byte[]{})) {
+            //target image is empty, force fail comparison
+            ReportManager.log("Failed to identify the element using AI; target screenshot is empty.");
+        } else {
+            Mat img_original = Imgcodecs.imdecode(new MatOfByte(currentPageScreenshot), Imgcodecs.IMREAD_COLOR);
+            Mat templ_original = Imgcodecs.imread(referenceImagePath, Imgcodecs.IMREAD_COLOR);
+
+            Mat img = preprocess(currentPageScreenshot);
+            Mat templ = preprocess(FileActions.getInstance(true).readFileAsByteArray(referenceImagePath));
+
+            // / Create the result matrix
+            int resultCols = img.cols() - templ.cols() + 1;
+            int resultRows = img.rows() - templ.rows() + 1;
+
+            Mat result = new Mat(resultRows, resultCols, CvType.CV_32FC1);
+
+            // / Do the Matching and Normalize
+            try {
+                // matchMethod 1 == Imgproc.TM_SQDIFF_NORMED
+                int matchMethod = Imgproc.TM_CCOEFF_NORMED;
+                double threshold = SHAFT.Properties.visuals.visualMatchingThreshold();
+
+                switch (attemptNumber) {
+                    case 1 -> matchMethod = Imgproc.TM_SQDIFF_NORMED;
+                    case 2 -> matchMethod = Imgproc.TM_CCORR_NORMED;
+                }
+
+                Imgproc.matchTemplate(img, templ, result, matchMethod);
+
+                // Localizing the best match with minMaxLoc
+                Core.MinMaxLocResult mmr = Core.minMaxLoc(result);
+
+                double minMaxVal;
+                double matchAccuracy;
+
+                org.opencv.core.Point matchLoc;
+                //noinspection ConstantValue
+                if (matchMethod == Imgproc.TM_SQDIFF || matchMethod == Imgproc.TM_SQDIFF_NORMED) {
+                    matchLoc = mmr.minLoc;
+                    minMaxVal = mmr.minVal;
+                    matchAccuracy = 1 - minMaxVal;
+                } else {
+                    matchLoc = mmr.maxLoc;
+                    minMaxVal = mmr.maxVal;
+                    matchAccuracy = minMaxVal;
+                }
+
+                var accuracyMessage = "Match accuracy is " + (int) Math.round(matchAccuracy * 100) + "% and threshold is " + (int) Math.round(threshold * 100) + "%. Match Method: " + matchMethod + ".";
+                ReportManager.logDiscrete(accuracyMessage);
+
+                if (SHAFT.Properties.reporting.debugMode()) {
+                    // debugging
+                    try {
+                        FileActions.getInstance(true).createFolder("target/openCV/");
+                        String timestamp = String.valueOf(System.currentTimeMillis());
+
+                        File output = new File("target/openCV/" + timestamp + "_1_templ.png");
+                        ImageIO.write((BufferedImage) HighGui.toBufferedImage(templ_original), "png", output);
+
+                        output = new File("target/openCV/" + timestamp + "_3_img.png");
+                        ImageIO.write((BufferedImage) HighGui.toBufferedImage(img_original), "png", output);
+
+                        Imgproc.rectangle(img_original, matchLoc, new Point(matchLoc.x + templ.cols(), matchLoc.y + templ.rows()),
+                                new Scalar(0, 0, 0), 2, 8, 0);
+                        output = new File("target/openCV/" + timestamp + "_5_output.png");
+                        ImageIO.write((BufferedImage) HighGui.toBufferedImage(img_original), "png", output);
+                    } catch (IOException e) {
+                        ReportManagerHelper.logDiscrete(e);
+                        return Collections.emptyList();
+                    }
+                }
+
+                if (matchAccuracy < threshold) {
+                    return Collections.emptyList();
+                }
+
+                // returning the top left corner +1 pixel
+                int x = Integer.parseInt(String.valueOf(matchLoc.x + 1).split("\\.")[0]);
+                int y = Integer.parseInt(String.valueOf(matchLoc.y + 1).split("\\.")[0]);
+
+                // creating highlighted image to be attached to the report
+                try {
+                    Imgproc.rectangle(img_original, matchLoc, new Point(matchLoc.x + templ.cols(), matchLoc.y + templ.rows()),
+                            new Scalar(67, 176, 42), 2, 8, 0); // selenium-green
+                    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                    ImageIO.write((BufferedImage) HighGui.toBufferedImage(img_original), "png", baos);
+                    var screenshot = new ScreenshotManager().prepareImageForReport(baos.toByteArray(), "AI identified element");
+                    List<List<Object>> attachments = new LinkedList<>();
+                    attachments.add(screenshot);
+                    ReportManagerHelper.log("Successfully identified the element using AI; OpenCV. " + accuracyMessage, attachments);
+                } catch (IOException e) {
+                    ReportManager.log("Successfully identified the element using AI; OpenCV. " + accuracyMessage);
+                }
+                return Arrays.asList(x, y);
+            } catch (org.opencv.core.CvException e) {
+                ReportManagerHelper.logDiscrete(e);
+                ReportManager.log("Failed to identify the element using AI; openCV core exception.");
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<Integer> findImageWithinCurrentPage(String referenceImagePath, byte[] currentPageScreenshot) {
+        int maxNumberOfAttempts = 3;
+        int attempts = 0;
+        List<Integer> foundLocation = Collections.emptyList();
+        do {
+            try {
+                foundLocation = attemptToFindImageUsingOpenCV(referenceImagePath, currentPageScreenshot, attempts);
+            } catch (Exception e) {
+                ReportManagerHelper.logDiscrete(e);
+            }
+            attempts++;
+        } while (Collections.emptyList().equals(foundLocation) && attempts < maxNumberOfAttempts);
+        return foundLocation;
+    }
+
+    @Override
+    public void load() {
+        var libName = "";
+        try {
+            //https://github.com/openpnp/opencv#api
+            libName = org.opencv.core.Core.NATIVE_LIBRARY_NAME;
+            OpenCV.loadLocally();
+            ReportManager.logDiscrete("Loaded OpenCV \"" + libName + "\".");
+        } catch (Throwable throwable) {
+            ReportManagerHelper.logDiscrete(throwable);
+            if (!libName.isEmpty()) {
+                ReportManager.logDiscrete("Failed to load OpenCV \"" + libName + "\". Try installing the binaries manually https://opencv.org/releases/, switching element highlighting to JavaScript...");
+            } else {
+                ReportManager.logDiscrete("Failed to load OpenCV. Try installing the binaries manually https://opencv.org/releases/, switching element highlighting to JavaScript...");
+            }
+            SHAFT.Properties.visuals.set().screenshotParamsHighlightMethod("JavaScript");
+        }
+    }
+
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/VisualProcessingProvider.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/VisualProcessingProvider.java
@@ -1,0 +1,25 @@
+package com.shaft.gui.internal.image;
+
+import java.util.List;
+
+/**
+ * SHAFT-owned contract for optional visual-processing implementations.
+ *
+ * <p>Implementations may use optional computer-vision libraries, while engine callers interact only with
+ * SHAFT and JDK types. Providers are discovered through {@link java.util.ServiceLoader}.</p>
+ */
+public interface VisualProcessingProvider {
+    /**
+     * Finds a reference image within a page screenshot.
+     *
+     * @param referenceImagePath path to the reference image
+     * @param currentPageScreenshot encoded current-page screenshot
+     * @return the matched x/y coordinates, or an empty list when no match is found
+     */
+    List<Integer> findImageWithinCurrentPage(String referenceImagePath, byte[] currentPageScreenshot);
+
+    /**
+     * Loads any native libraries required by this provider.
+     */
+    void load();
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/VisualProcessingProviderRegistry.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/VisualProcessingProviderRegistry.java
@@ -1,0 +1,51 @@
+package com.shaft.gui.internal.image;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+final class VisualProcessingProviderRegistry {
+    static final String MISSING_PROVIDER_MESSAGE = "Optional visual processing requires io.github.shafthq:shaft-visual on the runtime classpath.";
+    private static final ThreadLocal<Optional<VisualProcessingProvider>> providerOverride = new ThreadLocal<>();
+
+    private VisualProcessingProviderRegistry() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static Optional<VisualProcessingProvider> findProvider() {
+        if (providerOverride.get() != null) {
+            return providerOverride.get();
+        }
+        return selectProvider(ServiceLoader.load(VisualProcessingProvider.class)
+                .stream()
+                .map(ServiceLoader.Provider::get)
+                .toList());
+    }
+
+    static VisualProcessingProvider requireProvider() {
+        return findProvider().orElseThrow(() -> new IllegalStateException(MISSING_PROVIDER_MESSAGE));
+    }
+
+    static Optional<VisualProcessingProvider> selectProvider(List<VisualProcessingProvider> providers) {
+        List<VisualProcessingProvider> sortedProviders = providers.stream()
+                .sorted(Comparator.comparing(provider -> provider.getClass().getName()))
+                .toList();
+        if (sortedProviders.size() > 1) {
+            String providerNames = sortedProviders.stream()
+                    .map(provider -> provider.getClass().getName())
+                    .reduce((left, right) -> left + ", " + right)
+                    .orElse("");
+            throw new IllegalStateException("Multiple visual processing providers were found: " + providerNames);
+        }
+        return sortedProviders.stream().findFirst();
+    }
+
+    static void setProviderForTesting(VisualProcessingProvider provider) {
+        providerOverride.set(Optional.ofNullable(provider));
+    }
+
+    static void resetProviderForTesting() {
+        providerOverride.remove();
+    }
+}

--- a/shaft-engine/src/main/resources/META-INF/services/com.shaft.gui.internal.image.VisualProcessingProvider
+++ b/shaft-engine/src/main/resources/META-INF/services/com.shaft.gui.internal.image.VisualProcessingProvider
@@ -1,0 +1,1 @@
+com.shaft.gui.internal.image.OpenCvVisualProcessingProvider

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsCoverageUnitTest.java
@@ -40,8 +40,11 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -69,6 +72,7 @@ public class ImageProcessingActionsCoverageUnitTest {
     @AfterMethod(alwaysRun = true)
     public void afterMethod() throws Exception {
         setAiFolderPath(null);
+        VisualProcessingProviderRegistry.resetProviderForTesting();
         if (tempDir != null) {
             FILE_ACTIONS.deleteFolder(tempDir.toString());
         }
@@ -397,6 +401,50 @@ public class ImageProcessingActionsCoverageUnitTest {
         Assert.assertFalse(FILE_ACTIONS.doesFileExist(resizedTest.resolve("failedImagesDirectory").toString()));
     }
 
+
+    @Test
+    public void coreImageProcessingDescriptorsShouldNotExposeOpenCvTypes() {
+        boolean exposesOpenCvTypes = Arrays.stream(ImageProcessingActions.class.getDeclaredMethods())
+                .flatMap(method -> java.util.stream.Stream.concat(
+                        java.util.stream.Stream.of(method.getReturnType()),
+                        Arrays.stream(method.getParameterTypes())))
+                .map(Class::getName)
+                .anyMatch(typeName -> typeName.startsWith("org.opencv") || typeName.startsWith("nu.pattern"));
+
+        Assert.assertFalse(exposesOpenCvTypes);
+    }
+
+    @Test
+    public void coreImageProcessingClassShouldLoadWhenOpenCvIsBlocked() throws Exception {
+        ClassLoader blockingLoader = new OpenCvBlockingClassLoader(ImageProcessingActions.class.getClassLoader());
+
+        Class<?> imageProcessingClass = Class.forName(ImageProcessingActions.class.getName(), false, blockingLoader);
+
+        Assert.assertEquals(imageProcessingClass.getName(), ImageProcessingActions.class.getName());
+        Assert.assertTrue(Modifier.isPublic(imageProcessingClass.getModifiers()));
+        Assert.assertEquals(imageProcessingClass.getDeclaredMethod("formatElementLocatorToImagePath", By.class)
+                .getReturnType(), String.class);
+    }
+
+    @Test
+    public void missingVisualProviderShouldReportFutureShaftVisualCoordinate() {
+        VisualProcessingProviderRegistry.setProviderForTesting(null);
+
+        IllegalStateException exception = Assert.expectThrows(IllegalStateException.class,
+                () -> ImageProcessingActions.findImageWithinCurrentPage("reference.png", createPng(4, 4, Color.WHITE)));
+
+        Assert.assertTrue(exception.getMessage().contains("io.github.shafthq:shaft-visual"));
+    }
+
+    @Test
+    public void providerOverrideShouldKeepOptionalVisualDiscoveryDeterministic() {
+        VisualProcessingProvider provider = mock(VisualProcessingProvider.class);
+        when(provider.findImageWithinCurrentPage(anyString(), any())).thenReturn(List.of(1, 2));
+        VisualProcessingProviderRegistry.setProviderForTesting(provider);
+
+        Assert.assertEquals(ImageProcessingActions.findImageWithinCurrentPage("reference.png", new byte[]{1}), List.of(1, 2));
+    }
+
     @Test
     public void loadOpenCvShouldSwitchHighlightingToJavaScriptWhenLoadingFails() {
         try (MockedStatic<OpenCV> openCvMocked = Mockito.mockStatic(OpenCV.class)) {
@@ -471,4 +519,44 @@ public class ImageProcessingActionsCoverageUnitTest {
         }
         return output.toByteArray();
     }
+
+    private static class OpenCvBlockingClassLoader extends ClassLoader {
+        private static final String TARGET_CLASS = "com.shaft.gui.internal.image.ImageProcessingActions";
+
+        OpenCvBlockingClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (name.startsWith("org.opencv") || name.startsWith("nu.pattern")) {
+                throw new ClassNotFoundException(name);
+            }
+            if (TARGET_CLASS.equals(name)) {
+                Class<?> loadedClass = findLoadedClass(name);
+                if (loadedClass == null) {
+                    loadedClass = findClass(name);
+                }
+                if (resolve) {
+                    resolveClass(loadedClass);
+                }
+                return loadedClass;
+            }
+            return super.loadClass(name, resolve);
+        }
+
+        @Override
+        protected Class<?> findClass(String name) throws ClassNotFoundException {
+            if (!TARGET_CLASS.equals(name)) {
+                return super.findClass(name);
+            }
+            try {
+                byte[] bytes = Files.readAllBytes(Path.of("target", "classes", "com", "shaft", "gui", "internal", "image", "ImageProcessingActions.class"));
+                return defineClass(name, bytes, 0, bytes.length);
+            } catch (Exception e) {
+                throw new ClassNotFoundException(name, e);
+            }
+        }
+    }
+
 }

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/image/VisualProcessingProviderRegistryTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/image/VisualProcessingProviderRegistryTest.java
@@ -1,0 +1,67 @@
+package com.shaft.gui.internal.image;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+
+public class VisualProcessingProviderRegistryTest {
+    @AfterMethod(alwaysRun = true)
+    public void afterMethod() {
+        VisualProcessingProviderRegistry.resetProviderForTesting();
+    }
+
+    @Test
+    public void selectProviderShouldReturnEmptyForNoProviders() {
+        Assert.assertTrue(VisualProcessingProviderRegistry.selectProvider(Collections.emptyList()).isEmpty());
+    }
+
+    @Test
+    public void selectProviderShouldReturnTheSingleProvider() {
+        VisualProcessingProvider provider = mock(VisualProcessingProvider.class);
+
+        Assert.assertSame(VisualProcessingProviderRegistry.selectProvider(List.of(provider)).orElseThrow(), provider);
+    }
+
+    @Test
+    public void selectProviderShouldFailWithProvidersSortedByClassName() {
+        VisualProcessingProvider zuluProvider = new ZuluProvider();
+        VisualProcessingProvider alphaProvider = new AlphaProvider();
+
+        IllegalStateException exception = Assert.expectThrows(IllegalStateException.class,
+                () -> VisualProcessingProviderRegistry.selectProvider(List.of(zuluProvider, alphaProvider)));
+
+        String message = exception.getMessage();
+        Assert.assertTrue(message.contains("Multiple visual processing providers were found"));
+        Assert.assertTrue(message.indexOf(alphaProvider.getClass().getName())
+                < message.indexOf(zuluProvider.getClass().getName()));
+    }
+
+    private static class AlphaProvider implements VisualProcessingProvider {
+        @Override
+        public List<Integer> findImageWithinCurrentPage(String referenceImagePath, byte[] currentPageScreenshot) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void load() {
+            // No-op test provider.
+        }
+    }
+
+    private static class ZuluProvider implements VisualProcessingProvider {
+        @Override
+        public List<Integer> findImageWithinCurrentPage(String referenceImagePath, byte[] currentPageScreenshot) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void load() {
+            // No-op test provider.
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Decouple core screenshot capture and JDK-based image helpers from OpenCV-dependent visual processing so the heavy OpenCV artifact can be moved to an optional module. 
- Make provider discovery deterministic and testable while preserving existing OpenCV behavior until extraction. 

### Description
- Removed direct OpenCV types from `ImageProcessingActions` public surface and replaced element highlighting with a pure-JDK `BufferedImage`/`Graphics2D` implementation. 
- Delegated optional visual operations (`findImageWithinCurrentPage` and `loadOpenCV`) to a new SHAFT-owned provider contract `VisualProcessingProvider` and a `VisualProcessingProviderRegistry` that discovers implementations via `ServiceLoader`. 
- Added an in-repo OpenCV-backed provider `OpenCvVisualProcessingProvider` and registered it under `META-INF/services` so existing behavior remains available until `shaft-visual` is extracted. 
- Updated and added tests and a short doc: created `VisualProcessingProviderRegistryTest`, adjusted `ImageProcessingActionsCoverageUnitTest` to include class-loading/no-OpenCV scenarios, and added `docs/VISUAL_PROCESSING_PROVIDER_BOUNDARY.md` describing the boundary and decisions. 

### Testing
- Compiled the engine with `mvn -pl shaft-engine -am -DskipTests compile` which completed successfully. 
- Ran targeted unit tests `mvn -pl shaft-engine -am test -Dtest=ImageProcessingActionsCoverageUnitTest,VisualProcessingProviderRegistryTest` and observed `34` tests executed with `34` passed and `0` failures. 
- Performed a full module build `mvn clean install -DskipTests -Dgpg.skip` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26cb581d9c83209cad97cbaf41812f)