### PR TITLE
codex: migrate GitHub Actions and Allure paths to the Maven reactor

### DIFF
--- a/.github/actions/post-test-report/action.yml
+++ b/.github/actions/post-test-report/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: 'Codecov upload token'
     required: false
     default: ''
+  module-directory:
+    description: 'Module that produced the test and report outputs'
+    required: false
+    default: 'shaft-engine'
 runs:
   using: 'composite'
   steps:
@@ -39,7 +43,7 @@ runs:
       with:
         token: ${{ inputs.codecov-token }}
         fail_ci_if_error: false
-        files: ./target/jacoco/jacoco.xml
+        files: ./${{ inputs.module-directory }}/target/jacoco/jacoco.xml
         verbose: true
         disable_search: true
     - name: Generate Allure Report Fallback
@@ -48,27 +52,38 @@ runs:
       run: |
         # Derive Allure 3 version from Internal.java — the single source of truth for the engine.
         ALLURE3_VERSION=$(grep -A2 'Key("allure3Version")' \
-          src/main/java/com/shaft/properties/internal/Internal.java \
+          shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java \
           | grep '@DefaultValue' | sed 's/.*@DefaultValue("\([^"]*\)").*/\1/')
         ALLURE3_VERSION=${ALLURE3_VERSION:-3.3.1}
-        if [ -d "allure-results" ] && [ -n "$(ls -A allure-results 2>/dev/null)" ]; then
+        if [ -d "${{ inputs.module-directory }}/allure-results" ] && [ -n "$(ls -A "${{ inputs.module-directory }}/allure-results" 2>/dev/null)" ]; then
           # Generate single-file report if SHAFT didn't already create one
-          if ! ls allure-report/*AllureReport.html 1>/dev/null 2>&1; then
-            npx --yes allure@${ALLURE3_VERSION} generate allure-results --config allurerc.yaml -o allure-report 2>/dev/null || true
-            if [ -f "allure-report/index.html" ]; then
-              mv allure-report/index.html allure-report/AllureReport.html
+          if ! ls "${{ inputs.module-directory }}"/allure-report/*AllureReport.html 1>/dev/null 2>&1; then
+            CONFIG_FILE="${{ inputs.module-directory }}/allurerc.yaml"
+            if [ ! -f "$CONFIG_FILE" ]; then
+              CONFIG_FILE="${RUNNER_TEMP:-/tmp}/shaft-allurerc.yaml"
+              cat > "$CONFIG_FILE" <<'YAML'
+        plugins:
+          awesome:
+            options:
+              reportName: "SHAFT-powered test report"
+              singleFile: true
+        YAML
+            fi
+            npx --yes allure@${ALLURE3_VERSION} generate "${{ inputs.module-directory }}/allure-results" --config "$CONFIG_FILE" -o "${{ inputs.module-directory }}/allure-report" 2>/dev/null || true
+            if [ -f "${{ inputs.module-directory }}/allure-report/index.html" ]; then
+              mv "${{ inputs.module-directory }}/allure-report/index.html" "${{ inputs.module-directory }}/allure-report/AllureReport.html"
             fi
           fi
         fi
     - name: Rename Allure Report for Upload
       if: always()
       shell: bash
-      run: mv allure-report/*AllureReport.html "allure-report/${{ inputs.job-name }}_Allure.html" 2>/dev/null || true
+      run: mv "${{ inputs.module-directory }}"/allure-report/*AllureReport.html "${{ inputs.module-directory }}/allure-report/${{ inputs.job-name }}_Allure.html" 2>/dev/null || true
     - name: Upload Allure Report as Pipeline Artifact
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        path: "allure-report/${{ inputs.job-name }}_Allure.html"
+        path: "${{ inputs.module-directory }}/allure-report/${{ inputs.job-name }}_Allure.html"
         archive: false
     - name: Write Summary and Check Test Results
       id: collect_results
@@ -85,8 +100,15 @@ runs:
           grep -o "\"${field}\" *: *[0-9]*" "$file" 2>/dev/null | head -1 | grep -o '[0-9]*' || true
         }
 
+        # Count raw Allure result files before interpreting the generated summary.
+        # An empty raw-results directory means the run is invalid, even if a stale summary exists.
+        ALLURE_RESULTS_DIR="${{ inputs.module-directory }}/allure-results"
+        RESULT_COUNT=$(find "$ALLURE_RESULTS_DIR" -name '*-result.json' -type f 2>/dev/null | wc -l | tr -d ' ')
+        RESULT_COUNT=${RESULT_COUNT:-0}
+        echo "Allure raw result files: $RESULT_COUNT"
+
         # SHAFT writes summary.json at the report root after generating the single-file HTML.
-        ALLURE_SUMMARY="allure-report/summary.json"
+        ALLURE_SUMMARY="${{ inputs.module-directory }}/allure-report/summary.json"
 
         if [ -f "$ALLURE_SUMMARY" ]; then
           TOTAL=$(extract_field total "$ALLURE_SUMMARY");   TOTAL=${TOTAL:-0}
@@ -135,16 +157,21 @@ runs:
 
         # Primary check: use Allure report data.
         if [ -f "$ALLURE_SUMMARY" ]; then
+          if [ "$RESULT_COUNT" -eq 0 ]; then
+            echo "::error::No raw Allure result files were generated in $ALLURE_RESULTS_DIR. Treating this as an invalid test run."
+            exit 1
+          fi
           if [ "$TOTAL" -eq 0 ]; then
-            echo "::warning::No tests were executed. Check test configuration."
+            echo "::error::No tests were executed according to the Allure summary. Check test configuration."
+            exit 1
           fi
           if [ "$FAILED" -gt 0 ] || [ "$BROKEN" -gt 0 ]; then
             if command -v python3 >/dev/null 2>&1; then
               ALLURE_FAILURE_SOURCE=""
-              if [ -d "allure-results" ]; then
-                ALLURE_FAILURE_SOURCE="allure-results"
-              elif [ -d "allure-report" ]; then
-                ALLURE_FAILURE_SOURCE="allure-report"
+              if [ -d "${{ inputs.module-directory }}/allure-results" ]; then
+                ALLURE_FAILURE_SOURCE="${{ inputs.module-directory }}/allure-results"
+              elif [ -d "${{ inputs.module-directory }}/allure-report" ]; then
+                ALLURE_FAILURE_SOURCE="${{ inputs.module-directory }}/allure-report"
               fi
               if [ -n "$ALLURE_FAILURE_SOURCE" ]; then
                 {
@@ -159,10 +186,14 @@ runs:
           fi
           echo "All tests passed according to Allure report."
         else
+          if [ "$RESULT_COUNT" -eq 0 ]; then
+            echo "::error::No Allure summary or raw result files were generated for ${{ inputs.module-directory }}."
+            exit 1
+          fi
           echo "::warning::Allure report summary not found. Falling back to surefire reports."
           # Fallback: Check surefire reports if allure data is unavailable.
-          if [ -d "target/surefire-reports" ]; then
-            if grep -rq "failures=\"[1-9]" target/surefire-reports/ || grep -rq "errors=\"[1-9]" target/surefire-reports/; then
+          if [ -d "${{ inputs.module-directory }}/target/surefire-reports" ]; then
+            if grep -rq "failures=\"[1-9]" "${{ inputs.module-directory }}/target/surefire-reports/" || grep -rq "errors=\"[1-9]" "${{ inputs.module-directory }}/target/surefire-reports/"; then
               echo "::error::Surefire reports indicate test failures. Failing the job."
               exit 1
             fi

--- a/.github/workflows/code-quality-scan.yml
+++ b/.github/workflows/code-quality-scan.yml
@@ -30,13 +30,13 @@ jobs:
           maven-version: 3.9.5
 
       - name: Compile
-        run: mvn clean compile -DskipTests -Dgpg.skip -q
+        run: mvn -pl shaft-engine -am clean compile -DskipTests -Dgpg.skip -q
 
       - name: Check for Dependency Updates
         id: dep-updates
         run: |
-          mvn versions:display-dependency-updates -Dgpg.skip 2>&1 | tee /tmp/dep-updates-raw.txt || true
-          mvn versions:display-plugin-updates -Dgpg.skip 2>&1 | tee -a /tmp/dep-updates-raw.txt || true
+          mvn -pl shaft-engine,shaft-browserstack,shaft-video,shaft-visual -am versions:display-dependency-updates -Dgpg.skip 2>&1 | tee /tmp/dep-updates-raw.txt || true
+          mvn -pl shaft-engine,shaft-browserstack,shaft-video,shaft-visual -am versions:display-plugin-updates -Dgpg.skip 2>&1 | tee -a /tmp/dep-updates-raw.txt || true
 
           # Capture only true stable upgrades (exclude prereleases and version downgrades)
           python3 <<'PY'
@@ -132,7 +132,7 @@ jobs:
               VALIDATION_FAILED=true
               FAILED_POMS="${FAILED_POMS}\n- $POM"
             fi
-          done < <(find src/main/resources/examples -name "pom.xml" -print0)
+          done < <(find shaft-engine/src/main/resources/examples -name "pom.xml" -print0)
 
           if [ "$VALIDATION_FAILED" = true ]; then
             echo "Sample project validation failed for the following pom.xml files:"
@@ -147,7 +147,7 @@ jobs:
           DRIFT_FOUND=false
           DRIFT_DETAILS=""
 
-          for POM in $(find src/main/resources/examples -name "pom.xml"); do
+          for POM in $(find shaft-engine/src/main/resources/examples -name "pom.xml"); do
             SAMPLE_VERSION=$(grep '<shaft_engine.version>' "$POM" | head -1 | sed 's/.*<shaft_engine.version>\(.*\)<\/shaft_engine.version>.*/\1/' | tr -d ' ')
             if [ -n "$SAMPLE_VERSION" ] && [ "$SAMPLE_VERSION" != "$MAIN_VERSION" ]; then
               DRIFT_FOUND=true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -61,7 +61,7 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-        run: mvn -B clean package --file pom.xml -DskipTests
+        run: mvn -B -pl shaft-engine,shaft-browserstack,shaft-video,shaft-visual -am clean package --file pom.xml -DskipTests
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -29,4 +29,4 @@ jobs:
           maven-version: 3.9.5
 
       - name: Pre-download Maven dependencies
-        run: mvn dependency:resolve -DskipTests -Dgpg.skip
+        run: mvn -pl shaft-engine,shaft-browserstack,shaft-video,shaft-visual -am dependency:resolve -DskipTests -Dgpg.skip

--- a/.github/workflows/coverage-readiness.yml
+++ b/.github/workflows/coverage-readiness.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Generate JaCoCo report
         if: always()
-        run: mvn -pl shaft-engine jacoco:report -Dgpg.skip
+        run: mvn -pl shaft-engine -am jacoco:report -Dgpg.skip
 
       - name: Summarize coverage
         id: coverage

--- a/.github/workflows/e2eMoonTests.yml
+++ b/.github/workflows/e2eMoonTests.yml
@@ -72,9 +72,9 @@ jobs:
       - name: Enable JUnit Test Runtime
         shell: bash
         run: |
-          mkdir -p src/test/resources/META-INF/services
-          rm -f src/test/resources/META-INF/services/org.testng.ITestNGListener
-          printf 'com.shaft.listeners.JunitListener\n' > src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+          mkdir -p shaft-engine/src/test/resources/META-INF/services
+          rm -f shaft-engine/src/test/resources/META-INF/services/org.testng.ITestNGListener
+          printf 'com.shaft.listeners.JunitListener\n' > shaft-engine/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
 
       - name: Run Moon Tests
         continue-on-error: true
@@ -96,7 +96,7 @@ jobs:
         if: always()
         shell: bash
         run: |
-          RESULT_COUNT=$(find allure-results -name '*-result.json' -type f 2>/dev/null | wc -l | tr -d ' ')
+          RESULT_COUNT=$(find shaft-engine/allure-results -name '*-result.json' -type f 2>/dev/null | wc -l | tr -d ' ')
           echo "Allure result files: ${RESULT_COUNT}"
           if [ "${RESULT_COUNT}" -lt 2 ]; then
             echo "::error::Expected MoonTests to generate at least 2 Allure result files."

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   Workflow_Summary:
     if: always()
-    needs: [Ubuntu_Database, Ubuntu_APIs, Ubuntu_Firefox_Grid, Ubuntu_Chrome_Grid, Ubuntu_MicrosoftEdge_Grid, Android_Native_BrowserStack, iOS_Web_SAFARI_BrowserStack, Android_Web_Chrome_BrowserStack, MacOSX_Safari_BrowserStack, Ubuntu_Chrome_Cucumber_Grid, MacOSX_Safari_Cucumber_BrowserStack]
+    needs: [Ubuntu_Database, Ubuntu_APIs, Ubuntu_Visual_Module, Ubuntu_Desktop_Video_Module, Ubuntu_Firefox_Grid, Ubuntu_Chrome_Grid, Ubuntu_MicrosoftEdge_Grid, Android_Native_BrowserStack, iOS_Web_SAFARI_BrowserStack, Android_Web_Chrome_BrowserStack, MacOSX_Safari_BrowserStack, Ubuntu_Chrome_Cucumber_Grid, MacOSX_Safari_Cucumber_BrowserStack]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Connect to PostgreSQL
         run: |
-            cd src/main/resources/docker-compose/postgres/
+            cd shaft-engine/src/main/resources/docker-compose/postgres/
             npm install pg
             node client.js
         env:
@@ -107,6 +107,64 @@ jobs:
           job-name: Ubuntu_APIs
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
+  Ubuntu_Visual_Module:
+    runs-on: ubuntu-latest
+    outputs:
+      job: ${{ steps.post_test_report.outputs.job }}
+      total: ${{ steps.post_test_report.outputs.total }}
+      passed: ${{ steps.post_test_report.outputs.passed }}
+      failed: ${{ steps.post_test_report.outputs.failed }}
+      broken: ${{ steps.post_test_report.outputs.broken }}
+      skipped: ${{ steps.post_test_report.outputs.skipped }}
+      duration: ${{ steps.post_test_report.outputs.duration }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test-env
+        with:
+          node-version: '20'
+      - name: Run visual module tests
+        continue-on-error: true
+        run: mvn -pl shaft-visual -am -e test "-DretryMaximumNumberOfAttempts=1" "-DgenerateAllureReportArchive=true" "-Dtest=ImageProcessingActionsUnitTest"
+      - name: Post-Test Report and Check
+        id: post_test_report
+        if: always()
+        uses: ./.github/actions/post-test-report
+        with:
+          job-name: Ubuntu_Visual_Module
+          module-directory: shaft-visual
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
+  Ubuntu_Desktop_Video_Module:
+    runs-on: ubuntu-latest
+    outputs:
+      job: ${{ steps.post_test_report.outputs.job }}
+      total: ${{ steps.post_test_report.outputs.total }}
+      passed: ${{ steps.post_test_report.outputs.passed }}
+      failed: ${{ steps.post_test_report.outputs.failed }}
+      broken: ${{ steps.post_test_report.outputs.broken }}
+      skipped: ${{ steps.post_test_report.outputs.skipped }}
+      duration: ${{ steps.post_test_report.outputs.duration }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test-env
+        with:
+          node-version: '20'
+      - name: Run desktop video module tests
+        continue-on-error: true
+        run: mvn -pl shaft-video -am -e test "-DretryMaximumNumberOfAttempts=1" "-DgenerateAllureReportArchive=true" "-Dtest=DesktopVideoRecordingProviderRegistrationTest"
+      - name: Post-Test Report and Check
+        id: post_test_report
+        if: always()
+        uses: ./.github/actions/post-test-report
+        with:
+          job-name: Ubuntu_Desktop_Video_Module
+          module-directory: shaft-video
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
   Ubuntu_Firefox_Grid:
     runs-on: ubuntu-latest
     permissions:
@@ -123,7 +181,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
       - name: Set up Native Selenium Grid
-        run: docker compose -f src/main/resources/docker-compose/selenium4.yml up --scale chrome=0 --scale edge=0 --scale firefox=10 -d
+        run: docker compose -f shaft-engine/src/main/resources/docker-compose/selenium4.yml up --scale chrome=0 --scale edge=0 --scale firefox=10 -d
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test-env
         with:
@@ -157,7 +215,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
       - name: Set up Native Selenium Grid
-        run: docker compose -f src/main/resources/docker-compose/selenium4.yml up --scale chrome=10 --scale edge=0 --scale firefox=0 -d
+        run: docker compose -f shaft-engine/src/main/resources/docker-compose/selenium4.yml up --scale chrome=10 --scale edge=0 --scale firefox=0 -d
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test-env
         with:
@@ -191,7 +249,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
       - name: Set up Native Selenium Grid
-        run: docker compose -f src/main/resources/docker-compose/selenium4.yml up --scale chrome=0 --scale edge=10 --scale firefox=0 -d
+        run: docker compose -f shaft-engine/src/main/resources/docker-compose/selenium4.yml up --scale chrome=0 --scale edge=10 --scale firefox=0 -d
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test-env
         with:
@@ -336,7 +394,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
       - name: Set up Native Selenium Grid
-        run: docker compose -f src/main/resources/docker-compose/selenium4.yml up --scale chrome=10 --scale edge=0 --scale firefox=0 -d
+        run: docker compose -f shaft-engine/src/main/resources/docker-compose/selenium4.yml up --scale chrome=10 --scale edge=0 --scale firefox=0 -d
       - name: Setup Test Environment
         uses: ./.github/actions/setup-test-env
         with:

--- a/.github/workflows/publishJavaDocs.yml
+++ b/.github/workflows/publishJavaDocs.yml
@@ -52,3 +52,5 @@ jobs:
           javadoc-branch: javadoc
           java-version: 25
           project: maven
+          custom-command: mvn -pl shaft-engine -am javadoc:javadoc -Dgpg.skip
+          javadoc-source-folder: shaft-engine/target/reports/apidocs

--- a/.github/workflows/sync-sample-projects-version.yml
+++ b/.github/workflows/sync-sample-projects-version.yml
@@ -89,7 +89,7 @@ jobs:
         id: check-current
         run: |
           # Get unique shaft_engine versions from example pom.xml files
-          CURRENT_VERSIONS=$(find src/main/resources/examples -name "pom.xml" -exec grep -h '<shaft_engine.version>' {} \; | sed 's/.*<shaft_engine.version>\(.*\)<\/shaft_engine.version>.*/\1/' | tr -d ' ' | sort -u | tr '\n' ' ')
+          CURRENT_VERSIONS=$(find shaft-engine/src/main/resources/examples -name "pom.xml" -exec grep -h '<shaft_engine.version>' {} \; | sed 's/.*<shaft_engine.version>\(.*\)<\/shaft_engine.version>.*/\1/' | tr -d ' ' | sort -u | tr '\n' ' ')
           echo "CURRENT_VERSIONS=$CURRENT_VERSIONS" >> $GITHUB_OUTPUT
           echo "Current SHAFT versions in examples: $CURRENT_VERSIONS"
 
@@ -134,7 +134,7 @@ jobs:
           CHANGES_MADE=false
           FILES_UPDATED=()
 
-          for POM_FILE in $(find src/main/resources/examples -name "pom.xml"); do
+          for POM_FILE in $(find shaft-engine/src/main/resources/examples -name "pom.xml"); do
             FILE_CHANGED=false
 
             update_property "$POM_FILE" "shaft_engine.version" "$NEW_VERSION" && FILE_CHANGED=true
@@ -204,9 +204,9 @@ jobs:
             ${{ steps.update-files.outputs.files_updated }}
 
             ### 📁 Sample Projects Locations:
-            - `src/main/resources/examples/TestNG/`
-            - `src/main/resources/examples/JUnit/`
-            - `src/main/resources/examples/Cucumber/`
+            - `shaft-engine/src/main/resources/examples/TestNG/`
+            - `shaft-engine/src/main/resources/examples/JUnit/`
+            - `shaft-engine/src/main/resources/examples/Cucumber/`
 
             ### 📋 Trigger:
             - ${{ github.event_name == 'release' && format('Triggered by release: {0}', github.event.release.tag_name) || (github.event.inputs.version != '' && format('Manually triggered with version: {0}', github.event.inputs.version) || 'Manually triggered workflow') }}

--- a/.github/workflows/update-selenium-grid-versions.yml
+++ b/.github/workflows/update-selenium-grid-versions.yml
@@ -64,10 +64,10 @@ jobs:
       - name: Check Current Versions
         id: check-current
         run: |
-          CURRENT_CHROME=$(grep 'image: selenium/node-chrome:' src/main/resources/docker-compose/selenium4.yml | head -1 | sed 's/.*selenium\/node-chrome://; s/[[:space:]]*$//')
-          CURRENT_EDGE=$(grep 'image: selenium/node-edge:' src/main/resources/docker-compose/selenium4.yml | head -1 | sed 's/.*selenium\/node-edge://; s/[[:space:]]*$//')
-          CURRENT_FIREFOX=$(grep 'image: selenium/node-firefox:' src/main/resources/docker-compose/selenium4.yml | head -1 | sed 's/.*selenium\/node-firefox://; s/[[:space:]]*$//')
-          CURRENT_HUB=$(grep 'image: selenium/hub:' src/main/resources/docker-compose/selenium4.yml | head -1 | sed 's/.*selenium\/hub://; s/[[:space:]]*$//')
+          CURRENT_CHROME=$(grep 'image: selenium/node-chrome:' shaft-engine/src/main/resources/docker-compose/selenium4.yml | head -1 | sed 's/.*selenium\/node-chrome://; s/[[:space:]]*$//')
+          CURRENT_EDGE=$(grep 'image: selenium/node-edge:' shaft-engine/src/main/resources/docker-compose/selenium4.yml | head -1 | sed 's/.*selenium\/node-edge://; s/[[:space:]]*$//')
+          CURRENT_FIREFOX=$(grep 'image: selenium/node-firefox:' shaft-engine/src/main/resources/docker-compose/selenium4.yml | head -1 | sed 's/.*selenium\/node-firefox://; s/[[:space:]]*$//')
+          CURRENT_HUB=$(grep 'image: selenium/hub:' shaft-engine/src/main/resources/docker-compose/selenium4.yml | head -1 | sed 's/.*selenium\/hub://; s/[[:space:]]*$//')
           
           echo "CURRENT_CHROME=$CURRENT_CHROME" >> $GITHUB_OUTPUT
           echo "CURRENT_EDGE=$CURRENT_EDGE" >> $GITHUB_OUTPUT
@@ -98,25 +98,25 @@ jobs:
           
           if [ "$NEW_CHROME" != "$CURRENT_CHROME" ]; then
             echo "Updating Chrome from $CURRENT_CHROME to $NEW_CHROME"
-            sed -i "s|selenium/node-chrome:$CURRENT_CHROME|selenium/node-chrome:$NEW_CHROME|g" src/main/resources/docker-compose/selenium4.yml
+            sed -i "s|selenium/node-chrome:$CURRENT_CHROME|selenium/node-chrome:$NEW_CHROME|g" shaft-engine/src/main/resources/docker-compose/selenium4.yml
             CHANGES_MADE=true
           fi
           
           if [ "$NEW_EDGE" != "$CURRENT_EDGE" ]; then
             echo "Updating Edge from $CURRENT_EDGE to $NEW_EDGE"
-            sed -i "s|selenium/node-edge:$CURRENT_EDGE|selenium/node-edge:$NEW_EDGE|g" src/main/resources/docker-compose/selenium4.yml
+            sed -i "s|selenium/node-edge:$CURRENT_EDGE|selenium/node-edge:$NEW_EDGE|g" shaft-engine/src/main/resources/docker-compose/selenium4.yml
             CHANGES_MADE=true
           fi
           
           if [ "$NEW_FIREFOX" != "$CURRENT_FIREFOX" ]; then
             echo "Updating Firefox from $CURRENT_FIREFOX to $NEW_FIREFOX"
-            sed -i "s|selenium/node-firefox:$CURRENT_FIREFOX|selenium/node-firefox:$NEW_FIREFOX|g" src/main/resources/docker-compose/selenium4.yml
+            sed -i "s|selenium/node-firefox:$CURRENT_FIREFOX|selenium/node-firefox:$NEW_FIREFOX|g" shaft-engine/src/main/resources/docker-compose/selenium4.yml
             CHANGES_MADE=true
           fi
           
           if [ "$NEW_HUB" != "$CURRENT_HUB" ]; then
             echo "Updating Hub from $CURRENT_HUB to $NEW_HUB"
-            sed -i "s|selenium/hub:$CURRENT_HUB|selenium/hub:$NEW_HUB|g" src/main/resources/docker-compose/selenium4.yml
+            sed -i "s|selenium/hub:$CURRENT_HUB|selenium/hub:$NEW_HUB|g" shaft-engine/src/main/resources/docker-compose/selenium4.yml
             CHANGES_MADE=true
           fi
           
@@ -131,7 +131,7 @@ jobs:
       - name: Validate Docker Compose File
         if: steps.update-file.outputs.changes == 'true'
         run: |
-          docker compose -f src/main/resources/docker-compose/selenium4.yml config > /dev/null
+          docker compose -f shaft-engine/src/main/resources/docker-compose/selenium4.yml config > /dev/null
           echo "Docker Compose file validation successful"
 
       - name: Create Pull Request

--- a/docs/MAVEN_REACTOR.md
+++ b/docs/MAVEN_REACTOR.md
@@ -8,11 +8,12 @@ relocation artifact that points consumers to the canonical JAR.
 
 - The root `pom.xml` is the `io.github.shafthq:shaft-parent` aggregator and build parent. It owns shared version properties, dependency management, and plugin management.
 - `shaft-engine/pom.xml` builds the engine JAR. All framework source, resources, tests, examples, and runtime support assets remain under `shaft-engine/src/`; Java packages remain under `com.shaft`.
-- `shaft-bom/pom.xml` publishes the consumer BOM. Importing it manages the `shaft-engine`, `shaft-browserstack`, and `shaft-video` versions without adding dependencies by itself.
+- `shaft-bom/pom.xml` publishes the consumer BOM. Importing it manages the `shaft-engine`, `shaft-browserstack`, `shaft-video`, and `shaft-visual` versions without adding dependencies by itself.
 - `shaft-video/pom.xml` builds the optional desktop video recording provider. Add it when local desktop screen recording is needed; Appium-native recording remains in `shaft-engine`.
+- `shaft-visual/pom.xml` builds the optional OpenCV visual-processing provider and its focused visual tests.
 - `legacy-shaft-engine/pom.xml` publishes the legacy `SHAFT_ENGINE` coordinate as relocation metadata only; it contains no classes.
 
-API, Appium/mobile, database, OpenCV visual processing, and every other retained core capability remain dependencies of the engine module. Optional BrowserStack SDK support and desktop video/FFmpeg support are provided by `shaft-browserstack` and `shaft-video`.
+API, Appium/mobile, database, and other retained core capabilities remain dependencies of the engine module. Optional BrowserStack SDK, desktop video/FFmpeg, and OpenCV visual-processing support are provided by `shaft-browserstack`, `shaft-video`, and `shaft-visual` respectively.
 
 ## Consumer usage
 
@@ -56,7 +57,9 @@ Run commands from the repository root:
 python3 scripts/ci/validate_reactor_versions.py
 mvn clean install -DskipTests -Dgpg.skip
 mvn -pl shaft-engine -am test -Dtest=TestClassName
+mvn -pl shaft-browserstack -am test -Dtest=BrowserStackHelperUnitTest
 mvn -pl shaft-video -am test -Dtest=DesktopVideoRecordingProviderRegistrationTest
+mvn -pl shaft-visual -am test -Dtest=ImageProcessingActionsUnitTest
 mvn -pl shaft-engine -am test
 mvn -pl shaft-engine javadoc:javadoc
 ```
@@ -65,7 +68,8 @@ Build and test outputs are module-local. Important locations include:
 
 - Engine JAR: `shaft-engine/target/shaft-engine-<version>.jar`
 - Optional desktop video JAR: `shaft-video/target/shaft-video-<version>.jar`
-- Surefire reports: `shaft-engine/target/surefire-reports/` and `shaft-video/target/surefire-reports/`
+- Optional visual-processing JAR: `shaft-visual/target/shaft-visual-<version>.jar`
+- Surefire reports: `<module>/target/surefire-reports/`
 - JaCoCo report: `shaft-engine/target/jacoco/`
 - Allure results: `shaft-engine/allure-results/`
 - Allure report: `shaft-engine/allure-report/`
@@ -82,3 +86,22 @@ python3 scripts/ci/measure_consumer_dependencies.py --verify
 ```
 
 The measurement script seeds the canonical engine JAR, optional integration JARs, the BOM, the legacy relocation POM, and the reactor parent into each isolated Maven repository.
+
+
+## GitHub Actions reactor policy
+
+Workflow commands run from the repository root and select only the modules required by each job:
+
+| Workflow | Reactor policy |
+| --- | --- |
+| `e2eTests.yml` | Engine jobs use `-pl shaft-engine -am`; BrowserStack jobs use `-pl shaft-browserstack -am`; focused visual and desktop-video jobs use their respective optional modules. |
+| `e2eLocalTests.yml`, `e2eLambdaTestTests.yml`, `e2eMoonTests.yml` | Use `-pl shaft-engine -am`; Appium and ordinary browser jobs do not resolve `shaft-video`. |
+| `coverage-readiness.yml` | Runs tests and JaCoCo reporting with `-pl shaft-engine -am`. |
+| `code-quality-scan.yml`, `codeql-analysis.yml`, `copilot-setup-steps.yml` | Select the code-bearing engine and optional integration modules explicitly; BOM and relocation-only modules are excluded from compilation/analysis. |
+| `publishJavaDocs.yml` | Generates JavaDocs only for `shaft-engine` and publishes `shaft-engine/target/reports/apidocs`. |
+| `mavenCentral_cd.yml` | Intentionally deploys the complete reactor because every published module, BOM, and relocation POM belongs to a release. |
+| `reactor-version-check.yml` | Uses the reactor-version validation script and does not invoke Maven. |
+| `dependency_review.yml`, `link-check.yml`, `refresh-agent-instructions.yml` | Do not build Java modules and therefore require no reactor selection. |
+| `sync-sample-projects-version.yml`, `update-selenium-grid-versions.yml` | Operate on module-relative assets under `shaft-engine/src/main/resources`. |
+
+The shared post-test action defaults to `shaft-engine` but accepts `module-directory` for optional-module jobs. It reads and uploads `<module>/allure-results`, `<module>/allure-report`, `<module>/target/surefire-reports`, and `<module>/target/jacoco`. It counts raw `*-result.json` files before interpreting Allure summary status and fails an empty test run.


### PR DESCRIPTION
## Agent

Codex implemented this change. The authenticated token owner did not author these changes manually.

Closes #2818

## Summary

- Migrated E2E support paths from the former repository-root layout to module-relative `shaft-engine/...` locations.
- Made the shared post-test action module-aware for Allure, Surefire, JaCoCo, and artifact paths.
- Added mandatory raw Allure result counting before summary/status interpretation; empty result sets now fail as invalid runs.
- Kept ordinary/Appium jobs on `shaft-engine`, BrowserStack jobs on `shaft-browserstack`, and added focused `shaft-visual` and `shaft-video` jobs so optional-module coverage remains explicit.
- Made quality, CodeQL, Copilot setup, coverage, JavaDoc, sample-sync, and Selenium-version workflows reactor-aware.
- Documented every workflow's reactor policy, including intentionally whole-reactor Maven Central deployment.

## PDCA iterations

### Iteration 1 — module-relative paths

- **Plan:** Identify stale root-relative resources and report locations after the Maven reactor migration.
- **Do:** Updated Docker, sample-project, Moon listener, Allure, Surefire, and JaCoCo paths to their owning modules.
- **Check:** Parsed all workflow/action YAML and searched workflow references for stale root paths.
- **Act:** Centralized report path selection in the shared post-test action rather than duplicating per-job path logic.

### Iteration 2 — explicit optional-module selection

- **Plan:** Preserve optional integration coverage without resolving optional modules in ordinary jobs.
- **Do:** Kept engine/LambdaTest/Appium/local jobs on `shaft-engine`, BrowserStack jobs on `shaft-browserstack`, and added focused visual/video module jobs.
- **Check:** Ran the exact focused visual and video Maven selectors and confirmed populated module-local Allure results.
- **Act:** Added a `module-directory` action input so optional jobs reuse the same reporting contract.

### Iteration 3 — reporting safety and maintainability

- **Plan:** Prevent stale/empty Allure summaries from being interpreted as successful runs and document reactor intent.
- **Do:** Added raw result counts, zero-result failures, module-local fallback generation, single-file fallback configuration, and workflow policy documentation.
- **Check:** Validated fallback generation, Actionlint, YAML parsing, JavaDocs output, and the full reactor package/install.
- **Act:** Documented intentionally whole-reactor release behavior and module-targeted development commands.

## Validation

- `actionlint .github/workflows/*.yml`
- Ruby/Psych parsing of all `.github/workflows/*.yml` and `.github/actions/**/*.yml`
- `git diff --check`
- `mvn -pl shaft-visual -am -e test "-DretryMaximumNumberOfAttempts=1" "-DgenerateAllureReportArchive=true" "-Dtest=ImageProcessingActionsUnitTest"` — 19 passed; 19 raw Allure results.
- `mvn -pl shaft-video -am -e test "-DretryMaximumNumberOfAttempts=1" "-DgenerateAllureReportArchive=true" "-Dtest=DesktopVideoRecordingProviderRegistrationTest"` — 1 passed; 1 raw Allure result.
- Allure 3 fallback generation for `shaft-video` with a generated single-file config — populated `summary.json`, total 1, passed 1.
- `mvn -pl shaft-engine -am javadoc:javadoc -Dgpg.skip` — generated `shaft-engine/target/reports/apidocs/index.html`.
- `mvn clean install -DskipTests -Dgpg.skip` — all seven reactor projects succeeded.

## Environment-limited validation

Cloud-provider, Windows/macOS, Moon/Kubernetes, and Selenium Grid jobs require their hosted runners, credentials, browsers, or cluster services and therefore remain CI validations.
