### PR TITLE
codex: update examples and modularization upgrade guide

### DIFF
--- a/.github/RELEASE_BODY_TEMPLATE.md
+++ b/.github/RELEASE_BODY_TEMPLATE.md
@@ -1,3 +1,3 @@
-# SHAFT_ENGINE $RELEASE_VERSION
+# SHAFT $RELEASE_VERSION
 
-Auto-generated release notes for this version are included below.
+Auto-generated release notes are included below. Users upgrading from `SHAFT_ENGINE` should read the [modular SHAFT upgrade guide](https://github.com/ShaftHQ/SHAFT_ENGINE/blob/main/docs/UPGRADING_TO_MODULAR_SHAFT.md).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -772,9 +772,9 @@ Follow these steps in order when preparing a new SHAFT release:
   - change the `@DefaultValue` of `shaftEngineVersion()` to match the new release version.
   - also check and update `allure3Version()` to the latest stable Allure 3 npm package version.
   - also check and update `nodeLtsVersion()` to the latest Node.js LTS patch version.
-- **All example/demo `pom.xml` files** under `src/main/resources/examples/` (7 files — TestNG, JUnit, Cucumber variants): change `<shaft_engine.version>OLD</shaft_engine.version>` to `<shaft_engine.version>NEW</shaft_engine.version>` in the release PR itself. Do not wait for the post-release sync workflow to correct sample/demo projects after the release. You can do this in bulk with:
+- **All example/demo `pom.xml` files** under `src/main/resources/examples/` (7 files — TestNG, JUnit, Cucumber variants): change `<shaft.version>OLD</shaft.version>` to `<shaft.version>NEW</shaft.version>` in the release PR itself. Do not wait for the post-release sync workflow to correct sample/demo projects after the release. You can do this in bulk with:
   ```bash
-  find src/main/resources/examples -name "pom.xml" | xargs sed -i 's|<shaft_engine.version>OLD</shaft_engine.version>|<shaft_engine.version>NEW</shaft_engine.version>|g'
+  find src/main/resources/examples -name "pom.xml" | xargs sed -i 's|<shaft.version>OLD</shaft.version>|<shaft.version>NEW</shaft.version>|g'
   ```
 
 ### 2. Sync All Sample Project Properties with Main `pom.xml`
@@ -785,7 +785,7 @@ After updating the SHAFT version, compare every versioned property in each sampl
 
 | Property | Where to read the canonical value in main `pom.xml` |
 |---|---|
-| `shaft_engine.version` | `<project><version>` (line 6) |
+| `shaft.version` | `<project><version>` (line 6) |
 | `jdk.version` | `<source>` / `<target>` inside `maven-compiler-plugin` configuration |
 | `aspectjweaver.version` | `<version>` of `org.aspectj:aspectjweaver` in `<dependencies>` |
 | `maven-compiler-plugin.version` | `<version>` of the `maven-compiler-plugin` in `<build><plugins>` |
@@ -861,7 +861,7 @@ Merging to `main` automatically triggers the **Maven Central Continuous Delivery
 
 After the release is published, additional workflows fire automatically:
 - **JavaDocs Publisher** (`publishJavaDocs.yml`) — regenerates and publishes the JavaDoc site.
-- **Sync Sample Projects SHAFT Version** (`sync-sample-projects-version.yml`) — opens a PR syncing all example `pom.xml` files to the new `shaft_engine.version` **and** all tracked plugin/dependency versions (`jdk.version`, `aspectjweaver.version`, `maven-compiler-plugin.version`, `maven-resources-plugin.version`, `maven-surefire-plugin.version`, `surefire-testng.version`).
+- **Sync Sample Projects SHAFT Version** (`sync-sample-projects-version.yml`) — opens a PR syncing all example `pom.xml` files to the new `shaft.version` **and** all tracked plugin/dependency versions (`jdk.version`, `aspectjweaver.version`, `maven-compiler-plugin.version`, `maven-resources-plugin.version`, `maven-surefire-plugin.version`, `surefire-testng.version`).
 - **Automated Release Blog Post** (`shafthq.github.io/.github/workflows/automated-release-blog-post.yml`) — triggered by the `shaft-engine-release` `repository_dispatch` event; creates a PR adding a new blog post to the user guide. See notes below.
 
 ### Cross-Repo Dispatch Payload Contract
@@ -898,7 +898,7 @@ See: https://github.com/ShaftHQ/shafthq.github.io/issues/468
 - [ ] `Internal.java` `shaftEngineVersion` `@DefaultValue` updated
 - [ ] `Internal.java` `allure3Version` checked/updated to latest stable
 - [ ] `Internal.java` `nodeLtsVersion` checked/updated to latest LTS patch
-- [ ] All 7 example/demo `pom.xml` files under `src/main/resources/examples/` updated in this release PR — bump `<shaft_engine.version>` manually (use the bulk `sed` command above); do **not** wait for the **Sync Sample Projects SHAFT Version** workflow to fix release PR drift
+- [ ] All 7 example/demo `pom.xml` files under `src/main/resources/examples/` updated in this release PR — bump `<shaft.version>` manually (use the bulk `sed` command above); do **not** wait for the **Sync Sample Projects SHAFT Version** workflow to fix release PR drift
 - [ ] All 7 example `pom.xml` files synced with main `pom.xml` for plugin/dependency versions — the **Sync Sample Projects SHAFT Version** workflow handles `jdk.version`, `aspectjweaver.version`, `maven-compiler-plugin.version`, `maven-resources-plugin.version`, `maven-surefire-plugin.version`, and `surefire-testng.version` automatically; manually verify only if the workflow fails
 - [ ] Dependency currency gate executed: `versions:display-dependency-updates`, `versions:display-plugin-updates`, and `versions:display-property-updates`
 - [ ] No stable dependency/plugin/property updates skipped

--- a/.github/copilot-memory.md
+++ b/.github/copilot-memory.md
@@ -76,7 +76,7 @@ Purpose: keep high-signal, reusable learnings from implementation sessions in on
 - Date: 2026-05-13
 - Area: Release preparation / version metadata
 - Trigger: First Codex-generated release PR request for `10.2.20260513`.
-- Lesson: Release PRs are metadata-sensitive and must be opened directly once validated. Always inspect recent merged release PRs, compute the version with `{major}.{quarter}.{YYYYMMDD}`, update root `pom.xml`, `Internal.java` `shaftEngineVersion`, verify/update `allure3Version` and `nodeLtsVersion`, and update all seven sample/demo project `<shaft_engine.version>` values before opening the PR. Do not rely on the post-release sample-sync workflow to fix stale sample POMs.
+- Lesson: Release PRs are metadata-sensitive and must be opened directly once validated. Always inspect recent merged release PRs, compute the version with `{major}.{quarter}.{YYYYMMDD}`, update root `pom.xml`, `Internal.java` `shaftEngineVersion`, verify/update `allure3Version` and `nodeLtsVersion`, and update all seven sample/demo project `<shaft.version>` values before opening the PR. Do not rely on the post-release sample-sync workflow to fix stale sample POMs.
 - Evidence: PRs #2502, #2494, #2439, #2428, #2418; `pom.xml`; `src/main/java/com/shaft/properties/internal/Internal.java`; `src/main/resources/examples/**/pom.xml`; `.github/copilot-instructions.md`; `AGENTS.md`.
 - Action taken: Added release-preparation notes to agent instructions, framework-source instructions, and this memory entry while preparing the release branch.
 

--- a/.github/instructions/framework-source.instructions.md
+++ b/.github/instructions/framework-source.instructions.md
@@ -114,7 +114,7 @@ When preparing a SHAFT release and editing `shaft-engine/shaft-engine/src/main/j
 - `allure3Version` (latest stable Allure 3 npm package)
 - `nodeLtsVersion` (latest Node.js LTS patch)
 
-Release PRs must also update every sample/demo `<shaft_engine.version>` under `shaft-engine/src/main/resources/examples/**/pom.xml` in the same branch before the PR is opened; do not depend on the post-release sample-sync workflow to repair stale demo project versions.
+Release PRs must also update every sample/demo `<shaft.version>` under `shaft-engine/src/main/resources/examples/**/pom.xml` in the same branch before the PR is opened; do not depend on the post-release sample-sync workflow to repair stale demo project versions.
 
 ### ⛔ Mandatory Pre-Commit Rules (No Exceptions)
 > **You MUST NEVER commit untested framework code. There are no exceptions to these rules.**

--- a/.github/skills/github-copilot/release-dependency-guard.md
+++ b/.github/skills/github-copilot/release-dependency-guard.md
@@ -25,7 +25,7 @@ Verify that the SHAFT engine version is consistent across all required locations
 |---|---|---|
 | 1 | `pom.xml` (line 6) | `<version>X.Y.Z</version>` |
 | 2 | `src/main/java/com/shaft/properties/internal/Internal.java` | `@DefaultValue("X.Y.Z")` on `shaftEngineVersion()` |
-| 3 | All 7 `pom.xml` files under `src/main/resources/examples/` | `<shaft_engine.version>X.Y.Z</shaft_engine.version>` |
+| 3 | All 7 `pom.xml` files under `src/main/resources/examples/` | `<shaft.version>X.Y.Z</shaft.version>` |
 
 ### Validation Rules
 - All locations must declare the **same** version string.

--- a/.github/workflows/code-quality-scan.yml
+++ b/.github/workflows/code-quality-scan.yml
@@ -148,7 +148,7 @@ jobs:
           DRIFT_DETAILS=""
 
           for POM in $(find shaft-engine/src/main/resources/examples -name "pom.xml"); do
-            SAMPLE_VERSION=$(grep '<shaft_engine.version>' "$POM" | head -1 | sed 's/.*<shaft_engine.version>\(.*\)<\/shaft_engine.version>.*/\1/' | tr -d ' ')
+            SAMPLE_VERSION=$(grep '<shaft.version>' "$POM" | head -1 | sed 's/.*<shaft.version>\(.*\)<\/shaft.version>.*/\1/' | tr -d ' ')
             if [ -n "$SAMPLE_VERSION" ] && [ "$SAMPLE_VERSION" != "$MAIN_VERSION" ]; then
               DRIFT_FOUND=true
               DRIFT_DETAILS="$DRIFT_DETAILS\n- $POM: $SAMPLE_VERSION (expected $MAIN_VERSION)"
@@ -211,7 +211,7 @@ jobs:
           script: |
             const title = '⚠️ Sample Project Version Drift Detected';
             const labels = ['dependencies', 'automated', 'examples'];
-            const body = `## Sample Projects Out of Sync\n\nThe following sample project \`pom.xml\` files have a \`shaft_engine.version\` that does not match the current main \`pom.xml\` version.\n\n${{ steps.version-drift.outputs.drift_details }}\n\nRun the **Sync Sample Projects SHAFT Version** workflow to fix this automatically.`;
+            const body = `## Sample Projects Out of Sync\n\nThe following sample project \`pom.xml\` files have a \`shaft.version\` that does not match the current main \`pom.xml\` version.\n\n${{ steps.version-drift.outputs.drift_details }}\n\nRun the **Sync Sample Projects SHAFT Version** workflow to fix this automatically.`;
 
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,

--- a/.github/workflows/sync-sample-projects-version.yml
+++ b/.github/workflows/sync-sample-projects-version.yml
@@ -88,8 +88,8 @@ jobs:
       - name: Check Current Versions in Examples
         id: check-current
         run: |
-          # Get unique shaft_engine versions from example pom.xml files
-          CURRENT_VERSIONS=$(find shaft-engine/src/main/resources/examples -name "pom.xml" -exec grep -h '<shaft_engine.version>' {} \; | sed 's/.*<shaft_engine.version>\(.*\)<\/shaft_engine.version>.*/\1/' | tr -d ' ' | sort -u | tr '\n' ' ')
+          # Get unique shaft.version values from example pom.xml files
+          CURRENT_VERSIONS=$(find shaft-engine/src/main/resources/examples -name "pom.xml" -exec grep -h '<shaft.version>' {} \; | sed 's/.*<shaft.version>\(.*\)<\/shaft.version>.*/\1/' | tr -d ' ' | sort -u | tr '\n' ' ')
           echo "CURRENT_VERSIONS=$CURRENT_VERSIONS" >> $GITHUB_OUTPUT
           echo "Current SHAFT versions in examples: $CURRENT_VERSIONS"
 
@@ -105,7 +105,7 @@ jobs:
           NEW_SUREFIRE_TESTNG="${{ steps.extract-versions.outputs.SUREFIRE_TESTNG_VERSION }}"
 
           echo "Syncing all versioned properties to sample projects..."
-          echo "  shaft_engine.version          = $NEW_VERSION"
+          echo "  shaft.version          = $NEW_VERSION"
           echo "  jdk.version                   = $NEW_JDK"
           echo "  aspectjweaver.version         = $NEW_ASPECTJ"
           echo "  maven-compiler-plugin.version = $NEW_COMPILER"
@@ -137,7 +137,7 @@ jobs:
           for POM_FILE in $(find shaft-engine/src/main/resources/examples -name "pom.xml"); do
             FILE_CHANGED=false
 
-            update_property "$POM_FILE" "shaft_engine.version" "$NEW_VERSION" && FILE_CHANGED=true
+            update_property "$POM_FILE" "shaft.version" "$NEW_VERSION" && FILE_CHANGED=true
             [ -n "$NEW_JDK" ] && update_property "$POM_FILE" "jdk.version" "$NEW_JDK" && FILE_CHANGED=true
             [ -n "$NEW_ASPECTJ" ] && update_property "$POM_FILE" "aspectjweaver.version" "$NEW_ASPECTJ" && FILE_CHANGED=true
             [ -n "$NEW_COMPILER" ] && update_property "$POM_FILE" "maven-compiler-plugin.version" "$NEW_COMPILER" && FILE_CHANGED=true
@@ -192,7 +192,7 @@ jobs:
 
             | Property | New Value |
             |---|---|
-            | `shaft_engine.version` | `${{ steps.get-version.outputs.NEW_VERSION }}` |
+            | `shaft.version` | `${{ steps.get-version.outputs.NEW_VERSION }}` |
             | `jdk.version` | `${{ steps.extract-versions.outputs.JDK_VERSION }}` |
             | `aspectjweaver.version` | `${{ steps.extract-versions.outputs.ASPECTJWEAVER_VERSION }}` |
             | `maven-compiler-plugin.version` | `${{ steps.extract-versions.outputs.COMPILER_PLUGIN_VERSION }}` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ Use this protocol whenever a maintainer tags `@codex` to start work, says `start
 - Do not expose secrets or copy values from `.env`, credential files, BrowserStack/LambdaTest variables, Maven Central credentials, GPG keys, or CI secrets.
 - Do not run deployment/release commands, `scm-publish`, history rewrites, destructive cleanup, or credentialed cloud workflows unless explicitly requested.
 - Treat `target/`, generated reports, downloaded binaries, and build artifacts as generated outputs; do not commit them unless maintainers explicitly request it.
-- Be careful with release `pom.xml` version changes: release PRs must update the root `pom.xml` project version, `Internal.java` `shaftEngineVersion`, `allure3Version`, and `nodeLtsVersion`, and every sample/demo `<shaft_engine.version>` under `shaft-engine/src/main/resources/examples/**/pom.xml` in the same branch before opening the PR. Do not rely on the post-release sample-sync workflow to fix release PR drift.
+- Be careful with release `pom.xml` version changes: release PRs must update the root `pom.xml` project version, `Internal.java` `shaftEngineVersion`, `allure3Version`, and `nodeLtsVersion`, and every sample/demo `<shaft.version>` under `shaft-engine/src/main/resources/examples/**/pom.xml` in the same branch before opening the PR. Do not rely on the post-release sample-sync workflow to fix release PR drift.
 - Binary mobile test assets (`*.apk`, `*.ipa`) have special JaCoCo exclusions; do not move or reclassify them casually.
 - Docker Compose E2E services should be stopped/cleaned up after local use.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 SHAFT Engine is an open-source **Java test automation framework** built on top of [Selenium](https://www.selenium.dev/), [Appium](https://appium.io/), and [REST Assured](https://rest-assured.io/). It provides a unified, fluent API for **cross-browser testing**, **mobile app testing**, **API testing**, **CLI testing**, and **database testing** — so you can automate anything, from any platform, with zero boilerplate.
 
 [![GitHub Stars](https://img.shields.io/github/stars/ShaftHQ/SHAFT_ENGINE?style=for-the-badge&logo=github&label=Stars&color=gold)](https://github.com/ShaftHQ/SHAFT_ENGINE/stargazers)
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.shafthq/SHAFT_ENGINE?style=for-the-badge&logo=apachemaven&label=Maven%20Central&color=indigo)](https://central.sonatype.com/artifact/io.github.shafthq/SHAFT_ENGINE)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.shafthq/shaft-engine?style=for-the-badge&logo=apachemaven&label=Maven%20Central&color=indigo)](https://central.sonatype.com/artifact/io.github.shafthq/shaft-engine)
 [![License](https://img.shields.io/github/license/ShaftHQ/SHAFT_Engine?color=indigo&style=for-the-badge)](https://github.com/ShaftHQ/SHAFT_ENGINE/blob/master/LICENSE)
 [![E2E Tests](https://img.shields.io/github/actions/workflow/status/SHAFTHQ/SHAFT_Engine/e2eTests.yml?branch=main&color=forestgreen&label=E2E%20Tests&style=for-the-badge)](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/workflows/e2eTests.yml)
 [![Code QL](https://img.shields.io/github/actions/workflow/status/SHAFTHQ/SHAFT_Engine/codeql-analysis.yml?branch=main&label=Security&color=forestgreen&style=for-the-badge)](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/workflows/codeql-analysis.yml)
@@ -62,6 +62,7 @@ SHAFT Engine is an open-source **Java test automation framework** built on top o
 - [🚀 Why SHAFT?](#-why-shaft)
 - [💡 See the Difference](#-see-the-difference)
 - [⚡ Quick Start](#-quick-start)
+- [⬆️ Upgrade from `SHAFT_ENGINE`](docs/UPGRADING_TO_MODULAR_SHAFT.md)
 - [🧭 Allure CLI Version Enforcement (Opt-in)](#-allure-cli-version-enforcement-opt-in)
 - [✨ Key Features](#-key-features)
 - [🌍 Success Partners](#-success-partners)
@@ -176,18 +177,35 @@ mvn archetype:generate \
 <summary><b>Maven</b> — add to your <code>pom.xml</code></summary>
 
 ```xml
-<dependency>
-    <groupId>io.github.shafthq</groupId>
-    <artifactId>shaft-engine</artifactId>
+<properties>
     <!-- Get the latest version from Maven Central ↓ -->
-    <version><!-- SEE BADGE BELOW --></version>
-</dependency>
+    <shaft.version><!-- SEE BADGE BELOW --></shaft.version>
+</properties>
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.github.shafthq</groupId>
+            <artifactId>shaft-bom</artifactId>
+            <version>${shaft.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+<dependencies>
+    <dependency>
+        <groupId>io.github.shafthq</groupId>
+        <artifactId>shaft-engine</artifactId>
+    </dependency>
+</dependencies>
 ```
 </details>
 
 > ℹ️ This repository enforces a Maven-only execution policy for global consistency across local IDE runs and CI/CD pipelines.
 
 > 💡 Check the latest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.shafthq/shaft-engine?style=flat-square&label=latest%20version)](https://central.sonatype.com/artifact/io.github.shafthq/shaft-engine)
+
+> ⬆️ Upgrading from `io.github.shafthq:SHAFT_ENGINE`? Follow the **[modular SHAFT upgrade guide](docs/UPGRADING_TO_MODULAR_SHAFT.md)** before changing coordinates.
 
 ### Your First Test
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -92,6 +92,10 @@ graph TB
     class Allure,GitHub,Jenkins reporting
 ```
 
+## Published Maven modules
+
+`shaft-engine` contains the public facade plus web, mobile/Appium, API, database, CLI, reporting, and retained integrations. `shaft-browserstack`, `shaft-video`, and `shaft-visual` are optional provider JARs aligned by `shaft-bom`; the legacy `SHAFT_ENGINE` artifact is relocation-only. See the [upgrade guide](UPGRADING_TO_MODULAR_SHAFT.md).
+
 ## Module Overview
 
 ### Core Testing Modules

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,6 +1,8 @@
 # 🚀 Features
 
-SHAFT Engine provides comprehensive test automation capabilities across multiple platforms and testing needs.
+The base `shaft-engine` artifact provides comprehensive test automation capabilities across multiple platforms and testing needs.
+
+> BrowserStack SDK orchestration, desktop video, and OpenCV visual matching require `shaft-browserstack`, `shaft-video`, and `shaft-visual` respectively. API, mobile/Appium, and database support remain in the base artifact. See the [upgrade guide](UPGRADING_TO_MODULAR_SHAFT.md).
 
 ## Smart Features
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -282,6 +282,10 @@ Feature: Search functionality
 > After upgrading your Engine to a new major release it is sometimes recommended to delete the properties
 folder ```src\main\resources\properties``` and allow SHAFT to regenerate the defaults by running any test method.
 
+## Optional modular integrations
+
+The base coordinate is `io.github.shafthq:shaft-engine`. Import `io.github.shafthq:shaft-bom` to align versions, then add `shaft-browserstack`, `shaft-video`, or `shaft-visual` only when the project uses those capabilities. API, Appium/mobile, and database testing remain in `shaft-engine`. Existing `SHAFT_ENGINE` users should follow the [upgrade guide](UPGRADING_TO_MODULAR_SHAFT.md).
+
 ---
 
 [← Back to README](../README.md) | [Features →](FEATURES.md)

--- a/docs/UPGRADING_TO_MODULAR_SHAFT.md
+++ b/docs/UPGRADING_TO_MODULAR_SHAFT.md
@@ -1,0 +1,116 @@
+# Upgrade to modular SHAFT
+
+This guide upgrades projects from the final pre-modularization release, `10.2.20260605`, to the modular SHAFT release. The Java package namespace remains `com.shaft`; only Maven coordinates and optional dependency packaging change.
+
+## Coordinates: before and after
+
+Before:
+
+```xml
+<dependency>
+  <groupId>io.github.shafthq</groupId>
+  <artifactId>SHAFT_ENGINE</artifactId>
+  <version>10.2.20260605</version>
+</dependency>
+```
+
+After, with the recommended BOM:
+
+```xml
+<properties><shaft.version>MODULAR_RELEASE_VERSION</shaft.version></properties>
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>io.github.shafthq</groupId>
+      <artifactId>shaft-bom</artifactId>
+      <version>${shaft.version}</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+<dependencies>
+  <dependency>
+    <groupId>io.github.shafthq</groupId>
+    <artifactId>shaft-engine</artifactId>
+  </dependency>
+</dependencies>
+```
+
+Or use an explicit version without the BOM:
+
+```xml
+<dependency>
+  <groupId>io.github.shafthq</groupId>
+  <artifactId>shaft-engine</artifactId>
+  <version>${shaft.version}</version>
+</dependency>
+```
+
+Replace `MODULAR_RELEASE_VERSION` with the released version shown on [Maven Central](https://central.sonatype.com/artifact/io.github.shafthq/shaft-engine).
+
+## Choose optional modules
+
+All optional modules use the same version as `shaft-engine`; omit their `<version>` when importing `shaft-bom`.
+
+| Add this module | Only when you use |
+| --- | --- |
+| `shaft-browserstack` | BrowserStack SDK integration or `browserstack.yml` SDK orchestration. Ordinary remote WebDriver sessions do not require it. |
+| `shaft-video` | SHAFT-managed desktop screen recording and its platform FFmpeg/JAVE payload. Appium driver-native mobile recording remains in `shaft-engine`. |
+| `shaft-visual` | OpenCV-backed reference-image matching and visual comparison. Ordinary screenshots and reporting remain in `shaft-engine`. |
+
+```xml
+<dependency><groupId>io.github.shafthq</groupId><artifactId>shaft-browserstack</artifactId></dependency>
+<dependency><groupId>io.github.shafthq</groupId><artifactId>shaft-video</artifactId></dependency>
+<dependency><groupId>io.github.shafthq</groupId><artifactId>shaft-visual</artifactId></dependency>
+```
+
+REST Assured API testing, Appium/Flutter/mobile testing, database support and JDBC drivers, CLI, Cucumber, reporting, accessibility, and the public `com.shaft` API remain in `shaft-engine`. API and mobile projects must not add an optional module unless they independently use that optional capability.
+
+## Legacy relocation and support window
+
+The old `io.github.shafthq:SHAFT_ENGINE` coordinate is published as a relocation POM pointing to `io.github.shafthq:shaft-engine` for the modular release line. It is a compatibility bridge, not the recommended declaration. Existing builds can resolve while teams migrate, but new projects and the bundled examples use the lowercase coordinate immediately. The relocation bridge is supported for the modular release's major-version lifecycle; removal requires a future major release and advance deprecation notice.
+
+Relocation selects only `shaft-engine`. Maven cannot infer whether a project needs BrowserStack, desktop video, or OpenCV, so add those providers explicitly.
+
+## CI and cache migration
+
+1. Change cache keys when `pom.xml` hashes are not already part of the key. The coordinate rename and split modules create new paths under `~/.m2/repository/io/github/shafthq/`.
+2. Do not copy the old `SHAFT_ENGINE` directory into the new `shaft-engine` path. Let Maven verify checksums and populate it.
+3. Run `mvn dependency:purge-local-repository -DmanualInclude=io.github.shafthq:SHAFT_ENGINE,io.github.shafthq:shaft-engine -DreResolve=false` only when a stale local snapshot or failed relocation is suspected.
+4. Build once with an empty cache in CI before comparing download size or timing.
+
+### Missing-provider troubleshooting
+
+| Symptom | Action |
+| --- | --- |
+| BrowserStack SDK classes/configuration are unavailable | Add `shaft-browserstack`; verify `mvn dependency:tree` contains it. |
+| Desktop recording reports no provider | Add `shaft-video`; confirm the OS-specific `ws.schild:jave-nativebin-*` artifact resolves. |
+| Reference-image matching reports no visual provider | Add `shaft-visual`; confirm `org.openpnp:opencv` resolves. |
+| Mobile recording changed unexpectedly | Do not add `shaft-video` for Appium recording; verify `shaft-engine` is aligned and the driver supports native recording. |
+| `NoSuchMethodError` or mixed SHAFT modules | Import `shaft-bom`, remove explicit mismatched module versions, and inspect `mvn dependency:tree -Dincludes=io.github.shafthq`. |
+
+## Verified cold-cache download measurements
+
+The final table records compressed classpath JAR bytes from isolated empty Maven repositories. The pre-modularization graph is the committed `10.2.20260605` baseline captured at commit `570a836` before extraction. The modular engine graph is measured from the reactor artifact. Platform rows differ by the JAVE native binary selected by the old POM; `shaft-engine` itself is platform-neutral. MiB uses 1,048,576 bytes.
+
+| Supported platform | Before: `SHAFT_ENGINE` | After: `shaft-engine` only | Saved |
+| --- | ---: | ---: | ---: |
+| Linux x64 | 352,001,986 (335.70 MiB) | 169,941,464 (162.07 MiB) | 182,060,522 (173.63 MiB / 51.7%) |
+| Linux ARM64 | 348,005,291 (331.88 MiB) | 169,941,464 (162.07 MiB) | 178,063,827 (169.81 MiB / 51.2%) |
+| Windows x64 | 350,617,708 (334.38 MiB) | 169,941,464 (162.07 MiB) | 180,676,244 (172.31 MiB / 51.5%) |
+| macOS x64 | 344,700,722 (328.73 MiB) | 169,941,464 (162.07 MiB) | 174,759,258 (166.66 MiB / 50.7%) |
+| macOS ARM64 | 341,487,898 (325.67 MiB) | 169,941,464 (162.07 MiB) | 171,546,434 (163.60 MiB / 50.2%) |
+
+Reproduce the current graph after a reactor build with:
+
+```bash
+mvn clean install -DskipTests -Dgpg.skip
+python3 scripts/ci/measure_consumer_dependencies.py --fixture api --output target/modular-measurement
+```
+
+Starting from the measured Linux x64 baseline, the other platform totals subtract the 28,201,169-byte Linux x64 native JAR and add the resolved native JAR: Linux ARM64 24,204,474 bytes, Windows x64 26,816,891 bytes, macOS x64 20,899,905 bytes, or macOS ARM64 17,687,081 bytes. These are deterministic substitutions of exact Maven Central JAR sizes; they avoid claiming cross-run repository-growth or elapsed-time comparisons as download savings.
+
+## Rollback
+
+If migration blocks a release, revert the POM to `io.github.shafthq:SHAFT_ENGINE:10.2.20260605`, restore the previous dependency cache key, and remove the optional module declarations. This returns to the last monolithic release. Do not mix the old monolithic JAR with modular artifacts in one classpath. Capture `mvn dependency:tree` before rollback so a missing provider or version mismatch can be diagnosed, then reattempt with the BOM.

--- a/docs/modularization/dependency-baseline/REPORT.md
+++ b/docs/modularization/dependency-baseline/REPORT.md
@@ -4,14 +4,15 @@ Each fixture was compiled against its declared SHAFT module using an empty tempo
 
 | Fixture | Artifacts | Classpath JAR bytes | Repository growth bytes | Elapsed seconds |
 | --- | ---: | ---: | ---: | ---: |
-| api | 329 | 284,731,691 | 312,843,433 | 67.838 |
-| appium-mobile | 329 | 284,731,691 | 312,843,433 | 66.955 |
-| bom | 333 | 286,667,824 | 310,129,676 | 41.254 |
-| browserstack-sdk | 331 | 322,940,699 | 351,088,061 | 72.772 |
-| desktop-video | 342 | 313,850,103 | 342,074,693 | 76.184 |
-| junit-web | 329 | 284,731,691 | 312,843,433 | 75.297 |
-| legacy-coordinate | 329 | 284,731,691 | 312,843,433 | 69.006 |
-| opencv-visual | 329 | 284,731,691 | 312,843,433 | 79.584 |
-| testng-web | 329 | 284,731,691 | 312,843,433 | 73.035 |
+| api | 308 | 169,941,464 | 197,369,199 | 61.304 |
+| appium-mobile | 308 | 169,941,464 | 197,369,199 | 63.201 |
+| bom | 334 | 286,750,752 | 310,207,843 | 48.687 |
+| browserstack-sdk | 310 | 208,151,248 | 235,613,827 | 63.801 |
+| combined-modules | 345 | 353,844,292 | 381,372,591 | 44.794 |
+| desktop-video | 318 | 198,872,925 | 226,402,674 | 58.400 |
+| junit-web | 308 | 169,941,464 | 197,369,199 | 59.694 |
+| legacy-coordinate | 308 | 169,941,464 | 197,369,199 | 65.667 |
+| opencv-visual | 330 | 284,527,061 | 312,634,039 | 69.092 |
+| testng-web | 308 | 169,941,464 | 197,369,199 | 61.174 |
 
 Elapsed time and repository growth are observations, not equality gates. Artifact coordinates, scopes, compressed JAR sizes, and SHA-256 values are compared exactly by `--verify`.

--- a/docs/modularization/dependency-baseline/manifests/api.json
+++ b/docs/modularization/dependency-baseline/manifests/api.json
@@ -6,11 +6,11 @@
     "system": "Linux",
     "machine": "x86_64"
   },
-  "artifactCount": 329,
-  "artifactBytes": 284731691,
-  "seededRepositoryBytes": 791366,
-  "repositoryBytes": 313634799,
-  "repositoryGrowthBytes": 312843433,
-  "elapsedSeconds": 67.838,
+  "artifactCount": 308,
+  "artifactBytes": 169941464,
+  "seededRepositoryBytes": 812508,
+  "repositoryBytes": 198181707,
+  "repositoryGrowthBytes": 197369199,
+  "elapsedSeconds": 61.304,
   "artifactsRef": "artifacts.json"
 }

--- a/docs/modularization/dependency-baseline/manifests/appium-mobile.json
+++ b/docs/modularization/dependency-baseline/manifests/appium-mobile.json
@@ -6,11 +6,11 @@
     "system": "Linux",
     "machine": "x86_64"
   },
-  "artifactCount": 329,
-  "artifactBytes": 284731691,
-  "seededRepositoryBytes": 791366,
-  "repositoryBytes": 313634799,
-  "repositoryGrowthBytes": 312843433,
-  "elapsedSeconds": 66.955,
+  "artifactCount": 308,
+  "artifactBytes": 169941464,
+  "seededRepositoryBytes": 812508,
+  "repositoryBytes": 198181707,
+  "repositoryGrowthBytes": 197369199,
+  "elapsedSeconds": 63.201,
   "artifactsRef": "artifacts.json"
 }

--- a/docs/modularization/dependency-baseline/manifests/artifacts-browserstack-sdk.json
+++ b/docs/modularization/dependency-baseline/manifests/artifacts-browserstack-sdk.json
@@ -2,36 +2,6 @@
   "schemaVersion": 1,
   "artifacts": [
     {
-      "coordinate": "com.applitools:eyes-common-java4:jar:4.14.0",
-      "scope": "compile",
-      "compressedBytes": 95526,
-      "sha256": "7bf4d2d204cfc75145721ed7f31f5f19c14bda45194238b534a89391d40dc072"
-    },
-    {
-      "coordinate": "com.applitools:eyes-connectivity-java4-jersey2x:jar:4.14.0",
-      "scope": "compile",
-      "compressedBytes": 10509,
-      "sha256": "1aad1e29fdb7edccac77e8b4ccc40ceb088fa65d99bce5198da71c87e227457c"
-    },
-    {
-      "coordinate": "com.applitools:eyes-images-java4:jar:4.14.0",
-      "scope": "compile",
-      "compressedBytes": 11005,
-      "sha256": "09e9210a8521fe95741e497fd89a8a35be3a344081ab8d83184bf1d32cb322ed"
-    },
-    {
-      "coordinate": "com.applitools:eyes-sdk-core-java4:jar:4.14.0",
-      "scope": "compile",
-      "compressedBytes": 111149,
-      "sha256": "bcefc04ea6810e772b4862f093e1ff5bd89b4ad9e927a3f0a20e00a6e3458e95"
-    },
-    {
-      "coordinate": "com.assertthat:selenium-shutterbug:jar:1.6",
-      "scope": "compile",
-      "compressedBytes": 44532,
-      "sha256": "0a269d75ccb452d66c9f4062187164e431097011fa64fb9b4dc1dbe6c9f6eb48"
-    },
-    {
       "coordinate": "com.atlassian.oai:openapi-request-validator-core:jar:3.0.0",
       "scope": "compile",
       "compressedBytes": 200613,
@@ -228,12 +198,6 @@
       "scope": "compile",
       "compressedBytes": 117159,
       "sha256": "ad95b08b8bbf9d7d17e5e00814898fa23324f32bc5b62f1a37801e6a56ce0079"
-    },
-    {
-      "coordinate": "com.github.zafarkhaja:java-semver:jar:0.9.0",
-      "scope": "compile",
-      "compressedBytes": 46843,
-      "sha256": "2218c73b40f9af98b570d084420c1b4a81332297bd7fc27ddd552e903be8e93c"
     },
     {
       "coordinate": "com.google.android:annotations:jar:4.1.1.4",
@@ -446,18 +410,6 @@
       "sha256": "f430c92394c2053f168715853da96d99996e94e34e5a291b97c5c86a5ad62a98"
     },
     {
-      "coordinate": "com.helger:ph-commons:jar:9.0.2",
-      "scope": "compile",
-      "compressedBytes": 1269522,
-      "sha256": "ac56801148617c1fc0d77fb161cbe9435a6779d4ef5676d7e8b2779fcc47885f"
-    },
-    {
-      "coordinate": "com.helger:ph-css:jar:6.1.1",
-      "scope": "compile",
-      "compressedBytes": 509525,
-      "sha256": "0ba2e837ffa5c523f37d5f16e3b45152853a7afffa0ebba43d66a52b6a536829"
-    },
-    {
       "coordinate": "com.ibm.db2.jcc:db2jcc:jar:db2jcc4",
       "scope": "compile",
       "compressedBytes": 4239628,
@@ -546,12 +498,6 @@
       "scope": "compile",
       "compressedBytes": 295444,
       "sha256": "0076c249b4387d8369146528fd5dacb3efba098dc02ecf9ac81debdfc2e12fd5"
-    },
-    {
-      "coordinate": "com.vaadin.external.google:android-json:jar:0.0.20131108.vaadin1",
-      "scope": "compile",
-      "compressedBytes": 18279,
-      "sha256": "dfb7bae2f404cfe0b72b4d23944698cb716b7665171812a0a4d0f5926c0fac79"
     },
     {
       "coordinate": "com.zaxxer:SparseBitSet:jar:1.3",
@@ -730,14 +676,14 @@
     {
       "coordinate": "io.github.shafthq:shaft-browserstack:jar:10.2.20260605",
       "scope": "compile",
-      "compressedBytes": 4991,
-      "sha256": "ab74da4ccb2da847e2962f783f53d3bf6d983c5af0ea834e177938b07ddb4afc"
+      "compressedBytes": 5767,
+      "sha256": "d9911b43106e3e28994bf92437ee23f2a38a8cc747ca018686e2e7f58919c0b9"
     },
     {
       "coordinate": "io.github.shafthq:shaft-engine:jar:10.2.20260605",
       "scope": "compile",
-      "compressedBytes": 695946,
-      "sha256": "43869beba48828c2ecf3b8146786452c5436ddb47e730aa6d25bfda5e8e7b149"
+      "compressedBytes": 693114,
+      "sha256": "79bc203a06b277d6913aee0f595e3ecbc0ba24386c60be09b1b259a0ccffae73"
     },
     {
       "coordinate": "io.grpc:grpc-alts:jar:1.58.0",
@@ -1184,12 +1130,6 @@
       "sha256": "e04ba5195bcd555dc95650f7cc614d151e4bcd52d29a10b8aa2197f3ab89ab9b"
     },
     {
-      "coordinate": "javax.ws.rs:javax.ws.rs-api:jar:2.0.1",
-      "scope": "compile",
-      "compressedBytes": 115534,
-      "sha256": "38607d626f2288d8fbc1b1f8a62c369e63806d9a313ac7cbc5f9d6c94f4b466d"
-    },
-    {
       "coordinate": "joda-time:joda-time:jar:2.10.5",
       "scope": "compile",
       "compressedBytes": 643043,
@@ -1454,66 +1394,6 @@
       "sha256": "ab829182363e747a1530a368436242f4cca7ff309dd29bfca638a1fdc7b6771d"
     },
     {
-      "coordinate": "org.glassfish.hk2.external:aopalliance-repackaged:jar:2.4.0-b09",
-      "scope": "compile",
-      "compressedBytes": 14767,
-      "sha256": "a97667a617fa5d427c2e95ce6f3eab5cf2d21d00c69ad2a7524ff6d9a9144f58"
-    },
-    {
-      "coordinate": "org.glassfish.hk2.external:javax.inject:jar:2.4.0-b09",
-      "scope": "compile",
-      "compressedBytes": 5951,
-      "sha256": "2265cfd5566d311fcbd8bfe224fb7f978b3018827920b7e0d3167b128a8ff297"
-    },
-    {
-      "coordinate": "org.glassfish.hk2:hk2-api:jar:2.4.0-b09",
-      "scope": "compile",
-      "compressedBytes": 182425,
-      "sha256": "a4e767a36fcb0467d04d4e024a2355488c3064d633eda95935b2b7f9afabde28"
-    },
-    {
-      "coordinate": "org.glassfish.hk2:hk2-locator:jar:2.4.0-b09",
-      "scope": "compile",
-      "compressedBytes": 171065,
-      "sha256": "16d86f041fecbedf49f2d58cce66ee90e440e0ae041631f48f9e3b962c8a1368"
-    },
-    {
-      "coordinate": "org.glassfish.hk2:hk2-utils:jar:2.4.0-b09",
-      "scope": "compile",
-      "compressedBytes": 95318,
-      "sha256": "dfafcfc3a82d37fa7d66bd232920175a2a211e76e3375ff88544d4a5dbe92263"
-    },
-    {
-      "coordinate": "org.glassfish.hk2:osgi-resource-locator:jar:1.0.1",
-      "scope": "compile",
-      "compressedBytes": 20235,
-      "sha256": "775003be577e8806f51b6e442be1033d83be2cb2207227b349be0bf16e6c0843"
-    },
-    {
-      "coordinate": "org.glassfish.jersey.bundles.repackaged:jersey-guava:jar:2.16",
-      "scope": "compile",
-      "compressedBytes": 964502,
-      "sha256": "6ee96b6887386d3fca64789303aa2bf044c22c47377a3953c0b8ca47a70e385b"
-    },
-    {
-      "coordinate": "org.glassfish.jersey.connectors:jersey-apache-connector:jar:2.16",
-      "scope": "compile",
-      "compressedBytes": 23432,
-      "sha256": "9a4b86f05407f9710364828892fb815ff468f50810632a5fc3a8b546e3142a37"
-    },
-    {
-      "coordinate": "org.glassfish.jersey.core:jersey-client:jar:2.16",
-      "scope": "compile",
-      "compressedBytes": 155715,
-      "sha256": "b2cbe55fe21a836b5e1f978bc48ac66c8ce8438f5255e19ca53c2faec5aa9855"
-    },
-    {
-      "coordinate": "org.glassfish.jersey.core:jersey-common:jar:2.16",
-      "scope": "compile",
-      "compressedBytes": 676243,
-      "sha256": "f9dd3acdb6376945fa45f03370f590c532a0526ed69b8855be97fae50eb76ce8"
-    },
-    {
       "coordinate": "org.hamcrest:hamcrest:jar:2.2",
       "scope": "compile",
       "compressedBytes": 123360,
@@ -1524,12 +1404,6 @@
       "scope": "compile",
       "compressedBytes": 27893,
       "sha256": "6f128a71c5e87a16f810513a73ad3c77d0ee0bb622ee0ce1ead115bccbc76d0a"
-    },
-    {
-      "coordinate": "org.javassist:javassist:jar:3.18.1-GA",
-      "scope": "compile",
-      "compressedBytes": 714194,
-      "sha256": "3fb71231afd098bb0f93f5eb97aa8291c8d0556379125e596f92ec8f944c6162"
     },
     {
       "coordinate": "org.jcommander:jcommander:jar:1.83",
@@ -1578,6 +1452,12 @@
       "scope": "compile",
       "compressedBytes": 264973,
       "sha256": "fd68a98b32b1132035c62102e5df0b0fdc358e7c87a9f876ce7071450b4d10da"
+    },
+    {
+      "coordinate": "org.json:json:jar:20260522",
+      "scope": "compile",
+      "compressedBytes": 88704,
+      "sha256": "d671b45e5954211f3566722aa614fbd3b5d46e95f4f9da4dc58c173280bb1799"
     },
     {
       "coordinate": "org.jsoup:jsoup:jar:1.22.2",
@@ -1650,12 +1530,6 @@
       "scope": "compile",
       "compressedBytes": 1647024,
       "sha256": "12dbb224cea124a5d32968722e8eb161c967bf15f3c9a795d1b05592b1147975"
-    },
-    {
-      "coordinate": "org.openpnp:opencv:jar:4.9.0-0",
-      "scope": "compile",
-      "compressedBytes": 109619828,
-      "sha256": "17823d249cb8ba18bc3cdb878db84936694d1cfaeac0f95517e320c8a8c458d9"
     },
     {
       "coordinate": "org.opentest4j:opentest4j:jar:1.3.0",

--- a/docs/modularization/dependency-baseline/manifests/artifacts-combined-modules.json
+++ b/docs/modularization/dependency-baseline/manifests/artifacts-combined-modules.json
@@ -44,6 +44,30 @@
       "sha256": "3a6278740807c49f25ebe39172f4912a247187b5d1d57b05cd35dfaad04d4628"
     },
     {
+      "coordinate": "com.automation-remarks:video-recorder-core:jar:2.0",
+      "scope": "compile",
+      "compressedBytes": 343631,
+      "sha256": "8305b0a7aeabe23a55b4ec59cd3f6902a9c1b9c5c027453a27a5c4872059e7ae"
+    },
+    {
+      "coordinate": "com.automation-remarks:video-recorder-junit5:jar:2.0",
+      "scope": "compile",
+      "compressedBytes": 3393,
+      "sha256": "2b9e28b972dafcbc8c989859c7925e4fd05c805f12b2b07bf497eaf54d8e2e49"
+    },
+    {
+      "coordinate": "com.automation-remarks:video-recorder-testng:jar:2.0",
+      "scope": "compile",
+      "compressedBytes": 14434,
+      "sha256": "ebb03150253a9fccfcec26f0232463669de84da4be209f8d4df97decfde80cda"
+    },
+    {
+      "coordinate": "com.browserstack:browserstack-java-sdk:jar:1.59.8",
+      "scope": "compile",
+      "compressedBytes": 38204017,
+      "sha256": "846ac6af4a040b2e72e7ce8a4d20c61b2f6907ec9136c67d30abf314058a99df"
+    },
+    {
       "coordinate": "com.deque.html.axe-core:dequeutilites:jar:4.11.3",
       "scope": "compile",
       "compressedBytes": 23942,
@@ -716,10 +740,22 @@
       "sha256": "7a8a003f3aaa7df074f112178526477fa8466684c7ac2f695c900b708e7641f5"
     },
     {
+      "coordinate": "io.github.shafthq:shaft-browserstack:jar:10.2.20260605",
+      "scope": "compile",
+      "compressedBytes": 5767,
+      "sha256": "d9911b43106e3e28994bf92437ee23f2a38a8cc747ca018686e2e7f58919c0b9"
+    },
+    {
       "coordinate": "io.github.shafthq:shaft-engine:jar:10.2.20260605",
       "scope": "compile",
       "compressedBytes": 693114,
       "sha256": "79bc203a06b277d6913aee0f595e3ecbc0ba24386c60be09b1b259a0ccffae73"
+    },
+    {
+      "coordinate": "io.github.shafthq:shaft-video:jar:10.2.20260605",
+      "scope": "compile",
+      "compressedBytes": 7756,
+      "sha256": "9f27fb24294ab285244ba9b9376a1729b3617936701ebb6a4c96a4f6c4a35bbe"
     },
     {
       "coordinate": "io.github.shafthq:shaft-visual:jar:10.2.20260605",
@@ -1430,6 +1466,12 @@
       "sha256": "4fe86fdc18faea571f29129c70eaad5d121363504a06d7907be88f6c60ba3116"
     },
     {
+      "coordinate": "org.awaitility:awaitility:jar:3.1.6",
+      "scope": "compile",
+      "compressedBytes": 103377,
+      "sha256": "694e2e915312b6fe0123c3d532f6675eed3b6d60e4f2ab677d3688fde3defcfc"
+    },
+    {
       "coordinate": "org.brotli:dec:jar:0.1.2",
       "scope": "compile",
       "compressedBytes": 98115,
@@ -1670,6 +1712,12 @@
       "sha256": "12dbb224cea124a5d32968722e8eb161c967bf15f3c9a795d1b05592b1147975"
     },
     {
+      "coordinate": "org.objenesis:objenesis:jar:2.6",
+      "scope": "compile",
+      "compressedBytes": 55684,
+      "sha256": "5e168368fbc250af3c79aa5fef0c3467a2d64e5a7bd74005f25d8399aeb0708d"
+    },
+    {
       "coordinate": "org.openpnp:opencv:jar:4.9.0-0",
       "scope": "compile",
       "compressedBytes": 109619828,
@@ -1844,6 +1892,12 @@
       "sha256": "c8f7a98e7394adda02f6317249710e4d1b4c7a25aa8c7eace0c2eea52eb8bf85"
     },
     {
+      "coordinate": "org.zeroturnaround:zt-exec:jar:1.10",
+      "scope": "compile",
+      "compressedBytes": 57588,
+      "sha256": "1f8b1bca6d0f9b9ec7f9bc8fca3b45e42039bb4ea3cdd20614104085e809ec71"
+    },
+    {
       "coordinate": "software.amazon.awssdk:annotations:jar:2.27.14",
       "scope": "compile",
       "compressedBytes": 13759,
@@ -2004,6 +2058,18 @@
       "scope": "compile",
       "compressedBytes": 30193,
       "sha256": "0c37d8e696117f02c302191b8110b0d0eb20fa412fce34c3a269ec73c16ce822"
+    },
+    {
+      "coordinate": "ws.schild:jave-core:jar:3.5.0",
+      "scope": "compile",
+      "compressedBytes": 96724,
+      "sha256": "6583162960f5c79f8b1012ecdcc4d1aa3ef0e572bd3a9db2eecdfde64516354f"
+    },
+    {
+      "coordinate": "ws.schild:jave-nativebin-linux64:jar:3.5.0",
+      "scope": "compile",
+      "compressedBytes": 28201169,
+      "sha256": "19755e5437fc6fa2493eb6787ec55ceb676646f86bc27a68a344dc55b2e6ed0f"
     }
   ]
 }

--- a/docs/modularization/dependency-baseline/manifests/artifacts-desktop-video.json
+++ b/docs/modularization/dependency-baseline/manifests/artifacts-desktop-video.json
@@ -2,36 +2,6 @@
   "schemaVersion": 1,
   "artifacts": [
     {
-      "coordinate": "com.applitools:eyes-common-java4:jar:4.14.0",
-      "scope": "compile",
-      "compressedBytes": 95526,
-      "sha256": "7bf4d2d204cfc75145721ed7f31f5f19c14bda45194238b534a89391d40dc072"
-    },
-    {
-      "coordinate": "com.applitools:eyes-connectivity-java4-jersey2x:jar:4.14.0",
-      "scope": "compile",
-      "compressedBytes": 10509,
-      "sha256": "1aad1e29fdb7edccac77e8b4ccc40ceb088fa65d99bce5198da71c87e227457c"
-    },
-    {
-      "coordinate": "com.applitools:eyes-images-java4:jar:4.14.0",
-      "scope": "compile",
-      "compressedBytes": 11005,
-      "sha256": "09e9210a8521fe95741e497fd89a8a35be3a344081ab8d83184bf1d32cb322ed"
-    },
-    {
-      "coordinate": "com.applitools:eyes-sdk-core-java4:jar:4.14.0",
-      "scope": "compile",
-      "compressedBytes": 111149,
-      "sha256": "bcefc04ea6810e772b4862f093e1ff5bd89b4ad9e927a3f0a20e00a6e3458e95"
-    },
-    {
-      "coordinate": "com.assertthat:selenium-shutterbug:jar:1.6",
-      "scope": "compile",
-      "compressedBytes": 44532,
-      "sha256": "0a269d75ccb452d66c9f4062187164e431097011fa64fb9b4dc1dbe6c9f6eb48"
-    },
-    {
       "coordinate": "com.atlassian.oai:openapi-request-validator-core:jar:3.0.0",
       "scope": "compile",
       "compressedBytes": 200613,
@@ -240,12 +210,6 @@
       "scope": "compile",
       "compressedBytes": 117159,
       "sha256": "ad95b08b8bbf9d7d17e5e00814898fa23324f32bc5b62f1a37801e6a56ce0079"
-    },
-    {
-      "coordinate": "com.github.zafarkhaja:java-semver:jar:0.9.0",
-      "scope": "compile",
-      "compressedBytes": 46843,
-      "sha256": "2218c73b40f9af98b570d084420c1b4a81332297bd7fc27ddd552e903be8e93c"
     },
     {
       "coordinate": "com.google.android:annotations:jar:4.1.1.4",
@@ -458,18 +422,6 @@
       "sha256": "f430c92394c2053f168715853da96d99996e94e34e5a291b97c5c86a5ad62a98"
     },
     {
-      "coordinate": "com.helger:ph-commons:jar:9.0.2",
-      "scope": "compile",
-      "compressedBytes": 1269522,
-      "sha256": "ac56801148617c1fc0d77fb161cbe9435a6779d4ef5676d7e8b2779fcc47885f"
-    },
-    {
-      "coordinate": "com.helger:ph-css:jar:6.1.1",
-      "scope": "compile",
-      "compressedBytes": 509525,
-      "sha256": "0ba2e837ffa5c523f37d5f16e3b45152853a7afffa0ebba43d66a52b6a536829"
-    },
-    {
       "coordinate": "com.ibm.db2.jcc:db2jcc:jar:db2jcc4",
       "scope": "compile",
       "compressedBytes": 4239628,
@@ -558,12 +510,6 @@
       "scope": "compile",
       "compressedBytes": 295444,
       "sha256": "0076c249b4387d8369146528fd5dacb3efba098dc02ecf9ac81debdfc2e12fd5"
-    },
-    {
-      "coordinate": "com.vaadin.external.google:android-json:jar:0.0.20131108.vaadin1",
-      "scope": "compile",
-      "compressedBytes": 18279,
-      "sha256": "dfb7bae2f404cfe0b72b4d23944698cb716b7665171812a0a4d0f5926c0fac79"
     },
     {
       "coordinate": "com.zaxxer:SparseBitSet:jar:1.3",
@@ -748,14 +694,14 @@
     {
       "coordinate": "io.github.shafthq:shaft-engine:jar:10.2.20260605",
       "scope": "compile",
-      "compressedBytes": 695946,
-      "sha256": "43869beba48828c2ecf3b8146786452c5436ddb47e730aa6d25bfda5e8e7b149"
+      "compressedBytes": 693114,
+      "sha256": "79bc203a06b277d6913aee0f595e3ecbc0ba24386c60be09b1b259a0ccffae73"
     },
     {
       "coordinate": "io.github.shafthq:shaft-video:jar:10.2.20260605",
       "scope": "compile",
-      "compressedBytes": 7909,
-      "sha256": "d84be1ef3752c9f432ba7a1cd3b0d4d19f4e80f004c68921408f1a9788d4c4d3"
+      "compressedBytes": 7756,
+      "sha256": "9f27fb24294ab285244ba9b9376a1729b3617936701ebb6a4c96a4f6c4a35bbe"
     },
     {
       "coordinate": "io.grpc:grpc-alts:jar:1.58.0",
@@ -1202,12 +1148,6 @@
       "sha256": "e04ba5195bcd555dc95650f7cc614d151e4bcd52d29a10b8aa2197f3ab89ab9b"
     },
     {
-      "coordinate": "javax.ws.rs:javax.ws.rs-api:jar:2.0.1",
-      "scope": "compile",
-      "compressedBytes": 115534,
-      "sha256": "38607d626f2288d8fbc1b1f8a62c369e63806d9a313ac7cbc5f9d6c94f4b466d"
-    },
-    {
       "coordinate": "joda-time:joda-time:jar:2.10.5",
       "scope": "compile",
       "compressedBytes": 643043,
@@ -1478,78 +1418,6 @@
       "sha256": "ab829182363e747a1530a368436242f4cca7ff309dd29bfca638a1fdc7b6771d"
     },
     {
-      "coordinate": "org.glassfish.hk2.external:aopalliance-repackaged:jar:2.4.0-b09",
-      "scope": "compile",
-      "compressedBytes": 14767,
-      "sha256": "a97667a617fa5d427c2e95ce6f3eab5cf2d21d00c69ad2a7524ff6d9a9144f58"
-    },
-    {
-      "coordinate": "org.glassfish.hk2.external:javax.inject:jar:2.4.0-b09",
-      "scope": "compile",
-      "compressedBytes": 5951,
-      "sha256": "2265cfd5566d311fcbd8bfe224fb7f978b3018827920b7e0d3167b128a8ff297"
-    },
-    {
-      "coordinate": "org.glassfish.hk2:hk2-api:jar:2.4.0-b09",
-      "scope": "compile",
-      "compressedBytes": 182425,
-      "sha256": "a4e767a36fcb0467d04d4e024a2355488c3064d633eda95935b2b7f9afabde28"
-    },
-    {
-      "coordinate": "org.glassfish.hk2:hk2-locator:jar:2.4.0-b09",
-      "scope": "compile",
-      "compressedBytes": 171065,
-      "sha256": "16d86f041fecbedf49f2d58cce66ee90e440e0ae041631f48f9e3b962c8a1368"
-    },
-    {
-      "coordinate": "org.glassfish.hk2:hk2-utils:jar:2.4.0-b09",
-      "scope": "compile",
-      "compressedBytes": 95318,
-      "sha256": "dfafcfc3a82d37fa7d66bd232920175a2a211e76e3375ff88544d4a5dbe92263"
-    },
-    {
-      "coordinate": "org.glassfish.hk2:osgi-resource-locator:jar:1.0.1",
-      "scope": "compile",
-      "compressedBytes": 20235,
-      "sha256": "775003be577e8806f51b6e442be1033d83be2cb2207227b349be0bf16e6c0843"
-    },
-    {
-      "coordinate": "org.glassfish.jersey.bundles.repackaged:jersey-guava:jar:2.16",
-      "scope": "compile",
-      "compressedBytes": 964502,
-      "sha256": "6ee96b6887386d3fca64789303aa2bf044c22c47377a3953c0b8ca47a70e385b"
-    },
-    {
-      "coordinate": "org.glassfish.jersey.connectors:jersey-apache-connector:jar:2.16",
-      "scope": "compile",
-      "compressedBytes": 23432,
-      "sha256": "9a4b86f05407f9710364828892fb815ff468f50810632a5fc3a8b546e3142a37"
-    },
-    {
-      "coordinate": "org.glassfish.jersey.core:jersey-client:jar:2.16",
-      "scope": "compile",
-      "compressedBytes": 155715,
-      "sha256": "b2cbe55fe21a836b5e1f978bc48ac66c8ce8438f5255e19ca53c2faec5aa9855"
-    },
-    {
-      "coordinate": "org.glassfish.jersey.core:jersey-common:jar:2.16",
-      "scope": "compile",
-      "compressedBytes": 676243,
-      "sha256": "f9dd3acdb6376945fa45f03370f590c532a0526ed69b8855be97fae50eb76ce8"
-    },
-    {
-      "coordinate": "org.hamcrest:hamcrest-core:jar:1.3",
-      "scope": "compile",
-      "compressedBytes": 45024,
-      "sha256": "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9"
-    },
-    {
-      "coordinate": "org.hamcrest:hamcrest-library:jar:1.3",
-      "scope": "compile",
-      "compressedBytes": 53070,
-      "sha256": "711d64522f9ec410983bd310934296da134be4254a125080a0416ec178dfad1c"
-    },
-    {
       "coordinate": "org.hamcrest:hamcrest:jar:2.2",
       "scope": "compile",
       "compressedBytes": 123360,
@@ -1560,12 +1428,6 @@
       "scope": "compile",
       "compressedBytes": 27893,
       "sha256": "6f128a71c5e87a16f810513a73ad3c77d0ee0bb622ee0ce1ead115bccbc76d0a"
-    },
-    {
-      "coordinate": "org.javassist:javassist:jar:3.18.1-GA",
-      "scope": "compile",
-      "compressedBytes": 714194,
-      "sha256": "3fb71231afd098bb0f93f5eb97aa8291c8d0556379125e596f92ec8f944c6162"
     },
     {
       "coordinate": "org.jcommander:jcommander:jar:1.83",
@@ -1698,12 +1560,6 @@
       "scope": "compile",
       "compressedBytes": 55684,
       "sha256": "5e168368fbc250af3c79aa5fef0c3467a2d64e5a7bd74005f25d8399aeb0708d"
-    },
-    {
-      "coordinate": "org.openpnp:opencv:jar:4.9.0-0",
-      "scope": "compile",
-      "compressedBytes": 109619828,
-      "sha256": "17823d249cb8ba18bc3cdb878db84936694d1cfaeac0f95517e320c8a8c458d9"
     },
     {
       "coordinate": "org.opentest4j:opentest4j:jar:1.3.0",

--- a/docs/modularization/dependency-baseline/manifests/artifacts-opencv-visual.json
+++ b/docs/modularization/dependency-baseline/manifests/artifacts-opencv-visual.json
@@ -92,10 +92,10 @@
       "sha256": "5cf40ab0cc77828ab2b875b1f3ecd71c8295d7721933476abc2e08fddcea164a"
     },
     {
-      "coordinate": "com.fasterxml.jackson.core:jackson-annotations:jar:2.22",
+      "coordinate": "com.fasterxml.jackson.core:jackson-annotations:jar:2.21",
       "scope": "compile",
-      "compressedBytes": 84211,
-      "sha256": "21ddb598807d3a51a876704eb979d9296e1c6a6f47ab1826ff88c6d6a127a2d0"
+      "compressedBytes": 82104,
+      "sha256": "53ca085f4a150f703f49e1aabd935bd03b43e1ea3d55d135438292af22cef56b"
     },
     {
       "coordinate": "com.fasterxml.jackson.core:jackson-core:jar:2.22.0",
@@ -104,16 +104,16 @@
       "sha256": "d2e8dd4df1e0f61b786ea06792f5bf4235d8278f158f3be6e997e955931c0c98"
     },
     {
-      "coordinate": "com.fasterxml.jackson.core:jackson-databind:jar:2.22.0",
+      "coordinate": "com.fasterxml.jackson.core:jackson-databind:jar:2.21.2",
       "scope": "compile",
-      "compressedBytes": 1703374,
-      "sha256": "3520a0351f294699e3e1b7a37c7a726afd81e1a89ae702ac7d47ff347fd2ecbf"
+      "compressedBytes": 1701926,
+      "sha256": "8c982f01f148d805f0aaac2339011244757e0df7c6ff8951f2fa3f433b8ed849"
     },
     {
-      "coordinate": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.22.0",
+      "coordinate": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.18.3",
       "scope": "compile",
-      "compressedBytes": 60605,
-      "sha256": "bcdbf949c9d5bde823d144b1707ab137c7866f32dee5887ac25fa3049653c08b"
+      "compressedBytes": 55579,
+      "sha256": "3ca00e47cfcb43e79438ddcfc8fc735e9ebac3824fb7769138609be6bd56e483"
     },
     {
       "coordinate": "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.22.0",
@@ -122,10 +122,10 @@
       "sha256": "f1051ed0938aa5edb7567ab19c2c7e1fade58f7fbad43d99a74cb506389c1ac5"
     },
     {
-      "coordinate": "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.22.0",
+      "coordinate": "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.21.1",
       "scope": "compile",
-      "compressedBytes": 136581,
-      "sha256": "c8b3f56855523ed7eae685ca292d2dbe97ff2205adf2fe91a0759e3ee0754d4c"
+      "compressedBytes": 136580,
+      "sha256": "4d63378b0a6b53733f086ebd301023ba211b9387e417bd584a5400320cd08b8d"
     },
     {
       "coordinate": "com.github.ben-manes.caffeine:caffeine:jar:3.2.4",
@@ -236,10 +236,10 @@
       "sha256": "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15"
     },
     {
-      "coordinate": "com.google.api-client:google-api-client:jar:2.9.0",
+      "coordinate": "com.google.api-client:google-api-client:jar:2.2.0",
       "scope": "compile",
-      "compressedBytes": 303788,
-      "sha256": "461377a5c904e8e4e0091cd1b4752bc9ef58b7223d608886d9642436d4b21273"
+      "compressedBytes": 299589,
+      "sha256": "58eca9fb0a869391689ffc828b3bd0b19ac76042ff9fab4881eddf7fde76903f"
     },
     {
       "coordinate": "com.google.api.grpc:grpc-google-common-protos:jar:2.26.0",
@@ -254,16 +254,16 @@
       "sha256": "d6717c5eeacb589e23f9c8adfbc619767fd54a72cfd2cfc8aff1f9068bda11e3"
     },
     {
-      "coordinate": "com.google.api.grpc:proto-google-cloud-kms-v1:jar:2.96.0",
+      "coordinate": "com.google.api.grpc:proto-google-cloud-kms-v1:jar:0.124.0",
       "scope": "compile",
-      "compressedBytes": 1519801,
-      "sha256": "e22cbf998551ab34d23abe0e5087abb9cd2b99af3f9783c08008df346b08a45a"
+      "compressedBytes": 887790,
+      "sha256": "b77f2858bd0eae5ebd5513ecc03f4659ed5f9116d0c0db768f0f34a961bc9296"
     },
     {
-      "coordinate": "com.google.api.grpc:proto-google-common-protos:jar:2.72.0",
+      "coordinate": "com.google.api.grpc:proto-google-common-protos:jar:2.26.0",
       "scope": "compile",
-      "compressedBytes": 2829882,
-      "sha256": "ffcffa6f095043d257c0acd2861a6e01f43de62d6eb4cc59dff61461bb499e16"
+      "compressedBytes": 2030847,
+      "sha256": "66d5875ffe9c44f9e773843441ca11de3163c2730b3645a061269a3925ff00e9"
     },
     {
       "coordinate": "com.google.api.grpc:proto-google-iam-v1:jar:1.21.0",
@@ -272,10 +272,10 @@
       "sha256": "d56a8f10cb20f716299a3b67fdf1eeaefc2d6bf14558cf0c5bb4015c4e18415a"
     },
     {
-      "coordinate": "com.google.api:api-common:jar:2.64.0",
+      "coordinate": "com.google.api:api-common:jar:2.18.0",
       "scope": "compile",
-      "compressedBytes": 51404,
-      "sha256": "d2e69f2f7ab50eb3197ae33c532ee1d67902e964a49fbf711ab11b077ac39b0f"
+      "compressedBytes": 50119,
+      "sha256": "7fddde4add854f353c66299a9889e6815639510d70f32b6115108a0039c1357d"
     },
     {
       "coordinate": "com.google.api:gax-grpc:jar:2.35.0",
@@ -302,16 +302,16 @@
       "sha256": "6c98eb64a9b692127bc9f144837a6f70d5c391132ac198ebb92bfb326d3d2ab4"
     },
     {
-      "coordinate": "com.google.auth:google-auth-library-credentials:jar:1.48.0",
+      "coordinate": "com.google.auth:google-auth-library-credentials:jar:1.19.0",
       "scope": "compile",
-      "compressedBytes": 8554,
-      "sha256": "220b419a81679b2711cb2d3496e34ebcbef03c3ca38b68fac848462db37e1935"
+      "compressedBytes": 5950,
+      "sha256": "095984b0594888a47f311b3c9dcf6da9ed86feeea8f78140c55e14c27b0593e5"
     },
     {
-      "coordinate": "com.google.auth:google-auth-library-oauth2-http:jar:1.48.0",
+      "coordinate": "com.google.auth:google-auth-library-oauth2-http:jar:1.20.0",
       "scope": "compile",
-      "compressedBytes": 337580,
-      "sha256": "2ab4c031319b0e933a1be7cdc89dc8eef1cc5ce03eb779a3bfd7fd9dc5e15cd8"
+      "compressedBytes": 250402,
+      "sha256": "ab3ee74eeccb12fca40f4444af4d45df9e290f2c3f4751e855697dedf52f7a73"
     },
     {
       "coordinate": "com.google.auto.service:auto-service-annotations:jar:1.1.1",
@@ -320,10 +320,10 @@
       "sha256": "16a76dd00a2650568447f5d6e3a9e2c809d9a42367d56b45215cfb89731f4d24"
     },
     {
-      "coordinate": "com.google.auto.value:auto-value-annotations:jar:1.11.1",
+      "coordinate": "com.google.auto.value:auto-value-annotations:jar:1.10.4",
       "scope": "compile",
-      "compressedBytes": 7492,
-      "sha256": "6c61a11420a5cddf3313888e9d335d5eedfbeb9a8da26591470fbfe61f5bf859"
+      "compressedBytes": 7493,
+      "sha256": "e1c45e6beadaef9797cb0d9afd5a45621ad061cd8632012f85582853a3887825"
     },
     {
       "coordinate": "com.google.cloud:google-cloud-kms:jar:2.31.0",
@@ -338,10 +338,10 @@
       "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7"
     },
     {
-      "coordinate": "com.google.code.gson:gson:jar:2.14.0",
+      "coordinate": "com.google.code.gson:gson:jar:2.13.2",
       "scope": "compile",
-      "compressedBytes": 313604,
-      "sha256": "2cbd119bf1961c28788310963dc80ba65f58cdeec1dd139c8bdb1240faa2c36f"
+      "compressedBytes": 289901,
+      "sha256": "dd0ce1b55a3ed2080cb70f9c655850cda86c206862310009dcb5e5c95265a5e0"
     },
     {
       "coordinate": "com.google.crypto.tink:tink-awskms:jar:2.0.0",
@@ -362,10 +362,10 @@
       "sha256": "065086dbbd61c95529f782966c3462838cc8a801ba78420223aa319175a444ff"
     },
     {
-      "coordinate": "com.google.errorprone:error_prone_annotations:jar:2.49.0",
+      "coordinate": "com.google.errorprone:error_prone_annotations:jar:2.47.0",
       "scope": "compile",
-      "compressedBytes": 20255,
-      "sha256": "3b1003e51b8ae56fdbd7c71073e81d1683b97e6c4dff5a9151164d59b769d13c"
+      "compressedBytes": 20254,
+      "sha256": "5364bc6f22e72e98195e406a58d3ba1c09ffa11dea0729592cb870dc2de4056d"
     },
     {
       "coordinate": "com.google.guava:failureaccess:jar:1.0.3",
@@ -386,22 +386,22 @@
       "sha256": "b372a037d4230aa57fbeffdef30fd6123f9c0c2db85d0aced00c91b974f33f99"
     },
     {
-      "coordinate": "com.google.http-client:google-http-client-apache-v2:jar:2.0.0",
+      "coordinate": "com.google.http-client:google-http-client-apache-v2:jar:1.42.3",
       "scope": "compile",
-      "compressedBytes": 11666,
-      "sha256": "9dfeedb952d2f0351dabc3327c42d87431acba63ad15eee272282af56ec033ab"
+      "compressedBytes": 10666,
+      "sha256": "86d112c6f7e55c8f6d1bfbd47a02d25afd072c60a80dea8ef616fba278637600"
     },
     {
-      "coordinate": "com.google.http-client:google-http-client-gson:jar:2.1.0",
+      "coordinate": "com.google.http-client:google-http-client-gson:jar:1.43.3",
       "scope": "compile",
-      "compressedBytes": 12828,
-      "sha256": "3cf72c7b88375a34bf721c664f42edc8e096e2370e4126c9b8933c3c92e591f3"
+      "compressedBytes": 11941,
+      "sha256": "e31a4edcb9c83954a2587e14fa2f3f8f4aad56152381b3321a3bd0bcae03fa26"
     },
     {
-      "coordinate": "com.google.http-client:google-http-client:jar:2.1.0",
+      "coordinate": "com.google.http-client:google-http-client:jar:1.43.3",
       "scope": "compile",
-      "compressedBytes": 297122,
-      "sha256": "20aa0948f6ceb5cfa9b2b3adddd9b7e990ab40230e084081642cbb81235d3eef"
+      "compressedBytes": 292922,
+      "sha256": "60aca7428c5a1ff3655b70541a98ff3d70dded48ac1324dae1af39f1b61914af"
     },
     {
       "coordinate": "com.google.j2objc:j2objc-annotations:jar:3.1",
@@ -410,22 +410,22 @@
       "sha256": "84d3a150518485f8140ea99b8a985656749629f6433c92b80c75b36aba3b099b"
     },
     {
-      "coordinate": "com.google.oauth-client:google-oauth-client:jar:1.39.0",
+      "coordinate": "com.google.oauth-client:google-oauth-client:jar:1.34.1",
       "scope": "compile",
-      "compressedBytes": 81752,
-      "sha256": "27fc61ee2d526e33d31350b5ea383091c0879345e261f9b2e6fcc97a20c86f88"
+      "compressedBytes": 81086,
+      "sha256": "193edf97aefa28b93c5892bdc598bac34fa4c396588030084f290b1440e8b98a"
     },
     {
-      "coordinate": "com.google.protobuf:protobuf-java-util:jar:4.35.0",
+      "coordinate": "com.google.protobuf:protobuf-java-util:jar:3.24.3",
       "scope": "compile",
-      "compressedBytes": 79325,
-      "sha256": "1153aadc409482ac094727e8ed4f641aebc87a68e6d6f96cd602acd837c1846d"
+      "compressedBytes": 73057,
+      "sha256": "359e5e0833a49e845080441ce1dba42db80bddbc96bebbb2761a1617a31345f8"
     },
     {
-      "coordinate": "com.google.protobuf:protobuf-java:jar:4.35.0",
+      "coordinate": "com.google.protobuf:protobuf-java:jar:4.31.1",
       "scope": "compile",
-      "compressedBytes": 1843506,
-      "sha256": "400621a8f0aac52fab7ec88f492edd356f5a4355caa8f92028f217a8b5e4ac3b"
+      "compressedBytes": 1873183,
+      "sha256": "d60dfe7c68a0d38a248cca96924f289dc7e1966a887ee7cae397701af08575ae"
     },
     {
       "coordinate": "com.google.re2j:re2j:jar:1.7",
@@ -548,16 +548,16 @@
       "sha256": "f76b85adb0c00721ae267b7cfde4da7f71d3121cc2160c9fc00c0c89f8c53c8a"
     },
     {
-      "coordinate": "commons-codec:commons-codec:jar:1.22.0",
+      "coordinate": "commons-codec:commons-codec:jar:1.19.0",
       "scope": "compile",
-      "compressedBytes": 420480,
-      "sha256": "d164fe79f262c32d9b18a0b5b2d317d1c27653d5e98fd2b998c24bf901c72ce4"
+      "compressedBytes": 374716,
+      "sha256": "5c3881e4f556855e9c532927ee0c9dfde94cc66760d5805c031a59887070af5f"
     },
     {
-      "coordinate": "commons-io:commons-io:jar:2.22.0",
+      "coordinate": "commons-io:commons-io:jar:2.7",
       "scope": "compile",
-      "compressedBytes": 609182,
-      "sha256": "2b9a7b1f726fb86216dbd2c8321eabe0221dbd5b1be81c18e1cb53811b104758"
+      "compressedBytes": 276413,
+      "sha256": "4547858fff38bbf15262d520685b184a3dce96897bc1844871f055b96e8f6e95"
     },
     {
       "coordinate": "io.appium:java-client:jar:10.1.1",
@@ -728,178 +728,154 @@
       "sha256": "414ee0f7b60d015fb06e5add180cdd9c920608e299685d74f0fc64769a4c7683"
     },
     {
-      "coordinate": "io.grpc:grpc-alts:jar:1.81.0",
+      "coordinate": "io.grpc:grpc-alts:jar:1.58.0",
       "scope": "compile",
-      "compressedBytes": 324010,
-      "sha256": "d3cbd38d2f10c6a6cdaa32efecf3b7eea7b10d1faebe0ae469e0dfbba2520a9d"
+      "compressedBytes": 318074,
+      "sha256": "d108912b6466c16a15bcb62e3418a45ed3c9baa8d34a8e587384af84c52d0948"
     },
     {
-      "coordinate": "io.grpc:grpc-api:jar:1.81.0",
+      "coordinate": "io.grpc:grpc-api:jar:1.58.0",
       "scope": "compile",
-      "compressedBytes": 341888,
-      "sha256": "3e6a659ba3edcdac730c857b27725e2e4d985c2241055e8326eb4fe0f9573d53"
+      "compressedBytes": 293825,
+      "sha256": "d688d25f4f533979df2fcd0881e1e30c2928e5b654ff09bf1440923282b0d945"
     },
     {
-      "coordinate": "io.grpc:grpc-auth:jar:1.81.0",
+      "coordinate": "io.grpc:grpc-auth:jar:1.58.0",
       "scope": "compile",
-      "compressedBytes": 14757,
-      "sha256": "7f1b81147a731f3f097c609ccb76ee875350027a098e490ec54237b664d8ddff"
+      "compressedBytes": 14730,
+      "sha256": "5dfb03827cb61ddde6dde1799188e66071764d261594329f19c9b68e870fc63a"
     },
     {
-      "coordinate": "io.grpc:grpc-context:jar:1.81.0",
+      "coordinate": "io.grpc:grpc-context:jar:1.58.0",
       "scope": "compile",
-      "compressedBytes": 292,
-      "sha256": "05de695306f90ded01d41b083b7500eb13dc53763097ac8c5b0264842df06679"
+      "compressedBytes": 293,
+      "sha256": "3a7626d13084958bcdeab59412e4ec873f07c8315ff2510d363856fac7fadc51"
     },
     {
-      "coordinate": "io.grpc:grpc-core:jar:1.81.0",
+      "coordinate": "io.grpc:grpc-core:jar:1.58.0",
       "scope": "compile",
-      "compressedBytes": 655070,
-      "sha256": "3ffe1a91dedf0603269ce597469bf82f93477b12968a9e0d80fbd407e5ba6e99"
+      "compressedBytes": 630431,
+      "sha256": "93c8880824ee124b91c31f0f1052f86372719d6ece6e4be1c591b7d6dc639f5f"
     },
     {
-      "coordinate": "io.grpc:grpc-googleapis:jar:1.81.0",
+      "coordinate": "io.grpc:grpc-googleapis:jar:1.58.0",
       "scope": "runtime",
-      "compressedBytes": 14876,
-      "sha256": "dcbc663bce922ca56005336195367cdbc7d53267afa8b49251fe4f9b3b05fbc7"
+      "compressedBytes": 14731,
+      "sha256": "d76cac9caffc591ad4c8c526377d881057b538ebd38cd15f4be6dfa9585ceb88"
     },
     {
-      "coordinate": "io.grpc:grpc-grpclb:jar:1.81.0",
+      "coordinate": "io.grpc:grpc-grpclb:jar:1.58.0",
       "scope": "compile",
-      "compressedBytes": 181438,
-      "sha256": "77d6218e6814277ca3cb4f082968b0a3cb1dc82d62e88e7d98ab721065c08f03"
+      "compressedBytes": 177145,
+      "sha256": "a2bc4555451c58c1fb0d3ad49e9b97963bb731aab7a710efaa7d5bc92c22ae53"
     },
     {
-      "coordinate": "io.grpc:grpc-inprocess:jar:1.81.0",
+      "coordinate": "io.grpc:grpc-inprocess:jar:1.58.0",
       "scope": "compile",
-      "compressedBytes": 39596,
-      "sha256": "12dd243a8caf32b00095460a6f9531a2c5685b2e701fd162cb1931af04dd7dce"
+      "compressedBytes": 40269,
+      "sha256": "574864b84b212f211a45f67c3ca3ddfade655654fa76a17ab6a6f273b8800425"
     },
     {
-      "coordinate": "io.grpc:grpc-netty-shaded:jar:1.81.0",
+      "coordinate": "io.grpc:grpc-netty-shaded:jar:1.58.0",
       "scope": "compile",
-      "compressedBytes": 10740192,
-      "sha256": "37bc04a00311f268726c92dad9f8211d24551a442ef19dbcc907d5751d36ef12"
+      "compressedBytes": 9730914,
+      "sha256": "12fc8479b8a43ef62955c452a4fda63c47c20d6d78fd990f9b3a6a7c09fc0977"
     },
     {
-      "coordinate": "io.grpc:grpc-protobuf-lite:jar:1.81.0",
+      "coordinate": "io.grpc:grpc-protobuf-lite:jar:1.58.0",
       "scope": "compile",
-      "compressedBytes": 7814,
-      "sha256": "1bf6294b09925cc6aa82b1fd8750650010e45e0c88972670bdc3135c74aaab4c"
+      "compressedBytes": 7841,
+      "sha256": "f5d2a3f601620db036f72d51bde4a19f939ac7618058e5743fb3599e778992e7"
     },
     {
-      "coordinate": "io.grpc:grpc-protobuf:jar:1.81.0",
+      "coordinate": "io.grpc:grpc-protobuf:jar:1.58.0",
       "scope": "compile",
-      "compressedBytes": 5203,
-      "sha256": "d274af74b76a7846194e0279708d48900c19070f069241a4034bacd42918df1d"
+      "compressedBytes": 5241,
+      "sha256": "77f16774992d5802cfeef7a9d00b3a3f9a82d324ce1cab7f84c6f1a0df5a39c3"
     },
     {
-      "coordinate": "io.grpc:grpc-services:jar:1.81.0",
+      "coordinate": "io.grpc:grpc-services:jar:1.58.0",
       "scope": "runtime",
-      "compressedBytes": 951301,
-      "sha256": "b2ed13276b452af5fb5cf0900a49a264b214eef90149be9c94d90b9a146a8da6"
+      "compressedBytes": 829152,
+      "sha256": "5d8c55fa26f9175c0eac89c2afa9f50dd33d8f608851fed943e41d47a627b231"
     },
     {
-      "coordinate": "io.grpc:grpc-stub:jar:1.81.0",
+      "coordinate": "io.grpc:grpc-stub:jar:1.58.0",
       "scope": "compile",
-      "compressedBytes": 61813,
-      "sha256": "963e75cc63c3659ee8e4cb956436cefdd511761f4e85a674caeeb3052744e39d"
+      "compressedBytes": 49947,
+      "sha256": "1af7bbc56be7b1131c1322ba183126dd050306f91128193f4b9bd5ea71ac8c88"
     },
     {
-      "coordinate": "io.grpc:grpc-util:jar:1.81.0",
+      "coordinate": "io.grpc:grpc-util:jar:1.58.0",
       "scope": "runtime",
-      "compressedBytes": 108747,
-      "sha256": "5ef3f554329ebc18b7ca65de15289acf723a26b8c0bd4e502f41e41abe5a347f"
+      "compressedBytes": 96492,
+      "sha256": "9e8999d98523fb975c7a316bd524671576c1c638b1b1fd357340bb90be14b5db"
     },
     {
-      "coordinate": "io.grpc:grpc-xds:jar:1.81.0",
+      "coordinate": "io.grpc:grpc-xds:jar:1.58.0",
       "scope": "runtime",
-      "compressedBytes": 10958044,
-      "sha256": "7401920c5f909df5d2ff6a137a82ddb7aa09b31f8a3138fd8d9bc9d5b99737d4"
+      "compressedBytes": 12442659,
+      "sha256": "e59e2b4deb6facec9d36083d0f5f9fbef38849d48e0b0eac6bc21d6ffe82d89e"
     },
     {
-      "coordinate": "io.netty:netty-buffer:jar:4.2.15.Final",
+      "coordinate": "io.netty:netty-buffer:jar:4.1.112.Final",
       "scope": "runtime",
-      "compressedBytes": 371912,
-      "sha256": "1361fd9c9ba85b9831cf54a1b2e45ddc3ce34a768931726c099d3f5ef0efe4a3"
+      "compressedBytes": 336505,
+      "sha256": "bc182c48f5369d48cd8370d2ab0c5b8d99dd8ffa4a0f8ac701652d57bd380eff"
     },
     {
-      "coordinate": "io.netty:netty-codec-base:jar:4.2.15.Final",
+      "coordinate": "io.netty:netty-codec-http2:jar:4.1.112.Final",
       "scope": "runtime",
-      "compressedBytes": 152914,
-      "sha256": "2c6d39d7270628b8cfc3166fbd7a93d595958e59c461bc32ddb383c8c91bf811"
+      "compressedBytes": 490314,
+      "sha256": "7f73efc845e8818d71da23b21dc65d69132dd0e12ed0e80cc937bd79ab7d5749"
     },
     {
-      "coordinate": "io.netty:netty-codec-compression:jar:4.2.15.Final",
+      "coordinate": "io.netty:netty-codec-http:jar:4.1.112.Final",
       "scope": "runtime",
-      "compressedBytes": 183091,
-      "sha256": "4adaa5cdd4d2e9b50b23e4c3eff42e73de6eb40848718b3aa84cd5b454da6ce8"
+      "compressedBytes": 668248,
+      "sha256": "21b502d1374d6992728d004e0c1c95544d46d971f55ea78dcb854ce1ac0c83bc"
     },
     {
-      "coordinate": "io.netty:netty-codec-http2:jar:4.2.15.Final",
+      "coordinate": "io.netty:netty-codec:jar:4.1.112.Final",
       "scope": "runtime",
-      "compressedBytes": 494121,
-      "sha256": "4a9b052bd815c765d9c05e27b32abbd32a2c7c3e3364ccb992ce71da1a26bc0d"
+      "compressedBytes": 352121,
+      "sha256": "72db4f93629f7ea520d2998c08e2b1d69f9c6a4792b53da5e9a001d24c78b151"
     },
     {
-      "coordinate": "io.netty:netty-codec-http:jar:4.2.15.Final",
+      "coordinate": "io.netty:netty-common:jar:4.1.112.Final",
       "scope": "runtime",
-      "compressedBytes": 674986,
-      "sha256": "76ae57e87af37b3c4107140f50b9244b1456163a6a225510838f7c5a4458ec22"
+      "compressedBytes": 694486,
+      "sha256": "b03967f32c65de5ed339b97729170e0289b22ffa5729e7f45f68bf6b431fb567"
     },
     {
-      "coordinate": "io.netty:netty-codec-marshalling:jar:4.2.15.Final",
+      "coordinate": "io.netty:netty-handler:jar:4.1.112.Final",
       "scope": "runtime",
-      "compressedBytes": 20378,
-      "sha256": "bbc655b5253387f566b25d4185152951f0121fb3afef2c352e7aa52b9fb965d3"
+      "compressedBytes": 571223,
+      "sha256": "ea4d6062a5fb10a6e2364d8bbdebc1cfa814f1fc9f910ef57e5caf02fb15c588"
     },
     {
-      "coordinate": "io.netty:netty-codec-protobuf:jar:4.2.15.Final",
+      "coordinate": "io.netty:netty-resolver:jar:4.1.112.Final",
       "scope": "runtime",
-      "compressedBytes": 15111,
-      "sha256": "ecf3a24695374b3544700d94db56875da90c1dfbe1e43c744dcc15e1e8998a01"
+      "compressedBytes": 37838,
+      "sha256": "6b4ac9f3b67f562f0770d57c389279ff9c708eb401e1a3635f52297f0f897edc"
     },
     {
-      "coordinate": "io.netty:netty-codec:jar:4.2.15.Final",
+      "coordinate": "io.netty:netty-transport-classes-epoll:jar:4.1.112.Final",
       "scope": "runtime",
-      "compressedBytes": 3954,
-      "sha256": "153b11a166459733af79fb0d4667f30bfa39792896f689b21c93a4a4091387ea"
+      "compressedBytes": 147377,
+      "sha256": "96cf2e6622ea70e2bc67aed373607df32863f863d0d7b8c9c94d468efd1d0638"
     },
     {
-      "coordinate": "io.netty:netty-common:jar:4.2.15.Final",
+      "coordinate": "io.netty:netty-transport-native-unix-common:jar:4.1.112.Final",
       "scope": "runtime",
-      "compressedBytes": 818260,
-      "sha256": "78206aa7f6d197caa926291408c01889b6b910ca0f74017d3fcbdaccf9562959"
+      "compressedBytes": 44156,
+      "sha256": "e79ccea1b87a6348d4ebd3dfb37a2cccd9b7cb65c3375f6ccdac086c7b5ce487"
     },
     {
-      "coordinate": "io.netty:netty-handler:jar:4.2.15.Final",
+      "coordinate": "io.netty:netty-transport:jar:4.1.112.Final",
       "scope": "runtime",
-      "compressedBytes": 586442,
-      "sha256": "99b59e4bea72220d2aed52df8baf37d97431b06ade0b135226cdf73168975eab"
-    },
-    {
-      "coordinate": "io.netty:netty-resolver:jar:4.2.15.Final",
-      "scope": "runtime",
-      "compressedBytes": 32977,
-      "sha256": "24318497f2a3a645964fed418f48879ba11365cab8e1f8d66c47fa7da15ef19a"
-    },
-    {
-      "coordinate": "io.netty:netty-transport-classes-epoll:jar:4.2.15.Final",
-      "scope": "runtime",
-      "compressedBytes": 159908,
-      "sha256": "be509407fd71a4b83378567c613420db544d659bb522df7b253a1dbe8ca297fe"
-    },
-    {
-      "coordinate": "io.netty:netty-transport-native-unix-common:jar:4.2.15.Final",
-      "scope": "runtime",
-      "compressedBytes": 46876,
-      "sha256": "b9ea9fc5ad5eba04e99afdff75b2eb97b5ddfb2ad772e2f2ef5d8f277f3cbd76"
-    },
-    {
-      "coordinate": "io.netty:netty-transport:jar:4.2.15.Final",
-      "scope": "runtime",
-      "compressedBytes": 549606,
-      "sha256": "9fb671e96651066cf1a28dad3f1382c7c99df5b8326d4a214d9a375b311f8dc1"
+      "compressedBytes": 517957,
+      "sha256": "d38e31624d25ca790ee413d529c152170217ebedbcdcf61164fa6291f3a56c92"
     },
     {
       "coordinate": "io.opencensus:opencensus-api:jar:0.31.1",
@@ -1316,10 +1292,10 @@
       "sha256": "3f34a6e4a9104c492dbd397691d3e1d1863568b19c3132471bde0a65611b5156"
     },
     {
-      "coordinate": "org.apache.httpcomponents.client5:httpclient5:jar:5.6.1",
+      "coordinate": "org.apache.httpcomponents.client5:httpclient5:jar:5.6",
       "scope": "compile",
-      "compressedBytes": 1054142,
-      "sha256": "1e3d8444c3c27772e4b9d42a790f06b3345a8ece4fd16d00981f2f2460e1e772"
+      "compressedBytes": 1050450,
+      "sha256": "0992b7dd57fbfc8334df2201e1788a2752ff11b6a638f5ce521915bef72ca4ad"
     },
     {
       "coordinate": "org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4",
@@ -1334,16 +1310,16 @@
       "sha256": "cec2981fa7f520efb63f0787c24f10af2679e31f9f75c448c4dde40a3ae8100d"
     },
     {
-      "coordinate": "org.apache.httpcomponents:httpclient:jar:4.5.14",
+      "coordinate": "org.apache.httpcomponents:httpclient:jar:4.5.13",
       "scope": "compile",
-      "compressedBytes": 785639,
-      "sha256": "c8bc7e1c51a6d4ce72f40d2ebbabf1c4b68bfe76e732104b04381b493478e9d6"
+      "compressedBytes": 780321,
+      "sha256": "6fe9026a566c6a5001608cf3fc32196641f6c1e5e1986d1037ccdbd5f31ef743"
     },
     {
-      "coordinate": "org.apache.httpcomponents:httpcore:jar:4.4.16",
+      "coordinate": "org.apache.httpcomponents:httpcore:jar:4.4.13",
       "scope": "compile",
-      "compressedBytes": 327891,
-      "sha256": "6c9b3dd142a09dc468e23ad39aad6f75a0f2b85125104469f026e52a474e464f"
+      "compressedBytes": 328593,
+      "sha256": "e06e89d40943245fcfa39ec537cdbfce3762aecde8f9c597780d2b00c2b43424"
     },
     {
       "coordinate": "org.apache.httpcomponents:httpmime:jar:4.5.13",
@@ -1442,16 +1418,16 @@
       "sha256": "ac97f7b4b1d8e9337edfa0e34044f8d0efe7223f6ad8f3a85d54cc1018ea2e04"
     },
     {
-      "coordinate": "org.checkerframework:checker-qual:jar:4.2.0",
+      "coordinate": "org.checkerframework:checker-qual:jar:3.33.0",
       "scope": "compile",
-      "compressedBytes": 243432,
-      "sha256": "30bb4494b13f41cbd1502b094caafeb2b1d1f347311c72e7c74f83160acbdf0e"
+      "compressedBytes": 223979,
+      "sha256": "e316255bbfcd9fe50d165314b85abb2b33cb2a66a93c491db648e498a82c2de1"
     },
     {
-      "coordinate": "org.codehaus.mojo:animal-sniffer-annotations:jar:1.27",
-      "scope": "compile",
-      "compressedBytes": 3194,
-      "sha256": "cfd7e51a828fe6b98bc0dbb99e34900c9e9012322cb9ddd57fd8dd0b02da5e27"
+      "coordinate": "org.codehaus.mojo:animal-sniffer-annotations:jar:1.23",
+      "scope": "runtime",
+      "compressedBytes": 3109,
+      "sha256": "9ffe526bf43a6348e9d8b33b9cd6f580a7f5eed0cf055913007eda263de974d0"
     },
     {
       "coordinate": "org.conscrypt:conscrypt-openjdk-uber:jar:2.5.2",
@@ -1538,10 +1514,10 @@
       "sha256": "6f128a71c5e87a16f810513a73ad3c77d0ee0bb622ee0ce1ead115bccbc76d0a"
     },
     {
-      "coordinate": "org.javassist:javassist:jar:3.31.0-GA",
+      "coordinate": "org.javassist:javassist:jar:3.18.1-GA",
       "scope": "compile",
-      "compressedBytes": 812570,
-      "sha256": "44b6b900ca352f4a0048e9428efab16582a014e10f8f65b4e58f5136c704624e"
+      "compressedBytes": 714194,
+      "sha256": "3fb71231afd098bb0f93f5eb97aa8291c8d0556379125e596f92ec8f944c6162"
     },
     {
       "coordinate": "org.jcommander:jcommander:jar:1.83",
@@ -1556,22 +1532,22 @@
       "sha256": "cde3341ba18a2ba262b0b7cf6c55b20c90e8d434e42c9a13e6a3f770db965a88"
     },
     {
-      "coordinate": "org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:2.4.0",
+      "coordinate": "org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.8.21",
       "scope": "runtime",
-      "compressedBytes": 946,
-      "sha256": "5072265564b6b0296f9c7b21fee65edee760c5697436f5ae7427033fa58fc034"
+      "compressedBytes": 963,
+      "sha256": "33d148db0e11debd0d90677d28242bced907f9c77730000fd597867089039d86"
     },
     {
-      "coordinate": "org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:2.4.0",
+      "coordinate": "org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.8.21",
       "scope": "runtime",
-      "compressedBytes": 952,
-      "sha256": "d96b4e297136b8a4b2b88c1adcdc64d92e90d52a417e4315cdcf964adede8aa2"
+      "compressedBytes": 968,
+      "sha256": "3db752a30074f06ee6c57984aa6f27da44f4d2bbc7f5442651f6988f1cb2b7d7"
     },
     {
-      "coordinate": "org.jetbrains.kotlin:kotlin-stdlib:jar:2.4.0",
+      "coordinate": "org.jetbrains.kotlin:kotlin-stdlib:jar:1.8.21",
       "scope": "runtime",
-      "compressedBytes": 1841929,
-      "sha256": "ccb14ff83fabcb11458b798dbc9824748ccdffeec79c9aba789e6ed1cda86b1c"
+      "compressedBytes": 1670468,
+      "sha256": "042a1cd1ac976cdcfe5eb63f1d8e0b0b892c9248e15a69c8cfba495d546ea52a"
     },
     {
       "coordinate": "org.jetbrains:annotations:jar:13.0",
@@ -1808,16 +1784,16 @@
       "sha256": "719095c07d4203961320da593441d8b3b643c18eb1d81aa98ea933bb7eb351ba"
     },
     {
-      "coordinate": "org.slf4j:jcl-over-slf4j:jar:2.0.18",
+      "coordinate": "org.slf4j:jcl-over-slf4j:jar:1.7.30",
       "scope": "compile",
-      "compressedBytes": 18422,
-      "sha256": "ec5c36d57d2dbe100f84878f944575cb7871da32c7a115b8d7e0721277045d67"
+      "compressedBytes": 16537,
+      "sha256": "71e9ee37b9e4eb7802a2acc5f41728a4cf3915e7483d798db3b4ff2ec8847c50"
     },
     {
-      "coordinate": "org.slf4j:slf4j-api:jar:2.0.18",
+      "coordinate": "org.slf4j:slf4j-api:jar:2.0.17",
       "scope": "compile",
-      "compressedBytes": 69982,
-      "sha256": "44508fd1576500688c790b190acdd16fec4f8c79a3e0b900afd70503cf055f55"
+      "compressedBytes": 69908,
+      "sha256": "7b751d952061954d5abfed7181c1f645d336091b679891591d63329c622eb832"
     },
     {
       "coordinate": "org.testng:testng:jar:7.12.0",

--- a/docs/modularization/dependency-baseline/manifests/artifacts.json
+++ b/docs/modularization/dependency-baseline/manifests/artifacts.json
@@ -2,36 +2,6 @@
   "schemaVersion": 1,
   "artifacts": [
     {
-      "coordinate": "com.applitools:eyes-common-java4:jar:4.14.0",
-      "scope": "compile",
-      "compressedBytes": 95526,
-      "sha256": "7bf4d2d204cfc75145721ed7f31f5f19c14bda45194238b534a89391d40dc072"
-    },
-    {
-      "coordinate": "com.applitools:eyes-connectivity-java4-jersey2x:jar:4.14.0",
-      "scope": "compile",
-      "compressedBytes": 10509,
-      "sha256": "1aad1e29fdb7edccac77e8b4ccc40ceb088fa65d99bce5198da71c87e227457c"
-    },
-    {
-      "coordinate": "com.applitools:eyes-images-java4:jar:4.14.0",
-      "scope": "compile",
-      "compressedBytes": 11005,
-      "sha256": "09e9210a8521fe95741e497fd89a8a35be3a344081ab8d83184bf1d32cb322ed"
-    },
-    {
-      "coordinate": "com.applitools:eyes-sdk-core-java4:jar:4.14.0",
-      "scope": "compile",
-      "compressedBytes": 111149,
-      "sha256": "bcefc04ea6810e772b4862f093e1ff5bd89b4ad9e927a3f0a20e00a6e3458e95"
-    },
-    {
-      "coordinate": "com.assertthat:selenium-shutterbug:jar:1.6",
-      "scope": "compile",
-      "compressedBytes": 44532,
-      "sha256": "0a269d75ccb452d66c9f4062187164e431097011fa64fb9b4dc1dbe6c9f6eb48"
-    },
-    {
       "coordinate": "com.atlassian.oai:openapi-request-validator-core:jar:3.0.0",
       "scope": "compile",
       "compressedBytes": 200613,
@@ -222,12 +192,6 @@
       "scope": "compile",
       "compressedBytes": 117159,
       "sha256": "ad95b08b8bbf9d7d17e5e00814898fa23324f32bc5b62f1a37801e6a56ce0079"
-    },
-    {
-      "coordinate": "com.github.zafarkhaja:java-semver:jar:0.9.0",
-      "scope": "compile",
-      "compressedBytes": 46843,
-      "sha256": "2218c73b40f9af98b570d084420c1b4a81332297bd7fc27ddd552e903be8e93c"
     },
     {
       "coordinate": "com.google.android:annotations:jar:4.1.1.4",
@@ -440,18 +404,6 @@
       "sha256": "f430c92394c2053f168715853da96d99996e94e34e5a291b97c5c86a5ad62a98"
     },
     {
-      "coordinate": "com.helger:ph-commons:jar:9.0.2",
-      "scope": "compile",
-      "compressedBytes": 1269522,
-      "sha256": "ac56801148617c1fc0d77fb161cbe9435a6779d4ef5676d7e8b2779fcc47885f"
-    },
-    {
-      "coordinate": "com.helger:ph-css:jar:6.1.1",
-      "scope": "compile",
-      "compressedBytes": 509525,
-      "sha256": "0ba2e837ffa5c523f37d5f16e3b45152853a7afffa0ebba43d66a52b6a536829"
-    },
-    {
       "coordinate": "com.ibm.db2.jcc:db2jcc:jar:db2jcc4",
       "scope": "compile",
       "compressedBytes": 4239628,
@@ -540,12 +492,6 @@
       "scope": "compile",
       "compressedBytes": 295444,
       "sha256": "0076c249b4387d8369146528fd5dacb3efba098dc02ecf9ac81debdfc2e12fd5"
-    },
-    {
-      "coordinate": "com.vaadin.external.google:android-json:jar:0.0.20131108.vaadin1",
-      "scope": "compile",
-      "compressedBytes": 18279,
-      "sha256": "dfb7bae2f404cfe0b72b4d23944698cb716b7665171812a0a4d0f5926c0fac79"
     },
     {
       "coordinate": "com.zaxxer:SparseBitSet:jar:1.3",
@@ -724,8 +670,8 @@
     {
       "coordinate": "io.github.shafthq:shaft-engine:jar:10.2.20260605",
       "scope": "compile",
-      "compressedBytes": 695946,
-      "sha256": "43869beba48828c2ecf3b8146786452c5436ddb47e730aa6d25bfda5e8e7b149"
+      "compressedBytes": 693114,
+      "sha256": "79bc203a06b277d6913aee0f595e3ecbc0ba24386c60be09b1b259a0ccffae73"
     },
     {
       "coordinate": "io.grpc:grpc-alts:jar:1.58.0",
@@ -1172,12 +1118,6 @@
       "sha256": "e04ba5195bcd555dc95650f7cc614d151e4bcd52d29a10b8aa2197f3ab89ab9b"
     },
     {
-      "coordinate": "javax.ws.rs:javax.ws.rs-api:jar:2.0.1",
-      "scope": "compile",
-      "compressedBytes": 115534,
-      "sha256": "38607d626f2288d8fbc1b1f8a62c369e63806d9a313ac7cbc5f9d6c94f4b466d"
-    },
-    {
       "coordinate": "joda-time:joda-time:jar:2.10.5",
       "scope": "compile",
       "compressedBytes": 643043,
@@ -1442,66 +1382,6 @@
       "sha256": "ab829182363e747a1530a368436242f4cca7ff309dd29bfca638a1fdc7b6771d"
     },
     {
-      "coordinate": "org.glassfish.hk2.external:aopalliance-repackaged:jar:2.4.0-b09",
-      "scope": "compile",
-      "compressedBytes": 14767,
-      "sha256": "a97667a617fa5d427c2e95ce6f3eab5cf2d21d00c69ad2a7524ff6d9a9144f58"
-    },
-    {
-      "coordinate": "org.glassfish.hk2.external:javax.inject:jar:2.4.0-b09",
-      "scope": "compile",
-      "compressedBytes": 5951,
-      "sha256": "2265cfd5566d311fcbd8bfe224fb7f978b3018827920b7e0d3167b128a8ff297"
-    },
-    {
-      "coordinate": "org.glassfish.hk2:hk2-api:jar:2.4.0-b09",
-      "scope": "compile",
-      "compressedBytes": 182425,
-      "sha256": "a4e767a36fcb0467d04d4e024a2355488c3064d633eda95935b2b7f9afabde28"
-    },
-    {
-      "coordinate": "org.glassfish.hk2:hk2-locator:jar:2.4.0-b09",
-      "scope": "compile",
-      "compressedBytes": 171065,
-      "sha256": "16d86f041fecbedf49f2d58cce66ee90e440e0ae041631f48f9e3b962c8a1368"
-    },
-    {
-      "coordinate": "org.glassfish.hk2:hk2-utils:jar:2.4.0-b09",
-      "scope": "compile",
-      "compressedBytes": 95318,
-      "sha256": "dfafcfc3a82d37fa7d66bd232920175a2a211e76e3375ff88544d4a5dbe92263"
-    },
-    {
-      "coordinate": "org.glassfish.hk2:osgi-resource-locator:jar:1.0.1",
-      "scope": "compile",
-      "compressedBytes": 20235,
-      "sha256": "775003be577e8806f51b6e442be1033d83be2cb2207227b349be0bf16e6c0843"
-    },
-    {
-      "coordinate": "org.glassfish.jersey.bundles.repackaged:jersey-guava:jar:2.16",
-      "scope": "compile",
-      "compressedBytes": 964502,
-      "sha256": "6ee96b6887386d3fca64789303aa2bf044c22c47377a3953c0b8ca47a70e385b"
-    },
-    {
-      "coordinate": "org.glassfish.jersey.connectors:jersey-apache-connector:jar:2.16",
-      "scope": "compile",
-      "compressedBytes": 23432,
-      "sha256": "9a4b86f05407f9710364828892fb815ff468f50810632a5fc3a8b546e3142a37"
-    },
-    {
-      "coordinate": "org.glassfish.jersey.core:jersey-client:jar:2.16",
-      "scope": "compile",
-      "compressedBytes": 155715,
-      "sha256": "b2cbe55fe21a836b5e1f978bc48ac66c8ce8438f5255e19ca53c2faec5aa9855"
-    },
-    {
-      "coordinate": "org.glassfish.jersey.core:jersey-common:jar:2.16",
-      "scope": "compile",
-      "compressedBytes": 676243,
-      "sha256": "f9dd3acdb6376945fa45f03370f590c532a0526ed69b8855be97fae50eb76ce8"
-    },
-    {
       "coordinate": "org.hamcrest:hamcrest:jar:2.2",
       "scope": "compile",
       "compressedBytes": 123360,
@@ -1512,12 +1392,6 @@
       "scope": "compile",
       "compressedBytes": 27893,
       "sha256": "6f128a71c5e87a16f810513a73ad3c77d0ee0bb622ee0ce1ead115bccbc76d0a"
-    },
-    {
-      "coordinate": "org.javassist:javassist:jar:3.18.1-GA",
-      "scope": "compile",
-      "compressedBytes": 714194,
-      "sha256": "3fb71231afd098bb0f93f5eb97aa8291c8d0556379125e596f92ec8f944c6162"
     },
     {
       "coordinate": "org.jcommander:jcommander:jar:1.83",
@@ -1566,6 +1440,12 @@
       "scope": "compile",
       "compressedBytes": 264973,
       "sha256": "fd68a98b32b1132035c62102e5df0b0fdc358e7c87a9f876ce7071450b4d10da"
+    },
+    {
+      "coordinate": "org.json:json:jar:20260522",
+      "scope": "compile",
+      "compressedBytes": 88704,
+      "sha256": "d671b45e5954211f3566722aa614fbd3b5d46e95f4f9da4dc58c173280bb1799"
     },
     {
       "coordinate": "org.jsoup:jsoup:jar:1.22.2",
@@ -1638,12 +1518,6 @@
       "scope": "compile",
       "compressedBytes": 1647024,
       "sha256": "12dbb224cea124a5d32968722e8eb161c967bf15f3c9a795d1b05592b1147975"
-    },
-    {
-      "coordinate": "org.openpnp:opencv:jar:4.9.0-0",
-      "scope": "compile",
-      "compressedBytes": 109619828,
-      "sha256": "17823d249cb8ba18bc3cdb878db84936694d1cfaeac0f95517e320c8a8c458d9"
     },
     {
       "coordinate": "org.opentest4j:opentest4j:jar:1.3.0",

--- a/docs/modularization/dependency-baseline/manifests/bom.json
+++ b/docs/modularization/dependency-baseline/manifests/bom.json
@@ -6,11 +6,11 @@
     "system": "Linux",
     "machine": "x86_64"
   },
-  "artifactCount": 333,
-  "artifactBytes": 286667824,
-  "seededRepositoryBytes": 791366,
-  "repositoryBytes": 310921042,
-  "repositoryGrowthBytes": 310129676,
-  "elapsedSeconds": 41.254,
+  "artifactCount": 334,
+  "artifactBytes": 286750752,
+  "seededRepositoryBytes": 812508,
+  "repositoryBytes": 311020351,
+  "repositoryGrowthBytes": 310207843,
+  "elapsedSeconds": 48.687,
   "artifactsRef": "artifacts-bom.json"
 }

--- a/docs/modularization/dependency-baseline/manifests/browserstack-sdk.json
+++ b/docs/modularization/dependency-baseline/manifests/browserstack-sdk.json
@@ -6,11 +6,11 @@
     "system": "Linux",
     "machine": "x86_64"
   },
-  "artifactCount": 331,
-  "artifactBytes": 322940699,
-  "seededRepositoryBytes": 791366,
-  "repositoryBytes": 351879427,
-  "repositoryGrowthBytes": 351088061,
-  "elapsedSeconds": 72.772,
+  "artifactCount": 310,
+  "artifactBytes": 208151248,
+  "seededRepositoryBytes": 812508,
+  "repositoryBytes": 236426335,
+  "repositoryGrowthBytes": 235613827,
+  "elapsedSeconds": 63.801,
   "artifactsRef": "artifacts-browserstack-sdk.json"
 }

--- a/docs/modularization/dependency-baseline/manifests/combined-modules.json
+++ b/docs/modularization/dependency-baseline/manifests/combined-modules.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 1,
+  "fixture": "combined-modules",
+  "rootCoordinate": "io.github.shafthq:shaft-engine:10.2.20260605",
+  "platform": {
+    "system": "Linux",
+    "machine": "x86_64"
+  },
+  "artifactCount": 345,
+  "artifactBytes": 353844292,
+  "seededRepositoryBytes": 812508,
+  "repositoryBytes": 382185099,
+  "repositoryGrowthBytes": 381372591,
+  "elapsedSeconds": 44.794,
+  "artifactsRef": "artifacts-combined-modules.json"
+}

--- a/docs/modularization/dependency-baseline/manifests/desktop-video.json
+++ b/docs/modularization/dependency-baseline/manifests/desktop-video.json
@@ -6,11 +6,11 @@
     "system": "Linux",
     "machine": "x86_64"
   },
-  "artifactCount": 342,
-  "artifactBytes": 313850103,
-  "seededRepositoryBytes": 791366,
-  "repositoryBytes": 342866059,
-  "repositoryGrowthBytes": 342074693,
-  "elapsedSeconds": 76.184,
+  "artifactCount": 318,
+  "artifactBytes": 198872925,
+  "seededRepositoryBytes": 812508,
+  "repositoryBytes": 227215182,
+  "repositoryGrowthBytes": 226402674,
+  "elapsedSeconds": 58.4,
   "artifactsRef": "artifacts-desktop-video.json"
 }

--- a/docs/modularization/dependency-baseline/manifests/junit-web.json
+++ b/docs/modularization/dependency-baseline/manifests/junit-web.json
@@ -6,11 +6,11 @@
     "system": "Linux",
     "machine": "x86_64"
   },
-  "artifactCount": 329,
-  "artifactBytes": 284731691,
-  "seededRepositoryBytes": 791366,
-  "repositoryBytes": 313634799,
-  "repositoryGrowthBytes": 312843433,
-  "elapsedSeconds": 75.297,
+  "artifactCount": 308,
+  "artifactBytes": 169941464,
+  "seededRepositoryBytes": 812508,
+  "repositoryBytes": 198181707,
+  "repositoryGrowthBytes": 197369199,
+  "elapsedSeconds": 59.694,
   "artifactsRef": "artifacts.json"
 }

--- a/docs/modularization/dependency-baseline/manifests/legacy-coordinate.json
+++ b/docs/modularization/dependency-baseline/manifests/legacy-coordinate.json
@@ -6,11 +6,11 @@
     "system": "Linux",
     "machine": "x86_64"
   },
-  "artifactCount": 329,
-  "artifactBytes": 284731691,
-  "seededRepositoryBytes": 791366,
-  "repositoryBytes": 313634799,
-  "repositoryGrowthBytes": 312843433,
-  "elapsedSeconds": 69.006,
+  "artifactCount": 308,
+  "artifactBytes": 169941464,
+  "seededRepositoryBytes": 812508,
+  "repositoryBytes": 198181707,
+  "repositoryGrowthBytes": 197369199,
+  "elapsedSeconds": 65.667,
   "artifactsRef": "artifacts.json"
 }

--- a/docs/modularization/dependency-baseline/manifests/opencv-visual.json
+++ b/docs/modularization/dependency-baseline/manifests/opencv-visual.json
@@ -1,16 +1,16 @@
 {
   "schemaVersion": 1,
   "fixture": "opencv-visual",
-  "rootCoordinate": "io.github.shafthq:shaft-engine:10.2.20260605",
+  "rootCoordinate": "io.github.shafthq:shaft-visual:10.2.20260605",
   "platform": {
     "system": "Linux",
     "machine": "x86_64"
   },
-  "artifactCount": 329,
-  "artifactBytes": 284731691,
-  "seededRepositoryBytes": 791366,
-  "repositoryBytes": 313634799,
-  "repositoryGrowthBytes": 312843433,
-  "elapsedSeconds": 79.584,
-  "artifactsRef": "artifacts.json"
+  "artifactCount": 330,
+  "artifactBytes": 284527061,
+  "seededRepositoryBytes": 812508,
+  "repositoryBytes": 313446547,
+  "repositoryGrowthBytes": 312634039,
+  "elapsedSeconds": 69.092,
+  "artifactsRef": "artifacts-opencv-visual.json"
 }

--- a/docs/modularization/dependency-baseline/manifests/testng-web.json
+++ b/docs/modularization/dependency-baseline/manifests/testng-web.json
@@ -6,11 +6,11 @@
     "system": "Linux",
     "machine": "x86_64"
   },
-  "artifactCount": 329,
-  "artifactBytes": 284731691,
-  "seededRepositoryBytes": 791366,
-  "repositoryBytes": 313634799,
-  "repositoryGrowthBytes": 312843433,
-  "elapsedSeconds": 73.035,
+  "artifactCount": 308,
+  "artifactBytes": 169941464,
+  "seededRepositoryBytes": 812508,
+  "repositoryBytes": 198181707,
+  "repositoryGrowthBytes": 197369199,
+  "elapsedSeconds": 61.174,
   "artifactsRef": "artifacts.json"
 }

--- a/scripts/ci/measure_consumer_dependencies.py
+++ b/scripts/ci/measure_consumer_dependencies.py
@@ -27,11 +27,14 @@ BROWSERSTACK_ROOT = ROOT / "shaft-browserstack"
 BROWSERSTACK_POM = BROWSERSTACK_ROOT / "pom.xml"
 VIDEO_ROOT = ROOT / "shaft-video"
 VIDEO_POM = VIDEO_ROOT / "pom.xml"
+VISUAL_ROOT = ROOT / "shaft-visual"
+VISUAL_POM = VISUAL_ROOT / "pom.xml"
 LEGACY_POM = ROOT / "legacy-shaft-engine" / "pom.xml"
 PROJECT_COORDINATES = (
     "io.github.shafthq:shaft-engine",
     "io.github.shafthq:shaft-browserstack",
     "io.github.shafthq:shaft-video",
+    "io.github.shafthq:shaft-visual",
     "io.github.shafthq:SHAFT_ENGINE",
 )
 DEPENDENCY_LINE = re.compile(r"^\s*([^\s].*?):(/.*|[A-Za-z]:\\.*)$")
@@ -83,6 +86,13 @@ def seed_project_artifact(repository: Path, jar: Path, version: str) -> int:
     shutil.copy2(
         VIDEO_ROOT / "target" / f"shaft-video-{version}.jar",
         video_destination / f"shaft-video-{version}.jar",
+    )
+    visual_destination = repository / "io" / "github" / "shafthq" / "shaft-visual" / version
+    visual_destination.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(VISUAL_POM, visual_destination / f"shaft-visual-{version}.pom")
+    shutil.copy2(
+        VISUAL_ROOT / "target" / f"shaft-visual-{version}.jar",
+        visual_destination / f"shaft-visual-{version}.jar",
     )
     seed_pom(repository, "SHAFT_ENGINE", LEGACY_POM, version)
     seed_pom(repository, "shaft-parent", ROOT / "pom.xml", version)
@@ -148,11 +158,15 @@ def expected_jave_coordinate(system: str | None = None, machine: str | None = No
 def validate_required_artifacts(manifest: dict[str, object]) -> list[str]:
     artifacts = {artifact["coordinate"]: artifact for artifact in manifest["artifacts"]}
     errors: list[str] = []
-    required = {
-        "org.openpnp:opencv:jar:4.9.0-0": 109_619_828,
-    }
+    required: dict[str, int] = {}
+    opencv_coordinate = "org.openpnp:opencv:jar:4.9.0-0"
+    optional_fixture = str(manifest.get("fixture"))
+    if optional_fixture in {"opencv-visual", "bom", "combined-modules"}:
+        required[opencv_coordinate] = 109_619_828
+    elif opencv_coordinate in artifacts:
+        errors.append(f"forbidden artifact {opencv_coordinate}")
     browserstack_coordinate = "com.browserstack:browserstack-java-sdk:jar:1.59.8"
-    if manifest.get("fixture") == "browserstack-sdk":
+    if optional_fixture in {"browserstack-sdk", "combined-modules"}:
         required[browserstack_coordinate] = 38_204_017
     elif browserstack_coordinate in artifacts:
         errors.append(f"forbidden artifact {browserstack_coordinate}")
@@ -172,7 +186,7 @@ def validate_required_artifacts(manifest: dict[str, object]) -> list[str]:
     resolved_desktop = sorted(
         coordinate for coordinate in artifacts if coordinate.startswith(desktop_coordinates)
     )
-    if manifest.get("fixture") == "desktop-video":
+    if optional_fixture in {"desktop-video", "combined-modules"}:
         expected_jave = expected_jave_coordinate()
         resolved_jave = sorted(
             coordinate for coordinate in artifacts if coordinate.startswith("ws.schild:jave-nativebin-")

--- a/scripts/ci/validate_modular_documentation.py
+++ b/scripts/ci/validate_modular_documentation.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Validate bundled examples and user-facing modular SHAFT migration docs."""
+from pathlib import Path
+import sys
+import xml.etree.ElementTree as ET
+
+ROOT = Path(__file__).resolve().parents[2]
+EXAMPLES = ROOT / "shaft-engine/src/main/resources/examples"
+NS = {"m": "http://maven.apache.org/POM/4.0.0"}
+EXPECTED_OPTIONAL = {
+    "shaft-cucumber-web": "shaft-visual",
+    "shaft-junit-web": "shaft-video",
+    "shaft-testng-web": "shaft-browserstack",
+}
+REQUIRED_GUIDE_TERMS = (
+    "io.github.shafthq:SHAFT_ENGINE", "io.github.shafthq:shaft-engine",
+    "shaft-bom", "shaft-browserstack", "shaft-video", "shaft-visual",
+    "API", "Appium", "database", "relocation", "cache", "Rollback",
+    "Linux x64", "Linux ARM64", "Windows x64", "macOS x64", "macOS ARM64",
+)
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+def text(node, path):
+    return (node.findtext(path, default="", namespaces=NS) or "").strip()
+
+def main() -> None:
+    poms = sorted(EXAMPLES.rglob("pom.xml"))
+    if len(poms) != 7:
+        fail(f"expected seven bundled example POMs, found {len(poms)}")
+    for pom in poms:
+        root = ET.parse(pom).getroot()
+        artifact = text(root, "m:artifactId")
+        props = root.find("m:properties", NS)
+        prop_names = {child.tag.rsplit("}", 1)[-1] for child in list(props) if props is not None}
+        if "shaft.version" not in prop_names or "shaft_engine.version" in prop_names:
+            fail(f"{pom}: use <shaft.version> only")
+        managed = {text(d, "m:artifactId") for d in root.findall("m:dependencyManagement/m:dependencies/m:dependency", NS)}
+        if "shaft-bom" not in managed:
+            fail(f"{pom}: import shaft-bom")
+        deps = {text(d, "m:artifactId"): text(d, "m:version") for d in root.findall("m:dependencies/m:dependency", NS)}
+        if "SHAFT_ENGINE" in deps or "shaft-engine" not in deps:
+            fail(f"{pom}: declare shaft-engine and not SHAFT_ENGINE")
+        if deps["shaft-engine"]:
+            fail(f"{pom}: shaft-engine version must come from shaft-bom")
+        optional = {name for name in deps if name in {"shaft-browserstack", "shaft-video", "shaft-visual"}}
+        expected = {EXPECTED_OPTIONAL[artifact]} if artifact in EXPECTED_OPTIONAL else set()
+        if optional != expected:
+            fail(f"{pom}: expected optional modules {sorted(expected)}, found {sorted(optional)}")
+    guide = (ROOT / "docs/UPGRADING_TO_MODULAR_SHAFT.md").read_text(encoding="utf-8")
+    for term in REQUIRED_GUIDE_TERMS:
+        if term not in guide:
+            fail(f"upgrade guide is missing {term!r}")
+    if "FINAL_" in guide or "MODULAR_RELEASE_VERSION" not in guide:
+        fail("upgrade guide contains unfinished measurement placeholders or lacks release placeholder")
+    for path in (ROOT / "README.md", ROOT / ".github/RELEASE_BODY_TEMPLATE.md"):
+        if "UPGRADING_TO_MODULAR_SHAFT.md" not in path.read_text(encoding="utf-8"):
+            fail(f"{path}: prominently link the upgrade guide")
+    print("Modular examples and documentation contract is valid.")
+
+if __name__ == "__main__":
+    main()

--- a/shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260605</shaft_engine.version>
+        <shaft.version>10.2.20260605</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
@@ -18,11 +18,26 @@
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
         <surefireArgLine></surefireArgLine>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.github.shafthq</groupId>
+                <artifactId>shaft-bom</artifactId>
+                <version>${shaft.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
             <artifactId>shaft-engine</artifactId>
-            <version>${shaft_engine.version}</version>
+        </dependency>
+        <!-- Optional module used by this example; version is aligned by shaft-bom. -->
+        <dependency>
+            <groupId>io.github.shafthq</groupId>
+            <artifactId>shaft-visual</artifactId>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260605</shaft_engine.version>
+        <shaft.version>10.2.20260605</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
@@ -17,11 +17,21 @@
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
         <surefireArgLine></surefireArgLine>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.github.shafthq</groupId>
+                <artifactId>shaft-bom</artifactId>
+                <version>${shaft.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
             <artifactId>shaft-engine</artifactId>
-            <version>${shaft_engine.version}</version>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260605</shaft_engine.version>
+        <shaft.version>10.2.20260605</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
@@ -17,11 +17,21 @@
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
         <surefireArgLine></surefireArgLine>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.github.shafthq</groupId>
+                <artifactId>shaft-bom</artifactId>
+                <version>${shaft.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
             <artifactId>shaft-engine</artifactId>
-            <version>${shaft_engine.version}</version>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260605</shaft_engine.version>
+        <shaft.version>10.2.20260605</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
@@ -17,11 +17,26 @@
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
         <surefireArgLine></surefireArgLine>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.github.shafthq</groupId>
+                <artifactId>shaft-bom</artifactId>
+                <version>${shaft.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
             <artifactId>shaft-engine</artifactId>
-            <version>${shaft_engine.version}</version>
+        </dependency>
+        <!-- Optional module used by this example; version is aligned by shaft-bom. -->
+        <dependency>
+            <groupId>io.github.shafthq</groupId>
+            <artifactId>shaft-video</artifactId>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260605</shaft_engine.version>
+        <shaft.version>10.2.20260605</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
@@ -18,11 +18,21 @@
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
         <surefireArgLine></surefireArgLine>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.github.shafthq</groupId>
+                <artifactId>shaft-bom</artifactId>
+                <version>${shaft.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
             <artifactId>shaft-engine</artifactId>
-            <version>${shaft_engine.version}</version>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260605</shaft_engine.version>
+        <shaft.version>10.2.20260605</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
@@ -18,11 +18,21 @@
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
         <surefireArgLine></surefireArgLine>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.github.shafthq</groupId>
+                <artifactId>shaft-bom</artifactId>
+                <version>${shaft.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
             <artifactId>shaft-engine</artifactId>
-            <version>${shaft_engine.version}</version>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft_engine.version>10.2.20260605</shaft_engine.version>
+        <shaft.version>10.2.20260605</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
@@ -18,11 +18,26 @@
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
         <surefireArgLine></surefireArgLine>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.github.shafthq</groupId>
+                <artifactId>shaft-bom</artifactId>
+                <version>${shaft.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
             <artifactId>shaft-engine</artifactId>
-            <version>${shaft_engine.version}</version>
+        </dependency>
+        <!-- Optional module used by this example; version is aligned by shaft-bom. -->
+        <dependency>
+            <groupId>io.github.shafthq</groupId>
+            <artifactId>shaft-browserstack</artifactId>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/tests/scripts/test_measure_consumer_dependencies.py
+++ b/tests/scripts/test_measure_consumer_dependencies.py
@@ -64,7 +64,6 @@ The following files have been resolved:
         manifest = {
             "fixture": "desktop-video",
             "artifacts": [
-                {"coordinate": "org.openpnp:opencv:jar:4.9.0-0", "compressedBytes": 109_619_828},
                 {"coordinate": "ws.schild:jave-nativebin-linux64:jar:3.5.0", "compressedBytes": 28_201_169},
             ]
         }
@@ -79,7 +78,6 @@ The following files have been resolved:
         manifest = {
             "fixture": "testng-web",
             "artifacts": [
-                {"coordinate": "org.openpnp:opencv:jar:4.9.0-0", "compressedBytes": 109_619_828},
                 {"coordinate": "com.browserstack:browserstack-java-sdk:jar:1.59.8", "compressedBytes": 38_204_017},
             ],
         }
@@ -97,7 +95,6 @@ The following files have been resolved:
         manifest = {
             "fixture": "testng-web",
             "artifacts": [
-                {"coordinate": "org.openpnp:opencv:jar:4.9.0-0", "compressedBytes": 109_619_828},
                 {"coordinate": "ws.schild:jave-nativebin-linux64:jar:3.5.0", "compressedBytes": 28_201_169},
             ],
         }
@@ -111,14 +108,13 @@ The following files have been resolved:
         expected = {
             "schemaVersion": 1,
             "fixture": "desktop-video",
-            "artifactCount": 2,
-            "artifactBytes": 137_821_028,
+            "artifactCount": 1,
+            "artifactBytes": 28_201_200,
             "elapsedSeconds": 1.0,
             "repositoryBytes": 10,
             "repositoryGrowthBytes": 5,
             "seededRepositoryBytes": 5,
             "artifacts": [
-                {"coordinate": "org.openpnp:opencv:jar:4.9.0-0", "compressedBytes": 109_619_828},
                 {"coordinate": measure.expected_jave_coordinate(), "compressedBytes": 28_201_200},
             ],
         }
@@ -149,6 +145,9 @@ The following files have been resolved:
             video_root = root / "shaft-video"
             video_pom = video_root / "pom.xml"
             video_jar = video_root / "target" / "shaft-video-1.2.3.jar"
+            visual_root = root / "shaft-visual"
+            visual_pom = visual_root / "pom.xml"
+            visual_jar = visual_root / "target" / "shaft-visual-1.2.3.jar"
             legacy_pom = root / "legacy-pom.xml"
             jar.write_bytes(b"jar")
             engine_pom.write_text("<project>engine</project>", encoding="utf-8")
@@ -161,6 +160,10 @@ The following files have been resolved:
             video_pom.write_text("<project>video</project>", encoding="utf-8")
             video_jar.parent.mkdir(parents=True)
             video_jar.write_bytes(b"video-jar")
+            visual_pom.parent.mkdir(parents=True)
+            visual_pom.write_text("<project>visual</project>", encoding="utf-8")
+            visual_jar.parent.mkdir(parents=True)
+            visual_jar.write_bytes(b"visual-jar")
             legacy_pom.write_text("<project>legacy</project>", encoding="utf-8")
             (root / "pom.xml").write_text("<project>parent</project>", encoding="utf-8")
 
@@ -171,6 +174,8 @@ The following files have been resolved:
                 mock.patch.object(measure, "BROWSERSTACK_POM", browserstack_pom),
                 mock.patch.object(measure, "VIDEO_ROOT", video_root),
                 mock.patch.object(measure, "VIDEO_POM", video_pom),
+                mock.patch.object(measure, "VISUAL_ROOT", visual_root),
+                mock.patch.object(measure, "VISUAL_POM", visual_pom),
                 mock.patch.object(measure, "LEGACY_POM", legacy_pom),
                 mock.patch.object(measure, "ROOT", root),
             ):
@@ -202,6 +207,10 @@ The following files have been resolved:
             self.assertEqual(
                 (repository / "io/github/shafthq/shaft-video/1.2.3/shaft-video-1.2.3.jar").read_bytes(),
                 b"video-jar",
+            )
+            self.assertEqual(
+                (repository / "io/github/shafthq/shaft-visual/1.2.3/shaft-visual-1.2.3.jar").read_bytes(),
+                b"visual-jar",
             )
             self.assertEqual(
                 (repository / "io/github/shafthq/SHAFT_ENGINE/1.2.3/SHAFT_ENGINE-1.2.3.pom").read_text(encoding="utf-8"),

--- a/tests/scripts/test_validate_modular_documentation.py
+++ b/tests/scripts/test_validate_modular_documentation.py
@@ -1,0 +1,13 @@
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+class ModularDocumentationValidationTest(unittest.TestCase):
+    def test_repository_contract(self):
+        subprocess.run([sys.executable, str(ROOT / "scripts/ci/validate_modular_documentation.py")], cwd=ROOT, check=True)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Implementation agent
Codex implemented these changes. The authenticated maintainer token owner did not author them manually.

Closes #2821

## Summary
- Migrated all seven bundled example POMs to `<shaft.version>`, `shaft-bom`, and `shaft-engine`.
- Kept API and mobile examples on `shaft-engine` alone; added BOM-aligned optional examples for BrowserStack (`shaft-testng-web`), desktop video (`shaft-junit-web`), and OpenCV visual matching (`shaft-cucumber-web`).
- Added a dedicated upgrade guide from `10.2.20260605` covering old/new coordinates, BOM and explicit versions, optional-module selection, retained API/Appium/database support, relocation/support behavior, CI cache migration, provider troubleshooting, verified per-platform cold-cache measurements, and rollback.
- Updated README, quick start, architecture/features docs, release template, release workflows, code-quality drift checks, and durable agent/release guidance for the modular coordinates.
- Extended cold-cache tooling to seed and recognize `shaft-visual`, validate fixture-specific optional graphs, and record the combined-module graph.
- Added a deterministic documentation/example contract validator and refreshed all ten final modular dependency manifests.

## PDCA iterations
### Iteration 1 — examples
- **Plan:** migrate the smallest user-facing surface first.
- **Do:** changed seven POMs to the BOM/lowercase coordinate and assigned one optional module to each demonstrated web capability.
- **Check:** compiled every example with `mvn --batch-mode -f <example>/pom.xml test-compile -DskipTests`.
- **Act:** kept API/mobile free of optional modules and encoded that rule in validation.

### Iteration 2 — migration documentation
- **Plan:** satisfy every upgrade-guide topic with one canonical document and prominent links.
- **Do:** added the guide and synchronized README/docs/release/agent guidance.
- **Check:** added `validate_modular_documentation.py` plus unit coverage and YAML parsing checks.
- **Act:** changed README quick start to the recommended BOM form and updated sample-version automation to `<shaft.version>`.

### Iteration 3 — verified measurements
- **Plan:** replace intermediate dependency manifests with final post-extraction data.
- **Do:** added `shaft-visual` seeding and fixture-aware optional dependency validation, then measured all ten fixtures from empty Maven repositories.
- **Check:** recorded a lean engine graph of 169,941,464 compressed classpath bytes and verified all script tests.
- **Act:** documented exact per-platform before/after totals and deterministic native-JAR substitution methodology rather than comparing unstable elapsed time.

## Validation
- `mvn clean install -DskipTests -Dgpg.skip`
- All seven bundled POMs: `mvn --batch-mode -f <pom> test-compile -DskipTests`
- `python3 scripts/ci/measure_consumer_dependencies.py --record`
- `python3 scripts/ci/validate_modular_documentation.py`
- `python3 -m unittest discover -s tests/scripts -p 'test_*.py'` (60 tests)
- Ruby YAML parsing for changed workflows/release configuration
- `git diff --check`

## Acceptance criteria
- [x] All seven examples compile against reactor-installed artifacts.
- [x] No normal example uses `SHAFT_ENGINE`; relocation remains limited to compatibility fixtures/docs.
- [x] API and mobile examples prove no split occurred.
- [x] Optional examples use BOM-aligned modules.
- [x] Upgrade guide is linked prominently from README and release notes.
- [x] Documentation contains verified final measurements for Linux x64/ARM64, Windows x64, and macOS x64/ARM64.

## Risks / notes
- The guide uses `MODULAR_RELEASE_VERSION` intentionally until issue #2822 publishes the release; it links Maven Central for the actual released version.
- Elapsed time and repository growth remain observational. The published savings compare reproducible compressed classpath JAR bytes.
