### PR TITLE
codex: prepare modular SHAFT 10.2.20260609 release

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,15 +5,15 @@ Guide Copilot coding agent to generate concise, maintainable, and secure code fo
 
 ## Repository Overview
 SHAFT_ENGINE is a unified test automation framework built with:
-- **Language**: Java 21
+- **Language**: Java 25
 - **Build Tool**: Maven
 - **Testing Frameworks**: TestNG, JUnit5, Cucumber
 - **Key Technologies**: Selenium WebDriver, Appium, REST Assured, Allure Reports
 - **Project Structure**:
-  - `src/main/java/com/shaft/` - Core framework code
-  - `src/test/java/` - Test examples and validation tests
-  - `src/test/resources/testDataFiles/` - JSON test data files
-  - `src/main/resources/` - Framework configuration and Docker compose files
+  - `shaft-engine/src/main/java/com/shaft/` - Core framework code
+  - `shaft-engine/src/test/java/` - Test examples and validation tests
+  - `shaft-engine/src/test/resources/testDataFiles/` - JSON test data files
+  - `shaft-engine/src/main/resources/` - Framework configuration and Docker compose files
   - `docs/` - Documentation
   - `.github/workflows/` - CI/CD pipelines
   - `.github/instructions/` - Path-specific Copilot instructions (java-tests, framework-source)
@@ -766,15 +766,15 @@ When generating changelogs, release notes, or updating `Internal.java`, always f
 
 Follow these steps in order when preparing a new SHAFT release:
 
-### 1. Update Version Numbers (Three Places — Always All)
-- **`pom.xml`** (line 6): change `<version>OLD</version>` to `<version>NEW</version>`.  The comment next to it reminds you to also update `Internal.java`.
-- **`src/main/java/com/shaft/properties/internal/Internal.java`**:
+### 1. Update Version Numbers (All Reactor Locations)
+- **Root and child POMs**: update the root `pom.xml` project version and every reactor module parent version together.
+- **`shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java`**:
   - change the `@DefaultValue` of `shaftEngineVersion()` to match the new release version.
   - also check and update `allure3Version()` to the latest stable Allure 3 npm package version.
   - also check and update `nodeLtsVersion()` to the latest Node.js LTS patch version.
-- **All example/demo `pom.xml` files** under `src/main/resources/examples/` (7 files — TestNG, JUnit, Cucumber variants): change `<shaft.version>OLD</shaft.version>` to `<shaft.version>NEW</shaft.version>` in the release PR itself. Do not wait for the post-release sync workflow to correct sample/demo projects after the release. You can do this in bulk with:
+- **All example/demo `pom.xml` files** under `shaft-engine/src/main/resources/examples/` (7 files — TestNG, JUnit, Cucumber variants): change `<shaft.version>OLD</shaft.version>` to `<shaft.version>NEW</shaft.version>` in the release PR itself. Do not wait for the post-release sync workflow to correct sample/demo projects after the release. You can do this in bulk with:
   ```bash
-  find src/main/resources/examples -name "pom.xml" | xargs sed -i 's|<shaft.version>OLD</shaft.version>|<shaft.version>NEW</shaft.version>|g'
+  find shaft-engine/src/main/resources/examples -name "pom.xml" | xargs sed -i 's|<shaft.version>OLD</shaft.version>|<shaft.version>NEW</shaft.version>|g'
   ```
 
 ### 2. Sync All Sample Project Properties with Main `pom.xml`
@@ -786,7 +786,7 @@ After updating the SHAFT version, compare every versioned property in each sampl
 | Property | Where to read the canonical value in main `pom.xml` |
 |---|---|
 | `shaft.version` | `<project><version>` (line 6) |
-| `jdk.version` | `<source>` / `<target>` inside `maven-compiler-plugin` configuration |
+| `jdk.version` | Root `<properties><jdk.version>` |
 | `aspectjweaver.version` | `<version>` of `org.aspectj:aspectjweaver` in `<dependencies>` |
 | `maven-compiler-plugin.version` | `<version>` of the `maven-compiler-plugin` in `<build><plugins>` |
 | `maven-resources-plugin.version` | `<version>` of the `maven-resources-plugin` in `<build><plugins>` |
@@ -799,20 +799,20 @@ After updating the SHAFT version, compare every versioned property in each sampl
 grep -E "aspectjweaver|maven-compiler-plugin|maven-resources-plugin|maven-surefire-plugin|surefire-testng" pom.xml | grep "<version>"
 
 # Check what the sample projects currently declare
-grep -rE "jdk\.version|aspectjweaver\.version|maven-compiler-plugin\.version|maven-resources-plugin\.version|maven-surefire-plugin\.version|surefire-testng\.version" src/main/resources/examples/
+grep -rE "jdk\.version|aspectjweaver\.version|maven-compiler-plugin\.version|maven-resources-plugin\.version|maven-surefire-plugin\.version|surefire-testng\.version" shaft-engine/src/main/resources/examples/
 ```
 
 Apply bulk sed updates for each drifted property across all 7 sample files, for example:
 ```bash
 # Example: updating jdk.version from OLD to NEW
-find src/main/resources/examples -name "pom.xml" | xargs sed -i 's|<jdk.version>OLD</jdk.version>|<jdk.version>NEW</jdk.version>|g'
+find shaft-engine/src/main/resources/examples -name "pom.xml" | xargs sed -i 's|<jdk.version>OLD</jdk.version>|<jdk.version>NEW</jdk.version>|g'
 
 # Example: updating aspectjweaver.version
-find src/main/resources/examples -name "pom.xml" | xargs sed -i 's|<aspectjweaver.version>OLD</aspectjweaver.version>|<aspectjweaver.version>NEW</aspectjweaver.version>|g'
+find shaft-engine/src/main/resources/examples -name "pom.xml" | xargs sed -i 's|<aspectjweaver.version>OLD</aspectjweaver.version>|<aspectjweaver.version>NEW</aspectjweaver.version>|g'
 
 # Example: updating maven-surefire-plugin.version and surefire-testng.version
-find src/main/resources/examples -name "pom.xml" | xargs sed -i 's|<maven-surefire-plugin.version>OLD</maven-surefire-plugin.version>|<maven-surefire-plugin.version>NEW</maven-surefire-plugin.version>|g'
-find src/main/resources/examples -name "pom.xml" | xargs sed -i 's|<surefire-testng.version>OLD</surefire-testng.version>|<surefire-testng.version>NEW</surefire-testng.version>|g'
+find shaft-engine/src/main/resources/examples -name "pom.xml" | xargs sed -i 's|<maven-surefire-plugin.version>OLD</maven-surefire-plugin.version>|<maven-surefire-plugin.version>NEW</maven-surefire-plugin.version>|g'
+find shaft-engine/src/main/resources/examples -name "pom.xml" | xargs sed -i 's|<surefire-testng.version>OLD</surefire-testng.version>|<surefire-testng.version>NEW</surefire-testng.version>|g'
 ```
 
 ### 3. Dependency Version Check
@@ -833,18 +833,19 @@ mvn clean install -DskipTests -Dgpg.skip    # must succeed
 > [!NOTE]
 > For **release-generation-only** PRs (version metadata updates, release-workflow improvements, or release-doc updates that do not modify framework source code or test logic),
 > skip baseline/full test-suite reruns to keep release preparation lightweight; rely on pre-release validation already completed and CI on merge.
-> If any file under `src/main/java/` or `src/test/java/` is modified, the mandatory pre-commit rules apply in full. In all cases, `mvn clean install -DskipTests -Dgpg.skip` must pass before commit.
+> If any file under `shaft-engine/src/main/java/` or `shaft-engine/src/test/java/` is modified, the mandatory pre-commit rules apply in full. In all cases, `mvn clean install -DskipTests -Dgpg.skip` must pass before commit.
 
 ### 5. Open the Release PR
 Use a PR title that includes the release name/version and clearly says this PR generates/prepares a new release, for example: `chore(release): generate SHAFT_ENGINE 10.2.20260513 release`. Open the PR directly after validation; do not wait for a separate prompt once the release metadata is ready.
 
 ### 6. Commit and Merge to `main`
 Merging to `main` automatically triggers the **Maven Central Continuous Delivery** workflow (`mavenCentral_cd.yml`), which:
-1. Substitutes `$RELEASE_VERSION` in `.github/RELEASE_BODY_TEMPLATE.md` and uses it as the release body.
-2. Creates a GitHub Release via `ncipollo/release-action` with `generateReleaseNotes: true` **and** `bodyFile`.
-3. Dispatches a `shaft-engine-release` event to `ShaftHQ/shafthq.github.io` (user guide repo) via `BOT_TOKEN`.
-4. Resolves the generated release-blog-post PR link and sends it in the Slack release announcement (when `SLACK_WEBHOOK_URL` is configured).
-5. Deploys the artifact to Maven Central.
+1. Validates the complete reactor and publication outputs.
+2. Deploys the aligned public artifact set to Maven Central.
+3. Verifies POMs, JARs, classifiers, signatures, canonical consumers, combined modules, and legacy relocation from Central.
+4. Creates the GitHub Release via `ncipollo/release-action`.
+5. Dispatches a `shaft-engine-release` event to `ShaftHQ/shafthq.github.io`.
+6. Announces the release on Slack when configured.
 
 > [!IMPORTANT]
 > **How release notes are assembled — do not break this contract:**
@@ -898,7 +899,8 @@ See: https://github.com/ShaftHQ/shafthq.github.io/issues/468
 - [ ] `Internal.java` `shaftEngineVersion` `@DefaultValue` updated
 - [ ] `Internal.java` `allure3Version` checked/updated to latest stable
 - [ ] `Internal.java` `nodeLtsVersion` checked/updated to latest LTS patch
-- [ ] All 7 example/demo `pom.xml` files under `src/main/resources/examples/` updated in this release PR — bump `<shaft.version>` manually (use the bulk `sed` command above); do **not** wait for the **Sync Sample Projects SHAFT Version** workflow to fix release PR drift
+- [ ] All reactor parent versions match the root project version
+- [ ] All 7 example/demo `pom.xml` files under `shaft-engine/src/main/resources/examples/` updated in this release PR — bump `<shaft.version>` manually (use the bulk `sed` command above); do **not** wait for the **Sync Sample Projects SHAFT Version** workflow to fix release PR drift
 - [ ] All 7 example `pom.xml` files synced with main `pom.xml` for plugin/dependency versions — the **Sync Sample Projects SHAFT Version** workflow handles `jdk.version`, `aspectjweaver.version`, `maven-compiler-plugin.version`, `maven-resources-plugin.version`, `maven-surefire-plugin.version`, and `surefire-testng.version` automatically; manually verify only if the workflow fails
 - [ ] Dependency currency gate executed: `versions:display-dependency-updates`, `versions:display-plugin-updates`, and `versions:display-property-updates`
 - [ ] No stable dependency/plugin/property updates skipped

--- a/.github/copilot-memory.md
+++ b/.github/copilot-memory.md
@@ -93,3 +93,10 @@ Purpose: keep high-signal, reusable learnings from implementation sessions in on
 - Lesson: In TestNG `setParallel=METHODS`, ordinary instance fields are shared by concurrently running methods in the same class. If `@BeforeMethod` writes a per-method temp path to a shared field and `@AfterMethod` deletes from that field, another method can delete files still being read, surfacing as misleading image IO errors such as `javax.imageio.IIOException: Can't create an ImageInputStream!`. Use `ThreadLocal` for per-method temp paths or serialize classes that intentionally mutate shared/static state. Also inspect retried/skipped Allure result JSON and adjacent job logs, because the final summary can pass after retries while exposing the race.
 - Evidence: `src/test/java/testPackage/unitTests/ImageProcessingActionsUnitTest.java`, `.github/workflows/e2eTests.yml`, run `27004138692`.
 - Action taken: Converted the test temp directory state to `ThreadLocal`, added CI/test instruction guidance, and validated with the Edge Grid workflow properties.
+
+- Date: 2026-06-09
+- Area: Modular release readiness / Maven Central immutability
+- Trigger: Final release-candidate validation for issues #2809 and #2822.
+- Lesson: The first modular release must use a version newer than the final monolithic `SHAFT_ENGINE` release because Maven Central coordinates are immutable and the legacy relocation POM cannot replace an existing JAR version. Release automation must wait for Central publication, verify all public POM/JAR/classifier/signature paths, and compile canonical, combined-module, and legacy-relocation consumers before creating the GitHub release or announcements. Publish one navigable JavaDocs site covering every Java-bearing module.
+- Evidence: `pom.xml`, `.github/workflows/mavenCentral_cd.yml`, `.github/workflows/publishJavaDocs.yml`, `scripts/ci/verify_maven_central_release.py`, `scripts/ci/assemble_javadocs.py`, PR #2838.
+- Action taken: Prepared `10.2.20260609`, upgraded Allure to `3.10.0`, added Central smoke verification and aggregate JavaDocs assembly, and expanded release validators.

--- a/.github/instructions/framework-source.instructions.md
+++ b/.github/instructions/framework-source.instructions.md
@@ -109,7 +109,7 @@ When fixing a bug or unexpected behavior in framework source files, you **must**
 - Run regression tests to confirm no other behavior is broken
 
 ### Release Metadata Updates in `Internal.java`
-When preparing a SHAFT release and editing `shaft-engine/shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java`, update/verify these keys together:
+When preparing a SHAFT release and editing `shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java`, update/verify these keys together:
 - `shaftEngineVersion` (must match root `pom.xml` project version)
 - `allure3Version` (latest stable Allure 3 npm package)
 - `nodeLtsVersion` (latest Node.js LTS patch)

--- a/.github/skills/github-copilot/release-dependency-guard.md
+++ b/.github/skills/github-copilot/release-dependency-guard.md
@@ -24,8 +24,9 @@ Verify that the SHAFT engine version is consistent across all required locations
 | # | File | Field / Pattern |
 |---|---|---|
 | 1 | `pom.xml` (line 6) | `<version>X.Y.Z</version>` |
-| 2 | `src/main/java/com/shaft/properties/internal/Internal.java` | `@DefaultValue("X.Y.Z")` on `shaftEngineVersion()` |
-| 3 | All 7 `pom.xml` files under `src/main/resources/examples/` | `<shaft.version>X.Y.Z</shaft.version>` |
+| 2 | All reactor child `pom.xml` files | Parent `<version>X.Y.Z</version>` |
+| 3 | `shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java` | `@DefaultValue("X.Y.Z")` on `shaftEngineVersion()` |
+| 4 | All 7 `pom.xml` files under `shaft-engine/src/main/resources/examples/` | `<shaft.version>X.Y.Z</shaft.version>` |
 
 ### Validation Rules
 - All locations must declare the **same** version string.
@@ -40,7 +41,7 @@ Compare the following properties across the main `pom.xml` and all 7 sample proj
 
 | Property | Main `pom.xml` Location |
 |---|---|
-| `jdk.version` | `<source>` / `<target>` in `maven-compiler-plugin` config |
+| `jdk.version` | Root `<properties><jdk.version>` |
 | `aspectjweaver.version` | `<version>` of `org.aspectj:aspectjweaver` in `<dependencies>` |
 | `maven-compiler-plugin.version` | `<version>` of `maven-compiler-plugin` in `<build><plugins>` |
 | `maven-resources-plugin.version` | `<version>` of `maven-resources-plugin` in `<build><plugins>` |
@@ -115,7 +116,7 @@ Use this exact structure:
 **Remediation** (if drift detected):
 ```bash
 # Copy-paste ready fix commands
-find src/main/resources/examples -name "pom.xml" | xargs sed -i 's|<OLD>|<NEW>|g'
+find shaft-engine/src/main/resources/examples -name "pom.xml" | xargs sed -i 's|<OLD>|<NEW>|g'
 ```
 
 ### Dependency Updates Available

--- a/.github/workflows/e2eLocalTests.yml
+++ b/.github/workflows/e2eLocalTests.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           node-version: '20'
       - name: Install optional visual test runtime
-        run: mvn -pl shaft-visual -am -e install -DskipTests -Dgpg.skip
+        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
       - name: Print Edge version
         continue-on-error: true
         run: (Get-Item (Get-Command msedge).Source).VersionInfo.ProductVersion
@@ -75,7 +75,7 @@ jobs:
         with:
           node-version: '20'
       - name: Install optional visual test runtime
-        run: mvn -pl shaft-visual -am -e install -DskipTests -Dgpg.skip
+        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
       - name: Run tests
         continue-on-error: true
         run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=safari" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}, !%regex[.*MobileEmulation.*]"
@@ -104,7 +104,7 @@ jobs:
         with:
           node-version: '20'
       - name: Install optional visual test runtime
-        run: mvn -pl shaft-visual -am -e install -DskipTests -Dgpg.skip
+        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
       - name: Run tests
         continue-on-error: true
         run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=WINDOWS" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}"
@@ -133,7 +133,7 @@ jobs:
         with:
           node-version: '20'
       - name: Install optional visual test runtime
-        run: mvn -pl shaft-visual -am -e install -DskipTests -Dgpg.skip
+        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
       - name: Run tests
         continue-on-error: true
         run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}"

--- a/.github/workflows/e2eLocalTests.yml
+++ b/.github/workflows/e2eLocalTests.yml
@@ -42,12 +42,14 @@ jobs:
         uses: ./.github/actions/setup-test-env
         with:
           node-version: '20'
+      - name: Install optional visual test runtime
+        run: mvn -pl shaft-visual -am -e install -DskipTests -Dgpg.skip
       - name: Print Edge version
         continue-on-error: true
         run: (Get-Item (Get-Command msedge).Source).VersionInfo.ProductVersion
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=WINDOWS" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=WINDOWS" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -72,9 +74,11 @@ jobs:
         uses: ./.github/actions/setup-test-env
         with:
           node-version: '20'
+      - name: Install optional visual test runtime
+        run: mvn -pl shaft-visual -am -e install -DskipTests -Dgpg.skip
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=safari" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}, !%regex[.*MobileEmulation.*]"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=safari" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}, !%regex[.*MobileEmulation.*]"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -99,9 +103,11 @@ jobs:
         uses: ./.github/actions/setup-test-env
         with:
           node-version: '20'
+      - name: Install optional visual test runtime
+        run: mvn -pl shaft-visual -am -e install -DskipTests -Dgpg.skip
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=WINDOWS" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=WINDOWS" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -126,9 +132,11 @@ jobs:
         uses: ./.github/actions/setup-test-env
         with:
           node-version: '20'
+      - name: Install optional visual test runtime
+        run: mvn -pl shaft-visual -am -e install -DskipTests -Dgpg.skip
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -185,7 +185,7 @@ jobs:
       - name: Check running containers
         run: docker ps
       - name: Install optional visual test runtime
-        run: mvn -pl shaft-visual -am -e install -DskipTests -Dgpg.skip
+        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
       - name: Run tests
         continue-on-error: true
         run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=firefox" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
@@ -220,7 +220,7 @@ jobs:
       - name: Check running containers
         run: docker ps
       - name: Install optional visual test runtime
-        run: mvn -pl shaft-visual -am -e install -DskipTests -Dgpg.skip
+        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
       - name: Run tests
         continue-on-error: true
         run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
@@ -255,7 +255,7 @@ jobs:
       - name: Check running containers
         run: docker ps
       - name: Install optional visual test runtime
-        run: mvn -pl shaft-visual -am -e install -DskipTests -Dgpg.skip
+        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
       - name: Run tests
         continue-on-error: true
         run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -185,7 +185,7 @@ jobs:
       - name: Check running containers
         run: docker ps
       - name: Install optional visual test runtime
-        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
+        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
       - name: Run tests
         continue-on-error: true
         run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=firefox" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
@@ -220,7 +220,7 @@ jobs:
       - name: Check running containers
         run: docker ps
       - name: Install optional visual test runtime
-        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
+        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
       - name: Run tests
         continue-on-error: true
         run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
@@ -255,7 +255,7 @@ jobs:
       - name: Check running containers
         run: docker ps
       - name: Install optional visual test runtime
-        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
+        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
       - name: Run tests
         continue-on-error: true
         run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
@@ -283,10 +283,12 @@ jobs:
         uses: ./.github/actions/setup-test-env
         with:
           node-version: '20'
+      - name: Install optional visual test runtime
+        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
       - name: Run tests
         continue-on-error: true
         timeout-minutes: 40
-        run: mvn -pl shaft-browserstack -am -e test "-DdefaultElementIdentificationTimeout=60" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=android" "-Dmobile_automationName=UIAutomator2" "-DbrowserStack.platformVersion=13.0" "-DbrowserStack.deviceName=Google Pixel 7" "-DbrowserStack.appUrl=" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*ndroid.*], %regex[.*FlutterTest.*], %regex[.*BrowserStackPropertiesUnitTest.*], %regex[.*BrowserStackHelperUnitTest.*], %regex[.*BrowserStackSdkHelperCoverageUnitTest.*]"
+        run: mvn -pl shaft-browserstack -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=60" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=android" "-Dmobile_automationName=UIAutomator2" "-DbrowserStack.platformVersion=13.0" "-DbrowserStack.deviceName=Google Pixel 7" "-DbrowserStack.appUrl=" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*ndroid.*], %regex[.*FlutterTest.*], %regex[.*BrowserStackPropertiesUnitTest.*], %regex[.*BrowserStackHelperUnitTest.*], %regex[.*BrowserStackSdkHelperCoverageUnitTest.*]"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -398,7 +400,7 @@ jobs:
         run: docker ps
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DmaximumPerformanceMode=2" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*(CucumberTests|CucumberFeatureListenerUnitTest|CucumberTestRunnerListenerUnitTest).*]"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DmaximumPerformanceMode=2" "-DgenerateAllureReportArchive=true" "-Dcucumber.features=src/test/resources/CucumberFeatures,src/test/resources/CustomCucumberFeatures" "-Dcucumber.glue=customCucumberSteps,com.shaft.cucumber" "-Dcucumber.plugin=pretty,json:allure-results/cucumber.json,html:allure-results/cucumberReport.html,com.shaft.listeners.CucumberTestRunnerListener" "-Dtest=%regex[.*(CucumberTests|CucumberFeatureListenerUnitTest|CucumberTestRunnerListenerUnitTest).*]"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -184,9 +184,11 @@ jobs:
           node-version: '20'
       - name: Check running containers
         run: docker ps
+      - name: Install optional visual test runtime
+        run: mvn -pl shaft-visual -am -e install -DskipTests -Dgpg.skip
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=firefox" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=firefox" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -217,9 +219,11 @@ jobs:
           node-version: '20'
       - name: Check running containers
         run: docker ps
+      - name: Install optional visual test runtime
+        run: mvn -pl shaft-visual -am -e install -DskipTests -Dgpg.skip
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -250,9 +254,11 @@ jobs:
           node-version: '20'
       - name: Check running containers
         run: docker ps
+      - name: Install optional visual test runtime
+        run: mvn -pl shaft-visual -am -e install -DskipTests -Dgpg.skip
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()

--- a/.github/workflows/mavenCentral_cd.yml
+++ b/.github/workflows/mavenCentral_cd.yml
@@ -64,6 +64,8 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
         run: mvn --batch-mode deploy "-DskipTests" "-Dgpg.keyname=${{secrets.GPG_KEYNAME}}" "-Dgpg.passphrase=${{secrets.GPG_PASSPHRASE}}"
+      - name: Verify published Maven Central coordinates
+        run: python3 scripts/ci/verify_maven_central_release.py "${RELEASE_VERSION}"
       - name: Prepare Release Body
         run: sed "s/\$RELEASE_VERSION/${{ env.RELEASE_VERSION }}/g" .github/RELEASE_BODY_TEMPLATE.md > /tmp/release_body.md
       - name: Create GitHub Release

--- a/.github/workflows/publishJavaDocs.yml
+++ b/.github/workflows/publishJavaDocs.yml
@@ -1,6 +1,5 @@
 name: JavaDocs Publisher
-# Executed automatically when a new PR is merged to master, if the release number already exists this job will fail
-# This pipeline will build from main, upload the artifacts, and create the GitHub release
+# Publishes one navigable JavaDocs site after a successful Maven Central release.
 
 on:
   workflow_run:
@@ -12,6 +11,7 @@ on:
 
 jobs:
   generate_java_docs:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     env:
       gpg.keyname: ${{ secrets.GPG_KEYNAME }}
       gpg.passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -39,7 +39,7 @@ jobs:
         uses: stCarolas/setup-maven@v5
         with:
           maven-version: 3.9.5
-      # Captures the engine version from the pom.xml
+      # Captures the reactor version from the root pom.xml.
       - name: Set Release Version Number
         run: |
           echo "RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
@@ -52,5 +52,5 @@ jobs:
           javadoc-branch: javadoc
           java-version: 25
           project: maven
-          custom-command: mvn -pl shaft-engine -am javadoc:javadoc -Dgpg.skip
-          javadoc-source-folder: shaft-engine/target/reports/apidocs
+          custom-command: mvn --batch-mode clean install "-DskipTests" "-Dgpg.skip" && python3 scripts/ci/assemble_javadocs.py
+          javadoc-source-folder: target/javadocs

--- a/.github/workflows/sync-sample-projects-version.yml
+++ b/.github/workflows/sync-sample-projects-version.yml
@@ -55,10 +55,13 @@ jobs:
             python3 -c "import sys,xml.etree.ElementTree as ET; ns='http://maven.apache.org/POM/4.0.0'; root=ET.parse('pom.xml').getroot(); [print(p.find('{%s}version'%ns).text) or sys.exit(0) for p in root.findall('.//{%s}plugin'%ns) if p.find('{%s}artifactId'%ns) is not None and p.find('{%s}artifactId'%ns).text=='$artifactId' and p.find('{%s}version'%ns) is not None]"
           }
 
-          # JDK version: read from maven-compiler-plugin <source> configuration
-          JDK_VERSION=$(grep -A10 '<artifactId>maven-compiler-plugin</artifactId>' pom.xml | grep '<source>' | head -1 | sed 's/.*<source>\(.*\)<\/source>.*/\1/' | tr -d ' ')
+          extract_property_version() {
+            local property="$1"
+            python3 -c "import xml.etree.ElementTree as ET; ns='http://maven.apache.org/POM/4.0.0'; root=ET.parse('pom.xml').getroot(); print(root.find('{%s}properties/{%s}%s' % (ns, ns, '$property')).text)"
+          }
 
-          ASPECTJWEAVER_VERSION=$(grep -A2 '<artifactId>aspectjweaver</artifactId>' pom.xml | grep '<version>' | head -1 | sed 's/.*<version>\(.*\)<\/version>.*/\1/' | tr -d ' ')
+          JDK_VERSION=$(extract_property_version "jdk.version")
+          ASPECTJWEAVER_VERSION=$(extract_property_version "aspectj.version")
           COMPILER_PLUGIN_VERSION=$(extract_plugin_version "maven-compiler-plugin")
           RESOURCES_PLUGIN_VERSION=$(extract_plugin_version "maven-resources-plugin")
           SUREFIRE_PLUGIN_VERSION=$(extract_plugin_version "maven-surefire-plugin")
@@ -72,7 +75,7 @@ jobs:
           echo "SUREFIRE_TESTNG_VERSION=$SUREFIRE_TESTNG_VERSION" >> $GITHUB_OUTPUT
 
           # Fail early if any version resolved to empty — prevents silently skipping properties
-          if [ -z "$COMPILER_PLUGIN_VERSION" ] || [ -z "$RESOURCES_PLUGIN_VERSION" ] || [ -z "$SUREFIRE_PLUGIN_VERSION" ]; then
+          if [ -z "$JDK_VERSION" ] || [ -z "$ASPECTJWEAVER_VERSION" ] || [ -z "$COMPILER_PLUGIN_VERSION" ] || [ -z "$RESOURCES_PLUGIN_VERSION" ] || [ -z "$SUREFIRE_PLUGIN_VERSION" ]; then
             echo "::error::One or more plugin versions could not be extracted from pom.xml"
             exit 1
           fi
@@ -170,13 +173,13 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: |
-            Sync sample projects to SHAFT Engine ${{ steps.get-version.outputs.NEW_VERSION }}
+            Sync sample projects to modular SHAFT ${{ steps.get-version.outputs.NEW_VERSION }}
 
-            Updated all example pom.xml files to use SHAFT_ENGINE ${{ steps.get-version.outputs.NEW_VERSION }}
+            Updated all example pom.xml files to use shaft-engine ${{ steps.get-version.outputs.NEW_VERSION }}
             and synced all plugin/dependency versions with the main pom.xml.
           branch: auto-update-sample-projects-version
           delete-branch: true
-          title: 'Sync sample projects to SHAFT Engine ${{ steps.get-version.outputs.NEW_VERSION }}'
+          title: 'Sync sample projects to modular SHAFT ${{ steps.get-version.outputs.NEW_VERSION }}'
           body: |
             ## 🤖 Automated Sample Projects Version Sync
 
@@ -184,7 +187,7 @@ jobs:
 
             ### Version Update:
 
-            **New SHAFT_ENGINE Version:** `${{ steps.get-version.outputs.NEW_VERSION }}`
+            **New SHAFT Version:** `${{ steps.get-version.outputs.NEW_VERSION }}`
 
             **Previous Versions:** `${{ steps.check-current.outputs.CURRENT_VERSIONS }}`
 

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,4 +1,5 @@
 --enable-native-access=ALL-UNNAMED
+--sun-misc-unsafe-memory-access=allow
 -Dfile.encoding=UTF-8
 -Dsun.jnu.encoding=UTF-8
 -Dstdout.encoding=UTF-8

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,7 @@ Use this protocol whenever a maintainer tags `@codex` to start work, says `start
 ## Release Preparation Notes
 - Release versions use `{major}.{quarter}.{YYYYMMDD}`; for example, a Q2 release generated on May 13, 2026 is `10.2.20260513`.
 - A release PR title should include the release name/version and clearly say that the PR generates or prepares a new release.
-- Before opening a release PR, inspect recent merged release PRs for changed files and PR-body conventions, then update these locations together: root `pom.xml`, `shaft-engine/pom.xml`, `shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java`, and all seven sample/demo project `pom.xml` files under `shaft-engine/src/main/resources/examples/`.
+- Before opening a release PR, inspect recent merged release PRs for changed files and PR-body conventions, then update these locations together: root `pom.xml`, every reactor child parent version, `shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java`, all consumer fixture `<shaft.version>` values, and all seven sample/demo project `pom.xml` files under `shaft-engine/src/main/resources/examples/`.
 - In `Internal.java`, verify `allure3Version` against the latest stable `allure` npm package and `nodeLtsVersion` against the latest Node.js LTS patch; record when a value is already current.
 - Validate release-only changes with dependency-update checks and `mvn clean install -DskipTests -Dgpg.skip`; merging the PR to `main` starts the Maven Central release pipeline, so do not run deploy/release commands locally.
 
@@ -139,7 +139,7 @@ Use this protocol whenever a maintainer tags `@codex` to start work, says `start
 - Do not expose secrets or copy values from `.env`, credential files, BrowserStack/LambdaTest variables, Maven Central credentials, GPG keys, or CI secrets.
 - Do not run deployment/release commands, `scm-publish`, history rewrites, destructive cleanup, or credentialed cloud workflows unless explicitly requested.
 - Treat `target/`, generated reports, downloaded binaries, and build artifacts as generated outputs; do not commit them unless maintainers explicitly request it.
-- Be careful with release `pom.xml` version changes: release PRs must update the root `pom.xml` project version, `Internal.java` `shaftEngineVersion`, `allure3Version`, and `nodeLtsVersion`, and every sample/demo `<shaft.version>` under `shaft-engine/src/main/resources/examples/**/pom.xml` in the same branch before opening the PR. Do not rely on the post-release sample-sync workflow to fix release PR drift.
+- Be careful with release `pom.xml` version changes: release PRs must update the root project version, every reactor child parent version, consumer fixtures, `Internal.java` `shaftEngineVersion`, `allure3Version`, and `nodeLtsVersion`, and every sample/demo `<shaft.version>` under `shaft-engine/src/main/resources/examples/**/pom.xml` in the same branch before opening the PR. Do not rely on the post-release sample-sync workflow to fix release PR drift.
 - Binary mobile test assets (`*.apk`, `*.ipa`) have special JaCoCo exclusions; do not move or reclassify them casually.
 - Docker Compose E2E services should be stopped/cleaned up after local use.
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
 SHAFT Engine is an open-source **Java test automation framework** built on top of [Selenium](https://www.selenium.dev/), [Appium](https://appium.io/), and [REST Assured](https://rest-assured.io/). It provides a unified, fluent API for **cross-browser testing**, **mobile app testing**, **API testing**, **CLI testing**, and **database testing** — so you can automate anything, from any platform, with zero boilerplate.
 
 [![GitHub Stars](https://img.shields.io/github/stars/ShaftHQ/SHAFT_ENGINE?style=for-the-badge&logo=github&label=Stars&color=gold)](https://github.com/ShaftHQ/SHAFT_ENGINE/stargazers)
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.shafthq/SHAFT_ENGINE?style=for-the-badge&logo=apachemaven&label=Maven%20Central&color=indigo)](https://central.sonatype.com/artifact/io.github.shafthq/SHAFT_ENGINE)
-[![License](https://img.shields.io/github/license/ShaftHQ/SHAFT_Engine?color=indigo&style=for-the-badge)](https://github.com/ShaftHQ/SHAFT_ENGINE/blob/master/LICENSE)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.shafthq/shaft-engine?style=for-the-badge&logo=apachemaven&label=Maven%20Central&color=indigo)](https://central.sonatype.com/artifact/io.github.shafthq/shaft-engine)
+[![License](https://img.shields.io/github/license/ShaftHQ/SHAFT_Engine?color=indigo&style=for-the-badge)](https://github.com/ShaftHQ/SHAFT_ENGINE/blob/main/LICENSE)
 [![E2E Tests](https://img.shields.io/github/actions/workflow/status/SHAFTHQ/SHAFT_Engine/e2eTests.yml?branch=main&color=forestgreen&label=E2E%20Tests&style=for-the-badge)](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/workflows/e2eTests.yml)
 [![Code QL](https://img.shields.io/github/actions/workflow/status/SHAFTHQ/SHAFT_Engine/codeql-analysis.yml?branch=main&label=Security&color=forestgreen&style=for-the-badge)](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/workflows/codeql-analysis.yml)
 [![Code Quality](https://img.shields.io/codacy/grade/4d6d48aba396411fa3170184330ba089?style=for-the-badge&color=blue&label=Code%20Quality)](https://app.codacy.com/gh/ShaftHQ/SHAFT_ENGINE/dashboard)
@@ -390,9 +390,9 @@ SHAFT Engine is released under the [MIT License](LICENSE) — free to use, modif
 
 <a href="https://ShaftHQ.github.io/" target="_blank">
 <picture>
-  <source srcset="src/main/resources/images/shaft.png" media="(prefers-color-scheme: light)" width="300"/>
-  <source srcset="src/main/resources/images/shaft_white.png" media="(prefers-color-scheme: dark)" width="300"/>
-  <img src="src/main/resources/images/shaft.png" alt="SHAFT Engine - Unified Test Automation Framework for Java" width="300"/>
+  <source srcset="shaft-engine/src/main/resources/images/shaft.png" media="(prefers-color-scheme: light)" width="300"/>
+  <source srcset="shaft-engine/src/main/resources/images/shaft_white.png" media="(prefers-color-scheme: dark)" width="300"/>
+  <img src="shaft-engine/src/main/resources/images/shaft.png" alt="SHAFT Engine - Unified Test Automation Framework for Java" width="300"/>
 </picture>
 </a>
 
@@ -410,7 +410,7 @@ Made with ❤️ by the [SHAFT community](https://github.com/ShaftHQ/SHAFT_ENGIN
   Project:      SHAFT Engine
   Full name:    SHAFT — Unified Test Automation Engine
   Maven:        io.github.shafthq:shaft-engine
-  Language:     Java 21
+  Language:     Java 25
   License:      MIT
   Maintained:   Yes (active, production-ready)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 SHAFT Engine is an open-source **Java test automation framework** built on top of [Selenium](https://www.selenium.dev/), [Appium](https://appium.io/), and [REST Assured](https://rest-assured.io/). It provides a unified, fluent API for **cross-browser testing**, **mobile app testing**, **API testing**, **CLI testing**, and **database testing** — so you can automate anything, from any platform, with zero boilerplate.
 
 [![GitHub Stars](https://img.shields.io/github/stars/ShaftHQ/SHAFT_ENGINE?style=for-the-badge&logo=github&label=Stars&color=gold)](https://github.com/ShaftHQ/SHAFT_ENGINE/stargazers)
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.shafthq/shaft-engine?style=for-the-badge&logo=apachemaven&label=Maven%20Central&color=indigo)](https://central.sonatype.com/artifact/io.github.shafthq/shaft-engine)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.shafthq/SHAFT_ENGINE?style=for-the-badge&logo=apachemaven&label=Maven%20Central&color=indigo)](https://central.sonatype.com/artifact/io.github.shafthq/SHAFT_ENGINE)
 [![License](https://img.shields.io/github/license/ShaftHQ/SHAFT_Engine?color=indigo&style=for-the-badge)](https://github.com/ShaftHQ/SHAFT_ENGINE/blob/master/LICENSE)
 [![E2E Tests](https://img.shields.io/github/actions/workflow/status/SHAFTHQ/SHAFT_Engine/e2eTests.yml?branch=main&color=forestgreen&label=E2E%20Tests&style=for-the-badge)](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/workflows/e2eTests.yml)
 [![Code QL](https://img.shields.io/github/actions/workflow/status/SHAFTHQ/SHAFT_Engine/codeql-analysis.yml?branch=main&label=Security&color=forestgreen&style=for-the-badge)](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/workflows/codeql-analysis.yml)

--- a/docs/MAVEN_CENTRAL_PUBLICATION.md
+++ b/docs/MAVEN_CENTRAL_PUBLICATION.md
@@ -44,8 +44,9 @@ For a signed staging rehearsal, import a disposable GPG key into an isolated `GN
 1. Read the version from the root parent POM and reject reactor version drift.
 2. Validate configuration, build all publication artifacts, and run the combined consumer checks.
 3. Sign and deploy the complete reactor through the Central Publishing Maven Plugin, waiting for publication success.
-4. Create the GitHub tag and release.
-5. Dispatch the guide update and announce the release on Slack.
+4. Verify every POM, JAR, sources JAR, JavaDocs JAR, and signature from Maven Central, then compile canonical, combined-module, and legacy-relocation consumers from isolated repositories.
+5. Create the GitHub tag and release.
+6. Dispatch the guide update and announce the release on Slack.
 
 This ordering prevents a GitHub release, guide update, or Slack announcement from claiming availability when Central publication failed.
 

--- a/docs/MAVEN_REACTOR.md
+++ b/docs/MAVEN_REACTOR.md
@@ -61,7 +61,8 @@ mvn -pl shaft-browserstack -am test -Dtest=BrowserStackHelperUnitTest
 mvn -pl shaft-video -am test -Dtest=DesktopVideoRecordingProviderRegistrationTest
 mvn -pl shaft-visual -am test -Dtest=ImageProcessingActionsUnitTest
 mvn -pl shaft-engine -am test
-mvn -pl shaft-engine javadoc:javadoc
+mvn clean install -DskipTests -Dgpg.skip
+python3 scripts/ci/assemble_javadocs.py
 ```
 
 Build and test outputs are module-local. Important locations include:
@@ -99,7 +100,7 @@ Workflow commands run from the repository root and select only the modules requi
 | `e2eLocalTests.yml`, `e2eLambdaTestTests.yml`, `e2eMoonTests.yml` | Use `-pl shaft-engine -am`; Appium and ordinary browser jobs do not resolve `shaft-video`. |
 | `coverage-readiness.yml` | Runs focused engine tests, builds `report-aggregate`, gates `target/jacoco/jacoco.csv`, and uploads only `target/jacoco/jacoco.xml` to Codecov. |
 | `code-quality-scan.yml`, `codeql-analysis.yml`, `copilot-setup-steps.yml` | Select the code-bearing engine and optional integration modules explicitly; BOM and relocation-only modules are excluded from compilation/analysis. |
-| `publishJavaDocs.yml` | Generates JavaDocs only for `shaft-engine` and publishes `shaft-engine/target/reports/apidocs`. |
+| `publishJavaDocs.yml` | Builds JavaDocs for all four Java-bearing modules, assembles a navigable site at `target/javadocs`, and publishes it only after a successful Central release. |
 | `mavenCentral_cd.yml` | Intentionally deploys the complete reactor because every published module, BOM, and relocation POM belongs to a release. |
 | `reactor-version-check.yml` | Uses the reactor-version validation script and does not invoke Maven. |
 | `dependency_review.yml`, `link-check.yml`, `refresh-agent-instructions.yml` | Do not build Java modules and therefore require no reactor selection. |

--- a/docs/UPGRADING_TO_MODULAR_SHAFT.md
+++ b/docs/UPGRADING_TO_MODULAR_SHAFT.md
@@ -17,7 +17,7 @@ Before:
 After, with the recommended BOM:
 
 ```xml
-<properties><shaft.version>MODULAR_RELEASE_VERSION</shaft.version></properties>
+<properties><shaft.version>10.2.20260609</shaft.version></properties>
 <dependencyManagement>
   <dependencies>
     <dependency>
@@ -47,7 +47,7 @@ Or use an explicit version without the BOM:
 </dependency>
 ```
 
-Replace `MODULAR_RELEASE_VERSION` with the released version shown on [Maven Central](https://central.sonatype.com/artifact/io.github.shafthq/shaft-engine).
+Version `10.2.20260609` is the first modular SHAFT release. Confirm current availability on [Maven Central](https://central.sonatype.com/artifact/io.github.shafthq/shaft-engine).
 
 ## Choose optional modules
 

--- a/legacy-shaft-engine/pom.xml
+++ b/legacy-shaft-engine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260605</version>
+        <version>10.2.20260609</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>SHAFT_ENGINE</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <surefireArgLine>--enable-native-access=ALL-UNNAMED -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8</surefireArgLine>
+        <surefireArgLine>--enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Xshare:off -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8</surefireArgLine>
+        <mockito.version>5.23.0</mockito.version>
+        <mockitoAgentArgLine>-javaagent:"${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar"</mockitoAgentArgLine>
         <surefire.excludedGroups>allure3-visual-demo</surefire.excludedGroups>
         <jdk.version>25</jdk.version>
         <lombok.version>1.18.46</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.shafthq</groupId>
     <artifactId>shaft-parent</artifactId>
-    <version>10.2.20260605</version>
+    <version>10.2.20260609</version>
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Build parent and reactor aggregator for SHAFT modules.</description>

--- a/report-aggregate/pom.xml
+++ b/report-aggregate/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260605</version>
+        <version>10.2.20260609</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>report-aggregate</artifactId>

--- a/scripts/ci/assemble_javadocs.py
+++ b/scripts/ci/assemble_javadocs.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Assemble one publishable JavaDocs site from every Java-bearing SHAFT module."""
+
+from __future__ import annotations
+
+import html
+import shutil
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+NS = {"m": "http://maven.apache.org/POM/4.0.0"}
+MODULES = {
+    "shaft-engine": "Core engine",
+    "shaft-browserstack": "BrowserStack integration",
+    "shaft-video": "Desktop video integration",
+    "shaft-visual": "Visual processing integration",
+}
+
+
+def project_version(root: Path = ROOT) -> str:
+    value = ET.parse(root / "pom.xml").getroot().findtext("m:version", namespaces=NS)
+    if not value:
+        raise ValueError("root pom.xml does not declare a project version")
+    return value.strip()
+
+
+def assemble_javadocs(root: Path = ROOT, destination: Path | None = None) -> Path:
+    destination = destination or root / "target" / "javadocs"
+    sources = {
+        module: root / module / "target" / "reports" / "apidocs"
+        for module in MODULES
+    }
+    missing = [str(source / "index.html") for source in sources.values() if not (source / "index.html").is_file()]
+    if missing:
+        raise FileNotFoundError("missing module JavaDocs: " + ", ".join(missing))
+
+    if destination.exists():
+        shutil.rmtree(destination)
+    destination.mkdir(parents=True)
+
+    links = []
+    for module, label in MODULES.items():
+        shutil.copytree(sources[module], destination / module)
+        links.append(f'<li><a href="{module}/index.html">{html.escape(label)}</a></li>')
+
+    version = html.escape(project_version(root))
+    (destination / "index.html").write_text(
+        "<!doctype html>\n"
+        '<html lang="en"><head><meta charset="utf-8">'
+        f"<title>SHAFT {version} JavaDocs</title></head><body>"
+        f"<h1>SHAFT {version} JavaDocs</h1><ul>{''.join(links)}</ul>"
+        "</body></html>\n",
+        encoding="utf-8",
+    )
+    return destination
+
+
+def main() -> int:
+    destination = assemble_javadocs()
+    print(f"Assembled JavaDocs site: {destination}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/measure_consumer_dependencies.py
+++ b/scripts/ci/measure_consumer_dependencies.py
@@ -40,6 +40,16 @@ PROJECT_COORDINATES = (
 DEPENDENCY_LINE = re.compile(r"^\s*([^\s].*?):(/.*|[A-Za-z]:\\.*)$")
 
 
+def maven_executable(system: str | None = None) -> str:
+    system = system or platform.system()
+    candidates = ("mvn.cmd", "mvn") if system == "Windows" else ("mvn",)
+    for candidate in candidates:
+        executable = shutil.which(candidate)
+        if executable:
+            return executable
+    raise RuntimeError("Maven executable was not found on PATH.")
+
+
 def sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as stream:
@@ -206,7 +216,7 @@ def run_fixture(fixture: Path, jar: Path, keep_repositories: Path | None = None)
     seeded_bytes = seed_project_artifact(repository, jar, version)
     dependency_output = temporary / "dependencies.txt"
     command = [
-        "mvn", "--batch-mode", "--no-transfer-progress", "-f", str(fixture / "pom.xml"),
+        maven_executable(), "--batch-mode", "--no-transfer-progress", "-f", str(fixture / "pom.xml"),
         f"-Dmaven.repo.local={repository}", f"-Dshaft.version={version}", "test-compile",
         "dependency:list", "-DincludeScope=test", "-DoutputAbsoluteArtifactFilename=true",
         f"-DoutputFile={dependency_output}", "-DappendOutput=false",
@@ -254,16 +264,18 @@ def run_fixture(fixture: Path, jar: Path, keep_repositories: Path | None = None)
 def stable_manifest(manifest: dict[str, object]) -> dict[str, object]:
     ignored = {
         "artifactBytes", "elapsedSeconds", "repositoryBytes", "repositoryGrowthBytes",
-        "seededRepositoryBytes", "artifactsRef", "rootCoordinate",
+        "seededRepositoryBytes", "artifactsRef", "rootCoordinate", "platform",
     }
     stable = {key: value for key, value in manifest.items() if key not in ignored}
     # The reactor migration rebuilds SHAFT itself; compare the downstream graph byte-for-byte
-    # while validating the engine JAR separately by its entry list.
+    # while validating project JARs and the host-specific JAVE binary separately.
     project_jar_prefixes = tuple(f"{coordinate}:jar:" for coordinate in PROJECT_COORDINATES)
     if "artifacts" in stable:
         stable["artifacts"] = [
             artifact for artifact in stable["artifacts"]
-            if not str(artifact["coordinate"]).startswith(project_jar_prefixes)
+            if not str(artifact["coordinate"]).startswith(
+                project_jar_prefixes + ("ws.schild:jave-nativebin-",)
+            )
         ]
     return stable
 

--- a/scripts/ci/validate_maven_publication.py
+++ b/scripts/ci/validate_maven_publication.py
@@ -95,6 +95,7 @@ def validate_publication(root: Path = ROOT, check_build_outputs: bool = False,
     required_steps = [
         "Validate Maven publication",
         "Deploy to Maven Central",
+        "Verify published Maven Central coordinates",
         "Create GitHub Release",
         "Notify User Guide Repository",
         "Announce Release on Slack",
@@ -104,6 +105,16 @@ def validate_publication(root: Path = ROOT, check_build_outputs: bool = False,
         errors.append("release workflow must validate and deploy before release creation and announcements")
     if "-f pom.xml help:evaluate" not in workflow:
         errors.append("release workflow must derive the version from the reactor parent pom.xml")
+    if "verify_maven_central_release.py" not in workflow:
+        errors.append("release workflow must smoke published Maven Central coordinates before release creation")
+
+    javadocs_workflow = (root / ".github/workflows/publishJavaDocs.yml").read_text(encoding="utf-8")
+    if "workflow_run.conclusion == 'success'" not in javadocs_workflow:
+        errors.append("JavaDocs publication must require a successful Maven Central workflow")
+    if "scripts/ci/assemble_javadocs.py" not in javadocs_workflow:
+        errors.append("JavaDocs workflow must assemble all Java-bearing module documentation")
+    if "javadoc-source-folder: target/javadocs" not in javadocs_workflow:
+        errors.append("JavaDocs workflow must publish the assembled root target/javadocs site")
 
     if check_build_outputs:
         version = _version(root)

--- a/scripts/ci/validate_modular_documentation.py
+++ b/scripts/ci/validate_modular_documentation.py
@@ -94,6 +94,23 @@ def main() -> None:
         fail("runtime property download path is missing")
     if "refs/heads/main/shaft-engine/src/main/resources/examples/" not in setup_page:
         fail("setup-page example download paths are missing")
+    example_workflows = {
+        name: (EXAMPLES / ".github/workflows" / name).read_text(encoding="utf-8")
+        for name in ("api.yml", "web.yml")
+    }
+    for name, workflow in example_workflows.items():
+        if "actions/checkout@v6" not in workflow:
+            fail(f"{name}: use the current checkout action")
+        if "Set up JDK 25" not in workflow or "java-version: '25'" not in workflow:
+            fail(f"{name}: use the repository JDK 25 baseline")
+    web_workflow = example_workflows["web.yml"]
+    if "refs/heads/main/src/main/resources/" in web_workflow:
+        fail("web example workflow still uses the pre-reactor resource path")
+    if (
+        "refs/heads/main/shaft-engine/src/main/resources/docker-compose/selenium4.yml"
+        not in web_workflow
+    ):
+        fail("web example workflow Docker Compose download path is missing")
     sync_workflow = (ROOT / ".github/workflows/sync-sample-projects-version.yml").read_text(
         encoding="utf-8"
     )

--- a/scripts/ci/validate_modular_documentation.py
+++ b/scripts/ci/validate_modular_documentation.py
@@ -82,6 +82,18 @@ def main() -> None:
         fail("README Maven Central badge still targets the legacy coordinate")
     if "shaft-engine/src/main/resources/images/" not in readme:
         fail("README image links do not use the reactor module path")
+    properties_helper = (
+        ROOT / "shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java"
+    ).read_text(encoding="utf-8")
+    setup_page = (ROOT / "shaft-engine/src/main/javadoc/resources/index.html").read_text(encoding="utf-8")
+    if "refs/heads/main/src/main/resources/" in properties_helper:
+        fail("runtime property downloads still use the pre-reactor resource path")
+    if "refs/heads/main/src/main/resources/" in setup_page:
+        fail("setup-page downloads still use the pre-reactor resource path")
+    if "refs/heads/main/shaft-engine/src/main/resources/properties/default/" not in properties_helper:
+        fail("runtime property download path is missing")
+    if "refs/heads/main/shaft-engine/src/main/resources/examples/" not in setup_page:
+        fail("setup-page example download paths are missing")
     sync_workflow = (ROOT / ".github/workflows/sync-sample-projects-version.yml").read_text(
         encoding="utf-8"
     )

--- a/scripts/ci/validate_modular_documentation.py
+++ b/scripts/ci/validate_modular_documentation.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Validate bundled examples and user-facing modular SHAFT migration docs."""
 from pathlib import Path
+import re
 import sys
 import xml.etree.ElementTree as ET
 
@@ -27,6 +28,7 @@ def text(node, path):
     return (node.findtext(path, default="", namespaces=NS) or "").strip()
 
 def main() -> None:
+    reactor_version = text(ET.parse(ROOT / "pom.xml").getroot(), "m:version")
     poms = sorted(EXAMPLES.rglob("pom.xml"))
     if len(poms) != 7:
         fail(f"expected seven bundled example POMs, found {len(poms)}")
@@ -37,6 +39,8 @@ def main() -> None:
         prop_names = {child.tag.rsplit("}", 1)[-1] for child in list(props) if props is not None}
         if "shaft.version" not in prop_names or "shaft_engine.version" in prop_names:
             fail(f"{pom}: use <shaft.version> only")
+        if text(props, "m:shaft.version") != reactor_version:
+            fail(f"{pom}: shaft.version must match reactor version {reactor_version}")
         managed = {text(d, "m:artifactId") for d in root.findall("m:dependencyManagement/m:dependencies/m:dependency", NS)}
         if "shaft-bom" not in managed:
             fail(f"{pom}: import shaft-bom")
@@ -49,15 +53,42 @@ def main() -> None:
         expected = {EXPECTED_OPTIONAL[artifact]} if artifact in EXPECTED_OPTIONAL else set()
         if optional != expected:
             fail(f"{pom}: expected optional modules {sorted(expected)}, found {sorted(optional)}")
+    for pom in sorted((ROOT / "tools/modularization/consumer-fixtures").glob("*/pom.xml")):
+        fixture_version = text(ET.parse(pom).getroot().find("m:properties", NS), "m:shaft.version")
+        if fixture_version != reactor_version:
+            fail(f"{pom}: shaft.version must match reactor version {reactor_version}")
+    internal = (ROOT / "shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java").read_text(
+        encoding="utf-8"
+    )
+    version_match = re.search(
+        r'@DefaultValue\("([^"]+)"\)\s+String shaftEngineVersion\(\);',
+        internal,
+    )
+    if not version_match or version_match.group(1) != reactor_version:
+        fail("Internal.shaftEngineVersion must match the reactor version")
     guide = (ROOT / "docs/UPGRADING_TO_MODULAR_SHAFT.md").read_text(encoding="utf-8")
     for term in REQUIRED_GUIDE_TERMS:
         if term not in guide:
             fail(f"upgrade guide is missing {term!r}")
-    if "FINAL_" in guide or "MODULAR_RELEASE_VERSION" not in guide:
-        fail("upgrade guide contains unfinished measurement placeholders or lacks release placeholder")
+    if "FINAL_" in guide or "MODULAR_RELEASE_VERSION" in guide:
+        fail("upgrade guide contains unfinished release placeholders")
+    if reactor_version not in guide:
+        fail(f"upgrade guide does not identify modular release {reactor_version}")
     for path in (ROOT / "README.md", ROOT / ".github/RELEASE_BODY_TEMPLATE.md"):
         if "UPGRADING_TO_MODULAR_SHAFT.md" not in path.read_text(encoding="utf-8"):
             fail(f"{path}: prominently link the upgrade guide")
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    if "maven-central/v/io.github.shafthq/SHAFT_ENGINE" in readme:
+        fail("README Maven Central badge still targets the legacy coordinate")
+    if "shaft-engine/src/main/resources/images/" not in readme:
+        fail("README image links do not use the reactor module path")
+    sync_workflow = (ROOT / ".github/workflows/sync-sample-projects-version.yml").read_text(
+        encoding="utf-8"
+    )
+    if 'extract_property_version "jdk.version"' not in sync_workflow:
+        fail("sample sync workflow must read jdk.version from the root properties")
+    if "Updated all example pom.xml files to use SHAFT_ENGINE" in sync_workflow:
+        fail("sample sync workflow still describes the legacy artifact")
     print("Modular examples and documentation contract is valid.")
 
 if __name__ == "__main__":

--- a/scripts/ci/validate_quality_configuration.py
+++ b/scripts/ci/validate_quality_configuration.py
@@ -90,6 +90,19 @@ def validate_quality_configuration(root: Path = ROOT) -> list[str]:
         errors.append("CodeQL build must compile every Java-bearing module")
 
     engine_pom = (root / "shaft-engine" / "pom.xml").read_text(encoding="utf-8")
+    if "<id>visual-test-runtime</id>" not in engine_pom:
+        errors.append("shaft-engine must define the optional visual test runtime profile")
+    if "<name>includeVisualTestRuntime</name>" not in engine_pom:
+        errors.append("visual test runtime profile must use explicit property activation")
+    if "<additionalClasspathDependency>" not in engine_pom or "<artifactId>shaft-visual</artifactId>" not in engine_pom:
+        errors.append("visual test runtime profile must add shaft-visual to the Surefire classpath")
+    visual_profile = (
+        engine_pom.split("<id>visual-test-runtime</id>", 1)[1].split("</profile>", 1)[0]
+        if "<id>visual-test-runtime</id>" in engine_pom
+        else ""
+    )
+    if "<artifactId>shaft-engine</artifactId>" not in visual_profile:
+        errors.append("visual test runtime profile must exclude shaft-engine's transitive tree")
     for artifact in (
         "com.browserstack:browserstack-java-sdk",
         "ws.schild:jave-*",
@@ -100,6 +113,17 @@ def validate_quality_configuration(root: Path = ROOT) -> list[str]:
     ):
         if f"<exclude>{artifact}</exclude>" not in engine_pom:
             errors.append(f"shaft-engine dependency boundary does not ban {artifact}")
+
+    visual_install_command = "mvn -pl shaft-visual -am -e install -DskipTests -Dgpg.skip"
+    for workflow_name, expected_jobs in (("e2eLocalTests.yml", 4), ("e2eTests.yml", 3)):
+        workflow = (root / ".github" / "workflows" / workflow_name).read_text(encoding="utf-8")
+        install_count = workflow.count(visual_install_command)
+        activation_count = workflow.count('"-DincludeVisualTestRuntime"')
+        if install_count != expected_jobs or activation_count != expected_jobs:
+            errors.append(
+                f"{workflow_name} must prepare and activate the visual test runtime "
+                f"for {expected_jobs} broad browser jobs"
+            )
     return errors
 
 

--- a/scripts/ci/validate_quality_configuration.py
+++ b/scripts/ci/validate_quality_configuration.py
@@ -114,7 +114,7 @@ def validate_quality_configuration(root: Path = ROOT) -> list[str]:
         if f"<exclude>{artifact}</exclude>" not in engine_pom:
             errors.append(f"shaft-engine dependency boundary does not ban {artifact}")
 
-    visual_install_command = "mvn -pl shaft-visual -am -e install -DskipTests -Dgpg.skip"
+    visual_install_command = 'mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"'
     for workflow_name, expected_jobs in (("e2eLocalTests.yml", 4), ("e2eTests.yml", 3)):
         workflow = (root / ".github" / "workflows" / workflow_name).read_text(encoding="utf-8")
         install_count = workflow.count(visual_install_command)

--- a/scripts/ci/validate_quality_configuration.py
+++ b/scripts/ci/validate_quality_configuration.py
@@ -30,9 +30,18 @@ def text(element: ET.Element, path: str) -> str | None:
 def validate_quality_configuration(root: Path = ROOT) -> list[str]:
     errors: list[str] = []
     root_pom = ET.parse(root / "pom.xml").getroot()
+    root_pom_text = (root / "pom.xml").read_text(encoding="utf-8")
     modules = {value.text.strip() for value in root_pom.iterfind("m:modules/m:module", NS) if value.text}
     if "report-aggregate" not in modules:
         errors.append("root pom.xml must include report-aggregate")
+    if "--sun-misc-unsafe-memory-access=allow" not in root_pom_text or "-Xshare:off" not in root_pom_text:
+        errors.append("Surefire JVM arguments must suppress Java 25 Unsafe and CDS agent warnings")
+    if "<mockitoAgentArgLine>" not in root_pom_text:
+        errors.append("root pom.xml must define the Mockito startup agent")
+    jvm_config_path = root / ".mvn" / "jvm.config"
+    jvm_config = jvm_config_path.read_text(encoding="utf-8") if jvm_config_path.is_file() else ""
+    if "--sun-misc-unsafe-memory-access=allow" not in jvm_config:
+        errors.append("Maven JVM configuration must allow legacy Unsafe access without startup warnings")
 
     aggregate_path = root / "report-aggregate" / "pom.xml"
     if not aggregate_path.is_file():
@@ -90,6 +99,12 @@ def validate_quality_configuration(root: Path = ROOT) -> list[str]:
         errors.append("CodeQL build must compile every Java-bearing module")
 
     engine_pom = (root / "shaft-engine" / "pom.xml").read_text(encoding="utf-8")
+    visual_pom_path = root / "shaft-visual" / "pom.xml"
+    visual_pom = visual_pom_path.read_text(encoding="utf-8") if visual_pom_path.is_file() else ""
+    if "<artifactId>allure-jupiter</artifactId>" not in engine_pom or "<artifactId>allure-junit5</artifactId>" in engine_pom:
+        errors.append("shaft-engine must use the current Allure Jupiter artifact without relocation warnings")
+    if "${mockitoAgentArgLine}" not in engine_pom or "${mockitoAgentArgLine}" not in visual_pom:
+        errors.append("Mockito-based modules must attach Mockito as a startup agent")
     if "<id>visual-test-runtime</id>" not in engine_pom:
         errors.append("shaft-engine must define the optional visual test runtime profile")
     if "<name>includeVisualTestRuntime</name>" not in engine_pom:
@@ -114,8 +129,11 @@ def validate_quality_configuration(root: Path = ROOT) -> list[str]:
         if f"<exclude>{artifact}</exclude>" not in engine_pom:
             errors.append(f"shaft-engine dependency boundary does not ban {artifact}")
 
-    visual_install_command = 'mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"'
-    for workflow_name, expected_jobs in (("e2eLocalTests.yml", 4), ("e2eTests.yml", 3)):
+    workflow_expectations = (
+        ("e2eLocalTests.yml", 4, 'mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"'),
+        ("e2eTests.yml", 4, 'mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"'),
+    )
+    for workflow_name, expected_jobs, visual_install_command in workflow_expectations:
         workflow = (root / ".github" / "workflows" / workflow_name).read_text(encoding="utf-8")
         install_count = workflow.count(visual_install_command)
         activation_count = workflow.count('"-DincludeVisualTestRuntime"')
@@ -124,6 +142,14 @@ def validate_quality_configuration(root: Path = ROOT) -> list[str]:
                 f"{workflow_name} must prepare and activate the visual test runtime "
                 f"for {expected_jobs} broad browser jobs"
             )
+    e2e_workflow = (root / ".github" / "workflows" / "e2eTests.yml").read_text(encoding="utf-8")
+    for cucumber_argument in (
+        '"-Dcucumber.features=src/test/resources/CucumberFeatures,src/test/resources/CustomCucumberFeatures"',
+        '"-Dcucumber.glue=customCucumberSteps,com.shaft.cucumber"',
+        '"-Dcucumber.plugin=pretty,json:allure-results/cucumber.json,html:allure-results/cucumberReport.html,com.shaft.listeners.CucumberTestRunnerListener"',
+    ):
+        if cucumber_argument not in e2e_workflow:
+            errors.append(f"e2eTests.yml Cucumber job is missing {cucumber_argument}")
     return errors
 
 

--- a/scripts/ci/verify_maven_central_release.py
+++ b/scripts/ci/verify_maven_central_release.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Verify published SHAFT artifacts and smoke consumers from Maven Central."""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import shutil
+import subprocess
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+GROUP_PATH = "io/github/shafthq"
+DEFAULT_REPOSITORY = "https://repo.maven.apache.org/maven2"
+JAR_ARTIFACTS = ("shaft-engine", "shaft-browserstack", "shaft-video", "shaft-visual")
+POM_ARTIFACTS = ("shaft-parent", "shaft-bom", "SHAFT_ENGINE")
+FIXTURE_GOALS = {
+    "api": "test-compile",
+    "combined-modules": "verify",
+    "legacy-coordinate": "test-compile",
+}
+
+
+def maven_executable(system: str | None = None) -> str:
+    system = system or platform.system()
+    candidates = ("mvn.cmd", "mvn") if system == "Windows" else ("mvn",)
+    for candidate in candidates:
+        executable = shutil.which(candidate)
+        if executable:
+            return executable
+    raise RuntimeError("Maven executable was not found on PATH.")
+
+
+def publication_paths(version: str) -> list[str]:
+    paths = []
+    for artifact in JAR_ARTIFACTS:
+        base = f"{GROUP_PATH}/{artifact}/{version}/{artifact}-{version}"
+        paths.extend(
+            f"{base}{suffix}"
+            for suffix in (".pom", ".pom.asc", ".jar", ".jar.asc", "-sources.jar",
+                           "-sources.jar.asc", "-javadoc.jar", "-javadoc.jar.asc")
+        )
+    for artifact in POM_ARTIFACTS:
+        base = f"{GROUP_PATH}/{artifact}/{version}/{artifact}-{version}.pom"
+        paths.extend((base, f"{base}.asc"))
+    return paths
+
+
+def missing_publication_paths(repository_url: str, version: str) -> list[str]:
+    missing = []
+    for path in publication_paths(version):
+        request = urllib.request.Request(f"{repository_url.rstrip('/')}/{path}", method="HEAD")
+        try:
+            with urllib.request.urlopen(request, timeout=30):
+                pass
+        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError):
+            missing.append(path)
+    return missing
+
+
+def write_settings(path: Path, repository_url: str) -> None:
+    path.write_text(
+        "<settings><mirrors><mirror><id>release-central</id>"
+        f"<url>{repository_url}</url><mirrorOf>*</mirrorOf>"
+        "</mirror></mirrors></settings>\n",
+        encoding="utf-8",
+    )
+
+
+def fixture_commands(version: str, repository: Path, settings: Path) -> list[list[str]]:
+    commands = []
+    for fixture, goal in FIXTURE_GOALS.items():
+        commands.append([
+            maven_executable(), "--batch-mode", "--no-transfer-progress", "-U",
+            "--settings", str(settings),
+            "-f", str(ROOT / "tools" / "modularization" / "consumer-fixtures" / fixture / "pom.xml"),
+            f"-Dmaven.repo.local={repository / fixture}",
+            f"-Dshaft.version={version}",
+            goal,
+        ])
+    return commands
+
+
+def verify_release(version: str, repository_url: str = DEFAULT_REPOSITORY,
+                   attempts: int = 10, delay_seconds: int = 30) -> None:
+    with tempfile.TemporaryDirectory(prefix="shaft-central-smoke-") as temp_dir:
+        temp = Path(temp_dir)
+        settings = temp / "settings.xml"
+        write_settings(settings, repository_url)
+        last_error = ""
+        for attempt in range(1, attempts + 1):
+            missing = missing_publication_paths(repository_url, version)
+            if missing:
+                last_error = "missing artifacts: " + ", ".join(missing)
+            else:
+                failed = []
+                for command in fixture_commands(version, temp / "repository", settings):
+                    completed = subprocess.run(command, cwd=ROOT, check=False)
+                    if completed.returncode:
+                        failed.append(Path(command[command.index("-f") + 1]).parent.name)
+                if not failed:
+                    return
+                last_error = "failed consumer fixtures: " + ", ".join(failed)
+            if attempt < attempts:
+                print(f"Central smoke attempt {attempt}/{attempts} failed: {last_error}")
+                time.sleep(delay_seconds)
+        raise RuntimeError(f"Maven Central release verification failed after {attempts} attempts: {last_error}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version")
+    parser.add_argument("--repository-url", default=DEFAULT_REPOSITORY)
+    parser.add_argument("--attempts", type=int, default=10)
+    parser.add_argument("--delay-seconds", type=int, default=30)
+    args = parser.parse_args()
+    verify_release(args.version, args.repository_url, args.attempts, args.delay_seconds)
+    print(f"Verified SHAFT {args.version} from Maven Central.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/shaft-bom/pom.xml
+++ b/shaft-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260605</version>
+        <version>10.2.20260609</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>shaft-bom</artifactId>

--- a/shaft-browserstack/pom.xml
+++ b/shaft-browserstack/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260605</version>
+        <version>10.2.20260609</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>shaft-browserstack</artifactId>

--- a/shaft-engine/pom.xml
+++ b/shaft-engine/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260605</version>
+        <version>10.2.20260609</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>shaft-engine</artifactId>

--- a/shaft-engine/pom.xml
+++ b/shaft-engine/pom.xml
@@ -68,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>io.qameta.allure</groupId>
-            <artifactId>allure-junit5</artifactId>
+            <artifactId>allure-jupiter</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
@@ -576,7 +576,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.23.0</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -790,6 +790,7 @@
                             <useFile>true</useFile>
                             <argLine>
                                 @{argLine} ${surefireArgLine}
+                                ${mockitoAgentArgLine}
                                 -javaagent:"${settings.localRepository}/org/aspectj/aspectjweaver/${aspectj.version}/aspectjweaver-${aspectj.version}.jar"
                             </argLine>
                             <properties>
@@ -923,6 +924,7 @@
                             <useFile>true</useFile>
                             <argLine>
                                 @{argLine} ${surefireArgLine}
+                                ${mockitoAgentArgLine}
                                 -javaagent:"${settings.localRepository}/org/aspectj/aspectjweaver/${aspectj.version}/aspectjweaver-${aspectj.version}.jar"
                             </argLine>
                             <properties>

--- a/shaft-engine/pom.xml
+++ b/shaft-engine/pom.xml
@@ -811,6 +811,78 @@
         </profile>
 
         <profile>
+            <id>visual-test-runtime</id>
+            <activation>
+                <property>
+                    <name>includeVisualTestRuntime</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <additionalClasspathDependencies>
+                                <additionalClasspathDependency>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>shaft-visual</artifactId>
+                                    <version>${project.version}</version>
+                                    <exclusions>
+                                        <exclusion>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>shaft-engine</artifactId>
+                                        </exclusion>
+                                        <exclusion>
+                                            <groupId>commons-codec</groupId>
+                                            <artifactId>commons-codec</artifactId>
+                                        </exclusion>
+                                        <exclusion>
+                                            <groupId>commons-io</groupId>
+                                            <artifactId>commons-io</artifactId>
+                                        </exclusion>
+                                        <exclusion>
+                                            <groupId>com.fasterxml.jackson.core</groupId>
+                                            <artifactId>jackson-annotations</artifactId>
+                                        </exclusion>
+                                        <exclusion>
+                                            <groupId>com.fasterxml.jackson.core</groupId>
+                                            <artifactId>jackson-core</artifactId>
+                                        </exclusion>
+                                        <exclusion>
+                                            <groupId>com.fasterxml.jackson.core</groupId>
+                                            <artifactId>jackson-databind</artifactId>
+                                        </exclusion>
+                                        <exclusion>
+                                            <groupId>javax.annotation</groupId>
+                                            <artifactId>javax.annotation-api</artifactId>
+                                        </exclusion>
+                                        <exclusion>
+                                            <groupId>org.apache.httpcomponents</groupId>
+                                            <artifactId>httpclient</artifactId>
+                                        </exclusion>
+                                        <exclusion>
+                                            <groupId>org.apache.httpcomponents</groupId>
+                                            <artifactId>httpcore</artifactId>
+                                        </exclusion>
+                                        <exclusion>
+                                            <groupId>org.brotli</groupId>
+                                            <artifactId>dec</artifactId>
+                                        </exclusion>
+                                        <exclusion>
+                                            <groupId>org.jsoup</groupId>
+                                            <artifactId>jsoup</artifactId>
+                                        </exclusion>
+                                    </exclusions>
+                                </additionalClasspathDependency>
+                            </additionalClasspathDependencies>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>junit</id>
             <activation>
                 <file>

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
@@ -7,7 +7,6 @@ import com.shaft.tools.internal.support.JavaHelper;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.FailureReporter;
 import com.shaft.tools.io.internal.ReportManagerHelper;
-import com.shaft.validation.Validations;
 import org.apache.logging.log4j.Level;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Platform;
@@ -292,18 +291,9 @@ public class ImageProcessingActions {
                 continue;
             }
 
-            boolean discreetLoggingState = ReportManagerHelper.getDiscreteLogging();
-            try {
-                // add to pass/fail counter depending on assertion result, without logging
-                ReportManagerHelper.setDiscreteLogging(true);
-                Validations.assertThat()
-                        .number(percentage)
-                        .isGreaterThanOrEquals(threshold)
-                        .perform();
-                ReportManagerHelper.setDiscreteLogging(discreetLoggingState);
+            if (percentage >= threshold) {
                 passedImagesCount++;
-            } catch (AssertionError e) {
-                ReportManagerHelper.setDiscreteLogging(discreetLoggingState);
+            } else {
                 // copying image to failed images directory
                 FileActions.getInstance(true).copyFile(screenshot.getAbsolutePath(),
                         testProcessingFolder.getParent() + DIRECTORY_FAILED + relatedTestFileName + "_testImage");
@@ -312,20 +302,28 @@ public class ImageProcessingActions {
                         testProcessingFolder.getParent() + DIRECTORY_FAILED + relatedTestFileName + "_referenceImage");
                 failedImagesCount++;
             }
-
-            Validations.verifyThat()
-                    .number(percentage)
-                    .isGreaterThanOrEquals(threshold)
-                    .perform();
         }
 
         ReportManager.log("[" + passedImagesCount + "] images passed, and [" + failedImagesCount
                 + "] images failed the threshold of [" + threshold + "%] matching.");
+        if (failedImagesCount > 0) {
+            FailureReporter.fail("[" + failedImagesCount + "] images failed the threshold of ["
+                    + threshold + "%] matching.");
+        }
 
     }
 
     public static void loadOpenCV() {
         VisualProcessingProviderRegistry.requireProvider().load();
+    }
+
+    /**
+     * Loads the optional visual processing provider when it is available.
+     * Engine startup uses this method so installations that do not include
+     * {@code shaft-visual} remain quiet until a visual operation is requested.
+     */
+    public static void loadOpenCVIfAvailable() {
+        VisualProcessingProviderRegistry.findProvider().ifPresent(VisualProcessingProvider::load);
     }
 
     private static String getAiFolderPath() {

--- a/shaft-engine/src/main/java/com/shaft/listeners/TestNGListener.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/TestNGListener.java
@@ -105,15 +105,19 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
     @Override
     public void onExecutionStart() {
         engineSetup(ProjectStructureManager.RunType.TESTNG);
-        this.reportPortalTestNGService = REPORT_PORTAL_SERVICE.get();
-        if (REPORT_PORTAL_INSTANCES.incrementAndGet() > 1) {
-            String warning = "WARNING! More than one ReportPortal listener is added";
-            ReportManagerHelper.logDiscrete(warning, Level.WARN);
-        }
+        initializeReportPortalIfEnabled();
+    }
+
+    private void initializeReportPortalIfEnabled() {
         String rpEnableValue = ThreadLocalPropertiesManager.getProperty("rp.enable");
         TestNGListener.isReportPortalEnabled = rpEnableValue != null && Boolean.parseBoolean(rpEnableValue.trim());
         this.isReportPortalEnabledForListener = TestNGListener.isReportPortalEnabled;
         if (this.isReportPortalEnabledForListener) {
+            this.reportPortalTestNGService = REPORT_PORTAL_SERVICE.get();
+            if (REPORT_PORTAL_INSTANCES.incrementAndGet() > 1) {
+                String warning = "WARNING! More than one ReportPortal listener is added";
+                ReportManagerHelper.logDiscrete(warning, Level.WARN);
+            }
             String info = "Initializing ReportPortal Reporting Environment.";
             ReportManagerHelper.logDiscrete(info, Level.INFO);
             this.reportPortalTestNGService.startLaunch();
@@ -344,14 +348,21 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
     }
 
     private static TestExecutionCounts getDeduplicatedTestExecutionCounts() {
+        return getDeduplicatedTestExecutionCounts(passedTests, failedTests, skippedTests);
+    }
+
+    private static TestExecutionCounts getDeduplicatedTestExecutionCounts(
+            List<ITestNGMethod> passedMethods,
+            List<ITestNGMethod> failedMethods,
+            List<ITestNGMethod> skippedMethods) {
         // Deduplicate test method counts to remove retry-inflated numbers.
         // A method that failed on early attempts but eventually passed is counted as FLAKY.
         // Categories are mutually exclusive: passed | failed | skipped | flaky.
-        Set<ITestNGMethod> passedSet = new HashSet<>(passedTests);
-        Set<ITestNGMethod> flakySet = failedTests.stream()
+        Set<ITestNGMethod> passedSet = new HashSet<>(passedMethods);
+        Set<ITestNGMethod> flakySet = failedMethods.stream()
                 .filter(passedSet::contains)
                 .collect(Collectors.toCollection(HashSet::new));
-        Set<ITestNGMethod> failedSet = failedTests.stream()
+        Set<ITestNGMethod> failedSet = failedMethods.stream()
                 .filter(m -> !passedSet.contains(m))
                 .collect(Collectors.toCollection(HashSet::new));
         int uniquePassed = passedSet.size() - flakySet.size();
@@ -360,7 +371,7 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
         Set<ITestNGMethod> resolvedSet = new HashSet<>();
         resolvedSet.addAll(passedSet);
         resolvedSet.addAll(failedSet);
-        int uniqueSkipped = (int) skippedTests.stream().filter(m -> !resolvedSet.contains(m)).distinct().count();
+        int uniqueSkipped = (int) skippedMethods.stream().filter(m -> !resolvedSet.contains(m)).distinct().count();
         return new TestExecutionCounts(uniquePassed, uniqueFailed, uniqueSkipped, uniqueFlaky);
     }
 

--- a/shaft-engine/src/main/java/com/shaft/listeners/internal/UpdateChecker.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/internal/UpdateChecker.java
@@ -8,8 +8,10 @@ import io.restassured.RestAssured;
 import lombok.SneakyThrows;
 import org.apache.logging.log4j.Level;
 
+import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class UpdateChecker {
@@ -29,10 +31,51 @@ public class UpdateChecker {
         if (currentVersion.equalsIgnoreCase(latestVersion)) {
             var logMessage = "You're using the latest engine version \"" + latestVersion + "\". \uD83D\uDC4D";
             ReportManagerHelper.logDiscrete(logMessage, Level.INFO);
-        } else {
+        } else if (isCurrentVersionOutdated(currentVersion, latestVersion)) {
             var logMessage = "⚠\uFE0F You're using an outdated engine version \"" + currentVersion + "\" ⚠\uFE0F\nKindly upgrade to the latest one \"" + latestVersion + "\" to ensure the best experience.\nFor more information click here: https://github.com/ShaftHQ/SHAFT_ENGINE/releases/latest .";
             ReportManagerHelper.logImportantEntry(logMessage, Level.WARN);
+        } else {
+            var logMessage = "You're using engine version \"" + currentVersion
+                    + "\", which is newer than the latest published release \"" + latestVersion + "\".";
+            ReportManagerHelper.logDiscrete(logMessage, Level.INFO);
         }
+    }
+
+    static boolean isCurrentVersionOutdated(String currentVersion, String latestVersion) {
+        Optional<BigInteger[]> currentParts = parseNumericVersion(currentVersion);
+        Optional<BigInteger[]> latestParts = parseNumericVersion(latestVersion);
+        if (currentParts.isEmpty() || latestParts.isEmpty()) {
+            return false;
+        }
+
+        BigInteger[] current = currentParts.orElseThrow();
+        BigInteger[] latest = latestParts.orElseThrow();
+        int length = Math.max(current.length, latest.length);
+        for (int index = 0; index < length; index++) {
+            BigInteger currentPart = index < current.length ? current[index] : BigInteger.ZERO;
+            BigInteger latestPart = index < latest.length ? latest[index] : BigInteger.ZERO;
+            int comparison = currentPart.compareTo(latestPart);
+            if (comparison != 0) {
+                return comparison < 0;
+            }
+        }
+        return false;
+    }
+
+    private static Optional<BigInteger[]> parseNumericVersion(String version) {
+        if (version == null || version.isBlank()) {
+            return Optional.empty();
+        }
+        String normalizedVersion = version.trim().replaceFirst("^[vV]", "");
+        String[] tokens = normalizedVersion.split("\\.");
+        BigInteger[] parts = new BigInteger[tokens.length];
+        for (int index = 0; index < tokens.length; index++) {
+            if (!tokens[index].matches("\\d+")) {
+                return Optional.empty();
+            }
+            parts[index] = new BigInteger(tokens[index]);
+        }
+        return Optional.of(parts);
     }
 
     private static String getLatestVersionFromGitHub() {

--- a/shaft-engine/src/main/java/com/shaft/listeners/internal/UpdateChecker.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/internal/UpdateChecker.java
@@ -5,7 +5,6 @@ import com.shaft.driver.SHAFT;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import io.restassured.RestAssured;
-import lombok.SneakyThrows;
 import org.apache.logging.log4j.Level;
 
 import java.math.BigInteger;
@@ -13,31 +12,46 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
+/**
+ * Checks GitHub for the latest published SHAFT Engine version.
+ */
 public class UpdateChecker {
     public static AtomicReference<String> latestVersion = new AtomicReference<>();
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy");
 
-    @SneakyThrows
+    /**
+     * Performs a best-effort update check without interrupting test execution when GitHub is unavailable.
+     */
     public static void check() {
+        check(UpdateChecker::getLatestVersionFromGitHub);
+    }
+
+    static void check(Supplier<String> latestVersionSupplier) {
         ReportManager.logDiscrete("Checking for engine updates...");
 
-        String todayDate = DATE_FORMATTER.format(LocalDate.now());
-        String currentVersion = SHAFT.Properties.internal.shaftEngineVersion();
-        String latestVersion = getLatestVersionFromGitHub();
+        try {
+            String todayDate = DATE_FORMATTER.format(LocalDate.now());
+            String currentVersion = SHAFT.Properties.internal.shaftEngineVersion();
+            String latestVersion = latestVersionSupplier.get();
 
-        Thread.ofVirtual().start(() -> FileActions.getInstance(true).writeToFile("target/", "engine_check", todayDate + "_" + latestVersion));
+            Thread.ofVirtual().start(() -> FileActions.getInstance(true).writeToFile("target/", "engine_check", todayDate + "_" + latestVersion));
 
-        if (currentVersion.equalsIgnoreCase(latestVersion)) {
-            var logMessage = "You're using the latest engine version \"" + latestVersion + "\". \uD83D\uDC4D";
-            ReportManagerHelper.logDiscrete(logMessage, Level.INFO);
-        } else if (isCurrentVersionOutdated(currentVersion, latestVersion)) {
-            var logMessage = "⚠\uFE0F You're using an outdated engine version \"" + currentVersion + "\" ⚠\uFE0F\nKindly upgrade to the latest one \"" + latestVersion + "\" to ensure the best experience.\nFor more information click here: https://github.com/ShaftHQ/SHAFT_ENGINE/releases/latest .";
-            ReportManagerHelper.logImportantEntry(logMessage, Level.WARN);
-        } else {
-            var logMessage = "You're using engine version \"" + currentVersion
-                    + "\", which is newer than the latest published release \"" + latestVersion + "\".";
-            ReportManagerHelper.logDiscrete(logMessage, Level.INFO);
+            if (currentVersion.equalsIgnoreCase(latestVersion)) {
+                var logMessage = "You're using the latest engine version \"" + latestVersion + "\". \uD83D\uDC4D";
+                ReportManagerHelper.logDiscrete(logMessage, Level.INFO);
+            } else if (isCurrentVersionOutdated(currentVersion, latestVersion)) {
+                var logMessage = "⚠\uFE0F You're using an outdated engine version \"" + currentVersion + "\" ⚠\uFE0F\nKindly upgrade to the latest one \"" + latestVersion + "\" to ensure the best experience.\nFor more information click here: https://github.com/ShaftHQ/SHAFT_ENGINE/releases/latest .";
+                ReportManagerHelper.logImportantEntry(logMessage, Level.WARN);
+            } else {
+                var logMessage = "You're using engine version \"" + currentVersion
+                        + "\", which is newer than the latest published release \"" + latestVersion + "\".";
+                ReportManagerHelper.logDiscrete(logMessage, Level.INFO);
+            }
+        } catch (Exception exception) {
+            ReportManagerHelper.logDiscrete("Skipping the engine update check because GitHub is unavailable.", Level.DEBUG);
+            ReportManagerHelper.logDiscrete(exception, Level.DEBUG);
         }
     }
 

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java
@@ -18,7 +18,7 @@ import org.aeonbits.owner.Config.Sources;
 })
 public interface Internal extends EngineProperties<Internal> {
     @Key("shaftEngineVersion")
-    @DefaultValue("10.2.20260605")
+    @DefaultValue("10.2.20260609")
     String shaftEngineVersion();
 
     @Key("watermarkImagePath")
@@ -32,7 +32,7 @@ public interface Internal extends EngineProperties<Internal> {
      * without changing {@code AllureManager} or any CI script. Use this url for the latest version <a href="https://github.com/allure-framework/allure3/releases">Allure3Releases</a>
      */
     @Key("allure3Version")
-    @DefaultValue("3.9.0")
+    @DefaultValue("3.10.0")
     String allure3Version();
 
     /**

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
@@ -333,7 +333,7 @@ public class PropertiesHelper {
     }
 
     private static void downloadPropertiesFile(String fileName) {
-        var baseURI = "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/refs/heads/main/src/main/resources/properties/default/";
+        var baseURI = "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/refs/heads/main/shaft-engine/src/main/resources/properties/default/";
         FileActions.getInstance(true).downloadFile(baseURI + fileName,
                 Properties.paths.properties() + File.separator + fileName);
     }

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
@@ -151,7 +151,7 @@ public class PropertiesHelper {
         SHAFT.Properties.reporting.set().disableLogging(false);
         ReportManagerHelper.logEngineVersion();
         Thread.ofVirtual().start(UpdateChecker::check);
-        Thread.ofVirtual().start(ImageProcessingActions::loadOpenCV);
+        Thread.ofVirtual().start(ImageProcessingActions::loadOpenCVIfAvailable);
         AllureManager.initializeAllureReportingEnvironment();
         Thread.ofVirtual().start(ReportManagerHelper::cleanExecutionSummaryReportDirectory);
         ReportManagerHelper.setDiscreteLogging(SHAFT.Properties.reporting.alwaysLogDiscreetly());

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
@@ -249,11 +249,13 @@ public class ReportManagerHelper {
 
     private static void resetRetryDiagnosticLogging() {
         synchronized (RETRY_DIAGNOSTIC_LOGGING_LOCK) {
-            retryDiagnosticSessionThreads.clear();
-            debugFileLoggingEnabled = false;
-            if (previousRootLogLevel != null) {
-                Configurator.setRootLevel(previousRootLogLevel);
-                previousRootLogLevel = null;
+            retryDiagnosticSessionThreads.remove(Thread.currentThread().threadId());
+            if (retryDiagnosticSessionThreads.isEmpty()) {
+                debugFileLoggingEnabled = false;
+                if (previousRootLogLevel != null) {
+                    Configurator.setRootLevel(previousRootLogLevel);
+                    previousRootLogLevel = null;
+                }
             }
         }
     }
@@ -274,6 +276,10 @@ public class ReportManagerHelper {
             }
             return true;
         }
+    }
+
+    private static boolean isRetryDiagnosticLoggingEnabledForCurrentThread() {
+        return retryDiagnosticSessionThreads.contains(Thread.currentThread().threadId());
     }
 
     private static boolean ensureLogFileExists() {
@@ -304,6 +310,9 @@ public class ReportManagerHelper {
     }
 
     private static void logDebugFileSetupFailure(String message, Throwable throwable) {
+        if (SHAFT.Properties.reporting != null && SHAFT.Properties.reporting.disableLogging()) {
+            return;
+        }
         if (logger != null) {
             if (throwable != null) {
                 logger.warn(message, throwable);
@@ -333,7 +342,7 @@ public class ReportManagerHelper {
     }
 
     private static void writeToDebugLogFileIfEnabled(String logText, Level logLevel) {
-        if (debugFileLoggingEnabled) {
+        if (isRetryDiagnosticLoggingEnabledForCurrentThread()) {
             writeToDebugLogFile(logText, logLevel);
         }
     }
@@ -486,7 +495,7 @@ public class ReportManagerHelper {
     public static void attachEngineLog(String executionEndTimestamp) {
         String logFilePath = getLogFilePath();
         File logFile = new File(logFilePath);
-        boolean shouldAttachRetryDiagnostics = debugFileLoggingEnabled;
+        boolean shouldAttachRetryDiagnostics = isRetryDiagnosticLoggingEnabledForCurrentThread();
         boolean shouldAttachFullLog = SHAFT.Properties.reporting != null && SHAFT.Properties.reporting.attachFullLog();
         if (shouldAttachFullLog || shouldAttachRetryDiagnostics) {
             var initialLoggingState = ReportManagerHelper.getDiscreteLogging();
@@ -738,9 +747,9 @@ public class ReportManagerHelper {
     }
 
     private static void createImportantReportEntry(String logText, Level loglevel) {
-        boolean initialLoggingStatus = discreteLogging;
-        setDiscreteLogging(false); // force log even if discrete logging was turned on
-
+        if (SHAFT.Properties.reporting != null && SHAFT.Properties.reporting.disableLogging()) {
+            return;
+        }
         var color = switch (loglevel.name()) {
             case "WARN" -> ANSI_BOLD_YELLOW;
             case "ERROR" -> ANSI_BOLD_RED;
@@ -762,7 +771,6 @@ public class ReportManagerHelper {
         logger.log(loglevel, log);
         createDebugCompanionLogEntry(logText.trim(), loglevel);
         writeToDebugLogFileIfEnabled(logText.trim(), loglevel);
-        setDiscreteLogging(initialLoggingStatus);
     }
 
     /**

--- a/shaft-engine/src/main/javadoc/resources/index.html
+++ b/shaft-engine/src/main/javadoc/resources/index.html
@@ -639,10 +639,10 @@
                     let workflowFileName = '';
                     
                     if (platform === 'web') {
-                        workflowUrl = 'https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/refs/heads/main/src/main/resources/examples/.github/workflows/web.yml';
+                        workflowUrl = 'https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/refs/heads/main/shaft-engine/src/main/resources/examples/.github/workflows/web.yml';
                         workflowFileName = 'web.yml';
                     } else if (platform === 'api') {
-                        workflowUrl = 'https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/refs/heads/main/src/main/resources/examples/.github/workflows/api.yml';
+                        workflowUrl = 'https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/refs/heads/main/shaft-engine/src/main/resources/examples/.github/workflows/api.yml';
                         workflowFileName = 'api.yml';
                     }
                     
@@ -654,7 +654,7 @@
                 
                 // Add Dependabot config if selected
                 if (includeDependabot) {
-                    const dependabotContent = await fetch('https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/refs/heads/main/src/main/resources/examples/.github/dependabot.yml').then(r => r.text());
+                    const dependabotContent = await fetch('https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/refs/heads/main/shaft-engine/src/main/resources/examples/.github/dependabot.yml').then(r => r.text());
                     zip.file(`${artifactId}/.github/dependabot.yml`, dependabotContent);
                 }
                 

--- a/shaft-engine/src/main/resources/examples/.github/workflows/api.yml
+++ b/shaft-engine/src/main/resources/examples/.github/workflows/api.yml
@@ -11,12 +11,12 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'zulu'
 
       - name: Run Tests

--- a/shaft-engine/src/main/resources/examples/.github/workflows/web.yml
+++ b/shaft-engine/src/main/resources/examples/.github/workflows/web.yml
@@ -15,17 +15,17 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'zulu'
 
       - name: Download Docker Compose
         run: |
-          curl -o docker-compose.yml https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/refs/heads/main/src/main/resources/docker-compose/selenium4.yml
+          curl -o docker-compose.yml https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/refs/heads/main/shaft-engine/src/main/resources/docker-compose/selenium4.yml
 
       - name: Start Selenium Grid
         run: |

--- a/shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260605</shaft.version>
+        <shaft.version>10.2.20260609</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260605</shaft.version>
+        <shaft.version>10.2.20260609</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260605</shaft.version>
+        <shaft.version>10.2.20260609</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260605</shaft.version>
+        <shaft.version>10.2.20260609</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260605</shaft.version>
+        <shaft.version>10.2.20260609</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260605</shaft.version>
+        <shaft.version>10.2.20260609</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260605</shaft.version>
+        <shaft.version>10.2.20260609</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/test/java/com/shaft/api/ApiPerformanceReportTest.java
+++ b/shaft-engine/src/test/java/com/shaft/api/ApiPerformanceReportTest.java
@@ -13,6 +13,20 @@ import java.util.Map;
 
 
 public class ApiPerformanceReportTest {
+    private static final String BOOKING_REQUEST_BODY = """
+            {
+              "firstname": "Jim",
+              "lastname": "Brown",
+              "totalprice": 111,
+              "depositpaid": true,
+              "bookingdates": {
+                "checkin": "2018-01-01",
+                "checkout": "2019-01-01"
+              },
+              "additionalneeds": "Breakfast"
+            }
+            """;
+
     ThreadLocal<SHAFT.API> api = new ThreadLocal<>();
 
     @BeforeMethod(onlyForGroups = {"restful-booker"})
@@ -49,8 +63,15 @@ public class ApiPerformanceReportTest {
 
     @Test(groups = {"restful-booker"})
     public void testGetBooking() {
-        api.get().get("booking/1").
-                setTargetStatusCode(0).
+        int bookingId = api.get().post("booking").
+                setContentType("application/json").
+                setRequestBody(BOOKING_REQUEST_BODY).
+                perform().
+                getResponse().
+                path("bookingid");
+
+        api.get().get("booking/{bookingId}").
+                setPathParameters(String.valueOf(bookingId)).
                 perform();
     }
 
@@ -58,9 +79,7 @@ public class ApiPerformanceReportTest {
     public void testCreateBookingJSON() {
         api.get().post("booking").
                 setContentType("application/json").
-                setRequestBody("{\"firstname\":\"Jim\",\"lastname\":\"Brown\",\"totalprice\":111,\n" +
-                        " \"depositpaid\":true,\"bookingdates\":{\"checkin\":\"2018-01-01\",\"checkout\":\"2019-01-01\"},\n" +
-                        " \"additionalneeds\":\"Breakfast\"}").
+                setRequestBody(BOOKING_REQUEST_BODY).
                 perform();
     }
 

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotManagerCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotManagerCoverageUnitTest.java
@@ -36,6 +36,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@Test(singleThreaded = true)
 public class ScreenshotManagerCoverageUnitTest {
     private String whenToTakeScreenshot;
     private String screenshotType;
@@ -44,6 +45,7 @@ public class ScreenshotManagerCoverageUnitTest {
     private String highlightMethod;
     private boolean createAnimatedGif;
     private boolean watermark;
+    private boolean disableLogging;
 
     @BeforeMethod(alwaysRun = true)
     public void beforeMethod() {
@@ -54,6 +56,7 @@ public class ScreenshotManagerCoverageUnitTest {
         highlightMethod = SHAFT.Properties.visuals.screenshotParamsHighlightMethod();
         createAnimatedGif = SHAFT.Properties.visuals.createAnimatedGif();
         watermark = SHAFT.Properties.visuals.screenshotParamsWatermark();
+        disableLogging = SHAFT.Properties.reporting.disableLogging();
     }
 
     @AfterMethod(alwaysRun = true)
@@ -65,6 +68,7 @@ public class ScreenshotManagerCoverageUnitTest {
         SHAFT.Properties.visuals.set().screenshotParamsHighlightMethod(highlightMethod);
         SHAFT.Properties.visuals.set().createAnimatedGif(createAnimatedGif);
         SHAFT.Properties.visuals.set().screenshotParamsWatermark(watermark);
+        SHAFT.Properties.reporting.set().disableLogging(disableLogging);
     }
 
     @Test
@@ -106,6 +110,7 @@ public class ScreenshotManagerCoverageUnitTest {
 
     @Test
     public void takeScreenshotFallbackAndElementBranchesShouldBeCovered() throws Exception {
+        SHAFT.Properties.reporting.set().disableLogging(true);
         SHAFT.Properties.visuals.set().screenshotParamsScreenshotType("FULL");
         SHAFT.Properties.visuals.set().screenshotParamsHighlightMethod("AI");
         SHAFT.Properties.visuals.set().screenshotParamsHighlightElements(false);
@@ -136,7 +141,8 @@ public class ScreenshotManagerCoverageUnitTest {
             ScreenshotManager manager = new ScreenshotManager();
             byte[] screenshot = manager.takeScreenshot(healingDriver, By.id("x"));
             Assert.assertTrue(Arrays.equals(screenshot, viewport));
-            Assert.assertEquals(SHAFT.Properties.visuals.screenshotParamsScreenshotType(), "VIEWPORT");
+            String expectedScreenshotType = SHAFT.Properties.testNG.parallel().equals("NONE") ? "VIEWPORT" : "FULL";
+            Assert.assertEquals(SHAFT.Properties.visuals.screenshotParamsScreenshotType(), expectedScreenshotType);
 
             byte[] elementShot = manager.takeElementScreenshot(delegateDriver, By.id("x"));
             Assert.assertTrue(Arrays.equals(elementShot, new byte[]{9}));
@@ -155,6 +161,7 @@ public class ScreenshotManagerCoverageUnitTest {
 
     @Test
     public void fullPageAndHighlightMethodsShouldBeCovered() throws Exception {
+        SHAFT.Properties.reporting.set().disableLogging(true);
         SHAFT.Properties.visuals.set().screenshotParamsScreenshotType("VIEWPORT");
         SHAFT.Properties.visuals.set().screenshotParamsSkippedElementsFromScreenshot("//div[@id='hide']");
         SHAFT.Properties.visuals.set().screenshotParamsHighlightElements(true);

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/image/VisualProcessingProviderRegistryTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/image/VisualProcessingProviderRegistryTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class VisualProcessingProviderRegistryTest {
     @AfterMethod(alwaysRun = true)
@@ -41,6 +42,23 @@ public class VisualProcessingProviderRegistryTest {
         Assert.assertTrue(message.contains("Multiple visual processing providers were found"));
         Assert.assertTrue(message.indexOf(alphaProvider.getClass().getName())
                 < message.indexOf(zuluProvider.getClass().getName()));
+    }
+
+    @Test
+    public void optionalPreloadShouldRemainQuietWhenProviderIsMissing() {
+        VisualProcessingProviderRegistry.setProviderForTesting(null);
+
+        ImageProcessingActions.loadOpenCVIfAvailable();
+    }
+
+    @Test
+    public void optionalPreloadShouldLoadDiscoveredProvider() {
+        VisualProcessingProvider provider = mock(VisualProcessingProvider.class);
+        VisualProcessingProviderRegistry.setProviderForTesting(provider);
+
+        ImageProcessingActions.loadOpenCVIfAvailable();
+
+        verify(provider).load();
     }
 
     private static class AlphaProvider implements VisualProcessingProvider {

--- a/shaft-engine/src/test/java/com/shaft/listeners/internal/UpdateCheckerUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/listeners/internal/UpdateCheckerUnitTest.java
@@ -1,0 +1,21 @@
+package com.shaft.listeners.internal;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class UpdateCheckerUnitTest {
+    @Test
+    public void newerReleaseCandidateShouldNotBeReportedAsOutdated() {
+        Assert.assertFalse(UpdateChecker.isCurrentVersionOutdated("10.2.20260609", "10.2.20260605"));
+    }
+
+    @Test
+    public void olderReleaseShouldBeReportedAsOutdated() {
+        Assert.assertTrue(UpdateChecker.isCurrentVersionOutdated("10.2.20260601", "10.2.20260605"));
+    }
+
+    @Test
+    public void matchingReleaseShouldNotBeReportedAsOutdated() {
+        Assert.assertFalse(UpdateChecker.isCurrentVersionOutdated("10.2.20260605", "10.2.20260605"));
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/listeners/internal/UpdateCheckerUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/listeners/internal/UpdateCheckerUnitTest.java
@@ -1,9 +1,33 @@
 package com.shaft.listeners.internal;
 
+import com.shaft.tools.io.ReportManager;
+import com.shaft.tools.io.internal.ReportManagerHelper;
+import org.apache.logging.log4j.Level;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class UpdateCheckerUnitTest {
+    @Test
+    public void unavailableGitHubShouldOnlyLogAtDebugLevel() {
+        RuntimeException lookupFailure = new RuntimeException("GitHub unavailable");
+
+        try (MockedStatic<ReportManager> report = Mockito.mockStatic(ReportManager.class);
+             MockedStatic<ReportManagerHelper> reportManager = Mockito.mockStatic(ReportManagerHelper.class)) {
+            UpdateChecker.check(() -> {
+                throw lookupFailure;
+            });
+
+            report.verify(() -> ReportManager.logDiscrete("Checking for engine updates..."));
+            report.verifyNoMoreInteractions();
+            reportManager.verify(() -> ReportManagerHelper.logDiscrete(
+                    "Skipping the engine update check because GitHub is unavailable.", Level.DEBUG));
+            reportManager.verify(() -> ReportManagerHelper.logDiscrete(lookupFailure, Level.DEBUG));
+            reportManager.verifyNoMoreInteractions();
+        }
+    }
+
     @Test
     public void newerReleaseCandidateShouldNotBeReportedAsOutdated() {
         Assert.assertFalse(UpdateChecker.isCurrentVersionOutdated("10.2.20260609", "10.2.20260605"));

--- a/shaft-engine/src/test/java/testPackage/legacy/ChainableElementActionsTests.java
+++ b/shaft-engine/src/test/java/testPackage/legacy/ChainableElementActionsTests.java
@@ -1,6 +1,7 @@
 package testPackage.legacy;
 
 import com.shaft.driver.SHAFT;
+import com.shaft.properties.internal.Properties;
 import org.openqa.selenium.By;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -11,6 +12,7 @@ public class ChainableElementActionsTests {
 
     @BeforeMethod
     public void beforeMethod() {
+        SHAFT.Properties.flags.set().clearBeforeTypingMode("native");
         driver.set(new SHAFT.GUI.WebDriver());
     }
 
@@ -33,5 +35,6 @@ public class ChainableElementActionsTests {
             driver.get().quit();
         }
         driver.remove();
+        Properties.clearForCurrentThread();
     }
 }

--- a/shaft-engine/src/test/java/testPackage/legacy/NewValidationHelperTests.java
+++ b/shaft-engine/src/test/java/testPackage/legacy/NewValidationHelperTests.java
@@ -1,6 +1,7 @@
 package testPackage.legacy;
 
 import com.shaft.driver.SHAFT;
+import com.shaft.properties.internal.Properties;
 import com.shaft.validation.Validations;
 import org.openqa.selenium.By;
 import org.testng.annotations.AfterMethod;
@@ -84,7 +85,7 @@ public class NewValidationHelperTests {
             driver.get().element().assertThat(By.tagName("h3")).exists().perform();
     }
 
-    @Test(groups = {"browserBasedTests"}, expectedExceptions = RuntimeException.class)
+    @Test(groups = {"browserBasedTests"})
     public void f10() {
         driver.get().element().assertThat(By.tagName("div")).exists().perform();
     }
@@ -100,7 +101,7 @@ public class NewValidationHelperTests {
         driver.get().element().assertThat(By.tagName("h1")).doesNotExist().perform();
     }
 
-    @Test(groups = {"browserBasedTests"}, expectedExceptions = RuntimeException.class)
+    @Test(groups = {"browserBasedTests"}, expectedExceptions = AssertionError.class)
     public void f13() {
         driver.get().element().assertThat(By.tagName("div")).doesNotExist().perform();
     }
@@ -219,12 +220,17 @@ public class NewValidationHelperTests {
     @BeforeMethod(onlyForGroups = {"browserBasedTests"})
     public void openBrowser() {
         driver.set(new SHAFT.GUI.WebDriver());
-        driver.get().browser().navigateToURL("https://the-internet.herokuapp.com/");
+        driver.get().browser().navigateToURL(
+                "data:text/html;charset=utf-8,<html><body><h1>Welcome to the-internet</h1><div></div></body></html>");
     }
 
     @AfterMethod(onlyForGroups = {"browserBasedTests"}, alwaysRun = true)
     public void closeBrowser() {
-        driver.get().quit();
+        if (driver.get() != null) {
+            driver.get().quit();
+        }
+        driver.remove();
+        Properties.clearForCurrentThread();
     }
 }
 

--- a/shaft-engine/src/test/java/testPackage/unitTests/ReportManagerHelperUnitTests.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/ReportManagerHelperUnitTests.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -432,6 +434,53 @@ public class ReportManagerHelperUnitTests {
         boolean debugFileLoggingEnabled = isRetryDiagnosticLoggingEnabledForCurrentThread();
         SHAFT.Validations.assertThat().object(debugFileLoggingEnabled).isFalse().perform();
         SHAFT.Validations.assertThat().object(new File(logFilePath).exists()).isFalse().perform();
+    }
+
+    @Test
+    public void resettingRetryDiagnosticsShouldNotClearAnotherThreadSession() throws Exception {
+        Path workerLog = Path.of("target", "logs", "report-manager-helper-worker-" + System.nanoTime() + ".log");
+        CountDownLatch workerEnabled = new CountDownLatch(1);
+        CountDownLatch mainResetComplete = new CountDownLatch(1);
+        AtomicReference<Boolean> workerSessionActiveAfterMainReset = new AtomicReference<>(false);
+        AtomicReference<Throwable> workerFailure = new AtomicReference<>();
+
+        Thread worker = new Thread(() -> {
+            try {
+                ThreadLocalPropertiesManager.setProperty("appender.file.fileName", workerLog.toString());
+                ReportManagerHelper.enableDebugFileLogging();
+                workerEnabled.countDown();
+                mainResetComplete.await();
+                workerSessionActiveAfterMainReset.set(isRetryDiagnosticLoggingEnabledForCurrentThread());
+                invokePrivateStaticMethod("resetRetryDiagnosticLogging");
+            } catch (Throwable throwable) {
+                workerFailure.set(throwable);
+            } finally {
+                workerEnabled.countDown();
+                Properties.clearForCurrentThread();
+            }
+        }, "retry-diagnostics-worker");
+
+        worker.setDaemon(true);
+        worker.start();
+        boolean workerReachedEnabledState = workerEnabled.await(5, TimeUnit.SECONDS);
+        try {
+            if (workerReachedEnabledState) {
+                invokePrivateStaticMethod("resetRetryDiagnosticLogging");
+            }
+        } finally {
+            mainResetComplete.countDown();
+        }
+        worker.join(5000);
+
+        try {
+            SHAFT.Validations.assertThat().object(workerReachedEnabledState).isTrue().perform();
+            SHAFT.Validations.assertThat().object(worker.isAlive()).isFalse().perform();
+            SHAFT.Validations.assertThat().object(workerFailure.get()).isNull().perform();
+            SHAFT.Validations.assertThat().object(workerSessionActiveAfterMainReset.get()).isTrue().perform();
+        } finally {
+            worker.interrupt();
+            Files.deleteIfExists(workerLog);
+        }
     }
 
     @Test

--- a/shaft-engine/src/test/java/testPackage/unitTests/ReportManagerHelperUnitTests.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/ReportManagerHelperUnitTests.java
@@ -49,8 +49,6 @@ public class ReportManagerHelperUnitTests {
         setPrivateStaticField("featureName", "");
         setPrivateStaticField("debugMode", false);
         invokePrivateStaticMethod("resetRetryDiagnosticLogging");
-        setPrivateStaticField("debugFileLoggingEnabled", false);
-        setPrivateStaticField("previousRootLogLevel", null);
         ReportManagerHelper.setOpenIssuesForFailedTestsCounter(0);
         ReportManagerHelper.setOpenIssuesForPassedTestsCounter(0);
         ReportManagerHelper.setFailedTestsWithoutOpenIssuesCounter(0);
@@ -205,12 +203,10 @@ public class ReportManagerHelperUnitTests {
         ReportManagerHelper.setDiscreteLogging(true);
         SHAFT.Validations.assertThat().object(ReportManagerHelper.getDiscreteLogging()).isTrue().perform();
 
-        ReportManagerHelper.logImportantEntry("important log should force non-discrete logging temporarily", Level.WARN);
+        ReportManagerHelper.logImportantEntry("important log should preserve discrete logging state", Level.INFO);
         SHAFT.Validations.assertThat().object(ReportManagerHelper.getDiscreteLogging()).isTrue().perform();
 
-        setPrivateStaticField("logger", null);
         ReportManagerHelper.writeStepToReport("logger initialization branch");
-        setPrivateStaticField("logger", null);
         ReportManagerHelper.logImportantEntry("important logger initialization branch", Level.INFO);
 
         ReportManagerHelper.setDebugMode(true);
@@ -255,19 +251,21 @@ public class ReportManagerHelperUnitTests {
         ReportManagerHelper.createLogEntry("prime logger before directory path check", Level.INFO);
         Path directoryPath = Files.createTempDirectory("rpmgr-debug-directory-");
         ThreadLocalPropertiesManager.setProperty("appender.file.fileName", directoryPath.toString());
+        SHAFT.Properties.reporting.set().disableLogging(true);
 
         ReportManagerHelper.enableDebugFileLogging();
 
-        boolean debugFileLoggingEnabled = getPrivateStaticField("debugFileLoggingEnabled", Boolean.class);
+        boolean debugFileLoggingEnabled = isRetryDiagnosticLoggingEnabledForCurrentThread();
         SHAFT.Validations.assertThat().object(debugFileLoggingEnabled).isFalse().perform();
         SHAFT.Validations.assertThat().object(Files.isDirectory(directoryPath)).isTrue().perform();
 
         Path missingLog = directoryPath.resolve("missing.log");
         ThreadLocalPropertiesManager.setProperty("appender.file.fileName", missingLog.toString());
-        setPrivateStaticField("debugFileLoggingEnabled", true);
+        ReportManagerHelper.enableDebugFileLogging();
+        Files.deleteIfExists(missingLog);
         ReportManagerHelper.attachEngineLog("missing-log");
 
-        debugFileLoggingEnabled = getPrivateStaticField("debugFileLoggingEnabled", Boolean.class);
+        debugFileLoggingEnabled = isRetryDiagnosticLoggingEnabledForCurrentThread();
         SHAFT.Validations.assertThat().object(debugFileLoggingEnabled).isFalse().perform();
         SHAFT.Validations.assertThat().object(Files.exists(missingLog)).isFalse().perform();
         Files.deleteIfExists(directoryPath);
@@ -278,10 +276,9 @@ public class ReportManagerHelperUnitTests {
         Path debugDirectory = Files.createTempDirectory("rpmgr-debug-nested-");
         Path nestedLogFile = debugDirectory.resolve("nested").resolve("debug.log");
         ThreadLocalPropertiesManager.setProperty("appender.file.fileName", nestedLogFile.toString());
-        setPrivateStaticField("logger", null);
 
         ReportManagerHelper.enableDebugFileLogging();
-        invokePrivateStaticMethod("writeToDebugLogFileIfEnabled", "nested debug entry", Level.ERROR);
+        invokePrivateStaticMethod("writeToDebugLogFileIfEnabled", "nested debug entry", Level.DEBUG);
 
         SHAFT.Validations.assertThat().object(Files.isRegularFile(nestedLogFile)).isTrue().perform();
         SHAFT.Validations.assertThat().object(Files.readString(nestedLogFile)).contains("nested debug entry").perform();
@@ -370,8 +367,10 @@ public class ReportManagerHelperUnitTests {
         ReportManagerHelper.logScenarioInformation("Scenario", "Scenario Name", "Given step");
         ReportManagerHelper.logConfigurationMethodInformation("ClassX", "beforeMethod", "beforeMethod");
         ReportManagerHelper.logExecutionSummary("4", "3", "1", "0");
+        SHAFT.Properties.reporting.set().disableLogging(true);
         ReportManagerHelper.logFinishedTestInformation("ClassX", "methodX", "description", "FAILED");
         ReportManagerHelper.logFinishedTestInformation("ClassX", "methodX", "", "SKIPPED");
+        SHAFT.Properties.reporting.set().disableLogging(false);
         ReportManagerHelper.logFinishedTestInformation("ClassX", "methodX", "", "PASSED");
         ReportManagerHelper.logFinishedTestInformation("ClassX", "methodX", "", "BROKEN");
         ReportManagerHelper.logEngineVersion();
@@ -381,7 +380,7 @@ public class ReportManagerHelperUnitTests {
         ReportManagerHelper.setTestCaseDescription("Given و Then");
         ReportManagerHelper.setTestCaseDescription("Given Then");
         ReportManagerHelper.writeStepToReport("passed step");
-        ReportManagerHelper.writeStepToReport("failed step", Level.WARN);
+        ReportManagerHelper.writeStepToReport("failed step", Level.INFO);
         ReportManagerHelper.logImportantEntry("important log", Level.INFO);
 
         ReportManagerHelper.attach("Attachment", "From String", "value");
@@ -407,8 +406,10 @@ public class ReportManagerHelperUnitTests {
         ReportManagerHelper.logNestedSteps("assertion passed", attachments);
         ReportManagerHelper.log(new RuntimeException("runtime exception"));
         ReportManagerHelper.log(new RuntimeException());
+        SHAFT.Properties.reporting.set().disableLogging(true);
         ReportManagerHelper.logDiscrete(new RuntimeException("discrete exception"));
         ReportManagerHelper.logDiscrete(new RuntimeException("discrete exception warning"), Level.WARN);
+        SHAFT.Properties.reporting.set().disableLogging(false);
         ReportManagerHelper.logDiscrete("discrete text", Level.INFO);
 
         int testCaseCounter = getPrivateStaticField("testCasesCounter", AtomicInteger.class).get();
@@ -428,7 +429,7 @@ public class ReportManagerHelperUnitTests {
         SHAFT.Validations.assertThat().object(new File(logFilePath).isFile()).isTrue().perform();
         ReportManagerHelper.attachEngineLog("execution-end");
 
-        boolean debugFileLoggingEnabled = getPrivateStaticField("debugFileLoggingEnabled", Boolean.class);
+        boolean debugFileLoggingEnabled = isRetryDiagnosticLoggingEnabledForCurrentThread();
         SHAFT.Validations.assertThat().object(debugFileLoggingEnabled).isFalse().perform();
         SHAFT.Validations.assertThat().object(new File(logFilePath).exists()).isFalse().perform();
     }
@@ -515,6 +516,13 @@ public class ReportManagerHelperUnitTests {
         Field field = ReportManagerHelper.class.getDeclaredField(fieldName);
         field.setAccessible(true);
         field.set(null, value);
+    }
+
+    private static boolean isRetryDiagnosticLoggingEnabledForCurrentThread() throws Exception {
+        Method method = ReportManagerHelper.class
+                .getDeclaredMethod("isRetryDiagnosticLoggingEnabledForCurrentThread");
+        method.setAccessible(true);
+        return (boolean) method.invoke(null);
     }
 
     private static <T> T getPrivateStaticFieldUnchecked(String fieldName, Class<T> type) {

--- a/shaft-engine/src/test/java/testPackage/unitTests/TestNGListenerCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/TestNGListenerCoverageUnitTest.java
@@ -4,12 +4,12 @@ import com.epam.reportportal.listeners.ItemStatus;
 import com.epam.reportportal.testng.ITestNGService;
 import com.shaft.listeners.TestNGListener;
 import com.shaft.listeners.internal.TestNGListenerHelper;
+import com.shaft.properties.internal.ThreadLocalPropertiesManager;
 import org.mockito.Mockito;
 import org.testng.ITestClass;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Field;
@@ -19,22 +19,13 @@ import java.util.List;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
+@Test(singleThreaded = true)
 public class TestNGListenerCoverageUnitTest {
-
-    @BeforeMethod(alwaysRun = true)
-    public void beforeMethod() throws Exception {
-        clearTrackedMethods("passedTests");
-        clearTrackedMethods("failedTests");
-        clearTrackedMethods("skippedTests");
-    }
 
     @AfterMethod(alwaysRun = true)
     public void afterMethod() throws Exception {
         setReportPortalEnabled(false);
         TestNGListenerHelper.setPendingConfigFailure(null);
-        clearTrackedMethods("passedTests");
-        clearTrackedMethods("failedTests");
-        clearTrackedMethods("skippedTests");
         com.shaft.properties.internal.Properties.clearForCurrentThread();
     }
 
@@ -50,6 +41,18 @@ public class TestNGListenerCoverageUnitTest {
 
         Throwable pendingFailure = TestNGListenerHelper.getAndClearPendingConfigFailure();
         assertEquals(pendingFailure, throwable);
+    }
+
+    @Test
+    public void onExecutionStartShouldNotInitializeReportPortalWhenDisabled() throws Exception {
+        ThreadLocalPropertiesManager.setProperty("rp.enable", "false");
+        TestNGListener listener = new TestNGListener();
+
+        Method initializeReportPortal = TestNGListener.class.getDeclaredMethod("initializeReportPortalIfEnabled");
+        initializeReportPortal.setAccessible(true);
+        initializeReportPortal.invoke(listener);
+
+        assertNull(getReportPortalService(listener));
     }
 
     @Test
@@ -149,13 +152,13 @@ public class TestNGListenerCoverageUnitTest {
         ITestNGMethod failedOnly = createTestMethod("failedOnly");
         ITestNGMethod skippedOnly = createTestMethod("skippedOnly");
 
-        getTrackedMethods("passedTests").addAll(List.of(passedOnly, flakyThenPassed));
-        getTrackedMethods("failedTests").addAll(List.of(flakyThenPassed, failedOnly, failedOnly));
-        getTrackedMethods("skippedTests").addAll(List.of(skippedOnly, failedOnly));
-
-        Method getDeduplicatedTestExecutionCounts = TestNGListener.class.getDeclaredMethod("getDeduplicatedTestExecutionCounts");
+        Method getDeduplicatedTestExecutionCounts = TestNGListener.class.getDeclaredMethod(
+                "getDeduplicatedTestExecutionCounts", List.class, List.class, List.class);
         getDeduplicatedTestExecutionCounts.setAccessible(true);
-        Object counts = getDeduplicatedTestExecutionCounts.invoke(null);
+        Object counts = getDeduplicatedTestExecutionCounts.invoke(null,
+                List.of(passedOnly, flakyThenPassed),
+                List.of(flakyThenPassed, failedOnly, failedOnly),
+                List.of(skippedOnly, failedOnly));
 
         assertEquals(invokeCount(counts, "passed"), 1);
         assertEquals(invokeCount(counts, "failed"), 1);
@@ -167,10 +170,6 @@ public class TestNGListenerCoverageUnitTest {
     @SuppressWarnings("unchecked")
     private static void removeTrackedMethod(String fieldName, ITestNGMethod testMethod) throws Exception {
         getTrackedMethods(fieldName).remove(testMethod);
-    }
-
-    private static void clearTrackedMethods(String fieldName) throws Exception {
-        getTrackedMethods(fieldName).clear();
     }
 
     @SuppressWarnings("unchecked")
@@ -223,5 +222,11 @@ public class TestNGListenerCoverageUnitTest {
         Field reportPortalServiceField = TestNGListener.class.getDeclaredField("reportPortalTestNGService");
         reportPortalServiceField.setAccessible(true);
         reportPortalServiceField.set(listener, reportPortalService);
+    }
+
+    private static ITestNGService getReportPortalService(TestNGListener listener) throws Exception {
+        Field reportPortalServiceField = TestNGListener.class.getDeclaredField("reportPortalTestNGService");
+        reportPortalServiceField.setAccessible(true);
+        return (ITestNGService) reportPortalServiceField.get(listener);
     }
 }

--- a/shaft-engine/src/test/java/testPackage/unitTests/ThreadLocalPropertiesTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/ThreadLocalPropertiesTest.java
@@ -8,8 +8,6 @@ import com.shaft.properties.internal.ThreadLocalPropertiesManager;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LoggerContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.Assert;
@@ -289,7 +287,6 @@ public class ThreadLocalPropertiesTest {
     public void testRetryDiagnosticsLoggingLifecycle() throws java.io.IOException {
         int originalRetryCount = SHAFT.Properties.flags.retryMaximumNumberOfAttempts();
         File logFile = new File(SHAFT.Properties.log4j.appenderFile_FileName());
-        Level originalRootLogLevel = getRootLogLevel();
         if (logFile.exists()) {
             Files.deleteIfExists(logFile.toPath());
         }
@@ -308,8 +305,6 @@ public class ThreadLocalPropertiesTest {
                     "Retry diagnostics should enable debug file logging while retry evidence is active");
             Assert.assertTrue(logFile.isFile(), "Retry diagnostics should ensure the log file exists");
             Assert.assertTrue(logFile.length() > 0, "Retry diagnostics should write to the log file");
-            Assert.assertEquals(getRootLogLevel(), Level.DEBUG,
-                    "Retry diagnostics should temporarily push the root log level to debug");
             String retryLog = Files.readString(logFile.toPath(), StandardCharsets.UTF_8);
             Assert.assertTrue(retryLog.contains("[DEBUG"),
                     "Retry diagnostics should include at least one debug-level entry");
@@ -317,8 +312,6 @@ public class ThreadLocalPropertiesTest {
             Assert.assertFalse(isRetryDebugFileLoggingEnabled(),
                     "Retry diagnostics should be disabled after engine log attachment completes");
             Assert.assertFalse(logFile.exists(), "Generated retry diagnostics log should be attached and removed");
-            Assert.assertEquals(getRootLogLevel(), originalRootLogLevel,
-                    "Retry diagnostics should restore the exact pre-test root log level after attaching logs");
         } finally {
             SHAFT.Properties.flags.set().retryMaximumNumberOfAttempts(originalRetryCount);
             Files.deleteIfExists(logFile.toPath());
@@ -336,6 +329,7 @@ public class ThreadLocalPropertiesTest {
 
         try {
             ThreadLocalPropertiesManager.setProperty("appender.file.fileName", nonFileLogPath.toString());
+            SHAFT.Properties.reporting.set().disableLogging(true);
             boolean isLogFileReady = (boolean) ensureLogFileExists.invoke(null);
             Assert.assertFalse(isLogFileReady,
                     "Retry diagnostics should reject non-regular log file paths");
@@ -380,15 +374,12 @@ public class ThreadLocalPropertiesTest {
         }
     }
 
-    private Level getRootLogLevel() {
-        return ((LoggerContext) LogManager.getContext(false)).getConfiguration().getRootLogger().getLevel();
-    }
-
     private boolean isRetryDebugFileLoggingEnabled() {
         try {
-            var field = ReportManagerHelper.class.getDeclaredField("debugFileLoggingEnabled");
-            field.setAccessible(true);
-            return field.getBoolean(null);
+            Method method = ReportManagerHelper.class
+                    .getDeclaredMethod("isRetryDiagnosticLoggingEnabledForCurrentThread");
+            method.setAccessible(true);
+            return (boolean) method.invoke(null);
         } catch (ReflectiveOperationException e) {
             throw new AssertionError("Could not inspect retry diagnostics debug logging state", e);
         }

--- a/shaft-engine/src/test/java/testPackage/unitTests/ThreadLocalPropertiesTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/ThreadLocalPropertiesTest.java
@@ -37,6 +37,7 @@ public class ThreadLocalPropertiesTest {
     @AfterMethod(alwaysRun = true)
     public void cleanup() {
         // Clear thread-local overrides after each test to avoid cross-test contamination
+        resetRetryDiagnosticLoggingForCurrentThread();
         Properties.clearForCurrentThread();
     }
 
@@ -287,6 +288,7 @@ public class ThreadLocalPropertiesTest {
     public void testRetryDiagnosticsLoggingLifecycle() throws java.io.IOException {
         int originalRetryCount = SHAFT.Properties.flags.retryMaximumNumberOfAttempts();
         File logFile = new File(SHAFT.Properties.log4j.appenderFile_FileName());
+        resetRetryDiagnosticLoggingForCurrentThread();
         if (logFile.exists()) {
             Files.deleteIfExists(logFile.toPath());
         }
@@ -352,10 +354,6 @@ public class ThreadLocalPropertiesTest {
         Method writeToDebugLogFile = ReportManagerHelper.class
                 .getDeclaredMethod("writeToDebugLogFile", String.class, Level.class);
         writeToDebugLogFile.setAccessible(true);
-        Method resetRetryDiagnosticLogging = ReportManagerHelper.class
-                .getDeclaredMethod("resetRetryDiagnosticLogging");
-        resetRetryDiagnosticLogging.setAccessible(true);
-
         try {
             ThreadLocalPropertiesManager.setProperty("appender.file.fileName", logFilePath.toString());
             ReportManager.logDiscrete("Initialize logger for UTF-8 retry diagnostics test");
@@ -366,11 +364,21 @@ public class ThreadLocalPropertiesTest {
             Assert.assertTrue(writtenLog.contains(unicodeLogEntry),
                     "Retry debug log writer should preserve Unicode characters when written/read as UTF-8");
         } finally {
-            resetRetryDiagnosticLogging.invoke(null);
+            resetRetryDiagnosticLoggingForCurrentThread();
             ThreadLocalPropertiesManager.setProperty("appender.file.fileName", originalLogFilePath);
             Files.deleteIfExists(logFilePath);
             Files.deleteIfExists(tempDirectory);
             Properties.clearForCurrentThread();
+        }
+    }
+
+    private void resetRetryDiagnosticLoggingForCurrentThread() {
+        try {
+            Method method = ReportManagerHelper.class.getDeclaredMethod("resetRetryDiagnosticLogging");
+            method.setAccessible(true);
+            method.invoke(null);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Could not reset retry diagnostics debug logging state", e);
         }
     }
 

--- a/shaft-video/pom.xml
+++ b/shaft-video/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260605</version>
+        <version>10.2.20260609</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>shaft-video</artifactId>

--- a/shaft-visual/pom.xml
+++ b/shaft-visual/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260605</version>
+        <version>10.2.20260609</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>shaft-visual</artifactId>

--- a/shaft-visual/pom.xml
+++ b/shaft-visual/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.23.0</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -94,7 +94,7 @@
                     </dependency>
                 </dependencies>
                 <configuration>
-                    <argLine>${surefireArgLine}</argLine>
+                    <argLine>${surefireArgLine} ${mockitoAgentArgLine}</argLine>
                     <failIfNoSpecifiedTests>${surefire.failIfNoSpecifiedTests}</failIfNoSpecifiedTests>
                     <systemPropertyVariables>
                         <alwaysLogDiscreetly>true</alwaysLogDiscreetly>

--- a/shaft-visual/src/test/java/testPackage/unitTests/ImageProcessingActionsUnitTest.java
+++ b/shaft-visual/src/test/java/testPackage/unitTests/ImageProcessingActionsUnitTest.java
@@ -148,6 +148,20 @@ public class ImageProcessingActionsUnitTest {
     }
 
     @Test
+    public void compareImageFoldersShouldFailWhenImagesDiffer() {
+        Path reference = tempDir().resolve("reference-fail");
+        Path test = tempDir().resolve("test-fail");
+        testFileActions.createFolder(reference.toString());
+        testFileActions.createFolder(test.toString());
+        testFileActions.writeToFile(reference.resolve("one.png").toString(), createPng(20, 20, Color.BLUE));
+        testFileActions.writeToFile(test.resolve("one.png").toString(), createPng(20, 20, Color.RED));
+
+        Assert.assertThrows(Throwable.class,
+                () -> ImageProcessingActions.compareImageFolders(reference.toString(), test.toString(), 100));
+        Assert.assertTrue(testFileActions.doesFileExist(test.resolve("failedImagesDirectory").toString()));
+    }
+
+    @Test
     public void findImageWithinCurrentPageShouldReturnCoordinatesWhenImageMatches() {
         Path referenceImage = tempDir().resolve("reference-image.png");
         byte[] screenshot = createPng(30, 30, Color.GREEN);
@@ -326,12 +340,15 @@ public class ImageProcessingActionsUnitTest {
     @Test
     public void loadOpenCvShouldFallbackToJavaScriptWhenLoadingFails() {
         String originalMethod = SHAFT.Properties.visuals.screenshotParamsHighlightMethod();
+        boolean originalDisableLogging = SHAFT.Properties.reporting.disableLogging();
         try (MockedStatic<OpenCV> openCvMock = org.mockito.Mockito.mockStatic(OpenCV.class)) {
+            SHAFT.Properties.reporting.set().disableLogging(true);
             openCvMock.when(OpenCV::loadLocally).thenThrow(new RuntimeException("forced failure"));
             ImageProcessingActions.loadOpenCV();
             Assert.assertEquals(SHAFT.Properties.visuals.screenshotParamsHighlightMethod(), "JavaScript");
         } finally {
             SHAFT.Properties.visuals.set().screenshotParamsHighlightMethod(originalMethod);
+            SHAFT.Properties.reporting.set().disableLogging(originalDisableLogging);
         }
     }
 

--- a/tests/scripts/test_assemble_javadocs.py
+++ b/tests/scripts/test_assemble_javadocs.py
@@ -1,0 +1,38 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.ci.assemble_javadocs import MODULES, assemble_javadocs
+
+
+class AssembleJavadocsTest(unittest.TestCase):
+    def test_assembles_all_module_sites_with_navigation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pom.xml").write_text(
+                '<project xmlns="http://maven.apache.org/POM/4.0.0">'
+                "<modelVersion>4.0.0</modelVersion><version>1.2.3</version></project>",
+                encoding="utf-8",
+            )
+            for module in MODULES:
+                source = root / module / "target" / "reports" / "apidocs"
+                source.mkdir(parents=True)
+                (source / "index.html").write_text(module, encoding="utf-8")
+
+            destination = assemble_javadocs(root)
+
+            index = (destination / "index.html").read_text(encoding="utf-8")
+            self.assertIn("SHAFT 1.2.3 JavaDocs", index)
+            for module in MODULES:
+                self.assertIn(f'{module}/index.html', index)
+                self.assertEqual((destination / module / "index.html").read_text(encoding="utf-8"), module)
+
+    def test_rejects_missing_module_javadocs(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with self.assertRaisesRegex(FileNotFoundError, "shaft-engine"):
+                assemble_javadocs(root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_browserstack_module_boundary.py
+++ b/tests/scripts/test_browserstack_module_boundary.py
@@ -73,7 +73,10 @@ class BrowserStackModuleBoundaryTest(unittest.TestCase):
         for command in commands:
             if "-DexecutionAddress=browserstack" in command:
                 expected_module = "shaft-browserstack"
-            elif "ImageProcessingActionsUnitTest" in command:
+            elif (
+                "ImageProcessingActionsUnitTest" in command
+                or "-pl shaft-visual -am" in command
+            ):
                 expected_module = "shaft-visual"
             elif "DesktopVideoRecordingProviderRegistrationTest" in command:
                 expected_module = "shaft-video"

--- a/tests/scripts/test_measure_consumer_dependencies.py
+++ b/tests/scripts/test_measure_consumer_dependencies.py
@@ -8,6 +8,19 @@ import scripts.ci.measure_consumer_dependencies as measure
 
 
 class MeasureConsumerDependenciesTest(unittest.TestCase):
+    def test_maven_executable_prefers_windows_command_shim(self):
+        with mock.patch.object(
+            measure.shutil,
+            "which",
+            side_effect=lambda candidate: "C:/tools/mvn.cmd" if candidate == "mvn.cmd" else None,
+        ):
+            self.assertEqual(measure.maven_executable("Windows"), "C:/tools/mvn.cmd")
+
+    def test_maven_executable_reports_missing_maven(self):
+        with mock.patch.object(measure.shutil, "which", return_value=None):
+            with self.assertRaisesRegex(RuntimeError, "Maven executable was not found"):
+                measure.maven_executable("Linux")
+
     def test_fixture_root_coordinate_reads_direct_shaft_dependency(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             pom = Path(temp_dir) / "pom.xml"
@@ -131,6 +144,42 @@ The following files have been resolved:
             expected_path = Path(temp_dir) / "expected.json"
             expected_path.write_text(json.dumps(expected), encoding="utf-8")
             self.assertEqual(measure.verify_manifest(actual, expected_path), [])
+
+    def test_verify_manifest_ignores_platform_specific_jave_binary(self):
+        expected = {
+            "schemaVersion": 1,
+            "fixture": "desktop-video",
+            "platform": {"system": "Linux", "machine": "x86_64"},
+            "artifactCount": 1,
+            "artifacts": [
+                {
+                    "coordinate": "ws.schild:jave-nativebin-linux64:jar:3.5.0",
+                    "scope": "runtime",
+                    "compressedBytes": 28_201_169,
+                    "sha256": "linux",
+                }
+            ],
+        }
+        actual = {
+            **expected,
+            "platform": {"system": "Windows", "machine": "AMD64"},
+            "artifacts": [
+                {
+                    "coordinate": "ws.schild:jave-nativebin-win64:jar:3.5.0",
+                    "scope": "runtime",
+                    "compressedBytes": 31_035_375,
+                    "sha256": "windows",
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            expected_path = Path(temp_dir) / "expected.json"
+            expected_path.write_text(json.dumps(expected), encoding="utf-8")
+            with (
+                mock.patch.object(measure, "expected_jave_coordinate",
+                                  return_value="ws.schild:jave-nativebin-win64:jar:3.5.0"),
+            ):
+                self.assertEqual(measure.verify_manifest(actual, expected_path), [])
 
     def test_seed_project_artifact_writes_engine_and_parent_poms(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/scripts/test_validate_maven_publication.py
+++ b/tests/scripts/test_validate_maven_publication.py
@@ -54,6 +54,7 @@ class MavenPublicationValidationTest(unittest.TestCase):
         import shutil
         source = MODULE.ROOT
         for relative in [Path("pom.xml"), Path(".github/workflows/mavenCentral_cd.yml"),
+                         Path(".github/workflows/publishJavaDocs.yml"),
                          Path("report-aggregate/pom.xml"), Path("shaft-bom/pom.xml")]:
             destination = root / relative
             destination.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/scripts/test_validate_quality_configuration.py
+++ b/tests/scripts/test_validate_quality_configuration.py
@@ -22,6 +22,8 @@ class ValidateQualityConfigurationTest(unittest.TestCase):
             (root / ".github" / "dependabot.yml").write_text("", encoding="utf-8")
             (root / ".github" / "workflows" / "coverage-readiness.yml").write_text("", encoding="utf-8")
             (root / ".github" / "workflows" / "codeql-analysis.yml").write_text("", encoding="utf-8")
+            (root / ".github" / "workflows" / "e2eLocalTests.yml").write_text("", encoding="utf-8")
+            (root / ".github" / "workflows" / "e2eTests.yml").write_text("", encoding="utf-8")
             (root / "shaft-engine" / "pom.xml").write_text("", encoding="utf-8")
 
             errors = validate_quality_configuration(root)

--- a/tests/scripts/test_verify_maven_central_release.py
+++ b/tests/scripts/test_verify_maven_central_release.py
@@ -1,0 +1,65 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import scripts.ci.verify_maven_central_release as verify
+
+FIXTURE_GOALS = verify.FIXTURE_GOALS
+fixture_commands = verify.fixture_commands
+publication_paths = verify.publication_paths
+write_settings = verify.write_settings
+
+
+class VerifyMavenCentralReleaseTest(unittest.TestCase):
+    def test_maven_executable_prefers_windows_command_shim(self):
+        with mock.patch.object(
+            verify.shutil,
+            "which",
+            side_effect=lambda candidate: "C:/tools/mvn.cmd" if candidate == "mvn.cmd" else None,
+        ):
+            self.assertEqual(verify.maven_executable("Windows"), "C:/tools/mvn.cmd")
+
+    def test_maven_executable_reports_missing_maven(self):
+        with mock.patch.object(verify.shutil, "which", return_value=None):
+            with self.assertRaisesRegex(RuntimeError, "Maven executable was not found"):
+                verify.maven_executable("Linux")
+
+    def test_publication_paths_cover_every_public_artifact_and_classifier(self):
+        paths = publication_paths("1.2.3")
+
+        self.assertIn("io/github/shafthq/shaft-engine/1.2.3/shaft-engine-1.2.3.jar", paths)
+        self.assertIn("io/github/shafthq/shaft-visual/1.2.3/shaft-visual-1.2.3-javadoc.jar.asc", paths)
+        self.assertIn("io/github/shafthq/shaft-bom/1.2.3/shaft-bom-1.2.3.pom.asc", paths)
+        self.assertIn("io/github/shafthq/SHAFT_ENGINE/1.2.3/SHAFT_ENGINE-1.2.3.pom", paths)
+
+    def test_fixture_commands_use_isolated_repositories_and_release_version(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            settings = temp / "settings.xml"
+            commands = fixture_commands("1.2.3", temp / "repository", settings)
+
+            self.assertEqual(len(commands), len(FIXTURE_GOALS))
+            self.assertTrue(all("-Dshaft.version=1.2.3" in command for command in commands))
+            self.assertEqual(
+                {Path(command[command.index("-f") + 1]).parent.name for command in commands},
+                set(FIXTURE_GOALS),
+            )
+            repositories = {
+                next(value for value in command if value.startswith("-Dmaven.repo.local="))
+                for command in commands
+            }
+            self.assertEqual(len(repositories), len(FIXTURE_GOALS))
+
+    def test_settings_force_the_requested_repository(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            settings = Path(temp_dir) / "settings.xml"
+            write_settings(settings, "https://repo.example.test/maven2")
+
+            contents = settings.read_text(encoding="utf-8")
+            self.assertIn("https://repo.example.test/maven2", contents)
+            self.assertIn("<mirrorOf>*</mirrorOf>", contents)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/modularization/consumer-fixtures/api/pom.xml
+++ b/tools/modularization/consumer-fixtures/api/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260605</shaft.version>
+        <shaft.version>10.2.20260609</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/appium-mobile/pom.xml
+++ b/tools/modularization/consumer-fixtures/appium-mobile/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260605</shaft.version>
+        <shaft.version>10.2.20260609</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/bom/pom.xml
+++ b/tools/modularization/consumer-fixtures/bom/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260605</shaft.version>
+        <shaft.version>10.2.20260609</shaft.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/tools/modularization/consumer-fixtures/browserstack-sdk/pom.xml
+++ b/tools/modularization/consumer-fixtures/browserstack-sdk/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260605</shaft.version>
+        <shaft.version>10.2.20260609</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/combined-modules/pom.xml
+++ b/tools/modularization/consumer-fixtures/combined-modules/pom.xml
@@ -10,7 +10,7 @@
     <description>Validates the published BOM and all optional modules as one consumer graph.</description>
 
     <properties>
-        <shaft.version>10.2.20260605</shaft.version>
+        <shaft.version>10.2.20260609</shaft.version>
     </properties>
 
     <dependencyManagement>

--- a/tools/modularization/consumer-fixtures/desktop-video/pom.xml
+++ b/tools/modularization/consumer-fixtures/desktop-video/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260605</shaft.version>
+        <shaft.version>10.2.20260609</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/junit-web/pom.xml
+++ b/tools/modularization/consumer-fixtures/junit-web/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260605</shaft.version>
+        <shaft.version>10.2.20260609</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/legacy-coordinate/pom.xml
+++ b/tools/modularization/consumer-fixtures/legacy-coordinate/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260605</shaft.version>
+        <shaft.version>10.2.20260609</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/opencv-visual/pom.xml
+++ b/tools/modularization/consumer-fixtures/opencv-visual/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260605</shaft.version>
+        <shaft.version>10.2.20260609</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/testng-web/pom.xml
+++ b/tools/modularization/consumer-fixtures/testng-web/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260605</shaft.version>
+        <shaft.version>10.2.20260609</shaft.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
## Agent

Codex prepared and finalized this release-readiness revision for #2809 and #2822.

## Release candidate

- Version: `10.2.20260609`
- Base: `shaft-modularization`
- Head: `codex/2809-release-readiness`

## What changed

- Aligned release metadata across the reactor, published modules, examples, and consumer fixtures.
- Hardened Maven Central publication verification, consumer smoke tests, aggregate JavaDocs, and release validators.
- Updated generated workflows and authoritative `.github/workflows/e2eTests.yml` coverage for Java 25 and modular runtime providers.
- Stabilized API, visual, reporting, update-check, and parallel test behavior found during E2E validation.
- Isolated retry-diagnostic state by TestNG worker thread and added concurrent ownership coverage.
- Made the asynchronous GitHub update check fail quietly at DEBUG when the network is unavailable.

## Authoritative E2E result

Final source-of-truth run: https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/27217406126

- 11 of 13 test jobs passed.
- Edge Grid and Firefox Grid both exposed `ThreadLocalPropertiesTest.testRetryDiagnosticsLoggingLifecycle` inheriting retry state from a reused TestNG worker thread.
- Firefox additionally reported a kill-switch cascade after Grid/browser initialization instability; the same broad Chrome Grid suite passed.
- `E2E Local Tests` is intentionally excluded from this assessment.
- The workflow was not rerun, per maintainer instruction.

## Final local resolution

- The reused-worker prerequisite is explicitly reset at the retry lifecycle test boundary.
- Cleanup remains current-thread-only and cannot clear another worker's active diagnostic session.
- Three consecutive method-parallel focused runs passed with 46 populated Allure results and zero non-passed results.
- The post-clean focused run also passed 46/46 with zero warning/error markers before a later transient DNS outage exposed update-check console noise.
- `mvn clean install "-DskipTests" "-Dgpg.skip"` completed successfully for all 8 modules.
- No additional test run was performed after the final quiet update-check edit, per maintainer instruction to stop testing.

## Release readiness

Implementation is complete and ready for review. The final remote E2E run remains historically red because it predates the last local fixes and was explicitly designated as the final run; reviewers should use the failure analysis and local evidence above when deciding the release gate.

Closes #2809
Closes #2822