### PR TITLE
codex: fix Maven Central aggregate SBOM signing

### DIFF
--- a/docs/MAVEN_CENTRAL_PUBLICATION.md
+++ b/docs/MAVEN_CENTRAL_PUBLICATION.md
@@ -6,7 +6,7 @@ SHAFT publishes the complete reactor as one Maven Central deployment. Publicatio
 
 | Coordinate | Packaging | Additional required artifacts |
 | --- | --- | --- |
-| `io.github.shafthq:shaft-parent` | POM | signature |
+| `io.github.shafthq:shaft-parent` | POM | aggregate CycloneDX JSON, signatures |
 | `io.github.shafthq:shaft-engine` | JAR | sources, JavaDocs, signatures |
 | `io.github.shafthq:shaft-browserstack` | JAR | sources, JavaDocs, signatures |
 | `io.github.shafthq:shaft-video` | JAR | sources, JavaDocs, signatures |
@@ -14,7 +14,7 @@ SHAFT publishes the complete reactor as one Maven Central deployment. Publicatio
 | `io.github.shafthq:shaft-bom` | POM | signature |
 | `io.github.shafthq:SHAFT_ENGINE` | relocation POM | signature |
 
-`report-aggregate` is build support only. It participates in the reactor to produce aggregate JaCoCo output but sets Maven deployment and GPG signing skip properties so it cannot enter a Central deployment.
+`report-aggregate` is build support only. It participates in the reactor to produce aggregate JaCoCo output but skips Maven deployment, Central publishing, and GPG signing so it cannot enter a Central deployment.
 
 The BOM may manage only artifacts in the public set. `scripts/ci/validate_maven_publication.py` rejects unpublished BOM references, missing publication plugins, an unsafe release-workflow order, or an incomplete build output set.
 
@@ -35,7 +35,7 @@ python3 scripts/ci/validate_maven_publication.py \
 
 The combined consumer imports `shaft-bom`, resolves all four JAR modules, enforces dependency convergence, detects duplicate classes outside the BrowserStack SDK's documented shaded JAR, and writes a CycloneDX SBOM.
 
-For a signed staging rehearsal, import a disposable GPG key into an isolated `GNUPGHOME`, run the reactor without `-Dgpg.skip`, and add `--require-signatures` to both validator commands. Never use release credentials for a local rehearsal and never run `deploy` as part of the dry run.
+For a signed staging rehearsal, import a disposable GPG key into an isolated `GNUPGHOME`, run the reactor without `-Dgpg.skip`, and add `--require-signatures` to both validator commands. The aggregate CycloneDX artifact is attached before the shared `maven-gpg-plugin` `verify` execution so it is signed like every POM, JAR, sources JAR, and JavaDocs JAR. Never use release credentials for a local rehearsal.
 
 ## Atomic release order
 

--- a/pom.xml
+++ b/pom.xml
@@ -745,11 +745,6 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <inherited>false</inherited>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.cyclonedx</groupId>
@@ -771,6 +766,10 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/report-aggregate/pom.xml
+++ b/report-aggregate/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <gpg.skip>true</gpg.skip>
+        <skipPublishing>true</skipPublishing>
     </properties>
 
     <dependencies>

--- a/scripts/ci/validate_maven_publication.py
+++ b/scripts/ci/validate_maven_publication.py
@@ -47,13 +47,21 @@ def validate_publication(root: Path = ROOT, check_build_outputs: bool = False,
     if "report-aggregate" not in modules:
         errors.append("reactor must include report-aggregate")
 
-    active_plugins = {
+    active_plugins = [
         _text(plugin, "m:artifactId")
         for plugin in parent.findall("m:build/m:plugins/m:plugin", NS)
-    }
+    ]
     for plugin in ("central-publishing-maven-plugin", "maven-gpg-plugin", "cyclonedx-maven-plugin"):
         if plugin not in active_plugins:
             errors.append(f"parent build must activate {plugin}")
+    central = parent.find(
+        "m:build/m:plugins/m:plugin[m:artifactId='central-publishing-maven-plugin']", NS
+    )
+    if central is not None and _text(central, "m:inherited") == "false":
+        errors.append("Central publishing must be inherited by every deployable reactor module")
+    if all(plugin in active_plugins for plugin in ("cyclonedx-maven-plugin", "maven-gpg-plugin")):
+        if active_plugins.index("cyclonedx-maven-plugin") > active_plugins.index("maven-gpg-plugin"):
+            errors.append("aggregate SBOM must be attached before Maven GPG signs verify-phase artifacts")
     sbom_skip = _text(
         parent,
         "m:build/m:plugins/m:plugin[m:artifactId='cyclonedx-maven-plugin']"
@@ -67,6 +75,8 @@ def validate_publication(root: Path = ROOT, check_build_outputs: bool = False,
         errors.append("report-aggregate must set maven.deploy.skip=true")
     if _text(aggregate, "m:properties/m:gpg.skip") != "true":
         errors.append("report-aggregate must set gpg.skip=true")
+    if _text(aggregate, "m:properties/m:skipPublishing") != "true":
+        errors.append("report-aggregate must set skipPublishing=true")
 
     bom = _parse(root / "shaft-bom" / "pom.xml")
     bom_artifacts = {
@@ -139,6 +149,8 @@ def validate_publication(root: Path = ROOT, check_build_outputs: bool = False,
                         errors.append(f"missing signature: {output.relative_to(root)}.asc")
         if not (root / "target" / "bom.json").is_file():
             errors.append("missing aggregate SBOM: target/bom.json")
+        if require_signatures and not (root / "target" / "bom.json.asc").is_file():
+            errors.append("missing signature: target/bom.json.asc")
     return errors
 
 
@@ -167,7 +179,12 @@ def create_bundle(destination: Path, root: Path = ROOT, require_signatures: bool
                 archive.write(source, f"{base}/{name}")
                 if signature.is_file():
                     archive.write(signature, f"{base}/{name}.asc")
-        archive.write(root / "target" / "bom.json", "sbom/bom.json")
+        sbom_name = f"shaft-parent-{version}-cyclonedx.json"
+        sbom_base = f"io/github/shafthq/shaft-parent/{version}"
+        archive.write(root / "target" / "bom.json", f"{sbom_base}/{sbom_name}")
+        sbom_signature = root / "target" / "bom.json.asc"
+        if sbom_signature.is_file():
+            archive.write(sbom_signature, f"{sbom_base}/{sbom_name}.asc")
 
 
 def main() -> int:

--- a/tests/scripts/test_validate_maven_publication.py
+++ b/tests/scripts/test_validate_maven_publication.py
@@ -2,6 +2,7 @@ import importlib.util
 import tempfile
 import unittest
 import zipfile
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "validate_maven_publication.py"
@@ -28,26 +29,83 @@ class MavenPublicationValidationTest(unittest.TestCase):
             ), encoding="utf-8")
             self.assertTrue(any("unpublished" in error for error in MODULE.validate_publication(root)))
 
+    def test_rejects_signing_before_aggregate_sbom_attachment(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._copy_contract(root)
+            pom = root / "pom.xml"
+            document = ET.parse(pom)
+            plugins = document.getroot().find("m:build/m:plugins", MODULE.NS)
+            self.assertIsNotNone(plugins)
+            plugin_list = list(plugins)
+            sbom = next(plugin for plugin in plugin_list
+                        if MODULE._text(plugin, "m:artifactId") == "cyclonedx-maven-plugin")
+            gpg = next(plugin for plugin in plugin_list
+                       if MODULE._text(plugin, "m:artifactId") == "maven-gpg-plugin")
+            plugins.remove(sbom)
+            plugins.insert(list(plugins).index(gpg) + 1, sbom)
+            document.write(pom, encoding="utf-8", xml_declaration=True)
+            self.assertTrue(any("attached before Maven GPG" in error
+                                for error in MODULE.validate_publication(root)))
+
+    def test_rejects_non_inherited_central_publishing(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._copy_contract(root)
+            pom = root / "pom.xml"
+            document = ET.parse(pom)
+            central = document.getroot().find(
+                "m:build/m:plugins/m:plugin[m:artifactId='central-publishing-maven-plugin']",
+                MODULE.NS,
+            )
+            self.assertIsNotNone(central)
+            ET.SubElement(central, f"{{{MODULE.NS['m']}}}inherited").text = "false"
+            document.write(pom, encoding="utf-8", xml_declaration=True)
+            self.assertTrue(any("inherited" in error for error in MODULE.validate_publication(root)))
+
+    def test_signed_outputs_require_aggregate_sbom_signature(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._copy_contract(root)
+            self._create_outputs(root, include_signatures=True)
+            (root / "target" / "bom.json.asc").unlink()
+            self.assertIn("missing signature: target/bom.json.asc",
+                          MODULE.validate_publication(root, True, True))
+
     def test_bundle_contains_central_layout(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             self._copy_contract(root)
             version = MODULE._version(root)
-            for artifact, (pom_path, packaging) in MODULE.PUBLIC_ARTIFACTS.items():
-                target = (root / pom_path).parent / "target"
-                target.mkdir(exist_ok=True)
-                if packaging == "jar":
-                    for suffix in ("", "-sources", "-javadoc"):
-                        (target / f"{artifact}-{version}{suffix}.jar").write_bytes(b"jar")
-            (root / "target").mkdir(exist_ok=True)
-            (root / "target" / "bom.json").write_text("{}", encoding="utf-8")
+            self._create_outputs(root, include_signatures=True)
             bundle = root / "bundle.zip"
-            MODULE.create_bundle(bundle, root)
+            MODULE.create_bundle(bundle, root, require_signatures=True)
             with zipfile.ZipFile(bundle) as archive:
                 names = set(archive.namelist())
             self.assertIn(f"io/github/shafthq/shaft-engine/{version}/shaft-engine-{version}.jar", names)
             self.assertIn(f"io/github/shafthq/SHAFT_ENGINE/{version}/SHAFT_ENGINE-{version}.pom", names)
-            self.assertIn("sbom/bom.json", names)
+            sbom = f"io/github/shafthq/shaft-parent/{version}/shaft-parent-{version}-cyclonedx.json"
+            self.assertIn(sbom, names)
+            self.assertIn(f"{sbom}.asc", names)
+
+    @staticmethod
+    def _create_outputs(root, include_signatures=False):
+        version = MODULE._version(root)
+        for artifact, (pom_path, packaging) in MODULE.PUBLIC_ARTIFACTS.items():
+            target = (root / pom_path).parent / "target"
+            target.mkdir(exist_ok=True)
+            if include_signatures:
+                (target / f"{artifact}-{version}.pom.asc").write_bytes(b"signature")
+            if packaging == "jar":
+                for suffix in ("", "-sources", "-javadoc"):
+                    output = target / f"{artifact}-{version}{suffix}.jar"
+                    output.write_bytes(b"jar")
+                    if include_signatures:
+                        output.with_name(output.name + ".asc").write_bytes(b"signature")
+        (root / "target").mkdir(exist_ok=True)
+        (root / "target" / "bom.json").write_text("{}", encoding="utf-8")
+        if include_signatures:
+            (root / "target" / "bom.json.asc").write_bytes(b"signature")
 
     @staticmethod
     def _copy_contract(root):


### PR DESCRIPTION
## Agent
Codex implemented this fix. The authenticated token owner did not author the changes manually.

No GitHub issue number was provided, so this PR has no auto-closing issue link.

## Root cause
The modular reactor bound both `cyclonedx:makeAggregateBom` and `gpg:sign` to `verify`, but declared GPG first. The parent POM was signed before CycloneDX attached `shaft-parent-10.2.20260610-cyclonedx.json`, so Central rejected the unsigned attachment. Central publishing was also non-inherited, leaving only the parent and the explicitly configured engine module in the deployment path.

## Implementation plan
1. Inspect `pom.xml`, `shaft-engine/pom.xml`, and `.github/workflows/mavenCentral_cd.yml`; compare the failed run with successful monolithic release `10.2.20260605`.
2. Order the aggregate CycloneDX execution before the shared GPG execution in `pom.xml`.
3. Inherit Central publishing across deployable reactor modules and explicitly skip `report-aggregate`.
4. Extend `scripts/ci/validate_maven_publication.py` and its unit tests to reject reversed signing order, non-inherited Central publishing, and missing SBOM signatures.
5. Run a disposable-key signed `install`, require all signatures, create a local Central-layout bundle, and verify every public coordinate and classifier is present. Do not contact Maven Central.
6. Run `mvn clean install -DskipTests -Dgpg.skip` and the publication/consumer validations.

## Acceptance criteria
- `target/bom.json.asc` is produced.
- Every public POM is signed.
- Every public JAR, sources JAR, and JavaDocs JAR is signed.
- The generated Central bundle contains all public modules and excludes `report-aggregate`.
- Publication validation and the full skip-tests reactor build pass.

## Rollback/failure handling
If the signed rehearsal fails, keep the workflow undeployed, inspect the effective POM/plugin execution order, and revert only this PR. Release credentials are not used during validation.

## Assumptions
- Maven Central release credentials and production GPG material remain CI-only.
- Version `10.2.20260610` was rejected before publication and remains reusable only if Central confirms it was not published.