### PR TITLE
[codex] Add optional SHAFT Pilot AI-provider foundation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
     directories:
       - "/"
       - "/shaft-engine"
+      - "/shaft-pilot-core"
+      - "/shaft-ai"
       - "/shaft-browserstack"
       - "/shaft-video"
       - "/shaft-visual"

--- a/.github/workflows/code-quality-scan.yml
+++ b/.github/workflows/code-quality-scan.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Check for Dependency Updates
         id: dep-updates
         run: |
-          mvn -pl shaft-engine,shaft-browserstack,shaft-video,shaft-visual,shaft-mcp -am versions:display-dependency-updates -Dgpg.skip 2>&1 | tee /tmp/dep-updates-raw.txt || true
-          mvn -pl shaft-engine,shaft-browserstack,shaft-video,shaft-visual,shaft-mcp -am versions:display-plugin-updates -Dgpg.skip 2>&1 | tee -a /tmp/dep-updates-raw.txt || true
+          mvn -pl shaft-engine,shaft-pilot-core,shaft-ai,shaft-browserstack,shaft-video,shaft-visual,shaft-mcp -am versions:display-dependency-updates -Dgpg.skip 2>&1 | tee /tmp/dep-updates-raw.txt || true
+          mvn -pl shaft-engine,shaft-pilot-core,shaft-ai,shaft-browserstack,shaft-video,shaft-visual,shaft-mcp -am versions:display-plugin-updates -Dgpg.skip 2>&1 | tee -a /tmp/dep-updates-raw.txt || true
 
           # Capture only true stable upgrades (exclude prereleases and version downgrades)
           python3 <<'PY'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -61,7 +61,7 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-        run: mvn -B -pl shaft-engine,shaft-browserstack,shaft-video,shaft-visual,shaft-mcp -am clean package --file pom.xml -DskipTests -Dgpg.skip
+        run: mvn -B -pl shaft-engine,shaft-pilot-core,shaft-ai,shaft-browserstack,shaft-video,shaft-visual,shaft-mcp -am clean package --file pom.xml -DskipTests -Dgpg.skip
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -29,4 +29,4 @@ jobs:
           maven-version: 3.9.5
 
       - name: Pre-download Maven dependencies
-        run: mvn -pl shaft-engine,shaft-browserstack,shaft-video,shaft-visual,shaft-mcp -am dependency:resolve -DskipTests -Dgpg.skip
+        run: mvn -pl shaft-engine,shaft-pilot-core,shaft-ai,shaft-browserstack,shaft-video,shaft-visual,shaft-mcp -am dependency:resolve -DskipTests -Dgpg.skip

--- a/.github/workflows/shaft-mcp.yml
+++ b/.github/workflows/shaft-mcp.yml
@@ -1,23 +1,8 @@
 name: SHAFT MCP
 
 on:
-  pull_request:
-    paths:
-      - 'pom.xml'
-      - 'shaft-engine/**'
-      - 'shaft-mcp/**'
-      - 'shaft-bom/pom.xml'
-      - 'scripts/ci/validate_shaft_mcp_transports.py'
-      - '.github/workflows/shaft-mcp.yml'
-  push:
-    branches: [ main ]
-    paths:
-      - 'pom.xml'
-      - 'shaft-engine/**'
-      - 'shaft-mcp/**'
-      - 'shaft-bom/pom.xml'
-      - 'scripts/ci/validate_shaft_mcp_transports.py'
-      - '.github/workflows/shaft-mcp.yml'
+  schedule:
+    - cron: '00 1 * * *'
   workflow_dispatch:
 
 permissions:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,6 +14,8 @@ functionality remains in the required `shaft-engine` JAR.
 flowchart TB
     Consumer["Consumer project"] --> BOM["shaft-bom<br/>dependency management"]
     Consumer --> Engine["shaft-engine<br/>required runtime"]
+    Consumer -.->|optional| PilotCore["shaft-pilot-core<br/>contracts + security"]
+    Consumer -.->|optional| AI["shaft-ai<br/>direct providers"]
     Consumer -.->|optional| BrowserStack["shaft-browserstack<br/>BrowserStack Java SDK"]
     Consumer -.->|optional| Video["shaft-video<br/>local desktop recording"]
     Consumer -.->|optional| Visual["shaft-visual<br/>OpenCV + Eyes + Shutterbug"]
@@ -23,6 +25,8 @@ flowchart TB
     Video --> Engine
     Visual --> Engine
     MCP --> Engine
+    PilotCore --> Engine
+    AI --> PilotCore
 
     Legacy["SHAFT_ENGINE<br/>relocation POM only"] -.->|relocates| Engine
 
@@ -35,6 +39,8 @@ flowchart TB
 | Artifact             | Packaging      | Consumer purpose                                                                                                         |
 |----------------------|----------------|--------------------------------------------------------------------------------------------------------------------------|
 | `shaft-engine`       | JAR            | Required facade and core web, mobile, API, database, CLI, reporting, and accessibility implementation.                   |
+| `shaft-pilot-core`   | JAR            | Provider-neutral Pilot contracts, consent, redaction, budgets, audit metadata, and deterministic fallback.               |
+| `shaft-ai`           | JAR            | Optional direct OpenAI, Anthropic, Gemini, and Ollama HTTP adapters discovered through `ServiceLoader`.                  |
 | `shaft-browserstack` | JAR            | BrowserStack SDK interception and `browserstack.yml` orchestration. Direct BrowserStack sessions stay in `shaft-engine`. |
 | `shaft-video`        | JAR            | Local non-headless desktop recording. Appium-native recording stays in `shaft-engine`.                                   |
 | `shaft-visual`       | JAR            | Reference-image assertions and image-based lookup through OpenCV, Eyes, and Shutterbug.                                  |
@@ -119,6 +125,7 @@ present.
 - [Visual processing module](SHAFT_VISUAL_MODULE.md)
 - [Desktop video module](SHAFT_VIDEO_MODULE.md)
 - [SHAFT MCP](SHAFT_MCP.md)
+- [SHAFT Pilot AI](SHAFT_PILOT_AI.md)
 - [Maven reactor layout](MAVEN_REACTOR.md)
 
 ---

--- a/docs/MAVEN_CENTRAL_PUBLICATION.md
+++ b/docs/MAVEN_CENTRAL_PUBLICATION.md
@@ -8,6 +8,8 @@ SHAFT publishes the complete reactor as one Maven Central deployment. Publicatio
 | --- | --- | --- |
 | `io.github.shafthq:shaft-parent` | POM | aggregate CycloneDX JSON, signatures |
 | `io.github.shafthq:shaft-engine` | JAR | sources, JavaDocs, signatures |
+| `io.github.shafthq:shaft-pilot-core` | JAR | sources, JavaDocs, signatures |
+| `io.github.shafthq:shaft-ai` | JAR | sources, JavaDocs, signatures |
 | `io.github.shafthq:shaft-browserstack` | JAR | sources, JavaDocs, signatures |
 | `io.github.shafthq:shaft-video` | JAR | sources, JavaDocs, signatures |
 | `io.github.shafthq:shaft-visual` | JAR | sources, JavaDocs, signatures |
@@ -34,7 +36,7 @@ python3 scripts/ci/validate_maven_publication.py \
   --create-bundle target/publication-dry-run/central-bundle.zip
 ```
 
-The combined consumer imports `shaft-bom`, resolves the engine and optional library modules, enforces dependency convergence, detects duplicate classes outside the BrowserStack SDK's documented shaded JAR, and writes a CycloneDX SBOM. The separate `mcp` fixture resolves and copies the preserved executable coordinate without adding it to ordinary engine consumers.
+The combined consumer imports `shaft-bom`, resolves the engine and optional library modules, enforces dependency convergence, detects duplicate classes outside the BrowserStack SDK's documented shaded JAR, and writes a CycloneDX SBOM. The `pilot-core` fixture compiles against provider-neutral contracts while banning `shaft-ai`; the separate `mcp` fixture resolves and copies the preserved executable coordinate without adding it to ordinary engine consumers.
 
 For a signed staging rehearsal, import a disposable GPG key into an isolated `GNUPGHOME`, run the reactor without `-Dgpg.skip`, and add `--require-signatures` to both validator commands. The aggregate CycloneDX artifact is attached before the shared `maven-gpg-plugin` `verify` execution so it is signed like every POM, JAR, sources JAR, and JavaDocs JAR. Never use release credentials for a local rehearsal.
 

--- a/docs/MAVEN_REACTOR.md
+++ b/docs/MAVEN_REACTOR.md
@@ -8,7 +8,9 @@ relocation artifact that points consumers to the canonical JAR.
 
 - The root `pom.xml` is the `io.github.shafthq:shaft-parent` aggregator and build parent. It owns shared version properties, dependency management, and plugin management.
 - `shaft-engine/pom.xml` builds the engine JAR. All framework source, resources, tests, examples, and runtime support assets remain under `shaft-engine/src/`; Java packages remain under `com.shaft`.
-- `shaft-bom/pom.xml` publishes the consumer BOM. Importing it manages the `shaft-engine`, `shaft-browserstack`, `shaft-video`, `shaft-visual`, and `SHAFT_MCP` versions without adding dependencies by itself.
+- `shaft-bom/pom.xml` publishes the consumer BOM. Importing it manages the `shaft-engine`, `shaft-pilot-core`, `shaft-ai`, `shaft-browserstack`, `shaft-video`, `shaft-visual`, and `SHAFT_MCP` versions without adding dependencies by itself.
+- `shaft-pilot-core/pom.xml` builds provider-neutral Pilot contracts, security controls, configuration snapshots, and deterministic fallback. It depends on `shaft-engine`; the engine has no reverse dependency.
+- `shaft-ai/pom.xml` builds optional direct OpenAI, Anthropic, Gemini, and Ollama adapters. It depends on `shaft-pilot-core` and exposes no provider SDK types.
 - `shaft-mcp/pom.xml` builds the optional executable MCP server. It depends on `shaft-engine`; the engine has no reverse dependency on MCP.
 - `shaft-browserstack/pom.xml` builds the optional BrowserStack Java SDK integration. Direct BrowserStack
   WebDriver/Appium sessions remain in `shaft-engine`.
@@ -66,6 +68,7 @@ mvn -pl shaft-engine -am test -Dtest=TestClassName
 mvn -pl shaft-browserstack -am test -Dtest=BrowserStackHelperUnitTest
 mvn -pl shaft-video -am test -Dtest=DesktopVideoRecordingProviderRegistrationTest
 mvn -pl shaft-visual -am test -Dtest=ImageProcessingActionsUnitTest
+mvn -pl shaft-pilot-core,shaft-ai -am test
 mvn -pl shaft-mcp -am test -Dtest=ShaftMcpApplicationTests
 mvn -pl shaft-mcp -am package -DskipTests -Dgpg.skip
 python3 scripts/ci/validate_shaft_mcp_transports.py
@@ -77,6 +80,8 @@ python3 scripts/ci/assemble_javadocs.py
 Build and test outputs are module-local. Important locations include:
 
 - Engine JAR: `shaft-engine/target/shaft-engine-<version>.jar`
+- Pilot contracts JAR: `shaft-pilot-core/target/shaft-pilot-core-<version>.jar`
+- Optional direct providers JAR: `shaft-ai/target/shaft-ai-<version>.jar`
 - Optional BrowserStack SDK JAR: `shaft-browserstack/target/shaft-browserstack-<version>.jar`
 - Optional desktop video JAR: `shaft-video/target/shaft-video-<version>.jar`
 - Optional visual-processing JAR: `shaft-visual/target/shaft-visual-<version>.jar`
@@ -111,7 +116,7 @@ Workflow commands run from the repository root and select only the modules requi
 | `e2eLocalTests.yml`, `e2eLambdaTestTests.yml`, `e2eMoonTests.yml` | Use `-pl shaft-engine -am`; Appium and ordinary browser jobs do not resolve `shaft-video`. |
 | `coverage-readiness.yml` | Runs focused engine tests, builds `report-aggregate`, gates `target/jacoco/jacoco.csv`, and uploads only `target/jacoco/jacoco.xml` to Codecov. |
 | `code-quality-scan.yml`, `codeql-analysis.yml`, `copilot-setup-steps.yml` | Select the code-bearing engine, optional integrations, and MCP module explicitly; BOM and relocation-only modules are excluded from compilation/analysis. |
-| `shaft-mcp.yml` | Runs the MCP context test, packages the executable, and smokes stdio plus Streamable HTTP. |
+| `shaft-mcp.yml` | Runs manually and daily at 01:00 UTC with local E2E workflows; packages the executable and smokes stdio plus Streamable HTTP. |
 | `publishJavaDocs.yml` | Builds JavaDocs for all Java-bearing modules, assembles a navigable site at `target/javadocs`, and publishes it only after a successful Central release. |
 | `mavenCentral_cd.yml` | Intentionally deploys the complete reactor because every published module, BOM, and relocation POM belongs to a release. |
 | `reactor-version-check.yml` | Uses the reactor-version validation script and does not invoke Maven. |
@@ -122,7 +127,7 @@ The shared post-test action defaults to `shaft-engine` but accepts `module-direc
 
 ## Aggregate coverage continuity
 
-`report-aggregate` is a build-only module that depends on every Java-bearing module, including `shaft-mcp`, and writes JaCoCo XML, CSV, and HTML to root `target/jacoco`. It is skipped by Maven deploy and is not a published SHAFT artifact.
+`report-aggregate` is a build-only module that depends on every Java-bearing module, including the Pilot modules and `shaft-mcp`, and writes JaCoCo XML, CSV, and HTML to root `target/jacoco`. It is skipped by Maven deploy and is not a published SHAFT artifact.
 
 Use pre-reactor commit `570a83674b70477074621ea24d7cfa05517260c6` as the coverage-continuity reference. Run the same test selector on that commit and on the current branch, then compare the resulting CSV summaries with `scripts/ci/jacoco_coverage_gate.py`. The current reactor command is:
 
@@ -140,3 +145,6 @@ Consumer-facing method boundaries are documented in
 
 MCP client configuration, transport behavior, and credential boundaries are
 documented in [SHAFT MCP](SHAFT_MCP.md).
+
+Pilot contracts, direct-provider configuration, approval, and redaction are
+documented in [SHAFT Pilot AI](SHAFT_PILOT_AI.md).

--- a/docs/SHAFT_MCP.md
+++ b/docs/SHAFT_MCP.md
@@ -61,7 +61,9 @@ Client-specific locations:
 - **Gemini CLI:** place the server under the top-level `mcpServers` object in
   Gemini `settings.json`.
 - **GitHub Copilot in an MCP-capable IDE:** use the IDE's MCP server
-  configuration and the same `java -jar` command.
+  configuration and the same `java -jar` command. Copilot remains the MCP
+  host and uses its own authentication; there is no generic Copilot model API
+  key for SHAFT to request or store.
 - **Generic MCP clients:** configure a stdio server command with newline
   delimited JSON-RPC over stdin/stdout.
 
@@ -94,6 +96,9 @@ Current client references:
 - [Claude MCP](https://docs.anthropic.com/en/docs/claude-code/mcp)
 - [Gemini CLI MCP](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md)
 - [GitHub Copilot MCP](https://docs.github.com/copilot/how-tos/copilot-on-github/customize-copilot/configure-mcp-servers)
+
+Credential-free sample files for Codex, Claude Desktop, Gemini CLI, and VS Code
+with GitHub Copilot are under `docs/examples/shaft-pilot/mcp/`.
 
 ## Distribution identity
 

--- a/docs/SHAFT_PILOT_AI.md
+++ b/docs/SHAFT_PILOT_AI.md
@@ -1,0 +1,117 @@
+# SHAFT Pilot AI foundation
+
+SHAFT Pilot separates provider-neutral contracts from optional direct model
+access:
+
+- `shaft-pilot-core` contains immutable request/response records, approval and
+  redaction policies, budgets, safe audit metadata, provider capabilities,
+  `ServiceLoader` discovery, and deterministic fallback.
+- `shaft-ai` contains direct HTTP adapters for OpenAI, Anthropic, Google Gemini,
+  and local Ollama. It uses JDK `HttpClient`; no provider SDK type is exposed.
+- `shaft-engine` exposes only thread-local `SHAFT.Properties.pilot`
+  configuration. It has no dependency on either Pilot module.
+
+Capture and Doctor-style features depend on `shaft-pilot-core`. Add `shaft-ai`
+only when direct provider calls are required.
+
+## Safe defaults
+
+AI is off unless both settings are changed:
+
+```properties
+pilot.ai.enabled=false
+pilot.ai.provider=none
+```
+
+Provider models default to blank, remote and local consent default to `false`,
+and no evidence category is approved by default. Disabled or unavailable AI
+returns the request's `deterministicFallback` and makes no network call.
+
+Credentials are read only from environment variables:
+
+| Provider | Default variable |
+| --- | --- |
+| OpenAI | `OPENAI_API_KEY` |
+| Anthropic | `ANTHROPIC_API_KEY` |
+| Gemini | `GEMINI_API_KEY` |
+| Ollama | none |
+
+The environment variable names are configurable, but credential values are
+never SHAFT properties. Provider endpoints and models are configured through
+`SHAFT.Properties.pilot`; no model is selected implicitly.
+
+## Approval and evidence
+
+Every request carries an `ApprovalPolicy`, and the effective SHAFT properties
+must independently approve the same processing location and all submitted
+`EvidenceCategory` values. Remote calls require
+`pilot.ai.consent.remote=true`. Ollama requires
+`pilot.ai.consent.local=true`; a loopback endpoint is not trusted
+automatically.
+
+Before provider execution, `AiExecutionService`:
+
+1. checks provider capabilities and availability;
+2. enforces request size, token, cost, timeout, concurrency, and circuit-breaker
+   limits;
+3. rejects unapproved evidence categories;
+4. redacts authorization and cookie headers, password/secret assignments,
+   common tokens, configured DOM selectors, attributes, and patterns;
+5. validates provider JSON against the requested schema;
+6. returns deterministic fallback for every failure.
+
+Audit events contain only request ID, purpose, provider/model identifiers,
+redaction counts, duration, and status. Prompts, evidence, credentials, raw
+responses, and original secret values are excluded.
+
+## Example
+
+```java
+SHAFT.Properties.pilot.set()
+        .enabled(true)
+        .provider("ollama")
+        .localConsent(true)
+        .allowedEvidenceCategories("TEXT")
+        .ollamaModel("your-local-model");
+
+var schema = JsonNodeFactory.instance.objectNode()
+        .put("type", "object");
+schema.putObject("properties")
+        .putObject("summary")
+        .put("type", "string");
+schema.putArray("required").add("summary");
+
+var approval = new ApprovalPolicy(
+        true,
+        false,
+        Set.of(EvidenceCategory.TEXT));
+
+var request = AiRequest.builder("doctor-summary", schema)
+        .text(redactedDiagnosticText)
+        .approvalPolicy(approval)
+        .deterministicFallback(deterministicDiagnosis)
+        .build();
+
+AiResponse response = new AiExecutionService().execute(request);
+```
+
+Call `SHAFT.Properties.clearForCurrentThread()` at lifecycle boundaries after
+setting per-thread Pilot properties.
+
+## Direct providers and external agents
+
+Direct provider adapters are separate from MCP clients. OpenAI, Anthropic, and
+Gemini API credentials apply only to `shaft-ai` direct calls. GitHub/Microsoft
+Copilot is supported through SHAFT MCP and retains its own client
+authentication; SHAFT does not request or define a generic Copilot model API
+key.
+
+Credential-free MCP configuration fixtures are under
+`docs/examples/shaft-pilot/mcp/`. See [SHAFT MCP](SHAFT_MCP.md) for transport
+and deployment details.
+
+Provider request mappings follow the official
+[OpenAI structured output](https://developers.openai.com/api/docs/guides/structured-outputs),
+[Anthropic structured output](https://platform.claude.com/docs/en/build-with-claude/structured-outputs),
+[Gemini structured output](https://ai.google.dev/gemini-api/docs/structured-output),
+and [Ollama chat](https://docs.ollama.com/api/chat) contracts.

--- a/docs/examples/shaft-pilot/mcp/claude-desktop.json
+++ b/docs/examples/shaft-pilot/mcp/claude-desktop.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "shaft-mcp": {
+      "command": "java",
+      "args": ["-jar", "/absolute/path/SHAFT_MCP-<version>.jar"]
+    }
+  }
+}

--- a/docs/examples/shaft-pilot/mcp/codex-config.toml
+++ b/docs/examples/shaft-pilot/mcp/codex-config.toml
@@ -1,0 +1,4 @@
+[mcp_servers.shaft-mcp]
+command = "java"
+args = ["-jar", "/absolute/path/SHAFT_MCP-<version>.jar"]
+default_tools_approval_mode = "prompt"

--- a/docs/examples/shaft-pilot/mcp/gemini-settings.json
+++ b/docs/examples/shaft-pilot/mcp/gemini-settings.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "shaft-mcp": {
+      "command": "java",
+      "args": ["-jar", "/absolute/path/SHAFT_MCP-<version>.jar"]
+    }
+  }
+}

--- a/docs/examples/shaft-pilot/mcp/vscode-mcp.json
+++ b/docs/examples/shaft-pilot/mcp/vscode-mcp.json
@@ -1,0 +1,9 @@
+{
+  "servers": {
+    "shaft-mcp": {
+      "type": "stdio",
+      "command": "java",
+      "args": ["-jar", "/absolute/path/SHAFT_MCP-<version>.jar"]
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,8 @@
 
     <modules>
         <module>shaft-engine</module>
+        <module>shaft-pilot-core</module>
+        <module>shaft-ai</module>
         <module>shaft-mcp</module>
         <module>shaft-browserstack</module>
         <module>shaft-video</module>

--- a/report-aggregate/pom.xml
+++ b/report-aggregate/pom.xml
@@ -27,6 +27,16 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>shaft-pilot-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>shaft-ai</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>shaft-browserstack</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/scripts/ci/assemble_javadocs.py
+++ b/scripts/ci/assemble_javadocs.py
@@ -12,6 +12,8 @@ ROOT = Path(__file__).resolve().parents[2]
 NS = {"m": "http://maven.apache.org/POM/4.0.0"}
 MODULES = {
     "shaft-engine": "Core engine",
+    "shaft-pilot-core": "SHAFT Pilot contracts and security",
+    "shaft-ai": "Optional direct AI providers",
     "shaft-browserstack": "BrowserStack integration",
     "shaft-video": "Desktop video integration",
     "shaft-visual": "Visual processing integration",

--- a/scripts/ci/measure_consumer_dependencies.py
+++ b/scripts/ci/measure_consumer_dependencies.py
@@ -22,6 +22,10 @@ FIXTURES_ROOT = ROOT / "tools" / "modularization" / "consumer-fixtures"
 BASELINE_ROOT = ROOT / "docs" / "modularization" / "dependency-baseline"
 ENGINE_ROOT = ROOT / "shaft-engine"
 ENGINE_POM = ENGINE_ROOT / "pom.xml"
+PILOT_CORE_ROOT = ROOT / "shaft-pilot-core"
+PILOT_CORE_POM = PILOT_CORE_ROOT / "pom.xml"
+AI_ROOT = ROOT / "shaft-ai"
+AI_POM = AI_ROOT / "pom.xml"
 BOM_POM = ROOT / "shaft-bom" / "pom.xml"
 BROWSERSTACK_ROOT = ROOT / "shaft-browserstack"
 BROWSERSTACK_POM = BROWSERSTACK_ROOT / "pom.xml"
@@ -32,6 +36,8 @@ VISUAL_POM = VISUAL_ROOT / "pom.xml"
 LEGACY_POM = ROOT / "legacy-shaft-engine" / "pom.xml"
 PROJECT_COORDINATES = (
     "io.github.shafthq:shaft-engine",
+    "io.github.shafthq:shaft-pilot-core",
+    "io.github.shafthq:shaft-ai",
     "io.github.shafthq:shaft-browserstack",
     "io.github.shafthq:shaft-video",
     "io.github.shafthq:shaft-visual",
@@ -83,6 +89,20 @@ def seed_project_artifact(repository: Path, jar: Path, version: str) -> int:
     shutil.copy2(jar, engine_destination / f"shaft-engine-{version}.jar")
     shutil.copy2(ENGINE_POM, engine_destination / f"shaft-engine-{version}.pom")
     seed_pom(repository, "shaft-bom", BOM_POM, version)
+    pilot_core_destination = repository / "io" / "github" / "shafthq" / "shaft-pilot-core" / version
+    pilot_core_destination.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(PILOT_CORE_POM, pilot_core_destination / f"shaft-pilot-core-{version}.pom")
+    shutil.copy2(
+        PILOT_CORE_ROOT / "target" / f"shaft-pilot-core-{version}.jar",
+        pilot_core_destination / f"shaft-pilot-core-{version}.jar",
+    )
+    ai_destination = repository / "io" / "github" / "shafthq" / "shaft-ai" / version
+    ai_destination.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(AI_POM, ai_destination / f"shaft-ai-{version}.pom")
+    shutil.copy2(
+        AI_ROOT / "target" / f"shaft-ai-{version}.jar",
+        ai_destination / f"shaft-ai-{version}.jar",
+    )
     browserstack_destination = repository / "io" / "github" / "shafthq" / "shaft-browserstack" / version
     browserstack_destination.mkdir(parents=True, exist_ok=True)
     shutil.copy2(BROWSERSTACK_POM, browserstack_destination / f"shaft-browserstack-{version}.pom")

--- a/scripts/ci/validate_maven_publication.py
+++ b/scripts/ci/validate_maven_publication.py
@@ -14,6 +14,8 @@ NS = {"m": "http://maven.apache.org/POM/4.0.0"}
 PUBLIC_ARTIFACTS = {
     "shaft-parent": (Path("pom.xml"), "pom"),
     "shaft-engine": (Path("shaft-engine/pom.xml"), "jar"),
+    "shaft-pilot-core": (Path("shaft-pilot-core/pom.xml"), "jar"),
+    "shaft-ai": (Path("shaft-ai/pom.xml"), "jar"),
     "shaft-browserstack": (Path("shaft-browserstack/pom.xml"), "jar"),
     "shaft-video": (Path("shaft-video/pom.xml"), "jar"),
     "shaft-visual": (Path("shaft-visual/pom.xml"), "jar"),

--- a/scripts/ci/validate_modular_documentation.py
+++ b/scripts/ci/validate_modular_documentation.py
@@ -117,6 +117,25 @@ def main() -> None:
         for term in required_terms:
             if term not in contents:
                 fail(f"{filename}: missing dependency-boundary term {term!r}")
+    pilot_doc = (ROOT / "docs/SHAFT_PILOT_AI.md").read_text(encoding="utf-8")
+    for term in (
+        "pilot.ai.enabled=false",
+        "pilot.ai.provider=none",
+        "shaft-pilot-core",
+        "shaft-ai",
+        "deterministicFallback",
+        "GitHub/Microsoft",
+        "MCP",
+    ):
+        if term not in pilot_doc:
+            fail(f"SHAFT_PILOT_AI.md: missing security or dependency term {term!r}")
+    mcp_fixtures = ROOT / "docs/examples/shaft-pilot/mcp"
+    for fixture in ("codex-config.toml", "claude-desktop.json", "gemini-settings.json", "vscode-mcp.json"):
+        contents = (mcp_fixtures / fixture).read_text(encoding="utf-8")
+        if "SHAFT_MCP-<version>.jar" not in contents:
+            fail(f"{fixture}: missing versioned SHAFT MCP command")
+        if "API_KEY" in contents or "apiKey" in contents:
+            fail(f"{fixture}: MCP client fixture must not request a provider API key")
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     if "maven-central/v/io.github.shafthq/SHAFT_ENGINE" in readme:
         fail("README Maven Central badge still targets the legacy coordinate")

--- a/scripts/ci/validate_quality_configuration.py
+++ b/scripts/ci/validate_quality_configuration.py
@@ -9,10 +9,15 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 NS = {"m": "http://maven.apache.org/POM/4.0.0"}
-JAVA_MODULES = {"shaft-engine", "shaft-browserstack", "shaft-video", "shaft-visual", "SHAFT_MCP"}
+JAVA_MODULES = {
+    "shaft-engine", "shaft-pilot-core", "shaft-ai", "shaft-browserstack",
+    "shaft-video", "shaft-visual", "SHAFT_MCP",
+}
 DEPENDABOT_DIRECTORIES = {
     "/",
     "/shaft-engine",
+    "/shaft-pilot-core",
+    "/shaft-ai",
     "/shaft-browserstack",
     "/shaft-video",
     "/shaft-visual",
@@ -99,7 +104,7 @@ def validate_quality_configuration(root: Path = ROOT) -> list[str]:
     codecov_count = (workflow_text + action_text).count("codecov/codecov-action@")
 
     codeql = (root / ".github" / "workflows" / "codeql-analysis.yml").read_text(encoding="utf-8")
-    selector = "-pl shaft-engine,shaft-browserstack,shaft-video,shaft-visual,shaft-mcp -am"
+    selector = "-pl shaft-engine,shaft-pilot-core,shaft-ai,shaft-browserstack,shaft-video,shaft-visual,shaft-mcp -am"
     if selector not in codeql:
         errors.append("CodeQL build must compile every Java-bearing module")
 
@@ -124,6 +129,8 @@ def validate_quality_configuration(root: Path = ROOT) -> list[str]:
     if "<artifactId>shaft-engine</artifactId>" not in visual_profile:
         errors.append("visual test runtime profile must exclude shaft-engine's transitive tree")
     for artifact in (
+        "io.github.shafthq:shaft-pilot-core",
+        "io.github.shafthq:shaft-ai",
         "com.browserstack:browserstack-java-sdk",
         "ws.schild:jave-*",
         "com.automation-remarks:video-recorder-*",

--- a/scripts/ci/validate_shaft_mcp_configuration.py
+++ b/scripts/ci/validate_shaft_mcp_configuration.py
@@ -99,6 +99,11 @@ def validate(root: Path = ROOT) -> list[str]:
     for workflow in ("shaft-mcp.yml", "publish-shaft-mcp.yml", "deploy-shaft-mcp.yml"):
         if not (root / ".github/workflows" / workflow).is_file():
             errors.append(f"missing root MCP workflow: {workflow}")
+    mcp_workflow = (root / ".github/workflows/shaft-mcp.yml").read_text(encoding="utf-8")
+    if "workflow_dispatch:" not in mcp_workflow or "cron: '00 1 * * *'" not in mcp_workflow:
+        errors.append("shaft-mcp workflow must run manually and once daily with local E2E workflows")
+    if "pull_request:" in mcp_workflow or "\n  push:" in mcp_workflow:
+        errors.append("shaft-mcp workflow must not run on pull_request or push")
 
     for dockerfile in (root / "shaft-mcp").glob("Dockerfile*"):
         content = dockerfile.read_text(encoding="utf-8")

--- a/scripts/ci/verify_maven_central_release.py
+++ b/scripts/ci/verify_maven_central_release.py
@@ -16,13 +16,17 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 GROUP_PATH = "io/github/shafthq"
 DEFAULT_REPOSITORY = "https://repo.maven.apache.org/maven2"
-JAR_ARTIFACTS = ("shaft-engine", "shaft-browserstack", "shaft-video", "shaft-visual", "SHAFT_MCP")
+JAR_ARTIFACTS = (
+    "shaft-engine", "shaft-pilot-core", "shaft-ai", "shaft-browserstack",
+    "shaft-video", "shaft-visual", "SHAFT_MCP",
+)
 POM_ARTIFACTS = ("shaft-parent", "shaft-bom", "SHAFT_ENGINE")
 FIXTURE_GOALS = {
     "api": "test-compile",
     "combined-modules": "verify",
     "legacy-coordinate": "test-compile",
     "mcp": "verify",
+    "pilot-core": "verify",
 }
 
 

--- a/shaft-ai/.gitignore
+++ b/shaft-ai/.gitignore
@@ -1,0 +1,1 @@
+/allure-results/

--- a/shaft-ai/pom.xml
+++ b/shaft-ai/pom.xml
@@ -1,0 +1,73 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.shafthq</groupId>
+        <artifactId>shaft-parent</artifactId>
+        <version>10.2.20260610</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>shaft-ai</artifactId>
+    <packaging>jar</packaging>
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>Optional direct AI-provider adapters for SHAFT Pilot.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>shaft-pilot-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.qameta.allure</groupId>
+            <artifactId>allure-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>com/**/*</include>
+                        <include>META-INF/services/*</include>
+                    </includes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.6</version>
+                <configuration>
+                    <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/shaft-ai/src/main/java/com/shaft/ai/provider/AbstractHttpAiProvider.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/provider/AbstractHttpAiProvider.java
@@ -1,0 +1,213 @@
+package com.shaft.ai.provider;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.shaft.pilot.ai.AiCapabilities;
+import com.shaft.pilot.ai.AiProvider;
+import com.shaft.pilot.ai.AiProviderAvailability;
+import com.shaft.pilot.ai.AiRequest;
+import com.shaft.pilot.ai.AiResponse;
+import com.shaft.pilot.ai.AiResponseStatus;
+import com.shaft.pilot.ai.AiUsage;
+import com.shaft.pilot.config.PilotConfiguration;
+import com.shaft.pilot.config.ProviderConfiguration;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Shared safe HTTP execution for direct providers.
+ */
+public abstract class AbstractHttpAiProvider implements AiProvider {
+    protected static final ObjectMapper JSON = new ObjectMapper();
+    private final HttpClient httpClient;
+    private final Function<String, String> environment;
+
+    /**
+     * Creates a provider using the JDK HTTP client and process environment.
+     */
+    protected AbstractHttpAiProvider() {
+        this(HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build(), System::getenv);
+    }
+
+    /**
+     * Creates a provider with injectable HTTP and credential resolution.
+     *
+     * @param httpClient HTTP client
+     * @param environment environment variable resolver
+     */
+    protected AbstractHttpAiProvider(HttpClient httpClient, Function<String, String> environment) {
+        this.httpClient = Objects.requireNonNull(httpClient, "httpClient");
+        this.environment = Objects.requireNonNull(environment, "environment");
+    }
+
+    /**
+     * Checks model and credential configuration without contacting the provider.
+     *
+     * @return availability
+     */
+    @Override
+    public AiProviderAvailability availability() {
+        ProviderConfiguration configuration;
+        try {
+            configuration = PilotConfiguration.current().provider(id());
+        } catch (RuntimeException exception) {
+            return AiProviderAvailability.unavailable("Provider configuration is invalid.");
+        }
+        if (configuration.model().isBlank()) {
+            return AiProviderAvailability.unavailable("Provider model is not configured.");
+        }
+        if (requiresCredential()) {
+            String key = environment.apply(configuration.apiKeyEnvironmentVariable());
+            if (key == null || key.isBlank()) {
+                return AiProviderAvailability.unavailable("Provider credential environment variable is not set.");
+            }
+        }
+        return AiProviderAvailability.ready();
+    }
+
+    /**
+     * Executes an approved and redacted HTTP request.
+     *
+     * @param request approved and redacted request
+     * @return normalized response
+     */
+    @Override
+    public AiResponse execute(AiRequest request) {
+        Instant started = Instant.now();
+        ProviderConfiguration configuration = PilotConfiguration.current().provider(id());
+        try {
+            ObjectNode payload = buildPayload(request, configuration);
+            HttpRequest.Builder builder = HttpRequest.newBuilder(endpoint(configuration))
+                    .timeout(request.timeout())
+                    .header("Accept", "application/json")
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(JSON.writeValueAsString(payload)));
+            headers(configuration).forEach(builder::header);
+            HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+            Duration duration = Duration.between(started, Instant.now());
+            AiResponseStatus failureStatus = status(response.statusCode());
+            if (failureStatus != null) {
+                return AiResponse.failure(failureStatus, id(), configuration.model(),
+                        safeHttpReason(failureStatus), duration, request.deterministicFallback());
+            }
+            JsonNode responseBody = JSON.readTree(response.body());
+            JsonNode structuredPayload = parseStructuredPayload(responseBody);
+            return AiResponse.success(id(), responseModel(responseBody, configuration), structuredPayload,
+                    duration, usage(responseBody), request.deterministicFallback());
+        } catch (java.net.http.HttpTimeoutException exception) {
+            return AiResponse.failure(AiResponseStatus.TIMEOUT, id(), configuration.model(),
+                    "Provider request timed out.", Duration.between(started, Instant.now()),
+                    request.deterministicFallback());
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            return AiResponse.failure(AiResponseStatus.ERROR, id(), configuration.model(),
+                    "Provider request was interrupted.", Duration.between(started, Instant.now()),
+                    request.deterministicFallback());
+        } catch (JsonProcessingException exception) {
+            return AiResponse.failure(AiResponseStatus.INVALID_RESPONSE, id(), configuration.model(),
+                    "Provider returned malformed JSON.", Duration.between(started, Instant.now()),
+                    request.deterministicFallback());
+        } catch (IOException exception) {
+            return AiResponse.failure(AiResponseStatus.PROVIDER_UNAVAILABLE, id(), configuration.model(),
+                    "Provider could not be reached.", Duration.between(started, Instant.now()),
+                    request.deterministicFallback());
+        } catch (RuntimeException exception) {
+            return AiResponse.failure(AiResponseStatus.INVALID_RESPONSE, id(), configuration.model(),
+                    "Provider response could not be normalized.", Duration.between(started, Instant.now()),
+                    request.deterministicFallback());
+        }
+    }
+
+    /**
+     * Returns provider capabilities.
+     *
+     * @return capabilities
+     */
+    @Override
+    public abstract AiCapabilities capabilities();
+
+    protected abstract ObjectNode buildPayload(AiRequest request, ProviderConfiguration configuration);
+
+    protected abstract JsonNode parseStructuredPayload(JsonNode response) throws JsonProcessingException;
+
+    protected URI endpoint(ProviderConfiguration configuration) {
+        return configuration.endpoint();
+    }
+
+    protected Map<String, String> headers(ProviderConfiguration configuration) {
+        return Map.of();
+    }
+
+    protected AiUsage usage(JsonNode response) {
+        return AiUsage.empty();
+    }
+
+    protected String responseModel(JsonNode response, ProviderConfiguration configuration) {
+        return response.path("model").asText(configuration.model());
+    }
+
+    protected boolean requiresCredential() {
+        return true;
+    }
+
+    protected String credential(ProviderConfiguration configuration) {
+        return environment.apply(configuration.apiKeyEnvironmentVariable());
+    }
+
+    protected static long outputTokenLimit(AiRequest request, PilotConfiguration configuration) {
+        long requested = request.budget().maxOutputTokens();
+        return requested <= 0 ? configuration.maxOutputTokens() : Math.min(requested, configuration.maxOutputTokens());
+    }
+
+    protected static String prompt(AiRequest request) {
+        StringBuilder prompt = new StringBuilder();
+        prompt.append("Purpose: ").append(request.purpose()).append('\n');
+        if (!request.text().isBlank()) {
+            prompt.append(request.text());
+        }
+        request.evidence().forEach(evidence -> prompt.append("\n\nEvidence ")
+                .append(evidence.id()).append(" [").append(evidence.category()).append("]:\n")
+                .append(evidence.content()));
+        return prompt.toString();
+    }
+
+    private static AiResponseStatus status(int statusCode) {
+        if (statusCode >= 200 && statusCode < 300) {
+            return null;
+        }
+        if (statusCode == 401 || statusCode == 403) {
+            return AiResponseStatus.AUTHENTICATION_FAILED;
+        }
+        if (statusCode == 408 || statusCode == 504) {
+            return AiResponseStatus.TIMEOUT;
+        }
+        if (statusCode == 429) {
+            return AiResponseStatus.RATE_LIMITED;
+        }
+        if (statusCode >= 500) {
+            return AiResponseStatus.PROVIDER_UNAVAILABLE;
+        }
+        return AiResponseStatus.ERROR;
+    }
+
+    private static String safeHttpReason(AiResponseStatus status) {
+        return switch (status) {
+            case AUTHENTICATION_FAILED -> "Provider authentication failed.";
+            case RATE_LIMITED -> "Provider rate limit was reached.";
+            case TIMEOUT -> "Provider request timed out.";
+            case PROVIDER_UNAVAILABLE -> "Provider is unavailable.";
+            default -> "Provider rejected the request.";
+        };
+    }
+}

--- a/shaft-ai/src/main/java/com/shaft/ai/provider/AnthropicProvider.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/provider/AnthropicProvider.java
@@ -1,0 +1,90 @@
+package com.shaft.ai.provider;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.shaft.pilot.ai.AiCapabilities;
+import com.shaft.pilot.ai.AiImage;
+import com.shaft.pilot.ai.AiRequest;
+import com.shaft.pilot.ai.AiUsage;
+import com.shaft.pilot.ai.ProcessingLocation;
+import com.shaft.pilot.config.PilotConfiguration;
+import com.shaft.pilot.config.ProviderConfiguration;
+
+import java.net.http.HttpClient;
+import java.util.Base64;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Direct Anthropic Messages API adapter.
+ */
+public final class AnthropicProvider extends AbstractHttpAiProvider {
+    /**
+     * Creates the service-loadable provider.
+     */
+    public AnthropicProvider() {
+        super();
+    }
+
+    AnthropicProvider(HttpClient client, Function<String, String> environment) {
+        super(client, environment);
+    }
+
+    @Override
+    public String id() {
+        return "anthropic";
+    }
+
+    @Override
+    public AiCapabilities capabilities() {
+        return new AiCapabilities(true, true, true, 0, ProcessingLocation.REMOTE);
+    }
+
+    @Override
+    protected ObjectNode buildPayload(AiRequest request, ProviderConfiguration configuration) {
+        ObjectNode root = JSON.createObjectNode();
+        root.put("model", configuration.model());
+        root.put("max_tokens", outputTokenLimit(request, PilotConfiguration.current()));
+        ArrayNode messages = root.putArray("messages");
+        ObjectNode message = messages.addObject();
+        message.put("role", "user");
+        ArrayNode content = message.putArray("content");
+        content.addObject().put("type", "text").put("text", prompt(request));
+        for (AiImage image : request.images()) {
+            ObjectNode source = content.addObject().put("type", "image").putObject("source");
+            source.put("type", "base64");
+            source.put("media_type", image.mediaType());
+            source.put("data", Base64.getEncoder().encodeToString(image.data()));
+        }
+        ObjectNode format = root.putObject("output_config").putObject("format");
+        format.put("type", "json_schema");
+        format.set("schema", request.desiredResponseSchema());
+        return root;
+    }
+
+    @Override
+    protected Map<String, String> headers(ProviderConfiguration configuration) {
+        return Map.of(
+                "x-api-key", credential(configuration),
+                "anthropic-version", configuration.option("api-version"));
+    }
+
+    @Override
+    protected JsonNode parseStructuredPayload(JsonNode response) throws JsonProcessingException {
+        for (JsonNode content : response.path("content")) {
+            if ("text".equals(content.path("type").asText())) {
+                return JSON.readTree(content.path("text").asText());
+            }
+        }
+        throw new JsonProcessingException("Missing content text") {
+        };
+    }
+
+    @Override
+    protected AiUsage usage(JsonNode response) {
+        JsonNode usage = response.path("usage");
+        return new AiUsage(usage.path("input_tokens").asLong(), usage.path("output_tokens").asLong(), null);
+    }
+}

--- a/shaft-ai/src/main/java/com/shaft/ai/provider/GeminiProvider.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/provider/GeminiProvider.java
@@ -1,0 +1,99 @@
+package com.shaft.ai.provider;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.shaft.pilot.ai.AiCapabilities;
+import com.shaft.pilot.ai.AiImage;
+import com.shaft.pilot.ai.AiRequest;
+import com.shaft.pilot.ai.AiUsage;
+import com.shaft.pilot.ai.ProcessingLocation;
+import com.shaft.pilot.config.PilotConfiguration;
+import com.shaft.pilot.config.ProviderConfiguration;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Direct Google Gemini generateContent adapter.
+ */
+public final class GeminiProvider extends AbstractHttpAiProvider {
+    /**
+     * Creates the service-loadable provider.
+     */
+    public GeminiProvider() {
+        super();
+    }
+
+    GeminiProvider(HttpClient client, Function<String, String> environment) {
+        super(client, environment);
+    }
+
+    @Override
+    public String id() {
+        return "gemini";
+    }
+
+    @Override
+    public AiCapabilities capabilities() {
+        return new AiCapabilities(true, true, true, 0, ProcessingLocation.REMOTE);
+    }
+
+    @Override
+    protected URI endpoint(ProviderConfiguration configuration) {
+        String base = configuration.endpoint().toString().replaceAll("/+$", "");
+        String model = URLEncoder.encode(configuration.model(), StandardCharsets.UTF_8);
+        return URI.create(base + "/" + model + ":generateContent");
+    }
+
+    @Override
+    protected ObjectNode buildPayload(AiRequest request, ProviderConfiguration configuration) {
+        ObjectNode root = JSON.createObjectNode();
+        ArrayNode parts = root.putArray("contents").addObject().putArray("parts");
+        parts.addObject().put("text", prompt(request));
+        for (AiImage image : request.images()) {
+            ObjectNode inlineData = parts.addObject().putObject("inlineData");
+            inlineData.put("mimeType", image.mediaType());
+            inlineData.put("data", Base64.getEncoder().encodeToString(image.data()));
+        }
+        ObjectNode generationConfig = root.putObject("generationConfig");
+        generationConfig.put("maxOutputTokens", outputTokenLimit(request, PilotConfiguration.current()));
+        ObjectNode text = generationConfig.putObject("responseFormat").putObject("text");
+        text.put("mimeType", "application/json");
+        text.set("schema", request.desiredResponseSchema());
+        return root;
+    }
+
+    @Override
+    protected Map<String, String> headers(ProviderConfiguration configuration) {
+        return Map.of("x-goog-api-key", credential(configuration));
+    }
+
+    @Override
+    protected JsonNode parseStructuredPayload(JsonNode response) throws JsonProcessingException {
+        JsonNode text = response.path("candidates").path(0).path("content").path("parts").path(0).path("text");
+        if (!text.isTextual()) {
+            throw new JsonProcessingException("Missing candidate text") {
+            };
+        }
+        return JSON.readTree(text.asText());
+    }
+
+    @Override
+    protected AiUsage usage(JsonNode response) {
+        JsonNode usage = response.path("usageMetadata");
+        return new AiUsage(usage.path("promptTokenCount").asLong(),
+                usage.path("candidatesTokenCount").asLong(), null);
+    }
+
+    @Override
+    protected String responseModel(JsonNode response, ProviderConfiguration configuration) {
+        return response.path("modelVersion").asText(configuration.model());
+    }
+}

--- a/shaft-ai/src/main/java/com/shaft/ai/provider/OllamaProvider.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/provider/OllamaProvider.java
@@ -1,0 +1,84 @@
+package com.shaft.ai.provider;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.shaft.pilot.ai.AiCapabilities;
+import com.shaft.pilot.ai.AiImage;
+import com.shaft.pilot.ai.AiRequest;
+import com.shaft.pilot.ai.AiUsage;
+import com.shaft.pilot.ai.ProcessingLocation;
+import com.shaft.pilot.config.PilotConfiguration;
+import com.shaft.pilot.config.ProviderConfiguration;
+
+import java.net.http.HttpClient;
+import java.util.Base64;
+import java.util.function.Function;
+
+/**
+ * Direct local Ollama chat adapter.
+ */
+public final class OllamaProvider extends AbstractHttpAiProvider {
+    /**
+     * Creates the service-loadable provider.
+     */
+    public OllamaProvider() {
+        super();
+    }
+
+    OllamaProvider(HttpClient client, Function<String, String> environment) {
+        super(client, environment);
+    }
+
+    @Override
+    public String id() {
+        return "ollama";
+    }
+
+    @Override
+    public AiCapabilities capabilities() {
+        return new AiCapabilities(true, true, true, 0, ProcessingLocation.LOCAL);
+    }
+
+    @Override
+    protected boolean requiresCredential() {
+        return false;
+    }
+
+    @Override
+    protected ObjectNode buildPayload(AiRequest request, ProviderConfiguration configuration) {
+        ObjectNode root = JSON.createObjectNode();
+        root.put("model", configuration.model());
+        root.put("stream", false);
+        root.set("format", request.desiredResponseSchema());
+        ObjectNode message = root.putArray("messages").addObject();
+        message.put("role", "user");
+        message.put("content", prompt(request));
+        if (!request.images().isEmpty()) {
+            ArrayNode images = message.putArray("images");
+            for (AiImage image : request.images()) {
+                images.add(Base64.getEncoder().encodeToString(image.data()));
+            }
+        }
+        root.putObject("options").put("num_predict",
+                outputTokenLimit(request, PilotConfiguration.current()));
+        return root;
+    }
+
+    @Override
+    protected JsonNode parseStructuredPayload(JsonNode response) throws JsonProcessingException {
+        JsonNode text = response.path("message").path("content");
+        if (!text.isTextual()) {
+            throw new JsonProcessingException("Missing message content") {
+            };
+        }
+        return JSON.readTree(text.asText());
+    }
+
+    @Override
+    protected AiUsage usage(JsonNode response) {
+        return new AiUsage(response.path("prompt_eval_count").asLong(),
+                response.path("eval_count").asLong(), null);
+    }
+}

--- a/shaft-ai/src/main/java/com/shaft/ai/provider/OpenAiProvider.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/provider/OpenAiProvider.java
@@ -1,0 +1,93 @@
+package com.shaft.ai.provider;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.shaft.pilot.ai.AiCapabilities;
+import com.shaft.pilot.ai.AiImage;
+import com.shaft.pilot.ai.AiRequest;
+import com.shaft.pilot.ai.AiUsage;
+import com.shaft.pilot.ai.ProcessingLocation;
+import com.shaft.pilot.config.PilotConfiguration;
+import com.shaft.pilot.config.ProviderConfiguration;
+
+import java.net.http.HttpClient;
+import java.util.Base64;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Direct OpenAI Responses API adapter.
+ */
+public final class OpenAiProvider extends AbstractHttpAiProvider {
+    /**
+     * Creates the service-loadable provider.
+     */
+    public OpenAiProvider() {
+        super();
+    }
+
+    OpenAiProvider(HttpClient client, Function<String, String> environment) {
+        super(client, environment);
+    }
+
+    @Override
+    public String id() {
+        return "openai";
+    }
+
+    @Override
+    public AiCapabilities capabilities() {
+        return new AiCapabilities(true, true, true, 0, ProcessingLocation.REMOTE);
+    }
+
+    @Override
+    protected ObjectNode buildPayload(AiRequest request, ProviderConfiguration configuration) {
+        ObjectNode root = JSON.createObjectNode();
+        root.put("model", configuration.model());
+        root.put("store", false);
+        root.put("max_output_tokens", outputTokenLimit(request, PilotConfiguration.current()));
+        ArrayNode input = root.putArray("input");
+        ObjectNode message = input.addObject();
+        message.put("role", "user");
+        ArrayNode content = message.putArray("content");
+        content.addObject().put("type", "input_text").put("text", prompt(request));
+        for (AiImage image : request.images()) {
+            content.addObject()
+                    .put("type", "input_image")
+                    .put("image_url", "data:" + image.mediaType() + ";base64,"
+                            + Base64.getEncoder().encodeToString(image.data()));
+        }
+        ObjectNode format = root.putObject("text").putObject("format");
+        format.put("type", "json_schema");
+        format.put("name", "shaft_pilot_response");
+        format.put("strict", true);
+        format.set("schema", request.desiredResponseSchema());
+        return root;
+    }
+
+    @Override
+    protected Map<String, String> headers(ProviderConfiguration configuration) {
+        return Map.of("Authorization", "Bearer " + credential(configuration));
+    }
+
+    @Override
+    protected JsonNode parseStructuredPayload(JsonNode response) throws JsonProcessingException {
+        for (JsonNode output : response.path("output")) {
+            for (JsonNode content : output.path("content")) {
+                if ("output_text".equals(content.path("type").asText())) {
+                    return JSON.readTree(content.path("text").asText());
+                }
+            }
+        }
+        throw new JsonProcessingException("Missing output text") {
+        };
+    }
+
+    @Override
+    protected AiUsage usage(JsonNode response) {
+        JsonNode usage = response.path("usage");
+        return new AiUsage(usage.path("input_tokens").asLong(), usage.path("output_tokens").asLong(), null);
+    }
+}

--- a/shaft-ai/src/main/resources/META-INF/services/com.shaft.pilot.ai.AiProvider
+++ b/shaft-ai/src/main/resources/META-INF/services/com.shaft.pilot.ai.AiProvider
@@ -1,0 +1,4 @@
+com.shaft.ai.provider.AnthropicProvider
+com.shaft.ai.provider.GeminiProvider
+com.shaft.ai.provider.OllamaProvider
+com.shaft.ai.provider.OpenAiProvider

--- a/shaft-ai/src/test/java/com/shaft/ai/provider/ProviderConformanceTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/provider/ProviderConformanceTest.java
@@ -1,0 +1,234 @@
+package com.shaft.ai.provider;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import com.shaft.driver.SHAFT;
+import com.shaft.pilot.ai.AiBudget;
+import com.shaft.pilot.ai.AiExecutionService;
+import com.shaft.pilot.ai.AiProvider;
+import com.shaft.pilot.ai.AiProviderRegistry;
+import com.shaft.pilot.ai.AiRequest;
+import com.shaft.pilot.ai.AiResponse;
+import com.shaft.pilot.ai.AiResponseStatus;
+import com.shaft.pilot.ai.ApprovalPolicy;
+import com.shaft.pilot.ai.EvidenceCategory;
+import com.shaft.pilot.ai.ProcessingLocation;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.EnumSet;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ProviderConformanceTest {
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private HttpServer server;
+
+    @AfterEach
+    void cleanup() {
+        if (server != null) {
+            server.stop(0);
+        }
+        SHAFT.Properties.clearForCurrentThread();
+    }
+
+    @ParameterizedTest(name = "{0} returns the same structured contract")
+    @MethodSource("providerIds")
+    void allProvidersPassStructuredMockConformance(String providerId) throws Exception {
+        AtomicReference<String> capturedBody = new AtomicReference<>("");
+        server = server(exchange -> {
+            capturedBody.set(readBody(exchange));
+            respond(exchange, 200, successfulResponse(providerId, "{\"answer\":\"ok\"}"));
+        });
+        configure(providerId, server.getAddress().getPort());
+        AiResponse response = execute(providerId, request(providerId, Duration.ofSeconds(1)));
+
+        assertEquals(AiResponseStatus.SUCCESS, response.status());
+        assertEquals("ok", response.structuredPayload().path("answer").asText());
+        assertFalse(capturedBody.get().contains("do-not-transmit"));
+        assertTrue(capturedBody.get().contains("[REDACTED]"));
+        assertTrue(capturedBody.get().contains("answer"));
+    }
+
+    @ParameterizedTest(name = "{0} normalizes {1}")
+    @MethodSource("providerFailures")
+    void allProvidersNormalizeFailures(String providerId, FailureCase failureCase,
+                                       AiResponseStatus expectedStatus) throws Exception {
+        server = server(exchange -> {
+            if (failureCase == FailureCase.TIMEOUT) {
+                try {
+                    Thread.sleep(200);
+                } catch (InterruptedException exception) {
+                    Thread.currentThread().interrupt();
+                }
+                respondQuietly(exchange, 200, successfulResponse(providerId, "{\"answer\":\"late\"}"));
+            } else if (failureCase == FailureCase.MALFORMED_JSON) {
+                respond(exchange, 200, "{not-json");
+            } else if (failureCase == FailureCase.SCHEMA_VIOLATION) {
+                respond(exchange, 200, successfulResponse(providerId, "{\"wrong\":true}"));
+            } else if (failureCase == FailureCase.RATE_LIMIT) {
+                respond(exchange, 429, "{}");
+            } else {
+                respond(exchange, 401, "{}");
+            }
+        });
+        configure(providerId, server.getAddress().getPort());
+        Duration timeout = failureCase == FailureCase.TIMEOUT ? Duration.ofMillis(50) : Duration.ofSeconds(1);
+
+        AiResponse response = execute(providerId, request(providerId, timeout));
+
+        assertEquals(expectedStatus, response.status());
+        assertEquals("deterministic", response.structuredPayload().path("answer").asText());
+        assertFalse(response.fallbackReason().contains("do-not-transmit"));
+        assertFalse(response.fallbackReason().contains("test-credential"));
+    }
+
+    @Test
+    void serviceLoaderDiscoversAllDirectProviders() {
+        var ids = new AiProviderRegistry().serviceProviders().stream().map(AiProvider::id).toList();
+
+        assertEquals(java.util.List.of("anthropic", "gemini", "ollama", "openai"), ids);
+    }
+
+    private AiResponse execute(String providerId, AiRequest request) {
+        AiProviderRegistry registry = new AiProviderRegistry();
+        registry.registerForCurrentThread(provider(providerId));
+        try {
+            return new AiExecutionService(registry, com.shaft.pilot.config.PilotConfiguration::current,
+                    event -> {
+                    }).execute(request);
+        } finally {
+            registry.clearForCurrentThread();
+        }
+    }
+
+    private static AiProvider provider(String providerId) {
+        HttpClient client = HttpClient.newBuilder().build();
+        return switch (providerId) {
+            case "openai" -> new OpenAiProvider(client, ignored -> "test-credential");
+            case "anthropic" -> new AnthropicProvider(client, ignored -> "test-credential");
+            case "gemini" -> new GeminiProvider(client, ignored -> "test-credential");
+            case "ollama" -> new OllamaProvider(client, ignored -> "");
+            default -> throw new IllegalArgumentException("Unknown provider: " + providerId);
+        };
+    }
+
+    private static AiRequest request(String providerId, Duration timeout) {
+        JsonNode schema = JSON.createObjectNode()
+                .put("type", "object")
+                .set("properties", JSON.createObjectNode()
+                        .set("answer", JSON.createObjectNode().put("type", "string")));
+        ((com.fasterxml.jackson.databind.node.ObjectNode) schema).putArray("required").add("answer");
+        boolean local = "ollama".equals(providerId);
+        ApprovalPolicy approval = new ApprovalPolicy(local, !local, EnumSet.allOf(EvidenceCategory.class));
+        return AiRequest.builder("provider-conformance", schema)
+                .text("Authorization: Bearer do-not-transmit")
+                .budget(new AiBudget(1_000, 100, java.math.BigDecimal.ONE))
+                .approvalPolicy(approval)
+                .timeout(timeout)
+                .deterministicFallback(JSON.createObjectNode().put("answer", "deterministic"))
+                .build();
+    }
+
+    private static void configure(String providerId, int port) {
+        boolean local = "ollama".equals(providerId);
+        var properties = SHAFT.Properties.pilot.set()
+                .enabled(true)
+                .provider(providerId)
+                .localConsent(local)
+                .remoteConsent(!local)
+                .allowedEvidenceCategories("TEXT")
+                .retryMaxAttempts(1)
+                .timeoutSeconds(1);
+        String base = "http://127.0.0.1:" + port;
+        switch (providerId) {
+            case "openai" -> properties.openAiEndpoint(base + "/responses").openAiModel("test-model");
+            case "anthropic" -> properties.anthropicEndpoint(base + "/messages").anthropicModel("test-model");
+            case "gemini" -> properties.geminiEndpoint(base + "/v1beta/models").geminiModel("test-model");
+            case "ollama" -> properties.ollamaEndpoint(base + "/api/chat").ollamaModel("test-model");
+            default -> throw new IllegalArgumentException("Unknown provider: " + providerId);
+        }
+    }
+
+    private static Stream<String> providerIds() {
+        return Stream.of("openai", "anthropic", "gemini", "ollama");
+    }
+
+    private static Stream<Arguments> providerFailures() {
+        return providerIds().flatMap(providerId -> Stream.of(
+                Arguments.of(providerId, FailureCase.AUTHENTICATION, AiResponseStatus.AUTHENTICATION_FAILED),
+                Arguments.of(providerId, FailureCase.RATE_LIMIT, AiResponseStatus.RATE_LIMITED),
+                Arguments.of(providerId, FailureCase.TIMEOUT, AiResponseStatus.TIMEOUT),
+                Arguments.of(providerId, FailureCase.MALFORMED_JSON, AiResponseStatus.INVALID_RESPONSE),
+                Arguments.of(providerId, FailureCase.SCHEMA_VIOLATION, AiResponseStatus.INVALID_RESPONSE)));
+    }
+
+    private static HttpServer server(ExchangeHandler handler) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", exchange -> handler.handle(exchange));
+        server.start();
+        return server;
+    }
+
+    private static String successfulResponse(String providerId, String payload) {
+        String escaped = payload.replace("\\", "\\\\").replace("\"", "\\\"");
+        return switch (providerId) {
+            case "openai" -> "{\"model\":\"test-model\",\"output\":[{\"content\":[{\"type\":\"output_text\","
+                    + "\"text\":\"" + escaped + "\"}]}],\"usage\":{\"input_tokens\":3,\"output_tokens\":2}}";
+            case "anthropic" -> "{\"model\":\"test-model\",\"content\":[{\"type\":\"text\",\"text\":\""
+                    + escaped + "\"}],\"usage\":{\"input_tokens\":3,\"output_tokens\":2}}";
+            case "gemini" -> "{\"modelVersion\":\"test-model\",\"candidates\":[{\"content\":{\"parts\":[{\"text\":\""
+                    + escaped + "\"}]}}],\"usageMetadata\":{\"promptTokenCount\":3,\"candidatesTokenCount\":2}}";
+            case "ollama" -> "{\"model\":\"test-model\",\"message\":{\"role\":\"assistant\",\"content\":\""
+                    + escaped + "\"},\"prompt_eval_count\":3,\"eval_count\":2}";
+            default -> throw new IllegalArgumentException("Unknown provider: " + providerId);
+        };
+    }
+
+    private static String readBody(HttpExchange exchange) throws IOException {
+        return new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        exchange.getResponseBody().write(bytes);
+        exchange.close();
+    }
+
+    private static void respondQuietly(HttpExchange exchange, int status, String body) {
+        try {
+            respond(exchange, status, body);
+        } catch (IOException ignored) {
+            exchange.close();
+        }
+    }
+
+    @FunctionalInterface
+    private interface ExchangeHandler {
+        void handle(HttpExchange exchange) throws IOException;
+    }
+
+    private enum FailureCase {
+        AUTHENTICATION,
+        RATE_LIMIT,
+        TIMEOUT,
+        MALFORMED_JSON,
+        SCHEMA_VIOLATION
+    }
+}

--- a/shaft-bom/pom.xml
+++ b/shaft-bom/pom.xml
@@ -22,6 +22,16 @@
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
+                <artifactId>shaft-pilot-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>shaft-ai</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>shaft-browserstack</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/shaft-engine/pom.xml
+++ b/shaft-engine/pom.xml
@@ -667,8 +667,10 @@
                             <rules>
                                 <bannedDependencies>
                                     <searchTransitive>true</searchTransitive>
-                                    <message>Optional BrowserStack, desktop-video, and visual-processing dependencies must remain outside shaft-engine.</message>
+                                    <message>Optional BrowserStack, desktop-video, visual-processing, Pilot, and AI dependencies must remain outside shaft-engine.</message>
                                     <excludes>
+                                        <exclude>io.github.shafthq:shaft-pilot-core</exclude>
+                                        <exclude>io.github.shafthq:shaft-ai</exclude>
                                         <exclude>com.browserstack:browserstack-java-sdk</exclude>
                                         <exclude>ws.schild:jave-*</exclude>
                                         <exclude>com.automation-remarks:video-recorder-*</exclude>

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Pilot.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Pilot.java
@@ -1,0 +1,369 @@
+package com.shaft.properties.internal;
+
+import com.shaft.tools.io.ReportManager;
+import org.aeonbits.owner.Config.Sources;
+import org.aeonbits.owner.ConfigFactory;
+
+/**
+ * Configuration for optional SHAFT Pilot AI providers.
+ *
+ * <p>AI is disabled by default. Credentials are never configured here; providers
+ * resolve them from the named environment variables only after the caller has
+ * explicitly enabled AI and approved the relevant processing location.</p>
+ */
+@SuppressWarnings("unused")
+@Sources({"system:properties",
+        "file:src/main/resources/properties/custom.properties",
+        "file:src/main/resources/properties/default/custom.properties",
+        "classpath:custom.properties"})
+public interface Pilot extends EngineProperties<Pilot> {
+    private static void setProperty(String key, String value) {
+        ThreadLocalPropertiesManager.setProperty(key, value);
+        Properties.pilotOverride.set(ConfigFactory.create(Pilot.class, ThreadLocalPropertiesManager.getOverrides()));
+        ReportManager.logDiscrete("Setting \"" + key + "\" property with \"" + value + "\".");
+    }
+
+    /** @return whether optional AI execution is enabled */
+    @Key("pilot.ai.enabled")
+    @DefaultValue("false")
+    boolean enabled();
+
+    /** @return selected provider identifier */
+    @Key("pilot.ai.provider")
+    @DefaultValue("none")
+    String provider();
+
+    /** @return whether local inference is approved */
+    @Key("pilot.ai.consent.local")
+    @DefaultValue("false")
+    boolean localConsent();
+
+    /** @return whether remote inference is approved */
+    @Key("pilot.ai.consent.remote")
+    @DefaultValue("false")
+    boolean remoteConsent();
+
+    /** @return comma-separated approved evidence categories */
+    @Key("pilot.ai.allowedEvidenceCategories")
+    @DefaultValue("")
+    String allowedEvidenceCategories();
+
+    /** @return whether optional external telemetry is enabled */
+    @Key("pilot.ai.telemetry.enabled")
+    @DefaultValue("false")
+    boolean telemetryEnabled();
+
+    /** @return maximum provider timeout in seconds */
+    @Key("pilot.ai.timeoutSeconds")
+    @DefaultValue("30")
+    int timeoutSeconds();
+
+    /** @return maximum serialized request size */
+    @Key("pilot.ai.maxRequestBytes")
+    @DefaultValue("1048576")
+    int maxRequestBytes();
+
+    /** @return maximum estimated input tokens */
+    @Key("pilot.ai.maxInputTokens")
+    @DefaultValue("16000")
+    int maxInputTokens();
+
+    /** @return maximum output tokens */
+    @Key("pilot.ai.maxOutputTokens")
+    @DefaultValue("2000")
+    int maxOutputTokens();
+
+    /** @return maximum accepted provider-reported cost in USD */
+    @Key("pilot.ai.maxCostUsd")
+    @DefaultValue("0")
+    String maxCostUsd();
+
+    /** @return maximum provider execution attempts */
+    @Key("pilot.ai.retryMaxAttempts")
+    @DefaultValue("2")
+    int retryMaxAttempts();
+
+    /** @return maximum concurrent calls per provider */
+    @Key("pilot.ai.maxConcurrency")
+    @DefaultValue("2")
+    int maxConcurrency();
+
+    /** @return failures required to open the circuit */
+    @Key("pilot.ai.circuitBreaker.failureThreshold")
+    @DefaultValue("3")
+    int circuitBreakerFailureThreshold();
+
+    /** @return circuit-open cooldown in seconds */
+    @Key("pilot.ai.circuitBreaker.cooldownSeconds")
+    @DefaultValue("60")
+    int circuitBreakerCooldownSeconds();
+
+    /** @return comma-separated CSS selectors to redact */
+    @Key("pilot.ai.redaction.selectors")
+    @DefaultValue("input[type=password],[autocomplete=current-password],[autocomplete=new-password]")
+    String redactionSelectors();
+
+    /** @return comma-separated structured or DOM attributes to redact */
+    @Key("pilot.ai.redaction.attributes")
+    @DefaultValue("authorization,cookie,set-cookie,password,passwd,secret,token,api-key,apikey,access-key")
+    String redactionAttributes();
+
+    /** @return double-semicolon-separated custom regular expressions */
+    @Key("pilot.ai.redaction.patterns")
+    @DefaultValue("")
+    String redactionPatterns();
+
+    /** @return OpenAI Responses endpoint */
+    @Key("pilot.ai.openai.endpoint")
+    @DefaultValue("https://api.openai.com/v1/responses")
+    String openAiEndpoint();
+
+    /** @return configured OpenAI model */
+    @Key("pilot.ai.openai.model")
+    @DefaultValue("")
+    String openAiModel();
+
+    /** @return environment variable containing the OpenAI credential */
+    @Key("pilot.ai.openai.apiKeyEnvironmentVariable")
+    @DefaultValue("OPENAI_API_KEY")
+    String openAiApiKeyEnvironmentVariable();
+
+    /** @return Anthropic Messages endpoint */
+    @Key("pilot.ai.anthropic.endpoint")
+    @DefaultValue("https://api.anthropic.com/v1/messages")
+    String anthropicEndpoint();
+
+    /** @return configured Anthropic model */
+    @Key("pilot.ai.anthropic.model")
+    @DefaultValue("")
+    String anthropicModel();
+
+    /** @return environment variable containing the Anthropic credential */
+    @Key("pilot.ai.anthropic.apiKeyEnvironmentVariable")
+    @DefaultValue("ANTHROPIC_API_KEY")
+    String anthropicApiKeyEnvironmentVariable();
+
+    /** @return Anthropic API contract version */
+    @Key("pilot.ai.anthropic.version")
+    @DefaultValue("2023-06-01")
+    String anthropicVersion();
+
+    /** @return Gemini models endpoint */
+    @Key("pilot.ai.gemini.endpoint")
+    @DefaultValue("https://generativelanguage.googleapis.com/v1beta/models")
+    String geminiEndpoint();
+
+    /** @return configured Gemini model */
+    @Key("pilot.ai.gemini.model")
+    @DefaultValue("")
+    String geminiModel();
+
+    /** @return environment variable containing the Gemini credential */
+    @Key("pilot.ai.gemini.apiKeyEnvironmentVariable")
+    @DefaultValue("GEMINI_API_KEY")
+    String geminiApiKeyEnvironmentVariable();
+
+    /** @return Ollama chat endpoint */
+    @Key("pilot.ai.ollama.endpoint")
+    @DefaultValue("http://127.0.0.1:11434/api/chat")
+    String ollamaEndpoint();
+
+    /** @return configured Ollama model */
+    @Key("pilot.ai.ollama.model")
+    @DefaultValue("")
+    String ollamaModel();
+
+    /**
+     * Returns a fluent builder for current-thread overrides.
+     *
+     * @return current-thread property builder
+     */
+    default SetProperty set() {
+        return new SetProperty();
+    }
+
+    /**
+     * Fluent current-thread overrides for Pilot configuration.
+     */
+    class SetProperty implements EngineProperties.SetProperty {
+        /** @param value enabled state @return this builder */
+        public SetProperty enabled(boolean value) {
+            setProperty("pilot.ai.enabled", String.valueOf(value));
+            return this;
+        }
+
+        /** @param value provider identifier @return this builder */
+        public SetProperty provider(String value) {
+            setProperty("pilot.ai.provider", value);
+            return this;
+        }
+
+        /** @param value local consent state @return this builder */
+        public SetProperty localConsent(boolean value) {
+            setProperty("pilot.ai.consent.local", String.valueOf(value));
+            return this;
+        }
+
+        /** @param value remote consent state @return this builder */
+        public SetProperty remoteConsent(boolean value) {
+            setProperty("pilot.ai.consent.remote", String.valueOf(value));
+            return this;
+        }
+
+        /** @param value approved category list @return this builder */
+        public SetProperty allowedEvidenceCategories(String value) {
+            setProperty("pilot.ai.allowedEvidenceCategories", value);
+            return this;
+        }
+
+        /** @param value telemetry state @return this builder */
+        public SetProperty telemetryEnabled(boolean value) {
+            setProperty("pilot.ai.telemetry.enabled", String.valueOf(value));
+            return this;
+        }
+
+        /** @param value timeout seconds @return this builder */
+        public SetProperty timeoutSeconds(int value) {
+            setProperty("pilot.ai.timeoutSeconds", String.valueOf(value));
+            return this;
+        }
+
+        /** @param value maximum request bytes @return this builder */
+        public SetProperty maxRequestBytes(int value) {
+            setProperty("pilot.ai.maxRequestBytes", String.valueOf(value));
+            return this;
+        }
+
+        /** @param value maximum input tokens @return this builder */
+        public SetProperty maxInputTokens(int value) {
+            setProperty("pilot.ai.maxInputTokens", String.valueOf(value));
+            return this;
+        }
+
+        /** @param value maximum output tokens @return this builder */
+        public SetProperty maxOutputTokens(int value) {
+            setProperty("pilot.ai.maxOutputTokens", String.valueOf(value));
+            return this;
+        }
+
+        /** @param value maximum cost in USD @return this builder */
+        public SetProperty maxCostUsd(String value) {
+            setProperty("pilot.ai.maxCostUsd", value);
+            return this;
+        }
+
+        /** @param value maximum attempts @return this builder */
+        public SetProperty retryMaxAttempts(int value) {
+            setProperty("pilot.ai.retryMaxAttempts", String.valueOf(value));
+            return this;
+        }
+
+        /** @param value maximum concurrency @return this builder */
+        public SetProperty maxConcurrency(int value) {
+            setProperty("pilot.ai.maxConcurrency", String.valueOf(value));
+            return this;
+        }
+
+        /** @param value failure threshold @return this builder */
+        public SetProperty circuitBreakerFailureThreshold(int value) {
+            setProperty("pilot.ai.circuitBreaker.failureThreshold", String.valueOf(value));
+            return this;
+        }
+
+        /** @param value cooldown seconds @return this builder */
+        public SetProperty circuitBreakerCooldownSeconds(int value) {
+            setProperty("pilot.ai.circuitBreaker.cooldownSeconds", String.valueOf(value));
+            return this;
+        }
+
+        /** @param value selector list @return this builder */
+        public SetProperty redactionSelectors(String value) {
+            setProperty("pilot.ai.redaction.selectors", value);
+            return this;
+        }
+
+        /** @param value attribute list @return this builder */
+        public SetProperty redactionAttributes(String value) {
+            setProperty("pilot.ai.redaction.attributes", value);
+            return this;
+        }
+
+        /** @param value custom pattern list @return this builder */
+        public SetProperty redactionPatterns(String value) {
+            setProperty("pilot.ai.redaction.patterns", value);
+            return this;
+        }
+
+        /** @param value endpoint URL @return this builder */
+        public SetProperty openAiEndpoint(String value) {
+            setProperty("pilot.ai.openai.endpoint", value);
+            return this;
+        }
+
+        /** @param value model identifier @return this builder */
+        public SetProperty openAiModel(String value) {
+            setProperty("pilot.ai.openai.model", value);
+            return this;
+        }
+
+        /** @param value environment variable name @return this builder */
+        public SetProperty openAiApiKeyEnvironmentVariable(String value) {
+            setProperty("pilot.ai.openai.apiKeyEnvironmentVariable", value);
+            return this;
+        }
+
+        /** @param value endpoint URL @return this builder */
+        public SetProperty anthropicEndpoint(String value) {
+            setProperty("pilot.ai.anthropic.endpoint", value);
+            return this;
+        }
+
+        /** @param value model identifier @return this builder */
+        public SetProperty anthropicModel(String value) {
+            setProperty("pilot.ai.anthropic.model", value);
+            return this;
+        }
+
+        /** @param value environment variable name @return this builder */
+        public SetProperty anthropicApiKeyEnvironmentVariable(String value) {
+            setProperty("pilot.ai.anthropic.apiKeyEnvironmentVariable", value);
+            return this;
+        }
+
+        /** @param value Anthropic API contract version @return this builder */
+        public SetProperty anthropicVersion(String value) {
+            setProperty("pilot.ai.anthropic.version", value);
+            return this;
+        }
+
+        /** @param value base endpoint URL @return this builder */
+        public SetProperty geminiEndpoint(String value) {
+            setProperty("pilot.ai.gemini.endpoint", value);
+            return this;
+        }
+
+        /** @param value model identifier @return this builder */
+        public SetProperty geminiModel(String value) {
+            setProperty("pilot.ai.gemini.model", value);
+            return this;
+        }
+
+        /** @param value environment variable name @return this builder */
+        public SetProperty geminiApiKeyEnvironmentVariable(String value) {
+            setProperty("pilot.ai.gemini.apiKeyEnvironmentVariable", value);
+            return this;
+        }
+
+        /** @param value endpoint URL @return this builder */
+        public SetProperty ollamaEndpoint(String value) {
+            setProperty("pilot.ai.ollama.endpoint", value);
+            return this;
+        }
+
+        /** @param value model identifier @return this builder */
+        public SetProperty ollamaModel(String value) {
+            setProperty("pilot.ai.ollama.model", value);
+            return this;
+        }
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Properties.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Properties.java
@@ -47,6 +47,7 @@ public class Properties {
     static Performance basePerformance;
     static LambdaTest baseLambdaTest;
     static API baseApi;
+    static Pilot basePilot;
 
     // -------------------------------------------------------------------------
     // Thread-local override configs – updated by set() calls on each thread.
@@ -67,6 +68,7 @@ public class Properties {
     static final ThreadLocal<Performance> performanceOverride = new ThreadLocal<>();
     static final ThreadLocal<LambdaTest> lambdaTestOverride = new ThreadLocal<>();
     static final ThreadLocal<API> apiOverride = new ThreadLocal<>();
+    static final ThreadLocal<Pilot> pilotOverride = new ThreadLocal<>();
 
     // -------------------------------------------------------------------------
     // Public proxy fields – fully API-compatible with the previous static fields.
@@ -88,6 +90,7 @@ public class Properties {
     public static final Performance performance = createProxy(Performance.class, performanceOverride, () -> basePerformance);
     public static final LambdaTest lambdaTest = createProxy(LambdaTest.class, lambdaTestOverride, () -> baseLambdaTest);
     public static final API api = createProxy(API.class, apiOverride, () -> baseApi);
+    public static final Pilot pilot = createProxy(Pilot.class, pilotOverride, () -> basePilot);
 
     // Read-only properties – not mutable after initialisation, no proxy needed.
     public static Internal internal;
@@ -214,5 +217,6 @@ public class Properties {
         performanceOverride.remove();
         lambdaTestOverride.remove();
         apiOverride.remove();
+        pilotOverride.remove();
     }
 }

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
@@ -95,6 +95,7 @@ public class PropertiesHelper {
         Properties.basePerformance = ConfigFactory.create(Performance.class);
         Properties.baseLambdaTest = ConfigFactory.create(LambdaTest.class);
         Properties.baseApi = ConfigFactory.create(API.class);
+        Properties.basePilot = ConfigFactory.create(Pilot.class);
         Properties.initialized = true;
     }
 

--- a/shaft-pilot-core/.gitignore
+++ b/shaft-pilot-core/.gitignore
@@ -1,0 +1,1 @@
+/allure-results/

--- a/shaft-pilot-core/pom.xml
+++ b/shaft-pilot-core/pom.xml
@@ -1,0 +1,67 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.shafthq</groupId>
+        <artifactId>shaft-parent</artifactId>
+        <version>10.2.20260610</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>shaft-pilot-core</artifactId>
+    <packaging>jar</packaging>
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>Provider-neutral contracts, security controls, and deterministic fallback for SHAFT Pilot.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>shaft-engine</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.qameta.allure</groupId>
+            <artifactId>allure-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.6</version>
+                <configuration>
+                    <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiBudget.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiBudget.java
@@ -1,0 +1,25 @@
+package com.shaft.pilot.ai;
+
+import java.math.BigDecimal;
+
+/**
+ * Per-request limits for model usage.
+ *
+ * @param maxInputTokens maximum estimated input tokens
+ * @param maxOutputTokens maximum requested output tokens
+ * @param maxCostUsd maximum accepted provider-reported cost in USD
+ */
+public record AiBudget(long maxInputTokens, long maxOutputTokens, BigDecimal maxCostUsd) {
+    /**
+     * Creates and validates a request budget.
+     */
+    public AiBudget {
+        if (maxInputTokens < 0 || maxOutputTokens < 0) {
+            throw new IllegalArgumentException("Token budgets must not be negative.");
+        }
+        maxCostUsd = maxCostUsd == null ? BigDecimal.ZERO : maxCostUsd;
+        if (maxCostUsd.signum() < 0) {
+            throw new IllegalArgumentException("Cost budget must not be negative.");
+        }
+    }
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiCapabilities.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiCapabilities.java
@@ -1,0 +1,18 @@
+package com.shaft.pilot.ai;
+
+/**
+ * Provider capabilities that callers can inspect before submitting evidence.
+ *
+ * @param structuredOutput whether JSON-schema-constrained output is supported
+ * @param vision whether image input is supported
+ * @param toolCalling whether tool calling is supported
+ * @param contextLimitTokens advertised context limit, or zero when unknown
+ * @param processingLocation local, remote, or disabled processing
+ */
+public record AiCapabilities(
+        boolean structuredOutput,
+        boolean vision,
+        boolean toolCalling,
+        long contextLimitTokens,
+        ProcessingLocation processingLocation) {
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiExecutionService.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiExecutionService.java
@@ -1,0 +1,317 @@
+package com.shaft.pilot.ai;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shaft.pilot.audit.AiAuditEvent;
+import com.shaft.pilot.audit.AiAuditSink;
+import com.shaft.pilot.audit.ShaftAiAuditSink;
+import com.shaft.pilot.config.PilotConfiguration;
+import com.shaft.pilot.json.JsonSchemaValidator;
+import com.shaft.pilot.security.RedactionResult;
+import com.shaft.pilot.security.Redactor;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+/**
+ * Enforces approval, redaction, budgets, concurrency, retries, schema validation,
+ * and circuit breaking before accepting provider output.
+ */
+public final class AiExecutionService {
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private final AiProviderRegistry registry;
+    private final Supplier<PilotConfiguration> configurationSupplier;
+    private final AiAuditSink auditSink;
+    private final Map<String, Semaphore> concurrencyLimits = new ConcurrentHashMap<>();
+    private final Map<String, CircuitState> circuits = new ConcurrentHashMap<>();
+
+    /**
+     * Creates a service using current SHAFT properties, service discovery, and safe SHAFT audit logging.
+     */
+    public AiExecutionService() {
+        this(new AiProviderRegistry(), PilotConfiguration::current, new ShaftAiAuditSink());
+    }
+
+    /**
+     * Creates a service with injectable collaborators.
+     *
+     * @param registry provider registry
+     * @param configurationSupplier current-thread configuration supplier
+     * @param auditSink safe audit sink
+     */
+    public AiExecutionService(AiProviderRegistry registry, Supplier<PilotConfiguration> configurationSupplier,
+                              AiAuditSink auditSink) {
+        this.registry = Objects.requireNonNull(registry, "registry");
+        this.configurationSupplier = Objects.requireNonNull(configurationSupplier, "configurationSupplier");
+        this.auditSink = Objects.requireNonNull(auditSink, "auditSink");
+    }
+
+    /**
+     * Executes a request or returns its deterministic fallback.
+     *
+     * @param request request
+     * @return normalized response
+     */
+    public AiResponse execute(AiRequest request) {
+        Objects.requireNonNull(request, "request");
+        Instant started = Instant.now();
+        PilotConfiguration configuration;
+        try {
+            configuration = configurationSupplier.get();
+        } catch (RuntimeException exception) {
+            return finish(request, "none", "", "", started,
+                    AiResponse.failure(AiResponseStatus.DISABLED, "none", "",
+                            "AI configuration is invalid.", elapsed(started), request.deterministicFallback()));
+        }
+        AiProvider provider;
+        try {
+            provider = registry.resolve(configuration);
+        } catch (RuntimeException exception) {
+            return finish(request, "none", "", "", started,
+                    AiResponse.failure(AiResponseStatus.PROVIDER_UNAVAILABLE, "none", "",
+                            "Provider discovery failed.", elapsed(started), request.deterministicFallback()));
+        }
+        if (provider instanceof DisabledAiProvider) {
+            return finish(request, provider.id(), "", "", started, provider.execute(request));
+        }
+
+        String providerId = provider.id();
+        String model = safeModel(configuration, providerId);
+        AiResponse preflightFailure = preflight(request, configuration, provider, providerId, model, started);
+        if (preflightFailure != null) {
+            return finish(request, providerId, model, "", started, preflightFailure);
+        }
+
+        CircuitState circuit = circuits.computeIfAbsent(providerId, ignored -> new CircuitState());
+        if (circuit.isOpen(configuration.circuitBreakerCooldown())) {
+            return finish(request, providerId, model, "", started,
+                    failure(request, AiResponseStatus.CIRCUIT_OPEN, providerId, model,
+                            "Provider circuit is open.", started));
+        }
+
+        RedactionResult redaction = Redactor.redact(request, configuration.redactionPolicy());
+        AiRequest sanitized = request.withSanitizedContent(redaction.redactedText(), redaction.redactedEvidence())
+                .withTimeout(effectiveTimeout(request, configuration));
+        Semaphore semaphore = concurrencyLimits.computeIfAbsent(
+                providerId + ":" + configuration.maxConcurrency(),
+                ignored -> new Semaphore(configuration.maxConcurrency()));
+        boolean acquired = false;
+        AiResponse result;
+        try {
+            acquired = semaphore.tryAcquire(effectiveTimeout(request, configuration).toMillis(), TimeUnit.MILLISECONDS);
+            if (!acquired) {
+                result = failure(request, AiResponseStatus.TIMEOUT, providerId, model,
+                        "Timed out waiting for provider capacity.", started);
+            } else {
+                result = executeWithRetries(sanitized, configuration, provider, providerId, model, started);
+            }
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            result = failure(request, AiResponseStatus.ERROR, providerId, model,
+                    "Provider execution was interrupted.", started);
+        } finally {
+            if (acquired) {
+                semaphore.release();
+            }
+        }
+
+        if (result.successful()) {
+            circuit.success();
+        } else if (isCircuitFailure(result.status())) {
+            circuit.failure(configuration.circuitBreakerFailureThreshold());
+        }
+        return finish(request, providerId, model, redaction.safeSummary(), started, result);
+    }
+
+    private AiResponse preflight(AiRequest request, PilotConfiguration configuration, AiProvider provider,
+                                 String providerId, String model, Instant started) {
+        AiCapabilities capabilities = provider.capabilities();
+        if (!configuration.approvalPolicy().allows(capabilities.processingLocation(), request.evidenceCategories())
+                || !request.approvalPolicy().allows(capabilities.processingLocation(), request.evidenceCategories())) {
+            return failure(request, AiResponseStatus.CONSENT_REQUIRED, providerId, model,
+                    "Explicit consent is required for the processing location and evidence categories.", started);
+        }
+        if (!request.images().isEmpty() && !capabilities.vision()) {
+            return failure(request, AiResponseStatus.PROVIDER_UNAVAILABLE, providerId, model,
+                    "The selected provider does not support image evidence.", started);
+        }
+        if (!capabilities.structuredOutput()) {
+            return failure(request, AiResponseStatus.PROVIDER_UNAVAILABLE, providerId, model,
+                    "The selected provider does not support structured output.", started);
+        }
+        long requestBytes = requestSize(request);
+        if (requestBytes > configuration.maxRequestBytes()) {
+            return failure(request, AiResponseStatus.REQUEST_TOO_LARGE, providerId, model,
+                    "The request exceeds the configured size limit.", started);
+        }
+        long estimatedInputTokens = Math.max(1, (requestBytes + 3) / 4);
+        long inputLimit = inheritedLimit(request.budget().maxInputTokens(), configuration.maxInputTokens());
+        long outputLimit = inheritedLimit(request.budget().maxOutputTokens(), configuration.maxOutputTokens());
+        if (estimatedInputTokens > inputLimit || outputLimit > configuration.maxOutputTokens()) {
+            return failure(request, AiResponseStatus.BUDGET_EXCEEDED, providerId, model,
+                    "The request exceeds the configured token budget.", started);
+        }
+        AiProviderAvailability availability = provider.availability();
+        if (!availability.available()) {
+            return failure(request, AiResponseStatus.PROVIDER_UNAVAILABLE, providerId, model,
+                    availability.reason(), started);
+        }
+        return null;
+    }
+
+    private AiResponse executeWithRetries(AiRequest request, PilotConfiguration configuration, AiProvider provider,
+                                          String providerId, String model, Instant started) {
+        AiResponse last = null;
+        for (int attempt = 1; attempt <= configuration.retryMaxAttempts(); attempt++) {
+            try {
+                last = provider.execute(request);
+            } catch (RuntimeException exception) {
+                last = failure(request, AiResponseStatus.ERROR, providerId, model,
+                        "Provider execution failed.", started);
+            }
+            if (last.successful()) {
+                List<String> schemaErrors = JsonSchemaValidator.validate(request.desiredResponseSchema(),
+                        last.structuredPayload());
+                if (!schemaErrors.isEmpty()) {
+                    return failure(request, AiResponseStatus.INVALID_RESPONSE, providerId, model,
+                            "Provider output did not match the requested schema.", started);
+                }
+                BigDecimal cost = last.usage().costUsd();
+                BigDecimal costLimit = effectiveCostLimit(request, configuration);
+                if (cost != null && costLimit.signum() > 0 && cost.compareTo(costLimit) > 0) {
+                    return failure(request, AiResponseStatus.BUDGET_EXCEEDED, providerId, model,
+                            "Provider-reported cost exceeded the configured budget.", started);
+                }
+                return last;
+            }
+            if (!isRetryable(last.status())) {
+                return last;
+            }
+        }
+        return last == null
+                ? failure(request, AiResponseStatus.ERROR, providerId, model, "Provider did not return a result.", started)
+                : last;
+    }
+
+    private AiResponse finish(AiRequest request, String provider, String model, String redactionSummary,
+                              Instant started, AiResponse response) {
+        Duration duration = elapsed(started);
+        AiResponse normalized = new AiResponse(response.schemaVersion(), response.status(), provider,
+                response.model().isBlank() ? model : response.model(), response.structuredPayload(),
+                response.warnings(), duration, response.usage(), response.fallbackReason(),
+                request.deterministicFallback());
+        try {
+            auditSink.record(new AiAuditEvent(Instant.now(), request.requestId(), request.purpose(), provider,
+                    normalized.model(), redactionSummary, duration, normalized.status()));
+            return normalized;
+        } catch (RuntimeException auditFailure) {
+            java.util.ArrayList<String> warnings = new java.util.ArrayList<>(normalized.warnings());
+            warnings.add("Safe AI audit metadata could not be recorded.");
+            return new AiResponse(normalized.schemaVersion(), normalized.status(), normalized.provider(),
+                    normalized.model(), normalized.structuredPayload(), warnings, normalized.duration(),
+                    normalized.usage(), normalized.fallbackReason(), normalized.deterministicFallback());
+        }
+    }
+
+    private static AiResponse failure(AiRequest request, AiResponseStatus status, String provider, String model,
+                                      String reason, Instant started) {
+        return AiResponse.failure(status, provider, model, reason, elapsed(started), request.deterministicFallback());
+    }
+
+    private static Duration elapsed(Instant started) {
+        return Duration.between(started, Instant.now());
+    }
+
+    private static Duration effectiveTimeout(AiRequest request, PilotConfiguration configuration) {
+        return request.timeout().compareTo(configuration.timeout()) < 0 ? request.timeout() : configuration.timeout();
+    }
+
+    private static long inheritedLimit(long requested, long configured) {
+        return requested <= 0 ? configured : Math.min(requested, configured);
+    }
+
+    private static BigDecimal effectiveCostLimit(AiRequest request, PilotConfiguration configuration) {
+        BigDecimal requested = request.budget().maxCostUsd();
+        BigDecimal configured = configuration.maxCostUsd();
+        if (requested.signum() <= 0) {
+            return configured;
+        }
+        if (configured.signum() <= 0) {
+            return requested;
+        }
+        return requested.min(configured);
+    }
+
+    private static long requestSize(AiRequest request) {
+        long size = request.text().getBytes(StandardCharsets.UTF_8).length;
+        for (EvidenceReference evidence : request.evidence()) {
+            size += evidence.content().getBytes(StandardCharsets.UTF_8).length;
+        }
+        for (AiImage image : request.images()) {
+            size += image.data().length;
+        }
+        try {
+            size += JSON.writeValueAsBytes(request.desiredResponseSchema()).length;
+        } catch (JsonProcessingException ignored) {
+            size += request.desiredResponseSchema().toString().getBytes(StandardCharsets.UTF_8).length;
+        }
+        return size;
+    }
+
+    private static String safeModel(PilotConfiguration configuration, String providerId) {
+        try {
+            return configuration.provider(providerId).model();
+        } catch (IllegalArgumentException ignored) {
+            return "";
+        }
+    }
+
+    private static boolean isRetryable(AiResponseStatus status) {
+        return status == AiResponseStatus.RATE_LIMITED
+                || status == AiResponseStatus.TIMEOUT
+                || status == AiResponseStatus.PROVIDER_UNAVAILABLE
+                || status == AiResponseStatus.ERROR;
+    }
+
+    private static boolean isCircuitFailure(AiResponseStatus status) {
+        return isRetryable(status) || status == AiResponseStatus.INVALID_RESPONSE;
+    }
+
+    private static final class CircuitState {
+        private int consecutiveFailures;
+        private Instant openedAt;
+
+        synchronized boolean isOpen(Duration cooldown) {
+            if (openedAt == null) {
+                return false;
+            }
+            if (Duration.between(openedAt, Instant.now()).compareTo(cooldown) >= 0) {
+                consecutiveFailures = 0;
+                openedAt = null;
+                return false;
+            }
+            return true;
+        }
+
+        synchronized void success() {
+            consecutiveFailures = 0;
+            openedAt = null;
+        }
+
+        synchronized void failure(int threshold) {
+            consecutiveFailures++;
+            if (consecutiveFailures >= threshold) {
+                openedAt = Instant.now();
+            }
+        }
+    }
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiImage.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiImage.java
@@ -1,0 +1,27 @@
+package com.shaft.pilot.ai;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Immutable image evidence.
+ *
+ * @param category evidence category
+ * @param mediaType image media type
+ * @param data encoded image bytes
+ */
+public record AiImage(EvidenceCategory category, String mediaType, byte[] data) {
+    /**
+     * Creates an immutable defensive copy of image data.
+     */
+    public AiImage {
+        category = Objects.requireNonNull(category, "category");
+        mediaType = Objects.requireNonNullElse(mediaType, "image/png");
+        data = data == null ? new byte[0] : Arrays.copyOf(data, data.length);
+    }
+
+    @Override
+    public byte[] data() {
+        return Arrays.copyOf(data, data.length);
+    }
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiProvider.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiProvider.java
@@ -1,0 +1,38 @@
+package com.shaft.pilot.ai;
+
+/**
+ * SHAFT-owned contract implemented by optional AI providers.
+ */
+public interface AiProvider {
+    /**
+     * Returns the stable provider identifier used by {@code pilot.ai.provider}.
+     *
+     * @return provider identifier
+     */
+    String id();
+
+    /**
+     * Returns provider capabilities.
+     *
+     * @return provider capabilities
+     */
+    AiCapabilities capabilities();
+
+    /**
+     * Checks local configuration without transmitting evidence.
+     *
+     * @return availability result
+     */
+    AiProviderAvailability availability();
+
+    /**
+     * Executes an already approved and redacted request.
+     *
+     * <p>Implementations must honor {@link AiRequest#timeout()} and must not log
+     * request content, credentials, or raw provider responses.</p>
+     *
+     * @param request approved and redacted request
+     * @return normalized response
+     */
+    AiResponse execute(AiRequest request);
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiProviderAvailability.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiProviderAvailability.java
@@ -1,0 +1,28 @@
+package com.shaft.pilot.ai;
+
+/**
+ * Safe provider availability result.
+ *
+ * @param available whether the provider has enough configuration to execute
+ * @param reason safe reason that never contains credential values
+ */
+public record AiProviderAvailability(boolean available, String reason) {
+    /**
+     * Creates an available result.
+     *
+     * @return available result
+     */
+    public static AiProviderAvailability ready() {
+        return new AiProviderAvailability(true, "");
+    }
+
+    /**
+     * Creates an unavailable result.
+     *
+     * @param reason safe unavailability reason
+     * @return unavailable result
+     */
+    public static AiProviderAvailability unavailable(String reason) {
+        return new AiProviderAvailability(false, reason == null ? "Provider unavailable" : reason);
+    }
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiProviderRegistry.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiProviderRegistry.java
@@ -1,0 +1,82 @@
+package com.shaft.pilot.ai;
+
+import com.shaft.pilot.config.PilotConfiguration;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.ServiceLoader;
+
+/**
+ * Resolves explicit current-thread providers before {@link ServiceLoader} providers,
+ * then falls back to the disabled provider.
+ */
+public final class AiProviderRegistry {
+    private static final DisabledAiProvider DISABLED_PROVIDER = new DisabledAiProvider();
+    private static final ThreadLocal<AiProvider> EXPLICIT_PROVIDER = new ThreadLocal<>();
+
+    /**
+     * Registers a provider for the current thread.
+     *
+     * <p>This is intended for tests and controlled embedding. Call
+     * {@link #clearForCurrentThread()} at the lifecycle boundary.</p>
+     *
+     * @param provider provider override
+     */
+    public void registerForCurrentThread(AiProvider provider) {
+        if (provider == null) {
+            EXPLICIT_PROVIDER.remove();
+        } else {
+            EXPLICIT_PROVIDER.set(provider);
+        }
+    }
+
+    /**
+     * Clears the explicit provider for the current thread.
+     */
+    public void clearForCurrentThread() {
+        EXPLICIT_PROVIDER.remove();
+    }
+
+    /**
+     * Resolves the configured provider using explicit, service, then disabled precedence.
+     *
+     * @param configuration effective configuration
+     * @return resolved provider
+     */
+    public AiProvider resolve(PilotConfiguration configuration) {
+        if (!configuration.enabled() || "none".equals(configuration.provider())) {
+            return DISABLED_PROVIDER;
+        }
+        AiProvider explicit = EXPLICIT_PROVIDER.get();
+        if (explicit != null) {
+            return explicit;
+        }
+        List<AiProvider> matches = serviceProviders().stream()
+                .filter(provider -> normalize(provider.id()).equals(configuration.provider()))
+                .toList();
+        if (matches.size() > 1) {
+            String names = matches.stream().map(provider -> provider.getClass().getName())
+                    .sorted().reduce((left, right) -> left + ", " + right).orElse("");
+            throw new IllegalStateException("Multiple AI providers were found for "
+                    + configuration.provider() + ": " + names);
+        }
+        return matches.stream().findFirst().orElse(DISABLED_PROVIDER);
+    }
+
+    /**
+     * Returns deterministically ordered service providers.
+     *
+     * @return discovered providers
+     */
+    public List<AiProvider> serviceProviders() {
+        return ServiceLoader.load(AiProvider.class).stream()
+                .map(ServiceLoader.Provider::get)
+                .sorted(Comparator.comparing(provider -> provider.getClass().getName()))
+                .toList();
+    }
+
+    private static String normalize(String value) {
+        return value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiRequest.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiRequest.java
@@ -1,0 +1,239 @@
+package com.shaft.pilot.ai;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.NullNode;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Immutable provider-neutral request.
+ *
+ * @param requestId safe request correlation identifier
+ * @param purpose purpose-bound operation name
+ * @param schemaVersion request contract version
+ * @param text primary text input
+ * @param evidence additional textual evidence
+ * @param images approved image evidence
+ * @param desiredResponseSchema desired JSON response schema
+ * @param timeout request timeout
+ * @param budget request budget
+ * @param approvalPolicy explicit processing and evidence approval
+ * @param deterministicFallback caller-owned deterministic result
+ */
+public record AiRequest(
+        String requestId,
+        String purpose,
+        String schemaVersion,
+        String text,
+        List<EvidenceReference> evidence,
+        List<AiImage> images,
+        JsonNode desiredResponseSchema,
+        Duration timeout,
+        AiBudget budget,
+        ApprovalPolicy approvalPolicy,
+        JsonNode deterministicFallback) {
+    public static final String CURRENT_SCHEMA_VERSION = "1.0";
+
+    /**
+     * Creates and defensively copies a request.
+     */
+    public AiRequest {
+        requestId = requestId == null || requestId.isBlank() ? UUID.randomUUID().toString() : requestId;
+        purpose = Objects.requireNonNullElse(purpose, "").trim();
+        if (purpose.isEmpty()) {
+            throw new IllegalArgumentException("AI request purpose is required.");
+        }
+        schemaVersion = Objects.requireNonNullElse(schemaVersion, CURRENT_SCHEMA_VERSION);
+        text = Objects.requireNonNullElse(text, "");
+        evidence = evidence == null ? List.of() : List.copyOf(evidence);
+        images = images == null ? List.of() : List.copyOf(images);
+        desiredResponseSchema = desiredResponseSchema == null
+                ? JsonNodeFactory.instance.objectNode()
+                : desiredResponseSchema.deepCopy();
+        timeout = timeout == null ? Duration.ofSeconds(30) : timeout;
+        if (timeout.isZero() || timeout.isNegative()) {
+            throw new IllegalArgumentException("AI request timeout must be positive.");
+        }
+        budget = budget == null ? new AiBudget(0, 0, BigDecimal.ZERO) : budget;
+        approvalPolicy = approvalPolicy == null ? ApprovalPolicy.denyAll() : approvalPolicy;
+        deterministicFallback = deterministicFallback == null
+                ? NullNode.getInstance()
+                : deterministicFallback.deepCopy();
+    }
+
+    /**
+     * Starts a request builder.
+     *
+     * @param purpose purpose-bound operation name
+     * @param responseSchema desired JSON response schema
+     * @return request builder
+     */
+    public static Builder builder(String purpose, JsonNode responseSchema) {
+        return new Builder(purpose, responseSchema);
+    }
+
+    /**
+     * Returns all evidence categories present in this request.
+     *
+     * @return immutable category set
+     */
+    public Set<EvidenceCategory> evidenceCategories() {
+        EnumSet<EvidenceCategory> categories = EnumSet.noneOf(EvidenceCategory.class);
+        if (!text.isBlank()) {
+            categories.add(EvidenceCategory.TEXT);
+        }
+        evidence.forEach(item -> categories.add(item.category()));
+        images.forEach(item -> categories.add(item.category()));
+        return Set.copyOf(categories);
+    }
+
+    /**
+     * Creates a copy containing sanitized text and evidence.
+     *
+     * @param sanitizedText redacted primary text
+     * @param sanitizedEvidence redacted evidence
+     * @return sanitized request copy
+     */
+    public AiRequest withSanitizedContent(String sanitizedText, List<EvidenceReference> sanitizedEvidence) {
+        return new AiRequest(requestId, purpose, schemaVersion, sanitizedText, sanitizedEvidence, images,
+                desiredResponseSchema, timeout, budget, approvalPolicy, deterministicFallback);
+    }
+
+    /**
+     * Creates a copy with an effective timeout.
+     *
+     * @param effectiveTimeout timeout already constrained by global policy
+     * @return request copy
+     */
+    public AiRequest withTimeout(Duration effectiveTimeout) {
+        return new AiRequest(requestId, purpose, schemaVersion, text, evidence, images,
+                desiredResponseSchema, effectiveTimeout, budget, approvalPolicy, deterministicFallback);
+    }
+
+    /**
+     * Fluent builder for {@link AiRequest}.
+     */
+    public static final class Builder {
+        private String requestId;
+        private final String purpose;
+        private final JsonNode responseSchema;
+        private String text = "";
+        private final List<EvidenceReference> evidence = new ArrayList<>();
+        private final List<AiImage> images = new ArrayList<>();
+        private Duration timeout = Duration.ofSeconds(30);
+        private AiBudget budget = new AiBudget(0, 0, BigDecimal.ZERO);
+        private ApprovalPolicy approvalPolicy = ApprovalPolicy.denyAll();
+        private JsonNode deterministicFallback = NullNode.getInstance();
+
+        private Builder(String purpose, JsonNode responseSchema) {
+            this.purpose = purpose;
+            this.responseSchema = responseSchema;
+        }
+
+        /**
+         * Sets a safe request correlation identifier.
+         *
+         * @param value identifier
+         * @return this builder
+         */
+        public Builder requestId(String value) {
+            requestId = value;
+            return this;
+        }
+
+        /**
+         * Sets primary text input.
+         *
+         * @param value text input
+         * @return this builder
+         */
+        public Builder text(String value) {
+            text = value;
+            return this;
+        }
+
+        /**
+         * Adds textual evidence.
+         *
+         * @param value evidence
+         * @return this builder
+         */
+        public Builder evidence(EvidenceReference value) {
+            evidence.add(Objects.requireNonNull(value, "value"));
+            return this;
+        }
+
+        /**
+         * Adds image evidence.
+         *
+         * @param value image
+         * @return this builder
+         */
+        public Builder image(AiImage value) {
+            images.add(Objects.requireNonNull(value, "value"));
+            return this;
+        }
+
+        /**
+         * Sets the request timeout.
+         *
+         * @param value timeout
+         * @return this builder
+         */
+        public Builder timeout(Duration value) {
+            timeout = value;
+            return this;
+        }
+
+        /**
+         * Sets per-request budgets.
+         *
+         * @param value budget
+         * @return this builder
+         */
+        public Builder budget(AiBudget value) {
+            budget = value;
+            return this;
+        }
+
+        /**
+         * Sets explicit request approval.
+         *
+         * @param value approval policy
+         * @return this builder
+         */
+        public Builder approvalPolicy(ApprovalPolicy value) {
+            approvalPolicy = value;
+            return this;
+        }
+
+        /**
+         * Sets the deterministic result returned on failure.
+         *
+         * @param value fallback payload
+         * @return this builder
+         */
+        public Builder deterministicFallback(JsonNode value) {
+            deterministicFallback = value;
+            return this;
+        }
+
+        /**
+         * Builds the immutable request.
+         *
+         * @return request
+         */
+        public AiRequest build() {
+            return new AiRequest(requestId, purpose, CURRENT_SCHEMA_VERSION, text, evidence, images,
+                    responseSchema, timeout, budget, approvalPolicy, deterministicFallback);
+        }
+    }
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiResponse.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiResponse.java
@@ -1,0 +1,97 @@
+package com.shaft.pilot.ai;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Provider-neutral AI result with deterministic fallback.
+ *
+ * @param schemaVersion response contract version
+ * @param status normalized outcome
+ * @param provider provider identifier
+ * @param model model or configuration identifier
+ * @param structuredPayload validated provider payload
+ * @param warnings safe warnings
+ * @param duration request duration
+ * @param usage provider-reported usage
+ * @param fallbackReason safe fallback reason
+ * @param deterministicFallback caller-owned deterministic result
+ */
+public record AiResponse(
+        String schemaVersion,
+        AiResponseStatus status,
+        String provider,
+        String model,
+        JsonNode structuredPayload,
+        List<String> warnings,
+        Duration duration,
+        AiUsage usage,
+        String fallbackReason,
+        JsonNode deterministicFallback) {
+    public static final String CURRENT_SCHEMA_VERSION = "1.0";
+
+    /**
+     * Creates an immutable response.
+     */
+    public AiResponse {
+        schemaVersion = Objects.requireNonNullElse(schemaVersion, CURRENT_SCHEMA_VERSION);
+        status = Objects.requireNonNull(status, "status");
+        provider = Objects.requireNonNullElse(provider, "none");
+        model = Objects.requireNonNullElse(model, "");
+        structuredPayload = structuredPayload == null ? NullNode.getInstance() : structuredPayload.deepCopy();
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+        duration = duration == null ? Duration.ZERO : duration;
+        usage = usage == null ? AiUsage.empty() : usage;
+        fallbackReason = Objects.requireNonNullElse(fallbackReason, "");
+        deterministicFallback = deterministicFallback == null
+                ? NullNode.getInstance()
+                : deterministicFallback.deepCopy();
+    }
+
+    /**
+     * Creates a successful response.
+     *
+     * @param provider provider identifier
+     * @param model model identifier
+     * @param payload structured payload
+     * @param duration request duration
+     * @param usage usage metadata
+     * @param fallback deterministic fallback retained for caller reference
+     * @return successful response
+     */
+    public static AiResponse success(String provider, String model, JsonNode payload, Duration duration,
+                                     AiUsage usage, JsonNode fallback) {
+        return new AiResponse(CURRENT_SCHEMA_VERSION, AiResponseStatus.SUCCESS, provider, model, payload,
+                List.of(), duration, usage, "", fallback);
+    }
+
+    /**
+     * Creates a safe failure response that returns the deterministic result.
+     *
+     * @param status normalized failure
+     * @param provider provider identifier
+     * @param model model identifier
+     * @param reason safe reason
+     * @param duration elapsed duration
+     * @param fallback deterministic result
+     * @return failure response
+     */
+    public static AiResponse failure(AiResponseStatus status, String provider, String model, String reason,
+                                     Duration duration, JsonNode fallback) {
+        return new AiResponse(CURRENT_SCHEMA_VERSION, status, provider, model, fallback, List.of(),
+                duration, AiUsage.empty(), reason, fallback);
+    }
+
+    /**
+     * Returns whether provider output was accepted.
+     *
+     * @return {@code true} only for successful output
+     */
+    public boolean successful() {
+        return status == AiResponseStatus.SUCCESS;
+    }
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiResponseStatus.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiResponseStatus.java
@@ -1,0 +1,19 @@
+package com.shaft.pilot.ai;
+
+/**
+ * Normalized provider and policy outcomes.
+ */
+public enum AiResponseStatus {
+    SUCCESS,
+    DISABLED,
+    CONSENT_REQUIRED,
+    BUDGET_EXCEEDED,
+    REQUEST_TOO_LARGE,
+    PROVIDER_UNAVAILABLE,
+    AUTHENTICATION_FAILED,
+    RATE_LIMITED,
+    TIMEOUT,
+    INVALID_RESPONSE,
+    CIRCUIT_OPEN,
+    ERROR
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiUsage.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiUsage.java
@@ -1,0 +1,21 @@
+package com.shaft.pilot.ai;
+
+import java.math.BigDecimal;
+
+/**
+ * Provider-reported usage metadata.
+ *
+ * @param inputTokens input tokens, or zero when unavailable
+ * @param outputTokens output tokens, or zero when unavailable
+ * @param costUsd cost in USD, or {@code null} when unavailable
+ */
+public record AiUsage(long inputTokens, long outputTokens, BigDecimal costUsd) {
+    /**
+     * Returns empty usage metadata.
+     *
+     * @return empty usage
+     */
+    public static AiUsage empty() {
+        return new AiUsage(0, 0, null);
+    }
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/ApprovalPolicy.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/ApprovalPolicy.java
@@ -1,0 +1,51 @@
+package com.shaft.pilot.ai;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Explicit consent for local or remote inference and evidence categories.
+ *
+ * @param localInferenceAllowed whether local endpoints may receive evidence
+ * @param remoteInferenceAllowed whether remote endpoints may receive evidence
+ * @param allowedEvidenceCategories categories approved for this operation
+ */
+public record ApprovalPolicy(
+        boolean localInferenceAllowed,
+        boolean remoteInferenceAllowed,
+        Set<EvidenceCategory> allowedEvidenceCategories) {
+    /**
+     * Creates an immutable approval policy.
+     */
+    public ApprovalPolicy {
+        allowedEvidenceCategories = allowedEvidenceCategories == null || allowedEvidenceCategories.isEmpty()
+                ? Collections.emptySet()
+                : Collections.unmodifiableSet(EnumSet.copyOf(allowedEvidenceCategories));
+    }
+
+    /**
+     * Returns whether a provider location and all requested evidence categories are approved.
+     *
+     * @param location provider processing location
+     * @param requestedCategories evidence categories in the request
+     * @return {@code true} when the operation is explicitly approved
+     */
+    public boolean allows(ProcessingLocation location, Set<EvidenceCategory> requestedCategories) {
+        boolean locationAllowed = switch (location) {
+            case LOCAL -> localInferenceAllowed;
+            case REMOTE -> remoteInferenceAllowed;
+            case NONE -> false;
+        };
+        return locationAllowed && allowedEvidenceCategories.containsAll(requestedCategories);
+    }
+
+    /**
+     * Returns a policy that denies all inference.
+     *
+     * @return deny-all policy
+     */
+    public static ApprovalPolicy denyAll() {
+        return new ApprovalPolicy(false, false, Collections.emptySet());
+    }
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/DisabledAiProvider.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/DisabledAiProvider.java
@@ -1,0 +1,50 @@
+package com.shaft.pilot.ai;
+
+import java.time.Duration;
+
+/**
+ * Deterministic no-op provider used when AI is disabled or unavailable.
+ */
+public final class DisabledAiProvider implements AiProvider {
+    /**
+     * Returns the disabled provider identifier.
+     *
+     * @return {@code none}
+     */
+    @Override
+    public String id() {
+        return "none";
+    }
+
+    /**
+     * Returns disabled capabilities.
+     *
+     * @return disabled capabilities
+     */
+    @Override
+    public AiCapabilities capabilities() {
+        return new AiCapabilities(false, false, false, 0, ProcessingLocation.NONE);
+    }
+
+    /**
+     * Returns unavailable without performing any network call.
+     *
+     * @return unavailable result
+     */
+    @Override
+    public AiProviderAvailability availability() {
+        return AiProviderAvailability.unavailable("AI is disabled.");
+    }
+
+    /**
+     * Returns the caller's deterministic fallback without performing any network call.
+     *
+     * @param request request
+     * @return disabled response
+     */
+    @Override
+    public AiResponse execute(AiRequest request) {
+        return AiResponse.failure(AiResponseStatus.DISABLED, id(), "", "AI is disabled.",
+                Duration.ZERO, request.deterministicFallback());
+    }
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/EvidenceCategory.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/EvidenceCategory.java
@@ -1,0 +1,15 @@
+package com.shaft.pilot.ai;
+
+/**
+ * Evidence categories used by approval and redaction policies.
+ */
+public enum EvidenceCategory {
+    TEXT,
+    DOM,
+    SCREENSHOT,
+    LOG,
+    SOURCE,
+    TEST_DATA,
+    NETWORK,
+    CONFIGURATION
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/EvidenceReference.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/EvidenceReference.java
@@ -1,0 +1,23 @@
+package com.shaft.pilot.ai;
+
+import java.util.Objects;
+
+/**
+ * Textual evidence supplied to a provider after approval and redaction.
+ *
+ * @param id caller-owned stable identifier
+ * @param category evidence category
+ * @param mediaType evidence media type
+ * @param content evidence content
+ */
+public record EvidenceReference(String id, EvidenceCategory category, String mediaType, String content) {
+    /**
+     * Creates an immutable evidence reference.
+     */
+    public EvidenceReference {
+        id = Objects.requireNonNullElse(id, "");
+        category = Objects.requireNonNull(category, "category");
+        mediaType = Objects.requireNonNullElse(mediaType, "text/plain");
+        content = Objects.requireNonNullElse(content, "");
+    }
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/ProcessingLocation.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/ProcessingLocation.java
@@ -1,0 +1,10 @@
+package com.shaft.pilot.ai;
+
+/**
+ * Describes where a provider processes submitted evidence.
+ */
+public enum ProcessingLocation {
+    LOCAL,
+    REMOTE,
+    NONE
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/audit/AiAuditEvent.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/audit/AiAuditEvent.java
@@ -1,0 +1,44 @@
+package com.shaft.pilot.audit;
+
+import com.shaft.pilot.ai.AiResponseStatus;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Safe audit metadata that excludes prompts, evidence, responses, and credentials.
+ *
+ * @param timestamp event time
+ * @param requestId request correlation identifier
+ * @param purpose request purpose
+ * @param provider provider identifier
+ * @param model model identifier
+ * @param redactionSummary safe redaction counts
+ * @param duration elapsed duration
+ * @param status normalized outcome
+ */
+public record AiAuditEvent(
+        Instant timestamp,
+        String requestId,
+        String purpose,
+        String provider,
+        String model,
+        String redactionSummary,
+        Duration duration,
+        AiResponseStatus status) {
+    /**
+     * Normalizes user-controlled metadata before it reaches logs.
+     */
+    public AiAuditEvent {
+        requestId = safe(requestId, 128);
+        purpose = safe(purpose, 128);
+        provider = safe(provider, 64);
+        model = safe(model, 128);
+        redactionSummary = safe(redactionSummary, 256);
+    }
+
+    private static String safe(String value, int limit) {
+        String normalized = value == null ? "" : value.replaceAll("\\p{Cntrl}", " ");
+        return normalized.length() <= limit ? normalized : normalized.substring(0, limit);
+    }
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/audit/AiAuditSink.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/audit/AiAuditSink.java
@@ -1,0 +1,14 @@
+package com.shaft.pilot.audit;
+
+/**
+ * Receives safe local audit metadata.
+ */
+@FunctionalInterface
+public interface AiAuditSink {
+    /**
+     * Records one safe event.
+     *
+     * @param event audit event
+     */
+    void record(AiAuditEvent event);
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/audit/ShaftAiAuditSink.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/audit/ShaftAiAuditSink.java
@@ -1,0 +1,24 @@
+package com.shaft.pilot.audit;
+
+import com.shaft.driver.SHAFT;
+
+/**
+ * Writes safe audit metadata through SHAFT logging.
+ */
+public final class ShaftAiAuditSink implements AiAuditSink {
+    /**
+     * Records an event without request or response content.
+     *
+     * @param event audit event
+     */
+    @Override
+    public void record(AiAuditEvent event) {
+        SHAFT.Report.log("SHAFT Pilot AI audit: requestId=" + event.requestId()
+                + ", purpose=" + event.purpose()
+                + ", provider=" + event.provider()
+                + ", model=" + event.model()
+                + ", status=" + event.status()
+                + ", durationMs=" + event.duration().toMillis()
+                + ", redaction=\"" + event.redactionSummary() + "\"");
+    }
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/config/PilotConfiguration.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/config/PilotConfiguration.java
@@ -1,0 +1,155 @@
+package com.shaft.pilot.config;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.pilot.ai.ApprovalPolicy;
+import com.shaft.pilot.ai.EvidenceCategory;
+import com.shaft.pilot.security.RedactionPolicy;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Immutable snapshot of effective current-thread Pilot configuration.
+ *
+ * @param enabled whether AI execution is enabled
+ * @param provider selected provider identifier
+ * @param approvalPolicy global approval policy
+ * @param telemetryEnabled whether optional external telemetry is enabled
+ * @param timeout maximum provider timeout
+ * @param maxRequestBytes maximum serialized request size
+ * @param maxInputTokens maximum estimated input tokens
+ * @param maxOutputTokens maximum output tokens
+ * @param maxCostUsd maximum accepted provider-reported cost
+ * @param retryMaxAttempts maximum execution attempts
+ * @param maxConcurrency maximum concurrent calls per provider
+ * @param circuitBreakerFailureThreshold failures before opening the circuit
+ * @param circuitBreakerCooldown circuit-open cooldown
+ * @param redactionPolicy effective redaction policy
+ * @param providers provider-specific endpoint, model, and credential-source configuration
+ */
+public record PilotConfiguration(
+        boolean enabled,
+        String provider,
+        ApprovalPolicy approvalPolicy,
+        boolean telemetryEnabled,
+        Duration timeout,
+        int maxRequestBytes,
+        long maxInputTokens,
+        long maxOutputTokens,
+        BigDecimal maxCostUsd,
+        int retryMaxAttempts,
+        int maxConcurrency,
+        int circuitBreakerFailureThreshold,
+        Duration circuitBreakerCooldown,
+        RedactionPolicy redactionPolicy,
+        Map<String, ProviderConfiguration> providers) {
+    /**
+     * Reads a current-thread configuration snapshot through {@link SHAFT.Properties}.
+     *
+     * @return effective configuration
+     */
+    public static PilotConfiguration current() {
+        var properties = SHAFT.Properties.pilot;
+        Set<EvidenceCategory> categories = parseCategories(properties.allowedEvidenceCategories());
+        RedactionPolicy redactionPolicy = new RedactionPolicy(
+                split(properties.redactionAttributes(), ",").stream().collect(Collectors.toUnmodifiableSet()),
+                split(properties.redactionSelectors(), ","),
+                split(properties.redactionPatterns(), ";;"));
+        Map<String, ProviderConfiguration> providers = Map.of(
+                "openai", provider("openai", properties.openAiEndpoint(), properties.openAiModel(),
+                        properties.openAiApiKeyEnvironmentVariable()),
+                "anthropic", provider("anthropic", properties.anthropicEndpoint(), properties.anthropicModel(),
+                        properties.anthropicApiKeyEnvironmentVariable(),
+                        Map.of("api-version", properties.anthropicVersion())),
+                "gemini", provider("gemini", properties.geminiEndpoint(), properties.geminiModel(),
+                        properties.geminiApiKeyEnvironmentVariable()),
+                "ollama", provider("ollama", properties.ollamaEndpoint(), properties.ollamaModel(), ""));
+        return new PilotConfiguration(
+                properties.enabled(),
+                normalize(properties.provider()),
+                new ApprovalPolicy(properties.localConsent(), properties.remoteConsent(), categories),
+                properties.telemetryEnabled(),
+                Duration.ofSeconds(positive(properties.timeoutSeconds(), 30)),
+                positive(properties.maxRequestBytes(), 1_048_576),
+                positive(properties.maxInputTokens(), 16_000),
+                positive(properties.maxOutputTokens(), 2_000),
+                decimal(properties.maxCostUsd()),
+                positive(properties.retryMaxAttempts(), 1),
+                positive(properties.maxConcurrency(), 1),
+                positive(properties.circuitBreakerFailureThreshold(), 1),
+                Duration.ofSeconds(positive(properties.circuitBreakerCooldownSeconds(), 60)),
+                redactionPolicy,
+                providers);
+    }
+
+    /**
+     * Returns configuration for a provider.
+     *
+     * @param providerId provider identifier
+     * @return provider configuration
+     * @throws IllegalArgumentException when the provider is unknown
+     */
+    public ProviderConfiguration provider(String providerId) {
+        ProviderConfiguration configuration = providers.get(normalize(providerId));
+        if (configuration == null) {
+            throw new IllegalArgumentException("Unknown AI provider: " + providerId);
+        }
+        return configuration;
+    }
+
+    private static ProviderConfiguration provider(String id, String endpoint, String model, String environmentVariable) {
+        return provider(id, endpoint, model, environmentVariable, Map.of());
+    }
+
+    private static ProviderConfiguration provider(String id, String endpoint, String model, String environmentVariable,
+                                                  Map<String, String> options) {
+        return new ProviderConfiguration(id, URI.create(endpoint), model, environmentVariable, options);
+    }
+
+    private static Set<EvidenceCategory> parseCategories(String value) {
+        EnumSet<EvidenceCategory> categories = EnumSet.noneOf(EvidenceCategory.class);
+        for (String item : split(value, ",")) {
+            try {
+                categories.add(EvidenceCategory.valueOf(item.toUpperCase(Locale.ROOT)));
+            } catch (IllegalArgumentException ignored) {
+                // Unknown categories are denied rather than becoming implicitly approved.
+            }
+        }
+        return Set.copyOf(categories);
+    }
+
+    private static List<String> split(String value, String delimiter) {
+        if (value == null || value.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(value.split(java.util.regex.Pattern.quote(delimiter)))
+                .map(String::trim)
+                .filter(item -> !item.isEmpty())
+                .toList();
+    }
+
+    private static int positive(int value, int fallback) {
+        return value > 0 ? value : fallback;
+    }
+
+    private static BigDecimal decimal(String value) {
+        try {
+            BigDecimal parsed = new BigDecimal(value);
+            return parsed.signum() < 0 ? BigDecimal.ZERO : parsed;
+        } catch (NumberFormatException ignored) {
+            return BigDecimal.ZERO;
+        }
+    }
+
+    private static String normalize(String value) {
+        return value == null ? "none" : value.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/config/ProviderConfiguration.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/config/ProviderConfiguration.java
@@ -1,0 +1,42 @@
+package com.shaft.pilot.config;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Configuration for one direct provider.
+ *
+ * @param id provider identifier
+ * @param endpoint provider endpoint
+ * @param model model identifier
+ * @param apiKeyEnvironmentVariable environment variable containing credentials, or blank for local providers
+ * @param options non-secret provider protocol options
+ */
+public record ProviderConfiguration(
+        String id,
+        URI endpoint,
+        String model,
+        String apiKeyEnvironmentVariable,
+        Map<String, String> options) {
+    /**
+     * Creates validated provider configuration.
+     */
+    public ProviderConfiguration {
+        id = Objects.requireNonNull(id, "id");
+        endpoint = Objects.requireNonNull(endpoint, "endpoint");
+        model = Objects.requireNonNullElse(model, "").trim();
+        apiKeyEnvironmentVariable = Objects.requireNonNullElse(apiKeyEnvironmentVariable, "").trim();
+        options = options == null ? Map.of() : Map.copyOf(options);
+    }
+
+    /**
+     * Returns a non-secret provider option.
+     *
+     * @param name option name
+     * @return option value, or an empty string
+     */
+    public String option(String name) {
+        return options.getOrDefault(name, "");
+    }
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/json/JsonSchemaValidator.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/json/JsonSchemaValidator.java
@@ -1,0 +1,138 @@
+package com.shaft.pilot.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Deterministic validator for the JSON Schema subset shared by supported providers.
+ */
+public final class JsonSchemaValidator {
+    private JsonSchemaValidator() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Validates a payload against the supported schema subset.
+     *
+     * @param schema JSON schema
+     * @param payload candidate payload
+     * @return validation errors; empty when valid
+     */
+    public static List<String> validate(JsonNode schema, JsonNode payload) {
+        List<String> errors = new ArrayList<>();
+        validateNode(schema, payload, "$", errors);
+        return List.copyOf(errors);
+    }
+
+    private static void validateNode(JsonNode schema, JsonNode value, String path, List<String> errors) {
+        if (schema == null || schema.isMissingNode() || schema.isNull() || !schema.isObject()) {
+            return;
+        }
+        if (!matchesType(schema.get("type"), value)) {
+            errors.add(path + " does not match the required type.");
+            return;
+        }
+        JsonNode enumValues = schema.get("enum");
+        if (enumValues != null && enumValues.isArray()) {
+            boolean matched = false;
+            for (JsonNode allowed : enumValues) {
+                if (allowed.equals(value)) {
+                    matched = true;
+                    break;
+                }
+            }
+            if (!matched) {
+                errors.add(path + " is not an allowed enum value.");
+            }
+        }
+        if (value != null && value.isObject()) {
+            validateObject(schema, value, path, errors);
+        } else if (value != null && value.isArray()) {
+            validateArray(schema, value, path, errors);
+        } else if (value != null && value.isNumber()) {
+            validateNumber(schema, value, path, errors);
+        }
+    }
+
+    private static boolean matchesType(JsonNode type, JsonNode value) {
+        if (type == null || type.isNull()) {
+            return true;
+        }
+        if (type.isArray()) {
+            for (JsonNode candidate : type) {
+                if (matchesType(candidate, value)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return switch (type.asText()) {
+            case "object" -> value != null && value.isObject();
+            case "array" -> value != null && value.isArray();
+            case "string" -> value != null && value.isTextual();
+            case "number" -> value != null && value.isNumber();
+            case "integer" -> value != null && value.isIntegralNumber();
+            case "boolean" -> value != null && value.isBoolean();
+            case "null" -> value == null || value.isNull();
+            default -> true;
+        };
+    }
+
+    private static void validateObject(JsonNode schema, JsonNode value, String path, List<String> errors) {
+        Set<String> required = new HashSet<>();
+        JsonNode requiredNode = schema.get("required");
+        if (requiredNode != null && requiredNode.isArray()) {
+            requiredNode.forEach(item -> required.add(item.asText()));
+        }
+        required.stream().filter(name -> !value.has(name))
+                .forEach(name -> errors.add(path + "." + name + " is required."));
+
+        JsonNode properties = schema.get("properties");
+        if (properties != null && properties.isObject()) {
+            for (Map.Entry<String, JsonNode> field : properties.properties()) {
+                if (value.has(field.getKey())) {
+                    validateNode(field.getValue(), value.get(field.getKey()), path + "." + field.getKey(), errors);
+                }
+            }
+            if (schema.path("additionalProperties").isBoolean()
+                    && !schema.path("additionalProperties").asBoolean()) {
+                value.fieldNames().forEachRemaining(name -> {
+                    if (!properties.has(name)) {
+                        errors.add(path + "." + name + " is not allowed.");
+                    }
+                });
+            }
+        }
+    }
+
+    private static void validateArray(JsonNode schema, JsonNode value, String path, List<String> errors) {
+        if (schema.has("minItems") && value.size() < schema.path("minItems").asInt()) {
+            errors.add(path + " has fewer items than allowed.");
+        }
+        if (schema.has("maxItems") && value.size() > schema.path("maxItems").asInt()) {
+            errors.add(path + " has more items than allowed.");
+        }
+        JsonNode itemSchema = schema.get("items");
+        if (itemSchema != null) {
+            for (int index = 0; index < value.size(); index++) {
+                validateNode(itemSchema, value.get(index), path + "[" + index + "]", errors);
+            }
+        }
+    }
+
+    private static void validateNumber(JsonNode schema, JsonNode value, String path, List<String> errors) {
+        BigDecimal number = value.decimalValue();
+        if (schema.has("minimum") && number.compareTo(schema.path("minimum").decimalValue()) < 0) {
+            errors.add(path + " is below the minimum.");
+        }
+        if (schema.has("maximum") && number.compareTo(schema.path("maximum").decimalValue()) > 0) {
+            errors.add(path + " is above the maximum.");
+        }
+    }
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/security/RedactionPolicy.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/security/RedactionPolicy.java
@@ -1,0 +1,27 @@
+package com.shaft.pilot.security;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Deterministic redaction rules.
+ *
+ * @param sensitiveAttributes case-insensitive structured or DOM attribute names
+ * @param selectors CSS selectors whose values and text must be removed
+ * @param customPatterns additional regular expressions
+ */
+public record RedactionPolicy(
+        Set<String> sensitiveAttributes,
+        List<String> selectors,
+        List<String> customPatterns) {
+    /**
+     * Creates immutable redaction rules.
+     */
+    public RedactionPolicy {
+        sensitiveAttributes = sensitiveAttributes == null
+                ? Set.of()
+                : sensitiveAttributes.stream().map(String::toLowerCase).collect(java.util.stream.Collectors.toUnmodifiableSet());
+        selectors = selectors == null ? List.of() : List.copyOf(selectors);
+        customPatterns = customPatterns == null ? List.of() : List.copyOf(customPatterns);
+    }
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/security/RedactionResult.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/security/RedactionResult.java
@@ -1,0 +1,32 @@
+package com.shaft.pilot.security;
+
+import com.shaft.pilot.ai.EvidenceReference;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Redacted request content and a safe summary.
+ *
+ * @param redactedText sanitized primary text
+ * @param redactedEvidence sanitized evidence
+ * @param appliedRules names of rules that changed content
+ * @param removedFields field or attribute names removed without original values
+ * @param safeSummary safe summary suitable for audit logs
+ */
+public record RedactionResult(
+        String redactedText,
+        List<EvidenceReference> redactedEvidence,
+        Set<String> appliedRules,
+        Set<String> removedFields,
+        String safeSummary) {
+    /**
+     * Creates an immutable redaction result.
+     */
+    public RedactionResult {
+        redactedEvidence = redactedEvidence == null ? List.of() : List.copyOf(redactedEvidence);
+        appliedRules = appliedRules == null ? Set.of() : Set.copyOf(appliedRules);
+        removedFields = removedFields == null ? Set.of() : Set.copyOf(removedFields);
+        safeSummary = safeSummary == null ? "" : safeSummary;
+    }
+}

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/security/Redactor.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/security/Redactor.java
@@ -1,0 +1,123 @@
+package com.shaft.pilot.security;
+
+import com.shaft.pilot.ai.AiRequest;
+import com.shaft.pilot.ai.EvidenceReference;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Applies deterministic secret, field, and DOM redaction without retaining original values.
+ */
+public final class Redactor {
+    public static final String REPLACEMENT = "[REDACTED]";
+    private static final List<NamedPattern> BUILT_IN_PATTERNS = List.of(
+            new NamedPattern("authorization-header",
+                    Pattern.compile("(?im)(authorization|proxy-authorization)\\s*[:=]\\s*[^\\r\\n]+")),
+            new NamedPattern("cookie-header",
+                    Pattern.compile("(?im)(cookie|set-cookie)\\s*[:=]\\s*[^\\r\\n]+")),
+            new NamedPattern("secret-assignment",
+                    Pattern.compile("(?i)(password|passwd|secret|api[_-]?key|access[_-]?key|token)\\s*[:=]\\s*([^\\s,;]+)")),
+            new NamedPattern("bearer-token", Pattern.compile("(?i)bearer\\s+[a-z0-9._~+/=-]+")),
+            new NamedPattern("jwt", Pattern.compile("\\beyJ[a-zA-Z0-9_-]+\\.[a-zA-Z0-9_-]+\\.[a-zA-Z0-9_-]+\\b")),
+            new NamedPattern("private-key",
+                    Pattern.compile("(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----")),
+            new NamedPattern("aws-access-key", Pattern.compile("\\b(?:AKIA|ASIA)[A-Z0-9]{16}\\b")));
+
+    private Redactor() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Redacts primary and textual evidence content.
+     *
+     * @param request request to sanitize
+     * @param policy configured policy
+     * @return redacted content and safe summary
+     */
+    public static RedactionResult redact(AiRequest request, RedactionPolicy policy) {
+        Set<String> appliedRules = new LinkedHashSet<>();
+        Set<String> removedFields = new LinkedHashSet<>();
+        String redactedText = redactText(request.text(), policy, appliedRules, removedFields);
+        List<EvidenceReference> redactedEvidence = new ArrayList<>();
+        for (EvidenceReference evidence : request.evidence()) {
+            redactedEvidence.add(new EvidenceReference(evidence.id(), evidence.category(), evidence.mediaType(),
+                    redactText(evidence.content(), policy, appliedRules, removedFields)));
+        }
+        String summary = "Applied " + appliedRules.size() + " redaction rule(s); removed "
+                + removedFields.size() + " sensitive field name(s).";
+        return new RedactionResult(redactedText, redactedEvidence, appliedRules, removedFields, summary);
+    }
+
+    private static String redactText(String input, RedactionPolicy policy, Set<String> appliedRules,
+                                     Set<String> removedFields) {
+        String output = input == null ? "" : input;
+        if (looksLikeHtml(output)) {
+            output = redactHtml(output, policy, appliedRules, removedFields);
+        }
+        for (NamedPattern namedPattern : BUILT_IN_PATTERNS) {
+            String updated = namedPattern.pattern().matcher(output).replaceAll(REPLACEMENT);
+            if (!updated.equals(output)) {
+                appliedRules.add(namedPattern.name());
+                output = updated;
+            }
+        }
+        for (String expression : policy.customPatterns()) {
+            if (expression == null || expression.isBlank()) {
+                continue;
+            }
+            try {
+                String updated = Pattern.compile(expression).matcher(output).replaceAll(REPLACEMENT);
+                if (!updated.equals(output)) {
+                    appliedRules.add("custom-pattern");
+                    output = updated;
+                }
+            } catch (java.util.regex.PatternSyntaxException ignored) {
+                appliedRules.add("invalid-custom-pattern");
+            }
+        }
+        return output;
+    }
+
+    private static boolean looksLikeHtml(String value) {
+        return value.indexOf('<') >= 0 && value.indexOf('>') > value.indexOf('<');
+    }
+
+    private static String redactHtml(String input, RedactionPolicy policy, Set<String> appliedRules,
+                                     Set<String> removedFields) {
+        Document document = Jsoup.parseBodyFragment(input);
+        for (String selector : policy.selectors()) {
+            if (selector == null || selector.isBlank()) {
+                continue;
+            }
+            try {
+                for (Element element : document.select(selector)) {
+                    element.text(REPLACEMENT);
+                    element.attributes().forEach(attribute -> attribute.setValue(REPLACEMENT));
+                    appliedRules.add("dom-selector");
+                }
+            } catch (IllegalArgumentException ignored) {
+                appliedRules.add("invalid-dom-selector");
+            }
+        }
+        for (Element element : document.getAllElements()) {
+            for (String attributeName : policy.sensitiveAttributes()) {
+                if (element.hasAttr(attributeName)) {
+                    element.attr(attributeName, REPLACEMENT);
+                    removedFields.add(attributeName);
+                    appliedRules.add("dom-attribute");
+                }
+            }
+        }
+        return document.body().html();
+    }
+
+    private record NamedPattern(String name, Pattern pattern) {
+    }
+}

--- a/shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiExecutionServiceTest.java
+++ b/shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiExecutionServiceTest.java
@@ -1,0 +1,238 @@
+package com.shaft.pilot.ai;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shaft.pilot.config.PilotConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.EnumSet;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AiExecutionServiceTest {
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    @Test
+    void disabledConfigurationPerformsNoProviderCall() {
+        StubProvider provider = new StubProvider(ProcessingLocation.REMOTE);
+        AiProviderRegistry registry = new AiProviderRegistry();
+        registry.registerForCurrentThread(provider);
+        try {
+            AiExecutionService service = service(registry, PilotTestConfiguration.disabled());
+
+            AiResponse response = service.execute(request(ApprovalPolicy.denyAll()));
+
+            assertEquals(AiResponseStatus.DISABLED, response.status());
+            assertEquals(0, provider.calls.get());
+        } finally {
+            registry.clearForCurrentThread();
+        }
+    }
+
+    @Test
+    void invalidConfigurationReturnsFallbackWithoutProviderDiscovery() {
+        AiProviderRegistry registry = new AiProviderRegistry();
+        AiExecutionService service = new AiExecutionService(registry, () -> {
+            throw new IllegalArgumentException("invalid endpoint");
+        }, event -> {
+        });
+
+        AiResponse response = service.execute(request(ApprovalPolicy.denyAll()));
+
+        assertEquals(AiResponseStatus.DISABLED, response.status());
+        assertEquals("deterministic", response.structuredPayload().path("answer").asText());
+        assertEquals("AI configuration is invalid.", response.fallbackReason());
+    }
+
+    @Test
+    void remoteEvidenceRequiresConsentFromConfigurationAndRequest() {
+        StubProvider provider = new StubProvider(ProcessingLocation.REMOTE);
+        AiProviderRegistry registry = new AiProviderRegistry();
+        registry.registerForCurrentThread(provider);
+        PilotConfiguration configured = PilotTestConfiguration.enabled("stub", ProcessingLocation.REMOTE);
+        PilotConfiguration denied = new PilotConfiguration(
+                true, configured.provider(), ApprovalPolicy.denyAll(), false, configured.timeout(),
+                configured.maxRequestBytes(), configured.maxInputTokens(), configured.maxOutputTokens(),
+                configured.maxCostUsd(), configured.retryMaxAttempts(), configured.maxConcurrency(),
+                configured.circuitBreakerFailureThreshold(), configured.circuitBreakerCooldown(),
+                configured.redactionPolicy(), configured.providers());
+        try {
+            AiResponse response = service(registry, denied).execute(request(approved(ProcessingLocation.REMOTE)));
+
+            assertEquals(AiResponseStatus.CONSENT_REQUIRED, response.status());
+            assertEquals(0, provider.calls.get());
+        } finally {
+            registry.clearForCurrentThread();
+        }
+    }
+
+    @Test
+    void requestIsRedactedBeforeProviderExecution() {
+        StubProvider provider = new StubProvider(ProcessingLocation.REMOTE);
+        AiProviderRegistry registry = new AiProviderRegistry();
+        registry.registerForCurrentThread(provider);
+        try {
+            AiResponse response = service(registry,
+                    PilotTestConfiguration.enabled("stub", ProcessingLocation.REMOTE))
+                    .execute(request(approved(ProcessingLocation.REMOTE)));
+
+            assertEquals(AiResponseStatus.SUCCESS, response.status());
+            assertFalse(provider.lastRequest.get().text().contains("top-secret"));
+            assertTrue(provider.lastRequest.get().text().contains("[REDACTED]"));
+        } finally {
+            registry.clearForCurrentThread();
+        }
+    }
+
+    @Test
+    void schemaViolationReturnsDeterministicFallback() {
+        StubProvider provider = new StubProvider(ProcessingLocation.REMOTE);
+        provider.payload = JSON.createObjectNode().put("wrong", true);
+        AiProviderRegistry registry = new AiProviderRegistry();
+        registry.registerForCurrentThread(provider);
+        try {
+            AiResponse response = service(registry,
+                    PilotTestConfiguration.enabled("stub", ProcessingLocation.REMOTE))
+                    .execute(request(approved(ProcessingLocation.REMOTE)));
+
+            assertEquals(AiResponseStatus.INVALID_RESPONSE, response.status());
+            assertEquals("deterministic", response.structuredPayload().path("answer").asText());
+        } finally {
+            registry.clearForCurrentThread();
+        }
+    }
+
+    @Test
+    void retryableFailureIsRetried() {
+        StubProvider provider = new StubProvider(ProcessingLocation.REMOTE);
+        provider.failuresRemaining.set(1);
+        AiProviderRegistry registry = new AiProviderRegistry();
+        registry.registerForCurrentThread(provider);
+        try {
+            AiResponse response = service(registry,
+                    PilotTestConfiguration.enabled("stub", ProcessingLocation.REMOTE))
+                    .execute(request(approved(ProcessingLocation.REMOTE)));
+
+            assertEquals(AiResponseStatus.SUCCESS, response.status());
+            assertEquals(2, provider.calls.get());
+        } finally {
+            registry.clearForCurrentThread();
+        }
+    }
+
+    @Test
+    void circuitOpensAfterConfiguredFailureThreshold() {
+        StubProvider provider = new StubProvider(ProcessingLocation.REMOTE);
+        provider.alwaysFail = true;
+        AiProviderRegistry registry = new AiProviderRegistry();
+        registry.registerForCurrentThread(provider);
+        PilotConfiguration base = PilotTestConfiguration.enabled("stub", ProcessingLocation.REMOTE);
+        PilotConfiguration thresholdOne = new PilotConfiguration(
+                base.enabled(), base.provider(), base.approvalPolicy(), base.telemetryEnabled(), base.timeout(),
+                base.maxRequestBytes(), base.maxInputTokens(), base.maxOutputTokens(), base.maxCostUsd(), 1,
+                base.maxConcurrency(), 1, base.circuitBreakerCooldown(), base.redactionPolicy(), base.providers());
+        try {
+            AiExecutionService service = service(registry, thresholdOne);
+            assertEquals(AiResponseStatus.RATE_LIMITED,
+                    service.execute(request(approved(ProcessingLocation.REMOTE))).status());
+            assertEquals(AiResponseStatus.CIRCUIT_OPEN,
+                    service.execute(request(approved(ProcessingLocation.REMOTE))).status());
+            assertEquals(1, provider.calls.get());
+        } finally {
+            registry.clearForCurrentThread();
+        }
+    }
+
+    @Test
+    void auditSinkFailureDoesNotReplaceProviderOrFallbackResult() {
+        StubProvider provider = new StubProvider(ProcessingLocation.REMOTE);
+        AiProviderRegistry registry = new AiProviderRegistry();
+        registry.registerForCurrentThread(provider);
+        try {
+            AiExecutionService service = new AiExecutionService(registry,
+                    () -> PilotTestConfiguration.enabled("stub", ProcessingLocation.REMOTE),
+                    event -> {
+                        throw new IllegalStateException("audit unavailable");
+                    });
+
+            AiResponse response = service.execute(request(approved(ProcessingLocation.REMOTE)));
+
+            assertEquals(AiResponseStatus.SUCCESS, response.status());
+            assertTrue(response.warnings().contains("Safe AI audit metadata could not be recorded."));
+        } finally {
+            registry.clearForCurrentThread();
+        }
+    }
+
+    private static AiExecutionService service(AiProviderRegistry registry, PilotConfiguration configuration) {
+        return new AiExecutionService(registry, () -> configuration, event -> {
+        });
+    }
+
+    private static AiRequest request(ApprovalPolicy approvalPolicy) {
+        JsonNode schema = JSON.createObjectNode()
+                .put("type", "object")
+                .set("properties", JSON.createObjectNode()
+                        .set("answer", JSON.createObjectNode().put("type", "string")));
+        ((com.fasterxml.jackson.databind.node.ObjectNode) schema)
+                .putArray("required").add("answer");
+        return AiRequest.builder("unit-test", schema)
+                .text("password=top-secret")
+                .budget(new AiBudget(1_000, 100, BigDecimal.ONE))
+                .approvalPolicy(approvalPolicy)
+                .deterministicFallback(JSON.createObjectNode().put("answer", "deterministic"))
+                .timeout(Duration.ofSeconds(1))
+                .build();
+    }
+
+    private static ApprovalPolicy approved(ProcessingLocation location) {
+        return new ApprovalPolicy(location == ProcessingLocation.LOCAL, location == ProcessingLocation.REMOTE,
+                EnumSet.allOf(EvidenceCategory.class));
+    }
+
+    private static final class StubProvider implements AiProvider {
+        private final ProcessingLocation location;
+        private final AtomicInteger calls = new AtomicInteger();
+        private final AtomicInteger failuresRemaining = new AtomicInteger();
+        private final AtomicReference<AiRequest> lastRequest = new AtomicReference<>();
+        private JsonNode payload = JSON.createObjectNode().put("answer", "provider");
+        private boolean alwaysFail;
+
+        private StubProvider(ProcessingLocation location) {
+            this.location = location;
+        }
+
+        @Override
+        public String id() {
+            return "stub";
+        }
+
+        @Override
+        public AiCapabilities capabilities() {
+            return new AiCapabilities(true, true, false, 10_000, location);
+        }
+
+        @Override
+        public AiProviderAvailability availability() {
+            return AiProviderAvailability.ready();
+        }
+
+        @Override
+        public AiResponse execute(AiRequest request) {
+            calls.incrementAndGet();
+            lastRequest.set(request);
+            if (alwaysFail || failuresRemaining.getAndUpdate(value -> Math.max(0, value - 1)) > 0) {
+                return AiResponse.failure(AiResponseStatus.RATE_LIMITED, id(), "test-model",
+                        "Rate limited.", Duration.ZERO, request.deterministicFallback());
+            }
+            return AiResponse.success(id(), "test-model", payload, Duration.ZERO, AiUsage.empty(),
+                    request.deterministicFallback());
+        }
+    }
+}

--- a/shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiProviderRegistryTest.java
+++ b/shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiProviderRegistryTest.java
@@ -1,0 +1,88 @@
+package com.shaft.pilot.ai;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.pilot.config.PilotConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class AiProviderRegistryTest {
+    @AfterEach
+    void clearProperties() {
+        SHAFT.Properties.clearForCurrentThread();
+    }
+
+    @Test
+    void disabledConfigurationResolvesNoOpProvider() {
+        assertInstanceOf(DisabledAiProvider.class, new AiProviderRegistry().resolve(PilotTestConfiguration.disabled()));
+    }
+
+    @Test
+    void pilotConfigurationDefaultsAreDisabledAndDenyConsent() {
+        PilotConfiguration configuration = PilotConfiguration.current();
+
+        assertEquals(false, configuration.enabled());
+        assertEquals("none", configuration.provider());
+        assertEquals(ApprovalPolicy.denyAll(), configuration.approvalPolicy());
+    }
+
+    @Test
+    void explicitProviderTakesPrecedence() {
+        AiProviderRegistry registry = new AiProviderRegistry();
+        AiProvider provider = new MinimalProvider("explicit");
+        registry.registerForCurrentThread(provider);
+        try {
+            assertEquals(provider, registry.resolve(PilotTestConfiguration.enabled("openai",
+                    ProcessingLocation.REMOTE)));
+        } finally {
+            registry.clearForCurrentThread();
+        }
+    }
+
+    @Test
+    void pilotPropertyOverridesAreIsolatedPerThread() {
+        CompletableFuture<String> openAi = CompletableFuture.supplyAsync(() -> {
+            try {
+                SHAFT.Properties.pilot.set().enabled(true).provider("openai");
+                return PilotConfiguration.current().provider();
+            } finally {
+                SHAFT.Properties.clearForCurrentThread();
+            }
+        });
+        CompletableFuture<String> ollama = CompletableFuture.supplyAsync(() -> {
+            try {
+                SHAFT.Properties.pilot.set().enabled(true).provider("ollama");
+                return PilotConfiguration.current().provider();
+            } finally {
+                SHAFT.Properties.clearForCurrentThread();
+            }
+        });
+
+        assertEquals("openai", openAi.join());
+        assertEquals("ollama", ollama.join());
+        assertEquals("none", PilotConfiguration.current().provider());
+    }
+
+    private record MinimalProvider(String id) implements AiProvider {
+        @Override
+        public AiCapabilities capabilities() {
+            return new AiCapabilities(true, false, false, 0, ProcessingLocation.REMOTE);
+        }
+
+        @Override
+        public AiProviderAvailability availability() {
+            return AiProviderAvailability.ready();
+        }
+
+        @Override
+        public AiResponse execute(AiRequest request) {
+            return AiResponse.failure(AiResponseStatus.ERROR, id, "", "not used", Duration.ZERO,
+                    request.deterministicFallback());
+        }
+    }
+}

--- a/shaft-pilot-core/src/test/java/com/shaft/pilot/ai/PilotTestConfiguration.java
+++ b/shaft-pilot-core/src/test/java/com/shaft/pilot/ai/PilotTestConfiguration.java
@@ -1,0 +1,50 @@
+package com.shaft.pilot.ai;
+
+import com.shaft.pilot.config.PilotConfiguration;
+import com.shaft.pilot.config.ProviderConfiguration;
+import com.shaft.pilot.security.RedactionPolicy;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.Duration;
+import java.util.EnumSet;
+import java.util.Map;
+
+final class PilotTestConfiguration {
+    private PilotTestConfiguration() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static PilotConfiguration enabled(String provider, ProcessingLocation location) {
+        boolean local = location == ProcessingLocation.LOCAL;
+        boolean remote = location == ProcessingLocation.REMOTE;
+        return new PilotConfiguration(
+                true,
+                provider,
+                new ApprovalPolicy(local, remote, EnumSet.allOf(EvidenceCategory.class)),
+                false,
+                Duration.ofSeconds(1),
+                1024 * 1024,
+                10_000,
+                1_000,
+                BigDecimal.TEN,
+                2,
+                2,
+                2,
+                Duration.ofSeconds(30),
+                new RedactionPolicy(
+                        java.util.Set.of("password", "authorization", "cookie"),
+                        java.util.List.of("input[type=password]"),
+                        java.util.List.of()),
+                Map.of(provider, new ProviderConfiguration(provider, URI.create("http://127.0.0.1"),
+                        "test-model", provider.equals("ollama") ? "" : "TEST_API_KEY", Map.of())));
+    }
+
+    static PilotConfiguration disabled() {
+        PilotConfiguration enabled = enabled("openai", ProcessingLocation.REMOTE);
+        return new PilotConfiguration(false, "none", ApprovalPolicy.denyAll(), false, enabled.timeout(),
+                enabled.maxRequestBytes(), enabled.maxInputTokens(), enabled.maxOutputTokens(), enabled.maxCostUsd(),
+                enabled.retryMaxAttempts(), enabled.maxConcurrency(), enabled.circuitBreakerFailureThreshold(),
+                enabled.circuitBreakerCooldown(), enabled.redactionPolicy(), enabled.providers());
+    }
+}

--- a/shaft-pilot-core/src/test/java/com/shaft/pilot/security/RedactorTest.java
+++ b/shaft-pilot-core/src/test/java/com/shaft/pilot/security/RedactorTest.java
@@ -1,0 +1,60 @@
+package com.shaft.pilot.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shaft.pilot.ai.AiRequest;
+import com.shaft.pilot.ai.ApprovalPolicy;
+import com.shaft.pilot.ai.EvidenceCategory;
+import com.shaft.pilot.ai.EvidenceReference;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RedactorTest {
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    @Test
+    void removesHeadersSecretsPasswordFieldsAndConfiguredDomContent() {
+        String secret = "do-not-log-this";
+        AiRequest request = AiRequest.builder("redaction-test", JSON.createObjectNode())
+                .text("Authorization: Bearer " + secret + "\nCookie: session=" + secret
+                        + "\napi_key=" + secret + "\n"
+                        + "<input type='password' value='" + secret + "'>"
+                        + "<div data-private='" + secret + "'>" + secret + "</div>")
+                .evidence(new EvidenceReference("log", EvidenceCategory.LOG, "text/plain",
+                        "password=" + secret))
+                .approvalPolicy(ApprovalPolicy.denyAll())
+                .build();
+        RedactionPolicy policy = new RedactionPolicy(
+                Set.of("value", "data-private"),
+                List.of("input[type=password]", "div[data-private]"),
+                List.of());
+
+        RedactionResult result = Redactor.redact(request, policy);
+        String combined = result.redactedText() + result.redactedEvidence().getFirst().content();
+
+        assertFalse(combined.contains(secret));
+        assertTrue(combined.contains(Redactor.REPLACEMENT));
+        assertTrue(result.appliedRules().contains("dom-selector"));
+        assertTrue(result.removedFields().contains("data-private"));
+    }
+
+    @Test
+    void ignoresMalformedCustomPatternsWithoutLeakingBuiltInSecrets() {
+        String secret = "do-not-log-this";
+        AiRequest request = AiRequest.builder("redaction-test", JSON.createObjectNode())
+                .text("password=" + secret)
+                .approvalPolicy(ApprovalPolicy.denyAll())
+                .build();
+        RedactionPolicy policy = new RedactionPolicy(Set.of(), List.of(), List.of("["));
+
+        RedactionResult result = Redactor.redact(request, policy);
+
+        assertFalse(result.redactedText().contains(secret));
+        assertTrue(result.appliedRules().contains("invalid-custom-pattern"));
+        assertTrue(result.appliedRules().contains("secret-assignment"));
+    }
+}

--- a/tests/scripts/test_measure_consumer_dependencies.py
+++ b/tests/scripts/test_measure_consumer_dependencies.py
@@ -187,6 +187,12 @@ The following files have been resolved:
             repository = root / "repository"
             jar = root / "shaft-engine.jar"
             engine_pom = root / "shaft-engine-pom.xml"
+            pilot_core_root = root / "shaft-pilot-core"
+            pilot_core_pom = pilot_core_root / "pom.xml"
+            pilot_core_jar = pilot_core_root / "target" / "shaft-pilot-core-1.2.3.jar"
+            ai_root = root / "shaft-ai"
+            ai_pom = ai_root / "pom.xml"
+            ai_jar = ai_root / "target" / "shaft-ai-1.2.3.jar"
             bom_pom = root / "shaft-bom-pom.xml"
             browserstack_root = root / "shaft-browserstack"
             browserstack_pom = browserstack_root / "pom.xml"
@@ -200,6 +206,14 @@ The following files have been resolved:
             legacy_pom = root / "legacy-pom.xml"
             jar.write_bytes(b"jar")
             engine_pom.write_text("<project>engine</project>", encoding="utf-8")
+            pilot_core_pom.parent.mkdir(parents=True)
+            pilot_core_pom.write_text("<project>pilot-core</project>", encoding="utf-8")
+            pilot_core_jar.parent.mkdir(parents=True)
+            pilot_core_jar.write_bytes(b"pilot-core-jar")
+            ai_pom.parent.mkdir(parents=True)
+            ai_pom.write_text("<project>ai</project>", encoding="utf-8")
+            ai_jar.parent.mkdir(parents=True)
+            ai_jar.write_bytes(b"ai-jar")
             bom_pom.write_text("<project>bom</project>", encoding="utf-8")
             browserstack_pom.parent.mkdir(parents=True)
             browserstack_pom.write_text("<project>browserstack</project>", encoding="utf-8")
@@ -218,6 +232,10 @@ The following files have been resolved:
 
             with (
                 mock.patch.object(measure, "ENGINE_POM", engine_pom),
+                mock.patch.object(measure, "PILOT_CORE_ROOT", pilot_core_root),
+                mock.patch.object(measure, "PILOT_CORE_POM", pilot_core_pom),
+                mock.patch.object(measure, "AI_ROOT", ai_root),
+                mock.patch.object(measure, "AI_POM", ai_pom),
                 mock.patch.object(measure, "BOM_POM", bom_pom),
                 mock.patch.object(measure, "BROWSERSTACK_ROOT", browserstack_root),
                 mock.patch.object(measure, "BROWSERSTACK_POM", browserstack_pom),
@@ -240,6 +258,14 @@ The following files have been resolved:
             self.assertEqual(
                 (repository / "io/github/shafthq/shaft-bom/1.2.3/shaft-bom-1.2.3.pom").read_text(encoding="utf-8"),
                 "<project>bom</project>",
+            )
+            self.assertEqual(
+                (repository / "io/github/shafthq/shaft-pilot-core/1.2.3/shaft-pilot-core-1.2.3.jar").read_bytes(),
+                b"pilot-core-jar",
+            )
+            self.assertEqual(
+                (repository / "io/github/shafthq/shaft-ai/1.2.3/shaft-ai-1.2.3.jar").read_bytes(),
+                b"ai-jar",
             )
             self.assertEqual(
                 (repository / "io/github/shafthq/shaft-browserstack/1.2.3/shaft-browserstack-1.2.3.pom").read_text(encoding="utf-8"),

--- a/tests/scripts/test_pilot_module_boundary.py
+++ b/tests/scripts/test_pilot_module_boundary.py
@@ -1,0 +1,76 @@
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+NS = {"m": "http://maven.apache.org/POM/4.0.0"}
+
+
+def artifacts(path: Path) -> set[str]:
+    root = ET.parse(path).getroot()
+    return {
+        dependency.findtext("m:artifactId", namespaces=NS)
+        for dependency in root.findall("m:dependencies/m:dependency", NS)
+    }
+
+
+class PilotModuleBoundaryTest(unittest.TestCase):
+    def test_engine_has_no_pilot_or_provider_dependency(self):
+        engine_dependencies = artifacts(ROOT / "shaft-engine/pom.xml")
+
+        self.assertNotIn("shaft-pilot-core", engine_dependencies)
+        self.assertNotIn("shaft-ai", engine_dependencies)
+
+    def test_dependency_direction_is_engine_then_core_then_ai(self):
+        core_dependencies = artifacts(ROOT / "shaft-pilot-core/pom.xml")
+        ai_dependencies = artifacts(ROOT / "shaft-ai/pom.xml")
+
+        self.assertIn("shaft-engine", core_dependencies)
+        self.assertNotIn("shaft-ai", core_dependencies)
+        self.assertIn("shaft-pilot-core", ai_dependencies)
+
+    def test_direct_provider_module_uses_service_loader_without_provider_sdks(self):
+        ai_dependencies = artifacts(ROOT / "shaft-ai/pom.xml")
+        service = ROOT / "shaft-ai/src/main/resources/META-INF/services/com.shaft.pilot.ai.AiProvider"
+        providers = service.read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(
+            providers,
+            [
+                "com.shaft.ai.provider.AnthropicProvider",
+                "com.shaft.ai.provider.GeminiProvider",
+                "com.shaft.ai.provider.OllamaProvider",
+                "com.shaft.ai.provider.OpenAiProvider",
+            ],
+        )
+        self.assertTrue(all("openai" not in artifact.lower() for artifact in ai_dependencies))
+        self.assertTrue(all("anthropic" not in artifact.lower() for artifact in ai_dependencies))
+        self.assertTrue(all("gemini" not in artifact.lower() for artifact in ai_dependencies))
+        self.assertTrue(all("ollama" not in artifact.lower() for artifact in ai_dependencies))
+
+    def test_bom_and_consumer_fixture_expose_provider_neutral_core(self):
+        bom = ET.parse(ROOT / "shaft-bom/pom.xml").getroot()
+        managed = {
+            dependency.findtext("m:artifactId", namespaces=NS)
+            for dependency in bom.findall("m:dependencyManagement/m:dependencies/m:dependency", NS)
+        }
+        fixture_dependencies = artifacts(
+            ROOT / "tools/modularization/consumer-fixtures/pilot-core/pom.xml"
+        )
+
+        self.assertIn("shaft-pilot-core", managed)
+        self.assertIn("shaft-ai", managed)
+        self.assertEqual(fixture_dependencies, {"shaft-pilot-core"})
+
+    def test_mcp_workflow_is_manual_and_daily_only(self):
+        workflow = (ROOT / ".github/workflows/shaft-mcp.yml").read_text(encoding="utf-8")
+
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertIn("cron: '00 1 * * *'", workflow)
+        self.assertNotIn("pull_request:", workflow)
+        self.assertNotIn("\n  push:", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_validate_maven_publication.py
+++ b/tests/scripts/test_validate_maven_publication.py
@@ -83,6 +83,11 @@ class MavenPublicationValidationTest(unittest.TestCase):
             with zipfile.ZipFile(bundle) as archive:
                 names = set(archive.namelist())
             self.assertIn(f"io/github/shafthq/shaft-engine/{version}/shaft-engine-{version}.jar", names)
+            self.assertIn(
+                f"io/github/shafthq/shaft-pilot-core/{version}/shaft-pilot-core-{version}.jar",
+                names,
+            )
+            self.assertIn(f"io/github/shafthq/shaft-ai/{version}/shaft-ai-{version}.jar", names)
             self.assertIn(f"io/github/shafthq/SHAFT_ENGINE/{version}/SHAFT_ENGINE-{version}.pom", names)
             sbom = f"io/github/shafthq/shaft-parent/{version}/shaft-parent-{version}-cyclonedx.json"
             self.assertIn(sbom, names)

--- a/tests/scripts/test_verify_maven_central_release.py
+++ b/tests/scripts/test_verify_maven_central_release.py
@@ -29,6 +29,8 @@ class VerifyMavenCentralReleaseTest(unittest.TestCase):
         paths = publication_paths("1.2.3")
 
         self.assertIn("io/github/shafthq/shaft-engine/1.2.3/shaft-engine-1.2.3.jar", paths)
+        self.assertIn("io/github/shafthq/shaft-pilot-core/1.2.3/shaft-pilot-core-1.2.3.jar", paths)
+        self.assertIn("io/github/shafthq/shaft-ai/1.2.3/shaft-ai-1.2.3-javadoc.jar.asc", paths)
         self.assertIn("io/github/shafthq/shaft-visual/1.2.3/shaft-visual-1.2.3-javadoc.jar.asc", paths)
         self.assertIn("io/github/shafthq/shaft-bom/1.2.3/shaft-bom-1.2.3.pom.asc", paths)
         self.assertIn("io/github/shafthq/SHAFT_ENGINE/1.2.3/SHAFT_ENGINE-1.2.3.pom", paths)

--- a/tools/modularization/consumer-fixtures/README.md
+++ b/tools/modularization/consumer-fixtures/README.md
@@ -4,7 +4,8 @@ These independent Maven projects compile representative downstream usage against
 canonical `io.github.shafthq:shaft-engine` coordinate, `bom` imports `io.github.shafthq:shaft-bom` and declares a
 versionless engine dependency, `browserstack-sdk` uses the optional `io.github.shafthq:shaft-browserstack` integration,
 `desktop-video` uses the optional `io.github.shafthq:shaft-video` integration, and `legacy-coordinate` verifies the
-POM-only `io.github.shafthq:SHAFT_ENGINE` relocation path. They intentionally do not share a parent POM so each can be
+POM-only `io.github.shafthq:SHAFT_ENGINE` relocation path. `pilot-core` compiles against provider-neutral Pilot
+contracts while enforcing that `shaft-ai` is absent. They intentionally do not share a parent POM so each can be
 copied and resolved in isolation.
 
 Run the repository build first, then measure all fixtures with one empty temporary Maven repository each:
@@ -22,4 +23,4 @@ committed pre-modularization baseline is under `docs/modularization/dependency-b
 
 ## Combined publication consumer
 
-`combined-modules/pom.xml` imports `shaft-bom` and resolves the engine plus all optional modules together. Its `verify` phase enforces dependency convergence, checks duplicate classes/resources (while excluding BrowserStack's intentionally shaded SDK and documented upstream resource overlaps), and generates a CycloneDX JSON SBOM. `mcp/pom.xml` resolves and copies the preserved `io.github.shafthq:SHAFT_MCP` executable coordinate without adding it to ordinary engine consumers. See `docs/MAVEN_CENTRAL_PUBLICATION.md` for the release dry-run command.
+`combined-modules/pom.xml` imports `shaft-bom` and resolves the engine plus all optional modules together. Its `verify` phase enforces dependency convergence, checks duplicate classes/resources (while excluding BrowserStack's intentionally shaded SDK and documented upstream resource overlaps), and generates a CycloneDX JSON SBOM. `pilot-core/pom.xml` proves Capture and Doctor-style consumers do not resolve `shaft-ai`. `mcp/pom.xml` resolves and copies the preserved `io.github.shafthq:SHAFT_MCP` executable coordinate without adding it to ordinary engine consumers. See `docs/MAVEN_CENTRAL_PUBLICATION.md` for the release dry-run command.

--- a/tools/modularization/consumer-fixtures/combined-modules/pom.xml
+++ b/tools/modularization/consumer-fixtures/combined-modules/pom.xml
@@ -33,6 +33,16 @@
         </dependency>
         <dependency>
             <groupId>io.github.shafthq</groupId>
+            <artifactId>shaft-pilot-core</artifactId>
+            <version>${shaft.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.shafthq</groupId>
+            <artifactId>shaft-ai</artifactId>
+            <version>${shaft.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.shafthq</groupId>
             <artifactId>shaft-browserstack</artifactId>
             <version>${shaft.version}</version>
         </dependency>

--- a/tools/modularization/consumer-fixtures/pilot-core/pom.xml
+++ b/tools/modularization/consumer-fixtures/pilot-core/pom.xml
@@ -1,0 +1,68 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.github.shafthq.consumer-fixtures</groupId>
+    <artifactId>pilot-core-consumer</artifactId>
+    <version>1.0.0</version>
+    <name>SHAFT Pilot core consumer</name>
+    <description>Compiles against Pilot contracts without the optional direct-provider module.</description>
+
+    <properties>
+        <shaft.version>10.2.20260610</shaft.version>
+        <maven.compiler.release>25</maven.compiler.release>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.github.shafthq</groupId>
+                <artifactId>shaft-bom</artifactId>
+                <version>${shaft.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.shafthq</groupId>
+            <artifactId>shaft-pilot-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.15.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.6.3</version>
+                <executions>
+                    <execution>
+                        <id>exclude-direct-providers</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <searchTransitive>true</searchTransitive>
+                                    <excludes>
+                                        <exclude>io.github.shafthq:shaft-ai</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/modularization/consumer-fixtures/pilot-core/src/main/java/example/PilotCoreConsumer.java
+++ b/tools/modularization/consumer-fixtures/pilot-core/src/main/java/example/PilotCoreConsumer.java
@@ -1,0 +1,22 @@
+package example;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.shaft.pilot.ai.AiRequest;
+
+/**
+ * Compile-only consumer proving feature modules need only Pilot contracts.
+ */
+public final class PilotCoreConsumer {
+    private PilotCoreConsumer() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Creates a deterministic contract request without loading direct providers.
+     *
+     * @return request
+     */
+    public static AiRequest request() {
+        return AiRequest.builder("consumer-fixture", JsonNodeFactory.instance.objectNode()).build();
+    }
+}


### PR DESCRIPTION
## Summary

- add the provider-neutral `shaft-pilot-core` module with immutable contracts, approval policy, redaction, budgets, audit metadata, retries, circuit breaking, schema validation, and deterministic fallback
- add the optional `shaft-ai` module with ServiceLoader-based OpenAI, Anthropic, Gemini, and Ollama HTTP adapters
- expose thread-local Pilot configuration with disabled-by-default behavior, explicit consent, environment-only credential lookup, and telemetry opt-out
- integrate both modules into the reactor, BOM, publication checks, quality workflows, aggregate reporting, JavaDocs, Dependabot, and consumer fixtures
- restrict the SHAFT MCP workflow to manual dispatch and the daily `01:00 UTC` schedule used by local E2E workflows
- document direct-provider and MCP interoperability, including credential-free client fixtures and Copilot-through-MCP guidance

## Impact

AI remains disabled by default and performs no network call unless a provider, model, and the required local or remote consent are explicitly configured. `shaft-engine` does not depend on either Pilot module, and provider SDK types are not exposed.

## Validation

- 39 focused Java policy and provider-conformance tests passed against mock HTTP endpoints
- 29 Python boundary, publication, and configuration tests passed
- full 11-module Java 25 reactor: `mvn --batch-mode clean install -DskipTests -Dgpg.skip`
- core-only and combined-module consumer fixtures passed dependency enforcement, convergence, and duplicate-class checks
- publication, quality, MCP, modular-documentation, reactor-version, JavaDoc, and `git diff --check` validation passed
- Allure result files were populated for the focused SHAFT test runs

Closes #2851