### PR TITLE
[codex] Add managed browser SHAFT Capture recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ mvn archetype:generate \
 |--------------------------------------------------------------------------|----------------------|
 | Web, Appium/Flutter, API, DB, CLI, reporting, screenshots, accessibility | `shaft-engine`       |
 | Provider-neutral Pilot contracts, approval, redaction, and fallback      | `shaft-pilot-core`   |
-| Deterministic browser recording model, privacy, and JSON persistence     | `shaft-capture`      |
+| Managed Chrome/Edge recording, privacy, and JSON persistence             | `shaft-capture`      |
 | Optional direct OpenAI, Anthropic, Gemini, and Ollama calls              | `shaft-ai`           |
 | BrowserStack SDK and multi-platform `browserstack.yml` orchestration     | `shaft-browserstack` |
 | Local non-headless desktop recording                                     | `shaft-video`        |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,7 +15,7 @@ flowchart TB
     Consumer["Consumer project"] --> BOM["shaft-bom<br/>dependency management"]
     Consumer --> Engine["shaft-engine<br/>required runtime"]
     Consumer -.->|optional| PilotCore["shaft-pilot-core<br/>contracts + security"]
-    Consumer -.->|optional| Capture["shaft-capture<br/>recording model + privacy"]
+    Consumer -.->|optional| Capture["shaft-capture<br/>managed recording + privacy"]
     Consumer -.->|optional| AI["shaft-ai<br/>direct providers"]
     Consumer -.->|optional| BrowserStack["shaft-browserstack<br/>BrowserStack Java SDK"]
     Consumer -.->|optional| Video["shaft-video<br/>local desktop recording"]
@@ -26,6 +26,7 @@ flowchart TB
     Video --> Engine
     Visual --> Engine
     MCP --> Engine
+    MCP --> Capture
     PilotCore --> Engine
     Capture --> PilotCore
     AI --> PilotCore
@@ -42,12 +43,12 @@ flowchart TB
 |----------------------|----------------|--------------------------------------------------------------------------------------------------------------------------|
 | `shaft-engine`       | JAR            | Required facade and core web, mobile, API, database, CLI, reporting, and accessibility implementation.                   |
 | `shaft-pilot-core`   | JAR            | Provider-neutral Pilot contracts, consent, redaction, budgets, audit metadata, and deterministic fallback.               |
-| `shaft-capture`      | JAR            | Versioned recording model, deterministic privacy classification, schema migration, and atomic JSON persistence.          |
+| `shaft-capture`      | JAR            | Managed Chrome/Edge recording, deterministic privacy classification, versioned schema, and atomic JSON persistence.       |
 | `shaft-ai`           | JAR            | Optional direct OpenAI, Anthropic, Gemini, and Ollama HTTP adapters discovered through `ServiceLoader`.                  |
 | `shaft-browserstack` | JAR            | BrowserStack SDK interception and `browserstack.yml` orchestration. Direct BrowserStack sessions stay in `shaft-engine`. |
 | `shaft-video`        | JAR            | Local non-headless desktop recording. Appium-native recording stays in `shaft-engine`.                                   |
 | `shaft-visual`       | JAR            | Reference-image assertions and image-based lookup through OpenCV, Eyes, and Shutterbug.                                  |
-| `SHAFT_MCP`          | executable JAR | Optional MCP server exposing SHAFT browser automation tools over stdio and Streamable HTTP.                              |
+| `SHAFT_MCP`          | executable JAR | Optional MCP server and CLI exposing SHAFT browser automation and managed capture controls.                              |
 | `shaft-bom`          | POM            | Aligns all SHAFT artifact versions; adds no runtime classes.                                                             |
 | `SHAFT_ENGINE`       | relocation POM | Temporary legacy-coordinate bridge to `shaft-engine`; adds no optional providers.                                        |
 

--- a/docs/MAVEN_REACTOR.md
+++ b/docs/MAVEN_REACTOR.md
@@ -10,9 +10,9 @@ relocation artifact that points consumers to the canonical JAR.
 - `shaft-engine/pom.xml` builds the engine JAR. All framework source, resources, tests, examples, and runtime support assets remain under `shaft-engine/src/`; Java packages remain under `com.shaft`.
 - `shaft-bom/pom.xml` publishes the consumer BOM. Importing it manages the `shaft-engine`, `shaft-pilot-core`, `shaft-capture`, `shaft-ai`, `shaft-browserstack`, `shaft-video`, `shaft-visual`, and `SHAFT_MCP` versions without adding dependencies by itself.
 - `shaft-pilot-core/pom.xml` builds provider-neutral Pilot contracts, security controls, configuration snapshots, and deterministic fallback. It depends on `shaft-engine`; the engine has no reverse dependency.
-- `shaft-capture/pom.xml` builds versioned recording contracts, deterministic privacy classification, schema migration, and atomic JSON persistence. It depends on `shaft-pilot-core` and has no dependency on `shaft-ai`.
+- `shaft-capture/pom.xml` builds managed Chrome/Edge recording, versioned contracts, deterministic privacy classification, schema migration, and atomic JSON persistence. It depends on `shaft-pilot-core` and has no dependency on `shaft-ai`.
 - `shaft-ai/pom.xml` builds optional direct OpenAI, Anthropic, Gemini, and Ollama adapters. It depends on `shaft-pilot-core` and exposes no provider SDK types.
-- `shaft-mcp/pom.xml` builds the optional executable MCP server. It depends on `shaft-engine`; the engine has no reverse dependency on MCP.
+- `shaft-mcp/pom.xml` builds the optional executable MCP server and SHAFT Capture CLI. It depends on `shaft-engine` and `shaft-capture`; the engine has no reverse dependency on MCP.
 - `shaft-browserstack/pom.xml` builds the optional BrowserStack Java SDK integration. Direct BrowserStack
   WebDriver/Appium sessions remain in `shaft-engine`.
 - `shaft-video/pom.xml` builds the optional desktop video recording provider. Add it when local desktop screen recording is needed; Appium-native recording remains in `shaft-engine`.
@@ -151,5 +151,6 @@ documented in [SHAFT MCP](SHAFT_MCP.md).
 Pilot contracts, direct-provider configuration, approval, and redaction are
 documented in [SHAFT Pilot AI](SHAFT_PILOT_AI.md).
 
-The versioned browser recording format and deterministic privacy boundary are
-documented in [SHAFT Capture](SHAFT_CAPTURE.md).
+Managed-browser recording, its CLI/MCP controls, the versioned format, and the
+deterministic privacy boundary are documented in
+[SHAFT Capture](SHAFT_CAPTURE.md).

--- a/docs/SHAFT_CAPTURE.md
+++ b/docs/SHAFT_CAPTURE.md
@@ -1,13 +1,50 @@
-# SHAFT Capture recording format
+# SHAFT Capture
 
 `shaft-capture` defines the provider-neutral intermediate representation used
-by SHAFT Capture. It records browser intent for review, replay, migration, and
-future Java/JUnit/Cucumber generators without collecting browser events itself
-and without depending on `shaft-ai`.
+by SHAFT Capture and the managed-browser recorder that produces it. It records
+browser intent for review, replay, migration, and future Java/JUnit/Cucumber
+generators without depending on `shaft-ai`.
 
 Capture creation, validation, serialization, and privacy enforcement work with
 `pilot.ai.enabled=false`. Optional AI consumers may receive only the already
 redacted representation after the separate Pilot approval checks succeed.
+
+## Managed browser recording
+
+The recorder launches a fresh SHAFT-managed Chrome or Edge session. Firefox is
+rejected with an explicit unsupported-browser message until equivalent event
+coverage is available. WebDriver BiDi supplies navigation, browsing-context,
+prompt, and preload-script signals when available. A JavaScript listener
+drained through ordinary WebDriver provides deterministic interaction capture
+and remains the compatibility fallback.
+
+Build the executable MCP JAR, then use its `capture` subcommand:
+
+```bash
+mvn -pl shaft-mcp -am package -DskipTests -Dgpg.skip
+java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture start \
+  --url https://example.test --browser chrome \
+  --output recordings/example.json --headless
+java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture status
+java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture checkpoint \
+  --description "Checkout ready"
+java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture stop
+```
+
+Use `--runtime-dir <path>` on every command to isolate control files. `stop`
+also accepts `--discard`. Only one recorder may own a runtime directory at a
+time. The daemon control endpoint is bound to loopback, requires a generated
+bearer token, and removes its token and descriptor at shutdown. Browser
+profiles are temporary and removed after normal stop or interruption.
+
+The same lifecycle is exposed by the `capture_start`, `capture_status`, and
+`capture_stop` MCP tools. Status contains safe metadata and counts, never typed
+values.
+
+All process arguments and filesystem paths are built with Java APIs
+(`ProcessBuilder`, `Path`, and `Files`). No Windows, POSIX shell, or path
+separator is assumed; restrictive POSIX permissions are applied when supported
+and otherwise the host filesystem's inherited permissions are used.
 
 ## Format
 
@@ -78,4 +115,12 @@ Run the focused suite with:
 
 ```bash
 mvn -pl shaft-capture -am test
+```
+
+The real-browser Chrome and Edge suite is opt-in:
+
+```bash
+mvn -pl shaft-capture -am test \
+  -DincludeCaptureBrowserE2E=true \
+  -Dtest=ManagedCaptureRecorderBrowserTest
 ```

--- a/docs/SHAFT_MCP.md
+++ b/docs/SHAFT_MCP.md
@@ -19,10 +19,24 @@ The packaged server supports:
 
 - stdio by default, with protocol messages only on stdout and logs on stderr;
 - Streamable HTTP with `--spring.profiles.active=http`, at `/mcp`;
+- managed recording through `capture_start`, `capture_status`, and
+  `capture_stop`, with no AI provider required;
 - legacy SSE endpoint properties as configuration aliases during migration.
 
 The HTTP port defaults to `8081` and can be overridden with `PORT` or
 `--server.port`.
+
+The same JAR also provides a local SHAFT Capture CLI:
+
+```bash
+java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture start \
+  --url https://example.test --browser chrome --output recordings/example.json
+java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture status
+java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture stop
+```
+
+See [SHAFT Capture](SHAFT_CAPTURE.md) for checkpoint, runtime-directory,
+privacy, browser-support, and recovery details.
 
 ## Authentication boundary
 

--- a/shaft-capture/pom.xml
+++ b/shaft-capture/pom.xml
@@ -53,6 +53,7 @@
                     <includes>
                         <include>com/**/*</include>
                         <include>schema/**/*</include>
+                        <include>browser/**/*</include>
                     </includes>
                 </configuration>
             </plugin>
@@ -69,9 +70,34 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.6</version>
                 <configuration>
+                    <excludedGroups>external-e2e</excludedGroups>
                     <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
                 </configuration>
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>capture-browser-e2e</id>
+            <activation>
+                <property>
+                    <name>includeCaptureBrowserE2E</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration combine.self="override">
+                            <groups>external-e2e</groups>
+                            <excludedGroups/>
+                            <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/shaft-capture/src/main/java/com/shaft/capture/cli/CaptureCli.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/cli/CaptureCli.java
@@ -1,0 +1,400 @@
+package com.shaft.capture.cli;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.shaft.capture.control.CaptureControlClient;
+import com.shaft.capture.control.CaptureControlFiles;
+import com.shaft.capture.control.CaptureControlServer;
+import com.shaft.capture.model.Checkpoint;
+import com.shaft.capture.privacy.CapturePrivacyClassifier;
+import com.shaft.capture.runtime.CaptureBrowser;
+import com.shaft.capture.runtime.CaptureManager;
+import com.shaft.capture.runtime.CaptureStartRequest;
+import com.shaft.capture.runtime.CaptureStatus;
+
+import java.io.File;
+import java.io.FileDescriptor;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Executable local CLI for managed SHAFT Capture recording.
+ */
+public final class CaptureCli {
+    private static final Duration START_TIMEOUT = Duration.ofSeconds(60);
+    private static final Path DEFAULT_RUNTIME = Path.of("target", "shaft-capture");
+    private static final DateTimeFormatter FILE_TIME = DateTimeFormatter
+            .ofPattern("yyyyMMdd-HHmmss")
+            .withZone(ZoneOffset.UTC);
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    private static final PrintWriter OUTPUT = new PrintWriter(
+            new OutputStreamWriter(new FileOutputStream(FileDescriptor.out), StandardCharsets.UTF_8), true);
+    private static final PrintWriter ERROR = new PrintWriter(
+            new OutputStreamWriter(new FileOutputStream(FileDescriptor.err), StandardCharsets.UTF_8), true);
+
+    private CaptureCli() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * CLI entry point.
+     *
+     * @param args capture command arguments
+     */
+    public static void main(String[] args) {
+        int exitCode = run(args, defaultLaunchPrefix());
+        if (exitCode != 0) {
+            System.exit(exitCode);
+        }
+    }
+
+    /**
+     * Runs a command with an explicit daemon launch prefix.
+     *
+     * @param args capture command arguments
+     * @param launchPrefix command used to relaunch this CLI before the daemon subcommand
+     * @return process-style exit code
+     */
+    public static int run(String[] args, List<String> launchPrefix) {
+        try {
+            if (args == null || args.length == 0) {
+                throw new IllegalArgumentException(usage());
+            }
+            String command = args[0].trim().toLowerCase(Locale.ROOT);
+            Arguments options = Arguments.parse(Arrays.copyOfRange(args, 1, args.length));
+            return switch (command) {
+                case "start" -> start(options, launchPrefix);
+                case "status" -> status(options);
+                case "stop" -> stop(options);
+                case "checkpoint" -> checkpoint(options);
+                case "daemon" -> daemon(options);
+                default -> throw new IllegalArgumentException(usage());
+            };
+        } catch (RuntimeException exception) {
+            ERROR.println("SHAFT Capture command failed: " + safeMessage(exception));
+            return 1;
+        }
+    }
+
+    private static int start(Arguments options, List<String> launchPrefix) {
+        Path runtime = options.path("runtime-dir", DEFAULT_RUNTIME);
+        CaptureControlFiles files = new CaptureControlFiles(runtime);
+        CaptureControlClient client = new CaptureControlClient(runtime);
+        if (files.hasActiveControl() && isRunning(client.status().state())) {
+            throw new IllegalStateException("A SHAFT Capture session is already active.");
+        }
+        String url = options.required("url");
+        CaptureBrowser browser = CaptureBrowser.parse(options.value("browser", "chrome"));
+        Path output = options.path(
+                "output",
+                Path.of("recordings", "capture-" + FILE_TIME.format(Instant.now()) + ".json"));
+        CaptureStartRequest request = new CaptureStartRequest(
+                url,
+                browser,
+                output,
+                runtime,
+                options.flag("headless"));
+        var safeUrl = new CapturePrivacyClassifier().sanitizeUrl(url).value();
+        files.writeStatus(new CaptureStatus(
+                CaptureStatus.State.STARTING,
+                "",
+                browser.name().toLowerCase(),
+                safeUrl,
+                0,
+                List.of(),
+                request.outputPath().toString(),
+                false,
+                0,
+                Instant.now()));
+        Path requestFile = files.writeLaunchRequest(request);
+        Process process = launchDaemon(launchPrefix, runtime, requestFile);
+        CaptureStatus started = awaitStart(client, files, process);
+        print(started);
+        return started.state() == CaptureStatus.State.ACTIVE ? 0 : 1;
+    }
+
+    private static int status(Arguments options) {
+        CaptureStatus status = new CaptureControlClient(
+                options.path("runtime-dir", DEFAULT_RUNTIME)).status();
+        print(status);
+        return 0;
+    }
+
+    private static int stop(Arguments options) {
+        CaptureControlClient client = new CaptureControlClient(
+                options.path("runtime-dir", DEFAULT_RUNTIME));
+        CaptureStatus status = client.status();
+        if (!isRunning(status.state())) {
+            print(status);
+            return 0;
+        }
+        print(client.stop(options.flag("discard")));
+        return 0;
+    }
+
+    private static int checkpoint(Arguments options) {
+        CaptureControlClient client = new CaptureControlClient(
+                options.path("runtime-dir", DEFAULT_RUNTIME));
+        Checkpoint.CheckpointKind kind;
+        try {
+            kind = Checkpoint.CheckpointKind.valueOf(
+                    options.value("kind", "USER_MARKER").toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalArgumentException("Unsupported checkpoint kind.", exception);
+        }
+        print(client.checkpoint(options.required("description"), kind));
+        return 0;
+    }
+
+    private static int daemon(Arguments options) {
+        Path runtime = options.path("runtime-dir", DEFAULT_RUNTIME);
+        CaptureControlFiles files = new CaptureControlFiles(runtime);
+        CaptureStartRequest request = files.consumeLaunchRequest(options.pathRequired("request-file"));
+        if (!request.runtimeDirectory().equals(runtime.toAbsolutePath().normalize())) {
+            throw new IllegalArgumentException("Capture launch request runtime directory does not match.");
+        }
+        String token = token();
+        CountDownLatch stopped = new CountDownLatch(1);
+        CaptureManager manager = new CaptureManager();
+        CaptureControlServer server = new CaptureControlServer(manager, files, token, stopped::countDown);
+        Thread shutdownHook = new Thread(() -> {
+            manager.close();
+            files.writeStatus(manager.status());
+            files.clearActiveControl();
+        }, "shaft-capture-shutdown");
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
+        try {
+            int port = server.start();
+            files.writeToken(token);
+            files.writeDescriptor(new CaptureControlFiles.ControlDescriptor(
+                    port, ProcessHandle.current().pid()));
+            CaptureStatus active = manager.start(request);
+            files.writeStatus(active);
+            while (!stopped.await(500, TimeUnit.MILLISECONDS)) {
+                CaptureStatus current = manager.status();
+                files.writeStatus(current);
+                if (!isRunning(current.state())) {
+                    break;
+                }
+            }
+            files.writeStatus(manager.status());
+            return 0;
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            manager.close();
+            files.writeStatus(manager.status());
+            return 1;
+        } catch (RuntimeException exception) {
+            CaptureStatus failed = new CaptureStatus(
+                    CaptureStatus.State.FAILED,
+                    manager.status().sessionId(),
+                    request.browser().name().toLowerCase(),
+                    new CapturePrivacyClassifier().sanitizeUrl(request.targetUrl()).value(),
+                    manager.status().eventCount(),
+                    List.of("Managed browser startup failed."),
+                    request.outputPath().toString(),
+                    false,
+                    ProcessHandle.current().pid(),
+                    Instant.now());
+            files.writeStatus(failed);
+            return 1;
+        } finally {
+            server.close();
+            manager.close();
+            files.clearActiveControl();
+            try {
+                Runtime.getRuntime().removeShutdownHook(shutdownHook);
+            } catch (IllegalStateException ignored) {
+                // JVM shutdown is already running the same cleanup.
+            }
+        }
+    }
+
+    private static Process launchDaemon(List<String> launchPrefix, Path runtime, Path requestFile) {
+        if (launchPrefix == null || launchPrefix.isEmpty()) {
+            throw new IllegalArgumentException("Capture daemon launch command is unavailable.");
+        }
+        List<String> command = new ArrayList<>(launchPrefix);
+        command.add("daemon");
+        command.add("--runtime-dir");
+        command.add(runtime.toAbsolutePath().normalize().toString());
+        command.add("--request-file");
+        command.add(requestFile.toAbsolutePath().normalize().toString());
+        try {
+            Path normalizedRuntime = runtime.toAbsolutePath().normalize();
+            Files.createDirectories(normalizedRuntime);
+            Path log = normalizedRuntime.resolve("daemon.log");
+            return new ProcessBuilder(command)
+                    .directory(normalizedRuntime.toFile())
+                    .redirectOutput(ProcessBuilder.Redirect.appendTo(log.toFile()))
+                    .redirectError(ProcessBuilder.Redirect.appendTo(log.toFile()))
+                    .start();
+        } catch (java.io.IOException exception) {
+            throw new IllegalStateException("SHAFT Capture daemon process could not be launched.", exception);
+        }
+    }
+
+    private static CaptureStatus awaitStart(
+            CaptureControlClient client,
+            CaptureControlFiles files,
+            Process process) {
+        Instant deadline = Instant.now().plus(START_TIMEOUT);
+        while (Instant.now().isBefore(deadline)) {
+            if (!files.hasActiveControl() && process.isAlive()) {
+                sleepForStart();
+                continue;
+            }
+            CaptureStatus status = client.status();
+            if (status.state() == CaptureStatus.State.ACTIVE
+                    || status.state() == CaptureStatus.State.FAILED
+                    || status.state() == CaptureStatus.State.INCOMPLETE) {
+                return status;
+            }
+            if (!process.isAlive()) {
+                return files.readStatus();
+            }
+            sleepForStart();
+        }
+        process.destroy();
+        return new CaptureStatus(
+                CaptureStatus.State.FAILED,
+                "",
+                "",
+                "",
+                0,
+                List.of("Managed browser startup timed out."),
+                "",
+                false,
+                process.pid(),
+                null);
+    }
+
+    private static void sleepForStart() {
+        try {
+            Thread.sleep(200);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while starting SHAFT Capture.", exception);
+        }
+    }
+
+    private static List<String> defaultLaunchPrefix() {
+        String javaCommand = ProcessHandle.current().info().command().orElse("java");
+        return List.of(
+                javaCommand,
+                "-cp",
+                absoluteClassPath(ManagementFactory.getRuntimeMXBean().getClassPath()),
+                CaptureCli.class.getName());
+    }
+
+    private static String absoluteClassPath(String classPath) {
+        return Arrays.stream(classPath.split(Pattern.quote(File.pathSeparator)))
+                .map(entry -> Path.of(entry).toAbsolutePath().normalize().toString())
+                .collect(Collectors.joining(File.pathSeparator));
+    }
+
+    private static String token() {
+        byte[] bytes = new byte[32];
+        new SecureRandom().nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private static void print(CaptureStatus status) {
+        try {
+            OUTPUT.println(MAPPER.writeValueAsString(status));
+        } catch (com.fasterxml.jackson.core.JsonProcessingException exception) {
+            throw new IllegalStateException("Capture status could not be serialized.", exception);
+        }
+    }
+
+    private static boolean isRunning(CaptureStatus.State state) {
+        return state == CaptureStatus.State.STARTING
+                || state == CaptureStatus.State.ACTIVE
+                || state == CaptureStatus.State.STOPPING;
+    }
+
+    private static String safeMessage(RuntimeException exception) {
+        String message = exception.getMessage();
+        return message == null || message.isBlank() ? "operation failed." : message;
+    }
+
+    private static String usage() {
+        return "Usage: capture start --url <url> [--browser chrome|edge] [--output <path>] "
+                + "[--runtime-dir <path>] [--headless] | status | stop [--discard] | "
+                + "checkpoint --description <text> [--kind USER_MARKER|ASSERTION|PAGE_TRANSITION|RECOVERY]";
+    }
+
+    private record Arguments(Map<String, String> values, java.util.Set<String> flags) {
+        private static Arguments parse(String[] args) {
+            Map<String, String> values = new LinkedHashMap<>();
+            java.util.Set<String> flags = new java.util.LinkedHashSet<>();
+            for (int index = 0; index < args.length; index++) {
+                String argument = args[index];
+                if (!argument.startsWith("--")) {
+                    throw new IllegalArgumentException("Unexpected capture argument.");
+                }
+                String name = argument.substring(2);
+                if ("headless".equals(name) || "discard".equals(name)) {
+                    flags.add(name);
+                } else {
+                    if (index + 1 >= args.length || args[index + 1].startsWith("--")) {
+                        throw new IllegalArgumentException("Capture option --" + name + " requires a value.");
+                    }
+                    values.put(name, args[++index]);
+                }
+            }
+            return new Arguments(Map.copyOf(values), Set.copyOf(flags));
+        }
+
+        private String required(String name) {
+            String value = values.get(name);
+            if (value == null || value.isBlank()) {
+                throw new IllegalArgumentException("Capture option --" + name + " is required.");
+            }
+            return value;
+        }
+
+        private String value(String name, String fallback) {
+            String value = values.get(name);
+            return value == null || value.isBlank() ? fallback : value;
+        }
+
+        private Path path(String name, Path fallback) {
+            String value = values.get(name);
+            return value == null || value.isBlank() ? fallback : Path.of(value);
+        }
+
+        private Path pathRequired(String name) {
+            return Path.of(required(name));
+        }
+
+        private boolean flag(String name) {
+            return flags.contains(name);
+        }
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/collector/BidiBrowserEventCollector.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/collector/BidiBrowserEventCollector.java
@@ -1,0 +1,133 @@
+package com.shaft.capture.collector;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.bidi.browsingcontext.BrowsingContextInfo;
+import org.openqa.selenium.bidi.module.BrowsingContextInspector;
+import org.openqa.selenium.bidi.module.Script;
+import org.openqa.selenium.bidi.script.ChannelValue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+/**
+ * WebDriver BiDi collector using preload scripts for immediate cross-context signals.
+ */
+public final class BidiBrowserEventCollector implements BrowserEventCollector {
+    private static final String CHANNEL = "shaft-capture";
+
+    private final WebDriver driver;
+    private final Map<String, String> promptTypes = new ConcurrentHashMap<>();
+    private Script script;
+    private BrowsingContextInspector contexts;
+    private String preloadId;
+
+    /**
+     * Creates a BiDi collector.
+     *
+     * @param driver BiDi-capable driver
+     */
+    public BidiBrowserEventCollector(WebDriver driver) {
+        if (driver == null) {
+            throw new IllegalArgumentException("Capture WebDriver is required.");
+        }
+        this.driver = driver;
+    }
+
+    @Override
+    public void start(Consumer<BrowserSignal> signalConsumer, Consumer<String> warningConsumer) {
+        if (signalConsumer == null || warningConsumer == null) {
+            throw new IllegalArgumentException("Capture signal and warning consumers are required.");
+        }
+        script = new Script(driver);
+        script.onMessage(message -> {
+            if (!CHANNEL.equals(message.getChannel())) {
+                return;
+            }
+            Object value = message.getData().getValue().orElse("");
+            String contextId = message.getSource().getBrowsingContext().orElse("");
+            try {
+                signalConsumer.accept(BrowserSignal.fromJson(String.valueOf(value), contextId));
+            } catch (RuntimeException exception) {
+                warningConsumer.accept("A malformed browser interaction signal was ignored.");
+            }
+        });
+        preloadId = script.addPreloadScript(
+                BrowserEventScript.preloadFunction(),
+                List.of(new ChannelValue(CHANNEL)));
+
+        contexts = new BrowsingContextInspector(driver);
+        contexts.onNavigationCommitted(info -> signalConsumer.accept(BrowserSignal.generated(
+                "navigation",
+                info.getBrowsingContextId(),
+                Map.of("url", info.getUrl()),
+                Map.of("action", "OPEN"))));
+        contexts.onHistoryUpdated(info -> signalConsumer.accept(BrowserSignal.generated(
+                "navigation",
+                info.getBrowsingContextId(),
+                Map.of("url", info.getUrl()),
+                Map.of("action", "OPEN"))));
+        contexts.onBrowsingContextCreated(info -> {
+            if (isTopLevel(info)) {
+                signalConsumer.accept(BrowserSignal.generated(
+                        "window_open",
+                        info.getId(),
+                        Map.of("url", info.getUrl()),
+                        Map.of()));
+            }
+        });
+        contexts.onBrowsingContextDestroyed(info -> {
+            if (isTopLevel(info)) {
+                signalConsumer.accept(BrowserSignal.generated(
+                        "window_close",
+                        info.getId(),
+                        Map.of("url", info.getUrl()),
+                        Map.of()));
+            }
+        });
+        contexts.onUserPromptOpened(prompt ->
+                promptTypes.put(prompt.getBrowsingContextId(), prompt.getType().toString()));
+        contexts.onUserPromptClosed(prompt -> {
+            String promptType = promptTypes.remove(prompt.getBrowsingContextId());
+            signalConsumer.accept(BrowserSignal.generated(
+                    "alert",
+                    prompt.getBrowsingContextId(),
+                    Map.of(),
+                    Map.of(
+                            "accepted", prompt.getAccepted(),
+                            "promptType", promptType == null ? "" : promptType,
+                            "text", prompt.getUserText().orElse(""))));
+        });
+    }
+
+    @Override
+    public void close() {
+        if (script != null && preloadId != null) {
+            try {
+                script.removePreloadScript(preloadId);
+            } catch (RuntimeException ignored) {
+                // The browser may already have crashed or closed.
+            }
+        }
+        if (contexts != null) {
+            try {
+                contexts.close();
+            } catch (RuntimeException ignored) {
+                // Best-effort protocol cleanup.
+            }
+        }
+        if (script != null) {
+            try {
+                script.close();
+            } catch (RuntimeException ignored) {
+                // Best-effort protocol cleanup.
+            }
+        }
+    }
+
+    private static boolean isTopLevel(BrowsingContextInfo context) {
+        return context.getParentBrowsingContext() == null
+                || context.getParentBrowsingContext().isBlank();
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventCollector.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventCollector.java
@@ -1,0 +1,22 @@
+package com.shaft.capture.collector;
+
+import java.util.function.Consumer;
+
+/**
+ * Collects browser signals without persisting unclassified values.
+ */
+public interface BrowserEventCollector extends AutoCloseable {
+    /**
+     * Starts event collection.
+     *
+     * @param signalConsumer signal destination
+     * @param warningConsumer safe warning destination
+     */
+    void start(Consumer<BrowserSignal> signalConsumer, Consumer<String> warningConsumer);
+
+    /**
+     * Stops collection and releases protocol listeners.
+     */
+    @Override
+    void close();
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventScript.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventScript.java
@@ -1,0 +1,55 @@
+package com.shaft.capture.collector;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Loads the browser-side semantic event listener.
+ */
+public final class BrowserEventScript {
+    private static final String RESOURCE = "/browser/shaft-capture-recorder.js";
+    private static final String SCRIPT = load();
+
+    private BrowserEventScript() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Returns the BiDi preload function declaration.
+     *
+     * @return JavaScript function
+     */
+    public static String preloadFunction() {
+        return SCRIPT;
+    }
+
+    /**
+     * Returns JavaScript that installs the fallback queue listener.
+     *
+     * @return installation JavaScript
+     */
+    public static String fallbackInstallation() {
+        return "return (" + SCRIPT + ")(null);";
+    }
+
+    /**
+     * Returns JavaScript that drains fallback signals.
+     *
+     * @return queue drain JavaScript
+     */
+    public static String fallbackDrain() {
+        return "return globalThis.__shaftCaptureQueue ? globalThis.__shaftCaptureQueue.splice(0) : [];";
+    }
+
+    private static String load() {
+        try (InputStream input = BrowserEventScript.class.getResourceAsStream(RESOURCE)) {
+            if (input == null) {
+                throw new IllegalStateException("Bundled SHAFT Capture browser listener is missing.");
+            }
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException exception) {
+            throw new IllegalStateException("Bundled SHAFT Capture browser listener could not be read.", exception);
+        }
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/collector/BrowserSignal.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/collector/BrowserSignal.java
@@ -1,0 +1,159 @@
+package com.shaft.capture.collector;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shaft.capture.format.CaptureFormatException;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Raw browser signal containing an immediate DOM snapshot but no persisted value.
+ *
+ * @param kind normalized low-level signal kind
+ * @param timestamp signal time
+ * @param browsingContextId BiDi or fallback browsing-context identifier
+ * @param page safe page fields captured with the signal
+ * @param target immediate element evidence
+ * @param data transient action data awaiting privacy classification
+ */
+public record BrowserSignal(
+        String kind,
+        Instant timestamp,
+        String browsingContextId,
+        Map<String, Object> page,
+        Map<String, Object> target,
+        Map<String, Object> data) {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Creates an immutable signal.
+     */
+    public BrowserSignal {
+        kind = kind == null ? "" : kind.trim().toLowerCase();
+        timestamp = timestamp == null ? Instant.now() : timestamp;
+        browsingContextId = browsingContextId == null ? "" : browsingContextId;
+        page = copy(page);
+        target = copy(target);
+        data = copy(data);
+    }
+
+    /**
+     * Parses a browser-side JSON signal.
+     *
+     * @param json signal JSON
+     * @param browsingContextId source browsing context
+     * @return parsed signal
+     */
+    public static BrowserSignal fromJson(String json, String browsingContextId) {
+        try {
+            Map<String, Object> payload = MAPPER.readValue(json, new TypeReference<>() {
+            });
+            long timestamp = longValue(payload.get("timestamp"), System.currentTimeMillis());
+            return new BrowserSignal(
+                    string(payload.get("kind")),
+                    Instant.ofEpochMilli(timestamp),
+                    browsingContextId,
+                    map(payload.get("page")),
+                    map(payload.get("target")),
+                    map(payload.get("data")));
+        } catch (JsonProcessingException exception) {
+            throw new CaptureFormatException("Browser capture signal is malformed.", exception);
+        }
+    }
+
+    /**
+     * Creates a recorder-generated signal.
+     *
+     * @param kind signal kind
+     * @param contextId browsing context
+     * @param page page fields
+     * @param data action fields
+     * @return generated signal
+     */
+    public static BrowserSignal generated(
+            String kind,
+            String contextId,
+            Map<String, Object> page,
+            Map<String, Object> data) {
+        return new BrowserSignal(kind, Instant.now(), contextId, page, Map.of(), data);
+    }
+
+    /**
+     * Reads a string data field.
+     *
+     * @param key field name
+     * @return field value
+     */
+    public String dataString(String key) {
+        return string(data.get(key));
+    }
+
+    /**
+     * Reads an integer data field.
+     *
+     * @param key field name
+     * @param fallback fallback value
+     * @return field value
+     */
+    public int dataInt(String key, int fallback) {
+        return (int) longValue(data.get(key), fallback);
+    }
+
+    /**
+     * Reads a boolean data field.
+     *
+     * @param key field name
+     * @return field value
+     */
+    public boolean dataBoolean(String key) {
+        Object value = data.get(key);
+        return value instanceof Boolean bool ? bool : Boolean.parseBoolean(string(value));
+    }
+
+    /**
+     * Reads a list data field as strings.
+     *
+     * @param key field name
+     * @return string list
+     */
+    public List<String> dataStrings(String key) {
+        Object value = data.get(key);
+        if (!(value instanceof List<?> list)) {
+            return List.of();
+        }
+        return list.stream().map(BrowserSignal::string).filter(item -> !item.isBlank()).toList();
+    }
+
+    private static Map<String, Object> copy(Map<String, Object> value) {
+        return value == null ? Map.of() : Map.copyOf(new LinkedHashMap<>(value));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> map(Object value) {
+        if (!(value instanceof Map<?, ?> source)) {
+            return Map.of();
+        }
+        Map<String, Object> result = new LinkedHashMap<>();
+        source.forEach((key, item) -> result.put(string(key), item));
+        return result;
+    }
+
+    private static String string(Object value) {
+        return value == null ? "" : String.valueOf(value);
+    }
+
+    private static long longValue(Object value, long fallback) {
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        try {
+            return Long.parseLong(string(value));
+        } catch (NumberFormatException ignored) {
+            return fallback;
+        }
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/collector/CompositeBrowserEventCollector.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/collector/CompositeBrowserEventCollector.java
@@ -1,0 +1,50 @@
+package com.shaft.capture.collector;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Combines protocol and compatibility collectors behind one lifecycle.
+ */
+public final class CompositeBrowserEventCollector implements BrowserEventCollector {
+    private final List<BrowserEventCollector> collectors;
+
+    /**
+     * Creates a composite collector.
+     *
+     * @param collectors collectors to start and close together
+     */
+    public CompositeBrowserEventCollector(List<BrowserEventCollector> collectors) {
+        if (collectors == null || collectors.isEmpty() || collectors.stream().anyMatch(java.util.Objects::isNull)) {
+            throw new IllegalArgumentException("At least one browser event collector is required.");
+        }
+        this.collectors = List.copyOf(collectors);
+    }
+
+    @Override
+    public void start(Consumer<BrowserSignal> signalConsumer, Consumer<String> warningConsumer) {
+        int started = 0;
+        try {
+            for (BrowserEventCollector collector : collectors) {
+                collector.start(signalConsumer, warningConsumer);
+                started++;
+            }
+        } catch (RuntimeException exception) {
+            for (int index = started - 1; index >= 0; index--) {
+                collectors.get(index).close();
+            }
+            throw exception;
+        }
+    }
+
+    @Override
+    public void close() {
+        for (int index = collectors.size() - 1; index >= 0; index--) {
+            try {
+                collectors.get(index).close();
+            } catch (RuntimeException ignored) {
+                // Best-effort cleanup continues for the remaining collectors.
+            }
+        }
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/collector/PollingBrowserEventCollector.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/collector/PollingBrowserEventCollector.java
@@ -1,0 +1,142 @@
+package com.shaft.capture.collector;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchSessionException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
+
+import java.time.Duration;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+/**
+ * Classic WebDriver fallback for browsers where BiDi collection is unavailable.
+ */
+public final class PollingBrowserEventCollector implements BrowserEventCollector {
+    private static final Duration POLL_INTERVAL = Duration.ofMillis(100);
+
+    private final WebDriver driver;
+    private final boolean reportFallbackWarning;
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+        Thread thread = new Thread(runnable, "shaft-capture-polling");
+        thread.setDaemon(true);
+        return thread;
+    });
+    private final AtomicBoolean warned = new AtomicBoolean();
+    private volatile String lastUrl = "";
+    private Set<String> lastWindows = Set.of();
+
+    /**
+     * Creates a classic WebDriver collector.
+     *
+     * @param driver active driver
+     */
+    public PollingBrowserEventCollector(WebDriver driver) {
+        this(driver, true);
+    }
+
+    /**
+     * Creates a classic WebDriver collector.
+     *
+     * @param driver active driver
+     * @param reportFallbackWarning whether status should report reduced BiDi coverage
+     */
+    public PollingBrowserEventCollector(WebDriver driver, boolean reportFallbackWarning) {
+        if (driver == null) {
+            throw new IllegalArgumentException("Capture WebDriver is required.");
+        }
+        this.driver = driver;
+        this.reportFallbackWarning = reportFallbackWarning;
+    }
+
+    @Override
+    public void start(Consumer<BrowserSignal> signalConsumer, Consumer<String> warningConsumer) {
+        if (!(driver instanceof JavascriptExecutor)) {
+            throw new IllegalArgumentException("Capture fallback requires JavaScript execution.");
+        }
+        if (reportFallbackWarning) {
+            warningConsumer.accept(
+                    "WebDriver BiDi was unavailable; using the compatibility listener. "
+                            + "Cross-origin frame and prompt coverage may be limited.");
+        }
+        executor.scheduleWithFixedDelay(
+                () -> poll(signalConsumer, warningConsumer),
+                0,
+                POLL_INTERVAL.toMillis(),
+                TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void close() {
+        executor.shutdownNow();
+    }
+
+    private void poll(Consumer<BrowserSignal> signalConsumer, Consumer<String> warningConsumer) {
+        try {
+            Set<String> windows = new LinkedHashSet<>(driver.getWindowHandles());
+            for (String opened : difference(windows, lastWindows)) {
+                signalConsumer.accept(BrowserSignal.generated(
+                        "window_open", opened, Map.of(), Map.of()));
+            }
+            for (String closed : difference(lastWindows, windows)) {
+                signalConsumer.accept(BrowserSignal.generated(
+                        "window_close", closed, Map.of(), Map.of()));
+            }
+            lastWindows = Set.copyOf(windows);
+
+            String contextId = driver.getWindowHandle();
+            String currentUrl = driver.getCurrentUrl();
+            if (!currentUrl.equals(lastUrl)) {
+                lastUrl = currentUrl;
+                signalConsumer.accept(BrowserSignal.generated(
+                        "navigation",
+                        contextId,
+                        Map.of("url", currentUrl, "title", driver.getTitle()),
+                        Map.of("action", "OPEN")));
+            }
+
+            JavascriptExecutor javascript = (JavascriptExecutor) driver;
+            javascript.executeScript(BrowserEventScript.fallbackInstallation());
+            Object drained = javascript.executeScript(BrowserEventScript.fallbackDrain());
+            if (drained instanceof List<?> signals) {
+                for (Object item : signals) {
+                    accept(item, contextId, signalConsumer, warningConsumer);
+                }
+            }
+        } catch (NoSuchSessionException exception) {
+            close();
+        } catch (WebDriverException exception) {
+            if (warned.compareAndSet(false, true)) {
+                warningConsumer.accept("The compatibility listener temporarily lost browser access.");
+            }
+        }
+    }
+
+    private void accept(
+            Object item,
+            String contextId,
+            Consumer<BrowserSignal> signalConsumer,
+            Consumer<String> warningConsumer) {
+        try {
+            signalConsumer.accept(BrowserSignal.fromJson(mapper.writeValueAsString(item), contextId));
+        } catch (JsonProcessingException | RuntimeException exception) {
+            warningConsumer.accept("A malformed browser interaction signal was ignored.");
+        }
+    }
+
+    private static Set<String> difference(Set<String> left, Set<String> right) {
+        Set<String> result = new LinkedHashSet<>(left);
+        result.removeAll(right);
+        return result;
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlClient.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlClient.java
@@ -1,0 +1,158 @@
+package com.shaft.capture.control;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.shaft.capture.model.Checkpoint;
+import com.shaft.capture.runtime.CaptureStatus;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Authenticated client for a detached local capture recorder.
+ */
+public final class CaptureControlClient {
+    private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+    private final CaptureControlFiles files;
+    private final HttpClient client = HttpClient.newBuilder()
+            .connectTimeout(TIMEOUT)
+            .build();
+    private final ObjectMapper mapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    /**
+     * Creates a client for one runtime directory.
+     *
+     * @param runtimeDirectory local runtime directory
+     */
+    public CaptureControlClient(java.nio.file.Path runtimeDirectory) {
+        files = new CaptureControlFiles(runtimeDirectory);
+    }
+
+    /**
+     * Returns active endpoint status or the final local status snapshot.
+     *
+     * @return safe status
+     */
+    public CaptureStatus status() {
+        if (!files.hasActiveControl()) {
+            CaptureStatus last = files.readStatus();
+            if (last.state() == CaptureStatus.State.ACTIVE
+                    || last.state() == CaptureStatus.State.STARTING
+                    || last.state() == CaptureStatus.State.STOPPING) {
+                return new CaptureStatus(
+                        CaptureStatus.State.INCOMPLETE,
+                        last.sessionId(),
+                        last.browser(),
+                        last.currentUrl(),
+                        last.eventCount(),
+                        append(last.warnings(), "The recorder process is no longer reachable."),
+                        last.outputPath(),
+                        false,
+                        last.processId(),
+                        last.startedAt());
+            }
+            return last;
+        }
+        try {
+            return send("GET", "/status", "");
+        } catch (RuntimeException exception) {
+            files.clearActiveControl();
+            CaptureStatus last = files.readStatus();
+            if (last.state() == CaptureStatus.State.ACTIVE
+                    || last.state() == CaptureStatus.State.STARTING
+                    || last.state() == CaptureStatus.State.STOPPING) {
+                return new CaptureStatus(
+                        CaptureStatus.State.INCOMPLETE,
+                        last.sessionId(),
+                        last.browser(),
+                        last.currentUrl(),
+                        last.eventCount(),
+                        append(last.warnings(), "The recorder process is no longer reachable."),
+                        last.outputPath(),
+                        false,
+                        last.processId(),
+                        last.startedAt());
+            }
+            return last;
+        }
+    }
+
+    /**
+     * Adds a checkpoint to the active recorder.
+     *
+     * @param description checkpoint description
+     * @param kind checkpoint kind
+     * @return updated status
+     */
+    public CaptureStatus checkpoint(String description, Checkpoint.CheckpointKind kind) {
+        return sendJson("POST", "/checkpoint", Map.of(
+                "description", description == null ? "" : description,
+                "kind", kind == null ? Checkpoint.CheckpointKind.USER_MARKER.name() : kind.name()));
+    }
+
+    /**
+     * Stops the active recorder.
+     *
+     * @param discard whether to delete capture artifacts
+     * @return final status
+     */
+    public CaptureStatus stop(boolean discard) {
+        return sendJson("POST", "/stop", Map.of("discard", discard));
+    }
+
+    private CaptureStatus sendJson(String method, String path, Object body) {
+        try {
+            return send(method, path, mapper.writeValueAsString(body));
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("SHAFT Capture control request could not be serialized.", exception);
+        }
+    }
+
+    private CaptureStatus send(String method, String path, String body) {
+        CaptureControlFiles.ControlDescriptor descriptor = files.readDescriptor();
+        if (ProcessHandle.of(descriptor.processId()).isEmpty()) {
+            throw new IllegalStateException("SHAFT Capture recorder process is not running.");
+        }
+        HttpRequest.Builder request = HttpRequest.newBuilder()
+                .uri(URI.create("http://127.0.0.1:" + descriptor.port() + path))
+                .timeout(TIMEOUT)
+                .header("Authorization", "Bearer " + files.readToken())
+                .header("Content-Type", "application/json");
+        if ("GET".equals(method)) {
+            request.GET();
+        } else {
+            request.method(method, HttpRequest.BodyPublishers.ofString(body));
+        }
+        try {
+            HttpResponse<String> response = client.send(
+                    request.build(),
+                    HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                throw new IllegalStateException("SHAFT Capture control endpoint rejected the request.");
+            }
+            return mapper.readValue(response.body(), CaptureStatus.class);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("SHAFT Capture control request was interrupted.", exception);
+        } catch (IOException exception) {
+            throw new IllegalStateException("SHAFT Capture control endpoint is unavailable.", exception);
+        }
+    }
+
+    private static java.util.List<String> append(java.util.List<String> warnings, String warning) {
+        java.util.List<String> result = new java.util.ArrayList<>(warnings);
+        result.add(warning);
+        return List.copyOf(result);
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlFiles.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlFiles.java
@@ -1,0 +1,270 @@
+package com.shaft.capture.control;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.shaft.capture.runtime.CaptureStartRequest;
+import com.shaft.capture.runtime.CaptureStatus;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+
+/**
+ * Atomic local state files used by the detached capture process.
+ */
+public final class CaptureControlFiles {
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    private final Path runtimeDirectory;
+
+    /**
+     * Creates local control files under a runtime directory.
+     *
+     * @param runtimeDirectory local runtime directory
+     */
+    public CaptureControlFiles(Path runtimeDirectory) {
+        if (runtimeDirectory == null) {
+            throw new IllegalArgumentException("Capture runtime directory is required.");
+        }
+        this.runtimeDirectory = runtimeDirectory.toAbsolutePath().normalize();
+    }
+
+    /**
+     * Returns the local runtime directory.
+     *
+     * @return runtime directory
+     */
+    public Path runtimeDirectory() {
+        return runtimeDirectory;
+    }
+
+    /**
+     * Writes the safe status snapshot.
+     *
+     * @param status safe status
+     */
+    public void writeStatus(CaptureStatus status) {
+        writeJson(statusPath(), status, false);
+    }
+
+    /**
+     * Reads the safe status snapshot.
+     *
+     * @return latest status or not-running status
+     */
+    public CaptureStatus readStatus() {
+        if (!Files.isRegularFile(statusPath())) {
+            return CaptureStatus.notRunning();
+        }
+        return readJson(statusPath(), CaptureStatus.class);
+    }
+
+    /**
+     * Writes loopback control metadata.
+     *
+     * @param descriptor control descriptor
+     */
+    public void writeDescriptor(ControlDescriptor descriptor) {
+        writeJson(descriptorPath(), descriptor, false);
+    }
+
+    /**
+     * Reads loopback control metadata.
+     *
+     * @return descriptor
+     */
+    public ControlDescriptor readDescriptor() {
+        return readJson(descriptorPath(), ControlDescriptor.class);
+    }
+
+    /**
+     * Writes the per-session authorization token with owner-only permissions where supported.
+     *
+     * @param token authorization token
+     */
+    public void writeToken(String token) {
+        writeText(tokenPath(), token == null ? "" : token, true);
+    }
+
+    /**
+     * Reads the per-session authorization token.
+     *
+     * @return token
+     */
+    public String readToken() {
+        try {
+            return Files.readString(tokenPath(), StandardCharsets.UTF_8);
+        } catch (IOException exception) {
+            throw new IllegalStateException("SHAFT Capture authorization token is unavailable.", exception);
+        }
+    }
+
+    /**
+     * Writes a one-time daemon launch request.
+     *
+     * @param request start request
+     * @return request file
+     */
+    public Path writeLaunchRequest(CaptureStartRequest request) {
+        Path path = runtimeDirectory.resolve("launch-" + java.util.UUID.randomUUID() + ".json");
+        writeJson(path, new LaunchRequest(
+                request.targetUrl(),
+                request.browser().name(),
+                request.outputPath().toString(),
+                request.runtimeDirectory().toString(),
+                request.headless()), true);
+        return path;
+    }
+
+    /**
+     * Reads and removes a one-time daemon launch request.
+     *
+     * @param path request file
+     * @return request
+     */
+    public CaptureStartRequest consumeLaunchRequest(Path path) {
+        Path normalized = path.toAbsolutePath().normalize();
+        if (!normalized.startsWith(runtimeDirectory) || !normalized.getFileName().toString().startsWith("launch-")) {
+            throw new IllegalArgumentException("Capture launch request is outside the runtime directory.");
+        }
+        try {
+            LaunchRequest request = readJson(normalized, LaunchRequest.class);
+            return new CaptureStartRequest(
+                    request.targetUrl(),
+                    com.shaft.capture.runtime.CaptureBrowser.parse(request.browser()),
+                    Path.of(request.outputPath()),
+                    Path.of(request.runtimeDirectory()),
+                    request.headless());
+        } finally {
+            try {
+                Files.deleteIfExists(normalized);
+            } catch (IOException ignored) {
+                // The consumed request contains no reusable credential.
+            }
+        }
+    }
+
+    /**
+     * Removes active control metadata while preserving final status.
+     */
+    public void clearActiveControl() {
+        try {
+            Files.deleteIfExists(descriptorPath());
+            Files.deleteIfExists(tokenPath());
+        } catch (IOException ignored) {
+            // Stale metadata is rejected by PID and endpoint checks.
+        }
+    }
+
+    /**
+     * Returns whether active control metadata exists.
+     *
+     * @return true when descriptor and token are present
+     */
+    public boolean hasActiveControl() {
+        return Files.isRegularFile(descriptorPath()) && Files.isRegularFile(tokenPath());
+    }
+
+    private Path statusPath() {
+        return runtimeDirectory.resolve("status.json");
+    }
+
+    private Path descriptorPath() {
+        return runtimeDirectory.resolve("control.json");
+    }
+
+    private Path tokenPath() {
+        return runtimeDirectory.resolve("control.token");
+    }
+
+    private static <T> T readJson(Path path, Class<T> type) {
+        try {
+            return MAPPER.readValue(Files.readString(path, StandardCharsets.UTF_8), type);
+        } catch (IOException exception) {
+            throw new IllegalStateException("SHAFT Capture local control state is unreadable.", exception);
+        }
+    }
+
+    private static void writeJson(Path path, Object value, boolean restricted) {
+        try {
+            writeText(path, MAPPER.writeValueAsString(value) + "\n", restricted);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("SHAFT Capture local control state could not be serialized.", exception);
+        }
+    }
+
+    private static void writeText(Path path, String value, boolean restricted) {
+        Path temporary = null;
+        try {
+            Files.createDirectories(path.getParent());
+            temporary = Files.createTempFile(path.getParent(), "." + path.getFileName(), ".tmp");
+            if (restricted) {
+                restrict(temporary);
+            }
+            Files.writeString(temporary, value, StandardCharsets.UTF_8);
+            try {
+                Files.move(temporary, path, StandardCopyOption.ATOMIC_MOVE,
+                        StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException ignored) {
+                Files.move(temporary, path, StandardCopyOption.REPLACE_EXISTING);
+            }
+            if (restricted) {
+                restrict(path);
+            }
+        } catch (IOException exception) {
+            throw new IllegalStateException("SHAFT Capture local control state could not be written.", exception);
+        } finally {
+            if (temporary != null) {
+                try {
+                    Files.deleteIfExists(temporary);
+                } catch (IOException ignored) {
+                    // Best-effort cleanup of an unpublished temporary state file.
+                }
+            }
+        }
+    }
+
+    private static void restrict(Path path) {
+        try {
+            Files.setPosixFilePermissions(path, Set.of(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE));
+        } catch (UnsupportedOperationException | IOException ignored) {
+            // Non-POSIX filesystems use the runtime directory's inherited permissions.
+        }
+    }
+
+    /**
+     * Safe loopback endpoint metadata.
+     *
+     * @param port loopback TCP port
+     * @param processId owning process ID
+     */
+    public record ControlDescriptor(int port, long processId) {
+        /**
+         * Creates validated endpoint metadata.
+         */
+        public ControlDescriptor {
+            if (port < 1 || port > 65535 || processId < 1) {
+                throw new IllegalArgumentException("Capture control endpoint metadata is invalid.");
+            }
+        }
+    }
+
+    private record LaunchRequest(
+            String targetUrl,
+            String browser,
+            String outputPath,
+            String runtimeDirectory,
+            boolean headless) {
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlServer.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlServer.java
@@ -1,0 +1,193 @@
+package com.shaft.capture.control;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.shaft.capture.model.Checkpoint;
+import com.shaft.capture.runtime.CaptureManager;
+import com.shaft.capture.runtime.CaptureStatus;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Locale;
+import java.util.concurrent.Executors;
+
+/**
+ * Loopback-only authenticated control endpoint for a detached recorder.
+ */
+public final class CaptureControlServer implements AutoCloseable {
+    private static final int MAX_REQUEST_BYTES = 8192;
+
+    private final CaptureManager manager;
+    private final CaptureControlFiles files;
+    private final String token;
+    private final Runnable stoppedCallback;
+    private final ObjectMapper mapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    private final HttpServer server;
+
+    /**
+     * Creates the loopback control endpoint.
+     *
+     * @param manager capture lifecycle
+     * @param files local state files
+     * @param token authorization token
+     * @param stoppedCallback callback after stop
+     */
+    public CaptureControlServer(
+            CaptureManager manager,
+            CaptureControlFiles files,
+            String token,
+            Runnable stoppedCallback) {
+        if (manager == null || files == null || token == null || token.isBlank() || stoppedCallback == null) {
+            throw new IllegalArgumentException("Capture control server dependencies are required.");
+        }
+        this.manager = manager;
+        this.files = files;
+        this.token = token;
+        this.stoppedCallback = stoppedCallback;
+        try {
+            server = HttpServer.create(
+                    new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0),
+                    0);
+        } catch (IOException exception) {
+            throw new IllegalStateException("SHAFT Capture loopback control endpoint could not start.", exception);
+        }
+        server.createContext("/status", exchange -> handle(exchange, this::status));
+        server.createContext("/checkpoint", exchange -> handle(exchange, this::checkpoint));
+        server.createContext("/stop", exchange -> handle(exchange, this::stop));
+        server.setExecutor(Executors.newFixedThreadPool(2, runnable -> {
+            Thread thread = new Thread(runnable, "shaft-capture-control");
+            thread.setDaemon(true);
+            return thread;
+        }));
+    }
+
+    /**
+     * Starts accepting local control requests.
+     *
+     * @return assigned loopback port
+     */
+    public int start() {
+        server.start();
+        return server.getAddress().getPort();
+    }
+
+    @Override
+    public void close() {
+        server.stop(0);
+    }
+
+    private CaptureStatus status(HttpExchange exchange) {
+        requireMethod(exchange, "GET");
+        CaptureStatus status = manager.status();
+        files.writeStatus(status);
+        return status;
+    }
+
+    private CaptureStatus checkpoint(HttpExchange exchange) {
+        requireMethod(exchange, "POST");
+        CheckpointRequest request = read(exchange, CheckpointRequest.class);
+        Checkpoint.CheckpointKind kind;
+        try {
+            kind = Checkpoint.CheckpointKind.valueOf(
+                    request.kind() == null
+                            ? "USER_MARKER"
+                            : request.kind().trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException exception) {
+            throw new BadRequestException("Unsupported checkpoint kind.");
+        }
+        CaptureStatus status = manager.checkpoint(request.description(), kind);
+        files.writeStatus(status);
+        return status;
+    }
+
+    private CaptureStatus stop(HttpExchange exchange) {
+        requireMethod(exchange, "POST");
+        StopRequest request = read(exchange, StopRequest.class);
+        CaptureStatus status = manager.stop(request.discard());
+        files.writeStatus(status);
+        return status;
+    }
+
+    private void handle(HttpExchange exchange, Handler handler) throws IOException {
+        try (exchange) {
+            try {
+                if (!authorized(exchange)) {
+                    send(exchange, 401, new ErrorResponse("Unauthorized local capture control request."));
+                    return;
+                }
+                send(exchange, 200, handler.handle(exchange));
+                if ("/stop".equals(exchange.getHttpContext().getPath())) {
+                    stoppedCallback.run();
+                }
+            } catch (BadRequestException exception) {
+                send(exchange, 400, new ErrorResponse(exception.getMessage()));
+            } catch (RuntimeException exception) {
+                send(exchange, 409, new ErrorResponse("SHAFT Capture control operation failed."));
+            }
+        }
+    }
+
+    private boolean authorized(HttpExchange exchange) {
+        String header = exchange.getRequestHeaders().getFirst("Authorization");
+        String expected = "Bearer " + token;
+        return header != null && MessageDigest.isEqual(
+                header.getBytes(StandardCharsets.UTF_8),
+                expected.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private <T> T read(HttpExchange exchange, Class<T> type) {
+        try {
+            byte[] body = exchange.getRequestBody().readNBytes(MAX_REQUEST_BYTES + 1);
+            if (body.length > MAX_REQUEST_BYTES) {
+                throw new BadRequestException("Capture control request is too large.");
+            }
+            return mapper.readValue(body, type);
+        } catch (JsonProcessingException exception) {
+            throw new BadRequestException("Capture control request is invalid.");
+        } catch (IOException exception) {
+            throw new BadRequestException("Capture control request could not be read.");
+        }
+    }
+
+    private void send(HttpExchange exchange, int status, Object value) throws IOException {
+        byte[] body = mapper.writeValueAsBytes(value);
+        exchange.getResponseHeaders().set("Content-Type", "application/json; charset=utf-8");
+        exchange.sendResponseHeaders(status, body.length);
+        exchange.getResponseBody().write(body);
+    }
+
+    private static void requireMethod(HttpExchange exchange, String expected) {
+        if (!expected.equalsIgnoreCase(exchange.getRequestMethod())) {
+            throw new BadRequestException("Unsupported capture control method.");
+        }
+    }
+
+    @FunctionalInterface
+    private interface Handler {
+        CaptureStatus handle(HttpExchange exchange);
+    }
+
+    private record CheckpointRequest(String description, String kind) {
+    }
+
+    private record StopRequest(boolean discard) {
+    }
+
+    private record ErrorResponse(String error) {
+    }
+
+    private static final class BadRequestException extends RuntimeException {
+        private BadRequestException(String message) {
+            super(message);
+        }
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/privacy/CapturePrivacyClassifier.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/privacy/CapturePrivacyClassifier.java
@@ -193,6 +193,16 @@ public final class CapturePrivacyClassifier {
     }
 
     /**
+     * Redacts configured secret-looking patterns from browser metadata text.
+     *
+     * @param rawValue original text
+     * @return sanitized text and safe summary
+     */
+    public SanitizedText sanitizeText(String rawValue) {
+        return redactPatternMatches(rawValue, false);
+    }
+
+    /**
      * Produces a safe basename for upload or evidence artifacts.
      *
      * @param sourcePath original path or filename

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureBrowser.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureBrowser.java
@@ -1,0 +1,49 @@
+package com.shaft.capture.runtime;
+
+import com.shaft.driver.DriverFactory;
+
+import java.util.Locale;
+
+/**
+ * Browser families supported by managed SHAFT Capture recording.
+ */
+public enum CaptureBrowser {
+    /**
+     * Google Chrome.
+     */
+    CHROME(DriverFactory.DriverType.CHROME),
+    /**
+     * Microsoft Edge.
+     */
+    EDGE(DriverFactory.DriverType.EDGE);
+
+    private final DriverFactory.DriverType driverType;
+
+    CaptureBrowser(DriverFactory.DriverType driverType) {
+        this.driverType = driverType;
+    }
+
+    DriverFactory.DriverType driverType() {
+        return driverType;
+    }
+
+    /**
+     * Parses a supported browser name.
+     *
+     * @param value browser name
+     * @return supported browser
+     */
+    public static CaptureBrowser parse(String value) {
+        String normalized = value == null ? "" : value.trim().toUpperCase(Locale.ROOT);
+        if ("FIREFOX".equals(normalized)) {
+            throw new IllegalArgumentException(
+                    "Firefox is not supported by SHAFT Capture v1. Use Chrome or Edge.");
+        }
+        try {
+            return valueOf(normalized);
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalArgumentException(
+                    "Unsupported capture browser. Use Chrome or Edge.", exception);
+        }
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
@@ -1,0 +1,565 @@
+package com.shaft.capture.runtime;
+
+import com.shaft.capture.collector.BrowserSignal;
+import com.shaft.capture.model.CaptureEvent;
+import com.shaft.capture.model.Checkpoint;
+import com.shaft.capture.model.ElementSnapshot;
+import com.shaft.capture.model.EventContext;
+import com.shaft.capture.model.ExternalTestDataReference;
+import com.shaft.capture.model.LocatorCandidate;
+import com.shaft.capture.model.PageContext;
+import com.shaft.capture.model.RedactionSummary;
+import com.shaft.capture.privacy.CapturePrivacyClassifier;
+import com.shaft.capture.privacy.CapturePrivacyPolicy;
+import com.shaft.capture.privacy.ClassifiedValue;
+import com.shaft.capture.storage.CaptureSessionStore;
+import com.shaft.capture.storage.ExternalTestDataWriter;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * Converts low-level browser signals into ordered privacy-safe semantic events.
+ */
+final class CaptureEventPipeline implements AutoCloseable {
+    private static final Duration INPUT_DEBOUNCE = Duration.ofMillis(350);
+    private static final Duration CLICK_DEBOUNCE = Duration.ofMillis(300);
+    private static final Duration NAVIGATION_DEBOUNCE = Duration.ofMillis(750);
+
+    private final CaptureSessionStore store;
+    private final CapturePrivacyClassifier privacy;
+    private final CapturePrivacyPolicy policy;
+    private final ExternalTestDataWriter dataWriter = new ExternalTestDataWriter();
+    private final Path dataPath;
+    private final Consumer<String> currentUrlConsumer;
+    private final Consumer<String> warningConsumer;
+    private final List<ClassifiedValue> classifiedValues = new ArrayList<>();
+    private final Map<String, BrowserSignal> pendingInputs = new LinkedHashMap<>();
+    private final Map<String, BrowserSignal> pendingClicks = new LinkedHashMap<>();
+    private final Map<String, String> logicalWindows = new LinkedHashMap<>();
+    private final Map<String, Instant> recentSignals = new LinkedHashMap<>();
+    private final ScheduledExecutorService debounceExecutor;
+    private long sequence;
+    private String lastNavigationUrl = "";
+    private Instant lastNavigationAt = Instant.EPOCH;
+    private String lastWindow = "";
+    private List<String> lastFramePath = List.of();
+    private boolean closed;
+
+    CaptureEventPipeline(
+            CaptureSessionStore store,
+            Path outputPath,
+            CapturePrivacyPolicy policy,
+            Consumer<String> currentUrlConsumer,
+            Consumer<String> warningConsumer) {
+        if (store == null || outputPath == null || currentUrlConsumer == null || warningConsumer == null) {
+            throw new IllegalArgumentException("Capture event pipeline dependencies are required.");
+        }
+        this.store = store;
+        this.policy = policy == null ? CapturePrivacyPolicy.defaults() : policy;
+        privacy = new CapturePrivacyClassifier(this.policy);
+        dataPath = outputPath.toAbsolutePath().normalize().getParent().resolve(this.policy.externalDataPath());
+        this.currentUrlConsumer = currentUrlConsumer;
+        this.warningConsumer = warningConsumer;
+        debounceExecutor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "shaft-capture-debounce");
+            thread.setDaemon(true);
+            return thread;
+        });
+        debounceExecutor.scheduleWithFixedDelay(this::flushReady, 100, 100, TimeUnit.MILLISECONDS);
+    }
+
+    synchronized void accept(BrowserSignal signal) {
+        if (closed || signal == null) {
+            return;
+        }
+        if (isDuplicate(signal)) {
+            return;
+        }
+        try {
+            switch (signal.kind()) {
+                case "input" -> {
+                    pendingInputs.put(targetKey(signal), signal);
+                    if (signal.dataBoolean("committed")) {
+                        flushSignal(pendingInputs.remove(targetKey(signal)));
+                    }
+                }
+                case "click" -> pendingClicks.put(targetKey(signal), signal);
+                default -> {
+                    flushPendingBefore(signal.timestamp());
+                    emit(signal);
+                }
+            }
+        } catch (RuntimeException exception) {
+            warningConsumer.accept("A browser interaction could not be normalized and was skipped.");
+        }
+    }
+
+    synchronized void checkpoint(String description, Checkpoint.CheckpointKind kind) {
+        ensureOpen();
+        flushAll();
+        CapturePrivacyClassifier.SanitizedText safe = privacy.sanitizeText(description);
+        store.checkpoint(new Checkpoint(
+                "checkpoint-" + (store.read().checkpoints().size() + 1),
+                sequence,
+                Instant.now(),
+                kind,
+                safe.value()), safe.summary());
+    }
+
+    synchronized int eventCount() {
+        return Math.toIntExact(sequence);
+    }
+
+    @Override
+    public synchronized void close() {
+        if (closed) {
+            return;
+        }
+        flushAll();
+        closed = true;
+        debounceExecutor.shutdownNow();
+    }
+
+    private synchronized void flushReady() {
+        if (closed) {
+            return;
+        }
+        Instant now = Instant.now();
+        List<BrowserSignal> ready = new ArrayList<>();
+        collectReady(pendingInputs, now.minus(INPUT_DEBOUNCE), ready);
+        collectReady(pendingClicks, now.minus(CLICK_DEBOUNCE), ready);
+        flushOrdered(ready);
+    }
+
+    private void flushPendingBefore(Instant timestamp) {
+        List<BrowserSignal> ready = new ArrayList<>();
+        collectReady(pendingInputs, timestamp, ready);
+        collectReady(pendingClicks, timestamp, ready);
+        flushOrdered(ready);
+    }
+
+    private void collectReady(
+            Map<String, BrowserSignal> pending,
+            Instant timestamp,
+            List<BrowserSignal> destination) {
+        List<String> ready = pending.entrySet().stream()
+                .filter(entry -> !entry.getValue().timestamp().isAfter(timestamp))
+                .map(Map.Entry::getKey)
+                .toList();
+        ready.forEach(key -> destination.add(pending.remove(key)));
+    }
+
+    private void flushAll() {
+        List<BrowserSignal> pending = new ArrayList<>(pendingInputs.values());
+        pending.addAll(pendingClicks.values());
+        pendingInputs.clear();
+        pendingClicks.clear();
+        flushOrdered(pending);
+    }
+
+    private void flushOrdered(List<BrowserSignal> signals) {
+        signals.stream()
+                .sorted(java.util.Comparator.comparing(BrowserSignal::timestamp))
+                .forEach(this::flushSignal);
+    }
+
+    private void flushSignal(BrowserSignal signal) {
+        if (signal != null) {
+            emit(signal);
+        }
+    }
+
+    private void emit(BrowserSignal signal) {
+        switch (signal.kind()) {
+            case "navigation" -> emitNavigation(signal);
+            case "click" -> append(new CaptureEvent.ClickEvent(
+                    context(signal),
+                    target(signal).snapshot(),
+                    mouseButton(signal.dataInt("button", 0)),
+                    Math.max(1, signal.dataInt("clickCount", 1))),
+                    target(signal).summary(), List.of());
+            case "input" -> emitInput(signal);
+            case "select" -> emitSelect(signal);
+            case "toggle" -> append(new CaptureEvent.ToggleEvent(
+                    context(signal), target(signal).snapshot(), signal.dataBoolean("checked")),
+                    target(signal).summary(), List.of());
+            case "upload" -> emitUpload(signal);
+            case "keyboard" -> append(new CaptureEvent.KeyboardEvent(
+                    context(signal), target(signal).snapshot(), signal.dataStrings("keys")),
+                    target(signal).summary(), List.of());
+            case "window_open" -> append(new CaptureEvent.WindowEvent(
+                    context(signal), CaptureEvent.WindowAction.OPEN_TAB, logicalWindow(signal.browsingContextId())),
+                    RedactionSummary.empty(), List.of());
+            case "window_close" -> append(new CaptureEvent.WindowEvent(
+                    context(signal), CaptureEvent.WindowAction.CLOSE, logicalWindow(signal.browsingContextId())),
+                    RedactionSummary.empty(), List.of());
+            case "alert" -> emitAlert(signal);
+            default -> {
+                // Unknown browser noise is intentionally ignored.
+            }
+        }
+    }
+
+    private void emitNavigation(BrowserSignal signal) {
+        SafePage page = page(signal);
+        if (page.context().url().equals(lastNavigationUrl)
+                && Duration.between(lastNavigationAt, signal.timestamp()).abs()
+                .compareTo(NAVIGATION_DEBOUNCE) < 0) {
+            return;
+        }
+        lastNavigationUrl = page.context().url();
+        lastNavigationAt = signal.timestamp();
+        currentUrlConsumer.accept(page.context().url());
+        CaptureEvent.NavigationAction action = enumValue(
+                CaptureEvent.NavigationAction.class,
+                signal.dataString("action"),
+                CaptureEvent.NavigationAction.OPEN);
+        append(new CaptureEvent.NavigationEvent(context(signal, page), action, page.context().url()),
+                page.summary(), List.of());
+    }
+
+    private void emitInput(BrowserSignal signal) {
+        SafeTarget target = target(signal);
+        String value = signal.dataString("value");
+        if (value.isEmpty()) {
+            append(new CaptureEvent.ClearEvent(context(signal), target.snapshot()),
+                    target.summary(), List.of());
+            return;
+        }
+        ClassifiedValue classified = privacy.classifyValue(
+                logicalValueName(target.snapshot(), sequence + 1),
+                value,
+                bestSelector(target.snapshot()),
+                target.snapshot().normalizedAttributes());
+        classifiedValues.add(classified);
+        dataWriter.write(dataPath, classifiedValues);
+        append(new CaptureEvent.TypeEvent(context(signal), target.snapshot(), classified.reference()),
+                target.summary().merge(classified.summary()), List.of(classified.reference()));
+    }
+
+    private void emitSelect(BrowserSignal signal) {
+        SafeTarget target = target(signal);
+        String selected = signal.dataString("visibleText");
+        if (selected.isBlank()) {
+            selected = signal.dataString("value");
+        }
+        ClassifiedValue classified = privacy.classifyValue(
+                logicalValueName(target.snapshot(), sequence + 1),
+                selected,
+                bestSelector(target.snapshot()),
+                target.snapshot().normalizedAttributes());
+        classifiedValues.add(classified);
+        dataWriter.write(dataPath, classifiedValues);
+        append(new CaptureEvent.SelectEvent(
+                context(signal),
+                target.snapshot(),
+                CaptureEvent.SelectMode.VISIBLE_TEXT,
+                classified.reference()),
+                target.summary().merge(classified.summary()), List.of(classified.reference()));
+    }
+
+    private void emitUpload(BrowserSignal signal) {
+        SafeTarget target = target(signal);
+        var upload = privacy.classifyUpload(
+                logicalValueName(target.snapshot(), sequence + 1),
+                signal.dataString("fileName"),
+                signal.dataString("mediaType"),
+                Math.max(0, signal.dataInt("sizeBytes", 0)));
+        append(new CaptureEvent.UploadEvent(
+                context(signal),
+                target.snapshot(),
+                upload.reference(),
+                upload.safeFileName(),
+                upload.mediaType(),
+                upload.sizeBytes()),
+                target.summary().merge(upload.summary()), List.of(upload.reference()));
+    }
+
+    private void emitAlert(BrowserSignal signal) {
+        ExternalTestDataReference textReference = null;
+        RedactionSummary summary = RedactionSummary.empty();
+        String text = signal.dataString("text");
+        if (!text.isBlank()) {
+            ClassifiedValue classified = privacy.classifyValue(
+                    "alert-" + (sequence + 1),
+                    text,
+                    "",
+                    Map.of());
+            classifiedValues.add(classified);
+            dataWriter.write(dataPath, classifiedValues);
+            textReference = classified.reference();
+            summary = classified.summary();
+            append(new CaptureEvent.AlertEvent(
+                    context(signal), CaptureEvent.AlertAction.TYPE, textReference),
+                    summary, List.of(textReference));
+        }
+        append(new CaptureEvent.AlertEvent(
+                context(signal),
+                signal.dataBoolean("accepted")
+                        ? CaptureEvent.AlertAction.ACCEPT
+                        : CaptureEvent.AlertAction.DISMISS,
+                null),
+                RedactionSummary.empty(), List.of());
+    }
+
+    private EventContext context(BrowserSignal signal) {
+        return context(signal, page(signal));
+    }
+
+    private EventContext context(BrowserSignal signal, SafePage page) {
+        emitContextTransitions(signal, page);
+        return new EventContext(
+                ++sequence,
+                signal.timestamp(),
+                page.context(),
+                EventContext.ReplayStatus.NOT_REPLAYED,
+                List.of(),
+                Map.of());
+    }
+
+    private void emitContextTransitions(BrowserSignal signal, SafePage page) {
+        String window = page.context().logicalWindowId();
+        if (lastWindow.isBlank()) {
+            lastWindow = window;
+        } else if (!lastWindow.equals(window)
+                && !signal.kind().startsWith("window_")) {
+            append(new CaptureEvent.WindowEvent(
+                    bareContext(signal, page),
+                    CaptureEvent.WindowAction.SWITCH,
+                    window),
+                    page.summary(), List.of());
+            lastWindow = window;
+        }
+
+        List<String> frames = page.context().framePath();
+        if (!frames.equals(lastFramePath)) {
+            if (frames.isEmpty()) {
+                append(new CaptureEvent.FrameEvent(
+                        bareContext(signal, page),
+                        CaptureEvent.FrameAction.TOP,
+                        "",
+                        null),
+                        page.summary(), List.of());
+            } else {
+                append(new CaptureEvent.FrameEvent(
+                        bareContext(signal, page),
+                        CaptureEvent.FrameAction.ENTER,
+                        frames.getLast(),
+                        null),
+                        page.summary(), List.of());
+            }
+            lastFramePath = frames;
+        }
+    }
+
+    private EventContext bareContext(BrowserSignal signal, SafePage page) {
+        return new EventContext(
+                ++sequence,
+                signal.timestamp(),
+                page.context(),
+                EventContext.ReplayStatus.NOT_REPLAYED,
+                List.of(),
+                Map.of());
+    }
+
+    private SafePage page(BrowserSignal signal) {
+        var safeUrl = privacy.sanitizeUrl(string(signal.page().get("url")));
+        var safeTitle = privacy.sanitizeText(string(signal.page().get("title")));
+        RedactionSummary summary = safeUrl.summary().merge(safeTitle.summary());
+        List<String> frames = list(signal.page().get("framePath")).stream()
+                .map(privacy::sanitizeText)
+                .map(safe -> safe.value().isBlank() ? "frame" : safe.value())
+                .toList();
+        PageContext page = new PageContext(
+                safeUrl.value(),
+                safeTitle.value(),
+                logicalWindow(signal.browsingContextId()),
+                frames,
+                integer(signal.page().get("width"), 0),
+                integer(signal.page().get("height"), 0));
+        return new SafePage(page, summary);
+    }
+
+    private SafeTarget target(BrowserSignal signal) {
+        Map<String, String> rawAttributes = strings(signal.target().get("attributes"));
+        var attributes = privacy.sanitizeAttributes(rawAttributes);
+        var accessibleName = privacy.sanitizeText(string(signal.target().get("accessibleName")));
+        var label = privacy.sanitizeText(string(signal.target().get("label")));
+        var logicalId = privacy.sanitizeText(string(signal.target().get("logicalElementId")));
+        RedactionSummary summary = attributes.summary()
+                .merge(accessibleName.summary())
+                .merge(label.summary())
+                .merge(logicalId.summary());
+        List<LocatorCandidate> locators = new ArrayList<>();
+        Object rawLocators = signal.target().get("locators");
+        if (rawLocators instanceof List<?> items) {
+            for (Object item : items) {
+                if (!(item instanceof Map<?, ?> raw)) {
+                    continue;
+                }
+                var expression = privacy.sanitizeText(string(raw.get("expression")));
+                summary = summary.merge(expression.summary());
+                if (expression.value().isBlank()) {
+                    continue;
+                }
+                locators.add(new LocatorCandidate(
+                        enumValue(
+                                LocatorCandidate.LocatorStrategy.class,
+                                string(raw.get("strategy")),
+                                LocatorCandidate.LocatorStrategy.CSS),
+                        expression.value(),
+                        integer(raw.get("uniquenessCount"), 0),
+                        bool(raw.get("visible")),
+                        bool(raw.get("stable")),
+                        locatorSignals(raw.get("signals"))));
+            }
+        }
+        String targetId = logicalId.value().isBlank()
+                ? "element-" + (sequence + 1)
+                : logicalId.value();
+        ElementSnapshot snapshot = new ElementSnapshot(
+                targetId,
+                string(signal.target().get("tagName")),
+                string(signal.target().get("role")),
+                accessibleName.value(),
+                label.value(),
+                attributes.attributes(),
+                locators,
+                bool(signal.target().get("visible")),
+                bool(signal.target().get("enabled")),
+                bool(signal.target().get("selected")));
+        return new SafeTarget(snapshot, summary);
+    }
+
+    private void append(
+            CaptureEvent event,
+            RedactionSummary summary,
+            List<ExternalTestDataReference> references) {
+        store.append(event, references, summary);
+    }
+
+    private String logicalWindow(String contextId) {
+        String key = contextId == null || contextId.isBlank() ? "default" : contextId;
+        return logicalWindows.computeIfAbsent(key, ignored -> "window-" + (logicalWindows.size() + 1));
+    }
+
+    private static String targetKey(BrowserSignal signal) {
+        String target = string(signal.target().get("logicalElementId"));
+        return target.isBlank() ? signal.kind() + "-" + signal.browsingContextId() : target;
+    }
+
+    private boolean isDuplicate(BrowserSignal signal) {
+        String fingerprint = signal.kind()
+                + "|" + signal.timestamp().toEpochMilli()
+                + "|" + targetKey(signal)
+                + "|" + signal.data().hashCode();
+        if (recentSignals.containsKey(fingerprint)) {
+            return true;
+        }
+        recentSignals.put(fingerprint, signal.timestamp());
+        while (recentSignals.size() > 512) {
+            String oldest = recentSignals.keySet().iterator().next();
+            recentSignals.remove(oldest);
+        }
+        return false;
+    }
+
+    private static String logicalValueName(ElementSnapshot target, long eventSequence) {
+        return target.logicalElementId() + "-" + eventSequence;
+    }
+
+    private static String bestSelector(ElementSnapshot target) {
+        return target.locatorCandidates().isEmpty()
+                ? ""
+                : target.locatorCandidates().getFirst().expression();
+    }
+
+    private static CaptureEvent.MouseButton mouseButton(int button) {
+        return switch (button) {
+            case 1 -> CaptureEvent.MouseButton.MIDDLE;
+            case 2 -> CaptureEvent.MouseButton.SECONDARY;
+            default -> CaptureEvent.MouseButton.PRIMARY;
+        };
+    }
+
+    private static Set<LocatorCandidate.LocatorSignal> locatorSignals(Object value) {
+        EnumSet<LocatorCandidate.LocatorSignal> signals =
+                EnumSet.noneOf(LocatorCandidate.LocatorSignal.class);
+        for (String item : list(value)) {
+            try {
+                signals.add(LocatorCandidate.LocatorSignal.valueOf(item.toUpperCase(Locale.ROOT)));
+            } catch (IllegalArgumentException ignored) {
+                // Forward-compatible unknown scoring signals are ignored.
+            }
+        }
+        return signals;
+    }
+
+    private static Map<String, String> strings(Object value) {
+        if (!(value instanceof Map<?, ?> map)) {
+            return Map.of();
+        }
+        Map<String, String> result = new LinkedHashMap<>();
+        map.forEach((key, item) -> result.put(string(key), string(item)));
+        return result;
+    }
+
+    private static List<String> list(Object value) {
+        if (!(value instanceof List<?> list)) {
+            return List.of();
+        }
+        return list.stream().map(CaptureEventPipeline::string).filter(item -> !item.isBlank()).toList();
+    }
+
+    private static String string(Object value) {
+        return value == null ? "" : String.valueOf(value);
+    }
+
+    private static int integer(Object value, int fallback) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        try {
+            return Integer.parseInt(string(value));
+        } catch (NumberFormatException ignored) {
+            return fallback;
+        }
+    }
+
+    private static boolean bool(Object value) {
+        return value instanceof Boolean bool ? bool : Boolean.parseBoolean(string(value));
+    }
+
+    private static <E extends Enum<E>> E enumValue(Class<E> type, String value, E fallback) {
+        try {
+            return Enum.valueOf(type, value == null ? "" : value.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException exception) {
+            return fallback;
+        }
+    }
+
+    private void ensureOpen() {
+        if (closed) {
+            throw new IllegalStateException("Capture event pipeline is closed.");
+        }
+    }
+
+    private record SafePage(PageContext context, RedactionSummary summary) {
+    }
+
+    private record SafeTarget(ElementSnapshot snapshot, RedactionSummary summary) {
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureManager.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureManager.java
@@ -1,0 +1,215 @@
+package com.shaft.capture.runtime;
+
+import com.shaft.capture.model.Checkpoint;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+/**
+ * Thread-safe local lifecycle API shared by CLI and MCP capture controls.
+ */
+public final class CaptureManager implements AutoCloseable {
+    private static final Duration HEALTH_INTERVAL = Duration.ofSeconds(1);
+
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+        Thread thread = new Thread(runnable, "shaft-capture-manager");
+        thread.setDaemon(false);
+        return thread;
+    });
+    private final Function<CaptureStartRequest, ManagedCaptureRecorder> recorderFactory;
+    private volatile ManagedCaptureRecorder recorder;
+    private volatile CaptureStatus lastStatus = CaptureStatus.notRunning();
+    private CaptureSingleSessionLock sessionLock;
+    private ScheduledFuture<?> healthCheck;
+
+    /**
+     * Creates the default managed recorder lifecycle.
+     */
+    public CaptureManager() {
+        this(ManagedCaptureRecorder::new);
+    }
+
+    CaptureManager(Function<CaptureStartRequest, ManagedCaptureRecorder> recorderFactory) {
+        if (recorderFactory == null) {
+            throw new IllegalArgumentException("Capture recorder factory is required.");
+        }
+        this.recorderFactory = recorderFactory;
+    }
+
+    /**
+     * Starts one managed browser capture.
+     *
+     * @param request validated start request
+     * @return active recorder status
+     */
+    public synchronized CaptureStatus start(CaptureStartRequest request) {
+        if (isActive(lastStatus.state())) {
+            throw new IllegalStateException("A SHAFT Capture session is already active.");
+        }
+        lastStatus = new CaptureStatus(
+                CaptureStatus.State.STARTING,
+                "",
+                request.browser().name().toLowerCase(),
+                "",
+                0,
+                java.util.List.of(),
+                request.outputPath().toString(),
+                false,
+                ProcessHandle.current().pid(),
+                null);
+        return invoke(() -> {
+            sessionLock = CaptureSingleSessionLock.acquire(request.runtimeDirectory());
+            try {
+                recorder = recorderFactory.apply(request);
+                recorder.start();
+                lastStatus = recorder.status();
+                healthCheck = executor.scheduleWithFixedDelay(
+                        this::verifyBrowserHealth,
+                        HEALTH_INTERVAL.toMillis(),
+                        HEALTH_INTERVAL.toMillis(),
+                        TimeUnit.MILLISECONDS);
+                return lastStatus;
+            } catch (RuntimeException exception) {
+                recorder = null;
+                releaseLock();
+                throw exception;
+            }
+        });
+    }
+
+    /**
+     * Returns the latest safe status without captured values.
+     *
+     * @return recorder status
+     */
+    public CaptureStatus status() {
+        ManagedCaptureRecorder current = recorder;
+        if (current != null && isActive(lastStatus.state())) {
+            lastStatus = current.status();
+        }
+        return lastStatus;
+    }
+
+    /**
+     * Adds a human-review checkpoint to the active session.
+     *
+     * @param description checkpoint description
+     * @param kind checkpoint kind
+     * @return updated status
+     */
+    public CaptureStatus checkpoint(String description, Checkpoint.CheckpointKind kind) {
+        return invoke(() -> {
+            requireRecorder().checkpoint(description, kind);
+            lastStatus = recorder.status();
+            return lastStatus;
+        });
+    }
+
+    /**
+     * Stops the active session.
+     *
+     * @param discard whether to remove capture artifacts after clean shutdown
+     * @return final status
+     */
+    public synchronized CaptureStatus stop(boolean discard) {
+        if (recorder == null) {
+            return lastStatus;
+        }
+        lastStatus = copyWithState(status(), CaptureStatus.State.STOPPING);
+        return invoke(() -> {
+            cancelHealthCheck();
+            lastStatus = recorder.stop(discard);
+            recorder = null;
+            releaseLock();
+            return lastStatus;
+        });
+    }
+
+    @Override
+    public synchronized void close() {
+        if (recorder != null) {
+            invoke(() -> {
+                cancelHealthCheck();
+                lastStatus = recorder.interrupt();
+                recorder = null;
+                releaseLock();
+                return lastStatus;
+            });
+        }
+        executor.shutdownNow();
+    }
+
+    private void verifyBrowserHealth() {
+        ManagedCaptureRecorder current = recorder;
+        if (current == null || !isActive(lastStatus.state())) {
+            return;
+        }
+        if (!current.isBrowserAlive()) {
+            cancelHealthCheck();
+            lastStatus = current.interrupt();
+            recorder = null;
+            releaseLock();
+        }
+    }
+
+    private ManagedCaptureRecorder requireRecorder() {
+        if (recorder == null || !isActive(lastStatus.state())) {
+            throw new IllegalStateException("SHAFT Capture is not active.");
+        }
+        return recorder;
+    }
+
+    private <T> T invoke(java.util.concurrent.Callable<T> operation) {
+        try {
+            return executor.submit(operation).get();
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("SHAFT Capture control was interrupted.", exception);
+        } catch (ExecutionException exception) {
+            Throwable cause = exception.getCause();
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            throw new IllegalStateException("SHAFT Capture control failed.", cause);
+        }
+    }
+
+    private void cancelHealthCheck() {
+        if (healthCheck != null) {
+            healthCheck.cancel(false);
+            healthCheck = null;
+        }
+    }
+
+    private void releaseLock() {
+        if (sessionLock != null) {
+            sessionLock.close();
+            sessionLock = null;
+        }
+    }
+
+    private static boolean isActive(CaptureStatus.State state) {
+        return state == CaptureStatus.State.STARTING
+                || state == CaptureStatus.State.ACTIVE
+                || state == CaptureStatus.State.STOPPING;
+    }
+
+    private static CaptureStatus copyWithState(CaptureStatus status, CaptureStatus.State state) {
+        return new CaptureStatus(
+                state,
+                status.sessionId(),
+                status.browser(),
+                status.currentUrl(),
+                status.eventCount(),
+                status.warnings(),
+                status.outputPath(),
+                status.aiEnabled(),
+                status.processId(),
+                status.startedAt());
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureSingleSessionLock.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureSingleSessionLock.java
@@ -1,0 +1,60 @@
+package com.shaft.capture.runtime;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * Cross-process lock that permits one managed capture session per runtime directory.
+ */
+final class CaptureSingleSessionLock implements AutoCloseable {
+    private final FileChannel channel;
+    private final FileLock lock;
+
+    private CaptureSingleSessionLock(FileChannel channel, FileLock lock) {
+        this.channel = channel;
+        this.lock = lock;
+    }
+
+    static CaptureSingleSessionLock acquire(Path runtimeDirectory) {
+        try {
+            Files.createDirectories(runtimeDirectory);
+            FileChannel channel = FileChannel.open(
+                    runtimeDirectory.resolve("capture.lock"),
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.WRITE);
+            FileLock lock;
+            try {
+                lock = channel.tryLock();
+            } catch (OverlappingFileLockException exception) {
+                lock = null;
+            }
+            if (lock == null) {
+                channel.close();
+                throw new IllegalStateException(
+                        "Another SHAFT Capture session is already active for this runtime directory.");
+            }
+            return new CaptureSingleSessionLock(channel, lock);
+        } catch (IOException exception) {
+            throw new IllegalStateException("SHAFT Capture could not acquire its local session lock.", exception);
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            lock.release();
+        } catch (IOException ignored) {
+            // Closing the channel below also releases the process lock.
+        }
+        try {
+            channel.close();
+        } catch (IOException ignored) {
+            // Best-effort local lock cleanup.
+        }
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureStartRequest.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureStartRequest.java
@@ -1,0 +1,55 @@
+package com.shaft.capture.runtime;
+
+import java.net.URI;
+import java.nio.file.Path;
+
+/**
+ * Validated request for a managed browser capture session.
+ *
+ * @param targetUrl initial browser URL
+ * @param browser supported browser family
+ * @param outputPath capture JSON output
+ * @param runtimeDirectory local control and temporary-profile directory
+ * @param headless whether to launch without a visible browser window
+ */
+public record CaptureStartRequest(
+        String targetUrl,
+        CaptureBrowser browser,
+        Path outputPath,
+        Path runtimeDirectory,
+        boolean headless) {
+    /**
+     * Creates a validated request.
+     */
+    public CaptureStartRequest {
+        targetUrl = validateUrl(targetUrl);
+        browser = browser == null ? CaptureBrowser.CHROME : browser;
+        if (outputPath == null || runtimeDirectory == null) {
+            throw new IllegalArgumentException("Capture output and runtime directory are required.");
+        }
+        outputPath = outputPath.toAbsolutePath().normalize();
+        runtimeDirectory = runtimeDirectory.toAbsolutePath().normalize();
+        if (outputPath.startsWith(runtimeDirectory.resolve("profiles"))) {
+            throw new IllegalArgumentException("Capture output cannot be stored in the temporary profile directory.");
+        }
+    }
+
+    private static String validateUrl(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("Capture target URL is required.");
+        }
+        URI uri;
+        try {
+            uri = URI.create(value.trim());
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalArgumentException("Capture target URL is invalid.", exception);
+        }
+        String scheme = uri.getScheme();
+        if (scheme == null || (!scheme.equalsIgnoreCase("http")
+                && !scheme.equalsIgnoreCase("https")
+                && !scheme.equalsIgnoreCase("file"))) {
+            throw new IllegalArgumentException("Capture target URL must use http, https, or file.");
+        }
+        return uri.toString();
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureStatus.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureStatus.java
@@ -1,0 +1,73 @@
+package com.shaft.capture.runtime;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Safe recorder status returned by CLI and MCP controls.
+ *
+ * @param state recorder lifecycle state
+ * @param sessionId logical capture session identifier
+ * @param browser browser family
+ * @param currentUrl sanitized current URL
+ * @param eventCount persisted semantic event count
+ * @param warnings safe recorder warnings
+ * @param outputPath capture JSON output path
+ * @param aiEnabled always false for deterministic recording
+ * @param processId owning process ID
+ * @param startedAt session start time
+ */
+public record CaptureStatus(
+        State state,
+        String sessionId,
+        String browser,
+        String currentUrl,
+        int eventCount,
+        List<String> warnings,
+        String outputPath,
+        boolean aiEnabled,
+        long processId,
+        Instant startedAt) {
+    /**
+     * Recorder lifecycle states.
+     */
+    public enum State {
+        STARTING,
+        ACTIVE,
+        STOPPING,
+        COMPLETED,
+        INCOMPLETE,
+        DISCARDED,
+        FAILED,
+        NOT_RUNNING
+    }
+
+    /**
+     * Creates immutable safe status.
+     */
+    public CaptureStatus {
+        state = state == null ? State.NOT_RUNNING : state;
+        sessionId = text(sessionId);
+        browser = text(browser);
+        currentUrl = text(currentUrl);
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+        outputPath = text(outputPath);
+        if (eventCount < 0) {
+            throw new IllegalArgumentException("Capture event count cannot be negative.");
+        }
+    }
+
+    /**
+     * Returns a safe status for an idle runtime.
+     *
+     * @return not-running status
+     */
+    public static CaptureStatus notRunning() {
+        return new CaptureStatus(State.NOT_RUNNING, "", "", "", 0, List.of(),
+                "", false, ProcessHandle.current().pid(), null);
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java
@@ -1,0 +1,377 @@
+package com.shaft.capture.runtime;
+
+import com.shaft.capture.collector.BidiBrowserEventCollector;
+import com.shaft.capture.collector.BrowserEventCollector;
+import com.shaft.capture.collector.BrowserSignal;
+import com.shaft.capture.collector.CompositeBrowserEventCollector;
+import com.shaft.capture.collector.PollingBrowserEventCollector;
+import com.shaft.capture.model.BrowserMetadata;
+import com.shaft.capture.model.CaptureSession;
+import com.shaft.capture.model.Checkpoint;
+import com.shaft.capture.privacy.CapturePrivacyClassifier;
+import com.shaft.capture.privacy.CapturePrivacyPolicy;
+import com.shaft.capture.storage.CaptureSessionStore;
+import com.shaft.driver.SHAFT;
+import com.shaft.listeners.TestNGListener;
+import com.shaft.tools.io.internal.ProjectStructureManager;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.HasCapabilities;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.UnexpectedAlertBehaviour;
+import org.openqa.selenium.UnhandledAlertException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.edge.EdgeOptions;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Owns one SHAFT-managed browser and its deterministic capture pipeline.
+ */
+class ManagedCaptureRecorder {
+    private static final Object SHAFT_INITIALIZATION_LOCK = new Object();
+
+    private final CaptureStartRequest request;
+    private final CapturePrivacyPolicy privacyPolicy;
+    private final String sessionId = UUID.randomUUID().toString();
+    private final Instant startedAt = Instant.now();
+    private final List<String> warnings = new CopyOnWriteArrayList<>();
+    private final Path profileDirectory;
+    private CaptureStatus.State state = CaptureStatus.State.STARTING;
+    private SHAFT.GUI.WebDriver shaftDriver;
+    private WebDriver driver;
+    private BrowserEventCollector collector;
+    private CaptureSessionStore store;
+    private CaptureEventPipeline pipeline;
+    private String currentUrl;
+
+    ManagedCaptureRecorder(CaptureStartRequest request) {
+        this(request, CapturePrivacyPolicy.defaults());
+    }
+
+    ManagedCaptureRecorder(CaptureStartRequest request, CapturePrivacyPolicy privacyPolicy) {
+        if (request == null) {
+            throw new IllegalArgumentException("Capture start request is required.");
+        }
+        this.request = request;
+        this.privacyPolicy = privacyPolicy == null ? CapturePrivacyPolicy.defaults() : privacyPolicy;
+        Path profilesRoot = request.runtimeDirectory().resolve("profiles").toAbsolutePath().normalize();
+        profileDirectory = profilesRoot.resolve(sessionId).normalize();
+        if (!profileDirectory.startsWith(profilesRoot)) {
+            throw new IllegalArgumentException("Capture profile directory escaped the runtime root.");
+        }
+        currentUrl = new CapturePrivacyClassifier(this.privacyPolicy)
+                .sanitizeUrl(request.targetUrl()).value();
+    }
+
+    void start() {
+        try {
+            Files.createDirectories(profileDirectory);
+            Files.createDirectories(request.outputPath().getParent());
+            initializeShaftRuntime();
+            configureShaft();
+            shaftDriver = new SHAFT.GUI.WebDriver(request.browser().driverType(), browserOptions());
+            driver = shaftDriver.getDriver();
+            store = new CaptureSessionStore(request.outputPath());
+            store.start(CaptureSession.start(
+                    sessionId,
+                    startedAt,
+                    browserMetadata(driver)));
+            pipeline = new CaptureEventPipeline(
+                    store,
+                    request.outputPath(),
+                    privacyPolicy,
+                    value -> currentUrl = value,
+                    this::warn);
+            startCollector(driver);
+            driver.navigate().to(request.targetUrl());
+            if (driver instanceof JavascriptExecutor javascript) {
+                javascript.executeScript(
+                        com.shaft.capture.collector.BrowserEventScript.fallbackInstallation());
+            }
+            pipeline.accept(BrowserSignal.generated(
+                    "navigation",
+                    safeWindowHandle(),
+                    Map.of(
+                            "url", driver.getCurrentUrl(),
+                            "title", driver.getTitle(),
+                            "width", 0,
+                            "height", 0),
+                    Map.of("action", "OPEN")));
+            state = CaptureStatus.State.ACTIVE;
+        } catch (RuntimeException | IOException exception) {
+            state = CaptureStatus.State.FAILED;
+            interrupt();
+            throw new IllegalStateException("SHAFT Capture could not start the managed browser.", exception);
+        }
+    }
+
+    CaptureStatus status() {
+        return new CaptureStatus(
+                state,
+                sessionId,
+                request.browser().name().toLowerCase(),
+                currentUrl,
+                pipeline == null ? 0 : pipeline.eventCount(),
+                warnings,
+                request.outputPath().toString(),
+                false,
+                ProcessHandle.current().pid(),
+                startedAt);
+    }
+
+    void checkpoint(String description, Checkpoint.CheckpointKind kind) {
+        ensureActive();
+        pipeline.checkpoint(description, kind);
+    }
+
+    CaptureStatus stop(boolean discard) {
+        if (state != CaptureStatus.State.ACTIVE && state != CaptureStatus.State.STOPPING) {
+            return status();
+        }
+        state = CaptureStatus.State.STOPPING;
+        closeCollectorAndPipeline();
+        closeBrowser();
+        if (store != null) {
+            store.stop(Instant.now());
+        }
+        cleanupProfile();
+        SHAFT.Properties.clearForCurrentThread();
+        if (discard) {
+            deleteCaptureFiles();
+            state = CaptureStatus.State.DISCARDED;
+        } else {
+            state = CaptureStatus.State.COMPLETED;
+        }
+        return status();
+    }
+
+    CaptureStatus interrupt() {
+        closeCollectorAndPipeline();
+        closeBrowser();
+        if (store != null) {
+            try {
+                CaptureSession current = store.read();
+                if (current.status() == CaptureSession.SessionStatus.INCOMPLETE) {
+                    store.markIncomplete(Instant.now());
+                }
+            } catch (RuntimeException ignored) {
+                warn("The incomplete capture snapshot could not be updated after recorder failure.");
+            }
+        }
+        cleanupProfile();
+        SHAFT.Properties.clearForCurrentThread();
+        if (state != CaptureStatus.State.FAILED) {
+            state = CaptureStatus.State.INCOMPLETE;
+        }
+        return status();
+    }
+
+    boolean isBrowserAlive() {
+        if (driver == null || state != CaptureStatus.State.ACTIVE) {
+            return false;
+        }
+        try {
+            return !driver.getWindowHandles().isEmpty();
+        } catch (UnhandledAlertException exception) {
+            return true;
+        } catch (WebDriverException exception) {
+            return false;
+        }
+    }
+
+    WebDriver driverForTesting() {
+        return driver;
+    }
+
+    private void configureShaft() {
+        SHAFT.Properties.clearForCurrentThread();
+        SHAFT.Properties.platform.set()
+                .executionAddress("local")
+                .enableBiDi(true);
+        SHAFT.Properties.web.set()
+                .targetBrowserName(request.browser().name().toLowerCase())
+                .headlessExecution(request.headless())
+                .incognitoMode(false);
+    }
+
+    private static void initializeShaftRuntime() throws IOException {
+        if (com.shaft.properties.internal.Properties.isInitialized()) {
+            return;
+        }
+        synchronized (SHAFT_INITIALIZATION_LOCK) {
+            if (com.shaft.properties.internal.Properties.isInitialized()) {
+                return;
+            }
+            Files.createDirectories(Path.of("allure-results"));
+            Files.createDirectories(Path.of("src", "main", "resources", "properties"));
+            TestNGListener.engineSetup(ProjectStructureManager.RunType.AI_AGENT);
+        }
+    }
+
+    private MutableCapabilities browserOptions() {
+        String profileArgument = "--user-data-dir=" + profileDirectory;
+        if (request.browser() == CaptureBrowser.EDGE) {
+            EdgeOptions options = new EdgeOptions();
+            options.addArguments(profileArgument, "--profile-directory=Default");
+            options.setUnhandledPromptBehaviour(UnexpectedAlertBehaviour.IGNORE);
+            return options;
+        }
+        ChromeOptions options = new ChromeOptions();
+        options.addArguments(profileArgument, "--profile-directory=Default");
+        options.setUnhandledPromptBehaviour(UnexpectedAlertBehaviour.IGNORE);
+        return options;
+    }
+
+    private void startCollector(WebDriver activeDriver) {
+        try {
+            collector = new CompositeBrowserEventCollector(List.of(
+                    new BidiBrowserEventCollector(activeDriver),
+                    new PollingBrowserEventCollector(activeDriver, false)));
+            collector.start(pipeline::accept, this::warn);
+        } catch (RuntimeException exception) {
+            if (collector != null) {
+                collector.close();
+            }
+            warn("WebDriver BiDi initialization failed; the compatibility listener will be used.");
+            collector = new PollingBrowserEventCollector(activeDriver);
+            collector.start(pipeline::accept, this::warn);
+        }
+    }
+
+    private BrowserMetadata browserMetadata(WebDriver activeDriver) {
+        Map<String, String> safeCapabilities = new LinkedHashMap<>();
+        String browserName = request.browser().name().toLowerCase();
+        String browserVersion = "";
+        String platform = "";
+        if (activeDriver instanceof HasCapabilities hasCapabilities) {
+            Capabilities capabilities = hasCapabilities.getCapabilities();
+            browserName = value(capabilities.getBrowserName(), browserName);
+            browserVersion = value(capabilities.getBrowserVersion(), "");
+            platform = value(capabilities.getPlatformName(), platform);
+            putCapability(safeCapabilities, "browserName", capabilities.getBrowserName());
+            putCapability(safeCapabilities, "browserVersion", capabilities.getBrowserVersion());
+            putCapability(safeCapabilities, "platformName", capabilities.getPlatformName());
+            putCapability(safeCapabilities, "acceptInsecureCerts",
+                    capabilities.getCapability("acceptInsecureCerts"));
+            putCapability(safeCapabilities, "webSocketUrl",
+                    capabilities.getCapability("webSocketUrl") == null ? null : "enabled");
+        }
+        return new BrowserMetadata(
+                browserName,
+                browserVersion,
+                platform,
+                sessionId + "-browser",
+                safeCapabilities);
+    }
+
+    private void closeCollectorAndPipeline() {
+        if (collector != null) {
+            try {
+                collector.close();
+            } catch (RuntimeException ignored) {
+                warn("The browser event collector had already stopped.");
+            } finally {
+                collector = null;
+            }
+        }
+        if (pipeline != null) {
+            try {
+                pipeline.close();
+            } catch (RuntimeException ignored) {
+                warn("Pending browser events could not all be finalized.");
+            }
+        }
+    }
+
+    private void closeBrowser() {
+        if (shaftDriver != null) {
+            try {
+                shaftDriver.quit();
+            } catch (RuntimeException ignored) {
+                warn("The managed browser had already stopped before recorder cleanup.");
+            } finally {
+                shaftDriver = null;
+                driver = null;
+            }
+        }
+    }
+
+    private void cleanupProfile() {
+        Path profilesRoot = request.runtimeDirectory().resolve("profiles").toAbsolutePath().normalize();
+        if (!profileDirectory.startsWith(profilesRoot)) {
+            warn("The temporary browser profile path was rejected during cleanup.");
+            return;
+        }
+        try {
+            if (Files.exists(profileDirectory)) {
+                try (var paths = Files.walk(profileDirectory)) {
+                    paths.sorted(java.util.Comparator.reverseOrder()).forEach(path -> {
+                        try {
+                            Files.deleteIfExists(path);
+                        } catch (IOException exception) {
+                            throw new ProfileCleanupException(exception);
+                        }
+                    });
+                }
+            }
+        } catch (IOException | ProfileCleanupException exception) {
+            warn("The temporary browser profile could not be completely removed.");
+        }
+    }
+
+    private void deleteCaptureFiles() {
+        try {
+            Files.deleteIfExists(request.outputPath());
+            Files.deleteIfExists(request.outputPath().getParent().resolve(privacyPolicy.externalDataPath()));
+        } catch (IOException exception) {
+            warn("Discard completed, but one local capture artifact could not be removed.");
+        }
+    }
+
+    private String safeWindowHandle() {
+        try {
+            return driver.getWindowHandle();
+        } catch (WebDriverException exception) {
+            return "";
+        }
+    }
+
+    private void warn(String warning) {
+        if (warning != null && !warning.isBlank() && !warnings.contains(warning)) {
+            warnings.add(warning);
+        }
+    }
+
+    private void ensureActive() {
+        if (state != CaptureStatus.State.ACTIVE) {
+            throw new IllegalStateException("SHAFT Capture is not active.");
+        }
+    }
+
+    private static void putCapability(Map<String, String> target, String name, Object value) {
+        if (value != null && !String.valueOf(value).isBlank()) {
+            target.put(name, String.valueOf(value));
+        }
+    }
+
+    private static String value(Object value, String fallback) {
+        return value == null || String.valueOf(value).isBlank() ? fallback : String.valueOf(value);
+    }
+
+    private static final class ProfileCleanupException extends RuntimeException {
+        private ProfileCleanupException(IOException cause) {
+            super(cause);
+        }
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/storage/CaptureSessionStore.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/storage/CaptureSessionStore.java
@@ -4,10 +4,13 @@ import com.shaft.capture.format.CaptureJsonCodec;
 import com.shaft.capture.model.CaptureEvent;
 import com.shaft.capture.model.CaptureSession;
 import com.shaft.capture.model.Checkpoint;
+import com.shaft.capture.model.ExternalTestDataReference;
+import com.shaft.capture.model.RedactionSummary;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -72,6 +75,21 @@ public final class CaptureSessionStore {
     }
 
     /**
+     * Appends an event with privacy references and summary in one atomic snapshot.
+     *
+     * @param event event to append
+     * @param references external references used by the event
+     * @param summary safe privacy summary
+     * @return updated session
+     */
+    public CaptureSession append(
+            CaptureEvent event,
+            List<ExternalTestDataReference> references,
+            RedactionSummary summary) {
+        return update(session -> session.withDataReferences(references, summary).append(event));
+    }
+
+    /**
      * Adds a checkpoint and atomically publishes the updated session.
      *
      * @param checkpoint checkpoint to add
@@ -79,6 +97,17 @@ public final class CaptureSessionStore {
      */
     public CaptureSession checkpoint(Checkpoint checkpoint) {
         return update(session -> session.checkpoint(checkpoint));
+    }
+
+    /**
+     * Adds a checkpoint and its sanitized-text summary atomically.
+     *
+     * @param checkpoint checkpoint to add
+     * @param summary safe privacy summary
+     * @return updated session
+     */
+    public CaptureSession checkpoint(Checkpoint checkpoint, RedactionSummary summary) {
+        return update(session -> session.withDataReferences(List.of(), summary).checkpoint(checkpoint));
     }
 
     /**

--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -1,0 +1,236 @@
+(channel) => {
+  if (globalThis.__shaftCaptureInstalled) {
+    return;
+  }
+  globalThis.__shaftCaptureInstalled = true;
+  globalThis.__shaftCaptureQueue = globalThis.__shaftCaptureQueue || [];
+
+  const text = value => String(value || "").replace(/\s+/g, " ").trim().slice(0, 500);
+  const dynamic = value =>
+    /[0-9]{8,}/.test(value || "") ||
+    /[a-f0-9]{8}-[a-f0-9-]{27,}/i.test(value || "");
+  const cssEscape = value => {
+    if (globalThis.CSS && typeof globalThis.CSS.escape === "function") {
+      return globalThis.CSS.escape(value);
+    }
+    return String(value).replace(/[^a-zA-Z0-9_-]/g, "\\$&");
+  };
+  const send = payload => {
+    payload.timestamp = Date.now();
+    globalThis.__shaftCaptureQueue.push(payload);
+    if (typeof channel === "function") {
+      channel(JSON.stringify(payload));
+    }
+  };
+  const framePath = () => {
+    const path = [];
+    let current = globalThis;
+    try {
+      while (current !== current.top) {
+        const frame = current.frameElement;
+        path.unshift(text(frame && (frame.id || frame.name)) || "frame");
+        current = current.parent;
+      }
+    } catch (ignored) {
+      path.unshift("cross-origin-frame");
+    }
+    return path;
+  };
+  const page = () => ({
+    url: String(location.href || ""),
+    title: text(document.title),
+    framePath: framePath(),
+    width: Number(globalThis.innerWidth || 0),
+    height: Number(globalThis.innerHeight || 0)
+  });
+  const inferredRole = element => {
+    const explicit = text(element.getAttribute("role")).toLowerCase();
+    if (explicit) return explicit;
+    const tag = String(element.localName || "").toLowerCase();
+    const type = String(element.type || "").toLowerCase();
+    if (tag === "button" || type === "button" || type === "submit") return "button";
+    if (tag === "a" && element.hasAttribute("href")) return "link";
+    if (tag === "select") return "combobox";
+    if (type === "checkbox") return "checkbox";
+    if (type === "radio") return "radio";
+    if (tag === "textarea" || tag === "input") return "textbox";
+    return "";
+  };
+  const label = element => {
+    if (element.labels && element.labels.length) return text(element.labels[0].innerText);
+    const parent = element.closest && element.closest("label");
+    return text(parent && parent.innerText);
+  };
+  const accessibleName = element =>
+    text(element.getAttribute("aria-label")) ||
+    label(element) ||
+    text(element.getAttribute("alt")) ||
+    text(element.getAttribute("title")) ||
+    text(element.innerText);
+  const count = selector => {
+    try {
+      return document.querySelectorAll(selector).length;
+    } catch (ignored) {
+      return 0;
+    }
+  };
+  const cssPath = element => {
+    const parts = [];
+    let current = element;
+    while (current && current.nodeType === Node.ELEMENT_NODE && parts.length < 6) {
+      if (current.id) {
+        parts.unshift("#" + cssEscape(current.id));
+        break;
+      }
+      let part = String(current.localName || "*").toLowerCase();
+      const siblings = current.parentElement
+        ? Array.from(current.parentElement.children).filter(item => item.localName === current.localName)
+        : [];
+      if (siblings.length > 1) {
+        part += `:nth-of-type(${siblings.indexOf(current) + 1})`;
+      }
+      parts.unshift(part);
+      const root = current.getRootNode && current.getRootNode();
+      current = root && root.host ? root.host : current.parentElement;
+    }
+    return parts.join(" > ");
+  };
+  const locators = element => {
+    const result = [];
+    const visible = Boolean(element.getClientRects && element.getClientRects().length);
+    const add = (strategy, expression, selector, stable, signals) => {
+      if (!expression) return;
+      result.push({
+        strategy,
+        expression: text(expression),
+        uniquenessCount: selector ? count(selector) : 1,
+        visible,
+        stable,
+        signals
+      });
+    };
+    const role = inferredRole(element);
+    const name = accessibleName(element);
+    if (role && name) add("ROLE", `${role}:${name}`, "", true, ["ACCESSIBLE"]);
+    const targetLabel = label(element);
+    if (targetLabel) add("LABEL", targetLabel, "", true, ["ACCESSIBLE", "LABEL_ASSOCIATED"]);
+    ["data-testid", "data-test", "data-qa"].forEach(attribute => {
+      const value = element.getAttribute(attribute);
+      if (value) {
+        const selector = `[${attribute}="${cssEscape(value)}"]`;
+        add("TEST_ID", selector, selector, !dynamic(value), ["TEST_ATTRIBUTE", "STABLE_ATTRIBUTE"]);
+      }
+    });
+    if (element.id) {
+      const selector = `#${cssEscape(element.id)}`;
+      add("ID", element.id, selector, !dynamic(element.id), ["STABLE_ATTRIBUTE"]);
+    }
+    if (element.name) {
+      const selector = `[name="${cssEscape(element.name)}"]`;
+      add("NAME", element.name, selector, !dynamic(element.name), ["STABLE_ATTRIBUTE"]);
+    }
+    const generated = cssPath(element);
+    add("CSS", generated, generated, false, ["GENERATED", "POSITIONAL"]);
+    return result;
+  };
+  const snapshot = event => {
+    const path = event.composedPath ? event.composedPath() : [];
+    const element = path.find(item => item && item.nodeType === Node.ELEMENT_NODE) || event.target;
+    if (!element || element.nodeType !== Node.ELEMENT_NODE) return null;
+    if (element.closest && element.closest("[data-shaft-capture-control]")) return null;
+    const attributes = {};
+    ["id", "name", "type", "placeholder", "autocomplete", "data-testid",
+      "data-test", "data-qa", "aria-label", "role"].forEach(name => {
+      if (element.hasAttribute && element.hasAttribute(name)) {
+        attributes[name] = text(element.getAttribute(name));
+      }
+    });
+    const logical = text(
+      element.getAttribute && (
+        element.getAttribute("data-testid") ||
+        element.getAttribute("data-test") ||
+        element.id ||
+        element.name
+      )
+    ) || `${String(element.localName || "element")}-${Math.abs(cssPath(element).split("")
+      .reduce((hash, character) => ((hash << 5) - hash) + character.charCodeAt(0), 0))}`;
+    return {
+      logicalElementId: logical,
+      tagName: String(element.localName || "").toLowerCase(),
+      role: inferredRole(element),
+      accessibleName: accessibleName(element),
+      label: label(element),
+      attributes,
+      locators: locators(element),
+      visible: Boolean(element.getClientRects && element.getClientRects().length),
+      enabled: !Boolean(element.disabled),
+      selected: Boolean(element.checked || element.selected)
+    };
+  };
+  const emit = (kind, event, data) => {
+    const target = snapshot(event);
+    if (target) send({kind, page: page(), target, data: data || {}});
+  };
+  const isTextInput = element => {
+    const tag = String(element && element.localName || "").toLowerCase();
+    const type = String(element && element.type || "text").toLowerCase();
+    return tag === "textarea" || (tag === "input" &&
+      !["button", "submit", "reset", "checkbox", "radio", "file", "hidden"].includes(type));
+  };
+
+  addEventListener("click", event => {
+    const element = event.composedPath ? event.composedPath()[0] : event.target;
+    const type = String(element && element.type || "").toLowerCase();
+    const tag = String(element && element.localName || "").toLowerCase();
+    if (["checkbox", "radio", "file"].includes(type) || tag === "select" || tag === "option") return;
+    emit("click", event, {
+      button: Number(event.button || 0),
+      clickCount: Number(event.detail || 1)
+    });
+  }, true);
+  addEventListener("dblclick", event => emit("click", event, {
+    button: Number(event.button || 0),
+    clickCount: 2
+  }), true);
+  addEventListener("input", event => {
+    if (!isTextInput(event.target)) return;
+    emit("input", event, {value: String(event.target.value || "")});
+  }, true);
+  addEventListener("change", event => {
+    const element = event.target;
+    const tag = String(element && element.localName || "").toLowerCase();
+    const type = String(element && element.type || "").toLowerCase();
+    if (tag === "select") {
+      const option = element.options && element.selectedIndex >= 0
+        ? element.options[element.selectedIndex]
+        : null;
+      emit("select", event, {
+        value: String(element.value || ""),
+        visibleText: text(option && option.text),
+        index: Number(element.selectedIndex || 0)
+      });
+    } else if (type === "checkbox" || type === "radio") {
+      emit("toggle", event, {checked: Boolean(element.checked)});
+    } else if (type === "file") {
+      const file = element.files && element.files.length ? element.files[0] : null;
+      emit("upload", event, {
+        fileName: file ? String(file.name || "") : "",
+        mediaType: file ? String(file.type || "") : "",
+        sizeBytes: file ? Number(file.size || 0) : 0
+      });
+    } else if (isTextInput(element)) {
+      emit("input", event, {value: String(element.value || ""), committed: true});
+    }
+  }, true);
+  addEventListener("keydown", event => {
+    const modifiers = [];
+    if (event.ctrlKey) modifiers.push("CONTROL");
+    if (event.altKey) modifiers.push("ALT");
+    if (event.metaKey) modifiers.push("META");
+    if (event.shiftKey) modifiers.push("SHIFT");
+    const key = String(event.key || "");
+    const named = key.length > 1 && !["Shift", "Control", "Alt", "Meta"].includes(key);
+    if (!named && modifiers.length === 0) return;
+    emit("keyboard", event, {keys: [...modifiers, key.toUpperCase()]});
+  }, true);
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/format/CaptureJsonCodecTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/format/CaptureJsonCodecTest.java
@@ -44,7 +44,7 @@ class CaptureJsonCodecTest {
 
         CaptureSession session = codec.read(golden);
 
-        assertEquals(golden, codec.write(session));
+        assertEquals(normalizeLineEndings(golden), normalizeLineEndings(codec.write(session)));
     }
 
     @Test
@@ -122,5 +122,9 @@ class CaptureJsonCodecTest {
             }
             return new String(input.readAllBytes(), StandardCharsets.UTF_8);
         }
+    }
+
+    private static String normalizeLineEndings(String value) {
+        return value.replace("\r\n", "\n");
     }
 }

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
@@ -1,0 +1,181 @@
+package com.shaft.capture.runtime;
+
+import com.shaft.capture.collector.BrowserSignal;
+import com.shaft.capture.model.BrowserMetadata;
+import com.shaft.capture.model.CaptureEvent;
+import com.shaft.capture.model.CaptureSession;
+import com.shaft.capture.model.ExternalTestDataReference;
+import com.shaft.capture.privacy.CapturePrivacyPolicy;
+import com.shaft.capture.storage.CaptureSessionStore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CaptureEventPipelineTest {
+    private static final String SECRET_CANARY = "capture-secret-canary-value";
+    private static final Instant START = Instant.parse("2026-06-11T10:00:00Z");
+
+    @Test
+    void debouncesSemanticEventsAndClassifiesValuesBeforePersistence(@TempDir Path temp) throws Exception {
+        Path output = temp.resolve("path with spaces").resolve("session.json");
+        CaptureSessionStore store = startedStore(output);
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store, output, CapturePrivacyPolicy.defaults(), ignored -> {
+                }, ignored -> {
+                });
+
+        pipeline.accept(signal("navigation", START, Map.of(), Map.of("action", "OPEN"), Map.of()));
+        pipeline.accept(signal("input", START.plusMillis(10), passwordTarget(),
+                Map.of("value", SECRET_CANARY, "committed", true), Map.of()));
+        pipeline.accept(signal("input", START.plusMillis(20), usernameTarget(),
+                Map.of("value", "a"), Map.of()));
+        pipeline.accept(signal("input", START.plusMillis(30), usernameTarget(),
+                Map.of("value", "alice"), Map.of()));
+        pipeline.accept(signal("click", START.plusMillis(40), buttonTarget(),
+                Map.of("button", 0, "clickCount", 1), Map.of()));
+        pipeline.accept(signal("click", START.plusMillis(50), buttonTarget(),
+                Map.of("button", 0, "clickCount", 2), Map.of()));
+        pipeline.close();
+
+        CaptureSession session = store.read();
+        assertEquals(4, session.events().size());
+        assertInstanceOf(CaptureEvent.NavigationEvent.class, session.events().get(0));
+        CaptureEvent.TypeEvent secret = assertInstanceOf(
+                CaptureEvent.TypeEvent.class, session.events().get(1));
+        assertEquals(ExternalTestDataReference.DataClassification.SECRET,
+                secret.value().classification());
+        CaptureEvent.TypeEvent ordinary = assertInstanceOf(
+                CaptureEvent.TypeEvent.class, session.events().get(2));
+        assertEquals(ExternalTestDataReference.DataClassification.ORDINARY,
+                ordinary.value().classification());
+        CaptureEvent.ClickEvent click = assertInstanceOf(
+                CaptureEvent.ClickEvent.class, session.events().get(3));
+        assertEquals(2, click.clickCount());
+
+        String sessionJson = Files.readString(output, StandardCharsets.UTF_8);
+        String dataJson = Files.readString(output.getParent().resolve("capture-data.json"),
+                StandardCharsets.UTF_8);
+        assertFalse(sessionJson.contains(SECRET_CANARY));
+        assertFalse(dataJson.contains(SECRET_CANARY));
+        assertTrue(dataJson.contains("alice"));
+    }
+
+    @Test
+    void normalizesSelectToggleUploadKeyboardAndAlertActions(@TempDir Path temp) {
+        Path output = temp.resolve("session.json");
+        CaptureSessionStore store = startedStore(output);
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store, output, CapturePrivacyPolicy.defaults(), ignored -> {
+                }, ignored -> {
+                });
+
+        pipeline.accept(signal("select", START, selectTarget(),
+                Map.of("visibleText", "Egypt", "value", "eg", "index", 1), Map.of()));
+        pipeline.accept(signal("toggle", START.plusMillis(1), checkboxTarget(),
+                Map.of("checked", true), Map.of()));
+        pipeline.accept(signal("upload", START.plusMillis(2), uploadTarget(),
+                Map.of("fileName", "avatar.png", "mediaType", "image/png", "sizeBytes", 42), Map.of()));
+        pipeline.accept(signal("keyboard", START.plusMillis(3), usernameTarget(),
+                Map.of("keys", List.of("CONTROL", "A")), Map.of()));
+        pipeline.accept(signal("alert", START.plusMillis(4), Map.of(),
+                Map.of("accepted", true, "text", "ordinary prompt text"), Map.of()));
+        pipeline.close();
+
+        List<CaptureEvent> events = store.read().events();
+        assertEquals(6, events.size());
+        assertInstanceOf(CaptureEvent.SelectEvent.class, events.get(0));
+        assertInstanceOf(CaptureEvent.ToggleEvent.class, events.get(1));
+        assertInstanceOf(CaptureEvent.UploadEvent.class, events.get(2));
+        assertInstanceOf(CaptureEvent.KeyboardEvent.class, events.get(3));
+        assertEquals(CaptureEvent.AlertAction.TYPE,
+                assertInstanceOf(CaptureEvent.AlertEvent.class, events.get(4)).action());
+        assertEquals(CaptureEvent.AlertAction.ACCEPT,
+                assertInstanceOf(CaptureEvent.AlertEvent.class, events.get(5)).action());
+    }
+
+    private static CaptureSessionStore startedStore(Path output) {
+        CaptureSessionStore store = new CaptureSessionStore(output);
+        store.start(CaptureSession.start(
+                "pipeline",
+                START,
+                new BrowserMetadata("chrome", "1", "test", "browser", Map.of())));
+        return store;
+    }
+
+    private static BrowserSignal signal(
+            String kind,
+            Instant timestamp,
+            Map<String, Object> target,
+            Map<String, Object> data,
+            Map<String, Object> pageOverrides) {
+        Map<String, Object> page = new java.util.LinkedHashMap<>(Map.of(
+                "url", "https://example.test/form",
+                "title", "Form",
+                "width", 1280,
+                "height", 720,
+                "framePath", List.of()));
+        page.putAll(pageOverrides);
+        return new BrowserSignal(kind, timestamp, "context-1", page, target, data);
+    }
+
+    private static Map<String, Object> usernameTarget() {
+        return target("username", "input", "textbox",
+                Map.of("name", "username", "autocomplete", "username"));
+    }
+
+    private static Map<String, Object> passwordTarget() {
+        return target("password", "input", "textbox",
+                Map.of("name", "password", "type", "password"));
+    }
+
+    private static Map<String, Object> buttonTarget() {
+        return target("submit", "button", "button", Map.of("id", "submit"));
+    }
+
+    private static Map<String, Object> selectTarget() {
+        return target("country", "select", "combobox", Map.of("name", "country"));
+    }
+
+    private static Map<String, Object> checkboxTarget() {
+        return target("terms", "input", "checkbox", Map.of("name", "terms", "type", "checkbox"));
+    }
+
+    private static Map<String, Object> uploadTarget() {
+        return target("avatar", "input", "textbox", Map.of("name", "avatar", "type", "file"));
+    }
+
+    private static Map<String, Object> target(
+            String id,
+            String tag,
+            String role,
+            Map<String, String> attributes) {
+        return Map.of(
+                "logicalElementId", id,
+                "tagName", tag,
+                "role", role,
+                "accessibleName", id,
+                "label", id,
+                "attributes", attributes,
+                "locators", List.of(Map.of(
+                        "strategy", "ID",
+                        "expression", id,
+                        "uniquenessCount", 1,
+                        "visible", true,
+                        "stable", true,
+                        "signals", List.of("STABLE_ATTRIBUTE"))),
+                "visible", true,
+                "enabled", true,
+                "selected", false);
+    }
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureRuntimePortabilityTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureRuntimePortabilityTest.java
@@ -1,0 +1,70 @@
+package com.shaft.capture.runtime;
+
+import com.shaft.capture.control.CaptureControlFiles;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CaptureRuntimePortabilityTest {
+    @Test
+    void roundTripsPortablePathsWithSpacesAndRestrictedControlFiles(@TempDir Path temp) {
+        Path runtime = temp.resolve("runtime with spaces");
+        Path output = temp.resolve("recordings with spaces").resolve("capture.json");
+        CaptureStartRequest request = new CaptureStartRequest(
+                "https://example.test/path?token=secret",
+                CaptureBrowser.CHROME,
+                output,
+                runtime,
+                false);
+        CaptureControlFiles files = new CaptureControlFiles(runtime);
+
+        Path launchRequest = files.writeLaunchRequest(request);
+        CaptureStartRequest restored = files.consumeLaunchRequest(launchRequest);
+        files.writeToken("local-token");
+        files.writeDescriptor(new CaptureControlFiles.ControlDescriptor(43123, ProcessHandle.current().pid()));
+        files.writeStatus(new CaptureStatus(
+                CaptureStatus.State.ACTIVE,
+                "portable",
+                "chrome",
+                "https://example.test/path?token=%5Bdata%3Atoken%5D",
+                3,
+                List.of(),
+                output.toAbsolutePath().normalize().toString(),
+                false,
+                ProcessHandle.current().pid(),
+                Instant.parse("2026-06-11T10:00:00Z")));
+
+        assertEquals(request, restored);
+        assertEquals("local-token", files.readToken());
+        assertEquals(43123, files.readDescriptor().port());
+        assertEquals(output.toAbsolutePath().normalize().toString(), files.readStatus().outputPath());
+        assertTrue(runtime.resolve("status.json").toFile().isFile());
+    }
+
+    @Test
+    void singleSessionLockWorksWithoutPlatformSpecificShells(@TempDir Path temp) {
+        Path runtime = temp.resolve("runtime with spaces");
+        try (CaptureSingleSessionLock ignored = CaptureSingleSessionLock.acquire(runtime)) {
+            assertThrows(IllegalStateException.class, () -> CaptureSingleSessionLock.acquire(runtime));
+        }
+        try (CaptureSingleSessionLock ignored = CaptureSingleSessionLock.acquire(runtime)) {
+            assertTrue(runtime.resolve("capture.lock").toFile().isFile());
+        }
+    }
+
+    @Test
+    void rejectsUnsupportedFirefoxWithExplicitMessage() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> CaptureBrowser.parse("firefox"));
+
+        assertTrue(exception.getMessage().contains("not supported"));
+    }
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
@@ -1,0 +1,184 @@
+package com.shaft.capture.runtime;
+
+import com.shaft.capture.format.CaptureJsonCodec;
+import com.shaft.capture.model.CaptureEvent;
+import com.shaft.capture.model.CaptureSession;
+import com.shaft.capture.model.Checkpoint;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openqa.selenium.Alert;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.ui.Select;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("external-e2e")
+class ManagedCaptureRecorderBrowserTest {
+    private static final String SECRET_CANARY = "capture-browser-secret-canary";
+
+    @ParameterizedTest
+    @ValueSource(strings = {"chrome", "edge"})
+    void recordsRepresentativeJourneyAcrossSupportedBrowsers(
+            String browserName,
+            @TempDir Path temp) throws Exception {
+        HttpServer server = localFixture();
+        Path output = temp.resolve("recordings with spaces").resolve(browserName + ".json");
+        Path runtime = temp.resolve("runtime with spaces").resolve(browserName);
+        Path upload = temp.resolve("upload fixture.txt");
+        Files.writeString(upload, "fixture", StandardCharsets.UTF_8);
+        ManagedCaptureRecorder recorder = new ManagedCaptureRecorder(new CaptureStartRequest(
+                "http://127.0.0.1:" + server.getAddress().getPort() + "/",
+                CaptureBrowser.parse(browserName),
+                output,
+                runtime,
+                true));
+        try {
+            recorder.start();
+            WebDriver driver = recorder.driverForTesting();
+            driver.findElement(By.id("username")).sendKeys("alice");
+            driver.findElement(By.id("password")).sendKeys(SECRET_CANARY);
+            new Select(driver.findElement(By.id("country"))).selectByVisibleText("Egypt");
+            driver.findElement(By.id("terms")).click();
+            driver.findElement(By.id("upload")).sendKeys(upload.toAbsolutePath().toString());
+            new Actions(driver).doubleClick(driver.findElement(By.id("double"))).perform();
+            driver.findElement(By.id("replace")).click();
+
+            WebElement shadowHost = driver.findElement(By.id("shadow-host"));
+            shadowHost.getShadowRoot().findElement(By.cssSelector("button")).click();
+
+            driver.switchTo().frame(driver.findElement(By.id("child")));
+            driver.findElement(By.id("frame-button")).click();
+            driver.switchTo().defaultContent();
+
+            String originalWindow = driver.getWindowHandle();
+            driver.findElement(By.id("popup")).click();
+            waitFor(() -> driver.getWindowHandles().size() == 2);
+            String popup = driver.getWindowHandles().stream()
+                    .filter(handle -> !handle.equals(originalWindow))
+                    .findFirst()
+                    .orElseThrow();
+            driver.switchTo().window(popup);
+            driver.close();
+            driver.switchTo().window(originalWindow);
+
+            driver.findElement(By.id("prompt")).click();
+            Alert alert = driver.switchTo().alert();
+            alert.sendKeys("ordinary prompt text");
+            alert.accept();
+            recorder.checkpoint("Representative journey completed", Checkpoint.CheckpointKind.ASSERTION);
+            Thread.sleep(1500);
+            recorder.stop(false);
+        } finally {
+            if (recorder.status().state() == CaptureStatus.State.ACTIVE) {
+                recorder.interrupt();
+            }
+            server.stop(0);
+        }
+
+        CaptureSession session = new CaptureJsonCodec().read(output);
+        Set<Class<?>> eventTypes = session.events().stream()
+                .map(Object::getClass)
+                .collect(java.util.stream.Collectors.toSet());
+        assertTrue(eventTypes.contains(CaptureEvent.NavigationEvent.class));
+        assertTrue(eventTypes.contains(CaptureEvent.TypeEvent.class));
+        assertTrue(eventTypes.contains(CaptureEvent.SelectEvent.class));
+        assertTrue(eventTypes.contains(CaptureEvent.ToggleEvent.class));
+        assertTrue(eventTypes.contains(CaptureEvent.UploadEvent.class));
+        assertTrue(eventTypes.contains(CaptureEvent.FrameEvent.class));
+        assertTrue(eventTypes.contains(CaptureEvent.WindowEvent.class));
+        assertTrue(eventTypes.contains(CaptureEvent.AlertEvent.class));
+        assertFalse(Files.readString(output, StandardCharsets.UTF_8).contains(SECRET_CANARY));
+        assertFalse(Files.readString(output.getParent().resolve("capture-data.json"),
+                StandardCharsets.UTF_8).contains(SECRET_CANARY));
+        Path profiles = runtime.resolve("profiles");
+        if (Files.exists(profiles)) {
+            try (var entries = Files.list(profiles)) {
+                assertTrue(entries.findAny().isEmpty());
+            }
+        }
+    }
+
+    private static HttpServer localFixture() throws IOException {
+        HttpServer server = HttpServer.create(
+                new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0), 0);
+        server.createContext("/", exchange -> respond(exchange, """
+                <!doctype html>
+                <html>
+                <head><title>SHAFT Capture Fixture</title></head>
+                <body>
+                  <label>Username <input id="username" name="username"></label>
+                  <label>Password <input id="password" name="password" type="password"></label>
+                  <label>Country
+                    <select id="country" name="country">
+                      <option>United States</option><option>Egypt</option>
+                    </select>
+                  </label>
+                  <label><input id="terms" name="terms" type="checkbox"> Terms</label>
+                  <input id="upload" name="upload" type="file">
+                  <button id="double">Double</button>
+                  <button id="replace" onclick="this.outerHTML='<button id=&quot;replacement&quot;>Replacement</button>'">
+                    Replace dynamically
+                  </button>
+                  <div id="shadow-host"></div>
+                  <iframe id="child" src="/frame"></iframe>
+                  <button id="popup" onclick="window.open('/popup', '_blank')">Popup</button>
+                  <button id="prompt" onclick="prompt('Prompt value')">Prompt</button>
+                  <script>
+                    const root = document.querySelector('#shadow-host').attachShadow({mode: 'open'});
+                    root.innerHTML = '<button id="shadow-button">Shadow</button>';
+                  </script>
+                </body>
+                </html>
+                """));
+        server.createContext("/frame", exchange -> respond(exchange,
+                "<!doctype html><button id=\"frame-button\">Frame</button>"));
+        server.createContext("/popup", exchange -> respond(exchange,
+                "<!doctype html><title>Popup</title><p>Popup</p>"));
+        server.start();
+        return server;
+    }
+
+    private static void respond(HttpExchange exchange, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "text/html; charset=utf-8");
+        exchange.sendResponseHeaders(200, bytes.length);
+        try (exchange) {
+            exchange.getResponseBody().write(bytes);
+        }
+    }
+
+    private static void waitFor(java.util.function.BooleanSupplier condition) throws InterruptedException {
+        InstantDeadline deadline = new InstantDeadline(Duration.ofSeconds(5));
+        while (!condition.getAsBoolean() && !deadline.expired()) {
+            Thread.sleep(50);
+        }
+        assertTrue(condition.getAsBoolean());
+    }
+
+    private record InstantDeadline(long deadlineNanos) {
+        private InstantDeadline(Duration duration) {
+            this(System.nanoTime() + duration.toNanos());
+        }
+
+        private boolean expired() {
+            return System.nanoTime() >= deadlineNanos;
+        }
+    }
+}

--- a/shaft-mcp/pom.xml
+++ b/shaft-mcp/pom.xml
@@ -67,6 +67,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>shaft-capture</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/shaft-mcp/src/main/java/io/github/shafthq/SHAFT_MCP/CaptureService.java
+++ b/shaft-mcp/src/main/java/io/github/shafthq/SHAFT_MCP/CaptureService.java
@@ -1,0 +1,87 @@
+package io.github.shafthq.SHAFT_MCP;
+
+import com.shaft.capture.runtime.CaptureBrowser;
+import com.shaft.capture.runtime.CaptureManager;
+import com.shaft.capture.runtime.CaptureStartRequest;
+import com.shaft.capture.runtime.CaptureStatus;
+import jakarta.annotation.PreDestroy;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.stereotype.Service;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * MCP adapter for deterministic managed-browser SHAFT Capture recording.
+ */
+@Service
+public class CaptureService {
+    private static final DateTimeFormatter FILE_TIME = DateTimeFormatter
+            .ofPattern("yyyyMMdd-HHmmss")
+            .withZone(ZoneOffset.UTC);
+    private static final Path RUNTIME_DIRECTORY = Path.of("target", "shaft-capture-mcp");
+
+    private final CaptureManager manager = new CaptureManager();
+
+    /**
+     * Launches a fresh SHAFT-managed browser and starts deterministic capture.
+     *
+     * @param targetUrl initial http, https, or file URL
+     * @param browser Chrome or Edge; blank selects Chrome
+     * @param outputPath capture JSON path; blank selects a timestamped recording
+     * @param headless whether to launch without a visible window
+     * @return safe recorder status
+     */
+    @Tool(name = "capture_start",
+            description = "starts a privacy-safe SHAFT managed-browser recording with no AI provider")
+    public CaptureStatus start(
+            String targetUrl,
+            String browser,
+            String outputPath,
+            boolean headless) {
+        Path output = outputPath == null || outputPath.isBlank()
+                ? Path.of("recordings", "capture-" + FILE_TIME.format(Instant.now()) + ".json")
+                : Path.of(outputPath);
+        return manager.start(new CaptureStartRequest(
+                targetUrl,
+                browser == null || browser.isBlank()
+                        ? CaptureBrowser.CHROME
+                        : CaptureBrowser.parse(browser),
+                output,
+                RUNTIME_DIRECTORY,
+                headless));
+    }
+
+    /**
+     * Returns safe recorder status without captured values.
+     *
+     * @return current or final recorder status
+     */
+    @Tool(name = "capture_status",
+            description = "returns SHAFT Capture session, browser, URL, event count, warnings, and output status")
+    public CaptureStatus status() {
+        return manager.status();
+    }
+
+    /**
+     * Stops the active recording.
+     *
+     * @param discard whether to delete capture artifacts after shutdown
+     * @return final recorder status
+     */
+    @Tool(name = "capture_stop",
+            description = "stops SHAFT Capture and optionally discards the local recording")
+    public CaptureStatus stop(boolean discard) {
+        return manager.stop(discard);
+    }
+
+    /**
+     * Preserves an incomplete session when the MCP server shuts down unexpectedly.
+     */
+    @PreDestroy
+    void close() {
+        manager.close();
+    }
+}

--- a/shaft-mcp/src/main/java/io/github/shafthq/SHAFT_MCP/ShaftMcpApplication.java
+++ b/shaft-mcp/src/main/java/io/github/shafthq/SHAFT_MCP/ShaftMcpApplication.java
@@ -1,13 +1,21 @@
 package io.github.shafthq.SHAFT_MCP;
 
+import com.shaft.capture.cli.CaptureCli;
 import org.springframework.ai.support.ToolCallbacks;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
+import java.io.File;
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @SpringBootApplication
 public class ShaftMcpApplication {
@@ -17,6 +25,15 @@ public class ShaftMcpApplication {
      * @param args command-line arguments
      */
 	public static void main(String[] args) throws IOException {
+        if (args.length > 0 && "capture".equalsIgnoreCase(args[0])) {
+            int exitCode = CaptureCli.run(
+                    Arrays.copyOfRange(args, 1, args.length),
+                    captureLaunchPrefix());
+            if (exitCode != 0) {
+                System.exit(exitCode);
+            }
+            return;
+        }
         new SpringApplication(ShaftMcpApplication.class).run(args);
 	}
 
@@ -26,15 +43,59 @@ public class ShaftMcpApplication {
      * @return a list of ToolCallback instances
      */
 	@Bean
-	public List<ToolCallback> shaftTools(EngineService engineService, BrowserService browserService, ElementService elementService) {
+	public List<ToolCallback> shaftTools(
+            EngineService engineService,
+            BrowserService browserService,
+            ElementService elementService,
+            CaptureService captureService) {
         var engineServiceList = List.of(ToolCallbacks.from(engineService));
         var browserServiceList = List.of(ToolCallbacks.from(browserService));
         var elementServiceList = List.of(ToolCallbacks.from(elementService));
+        var captureServiceList = List.of(ToolCallbacks.from(captureService));
 
         var serviceList = new java.util.ArrayList<ToolCallback>();
         serviceList.addAll(engineServiceList);
         serviceList.addAll(browserServiceList);
         serviceList.addAll(elementServiceList);
+        serviceList.addAll(captureServiceList);
         return serviceList;
 	}
+
+    private static List<String> captureLaunchPrefix() {
+        String javaCommand = ProcessHandle.current().info().command().orElse("java");
+        String[] processArguments = ProcessHandle.current().info().arguments().orElse(new String[0]);
+        for (int index = 0; index + 1 < processArguments.length; index++) {
+            if ("-jar".equals(processArguments[index])) {
+                return List.of(javaCommand, "-jar", processArguments[index + 1], "capture");
+            }
+        }
+        String classPath = ManagementFactory.getRuntimeMXBean().getClassPath();
+        String[] classPathEntries = classPath.split(Pattern.quote(File.pathSeparator));
+        if (classPathEntries.length == 1) {
+            Path executable = Path.of(classPathEntries[0]).toAbsolutePath().normalize();
+            if (Files.isRegularFile(executable) && executable.getFileName().toString().endsWith(".jar")) {
+                return List.of(javaCommand, "-jar", executable.toString(), "capture");
+            }
+        }
+        try {
+            Path application = Path.of(ShaftMcpApplication.class.getProtectionDomain()
+                    .getCodeSource().getLocation().toURI());
+            if (Files.isRegularFile(application) && application.getFileName().toString().endsWith(".jar")) {
+                return List.of(javaCommand, "-jar", application.toString(), "capture");
+            }
+        } catch (Exception ignored) {
+            // Development and test runs use the current classpath below.
+        }
+        return List.of(
+                javaCommand,
+                "-cp",
+                absoluteClassPath(classPath),
+                CaptureCli.class.getName());
+    }
+
+    private static String absoluteClassPath(String classPath) {
+        return Arrays.stream(classPath.split(Pattern.quote(File.pathSeparator)))
+                .map(entry -> Path.of(entry).toAbsolutePath().normalize().toString())
+                .collect(Collectors.joining(File.pathSeparator));
+    }
 }

--- a/shaft-mcp/src/test/java/io/github/shafthq/SHAFT_MCP/ShaftMcpApplicationTests.java
+++ b/shaft-mcp/src/test/java/io/github/shafthq/SHAFT_MCP/ShaftMcpApplicationTests.java
@@ -20,7 +20,10 @@ class ShaftMcpApplicationTests {
             "driver_initialize",
             "browser_navigate",
             "browser_get_current_url",
-            "element_click"
+            "element_click",
+            "capture_start",
+            "capture_status",
+            "capture_stop"
     );
 
     @Autowired
@@ -31,7 +34,7 @@ class ShaftMcpApplicationTests {
         Object bean = context.getBean("shaftTools");
         assertTrue(bean instanceof List<?>);
         List<?> callbacks = (List<?>) bean;
-        assertEquals(40, callbacks.size());
+        assertEquals(43, callbacks.size());
 
         Set<String> toolNames = callbacks.stream()
                 .map(ToolCallback.class::cast)


### PR DESCRIPTION
## Summary

- add deterministic managed-browser SHAFT Capture recording for Chrome and Edge
- expose `capture start/status/checkpoint/stop` through the executable JAR and `capture_start/status/stop` through MCP
- collect semantic browser events with WebDriver BiDi plus an injected compatibility listener
- enforce privacy classification before persistence, authenticated loopback control, single-session locking, crash recovery, and temporary-profile cleanup
- keep process and filesystem handling OS agnostic with Java `Path`, `Files`, `ProcessBuilder`, portable classpaths, and optional POSIX permissions
- document the capture lifecycle, supported browsers, privacy boundary, and module architecture

Closes #2853.

## Validation

- `mvn -pl shaft-capture test -Dgpg.skip` (`18` passed)
- `mvn -pl shaft-capture -am test -DincludeCaptureBrowserE2E=true -Dtest=ManagedCaptureRecorderBrowserTest -Dgpg.skip` (Chrome and Edge passed; Allure results populated)
- `mvn -pl shaft-mcp -am test -Dtest=ShaftMcpApplicationTests -Dgpg.skip` (`43` tools registered)
- `mvn -pl shaft-mcp -am clean package -DskipTests -Dgpg.skip`
- packaged CLI `start/status/checkpoint/stop` smoke with paths containing spaces; daemon/profile/control cleanup verified
- `python scripts/ci/validate_shaft_mcp_transports.py`
- `python scripts/ci/validate_modular_documentation.py`
- `python scripts/ci/validate_shaft_mcp_configuration.py`
- `python scripts/ci/validate_quality_configuration.py`
- `python scripts/ci/validate_agent_guidance.py`
- `git diff --check`

## Known validation limitation

`mvn -pl shaft-capture,shaft-mcp -am test -Dgpg.skip` was attempted, but the upstream engine suite exceeded 30 minutes while waiting in the external `Test_LTDesktopWebMac` LambdaTest workflow. The task-owned Maven, Surefire, and WebDriver processes were cleaned up; the changed modules and local real-browser paths pass independently.