### PR TITLE
[codex] Generate reliable SHAFT TestNG tests from Capture sessions

### DIFF
--- a/docs/MAVEN_REACTOR.md
+++ b/docs/MAVEN_REACTOR.md
@@ -10,7 +10,7 @@ relocation artifact that points consumers to the canonical JAR.
 - `shaft-engine/pom.xml` builds the engine JAR. All framework source, resources, tests, examples, and runtime support assets remain under `shaft-engine/src/`; Java packages remain under `com.shaft`.
 - `shaft-bom/pom.xml` publishes the consumer BOM. Importing it manages the `shaft-engine`, `shaft-pilot-core`, `shaft-capture`, `shaft-ai`, `shaft-browserstack`, `shaft-video`, `shaft-visual`, and `SHAFT_MCP` versions without adding dependencies by itself.
 - `shaft-pilot-core/pom.xml` builds provider-neutral Pilot contracts, security controls, configuration snapshots, and deterministic fallback. It depends on `shaft-engine`; the engine has no reverse dependency.
-- `shaft-capture/pom.xml` builds managed Chrome/Edge recording, versioned contracts, deterministic privacy classification, schema migration, and atomic JSON persistence. It depends on `shaft-pilot-core` and has no dependency on `shaft-ai`.
+- `shaft-capture/pom.xml` builds managed Chrome/Edge recording, versioned contracts, deterministic privacy classification, Java/TestNG generation, compile/replay validation, schema migration, and atomic JSON persistence. It depends on `shaft-pilot-core` and has no dependency on `shaft-ai`.
 - `shaft-ai/pom.xml` builds optional direct OpenAI, Anthropic, Gemini, and Ollama adapters. It depends on `shaft-pilot-core` and exposes no provider SDK types.
 - `shaft-mcp/pom.xml` builds the optional executable MCP server and SHAFT Capture CLI. It depends on `shaft-engine` and `shaft-capture`; the engine has no reverse dependency on MCP.
 - `shaft-browserstack/pom.xml` builds the optional BrowserStack Java SDK integration. Direct BrowserStack

--- a/docs/SHAFT_CAPTURE.md
+++ b/docs/SHAFT_CAPTURE.md
@@ -3,7 +3,8 @@
 `shaft-capture` defines the provider-neutral intermediate representation used
 by SHAFT Capture and the managed-browser recorder that produces it. It records
 browser intent for review, replay, migration, and future Java/JUnit/Cucumber
-generators without depending on `shaft-ai`.
+consumers. It generates Java 25 SHAFT/TestNG tests without depending on
+`shaft-ai`; provider adapters remain optional.
 
 Capture creation, validation, serialization, and privacy enforcement work with
 `pilot.ai.enabled=false`. Optional AI consumers may receive only the already
@@ -38,8 +39,8 @@ bearer token, and removes its token and descriptor at shutdown. Browser
 profiles are temporary and removed after normal stop or interruption.
 
 The same lifecycle is exposed by the `capture_start`, `capture_status`, and
-`capture_stop` MCP tools. Status contains safe metadata and counts, never typed
-values.
+`capture_stop` MCP tools. Generation is exposed by `capture_generate`. Status
+contains safe metadata and counts, never typed values.
 
 All process arguments and filesystem paths are built with Java APIs
 (`ProcessBuilder`, `Path`, and `Files`). No Windows, POSIX shell, or path
@@ -111,16 +112,80 @@ store.append(captureEvent);
 store.stop(Instant.now());
 ```
 
+## Deterministic TestNG generation
+
+Generate a test, SHAFT JSON test data, and a deterministic report:
+
+```bash
+java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture generate \
+  --session recordings/example.json \
+  --output-dir generated-tests
+```
+
+The default output layout is:
+
+```text
+generated-tests/
+  src/test/java/generated/capture/<SessionName>Test.java
+  src/test/resources/testDataFiles/<session-name>-test.json
+  target/shaft-capture/generation-report.json
+```
+
+Generation selects locators in the accessibility, label, test-ID, stable
+ID/name, CSS, then XPath family. The report records the score contribution from
+uniqueness, visibility, interactability, semantic match, volatility,
+frame/shadow context, and replay evidence, plus ranked fallbacks. Stable
+user-provided locators can outrank volatile semantic evidence.
+
+Ordinary values are copied from the recording's external JSON into the
+generated test-data file. Secret and sensitive references become required
+environment variables and are typed securely. Uploads remain relative fixture
+references under `src/test/resources`. Missing data is reported as required
+user input. Captured credentials, cookies, authorization values, and absolute
+personal paths fail the privacy scan instead of entering generated artifacts.
+
+Every generated class creates a fresh driver in `@BeforeMethod` and calls
+`driver.quit()` from `@AfterMethod(alwaysRun = true)`. Only explicit
+`VerificationEvent` records become assertions. An `ASSERTION` checkpoint must
+point at a verification event; unsupported steps fail generation with their
+event IDs and remediation.
+
+Compilation is enabled by default. Add `--replay` to run the compiled TestNG
+class in an isolated process and require populated, passing Allure result
+files. Existing source, data, report, or preview files are never replaced
+unless `--overwrite` is supplied.
+
+AI enrichment is optional and uses two phases:
+
+```bash
+# Calls the enabled provider only with explicit processing approval.
+java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture generate \
+  --session recordings/example.json --output-dir generated-tests \
+  --ai-preview --allow-local-ai
+
+# Apply the reviewed, fingerprinted preview.
+java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture generate \
+  --session recordings/example.json --output-dir generated-tests-enriched \
+  --apply-enrichment generated-tests/target/shaft-capture/enrichment-preview.json \
+  --approve-enrichment --replay
+```
+
+The provider may suggest Java names and captured-state assertions only. It
+cannot replace deterministic locators. Preview output is schema-validated and
+privacy-scanned; apply rejects stale fingerprints, invalid identifiers,
+unknown events, and assertions that contradict captured state. Accepted
+changes are compiled and replayed again.
+
 Run the focused suite with:
 
 ```bash
 mvn -pl shaft-capture -am test
 ```
 
-The real-browser Chrome and Edge suite is opt-in:
+The real-browser recording and generated-replay suites are opt-in:
 
 ```bash
 mvn -pl shaft-capture -am test \
   -DincludeCaptureBrowserE2E=true \
-  -Dtest=ManagedCaptureRecorderBrowserTest
+  -Dtest=ManagedCaptureRecorderBrowserTest,CaptureGeneratedReplayBrowserTest
 ```

--- a/docs/SHAFT_MCP.md
+++ b/docs/SHAFT_MCP.md
@@ -21,6 +21,8 @@ The packaged server supports:
 - Streamable HTTP with `--spring.profiles.active=http`, at `/mcp`;
 - managed recording through `capture_start`, `capture_status`, and
   `capture_stop`, with no AI provider required;
+- deterministic TestNG generation through `capture_generate`, with compile,
+  optional replay, and review-only AI enrichment phases;
 - legacy SSE endpoint properties as configuration aliases during migration.
 
 The HTTP port defaults to `8081` and can be overridden with `PORT` or
@@ -33,10 +35,13 @@ java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture start \
   --url https://example.test --browser chrome --output recordings/example.json
 java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture status
 java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture stop
+java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar capture generate \
+  --session recordings/example.json --output-dir generated-tests
 ```
 
 See [SHAFT Capture](SHAFT_CAPTURE.md) for checkpoint, runtime-directory,
-privacy, browser-support, and recovery details.
+privacy, generation, replay, enrichment approval, browser-support, and
+recovery details.
 
 ## Authentication boundary
 

--- a/shaft-capture/pom.xml
+++ b/shaft-capture/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>shaft-capture</artifactId>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
-    <description>Deterministic SHAFT Capture recording contracts, privacy controls, and persistence.</description>
+    <description>Deterministic SHAFT Capture recording, privacy, TestNG generation, and replay validation.</description>
 
     <dependencies>
         <dependency>

--- a/shaft-capture/src/main/java/com/shaft/capture/cli/CaptureCli.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/cli/CaptureCli.java
@@ -6,12 +6,17 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.shaft.capture.control.CaptureControlClient;
 import com.shaft.capture.control.CaptureControlFiles;
 import com.shaft.capture.control.CaptureControlServer;
+import com.shaft.capture.generate.CaptureGenerationRequest;
+import com.shaft.capture.generate.CaptureGenerationResult;
+import com.shaft.capture.generate.CaptureGenerator;
 import com.shaft.capture.model.Checkpoint;
 import com.shaft.capture.privacy.CapturePrivacyClassifier;
 import com.shaft.capture.runtime.CaptureBrowser;
 import com.shaft.capture.runtime.CaptureManager;
 import com.shaft.capture.runtime.CaptureStartRequest;
 import com.shaft.capture.runtime.CaptureStatus;
+import com.shaft.pilot.ai.ApprovalPolicy;
+import com.shaft.pilot.ai.EvidenceCategory;
 
 import java.io.File;
 import java.io.FileDescriptor;
@@ -30,6 +35,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -92,6 +98,7 @@ public final class CaptureCli {
                 case "status" -> status(options);
                 case "stop" -> stop(options);
                 case "checkpoint" -> checkpoint(options);
+                case "generate" -> generate(options);
                 case "daemon" -> daemon(options);
                 default -> throw new IllegalArgumentException(usage());
             };
@@ -169,6 +176,42 @@ public final class CaptureCli {
         }
         print(client.checkpoint(options.required("description"), kind));
         return 0;
+    }
+
+    private static int generate(Arguments options) {
+        CaptureGenerationRequest.EnrichmentMode enrichmentMode =
+                options.flag("ai-preview")
+                        ? CaptureGenerationRequest.EnrichmentMode.PREVIEW
+                        : options.values().containsKey("apply-enrichment")
+                        ? CaptureGenerationRequest.EnrichmentMode.APPLY
+                        : CaptureGenerationRequest.EnrichmentMode.NONE;
+        Path output = options.path("output-dir", Path.of("generated-tests"));
+        Path preview = enrichmentMode == CaptureGenerationRequest.EnrichmentMode.APPLY
+                ? options.pathRequired("apply-enrichment")
+                : options.path("enrichment-preview",
+                output.resolve("target/shaft-capture/enrichment-preview.json"));
+        ApprovalPolicy approval = new ApprovalPolicy(
+                options.flag("allow-local-ai"),
+                options.flag("allow-remote-ai"),
+                EnumSet.of(EvidenceCategory.TEXT));
+        long timeoutSeconds = parsePositiveLong(
+                options.value("replay-timeout-seconds", "300"),
+                "replay-timeout-seconds");
+        CaptureGenerationResult result = new CaptureGenerator().generate(new CaptureGenerationRequest(
+                options.pathRequired("session"),
+                output,
+                options.value("package", "generated.capture"),
+                options.value("class-name", ""),
+                options.flag("overwrite"),
+                !options.flag("skip-compile"),
+                options.flag("replay"),
+                Duration.ofSeconds(timeoutSeconds),
+                enrichmentMode,
+                preview,
+                options.flag("approve-enrichment"),
+                approval));
+        print(result);
+        return result.successful() ? 0 : 1;
     }
 
     private static int daemon(Arguments options) {
@@ -325,10 +368,18 @@ public final class CaptureCli {
     }
 
     private static void print(CaptureStatus status) {
+        printJson(status, "Capture status could not be serialized.");
+    }
+
+    private static void print(CaptureGenerationResult result) {
+        printJson(result, "Capture generation result could not be serialized.");
+    }
+
+    private static void printJson(Object value, String failureMessage) {
         try {
-            OUTPUT.println(MAPPER.writeValueAsString(status));
+            OUTPUT.println(MAPPER.writeValueAsString(value));
         } catch (com.fasterxml.jackson.core.JsonProcessingException exception) {
-            throw new IllegalStateException("Capture status could not be serialized.", exception);
+            throw new IllegalStateException(failureMessage, exception);
         }
     }
 
@@ -346,7 +397,25 @@ public final class CaptureCli {
     private static String usage() {
         return "Usage: capture start --url <url> [--browser chrome|edge] [--output <path>] "
                 + "[--runtime-dir <path>] [--headless] | status | stop [--discard] | "
-                + "checkpoint --description <text> [--kind USER_MARKER|ASSERTION|PAGE_TRANSITION|RECOVERY]";
+                + "checkpoint --description <text> [--kind USER_MARKER|ASSERTION|PAGE_TRANSITION|RECOVERY] | "
+                + "generate --session <capture.json> [--output-dir <path>] [--package <name>] "
+                + "[--class-name <name>] [--overwrite] [--skip-compile] [--replay] "
+                + "[--replay-timeout-seconds <seconds>] [--ai-preview --allow-local-ai|--allow-remote-ai] "
+                + "[--enrichment-preview <path>] "
+                + "[--apply-enrichment <path> --approve-enrichment]";
+    }
+
+    private static long parsePositiveLong(String value, String option) {
+        try {
+            long parsed = Long.parseLong(value);
+            if (parsed <= 0) {
+                throw new NumberFormatException();
+            }
+            return parsed;
+        } catch (NumberFormatException exception) {
+            throw new IllegalArgumentException("Capture option --" + option
+                    + " must be a positive integer.", exception);
+        }
     }
 
     private record Arguments(Map<String, String> values, java.util.Set<String> flags) {
@@ -359,7 +428,16 @@ public final class CaptureCli {
                     throw new IllegalArgumentException("Unexpected capture argument.");
                 }
                 String name = argument.substring(2);
-                if ("headless".equals(name) || "discard".equals(name)) {
+                if (Set.of(
+                        "headless",
+                        "discard",
+                        "overwrite",
+                        "skip-compile",
+                        "replay",
+                        "ai-preview",
+                        "approve-enrichment",
+                        "allow-local-ai",
+                        "allow-remote-ai").contains(name)) {
                     flags.add(name);
                 } else {
                     if (index + 1 >= args.length || args[index + 1].startsWith("--")) {

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureEnrichmentPreview.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureEnrichmentPreview.java
@@ -1,0 +1,76 @@
+package com.shaft.capture.generate;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Reviewable, fingerprinted AI proposal that is never applied implicitly.
+ *
+ * @param schemaVersion preview schema version
+ * @param deterministicFingerprint fingerprint of the deterministic source and session
+ * @param provider provider identifier
+ * @param proposal schema-validated proposal
+ * @param diff visible proposed changes
+ */
+public record CaptureEnrichmentPreview(
+        String schemaVersion,
+        String deterministicFingerprint,
+        String provider,
+        Proposal proposal,
+        List<String> diff) {
+    public static final String CURRENT_SCHEMA_VERSION = "1.0";
+
+    /**
+     * Optional source naming and assertion suggestions.
+     *
+     * @param className optional Java class name
+     * @param methodName optional Java test method name
+     * @param elementNames logical element IDs mapped to Java field names
+     * @param assertions additional approved state assertions
+     */
+    public record Proposal(
+            String className,
+            String methodName,
+            Map<String, String> elementNames,
+            List<AssertionSuggestion> assertions) {
+        /**
+         * Creates an immutable proposal.
+         */
+        public Proposal {
+            className = className == null ? "" : className;
+            methodName = methodName == null ? "" : methodName;
+            elementNames = elementNames == null ? Map.of() : Map.copyOf(elementNames);
+            assertions = assertions == null ? List.of() : List.copyOf(assertions);
+        }
+
+        /**
+         * Returns an empty deterministic proposal.
+         *
+         * @return empty proposal
+         */
+        public static Proposal empty() {
+            return new Proposal("", "", Map.of(), List.of());
+        }
+    }
+
+    /**
+     * Additional assertion bound to captured element state.
+     *
+     * @param eventSequence captured event sequence
+     * @param verification verification kind
+     * @param negated whether the state assertion is negated
+     */
+    public record AssertionSuggestion(long eventSequence, String verification, boolean negated) {
+    }
+
+    /**
+     * Creates an immutable preview.
+     */
+    public CaptureEnrichmentPreview {
+        schemaVersion = schemaVersion == null ? CURRENT_SCHEMA_VERSION : schemaVersion;
+        deterministicFingerprint = deterministicFingerprint == null ? "" : deterministicFingerprint;
+        provider = provider == null ? "none" : provider;
+        proposal = proposal == null ? Proposal.empty() : proposal;
+        diff = diff == null ? List.of() : List.copyOf(diff);
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureEnrichmentService.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureEnrichmentService.java
@@ -1,0 +1,257 @@
+package com.shaft.capture.generate;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.shaft.capture.model.CaptureEvent;
+import com.shaft.capture.model.CaptureSession;
+import com.shaft.pilot.ai.AiBudget;
+import com.shaft.pilot.ai.AiExecutionService;
+import com.shaft.pilot.ai.AiRequest;
+import com.shaft.pilot.ai.AiResponse;
+import com.shaft.pilot.ai.ApprovalPolicy;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+/**
+ * Produces schema-validated AI naming and assertion previews from sanitized Capture metadata.
+ */
+public final class CaptureEnrichmentService {
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final Pattern JAVA_IDENTIFIER = Pattern.compile("[A-Za-z_$][A-Za-z0-9_$]*");
+    private final Function<AiRequest, AiResponse> executor;
+
+    /**
+     * Creates a service using the configured SHAFT Pilot provider.
+     */
+    public CaptureEnrichmentService() {
+        this(new AiExecutionService()::execute);
+    }
+
+    /**
+     * Creates a service with an injectable provider execution boundary.
+     *
+     * @param executor provider request executor
+     */
+    public CaptureEnrichmentService(Function<AiRequest, AiResponse> executor) {
+        this.executor = Objects.requireNonNull(executor, "executor");
+    }
+
+    /**
+     * Requests a review-only enrichment proposal.
+     *
+     * @param session sanitized Capture session
+     * @param fingerprint deterministic source fingerprint
+     * @param deterministicClassName current class name
+     * @param deterministicMethodName current method name
+     * @param deterministicElementNames current field names
+     * @param approvalPolicy explicit provider approval
+     * @return reviewable preview
+     */
+    public CaptureEnrichmentPreview preview(
+            CaptureSession session,
+            String fingerprint,
+            String deterministicClassName,
+            String deterministicMethodName,
+            Map<String, String> deterministicElementNames,
+            ApprovalPolicy approvalPolicy) {
+        Objects.requireNonNull(session, "session");
+        JsonNode fallback = JSON.valueToTree(CaptureEnrichmentPreview.Proposal.empty());
+        AiRequest request = AiRequest.builder("shaft-capture-generation-enrichment", schema())
+                .requestId("capture-enrichment-" + fingerprint.substring(0, Math.min(16, fingerprint.length())))
+                .text(prompt(session, deterministicClassName, deterministicMethodName, deterministicElementNames))
+                .timeout(Duration.ofSeconds(30))
+                .budget(new AiBudget(8_000, 1_500, BigDecimal.ZERO))
+                .approvalPolicy(approvalPolicy)
+                .deterministicFallback(fallback)
+                .build();
+        AiResponse response = executor.apply(request);
+        if (!response.successful()) {
+            throw new IllegalStateException("AI enrichment preview was not accepted: " + response.status()
+                    + (response.fallbackReason().isBlank() ? "" : " (" + response.fallbackReason() + ")"));
+        }
+        CaptureEnrichmentPreview.Proposal proposal = parseProposal(response.structuredPayload());
+        validateProposal(proposal, deterministicElementNames);
+        List<String> diff = diff(deterministicClassName, deterministicMethodName,
+                deterministicElementNames, proposal);
+        return new CaptureEnrichmentPreview(
+                CaptureEnrichmentPreview.CURRENT_SCHEMA_VERSION,
+                fingerprint,
+                response.provider(),
+                proposal,
+                diff);
+    }
+
+    private static String prompt(
+            CaptureSession session,
+            String className,
+            String methodName,
+            Map<String, String> elementNames) {
+        ObjectNode root = JSON.createObjectNode();
+        root.put("instruction", "Suggest concise Java names and optional state assertions only. "
+                + "Do not suggest locators, values, URLs, credentials, or assertions that are not supported "
+                + "by captured visible/enabled/selected state.");
+        root.put("sessionId", session.sessionId());
+        root.put("className", className);
+        root.put("methodName", methodName);
+        root.set("elementNames", JSON.valueToTree(elementNames));
+        ArrayNode events = root.putArray("events");
+        for (CaptureEvent event : session.events()) {
+            ObjectNode item = events.addObject();
+            item.put("sequence", event.context().sequence());
+            item.put("type", event.getClass().getSimpleName());
+            target(event).ifPresent(target -> {
+                item.put("logicalElementId", target.logicalElementId());
+                item.put("tagName", target.tagName());
+                item.put("role", target.role());
+                item.put("accessibleName", target.accessibleName());
+                item.put("label", target.label());
+                item.put("visible", target.visible());
+                item.put("enabled", target.enabled());
+                item.put("selected", target.selected());
+            });
+        }
+        try {
+            return JSON.writeValueAsString(root);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("Sanitized enrichment context could not be serialized.", exception);
+        }
+    }
+
+    private static JsonNode schema() {
+        ObjectNode assertion = JSON.createObjectNode();
+        assertion.put("type", "object");
+        assertion.putArray("required").add("eventSequence").add("verification").add("negated");
+        ObjectNode assertionProperties = assertion.putObject("properties");
+        assertionProperties.putObject("eventSequence").put("type", "integer").put("minimum", 1);
+        assertionProperties.putObject("verification").put("type", "string")
+                .putArray("enum")
+                .add("ELEMENT_PRESENT")
+                .add("ELEMENT_VISIBLE")
+                .add("ELEMENT_ENABLED")
+                .add("ELEMENT_SELECTED");
+        assertionProperties.putObject("negated").put("type", "boolean");
+        assertion.put("additionalProperties", false);
+
+        ObjectNode schema = JSON.createObjectNode();
+        schema.put("type", "object");
+        schema.putArray("required").add("className").add("methodName").add("elementNames").add("assertions");
+        ObjectNode properties = schema.putObject("properties");
+        properties.putObject("className").put("type", "string");
+        properties.putObject("methodName").put("type", "string");
+        properties.putObject("elementNames").put("type", "object");
+        properties.putObject("assertions").put("type", "array").set("items", assertion);
+        schema.put("additionalProperties", false);
+        return schema;
+    }
+
+    private static CaptureEnrichmentPreview.Proposal parseProposal(JsonNode payload) {
+        Map<String, String> elementNames = new LinkedHashMap<>();
+        payload.path("elementNames").fields().forEachRemaining(entry ->
+                elementNames.put(entry.getKey(), entry.getValue().asText("")));
+        List<CaptureEnrichmentPreview.AssertionSuggestion> assertions = new ArrayList<>();
+        for (JsonNode item : payload.path("assertions")) {
+            assertions.add(new CaptureEnrichmentPreview.AssertionSuggestion(
+                    item.path("eventSequence").asLong(),
+                    item.path("verification").asText(),
+                    item.path("negated").asBoolean()));
+        }
+        return new CaptureEnrichmentPreview.Proposal(
+                payload.path("className").asText(""),
+                payload.path("methodName").asText(""),
+                elementNames,
+                assertions);
+    }
+
+    private static void validateProposal(
+            CaptureEnrichmentPreview.Proposal proposal,
+            Map<String, String> deterministicElementNames) {
+        if (!proposal.className().isBlank() && !JAVA_IDENTIFIER.matcher(proposal.className()).matches()) {
+            throw new IllegalStateException("AI enrichment class name is not a Java identifier.");
+        }
+        if (!proposal.methodName().isBlank() && !JAVA_IDENTIFIER.matcher(proposal.methodName()).matches()) {
+            throw new IllegalStateException("AI enrichment method name is not a Java identifier.");
+        }
+        Set<String> names = new HashSet<>();
+        proposal.elementNames().forEach((id, name) -> {
+            if (!deterministicElementNames.containsKey(id)) {
+                throw new IllegalStateException("AI enrichment references an unknown element.");
+            }
+            if (!JAVA_IDENTIFIER.matcher(name).matches() || !names.add(name)) {
+                throw new IllegalStateException("AI enrichment element names must be unique Java identifiers.");
+            }
+        });
+    }
+
+    private static List<String> diff(
+            String className,
+            String methodName,
+            Map<String, String> elementNames,
+            CaptureEnrichmentPreview.Proposal proposal) {
+        List<String> diff = new ArrayList<>();
+        addChange(diff, "class", className, proposal.className());
+        addChange(diff, "method", methodName, proposal.methodName());
+        proposal.elementNames().entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> addChange(diff, "element " + entry.getKey(),
+                        elementNames.getOrDefault(entry.getKey(), ""), entry.getValue()));
+        proposal.assertions().stream()
+                .sorted(java.util.Comparator.comparingLong(CaptureEnrichmentPreview.AssertionSuggestion::eventSequence)
+                        .thenComparing(CaptureEnrichmentPreview.AssertionSuggestion::verification))
+                .forEach(assertion -> diff.add("+ assertion event-" + assertion.eventSequence() + " "
+                        + (assertion.negated() ? "NOT " : "") + assertion.verification()));
+        return List.copyOf(diff);
+    }
+
+    private static void addChange(List<String> diff, String label, String before, String after) {
+        if (after != null && !after.isBlank() && !after.equals(before)) {
+            diff.add(label + ": " + before + " -> " + after);
+        }
+    }
+
+    private static java.util.Optional<com.shaft.capture.model.ElementSnapshot> target(CaptureEvent event) {
+        if (event instanceof CaptureEvent.ClickEvent value) {
+            return java.util.Optional.of(value.target());
+        }
+        if (event instanceof CaptureEvent.TypeEvent value) {
+            return java.util.Optional.of(value.target());
+        }
+        if (event instanceof CaptureEvent.ClearEvent value) {
+            return java.util.Optional.of(value.target());
+        }
+        if (event instanceof CaptureEvent.SelectEvent value) {
+            return java.util.Optional.of(value.target());
+        }
+        if (event instanceof CaptureEvent.ToggleEvent value) {
+            return java.util.Optional.of(value.target());
+        }
+        if (event instanceof CaptureEvent.UploadEvent value) {
+            return java.util.Optional.of(value.target());
+        }
+        if (event instanceof CaptureEvent.KeyboardEvent value) {
+            return java.util.Optional.ofNullable(value.target());
+        }
+        if (event instanceof CaptureEvent.FrameEvent value) {
+            return java.util.Optional.ofNullable(value.target());
+        }
+        if (event instanceof CaptureEvent.WaitEvent value) {
+            return java.util.Optional.ofNullable(value.target());
+        }
+        if (event instanceof CaptureEvent.VerificationEvent value) {
+            return java.util.Optional.ofNullable(value.target());
+        }
+        return java.util.Optional.empty();
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationReport.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationReport.java
@@ -1,0 +1,152 @@
+package com.shaft.capture.generate;
+
+import java.util.List;
+
+/**
+ * Deterministic generation, locator-selection, compilation, and replay report.
+ *
+ * @param schemaVersion report schema version
+ * @param sessionId source Capture session
+ * @param status generation status
+ * @param sourcePath output-root-relative source path
+ * @param testDataPath output-root-relative test-data path
+ * @param locatorDecisions selected locator rationale
+ * @param unsupportedEvents unsupported event diagnostics
+ * @param flakySteps replay-risk diagnostics
+ * @param fallbackLocators available fallback locator diagnostics
+ * @param requiredUserInputs unresolved external inputs
+ * @param warnings safe warnings
+ * @param compilation compilation result
+ * @param replay replay result
+ * @param enrichment enrichment result
+ */
+public record CaptureGenerationReport(
+        String schemaVersion,
+        String sessionId,
+        Status status,
+        String sourcePath,
+        String testDataPath,
+        List<LocatorDecision> locatorDecisions,
+        List<String> unsupportedEvents,
+        List<String> flakySteps,
+        List<String> fallbackLocators,
+        List<String> requiredUserInputs,
+        List<String> warnings,
+        Validation compilation,
+        Validation replay,
+        Enrichment enrichment) {
+    public static final String CURRENT_SCHEMA_VERSION = "1.0";
+
+    /**
+     * Generation status.
+     */
+    public enum Status {
+        SUCCESS,
+        FAILED
+    }
+
+    /**
+     * One explainable locator choice.
+     *
+     * @param eventIds related event IDs
+     * @param logicalElementId logical target
+     * @param strategy selected strategy
+     * @param expression sanitized expression
+     * @param score deterministic score
+     * @param scoreBreakdown ordered score explanation
+     * @param alternatives ranked alternatives
+     */
+    public record LocatorDecision(
+            List<String> eventIds,
+            String logicalElementId,
+            String strategy,
+            String expression,
+            int score,
+            List<String> scoreBreakdown,
+            List<String> alternatives) {
+    }
+
+    /**
+     * Compile or replay result.
+     *
+     * @param status validation status
+     * @param diagnostics safe diagnostics
+     * @param allureResultCount populated Allure result count
+     */
+    public record Validation(
+            ValidationStatus status,
+            List<String> diagnostics,
+            int allureResultCount) {
+        /**
+         * Validation status.
+         */
+        public enum ValidationStatus {
+            PASSED,
+            FAILED,
+            SKIPPED
+        }
+
+        /**
+         * Returns a skipped validation.
+         *
+         * @param reason skip reason
+         * @return skipped validation
+         */
+        public static Validation skipped(String reason) {
+            return new Validation(ValidationStatus.SKIPPED, List.of(reason), 0);
+        }
+    }
+
+    /**
+     * Optional AI enrichment state.
+     *
+     * @param status enrichment phase
+     * @param previewPath output-root-relative preview path
+     * @param diff reviewed or proposed changes
+     * @param provider provider identifier
+     */
+    public record Enrichment(
+            EnrichmentStatus status,
+            String previewPath,
+            List<String> diff,
+            String provider) {
+        /**
+         * Enrichment status.
+         */
+        public enum EnrichmentStatus {
+            NOT_REQUESTED,
+            PREVIEWED,
+            APPLIED,
+            REJECTED
+        }
+
+        /**
+         * Returns the default deterministic state.
+         *
+         * @return no-enrichment state
+         */
+        public static Enrichment notRequested() {
+            return new Enrichment(EnrichmentStatus.NOT_REQUESTED, "", List.of(), "none");
+        }
+    }
+
+    /**
+     * Creates an immutable report.
+     */
+    public CaptureGenerationReport {
+        schemaVersion = schemaVersion == null ? CURRENT_SCHEMA_VERSION : schemaVersion;
+        sessionId = sessionId == null ? "" : sessionId;
+        status = status == null ? Status.FAILED : status;
+        sourcePath = sourcePath == null ? "" : sourcePath;
+        testDataPath = testDataPath == null ? "" : testDataPath;
+        locatorDecisions = locatorDecisions == null ? List.of() : List.copyOf(locatorDecisions);
+        unsupportedEvents = unsupportedEvents == null ? List.of() : List.copyOf(unsupportedEvents);
+        flakySteps = flakySteps == null ? List.of() : List.copyOf(flakySteps);
+        fallbackLocators = fallbackLocators == null ? List.of() : List.copyOf(fallbackLocators);
+        requiredUserInputs = requiredUserInputs == null ? List.of() : List.copyOf(requiredUserInputs);
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+        compilation = compilation == null ? Validation.skipped("Compilation was not requested.") : compilation;
+        replay = replay == null ? Validation.skipped("Replay was not requested.") : replay;
+        enrichment = enrichment == null ? Enrichment.notRequested() : enrichment;
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationRequest.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationRequest.java
@@ -1,0 +1,94 @@
+package com.shaft.capture.generate;
+
+import com.shaft.pilot.ai.ApprovalPolicy;
+
+import java.nio.file.Path;
+import java.time.Duration;
+
+/**
+ * Immutable options for converting a persisted Capture session into a SHAFT TestNG test.
+ *
+ * @param sessionPath persisted Capture session
+ * @param outputDirectory generated project root
+ * @param packageName generated Java package
+ * @param className optional generated class name
+ * @param overwrite whether existing generated artifacts may be replaced
+ * @param compile whether to compile the generated source
+ * @param replay whether to execute the compiled TestNG test
+ * @param replayTimeout maximum replay duration
+ * @param enrichmentMode optional AI enrichment phase
+ * @param enrichmentPreviewPath preview path to write or apply
+ * @param enrichmentApproved whether a reviewed preview may be applied
+ * @param aiApprovalPolicy explicit evidence and processing-location approval for preview generation
+ */
+public record CaptureGenerationRequest(
+        Path sessionPath,
+        Path outputDirectory,
+        String packageName,
+        String className,
+        boolean overwrite,
+        boolean compile,
+        boolean replay,
+        Duration replayTimeout,
+        EnrichmentMode enrichmentMode,
+        Path enrichmentPreviewPath,
+        boolean enrichmentApproved,
+        ApprovalPolicy aiApprovalPolicy) {
+    /**
+     * AI enrichment lifecycle.
+     */
+    public enum EnrichmentMode {
+        NONE,
+        PREVIEW,
+        APPLY
+    }
+
+    /**
+     * Creates normalized generation options.
+     */
+    public CaptureGenerationRequest {
+        if (sessionPath == null) {
+            throw new IllegalArgumentException("Capture session path is required.");
+        }
+        outputDirectory = outputDirectory == null ? Path.of("generated-tests") : outputDirectory;
+        packageName = packageName == null || packageName.isBlank()
+                ? "generated.capture"
+                : packageName.trim();
+        className = className == null ? "" : className.trim();
+        compile = compile || replay;
+        replayTimeout = replayTimeout == null ? Duration.ofMinutes(5) : replayTimeout;
+        if (replayTimeout.isNegative() || replayTimeout.isZero()) {
+            throw new IllegalArgumentException("Replay timeout must be positive.");
+        }
+        enrichmentMode = enrichmentMode == null ? EnrichmentMode.NONE : enrichmentMode;
+        enrichmentPreviewPath = enrichmentPreviewPath == null
+                ? outputDirectory.resolve("target/shaft-capture/enrichment-preview.json")
+                : enrichmentPreviewPath;
+        aiApprovalPolicy = aiApprovalPolicy == null ? ApprovalPolicy.denyAll() : aiApprovalPolicy;
+        if (enrichmentMode == EnrichmentMode.APPLY && !enrichmentApproved) {
+            throw new IllegalArgumentException("Applying AI enrichment requires explicit approval.");
+        }
+    }
+
+    /**
+     * Creates deterministic defaults for one session.
+     *
+     * @param sessionPath persisted session
+     * @return default request
+     */
+    public static CaptureGenerationRequest defaults(Path sessionPath) {
+        return new CaptureGenerationRequest(
+                sessionPath,
+                Path.of("generated-tests"),
+                "generated.capture",
+                "",
+                false,
+                true,
+                false,
+                Duration.ofMinutes(5),
+                EnrichmentMode.NONE,
+                null,
+                false,
+                ApprovalPolicy.denyAll());
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationResult.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationResult.java
@@ -1,0 +1,28 @@
+package com.shaft.capture.generate;
+
+import java.nio.file.Path;
+
+/**
+ * Generated artifact paths and their deterministic report.
+ *
+ * @param sourcePath generated Java source
+ * @param testDataPath generated JSON test data
+ * @param reportPath generation report
+ * @param enrichmentPreviewPath optional enrichment preview
+ * @param report generation report
+ */
+public record CaptureGenerationResult(
+        Path sourcePath,
+        Path testDataPath,
+        Path reportPath,
+        Path enrichmentPreviewPath,
+        CaptureGenerationReport report) {
+    /**
+     * Returns whether generation and all requested validations succeeded.
+     *
+     * @return true for a successful report
+     */
+    public boolean successful() {
+        return report != null && report.status() == CaptureGenerationReport.Status.SUCCESS;
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -1,0 +1,1503 @@
+package com.shaft.capture.generate;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.shaft.capture.format.CaptureJsonCodec;
+import com.shaft.capture.model.CaptureEvent;
+import com.shaft.capture.model.CaptureSession;
+import com.shaft.capture.model.Checkpoint;
+import com.shaft.capture.model.ElementSnapshot;
+import com.shaft.capture.model.EventContext;
+import com.shaft.capture.model.ExternalTestDataReference;
+import com.shaft.capture.model.LocatorCandidate;
+import com.shaft.capture.privacy.CapturePrivacyClassifier;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Pattern;
+
+/**
+ * Deterministic pipeline that validates, renders, compiles, replays, and reports generated SHAFT tests.
+ */
+public final class CaptureGenerator {
+    private static final Pattern JAVA_IDENTIFIER = Pattern.compile("[A-Za-z_$][A-Za-z0-9_$]*");
+    private static final Pattern JAVA_PACKAGE = Pattern.compile(
+            "[A-Za-z_$][A-Za-z0-9_$]*(\\.[A-Za-z_$][A-Za-z0-9_$]*)*");
+    private static final Pattern WINDOWS_PERSONAL_PATH = Pattern.compile(
+            "(?i)(?:file:/+)?[A-Z]:[/\\\\](?:Users|Documents and Settings)[/\\\\][^/\\\\\\s\"']+");
+    private static final Pattern UNIX_PERSONAL_PATH = Pattern.compile(
+            "(?:file:/+)?/(?:Users|home)/[^/\\s\"']+");
+    private static final Pattern BEARER_SECRET = Pattern.compile("(?i)Bearer\\s+[A-Za-z0-9._~+/-]{8,}");
+    private static final Pattern JWT_SECRET = Pattern.compile(
+            "eyJ[A-Za-z0-9_-]{6,}\\.[A-Za-z0-9_-]{6,}\\.[A-Za-z0-9_-]{6,}");
+    private static final Pattern API_KEY_SECRET = Pattern.compile(
+            "(?i)(?:sk|api|token)[-_][A-Za-z0-9_-]{12,}");
+    private static final Pattern NAMED_SECRET = Pattern.compile(
+            "(?i)(?:password|authorization|cookie|api[-_]?key|access[-_]?token)"
+                    + "\\s*[:=]\\s*[\"']?[^\\s\"']{6,}");
+    private static final ObjectMapper JSON = new ObjectMapper()
+            .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
+    private static final DefaultPrettyPrinter PRINTER = printer();
+
+    private final CaptureJsonCodec codec;
+    private final LocatorRanker locatorRanker;
+    private final GeneratedTestValidator validator;
+    private final CaptureEnrichmentService enrichmentService;
+
+    /**
+     * Creates the default generation pipeline.
+     */
+    public CaptureGenerator() {
+        this(new CaptureJsonCodec(), new LocatorRanker(), new GeneratedTestValidator(),
+                new CaptureEnrichmentService());
+    }
+
+    /**
+     * Creates an injectable generation pipeline.
+     *
+     * @param codec Capture session codec
+     * @param locatorRanker deterministic locator ranker
+     * @param validator generated test validator
+     * @param enrichmentService optional enrichment preview service
+     */
+    public CaptureGenerator(
+            CaptureJsonCodec codec,
+            LocatorRanker locatorRanker,
+            GeneratedTestValidator validator,
+            CaptureEnrichmentService enrichmentService) {
+        this.codec = Objects.requireNonNull(codec, "codec");
+        this.locatorRanker = Objects.requireNonNull(locatorRanker, "locatorRanker");
+        this.validator = Objects.requireNonNull(validator, "validator");
+        this.enrichmentService = Objects.requireNonNull(enrichmentService, "enrichmentService");
+    }
+
+    /**
+     * Generates, validates, and reports one SHAFT TestNG test.
+     *
+     * @param request generation options
+     * @return generated artifacts and report
+     */
+    public CaptureGenerationResult generate(CaptureGenerationRequest request) {
+        Objects.requireNonNull(request, "request");
+        Path sessionPath = request.sessionPath().toAbsolutePath().normalize();
+        Path outputRoot = request.outputDirectory().toAbsolutePath().normalize();
+        Path reportPath = outputRoot.resolve("target/shaft-capture/generation-report.json");
+        CaptureSession session = null;
+        ArtifactPaths paths = null;
+        try {
+            session = codec.read(sessionPath);
+            validatePackage(request.packageName());
+            String deterministicClassName = request.className().isBlank()
+                    ? javaClassName(session.sessionId()) + "Test"
+                    : request.className();
+            validateJavaIdentifier(deterministicClassName, "Generated class name");
+            String deterministicMethodName = "replay" + javaClassName(session.sessionId());
+            paths = artifactPaths(outputRoot, request.packageName(), deterministicClassName);
+
+            GenerationState state = analyze(session, sessionPath);
+            Map<String, String> elementNames = defaultElementNames(state.targets());
+            String deterministicSource = renderSource(session, request.packageName(), deterministicClassName,
+                    deterministicMethodName, state.targets(), state.data(), elementNames, List.of());
+            String fingerprint = fingerprint(codec.write(session), deterministicSource);
+
+            CaptureGenerationReport.Enrichment enrichment = CaptureGenerationReport.Enrichment.notRequested();
+            CaptureEnrichmentPreview.Proposal appliedProposal = CaptureEnrichmentPreview.Proposal.empty();
+            if (request.enrichmentMode() == CaptureGenerationRequest.EnrichmentMode.PREVIEW) {
+                CaptureEnrichmentPreview preview = enrichmentService.preview(
+                        session,
+                        fingerprint,
+                        deterministicClassName,
+                        deterministicMethodName,
+                        elementNames,
+                        request.aiApprovalPolicy());
+                List<String> previewPrivacy = privacyFindings(writeJson(preview));
+                if (!previewPrivacy.isEmpty()) {
+                    state.unsupported().addAll(previewPrivacy);
+                    enrichment = new CaptureGenerationReport.Enrichment(
+                            CaptureGenerationReport.Enrichment.EnrichmentStatus.REJECTED,
+                            relative(outputRoot, request.enrichmentPreviewPath().toAbsolutePath().normalize()),
+                            preview.diff(),
+                            preview.provider());
+                } else {
+                    ensureWritable(request.enrichmentPreviewPath().toAbsolutePath().normalize(), request.overwrite());
+                    atomicWrite(request.enrichmentPreviewPath().toAbsolutePath().normalize(), writeJson(preview));
+                    enrichment = new CaptureGenerationReport.Enrichment(
+                            CaptureGenerationReport.Enrichment.EnrichmentStatus.PREVIEWED,
+                            relative(outputRoot, request.enrichmentPreviewPath().toAbsolutePath().normalize()),
+                            preview.diff(),
+                            preview.provider());
+                }
+            } else if (request.enrichmentMode() == CaptureGenerationRequest.EnrichmentMode.APPLY) {
+                CaptureEnrichmentPreview preview = readPreview(request.enrichmentPreviewPath());
+                List<String> proposalErrors = validateProposal(preview, fingerprint, state.targets());
+                if (!proposalErrors.isEmpty()) {
+                    state.unsupported().addAll(proposalErrors);
+                    enrichment = new CaptureGenerationReport.Enrichment(
+                            CaptureGenerationReport.Enrichment.EnrichmentStatus.REJECTED,
+                            relative(outputRoot, request.enrichmentPreviewPath().toAbsolutePath().normalize()),
+                            preview.diff(),
+                            preview.provider());
+                } else {
+                    appliedProposal = preview.proposal();
+                    enrichment = new CaptureGenerationReport.Enrichment(
+                            CaptureGenerationReport.Enrichment.EnrichmentStatus.APPLIED,
+                            relative(outputRoot, request.enrichmentPreviewPath().toAbsolutePath().normalize()),
+                            preview.diff(),
+                            preview.provider());
+                }
+            }
+
+            String className = appliedProposal.className().isBlank()
+                    ? deterministicClassName
+                    : appliedProposal.className();
+            String methodName = appliedProposal.methodName().isBlank()
+                    ? deterministicMethodName
+                    : appliedProposal.methodName();
+            Map<String, String> finalElementNames = mergeElementNames(elementNames, appliedProposal.elementNames());
+            if (!className.equals(deterministicClassName)) {
+                paths = artifactPaths(outputRoot, request.packageName(), className);
+            }
+            String source = renderSource(session, request.packageName(), className, methodName,
+                    state.targets(), state.data(), finalElementNames, appliedProposal.assertions());
+            String dataJson = writeJson(state.data().root());
+
+            List<String> privacy = new ArrayList<>();
+            privacy.addAll(privacyFindings(codec.write(session)));
+            privacy.addAll(privacyFindings(source));
+            privacy.addAll(privacyFindings(dataJson));
+            privacy.stream().distinct().forEach(state.unsupported()::add);
+            validateOutputs(paths, reportPath, request.overwrite(), state.unsupported());
+
+            if (!state.unsupported().isEmpty()) {
+                CaptureGenerationReport report = report(
+                        session,
+                        paths,
+                        state,
+                        CaptureGenerationReport.Status.FAILED,
+                        CaptureGenerationReport.Validation.skipped("Generation failed before compilation."),
+                        CaptureGenerationReport.Validation.skipped("Generation failed before replay."),
+                        enrichment);
+                writeReportIfPossible(reportPath, report, request.overwrite());
+                return new CaptureGenerationResult(paths.source(), paths.data(), reportPath,
+                        request.enrichmentPreviewPath(), report);
+            }
+
+            atomicWrite(paths.source(), source);
+            atomicWrite(paths.data(), dataJson);
+            CaptureGenerationReport.Validation compilation = request.compile()
+                    ? validator.compile(paths.source(), paths.classes())
+                    : CaptureGenerationReport.Validation.skipped("Compilation was not requested.");
+            CaptureGenerationReport.Validation replay = CaptureGenerationReport.Validation.skipped(
+                    "Replay was not requested.");
+            if (request.replay()
+                    && compilation.status() == CaptureGenerationReport.Validation.ValidationStatus.PASSED) {
+                replay = validator.replay(
+                        request.packageName() + "." + className,
+                        paths.classes(),
+                        outputRoot.resolve("src/test/resources"),
+                        outputRoot,
+                        request.replayTimeout());
+            } else if (request.replay()) {
+                replay = CaptureGenerationReport.Validation.skipped(
+                        "Replay was skipped because compilation failed.");
+            }
+            boolean successful = compilation.status()
+                    != CaptureGenerationReport.Validation.ValidationStatus.FAILED
+                    && replay.status() != CaptureGenerationReport.Validation.ValidationStatus.FAILED;
+            CaptureGenerationReport report = report(
+                    session,
+                    paths,
+                    state,
+                    successful ? CaptureGenerationReport.Status.SUCCESS : CaptureGenerationReport.Status.FAILED,
+                    compilation,
+                    replay,
+                    enrichment);
+            String reportJson = writeJson(report);
+            List<String> reportPrivacy = privacyFindings(reportJson);
+            if (!reportPrivacy.isEmpty()) {
+                CaptureGenerationReport privacyFailure = report(
+                        session,
+                        paths,
+                        state.withUnsupported(reportPrivacy),
+                        CaptureGenerationReport.Status.FAILED,
+                        compilation,
+                        replay,
+                        enrichment);
+                atomicWrite(reportPath, writeJson(privacyFailure));
+                return new CaptureGenerationResult(paths.source(), paths.data(), reportPath,
+                        request.enrichmentPreviewPath(), privacyFailure);
+            }
+            atomicWrite(reportPath, reportJson);
+            return new CaptureGenerationResult(paths.source(), paths.data(), reportPath,
+                    request.enrichmentPreviewPath(), report);
+        } catch (RuntimeException exception) {
+            String sessionId = session == null ? "" : session.sessionId();
+            ArtifactPaths safePaths = paths == null
+                    ? artifactPaths(outputRoot, "generated.capture", "CapturedJourneyTest")
+                    : paths;
+            GenerationState failure = GenerationState.failure(safeMessage(exception));
+            CaptureGenerationReport report = report(
+                    sessionId,
+                    safePaths,
+                    failure,
+                    CaptureGenerationReport.Status.FAILED,
+                    CaptureGenerationReport.Validation.skipped("Generation failed before compilation."),
+                    CaptureGenerationReport.Validation.skipped("Generation failed before replay."),
+                    CaptureGenerationReport.Enrichment.notRequested());
+            writeReportIfPossible(reportPath, report, request.overwrite());
+            return new CaptureGenerationResult(safePaths.source(), safePaths.data(), reportPath,
+                    request.enrichmentPreviewPath(), report);
+        }
+    }
+
+    private GenerationState analyze(CaptureSession session, Path sessionPath) {
+        List<String> unsupported = new ArrayList<>();
+        List<String> flaky = new ArrayList<>();
+        List<String> fallback = new ArrayList<>();
+        List<String> required = new ArrayList<>();
+        List<String> warnings = new ArrayList<>();
+        Map<String, MutableTargetPlan> targets = new LinkedHashMap<>();
+        Set<Long> verificationSequences = new HashSet<>();
+        Set<String> knownWindows = new LinkedHashSet<>();
+        if (!session.events().isEmpty()) {
+            knownWindows.add(session.events().getFirst().context().page().logicalWindowId());
+        }
+        for (CaptureEvent event : session.events()) {
+            String eventId = eventId(event);
+            if (event.context().replayStatus() == EventContext.ReplayStatus.UNSUPPORTED) {
+                unsupported.add(eventId + ": the recorder marked this step unsupported. "
+                        + "Record a supported equivalent action.");
+            } else if (event.context().replayStatus() == EventContext.ReplayStatus.FAILED
+                    || event.context().replayStatus() == EventContext.ReplayStatus.SKIPPED) {
+                flaky.add(eventId + ": recorded replay status is " + event.context().replayStatus() + ".");
+            }
+            validateEvent(event, unsupported, required, knownWindows);
+            if (event instanceof CaptureEvent.VerificationEvent) {
+                verificationSequences.add(event.context().sequence());
+            }
+            target(event).ifPresent(target -> {
+                if (target.locatorCandidates().isEmpty()) {
+                    unsupported.add(eventId + ": element " + target.logicalElementId()
+                            + " has no locator evidence. Re-record the step with a visible target.");
+                    return;
+                }
+                LocatorRanker.LocatorSelection selection =
+                        locatorRanker.select(target, event.context(), interaction(event));
+                MutableTargetPlan existing = targets.computeIfAbsent(
+                        target.logicalElementId(),
+                        ignored -> new MutableTargetPlan(target, event.context(), selection));
+                existing.eventIds.add(eventId);
+                if (selection.selected().score() > existing.selection.selected().score()) {
+                    existing.target = target;
+                    existing.context = event.context();
+                    existing.selection = selection;
+                }
+            });
+        }
+        for (Checkpoint checkpoint : session.checkpoints()) {
+            if (checkpoint.kind() == Checkpoint.CheckpointKind.ASSERTION
+                    && !verificationSequences.contains(checkpoint.sequence())) {
+                unsupported.add("checkpoint-" + checkpoint.id() + ": assertion checkpoints require a "
+                        + "VerificationEvent at sequence " + checkpoint.sequence()
+                        + ". Record the expected target and value explicitly.");
+            }
+        }
+        List<TargetPlan> immutableTargets = targets.entrySet().stream()
+                .map(entry -> entry.getValue().immutable(entry.getKey()))
+                .sorted(Comparator.comparing(TargetPlan::logicalElementId))
+                .toList();
+        for (TargetPlan target : immutableTargets) {
+            if (!target.selection().alternatives().isEmpty()) {
+                LocatorRanker.ScoredLocator alternative = target.selection().alternatives().getFirst();
+                fallback.add(target.logicalElementId() + ": "
+                        + alternative.candidate().strategy() + " "
+                        + alternative.candidate().expression() + " (score " + alternative.score() + ")");
+            }
+            LocatorCandidate selected = target.selection().selected().candidate();
+            if (selected.uniquenessCount() != 1 || !selected.stable()
+                    || target.selection().selected().score() < 500) {
+                flaky.add(target.logicalElementId() + ": selected "
+                        + selected.strategy() + " locator has score "
+                        + target.selection().selected().score() + ".");
+            }
+        }
+        DataPlan data = data(session, sessionPath, required, unsupported);
+        if (session.status() != CaptureSession.SessionStatus.COMPLETED) {
+            warnings.add("The source Capture session is incomplete.");
+        }
+        if (session.events().isEmpty()) {
+            warnings.add("The source Capture session contains no events.");
+        }
+        return new GenerationState(
+                immutableTargets,
+                data,
+                unsupported,
+                flaky,
+                fallback,
+                required,
+                warnings);
+    }
+
+    private static void validateEvent(
+            CaptureEvent event,
+            List<String> unsupported,
+            List<String> required,
+            Set<String> knownWindows) {
+        String id = eventId(event);
+        if (hasShadowContext(event.context())) {
+            unsupported.add(id + ": shadow-root replay requires a recorded host-selector chain. "
+                    + "Re-record after enabling shadow-host evidence.");
+        }
+        if (event instanceof CaptureEvent.ClickEvent value) {
+            if (value.button() != CaptureEvent.MouseButton.PRIMARY) {
+                unsupported.add(id + ": only primary-button clicks are generated in v1.");
+            }
+            if (value.clickCount() > 2) {
+                unsupported.add(id + ": click counts above two are unsupported.");
+            }
+        } else if (event instanceof CaptureEvent.SelectEvent value
+                && value.mode() == CaptureEvent.SelectMode.INDEX) {
+            unsupported.add(id + ": index-based selection is volatile. Record value or visible text.");
+        } else if (event instanceof CaptureEvent.SelectEvent value && isSecret(value.value())) {
+            unsupported.add(id + ": secret select values are not generated because selection diagnostics "
+                    + "could expose them.");
+        } else if (event instanceof CaptureEvent.WindowEvent value) {
+            if (value.action() == CaptureEvent.WindowAction.OPEN_TAB
+                    || value.action() == CaptureEvent.WindowAction.OPEN_WINDOW) {
+                knownWindows.add(value.logicalWindowId());
+            } else if (value.action() == CaptureEvent.WindowAction.SWITCH
+                    && !knownWindows.contains(value.logicalWindowId())) {
+                unsupported.add(id + ": logical window " + value.logicalWindowId()
+                        + " was not opened earlier in the session.");
+            }
+        } else if (event instanceof CaptureEvent.WaitEvent value) {
+            boolean elementCondition = switch (value.condition()) {
+                case ELEMENT_PRESENT, ELEMENT_VISIBLE, ELEMENT_CLICKABLE, ELEMENT_ABSENT -> true;
+                default -> false;
+            };
+            if (elementCondition && value.target() == null) {
+                unsupported.add(id + ": element wait requires target evidence.");
+            }
+            if ((value.condition() == CaptureEvent.WaitCondition.URL_CONTAINS
+                    || value.condition() == CaptureEvent.WaitCondition.TITLE_CONTAINS)
+                    && value.expected() == null) {
+                unsupported.add(id + ": URL/title wait requires an expected data reference.");
+            } else if ((value.condition() == CaptureEvent.WaitCondition.URL_CONTAINS
+                    || value.condition() == CaptureEvent.WaitCondition.TITLE_CONTAINS)
+                    && isSecret(value.expected())) {
+                unsupported.add(id + ": secret URL/title wait values are not generated because wait "
+                        + "diagnostics could expose them.");
+            }
+        } else if (event instanceof CaptureEvent.VerificationEvent value) {
+            validateVerification(id, value.verification(), value.target(), value.expected(),
+                    value.context(), unsupported);
+        } else if (event instanceof CaptureEvent.AlertEvent value
+                && value.action() == CaptureEvent.AlertAction.VERIFY_TEXT
+                && isSecret(value.text())) {
+            unsupported.add(id + ": secret alert text cannot be asserted without exposing it in reports.");
+        } else if (event instanceof CaptureEvent.NavigationEvent value
+                && value.targetUrl().contains("[data:")) {
+            required.add(id + ": replace sanitized URL data placeholders before replay.");
+        }
+    }
+
+    private static void validateVerification(
+            String eventId,
+            CaptureEvent.VerificationKind verification,
+            ElementSnapshot target,
+            ExternalTestDataReference expected,
+            EventContext context,
+            List<String> unsupported) {
+        boolean targetRequired = switch (verification) {
+            case URL_EQUALS, URL_CONTAINS, TITLE_EQUALS -> false;
+            default -> true;
+        };
+        boolean expectedRequired = switch (verification) {
+            case TEXT_EQUALS, TEXT_CONTAINS, ATTRIBUTE_EQUALS, URL_EQUALS, URL_CONTAINS, TITLE_EQUALS -> true;
+            default -> false;
+        };
+        if (targetRequired && target == null) {
+            unsupported.add(eventId + ": " + verification + " requires target evidence.");
+        }
+        if (expectedRequired && expected == null) {
+            unsupported.add(eventId + ": " + verification + " requires an expected data reference.");
+        }
+        if (expectedRequired && isSecret(expected)) {
+            unsupported.add(eventId + ": secret values cannot be rendered as assertion expectations.");
+        }
+        if (verification == CaptureEvent.VerificationKind.ATTRIBUTE_EQUALS
+                && extensionText(context, "attributeName").isBlank()) {
+            unsupported.add(eventId + ": ATTRIBUTE_EQUALS requires context.extensions.attributeName.");
+        }
+    }
+
+    private static DataPlan data(
+            CaptureSession session,
+            Path sessionPath,
+            List<String> required,
+            List<String> unsupported) {
+        Map<String, ExternalTestDataReference> references = new TreeMap<>();
+        session.dataReferences().forEach(reference -> references.put(reference.id(), reference));
+        session.events().forEach(event -> eventReferences(event)
+                .forEach(reference -> references.put(reference.id(), reference)));
+        Map<String, String> keys = new LinkedHashMap<>();
+        Map<String, String> environment = new LinkedHashMap<>();
+        Set<String> usedKeys = new HashSet<>();
+        ObjectNode root = JSON.createObjectNode();
+        root.put("schemaVersion", "1.0");
+        ObjectNode values = root.putObject("values");
+        Map<Path, JsonNode> sourceFiles = new HashMap<>();
+        for (ExternalTestDataReference reference : references.values()) {
+            String key = uniqueDataKey(reference.logicalName(), usedKeys);
+            keys.put(reference.id(), key);
+            if (reference.source() == ExternalTestDataReference.DataSource.JSON) {
+                Path source = sessionPath.getParent().resolve(reference.relativePath()).normalize();
+                try {
+                    JsonNode sourceRoot = sourceFiles.computeIfAbsent(source, CaptureGenerator::readJsonUnchecked);
+                    JsonNode value = sourceRoot.at(JsonPointer.compile(reference.jsonPointer()));
+                    if (value.isMissingNode() || value.isNull()) {
+                        required.add(reference.id() + ": provide JSON test data for " + reference.logicalName() + ".");
+                    } else if (value.isContainerNode()) {
+                        unsupported.add(reference.id() + ": generated test data values must be scalar.");
+                    } else {
+                        values.set(key, value.deepCopy());
+                    }
+                } catch (RuntimeException exception) {
+                    required.add(reference.id() + ": source test data file is unavailable.");
+                }
+            } else if (reference.source() == ExternalTestDataReference.DataSource.ENVIRONMENT
+                    || reference.source() == ExternalTestDataReference.DataSource.SECRET_PROVIDER) {
+                String name = environmentName(reference.id());
+                environment.put(reference.id(), name);
+                required.add(reference.id() + ": set environment variable " + name + " before replay.");
+            } else if (reference.source() == ExternalTestDataReference.DataSource.FILE_FIXTURE) {
+                required.add(reference.id() + ": provide fixture src/test/resources/"
+                        + reference.relativePath() + " before replay.");
+            }
+        }
+        return new DataPlan(root, Map.copyOf(keys), Map.copyOf(environment), Map.copyOf(references));
+    }
+
+    private static JsonNode readJsonUnchecked(Path path) {
+        try {
+            return JSON.readTree(Files.readString(path, StandardCharsets.UTF_8));
+        } catch (IOException exception) {
+            throw new IllegalStateException("External test data could not be read.", exception);
+        }
+    }
+
+    private static String renderSource(
+            CaptureSession session,
+            String packageName,
+            String className,
+            String methodName,
+            List<TargetPlan> targets,
+            DataPlan data,
+            Map<String, String> elementNames,
+            List<CaptureEnrichmentPreview.AssertionSuggestion> extraAssertions) {
+        StringBuilder source = new StringBuilder();
+        line(source, "package " + packageName + ";");
+        line(source, "");
+        line(source, "import com.shaft.driver.DriverFactory;");
+        line(source, "import com.shaft.driver.SHAFT;");
+        line(source, "import com.shaft.gui.internal.locator.Role;");
+        line(source, "import org.openqa.selenium.By;");
+        line(source, "import org.openqa.selenium.Keys;");
+        line(source, "import org.openqa.selenium.WindowType;");
+        line(source, "import org.openqa.selenium.support.ui.ExpectedConditions;");
+        line(source, "import org.testng.annotations.AfterMethod;");
+        line(source, "import org.testng.annotations.BeforeMethod;");
+        line(source, "import org.testng.annotations.Test;");
+        line(source, "");
+        line(source, "import java.nio.file.Path;");
+        line(source, "import java.util.HashMap;");
+        line(source, "import java.util.Map;");
+        line(source, "");
+        line(source, "public class " + className + " {");
+        for (TargetPlan target : targets) {
+            line(source, "    private static final By " + elementNames.get(target.logicalElementId()) + " = "
+                    + locatorExpression(target) + ";");
+        }
+        if (!targets.isEmpty()) {
+            line(source, "");
+        }
+        line(source, "    private SHAFT.GUI.WebDriver driver;");
+        line(source, "    private SHAFT.TestData.JSON testData;");
+        line(source, "    private final Map<String, String> windows = new HashMap<>();");
+        line(source, "");
+        line(source, "    @BeforeMethod");
+        line(source, "    public void setUp() {");
+        line(source, "        driver = new SHAFT.GUI.WebDriver(DriverFactory.DriverType."
+                + driverType(session.browser().browserName()) + ");");
+        line(source, "        testData = new SHAFT.TestData.JSON(\"" + javaString(dataFileName(className)) + "\");");
+        if (!session.events().isEmpty()) {
+            line(source, "        windows.put(\""
+                    + javaString(session.events().getFirst().context().page().logicalWindowId())
+                    + "\", driver.getDriver().getWindowHandle());");
+        }
+        line(source, "    }");
+        line(source, "");
+        line(source, "    @Test");
+        line(source, "    public void " + methodName + "() throws Exception {");
+        Map<Long, List<Checkpoint>> checkpoints = checkpoints(session.checkpoints());
+        Map<Long, List<CaptureEnrichmentPreview.AssertionSuggestion>> assertions =
+                extraAssertions(extraAssertions);
+        Map<Long, CaptureEvent> eventsBySequence = new HashMap<>();
+        session.events().forEach(event -> eventsBySequence.put(event.context().sequence(), event));
+        for (CaptureEvent event : session.events()) {
+            renderEvent(source, event, targets, elementNames, data);
+            for (Checkpoint checkpoint : checkpoints.getOrDefault(event.context().sequence(), List.of())) {
+                line(source, "        // Recorded checkpoint " + safeComment(checkpoint.id())
+                        + " (" + checkpoint.kind() + ").");
+            }
+            for (CaptureEnrichmentPreview.AssertionSuggestion assertion :
+                    assertions.getOrDefault(event.context().sequence(), List.of())) {
+                renderSuggestedAssertion(source, eventsBySequence.get(assertion.eventSequence()),
+                        assertion, targets, elementNames);
+            }
+        }
+        line(source, "    }");
+        line(source, "");
+        line(source, "    private String requiredData(String key) {");
+        line(source, "        String value = testData.getTestData(\"values.\" + key);");
+        line(source, "        if (value == null) {");
+        line(source, "            throw new IllegalStateException(\"Missing generated test data: \" + key);");
+        line(source, "        }");
+        line(source, "        return value;");
+        line(source, "    }");
+        line(source, "");
+        line(source, "    private String requiredEnvironment(String name) {");
+        line(source, "        String value = System.getenv(name);");
+        line(source, "        if (value == null || value.isBlank()) {");
+        line(source, "            throw new IllegalStateException(\"Missing required environment variable: \" + name);");
+        line(source, "        }");
+        line(source, "        return value;");
+        line(source, "    }");
+        line(source, "");
+        line(source, "    @AfterMethod(alwaysRun = true)");
+        line(source, "    public void tearDown() {");
+        line(source, "        if (driver != null) {");
+        line(source, "            driver.quit();");
+        line(source, "        }");
+        line(source, "    }");
+        line(source, "}");
+        return source.toString();
+    }
+
+    private static void renderEvent(
+            StringBuilder source,
+            CaptureEvent event,
+            List<TargetPlan> targets,
+            Map<String, String> elementNames,
+            DataPlan data) {
+        String locator = target(event)
+                .map(ElementSnapshot::logicalElementId)
+                .map(elementNames::get)
+                .orElse("");
+        if (event instanceof CaptureEvent.NavigationEvent value) {
+            String statement = switch (value.action()) {
+                case OPEN -> "driver.browser().navigateToURL(\"" + javaString(value.targetUrl()) + "\");";
+                case BACK -> "driver.browser().navigateBack();";
+                case FORWARD -> "driver.browser().navigateForward();";
+                case REFRESH -> "driver.browser().refreshCurrentPage();";
+            };
+            line(source, "        " + statement);
+        } else if (event instanceof CaptureEvent.ClickEvent value) {
+            line(source, "        driver.element()."
+                    + (value.clickCount() == 2 ? "doubleClick" : "click")
+                    + "(" + locator + ");");
+        } else if (event instanceof CaptureEvent.TypeEvent value) {
+            line(source, "        driver.element()."
+                    + (isSecret(value.value()) ? "typeSecure" : "type")
+                    + "(" + locator + ", " + dataExpression(value.value(), data) + ");");
+        } else if (event instanceof CaptureEvent.ClearEvent) {
+            line(source, "        driver.element().clear(" + locator + ");");
+        } else if (event instanceof CaptureEvent.SelectEvent value) {
+            line(source, "        driver.element().select(" + locator + ", "
+                    + dataExpression(value.value(), data) + ");");
+        } else if (event instanceof CaptureEvent.ToggleEvent value) {
+            line(source, "        if (driver.getDriver().findElement(" + locator + ").isSelected() != "
+                    + value.checked() + ") {");
+            line(source, "            driver.element().click(" + locator + ");");
+            line(source, "        }");
+        } else if (event instanceof CaptureEvent.UploadEvent value) {
+            line(source, "        driver.element().typeFileLocationForUpload(" + locator + ", "
+                    + dataExpression(value.file(), data) + ");");
+        } else if (event instanceof CaptureEvent.KeyboardEvent value) {
+            String keys = keys(value.keys());
+            if (value.target() == null) {
+                line(source, "        new org.openqa.selenium.interactions.Actions(driver.getDriver())"
+                        + ".sendKeys(" + keys + ").perform();");
+            } else {
+                line(source, "        driver.element().typeAppend(" + locator + ", " + keys + ");");
+            }
+        } else if (event instanceof CaptureEvent.WindowEvent value) {
+            renderWindow(source, value);
+        } else if (event instanceof CaptureEvent.FrameEvent value) {
+            if (value.action() == CaptureEvent.FrameAction.TOP) {
+                line(source, "        driver.element().switchToDefaultContent();");
+            } else if (value.action() == CaptureEvent.FrameAction.EXIT) {
+                line(source, "        driver.getDriver().switchTo().parentFrame();");
+            } else if (value.target() != null) {
+                line(source, "        driver.element().switchToIframe(" + locator + ");");
+            } else {
+                line(source, "        driver.element().switchToIframe(By.id(\""
+                        + javaString(value.logicalFrameId()) + "\"));");
+            }
+        } else if (event instanceof CaptureEvent.AlertEvent value) {
+            renderAlert(source, value, data);
+        } else if (event instanceof CaptureEvent.WaitEvent value) {
+            renderWait(source, value, locator, data);
+        } else if (event instanceof CaptureEvent.VerificationEvent value) {
+            renderVerification(source, value.verification(), value.target(), value.expected(),
+                    value.negated(), value.context(), locator, data);
+        }
+    }
+
+    private static void renderWindow(StringBuilder source, CaptureEvent.WindowEvent value) {
+        switch (value.action()) {
+            case OPEN_TAB, OPEN_WINDOW -> {
+                line(source, "        driver.getDriver().switchTo().newWindow(WindowType."
+                        + (value.action() == CaptureEvent.WindowAction.OPEN_TAB ? "TAB" : "WINDOW") + ");");
+                line(source, "        windows.put(\"" + javaString(value.logicalWindowId())
+                        + "\", driver.getDriver().getWindowHandle());");
+            }
+            case SWITCH -> line(source, "        driver.browser().switchToWindow(windows.get(\""
+                    + javaString(value.logicalWindowId()) + "\"));");
+            case CLOSE -> line(source, "        driver.browser().closeCurrentWindow();");
+        }
+    }
+
+    private static void renderAlert(
+            StringBuilder source,
+            CaptureEvent.AlertEvent value,
+            DataPlan data) {
+        switch (value.action()) {
+            case ACCEPT -> line(source, "        driver.alert().acceptAlert();");
+            case DISMISS -> line(source, "        driver.alert().dismissAlert();");
+            case TYPE -> {
+                if (isSecret(value.text())) {
+                    line(source, "        driver.getDriver().switchTo().alert().sendKeys("
+                            + dataExpression(value.text(), data) + ");");
+                } else {
+                    line(source, "        driver.alert().typeIntoPromptAlert("
+                            + dataExpression(value.text(), data) + ");");
+                }
+            }
+            case VERIFY_TEXT -> line(source, "        SHAFT.Validations.assertThat()"
+                    + ".object(driver.alert().getAlertText()).isEqualTo("
+                    + dataExpression(value.text(), data) + ").perform();");
+        }
+    }
+
+    private static void renderWait(
+            StringBuilder source,
+            CaptureEvent.WaitEvent value,
+            String locator,
+            DataPlan data) {
+        long seconds = Math.max(1, value.timeout().toSeconds());
+        switch (value.condition()) {
+            case ELEMENT_PRESENT -> waitUntil(source, "presenceOfElementLocated(" + locator + ")", seconds);
+            case ELEMENT_VISIBLE -> waitUntil(source, "visibilityOfElementLocated(" + locator + ")", seconds);
+            case ELEMENT_CLICKABLE -> waitUntil(source, "elementToBeClickable(" + locator + ")", seconds);
+            case ELEMENT_ABSENT -> waitUntil(source, "invisibilityOfElementLocated(" + locator + ")", seconds);
+            case URL_CONTAINS -> waitUntil(source, "urlContains(" + dataExpression(value.expected(), data) + ")",
+                    seconds);
+            case TITLE_CONTAINS -> waitUntil(source,
+                    "titleContains(" + dataExpression(value.expected(), data) + ")", seconds);
+            case DOCUMENT_READY -> line(source, "        driver.browser().waitForLazyLoading();");
+            case FIXED_DURATION -> line(source, "        Thread.sleep(" + value.timeout().toMillis() + "L);");
+        }
+    }
+
+    private static void waitUntil(StringBuilder source, String condition, long seconds) {
+        line(source, "        driver.element().waitUntil(ExpectedConditions." + condition
+                + ", java.time.Duration.ofSeconds(" + seconds + "));");
+    }
+
+    private static void renderVerification(
+            StringBuilder source,
+            CaptureEvent.VerificationKind verification,
+            ElementSnapshot target,
+            ExternalTestDataReference expected,
+            boolean negated,
+            EventContext context,
+            String locator,
+            DataPlan data) {
+        switch (verification) {
+            case ELEMENT_PRESENT -> line(source, "        driver.assertThat().element(" + locator + ")."
+                    + (negated ? "doesNotExist" : "exists") + "().perform();");
+            case ELEMENT_VISIBLE -> {
+                if (negated) {
+                    stateAssertion(source, "driver.getDriver().findElement(" + locator + ").isDisplayed()", true);
+                } else {
+                    line(source, "        driver.assertThat().element(" + locator + ").isVisible().perform();");
+                }
+            }
+            case ELEMENT_ENABLED -> line(source, "        driver.assertThat().element(" + locator + ")."
+                    + (negated ? "isDisabled" : "isEnabled") + "().perform();");
+            case ELEMENT_SELECTED -> line(source, "        driver.assertThat().element(" + locator + ")."
+                    + (negated ? "isNotSelected" : "isSelected") + "().perform();");
+            case TEXT_EQUALS -> nativeAssertion(source,
+                    "driver.assertThat().element(" + locator + ").text()",
+                    negated ? "doesNotEqual" : "isEqualTo", dataExpression(expected, data));
+            case TEXT_CONTAINS -> nativeAssertion(source,
+                    "driver.assertThat().element(" + locator + ").text()",
+                    negated ? "doesNotContain" : "contains", dataExpression(expected, data));
+            case ATTRIBUTE_EQUALS -> nativeAssertion(source,
+                    "driver.assertThat().element(" + locator + ").attribute(\""
+                            + javaString(extensionText(context, "attributeName")) + "\")",
+                    negated ? "doesNotEqual" : "isEqualTo", dataExpression(expected, data));
+            case URL_EQUALS -> nativeAssertion(source, "driver.assertThat().browser().url()",
+                    negated ? "doesNotEqual" : "isEqualTo", dataExpression(expected, data));
+            case URL_CONTAINS -> nativeAssertion(source, "driver.assertThat().browser().url()",
+                    negated ? "doesNotContain" : "contains", dataExpression(expected, data));
+            case TITLE_EQUALS -> nativeAssertion(source, "driver.assertThat().browser().title()",
+                    negated ? "doesNotEqual" : "isEqualTo", dataExpression(expected, data));
+        }
+    }
+
+    private static void nativeAssertion(
+            StringBuilder source,
+            String builder,
+            String comparison,
+            String expected) {
+        line(source, "        " + builder + "." + comparison + "(" + expected + ").perform();");
+    }
+
+    private static void stateAssertion(StringBuilder source, String actual, boolean expectedFalse) {
+        line(source, "        SHAFT.Validations.assertThat().object(" + actual + ")."
+                + (expectedFalse ? "isFalse" : "isTrue") + "().perform();");
+    }
+
+    private static void renderSuggestedAssertion(
+            StringBuilder source,
+            CaptureEvent event,
+            CaptureEnrichmentPreview.AssertionSuggestion suggestion,
+            List<TargetPlan> targets,
+            Map<String, String> elementNames) {
+        Optional<ElementSnapshot> target = target(event);
+        if (target.isEmpty()) {
+            return;
+        }
+        String locator = elementNames.get(target.get().logicalElementId());
+        CaptureEvent.VerificationKind verification =
+                CaptureEvent.VerificationKind.valueOf(suggestion.verification());
+        renderVerification(source, verification, target.get(), null, suggestion.negated(),
+                event.context(), locator, null);
+    }
+
+    private static String locatorExpression(TargetPlan plan) {
+        LocatorCandidate candidate = plan.selection().selected().candidate();
+        ElementSnapshot target = plan.target();
+        String name = !target.accessibleName().isBlank() ? target.accessibleName() : target.label();
+        return switch (candidate.strategy()) {
+            case ROLE, ACCESSIBLE_NAME, LABEL -> semanticLocator(target, name, candidate);
+            case TEST_ID, CSS -> "By.cssSelector(\"" + javaString(candidate.expression()) + "\")";
+            case ID -> "SHAFT.GUI.Locator.hasAnyTagName().hasId(\""
+                    + javaString(candidate.expression()) + "\").build()";
+            case NAME -> "SHAFT.GUI.Locator.hasAnyTagName().hasAttribute(\"name\", \""
+                    + javaString(candidate.expression()) + "\").build()";
+            case XPATH -> "By.xpath(\"" + javaString(candidate.expression()) + "\")";
+        };
+    }
+
+    private static String semanticLocator(
+            ElementSnapshot target,
+            String name,
+            LocatorCandidate candidate) {
+        String semanticName = name;
+        if (candidate.strategy() == LocatorCandidate.LocatorStrategy.ROLE
+                && candidate.expression().contains(":")) {
+            semanticName = candidate.expression().substring(candidate.expression().indexOf(':') + 1);
+        } else if (semanticName.isBlank()) {
+            semanticName = candidate.expression();
+        }
+        if (isInput(target)) {
+            return "SHAFT.GUI.Locator.inputField(\"" + javaString(semanticName) + "\")";
+        }
+        if (isClickable(target)) {
+            return "SHAFT.GUI.Locator.clickableField(\"" + javaString(semanticName) + "\")";
+        }
+        String role = target.role().toUpperCase(Locale.ROOT).replace('-', '_');
+        if (Set.of("BUTTON", "LINK", "TEXTBOX", "CHECKBOX", "RADIO", "COMBOBOX", "HEADING",
+                "IMAGE", "LIST", "LISTITEM", "TABLE", "TABLE_ROW", "TABLE_CELL",
+                "TABLE_COLUMNHEADER").contains(role)) {
+            String suffix = semanticName.isBlank() ? "" : ".hasText(\"" + javaString(semanticName) + "\")";
+            return "SHAFT.GUI.Locator.hasRole(Role." + role + ")" + suffix + ".build()";
+        }
+        return "By.xpath(\"" + javaString(candidate.expression()) + "\")";
+    }
+
+    private static String dataExpression(ExternalTestDataReference reference, DataPlan data) {
+        if (reference == null) {
+            return "\"\"";
+        }
+        return switch (reference.source()) {
+            case JSON -> "requiredData(\"" + javaString(data.keys().get(reference.id())) + "\")";
+            case ENVIRONMENT, SECRET_PROVIDER -> "requiredEnvironment(\""
+                    + javaString(data.environment().get(reference.id())) + "\")";
+            case FILE_FIXTURE -> "Path.of(\"src/test/resources/"
+                    + javaString(reference.relativePath()) + "\").toString()";
+        };
+    }
+
+    private static String keys(List<String> values) {
+        List<String> rendered = values.stream().map(CaptureGenerator::key).toList();
+        return rendered.size() == 1
+                ? rendered.getFirst()
+                : "Keys.chord(" + String.join(", ", rendered) + ")";
+    }
+
+    private static String key(String value) {
+        String normalized = value == null ? "" : value.trim().toUpperCase(Locale.ROOT);
+        if (Set.of("NULL", "CANCEL", "HELP", "BACK_SPACE", "TAB", "CLEAR", "RETURN", "ENTER",
+                "SHIFT", "CONTROL", "ALT", "PAUSE", "ESCAPE", "SPACE", "PAGE_UP", "PAGE_DOWN",
+                "END", "HOME", "ARROW_LEFT", "LEFT", "ARROW_UP", "UP", "ARROW_RIGHT", "RIGHT",
+                "ARROW_DOWN", "DOWN", "INSERT", "DELETE", "SEMICOLON", "EQUALS", "NUMPAD0",
+                "NUMPAD1", "NUMPAD2", "NUMPAD3", "NUMPAD4", "NUMPAD5", "NUMPAD6", "NUMPAD7",
+                "NUMPAD8", "NUMPAD9", "MULTIPLY", "ADD", "SEPARATOR", "SUBTRACT", "DECIMAL",
+                "DIVIDE", "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10",
+                "F11", "F12", "META", "COMMAND", "ZENKAKU_HANKAKU").contains(normalized)) {
+            return "Keys." + normalized;
+        }
+        return "\"" + javaString(value) + "\"";
+    }
+
+    private static Map<String, String> defaultElementNames(List<TargetPlan> targets) {
+        Map<String, String> names = new LinkedHashMap<>();
+        Set<String> used = new HashSet<>();
+        for (TargetPlan target : targets) {
+            String base = constantName(target.logicalElementId()) + "_LOCATOR";
+            String name = base;
+            int suffix = 2;
+            while (!used.add(name)) {
+                name = base + "_" + suffix++;
+            }
+            names.put(target.logicalElementId(), name);
+        }
+        return Map.copyOf(names);
+    }
+
+    private static Map<String, String> mergeElementNames(
+            Map<String, String> deterministic,
+            Map<String, String> proposed) {
+        Map<String, String> result = new LinkedHashMap<>(deterministic);
+        proposed.forEach((key, value) -> {
+            if (result.containsKey(key) && value != null && !value.isBlank()) {
+                result.put(key, value);
+            }
+        });
+        return Map.copyOf(result);
+    }
+
+    private static List<String> validateProposal(
+            CaptureEnrichmentPreview preview,
+            String fingerprint,
+            List<TargetPlan> targets) {
+        List<String> errors = new ArrayList<>();
+        if (!CaptureEnrichmentPreview.CURRENT_SCHEMA_VERSION.equals(preview.schemaVersion())) {
+            errors.add("AI enrichment preview uses an unsupported schema version.");
+        }
+        if (!fingerprint.equals(preview.deterministicFingerprint())) {
+            errors.add("AI enrichment preview does not match the deterministic source.");
+        }
+        validateOptionalIdentifier(preview.proposal().className(), "AI class name", errors);
+        validateOptionalIdentifier(preview.proposal().methodName(), "AI method name", errors);
+        Map<String, TargetPlan> byId = targets.stream()
+                .collect(java.util.stream.Collectors.toMap(TargetPlan::logicalElementId, item -> item));
+        Set<String> names = new HashSet<>();
+        preview.proposal().elementNames().forEach((id, name) -> {
+            if (!byId.containsKey(id)) {
+                errors.add("AI element name references unknown target " + id + ".");
+            }
+            if (!JAVA_IDENTIFIER.matcher(name).matches()) {
+                errors.add("AI element name for " + id + " is not a Java identifier.");
+            }
+            if (!names.add(name)) {
+                errors.add("AI element names must be unique.");
+            }
+        });
+        Map<Long, TargetPlan> bySequence = new HashMap<>();
+        for (TargetPlan target : targets) {
+            for (String eventId : target.eventIds()) {
+                bySequence.put(Long.parseLong(eventId.substring("event-".length())), target);
+            }
+        }
+        for (CaptureEnrichmentPreview.AssertionSuggestion assertion : preview.proposal().assertions()) {
+            TargetPlan target = bySequence.get(assertion.eventSequence());
+            if (target == null) {
+                errors.add("AI assertion references an event without captured target state: event-"
+                        + assertion.eventSequence() + ".");
+                continue;
+            }
+            boolean observed = switch (assertion.verification()) {
+                case "ELEMENT_PRESENT" -> true;
+                case "ELEMENT_VISIBLE" -> target.target().visible();
+                case "ELEMENT_ENABLED" -> target.target().enabled();
+                case "ELEMENT_SELECTED" -> target.target().selected();
+                default -> false;
+            };
+            if (observed == assertion.negated()) {
+                errors.add("AI assertion contradicts captured state at event-"
+                        + assertion.eventSequence() + ".");
+            }
+        }
+        return List.copyOf(errors);
+    }
+
+    private static CaptureEnrichmentPreview readPreview(Path path) {
+        try {
+            return JSON.readValue(Files.readString(path, StandardCharsets.UTF_8),
+                    CaptureEnrichmentPreview.class);
+        } catch (IOException exception) {
+            throw new IllegalStateException("AI enrichment preview could not be read.", exception);
+        }
+    }
+
+    private static CaptureGenerationReport report(
+            CaptureSession session,
+            ArtifactPaths paths,
+            GenerationState state,
+            CaptureGenerationReport.Status status,
+            CaptureGenerationReport.Validation compilation,
+            CaptureGenerationReport.Validation replay,
+            CaptureGenerationReport.Enrichment enrichment) {
+        return report(session == null ? "" : session.sessionId(), paths, state, status,
+                compilation, replay, enrichment);
+    }
+
+    private static CaptureGenerationReport report(
+            String sessionId,
+            ArtifactPaths paths,
+            GenerationState state,
+            CaptureGenerationReport.Status status,
+            CaptureGenerationReport.Validation compilation,
+            CaptureGenerationReport.Validation replay,
+            CaptureGenerationReport.Enrichment enrichment) {
+        List<CaptureGenerationReport.LocatorDecision> decisions = state.targets().stream()
+                .map(target -> new CaptureGenerationReport.LocatorDecision(
+                        target.eventIds(),
+                        target.logicalElementId(),
+                        target.selection().selected().candidate().strategy().name(),
+                        target.selection().selected().candidate().expression(),
+                        target.selection().selected().score(),
+                        target.selection().selected().breakdown(),
+                        target.selection().alternatives().stream()
+                                .map(item -> item.candidate().strategy() + " "
+                                        + item.candidate().expression() + " (score " + item.score() + ")")
+                                .toList()))
+                .toList();
+        return new CaptureGenerationReport(
+                CaptureGenerationReport.CURRENT_SCHEMA_VERSION,
+                sessionId,
+                status,
+                relative(paths.root(), paths.source()),
+                relative(paths.root(), paths.data()),
+                decisions,
+                state.unsupported().stream().distinct().sorted().toList(),
+                state.flaky().stream().distinct().sorted().toList(),
+                state.fallback().stream().distinct().sorted().toList(),
+                state.required().stream().distinct().sorted().toList(),
+                state.warnings().stream().distinct().sorted().toList(),
+                compilation,
+                replay,
+                enrichment);
+    }
+
+    private static void validateOutputs(
+            ArtifactPaths paths,
+            Path reportPath,
+            boolean overwrite,
+            List<String> unsupported) {
+        for (Path path : List.of(paths.source(), paths.data(), reportPath)) {
+            if (Files.exists(path) && !overwrite) {
+                unsupported.add("output: " + relative(paths.root(), path)
+                        + " already exists. Supply an explicit output directory and overwrite approval.");
+            }
+        }
+    }
+
+    private static void ensureWritable(Path path, boolean overwrite) {
+        if (Files.exists(path) && !overwrite) {
+            throw new IllegalStateException("Enrichment preview already exists and overwrite was not approved.");
+        }
+    }
+
+    private static void writeReportIfPossible(
+            Path reportPath,
+            CaptureGenerationReport report,
+            boolean overwrite) {
+        try {
+            if (!Files.exists(reportPath) || overwrite) {
+                atomicWrite(reportPath, writeJson(report));
+            }
+        } catch (RuntimeException ignored) {
+            // The returned in-memory report remains available when the filesystem is not writable.
+        }
+    }
+
+    private static List<String> privacyFindings(String content) {
+        List<String> findings = new ArrayList<>();
+        if (content == null || content.isBlank()) {
+            return findings;
+        }
+        addFinding(findings, WINDOWS_PERSONAL_PATH, content,
+                "privacy: generated artifacts contain an absolute personal Windows path.");
+        addFinding(findings, UNIX_PERSONAL_PATH, content,
+                "privacy: generated artifacts contain an absolute personal POSIX path.");
+        addFinding(findings, BEARER_SECRET, content,
+                "privacy: generated artifacts contain a bearer credential.");
+        addFinding(findings, JWT_SECRET, content,
+                "privacy: generated artifacts contain a JWT-like credential.");
+        addFinding(findings, API_KEY_SECRET, content,
+                "privacy: generated artifacts contain an API-key-like value.");
+        addFinding(findings, NAMED_SECRET, content,
+                "privacy: generated artifacts contain a named secret value.");
+        var sanitized = new CapturePrivacyClassifier().sanitizeText(content);
+        if (!sanitized.value().equals(content)) {
+            findings.add("privacy: generated artifacts contain a configured secret-pattern match.");
+        }
+        return findings.stream().distinct().toList();
+    }
+
+    private static void addFinding(List<String> findings, Pattern pattern, String content, String message) {
+        if (pattern.matcher(content).find()) {
+            findings.add(message);
+        }
+    }
+
+    private static ArtifactPaths artifactPaths(Path root, String packageName, String className) {
+        Path source = root.resolve("src/test/java")
+                .resolve(packageName.replace('.', '/'))
+                .resolve(className + ".java")
+                .normalize();
+        Path data = root.resolve("src/test/resources/testDataFiles")
+                .resolve(dataFileName(className))
+                .normalize();
+        Path classes = root.resolve("target/shaft-capture/classes").normalize();
+        ensureWithin(root, source);
+        ensureWithin(root, data);
+        ensureWithin(root, classes);
+        return new ArtifactPaths(root, source, data, classes);
+    }
+
+    private static void ensureWithin(Path root, Path target) {
+        if (!target.toAbsolutePath().normalize().startsWith(root.toAbsolutePath().normalize())) {
+            throw new IllegalArgumentException("Generated artifact path escapes the output directory.");
+        }
+    }
+
+    private static String relative(Path root, Path target) {
+        try {
+            return root.toAbsolutePath().normalize()
+                    .relativize(target.toAbsolutePath().normalize())
+                    .toString()
+                    .replace('\\', '/');
+        } catch (IllegalArgumentException exception) {
+            return target.getFileName() == null ? "" : target.getFileName().toString();
+        }
+    }
+
+    private static String writeJson(Object value) {
+        try {
+            return JSON.writer(PRINTER).writeValueAsString(value) + "\n";
+        } catch (IOException exception) {
+            throw new IllegalStateException("Generated JSON could not be serialized.", exception);
+        }
+    }
+
+    private static void atomicWrite(Path destination, String content) {
+        Path absolute = destination.toAbsolutePath().normalize();
+        Path parent = absolute.getParent();
+        if (parent == null) {
+            throw new IllegalArgumentException("Generated artifact requires a parent directory.");
+        }
+        Path temporary = null;
+        try {
+            Files.createDirectories(parent);
+            temporary = Files.createTempFile(parent, "." + absolute.getFileName(), ".tmp");
+            Files.writeString(temporary, content, StandardCharsets.UTF_8);
+            moveReplacing(temporary, absolute);
+        } catch (IOException exception) {
+            throw new IllegalStateException("Generated artifact could not be written atomically.", exception);
+        } finally {
+            if (temporary != null) {
+                try {
+                    Files.deleteIfExists(temporary);
+                } catch (IOException ignored) {
+                    // Best-effort cleanup of an unpublished temporary artifact.
+                }
+            }
+        }
+    }
+
+    private static void moveReplacing(Path temporary, Path destination) throws IOException {
+        boolean atomic = true;
+        for (int attempt = 1; attempt <= 50; attempt++) {
+            try {
+                if (atomic) {
+                    Files.move(temporary, destination, StandardCopyOption.ATOMIC_MOVE,
+                            StandardCopyOption.REPLACE_EXISTING);
+                } else {
+                    Files.move(temporary, destination, StandardCopyOption.REPLACE_EXISTING);
+                }
+                return;
+            } catch (AtomicMoveNotSupportedException ignored) {
+                atomic = false;
+            } catch (AccessDeniedException exception) {
+                if (attempt == 50) {
+                    throw exception;
+                }
+                try {
+                    Thread.sleep(10);
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Interrupted while publishing generated artifact.", interrupted);
+                }
+            }
+        }
+    }
+
+    private static String fingerprint(String sessionJson, String source) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = digest.digest((sessionJson + "\n" + source).getBytes(StandardCharsets.UTF_8));
+            return java.util.HexFormat.of().formatHex(bytes);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 is unavailable.", exception);
+        }
+    }
+
+    private static Optional<ElementSnapshot> target(CaptureEvent event) {
+        if (event instanceof CaptureEvent.ClickEvent value) {
+            return Optional.of(value.target());
+        }
+        if (event instanceof CaptureEvent.TypeEvent value) {
+            return Optional.of(value.target());
+        }
+        if (event instanceof CaptureEvent.ClearEvent value) {
+            return Optional.of(value.target());
+        }
+        if (event instanceof CaptureEvent.SelectEvent value) {
+            return Optional.of(value.target());
+        }
+        if (event instanceof CaptureEvent.ToggleEvent value) {
+            return Optional.of(value.target());
+        }
+        if (event instanceof CaptureEvent.UploadEvent value) {
+            return Optional.of(value.target());
+        }
+        if (event instanceof CaptureEvent.KeyboardEvent value) {
+            return Optional.ofNullable(value.target());
+        }
+        if (event instanceof CaptureEvent.FrameEvent value) {
+            return Optional.ofNullable(value.target());
+        }
+        if (event instanceof CaptureEvent.WaitEvent value) {
+            return Optional.ofNullable(value.target());
+        }
+        if (event instanceof CaptureEvent.VerificationEvent value) {
+            return Optional.ofNullable(value.target());
+        }
+        return Optional.empty();
+    }
+
+    private static List<ExternalTestDataReference> eventReferences(CaptureEvent event) {
+        List<ExternalTestDataReference> references = new ArrayList<>();
+        if (event instanceof CaptureEvent.TypeEvent value) {
+            references.add(value.value());
+        } else if (event instanceof CaptureEvent.SelectEvent value) {
+            references.add(value.value());
+        } else if (event instanceof CaptureEvent.UploadEvent value) {
+            references.add(value.file());
+        } else if (event instanceof CaptureEvent.AlertEvent value && value.text() != null) {
+            references.add(value.text());
+        } else if (event instanceof CaptureEvent.WaitEvent value && value.expected() != null) {
+            references.add(value.expected());
+        } else if (event instanceof CaptureEvent.VerificationEvent value && value.expected() != null) {
+            references.add(value.expected());
+        }
+        return references;
+    }
+
+    private static boolean interaction(CaptureEvent event) {
+        return event instanceof CaptureEvent.ClickEvent
+                || event instanceof CaptureEvent.TypeEvent
+                || event instanceof CaptureEvent.ClearEvent
+                || event instanceof CaptureEvent.SelectEvent
+                || event instanceof CaptureEvent.ToggleEvent
+                || event instanceof CaptureEvent.UploadEvent
+                || event instanceof CaptureEvent.KeyboardEvent
+                || event instanceof CaptureEvent.FrameEvent;
+    }
+
+    private static boolean isSecret(ExternalTestDataReference reference) {
+        return reference != null
+                && (reference.classification() == ExternalTestDataReference.DataClassification.SECRET
+                || reference.classification() == ExternalTestDataReference.DataClassification.SENSITIVE);
+    }
+
+    private static boolean hasShadowContext(EventContext context) {
+        JsonNode shadowHosts = context.extensions().get("shadowHosts");
+        return shadowHosts != null && shadowHosts.isArray() && !shadowHosts.isEmpty();
+    }
+
+    private static String extensionText(EventContext context, String name) {
+        JsonNode value = context.extensions().get(name);
+        return value == null ? "" : value.asText("");
+    }
+
+    private static boolean isInput(ElementSnapshot target) {
+        return "textbox".equals(target.role())
+                || "combobox".equals(target.role())
+                || "input".equals(target.tagName())
+                || "textarea".equals(target.tagName())
+                || "select".equals(target.tagName());
+    }
+
+    private static boolean isClickable(ElementSnapshot target) {
+        return Set.of("button", "link", "checkbox", "radio").contains(target.role())
+                || Set.of("button", "a").contains(target.tagName());
+    }
+
+    private static String eventId(CaptureEvent event) {
+        return "event-" + event.context().sequence();
+    }
+
+    private static Map<Long, List<Checkpoint>> checkpoints(List<Checkpoint> checkpoints) {
+        Map<Long, List<Checkpoint>> result = new TreeMap<>();
+        checkpoints.forEach(checkpoint ->
+                result.computeIfAbsent(checkpoint.sequence(), ignored -> new ArrayList<>()).add(checkpoint));
+        return result;
+    }
+
+    private static Map<Long, List<CaptureEnrichmentPreview.AssertionSuggestion>> extraAssertions(
+            List<CaptureEnrichmentPreview.AssertionSuggestion> assertions) {
+        Map<Long, List<CaptureEnrichmentPreview.AssertionSuggestion>> result = new TreeMap<>();
+        assertions.stream()
+                .sorted(Comparator.comparingLong(CaptureEnrichmentPreview.AssertionSuggestion::eventSequence)
+                        .thenComparing(CaptureEnrichmentPreview.AssertionSuggestion::verification))
+                .forEach(assertion -> result.computeIfAbsent(
+                        assertion.eventSequence(), ignored -> new ArrayList<>()).add(assertion));
+        return result;
+    }
+
+    private static String javaClassName(String value) {
+        StringBuilder result = new StringBuilder();
+        for (String part : splitWords(value)) {
+            if (!part.isBlank()) {
+                result.append(Character.toUpperCase(part.charAt(0)));
+                if (part.length() > 1) {
+                    result.append(part.substring(1).toLowerCase(Locale.ROOT));
+                }
+            }
+        }
+        if (result.isEmpty()) {
+            result.append("CapturedJourney");
+        }
+        if (!Character.isJavaIdentifierStart(result.charAt(0))) {
+            result.insert(0, "Capture");
+        }
+        return result.toString();
+    }
+
+    private static String constantName(String value) {
+        String normalized = value == null ? "ELEMENT" : value.replaceAll("[^A-Za-z0-9]+", "_")
+                .replaceAll("^_+|_+$", "")
+                .toUpperCase(Locale.ROOT);
+        if (normalized.isBlank()) {
+            normalized = "ELEMENT";
+        }
+        if (!Character.isJavaIdentifierStart(normalized.charAt(0))) {
+            normalized = "ELEMENT_" + normalized;
+        }
+        return normalized;
+    }
+
+    private static String uniqueDataKey(String value, Set<String> used) {
+        String base = value == null ? "value" : value.trim().toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z0-9]+", "_")
+                .replaceAll("^_+|_+$", "");
+        if (base.isBlank()) {
+            base = "value";
+        }
+        if (Character.isDigit(base.charAt(0))) {
+            base = "value_" + base;
+        }
+        String candidate = base;
+        int suffix = 2;
+        while (!used.add(candidate)) {
+            candidate = base + "_" + suffix++;
+        }
+        return candidate;
+    }
+
+    private static String environmentName(String id) {
+        return "SHAFT_CAPTURE_" + constantName(id);
+    }
+
+    private static String dataFileName(String className) {
+        return className.replaceAll("([a-z0-9])([A-Z])", "$1-$2")
+                .replace('_', '-')
+                .toLowerCase(Locale.ROOT) + ".json";
+    }
+
+    private static String driverType(String browserName) {
+        return "edge".equalsIgnoreCase(browserName) ? "EDGE" : "CHROME";
+    }
+
+    private static List<String> splitWords(String value) {
+        if (value == null) {
+            return List.of();
+        }
+        return java.util.Arrays.stream(value.split("[^A-Za-z0-9]+"))
+                .filter(part -> !part.isBlank())
+                .toList();
+    }
+
+    private static void validatePackage(String packageName) {
+        if (!JAVA_PACKAGE.matcher(packageName).matches()) {
+            throw new IllegalArgumentException("Generated package name is invalid.");
+        }
+    }
+
+    private static void validateJavaIdentifier(String value, String label) {
+        if (!JAVA_IDENTIFIER.matcher(value).matches()) {
+            throw new IllegalArgumentException(label + " is not a valid Java identifier.");
+        }
+    }
+
+    private static void validateOptionalIdentifier(String value, String label, List<String> errors) {
+        if (value != null && !value.isBlank() && !JAVA_IDENTIFIER.matcher(value).matches()) {
+            errors.add(label + " is not a Java identifier.");
+        }
+    }
+
+    private static String javaString(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\r", "\\r")
+                .replace("\n", "\\n")
+                .replace("\t", "\\t");
+    }
+
+    private static String safeComment(String value) {
+        return (value == null ? "" : value).replace("*/", "* /")
+                .replace('\r', ' ')
+                .replace('\n', ' ');
+    }
+
+    private static String safeMessage(RuntimeException exception) {
+        String message = exception.getMessage();
+        return message == null || message.isBlank() ? "Generation failed." : message;
+    }
+
+    private static void line(StringBuilder source, String value) {
+        source.append(value).append('\n');
+    }
+
+    private static DefaultPrettyPrinter printer() {
+        DefaultPrettyPrinter printer = new DefaultPrettyPrinter();
+        DefaultIndenter indenter = new DefaultIndenter("  ", "\n");
+        printer.indentArraysWith(indenter);
+        printer.indentObjectsWith(indenter);
+        return printer;
+    }
+
+    private record ArtifactPaths(Path root, Path source, Path data, Path classes) {
+    }
+
+    private record DataPlan(
+            ObjectNode root,
+            Map<String, String> keys,
+            Map<String, String> environment,
+            Map<String, ExternalTestDataReference> references) {
+    }
+
+    private record TargetPlan(
+            String logicalElementId,
+            ElementSnapshot target,
+            EventContext context,
+            LocatorRanker.LocatorSelection selection,
+            List<String> eventIds) {
+    }
+
+    private static final class MutableTargetPlan {
+        private ElementSnapshot target;
+        private EventContext context;
+        private LocatorRanker.LocatorSelection selection;
+        private final List<String> eventIds = new ArrayList<>();
+
+        private MutableTargetPlan(
+                ElementSnapshot target,
+                EventContext context,
+                LocatorRanker.LocatorSelection selection) {
+            this.target = target;
+            this.context = context;
+            this.selection = selection;
+        }
+
+        private TargetPlan immutable(String logicalElementId) {
+            return new TargetPlan(logicalElementId, target, context, selection, List.copyOf(eventIds));
+        }
+    }
+
+    private record GenerationState(
+            List<TargetPlan> targets,
+            DataPlan data,
+            List<String> unsupported,
+            List<String> flaky,
+            List<String> fallback,
+            List<String> required,
+            List<String> warnings) {
+        private static GenerationState failure(String message) {
+            ObjectNode root = JSON.createObjectNode();
+            root.put("schemaVersion", "1.0");
+            root.putObject("values");
+            return new GenerationState(
+                    List.of(),
+                    new DataPlan(root, Map.of(), Map.of(), Map.of()),
+                    new ArrayList<>(List.of(message)),
+                    new ArrayList<>(),
+                    new ArrayList<>(),
+                    new ArrayList<>(),
+                    new ArrayList<>());
+        }
+
+        private GenerationState withUnsupported(List<String> additional) {
+            List<String> merged = new ArrayList<>(unsupported);
+            merged.addAll(additional);
+            return new GenerationState(targets, data, merged, flaky, fallback, required, warnings);
+        }
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/GeneratedTestValidator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/GeneratedTestValidator.java
@@ -1,0 +1,267 @@
+package com.shaft.capture.generate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Stream;
+
+/**
+ * Compiles generated Java and optionally replays it in an isolated TestNG process.
+ */
+public class GeneratedTestValidator {
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    /**
+     * Compiles one generated test class against the current SHAFT runtime.
+     *
+     * @param source generated Java source
+     * @param classesDirectory isolated class output
+     * @return compilation result
+     */
+    public CaptureGenerationReport.Validation compile(Path source, Path classesDirectory) {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        if (compiler == null) {
+            return failed("A full Java 25 JDK is required to compile generated tests.");
+        }
+        DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+        try {
+            Files.createDirectories(classesDirectory);
+            try (StandardJavaFileManager files = compiler.getStandardFileManager(
+                    diagnostics, Locale.ROOT, StandardCharsets.UTF_8)) {
+                Iterable<? extends JavaFileObject> units =
+                        files.getJavaFileObjectsFromPaths(List.of(source));
+                List<String> options = List.of(
+                        "--release", "25",
+                        "-classpath", resolvedClasspath(classesDirectory),
+                        "-d", classesDirectory.toString(),
+                        "-encoding", "UTF-8");
+                boolean success = Boolean.TRUE.equals(compiler.getTask(
+                        null, files, diagnostics, options, null, units).call());
+                List<String> safeDiagnostics = diagnostics.getDiagnostics().stream()
+                        .map(GeneratedTestValidator::diagnostic)
+                        .limit(20)
+                        .toList();
+                return new CaptureGenerationReport.Validation(
+                        success
+                                ? CaptureGenerationReport.Validation.ValidationStatus.PASSED
+                                : CaptureGenerationReport.Validation.ValidationStatus.FAILED,
+                        safeDiagnostics,
+                        0);
+            }
+        } catch (IOException exception) {
+            return failed("Generated source compilation could not be initialized.");
+        }
+    }
+
+    /**
+     * Replays a compiled TestNG class and requires populated, passing Allure results.
+     *
+     * @param fullyQualifiedClassName generated class
+     * @param classesDirectory compiled classes
+     * @param resourcesDirectory generated test resources
+     * @param workDirectory isolated replay directory
+     * @param timeout maximum replay duration
+     * @return replay result
+     */
+    public CaptureGenerationReport.Validation replay(
+            String fullyQualifiedClassName,
+            Path classesDirectory,
+            Path resourcesDirectory,
+            Path workDirectory,
+            Duration timeout) {
+        Path replayDirectory = workDirectory.resolve("target/shaft-capture/replay");
+        Path allureResults = replayDirectory.resolve("allure-results");
+        Path testngOutput = replayDirectory.resolve("testng-output");
+        Path outputLog = replayDirectory.resolve("replay.log");
+        try {
+            Files.createDirectories(allureResults);
+            Files.createDirectories(testngOutput);
+            List<String> command = new ArrayList<>();
+            command.add(javaCommand());
+            command.add("-Dallure.results.directory=" + allureResults.toAbsolutePath().normalize());
+            command.add("-DheadlessExecution="
+                    + System.getProperty("headlessExecution", "true"));
+            command.add("-cp");
+            command.add(classesDirectory.toAbsolutePath().normalize()
+                    + File.pathSeparator
+                    + resourcesDirectory.toAbsolutePath().normalize()
+                    + File.pathSeparator
+                    + resolvedClasspath(classesDirectory));
+            command.add("org.testng.TestNG");
+            command.add("-usedefaultlisteners");
+            command.add("false");
+            command.add("-d");
+            command.add(testngOutput.toAbsolutePath().normalize().toString());
+            command.add("-testclass");
+            command.add(fullyQualifiedClassName);
+            Process process = new ProcessBuilder(command)
+                    .directory(workDirectory.toAbsolutePath().normalize().toFile())
+                    .redirectErrorStream(true)
+                    .redirectOutput(outputLog.toFile())
+                    .start();
+            boolean finished = process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+                return failed("Generated test replay timed out.");
+            }
+            AllureSummary allure = allure(allureResults);
+            List<String> diagnostics = new ArrayList<>();
+            if (process.exitValue() != 0) {
+                diagnostics.add("TestNG replay exited with code " + process.exitValue() + ".");
+            }
+            diagnostics.addAll(allure.diagnostics());
+            boolean passed = process.exitValue() == 0 && allure.count() > 0 && allure.failed() == 0;
+            return new CaptureGenerationReport.Validation(
+                    passed
+                            ? CaptureGenerationReport.Validation.ValidationStatus.PASSED
+                            : CaptureGenerationReport.Validation.ValidationStatus.FAILED,
+                    List.copyOf(diagnostics),
+                    allure.count());
+        } catch (IOException exception) {
+            return failed("Generated test replay could not be launched.");
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            return failed("Generated test replay was interrupted.");
+        }
+    }
+
+    private static AllureSummary allure(Path directory) throws IOException {
+        int count = 0;
+        int failed = 0;
+        try (Stream<Path> files = Files.list(directory)) {
+            for (Path file : files.filter(path -> path.getFileName().toString().endsWith("-result.json")).toList()) {
+                count++;
+                JsonNode result = JSON.readTree(Files.readString(file, StandardCharsets.UTF_8));
+                if (!"passed".equalsIgnoreCase(result.path("status").asText())) {
+                    failed++;
+                }
+            }
+        }
+        List<String> diagnostics = count == 0
+                ? List.of("Replay produced no populated Allure result files.")
+                : failed == 0
+                ? List.of("Replay produced " + count + " passing Allure result file(s).")
+                : List.of("Replay produced " + failed + " non-passing Allure result file(s).");
+        return new AllureSummary(count, failed, diagnostics);
+    }
+
+    private static String diagnostic(Diagnostic<? extends JavaFileObject> diagnostic) {
+        return "line " + diagnostic.getLineNumber() + ": "
+                + diagnostic.getMessage(Locale.ROOT).replaceAll("\\s+", " ").trim();
+    }
+
+    private static CaptureGenerationReport.Validation failed(String diagnostic) {
+        return new CaptureGenerationReport.Validation(
+                CaptureGenerationReport.Validation.ValidationStatus.FAILED,
+                List.of(diagnostic),
+                0);
+    }
+
+    private static String javaCommand() {
+        return ProcessHandle.current().info().command().orElse("java");
+    }
+
+    private static String resolvedClasspath(Path classesDirectory) {
+        List<String> resolved = new ArrayList<>();
+        for (String entry : System.getProperty("java.class.path", "").split(
+                java.util.regex.Pattern.quote(File.pathSeparator))) {
+            if (entry.isBlank()) {
+                continue;
+            }
+            Path path = Path.of(entry).toAbsolutePath().normalize();
+            if (isSpringBootArchive(path)) {
+                resolved.addAll(extractSpringBootClasspath(
+                        path,
+                        classesDirectory.toAbsolutePath().normalize().getParent()
+                                .resolve("runtime-classpath")));
+            } else {
+                resolved.add(path.toString());
+            }
+        }
+        return String.join(File.pathSeparator, resolved);
+    }
+
+    private static boolean isSpringBootArchive(Path path) {
+        if (!Files.isRegularFile(path) || !path.getFileName().toString().endsWith(".jar")) {
+            return false;
+        }
+        try (JarFile jar = new JarFile(path.toFile())) {
+            return jar.getEntry("BOOT-INF/lib/") != null || jar.stream()
+                    .anyMatch(entry -> entry.getName().startsWith("BOOT-INF/lib/"));
+        } catch (IOException exception) {
+            return false;
+        }
+    }
+
+    private static synchronized List<String> extractSpringBootClasspath(Path archive, Path destination) {
+        Path classes = destination.resolve("classes").toAbsolutePath().normalize();
+        Path libraries = destination.resolve("lib").toAbsolutePath().normalize();
+        try {
+            Files.createDirectories(classes);
+            Files.createDirectories(libraries);
+            try (JarFile jar = new JarFile(archive.toFile())) {
+                for (JarEntry entry : java.util.Collections.list(jar.entries())) {
+                    if (entry.isDirectory()) {
+                        continue;
+                    }
+                    if (entry.getName().startsWith("BOOT-INF/classes/")) {
+                        Path output = classes.resolve(
+                                entry.getName().substring("BOOT-INF/classes/".length())).normalize();
+                        copyJarEntry(jar, entry, output, classes);
+                    } else if (entry.getName().startsWith("BOOT-INF/lib/")
+                            && entry.getName().endsWith(".jar")) {
+                        Path output = libraries.resolve(
+                                entry.getName().substring("BOOT-INF/lib/".length())).normalize();
+                        copyJarEntry(jar, entry, output, libraries);
+                    }
+                }
+            }
+            List<String> classpath = new ArrayList<>();
+            classpath.add(classes.toString());
+            try (Stream<Path> files = Files.list(libraries)) {
+                files.filter(Files::isRegularFile)
+                        .sorted()
+                        .map(Path::toString)
+                        .forEach(classpath::add);
+            }
+            return List.copyOf(classpath);
+        } catch (IOException exception) {
+            throw new IllegalStateException("Spring Boot runtime classpath could not be extracted.", exception);
+        }
+    }
+
+    private static void copyJarEntry(
+            JarFile jar,
+            JarEntry entry,
+            Path output,
+            Path allowedRoot) throws IOException {
+        if (!output.toAbsolutePath().normalize().startsWith(allowedRoot)) {
+            throw new IOException("Spring Boot archive entry escapes the validation directory.");
+        }
+        Files.createDirectories(output.getParent());
+        try (var input = jar.getInputStream(entry)) {
+            Files.copy(input, output, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    private record AllureSummary(int count, int failed, List<String> diagnostics) {
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/LocatorRanker.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/LocatorRanker.java
@@ -1,0 +1,189 @@
+package com.shaft.capture.generate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.shaft.capture.model.ElementSnapshot;
+import com.shaft.capture.model.EventContext;
+import com.shaft.capture.model.LocatorCandidate;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+/**
+ * Deterministically ranks captured locator evidence with explainable scoring.
+ */
+public final class LocatorRanker {
+    private static final Map<LocatorCandidate.LocatorStrategy, Integer> STRATEGY_PRIORITY = Map.of(
+            LocatorCandidate.LocatorStrategy.ROLE, 800,
+            LocatorCandidate.LocatorStrategy.ACCESSIBLE_NAME, 750,
+            LocatorCandidate.LocatorStrategy.LABEL, 700,
+            LocatorCandidate.LocatorStrategy.TEST_ID, 650,
+            LocatorCandidate.LocatorStrategy.ID, 600,
+            LocatorCandidate.LocatorStrategy.NAME, 550,
+            LocatorCandidate.LocatorStrategy.CSS, 400,
+            LocatorCandidate.LocatorStrategy.XPATH, 200);
+
+    /**
+     * Selects the strongest candidate for one captured target.
+     *
+     * @param target target evidence
+     * @param context event context
+     * @param interaction whether the event interacts with the target
+     * @return ranked selection
+     */
+    public LocatorSelection select(ElementSnapshot target, EventContext context, boolean interaction) {
+        Objects.requireNonNull(target, "target");
+        Objects.requireNonNull(context, "context");
+        if (target.locatorCandidates().isEmpty()) {
+            throw new IllegalArgumentException("Element " + target.logicalElementId()
+                    + " has no locator candidates.");
+        }
+        List<ScoredLocator> ranked = target.locatorCandidates().stream()
+                .map(candidate -> score(candidate, target, context, interaction))
+                .sorted(Comparator.comparingInt(ScoredLocator::score).reversed()
+                        .thenComparingInt(item -> -STRATEGY_PRIORITY.get(item.candidate().strategy()))
+                        .thenComparing(item -> item.candidate().strategy().name())
+                        .thenComparing(item -> item.candidate().expression()))
+                .toList();
+        return new LocatorSelection(ranked.getFirst(), ranked.subList(1, ranked.size()));
+    }
+
+    private static ScoredLocator score(
+            LocatorCandidate candidate,
+            ElementSnapshot target,
+            EventContext context,
+            boolean interaction) {
+        Map<String, Integer> components = new TreeMap<>();
+        components.put("strategy", STRATEGY_PRIORITY.get(candidate.strategy()));
+        components.put("uniqueness", uniqueness(candidate.uniquenessCount()));
+        components.put("visibility", candidate.visible() && target.visible() ? 80 : -120);
+        components.put("interactability", interaction ? (target.enabled() ? 70 : -180) : 0);
+        components.put("semanticMatch", semantic(candidate, target));
+        components.put("volatility", volatility(candidate));
+        components.put("context", context(candidate, context));
+        components.put("replay", replay(candidate, context));
+        return new ScoredLocator(candidate, components.values().stream().mapToInt(Integer::intValue).sum(),
+                components.entrySet().stream()
+                        .map(entry -> entry.getKey() + "=" + signed(entry.getValue()))
+                        .toList());
+    }
+
+    private static int uniqueness(int count) {
+        if (count == 1) {
+            return 240;
+        }
+        if (count == 0) {
+            return -240;
+        }
+        return -60 - Math.min(240, (count - 1) * 30);
+    }
+
+    private static int semantic(LocatorCandidate candidate, ElementSnapshot target) {
+        String expression = candidate.expression().toLowerCase(Locale.ROOT);
+        String name = target.accessibleName().toLowerCase(Locale.ROOT);
+        String label = target.label().toLowerCase(Locale.ROOT);
+        return switch (candidate.strategy()) {
+            case ROLE -> expression.equals(target.role() + ":" + name) ? 160 : 80;
+            case ACCESSIBLE_NAME -> expression.equals(name) ? 150 : 70;
+            case LABEL -> expression.equals(label) ? 140 : 60;
+            case TEST_ID -> hasAttributeValue(target, expression, "data-testid", "data-test", "data-qa") ? 120 : 70;
+            case ID -> expression.equals(value(target, "id")) ? 100 : 50;
+            case NAME -> expression.equals(value(target, "name")) ? 90 : 40;
+            case CSS -> 20;
+            case XPATH -> 0;
+        };
+    }
+
+    private static int volatility(LocatorCandidate candidate) {
+        int score = candidate.stable() ? 100 : -80;
+        for (LocatorCandidate.LocatorSignal signal : candidate.signals()) {
+            score += switch (signal) {
+                case USER_PROVIDED -> 260;
+                case ACCESSIBLE -> 50;
+                case LABEL_ASSOCIATED -> 40;
+                case TEST_ATTRIBUTE -> 50;
+                case STABLE_ATTRIBUTE -> 60;
+                case GENERATED -> -50;
+                case POSITIONAL -> -130;
+                case DYNAMIC_VALUE -> -240;
+            };
+        }
+        return score;
+    }
+
+    private static int context(LocatorCandidate candidate, EventContext context) {
+        int score = context.page().framePath().isEmpty() ? 20 : 0;
+        JsonNode shadowHosts = context.extensions().get("shadowHosts");
+        if (shadowHosts != null && shadowHosts.isArray() && !shadowHosts.isEmpty()) {
+            score += candidate.strategy() == LocatorCandidate.LocatorStrategy.CSS ? 50 : -80;
+        }
+        return score;
+    }
+
+    private static int replay(LocatorCandidate candidate, EventContext context) {
+        JsonNode locatorReplay = context.extensions().get("locatorReplay");
+        String value = locatorReplay != null && locatorReplay.isObject()
+                ? locatorReplay.path(candidate.expression()).asText("")
+                : context.replayStatus().name();
+        return switch (value.toUpperCase(Locale.ROOT)) {
+            case "PASSED" -> 180;
+            case "FAILED" -> -220;
+            case "SKIPPED" -> -40;
+            case "UNSUPPORTED" -> -300;
+            default -> 0;
+        };
+    }
+
+    private static boolean hasAttributeValue(ElementSnapshot target, String expression, String... names) {
+        for (String name : names) {
+            String value = value(target, name);
+            if (!value.isBlank() && expression.contains(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String value(ElementSnapshot target, String name) {
+        return target.normalizedAttributes().getOrDefault(name, "").toLowerCase(Locale.ROOT);
+    }
+
+    private static String signed(int value) {
+        return value > 0 ? "+" + value : String.valueOf(value);
+    }
+
+    /**
+     * Ranked selection and fallback candidates.
+     *
+     * @param selected selected candidate
+     * @param alternatives ranked fallback candidates
+     */
+    public record LocatorSelection(ScoredLocator selected, List<ScoredLocator> alternatives) {
+        /**
+         * Creates an immutable selection.
+         */
+        public LocatorSelection {
+            alternatives = alternatives == null ? List.of() : List.copyOf(alternatives);
+        }
+    }
+
+    /**
+     * One scored candidate.
+     *
+     * @param candidate captured candidate
+     * @param score deterministic score
+     * @param breakdown ordered score explanation
+     */
+    public record ScoredLocator(LocatorCandidate candidate, int score, List<String> breakdown) {
+        /**
+         * Creates an immutable score.
+         */
+        public ScoredLocator {
+            breakdown = breakdown == null ? List.of() : List.copyOf(new ArrayList<>(breakdown));
+        }
+    }
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratedReplayBrowserTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratedReplayBrowserTest.java
@@ -1,0 +1,174 @@
+package com.shaft.capture.generate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.shaft.capture.CaptureFixtures;
+import com.shaft.capture.format.CaptureJsonCodec;
+import com.shaft.capture.model.CaptureEvent;
+import com.shaft.capture.model.CaptureSession;
+import com.shaft.capture.model.Checkpoint;
+import com.shaft.capture.model.ElementSnapshot;
+import com.shaft.capture.model.ExternalTestDataReference;
+import com.shaft.capture.model.LocatorCandidate;
+import com.shaft.capture.model.RedactionSummary;
+import com.shaft.pilot.ai.ApprovalPolicy;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("external-e2e")
+class CaptureGeneratedReplayBrowserTest {
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    @TempDir
+    Path temp;
+
+    @Test
+    void generatedJourneyReplaysAgainstLocalPageAndPopulatesAllureResults() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", exchange -> {
+            byte[] response = """
+                    <!doctype html>
+                    <html>
+                    <body>
+                      <label for="username">Username</label>
+                      <input id="username" name="username">
+                      <button id="submit" onclick="message.textContent=username.value">Submit</button>
+                      <p id="message"></p>
+                    </body>
+                    </html>
+                    """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "text/html; charset=utf-8");
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+        server.start();
+        try {
+            String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/";
+            Path sessionPath = temp.resolve("capture.json");
+            new CaptureJsonCodec().write(sessionPath, session(url));
+            writeData();
+
+            CaptureGenerationResult result = new CaptureGenerator().generate(new CaptureGenerationRequest(
+                    sessionPath,
+                    temp.resolve("generated"),
+                    "generated.capture",
+                    "LocalReplayTest",
+                    false,
+                    true,
+                    true,
+                    Duration.ofMinutes(2),
+                    CaptureGenerationRequest.EnrichmentMode.NONE,
+                    null,
+                    false,
+                    ApprovalPolicy.denyAll()));
+
+            assertTrue(result.successful(), result.report().replay().diagnostics().toString());
+            assertEquals(CaptureGenerationReport.Validation.ValidationStatus.PASSED,
+                    result.report().replay().status());
+            assertTrue(result.report().replay().allureResultCount() > 0);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    private CaptureSession session(String url) {
+        ExternalTestDataReference username = reference("data.username", "username");
+        ExternalTestDataReference expected = reference("data.expected-message", "expected-message");
+        ElementSnapshot input = target("username", "input", "textbox", "Username");
+        ElementSnapshot button = target("submit", "button", "button", "Submit");
+        ElementSnapshot message = target("message", "p", "", "");
+        List<CaptureEvent> events = List.of(
+                new CaptureEvent.NavigationEvent(
+                        CaptureFixtures.context(1),
+                        CaptureEvent.NavigationAction.OPEN,
+                        url),
+                new CaptureEvent.TypeEvent(CaptureFixtures.context(2), input, username),
+                new CaptureEvent.ClickEvent(
+                        CaptureFixtures.context(3),
+                        button,
+                        CaptureEvent.MouseButton.PRIMARY,
+                        1),
+                new CaptureEvent.VerificationEvent(
+                        CaptureFixtures.context(4),
+                        CaptureEvent.VerificationKind.TEXT_EQUALS,
+                        message,
+                        expected,
+                        false));
+        return new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "local-replay",
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(10),
+                CaptureFixtures.browser(),
+                events,
+                List.of(new Checkpoint(
+                        "assert-message",
+                        4,
+                        CaptureFixtures.STARTED.plusSeconds(5),
+                        Checkpoint.CheckpointKind.ASSERTION,
+                        "Message equals typed value")),
+                List.of(username, expected),
+                RedactionSummary.empty(),
+                Map.of());
+    }
+
+    private static ElementSnapshot target(
+            String id,
+            String tag,
+            String role,
+            String accessibleName) {
+        return new ElementSnapshot(
+                id,
+                tag,
+                role,
+                accessibleName,
+                accessibleName,
+                Map.of("id", id),
+                List.of(new LocatorCandidate(
+                        LocatorCandidate.LocatorStrategy.ID,
+                        id,
+                        1,
+                        true,
+                        true,
+                        Set.of(LocatorCandidate.LocatorSignal.STABLE_ATTRIBUTE))),
+                true,
+                true,
+                false);
+    }
+
+    private static ExternalTestDataReference reference(String id, String logicalName) {
+        return new ExternalTestDataReference(
+                id,
+                logicalName,
+                ExternalTestDataReference.DataSource.JSON,
+                "capture-data.json",
+                "/values/" + id,
+                ExternalTestDataReference.DataClassification.ORDINARY);
+    }
+
+    private void writeData() throws Exception {
+        ObjectNode root = JSON.createObjectNode();
+        root.put("schemaVersion", "1.0");
+        ObjectNode values = root.putObject("values");
+        values.put("data.username", "Alice");
+        values.put("data.expected-message", "Alice");
+        Files.writeString(temp.resolve("capture-data.json"),
+                JSON.writerWithDefaultPrettyPrinter().writeValueAsString(root), StandardCharsets.UTF_8);
+    }
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -1,0 +1,224 @@
+package com.shaft.capture.generate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.shaft.capture.CaptureFixtures;
+import com.shaft.capture.format.CaptureJsonCodec;
+import com.shaft.capture.model.CaptureEvent;
+import com.shaft.capture.model.CaptureSession;
+import com.shaft.pilot.ai.AiResponse;
+import com.shaft.pilot.ai.AiUsage;
+import com.shaft.pilot.ai.ApprovalPolicy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CaptureGeneratorTest {
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    @TempDir
+    Path temp;
+
+    @Test
+    void representativeSessionGeneratesDeterministicCompilableSourceAndExternalData() throws Exception {
+        Path session = session(CaptureFixtures.representativeSession());
+        writeCaptureData("alice");
+
+        CaptureGenerationResult first = new CaptureGenerator().generate(request(session, temp.resolve("first")));
+        CaptureGenerationResult second = new CaptureGenerator().generate(request(session, temp.resolve("second")));
+
+        assertTrue(first.successful(), first.report().unsupportedEvents().toString());
+        assertEquals(CaptureGenerationReport.Validation.ValidationStatus.PASSED,
+                first.report().compilation().status());
+        assertEquals(Files.readString(first.sourcePath()), Files.readString(second.sourcePath()));
+        assertEquals(Files.readString(first.testDataPath()), Files.readString(second.testDataPath()));
+        assertEquals(first.report(), second.report());
+
+        String source = Files.readString(first.sourcePath());
+        String data = Files.readString(first.testDataPath());
+        String golden = Files.readString(Path.of(
+                "src/test/resources/fixtures/golden-generated-session-1.java"));
+        assertEquals(golden, source);
+        assertTrue(source.contains("@AfterMethod(alwaysRun = true)"));
+        assertTrue(source.contains("driver.quit();"));
+        assertTrue(source.contains("SHAFT.GUI.Locator.inputField(\"Username\")"));
+        assertTrue(source.contains("driver.assertThat().element(USERNAME_INPUT_LOCATOR).text()"));
+        assertFalse(source.contains("alice"));
+        assertTrue(data.contains("\"username\" : \"alice\""));
+        assertFalse(data.toLowerCase().contains("password"));
+
+    }
+
+    @Test
+    void unsupportedStepFailsWithEventIdAndRemediation() throws Exception {
+        CaptureSession base = CaptureFixtures.representativeSession();
+        CaptureEvent.ClickEvent click = (CaptureEvent.ClickEvent) base.events().get(1);
+        List<CaptureEvent> events = new java.util.ArrayList<>(base.events());
+        events.set(1, new CaptureEvent.ClickEvent(
+                click.context(), click.target(), CaptureEvent.MouseButton.SECONDARY, 1));
+        CaptureSession unsupported = new CaptureSession(
+                base.schemaVersion(), base.sessionId(), base.status(), base.startedAt(), base.endedAt(),
+                base.browser(), events, base.checkpoints(), base.dataReferences(),
+                base.redactionSummary(), base.extensions());
+        Path session = session(unsupported);
+        writeCaptureData("alice");
+
+        CaptureGenerationResult result =
+                new CaptureGenerator().generate(request(session, temp.resolve("unsupported")));
+
+        assertFalse(result.successful());
+        assertTrue(result.report().unsupportedEvents().stream()
+                .anyMatch(message -> message.contains("event-2") && message.contains("primary-button")));
+        assertFalse(Files.exists(result.sourcePath()));
+    }
+
+    @Test
+    void secretCanaryInExternalDataIsRejectedWithoutLeakingIntoReport() throws Exception {
+        Path session = session(CaptureFixtures.representativeSession());
+        String canary = "sk-secret-canary-123456789";
+        writeCaptureData(canary);
+
+        CaptureGenerationResult result =
+                new CaptureGenerator().generate(request(session, temp.resolve("secret")));
+
+        assertFalse(result.successful());
+        String report = Files.readString(result.reportPath());
+        assertFalse(report.contains(canary));
+        assertTrue(result.report().unsupportedEvents().stream()
+                .anyMatch(message -> message.startsWith("privacy:")));
+    }
+
+    @Test
+    void approvedEnrichmentIsAppliedThenRecompiled() throws Exception {
+        Path session = session(CaptureFixtures.representativeSession());
+        writeCaptureData("alice");
+        ObjectNode payload = JSON.createObjectNode();
+        payload.put("className", "EnrichedJourneyTest");
+        payload.put("methodName", "completeCheckout");
+        payload.putObject("elementNames").put("username-input", "USERNAME_FIELD");
+        payload.putArray("assertions").addObject()
+                .put("eventSequence", 2)
+                .put("verification", "ELEMENT_VISIBLE")
+                .put("negated", false);
+        CaptureEnrichmentService enrichment = new CaptureEnrichmentService(request ->
+                AiResponse.success("mock", "mock-model", payload, Duration.ZERO,
+                        AiUsage.empty(), request.deterministicFallback()));
+        CaptureGenerator generator = new CaptureGenerator(
+                new CaptureJsonCodec(), new LocatorRanker(), new GeneratedTestValidator(), enrichment);
+        Path preview = temp.resolve("preview.json");
+
+        CaptureGenerationResult previewResult = generator.generate(new CaptureGenerationRequest(
+                session, temp.resolve("preview-output"), "generated.capture", "", false,
+                true, false, Duration.ofMinutes(1),
+                CaptureGenerationRequest.EnrichmentMode.PREVIEW, preview, false,
+                new ApprovalPolicy(true, true, java.util.Set.of(com.shaft.pilot.ai.EvidenceCategory.TEXT))));
+        assertTrue(previewResult.successful());
+        assertTrue(Files.readString(preview).contains("EnrichedJourneyTest"));
+
+        CaptureGenerationResult applied = generator.generate(new CaptureGenerationRequest(
+                session, temp.resolve("applied-output"), "generated.capture", "", false,
+                true, false, Duration.ofMinutes(1),
+                CaptureGenerationRequest.EnrichmentMode.APPLY, preview, true,
+                ApprovalPolicy.denyAll()));
+
+        assertTrue(applied.successful(), applied.report().unsupportedEvents().toString());
+        assertEquals(CaptureGenerationReport.Enrichment.EnrichmentStatus.APPLIED,
+                applied.report().enrichment().status());
+        String source = Files.readString(applied.sourcePath());
+        assertTrue(source.contains("public class EnrichedJourneyTest"));
+        assertTrue(source.contains("public void completeCheckout()"));
+        assertTrue(source.contains("private static final By USERNAME_FIELD"));
+        assertTrue(source.contains("driver.assertThat().element(USERNAME_FIELD).isVisible().perform();"));
+        assertEquals(CaptureGenerationReport.Validation.ValidationStatus.PASSED,
+                applied.report().compilation().status());
+    }
+
+    @Test
+    void staleOrInvalidEnrichmentPreviewIsRejected() throws Exception {
+        Path session = session(CaptureFixtures.representativeSession());
+        writeCaptureData("alice");
+        Path preview = temp.resolve("invalid-preview.json");
+        Files.writeString(preview, """
+                {
+                  "schemaVersion": "1.0",
+                  "deterministicFingerprint": "stale",
+                  "provider": "mock",
+                  "proposal": {
+                    "className": "not-valid!",
+                    "methodName": "",
+                    "elementNames": {},
+                    "assertions": []
+                  },
+                  "diff": []
+                }
+                """, StandardCharsets.UTF_8);
+
+        CaptureGenerationResult result = new CaptureGenerator().generate(new CaptureGenerationRequest(
+                session, temp.resolve("invalid-output"), "generated.capture", "", false,
+                true, false, Duration.ofMinutes(1),
+                CaptureGenerationRequest.EnrichmentMode.APPLY, preview, true,
+                ApprovalPolicy.denyAll()));
+
+        assertFalse(result.successful());
+        assertEquals(CaptureGenerationReport.Enrichment.EnrichmentStatus.REJECTED,
+                result.report().enrichment().status());
+        assertTrue(result.report().unsupportedEvents().stream()
+                .anyMatch(message -> message.contains("does not match")));
+        assertTrue(result.report().unsupportedEvents().stream()
+                .anyMatch(message -> message.contains("not a Java identifier")));
+    }
+
+    @Test
+    void invalidProviderProposalIsRejectedBeforePreviewPersistence() {
+        ObjectNode payload = JSON.createObjectNode();
+        payload.put("className", "not-valid!");
+        payload.put("methodName", "");
+        payload.putObject("elementNames");
+        payload.putArray("assertions");
+        CaptureEnrichmentService enrichment = new CaptureEnrichmentService(request ->
+                AiResponse.success("mock", "mock-model", payload, Duration.ZERO,
+                        AiUsage.empty(), request.deterministicFallback()));
+
+        assertThrows(IllegalStateException.class, () -> enrichment.preview(
+                CaptureFixtures.representativeSession(),
+                "1234567890abcdef",
+                "Session1Test",
+                "replaySession1",
+                Map.of("username-input", "USERNAME_INPUT_LOCATOR"),
+                new ApprovalPolicy(true, true,
+                        java.util.Set.of(com.shaft.pilot.ai.EvidenceCategory.TEXT))));
+    }
+
+    private CaptureGenerationRequest request(Path session, Path output) {
+        return new CaptureGenerationRequest(
+                session, output, "generated.capture", "", false,
+                true, false, Duration.ofMinutes(1),
+                CaptureGenerationRequest.EnrichmentMode.NONE, null, false,
+                ApprovalPolicy.denyAll());
+    }
+
+    private Path session(CaptureSession captureSession) {
+        Path path = temp.resolve("capture.json");
+        new CaptureJsonCodec().write(path, captureSession);
+        return path;
+    }
+
+    private void writeCaptureData(String username) throws Exception {
+        ObjectNode root = JSON.createObjectNode();
+        root.put("schemaVersion", "1.0");
+        root.putObject("values").put("data.username", username);
+        Files.writeString(temp.resolve("capture-data.json"),
+                JSON.writerWithDefaultPrettyPrinter().writeValueAsString(root), StandardCharsets.UTF_8);
+    }
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/LocatorRankerTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/LocatorRankerTest.java
@@ -1,0 +1,105 @@
+package com.shaft.capture.generate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shaft.capture.CaptureFixtures;
+import com.shaft.capture.model.ElementSnapshot;
+import com.shaft.capture.model.EventContext;
+import com.shaft.capture.model.LocatorCandidate;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LocatorRankerTest {
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    @Test
+    void accessibilityWinsStableTieAndReportsEveryScoringDimension() {
+        ElementSnapshot target = target(List.of(
+                candidate(LocatorCandidate.LocatorStrategy.ID, "username", 1, true, true,
+                        LocatorCandidate.LocatorSignal.STABLE_ATTRIBUTE),
+                candidate(LocatorCandidate.LocatorStrategy.LABEL, "Username", 1, true, true,
+                        LocatorCandidate.LocatorSignal.ACCESSIBLE,
+                        LocatorCandidate.LocatorSignal.LABEL_ASSOCIATED)));
+
+        LocatorRanker.LocatorSelection selection =
+                new LocatorRanker().select(target, CaptureFixtures.context(1), true);
+
+        assertEquals(LocatorCandidate.LocatorStrategy.LABEL, selection.selected().candidate().strategy());
+        assertEquals(List.of("context=+20", "interactability=+70", "replay=0", "semanticMatch=+140",
+                        "strategy=+700", "uniqueness=+240", "visibility=+80", "volatility=+190"),
+                selection.selected().breakdown());
+    }
+
+    @Test
+    void userProvidedStableLocatorCanOutrankVolatileSemanticCandidate() {
+        ElementSnapshot target = target(List.of(
+                candidate(LocatorCandidate.LocatorStrategy.ROLE, "textbox:Username", 3, true, false,
+                        LocatorCandidate.LocatorSignal.DYNAMIC_VALUE),
+                candidate(LocatorCandidate.LocatorStrategy.ID, "username", 1, true, true,
+                        LocatorCandidate.LocatorSignal.USER_PROVIDED,
+                        LocatorCandidate.LocatorSignal.STABLE_ATTRIBUTE)));
+
+        LocatorRanker.LocatorSelection selection =
+                new LocatorRanker().select(target, CaptureFixtures.context(1), true);
+
+        assertEquals(LocatorCandidate.LocatorStrategy.ID, selection.selected().candidate().strategy());
+    }
+
+    @Test
+    void replayAndShadowContextAffectRankingDeterministically() {
+        var extensions = Map.<String, com.fasterxml.jackson.databind.JsonNode>of(
+                "shadowHosts", JSON.valueToTree(List.of("#host")),
+                "locatorReplay", JSON.valueToTree(Map.of(
+                        "#username", "PASSED",
+                        "//input[@name='username']", "FAILED")));
+        EventContext context = new EventContext(
+                1,
+                CaptureFixtures.STARTED,
+                new com.shaft.capture.model.PageContext(
+                        "https://example.test", "Example", "window-1", List.of("frame-1"), 100, 100),
+                EventContext.ReplayStatus.NOT_REPLAYED,
+                List.of(),
+                extensions);
+        ElementSnapshot target = target(List.of(
+                candidate(LocatorCandidate.LocatorStrategy.CSS, "#username", 1, true, true,
+                        LocatorCandidate.LocatorSignal.STABLE_ATTRIBUTE),
+                candidate(LocatorCandidate.LocatorStrategy.XPATH, "//input[@name='username']", 1, true, true,
+                        LocatorCandidate.LocatorSignal.STABLE_ATTRIBUTE)));
+
+        LocatorRanker.LocatorSelection selection = new LocatorRanker().select(target, context, true);
+
+        assertEquals(LocatorCandidate.LocatorStrategy.CSS, selection.selected().candidate().strategy());
+        assertTrue(selection.selected().breakdown().contains("context=+50"));
+        assertTrue(selection.selected().breakdown().contains("replay=+180"));
+    }
+
+    private static ElementSnapshot target(List<LocatorCandidate> candidates) {
+        return new ElementSnapshot(
+                "username",
+                "input",
+                "textbox",
+                "Username",
+                "Username",
+                Map.of("id", "username", "name", "username"),
+                new ArrayList<>(candidates),
+                true,
+                true,
+                false);
+    }
+
+    private static LocatorCandidate candidate(
+            LocatorCandidate.LocatorStrategy strategy,
+            String expression,
+            int uniqueness,
+            boolean visible,
+            boolean stable,
+            LocatorCandidate.LocatorSignal... signals) {
+        return new LocatorCandidate(strategy, expression, uniqueness, visible, stable, Set.of(signals));
+    }
+}

--- a/shaft-capture/src/test/resources/fixtures/golden-generated-session-1.java
+++ b/shaft-capture/src/test/resources/fixtures/golden-generated-session-1.java
@@ -1,0 +1,78 @@
+package generated.capture;
+
+import com.shaft.driver.DriverFactory;
+import com.shaft.driver.SHAFT;
+import com.shaft.gui.internal.locator.Role;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WindowType;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Session1Test {
+    private static final By USERNAME_INPUT_LOCATOR = SHAFT.GUI.Locator.inputField("Username");
+
+    private SHAFT.GUI.WebDriver driver;
+    private SHAFT.TestData.JSON testData;
+    private final Map<String, String> windows = new HashMap<>();
+
+    @BeforeMethod
+    public void setUp() {
+        driver = new SHAFT.GUI.WebDriver(DriverFactory.DriverType.CHROME);
+        testData = new SHAFT.TestData.JSON("session1-test.json");
+        windows.put("window-1", driver.getDriver().getWindowHandle());
+    }
+
+    @Test
+    public void replaySession1() throws Exception {
+        driver.browser().navigateToURL("https://example.test/form");
+        driver.element().click(USERNAME_INPUT_LOCATOR);
+        driver.element().type(USERNAME_INPUT_LOCATOR, requiredData("username"));
+        driver.element().clear(USERNAME_INPUT_LOCATOR);
+        driver.element().select(USERNAME_INPUT_LOCATOR, requiredData("username"));
+        if (driver.getDriver().findElement(USERNAME_INPUT_LOCATOR).isSelected() != true) {
+            driver.element().click(USERNAME_INPUT_LOCATOR);
+        }
+        if (driver.getDriver().findElement(USERNAME_INPUT_LOCATOR).isSelected() != false) {
+            driver.element().click(USERNAME_INPUT_LOCATOR);
+        }
+        driver.element().typeFileLocationForUpload(USERNAME_INPUT_LOCATOR, Path.of("src/test/resources/test-data/uploads/avatar.png").toString());
+        driver.element().typeAppend(USERNAME_INPUT_LOCATOR, Keys.chord(Keys.CONTROL, "A"));
+        driver.getDriver().switchTo().newWindow(WindowType.TAB);
+        windows.put("window-2", driver.getDriver().getWindowHandle());
+        driver.element().switchToIframe(USERNAME_INPUT_LOCATOR);
+        driver.alert().typeIntoPromptAlert(requiredData("username"));
+        driver.element().waitUntil(ExpectedConditions.visibilityOfElementLocated(USERNAME_INPUT_LOCATOR), java.time.Duration.ofSeconds(10));
+        driver.assertThat().element(USERNAME_INPUT_LOCATOR).text().isEqualTo(requiredData("username")).perform();
+        // Recorded checkpoint checkpoint-1 (ASSERTION).
+    }
+
+    private String requiredData(String key) {
+        String value = testData.getTestData("values." + key);
+        if (value == null) {
+            throw new IllegalStateException("Missing generated test data: " + key);
+        }
+        return value;
+    }
+
+    private String requiredEnvironment(String name) {
+        String value = System.getenv(name);
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException("Missing required environment variable: " + name);
+        }
+        return value;
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() {
+        if (driver != null) {
+            driver.quit();
+        }
+    }
+}

--- a/shaft-mcp/src/main/java/io/github/shafthq/SHAFT_MCP/CaptureService.java
+++ b/shaft-mcp/src/main/java/io/github/shafthq/SHAFT_MCP/CaptureService.java
@@ -1,17 +1,24 @@
 package io.github.shafthq.SHAFT_MCP;
 
+import com.shaft.capture.generate.CaptureGenerationRequest;
+import com.shaft.capture.generate.CaptureGenerationResult;
+import com.shaft.capture.generate.CaptureGenerator;
 import com.shaft.capture.runtime.CaptureBrowser;
 import com.shaft.capture.runtime.CaptureManager;
 import com.shaft.capture.runtime.CaptureStartRequest;
 import com.shaft.capture.runtime.CaptureStatus;
+import com.shaft.pilot.ai.ApprovalPolicy;
+import com.shaft.pilot.ai.EvidenceCategory;
 import jakarta.annotation.PreDestroy;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.stereotype.Service;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.EnumSet;
 
 /**
  * MCP adapter for deterministic managed-browser SHAFT Capture recording.
@@ -75,6 +82,67 @@ public class CaptureService {
             description = "stops SHAFT Capture and optionally discards the local recording")
     public CaptureStatus stop(boolean discard) {
         return manager.stop(discard);
+    }
+
+    /**
+     * Generates a deterministic SHAFT TestNG test from a persisted Capture session.
+     *
+     * @param sessionPath persisted Capture JSON path
+     * @param outputDirectory generated project root
+     * @param packageName generated Java package
+     * @param className optional generated class name
+     * @param overwrite whether existing artifacts may be replaced
+     * @param replay whether to execute the compiled generated test
+     * @param aiPreview whether to request a review-only AI proposal
+     * @param enrichmentPreviewPath preview path to write or apply
+     * @param applyEnrichment whether to apply the reviewed preview
+     * @param approveEnrichment explicit approval to apply the preview
+     * @param allowLocalAi explicit approval for local inference
+     * @param allowRemoteAi explicit approval for remote inference
+     * @return generated artifacts and validation report
+     */
+    @Tool(name = "capture_generate",
+            description = "generates, compiles, and optionally replays a deterministic SHAFT TestNG test")
+    public CaptureGenerationResult generate(
+            String sessionPath,
+            String outputDirectory,
+            String packageName,
+            String className,
+            boolean overwrite,
+            boolean replay,
+            boolean aiPreview,
+            String enrichmentPreviewPath,
+            boolean applyEnrichment,
+            boolean approveEnrichment,
+            boolean allowLocalAi,
+            boolean allowRemoteAi) {
+        Path output = outputDirectory == null || outputDirectory.isBlank()
+                ? Path.of("generated-tests")
+                : Path.of(outputDirectory);
+        Path preview = enrichmentPreviewPath == null || enrichmentPreviewPath.isBlank()
+                ? output.resolve("target/shaft-capture/enrichment-preview.json")
+                : Path.of(enrichmentPreviewPath);
+        CaptureGenerationRequest.EnrichmentMode mode = applyEnrichment
+                ? CaptureGenerationRequest.EnrichmentMode.APPLY
+                : aiPreview
+                ? CaptureGenerationRequest.EnrichmentMode.PREVIEW
+                : CaptureGenerationRequest.EnrichmentMode.NONE;
+        return new CaptureGenerator().generate(new CaptureGenerationRequest(
+                Path.of(sessionPath),
+                output,
+                packageName,
+                className,
+                overwrite,
+                true,
+                replay,
+                Duration.ofMinutes(5),
+                mode,
+                preview,
+                approveEnrichment,
+                new ApprovalPolicy(
+                        allowLocalAi,
+                        allowRemoteAi,
+                        EnumSet.of(EvidenceCategory.TEXT))));
     }
 
     /**

--- a/shaft-mcp/src/test/java/io/github/shafthq/SHAFT_MCP/ShaftMcpApplicationTests.java
+++ b/shaft-mcp/src/test/java/io/github/shafthq/SHAFT_MCP/ShaftMcpApplicationTests.java
@@ -23,7 +23,8 @@ class ShaftMcpApplicationTests {
             "element_click",
             "capture_start",
             "capture_status",
-            "capture_stop"
+            "capture_stop",
+            "capture_generate"
     );
 
     @Autowired
@@ -34,7 +35,7 @@ class ShaftMcpApplicationTests {
         Object bean = context.getBean("shaftTools");
         assertTrue(bean instanceof List<?>);
         List<?> callbacks = (List<?>) bean;
-        assertEquals(43, callbacks.size());
+        assertEquals(44, callbacks.size());
 
         Set<String> toolNames = callbacks.stream()
                 .map(ToolCallback.class::cast)


### PR DESCRIPTION
## Summary

- Add deterministic Capture-to-SHAFT Java 25/TestNG generation with external test data, privacy enforcement, explainable locator ranking, and actionable unsupported-event reports.
- Compile generated tests by default and optionally replay them in an isolated TestNG process, requiring populated passing Allure results.
- Add review-only, approval-gated AI enrichment previews that cannot replace deterministic locators and are revalidated on apply.
- Expose generation through `capture generate` and the `capture_generate` MCP tool, including packaged fat-JAR classpath support.
- Document the completed generation workflow and add golden, privacy, ranking, enrichment, MCP-registration, and real-browser replay coverage.

## Impact

Capture recordings can now produce deterministic, compilable SHAFT tests without requiring an AI provider. Sensitive values remain externalized or become required environment inputs, existing artifacts are protected unless overwrite is explicit, and generation/replay decisions are recorded in a machine-readable report.

## Validation

- All 27 non-external `shaft-capture` tests passed, with 27 populated passing Allure result files.
- `CaptureGeneratedReplayBrowserTest` passed with `includeCaptureBrowserE2E=true`.
- `ShaftMcpApplicationTests` passed with the new 44-tool registration count.
- `mvn -pl shaft-capture -am javadoc:javadoc -DskipTests -Dgpg.skip`
- `mvn clean install -DskipTests -Dgpg.skip`
- Packaged `capture generate` CLI smoke completed with compilation `PASSED`.
- `python scripts/ci/validate_agent_guidance.py`
- `python scripts/ci/validate_shaft_mcp_transports.py`
- `git diff --cached --check`

Closes #2854