### PR TITLE
[codex] Add optional AI-assisted SHAFT Doctor analysis

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,6 +29,7 @@ flowchart TB
     MCP --> Engine
     MCP --> Capture
     MCP --> Doctor
+    MCP --> AI
     PilotCore --> Engine
     Capture --> PilotCore
     Doctor --> PilotCore
@@ -47,12 +48,12 @@ flowchart TB
 | `shaft-engine`       | JAR            | Required facade and core web, mobile, API, database, CLI, reporting, and accessibility implementation.                   |
 | `shaft-pilot-core`   | JAR            | Provider-neutral Pilot contracts, consent, redaction, budgets, audit metadata, and deterministic fallback.               |
 | `shaft-capture`      | JAR            | Managed Chrome/Edge recording, deterministic privacy classification, versioned schema, and atomic JSON persistence.       |
-| `shaft-doctor`       | JAR            | Portable redacted evidence bundles, deterministic diagnosis rules, and JSON/Markdown reports.                            |
+| `shaft-doctor`       | JAR            | Portable redacted evidence bundles, deterministic diagnosis rules, and optional separately rendered provider advisory.    |
 | `shaft-ai`           | JAR            | Optional direct OpenAI, Anthropic, Gemini, and Ollama HTTP adapters discovered through `ServiceLoader`.                  |
 | `shaft-browserstack` | JAR            | BrowserStack SDK interception and `browserstack.yml` orchestration. Direct BrowserStack sessions stay in `shaft-engine`. |
 | `shaft-video`        | JAR            | Local non-headless desktop recording. Appium-native recording stays in `shaft-engine`.                                   |
 | `shaft-visual`       | JAR            | Reference-image assertions and image-based lookup through OpenCV, Eyes, and Shutterbug.                                  |
-| `SHAFT_MCP`          | executable JAR | Optional MCP server and CLI exposing browser automation, managed capture, and offline Doctor analysis.                    |
+| `SHAFT_MCP`          | executable JAR | Optional MCP server and CLI exposing browser automation, managed capture, Doctor analysis, and packaged direct adapters.  |
 | `shaft-bom`          | POM            | Aligns all SHAFT artifact versions; adds no runtime classes.                                                             |
 | `SHAFT_ENGINE`       | relocation POM | Temporary legacy-coordinate bridge to `shaft-engine`; adds no optional providers.                                        |
 

--- a/docs/MAVEN_REACTOR.md
+++ b/docs/MAVEN_REACTOR.md
@@ -11,9 +11,9 @@ relocation artifact that points consumers to the canonical JAR.
 - `shaft-bom/pom.xml` publishes the consumer BOM. Importing it manages the `shaft-engine`, `shaft-pilot-core`, `shaft-capture`, `shaft-doctor`, `shaft-ai`, `shaft-browserstack`, `shaft-video`, `shaft-visual`, and `SHAFT_MCP` versions without adding dependencies by itself.
 - `shaft-pilot-core/pom.xml` builds provider-neutral Pilot contracts, security controls, configuration snapshots, and deterministic fallback. It depends on `shaft-engine`; the engine has no reverse dependency.
 - `shaft-capture/pom.xml` builds managed Chrome/Edge recording, versioned contracts, deterministic privacy classification, Java/TestNG generation, compile/replay validation, schema migration, and atomic JSON persistence. It depends on `shaft-pilot-core` and has no dependency on `shaft-ai`.
-- `shaft-doctor/pom.xml` builds allowlisted local evidence collection, redacted portable bundles, deterministic failure rules, and JSON/Markdown reports. It depends on `shaft-pilot-core` and has no dependency on `shaft-ai`.
+- `shaft-doctor/pom.xml` builds allowlisted local evidence collection, redacted portable bundles, deterministic failure rules, JSON/Markdown reports, and provider-neutral optional advisory integration. It depends on `shaft-pilot-core` and has no dependency on `shaft-ai`.
 - `shaft-ai/pom.xml` builds optional direct OpenAI, Anthropic, Gemini, and Ollama adapters. It depends on `shaft-pilot-core` and exposes no provider SDK types.
-- `shaft-mcp/pom.xml` builds the optional executable MCP server plus SHAFT Capture and Doctor CLIs. It depends on `shaft-engine`, `shaft-capture`, and `shaft-doctor`; the engine has no reverse dependency on MCP.
+- `shaft-mcp/pom.xml` builds the optional executable MCP server plus SHAFT Capture and Doctor CLIs. It depends on `shaft-engine`, `shaft-capture`, `shaft-doctor`, and `shaft-ai` so the executable can offer explicitly configured direct-provider advisories; the engine has no reverse dependency on MCP.
 - `shaft-browserstack/pom.xml` builds the optional BrowserStack Java SDK integration. Direct BrowserStack
   WebDriver/Appium sessions remain in `shaft-engine`.
 - `shaft-video/pom.xml` builds the optional desktop video recording provider. Add it when local desktop screen recording is needed; Appium-native recording remains in `shaft-engine`.

--- a/docs/SHAFT_DOCTOR.md
+++ b/docs/SHAFT_DOCTOR.md
@@ -5,6 +5,10 @@ evidence into a portable, redacted bundle and applies ordered deterministic
 rules. It does not require `shaft-ai`, a provider credential, or network
 access. The complete baseline works with `pilot.ai.enabled=false`.
 
+Optional provider analysis is advisory only. It is disabled unless explicitly
+requested, receives only minimized already-redacted evidence, and never
+replaces the deterministic diagnosis, findings, confidence, or remediation.
+
 ## Outputs
 
 Each analysis writes:
@@ -12,7 +16,8 @@ Each analysis writes:
 - `doctor-evidence.json`: versioned `EvidenceBundle` with checksums,
   provenance, relative paths, size-limit decisions, and a redaction summary;
 - `doctor-report.json`: the bundle plus versioned `Diagnosis`, cited
-  `Finding` records, confidence, uncertainty, and `Remediation` actions;
+  `Finding` records, confidence, uncertainty, and `Remediation` actions, plus
+  a separately identified advisory when provider analysis is requested;
 - `doctor-report.md`: a portable human-readable report and evidence index;
 - `artifacts/`: approved binary evidence such as screenshots.
 
@@ -55,12 +60,75 @@ retention limits. Use `--minimum-results` when the expected run size is known;
 an empty, malformed, truncated, or unexpectedly small Allure run is reported
 as incomplete and is never interpreted as successful.
 
+## Optional provider advisory
+
+Add `shaft-ai` when invoking `DoctorAnalyzer.analyzeWithAi(...)` directly. The
+executable `SHAFT_MCP` JAR already packages the OpenAI, Anthropic, Gemini, and
+Ollama adapters. CLI provider analysis also requires `--ai`; Pilot properties
+must independently enable the provider, processing location, model, and every
+submitted evidence category.
+
+Local Ollama example:
+
+```bash
+java \
+  -Dpilot.ai.enabled=true \
+  -Dpilot.ai.provider=ollama \
+  -Dpilot.ai.consent.local=true \
+  -Dpilot.ai.allowedEvidenceCategories=TEXT,LOG,CONFIGURATION \
+  -Dpilot.ai.ollama.model=<local-model> \
+  -jar shaft-mcp/target/SHAFT_MCP-<version>.jar doctor analyze \
+  --input allure-results \
+  --allowed-root "$PWD" \
+  --output-dir target/shaft-doctor \
+  --ai
+```
+
+Ollama defaults to `http://127.0.0.1:11434/api/chat`. Changing the endpoint does
+not weaken consent, redaction, minimization, schema validation, or evidence-ID
+checks.
+
+For OpenAI, Anthropic, or Gemini, select the provider and model, approve remote
+processing, and approve the same evidence categories. Credentials remain in
+the provider-specific environment variable documented in
+[SHAFT Pilot AI](SHAFT_PILOT_AI.md); they are never Doctor arguments or report
+fields.
+
+Doctor submits the deterministic diagnosis, its explicit uncertainty, and only
+the textual evidence cited by deterministic findings. Unknown cases may submit
+the smallest available textual evidence set. Provider output must match the
+versioned `shaft-doctor-advisory-1.0` schema and may contain observations,
+hypotheses with confidence, missing evidence, recommended actions, and
+limitations. References outside the submitted evidence-ID allowlist reject the
+entire advisory. Uncited claims and hypotheses that contradict the
+deterministic primary cause are visibly marked.
+
+Timeout, rate limit, invalid credentials, unavailable provider, malformed JSON,
+schema violation, oversized output, invented evidence, and budget exhaustion
+produce an explicit fallback advisory while retaining the complete
+deterministic report. Reports contain provider/model/configuration identifiers,
+duration, usage when available, cache state, and a safe fallback reason. They
+never contain credentials, raw provider responses, or hidden reasoning.
+
+Use `--ai-cache` to explicitly cache successful safe structured advisories
+under the output directory. Cache keys include the evidence bundle checksum,
+deterministic diagnosis checksum, and a non-secret provider/configuration
+checksum. Failures and raw evidence are never cached.
+
 ## MCP
 
 `doctor_analyze` accepts explicit input paths, historical bundle paths,
 allowed roots, an output directory, screenshot/page-snapshot approvals, and
 the minimum expected Allure result count. The tool calls the same
-`DoctorAnalyzer` used by the CLI and performs no outbound request.
+`DoctorAnalyzer` used by the CLI. It remains deterministic when Pilot AI is
+disabled; when the MCP server is explicitly started with an enabled provider,
+the same separate advisory and fallback rules apply.
+
+ChatGPT, Codex, Claude, Gemini, and GitHub Copilot can invoke
+`doctor_analyze` as external MCP clients. Their model authentication stays in
+the client and is not ingested by SHAFT. Copilot is MCP interoperability, not a
+generic Copilot API-key adapter. Credential-free representative invocations
+are in `docs/examples/shaft-pilot/mcp/doctor-analyze-invocations.json`.
 
 ## Evidence
 
@@ -110,6 +178,6 @@ opt-in. Doctor never uploads evidence automatically.
 Run from the repository root:
 
 ```bash
-mvn -pl shaft-doctor,shaft-mcp -am test
+mvn -pl shaft-doctor,shaft-ai,shaft-mcp -am test
 mvn -pl shaft-doctor -am javadoc:javadoc
 ```

--- a/docs/SHAFT_MCP.md
+++ b/docs/SHAFT_MCP.md
@@ -23,8 +23,9 @@ The packaged server supports:
   `capture_stop`, with no AI provider required;
 - deterministic TestNG generation through `capture_generate`, with compile,
   optional replay, and review-only AI enrichment phases;
-- offline deterministic diagnosis through `doctor_analyze`, restricted to
-  explicit input paths and allowed roots;
+- deterministic diagnosis through `doctor_analyze`, restricted to explicit
+  input paths and allowed roots, with an optional separately identified
+  provider advisory when Pilot AI is explicitly enabled;
 - legacy SSE endpoint properties as configuration aliases during migration.
 
 The HTTP port defaults to `8081` and can be overridden with `PORT` or
@@ -49,7 +50,8 @@ privacy, generation, replay, enrichment approval, browser-support, and
 recovery details.
 
 See [SHAFT Doctor](SHAFT_DOCTOR.md) for evidence categories, allowlisted path
-handling, deterministic rules, redaction, and offline bundle analysis.
+handling, deterministic rules, redaction, offline bundle analysis, optional
+provider advisories, and safe fallback behavior.
 
 ## Authentication boundary
 
@@ -126,6 +128,10 @@ Current client references:
 
 Credential-free sample files for Codex, Claude Desktop, Gemini CLI, and VS Code
 with GitHub Copilot are under `docs/examples/shaft-pilot/mcp/`.
+`doctor-analyze-invocations.json` adds representative ChatGPT, Codex, Claude,
+Gemini, and GitHub Copilot calls to the same `doctor_analyze` tool. Client
+authentication remains outside SHAFT; Copilot is not treated as a direct
+generic API-key provider.
 
 ## Distribution identity
 

--- a/docs/SHAFT_PILOT_AI.md
+++ b/docs/SHAFT_PILOT_AI.md
@@ -16,6 +16,12 @@ access:
 validation, migration, and redaction remain deterministic with
 `pilot.ai.enabled=false`.
 
+SHAFT Doctor uses these contracts for an optional separately rendered advisory.
+It submits only minimized evidence from an already-redacted `EvidenceBundle`
+plus the deterministic diagnosis. Provider output cannot replace the baseline,
+must cite only submitted evidence IDs, and falls back safely for provider,
+budget, timeout, or validation failures. See [SHAFT Doctor](SHAFT_DOCTOR.md).
+
 ## Safe defaults
 
 AI is off unless both settings are changed:
@@ -110,7 +116,9 @@ key.
 
 Credential-free MCP configuration fixtures are under
 `docs/examples/shaft-pilot/mcp/`. See [SHAFT MCP](SHAFT_MCP.md) for transport
-and deployment details.
+and deployment details. The representative `doctor_analyze` fixture covers
+ChatGPT, Codex, Claude, Gemini, and GitHub Copilot without embedding any client
+or provider credential.
 
 Provider request mappings follow the official
 [OpenAI structured output](https://developers.openai.com/api/docs/guides/structured-outputs),

--- a/docs/examples/shaft-pilot/mcp/doctor-analyze-invocations.json
+++ b/docs/examples/shaft-pilot/mcp/doctor-analyze-invocations.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": "1.0",
+  "tool": "doctor_analyze",
+  "clients": [
+    {
+      "name": "ChatGPT",
+      "transport": "streamable-http"
+    },
+    {
+      "name": "Codex",
+      "transport": "stdio-or-streamable-http"
+    },
+    {
+      "name": "Claude",
+      "transport": "stdio-or-streamable-http"
+    },
+    {
+      "name": "Gemini",
+      "transport": "stdio"
+    },
+    {
+      "name": "GitHub Copilot",
+      "transport": "stdio-or-streamable-http"
+    }
+  ],
+  "arguments": {
+    "inputPaths": [
+      "/absolute/project/allure-results"
+    ],
+    "historicalBundlePaths": [],
+    "allowedRoots": [
+      "/absolute/project"
+    ],
+    "outputDirectory": "/absolute/project/target/shaft-doctor",
+    "includeScreenshots": false,
+    "includePageSnapshots": false,
+    "minimumAllureResults": 1
+  }
+}

--- a/scripts/ci/validate_modular_documentation.py
+++ b/scripts/ci/validate_modular_documentation.py
@@ -160,6 +160,12 @@ def main() -> None:
             fail(f"{fixture}: missing versioned SHAFT MCP command")
         if "API_KEY" in contents or "apiKey" in contents:
             fail(f"{fixture}: MCP client fixture must not request a provider API key")
+    doctor_invocations = (mcp_fixtures / "doctor-analyze-invocations.json").read_text(encoding="utf-8")
+    for term in ("doctor_analyze", "ChatGPT", "Codex", "Claude", "Gemini", "GitHub Copilot"):
+        if term not in doctor_invocations:
+            fail(f"doctor-analyze-invocations.json: missing {term!r}")
+    if "API_KEY" in doctor_invocations or "apiKey" in doctor_invocations:
+        fail("doctor-analyze-invocations.json must not request provider credentials")
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     if "maven-central/v/io.github.shafthq/SHAFT_ENGINE" in readme:
         fail("README Maven Central badge still targets the legacy coordinate")

--- a/scripts/ci/validate_shaft_mcp_configuration.py
+++ b/scripts/ci/validate_shaft_mcp_configuration.py
@@ -48,6 +48,8 @@ def validate(root: Path = ROOT) -> list[str]:
         errors.append("shaft-mcp must use the canonical in-reactor shaft-engine dependency")
     if ("shaft-doctor", "${project.version}") not in dependencies:
         errors.append("shaft-mcp must use the in-reactor shaft-doctor dependency")
+    if ("shaft-ai", "${project.version}") not in dependencies:
+        errors.append("shaft-mcp must package the in-reactor direct provider adapters")
     mcp_pom_text = (root / "shaft-mcp" / "pom.xml").read_text(encoding="utf-8")
     if "shaft_engine.version" in mcp_pom_text:
         errors.append("shaft-mcp must not define an independent SHAFT engine version")

--- a/shaft-ai/pom.xml
+++ b/shaft-ai/pom.xml
@@ -25,6 +25,12 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>shaft-doctor</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/shaft-ai/src/test/java/com/shaft/ai/provider/ProviderConformanceTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/provider/ProviderConformanceTest.java
@@ -1,10 +1,22 @@
 package com.shaft.ai.provider;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import com.shaft.driver.SHAFT;
+import com.shaft.doctor.DoctorAiAnalysisRequest;
+import com.shaft.doctor.ai.DoctorAiAnalysisService;
+import com.shaft.doctor.model.CauseCategory;
+import com.shaft.doctor.model.Confidence;
+import com.shaft.doctor.model.Diagnosis;
+import com.shaft.doctor.model.DoctorAdvisory;
+import com.shaft.doctor.model.EvidenceBundle;
+import com.shaft.doctor.model.EvidenceItem;
+import com.shaft.doctor.model.EvidenceProvenance;
+import com.shaft.doctor.model.Finding;
+import com.shaft.doctor.model.RedactionSummary;
 import com.shaft.pilot.ai.AiBudget;
 import com.shaft.pilot.ai.AiExecutionService;
 import com.shaft.pilot.ai.AiProvider;
@@ -15,8 +27,10 @@ import com.shaft.pilot.ai.AiResponseStatus;
 import com.shaft.pilot.ai.ApprovalPolicy;
 import com.shaft.pilot.ai.EvidenceCategory;
 import com.shaft.pilot.ai.ProcessingLocation;
+import com.shaft.pilot.config.PilotConfiguration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -25,8 +39,11 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
@@ -36,6 +53,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ProviderConformanceTest {
     private static final ObjectMapper JSON = new ObjectMapper();
+    @TempDir
+    Path temp;
     private HttpServer server;
 
     @AfterEach
@@ -62,6 +81,45 @@ class ProviderConformanceTest {
         assertFalse(capturedBody.get().contains("do-not-transmit"));
         assertTrue(capturedBody.get().contains("[REDACTED]"));
         assertTrue(capturedBody.get().contains("answer"));
+    }
+
+    @ParameterizedTest(name = "{0} accepts the Doctor advisory contract")
+    @MethodSource("providerIds")
+    void allProvidersPassDoctorAdvisoryConformance(String providerId) throws Exception {
+        AtomicReference<String> capturedBody = new AtomicReference<>("");
+        server = server(exchange -> {
+            capturedBody.set(readBody(exchange));
+            respond(exchange, 200, successfulResponse(providerId, doctorPayload()));
+        });
+        configure(providerId, server.getAddress().getPort());
+        boolean local = "ollama".equals(providerId);
+        ApprovalPolicy approval = new ApprovalPolicy(local, !local, EnumSet.allOf(EvidenceCategory.class));
+        AiProviderRegistry registry = new AiProviderRegistry();
+        registry.registerForCurrentThread(provider(providerId));
+        try {
+            DoctorAiAnalysisService service = new DoctorAiAnalysisService(
+                    request -> new AiExecutionService(
+                            registry,
+                            PilotConfiguration::current,
+                            event -> {
+                            }).execute(request),
+                    PilotConfiguration::current);
+
+            DoctorAdvisory advisory = service.analyze(
+                    doctorBundle(),
+                    doctorDiagnosis(),
+                    DoctorAiAnalysisRequest.defaults(approval),
+                    temp.resolve(providerId));
+
+            assertEquals(DoctorAdvisory.Status.SUCCESS, advisory.status());
+            assertEquals(providerId, advisory.metadata().provider());
+            assertEquals(List.of("evidence-1"),
+                    advisory.analysis().observations().getFirst().evidenceIds());
+            assertTrue(capturedBody.get().contains("schemaVersion"));
+            assertTrue(capturedBody.get().contains("evidence-1"));
+        } finally {
+            registry.clearForCurrentThread();
+        }
     }
 
     @ParameterizedTest(name = "{0} normalizes {1}")
@@ -151,7 +209,7 @@ class ProviderConformanceTest {
                 .provider(providerId)
                 .localConsent(local)
                 .remoteConsent(!local)
-                .allowedEvidenceCategories("TEXT")
+                .allowedEvidenceCategories("TEXT,LOG,CONFIGURATION,DOM")
                 .retryMaxAttempts(1)
                 .timeoutSeconds(1);
         String base = "http://127.0.0.1:" + port;
@@ -175,6 +233,66 @@ class ProviderConformanceTest {
                 Arguments.of(providerId, FailureCase.TIMEOUT, AiResponseStatus.TIMEOUT),
                 Arguments.of(providerId, FailureCase.MALFORMED_JSON, AiResponseStatus.INVALID_RESPONSE),
                 Arguments.of(providerId, FailureCase.SCHEMA_VIOLATION, AiResponseStatus.INVALID_RESPONSE)));
+    }
+
+    private static String doctorPayload() throws JsonProcessingException {
+        return JSON.writeValueAsString(Map.of(
+                "schemaVersion", "1.0",
+                "observations", List.of(Map.of(
+                        "statement", "The submitted exception reports a missing element.",
+                        "evidenceIds", List.of("evidence-1"))),
+                "hypotheses", List.of(Map.of(
+                        "causeCategory", "LOCATOR",
+                        "statement", "The locator likely no longer matches the intended element.",
+                        "confidence", "HIGH",
+                        "evidenceIds", List.of("evidence-1"))),
+                "missingEvidence", List.of("Current DOM snapshot"),
+                "recommendedActions", List.of(Map.of(
+                        "title", "Inspect locator",
+                        "action", "Compare the locator with the current DOM.",
+                        "evidenceIds", List.of("evidence-1"))),
+                "limitations", List.of("Only submitted evidence was analyzed.")));
+    }
+
+    private static EvidenceBundle doctorBundle() {
+        return new EvidenceBundle(
+                EvidenceBundle.CURRENT_SCHEMA_VERSION,
+                "bundle-1",
+                List.of(new EvidenceItem(
+                        "evidence-1",
+                        com.shaft.doctor.model.EvidenceCategory.EXCEPTION_CHAIN,
+                        "text/plain",
+                        "",
+                        "sha-1",
+                        50,
+                        "NoSuchElementException: unable to locate element",
+                        true,
+                        false,
+                        Map.of(),
+                        new EvidenceProvenance("fixture", "fixture/result.json", "sha-1"))),
+                new RedactionSummary(List.of(), List.of(), 0),
+                Map.of());
+    }
+
+    private static Diagnosis doctorDiagnosis() {
+        return new Diagnosis(
+                Diagnosis.CURRENT_SCHEMA_VERSION,
+                CauseCategory.LOCATOR,
+                List.of(),
+                Confidence.HIGH,
+                "Locator did not resolve an element.",
+                "The deterministic locator rule matched submitted evidence.",
+                List.of(new Finding(
+                        "finding-1",
+                        Finding.Kind.INFERENCE,
+                        CauseCategory.LOCATOR,
+                        Finding.Severity.ERROR,
+                        "Locator not found",
+                        "The locator did not resolve an element.",
+                        "locator-not-found",
+                        List.of("evidence-1"))),
+                List.of(),
+                List.of("Current DOM snapshot"));
     }
 
     private static HttpServer server(ExchangeHandler handler) throws IOException {

--- a/shaft-doctor/src/main/java/com/shaft/doctor/DoctorAiAnalysisRequest.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/DoctorAiAnalysisRequest.java
@@ -1,0 +1,92 @@
+package com.shaft.doctor;
+
+import com.shaft.pilot.ai.AiBudget;
+import com.shaft.pilot.ai.ApprovalPolicy;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+
+/**
+ * Explicit policy for one optional provider-assisted Doctor analysis.
+ *
+ * @param enabled whether provider analysis is requested
+ * @param approvalPolicy explicit processing-location and evidence-category approval
+ * @param timeout provider request timeout
+ * @param budget provider request budget
+ * @param maxEvidenceItems maximum minimized evidence items sent to the provider
+ * @param maxEvidenceBytes maximum UTF-8 bytes across submitted evidence
+ * @param maxResponseBytes maximum accepted structured provider response bytes
+ * @param cacheEnabled whether safe structured successful advisories may be cached
+ */
+public record DoctorAiAnalysisRequest(
+        boolean enabled,
+        ApprovalPolicy approvalPolicy,
+        Duration timeout,
+        AiBudget budget,
+        int maxEvidenceItems,
+        long maxEvidenceBytes,
+        long maxResponseBytes,
+        boolean cacheEnabled) {
+    /**
+     * Default maximum number of minimized evidence items.
+     */
+    public static final int DEFAULT_MAX_EVIDENCE_ITEMS = 12;
+    /**
+     * Default maximum submitted evidence size.
+     */
+    public static final long DEFAULT_MAX_EVIDENCE_BYTES = 131_072;
+    /**
+     * Default maximum structured provider response size.
+     */
+    public static final long DEFAULT_MAX_RESPONSE_BYTES = 65_536;
+
+    /**
+     * Creates a validated provider-analysis policy.
+     */
+    public DoctorAiAnalysisRequest {
+        approvalPolicy = approvalPolicy == null ? ApprovalPolicy.denyAll() : approvalPolicy;
+        timeout = timeout == null ? Duration.ofSeconds(30) : timeout;
+        budget = budget == null ? new AiBudget(8_000, 1_500, BigDecimal.ZERO) : budget;
+        if (timeout.isZero() || timeout.isNegative()) {
+            throw new IllegalArgumentException("Doctor AI timeout must be positive.");
+        }
+        if (maxEvidenceItems <= 0 || maxEvidenceBytes <= 0 || maxResponseBytes <= 0) {
+            throw new IllegalArgumentException("Doctor AI evidence and response limits must be positive.");
+        }
+    }
+
+    /**
+     * Creates conservative enabled defaults.
+     *
+     * @param approvalPolicy explicit provider approval
+     * @return enabled provider-analysis request
+     */
+    public static DoctorAiAnalysisRequest defaults(ApprovalPolicy approvalPolicy) {
+        return new DoctorAiAnalysisRequest(
+                true,
+                approvalPolicy,
+                Duration.ofSeconds(30),
+                new AiBudget(8_000, 1_500, BigDecimal.ZERO),
+                DEFAULT_MAX_EVIDENCE_ITEMS,
+                DEFAULT_MAX_EVIDENCE_BYTES,
+                DEFAULT_MAX_RESPONSE_BYTES,
+                false);
+    }
+
+    /**
+     * Creates a disabled request that preserves deterministic output.
+     *
+     * @return disabled request
+     */
+    public static DoctorAiAnalysisRequest disabled() {
+        return new DoctorAiAnalysisRequest(
+                false,
+                ApprovalPolicy.denyAll(),
+                Duration.ofSeconds(30),
+                new AiBudget(0, 0, BigDecimal.ZERO),
+                DEFAULT_MAX_EVIDENCE_ITEMS,
+                DEFAULT_MAX_EVIDENCE_BYTES,
+                DEFAULT_MAX_RESPONSE_BYTES,
+                false);
+    }
+}

--- a/shaft-doctor/src/main/java/com/shaft/doctor/DoctorAnalyzer.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/DoctorAnalyzer.java
@@ -1,9 +1,12 @@
 package com.shaft.doctor;
 
+import com.shaft.doctor.ai.DoctorAiAnalysisService;
 import com.shaft.doctor.analysis.DeterministicRuleEngine;
 import com.shaft.doctor.collect.EvidenceCollector;
 import com.shaft.doctor.format.DoctorJsonCodec;
 import com.shaft.doctor.model.Diagnosis;
+import com.shaft.doctor.model.DoctorAdvisory;
+import com.shaft.doctor.model.DoctorAiAnalysisResult;
 import com.shaft.doctor.model.DoctorAnalysisResult;
 import com.shaft.doctor.model.EvidenceBundle;
 import com.shaft.doctor.report.DoctorReportWriter;
@@ -22,13 +25,14 @@ public final class DoctorAnalyzer {
     private final DeterministicRuleEngine rules;
     private final DoctorJsonCodec codec;
     private final DoctorReportWriter reports;
+    private final DoctorAiAnalysisService aiAnalysis;
 
     /**
      * Creates the default analyzer.
      */
     public DoctorAnalyzer() {
         this(new EvidenceCollector(), new DeterministicRuleEngine(),
-                new DoctorJsonCodec(), new DoctorReportWriter());
+                new DoctorJsonCodec(), new DoctorReportWriter(), new DoctorAiAnalysisService());
     }
 
     DoctorAnalyzer(
@@ -36,10 +40,20 @@ public final class DoctorAnalyzer {
             DeterministicRuleEngine rules,
             DoctorJsonCodec codec,
             DoctorReportWriter reports) {
+        this(collector, rules, codec, reports, new DoctorAiAnalysisService());
+    }
+
+    DoctorAnalyzer(
+            EvidenceCollector collector,
+            DeterministicRuleEngine rules,
+            DoctorJsonCodec codec,
+            DoctorReportWriter reports,
+            DoctorAiAnalysisService aiAnalysis) {
         this.collector = collector;
         this.rules = rules;
         this.codec = codec;
         this.reports = reports;
+        this.aiAnalysis = aiAnalysis;
     }
 
     /**
@@ -65,6 +79,45 @@ public final class DoctorAnalyzer {
                 bundlePath.toString(),
                 jsonReportPath.toString(),
                 markdownReportPath.toString());
+    }
+
+    /**
+     * Runs deterministic analysis first, then optionally appends a separate provider advisory.
+     *
+     * <p>The deterministic diagnosis is never replaced or rewritten. A disabled request
+     * delegates to {@link #analyze(DoctorAnalysisRequest)} without changing report bytes.</p>
+     *
+     * @param request explicit local analysis policy
+     * @param aiRequest explicit provider-analysis policy
+     * @return deterministic result and separately identified advisory
+     */
+    public DoctorAiAnalysisResult analyzeWithAi(
+            DoctorAnalysisRequest request,
+            DoctorAiAnalysisRequest aiRequest) {
+        DoctorAiAnalysisRequest resolvedAiRequest =
+                aiRequest == null ? DoctorAiAnalysisRequest.disabled() : aiRequest;
+        DoctorAnalysisResult deterministic = analyze(request);
+        if (!resolvedAiRequest.enabled()) {
+            return new DoctorAiAnalysisResult(deterministic, DoctorAdvisory.disabled());
+        }
+
+        Path output = Path.of(deterministic.jsonReportPath()).toAbsolutePath().normalize().getParent();
+        DoctorAdvisory advisory = aiAnalysis.analyze(
+                deterministic.bundle(),
+                deterministic.diagnosis(),
+                resolvedAiRequest,
+                output);
+        codec.writeReport(
+                Path.of(deterministic.jsonReportPath()),
+                deterministic.bundle(),
+                deterministic.diagnosis(),
+                advisory);
+        reports.writeMarkdown(
+                Path.of(deterministic.markdownReportPath()),
+                deterministic.bundle(),
+                deterministic.diagnosis(),
+                advisory);
+        return new DoctorAiAnalysisResult(deterministic, advisory);
     }
 
     private static DoctorAnalysisRequest resolveOutputBoundary(DoctorAnalysisRequest request) {

--- a/shaft-doctor/src/main/java/com/shaft/doctor/ai/DoctorAiAnalysisService.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/ai/DoctorAiAnalysisService.java
@@ -1,0 +1,661 @@
+package com.shaft.doctor.ai;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.shaft.doctor.DoctorAiAnalysisRequest;
+import com.shaft.doctor.format.DoctorFormatException;
+import com.shaft.doctor.format.DoctorJsonCodec;
+import com.shaft.doctor.internal.DoctorHashing;
+import com.shaft.doctor.internal.DoctorRedactor;
+import com.shaft.doctor.model.CauseCategory;
+import com.shaft.doctor.model.Confidence;
+import com.shaft.doctor.model.Diagnosis;
+import com.shaft.doctor.model.DoctorAdvisory;
+import com.shaft.doctor.model.EvidenceBundle;
+import com.shaft.doctor.model.EvidenceItem;
+import com.shaft.pilot.ai.AiExecutionService;
+import com.shaft.pilot.ai.AiRequest;
+import com.shaft.pilot.ai.AiResponse;
+import com.shaft.pilot.ai.AiResponseStatus;
+import com.shaft.pilot.ai.AiUsage;
+import com.shaft.pilot.ai.EvidenceReference;
+import com.shaft.pilot.config.PilotConfiguration;
+import com.shaft.pilot.json.JsonSchemaValidator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Builds minimized Doctor provider requests and validates separately rendered advisories.
+ */
+public final class DoctorAiAnalysisService {
+    private static final String SCHEMA_RESOURCE = "/schema/shaft-doctor-advisory-1.0.schema.json";
+    private static final int MAX_TEXT_LENGTH = 2_000;
+    private static final ObjectMapper JSON = new ObjectMapper()
+            .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
+    private static final JsonNode RESPONSE_SCHEMA = loadSchema();
+
+    private final Function<AiRequest, AiResponse> executor;
+    private final Supplier<PilotConfiguration> configurationSupplier;
+
+    /**
+     * Creates a service using current SHAFT properties and the shared provider registry.
+     */
+    public DoctorAiAnalysisService() {
+        this(new AiExecutionService()::execute, PilotConfiguration::current);
+    }
+
+    /**
+     * Creates a service with injectable execution and configuration boundaries.
+     *
+     * @param executor provider execution function
+     * @param configurationSupplier effective configuration supplier
+     */
+    public DoctorAiAnalysisService(
+            Function<AiRequest, AiResponse> executor,
+            Supplier<PilotConfiguration> configurationSupplier) {
+        this.executor = Objects.requireNonNull(executor, "executor");
+        this.configurationSupplier = Objects.requireNonNull(configurationSupplier, "configurationSupplier");
+    }
+
+    /**
+     * Produces an optional advisory without changing deterministic diagnosis fields.
+     *
+     * @param bundle already-redacted deterministic evidence bundle
+     * @param diagnosis deterministic diagnosis
+     * @param request explicit provider policy
+     * @param outputDirectory Doctor report output directory
+     * @return validated advisory or safe fallback notice
+     */
+    public DoctorAdvisory analyze(
+            EvidenceBundle bundle,
+            Diagnosis diagnosis,
+            DoctorAiAnalysisRequest request,
+            Path outputDirectory) {
+        Objects.requireNonNull(bundle, "bundle");
+        Objects.requireNonNull(diagnosis, "diagnosis");
+        Objects.requireNonNull(request, "request");
+        Objects.requireNonNull(outputDirectory, "outputDirectory");
+        if (!request.enabled()) {
+            return DoctorAdvisory.disabled();
+        }
+
+        ConfigurationIdentity identity = configurationIdentity(request);
+        List<EvidenceReference> evidence = minimize(bundle, diagnosis, request);
+        Set<com.shaft.pilot.ai.EvidenceCategory> requestedCategories =
+                EnumSet.of(com.shaft.pilot.ai.EvidenceCategory.TEXT);
+        evidence.forEach(item -> requestedCategories.add(item.category()));
+        if (!request.approvalPolicy().allowedEvidenceCategories().containsAll(requestedCategories)) {
+            return fallback(AiResponseStatus.CONSENT_REQUIRED, identity.provider(), identity.model(),
+                    identity.identifier(), Duration.ZERO, AiUsage.empty(),
+                    "Explicit consent is required for every minimized evidence category.", List.of());
+        }
+
+        String cacheKey = cacheKey(bundle, diagnosis, request, identity);
+        Path cachePath = safeCachePath(outputDirectory, cacheKey);
+        boolean ignoredCacheEntry = request.cacheEnabled() && cachePath == null;
+        if (request.cacheEnabled() && cachePath != null && Files.isRegularFile(cachePath)) {
+            try {
+                DoctorAdvisory cached = JSON.readValue(cachePath.toFile(), DoctorAdvisory.class);
+                validateCached(cached, evidence, identity);
+                return new DoctorAdvisory(cached.schemaVersion(), cached.status(), cached.analysis(),
+                        cached.metadata().asCacheHit());
+            } catch (IOException | RuntimeException ignored) {
+                ignoredCacheEntry = true;
+            }
+        }
+
+        AiRequest providerRequest = providerRequest(bundle, diagnosis, request, evidence, identity);
+        AiResponse response;
+        try {
+            response = executor.apply(providerRequest);
+        } catch (RuntimeException exception) {
+            return fallback(AiResponseStatus.ERROR, identity.provider(), identity.model(),
+                    identity.identifier(), Duration.ZERO, AiUsage.empty(),
+                    "Provider execution failed.", cacheWarning(ignoredCacheEntry));
+        }
+        if (response == null) {
+            return fallback(AiResponseStatus.ERROR, identity.provider(), identity.model(),
+                    identity.identifier(), Duration.ZERO, AiUsage.empty(),
+                    "Provider did not return a result.", cacheWarning(ignoredCacheEntry));
+        }
+        if (!response.successful()) {
+            return fallback(response.status(), safe(response.provider()), safe(response.model()),
+                    identity.identifier(), response.duration(), response.usage(),
+                    safeFallbackReason(response.fallbackReason()),
+                    responseWarnings(response, ignoredCacheEntry));
+        }
+
+        try {
+            byte[] responseBytes = JSON.writeValueAsBytes(response.structuredPayload());
+            if (responseBytes.length > request.maxResponseBytes()) {
+                return fallback(AiResponseStatus.INVALID_RESPONSE, safe(response.provider()), safe(response.model()),
+                        identity.identifier(), response.duration(), response.usage(),
+                        "Provider output exceeded the Doctor response size limit.",
+                        cacheWarning(ignoredCacheEntry));
+            }
+            List<String> schemaErrors = JsonSchemaValidator.validate(RESPONSE_SCHEMA, response.structuredPayload());
+            if (!schemaErrors.isEmpty()) {
+                return fallback(AiResponseStatus.INVALID_RESPONSE, safe(response.provider()), safe(response.model()),
+                        identity.identifier(), response.duration(), response.usage(),
+                        "Provider output did not match the Doctor advisory schema.",
+                        cacheWarning(ignoredCacheEntry));
+            }
+
+            DoctorRedactor redactor = new DoctorRedactor();
+            JsonNode sanitized = redactor.redact(response.structuredPayload());
+            List<String> warnings = new ArrayList<>(responseWarnings(response, ignoredCacheEntry));
+            if (!sanitized.equals(response.structuredPayload())) {
+                warnings.add("Sensitive-looking provider text was redacted before advisory rendering.");
+            }
+            DoctorAdvisory.ProviderAnalysis analysis =
+                    parse(sanitized, evidence, diagnosis, warnings);
+            DoctorAdvisory advisory = new DoctorAdvisory(
+                    DoctorAdvisory.CURRENT_SCHEMA_VERSION,
+                    DoctorAdvisory.Status.SUCCESS,
+                    analysis,
+                    new DoctorAdvisory.Metadata(
+                            AiResponseStatus.SUCCESS,
+                            safe(response.provider()),
+                            safe(response.model()),
+                            identity.identifier(),
+                            millis(response.duration()),
+                            response.usage(),
+                            "",
+                            false,
+                            warnings));
+            if (request.cacheEnabled() && cachePath != null) {
+                writeCache(cachePath, advisory);
+            }
+            return advisory;
+        } catch (JsonProcessingException | IllegalArgumentException exception) {
+            return fallback(AiResponseStatus.INVALID_RESPONSE, safe(response.provider()), safe(response.model()),
+                    identity.identifier(), response.duration(), response.usage(),
+                    "Provider output failed Doctor advisory validation.", cacheWarning(ignoredCacheEntry));
+        }
+    }
+
+    private static AiRequest providerRequest(
+            EvidenceBundle bundle,
+            Diagnosis diagnosis,
+            DoctorAiAnalysisRequest request,
+            List<EvidenceReference> evidence,
+            ConfigurationIdentity identity) {
+        ObjectNode fallback = JSON.createObjectNode();
+        fallback.put("schemaVersion", DoctorAdvisory.ProviderAnalysis.CURRENT_SCHEMA_VERSION);
+        fallback.putArray("observations");
+        fallback.putArray("hypotheses");
+        fallback.putArray("missingEvidence");
+        fallback.putArray("recommendedActions");
+        fallback.putArray("limitations");
+
+        AiRequest.Builder builder = AiRequest.builder("shaft-doctor-advisory", RESPONSE_SCHEMA)
+                .requestId("doctor-advisory-" + shortValue(bundle.bundleId())
+                        + "-" + shortValue(identity.identifier()))
+                .text(prompt(diagnosis))
+                .timeout(request.timeout())
+                .budget(request.budget())
+                .approvalPolicy(request.approvalPolicy())
+                .deterministicFallback(fallback);
+        evidence.forEach(builder::evidence);
+        return builder.build();
+    }
+
+    private static String prompt(Diagnosis diagnosis) {
+        return """
+                Analyze only the submitted redacted evidence and deterministic SHAFT Doctor diagnosis.
+                Return conclusions in the requested JSON schema. Do not include chain-of-thought, hidden reasoning,
+                credentials, patches, test-status changes, or evidence IDs that were not submitted.
+                The deterministic diagnosis remains authoritative; identify uncertainty and contradictions explicitly.
+
+                Deterministic diagnosis:
+                """ + new DoctorJsonCodec().write(diagnosis);
+    }
+
+    private static List<EvidenceReference> minimize(
+            EvidenceBundle bundle,
+            Diagnosis diagnosis,
+            DoctorAiAnalysisRequest request) {
+        Set<String> citedIds = new LinkedHashSet<>();
+        diagnosis.findings().forEach(finding -> citedIds.addAll(finding.evidenceIds()));
+        List<EvidenceItem> candidates = bundle.evidence().stream()
+                .filter(item -> item.content() != null && !item.content().isBlank())
+                .filter(item -> citedIds.isEmpty() || citedIds.contains(item.id()))
+                .sorted(Comparator.comparingInt(item -> evidencePriority(item.category())))
+                .toList();
+
+        List<EvidenceReference> selected = new ArrayList<>();
+        long retainedBytes = 0;
+        for (EvidenceItem item : candidates) {
+            if (selected.size() >= request.maxEvidenceItems() || retainedBytes >= request.maxEvidenceBytes()) {
+                break;
+            }
+            long remaining = request.maxEvidenceBytes() - retainedBytes;
+            String content = boundedUtf8(item.content(), remaining);
+            if (content.isBlank()) {
+                continue;
+            }
+            selected.add(new EvidenceReference(
+                    item.id(),
+                    providerCategory(item.category()),
+                    item.mediaType(),
+                    content));
+            retainedBytes += content.getBytes(StandardCharsets.UTF_8).length;
+        }
+        return List.copyOf(selected);
+    }
+
+    private static DoctorAdvisory.ProviderAnalysis parse(
+            JsonNode payload,
+            List<EvidenceReference> submittedEvidence,
+            Diagnosis diagnosis,
+            List<String> warnings) {
+        Set<String> allowedIds = submittedEvidence.stream()
+                .map(EvidenceReference::id)
+                .collect(java.util.stream.Collectors.toUnmodifiableSet());
+        String schemaVersion = safeText(payload.path("schemaVersion").asText(), "schema version");
+        if (!DoctorAdvisory.ProviderAnalysis.CURRENT_SCHEMA_VERSION.equals(schemaVersion)) {
+            throw new IllegalArgumentException("Unsupported advisory schema version.");
+        }
+
+        List<DoctorAdvisory.Observation> observations = new ArrayList<>();
+        for (JsonNode item : payload.path("observations")) {
+            List<String> evidenceIds = evidenceIds(item.path("evidenceIds"), allowedIds);
+            boolean cited = !evidenceIds.isEmpty();
+            if (!cited) {
+                warnings.add("Provider observation is uncited.");
+            }
+            observations.add(new DoctorAdvisory.Observation(
+                    safeText(item.path("statement").asText(), "observation"),
+                    evidenceIds,
+                    cited));
+        }
+
+        List<DoctorAdvisory.Hypothesis> hypotheses = new ArrayList<>();
+        for (JsonNode item : payload.path("hypotheses")) {
+            CauseCategory category = CauseCategory.valueOf(item.path("causeCategory").asText());
+            Confidence confidence = Confidence.valueOf(item.path("confidence").asText());
+            List<String> evidenceIds = evidenceIds(item.path("evidenceIds"), allowedIds);
+            boolean cited = !evidenceIds.isEmpty();
+            boolean contradicts = contradicts(diagnosis, category);
+            if (!cited) {
+                warnings.add("Provider hypothesis is uncited.");
+            }
+            if (contradicts) {
+                warnings.add("Provider hypothesis contradicts the deterministic primary cause.");
+            }
+            hypotheses.add(new DoctorAdvisory.Hypothesis(
+                    category,
+                    safeText(item.path("statement").asText(), "hypothesis"),
+                    confidence,
+                    evidenceIds,
+                    cited,
+                    contradicts));
+        }
+
+        List<DoctorAdvisory.RecommendedAction> actions = new ArrayList<>();
+        for (JsonNode item : payload.path("recommendedActions")) {
+            List<String> evidenceIds = evidenceIds(item.path("evidenceIds"), allowedIds);
+            boolean cited = !evidenceIds.isEmpty();
+            if (!cited) {
+                warnings.add("Provider recommended action is uncited.");
+            }
+            actions.add(new DoctorAdvisory.RecommendedAction(
+                    safeText(item.path("title").asText(), "action title"),
+                    safeText(item.path("action").asText(), "action"),
+                    evidenceIds,
+                    cited));
+        }
+
+        return new DoctorAdvisory.ProviderAnalysis(
+                schemaVersion,
+                observations,
+                hypotheses,
+                textList(payload.path("missingEvidence"), "missing evidence"),
+                actions,
+                textList(payload.path("limitations"), "limitation"));
+    }
+
+    private static List<String> evidenceIds(JsonNode values, Set<String> allowedIds) {
+        LinkedHashSet<String> references = new LinkedHashSet<>();
+        for (JsonNode value : values) {
+            String id = safeText(value.asText(), "evidence ID");
+            if (!allowedIds.contains(id)) {
+                throw new IllegalArgumentException("Provider referenced evidence that was not submitted.");
+            }
+            references.add(id);
+        }
+        return List.copyOf(references);
+    }
+
+    private static List<String> textList(JsonNode values, String label) {
+        List<String> result = new ArrayList<>();
+        for (JsonNode value : values) {
+            result.add(safeText(value.asText(), label));
+        }
+        return List.copyOf(result);
+    }
+
+    private static String safeText(String value, String label) {
+        String normalized = value == null ? "" : value.trim();
+        if (normalized.isEmpty() || normalized.length() > MAX_TEXT_LENGTH) {
+            throw new IllegalArgumentException("Provider " + label + " is empty or oversized.");
+        }
+        for (int index = 0; index < normalized.length(); index++) {
+            char character = normalized.charAt(index);
+            if (Character.isISOControl(character) && character != '\n'
+                    && character != '\r' && character != '\t') {
+                throw new IllegalArgumentException("Provider " + label + " contains unsafe control text.");
+            }
+        }
+        return normalized;
+    }
+
+    private ConfigurationIdentity configurationIdentity(DoctorAiAnalysisRequest request) {
+        String provider = "none";
+        String model = "";
+        String effectiveConfiguration = "invalid";
+        try {
+            PilotConfiguration configuration = configurationSupplier.get();
+            provider = safe(configuration.provider());
+            String globalCategories = configuration.approvalPolicy().allowedEvidenceCategories().stream()
+                    .map(Enum::name)
+                    .sorted()
+                    .collect(java.util.stream.Collectors.joining(","));
+            if (!provider.isBlank() && !"none".equals(provider)) {
+                var providerConfiguration = configuration.provider(provider);
+                model = safe(providerConfiguration.model());
+                effectiveConfiguration = configuration.enabled() + "\n"
+                        + configuration.approvalPolicy().localInferenceAllowed() + "\n"
+                        + configuration.approvalPolicy().remoteInferenceAllowed() + "\n"
+                        + globalCategories + "\n"
+                        + configuration.timeout() + "\n"
+                        + configuration.maxRequestBytes() + "\n"
+                        + configuration.maxInputTokens() + "\n"
+                        + configuration.maxOutputTokens() + "\n"
+                        + configuration.maxCostUsd() + "\n"
+                        + configuration.retryMaxAttempts() + "\n"
+                        + configuration.maxConcurrency() + "\n"
+                        + providerConfiguration.endpoint() + "\n"
+                        + new java.util.TreeMap<>(providerConfiguration.options());
+            } else {
+                effectiveConfiguration = configuration.enabled() + "\n"
+                        + configuration.approvalPolicy().localInferenceAllowed() + "\n"
+                        + configuration.approvalPolicy().remoteInferenceAllowed() + "\n"
+                        + globalCategories;
+            }
+        } catch (RuntimeException ignored) {
+            provider = "none";
+            model = "";
+        }
+        String categories = request.approvalPolicy().allowedEvidenceCategories().stream()
+                .map(Enum::name)
+                .sorted()
+                .collect(java.util.stream.Collectors.joining(","));
+        String source = provider + "\n" + model + "\n" + effectiveConfiguration + "\n"
+                + request.approvalPolicy().localInferenceAllowed() + "\n"
+                + request.approvalPolicy().remoteInferenceAllowed() + "\n"
+                + request.timeout() + "\n"
+                + request.budget() + "\n" + categories + "\n"
+                + request.maxEvidenceItems() + "\n" + request.maxEvidenceBytes() + "\n"
+                + request.maxResponseBytes();
+        return new ConfigurationIdentity(provider, model,
+                DoctorHashing.sha256(source.getBytes(StandardCharsets.UTF_8)).substring(0, 16));
+    }
+
+    private static String cacheKey(
+            EvidenceBundle bundle,
+            Diagnosis diagnosis,
+            DoctorAiAnalysisRequest request,
+            ConfigurationIdentity identity) {
+        String source = bundle.bundleId() + "\n"
+                + DoctorHashing.sha256(new DoctorJsonCodec().write(diagnosis).getBytes(StandardCharsets.UTF_8)) + "\n"
+                + identity.identifier() + "\n"
+                + request.maxEvidenceItems() + "\n"
+                + request.maxEvidenceBytes() + "\n"
+                + request.maxResponseBytes();
+        return DoctorHashing.sha256(source.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static void validateCached(
+            DoctorAdvisory advisory,
+            List<EvidenceReference> submittedEvidence,
+            ConfigurationIdentity identity) {
+        if (advisory.status() != DoctorAdvisory.Status.SUCCESS
+                || advisory.metadata().providerStatus() != AiResponseStatus.SUCCESS
+                || !identity.identifier().equals(advisory.metadata().configurationIdentifier())
+                || !identity.provider().equals(advisory.metadata().provider())
+                || !DoctorAdvisory.ProviderAnalysis.CURRENT_SCHEMA_VERSION
+                .equals(advisory.analysis().schemaVersion())) {
+            throw new IllegalArgumentException("Cached advisory metadata is not valid.");
+        }
+        Set<String> allowedIds = submittedEvidence.stream().map(EvidenceReference::id)
+                .collect(java.util.stream.Collectors.toUnmodifiableSet());
+        advisory.analysis().observations().forEach(value -> {
+            safeText(value.statement(), "cached observation");
+            validateCachedIds(value.evidenceIds(), allowedIds);
+        });
+        advisory.analysis().hypotheses().forEach(value -> {
+            safeText(value.statement(), "cached hypothesis");
+            validateCachedIds(value.evidenceIds(), allowedIds);
+        });
+        advisory.analysis().recommendedActions().forEach(value -> {
+            safeText(value.title(), "cached action title");
+            safeText(value.action(), "cached action");
+            validateCachedIds(value.evidenceIds(), allowedIds);
+        });
+        advisory.analysis().missingEvidence().forEach(value -> safeText(value, "cached missing evidence"));
+        advisory.analysis().limitations().forEach(value -> safeText(value, "cached limitation"));
+        safeOptionalText(advisory.metadata().provider(), "cached provider");
+        safeOptionalText(advisory.metadata().model(), "cached model");
+        safeOptionalText(advisory.metadata().configurationIdentifier(), "cached configuration identifier");
+        safeOptionalText(advisory.metadata().fallbackReason(), "cached fallback reason");
+        advisory.metadata().warnings().forEach(value -> safeText(value, "cached warning"));
+        JsonNode cachedTree = JSON.valueToTree(advisory);
+        if (!new DoctorRedactor().redact(cachedTree).equals(cachedTree)) {
+            throw new IllegalArgumentException("Cached advisory contains sensitive-looking text.");
+        }
+    }
+
+    private static void validateCachedIds(List<String> values, Set<String> allowedIds) {
+        if (!allowedIds.containsAll(values)) {
+            throw new IllegalArgumentException("Cached advisory references unknown evidence.");
+        }
+    }
+
+    private static void writeCache(Path path, DoctorAdvisory advisory) {
+        Path temporary = null;
+        try {
+            Files.createDirectories(path.getParent());
+            temporary = Files.createTempFile(path.getParent(), ".doctor-ai-", ".tmp");
+            Files.writeString(temporary,
+                    JSON.writerWithDefaultPrettyPrinter().writeValueAsString(advisory) + "\n",
+                    StandardCharsets.UTF_8);
+            Files.move(temporary, path, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException ignored) {
+            // Cache persistence is optional and must never fail Doctor analysis.
+        } finally {
+            if (temporary != null) {
+                try {
+                    Files.deleteIfExists(temporary);
+                } catch (IOException ignored) {
+                    // Best-effort cleanup of an unpublished cache entry.
+                }
+            }
+        }
+    }
+
+    private static DoctorAdvisory fallback(
+            AiResponseStatus status,
+            String provider,
+            String model,
+            String configurationIdentifier,
+            Duration duration,
+            AiUsage usage,
+            String reason,
+            List<String> warnings) {
+        return new DoctorAdvisory(
+                DoctorAdvisory.CURRENT_SCHEMA_VERSION,
+                DoctorAdvisory.Status.FALLBACK,
+                DoctorAdvisory.ProviderAnalysis.empty(),
+                new DoctorAdvisory.Metadata(
+                        status,
+                        safe(provider),
+                        safe(model),
+                        safe(configurationIdentifier),
+                        millis(duration),
+                        usage,
+                        safeFallbackReason(reason),
+                        false,
+                        warnings));
+    }
+
+    private static List<String> cacheWarning(boolean ignoredCacheEntry) {
+        return ignoredCacheEntry
+                ? List.of("An invalid safe advisory cache entry was ignored.")
+                : List.of();
+    }
+
+    private static List<String> responseWarnings(AiResponse response, boolean ignoredCacheEntry) {
+        List<String> warnings = new ArrayList<>(cacheWarning(ignoredCacheEntry));
+        for (String warning : response.warnings()) {
+            String sanitized = new DoctorRedactor().redact(warning);
+            if (!sanitized.isBlank() && sanitized.length() <= MAX_TEXT_LENGTH) {
+                warnings.add(sanitized);
+            }
+        }
+        return List.copyOf(warnings);
+    }
+
+    private static String safeFallbackReason(String reason) {
+        String sanitized = new DoctorRedactor().redact(reason);
+        if (sanitized.isBlank()) {
+            return "Provider analysis was unavailable; the deterministic diagnosis was retained.";
+        }
+        return sanitized.length() <= MAX_TEXT_LENGTH
+                ? sanitized
+                : "Provider analysis was unavailable; the deterministic diagnosis was retained.";
+    }
+
+    private static String safe(String value) {
+        String sanitized = new DoctorRedactor().redact(value);
+        return sanitized.length() <= MAX_TEXT_LENGTH ? sanitized : "";
+    }
+
+    private static String safeOptionalText(String value, String label) {
+        String normalized = value == null ? "" : value.trim();
+        if (normalized.length() > MAX_TEXT_LENGTH) {
+            throw new IllegalArgumentException("Provider " + label + " is oversized.");
+        }
+        for (int index = 0; index < normalized.length(); index++) {
+            char character = normalized.charAt(index);
+            if (Character.isISOControl(character) && character != '\n'
+                    && character != '\r' && character != '\t') {
+                throw new IllegalArgumentException("Provider " + label + " contains unsafe control text.");
+            }
+        }
+        return normalized;
+    }
+
+    private static boolean contradicts(Diagnosis diagnosis, CauseCategory category) {
+        return diagnosis.primaryCause() != CauseCategory.UNKNOWN
+                && category != CauseCategory.UNKNOWN
+                && category != diagnosis.primaryCause()
+                && !diagnosis.contributingCauses().contains(category);
+    }
+
+    private static int evidencePriority(com.shaft.doctor.model.EvidenceCategory category) {
+        return switch (category) {
+            case EXCEPTION_CHAIN -> 0;
+            case SHAFT_LOG -> 1;
+            case ALLURE_RESULT -> 2;
+            case CONFIGURATION, ENVIRONMENT, DEPENDENCY_BUILD -> 3;
+            case PAGE_SNAPSHOT -> 4;
+            case SCREENSHOT, OTHER -> 5;
+        };
+    }
+
+    private static com.shaft.pilot.ai.EvidenceCategory providerCategory(
+            com.shaft.doctor.model.EvidenceCategory category) {
+        return switch (category) {
+            case EXCEPTION_CHAIN, SHAFT_LOG -> com.shaft.pilot.ai.EvidenceCategory.LOG;
+            case PAGE_SNAPSHOT -> com.shaft.pilot.ai.EvidenceCategory.DOM;
+            case CONFIGURATION, ENVIRONMENT, DEPENDENCY_BUILD ->
+                    com.shaft.pilot.ai.EvidenceCategory.CONFIGURATION;
+            case ALLURE_RESULT, OTHER, SCREENSHOT -> com.shaft.pilot.ai.EvidenceCategory.TEXT;
+        };
+    }
+
+    private static String boundedUtf8(String value, long maxBytes) {
+        if (maxBytes <= 0) {
+            return "";
+        }
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length <= maxBytes) {
+            return value;
+        }
+        int length = Math.toIntExact(Math.min(maxBytes, Integer.MAX_VALUE));
+        String bounded = new String(bytes, 0, length, StandardCharsets.UTF_8);
+        while (!bounded.isEmpty()
+                && bounded.getBytes(StandardCharsets.UTF_8).length > maxBytes) {
+            bounded = bounded.substring(0, bounded.length() - 1);
+        }
+        return bounded;
+    }
+
+    private static long millis(Duration duration) {
+        return duration == null ? 0 : Math.max(0, duration.toMillis());
+    }
+
+    private static Path safeCachePath(Path outputDirectory, String cacheKey) {
+        try {
+            Path output = outputDirectory.toAbsolutePath().normalize();
+            Files.createDirectories(output);
+            Path resolvedOutput = output.toRealPath();
+            Path cacheDirectory = output.resolve(".doctor-ai-cache");
+            if (Files.exists(cacheDirectory)
+                    && !cacheDirectory.toRealPath().startsWith(resolvedOutput)) {
+                return null;
+            }
+            return cacheDirectory.resolve(cacheKey + ".json");
+        } catch (IOException exception) {
+            return null;
+        }
+    }
+
+    private static String shortValue(String value) {
+        String normalized = value == null ? "" : value;
+        return normalized.substring(0, Math.min(16, normalized.length()));
+    }
+
+    private static JsonNode loadSchema() {
+        try (InputStream input = DoctorAiAnalysisService.class.getResourceAsStream(SCHEMA_RESOURCE)) {
+            if (input == null) {
+                throw new DoctorFormatException("Bundled Doctor advisory schema is missing.");
+            }
+            return JSON.readTree(input);
+        } catch (IOException exception) {
+            throw new DoctorFormatException("Bundled Doctor advisory schema could not be read.", exception);
+        }
+    }
+
+    private record ConfigurationIdentity(String provider, String model, String identifier) {
+    }
+}

--- a/shaft-doctor/src/main/java/com/shaft/doctor/cli/DoctorCli.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/cli/DoctorCli.java
@@ -2,9 +2,14 @@ package com.shaft.doctor.cli;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.shaft.doctor.DoctorAiAnalysisRequest;
 import com.shaft.doctor.DoctorAnalysisRequest;
 import com.shaft.doctor.DoctorAnalyzer;
+import com.shaft.doctor.model.DoctorAdvisory;
+import com.shaft.doctor.model.DoctorAiAnalysisResult;
 import com.shaft.doctor.model.DoctorAnalysisResult;
+import com.shaft.pilot.ai.ApprovalPolicy;
+import com.shaft.pilot.config.PilotConfiguration;
 
 import java.io.FileDescriptor;
 import java.io.FileOutputStream;
@@ -72,7 +77,10 @@ public final class DoctorCli {
                 throw new IllegalArgumentException(usage());
             }
             Arguments options = Arguments.parse(Arrays.copyOfRange(args, 1, args.length));
-            DoctorAnalysisResult result = new DoctorAnalyzer().analyze(new DoctorAnalysisRequest(
+            if (options.flag("ai-cache") && !options.flag("ai")) {
+                throw new IllegalArgumentException("Doctor option --ai-cache requires --ai.");
+            }
+            DoctorAnalysisRequest request = new DoctorAnalysisRequest(
                     options.pathsRequired("input"),
                     options.paths("history"),
                     options.pathsRequired("allowed-root"),
@@ -81,14 +89,41 @@ public final class DoctorCli {
                     options.flag("include-page-snapshots"),
                     Math.toIntExact(options.positiveLong("minimum-results", 1)),
                     options.positiveLong("max-item-bytes", DoctorAnalysisRequest.DEFAULT_MAX_ITEM_BYTES),
-                    options.positiveLong("max-bundle-bytes", DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES)));
-            output.println(MAPPER.writeValueAsString(Map.of(
-                    "bundleId", result.bundle().bundleId(),
-                    "primaryCause", result.diagnosis().primaryCause(),
-                    "confidence", result.diagnosis().confidence(),
-                    "bundlePath", result.bundlePath(),
-                    "jsonReportPath", result.jsonReportPath(),
-                    "markdownReportPath", result.markdownReportPath())));
+                    options.positiveLong("max-bundle-bytes", DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES));
+            DoctorAnalyzer analyzer = new DoctorAnalyzer();
+            DoctorAnalysisResult result;
+            DoctorAdvisory advisory = null;
+            if (options.flag("ai")) {
+                DoctorAiAnalysisRequest defaults = DoctorAiAnalysisRequest.defaults(currentApprovalPolicy());
+                DoctorAiAnalysisResult aiResult = analyzer.analyzeWithAi(request, new DoctorAiAnalysisRequest(
+                        true,
+                        defaults.approvalPolicy(),
+                        defaults.timeout(),
+                        defaults.budget(),
+                        defaults.maxEvidenceItems(),
+                        defaults.maxEvidenceBytes(),
+                        defaults.maxResponseBytes(),
+                        options.flag("ai-cache")));
+                result = aiResult.deterministic();
+                advisory = aiResult.advisory();
+            } else {
+                result = analyzer.analyze(request);
+            }
+            Map<String, Object> summary = new LinkedHashMap<>();
+            summary.put("bundleId", result.bundle().bundleId());
+            summary.put("primaryCause", result.diagnosis().primaryCause());
+            summary.put("confidence", result.diagnosis().confidence());
+            summary.put("bundlePath", result.bundlePath());
+            summary.put("jsonReportPath", result.jsonReportPath());
+            summary.put("markdownReportPath", result.markdownReportPath());
+            if (advisory != null) {
+                summary.put("advisoryStatus", advisory.status());
+                summary.put("providerStatus", advisory.metadata().providerStatus());
+                summary.put("provider", advisory.metadata().provider());
+                summary.put("model", advisory.metadata().model());
+                summary.put("fallbackReason", advisory.metadata().fallbackReason());
+            }
+            output.println(MAPPER.writeValueAsString(summary));
             return 0;
         } catch (RuntimeException exception) {
             error.println("SHAFT Doctor command failed: " + safeMessage(exception));
@@ -110,7 +145,16 @@ public final class DoctorCli {
                 + "[--history <doctor-evidence.json>] [--output-dir <path>] "
                 + "[--include-screenshots] [--include-page-snapshots] "
                 + "[--minimum-results <count>] "
-                + "[--max-item-bytes <bytes>] [--max-bundle-bytes <bytes>]";
+                + "[--max-item-bytes <bytes>] [--max-bundle-bytes <bytes>] "
+                + "[--ai] [--ai-cache]";
+    }
+
+    private static ApprovalPolicy currentApprovalPolicy() {
+        try {
+            return PilotConfiguration.current().approvalPolicy();
+        } catch (RuntimeException ignored) {
+            return ApprovalPolicy.denyAll();
+        }
     }
 
     private record Arguments(Map<String, List<String>> values, Set<String> flags) {
@@ -123,7 +167,7 @@ public final class DoctorCli {
                     throw new IllegalArgumentException("Unexpected Doctor argument.");
                 }
                 String name = argument.substring(2).toLowerCase(Locale.ROOT);
-                if (Set.of("include-screenshots", "include-page-snapshots").contains(name)) {
+                if (Set.of("include-screenshots", "include-page-snapshots", "ai", "ai-cache").contains(name)) {
                     flags.add(name);
                 } else {
                     if (index + 1 >= args.length || args[index + 1].startsWith("--")) {

--- a/shaft-doctor/src/main/java/com/shaft/doctor/format/DoctorJsonCodec.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/format/DoctorJsonCodec.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.shaft.doctor.model.Diagnosis;
+import com.shaft.doctor.model.DoctorAdvisory;
 import com.shaft.doctor.model.EvidenceBundle;
 import com.shaft.pilot.json.JsonSchemaValidator;
 
@@ -144,6 +145,34 @@ public final class DoctorJsonCodec {
             atomicWrite(path, json);
         } catch (JsonProcessingException exception) {
             throw new DoctorFormatException("Doctor report could not be serialized.", exception);
+        }
+    }
+
+    /**
+     * Writes the combined report with a separately identified optional advisory.
+     *
+     * @param path destination
+     * @param bundle evidence bundle
+     * @param diagnosis deterministic diagnosis
+     * @param advisory provider advisory or safe fallback
+     */
+    public void writeReport(
+            Path path,
+            EvidenceBundle bundle,
+            Diagnosis diagnosis,
+            DoctorAdvisory advisory) {
+        if (advisory == null) {
+            throw new DoctorFormatException("Doctor advisory is required.");
+        }
+        try {
+            JsonNode bundleTree = mapper.readTree(write(bundle));
+            JsonNode diagnosisTree = mapper.readTree(write(diagnosis));
+            JsonNode advisoryTree = mapper.valueToTree(advisory);
+            String json = mapper.writer(printer).writeValueAsString(
+                    Map.of("bundle", bundleTree, "diagnosis", diagnosisTree, "advisory", advisoryTree)) + "\n";
+            atomicWrite(path, json);
+        } catch (JsonProcessingException exception) {
+            throw new DoctorFormatException("Doctor advisory report could not be serialized.", exception);
         }
     }
 

--- a/shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAdvisory.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAdvisory.java
@@ -1,0 +1,222 @@
+package com.shaft.doctor.model;
+
+import com.shaft.pilot.ai.AiResponseStatus;
+import com.shaft.pilot.ai.AiUsage;
+
+import java.util.List;
+
+/**
+ * Separately identified optional provider advisory that never replaces the deterministic diagnosis.
+ *
+ * @param schemaVersion Doctor advisory envelope schema version
+ * @param status advisory outcome
+ * @param analysis schema-validated provider analysis
+ * @param metadata safe provider and fallback metadata
+ */
+public record DoctorAdvisory(
+        String schemaVersion,
+        Status status,
+        ProviderAnalysis analysis,
+        Metadata metadata) {
+    /**
+     * Current advisory envelope schema version.
+     */
+    public static final String CURRENT_SCHEMA_VERSION = "1.0";
+
+    /**
+     * Advisory outcome.
+     */
+    public enum Status {
+        SUCCESS,
+        FALLBACK,
+        DISABLED
+    }
+
+    /**
+     * Versioned provider output accepted by Doctor.
+     *
+     * @param schemaVersion provider analysis schema version
+     * @param observations evidence-cited observations
+     * @param hypotheses advisory hypotheses
+     * @param missingEvidence evidence gaps identified by the provider
+     * @param recommendedActions advisory actions
+     * @param limitations limitations stated by the provider
+     */
+    public record ProviderAnalysis(
+            String schemaVersion,
+            List<Observation> observations,
+            List<Hypothesis> hypotheses,
+            List<String> missingEvidence,
+            List<RecommendedAction> recommendedActions,
+            List<String> limitations) {
+        /**
+         * Current provider analysis schema version.
+         */
+        public static final String CURRENT_SCHEMA_VERSION = "1.0";
+
+        /**
+         * Creates immutable provider analysis.
+         */
+        public ProviderAnalysis {
+            schemaVersion = DoctorModelSupport.requireText(schemaVersion, "Advisory analysis schema version");
+            observations = DoctorModelSupport.list(observations);
+            hypotheses = DoctorModelSupport.list(hypotheses);
+            missingEvidence = DoctorModelSupport.list(missingEvidence);
+            recommendedActions = DoctorModelSupport.list(recommendedActions);
+            limitations = DoctorModelSupport.list(limitations);
+        }
+
+        /**
+         * Returns an empty provider analysis.
+         *
+         * @return empty analysis
+         */
+        public static ProviderAnalysis empty() {
+            return new ProviderAnalysis(CURRENT_SCHEMA_VERSION, List.of(), List.of(),
+                    List.of(), List.of(), List.of());
+        }
+    }
+
+    /**
+     * One provider observation.
+     *
+     * @param statement safe observation text
+     * @param evidenceIds submitted evidence references
+     * @param cited whether at least one submitted evidence item supports the claim
+     */
+    public record Observation(String statement, List<String> evidenceIds, boolean cited) {
+        /**
+         * Creates an immutable observation.
+         */
+        public Observation {
+            statement = DoctorModelSupport.requireText(statement, "Advisory observation");
+            evidenceIds = DoctorModelSupport.list(evidenceIds);
+        }
+    }
+
+    /**
+     * One provider hypothesis.
+     *
+     * @param causeCategory proposed cause category
+     * @param statement safe hypothesis text
+     * @param confidence provider confidence
+     * @param evidenceIds submitted evidence references
+     * @param cited whether at least one submitted evidence item supports the claim
+     * @param contradictsDeterministic whether the category conflicts with the deterministic diagnosis
+     */
+    public record Hypothesis(
+            CauseCategory causeCategory,
+            String statement,
+            Confidence confidence,
+            List<String> evidenceIds,
+            boolean cited,
+            boolean contradictsDeterministic) {
+        /**
+         * Creates an immutable hypothesis.
+         */
+        public Hypothesis {
+            causeCategory = causeCategory == null ? CauseCategory.UNKNOWN : causeCategory;
+            statement = DoctorModelSupport.requireText(statement, "Advisory hypothesis");
+            confidence = confidence == null ? Confidence.UNKNOWN : confidence;
+            evidenceIds = DoctorModelSupport.list(evidenceIds);
+        }
+    }
+
+    /**
+     * One provider-recommended action.
+     *
+     * @param title concise action title
+     * @param action safe action text
+     * @param evidenceIds submitted evidence references
+     * @param cited whether at least one submitted evidence item supports the action
+     */
+    public record RecommendedAction(
+            String title,
+            String action,
+            List<String> evidenceIds,
+            boolean cited) {
+        /**
+         * Creates an immutable recommended action.
+         */
+        public RecommendedAction {
+            title = DoctorModelSupport.requireText(title, "Advisory action title");
+            action = DoctorModelSupport.requireText(action, "Advisory action");
+            evidenceIds = DoctorModelSupport.list(evidenceIds);
+        }
+    }
+
+    /**
+     * Safe provider, timing, usage, cache, and fallback metadata.
+     *
+     * @param providerStatus normalized provider outcome
+     * @param provider provider identifier
+     * @param model model identifier
+     * @param configurationIdentifier non-secret configuration checksum
+     * @param durationMillis elapsed provider duration
+     * @param usage provider-reported usage
+     * @param fallbackReason safe fallback reason
+     * @param cacheHit whether the advisory came from the explicit safe cache
+     * @param warnings safe validation warnings
+     */
+    public record Metadata(
+            AiResponseStatus providerStatus,
+            String provider,
+            String model,
+            String configurationIdentifier,
+            long durationMillis,
+            AiUsage usage,
+            String fallbackReason,
+            boolean cacheHit,
+            List<String> warnings) {
+        /**
+         * Creates immutable safe metadata.
+         */
+        public Metadata {
+            providerStatus = providerStatus == null ? AiResponseStatus.DISABLED : providerStatus;
+            provider = DoctorModelSupport.text(provider);
+            model = DoctorModelSupport.text(model);
+            configurationIdentifier = DoctorModelSupport.text(configurationIdentifier);
+            if (durationMillis < 0) {
+                throw new IllegalArgumentException("Advisory duration cannot be negative.");
+            }
+            usage = usage == null ? AiUsage.empty() : usage;
+            fallbackReason = DoctorModelSupport.text(fallbackReason);
+            warnings = DoctorModelSupport.list(warnings);
+        }
+
+        /**
+         * Returns a cache-hit copy.
+         *
+         * @return cache-hit metadata
+         */
+        public Metadata asCacheHit() {
+            return new Metadata(providerStatus, provider, model, configurationIdentifier,
+                    durationMillis, usage, fallbackReason, true, warnings);
+        }
+    }
+
+    /**
+     * Creates a validated advisory.
+     */
+    public DoctorAdvisory {
+        schemaVersion = DoctorModelSupport.requireText(schemaVersion, "Advisory schema version");
+        status = status == null ? Status.DISABLED : status;
+        analysis = analysis == null ? ProviderAnalysis.empty() : analysis;
+        metadata = metadata == null
+                ? new Metadata(AiResponseStatus.DISABLED, "none", "", "", 0,
+                AiUsage.empty(), "", false, List.of())
+                : metadata;
+    }
+
+    /**
+     * Returns a disabled advisory that is not rendered into deterministic reports.
+     *
+     * @return disabled advisory
+     */
+    public static DoctorAdvisory disabled() {
+        return new DoctorAdvisory(CURRENT_SCHEMA_VERSION, Status.DISABLED,
+                ProviderAnalysis.empty(),
+                new Metadata(AiResponseStatus.DISABLED, "none", "", "", 0,
+                        AiUsage.empty(), "", false, List.of()));
+    }
+}

--- a/shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAiAnalysisResult.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAiAnalysisResult.java
@@ -1,0 +1,20 @@
+package com.shaft.doctor.model;
+
+/**
+ * Deterministic Doctor result plus a separately identified optional advisory.
+ *
+ * @param deterministic deterministic analysis result
+ * @param advisory optional provider advisory or safe fallback notice
+ */
+public record DoctorAiAnalysisResult(
+        DoctorAnalysisResult deterministic,
+        DoctorAdvisory advisory) {
+    /**
+     * Creates a complete result.
+     */
+    public DoctorAiAnalysisResult {
+        if (deterministic == null || advisory == null) {
+            throw new IllegalArgumentException("Deterministic result and advisory are required.");
+        }
+    }
+}

--- a/shaft-doctor/src/main/java/com/shaft/doctor/report/DoctorReportWriter.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/report/DoctorReportWriter.java
@@ -1,6 +1,7 @@
 package com.shaft.doctor.report;
 
 import com.shaft.doctor.model.Diagnosis;
+import com.shaft.doctor.model.DoctorAdvisory;
 import com.shaft.doctor.model.EvidenceBundle;
 import com.shaft.doctor.model.Finding;
 import com.shaft.doctor.model.Remediation;
@@ -23,6 +24,22 @@ public final class DoctorReportWriter {
      * @param diagnosis diagnosis
      */
     public void writeMarkdown(Path path, EvidenceBundle bundle, Diagnosis diagnosis) {
+        writeMarkdown(path, bundle, diagnosis, null);
+    }
+
+    /**
+     * Writes a Markdown report with a separately identified optional advisory.
+     *
+     * @param path destination
+     * @param bundle evidence bundle
+     * @param diagnosis deterministic diagnosis
+     * @param advisory optional provider advisory
+     */
+    public void writeMarkdown(
+            Path path,
+            EvidenceBundle bundle,
+            Diagnosis diagnosis,
+            DoctorAdvisory advisory) {
         StringBuilder report = new StringBuilder();
         report.append("# SHAFT Doctor Report\n\n");
         report.append("- Evidence schema: `").append(bundle.schemaVersion()).append("`\n");
@@ -84,6 +101,10 @@ public final class DoctorReportWriter {
             report.append("\n");
         }
 
+        if (advisory != null && advisory.status() != DoctorAdvisory.Status.DISABLED) {
+            appendAdvisory(report, advisory);
+        }
+
         report.append("## Evidence Index\n\n");
         report.append("| ID | Category | Source | Bytes | Redacted | Truncated | Checksum |\n");
         report.append("|---|---|---|---:|---|---|---|\n");
@@ -113,6 +134,118 @@ public final class DoctorReportWriter {
         } catch (IOException exception) {
             throw new IllegalStateException("Doctor Markdown report could not be written.", exception);
         }
+    }
+
+    private static void appendAdvisory(StringBuilder report, DoctorAdvisory advisory) {
+        report.append("## AI Advisory\n\n");
+        report.append("> Advisory only. The deterministic diagnosis above remains authoritative and unchanged.\n\n");
+        report.append("- Status: `").append(advisory.status()).append("`\n");
+        report.append("- Provider status: `").append(advisory.metadata().providerStatus()).append("`\n");
+        report.append("- Provider: `").append(code(advisory.metadata().provider())).append("`\n");
+        report.append("- Model: `").append(code(advisory.metadata().model())).append("`\n");
+        report.append("- Configuration: `")
+                .append(code(advisory.metadata().configurationIdentifier())).append("`\n");
+        report.append("- Duration: ").append(advisory.metadata().durationMillis()).append(" ms\n");
+        report.append("- Usage: ").append(advisory.metadata().usage().inputTokens())
+                .append(" input / ").append(advisory.metadata().usage().outputTokens())
+                .append(" output tokens\n");
+        report.append("- Cache hit: ").append(advisory.metadata().cacheHit()).append("\n\n");
+
+        if (!advisory.metadata().fallbackReason().isBlank()) {
+            report.append("Fallback: ").append(markdown(advisory.metadata().fallbackReason())).append("\n\n");
+        }
+        if (!advisory.metadata().warnings().isEmpty()) {
+            report.append("Warnings:\n\n");
+            advisory.metadata().warnings().forEach(warning ->
+                    report.append("- ").append(markdown(warning)).append("\n"));
+            report.append("\n");
+        }
+        if (advisory.status() != DoctorAdvisory.Status.SUCCESS) {
+            report.append("No provider analysis was accepted. The deterministic report is complete and retained.\n\n");
+            return;
+        }
+
+        report.append("### Observations\n\n");
+        if (advisory.analysis().observations().isEmpty()) {
+            report.append("No provider observations were returned.\n\n");
+        } else {
+            for (DoctorAdvisory.Observation observation : advisory.analysis().observations()) {
+                report.append("- ").append(markdown(observation.statement()))
+                        .append(" Evidence: ").append(references(observation.evidenceIds()))
+                        .append(observation.cited() ? "" : " (uncited)")
+                        .append("\n");
+            }
+            report.append("\n");
+        }
+
+        report.append("### Hypotheses\n\n");
+        if (advisory.analysis().hypotheses().isEmpty()) {
+            report.append("No provider hypotheses were returned.\n\n");
+        } else {
+            for (DoctorAdvisory.Hypothesis hypothesis : advisory.analysis().hypotheses()) {
+                report.append("- `").append(hypothesis.causeCategory()).append("` ")
+                        .append("(`").append(hypothesis.confidence()).append("`): ")
+                        .append(markdown(hypothesis.statement()))
+                        .append(" Evidence: ").append(references(hypothesis.evidenceIds()))
+                        .append(hypothesis.cited() ? "" : " (uncited)")
+                        .append(hypothesis.contradictsDeterministic()
+                                ? " (contradicts deterministic primary cause)" : "")
+                        .append("\n");
+            }
+            report.append("\n");
+        }
+
+        report.append("### Recommended Actions\n\n");
+        if (advisory.analysis().recommendedActions().isEmpty()) {
+            report.append("No provider actions were returned.\n\n");
+        } else {
+            for (DoctorAdvisory.RecommendedAction action : advisory.analysis().recommendedActions()) {
+                report.append("1. **").append(markdown(action.title())).append("**: ")
+                        .append(markdown(action.action()))
+                        .append(" Evidence: ").append(references(action.evidenceIds()))
+                        .append(action.cited() ? "" : " (uncited)")
+                        .append("\n");
+            }
+            report.append("\n");
+        }
+
+        report.append("### Provider Missing Evidence\n\n");
+        appendTextList(report, advisory.analysis().missingEvidence(),
+                "The provider did not identify additional missing evidence.");
+        report.append("### Limitations\n\n");
+        appendTextList(report, advisory.analysis().limitations(),
+                "The provider did not state additional limitations.");
+    }
+
+    private static void appendTextList(StringBuilder report, java.util.List<String> values, String emptyText) {
+        if (values.isEmpty()) {
+            report.append(emptyText).append("\n\n");
+            return;
+        }
+        values.forEach(value -> report.append("- ").append(markdown(value)).append("\n"));
+        report.append("\n");
+    }
+
+    private static String references(java.util.List<String> evidenceIds) {
+        return evidenceIds.isEmpty()
+                ? "none"
+                : evidenceIds.stream().map(id -> "`" + id + "`").collect(Collectors.joining(", "));
+    }
+
+    private static String markdown(String value) {
+        return cell(value)
+                .replace("\\", "\\\\")
+                .replace("`", "\\`")
+                .replace("*", "\\*")
+                .replace("_", "\\_")
+                .replace("[", "\\[")
+                .replace("]", "\\]")
+                .replace("<", "\\<")
+                .replace(">", "\\>");
+    }
+
+    private static String code(String value) {
+        return cell(value).replace("`", "\\`");
     }
 
     private static String cell(String value) {

--- a/shaft-doctor/src/main/resources/schema/shaft-doctor-advisory-1.0.schema.json
+++ b/shaft-doctor/src/main/resources/schema/shaft-doctor-advisory-1.0.schema.json
@@ -1,0 +1,134 @@
+{
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "observations",
+    "hypotheses",
+    "missingEvidence",
+    "recommendedActions",
+    "limitations"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "enum": [
+        "1.0"
+      ]
+    },
+    "observations": {
+      "type": "array",
+      "maxItems": 20,
+      "items": {
+        "type": "object",
+        "required": [
+          "statement",
+          "evidenceIds"
+        ],
+        "properties": {
+          "statement": {
+            "type": "string"
+          },
+          "evidenceIds": {
+            "type": "array",
+            "maxItems": 12,
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "hypotheses": {
+      "type": "array",
+      "maxItems": 12,
+      "items": {
+        "type": "object",
+        "required": [
+          "causeCategory",
+          "statement",
+          "confidence",
+          "evidenceIds"
+        ],
+        "properties": {
+          "causeCategory": {
+            "type": "string",
+            "enum": [
+              "PRODUCT",
+              "TEST",
+              "LOCATOR",
+              "DATA",
+              "TIMING_SYNCHRONIZATION",
+              "ENVIRONMENT_CONFIGURATION",
+              "INFRASTRUCTURE",
+              "UNKNOWN"
+            ]
+          },
+          "statement": {
+            "type": "string"
+          },
+          "confidence": {
+            "type": "string",
+            "enum": [
+              "HIGH",
+              "MEDIUM",
+              "LOW",
+              "UNKNOWN"
+            ]
+          },
+          "evidenceIds": {
+            "type": "array",
+            "maxItems": 12,
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "missingEvidence": {
+      "type": "array",
+      "maxItems": 20,
+      "items": {
+        "type": "string"
+      }
+    },
+    "recommendedActions": {
+      "type": "array",
+      "maxItems": 20,
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "action",
+          "evidenceIds"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "action": {
+            "type": "string"
+          },
+          "evidenceIds": {
+            "type": "array",
+            "maxItems": 12,
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "maxItems": 20,
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/shaft-doctor/src/test/java/com/shaft/doctor/DoctorAnalyzerTest.java
+++ b/shaft-doctor/src/test/java/com/shaft/doctor/DoctorAnalyzerTest.java
@@ -2,10 +2,19 @@ package com.shaft.doctor;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.shaft.doctor.cli.DoctorCli;
+import com.shaft.doctor.ai.DoctorAiAnalysisService;
+import com.shaft.doctor.analysis.DeterministicRuleEngine;
+import com.shaft.doctor.collect.EvidenceCollector;
 import com.shaft.doctor.format.DoctorJsonCodec;
 import com.shaft.doctor.model.CauseCategory;
+import com.shaft.doctor.model.DoctorAdvisory;
+import com.shaft.doctor.model.DoctorAiAnalysisResult;
 import com.shaft.doctor.model.DoctorAnalysisResult;
 import com.shaft.doctor.model.EvidenceCategory;
+import com.shaft.doctor.report.DoctorReportWriter;
+import com.shaft.pilot.ai.AiResponse;
+import com.shaft.pilot.ai.AiUsage;
+import com.shaft.pilot.ai.ApprovalPolicy;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -20,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.EnumSet;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assumptions.abort;
@@ -215,6 +225,82 @@ class DoctorAnalyzerTest {
     }
 
     @Test
+    void disabledAiLeavesDeterministicReportsByteStable(@TempDir Path temp) throws IOException {
+        Path input = Files.createDirectories(temp.resolve("disabled-ai-input"));
+        writeResult(input.resolve("locator-result.json"), "failed",
+                "NoSuchElementException: unable to locate element", "trace", "disabled-ai", 1);
+        DoctorAnalysisRequest baselineRequest = request(temp, input, "disabled-ai-baseline");
+        DoctorAnalysisRequest disabledRequest = request(temp, input, "disabled-ai-result");
+
+        DoctorAnalysisResult baseline = new DoctorAnalyzer().analyze(baselineRequest);
+        DoctorAiAnalysisResult disabled = new DoctorAnalyzer()
+                .analyzeWithAi(disabledRequest, DoctorAiAnalysisRequest.disabled());
+
+        assertEquals(Files.readString(Path.of(baseline.jsonReportPath())),
+                Files.readString(Path.of(disabled.deterministic().jsonReportPath())));
+        assertEquals(Files.readString(Path.of(baseline.markdownReportPath())),
+                Files.readString(Path.of(disabled.deterministic().markdownReportPath())));
+        assertEquals(DoctorAdvisory.Status.DISABLED, disabled.advisory().status());
+    }
+
+    @Test
+    void acceptedProviderAnalysisAddsSeparateAdvisoryWithoutRemovingDiagnosis(@TempDir Path temp) throws Exception {
+        Path input = Files.createDirectories(temp.resolve("advisory-input"));
+        writeResult(input.resolve("locator-result.json"), "failed",
+                "NoSuchElementException: unable to locate element", "trace", "advisory", 1);
+        DoctorAiAnalysisService service = new DoctorAiAnalysisService(request -> {
+            String evidenceId = request.evidence().getFirst().id();
+            var payload = MAPPER.createObjectNode();
+            payload.put("schemaVersion", "1.0");
+            payload.putArray("observations").addObject()
+                    .put("statement", "Authorization: Bearer advisory-report-secret\n## Fake Diagnosis")
+                    .putArray("evidenceIds").add(evidenceId);
+            payload.putArray("hypotheses").addObject()
+                    .put("causeCategory", "LOCATOR")
+                    .put("statement", "The locator likely needs inspection.")
+                    .put("confidence", "HIGH")
+                    .putArray("evidenceIds").add(evidenceId);
+            payload.putArray("missingEvidence").add("Current DOM snapshot");
+            payload.putArray("recommendedActions").addObject()
+                    .put("title", "Inspect locator")
+                    .put("action", "Compare the locator with the current DOM.")
+                    .putArray("evidenceIds").add(evidenceId);
+            payload.putArray("limitations").add("Only submitted evidence was analyzed.");
+            return AiResponse.success("mock", "mock-model", payload, java.time.Duration.ofMillis(2),
+                    AiUsage.empty(), request.deterministicFallback());
+        }, () -> {
+            throw new IllegalArgumentException("test configuration unavailable");
+        });
+        DoctorAnalyzer analyzer = new DoctorAnalyzer(
+                new EvidenceCollector(),
+                new DeterministicRuleEngine(),
+                new DoctorJsonCodec(),
+                new DoctorReportWriter(),
+                service);
+        ApprovalPolicy approval = new ApprovalPolicy(
+                true,
+                true,
+                EnumSet.allOf(com.shaft.pilot.ai.EvidenceCategory.class));
+
+        DoctorAiAnalysisResult result = analyzer.analyzeWithAi(
+                request(temp, input, "advisory-output"),
+                DoctorAiAnalysisRequest.defaults(approval));
+
+        assertEquals(CauseCategory.LOCATOR, result.deterministic().diagnosis().primaryCause());
+        assertEquals(DoctorAdvisory.Status.SUCCESS, result.advisory().status());
+        String json = Files.readString(Path.of(result.deterministic().jsonReportPath()));
+        String markdown = Files.readString(Path.of(result.deterministic().markdownReportPath()));
+        assertTrue(json.contains("\"diagnosis\""));
+        assertTrue(json.contains("\"advisory\""));
+        assertTrue(markdown.contains("## Diagnosis"));
+        assertTrue(markdown.contains("## AI Advisory"));
+        assertTrue(markdown.contains("deterministic diagnosis above remains authoritative"));
+        assertFalse(json.contains("advisory-report-secret"));
+        assertFalse(markdown.contains("advisory-report-secret"));
+        assertFalse(markdown.contains("\n## Fake Diagnosis"));
+    }
+
+    @Test
     void contradictoryDisjointHighConfidenceFailuresRemainUnknown(@TempDir Path temp) throws IOException {
         Path input = Files.createDirectories(temp.resolve("contradictory"));
         writeResult(input.resolve("locator-result.json"), "failed",
@@ -399,6 +485,19 @@ class DoctorAnalyzerTest {
                 minimumResults,
                 DoctorAnalysisRequest.DEFAULT_MAX_ITEM_BYTES,
                 DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES));
+    }
+
+    private static DoctorAnalysisRequest request(Path root, Path input, String outputName) {
+        return new DoctorAnalysisRequest(
+                List.of(input),
+                List.of(),
+                List.of(root),
+                root.resolve(outputName),
+                false,
+                false,
+                1,
+                DoctorAnalysisRequest.DEFAULT_MAX_ITEM_BYTES,
+                DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES);
     }
 
     private static void writeResult(

--- a/shaft-doctor/src/test/java/com/shaft/doctor/ai/DoctorAiAnalysisServiceTest.java
+++ b/shaft-doctor/src/test/java/com/shaft/doctor/ai/DoctorAiAnalysisServiceTest.java
@@ -1,0 +1,360 @@
+package com.shaft.doctor.ai;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.shaft.doctor.DoctorAiAnalysisRequest;
+import com.shaft.doctor.model.CauseCategory;
+import com.shaft.doctor.model.Confidence;
+import com.shaft.doctor.model.Diagnosis;
+import com.shaft.doctor.model.DoctorAdvisory;
+import com.shaft.doctor.model.EvidenceBundle;
+import com.shaft.doctor.model.EvidenceItem;
+import com.shaft.doctor.model.EvidenceProvenance;
+import com.shaft.doctor.model.Finding;
+import com.shaft.doctor.model.RedactionSummary;
+import com.shaft.pilot.ai.AiBudget;
+import com.shaft.pilot.ai.AiRequest;
+import com.shaft.pilot.ai.AiResponse;
+import com.shaft.pilot.ai.AiResponseStatus;
+import com.shaft.pilot.ai.AiUsage;
+import com.shaft.pilot.ai.ApprovalPolicy;
+import com.shaft.pilot.ai.EvidenceCategory;
+import com.shaft.pilot.config.PilotConfiguration;
+import com.shaft.pilot.config.ProviderConfiguration;
+import com.shaft.pilot.security.RedactionPolicy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DoctorAiAnalysisServiceTest {
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final ApprovalPolicy APPROVED = new ApprovalPolicy(
+            false,
+            true,
+            EnumSet.allOf(EvidenceCategory.class));
+
+    @Test
+    void successfulAnalysisUsesOnlyCitedMinimizedEvidenceAndRedactsProviderText(
+            @TempDir Path temp) throws Exception {
+        AtomicReference<AiRequest> captured = new AtomicReference<>();
+        JsonNode payload = fixture("high-quality.json").deepCopy();
+        ((ObjectNode) payload.path("observations").path(0))
+                .put("statement", "Authorization: Bearer provider-secret-canary");
+        DoctorAiAnalysisService service = service(request -> {
+            captured.set(request);
+            return success(request, payload);
+        });
+
+        DoctorAdvisory advisory = service.analyze(bundle(), diagnosis(),
+                DoctorAiAnalysisRequest.defaults(APPROVED), temp);
+
+        assertEquals(DoctorAdvisory.Status.SUCCESS, advisory.status());
+        assertEquals(List.of("evidence-1"),
+                captured.get().evidence().stream().map(value -> value.id()).toList());
+        assertFalse(captured.get().text().contains("provider-secret-canary"));
+        assertFalse(captured.get().evidence().stream()
+                .anyMatch(value -> value.content().contains("browser=chrome")));
+        assertFalse(advisory.analysis().observations().getFirst().statement()
+                .contains("provider-secret-canary"));
+        assertTrue(advisory.analysis().observations().getFirst().statement().contains("[REDACTED]"));
+        assertTrue(advisory.metadata().warnings().stream()
+                .anyMatch(value -> value.contains("redacted")));
+    }
+
+    @Test
+    void categoryConsentIsEnforcedBeforeRequestCreation(@TempDir Path temp) {
+        AtomicInteger calls = new AtomicInteger();
+        ApprovalPolicy textOnly = new ApprovalPolicy(false, true, Set.of(EvidenceCategory.TEXT));
+        DoctorAiAnalysisService service = service(request -> {
+            calls.incrementAndGet();
+            return success(request, fixtureUnchecked("high-quality.json"));
+        });
+
+        DoctorAdvisory advisory = service.analyze(bundle(), diagnosis(),
+                DoctorAiAnalysisRequest.defaults(textOnly), temp);
+
+        assertEquals(DoctorAdvisory.Status.FALLBACK, advisory.status());
+        assertEquals(AiResponseStatus.CONSENT_REQUIRED, advisory.metadata().providerStatus());
+        assertEquals(0, calls.get());
+    }
+
+    @Test
+    void inventedEvidenceReferencesAreRejected(@TempDir Path temp) throws Exception {
+        DoctorAiAnalysisService service =
+                service(request -> success(request, fixtureUnchecked("hallucinated-evidence.json")));
+
+        DoctorAdvisory advisory = service.analyze(bundle(), diagnosis(),
+                DoctorAiAnalysisRequest.defaults(APPROVED), temp);
+
+        assertEquals(DoctorAdvisory.Status.FALLBACK, advisory.status());
+        assertEquals(AiResponseStatus.INVALID_RESPONSE, advisory.metadata().providerStatus());
+        assertTrue(advisory.metadata().fallbackReason().contains("validation"));
+    }
+
+    @Test
+    void contradictoryAndUncitedClaimsAreMarkedWithoutChangingBaseline(@TempDir Path temp) throws Exception {
+        ObjectNode payload = (ObjectNode) fixture("contradictory.json").deepCopy();
+        payload.withArray("observations").addObject()
+                .put("statement", "The test may also have stale data.")
+                .putArray("evidenceIds");
+        DoctorAiAnalysisService service = service(request -> success(request, payload));
+
+        DoctorAdvisory advisory = service.analyze(bundle(), diagnosis(),
+                DoctorAiAnalysisRequest.defaults(APPROVED), temp);
+
+        assertEquals(DoctorAdvisory.Status.SUCCESS, advisory.status());
+        assertTrue(advisory.analysis().hypotheses().getFirst().contradictsDeterministic());
+        assertFalse(advisory.analysis().observations().getLast().cited());
+        assertTrue(advisory.metadata().warnings().stream()
+                .anyMatch(value -> value.contains("contradicts")));
+        assertTrue(advisory.metadata().warnings().stream()
+                .anyMatch(value -> value.contains("uncited")));
+        assertEquals(CauseCategory.LOCATOR, diagnosis().primaryCause());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = AiResponseStatus.class, names = {
+            "TIMEOUT",
+            "RATE_LIMITED",
+            "AUTHENTICATION_FAILED",
+            "INVALID_RESPONSE",
+            "BUDGET_EXCEEDED",
+            "PROVIDER_UNAVAILABLE"
+    })
+    void providerFailuresReturnExplicitDeterministicFallback(
+            AiResponseStatus status,
+            @TempDir Path temp) {
+        DoctorAiAnalysisService service = service(request ->
+                AiResponse.failure(status, "mock", "mock-model", "Safe provider fallback.",
+                        Duration.ofMillis(5), request.deterministicFallback()));
+
+        DoctorAdvisory advisory = service.analyze(bundle(), diagnosis(),
+                DoctorAiAnalysisRequest.defaults(APPROVED), temp);
+
+        assertEquals(DoctorAdvisory.Status.FALLBACK, advisory.status());
+        assertEquals(status, advisory.metadata().providerStatus());
+        assertEquals("Safe provider fallback.", advisory.metadata().fallbackReason());
+        assertEquals(CauseCategory.LOCATOR, diagnosis().primaryCause());
+    }
+
+    @Test
+    void oversizedOutputReturnsFallback(@TempDir Path temp) throws Exception {
+        ObjectNode payload = (ObjectNode) fixture("high-quality.json").deepCopy();
+        payload.withArray("limitations").add("x".repeat(4_000));
+        DoctorAiAnalysisRequest defaults = DoctorAiAnalysisRequest.defaults(APPROVED);
+        DoctorAiAnalysisRequest bounded = new DoctorAiAnalysisRequest(
+                true,
+                defaults.approvalPolicy(),
+                defaults.timeout(),
+                defaults.budget(),
+                defaults.maxEvidenceItems(),
+                defaults.maxEvidenceBytes(),
+                512,
+                false);
+        DoctorAiAnalysisService service = service(request -> success(request, payload));
+
+        DoctorAdvisory advisory = service.analyze(bundle(), diagnosis(), bounded, temp);
+
+        assertEquals(DoctorAdvisory.Status.FALLBACK, advisory.status());
+        assertTrue(advisory.metadata().fallbackReason().contains("size limit"));
+    }
+
+    @Test
+    void explicitSafeCacheReusesOnlyValidatedStructuredAdvisory(@TempDir Path temp) throws Exception {
+        AtomicInteger calls = new AtomicInteger();
+        DoctorAiAnalysisService service = service(request -> {
+            calls.incrementAndGet();
+            return success(request, fixtureUnchecked("high-quality.json"));
+        });
+        DoctorAiAnalysisRequest defaults = DoctorAiAnalysisRequest.defaults(APPROVED);
+        DoctorAiAnalysisRequest cached = new DoctorAiAnalysisRequest(
+                true,
+                defaults.approvalPolicy(),
+                defaults.timeout(),
+                defaults.budget(),
+                defaults.maxEvidenceItems(),
+                defaults.maxEvidenceBytes(),
+                defaults.maxResponseBytes(),
+                true);
+
+        DoctorAdvisory first = service.analyze(bundle(), diagnosis(), cached, temp);
+        DoctorAdvisory second = service.analyze(bundle(), diagnosis(), cached, temp);
+
+        assertEquals(DoctorAdvisory.Status.SUCCESS, first.status());
+        assertEquals(DoctorAdvisory.Status.SUCCESS, second.status());
+        assertFalse(first.metadata().cacheHit());
+        assertTrue(second.metadata().cacheHit());
+        assertEquals(1, calls.get());
+        try (var entries = java.nio.file.Files.list(temp.resolve(".doctor-ai-cache"))) {
+            assertTrue(entries.findAny().isPresent());
+        }
+    }
+
+    @Test
+    void safeCacheIsNotReusedAfterEffectiveConsentChanges(@TempDir Path temp) {
+        AtomicInteger calls = new AtomicInteger();
+        AtomicReference<PilotConfiguration> configuration = new AtomicReference<>(configuration());
+        DoctorAiAnalysisService service = new DoctorAiAnalysisService(request -> {
+            calls.incrementAndGet();
+            return success(request, fixtureUnchecked("high-quality.json"));
+        }, configuration::get);
+        DoctorAiAnalysisRequest defaults = DoctorAiAnalysisRequest.defaults(APPROVED);
+        DoctorAiAnalysisRequest cached = new DoctorAiAnalysisRequest(
+                true,
+                defaults.approvalPolicy(),
+                defaults.timeout(),
+                defaults.budget(),
+                defaults.maxEvidenceItems(),
+                defaults.maxEvidenceBytes(),
+                defaults.maxResponseBytes(),
+                true);
+
+        service.analyze(bundle(), diagnosis(), cached, temp);
+        PilotConfiguration approved = configuration();
+        configuration.set(new PilotConfiguration(
+                approved.enabled(),
+                approved.provider(),
+                ApprovalPolicy.denyAll(),
+                approved.telemetryEnabled(),
+                approved.timeout(),
+                approved.maxRequestBytes(),
+                approved.maxInputTokens(),
+                approved.maxOutputTokens(),
+                approved.maxCostUsd(),
+                approved.retryMaxAttempts(),
+                approved.maxConcurrency(),
+                approved.circuitBreakerFailureThreshold(),
+                approved.circuitBreakerCooldown(),
+                approved.redactionPolicy(),
+                approved.providers()));
+        DoctorAdvisory second = service.analyze(bundle(), diagnosis(), cached, temp);
+
+        assertFalse(second.metadata().cacheHit());
+        assertEquals(2, calls.get());
+    }
+
+    private static DoctorAiAnalysisService service(
+            java.util.function.Function<AiRequest, AiResponse> executor) {
+        return new DoctorAiAnalysisService(executor, DoctorAiAnalysisServiceTest::configuration);
+    }
+
+    private static AiResponse success(AiRequest request, JsonNode payload) {
+        return AiResponse.success("mock", "mock-model", payload, Duration.ofMillis(5),
+                new AiUsage(100, 50, null), request.deterministicFallback());
+    }
+
+    private static PilotConfiguration configuration() {
+        return new PilotConfiguration(
+                true,
+                "mock",
+                APPROVED,
+                false,
+                Duration.ofSeconds(1),
+                1_048_576,
+                16_000,
+                2_000,
+                BigDecimal.ZERO,
+                1,
+                1,
+                3,
+                Duration.ofSeconds(60),
+                new RedactionPolicy(Set.of(), List.of(), List.of()),
+                Map.of("mock", new ProviderConfiguration(
+                        "mock",
+                        URI.create("https://provider.invalid"),
+                        "mock-model",
+                        "MOCK_API_KEY",
+                        Map.of())));
+    }
+
+    private static EvidenceBundle bundle() {
+        EvidenceItem cited = new EvidenceItem(
+                "evidence-1",
+                com.shaft.doctor.model.EvidenceCategory.EXCEPTION_CHAIN,
+                "text/plain",
+                "",
+                "sha-1",
+                50,
+                "NoSuchElementException: unable to locate element",
+                true,
+                false,
+                Map.of(),
+                new EvidenceProvenance("fixture", "fixture/result.json", "sha-1"));
+        EvidenceItem uncited = new EvidenceItem(
+                "evidence-2",
+                com.shaft.doctor.model.EvidenceCategory.CONFIGURATION,
+                "text/plain",
+                "",
+                "sha-2",
+                20,
+                "browser=chrome",
+                true,
+                false,
+                Map.of(),
+                new EvidenceProvenance("fixture", "fixture/config.txt", "sha-2"));
+        return new EvidenceBundle(
+                EvidenceBundle.CURRENT_SCHEMA_VERSION,
+                "bundle-1",
+                List.of(cited, uncited),
+                new RedactionSummary(List.of(), List.of(), 0),
+                Map.of());
+    }
+
+    private static Diagnosis diagnosis() {
+        return new Diagnosis(
+                Diagnosis.CURRENT_SCHEMA_VERSION,
+                CauseCategory.LOCATOR,
+                List.of(),
+                Confidence.HIGH,
+                "Locator did not resolve an element.",
+                "The deterministic locator rule matched submitted evidence.",
+                List.of(new Finding(
+                        "finding-1",
+                        Finding.Kind.INFERENCE,
+                        CauseCategory.LOCATOR,
+                        Finding.Severity.ERROR,
+                        "Locator not found",
+                        "The locator did not resolve an element.",
+                        "locator-not-found",
+                        List.of("evidence-1"))),
+                List.of(),
+                List.of("Current DOM snapshot"));
+    }
+
+    private static JsonNode fixture(String name) throws IOException {
+        try (var input = DoctorAiAnalysisServiceTest.class
+                .getResourceAsStream("/fixtures/ai/" + name)) {
+            if (input == null) {
+                throw new IOException("Missing fixture: " + name);
+            }
+            return JSON.readTree(input);
+        }
+    }
+
+    private static JsonNode fixtureUnchecked(String name) {
+        try {
+            return fixture(name);
+        } catch (IOException exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+}

--- a/shaft-doctor/src/test/resources/fixtures/ai/contradictory.json
+++ b/shaft-doctor/src/test/resources/fixtures/ai/contradictory.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "1.0",
+  "observations": [
+    {
+      "statement": "The submitted evidence reports a locator exception.",
+      "evidenceIds": [
+        "evidence-1"
+      ]
+    }
+  ],
+  "hypotheses": [
+    {
+      "causeCategory": "INFRASTRUCTURE",
+      "statement": "The remote execution infrastructure may be unavailable.",
+      "confidence": "MEDIUM",
+      "evidenceIds": [
+        "evidence-1"
+      ]
+    }
+  ],
+  "missingEvidence": [],
+  "recommendedActions": [],
+  "limitations": [
+    "The hypothesis conflicts with the deterministic locator classification."
+  ]
+}

--- a/shaft-doctor/src/test/resources/fixtures/ai/hallucinated-evidence.json
+++ b/shaft-doctor/src/test/resources/fixtures/ai/hallucinated-evidence.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "1.0",
+  "observations": [
+    {
+      "statement": "An unsubmitted network trace shows a connection failure.",
+      "evidenceIds": [
+        "invented-evidence"
+      ]
+    }
+  ],
+  "hypotheses": [],
+  "missingEvidence": [],
+  "recommendedActions": [],
+  "limitations": []
+}

--- a/shaft-doctor/src/test/resources/fixtures/ai/high-quality.json
+++ b/shaft-doctor/src/test/resources/fixtures/ai/high-quality.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": "1.0",
+  "observations": [
+    {
+      "statement": "The failure contains a locator-not-found exception.",
+      "evidenceIds": [
+        "evidence-1"
+      ]
+    }
+  ],
+  "hypotheses": [
+    {
+      "causeCategory": "LOCATOR",
+      "statement": "The locator likely no longer matches the intended element.",
+      "confidence": "HIGH",
+      "evidenceIds": [
+        "evidence-1"
+      ]
+    }
+  ],
+  "missingEvidence": [
+    "A current DOM snapshot would distinguish a changed locator from a wrong page state."
+  ],
+  "recommendedActions": [
+    {
+      "title": "Inspect the locator",
+      "action": "Compare the locator with the current application DOM before changing synchronization.",
+      "evidenceIds": [
+        "evidence-1"
+      ]
+    }
+  ],
+  "limitations": [
+    "Only the submitted redacted exception evidence was analyzed."
+  ]
+}

--- a/shaft-doctor/src/test/resources/fixtures/ai/malformed.json
+++ b/shaft-doctor/src/test/resources/fixtures/ai/malformed.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": "1.0",
+  "observations": [
+}

--- a/shaft-doctor/src/test/resources/fixtures/ai/unavailable.json
+++ b/shaft-doctor/src/test/resources/fixtures/ai/unavailable.json
@@ -1,0 +1,4 @@
+{
+  "status": "provider-unavailable",
+  "reason": "The mock provider is unavailable."
+}

--- a/shaft-mcp/pom.xml
+++ b/shaft-mcp/pom.xml
@@ -77,6 +77,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>shaft-ai</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/shaft-mcp/src/main/java/io/github/shafthq/SHAFT_MCP/DoctorService.java
+++ b/shaft-mcp/src/main/java/io/github/shafthq/SHAFT_MCP/DoctorService.java
@@ -1,8 +1,11 @@
 package io.github.shafthq.SHAFT_MCP;
 
+import com.shaft.doctor.DoctorAiAnalysisRequest;
 import com.shaft.doctor.DoctorAnalysisRequest;
 import com.shaft.doctor.DoctorAnalyzer;
+import com.shaft.doctor.model.DoctorAnalysisResult;
 import com.shaft.doctor.model.DoctorAnalysisSummary;
+import com.shaft.pilot.config.PilotConfiguration;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.stereotype.Service;
 
@@ -10,12 +13,12 @@ import java.nio.file.Path;
 import java.util.List;
 
 /**
- * MCP adapter for offline deterministic SHAFT Doctor analysis.
+ * MCP adapter for deterministic SHAFT Doctor analysis with optional configured provider advisory.
  */
 @Service
 public class DoctorService {
     /**
-     * Analyzes explicitly allowed local evidence without AI or network access.
+     * Analyzes explicitly allowed local evidence and optionally appends a configured provider advisory.
      *
      * @param inputPaths explicit evidence files or directories
      * @param historicalBundlePaths optional older Doctor bundle files
@@ -27,7 +30,8 @@ public class DoctorService {
      * @return deterministic diagnosis and local report paths
      */
     @Tool(name = "doctor_analyze",
-            description = "analyzes allowlisted local SHAFT evidence offline with deterministic cited rules")
+            description = "analyzes allowlisted SHAFT evidence with deterministic cited rules"
+                    + " and an optional separately identified provider advisory")
     public DoctorAnalysisSummary analyze(
             List<String> inputPaths,
             List<String> historicalBundlePaths,
@@ -42,7 +46,7 @@ public class DoctorService {
         Path output = outputDirectory == null || outputDirectory.isBlank()
                 ? Path.of("target", "shaft-doctor")
                 : Path.of(outputDirectory);
-        return DoctorAnalysisSummary.from(new DoctorAnalyzer().analyze(new DoctorAnalysisRequest(
+        DoctorAnalysisRequest request = new DoctorAnalysisRequest(
                 inputs,
                 history,
                 roots,
@@ -51,10 +55,30 @@ public class DoctorService {
                 includePageSnapshots,
                 minimumAllureResults <= 0 ? 1 : minimumAllureResults,
                 DoctorAnalysisRequest.DEFAULT_MAX_ITEM_BYTES,
-                DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES)));
+                DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES);
+        DoctorAnalyzer analyzer = new DoctorAnalyzer();
+        DoctorAnalysisResult result;
+        PilotConfiguration configuration = currentConfiguration();
+        if (configuration != null && configuration.enabled()) {
+            result = analyzer.analyzeWithAi(
+                    request,
+                    DoctorAiAnalysisRequest.defaults(configuration.approvalPolicy()))
+                    .deterministic();
+        } else {
+            result = analyzer.analyze(request);
+        }
+        return DoctorAnalysisSummary.from(result);
     }
 
     private static List<Path> paths(List<String> values) {
         return values == null ? List.of() : values.stream().map(Path::of).toList();
+    }
+
+    private static PilotConfiguration currentConfiguration() {
+        try {
+            return PilotConfiguration.current();
+        } catch (RuntimeException ignored) {
+            return null;
+        }
     }
 }

--- a/shaft-mcp/src/test/java/io/github/shafthq/SHAFT_MCP/DoctorServiceTest.java
+++ b/shaft-mcp/src/test/java/io/github/shafthq/SHAFT_MCP/DoctorServiceTest.java
@@ -1,7 +1,17 @@
 package io.github.shafthq.SHAFT_MCP;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shaft.driver.SHAFT;
 import com.shaft.doctor.model.CauseCategory;
+import com.shaft.pilot.ai.AiCapabilities;
+import com.shaft.pilot.ai.AiProvider;
+import com.shaft.pilot.ai.AiProviderAvailability;
+import com.shaft.pilot.ai.AiProviderRegistry;
+import com.shaft.pilot.ai.AiRequest;
+import com.shaft.pilot.ai.AiResponse;
+import com.shaft.pilot.ai.AiUsage;
+import com.shaft.pilot.ai.ProcessingLocation;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -10,11 +20,21 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DoctorServiceTest {
+    private final AiProviderRegistry registry = new AiProviderRegistry();
+
+    @AfterEach
+    void cleanup() {
+        registry.clearForCurrentThread();
+        SHAFT.Properties.clearForCurrentThread();
+    }
+
     @Test
     void toolAnalyzesAllowlistedEvidenceOffline(@TempDir Path temp) throws Exception {
         Path input = Files.createDirectories(temp.resolve("allure-results"));
@@ -43,5 +63,112 @@ class DoctorServiceTest {
         assertEquals(CauseCategory.TIMING_SYNCHRONIZATION, analysis.diagnosis().primaryCause());
         assertEquals(2, analysis.evidenceItemCount());
         assertTrue(Files.isRegularFile(Path.of(analysis.markdownReportPath())));
+    }
+
+    @Test
+    void configuredProviderAddsAdvisoryThroughDoctorAnalyze(@TempDir Path temp) throws Exception {
+        Path input = Files.createDirectories(temp.resolve("provider-allure-results"));
+        Files.writeString(input.resolve("provider-result.json"), new ObjectMapper().writeValueAsString(Map.of(
+                "uuid", "provider",
+                "historyId", "provider",
+                "name", "provider",
+                "fullName", "example.Provider.test",
+                "status", "failed",
+                "start", 1,
+                "stop", 2,
+                "statusDetails", Map.of(
+                        "message", "NoSuchElementException: unable to locate element",
+                        "trace", "trace"))), StandardCharsets.UTF_8);
+        registry.registerForCurrentThread(new DoctorProvider());
+        SHAFT.Properties.pilot.set()
+                .enabled(true)
+                .provider("doctor-test")
+                .remoteConsent(true)
+                .allowedEvidenceCategories("TEXT,LOG");
+
+        var analysis = new DoctorService().analyze(
+                List.of(input.toString()),
+                List.of(),
+                List.of(temp.toString()),
+                temp.resolve("provider-doctor-output").toString(),
+                false,
+                false,
+                1);
+
+        String report = Files.readString(Path.of(analysis.jsonReportPath()), StandardCharsets.UTF_8);
+        assertEquals(CauseCategory.LOCATOR, analysis.diagnosis().primaryCause());
+        assertTrue(report.contains("\"advisory\""));
+        assertTrue(report.contains("\"provider\" : \"doctor-test\""));
+        assertTrue(report.contains("\"status\" : \"SUCCESS\""));
+    }
+
+    @Test
+    void documentedExternalClientsInvokeDoctorAnalyzeWithoutCredentials() throws Exception {
+        Path root = repositoryRoot();
+        String json = Files.readString(root.resolve(
+                "docs/examples/shaft-pilot/mcp/doctor-analyze-invocations.json"));
+        var fixture = new ObjectMapper().readTree(json);
+
+        assertEquals("doctor_analyze", fixture.path("tool").asText());
+        Set<String> clients = new java.util.LinkedHashSet<>();
+        fixture.path("clients").forEach(client -> clients.add(client.path("name").asText()));
+        assertEquals(Set.of("ChatGPT", "Codex", "Claude", "Gemini", "GitHub Copilot"), clients);
+        assertTrue(fixture.path("arguments").path("includeScreenshots").isBoolean());
+        assertTrue(fixture.path("arguments").path("includePageSnapshots").isBoolean());
+        assertTrue(!json.contains("API_KEY") && !json.contains("apiKey")
+                && !json.toLowerCase(java.util.Locale.ROOT).contains("authorization"));
+    }
+
+    private static Path repositoryRoot() {
+        Path current = Path.of("").toAbsolutePath().normalize();
+        while (current != null) {
+            if (Files.isRegularFile(current.resolve("pom.xml"))
+                    && Files.isDirectory(current.resolve("shaft-mcp"))
+                    && Files.isDirectory(current.resolve("docs"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Repository root could not be resolved.");
+    }
+
+    private static final class DoctorProvider implements AiProvider {
+        @Override
+        public String id() {
+            return "doctor-test";
+        }
+
+        @Override
+        public AiCapabilities capabilities() {
+            return new AiCapabilities(true, false, false, 16_000, ProcessingLocation.REMOTE);
+        }
+
+        @Override
+        public AiProviderAvailability availability() {
+            return AiProviderAvailability.ready();
+        }
+
+        @Override
+        public AiResponse execute(AiRequest request) {
+            String evidenceId = request.evidence().getFirst().id();
+            var payload = new ObjectMapper().createObjectNode();
+            payload.put("schemaVersion", "1.0");
+            payload.putArray("observations").addObject()
+                    .put("statement", "The exception reports a missing element.")
+                    .putArray("evidenceIds").add(evidenceId);
+            payload.putArray("hypotheses").addObject()
+                    .put("causeCategory", "LOCATOR")
+                    .put("statement", "The locator likely needs inspection.")
+                    .put("confidence", "HIGH")
+                    .putArray("evidenceIds").add(evidenceId);
+            payload.putArray("missingEvidence").add("Current DOM snapshot");
+            payload.putArray("recommendedActions").addObject()
+                    .put("title", "Inspect locator")
+                    .put("action", "Compare the locator with the current DOM.")
+                    .putArray("evidenceIds").add(evidenceId);
+            payload.putArray("limitations").add("Only submitted evidence was analyzed.");
+            return AiResponse.success(id(), "doctor-test-model", payload,
+                    Duration.ofMillis(1), AiUsage.empty(), request.deterministicFallback());
+        }
     }
 }


### PR DESCRIPTION
## Summary

- add a versioned Doctor advisory contract on the provider-neutral Pilot AI APIs
- minimize already-redacted evidence, enforce consent and evidence-ID allowlists, sanitize provider text, and preserve the deterministic diagnosis
- render separate JSON/Markdown advisory or fallback sections with provider, model, configuration checksum, timing, usage, cache, warning, and fallback metadata
- package OpenAI, Anthropic, Gemini, and Ollama adapters in the MCP executable while keeping `shaft-doctor` independent of `shaft-ai`
- document CLI, Ollama, direct-provider, ChatGPT, Codex, Claude, Gemini, and GitHub Copilot MCP usage without ingesting client credentials

## Safety

- AI remains disabled by default and deterministic output stays byte-stable when disabled
- provider, authentication, rate-limit, timeout, budget, malformed/schema-invalid/oversized output, and invented-evidence failures retain the deterministic report with a safe fallback notice
- provider text is redacted and Markdown-escaped; raw credentials, raw responses, hidden reasoning, and unapproved evidence are not persisted
- opt-in cache entries contain successful structured advisories only and are invalidated by evidence, diagnosis, consent, or provider configuration changes

## Validation

- `mvn -pl shaft-doctor,shaft-ai,shaft-mcp -am test '-Dtest=DoctorAnalyzerTest,DoctorAiAnalysisServiceTest,ProviderConformanceTest,DoctorServiceTest'`
- `mvn -pl shaft-doctor,shaft-ai,shaft-mcp -am package '-DskipTests' '-Dgpg.skip'`
- focused post-review Doctor tests and package refresh
- `python scripts/ci/validate_modular_documentation.py`
- `python scripts/ci/validate_shaft_mcp_configuration.py`
- `python scripts/ci/validate_agent_guidance.py`
- `git diff --check`

Allure result JSON was populated for Doctor, AI provider, and MCP modules.

Closes #2856