### PR TITLE
[codex] release SHAFT Pilot 10.2.20260612

### DIFF
--- a/.github/RELEASE_BODY_TEMPLATE.md
+++ b/.github/RELEASE_BODY_TEMPLATE.md
@@ -1,3 +1,12 @@
 # SHAFT $RELEASE_VERSION
 
 Auto-generated release notes are included below. Users upgrading from `SHAFT_ENGINE` should read the [modular SHAFT upgrade guide](https://github.com/ShaftHQ/SHAFT_ENGINE/blob/main/docs/UPGRADING_TO_MODULAR_SHAFT.md).
+
+SHAFT Pilot adds deterministic Capture, TestNG generation, Doctor diagnosis,
+reviewed repair proposals, and MCP interoperability. AI is optional, disabled
+by default, and direct OpenAI, Anthropic, Gemini, or Ollama access requires
+explicit enablement and consent. Microsoft/GitHub Copilot integrates through
+MCP rather than a generic provider API-key adapter.
+
+See the [SHAFT Pilot guide](https://github.com/ShaftHQ/SHAFT_ENGINE/blob/main/docs/SHAFT_PILOT.md)
+for installation, configuration, privacy, troubleshooting, and usage examples.

--- a/.github/workflows/mavenCentral_cd.yml
+++ b/.github/workflows/mavenCentral_cd.yml
@@ -46,13 +46,73 @@ jobs:
       - name: Set Release Version Number
         run: |
           echo "RELEASE_VERSION=$(mvn -f pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)" >> "$GITHUB_ENV"
+      - name: Validate SHAFT Pilot release contract
+        run: |
+          python3 scripts/ci/validate_modular_documentation.py
+          python3 scripts/ci/validate_shaft_mcp_configuration.py
+          python3 scripts/ci/validate_shaft_pilot_release.py
+      - name: Install SHAFT Pilot prerequisites without tests
+        run: >-
+          mvn --batch-mode
+          -pl shaft-engine,shaft-pilot-core,shaft-capture,shaft-doctor,shaft-ai,shaft-mcp
+          -am install -DskipTests -Dgpg.skip
+      - name: Reset Pilot Allure result contents
+        run: |
+          for module in shaft-pilot-core shaft-capture shaft-doctor shaft-ai shaft-mcp; do
+            mkdir -p "${module}/allure-results"
+            find "${module}/allure-results" -mindepth 1 -delete
+          done
+      - name: Run deterministic SHAFT Pilot tests
+        run: >-
+          mvn --batch-mode
+          -pl shaft-pilot-core,shaft-capture,shaft-doctor,shaft-ai,shaft-mcp
+          test -Dgpg.skip
+      - name: Verify populated Pilot Allure results
+        run: python3 scripts/ci/validate_shaft_pilot_release.py --check-test-results
+      - name: Run headless SHAFT Capture release journey
+        run: >-
+          mvn --batch-mode
+          -pl shaft-capture test
+          -DincludeCaptureBrowserE2E
+          -Dtest=ManagedCaptureRecorderBrowserTest,CaptureGeneratedReplayBrowserTest
+          -Dgpg.skip
       - name: Validate Maven publication
         run: |
           python3 scripts/ci/validate_maven_publication.py
           mvn --batch-mode clean install -DskipTests -Dgpg.skip
           python3 scripts/ci/validate_maven_publication.py --check-build-outputs
+          python3 scripts/ci/validate_shaft_pilot_release.py --check-build-outputs
+          python3 scripts/ci/validate_shaft_mcp_transports.py
+          mvn --batch-mode -f tools/modularization/consumer-fixtures/pilot-core/pom.xml verify \
+            "-Dshaft.version=${RELEASE_VERSION}"
           mvn --batch-mode -f tools/modularization/consumer-fixtures/combined-modules/pom.xml verify \
             "-Dshaft.version=${RELEASE_VERSION}"
+          mvn --batch-mode -f tools/modularization/consumer-fixtures/mcp/pom.xml verify \
+            "-Dshaft.version=${RELEASE_VERSION}"
+      - name: Build and smoke SHAFT MCP container
+        shell: bash
+        run: |
+          docker build -f shaft-mcp/Dockerfile -t shaft-pilot-release:test .
+          cleanup() {
+            docker rm -f shaft-pilot-release-smoke >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          docker run -d --name shaft-pilot-release-smoke \
+            -e SPRING_PROFILES_ACTIVE=http \
+            -p 127.0.0.1:8081:8081 \
+            shaft-pilot-release:test
+          for attempt in {1..60}; do
+            if curl --fail --silent --show-error \
+              -H "Accept: application/json, text/event-stream" \
+              -H "Content-Type: application/json" \
+              --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"release-smoke","version":"1.0"}}}' \
+              http://127.0.0.1:8081/mcp | grep -q '"name":"shaft-mcp"'; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs shaft-pilot-release-smoke
+          exit 1
       - name: Setup Prerequisites
         run: |
           git config --global user.signingKey "${{ secrets.GPG_KEYNAME }}"

--- a/.github/workflows/mavenCentral_cd.yml
+++ b/.github/workflows/mavenCentral_cd.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
       - name: Reject existing Maven Central release version
         run: python3 scripts/ci/check_maven_release_version.py
       - name: Set up JDK 25

--- a/.github/workflows/shaft-pilot-release.yml
+++ b/.github/workflows/shaft-pilot-release.yml
@@ -34,6 +34,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
       - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/shaft-pilot-release.yml
+++ b/.github/workflows/shaft-pilot-release.yml
@@ -1,0 +1,118 @@
+name: SHAFT Pilot Release Candidate
+
+on:
+  pull_request:
+    paths:
+      - "pom.xml"
+      - "shaft-engine/**"
+      - "shaft-pilot-core/**"
+      - "shaft-capture/**"
+      - "shaft-doctor/**"
+      - "shaft-ai/**"
+      - "shaft-mcp/**"
+      - "shaft-bom/**"
+      - "report-aggregate/**"
+      - "docs/SHAFT_PILOT*.md"
+      - "docs/SHAFT_CAPTURE.md"
+      - "docs/SHAFT_DOCTOR.md"
+      - "docs/SHAFT_MCP.md"
+      - "docs/examples/shaft-pilot/**"
+      - "scripts/ci/validate_shaft_pilot_release.py"
+      - "scripts/ci/validate_maven_publication.py"
+      - "scripts/ci/validate_reactor_versions.py"
+      - "tools/modularization/consumer-fixtures/**"
+      - ".github/workflows/shaft-pilot-release.yml"
+      - ".github/workflows/mavenCentral_cd.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release-candidate:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: "25"
+          distribution: "zulu"
+          check-latest: true
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: 3.9.5
+      - name: Validate release contracts
+        run: |
+          python3 scripts/ci/validate_reactor_versions.py
+          python3 scripts/ci/validate_modular_documentation.py
+          python3 scripts/ci/validate_maven_publication.py
+          python3 scripts/ci/validate_shaft_mcp_configuration.py
+          python3 scripts/ci/validate_shaft_pilot_release.py
+      - name: Install SHAFT Pilot prerequisites without tests
+        run: >-
+          mvn --batch-mode
+          -pl shaft-engine,shaft-pilot-core,shaft-capture,shaft-doctor,shaft-ai,shaft-mcp
+          -am install -DskipTests -Dgpg.skip
+      - name: Reset Pilot Allure result contents
+        run: |
+          for module in shaft-pilot-core shaft-capture shaft-doctor shaft-ai shaft-mcp; do
+            mkdir -p "${module}/allure-results"
+            find "${module}/allure-results" -mindepth 1 -delete
+          done
+      - name: Run deterministic SHAFT Pilot tests
+        run: >-
+          mvn --batch-mode
+          -pl shaft-pilot-core,shaft-capture,shaft-doctor,shaft-ai,shaft-mcp
+          test -Dgpg.skip
+      - name: Verify populated Pilot Allure results
+        run: python3 scripts/ci/validate_shaft_pilot_release.py --check-test-results
+      - name: Run headless SHAFT Capture release journey
+        run: >-
+          mvn --batch-mode
+          -pl shaft-capture test
+          -DincludeCaptureBrowserE2E
+          -Dtest=ManagedCaptureRecorderBrowserTest,CaptureGeneratedReplayBrowserTest
+          -Dgpg.skip
+      - name: Package the complete reactor
+        run: mvn --batch-mode clean install -DskipTests -Dgpg.skip
+      - name: Validate packaged release outputs and MCP transports
+        run: |
+          python3 scripts/ci/validate_maven_publication.py --check-build-outputs
+          python3 scripts/ci/validate_shaft_pilot_release.py --check-build-outputs
+          python3 scripts/ci/validate_shaft_mcp_transports.py
+      - name: Validate clean Pilot consumers
+        run: |
+          VERSION="$(mvn -f pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)"
+          mvn --batch-mode -f tools/modularization/consumer-fixtures/pilot-core/pom.xml \
+            verify "-Dshaft.version=${VERSION}"
+          mvn --batch-mode -f tools/modularization/consumer-fixtures/combined-modules/pom.xml \
+            verify "-Dshaft.version=${VERSION}"
+          mvn --batch-mode -f tools/modularization/consumer-fixtures/mcp/pom.xml \
+            verify "-Dshaft.version=${VERSION}"
+      - name: Build and smoke the release container
+        shell: bash
+        run: |
+          docker build -f shaft-mcp/Dockerfile -t shaft-pilot-release:test .
+          cleanup() {
+            docker rm -f shaft-pilot-release-smoke >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          docker run -d --name shaft-pilot-release-smoke \
+            -e SPRING_PROFILES_ACTIVE=http \
+            -p 127.0.0.1:8081:8081 \
+            shaft-pilot-release:test
+          for attempt in {1..60}; do
+            if curl --fail --silent --show-error \
+              -H "Accept: application/json, text/event-stream" \
+              -H "Content-Type: application/json" \
+              --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"release-smoke","version":"1.0"}}}' \
+              http://127.0.0.1:8081/mcp | grep -q '"name":"shaft-mcp"'; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs shaft-pilot-release-smoke
+          exit 1

--- a/README.md
+++ b/README.md
@@ -236,6 +236,10 @@ and `ImageProcessingActions.compareImageFolders(...)` remain in
 [upgrade guide](docs/UPGRADING_TO_MODULAR_SHAFT.md) lists the exact methods
 that cross each optional dependency boundary.
 
+Use the [SHAFT Pilot guide](docs/SHAFT_PILOT.md) for complete Capture, TestNG
+generation, Doctor, reviewed repair, MCP, provider, privacy, and
+troubleshooting examples.
+
 ### Your First Test
 
 ```java
@@ -352,6 +356,7 @@ When enabled, SHAFT checks `allure --version` and only uses system `allure` when
 |--------------------------------------------------------------------|---------------------------------------------------------------------|
 | 📖 **[User Guide](https://ShaftHQ.github.io/)**                    | Comprehensive documentation, tutorials, and configuration reference |
 | 🏗️ **[Architecture](docs/ARCHITECTURE.md)**                       | Framework design, module overview, and Mermaid diagrams             |
+| 🧭 **[SHAFT Pilot](docs/SHAFT_PILOT.md)**                         | Capture, Doctor, MCP, optional providers, and usage examples         |
 | ⬆️ **[Modular Upgrade Guide](docs/UPGRADING_TO_MODULAR_SHAFT.md)** | Complete migration checklist and method-level dependency matrix     |
 | 🌐 **[BrowserStack Module](docs/SHAFT_BROWSERSTACK_MODULE.md)**    | Direct-session versus BrowserStack SDK behavior                     |
 | 🖼️ **[Visual Module](docs/SHAFT_VISUAL_MODULE.md)**               | Exact APIs that require OpenCV/Eyes/Shutterbug                      |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -133,6 +133,8 @@ present.
 - [BrowserStack SDK module](SHAFT_BROWSERSTACK_MODULE.md)
 - [Visual processing module](SHAFT_VISUAL_MODULE.md)
 - [Desktop video module](SHAFT_VIDEO_MODULE.md)
+- [SHAFT Pilot](SHAFT_PILOT.md)
+- [SHAFT Pilot release runbook](SHAFT_PILOT_RELEASE.md)
 - [SHAFT MCP](SHAFT_MCP.md)
 - [SHAFT Pilot AI](SHAFT_PILOT_AI.md)
 - [SHAFT Capture](SHAFT_CAPTURE.md)

--- a/docs/MAVEN_CENTRAL_PUBLICATION.md
+++ b/docs/MAVEN_CENTRAL_PUBLICATION.md
@@ -30,9 +30,15 @@ A normal unsigned local validation does not contact Maven Central:
 ```bash
 python3 scripts/ci/validate_reactor_versions.py
 python3 scripts/ci/validate_maven_publication.py
+python3 scripts/ci/validate_shaft_pilot_release.py
 mvn --batch-mode clean install -DskipTests -Dgpg.skip
 python3 scripts/ci/validate_maven_publication.py --check-build-outputs
+python3 scripts/ci/validate_shaft_pilot_release.py --check-build-outputs
+mvn --batch-mode -f tools/modularization/consumer-fixtures/pilot-core/pom.xml \
+  verify -Dshaft.version="$(mvn -f pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)"
 mvn --batch-mode -f tools/modularization/consumer-fixtures/combined-modules/pom.xml \
+  verify -Dshaft.version="$(mvn -f pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)"
+mvn --batch-mode -f tools/modularization/consumer-fixtures/mcp/pom.xml \
   verify -Dshaft.version="$(mvn -f pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)"
 python3 scripts/ci/validate_maven_publication.py \
   --create-bundle target/publication-dry-run/central-bundle.zip
@@ -48,9 +54,9 @@ For a signed staging rehearsal, import a disposable GPG key into an isolated `GN
 
 1. Immediately after checkout, probe the root parent POM coordinate on Maven Central. An existing version or an inconclusive Central response stops the job before JDK, Maven, signing, or build setup.
 2. Read the version from the root parent POM and reject reactor version drift.
-3. Validate configuration, build all publication artifacts, and run the combined consumer checks.
+3. Validate the Pilot contract, run deterministic Pilot module tests with populated Allure results, complete the headless Capture release journey, build all publication artifacts, run the provider-neutral core, combined-module, and MCP consumer checks, and smoke-test the HTTP MCP container.
 4. Sign and deploy the complete reactor through the Central Publishing Maven Plugin, waiting for publication success.
-5. Verify every POM, JAR, sources JAR, JavaDocs JAR, and signature from Maven Central, then compile canonical, combined-module, legacy-relocation, and MCP consumers from isolated repositories.
+5. Verify every POM, JAR, sources JAR, JavaDocs JAR, and signature from Maven Central, then compile canonical, provider-neutral core, combined-module, legacy-relocation, and MCP consumers from isolated repositories.
 6. Create the GitHub tag and release.
 7. Dispatch the guide update and announce the release on Slack.
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -328,6 +328,23 @@ in `shaft-engine`.
 Use the [module selection and migration guide](UPGRADING_TO_MODULAR_SHAFT.md)
 for the complete method matrix.
 
+For a no-AI browser-recording workflow, build or download the executable
+`SHAFT_MCP` JAR and run:
+
+```bash
+java -jar SHAFT_MCP-<version>.jar capture start \
+  --url https://example.test --browser chrome \
+  --output recordings/example.json --headless
+java -jar SHAFT_MCP-<version>.jar capture stop
+java -jar SHAFT_MCP-<version>.jar capture generate \
+  --session recordings/example.json \
+  --output-dir generated-tests --replay
+```
+
+See the [SHAFT Pilot guide](SHAFT_PILOT.md) for Doctor analysis, reviewed
+repairs, MCP clients, optional provider configuration, privacy controls, and
+troubleshooting.
+
 ---
 
 [← Back to README](../README.md) | [Features →](FEATURES.md)

--- a/docs/SHAFT_MCP.md
+++ b/docs/SHAFT_MCP.md
@@ -53,6 +53,11 @@ See [SHAFT Doctor](SHAFT_DOCTOR.md) for evidence categories, allowlisted path
 handling, deterministic rules, redaction, offline bundle analysis, optional
 provider advisories, and safe fallback behavior.
 
+See [SHAFT Pilot](SHAFT_PILOT.md) for installation, provider configuration,
+Capture and Doctor examples, privacy defaults, and client-specific MCP setup.
+Maintainers should use the [SHAFT Pilot release runbook](SHAFT_PILOT_RELEASE.md)
+for the deterministic release gate and standalone-repository archival order.
+
 ## Authentication boundary
 
 SHAFT MCP does not require or store OpenAI, Anthropic, Google, Microsoft, or

--- a/docs/SHAFT_PILOT.md
+++ b/docs/SHAFT_PILOT.md
@@ -1,0 +1,229 @@
+# SHAFT Pilot
+
+SHAFT Pilot combines deterministic browser Capture, TestNG generation, failure
+diagnosis, reviewed repair proposals, and MCP interoperability.
+AI is optional and disabled by default.
+Capture, generation, Doctor, and MCP remain usable without a provider account,
+API key, model, or network call.
+
+## Modules
+
+| Module | Purpose |
+| --- | --- |
+| `shaft-pilot-core` | Approval, redaction, budget, schema, audit, and deterministic fallback contracts. |
+| `shaft-capture` | Managed Chrome/Edge recording and deterministic TestNG generation. |
+| `shaft-doctor` | Portable evidence, deterministic diagnosis, and isolated reviewed repair proposals. |
+| `shaft-ai` | Optional direct OpenAI, Anthropic, Gemini, and Ollama adapters. |
+| `SHAFT_MCP` | Executable stdio and Streamable HTTP server plus Capture and Doctor CLI. |
+
+Library consumers should import `shaft-bom` and add only the modules they use:
+
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>io.github.shafthq</groupId>
+      <artifactId>shaft-bom</artifactId>
+      <version>${shaft.version}</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+
+<dependencies>
+  <dependency>
+    <groupId>io.github.shafthq</groupId>
+    <artifactId>shaft-capture</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>io.github.shafthq</groupId>
+    <artifactId>shaft-doctor</artifactId>
+  </dependency>
+</dependencies>
+```
+
+Add `shaft-ai` only for direct provider calls. External ChatGPT, Codex,
+Claude, Gemini, and GitHub Copilot clients use SHAFT through MCP and keep their
+own authentication.
+
+## Install the executable
+
+Download `io.github.shafthq:SHAFT_MCP:<version>` from Maven Central, or build it
+from the monorepo:
+
+```bash
+mvn -pl shaft-mcp -am package -DskipTests -Dgpg.skip
+java -jar shaft-mcp/target/SHAFT_MCP-<version>.jar
+```
+
+The default process is an MCP stdio server. The same JAR dispatches `capture`
+and `doctor` subcommands.
+
+## Capture example
+
+Start a privacy-filtered recording. This example is headless for CI or scripted
+use; omit `--headless` when a person will drive the browser locally:
+
+```bash
+java -jar SHAFT_MCP-<version>.jar capture start \
+  --url https://example.test \
+  --browser chrome \
+  --output recordings/example.json \
+  --headless
+java -jar SHAFT_MCP-<version>.jar capture status
+```
+
+Drive the visible browser or the automation controlling the headless session,
+optionally add a checkpoint, then stop and generate:
+
+```bash
+java -jar SHAFT_MCP-<version>.jar capture checkpoint \
+  --description "Checkout confirmation is visible" --kind ASSERTION
+java -jar SHAFT_MCP-<version>.jar capture stop
+java -jar SHAFT_MCP-<version>.jar capture generate \
+  --session recordings/example.json \
+  --output-dir generated-tests \
+  --package generated.capture \
+  --class-name CheckoutJourneyTest \
+  --replay
+```
+
+Generation writes Java source, externalized ordinary test data, and
+`target/shaft-capture/generation-report.json`. Passwords, configured sensitive
+fields, credential-shaped values, private paths, and unsafe locator evidence
+are excluded or redacted. Replay succeeds only when the generated project
+compiles, passes, and produces populated Allure result JSON.
+
+## Doctor example
+
+Analyze only explicitly allowed evidence:
+
+```bash
+java -jar SHAFT_MCP-<version>.jar doctor analyze \
+  --input allure-results \
+  --allowed-root "$PWD" \
+  --output-dir target/shaft-doctor
+```
+
+Outputs include `doctor-evidence.json`, `doctor-report.json`, and
+`doctor-report.md`. The deterministic rules classify product, test, locator,
+data, timing/synchronization, environment/configuration, infrastructure, and
+unknown failures. Empty and retry-only evidence remains visible instead of
+being converted into a false success.
+
+## Reviewed repair example
+
+Create a complete reviewed input based on
+`examples/shaft-pilot/doctor/repair-input.json`, then run:
+
+```bash
+java -jar SHAFT_MCP-<version>.jar doctor propose-fix \
+  --repository "$PWD" \
+  --base-sha <40-character-commit> \
+  --diagnosis target/shaft-doctor/doctor-report.json \
+  --evidence-bundle target/shaft-doctor/doctor-evidence.json \
+  --issue <issue-or-session> \
+  --allowed-path src/test/java/example/CheckoutTest.java \
+  --repair-input docs/examples/shaft-pilot/doctor/repair-input.json \
+  --output-dir target/shaft-doctor/repairs
+```
+
+Doctor creates and validates a temporary isolated worktree. It does not modify
+the current branch or write to GitHub. After reviewing the diff and validation
+result, publish only a draft pull request with the exact returned token:
+
+```bash
+java -jar SHAFT_MCP-<version>.jar doctor publish-draft-pr \
+  --manifest target/shaft-doctor/repairs/repair-proposal-<id>.json \
+  --approval-token <exact-token> \
+  --approve
+```
+
+The MCP equivalents are `doctor_propose_fix` and
+`doctor_publish_draft_pr`. Publication cannot merge, bypass branch protection,
+or proceed without separate explicit approval.
+
+## MCP clients
+
+For local clients, configure `java -jar /absolute/path/SHAFT_MCP-<version>.jar`
+as a stdio server named `shaft-mcp`. Ready-to-edit examples are under
+`docs/examples/shaft-pilot/mcp/` for Codex, Claude Desktop and Claude Code,
+Gemini CLI, and VS Code with GitHub Copilot.
+
+Start Streamable HTTP for clients that need a reachable HTTPS endpoint:
+
+```bash
+java -jar SHAFT_MCP-<version>.jar --spring.profiles.active=http
+```
+
+The endpoint is `/mcp` and the default port is `8081`. ChatGPT developer
+mode/apps and cloud agents cannot launch a local JAR, so deploy the container
+and expose `/mcp` over HTTPS. GitHub Copilot is an MCP client integration; it is
+not a direct provider API-key adapter.
+
+External client capabilities were verified against official documentation on
+June 12, 2026:
+
+| Client | Supported SHAFT connection | Current limitation or control |
+| --- | --- | --- |
+| ChatGPT apps/developer mode | Public HTTPS Streamable HTTP `/mcp`. See [Connect from ChatGPT](https://developers.openai.com/apps-sdk/deploy/connect-chatgpt). | Hosted ChatGPT cannot start the local JAR; workspace plan and administrator controls apply. |
+| Codex CLI and IDE extension | Local stdio or Streamable HTTP, configured by CLI or shared `config.toml`. See [Codex MCP](https://developers.openai.com/codex/mcp). | Tool approval remains a Codex client policy. |
+| Claude Code and Desktop | Local stdio; Claude Code also supports HTTP and can import Desktop configuration. See [Claude Code MCP](https://docs.anthropic.com/en/docs/claude-code/mcp). | The Claude Messages API uses its separate remote [MCP connector](https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector). |
+| Gemini CLI | Local stdio, SSE, or Streamable HTTP through `settings.json`. See [Gemini CLI MCP](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md). | Server trust and tool confirmation are controlled by Gemini CLI. |
+| GitHub Copilot | MCP-capable IDEs and CLI can use local or remote servers; cloud agent uses repository MCP configuration. See [GitHub Copilot MCP](https://docs.github.com/en/copilot/concepts/context/mcp). | Cloud agent/code review currently consume tools only, and organization policy may restrict MCP. |
+
+## Optional providers
+
+Safe defaults:
+
+```properties
+pilot.ai.enabled=false
+pilot.ai.provider=none
+pilot.ai.consent.local=false
+pilot.ai.consent.remote=false
+pilot.ai.allowedEvidenceCategories=
+```
+
+Provider examples are under `docs/examples/shaft-pilot/providers/`. OpenAI,
+Anthropic, and Gemini read credentials only from their configured environment
+variable names. Ollama needs no credential but still requires local consent.
+Remote consent, local consent, and every evidence category are denied unless
+explicitly enabled.
+
+Provider output is advisory. It cannot replace deterministic diagnosis, apply
+a Capture enrichment without review, or publish a repair without a second
+approval. Timeout, rate limit, authentication, malformed JSON, schema failure,
+budget exhaustion, and provider unavailability all preserve deterministic
+output.
+
+## Privacy and security
+
+- Review recordings, externalized data, Doctor bundles, and repair manifests
+  before sharing them.
+- Screenshots and page snapshots are excluded from Doctor unless explicitly
+  requested.
+- Remote provider sharing requires explicit consent after minimization and
+  redaction.
+- Credentials remain in environment variables or provider-native client
+  authentication and must not be stored in SHAFT properties, examples, logs,
+  generated tests, or Allure attachments.
+- Pilot audit events contain provider/model identifiers, redaction counts,
+  duration, and status, but not prompts, evidence, credentials, or raw model
+  responses.
+
+## Troubleshooting
+
+| Symptom | Resolution |
+| --- | --- |
+| MCP process exits or prints non-protocol output | Use Java 25, run the packaged JAR directly, and keep stdio logs on stderr. |
+| HTTP client cannot connect | Start with `--spring.profiles.active=http`, expose port `8081`, and use `/mcp`. |
+| Capture cannot start | Confirm Chrome or Edge is installed, no prior Capture session owns the runtime directory, and use `--headless` in CI. |
+| Generated test does not replay | Read `generation-report.json`; fix missing external data or an unsupported/ambiguous locator before regenerating. |
+| Doctor reports incomplete evidence | Provide populated `*-result.json` Allure files and set the correct `--allowed-root`. |
+| Provider is unavailable | Keep the deterministic result; verify enablement, consent, model, endpoint, budget, and environment variable name before retrying. |
+| Repair proposal is rejected | Use an exact base SHA, repository-relative allowlist, complete file content, tokenized Maven commands, and a clean isolated worktree. |
+
+See [SHAFT Capture](SHAFT_CAPTURE.md), [SHAFT Doctor](SHAFT_DOCTOR.md),
+[SHAFT Pilot AI](SHAFT_PILOT_AI.md), and [SHAFT MCP](SHAFT_MCP.md) for the
+complete contracts.

--- a/docs/SHAFT_PILOT_RELEASE.md
+++ b/docs/SHAFT_PILOT_RELEASE.md
@@ -1,0 +1,108 @@
+# SHAFT Pilot release
+
+This runbook prepares and verifies the first monorepo SHAFT Pilot release.
+Publication and repository archival are ordered so no external channel points
+to an unverified artifact.
+
+## Release-candidate matrix
+
+| Area | Required release evidence |
+| --- | --- |
+| Runtime | JDK 25 and Maven 3.9 or newer. |
+| Modules | `shaft-pilot-core`, `shaft-capture`, `shaft-doctor`, `shaft-ai`, and `SHAFT_MCP` tests plus full reactor package. |
+| No-AI path | `pilot.ai.enabled=false`, provider `none`, Capture generation/replay, Doctor diagnosis, and MCP tools pass without credentials. |
+| Browsers | Headless Chrome and Edge record the representative local fixture; generated Chrome replay compiles, passes, and populates Allure. |
+| Doctor | Product, test, locator, data, timing, environment, infrastructure, unknown, empty, and retry evidence fixtures pass. |
+| Providers | OpenAI, Anthropic, Gemini, and Ollama use local mock endpoints for success, timeout, rate-limit, authentication, malformed-response, schema, redaction, and fallback conformance. |
+| MCP transports | Packaged stdio and Streamable HTTP `/mcp` initialization and tool discovery pass. |
+| Containers | The release Docker image starts in HTTP mode and completes MCP initialization. |
+| External agents | ChatGPT, Codex, Claude, Gemini, and GitHub Copilot setup is documented with current client limitations and credential ownership. |
+| Publication | Maven Central artifacts, sources, JavaDocs, signatures, BOM, executable JAR, aggregate SBOM, GHCR image, MCP registry metadata, and GitHub release use one version. |
+| Migration | The preserved `io.github.shafthq:SHAFT_MCP` coordinate, `shaft-mcp` server ID, and `ghcr.io/shafthq/shaft-mcp` image resolve before the standalone repository is archived. |
+
+Live paid-provider smoke tests are optional. Run them only with explicit
+approval and credentials in the provider-native environment variable. Their
+absence cannot fail the normal release gate.
+
+## Deterministic gate
+
+Run from a clean checkout:
+
+```bash
+python3 scripts/ci/validate_reactor_versions.py
+python3 scripts/ci/validate_modular_documentation.py
+python3 scripts/ci/validate_shaft_pilot_release.py
+mvn -pl shaft-engine,shaft-pilot-core,shaft-capture,shaft-doctor,shaft-ai,shaft-mcp \
+  -am install -DskipTests -Dgpg.skip
+mvn -pl shaft-pilot-core,shaft-capture,shaft-doctor,shaft-ai,shaft-mcp test -Dgpg.skip
+python3 scripts/ci/validate_shaft_pilot_release.py --check-test-results
+mvn -pl shaft-capture test \
+  -DincludeCaptureBrowserE2E \
+  -Dtest=ManagedCaptureRecorderBrowserTest,CaptureGeneratedReplayBrowserTest \
+  -Dgpg.skip
+mvn clean install -DskipTests -Dgpg.skip
+python3 scripts/ci/validate_maven_publication.py --check-build-outputs
+python3 scripts/ci/validate_shaft_pilot_release.py --check-build-outputs
+python3 scripts/ci/validate_shaft_mcp_transports.py
+```
+
+On PowerShell, single-quote every Maven `-D` argument. Verify that each Pilot
+module has populated `allure-results/*-result.json`; Surefire summaries alone
+are not sufficient.
+
+The Maven Central workflow repeats this evidence before deployment, then
+validates clean consumer fixtures for provider-neutral core, combined modules,
+and the executable MCP coordinate.
+
+## Distribution verification
+
+After Maven Central succeeds:
+
+1. Run `scripts/ci/verify_maven_central_release.py <version>` from isolated
+   local repositories.
+2. Pull `ghcr.io/shafthq/shaft-mcp:<version>` and initialize `/mcp` in a clean
+   container.
+3. Confirm the MCP registry entry `io.github.ShaftHQ/shaft-mcp` references the
+   same package version.
+4. Confirm the GitHub release, JavaDocs, aggregate CycloneDX SBOM, sources,
+   signatures, BOM, and legacy relocation coordinate use the same version.
+5. Exercise one credential-free stdio client configuration and one reachable
+   HTTPS Streamable HTTP client.
+
+Record exact versions, immutable URLs, checksums, workflow runs, and known
+limitations in the release or pull request before migration finalization.
+
+## Standalone repository migration
+
+Do not archive `ShaftHQ/SHAFT_MCP` until every distribution check above passes.
+Then:
+
+1. Replace its README introduction with a prominent notice that development,
+   releases, documentation, issues, and source moved to
+   `ShaftHQ/SHAFT_ENGINE`.
+2. Link the verified monorepo release, [SHAFT Pilot](SHAFT_PILOT.md), and
+   [SHAFT MCP](SHAFT_MCP.md).
+3. Update the repository description and homepage to the canonical repository.
+4. Disable write-oriented workflows and direct users to the canonical issue
+   tracker while preserving existing history, issues, tags, and releases.
+5. Verify the notice on the default branch.
+6. Archive the repository with administrator approval.
+7. Recheck the README, release links, Maven coordinate, image, and registry
+   entry from a logged-out browser.
+
+Archival is a post-release operation. A failed or incomplete distribution
+check leaves the old repository unarchived.
+
+## Rollback
+
+- Before Maven Central succeeds, fix the gate and rerun with the same available
+  version.
+- After Maven Central succeeds, never overwrite or delete the immutable
+  release. Publish a newer version for corrections.
+- If GHCR, registry, hosted MCP, JavaDocs, or release creation fails, repair
+  only that downstream channel and keep the verified Maven version.
+- If migration verification fails, leave `ShaftHQ/SHAFT_MCP` writable and
+  restore its normal automation until the canonical path is confirmed.
+- If a secret canary appears in a recording, report, generated test, image,
+  log, example, or packaged artifact, stop publication, remove the output,
+  rotate any real credential, and repeat the full gate.

--- a/docs/UPGRADING_TO_MODULAR_SHAFT.md
+++ b/docs/UPGRADING_TO_MODULAR_SHAFT.md
@@ -373,7 +373,7 @@ After, using the recommended BOM:
 
 ```xml
 <properties>
-    <shaft.version>10.2.20260610</shaft.version>
+    <shaft.version>10.2.20260612</shaft.version>
 </properties>
 
 <dependencyManagement>
@@ -396,13 +396,13 @@ After, using the recommended BOM:
 </dependencies>
 ```
 
-Version `10.2.20260610` is the prepared first modular SHAFT release.
+Version `10.2.20260612` is the prepared SHAFT Pilot release.
 
 > [!IMPORTANT]
 > Do not change production coordinates until
 > [the canonical artifact on Maven Central](https://central.sonatype.com/artifact/io.github.shafthq/shaft-engine)
-> lists `10.2.20260610`. Until that publication completes, the latest public
-> artifact remains `io.github.shafthq:SHAFT_ENGINE:10.2.20260605`.
+> lists `10.2.20260612`. Until that publication completes, the latest public
+> modular artifact remains `io.github.shafthq:shaft-engine:10.2.20260610`.
 
 ## Module map
 

--- a/docs/examples/shaft-pilot/README.md
+++ b/docs/examples/shaft-pilot/README.md
@@ -1,0 +1,41 @@
+# SHAFT Pilot examples
+
+These examples contain no credentials and assume the executable
+`SHAFT_MCP-<version>.jar` has been downloaded from Maven Central or built from
+the monorepo.
+
+## No-AI Capture to TestNG
+
+```bash
+java -jar SHAFT_MCP-<version>.jar capture start \
+  --url https://example.test --browser chrome \
+  --output recordings/example.json --headless
+java -jar SHAFT_MCP-<version>.jar capture status
+java -jar SHAFT_MCP-<version>.jar capture stop
+java -jar SHAFT_MCP-<version>.jar capture generate \
+  --session recordings/example.json \
+  --output-dir generated-tests --replay
+```
+
+## No-AI Doctor analysis
+
+```bash
+java -jar SHAFT_MCP-<version>.jar doctor analyze \
+  --input allure-results --allowed-root "$PWD" \
+  --output-dir target/shaft-doctor
+```
+
+## Optional local Ollama advisory
+
+Load `providers/ollama.properties` as SHAFT properties, start Ollama locally,
+and add `--ai` to the Doctor command. The deterministic diagnosis remains the
+baseline if Ollama is unavailable or returns invalid output.
+
+## Reviewed repair proposal
+
+Use `doctor/repair-input.json` only after replacing its paths and content with a
+reviewed change. `doctor propose-fix` creates an isolated worktree and does not
+publish to GitHub. Publishing requires a second command with the exact approval
+token returned by the proposal.
+
+MCP client configurations are in `mcp/`.

--- a/docs/examples/shaft-pilot/doctor/repair-input.json
+++ b/docs/examples/shaft-pilot/doctor/repair-input.json
@@ -1,0 +1,31 @@
+{
+  "patches": [
+    {
+      "path": "src/test/java/example/CheckoutTest.java",
+      "operation": "REPLACE",
+      "content": "package example;\n\npublic class CheckoutTest {\n    // Replace with the complete reviewed file content.\n}\n",
+      "rationale": "Apply the reviewed locator correction supported by evidence-1.",
+      "evidenceIds": [
+        "evidence-1"
+      ]
+    }
+  ],
+  "validationCommands": [
+    [
+      "mvn",
+      "-pl",
+      "shaft-engine",
+      "-am",
+      "test",
+      "-Dtest=CheckoutTest"
+    ],
+    [
+      "mvn",
+      "-pl",
+      "shaft-engine",
+      "-am",
+      "compile",
+      "-DskipTests"
+    ]
+  ]
+}

--- a/docs/examples/shaft-pilot/providers/anthropic.properties
+++ b/docs/examples/shaft-pilot/providers/anthropic.properties
@@ -1,0 +1,8 @@
+pilot.ai.enabled=true
+pilot.ai.provider=anthropic
+pilot.ai.consent.local=false
+pilot.ai.consent.remote=true
+pilot.ai.allowedEvidenceCategories=TEXT,LOG,CONFIGURATION
+pilot.ai.anthropic.model=<model>
+pilot.ai.anthropic.apiKeyEnvironmentVariable=ANTHROPIC_API_KEY
+pilot.ai.telemetry.enabled=false

--- a/docs/examples/shaft-pilot/providers/gemini.properties
+++ b/docs/examples/shaft-pilot/providers/gemini.properties
@@ -1,0 +1,8 @@
+pilot.ai.enabled=true
+pilot.ai.provider=gemini
+pilot.ai.consent.local=false
+pilot.ai.consent.remote=true
+pilot.ai.allowedEvidenceCategories=TEXT,LOG,CONFIGURATION
+pilot.ai.gemini.model=<model>
+pilot.ai.gemini.apiKeyEnvironmentVariable=GEMINI_API_KEY
+pilot.ai.telemetry.enabled=false

--- a/docs/examples/shaft-pilot/providers/no-ai.properties
+++ b/docs/examples/shaft-pilot/providers/no-ai.properties
@@ -1,0 +1,6 @@
+pilot.ai.enabled=false
+pilot.ai.provider=none
+pilot.ai.consent.local=false
+pilot.ai.consent.remote=false
+pilot.ai.allowedEvidenceCategories=
+pilot.ai.telemetry.enabled=false

--- a/docs/examples/shaft-pilot/providers/ollama.properties
+++ b/docs/examples/shaft-pilot/providers/ollama.properties
@@ -1,0 +1,8 @@
+pilot.ai.enabled=true
+pilot.ai.provider=ollama
+pilot.ai.consent.local=true
+pilot.ai.consent.remote=false
+pilot.ai.allowedEvidenceCategories=TEXT,LOG,CONFIGURATION
+pilot.ai.ollama.endpoint=http://127.0.0.1:11434/api/chat
+pilot.ai.ollama.model=<local-model>
+pilot.ai.telemetry.enabled=false

--- a/docs/examples/shaft-pilot/providers/openai.properties
+++ b/docs/examples/shaft-pilot/providers/openai.properties
@@ -1,0 +1,8 @@
+pilot.ai.enabled=true
+pilot.ai.provider=openai
+pilot.ai.consent.local=false
+pilot.ai.consent.remote=true
+pilot.ai.allowedEvidenceCategories=TEXT,LOG,CONFIGURATION
+pilot.ai.openai.model=<model>
+pilot.ai.openai.apiKeyEnvironmentVariable=OPENAI_API_KEY
+pilot.ai.telemetry.enabled=false

--- a/legacy-shaft-engine/pom.xml
+++ b/legacy-shaft-engine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260610</version>
+        <version>10.2.20260612</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>SHAFT_ENGINE</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.shafthq</groupId>
     <artifactId>shaft-parent</artifactId>
-    <version>10.2.20260610</version>
+    <version>10.2.20260612</version>
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Build parent and reactor aggregator for SHAFT modules.</description>

--- a/report-aggregate/pom.xml
+++ b/report-aggregate/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260610</version>
+        <version>10.2.20260612</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>report-aggregate</artifactId>

--- a/scripts/ci/validate_shaft_pilot_release.py
+++ b/scripts/ci/validate_shaft_pilot_release.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Validate SHAFT Pilot release documentation, evidence, and packaged outputs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+NS = {"m": "http://maven.apache.org/POM/4.0.0"}
+PILOT_MODULES = (
+    "shaft-pilot-core",
+    "shaft-capture",
+    "shaft-doctor",
+    "shaft-ai",
+    "shaft-mcp",
+)
+PUBLIC_ARTIFACTS = {
+    "shaft-pilot-core": "shaft-pilot-core",
+    "shaft-capture": "shaft-capture",
+    "shaft-doctor": "shaft-doctor",
+    "shaft-ai": "shaft-ai",
+    "shaft-mcp": "SHAFT_MCP",
+}
+SECRET_CANARIES = (
+    b"DO-NOT-RETAIN-SECRET",
+    b"capture-browser-secret-canary",
+    b"capture-secret-canary-value",
+    b"sk-secret-canary-123456789",
+    b"provider-secret-canary",
+    b"advisory-report-secret",
+    b"truncated-json-canary",
+)
+CREDENTIAL_PATTERNS = (
+    re.compile(
+        rb"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"
+        rb"\s+[A-Za-z0-9+/=\r\n]{40,}"
+    ),
+    re.compile(rb"\bsk-(?:proj|ant)-[A-Za-z0-9_-]{16,}\b"),
+    re.compile(rb"\bgithub_pat_[A-Za-z0-9_]{16,}\b"),
+    re.compile(rb"\bgh[pousr]_[A-Za-z0-9]{20,}\b"),
+    re.compile(rb"\bAKIA[0-9A-Z]{16}\b"),
+)
+
+
+def text(element: ET.Element, path: str) -> str:
+    return (element.findtext(path, default="", namespaces=NS) or "").strip()
+
+
+def reactor_version(root: Path = ROOT) -> str:
+    return text(ET.parse(root / "pom.xml").getroot(), "m:version")
+
+
+def scan_bytes(label: str, content: bytes) -> list[str]:
+    errors = []
+    for canary in SECRET_CANARIES:
+        if canary in content:
+            errors.append(f"{label}: contains Pilot secret canary {canary.decode('ascii')}")
+    for pattern in CREDENTIAL_PATTERNS:
+        if pattern.search(content):
+            errors.append(f"{label}: contains a credential-shaped value")
+    return errors
+
+
+def validate_static(root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+    version = reactor_version(root)
+    if not re.fullmatch(r"\d+\.[1-4]\.\d{8}", version):
+        errors.append(f"reactor version is not a dated SHAFT release: {version!r}")
+
+    parent = ET.parse(root / "pom.xml").getroot()
+    modules = {
+        text(module, ".")
+        for module in parent.findall("m:modules/m:module", NS)
+    }
+    missing_modules = set(PILOT_MODULES) - modules
+    if missing_modules:
+        errors.append(f"reactor is missing Pilot modules: {sorted(missing_modules)}")
+
+    bom = ET.parse(root / "shaft-bom/pom.xml").getroot()
+    managed = {
+        text(dependency, "m:artifactId")
+        for dependency in bom.findall(
+            "m:dependencyManagement/m:dependencies/m:dependency", NS
+        )
+    }
+    expected_managed = set(PUBLIC_ARTIFACTS.values())
+    if not expected_managed.issubset(managed):
+        errors.append(
+            f"shaft-bom is missing Pilot artifacts: {sorted(expected_managed - managed)}"
+        )
+
+    internal = (
+        root / "shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java"
+    ).read_text(encoding="utf-8")
+    version_match = re.search(
+        r'@DefaultValue\("([^"]+)"\)\s+String shaftEngineVersion\(\);',
+        internal,
+    )
+    if not version_match or version_match.group(1) != version:
+        errors.append("Internal.shaftEngineVersion must match the reactor version")
+
+    pilot_properties = (
+        root / "shaft-engine/src/main/java/com/shaft/properties/internal/Pilot.java"
+    ).read_text(encoding="utf-8")
+    for required in (
+        '@Key("pilot.ai.enabled")\n    @DefaultValue("false")',
+        '@Key("pilot.ai.provider")\n    @DefaultValue("none")',
+        '@Key("pilot.ai.consent.local")\n    @DefaultValue("false")',
+        '@Key("pilot.ai.consent.remote")\n    @DefaultValue("false")',
+        '@Key("pilot.ai.telemetry.enabled")\n    @DefaultValue("false")',
+    ):
+        if required not in pilot_properties:
+            errors.append(f"Pilot safe default is missing: {required.splitlines()[0]}")
+
+    guide = (root / "docs/SHAFT_PILOT.md").read_text(encoding="utf-8")
+    for required in (
+        "AI is optional and disabled by default",
+        "pilot.ai.enabled=false",
+        "capture start",
+        "capture generate",
+        "doctor analyze",
+        "doctor propose-fix",
+        "doctor_publish_draft_pr",
+        "OpenAI",
+        "Anthropic",
+        "Gemini",
+        "Ollama",
+        "GitHub Copilot",
+        "Troubleshooting",
+    ):
+        if required not in guide:
+            errors.append(f"SHAFT_PILOT.md is missing {required!r}")
+
+    release_guide = (root / "docs/SHAFT_PILOT_RELEASE.md").read_text(
+        encoding="utf-8"
+    )
+    for required in (
+        "Release-candidate matrix",
+        "JDK 25",
+        "Maven 3.9",
+        "Chrome",
+        "Edge",
+        "stdio",
+        "Streamable HTTP",
+        "mock",
+        "Maven Central",
+        "ghcr.io/shafthq/shaft-mcp",
+        "ShaftHQ/SHAFT_MCP",
+        "Rollback",
+    ):
+        if required not in release_guide:
+            errors.append(f"SHAFT_PILOT_RELEASE.md is missing {required!r}")
+
+    examples = root / "docs/examples/shaft-pilot"
+    for path in sorted(examples.rglob("*")):
+        if not path.is_file():
+            continue
+        content = path.read_bytes()
+        errors.extend(scan_bytes(str(path.relative_to(root)), content))
+        if path.suffix == ".json":
+            try:
+                json.loads(content)
+            except json.JSONDecodeError as error:
+                errors.append(f"{path.relative_to(root)}: invalid JSON: {error}")
+        if path.suffix == ".toml":
+            try:
+                tomllib.loads(content.decode("utf-8"))
+            except (UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+                errors.append(f"{path.relative_to(root)}: invalid TOML: {error}")
+
+    workflow = (root / ".github/workflows/mavenCentral_cd.yml").read_text(
+        encoding="utf-8"
+    )
+    required_steps = (
+        "Validate SHAFT Pilot release contract",
+        "Run deterministic SHAFT Pilot tests",
+        "Run headless SHAFT Capture release journey",
+        "Validate Maven publication",
+        "Deploy to Maven Central",
+        "Verify published Maven Central coordinates",
+    )
+    positions = [workflow.find(step) for step in required_steps]
+    if any(position < 0 for position in positions) or positions != sorted(positions):
+        errors.append("Maven Central workflow does not enforce the Pilot release gate")
+
+    return errors
+
+
+def validate_test_results(root: Path = ROOT) -> list[str]:
+    errors = []
+    for module in PILOT_MODULES:
+        results = root / module / "allure-results"
+        populated = list(results.glob("*-result.json")) if results.is_dir() else []
+        if not populated:
+            errors.append(f"{module}: populated Allure result JSON is missing")
+            continue
+        for path in results.rglob("*"):
+            if path.is_file() and path.stat().st_size <= 10 * 1024 * 1024:
+                errors.extend(
+                    scan_bytes(str(path.relative_to(root)), path.read_bytes())
+                )
+
+    for relative in (
+        Path("shaft-capture/target/shaft-capture"),
+        Path("shaft-doctor/target/shaft-doctor"),
+    ):
+        directory = root / relative
+        if not directory.is_dir():
+            continue
+        for path in directory.rglob("*"):
+            if path.is_file() and path.stat().st_size <= 10 * 1024 * 1024:
+                errors.extend(
+                    scan_bytes(str(path.relative_to(root)), path.read_bytes())
+                )
+    return errors
+
+
+def validate_build_outputs(root: Path = ROOT) -> list[str]:
+    errors = []
+    version = reactor_version(root)
+    for module, artifact in PUBLIC_ARTIFACTS.items():
+        jar = root / module / "target" / f"{artifact}-{version}.jar"
+        if not jar.is_file():
+            errors.append(f"missing packaged Pilot artifact: {jar.relative_to(root)}")
+            continue
+        try:
+            with zipfile.ZipFile(jar) as archive:
+                for entry in archive.infolist():
+                    if entry.is_dir() or entry.file_size > 10 * 1024 * 1024:
+                        continue
+                    errors.extend(
+                        scan_bytes(
+                            f"{jar.relative_to(root)}!/{entry.filename}",
+                            archive.read(entry),
+                        )
+                    )
+        except zipfile.BadZipFile as error:
+            errors.append(f"{jar.relative_to(root)}: invalid JAR: {error}")
+
+    if not (root / "target/bom.json").is_file():
+        errors.append("missing aggregate CycloneDX output: target/bom.json")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check-test-results", action="store_true")
+    parser.add_argument("--check-build-outputs", action="store_true")
+    args = parser.parse_args()
+
+    errors = validate_static()
+    if args.check_test_results:
+        errors.extend(validate_test_results())
+    if args.check_build_outputs:
+        errors.extend(validate_build_outputs())
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    print("SHAFT Pilot release contract is valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/shaft-ai/pom.xml
+++ b/shaft-ai/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260610</version>
+        <version>10.2.20260612</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shaft-bom/pom.xml
+++ b/shaft-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260610</version>
+        <version>10.2.20260612</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>shaft-bom</artifactId>

--- a/shaft-browserstack/pom.xml
+++ b/shaft-browserstack/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260610</version>
+        <version>10.2.20260612</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>shaft-browserstack</artifactId>

--- a/shaft-capture/pom.xml
+++ b/shaft-capture/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260610</version>
+        <version>10.2.20260612</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -49,7 +49,7 @@ class CaptureGeneratorTest {
         String data = Files.readString(first.testDataPath());
         String golden = Files.readString(Path.of(
                 "src/test/resources/fixtures/golden-generated-session-1.java"));
-        assertEquals(golden, source);
+        assertEquals(normalizeLineEndings(golden), normalizeLineEndings(source));
         assertTrue(source.contains("@AfterMethod(alwaysRun = true)"));
         assertTrue(source.contains("driver.quit();"));
         assertTrue(source.contains("SHAFT.GUI.Locator.inputField(\"Username\")"));
@@ -212,6 +212,10 @@ class CaptureGeneratorTest {
         Path path = temp.resolve("capture.json");
         new CaptureJsonCodec().write(path, captureSession);
         return path;
+    }
+
+    private static String normalizeLineEndings(String value) {
+        return value.replace("\r\n", "\n").replace('\r', '\n');
     }
 
     private void writeCaptureData(String username) throws Exception {

--- a/shaft-doctor/pom.xml
+++ b/shaft-doctor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260610</version>
+        <version>10.2.20260612</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shaft-engine/pom.xml
+++ b/shaft-engine/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260610</version>
+        <version>10.2.20260612</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>shaft-engine</artifactId>

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java
@@ -18,7 +18,7 @@ import org.aeonbits.owner.Config.Sources;
 })
 public interface Internal extends EngineProperties<Internal> {
     @Key("shaftEngineVersion")
-    @DefaultValue("10.2.20260610")
+    @DefaultValue("10.2.20260612")
     String shaftEngineVersion();
 
     @Key("watermarkImagePath")
@@ -32,7 +32,7 @@ public interface Internal extends EngineProperties<Internal> {
      * without changing {@code AllureManager} or any CI script. Use this url for the latest version <a href="https://github.com/allure-framework/allure3/releases">Allure3Releases</a>
      */
     @Key("allure3Version")
-    @DefaultValue("3.10.0")
+    @DefaultValue("3.11.0")
     String allure3Version();
 
     /**

--- a/shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260610</shaft.version>
+        <shaft.version>10.2.20260612</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260610</shaft.version>
+        <shaft.version>10.2.20260612</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260610</shaft.version>
+        <shaft.version>10.2.20260612</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260610</shaft.version>
+        <shaft.version>10.2.20260612</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260610</shaft.version>
+        <shaft.version>10.2.20260612</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260610</shaft.version>
+        <shaft.version>10.2.20260612</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260610</shaft.version>
+        <shaft.version>10.2.20260612</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-mcp/pom.xml
+++ b/shaft-mcp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260610</version>
+        <version>10.2.20260612</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shaft-pilot-core/pom.xml
+++ b/shaft-pilot-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260610</version>
+        <version>10.2.20260612</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shaft-video/pom.xml
+++ b/shaft-video/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260610</version>
+        <version>10.2.20260612</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>shaft-video</artifactId>

--- a/shaft-visual/pom.xml
+++ b/shaft-visual/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260610</version>
+        <version>10.2.20260612</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>shaft-visual</artifactId>

--- a/tests/scripts/test_validate_shaft_pilot_release.py
+++ b/tests/scripts/test_validate_shaft_pilot_release.py
@@ -1,0 +1,92 @@
+import importlib.util
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/ci/validate_shaft_pilot_release.py"
+SPEC = importlib.util.spec_from_file_location("validate_shaft_pilot_release", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class ShaftPilotReleaseValidatorTest(unittest.TestCase):
+    def test_repository_static_contract_is_valid(self):
+        self.assertEqual([], MODULE.validate_static(ROOT))
+
+    def test_credential_shaped_values_are_rejected(self):
+        errors = MODULE.scan_bytes("fixture", b"token=ghp_12345678901234567890")
+
+        self.assertTrue(errors)
+
+    def test_private_key_detection_marker_is_not_treated_as_key_material(self):
+        errors = MODULE.scan_bytes("fixture", b"-----BEGIN PRIVATE KEY-----")
+
+        self.assertEqual([], errors)
+
+    def test_private_key_material_is_rejected(self):
+        content = (
+            b"-----BEGIN PRIVATE KEY-----\n"
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwx"
+        )
+
+        self.assertTrue(MODULE.scan_bytes("fixture", content))
+
+    def test_allure_attachments_are_scanned_for_canaries(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            for module in MODULE.PILOT_MODULES:
+                results = root / module / "allure-results"
+                results.mkdir(parents=True)
+                (results / f"{module}-result.json").write_text(
+                    '{"status":"passed"}',
+                    encoding="utf-8",
+                )
+            (
+                root / "shaft-capture/allure-results/browser-attachment.txt"
+            ).write_text("capture-browser-secret-canary", encoding="utf-8")
+
+            errors = MODULE.validate_test_results(root)
+
+        self.assertTrue(
+            any("capture-browser-secret-canary" in error for error in errors)
+        )
+
+    def test_packaged_secret_canaries_are_rejected(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            version = "10.2.20260612"
+            (root / "pom.xml").write_text(
+                f"""<project xmlns="http://maven.apache.org/POM/4.0.0">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>io.github.shafthq</groupId>
+                <artifactId>shaft-parent</artifactId>
+                <version>{version}</version>
+                </project>""",
+                encoding="utf-8",
+            )
+            for module, artifact in MODULE.PUBLIC_ARTIFACTS.items():
+                target = root / module / "target"
+                target.mkdir(parents=True)
+                with zipfile.ZipFile(target / f"{artifact}-{version}.jar", "w") as jar:
+                    content = (
+                        b"capture-browser-secret-canary"
+                        if module == "shaft-capture"
+                        else b"safe"
+                    )
+                    jar.writestr("fixture.txt", content)
+            (root / "target").mkdir()
+            (root / "target/bom.json").write_text("{}", encoding="utf-8")
+
+            errors = MODULE.validate_build_outputs(root)
+
+        self.assertTrue(
+            any("capture-browser-secret-canary" in error for error in errors)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/modularization/consumer-fixtures/api/pom.xml
+++ b/tools/modularization/consumer-fixtures/api/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260610</shaft.version>
+        <shaft.version>10.2.20260612</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/appium-mobile/pom.xml
+++ b/tools/modularization/consumer-fixtures/appium-mobile/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260610</shaft.version>
+        <shaft.version>10.2.20260612</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/bom/pom.xml
+++ b/tools/modularization/consumer-fixtures/bom/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260610</shaft.version>
+        <shaft.version>10.2.20260612</shaft.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/tools/modularization/consumer-fixtures/browserstack-sdk/pom.xml
+++ b/tools/modularization/consumer-fixtures/browserstack-sdk/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260610</shaft.version>
+        <shaft.version>10.2.20260612</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/combined-modules/pom.xml
+++ b/tools/modularization/consumer-fixtures/combined-modules/pom.xml
@@ -10,7 +10,7 @@
     <description>Validates the published BOM and all optional modules as one consumer graph.</description>
 
     <properties>
-        <shaft.version>10.2.20260610</shaft.version>
+        <shaft.version>10.2.20260612</shaft.version>
     </properties>
 
     <dependencyManagement>

--- a/tools/modularization/consumer-fixtures/desktop-video/pom.xml
+++ b/tools/modularization/consumer-fixtures/desktop-video/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260610</shaft.version>
+        <shaft.version>10.2.20260612</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/junit-web/pom.xml
+++ b/tools/modularization/consumer-fixtures/junit-web/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260610</shaft.version>
+        <shaft.version>10.2.20260612</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/legacy-coordinate/pom.xml
+++ b/tools/modularization/consumer-fixtures/legacy-coordinate/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260610</shaft.version>
+        <shaft.version>10.2.20260612</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/mcp/pom.xml
+++ b/tools/modularization/consumer-fixtures/mcp/pom.xml
@@ -9,7 +9,7 @@
     <description>Resolves the preserved SHAFT_MCP executable coordinate through the SHAFT BOM.</description>
 
     <properties>
-        <shaft.version>10.2.20260610</shaft.version>
+        <shaft.version>10.2.20260612</shaft.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/tools/modularization/consumer-fixtures/opencv-visual/pom.xml
+++ b/tools/modularization/consumer-fixtures/opencv-visual/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260610</shaft.version>
+        <shaft.version>10.2.20260612</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/pilot-core/pom.xml
+++ b/tools/modularization/consumer-fixtures/pilot-core/pom.xml
@@ -9,7 +9,7 @@
     <description>Compiles against Pilot contracts without the optional direct-provider module.</description>
 
     <properties>
-        <shaft.version>10.2.20260610</shaft.version>
+        <shaft.version>10.2.20260612</shaft.version>
         <maven.compiler.release>25</maven.compiler.release>
     </properties>
 

--- a/tools/modularization/consumer-fixtures/testng-web/pom.xml
+++ b/tools/modularization/consumer-fixtures/testng-web/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260610</shaft.version>
+        <shaft.version>10.2.20260612</shaft.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
## Summary

- prepare the version-aligned `10.2.20260612` SHAFT Pilot release across the reactor, BOM, examples, fixtures, and internal version metadata
- add deterministic release gates for Pilot modules, populated Allure evidence, headless Capture record/replay, packaged secret scanning, clean consumers, MCP transports, and the HTTP container
- publish consolidated installation, provider, privacy, security, troubleshooting, migration, release, and usage documentation with credential-free examples
- update Allure 3 to `3.11.0` while leaving the existing analytics key and telemetry implementation unchanged

## Why

Issues #2858 and #2848 require the final cross-module validation and release process before the standalone `ShaftHQ/SHAFT_MCP` repository can be redirected and archived. The previous reactor version is already immutable on Maven Central, so this candidate uses `10.2.20260612`.

## Validation

- 117 deterministic Pilot module tests with populated Allure JSON
- 3 headless Capture browser journeys, including generated-project compile/replay
- packaged stdio and Streamable HTTP MCP smoke tests
- full reactor packaging completed; the initial clean stopped only because IntelliJ Copilot was actively using the prior MCP JAR, then the reactor resumed successfully from `shaft-mcp`
- Maven publication and Pilot packaged-output validators
- provider-neutral Pilot core, combined-module BOM, and MCP consumer fixtures
- 22 CI-script regression tests plus 6 focused Pilot release-validator tests
- JavaDocs assembly, quality configuration, workflow YAML lint, documentation links, agent-guidance validation, and `git diff --check`

## Remaining protected release steps

The PR workflow must still run the clean Linux build and Docker smoke. After merge, keep #2858 and #2848 open until Maven Central, GitHub release, JavaDocs, GHCR, MCP registry, hosted MCP endpoints, and the archived standalone repository have all been verified.