### PR TITLE
fix: link SHAFT MCP image to canonical repository

### DIFF
--- a/shaft-mcp/Dockerfile
+++ b/shaft-mcp/Dockerfile
@@ -9,7 +9,10 @@ RUN mvn --batch-mode --no-transfer-progress -pl shaft-mcp -am package -DskipTest
 
 FROM eclipse-temurin:25-jre
 
-LABEL io.modelcontextprotocol.server.name="io.github.ShaftHQ/shaft-mcp"
+LABEL io.modelcontextprotocol.server.name="io.github.ShaftHQ/shaft-mcp" \
+      org.opencontainers.image.source="https://github.com/ShaftHQ/SHAFT_ENGINE" \
+      org.opencontainers.image.description="SHAFT MCP server for browser and test automation" \
+      org.opencontainers.image.licenses="MIT"
 
 WORKDIR /app
 COPY --from=builder /build/SHAFT_MCP.jar /app/SHAFT_MCP.jar


### PR DESCRIPTION
## Summary
- add the canonical SHAFT_ENGINE source label to the SHAFT MCP OCI image
- add package description and license metadata
- enable the existing GHCR package to be handed off from the legacy repository

## Validation
- git diff --check
- final proof is the canonical Publish SHAFT MCP Distributions workflow pushing version 10.2.20260612

Related to #2858