### PR TITLE
fix: publish SHAFT MCP from canonical GHCR package

### DIFF
--- a/.github/workflows/publish-shaft-mcp.yml
+++ b/.github/workflows/publish-shaft-mcp.yml
@@ -42,8 +42,8 @@ jobs:
           file: shaft-mcp/Dockerfile
           push: true
           tags: |
-            ghcr.io/shafthq/shaft-mcp:${{ env.VERSION }}
-            ghcr.io/shafthq/shaft-mcp:latest
+            ghcr.io/shafthq/shaft-engine-mcp:${{ env.VERSION }}
+            ghcr.io/shafthq/shaft-engine-mcp:latest
       - name: Materialize and validate MCP registry metadata
         working-directory: shaft-mcp
         run: |

--- a/docs/SHAFT_MCP.md
+++ b/docs/SHAFT_MCP.md
@@ -144,10 +144,12 @@ The first monorepo release preserves:
 
 - Maven: `io.github.shafthq:SHAFT_MCP`
 - MCP server name: `shaft-mcp`
-- OCI image: `ghcr.io/shafthq/shaft-mcp`
+- Canonical OCI image: `ghcr.io/shafthq/shaft-engine-mcp`
+- First-release compatibility image: `ghcr.io/shafthq/shaft-mcp:10.2.20260612`
 - MCP registry name: `io.github.ShaftHQ/shaft-mcp`
 - Java package and existing tool names
 
 `shaft-mcp/server.json` is a release template. The publication workflow
 replaces `@project.version@` from the root reactor version before registry
-validation and publication.
+validation and publication. Existing users of the historical image can pin
+the compatibility version above; use the canonical image for upgrades.

--- a/docs/SHAFT_PILOT_RELEASE.md
+++ b/docs/SHAFT_PILOT_RELEASE.md
@@ -18,7 +18,7 @@ to an unverified artifact.
 | Containers | The release Docker image starts in HTTP mode and completes MCP initialization. |
 | External agents | ChatGPT, Codex, Claude, Gemini, and GitHub Copilot setup is documented with current client limitations and credential ownership. |
 | Publication | Maven Central artifacts, sources, JavaDocs, signatures, BOM, executable JAR, aggregate SBOM, GHCR image, MCP registry metadata, and GitHub release use one version. |
-| Migration | The preserved `io.github.shafthq:SHAFT_MCP` coordinate, `shaft-mcp` server ID, and `ghcr.io/shafthq/shaft-mcp` image resolve before the standalone repository is archived. |
+| Migration | The preserved `io.github.shafthq:SHAFT_MCP` coordinate and `shaft-mcp` server ID resolve. `ghcr.io/shafthq/shaft-mcp:10.2.20260612` remains a tested compatibility image, while `ghcr.io/shafthq/shaft-engine-mcp` is published by the monorepo for current and future releases. |
 
 Live paid-provider smoke tests are optional. Run them only with explicit
 approval and credentials in the provider-native environment variable. Their
@@ -60,8 +60,9 @@ After Maven Central succeeds:
 
 1. Run `scripts/ci/verify_maven_central_release.py <version>` from isolated
    local repositories.
-2. Pull `ghcr.io/shafthq/shaft-mcp:<version>` and initialize `/mcp` in a clean
-   container.
+2. Pull `ghcr.io/shafthq/shaft-engine-mcp:<version>` and initialize `/mcp` in
+   a clean container. For the first monorepo release, also verify the
+   `ghcr.io/shafthq/shaft-mcp:10.2.20260612` compatibility image.
 3. Confirm the MCP registry entry `io.github.ShaftHQ/shaft-mcp` references the
    same package version.
 4. Confirm the GitHub release, JavaDocs, aggregate CycloneDX SBOM, sources,

--- a/scripts/ci/validate_shaft_pilot_release.py
+++ b/scripts/ci/validate_shaft_pilot_release.py
@@ -151,6 +151,7 @@ def validate_static(root: Path = ROOT) -> list[str]:
         "Streamable HTTP",
         "mock",
         "Maven Central",
+        "ghcr.io/shafthq/shaft-engine-mcp",
         "ghcr.io/shafthq/shaft-mcp",
         "ShaftHQ/SHAFT_MCP",
         "Rollback",

--- a/shaft-mcp/.github/copilot-instructions.md
+++ b/shaft-mcp/.github/copilot-instructions.md
@@ -161,7 +161,7 @@ When writing XPath locators for SHAFT Engine:
 
 ### Dockerfile
 - Downloads released JAR from Maven Central (STDIO transport)
-- Published to GitHub Container Registry: `ghcr.io/shafthq/shaft-mcp`
+- Published to GitHub Container Registry: `ghcr.io/shafthq/shaft-engine-mcp`
 
 ### Dockerfile.smithery
 - Downloads released JAR from Maven Central (HTTP/SSE transport)

--- a/shaft-mcp/SMITHERY_DEPLOYMENT.md
+++ b/shaft-mcp/SMITHERY_DEPLOYMENT.md
@@ -56,13 +56,14 @@ https://shaft-mcp.fly.dev/mcp
 1. The root Maven Central workflow publishes `io.github.shafthq:SHAFT_MCP`
    with the complete SHAFT reactor.
 2. `publish-shaft-mcp.yml` builds and pushes
-   `ghcr.io/shafthq/shaft-mcp:<version>` and `latest`.
+   `ghcr.io/shafthq/shaft-engine-mcp:<version>` and `latest`.
 3. The same workflow renders `shaft-mcp/server.json` from the root version,
    validates it against the MCP registry schema, and publishes it with GitHub
    OIDC.
 4. `deploy-shaft-mcp.yml` triggers configured Render and Fly.io deployments;
    Smithery rebuilds through its GitHub integration.
 
-The source `ShaftHQ/SHAFT_MCP` repository remains active during the transition.
-The preserved Maven, OCI, server, and registry identifiers let existing
-consumers move to monorepo-produced releases without a naming migration.
+The historical `ShaftHQ/SHAFT_MCP` repository is read-only. Its
+`ghcr.io/shafthq/shaft-mcp:10.2.20260612` compatibility image was built from
+the monorepo and remains available for migration. Use
+`ghcr.io/shafthq/shaft-engine-mcp` for current and future container releases.

--- a/shaft-mcp/readme.md
+++ b/shaft-mcp/readme.md
@@ -2,8 +2,10 @@
 
 SHAFT MCP exposes SHAFT browser automation through the Model Context Protocol.
 The module preserves the published `io.github.shafthq:SHAFT_MCP` coordinate,
-`shaft-mcp` server name, existing Java packages and tool names, and the
-`ghcr.io/shafthq/shaft-mcp` image identity.
+`shaft-mcp` server name, existing Java packages, and tool names. New container
+releases use the canonical `ghcr.io/shafthq/shaft-engine-mcp` image. The
+verified `ghcr.io/shafthq/shaft-mcp:10.2.20260612` image remains available as
+the standalone-repository migration alias.
 
 ## Build
 

--- a/shaft-mcp/server.json
+++ b/shaft-mcp/server.json
@@ -12,7 +12,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/shafthq/shaft-mcp:@project.version@",
+      "identifier": "ghcr.io/shafthq/shaft-engine-mcp:@project.version@",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
- publish future SHAFT MCP containers as ghcr.io/shafthq/shaft-engine-mcp`n- point MCP registry metadata at the canonical package owned by SHAFT_ENGINE
- document ghcr.io/shafthq/shaft-mcp:10.2.20260612 as the verified first-release compatibility alias
- enforce both canonical and compatibility identities in the Pilot release validator

## Why
The pre-existing granular GHCR package grants Actions write access only to the legacy SHAFT_MCP repository. The compatibility tag has been rebuilt from the monorepo and verified. A canonical package lets SHAFT_ENGINE own all future publication without a PAT or the legacy repository.

## Validation
- python scripts/ci/validate_shaft_pilot_release.py`n- python -m unittest tests.scripts.test_validate_shaft_pilot_release`n- python scripts/ci/validate_shaft_mcp_configuration.py`n- python scripts/ci/validate_modular_documentation.py`n- JSON parse and git diff --check`n
Closes the final GHCR handoff portion of #2858