### PR TITLE
docs: record optional MCP hosting status

### DIFF
--- a/.github/workflows/deploy-shaft-mcp.yml
+++ b/.github/workflows/deploy-shaft-mcp.yml
@@ -49,5 +49,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-22.04
     steps:
-      - name: Record Smithery deployment handoff
-        run: echo "Smithery rebuilds from the root smithery.yaml GitHub integration."
+      - name: Record optional Smithery deployment handoff
+        run: |
+          echo "This job does not deploy to Smithery."
+          echo "Connect ShaftHQ/SHAFT_ENGINE in Smithery, then verify the resulting /mcp endpoint."

--- a/docs/SHAFT_PILOT_RELEASE.md
+++ b/docs/SHAFT_PILOT_RELEASE.md
@@ -67,11 +67,19 @@ After Maven Central succeeds:
    same package version.
 4. Confirm the GitHub release, JavaDocs, aggregate CycloneDX SBOM, sources,
    signatures, BOM, and legacy relocation coordinate use the same version.
-5. Exercise one credential-free stdio client configuration and one reachable
-   HTTPS Streamable HTTP client.
+5. Exercise one credential-free stdio client configuration and the packaged
+   Streamable HTTP transport. Exercise a hosted HTTPS endpoint only when its
+   external deployment account is configured; otherwise record it as a known
+   limitation instead of presenting the endpoint as live.
 
 Record exact versions, immutable URLs, checksums, workflow runs, and known
 limitations in the release or pull request before migration finalization.
+
+For release `10.2.20260612`, the Render and Fly repository secrets were not
+configured, the Fly hostname did not resolve, Render returned `404` at `/mcp`,
+and the historical Smithery listing was unavailable. These optional hosted
+services are not release installation paths. GHCR, MCP Registry, the executable
+JAR, stdio, and packaged/container Streamable HTTP were verified.
 
 ## Standalone repository migration
 

--- a/shaft-mcp/.github/copilot-instructions.md
+++ b/shaft-mcp/.github/copilot-instructions.md
@@ -216,9 +216,12 @@ The following are auto-generated and must never be committed (already in `.gitig
 - IDE-specific files (`.idea/`, `.vscode/`, `.settings/`, etc.)
 - `HELP.md` - Auto-generated Spring Boot help
 
-## Cloud Deployment (Smithery)
+## Optional Cloud Deployment
 
-SHAFT MCP is listed on [Smithery.ai](https://smithery.ai/server/@ShaftHQ/shaft-mcp) and supports zero-install cloud deployment via HTTP/SSE transport.
+The repository includes Smithery, Render, and Fly.io templates for Streamable
+HTTP deployment. No hosted endpoint is guaranteed by the source repository;
+verify the external account integration and `/mcp` initialization before
+documenting one as live.
 
 ### Deployment Flow
 1. Smithery uses `smithery.yaml` → builds via `Dockerfile.smithery.build`
@@ -313,5 +316,4 @@ Pull requests should:
 - Model Context Protocol Spec: https://modelcontextprotocol.io/
 - Spring AI MCP: https://docs.spring.io/spring-ai/reference/api/mcp/index.html
 - Maven Central: https://central.sonatype.com/artifact/io.github.shafthq/SHAFT_MCP
-- Smithery listing: https://smithery.ai/server/@ShaftHQ/shaft-mcp
 

--- a/shaft-mcp/SMITHERY_DEPLOYMENT.md
+++ b/shaft-mcp/SMITHERY_DEPLOYMENT.md
@@ -4,6 +4,12 @@ Hosted deployments use Streamable HTTP at `/mcp` with
 `SPRING_PROFILES_ACTIVE=http`. The server defaults to port `8081`; Fly.io sets
 `PORT=8080`.
 
+These files are deployment templates, not a promise that a SHAFT-hosted
+endpoint is active. Maven Central, GHCR, and the MCP Registry are the supported
+public distribution channels. A hosted service becomes available only after
+its external account, repository integration, and required secret are
+configured and its `/mcp` endpoint passes initialization.
+
 All container builds use the SHAFT_ENGINE repository root as their Docker build
 context so `shaft-mcp` is compiled with the same reactor version and canonical
 `shaft-engine` dependency as the Maven Central release.
@@ -24,17 +30,18 @@ The root `smithery.yaml` selects
 repository in Smithery. Smithery rebuilds from the GitHub integration after a
 release; no model-provider key is passed to the SHAFT image.
 
+Release `10.2.20260612` has no active Smithery listing. Treat the workflow step
+as a handoff reminder until the canonical repository integration is configured
+and verified.
+
 ## Render
 
 The root `render.yaml` defines the `shaft-mcp` web service and selects
 `shaft-mcp/Dockerfile.render`. The post-release workflow calls
 `RENDER_DEPLOY_HOOK_URL` when that repository secret is configured.
 
-The public endpoint is:
-
-```text
-https://<render-service>/mcp
-```
+Release `10.2.20260612` did not configure that secret. No Render endpoint is
+advertised for this release.
 
 ## Fly.io
 
@@ -44,12 +51,9 @@ Deploy from the repository root:
 flyctl deploy --remote-only --config shaft-mcp/fly.toml
 ```
 
-The release workflow uses `FLY_API_TOKEN` when configured. The public endpoint
-is:
-
-```text
-https://shaft-mcp.fly.dev/mcp
-```
+The release workflow uses `FLY_API_TOKEN` when configured. Release
+`10.2.20260612` did not configure that secret, and
+`https://shaft-mcp.fly.dev/mcp` is not an active endpoint.
 
 ## Release flow
 
@@ -60,8 +64,9 @@ https://shaft-mcp.fly.dev/mcp
 3. The same workflow renders `shaft-mcp/server.json` from the root version,
    validates it against the MCP registry schema, and publishes it with GitHub
    OIDC.
-4. `deploy-shaft-mcp.yml` triggers configured Render and Fly.io deployments;
-   Smithery rebuilds through its GitHub integration.
+4. `deploy-shaft-mcp.yml` triggers configured Render and Fly.io deployments
+   and records the Smithery handoff. Missing external configuration is reported
+   as an explicit no-op.
 
 The historical `ShaftHQ/SHAFT_MCP` repository is read-only. Its
 `ghcr.io/shafthq/shaft-mcp:10.2.20260612` compatibility image was built from


### PR DESCRIPTION
## Summary
- identify Smithery, Render, and Fly as optional deployment templates rather than guaranteed release endpoints
- record the verified 10.2.20260612 external-account limitations
- keep Maven Central, GHCR, MCP Registry, executable JAR, stdio, and packaged/container HTTP as the supported release paths
- make the Smithery workflow step explicitly state that it performs no deployment

## Validation
- release contract and 6 regression tests
- MCP configuration validator
- modular documentation validator
- quality configuration validator
- git diff --check

Related to #2858