### PR TITLE
[codex] preserve documentation delivery standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,11 @@ The bridge skills point to canonical rules under `.github/instructions/` and
 - Preserve user changes in a dirty worktree. Never revert unrelated work.
 - Use structured APIs for XML, JSON, YAML, and other structured data.
 - Reproduce bugs and add focused regression coverage when practical.
-- For public behavior changes, update the Docusaurus repository and link its PR.
+- Public documentation lives only in `ShaftHQ/shafthq.github.io`; recurring
+  commands and versions belong in its shared data/components, not this repo.
+- Deliver user-facing changes site-first: verify the docs preview, deploy it,
+  and confirm canonical production routes return HTTP 200 before merging a
+  dependent engine cleanup or removing its previous documentation.
 - Do not add local public guides or non-root README files.
 - Preserve public API compatibility; removals and renames require deprecation.
 - Never expose secrets or credentials.
@@ -71,6 +75,7 @@ mvn clean install -DskipTests -Dgpg.skip
 mvn -pl shaft-engine javadoc:javadoc
 python3 scripts/ci/validate_agent_guidance.py
 python3 scripts/ci/validate_documentation_boundaries.py
+python3 scripts/ci/validate_modular_documentation.py
 ```
 
 On PowerShell, single-quote every Maven `-D` argument. For SHAFT tests, confirm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,8 +63,11 @@ guides, module READMEs, or a local `docs/` tree to this repository.
 When a change affects users:
 
 1. Update [ShaftHQ/shafthq.github.io](https://github.com/ShaftHQ/shafthq.github.io).
-2. Link the documentation pull request in the engine pull request.
-3. If documentation is not required, provide a concrete reason in the pull
+2. Verify the documentation deploy preview and its affected canonical routes.
+3. Link the documentation pull request in the engine pull request.
+4. Merge and deploy the documentation first. Confirm the production routes
+   return HTTP 200 before merging dependent engine documentation cleanup.
+5. If documentation is not required, provide a concrete reason in the pull
    request template.
 
 Operational Markdown remains allowed for agent instructions, governance,


### PR DESCRIPTION
## Summary

- make the Docusaurus repository the explicit owner of reusable documentation commands and release metadata
- preserve the site-first delivery sequence for user-facing changes
- require deploy-preview verification and production HTTP 200 checks before dependent engine documentation cleanup merges
- add the modular documentation contract validator to the common guidance checks

## Impact

This is guidance-only. It prevents future engine changes from recreating local public documentation or merging documentation cleanup before canonical site routes are live.

## Validation

- `python scripts/ci/validate_agent_guidance.py`
- `python scripts/ci/validate_documentation_boundaries.py`
- `python scripts/ci/validate_modular_documentation.py`
- `git diff --check`

All passed locally.

## Documentation Site

Documentation content is not required because this PR only preserves cross-repository contributor and agent workflow standards. The matching site guidance PR is being opened from the same branch name.