### PR TITLE
add SFTP upload and download to remote terminal

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
@@ -1,9 +1,11 @@
 package com.shaft.cli;
 
 import com.jcraft.jsch.ChannelExec;
+import com.jcraft.jsch.ChannelSftp;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
+import com.jcraft.jsch.SftpException;
 import com.shaft.driver.SHAFT;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.FailureReporter;
@@ -15,6 +17,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -294,6 +298,33 @@ public class TerminalActions {
     }
 
     /**
+     * Uploads a local file to the connected remote host over SFTP.
+     *
+     * <p>Requires a remote terminal created through a remote SSH constructor or
+     * {@link com.shaft.driver.SHAFT.CLI#remoteTerminal(String, int, String, String, String)}.
+     * Docker-wrapped remote terminals are not supported; use {@link #performTerminalCommand(String)}
+     * for file operations inside a container.</p>
+     *
+     * @param localFilePath  relative or absolute path to the local source file
+     * @param remoteFilePath destination path on the remote host
+     * @return the remote destination path for assertions
+     */
+    public String uploadFile(String localFilePath, String remoteFilePath) {
+        return performSftpTransfer(SftpTransferDirection.UPLOAD, localFilePath, remoteFilePath);
+    }
+
+    /**
+     * Downloads a file from the connected remote host over SFTP.
+     *
+     * @param remoteFilePath source path on the remote host
+     * @param localFilePath  relative or absolute destination path on the local machine
+     * @return the local absolute destination path for assertions
+     */
+    public String downloadFile(String remoteFilePath, String localFilePath) {
+        return performSftpTransfer(SftpTransferDirection.DOWNLOAD, remoteFilePath, localFilePath);
+    }
+
+    /**
      * Disconnects any reusable SSH session owned by this terminal actions instance.
      *
      * <p>This method is safe to call before the first remote command is executed and is a no-op
@@ -393,6 +424,87 @@ public class TerminalActions {
     private void disconnectRemoteSessionIfEphemeral(Session session) {
         if (!reuseRemoteSession && session != null && session.isConnected()) {
             session.disconnect();
+        }
+    }
+
+    private enum SftpTransferDirection {
+        UPLOAD,
+        DOWNLOAD
+    }
+
+    private String performSftpTransfer(SftpTransferDirection direction, String sourcePath, String destinationPath) {
+        verifyRemoteSftpTerminal();
+        String localPath;
+        String remotePath;
+        if (direction == SftpTransferDirection.UPLOAD) {
+            // upload sources may live under the test data folder, so reuse SHAFT path resolution
+            localPath = FileActions.getInstance(true).getAbsolutePath(sourcePath);
+            remotePath = destinationPath;
+        } else {
+            remotePath = sourcePath;
+            // download destinations are saved exactly where the caller asks, relative to the project directory
+            localPath = new File(destinationPath).getAbsolutePath();
+        }
+
+        String testData = "Host Name: \"" + sshHostName + "\" | SSH Port Number: \"" + sshPortNumber
+                + "\" | SSH Username: \"" + sshUsername + "\" | Local Path: \"" + localPath
+                + "\" | Remote Path: \"" + remotePath + "\"";
+
+        if (direction == SftpTransferDirection.UPLOAD && !Files.isRegularFile(Path.of(localPath))) {
+            failAction(testData, new IOException("Local file does not exist: \"" + localPath + "\""));
+        }
+
+        if (direction == SftpTransferDirection.DOWNLOAD) {
+            Path localDestination = Path.of(localPath);
+            Path parentDirectory = localDestination.getParent();
+            if (parentDirectory != null) {
+                FileActions.getInstance(true).createFolder(parentDirectory.toString());
+            }
+        }
+
+        Session remoteSession = getRemoteSession();
+        ChannelSftp sftpChannel = null;
+        try {
+            sftpChannel = openSftpChannel(remoteSession);
+            if (direction == SftpTransferDirection.UPLOAD) {
+                sftpChannel.put(localPath, remotePath);
+                passAction(testData, "Uploaded file to \"" + remotePath + "\"");
+                return remotePath;
+            }
+            sftpChannel.get(remotePath, localPath);
+            passAction(testData, "Downloaded file to \"" + localPath + "\"");
+            return localPath;
+        } catch (JSchException | SftpException exception) {
+            failAction(testData, exception);
+            return "";
+        } finally {
+            disconnectSftpChannel(sftpChannel);
+            disconnectRemoteSessionIfEphemeral(remoteSession);
+        }
+    }
+
+    private void verifyRemoteSftpTerminal() {
+        if (!isRemoteTerminal()) {
+            failAction("SFTP file transfer",
+                    new IllegalStateException("SFTP is only supported for remote SSH terminals."));
+        }
+        if (isDockerizedTerminal()) {
+            failAction("SFTP file transfer", new IllegalStateException(
+                    "SFTP operates on the remote host filesystem. Use performTerminalCommand(...) for dockerized remote terminals."));
+        }
+    }
+
+    private ChannelSftp openSftpChannel(Session session) throws JSchException {
+        int sessionTimeout = Math.toIntExact(TimeUnit.MINUTES.toMillis(SHAFT.Properties.timeouts.shellSessionTimeout()));
+        session.setTimeout(sessionTimeout);
+        ChannelSftp sftpChannel = (ChannelSftp) session.openChannel("sftp");
+        sftpChannel.connect();
+        return sftpChannel;
+    }
+
+    private void disconnectSftpChannel(ChannelSftp sftpChannel) {
+        if (sftpChannel != null && sftpChannel.isConnected()) {
+            sftpChannel.disconnect();
         }
     }
 

--- a/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
@@ -193,6 +193,45 @@ public class TerminalActionsUnitTest {
                 "Fluent terminal execution should return the same TerminalActions instance");
     }
 
+    @Test(description = "uploadFile should fail for local terminals")
+    public void uploadFileShouldFailForLocalTerminal() {
+        TerminalActions terminal = new TerminalActions();
+        RuntimeException failure = Assert.expectThrows(RuntimeException.class,
+                () -> terminal.uploadFile("local.txt", "/tmp/remote.txt"));
+        Assert.assertTrue(failure.getMessage().contains("SFTP is only supported for remote SSH terminals"));
+    }
+
+    @Test(description = "downloadFile should fail for local terminals")
+    public void downloadFileShouldFailForLocalTerminal() {
+        TerminalActions terminal = new TerminalActions();
+        RuntimeException failure = Assert.expectThrows(RuntimeException.class,
+                () -> terminal.downloadFile("/tmp/remote.txt", "local.txt"));
+        Assert.assertTrue(failure.getMessage().contains("SFTP is only supported for remote SSH terminals"));
+    }
+
+    @Test(description = "uploadFile should fail for dockerized remote terminals")
+    public void uploadFileShouldFailForDockerizedRemoteTerminal() throws Exception {
+        Files.createDirectories(TEMP_DIR);
+        Path localFile = TEMP_DIR.resolve("upload-source.txt");
+        Files.writeString(localFile, "payload");
+
+        TerminalActions terminal = new TerminalActions(
+                "host.example.com", 22, "user", TEMP_DIR.toAbsolutePath() + "/", "id_rsa",
+                "appContainer", "appUser");
+
+        RuntimeException failure = Assert.expectThrows(RuntimeException.class,
+                () -> terminal.uploadFile(localFile.toString(), "/tmp/remote.txt"));
+        Assert.assertTrue(failure.getMessage().contains("dockerized remote terminals"));
+    }
+
+    @Test(description = "uploadFile should fail when the local source file does not exist")
+    public void uploadFileShouldFailWhenLocalSourceFileIsMissing() {
+        TerminalActions terminal = new TerminalActions("host.example.com", 22, "user", "/keys/", "id_rsa");
+        RuntimeException failure = Assert.expectThrows(RuntimeException.class,
+                () -> terminal.uploadFile("target/temp/does-not-exist.txt", "/tmp/remote.txt"));
+        Assert.assertTrue(failure.getMessage().contains("Local file does not exist"));
+    }
+
     // --- Default SSH Values ---
 
     @Test(description = "Default SSH port should be 22")


### PR DESCRIPTION
Part of #2695

Builds on the reusable remote terminal from #2741 by adding file transfer over the same SSH session.

## changes
- `TerminalActions.uploadFile(localPath, remotePath)` returns the remote path
- `TerminalActions.downloadFile(remotePath, localPath)` returns the local path
- Both run over SFTP on the existing session from `SHAFT.CLI.remoteTerminal(...)`

## Behavior
- Reuses `getRemoteSession()`, so a reusable session stays open across transfers and commands, and ephemeral remote terminals still disconnect after each call
- Opens and closes a fresh `ChannelSftp` per transfer
- Upload fails early if the local source file is missing
- Download creates the local parent folder if needed
- Clear failure when called on a local terminal or a dockerized remote terminal

 ## Tests
Added four cases to TerminalActionsUnitTest (local guard, docker guard, missing source) --> 37 passed.
[Tests.html](https://github.com/user-attachments/files/28914442/Tests.html)
The Tests Report

## Usage
```java
TerminalActions terminal = SHAFT.CLI.remoteTerminal("host", 22, "user", "src/test/resources/keys/", "id_rsa");
String remotePath = terminal.uploadFile("src/test/resources/data.txt", "/tmp/data.txt");
String localPath = terminal.downloadFile("/tmp/result.log", "target/temp/result.log");
terminal.quit();

