### PR TITLE
ci: restore Codecov uploads after every test run

### DIFF
--- a/.github/actions/post-test-report/action.yml
+++ b/.github/actions/post-test-report/action.yml
@@ -1,5 +1,5 @@
 name: 'Post-Test Report and Check'
-description: 'Generates Allure report artifacts, creates test summary, and checks test results using Allure data'
+description: 'Uploads coverage, generates Allure report artifacts, creates test summary, and checks test results using Allure data'
 outputs:
   job:
     description: 'Job display name'
@@ -31,9 +31,34 @@ inputs:
     description: 'Module that produced the test and report outputs'
     required: false
     default: 'shaft-engine'
+
+  codecov-token:
+    description: 'Codecov upload token'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
+    - name: Upload coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@v7
+      with:
+        token: ${{ inputs.codecov-token }}
+        fail_ci_if_error: false
+        disable_search: true
+        files: >-
+          ./target/jacoco/jacoco.xml,
+          ./shaft-engine/target/jacoco/jacoco.xml,
+          ./shaft-pilot-core/target/jacoco/jacoco.xml,
+          ./shaft-capture/target/jacoco/jacoco.xml,
+          ./shaft-doctor/target/jacoco/jacoco.xml,
+          ./shaft-ai/target/jacoco/jacoco.xml,
+          ./shaft-heal/target/jacoco/jacoco.xml,
+          ./shaft-browserstack/target/jacoco/jacoco.xml,
+          ./shaft-video/target/jacoco/jacoco.xml,
+          ./shaft-visual/target/jacoco/jacoco.xml,
+          ./shaft-mcp/target/jacoco/jacoco.xml
+        verbose: true
     - name: Generate Allure Report Fallback
       if: always()
       shell: bash

--- a/.github/workflows/e2eLambdaTestTests.yml
+++ b/.github/workflows/e2eLambdaTestTests.yml
@@ -35,6 +35,7 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: LambdaTest_NativeAndroid
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   LambdaTest_NativeIOS:
     runs-on: ubuntu-latest
@@ -63,6 +64,7 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: LambdaTest_NativeIOS
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   LambdaTest_WebApp:
     runs-on: ubuntu-latest
@@ -91,6 +93,7 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: LambdaTest_WebApp
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   LambdaTest_DesktopWeb:
     runs-on: ubuntu-latest
@@ -119,6 +122,7 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: LambdaTest_DesktopWeb
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Workflow_Summary:
     if: always()

--- a/.github/workflows/e2eLocalTests.yml
+++ b/.github/workflows/e2eLocalTests.yml
@@ -56,6 +56,7 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: Windows_Edge_Local
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   MacOSX_Safari_Local:
     runs-on: macos-latest
@@ -85,6 +86,7 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: MacOSX_Safari_Local
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Windows_Chrome_Local:
     runs-on: windows-latest
@@ -114,6 +116,7 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: Windows_Chrome_Local
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   MacOSX_Chrome_Local:
     runs-on: macos-latest
@@ -143,6 +146,7 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: MacOSX_Chrome_Local
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Windows_Edge_Cucumber_Local:
     runs-on: windows-latest
@@ -173,3 +177,4 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: Windows_Edge_Cucumber_Local
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/e2eMoonTests.yml
+++ b/.github/workflows/e2eMoonTests.yml
@@ -127,3 +127,4 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: Ubuntu_Chrome_Moon
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -77,6 +77,7 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: Ubuntu_Database
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Ubuntu_APIs:
     runs-on: ubuntu-latest
@@ -104,6 +105,7 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: Ubuntu_APIs
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Ubuntu_Visual_Module:
     runs-on: ubuntu-latest
@@ -131,6 +133,7 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: Ubuntu_Visual_Module
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
           module-directory: shaft-visual
 
   Ubuntu_Desktop_Video_Module:
@@ -159,6 +162,7 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: Ubuntu_Desktop_Video_Module
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
           module-directory: shaft-video
 
   Ubuntu_Firefox_Grid:
@@ -195,6 +199,7 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: Ubuntu_Firefox_Grid
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Ubuntu_Chrome_Grid:
     runs-on: ubuntu-latest
@@ -230,6 +235,7 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: Ubuntu_Chrome_Grid
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Ubuntu_MicrosoftEdge_Grid:
     runs-on: ubuntu-latest
@@ -265,6 +271,7 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: Ubuntu_MicrosoftEdge_Grid
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Android_Native_BrowserStack:
     runs-on: ubuntu-latest
@@ -295,6 +302,7 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: Android_Native_BrowserStack
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   iOS_Web_SAFARI_BrowserStack:
     runs-on: ubuntu-latest
@@ -322,6 +330,7 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: iOS_Web_SAFARI_BrowserStack
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Android_Web_Chrome_BrowserStack:
     runs-on: ubuntu-latest
@@ -349,6 +358,7 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: Android_Web_Chrome_BrowserStack
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   MacOSX_Safari_BrowserStack:
     runs-on: ubuntu-latest
@@ -376,6 +386,7 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: MacOSX_Safari_BrowserStack
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Ubuntu_Chrome_Cucumber_Grid:
     runs-on: ubuntu-latest
@@ -407,6 +418,7 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: Ubuntu_Chrome_Cucumber_Grid
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   MacOSX_Safari_Cucumber_BrowserStack:
     runs-on: ubuntu-latest
@@ -434,3 +446,4 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: MacOSX_Safari_Cucumber_BrowserStack
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/shaft-mcp.yml
+++ b/.github/workflows/shaft-mcp.yml
@@ -30,6 +30,18 @@ jobs:
           python3 scripts/ci/validate_shaft_mcp_configuration.py
       - name: Run MCP module tests
         run: mvn --batch-mode -pl shaft-mcp -am test -Dgpg.skip
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          disable_search: true
+          files: >-
+            ./target/jacoco/jacoco.xml,
+            ./shaft-engine/target/jacoco/jacoco.xml,
+            ./shaft-mcp/target/jacoco/jacoco.xml
+          verbose: true
       - name: Verify MCP Allure results
         run: test -n "$(find shaft-mcp/allure-results -name '*-result.json' -type f -print -quit)"
       - name: Package and smoke transports


### PR DESCRIPTION
### Motivation

- Reinstate automatic JaCoCo coverage uploads to Codecov after each test job so coverage artifacts from the Maven reactor and modules are reported as they were previously.
- Ensure all E2E job types (local, LambdaTest, Moon, Selenium Grid, BrowserStack) and the MCP module publish their coverage artifacts.

### Description

- Added a `codecov-token` input and an always-run Codecov upload step to the composite action `.github/actions/post-test-report/action.yml` using `codecov/codecov-action@v7`, targeting JaCoCo XML files from the reactor root and Java modules.
- Updated all E2E workflows to pass `codecov-token: ${{ secrets.CODECOV_TOKEN }}` into the shared `post-test-report` action invocations so each job uploads its coverage.
- Added an explicit always-run Codecov upload step after the SHAFT MCP test step to cover the MCP/engine reports produced by that job.
- Kept uploads non-blocking (`fail_ci_if_error: false`) and enabled `disable_search`/`verbose` to limit Codecov file discovery and improve diagnostics.

### Testing

- Validated all modified YAML files parse successfully with Ruby Psych.
- Ran `python3 scripts/ci/validate_agent_guidance.py` successfully.
- Ran `python3 scripts/ci/validate_documentation_boundaries.py` successfully.
- Ran `git diff --check` successfully.
- Confirmed all 23 shared post-test action invocations include the Codecov token and that the remaining MCP test command has a dedicated upload step.
