### PR TITLE
Fix canonical documentation link in default properties template

### DIFF
--- a/shaft-engine/src/main/resources/properties/default/custom.properties
+++ b/shaft-engine/src/main/resources/properties/default/custom.properties
@@ -1,6 +1,6 @@
 # SHAFT custom overrides
 # Keep only the properties you want to customize. Any property left with its default value below behaves the same as SHAFT defaults.
-# Learn more from the user guide: https://shafthq.github.io/
+# Learn more from the user guide: https://shaftengine.netlify.app/
 
 # Execution platform
 executionAddress=local


### PR DESCRIPTION
### Motivation
- The regression test expects the canonical documentation site `https://shaftengine.netlify.app/`, but the shipped default `custom.properties` template still pointed at the old `https://shafthq.github.io/`, causing a deterministic unit-test failure across multiple grid jobs.

### Description
- Update `shaft-engine/src/main/resources/properties/default/custom.properties` to replace the old documentation URL with `https://shaftengine.netlify.app/` so the packaged template matches the test expectation.

### Testing
- Ran `mvn -pl shaft-engine -am test -Dtest=PropertiesHelperInitializationUnitTest` which passed (2 tests, 0 failures) and produced 2 Allure result files, and executed `python3 scripts/ci/validate_documentation_boundaries.py`, `python3 scripts/ci/validate_modular_documentation.py`, `python3 scripts/ci/validate_agent_guidance.py`, and `curl https://shaftengine.netlify.app/` (HTTP 200), all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e2ad2cb3c832088676d2fff1f09d8)