### PR TITLE
[codex] Rename SHAFT MCP module to shaft-mcp

### DIFF
--- a/.github/workflows/deploy-shaft-mcp.yml
+++ b/.github/workflows/deploy-shaft-mcp.yml
@@ -1,8 +1,8 @@
-name: Deploy SHAFT MCP
+name: Deploy shaft-mcp
 
 on:
   workflow_run:
-    workflows: ["Publish SHAFT MCP Distributions"]
+    workflows: ["Publish shaft-mcp Distributions"]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/mavenCentral_cd.yml
+++ b/.github/workflows/mavenCentral_cd.yml
@@ -98,7 +98,7 @@ jobs:
             "-Dshaft.version=${RELEASE_VERSION}"
           mvn --batch-mode -f tools/modularization/consumer-fixtures/mcp/pom.xml verify \
             "-Dshaft.version=${RELEASE_VERSION}"
-      - name: Build and smoke SHAFT MCP container
+      - name: Build and smoke shaft-mcp container
         shell: bash
         run: |
           docker build -f shaft-mcp/Dockerfile -t shaft-pilot-release:test .

--- a/.github/workflows/publish-shaft-mcp.yml
+++ b/.github/workflows/publish-shaft-mcp.yml
@@ -1,4 +1,4 @@
-name: Publish SHAFT MCP Distributions
+name: Publish shaft-mcp Distributions
 
 on:
   workflow_run:

--- a/.github/workflows/reactor-version-check.yml
+++ b/.github/workflows/reactor-version-check.yml
@@ -49,7 +49,7 @@ jobs:
         run: python3 scripts/ci/validate_reactor_versions.py
       - name: Validate aggregate quality configuration
         run: python3 scripts/ci/validate_quality_configuration.py
-      - name: Validate SHAFT MCP integration
+      - name: Validate shaft-mcp integration
         run: python3 scripts/ci/validate_shaft_mcp_configuration.py
       - name: Test configuration validators
         run: >-

--- a/.github/workflows/shaft-mcp.yml
+++ b/.github/workflows/shaft-mcp.yml
@@ -1,4 +1,4 @@
-name: SHAFT MCP
+name: shaft-mcp
 
 on:
   schedule:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ and optional agent tools without rebuilding the framework for every surface.
 
 </div>
 
-## Launch SHAFT MCP
+## Launch shaft-mcp
 
 Connect Codex to SHAFT browser automation, Capture, and Doctor:
 

--- a/report-aggregate/pom.xml
+++ b/report-aggregate/pom.xml
@@ -67,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>SHAFT_MCP</artifactId>
+            <artifactId>shaft-mcp</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/scripts/ci/validate_maven_publication.py
+++ b/scripts/ci/validate_maven_publication.py
@@ -22,7 +22,7 @@ PUBLIC_ARTIFACTS = {
     "shaft-browserstack": (Path("shaft-browserstack/pom.xml"), "jar"),
     "shaft-video": (Path("shaft-video/pom.xml"), "jar"),
     "shaft-visual": (Path("shaft-visual/pom.xml"), "jar"),
-    "SHAFT_MCP": (Path("shaft-mcp/pom.xml"), "jar"),
+    "shaft-mcp": (Path("shaft-mcp/pom.xml"), "jar"),
     "shaft-bom": (Path("shaft-bom/pom.xml"), "pom"),
     "SHAFT_ENGINE": (Path("legacy-shaft-engine/pom.xml"), "pom"),
 }

--- a/scripts/ci/validate_modular_documentation.py
+++ b/scripts/ci/validate_modular_documentation.py
@@ -129,8 +129,8 @@ def main() -> None:
         "vscode-mcp.json",
     ):
         contents = (MCP_FIXTURES / fixture).read_text(encoding="utf-8")
-        if "SHAFT_MCP-<version>.jar" not in contents:
-            fail(f"{fixture}: missing versioned SHAFT MCP command")
+        if "shaft-mcp-<version>.jar" not in contents:
+            fail(f"{fixture}: missing versioned shaft-mcp command")
         if "API_KEY" in contents or "apiKey" in contents:
             fail(f"{fixture}: MCP client fixture must not request a provider API key")
 

--- a/scripts/ci/validate_quality_configuration.py
+++ b/scripts/ci/validate_quality_configuration.py
@@ -11,7 +11,7 @@ ROOT = Path(__file__).resolve().parents[2]
 NS = {"m": "http://maven.apache.org/POM/4.0.0"}
 JAVA_MODULES = {
     "shaft-engine", "shaft-pilot-core", "shaft-capture", "shaft-doctor", "shaft-ai", "shaft-heal",
-    "shaft-browserstack", "shaft-video", "shaft-visual", "SHAFT_MCP",
+    "shaft-browserstack", "shaft-video", "shaft-visual", "shaft-mcp",
 }
 DEPENDABOT_DIRECTORIES = {
     "/",

--- a/scripts/ci/validate_shaft_mcp_configuration.py
+++ b/scripts/ci/validate_shaft_mcp_configuration.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate SHAFT MCP reactor, transport, metadata, and workflow integration."""
+"""Validate shaft-mcp reactor, transport, metadata, and workflow integration."""
 
 from __future__ import annotations
 
@@ -38,8 +38,8 @@ def validate(root: Path = ROOT) -> list[str]:
         errors.append("root reactor must include shaft-mcp")
 
     mcp = ET.parse(root / "shaft-mcp" / "pom.xml").getroot()
-    if text(mcp, "m:artifactId") != "SHAFT_MCP":
-        errors.append("shaft-mcp must preserve the SHAFT_MCP artifactId")
+    if text(mcp, "m:artifactId") != "shaft-mcp":
+        errors.append("shaft-mcp must use the shaft-mcp artifactId")
     dependencies = {
         (text(dependency, "m:artifactId"), text(dependency, "m:version"))
         for dependency in mcp.findall("m:dependencies/m:dependency", NS)
@@ -55,16 +55,16 @@ def validate(root: Path = ROOT) -> list[str]:
         errors.append("shaft-mcp must not define an independent SHAFT engine version")
 
     engine_pom = (root / "shaft-engine" / "pom.xml").read_text(encoding="utf-8")
-    if "<artifactId>SHAFT_MCP</artifactId>" in engine_pom:
-        errors.append("shaft-engine must not depend on SHAFT_MCP")
+    if "<artifactId>shaft-mcp</artifactId>" in engine_pom:
+        errors.append("shaft-engine must not depend on shaft-mcp")
 
     bom = ET.parse(root / "shaft-bom" / "pom.xml").getroot()
     bom_artifacts = {
         text(dependency, "m:artifactId")
         for dependency in bom.findall("m:dependencyManagement/m:dependencies/m:dependency", NS)
     }
-    if "SHAFT_MCP" not in bom_artifacts:
-        errors.append("shaft-bom must manage SHAFT_MCP without adding it as a dependency")
+    if "shaft-mcp" not in bom_artifacts:
+        errors.append("shaft-bom must manage shaft-mcp without adding it as a dependency")
 
     stdio = property_map(root / "shaft-mcp" / "src/main/resources/application.properties")
     expected_stdio = {
@@ -91,7 +91,7 @@ def validate(root: Path = ROOT) -> list[str]:
 
     logback = (root / "shaft-mcp/src/main/resources/logback-spring.xml").read_text(encoding="utf-8")
     if "<target>System.err</target>" not in logback:
-        errors.append("SHAFT MCP logging must target stderr")
+        errors.append("shaft-mcp logging must target stderr")
 
     server_json = (root / "shaft-mcp/server.json").read_text(encoding="utf-8")
     if server_json.count("@project.version@") < 2:
@@ -99,7 +99,7 @@ def validate(root: Path = ROOT) -> list[str]:
 
     nested_workflows = list((root / "shaft-mcp/.github/workflows").glob("*.yml"))
     if nested_workflows:
-        errors.append("SHAFT MCP workflows must live under the root .github/workflows directory")
+        errors.append("shaft-mcp workflows must live under the root .github/workflows directory")
     for workflow in ("shaft-mcp.yml", "publish-shaft-mcp.yml", "deploy-shaft-mcp.yml"):
         if not (root / ".github/workflows" / workflow).is_file():
             errors.append(f"missing root MCP workflow: {workflow}")
@@ -111,7 +111,7 @@ def validate(root: Path = ROOT) -> list[str]:
 
     for dockerfile in (root / "shaft-mcp").glob("Dockerfile*"):
         content = dockerfile.read_text(encoding="utf-8")
-        if "repo1.maven.org" in content or "SHAFT_MCP/10." in content:
+        if "repo1.maven.org" in content or "shaft-mcp/10." in content:
             errors.append(f"{dockerfile.name} must build from the reactor without a hardcoded release")
         if "-pl shaft-mcp -am" not in content:
             errors.append(f"{dockerfile.name} must build shaft-mcp from the root reactor")
@@ -123,7 +123,7 @@ def main() -> int:
     if errors:
         print("\n".join(errors), file=sys.stderr)
         return 1
-    print("SHAFT MCP reactor, transport, metadata, container, and workflow configuration is valid.")
+    print("shaft-mcp reactor, transport, metadata, container, and workflow configuration is valid.")
     return 0
 
 

--- a/scripts/ci/validate_shaft_mcp_transports.py
+++ b/scripts/ci/validate_shaft_mcp_transports.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Smoke the packaged SHAFT MCP server over stdio and Streamable HTTP."""
+"""Smoke the packaged shaft-mcp server over stdio and Streamable HTTP."""
 
 from __future__ import annotations
 
@@ -261,7 +261,7 @@ def main() -> int:
     parser.add_argument(
         "--jar",
         type=Path,
-        default=ROOT / "shaft-mcp" / "target" / f"SHAFT_MCP-{version}.jar",
+        default=ROOT / "shaft-mcp" / "target" / f"shaft-mcp-{version}.jar",
     )
     args = parser.parse_args()
     jar = args.jar.resolve()
@@ -269,7 +269,7 @@ def main() -> int:
         raise FileNotFoundError(f"Packaged MCP server is missing: {jar}")
     validate_stdio(jar, version)
     validate_http(jar, version)
-    print(f"SHAFT MCP {version} passed packaged stdio and Streamable HTTP smoke tests.")
+    print(f"shaft-mcp {version} passed packaged stdio and Streamable HTTP smoke tests.")
     return 0
 
 

--- a/scripts/ci/validate_shaft_pilot_release.py
+++ b/scripts/ci/validate_shaft_pilot_release.py
@@ -26,7 +26,7 @@ PUBLIC_ARTIFACTS = {
     "shaft-capture": "shaft-capture",
     "shaft-doctor": "shaft-doctor",
     "shaft-ai": "shaft-ai",
-    "shaft-mcp": "SHAFT_MCP",
+    "shaft-mcp": "shaft-mcp",
 }
 SECRET_CANARIES = (
     b"DO-NOT-RETAIN-SECRET",

--- a/scripts/ci/verify_maven_central_release.py
+++ b/scripts/ci/verify_maven_central_release.py
@@ -18,7 +18,7 @@ GROUP_PATH = "io/github/shafthq"
 DEFAULT_REPOSITORY = "https://repo.maven.apache.org/maven2"
 JAR_ARTIFACTS = (
     "shaft-engine", "shaft-pilot-core", "shaft-capture", "shaft-doctor", "shaft-ai", "shaft-heal",
-    "shaft-browserstack", "shaft-video", "shaft-visual", "SHAFT_MCP",
+    "shaft-browserstack", "shaft-video", "shaft-visual", "shaft-mcp",
 )
 POM_ARTIFACTS = ("shaft-parent", "shaft-bom", "SHAFT_ENGINE")
 FIXTURE_GOALS = {

--- a/shaft-bom/pom.xml
+++ b/shaft-bom/pom.xml
@@ -62,7 +62,7 @@
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
-                <artifactId>SHAFT_MCP</artifactId>
+                <artifactId>shaft-mcp</artifactId>
                 <version>${project.version}</version>
             </dependency>
         </dependencies>

--- a/shaft-mcp/.github/copilot-instructions.md
+++ b/shaft-mcp/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-# SHAFT MCP Copilot Instructions
+# shaft-mcp Copilot Instructions
 
 Follow the repository-root `AGENTS.md` and `.github/copilot-instructions.md`.
 
@@ -7,7 +7,7 @@ Follow the repository-root `AGENTS.md` and `.github/copilot-instructions.md`.
 - Preserve stdio protocol purity: JSON-RPC belongs on stdout and diagnostics
   belong on stderr.
 - Keep HTTP transport behavior at `/mcp` compatible with existing clients.
-- Do not add model-provider credentials to SHAFT MCP configuration or tests.
+- Do not add model-provider credentials to shaft-mcp configuration or tests.
 - Store executable client examples under
   `src/test/resources/fixtures/shaft-pilot/`; public guidance belongs on the
   [Docusaurus MCP page](https://shaftengine.netlify.app/docs/agentic/mcp).

--- a/shaft-mcp/Dockerfile
+++ b/shaft-mcp/Dockerfile
@@ -3,20 +3,24 @@ FROM maven:3.9.11-eclipse-temurin-25 AS builder
 WORKDIR /build
 COPY . .
 RUN mvn --batch-mode --no-transfer-progress -pl shaft-mcp -am package -DskipTests -Dgpg.skip \
-    && find shaft-mcp/target -maxdepth 1 -name 'SHAFT_MCP-*.jar' \
+    && find shaft-mcp/target -maxdepth 1 -name 'shaft-mcp-*.jar' \
         ! -name '*-sources.jar' ! -name '*-javadoc.jar' \
-        -exec cp {} /build/SHAFT_MCP.jar \; -quit
+        -exec cp {} /build/shaft-mcp.jar \; -quit
 
-FROM eclipse-temurin:25-jre
+FROM selenium/standalone-all-browsers:latest
 
 LABEL io.modelcontextprotocol.server.name="io.github.ShaftHQ/shaft-mcp" \
       org.opencontainers.image.source="https://github.com/ShaftHQ/SHAFT_ENGINE" \
-      org.opencontainers.image.description="SHAFT MCP server for browser and test automation" \
+      org.opencontainers.image.description="shaft-mcp server for browser and test automation" \
       org.opencontainers.image.licenses="MIT"
 
 WORKDIR /app
-COPY --from=builder /build/SHAFT_MCP.jar /app/SHAFT_MCP.jar
+COPY --from=builder /opt/java/openjdk /opt/java/openjdk
+COPY --from=builder /build/shaft-mcp.jar /app/shaft-mcp.jar
 
-ENV REMOTE_DRIVER_ADDRESS=""
+ENV JAVA_HOME=/opt/java/openjdk \
+    PATH="/opt/java/openjdk/bin:${PATH}" \
+    REMOTE_DRIVER_ADDRESS=""
 
-CMD ["java", "-jar", "SHAFT_MCP.jar"]
+ENTRYPOINT []
+CMD ["java", "-jar", "shaft-mcp.jar"]

--- a/shaft-mcp/Dockerfile.fly
+++ b/shaft-mcp/Dockerfile.fly
@@ -3,29 +3,22 @@ FROM maven:3.9.11-eclipse-temurin-25 AS builder
 WORKDIR /build
 COPY . .
 RUN mvn --batch-mode --no-transfer-progress -pl shaft-mcp -am package -DskipTests -Dgpg.skip \
-    && find shaft-mcp/target -maxdepth 1 -name 'SHAFT_MCP-*.jar' \
+    && find shaft-mcp/target -maxdepth 1 -name 'shaft-mcp-*.jar' \
         ! -name '*-sources.jar' ! -name '*-javadoc.jar' \
-        -exec cp {} /build/SHAFT_MCP.jar \; -quit
+        -exec cp {} /build/shaft-mcp.jar \; -quit
 
-FROM eclipse-temurin:25-jre
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates dumb-init gnupg wget \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub \
-        | gpg --dearmor -o /usr/share/keyrings/googlechrome-linux-keyring.gpg \
-    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/googlechrome-linux-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
-        > /etc/apt/sources.list.d/google.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends google-chrome-stable \
-    && rm -rf /var/lib/apt/lists/*
+FROM selenium/standalone-all-browsers:latest
 
 LABEL io.modelcontextprotocol.server.name="io.github.ShaftHQ/shaft-mcp"
 
 WORKDIR /app
-COPY --from=builder /build/SHAFT_MCP.jar /app/SHAFT_MCP.jar
+COPY --from=builder /opt/java/openjdk /opt/java/openjdk
+COPY --from=builder /build/shaft-mcp.jar /app/shaft-mcp.jar
 
 EXPOSE 8080
-ENV SPRING_PROFILES_ACTIVE=http
+ENV JAVA_HOME=/opt/java/openjdk \
+    PATH="/opt/java/openjdk/bin:${PATH}" \
+    SPRING_PROFILES_ACTIVE=http
 
-ENTRYPOINT ["dumb-init", "--"]
-CMD ["java", "-XX:+UseSerialGC", "-Xms128m", "-Xmx384m", "-XX:MaxMetaspaceSize=64m", "-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-Dspring.main.lazy-initialization=true", "-jar", "SHAFT_MCP.jar"]
+ENTRYPOINT []
+CMD ["java", "-XX:+UseSerialGC", "-Xms128m", "-Xmx384m", "-XX:MaxMetaspaceSize=64m", "-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-Dspring.main.lazy-initialization=true", "-jar", "shaft-mcp.jar"]

--- a/shaft-mcp/Dockerfile.render
+++ b/shaft-mcp/Dockerfile.render
@@ -3,28 +3,22 @@ FROM maven:3.9.11-eclipse-temurin-25 AS builder
 WORKDIR /build
 COPY . .
 RUN mvn --batch-mode --no-transfer-progress -pl shaft-mcp -am package -DskipTests -Dgpg.skip \
-    && find shaft-mcp/target -maxdepth 1 -name 'SHAFT_MCP-*.jar' \
+    && find shaft-mcp/target -maxdepth 1 -name 'shaft-mcp-*.jar' \
         ! -name '*-sources.jar' ! -name '*-javadoc.jar' \
-        -exec cp {} /build/SHAFT_MCP.jar \; -quit
+        -exec cp {} /build/shaft-mcp.jar \; -quit
 
-FROM eclipse-temurin:25-jre
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates gnupg wget \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub \
-        | gpg --dearmor -o /usr/share/keyrings/googlechrome-linux-keyring.gpg \
-    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/googlechrome-linux-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
-        > /etc/apt/sources.list.d/google.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends google-chrome-stable \
-    && rm -rf /var/lib/apt/lists/*
+FROM selenium/standalone-all-browsers:latest
 
 LABEL io.modelcontextprotocol.server.name="io.github.ShaftHQ/shaft-mcp"
 
 WORKDIR /app
-COPY --from=builder /build/SHAFT_MCP.jar /app/SHAFT_MCP.jar
+COPY --from=builder /opt/java/openjdk /opt/java/openjdk
+COPY --from=builder /build/shaft-mcp.jar /app/shaft-mcp.jar
 
 EXPOSE 8081
-ENV SPRING_PROFILES_ACTIVE=http
+ENV JAVA_HOME=/opt/java/openjdk \
+    PATH="/opt/java/openjdk/bin:${PATH}" \
+    SPRING_PROFILES_ACTIVE=http
 
-CMD ["java", "-XX:+UseSerialGC", "-Xms128m", "-Xmx384m", "-XX:MaxMetaspaceSize=64m", "-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-Dspring.main.lazy-initialization=true", "-jar", "SHAFT_MCP.jar"]
+ENTRYPOINT []
+CMD ["java", "-XX:+UseSerialGC", "-Xms128m", "-Xmx384m", "-XX:MaxMetaspaceSize=64m", "-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-Dspring.main.lazy-initialization=true", "-jar", "shaft-mcp.jar"]

--- a/shaft-mcp/Dockerfile.smithery
+++ b/shaft-mcp/Dockerfile.smithery
@@ -3,28 +3,22 @@ FROM maven:3.9.11-eclipse-temurin-25 AS builder
 WORKDIR /build
 COPY . .
 RUN mvn --batch-mode --no-transfer-progress -pl shaft-mcp -am package -DskipTests -Dgpg.skip \
-    && find shaft-mcp/target -maxdepth 1 -name 'SHAFT_MCP-*.jar' \
+    && find shaft-mcp/target -maxdepth 1 -name 'shaft-mcp-*.jar' \
         ! -name '*-sources.jar' ! -name '*-javadoc.jar' \
-        -exec cp {} /build/SHAFT_MCP.jar \; -quit
+        -exec cp {} /build/shaft-mcp.jar \; -quit
 
-FROM eclipse-temurin:25-jre
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates gnupg wget \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub \
-        | gpg --dearmor -o /usr/share/keyrings/googlechrome-linux-keyring.gpg \
-    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/googlechrome-linux-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
-        > /etc/apt/sources.list.d/google.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends google-chrome-stable \
-    && rm -rf /var/lib/apt/lists/*
+FROM selenium/standalone-all-browsers:latest
 
 LABEL io.modelcontextprotocol.server.name="io.github.ShaftHQ/shaft-mcp"
 
 WORKDIR /app
-COPY --from=builder /build/SHAFT_MCP.jar /app/SHAFT_MCP.jar
+COPY --from=builder /opt/java/openjdk /opt/java/openjdk
+COPY --from=builder /build/shaft-mcp.jar /app/shaft-mcp.jar
 
 EXPOSE 8081
-ENV SPRING_PROFILES_ACTIVE=http
+ENV JAVA_HOME=/opt/java/openjdk \
+    PATH="/opt/java/openjdk/bin:${PATH}" \
+    SPRING_PROFILES_ACTIVE=http
 
-CMD ["java", "-jar", "SHAFT_MCP.jar"]
+ENTRYPOINT []
+CMD ["java", "-jar", "shaft-mcp.jar"]

--- a/shaft-mcp/Dockerfile.smithery.build
+++ b/shaft-mcp/Dockerfile.smithery.build
@@ -3,28 +3,22 @@ FROM maven:3.9.11-eclipse-temurin-25 AS builder
 WORKDIR /build
 COPY . .
 RUN mvn --batch-mode --no-transfer-progress -pl shaft-mcp -am package -DskipTests -Dgpg.skip \
-    && find shaft-mcp/target -maxdepth 1 -name 'SHAFT_MCP-*.jar' \
+    && find shaft-mcp/target -maxdepth 1 -name 'shaft-mcp-*.jar' \
         ! -name '*-sources.jar' ! -name '*-javadoc.jar' \
-        -exec cp {} /build/SHAFT_MCP.jar \; -quit
+        -exec cp {} /build/shaft-mcp.jar \; -quit
 
-FROM eclipse-temurin:25-jre
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates gnupg wget \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub \
-        | gpg --dearmor -o /usr/share/keyrings/googlechrome-linux-keyring.gpg \
-    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/googlechrome-linux-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
-        > /etc/apt/sources.list.d/google.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends google-chrome-stable \
-    && rm -rf /var/lib/apt/lists/*
+FROM selenium/standalone-all-browsers:latest
 
 LABEL io.modelcontextprotocol.server.name="io.github.ShaftHQ/shaft-mcp"
 
 WORKDIR /app
-COPY --from=builder /build/SHAFT_MCP.jar /app/SHAFT_MCP.jar
+COPY --from=builder /opt/java/openjdk /opt/java/openjdk
+COPY --from=builder /build/shaft-mcp.jar /app/shaft-mcp.jar
 
 EXPOSE 8081
-ENV SPRING_PROFILES_ACTIVE=http
+ENV JAVA_HOME=/opt/java/openjdk \
+    PATH="/opt/java/openjdk/bin:${PATH}" \
+    SPRING_PROFILES_ACTIVE=http
 
-CMD ["java", "-jar", "SHAFT_MCP.jar"]
+ENTRYPOINT []
+CMD ["java", "-jar", "shaft-mcp.jar"]

--- a/shaft-mcp/fly.toml
+++ b/shaft-mcp/fly.toml
@@ -1,4 +1,4 @@
-# Fly.io configuration for SHAFT MCP
+# Fly.io configuration for shaft-mcp
 # MCP Server-Sent Events endpoint is available at /mcp
 
 app = "shaft-mcp"

--- a/shaft-mcp/pom.xml
+++ b/shaft-mcp/pom.xml
@@ -10,9 +10,9 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>SHAFT_MCP</artifactId>
+    <artifactId>shaft-mcp</artifactId>
     <packaging>jar</packaging>
-    <name>SHAFT_MCP</name>
+    <name>shaft-mcp</name>
     <description>Model Context Protocol server for SHAFT browser automation.</description>
 
     <properties>
@@ -124,7 +124,7 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <includes>
-                        <include>io/**</include>
+                        <include>com/**</include>
                         <include>application*.properties</include>
                         <include>logback-spring.xml</include>
                     </includes>
@@ -135,7 +135,7 @@
                 <artifactId>maven-source-plugin</artifactId>
                 <configuration>
                     <includes>
-                        <include>io/**</include>
+                        <include>com/**</include>
                     </includes>
                 </configuration>
             </plugin>
@@ -143,8 +143,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <header>SHAFT_MCP, ${project.version}</header>
-                    <doctitle>SHAFT_MCP, ${project.version}</doctitle>
+                    <header>shaft-mcp, ${project.version}</header>
+                    <doctitle>shaft-mcp, ${project.version}</doctitle>
                 </configuration>
             </plugin>
             <plugin>

--- a/shaft-mcp/server.json
+++ b/shaft-mcp/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.ShaftHQ/shaft-mcp",
-  "title": "SHAFT MCP",
+  "title": "shaft-mcp",
   "description": "SHAFT browser automation, capture, and offline deterministic failure diagnosis",
   "version": "@project.version@",
   "repository": {

--- a/shaft-mcp/src/main/java/com/shaft/mcp/BrowserService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/BrowserService.java
@@ -1,4 +1,4 @@
-package io.github.shafthq.SHAFT_MCP;
+package com.shaft.mcp;
 
 import com.shaft.driver.SHAFT;
 import org.slf4j.Logger;
@@ -6,7 +6,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.stereotype.Service;
 
-import static io.github.shafthq.SHAFT_MCP.EngineService.getDriver;
+import static com.shaft.mcp.EngineService.getDriver;
 
 @Service
 public class BrowserService {

--- a/shaft-mcp/src/main/java/com/shaft/mcp/BrowserType.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/BrowserType.java
@@ -1,4 +1,4 @@
-package io.github.shafthq.SHAFT_MCP;
+package com.shaft.mcp;
 
 /**
  * Supported browser types for SHAFT WebDriver initialization.

--- a/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
@@ -1,4 +1,4 @@
-package io.github.shafthq.SHAFT_MCP;
+package com.shaft.mcp;
 
 import com.shaft.capture.generate.CaptureGenerationRequest;
 import com.shaft.capture.generate.CaptureGenerationResult;

--- a/shaft-mcp/src/main/java/com/shaft/mcp/DoctorService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/DoctorService.java
@@ -1,4 +1,4 @@
-package io.github.shafthq.SHAFT_MCP;
+package com.shaft.mcp;
 
 import com.shaft.doctor.DoctorAiAnalysisRequest;
 import com.shaft.doctor.DoctorAnalysisRequest;

--- a/shaft-mcp/src/main/java/com/shaft/mcp/ElementService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/ElementService.java
@@ -1,4 +1,4 @@
-package io.github.shafthq.SHAFT_MCP;
+package com.shaft.mcp;
 
 import com.shaft.driver.SHAFT;
 import org.openqa.selenium.By;
@@ -7,8 +7,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.stereotype.Service;
 
-import static io.github.shafthq.SHAFT_MCP.EngineService.getDriver;
-import static io.github.shafthq.SHAFT_MCP.EngineService.getLocator;
+import static com.shaft.mcp.EngineService.getDriver;
+import static com.shaft.mcp.EngineService.getLocator;
 
 @Service
 public class ElementService {

--- a/shaft-mcp/src/main/java/com/shaft/mcp/EngineService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/EngineService.java
@@ -1,4 +1,4 @@
-package io.github.shafthq.SHAFT_MCP;
+package com.shaft.mcp;
 
 import com.shaft.driver.SHAFT;
 import com.shaft.listeners.TestNGListener;

--- a/shaft-mcp/src/main/java/com/shaft/mcp/ShaftMcpApplication.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/ShaftMcpApplication.java
@@ -1,4 +1,4 @@
-package io.github.shafthq.SHAFT_MCP;
+package com.shaft.mcp;
 
 import com.shaft.capture.cli.CaptureCli;
 import com.shaft.doctor.cli.DoctorCli;

--- a/shaft-mcp/src/main/java/com/shaft/mcp/locatorStrategy.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/locatorStrategy.java
@@ -1,4 +1,4 @@
-package io.github.shafthq.SHAFT_MCP;
+package com.shaft.mcp;
 
 /**
  * Locator strategies for finding elements on a web page.

--- a/shaft-mcp/src/main/resources/application-http.properties
+++ b/shaft-mcp/src/main/resources/application-http.properties
@@ -1,5 +1,5 @@
 # Streamable HTTP transport configuration for hosted deployments
-spring.application.name=SHAFT_MCP
+spring.application.name=shaft-mcp
 spring.main.web-application-type=servlet
 spring.ai.mcp.server.name=shaft-mcp
 spring.ai.mcp.server.version=@project.version@
@@ -16,5 +16,5 @@ spring.ai.mcp.server.sse-endpoint=/mcp
 # Enable banner and logging for HTTP mode
 spring.main.banner-mode=console
 logging.level.root=INFO
-logging.level.io.github.shafthq.SHAFT_MCP=DEBUG
+logging.level.com.shaft.mcp=DEBUG
 logging.pattern.console=%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n

--- a/shaft-mcp/src/main/resources/application.properties
+++ b/shaft-mcp/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.application.name=SHAFT_MCP
+spring.application.name=shaft-mcp
 spring.main.web-application-type=none
 spring.ai.mcp.server.name=shaft-mcp
 spring.ai.mcp.server.version=@project.version@

--- a/shaft-mcp/src/test/java/com/shaft/mcp/DoctorServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/DoctorServiceTest.java
@@ -1,4 +1,4 @@
-package io.github.shafthq.SHAFT_MCP;
+package com.shaft.mcp;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.shaft.driver.SHAFT;

--- a/shaft-mcp/src/test/java/com/shaft/mcp/EngineServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/EngineServiceTest.java
@@ -1,4 +1,4 @@
-package io.github.shafthq.SHAFT_MCP;
+package com.shaft.mcp;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
@@ -11,7 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Integration tests for SHAFT MCP services.
+ * Integration tests for shaft-mcp services.
  * These tests verify that the MCP server can actually open a browser,
  * navigate to pages, interact with elements, and retrieve data.
  */

--- a/shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java
@@ -1,4 +1,4 @@
-package io.github.shafthq.SHAFT_MCP;
+package com.shaft.mcp;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.tool.ToolCallback;

--- a/shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/claude-desktop.json
+++ b/shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/claude-desktop.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "shaft-mcp": {
       "command": "java",
-      "args": ["-jar", "/absolute/path/SHAFT_MCP-<version>.jar"]
+      "args": ["-jar", "/absolute/path/shaft-mcp-<version>.jar"]
     }
   }
 }

--- a/shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/codex-config.toml
+++ b/shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/codex-config.toml
@@ -1,4 +1,4 @@
 [mcp_servers.shaft-mcp]
 command = "java"
-args = ["-jar", "/absolute/path/SHAFT_MCP-<version>.jar"]
+args = ["-jar", "/absolute/path/shaft-mcp-<version>.jar"]
 default_tools_approval_mode = "prompt"

--- a/shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/gemini-settings.json
+++ b/shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/gemini-settings.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "shaft-mcp": {
       "command": "java",
-      "args": ["-jar", "/absolute/path/SHAFT_MCP-<version>.jar"]
+      "args": ["-jar", "/absolute/path/shaft-mcp-<version>.jar"]
     }
   }
 }

--- a/shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/vscode-mcp.json
+++ b/shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/vscode-mcp.json
@@ -3,7 +3,7 @@
     "shaft-mcp": {
       "type": "stdio",
       "command": "java",
-      "args": ["-jar", "/absolute/path/SHAFT_MCP-<version>.jar"]
+      "args": ["-jar", "/absolute/path/shaft-mcp-<version>.jar"]
     }
   }
 }

--- a/tools/modularization/consumer-fixtures/mcp/pom.xml
+++ b/tools/modularization/consumer-fixtures/mcp/pom.xml
@@ -5,8 +5,8 @@
     <groupId>io.github.shafthq.fixture</groupId>
     <artifactId>shaft-mcp-consumer</artifactId>
     <version>1.0.0</version>
-    <name>SHAFT MCP publication consumer</name>
-    <description>Resolves the preserved SHAFT_MCP executable coordinate through the SHAFT BOM.</description>
+    <name>shaft-mcp publication consumer</name>
+    <description>Resolves the shaft-mcp executable coordinate through the SHAFT BOM.</description>
 
     <properties>
         <shaft.version>10.2.20260614</shaft.version>
@@ -28,7 +28,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.shafthq</groupId>
-            <artifactId>SHAFT_MCP</artifactId>
+            <artifactId>shaft-mcp</artifactId>
             <scope>runtime</scope>
         </dependency>
     </dependencies>
@@ -50,10 +50,10 @@
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>io.github.shafthq</groupId>
-                                    <artifactId>SHAFT_MCP</artifactId>
+                                    <artifactId>shaft-mcp</artifactId>
                                     <version>${shaft.version}</version>
                                     <outputDirectory>${project.build.directory}</outputDirectory>
-                                    <destFileName>SHAFT_MCP.jar</destFileName>
+                                    <destFileName>shaft-mcp.jar</destFileName>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>


### PR DESCRIPTION
## Summary

- rename the Maven artifact, generated JARs, workflows, fixtures, validators, and text references from `SHAFT_MCP` to `shaft-mcp`
- move the Java package from `io.github.shafthq.SHAFT_MCP` to `com.shaft.mcp`
- update BOM, publication, release, Docker, and consumer configuration for the new coordinate
- use `selenium/standalone-all-browsers:latest` as the runtime base for every shaft-mcp Dockerfile while preserving the Java 25 runtime

## Why

The MCP module used an uppercase underscore artifact and package identity that did not match the repository's lowercase kebab-case module convention. Its container images also installed or omitted browsers independently instead of using the requested Selenium all-browsers runtime.

## Impact

Consumers must use `io.github.shafthq:shaft-mcp` and `shaft-mcp-<version>.jar`. Java references move to `com.shaft.mcp`. Published container builds now track the latest `selenium/standalone-all-browsers` runtime image.

## Validation

Passed before the final Docker base-image edit:

- focused non-external shaft-mcp tests: 5 passed with populated Allure result JSON
- `mvn --batch-mode --no-transfer-progress -pl shaft-mcp -am package -DskipTests -Dgpg.skip`
- shaft-mcp configuration, Maven publication, quality, modular documentation, documentation-boundary, agent-guidance, and Pilot release validators
- packaged JAR inspection confirmed `Start-Class: com.shaft.mcp.ShaftMcpApplication`
- `git diff --check`

No tests or validators were rerun after the Docker base-image change, per explicit request.