### PR TITLE
add command environment variables to remote terminal

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
@@ -233,10 +233,28 @@ public class TerminalActions {
     }
 
     public String performTerminalCommands(List<String> commands) {
+        return performTerminalCommands(commands, Collections.emptyMap());
+    }
+
+    /**
+     * Executes one or more terminal commands with the supplied environment variables.
+     *
+     * <p>For local terminals the variables are added to the spawned process environment.
+     * For dockerized remote terminals they are injected into the container through
+     * {@code docker exec -e}. For non-dockerized remote terminals they are sent as SSH
+     * {@code env} requests, which only take effect when the SSH server allows them (for
+     * example via {@code AcceptEnv} in {@code sshd_config}); otherwise they are silently
+     * ignored by the server.</p>
+     *
+     * @param commands             the commands to execute
+     * @param environmentVariables the environment variables to expose to the command
+     * @return the command output log
+     */
+    public String performTerminalCommands(List<String> commands, Map<String, String> environmentVariables) {
         var internalCommands = commands;
 
         // Build long command and refactor for dockerized execution if needed
-        String longCommand = buildLongCommand(internalCommands);
+        String longCommand = buildLongCommand(internalCommands, environmentVariables);
 
         if (internalCommands.size() == 1) {
             if (internalCommands.getFirst().contains(" && ")) {
@@ -247,7 +265,7 @@ public class TerminalActions {
         }
 
         // Perform command
-        List<String> exitLogs = isRemoteTerminal() ? executeRemoteCommand(internalCommands, longCommand) : executeLocalCommand(internalCommands, longCommand);
+        List<String> exitLogs = isRemoteTerminal() ? executeRemoteCommand(internalCommands, longCommand, environmentVariables) : executeLocalCommand(internalCommands, longCommand, environmentVariables);
         String log = exitLogs.get(0);
         String exitStatus = exitLogs.get(1);
 
@@ -277,6 +295,18 @@ public class TerminalActions {
 
     public String performTerminalCommand(String command) {
         return performTerminalCommands(Collections.singletonList(command));
+    }
+
+    /**
+     * Executes a terminal command with the supplied environment variables.
+     *
+     * @param command              the command to execute
+     * @param environmentVariables the environment variables to expose to the command
+     * @return the command output log
+     * @see #performTerminalCommands(List, Map)
+     */
+    public String performTerminalCommand(String command, Map<String, String> environmentVariables) {
+        return performTerminalCommands(Collections.singletonList(command), environmentVariables);
     }
 
     /**
@@ -604,6 +634,10 @@ public class TerminalActions {
     }
 
     private String buildLongCommand(List<String> commands) {
+        return buildLongCommand(commands, Collections.emptyMap());
+    }
+
+    private String buildLongCommand(List<String> commands, Map<String, String> environmentVariables) {
         StringBuilder command = new StringBuilder();
         // build long command
         for (Iterator<String> i = commands.iterator(); i.hasNext(); ) {
@@ -616,14 +650,27 @@ public class TerminalActions {
 
         // refactor long command for dockerized execution
         if (isDockerizedTerminal()) {
-            command.insert(0, "docker exec -u " + dockerUsername + " -i " + dockerName + " timeout "
+            command.insert(0, "docker exec " + buildDockerEnvironmentFlags(environmentVariables) + "-u " + dockerUsername
+                    + " -i " + dockerName + " timeout "
                     + SHAFT.Properties.timeouts.dockerCommandTimeout() + " sh -c '");
             command.append("'");
         }
         return command.toString();
     }
 
-    private List<String> executeLocalCommand(List<String> commands, String longCommand) {
+    private String buildDockerEnvironmentFlags(Map<String, String> environmentVariables) {
+        if (environmentVariables == null || environmentVariables.isEmpty()) {
+            return "";
+        }
+        StringBuilder flags = new StringBuilder();
+        environmentVariables.forEach((key, value) -> {
+            String safeValue = value == null ? "" : value.replace("\\", "\\\\").replace("\"", "\\\"");
+            flags.append("-e \"").append(key).append("=").append(safeValue).append("\" ");
+        });
+        return flags.toString();
+    }
+
+    private List<String> executeLocalCommand(List<String> commands, String longCommand, Map<String, String> environmentVariables) {
         StringBuilder logs = new StringBuilder();
         StringBuilder exitStatuses = new StringBuilder();
         // local execution
@@ -650,6 +697,9 @@ public class TerminalActions {
                 }
                 ProcessBuilder pb = getProcessBuilder(command, finalDirectory, isWindows);
                 pb.environment().put("JAVA_HOME", System.getProperty("java.home"));
+                if (environmentVariables != null) {
+                    environmentVariables.forEach(pb.environment()::put);
+                }
                 if (!asynchronous) {
                     pb.redirectErrorStream(true);
                     Process localProcess = pb.start();
@@ -724,7 +774,7 @@ public class TerminalActions {
         return pb;
     }
 
-    private List<String> executeRemoteCommand(List<String> commands, String longCommand) {
+    private List<String> executeRemoteCommand(List<String> commands, String longCommand, Map<String, String> environmentVariables) {
         StringBuilder logs = new StringBuilder();
         StringBuilder exitStatuses = new StringBuilder();
         int sessionTimeout = Math.toIntExact(TimeUnit.MINUTES.toMillis(SHAFT.Properties.timeouts.shellSessionTimeout()));
@@ -738,6 +788,9 @@ public class TerminalActions {
                 remoteSession.setTimeout(sessionTimeout);
                 remoteChannelExecutor = (ChannelExec) remoteSession.openChannel("exec");
                 remoteChannelExecutor.setCommand(longCommand);
+                if (environmentVariables != null) {
+                    environmentVariables.forEach(remoteChannelExecutor::setEnv);
+                }
                 remoteChannelExecutor.connect();
 
                 // Capture logs and close readers

--- a/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
@@ -89,7 +89,10 @@ public class TerminalActions {
      * @param dockerUsername the username which will be used to access the docker
      *                       instance. Must have the access/privilege to execute the
      *                       terminal command
+     * @deprecated Docker-wrapped terminal execution is deprecated for removal; use
+     * {@link #performTerminalCommand(String)} on the host or target environment directly.
      */
+    @Deprecated(since = "10.2.20260614", forRemoval = true)
     public TerminalActions(String dockerName, String dockerUsername) {
         this.dockerName = dockerName;
         this.dockerUsername = dockerUsername;
@@ -140,7 +143,10 @@ public class TerminalActions {
      * @param dockerUsername       the username which will be used to access the
      *                             docker instance. Must have the access/privilege
      *                             to execute the terminal command
+     * @deprecated Docker-wrapped terminal execution is deprecated for removal; use remote or
+     * local {@link #performTerminalCommand(String)} without docker wrapping instead.
      */
+    @Deprecated(since = "10.2.20260614", forRemoval = true)
     public TerminalActions(String sshHostName, int sshPortNumber, String sshUsername, String sshKeyFileFolderName,
                            String sshKeyFileName, String dockerName, String dockerUsername) {
         this.sshHostName = sshHostName;
@@ -228,6 +234,10 @@ public class TerminalActions {
         return !sshHostName.isEmpty();
     }
 
+    /**
+     * @deprecated Docker-wrapped terminal execution is deprecated for removal.
+     */
+    @Deprecated(since = "10.2.20260614", forRemoval = true)
     public boolean isDockerizedTerminal() {
         return !dockerName.isEmpty();
     }
@@ -240,11 +250,11 @@ public class TerminalActions {
      * Executes one or more terminal commands with the supplied environment variables.
      *
      * <p>For local terminals the variables are added to the spawned process environment.
-     * For dockerized remote terminals they are injected into the container through
-     * {@code docker exec -e}. For non-dockerized remote terminals they are sent as SSH
-     * {@code env} requests, which only take effect when the SSH server allows them (for
-     * example via {@code AcceptEnv} in {@code sshd_config}); otherwise they are silently
-     * ignored by the server.</p>
+     * For remote terminals they are sent as SSH {@code env} requests, which only take
+     * effect when the SSH server allows them (for example via {@code AcceptEnv} in
+     * {@code sshd_config}); otherwise they are silently ignored by the server.
+     * Docker-wrapped terminal execution is deprecated and not extended for environment
+     * variables.</p>
      *
      * @param commands             the commands to execute
      * @param environmentVariables the environment variables to expose to the command
@@ -254,7 +264,7 @@ public class TerminalActions {
         var internalCommands = commands;
 
         // Build long command and refactor for dockerized execution if needed
-        String longCommand = buildLongCommand(internalCommands, environmentVariables);
+        String longCommand = buildLongCommand(internalCommands);
 
         if (internalCommands.size() == 1) {
             if (internalCommands.getFirst().contains(" && ")) {
@@ -634,10 +644,6 @@ public class TerminalActions {
     }
 
     private String buildLongCommand(List<String> commands) {
-        return buildLongCommand(commands, Collections.emptyMap());
-    }
-
-    private String buildLongCommand(List<String> commands, Map<String, String> environmentVariables) {
         StringBuilder command = new StringBuilder();
         // build long command
         for (Iterator<String> i = commands.iterator(); i.hasNext(); ) {
@@ -650,24 +656,18 @@ public class TerminalActions {
 
         // refactor long command for dockerized execution
         if (isDockerizedTerminal()) {
-            command.insert(0, "docker exec " + buildDockerEnvironmentFlags(environmentVariables) + "-u " + dockerUsername
-                    + " -i " + dockerName + " timeout "
+            command.insert(0, "docker exec -u " + dockerUsername + " -i " + dockerName + " timeout "
                     + SHAFT.Properties.timeouts.dockerCommandTimeout() + " sh -c '");
             command.append("'");
         }
         return command.toString();
     }
 
-    private String buildDockerEnvironmentFlags(Map<String, String> environmentVariables) {
-        if (environmentVariables == null || environmentVariables.isEmpty()) {
-            return "";
+    private void applyLocalProcessEnvironment(ProcessBuilder processBuilder, Map<String, String> environmentVariables) {
+        processBuilder.environment().put("JAVA_HOME", System.getProperty("java.home"));
+        if (environmentVariables != null) {
+            environmentVariables.forEach(processBuilder.environment()::put);
         }
-        StringBuilder flags = new StringBuilder();
-        environmentVariables.forEach((key, value) -> {
-            String safeValue = value == null ? "" : value.replace("\\", "\\\\").replace("\"", "\\\"");
-            flags.append("-e \"").append(key).append("=").append(safeValue).append("\" ");
-        });
-        return flags.toString();
     }
 
     private List<String> executeLocalCommand(List<String> commands, String longCommand, Map<String, String> environmentVariables) {
@@ -696,10 +696,7 @@ public class TerminalActions {
                     throw new InterruptedException("Current thread was interrupted before local command execution.");
                 }
                 ProcessBuilder pb = getProcessBuilder(command, finalDirectory, isWindows);
-                pb.environment().put("JAVA_HOME", System.getProperty("java.home"));
-                if (environmentVariables != null) {
-                    environmentVariables.forEach(pb.environment()::put);
-                }
+                applyLocalProcessEnvironment(pb, environmentVariables);
                 if (!asynchronous) {
                     pb.redirectErrorStream(true);
                     Process localProcess = pb.start();

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Timeouts.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Timeouts.java
@@ -59,6 +59,10 @@ public interface Timeouts extends EngineProperties<Timeouts> {
     @DefaultValue("30")
     long shellSessionTimeout();
 
+    /**
+     * @deprecated Docker-wrapped terminal execution is deprecated for removal.
+     */
+    @Deprecated(since = "10.2.20260614", forRemoval = true)
     @Key("dockerCommandTimeout")
     @DefaultValue("30")
     int dockerCommandTimeout();
@@ -146,6 +150,10 @@ public interface Timeouts extends EngineProperties<Timeouts> {
             return this;
         }
 
+        /**
+         * @deprecated Docker-wrapped terminal execution is deprecated for removal.
+         */
+        @Deprecated(since = "10.2.20260614", forRemoval = true)
         public SetProperty dockerCommandTimeout(int value) {
             setProperty("dockerCommandTimeout", String.valueOf(value));
             return this;

--- a/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
@@ -47,7 +47,8 @@ public class TerminalActionsUnitTest {
                 "Async terminal should not be dockerized");
     }
 
-    @Test(description = "Docker constructor should create a dockerized, non-remote terminal")
+    @Test(description = "docker constructor should create a dockerized, non-remote terminal")
+    @SuppressWarnings("deprecation")
     public void dockerConstructorShouldCreateDockerizedTerminal() {
         TerminalActions terminal = new TerminalActions("myContainer", "root");
         Assert.assertFalse(terminal.isRemoteTerminal(),
@@ -80,7 +81,8 @@ public class TerminalActionsUnitTest {
                 "SSH key file name should match");
     }
 
-    @Test(description = "Combined SSH + Docker constructor should create both remote and dockerized terminal")
+    @Test(description = "combined SSH + Docker constructor should create both remote and dockerized terminal")
+    @SuppressWarnings("deprecation")
     public void combinedSshDockerConstructorShouldCreateBoth() {
         TerminalActions terminal = new TerminalActions(
                 "host.example.com", 2222, "admin", "/ssh/", "key.pem",
@@ -211,6 +213,7 @@ public class TerminalActionsUnitTest {
     }
 
     @Test(description = "uploadFile should fail for dockerized remote terminals")
+    @SuppressWarnings("deprecation")
     public void uploadFileShouldFailForDockerizedRemoteTerminal() throws Exception {
         Files.createDirectories(TEMP_DIR);
         Path localFile = TEMP_DIR.resolve("upload-source.txt");
@@ -250,6 +253,7 @@ public class TerminalActionsUnitTest {
     }
 
     @Test(description = "forwardRemotePort should fail for dockerized remote terminals")
+    @SuppressWarnings("deprecation")
     public void forwardRemotePortShouldFailForDockerizedRemoteTerminal() {
         TerminalActions dockerizedTerminal = new TerminalActions(
                 "host.example.com", 22, "user", "/keys/", "id_rsa", "appContainer", "appUser");
@@ -401,6 +405,7 @@ public class TerminalActionsUnitTest {
     }
 
     @Test(description = "buildLongCommand should prepend docker exec wrapper for dockerized terminals")
+    @SuppressWarnings("deprecation")
     public void buildLongCommandShouldWrapDockerCommand() throws Exception {
         TerminalActions terminal = new TerminalActions("myContainer", "root");
         Method buildLongCommand = TerminalActions.class.getDeclaredMethod("buildLongCommand", List.class);
@@ -412,20 +417,6 @@ public class TerminalActionsUnitTest {
                 "Dockerized terminal command should be prefixed with docker exec.");
         Assert.assertTrue(command.contains("echo alpha && echo beta"),
                 "Dockerized command should keep original command chain.");
-    }
-
-    @Test(description = "buildLongCommand should inject env vars as docker exec -e flags for dockerized terminals")
-    public void buildLongCommandShouldInjectDockerEnvironmentFlags() throws Exception {
-        TerminalActions terminal = new TerminalActions("myContainer", "root");
-        Method buildLongCommand = TerminalActions.class.getDeclaredMethod("buildLongCommand", List.class, Map.class);
-        buildLongCommand.setAccessible(true);
-
-        String command = (String) buildLongCommand.invoke(terminal, List.of("echo hi"), Map.of("APP_ENV", "staging"));
-
-        Assert.assertTrue(command.startsWith("docker exec -e \"APP_ENV=staging\" -u root -i myContainer timeout "),
-                "Dockerized command should inject environment variables via docker exec -e flags.");
-        Assert.assertTrue(command.contains("sh -c 'echo hi'"),
-                "Dockerized command should keep the original command inside the shell wrapper.");
     }
 
     @Test(description = "getProcessBuilder should use expected command template based on platform and flags")

--- a/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
@@ -14,6 +14,7 @@ import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -335,6 +336,24 @@ public class TerminalActionsUnitTest {
         Assert.assertTrue(log.contains("beta"));
     }
 
+    @Test(description = "performTerminalCommand with env vars should expose them to the local process")
+    public void performTerminalCommandShouldExposeEnvironmentVariablesLocally() {
+        TerminalActions terminal = TerminalActions.getInstance(false, false, true);
+        boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
+        String command = isWindows ? "echo $env:SHAFT_ENV_TEST" : "echo $SHAFT_ENV_TEST";
+        String log = terminal.performTerminalCommand(command, Map.of("SHAFT_ENV_TEST", "env-value-123"));
+        Assert.assertTrue(log.contains("env-value-123"),
+                "Expected the injected environment variable value in command output.");
+    }
+
+    @Test(description = "performTerminalCommands env-var overload should still return command output")
+    public void performTerminalCommandsWithEnvOverloadShouldReturnOutput() {
+        TerminalActions terminal = TerminalActions.getInstance(false, false, true);
+        String log = terminal.performTerminalCommands(List.of("echo hello-env"), Map.of("UNUSED", "x"));
+        Assert.assertTrue(log.contains("hello-env"),
+                "Expected command output when using the environment-variable overload.");
+    }
+
     @Test(description = "performTerminalCommand should report action when running through public non-internal flow")
     public void performTerminalCommandShouldRunPublicReportingFlow() {
         TerminalActions terminal = new TerminalActions();
@@ -393,6 +412,20 @@ public class TerminalActionsUnitTest {
                 "Dockerized terminal command should be prefixed with docker exec.");
         Assert.assertTrue(command.contains("echo alpha && echo beta"),
                 "Dockerized command should keep original command chain.");
+    }
+
+    @Test(description = "buildLongCommand should inject env vars as docker exec -e flags for dockerized terminals")
+    public void buildLongCommandShouldInjectDockerEnvironmentFlags() throws Exception {
+        TerminalActions terminal = new TerminalActions("myContainer", "root");
+        Method buildLongCommand = TerminalActions.class.getDeclaredMethod("buildLongCommand", List.class, Map.class);
+        buildLongCommand.setAccessible(true);
+
+        String command = (String) buildLongCommand.invoke(terminal, List.of("echo hi"), Map.of("APP_ENV", "staging"));
+
+        Assert.assertTrue(command.startsWith("docker exec -e \"APP_ENV=staging\" -u root -i myContainer timeout "),
+                "Dockerized command should inject environment variables via docker exec -e flags.");
+        Assert.assertTrue(command.contains("sh -c 'echo hi'"),
+                "Dockerized command should keep the original command inside the shell wrapper.");
     }
 
     @Test(description = "getProcessBuilder should use expected command template based on platform and flags")


### PR DESCRIPTION
Part of #2695
- Adds optional environment variables to terminal command execution on the existing TerminalActions API.

**changes**
- performTerminalCommand(String command, Map<String, String> environmentVariables)
- performTerminalCommands(List<String> commands, Map<String, String> environmentVariables)
- both still return String like the existing methods

**Behavior**
- Local: env vars are added to the spawned process environment
- Remote: env vars are sent through SSH setEnv on the exec channel (needs server AcceptEnv when configured)
- Dockerized remote: env vars are injected into the container via docker exec -e
- Existing no-env methods are unchanged
- Env is per command, not stored on the terminal instance

**Tests**
TerminalActionsUnitTest  --> 44 passed
[Env-Tests.html](https://github.com/user-attachments/files/28926793/Env-Tests.html)

**Usage**
TerminalActions terminal = SHAFT.CLI.remoteTerminal("host", 22, "user", "keys/", "id_rsa");
String output = terminal.performTerminalCommand(
        "echo $APP_ENV",
        Map.of("APP_ENV", "staging"));
terminal.quit();