### PR TITLE
build: keep dependency updates and restore shaft-mcp runtime images

### DIFF
--- a/scripts/ci/validate_shaft_mcp_configuration.py
+++ b/scripts/ci/validate_shaft_mcp_configuration.py
@@ -115,6 +115,10 @@ def validate(root: Path = ROOT) -> list[str]:
             errors.append(f"{dockerfile.name} must build from the reactor without a hardcoded release")
         if "-pl shaft-mcp -am" not in content:
             errors.append(f"{dockerfile.name} must build shaft-mcp from the root reactor")
+        if "google-chrome-stable" not in content:
+            errors.append(f"{dockerfile.name} must install Chrome and its runtime dependencies")
+        if '"-DheadlessExecution=true"' not in content:
+            errors.append(f"{dockerfile.name} must launch Chrome headlessly in its container")
     return errors
 
 

--- a/shaft-mcp/Dockerfile
+++ b/shaft-mcp/Dockerfile
@@ -9,6 +9,16 @@ RUN mvn --batch-mode --no-transfer-progress -pl shaft-mcp -am package -DskipTest
 
 FROM eclipse-temurin:25-jre
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates gnupg wget \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub \
+        | gpg --dearmor -o /usr/share/keyrings/googlechrome-linux-keyring.gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/googlechrome-linux-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
+        > /etc/apt/sources.list.d/google.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends google-chrome-stable \
+    && rm -rf /var/lib/apt/lists/*
+
 LABEL io.modelcontextprotocol.server.name="io.github.ShaftHQ/shaft-mcp" \
       org.opencontainers.image.source="https://github.com/ShaftHQ/SHAFT_ENGINE" \
       org.opencontainers.image.description="shaft-mcp server for browser and test automation" \
@@ -19,4 +29,4 @@ COPY --from=builder /build/shaft-mcp.jar /app/shaft-mcp.jar
 
 ENV REMOTE_DRIVER_ADDRESS=""
 
-CMD ["java", "-jar", "shaft-mcp.jar"]
+CMD ["java", "-DheadlessExecution=true", "-jar", "shaft-mcp.jar"]

--- a/shaft-mcp/Dockerfile
+++ b/shaft-mcp/Dockerfile
@@ -7,7 +7,7 @@ RUN mvn --batch-mode --no-transfer-progress -pl shaft-mcp -am package -DskipTest
         ! -name '*-sources.jar' ! -name '*-javadoc.jar' \
         -exec cp {} /build/shaft-mcp.jar \; -quit
 
-FROM selenium/standalone-all-browsers:latest
+FROM eclipse-temurin:25-jre
 
 LABEL io.modelcontextprotocol.server.name="io.github.ShaftHQ/shaft-mcp" \
       org.opencontainers.image.source="https://github.com/ShaftHQ/SHAFT_ENGINE" \
@@ -15,12 +15,8 @@ LABEL io.modelcontextprotocol.server.name="io.github.ShaftHQ/shaft-mcp" \
       org.opencontainers.image.licenses="MIT"
 
 WORKDIR /app
-COPY --from=builder /opt/java/openjdk /opt/java/openjdk
 COPY --from=builder /build/shaft-mcp.jar /app/shaft-mcp.jar
 
-ENV JAVA_HOME=/opt/java/openjdk \
-    PATH="/opt/java/openjdk/bin:${PATH}" \
-    REMOTE_DRIVER_ADDRESS=""
+ENV REMOTE_DRIVER_ADDRESS=""
 
-ENTRYPOINT []
 CMD ["java", "-jar", "shaft-mcp.jar"]

--- a/shaft-mcp/Dockerfile.fly
+++ b/shaft-mcp/Dockerfile.fly
@@ -7,18 +7,25 @@ RUN mvn --batch-mode --no-transfer-progress -pl shaft-mcp -am package -DskipTest
         ! -name '*-sources.jar' ! -name '*-javadoc.jar' \
         -exec cp {} /build/shaft-mcp.jar \; -quit
 
-FROM selenium/standalone-all-browsers:latest
+FROM eclipse-temurin:25-jre
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates dumb-init gnupg wget \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub \
+        | gpg --dearmor -o /usr/share/keyrings/googlechrome-linux-keyring.gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/googlechrome-linux-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
+        > /etc/apt/sources.list.d/google.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends google-chrome-stable \
+    && rm -rf /var/lib/apt/lists/*
 
 LABEL io.modelcontextprotocol.server.name="io.github.ShaftHQ/shaft-mcp"
 
 WORKDIR /app
-COPY --from=builder /opt/java/openjdk /opt/java/openjdk
 COPY --from=builder /build/shaft-mcp.jar /app/shaft-mcp.jar
 
 EXPOSE 8080
-ENV JAVA_HOME=/opt/java/openjdk \
-    PATH="/opt/java/openjdk/bin:${PATH}" \
-    SPRING_PROFILES_ACTIVE=http
+ENV SPRING_PROFILES_ACTIVE=http
 
-ENTRYPOINT []
+ENTRYPOINT ["dumb-init", "--"]
 CMD ["java", "-XX:+UseSerialGC", "-Xms128m", "-Xmx384m", "-XX:MaxMetaspaceSize=64m", "-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-Dspring.main.lazy-initialization=true", "-jar", "shaft-mcp.jar"]

--- a/shaft-mcp/Dockerfile.fly
+++ b/shaft-mcp/Dockerfile.fly
@@ -28,4 +28,4 @@ EXPOSE 8080
 ENV SPRING_PROFILES_ACTIVE=http
 
 ENTRYPOINT ["dumb-init", "--"]
-CMD ["java", "-XX:+UseSerialGC", "-Xms128m", "-Xmx384m", "-XX:MaxMetaspaceSize=64m", "-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-Dspring.main.lazy-initialization=true", "-jar", "shaft-mcp.jar"]
+CMD ["java", "-XX:+UseSerialGC", "-Xms128m", "-Xmx384m", "-XX:MaxMetaspaceSize=64m", "-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-Dspring.main.lazy-initialization=true", "-DheadlessExecution=true", "-jar", "shaft-mcp.jar"]

--- a/shaft-mcp/Dockerfile.render
+++ b/shaft-mcp/Dockerfile.render
@@ -7,18 +7,24 @@ RUN mvn --batch-mode --no-transfer-progress -pl shaft-mcp -am package -DskipTest
         ! -name '*-sources.jar' ! -name '*-javadoc.jar' \
         -exec cp {} /build/shaft-mcp.jar \; -quit
 
-FROM selenium/standalone-all-browsers:latest
+FROM eclipse-temurin:25-jre
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates gnupg wget \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub \
+        | gpg --dearmor -o /usr/share/keyrings/googlechrome-linux-keyring.gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/googlechrome-linux-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
+        > /etc/apt/sources.list.d/google.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends google-chrome-stable \
+    && rm -rf /var/lib/apt/lists/*
 
 LABEL io.modelcontextprotocol.server.name="io.github.ShaftHQ/shaft-mcp"
 
 WORKDIR /app
-COPY --from=builder /opt/java/openjdk /opt/java/openjdk
 COPY --from=builder /build/shaft-mcp.jar /app/shaft-mcp.jar
 
 EXPOSE 8081
-ENV JAVA_HOME=/opt/java/openjdk \
-    PATH="/opt/java/openjdk/bin:${PATH}" \
-    SPRING_PROFILES_ACTIVE=http
+ENV SPRING_PROFILES_ACTIVE=http
 
-ENTRYPOINT []
 CMD ["java", "-XX:+UseSerialGC", "-Xms128m", "-Xmx384m", "-XX:MaxMetaspaceSize=64m", "-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-Dspring.main.lazy-initialization=true", "-jar", "shaft-mcp.jar"]

--- a/shaft-mcp/Dockerfile.render
+++ b/shaft-mcp/Dockerfile.render
@@ -27,4 +27,4 @@ COPY --from=builder /build/shaft-mcp.jar /app/shaft-mcp.jar
 EXPOSE 8081
 ENV SPRING_PROFILES_ACTIVE=http
 
-CMD ["java", "-XX:+UseSerialGC", "-Xms128m", "-Xmx384m", "-XX:MaxMetaspaceSize=64m", "-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-Dspring.main.lazy-initialization=true", "-jar", "shaft-mcp.jar"]
+CMD ["java", "-XX:+UseSerialGC", "-Xms128m", "-Xmx384m", "-XX:MaxMetaspaceSize=64m", "-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-Dspring.main.lazy-initialization=true", "-DheadlessExecution=true", "-jar", "shaft-mcp.jar"]

--- a/shaft-mcp/Dockerfile.smithery
+++ b/shaft-mcp/Dockerfile.smithery
@@ -7,18 +7,24 @@ RUN mvn --batch-mode --no-transfer-progress -pl shaft-mcp -am package -DskipTest
         ! -name '*-sources.jar' ! -name '*-javadoc.jar' \
         -exec cp {} /build/shaft-mcp.jar \; -quit
 
-FROM selenium/standalone-all-browsers:latest
+FROM eclipse-temurin:25-jre
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates gnupg wget \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub \
+        | gpg --dearmor -o /usr/share/keyrings/googlechrome-linux-keyring.gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/googlechrome-linux-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
+        > /etc/apt/sources.list.d/google.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends google-chrome-stable \
+    && rm -rf /var/lib/apt/lists/*
 
 LABEL io.modelcontextprotocol.server.name="io.github.ShaftHQ/shaft-mcp"
 
 WORKDIR /app
-COPY --from=builder /opt/java/openjdk /opt/java/openjdk
 COPY --from=builder /build/shaft-mcp.jar /app/shaft-mcp.jar
 
 EXPOSE 8081
-ENV JAVA_HOME=/opt/java/openjdk \
-    PATH="/opt/java/openjdk/bin:${PATH}" \
-    SPRING_PROFILES_ACTIVE=http
+ENV SPRING_PROFILES_ACTIVE=http
 
-ENTRYPOINT []
 CMD ["java", "-jar", "shaft-mcp.jar"]

--- a/shaft-mcp/Dockerfile.smithery
+++ b/shaft-mcp/Dockerfile.smithery
@@ -27,4 +27,4 @@ COPY --from=builder /build/shaft-mcp.jar /app/shaft-mcp.jar
 EXPOSE 8081
 ENV SPRING_PROFILES_ACTIVE=http
 
-CMD ["java", "-jar", "shaft-mcp.jar"]
+CMD ["java", "-DheadlessExecution=true", "-jar", "shaft-mcp.jar"]

--- a/shaft-mcp/Dockerfile.smithery.build
+++ b/shaft-mcp/Dockerfile.smithery.build
@@ -7,18 +7,24 @@ RUN mvn --batch-mode --no-transfer-progress -pl shaft-mcp -am package -DskipTest
         ! -name '*-sources.jar' ! -name '*-javadoc.jar' \
         -exec cp {} /build/shaft-mcp.jar \; -quit
 
-FROM selenium/standalone-all-browsers:latest
+FROM eclipse-temurin:25-jre
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates gnupg wget \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub \
+        | gpg --dearmor -o /usr/share/keyrings/googlechrome-linux-keyring.gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/googlechrome-linux-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
+        > /etc/apt/sources.list.d/google.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends google-chrome-stable \
+    && rm -rf /var/lib/apt/lists/*
 
 LABEL io.modelcontextprotocol.server.name="io.github.ShaftHQ/shaft-mcp"
 
 WORKDIR /app
-COPY --from=builder /opt/java/openjdk /opt/java/openjdk
 COPY --from=builder /build/shaft-mcp.jar /app/shaft-mcp.jar
 
 EXPOSE 8081
-ENV JAVA_HOME=/opt/java/openjdk \
-    PATH="/opt/java/openjdk/bin:${PATH}" \
-    SPRING_PROFILES_ACTIVE=http
+ENV SPRING_PROFILES_ACTIVE=http
 
-ENTRYPOINT []
 CMD ["java", "-jar", "shaft-mcp.jar"]

--- a/shaft-mcp/Dockerfile.smithery.build
+++ b/shaft-mcp/Dockerfile.smithery.build
@@ -27,4 +27,4 @@ COPY --from=builder /build/shaft-mcp.jar /app/shaft-mcp.jar
 EXPOSE 8081
 ENV SPRING_PROFILES_ACTIVE=http
 
-CMD ["java", "-jar", "shaft-mcp.jar"]
+CMD ["java", "-DheadlessExecution=true", "-jar", "shaft-mcp.jar"]


### PR DESCRIPTION
### Motivation

- The branch consolidated many reactor-wide stable dependency updates but also changed the `shaft-mcp` container runtime to a browser-heavy base image; the runtime change needs to be reverted while keeping the dependency alignment.

### Description

- Restored `shaft-mcp` runtime images from `selenium/standalone-all-browsers:latest` back to `eclipse-temurin:25-jre` across `shaft-mcp/Dockerfile*` and preserved the renamed `shaft-mcp` artifact and JAR paths. 
- Reintroduced explicit Google Chrome installation for Fly/Render/Smithery images and re-added `dumb-init` as the Fly image entrypoint. 
- Ensured Dockerfiles build the packaged `shaft-mcp` JAR produced by the reactor (copying `/build/shaft-mcp.jar`) and removed the previously added JDK extraction/copy steps. 

### Testing

- Ran Maven Versions Plugin across the reactor with `mvn ... versions:display-* -DallowSnapshots=false -DprocessAllModules=true` to review available stable updates and confirmed explicitly-managed properties are current. 
- Ran validation and quality checks with `python3 scripts/ci/validate_reactor_versions.py`, `python3 scripts/ci/validate_quality_configuration.py`, and `python3 scripts/ci/validate_shaft_mcp_configuration.py`, all of which passed. 
- Built the MCP module with `mvn -pl shaft-mcp -am package -DskipTests -Dgpg.skip` and ran `python3 scripts/ci/validate_shaft_mcp_transports.py` to smoke-test packaged stdio and HTTP transports, which succeeded. 
- Performed `git diff --check` to confirm no whitespace or trivial issues remained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ea967d51883209dc127e71a5eba61)