### PR TITLE
[codex] release 10.2.20260615

### DIFF
--- a/legacy-shaft-engine/pom.xml
+++ b/legacy-shaft-engine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260614</version>
+        <version>10.2.20260615</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>SHAFT_ENGINE</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.shafthq</groupId>
     <artifactId>shaft-parent</artifactId>
-    <version>10.2.20260614</version>
+    <version>10.2.20260615</version>
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Build parent and reactor aggregator for SHAFT modules.</description>

--- a/report-aggregate/pom.xml
+++ b/report-aggregate/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260614</version>
+        <version>10.2.20260615</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>report-aggregate</artifactId>

--- a/shaft-ai/pom.xml
+++ b/shaft-ai/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260614</version>
+        <version>10.2.20260615</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shaft-bom/pom.xml
+++ b/shaft-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260614</version>
+        <version>10.2.20260615</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>shaft-bom</artifactId>

--- a/shaft-browserstack/pom.xml
+++ b/shaft-browserstack/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260614</version>
+        <version>10.2.20260615</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>shaft-browserstack</artifactId>

--- a/shaft-capture/pom.xml
+++ b/shaft-capture/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260614</version>
+        <version>10.2.20260615</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shaft-doctor/pom.xml
+++ b/shaft-doctor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260614</version>
+        <version>10.2.20260615</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shaft-engine/pom.xml
+++ b/shaft-engine/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260614</version>
+        <version>10.2.20260615</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>shaft-engine</artifactId>

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java
@@ -18,7 +18,7 @@ import org.aeonbits.owner.Config.Sources;
 })
 public interface Internal extends EngineProperties<Internal> {
     @Key("shaftEngineVersion")
-    @DefaultValue("10.2.20260614")
+    @DefaultValue("10.2.20260615")
     String shaftEngineVersion();
 
     @Key("watermarkImagePath")

--- a/shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260614</shaft.version>
+        <shaft.version>10.2.20260615</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260614</shaft.version>
+        <shaft.version>10.2.20260615</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260614</shaft.version>
+        <shaft.version>10.2.20260615</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260614</shaft.version>
+        <shaft.version>10.2.20260615</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260614</shaft.version>
+        <shaft.version>10.2.20260615</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260614</shaft.version>
+        <shaft.version>10.2.20260615</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260614</shaft.version>
+        <shaft.version>10.2.20260615</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-heal/pom.xml
+++ b/shaft-heal/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260614</version>
+        <version>10.2.20260615</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shaft-mcp/pom.xml
+++ b/shaft-mcp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260614</version>
+        <version>10.2.20260615</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shaft-pilot-core/pom.xml
+++ b/shaft-pilot-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260614</version>
+        <version>10.2.20260615</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shaft-video/pom.xml
+++ b/shaft-video/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260614</version>
+        <version>10.2.20260615</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>shaft-video</artifactId>

--- a/shaft-visual/pom.xml
+++ b/shaft-visual/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260614</version>
+        <version>10.2.20260615</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>shaft-visual</artifactId>

--- a/tools/modularization/consumer-fixtures/api/pom.xml
+++ b/tools/modularization/consumer-fixtures/api/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260614</shaft.version>
+        <shaft.version>10.2.20260615</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/appium-mobile/pom.xml
+++ b/tools/modularization/consumer-fixtures/appium-mobile/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260614</shaft.version>
+        <shaft.version>10.2.20260615</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/bom/pom.xml
+++ b/tools/modularization/consumer-fixtures/bom/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260614</shaft.version>
+        <shaft.version>10.2.20260615</shaft.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/tools/modularization/consumer-fixtures/browserstack-sdk/pom.xml
+++ b/tools/modularization/consumer-fixtures/browserstack-sdk/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260614</shaft.version>
+        <shaft.version>10.2.20260615</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/combined-modules/pom.xml
+++ b/tools/modularization/consumer-fixtures/combined-modules/pom.xml
@@ -10,7 +10,7 @@
     <description>Validates the published BOM and all optional modules as one consumer graph.</description>
 
     <properties>
-        <shaft.version>10.2.20260614</shaft.version>
+        <shaft.version>10.2.20260615</shaft.version>
     </properties>
 
     <dependencyManagement>

--- a/tools/modularization/consumer-fixtures/desktop-video/pom.xml
+++ b/tools/modularization/consumer-fixtures/desktop-video/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260614</shaft.version>
+        <shaft.version>10.2.20260615</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/junit-web/pom.xml
+++ b/tools/modularization/consumer-fixtures/junit-web/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260614</shaft.version>
+        <shaft.version>10.2.20260615</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/legacy-coordinate/pom.xml
+++ b/tools/modularization/consumer-fixtures/legacy-coordinate/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260614</shaft.version>
+        <shaft.version>10.2.20260615</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/mcp/pom.xml
+++ b/tools/modularization/consumer-fixtures/mcp/pom.xml
@@ -9,7 +9,7 @@
     <description>Resolves the shaft-mcp executable coordinate through the SHAFT BOM.</description>
 
     <properties>
-        <shaft.version>10.2.20260614</shaft.version>
+        <shaft.version>10.2.20260615</shaft.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/tools/modularization/consumer-fixtures/opencv-visual/pom.xml
+++ b/tools/modularization/consumer-fixtures/opencv-visual/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260614</shaft.version>
+        <shaft.version>10.2.20260615</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/pilot-core/pom.xml
+++ b/tools/modularization/consumer-fixtures/pilot-core/pom.xml
@@ -9,7 +9,7 @@
     <description>Compiles against Pilot contracts without the optional direct-provider module.</description>
 
     <properties>
-        <shaft.version>10.2.20260614</shaft.version>
+        <shaft.version>10.2.20260615</shaft.version>
         <maven.compiler.release>25</maven.compiler.release>
     </properties>
 

--- a/tools/modularization/consumer-fixtures/testng-web/pom.xml
+++ b/tools/modularization/consumer-fixtures/testng-web/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260614</shaft.version>
+        <shaft.version>10.2.20260615</shaft.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
## Summary

- align the full Maven reactor on `10.2.20260615`
- update SHAFT runtime version metadata, bundled examples, and all modular consumer fixtures
- release the MCP module as `io.github.shafthq:shaft-mcp:10.2.20260615` with `shaft-mcp-10.2.20260615.jar`
- confirm tracked content on both `ShaftHQ/SHAFT_ENGINE` and `ShaftHQ/shafthq.github.io` contains no `SHAFT_MCP` reference
- retain Allure `3.11.0`, Node LTS `24.16.0`, and existing top-level dependency/plugin properties after update review

## Why

Changes merged after `10.2.20260614`, including the lowercase shaft-mcp rename, need a new immutable Maven Central coordinate. The release version follows `{major}.{quarter}.{YYYYMMDD}` for June 15, 2026.

## Validation

- reactor, shaft-mcp configuration, SHAFT Pilot release, Maven publication, quality, documentation-boundary, modular documentation, and agent-guidance validators
- packaged-output variants of the SHAFT Pilot and Maven publication validators
- Maven Central availability check for `io.github.shafthq:shaft-parent:10.2.20260615`
- npm registry check for Allure `3.11.0` and Node release-index check for LTS `24.16.0`
- 23 focused release CI-script tests
- `mvn --batch-mode --no-transfer-progress clean install '-DskipTests' '-Dgpg.skip'` across all 14 reactor modules
- canonical API, combined-module, legacy-relocation, Pilot core, and shaft-mcp consumer smoke builds
- packaged shaft-mcp filename, coordinate, manifest start class, and legacy-package inspection
- tracked-tree `SHAFT_MCP` searches in the engine and user guide repositories
- `git diff --check`

## Not run

Further Maven product tests were skipped by request. The interrupted shaft-mcp test process was terminated before commit.

## Remaining protected release steps

The PR workflows must still run the clean Linux release gates. After merge, verify Maven Central publication, the GitHub release, JavaDocs, GHCR/MCP publication, and release-triggered downstream workflows before treating the release as complete.