### PR TITLE
[codex] add local shaft-mcp installer

### DIFF
--- a/.github/workflows/mavenCentral_cd.yml
+++ b/.github/workflows/mavenCentral_cd.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: write  # if you have a protection rule on your repository, you'll need to give write permission to the workflow.
+    outputs:
+      release_version: ${{ steps.release_version.outputs.version }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -43,13 +45,15 @@ jobs:
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5
         with:
-          maven-version: 3.9.5
+          maven-version: 3.9.12
       - name: Reject divergent SHAFT reactor versions
         run: python3 scripts/ci/validate_reactor_versions.py
       # Read the canonical release version from the reactor parent.
       - name: Set Release Version Number
+        id: release_version
         run: |
           echo "RELEASE_VERSION=$(mvn -f pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)" >> "$GITHUB_ENV"
+          echo "version=$(mvn -f pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)" >> "$GITHUB_OUTPUT"
       - name: Validate SHAFT Pilot release contract
         run: |
           python3 scripts/ci/validate_modular_documentation.py
@@ -137,8 +141,48 @@ jobs:
         run: mvn --batch-mode deploy "-DskipTests" "-Dgpg.keyname=${{secrets.GPG_KEYNAME}}" "-Dgpg.passphrase=${{secrets.GPG_PASSPHRASE}}"
       - name: Verify published Maven Central coordinates
         run: python3 scripts/ci/verify_maven_central_release.py "${RELEASE_VERSION}"
+
+  verify_public_shaft_mcp_installer:
+    name: Verify public shaft-mcp installer (${{ matrix.os }})
+    needs: build_release_and_deliver
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-15, windows-2025]
+    steps:
+      - name: Checkout released source
+        uses: actions/checkout@v6
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'zulu'
+          check-latest: true
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: 3.9.12
+      - name: Run the public LATEST installer twice
+        run: python scripts/ci/verify_shaft_mcp_installer_release.py
+
+  announce_release:
+    name: Announce verified release
+    needs: [build_release_and_deliver, verify_public_shaft_mcp_installer]
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout released source
+        uses: actions/checkout@v6
       - name: Prepare Release Body
-        run: sed "s/\$RELEASE_VERSION/${{ env.RELEASE_VERSION }}/g" .github/RELEASE_BODY_TEMPLATE.md > /tmp/release_body.md
+        env:
+          RELEASE_VERSION: ${{ needs.build_release_and_deliver.outputs.release_version }}
+        run: sed "s/\$RELEASE_VERSION/${RELEASE_VERSION}/g" .github/RELEASE_BODY_TEMPLATE.md > /tmp/release_body.md
       - name: Create GitHub Release
         id: create_release
         uses: ncipollo/release-action@v1.21.0
@@ -148,19 +192,19 @@ jobs:
           allowUpdates: false
           generateReleaseNotes: true
           bodyFile: /tmp/release_body.md
-          name: ${{ env.RELEASE_VERSION }}
-          tag: ${{ env.RELEASE_VERSION }}
+          name: ${{ needs.build_release_and_deliver.outputs.release_version }}
+          tag: ${{ needs.build_release_and_deliver.outputs.release_version }}
       - name: Notify User Guide Repository
         uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.BOT_TOKEN }}
           repository: ShaftHQ/shafthq.github.io
           event-type: shaft-engine-release
-          client-payload: '{"tag_name": "${{ env.RELEASE_VERSION }}", "version": "${{ env.RELEASE_VERSION }}", "release_url": "${{ steps.create_release.outputs.html_url }}"}'
+          client-payload: '{"tag_name": "${{ needs.build_release_and_deliver.outputs.release_version }}", "version": "${{ needs.build_release_and_deliver.outputs.release_version }}", "release_url": "${{ steps.create_release.outputs.html_url }}"}'
       - name: Announce Release on Slack
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+          RELEASE_VERSION: ${{ needs.build_release_and_deliver.outputs.release_version }}
           RELEASE_URL: ${{ steps.create_release.outputs.html_url }}
         run: |
           if [ -z "$SLACK_WEBHOOK_URL" ]; then

--- a/.github/workflows/shaft-mcp.yml
+++ b/.github/workflows/shaft-mcp.yml
@@ -9,7 +9,36 @@ permissions:
   contents: read
 
 jobs:
+  installer-tests:
+    name: Installer tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-15, windows-2025]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'zulu'
+          check-latest: true
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: 3.9.12
+      - name: Run isolated installer tests
+        shell: bash
+        run: >-
+          mvn --batch-mode -pl shaft-mcp -am test
+          -Dtest=ShaftMcpInstallerTest
+          -Dsurefire.failIfNoSpecifiedTests=false
+          -Dgpg.skip
+
   package-and-smoke:
+    needs: installer-tests
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
@@ -23,7 +52,7 @@ jobs:
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5
         with:
-          maven-version: 3.9.5
+          maven-version: 3.9.12
       - name: Validate reactor versions
         run: |
           python3 scripts/ci/validate_reactor_versions.py

--- a/scripts/ci/validate_shaft_mcp_configuration.py
+++ b/scripts/ci/validate_shaft_mcp_configuration.py
@@ -53,6 +53,14 @@ def validate(root: Path = ROOT) -> list[str]:
     mcp_pom_text = (root / "shaft-mcp" / "pom.xml").read_text(encoding="utf-8")
     if "shaft_engine.version" in mcp_pom_text:
         errors.append("shaft-mcp must not define an independent SHAFT engine version")
+    if "<Implementation-Version>${project.version}</Implementation-Version>" not in mcp_pom_text:
+        errors.append("shaft-mcp executable manifest must expose the reactor Implementation-Version")
+
+    application_source = (
+        root / "shaft-mcp/src/main/java/com/shaft/mcp/ShaftMcpApplication.java"
+    ).read_text(encoding="utf-8")
+    if '"install".equalsIgnoreCase(args[0])' not in application_source:
+        errors.append("shaft-mcp must route the install command before Spring MCP startup")
 
     engine_pom = (root / "shaft-engine" / "pom.xml").read_text(encoding="utf-8")
     if "<artifactId>shaft-mcp</artifactId>" in engine_pom:
@@ -108,6 +116,14 @@ def validate(root: Path = ROOT) -> list[str]:
         errors.append("shaft-mcp workflow must run manually and once daily with local E2E workflows")
     if "pull_request:" in mcp_workflow or "\n  push:" in mcp_workflow:
         errors.append("shaft-mcp workflow must not run on pull_request or push")
+    for runner in ("ubuntu-22.04", "macos-15", "windows-2025"):
+        if runner not in mcp_workflow:
+            errors.append(f"shaft-mcp installer tests must run on {runner}")
+    central_workflow = (root / ".github/workflows/mavenCentral_cd.yml").read_text(encoding="utf-8")
+    if "verify_shaft_mcp_installer_release.py" not in central_workflow:
+        errors.append("Maven Central delivery must verify the public shaft-mcp LATEST installer")
+    if "needs: [build_release_and_deliver, verify_public_shaft_mcp_installer]" not in central_workflow:
+        errors.append("release announcements must wait for the public shaft-mcp installer matrix")
 
     for dockerfile in (root / "shaft-mcp").glob("Dockerfile*"):
         content = dockerfile.read_text(encoding="utf-8")

--- a/scripts/ci/verify_shaft_mcp_installer_release.py
+++ b/scripts/ci/verify_shaft_mcp_installer_release.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Run the public shaft-mcp LATEST installer twice in an isolated user profile."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import shutil
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+ARTIFACT = "io.github.shafthq:shaft-mcp:LATEST"
+DEPENDENCY_GOAL = "org.apache.maven.plugins:maven-dependency-plugin:3.9.0:copy"
+EXEC_GOAL = "org.codehaus.mojo:exec-maven-plugin:3.6.3:exec"
+
+
+def maven_executable() -> str:
+    candidates = ("mvn.cmd", "mvn") if platform.system() == "Windows" else ("mvn",)
+    for candidate in candidates:
+        executable = shutil.which(candidate)
+        if executable:
+            return executable
+    raise RuntimeError("Maven 3.9+ was not found on PATH.")
+
+
+def write_fake_copilot(bin_directory: Path) -> None:
+    bin_directory.mkdir(parents=True, exist_ok=True)
+    if platform.system() == "Windows":
+        executable = bin_directory / "copilot.cmd"
+        executable.write_text(
+            "@echo off\r\n"
+            "if \"%1\"==\"--version\" (\r\n"
+            "  echo copilot release verifier\r\n"
+            "  exit /b 0\r\n"
+            ")\r\n"
+            "exit /b 1\r\n",
+            encoding="utf-8",
+        )
+        return
+    executable = bin_directory / "copilot"
+    executable.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1\" = \"--version\" ]; then\n"
+        "  echo 'copilot release verifier'\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+
+
+def installer_command() -> list[str]:
+    return [
+        maven_executable(),
+        "--batch-mode",
+        "--no-transfer-progress",
+        "-U",
+        "-N",
+        DEPENDENCY_GOAL,
+        EXEC_GOAL,
+        f"-Dartifact={ARTIFACT}",
+        "-DoutputDirectory=${java.io.tmpdir}/shaft-mcp-bootstrap",
+        "-Dmdep.stripVersion=true",
+        "-Dmdep.overWriteReleases=true",
+        "-Dexec.executable=java",
+        '-Dexec.args=-jar "${java.io.tmpdir}/shaft-mcp-bootstrap/shaft-mcp.jar" install --copilot',
+    ]
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def installed_jar(root: Path, home: Path, environment: dict[str, str]) -> Path:
+    system = platform.system()
+    if system == "Windows":
+        versions = root / "local-app-data" / "ShaftHQ" / "shaft-mcp" / "versions"
+    elif system == "Darwin":
+        versions = home / "Library" / "Application Support" / "ShaftHQ" / "shaft-mcp" / "versions"
+    elif system == "Linux":
+        versions = Path(environment["XDG_DATA_HOME"]) / "shafthq" / "shaft-mcp" / "versions"
+    else:
+        raise RuntimeError(f"Unsupported release-verification operating system: {system}")
+    jars = list(versions.glob("*/shaft-mcp.jar"))
+    if len(jars) != 1:
+        raise RuntimeError(f"Expected one installed shaft-mcp JAR, found: {jars}")
+    return jars[0].resolve()
+
+
+def verify_configuration(configuration: Path, java: Path, jar: Path) -> None:
+    root = json.loads(configuration.read_text(encoding="utf-8"))
+    entry = root["mcpServers"]["shaft-mcp"]
+    if Path(entry["command"]).resolve() != java.resolve():
+        raise RuntimeError(f"Unexpected Java command in {configuration}: {entry['command']}")
+    if entry["args"] != ["-jar", str(jar)]:
+        raise RuntimeError(f"Unexpected shaft-mcp arguments in {configuration}: {entry['args']}")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="shaft-mcp-public-installer-") as temporary:
+        root = Path(temporary).resolve()
+        home = root / "home"
+        java_temp = root / "java-temp"
+        fake_bin = root / "bin"
+        copilot_home = home / ".copilot"
+        for directory in (home, java_temp, copilot_home):
+            directory.mkdir(parents=True, exist_ok=True)
+        write_fake_copilot(fake_bin)
+
+        environment = os.environ.copy()
+        environment["HOME"] = str(home)
+        environment["USERPROFILE"] = str(home)
+        environment["COPILOT_HOME"] = str(copilot_home)
+        environment["LOCALAPPDATA"] = str(root / "local-app-data")
+        environment["APPDATA"] = str(root / "roaming-app-data")
+        environment["XDG_DATA_HOME"] = str(root / "xdg-data")
+        environment["XDG_CONFIG_HOME"] = str(root / "xdg-config")
+        environment["PATH"] = str(fake_bin) + os.pathsep + environment.get("PATH", "")
+        java_options = f"-Duser.home={home} -Djava.io.tmpdir={java_temp}"
+        existing_options = environment.get("JAVA_TOOL_OPTIONS", "").strip()
+        environment["JAVA_TOOL_OPTIONS"] = f"{existing_options} {java_options}".strip()
+
+        command = installer_command()
+        subprocess.run(command, cwd=root, env=environment, check=True)
+        jar = installed_jar(root, home, environment)
+        first_hash = sha256(jar)
+        first_timestamp = jar.stat().st_mtime_ns
+        configuration = copilot_home / "mcp-config.json"
+        verify_configuration(configuration, Path(shutil.which("java") or "java"), jar)
+
+        subprocess.run(command, cwd=root, env=environment, check=True)
+        if sha256(jar) != first_hash or jar.stat().st_mtime_ns != first_timestamp:
+            raise RuntimeError("Repeated public installation did not reuse the verified JAR.")
+        verify_configuration(configuration, Path(shutil.which("java") or "java"), jar)
+        print(f"Verified public shaft-mcp LATEST installer on {platform.system()}: {jar.parent.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/shaft-mcp/pom.xml
+++ b/shaft-mcp/pom.xml
@@ -123,6 +123,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Implementation-Version>${project.version}</Implementation-Version>
+                        </manifestEntries>
+                    </archive>
                     <includes>
                         <include>com/**</include>
                         <include>application*.properties</include>

--- a/shaft-mcp/src/main/java/com/shaft/mcp/ShaftMcpApplication.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/ShaftMcpApplication.java
@@ -2,6 +2,7 @@ package com.shaft.mcp;
 
 import com.shaft.capture.cli.CaptureCli;
 import com.shaft.doctor.cli.DoctorCli;
+import com.shaft.mcp.install.ShaftMcpInstaller;
 import org.springframework.ai.support.ToolCallbacks;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.boot.SpringApplication;
@@ -37,6 +38,13 @@ public class ShaftMcpApplication {
             int exitCode = CaptureCli.run(
                     Arrays.copyOfRange(args, 1, args.length),
                     captureLaunchPrefix());
+            if (exitCode != 0) {
+                System.exit(exitCode);
+            }
+            return;
+        }
+        if (args.length > 0 && "install".equalsIgnoreCase(args[0])) {
+            int exitCode = ShaftMcpInstaller.run(Arrays.copyOfRange(args, 1, args.length));
             if (exitCode != 0) {
                 System.exit(exitCode);
             }

--- a/shaft-mcp/src/main/java/com/shaft/mcp/install/InstallerFileOperations.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/install/InstallerFileOperations.java
@@ -1,0 +1,227 @@
+package com.shaft.mcp.install;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+final class InstallerFileOperations {
+    private static final ObjectMapper JSON = new ObjectMapper(
+            new JsonFactory().enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION))
+            .enable(SerializationFeature.INDENT_OUTPUT);
+
+    private InstallerFileOperations() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static ObjectNode readJsonObject(Path path) throws IOException {
+        if (!Files.exists(path)) {
+            return JSON.createObjectNode();
+        }
+        JsonNode value = JSON.readTree(Files.readAllBytes(path));
+        if (!(value instanceof ObjectNode object)) {
+            throw new IOException("Configuration root must be a JSON object: " + path);
+        }
+        return object;
+    }
+
+    static JsonNode parseJson(String value) throws IOException {
+        return JSON.readTree(value);
+    }
+
+    static ObjectNode newJsonObject() {
+        return JSON.createObjectNode();
+    }
+
+    static String writeJson(ObjectNode value) throws IOException {
+        return JSON.writeValueAsString(value);
+    }
+
+    static void writeJsonAtomically(Path destination, ObjectNode value) throws IOException {
+        byte[] content = (JSON.writerWithDefaultPrettyPrinter().writeValueAsString(value) + System.lineSeparator())
+                .getBytes(StandardCharsets.UTF_8);
+        Path absolute = destination.toAbsolutePath().normalize();
+        Path parent = requireParent(absolute);
+        Files.createDirectories(parent);
+        Path temporary = Files.createTempFile(parent, "." + absolute.getFileName(), ".tmp");
+        try {
+            try (FileChannel channel = FileChannel.open(
+                    temporary,
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.TRUNCATE_EXISTING)) {
+                channel.write(ByteBuffer.wrap(content));
+                channel.force(true);
+            }
+            readJsonObject(temporary);
+            moveReplacing(temporary, absolute);
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    static void copyVerifiedAtomically(Path source, Path destination) throws IOException {
+        Path absoluteSource = source.toAbsolutePath().normalize();
+        Path absoluteDestination = destination.toAbsolutePath().normalize();
+        String sourceHash = sha256(absoluteSource);
+        if (Files.isRegularFile(absoluteDestination) && sourceHash.equals(sha256(absoluteDestination))) {
+            return;
+        }
+
+        Path parent = requireParent(absoluteDestination);
+        Files.createDirectories(parent);
+        Path temporary = Files.createTempFile(parent, "." + absoluteDestination.getFileName(), ".tmp");
+        try {
+            Files.copy(absoluteSource, temporary, StandardCopyOption.REPLACE_EXISTING);
+            if (!sourceHash.equals(sha256(temporary))) {
+                throw new IOException("Copied shaft-mcp JAR failed SHA-256 verification.");
+            }
+            moveReplacing(temporary, absoluteDestination);
+            if (!sourceHash.equals(sha256(absoluteDestination))) {
+                throw new IOException("Installed shaft-mcp JAR failed SHA-256 verification.");
+            }
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    static String sha256(Path path) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            try (var input = Files.newInputStream(path)) {
+                byte[] buffer = new byte[8192];
+                int count;
+                while ((count = input.read(buffer)) >= 0) {
+                    if (count > 0) {
+                        digest.update(buffer, 0, count);
+                    }
+                }
+            }
+            return HexFormat.of().formatHex(digest.digest());
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 is unavailable.", exception);
+        }
+    }
+
+    static void writeBytesAtomically(Path destination, byte[] content) throws IOException {
+        Path absolute = destination.toAbsolutePath().normalize();
+        Path parent = requireParent(absolute);
+        Files.createDirectories(parent);
+        Path temporary = Files.createTempFile(parent, "." + absolute.getFileName(), ".tmp");
+        try {
+            try (FileChannel channel = FileChannel.open(
+                    temporary,
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.TRUNCATE_EXISTING)) {
+                channel.write(ByteBuffer.wrap(content));
+                channel.force(true);
+            }
+            moveReplacing(temporary, absolute);
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private static Path requireParent(Path path) throws IOException {
+        Path parent = path.getParent();
+        if (parent == null) {
+            throw new IOException("Configuration path requires a parent directory: " + path);
+        }
+        return parent;
+    }
+
+    private static void moveReplacing(Path source, Path destination) throws IOException {
+        boolean atomic = true;
+        for (int attempt = 1; attempt <= 50; attempt++) {
+            try {
+                if (atomic) {
+                    Files.move(source, destination, StandardCopyOption.ATOMIC_MOVE,
+                            StandardCopyOption.REPLACE_EXISTING);
+                } else {
+                    Files.move(source, destination, StandardCopyOption.REPLACE_EXISTING);
+                }
+                return;
+            } catch (AtomicMoveNotSupportedException ignored) {
+                atomic = false;
+            } catch (AccessDeniedException exception) {
+                if (attempt == 50) {
+                    throw exception;
+                }
+                try {
+                    Thread.sleep(10);
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Interrupted while publishing installer data.", interrupted);
+                }
+            }
+        }
+    }
+
+    static final class ConfigurationBackup implements AutoCloseable {
+        private final Path configuration;
+        private final boolean existed;
+        private final byte[] original;
+        private final Path backup;
+        private boolean committed;
+        private boolean restored;
+
+        ConfigurationBackup(Path configuration) throws IOException {
+            this.configuration = configuration.toAbsolutePath().normalize();
+            existed = Files.exists(this.configuration);
+            original = existed ? Files.readAllBytes(this.configuration) : new byte[0];
+            Path parent = requireParent(this.configuration);
+            Files.createDirectories(parent);
+            backup = Files.createTempFile(parent, "." + this.configuration.getFileName(), ".shaft-mcp-backup");
+            try (FileChannel channel = FileChannel.open(
+                    backup,
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.TRUNCATE_EXISTING)) {
+                channel.write(ByteBuffer.wrap(original));
+                channel.force(true);
+            }
+        }
+
+        Path path() {
+            return configuration;
+        }
+
+        Path backupPath() {
+            return backup;
+        }
+
+        void commit() {
+            committed = true;
+        }
+
+        void restore() throws IOException {
+            if (existed) {
+                writeBytesAtomically(configuration, original);
+            } else {
+                Files.deleteIfExists(configuration);
+            }
+            restored = true;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (committed || restored) {
+                Files.deleteIfExists(backup);
+            }
+        }
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/install/InstallerStdioProbe.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/install/InstallerStdioProbe.java
@@ -1,0 +1,117 @@
+package com.shaft.mcp.install;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+final class InstallerStdioProbe {
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final Duration RESPONSE_TIMEOUT = Duration.ofSeconds(45);
+
+    private InstallerStdioProbe() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static void verify(Path javaExecutable, Path jar) throws IOException {
+        Process process = new ProcessBuilder(
+                javaExecutable.toString(),
+                "-jar",
+                jar.toAbsolutePath().normalize().toString())
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
+                .start();
+        BlockingQueue<String> lines = new LinkedBlockingQueue<>();
+        Thread readerThread = Thread.startVirtualThread(() -> {
+            try (var reader = process.inputReader(StandardCharsets.UTF_8)) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    lines.put(line);
+                }
+            } catch (IOException ignored) {
+                // Process shutdown closes the stream after the required responses are read.
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        try (var writer = new BufferedWriter(
+                new OutputStreamWriter(process.getOutputStream(), StandardCharsets.UTF_8))) {
+            send(writer, """
+                    {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"shaft-mcp-installer","version":"1.0"}}}
+                    """);
+            JsonNode initialize = await(lines, process, 1);
+            if (!"shaft-mcp".equals(initialize.path("result").path("serverInfo").path("name").asText())) {
+                throw new IOException("Installed JAR returned an unexpected MCP server identity.");
+            }
+
+            send(writer, """
+                    {"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
+                    """);
+            send(writer, """
+                    {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+                    """);
+            JsonNode tools = await(lines, process, 2);
+            if (!tools.path("result").path("tools").isArray() || tools.path("result").path("tools").isEmpty()) {
+                throw new IOException("Installed JAR returned no MCP tools.");
+            }
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while probing the installed shaft-mcp JAR.", exception);
+        } finally {
+            process.destroy();
+            try {
+                if (!process.waitFor(5, TimeUnit.SECONDS)) {
+                    process.destroyForcibly();
+                    process.waitFor(5, TimeUnit.SECONDS);
+                }
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                process.destroyForcibly();
+            }
+            try {
+                readerThread.join(Duration.ofSeconds(5));
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static void send(BufferedWriter writer, String message) throws IOException {
+        writer.write(message.strip());
+        writer.newLine();
+        writer.flush();
+    }
+
+    private static JsonNode await(BlockingQueue<String> lines, Process process, int requestId)
+            throws IOException, InterruptedException {
+        long deadline = System.nanoTime() + RESPONSE_TIMEOUT.toNanos();
+        while (System.nanoTime() < deadline) {
+            String line = lines.poll(250, TimeUnit.MILLISECONDS);
+            if (line != null) {
+                JsonNode response;
+                try {
+                    response = JSON.readTree(line);
+                } catch (IOException exception) {
+                    throw new IOException("shaft-mcp wrote non-JSON data to stdout during the installer probe.",
+                            exception);
+                }
+                if (response.path("id").asInt(-1) == requestId) {
+                    if (response.has("error")) {
+                        throw new IOException("shaft-mcp installer probe failed: " + response.path("error"));
+                    }
+                    return response;
+                }
+            } else if (!process.isAlive()) {
+                throw new IOException("shaft-mcp exited before completing the installer probe.");
+            }
+        }
+        throw new IOException("Timed out while probing the installed shaft-mcp JAR.");
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/install/ShaftMcpInstaller.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/install/ShaftMcpInstaller.java
@@ -1,0 +1,773 @@
+package com.shaft.mcp.install;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Installs the running shaft-mcp executable JAR and configures one local MCP client.
+ */
+public final class ShaftMcpInstaller {
+    /** Manual setup and recovery documentation. */
+    public static final String MANUAL_URL = "https://shaftengine.netlify.app/docs/agentic/mcp/manual";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ShaftMcpInstaller.class);
+    private static final Pattern VERSION_PATTERN = Pattern.compile("([A-Za-z0-9][A-Za-z0-9._-]*)");
+    private static final Pattern MAVEN_VERSION = Pattern.compile("Apache Maven\\s+(\\d+)\\.(\\d+)");
+    private static final String SERVER_NAME = "shaft-mcp";
+
+    private ShaftMcpInstaller() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Runs the local installer.
+     *
+     * @param arguments installer target flag
+     * @return zero on success, nonzero on failure
+     */
+    public static int run(String[] arguments) {
+        try {
+            return run(arguments, InstallerEnvironment.system());
+        } catch (Exception exception) {
+            LOGGER.error("shaft-mcp installation failed. {} Manual setup: {}",
+                    exception.getMessage(), MANUAL_URL);
+            return 2;
+        }
+    }
+
+    static int run(String[] arguments, InstallerEnvironment environment) {
+        Objects.requireNonNull(environment, "environment");
+        try {
+            Target target = Target.parse(arguments);
+            validatePrerequisites(target, environment);
+            detectProjectOverride(target, environment);
+            Path installedJar = installJar(environment);
+            try {
+                environment.probe().accept(environment.javaExecutable(), installedJar);
+            } catch (ProbeFailure failure) {
+                throw new InstallerFailure("The installed shaft-mcp JAR failed its stdio probe.", 4, failure);
+            }
+            configure(target, environment, installedJar);
+            LOGGER.info("shaft-mcp {} is installed and configured for {}.",
+                    environment.version(), target.displayName());
+            target.restartMessage().ifPresent(message -> LOGGER.info(message));
+            return 0;
+        } catch (InstallerFailure failure) {
+            LOGGER.error("{} Manual setup: {}", failure.getMessage(), MANUAL_URL);
+            return failure.exitCode();
+        }
+    }
+
+    private static void validatePrerequisites(Target target, InstallerEnvironment environment)
+            throws InstallerFailure {
+        if (environment.javaFeatureVersion() != 25) {
+            throw new InstallerFailure("Java 25 is required; detected Java "
+                    + environment.javaFeatureVersion() + ".", 3);
+        }
+        CommandResult maven = environment.commandRunner().run(List.of("mvn", "--version"));
+        Matcher matcher = MAVEN_VERSION.matcher(maven.output());
+        if (maven.exitCode() != 0 || !matcher.find()
+                || Integer.parseInt(matcher.group(1)) < 3
+                || Integer.parseInt(matcher.group(1)) == 3 && Integer.parseInt(matcher.group(2)) < 9) {
+            throw new InstallerFailure("Maven 3.9 or newer is required.", 3);
+        }
+        if (!target.supportedOperatingSystems().contains(environment.operatingSystem())) {
+            throw new InstallerFailure(target.displayName() + " is not supported on "
+                    + environment.operatingSystem().displayName() + ".", 3);
+        }
+        if (!clientAvailable(target, environment)) {
+            throw new InstallerFailure(target.displayName()
+                    + " is not installed or its command is unavailable.", 3);
+        }
+    }
+
+    private static boolean clientAvailable(Target target, InstallerEnvironment environment) {
+        if (target == Target.CLAUDE_DESKTOP) {
+            return environment.claudeDesktopInstalled();
+        }
+        return environment.commandRunner().run(List.of(target.clientCommand(), "--version")).exitCode() == 0;
+    }
+
+    private static Path installJar(InstallerEnvironment environment) throws InstallerFailure {
+        if (!VERSION_PATTERN.matcher(environment.version()).matches()) {
+            throw new InstallerFailure("The executable JAR does not contain a valid Implementation-Version.", 4);
+        }
+        if (!Files.isRegularFile(environment.sourceJar())) {
+            throw new InstallerFailure("Run the installer from the executable shaft-mcp JAR.", 4);
+        }
+        Path destination = environment.applicationDataRoot()
+                .resolve("versions")
+                .resolve(environment.version())
+                .resolve("shaft-mcp.jar")
+                .toAbsolutePath()
+                .normalize();
+        try {
+            InstallerFileOperations.copyVerifiedAtomically(environment.sourceJar(), destination);
+            return destination;
+        } catch (IOException exception) {
+            throw new InstallerFailure("Could not install shaft-mcp into " + destination + ".", 4, exception);
+        }
+    }
+
+    private static void configure(Target target, InstallerEnvironment environment, Path jar)
+            throws InstallerFailure {
+        Path configuration = configurationPath(target, environment);
+        try (var backup = new InstallerFileOperations.ConfigurationBackup(configuration)) {
+            try {
+                switch (target) {
+                    case CODEX, CODEX_APP -> configureCodex(environment, jar);
+                    case CLAUDE -> configureClaudeCode(environment, jar);
+                    case CLAUDE_DESKTOP -> configureClaudeDesktop(environment, jar);
+                    case COPILOT -> configureCopilot(environment, jar);
+                    case COPILOT_VSCODE -> configureVsCode(environment, jar);
+                }
+                verifyConfiguration(target, environment, jar);
+                backup.commit();
+            } catch (Exception failure) {
+                restoreAfterFailure(backup, failure);
+            }
+        } catch (InstallerFailure failure) {
+            throw failure;
+        } catch (IOException exception) {
+            throw new InstallerFailure("Could not create or remove the configuration backup.", 5, exception);
+        }
+    }
+
+    private static void restoreAfterFailure(
+            InstallerFileOperations.ConfigurationBackup backup,
+            Exception failure) throws InstallerFailure {
+        try {
+            backup.restore();
+            throw new InstallerFailure("Client configuration failed and configuration was restored.", 5, failure);
+        } catch (IOException restorationFailure) {
+            failure.addSuppressed(restorationFailure);
+            throw new InstallerFailure("Client configuration failed and restoration also failed. Backup retained at "
+                    + backup.backupPath() + ".", 6, failure);
+        }
+    }
+
+    private static void configureCodex(InstallerEnvironment environment, Path jar) throws InstallerFailure {
+        CommandResult result = environment.commandRunner().run(List.of(
+                "codex", "mcp", "add", SERVER_NAME, "--",
+                environment.javaExecutable().toString(), "-jar", jar.toString()));
+        requireSuccess(result, "Codex MCP configuration command failed.");
+    }
+
+    private static void configureClaudeCode(InstallerEnvironment environment, Path jar) throws InstallerFailure {
+        Path configuration = configurationPath(Target.CLAUDE, environment);
+        try {
+            JsonNode existing = InstallerFileOperations.readJsonObject(configuration)
+                    .path("mcpServers").path(SERVER_NAME);
+            if (!existing.isMissingNode()) {
+                requireSuccess(
+                        environment.commandRunner().run(
+                                List.of("claude", "mcp", "remove", SERVER_NAME, "-s", "user")),
+                        "Claude Code could not remove the previous shaft-mcp entry.");
+            }
+        } catch (IOException exception) {
+            throw new InstallerFailure("Claude Code configuration is malformed.", 5, exception);
+        }
+        requireSuccess(environment.commandRunner().run(List.of(
+                "claude", "mcp", "add", "-s", "user", SERVER_NAME, "--",
+                environment.javaExecutable().toString(), "-jar", jar.toString())),
+                "Claude Code MCP configuration command failed.");
+    }
+
+    private static void configureClaudeDesktop(InstallerEnvironment environment, Path jar)
+            throws IOException {
+        ObjectNode root = InstallerFileOperations.readJsonObject(
+                configurationPath(Target.CLAUDE_DESKTOP, environment));
+        ObjectNode servers = object(root, "mcpServers");
+        servers.set(SERVER_NAME, stdioEntry(environment.javaExecutable(), jar, false));
+        InstallerFileOperations.writeJsonAtomically(
+                configurationPath(Target.CLAUDE_DESKTOP, environment), root);
+    }
+
+    private static void configureCopilot(InstallerEnvironment environment, Path jar) throws IOException {
+        ObjectNode root = InstallerFileOperations.readJsonObject(configurationPath(Target.COPILOT, environment));
+        ObjectNode servers = object(root, "mcpServers");
+        ObjectNode entry = stdioEntry(environment.javaExecutable(), jar, true);
+        entry.put("type", "local");
+        ArrayNode tools = entry.putArray("tools");
+        tools.add("*");
+        servers.set(SERVER_NAME, entry);
+        InstallerFileOperations.writeJsonAtomically(configurationPath(Target.COPILOT, environment), root);
+    }
+
+    private static void configureVsCode(InstallerEnvironment environment, Path jar)
+            throws IOException, InstallerFailure {
+        ObjectNode entry = stdioEntry(environment.javaExecutable(), jar, true);
+        entry.put("name", SERVER_NAME);
+        entry.put("type", "stdio");
+        requireSuccess(environment.commandRunner().run(
+                List.of("code", "--add-mcp", InstallerFileOperations.writeJson(entry))),
+                "VS Code MCP configuration command failed.");
+    }
+
+    private static ObjectNode stdioEntry(Path javaExecutable, Path jar, boolean argsBeforeCommand) {
+        ObjectNode entry = InstallerFileOperations.newJsonObject();
+        if (argsBeforeCommand) {
+            ArrayNode arguments = entry.putArray("args");
+            arguments.add("-jar");
+            arguments.add(jar.toString());
+            entry.put("command", javaExecutable.toString());
+        } else {
+            entry.put("command", javaExecutable.toString());
+            ArrayNode arguments = entry.putArray("args");
+            arguments.add("-jar");
+            arguments.add(jar.toString());
+        }
+        return entry;
+    }
+
+    private static ObjectNode object(ObjectNode parent, String property) throws IOException {
+        JsonNode existing = parent.get(property);
+        if (existing == null) {
+            return parent.putObject(property);
+        }
+        if (existing instanceof ObjectNode object) {
+            return object;
+        }
+        throw new IOException("Configuration property must be an object: " + property);
+    }
+
+    private static void verifyConfiguration(Target target, InstallerEnvironment environment, Path jar)
+            throws InstallerFailure, IOException {
+        if (target == Target.CODEX || target == Target.CODEX_APP) {
+            CommandResult result = environment.commandRunner().run(
+                    List.of("codex", "mcp", "get", SERVER_NAME, "--json"));
+            requireSuccess(result, "Codex could not verify the shaft-mcp entry.");
+            JsonNode entry = InstallerFileOperations.parseJson(result.output());
+            verifyCommand(entry.path("transport"), environment.javaExecutable(), jar);
+            return;
+        }
+
+        Path path = configurationPath(target, environment);
+        JsonNode root = InstallerFileOperations.readJsonObject(path);
+        JsonNode entry = switch (target) {
+            case CLAUDE, CLAUDE_DESKTOP, COPILOT -> root.path("mcpServers").path(SERVER_NAME);
+            case COPILOT_VSCODE -> root.path("servers").path(SERVER_NAME);
+            default -> throw new IllegalStateException("Unexpected target: " + target);
+        };
+        verifyCommand(entry, environment.javaExecutable(), jar);
+    }
+
+    private static void verifyCommand(JsonNode entry, Path javaExecutable, Path jar) throws InstallerFailure {
+        if (!javaExecutable.toString().equals(entry.path("command").asText())) {
+            throw new InstallerFailure("The resulting shaft-mcp Java command is incorrect.", 5);
+        }
+        JsonNode arguments = entry.path("args");
+        if (!arguments.isArray() || arguments.size() != 2
+                || !"-jar".equals(arguments.get(0).asText())
+                || !jar.toString().equals(arguments.get(1).asText())) {
+            throw new InstallerFailure("The resulting shaft-mcp JAR arguments are incorrect.", 5);
+        }
+    }
+
+    private static void requireSuccess(CommandResult result, String message) throws InstallerFailure {
+        if (result.exitCode() != 0) {
+            String detail = result.output().isBlank() ? "" : " " + result.output().strip();
+            throw new InstallerFailure(message + detail, 5);
+        }
+    }
+
+    private static Path configurationPath(Target target, InstallerEnvironment environment) {
+        Path home = environment.userHome();
+        Map<String, String> variables = environment.environmentVariables();
+        return switch (target) {
+            case CODEX, CODEX_APP -> optionalPath(variables.get("CODEX_HOME"))
+                    .orElse(home.resolve(".codex"))
+                    .resolve("config.toml");
+            case CLAUDE -> home.resolve(".claude.json");
+            case CLAUDE_DESKTOP -> environment.operatingSystem() == OperatingSystem.WINDOWS
+                    ? Path.of(requiredVariable(variables, "APPDATA")).resolve("Claude").resolve("claude_desktop_config.json")
+                    : home.resolve("Library").resolve("Application Support").resolve("Claude")
+                            .resolve("claude_desktop_config.json");
+            case COPILOT -> optionalPath(variables.get("COPILOT_HOME"))
+                    .orElse(home.resolve(".copilot"))
+                    .resolve("mcp-config.json");
+            case COPILOT_VSCODE -> switch (environment.operatingSystem()) {
+                case WINDOWS -> Path.of(requiredVariable(variables, "APPDATA"))
+                        .resolve("Code").resolve("User").resolve("mcp.json");
+                case MACOS -> home.resolve("Library").resolve("Application Support")
+                        .resolve("Code").resolve("User").resolve("mcp.json");
+                case LINUX -> optionalPath(variables.get("XDG_CONFIG_HOME"))
+                        .orElse(home.resolve(".config"))
+                        .resolve("Code").resolve("User").resolve("mcp.json");
+            };
+        };
+    }
+
+    private static Optional<Path> optionalPath(String value) {
+        return value == null || value.isBlank() ? Optional.empty() : Optional.of(Path.of(value));
+    }
+
+    private static String requiredVariable(Map<String, String> variables, String name) {
+        String value = variables.get(name);
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException(name + " is unavailable.");
+        }
+        return value;
+    }
+
+    private static void detectProjectOverride(Target target, InstallerEnvironment environment)
+            throws InstallerFailure {
+        List<Path> candidates = new ArrayList<>();
+        for (Path directory = environment.workingDirectory().toAbsolutePath().normalize();
+             directory != null;
+             directory = directory.getParent()) {
+            switch (target) {
+                case CODEX, CODEX_APP -> candidates.add(directory.resolve(".codex").resolve("config.toml"));
+                case CLAUDE, CLAUDE_DESKTOP -> candidates.add(directory.resolve(".mcp.json"));
+                case COPILOT -> {
+                    candidates.add(directory.resolve(".github").resolve("mcp.json"));
+                    candidates.add(directory.resolve(".mcp.json"));
+                }
+                case COPILOT_VSCODE -> candidates.add(directory.resolve(".vscode").resolve("mcp.json"));
+            }
+            if (directory.equals(environment.userHome().toAbsolutePath().normalize())) {
+                break;
+            }
+        }
+        for (Path candidate : candidates) {
+            if (containsProjectEntry(candidate, target)) {
+                throw new InstallerFailure("Project configuration at " + candidate
+                        + " defines shaft-mcp and would override the per-user entry.", 5);
+            }
+        }
+    }
+
+    private static boolean containsProjectEntry(Path path, Target target) throws InstallerFailure {
+        if (!Files.isRegularFile(path)) {
+            return false;
+        }
+        try {
+            if (target == Target.CODEX || target == Target.CODEX_APP) {
+                String toml = Files.readString(path, StandardCharsets.UTF_8);
+                return Pattern.compile("(?m)^\\s*(?:"
+                                + "\\[\\s*mcp_servers\\.(?:\"shaft-mcp\"|shaft-mcp)\\s*]"
+                                + "|mcp_servers\\.(?:\"shaft-mcp\"|shaft-mcp)\\s*=)")
+                        .matcher(toml)
+                        .find();
+            }
+            JsonNode root = InstallerFileOperations.readJsonObject(path);
+            return root.path("mcpServers").has(SERVER_NAME)
+                    || root.path("servers").has(SERVER_NAME);
+        } catch (IOException exception) {
+            throw new InstallerFailure("Project MCP configuration is malformed: " + path, 5, exception);
+        }
+    }
+
+    enum Target {
+        CODEX("--codex", "Codex CLI and IDE extension", "codex", EnumSet.allOf(OperatingSystem.class), null),
+        CODEX_APP("--codex-app", "Codex App", "codex", EnumSet.allOf(OperatingSystem.class),
+                "Start a new Codex App session to load shaft-mcp."),
+        CLAUDE("--claude", "Claude Code", "claude", EnumSet.allOf(OperatingSystem.class), null),
+        CLAUDE_DESKTOP("--claude-desktop", "Claude Desktop", "",
+                EnumSet.of(OperatingSystem.WINDOWS, OperatingSystem.MACOS),
+                "Restart Claude Desktop to load shaft-mcp."),
+        COPILOT("--copilot", "GitHub Copilot CLI", "copilot", EnumSet.allOf(OperatingSystem.class), null),
+        COPILOT_VSCODE("--copilot-vscode", "GitHub Copilot in VS Code", "code",
+                EnumSet.allOf(OperatingSystem.class), null);
+
+        private final String flag;
+        private final String displayName;
+        private final String clientCommand;
+        private final EnumSet<OperatingSystem> supportedOperatingSystems;
+        private final String restartMessage;
+
+        Target(
+                String flag,
+                String displayName,
+                String clientCommand,
+                EnumSet<OperatingSystem> supportedOperatingSystems,
+                String restartMessage) {
+            this.flag = flag;
+            this.displayName = displayName;
+            this.clientCommand = clientCommand;
+            this.supportedOperatingSystems = supportedOperatingSystems;
+            this.restartMessage = restartMessage;
+        }
+
+        static Target parse(String[] arguments) throws InstallerFailure {
+            if (arguments == null || arguments.length != 1) {
+                throw new InstallerFailure("Pass exactly one target: "
+                        + Arrays.stream(values()).map(target -> target.flag).toList() + ".", 2);
+            }
+            return Arrays.stream(values())
+                    .filter(target -> target.flag.equals(arguments[0]))
+                    .findFirst()
+                    .orElseThrow(() -> new InstallerFailure("Unsupported installer target: "
+                            + arguments[0] + ".", 2));
+        }
+
+        String displayName() {
+            return displayName;
+        }
+
+        String clientCommand() {
+            return clientCommand;
+        }
+
+        EnumSet<OperatingSystem> supportedOperatingSystems() {
+            return supportedOperatingSystems;
+        }
+
+        Optional<String> restartMessage() {
+            return Optional.ofNullable(restartMessage);
+        }
+    }
+
+    enum OperatingSystem {
+        WINDOWS("Windows"),
+        MACOS("macOS"),
+        LINUX("Linux");
+
+        private final String displayName;
+
+        OperatingSystem(String displayName) {
+            this.displayName = displayName;
+        }
+
+        String displayName() {
+            return displayName;
+        }
+
+        static OperatingSystem current() throws InstallerFailure {
+            String name = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+            if (name.contains("win")) {
+                return WINDOWS;
+            }
+            if (name.contains("mac") || name.contains("darwin")) {
+                return MACOS;
+            }
+            if (name.contains("linux")) {
+                return LINUX;
+            }
+            throw new InstallerFailure("Unsupported operating system: "
+                    + System.getProperty("os.name", "unknown") + ".", 3);
+        }
+    }
+
+    record CommandResult(int exitCode, String output) {
+        CommandResult {
+            output = output == null ? "" : output;
+        }
+    }
+
+    @FunctionalInterface
+    interface CommandRunner {
+        CommandResult run(List<String> command);
+    }
+
+    record InstallerEnvironment(
+            OperatingSystem operatingSystem,
+            Map<String, String> environmentVariables,
+            Path userHome,
+            Path workingDirectory,
+            Path javaExecutable,
+            int javaFeatureVersion,
+            Path sourceJar,
+            String version,
+            Path applicationDataRoot,
+            CommandRunner commandRunner,
+            BiConsumer<Path, Path> probe,
+            boolean claudeDesktopInstalled) {
+
+        InstallerEnvironment {
+            environmentVariables = Map.copyOf(environmentVariables);
+            userHome = userHome.toAbsolutePath().normalize();
+            workingDirectory = workingDirectory.toAbsolutePath().normalize();
+            javaExecutable = javaExecutable.toAbsolutePath().normalize();
+            sourceJar = sourceJar.toAbsolutePath().normalize();
+            applicationDataRoot = applicationDataRoot.toAbsolutePath().normalize();
+        }
+
+        static InstallerEnvironment system() throws InstallerFailure {
+            OperatingSystem os = OperatingSystem.current();
+            Map<String, String> variables = new HashMap<>(System.getenv());
+            Path home = Path.of(System.getProperty("user.home")).toAbsolutePath().normalize();
+            Path java = ProcessHandle.current().info().command()
+                    .map(Path::of)
+                    .orElseGet(() -> Path.of(System.getProperty("java.home"), "bin",
+                            os == OperatingSystem.WINDOWS ? "java.exe" : "java"))
+                    .toAbsolutePath()
+                    .normalize();
+            Path source = discoverSourceJar();
+            String implementationVersion = Optional.ofNullable(
+                    ShaftMcpInstaller.class.getPackage().getImplementationVersion())
+                    .orElse("");
+            Path appData = applicationDataRoot(os, variables, home);
+            return new InstallerEnvironment(
+                    os,
+                    variables,
+                    home,
+                    Path.of("").toAbsolutePath(),
+                    java,
+                    Runtime.version().feature(),
+                    source,
+                    implementationVersion,
+                    appData,
+                    new SystemCommandRunner(os),
+                    (javaExecutable, jar) -> {
+                        try {
+                            InstallerStdioProbe.verify(javaExecutable, jar);
+                        } catch (IOException exception) {
+                            throw new ProbeFailure(exception);
+                        }
+                    },
+                    claudeDesktopInstalled(os, variables, home));
+        }
+
+        private static Path discoverSourceJar() throws InstallerFailure {
+            String[] processArguments = ProcessHandle.current().info().arguments().orElse(new String[0]);
+            for (int index = 0; index + 1 < processArguments.length; index++) {
+                if ("-jar".equals(processArguments[index])) {
+                    Path launchedJar = Path.of(processArguments[index + 1])
+                            .toAbsolutePath()
+                            .normalize();
+                    if (Files.isRegularFile(launchedJar)) {
+                        return launchedJar;
+                    }
+                }
+            }
+            String[] classPathEntries = ManagementFactory.getRuntimeMXBean()
+                    .getClassPath()
+                    .split(Pattern.quote(File.pathSeparator));
+            if (classPathEntries.length == 1) {
+                Path classPathJar = Path.of(classPathEntries[0]).toAbsolutePath().normalize();
+                if (Files.isRegularFile(classPathJar)
+                        && classPathJar.getFileName().toString().endsWith(".jar")) {
+                    return classPathJar;
+                }
+            }
+            try {
+                Path source = Path.of(ShaftMcpInstaller.class.getProtectionDomain()
+                        .getCodeSource().getLocation().toURI())
+                        .toAbsolutePath()
+                        .normalize();
+                if (!Files.isRegularFile(source)) {
+                    throw new InstallerFailure("Run the installer from the executable shaft-mcp JAR.", 4);
+                }
+                return source;
+            } catch (URISyntaxException exception) {
+                throw new InstallerFailure("Could not locate the running shaft-mcp JAR.", 4, exception);
+            }
+        }
+
+        private static Path applicationDataRoot(
+                OperatingSystem os,
+                Map<String, String> variables,
+                Path home) throws InstallerFailure {
+            return switch (os) {
+                case WINDOWS -> {
+                    String localAppData = variables.get("LOCALAPPDATA");
+                    if (localAppData == null || localAppData.isBlank()) {
+                        throw new InstallerFailure("LOCALAPPDATA is unavailable.", 3);
+                    }
+                    yield Path.of(localAppData).resolve("ShaftHQ").resolve("shaft-mcp");
+                }
+                case MACOS -> home.resolve("Library").resolve("Application Support")
+                        .resolve("ShaftHQ").resolve("shaft-mcp");
+                case LINUX -> optionalPath(variables.get("XDG_DATA_HOME"))
+                        .orElse(home.resolve(".local").resolve("share"))
+                        .resolve("shafthq").resolve("shaft-mcp");
+            };
+        }
+
+        private static boolean claudeDesktopInstalled(
+                OperatingSystem os,
+                Map<String, String> variables,
+                Path home) {
+            if (os == OperatingSystem.MACOS) {
+                return Files.isDirectory(Path.of("/Applications/Claude.app"))
+                        || Files.isDirectory(home.resolve("Applications").resolve("Claude.app"));
+            }
+            if (os != OperatingSystem.WINDOWS) {
+                return false;
+            }
+            List<Path> candidates = new ArrayList<>();
+            optionalPath(variables.get("LOCALAPPDATA")).ifPresent(local -> {
+                candidates.add(local.resolve("AnthropicClaude").resolve("claude.exe"));
+                candidates.add(local.resolve("Programs").resolve("Claude").resolve("Claude.exe"));
+            });
+            optionalPath(variables.get("PROGRAMFILES")).ifPresent(programFiles ->
+                    candidates.add(programFiles.resolve("Claude").resolve("Claude.exe")));
+            return candidates.stream().anyMatch(Files::isRegularFile);
+        }
+    }
+
+    static final class SystemCommandRunner implements CommandRunner {
+        private final OperatingSystem operatingSystem;
+
+        SystemCommandRunner(OperatingSystem operatingSystem) {
+            this.operatingSystem = operatingSystem;
+        }
+
+        @Override
+        public CommandResult run(List<String> command) {
+            List<String> launchCommand = command;
+            boolean nativeVsCode = false;
+            if (operatingSystem == OperatingSystem.WINDOWS) {
+                Optional<List<String>> nativeCommand = nativeVsCodeCommand(command);
+                if (nativeCommand.isPresent()) {
+                    launchCommand = nativeCommand.get();
+                    nativeVsCode = true;
+                } else {
+                    launchCommand = windowsCommand(command)
+                            .orElse(command);
+                }
+            }
+            try {
+                ProcessBuilder builder = new ProcessBuilder(launchCommand)
+                        .redirectErrorStream(true);
+                if (nativeVsCode) {
+                    builder.environment().put("ELECTRON_RUN_AS_NODE", "1");
+                }
+                Process process = builder.start();
+                boolean finished = process.waitFor(Duration.ofSeconds(30).toMillis(), TimeUnit.MILLISECONDS);
+                if (!finished) {
+                    process.destroyForcibly();
+                    return new CommandResult(124, "Command timed out.");
+                }
+                return new CommandResult(
+                        process.exitValue(),
+                        new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8));
+            } catch (IOException exception) {
+                return new CommandResult(127, exception.getMessage());
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                return new CommandResult(130, "Command interrupted.");
+            }
+        }
+
+        private static Optional<List<String>> nativeVsCodeCommand(List<String> command) {
+            if (command.isEmpty() || !"code".equalsIgnoreCase(command.getFirst())) {
+                return Optional.empty();
+            }
+            List<Path> roots = new ArrayList<>();
+            optionalPath(System.getenv("LOCALAPPDATA")).ifPresent(local ->
+                    roots.add(local.resolve("Programs")));
+            optionalPath(System.getenv("PROGRAMFILES")).ifPresent(roots::add);
+            optionalPath(System.getenv("PROGRAMFILES(X86)")).ifPresent(roots::add);
+            for (Path root : roots) {
+                for (String directory : List.of("Microsoft VS Code", "Microsoft VS Code Insiders")) {
+                    Path installation = root.resolve(directory);
+                    Path executable = installation.resolve(
+                            directory.endsWith("Insiders") ? "Code - Insiders.exe" : "Code.exe");
+                    Path cli = installation.resolve("resources").resolve("app")
+                            .resolve("out").resolve("cli.js");
+                    if (Files.isRegularFile(executable) && Files.isRegularFile(cli)) {
+                        List<String> nativeCommand = new ArrayList<>();
+                        nativeCommand.add(executable.toString());
+                        nativeCommand.add(cli.toString());
+                        nativeCommand.addAll(command.subList(1, command.size()));
+                        return Optional.of(nativeCommand);
+                    }
+                }
+            }
+            return Optional.empty();
+        }
+
+        private static Optional<List<String>> windowsCommand(List<String> command) {
+            if (command.isEmpty()) {
+                return Optional.empty();
+            }
+            Optional<Path> executable = resolveWindowsExecutable(command.getFirst());
+            if (executable.isEmpty()) {
+                return Optional.empty();
+            }
+            String fileName = executable.get().getFileName().toString().toLowerCase(Locale.ROOT);
+            List<String> resolved = new ArrayList<>();
+            if (fileName.endsWith(".cmd") || fileName.endsWith(".bat")) {
+                resolved.addAll(List.of("cmd.exe", "/d", "/s", "/c", "call"));
+            }
+            resolved.add(executable.get().toString());
+            resolved.addAll(command.subList(1, command.size()));
+            return Optional.of(resolved);
+        }
+
+        private static Optional<Path> resolveWindowsExecutable(String command) {
+            Path requested = Path.of(command);
+            if (requested.getNameCount() > 1 || requested.isAbsolute()) {
+                return Files.isRegularFile(requested)
+                        ? Optional.of(requested.toAbsolutePath().normalize())
+                        : Optional.empty();
+            }
+            String pathValue = System.getenv("PATH");
+            if (pathValue == null || pathValue.isBlank()) {
+                return Optional.empty();
+            }
+            String pathExtensions = Optional.ofNullable(System.getenv("PATHEXT"))
+                    .filter(value -> !value.isBlank())
+                    .orElse(".COM;.EXE;.BAT;.CMD");
+            List<String> candidates = new ArrayList<>(Arrays.stream(pathExtensions.split(";"))
+                    .filter(extension -> !extension.isBlank())
+                    .toList());
+            if (command.contains(".")) {
+                candidates.addFirst("");
+            }
+            for (String directory : pathValue.split(Pattern.quote(File.pathSeparator))) {
+                if (directory.isBlank()) {
+                    continue;
+                }
+                for (String extension : candidates) {
+                    Path candidate = Path.of(directory, command + extension);
+                    if (Files.isRegularFile(candidate)) {
+                        return Optional.of(candidate.toAbsolutePath().normalize());
+                    }
+                }
+            }
+            return Optional.empty();
+        }
+    }
+
+    static final class ProbeFailure extends RuntimeException {
+        ProbeFailure(IOException cause) {
+            super(cause.getMessage(), cause);
+        }
+    }
+
+    static class InstallerFailure extends Exception {
+        private final int exitCode;
+
+        InstallerFailure(String message, int exitCode) {
+            super(message);
+            this.exitCode = exitCode;
+        }
+
+        InstallerFailure(String message, int exitCode, Throwable cause) {
+            super(message, cause);
+            this.exitCode = exitCode;
+        }
+
+        int exitCode() {
+            return exitCode;
+        }
+    }
+}

--- a/shaft-mcp/src/test/java/com/shaft/mcp/install/ShaftMcpInstallerTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/install/ShaftMcpInstallerTest.java
@@ -1,0 +1,487 @@
+package com.shaft.mcp.install;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShaftMcpInstallerTest {
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    @ParameterizedTest
+    @MethodSource("targets")
+    void installsAndConfiguresEveryTarget(
+            String flag,
+            ShaftMcpInstaller.OperatingSystem operatingSystem,
+            @TempDir Path temp) throws Exception {
+        TestSetup setup = setup(temp, operatingSystem, "1.2.3", "jar-one");
+
+        int exitCode = ShaftMcpInstaller.run(new String[]{flag}, setup.environment());
+
+        assertEquals(0, exitCode);
+        Path installed = setup.installedJar();
+        assertTrue(Files.isRegularFile(installed));
+        assertEquals("jar-one", Files.readString(installed));
+        assertEquals(installed, setup.probedJar().get());
+        assertConfigured(flag, setup, installed);
+    }
+
+    static Stream<Arguments> targets() {
+        return Stream.of(
+                Arguments.of("--codex", ShaftMcpInstaller.OperatingSystem.WINDOWS),
+                Arguments.of("--codex-app", ShaftMcpInstaller.OperatingSystem.MACOS),
+                Arguments.of("--claude", ShaftMcpInstaller.OperatingSystem.LINUX),
+                Arguments.of("--claude-desktop", ShaftMcpInstaller.OperatingSystem.WINDOWS),
+                Arguments.of("--copilot", ShaftMcpInstaller.OperatingSystem.MACOS),
+                Arguments.of("--copilot-vscode", ShaftMcpInstaller.OperatingSystem.LINUX));
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    void windowsCommandRunnerExecutesMavenBatchFile() {
+        var result = new ShaftMcpInstaller.SystemCommandRunner(
+                ShaftMcpInstaller.OperatingSystem.WINDOWS)
+                .run(List.of("mvn", "--version"));
+
+        assertEquals(0, result.exitCode(), result.output());
+        assertTrue(result.output().contains("Apache Maven"), result.output());
+    }
+
+    @Test
+    void repeatedInstallationReusesVerifiedJar(@TempDir Path temp) throws Exception {
+        TestSetup setup = setup(temp, ShaftMcpInstaller.OperatingSystem.LINUX, "1.2.3", "same-jar");
+        assertEquals(0, ShaftMcpInstaller.run(new String[]{"--copilot"}, setup.environment()));
+        FileTime sentinel = FileTime.fromMillis(1_700_000_000_000L);
+        Files.setLastModifiedTime(setup.installedJar(), sentinel);
+
+        assertEquals(0, ShaftMcpInstaller.run(new String[]{"--copilot"}, setup.environment()));
+
+        assertEquals(sentinel, Files.getLastModifiedTime(setup.installedJar()));
+    }
+
+    @Test
+    void versionUpgradeKeepsOldJarAndPointsConfigurationToNewJar(@TempDir Path temp) throws Exception {
+        TestSetup first = setup(temp, ShaftMcpInstaller.OperatingSystem.LINUX, "1.0.0", "old-jar");
+        assertEquals(0, ShaftMcpInstaller.run(new String[]{"--copilot"}, first.environment()));
+        TestSetup second = setup(temp, ShaftMcpInstaller.OperatingSystem.LINUX, "2.0.0", "new-jar");
+
+        assertEquals(0, ShaftMcpInstaller.run(new String[]{"--copilot"}, second.environment()));
+
+        assertEquals("old-jar", Files.readString(first.installedJar()));
+        assertEquals("new-jar", Files.readString(second.installedJar()));
+        JsonNode entry = JSON.readTree(Files.readString(second.copilotConfig()))
+                .path("mcpServers").path("shaft-mcp");
+        assertEquals(second.installedJar().toString(), entry.path("args").get(1).asText());
+    }
+
+    @Test
+    void duplicateNamedEntryIsReplacedWithoutRemovingOtherServers(@TempDir Path temp) throws Exception {
+        TestSetup setup = setup(temp, ShaftMcpInstaller.OperatingSystem.MACOS, "1.2.3", "jar");
+        Files.createDirectories(setup.copilotConfig().getParent());
+        Files.writeString(setup.copilotConfig(), """
+                {
+                  "mcpServers": {
+                    "shaft-mcp": {"command": "old", "args": []},
+                    "other": {"command": "keep", "args": []}
+                  }
+                }
+                """);
+
+        assertEquals(0, ShaftMcpInstaller.run(new String[]{"--copilot"}, setup.environment()));
+
+        JsonNode servers = JSON.readTree(Files.readString(setup.copilotConfig())).path("mcpServers");
+        assertEquals(2, servers.size());
+        assertEquals("keep", servers.path("other").path("command").asText());
+        assertEquals(setup.javaExecutable().toString(),
+                servers.path("shaft-mcp").path("command").asText());
+    }
+
+    @Test
+    void projectConfigurationConflictLeavesUserConfigurationUntouched(@TempDir Path temp) throws Exception {
+        TestSetup setup = setup(temp, ShaftMcpInstaller.OperatingSystem.LINUX, "1.2.3", "jar");
+        Path projectConfig = setup.workingDirectory().resolve(".vscode").resolve("mcp.json");
+        Files.createDirectories(projectConfig.getParent());
+        Files.writeString(projectConfig, """
+                {"servers":{"shaft-mcp":{"command":"project","args":[]}}}
+                """);
+        Path userConfig = setup.vsCodeConfig();
+        Files.createDirectories(userConfig.getParent());
+        byte[] original = "{\"servers\":{\"keep\":{}}}\r\n".getBytes(StandardCharsets.UTF_8);
+        Files.write(userConfig, original);
+
+        int exitCode = ShaftMcpInstaller.run(
+                new String[]{"--copilot-vscode"}, setup.environment());
+
+        assertEquals(5, exitCode);
+        assertArrayEquals(original, Files.readAllBytes(userConfig));
+        assertFalse(Files.exists(setup.installedJar()));
+    }
+
+    @Test
+    void rejectsUnsupportedDesktopOperatingSystem(@TempDir Path temp) throws Exception {
+        TestSetup setup = setup(temp, ShaftMcpInstaller.OperatingSystem.LINUX, "1.2.3", "jar");
+
+        int exitCode = ShaftMcpInstaller.run(
+                new String[]{"--claude-desktop"}, setup.environment());
+
+        assertEquals(3, exitCode);
+        assertFalse(Files.exists(setup.installedJar()));
+    }
+
+    @Test
+    void malformedJsonIsRestoredByteForByte(@TempDir Path temp) throws Exception {
+        TestSetup setup = setup(temp, ShaftMcpInstaller.OperatingSystem.WINDOWS, "1.2.3", "jar");
+        Path configuration = setup.claudeDesktopConfig();
+        Files.createDirectories(configuration.getParent());
+        byte[] original = """
+                {"mcpServers":{"shaft-mcp":{},"shaft-mcp":{"command":"duplicate"}}}
+                """.getBytes(StandardCharsets.UTF_8);
+        Files.write(configuration, original);
+
+        int exitCode = ShaftMcpInstaller.run(
+                new String[]{"--claude-desktop"}, setup.environment());
+
+        assertEquals(5, exitCode);
+        assertArrayEquals(original, Files.readAllBytes(configuration));
+    }
+
+    @Test
+    void failedClientCommandRollsBackExactOriginalBytes(@TempDir Path temp) throws Exception {
+        TestSetup setup = setup(temp, ShaftMcpInstaller.OperatingSystem.WINDOWS, "1.2.3", "jar");
+        Path configuration = setup.codexConfig();
+        Files.createDirectories(configuration.getParent());
+        byte[] original = "# original\r\n[mcp_servers.keep]\r\ncommand = \"keep\"\r\n"
+                .getBytes(StandardCharsets.UTF_8);
+        Files.write(configuration, original);
+        setup.runner().failCodexAdd = true;
+
+        int exitCode = ShaftMcpInstaller.run(new String[]{"--codex"}, setup.environment());
+
+        assertEquals(5, exitCode);
+        assertArrayEquals(original, Files.readAllBytes(configuration));
+        try (var backups = Files.list(configuration.getParent())) {
+            assertFalse(backups.anyMatch(path -> path.getFileName().toString().contains("shaft-mcp-backup")));
+        }
+    }
+
+    @Test
+    void rejectsMultipleFlagsInvalidJavaAndUnavailableClient(@TempDir Path temp) throws Exception {
+        TestSetup setup = setup(temp, ShaftMcpInstaller.OperatingSystem.LINUX, "1.2.3", "jar");
+        assertEquals(2, ShaftMcpInstaller.run(
+                new String[]{"--codex", "--claude"}, setup.environment()));
+
+        var invalidJava = environment(
+                setup,
+                24,
+                setup.runner(),
+                setup.probedJar(),
+                true);
+        assertEquals(3, ShaftMcpInstaller.run(new String[]{"--codex"}, invalidJava));
+
+        setup.runner().mavenVersion = "3.8.9";
+        assertEquals(3, ShaftMcpInstaller.run(new String[]{"--codex"}, setup.environment()));
+        setup.runner().mavenVersion = "3.9.12";
+
+        setup.runner().unavailableCommands.add("copilot");
+        assertEquals(3, ShaftMcpInstaller.run(new String[]{"--copilot"}, setup.environment()));
+    }
+
+    @Test
+    void failedProbeDoesNotChangeClientConfiguration(@TempDir Path temp) throws Exception {
+        TestSetup setup = setup(temp, ShaftMcpInstaller.OperatingSystem.LINUX, "1.2.3", "jar");
+        Path configuration = setup.copilotConfig();
+        Files.createDirectories(configuration.getParent());
+        byte[] original = "{\"mcpServers\":{\"keep\":{}}}\n".getBytes(StandardCharsets.UTF_8);
+        Files.write(configuration, original);
+        var environment = new ShaftMcpInstaller.InstallerEnvironment(
+                setup.environment().operatingSystem(),
+                setup.environment().environmentVariables(),
+                setup.environment().userHome(),
+                setup.environment().workingDirectory(),
+                setup.environment().javaExecutable(),
+                setup.environment().javaFeatureVersion(),
+                setup.environment().sourceJar(),
+                setup.environment().version(),
+                setup.environment().applicationDataRoot(),
+                setup.runner(),
+                (javaExecutable, jar) -> {
+                    throw new ShaftMcpInstaller.ProbeFailure(new IOException("probe failed"));
+                },
+                true);
+
+        int exitCode = ShaftMcpInstaller.run(new String[]{"--copilot"}, environment);
+
+        assertEquals(4, exitCode);
+        assertArrayEquals(original, Files.readAllBytes(configuration));
+    }
+
+    private static TestSetup setup(
+            Path temp,
+            ShaftMcpInstaller.OperatingSystem operatingSystem,
+            String version,
+            String jarContent) throws IOException {
+        Path root = temp.resolve(operatingSystem.name().toLowerCase()).resolve(version);
+        Path home = root.resolve("home");
+        Path work = root.resolve("work").resolve("repo");
+        Path appData = root.resolve("application-data").resolve("shaft-mcp");
+        Path source = root.resolve("bootstrap").resolve("shaft-mcp.jar");
+        Path java = root.resolve("jdk").resolve("bin")
+                .resolve(operatingSystem == ShaftMcpInstaller.OperatingSystem.WINDOWS ? "java.exe" : "java");
+        Files.createDirectories(source.getParent());
+        Files.createDirectories(java.getParent());
+        Files.createDirectories(work);
+        Files.writeString(source, jarContent);
+        Files.writeString(java, "fake-java");
+
+        Map<String, String> variables = new HashMap<>();
+        variables.put("APPDATA", root.resolve("appdata").toString());
+        variables.put("LOCALAPPDATA", root.resolve("localappdata").toString());
+        variables.put("XDG_CONFIG_HOME", root.resolve("xdg-config").toString());
+        variables.put("XDG_DATA_HOME", root.resolve("xdg-data").toString());
+        variables.put("CODEX_HOME", home.resolve(".codex").toString());
+        variables.put("COPILOT_HOME", home.resolve(".copilot").toString());
+
+        AtomicReference<Path> probedJar = new AtomicReference<>();
+        FakeCommandRunner runner = new FakeCommandRunner(operatingSystem, variables, home);
+        var environment = new ShaftMcpInstaller.InstallerEnvironment(
+                operatingSystem,
+                variables,
+                home,
+                work,
+                java,
+                25,
+                source,
+                version,
+                appData,
+                runner,
+                (javaExecutable, jar) -> probedJar.set(jar),
+                true);
+        return new TestSetup(environment, runner, probedJar);
+    }
+
+    private static ShaftMcpInstaller.InstallerEnvironment environment(
+            TestSetup setup,
+            int javaFeature,
+            FakeCommandRunner runner,
+            AtomicReference<Path> probe,
+            boolean desktopInstalled) {
+        var current = setup.environment();
+        return new ShaftMcpInstaller.InstallerEnvironment(
+                current.operatingSystem(),
+                current.environmentVariables(),
+                current.userHome(),
+                current.workingDirectory(),
+                current.javaExecutable(),
+                javaFeature,
+                current.sourceJar(),
+                current.version(),
+                current.applicationDataRoot(),
+                runner,
+                (javaExecutable, jar) -> probe.set(jar),
+                desktopInstalled);
+    }
+
+    private static void assertConfigured(String flag, TestSetup setup, Path installed) throws Exception {
+        if ("--codex".equals(flag) || "--codex-app".equals(flag)) {
+            assertTrue(Files.readString(setup.codexConfig()).contains("[mcp_servers.shaft-mcp]"));
+            assertEquals(installed, setup.runner().configuredJar);
+            return;
+        }
+        Path configuration = switch (flag) {
+            case "--claude" -> setup.claudeCodeConfig();
+            case "--claude-desktop" -> setup.claudeDesktopConfig();
+            case "--copilot" -> setup.copilotConfig();
+            case "--copilot-vscode" -> setup.vsCodeConfig();
+            default -> throw new IllegalArgumentException(flag);
+        };
+        JsonNode root = JSON.readTree(Files.readString(configuration));
+        JsonNode entry = "--copilot-vscode".equals(flag)
+                ? root.path("servers").path("shaft-mcp")
+                : root.path("mcpServers").path("shaft-mcp");
+        assertEquals(setup.javaExecutable().toString(), entry.path("command").asText());
+        assertEquals(List.of("-jar", installed.toString()),
+                JSON.convertValue(entry.path("args"), JSON.getTypeFactory().constructCollectionType(List.class, String.class)));
+    }
+
+    private record TestSetup(
+            ShaftMcpInstaller.InstallerEnvironment environment,
+            FakeCommandRunner runner,
+            AtomicReference<Path> probedJar) {
+
+        Path installedJar() {
+            return environment.applicationDataRoot().resolve("versions")
+                    .resolve(environment.version()).resolve("shaft-mcp.jar").toAbsolutePath().normalize();
+        }
+
+        Path javaExecutable() {
+            return environment.javaExecutable();
+        }
+
+        Path workingDirectory() {
+            return environment.workingDirectory();
+        }
+
+        Path codexConfig() {
+            return Path.of(environment.environmentVariables().get("CODEX_HOME")).resolve("config.toml");
+        }
+
+        Path claudeCodeConfig() {
+            return environment.userHome().resolve(".claude.json");
+        }
+
+        Path claudeDesktopConfig() {
+            return environment.operatingSystem() == ShaftMcpInstaller.OperatingSystem.WINDOWS
+                    ? Path.of(environment.environmentVariables().get("APPDATA"))
+                            .resolve("Claude").resolve("claude_desktop_config.json")
+                    : environment.userHome().resolve("Library").resolve("Application Support")
+                            .resolve("Claude").resolve("claude_desktop_config.json");
+        }
+
+        Path copilotConfig() {
+            return Path.of(environment.environmentVariables().get("COPILOT_HOME")).resolve("mcp-config.json");
+        }
+
+        Path vsCodeConfig() {
+            return switch (environment.operatingSystem()) {
+                case WINDOWS -> Path.of(environment.environmentVariables().get("APPDATA"))
+                        .resolve("Code").resolve("User").resolve("mcp.json");
+                case MACOS -> environment.userHome().resolve("Library").resolve("Application Support")
+                        .resolve("Code").resolve("User").resolve("mcp.json");
+                case LINUX -> Path.of(environment.environmentVariables().get("XDG_CONFIG_HOME"))
+                        .resolve("Code").resolve("User").resolve("mcp.json");
+            };
+        }
+    }
+
+    private static final class FakeCommandRunner implements ShaftMcpInstaller.CommandRunner {
+        private final ShaftMcpInstaller.OperatingSystem operatingSystem;
+        private final Map<String, String> variables;
+        private final Path home;
+        private final List<String> unavailableCommands = new ArrayList<>();
+        private boolean failCodexAdd;
+        private String mavenVersion = "3.9.12";
+        private Path configuredJava;
+        private Path configuredJar;
+
+        private FakeCommandRunner(
+                ShaftMcpInstaller.OperatingSystem operatingSystem,
+                Map<String, String> variables,
+                Path home) {
+            this.operatingSystem = operatingSystem;
+            this.variables = variables;
+            this.home = home;
+        }
+
+        @Override
+        public ShaftMcpInstaller.CommandResult run(List<String> command) {
+            try {
+                if ("mvn".equals(command.getFirst())) {
+                    return success("Apache Maven " + mavenVersion);
+                }
+                if (command.size() == 2 && "--version".equals(command.get(1))) {
+                    return unavailableCommands.contains(command.getFirst())
+                            ? failure("not found")
+                            : success(command.getFirst() + " test");
+                }
+                if (command.size() >= 4 && command.subList(0, 3).equals(List.of("codex", "mcp", "add"))) {
+                    captureCommand(command);
+                    Path config = Path.of(variables.get("CODEX_HOME")).resolve("config.toml");
+                    Files.createDirectories(config.getParent());
+                    Files.writeString(config, failCodexAdd
+                            ? "damaged"
+                            : "[mcp_servers.shaft-mcp]\ncommand = \"" + configuredJava + "\"\n");
+                    return failCodexAdd ? failure("simulated failure") : success("");
+                }
+                if (command.equals(List.of("codex", "mcp", "get", "shaft-mcp", "--json"))) {
+                    ObjectNode transport = JSON.createObjectNode();
+                    transport.put("command", configuredJava.toString());
+                    transport.putArray("args").add("-jar").add(configuredJar.toString());
+                    ObjectNode result = JSON.createObjectNode();
+                    result.set("transport", transport);
+                    return success(JSON.writeValueAsString(result));
+                }
+                if (command.size() >= 5 && command.subList(0, 3).equals(List.of("claude", "mcp", "remove"))) {
+                    writeClaude(null, null);
+                    return success("");
+                }
+                if (command.size() >= 6 && command.subList(0, 3).equals(List.of("claude", "mcp", "add"))) {
+                    captureCommand(command);
+                    writeClaude(configuredJava, configuredJar);
+                    return success("");
+                }
+                if (command.size() == 3 && command.subList(0, 2).equals(List.of("code", "--add-mcp"))) {
+                    JsonNode entry = JSON.readTree(command.get(2));
+                    Path config = vsCodeConfig();
+                    ObjectNode root = JSON.createObjectNode();
+                    ObjectNode stored = entry.deepCopy();
+                    stored.remove("name");
+                    root.putObject("servers").set("shaft-mcp", stored);
+                    InstallerFileOperations.writeJsonAtomically(config, root);
+                    return success("");
+                }
+                return failure("unexpected command: " + command);
+            } catch (IOException exception) {
+                return failure(exception.getMessage());
+            }
+        }
+
+        private void captureCommand(List<String> command) {
+            int separator = command.indexOf("--");
+            configuredJava = Path.of(command.get(separator + 1)).toAbsolutePath().normalize();
+            configuredJar = Path.of(command.get(separator + 3)).toAbsolutePath().normalize();
+        }
+
+        private void writeClaude(Path java, Path jar) throws IOException {
+            ObjectNode root = JSON.createObjectNode();
+            ObjectNode servers = root.putObject("mcpServers");
+            if (java != null && jar != null) {
+                ObjectNode entry = servers.putObject("shaft-mcp");
+                entry.put("command", java.toString());
+                entry.putArray("args").add("-jar").add(jar.toString());
+            }
+            InstallerFileOperations.writeJsonAtomically(home.resolve(".claude.json"), root);
+        }
+
+        private Path vsCodeConfig() {
+            return switch (operatingSystem) {
+                case WINDOWS -> Path.of(variables.get("APPDATA"))
+                        .resolve("Code").resolve("User").resolve("mcp.json");
+                case MACOS -> home.resolve("Library").resolve("Application Support")
+                        .resolve("Code").resolve("User").resolve("mcp.json");
+                case LINUX -> Path.of(variables.get("XDG_CONFIG_HOME"))
+                        .resolve("Code").resolve("User").resolve("mcp.json");
+            };
+        }
+
+        private static ShaftMcpInstaller.CommandResult success(String output) {
+            return new ShaftMcpInstaller.CommandResult(0, output);
+        }
+
+        private static ShaftMcpInstaller.CommandResult failure(String output) {
+            return new ShaftMcpInstaller.CommandResult(1, output);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add `java -jar shaft-mcp.jar install <agent-flag>` before Spring MCP startup
- install the verified executable JAR into an OS-appropriate per-user version directory
- configure Codex, Claude, Claude Desktop, Copilot CLI, and VS Code without duplicate entries
- back up, validate, atomically replace, and roll back client configuration changes
- add isolated installer coverage and Windows/macOS/Linux CI
- gate release announcements on exercising the public Maven Central `LATEST` installer twice on all three operating systems

## Why

Users need one repeatable Maven command that downloads the latest shaft-mcp release and safely configures their selected local MCP client. The installer must be deterministic across repeated runs and must not corrupt or silently override project configuration.

## Companion PR

- Documentation: https://github.com/ShaftHQ/shafthq.github.io/pull/528

## Validation

- `mvn --batch-mode -pl shaft-mcp -am test '-Dtest=ShaftMcpInstallerTest' '-Dsurefire.failIfNoSpecifiedTests=false' '-Dgpg.skip'` (16 tests)
- packaged shaft-mcp stdio and HTTP transport smoke tests
- isolated packaged Windows install and repeated-install verification
- agent guidance, documentation-boundary, modular-documentation, and shaft-mcp configuration validators
- GitHub workflow YAML parse and `git diff --check`

## Release notes

The currently published immutable `10.2.20260615` artifact predates this installer. After this PR merges, publish a new reactor version and allow the new public-installer matrix to pass before advertising the command in production documentation.