### PR TITLE
[codex] optimize agent guidance and repository memory

### DIFF
--- a/.agents/skills/ci-failure-investigator/SKILL.md
+++ b/.agents/skills/ci-failure-investigator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci-failure-investigator
-description: Investigate GitHub Actions or SHAFT Allure failures and separate code defects from infrastructure or provider failures.
+description: Use when a GitHub Actions job, SHAFT Allure report, or provider E2E run fails; identify the first actionable failure and separate code defects from infrastructure, credentials, and provider faults.
 ---
 
 # CI Failure Investigator

--- a/.agents/skills/ci-failure-investigator/agents/openai.yaml
+++ b/.agents/skills/ci-failure-investigator/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "CI Failure Investigator"
+  short_description: "Debug GitHub Actions and Allure failures"
+  default_prompt: "Use $ci-failure-investigator to identify and fix the root cause of this CI failure."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/flaky-test-stabilizer/SKILL.md
+++ b/.agents/skills/flaky-test-stabilizer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flaky-test-stabilizer
-description: Diagnose and stabilize intermittent SHAFT tests involving parallelism, shared state, files, drivers, timing, or external dependencies.
+description: Use when a SHAFT test is intermittent, retry-only, parallel-only, or environment-sensitive; diagnose shared state, files, drivers, timing, and external dependencies without weakening assertions.
 ---
 
 # Flaky Test Stabilizer

--- a/.agents/skills/flaky-test-stabilizer/agents/openai.yaml
+++ b/.agents/skills/flaky-test-stabilizer/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Flaky Test Stabilizer"
+  short_description: "Stabilize intermittent and parallel tests"
+  default_prompt: "Use $flaky-test-stabilizer to diagnose and remove the cause of this intermittent test failure."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/framework-source-rules/SKILL.md
+++ b/.agents/skills/framework-source-rules/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: framework-source-rules
-description: Apply SHAFT production Java compatibility, API, properties, logging, Allure, and WebDriver rules when editing src/main Java files.
+description: Use when editing or reviewing any src/main Java file in SHAFT; apply production compatibility, public API, properties, logging, Allure, concurrency, and WebDriver rules.
 ---
 
 # Framework Source Rules
 
 Read and follow the [canonical production Java rules](../../../.github/instructions/framework-source.instructions.md).
-Load them only when production Java is in scope.

--- a/.agents/skills/framework-source-rules/agents/openai.yaml
+++ b/.agents/skills/framework-source-rules/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Framework Source Rules"
+  short_description: "Apply production Java framework rules"
+  default_prompt: "Use $framework-source-rules while implementing this production Java change."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/java-test-rules/SKILL.md
+++ b/.agents/skills/java-test-rules/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: java-test-rules
-description: Apply SHAFT Java test lifecycle, parallelism, isolation, Allure, browser, and regression rules when editing src/test Java files.
+description: Use when editing or reviewing any src/test Java file in SHAFT; apply lifecycle, parallelism, isolation, Allure, browser, mocking, and focused regression rules.
 ---
 
 # Java Test Rules
 
 Read and follow the [canonical Java test rules](../../../.github/instructions/java-tests.instructions.md).
-Load them only when test Java is in scope.

--- a/.agents/skills/java-test-rules/agents/openai.yaml
+++ b/.agents/skills/java-test-rules/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Java Test Rules"
+  short_description: "Apply Java test isolation and lifecycle rules"
+  default_prompt: "Use $java-test-rules while implementing or reviewing this Java test change."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/release-dependency-guard/SKILL.md
+++ b/.agents/skills/release-dependency-guard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-dependency-guard
-description: Prepare or review SHAFT releases and dependency updates without running deployment or publication commands.
+description: Use when preparing or reviewing a SHAFT release, version alignment, dependency or plugin updates, or Maven Central safeguards; validate metadata without deploying or publishing.
 ---
 
 # Release And Dependency Guard

--- a/.agents/skills/release-dependency-guard/agents/openai.yaml
+++ b/.agents/skills/release-dependency-guard/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Release And Dependency Guard"
+  short_description: "Guard releases and dependency updates"
+  default_prompt: "Use $release-dependency-guard to prepare or review this release or dependency update."
+policy:
+  allow_implicit_invocation: true

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,12 @@
+[mcp_servers.shaft-memory]
+command = "npx"
+args = ["--yes", "--package", "@aictx/memory@0.1.55", "--", "memory-mcp"]
+cwd = ".."
+enabled_tools = ["load_memory", "search_memory", "inspect_memory", "remember_memory"]
+default_tools_approval_mode = "auto"
+startup_timeout_sec = 30
+tool_timeout_sec = 60
+required = false
+
+[mcp_servers.shaft-memory.tools.remember_memory]
+approval_mode = "prompt"

--- a/.github/codex/prompts/refresh-agent-instructions.md
+++ b/.github/codex/prompts/refresh-agent-instructions.md
@@ -31,12 +31,10 @@ the explicit maintainer reason.
 Run:
 
 ```bash
-python3 scripts/ci/validate_agent_guidance.py
-python3 scripts/ci/validate_documentation_boundaries.py
-git diff --check
+python3 scripts/ci/validate_agent_setup.py
 ```
 
-If both already pass and the maintainer reason requires no durable change,
+If it already passes and the maintainer reason requires no durable change,
 leave the repository unchanged. In the final response, list changed guidance
 files, validation results, and any fact that remains uncertain. State that no
 product code was intentionally changed.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,6 +10,5 @@ Follow `AGENTS.md` as the canonical repository policy.
 - Prefer targeted reads and deterministic local checks; reuse valid evidence.
 - Preserve unrelated work and never expose secrets or claim unverified remote
   results.
-- For guidance changes, run `python3 scripts/ci/validate_agent_guidance.py`,
-  `python3 scripts/ci/validate_documentation_boundaries.py`, and
-  `git diff --check`.
+- For guidance or memory changes, run
+  `python3 scripts/ci/validate_agent_setup.py`.

--- a/.github/workflows/agent-guidance-check.yml
+++ b/.github/workflows/agent-guidance-check.yml
@@ -7,16 +7,20 @@ on:
       - 'CLAUDE.md'
       - 'CONTRIBUTING.md'
       - '.agents/skills/**'
+      - '.codex/**'
       - '.github/copilot-instructions.md'
       - '.github/instructions/**'
       - '.github/skills/**'
+      - '.memory/**'
       - '.github/pull_request_template.md'
       - '.github/codex/prompts/refresh-agent-instructions.md'
       - '.github/workflows/agent-guidance-check.yml'
       - '.github/workflows/refresh-agent-instructions.yml'
       - 'scripts/ci/agent_guidance_budget.json'
+      - 'scripts/ci/validate_agent_setup.py'
       - 'scripts/ci/validate_agent_guidance.py'
       - 'scripts/ci/validate_documentation_boundaries.py'
+      - 'tests/scripts/test_validate_agent_setup.py'
       - 'tests/scripts/test_validate_agent_guidance.py'
   push:
     branches: [ main ]
@@ -25,16 +29,20 @@ on:
       - 'CLAUDE.md'
       - 'CONTRIBUTING.md'
       - '.agents/skills/**'
+      - '.codex/**'
       - '.github/copilot-instructions.md'
       - '.github/instructions/**'
       - '.github/skills/**'
+      - '.memory/**'
       - '.github/pull_request_template.md'
       - '.github/codex/prompts/refresh-agent-instructions.md'
       - '.github/workflows/agent-guidance-check.yml'
       - '.github/workflows/refresh-agent-instructions.yml'
       - 'scripts/ci/agent_guidance_budget.json'
+      - 'scripts/ci/validate_agent_setup.py'
       - 'scripts/ci/validate_agent_guidance.py'
       - 'scripts/ci/validate_documentation_boundaries.py'
+      - 'tests/scripts/test_validate_agent_setup.py'
       - 'tests/scripts/test_validate_agent_guidance.py'
   workflow_dispatch:
 
@@ -47,9 +55,14 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
       - name: Validate Agent Guidance
-        run: |
-          python3 scripts/ci/validate_agent_guidance.py
-          python3 scripts/ci/validate_documentation_boundaries.py
+        run: python3 scripts/ci/validate_agent_setup.py
       - name: Test Agent Guidance Validator
-        run: python3 -m unittest tests.scripts.test_validate_agent_guidance
+        run: >-
+          python3 -m unittest
+          tests.scripts.test_validate_agent_guidance
+          tests.scripts.test_validate_agent_setup

--- a/.github/workflows/refresh-agent-instructions.yml
+++ b/.github/workflows/refresh-agent-instructions.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - name: Audit Current Guidance
         id: audit
         shell: bash
@@ -38,7 +43,7 @@ jobs:
           REFRESH_REASON: ${{ inputs.reason }}
         run: |
           set +e
-          python3 scripts/ci/validate_agent_guidance.py --format json > .agent-guidance-audit.json
+          python3 scripts/ci/validate_agent_setup.py --format json > .agent-guidance-audit.json
           audit_status=$?
           set -e
 
@@ -80,9 +85,7 @@ jobs:
         run: rm -f .agent-guidance-audit.json .agent-guidance-refresh-request.md
 
       - name: Validate Final Guidance
-        run: |
-          python3 scripts/ci/validate_agent_guidance.py
-          python3 scripts/ci/validate_documentation_boundaries.py
+        run: python3 scripts/ci/validate_agent_setup.py
 
       - name: Check Changes and Enforce Allowlist
         id: changes
@@ -152,7 +155,7 @@ jobs:
             ${{ steps.changes.outputs.files }}
 
             ## Validation
-            - `python3 scripts/ci/validate_agent_guidance.py`
+            - `python3 scripts/ci/validate_agent_setup.py`
             - Paid AI review ran only because the audit found drift or
               `force_ai` was selected.
 

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,10 @@ __pycache__/
 /src/main/resources/examples/*/*/generate_allure_report.bat
 /src/test/resources/META-INF/services/
 /src/main/resources/examples/*/*/performanceReport/
+
+.memory/index/
+.memory/context/
+.memory/exports/
+.memory/recovery/
+.memory/.backup/
+.memory/.lock

--- a/.memory/config.json
+++ b/.memory/config.json
@@ -1,0 +1,15 @@
+{
+  "git": {
+    "trackContextPacks": false
+  },
+  "memory": {
+    "autoIndex": true,
+    "defaultTokenBudget": 600,
+    "saveContextPacks": false
+  },
+  "project": {
+    "id": "project.shaft-engine",
+    "name": "Shaft Engine"
+  },
+  "version": 4
+}

--- a/.memory/events.jsonl
+++ b/.memory/events.jsonl
@@ -1,0 +1,16 @@
+{"actor":"agent","event":"memory.created","id":"decision.agent-guidance-progressive-disclosure","timestamp":"2026-06-15T17:06:51+03:00"}
+{"actor":"agent","event":"memory.created","id":"constraint.paid-agent-work-audit-gated","timestamp":"2026-06-15T17:06:51+03:00"}
+{"actor":"agent","event":"memory.created","id":"decision.public-docs-external","timestamp":"2026-06-15T17:06:51+03:00"}
+{"actor":"agent","event":"memory.created","id":"decision.utf8-all-runtime-layers","timestamp":"2026-06-15T17:06:51+03:00"}
+{"actor":"agent","event":"memory.created","id":"gotcha.allure-result-population","timestamp":"2026-06-15T17:06:51+03:00"}
+{"actor":"agent","event":"memory.created","id":"gotcha.windows-allure-root-race","timestamp":"2026-06-15T17:06:51+03:00"}
+{"actor":"agent","event":"memory.created","id":"gotcha.testng-method-parallel-shared-instance-fields","timestamp":"2026-06-15T17:06:51+03:00"}
+{"actor":"agent","event":"memory.created","id":"gotcha.testng-single-threaded-static-state","timestamp":"2026-06-15T17:06:51+03:00"}
+{"actor":"agent","event":"memory.created","id":"gotcha.java25-isuite-mocking","timestamp":"2026-06-15T17:06:51+03:00"}
+{"actor":"agent","event":"memory.created","id":"gotcha.coverage-constructors-start-browser","timestamp":"2026-06-15T17:06:51+03:00"}
+{"actor":"agent","event":"memory.created","id":"decision.namespaced-video-capabilities","timestamp":"2026-06-15T17:06:51+03:00"}
+{"actor":"agent","event":"memory.created","id":"constraint.maven-central-version-immutability","timestamp":"2026-06-15T17:06:51+03:00"}
+{"actor":"agent","event":"memory.updated","id":"project.shaft-engine","timestamp":"2026-06-15T17:06:51+03:00"}
+{"actor":"agent","event":"memory.updated","id":"architecture.current","timestamp":"2026-06-15T17:06:51+03:00"}
+{"actor":"agent","event":"memory.updated","id":"decision.public-docs-external","timestamp":"2026-06-15T17:09:35+03:00"}
+{"actor":"agent","event":"memory.updated","id":"gotcha.testng-method-parallel-shared-instance-fields","timestamp":"2026-06-15T17:09:35+03:00"}

--- a/.memory/memory/architecture.json
+++ b/.memory/memory/architecture.json
@@ -1,0 +1,39 @@
+{
+  "body_path": "memory/architecture.md",
+  "content_hash": "sha256:ac915d5d5503ffb8d96ee46b023965a416d84e7f7687be9fadac7c70306455a5",
+  "created_at": "2026-06-15T16:59:56+03:00",
+  "evidence": [
+    {
+      "id": "pom.xml",
+      "kind": "file"
+    },
+    {
+      "id": "AGENTS.md",
+      "kind": "file"
+    }
+  ],
+  "facets": {
+    "applies_to": [
+      "pom.xml",
+      ".agents/skills/",
+      ".github/instructions/",
+      "scripts/ci/"
+    ],
+    "category": "architecture"
+  },
+  "id": "architecture.current",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "system"
+  },
+  "status": "active",
+  "tags": [],
+  "title": "Current Architecture",
+  "type": "architecture",
+  "updated_at": "2026-06-15T17:06:51+03:00"
+}

--- a/.memory/memory/architecture.md
+++ b/.memory/memory/architecture.md
@@ -1,0 +1,3 @@
+# Current Architecture
+
+The root Maven reactor coordinates the core shaft-engine module, optional feature modules, publication/compatibility modules, and deterministic scripts under scripts/ci. Agent guidance uses a compact global file, scoped Java rules, five progressively disclosed skills, and repository memory loaded only on demand.

--- a/.memory/memory/constraints/maven-central-version-immutability.json
+++ b/.memory/memory/constraints/maven-central-version-immutability.json
@@ -1,0 +1,46 @@
+{
+  "body_path": "memory/constraints/maven-central-version-immutability.md",
+  "content_hash": "sha256:3bb0b9f90e855414404bea035bffc664136a81b22ca8b1ac990313a46cab1edc",
+  "created_at": "2026-06-15T17:06:51+03:00",
+  "evidence": [
+    {
+      "id": "pom.xml",
+      "kind": "file"
+    },
+    {
+      "id": ".github/workflows/mavenCentral_cd.yml",
+      "kind": "file"
+    },
+    {
+      "id": "scripts/ci/verify_maven_central_release.py",
+      "kind": "file"
+    }
+  ],
+  "facets": {
+    "applies_to": [
+      "pom.xml",
+      ".github/workflows/mavenCentral_cd.yml"
+    ],
+    "category": "business-rule"
+  },
+  "id": "constraint.maven-central-version-immutability",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Seed durable SHAFT project memory from the retired high-signal ledger"
+  },
+  "status": "active",
+  "tags": [
+    "release",
+    "maven-central",
+    "versioning"
+  ],
+  "title": "Maven Central coordinates are immutable",
+  "type": "constraint",
+  "updated_at": "2026-06-15T17:06:51+03:00"
+}

--- a/.memory/memory/constraints/maven-central-version-immutability.md
+++ b/.memory/memory/constraints/maven-central-version-immutability.md
@@ -1,0 +1,1 @@
+A modular or relocation release cannot replace an existing coordinate version. Choose a version newer than the final monolithic release, wait for Central publication, and verify public artifacts plus canonical, combined-module, and legacy consumers before release announcements.

--- a/.memory/memory/constraints/paid-agent-work-audit-gated.json
+++ b/.memory/memory/constraints/paid-agent-work-audit-gated.json
@@ -1,0 +1,37 @@
+{
+  "body_path": "memory/constraints/paid-agent-work-audit-gated.md",
+  "content_hash": "sha256:7e9105c42c75a417bcc93d14aaa45acceb2994cba322906abf17c5016db546c8",
+  "created_at": "2026-06-15T17:06:51+03:00",
+  "evidence": [
+    {
+      "id": ".github/workflows/refresh-agent-instructions.yml",
+      "kind": "file"
+    }
+  ],
+  "facets": {
+    "applies_to": [
+      ".github/workflows/refresh-agent-instructions.yml"
+    ],
+    "category": "agent-guidance"
+  },
+  "id": "constraint.paid-agent-work-audit-gated",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Seed durable SHAFT project memory from the retired high-signal ledger"
+  },
+  "status": "active",
+  "tags": [
+    "agents",
+    "cost",
+    "ci"
+  ],
+  "title": "Gate paid agent refresh behind deterministic audit",
+  "type": "constraint",
+  "updated_at": "2026-06-15T17:06:51+03:00"
+}

--- a/.memory/memory/constraints/paid-agent-work-audit-gated.md
+++ b/.memory/memory/constraints/paid-agent-work-audit-gated.md
@@ -1,0 +1,1 @@
+Agent-instruction refresh is manual. Run deterministic validation first and invoke the paid Codex action only when validation finds drift or a maintainer explicitly forces review.

--- a/.memory/memory/decisions/agent-guidance-progressive-disclosure.json
+++ b/.memory/memory/decisions/agent-guidance-progressive-disclosure.json
@@ -1,0 +1,44 @@
+{
+  "body_path": "memory/decisions/agent-guidance-progressive-disclosure.md",
+  "content_hash": "sha256:b80a257f34df4e8931e9316109043fc889dd5b90cf98bbbb508c7551faad4f53",
+  "created_at": "2026-06-15T17:06:51+03:00",
+  "evidence": [
+    {
+      "id": "AGENTS.md",
+      "kind": "file"
+    },
+    {
+      "id": "scripts/ci/validate_agent_guidance.py",
+      "kind": "file"
+    }
+  ],
+  "facets": {
+    "applies_to": [
+      "AGENTS.md",
+      ".agents/skills/",
+      ".github/instructions/",
+      ".github/skills/"
+    ],
+    "category": "decision-rationale"
+  },
+  "id": "decision.agent-guidance-progressive-disclosure",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Seed durable SHAFT project memory from the retired high-signal ledger"
+  },
+  "status": "active",
+  "tags": [
+    "agents",
+    "tokens",
+    "guidance"
+  ],
+  "title": "Use progressive disclosure for agent guidance",
+  "type": "decision",
+  "updated_at": "2026-06-15T17:06:51+03:00"
+}

--- a/.memory/memory/decisions/agent-guidance-progressive-disclosure.md
+++ b/.memory/memory/decisions/agent-guidance-progressive-disclosure.md
@@ -1,0 +1,1 @@
+Keep global guidance compact. Route task-specific rules through exactly five thin Codex bridge skills to canonical scoped rules or playbooks. Deterministic validators enforce budgets, routing, and duplicate-content limits.

--- a/.memory/memory/decisions/namespaced-video-capabilities.json
+++ b/.memory/memory/decisions/namespaced-video-capabilities.json
@@ -1,0 +1,41 @@
+{
+  "body_path": "memory/decisions/namespaced-video-capabilities.md",
+  "content_hash": "sha256:a15a6d5758b7aec26a976118de8a5a3c60229da2431a0c962cbcd9e4a6695898",
+  "created_at": "2026-06-15T17:06:51+03:00",
+  "evidence": [
+    {
+      "id": "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java",
+      "kind": "file"
+    },
+    {
+      "id": "shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/OptionsManagerCoverageUnitTest.java",
+      "kind": "file"
+    }
+  ],
+  "facets": {
+    "applies_to": [
+      "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java"
+    ],
+    "category": "decision-rationale"
+  },
+  "id": "decision.namespaced-video-capabilities",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Seed durable SHAFT project memory from the retired high-signal ledger"
+  },
+  "status": "active",
+  "tags": [
+    "webdriver",
+    "capabilities",
+    "grid"
+  ],
+  "title": "Keep remote video capabilities namespaced",
+  "type": "decision",
+  "updated_at": "2026-06-15T17:06:51+03:00"
+}

--- a/.memory/memory/decisions/namespaced-video-capabilities.md
+++ b/.memory/memory/decisions/namespaced-video-capabilities.md
@@ -1,0 +1,1 @@
+Never emit top-level enableVideo. Merge video settings into existing provider maps such as selenoid:options, moon:options, or se:recordVideo without overwriting unrelated provider keys.

--- a/.memory/memory/decisions/public-docs-external.json
+++ b/.memory/memory/decisions/public-docs-external.json
@@ -1,0 +1,41 @@
+{
+  "body_path": "memory/decisions/public-docs-external.md",
+  "content_hash": "sha256:0a3bf097f1086ea09554798e1fab5ef634b6d443b8ef0cd72801ea66986ce86f",
+  "created_at": "2026-06-15T17:06:51+03:00",
+  "evidence": [
+    {
+      "id": "scripts/ci/validate_documentation_boundaries.py",
+      "kind": "file"
+    },
+    {
+      "id": "README.md",
+      "kind": "file"
+    }
+  ],
+  "facets": {
+    "applies_to": [
+      "README.md",
+      "scripts/ci/validate_documentation_boundaries.py"
+    ],
+    "category": "decision-rationale"
+  },
+  "id": "decision.public-docs-external",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Seed durable SHAFT project memory from the retired high-signal ledger"
+  },
+  "status": "active",
+  "tags": [
+    "documentation",
+    "repository"
+  ],
+  "title": "Keep public documentation outside the engine repository",
+  "type": "decision",
+  "updated_at": "2026-06-15T17:09:35+03:00"
+}

--- a/.memory/memory/decisions/public-docs-external.md
+++ b/.memory/memory/decisions/public-docs-external.md
@@ -1,0 +1,1 @@
+Public product and maintainer documentation is maintained outside the engine repository and served at https://shaftengine.netlify.app. This repository keeps only operational guidance and its root landing page.

--- a/.memory/memory/decisions/utf8-all-runtime-layers.json
+++ b/.memory/memory/decisions/utf8-all-runtime-layers.json
@@ -1,0 +1,51 @@
+{
+  "body_path": "memory/decisions/utf8-all-runtime-layers.md",
+  "content_hash": "sha256:1fd9ff7785003ca48296f72da34bd5826b3f98abb5052e47b46ba7edd9b5fffd",
+  "created_at": "2026-06-15T17:06:51+03:00",
+  "evidence": [
+    {
+      "id": "pom.xml",
+      "kind": "file"
+    },
+    {
+      "id": ".mvn/jvm.config",
+      "kind": "file"
+    },
+    {
+      "id": ".github/actions/setup-test-env/action.yml",
+      "kind": "file"
+    },
+    {
+      "id": "shaft-engine/src/test/java/testPackage/properties/Log4jTests.java",
+      "kind": "file"
+    }
+  ],
+  "facets": {
+    "applies_to": [
+      "pom.xml",
+      ".mvn/jvm.config",
+      ".github/actions/setup-test-env/action.yml"
+    ],
+    "category": "decision-rationale"
+  },
+  "id": "decision.utf8-all-runtime-layers",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Seed durable SHAFT project memory from the retired high-signal ledger"
+  },
+  "status": "active",
+  "tags": [
+    "encoding",
+    "ci",
+    "maven"
+  ],
+  "title": "Enforce UTF-8 at every runtime layer",
+  "type": "decision",
+  "updated_at": "2026-06-15T17:06:51+03:00"
+}

--- a/.memory/memory/decisions/utf8-all-runtime-layers.md
+++ b/.memory/memory/decisions/utf8-all-runtime-layers.md
@@ -1,0 +1,1 @@
+Cross-host Unicode correctness requires explicit UTF-8 configuration for the Maven JVM, forked test JVMs, and CI job environment; host defaults are insufficient.

--- a/.memory/memory/gotchas/allure-result-population.json
+++ b/.memory/memory/gotchas/allure-result-population.json
@@ -1,0 +1,38 @@
+{
+  "body_path": "memory/gotchas/allure-result-population.md",
+  "content_hash": "sha256:d355e81badf55d66bc1a6758da2f809a3b33ae2b745746c232f10bc904463599",
+  "created_at": "2026-06-15T17:06:51+03:00",
+  "evidence": [
+    {
+      "id": ".github/skills/ci-failure-investigator/SKILL.md",
+      "kind": "file"
+    }
+  ],
+  "facets": {
+    "applies_to": [
+      "allure-results/",
+      ".github/skills/ci-failure-investigator/SKILL.md"
+    ],
+    "category": "gotcha"
+  },
+  "id": "gotcha.allure-result-population",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Seed durable SHAFT project memory from the retired high-signal ledger"
+  },
+  "status": "active",
+  "tags": [
+    "allure",
+    "ci",
+    "debugging"
+  ],
+  "title": "Verify Allure results are populated before trusting status",
+  "type": "gotcha",
+  "updated_at": "2026-06-15T17:06:51+03:00"
+}

--- a/.memory/memory/gotchas/allure-result-population.md
+++ b/.memory/memory/gotchas/allure-result-population.md
@@ -1,0 +1,1 @@
+An empty or unexpectedly small Allure report invalidates verdict analysis. Count result JSON or executed tests first, and inspect failed, broken, retried, and skipped attempts when the final summary hides an intermittent failure.

--- a/.memory/memory/gotchas/coverage-constructors-start-browser.json
+++ b/.memory/memory/gotchas/coverage-constructors-start-browser.json
@@ -1,0 +1,37 @@
+{
+  "body_path": "memory/gotchas/coverage-constructors-start-browser.md",
+  "content_hash": "sha256:2719439b098c4d95f96c68871cd432086d8817ec56c7b1600716d88ca56a1670",
+  "created_at": "2026-06-15T17:06:51+03:00",
+  "evidence": [
+    {
+      "id": "shaft-engine/src/test/java/testPackage/unitTests/ElementActionsCoverageUnitTest.java",
+      "kind": "file"
+    }
+  ],
+  "facets": {
+    "applies_to": [
+      "shaft-engine/src/test/java/testPackage/unitTests/ElementActionsCoverageUnitTest.java"
+    ],
+    "category": "gotcha"
+  },
+  "id": "gotcha.coverage-constructors-start-browser",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Seed durable SHAFT project memory from the retired high-signal ledger"
+  },
+  "status": "active",
+  "tags": [
+    "coverage",
+    "webdriver",
+    "unit-tests"
+  ],
+  "title": "Coverage constructors can start real browser sessions",
+  "type": "gotcha",
+  "updated_at": "2026-06-15T17:06:51+03:00"
+}

--- a/.memory/memory/gotchas/coverage-constructors-start-browser.md
+++ b/.memory/memory/gotchas/coverage-constructors-start-browser.md
@@ -1,0 +1,1 @@
+Coverage-only unit tests must not call facade or default constructors that route through the driver factory. Use explicit mock-backed constructors and reserve session creation for integration tests.

--- a/.memory/memory/gotchas/java25-isuite-mocking.json
+++ b/.memory/memory/gotchas/java25-isuite-mocking.json
@@ -1,0 +1,41 @@
+{
+  "body_path": "memory/gotchas/java25-isuite-mocking.md",
+  "content_hash": "sha256:9e368b7d4687941f42c52f2f717403cdc1f681dd5ebbbf5e22eba1ceaf8dd7a4",
+  "created_at": "2026-06-15T17:06:51+03:00",
+  "evidence": [
+    {
+      "id": "shaft-engine/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java",
+      "kind": "file"
+    },
+    {
+      "id": "shaft-engine/src/test/java/testPackage/unitTests/TestNGListenerHelperCoverageUnitTest.java",
+      "kind": "file"
+    }
+  ],
+  "facets": {
+    "applies_to": [
+      "shaft-engine/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java"
+    ],
+    "category": "gotcha"
+  },
+  "id": "gotcha.java25-isuite-mocking",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Seed durable SHAFT project memory from the retired high-signal ledger"
+  },
+  "status": "active",
+  "tags": [
+    "java25",
+    "testng",
+    "mocking"
+  ],
+  "title": "Avoid mocking TestNG ISuite on Java 25",
+  "type": "gotcha",
+  "updated_at": "2026-06-15T17:06:51+03:00"
+}

--- a/.memory/memory/gotchas/java25-isuite-mocking.md
+++ b/.memory/memory/gotchas/java25-isuite-mocking.md
@@ -1,0 +1,1 @@
+Mockito or proxy paths touching org.testng.ISuite can pull optional Guice types and fail on Java 25. Extract list/value helper logic and test it directly when suite behavior is not the subject.

--- a/.memory/memory/gotchas/testng-method-parallel-shared-instance-fields.json
+++ b/.memory/memory/gotchas/testng-method-parallel-shared-instance-fields.json
@@ -1,0 +1,38 @@
+{
+  "body_path": "memory/gotchas/testng-method-parallel-shared-instance-fields.md",
+  "content_hash": "sha256:04f6ba1f3c1948755d426e4e2e917efde8570a3cffc89e23b05e150145d823c2",
+  "created_at": "2026-06-15T17:06:51+03:00",
+  "evidence": [
+    {
+      "id": "shaft-visual/src/test/java/testPackage/unitTests/ImageProcessingActionsUnitTest.java",
+      "kind": "file"
+    }
+  ],
+  "facets": {
+    "applies_to": [
+      "shaft-engine/src/test/java/",
+      "shaft-visual/src/test/java/"
+    ],
+    "category": "gotcha"
+  },
+  "id": "gotcha.testng-method-parallel-shared-instance-fields",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Seed durable SHAFT project memory from the retired high-signal ledger"
+  },
+  "status": "active",
+  "tags": [
+    "testng",
+    "parallelism",
+    "isolation"
+  ],
+  "title": "TestNG method parallelism shares instance fields",
+  "type": "gotcha",
+  "updated_at": "2026-06-15T17:09:35+03:00"
+}

--- a/.memory/memory/gotchas/testng-method-parallel-shared-instance-fields.md
+++ b/.memory/memory/gotchas/testng-method-parallel-shared-instance-fields.md
@@ -1,0 +1,1 @@
+Concurrent methods in one TestNG instance share ordinary fields. Per-method paths, files, mocks, and drivers must use locals or ThreadLocal, and cleanup must use the same thread-owned state.

--- a/.memory/memory/gotchas/testng-single-threaded-static-state.json
+++ b/.memory/memory/gotchas/testng-single-threaded-static-state.json
@@ -1,0 +1,41 @@
+{
+  "body_path": "memory/gotchas/testng-single-threaded-static-state.md",
+  "content_hash": "sha256:96185473680f4ec6117279b2bcba84b31ad9dd38b41eebd882b7cb2848e2a9e5",
+  "created_at": "2026-06-15T17:06:51+03:00",
+  "evidence": [
+    {
+      "id": "shaft-engine/src/test/java/testPackage/unitTests/RealtimeReporterTestLock.java",
+      "kind": "file"
+    },
+    {
+      "id": "shaft-engine/src/test/java/testPackage/unitTests/RealtimeReporterServerUnitTest.java",
+      "kind": "file"
+    }
+  ],
+  "facets": {
+    "applies_to": [
+      "shaft-engine/src/test/java/testPackage/unitTests/RealtimeReporter*"
+    ],
+    "category": "gotcha"
+  },
+  "id": "gotcha.testng-single-threaded-static-state",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Seed durable SHAFT project memory from the retired high-signal ledger"
+  },
+  "status": "active",
+  "tags": [
+    "testng",
+    "parallelism",
+    "static-state"
+  ],
+  "title": "TestNG singleThreaded does not isolate static state",
+  "type": "gotcha",
+  "updated_at": "2026-06-15T17:06:51+03:00"
+}

--- a/.memory/memory/gotchas/testng-single-threaded-static-state.md
+++ b/.memory/memory/gotchas/testng-single-threaded-static-state.md
@@ -1,0 +1,1 @@
+TestNG singleThreaded serializes methods in one class only. Static services shared across classes need an explicit cross-class lock, readiness checks where applicable, and always-run restoration.

--- a/.memory/memory/gotchas/windows-allure-root-race.json
+++ b/.memory/memory/gotchas/windows-allure-root-race.json
@@ -1,0 +1,41 @@
+{
+  "body_path": "memory/gotchas/windows-allure-root-race.md",
+  "content_hash": "sha256:f3c9162ed5ef97d6904288d3cb97c3a773664ee25e8ddd95cc850f71d0fcde9f",
+  "created_at": "2026-06-15T17:06:51+03:00",
+  "evidence": [
+    {
+      "id": "shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java",
+      "kind": "file"
+    },
+    {
+      "id": "shaft-engine/src/test/java/testPackage/unitTests/AllureManagerUnitTest.java",
+      "kind": "file"
+    }
+  ],
+  "facets": {
+    "applies_to": [
+      "shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java"
+    ],
+    "category": "gotcha"
+  },
+  "id": "gotcha.windows-allure-root-race",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Seed durable SHAFT project memory from the retired high-signal ledger"
+  },
+  "status": "active",
+  "tags": [
+    "allure",
+    "windows",
+    "concurrency"
+  ],
+  "title": "Preserve the Allure results root on Windows",
+  "type": "gotcha",
+  "updated_at": "2026-06-15T17:06:51+03:00"
+}

--- a/.memory/memory/gotchas/windows-allure-root-race.md
+++ b/.memory/memory/gotchas/windows-allure-root-race.md
@@ -1,0 +1,1 @@
+Deleting and recreating the live allure-results root can race with Allure writers on Windows and surface as FileAlreadyExistsException. Delete only its contents while preserving the directory.

--- a/.memory/memory/project.json
+++ b/.memory/memory/project.json
@@ -1,0 +1,38 @@
+{
+  "body_path": "memory/project.md",
+  "content_hash": "sha256:d9aadaf26e9c94aa7121399bdf534b300c2869cd25ae00ff20a5691f314b0227",
+  "created_at": "2026-06-15T16:59:56+03:00",
+  "evidence": [
+    {
+      "id": "pom.xml",
+      "kind": "file"
+    },
+    {
+      "id": "AGENTS.md",
+      "kind": "file"
+    }
+  ],
+  "facets": {
+    "applies_to": [
+      "pom.xml",
+      "shaft-engine/",
+      "scripts/ci/"
+    ],
+    "category": "project-description"
+  },
+  "id": "project.shaft-engine",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "system"
+  },
+  "status": "active",
+  "tags": [],
+  "title": "SHAFT Engine",
+  "type": "project",
+  "updated_at": "2026-06-15T17:06:51+03:00"
+}

--- a/.memory/memory/project.md
+++ b/.memory/memory/project.md
@@ -1,0 +1,3 @@
+# SHAFT Engine
+
+Java 25 multi-module test-automation framework published through Maven Central. The core framework is in shaft-engine; optional, tooling, compatibility, BOM, and reporting modules live in sibling directories. Executable configuration and current code override memory.

--- a/.memory/relations/project-shaft-engine-related-to-architecture-current.json
+++ b/.memory/relations/project-shaft-engine-related-to-architecture-current.json
@@ -1,0 +1,21 @@
+{
+  "confidence": "high",
+  "content_hash": "sha256:b41ba6f6f01a2ef1763c1972617565a580280978298b2b2f930fff4197215f69",
+  "created_at": "2026-06-15T16:59:56+03:00",
+  "evidence": [
+    {
+      "id": "project.shaft-engine",
+      "kind": "memory"
+    },
+    {
+      "id": "architecture.current",
+      "kind": "memory"
+    }
+  ],
+  "from": "project.shaft-engine",
+  "id": "rel.project-shaft-engine-related-to-architecture-current",
+  "predicate": "related_to",
+  "status": "active",
+  "to": "architecture.current",
+  "updated_at": "2026-06-15T16:59:56+03:00"
+}

--- a/.memory/schema/config.schema.json
+++ b/.memory/schema/config.schema.json
@@ -1,0 +1,74 @@
+{
+  "$id": "https://aictx.dev/schemas/v4/config.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "git": {
+      "additionalProperties": false,
+      "properties": {
+        "trackContextPacks": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "trackContextPacks"
+      ],
+      "type": "object"
+    },
+    "memory": {
+      "additionalProperties": false,
+      "properties": {
+        "autoIndex": {
+          "type": "boolean"
+        },
+        "defaultTokenBudget": {
+          "maximum": 50000,
+          "minimum": 501,
+          "type": "integer"
+        },
+        "saveContextPacks": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "defaultTokenBudget",
+        "autoIndex",
+        "saveContextPacks"
+      ],
+      "type": "object"
+    },
+    "project": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "pattern": "^project\\.[a-z0-9][a-z0-9-]*$",
+          "type": "string"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name"
+      ],
+      "type": "object"
+    },
+    "version": {
+      "enum": [
+        1,
+        2,
+        3,
+        4
+      ]
+    }
+  },
+  "required": [
+    "version",
+    "project",
+    "memory",
+    "git"
+  ],
+  "type": "object"
+}

--- a/.memory/schema/event.schema.json
+++ b/.memory/schema/event.schema.json
@@ -1,0 +1,84 @@
+{
+  "$id": "https://aictx.dev/schemas/v4/event.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "event": {
+            "pattern": "^memory\\."
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "id"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "event": {
+            "pattern": "^relation\\."
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "relation_id"
+        ]
+      }
+    }
+  ],
+  "properties": {
+    "actor": {
+      "enum": [
+        "agent",
+        "user",
+        "cli",
+        "mcp",
+        "system"
+      ]
+    },
+    "event": {
+      "enum": [
+        "memory.created",
+        "memory.updated",
+        "memory.marked_stale",
+        "memory.superseded",
+        "memory.deleted",
+        "relation.created",
+        "relation.updated",
+        "relation.deleted",
+        "index.rebuilt",
+        "context.generated"
+      ]
+    },
+    "id": {
+      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$",
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    },
+    "reason": {
+      "type": "string"
+    },
+    "relation_id": {
+      "pattern": "^rel\\.[a-z0-9][a-z0-9-]*$",
+      "type": "string"
+    },
+    "timestamp": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "event",
+    "actor",
+    "timestamp"
+  ],
+  "type": "object"
+}

--- a/.memory/schema/object.schema.json
+++ b/.memory/schema/object.schema.json
@@ -1,0 +1,296 @@
+{
+  "$id": "https://aictx.dev/schemas/v4/object.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "else": {
+        "properties": {
+          "status": {
+            "enum": [
+              "active",
+              "stale",
+              "superseded"
+            ]
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "type": {
+            "const": "question"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "status": {
+            "enum": [
+              "stale",
+              "superseded",
+              "open",
+              "closed"
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "properties": {
+    "body_path": {
+      "pattern": "^memory\\/.+\\.md$",
+      "type": "string"
+    },
+    "content_hash": {
+      "pattern": "^sha256:[a-f0-9]{64}$",
+      "type": "string"
+    },
+    "created_at": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$",
+      "type": "string"
+    },
+    "evidence": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "memory",
+              "relation",
+              "file",
+              "commit",
+              "task",
+              "source"
+            ]
+          }
+        },
+        "required": [
+          "kind",
+          "id"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "facets": {
+      "additionalProperties": false,
+      "properties": {
+        "applies_to": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "category": {
+          "enum": [
+            "project-description",
+            "architecture",
+            "stack",
+            "convention",
+            "file-layout",
+            "product-feature",
+            "testing",
+            "decision-rationale",
+            "abandoned-attempt",
+            "workflow",
+            "gotcha",
+            "debugging-fact",
+            "source",
+            "product-intent",
+            "feature-map",
+            "roadmap",
+            "agent-guidance",
+            "concept",
+            "open-question",
+            "domain",
+            "bounded-context",
+            "capability",
+            "business-rule",
+            "unresolved-conflict"
+          ]
+        },
+        "load_modes": {
+          "items": {
+            "enum": [
+              "coding",
+              "debugging",
+              "review",
+              "architecture",
+              "onboarding"
+            ]
+          },
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "category"
+      ],
+      "type": "object"
+    },
+    "id": {
+      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$",
+      "type": "string"
+    },
+    "origin": {
+      "additionalProperties": false,
+      "properties": {
+        "captured_at": {
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$",
+          "type": "string"
+        },
+        "digest": {
+          "pattern": "^sha256:[a-f0-9]{64}$",
+          "type": "string"
+        },
+        "kind": {
+          "enum": [
+            "file",
+            "url",
+            "user",
+            "external"
+          ]
+        },
+        "locator": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "media_type": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "locator"
+      ],
+      "type": "object"
+    },
+    "scope": {
+      "additionalProperties": false,
+      "properties": {
+        "branch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "kind": {
+          "enum": [
+            "project",
+            "branch",
+            "task"
+          ]
+        },
+        "project": {
+          "pattern": "^project\\.[a-z0-9][a-z0-9-]*$",
+          "type": "string"
+        },
+        "task": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "kind",
+        "project",
+        "branch",
+        "task"
+      ],
+      "type": "object"
+    },
+    "source": {
+      "additionalProperties": false,
+      "properties": {
+        "commit": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "kind": {
+          "enum": [
+            "agent",
+            "user",
+            "cli",
+            "mcp",
+            "system"
+          ]
+        },
+        "task": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    "status": {
+      "enum": [
+        "active",
+        "stale",
+        "superseded",
+        "open",
+        "closed"
+      ]
+    },
+    "superseded_by": {
+      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "tags": {
+      "items": {
+        "pattern": "^[a-z0-9][a-z0-9-]*$",
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "title": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "type": {
+      "enum": [
+        "project",
+        "architecture",
+        "source",
+        "synthesis",
+        "decision",
+        "constraint",
+        "question",
+        "fact",
+        "gotcha",
+        "workflow",
+        "note",
+        "concept"
+      ]
+    },
+    "updated_at": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "type",
+    "status",
+    "title",
+    "body_path",
+    "scope",
+    "content_hash",
+    "created_at",
+    "updated_at"
+  ],
+  "type": "object"
+}

--- a/.memory/schema/patch.schema.json
+++ b/.memory/schema/patch.schema.json
@@ -1,0 +1,558 @@
+{
+  "$defs": {
+    "createObject": {
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidence"
+        },
+        "facets": {
+          "$ref": "#/$defs/facets"
+        },
+        "id": {
+          "$ref": "#/$defs/objectId"
+        },
+        "op": {
+          "const": "create_object"
+        },
+        "origin": {
+          "$ref": "#/$defs/origin"
+        },
+        "scope": {
+          "$ref": "#/$defs/scope"
+        },
+        "source": {
+          "$ref": "#/$defs/source"
+        },
+        "status": {
+          "enum": [
+            "active",
+            "stale",
+            "superseded",
+            "open",
+            "closed"
+          ]
+        },
+        "tags": {
+          "$ref": "#/$defs/tags"
+        },
+        "title": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "project",
+            "architecture",
+            "source",
+            "synthesis",
+            "decision",
+            "constraint",
+            "question",
+            "fact",
+            "gotcha",
+            "workflow",
+            "note",
+            "concept"
+          ]
+        }
+      },
+      "required": [
+        "op",
+        "type",
+        "title",
+        "body"
+      ],
+      "type": "object"
+    },
+    "createRelation": {
+      "additionalProperties": false,
+      "properties": {
+        "confidence": {
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidence"
+        },
+        "from": {
+          "$ref": "#/$defs/objectId"
+        },
+        "id": {
+          "$ref": "#/$defs/relationId"
+        },
+        "op": {
+          "const": "create_relation"
+        },
+        "predicate": {
+          "enum": [
+            "affects",
+            "requires",
+            "depends_on",
+            "supersedes",
+            "conflicts_with",
+            "supports",
+            "challenges",
+            "derived_from",
+            "summarizes",
+            "documents",
+            "mentions",
+            "implements",
+            "related_to"
+          ]
+        },
+        "status": {
+          "enum": [
+            "active",
+            "stale",
+            "rejected"
+          ]
+        },
+        "to": {
+          "$ref": "#/$defs/objectId"
+        }
+      },
+      "required": [
+        "op",
+        "from",
+        "predicate",
+        "to"
+      ],
+      "type": "object"
+    },
+    "deleteObject": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/objectId"
+        },
+        "op": {
+          "const": "delete_object"
+        }
+      },
+      "required": [
+        "op",
+        "id"
+      ],
+      "type": "object"
+    },
+    "deleteRelation": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/relationId"
+        },
+        "op": {
+          "const": "delete_relation"
+        }
+      },
+      "required": [
+        "op",
+        "id"
+      ],
+      "type": "object"
+    },
+    "evidence": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "memory",
+              "relation",
+              "file",
+              "commit",
+              "task",
+              "source"
+            ]
+          }
+        },
+        "required": [
+          "kind",
+          "id"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "facets": {
+      "additionalProperties": false,
+      "properties": {
+        "applies_to": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "category": {
+          "enum": [
+            "project-description",
+            "architecture",
+            "stack",
+            "convention",
+            "file-layout",
+            "product-feature",
+            "testing",
+            "decision-rationale",
+            "abandoned-attempt",
+            "workflow",
+            "gotcha",
+            "debugging-fact",
+            "source",
+            "product-intent",
+            "feature-map",
+            "roadmap",
+            "agent-guidance",
+            "concept",
+            "open-question",
+            "domain",
+            "bounded-context",
+            "capability",
+            "business-rule",
+            "unresolved-conflict"
+          ]
+        },
+        "load_modes": {
+          "items": {
+            "enum": [
+              "coding",
+              "debugging",
+              "review",
+              "architecture",
+              "onboarding"
+            ]
+          },
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "category"
+      ],
+      "type": "object"
+    },
+    "markStale": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/objectId"
+        },
+        "op": {
+          "const": "mark_stale"
+        },
+        "reason": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "op",
+        "id",
+        "reason"
+      ],
+      "type": "object"
+    },
+    "objectId": {
+      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$",
+      "type": "string"
+    },
+    "origin": {
+      "additionalProperties": false,
+      "properties": {
+        "captured_at": {
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$",
+          "type": "string"
+        },
+        "digest": {
+          "pattern": "^sha256:[a-f0-9]{64}$",
+          "type": "string"
+        },
+        "kind": {
+          "enum": [
+            "file",
+            "url",
+            "user",
+            "external"
+          ]
+        },
+        "locator": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "media_type": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "locator"
+      ],
+      "type": "object"
+    },
+    "relationId": {
+      "pattern": "^rel\\.[a-z0-9][a-z0-9-]*$",
+      "type": "string"
+    },
+    "scope": {
+      "additionalProperties": false,
+      "properties": {
+        "branch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "kind": {
+          "enum": [
+            "project",
+            "branch",
+            "task"
+          ]
+        },
+        "project": {
+          "pattern": "^project\\.[a-z0-9][a-z0-9-]*$",
+          "type": "string"
+        },
+        "task": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "kind",
+        "project",
+        "branch",
+        "task"
+      ],
+      "type": "object"
+    },
+    "source": {
+      "additionalProperties": false,
+      "properties": {
+        "commit": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "kind": {
+          "enum": [
+            "agent",
+            "user",
+            "cli",
+            "mcp",
+            "system"
+          ]
+        },
+        "task": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    "supersedeObject": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/objectId"
+        },
+        "op": {
+          "const": "supersede_object"
+        },
+        "reason": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "superseded_by": {
+          "$ref": "#/$defs/objectId"
+        }
+      },
+      "required": [
+        "op",
+        "id",
+        "superseded_by",
+        "reason"
+      ],
+      "type": "object"
+    },
+    "tags": {
+      "items": {
+        "pattern": "^[a-z0-9][a-z0-9-]*$",
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "updateObject": {
+      "additionalProperties": false,
+      "properties": {
+        "body": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidence"
+        },
+        "facets": {
+          "$ref": "#/$defs/facets"
+        },
+        "id": {
+          "$ref": "#/$defs/objectId"
+        },
+        "op": {
+          "const": "update_object"
+        },
+        "origin": {
+          "$ref": "#/$defs/origin"
+        },
+        "scope": {
+          "$ref": "#/$defs/scope"
+        },
+        "source": {
+          "$ref": "#/$defs/source"
+        },
+        "status": {
+          "enum": [
+            "active",
+            "stale",
+            "superseded",
+            "open",
+            "closed"
+          ]
+        },
+        "superseded_by": {
+          "$ref": "#/$defs/objectId"
+        },
+        "tags": {
+          "$ref": "#/$defs/tags"
+        },
+        "title": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "op",
+        "id"
+      ],
+      "type": "object"
+    },
+    "updateRelation": {
+      "additionalProperties": false,
+      "properties": {
+        "confidence": {
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidence"
+        },
+        "id": {
+          "$ref": "#/$defs/relationId"
+        },
+        "op": {
+          "const": "update_relation"
+        },
+        "status": {
+          "enum": [
+            "active",
+            "stale",
+            "rejected"
+          ]
+        }
+      },
+      "required": [
+        "op",
+        "id"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://aictx.dev/schemas/v4/patch.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "changes": {
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/$defs/createObject"
+          },
+          {
+            "$ref": "#/$defs/updateObject"
+          },
+          {
+            "$ref": "#/$defs/markStale"
+          },
+          {
+            "$ref": "#/$defs/supersedeObject"
+          },
+          {
+            "$ref": "#/$defs/deleteObject"
+          },
+          {
+            "$ref": "#/$defs/createRelation"
+          },
+          {
+            "$ref": "#/$defs/updateRelation"
+          },
+          {
+            "$ref": "#/$defs/deleteRelation"
+          }
+        ]
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "source": {
+      "additionalProperties": false,
+      "properties": {
+        "commit": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "kind": {
+          "enum": [
+            "agent",
+            "user",
+            "cli",
+            "mcp",
+            "system"
+          ]
+        },
+        "task": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "source",
+    "changes"
+  ],
+  "type": "object"
+}

--- a/.memory/schema/relation.schema.json
+++ b/.memory/schema/relation.schema.json
@@ -1,0 +1,99 @@
+{
+  "$id": "https://aictx.dev/schemas/v4/relation.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "confidence": {
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    "content_hash": {
+      "pattern": "^sha256:[a-f0-9]{64}$",
+      "type": "string"
+    },
+    "created_at": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$",
+      "type": "string"
+    },
+    "evidence": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "memory",
+              "relation",
+              "file",
+              "commit",
+              "task",
+              "source"
+            ]
+          }
+        },
+        "required": [
+          "kind",
+          "id"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "from": {
+      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$",
+      "type": "string"
+    },
+    "id": {
+      "pattern": "^rel\\.[a-z0-9][a-z0-9-]*$",
+      "type": "string"
+    },
+    "predicate": {
+      "enum": [
+        "affects",
+        "requires",
+        "depends_on",
+        "supersedes",
+        "conflicts_with",
+        "supports",
+        "challenges",
+        "derived_from",
+        "summarizes",
+        "documents",
+        "mentions",
+        "implements",
+        "related_to"
+      ]
+    },
+    "status": {
+      "enum": [
+        "active",
+        "stale",
+        "rejected"
+      ]
+    },
+    "to": {
+      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$",
+      "type": "string"
+    },
+    "updated_at": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "from",
+    "predicate",
+    "to",
+    "status",
+    "created_at",
+    "updated_at"
+  ],
+  "type": "object"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,88 +2,71 @@
 
 ## Repository
 
-SHAFT_ENGINE is a Maven-published Java 25 test-automation framework.
-Executable configuration (`pom.xml`, `.java-version`, `.sdkmanrc`,
-`.mvn/jvm.config`, and workflows) overrides prose.
+SHAFT_ENGINE is a Maven-published Java 25 automation framework.
+Executable configuration overrides prose.
 
-Key locations:
+`shaft-engine/` is the core module; sibling `shaft-*` directories contain
+optional or publication modules. Deterministic tools live in `scripts/ci/`.
+Canonical docs are at `https://shaftengine.netlify.app`.
 
-- `shaft-engine/`: core framework, tests, resources, and compatibility artifact.
-- `shaft-browserstack/`, `shaft-video/`, `shaft-visual/`: optional modules.
-- `shaft-bom/`, `legacy-shaft-engine/`, `report-aggregate/`: publication modules.
-- `scripts/ci/`: deterministic validators and report tools.
-- `https://shaftengine.netlify.app`: canonical product and maintainer docs,
-  sourced from `ShaftHQ/shafthq.github.io`.
-
-Start with the user goal and directly relevant files. Prefer `rg`, targeted
-excerpts, structured parsers, and existing local scripts. Expand context only
-to resolve a concrete uncertainty, and reuse valid command evidence.
+Start from the goal and relevant files. Prefer `rg`, targeted excerpts,
+structured parsers and scripts. Expand context only for a concrete uncertainty.
 
 ## Routing
 
-Codex discovers task guidance in `.agents/skills/`. Load only the matching
-skill:
+Load only the matching `.agents/skills/` workflow:
 
 - Production Java: `framework-source-rules`
 - Test Java: `java-test-rules`
-- CI failures: `ci-failure-investigator`
-- Flaky tests: `flaky-test-stabilizer`
-- Releases or dependency currency: `release-dependency-guard`
+- CI or Allure failure: `ci-failure-investigator`
+- Intermittent test: `flaky-test-stabilizer`
+- Release or dependency work: `release-dependency-guard`
 
-The bridge skills point to canonical rules under `.github/instructions/` and
-`.github/skills/`; do not preload or duplicate those bodies.
+Bridge skills point to canonical `.github/` rules; do not preload them.
 
 ## Working Rules
 
-- Read before editing, follow existing patterns, and keep changes focused.
-- Preserve user changes in a dirty worktree. Never revert unrelated work.
+- Read before editing, follow existing patterns, keep changes focused, and
+  preserve unrelated user work.
 - Use structured APIs for XML, JSON, YAML, and other structured data.
-- Reproduce bugs and add focused regression coverage when practical.
-- Public documentation lives only in `ShaftHQ/shafthq.github.io`; recurring
-  commands and versions belong in its shared data/components, not this repo.
-- Deliver user-facing changes site-first: verify the docs preview, deploy it,
-  and confirm canonical production routes return HTTP 200 before merging a
-  dependent engine cleanup or removing its previous documentation.
-- Do not add local public guides or non-root README files.
-- Preserve public API compatibility; removals and renames require deprecation.
-- Never expose secrets or credentials.
-- Do not run deployment, publication, history rewrites, destructive cleanup,
-  or credentialed cloud suites unless the user explicitly requires them.
-- Do not commit `target/`, reports, downloaded binaries, or generated assets
-  unless explicitly requested.
-- Run browser tests headlessly; headed-only validation requires user approval.
-- For a user-assigned GitHub ticket, sync the default branch, create a dedicated
-  branch, implement and validate the work, then open a pull request.
+- Reproduce defects and add focused regression coverage when practical.
+- Preserve public API compatibility; deprecate before removing or renaming.
+- Public docs live in `ShaftHQ/shafthq.github.io`; do not add local public
+  guides or non-root READMEs.
+- Never expose secrets or run deployment, publication, history rewrites,
+  destructive cleanup, or credentialed cloud suites unless explicitly required.
+- Do not commit generated reports, binaries, or `target/`.
+- Run browser tests headlessly unless headed validation is explicitly approved.
+- For assigned GitHub work, sync the default branch, use a dedicated branch,
+  implement and validate, then open a pull request.
+
+## Memory
+
+Memory lives in `.memory/`; current code, tests, config, and the request win.
+
+- Do not load memory automatically or for routine, self-contained work.
+- Use at most one `load_memory` call when history or a known pitfall is material
+  and current files do not answer it. Add file/subsystem hints; budget <= 600.
+- Save only novel durable decisions, constraints, gotchas, workflows, or user
+  corrections with reviewable evidence. Do not save diaries, transient status,
+  or facts clear from code or active guidance.
+- Do not save automatically at session end; use `remember_memory` only when the
+  preceding rule applies.
 
 ## Validation
 
 Use the smallest check that proves the change:
 
-- Guidance/docs: relevant validator, documentation-boundary check, and
-  `git diff --check`.
+- Guidance or memory: `python3 scripts/ci/validate_agent_setup.py`
 - Localized code: affected tests, then one compile/package pass.
-- Shared API, concurrency, build, or release: targeted tests, module checks,
-  then full compile/package.
-- Visual behavior: relevant test plus image or browser evidence.
+- Shared API, concurrency, build, or release: targeted checks, then full
+  compile/package.
+- Visual behavior: relevant test plus image/browser evidence.
 - External/cloud E2E: only when infrastructure is available and required.
 
-Common commands:
-
-```bash
-mvn -pl shaft-engine -am test -Dtest=TestClassName
-mvn clean install -DskipTests -Dgpg.skip
-mvn -pl shaft-engine javadoc:javadoc
-python3 scripts/ci/validate_agent_guidance.py
-python3 scripts/ci/validate_documentation_boundaries.py
-python3 scripts/ci/validate_modular_documentation.py
-```
-
-On PowerShell, single-quote every Maven `-D` argument. For SHAFT tests, confirm
-Allure result files are populated before trusting the verdict; Surefire may be
-supporting diagnostics because failures can be ignored for report generation.
+On PowerShell, single-quote Maven `-D` arguments. Confirm Allure result files
+are populated before trusting SHAFT test verdicts.
 
 ## Completion
 
-Report changed behavior, files, checks and outcomes, plus unverified risk or
-environment limits. Claim branch, issue, pull-request, or remote results only
-after verification.
+Report changes, checks, outcomes, and unverified risk. Verify remote claims.

--- a/scripts/ci/agent_guidance_budget.json
+++ b/scripts/ci/agent_guidance_budget.json
@@ -1,7 +1,7 @@
 {
   "file_budgets": {
     "AGENTS.md": {
-      "max_bytes": 4096
+      "max_bytes": 3072
     },
     "CLAUDE.md": {
       "max_bytes": 1536,
@@ -40,11 +40,12 @@
       ".agents/skills/*/SKILL.md"
     ]
   },
-  "max_estimated_tokens_per_host": 2500,
+  "max_estimated_tokens_per_host": 2100,
   "active_guidance_globs": [
     "AGENTS.md",
     "CLAUDE.md",
     ".agents/skills/*/SKILL.md",
+    ".agents/skills/*/agents/openai.yaml",
     ".github/copilot-instructions.md",
     ".github/instructions/*.instructions.md",
     ".github/skills/*/SKILL.md"
@@ -60,7 +61,28 @@
     ".github/codex/prompts/refresh-agent-instructions.md"
   ],
   "reduction_baseline_bytes": 145162,
-  "minimum_reduction_percent": 80,
+  "minimum_reduction_percent": 85,
+  "expected_skill_names": {
+    ".agents/skills": [
+      "ci-failure-investigator",
+      "flaky-test-stabilizer",
+      "framework-source-rules",
+      "java-test-rules",
+      "release-dependency-guard"
+    ],
+    ".github/skills": [
+      "ci-failure-investigator",
+      "flaky-test-stabilizer",
+      "release-dependency-guard"
+    ]
+  },
+  "skill_budgets": {
+    ".agents/skills": {
+      "max_description_chars": 220,
+      "max_body_chars": 300,
+      "require_openai_yaml": true
+    }
+  },
   "reference_scan_globs": [
     "AGENTS.md",
     "CLAUDE.md",

--- a/scripts/ci/validate_agent_guidance.py
+++ b/scripts/ci/validate_agent_guidance.py
@@ -140,6 +140,63 @@ def parse_frontmatter(content: str) -> dict[str, str] | None:
     return values
 
 
+def markdown_body(content: str) -> str:
+    """Return Markdown after optional frontmatter."""
+    if not content.startswith("---\n"):
+        return content.strip()
+    marker = content.find("\n---\n", 4)
+    return content[marker + 5 :].strip() if marker >= 0 else content.strip()
+
+
+def quoted_yaml_value(content: str, key: str) -> str | None:
+    """Read one quoted scalar from the small agents/openai.yaml interface."""
+    match = re.search(rf'(?m)^\s*{re.escape(key)}:\s*"([^"]*)"\s*$', content)
+    return match.group(1) if match else None
+
+
+def validate_skill_interface(
+    root: Path, directory: Path, skill_name: str
+) -> list[dict[str, str]]:
+    """Validate concise Codex UI metadata for a discoverable skill."""
+    metadata_path = directory / "agents/openai.yaml"
+    metadata_relative = relative(root, metadata_path)
+    if not metadata_path.is_file():
+        return [issue("skill-metadata", metadata_relative, "agents/openai.yaml is required")]
+
+    content = metadata_path.read_text(encoding="utf-8")
+    display_name = quoted_yaml_value(content, "display_name")
+    short_description = quoted_yaml_value(content, "short_description")
+    default_prompt = quoted_yaml_value(content, "default_prompt")
+    errors: list[dict[str, str]] = []
+    if not display_name:
+        errors.append(issue("skill-metadata", metadata_relative, "display_name is required"))
+    if not short_description or not 25 <= len(short_description) <= 64:
+        errors.append(
+            issue(
+                "skill-metadata",
+                metadata_relative,
+                "short_description must be 25 to 64 characters",
+            )
+        )
+    if not default_prompt or f"${skill_name}" not in default_prompt:
+        errors.append(
+            issue(
+                "skill-metadata",
+                metadata_relative,
+                f"default_prompt must mention ${skill_name}",
+            )
+        )
+    if not re.search(r"(?m)^\s*allow_implicit_invocation:\s*true\s*$", content):
+        errors.append(
+            issue(
+                "skill-metadata",
+                metadata_relative,
+                "allow_implicit_invocation must be true",
+            )
+        )
+    return errors
+
+
 def validate_skills(root: Path, budget: dict) -> list[dict[str, str]]:
     """Validate discoverable skill directories and required frontmatter."""
     errors: list[dict[str, str]] = []
@@ -153,7 +210,24 @@ def validate_skills(root: Path, budget: dict) -> list[dict[str, str]]:
                 issue("skill-root-missing", configured_root, "skills root is missing")
             )
             continue
-        for directory in sorted(path for path in skills_root.iterdir() if path.is_dir()):
+        directories = sorted(path for path in skills_root.iterdir() if path.is_dir())
+        actual_names = {
+            directory.name
+            for directory in directories
+            if any(path.is_file() for path in directory.rglob("*"))
+        }
+        expected_names = set(budget.get("expected_skill_names", {}).get(configured_root, []))
+        if expected_names:
+            for missing in sorted(expected_names - actual_names):
+                errors.append(
+                    issue("skill-set", configured_root, f"expected skill is missing: {missing}")
+                )
+            for unexpected in sorted(actual_names - expected_names):
+                errors.append(
+                    issue("skill-set", configured_root, f"unexpected skill is present: {unexpected}")
+                )
+        limits = budget.get("skill_budgets", {}).get(configured_root, {})
+        for directory in directories:
             if not any(path.is_file() for path in directory.rglob("*")):
                 continue
             skill_path = directory / "SKILL.md"
@@ -163,7 +237,8 @@ def validate_skills(root: Path, budget: dict) -> list[dict[str, str]]:
                     issue("skill-missing", skill_relative, "skill directory must contain SKILL.md")
                 )
                 continue
-            frontmatter = parse_frontmatter(skill_path.read_text(encoding="utf-8"))
+            content = skill_path.read_text(encoding="utf-8")
+            frontmatter = parse_frontmatter(content)
             if frontmatter is None:
                 errors.append(
                     issue("skill-frontmatter", skill_relative, "valid YAML frontmatter is required")
@@ -181,6 +256,29 @@ def validate_skills(root: Path, budget: dict) -> list[dict[str, str]]:
                 errors.append(
                     issue("skill-description", skill_relative, "frontmatter description is required")
                 )
+            maximum_description = limits.get("max_description_chars")
+            if (
+                maximum_description is not None
+                and len(frontmatter.get("description", "")) > maximum_description
+            ):
+                errors.append(
+                    issue(
+                        "skill-description-budget",
+                        skill_relative,
+                        f"description exceeds {maximum_description} characters",
+                    )
+                )
+            maximum_body = limits.get("max_body_chars")
+            if maximum_body is not None and len(markdown_body(content)) > maximum_body:
+                errors.append(
+                    issue(
+                        "skill-body-budget",
+                        skill_relative,
+                        f"body exceeds {maximum_body} characters",
+                    )
+                )
+            if limits.get("require_openai_yaml"):
+                errors.extend(validate_skill_interface(root, directory, directory.name))
     return errors
 
 
@@ -322,7 +420,7 @@ def validate_refresh_workflow(root: Path, budget: dict) -> list[dict[str, str]]:
         "workflow_dispatch:": "manual dispatch trigger is required",
         "reason:": "required reason input is missing",
         "force_ai:": "force_ai input is missing",
-        "python3 scripts/ci/validate_agent_guidance.py": "deterministic audit step is missing",
+        "python3 scripts/ci/validate_agent_setup.py": "deterministic audit step is missing",
         "if: steps.audit.outputs.needs_ai == 'true'": "paid action is not audit-gated",
     }
     errors: list[dict[str, str]] = []

--- a/scripts/ci/validate_agent_setup.py
+++ b/scripts/ci/validate_agent_setup.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Validate agent guidance, repository memory, and their deterministic checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.ci.validate_agent_guidance import (  # noqa: E402
+    expand_globs,
+    load_budget,
+    parse_frontmatter,
+    validate_repository as validate_guidance,
+)
+from scripts.ci.validate_documentation_boundaries import (  # noqa: E402
+    validate_repository as validate_documentation,
+)
+
+MEMORY_PACKAGE = "@aictx/memory@0.1.55"
+MEMORY_TOOLS = {
+    "inspect_memory",
+    "load_memory",
+    "remember_memory",
+    "search_memory",
+}
+GENERATED_MEMORY_PATHS = {
+    ".memory/index/",
+    ".memory/context/",
+    ".memory/exports/",
+    ".memory/recovery/",
+    ".memory/.backup/",
+    ".memory/.lock",
+}
+
+
+def issue(code: str, path: str, message: str) -> dict[str, str]:
+    """Create a stable setup issue."""
+    return {"code": code, "path": path, "message": message}
+
+
+def read_json(path: Path) -> dict:
+    """Read one UTF-8 JSON object."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def toml_section(content: str, name: str) -> str:
+    """Return one top-level TOML table body from the small project config."""
+    match = re.search(
+        rf"(?ms)^\[{re.escape(name)}\]\s*$\n(.*?)(?=^\[|\Z)", content
+    )
+    return match.group(1) if match else ""
+
+
+def validate_memory_setup(root: Path = ROOT) -> list[dict[str, str]]:
+    """Validate pinned Aictx storage and the restricted Codex MCP surface."""
+    errors: list[dict[str, str]] = []
+    required_files = [
+        ".memory/config.json",
+        ".memory/events.jsonl",
+        ".memory/schema/config.schema.json",
+        ".memory/schema/event.schema.json",
+        ".memory/schema/object.schema.json",
+        ".memory/schema/patch.schema.json",
+        ".memory/schema/relation.schema.json",
+        ".memory/memory/project.md",
+        ".memory/memory/project.json",
+        ".memory/memory/architecture.md",
+        ".memory/memory/architecture.json",
+        ".codex/config.toml",
+    ]
+    for configured_path in required_files:
+        if not (root / configured_path).is_file():
+            errors.append(issue("memory-file", configured_path, "required file is missing"))
+    if errors:
+        return errors
+
+    try:
+        config = read_json(root / ".memory/config.json")
+    except (OSError, json.JSONDecodeError) as error:
+        return [issue("memory-config", ".memory/config.json", str(error))]
+
+    expected_config = {
+        "version": 4,
+        "project": {"id": "project.shaft-engine", "name": "Shaft Engine"},
+        "memory": {
+            "autoIndex": True,
+            "defaultTokenBudget": 600,
+            "saveContextPacks": False,
+        },
+        "git": {"trackContextPacks": False},
+    }
+    if config != expected_config:
+        errors.append(
+            issue(
+                "memory-config",
+                ".memory/config.json",
+                "configuration must use schema v4, project.shaft-engine, and a 600-token budget",
+            )
+        )
+
+    ignored = {
+        line.strip()
+        for line in (root / ".gitignore").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    }
+    for generated_path in sorted(GENERATED_MEMORY_PATHS - ignored):
+        errors.append(
+            issue("memory-ignore", ".gitignore", f"generated path is not ignored: {generated_path}")
+        )
+
+    codex_content = (root / ".codex/config.toml").read_text(encoding="utf-8")
+    server_content = toml_section(codex_content, "mcp_servers.shaft-memory")
+    remember_content = toml_section(
+        codex_content, "mcp_servers.shaft-memory.tools.remember_memory"
+    )
+    list_values: dict[str, list[str]] = {}
+    for key in ("args", "enabled_tools"):
+        match = re.search(rf"(?m)^{key}\s*=\s*(\[[^\n]+\])\s*$", server_content)
+        if match:
+            try:
+                list_values[key] = json.loads(match.group(1))
+            except json.JSONDecodeError:
+                list_values[key] = []
+    checks = {
+        "server section": bool(server_content),
+        "command": re.search(r'(?m)^command\s*=\s*"npx"\s*$', server_content)
+        is not None,
+        "args": list_values.get("args")
+        == ["--yes", "--package", MEMORY_PACKAGE, "--", "memory-mcp"],
+        "cwd": re.search(r'(?m)^cwd\s*=\s*"\.\."\s*$', server_content)
+        is not None,
+        "enabled_tools": set(list_values.get("enabled_tools", [])) == MEMORY_TOOLS,
+        "default_tools_approval_mode": re.search(
+            r'(?m)^default_tools_approval_mode\s*=\s*"auto"\s*$', server_content
+        )
+        is not None,
+        "required": re.search(r"(?m)^required\s*=\s*false\s*$", server_content)
+        is not None,
+        "remember approval": (
+            bool(remember_content)
+            and re.search(r'(?m)^approval_mode\s*=\s*"prompt"\s*$', remember_content)
+            is not None
+        ),
+    }
+    for name, valid in checks.items():
+        if not valid:
+            errors.append(
+                issue("memory-mcp", ".codex/config.toml", f"invalid shaft-memory {name}")
+            )
+    return errors
+
+
+def run_command(root: Path, command: list[str], code: str) -> list[dict[str, str]]:
+    """Run one external check and return a concise issue on failure."""
+    executable = shutil.which(command[0])
+    if executable is None:
+        return [issue(code, command[0], "required executable is unavailable")]
+    completed = subprocess.run(
+        [executable, *command[1:]],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    if completed.returncode == 0:
+        return []
+    detail = (completed.stderr or completed.stdout).strip().replace("\n", " ")
+    return [issue(code, command[0], detail[:500] or f"exit code {completed.returncode}")]
+
+
+def collect_metrics(root: Path = ROOT) -> dict:
+    """Collect stable context and memory size metrics."""
+    budget = load_budget(root / "scripts/ci/agent_guidance_budget.json")
+    guidance_paths = expand_globs(root, budget.get("total_guidance_globs", []))
+    host_tokens: dict[str, int] = {}
+    for host, configured_paths in budget.get("host_contexts", {}).items():
+        characters = sum(
+            len((root / path).read_text(encoding="utf-8"))
+            for path in configured_paths
+            if (root / path).is_file()
+        )
+        for path in expand_globs(
+            root, budget.get("host_skill_metadata_globs", {}).get(host, [])
+        ):
+            frontmatter = parse_frontmatter(path.read_text(encoding="utf-8")) or {}
+            characters += len(frontmatter.get("name", ""))
+            characters += len(frontmatter.get("description", ""))
+        host_tokens[host] = math.ceil(characters / 4)
+    baseline = budget.get("reduction_baseline_bytes", 0)
+    guidance_bytes = sum(path.stat().st_size for path in guidance_paths)
+    reduction = 0 if not baseline else round((1 - guidance_bytes / baseline) * 100, 2)
+    memory_config = root / ".memory/config.json"
+    memory_budget = None
+    if memory_config.is_file():
+        try:
+            memory_budget = read_json(memory_config).get("memory", {}).get(
+                "defaultTokenBudget"
+            )
+        except (OSError, json.JSONDecodeError):
+            pass
+    memory_root = root / ".memory/memory"
+    return {
+        "guidance_bytes": guidance_bytes,
+        "guidance_reduction_percent": reduction,
+        "estimated_host_tokens": host_tokens,
+        "memory_objects": len(list(memory_root.rglob("*.json")))
+        if memory_root.is_dir()
+        else 0,
+        "memory_default_token_budget": memory_budget,
+        "codex_memory_tools": sorted(MEMORY_TOOLS),
+    }
+
+
+def validate_repository(
+    root: Path = ROOT, *, run_external: bool = True
+) -> tuple[list[dict[str, str]], dict]:
+    """Run all agent setup checks."""
+    errors = [
+        *validate_guidance(root),
+        *[
+            issue("documentation-boundary", "documentation", message)
+            for message in validate_documentation(root)
+        ],
+        *validate_memory_setup(root),
+    ]
+    if run_external:
+        errors.extend(
+            run_command(
+                root,
+                [
+                    "npx",
+                    "--yes",
+                    "--package",
+                    MEMORY_PACKAGE,
+                    "--",
+                    "memory",
+                    "check",
+                ],
+                "memory-check",
+            )
+        )
+        errors.extend(run_command(root, ["git", "diff", "--check"], "diff-check"))
+    return (
+        sorted(errors, key=lambda item: (item["path"], item["code"], item["message"])),
+        collect_metrics(root),
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument(
+        "--skip-external",
+        action="store_true",
+        help="Skip pinned Memory CLI and git diff checks.",
+    )
+    return parser
+
+
+def main() -> int:
+    """Run the CLI."""
+    args = build_parser().parse_args()
+    errors, metrics = validate_repository(
+        args.root.resolve(), run_external=not args.skip_external
+    )
+    if args.format == "json":
+        print(json.dumps({"valid": not errors, "errors": errors, "metrics": metrics}, indent=2))
+    elif errors:
+        for error in errors:
+            print(f"{error['code']}: {error['path']}: {error['message']}", file=sys.stderr)
+    else:
+        print(
+            "Agent setup is valid: "
+            f"{metrics['guidance_bytes']} guidance bytes, "
+            f"{metrics['guidance_reduction_percent']}% reduction, "
+            f"{metrics['memory_objects']} memory objects."
+        )
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/validate_documentation_boundaries.py
+++ b/scripts/ci/validate_documentation_boundaries.py
@@ -28,6 +28,8 @@ ALLOWED_GLOBS = (
     ".github/instructions/*.instructions.md",
     ".github/ISSUE_TEMPLATE/*.md",
     ".github/skills/*/SKILL.md",
+    ".memory/memory/*.md",
+    ".memory/memory/**/*.md",
     "*/src/test/resources/fixtures/**/*.md",
 )
 FORBIDDEN_LINK_FRAGMENTS = (
@@ -45,9 +47,9 @@ IGNORED_DIRECTORIES = {
 }
 
 
-def tracked_markdown() -> list[str]:
+def tracked_markdown(root: Path = ROOT) -> list[str]:
     paths: list[str] = []
-    for directory, child_directories, files in os.walk(ROOT):
+    for directory, child_directories, files in os.walk(root):
         child_directories[:] = [
             child for child in child_directories
             if child not in IGNORED_DIRECTORIES
@@ -56,7 +58,7 @@ def tracked_markdown() -> list[str]:
             if Path(filename).suffix.lower() not in {".md", ".mdx"}:
                 continue
             paths.append(
-                (Path(directory) / filename).relative_to(ROOT).as_posix()
+                (Path(directory) / filename).relative_to(root).as_posix()
             )
     return sorted(paths)
 
@@ -65,9 +67,9 @@ def is_allowed(path: str) -> bool:
     return path in ALLOWED_EXACT or any(fnmatch(path, pattern) for pattern in ALLOWED_GLOBS)
 
 
-def main() -> int:
+def validate_repository(root: Path = ROOT) -> list[str]:
     errors: list[str] = []
-    markdown = tracked_markdown()
+    markdown = tracked_markdown(root)
 
     for path in markdown:
         if not is_allowed(path):
@@ -76,7 +78,7 @@ def main() -> int:
             if path != ".github/skills/README.md":
                 errors.append(f"non-root README is prohibited: {path}")
 
-    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    readme = (root / "README.md").read_text(encoding="utf-8")
     if len(readme.splitlines()) > 160:
         errors.append("README.md exceeds the 160-line landing-page budget")
     for route in (
@@ -98,18 +100,25 @@ def main() -> int:
         if path != "shaft-doctor/src/test/resources/fixtures/golden/doctor-report.md"
     ]
     for path in scan_paths:
-        content = (ROOT / path).read_text(encoding="utf-8")
+        content = (root / path).read_text(encoding="utf-8")
         for fragment in FORBIDDEN_LINK_FRAGMENTS:
             if fragment in content:
                 errors.append(f"{path}: links to deleted repository documentation")
 
-    if (ROOT / "docs").exists():
+    if (root / "docs").exists():
         errors.append("the local docs/ tree must not exist")
 
+    return errors
+
+
+def main() -> int:
+    errors = validate_repository()
     if errors:
         print("\n".join(f"ERROR: {error}" for error in errors), file=sys.stderr)
         return 1
-    print(f"Documentation boundary is valid ({len(markdown)} tracked Markdown files).")
+    print(
+        f"Documentation boundary is valid ({len(tracked_markdown())} tracked Markdown files)."
+    )
     return 0
 
 

--- a/tests/scripts/test_validate_agent_guidance.py
+++ b/tests/scripts/test_validate_agent_guidance.py
@@ -44,7 +44,7 @@ on:
         default: false
 steps:
   - id: audit
-    run: python3 scripts/ci/validate_agent_guidance.py
+    run: python3 scripts/ci/validate_agent_setup.py
   - if: steps.audit.outputs.needs_ai == 'true'
     uses: openai/codex-action@v1
 """,
@@ -170,6 +170,41 @@ steps:
         codes = self.codes()
         self.assertIn("skill-name", codes)
         self.assertIn("skill-description", codes)
+
+    def test_enforces_exact_skill_set(self):
+        self.budget["expected_skill_names"] = {
+            ".agents/skills": ["example-bridge"],
+            ".github/skills": ["example"],
+        }
+        self.write_budget()
+        self.write(
+            ".agents/skills/unexpected/SKILL.md",
+            "---\nname: unexpected\ndescription: Unexpected workflow.\n---\n\n# Unexpected\n",
+        )
+        self.assertIn("skill-set", self.codes())
+
+    def test_requires_valid_codex_skill_metadata(self):
+        self.budget["skill_budgets"] = {
+            ".agents/skills": {
+                "max_description_chars": 100,
+                "max_body_chars": 100,
+                "require_openai_yaml": True,
+            }
+        }
+        self.write_budget()
+        self.assertIn("skill-metadata", self.codes())
+
+        self.write(
+            ".agents/skills/example-bridge/agents/openai.yaml",
+            """interface:
+  display_name: "Example Bridge"
+  short_description: "Load the canonical example workflow"
+  default_prompt: "Use $example-bridge to handle this example task."
+policy:
+  allow_implicit_invocation: true
+""",
+        )
+        self.assertNotIn("skill-metadata", self.codes())
 
     def test_rejects_unmatched_path_scope(self):
         self.write(

--- a/tests/scripts/test_validate_agent_setup.py
+++ b/tests/scripts/test_validate_agent_setup.py
@@ -1,0 +1,92 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.ci.validate_agent_setup import (
+    GENERATED_MEMORY_PATHS,
+    validate_memory_setup,
+    validate_repository,
+)
+
+
+class ValidateAgentSetupTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.write(
+            ".memory/config.json",
+            json.dumps(
+                {
+                    "version": 4,
+                    "project": {"id": "project.shaft-engine", "name": "Shaft Engine"},
+                    "memory": {
+                        "autoIndex": True,
+                        "defaultTokenBudget": 600,
+                        "saveContextPacks": False,
+                    },
+                    "git": {"trackContextPacks": False},
+                }
+            ),
+        )
+        self.write(".memory/events.jsonl", "")
+        for name in ("config", "event", "object", "patch", "relation"):
+            self.write(f".memory/schema/{name}.schema.json", "{}")
+        self.write(".memory/memory/project.md", "# SHAFT Engine\n")
+        self.write(".memory/memory/project.json", "{}")
+        self.write(".memory/memory/architecture.md", "# Architecture\n")
+        self.write(".memory/memory/architecture.json", "{}")
+        self.write(".gitignore", "\n".join(sorted(GENERATED_MEMORY_PATHS)) + "\n")
+        self.write(
+            ".codex/config.toml",
+            """[mcp_servers.shaft-memory]
+command = "npx"
+args = ["--yes", "--package", "@aictx/memory@0.1.55", "--", "memory-mcp"]
+cwd = ".."
+enabled_tools = ["load_memory", "search_memory", "inspect_memory", "remember_memory"]
+default_tools_approval_mode = "auto"
+startup_timeout_sec = 30
+tool_timeout_sec = 60
+required = false
+
+[mcp_servers.shaft-memory.tools.remember_memory]
+approval_mode = "prompt"
+""",
+        )
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def write(self, relative_path, content):
+        path = self.root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    def codes(self):
+        return {error["code"] for error in validate_memory_setup(self.root)}
+
+    def test_valid_memory_setup_passes(self):
+        self.assertEqual(validate_memory_setup(self.root), [])
+
+    def test_rejects_large_default_memory_budget(self):
+        config = json.loads((self.root / ".memory/config.json").read_text(encoding="utf-8"))
+        config["memory"]["defaultTokenBudget"] = 6000
+        self.write(".memory/config.json", json.dumps(config))
+        self.assertIn("memory-config", self.codes())
+
+    def test_rejects_broader_mcp_tool_surface(self):
+        path = self.root / ".codex/config.toml"
+        content = path.read_text(encoding="utf-8").replace(
+            '"remember_memory"]', '"remember_memory", "save_memory_patch"]'
+        )
+        self.write(".codex/config.toml", content)
+        self.assertIn("memory-mcp", self.codes())
+
+    def test_current_repository_setup_is_valid_without_external_calls(self):
+        repository_root = Path(__file__).resolve().parents[2]
+        errors, _ = validate_repository(repository_root, run_external=False)
+        self.assertEqual(errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reduce always-loaded agent guidance and tighten deterministic context budgets
- refine the five project skills and add Codex `agents/openai.yaml` metadata
- add pinned Aictx repository memory with a 600-token retrieval budget and 14 durable project records
- expose only four memory MCP tools and require approval for memory writes
- consolidate guidance, memory, documentation, and diff checks behind one validator
- keep paid Codex instruction refresh manual and audit-gated

## Impact

- estimated Codex context drops from 1,152 to 1,003 tokens
- total guidance remains 87.55% below the configured legacy baseline
- routine agent validation becomes one command: `python3 scripts/ci/validate_agent_setup.py`
- generated memory indexes and context packs remain ignored
- no product Java or Maven behavior changes

## Validation

- `python scripts/ci/validate_agent_setup.py`
- `python -m unittest tests.scripts.test_validate_agent_guidance tests.scripts.test_validate_agent_setup`
- all five skills pass the Codex skill validator
- `memory check` passes
- memory audit reports zero warnings
- a 600-token retrieval smoke test returned the targeted TestNG parallelism lesson
- `git diff --check`

## Notes

A new Codex session is required for the project MCP server to be discovered.