### PR TITLE
[codex] Fix shaft-mcp runtime paths

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Paths.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Paths.java
@@ -34,6 +34,10 @@ public interface Paths extends EngineProperties<Paths> {
     @DefaultValue("src/main/resources/properties/default")
     String defaultProperties();
 
+    @Key("aiAgentWorkspaceRoot")
+    @DefaultValue("")
+    String aiAgentWorkspaceRoot();
+
     @Key("dynamicObjectRepositoryPath")
     @DefaultValue("src/main/resources/dynamicObjectRepository/")
     String dynamicObjectRepository();
@@ -82,6 +86,11 @@ public interface Paths extends EngineProperties<Paths> {
     class SetProperty implements EngineProperties.SetProperty {
         public SetProperty properties(String value) {
             setProperty("propertiesFolderPath", value);
+            return this;
+        }
+
+        public SetProperty aiAgentWorkspaceRoot(String value) {
+            setProperty("aiAgentWorkspaceRoot", value);
             return this;
         }
 

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
@@ -23,6 +23,7 @@ import java.awt.*;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -261,10 +262,10 @@ public class PropertiesHelper {
         }
     }
 
-    private static void downloadDefaultProperties(){
-        ReportManager.logDiscrete("Downloading default properties to user.home...");
+    private static void downloadDefaultProperties() {
+        ReportManager.logDiscrete("Downloading default properties to AI-agent runtime workspace...");
 
-        var propertiesFolderPath = "target" + File.separator + "temp" + File.separator + "properties";
+        var propertiesFolderPath = resolveAiAgentPath("target" + File.separator + "temp" + File.separator + "properties");
         Properties.paths.set().properties(propertiesFolderPath);
 
         Arrays.asList(
@@ -309,34 +310,37 @@ public class PropertiesHelper {
             }
         }
         // override target properties only if they do not exist
-        overrideTargetProperties();
+        overrideTargetProperties(forceDownload);
     }
 
-    private static void overrideTargetProperties(){
+    private static void overrideTargetProperties(boolean aiAgentMode) {
         var fileActions = FileActions.getInstance(true);
         var propertiesFolderPath = Properties.paths.properties();
         boolean isExternalRun = propertiesFolderPath.contains("file:") && propertiesFolderPath.contains(".jar!");
+        var targetPropertiesFolderPath = aiAgentMode
+                ? resolveAiAgentPath(TARGET_PROPERTIES_FOLDER_PATH)
+                : TARGET_PROPERTIES_FOLDER_PATH;
 
         Arrays.asList("/custom.properties")
                 .forEach(file -> {
-                    if (!fileActions.doesFileExist(TARGET_PROPERTIES_FOLDER_PATH + file)) {
+                    if (!fileActions.doesFileExist(targetPropertiesFolderPath + file)) {
                         if (isExternalRun) {
                             var tempPath = propertiesFolderPath.replace("/default", "");
                             try {
                                 if (tempPath.contains("file:")) {
-                                    fileActions.copyFileFromJar(tempPath, TARGET_PROPERTIES_FOLDER_PATH, file.replace("/", ""));
+                                    fileActions.copyFileFromJar(tempPath, targetPropertiesFolderPath, file.replace("/", ""));
                                 } else {
                                     throw new IOException("Properties folder path does not contain 'file:' protocol, indicating it is not running from a jar file.");
                                 }
                             } catch (Throwable ignored) {
-                                fileActions.copyFile(tempPath + file, TARGET_PROPERTIES_FOLDER_PATH + file);
+                                fileActions.copyFile(tempPath + file, targetPropertiesFolderPath + file);
                             }
                         } else {
-                            fileActions.copyFile(propertiesFolderPath + file, TARGET_PROPERTIES_FOLDER_PATH + file);
+                            fileActions.copyFile(propertiesFolderPath + file, targetPropertiesFolderPath + file);
                         }
                     }
                 });
-        Properties.paths.set().properties(TARGET_PROPERTIES_FOLDER_PATH);
+        Properties.paths.set().properties(targetPropertiesFolderPath);
     }
 
     private static void downloadPropertiesFile(String fileName) {
@@ -346,9 +350,22 @@ public class PropertiesHelper {
     }
 
     private static void attachPropertyFiles() {
-        ReportManager.logDiscrete("Reading properties directory: " + TARGET_PROPERTIES_FOLDER_PATH, Level.DEBUG);
-        FileUtils.listFiles(new File(TARGET_PROPERTIES_FOLDER_PATH), new String[]{"properties"},
+        var targetPropertiesFolderPath = Properties.paths.properties();
+        ReportManager.logDiscrete("Reading properties directory: " + targetPropertiesFolderPath, Level.DEBUG);
+        FileUtils.listFiles(new File(targetPropertiesFolderPath), new String[]{"properties"},
                 false).forEach(propertyFile -> ReportManager.logDiscrete("Loading properties file: " + propertyFile, Level.DEBUG));
+    }
+
+    private static String resolveAiAgentPath(String path) {
+        String workspaceRoot = SHAFT.Properties.paths.aiAgentWorkspaceRoot();
+        if (workspaceRoot == null || workspaceRoot.isBlank()) {
+            return path;
+        }
+        Path configuredPath = Path.of(path);
+        if (configuredPath.isAbsolute()) {
+            return configuredPath.normalize().toString();
+        }
+        return Path.of(workspaceRoot).resolve(configuredPath).normalize().toString();
     }
 
     private static void overridePropertiesForMaximumPerformanceMode() {

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java
@@ -19,6 +19,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
@@ -77,7 +78,6 @@ public class AllureManager {
     // ─── Allure 3 report paths & config ────────────────────────────────────────
     private static final String allureReportPath = "allure-report";
     private static final String allureConfigFileName = "allurerc.yaml";
-    private static final String allureRealtimeLogFile = System.getProperty("user.dir") + File.separator + "target" + File.separator + "allure-watch.log";
 
     // ─── Portable Node.js bootstrap ────────────────────────────────────────────
     /** Cache directory for the downloaded portable Node.js distribution. */
@@ -154,7 +154,7 @@ public class AllureManager {
     }
 
     private static void copyAndOpenAllure() {
-        internalFileSession.copyFolder(allureOutPutDirectory, allureReportPath);
+        internalFileSession.copyFolder(allureOutPutDirectory, reportDirectoryPath().toString());
         internalFileSession.deleteFile(allureOutPutDirectory);
         String newFileName = renameAllureReport();
         if (newFileName != null) {
@@ -172,7 +172,7 @@ public class AllureManager {
         String newFileName = "AllureReport.html";
         if (SHAFT.Properties.allure.accumulateReports())
             newFileName = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss-SSS")) + "_AllureReport.html";
-        String sourceFile = System.getProperty("user.dir") + File.separator + allureReportPath + File.separator + "index.html";
+        String sourceFile = reportDirectoryPath().resolve("index.html").toString();
         if (!internalFileSession.doesFileExist(sourceFile)) {
             // Allure report was not generated (CLI bootstrap failed or allure-results was empty)
             ReportManager.logDiscrete("Allure report 'index.html' not found — 'allure generate' may have failed."
@@ -184,7 +184,7 @@ public class AllureManager {
     }
 
     private static void openAllureReport(String newFileName) {
-        String reportPath = new File(allureReportPath, newFileName).getAbsolutePath();
+        String reportPath = reportDirectoryPath().resolve(newFileName).toFile().getAbsolutePath();
         if (SystemUtils.IS_OS_WINDOWS) {
             reportPath = reportPath.replace("'", "''");
             internalTerminalSession.performTerminalCommand(
@@ -239,6 +239,39 @@ public class AllureManager {
         return allureResultsFolderPath;
     }
 
+    private static Path getExecutionRootPath() {
+        String resultsPath = getResultsPath();
+        if (resultsPath != null && !resultsPath.isBlank()) {
+            Path configuredResultsPath = Path.of(resultsPath);
+            if (configuredResultsPath.isAbsolute()) {
+                Path normalizedResultsPath = configuredResultsPath.toAbsolutePath().normalize();
+                Path parent = normalizedResultsPath.getParent();
+                return parent == null ? normalizedResultsPath : parent;
+            }
+        }
+        return Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize();
+    }
+
+    private static Path resolveExecutionPath(String first, String... more) {
+        return getExecutionRootPath().resolve(Path.of(first, more)).normalize();
+    }
+
+    private static Path reportDirectoryPath() {
+        return resolveExecutionPath(allureReportPath);
+    }
+
+    private static Path reportOutputDirectoryPath() {
+        return resolveExecutionPath("target", allureReportPath);
+    }
+
+    private static Path allureConfigPath() {
+        return resolveExecutionPath(allureConfigFileName);
+    }
+
+    private static Path allureRealtimeLogPath() {
+        return resolveExecutionPath("target", "allure-watch.log");
+    }
+
     private static void writeGenerateReportShellFilesToProjectDirectory() {
         // create generate_allure_report.sh or generate_allure_report.bat
         // These scripts re-generate the report from allure-results and serve it via HTTP.
@@ -251,22 +284,24 @@ public class AllureManager {
                         "@echo off",
                         "allure serve \"" + resultsPath + "\"",
                         "pause", "exit");
-                internalFileSession.writeToFile("", "generate_allure_report.bat", commands);
+                internalFileSession.writeToFile(resolveExecutionPath("generate_allure_report.bat").toString(),
+                        String.join(System.lineSeparator(), commands));
             } else {
                 List<String> commands = Arrays.asList(
                         "#!/bin/bash",
                         "allure serve \"" + resultsPath + "\"");
-                internalFileSession.writeToFile("", "generate_allure_report.sh", commands);
-                internalTerminalSession.performTerminalCommand("chmod u+x generate_allure_report.sh");
+                Path scriptPath = resolveExecutionPath("generate_allure_report.sh");
+                internalFileSession.writeToFile(scriptPath.toString(), String.join(System.lineSeparator(), commands));
+                internalTerminalSession.performTerminalCommand("chmod u+x \"" + scriptPath + "\"");
             }
             return;
         }
 
-        // Allure 3 mode: --config allurerc.yaml is passed explicitly so the singleFile/groupBy/reportName
+        // Allure 3 mode: --config is passed explicitly so the singleFile/groupBy/reportName
         // options written by writeAllureConfig() are honoured when the user runs the script manually.
         String allure3Version = SHAFT.Properties.internal.allure3Version();
         boolean enforceConfiguredCliVersion = SHAFT.Properties.allure.forceConfiguredCliVersion();
-        String serveArguments = "serve --config allurerc.yaml \"" + resultsPath + "\"";
+        String serveArguments = "serve --config \"" + allureConfigPath() + "\" \"" + resultsPath + "\"";
         List<String> commandsToServeAllureReport;
         if (SystemUtils.IS_OS_WINDOWS) {
             if (enforceConfiguredCliVersion) {
@@ -280,7 +315,8 @@ public class AllureManager {
                         "where allure >nul 2>&1 && (allure " + serveArguments + ") || (npx --yes allure@" + allure3Version + " " + serveArguments + ")",
                         "pause", "exit");
             }
-            internalFileSession.writeToFile("", "generate_allure_report.bat", commandsToServeAllureReport);
+            internalFileSession.writeToFile(resolveExecutionPath("generate_allure_report.bat").toString(),
+                    String.join(System.lineSeparator(), commandsToServeAllureReport));
         } else {
             if (enforceConfiguredCliVersion) {
                 commandsToServeAllureReport = Arrays.asList(
@@ -295,9 +331,10 @@ public class AllureManager {
                         "  npx --yes allure@" + allure3Version + " " + serveArguments,
                         "fi");
             }
-            internalFileSession.writeToFile("", "generate_allure_report.sh", commandsToServeAllureReport);
+            Path scriptPath = resolveExecutionPath("generate_allure_report.sh");
+            internalFileSession.writeToFile(scriptPath.toString(), String.join(System.lineSeparator(), commandsToServeAllureReport));
             // make script executable on Unix-based shells
-            internalTerminalSession.performTerminalCommand("chmod u+x generate_allure_report.sh");
+            internalTerminalSession.performTerminalCommand("chmod u+x \"" + scriptPath + "\"");
         }
     }
 
@@ -356,15 +393,15 @@ public class AllureManager {
         // clean allure-report directory before execution
         if (!SHAFT.Properties.allure.accumulateReports()) {
             try {
-                internalFileSession.deleteFolder(allureReportPath);
+                internalFileSession.deleteFolder(reportDirectoryPath().toString());
             } catch (Exception t) {
-                ReportManager.log("Failed to delete '" + allureReportPath + "' as it is currently open. Kindly restart your device to unlock the directory.");
+                ReportManager.log("Failed to delete '" + reportDirectoryPath() + "' as it is currently open. Kindly restart your device to unlock the directory.");
             }
         }
     }
 
     private static void writeAllureReport() {
-        allureOutPutDirectory = System.getProperty("user.dir") + File.separator + "target" + File.separator + allureReportPath;
+        allureOutPutDirectory = reportOutputDirectoryPath().toString();
         var customReportName = SHAFT.Properties.allure.customTitle();
         internalFileSession.createFolder(allureOutPutDirectory);
 
@@ -409,8 +446,7 @@ public class AllureManager {
         configBuilder.append("output: \"").append(safeOutputDir).append("\"\n");
 
         if (SHAFT.Properties.allure.accumulateHistory()) {
-            String historyPath = escapeYamlString((System.getProperty("user.dir") + File.separator + "target"
-                    + File.separator + "history.jsonl").replace("\\", "/"));
+            String historyPath = escapeYamlString(resolveExecutionPath("target", "history.jsonl").toString().replace("\\", "/"));
             configBuilder.append("historyPath: \"").append(historyPath).append("\"\n");
             configBuilder.append("appendHistory: true\n");
         }
@@ -433,7 +469,7 @@ public class AllureManager {
         }
 
         internalFileSession.writeToFile(
-                System.getProperty("user.dir") + File.separator + allureConfigFileName,
+                allureConfigPath().toString(),
                 configBuilder.toString());
     }
 
@@ -453,7 +489,7 @@ public class AllureManager {
         ProcessBuilder processBuilder = SystemUtils.IS_OS_WINDOWS
                 ? new ProcessBuilder("cmd.exe", "/c", command)
                 : new ProcessBuilder("sh", "-c", command);
-        processBuilder.directory(new File(System.getProperty("user.dir")));
+        processBuilder.directory(getExecutionRootPath().toFile());
 
         ExecutorService streamReaders = Executors.newFixedThreadPool(2);
         try {
@@ -558,9 +594,15 @@ public class AllureManager {
             ProcessBuilder processBuilder = SystemUtils.IS_OS_WINDOWS
                     ? new ProcessBuilder("cmd.exe", "/c", command)
                     : new ProcessBuilder("sh", "-c", command);
-            processBuilder.directory(new File(System.getProperty("user.dir")));
+            Path executionRoot = getExecutionRootPath();
+            if (!Files.isDirectory(executionRoot)) {
+                return null;
+            }
+            Path realtimeLogPath = allureRealtimeLogPath();
+            Files.createDirectories(realtimeLogPath.getParent());
+            processBuilder.directory(executionRoot.toFile());
             processBuilder.redirectErrorStream(true);
-            processBuilder.redirectOutput(ProcessBuilder.Redirect.appendTo(new File(allureRealtimeLogFile)));
+            processBuilder.redirectOutput(ProcessBuilder.Redirect.appendTo(realtimeLogPath.toFile()));
             return processBuilder.start();
         } catch (IOException e) {
             ReportManager.logDiscrete("Failed to start Allure real-time monitoring: " + e.getMessage());
@@ -787,7 +829,7 @@ public class AllureManager {
         }
 
         // Allure 3: pass --config explicitly so allurerc.yaml is always applied
-        String configPath = System.getProperty("user.dir") + File.separator + allureConfigFileName;
+        String configPath = allureConfigPath().toString();
         return prefix + " generate --config \"" + configPath + "\" \""
                 + resultsPath + "\" -o \"" + allureOutPutDirectory + "\"";
     }
@@ -1158,7 +1200,8 @@ public class AllureManager {
     }
 
     private static void createAllureReportArchive() {
-        internalFileSession.zipFiles(allureOutPutDirectory, "generatedReport_" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss-SSS")) + ".zip");
+        String archivePath = resolveExecutionPath("generatedReport_" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss-SSS")) + ".zip").toString();
+        internalFileSession.zipFiles(allureOutPutDirectory, archivePath);
     }
 
     private static void writeEnvironmentVariablesToAllureResultsDirectory() {

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureManagerCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureManagerCoverageUnitTest.java
@@ -142,7 +142,9 @@ public class AllureManagerCoverageUnitTest {
         String scriptContents = Files.readString(script, StandardCharsets.UTF_8);
 
         Assert.assertTrue(scriptContents.contains("npx --yes allure@" + SHAFT.Properties.internal.allure3Version()), scriptContents);
-        Assert.assertTrue(scriptContents.contains("serve --config allurerc.yaml " + quote(allureResultsDirectory.toString())), scriptContents);
+        Assert.assertTrue(scriptContents.contains("serve --config "
+                + quote(Path.of("allurerc.yaml").toAbsolutePath().toString())
+                + " " + quote(allureResultsDirectory.toString())), scriptContents);
         Assert.assertFalse(scriptContents.contains(allureResultsDirectory + File.separator + "\""), scriptContents);
     }
 

--- a/shaft-engine/src/test/java/testPackage/unitTests/AllureManagerUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/AllureManagerUnitTest.java
@@ -110,6 +110,56 @@ public class AllureManagerUnitTest {
         SHAFT.Validations.assertThat().object(getResultsPath.invoke(null).toString()).isEqualTo("").perform();
     }
 
+    @Test(description = "Absolute allureResultsFolderPath should define the Allure execution root")
+    public void absoluteAllureResultsPathShouldDefineExecutionRoot() throws Exception {
+        Path executionRoot = Path.of(System.getProperty("user.dir"), "target", "allure-absolute-execution-root")
+                .toAbsolutePath()
+                .normalize();
+        Path resultsDirectory = executionRoot.resolve("allure-results");
+        Files.createDirectories(resultsDirectory);
+        setStaticField(AllureManager.class, "allureResultsFolderPath", resultsDirectory.toString());
+        setStaticField(AllureManager.class, "cachedAllureCommandPrefix", "echo");
+        setStaticField(AllureManager.class, "cachedIsAllure2", false);
+        SHAFT.Properties.allure.set().forceConfiguredCliVersion(true).accumulateHistory(true);
+
+        Method reportDirectoryPath = AllureManager.class.getDeclaredMethod("reportDirectoryPath");
+        Method reportOutputDirectoryPath = AllureManager.class.getDeclaredMethod("reportOutputDirectoryPath");
+        Method allureConfigPath = AllureManager.class.getDeclaredMethod("allureConfigPath");
+        Method writeGenerateReportShellFiles = AllureManager.class.getDeclaredMethod("writeGenerateReportShellFilesToProjectDirectory");
+        Method writeAllureConfig = AllureManager.class.getDeclaredMethod("writeAllureConfig", String.class, String.class);
+        Method getCommandToCreateAllureReport = AllureManager.class.getDeclaredMethod("getCommandToCreateAllureReport");
+        reportDirectoryPath.setAccessible(true);
+        reportOutputDirectoryPath.setAccessible(true);
+        allureConfigPath.setAccessible(true);
+        writeGenerateReportShellFiles.setAccessible(true);
+        writeAllureConfig.setAccessible(true);
+        getCommandToCreateAllureReport.setAccessible(true);
+
+        Path reportDirectory = (Path) reportDirectoryPath.invoke(null);
+        Path reportOutputDirectory = (Path) reportOutputDirectoryPath.invoke(null);
+        Path configPath = (Path) allureConfigPath.invoke(null);
+        writeGenerateReportShellFiles.invoke(null);
+        writeAllureConfig.invoke(null, "Absolute Root Report", reportOutputDirectory.toString());
+        setStaticField(AllureManager.class, "allureOutPutDirectory", reportOutputDirectory.toString());
+        String command = (String) getCommandToCreateAllureReport.invoke(null);
+
+        String scriptFileName = SystemUtils.IS_OS_WINDOWS ? "generate_allure_report.bat" : "generate_allure_report.sh";
+        Path scriptPath = executionRoot.resolve(scriptFileName);
+        String scriptContent = Files.readString(scriptPath, StandardCharsets.UTF_8);
+        String configContent = Files.readString(configPath, StandardCharsets.UTF_8);
+
+        SHAFT.Validations.assertThat().object(reportDirectory).isEqualTo(executionRoot.resolve("allure-report")).perform();
+        SHAFT.Validations.assertThat().object(reportOutputDirectory).isEqualTo(executionRoot.resolve("target").resolve("allure-report")).perform();
+        SHAFT.Validations.assertThat().object(configPath).isEqualTo(executionRoot.resolve("allurerc.yaml")).perform();
+        SHAFT.Validations.assertThat().object(scriptContent).contains(configPath.toString()).perform();
+        SHAFT.Validations.assertThat().object(scriptContent).contains(resultsDirectory.toString()).perform();
+        SHAFT.Validations.assertThat().object(configContent).contains(reportOutputDirectory.toString().replace("\\", "/")).perform();
+        SHAFT.Validations.assertThat().object(configContent).contains(executionRoot.resolve("target").resolve("history.jsonl").toString().replace("\\", "/")).perform();
+        SHAFT.Validations.assertThat().object(command).contains(configPath.toString()).perform();
+        SHAFT.Validations.assertThat().object(command).contains(resultsDirectory.toString()).perform();
+        SHAFT.Validations.assertThat().object(command).contains(reportOutputDirectory.toString()).perform();
+    }
+
     @Test(description = "cleanAllureResultsDirectory should leave the results directory ready for parallel Allure writers")
     public void cleanAllureResultsDirectoryShouldRecreateResultsDirectory() throws Exception {
         Path resultsDirectory = Files.createTempDirectory("shaft-allure-results");
@@ -609,6 +659,7 @@ public class AllureManagerUnitTest {
         writeAllureReport.invoke(null);
 
         Files.deleteIfExists(Path.of(System.getProperty("user.dir"), "allurerc.yaml"));
+        Files.deleteIfExists(resultsDirectory.getParent().resolve("allurerc.yaml"));
     }
 
     @Test(description = "resolveAllureCommandPrefix should support legacy resolution and cached-empty shortcut")
@@ -798,7 +849,8 @@ public class AllureManagerUnitTest {
         setStaticField(AllureManager.class, "cachedIsAllure2", true);
 
         SHAFT.Properties.allure.set().generateArchive(true);
-        try (Stream<Path> existingArchives = Files.list(Path.of(System.getProperty("user.dir")))) {
+        Path archiveRoot = resultsDirectory.getParent();
+        try (Stream<Path> existingArchives = Files.list(archiveRoot)) {
             existingArchives.filter(path -> path.getFileName().toString().startsWith("generatedReport_")
                             && path.getFileName().toString().endsWith(".zip"))
                     .forEach(path -> {
@@ -811,14 +863,14 @@ public class AllureManagerUnitTest {
 
         AllureManager.generateAllureReportArchive();
 
-        try (Stream<Path> generatedArchives = Files.list(Path.of(System.getProperty("user.dir")))) {
+        try (Stream<Path> generatedArchives = Files.list(archiveRoot)) {
             long archiveCount = generatedArchives.filter(path -> path.getFileName().toString().startsWith("generatedReport_")
                             && path.getFileName().toString().endsWith(".zip"))
                     .count();
             SHAFT.Validations.assertThat().number((int) archiveCount).isEqualTo(1).perform();
         } finally {
             SHAFT.Properties.allure.set().generateArchive(false);
-            try (Stream<Path> generatedArchives = Files.list(Path.of(System.getProperty("user.dir")))) {
+            try (Stream<Path> generatedArchives = Files.list(archiveRoot)) {
                 generatedArchives.filter(path -> path.getFileName().toString().startsWith("generatedReport_")
                                 && path.getFileName().toString().endsWith(".zip"))
                         .forEach(path -> {

--- a/shaft-engine/src/test/java/testPackage/unitTests/PropertiesHelperCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/PropertiesHelperCoverageUnitTest.java
@@ -12,6 +12,8 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @Test(singleThreaded = true)
@@ -80,6 +82,25 @@ public class PropertiesHelperCoverageUnitTest {
         Assert.assertTrue(Properties.isInitialized(), "AI-agent initialization should load properties.");
         Assert.assertTrue(new File("target" + File.separator + "temp" + File.separator + "properties").exists(),
                 "AI-agent initialization should create the temporary properties directory.");
+    }
+
+    @Test
+    public void aiAgentPathResolverShouldUseConfiguredWorkspaceRootForRelativePaths() throws Exception {
+        Path workspaceRoot = Path.of(System.getProperty("user.dir"), "target", "ai-agent-workspace-root-test")
+                .toAbsolutePath()
+                .normalize();
+        Files.createDirectories(workspaceRoot);
+        SHAFT.Properties.paths.set().aiAgentWorkspaceRoot(workspaceRoot.toString());
+
+        Method resolver = PropertiesHelper.class.getDeclaredMethod("resolveAiAgentPath", String.class);
+        resolver.setAccessible(true);
+        String relativePath = "target" + File.separator + "temp" + File.separator + "properties";
+        String absolutePath = workspaceRoot.resolve("absolute-properties").toString();
+
+        Assert.assertEquals(resolver.invoke(null, relativePath),
+                workspaceRoot.resolve(relativePath).normalize().toString());
+        Assert.assertEquals(resolver.invoke(null, absolutePath),
+                Path.of(absolutePath).normalize().toString());
     }
 
     @Test

--- a/shaft-mcp/src/main/java/com/shaft/mcp/EngineService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/EngineService.java
@@ -12,13 +12,27 @@ import org.slf4j.LoggerFactory;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.stereotype.Service;
 
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 @Service
 public class EngineService {
     private static final Logger logger = LoggerFactory.getLogger(EngineService.class);
     private static SHAFT.GUI.WebDriver driver;
     private static boolean engineInitialized = false;
+    private static final String[][] MCP_PATH_PROPERTIES = {
+            {"allureResultsFolderPath", "allure-results"},
+            {"propertiesFolderPath", "src/main/resources/properties"},
+            {"downloadsFolderPath", "target/downloadedFiles"},
+            {"video.folder", "allure-results/videos"},
+            {"servicesFolderPath", "src/test/resources/META-INF/services"},
+            {"dynamicObjectRepositoryPath", "src/main/resources/dynamicObjectRepository"},
+            {"testDataFolderPath", "src/test/resources/testDataFiles"},
+            {"extentReportsFolderPath", "extent-reports"},
+            {"executionSummaryReportFolderPath", "execution-summary"},
+            {"PerformanceReportFolderPath", "performanceReport"}
+    };
 
     /**
      * Called by Spring after this bean is constructed.
@@ -33,6 +47,7 @@ public class EngineService {
         if (System.getProperty("rp.enable") == null) {
             System.setProperty("rp.enable", "false");
         }
+        configureRuntimePaths();
 
         // Configure remote WebDriver if REMOTE_DRIVER_ADDRESS environment variable is set.
         // SHAFT Engine uses a single "executionAddress" property:
@@ -112,28 +127,47 @@ public class EngineService {
         // Initialize engine setup only once to avoid repeated initialization warnings
         if (!engineInitialized) {
             logger.info("Initializing SHAFT Engine for AI Agent mode...");
-
-            // Pre-create directories to prevent issues during SHAFT Engine initialization.
-            // The allure-results directory must exist before Allure lifecycle is initialized.
-            // The properties directory must exist (empty) before engineSetup() to prevent
-            // SHAFT Engine from extracting default property files with subdirectories that
-            // cause "Is a directory" IOException during ReportHelper.attachPropertyFiles().
-            for (String dirPath : new String[]{
-                    System.getProperty("user.dir") + File.separator + "allure-results",
-                    "src" + File.separator + "main" + File.separator + "resources" + File.separator + "properties"
-            }) {
-                File dir = new File(dirPath);
-                if (!dir.exists()) {
-                    if (dir.mkdirs()) {
-                        logger.debug("Created directory: {}", dirPath);
-                    } else {
-                        logger.warn("Failed to create directory: {}", dirPath);
-                    }
-                }
-            }
-
+            configureRuntimePaths();
             TestNGListener.engineSetup(ProjectStructureManager.RunType.AI_AGENT);
             engineInitialized = true;
+        }
+    }
+
+    static Path configureRuntimePaths() {
+        return configureRuntimePaths(McpRuntimePaths.currentRoot());
+    }
+
+    static Path configureRuntimePaths(Path runtimeRoot) {
+        Path root = runtimeRoot.toAbsolutePath().normalize();
+        setPathProperty("aiAgentWorkspaceRoot", root, root.toString());
+        for (String[] pathProperty : MCP_PATH_PROPERTIES) {
+            setPathProperty(pathProperty[0], root, pathProperty[1]);
+        }
+        for (String[] pathProperty : MCP_PATH_PROPERTIES) {
+            createDirectory(System.getProperty(pathProperty[0]), pathProperty[0]);
+        }
+        return root;
+    }
+
+    private static void setPathProperty(String key, Path root, String defaultValue) {
+        String configured = System.getProperty(key);
+        String value = configured == null || configured.isBlank()
+                ? defaultValue
+                : configured;
+        Path path = Path.of(value);
+        if (!path.isAbsolute()) {
+            path = root.resolve(path).normalize();
+        }
+        System.setProperty(key, path.toString());
+    }
+
+    private static void createDirectory(String configuredPath, String propertyKey) {
+        try {
+            Files.createDirectories(Path.of(configuredPath));
+        } catch (IOException exception) {
+            throw new IllegalStateException(
+                    "Could not create MCP runtime directory for " + propertyKey + ": " + configuredPath,
+                    exception);
         }
     }
 

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpRuntimePaths.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpRuntimePaths.java
@@ -1,0 +1,125 @@
+package com.shaft.mcp;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Resolves the writable local root used by the MCP server for generated engine artifacts.
+ */
+final class McpRuntimePaths {
+    static final String WORKSPACE_ENVIRONMENT_VARIABLE = "SHAFT_MCP_WORKSPACE_ROOT";
+
+    private McpRuntimePaths() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Resolves and creates the effective MCP runtime root for the current process.
+     *
+     * @return writable runtime root
+     */
+    static Path currentRoot() {
+        return resolveRoot(
+                System.getenv(),
+                Path.of("").toAbsolutePath().normalize(),
+                System.getProperty("os.name", ""),
+                Path.of(System.getProperty("user.home")).toAbsolutePath().normalize());
+    }
+
+    static Path resolveRoot(
+            Map<String, String> environment,
+            Path currentDirectory,
+            String operatingSystemName,
+            Path userHome) {
+        String configuredWorkspace = environment.get(WORKSPACE_ENVIRONMENT_VARIABLE);
+        if (configuredWorkspace != null && !configuredWorkspace.isBlank()) {
+            return ensureWritableDirectory(Path.of(configuredWorkspace));
+        }
+
+        Path normalizedCurrentDirectory = currentDirectory.toAbsolutePath().normalize();
+        if (!isProtectedWindowsDirectory(normalizedCurrentDirectory, environment, operatingSystemName)
+                && isWritableDirectory(normalizedCurrentDirectory)) {
+            return normalizedCurrentDirectory;
+        }
+
+        return ensureWritableDirectory(applicationDataRoot(environment, operatingSystemName, userHome)
+                .resolve("work"));
+    }
+
+    private static Path applicationDataRoot(
+            Map<String, String> environment,
+            String operatingSystemName,
+            Path userHome) {
+        String normalizedOperatingSystem = operatingSystemName.toLowerCase(Locale.ROOT);
+        if (normalizedOperatingSystem.contains("win")) {
+            String localAppData = environment.get("LOCALAPPDATA");
+            Path base = localAppData == null || localAppData.isBlank()
+                    ? userHome.resolve("AppData").resolve("Local")
+                    : Path.of(localAppData);
+            return base.resolve("ShaftHQ").resolve("shaft-mcp");
+        }
+        if (normalizedOperatingSystem.contains("mac") || normalizedOperatingSystem.contains("darwin")) {
+            return userHome.resolve("Library").resolve("Application Support")
+                    .resolve("ShaftHQ").resolve("shaft-mcp");
+        }
+        String xdgDataHome = environment.get("XDG_DATA_HOME");
+        Path base = xdgDataHome == null || xdgDataHome.isBlank()
+                ? userHome.resolve(".local").resolve("share")
+                : Path.of(xdgDataHome);
+        return base.resolve("shafthq").resolve("shaft-mcp");
+    }
+
+    private static boolean isProtectedWindowsDirectory(
+            Path directory,
+            Map<String, String> environment,
+            String operatingSystemName) {
+        if (!operatingSystemName.toLowerCase(Locale.ROOT).contains("win")) {
+            return false;
+        }
+        String windowsRoot = firstNonBlank(environment.get("SystemRoot"), environment.get("WINDIR"));
+        if (windowsRoot == null) {
+            Path root = directory.getRoot();
+            windowsRoot = root == null ? "C:\\Windows" : root.resolve("Windows").toString();
+        }
+        return directory.startsWith(Path.of(windowsRoot).toAbsolutePath().normalize());
+    }
+
+    private static String firstNonBlank(String first, String second) {
+        if (first != null && !first.isBlank()) {
+            return first;
+        }
+        if (second != null && !second.isBlank()) {
+            return second;
+        }
+        return null;
+    }
+
+    private static boolean isWritableDirectory(Path directory) {
+        if (!Files.isDirectory(directory)) {
+            return false;
+        }
+        try {
+            Path marker = Files.createTempFile(directory, ".shaft-mcp-write-test", ".tmp");
+            Files.deleteIfExists(marker);
+            return true;
+        } catch (IOException | RuntimeException ignored) {
+            return false;
+        }
+    }
+
+    private static Path ensureWritableDirectory(Path directory) {
+        Path normalized = directory.toAbsolutePath().normalize();
+        try {
+            Files.createDirectories(normalized);
+        } catch (IOException exception) {
+            throw new IllegalStateException("MCP runtime root cannot be created: " + normalized, exception);
+        }
+        if (!isWritableDirectory(normalized)) {
+            throw new IllegalStateException("MCP runtime root is not writable: " + normalized);
+        }
+        return normalized;
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpWorkspacePolicy.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpWorkspacePolicy.java
@@ -10,8 +10,6 @@ import java.util.List;
  * Local MCP workspace boundary for user-supplied filesystem paths.
  */
 final class McpWorkspacePolicy {
-    private static final String WORKSPACE_ENVIRONMENT_VARIABLE = "SHAFT_MCP_WORKSPACE_ROOT";
-
     private final Path root;
 
     private McpWorkspacePolicy(Path root) {
@@ -19,16 +17,12 @@ final class McpWorkspacePolicy {
     }
 
     /**
-     * Creates a policy from {@code SHAFT_MCP_WORKSPACE_ROOT}, or the current working directory when unset.
+     * Creates a policy from the effective MCP runtime root.
      *
      * @return effective workspace policy
      */
     static McpWorkspacePolicy current() {
-        String configured = System.getenv(WORKSPACE_ENVIRONMENT_VARIABLE);
-        Path root = configured == null || configured.isBlank()
-                ? Path.of("")
-                : Path.of(configured);
-        return new McpWorkspacePolicy(root);
+        return new McpWorkspacePolicy(McpRuntimePaths.currentRoot());
     }
 
     /**

--- a/shaft-mcp/src/test/java/com/shaft/mcp/EngineServiceRuntimePathTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/EngineServiceRuntimePathTest.java
@@ -1,0 +1,91 @@
+package com.shaft.mcp;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EngineServiceRuntimePathTest {
+    private static final List<String> RUNTIME_PATH_PROPERTIES = List.of(
+            "aiAgentWorkspaceRoot",
+            "allureResultsFolderPath",
+            "propertiesFolderPath",
+            "downloadsFolderPath",
+            "video.folder",
+            "servicesFolderPath",
+            "dynamicObjectRepositoryPath",
+            "testDataFolderPath",
+            "extentReportsFolderPath",
+            "executionSummaryReportFolderPath",
+            "PerformanceReportFolderPath");
+
+    @TempDir
+    Path temp;
+
+    private Map<String, String> originalProperties;
+
+    @BeforeEach
+    void captureOriginalProperties() {
+        originalProperties = new HashMap<>();
+        RUNTIME_PATH_PROPERTIES.forEach(property -> originalProperties.put(property, System.getProperty(property)));
+        RUNTIME_PATH_PROPERTIES.forEach(System::clearProperty);
+    }
+
+    @AfterEach
+    void restoreOriginalProperties() {
+        RUNTIME_PATH_PROPERTIES.forEach(System::clearProperty);
+        originalProperties.forEach((property, value) -> {
+            if (value != null) {
+                System.setProperty(property, value);
+            }
+        });
+    }
+
+    @Test
+    void configureRuntimePathsShouldResolveRelativePropertiesUnderRuntimeRoot() {
+        Path runtimeRoot = temp.resolve("runtime-root");
+        System.setProperty("allureResultsFolderPath", "custom-results");
+        System.setProperty("downloadsFolderPath", "downloads");
+
+        Path resolvedRoot = EngineService.configureRuntimePaths(runtimeRoot);
+
+        assertEquals(runtimeRoot.toAbsolutePath().normalize(), resolvedRoot);
+        assertEquals(resolvedRoot.toString(), System.getProperty("aiAgentWorkspaceRoot"));
+        assertEquals(resolvedRoot.resolve("custom-results").toString(),
+                System.getProperty("allureResultsFolderPath"));
+        assertEquals(resolvedRoot.resolve("downloads").toString(),
+                System.getProperty("downloadsFolderPath"));
+        assertEquals(resolvedRoot.resolve("src/main/resources/properties").toString(),
+                System.getProperty("propertiesFolderPath"));
+        assertTrue(Files.isDirectory(resolvedRoot.resolve("custom-results")));
+        assertTrue(Files.isDirectory(resolvedRoot.resolve("downloads")));
+        assertTrue(Files.isDirectory(resolvedRoot.resolve("src/main/resources/properties")));
+    }
+
+    @Test
+    void configureRuntimePathsShouldPreserveExplicitAbsoluteOverrides() {
+        Path runtimeRoot = temp.resolve("runtime-root");
+        Path absoluteResults = temp.resolve("absolute-results");
+        Path absoluteServices = temp.resolve("absolute-services");
+        System.setProperty("allureResultsFolderPath", absoluteResults.toString());
+        System.setProperty("servicesFolderPath", absoluteServices.toString());
+
+        EngineService.configureRuntimePaths(runtimeRoot);
+
+        assertEquals(absoluteResults.toAbsolutePath().normalize().toString(),
+                System.getProperty("allureResultsFolderPath"));
+        assertEquals(absoluteServices.toAbsolutePath().normalize().toString(),
+                System.getProperty("servicesFolderPath"));
+        assertTrue(Files.isDirectory(absoluteResults));
+        assertTrue(Files.isDirectory(absoluteServices));
+    }
+}

--- a/shaft-mcp/src/test/java/com/shaft/mcp/McpRuntimePathsTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/McpRuntimePathsTest.java
@@ -1,0 +1,71 @@
+package com.shaft.mcp;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class McpRuntimePathsTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void configuredWorkspaceRootShouldWinAndBeCreated() {
+        Path configuredWorkspace = temp.resolve("configured-workspace");
+        Map<String, String> environment = Map.of(
+                McpRuntimePaths.WORKSPACE_ENVIRONMENT_VARIABLE, configuredWorkspace.toString());
+
+        Path resolvedRoot = McpRuntimePaths.resolveRoot(
+                environment,
+                temp.resolve("current-directory"),
+                "Windows 11",
+                temp.resolve("home"));
+
+        assertEquals(configuredWorkspace.toAbsolutePath().normalize(), resolvedRoot);
+        assertTrue(Files.isDirectory(resolvedRoot));
+    }
+
+    @Test
+    void writableNonProtectedCurrentDirectoryShouldBeUsed() throws Exception {
+        Path currentDirectory = Files.createDirectories(temp.resolve("current-directory"));
+
+        Path resolvedRoot = McpRuntimePaths.resolveRoot(
+                Map.of(),
+                currentDirectory,
+                "Linux",
+                temp.resolve("home"));
+
+        assertEquals(currentDirectory.toAbsolutePath().normalize(), resolvedRoot);
+    }
+
+    @Test
+    void protectedWindowsDirectoryShouldFallBackToLocalAppData() throws Exception {
+        Path windowsRoot = Files.createDirectories(temp.resolve("Windows"));
+        Path currentDirectory = Files.createDirectories(windowsRoot.resolve("System32"));
+        Path localAppData = temp.resolve("local-app-data");
+        Map<String, String> environment = new HashMap<>();
+        environment.put("SystemRoot", windowsRoot.toString());
+        environment.put("LOCALAPPDATA", localAppData.toString());
+
+        Path resolvedRoot = McpRuntimePaths.resolveRoot(
+                environment,
+                currentDirectory,
+                "Windows 11",
+                temp.resolve("home"));
+
+        Path expectedRoot = localAppData
+                .resolve("ShaftHQ")
+                .resolve("shaft-mcp")
+                .resolve("work")
+                .toAbsolutePath()
+                .normalize();
+        assertEquals(expectedRoot, resolvedRoot);
+        assertTrue(Files.isDirectory(resolvedRoot));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes `shaft-mcp` startup when the MCP host launches the server from `C:\Windows\system32` or another unsuitable working directory.

Root cause: SHAFT engine bootstrap and Allure report generation relied on relative paths and `user.dir`. When the MCP process starts from a protected Windows system directory, default property downloads and Allure result/report files resolve under `system32`, causing `AccessDeniedException` and preventing the MCP tool flow from creating the files the engine needs.

## What changed

- Added a package-private MCP runtime path resolver that chooses:
  - `SHAFT_MCP_WORKSPACE_ROOT` when configured.
  - The current directory only when writable and not a protected Windows system directory.
  - OS app-data fallback roots otherwise.
- Normalized MCP SHAFT path properties to absolute paths before engine bootstrap while preserving explicit absolute user overrides.
- Added `aiAgentWorkspaceRoot` to SHAFT path properties and used it for AI-agent default property downloads and copied target properties.
- Updated Allure report generation so an absolute `allureResultsFolderPath` anchors `allure-report`, `target/allure-report`, `allurerc.yaml`, helper scripts, archives, history, and the Allure process working directory.
- Kept MCP tool names and arguments unchanged.

## Validation

- `mvn --batch-mode -pl shaft-mcp -am test '-Dtest=ShaftMcpApplicationTests,ShaftMcpInstallerTest,McpRuntimePathsTest,EngineServiceRuntimePathTest' '-Dgpg.skip'`
- `mvn --batch-mode -pl shaft-engine '-Dtest=PropertiesHelperCoverageUnitTest,AllureManagerUnitTest' test '-Dgpg.skip'`
- `mvn --batch-mode -pl shaft-mcp -am package '-DskipTests' '-Dgpg.skip'`
- `python scripts/ci/validate_shaft_mcp_configuration.py`

`python3` is not available on this Windows machine, so the validator was run with `python`.

## Docs follow-up

A separate user-guide update is needed in `shafthq.github.io`, primarily `docs/agentic/mcp.mdx` and manual setup docs, to document the new runtime workspace behavior and `SHAFT_MCP_WORKSPACE_ROOT`.