### PR TITLE
[codex] Optimize SHAFT performance hot paths

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/api/RestActions.java
+++ b/shaft-engine/src/main/java/com/shaft/api/RestActions.java
@@ -85,6 +85,9 @@ import static io.restassured.RestAssured.given;
  */
 @SuppressWarnings("unused")
 public class RestActions {
+    private static final ObjectMapper JACKSON_MAPPER = new ObjectMapper();
+    private static final Gson GSON = new Gson();
+    private static final Gson PRETTY_GSON = new GsonBuilder().setPrettyPrinting().create();
     private static final String ARGUMENT_SEPARATOR = "?";
     private static final String ERROR_NOT_FOUND = "Either actual value is \"null\" or couldn't find anything that matches with the desired ";
     private static final String ERROR_INCORRECT_JSONPATH = "Incorrect jsonPath ";
@@ -420,7 +423,7 @@ public class RestActions {
             List<Object> jsonList = null;
             try {
                 JSONArray jsonArray = JsonPath.compile(jsonPath).read(new JSONObject(jsonObject), confOrgJsonProvider);
-                jsonList = new ObjectMapper().readValue(Objects.requireNonNull(jsonArray).toString(), new TypeReference<>() {
+                jsonList = JACKSON_MAPPER.readValue(Objects.requireNonNull(jsonArray).toString(), new TypeReference<>() {
                 });
             } catch (JSONException | JsonProcessingException rootCauseException) {
                 ReportManager.log(ERROR_FAILED_TO_PARSE_JSON, Level.ERROR);
@@ -634,7 +637,6 @@ public class RestActions {
                     + "\", jsonPath to target array \"" + jsonPathToTargetArray + "\".");
         }
         boolean comparisonResult;
-        ObjectMapper jacksonMapper = new ObjectMapper();
         List<Object> expectedJSONAttachment = null;
 
         try {
@@ -642,7 +644,7 @@ public class RestActions {
             ObjectNode actualJsonObject = null;
             ArrayNode actualJsonArray = null;
 
-            var actualRoot = jacksonMapper.readTree(response.asString());
+            var actualRoot = JACKSON_MAPPER.readTree(response.asString());
             if (actualRoot instanceof ObjectNode) {
                 actualJsonObject = (ObjectNode) actualRoot;
             } else {
@@ -656,18 +658,17 @@ public class RestActions {
 
             JsonNode expectedRoot;
             try (FileReader expectedReader = new FileReader(referenceJsonFilePath)) {
-                expectedRoot = jacksonMapper.readTree(expectedReader);
+                expectedRoot = JACKSON_MAPPER.readTree(expectedReader);
             }
             if (expectedRoot instanceof ObjectNode) {
                 expectedJsonObject = (ObjectNode) expectedRoot;
                 expectedJSONAttachment = Arrays.asList("File Content", "Expected JSON",
-                        new GsonBuilder().setPrettyPrinting().create()
-                                .toJson(JsonParser.parseString(expectedJsonObject.toString())));
+                        PRETTY_GSON.toJson(JsonParser.parseString(expectedJsonObject.toString())));
             } else {
                 // expectedRoot is an array
                 expectedJsonArray = (ArrayNode) expectedRoot;
-                expectedJSONAttachment = Arrays.asList("File Content", "Expected JSON", new GsonBuilder()
-                        .setPrettyPrinting().create().toJson(JsonParser.parseString(expectedJsonArray.toString())));
+                expectedJSONAttachment = Arrays.asList("File Content", "Expected JSON",
+                        PRETTY_GSON.toJson(JsonParser.parseString(expectedJsonArray.toString())));
             }
 
             // handle different combinations of expected and actual (object vs array)
@@ -752,13 +753,12 @@ public class RestActions {
     }
 
     private static InputStream parseJsonBody(Object body) throws IOException {
-        ObjectMapper jacksonMapper = new ObjectMapper();
         ObjectNode actualJsonObject = null;
         ArrayNode actualJsonArray = null;
         if (body.getClass().getName().toLowerCase().contains("restassured")) {
             String bodyString = ((ResponseBody<?>) body).asString();
             if (!bodyString.isEmpty()) {
-                var root = jacksonMapper.readTree(bodyString);
+                var root = JACKSON_MAPPER.readTree(bodyString);
                 if (root instanceof ObjectNode) {
                     actualJsonObject = (ObjectNode) root;
                 } else {
@@ -766,7 +766,7 @@ public class RestActions {
                 }
             }
         } else if (body instanceof InputStream bodyStream) {
-            var root = jacksonMapper.readTree(bodyStream);
+            var root = JACKSON_MAPPER.readTree(bodyStream);
             if (root instanceof ObjectNode) {
                 actualJsonObject = (ObjectNode) root;
             } else {
@@ -777,18 +777,18 @@ public class RestActions {
         } else if (body instanceof ArrayNode) {
             actualJsonArray = (ArrayNode) body;
         } else if (body.getClass().getName().toLowerCase().contains("jsonobject")) {
-            var root = jacksonMapper.readTree(body.toString());
+            var root = JACKSON_MAPPER.readTree(body.toString());
             if (root instanceof ObjectNode) {
                 actualJsonObject = (ObjectNode) root;
             } else if (root instanceof ArrayNode) {
                 actualJsonArray = (ArrayNode) root;
             } else {
-                actualJsonObject = jacksonMapper.createObjectNode().set("value", root);
+                actualJsonObject = JACKSON_MAPPER.createObjectNode().set("value", root);
             }
         } else if (body instanceof Map<?, ?> bodyMap) {
-            actualJsonObject = jacksonMapper.valueToTree(bodyMap);
+            actualJsonObject = JACKSON_MAPPER.valueToTree(bodyMap);
         } else {
-            var root = jacksonMapper.readTree(body.toString());
+            var root = JACKSON_MAPPER.readTree(body.toString());
             if (root instanceof ObjectNode) {
                 actualJsonObject = (ObjectNode) root;
             } else {
@@ -796,10 +796,10 @@ public class RestActions {
             }
         }
         if (actualJsonObject != null) {
-            return new ByteArrayInputStream((new GsonBuilder().setPrettyPrinting().create()
+            return new ByteArrayInputStream((PRETTY_GSON
                     .toJson(JsonParser.parseString(actualJsonObject.toString()))).getBytes());
         } else if (actualJsonArray != null) {
-            return new ByteArrayInputStream((new GsonBuilder().setPrettyPrinting().create()
+            return new ByteArrayInputStream((PRETTY_GSON
                     .toJson(JsonParser.parseString(actualJsonArray.toString()))).getBytes());
         } else {
             // in case of an empty body
@@ -846,13 +846,11 @@ public class RestActions {
                                                ArrayNode expectedJsonArray, ObjectNode actualJsonObject, ArrayNode actualJsonArray,
                                                String jsonPathToTargetArray)
             throws JSONException, IOException {
-        ObjectMapper jacksonMapper = new ObjectMapper();
-        Gson gson = new Gson();
         if (!jsonPathToTargetArray.isEmpty() && (expectedJsonArray != null)) {
             // if expected is an array and the user provided the path to extract it from the
             // response
-            ArrayNode actualJsonArrayFromJsonPath = (ArrayNode) jacksonMapper
-                    .readTree(gson.toJsonTree(getResponseJSONValueAsList(response, jsonPathToTargetArray))
+            ArrayNode actualJsonArrayFromJsonPath = (ArrayNode) JACKSON_MAPPER
+                    .readTree(GSON.toJsonTree(getResponseJSONValueAsList(response, jsonPathToTargetArray))
                             .getAsJsonArray().toString());
             // check that all expected elements are present in the actual array.
             // O(n*m) scan matches the previous json-simple containsAll() semantics because
@@ -871,8 +869,8 @@ public class RestActions {
         } else if (jsonPathToTargetArray.isEmpty() && (expectedJsonArray != null)) {
             // if expected is an array and the user did not provide the path to extract it
             // from the response
-            String actual = actualJsonArray == null ? gson.toJson(actualJsonObject) : actualJsonArray.toString();
-            String expected = gson.toJson(jacksonMapper.readTree(expectedJsonArray.toString()));
+            String actual = actualJsonArray == null ? GSON.toJson(actualJsonObject) : actualJsonArray.toString();
+            String expected = GSON.toJson(JACKSON_MAPPER.readTree(expectedJsonArray.toString()));
             return actual.contains(expected.substring(1));
         } else if (expectedJsonObject != null) {
             // if expected is an object and actual is also an object

--- a/shaft-engine/src/main/java/com/shaft/api/ShaftRestAssuredFilter.java
+++ b/shaft-engine/src/main/java/com/shaft/api/ShaftRestAssuredFilter.java
@@ -1,5 +1,6 @@
 package com.shaft.api;
 
+import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
@@ -48,6 +49,7 @@ import java.nio.charset.StandardCharsets;
  *      io.restassured.specification.RequestSpecification)
  */
 public class ShaftRestAssuredFilter implements Filter {
+    private static final Gson PRETTY_GSON = new GsonBuilder().setPrettyPrinting().create();
 
     /**
      * Intercepts every REST Assured request, attaches the request and response
@@ -328,8 +330,7 @@ public class ShaftRestAssuredFilter implements Filter {
     public String formatBody(String body, String contentType) {
         if ("application/json".equals(contentType)) {
             try {
-                return new GsonBuilder().setPrettyPrinting().create()
-                        .toJson(JsonParser.parseString(body));
+                return PRETTY_GSON.toJson(JsonParser.parseString(body));
             } catch (JsonParseException ignored) {
                 // If parsing fails return the original
             }

--- a/shaft-engine/src/main/java/com/shaft/gui/element/ElementActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/ElementActions.java
@@ -9,6 +9,7 @@ import com.shaft.gui.element.internal.Actions;
 import com.shaft.gui.element.internal.ElementInformation;
 import com.shaft.gui.internal.image.ScreenshotManager;
 import com.shaft.gui.internal.locator.LocatorBuilder;
+import com.shaft.tools.internal.support.JavaHelper;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import com.shaft.validation.internal.WebDriverElementValidationsBuilder;
@@ -308,19 +309,24 @@ public class ElementActions extends FluentWebDriverAction {
         } else {
 
             try {
-                String elementName = elementActionsHelper.getElementName(driverFactoryHelper.getDriver(), elementLocator);
+                String elementName = elementInformation.getElementName();
+                if (elementName == null || elementName.isBlank()) {
+                    elementName = JavaHelper.formatLocatorToString(elementLocator);
+                }
                 if (!elementActionsHelper.waitForElementTextToBeNot(driverFactoryHelper.getDriver(), elementLocator, "")) {
                     elementActionsHelper.failAction(driverFactoryHelper.getDriver(), valueOrVisibleText, elementLocator);
                 }
 
+                elementInformation = ElementInformation.fromList(elementActionsHelper.identifyUniqueElement(driverFactoryHelper.getDriver(), elementLocator));
+                Select selectElement = new Select(elementInformation.getFirstElement());
                 boolean isOptionFound = false;
-                List<WebElement> availableOptionsList = (new Select((WebElement) elementActionsHelper.identifyUniqueElement(driverFactoryHelper.getDriver(), elementLocator).get(1))).getOptions();
+                List<WebElement> availableOptionsList = selectElement.getOptions();
 
                 for (int i = 0; i < availableOptionsList.size(); ++i) {
                     String visibleText = availableOptionsList.get(i).getText();
                     String value = availableOptionsList.get(i).getDomProperty("value");
                     if (visibleText.trim().equals(valueOrVisibleText) || Objects.requireNonNull(value).trim().equals(valueOrVisibleText)) {
-                        (new Select((WebElement) elementActionsHelper.identifyUniqueElement(driverFactoryHelper.getDriver(), elementLocator).get(1))).selectByIndex(i);
+                        selectElement.selectByIndex(i);
                         elementActionsHelper.passAction(driverFactoryHelper.getDriver(), elementLocator, Thread.currentThread().getStackTrace()[1].getMethodName(), valueOrVisibleText, null, elementName);
                         isOptionFound = true;
                         break;

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -862,8 +862,9 @@ public class Actions extends ElementActions {
                         List<WebElement> skippedElementsList = new ArrayList<>();
                         String[] skippedElementLocators = SHAFT.Properties.visuals.screenshotParamsSkippedElementsFromScreenshot().split(";");
                         for (String locator : skippedElementLocators) {
-                            if (elementActionsHelper.getElementsCount(driverFactoryHelper.getDriver(), By.xpath(locator)) == 1) {
-                                skippedElementsList.add(((WebElement) elementActionsHelper.identifyUniqueElementIgnoringVisibility(driverFactoryHelper.getDriver(), By.xpath(locator)).get(1)));
+                            WebElement skippedElement = findUniqueElementIgnoringVisibility(By.xpath(locator));
+                            if (skippedElement != null) {
+                                skippedElementsList.add(skippedElement);
                             }
                         }
                         WebElement[] skippedElementsArray = new WebElement[skippedElementsList.size()];
@@ -894,6 +895,15 @@ public class Actions extends ElementActions {
         //append shaft watermark
         screenshot = appendShaftWatermark(screenshot);
         return screenshot;
+    }
+
+    private WebElement findUniqueElementIgnoringVisibility(By targetElementLocator) {
+        List<Object> elementInformation = elementActionsHelper.getMatchingElementsInformation(
+                driverFactoryHelper.getDriver(), targetElementLocator, false);
+        if (Integer.parseInt(elementInformation.getFirst().toString()) == 1) {
+            return (WebElement) elementInformation.get(1);
+        }
+        return null;
     }
 
     private byte[] takeAIHighlightedScreenshot(WebElement element, boolean isPass) {

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotManager.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotManager.java
@@ -140,8 +140,9 @@ public class ScreenshotManager {
             List<WebElement> skippedElementsList = new ArrayList<>();
             String[] skippedElementLocators = SHAFT.Properties.visuals.screenshotParamsSkippedElementsFromScreenshot().split(";");
             for (String locator : skippedElementLocators) {
-                if (elementActionsHelper.getElementsCount(driver, By.xpath(locator)) == 1) {
-                    skippedElementsList.add(((WebElement) elementActionsHelper.identifyUniqueElementIgnoringVisibility(driver, By.xpath(locator)).get(1)));
+                WebElement skippedElement = findUniqueElementIgnoringVisibility(driver, By.xpath(locator));
+                if (skippedElement != null) {
+                    skippedElementsList.add(skippedElement);
                 }
             }
             WebElement[] skippedElementsArray = new WebElement[skippedElementsList.size()];
@@ -159,8 +160,9 @@ public class ScreenshotManager {
     private byte[] takeElementScreenshot(WebDriver driver, By targetElementLocator, Boolean
             returnRegularScreenshotInCaseOfFailure) {
         try {
-            if (targetElementLocator != null && elementActionsHelper.getElementsCount(driver, targetElementLocator) == 1) {
-                return ((WebElement) elementActionsHelper.identifyUniqueElementIgnoringVisibility(driver, targetElementLocator).get(1)).getScreenshotAs(OutputType.BYTES);
+            WebElement targetElement = findUniqueElementIgnoringVisibility(driver, targetElementLocator);
+            if (targetElement != null) {
+                return targetElement.getScreenshotAs(OutputType.BYTES);
             } else {
                 if (returnRegularScreenshotInCaseOfFailure) {
                     return this.takeViewportScreenshot(driver);
@@ -176,6 +178,17 @@ public class ScreenshotManager {
                 return new byte[]{};
             }
         }
+    }
+
+    private WebElement findUniqueElementIgnoringVisibility(WebDriver driver, By targetElementLocator) {
+        if (targetElementLocator == null) {
+            return null;
+        }
+        List<Object> elementInformation = elementActionsHelper.getMatchingElementsInformation(driver, targetElementLocator, false);
+        if (Integer.parseInt(elementInformation.getFirst().toString()) == 1) {
+            return (WebElement) elementInformation.get(1);
+        }
+        return null;
     }
 
     private List<Object> internalCaptureScreenShot(WebDriver driver, By elementLocator, String actionName, boolean shouldCaptureScreenshot, boolean isPass) {

--- a/shaft-engine/src/main/java/com/shaft/tools/io/JSONFileManager.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/JSONFileManager.java
@@ -9,12 +9,15 @@ import io.restassured.path.json.JsonPath;
 import io.restassured.path.json.exception.JsonPathException;
 
 import java.io.ByteArrayInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -39,6 +42,10 @@ import java.util.Map;
 public class JSONFileManager {
     private static final ThreadLocal<FileReader> reader = new ThreadLocal<>();
     private final String jsonFilePath;
+    private final Path resolvedJsonFilePath;
+    private String cachedJsonContent;
+    private long cachedFileSize = -1L;
+    private FileTime cachedLastModifiedTime;
 
     /**
      * Creates a new instance of the test data json reader using the target json
@@ -50,18 +57,10 @@ public class JSONFileManager {
         DriverFactory.reloadProperties();
         jsonFilePath = JavaHelper.appendTestDataToRelativePath(jsonFilePath);
         this.jsonFilePath = jsonFilePath;
-        initializeReader();
-        // Reader was opened only to validate file existence; close it immediately so no
-        // ThreadLocal reference lingers until the first getTestData() call.
-        closeReader();
+        this.resolvedJsonFilePath = Paths.get(FileActions.getInstance(true).getAbsolutePath(jsonFilePath));
         List<List<Object>> attachments = new ArrayList<>();
-        List<Object> testDataFileAttachment = null;
-        try {
-            byte[] raw = Files.readAllBytes(Paths.get(jsonFilePath));
-            testDataFileAttachment = Arrays.asList("Test Data", "JSON", new ByteArrayInputStream(raw));
-        } catch (IOException e) {
-            ReportManagerHelper.logDiscrete(e);
-        }
+        byte[] raw = readJsonBytes();
+        List<Object> testDataFileAttachment = Arrays.asList("Test Data", "JSON", new ByteArrayInputStream(raw));
         attachments.add(testDataFileAttachment);
         ReportManagerHelper.log("Loaded Test Data: \"" + jsonFilePath + "\".", attachments);
     }
@@ -156,60 +155,63 @@ public class JSONFileManager {
      */
     private Object getTestData(String jsonPath, DataType dataType) {
         Object testData = null;
-        initializeReader();
         try {
+            String jsonContent = getJsonContent();
             switch (dataType) {
-                case STRING -> testData = JsonPath.from(reader.get()).getString(jsonPath);
-                case LIST -> testData = JsonPath.from(reader.get()).getList(jsonPath);
-                case MAP -> testData = JsonPath.from(reader.get()).getMap(jsonPath);
-                case JSON -> testData = JsonPath.from(reader.get()).getJsonObject(jsonPath);
+                case STRING -> testData = JsonPath.from(jsonContent).getString(jsonPath);
+                case LIST -> testData = JsonPath.from(jsonContent).getList(jsonPath);
+                case MAP -> testData = JsonPath.from(jsonContent).getMap(jsonPath);
+                case JSON -> testData = JsonPath.from(jsonContent).getJsonObject(jsonPath);
             }
         } catch (ClassCastException rootCauseException) {
             FailureReporter.fail(this.getClass(), "Incorrect jsonPath. [" + jsonPath + "].", rootCauseException);
         } catch (JsonPathException | IllegalArgumentException rootCauseException) {
             FailureReporter.fail(this.getClass(), "Couldn't read the desired file. [" + this.jsonFilePath + "].", rootCauseException);
-        } finally {
-            closeReader();
         }
         return testData;
     }
 
     /**
-     * initializes the json reader using the target json file path
+     * Returns cached JSON content, refreshing it when the underlying file changes.
+     *
+     * @return JSON content as UTF-8 text
      */
-    private void initializeReader() {
+    private synchronized String getJsonContent() {
+        if (isCacheStale()) {
+            readJsonBytes();
+        }
+        return cachedJsonContent;
+    }
+
+    private synchronized byte[] readJsonBytes() {
         try {
-            // Close existing reader before creating a new one to prevent resource leaks
-            FileReader existingReader = reader.get();
-            if (existingReader != null) {
-                try {
-                    existingReader.close();
-                } catch (IOException ignored) {
-                    // best-effort close
-                }
-            }
-            reader.set(new FileReader(FileActions.getInstance(true).getAbsolutePath(jsonFilePath), StandardCharsets.UTF_8));
-        } catch (FileNotFoundException rootCauseException) {
+            BasicFileAttributes attributes = Files.readAttributes(resolvedJsonFilePath, BasicFileAttributes.class);
+            byte[] raw = Files.readAllBytes(resolvedJsonFilePath);
+            cachedJsonContent = new String(raw, StandardCharsets.UTF_8);
+            cachedFileSize = attributes.size();
+            cachedLastModifiedTime = attributes.lastModifiedTime();
+            reader.remove();
+            return raw;
+        } catch (NoSuchFileException rootCauseException) {
             FailureReporter.fail(this.getClass(), "Couldn't read the desired file. [" + this.jsonFilePath + "].", rootCauseException);
         } catch (IOException formatException) {
             FailureReporter.fail(this.getClass(), "file didn't match the specified format. [" + this.jsonFilePath + "].", formatException);
         }
+        return new byte[0];
     }
 
-    /**
-     * Closes the current thread-local {@link FileReader} and removes it from the
-     * {@link ThreadLocal} to prevent memory leaks on pooled or long-lived threads.
-     */
-    private void closeReader() {
-        FileReader existingReader = reader.get();
-        if (existingReader != null) {
-            try {
-                existingReader.close();
-            } catch (IOException ignored) {
-                // best-effort close
-            }
-            reader.remove();
+    private boolean isCacheStale() {
+        if (cachedJsonContent == null || cachedLastModifiedTime == null) {
+            return true;
         }
+        try {
+            BasicFileAttributes attributes = Files.readAttributes(resolvedJsonFilePath, BasicFileAttributes.class);
+            return cachedFileSize != attributes.size()
+                    || !cachedLastModifiedTime.equals(attributes.lastModifiedTime());
+        } catch (IOException formatException) {
+            FailureReporter.fail(this.getClass(), "file didn't match the specified format. [" + this.jsonFilePath + "].", formatException);
+        }
+        return true;
     }
 
     public enum DataType {

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
@@ -782,11 +782,17 @@ public class ReportManagerHelper {
      */
     private static void createDebugCompanionLogEntry(String logText, Level sourceLevel) {
         if (!Level.DEBUG.equals(sourceLevel)) {
+            boolean debugLoggingEnabled = logger != null && logger.isDebugEnabled();
+            if (!debugLoggingEnabled && !debugFileLoggingEnabled) {
+                return;
+            }
             String caller = getCallingMethodFullName();
             String debugLogText = caller == null || caller.isBlank()
                     ? "Debug action details: " + logText
                     : "Debug action details [caller=" + caller + "]: " + logText;
-            logger.debug(debugLogText);
+            if (debugLoggingEnabled) {
+                logger.debug(debugLogText);
+            }
             writeToDebugLogFileIfEnabled(debugLogText, Level.DEBUG);
         }
     }

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
@@ -25,6 +25,7 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Sequence;
 import org.openqa.selenium.remote.RemoteWebElement;
+import org.mockito.MockedConstruction;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -527,7 +528,14 @@ public class ActionsCoverageUnitTest {
         try (var ignoredWait = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class);
              var screenshotHelper = org.mockito.Mockito.mockStatic(ScreenshotHelper.class);
              var animatedGif = org.mockito.Mockito.mockStatic(AnimatedGifManager.class);
-             var imageProcessing = org.mockito.Mockito.mockStatic(ImageProcessingActions.class)) {
+             var imageProcessing = org.mockito.Mockito.mockStatic(ImageProcessingActions.class);
+             MockedConstruction<ElementActionsHelper> helperConstruction = org.mockito.Mockito.mockConstruction(ElementActionsHelper.class,
+                     (mock, context) -> {
+                         List<Object> skippedElementInformation = new ArrayList<>(List.of(
+                                 1, element, By.xpath("//div[@id='skip']"), "div", "skip", "", "", ""));
+                         when(mock.getMatchingElementsInformation(any(WebDriver.class), any(By.class), eq(false)))
+                                 .thenReturn(skippedElementInformation);
+                     })) {
             screenshotHelper.when(() -> ScreenshotHelper.makeFullScreenshot(any(WebDriver.class))).thenReturn(PNG);
             screenshotHelper.when(() -> ScreenshotHelper.makeFullScreenshot(any(WebDriver.class), any(WebElement[].class))).thenReturn(PNG);
             imageProcessing.when(() -> ImageProcessingActions.highlightElementInScreenshot(any(byte[].class), any(Rectangle.class), any(Color.class))).thenReturn(PNG);
@@ -536,9 +544,13 @@ public class ActionsCoverageUnitTest {
 
             SHAFT.Properties.visuals.set().screenshotParamsWhenToTakeAScreenshot("Always");
             SHAFT.Properties.visuals.set().screenshotParamsScreenshotType("FULL");
-            SHAFT.Properties.visuals.set().screenshotParamsSkippedElementsFromScreenshot("");
+            SHAFT.Properties.visuals.set().screenshotParamsSkippedElementsFromScreenshot("//div[@id='skip']");
             Assert.assertNotNull(invoke(actions, "takeActionScreenshot", new Class[]{WebElement.class}, element));
             Assert.assertNotNull(invoke(actions, "takeFailureScreenshot", new Class[]{WebElement.class}, element));
+            ElementActionsHelper mockedHelper = helperConstruction.constructed().getFirst();
+            verify(mockedHelper, atLeastOnce()).getMatchingElementsInformation(any(WebDriver.class), any(By.class), eq(false));
+            verify(mockedHelper, org.mockito.Mockito.never()).getElementsCount(any(WebDriver.class), any(By.class));
+            verify(mockedHelper, org.mockito.Mockito.never()).identifyUniqueElementIgnoringVisibility(any(WebDriver.class), any(By.class));
 
             SHAFT.Properties.visuals.set().screenshotParamsScreenshotType("ELEMENT");
             Assert.assertNotNull(invoke(actions, "captureScreenshot", new Class[]{WebElement.class, boolean.class}, element, true));

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotManagerCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotManagerCoverageUnitTest.java
@@ -115,6 +115,7 @@ public class ScreenshotManagerCoverageUnitTest {
         SHAFT.Properties.visuals.set().screenshotParamsHighlightMethod("AI");
         SHAFT.Properties.visuals.set().screenshotParamsHighlightElements(false);
         SHAFT.Properties.visuals.set().screenshotParamsWatermark(false);
+        SHAFT.Properties.visuals.set().screenshotParamsSkippedElementsFromScreenshot("");
 
         WebDriver delegateDriver = mock(WebDriver.class);
         SelfHealingDriver healingDriver = mock(SelfHealingDriver.class);
@@ -125,14 +126,17 @@ public class ScreenshotManagerCoverageUnitTest {
 
         try (MockedConstruction<ElementActionsHelper> helperMocked = Mockito.mockConstruction(ElementActionsHelper.class,
                 (mock, context) -> {
-                    when(mock.getElementsCount(any(WebDriver.class), any(By.class))).thenReturn(1, 0);
-                    when(mock.identifyUniqueElementIgnoringVisibility(any(WebDriver.class), any(By.class)))
-                            .thenReturn(List.of(1, element, By.id("x"), "", "", "", "", new Rectangle(1, 2, 3, 4)));
+                    when(mock.getMatchingElementsInformation(any(WebDriver.class), any(By.class), anyBoolean()))
+                            .thenReturn(
+                                    List.of(1, element, By.id("x"), "", "", "", "", new Rectangle(1, 2, 3, 4)),
+                                    Arrays.asList(0, null, By.id("x"), "", "", "", "", null));
                 });
              MockedStatic<ScreenshotHelper> screenshotHelperMocked = Mockito.mockStatic(ScreenshotHelper.class);
              MockedStatic<AnimatedGifManager> animatedGifMocked = Mockito.mockStatic(AnimatedGifManager.class)) {
             byte[] viewport = createPng(20, 20, Color.RED);
             screenshotHelperMocked.when(() -> ScreenshotHelper.makeFullScreenshot(any(WebDriver.class), any(WebElement[].class)))
+                    .thenThrow(new RuntimeException("force full failure"));
+            screenshotHelperMocked.when(() -> ScreenshotHelper.makeFullScreenshot(any(WebDriver.class)))
                     .thenThrow(new RuntimeException("force full failure"));
             screenshotHelperMocked.when(() -> ScreenshotHelper.takeViewportScreenshot(any(WebDriver.class), anyInt()))
                     .thenReturn(viewport);
@@ -153,7 +157,10 @@ public class ScreenshotManagerCoverageUnitTest {
             Assert.assertTrue(Arrays.equals(fallbackElement, viewport));
 
             ElementActionsHelper helper = helperMocked.constructed().getFirst();
-            when(helper.getElementsCount(any(WebDriver.class), any(By.class))).thenThrow(new RuntimeException("boom"));
+            Mockito.verify(helper, Mockito.never()).getElementsCount(any(WebDriver.class), any(By.class));
+            Mockito.verify(helper, Mockito.never()).identifyUniqueElementIgnoringVisibility(any(WebDriver.class), any(By.class));
+            when(helper.getMatchingElementsInformation(any(WebDriver.class), any(By.class), anyBoolean()))
+                    .thenThrow(new RuntimeException("boom"));
             byte[] noFallback = (byte[]) elementPrivate.invoke(manager, delegateDriver, By.id("x"), false);
             Assert.assertEquals(noFallback.length, 0);
         }
@@ -176,7 +183,8 @@ public class ScreenshotManagerCoverageUnitTest {
 
         try (MockedConstruction<ElementActionsHelper> helperMocked = Mockito.mockConstruction(ElementActionsHelper.class,
                 (mock, context) -> {
-                    when(mock.getElementsCount(any(WebDriver.class), any(By.class))).thenReturn(1);
+                    when(mock.getMatchingElementsInformation(any(WebDriver.class), any(By.class), anyBoolean()))
+                            .thenReturn(List.of(1, element, By.id("x"), "", "", "", "", new Rectangle(10, 10, 25, 25)));
                     when(mock.identifyUniqueElementIgnoringVisibility(any(WebDriver.class), any(By.class)))
                             .thenReturn(List.of(1, element, By.id("x"), "", "", "", "", new Rectangle(10, 10, 25, 25)));
                 });
@@ -234,6 +242,9 @@ public class ScreenshotManagerCoverageUnitTest {
             Assert.assertEquals(failed.length, 0);
 
             Assert.assertTrue(helperMocked.constructed().size() >= 1);
+            ElementActionsHelper helper = helperMocked.constructed().getFirst();
+            Mockito.verify(helper, Mockito.atLeastOnce()).getMatchingElementsInformation(any(WebDriver.class), any(By.class), anyBoolean());
+            Mockito.verify(helper, Mockito.never()).getElementsCount(any(WebDriver.class), any(By.class));
         }
     }
 

--- a/shaft-engine/src/test/java/testPackage/unitTests/MemoryLeakFixTests.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/MemoryLeakFixTests.java
@@ -8,6 +8,11 @@ import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+
 /**
  * Unit tests for ThreadLocal memory-leak fixes in {@link JSONFileManager}
  * and {@link LocatorBuilder}.
@@ -26,21 +31,21 @@ public class MemoryLeakFixTests {
     public void jsonFileManagerShouldClearReaderThreadLocalAfterRead() {
         JSONFileManager testData = new JSONFileManager("simpleJSON.json");
 
-        // The constructor should close and remove the reader immediately
+        // The constructor should not retain a reader in ThreadLocal state.
         Assert.assertNull(JSONFileManagerTestAccessor.getReader(),
-                "reader ThreadLocal should be null after the constructor closes it.");
+                "reader ThreadLocal should be null after the constructor.");
 
         testData.getTestData("name");
 
         Assert.assertNull(JSONFileManagerTestAccessor.getReader(),
-                "reader ThreadLocal should be null after getTestData() closes it in the finally block.");
+                "reader ThreadLocal should be null after getTestData().");
     }
 
     @Test(description = "JSONFileManager should read correct value even after ThreadLocal is cleared between calls")
     public void jsonFileManagerShouldReturnCorrectValueAfterThreadLocalCleanup() {
         JSONFileManager testData = new JSONFileManager("simpleJSON.json");
 
-        // First call – opens, reads, and closes reader
+        // First call reads from cached content.
         String firstValue = testData.getTestData("name");
         Assert.assertNotNull(firstValue,
                 "First getTestData() call should return a non-null value.");
@@ -49,13 +54,36 @@ public class MemoryLeakFixTests {
         Assert.assertNull(JSONFileManagerTestAccessor.getReader(),
                 "reader ThreadLocal should be null between calls.");
 
-        // Second call – should open a fresh reader and return the same value
+        // Second call should reuse valid cached content and return the same value.
         String secondValue = testData.getTestData("name");
         Assert.assertEquals(secondValue, firstValue,
                 "Second getTestData() call should return the same value as the first.");
 
         Assert.assertNull(JSONFileManagerTestAccessor.getReader(),
                 "reader ThreadLocal should be null after the second getTestData() call.");
+    }
+
+    @Test(description = "JSONFileManager should refresh cached content when the source file changes")
+    public void jsonFileManagerShouldRefreshCachedContentAfterFileChange() throws Exception {
+        Path tempJson = Files.createTempFile("shaft-json-cache", ".json");
+        try {
+            Files.writeString(tempJson, "{\"name\":\"first\"}", StandardCharsets.UTF_8);
+
+            JSONFileManager testData = new JSONFileManager(tempJson.toString());
+            Assert.assertEquals(testData.getTestData("name"), "first");
+            Assert.assertNull(JSONFileManagerTestAccessor.getReader(),
+                    "reader ThreadLocal should remain null when cached content is used.");
+
+            Files.writeString(tempJson, "{\"name\":\"second\"}", StandardCharsets.UTF_8);
+            Files.setLastModifiedTime(tempJson,
+                    FileTime.fromMillis(System.currentTimeMillis() + 2_000));
+
+            Assert.assertEquals(testData.getTestData("name"), "second");
+            Assert.assertNull(JSONFileManagerTestAccessor.getReader(),
+                    "reader ThreadLocal should remain null after cache refresh.");
+        } finally {
+            Files.deleteIfExists(tempJson);
+        }
     }
 
     // ── LocatorBuilder ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Cache JSONFileManager UTF-8 content per instance and refresh it when file metadata changes, without retaining FileReader state.
- Reuse Gson/ObjectMapper instances in REST hot paths and skip debug companion caller lookup when debug output is inactive.
- Replace screenshot skipped-element and element-screenshot double lookups with a single matching-elements lookup.
- Reuse select element metadata and a single Select instance while selecting options.

## Validation
- `mvn -pl shaft-engine '-Dtest=JSONFileManagerUnitTest,MemoryLeakFixTests,ShaftRestAssuredFilterUnitTest,RestActionsCoverageUnitTest,ScreenshotManagerCoverageUnitTest,ActionsCoverageUnitTest,ElementActionsCoverageUnitTest,ReportManagerHelperUnitTests' test`
- `mvn -pl shaft-engine '-DskipTests' package`
- Confirmed `shaft-engine/allure-results` contains 135 populated `*-result.json` files, minimum size 1264 bytes.

## Docs
- No public user-guide update included; this is behavior-compatible internal performance work.