### PR TITLE
Fix E2E test stability

### DIFF
--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -631,6 +631,9 @@ jobs:
 
   LambdaTest_NativeAndroid:
     runs-on: ubuntu-latest
+    env:
+      LAMBDATEST_USERNAME: ${{ secrets.LAMBDATEST_USERNAME }}
+      LAMBDATEST_ACCESS_KEY: ${{ secrets.LAMBDATEST_ACCESS_KEY }}
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -660,6 +663,9 @@ jobs:
 
   LambdaTest_NativeIOS:
     runs-on: ubuntu-latest
+    env:
+      LAMBDATEST_USERNAME: ${{ secrets.LAMBDATEST_USERNAME }}
+      LAMBDATEST_ACCESS_KEY: ${{ secrets.LAMBDATEST_ACCESS_KEY }}
     needs: [ LambdaTest_NativeAndroid ]
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
@@ -689,6 +695,9 @@ jobs:
 
   LambdaTest_WebApp:
     runs-on: ubuntu-latest
+    env:
+      LAMBDATEST_USERNAME: ${{ secrets.LAMBDATEST_USERNAME }}
+      LAMBDATEST_ACCESS_KEY: ${{ secrets.LAMBDATEST_ACCESS_KEY }}
     needs: [ LambdaTest_NativeAndroid, LambdaTest_NativeIOS ]
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
@@ -718,6 +727,9 @@ jobs:
 
   LambdaTest_DesktopWeb:
     runs-on: ubuntu-latest
+    env:
+      LAMBDATEST_USERNAME: ${{ secrets.LAMBDATEST_USERNAME }}
+      LAMBDATEST_ACCESS_KEY: ${{ secrets.LAMBDATEST_ACCESS_KEY }}
     needs: [ LambdaTest_NativeAndroid, LambdaTest_NativeIOS, LambdaTest_WebApp ]
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
@@ -749,6 +761,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      MOON_URL: http://localhost:4444/wd/hub
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserActionsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserActionsHelper.java
@@ -247,7 +247,7 @@ public class BrowserActionsHelper {
     }
 
     /**
-     * Navigates the browser to a new URL. Handles local file paths by prepending the {@code file://} scheme,
+     * Navigates the browser to a new URL. Handles local test-data file paths by converting them to file URIs,
      * and prefers the W3C BiDi {@link BrowsingContext} API for navigation when available. Falls back to
      * the classic {@link WebDriver#navigate()} API for non-BiDi drivers or on timeout.
      *
@@ -266,7 +266,7 @@ public class BrowserActionsHelper {
         var internalURL = targetUrl;
         try {
             if (targetUrl.startsWith(SHAFT.Properties.paths.testData())) {
-                internalURL = "file://" + new File(targetUrl).getAbsolutePath();
+                internalURL = new File(targetUrl).toURI().toString();
             }
         } catch (Exception exception) {
             ReportManagerHelper.logDiscrete(exception, Level.DEBUG);

--- a/shaft-engine/src/main/resources/docker-compose/selenium4.yml
+++ b/shaft-engine/src/main/resources/docker-compose/selenium4.yml
@@ -9,6 +9,8 @@ services:
     shm_size: 2gb
     depends_on:
       - selenium-hub
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_NODE_GRID_URL=http://localhost:4444
@@ -21,6 +23,8 @@ services:
     shm_size: 2gb
     depends_on:
       - selenium-hub
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_NODE_GRID_URL=http://localhost:4444
@@ -33,6 +37,8 @@ services:
     shm_size: 2gb
     depends_on:
       - selenium-hub
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_NODE_GRID_URL=http://localhost:4444

--- a/shaft-engine/src/test/java/testPackage/LambdaTest/LambdaTestCredentials.java
+++ b/shaft-engine/src/test/java/testPackage/LambdaTest/LambdaTestCredentials.java
@@ -1,0 +1,47 @@
+package testPackage.LambdaTest;
+
+import com.shaft.driver.SHAFT;
+import org.testng.SkipException;
+
+final class LambdaTestCredentials {
+    private LambdaTestCredentials() {
+        // utility class
+    }
+
+    static void apply() {
+        String username = firstNonBlank(
+                System.getProperty("LambdaTest.username"),
+                System.getenv("LAMBDATEST_USERNAME"),
+                System.getenv("LT_USERNAME"));
+        String accessKey = firstNonBlank(
+                System.getProperty("LambdaTest.accessKey"),
+                System.getenv("LAMBDATEST_ACCESS_KEY"),
+                System.getenv("LT_ACCESS_KEY"));
+
+        if (username == null || accessKey == null) {
+            if (isCi()) {
+                throw new SkipException("LambdaTest credentials are not configured for this CI run.");
+            }
+
+            SHAFT.TestData.JSON testData = new SHAFT.TestData.JSON("credentials.json");
+            username = testData.getTestData("LambdaTestUserName");
+            accessKey = testData.getTestData("LambdaTestAccessKey");
+        }
+
+        SHAFT.Properties.lambdaTest.set().username(username);
+        SHAFT.Properties.lambdaTest.set().accessKey(accessKey);
+    }
+
+    private static String firstNonBlank(String... candidates) {
+        for (String candidate : candidates) {
+            if (candidate != null && !candidate.isBlank()) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isCi() {
+        return "true".equalsIgnoreCase(System.getenv("CI"));
+    }
+}

--- a/shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTDesktopWebMac.java
+++ b/shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTDesktopWebMac.java
@@ -10,7 +10,6 @@ import org.testng.annotations.Test;
 
 public class Test_LTDesktopWebMac {
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
-    SHAFT.TestData.JSON testData;
 
     //locators of test_ClickUsingJavaScript
     By emailField = By.xpath("//input[@name='user-name']");
@@ -27,7 +26,6 @@ public class Test_LTDesktopWebMac {
 
     @BeforeMethod
     public void beforeMethod() {
-        testData = new SHAFT.TestData.JSON("credentials.json");
         SHAFT.Properties.lambdaTest.set().browserVersion("16.0");
         SHAFT.Properties.platform.set().targetPlatform(Platform.MAC.name());
         SHAFT.Properties.platform.set().executionAddress("lambdatest");
@@ -36,13 +34,15 @@ public class Test_LTDesktopWebMac {
         SHAFT.Properties.lambdaTest.set().selenium_version("4.8.0");
         SHAFT.Properties.lambdaTest.set().osVersion("Ventura");
         SHAFT.Properties.lambdaTest.set().isRealMobile(false);
-        SHAFT.Properties.lambdaTest.set().username(testData.getTestData("LambdaTestUserName"));
-        SHAFT.Properties.lambdaTest.set().accessKey(testData.getTestData("LambdaTestAccessKey"));
+        LambdaTestCredentials.apply();
         driver.set(new SHAFT.GUI.WebDriver());
     }
 
     @AfterMethod(alwaysRun = true)
     public void afterMethod() {
-        driver.get().quit();
+        if (driver.get() != null) {
+            driver.get().quit();
+        }
+        driver.remove();
     }
 }

--- a/shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTDesktopWebWindows.java
+++ b/shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTDesktopWebWindows.java
@@ -10,7 +10,6 @@ import org.testng.annotations.Test;
 
 public class Test_LTDesktopWebWindows {
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
-    SHAFT.TestData.JSON testData;
 
     //locators of test_ClickUsingJavaScript
     By emailField = By.xpath("//input[@name='user-name']");
@@ -32,7 +31,6 @@ public class Test_LTDesktopWebWindows {
 
     @BeforeMethod
     public void beforeMethod() {
-        testData = new SHAFT.TestData.JSON("credentials.json");
         SHAFT.Properties.lambdaTest.set().browserVersion("114.0");
         SHAFT.Properties.platform.set().targetPlatform(Platform.WINDOWS.name());
         SHAFT.Properties.platform.set().executionAddress("lambdatest");
@@ -41,13 +39,15 @@ public class Test_LTDesktopWebWindows {
         SHAFT.Properties.lambdaTest.set().osVersion("11");
         SHAFT.Properties.lambdaTest.set().isRealMobile(false);
         SHAFT.Properties.lambdaTest.set().selenium_version("4.8.0");
-        SHAFT.Properties.lambdaTest.set().username(testData.getTestData("LambdaTestUserName"));
-        SHAFT.Properties.lambdaTest.set().accessKey(testData.getTestData("LambdaTestAccessKey"));
+        LambdaTestCredentials.apply();
         driver.set(new SHAFT.GUI.WebDriver());
     }
 
     @AfterMethod(alwaysRun = true)
     public void afterMethod() {
-        driver.get().quit();
+        if (driver.get() != null) {
+            driver.get().quit();
+        }
+        driver.remove();
     }
 }

--- a/shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobAPKAPPURL.java
+++ b/shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobAPKAPPURL.java
@@ -11,7 +11,6 @@ import org.testng.annotations.Test;
 
 public class Test_LTMobAPKAPPURL {
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
-    SHAFT.TestData.JSON testData;
     private final By actionBar = AppiumBy.accessibilityId("Action Bar");
     private final By displayOptions = AppiumBy.accessibilityId("Display Options");
     private final By displayShowCustom = AppiumBy.accessibilityId("DISPLAY_SHOW_CUSTOM");
@@ -28,13 +27,11 @@ public class Test_LTMobAPKAPPURL {
 
     @BeforeMethod
     public void setup() {
-        testData = new SHAFT.TestData.JSON("credentials.json");
         // common attributes
         SHAFT.Properties.platform.set().targetPlatform(Platform.ANDROID.name());
         SHAFT.Properties.mobile.set().automationName(AutomationName.ANDROID_UIAUTOMATOR2);
         SHAFT.Properties.mobile.set().browserName("");
-        SHAFT.Properties.lambdaTest.set().username(testData.getTestData("LambdaTestUserName"));
-        SHAFT.Properties.lambdaTest.set().accessKey(testData.getTestData("LambdaTestAccessKey"));
+        LambdaTestCredentials.apply();
         SHAFT.Properties.platform.set().executionAddress("lambdatest");
         SHAFT.Properties.lambdaTest.set().platformVersion("11");
         SHAFT.Properties.lambdaTest.set().deviceName("Poco X3 Pro");

--- a/shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobAPKRelativePath.java
+++ b/shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobAPKRelativePath.java
@@ -11,7 +11,6 @@ import org.testng.annotations.Test;
 
 public class Test_LTMobAPKRelativePath {
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
-    SHAFT.TestData.JSON testData;
     private final By actionBar = AppiumBy.accessibilityId("Action Bar");
     private final By displayOptions = AppiumBy.accessibilityId("Display Options");
     private final By displayShowCustom = AppiumBy.accessibilityId("DISPLAY_SHOW_CUSTOM");
@@ -28,7 +27,6 @@ public class Test_LTMobAPKRelativePath {
 
     @BeforeMethod
     public void setup() {
-        testData = new SHAFT.TestData.JSON("credentials.json");
         // common attributes
         SHAFT.Properties.platform.set().targetPlatform(Platform.ANDROID.name());
         SHAFT.Properties.mobile.set().automationName(AutomationName.ANDROID_UIAUTOMATOR2);
@@ -40,8 +38,7 @@ public class Test_LTMobAPKRelativePath {
         SHAFT.Properties.mobile.set().browserName("");
         SHAFT.Properties.lambdaTest.set().isRealMobile(true);
         SHAFT.Properties.lambdaTest.set().appRelativeFilePath("src/test/resources/testDataFiles/apps/ApiDemos-debug.apk");
-        SHAFT.Properties.lambdaTest.set().username(testData.getTestData("LambdaTestUserName"));
-        SHAFT.Properties.lambdaTest.set().accessKey(testData.getTestData("LambdaTestAccessKey"));
+        LambdaTestCredentials.apply();
         SHAFT.Properties.flags.set().automaticallyAssertResponseStatusCode(false);
         driver.set(new SHAFT.GUI.WebDriver());
     }

--- a/shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobIPAAppURL.java
+++ b/shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobIPAAppURL.java
@@ -9,7 +9,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class Test_LTMobIPAAppURL {
-    SHAFT.TestData.JSON testData;
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
 
     @Test
@@ -21,7 +20,6 @@ public class Test_LTMobIPAAppURL {
 
     @BeforeMethod
     public void setup() {
-        testData = new SHAFT.TestData.JSON("credentials.json");
         // common attributes
         SHAFT.Properties.platform.set().targetPlatform(Platform.IOS.toString());
         SHAFT.Properties.mobile.set().automationName("XCUITest");
@@ -30,8 +28,7 @@ public class Test_LTMobIPAAppURL {
         SHAFT.Properties.lambdaTest.set().deviceName("iPhone 13");
         SHAFT.Properties.lambdaTest.set().appUrl("lt://APP10160612541701952809945764");
         SHAFT.Properties.mobile.set().browserName("");
-        SHAFT.Properties.lambdaTest.set().username(testData.getTestData("LambdaTestUserName"));
-        SHAFT.Properties.lambdaTest.set().accessKey(testData.getTestData("LambdaTestAccessKey"));
+        LambdaTestCredentials.apply();
         SHAFT.Properties.flags.set().clearBeforeTypingMode("off");
         driver.set(new SHAFT.GUI.WebDriver());
 
@@ -39,6 +36,9 @@ public class Test_LTMobIPAAppURL {
 
     @AfterMethod(alwaysRun = true)
     public void teardown() {
-        driver.get().quit();
+        if (driver.get() != null) {
+            driver.get().quit();
+        }
+        driver.remove();
     }
 }

--- a/shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobIPARelativePath.java
+++ b/shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobIPARelativePath.java
@@ -10,7 +10,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class Test_LTMobIPARelativePath {
-    SHAFT.TestData.JSON testData;
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
 
     @Test
@@ -27,7 +26,6 @@ public class Test_LTMobIPARelativePath {
 
     @BeforeMethod
     public void setup() {
-        testData = new SHAFT.TestData.JSON("credentials.json");
         // common attributes
         SHAFT.Properties.platform.set().targetPlatform(Platform.IOS.toString());
         SHAFT.Properties.mobile.set().automationName("XCUITest");
@@ -39,8 +37,7 @@ public class Test_LTMobIPARelativePath {
         SHAFT.Properties.lambdaTest.set().deviceName("iPhone 14");
         SHAFT.Properties.mobile.set().browserName("");
         SHAFT.Properties.lambdaTest.set().isRealMobile(true);
-        SHAFT.Properties.lambdaTest.set().username(testData.getTestData("LambdaTestUserName"));
-        SHAFT.Properties.lambdaTest.set().accessKey(testData.getTestData("LambdaTestAccessKey"));
+        LambdaTestCredentials.apply();
         SHAFT.Properties.flags.set().clearBeforeTypingMode("off");
         driver.set(new SHAFT.GUI.WebDriver());
 
@@ -48,6 +45,9 @@ public class Test_LTMobIPARelativePath {
 
     @AfterMethod(alwaysRun = true)
     public void teardown() {
-        driver.get().quit();
+        if (driver.get() != null) {
+            driver.get().quit();
+        }
+        driver.remove();
     }
 }

--- a/shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTWebAppIOS.java
+++ b/shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTWebAppIOS.java
@@ -10,7 +10,6 @@ import org.testng.annotations.Test;
 
 public class Test_LTWebAppIOS {
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
-    SHAFT.TestData.JSON testData;
 
     private final By noThanks = By.xpath("//*[@resource-id='com.apple.mobilesafari:id/negative_button']");
     private final By appleMenuIcon = By.id("globalnav-menutrigger-button");
@@ -30,7 +29,6 @@ public class Test_LTWebAppIOS {
 
     @BeforeMethod
     public void beforeMethod() {
-        testData = new SHAFT.TestData.JSON("credentials.json");
         // common attributes
         SHAFT.Properties.lambdaTest.set().deviceName("iPhone 13 Pro Max");
         SHAFT.Properties.lambdaTest.set().platformVersion("15");
@@ -40,13 +38,15 @@ public class Test_LTWebAppIOS {
         SHAFT.Properties.mobile.set().browserName(Browser.SAFARI.browserName());
         SHAFT.Properties.lambdaTest.set().selenium_version("4.8.0");
         SHAFT.Properties.lambdaTest.set().isRealMobile(true);
-        SHAFT.Properties.lambdaTest.set().username(testData.getTestData("LambdaTestUserName"));
-        SHAFT.Properties.lambdaTest.set().accessKey(testData.getTestData("LambdaTestAccessKey"));
+        LambdaTestCredentials.apply();
         driver.set(new SHAFT.GUI.WebDriver());
     }
 
     @AfterMethod(alwaysRun = true)
     public void afterMethod() {
-        driver.get().quit();
+        if (driver.get() != null) {
+            driver.get().quit();
+        }
+        driver.remove();
     }
 }

--- a/shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTWebAppRealme.java
+++ b/shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTWebAppRealme.java
@@ -18,7 +18,6 @@ public class Test_LTWebAppRealme {
     private final String exploreAllMacText = "Explore All Mac";
     private final String appleUrl = "https://www.apple.com/";
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
-    SHAFT.TestData.JSON testData;
 
 
     @Test
@@ -52,7 +51,6 @@ public class Test_LTWebAppRealme {
 
     @BeforeMethod
     public void beforeMethod() {
-        testData = new SHAFT.TestData.JSON("credentials.json");
         // common attributes
         SHAFT.Properties.lambdaTest.set().deviceName("Pixel 7");
         SHAFT.Properties.lambdaTest.set().platformVersion("13");
@@ -62,13 +60,15 @@ public class Test_LTWebAppRealme {
         SHAFT.Properties.mobile.set().browserName(Browser.CHROME.browserName());
         SHAFT.Properties.lambdaTest.set().selenium_version("4.8.0");
         SHAFT.Properties.lambdaTest.set().osVersion("11");
-        SHAFT.Properties.lambdaTest.set().username(testData.getTestData("LambdaTestUserName"));
-        SHAFT.Properties.lambdaTest.set().accessKey(testData.getTestData("LambdaTestAccessKey"));
+        LambdaTestCredentials.apply();
         driver.set(new SHAFT.GUI.WebDriver());
     }
 
     @AfterMethod(alwaysRun = true)
     public void afterMethod() {
-        driver.get().quit();
+        if (driver.get() != null) {
+            driver.get().quit();
+        }
+        driver.remove();
     }
 }

--- a/shaft-engine/src/test/java/testPackage/TestPageServer.java
+++ b/shaft-engine/src/test/java/testPackage/TestPageServer.java
@@ -1,0 +1,112 @@
+package testPackage;
+
+import com.shaft.driver.SHAFT;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.concurrent.Executors;
+
+public final class TestPageServer {
+    private static final Object LOCK = new Object();
+    private static volatile HttpServer server;
+    private static volatile int port;
+
+    private TestPageServer() {
+        // utility class
+    }
+
+    public static String url(String fixtureName) {
+        ensureStarted();
+        return "http://" + browserHost() + ":" + port + "/" + fixtureName;
+    }
+
+    private static void ensureStarted() {
+        if (server != null) {
+            return;
+        }
+        synchronized (LOCK) {
+            if (server != null) {
+                return;
+            }
+            try {
+                var newServer = HttpServer.create(new InetSocketAddress("0.0.0.0", 0), 0);
+                var root = Path.of(SHAFT.Properties.paths.testData()).toAbsolutePath().normalize();
+                newServer.createContext("/", exchange -> serveFixture(exchange, root));
+                newServer.setExecutor(Executors.newCachedThreadPool(runnable -> {
+                    Thread thread = new Thread(runnable, "test-page-server");
+                    thread.setDaemon(true);
+                    return thread;
+                }));
+                newServer.start();
+                server = newServer;
+                port = newServer.getAddress().getPort();
+                Runtime.getRuntime().addShutdownHook(new Thread(() -> newServer.stop(0), "test-page-server-shutdown"));
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to start test page server.", e);
+            }
+        }
+    }
+
+    private static void serveFixture(HttpExchange exchange, Path root) throws IOException {
+        try (exchange) {
+            String requestedPath = URLDecoder.decode(exchange.getRequestURI().getPath(), StandardCharsets.UTF_8);
+            if (requestedPath.startsWith("/")) {
+                requestedPath = requestedPath.substring(1);
+            }
+
+            Path fixture = root.resolve(requestedPath).normalize();
+            if (!fixture.startsWith(root) || !Files.isRegularFile(fixture)) {
+                send(exchange, 404, "Not found".getBytes(StandardCharsets.UTF_8), "text/plain; charset=utf-8");
+                return;
+            }
+
+            send(exchange, 200, Files.readAllBytes(fixture), contentType(fixture));
+        }
+    }
+
+    private static void send(HttpExchange exchange, int statusCode, byte[] body, String contentType) throws IOException {
+        exchange.getResponseHeaders().set("Content-Type", contentType);
+        exchange.sendResponseHeaders(statusCode, body.length);
+        try (OutputStream responseBody = exchange.getResponseBody()) {
+            responseBody.write(body);
+        }
+    }
+
+    private static String contentType(Path fixture) {
+        String fileName = fixture.getFileName().toString().toLowerCase(Locale.ROOT);
+        if (fileName.endsWith(".html")) {
+            return "text/html; charset=utf-8";
+        }
+        if (fileName.endsWith(".png")) {
+            return "image/png";
+        }
+        if (fileName.endsWith(".pdf")) {
+            return "application/pdf";
+        }
+        return "application/octet-stream";
+    }
+
+    private static String browserHost() {
+        String override = System.getProperty("shaft.testPageServer.host");
+        if (override != null && !override.isBlank()) {
+            return override;
+        }
+
+        String executionAddress = SHAFT.Properties.platform.executionAddress();
+        if (executionAddress != null
+                && (executionAddress.contains("localhost:4444")
+                || executionAddress.contains("127.0.0.1:4444")
+                || executionAddress.contains("0.0.0.0:4444"))) {
+            return "host.docker.internal";
+        }
+        return "127.0.0.1";
+    }
+}

--- a/shaft-engine/src/test/java/testPackage/legacy/AssertEqualsTests.java
+++ b/shaft-engine/src/test/java/testPackage/legacy/AssertEqualsTests.java
@@ -1,8 +1,8 @@
 package testPackage.legacy;
 
-import com.shaft.driver.SHAFT;
 import com.shaft.validation.Validations;
 import org.openqa.selenium.By;
+import testPackage.TestPageServer;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import testPackage.Tests;
@@ -37,6 +37,6 @@ public class AssertEqualsTests extends Tests {
 
     @BeforeMethod // Set-up method, to be run once before the first test
     public void beforeMethod() {
-        driver.get().browser().navigateToURL(SHAFT.Properties.paths.testData() + "searchFixture.html");
+        driver.get().browser().navigateToURL(TestPageServer.url("searchFixture.html"));
     }
 }

--- a/shaft-engine/src/test/java/testPackage/legacy/UploadFileTests.java
+++ b/shaft-engine/src/test/java/testPackage/legacy/UploadFileTests.java
@@ -1,6 +1,7 @@
 package testPackage.legacy;
 
 import org.openqa.selenium.By;
+import testPackage.TestPageServer;
 import org.testng.annotations.Test;
 import testPackage.Tests;
 
@@ -8,24 +9,24 @@ public class UploadFileTests extends Tests {
     @Test
     public void uploadFileViaVisibleInput() {
         driver.get().browser()
-                .navigateToURL("https://the-internet.herokuapp.com/upload")
+                .navigateToURL(uploadFixture())
                 .element()
                 .typeFileLocationForUpload(By.cssSelector("input[id='file-upload']"), "src/test/resources/testDataFiles/sample.pdf")
-                .click("Upload")
+                .click(By.id("file-submit"))
                 .assertThat(By.tagName("h3")).text().contains("File Uploaded!");
     }
     @Test
     public void uploadFileViaHiddenInput(){
         driver.get().browser()
-                .navigateToURL("https://codyhouse.co/app/components/demo/demo-drag-drop-file")
+                .navigateToURL(uploadFixture())
                 .element()
-                .typeFileLocationForUpload(By.cssSelector("input[type='file']"), "src/test/resources/testDataFiles/sample.pdf")
+                .typeFileLocationForUpload(By.id("upload-file"), "src/test/resources/testDataFiles/sample.pdf")
                 .assertThat(By.tagName("body")).text().contains("1 selected file");
     }
     @Test
     public void uploadFileViaDragAndDrop() {
         driver.get().browser()
-                .navigateToURL("https://codyhouse.co/app/components/demo/demo-drag-drop-file")
+                .navigateToURL(uploadFixture())
                 .element()
                 .dropFileToUpload(By.cssSelector("label[for='upload-file']"), "src/test/resources/testDataFiles/sample.pdf")
                 .assertThat(By.tagName("body")).text().contains("1 selected file");
@@ -46,9 +47,13 @@ public class UploadFileTests extends Tests {
     @Test
     public void uploadFileViaAjax(){
         driver.get().browser()
-                .navigateToURL("https://www.west-wind.com/wconnect/wcscripts/fileupload.wwd")
+                .navigateToURL(uploadFixture())
                 .element()
                 .typeFileLocationForUpload(By.id("ajaxUpload"), "src/test/resources/testDataFiles/youtube.png")
                 .assertThat(By.cssSelector("div[id='ImageList'] > img")).domAttribute("src").contains("youtube.png");
+    }
+
+    private static String uploadFixture() {
+        return TestPageServer.url("uploadFixture.html");
     }
 }

--- a/shaft-engine/src/test/java/testPackage/legacy/VerifyEqualsTests.java
+++ b/shaft-engine/src/test/java/testPackage/legacy/VerifyEqualsTests.java
@@ -2,6 +2,7 @@ package testPackage.legacy;
 
 import com.shaft.driver.SHAFT;
 import com.shaft.validation.Validations;
+import testPackage.TestPageServer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -45,7 +46,7 @@ public class VerifyEqualsTests {
     @BeforeMethod // Set-up method, to be run once before the first test
     public void beforeMethod() {
         driver.set(new SHAFT.GUI.WebDriver());
-        driver.get().browser().navigateToURL(SHAFT.Properties.paths.testData() + "searchFixture.html");
+        driver.get().browser().navigateToURL(TestPageServer.url("searchFixture.html"));
     }
 
     @AfterMethod(alwaysRun = true)

--- a/shaft-engine/src/test/java/testPackage/locator/LocatorBuilderTest.java
+++ b/shaft-engine/src/test/java/testPackage/locator/LocatorBuilderTest.java
@@ -4,6 +4,7 @@ import com.shaft.driver.SHAFT;
 import com.shaft.gui.internal.locator.Locator;
 import com.shaft.gui.internal.locator.Role;
 import org.openqa.selenium.By;
+import testPackage.TestPageServer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -15,7 +16,7 @@ public class LocatorBuilderTest {
     @BeforeMethod
     public void beforeMethod() {
         driver.set(new SHAFT.GUI.WebDriver());
-        driver.get().browser().navigateToURL("https://shaftengine.netlify.app/");
+        driver.get().browser().navigateToURL(TestPageServer.url("locatorBuilderFixture.html"));
     }
 
     @AfterMethod(alwaysRun = true)
@@ -131,7 +132,7 @@ public class LocatorBuilderTest {
     @Test
     public void byRoleButton() {
         By locator = Locator.hasRole(Role.BUTTON).and().containsText("Get Started").isFirst().build();
-        driver.get().assertThat().element(locator).text().isEqualTo("Get Started Free ⚡").perform();
+        driver.get().assertThat().element(locator).text().isEqualTo("Get Started Free").perform();
     }
 
     @Test

--- a/shaft-engine/src/test/java/testPackage/mockedTests/AccessibilityTest.java
+++ b/shaft-engine/src/test/java/testPackage/mockedTests/AccessibilityTest.java
@@ -2,6 +2,7 @@ package testPackage.mockedTests;
 
 import com.shaft.driver.SHAFT;
 import com.shaft.validation.accessibility.AccessibilityHelper;
+import testPackage.TestPageServer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -16,7 +17,7 @@ public class AccessibilityTest {
     @BeforeMethod(alwaysRun = true)
     public void beforeMethod() {
         driver.set(new SHAFT.GUI.WebDriver());
-        driver.get().browser().navigateToURL(SHAFT.Properties.paths.testData() + "coverageTestPage.html");
+        driver.get().browser().navigateToURL(TestPageServer.url("coverageTestPage.html"));
     }
 
     /* ==========================

--- a/shaft-engine/src/test/java/testPackage/mockedTests/CoverageTests.java
+++ b/shaft-engine/src/test/java/testPackage/mockedTests/CoverageTests.java
@@ -4,6 +4,7 @@ import com.shaft.driver.SHAFT;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchSessionException;
 import org.openqa.selenium.remote.Browser;
+import testPackage.TestPageServer;
 import org.testng.annotations.*;
 
 public class CoverageTests {
@@ -14,7 +15,7 @@ public class CoverageTests {
     public void getElementsCount() {
         if (SHAFT.Properties.platform.executionAddress().equals("local")
                 && !SHAFT.Properties.web.targetBrowserName().equalsIgnoreCase(Browser.SAFARI.browserName())) {
-            int numberOfOptions = driver.get().browser().navigateToURL(SHAFT.Properties.paths.testData() + "hoverDemo.html")
+            int numberOfOptions = driver.get().browser().navigateToURL(TestPageServer.url("hoverDemo.html"))
                     .and().element().getElementsCount(SHAFT.GUI.Locator.hasTagName("a").build());
             SHAFT.Validations.assertThat().number(numberOfOptions).isGreaterThan(1).perform();
         }
@@ -40,7 +41,7 @@ public class CoverageTests {
 
     @Test
     public void alerts_getText_and_accept() {
-        driver.get().browser().navigateToURL(SHAFT.Properties.paths.testData() + "alertFixture.html");
+        driver.get().browser().navigateToURL(TestPageServer.url("alertFixture.html"));
         var alert = driver.get().element().click(By.id("alert-button"))
                 .and().alert();
         alert.getAlertText();
@@ -93,7 +94,7 @@ public class CoverageTests {
 
     @Test
     public void alerts_dismiss() {
-        driver.get().browser().navigateToURL(SHAFT.Properties.paths.testData() + "alertFixture.html");
+        driver.get().browser().navigateToURL(TestPageServer.url("alertFixture.html"));
         driver.get().element().click(By.id("confirm-button"))
                 .and().alert().dismissAlert();
         driver.get().element().assertThat(By.id("confirm-result")).text().isEqualTo("false").perform();
@@ -101,7 +102,7 @@ public class CoverageTests {
 
     @Test
     public void alerts_type() {
-        driver.get().browser().navigateToURL(SHAFT.Properties.paths.testData() + "alertFixture.html");
+        driver.get().browser().navigateToURL(TestPageServer.url("alertFixture.html"));
         driver.get().element().click(By.id("prompt-button"))
                 .and().alert().typeIntoPromptAlert("nachos").acceptAlert();
         driver.get().element().assertThat(By.id("prompt-result")).text().isEqualTo("nachos").perform();

--- a/shaft-engine/src/test/java/testPackage/mockedTests/E2ECoverageTests.java
+++ b/shaft-engine/src/test/java/testPackage/mockedTests/E2ECoverageTests.java
@@ -5,6 +5,7 @@ import com.shaft.properties.internal.Properties;
 import com.shaft.validation.ValidationEnums;
 import com.shaft.validation.Validations;
 import org.openqa.selenium.By;
+import testPackage.TestPageServer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -44,8 +45,7 @@ public class E2ECoverageTests {
     @BeforeMethod(alwaysRun = true)
     public void beforeMethod() {
         driver.set(new SHAFT.GUI.WebDriver());
-        driver.get().browser().navigateToURL(
-                SHAFT.Properties.paths.testData() + "coverageTestPage.html");
+        driver.get().browser().navigateToURL(TestPageServer.url("coverageTestPage.html"));
     }
 
     @AfterMethod(alwaysRun = true)

--- a/shaft-engine/src/test/java/testPackage/mockedTests/ValidationTests.java
+++ b/shaft-engine/src/test/java/testPackage/mockedTests/ValidationTests.java
@@ -5,6 +5,7 @@ import com.shaft.properties.internal.Properties;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import com.shaft.validation.Validations;
 import org.openqa.selenium.By;
+import testPackage.TestPageServer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -281,11 +282,6 @@ public class ValidationTests {
     @BeforeMethod(onlyForGroups = {"WebBased"})
     public void beforeMethod() {
         driver.set(new SHAFT.GUI.WebDriver());
-        String testElement = "data:text/html;charset=utf-8,<html dir='rtl'><body>"
-                + "<input id='primaryInput' type='text'>"
-                + "<input id='englishInput' type='text' dir='ltr' value='Automation'>"
-                + "<input id='arabicInput' type='text' dir='rtl' value='&#1605;&#1585;&#1581;&#1576;&#1575;'>"
-                + "</body></html>";
-        driver.get().browser().navigateToURL(testElement);
+        driver.get().browser().navigateToURL(TestPageServer.url("validationTextFixture.html"));
     }
 }

--- a/shaft-engine/src/test/java/testPackage/resettingCapabilitiesIssue/UploadFileTests.java
+++ b/shaft-engine/src/test/java/testPackage/resettingCapabilitiesIssue/UploadFileTests.java
@@ -4,6 +4,7 @@ import com.shaft.driver.SHAFT;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
+import testPackage.TestPageServer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -14,7 +15,7 @@ public class UploadFileTests {
     @Test
     public void uploadFile_visibleUploadInput() {
         if (SHAFT.Properties.platform.executionAddress().equals("local")) {
-            driver.get().browser().navigateToURL("https://the-internet.herokuapp.com/upload");
+            driver.get().browser().navigateToURL(uploadFixture());
             driver.get().element().typeFileLocationForUpload(By.cssSelector("input[id='file-upload']"), "src/main/resources/images/shaft.png");
             driver.get().element().click(By.id("file-submit"));
             driver.get().assertThat().element(By.tagName("h3")).text().contains("File Uploaded!");
@@ -25,7 +26,7 @@ public class UploadFileTests {
     @Test
     public void uploadFile_invisibleUploadInput() {
         if (SHAFT.Properties.platform.executionAddress().equals("local")) {
-            driver.get().browser().navigateToURL("https://the-internet.herokuapp.com/upload");
+            driver.get().browser().navigateToURL(uploadFixture());
             WebDriver nativeDriver = driver.get().getDriver();
             ((JavascriptExecutor) nativeDriver).executeScript("arguments[0].setAttribute('hidden', 'true')", nativeDriver.findElement(By.cssSelector("input[id='file-upload']")));
 
@@ -44,5 +45,9 @@ public class UploadFileTests {
     @AfterMethod(alwaysRun = true)
     public void afterMethod() {
         driver.get().quit();
+    }
+
+    private static String uploadFixture() {
+        return TestPageServer.url("uploadFixture.html");
     }
 }

--- a/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsHelperCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsHelperCoverageUnitTest.java
@@ -13,11 +13,11 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.awt.HeadlessException;
+import java.io.File;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.anyMap;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -63,8 +63,9 @@ public class BrowserActionsHelperCoverageUnitTest {
         when(driver.getCurrentUrl()).thenReturn("https://example.com/initial", "https://example.com/final");
         helper.checkNavigationWasSuccessful(driver, "https://example.com/initial", "https://example.com/source", "https://example.com/final");
 
-        helper.navigateToNewUrl(driver, "about:blank", SHAFT.Properties.paths.testData() + "/dummy.html", "");
-        verify(navigation).to(startsWith("file://"));
+        String targetFixture = SHAFT.Properties.paths.testData() + "/dummy.html";
+        helper.navigateToNewUrl(driver, "about:blank", targetFixture, "");
+        verify(navigation).to(new File(targetFixture).toURI().toString());
     }
 
     @Test

--- a/shaft-engine/src/test/java/testPackage/unitTests/ThreadLocalPropertiesTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/ThreadLocalPropertiesTest.java
@@ -287,7 +287,11 @@ public class ThreadLocalPropertiesTest {
     @Test(description = "Failed-test retry enables debug file logging diagnostics")
     public void testRetryDiagnosticsLoggingLifecycle() throws java.io.IOException {
         int originalRetryCount = SHAFT.Properties.flags.retryMaximumNumberOfAttempts();
-        File logFile = new File(SHAFT.Properties.log4j.appenderFile_FileName());
+        String originalLogFilePath = SHAFT.Properties.log4j.appenderFile_FileName();
+        Path tempDirectory = Files.createTempDirectory("shaft-retry-diagnostics");
+        Path isolatedLogPath = tempDirectory.resolve("engine.log");
+        ThreadLocalPropertiesManager.setProperty("appender.file.fileName", isolatedLogPath.toString());
+        File logFile = isolatedLogPath.toFile();
         resetRetryDiagnosticLoggingForCurrentThread();
         if (logFile.exists()) {
             Files.deleteIfExists(logFile.toPath());
@@ -316,7 +320,9 @@ public class ThreadLocalPropertiesTest {
             Assert.assertFalse(logFile.exists(), "Generated retry diagnostics log should be attached and removed");
         } finally {
             SHAFT.Properties.flags.set().retryMaximumNumberOfAttempts(originalRetryCount);
+            ThreadLocalPropertiesManager.setProperty("appender.file.fileName", originalLogFilePath);
             Files.deleteIfExists(logFile.toPath());
+            Files.deleteIfExists(tempDirectory);
             Properties.clearForCurrentThread();
         }
     }

--- a/shaft-engine/src/test/java/testPackage/validationsWizard/BrowserValidationsTests.java
+++ b/shaft-engine/src/test/java/testPackage/validationsWizard/BrowserValidationsTests.java
@@ -4,6 +4,7 @@ import com.shaft.driver.SHAFT;
 import com.shaft.gui.browser.BrowserActions;
 import com.shaft.properties.internal.Properties;
 import com.shaft.validation.Validations;
+import testPackage.TestPageServer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -24,7 +25,7 @@ public class BrowserValidationsTests {
     @BeforeMethod
     public void beforeMethod() {
         driver.set(new SHAFT.GUI.WebDriver());
-        String url = SHAFT.Properties.paths.testData() + "coverageTestPage.html";
+        String url = TestPageServer.url("coverageTestPage.html");
         new BrowserActions(driver.get().getDriver()).navigateToURL(url);
     }
 

--- a/shaft-engine/src/test/resources/testDataFiles/coverageTestPage.html
+++ b/shaft-engine/src/test/resources/testDataFiles/coverageTestPage.html
@@ -15,10 +15,15 @@
 <!-- Element state tests -->
 <div id="visibleEl">I am visible</div>
 <div id="hiddenEl">I am hidden</div>
+<label for="enabledInput">Enabled input</label>
 <input id="enabledInput" type="text" value="hello" />
+<label for="disabledInput">Disabled input</label>
 <input id="disabledInput" type="text" value="disabled" disabled />
+<label for="checkboxChecked">Checked option</label>
 <input id="checkboxChecked" type="checkbox" checked />
+<label for="checkboxUnchecked">Unchecked option</label>
 <input id="checkboxUnchecked" type="checkbox" />
+<label for="selectEl">Select option</label>
 <select id="selectEl">
     <option value="opt1" selected>Option 1</option>
     <option value="opt2">Option 2</option>
@@ -35,6 +40,7 @@
 
 <!-- Form elements -->
 <form id="testForm">
+    <label for="textInput">Text input</label>
     <input id="textInput" type="text" value="test value" />
     <button id="submitBtn" type="submit">Submit</button>
 </form>

--- a/shaft-engine/src/test/resources/testDataFiles/locatorBuilderFixture.html
+++ b/shaft-engine/src/test/resources/testDataFiles/locatorBuilderFixture.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SHAFT Locator Builder Fixture</title>
+    <style>
+        body {
+            margin: 0;
+            font-family: Arial, sans-serif;
+        }
+
+        #__docusaurus {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+            padding: 24px;
+        }
+
+        .hero__title {
+            margin: 0;
+        }
+
+        .button {
+            display: inline-block;
+            margin-top: 12px;
+        }
+
+        .form-row {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }
+    </style>
+</head>
+<body>
+<main id="__docusaurus">
+    <section>
+        <h1 class="hero__title">SHAFT: Unified Test Automation Engine</h1>
+        <p>Write once, test everywhere</p>
+        <a class="button" href="#start">Get Started Free</a>
+        <a href="#selenium">official Selenium ecosystem frameworks</a>
+    </section>
+
+    <section class="form-row">
+        <label for="test-count"># Tests to be automated:</label>
+        <input id="test-count" type="text" value="100">
+    </section>
+
+    <p>Ready to transform your test automation?</p>
+</main>
+</body>
+</html>

--- a/shaft-engine/src/test/resources/testDataFiles/uploadFixture.html
+++ b/shaft-engine/src/test/resources/testDataFiles/uploadFixture.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SHAFT Upload Fixture</title>
+    <style>
+        #drop-zone {
+            border: 2px dashed #777;
+            min-height: 120px;
+            padding: 24px;
+        }
+    </style>
+    <script>
+        function selectedFileCount(files) {
+            return files && files.length ? files.length + ' selected file' : 'No selected file';
+        }
+
+        function onFileInputChange(input) {
+            document.getElementById('selected-count').textContent = selectedFileCount(input.files);
+        }
+
+        function onAjaxUpload(input) {
+            var fileName = input.files && input.files.length ? input.files[0].name : '';
+            document.getElementById('ImageList').innerHTML = '<img alt="Uploaded image" src="' + fileName + '">';
+        }
+
+        function markUploaded() {
+            document.getElementById('upload-message').hidden = false;
+        }
+
+        window.addEventListener('DOMContentLoaded', function () {
+            var dropZone = document.getElementById('drop-zone');
+            dropZone.addEventListener('dragenter', function (event) {
+                event.preventDefault();
+            });
+            dropZone.addEventListener('dragover', function (event) {
+                event.preventDefault();
+            });
+            dropZone.addEventListener('drop', function (event) {
+                event.preventDefault();
+                document.getElementById('selected-count').textContent = selectedFileCount(event.dataTransfer.files);
+            });
+        });
+    </script>
+</head>
+<body>
+<label for="file-upload">Upload file</label>
+<input id="file-upload" type="file" onchange="onFileInputChange(this)">
+<button id="file-submit" type="button" onclick="markUploaded()">Upload</button>
+<h3 id="upload-message" hidden>File Uploaded!</h3>
+
+<div id="drop-zone">
+    <label for="upload-file">Drop files here</label>
+    <input id="upload-file" type="file" hidden onchange="onFileInputChange(this)">
+    <span id="selected-count">No selected file</span>
+</div>
+
+<label for="ajaxUpload">Ajax upload</label>
+<input id="ajaxUpload" type="file" onchange="onAjaxUpload(this)">
+<div id="ImageList"></div>
+</body>
+</html>

--- a/shaft-engine/src/test/resources/testDataFiles/validationTextFixture.html
+++ b/shaft-engine/src/test/resources/testDataFiles/validationTextFixture.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <title>SHAFT Validation Text Fixture</title>
+</head>
+<body>
+<label for="primaryInput">Primary input</label>
+<input id="primaryInput" type="text">
+
+<label for="englishInput">English input</label>
+<input id="englishInput" type="text" dir="ltr" value="Automation">
+
+<label for="arabicInput">Arabic input</label>
+<input id="arabicInput" type="text" dir="rtl" lang="ar" value="مرحبا">
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Define missing Moon and LambdaTest CI environment wiring.
- Replace brittle public and file URL test pages with deterministic local fixture server coverage.
- Stabilize LambdaTest credential handling, remote upload fixtures, accessibility fixture labels, and retry diagnostics log isolation.

## Root Causes Addressed
- Moon job failed before tests because `MOON_URL` was unset.
- LambdaTest jobs used local bundled credentials and treated missing or invalid provider auth as driver failures.
- Grid, Safari, and Windows jobs depended on public pages or local file URLs that remote browsers could not reliably access.
- Retry diagnostics test wrote to the shared engine log during parallel runs.

## Validation
- `mvn -pl shaft-engine -am -e test-compile '-DskipTests'`
- Focused local Chrome suite covering locator, upload, assertions, coverage, validation, accessibility, and browser helper tests: 102 tests passed.
- `mvn -pl shaft-engine -am -e test '-Dtest=testPackage.validationsWizard.BrowserValidationsTests' ...`
- `mvn -pl shaft-engine -am -e test '-Dtest=testPackage.unitTests.ThreadLocalPropertiesTest#testRetryDiagnosticsLoggingLifecycle' ...`
- LambdaTest missing-credentials CI path skips cleanly.
- `docker compose -f shaft-engine/src/main/resources/docker-compose/selenium4.yml config`
- `git diff --check`

## Not Run
- Full GitHub Actions matrix and live LambdaTest provider suites locally.