### PR TITLE
[codex] Enforce JaCoCo uploads for test workflows

### DIFF
--- a/.github/actions/upload-jacoco-coverage/action.yml
+++ b/.github/actions/upload-jacoco-coverage/action.yml
@@ -1,5 +1,5 @@
 name: 'Upload JaCoCo Coverage'
-description: 'Verifies expected JaCoCo XML reports exist, then uploads existing reports to Codecov.'
+description: 'Generates missing JaCoCo XML reports from execution data, verifies expected reports exist, then uploads them to Codecov.'
 inputs:
   codecov-token:
     description: 'Codecov upload token'
@@ -42,6 +42,56 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Generate missing JaCoCo XML reports
+      if: always()
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        normalize_paths() {
+          local value="$1"
+          value="${value//$'\r'/ }"
+          value="${value//$'\n'/ }"
+          value="${value//$'\t'/ }"
+          value="${value//,/ }"
+          value="${value//;/ }"
+          for item in $value; do
+            item="${item//\\//}"
+            printf '%s\n' "$item"
+          done
+        }
+
+        coverage_targets="${{ inputs.required-files }}"
+        if [ -z "$(normalize_paths "$coverage_targets" | tr -d '[:space:]')" ]; then
+          coverage_targets="${{ inputs.files }}"
+        fi
+
+        while IFS= read -r coverage_file; do
+          [ -z "$coverage_file" ] && continue
+          [ -s "$coverage_file" ] && continue
+
+          case "$coverage_file" in
+            */target/jacoco/jacoco.xml)
+              module_dir="${coverage_file%/target/jacoco/jacoco.xml}"
+              ;;
+            *)
+              echo "::notice::Cannot infer Maven module for JaCoCo report: $coverage_file"
+              continue
+              ;;
+          esac
+
+          [ -n "$module_dir" ] || module_dir="."
+          jacoco_exec="${module_dir}/target/jacoco.exec"
+          pom_file="${module_dir}/pom.xml"
+
+          if [ -s "$jacoco_exec" ] && [ -f "$pom_file" ]; then
+            echo "Generating JaCoCo XML report for ${module_dir} from ${jacoco_exec}"
+            mvn --batch-mode -f "$pom_file" jacoco:report@default-report -DskipTests -Dgpg.skip
+          else
+            echo "::notice::Cannot generate $coverage_file; missing $jacoco_exec or $pom_file"
+          fi
+        done < <(normalize_paths "$coverage_targets")
+
     - name: Resolve JaCoCo XML files
       id: resolve
       shell: bash
@@ -59,6 +109,7 @@ runs:
           value="${value//,/ }"
           value="${value//;/ }"
           for item in $value; do
+            item="${item//\\//}"
             printf '%s\n' "$item"
           done
         }

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -156,7 +156,6 @@ jobs:
           job-name: Ubuntu_Visual_Module
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           module-directory: shaft-visual
-          require-coverage: false
 
   Ubuntu_Desktop_Video_Module:
     runs-on: ubuntu-latest
@@ -186,7 +185,6 @@ jobs:
           job-name: Ubuntu_Desktop_Video_Module
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           module-directory: shaft-video
-          require-coverage: false
 
   Ubuntu_Firefox_Grid:
     runs-on: ubuntu-latest
@@ -295,7 +293,6 @@ jobs:
         with:
           job-name: Ubuntu_MicrosoftEdge_Grid
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
-          require-coverage: false
 
   Android_Native_BrowserStack:
     runs-on: ubuntu-latest
@@ -504,7 +501,6 @@ jobs:
         with:
           job-name: Windows_Edge_Local
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
-          require-coverage: false
 
   MacOSX_Safari_Local:
     runs-on: macos-latest
@@ -535,7 +531,6 @@ jobs:
         with:
           job-name: MacOSX_Safari_Local
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
-          require-coverage: false
 
   Windows_Chrome_Local:
     runs-on: windows-latest
@@ -566,7 +561,6 @@ jobs:
         with:
           job-name: Windows_Chrome_Local
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
-          require-coverage: false
 
   MacOSX_Chrome_Local:
     runs-on: macos-latest
@@ -659,7 +653,6 @@ jobs:
         with:
           job-name: LambdaTest_NativeAndroid
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
-          require-coverage: false
 
   LambdaTest_NativeIOS:
     runs-on: ubuntu-latest
@@ -886,4 +879,3 @@ jobs:
         with:
           job-name: Ubuntu_Chrome_Moon
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
-          require-coverage: false

--- a/.github/workflows/shaft-pilot-release.yml
+++ b/.github/workflows/shaft-pilot-release.yml
@@ -9,6 +9,7 @@ on:
       - "shaft-capture/**"
       - "shaft-doctor/**"
       - "shaft-ai/**"
+      - "shaft-heal/**"
       - "shaft-mcp/**"
       - "shaft-bom/**"
       - "report-aggregate/**"
@@ -59,18 +60,18 @@ jobs:
       - name: Install SHAFT Pilot prerequisites without tests
         run: >-
           mvn --batch-mode
-          -pl shaft-engine,shaft-pilot-core,shaft-capture,shaft-doctor,shaft-ai,shaft-mcp
+          -pl shaft-engine,shaft-pilot-core,shaft-capture,shaft-doctor,shaft-ai,shaft-heal,shaft-mcp
           -am install -DskipTests -Dgpg.skip
       - name: Reset Pilot Allure result contents
         run: |
-          for module in shaft-pilot-core shaft-capture shaft-doctor shaft-ai shaft-mcp; do
+          for module in shaft-pilot-core shaft-capture shaft-doctor shaft-ai shaft-heal shaft-mcp; do
             mkdir -p "${module}/allure-results"
             find "${module}/allure-results" -mindepth 1 -delete
           done
       - name: Run deterministic SHAFT Pilot tests
         run: >-
           mvn --batch-mode
-          -pl shaft-pilot-core,shaft-capture,shaft-doctor,shaft-ai,shaft-mcp
+          -pl shaft-pilot-core,shaft-capture,shaft-doctor,shaft-ai,shaft-heal,shaft-mcp
           test -Dgpg.skip
       - name: Verify populated Pilot Allure results
         run: python3 scripts/ci/validate_shaft_pilot_release.py --check-test-results

--- a/scripts/ci/validate_quality_configuration.py
+++ b/scripts/ci/validate_quality_configuration.py
@@ -31,6 +31,10 @@ DEPENDABOT_DIRECTORIES = {
 }
 JAVA_25_UNSAFE_FLAG = "--sun-misc-unsafe-memory-access=allow"
 IGNORE_UNRECOGNIZED_VM_OPTIONS = "-XX:+IgnoreUnrecognizedVMOptions"
+FORBIDDEN_OPTIONAL_COVERAGE_SETTINGS = (
+    "require-coverage: false",
+    "allow-missing-coverage: true",
+)
 
 
 def text(element: ET.Element, path: str) -> str | None:
@@ -50,6 +54,43 @@ def validate_maven_jvm_configuration(root: Path = ROOT) -> list[str]:
     return []
 
 
+def validate_surefire_jacoco_arg_lines(root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+    for module in sorted(JAVA_MODULES):
+        pom_path = root / module / "pom.xml"
+        if not pom_path.is_file():
+            continue
+        try:
+            project = ET.parse(pom_path).getroot()
+        except ET.ParseError as error:
+            errors.append(f"{pom_path.relative_to(root).as_posix()} is not valid XML: {error}")
+            continue
+        plugins = project.findall(".//m:plugin[m:artifactId='maven-surefire-plugin']", NS)
+        for plugin in plugins:
+            arg_line = plugin.find("m:configuration/m:argLine", NS)
+            if arg_line is not None and "@{argLine}" not in (arg_line.text or ""):
+                errors.append(
+                    f"{module} Surefire argLine must preserve JaCoCo's @{{argLine}} injection"
+                )
+    return errors
+
+
+def validate_workflow_coverage_policy(root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+    workflows = root / ".github" / "workflows"
+    if not workflows.is_dir():
+        return errors
+
+    for path in sorted(workflows.glob("*.yml")):
+        workflow = path.read_text(encoding="utf-8")
+        for forbidden in FORBIDDEN_OPTIONAL_COVERAGE_SETTINGS:
+            if forbidden in workflow:
+                errors.append(
+                    f"{path.relative_to(root).as_posix()} must not mark JaCoCo coverage optional with {forbidden!r}"
+                )
+    return errors
+
+
 def validate_quality_configuration(root: Path = ROOT) -> list[str]:
     errors: list[str] = []
     root_pom = ET.parse(root / "pom.xml").getroot()
@@ -64,6 +105,8 @@ def validate_quality_configuration(root: Path = ROOT) -> list[str]:
     if root_pom.find("m:build/m:plugins/m:plugin[m:artifactId='jacoco-maven-plugin']", NS) is None:
         errors.append("root build plugins must inherit managed JaCoCo execution for module reports")
     errors.extend(validate_maven_jvm_configuration(root))
+    errors.extend(validate_surefire_jacoco_arg_lines(root))
+    errors.extend(validate_workflow_coverage_policy(root))
 
     aggregate_path = root / "report-aggregate" / "pom.xml"
     if not aggregate_path.is_file():

--- a/scripts/ci/validate_shaft_pilot_release.py
+++ b/scripts/ci/validate_shaft_pilot_release.py
@@ -19,6 +19,7 @@ PILOT_MODULES = (
     "shaft-capture",
     "shaft-doctor",
     "shaft-ai",
+    "shaft-heal",
     "shaft-mcp",
 )
 PUBLIC_ARTIFACTS = {
@@ -26,6 +27,7 @@ PUBLIC_ARTIFACTS = {
     "shaft-capture": "shaft-capture",
     "shaft-doctor": "shaft-doctor",
     "shaft-ai": "shaft-ai",
+    "shaft-heal": "shaft-heal",
     "shaft-mcp": "shaft-mcp",
 }
 SECRET_CANARIES = (

--- a/shaft-heal/pom.xml
+++ b/shaft-heal/pom.xml
@@ -97,7 +97,7 @@
                     </dependency>
                 </dependencies>
                 <configuration>
-                    <argLine>${surefireArgLine} ${mockitoAgentArgLine}</argLine>
+                    <argLine>@{argLine} ${surefireArgLine} ${mockitoAgentArgLine}</argLine>
                     <failIfNoSpecifiedTests>${surefire.failIfNoSpecifiedTests}</failIfNoSpecifiedTests>
                     <systemPropertyVariables>
                         <alwaysLogDiscreetly>true</alwaysLogDiscreetly>

--- a/shaft-visual/pom.xml
+++ b/shaft-visual/pom.xml
@@ -106,7 +106,7 @@
                     </dependency>
                 </dependencies>
                 <configuration>
-                    <argLine>${surefireArgLine} ${mockitoAgentArgLine}</argLine>
+                    <argLine>@{argLine} ${surefireArgLine} ${mockitoAgentArgLine}</argLine>
                     <failIfNoSpecifiedTests>${surefire.failIfNoSpecifiedTests}</failIfNoSpecifiedTests>
                     <systemPropertyVariables>
                         <alwaysLogDiscreetly>true</alwaysLogDiscreetly>

--- a/tests/scripts/test_validate_quality_configuration.py
+++ b/tests/scripts/test_validate_quality_configuration.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from scripts.ci.validate_quality_configuration import (
     validate_maven_jvm_configuration,
     validate_quality_configuration,
+    validate_surefire_jacoco_arg_lines,
+    validate_workflow_coverage_policy,
 )
 
 
@@ -40,6 +42,53 @@ class ValidateQualityConfigurationTest(unittest.TestCase):
             )
 
             self.assertEqual(validate_maven_jvm_configuration(root), [])
+
+    def test_rejects_surefire_arg_line_that_drops_jacoco_injection(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            module = root / "shaft-visual"
+            module.mkdir()
+            (module / "pom.xml").write_text(
+                """<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>${surefireArgLine} ${mockitoAgentArgLine}</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>""",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                validate_surefire_jacoco_arg_lines(root),
+                ["shaft-visual Surefire argLine must preserve JaCoCo's @{argLine} injection"],
+            )
+
+    def test_rejects_optional_jacoco_coverage_in_workflows(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            workflows = root / ".github" / "workflows"
+            workflows.mkdir(parents=True)
+            (workflows / "e2eTests.yml").write_text(
+                "steps:\n"
+                "  - uses: ./.github/actions/post-test-report\n"
+                "    with:\n"
+                "      require-coverage: false\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                validate_workflow_coverage_policy(root),
+                [
+                    ".github/workflows/e2eTests.yml must not mark JaCoCo coverage "
+                    "optional with 'require-coverage: false'"
+                ],
+            )
 
     def test_reports_missing_aggregate_module(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

- Require JaCoCo coverage for Java test-running E2E jobs instead of allowing optional coverage.
- Preserve JaCoCo `@{argLine}` injection in module Surefire overrides and add a fallback upload-action step that regenerates missing XML from `jacoco.exec` before Codecov upload.
- Align the Pilot release candidate workflow and validator with `shaft-heal` coverage, and add quality-validator checks to prevent optional coverage settings or dropped JaCoCo argLine wiring from returning.

## Why

Some test workflows could complete without a JaCoCo XML file and still continue to the reporting path because coverage was explicitly optional in several jobs. Module Surefire overrides also needed to preserve JaCoCo's injected agent argument so the XML can always be produced when tests run.

## Validation

- `python -m unittest tests.scripts.test_validate_quality_configuration tests.scripts.test_validate_shaft_pilot_release`
- `python scripts/ci/validate_quality_configuration.py`
- `python scripts/ci/validate_shaft_pilot_release.py`
- `mvn -pl shaft-visual -am -e clean test '-Dtest=ImageProcessingActionsUnitTest' '-DgenerateAllureReportArchive=true' '-Dgpg.skip'`
- Confirmed `shaft-visual/target/jacoco/jacoco.xml` was generated during the Maven test run.
- `git diff --cached --check`