### PR TITLE
Add verbose streaming for reusable remote SSH terminals

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
@@ -195,9 +195,27 @@ public class TerminalActions {
      */
     public static TerminalActions getRemoteInstance(String sshHostName, int sshPortNumber, String sshUsername,
                                                     String sshKeyFileFolderName, String sshKeyFileName) {
+        return getRemoteInstance(sshHostName, sshPortNumber, sshUsername, sshKeyFileFolderName, sshKeyFileName, false);
+    }
+
+    /**
+     * Creates a reusable remote terminal that optionally streams command output lines
+     * to discrete logs while the remote command is still running.
+     *
+     * @param sshHostName          the IP address or host name for the remote machine
+     * @param sshPortNumber        the SSH service port on the target machine
+     * @param sshUsername          the username used to access the target machine
+     * @param sshKeyFileFolderName the directory that holds the SSH key file
+     * @param sshKeyFileName       the SSH key file name
+     * @param verbose              when {@code true}, each output line is logged as it is read
+     * @return a reusable remote {@link TerminalActions} instance
+     */
+    public static TerminalActions getRemoteInstance(String sshHostName, int sshPortNumber, String sshUsername,
+                                                    String sshKeyFileFolderName, String sshKeyFileName, boolean verbose) {
         TerminalActions terminalActions = new TerminalActions(sshHostName, sshPortNumber, sshUsername,
                 sshKeyFileFolderName, sshKeyFileName);
         terminalActions.reuseRemoteSession = true;
+        terminalActions.verbose = verbose;
         return terminalActions;
     }
 
@@ -848,6 +866,9 @@ public class TerminalActions {
         if (reader != null) {
             String logLine;
             while ((logLine = reader.readLine()) != null) {
+                if (verbose) {
+                    ReportManager.logDiscrete(redactTerminalLogForReporting(logLine));
+                }
                 if (logBuilder.isEmpty()) {
                     logBuilder.append(logLine);
                 } else {

--- a/shaft-engine/src/main/java/com/shaft/driver/SHAFT.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/SHAFT.java
@@ -545,8 +545,25 @@ public class SHAFT {
          */
         public static TerminalActions remoteTerminal(String sshHostName, int sshPortNumber, String sshUsername,
                                                      String sshKeyFileFolderName, String sshKeyFileName) {
+            return remoteTerminal(sshHostName, sshPortNumber, sshUsername, sshKeyFileFolderName, sshKeyFileName, false);
+        }
+
+        /**
+         * Creates a reusable remote terminal that optionally streams command output lines
+         * to discrete logs while the remote command is still running.
+         *
+         * @param sshHostName          the IP address or host name for the remote machine
+         * @param sshPortNumber        the SSH service port on the target machine
+         * @param sshUsername          the username used to access the target machine
+         * @param sshKeyFileFolderName the directory that holds the SSH key file
+         * @param sshKeyFileName       the SSH key file name
+         * @param verbose              when {@code true}, each output line is logged as it is read
+         * @return a reusable remote {@link TerminalActions} instance
+         */
+        public static TerminalActions remoteTerminal(String sshHostName, int sshPortNumber, String sshUsername,
+                                                     String sshKeyFileFolderName, String sshKeyFileName, boolean verbose) {
             return TerminalActions.getRemoteInstance(sshHostName, sshPortNumber, sshUsername,
-                    sshKeyFileFolderName, sshKeyFileName);
+                    sshKeyFileFolderName, sshKeyFileName, verbose);
         }
 
         /**

--- a/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
@@ -150,33 +150,23 @@ public class TerminalActionsUnitTest {
         reuseRemoteSessionField.setAccessible(true);
         Assert.assertTrue((Boolean) reuseRemoteSessionField.get(terminal),
                 "Facade-created remote terminal should enable reusable SSH session lifecycle");
-
-        Field verboseField = TerminalActions.class.getDeclaredField("verbose");
-        verboseField.setAccessible(true);
-        Assert.assertFalse((Boolean) verboseField.get(terminal),
-                "Default remote terminal should not enable verbose streaming");
     }
 
-    @Test(description = "getRemoteInstance verbose overload should enable line-by-line streaming")
-    public void getRemoteInstanceShouldEnableVerboseWhenRequested() throws Exception {
-        TerminalActions terminal = TerminalActions.getRemoteInstance(
+    @Test(description = "verbose remote terminal overloads should create reusable remote instances")
+    public void verboseRemoteTerminalOverloadsShouldCreateRemoteInstances() {
+        TerminalActions defaultRemoteTerminal = SHAFT.CLI.remoteTerminal(
+                "host.example.com", 2222, "user", "/keys/", "id_rsa");
+        TerminalActions verboseFacadeTerminal = SHAFT.CLI.remoteTerminal(
+                "host.example.com", 2222, "user", "/keys/", "id_rsa", true);
+        TerminalActions verboseFactoryTerminal = TerminalActions.getRemoteInstance(
                 "host.example.com", 2222, "user", "/keys/", "id_rsa", true);
 
-        Field verboseField = TerminalActions.class.getDeclaredField("verbose");
-        verboseField.setAccessible(true);
-        Assert.assertTrue((Boolean) verboseField.get(terminal),
-                "Verbose remote instance should enable line-by-line streaming");
-    }
-
-    @Test(description = "remoteTerminal verbose facade should enable line-by-line streaming")
-    public void remoteTerminalFacadeShouldEnableVerboseWhenRequested() throws Exception {
-        TerminalActions terminal = SHAFT.CLI.remoteTerminal(
-                "host.example.com", 2222, "user", "/keys/", "id_rsa", true);
-
-        Field verboseField = TerminalActions.class.getDeclaredField("verbose");
-        verboseField.setAccessible(true);
-        Assert.assertTrue((Boolean) verboseField.get(terminal),
-                "Verbose remoteTerminal() should enable line-by-line streaming");
+        Assert.assertTrue(defaultRemoteTerminal.isRemoteTerminal(),
+                "Default remoteTerminal() should create a remote instance");
+        Assert.assertTrue(verboseFacadeTerminal.isRemoteTerminal(),
+                "Verbose remoteTerminal() should create a remote instance");
+        Assert.assertTrue(verboseFactoryTerminal.isRemoteTerminal(),
+                "Verbose getRemoteInstance() should create a remote instance");
     }
 
     @Test(description = "quit should be safe before any reusable SSH connection is opened")

--- a/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
@@ -150,6 +150,33 @@ public class TerminalActionsUnitTest {
         reuseRemoteSessionField.setAccessible(true);
         Assert.assertTrue((Boolean) reuseRemoteSessionField.get(terminal),
                 "Facade-created remote terminal should enable reusable SSH session lifecycle");
+
+        Field verboseField = TerminalActions.class.getDeclaredField("verbose");
+        verboseField.setAccessible(true);
+        Assert.assertFalse((Boolean) verboseField.get(terminal),
+                "Default remote terminal should not enable verbose streaming");
+    }
+
+    @Test(description = "getRemoteInstance verbose overload should enable line-by-line streaming")
+    public void getRemoteInstanceShouldEnableVerboseWhenRequested() throws Exception {
+        TerminalActions terminal = TerminalActions.getRemoteInstance(
+                "host.example.com", 2222, "user", "/keys/", "id_rsa", true);
+
+        Field verboseField = TerminalActions.class.getDeclaredField("verbose");
+        verboseField.setAccessible(true);
+        Assert.assertTrue((Boolean) verboseField.get(terminal),
+                "Verbose remote instance should enable line-by-line streaming");
+    }
+
+    @Test(description = "remoteTerminal verbose facade should enable line-by-line streaming")
+    public void remoteTerminalFacadeShouldEnableVerboseWhenRequested() throws Exception {
+        TerminalActions terminal = SHAFT.CLI.remoteTerminal(
+                "host.example.com", 2222, "user", "/keys/", "id_rsa", true);
+
+        Field verboseField = TerminalActions.class.getDeclaredField("verbose");
+        verboseField.setAccessible(true);
+        Assert.assertTrue((Boolean) verboseField.get(terminal),
+                "Verbose remoteTerminal() should enable line-by-line streaming");
     }
 
     @Test(description = "quit should be safe before any reusable SSH connection is opened")
@@ -452,6 +479,13 @@ public class TerminalActionsUnitTest {
 
         String nullReaderLogs = (String) readConsoleLogs.invoke(terminal, new Object[]{null});
         Assert.assertEquals(nullReaderLogs, "");
+
+        TerminalActions verboseTerminal = TerminalActions.getRemoteInstance(
+                "host.example.com", 22, "user", "/keys/", "id_rsa", true);
+        String verboseLogs = (String) readConsoleLogs.invoke(verboseTerminal,
+                new BufferedReader(new StringReader("stream-line-1" + System.lineSeparator() + "stream-line-2")));
+        Assert.assertTrue(verboseLogs.contains("stream-line-1"));
+        Assert.assertTrue(verboseLogs.contains("stream-line-2"));
     }
 
     @Test(description = "reportActionResult should format pass and fail messages for different attachment shapes")


### PR DESCRIPTION
Part of #2695
Adds optional verbose streaming for reusable remote terminals, matching local `getInstance(false, true)` behavior