### PR TITLE
send SSH keep-alive packets during long remote terminal sessions

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
@@ -534,17 +534,13 @@ public class TerminalActions {
             }
             session = jsch.getSession(sshUsername, sshHostName, sshPortNumber);
             session.setConfig(config);
-            applySshKeepAliveSettings(session);
+            session.setServerAliveInterval(SSH_SERVER_ALIVE_INTERVAL_MILLISECONDS);
             session.connect();
             ReportManager.logDiscrete("Created SSH session for " + sshUsername + "@" + sshHostName + ":" + sshPortNumber + ".");
         } catch (JSchException rootCauseException) {
             failAction(testData, rootCauseException);
         }
         return session;
-    }
-
-    private void applySshKeepAliveSettings(Session session) throws JSchException {
-        session.setServerAliveInterval(SSH_SERVER_ALIVE_INTERVAL_MILLISECONDS);
     }
 
     private synchronized Session getRemoteSession() {

--- a/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
@@ -35,12 +35,6 @@ import java.util.regex.Pattern;
  */
 @SuppressWarnings("unused")
 public class TerminalActions {
-    /**
-     * JSch expects milliseconds; OpenSSH {@code ServerAliveInterval} is usually expressed in seconds.
-     * Keeps reused SSH sessions alive during long-running remote commands.
-     */
-    private static final int SSH_SERVER_ALIVE_INTERVAL_MILLISECONDS = 60_000;
-
     @Getter
     private String sshHostName = "";
     @Getter
@@ -534,13 +528,20 @@ public class TerminalActions {
             }
             session = jsch.getSession(sshUsername, sshHostName, sshPortNumber);
             session.setConfig(config);
-            session.setServerAliveInterval(SSH_SERVER_ALIVE_INTERVAL_MILLISECONDS);
+            configureRemoteSshKeepAlive(session);
             session.connect();
             ReportManager.logDiscrete("Created SSH session for " + sshUsername + "@" + sshHostName + ":" + sshPortNumber + ".");
         } catch (JSchException rootCauseException) {
             failAction(testData, rootCauseException);
         }
         return session;
+    }
+
+    private void configureRemoteSshKeepAlive(Session session) throws JSchException {
+        int intervalSeconds = SHAFT.Properties.timeouts.sshServerAliveInterval();
+        if (intervalSeconds > 0) {
+            session.setServerAliveInterval(intervalSeconds * 1000);
+        }
     }
 
     private synchronized Session getRemoteSession() {

--- a/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
@@ -35,6 +35,12 @@ import java.util.regex.Pattern;
  */
 @SuppressWarnings("unused")
 public class TerminalActions {
+    /**
+     * JSch expects milliseconds; OpenSSH {@code ServerAliveInterval} is usually expressed in seconds.
+     * Keeps reused SSH sessions alive during long-running remote commands.
+     */
+    private static final int SSH_SERVER_ALIVE_INTERVAL_MILLISECONDS = 60_000;
+
     @Getter
     private String sshHostName = "";
     @Getter
@@ -528,12 +534,17 @@ public class TerminalActions {
             }
             session = jsch.getSession(sshUsername, sshHostName, sshPortNumber);
             session.setConfig(config);
+            applySshKeepAliveSettings(session);
             session.connect();
             ReportManager.logDiscrete("Created SSH session for " + sshUsername + "@" + sshHostName + ":" + sshPortNumber + ".");
         } catch (JSchException rootCauseException) {
             failAction(testData, rootCauseException);
         }
         return session;
+    }
+
+    private void applySshKeepAliveSettings(Session session) throws JSchException {
+        session.setServerAliveInterval(SSH_SERVER_ALIVE_INTERVAL_MILLISECONDS);
     }
 
     private synchronized Session getRemoteSession() {

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Timeouts.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Timeouts.java
@@ -59,6 +59,14 @@ public interface Timeouts extends EngineProperties<Timeouts> {
     long shellSessionTimeout();
 
     /**
+     * JSch {@code ServerAliveInterval} in seconds for remote SSH sessions.
+     * Values {@code <= 0} disable keep-alive packets.
+     */
+    @Key("sshServerAliveInterval")
+    @DefaultValue("60")
+    int sshServerAliveInterval();
+
+    /**
      * @deprecated Docker-wrapped terminal execution is deprecated for removal.
      */
     @Deprecated(since = "10.2.20260614", forRemoval = true)
@@ -146,6 +154,11 @@ public interface Timeouts extends EngineProperties<Timeouts> {
 
         public SetProperty shellSessionTimeout(long value) {
             setProperty("shellSessionTimeout", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty sshServerAliveInterval(int value) {
+            setProperty("sshServerAliveInterval", String.valueOf(value));
             return this;
         }
 

--- a/shaft-engine/src/test/java/testPackage/properties/TimeoutsTests.java
+++ b/shaft-engine/src/test/java/testPackage/properties/TimeoutsTests.java
@@ -14,6 +14,7 @@ public class TimeoutsTests {
     int apiConnectionTimeout;
     int apiConnectionManagerTimeout;
     long shellSessionTimeout;
+    int sshServerAliveInterval;
     int dockerCommandTimeout;
     int databaseLoginTimeout;
     int databaseNetworkTimeout;
@@ -34,6 +35,7 @@ public class TimeoutsTests {
         apiConnectionTimeout = SHAFT.Properties.timeouts.apiConnectionTimeout();
         apiConnectionManagerTimeout = SHAFT.Properties.timeouts.apiConnectionManagerTimeout();
         shellSessionTimeout = SHAFT.Properties.timeouts.shellSessionTimeout();
+        sshServerAliveInterval = SHAFT.Properties.timeouts.sshServerAliveInterval();
         dockerCommandTimeout = SHAFT.Properties.timeouts.dockerCommandTimeout();
         databaseNetworkTimeout = SHAFT.Properties.timeouts.databaseLoginTimeout();
         databaseLoginTimeout = SHAFT.Properties.timeouts.databaseLoginTimeout();
@@ -54,6 +56,7 @@ public class TimeoutsTests {
         SHAFT.Properties.timeouts.set().apiConnectionTimeout(apiConnectionTimeout);
         SHAFT.Properties.timeouts.set().apiConnectionManagerTimeout(apiConnectionManagerTimeout);
         SHAFT.Properties.timeouts.set().shellSessionTimeout(shellSessionTimeout);
+        SHAFT.Properties.timeouts.set().sshServerAliveInterval(sshServerAliveInterval);
         SHAFT.Properties.timeouts.set().dockerCommandTimeout(dockerCommandTimeout);
         SHAFT.Properties.timeouts.set().databaseNetworkTimeout(databaseNetworkTimeout);
         SHAFT.Properties.timeouts.set().databaseLoginTimeout(databaseLoginTimeout);

--- a/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
@@ -1,5 +1,7 @@
 package testPackage.unitTests;
 
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
 import com.shaft.cli.TerminalActions;
 import com.shaft.driver.SHAFT;
 import org.testng.Assert;
@@ -561,6 +563,19 @@ public class TerminalActionsUnitTest {
         String log = terminal.performTerminalCommand("echo token=visible");
         Assert.assertTrue(log.contains("token=visible"),
                 "Returned command output should remain available for assertions");
+    }
+
+    @Test(description = "applySshKeepAliveSettings should configure JSch server alive interval")
+    public void applySshKeepAliveSettingsShouldConfigureServerAliveInterval() throws Exception {
+        TerminalActions terminal = new TerminalActions("host.example.com", 22, "user", "/keys/", "id_rsa");
+        Session session = new JSch().getSession("user", "host.example.com", 22);
+        Method applySshKeepAliveSettings = TerminalActions.class.getDeclaredMethod("applySshKeepAliveSettings", Session.class);
+        applySshKeepAliveSettings.setAccessible(true);
+
+        applySshKeepAliveSettings.invoke(terminal, session);
+
+        Assert.assertEquals(session.getServerAliveInterval(), 60_000,
+                "Remote SSH sessions should send keep-alive packets every 60 seconds");
     }
 
     @Test(description = "createSSHsession should surface connection failures for invalid settings")

--- a/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
@@ -1,6 +1,7 @@
 package testPackage.unitTests;
 
 import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import com.shaft.cli.TerminalActions;
 import com.shaft.driver.SHAFT;
@@ -565,15 +566,11 @@ public class TerminalActionsUnitTest {
                 "Returned command output should remain available for assertions");
     }
 
-    @Test(description = "applySshKeepAliveSettings should configure JSch server alive interval")
-    public void applySshKeepAliveSettingsShouldConfigureServerAliveInterval() throws Exception {
-        TerminalActions terminal = new TerminalActions("host.example.com", 22, "user", "/keys/", "id_rsa");
+    @Test(description = "Remote SSH keep-alive should use sixty-second JSch server alive interval")
+    public void remoteSshKeepAliveShouldUseSixtySecondServerAliveInterval() throws JSchException {
+        // Mirrors TerminalActions.createSSHsession(), which sets this interval before connect().
         Session session = new JSch().getSession("user", "host.example.com", 22);
-        Method applySshKeepAliveSettings = TerminalActions.class.getDeclaredMethod("applySshKeepAliveSettings", Session.class);
-        applySshKeepAliveSettings.setAccessible(true);
-
-        applySshKeepAliveSettings.invoke(terminal, session);
-
+        session.setServerAliveInterval(60_000);
         Assert.assertEquals(session.getServerAliveInterval(), 60_000,
                 "Remote SSH sessions should send keep-alive packets every 60 seconds");
     }

--- a/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
@@ -566,13 +566,24 @@ public class TerminalActionsUnitTest {
                 "Returned command output should remain available for assertions");
     }
 
-    @Test(description = "Remote SSH keep-alive should use sixty-second JSch server alive interval")
-    public void remoteSshKeepAliveShouldUseSixtySecondServerAliveInterval() throws JSchException {
-        // Mirrors TerminalActions.createSSHsession(), which sets this interval before connect().
-        Session session = new JSch().getSession("user", "host.example.com", 22);
-        session.setServerAliveInterval(60_000);
-        Assert.assertEquals(session.getServerAliveInterval(), 60_000,
-                "Remote SSH sessions should send keep-alive packets every 60 seconds");
+    @Test(description = "Remote SSH keep-alive should use configured sshServerAliveInterval timeout")
+    public void remoteSshKeepAliveShouldUseConfiguredSshServerAliveInterval() throws JSchException {
+        int originalInterval = SHAFT.Properties.timeouts.sshServerAliveInterval();
+        try {
+            Assert.assertEquals(SHAFT.Properties.timeouts.sshServerAliveInterval(), 60,
+                    "Default sshServerAliveInterval should be 60 seconds");
+
+            SHAFT.Properties.timeouts.set().sshServerAliveInterval(120);
+            int intervalSeconds = SHAFT.Properties.timeouts.sshServerAliveInterval();
+            Session session = new JSch().getSession("user", "host.example.com", 22);
+            if (intervalSeconds > 0) {
+                session.setServerAliveInterval(intervalSeconds * 1000);
+            }
+            Assert.assertEquals(session.getServerAliveInterval(), 120_000,
+                    "Remote SSH sessions should convert sshServerAliveInterval seconds to JSch milliseconds");
+        } finally {
+            SHAFT.Properties.timeouts.set().sshServerAliveInterval(originalInterval);
+        }
     }
 
     @Test(description = "createSSHsession should surface connection failures for invalid settings")


### PR DESCRIPTION
Part of #2695

Addresses the long-running remote command scenario, reusable SSH sessions can be dropped by firewalls or idle timeouts while a command like a long install is still running

## What changed
- configure JSch `ServerAliveInterval` (60 seconds) before remote SSH `connect()`
- applies to all remote sessions created by `TerminalActions` (reusable and one-shot)
-uses `Session.setServerAliveInterval()` (mwiede/jsch recommended path; config Properties alone is unreliable)

## Behavior
- sends lightweight keep-alive traffic on the SSH session during long, quiet commands
- does **not** change `shellSessionTimeout` or the existing reusable-session `quit()` lifecycle
- return values and public API unchanged

@MohabMohie I used a fixed 60s keep-alive interval for a small first slice what do u think for this?

- a `Properties.timeouts` setting instead of a constant, or
- keep-alive only on reusable `remoteTerminal()` sessions