### PR TITLE
fix(visuals): restore element-highlight screenshots on native mobile (flatten alpha before JPEG encode)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
@@ -130,6 +130,21 @@ public class ImageProcessingActions {
             throw new IllegalArgumentException("Failed to decode screenshot bytes.");
         }
 
+        // JPEG cannot encode an alpha channel: ImageIO.write(.., "jpg", ..) silently returns false
+        // and produces an empty byte[] for an alpha-bearing image. Native mobile-app screenshots
+        // (PNG) decode with alpha, so the highlighted screenshot would come back empty and be
+        // dropped from the report. Flatten onto an opaque RGB raster before drawing/encoding.
+        if (image.getColorModel().hasAlpha()) {
+            BufferedImage opaqueImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_INT_RGB);
+            Graphics2D flatten = opaqueImage.createGraphics();
+            try {
+                flatten.drawImage(image, 0, 0, null);
+            } finally {
+                flatten.dispose();
+            }
+            image = opaqueImage;
+        }
+
         int outlineThickness = 5;
         double elementHeight = elementLocation.getHeight();
         double elementWidth = elementLocation.getWidth();

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotManager.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotManager.java
@@ -219,11 +219,21 @@ public class ScreenshotManager {
                 elementLocation = elementInformation.getElementRect();
             }
         }
+        byte[] src;
         try {
             //takeScreenshot
-            byte[] src = takeScreenshot(driver, elementLocator);
-            //highlightElement using OpenCV
-            if (elementLocation != null) {
+            src = takeScreenshot(driver, elementLocator);
+        } catch (WebDriverException e) {
+            // we genuinely failed to capture a screenshot — nothing to report
+            ReportManagerHelper.logDiscrete(e);
+            return new byte[0];
+        }
+        //highlightElement (best-effort): a highlighting failure must never discard a captured
+        //screenshot. On some targets (e.g. native mobile apps) the highlight step can throw a
+        //non-WebDriverException (image decode/draw/encode); in that case keep the un-highlighted
+        //screenshot instead of dropping it.
+        if (elementLocation != null) {
+            try {
                 Color color;
                 if (isPass) {
                     color = new Color(67, 176, 42); // selenium-green
@@ -231,16 +241,13 @@ public class ScreenshotManager {
                     color = new Color(255, 255, 153); // yellow
                 }
                 src = ImageProcessingActions.highlightElementInScreenshot(src, elementLocation, color);
+            } catch (Exception highlightFailure) {
+                ReportManagerHelper.logDiscrete(highlightFailure);
             }
-            //append highlighted element to GIF
-            AnimatedGifManager.startOrAppendToAnimatedGif(src);
-            return src;
-        } catch (WebDriverException e) {
-            // in case we failed to take a screenshot
-            ReportManagerHelper.logDiscrete(e);
         }
-        //return an empty byteArray if no screenshot was needed or if we failed to take it
-        return new byte[0];
+        //append (highlighted or plain) screenshot to GIF
+        AnimatedGifManager.startOrAppendToAnimatedGif(src);
+        return src;
     }
 
     private byte[] takeJavaScriptHighlightedScreenshot(WebDriver driver, By elementLocator, boolean isPass) {

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotManager.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotManager.java
@@ -229,9 +229,9 @@ public class ScreenshotManager {
             return new byte[0];
         }
         //highlightElement (best-effort): a highlighting failure must never discard a captured
-        //screenshot. On some targets (e.g. native mobile apps) the highlight step can throw a
-        //non-WebDriverException (image decode/draw/encode); in that case keep the un-highlighted
-        //screenshot instead of dropping it.
+        //screenshot. The highlight step can throw a non-WebDriverException, or return an
+        //empty/null array (e.g. an image it cannot re-encode), so only adopt its result when it
+        //actually produced bytes; otherwise keep the un-highlighted screenshot.
         if (elementLocation != null) {
             try {
                 Color color;
@@ -240,7 +240,10 @@ public class ScreenshotManager {
                 } else {
                     color = new Color(255, 255, 153); // yellow
                 }
-                src = ImageProcessingActions.highlightElementInScreenshot(src, elementLocation, color);
+                byte[] highlighted = ImageProcessingActions.highlightElementInScreenshot(src, elementLocation, color);
+                if (highlighted != null && highlighted.length > 0) {
+                    src = highlighted;
+                }
             } catch (Exception highlightFailure) {
                 ReportManagerHelper.logDiscrete(highlightFailure);
             }

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotManagerCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotManagerCoverageUnitTest.java
@@ -248,6 +248,45 @@ public class ScreenshotManagerCoverageUnitTest {
         }
     }
 
+    @Test
+    public void aiHighlightFailureShouldFallBackToUnhighlightedScreenshot() {
+        // Regression for the native-mobile highlight bug: when
+        // ImageProcessingActions.highlightElementInScreenshot throws a
+        // non-WebDriverException (e.g. an image decode/draw/encode failure on a
+        // native app screenshot), the captured screenshot must still be reported
+        // un-highlighted instead of being silently dropped as an empty byte[].
+        SHAFT.Properties.reporting.set().disableLogging(true);
+        SHAFT.Properties.visuals.set().screenshotParamsScreenshotType("VIEWPORT");
+        SHAFT.Properties.visuals.set().screenshotParamsHighlightMethod("AI");
+        SHAFT.Properties.visuals.set().screenshotParamsHighlightElements(true);
+        SHAFT.Properties.visuals.set().screenshotParamsWatermark(false);
+        SHAFT.Properties.visuals.set().createAnimatedGif(false);
+
+        WebDriver driver = mock(WebDriver.class);
+        WebElement element = mock(WebElement.class);
+        when(element.getScreenshotAs(OutputType.BYTES)).thenReturn(createPng(12, 12, Color.BLACK));
+
+        try (MockedConstruction<ElementActionsHelper> ignored = Mockito.mockConstruction(ElementActionsHelper.class,
+                (mock, context) -> when(mock.identifyUniqueElementIgnoringVisibility(any(WebDriver.class), any(By.class)))
+                        .thenReturn(List.of(1, element, By.id("x"), "", "", "", "", new Rectangle(2, 2, 5, 5))));
+             MockedStatic<ScreenshotHelper> screenshotHelperMocked = Mockito.mockStatic(ScreenshotHelper.class);
+             MockedStatic<AnimatedGifManager> animatedGifMocked = Mockito.mockStatic(AnimatedGifManager.class);
+             MockedStatic<ImageProcessingActions> imageProcessingMocked = Mockito.mockStatic(ImageProcessingActions.class)) {
+            byte[] viewport = createPng(30, 30, Color.GREEN);
+            screenshotHelperMocked.when(() -> ScreenshotHelper.takeViewportScreenshot(any(WebDriver.class), anyInt()))
+                    .thenReturn(viewport);
+            animatedGifMocked.when(() -> AnimatedGifManager.startOrAppendToAnimatedGif(any(byte[].class))).thenAnswer(i -> null);
+            imageProcessingMocked.when(() -> ImageProcessingActions.highlightElementInScreenshot(any(byte[].class), any(Rectangle.class), any(Color.class)))
+                    .thenThrow(new IllegalArgumentException("Failed to decode screenshot bytes."));
+
+            ScreenshotManager manager = new ScreenshotManager();
+            byte[] result = manager.internalCaptureScreenshot(driver, By.id("x"), true);
+
+            Assert.assertTrue(result.length > 0, "a highlight failure must not drop the captured screenshot");
+            Assert.assertTrue(Arrays.equals(result, viewport), "should fall back to the un-highlighted viewport screenshot");
+        }
+    }
+
     private byte[] createPng(int width, int height, Color color) {
         try {
             BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);

--- a/shaft-visual/src/test/java/testPackage/unitTests/ImageProcessingActionsUnitTest.java
+++ b/shaft-visual/src/test/java/testPackage/unitTests/ImageProcessingActionsUnitTest.java
@@ -216,6 +216,22 @@ public class ImageProcessingActionsUnitTest {
     }
 
     @Test
+    public void highlightElementInScreenshotShouldHandleAlphaBearingScreenshot() {
+        // Native mobile-app screenshots decode to an alpha-bearing image, and JPEG cannot encode
+        // alpha (ImageIO.write returns false → empty byte[]), which previously dropped the
+        // highlighted screenshot from the report. The highlight step must flatten alpha first so
+        // it still returns usable, non-empty bytes. Regression for missing mobile screenshots.
+        byte[] highlighted = ImageProcessingActions.highlightElementInScreenshot(
+                createArgbPng(50, 50, Color.WHITE),
+                new org.openqa.selenium.Rectangle(10, 10, 20, 20),
+                Color.RED
+        );
+
+        Assert.assertTrue(highlighted.length > 0,
+                "highlighting an alpha-bearing (mobile) screenshot must still produce image bytes");
+    }
+
+    @Test
     public void highlightElementInScreenshotShouldHandleWindowsScaling() {
         String originalTargetPlatform = SHAFT.Properties.platform.targetPlatform();
         double originalScalingFactor = SHAFT.Properties.visuals.screenshotParamsScalingFactor();
@@ -393,6 +409,22 @@ public class ImageProcessingActionsUnitTest {
 
     private static byte[] createPng(int width, int height, Color color) {
         BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        graphics.setColor(color);
+        graphics.fillRect(0, 0, width, height);
+        graphics.dispose();
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try {
+            ImageIO.write(image, "png", output);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return output.toByteArray();
+    }
+
+    private static byte[] createArgbPng(int width, int height, Color color) {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
         Graphics2D graphics = image.createGraphics();
         graphics.setColor(color);
         graphics.fillRect(0, 0, width, height);


### PR DESCRIPTION
## 📋 Description

Element-highlight validation screenshots were silently dropped on **native mobile** executions. The Android screenshot decodes to an alpha-bearing image, and `ImageProcessingActions.highlightElementInScreenshot(...)` re-encodes the highlighted result with `ImageIO.write(.., "jpg", ..)` — which **cannot encode an alpha channel** and returns `false`/empty **without throwing**, so the screenshot is dropped from the report. This PR flattens the image to an opaque RGB raster before drawing/encoding so the highlighted screenshot is always JPEG-encodable, and hardens `ScreenshotManager` so a future empty/exceptional highlight result keeps the un-highlighted screenshot instead of discarding it.

## 🔗 Related Issue(s)

- Closes #2928

## 🗂️ Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Test coverage improvement

## ✅ Pre-Submission Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md) and this PR follows its guidelines.
- [x] Behavior changes have focused automated coverage. (`ImageProcessingActionsUnitTest.highlightElementInScreenshotShouldHandleAlphaBearingScreenshot`, `ScreenshotManagerCoverageUnitTest.aiHighlightFailureShouldFallBackToUnhighlightedScreenshot`)
- [ ] Affected tests pass: `mvn -pl shaft-engine -am test -Dtest=<AffectedTestClass>`. — *Not run in my local environment; left for CI. The change was instead validated end-to-end on a real Android emulator (see Evidence).*
- [ ] Code/build changes compile once with `mvn clean install -DskipTests -Dgpg.skip`. — *Same as above; the two modified classes were compiled and exercised on a real Android CI run.*
- [x] New `public` methods and classes have JavaDoc comments. — *N/A: no new public API; changes are inside existing methods.*
- [x] I have not introduced any hardcoded credentials, secrets, or sensitive data.
- [x] I have not broken backward compatibility.

## 🧪 How to Test

1. Run an **Android native** test with `screenshotParams_highlightElements=true` (default) and an `assert`/`verify` against a located element.
2. Open the Allure report — each validation step now has a highlighted screenshot attached (previously missing).
3. Unit coverage: `mvn -pl shaft-engine -am test -Dtest=ScreenshotManagerCoverageUnitTest` and `mvn -pl shaft-visual -am test -Dtest=ImageProcessingActionsUnitTest`.

## Evidence

**Root cause, reproduced in isolation** (plain `ImageIO`, no SHAFT):

```
ARGB(alpha)   -> ImageIO.write(jpg) returned false, bytes=0
RGB(no alpha) -> ImageIO.write(jpg) returned true,  bytes=663
```

**End-to-end on a real Android emulator (UIAutomator2), highlight ON:**
- Before: 1 screenshot attachment in the Allure results (app-launch only); 6 validations with 0 screenshots.
- After: 7 screenshot attachments; all 6 validations attach a highlighted screenshot (green box around the asserted element). Confirmed by inspecting the captured PNGs.

## Documentation Site

- Documentation not required because: this is an internal rendering/encoding bug fix with no change to public API, properties, or user-facing behavior other than restoring screenshots that were always intended to be captured.

## 📝 Additional Notes

The fix is intentionally minimal and surgical:
- `ImageProcessingActions.highlightElementInScreenshot` — if the decoded image has an alpha channel, draw onto an opaque `TYPE_INT_RGB` copy before highlighting/encoding. (Only alpha-bearing images are affected; web screenshots are unchanged.)
- `ScreenshotManager.takeAIHighlightedScreenshot` — separate capture from highlight; treat the highlight step as best-effort and keep the un-highlighted screenshot if it throws **or returns empty/null**, so a screenshot is never silently lost again.
