### PR TITLE
[codex] Lean assertion Allure reporting

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -989,6 +989,14 @@ public class Actions extends ElementActions {
         if (!status.equals(Status.PASSED))
             stepName.append(" is ").append(status.name().toLowerCase());
 
+        if (elementActionsHelper.isSilent()) {
+            ReportManager.logDiscrete(stepName.toString(), Status.PASSED.equals(status) ? Level.DEBUG : Level.ERROR);
+            if (exception != null) {
+                throw new RuntimeException(createFailureMessageWithCausedBy(exception), exception);
+            }
+            return;
+        }
+
         Allure.getLifecycle().updateStep(update -> update.setName(stepName.toString()));
 
         // handle secure typing

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java
@@ -54,6 +54,10 @@ public class ElementActionsHelper {
         this.isSilent = isSilent;
     }
 
+    boolean isSilent() {
+        return isSilent;
+    }
+
     /**
      * Safely calls {@code driver.findElements(locator)}, handling the infinite recursion
      * between Selenium 4.41.0's {@code ElementLocation} and Appium java-client 10.0.0's

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsBuilder.java
@@ -1,6 +1,5 @@
 package com.shaft.validation.internal;
 
-import com.shaft.tools.internal.support.JavaHelper;
 import com.shaft.validation.ValidationEnums;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
@@ -45,7 +44,7 @@ public class ValidationsBuilder {
     }
 
     public WebDriverElementValidationsBuilder element(WebDriver driver, By locator) {
-        reportMessageBuilder.append("the element located by \"").append(JavaHelper.formatLocatorToString(locator)).append("\" ");
+        reportMessageBuilder.append("the element ");
         return new WebDriverElementValidationsBuilder(validationCategory, driver, locator, reportMessageBuilder);
     }
 

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper2.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper2.java
@@ -189,7 +189,7 @@ public class ValidationsHelper2 {
 
         try {
             new SynchronizationManager(driver).fluentWait(false).until(f -> {
-                actual.set(new Actions(driver, true).get().domProperty(locator, domProperty));
+                actual.set(new SilentElementReader(driver).readDomProperty(locator, domProperty));
                 validationState.set(performValidation(expected, actual.get(), comparisonType, validationType));
                 return validationState.get();
             });
@@ -213,11 +213,12 @@ public class ValidationsHelper2 {
 
         try {
             new SynchronizationManager(driver).fluentWait(false).until(f -> {
+                SilentElementReader elementReader = new SilentElementReader(driver);
                 actual.set(switch (attribute.toLowerCase()) {
-                    case "text" -> new Actions(driver, true).get().text(locator);
-                    case "texttrimmed", "trimmedtext" -> new Actions(driver, true).get().text(locator).trim();
-                    case "selectedtext" -> new Actions(driver, true).get().selectedText(locator);
-                    default -> new Actions(driver, true).get().attribute(locator, attribute);
+                    case "text" -> elementReader.readText(locator);
+                    case "texttrimmed", "trimmedtext" -> elementReader.readText(locator).trim();
+                    case "selectedtext" -> elementReader.readSelectedText(locator);
+                    default -> elementReader.readAttribute(locator, attribute);
                 });
                 validationState.set(performValidation(expected, actual.get(), comparisonType, validationType));
                 return validationState.get();
@@ -244,15 +245,16 @@ public class ValidationsHelper2 {
 
         try {
             new SynchronizationManager(driver).fluentWait(false).until(f -> {
+                SilentElementReader elementReader = new SilentElementReader(driver);
                 actual.set(switch (attribute.toLowerCase()) {
-                    case "text" -> new Actions(driver, true).get().text(locator);
-                    case "texttrimmed", "trimmedtext" -> new Actions(driver, true).get().text(locator).trim();
-                    case "selectedtext" -> new Actions(driver, true).get().selectedText(locator);
+                    case "text" -> elementReader.readText(locator);
+                    case "texttrimmed", "trimmedtext" -> elementReader.readText(locator).trim();
+                    case "selectedtext" -> elementReader.readSelectedText(locator);
                     case "textdirection" -> getElementTextDirection(driver, locator);
                     case "textalignment" -> getElementTextAlignmentDirection(driver, locator);
                     case "textorientation" -> getElementTextOrientationDirection(driver, locator);
                     case "textdisplaystyle" -> getElementTextDisplayStyleDirection(driver, locator);
-                    default -> new Actions(driver, true).get().domAttribute(locator, attribute);
+                    default -> elementReader.readDomAttribute(locator, attribute);
                 });
                 validationState.set(performValidation(expected, actual.get(), comparisonType, validationType));
                 return validationState.get();
@@ -279,7 +281,7 @@ public class ValidationsHelper2 {
 
         try {
             new SynchronizationManager(driver).fluentWait(false).until(f -> {
-                actual.set(new Actions(driver, true).get().cssValue(locator, property));
+                actual.set(new SilentElementReader(driver).readCssValue(locator, property));
                 validationState.set(performValidation(expected, actual.get(), comparisonType, validationType));
                 return validationState.get();
             });
@@ -521,6 +523,36 @@ public class ValidationsHelper2 {
         commonParams.put("Comparison type", JavaHelper.convertToSentenceCase(comparisonType));
         commonParams.put("Actual value", String.valueOf(actual));
         return commonParams;
+    }
+
+    private static class SilentElementReader extends Actions {
+        SilentElementReader(WebDriver driver) {
+            super(driver, true);
+        }
+
+        String readAttribute(By locator, String attributeName) {
+            return performAction(ActionType.GET_ATTRIBUTE, locator, attributeName);
+        }
+
+        String readDomAttribute(By locator, String attributeName) {
+            return performAction(ActionType.GET_DOM_ATTRIBUTE, locator, attributeName);
+        }
+
+        String readDomProperty(By locator, String propertyName) {
+            return performAction(ActionType.GET_DOM_PROPERTY, locator, propertyName);
+        }
+
+        String readText(By locator) {
+            return performAction(ActionType.GET_TEXT, locator, null);
+        }
+
+        String readSelectedText(By locator) {
+            return performAction(ActionType.GET_SELECTED_TEXT, locator, null);
+        }
+
+        String readCssValue(By locator, String propertyName) {
+            return performAction(ActionType.GET_CSS_VALUE, locator, propertyName);
+        }
     }
 
     // this method will accept a hashmap of String parameter names and values to be added to the current step in allure

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
@@ -9,8 +9,12 @@ import com.shaft.gui.internal.image.ScreenshotHelper;
 import com.shaft.gui.internal.locator.LocatorBuilder;
 import com.shaft.gui.internal.locator.ShadowLocatorBuilder;
 import com.shaft.properties.internal.Properties;
+import com.shaft.tools.io.ReportManager;
 import io.appium.java_client.AppiumDriver;
+import io.qameta.allure.Allure;
+import io.qameta.allure.model.Status;
 import io.qameta.allure.model.StatusDetails;
+import org.apache.logging.log4j.Level;
 import org.openqa.selenium.By;
 import org.openqa.selenium.InvalidElementStateException;
 import org.openqa.selenium.JavascriptExecutor;
@@ -26,6 +30,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Sequence;
 import org.openqa.selenium.remote.RemoteWebElement;
 import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -109,6 +114,23 @@ public class ActionsCoverageUnitTest {
             Assert.assertSame(actions.dragAndDropByOffset(LOCATOR, 5, 7), actions);
             assertRecorded(actions, Actions.ActionType.DRAG_AND_DROP_BY_OFFSET, LOCATOR, new ArrayList<>(List.of(5, 7)));
             Assert.assertSame(actions.and(), actions);
+        }
+    }
+
+    @Test
+    public void silentPassedActionShouldOnlyWriteDebugDiscreteLog() throws Exception {
+        WebDriver driver = mock(WebDriver.class);
+
+        try (MockedStatic<JavaScriptWaitManager> javaScriptWaitManager = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class);
+             MockedStatic<ReportManager> reportManager = org.mockito.Mockito.mockStatic(ReportManager.class);
+             MockedStatic<Allure> allure = org.mockito.Mockito.mockStatic(Allure.class)) {
+            Actions actions = new Actions(driver, true);
+
+            invoke(actions, "report", new Class[]{String.class, String.class, Status.class, byte[].class, RuntimeException.class},
+                    "GET_TEXT", "By.id: target", Status.PASSED, null, null);
+
+            reportManager.verify(() -> ReportManager.logDiscrete("Get text \"By.id: target\"", Level.DEBUG));
+            allure.verifyNoInteractions();
         }
     }
 

--- a/shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelper2CoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelper2CoverageUnitTest.java
@@ -1,11 +1,12 @@
 package com.shaft.validation.internal;
 
+import com.shaft.driver.SHAFT;
 import com.shaft.gui.browser.BrowserActions;
 import com.shaft.gui.browser.internal.BrowserActionsHelper;
-import com.shaft.gui.element.ElementActions;
-import com.shaft.gui.element.internal.Actions;
+import com.shaft.gui.browser.internal.JavaScriptWaitManager;
 import com.shaft.gui.internal.image.ImageProcessingActions;
 import com.shaft.gui.internal.image.ScreenshotManager;
+import com.shaft.properties.internal.Properties;
 import com.shaft.validation.ValidationEnums;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
@@ -31,6 +32,7 @@ public class ValidationsHelper2CoverageUnitTest {
     @AfterMethod(alwaysRun = true)
     public void resetState() {
         ValidationsHelper.resetVerificationStateAfterFailing();
+        Properties.clearForCurrentThread();
     }
 
     @Test(description = "Covers hard-assert equality and number validation pass paths")
@@ -51,12 +53,29 @@ public class ValidationsHelper2CoverageUnitTest {
 
         WebDriver driver = mock(WebDriver.class, Mockito.withSettings().extraInterfaces(JavascriptExecutor.class));
         WebElement element = mock(WebElement.class);
+        WebElement option = mock(WebElement.class);
+        SHAFT.Properties.reporting.set().captureElementName(false);
+        SHAFT.Properties.flags.set().forceCheckElementLocatorIsUnique(false);
+        SHAFT.Properties.flags.set().scrollingMode("legacy");
+        SHAFT.Properties.visuals.set().createAnimatedGif(false);
+        SHAFT.Properties.visuals.set().screenshotParamsWhenToTakeAScreenshot("ValidationPointsOnly");
         when(driver.findElement(any(By.class))).thenReturn(element);
+        when(driver.findElements(any(By.class))).thenReturn(List.of(element));
         when(element.getScreenshotAs(any())).thenReturn(new byte[]{2});
+        when(element.getText()).thenReturn("  element text  ");
+        when(element.getAttribute("aria-label")).thenReturn("attrValue");
+        when(element.getDomAttribute("data-id")).thenReturn("domAttrValue");
+        when(element.getDomProperty("value")).thenReturn("domPropValue");
+        when(element.getCssValue("color")).thenReturn("cssValue");
+        when(element.getTagName()).thenReturn("select");
+        when(element.findElements(any(By.class))).thenReturn(List.of(option));
+        when(option.isSelected()).thenReturn(true);
+        when(option.getText()).thenReturn("selected");
         when(((JavascriptExecutor) driver).executeScript(anyString(), any())).thenReturn("rtl");
         when(((JavascriptExecutor) driver).executeScript(anyString())).thenReturn("rtl");
 
-        try (MockedStatic<ImageProcessingActions> imageProcessingMocked = Mockito.mockStatic(ImageProcessingActions.class);
+        try (MockedStatic<JavaScriptWaitManager> javaScriptWaitManagerMocked = Mockito.mockStatic(JavaScriptWaitManager.class);
+             MockedStatic<ImageProcessingActions> imageProcessingMocked = Mockito.mockStatic(ImageProcessingActions.class);
              MockedConstruction<ScreenshotManager> screenshotManagerMocked = Mockito.mockConstruction(ScreenshotManager.class,
                 (mock, context) -> when(mock.takeScreenshot(any(), any(), anyString(), any(Boolean.class)))
                         .thenReturn(List.of("Validation", "Screenshot", "bytes")));
@@ -68,22 +87,9 @@ public class ValidationsHelper2CoverageUnitTest {
                          when(mock.getPageSource()).thenReturn("<html/>");
                          when(mock.getCurrentWindowTitle()).thenReturn("Title");
                          when(mock.getWindowHandle()).thenReturn("WINDOW_HANDLE");
-                         when(mock.getWindowPosition()).thenReturn("0,0");
-                         when(mock.getWindowSize()).thenReturn("1200x800");
-                     });
-             MockedConstruction<Actions> actionsMocked = Mockito.mockConstruction(Actions.class,
-                     (mock, context) -> {
-                         Actions.GetElementInformation getInfo = mock(Actions.GetElementInformation.class);
-                         when(getInfo.text(any(By.class))).thenReturn("  element text  ");
-                         when(getInfo.selectedText(any(By.class))).thenReturn("selected");
-                         when(getInfo.attribute(any(By.class), anyString())).thenReturn("attrValue");
-                         when(getInfo.domAttribute(any(By.class), anyString())).thenReturn("domAttrValue");
-                         when(getInfo.domProperty(any(By.class), anyString())).thenReturn("domPropValue");
-                         when(getInfo.cssValue(any(By.class), anyString())).thenReturn("cssValue");
-                         when(mock.get()).thenReturn(getInfo);
-                     });
-             MockedConstruction<ElementActions> elementActionsMocked = Mockito.mockConstruction(ElementActions.class,
-                     (mock, context) -> when(mock.getElementsCount(any(By.class))).thenReturn(1))) {
+                          when(mock.getWindowPosition()).thenReturn("0,0");
+                          when(mock.getWindowSize()).thenReturn("1200x800");
+                      })) {
             imageProcessingMocked.when(() -> ImageProcessingActions.getReferenceImage(any(By.class)))
                     .thenReturn(new byte[]{1});
             imageProcessingMocked.when(() -> ImageProcessingActions.compareAgainstBaseline(any(), any(By.class), any(byte[].class), any()))
@@ -144,6 +150,16 @@ public class ValidationsHelper2CoverageUnitTest {
             helper.validateElementMatches(driver, locator, ValidationEnums.VisualValidationEngine.EXACT_OPENCV,
                     ValidationEnums.ValidationType.POSITIVE);
         }
+    }
+
+    @Test(description = "Generated element assertion messages should not repeat locator text")
+    public void generatedElementAssertionMessageShouldLeaveLocatorForParametersOnly() {
+        ValidationsBuilder builder = new ValidationsBuilder(ValidationEnums.ValidationCategory.HARD_ASSERT);
+        WebDriverElementValidationsBuilder elementBuilder = builder.element(mock(WebDriver.class), By.id("message"));
+
+        Assert.assertEquals(elementBuilder.reportMessageBuilder.toString(), "the element ");
+        Assert.assertEquals(elementBuilder.locator, By.id("message"));
+        Assert.assertFalse(elementBuilder.reportMessageBuilder.toString().contains("By.id: message"));
     }
 
     @Test(description = "Covers private utility methods used by validation reporting")


### PR DESCRIPTION
## Summary
- Remove the element locator from generated element assertion step text while keeping the existing `Locator` Allure parameter.
- Route assertion-time element reads through a non-annotated silent reader so `Get text` and related reads no longer appear as duplicate child Allure steps.
- Honor silent element action reporting by writing successful silent reads at DEBUG level only.
- Add focused coverage for generated assertion text and silent action reporting.

## Impact
Assertion reports are cleaner: the assertion step describes the check, the locator appears once as a parameter, and internal element reads remain available in debug logs.

## Docs
- Docs PR: https://github.com/ShaftHQ/shafthq.github.io/pull/543

## Validation
- `mvn -pl shaft-engine '-DskipTests' test-compile`
- `git diff --check`
- `git diff --cached --check`

## Notes
- Graphify refresh intentionally skipped for this PR per maintainer instruction.
- Surefire/TestNG tests were not run in this live worktree because of the recorded SHAFT gotcha where forked TestNG validation can delete module files.
