### PR TITLE
[codex] Improve performance cleanup paths

### DIFF
--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -516,7 +516,6 @@
   "514": "Community 514",
   "515": "Community 515",
   "516": "Community 516",
-  "517": "Community 517",
   "518": "Community 518",
   "519": "Community 519",
   "520": "Community 520",
@@ -543,7 +542,6 @@
   "541": "Community 541",
   "542": "Community 542",
   "543": "Community 543",
-  "544": "Community 544",
   "545": "Community 545",
   "546": "Community 546",
   "547": "Community 547",
@@ -677,7 +675,5 @@
   "675": "Community 675",
   "676": "Community 676",
   "677": "Community 677",
-  "678": "Community 678",
-  "679": "Community 679",
-  "680": "Community 680"
+  "678": "Community 678"
 }

--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -669,5 +669,17 @@
   "667": "Community 667",
   "668": "Community 668",
   "669": "Community 669",
-  "670": "Community 670"
+  "670": "Community 670",
+  "671": "Community 671",
+  "672": "Community 672",
+  "673": "Community 673",
+  "674": "Community 674",
+  "675": "Community 675",
+  "676": "Community 676",
+  "677": "Community 677",
+  "678": "Community 678",
+  "679": "Community 679",
+  "680": "Community 680",
+  "681": "Community 681",
+  "682": "Community 682"
 }

--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -679,7 +679,5 @@
   "677": "Community 677",
   "678": "Community 678",
   "679": "Community 679",
-  "680": "Community 680",
-  "681": "Community 681",
-  "682": "Community 682"
+  "680": "Community 680"
 }

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - SHAFT_ENGINE_perf_cleanups  (2026-06-18)
 
 ## Corpus Check
-- 882 files · ~501,474 words
+- 882 files · ~501,514 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 12008 nodes · 30394 edges · 681 communities (600 shown, 81 thin omitted)
-- Extraction: 80% EXTRACTED · 20% INFERRED · 0% AMBIGUOUS · INFERRED: 6032 edges (avg confidence: 0.8)
+- 12009 nodes · 30398 edges · 677 communities (593 shown, 84 thin omitted)
+- Extraction: 80% EXTRACTED · 20% INFERRED · 0% AMBIGUOUS · INFERRED: 6034 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `f12a1d16`
+- Built from commit: `c0a1ca17`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -449,7 +449,6 @@
 - [[_COMMUNITY_Community 431|Community 431]]
 - [[_COMMUNITY_Community 432|Community 432]]
 - [[_COMMUNITY_Community 433|Community 433]]
-- [[_COMMUNITY_Community 434|Community 434]]
 - [[_COMMUNITY_Community 435|Community 435]]
 - [[_COMMUNITY_Community 436|Community 436]]
 - [[_COMMUNITY_Community 437|Community 437]]
@@ -532,7 +531,6 @@
 - [[_COMMUNITY_Community 514|Community 514]]
 - [[_COMMUNITY_Community 515|Community 515]]
 - [[_COMMUNITY_Community 516|Community 516]]
-- [[_COMMUNITY_Community 517|Community 517]]
 - [[_COMMUNITY_Community 518|Community 518]]
 - [[_COMMUNITY_Community 519|Community 519]]
 - [[_COMMUNITY_Community 520|Community 520]]
@@ -558,7 +556,6 @@
 - [[_COMMUNITY_Community 541|Community 541]]
 - [[_COMMUNITY_Community 542|Community 542]]
 - [[_COMMUNITY_Community 543|Community 543]]
-- [[_COMMUNITY_Community 544|Community 544]]
 - [[_COMMUNITY_Community 545|Community 545]]
 - [[_COMMUNITY_Community 546|Community 546]]
 - [[_COMMUNITY_Community 547|Community 547]]
@@ -598,8 +595,6 @@
 - [[_COMMUNITY_Community 676|Community 676]]
 - [[_COMMUNITY_Community 677|Community 677]]
 - [[_COMMUNITY_Community 678|Community 678]]
-- [[_COMMUNITY_Community 679|Community 679]]
-- [[_COMMUNITY_Community 680|Community 680]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `SHAFT` - 271 edges
@@ -608,9 +603,9 @@
 4. `IOException` - 97 edges
 5. `ReportManagerHelper` - 75 edges
 6. `CaptureGenerator` - 66 edges
-7. `Actions` - 57 edges
-8. `JavaHelperUnitTest` - 57 edges
-9. `Test` - 57 edges
+7. `JavaHelperUnitTest` - 58 edges
+8. `Test` - 58 edges
+9. `Actions` - 57 edges
 10. `AllureManager` - 53 edges
 
 ## Surprising Connections (you probably didn't know these)
@@ -628,39 +623,39 @@
 ## Import Cycles
 - None detected.
 
-## Communities (681 total, 81 thin omitted)
+## Communities (677 total, 84 thin omitted)
 
 ### Community 0 - "Community 0"
 Cohesion: 0.04
-Nodes (6): RestActionsComprehensiveTests, ComparisonType, InputStream, SuppressWarnings, BeforeMethod, Test
+Nodes (4): RestActionsComprehensiveTests, ComparisonType, BeforeMethod, Test
 
 ### Community 1 - "Community 1"
-Cohesion: 0.08
-Nodes (4): AfterMethod, SuppressWarnings, Test, TerminalActionsUnitTest
+Cohesion: 0.09
+Nodes (3): AfterMethod, Test, TerminalActionsUnitTest
 
 ### Community 2 - "Community 2"
 Cohesion: 0.12
 Nodes (23): DeterministicRuleEngine, DoctorAnalyzer, DoctorAnalyzerTest, DoctorAiAnalysisResult, DoctorReportWriter, EvidenceCollector, DoctorAiAnalysisRequest, DoctorAiAnalysisService (+15 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.06
-Nodes (25): Cucumber, CucumberHelper, Mobile, SetProperty, PropertiesManagerTests, CucumberTests, List, Status (+17 more)
+Cohesion: 0.07
+Nodes (24): Cucumber, CucumberHelper, Mobile, SetProperty, PropertiesManagerTests, CucumberTests, List, Status (+16 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.07
 Nodes (6): Pilot, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 5 - "Community 5"
-Cohesion: 0.11
-Nodes (12): FileUploadDownloadTest, File, Test, AfterMethod, BeforeMethod, RemoteWebDriver, Runnable, Test (+4 more)
+Cohesion: 0.16
+Nodes (8): ElementActionsHelper, AfterMethod, BeforeMethod, RemoteWebDriver, Runnable, Test, TouchActions, AndroidTouchActionsCoverageUnitTest
 
 ### Community 6 - "Community 6"
 Cohesion: 0.06
 Nodes (14): CSVFileManager, CSVFileManagerTest, List, Map, String, BeforeMethod, Test, AfterMethod (+6 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.07
-Nodes (38): AlertEvent, ArtifactPaths, AssertionSuggestion, CaptureGenerationReport, DataPlan, CaptureGenerator, failure(), withUnsupported() (+30 more)
+Cohesion: 0.08
+Nodes (29): AlertEvent, AssertionSuggestion, DataPlan, CaptureGenerator, MutableTargetPlan, withUnsupported(), Sequence, CaptureEvent (+21 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.05
@@ -671,20 +666,20 @@ Cohesion: 0.27
 Nodes (4): Jira, DefaultValue, Key, SetProperty
 
 ### Community 10 - "Community 10"
-Cohesion: 0.07
-Nodes (23): BrowserStackSdkHelper, BrowserStackSdkTests, List, Map, Object, String, AfterMethod, BeforeMethod (+15 more)
+Cohesion: 0.05
+Nodes (29): BrowserStackSdkHelper, FileReader, JSONFileManagerTestAccessor, BrowserStackSdkTests, List, Map, Object, String (+21 more)
 
 ### Community 11 - "Community 11"
 Cohesion: 0.09
-Nodes (13): AsyncAppender, ReportManagerHelper, TestCaseStarted, CheckpointStatus, InputStream, Level, List, Object (+5 more)
+Nodes (8): AsyncAppender, ReportManagerHelper, TestCaseStarted, Boolean, Level, Path, Status, String
 
 ### Community 12 - "Community 12"
 Cohesion: 0.09
 Nodes (23): KeyboardKeys, LocatorOperation, MobileService, McpMobileAccessibilityTree, McpMobileActionResult, McpMobileContextSnapshot, McpMobileSessionResult, BrowserType (+15 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.07
-Nodes (11): BrowserStack, SetProperty, DefaultValue, Key, SetProperty, String, AfterMethod, Object (+3 more)
+Cohesion: 0.22
+Nodes (5): BrowserStack, DefaultValue, Key, SetProperty, String
 
 ### Community 14 - "Community 14"
 Cohesion: 0.07
@@ -703,48 +698,48 @@ Cohesion: 0.14
 Nodes (13): WebDriverListener, Navigation, Alert, By, Method, Object, String, URL (+5 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.09
-Nodes (11): AfterSuite, ApiPerformanceReportTest, SwaggerContractTest, ContentType, AfterMethod, BeforeMethod, Test, AfterClass (+3 more)
+Cohesion: 0.13
+Nodes (5): AfterSuite, ApiPerformanceReportTest, AfterMethod, BeforeMethod, Test
 
 ### Community 19 - "Community 19"
 Cohesion: 0.08
-Nodes (19): RequestBuilder, RequestBuilderTests, AuthenticationType, API, Exception, Object, RequestSpecification, RequestType (+11 more)
+Nodes (24): RequestBuilder, RequestBuilderTests, AuthenticationType, RestAssuredConfig, API, ContentType, Exception, Map (+16 more)
 
 ### Community 20 - "Community 20"
-Cohesion: 0.15
-Nodes (16): dataString(), E, LocatorSignal, empty(), merge(), MouseButton, CaptureEventPipeline, SafePage (+8 more)
+Cohesion: 0.09
+Nodes (29): dataString(), E, LocatorSignal, empty(), merge(), MouseButton, CaptureEventPipeline, SafePage (+21 more)
 
 ### Community 21 - "Community 21"
-Cohesion: 0.09
-Nodes (13): WebDriverElementValidationsBuilder, GuiVerificationTests, By, NativeValidationsBuilder, String, StringBuilder, ValidationCategory, ValidationsExecutor (+5 more)
+Cohesion: 0.05
+Nodes (17): WebDriverElementValidationsBuilder, GuiVerificationTests, By, NativeValidationsBuilder, String, StringBuilder, ValidationCategory, ValidationsExecutor (+9 more)
 
 ### Community 22 - "Community 22"
-Cohesion: 0.08
-Nodes (7): Object, Override, SuppressWarnings, ValidationsExecutor, AfterMethod, Test, NativeValidationsBuilderUnitTest
+Cohesion: 0.10
+Nodes (3): AfterMethod, Test, NativeValidationsBuilderUnitTest
 
 ### Community 23 - "Community 23"
 Cohesion: 0.08
-Nodes (25): empty(), disabled(), Metadata, asCacheHit(), disabled(), empty(), defaults(), lower() (+17 more)
+Nodes (28): empty(), LocatorRankerTest, disabled(), Metadata, asCacheHit(), disabled(), empty(), defaults() (+20 more)
 
 ### Community 24 - "Community 24"
-Cohesion: 0.05
-Nodes (17): NativeValidationsBuilder, TextDirectionValidationsBuilder, E2ECoverageTests, FileValidationsBuilder, RestValidationsBuilder, String, ValidationsBuilder, WebDriverBrowserValidationsBuilder (+9 more)
+Cohesion: 0.08
+Nodes (5): E2ECoverageTests, AfterMethod, BeforeMethod, Test, TextLanguageValidationsBuilder
 
 ### Community 25 - "Community 25"
 Cohesion: 0.06
-Nodes (22): PathParamTest, TestUpload, BasicAPITests, GraphqlRequestTests, Map, ParametersType, AfterClass, BeforeClass (+14 more)
+Nodes (19): PathParamTest, SwaggerContractTest, TestUpload, ParametersType, AfterClass, BeforeClass, Test, AfterClass (+11 more)
 
 ### Community 26 - "Community 26"
-Cohesion: 0.05
-Nodes (50): AllureSnapshot, AllureSummary, AllureVerdict, Diagnostic, DoctorRepairPublicationRequest, ExistingPullRequest, GeneratedTestValidator, JarEntry (+42 more)
+Cohesion: 0.17
+Nodes (10): DoctorRepairPublicationRequest, ExistingPullRequest, DoctorRepairService, DoctorRepairRequest, Duration, Path, RepairProposal, RepairPublicationResult (+2 more)
 
 ### Community 27 - "Community 27"
-Cohesion: 0.14
-Nodes (12): FileActions, Boolean, Collection, File, String, SuppressWarnings, TerminalActions, URL (+4 more)
+Cohesion: 0.13
+Nodes (13): FileActions, Boolean, Collection, File, String, SuppressWarnings, TerminalActions, URL (+5 more)
 
 ### Community 28 - "Community 28"
-Cohesion: 0.07
-Nodes (15): DriverFactoryHelperCoverageUnitTest, TestableDriverFactoryHelper, OptionsManager, AfterMethod, AtomicInteger, CountDownLatch, DriverFactoryHelper, DriverType (+7 more)
+Cohesion: 0.09
+Nodes (7): DriverFactoryHelperCoverageUnitTest, DriverType, Object, Override, String, SuppressWarnings, Test
 
 ### Community 29 - "Community 29"
 Cohesion: 0.11
@@ -755,32 +750,36 @@ Cohesion: 0.08
 Nodes (6): Flags, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 31 - "Community 31"
-Cohesion: 0.09
+Cohesion: 0.10
 Nodes (11): AfterMethod, BeforeMethod, Class, List, Object, Path, String, T (+3 more)
 
+### Community 32 - "Community 32"
+Cohesion: 0.07
+Nodes (8): Boolean, By, NumbersComparativeRelation, Object, String, Test, JavaHelper, JavaHelperUnitTest
+
 ### Community 33 - "Community 33"
-Cohesion: 0.11
-Nodes (14): AccessibilityConfig, AccessibilityHelper, AccessibilityResult, JSONArray, JSONObject, AccessibilityResult, Integer, List (+6 more)
+Cohesion: 0.10
+Nodes (15): AccessibilityConfig, AccessibilityHelper, AccessibilityResult, AxeBuilder, JSONArray, JSONObject, AccessibilityResult, Integer (+7 more)
 
 ### Community 34 - "Community 34"
 Cohesion: 0.08
 Nodes (11): NumberValidationsBuilder, Number, Object, Override, RestValidationsBuilder, SuppressWarnings, ValidationsBuilder, ValidationsExecutor (+3 more)
 
 ### Community 35 - "Community 35"
-Cohesion: 0.19
-Nodes (12): PilotNaturalActionPlanner, NaturalActionKind, NaturalActionPlanner, NaturalActionStep, AiExecutionService, By, JsonNode, NaturalActionPlan (+4 more)
+Cohesion: 0.08
+Nodes (27): DeterministicNaturalActionPlanner, unsupported(), NaturalActionPlannerRegistry, PilotNaturalActionPlanner, NaturalActionKind, NaturalActionPlanner, NaturalActionStep, List (+19 more)
 
 ### Community 36 - "Community 36"
-Cohesion: 0.07
-Nodes (28): DataTableArgument, EmbedEvent, HookTestStep, CucumberFeatureListener, Parameter, PickleStepTestStep, Result, Scenario (+20 more)
+Cohesion: 0.12
+Nodes (16): DataTableArgument, EmbedEvent, HookTestStep, CucumberFeatureListener, Parameter, PickleStepTestStep, Scenario, List (+8 more)
 
 ### Community 37 - "Community 37"
 Cohesion: 0.08
-Nodes (12): EngineServiceRuntimePathTest, PostConstruct, Class, Object, Path, String, Test, Path (+4 more)
+Nodes (11): EngineServiceRuntimePathTest, Class, Object, Path, String, Test, Path, AfterEach (+3 more)
 
 ### Community 38 - "Community 38"
-Cohesion: 0.13
-Nodes (5): NumberValidationsBuilder, AfterMethod, BeforeClass, Test, RestValidationsBuilderUnitTest
+Cohesion: 0.10
+Nodes (9): RestValidationsBuilder, NativeValidationsBuilder, NumberValidationsBuilder, String, ValidationsExecutor, AfterMethod, BeforeClass, Test (+1 more)
 
 ### Community 39 - "Community 39"
 Cohesion: 0.08
@@ -792,43 +791,43 @@ Nodes (23): DoctorAiAnalysisService, ConfigurationIdentity, AiRequest, AiRespons
 
 ### Community 41 - "Community 41"
 Cohesion: 0.08
-Nodes (11): AssertApiResponseEqualsTests, ApiActionsMockedTests, RequestBuilder, Test, AfterMethod, BeforeMethod, Test, AfterClass (+3 more)
+Nodes (12): AssertApiResponseEqualsTests, ApiActionsMockedTests, RequestBuilder, RequestType, Test, AfterMethod, BeforeMethod, Test (+4 more)
 
 ### Community 42 - "Community 42"
-Cohesion: 0.06
-Nodes (21): testPostRequest, Constructor, SHAFT, FileInputStream, AppiumMobileConsumer, BrowserStackSdkConsumer, LegacyCoordinateConsumer, $ (+13 more)
+Cohesion: 0.08
+Nodes (21): testPostRequest, Constructor, SHAFT, DriverFactoryHelper, FileInputStream, HasCdp, $, InvocationTargetException (+13 more)
 
 ### Community 43 - "Community 43"
-Cohesion: 0.08
-Nodes (24): IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, IResultListener2, ISuiteListener (+16 more)
+Cohesion: 0.09
+Nodes (21): IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, IResultListener2, ISuiteListener (+13 more)
 
 ### Community 44 - "Community 44"
-Cohesion: 0.16
-Nodes (8): AssertionSteps, PDFTests, ValidationsBuilderTests, String, Then, ThreadLocal, WebDriver, String
+Cohesion: 0.21
+Nodes (5): AssertionSteps, PDFTests, String, Then, String
 
 ### Community 45 - "Community 45"
-Cohesion: 0.16
-Nodes (15): CollectionState, EvidenceCollector, FilesSize, CollectionState, DoctorRedactor, DefaultPrettyPrinter, DoctorAnalysisRequest, EvidenceCategory (+7 more)
+Cohesion: 0.17
+Nodes (15): CollectionState, EvidenceCollector, CollectionState, DoctorRedactor, DefaultPrettyPrinter, DoctorAnalysisRequest, EvidenceBundle, EvidenceCategory (+7 more)
 
 ### Community 46 - "Community 46"
 Cohesion: 0.09
 Nodes (19): CaptureFixtures, CaptureJsonCodecTest, CaptureGeneratorTest, PageContext, BrowserMetadata, CaptureEvent, CaptureSession, ElementSnapshot (+11 more)
 
 ### Community 47 - "Community 47"
-Cohesion: 0.11
-Nodes (14): ChromeOptions, WebDomHealingAcceptanceTest, MoonTests, AfterEach, BeforeEach, String, Test, WebDriver (+6 more)
+Cohesion: 0.22
+Nodes (8): ChromeOptions, MoonTests, AfterEach, BeforeEach, String, Test, WebDriver, TestInfo
 
 ### Community 48 - "Community 48"
-Cohesion: 0.13
-Nodes (16): RestActions, RequestSpecBuilder, RestAssuredConfig, API, ArrayNode, Boolean, ContentType, List (+8 more)
+Cohesion: 0.11
+Nodes (15): RestActions, GraphqlRequestTests, RequestSpecBuilder, API, ArrayNode, Boolean, InputStream, List (+7 more)
 
 ### Community 49 - "Community 49"
-Cohesion: 0.07
-Nodes (21): ImageProcessingActions, ImageProcessingActionsCoverageUnitTest, Boolean, By, File, Integer, List, String (+13 more)
+Cohesion: 0.11
+Nodes (13): ImageProcessingActionsCoverageUnitTest, List, AfterMethod, BeforeMethod, BufferedImage, Color, DataProvider, Map (+5 more)
 
 ### Community 50 - "Community 50"
-Cohesion: 0.15
-Nodes (3): AllureManager, Path, Process
+Cohesion: 0.14
+Nodes (4): AllureManager, Path, Process, String
 
 ### Community 51 - "Community 51"
 Cohesion: 0.08
@@ -840,19 +839,19 @@ Nodes (47): additionalProperties, minLength, type, maximum, minimum, type, type,
 
 ### Community 53 - "Community 53"
 Cohesion: 0.05
-Nodes (44): AttachmentFormat, Date, DoctorRepairPatchResult, CaptureJsonCodec, DoctorJsonCodec, InputStream, AttachmentReporter, DoctorRepairAiService (+36 more)
+Nodes (40): AttachmentFormat, AttachmentReporter, getType(), LauncherSession, LauncherSessionListener, JunitListener, Screenshots, Override (+32 more)
 
 ### Community 54 - "Community 54"
-Cohesion: 0.10
-Nodes (6): BrowserActions, Override, Screenshots, String, SuppressWarnings, WebDriverBrowserValidationsBuilder
+Cohesion: 0.11
+Nodes (7): BrowserActions, Cookie, Override, Screenshots, Set, String, SuppressWarnings
 
 ### Community 55 - "Community 55"
-Cohesion: 0.13
-Nodes (14): Capabilities, DriverFactoryHelper, Class, DriverType, List, MutableCapabilities, Object, Runnable (+6 more)
+Cohesion: 0.14
+Nodes (13): Capabilities, DriverFactoryHelper, Class, DriverType, List, MutableCapabilities, Object, Runnable (+5 more)
 
 ### Community 56 - "Community 56"
-Cohesion: 0.15
-Nodes (7): ElementLookup, GetElementInformation, Actions, NoSuchElementException, JavascriptExecutor, List, WebElement
+Cohesion: 0.17
+Nodes (16): RecordingRunner, DoctorRepairServiceTest, RecordingRunner, validationPassed(), RepairProcessRunner, RepositoryFixture, DoctorRepairRequest, Duration (+8 more)
 
 ### Community 57 - "Community 57"
 Cohesion: 0.08
@@ -864,34 +863,34 @@ Nodes (34): AllureFailure, _clean_cell(), extract_failures(), extract_surefire_f
 
 ### Community 59 - "Community 59"
 Cohesion: 0.11
-Nodes (13): List, Color, Rectangle, AfterMethod, BeforeMethod, Color, Map, Method (+5 more)
+Nodes (12): Color, Rectangle, AfterMethod, BeforeMethod, Color, Map, Method, Path (+4 more)
 
 ### Community 60 - "Community 60"
-Cohesion: 0.15
-Nodes (3): SetProperty, Deprecated, String
+Cohesion: 0.09
+Nodes (8): SetProperty, Timeouts, Boolean, DefaultValue, Deprecated, Key, SetProperty, String
 
 ### Community 61 - "Community 61"
 Cohesion: 0.12
-Nodes (22): AiBudget, ExchangeHandler, FailureCase, ExchangeHandler, ProviderConformanceTest, AfterEach, AiProvider, AiRequest (+14 more)
+Nodes (21): ExchangeHandler, FailureCase, ExchangeHandler, ProviderConformanceTest, AfterEach, AiProvider, AiRequest, AiResponse (+13 more)
 
 ### Community 62 - "Community 62"
 Cohesion: 0.10
 Nodes (23): DoctorRepairProposalResult, DoctorRepairService, HealingLocatorProposalRequest, DoctorService, DoctorServiceTest, McpDoctorRemediationService, ApprovalPolicy, Diagnosis (+15 more)
 
 ### Community 63 - "Community 63"
-Cohesion: 0.21
-Nodes (6): GetElementInformation, ActionType, Beta, By, Override, Step
+Cohesion: 0.07
+Nodes (25): ElementLookup, GetElementInformation, Actions, ClipboardAction, GetElementInformation, ActionType, AppiumDriver, Beta (+17 more)
 
 ### Community 64 - "Community 64"
-Cohesion: 0.09
-Nodes (18): UnitTestsRestActions, ActionsCoverageUnitTest, RecordingActions, RecordingActions, ActionType, AfterMethod, BeforeMethod, By (+10 more)
+Cohesion: 0.08
+Nodes (21): UnitTestsRestActions, AsyncElementActionsCoverageUnitTest, ActionsCoverageUnitTest, RecordingActions, RecordingActions, Test, ActionType, AfterMethod (+13 more)
 
 ### Community 65 - "Community 65"
 Cohesion: 0.12
 Nodes (14): AllureListenerCoverageUnitTest, Throwable, AfterMethod, BeforeMethod, ITestResult, List, Path, String (+6 more)
 
 ### Community 66 - "Community 66"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (11): ContainerLifecycleListener, FixtureLifecycleListener, FixtureResult, AllureListener, AllureLifecycle, Override, TestResult, StepLifecycleListener (+3 more)
 
 ### Community 67 - "Community 67"
@@ -923,8 +922,8 @@ Cohesion: 0.11
 Nodes (41): expand_globs(), issue(), local_link_targets(), markdown_body(), normalized_paragraphs(), parse_frontmatter(), quoted_yaml_value(), Keep the consolidated guidance below the approved baseline reduction. (+33 more)
 
 ### Community 74 - "Community 74"
-Cohesion: 0.15
-Nodes (15): ElementActionsHelper, TextDetectionStrategy(), Boolean, By, Class, ClipboardAction, HealingResolution, List (+7 more)
+Cohesion: 0.17
+Nodes (15): ElementActionsHelper, TextDetectionStrategy(), NoSuchElementException, Boolean, By, Class, ClipboardAction, HealingResolution (+7 more)
 
 ### Community 75 - "Community 75"
 Cohesion: 0.15
@@ -947,19 +946,19 @@ Cohesion: 0.05
 Nodes (40): additionalProperties, enum, pattern, type, pattern, type, items, type (+32 more)
 
 ### Community 80 - "Community 80"
-Cohesion: 0.09
-Nodes (14): ChromiumOptions, DesiredCapabilities, DriverFactoryHelper, LoggingPreferences, AfterMethod, AtomicInteger, CountDownLatch, DriverType (+6 more)
+Cohesion: 0.11
+Nodes (10): AfterMethod, AtomicInteger, CountDownLatch, DriverType, Method, MutableCapabilities, Override, Test (+2 more)
 
 ### Community 81 - "Community 81"
-Cohesion: 0.10
-Nodes (11): IIOMetadataNode, AnimatedGifManager, GifSession, ImageOutputStream, ImageWriter, getType(), RenderedImage, Screenshots (+3 more)
+Cohesion: 0.11
+Nodes (10): IIOMetadataNode, AnimatedGifManager, GifSession, ImageOutputStream, ImageWriter, RenderedImage, BufferedImage, String (+2 more)
 
 ### Community 82 - "Community 82"
-Cohesion: 0.17
-Nodes (15): Actions, SilentElementReader, ValidationsHelper2, LinkedHashMap, AssertionError, By, List, Number (+7 more)
+Cohesion: 0.05
+Nodes (40): Actions, CheckpointType, ElementStepsCoverageUnitTest, CheckpointCounter, ValidationsExecutor, SilentElementReader, ValidationsHelper2, ValidationsHelper2CoverageUnitTest (+32 more)
 
 ### Community 83 - "Community 83"
-Cohesion: 0.21
+Cohesion: 0.20
 Nodes (4): LocatorBuilderTest, AfterMethod, BeforeMethod, Test
 
 ### Community 84 - "Community 84"
@@ -967,12 +966,12 @@ Cohesion: 0.05
 Nodes (39): additionalProperties, type, maximum, minimum, type, additionalProperties, properties, required (+31 more)
 
 ### Community 86 - "Community 86"
-Cohesion: 0.18
-Nodes (11): ClassifiedUpload, CapturePrivacyClassifier, SanitizedAttributes, SanitizedText, CapturePrivacyPolicy, ClassifiedValue, List, Map (+3 more)
+Cohesion: 0.14
+Nodes (14): ClassifiedUpload, CapturePrivacyClassifier, CapturePrivacyClassifierTest, SanitizedAttributes, SanitizedText, CapturePrivacyPolicy, ClassifiedValue, List (+6 more)
 
 ### Community 87 - "Community 87"
-Cohesion: 0.10
-Nodes (15): HasCdp, Image, ScreenshotHelper, ScreenshotHelperCoverageUnitTest, Boolean, BufferedImage, String, SuppressWarnings (+7 more)
+Cohesion: 0.14
+Nodes (10): Image, ScreenshotHelperCoverageUnitTest, BufferedImage, String, AfterMethod, BeforeMethod, Color, Object (+2 more)
 
 ### Community 88 - "Community 88"
 Cohesion: 0.05
@@ -983,16 +982,16 @@ Cohesion: 0.07
 Nodes (14): be(), Bt(), Dt(), $e(), Ee(), ft(), ke(), l() (+6 more)
 
 ### Community 90 - "Community 90"
-Cohesion: 0.12
-Nodes (11): ElementActions, Actions, By, DriverFactoryHelper, List, Map, Override, String (+3 more)
+Cohesion: 0.09
+Nodes (15): ElementActions, FrameTests, Actions, By, DriverFactoryHelper, List, Map, Override (+7 more)
 
 ### Community 91 - "Community 91"
 Cohesion: 0.16
 Nodes (17): CandidateExtractor, LocatorProposal, validateUrl(), SearchContext, String, By, Collection, HealingConfiguration (+9 more)
 
 ### Community 92 - "Community 92"
-Cohesion: 0.11
-Nodes (7): LocatorBuilder, RelativeBy, ArrayList, By, Role, String, SuppressWarnings
+Cohesion: 0.09
+Nodes (11): LocatorBuilder, JDK21VirtualThreadsAndAsyncActionsTests, RelativeBy, ArrayList, By, Role, String, SuppressWarnings (+3 more)
 
 ### Community 93 - "Community 93"
 Cohesion: 0.06
@@ -1007,24 +1006,24 @@ Cohesion: 0.16
 Nodes (14): AiExecutionServiceTest, StubProvider, AiCapabilities, AiExecutionService, AiProviderAvailability, AiProviderRegistry, AiRequest, AiResponse (+6 more)
 
 ### Community 96 - "Community 96"
-Cohesion: 0.21
-Nodes (15): DoctorAiAnalysisServiceTest, EnumSource, AiRequest, AiResponse, AiResponseStatus, Diagnosis, DoctorAiAnalysisService, EvidenceBundle (+7 more)
+Cohesion: 0.16
+Nodes (19): DoctorAiAnalysisServiceTest, AiBudget, EnumSource, defaults(), ApprovalPolicy, DoctorRepairAiRequest, AiRequest, AiResponse (+11 more)
 
 ### Community 97 - "Community 97"
 Cohesion: 0.13
 Nodes (16): AlertActionsContext, AlertActions, DriverFactoryHelper, String, SuppressWarnings, WebDriver, AfterMethod, Alert (+8 more)
 
 ### Community 98 - "Community 98"
-Cohesion: 0.13
-Nodes (11): FluentWait, ElementsHelperCoverageUnitTest, MockedStatic, AfterMethod, BeforeMethod, DriverFactoryHelper, MockedConstruction, RuntimeException (+3 more)
+Cohesion: 0.10
+Nodes (15): SynchronizationManager, FluentWait, ElementsHelperCoverageUnitTest, Class, Exception, List, WebDriver, AfterMethod (+7 more)
 
 ### Community 99 - "Community 99"
-Cohesion: 0.05
-Nodes (19): PropertyFileManager, ThreadLocalPropertiesManager, File, HashMap, Map, MutableCapabilities, Object, Properties (+11 more)
+Cohesion: 0.12
+Nodes (6): BeforeMethod, AfterMethod, Path, String, Test, ThreadLocalPropertiesTest
 
 ### Community 100 - "Community 100"
-Cohesion: 0.18
-Nodes (10): ElementService, LocatorOperation, By, Deprecated, LocatorOperation, locatorStrategy, String, Tool (+2 more)
+Cohesion: 0.19
+Nodes (9): ElementService, LocatorOperation, By, Deprecated, LocatorOperation, locatorStrategy, String, Tool (+1 more)
 
 ### Community 101 - "Community 101"
 Cohesion: 0.13
@@ -1035,20 +1034,20 @@ Cohesion: 0.17
 Nodes (17): DeterministicRuleEngine, Confidence, Finding, Remediation, RetrySummary, RuleMatch, CauseCategory, Diagnosis (+9 more)
 
 ### Community 103 - "Community 103"
-Cohesion: 0.16
-Nodes (11): DriverFactory, DriverType(), DatabaseActions, DatabaseType, DriverFactoryHelper, DriverType, MutableCapabilities, RestActions (+3 more)
+Cohesion: 0.11
+Nodes (15): DriverFactory, DriverType(), DatabaseActions, DatabaseType, DriverFactoryHelper, DriverType, MutableCapabilities, RestActions (+7 more)
 
 ### Community 104 - "Community 104"
 Cohesion: 0.13
 Nodes (6): Healing, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 105 - "Community 105"
-Cohesion: 0.12
-Nodes (12): ChannelSftp, TerminalActions, ProcessBuilder, Session, SftpTransferDirection, Boolean, BufferedReader, Deprecated (+4 more)
+Cohesion: 0.14
+Nodes (11): ChannelSftp, TerminalActions, ProcessBuilder, Session, SftpTransferDirection, Boolean, BufferedReader, List (+3 more)
 
 ### Community 106 - "Community 106"
 Cohesion: 0.11
-Nodes (10): AfterMethod, BeforeMethod, Issue, Issues, ITestResult, String, Test, TmsLink (+2 more)
+Nodes (9): AfterMethod, BeforeMethod, Issue, Issues, ITestResult, String, Test, TmsLink (+1 more)
 
 ### Community 107 - "Community 107"
 Cohesion: 0.06
@@ -1066,17 +1065,13 @@ Nodes (12): CapturePrivacyClassifier, ManagedCaptureRecorder, BrowserMetadata, C
 Cohesion: 0.13
 Nodes (3): YAMLFileManagerTests, BeforeMethod, Test
 
-### Community 111 - "Community 111"
-Cohesion: 0.14
-Nodes (15): LauncherSession, Override, AfterMethod, BeforeMethod, Duration, List, Object, Optional (+7 more)
-
 ### Community 112 - "Community 112"
 Cohesion: 0.18
 Nodes (14): AiExecutionService, CircuitState, AiAuditSink, AiProvider, AiProviderRegistry, AiRequest, AiResponse, AiResponseStatus (+6 more)
 
 ### Community 113 - "Community 113"
-Cohesion: 0.19
-Nodes (7): Log4j, Log4jTests, DefaultValue, Key, String, BeforeClass, Test
+Cohesion: 0.26
+Nodes (4): Log4j, DefaultValue, Key, String
 
 ### Community 114 - "Community 114"
 Cohesion: 0.21
@@ -1099,20 +1094,20 @@ Cohesion: 0.07
 Nodes (31): deleteObject, deleteRelation, markStale, supersedeObject, additionalProperties, properties, required, type (+23 more)
 
 ### Community 119 - "Community 119"
-Cohesion: 0.17
-Nodes (11): AccessibilityHelperCoverageUnitTest, AxeBuilder, AfterMethod, List, MockedConstruction, Path, Results, Rule (+3 more)
+Cohesion: 0.19
+Nodes (10): AccessibilityHelperCoverageUnitTest, AfterMethod, List, MockedConstruction, Path, Results, Rule, String (+2 more)
 
 ### Community 120 - "Community 120"
-Cohesion: 0.10
-Nodes (15): IOSBasicInteractionsTest, ElementActions, Test_LTMobIPAAppURL, Test_LTMobIPARelativePath, AfterMethod, BeforeMethod, SuppressWarnings, Test (+7 more)
+Cohesion: 0.15
+Nodes (9): IOSBasicInteractionsTest, Test_LTMobIPARelativePath, AfterMethod, BeforeMethod, SuppressWarnings, Test, AfterMethod, BeforeMethod (+1 more)
 
 ### Community 121 - "Community 121"
-Cohesion: 0.08
-Nodes (20): AndroidDriver, AndroidTouchActionsTests, getValue(), KeyboardKeys(), TouchActions, ImmutableMap, ScreenOrientation, By (+12 more)
+Cohesion: 0.11
+Nodes (18): getValue(), KeyboardKeys(), TouchActions, ImmutableMap, By, DriverFactoryHelper, File, HashMap (+10 more)
 
 ### Community 122 - "Community 122"
-Cohesion: 0.17
-Nodes (9): CaptureControlFiles, ControlDescriptor, CaptureStartRequest, CaptureStatus, Class, Object, Path, String (+1 more)
+Cohesion: 0.13
+Nodes (13): CaptureControlFiles, ControlDescriptor, notRunning(), text(), CaptureStartRequest, CaptureStatus, Class, Object (+5 more)
 
 ### Community 123 - "Community 123"
 Cohesion: 0.16
@@ -1123,8 +1118,8 @@ Cohesion: 0.12
 Nodes (9): TestNGListenerHelper, ISuite, ITestContext, ITestNGMethod, ITestResult, List, Method, String (+1 more)
 
 ### Community 125 - "Community 125"
-Cohesion: 0.06
-Nodes (20): DataType, FileReader, JSONFileManager, JSONFileManagerTestAccessor, JSONFileManagerTests, List, Map, Object (+12 more)
+Cohesion: 0.08
+Nodes (14): DataType, JSONFileManager, JSONFileManagerTests, List, Map, Object, String, Test (+6 more)
 
 ### Community 126 - "Community 126"
 Cohesion: 0.17
@@ -1139,7 +1134,7 @@ Cohesion: 0.12
 Nodes (5): AfterMethod, Runnable, String, Test, ValidationHelperUnitTest
 
 ### Community 129 - "Community 129"
-Cohesion: 0.17
+Cohesion: 0.18
 Nodes (12): Bean, BrowserService, ElementService, ShaftMcpApplication, MobileService, NaturalActionService, CaptureService, DoctorService (+4 more)
 
 ### Community 130 - "Community 130"
@@ -1147,24 +1142,24 @@ Cohesion: 0.13
 Nodes (3): ActionsCoverageTests, BeforeMethod, Test
 
 ### Community 131 - "Community 131"
-Cohesion: 0.11
-Nodes (11): Browser, ShadowDomTest, CoverageTests, AfterMethod, BeforeMethod, Test, AfterClass, AfterMethod (+3 more)
+Cohesion: 0.09
+Nodes (13): Browser, BasicAuthenticationTests, ShadowDomTest, CoverageTests, Test, AfterMethod, BeforeMethod, Test (+5 more)
 
 ### Community 132 - "Community 132"
 Cohesion: 0.14
 Nodes (14): BadRequestException, CaptureControlServer, Handler, Handler, CaptureControlFiles, CaptureManager, CaptureStatus, Class (+6 more)
 
 ### Community 133 - "Community 133"
-Cohesion: 0.33
-Nodes (4): VisualProcessingProviderRegistry, List, Optional, VisualProcessingProvider
+Cohesion: 0.10
+Nodes (15): ImageProcessingActions, VisualProcessingProviderRegistry, ImageComparisonTests, Boolean, By, File, Integer, List (+7 more)
 
 ### Community 134 - "Community 134"
 Cohesion: 0.14
 Nodes (14): AlphaProvider, VisualProcessingProviderRegistryTest, ZuluProvider, AfterMethod, Boolean, By, Integer, List (+6 more)
 
 ### Community 135 - "Community 135"
-Cohesion: 0.19
-Nodes (12): ScreenshotManager, Object, Boolean, By, JavascriptExecutor, List, Object, Screenshots (+4 more)
+Cohesion: 0.21
+Nodes (11): ScreenshotManager, Boolean, By, JavascriptExecutor, List, Object, Screenshots, SneakyThrows (+3 more)
 
 ### Community 136 - "Community 136"
 Cohesion: 0.14
@@ -1175,16 +1170,16 @@ Cohesion: 0.11
 Nodes (25): build_parser(), confirm_upgrade(), coordinates_have_supported_runner(), log(), main(), OpenAIRepairClient, print_analysis(), ProjectAnalysis (+17 more)
 
 ### Community 138 - "Community 138"
-Cohesion: 0.19
-Nodes (4): AccessibilityTest, AfterMethod, BeforeMethod, Test
+Cohesion: 0.12
+Nodes (11): AccessibilityActions, AccessibilityConfig, AccessibilityTest, AccessibilityResult, BrowserActions, List, String, WebDriver (+3 more)
 
 ### Community 139 - "Community 139"
-Cohesion: 0.10
-Nodes (18): builder(), evidenceCategories(), withSanitizedContent(), withTimeout(), AiAuditSink, AiImage, ShaftAiAuditSink, AiRequest (+10 more)
+Cohesion: 0.11
+Nodes (17): builder(), evidenceCategories(), withSanitizedContent(), withTimeout(), AiAuditSink, ShaftAiAuditSink, AiRequest, ApprovalPolicy (+9 more)
 
 ### Community 140 - "Community 140"
-Cohesion: 0.17
-Nodes (6): API, JSON, List, Object, RequestBuilder, String
+Cohesion: 0.15
+Nodes (7): API, JSON, YAML, List, Object, RequestBuilder, String
 
 ### Community 141 - "Community 141"
 Cohesion: 0.09
@@ -1207,8 +1202,8 @@ Cohesion: 0.17
 Nodes (9): ElementSteps, getValue(), LocatorType(), By, String, SuppressWarnings, ThreadLocal, WebDriver (+1 more)
 
 ### Community 146 - "Community 146"
-Cohesion: 0.29
-Nodes (7): DeterministicScorerTest, Double, HealingConfiguration, LocatorFingerprint, RankedCandidate, String, Test
+Cohesion: 0.14
+Nodes (14): DecisionResult, DeterministicScorerTest, HealingDecisionEngine, HealingConfiguration, List, RankedCandidate, Status, String (+6 more)
 
 ### Community 147 - "Community 147"
 Cohesion: 0.20
@@ -1219,8 +1214,8 @@ Cohesion: 0.12
 Nodes (11): FluentWebDriverAction, SelectedValueTests, Actions, AlertActions, BrowserActions, DriverFactoryHelper, TouchActions, WebDriver (+3 more)
 
 ### Community 149 - "Community 149"
-Cohesion: 0.22
-Nodes (4): ProgressBarLoggerTestAccessor, AfterMethod, Test, ValidationAndProgressBarTests
+Cohesion: 0.06
+Nodes (22): AutoCloseable, ProgressBarLogger, ProgressBarLoggerCoverageUnitTest, ProgressBarLoggerTestAccessor, ValidationsHelperTestAccessor, Override, String, AfterMethod (+14 more)
 
 ### Community 150 - "Community 150"
 Cohesion: 0.17
@@ -1235,24 +1230,24 @@ Cohesion: 0.18
 Nodes (10): ManagedCaptureRecorder, CaptureManager, CaptureStartRequest, CaptureStatus, CheckpointKind, Function, Override, State (+2 more)
 
 ### Community 153 - "Community 153"
-Cohesion: 0.13
-Nodes (4): AfterMethod, BeforeMethod, Test, NegativeValidationsTests
+Cohesion: 0.14
+Nodes (12): NativeValidationsBuilder, FileValidationsBuilder, Object, Override, RestValidationsBuilder, String, SuppressWarnings, ValidationsBuilder (+4 more)
 
 ### Community 154 - "Community 154"
 Cohesion: 0.08
 Nodes (24): enum, additionalProperties, allOf, enum, $id, pattern, type, type (+16 more)
 
 ### Community 155 - "Community 155"
-Cohesion: 0.16
-Nodes (8): String, AfterClass, AfterMethod, SuppressWarnings, Test, ThreadLocal, WebDriver, RecordManagerTest
+Cohesion: 0.11
+Nodes (14): IOSDriver, InputStream, Path, String, SuppressWarnings, WebDriver, AfterClass, AfterMethod (+6 more)
 
 ### Community 156 - "Community 156"
 Cohesion: 0.13
-Nodes (7): AndroidBasicInteractionsTests, AndroidDragAndDropTest, MobileTest, Test, Test, AfterMethod, BeforeMethod
+Nodes (8): AndroidDriver, AndroidBasicInteractionsTests, AfterMethod, BeforeClass, BeforeMethod, Test, TestClass, Test
 
 ### Community 157 - "Community 157"
-Cohesion: 0.09
-Nodes (15): AsyncElementActions, Async, CLI, GUI, Locator, Properties, TestData, Validations (+7 more)
+Cohesion: 0.22
+Nodes (5): Validations, Response, RestValidationsBuilder, StandaloneAssertions, StandaloneVerifications
 
 ### Community 158 - "Community 158"
 Cohesion: 0.19
@@ -1267,28 +1262,28 @@ Cohesion: 0.28
 Nodes (12): ValidationsHelper, Boolean, ComparisonType, List, Object, Response, String, Throwable (+4 more)
 
 ### Community 161 - "Community 161"
-Cohesion: 0.21
-Nodes (4): Path, String, Test, AttachmentReporterUnitTest
+Cohesion: 0.18
+Nodes (13): DoctorRepairPatchResult, DoctorRepairAiService, AiRequest, AiResponse, AiResponseStatus, Diagnosis, DoctorRepairAiRequest, EvidenceReference (+5 more)
 
 ### Community 162 - "Community 162"
 Cohesion: 0.16
 Nodes (3): AfterMethod, Test, ValidationsBuilderUnitTest
 
 ### Community 163 - "Community 163"
-Cohesion: 0.22
-Nodes (5): Timeouts, Boolean, DefaultValue, Key, SetProperty
+Cohesion: 0.17
+Nodes (8): PropertyFileManager, File, HashMap, Map, MutableCapabilities, Object, Properties, String
 
 ### Community 164 - "Community 164"
 Cohesion: 0.24
 Nodes (6): Dimension, BrowserActionsHelper, Boolean, SneakyThrows, String, WebDriver
 
 ### Community 165 - "Community 165"
-Cohesion: 0.20
-Nodes (6): CheckpointType, CheckpointCounter, CheckpointStatus, String, Test, CheckpointAndReportingTest
+Cohesion: 0.23
+Nodes (10): AllureSummary, Diagnostic, GeneratedTestValidator, JarFile, JavaFileObject, Duration, List, Path (+2 more)
 
 ### Community 166 - "Community 166"
-Cohesion: 0.16
-Nodes (9): OptionsManager, OptionsManagerCoverageUnitTest, DriverType, MutableCapabilities, String, SuppressWarnings, AfterMethod, BeforeMethod (+1 more)
+Cohesion: 0.13
+Nodes (12): ChromiumOptions, DesiredCapabilities, OptionsManager, OptionsManagerCoverageUnitTest, LoggingPreferences, DriverType, MutableCapabilities, String (+4 more)
 
 ### Community 167 - "Community 167"
 Cohesion: 0.15
@@ -1299,8 +1294,8 @@ Cohesion: 0.17
 Nodes (10): BrowserEventScript, PollingBrowserEventCollector, String, BrowserSignal, Consumer, Object, Override, Set (+2 more)
 
 ### Community 169 - "Community 169"
-Cohesion: 0.11
-Nodes (9): AsyncElementActions, JDK21VirtualThreadsAndAsyncActionsTests, By, ClipboardAction, DriverFactoryHelper, String, AfterMethod, BeforeMethod (+1 more)
+Cohesion: 0.16
+Nodes (5): AsyncElementActions, By, ClipboardAction, DriverFactoryHelper, String
 
 ### Community 170 - "Community 170"
 Cohesion: 0.20
@@ -1319,8 +1314,8 @@ Cohesion: 0.14
 Nodes (23): analyze_project(), collect_ai_context(), coordinates_have_supported_stack(), dependency_coordinates(), detect_markers(), discover_poms(), format_diff(), is_ignored() (+15 more)
 
 ### Community 175 - "Community 175"
-Cohesion: 0.19
-Nodes (12): OpenAiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode, Map (+4 more)
+Cohesion: 0.17
+Nodes (13): AiImage, OpenAiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode (+5 more)
 
 ### Community 176 - "Community 176"
 Cohesion: 0.16
@@ -1335,8 +1330,8 @@ Cohesion: 0.21
 Nodes (18): A(), ba(), c(), D(), E(), G(), i(), j() (+10 more)
 
 ### Community 179 - "Community 179"
-Cohesion: 0.21
-Nodes (10): HealingManager, By, HealingExplanation, HealingProvider, HealingResolution, List, Optional, String (+2 more)
+Cohesion: 0.07
+Nodes (30): HealingManager, current(), HealingStrategy(), parse(), usesHealenium(), usesShaftHeal(), HealingStrategyTest, NaturalActionExecutor (+22 more)
 
 ### Community 180 - "Community 180"
 Cohesion: 0.19
@@ -1363,20 +1358,20 @@ Cohesion: 0.17
 Nodes (3): AfterMethod, Test, TextDirectionValidationsBuilderUnitTest
 
 ### Community 186 - "Community 186"
-Cohesion: 0.12
-Nodes (15): AccessibilityActions, AccessibilityConfig, AccessibilityResult, BrowserActions, List, String, WebDriver, AccessibilityResult (+7 more)
+Cohesion: 0.22
+Nodes (8): AccessibilityResult, AfterMethod, BeforeMethod, List, Rule, String, Test, AccessibilityActionsCoverageUnitTest
 
 ### Community 187 - "Community 187"
-Cohesion: 0.10
-Nodes (10): Async, WebDriver, Actions, AlertActions, BrowserActions, DriverType, MutableCapabilities, TouchActions (+2 more)
+Cohesion: 0.07
+Nodes (20): Async, AsyncElementActions, Async, CLI, GUI, Locator, Properties, TestData (+12 more)
 
 ### Community 188 - "Community 188"
 Cohesion: 0.12
 Nodes (4): CommandResult, command_result(), FakeRepairClient, UpgradeToModularShaftTests
 
 ### Community 189 - "Community 189"
-Cohesion: 0.14
-Nodes (12): AppiumDriver, DriverFactoryHelper, Duration, Function, Map, Object, Rectangle, RuntimeException (+4 more)
+Cohesion: 0.17
+Nodes (7): AndroidDragAndDropTest, FileUploadDownloadTest, MobileTest, Test, Test, AfterMethod, BeforeMethod
 
 ### Community 190 - "Community 190"
 Cohesion: 0.24
@@ -1387,8 +1382,8 @@ Cohesion: 0.24
 Nodes (7): HealingScore, DeterministicScorer, Double, HealingConfiguration, LocatorFingerprint, Map, String
 
 ### Community 192 - "Community 192"
-Cohesion: 0.18
-Nodes (6): ElementInformation, ElementInformationCoverageUnitTest, Element, List, String, Test
+Cohesion: 0.17
+Nodes (7): ElementInformation, ElementInformationCoverageUnitTest, Element, List, Object, String, Test
 
 ### Community 193 - "Community 193"
 Cohesion: 0.19
@@ -1399,8 +1394,8 @@ Cohesion: 0.17
 Nodes (8): KeysetHandle, GoogleTink, GoogleTinkApiCoverageUnitTest, String, AfterMethod, BeforeMethod, Path, Test
 
 ### Community 195 - "Community 195"
-Cohesion: 0.19
-Nodes (10): NaturalActionExecutor, By, CharSequence, DriverFactoryHelper, NaturalActionPlan, Object, Set, String (+2 more)
+Cohesion: 0.21
+Nodes (4): AfterMethod, String, Test, PropertyFileManagerUnitTest
 
 ### Community 196 - "Community 196"
 Cohesion: 0.20
@@ -1422,10 +1417,6 @@ Nodes (6): AfterMethod, DataProvider, Object, String, Test, DriverFactoryHelperU
 Cohesion: 0.18
 Nodes (3): AfterMethod, Test, RestActionsUtilsUnitTest
 
-### Community 201 - "Community 201"
-Cohesion: 0.14
-Nodes (8): RestValidationsBuilder, JsonCompareWithSpecialCharactersTests, MatchJsonSchemaTests, NativeValidationsBuilder, String, ValidationsExecutor, Test, Test
-
 ### Community 202 - "Community 202"
 Cohesion: 0.21
 Nodes (10): CaptureService, McpCaptureCodeBlockService, McpCaptureReplayResult, PreDestroy, CaptureGenerationResult, CaptureManager, CaptureStatus, McpWorkspacePolicy (+2 more)
@@ -1443,8 +1434,8 @@ Cohesion: 0.23
 Nodes (10): OpenCvVisualProcessingProvider, Boolean, By, Integer, List, Mat, Override, String (+2 more)
 
 ### Community 206 - "Community 206"
-Cohesion: 0.18
-Nodes (7): ElementActionsHelper, FailureReporter, Class, String, Throwable, Test, FailureReporterUnitTest
+Cohesion: 0.19
+Nodes (6): FailureReporter, Class, String, Throwable, Test, FailureReporterUnitTest
 
 ### Community 207 - "Community 207"
 Cohesion: 0.23
@@ -1471,12 +1462,12 @@ Cohesion: 0.10
 Nodes (20): pattern, type, pattern, type, properties, body_path, created_at, status (+12 more)
 
 ### Community 213 - "Community 213"
-Cohesion: 0.11
-Nodes (29): append(), checkpoint(), complete(), ensureIncomplete(), interrupt(), sortedCheckpoints(), sortedEvents(), sortedReferences() (+21 more)
+Cohesion: 0.22
+Nodes (11): CaptureEvent, CaptureJsonCodec, CaptureSession, Checkpoint, ExternalTestDataReference, Instant, List, Path (+3 more)
 
 ### Community 214 - "Community 214"
-Cohesion: 0.14
-Nodes (5): Boolean, NumbersComparativeRelation, Object, String, JavaHelper
+Cohesion: 0.22
+Nodes (18): append(), checkpoint(), complete(), ensureIncomplete(), interrupt(), sortedCheckpoints(), sortedEvents(), sortedReferences() (+10 more)
 
 ### Community 215 - "Community 215"
 Cohesion: 0.20
@@ -1491,8 +1482,8 @@ Cohesion: 0.17
 Nodes (10): PilotTestConfiguration, RedactionPolicy, RedactionResult, Redactor, AiRequest, Set, String, PilotConfiguration (+2 more)
 
 ### Community 219 - "Community 219"
-Cohesion: 0.33
-Nodes (3): ProgressBarLoggerCoverageUnitTest, AfterMethod, Test
+Cohesion: 0.29
+Nodes (8): DoctorJsonCodec, Diagnosis, DoctorAdvisory, EvidenceBundle, JsonNode, Object, Path, String
 
 ### Community 220 - "Community 220"
 Cohesion: 0.27
@@ -1535,8 +1526,8 @@ Cohesion: 0.16
 Nodes (6): AfterTest, BeforeTest, ConfigurationHelper, ReportHelper, ITestContext, Step
 
 ### Community 232 - "Community 232"
-Cohesion: 0.15
-Nodes (11): BrowserEventCollector, CompositeBrowserEventCollector, BrowserSignal, Consumer, Override, String, BrowserSignal, Consumer (+3 more)
+Cohesion: 0.09
+Nodes (18): BrowsingContextInfo, BidiBrowserEventCollector, BrowserEventCollector, CompositeBrowserEventCollector, BrowserSignal, Consumer, Override, String (+10 more)
 
 ### Community 233 - "Community 233"
 Cohesion: 0.25
@@ -1550,17 +1541,17 @@ Nodes (7): CucumberTestRunnerListener, AfterMethod, Class, Object, String, Test,
 Cohesion: 0.28
 Nodes (7): LocatorRanker, ScoredLocator, ElementSnapshot, EventContext, LocatorCandidate, LocatorSelection, String
 
-### Community 236 - "Community 236"
-Cohesion: 0.19
-Nodes (10): current(), HealingStrategy(), parse(), usesHealenium(), usesShaftHeal(), HealingStrategyTest, String, AfterMethod (+2 more)
+### Community 237 - "Community 237"
+Cohesion: 0.13
+Nodes (6): Allure, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 238 - "Community 238"
-Cohesion: 0.18
-Nodes (11): CaptureEvent, CapturePrivacyPolicy, CaptureSessionStore, Consumer, ExternalTestDataReference, Instant, List, Map (+3 more)
+Cohesion: 0.28
+Nodes (6): CheckpointStatus, InputStream, List, Object, Step, Throwable
 
 ### Community 239 - "Community 239"
-Cohesion: 0.25
-Nodes (9): DeterministicNaturalActionPlanner, unsupported(), List, NaturalActionPlan, NaturalActionRequest, Override, String, NaturalActionPlan (+1 more)
+Cohesion: 0.28
+Nodes (6): BasicAPITests, AfterClass, BeforeClass, List, Map, String
 
 ### Community 240 - "Community 240"
 Cohesion: 0.25
@@ -1571,8 +1562,8 @@ Cohesion: 0.20
 Nodes (4): ValidationsMockedTests, AfterMethod, BeforeMethod, Test
 
 ### Community 242 - "Community 242"
-Cohesion: 0.31
-Nodes (5): HealingLocatorProposalService, HealingLocatorProposal, JsonNode, Path, String
+Cohesion: 0.16
+Nodes (11): HealingLocatorProposalService, HealingLocatorProposalServiceTest, HealingLocatorProposal, JsonNode, Path, String, AfterEach, BeforeEach (+3 more)
 
 ### Community 243 - "Community 243"
 Cohesion: 0.21
@@ -1595,8 +1586,8 @@ Cohesion: 0.17
 Nodes (11): AiProviderRegistryTest, availability(), capabilities(), execute(), AfterEach, AiCapabilities, AiProviderAvailability, AiRequest (+3 more)
 
 ### Community 249 - "Community 249"
-Cohesion: 0.15
-Nodes (10): AllureCucumber7Jvm, CucumberTestRunnerListener, EventPublisher, Feature, Optional, Override, TestCaseFinished, TestSourceParsed (+2 more)
+Cohesion: 0.18
+Nodes (9): AllureCucumber7Jvm, CucumberTestRunnerListener, EventPublisher, Feature, Optional, Override, TestSourceParsed, TestStepStarted (+1 more)
 
 ### Community 250 - "Community 250"
 Cohesion: 0.23
@@ -1611,12 +1602,12 @@ Cohesion: 0.18
 Nodes (6): BrowserSteps, Given, String, ThreadLocal, WebDriver, When
 
 ### Community 253 - "Community 253"
-Cohesion: 0.27
-Nodes (4): Allure, DefaultValue, Key, SetProperty
+Cohesion: 0.21
+Nodes (7): Date, InputStream, Override, Path, Test, CloseTrackingInputStream, ReportManagerHelperAttachmentIoUnitTest
 
 ### Community 254 - "Community 254"
-Cohesion: 0.14
-Nodes (10): LambdaTestHelper, Boolean, DriverFactoryHelper, HashMap, MutableCapabilities, Object, String, AfterMethod (+2 more)
+Cohesion: 0.28
+Nodes (7): LambdaTestHelper, Boolean, DriverFactoryHelper, HashMap, MutableCapabilities, Object, String
 
 ### Community 255 - "Community 255"
 Cohesion: 0.25
@@ -1655,16 +1646,16 @@ Cohesion: 0.21
 Nodes (4): AfterClass, BeforeClass, Test, FileHelperUnitTest
 
 ### Community 265 - "Community 265"
-Cohesion: 0.18
-Nodes (5): RestActionsCoverageUnitTest, Cookie, Set, AfterMethod, Test
+Cohesion: 0.21
+Nodes (3): RestActionsCoverageUnitTest, AfterMethod, Test
 
 ### Community 266 - "Community 266"
-Cohesion: 0.22
+Cohesion: 0.20
 Nodes (11): BooleanSupplier, expired(), InstantDeadline(), ManagedCaptureRecorderBrowserTest, Duration, HttpExchange, HttpServer, ParameterizedTest (+3 more)
 
 ### Community 267 - "Community 267"
-Cohesion: 0.19
-Nodes (4): List, BeforeMethod, Test, BrowserActionsCoverageUnitTest
+Cohesion: 0.15
+Nodes (6): List, AfterMethod, BeforeMethod, Test, BrowserActionsCoverageUnitTest, Window
 
 ### Community 268 - "Community 268"
 Cohesion: 0.21
@@ -1679,28 +1670,28 @@ Cohesion: 0.27
 Nodes (7): CaptureControlClient, CaptureStatus, CheckpointKind, List, Object, Path, String
 
 ### Community 271 - "Community 271"
-Cohesion: 0.24
-Nodes (4): FrameTests, AfterMethod, BeforeMethod, Test
+Cohesion: 0.31
+Nodes (4): ScreenshotHelper, Boolean, SuppressWarnings, WebDriver
 
 ### Community 272 - "Community 272"
-Cohesion: 0.33
-Nodes (6): HealingLocatorProposalServiceTest, AfterEach, BeforeEach, Path, String, Test
+Cohesion: 0.23
+Nodes (4): ThreadLocalPropertiesManager, Properties, String, AfterMethod
 
 ### Community 274 - "Community 274"
 Cohesion: 0.21
 Nodes (9): AiProvider, DoctorSnippetProvider, AfterEach, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse, Override (+1 more)
 
 ### Community 275 - "Community 275"
-Cohesion: 0.14
-Nodes (10): FileActionsCoverageUnitTest, FileActionsReflectionInvoker, AfterMethod, BeforeMethod, Path, String, Test, FileActions (+2 more)
+Cohesion: 0.15
+Nodes (9): FileActionsCoverageUnitTest, FileActionsReflectionInvoker, JarEntry, AfterMethod, Path, String, Test, FileActions (+1 more)
 
 ### Community 276 - "Community 276"
-Cohesion: 0.27
-Nodes (6): ValidationsHelperTestAccessor, ArrayList, By, List, String, SuppressWarnings
+Cohesion: 0.26
+Nodes (5): AfterMethod, Object, String, Test, BrowserStackPropertiesUnitTest
 
 ### Community 277 - "Community 277"
-Cohesion: 0.29
-Nodes (6): AutoCloseable, FileChannel, FileLock, CaptureSingleSessionLock, Override, Path
+Cohesion: 0.20
+Nodes (8): FileChannel, FileLock, CaptureRuntimePortabilityTest, CaptureSingleSessionLock, Override, Path, Path, Test
 
 ### Community 278 - "Community 278"
 Cohesion: 0.20
@@ -1715,8 +1706,8 @@ Cohesion: 0.19
 Nodes (7): HealingVisualProvider, OpenCvHealingVisualProvider, OpenCvHealingVisualProviderTest, Override, String, Color, Test
 
 ### Community 281 - "Community 281"
-Cohesion: 0.27
-Nodes (5): ValidationsHelperCoverageUnitTest, AssertionError, AfterMethod, SuppressWarnings, Test
+Cohesion: 0.13
+Nodes (11): ValidationsHelperCoverageUnitTest, AssertionError, AfterMethod, SuppressWarnings, Test, AfterMethod, Object, String (+3 more)
 
 ### Community 282 - "Community 282"
 Cohesion: 0.23
@@ -1727,8 +1718,8 @@ Cohesion: 0.13
 Nodes (15): type, uniqueItems, enum, additionalProperties, properties, required, type, enum (+7 more)
 
 ### Community 284 - "Community 284"
-Cohesion: 0.13
-Nodes (15): type, uniqueItems, enum, facets, additionalProperties, properties, required, type (+7 more)
+Cohesion: 0.17
+Nodes (12): enum, facets, additionalProperties, properties, required, type, enum, items (+4 more)
 
 ### Community 285 - "Community 285"
 Cohesion: 0.17
@@ -1750,17 +1741,21 @@ Nodes (5): AfterMethod, BeforeMethod, Path, Test, ExcelFileManagerCoverageUnitTe
 Cohesion: 0.21
 Nodes (7): AfterMethod, BeforeClass, BeforeMethod, Override, String, Test, TestClass
 
+### Community 291 - "Community 291"
+Cohesion: 0.31
+Nodes (4): AfterMethod, String, Test, PropertiesHelperInitializationUnitTest
+
 ### Community 292 - "Community 292"
-Cohesion: 0.18
-Nodes (7): Callable, Path, Test, DesktopVideoRecordingProvider, Optional, CaptureSessionStoreTest, DesktopVideoRecordingProviderRegistry
+Cohesion: 0.46
+Nodes (4): Callable, Path, Test, CaptureSessionStoreTest
 
 ### Community 293 - "Community 293"
 Cohesion: 0.19
 Nodes (14): A(), Ae(), b(), ce(), ge(), le(), pe(), qe() (+6 more)
 
 ### Community 294 - "Community 294"
-Cohesion: 0.22
-Nodes (7): ElementStepsCoverageUnitTest, BeforeMethod, By, DataProvider, Object, String, Test
+Cohesion: 0.24
+Nodes (3): AndroidTouchActionsTests, ScreenOrientation, Test
 
 ### Community 295 - "Community 295"
 Cohesion: 0.25
@@ -1779,24 +1774,20 @@ Cohesion: 0.32
 Nodes (4): Reporting, DefaultValue, Key, SetProperty
 
 ### Community 299 - "Community 299"
-Cohesion: 0.24
-Nodes (4): ElementActionsMockedTests, AfterMethod, BeforeMethod, Test
+Cohesion: 0.22
+Nodes (5): ElementActions, ElementActionsMockedTests, AfterMethod, BeforeMethod, Test
 
 ### Community 300 - "Community 300"
 Cohesion: 0.26
 Nodes (6): ModelSupport, JsonNode, List, Map, String, T
 
 ### Community 301 - "Community 301"
-Cohesion: 0.14
-Nodes (14): items, tags, items, additionalProperties, minLength, pattern, properties, required (+6 more)
+Cohesion: 0.12
+Nodes (17): items, type, uniqueItems, tags, items, additionalProperties, minLength, pattern (+9 more)
 
 ### Community 302 - "Community 302"
-Cohesion: 0.27
-Nodes (5): InputStream, Path, SuppressWarnings, WebDriver, RecordManager
-
-### Community 303 - "Community 303"
-Cohesion: 0.27
-Nodes (3): UnitTestsSHAFT, TerminalActions, Test
+Cohesion: 0.32
+Nodes (5): CaptureJsonCodec, CaptureSession, JsonNode, Path, String
 
 ### Community 304 - "Community 304"
 Cohesion: 0.25
@@ -1811,8 +1802,8 @@ Cohesion: 0.14
 Nodes (13): additionalProperties, type, type, properties, body, id, title, userId (+5 more)
 
 ### Community 307 - "Community 307"
-Cohesion: 0.19
-Nodes (9): AccessibilityActions, HttpRequest, HttpResponse, IOSDriver, DriverFactoryHelper, Predicate, Step, WebDriver (+1 more)
+Cohesion: 0.20
+Nodes (8): AccessibilityActions, HttpRequest, HttpResponse, DriverFactoryHelper, Predicate, Step, WebDriver, WebDriverBrowserValidationsBuilder
 
 ### Community 308 - "Community 308"
 Cohesion: 0.23
@@ -1835,8 +1826,8 @@ Cohesion: 0.21
 Nodes (7): WebDriverBrowserValidationsBuilder, NativeValidationsBuilder, String, StringBuilder, SuppressWarnings, ValidationCategory, WebDriver
 
 ### Community 314 - "Community 314"
-Cohesion: 0.26
-Nodes (8): LauncherSessionListener, JunitListener, Status, String, TestIdentifier, Throwable, StatusIcon, TestExecutionResult
+Cohesion: 0.25
+Nodes (6): WebDomHealingAcceptanceTest, AfterMethod, BeforeMethod, Path, String, Test
 
 ### Community 315 - "Community 315"
 Cohesion: 0.26
@@ -1867,16 +1858,16 @@ Cohesion: 0.26
 Nodes (4): AfterMethod, BeforeMethod, Test, BrowserActionsHelperCoverageUnitTest
 
 ### Community 322 - "Community 322"
-Cohesion: 0.27
-Nodes (5): HttpExchange, HttpServer, Override, String, LocalApiServer
+Cohesion: 0.26
+Nodes (3): AfterMethod, Test, LambdaTestHelperUnitTest
 
 ### Community 323 - "Community 323"
 Cohesion: 0.27
 Nodes (4): LocalApiTestServer, HttpExchange, HttpServer, String
 
 ### Community 324 - "Community 324"
-Cohesion: 0.25
-Nodes (4): RunType, AfterMethod, Test, DriverFactoryCoverageUnitTest
+Cohesion: 0.18
+Nodes (7): AllureLifecycle, Feature, Optional, SuppressWarnings, TestSourceParsed, URI, TestRunFinished
 
 ### Community 325 - "Community 325"
 Cohesion: 0.30
@@ -1899,8 +1890,8 @@ Cohesion: 0.29
 Nodes (7): Description, AfterMethod, BeforeClass, BeforeMethod, Step, Test, FluentGuiActionsTest
 
 ### Community 330 - "Community 330"
-Cohesion: 0.24
-Nodes (4): ArrayNode, InputStream, List, ObjectNode
+Cohesion: 0.21
+Nodes (5): Future, ArrayNode, InputStream, List, ObjectNode
 
 ### Community 331 - "Community 331"
 Cohesion: 0.32
@@ -1915,7 +1906,7 @@ Cohesion: 0.18
 Nodes (5): ExecutionSummaryReport, StatusIcon(), CheckpointStatus, String, StringBuilder
 
 ### Community 335 - "Community 335"
-Cohesion: 0.30
+Cohesion: 0.18
 Nodes (6): IssueReporter, Boolean, ITestNGMethod, ITestResult, List, String
 
 ### Community 336 - "Community 336"
@@ -1935,12 +1926,12 @@ Cohesion: 0.29
 Nodes (4): DragAndDropTests, AfterMethod, BeforeMethod, Test
 
 ### Community 340 - "Community 340"
-Cohesion: 0.27
+Cohesion: 0.29
 Nodes (3): EngineServiceTest, AfterEach, Test
 
 ### Community 341 - "Community 341"
-Cohesion: 0.24
-Nodes (6): LogRedirector, Logger, InputStream, OutputStream, Level, Override
+Cohesion: 0.17
+Nodes (8): LogRedirector, ProjectStructureManager, Logger, InputStream, OutputStream, Level, Override, RunType
 
 ### Community 342 - "Community 342"
 Cohesion: 0.32
@@ -1975,16 +1966,16 @@ Cohesion: 0.26
 Nodes (5): AfterMethod, BeforeClass, BeforeMethod, Test, TestClass
 
 ### Community 350 - "Community 350"
-Cohesion: 0.35
+Cohesion: 0.36
 Nodes (4): HttpExchange, Path, String, TestPageServer
 
 ### Community 352 - "Community 352"
-Cohesion: 0.35
+Cohesion: 0.36
 Nodes (3): XpathAxis, LocatorBuilder, String
 
 ### Community 353 - "Community 353"
-Cohesion: 0.24
-Nodes (6): AfterMethod, Object, String, Test, ValidationsExecutor, ValidationsExecutorCoverageUnitTest
+Cohesion: 0.29
+Nodes (5): Test_LTMobIPAAppURL, AfterMethod, BeforeMethod, String, Test
 
 ### Community 354 - "Community 354"
 Cohesion: 0.18
@@ -2007,12 +1998,12 @@ Cohesion: 0.25
 Nodes (4): DatabaseActions, DB, DatabaseType, ResultSet
 
 ### Community 359 - "Community 359"
-Cohesion: 0.47
-Nodes (3): CapturePrivacyClassifierTest, Path, Test
+Cohesion: 0.27
+Nodes (8): TestableDriverFactoryHelper, OptionsManager, AfterMethod, AtomicInteger, CountDownLatch, DriverFactoryHelper, Method, MutableCapabilities
 
 ### Community 360 - "Community 360"
-Cohesion: 0.18
-Nodes (8): ValidationsExecutor, FileValidationsBuilder, NativeValidationsBuilder, NumberValidationsBuilder, RestValidationsBuilder, Step, ValidationsBuilder, WebDriverElementValidationsBuilder
+Cohesion: 0.33
+Nodes (4): TextDirectionValidationsBuilder, NativeValidationsBuilder, ValidationsExecutor, TextDirection
 
 ### Community 361 - "Community 361"
 Cohesion: 0.29
@@ -2070,10 +2061,6 @@ Nodes (5): AiProviderRegistry, AiProvider, List, PilotConfiguration, String
 Cohesion: 0.33
 Nodes (8): failure(), success(), AiResponse, AiResponseStatus, AiUsage, Duration, JsonNode, String
 
-### Community 376 - "Community 376"
-Cohesion: 0.67
-Nodes (3): defaults(), ApprovalPolicy, DoctorRepairAiRequest
-
 ### Community 377 - "Community 377"
 Cohesion: 0.20
 Nodes (9): Build & Test, Code Quality Standards, Complexity, Documentation, JavaDocs, Logging, Requirements, Testing (+1 more)
@@ -2103,8 +2090,8 @@ Cohesion: 0.27
 Nodes (6): AiCandidateRerankerTest, AfterMethod, HealingConfiguration, HttpExchange, String, Test
 
 ### Community 385 - "Community 385"
-Cohesion: 0.36
-Nodes (3): ProgressBarLogger, Override, String
+Cohesion: 0.43
+Nodes (3): Result, Status, TestStepFinished
 
 ### Community 386 - "Community 386"
 Cohesion: 0.40
@@ -2155,8 +2142,8 @@ Cohesion: 0.33
 Nodes (4): HoverTests, AfterMethod, BeforeMethod, Test
 
 ### Community 398 - "Community 398"
-Cohesion: 0.29
-Nodes (6): NaturalActionPlannerRegistry, List, NaturalActionPlan, NaturalActionPlanner, NaturalActionRequest, String
+Cohesion: 0.32
+Nodes (3): DesktopVideoRecordingProvider, Optional, DesktopVideoRecordingProviderRegistry
 
 ### Community 399 - "Community 399"
 Cohesion: 0.31
@@ -2167,8 +2154,8 @@ Cohesion: 0.31
 Nodes (4): AfterMethod, BeforeMethod, Test, VisualValidationTests
 
 ### Community 401 - "Community 401"
-Cohesion: 0.39
-Nodes (3): ValidationsHelper2CoverageUnitTest, AfterMethod, Test
+Cohesion: 0.43
+Nodes (6): bounded(), current(), split(), HealingConfiguration, List, String
 
 ### Community 402 - "Community 402"
 Cohesion: 0.36
@@ -2180,7 +2167,7 @@ Nodes (5): steps, Given, String, Then, When
 
 ### Community 404 - "Community 404"
 Cohesion: 0.33
-Nodes (5): SynchronizationManager, Class, Exception, List, WebDriver
+Nodes (6): parse_xml(), Parse XML while preserving comments., Return version property, direct SHAFT dependencies, and managed BOM version., Enforce the modular SHAFT dependency contract after every repair., shaft_dependency_state(), validate_upgraded_poms()
 
 ### Community 405 - "Community 405"
 Cohesion: 0.22
@@ -2191,8 +2178,8 @@ Cohesion: 0.28
 Nodes (5): JSONValidationsBuilder, NativeValidationsBuilder, Object, RestValidationsBuilder, ValidationsExecutor
 
 ### Community 408 - "Community 408"
-Cohesion: 0.18
-Nodes (11): bounded(), current(), split(), ShaftMcpApplicationTests, EvidenceBundle, HealingConfiguration, List, String (+3 more)
+Cohesion: 0.21
+Nodes (8): Autowired, ShaftMcpApplicationTests, McpMobileRecordingService, EngineService, McpWorkspacePolicy, Set, String, Test
 
 ### Community 409 - "Community 409"
 Cohesion: 0.22
@@ -2211,12 +2198,16 @@ Cohesion: 0.36
 Nodes (4): ChecksumTests, Path, String, Test
 
 ### Community 413 - "Community 413"
-Cohesion: 0.27
-Nodes (7): DecisionResult, HealingDecisionEngine, HealingConfiguration, List, RankedCandidate, Status, String
+Cohesion: 0.50
+Nodes (3): Log4jTests, BeforeClass, Test
 
 ### Community 414 - "Community 414"
 Cohesion: 0.47
 Nodes (4): SmartLocators, PathStrategy, By, String
+
+### Community 415 - "Community 415"
+Cohesion: 0.15
+Nodes (13): AllureSnapshot, AllureVerdict, PatchManifestEntry, changedSince(), RepairGuard, RepairProposalStore, Diagnosis, DoctorJsonCodec (+5 more)
 
 ### Community 416 - "Community 416"
 Cohesion: 0.29
@@ -2243,15 +2234,15 @@ Cohesion: 0.42
 Nodes (5): ClassifiedValue, Collection, Path, String, ExternalTestDataWriter
 
 ### Community 423 - "Community 423"
-Cohesion: 0.29
+Cohesion: 0.31
 Nodes (5): AfterEach, BeforeAll, BeforeEach, Test, TestClass
 
 ### Community 424 - "Community 424"
-Cohesion: 0.29
+Cohesion: 0.31
 Nodes (5): AfterMethod, BeforeClass, BeforeMethod, Test, TestClass
 
 ### Community 425 - "Community 425"
-Cohesion: 0.33
+Cohesion: 0.31
 Nodes (4): AfterMethod, BeforeMethod, Test, TopUncoveredClassesCoverageUnitTest
 
 ### Community 426 - "Community 426"
@@ -2282,16 +2273,12 @@ Nodes (4): CaptureServiceTest, CaptureService, Path, Test
 Cohesion: 0.25
 Nodes (7): Diagnosis, Evidence Index, Findings, Missing Evidence, Privacy, Remediation, SHAFT Doctor Report
 
-### Community 434 - "Community 434"
-Cohesion: 0.29
-Nodes (5): AfterMethod, BeforeClass, BeforeMethod, Test, TestClass
-
 ### Community 435 - "Community 435"
 Cohesion: 0.43
 Nodes (3): AfterMethod, Test, ProjectStructureManagerTest
 
 ### Community 436 - "Community 436"
-Cohesion: 0.33
+Cohesion: 0.39
 Nodes (3): ReportManager, Level, String
 
 ### Community 437 - "Community 437"
@@ -2335,7 +2322,7 @@ Cohesion: 0.36
 Nodes (4): LazyLoadingTests, AfterMethod, BeforeMethod, Test
 
 ### Community 448 - "Community 448"
-Cohesion: 0.36
+Cohesion: 0.38
 Nodes (4): RemoteGridVideoAttachmentIT, AfterMethod, BeforeMethod, Test
 
 ### Community 449 - "Community 449"
@@ -2396,11 +2383,7 @@ Nodes (3): MobileEmulationTests, AfterMethod, Test
 
 ### Community 465 - "Community 465"
 Cohesion: 0.09
-Nodes (10): BasicAuthenticationTests, NetworkInterceptionTest, TableTests, SmartLocatorsTests, Test, Test, String, AfterMethod (+2 more)
-
-### Community 466 - "Community 466"
-Cohesion: 0.53
-Nodes (3): CaptureRuntimePortabilityTest, Path, Test
+Nodes (10): NetworkInterceptionTest, TableTests, SmartLocatorsTests, Test, String, Test, AfterMethod, BeforeMethod (+2 more)
 
 ### Community 467 - "Community 467"
 Cohesion: 0.43
@@ -2455,16 +2438,12 @@ Cohesion: 0.47
 Nodes (3): CaptureSchemaMigrator, JsonNode, ObjectNode
 
 ### Community 481 - "Community 481"
-Cohesion: 0.33
-Nodes (5): notRequested(), skipped(), Enrichment, String, Validation
+Cohesion: 0.09
+Nodes (18): ArtifactPaths, CaptureGenerationReport, notRequested(), skipped(), failure(), GenerationState, Enrichment, String (+10 more)
 
 ### Community 482 - "Community 482"
 Cohesion: 0.33
 Nodes (3): PrivacySanitizer, SanitizedValue, String
-
-### Community 484 - "Community 484"
-Cohesion: 0.32
-Nodes (7): LocatorRankerTest, ElementSnapshot, List, LocatorCandidate, LocatorStrategy, String, Test
 
 ### Community 486 - "Community 486"
 Cohesion: 0.47
@@ -2539,15 +2518,15 @@ Cohesion: 0.60
 Nodes (3): AbstractTestNGCucumberTests, CucumberTests, CucumberTests
 
 ### Community 506 - "Community 506"
-Cohesion: 0.17
-Nodes (8): CaptureEnrichmentService, MutableTargetPlan, GeneratedTestValidator, LocatorRanker, CaptureJsonCodec, ElementSnapshot, LocatorCandidate, LocatorSelection
+Cohesion: 0.40
+Nodes (4): CaptureEnrichmentService, GeneratedTestValidator, LocatorRanker, CaptureJsonCodec
 
 ### Community 507 - "Community 507"
 Cohesion: 0.60
 Nodes (4): defaults(), DoctorAnalysisRequest, List, Path
 
 ### Community 511 - "Community 511"
-Cohesion: 0.47
+Cohesion: 0.36
 Nodes (3): OpenCvVisualConsumer, Mat, String
 
 ### Community 512 - "Community 512"
@@ -2562,17 +2541,9 @@ Nodes (4): LocatorFingerprint(), safe(), Map, String
 Cohesion: 0.40
 Nodes (4): Allowed Work, Constraints, Refresh Agent Guidance, Validation
 
-### Community 515 - "Community 515"
-Cohesion: 0.40
-Nodes (4): notRunning(), text(), CaptureStatus, String
-
 ### Community 516 - "Community 516"
 Cohesion: 0.29
 Nodes (7): type, additionalProperties, type, additionalProperties, type, attributes, metadata
-
-### Community 517 - "Community 517"
-Cohesion: 0.24
-Nodes (7): BrowsingContextInfo, BidiBrowserEventCollector, BrowserSignal, Consumer, Override, String, WebDriver
 
 ### Community 520 - "Community 520"
 Cohesion: 0.50
@@ -2606,10 +2577,6 @@ Nodes (3): { Client }, pgclient, values
 Cohesion: 0.67
 Nodes (3): pattern, type, content_hash
 
-### Community 544 - "Community 544"
-Cohesion: 0.40
-Nodes (4): Autowired, McpMobileRecordingService, EngineService, McpWorkspacePolicy
-
 ### Community 545 - "Community 545"
 Cohesion: 0.67
 Nodes (3): enum, type, category
@@ -2642,29 +2609,25 @@ Nodes (3): minLength, type, mediaType
 Cohesion: 0.38
 Nodes (5): ready(), unavailable(), AiProviderAvailability, AiProviderAvailability, String
 
-### Community 678 - "Community 678"
-Cohesion: 0.33
-Nodes (6): parse_xml(), Parse XML while preserving comments., Return version property, direct SHAFT dependencies, and managed BOM version., Enforce the modular SHAFT dependency contract after every repair., shaft_dependency_state(), validate_upgraded_poms()
-
 ## Knowledge Gaps
 - **1223 isolated node(s):** `$id`, `$schema`, `additionalProperties`, `additionalProperties`, `type` (+1218 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **81 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **84 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `SHAFT` connect `Community 42` to `Community 3`, `Community 5`, `Community 8`, `Community 10`, `Community 11`, `Community 12`, `Community 525`, `Community 14`, `Community 13`, `Community 15`, `Community 17`, `Community 18`, `Community 19`, `Community 21`, `Community 536`, `Community 25`, `Community 24`, `Community 27`, `Community 28`, `Community 31`, `Community 35`, `Community 36`, `Community 37`, `Community 39`, `Community 43`, `Community 44`, `Community 47`, `Community 48`, `Community 49`, `Community 51`, `Community 53`, `Community 55`, `Community 57`, `Community 59`, `Community 61`, `Community 64`, `Community 72`, `Community 74`, `Community 76`, `Community 80`, `Community 81`, `Community 82`, `Community 83`, `Community 87`, `Community 90`, `Community 94`, `Community 97`, `Community 98`, `Community 99`, `Community 100`, `Community 105`, `Community 106`, `Community 109`, `Community 110`, `Community 111`, `Community 113`, `Community 117`, `Community 120`, `Community 121`, `Community 124`, `Community 125`, `Community 130`, `Community 131`, `Community 135`, `Community 136`, `Community 138`, `Community 139`, `Community 144`, `Community 145`, `Community 148`, `Community 153`, `Community 155`, `Community 156`, `Community 157`, `Community 159`, `Community 160`, `Community 161`, `Community 164`, `Community 166`, `Community 679`, `Community 680`, `Community 169`, `Community 170`, `Community 180`, `Community 184`, `Community 186`, `Community 189`, `Community 194`, `Community 195`, `Community 199`, `Community 201`, `Community 203`, `Community 205`, `Community 208`, `Community 215`, `Community 216`, `Community 220`, `Community 222`, `Community 223`, `Community 225`, `Community 229`, `Community 231`, `Community 233`, `Community 236`, `Community 240`, `Community 242`, `Community 243`, `Community 246`, `Community 248`, `Community 249`, `Community 250`, `Community 252`, `Community 254`, `Community 258`, `Community 259`, `Community 265`, `Community 271`, `Community 272`, `Community 274`, `Community 275`, `Community 289`, `Community 290`, `Community 294`, `Community 295`, `Community 296`, `Community 297`, `Community 302`, `Community 303`, `Community 307`, `Community 316`, `Community 317`, `Community 318`, `Community 320`, `Community 321`, `Community 324`, `Community 329`, `Community 330`, `Community 334`, `Community 336`, `Community 339`, `Community 342`, `Community 348`, `Community 349`, `Community 350`, `Community 353`, `Community 355`, `Community 356`, `Community 358`, `Community 361`, `Community 362`, `Community 363`, `Community 364`, `Community 366`, `Community 370`, `Community 372`, `Community 380`, `Community 382`, `Community 384`, `Community 385`, `Community 387`, `Community 388`, `Community 396`, `Community 397`, `Community 398`, `Community 399`, `Community 400`, `Community 401`, `Community 403`, `Community 404`, `Community 408`, `Community 410`, `Community 411`, `Community 420`, `Community 423`, `Community 424`, `Community 426`, `Community 434`, `Community 435`, `Community 438`, `Community 439`, `Community 440`, `Community 441`, `Community 442`, `Community 443`, `Community 444`, `Community 445`, `Community 446`, `Community 448`, `Community 450`, `Community 452`, `Community 455`, `Community 456`, `Community 457`, `Community 458`, `Community 459`, `Community 460`, `Community 463`, `Community 464`, `Community 465`, `Community 467`, `Community 468`, `Community 479`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 493`, `Community 494`, `Community 495`, `Community 496`, `Community 497`, `Community 503`, `Community 508`?**
-  _High betweenness centrality (0.119) - this node is a cross-community bridge._
-- **Why does `ThreadLocalPropertiesManager` connect `Community 99` to `Community 37`, `Community 158`?**
-  _High betweenness centrality (0.044) - this node is a cross-community bridge._
-- **Why does `IOException` connect `Community 42` to `Community 2`, `Community 5`, `Community 7`, `Community 10`, `Community 12`, `Community 18`, `Community 23`, `Community 25`, `Community 26`, `Community 33`, `Community 37`, `Community 40`, `Community 45`, `Community 46`, `Community 47`, `Community 49`, `Community 53`, `Community 61`, `Community 62`, `Community 65`, `Community 67`, `Community 68`, `Community 76`, `Community 96`, `Community 99`, `Community 101`, `Community 105`, `Community 109`, `Community 115`, `Community 117`, `Community 119`, `Community 121`, `Community 122`, `Community 125`, `Community 129`, `Community 132`, `Community 135`, `Community 141`, `Community 144`, `Community 168`, `Community 176`, `Community 180`, `Community 189`, `Community 190`, `Community 204`, `Community 205`, `Community 207`, `Community 210`, `Community 216`, `Community 242`, `Community 246`, `Community 260`, `Community 264`, `Community 266`, `Community 270`, `Community 275`, `Community 277`, `Community 278`, `Community 282`, `Community 288`, `Community 290`, `Community 302`, `Community 307`, `Community 322`, `Community 323`, `Community 330`, `Community 350`, `Community 359`, `Community 371`, `Community 372`, `Community 384`, `Community 386`, `Community 419`, `Community 422`, `Community 431`, `Community 435`, `Community 448`, `Community 462`, `Community 498`?**
-  _High betweenness centrality (0.025) - this node is a cross-community bridge._
+- **Why does `SHAFT` connect `Community 42` to `Community 1`, `Community 3`, `Community 515`, `Community 5`, `Community 8`, `Community 10`, `Community 11`, `Community 12`, `Community 525`, `Community 14`, `Community 15`, `Community 528`, `Community 17`, `Community 18`, `Community 19`, `Community 21`, `Community 536`, `Community 25`, `Community 24`, `Community 27`, `Community 31`, `Community 32`, `Community 35`, `Community 39`, `Community 44`, `Community 47`, `Community 48`, `Community 49`, `Community 51`, `Community 53`, `Community 55`, `Community 57`, `Community 61`, `Community 63`, `Community 64`, `Community 72`, `Community 74`, `Community 76`, `Community 80`, `Community 81`, `Community 82`, `Community 83`, `Community 90`, `Community 92`, `Community 94`, `Community 97`, `Community 98`, `Community 99`, `Community 100`, `Community 105`, `Community 109`, `Community 110`, `Community 117`, `Community 120`, `Community 121`, `Community 124`, `Community 125`, `Community 130`, `Community 131`, `Community 133`, `Community 135`, `Community 136`, `Community 138`, `Community 139`, `Community 144`, `Community 145`, `Community 148`, `Community 149`, `Community 155`, `Community 156`, `Community 159`, `Community 160`, `Community 164`, `Community 166`, `Community 170`, `Community 179`, `Community 180`, `Community 184`, `Community 187`, `Community 189`, `Community 194`, `Community 199`, `Community 201`, `Community 203`, `Community 205`, `Community 208`, `Community 215`, `Community 216`, `Community 220`, `Community 222`, `Community 223`, `Community 225`, `Community 229`, `Community 231`, `Community 233`, `Community 239`, `Community 240`, `Community 242`, `Community 246`, `Community 248`, `Community 249`, `Community 250`, `Community 252`, `Community 254`, `Community 258`, `Community 259`, `Community 265`, `Community 267`, `Community 274`, `Community 275`, `Community 276`, `Community 281`, `Community 289`, `Community 290`, `Community 295`, `Community 296`, `Community 297`, `Community 303`, `Community 307`, `Community 314`, `Community 316`, `Community 317`, `Community 318`, `Community 320`, `Community 321`, `Community 324`, `Community 329`, `Community 330`, `Community 334`, `Community 336`, `Community 339`, `Community 342`, `Community 348`, `Community 349`, `Community 353`, `Community 355`, `Community 356`, `Community 358`, `Community 359`, `Community 361`, `Community 362`, `Community 363`, `Community 364`, `Community 366`, `Community 370`, `Community 372`, `Community 380`, `Community 382`, `Community 384`, `Community 387`, `Community 388`, `Community 396`, `Community 397`, `Community 399`, `Community 400`, `Community 401`, `Community 403`, `Community 410`, `Community 411`, `Community 413`, `Community 420`, `Community 423`, `Community 424`, `Community 426`, `Community 430`, `Community 435`, `Community 438`, `Community 439`, `Community 440`, `Community 441`, `Community 442`, `Community 443`, `Community 444`, `Community 445`, `Community 446`, `Community 447`, `Community 448`, `Community 450`, `Community 452`, `Community 455`, `Community 456`, `Community 457`, `Community 458`, `Community 459`, `Community 460`, `Community 463`, `Community 464`, `Community 465`, `Community 466`, `Community 467`, `Community 468`, `Community 479`, `Community 483`, `Community 484`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 493`, `Community 494`, `Community 495`, `Community 496`, `Community 497`, `Community 501`, `Community 503`, `Community 508`?**
+  _High betweenness centrality (0.120) - this node is a cross-community bridge._
+- **Why does `ThreadLocalPropertiesManager` connect `Community 272` to `Community 37`, `Community 158`?**
+  _High betweenness centrality (0.045) - this node is a cross-community bridge._
+- **Why does `IOException` connect `Community 42` to `Community 2`, `Community 7`, `Community 10`, `Community 12`, `Community 18`, `Community 33`, `Community 40`, `Community 45`, `Community 46`, `Community 53`, `Community 56`, `Community 61`, `Community 62`, `Community 63`, `Community 65`, `Community 67`, `Community 68`, `Community 76`, `Community 86`, `Community 96`, `Community 101`, `Community 105`, `Community 109`, `Community 115`, `Community 117`, `Community 119`, `Community 121`, `Community 122`, `Community 125`, `Community 129`, `Community 132`, `Community 133`, `Community 135`, `Community 141`, `Community 144`, `Community 149`, `Community 155`, `Community 161`, `Community 163`, `Community 165`, `Community 168`, `Community 176`, `Community 180`, `Community 189`, `Community 190`, `Community 204`, `Community 205`, `Community 207`, `Community 210`, `Community 216`, `Community 219`, `Community 239`, `Community 242`, `Community 246`, `Community 253`, `Community 260`, `Community 264`, `Community 266`, `Community 270`, `Community 275`, `Community 277`, `Community 278`, `Community 282`, `Community 288`, `Community 290`, `Community 291`, `Community 302`, `Community 307`, `Community 314`, `Community 323`, `Community 330`, `Community 371`, `Community 372`, `Community 384`, `Community 386`, `Community 415`, `Community 419`, `Community 422`, `Community 431`, `Community 435`, `Community 448`, `Community 462`, `Community 498`?**
+  _High betweenness centrality (0.026) - this node is a cross-community bridge._
 - **What connects `$id`, `$schema`, `additionalProperties` to the rest of the system?**
   _1316 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.042869057547956634 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.043025921354258506 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.08182349503214495 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.08973172987974098 - nodes in this community are weakly interconnected._
 - **Should `Community 2` be split into smaller, more focused modules?**
   _Cohesion score 0.11510204081632654 - nodes in this community are weakly interconnected._

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
-# Graph Report - SHAFT_ENGINE  (2026-06-18)
+# Graph Report - SHAFT_ENGINE_perf_cleanups  (2026-06-18)
 
 ## Corpus Check
-- 1260 files · ~531,007 words
+- 882 files · ~501,109 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 12006 nodes · 30360 edges · 671 communities (598 shown, 73 thin omitted)
-- Extraction: 80% EXTRACTED · 20% INFERRED · 0% AMBIGUOUS · INFERRED: 6010 edges (avg confidence: 0.8)
+- 12003 nodes · 30359 edges · 683 communities (601 shown, 82 thin omitted)
+- Extraction: 80% EXTRACTED · 20% INFERRED · 0% AMBIGUOUS · INFERRED: 6023 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `0de651f9`
+- Built from commit: `f3c1362f`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -589,9 +589,21 @@
 - [[_COMMUNITY_Community 578|Community 578]]
 - [[_COMMUNITY_Community 579|Community 579]]
 - [[_COMMUNITY_Community 669|Community 669]]
+- [[_COMMUNITY_Community 671|Community 671]]
+- [[_COMMUNITY_Community 672|Community 672]]
+- [[_COMMUNITY_Community 673|Community 673]]
+- [[_COMMUNITY_Community 674|Community 674]]
+- [[_COMMUNITY_Community 675|Community 675]]
+- [[_COMMUNITY_Community 676|Community 676]]
+- [[_COMMUNITY_Community 677|Community 677]]
+- [[_COMMUNITY_Community 678|Community 678]]
+- [[_COMMUNITY_Community 679|Community 679]]
+- [[_COMMUNITY_Community 680|Community 680]]
+- [[_COMMUNITY_Community 681|Community 681]]
+- [[_COMMUNITY_Community 682|Community 682]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `SHAFT` - 270 edges
+1. `SHAFT` - 271 edges
 2. `RestActionsComprehensiveTests` - 99 edges
 3. `Test` - 98 edges
 4. `IOException` - 97 edges
@@ -617,59 +629,59 @@
 ## Import Cycles
 - None detected.
 
-## Communities (671 total, 73 thin omitted)
+## Communities (683 total, 82 thin omitted)
 
 ### Community 0 - "Community 0"
 Cohesion: 0.04
-Nodes (6): RestActionsComprehensiveTests, ComparisonType, InputStream, SuppressWarnings, BeforeMethod, Test
+Nodes (6): RestActionsComprehensiveTests, GraphqlRequestTests, ComparisonType, InputStream, SuppressWarnings, Test
 
 ### Community 1 - "Community 1"
-Cohesion: 0.05
-Nodes (18): ChannelSftp, TerminalActions, LocalShellTests, ProcessBuilder, Session, SftpTransferDirection, Boolean, BufferedReader (+10 more)
+Cohesion: 0.07
+Nodes (5): Deprecated, AfterMethod, SuppressWarnings, Test, TerminalActionsUnitTest
 
 ### Community 2 - "Community 2"
-Cohesion: 0.06
-Nodes (51): DoctorCli, flag(), optionalPath(), parse(), path(), pathRequired(), paths(), pathsRequired() (+43 more)
+Cohesion: 0.13
+Nodes (22): DoctorAnalyzerTest, empty(), disabled(), defaults(), lower(), normalizePath(), Proposal, CapturePrivacyPolicy (+14 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.06
-Nodes (35): $, Cucumber, CucumberHelper, StandaloneAssertions, StandaloneVerifications, WebDriverAssertions, WebDriverVerifications, WizardHelpers (+27 more)
+Nodes (25): Cucumber, CucumberHelper, Mobile, SetProperty, PropertiesManagerTests, CucumberTests, List, Status (+17 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.07
 Nodes (6): Pilot, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 5 - "Community 5"
-Cohesion: 0.06
-Nodes (30): AndroidDriver, FileUploadDownloadTest, getValue(), KeyboardKeys(), TouchActions, ElementActionsHelper, ImmutableMap, IOSDriver (+22 more)
+Cohesion: 0.11
+Nodes (13): FileUploadDownloadTest, ElementActionsHelper, IOSDriver, Test, AfterMethod, BeforeMethod, RemoteWebDriver, Runnable (+5 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.06
 Nodes (14): CSVFileManager, CSVFileManagerTest, List, Map, String, BeforeMethod, Test, AfterMethod (+6 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.08
-Nodes (30): ArtifactPaths, AssertionSuggestion, CaptureGenerationReport, CaptureGenerator, failure(), withUnsupported(), GenerationState, Sequence (+22 more)
+Cohesion: 0.06
+Nodes (42): AlertEvent, ArtifactPaths, AssertionSuggestion, CaptureGenerationReport, DataPlan, CaptureGenerator, failure(), MutableTargetPlan (+34 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.05
 Nodes (25): ApiPerformanceExecutionReport, Paths, SetProperty, Performance, SetProperty, PathsTests, DefaultValue, Key (+17 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.06
-Nodes (16): Jira, SetProperty, Mobile, SetProperty, PropertiesManagerTests, JiraTests, DefaultValue, Key (+8 more)
+Cohesion: 0.25
+Nodes (4): Jira, DefaultValue, Key, SetProperty
 
 ### Community 10 - "Community 10"
 Cohesion: 0.07
 Nodes (23): BrowserStackSdkHelper, BrowserStackSdkTests, List, Map, Object, String, AfterMethod, BeforeMethod (+15 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.08
-Nodes (15): AsyncAppender, ReportManagerHelper, TestCaseStarted, Boolean, ByteArrayOutputStream, CheckpointStatus, InputStream, Level (+7 more)
+Cohesion: 0.09
+Nodes (13): AsyncAppender, ReportManagerHelper, RunType, CheckpointStatus, InputStream, Level, List, Object (+5 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.09
-Nodes (23): KeyboardKeys, LocatorOperation, MobileService, McpMobileAccessibilityTree, McpMobileActionResult, McpMobileContextSnapshot, McpMobileSessionResult, BrowserType (+15 more)
+Nodes (26): Autowired, LocatorOperation, MobileService, McpMobileAccessibilityTree, McpMobileActionResult, McpMobileContextSnapshot, McpMobileRecordingService, McpMobileSessionResult (+18 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.07
@@ -688,56 +700,56 @@ Cohesion: 0.10
 Nodes (67): CompletedProcess, adoptium_os_arch(), application_data_root(), architecture(), await_probe_response(), choose_client(), command_path(), configuration_path() (+59 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.08
-Nodes (24): HealingSupport, WebDriverListener, InvocationTargetException, nativePlatform(), Navigation, Alert, By, Method (+16 more)
+Cohesion: 0.07
+Nodes (29): HealingSupport, Properties, WebDriverListener, InvocationTargetException, Navigation, Alert, By, Method (+21 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.07
-Nodes (16): AfterSuite, ApiPerformanceReportTest, SwaggerContractTest, testPostRequest, TestUpload, ParametersType, AfterMethod, BeforeMethod (+8 more)
+Cohesion: 0.06
+Nodes (21): AfterSuite, ApiPerformanceReportTest, PathParamTest, SwaggerContractTest, TestUpload, Map, ParametersType, AfterMethod (+13 more)
 
 ### Community 19 - "Community 19"
 Cohesion: 0.08
-Nodes (21): RequestBuilder, RequestBuilderTests, AuthenticationType, API, ContentType, Exception, Map, Object (+13 more)
+Nodes (20): RequestBuilder, RequestBuilderTests, AuthenticationType, API, ContentType, Exception, Object, RequestSpecification (+12 more)
 
 ### Community 20 - "Community 20"
-Cohesion: 0.09
-Nodes (29): dataString(), E, LocatorSignal, empty(), merge(), MouseButton, CaptureEventPipeline, SafePage (+21 more)
+Cohesion: 0.15
+Nodes (16): dataString(), E, LocatorSignal, empty(), merge(), MouseButton, CaptureEventPipeline, SafePage (+8 more)
 
 ### Community 21 - "Community 21"
-Cohesion: 0.05
-Nodes (17): WebDriverElementValidationsBuilder, GuiVerificationTests, By, NativeValidationsBuilder, String, StringBuilder, ValidationCategory, ValidationsExecutor (+9 more)
+Cohesion: 0.09
+Nodes (13): WebDriverElementValidationsBuilder, GuiVerificationTests, By, NativeValidationsBuilder, String, StringBuilder, ValidationCategory, ValidationsExecutor (+5 more)
 
 ### Community 22 - "Community 22"
-Cohesion: 0.06
-Nodes (15): NativeValidationsBuilder, FileValidationsBuilder, Object, Override, RestValidationsBuilder, String, SuppressWarnings, ValidationsBuilder (+7 more)
+Cohesion: 0.08
+Nodes (7): Object, Override, SuppressWarnings, ValidationsExecutor, AfterMethod, Test, NativeValidationsBuilderUnitTest
 
 ### Community 23 - "Community 23"
-Cohesion: 0.07
-Nodes (27): empty(), DoctorHashing, disabled(), Metadata, asCacheHit(), disabled(), empty(), defaults() (+19 more)
+Cohesion: 0.24
+Nodes (5): List, Set, String, Test, TelemetryDeduplicationUnitTest
 
 ### Community 24 - "Community 24"
-Cohesion: 0.07
-Nodes (9): TextDirectionValidationsBuilder, E2ECoverageTests, NativeValidationsBuilder, ValidationsExecutor, AfterMethod, BeforeMethod, Test, TextDirection (+1 more)
+Cohesion: 0.05
+Nodes (17): NativeValidationsBuilder, TextDirectionValidationsBuilder, E2ECoverageTests, FileValidationsBuilder, RestValidationsBuilder, String, ValidationsBuilder, WebDriverBrowserValidationsBuilder (+9 more)
 
 ### Community 25 - "Community 25"
-Cohesion: 0.07
-Nodes (16): PathParamTest, BasicAPITests, GraphqlRequestTests, AfterClass, BeforeClass, Test, AfterClass, BeforeClass (+8 more)
+Cohesion: 0.17
+Nodes (4): AfterClass, BeforeClass, Test, APITests
 
 ### Community 26 - "Community 26"
-Cohesion: 0.10
-Nodes (24): AllureSnapshot, AllureVerdict, DoctorRepairPublicationRequest, ExistingPullRequest, PatchManifestEntry, changedSince(), DoctorRepairService, validationPassed() (+16 more)
+Cohesion: 0.11
+Nodes (23): AllureSnapshot, AllureVerdict, DoctorRepairPublicationRequest, ExistingPullRequest, PatchManifestEntry, changedSince(), DoctorRepairService, RepairGuard (+15 more)
 
 ### Community 27 - "Community 27"
-Cohesion: 0.12
-Nodes (14): FileActions, Boolean, Collection, File, InputStream, String, SuppressWarnings, TerminalActions (+6 more)
+Cohesion: 0.14
+Nodes (13): FileActions, Boolean, Collection, File, InputStream, String, SuppressWarnings, URL (+5 more)
 
 ### Community 28 - "Community 28"
-Cohesion: 0.08
-Nodes (14): DriverFactoryHelperCoverageUnitTest, TestableDriverFactoryHelper, AfterMethod, AtomicInteger, CountDownLatch, DriverFactoryHelper, DriverType, Method (+6 more)
+Cohesion: 0.07
+Nodes (15): DriverFactoryHelperCoverageUnitTest, TestableDriverFactoryHelper, OptionsManager, AfterMethod, AtomicInteger, CountDownLatch, DriverFactoryHelper, DriverType (+7 more)
 
 ### Community 29 - "Community 29"
-Cohesion: 0.10
-Nodes (11): OptionsManagerCoverageUnitTest, MobileRecordingServiceTest, Role, Override, AfterMethod, BeforeMethod, Test, AfterMethod (+3 more)
+Cohesion: 0.11
+Nodes (11): CaptureServiceTest, MobileRecordingServiceTest, Role, Override, AfterMethod, Test, CaptureService, Path (+3 more)
 
 ### Community 30 - "Community 30"
 Cohesion: 0.08
@@ -748,8 +760,8 @@ Cohesion: 0.09
 Nodes (11): AfterMethod, BeforeMethod, Class, List, Object, Path, String, T (+3 more)
 
 ### Community 33 - "Community 33"
-Cohesion: 0.10
-Nodes (15): AccessibilityConfig, AccessibilityHelper, AccessibilityResult, AxeBuilder, JSONArray, JSONObject, AccessibilityResult, Integer (+7 more)
+Cohesion: 0.13
+Nodes (13): AccessibilityConfig, AccessibilityHelper, JSONArray, JSONObject, AccessibilityResult, Integer, List, Map (+5 more)
 
 ### Community 34 - "Community 34"
 Cohesion: 0.08
@@ -760,16 +772,16 @@ Cohesion: 0.08
 Nodes (27): DeterministicNaturalActionPlanner, unsupported(), NaturalActionPlannerRegistry, PilotNaturalActionPlanner, NaturalActionKind, NaturalActionPlanner, NaturalActionStep, List (+19 more)
 
 ### Community 36 - "Community 36"
-Cohesion: 0.07
-Nodes (28): DataTableArgument, EmbedEvent, HookTestStep, CucumberFeatureListener, Parameter, PickleStepTestStep, Result, Scenario (+20 more)
+Cohesion: 0.06
+Nodes (30): DataTableArgument, EmbedEvent, HookTestStep, CucumberFeatureListener, Parameter, PickleStepTestStep, Result, Scenario (+22 more)
 
 ### Community 37 - "Community 37"
 Cohesion: 0.10
 Nodes (7): AfterMethod, Class, Object, Path, String, Test, AllureManagerUnitTest
 
 ### Community 38 - "Community 38"
-Cohesion: 0.08
-Nodes (14): RestValidationsBuilder, JsonCompareWithSpecialCharactersTests, NativeValidationsBuilder, NumberValidationsBuilder, Object, String, StringBuilder, ValidationCategory (+6 more)
+Cohesion: 0.13
+Nodes (5): NumberValidationsBuilder, AfterMethod, BeforeClass, Test, RestValidationsBuilderUnitTest
 
 ### Community 39 - "Community 39"
 Cohesion: 0.08
@@ -780,43 +792,43 @@ Cohesion: 0.12
 Nodes (23): DoctorAiAnalysisService, ConfigurationIdentity, AiRequest, AiResponse, AiResponseStatus, AiUsage, CauseCategory, Diagnosis (+15 more)
 
 ### Community 41 - "Community 41"
-Cohesion: 0.07
-Nodes (13): AssertApiResponseEqualsTests, MatchJsonSchemaTests, ApiActionsMockedTests, RequestBuilder, Test, Test, AfterMethod, BeforeMethod (+5 more)
+Cohesion: 0.08
+Nodes (11): AssertApiResponseEqualsTests, ApiActionsMockedTests, RequestBuilder, Test, AfterMethod, BeforeMethod, Test, AfterClass (+3 more)
 
 ### Community 42 - "Community 42"
 Cohesion: 0.06
-Nodes (19): SHAFT, FileInputStream, AppiumMobileConsumer, BrowserStackSdkConsumer, JUnitWebConsumer, LegacyCoordinateConsumer, TestNgWebConsumer, IOException (+11 more)
+Nodes (20): testPostRequest, SHAFT, FileInputStream, AppiumMobileConsumer, BrowserStackSdkConsumer, LegacyCoordinateConsumer, AiCandidateRerankerTest, IOException (+12 more)
 
 ### Community 43 - "Community 43"
 Cohesion: 0.08
-Nodes (24): Constructor, IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, IResultListener2 (+16 more)
+Nodes (25): Constructor, IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, IResultListener2 (+17 more)
 
 ### Community 44 - "Community 44"
-Cohesion: 0.15
+Cohesion: 0.16
 Nodes (8): AssertionSteps, PDFTests, ValidationsBuilderTests, String, Then, ThreadLocal, WebDriver, String
 
 ### Community 45 - "Community 45"
-Cohesion: 0.16
-Nodes (16): CollectionState, EvidenceCollector, FilesSize, CollectionState, DoctorRedactor, DefaultPrettyPrinter, DoctorAnalysisRequest, EvidenceBundle (+8 more)
+Cohesion: 0.17
+Nodes (15): CollectionState, EvidenceCollector, CollectionState, DoctorRedactor, DefaultPrettyPrinter, DoctorAnalysisRequest, EvidenceBundle, EvidenceCategory (+7 more)
 
 ### Community 46 - "Community 46"
-Cohesion: 0.09
-Nodes (19): CaptureFixtures, CaptureJsonCodecTest, CaptureGeneratorTest, PageContext, BrowserMetadata, CaptureEvent, CaptureSession, ElementSnapshot (+11 more)
+Cohesion: 0.13
+Nodes (15): CaptureFixtures, CaptureGeneratorTest, PageContext, BrowserMetadata, CaptureEvent, CaptureSession, ElementSnapshot, EventContext (+7 more)
 
 ### Community 47 - "Community 47"
-Cohesion: 0.09
-Nodes (8): ThreadLocalPropertiesManager, Properties, String, AfterMethod, Path, String, Test, ThreadLocalPropertiesTest
+Cohesion: 0.13
+Nodes (5): AfterMethod, Path, String, Test, ThreadLocalPropertiesTest
 
 ### Community 48 - "Community 48"
 Cohesion: 0.13
 Nodes (16): RestActions, RequestSpecBuilder, RestAssuredConfig, API, ArrayNode, Boolean, ContentType, List (+8 more)
 
 ### Community 49 - "Community 49"
-Cohesion: 0.10
-Nodes (12): ImageProcessingActionsCoverageUnitTest, AfterMethod, BeforeMethod, BufferedImage, Color, DataProvider, Map, Method (+4 more)
+Cohesion: 0.07
+Nodes (21): ImageProcessingActions, ImageProcessingActionsCoverageUnitTest, Boolean, By, File, Integer, List, String (+13 more)
 
 ### Community 50 - "Community 50"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (4): AllureManager, Path, Process, String
 
 ### Community 51 - "Community 51"
@@ -828,20 +840,20 @@ Cohesion: 0.04
 Nodes (47): additionalProperties, minLength, type, maximum, minimum, type, type, minLength (+39 more)
 
 ### Community 53 - "Community 53"
-Cohesion: 0.16
-Nodes (12): AttachmentFormat, AttachmentReporter, ByteArrayOutputStream, Path, String, SuppressWarnings, ByteArrayOutputStream, Severity (+4 more)
+Cohesion: 0.07
+Nodes (31): AttachmentFormat, Date, CaptureJsonCodec, DoctorJsonCodec, InputStream, AttachmentReporter, CaptureSession, JsonNode (+23 more)
 
 ### Community 54 - "Community 54"
-Cohesion: 0.09
-Nodes (10): BrowserActions, Cookie, DriverFactoryHelper, Override, Screenshots, Set, String, SuppressWarnings (+2 more)
+Cohesion: 0.10
+Nodes (7): BrowserActions, Cookie, Override, Screenshots, Set, String, SuppressWarnings
 
 ### Community 55 - "Community 55"
-Cohesion: 0.12
+Cohesion: 0.13
 Nodes (14): Capabilities, DriverFactoryHelper, Class, DriverType, List, MutableCapabilities, Object, Runnable (+6 more)
 
 ### Community 56 - "Community 56"
-Cohesion: 0.10
-Nodes (17): ElementLookup, GetElementInformation, Actions, NoSuchElementException, AppiumDriver, DriverFactoryHelper, Duration, Function (+9 more)
+Cohesion: 0.21
+Nodes (5): ElementLookup, GetElementInformation, Actions, JavascriptExecutor, WebElement
 
 ### Community 57 - "Community 57"
 Cohesion: 0.08
@@ -856,20 +868,20 @@ Cohesion: 0.11
 Nodes (13): List, Color, Rectangle, AfterMethod, BeforeMethod, Color, Map, Method (+5 more)
 
 ### Community 60 - "Community 60"
-Cohesion: 0.09
-Nodes (8): SetProperty, Timeouts, Boolean, DefaultValue, Deprecated, Key, SetProperty, String
+Cohesion: 0.15
+Nodes (3): SetProperty, Deprecated, String
 
 ### Community 61 - "Community 61"
 Cohesion: 0.13
 Nodes (21): ExchangeHandler, FailureCase, ExchangeHandler, ProviderConformanceTest, AfterEach, AiProvider, AiRequest, AiResponse (+13 more)
 
 ### Community 62 - "Community 62"
-Cohesion: 0.10
-Nodes (23): DoctorRepairProposalResult, DoctorRepairService, HealingLocatorProposalRequest, DoctorService, DoctorServiceTest, McpDoctorRemediationService, ApprovalPolicy, Diagnosis (+15 more)
+Cohesion: 0.14
+Nodes (19): DoctorRepairProposalResult, DoctorRepairService, HealingLocatorProposalRequest, DoctorService, McpDoctorRemediationService, ApprovalPolicy, Diagnosis, DoctorAnalysisResult (+11 more)
 
 ### Community 63 - "Community 63"
-Cohesion: 0.15
-Nodes (9): ClipboardAction, GetElementInformation, ActionType, Beta, By, ClipboardAction, Override, Step (+1 more)
+Cohesion: 0.17
+Nodes (7): ClipboardAction, GetElementInformation, ActionType, By, ClipboardAction, Override, Step
 
 ### Community 64 - "Community 64"
 Cohesion: 0.12
@@ -877,10 +889,10 @@ Nodes (16): ActionsCoverageUnitTest, RecordingActions, RecordingActions, ActionT
 
 ### Community 65 - "Community 65"
 Cohesion: 0.12
-Nodes (15): AllureListenerCoverageUnitTest, Throwable, AfterMethod, BeforeMethod, ITestResult, List, Path, String (+7 more)
+Nodes (14): AllureListenerCoverageUnitTest, Throwable, AfterMethod, BeforeMethod, ITestResult, List, Path, String (+6 more)
 
 ### Community 66 - "Community 66"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (11): ContainerLifecycleListener, FixtureLifecycleListener, FixtureResult, AllureListener, AllureLifecycle, Override, TestResult, StepLifecycleListener (+3 more)
 
 ### Community 67 - "Community 67"
@@ -888,8 +900,8 @@ Cohesion: 0.11
 Nodes (11): COSDocument, DeleteFileAfterValidationStatus, PdfFileManager, PDFParser, RandomAccessReadBufferedFile, File, String, AfterMethod (+3 more)
 
 ### Community 68 - "Community 68"
-Cohesion: 0.15
-Nodes (20): McpDoctorRemediationService, McpActionRecord, ProviderBlocks, AiRequest, AiResponse, ApprovalPolicy, Diagnosis, DoctorAnalysisResult (+12 more)
+Cohesion: 0.06
+Nodes (42): CaptureService, McpDoctorRemediationService, McpMobileRecordingService, McpActionRecord, McpCaptureCodeBlockService, McpCaptureReplayResult, McpMobileRecording, PreDestroy (+34 more)
 
 ### Community 69 - "Community 69"
 Cohesion: 0.05
@@ -904,28 +916,28 @@ Cohesion: 0.05
 Nodes (42): additionalProperties, default, description, examples, $id, title, type, default (+34 more)
 
 ### Community 72 - "Community 72"
-Cohesion: 0.10
-Nodes (11): UnitTestsRestActions, UnitTestsSHAFT, HealingActionsIntegrationTest, AfterMethod, BeforeMethod, DataProvider, Object, String (+3 more)
+Cohesion: 0.18
+Nodes (7): HealingActionsIntegrationTest, AfterMethod, BeforeMethod, DataProvider, Object, String, Test
 
 ### Community 73 - "Community 73"
 Cohesion: 0.11
 Nodes (41): expand_globs(), issue(), local_link_targets(), markdown_body(), normalized_paragraphs(), parse_frontmatter(), quoted_yaml_value(), Keep the consolidated guidance below the approved baseline reduction. (+33 more)
 
 ### Community 74 - "Community 74"
-Cohesion: 0.18
-Nodes (14): ElementActionsHelper, TextDetectionStrategy(), Boolean, By, Class, ClipboardAction, HealingResolution, List (+6 more)
+Cohesion: 0.21
+Nodes (11): ElementActionsHelper, TextDetectionStrategy(), Boolean, By, ClipboardAction, HealingResolution, List, Object (+3 more)
 
 ### Community 75 - "Community 75"
 Cohesion: 0.15
 Nodes (19): CaptureControlClient, CaptureCli, flag(), parse(), path(), pathRequired(), required(), value() (+11 more)
 
 ### Community 76 - "Community 76"
-Cohesion: 0.13
-Nodes (15): ShaftHeal, ShaftHealingProviderTest, HealingReport, Optional, AfterMethod, AppiumDriver, BeforeMethod, DataProvider (+7 more)
+Cohesion: 0.06
+Nodes (29): ChromeOptions, ShaftHeal, ShaftHealingProviderTest, WebDomHealingAcceptanceTest, MoonTests, AfterEach, BeforeEach, String (+21 more)
 
 ### Community 77 - "Community 77"
-Cohesion: 0.11
-Nodes (3): SetProperty, Boolean, String
+Cohesion: 0.08
+Nodes (7): LambdaTest, SetProperty, Boolean, DefaultValue, Key, SetProperty, String
 
 ### Community 78 - "Community 78"
 Cohesion: 0.12
@@ -936,16 +948,16 @@ Cohesion: 0.05
 Nodes (40): additionalProperties, enum, pattern, type, pattern, type, items, type (+32 more)
 
 ### Community 80 - "Community 80"
-Cohesion: 0.10
-Nodes (12): DriverFactoryHelper, OptionsManager, AfterMethod, AtomicInteger, CountDownLatch, DriverType, Method, MutableCapabilities (+4 more)
+Cohesion: 0.09
+Nodes (14): ChromiumOptions, DesiredCapabilities, DriverFactoryHelper, LoggingPreferences, AfterMethod, AtomicInteger, CountDownLatch, DriverType (+6 more)
 
 ### Community 81 - "Community 81"
-Cohesion: 0.10
-Nodes (11): IIOMetadataNode, AnimatedGifManager, GifSession, ImageOutputStream, ImageWriter, getType(), RenderedImage, Screenshots (+3 more)
+Cohesion: 0.12
+Nodes (9): IIOMetadataNode, AnimatedGifManager, GifSession, ImageOutputStream, ImageWriter, RenderedImage, BufferedImage, String (+1 more)
 
 ### Community 82 - "Community 82"
-Cohesion: 0.23
-Nodes (13): ValidationsHelper2, LinkedHashMap, AssertionError, By, List, Number, NumbersComparativeRelation, Object (+5 more)
+Cohesion: 0.18
+Nodes (14): SilentElementReader, ValidationsHelper2, LinkedHashMap, AssertionError, By, List, Number, NumbersComparativeRelation (+6 more)
 
 ### Community 83 - "Community 83"
 Cohesion: 0.13
@@ -956,12 +968,12 @@ Cohesion: 0.05
 Nodes (39): additionalProperties, type, maximum, minimum, type, additionalProperties, properties, required (+31 more)
 
 ### Community 86 - "Community 86"
-Cohesion: 0.14
-Nodes (14): ClassifiedUpload, CapturePrivacyClassifier, CapturePrivacyClassifierTest, SanitizedAttributes, SanitizedText, CapturePrivacyPolicy, ClassifiedValue, List (+6 more)
+Cohesion: 0.18
+Nodes (11): ClassifiedUpload, CapturePrivacyClassifier, SanitizedAttributes, SanitizedText, CapturePrivacyPolicy, ClassifiedValue, List, Map (+3 more)
 
 ### Community 87 - "Community 87"
-Cohesion: 0.10
-Nodes (15): HasCdp, Image, ScreenshotHelper, ScreenshotHelperCoverageUnitTest, Boolean, BufferedImage, String, SuppressWarnings (+7 more)
+Cohesion: 0.15
+Nodes (10): HasCdp, Image, ScreenshotHelperCoverageUnitTest, BufferedImage, AfterMethod, BeforeMethod, Color, Object (+2 more)
 
 ### Community 88 - "Community 88"
 Cohesion: 0.05
@@ -972,15 +984,15 @@ Cohesion: 0.07
 Nodes (14): be(), Bt(), Dt(), $e(), Ee(), ft(), ke(), l() (+6 more)
 
 ### Community 90 - "Community 90"
-Cohesion: 0.14
-Nodes (10): ElementActions, Actions, By, DriverFactoryHelper, List, Map, Override, String (+2 more)
+Cohesion: 0.13
+Nodes (9): ElementActions, Actions, By, DriverFactoryHelper, Override, String, SuppressWarnings, WebDriver (+1 more)
 
 ### Community 91 - "Community 91"
-Cohesion: 0.16
-Nodes (17): CandidateExtractor, LocatorProposal, validateUrl(), SearchContext, String, By, Collection, HealingConfiguration (+9 more)
+Cohesion: 0.15
+Nodes (18): CandidateExtractor, LocatorProposal, nativePlatform(), validateUrl(), SearchContext, String, By, Collection (+10 more)
 
 ### Community 92 - "Community 92"
-Cohesion: 0.09
+Cohesion: 0.08
 Nodes (11): LocatorBuilder, JDK21VirtualThreadsAndAsyncActionsTests, RelativeBy, ArrayList, By, Role, String, SuppressWarnings (+3 more)
 
 ### Community 93 - "Community 93"
@@ -996,20 +1008,20 @@ Cohesion: 0.15
 Nodes (15): AiExecutionServiceTest, StubProvider, denyAll(), AiCapabilities, AiExecutionService, AiProviderAvailability, AiProviderRegistry, AiRequest (+7 more)
 
 ### Community 96 - "Community 96"
-Cohesion: 0.17
-Nodes (18): DoctorAiAnalysisServiceTest, EnumSource, from(), DoctorAnalysisResult, DoctorAnalysisSummary, AiRequest, AiResponse, AiResponseStatus (+10 more)
+Cohesion: 0.20
+Nodes (15): DoctorAiAnalysisServiceTest, EnumSource, AiRequest, AiResponse, AiResponseStatus, Diagnosis, DoctorAiAnalysisService, EvidenceBundle (+7 more)
 
 ### Community 97 - "Community 97"
-Cohesion: 0.19
-Nodes (11): AlertActionsContext, AfterMethod, Alert, AlertActions, BeforeMethod, Object, String, Test (+3 more)
+Cohesion: 0.13
+Nodes (16): AlertActionsContext, AlertActions, DriverFactoryHelper, String, SuppressWarnings, WebDriver, AfterMethod, Alert (+8 more)
 
 ### Community 98 - "Community 98"
 Cohesion: 0.13
 Nodes (11): FluentWait, ElementsHelperCoverageUnitTest, MockedStatic, AfterMethod, BeforeMethod, DriverFactoryHelper, MockedConstruction, RuntimeException (+3 more)
 
 ### Community 99 - "Community 99"
-Cohesion: 0.11
-Nodes (11): PropertyFileManager, File, HashMap, Map, Object, Properties, String, AfterMethod (+3 more)
+Cohesion: 0.08
+Nodes (15): PropertyFileManager, ThreadLocalPropertiesManager, File, HashMap, Map, MutableCapabilities, Object, Properties (+7 more)
 
 ### Community 100 - "Community 100"
 Cohesion: 0.20
@@ -1028,15 +1040,15 @@ Cohesion: 0.11
 Nodes (14): DriverFactory, DriverType(), DatabaseActions, DatabaseType, DriverFactoryHelper, DriverType, MutableCapabilities, RestActions (+6 more)
 
 ### Community 104 - "Community 104"
-Cohesion: 0.13
-Nodes (6): Healing, SetProperty, DefaultValue, Key, SetProperty, String
+Cohesion: 0.27
+Nodes (4): Healing, DefaultValue, Key, SetProperty
 
 ### Community 105 - "Community 105"
-Cohesion: 0.15
-Nodes (4): LambdaTest, DefaultValue, Key, SetProperty
+Cohesion: 0.14
+Nodes (11): ChannelSftp, TerminalActions, ProcessBuilder, Session, SftpTransferDirection, Boolean, BufferedReader, List (+3 more)
 
 ### Community 106 - "Community 106"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (10): AfterMethod, BeforeMethod, Issue, Issues, ITestResult, String, Test, TmsLink (+2 more)
 
 ### Community 107 - "Community 107"
@@ -1048,7 +1060,7 @@ Cohesion: 0.10
 Nodes (35): add_text_child(), child_text(), copy_dependency_metadata(), create_dependency(), dependency_coordinate(), dependency_template(), direct_child(), elements_named() (+27 more)
 
 ### Community 109 - "Community 109"
-Cohesion: 0.13
+Cohesion: 0.12
 Nodes (12): CapturePrivacyClassifier, ManagedCaptureRecorder, BrowserMetadata, CapturePrivacyPolicy, CaptureStartRequest, CaptureStatus, CheckpointKind, Map (+4 more)
 
 ### Community 110 - "Community 110"
@@ -1056,8 +1068,8 @@ Cohesion: 0.13
 Nodes (3): YAMLFileManagerTests, BeforeMethod, Test
 
 ### Community 111 - "Community 111"
-Cohesion: 0.14
-Nodes (15): LauncherSession, Override, AfterMethod, BeforeMethod, Duration, List, Object, Optional (+7 more)
+Cohesion: 0.13
+Nodes (17): getType(), LauncherSession, Screenshots, Override, AfterMethod, BeforeMethod, Duration, List (+9 more)
 
 ### Community 112 - "Community 112"
 Cohesion: 0.18
@@ -1088,16 +1100,16 @@ Cohesion: 0.07
 Nodes (31): deleteObject, deleteRelation, markStale, supersedeObject, additionalProperties, properties, required, type (+23 more)
 
 ### Community 119 - "Community 119"
-Cohesion: 0.18
-Nodes (10): AccessibilityHelperCoverageUnitTest, AfterMethod, List, MockedConstruction, Path, Results, Rule, String (+2 more)
+Cohesion: 0.17
+Nodes (11): AccessibilityHelperCoverageUnitTest, AxeBuilder, AfterMethod, List, MockedConstruction, Path, Results, Rule (+3 more)
 
 ### Community 120 - "Community 120"
-Cohesion: 0.10
-Nodes (15): IOSBasicInteractionsTest, ElementActions, Test_LTMobIPAAppURL, Test_LTMobIPARelativePath, AfterMethod, BeforeMethod, SuppressWarnings, Test (+7 more)
+Cohesion: 0.29
+Nodes (5): Test_LTMobIPAAppURL, AfterMethod, BeforeMethod, String, Test
 
 ### Community 121 - "Community 121"
 Cohesion: 0.11
-Nodes (14): ChromeOptions, WebDomHealingAcceptanceTest, MoonTests, AfterEach, BeforeEach, String, Test, WebDriver (+6 more)
+Nodes (18): getValue(), KeyboardKeys(), TouchActions, ImmutableMap, KeyboardKeys, By, DriverFactoryHelper, File (+10 more)
 
 ### Community 122 - "Community 122"
 Cohesion: 0.17
@@ -1108,55 +1120,55 @@ Cohesion: 0.16
 Nodes (8): IAssert, CustomSoftAssert, AssertionError, Override, String, Test, SoftAssert, CustomSoftAssertTest
 
 ### Community 124 - "Community 124"
-Cohesion: 0.11
-Nodes (11): TestNGListenerHelper, ISuite, ITestContext, ITestNGMethod, ITestResult, List, Method, String (+3 more)
+Cohesion: 0.13
+Nodes (10): TestNGListenerHelper, ISuite, ITestContext, ITestNGMethod, ITestResult, List, Method, String (+2 more)
 
 ### Community 125 - "Community 125"
-Cohesion: 0.14
-Nodes (4): AfterMethod, BeforeClass, Test, JSONFileManagerUnitTest
+Cohesion: 0.06
+Nodes (20): DataType, FileReader, JSONFileManager, JSONFileManagerTestAccessor, JSONFileManagerTests, List, Map, Object (+12 more)
 
 ### Community 126 - "Community 126"
 Cohesion: 0.17
 Nodes (12): ITestNGService, AfterMethod, ITestNGMethod, ITestResult, List, Object, String, SuppressWarnings (+4 more)
 
 ### Community 127 - "Community 127"
-Cohesion: 0.19
-Nodes (15): RecordingRunner, DoctorRepairServiceTest, RecordingRunner, RepairProcessRunner, RepositoryFixture, DoctorRepairRequest, Duration, FilePatch (+7 more)
+Cohesion: 0.17
+Nodes (16): RecordingRunner, DoctorRepairServiceTest, RecordingRunner, validationPassed(), RepairProcessRunner, RepositoryFixture, DoctorRepairRequest, Duration (+8 more)
 
 ### Community 128 - "Community 128"
 Cohesion: 0.12
 Nodes (5): AfterMethod, Runnable, String, Test, ValidationHelperUnitTest
 
 ### Community 129 - "Community 129"
-Cohesion: 0.10
-Nodes (20): Autowired, Bean, BrowserService, ElementService, ShaftMcpApplication, ShaftMcpApplicationTests, McpMobileRecordingService, MobileService (+12 more)
+Cohesion: 0.17
+Nodes (12): Bean, BrowserService, ElementService, ShaftMcpApplication, MobileService, NaturalActionService, CaptureService, DoctorService (+4 more)
 
 ### Community 130 - "Community 130"
 Cohesion: 0.13
 Nodes (3): ActionsCoverageTests, BeforeMethod, Test
 
 ### Community 131 - "Community 131"
-Cohesion: 0.13
-Nodes (9): Browser, BasicAuthenticationTests, CoverageTests, Test, AfterClass, AfterMethod, BeforeClass, BeforeMethod (+1 more)
+Cohesion: 0.07
+Nodes (19): Browser, BasicAuthenticationTests, NetworkInterceptionTest, ShadowDomTest, CoverageTests, HoverTests, Test, Test (+11 more)
 
 ### Community 132 - "Community 132"
 Cohesion: 0.14
 Nodes (14): BadRequestException, CaptureControlServer, Handler, Handler, CaptureControlFiles, CaptureManager, CaptureStatus, Class (+6 more)
 
 ### Community 133 - "Community 133"
-Cohesion: 0.12
-Nodes (13): ImageProcessingActions, VisualProcessingProviderRegistry, Boolean, By, File, Integer, List, String (+5 more)
+Cohesion: 0.33
+Nodes (4): VisualProcessingProviderRegistry, List, Optional, VisualProcessingProvider
 
 ### Community 134 - "Community 134"
-Cohesion: 0.15
-Nodes (13): AlphaProvider, VisualProcessingProviderRegistryTest, ZuluProvider, AfterMethod, Boolean, By, Integer, List (+5 more)
+Cohesion: 0.11
+Nodes (16): BomConsumer, AlphaProvider, VisualProcessingProviderRegistryTest, ZuluProvider, AfterMethod, Boolean, By, Integer (+8 more)
 
 ### Community 135 - "Community 135"
-Cohesion: 0.19
-Nodes (12): ScreenshotManager, Object, Boolean, By, JavascriptExecutor, List, Object, Screenshots (+4 more)
+Cohesion: 0.21
+Nodes (11): ScreenshotManager, Boolean, By, JavascriptExecutor, List, Object, Screenshots, SneakyThrows (+3 more)
 
 ### Community 136 - "Community 136"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (9): Platform, SetProperty, PlatformTests, DefaultValue, Key, SetProperty, String, BeforeClass (+1 more)
 
 ### Community 137 - "Community 137"
@@ -1164,20 +1176,20 @@ Cohesion: 0.11
 Nodes (25): build_parser(), confirm_upgrade(), coordinates_have_supported_runner(), log(), main(), OpenAIRepairClient, print_analysis(), ProjectAnalysis (+17 more)
 
 ### Community 138 - "Community 138"
-Cohesion: 0.20
-Nodes (4): AccessibilityTest, AfterMethod, BeforeMethod, Test
+Cohesion: 0.12
+Nodes (11): AccessibilityActions, AccessibilityConfig, AccessibilityTest, AccessibilityResult, BrowserActions, List, String, WebDriver (+3 more)
 
 ### Community 139 - "Community 139"
 Cohesion: 0.11
 Nodes (17): builder(), evidenceCategories(), withSanitizedContent(), withTimeout(), AiAuditSink, ShaftAiAuditSink, AiRequest, ApprovalPolicy (+9 more)
 
 ### Community 140 - "Community 140"
-Cohesion: 0.15
-Nodes (7): API, JSON, YAML, List, Object, RequestBuilder, String
+Cohesion: 0.08
+Nodes (15): CSVFileManager, API, CSV, EXCEL, JSON, Report, YAML, InputStream (+7 more)
 
 ### Community 141 - "Community 141"
-Cohesion: 0.15
-Nodes (18): HealingProvider, ShaftHealingProvider, HealingActionOutcome, HealingCandidate, HealingContext, HealingDecision, HealingExplanation, HealingObservation (+10 more)
+Cohesion: 0.09
+Nodes (25): HealingProvider, HealingReportWriter, ShaftHealingProvider, safe(), stableKey(), HealingConfiguration, HealingReport, String (+17 more)
 
 ### Community 142 - "Community 142"
 Cohesion: 0.17
@@ -1200,16 +1212,16 @@ Cohesion: 0.14
 Nodes (14): DecisionResult, DeterministicScorerTest, HealingDecisionEngine, HealingConfiguration, List, RankedCandidate, Status, String (+6 more)
 
 ### Community 147 - "Community 147"
-Cohesion: 0.18
-Nodes (13): DoctorRepairPatchResult, DoctorRepairAiService, AiRequest, AiResponse, AiResponseStatus, Diagnosis, DoctorRepairAiRequest, EvidenceReference (+5 more)
+Cohesion: 0.10
+Nodes (33): DoctorCli, flag(), optionalPath(), parse(), path(), pathRequired(), paths(), pathsRequired() (+25 more)
 
 ### Community 148 - "Community 148"
 Cohesion: 0.19
 Nodes (7): FluentWebDriverAction, Actions, AlertActions, BrowserActions, DriverFactoryHelper, TouchActions, WebDriver
 
 ### Community 149 - "Community 149"
-Cohesion: 0.12
-Nodes (10): ProgressBarLoggerTestAccessor, ValidationsHelperTestAccessor, ArrayList, By, List, String, SuppressWarnings, AfterMethod (+2 more)
+Cohesion: 0.22
+Nodes (4): ProgressBarLoggerTestAccessor, AfterMethod, Test, ValidationAndProgressBarTests
 
 ### Community 150 - "Community 150"
 Cohesion: 0.17
@@ -1220,12 +1232,12 @@ Cohesion: 0.27
 Nodes (8): FingerprintExtractor, HealingConfiguration, LocatorFingerprint, Map, String, Supplier, WebDriver, WebElement
 
 ### Community 152 - "Community 152"
-Cohesion: 0.17
+Cohesion: 0.18
 Nodes (10): ManagedCaptureRecorder, CaptureManager, CaptureStartRequest, CaptureStatus, CheckpointKind, Function, Override, State (+2 more)
 
 ### Community 153 - "Community 153"
-Cohesion: 0.16
-Nodes (12): McpMobileRecordingService, McpMobileRecording, List, locatorStrategy, Map, McpCodeBlock, McpMobileRecordedAction, McpMobileRecordingStatus (+4 more)
+Cohesion: 0.13
+Nodes (4): AfterMethod, BeforeMethod, Test, NegativeValidationsTests
 
 ### Community 154 - "Community 154"
 Cohesion: 0.08
@@ -1240,16 +1252,16 @@ Cohesion: 0.13
 Nodes (7): AndroidBasicInteractionsTests, AndroidDragAndDropTest, MobileTest, Test, Test, AfterMethod, BeforeMethod
 
 ### Community 157 - "Community 157"
-Cohesion: 0.10
-Nodes (15): AsyncElementActions, Async, CLI, GUI, Locator, Properties, TestData, Validations (+7 more)
+Cohesion: 0.33
+Nodes (3): Validations, StandaloneAssertions, StandaloneVerifications
 
 ### Community 158 - "Community 158"
-Cohesion: 0.12
-Nodes (12): API, SetProperty, Properties, DefaultValue, Key, SetProperty, String, Class (+4 more)
+Cohesion: 0.19
+Nodes (6): API, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 159 - "Community 159"
-Cohesion: 0.15
-Nodes (3): PropertiesHelper, RunType, String
+Cohesion: 0.10
+Nodes (6): PropertiesHelper, String, AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
 
 ### Community 160 - "Community 160"
 Cohesion: 0.28
@@ -1264,8 +1276,8 @@ Cohesion: 0.16
 Nodes (3): AfterMethod, Test, ValidationsBuilderUnitTest
 
 ### Community 163 - "Community 163"
-Cohesion: 0.21
-Nodes (8): AlertEvent, DataPlan, EventContext, ExternalTestDataReference, StringBuilder, VerificationKind, WaitEvent, WindowEvent
+Cohesion: 0.22
+Nodes (5): Timeouts, Boolean, DefaultValue, Key, SetProperty
 
 ### Community 164 - "Community 164"
 Cohesion: 0.24
@@ -1276,8 +1288,8 @@ Cohesion: 0.20
 Nodes (6): CheckpointType, CheckpointCounter, CheckpointStatus, String, Test, CheckpointAndReportingTest
 
 ### Community 166 - "Community 166"
-Cohesion: 0.19
-Nodes (9): ChromiumOptions, DesiredCapabilities, OptionsManager, LoggingPreferences, DriverType, MutableCapabilities, String, SuppressWarnings (+1 more)
+Cohesion: 0.16
+Nodes (9): OptionsManager, OptionsManagerCoverageUnitTest, DriverType, MutableCapabilities, String, SuppressWarnings, AfterMethod, BeforeMethod (+1 more)
 
 ### Community 167 - "Community 167"
 Cohesion: 0.15
@@ -1288,11 +1300,11 @@ Cohesion: 0.17
 Nodes (10): BrowserEventScript, PollingBrowserEventCollector, String, BrowserSignal, Consumer, Object, Override, Set (+2 more)
 
 ### Community 169 - "Community 169"
-Cohesion: 0.18
-Nodes (5): AsyncElementActions, By, ClipboardAction, DriverFactoryHelper, String
+Cohesion: 0.20
+Nodes (3): AsyncElementActions, By, String
 
 ### Community 170 - "Community 170"
-Cohesion: 0.23
+Cohesion: 0.21
 Nodes (7): TestNG, TestNGTests, DefaultValue, Integer, Key, String, Test
 
 ### Community 171 - "Community 171"
@@ -1336,28 +1348,28 @@ Cohesion: 0.20
 Nodes (13): AiCandidateReranker, RerankResult, AiExecutionService, Double, HealingConfiguration, JsonNode, List, Map (+5 more)
 
 ### Community 182 - "Community 182"
-Cohesion: 0.21
-Nodes (10): CaptureService, McpCaptureCodeBlockService, McpCaptureReplayResult, PreDestroy, CaptureGenerationResult, CaptureManager, CaptureStatus, McpWorkspacePolicy (+2 more)
+Cohesion: 0.17
+Nodes (9): WebDriverAssertions, WebDriverVerifications, WizardHelpers, By, DriverFactoryHelper, NativeValidationsBuilder, Object, WebDriverBrowserValidationsBuilder (+1 more)
 
 ### Community 183 - "Community 183"
 Cohesion: 0.12
 Nodes (22): minLength, type, properties, $ref, $ref, $ref, body, evidence (+14 more)
 
 ### Community 184 - "Community 184"
-Cohesion: 0.19
-Nodes (11): AfterMethod, BeforeMethod, By, ElementActions, List, Object, Runnable, String (+3 more)
+Cohesion: 0.15
+Nodes (14): List, Map, Map, AfterMethod, BeforeMethod, By, ElementActions, List (+6 more)
 
 ### Community 185 - "Community 185"
 Cohesion: 0.17
 Nodes (3): AfterMethod, Test, TextDirectionValidationsBuilderUnitTest
 
 ### Community 186 - "Community 186"
-Cohesion: 0.12
-Nodes (15): AccessibilityActions, AccessibilityConfig, AccessibilityResult, BrowserActions, List, String, WebDriver, AccessibilityResult (+7 more)
+Cohesion: 0.22
+Nodes (8): AccessibilityResult, AfterMethod, BeforeMethod, List, Rule, String, Test, AccessibilityActionsCoverageUnitTest
 
 ### Community 187 - "Community 187"
-Cohesion: 0.10
-Nodes (10): Async, WebDriver, Actions, AlertActions, BrowserActions, DriverType, MutableCapabilities, TouchActions (+2 more)
+Cohesion: 0.07
+Nodes (18): Async, AsyncElementActions, Async, CLI, GUI, Locator, Properties, TestData (+10 more)
 
 ### Community 188 - "Community 188"
 Cohesion: 0.12
@@ -1365,7 +1377,7 @@ Nodes (4): CommandResult, command_result(), FakeRepairClient, UpgradeToModularSh
 
 ### Community 189 - "Community 189"
 Cohesion: 0.16
-Nodes (8): FileReader, JSONFileManagerTestAccessor, List, Map, SuppressWarnings, AfterMethod, Test, MemoryLeakFixTests
+Nodes (11): AppiumDriver, Beta, DriverFactoryHelper, Duration, Function, Map, Object, Rectangle (+3 more)
 
 ### Community 190 - "Community 190"
 Cohesion: 0.24
@@ -1376,8 +1388,8 @@ Cohesion: 0.24
 Nodes (7): HealingScore, DeterministicScorer, Double, HealingConfiguration, LocatorFingerprint, Map, String
 
 ### Community 192 - "Community 192"
-Cohesion: 0.18
-Nodes (6): ElementInformation, ElementInformationCoverageUnitTest, Element, List, String, Test
+Cohesion: 0.17
+Nodes (7): ElementInformation, ElementInformationCoverageUnitTest, Element, List, Object, String, Test
 
 ### Community 193 - "Community 193"
 Cohesion: 0.19
@@ -1412,12 +1424,12 @@ Cohesion: 0.18
 Nodes (3): AfterMethod, Test, RestActionsUtilsUnitTest
 
 ### Community 201 - "Community 201"
-Cohesion: 0.38
-Nodes (5): ready(), unavailable(), AiProviderAvailability, AiProviderAvailability, String
+Cohesion: 0.27
+Nodes (4): RestValidationsBuilder, NativeValidationsBuilder, String, ValidationsExecutor
 
 ### Community 202 - "Community 202"
-Cohesion: 0.19
-Nodes (8): DataType, JSONFileManager, JSONFileManagerTests, Object, String, Test, Test, WizardTestDataTests
+Cohesion: 0.21
+Nodes (11): DeterministicRuleEngine, DoctorAnalyzer, DoctorAiAnalysisResult, DoctorReportWriter, EvidenceCollector, DoctorAiAnalysisRequest, DoctorAiAnalysisService, DoctorAnalysisRequest (+3 more)
 
 ### Community 203 - "Community 203"
 Cohesion: 0.14
@@ -1460,8 +1472,8 @@ Cohesion: 0.10
 Nodes (20): pattern, type, pattern, type, properties, body_path, created_at, status (+12 more)
 
 ### Community 213 - "Community 213"
-Cohesion: 0.22
-Nodes (11): CaptureEvent, CaptureJsonCodec, CaptureSession, Checkpoint, ExternalTestDataReference, Instant, List, Path (+3 more)
+Cohesion: 0.11
+Nodes (29): append(), checkpoint(), complete(), ensureIncomplete(), interrupt(), sortedCheckpoints(), sortedEvents(), sortedReferences() (+21 more)
 
 ### Community 214 - "Community 214"
 Cohesion: 0.13
@@ -1470,10 +1482,6 @@ Nodes (6): Boolean, By, NumbersComparativeRelation, Object, String, JavaHelper
 ### Community 215 - "Community 215"
 Cohesion: 0.20
 Nodes (4): AfterMethod, BeforeMethod, Test, BrowserActionsTests
-
-### Community 216 - "Community 216"
-Cohesion: 0.21
-Nodes (4): AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
 
 ### Community 217 - "Community 217"
 Cohesion: 0.15
@@ -1484,20 +1492,20 @@ Cohesion: 0.17
 Nodes (10): PilotTestConfiguration, RedactionPolicy, RedactionResult, Redactor, AiRequest, Set, String, PilotConfiguration (+2 more)
 
 ### Community 219 - "Community 219"
-Cohesion: 0.16
-Nodes (7): AutoCloseable, ProgressBarLogger, ProgressBarLoggerCoverageUnitTest, Override, String, AfterMethod, Test
+Cohesion: 0.33
+Nodes (3): ProgressBarLoggerCoverageUnitTest, AfterMethod, Test
 
 ### Community 220 - "Community 220"
-Cohesion: 0.28
+Cohesion: 0.27
 Nodes (6): Config, List, String, SuppressWarnings, Test, XrayIntegrationHelper
 
 ### Community 221 - "Community 221"
-Cohesion: 0.20
-Nodes (8): CucumberFeatureListener, Class, Object, String, SuppressWarnings, Test, TableRow, CucumberFeatureListenerUnitTest
+Cohesion: 0.24
+Nodes (7): CucumberFeatureListener, Class, Object, String, SuppressWarnings, Test, CucumberFeatureListenerUnitTest
 
 ### Community 222 - "Community 222"
-Cohesion: 0.16
-Nodes (9): DesktopVideoRecordingProvider, AfterMethod, BeforeMethod, InputStream, Override, String, Test, RecordManagerDesktopProviderTest (+1 more)
+Cohesion: 0.31
+Nodes (4): AfterMethod, BeforeMethod, Test, RecordManagerDesktopProviderTest
 
 ### Community 223 - "Community 223"
 Cohesion: 0.29
@@ -1516,20 +1524,16 @@ Cohesion: 0.20
 Nodes (6): NaturalActions, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 227 - "Community 227"
-Cohesion: 0.26
-Nodes (4): Visuals, DefaultValue, Key, SetProperty
+Cohesion: 0.13
+Nodes (6): SetProperty, Visuals, DefaultValue, Key, SetProperty, String
 
 ### Community 229 - "Community 229"
 Cohesion: 0.23
 Nodes (5): ThreadSafeGuiWizardTests, AfterMethod, BeforeMethod, SuppressWarnings, Test
 
-### Community 230 - "Community 230"
-Cohesion: 0.22
-Nodes (18): append(), checkpoint(), complete(), ensureIncomplete(), interrupt(), sortedCheckpoints(), sortedEvents(), sortedReferences() (+10 more)
-
 ### Community 231 - "Community 231"
-Cohesion: 0.16
-Nodes (6): AfterTest, BeforeTest, ConfigurationHelper, ReportHelper, ITestContext, Step
+Cohesion: 0.31
+Nodes (5): AfterTest, BeforeTest, ConfigurationHelper, ITestContext, Step
 
 ### Community 232 - "Community 232"
 Cohesion: 0.15
@@ -1551,9 +1555,17 @@ Nodes (7): LocatorRanker, ScoredLocator, ElementSnapshot, EventContext, LocatorC
 Cohesion: 0.19
 Nodes (10): current(), HealingStrategy(), parse(), usesHealenium(), usesShaftHeal(), HealingStrategyTest, String, AfterMethod (+2 more)
 
+### Community 237 - "Community 237"
+Cohesion: 0.13
+Nodes (6): Allure, SetProperty, DefaultValue, Key, SetProperty, String
+
 ### Community 238 - "Community 238"
-Cohesion: 0.27
-Nodes (4): Allure, DefaultValue, Key, SetProperty
+Cohesion: 0.18
+Nodes (11): CaptureEvent, CapturePrivacyPolicy, CaptureSessionStore, Consumer, ExternalTestDataReference, Instant, List, Map (+3 more)
+
+### Community 239 - "Community 239"
+Cohesion: 0.31
+Nodes (4): ScreenshotHelper, Boolean, SuppressWarnings, WebDriver
 
 ### Community 240 - "Community 240"
 Cohesion: 0.25
@@ -1564,16 +1576,16 @@ Cohesion: 0.20
 Nodes (4): ValidationsMockedTests, AfterMethod, BeforeMethod, Test
 
 ### Community 242 - "Community 242"
-Cohesion: 0.31
-Nodes (5): HealingLocatorProposalService, HealingLocatorProposal, JsonNode, Path, String
+Cohesion: 0.16
+Nodes (11): HealingLocatorProposalService, HealingLocatorProposalServiceTest, HealingLocatorProposal, JsonNode, Path, String, AfterEach, BeforeEach (+3 more)
 
 ### Community 243 - "Community 243"
 Cohesion: 0.21
 Nodes (6): AfterMethod, Class, Object, String, Test, BrowserStackHelperUnitTest
 
 ### Community 244 - "Community 244"
-Cohesion: 0.20
-Nodes (3): BeforeMethod, Test, LogRedirectorUnitTest
+Cohesion: 0.08
+Nodes (20): LogRedirector, Logger, apply(), applyEnabled(), current(), NaturalActionService, textOrDefault(), withOverrides() (+12 more)
 
 ### Community 246 - "Community 246"
 Cohesion: 0.20
@@ -1604,12 +1616,12 @@ Cohesion: 0.18
 Nodes (6): BrowserSteps, Given, String, ThreadLocal, WebDriver, When
 
 ### Community 253 - "Community 253"
-Cohesion: 0.24
-Nodes (5): EXCEL, ExcelFileManager, TestDataTests, String, Test
+Cohesion: 0.21
+Nodes (7): StandaloneAssertions, StandaloneVerifications, FileValidationsBuilder, Number, NumberValidationsBuilder, String, ValidationsExecutor
 
 ### Community 254 - "Community 254"
-Cohesion: 0.28
-Nodes (7): LambdaTestHelper, Boolean, DriverFactoryHelper, HashMap, MutableCapabilities, Object, String
+Cohesion: 0.14
+Nodes (10): LambdaTestHelper, Boolean, DriverFactoryHelper, HashMap, MutableCapabilities, Object, String, AfterMethod (+2 more)
 
 ### Community 255 - "Community 255"
 Cohesion: 0.25
@@ -1622,10 +1634,6 @@ Nodes (4): IOActionsMockedTests, AfterMethod, BeforeMethod, Test
 ### Community 258 - "Community 258"
 Cohesion: 0.24
 Nodes (8): NaturalActionExecutorTest, AfterMethod, BeforeMethod, By, List, Test, WebDriver, WebElement
-
-### Community 259 - "Community 259"
-Cohesion: 0.33
-Nodes (6): HealingLocatorProposalServiceTest, AfterEach, BeforeEach, Path, String, Test
 
 ### Community 260 - "Community 260"
 Cohesion: 0.26
@@ -1648,7 +1656,7 @@ Cohesion: 0.21
 Nodes (4): AfterClass, BeforeClass, Test, FileHelperUnitTest
 
 ### Community 265 - "Community 265"
-Cohesion: 0.23
+Cohesion: 0.24
 Nodes (3): RestActionsCoverageUnitTest, AfterMethod, Test
 
 ### Community 266 - "Community 266"
@@ -1656,44 +1664,44 @@ Cohesion: 0.22
 Nodes (11): BooleanSupplier, expired(), InstantDeadline(), ManagedCaptureRecorderBrowserTest, Duration, HttpExchange, HttpServer, ParameterizedTest (+3 more)
 
 ### Community 267 - "Community 267"
-Cohesion: 0.15
-Nodes (6): List, AfterMethod, BeforeMethod, Test, BrowserActionsCoverageUnitTest, Window
+Cohesion: 0.17
+Nodes (5): List, AfterMethod, BeforeMethod, Test, BrowserActionsCoverageUnitTest
 
 ### Community 268 - "Community 268"
 Cohesion: 0.21
 Nodes (9): fixture_commands(), main(), maven_executable(), missing_publication_paths(), publication_paths(), verify_release(), write_settings(), Path (+1 more)
 
 ### Community 269 - "Community 269"
-Cohesion: 0.14
-Nodes (22): BrowsingContextInfo, BidiBrowserEventCollector, copy(), dataBoolean(), dataInt(), dataStrings(), fromJson(), generated() (+14 more)
+Cohesion: 0.29
+Nodes (15): copy(), dataBoolean(), dataInt(), dataStrings(), fromJson(), generated(), longValue(), map() (+7 more)
 
 ### Community 270 - "Community 270"
-Cohesion: 0.24
+Cohesion: 0.27
 Nodes (7): CaptureControlClient, CaptureStatus, CheckpointKind, List, Object, Path, String
 
 ### Community 271 - "Community 271"
-Cohesion: 0.18
-Nodes (5): FrameTests, SuppressWarnings, AfterMethod, BeforeMethod, Test
+Cohesion: 0.24
+Nodes (4): FrameTests, AfterMethod, BeforeMethod, Test
 
 ### Community 272 - "Community 272"
-Cohesion: 0.25
-Nodes (13): apply(), applyEnabled(), current(), NaturalActionService, textOrDefault(), withOverrides(), McpNaturalActionResult, NaturalActionSettings (+5 more)
+Cohesion: 0.29
+Nodes (4): CaptureJsonCodecTest, Path, String, Test
 
 ### Community 274 - "Community 274"
 Cohesion: 0.21
 Nodes (9): AiProvider, DoctorSnippetProvider, AfterEach, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse, Override (+1 more)
 
 ### Community 275 - "Community 275"
-Cohesion: 0.25
-Nodes (6): FileActionsCoverageUnitTest, AfterMethod, BeforeMethod, Path, String, Test
+Cohesion: 0.15
+Nodes (9): FileActionsCoverageUnitTest, FileActionsReflectionInvoker, AfterMethod, BeforeMethod, Path, String, Test, FileActions (+1 more)
 
 ### Community 276 - "Community 276"
-Cohesion: 0.21
-Nodes (7): Date, InputStream, Override, Path, Test, CloseTrackingInputStream, ReportManagerHelperAttachmentIoUnitTest
+Cohesion: 0.27
+Nodes (6): ValidationsHelperTestAccessor, ArrayList, By, List, String, SuppressWarnings
 
 ### Community 277 - "Community 277"
-Cohesion: 0.20
-Nodes (8): FileChannel, FileLock, CaptureRuntimePortabilityTest, CaptureSingleSessionLock, Override, Path, Path, Test
+Cohesion: 0.29
+Nodes (6): AutoCloseable, FileChannel, FileLock, CaptureSingleSessionLock, Override, Path
 
 ### Community 278 - "Community 278"
 Cohesion: 0.20
@@ -1704,8 +1712,8 @@ Cohesion: 0.16
 Nodes (9): HealingProvider, HealingActionOutcome, HealingExplanation, HealingObservation, HealingRequest, HealingResolution, Optional, String (+1 more)
 
 ### Community 280 - "Community 280"
-Cohesion: 0.19
-Nodes (7): HealingVisualProvider, OpenCvHealingVisualProvider, OpenCvHealingVisualProviderTest, Override, String, Color, Test
+Cohesion: 0.18
+Nodes (7): OpenCvVisualConsumer, HealingVisualProvider, OpenCvHealingVisualProvider, Override, String, Mat, String
 
 ### Community 281 - "Community 281"
 Cohesion: 0.27
@@ -1720,12 +1728,12 @@ Cohesion: 0.13
 Nodes (15): type, uniqueItems, enum, additionalProperties, properties, required, type, enum (+7 more)
 
 ### Community 284 - "Community 284"
-Cohesion: 0.17
-Nodes (12): enum, facets, additionalProperties, properties, required, type, enum, items (+4 more)
+Cohesion: 0.13
+Nodes (15): type, uniqueItems, enum, facets, additionalProperties, properties, required, type (+7 more)
 
 ### Community 285 - "Community 285"
 Cohesion: 0.17
-Nodes (12): type, items, properties, required, type, content, redacted, relativePath (+4 more)
+Nodes (12): type, properties, minLength, type, content, mediaType, redacted, relativePath (+4 more)
 
 ### Community 286 - "Community 286"
 Cohesion: 0.13
@@ -1736,8 +1744,8 @@ Cohesion: 0.20
 Nodes (7): AfterMethod, InputStream, Override, String, Test, DesktopVideoRecordingProviderRegistryTest, StubDesktopVideoRecordingProvider
 
 ### Community 288 - "Community 288"
-Cohesion: 0.23
-Nodes (5): AfterMethod, BeforeMethod, Path, Test, ExcelFileManagerCoverageUnitTest
+Cohesion: 0.10
+Nodes (12): ExcelFileManager, TestDataTests, String, Test, AfterMethod, BeforeMethod, Path, Test (+4 more)
 
 ### Community 290 - "Community 290"
 Cohesion: 0.21
@@ -1748,8 +1756,8 @@ Cohesion: 0.24
 Nodes (3): AndroidTouchActionsTests, ScreenOrientation, Test
 
 ### Community 292 - "Community 292"
-Cohesion: 0.25
-Nodes (6): Callable, Path, Test, Test, CaptureSessionStoreTest, RestActionsFailureLoggingUnitTest
+Cohesion: 0.21
+Nodes (7): Callable, FilesSize, Path, Test, Test, CaptureSessionStoreTest, RestActionsFailureLoggingUnitTest
 
 ### Community 293 - "Community 293"
 Cohesion: 0.19
@@ -1760,8 +1768,8 @@ Cohesion: 0.22
 Nodes (7): ElementStepsCoverageUnitTest, BeforeMethod, By, DataProvider, Object, String, Test
 
 ### Community 295 - "Community 295"
-Cohesion: 0.32
-Nodes (5): CaptureJsonCodec, CaptureSession, JsonNode, Path, String
+Cohesion: 0.35
+Nodes (5): BasicAPITests, BeforeClass, List, Map, String
 
 ### Community 296 - "Community 296"
 Cohesion: 0.29
@@ -1784,16 +1792,16 @@ Cohesion: 0.26
 Nodes (6): ModelSupport, JsonNode, List, Map, String, T
 
 ### Community 301 - "Community 301"
-Cohesion: 0.12
-Nodes (17): items, type, uniqueItems, tags, items, additionalProperties, minLength, pattern (+9 more)
+Cohesion: 0.14
+Nodes (14): items, tags, items, additionalProperties, minLength, pattern, properties, required (+6 more)
 
 ### Community 302 - "Community 302"
 Cohesion: 0.23
 Nodes (6): InputStream, Path, String, SuppressWarnings, WebDriver, RecordManager
 
 ### Community 303 - "Community 303"
-Cohesion: 0.25
-Nodes (3): AfterMethod, Test, LambdaTestHelperUnitTest
+Cohesion: 0.27
+Nodes (3): UnitTestsSHAFT, TerminalActions, Test
 
 ### Community 304 - "Community 304"
 Cohesion: 0.25
@@ -1808,8 +1816,8 @@ Cohesion: 0.14
 Nodes (13): additionalProperties, type, type, properties, body, id, title, userId (+5 more)
 
 ### Community 307 - "Community 307"
-Cohesion: 0.27
-Nodes (7): AccessibilityActions, HttpRequest, HttpResponse, NetworkInterceptionTest, Predicate, Step, Test
+Cohesion: 0.18
+Nodes (9): AccessibilityActions, HttpRequest, HttpResponse, NavigationAction, DriverFactoryHelper, Predicate, Step, WebDriver (+1 more)
 
 ### Community 308 - "Community 308"
 Cohesion: 0.23
@@ -1832,8 +1840,8 @@ Cohesion: 0.21
 Nodes (7): WebDriverBrowserValidationsBuilder, NativeValidationsBuilder, String, StringBuilder, SuppressWarnings, ValidationCategory, WebDriver
 
 ### Community 314 - "Community 314"
-Cohesion: 0.26
-Nodes (8): LauncherSessionListener, JunitListener, Status, String, TestIdentifier, Throwable, StatusIcon, TestExecutionResult
+Cohesion: 0.23
+Nodes (9): $, LauncherSessionListener, JunitListener, Status, String, TestIdentifier, Throwable, StatusIcon (+1 more)
 
 ### Community 315 - "Community 315"
 Cohesion: 0.26
@@ -1872,8 +1880,8 @@ Cohesion: 0.27
 Nodes (4): LocalApiTestServer, HttpExchange, HttpServer, String
 
 ### Community 324 - "Community 324"
-Cohesion: 0.30
-Nodes (5): AlertActions, DriverFactoryHelper, String, SuppressWarnings, WebDriver
+Cohesion: 0.39
+Nodes (4): DoctorServiceTest, DoctorService, Path, Test
 
 ### Community 325 - "Community 325"
 Cohesion: 0.30
@@ -1896,7 +1904,7 @@ Cohesion: 0.29
 Nodes (7): Description, AfterMethod, BeforeClass, BeforeMethod, Step, Test, FluentGuiActionsTest
 
 ### Community 330 - "Community 330"
-Cohesion: 0.17
+Cohesion: 0.23
 Nodes (5): Future, ArrayNode, InputStream, List, ObjectNode
 
 ### Community 331 - "Community 331"
@@ -1906,6 +1914,10 @@ Nodes (6): CaptureGeneratedReplayBrowserTest, CaptureSession, ElementSnapshot, E
 ### Community 332 - "Community 332"
 Cohesion: 0.23
 Nodes (8): VisualProcessingProvider, Boolean, By, Integer, List, String, VisualValidationEngine, WebDriver
+
+### Community 333 - "Community 333"
+Cohesion: 0.18
+Nodes (4): ActionsExceptionDetailsUnitTest, NoSuchElementException, List, Test
 
 ### Community 334 - "Community 334"
 Cohesion: 0.18
@@ -1932,12 +1944,12 @@ Cohesion: 0.29
 Nodes (4): DragAndDropTests, AfterMethod, BeforeMethod, Test
 
 ### Community 340 - "Community 340"
-Cohesion: 0.29
+Cohesion: 0.24
 Nodes (3): EngineServiceTest, AfterEach, Test
 
 ### Community 341 - "Community 341"
-Cohesion: 0.33
-Nodes (4): HoverTests, AfterMethod, BeforeMethod, Test
+Cohesion: 0.27
+Nodes (5): IOSBasicInteractionsTest, AfterMethod, BeforeMethod, SuppressWarnings, Test
 
 ### Community 342 - "Community 342"
 Cohesion: 0.32
@@ -1960,8 +1972,8 @@ Cohesion: 0.17
 Nodes (12): type, scope, pattern, type, branch, project, task, additionalProperties (+4 more)
 
 ### Community 347 - "Community 347"
-Cohesion: 0.33
-Nodes (5): $id, required, $schema, title, type
+Cohesion: 0.13
+Nodes (14): items, type, $id, required, type, properties, evidence, redaction (+6 more)
 
 ### Community 348 - "Community 348"
 Cohesion: 0.26
@@ -2004,8 +2016,8 @@ Cohesion: 0.25
 Nodes (4): DatabaseActions, DB, DatabaseType, ResultSet
 
 ### Community 359 - "Community 359"
-Cohesion: 0.25
-Nodes (6): AiCandidateRerankerTest, AfterMethod, HealingConfiguration, HttpExchange, String, Test
+Cohesion: 0.47
+Nodes (3): CapturePrivacyClassifierTest, Path, Test
 
 ### Community 360 - "Community 360"
 Cohesion: 0.18
@@ -2026,10 +2038,6 @@ Nodes (4): GroupsTests, AfterMethod, BeforeMethod, Test
 ### Community 364 - "Community 364"
 Cohesion: 0.29
 Nodes (5): SelectMethodTests, AfterMethod, BeforeMethod, String, Test
-
-### Community 365 - "Community 365"
-Cohesion: 0.31
-Nodes (3): NavigationAction, Test, NavigationActionUnitTest
 
 ### Community 366 - "Community 366"
 Cohesion: 0.29
@@ -2096,12 +2104,12 @@ Cohesion: 0.40
 Nodes (3): UploadFileTests, String, Test
 
 ### Community 384 - "Community 384"
-Cohesion: 0.27
-Nodes (4): ShadowDomTest, AfterMethod, BeforeMethod, Test
+Cohesion: 0.31
+Nodes (4): AfterMethod, String, Test, PropertiesHelperInitializationUnitTest
 
 ### Community 385 - "Community 385"
-Cohesion: 0.38
-Nodes (4): CaptureServiceTest, CaptureService, Path, Test
+Cohesion: 0.36
+Nodes (3): ProgressBarLogger, Override, String
 
 ### Community 386 - "Community 386"
 Cohesion: 0.40
@@ -2144,27 +2152,23 @@ Cohesion: 0.20
 Nodes (9): Alternative: Email, Dependency Security, Disclosure Policy, Preferred: GitHub Private Security Advisory, Reporting a Vulnerability, Response Timeline, Scope, Security Policy (+1 more)
 
 ### Community 396 - "Community 396"
-Cohesion: 0.29
-Nodes (5): AfterEach, BeforeAll, BeforeEach, Test, TestClass
+Cohesion: 0.13
+Nodes (11): AndroidDriver, AfterEach, BeforeAll, BeforeEach, Test, TestClass, AfterMethod, BeforeClass (+3 more)
 
 ### Community 397 - "Community 397"
-Cohesion: 0.29
-Nodes (5): AfterMethod, BeforeClass, BeforeMethod, Test, TestClass
-
-### Community 398 - "Community 398"
-Cohesion: 0.33
-Nodes (3): BeforeClass, Test, IoExcelFileManagerTests
+Cohesion: 0.36
+Nodes (4): Test_LTMobIPARelativePath, AfterMethod, BeforeMethod, Test
 
 ### Community 399 - "Community 399"
 Cohesion: 0.31
 Nodes (4): AfterMethod, Object, Test, LambdaTestSetPropertyCoverageUnitTest
 
 ### Community 400 - "Community 400"
-Cohesion: 0.31
-Nodes (4): AfterMethod, BeforeMethod, Test, VisualValidationTests
+Cohesion: 0.24
+Nodes (5): String, AfterMethod, BeforeMethod, Test, VisualValidationTests
 
 ### Community 401 - "Community 401"
-Cohesion: 0.31
+Cohesion: 0.29
 Nodes (4): Actions, ValidationsHelper2CoverageUnitTest, AfterMethod, Test
 
 ### Community 402 - "Community 402"
@@ -2187,9 +2191,13 @@ Nodes (8): 📝 Additional Notes, 📋 Description, Documentation Site, Evidence
 Cohesion: 0.28
 Nodes (5): JSONValidationsBuilder, NativeValidationsBuilder, Object, RestValidationsBuilder, ValidationsExecutor
 
+### Community 407 - "Community 407"
+Cohesion: 0.24
+Nodes (3): JunitListenerHelper, TestIdentifier, Boolean
+
 ### Community 408 - "Community 408"
-Cohesion: 0.39
-Nodes (4): LogRedirector, Logger, Level, Override
+Cohesion: 0.43
+Nodes (4): ShaftMcpApplicationTests, Set, String, Test
 
 ### Community 409 - "Community 409"
 Cohesion: 0.22
@@ -2204,12 +2212,12 @@ Cohesion: 0.33
 Nodes (4): Test_LTWebAppRealme, AfterMethod, BeforeMethod, Test
 
 ### Community 412 - "Community 412"
-Cohesion: 0.36
-Nodes (4): ChecksumTests, Path, String, Test
+Cohesion: 0.24
+Nodes (5): ChecksumTests, TerminalActions, Path, String, Test
 
 ### Community 413 - "Community 413"
 Cohesion: 0.33
-Nodes (6): parse_xml(), Parse XML while preserving comments., Return version property, direct SHAFT dependencies, and managed BOM version., Enforce the modular SHAFT dependency contract after every repair., shaft_dependency_state(), validate_upgraded_poms()
+Nodes (6): Metadata, asCacheHit(), disabled(), empty(), DoctorAdvisory, ProviderAnalysis
 
 ### Community 414 - "Community 414"
 Cohesion: 0.47
@@ -2244,7 +2252,7 @@ Cohesion: 0.29
 Nodes (5): AfterEach, BeforeAll, BeforeEach, Test, TestClass
 
 ### Community 424 - "Community 424"
-Cohesion: 0.29
+Cohesion: 0.31
 Nodes (5): AfterMethod, BeforeClass, BeforeMethod, Test, TestClass
 
 ### Community 425 - "Community 425"
@@ -2273,18 +2281,18 @@ Nodes (5): DoctorFormatException, ProfileCleanupException, RuntimeException, Str
 
 ### Community 432 - "Community 432"
 Cohesion: 0.32
-Nodes (4): MutableTargetPlan, ElementSnapshot, LocatorCandidate, LocatorSelection
+Nodes (5): DesktopVideoRecordingProvider, InputStream, Override, String, StubDesktopVideoRecordingProvider
 
 ### Community 433 - "Community 433"
 Cohesion: 0.25
 Nodes (7): Diagnosis, Evidence Index, Findings, Missing Evidence, Privacy, Remediation, SHAFT Doctor Report
 
 ### Community 435 - "Community 435"
-Cohesion: 0.36
-Nodes (4): HealingReportWriter, HealingConfiguration, HealingReport, String
+Cohesion: 0.43
+Nodes (3): AfterMethod, Test, ProjectStructureManagerTest
 
 ### Community 436 - "Community 436"
-Cohesion: 0.39
+Cohesion: 0.33
 Nodes (3): ReportManager, Level, String
 
 ### Community 437 - "Community 437"
@@ -2327,12 +2335,8 @@ Nodes (4): IsElementClickableTest, AfterMethod, BeforeMethod, Test
 Cohesion: 0.36
 Nodes (4): LazyLoadingTests, AfterMethod, BeforeMethod, Test
 
-### Community 447 - "Community 447"
-Cohesion: 0.36
-Nodes (4): RelativeLocatorsTests, AfterMethod, BeforeMethod, Test
-
 ### Community 448 - "Community 448"
-Cohesion: 0.36
+Cohesion: 0.38
 Nodes (4): RemoteGridVideoAttachmentIT, AfterMethod, BeforeMethod, Test
 
 ### Community 449 - "Community 449"
@@ -2391,9 +2395,13 @@ Nodes (4): RetryAnalyzer, IRetryAnalyzer, ITestResult, Override
 Cohesion: 0.43
 Nodes (3): MobileEmulationTests, AfterMethod, Test
 
+### Community 465 - "Community 465"
+Cohesion: 0.22
+Nodes (5): TableTests, String, AfterMethod, BeforeMethod, Tests
+
 ### Community 466 - "Community 466"
-Cohesion: 0.38
-Nodes (3): AfterMethod, BeforeMethod, Tests
+Cohesion: 0.53
+Nodes (3): CaptureRuntimePortabilityTest, Path, Test
 
 ### Community 467 - "Community 467"
 Cohesion: 0.43
@@ -2438,14 +2446,6 @@ Nodes (5): option(), ProviderConfiguration(), Map, String, URI
 ### Community 477 - "Community 477"
 Cohesion: 0.40
 Nodes (4): MultipleElementsFoundException, String, Throwable, WebDriverException
-
-### Community 478 - "Community 478"
-Cohesion: 0.40
-Nodes (3): FileActionsReflectionInvoker, FileActions, String
-
-### Community 479 - "Community 479"
-Cohesion: 0.22
-Nodes (6): BomConsumer, OpenCvVisualConsumer, String, Mat, String, VisualProcessingProvider
 
 ### Community 480 - "Community 480"
 Cohesion: 0.47
@@ -2524,8 +2524,8 @@ Cohesion: 0.33
 Nodes (5): CommandResult, Captured process result., Return stdout and stderr as one diagnostic string., Run a process without a shell and capture diagnostics., run_command()
 
 ### Community 503 - "Community 503"
-Cohesion: 0.33
-Nodes (4): DynamicLoadingTest, AfterMethod, BeforeMethod, Test
+Cohesion: 0.16
+Nodes (9): ElementActions, DynamicLoadingTest, RelativeLocatorsTests, AfterMethod, BeforeMethod, Test, AfterMethod, BeforeMethod (+1 more)
 
 ### Community 504 - "Community 504"
 Cohesion: 0.47
@@ -2568,8 +2568,8 @@ Cohesion: 0.29
 Nodes (7): type, additionalProperties, type, additionalProperties, type, attributes, metadata
 
 ### Community 517 - "Community 517"
-Cohesion: 0.67
-Nodes (3): minLength, type, mediaType
+Cohesion: 0.24
+Nodes (7): BrowsingContextInfo, BidiBrowserEventCollector, BrowserSignal, Consumer, Override, String, WebDriver
 
 ### Community 520 - "Community 520"
 Cohesion: 0.50
@@ -2584,16 +2584,12 @@ Cohesion: 0.50
 Nodes (3): Output, Workflow, Flaky Test Stabilizer
 
 ### Community 525 - "Community 525"
-Cohesion: 0.67
-Nodes (3): defaults(), CaptureGenerationRequest, Path
+Cohesion: 0.50
+Nodes (3): JiraTests, BeforeClass, Test
 
 ### Community 526 - "Community 526"
 Cohesion: 0.50
 Nodes (3): Release And Dependency Guard, Output, Workflow
-
-### Community 529 - "Community 529"
-Cohesion: 0.67
-Nodes (3): safe(), stableKey(), String
 
 ### Community 532 - "Community 532"
 Cohesion: 0.50
@@ -2604,8 +2600,8 @@ Cohesion: 0.67
 Nodes (3): pattern, type, content_hash
 
 ### Community 544 - "Community 544"
-Cohesion: 0.17
-Nodes (12): minLength, type, type, properties, bundleId, evidence, redaction, schemaVersion (+4 more)
+Cohesion: 0.67
+Nodes (3): minLength, type, bundleId
 
 ### Community 545 - "Community 545"
 Cohesion: 0.67
@@ -2623,25 +2619,53 @@ Nodes (3): sha256, minLength, type
 Cohesion: 0.67
 Nodes (3): sizeBytes, minimum, type
 
+### Community 671 - "Community 671"
+Cohesion: 0.50
+Nodes (3): Object, StringBuilder, ValidationCategory
+
+### Community 673 - "Community 673"
+Cohesion: 0.50
+Nodes (3): from(), DoctorAnalysisResult, DoctorAnalysisSummary
+
+### Community 676 - "Community 676"
+Cohesion: 0.38
+Nodes (5): ready(), unavailable(), AiProviderAvailability, AiProviderAvailability, String
+
+### Community 677 - "Community 677"
+Cohesion: 0.48
+Nodes (3): OpenCvHealingVisualProviderTest, Color, Test
+
+### Community 678 - "Community 678"
+Cohesion: 0.33
+Nodes (6): parse_xml(), Parse XML while preserving comments., Return version property, direct SHAFT dependencies, and managed BOM version., Enforce the modular SHAFT dependency contract after every repair., shaft_dependency_state(), validate_upgraded_poms()
+
+### Community 681 - "Community 681"
+Cohesion: 0.67
+Nodes (3): defaults(), CaptureGenerationRequest, Path
+
+### Community 682 - "Community 682"
+Cohesion: 0.67
+Nodes (3): schemaVersion, enum, type
+
 ## Knowledge Gaps
-- **1225 isolated node(s):** `$id`, `$schema`, `additionalProperties`, `additionalProperties`, `type` (+1220 more)
+- **1223 isolated node(s):** `$id`, `$schema`, `additionalProperties`, `additionalProperties`, `type` (+1218 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **73 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **82 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `SHAFT` connect `Community 42` to `Community 1`, `Community 3`, `Community 5`, `Community 8`, `Community 9`, `Community 10`, `Community 11`, `Community 12`, `Community 13`, `Community 14`, `Community 15`, `Community 17`, `Community 18`, `Community 19`, `Community 21`, `Community 536`, `Community 24`, `Community 25`, `Community 27`, `Community 28`, `Community 29`, `Community 31`, `Community 32`, `Community 35`, `Community 36`, `Community 37`, `Community 38`, `Community 39`, `Community 41`, `Community 43`, `Community 44`, `Community 47`, `Community 48`, `Community 49`, `Community 51`, `Community 53`, `Community 55`, `Community 56`, `Community 57`, `Community 59`, `Community 61`, `Community 64`, `Community 72`, `Community 74`, `Community 76`, `Community 80`, `Community 81`, `Community 83`, `Community 87`, `Community 90`, `Community 92`, `Community 94`, `Community 97`, `Community 98`, `Community 99`, `Community 100`, `Community 103`, `Community 106`, `Community 109`, `Community 110`, `Community 111`, `Community 113`, `Community 117`, `Community 120`, `Community 121`, `Community 124`, `Community 125`, `Community 130`, `Community 131`, `Community 133`, `Community 135`, `Community 136`, `Community 138`, `Community 139`, `Community 144`, `Community 145`, `Community 155`, `Community 156`, `Community 157`, `Community 669`, `Community 160`, `Community 161`, `Community 164`, `Community 166`, `Community 170`, `Community 180`, `Community 184`, `Community 186`, `Community 194`, `Community 195`, `Community 199`, `Community 202`, `Community 203`, `Community 205`, `Community 208`, `Community 209`, `Community 214`, `Community 215`, `Community 216`, `Community 219`, `Community 220`, `Community 222`, `Community 223`, `Community 225`, `Community 229`, `Community 231`, `Community 233`, `Community 236`, `Community 240`, `Community 242`, `Community 243`, `Community 246`, `Community 248`, `Community 249`, `Community 250`, `Community 252`, `Community 253`, `Community 254`, `Community 258`, `Community 259`, `Community 265`, `Community 267`, `Community 271`, `Community 272`, `Community 274`, `Community 275`, `Community 289`, `Community 290`, `Community 292`, `Community 294`, `Community 296`, `Community 297`, `Community 302`, `Community 303`, `Community 307`, `Community 316`, `Community 317`, `Community 318`, `Community 320`, `Community 321`, `Community 329`, `Community 330`, `Community 334`, `Community 336`, `Community 339`, `Community 341`, `Community 342`, `Community 348`, `Community 349`, `Community 350`, `Community 353`, `Community 355`, `Community 356`, `Community 358`, `Community 359`, `Community 361`, `Community 362`, `Community 363`, `Community 364`, `Community 366`, `Community 370`, `Community 380`, `Community 382`, `Community 384`, `Community 387`, `Community 388`, `Community 396`, `Community 397`, `Community 398`, `Community 399`, `Community 400`, `Community 401`, `Community 403`, `Community 404`, `Community 410`, `Community 411`, `Community 420`, `Community 423`, `Community 424`, `Community 426`, `Community 438`, `Community 439`, `Community 440`, `Community 441`, `Community 442`, `Community 443`, `Community 444`, `Community 445`, `Community 446`, `Community 447`, `Community 448`, `Community 450`, `Community 452`, `Community 456`, `Community 457`, `Community 458`, `Community 459`, `Community 460`, `Community 462`, `Community 463`, `Community 464`, `Community 466`, `Community 467`, `Community 468`, `Community 479`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 493`, `Community 494`, `Community 495`, `Community 496`, `Community 497`, `Community 503`, `Community 511`?**
-  _High betweenness centrality (0.133) - this node is a cross-community bridge._
-- **Why does `ThreadLocalPropertiesManager` connect `Community 47` to `Community 37`, `Community 158`?**
-  _High betweenness centrality (0.047) - this node is a cross-community bridge._
-- **Why does `IOException` connect `Community 42` to `Community 1`, `Community 2`, `Community 5`, `Community 7`, `Community 10`, `Community 12`, `Community 18`, `Community 23`, `Community 26`, `Community 33`, `Community 40`, `Community 45`, `Community 46`, `Community 53`, `Community 56`, `Community 61`, `Community 62`, `Community 65`, `Community 67`, `Community 68`, `Community 76`, `Community 86`, `Community 96`, `Community 101`, `Community 109`, `Community 115`, `Community 117`, `Community 119`, `Community 121`, `Community 122`, `Community 127`, `Community 129`, `Community 132`, `Community 133`, `Community 135`, `Community 142`, `Community 144`, `Community 147`, `Community 153`, `Community 168`, `Community 176`, `Community 180`, `Community 189`, `Community 190`, `Community 204`, `Community 205`, `Community 207`, `Community 209`, `Community 210`, `Community 242`, `Community 246`, `Community 260`, `Community 264`, `Community 266`, `Community 270`, `Community 275`, `Community 276`, `Community 277`, `Community 278`, `Community 282`, `Community 288`, `Community 290`, `Community 295`, `Community 302`, `Community 307`, `Community 322`, `Community 323`, `Community 330`, `Community 350`, `Community 359`, `Community 371`, `Community 386`, `Community 419`, `Community 422`, `Community 431`, `Community 435`, `Community 448`, `Community 498`?**
-  _High betweenness centrality (0.029) - this node is a cross-community bridge._
+- **Why does `SHAFT` connect `Community 42` to `Community 1`, `Community 3`, `Community 5`, `Community 8`, `Community 10`, `Community 11`, `Community 12`, `Community 525`, `Community 14`, `Community 13`, `Community 15`, `Community 17`, `Community 18`, `Community 19`, `Community 21`, `Community 536`, `Community 24`, `Community 25`, `Community 27`, `Community 28`, `Community 31`, `Community 32`, `Community 35`, `Community 36`, `Community 37`, `Community 39`, `Community 43`, `Community 44`, `Community 47`, `Community 48`, `Community 49`, `Community 51`, `Community 53`, `Community 55`, `Community 57`, `Community 59`, `Community 61`, `Community 64`, `Community 72`, `Community 74`, `Community 76`, `Community 80`, `Community 81`, `Community 83`, `Community 87`, `Community 90`, `Community 92`, `Community 94`, `Community 97`, `Community 98`, `Community 99`, `Community 100`, `Community 103`, `Community 105`, `Community 106`, `Community 109`, `Community 110`, `Community 111`, `Community 113`, `Community 117`, `Community 120`, `Community 121`, `Community 124`, `Community 125`, `Community 130`, `Community 131`, `Community 134`, `Community 135`, `Community 136`, `Community 138`, `Community 139`, `Community 144`, `Community 145`, `Community 153`, `Community 155`, `Community 156`, `Community 669`, `Community 159`, `Community 160`, `Community 672`, `Community 161`, `Community 164`, `Community 166`, `Community 679`, `Community 680`, `Community 170`, `Community 180`, `Community 184`, `Community 187`, `Community 189`, `Community 194`, `Community 195`, `Community 199`, `Community 203`, `Community 205`, `Community 208`, `Community 209`, `Community 214`, `Community 215`, `Community 220`, `Community 222`, `Community 223`, `Community 225`, `Community 229`, `Community 233`, `Community 236`, `Community 240`, `Community 242`, `Community 243`, `Community 244`, `Community 246`, `Community 248`, `Community 249`, `Community 250`, `Community 252`, `Community 254`, `Community 258`, `Community 267`, `Community 271`, `Community 274`, `Community 275`, `Community 288`, `Community 289`, `Community 290`, `Community 292`, `Community 294`, `Community 296`, `Community 297`, `Community 302`, `Community 303`, `Community 307`, `Community 314`, `Community 316`, `Community 317`, `Community 318`, `Community 320`, `Community 321`, `Community 329`, `Community 330`, `Community 334`, `Community 336`, `Community 339`, `Community 341`, `Community 342`, `Community 348`, `Community 349`, `Community 350`, `Community 353`, `Community 355`, `Community 356`, `Community 358`, `Community 361`, `Community 362`, `Community 363`, `Community 364`, `Community 366`, `Community 370`, `Community 380`, `Community 382`, `Community 385`, `Community 387`, `Community 388`, `Community 396`, `Community 397`, `Community 398`, `Community 399`, `Community 400`, `Community 401`, `Community 403`, `Community 404`, `Community 410`, `Community 411`, `Community 420`, `Community 423`, `Community 424`, `Community 426`, `Community 435`, `Community 438`, `Community 439`, `Community 440`, `Community 441`, `Community 442`, `Community 443`, `Community 444`, `Community 445`, `Community 446`, `Community 448`, `Community 450`, `Community 452`, `Community 456`, `Community 457`, `Community 458`, `Community 459`, `Community 460`, `Community 462`, `Community 463`, `Community 464`, `Community 465`, `Community 467`, `Community 468`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 493`, `Community 494`, `Community 495`, `Community 496`, `Community 497`, `Community 503`, `Community 508`, `Community 511`?**
+  _High betweenness centrality (0.130) - this node is a cross-community bridge._
+- **Why does `ThreadLocalPropertiesManager` connect `Community 99` to `Community 37`, `Community 158`?**
+  _High betweenness centrality (0.048) - this node is a cross-community bridge._
+- **Why does `IOException` connect `Community 42` to `Community 2`, `Community 5`, `Community 7`, `Community 10`, `Community 12`, `Community 18`, `Community 26`, `Community 33`, `Community 40`, `Community 45`, `Community 49`, `Community 53`, `Community 61`, `Community 62`, `Community 65`, `Community 67`, `Community 68`, `Community 76`, `Community 96`, `Community 99`, `Community 101`, `Community 105`, `Community 109`, `Community 115`, `Community 117`, `Community 119`, `Community 121`, `Community 122`, `Community 125`, `Community 127`, `Community 129`, `Community 132`, `Community 135`, `Community 141`, `Community 142`, `Community 144`, `Community 147`, `Community 168`, `Community 176`, `Community 180`, `Community 189`, `Community 190`, `Community 202`, `Community 204`, `Community 205`, `Community 207`, `Community 209`, `Community 210`, `Community 242`, `Community 246`, `Community 260`, `Community 264`, `Community 266`, `Community 270`, `Community 272`, `Community 275`, `Community 277`, `Community 278`, `Community 282`, `Community 288`, `Community 290`, `Community 302`, `Community 307`, `Community 322`, `Community 323`, `Community 330`, `Community 350`, `Community 359`, `Community 371`, `Community 384`, `Community 386`, `Community 419`, `Community 422`, `Community 431`, `Community 435`, `Community 448`, `Community 498`?**
+  _High betweenness centrality (0.031) - this node is a cross-community bridge._
 - **What connects `$id`, `$schema`, `additionalProperties` to the rest of the system?**
-  _1318 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _1316 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.04242424242424243 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.04124525916561315 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.050628610261637785 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.07490079365079365 - nodes in this community are weakly interconnected._
 - **Should `Community 2` be split into smaller, more focused modules?**
-  _Cohesion score 0.05833848690991548 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.13043478260869565 - nodes in this community are weakly interconnected._

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - SHAFT_ENGINE_perf_cleanups  (2026-06-18)
 
 ## Corpus Check
-- 882 files · ~501,109 words
+- 882 files · ~501,474 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 12003 nodes · 30359 edges · 683 communities (601 shown, 82 thin omitted)
-- Extraction: 80% EXTRACTED · 20% INFERRED · 0% AMBIGUOUS · INFERRED: 6023 edges (avg confidence: 0.8)
+- 12008 nodes · 30394 edges · 681 communities (600 shown, 81 thin omitted)
+- Extraction: 80% EXTRACTED · 20% INFERRED · 0% AMBIGUOUS · INFERRED: 6032 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `f3c1362f`
+- Built from commit: `f12a1d16`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -449,6 +449,7 @@
 - [[_COMMUNITY_Community 431|Community 431]]
 - [[_COMMUNITY_Community 432|Community 432]]
 - [[_COMMUNITY_Community 433|Community 433]]
+- [[_COMMUNITY_Community 434|Community 434]]
 - [[_COMMUNITY_Community 435|Community 435]]
 - [[_COMMUNITY_Community 436|Community 436]]
 - [[_COMMUNITY_Community 437|Community 437]]
@@ -599,8 +600,6 @@
 - [[_COMMUNITY_Community 678|Community 678]]
 - [[_COMMUNITY_Community 679|Community 679]]
 - [[_COMMUNITY_Community 680|Community 680]]
-- [[_COMMUNITY_Community 681|Community 681]]
-- [[_COMMUNITY_Community 682|Community 682]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `SHAFT` - 271 edges
@@ -609,16 +608,16 @@
 4. `IOException` - 97 edges
 5. `ReportManagerHelper` - 75 edges
 6. `CaptureGenerator` - 66 edges
-7. `JavaHelperUnitTest` - 57 edges
-8. `Test` - 57 edges
-9. `Actions` - 53 edges
+7. `Actions` - 57 edges
+8. `JavaHelperUnitTest` - 57 edges
+9. `Test` - 57 edges
 10. `AllureManager` - 53 edges
 
 ## Surprising Connections (you probably didn't know these)
-- `defaults()` --calls--> `denyAll()`  [INFERRED]
-  shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationRequest.java → shaft-pilot-core/src/main/java/com/shaft/pilot/ai/ApprovalPolicy.java
 - `sortedEvents()` --calls--> `Sequence`  [INFERRED]
   shaft-capture/src/main/java/com/shaft/capture/model/CaptureSession.java → shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+- `defaults()` --calls--> `denyAll()`  [INFERRED]
+  shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationRequest.java → shaft-pilot-core/src/main/java/com/shaft/pilot/ai/ApprovalPolicy.java
 - `disabled()` --calls--> `denyAll()`  [INFERRED]
   shaft-doctor/src/main/java/com/shaft/doctor/DoctorAiAnalysisRequest.java → shaft-pilot-core/src/main/java/com/shaft/pilot/ai/ApprovalPolicy.java
 - `CaptureFormatException` --inherits--> `IllegalArgumentException`  [EXTRACTED]
@@ -629,19 +628,19 @@
 ## Import Cycles
 - None detected.
 
-## Communities (683 total, 82 thin omitted)
+## Communities (681 total, 81 thin omitted)
 
 ### Community 0 - "Community 0"
 Cohesion: 0.04
-Nodes (6): RestActionsComprehensiveTests, GraphqlRequestTests, ComparisonType, InputStream, SuppressWarnings, Test
+Nodes (6): RestActionsComprehensiveTests, ComparisonType, InputStream, SuppressWarnings, BeforeMethod, Test
 
 ### Community 1 - "Community 1"
-Cohesion: 0.07
-Nodes (5): Deprecated, AfterMethod, SuppressWarnings, Test, TerminalActionsUnitTest
+Cohesion: 0.08
+Nodes (4): AfterMethod, SuppressWarnings, Test, TerminalActionsUnitTest
 
 ### Community 2 - "Community 2"
-Cohesion: 0.13
-Nodes (22): DoctorAnalyzerTest, empty(), disabled(), defaults(), lower(), normalizePath(), Proposal, CapturePrivacyPolicy (+14 more)
+Cohesion: 0.12
+Nodes (23): DeterministicRuleEngine, DoctorAnalyzer, DoctorAnalyzerTest, DoctorAiAnalysisResult, DoctorReportWriter, EvidenceCollector, DoctorAiAnalysisRequest, DoctorAiAnalysisService (+15 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.06
@@ -653,22 +652,22 @@ Nodes (6): Pilot, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 5 - "Community 5"
 Cohesion: 0.11
-Nodes (13): FileUploadDownloadTest, ElementActionsHelper, IOSDriver, Test, AfterMethod, BeforeMethod, RemoteWebDriver, Runnable (+5 more)
+Nodes (12): FileUploadDownloadTest, File, Test, AfterMethod, BeforeMethod, RemoteWebDriver, Runnable, Test (+4 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.06
 Nodes (14): CSVFileManager, CSVFileManagerTest, List, Map, String, BeforeMethod, Test, AfterMethod (+6 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.06
-Nodes (42): AlertEvent, ArtifactPaths, AssertionSuggestion, CaptureGenerationReport, DataPlan, CaptureGenerator, failure(), MutableTargetPlan (+34 more)
+Cohesion: 0.07
+Nodes (38): AlertEvent, ArtifactPaths, AssertionSuggestion, CaptureGenerationReport, DataPlan, CaptureGenerator, failure(), withUnsupported() (+30 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.05
 Nodes (25): ApiPerformanceExecutionReport, Paths, SetProperty, Performance, SetProperty, PathsTests, DefaultValue, Key (+17 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.25
+Cohesion: 0.27
 Nodes (4): Jira, DefaultValue, Key, SetProperty
 
 ### Community 10 - "Community 10"
@@ -677,11 +676,11 @@ Nodes (23): BrowserStackSdkHelper, BrowserStackSdkTests, List, Map, Object, Stri
 
 ### Community 11 - "Community 11"
 Cohesion: 0.09
-Nodes (13): AsyncAppender, ReportManagerHelper, RunType, CheckpointStatus, InputStream, Level, List, Object (+5 more)
+Nodes (13): AsyncAppender, ReportManagerHelper, TestCaseStarted, CheckpointStatus, InputStream, Level, List, Object (+5 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.09
-Nodes (26): Autowired, LocatorOperation, MobileService, McpMobileAccessibilityTree, McpMobileActionResult, McpMobileContextSnapshot, McpMobileRecordingService, McpMobileSessionResult (+18 more)
+Nodes (23): KeyboardKeys, LocatorOperation, MobileService, McpMobileAccessibilityTree, McpMobileActionResult, McpMobileContextSnapshot, McpMobileSessionResult, BrowserType (+15 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.07
@@ -689,7 +688,7 @@ Nodes (11): BrowserStack, SetProperty, DefaultValue, Key, SetProperty, String, A
 
 ### Community 14 - "Community 14"
 Cohesion: 0.07
-Nodes (21): Connection, DatabaseActions, ApiAndRetainedSurfaceConsumer, DatabaseActionsMockedTests, DbTests, Boolean, DatabaseType, ResultSet (+13 more)
+Nodes (20): Connection, DatabaseActions, ApiAndRetainedSurfaceConsumer, DatabaseActionsMockedTests, DbTests, Boolean, DatabaseType, ResultSet (+12 more)
 
 ### Community 15 - "Community 15"
 Cohesion: 0.08
@@ -700,16 +699,16 @@ Cohesion: 0.10
 Nodes (67): CompletedProcess, adoptium_os_arch(), application_data_root(), architecture(), await_probe_response(), choose_client(), command_path(), configuration_path() (+59 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.07
-Nodes (29): HealingSupport, Properties, WebDriverListener, InvocationTargetException, Navigation, Alert, By, Method (+21 more)
+Cohesion: 0.14
+Nodes (13): WebDriverListener, Navigation, Alert, By, Method, Object, String, URL (+5 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.06
-Nodes (21): AfterSuite, ApiPerformanceReportTest, PathParamTest, SwaggerContractTest, TestUpload, Map, ParametersType, AfterMethod (+13 more)
+Cohesion: 0.09
+Nodes (11): AfterSuite, ApiPerformanceReportTest, SwaggerContractTest, ContentType, AfterMethod, BeforeMethod, Test, AfterClass (+3 more)
 
 ### Community 19 - "Community 19"
 Cohesion: 0.08
-Nodes (20): RequestBuilder, RequestBuilderTests, AuthenticationType, API, ContentType, Exception, Object, RequestSpecification (+12 more)
+Nodes (19): RequestBuilder, RequestBuilderTests, AuthenticationType, API, Exception, Object, RequestSpecification, RequestType (+11 more)
 
 ### Community 20 - "Community 20"
 Cohesion: 0.15
@@ -724,24 +723,24 @@ Cohesion: 0.08
 Nodes (7): Object, Override, SuppressWarnings, ValidationsExecutor, AfterMethod, Test, NativeValidationsBuilderUnitTest
 
 ### Community 23 - "Community 23"
-Cohesion: 0.24
-Nodes (5): List, Set, String, Test, TelemetryDeduplicationUnitTest
+Cohesion: 0.08
+Nodes (25): empty(), disabled(), Metadata, asCacheHit(), disabled(), empty(), defaults(), lower() (+17 more)
 
 ### Community 24 - "Community 24"
 Cohesion: 0.05
 Nodes (17): NativeValidationsBuilder, TextDirectionValidationsBuilder, E2ECoverageTests, FileValidationsBuilder, RestValidationsBuilder, String, ValidationsBuilder, WebDriverBrowserValidationsBuilder (+9 more)
 
 ### Community 25 - "Community 25"
-Cohesion: 0.17
-Nodes (4): AfterClass, BeforeClass, Test, APITests
+Cohesion: 0.06
+Nodes (22): PathParamTest, TestUpload, BasicAPITests, GraphqlRequestTests, Map, ParametersType, AfterClass, BeforeClass (+14 more)
 
 ### Community 26 - "Community 26"
-Cohesion: 0.11
-Nodes (23): AllureSnapshot, AllureVerdict, DoctorRepairPublicationRequest, ExistingPullRequest, PatchManifestEntry, changedSince(), DoctorRepairService, RepairGuard (+15 more)
+Cohesion: 0.05
+Nodes (50): AllureSnapshot, AllureSummary, AllureVerdict, Diagnostic, DoctorRepairPublicationRequest, ExistingPullRequest, GeneratedTestValidator, JarEntry (+42 more)
 
 ### Community 27 - "Community 27"
 Cohesion: 0.14
-Nodes (13): FileActions, Boolean, Collection, File, InputStream, String, SuppressWarnings, URL (+5 more)
+Nodes (12): FileActions, Boolean, Collection, File, String, SuppressWarnings, TerminalActions, URL (+4 more)
 
 ### Community 28 - "Community 28"
 Cohesion: 0.07
@@ -749,7 +748,7 @@ Nodes (15): DriverFactoryHelperCoverageUnitTest, TestableDriverFactoryHelper, Op
 
 ### Community 29 - "Community 29"
 Cohesion: 0.11
-Nodes (11): CaptureServiceTest, MobileRecordingServiceTest, Role, Override, AfterMethod, Test, CaptureService, Path (+3 more)
+Nodes (13): MobileRecordingServiceTest, Role, Override, AfterMethod, Test, Class, Object, String (+5 more)
 
 ### Community 30 - "Community 30"
 Cohesion: 0.08
@@ -760,24 +759,24 @@ Cohesion: 0.09
 Nodes (11): AfterMethod, BeforeMethod, Class, List, Object, Path, String, T (+3 more)
 
 ### Community 33 - "Community 33"
-Cohesion: 0.13
-Nodes (13): AccessibilityConfig, AccessibilityHelper, JSONArray, JSONObject, AccessibilityResult, Integer, List, Map (+5 more)
+Cohesion: 0.11
+Nodes (14): AccessibilityConfig, AccessibilityHelper, AccessibilityResult, JSONArray, JSONObject, AccessibilityResult, Integer, List (+6 more)
 
 ### Community 34 - "Community 34"
 Cohesion: 0.08
 Nodes (11): NumberValidationsBuilder, Number, Object, Override, RestValidationsBuilder, SuppressWarnings, ValidationsBuilder, ValidationsExecutor (+3 more)
 
 ### Community 35 - "Community 35"
-Cohesion: 0.08
-Nodes (27): DeterministicNaturalActionPlanner, unsupported(), NaturalActionPlannerRegistry, PilotNaturalActionPlanner, NaturalActionKind, NaturalActionPlanner, NaturalActionStep, List (+19 more)
+Cohesion: 0.19
+Nodes (12): PilotNaturalActionPlanner, NaturalActionKind, NaturalActionPlanner, NaturalActionStep, AiExecutionService, By, JsonNode, NaturalActionPlan (+4 more)
 
 ### Community 36 - "Community 36"
-Cohesion: 0.06
-Nodes (30): DataTableArgument, EmbedEvent, HookTestStep, CucumberFeatureListener, Parameter, PickleStepTestStep, Result, Scenario (+22 more)
+Cohesion: 0.07
+Nodes (28): DataTableArgument, EmbedEvent, HookTestStep, CucumberFeatureListener, Parameter, PickleStepTestStep, Result, Scenario (+20 more)
 
 ### Community 37 - "Community 37"
-Cohesion: 0.10
-Nodes (7): AfterMethod, Class, Object, Path, String, Test, AllureManagerUnitTest
+Cohesion: 0.08
+Nodes (12): EngineServiceRuntimePathTest, PostConstruct, Class, Object, Path, String, Test, Path (+4 more)
 
 ### Community 38 - "Community 38"
 Cohesion: 0.13
@@ -797,27 +796,27 @@ Nodes (11): AssertApiResponseEqualsTests, ApiActionsMockedTests, RequestBuilder,
 
 ### Community 42 - "Community 42"
 Cohesion: 0.06
-Nodes (20): testPostRequest, SHAFT, FileInputStream, AppiumMobileConsumer, BrowserStackSdkConsumer, LegacyCoordinateConsumer, AiCandidateRerankerTest, IOException (+12 more)
+Nodes (21): testPostRequest, Constructor, SHAFT, FileInputStream, AppiumMobileConsumer, BrowserStackSdkConsumer, LegacyCoordinateConsumer, $ (+13 more)
 
 ### Community 43 - "Community 43"
 Cohesion: 0.08
-Nodes (25): Constructor, IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, IResultListener2 (+17 more)
+Nodes (24): IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, IResultListener2, ISuiteListener (+16 more)
 
 ### Community 44 - "Community 44"
 Cohesion: 0.16
 Nodes (8): AssertionSteps, PDFTests, ValidationsBuilderTests, String, Then, ThreadLocal, WebDriver, String
 
 ### Community 45 - "Community 45"
-Cohesion: 0.17
-Nodes (15): CollectionState, EvidenceCollector, CollectionState, DoctorRedactor, DefaultPrettyPrinter, DoctorAnalysisRequest, EvidenceBundle, EvidenceCategory (+7 more)
+Cohesion: 0.16
+Nodes (15): CollectionState, EvidenceCollector, FilesSize, CollectionState, DoctorRedactor, DefaultPrettyPrinter, DoctorAnalysisRequest, EvidenceCategory (+7 more)
 
 ### Community 46 - "Community 46"
-Cohesion: 0.13
-Nodes (15): CaptureFixtures, CaptureGeneratorTest, PageContext, BrowserMetadata, CaptureEvent, CaptureSession, ElementSnapshot, EventContext (+7 more)
+Cohesion: 0.09
+Nodes (19): CaptureFixtures, CaptureJsonCodecTest, CaptureGeneratorTest, PageContext, BrowserMetadata, CaptureEvent, CaptureSession, ElementSnapshot (+11 more)
 
 ### Community 47 - "Community 47"
-Cohesion: 0.13
-Nodes (5): AfterMethod, Path, String, Test, ThreadLocalPropertiesTest
+Cohesion: 0.11
+Nodes (14): ChromeOptions, WebDomHealingAcceptanceTest, MoonTests, AfterEach, BeforeEach, String, Test, WebDriver (+6 more)
 
 ### Community 48 - "Community 48"
 Cohesion: 0.13
@@ -828,8 +827,8 @@ Cohesion: 0.07
 Nodes (21): ImageProcessingActions, ImageProcessingActionsCoverageUnitTest, Boolean, By, File, Integer, List, String (+13 more)
 
 ### Community 50 - "Community 50"
-Cohesion: 0.13
-Nodes (4): AllureManager, Path, Process, String
+Cohesion: 0.15
+Nodes (3): AllureManager, Path, Process
 
 ### Community 51 - "Community 51"
 Cohesion: 0.08
@@ -840,20 +839,20 @@ Cohesion: 0.04
 Nodes (47): additionalProperties, minLength, type, maximum, minimum, type, type, minLength (+39 more)
 
 ### Community 53 - "Community 53"
-Cohesion: 0.07
-Nodes (31): AttachmentFormat, Date, CaptureJsonCodec, DoctorJsonCodec, InputStream, AttachmentReporter, CaptureSession, JsonNode (+23 more)
+Cohesion: 0.05
+Nodes (44): AttachmentFormat, Date, DoctorRepairPatchResult, CaptureJsonCodec, DoctorJsonCodec, InputStream, AttachmentReporter, DoctorRepairAiService (+36 more)
 
 ### Community 54 - "Community 54"
 Cohesion: 0.10
-Nodes (7): BrowserActions, Cookie, Override, Screenshots, Set, String, SuppressWarnings
+Nodes (6): BrowserActions, Override, Screenshots, String, SuppressWarnings, WebDriverBrowserValidationsBuilder
 
 ### Community 55 - "Community 55"
 Cohesion: 0.13
 Nodes (14): Capabilities, DriverFactoryHelper, Class, DriverType, List, MutableCapabilities, Object, Runnable (+6 more)
 
 ### Community 56 - "Community 56"
-Cohesion: 0.21
-Nodes (5): ElementLookup, GetElementInformation, Actions, JavascriptExecutor, WebElement
+Cohesion: 0.15
+Nodes (7): ElementLookup, GetElementInformation, Actions, NoSuchElementException, JavascriptExecutor, List, WebElement
 
 ### Community 57 - "Community 57"
 Cohesion: 0.08
@@ -872,27 +871,27 @@ Cohesion: 0.15
 Nodes (3): SetProperty, Deprecated, String
 
 ### Community 61 - "Community 61"
-Cohesion: 0.13
-Nodes (21): ExchangeHandler, FailureCase, ExchangeHandler, ProviderConformanceTest, AfterEach, AiProvider, AiRequest, AiResponse (+13 more)
+Cohesion: 0.12
+Nodes (22): AiBudget, ExchangeHandler, FailureCase, ExchangeHandler, ProviderConformanceTest, AfterEach, AiProvider, AiRequest (+14 more)
 
 ### Community 62 - "Community 62"
-Cohesion: 0.14
-Nodes (19): DoctorRepairProposalResult, DoctorRepairService, HealingLocatorProposalRequest, DoctorService, McpDoctorRemediationService, ApprovalPolicy, Diagnosis, DoctorAnalysisResult (+11 more)
+Cohesion: 0.10
+Nodes (23): DoctorRepairProposalResult, DoctorRepairService, HealingLocatorProposalRequest, DoctorService, DoctorServiceTest, McpDoctorRemediationService, ApprovalPolicy, Diagnosis (+15 more)
 
 ### Community 63 - "Community 63"
-Cohesion: 0.17
-Nodes (7): ClipboardAction, GetElementInformation, ActionType, By, ClipboardAction, Override, Step
+Cohesion: 0.21
+Nodes (6): GetElementInformation, ActionType, Beta, By, Override, Step
 
 ### Community 64 - "Community 64"
-Cohesion: 0.12
-Nodes (16): ActionsCoverageUnitTest, RecordingActions, RecordingActions, ActionType, AfterMethod, BeforeMethod, By, Class (+8 more)
+Cohesion: 0.09
+Nodes (18): UnitTestsRestActions, ActionsCoverageUnitTest, RecordingActions, RecordingActions, ActionType, AfterMethod, BeforeMethod, By (+10 more)
 
 ### Community 65 - "Community 65"
 Cohesion: 0.12
 Nodes (14): AllureListenerCoverageUnitTest, Throwable, AfterMethod, BeforeMethod, ITestResult, List, Path, String (+6 more)
 
 ### Community 66 - "Community 66"
-Cohesion: 0.14
+Cohesion: 0.15
 Nodes (11): ContainerLifecycleListener, FixtureLifecycleListener, FixtureResult, AllureListener, AllureLifecycle, Override, TestResult, StepLifecycleListener (+3 more)
 
 ### Community 67 - "Community 67"
@@ -900,8 +899,8 @@ Cohesion: 0.11
 Nodes (11): COSDocument, DeleteFileAfterValidationStatus, PdfFileManager, PDFParser, RandomAccessReadBufferedFile, File, String, AfterMethod (+3 more)
 
 ### Community 68 - "Community 68"
-Cohesion: 0.06
-Nodes (42): CaptureService, McpDoctorRemediationService, McpMobileRecordingService, McpActionRecord, McpCaptureCodeBlockService, McpCaptureReplayResult, McpMobileRecording, PreDestroy (+34 more)
+Cohesion: 0.15
+Nodes (20): McpDoctorRemediationService, McpActionRecord, ProviderBlocks, AiRequest, AiResponse, ApprovalPolicy, Diagnosis, DoctorAnalysisResult (+12 more)
 
 ### Community 69 - "Community 69"
 Cohesion: 0.05
@@ -924,16 +923,16 @@ Cohesion: 0.11
 Nodes (41): expand_globs(), issue(), local_link_targets(), markdown_body(), normalized_paragraphs(), parse_frontmatter(), quoted_yaml_value(), Keep the consolidated guidance below the approved baseline reduction. (+33 more)
 
 ### Community 74 - "Community 74"
-Cohesion: 0.21
-Nodes (11): ElementActionsHelper, TextDetectionStrategy(), Boolean, By, ClipboardAction, HealingResolution, List, Object (+3 more)
+Cohesion: 0.15
+Nodes (15): ElementActionsHelper, TextDetectionStrategy(), Boolean, By, Class, ClipboardAction, HealingResolution, List (+7 more)
 
 ### Community 75 - "Community 75"
 Cohesion: 0.15
 Nodes (19): CaptureControlClient, CaptureCli, flag(), parse(), path(), pathRequired(), required(), value() (+11 more)
 
 ### Community 76 - "Community 76"
-Cohesion: 0.06
-Nodes (29): ChromeOptions, ShaftHeal, ShaftHealingProviderTest, WebDomHealingAcceptanceTest, MoonTests, AfterEach, BeforeEach, String (+21 more)
+Cohesion: 0.13
+Nodes (15): ShaftHeal, ShaftHealingProviderTest, HealingReport, Optional, AfterMethod, AppiumDriver, BeforeMethod, DataProvider (+7 more)
 
 ### Community 77 - "Community 77"
 Cohesion: 0.08
@@ -952,16 +951,16 @@ Cohesion: 0.09
 Nodes (14): ChromiumOptions, DesiredCapabilities, DriverFactoryHelper, LoggingPreferences, AfterMethod, AtomicInteger, CountDownLatch, DriverType (+6 more)
 
 ### Community 81 - "Community 81"
-Cohesion: 0.12
-Nodes (9): IIOMetadataNode, AnimatedGifManager, GifSession, ImageOutputStream, ImageWriter, RenderedImage, BufferedImage, String (+1 more)
+Cohesion: 0.10
+Nodes (11): IIOMetadataNode, AnimatedGifManager, GifSession, ImageOutputStream, ImageWriter, getType(), RenderedImage, Screenshots (+3 more)
 
 ### Community 82 - "Community 82"
-Cohesion: 0.18
-Nodes (14): SilentElementReader, ValidationsHelper2, LinkedHashMap, AssertionError, By, List, Number, NumbersComparativeRelation (+6 more)
+Cohesion: 0.17
+Nodes (15): Actions, SilentElementReader, ValidationsHelper2, LinkedHashMap, AssertionError, By, List, Number (+7 more)
 
 ### Community 83 - "Community 83"
-Cohesion: 0.13
-Nodes (7): LocatorBuilderTest, XpathAxis, LocatorBuilder, String, AfterMethod, BeforeMethod, Test
+Cohesion: 0.21
+Nodes (4): LocatorBuilderTest, AfterMethod, BeforeMethod, Test
 
 ### Community 84 - "Community 84"
 Cohesion: 0.05
@@ -972,8 +971,8 @@ Cohesion: 0.18
 Nodes (11): ClassifiedUpload, CapturePrivacyClassifier, SanitizedAttributes, SanitizedText, CapturePrivacyPolicy, ClassifiedValue, List, Map (+3 more)
 
 ### Community 87 - "Community 87"
-Cohesion: 0.15
-Nodes (10): HasCdp, Image, ScreenshotHelperCoverageUnitTest, BufferedImage, AfterMethod, BeforeMethod, Color, Object (+2 more)
+Cohesion: 0.10
+Nodes (15): HasCdp, Image, ScreenshotHelper, ScreenshotHelperCoverageUnitTest, Boolean, BufferedImage, String, SuppressWarnings (+7 more)
 
 ### Community 88 - "Community 88"
 Cohesion: 0.05
@@ -984,16 +983,16 @@ Cohesion: 0.07
 Nodes (14): be(), Bt(), Dt(), $e(), Ee(), ft(), ke(), l() (+6 more)
 
 ### Community 90 - "Community 90"
-Cohesion: 0.13
-Nodes (9): ElementActions, Actions, By, DriverFactoryHelper, Override, String, SuppressWarnings, WebDriver (+1 more)
+Cohesion: 0.12
+Nodes (11): ElementActions, Actions, By, DriverFactoryHelper, List, Map, Override, String (+3 more)
 
 ### Community 91 - "Community 91"
-Cohesion: 0.15
-Nodes (18): CandidateExtractor, LocatorProposal, nativePlatform(), validateUrl(), SearchContext, String, By, Collection (+10 more)
+Cohesion: 0.16
+Nodes (17): CandidateExtractor, LocatorProposal, validateUrl(), SearchContext, String, By, Collection, HealingConfiguration (+9 more)
 
 ### Community 92 - "Community 92"
-Cohesion: 0.08
-Nodes (11): LocatorBuilder, JDK21VirtualThreadsAndAsyncActionsTests, RelativeBy, ArrayList, By, Role, String, SuppressWarnings (+3 more)
+Cohesion: 0.11
+Nodes (7): LocatorBuilder, RelativeBy, ArrayList, By, Role, String, SuppressWarnings
 
 ### Community 93 - "Community 93"
 Cohesion: 0.06
@@ -1004,11 +1003,11 @@ Cohesion: 0.10
 Nodes (4): AfterMethod, BeforeClass, Test, YAMLFileManagerUnitTest
 
 ### Community 95 - "Community 95"
-Cohesion: 0.15
-Nodes (15): AiExecutionServiceTest, StubProvider, denyAll(), AiCapabilities, AiExecutionService, AiProviderAvailability, AiProviderRegistry, AiRequest (+7 more)
+Cohesion: 0.16
+Nodes (14): AiExecutionServiceTest, StubProvider, AiCapabilities, AiExecutionService, AiProviderAvailability, AiProviderRegistry, AiRequest, AiResponse (+6 more)
 
 ### Community 96 - "Community 96"
-Cohesion: 0.20
+Cohesion: 0.21
 Nodes (15): DoctorAiAnalysisServiceTest, EnumSource, AiRequest, AiResponse, AiResponseStatus, Diagnosis, DoctorAiAnalysisService, EvidenceBundle (+7 more)
 
 ### Community 97 - "Community 97"
@@ -1020,12 +1019,12 @@ Cohesion: 0.13
 Nodes (11): FluentWait, ElementsHelperCoverageUnitTest, MockedStatic, AfterMethod, BeforeMethod, DriverFactoryHelper, MockedConstruction, RuntimeException (+3 more)
 
 ### Community 99 - "Community 99"
-Cohesion: 0.08
-Nodes (15): PropertyFileManager, ThreadLocalPropertiesManager, File, HashMap, Map, MutableCapabilities, Object, Properties (+7 more)
+Cohesion: 0.05
+Nodes (19): PropertyFileManager, ThreadLocalPropertiesManager, File, HashMap, Map, MutableCapabilities, Object, Properties (+11 more)
 
 ### Community 100 - "Community 100"
-Cohesion: 0.20
-Nodes (9): ElementService, LocatorOperation, By, Deprecated, LocatorOperation, locatorStrategy, String, Tool (+1 more)
+Cohesion: 0.18
+Nodes (10): ElementService, LocatorOperation, By, Deprecated, LocatorOperation, locatorStrategy, String, Tool (+2 more)
 
 ### Community 101 - "Community 101"
 Cohesion: 0.13
@@ -1036,19 +1035,19 @@ Cohesion: 0.17
 Nodes (17): DeterministicRuleEngine, Confidence, Finding, Remediation, RetrySummary, RuleMatch, CauseCategory, Diagnosis (+9 more)
 
 ### Community 103 - "Community 103"
-Cohesion: 0.11
-Nodes (14): DriverFactory, DriverType(), DatabaseActions, DatabaseType, DriverFactoryHelper, DriverType, MutableCapabilities, RestActions (+6 more)
+Cohesion: 0.16
+Nodes (11): DriverFactory, DriverType(), DatabaseActions, DatabaseType, DriverFactoryHelper, DriverType, MutableCapabilities, RestActions (+3 more)
 
 ### Community 104 - "Community 104"
-Cohesion: 0.27
-Nodes (4): Healing, DefaultValue, Key, SetProperty
+Cohesion: 0.13
+Nodes (6): Healing, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 105 - "Community 105"
-Cohesion: 0.14
-Nodes (11): ChannelSftp, TerminalActions, ProcessBuilder, Session, SftpTransferDirection, Boolean, BufferedReader, List (+3 more)
+Cohesion: 0.12
+Nodes (12): ChannelSftp, TerminalActions, ProcessBuilder, Session, SftpTransferDirection, Boolean, BufferedReader, Deprecated (+4 more)
 
 ### Community 106 - "Community 106"
-Cohesion: 0.10
+Cohesion: 0.11
 Nodes (10): AfterMethod, BeforeMethod, Issue, Issues, ITestResult, String, Test, TmsLink (+2 more)
 
 ### Community 107 - "Community 107"
@@ -1068,8 +1067,8 @@ Cohesion: 0.13
 Nodes (3): YAMLFileManagerTests, BeforeMethod, Test
 
 ### Community 111 - "Community 111"
-Cohesion: 0.13
-Nodes (17): getType(), LauncherSession, Screenshots, Override, AfterMethod, BeforeMethod, Duration, List (+9 more)
+Cohesion: 0.14
+Nodes (15): LauncherSession, Override, AfterMethod, BeforeMethod, Duration, List, Object, Optional (+7 more)
 
 ### Community 112 - "Community 112"
 Cohesion: 0.18
@@ -1104,12 +1103,12 @@ Cohesion: 0.17
 Nodes (11): AccessibilityHelperCoverageUnitTest, AxeBuilder, AfterMethod, List, MockedConstruction, Path, Results, Rule (+3 more)
 
 ### Community 120 - "Community 120"
-Cohesion: 0.29
-Nodes (5): Test_LTMobIPAAppURL, AfterMethod, BeforeMethod, String, Test
+Cohesion: 0.10
+Nodes (15): IOSBasicInteractionsTest, ElementActions, Test_LTMobIPAAppURL, Test_LTMobIPARelativePath, AfterMethod, BeforeMethod, SuppressWarnings, Test (+7 more)
 
 ### Community 121 - "Community 121"
-Cohesion: 0.11
-Nodes (18): getValue(), KeyboardKeys(), TouchActions, ImmutableMap, KeyboardKeys, By, DriverFactoryHelper, File (+10 more)
+Cohesion: 0.08
+Nodes (20): AndroidDriver, AndroidTouchActionsTests, getValue(), KeyboardKeys(), TouchActions, ImmutableMap, ScreenOrientation, By (+12 more)
 
 ### Community 122 - "Community 122"
 Cohesion: 0.17
@@ -1120,8 +1119,8 @@ Cohesion: 0.16
 Nodes (8): IAssert, CustomSoftAssert, AssertionError, Override, String, Test, SoftAssert, CustomSoftAssertTest
 
 ### Community 124 - "Community 124"
-Cohesion: 0.13
-Nodes (10): TestNGListenerHelper, ISuite, ITestContext, ITestNGMethod, ITestResult, List, Method, String (+2 more)
+Cohesion: 0.12
+Nodes (9): TestNGListenerHelper, ISuite, ITestContext, ITestNGMethod, ITestResult, List, Method, String (+1 more)
 
 ### Community 125 - "Community 125"
 Cohesion: 0.06
@@ -1132,8 +1131,8 @@ Cohesion: 0.17
 Nodes (12): ITestNGService, AfterMethod, ITestNGMethod, ITestResult, List, Object, String, SuppressWarnings (+4 more)
 
 ### Community 127 - "Community 127"
-Cohesion: 0.17
-Nodes (16): RecordingRunner, DoctorRepairServiceTest, RecordingRunner, validationPassed(), RepairProcessRunner, RepositoryFixture, DoctorRepairRequest, Duration (+8 more)
+Cohesion: 0.21
+Nodes (10): HealingSupport, nativePlatform(), By, HealingContext, HealingPlatform, RemoteWebDriver, String, Supplier (+2 more)
 
 ### Community 128 - "Community 128"
 Cohesion: 0.12
@@ -1148,8 +1147,8 @@ Cohesion: 0.13
 Nodes (3): ActionsCoverageTests, BeforeMethod, Test
 
 ### Community 131 - "Community 131"
-Cohesion: 0.07
-Nodes (19): Browser, BasicAuthenticationTests, NetworkInterceptionTest, ShadowDomTest, CoverageTests, HoverTests, Test, Test (+11 more)
+Cohesion: 0.11
+Nodes (11): Browser, ShadowDomTest, CoverageTests, AfterMethod, BeforeMethod, Test, AfterClass, AfterMethod (+3 more)
 
 ### Community 132 - "Community 132"
 Cohesion: 0.14
@@ -1160,15 +1159,15 @@ Cohesion: 0.33
 Nodes (4): VisualProcessingProviderRegistry, List, Optional, VisualProcessingProvider
 
 ### Community 134 - "Community 134"
-Cohesion: 0.11
-Nodes (16): BomConsumer, AlphaProvider, VisualProcessingProviderRegistryTest, ZuluProvider, AfterMethod, Boolean, By, Integer (+8 more)
+Cohesion: 0.14
+Nodes (14): AlphaProvider, VisualProcessingProviderRegistryTest, ZuluProvider, AfterMethod, Boolean, By, Integer, List (+6 more)
 
 ### Community 135 - "Community 135"
-Cohesion: 0.21
-Nodes (11): ScreenshotManager, Boolean, By, JavascriptExecutor, List, Object, Screenshots, SneakyThrows (+3 more)
+Cohesion: 0.19
+Nodes (12): ScreenshotManager, Object, Boolean, By, JavascriptExecutor, List, Object, Screenshots (+4 more)
 
 ### Community 136 - "Community 136"
-Cohesion: 0.13
+Cohesion: 0.14
 Nodes (9): Platform, SetProperty, PlatformTests, DefaultValue, Key, SetProperty, String, BeforeClass (+1 more)
 
 ### Community 137 - "Community 137"
@@ -1176,24 +1175,24 @@ Cohesion: 0.11
 Nodes (25): build_parser(), confirm_upgrade(), coordinates_have_supported_runner(), log(), main(), OpenAIRepairClient, print_analysis(), ProjectAnalysis (+17 more)
 
 ### Community 138 - "Community 138"
-Cohesion: 0.12
-Nodes (11): AccessibilityActions, AccessibilityConfig, AccessibilityTest, AccessibilityResult, BrowserActions, List, String, WebDriver (+3 more)
+Cohesion: 0.19
+Nodes (4): AccessibilityTest, AfterMethod, BeforeMethod, Test
 
 ### Community 139 - "Community 139"
-Cohesion: 0.11
-Nodes (17): builder(), evidenceCategories(), withSanitizedContent(), withTimeout(), AiAuditSink, ShaftAiAuditSink, AiRequest, ApprovalPolicy (+9 more)
+Cohesion: 0.10
+Nodes (18): builder(), evidenceCategories(), withSanitizedContent(), withTimeout(), AiAuditSink, AiImage, ShaftAiAuditSink, AiRequest (+10 more)
 
 ### Community 140 - "Community 140"
-Cohesion: 0.08
-Nodes (15): CSVFileManager, API, CSV, EXCEL, JSON, Report, YAML, InputStream (+7 more)
+Cohesion: 0.17
+Nodes (6): API, JSON, List, Object, RequestBuilder, String
 
 ### Community 141 - "Community 141"
 Cohesion: 0.09
 Nodes (25): HealingProvider, HealingReportWriter, ShaftHealingProvider, safe(), stableKey(), HealingConfiguration, HealingReport, String (+17 more)
 
 ### Community 142 - "Community 142"
-Cohesion: 0.17
-Nodes (11): HistoryDocument, HistoryRecord, HealingHistoryStore, HealingConfiguration, HealingContext, LocatorFingerprint, Optional, Path (+3 more)
+Cohesion: 0.35
+Nodes (4): HistoryDocument, HistoryRecord, HealingHistoryStore, String
 
 ### Community 143 - "Community 143"
 Cohesion: 0.14
@@ -1208,16 +1207,16 @@ Cohesion: 0.17
 Nodes (9): ElementSteps, getValue(), LocatorType(), By, String, SuppressWarnings, ThreadLocal, WebDriver (+1 more)
 
 ### Community 146 - "Community 146"
-Cohesion: 0.14
-Nodes (14): DecisionResult, DeterministicScorerTest, HealingDecisionEngine, HealingConfiguration, List, RankedCandidate, Status, String (+6 more)
+Cohesion: 0.29
+Nodes (7): DeterministicScorerTest, Double, HealingConfiguration, LocatorFingerprint, RankedCandidate, String, Test
 
 ### Community 147 - "Community 147"
-Cohesion: 0.10
-Nodes (33): DoctorCli, flag(), optionalPath(), parse(), path(), pathRequired(), paths(), pathsRequired() (+25 more)
+Cohesion: 0.20
+Nodes (20): DoctorCli, flag(), optionalPath(), parse(), path(), pathRequired(), paths(), pathsRequired() (+12 more)
 
 ### Community 148 - "Community 148"
-Cohesion: 0.19
-Nodes (7): FluentWebDriverAction, Actions, AlertActions, BrowserActions, DriverFactoryHelper, TouchActions, WebDriver
+Cohesion: 0.12
+Nodes (11): FluentWebDriverAction, SelectedValueTests, Actions, AlertActions, BrowserActions, DriverFactoryHelper, TouchActions, WebDriver (+3 more)
 
 ### Community 149 - "Community 149"
 Cohesion: 0.22
@@ -1244,24 +1243,24 @@ Cohesion: 0.08
 Nodes (24): enum, additionalProperties, allOf, enum, $id, pattern, type, type (+16 more)
 
 ### Community 155 - "Community 155"
-Cohesion: 0.18
-Nodes (7): AfterClass, AfterMethod, SuppressWarnings, Test, ThreadLocal, WebDriver, RecordManagerTest
+Cohesion: 0.16
+Nodes (8): String, AfterClass, AfterMethod, SuppressWarnings, Test, ThreadLocal, WebDriver, RecordManagerTest
 
 ### Community 156 - "Community 156"
 Cohesion: 0.13
 Nodes (7): AndroidBasicInteractionsTests, AndroidDragAndDropTest, MobileTest, Test, Test, AfterMethod, BeforeMethod
 
 ### Community 157 - "Community 157"
-Cohesion: 0.33
-Nodes (3): Validations, StandaloneAssertions, StandaloneVerifications
+Cohesion: 0.09
+Nodes (15): AsyncElementActions, Async, CLI, GUI, Locator, Properties, TestData, Validations (+7 more)
 
 ### Community 158 - "Community 158"
 Cohesion: 0.19
 Nodes (6): API, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 159 - "Community 159"
-Cohesion: 0.10
-Nodes (6): PropertiesHelper, String, AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
+Cohesion: 0.20
+Nodes (4): AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
 
 ### Community 160 - "Community 160"
 Cohesion: 0.28
@@ -1300,12 +1299,12 @@ Cohesion: 0.17
 Nodes (10): BrowserEventScript, PollingBrowserEventCollector, String, BrowserSignal, Consumer, Object, Override, Set (+2 more)
 
 ### Community 169 - "Community 169"
-Cohesion: 0.20
-Nodes (3): AsyncElementActions, By, String
+Cohesion: 0.11
+Nodes (9): AsyncElementActions, JDK21VirtualThreadsAndAsyncActionsTests, By, ClipboardAction, DriverFactoryHelper, String, AfterMethod, BeforeMethod (+1 more)
 
 ### Community 170 - "Community 170"
-Cohesion: 0.21
-Nodes (7): TestNG, TestNGTests, DefaultValue, Integer, Key, String, Test
+Cohesion: 0.20
+Nodes (8): TestNG, TestNGTests, XmlSuite, DefaultValue, Integer, Key, String, Test
 
 ### Community 171 - "Community 171"
 Cohesion: 0.11
@@ -1320,12 +1319,12 @@ Cohesion: 0.14
 Nodes (23): analyze_project(), collect_ai_context(), coordinates_have_supported_stack(), dependency_coordinates(), detect_markers(), discover_poms(), format_diff(), is_ignored() (+15 more)
 
 ### Community 175 - "Community 175"
-Cohesion: 0.17
-Nodes (13): AiImage, OpenAiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode (+5 more)
+Cohesion: 0.19
+Nodes (12): OpenAiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode, Map (+4 more)
 
 ### Community 176 - "Community 176"
-Cohesion: 0.22
-Nodes (11): AllureSummary, Diagnostic, GeneratedTestValidator, JarEntry, JarFile, JavaFileObject, Duration, List (+3 more)
+Cohesion: 0.16
+Nodes (12): McpMobileRecordingService, McpMobileRecording, List, locatorStrategy, Map, McpCodeBlock, McpMobileRecordedAction, McpMobileRecordingStatus (+4 more)
 
 ### Community 177 - "Community 177"
 Cohesion: 0.23
@@ -1348,36 +1347,36 @@ Cohesion: 0.20
 Nodes (13): AiCandidateReranker, RerankResult, AiExecutionService, Double, HealingConfiguration, JsonNode, List, Map (+5 more)
 
 ### Community 182 - "Community 182"
-Cohesion: 0.17
-Nodes (9): WebDriverAssertions, WebDriverVerifications, WizardHelpers, By, DriverFactoryHelper, NativeValidationsBuilder, Object, WebDriverBrowserValidationsBuilder (+1 more)
+Cohesion: 0.10
+Nodes (16): StandaloneAssertions, StandaloneVerifications, WebDriverAssertions, WebDriverVerifications, WizardHelpers, By, DriverFactoryHelper, FileValidationsBuilder (+8 more)
 
 ### Community 183 - "Community 183"
 Cohesion: 0.12
 Nodes (22): minLength, type, properties, $ref, $ref, $ref, body, evidence (+14 more)
 
 ### Community 184 - "Community 184"
-Cohesion: 0.15
-Nodes (14): List, Map, Map, AfterMethod, BeforeMethod, By, ElementActions, List (+6 more)
+Cohesion: 0.20
+Nodes (11): AfterMethod, BeforeMethod, By, ElementActions, List, Object, Runnable, String (+3 more)
 
 ### Community 185 - "Community 185"
 Cohesion: 0.17
 Nodes (3): AfterMethod, Test, TextDirectionValidationsBuilderUnitTest
 
 ### Community 186 - "Community 186"
-Cohesion: 0.22
-Nodes (8): AccessibilityResult, AfterMethod, BeforeMethod, List, Rule, String, Test, AccessibilityActionsCoverageUnitTest
+Cohesion: 0.12
+Nodes (15): AccessibilityActions, AccessibilityConfig, AccessibilityResult, BrowserActions, List, String, WebDriver, AccessibilityResult (+7 more)
 
 ### Community 187 - "Community 187"
-Cohesion: 0.07
-Nodes (18): Async, AsyncElementActions, Async, CLI, GUI, Locator, Properties, TestData (+10 more)
+Cohesion: 0.10
+Nodes (10): Async, WebDriver, Actions, AlertActions, BrowserActions, DriverType, MutableCapabilities, TouchActions (+2 more)
 
 ### Community 188 - "Community 188"
 Cohesion: 0.12
 Nodes (4): CommandResult, command_result(), FakeRepairClient, UpgradeToModularShaftTests
 
 ### Community 189 - "Community 189"
-Cohesion: 0.16
-Nodes (11): AppiumDriver, Beta, DriverFactoryHelper, Duration, Function, Map, Object, Rectangle (+3 more)
+Cohesion: 0.14
+Nodes (12): AppiumDriver, DriverFactoryHelper, Duration, Function, Map, Object, Rectangle, RuntimeException (+4 more)
 
 ### Community 190 - "Community 190"
 Cohesion: 0.24
@@ -1388,8 +1387,8 @@ Cohesion: 0.24
 Nodes (7): HealingScore, DeterministicScorer, Double, HealingConfiguration, LocatorFingerprint, Map, String
 
 ### Community 192 - "Community 192"
-Cohesion: 0.17
-Nodes (7): ElementInformation, ElementInformationCoverageUnitTest, Element, List, Object, String, Test
+Cohesion: 0.18
+Nodes (6): ElementInformation, ElementInformationCoverageUnitTest, Element, List, String, Test
 
 ### Community 193 - "Community 193"
 Cohesion: 0.19
@@ -1424,12 +1423,12 @@ Cohesion: 0.18
 Nodes (3): AfterMethod, Test, RestActionsUtilsUnitTest
 
 ### Community 201 - "Community 201"
-Cohesion: 0.27
-Nodes (4): RestValidationsBuilder, NativeValidationsBuilder, String, ValidationsExecutor
+Cohesion: 0.14
+Nodes (8): RestValidationsBuilder, JsonCompareWithSpecialCharactersTests, MatchJsonSchemaTests, NativeValidationsBuilder, String, ValidationsExecutor, Test, Test
 
 ### Community 202 - "Community 202"
 Cohesion: 0.21
-Nodes (11): DeterministicRuleEngine, DoctorAnalyzer, DoctorAiAnalysisResult, DoctorReportWriter, EvidenceCollector, DoctorAiAnalysisRequest, DoctorAiAnalysisService, DoctorAnalysisRequest (+3 more)
+Nodes (10): CaptureService, McpCaptureCodeBlockService, McpCaptureReplayResult, PreDestroy, CaptureGenerationResult, CaptureManager, CaptureStatus, McpWorkspacePolicy (+2 more)
 
 ### Community 203 - "Community 203"
 Cohesion: 0.14
@@ -1444,8 +1443,8 @@ Cohesion: 0.23
 Nodes (10): OpenCvVisualProcessingProvider, Boolean, By, Integer, List, Mat, Override, String (+2 more)
 
 ### Community 206 - "Community 206"
-Cohesion: 0.19
-Nodes (6): FailureReporter, Class, String, Throwable, Test, FailureReporterUnitTest
+Cohesion: 0.18
+Nodes (7): ElementActionsHelper, FailureReporter, Class, String, Throwable, Test, FailureReporterUnitTest
 
 ### Community 207 - "Community 207"
 Cohesion: 0.23
@@ -1456,8 +1455,8 @@ Cohesion: 0.17
 Nodes (6): LightHouseGenerateReport, LightHouseGenerateReportCoverageUnitTest, String, WebDriver, AfterMethod, Test
 
 ### Community 209 - "Community 209"
-Cohesion: 0.18
-Nodes (8): EngineService, PostConstruct, BrowserType, By, Path, String, Tool, WebDriver
+Cohesion: 0.26
+Nodes (5): EngineService, BrowserType, String, Tool, WebDriver
 
 ### Community 210 - "Community 210"
 Cohesion: 0.23
@@ -1476,8 +1475,8 @@ Cohesion: 0.11
 Nodes (29): append(), checkpoint(), complete(), ensureIncomplete(), interrupt(), sortedCheckpoints(), sortedEvents(), sortedReferences() (+21 more)
 
 ### Community 214 - "Community 214"
-Cohesion: 0.13
-Nodes (6): Boolean, By, NumbersComparativeRelation, Object, String, JavaHelper
+Cohesion: 0.14
+Nodes (5): Boolean, NumbersComparativeRelation, Object, String, JavaHelper
 
 ### Community 215 - "Community 215"
 Cohesion: 0.20
@@ -1497,18 +1496,18 @@ Nodes (3): ProgressBarLoggerCoverageUnitTest, AfterMethod, Test
 
 ### Community 220 - "Community 220"
 Cohesion: 0.27
-Nodes (6): Config, List, String, SuppressWarnings, Test, XrayIntegrationHelper
+Nodes (7): List, String, SuppressWarnings, HttpExchange, Test, XrayIntegrationHelper, XrayIntegrationHelperCoverageUnitTest
 
 ### Community 221 - "Community 221"
-Cohesion: 0.24
-Nodes (7): CucumberFeatureListener, Class, Object, String, SuppressWarnings, Test, CucumberFeatureListenerUnitTest
+Cohesion: 0.20
+Nodes (8): CucumberFeatureListener, Class, Object, String, SuppressWarnings, Test, TableRow, CucumberFeatureListenerUnitTest
 
 ### Community 222 - "Community 222"
-Cohesion: 0.31
-Nodes (4): AfterMethod, BeforeMethod, Test, RecordManagerDesktopProviderTest
+Cohesion: 0.16
+Nodes (9): DesktopVideoRecordingProvider, AfterMethod, BeforeMethod, InputStream, Override, String, Test, RecordManagerDesktopProviderTest (+1 more)
 
 ### Community 223 - "Community 223"
-Cohesion: 0.29
+Cohesion: 0.27
 Nodes (5): BrowserStackHelper, Boolean, DriverFactoryHelper, MutableCapabilities, String
 
 ### Community 224 - "Community 224"
@@ -1532,8 +1531,8 @@ Cohesion: 0.23
 Nodes (5): ThreadSafeGuiWizardTests, AfterMethod, BeforeMethod, SuppressWarnings, Test
 
 ### Community 231 - "Community 231"
-Cohesion: 0.31
-Nodes (5): AfterTest, BeforeTest, ConfigurationHelper, ITestContext, Step
+Cohesion: 0.16
+Nodes (6): AfterTest, BeforeTest, ConfigurationHelper, ReportHelper, ITestContext, Step
 
 ### Community 232 - "Community 232"
 Cohesion: 0.15
@@ -1555,17 +1554,13 @@ Nodes (7): LocatorRanker, ScoredLocator, ElementSnapshot, EventContext, LocatorC
 Cohesion: 0.19
 Nodes (10): current(), HealingStrategy(), parse(), usesHealenium(), usesShaftHeal(), HealingStrategyTest, String, AfterMethod (+2 more)
 
-### Community 237 - "Community 237"
-Cohesion: 0.13
-Nodes (6): Allure, SetProperty, DefaultValue, Key, SetProperty, String
-
 ### Community 238 - "Community 238"
 Cohesion: 0.18
 Nodes (11): CaptureEvent, CapturePrivacyPolicy, CaptureSessionStore, Consumer, ExternalTestDataReference, Instant, List, Map (+3 more)
 
 ### Community 239 - "Community 239"
-Cohesion: 0.31
-Nodes (4): ScreenshotHelper, Boolean, SuppressWarnings, WebDriver
+Cohesion: 0.25
+Nodes (9): DeterministicNaturalActionPlanner, unsupported(), List, NaturalActionPlan, NaturalActionRequest, Override, String, NaturalActionPlan (+1 more)
 
 ### Community 240 - "Community 240"
 Cohesion: 0.25
@@ -1576,16 +1571,16 @@ Cohesion: 0.20
 Nodes (4): ValidationsMockedTests, AfterMethod, BeforeMethod, Test
 
 ### Community 242 - "Community 242"
-Cohesion: 0.16
-Nodes (11): HealingLocatorProposalService, HealingLocatorProposalServiceTest, HealingLocatorProposal, JsonNode, Path, String, AfterEach, BeforeEach (+3 more)
+Cohesion: 0.31
+Nodes (5): HealingLocatorProposalService, HealingLocatorProposal, JsonNode, Path, String
 
 ### Community 243 - "Community 243"
 Cohesion: 0.21
 Nodes (6): AfterMethod, Class, Object, String, Test, BrowserStackHelperUnitTest
 
 ### Community 244 - "Community 244"
-Cohesion: 0.08
-Nodes (20): LogRedirector, Logger, apply(), applyEnabled(), current(), NaturalActionService, textOrDefault(), withOverrides() (+12 more)
+Cohesion: 0.20
+Nodes (3): BeforeMethod, Test, LogRedirectorUnitTest
 
 ### Community 246 - "Community 246"
 Cohesion: 0.20
@@ -1616,8 +1611,8 @@ Cohesion: 0.18
 Nodes (6): BrowserSteps, Given, String, ThreadLocal, WebDriver, When
 
 ### Community 253 - "Community 253"
-Cohesion: 0.21
-Nodes (7): StandaloneAssertions, StandaloneVerifications, FileValidationsBuilder, Number, NumberValidationsBuilder, String, ValidationsExecutor
+Cohesion: 0.27
+Nodes (4): Allure, DefaultValue, Key, SetProperty
 
 ### Community 254 - "Community 254"
 Cohesion: 0.14
@@ -1634,6 +1629,10 @@ Nodes (4): IOActionsMockedTests, AfterMethod, BeforeMethod, Test
 ### Community 258 - "Community 258"
 Cohesion: 0.24
 Nodes (8): NaturalActionExecutorTest, AfterMethod, BeforeMethod, By, List, Test, WebDriver, WebElement
+
+### Community 259 - "Community 259"
+Cohesion: 0.24
+Nodes (5): EXCEL, ExcelFileManager, TestDataTests, String, Test
 
 ### Community 260 - "Community 260"
 Cohesion: 0.26
@@ -1656,16 +1655,16 @@ Cohesion: 0.21
 Nodes (4): AfterClass, BeforeClass, Test, FileHelperUnitTest
 
 ### Community 265 - "Community 265"
-Cohesion: 0.24
-Nodes (3): RestActionsCoverageUnitTest, AfterMethod, Test
+Cohesion: 0.18
+Nodes (5): RestActionsCoverageUnitTest, Cookie, Set, AfterMethod, Test
 
 ### Community 266 - "Community 266"
 Cohesion: 0.22
 Nodes (11): BooleanSupplier, expired(), InstantDeadline(), ManagedCaptureRecorderBrowserTest, Duration, HttpExchange, HttpServer, ParameterizedTest (+3 more)
 
 ### Community 267 - "Community 267"
-Cohesion: 0.17
-Nodes (5): List, AfterMethod, BeforeMethod, Test, BrowserActionsCoverageUnitTest
+Cohesion: 0.19
+Nodes (4): List, BeforeMethod, Test, BrowserActionsCoverageUnitTest
 
 ### Community 268 - "Community 268"
 Cohesion: 0.21
@@ -1684,16 +1683,16 @@ Cohesion: 0.24
 Nodes (4): FrameTests, AfterMethod, BeforeMethod, Test
 
 ### Community 272 - "Community 272"
-Cohesion: 0.29
-Nodes (4): CaptureJsonCodecTest, Path, String, Test
+Cohesion: 0.33
+Nodes (6): HealingLocatorProposalServiceTest, AfterEach, BeforeEach, Path, String, Test
 
 ### Community 274 - "Community 274"
 Cohesion: 0.21
 Nodes (9): AiProvider, DoctorSnippetProvider, AfterEach, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse, Override (+1 more)
 
 ### Community 275 - "Community 275"
-Cohesion: 0.15
-Nodes (9): FileActionsCoverageUnitTest, FileActionsReflectionInvoker, AfterMethod, BeforeMethod, Path, String, Test, FileActions (+1 more)
+Cohesion: 0.14
+Nodes (10): FileActionsCoverageUnitTest, FileActionsReflectionInvoker, AfterMethod, BeforeMethod, Path, String, Test, FileActions (+2 more)
 
 ### Community 276 - "Community 276"
 Cohesion: 0.27
@@ -1712,8 +1711,8 @@ Cohesion: 0.16
 Nodes (9): HealingProvider, HealingActionOutcome, HealingExplanation, HealingObservation, HealingRequest, HealingResolution, Optional, String (+1 more)
 
 ### Community 280 - "Community 280"
-Cohesion: 0.18
-Nodes (7): OpenCvVisualConsumer, HealingVisualProvider, OpenCvHealingVisualProvider, Override, String, Mat, String
+Cohesion: 0.19
+Nodes (7): HealingVisualProvider, OpenCvHealingVisualProvider, OpenCvHealingVisualProviderTest, Override, String, Color, Test
 
 ### Community 281 - "Community 281"
 Cohesion: 0.27
@@ -1733,7 +1732,7 @@ Nodes (15): type, uniqueItems, enum, facets, additionalProperties, properties, r
 
 ### Community 285 - "Community 285"
 Cohesion: 0.17
-Nodes (12): type, properties, minLength, type, content, mediaType, redacted, relativePath (+4 more)
+Nodes (12): type, items, properties, required, type, content, redacted, relativePath (+4 more)
 
 ### Community 286 - "Community 286"
 Cohesion: 0.13
@@ -1744,20 +1743,16 @@ Cohesion: 0.20
 Nodes (7): AfterMethod, InputStream, Override, String, Test, DesktopVideoRecordingProviderRegistryTest, StubDesktopVideoRecordingProvider
 
 ### Community 288 - "Community 288"
-Cohesion: 0.10
-Nodes (12): ExcelFileManager, TestDataTests, String, Test, AfterMethod, BeforeMethod, Path, Test (+4 more)
+Cohesion: 0.23
+Nodes (5): AfterMethod, BeforeMethod, Path, Test, ExcelFileManagerCoverageUnitTest
 
 ### Community 290 - "Community 290"
 Cohesion: 0.21
 Nodes (7): AfterMethod, BeforeClass, BeforeMethod, Override, String, Test, TestClass
 
-### Community 291 - "Community 291"
-Cohesion: 0.24
-Nodes (3): AndroidTouchActionsTests, ScreenOrientation, Test
-
 ### Community 292 - "Community 292"
-Cohesion: 0.21
-Nodes (7): Callable, FilesSize, Path, Test, Test, CaptureSessionStoreTest, RestActionsFailureLoggingUnitTest
+Cohesion: 0.18
+Nodes (7): Callable, Path, Test, DesktopVideoRecordingProvider, Optional, CaptureSessionStoreTest, DesktopVideoRecordingProviderRegistry
 
 ### Community 293 - "Community 293"
 Cohesion: 0.19
@@ -1768,8 +1763,8 @@ Cohesion: 0.22
 Nodes (7): ElementStepsCoverageUnitTest, BeforeMethod, By, DataProvider, Object, String, Test
 
 ### Community 295 - "Community 295"
-Cohesion: 0.35
-Nodes (5): BasicAPITests, BeforeClass, List, Map, String
+Cohesion: 0.25
+Nodes (13): apply(), applyEnabled(), current(), NaturalActionService, textOrDefault(), withOverrides(), McpNaturalActionResult, NaturalActionSettings (+5 more)
 
 ### Community 296 - "Community 296"
 Cohesion: 0.29
@@ -1796,8 +1791,8 @@ Cohesion: 0.14
 Nodes (14): items, tags, items, additionalProperties, minLength, pattern, properties, required (+6 more)
 
 ### Community 302 - "Community 302"
-Cohesion: 0.23
-Nodes (6): InputStream, Path, String, SuppressWarnings, WebDriver, RecordManager
+Cohesion: 0.27
+Nodes (5): InputStream, Path, SuppressWarnings, WebDriver, RecordManager
 
 ### Community 303 - "Community 303"
 Cohesion: 0.27
@@ -1816,8 +1811,8 @@ Cohesion: 0.14
 Nodes (13): additionalProperties, type, type, properties, body, id, title, userId (+5 more)
 
 ### Community 307 - "Community 307"
-Cohesion: 0.18
-Nodes (9): AccessibilityActions, HttpRequest, HttpResponse, NavigationAction, DriverFactoryHelper, Predicate, Step, WebDriver (+1 more)
+Cohesion: 0.19
+Nodes (9): AccessibilityActions, HttpRequest, HttpResponse, IOSDriver, DriverFactoryHelper, Predicate, Step, WebDriver (+1 more)
 
 ### Community 308 - "Community 308"
 Cohesion: 0.23
@@ -1840,8 +1835,8 @@ Cohesion: 0.21
 Nodes (7): WebDriverBrowserValidationsBuilder, NativeValidationsBuilder, String, StringBuilder, SuppressWarnings, ValidationCategory, WebDriver
 
 ### Community 314 - "Community 314"
-Cohesion: 0.23
-Nodes (9): $, LauncherSessionListener, JunitListener, Status, String, TestIdentifier, Throwable, StatusIcon (+1 more)
+Cohesion: 0.26
+Nodes (8): LauncherSessionListener, JunitListener, Status, String, TestIdentifier, Throwable, StatusIcon, TestExecutionResult
 
 ### Community 315 - "Community 315"
 Cohesion: 0.26
@@ -1880,8 +1875,8 @@ Cohesion: 0.27
 Nodes (4): LocalApiTestServer, HttpExchange, HttpServer, String
 
 ### Community 324 - "Community 324"
-Cohesion: 0.39
-Nodes (4): DoctorServiceTest, DoctorService, Path, Test
+Cohesion: 0.25
+Nodes (4): RunType, AfterMethod, Test, DriverFactoryCoverageUnitTest
 
 ### Community 325 - "Community 325"
 Cohesion: 0.30
@@ -1904,8 +1899,8 @@ Cohesion: 0.29
 Nodes (7): Description, AfterMethod, BeforeClass, BeforeMethod, Step, Test, FluentGuiActionsTest
 
 ### Community 330 - "Community 330"
-Cohesion: 0.23
-Nodes (5): Future, ArrayNode, InputStream, List, ObjectNode
+Cohesion: 0.24
+Nodes (4): ArrayNode, InputStream, List, ObjectNode
 
 ### Community 331 - "Community 331"
 Cohesion: 0.32
@@ -1914,10 +1909,6 @@ Nodes (6): CaptureGeneratedReplayBrowserTest, CaptureSession, ElementSnapshot, E
 ### Community 332 - "Community 332"
 Cohesion: 0.23
 Nodes (8): VisualProcessingProvider, Boolean, By, Integer, List, String, VisualValidationEngine, WebDriver
-
-### Community 333 - "Community 333"
-Cohesion: 0.18
-Nodes (4): ActionsExceptionDetailsUnitTest, NoSuchElementException, List, Test
 
 ### Community 334 - "Community 334"
 Cohesion: 0.18
@@ -1944,12 +1935,12 @@ Cohesion: 0.29
 Nodes (4): DragAndDropTests, AfterMethod, BeforeMethod, Test
 
 ### Community 340 - "Community 340"
-Cohesion: 0.24
+Cohesion: 0.27
 Nodes (3): EngineServiceTest, AfterEach, Test
 
 ### Community 341 - "Community 341"
-Cohesion: 0.27
-Nodes (5): IOSBasicInteractionsTest, AfterMethod, BeforeMethod, SuppressWarnings, Test
+Cohesion: 0.24
+Nodes (6): LogRedirector, Logger, InputStream, OutputStream, Level, Override
 
 ### Community 342 - "Community 342"
 Cohesion: 0.32
@@ -1972,8 +1963,8 @@ Cohesion: 0.17
 Nodes (12): type, scope, pattern, type, branch, project, task, additionalProperties (+4 more)
 
 ### Community 347 - "Community 347"
-Cohesion: 0.13
-Nodes (14): items, type, $id, required, type, properties, evidence, redaction (+6 more)
+Cohesion: 0.17
+Nodes (12): minLength, type, type, properties, bundleId, evidence, redaction, schemaVersion (+4 more)
 
 ### Community 348 - "Community 348"
 Cohesion: 0.26
@@ -1988,11 +1979,11 @@ Cohesion: 0.35
 Nodes (4): HttpExchange, Path, String, TestPageServer
 
 ### Community 352 - "Community 352"
-Cohesion: 0.24
-Nodes (6): Class, Object, String, SuppressWarnings, Test, SmartLocatorsCoverageUnitTest
+Cohesion: 0.35
+Nodes (3): XpathAxis, LocatorBuilder, String
 
 ### Community 353 - "Community 353"
-Cohesion: 0.26
+Cohesion: 0.24
 Nodes (6): AfterMethod, Object, String, Test, ValidationsExecutor, ValidationsExecutorCoverageUnitTest
 
 ### Community 354 - "Community 354"
@@ -2039,6 +2030,10 @@ Nodes (4): GroupsTests, AfterMethod, BeforeMethod, Test
 Cohesion: 0.29
 Nodes (5): SelectMethodTests, AfterMethod, BeforeMethod, String, Test
 
+### Community 365 - "Community 365"
+Cohesion: 0.31
+Nodes (3): NavigationAction, Test, NavigationActionUnitTest
+
 ### Community 366 - "Community 366"
 Cohesion: 0.29
 Nodes (5): UploadFileTests, AfterMethod, BeforeMethod, String, Test
@@ -2060,8 +2055,8 @@ Cohesion: 0.31
 Nodes (3): AfterMethod, Test, FileValidationsBuilderUnitTest
 
 ### Community 372 - "Community 372"
-Cohesion: 0.27
-Nodes (6): AfterMethod, BeforeMethod, HttpExchange, Object, String, XrayIntegrationHelperCoverageUnitTest
+Cohesion: 0.29
+Nodes (4): AfterMethod, BeforeMethod, Object, String
 
 ### Community 373 - "Community 373"
 Cohesion: 0.18
@@ -2076,8 +2071,8 @@ Cohesion: 0.33
 Nodes (8): failure(), success(), AiResponse, AiResponseStatus, AiUsage, Duration, JsonNode, String
 
 ### Community 376 - "Community 376"
-Cohesion: 0.27
-Nodes (8): AiBudget, defaults(), disabled(), defaults(), ApprovalPolicy, DoctorAiAnalysisRequest, ApprovalPolicy, DoctorRepairAiRequest
+Cohesion: 0.67
+Nodes (3): defaults(), ApprovalPolicy, DoctorRepairAiRequest
 
 ### Community 377 - "Community 377"
 Cohesion: 0.20
@@ -2088,8 +2083,8 @@ Cohesion: 0.33
 Nodes (4): HealingProviderRegistry, HealingProvider, List, Optional
 
 ### Community 379 - "Community 379"
-Cohesion: 0.31
-Nodes (5): EngineProperties, SetProperty, Object, SetProperty, String
+Cohesion: 0.23
+Nodes (6): Config, EngineProperties, SetProperty, Object, SetProperty, String
 
 ### Community 381 - "Community 381"
 Cohesion: 0.36
@@ -2104,8 +2099,8 @@ Cohesion: 0.40
 Nodes (3): UploadFileTests, String, Test
 
 ### Community 384 - "Community 384"
-Cohesion: 0.31
-Nodes (4): AfterMethod, String, Test, PropertiesHelperInitializationUnitTest
+Cohesion: 0.27
+Nodes (6): AiCandidateRerankerTest, AfterMethod, HealingConfiguration, HttpExchange, String, Test
 
 ### Community 385 - "Community 385"
 Cohesion: 0.36
@@ -2152,24 +2147,28 @@ Cohesion: 0.20
 Nodes (9): Alternative: Email, Dependency Security, Disclosure Policy, Preferred: GitHub Private Security Advisory, Reporting a Vulnerability, Response Timeline, Scope, Security Policy (+1 more)
 
 ### Community 396 - "Community 396"
-Cohesion: 0.13
-Nodes (11): AndroidDriver, AfterEach, BeforeAll, BeforeEach, Test, TestClass, AfterMethod, BeforeClass (+3 more)
+Cohesion: 0.29
+Nodes (5): AfterEach, BeforeAll, BeforeEach, Test, TestClass
 
 ### Community 397 - "Community 397"
-Cohesion: 0.36
-Nodes (4): Test_LTMobIPARelativePath, AfterMethod, BeforeMethod, Test
+Cohesion: 0.33
+Nodes (4): HoverTests, AfterMethod, BeforeMethod, Test
+
+### Community 398 - "Community 398"
+Cohesion: 0.29
+Nodes (6): NaturalActionPlannerRegistry, List, NaturalActionPlan, NaturalActionPlanner, NaturalActionRequest, String
 
 ### Community 399 - "Community 399"
 Cohesion: 0.31
 Nodes (4): AfterMethod, Object, Test, LambdaTestSetPropertyCoverageUnitTest
 
 ### Community 400 - "Community 400"
-Cohesion: 0.24
-Nodes (5): String, AfterMethod, BeforeMethod, Test, VisualValidationTests
+Cohesion: 0.31
+Nodes (4): AfterMethod, BeforeMethod, Test, VisualValidationTests
 
 ### Community 401 - "Community 401"
-Cohesion: 0.29
-Nodes (4): Actions, ValidationsHelper2CoverageUnitTest, AfterMethod, Test
+Cohesion: 0.39
+Nodes (3): ValidationsHelper2CoverageUnitTest, AfterMethod, Test
 
 ### Community 402 - "Community 402"
 Cohesion: 0.36
@@ -2191,13 +2190,9 @@ Nodes (8): 📝 Additional Notes, 📋 Description, Documentation Site, Evidence
 Cohesion: 0.28
 Nodes (5): JSONValidationsBuilder, NativeValidationsBuilder, Object, RestValidationsBuilder, ValidationsExecutor
 
-### Community 407 - "Community 407"
-Cohesion: 0.24
-Nodes (3): JunitListenerHelper, TestIdentifier, Boolean
-
 ### Community 408 - "Community 408"
-Cohesion: 0.43
-Nodes (4): ShaftMcpApplicationTests, Set, String, Test
+Cohesion: 0.18
+Nodes (11): bounded(), current(), split(), ShaftMcpApplicationTests, EvidenceBundle, HealingConfiguration, List, String (+3 more)
 
 ### Community 409 - "Community 409"
 Cohesion: 0.22
@@ -2212,20 +2207,20 @@ Cohesion: 0.33
 Nodes (4): Test_LTWebAppRealme, AfterMethod, BeforeMethod, Test
 
 ### Community 412 - "Community 412"
-Cohesion: 0.24
-Nodes (5): ChecksumTests, TerminalActions, Path, String, Test
+Cohesion: 0.36
+Nodes (4): ChecksumTests, Path, String, Test
 
 ### Community 413 - "Community 413"
-Cohesion: 0.33
-Nodes (6): Metadata, asCacheHit(), disabled(), empty(), DoctorAdvisory, ProviderAnalysis
+Cohesion: 0.27
+Nodes (7): DecisionResult, HealingDecisionEngine, HealingConfiguration, List, RankedCandidate, Status, String
 
 ### Community 414 - "Community 414"
 Cohesion: 0.47
 Nodes (4): SmartLocators, PathStrategy, By, String
 
 ### Community 416 - "Community 416"
-Cohesion: 0.33
-Nodes (4): EngineServiceRuntimePathTest, AfterEach, BeforeEach, Test
+Cohesion: 0.29
+Nodes (6): Properties, Class, Supplier, SuppressWarnings, T, ThreadLocal
 
 ### Community 417 - "Community 417"
 Cohesion: 0.25
@@ -2252,7 +2247,7 @@ Cohesion: 0.29
 Nodes (5): AfterEach, BeforeAll, BeforeEach, Test, TestClass
 
 ### Community 424 - "Community 424"
-Cohesion: 0.31
+Cohesion: 0.29
 Nodes (5): AfterMethod, BeforeClass, BeforeMethod, Test, TestClass
 
 ### Community 425 - "Community 425"
@@ -2280,12 +2275,16 @@ Cohesion: 0.25
 Nodes (5): DoctorFormatException, ProfileCleanupException, RuntimeException, String, Throwable
 
 ### Community 432 - "Community 432"
-Cohesion: 0.32
-Nodes (5): DesktopVideoRecordingProvider, InputStream, Override, String, StubDesktopVideoRecordingProvider
+Cohesion: 0.38
+Nodes (4): CaptureServiceTest, CaptureService, Path, Test
 
 ### Community 433 - "Community 433"
 Cohesion: 0.25
 Nodes (7): Diagnosis, Evidence Index, Findings, Missing Evidence, Privacy, Remediation, SHAFT Doctor Report
+
+### Community 434 - "Community 434"
+Cohesion: 0.29
+Nodes (5): AfterMethod, BeforeClass, BeforeMethod, Test, TestClass
 
 ### Community 435 - "Community 435"
 Cohesion: 0.43
@@ -2336,12 +2335,12 @@ Cohesion: 0.36
 Nodes (4): LazyLoadingTests, AfterMethod, BeforeMethod, Test
 
 ### Community 448 - "Community 448"
-Cohesion: 0.38
+Cohesion: 0.36
 Nodes (4): RemoteGridVideoAttachmentIT, AfterMethod, BeforeMethod, Test
 
 ### Community 449 - "Community 449"
-Cohesion: 0.43
-Nodes (4): SkipDueToIssueTests, Issue, Issues, Test
+Cohesion: 0.31
+Nodes (5): SkipDueToIssueTests, Issue, Issues, Test, Path
 
 ### Community 450 - "Community 450"
 Cohesion: 0.36
@@ -2360,8 +2359,8 @@ Cohesion: 0.15
 Nodes (13): items, items, type, additionalProperties, minLength, pattern, required, type (+5 more)
 
 ### Community 455 - "Community 455"
-Cohesion: 0.32
-Nodes (3): DesktopVideoRecordingProvider, Optional, DesktopVideoRecordingProviderRegistry
+Cohesion: 0.33
+Nodes (3): BeforeClass, Test, IoExcelFileManagerTests
 
 ### Community 456 - "Community 456"
 Cohesion: 0.36
@@ -2384,8 +2383,8 @@ Cohesion: 0.48
 Nodes (6): main(), property_map(), text(), validate(), Element, Path
 
 ### Community 462 - "Community 462"
-Cohesion: 0.43
-Nodes (6): bounded(), current(), split(), HealingConfiguration, List, String
+Cohesion: 0.22
+Nodes (6): HealingConfiguration, HealingContext, LocatorFingerprint, Optional, Supplier, T
 
 ### Community 463 - "Community 463"
 Cohesion: 0.43
@@ -2396,8 +2395,8 @@ Cohesion: 0.43
 Nodes (3): MobileEmulationTests, AfterMethod, Test
 
 ### Community 465 - "Community 465"
-Cohesion: 0.22
-Nodes (5): TableTests, String, AfterMethod, BeforeMethod, Tests
+Cohesion: 0.09
+Nodes (10): BasicAuthenticationTests, NetworkInterceptionTest, TableTests, SmartLocatorsTests, Test, Test, String, AfterMethod (+2 more)
 
 ### Community 466 - "Community 466"
 Cohesion: 0.53
@@ -2428,8 +2427,8 @@ Cohesion: 0.33
 Nodes (3): InputStream, String, DesktopVideoRecordingProvider
 
 ### Community 473 - "Community 473"
-Cohesion: 0.53
-Nodes (5): allows(), ApprovalPolicy(), EvidenceCategory, ProcessingLocation, Set
+Cohesion: 0.18
+Nodes (13): allows(), ApprovalPolicy(), denyAll(), defaults(), disabled(), defaults(), CaptureGenerationRequest, Path (+5 more)
 
 ### Community 474 - "Community 474"
 Cohesion: 0.67
@@ -2446,6 +2445,10 @@ Nodes (5): option(), ProviderConfiguration(), Map, String, URI
 ### Community 477 - "Community 477"
 Cohesion: 0.40
 Nodes (4): MultipleElementsFoundException, String, Throwable, WebDriverException
+
+### Community 479 - "Community 479"
+Cohesion: 0.36
+Nodes (4): RelativeLocatorsTests, AfterMethod, BeforeMethod, Test
 
 ### Community 480 - "Community 480"
 Cohesion: 0.47
@@ -2524,8 +2527,8 @@ Cohesion: 0.33
 Nodes (5): CommandResult, Captured process result., Return stdout and stderr as one diagnostic string., Run a process without a shell and capture diagnostics., run_command()
 
 ### Community 503 - "Community 503"
-Cohesion: 0.16
-Nodes (9): ElementActions, DynamicLoadingTest, RelativeLocatorsTests, AfterMethod, BeforeMethod, Test, AfterMethod, BeforeMethod (+1 more)
+Cohesion: 0.33
+Nodes (4): DynamicLoadingTest, AfterMethod, BeforeMethod, Test
 
 ### Community 504 - "Community 504"
 Cohesion: 0.47
@@ -2536,16 +2539,16 @@ Cohesion: 0.60
 Nodes (3): AbstractTestNGCucumberTests, CucumberTests, CucumberTests
 
 ### Community 506 - "Community 506"
-Cohesion: 0.40
-Nodes (4): CaptureEnrichmentService, GeneratedTestValidator, LocatorRanker, CaptureJsonCodec
+Cohesion: 0.17
+Nodes (8): CaptureEnrichmentService, MutableTargetPlan, GeneratedTestValidator, LocatorRanker, CaptureJsonCodec, ElementSnapshot, LocatorCandidate, LocatorSelection
 
 ### Community 507 - "Community 507"
 Cohesion: 0.60
 Nodes (4): defaults(), DoctorAnalysisRequest, List, Path
 
 ### Community 511 - "Community 511"
-Cohesion: 0.31
-Nodes (4): SelectedValueTests, AfterMethod, BeforeMethod, Test
+Cohesion: 0.47
+Nodes (3): OpenCvVisualConsumer, Mat, String
 
 ### Community 512 - "Community 512"
 Cohesion: 0.70
@@ -2584,12 +2587,16 @@ Cohesion: 0.50
 Nodes (3): Output, Workflow, Flaky Test Stabilizer
 
 ### Community 525 - "Community 525"
-Cohesion: 0.50
+Cohesion: 0.47
 Nodes (3): JiraTests, BeforeClass, Test
 
 ### Community 526 - "Community 526"
 Cohesion: 0.50
 Nodes (3): Release And Dependency Guard, Output, Workflow
+
+### Community 529 - "Community 529"
+Cohesion: 0.33
+Nodes (5): $id, required, $schema, title, type
 
 ### Community 532 - "Community 532"
 Cohesion: 0.50
@@ -2600,8 +2607,8 @@ Cohesion: 0.67
 Nodes (3): pattern, type, content_hash
 
 ### Community 544 - "Community 544"
-Cohesion: 0.67
-Nodes (3): minLength, type, bundleId
+Cohesion: 0.40
+Nodes (4): Autowired, McpMobileRecordingService, EngineService, McpWorkspacePolicy
 
 ### Community 545 - "Community 545"
 Cohesion: 0.67
@@ -2627,45 +2634,37 @@ Nodes (3): Object, StringBuilder, ValidationCategory
 Cohesion: 0.50
 Nodes (3): from(), DoctorAnalysisResult, DoctorAnalysisSummary
 
+### Community 675 - "Community 675"
+Cohesion: 0.67
+Nodes (3): minLength, type, mediaType
+
 ### Community 676 - "Community 676"
 Cohesion: 0.38
 Nodes (5): ready(), unavailable(), AiProviderAvailability, AiProviderAvailability, String
-
-### Community 677 - "Community 677"
-Cohesion: 0.48
-Nodes (3): OpenCvHealingVisualProviderTest, Color, Test
 
 ### Community 678 - "Community 678"
 Cohesion: 0.33
 Nodes (6): parse_xml(), Parse XML while preserving comments., Return version property, direct SHAFT dependencies, and managed BOM version., Enforce the modular SHAFT dependency contract after every repair., shaft_dependency_state(), validate_upgraded_poms()
 
-### Community 681 - "Community 681"
-Cohesion: 0.67
-Nodes (3): defaults(), CaptureGenerationRequest, Path
-
-### Community 682 - "Community 682"
-Cohesion: 0.67
-Nodes (3): schemaVersion, enum, type
-
 ## Knowledge Gaps
 - **1223 isolated node(s):** `$id`, `$schema`, `additionalProperties`, `additionalProperties`, `type` (+1218 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **82 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **81 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `SHAFT` connect `Community 42` to `Community 1`, `Community 3`, `Community 5`, `Community 8`, `Community 10`, `Community 11`, `Community 12`, `Community 525`, `Community 14`, `Community 13`, `Community 15`, `Community 17`, `Community 18`, `Community 19`, `Community 21`, `Community 536`, `Community 24`, `Community 25`, `Community 27`, `Community 28`, `Community 31`, `Community 32`, `Community 35`, `Community 36`, `Community 37`, `Community 39`, `Community 43`, `Community 44`, `Community 47`, `Community 48`, `Community 49`, `Community 51`, `Community 53`, `Community 55`, `Community 57`, `Community 59`, `Community 61`, `Community 64`, `Community 72`, `Community 74`, `Community 76`, `Community 80`, `Community 81`, `Community 83`, `Community 87`, `Community 90`, `Community 92`, `Community 94`, `Community 97`, `Community 98`, `Community 99`, `Community 100`, `Community 103`, `Community 105`, `Community 106`, `Community 109`, `Community 110`, `Community 111`, `Community 113`, `Community 117`, `Community 120`, `Community 121`, `Community 124`, `Community 125`, `Community 130`, `Community 131`, `Community 134`, `Community 135`, `Community 136`, `Community 138`, `Community 139`, `Community 144`, `Community 145`, `Community 153`, `Community 155`, `Community 156`, `Community 669`, `Community 159`, `Community 160`, `Community 672`, `Community 161`, `Community 164`, `Community 166`, `Community 679`, `Community 680`, `Community 170`, `Community 180`, `Community 184`, `Community 187`, `Community 189`, `Community 194`, `Community 195`, `Community 199`, `Community 203`, `Community 205`, `Community 208`, `Community 209`, `Community 214`, `Community 215`, `Community 220`, `Community 222`, `Community 223`, `Community 225`, `Community 229`, `Community 233`, `Community 236`, `Community 240`, `Community 242`, `Community 243`, `Community 244`, `Community 246`, `Community 248`, `Community 249`, `Community 250`, `Community 252`, `Community 254`, `Community 258`, `Community 267`, `Community 271`, `Community 274`, `Community 275`, `Community 288`, `Community 289`, `Community 290`, `Community 292`, `Community 294`, `Community 296`, `Community 297`, `Community 302`, `Community 303`, `Community 307`, `Community 314`, `Community 316`, `Community 317`, `Community 318`, `Community 320`, `Community 321`, `Community 329`, `Community 330`, `Community 334`, `Community 336`, `Community 339`, `Community 341`, `Community 342`, `Community 348`, `Community 349`, `Community 350`, `Community 353`, `Community 355`, `Community 356`, `Community 358`, `Community 361`, `Community 362`, `Community 363`, `Community 364`, `Community 366`, `Community 370`, `Community 380`, `Community 382`, `Community 385`, `Community 387`, `Community 388`, `Community 396`, `Community 397`, `Community 398`, `Community 399`, `Community 400`, `Community 401`, `Community 403`, `Community 404`, `Community 410`, `Community 411`, `Community 420`, `Community 423`, `Community 424`, `Community 426`, `Community 435`, `Community 438`, `Community 439`, `Community 440`, `Community 441`, `Community 442`, `Community 443`, `Community 444`, `Community 445`, `Community 446`, `Community 448`, `Community 450`, `Community 452`, `Community 456`, `Community 457`, `Community 458`, `Community 459`, `Community 460`, `Community 462`, `Community 463`, `Community 464`, `Community 465`, `Community 467`, `Community 468`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 493`, `Community 494`, `Community 495`, `Community 496`, `Community 497`, `Community 503`, `Community 508`, `Community 511`?**
-  _High betweenness centrality (0.130) - this node is a cross-community bridge._
+- **Why does `SHAFT` connect `Community 42` to `Community 3`, `Community 5`, `Community 8`, `Community 10`, `Community 11`, `Community 12`, `Community 525`, `Community 14`, `Community 13`, `Community 15`, `Community 17`, `Community 18`, `Community 19`, `Community 21`, `Community 536`, `Community 25`, `Community 24`, `Community 27`, `Community 28`, `Community 31`, `Community 35`, `Community 36`, `Community 37`, `Community 39`, `Community 43`, `Community 44`, `Community 47`, `Community 48`, `Community 49`, `Community 51`, `Community 53`, `Community 55`, `Community 57`, `Community 59`, `Community 61`, `Community 64`, `Community 72`, `Community 74`, `Community 76`, `Community 80`, `Community 81`, `Community 82`, `Community 83`, `Community 87`, `Community 90`, `Community 94`, `Community 97`, `Community 98`, `Community 99`, `Community 100`, `Community 105`, `Community 106`, `Community 109`, `Community 110`, `Community 111`, `Community 113`, `Community 117`, `Community 120`, `Community 121`, `Community 124`, `Community 125`, `Community 130`, `Community 131`, `Community 135`, `Community 136`, `Community 138`, `Community 139`, `Community 144`, `Community 145`, `Community 148`, `Community 153`, `Community 155`, `Community 156`, `Community 157`, `Community 159`, `Community 160`, `Community 161`, `Community 164`, `Community 166`, `Community 679`, `Community 680`, `Community 169`, `Community 170`, `Community 180`, `Community 184`, `Community 186`, `Community 189`, `Community 194`, `Community 195`, `Community 199`, `Community 201`, `Community 203`, `Community 205`, `Community 208`, `Community 215`, `Community 216`, `Community 220`, `Community 222`, `Community 223`, `Community 225`, `Community 229`, `Community 231`, `Community 233`, `Community 236`, `Community 240`, `Community 242`, `Community 243`, `Community 246`, `Community 248`, `Community 249`, `Community 250`, `Community 252`, `Community 254`, `Community 258`, `Community 259`, `Community 265`, `Community 271`, `Community 272`, `Community 274`, `Community 275`, `Community 289`, `Community 290`, `Community 294`, `Community 295`, `Community 296`, `Community 297`, `Community 302`, `Community 303`, `Community 307`, `Community 316`, `Community 317`, `Community 318`, `Community 320`, `Community 321`, `Community 324`, `Community 329`, `Community 330`, `Community 334`, `Community 336`, `Community 339`, `Community 342`, `Community 348`, `Community 349`, `Community 350`, `Community 353`, `Community 355`, `Community 356`, `Community 358`, `Community 361`, `Community 362`, `Community 363`, `Community 364`, `Community 366`, `Community 370`, `Community 372`, `Community 380`, `Community 382`, `Community 384`, `Community 385`, `Community 387`, `Community 388`, `Community 396`, `Community 397`, `Community 398`, `Community 399`, `Community 400`, `Community 401`, `Community 403`, `Community 404`, `Community 408`, `Community 410`, `Community 411`, `Community 420`, `Community 423`, `Community 424`, `Community 426`, `Community 434`, `Community 435`, `Community 438`, `Community 439`, `Community 440`, `Community 441`, `Community 442`, `Community 443`, `Community 444`, `Community 445`, `Community 446`, `Community 448`, `Community 450`, `Community 452`, `Community 455`, `Community 456`, `Community 457`, `Community 458`, `Community 459`, `Community 460`, `Community 463`, `Community 464`, `Community 465`, `Community 467`, `Community 468`, `Community 479`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 493`, `Community 494`, `Community 495`, `Community 496`, `Community 497`, `Community 503`, `Community 508`?**
+  _High betweenness centrality (0.119) - this node is a cross-community bridge._
 - **Why does `ThreadLocalPropertiesManager` connect `Community 99` to `Community 37`, `Community 158`?**
-  _High betweenness centrality (0.048) - this node is a cross-community bridge._
-- **Why does `IOException` connect `Community 42` to `Community 2`, `Community 5`, `Community 7`, `Community 10`, `Community 12`, `Community 18`, `Community 26`, `Community 33`, `Community 40`, `Community 45`, `Community 49`, `Community 53`, `Community 61`, `Community 62`, `Community 65`, `Community 67`, `Community 68`, `Community 76`, `Community 96`, `Community 99`, `Community 101`, `Community 105`, `Community 109`, `Community 115`, `Community 117`, `Community 119`, `Community 121`, `Community 122`, `Community 125`, `Community 127`, `Community 129`, `Community 132`, `Community 135`, `Community 141`, `Community 142`, `Community 144`, `Community 147`, `Community 168`, `Community 176`, `Community 180`, `Community 189`, `Community 190`, `Community 202`, `Community 204`, `Community 205`, `Community 207`, `Community 209`, `Community 210`, `Community 242`, `Community 246`, `Community 260`, `Community 264`, `Community 266`, `Community 270`, `Community 272`, `Community 275`, `Community 277`, `Community 278`, `Community 282`, `Community 288`, `Community 290`, `Community 302`, `Community 307`, `Community 322`, `Community 323`, `Community 330`, `Community 350`, `Community 359`, `Community 371`, `Community 384`, `Community 386`, `Community 419`, `Community 422`, `Community 431`, `Community 435`, `Community 448`, `Community 498`?**
-  _High betweenness centrality (0.031) - this node is a cross-community bridge._
+  _High betweenness centrality (0.044) - this node is a cross-community bridge._
+- **Why does `IOException` connect `Community 42` to `Community 2`, `Community 5`, `Community 7`, `Community 10`, `Community 12`, `Community 18`, `Community 23`, `Community 25`, `Community 26`, `Community 33`, `Community 37`, `Community 40`, `Community 45`, `Community 46`, `Community 47`, `Community 49`, `Community 53`, `Community 61`, `Community 62`, `Community 65`, `Community 67`, `Community 68`, `Community 76`, `Community 96`, `Community 99`, `Community 101`, `Community 105`, `Community 109`, `Community 115`, `Community 117`, `Community 119`, `Community 121`, `Community 122`, `Community 125`, `Community 129`, `Community 132`, `Community 135`, `Community 141`, `Community 144`, `Community 168`, `Community 176`, `Community 180`, `Community 189`, `Community 190`, `Community 204`, `Community 205`, `Community 207`, `Community 210`, `Community 216`, `Community 242`, `Community 246`, `Community 260`, `Community 264`, `Community 266`, `Community 270`, `Community 275`, `Community 277`, `Community 278`, `Community 282`, `Community 288`, `Community 290`, `Community 302`, `Community 307`, `Community 322`, `Community 323`, `Community 330`, `Community 350`, `Community 359`, `Community 371`, `Community 372`, `Community 384`, `Community 386`, `Community 419`, `Community 422`, `Community 431`, `Community 435`, `Community 448`, `Community 462`, `Community 498`?**
+  _High betweenness centrality (0.025) - this node is a cross-community bridge._
 - **What connects `$id`, `$schema`, `additionalProperties` to the rest of the system?**
   _1316 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.04124525916561315 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.042869057547956634 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.07490079365079365 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.08182349503214495 - nodes in this community are weakly interconnected._
 - **Should `Community 2` be split into smaller, more focused modules?**
-  _Cohesion score 0.13043478260869565 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.11510204081632654 - nodes in this community are weakly interconnected._

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1445,8 +1445,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/JavaHelper.java": {
-    "mtime": 1781769439.8134294,
-    "ast_hash": "ed73c5c20483f9571b67d9b340812be8",
+    "mtime": 1781782271.7859585,
+    "ast_hash": "fb0e071f32882ff39a72f1069cabcef2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/JavaScriptHelper.java": {
@@ -1830,8 +1830,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java": {
-    "mtime": 1781780360.7515037,
-    "ast_hash": "9ca7c0c0031ba4caed9d0dea75078780",
+    "mtime": 1781782271.7869594,
+    "ast_hash": "8288f5e7a65416b25ef579fbda93b2a5",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsExceptionDetailsUnitTest.java": {
@@ -2485,8 +2485,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/MultipleElementsFailureTest.java": {
-    "mtime": 1781769440.0986853,
-    "ast_hash": "241d67949c16293b2350791d139a82fe",
+    "mtime": 1781782563.4762137,
+    "ast_hash": "909b2eba6f1cf274f2b04b7c07ef7a69",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/MultipleTypeCyclesTest.java": {
@@ -2850,8 +2850,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/JavaHelperUnitTest.java": {
-    "mtime": 1781769440.1301465,
-    "ast_hash": "c09490944c2173777d187a7ae1ae7898",
+    "mtime": 1781782271.7879632,
+    "ast_hash": "79e34e3aa072c060c6d5d6863091b665",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/JunitListenerApiCoverageUnitTest.java": {
@@ -2955,8 +2955,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ReportManagerHelperUnitTests.java": {
-    "mtime": 1781769440.1392891,
-    "ast_hash": "398246ec1c6f2392c6f5d655c7e887e9",
+    "mtime": 1781781948.1145775,
+    "ast_hash": "aa879c4f77dc5625400f89625e5edbbe",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RestActionsFailureLoggingUnitTest.java": {

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1020,8 +1020,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java": {
-    "mtime": 1781769439.7734878,
-    "ast_hash": "95ed51b85934932c7c9c9d0449b98fdd",
+    "mtime": 1781780004.9564764,
+    "ast_hash": "8ac06b1b00ecbb3c0def2e30fdb2861e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java": {
@@ -1830,8 +1830,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java": {
-    "mtime": 1781769440.0315223,
-    "ast_hash": "9f4d311834c058cb0af3888c87dca6bb",
+    "mtime": 1781780360.7515037,
+    "ast_hash": "9ca7c0c0031ba4caed9d0dea75078780",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsExceptionDetailsUnitTest.java": {

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1,7066 +1,4791 @@
 {
   ".memory/config.json": {
-    "mtime": 1781532137.9712684,
-    "ast_hash": "fe73b1fa613388699b7cba0b5d6195c7",
+    "mtime": 1781769439.5793602,
+    "ast_hash": "4ece894daf076c559889cf9afe6211e8",
     "semantic_hash": ""
   },
   ".memory/memory/architecture.json": {
-    "mtime": 1781532411.322919,
-    "ast_hash": "5098c46dde3c89ade906289c709b8d5f",
+    "mtime": 1781769439.5803604,
+    "ast_hash": "cfc3c045ead7b74d483c04bc6746ea4e",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/maven-central-version-immutability.json": {
-    "mtime": 1781532411.3139193,
-    "ast_hash": "64d5e0839a0b7b6ec04c0301a0a3a26d",
+    "mtime": 1781769439.5823598,
+    "ast_hash": "434d7f5918634bb78e5a7abc8d7bf7ce",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/paid-agent-work-audit-gated.json": {
-    "mtime": 1781532411.2597613,
-    "ast_hash": "829aaec967a65269761648ac86b88b8c",
+    "mtime": 1781769439.5823598,
+    "ast_hash": "61f81f00078da8d614a21373fd7e8089",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/agent-guidance-progressive-disclosure.json": {
-    "mtime": 1781532411.2537606,
-    "ast_hash": "61c923e22c1d55b55c62d1620f7a449b",
+    "mtime": 1781769439.58336,
+    "ast_hash": "e128e34dc07f199c0c8f65b940905761",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/namespaced-video-capabilities.json": {
-    "mtime": 1781532411.3079193,
-    "ast_hash": "2a5aa7224c7e1e8f475c4566d1c0b51d",
+    "mtime": 1781769439.5843606,
+    "ast_hash": "38736f88f73b401031d168040fb2e609",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/public-docs-external.json": {
-    "mtime": 1781532575.6156359,
-    "ast_hash": "4415d00b4d53a429a1cf35f573571f5b",
+    "mtime": 1781769439.5853598,
+    "ast_hash": "2ff158084eb2a6eb7d8e2ff4aafaf67c",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/utf8-all-runtime-layers.json": {
-    "mtime": 1781532411.270761,
-    "ast_hash": "913df32147be61c076ebaec3b2c73ab3",
+    "mtime": 1781769439.5853598,
+    "ast_hash": "0537ffa6937eab44bf326e9a2af4eca9",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/allure-result-population.json": {
-    "mtime": 1781532411.2767615,
-    "ast_hash": "bff8ce7b4f6eeed7fd8f6f42ed6a32df",
+    "mtime": 1781769439.5863597,
+    "ast_hash": "0b408e349588a98b38afad0c067e86da",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/coverage-constructors-start-browser.json": {
-    "mtime": 1781532411.3031101,
-    "ast_hash": "e032c7b71fb63e76a7fb9038ead45b2d",
+    "mtime": 1781769439.58786,
+    "ast_hash": "c26c533a52af00631104647ed120e846",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/java25-isuite-mocking.json": {
-    "mtime": 1781532411.2980642,
-    "ast_hash": "645422dad9af1d328de86fda4ba01c29",
+    "mtime": 1781769439.58786,
+    "ast_hash": "172391dc5cc831f90c86f7f71b305c19",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/surefire-testng-deletes-module.json": {
-    "mtime": 1781687980.9192278,
+    "mtime": 1781769439.5898657,
     "ast_hash": "a95394b696c3f3efb8b9116113281e2e",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/testng-method-parallel-shared-instance-fields.json": {
-    "mtime": 1781532575.6179595,
-    "ast_hash": "068a335ff6b1a047f9e2794227a70885",
+    "mtime": 1781769439.5908654,
+    "ast_hash": "1d489c077df56ae50e23e4b41f6da2f3",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/testng-single-threaded-static-state.json": {
-    "mtime": 1781532411.2929628,
-    "ast_hash": "015cbc0174215cd557582f1fc31b4a92",
+    "mtime": 1781769439.5918655,
+    "ast_hash": "41ae606ccc9cebd6325667da85ac2392",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/windows-allure-root-race.json": {
-    "mtime": 1781532411.281962,
-    "ast_hash": "cbf6bcab86461e2dd2930d37c022e9f7",
+    "mtime": 1781769439.5918655,
+    "ast_hash": "2f12b8774174d36ad6dd9f7375c9ebca",
     "semantic_hash": ""
   },
   ".memory/memory/project.json": {
-    "mtime": 1781532411.3189185,
-    "ast_hash": "16bd763b46c368f19e7ea7eb867e181c",
+    "mtime": 1781769439.5934837,
+    "ast_hash": "f0a00de79160381997ea0562bcea283c",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/issue-linked-pr-closure-and-focused-tests.json": {
-    "mtime": 1781684453.1693225,
-    "ast_hash": "aa223d0931d158d4f0488b81e293baff",
+    "mtime": 1781769439.5995455,
+    "ast_hash": "ec46aa71d095fface3f1692bde6926b1",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/low-token-user-guide-work.json": {
-    "mtime": 1781592922.436471,
+    "mtime": 1781769439.6005454,
     "ast_hash": "b4fd7b27d046eccd67b552fac5f7d31c",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/proactive-memory-use-when-material.json": {
-    "mtime": 1781592922.4374704,
+    "mtime": 1781769439.6025455,
     "ast_hash": "dcc3243cb2aef6624523d32b6a2ec027",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/start-new-tasks-from-origin-main.json": {
-    "mtime": 1781592922.4384708,
+    "mtime": 1781769439.6045456,
     "ast_hash": "2787b374085373936debe0a9cc90196f",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/update-official-user-guide-for-functionality-changes.json": {
-    "mtime": 1781592922.439472,
+    "mtime": 1781769439.6055448,
     "ast_hash": "25cd51397aafa8823d00734801c3b62f",
     "semantic_hash": ""
   },
   ".memory/relations/project-shaft-engine-related-to-architecture-current.json": {
-    "mtime": 1781531996.1462579,
-    "ast_hash": "6ae71251a432cf12a2f3f5da5c6ce3d3",
+    "mtime": 1781769439.6075456,
+    "ast_hash": "61f899057083188f3c611b1207e86344",
     "semantic_hash": ""
   },
   ".memory/schema/config.schema.json": {
-    "mtime": 1781531996.123257,
-    "ast_hash": "573d9931fde886f4acaa82e025d53f68",
+    "mtime": 1781769439.6105502,
+    "ast_hash": "a9df65611183adc20ed4598acd8c8496",
     "semantic_hash": ""
   },
   ".memory/schema/event.schema.json": {
-    "mtime": 1781531996.1312582,
-    "ast_hash": "6ceff41ef29eb4c95d1e9fbcfd67b465",
+    "mtime": 1781769439.6115496,
+    "ast_hash": "b48fe7cc7267789e3f05371800d2572f",
     "semantic_hash": ""
   },
   ".memory/schema/object.schema.json": {
-    "mtime": 1781531996.1262586,
-    "ast_hash": "d5c0f4b8b3a0a71002ff95ffc1086f3a",
+    "mtime": 1781769439.6115496,
+    "ast_hash": "df0c4608282c91449d7445ca2109376f",
     "semantic_hash": ""
   },
   ".memory/schema/patch.schema.json": {
-    "mtime": 1781531996.134257,
-    "ast_hash": "6253ea387ffbcc421315cd018f01db91",
+    "mtime": 1781769439.6115496,
+    "ast_hash": "5476dea56f653fe6ae9b3237c911dc6a",
     "semantic_hash": ""
   },
   ".memory/schema/relation.schema.json": {
-    "mtime": 1781531996.1282597,
-    "ast_hash": "a042c5d488da226dc4c52a5dd589cb59",
+    "mtime": 1781769439.6125498,
+    "ast_hash": "05342c9eb8c7b7bdc8ef3a73d3eedc5a",
     "semantic_hash": ""
   },
   "scripts/ci/agent_guidance_budget.json": {
-    "mtime": 1781532137.9712684,
-    "ast_hash": "ead023ad60324e11804b6853a017f1da",
+    "mtime": 1781769439.6695595,
+    "ast_hash": "2b80174c06109db459e1b9247b7110b6",
     "semantic_hash": ""
   },
   "scripts/ci/assemble_javadocs.py": {
-    "mtime": 1781282308.4886944,
-    "ast_hash": "12c110d7d37ed1347d258c9fcceb9008",
+    "mtime": 1781769439.6705594,
+    "ast_hash": "9cdc9e1b51d3d133a9c8b984cb7bab10",
     "semantic_hash": ""
   },
   "scripts/ci/check_maven_release_version.py": {
-    "mtime": 1781183200.1007686,
+    "mtime": 1781769439.6705594,
     "ast_hash": "e92141a897e15092ed65fcd13f36fa6d",
     "semantic_hash": ""
   },
   "scripts/ci/extract_allure_failures.py": {
-    "mtime": 1781170594.8061461,
+    "mtime": 1781769439.6715598,
     "ast_hash": "1392425a815e5e3d6c98a0a07531a282",
     "semantic_hash": ""
   },
   "scripts/ci/github-auth-env.sh": {
-    "mtime": 1781170594.8061461,
+    "mtime": 1781769439.6715598,
     "ast_hash": "2f1a16109a60700251b2b1e8b204a331",
     "semantic_hash": ""
   },
   "scripts/ci/validate_agent_guidance.py": {
-    "mtime": 1781532169.0502758,
-    "ast_hash": "8b9d3f2297c62cdb570efe919933f8d8",
+    "mtime": 1781769439.6725588,
+    "ast_hash": "6efb73d9c1754b06f29ff45b3d15f6ad",
     "semantic_hash": ""
   },
   "scripts/ci/validate_agent_setup.py": {
-    "mtime": 1781532638.7473931,
-    "ast_hash": "1b9b793f7aa5583f788a4eafc9919ff5",
+    "mtime": 1781769439.6725588,
+    "ast_hash": "510d4cb0ac7e970d1e485e0798690b22",
     "semantic_hash": ""
   },
   "scripts/ci/validate_documentation_boundaries.py": {
-    "mtime": 1781684639.6344943,
-    "ast_hash": "23d8ff37a9d9172622e27112e4ad1a7d",
+    "mtime": 1781769439.6725588,
+    "ast_hash": "73765afafaf6e0bdbdbad78962958428",
     "semantic_hash": ""
   },
   "scripts/ci/validate_maven_publication.py": {
-    "mtime": 1781692327.935221,
-    "ast_hash": "f9a60c176191f60ee1956171cb159c9b",
+    "mtime": 1781769439.6735594,
+    "ast_hash": "b30a099549e23dba6a1c00877649c186",
     "semantic_hash": ""
   },
   "scripts/ci/validate_modular_documentation.py": {
-    "mtime": 1781710434.3967495,
-    "ast_hash": "055795880ad2f4dd05b6a5e10f5d5c46",
+    "mtime": 1781769439.6735594,
+    "ast_hash": "b1104cea9defbd820b486389d0ebbb31",
     "semantic_hash": ""
   },
   "scripts/ci/validate_quality_configuration.py": {
-    "mtime": 1781721189.8903306,
-    "ast_hash": "49f22e6c26966e5c096403e3630d95d6",
+    "mtime": 1781769439.6745596,
+    "ast_hash": "7ea8e7c413b65535474333a58f004843",
     "semantic_hash": ""
   },
   "scripts/ci/validate_reactor_versions.py": {
-    "mtime": 1781170594.8111436,
+    "mtime": 1781769439.6745596,
     "ast_hash": "7ada71bfaf0bf09a2a118f3a172169e4",
     "semantic_hash": ""
   },
   "scripts/ci/validate_shaft_mcp_configuration.py": {
-    "mtime": 1781692539.3759117,
-    "ast_hash": "07b67df1acbdaffb5c7f1c2ed1a34a01",
+    "mtime": 1781769439.6755595,
+    "ast_hash": "175c2bfd37f468d3827417eb039084f6",
     "semantic_hash": ""
   },
   "scripts/ci/validate_shaft_mcp_transports.py": {
-    "mtime": 1781692904.353998,
-    "ast_hash": "2b36e8e77d9e0af278fff06b10933ced",
+    "mtime": 1781769439.6755595,
+    "ast_hash": "3d3af24b9169dfbdb6690c41b5c9caec",
     "semantic_hash": ""
   },
   "scripts/ci/validate_shaft_pilot_release.py": {
-    "mtime": 1781685472.077168,
-    "ast_hash": "3dce6ef2ca2019f053ea2d3904ff1aac",
+    "mtime": 1781769439.676559,
+    "ast_hash": "b9f4064afb31d843b66fa3323ca29d6f",
     "semantic_hash": ""
   },
   "scripts/ci/verify_maven_central_release.py": {
-    "mtime": 1781428152.3247216,
-    "ast_hash": "be8ac9953873460f2c2d94950bc94851",
+    "mtime": 1781769439.676559,
+    "ast_hash": "3dd9c72e612d9631577e8d6d75da3e50",
     "semantic_hash": ""
   },
   "scripts/ci/verify_shaft_mcp_installer_release.py": {
-    "mtime": 1781691702.5153542,
-    "ast_hash": "f69d0d45b1ecf03822417cca5492a938",
+    "mtime": 1781769439.676559,
+    "ast_hash": "80d247522d7fdc48d0d409f8af901a6f",
     "semantic_hash": ""
   },
   "scripts/maintenance/flatten-history.sh": {
-    "mtime": 1781170594.8141456,
+    "mtime": 1781769439.6775596,
     "ast_hash": "dde238359c6206f7dd16219757f04f07",
     "semantic_hash": ""
   },
   "scripts/mcp/install-shaft-mcp.ps1": {
-    "mtime": 1781642509.7728486,
+    "mtime": 1781769439.6785588,
     "ast_hash": "af6a0f91484d8cbe9c99f3025bec0fd7",
     "semantic_hash": ""
   },
   "scripts/mcp/install-shaft-mcp.sh": {
-    "mtime": 1781642509.773848,
+    "mtime": 1781769439.6785588,
     "ast_hash": "1baff48fb0433a69fdce5c1f5894f440",
     "semantic_hash": ""
   },
   "scripts/mcp/install_shaft_mcp.py": {
-    "mtime": 1781691621.2331731,
-    "ast_hash": "587b85141c7c99810579d7ddaddbf62a",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/003e1f82-c602-45de-a593-6e487c50045e-result.json": {
-    "mtime": 1781544169.3793347,
-    "ast_hash": "530f709fdbdf90ee77e0315243abd2dd",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/00e78cd6-5205-46a5-960a-3d64735d8b2b-result.json": {
-    "mtime": 1781285621.7987845,
-    "ast_hash": "783d09a78cd0326594cbc611c3a5d6fe",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/029e6b5d-d5f3-446e-b28f-2be3123a823b-result.json": {
-    "mtime": 1781261318.512862,
-    "ast_hash": "c002674493cc396345fc0318e4684ad7",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/03646478-b0e0-458e-818c-754c40cbd14d-result.json": {
-    "mtime": 1781544168.6979864,
-    "ast_hash": "8e7eda3e6f60bb85a5decd28af8af33a",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/054c8a28-5443-4067-893d-c2d27844faee-result.json": {
-    "mtime": 1781261321.8718698,
-    "ast_hash": "323857f4748dd3077a0cc5c657d79f9b",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/05d4b4f2-a33c-4b7f-820b-114fabe581b0-container.json": {
-    "mtime": 1781285621.9678926,
-    "ast_hash": "872b2525eb84213d1b76afa6b32c85f7",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/05d66aee-53c9-4b1f-8281-7eb3bb57951f-result.json": {
-    "mtime": 1781544169.354348,
-    "ast_hash": "2fa3971ce09b2fd751e98793c241e887",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/065e20bb-e470-4c6b-a7c7-e9a5ee9349e9-container.json": {
-    "mtime": 1781285622.259012,
-    "ast_hash": "c4799ab83abe5143b74278f08e3ed996",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/0a1e1bca-131d-45ca-ac40-e125307b823e-container.json": {
-    "mtime": 1781544169.6461914,
-    "ast_hash": "2d0b7d6eb6656971445d84471fcb4727",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/0ccf1454-ba8e-4534-a089-69715cf63610-container.json": {
-    "mtime": 1781285621.4925168,
-    "ast_hash": "847a56caa549f09d4e8daec5adc2303e",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/0cf75200-8b2f-4eff-afc3-5eb36a61e214-container.json": {
-    "mtime": 1781261320.0432613,
-    "ast_hash": "ff0bb284b4a484a7b5dbceaacc321d7d",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/0d49aa3f-e89a-4ef1-b98c-80501e0b0bbe-container.json": {
-    "mtime": 1781261319.9733706,
-    "ast_hash": "7aac6f239406b7ae4dc288ff499f4857",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/0fcd36b9-ca3e-4209-a7ab-4a2ae297b6c9-container.json": {
-    "mtime": 1781544167.6984634,
-    "ast_hash": "b37b5564cefe5652340143ed0cc0b367",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/1111116b-da7c-42bb-92fb-6a7efe12626b-result.json": {
-    "mtime": 1781285621.23661,
-    "ast_hash": "5bce7efed8c0a686c93b63d65f5cb260",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/11558f66-728f-4209-afc5-b9a5f708f099-container.json": {
-    "mtime": 1781544168.7864978,
-    "ast_hash": "db877f11d0b470a0794f8b5ae19ff5c9",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/14044b16-2558-40ea-b0c4-33c17ae8f327-container.json": {
-    "mtime": 1781285621.2376099,
-    "ast_hash": "90b08a2cbca636050f84b74b35d86591",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/1561e036-d4a1-4783-9e92-c81831812650-container.json": {
-    "mtime": 1781285621.8617828,
-    "ast_hash": "1a68c48b061755f0e74520cdbfcec27e",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/158f164b-e018-4830-bc68-61ddda0719ee-container.json": {
-    "mtime": 1781261317.902633,
-    "ast_hash": "9b1d67eccf660a756befa3762a8023a3",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/1620c056-2a31-40df-9891-fa7737db7203-container.json": {
-    "mtime": 1781544169.0503466,
-    "ast_hash": "f903d5e91218a236ce9179b916481774",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/18fd07d0-5677-46c5-b597-6bbe45f98ab9-result.json": {
-    "mtime": 1781544167.7850475,
-    "ast_hash": "1331c3ce9a504c4fd57a5a16c90b4077",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/1ab47115-cdbc-44bd-ba5c-d87936415622-result.json": {
-    "mtime": 1781544169.5161636,
-    "ast_hash": "b8915c434a030f87f2d34249fe7635de",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/1b29b644-617f-4b22-81ea-11c6935473bc-container.json": {
-    "mtime": 1781285620.7548947,
-    "ast_hash": "2e26622b25a51a4f10f331051fd520e4",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/1da089c3-e0ea-4f7a-87ac-d7edbb504b2f-result.json": {
-    "mtime": 1781261322.103384,
-    "ast_hash": "e63713e46a094cad0c85d9f956733f83",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/1e77a8d1-c322-4464-bfb3-4cc11fc97041-result.json": {
-    "mtime": 1781261320.5309844,
-    "ast_hash": "3b2305b98182c3308b8c2bbf89175227",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/1ec465c9-e2e7-4dba-b545-2fe7056d0533-container.json": {
-    "mtime": 1781544167.7770483,
-    "ast_hash": "318de62b84ac821b55c5b9a1c7193b56",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/2190097c-b583-47a1-9b91-7c65578d1a51-container.json": {
-    "mtime": 1781261318.6379774,
-    "ast_hash": "c5759caab29409d11a61f22ee3ac7502",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/21f086ee-4c99-44ce-a128-479f6eed1a72-result.json": {
-    "mtime": 1781544168.4313269,
-    "ast_hash": "6775ef8878d61b00018bed2682ed6a35",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/228915c6-8092-43ef-9346-04157e646166-container.json": {
-    "mtime": 1781261316.7489552,
-    "ast_hash": "365b3a6718b53f9900fce2c5c31b1b86",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/22eea95f-a595-4d66-9716-0a4e27d2234e-result.json": {
-    "mtime": 1781544168.7864978,
-    "ast_hash": "03dc4e5d1dd073ecff4e04808d9fd1dc",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/28dbf8ae-311d-47f4-a108-5a3946a0df81-container.json": {
-    "mtime": 1781261320.5319872,
-    "ast_hash": "8211b6b5d971b886099d3527be06c7ad",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/29335458-4873-4020-a2ad-1079e3f224ba-result.json": {
-    "mtime": 1781285621.9008975,
-    "ast_hash": "c28f410ded2069074210b33403d037a3",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/2a58c4ef-614d-44bc-ae22-854344717d98-container.json": {
-    "mtime": 1781261321.67352,
-    "ast_hash": "dabc1d7336b5f2c1dfbe1c2dd75bd190",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/2af14a68-1378-4ce5-8224-f2248a10aa0a-result.json": {
-    "mtime": 1781285621.545509,
-    "ast_hash": "e96f71edc0451c346b9b6a03566f0f46",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/2c91a449-7f68-4e1b-8082-57dc96138868-container.json": {
-    "mtime": 1781544168.6989858,
-    "ast_hash": "1c169ea7987a8493ac8369997e782c2f",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/2fe4e440-6603-47fa-a1a0-12bae1a3ee0a-result.json": {
-    "mtime": 1781285621.9348967,
-    "ast_hash": "07d3547c464a7e67cc56b6aa395db3d2",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/32e0fa54-4849-42b7-a4ec-c5d723fc4b19-result.json": {
-    "mtime": 1781544169.4387085,
-    "ast_hash": "9136909134e62531730ab51f7e09f74d",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/3368c5e8-0701-4a68-b91b-4807d6d72167-result.json": {
-    "mtime": 1781285622.1659243,
-    "ast_hash": "35a2181b85a8ffef0a886e28ee5ba504",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/35436527-1b31-4a74-a969-9d4e973f77fe-container.json": {
-    "mtime": 1781261322.1113656,
-    "ast_hash": "67a6b7b680dae1eb00ef97712b33440d",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/3869519d-c91a-4a6b-855c-fd553a363dfb-container.json": {
-    "mtime": 1781285622.299257,
-    "ast_hash": "f256443d848b539d3f97ada15132d13a",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/3d25548a-d9af-4c92-a9de-f91f22c81534-result.json": {
-    "mtime": 1781285621.4915168,
-    "ast_hash": "7c18ed3fdc8471b2ff18ce55fbaf8ba3",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/3dbae705-4499-4266-b0cf-c233ad57b25e-container.json": {
-    "mtime": 1781285621.9348967,
-    "ast_hash": "0e362d6b4516899adced6b4128e0b8fa",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/4009486d-c4e7-489b-be4c-4b58d728282e-container.json": {
-    "mtime": 1781544169.775251,
-    "ast_hash": "c187a5aeaa77c4958f20d4129f2e9e2e",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/417eb7a4-f0e1-427d-bd4a-c69d3e766586-result.json": {
-    "mtime": 1781285621.829784,
-    "ast_hash": "6f5f5320d43cf42ff9cde3ea9cdbc0d5",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/447ff5fa-1430-4556-8c36-2f05145b8f0c-container.json": {
-    "mtime": 1781544168.330366,
-    "ast_hash": "df6e0a420edd5ca476b810c4eb406267",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/4497eb79-2055-4c0e-8a61-5cc410f2e139-container.json": {
-    "mtime": 1781544169.0218415,
-    "ast_hash": "499b940733fe6ccbecb1f92111f0e099",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/45290117-53b7-44fc-8d97-2c0bad3b0be5-result.json": {
-    "mtime": 1781261321.6685355,
-    "ast_hash": "e3bf9aca80857c8076e7092791640fe1",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/452fd3d7-302b-4477-95b2-5e5d5e48896f-container.json": {
-    "mtime": 1781544167.7549763,
-    "ast_hash": "34c101372900b78f4142b3e135680a60",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/47eaec97-7ac4-49ef-bf39-c0af5028d65d-container.json": {
-    "mtime": 1781544168.400811,
-    "ast_hash": "57407a62cec9782dabf5d0c85fd5478f",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/49094527-7b5f-4452-b1d8-d9d723e12b01-result.json": {
-    "mtime": 1781261321.4015617,
-    "ast_hash": "b851a6f09e8bc5d8e4f4a6b6e427ff16",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/4a67047e-e108-4b64-b472-892f901a3eaf-container.json": {
-    "mtime": 1781261319.8125777,
-    "ast_hash": "4fff48995a60bdff89462b41b179a789",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/4c1b4ac3-438d-4498-9edf-e1fe80b8e5b4-result.json": {
-    "mtime": 1781544168.7274983,
-    "ast_hash": "928cbb66e9942357bcf51db5450e71a8",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/4cb545fe-ba30-471f-8696-b42996e18000-container.json": {
-    "mtime": 1781544169.7702487,
-    "ast_hash": "7a941454371b6d3bc93f802efc3e435b",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/4cff752c-cd5f-4841-83ce-ce817976c841-result.json": {
-    "mtime": 1781544169.020846,
-    "ast_hash": "16d32380d2fda21c8c5e6997ab8a6997",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/4f9b8307-16e9-4230-b848-d0869133c4c0-container.json": {
-    "mtime": 1781261323.8503633,
-    "ast_hash": "4e71838dd124576489c41428f9ebffd7",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/50d12967-9139-4329-a634-560ca5ef172c-result.json": {
-    "mtime": 1781544168.3293679,
-    "ast_hash": "18efd67a50d3c1efc13299532e1e0a7a",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/5440ed31-0ad7-42bf-aba0-ccb38ce0da01-container.json": {
-    "mtime": 1781544169.5171683,
-    "ast_hash": "775f92187cd979af9f783d4d8e1d1f1c",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/54aefe6a-2059-4137-9160-7f73633460a4-container.json": {
-    "mtime": 1781285620.4636307,
-    "ast_hash": "6ce1cd9efbef7bb737496707d16a8edb",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/5518a1e6-049d-4ad3-bad6-461e7d2b921f-result.json": {
-    "mtime": 1781285620.8584082,
-    "ast_hash": "d0ede7bb22ac67c8e4bd1b29e2cfadec",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/55dc9390-c0e3-44fd-bae3-6f10204bbb13-result.json": {
-    "mtime": 1781261319.710932,
-    "ast_hash": "9aeb1b4468e2501465565559a3f291de",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/5634b50e-18ed-4247-a609-4f0e25bcbe7c-result.json": {
-    "mtime": 1781285621.9668915,
-    "ast_hash": "6c92b195480672723a744164cbb43bb3",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/571eb065-095c-42de-a577-d60c14627f12-result.json": {
-    "mtime": 1781544168.6711276,
-    "ast_hash": "e956001ae42abcec31b0bda3000e5787",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/588f6285-7522-4c2e-9769-a95a940f3256-container.json": {
-    "mtime": 1781285621.8607833,
-    "ast_hash": "33cbfce9fa9a37ffcf88b76e87f4eba4",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/58e7f1e6-7279-47df-a265-1b83f4c84ae3-container.json": {
-    "mtime": 1781544168.4313269,
-    "ast_hash": "ffbe9b6958c7e613c201653cc3fdab23",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/5a10ed6e-5421-4e00-83b4-ed50a235d47f-container.json": {
-    "mtime": 1781544169.3553374,
-    "ast_hash": "5e5fe8d37fdafb245c98228a7f0bef24",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/5f5153ce-f10c-4053-be00-e4d1c22ffc6b-container.json": {
-    "mtime": 1781544169.4651663,
-    "ast_hash": "3cd4f1997ea430eaae22ee82ad522793",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/5ff4776a-6c26-4c96-96dd-841a3dd42891-result.json": {
-    "mtime": 1781544169.0493486,
-    "ast_hash": "b1237a23903863bace5004736f4110be",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/62738233-ea95-44ba-ab50-6792a24625cb-container.json": {
-    "mtime": 1781285621.2106109,
-    "ast_hash": "8653ce964ee41432a3de181f10260b13",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/6279ad8f-bf1b-4c2b-8df9-1ff017b8b01e-result.json": {
-    "mtime": 1781261318.8578725,
-    "ast_hash": "3bfc3ab502898f405ab3dd48af27cec8",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/631ba120-0ad9-41e4-8fef-c05f3fa66b50-result.json": {
-    "mtime": 1781544169.1013443,
-    "ast_hash": "9f8ab06e805884d89dff08b0821f7d63",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/63a37372-fb09-4712-b601-3d6fe478e191-result.json": {
-    "mtime": 1781261319.8095944,
-    "ast_hash": "44d4fbabbd36e2c7db9fe64c479006f4",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/63ab7c58-a725-495a-9f8d-66769810c97c-result.json": {
-    "mtime": 1781544169.4048698,
-    "ast_hash": "b8132acc8c5e79ddba5e7908a6961e39",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/65dc24b7-9f20-4609-a88c-17b16666e373-container.json": {
-    "mtime": 1781544169.3803363,
-    "ast_hash": "0fea4743191e06ac817db7394ab50352",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/6608f3db-cef0-4afd-8717-2d48db895a7c-result.json": {
-    "mtime": 1781544169.1278596,
-    "ast_hash": "e8d5503c398fa2007c3a2d23b689600e",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/6732249f-aad0-40ce-8fa0-38b6b94e4f5d-container.json": {
-    "mtime": 1781285621.1751037,
-    "ast_hash": "24c102ef40098fbad596e2e4e241462e",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/69b1f0e4-6e3f-4702-bd9f-895b385c905b-result.json": {
-    "mtime": 1781544169.464165,
-    "ast_hash": "408a2e0b791e24c5e6db8f450789c022",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/6b0571bc-6fec-440e-8db8-81e4ebfad30d-container.json": {
-    "mtime": 1781261318.111889,
-    "ast_hash": "ffc4e0b2b3e7c0fac2242eab148b2fff",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/6e80c07e-5f7a-47aa-8b14-0305c87c3c46-container.json": {
-    "mtime": 1781544167.7863731,
-    "ast_hash": "1ce281ceb6e891ef7574ffefe8f2f8d3",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/6fe23e48-73cb-4a7c-864a-4e13b517a3bf-result.json": {
-    "mtime": 1781285622.2580118,
-    "ast_hash": "4008bc7e801551d72c6b7c2700574b8b",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/7102bcb3-7427-4bdf-8971-3a28c9d0031f-container.json": {
-    "mtime": 1781261320.7898326,
-    "ast_hash": "8458f24cf547d7fbcf78e00875dfb43f",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/723b5384-e213-4b60-bce6-2151852e019f-result.json": {
-    "mtime": 1781261320.8617146,
-    "ast_hash": "a18be352dcf5d1ed06962fab3711ba70",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/7365999c-8fa9-40fe-8388-54be6da3a297-result.json": {
-    "mtime": 1781261319.0301943,
-    "ast_hash": "5a340906a3114b2ef5ddab23393531a3",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/748b05f8-62ba-4637-b2f8-2e89c723308a-result.json": {
-    "mtime": 1781544169.4901657,
-    "ast_hash": "111a54a229b8da7eff8f76d8b52e7b3b",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/749145a6-2ab7-49f7-8c78-c07c3da8b71e-container.json": {
-    "mtime": 1781544168.056623,
-    "ast_hash": "54340567773e31c4dd60960aed7fd078",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/78005d90-cc54-4ce6-bdbf-747f40d4405d-container.json": {
-    "mtime": 1781261319.712934,
-    "ast_hash": "37ec80ec62bbe3d169786545f8caf472",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/7811eb27-254d-44bc-b296-b59343bb4537-container.json": {
-    "mtime": 1781261320.6243238,
-    "ast_hash": "4f583f3ff37a9a2c58cbb15bd7c4f164",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/7847e137-7c92-4921-95d6-dfd18be93a60-container.json": {
-    "mtime": 1781261320.4715843,
-    "ast_hash": "8c698a89b67bf6edbc04c261acd8858d",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/786b04d8-d942-4ba4-9a62-e0508d692fdd-container.json": {
-    "mtime": 1781261319.0342038,
-    "ast_hash": "02e393f622828afdf907b22a5377b1d8",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/792ecf1d-6ce5-4f56-9dbb-cbb8453c409e-result.json": {
-    "mtime": 1781285621.1191113,
-    "ast_hash": "e74710695acab43473fb489432f3a13f",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/79e8f769-2d31-4d14-9f58-3b83e07ece41-result.json": {
-    "mtime": 1781285622.0024202,
-    "ast_hash": "67aaa795a378a0d1d20940f255ade841",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/7afed354-5ad8-4e29-82c9-b2a00e99d137-container.json": {
-    "mtime": 1781285620.7924104,
-    "ast_hash": "9975273afbab8d5a9568d14bbd713dd0",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/7d9b58c3-7c46-4907-972c-b2e74accf458-result.json": {
-    "mtime": 1781544168.756502,
-    "ast_hash": "bdd7acf1c9cdb2ede3846306d49b87c3",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/7e2738c2-6930-4121-ba7d-25ed2e7170c0-result.json": {
-    "mtime": 1781261319.46795,
-    "ast_hash": "3247c9fb477283f3ce1519e370ffbca0",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/8021fbd2-3387-44bc-9e17-f139d2df8074-container.json": {
-    "mtime": 1781544168.367812,
-    "ast_hash": "cb59b4a69a515883879bcb1f2ba4fe15",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/807960ee-825c-4913-8759-a86588cda50c-container.json": {
-    "mtime": 1781285621.464998,
-    "ast_hash": "35cc3562a819bea11ab79af0b73c4b67",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/8110ca74-d6ad-4dda-b8c4-19a3a897d4c0-container.json": {
-    "mtime": 1781544168.7284977,
-    "ast_hash": "cb95440a02f33035a5accc4393f8e748",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/81c59e44-5b6d-4f90-b4d1-ceede08ad0c9-container.json": {
-    "mtime": 1781261318.51591,
-    "ast_hash": "fb68d4d21be87d7e8d06fccd8fb75dde",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/87c49acf-f173-4df6-a20b-aed62033baed-result.json": {
-    "mtime": 1781285622.2140138,
-    "ast_hash": "4002d8b292e3c775099a2a9651d13898",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/87d9062a-3ae3-4ba5-9d4b-a511ab5581da-container.json": {
-    "mtime": 1781285621.120101,
-    "ast_hash": "b273a8be544f22ce5398694e2ef834b2",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/8884b183-2d37-4b0d-8d2e-b8d3ef0b8941-container.json": {
-    "mtime": 1781285621.5465138,
-    "ast_hash": "642c346948ea500d68682c2855d00818",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/88e3a731-2957-437d-a93f-42194146f27f-container.json": {
-    "mtime": 1781285621.7997837,
-    "ast_hash": "f0a14707bdb5bfea5d482283acb9cbc0",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/890089cb-484b-498b-a12b-6ccd3e4bd7c9-result.json": {
-    "mtime": 1781261320.788321,
-    "ast_hash": "29664584c0676408cfcae8a4522dd8ca",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/8ad169a7-918d-426d-a498-55624b19d089-container.json": {
-    "mtime": 1781261321.3364758,
-    "ast_hash": "adecacd199d437212f354cc806a5f12d",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/8c7f6a3b-dbd3-4f28-9805-f246130979ad-container.json": {
-    "mtime": 1781544169.4911652,
-    "ast_hash": "48bacb9529fa39d8e013309c4114404b",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/8cd537fa-ed5f-4492-9474-e1e1b9cd7c3e-container.json": {
-    "mtime": 1781544169.4048698,
-    "ast_hash": "18b1f7e4a2744dacad9866505ae62dcc",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/8cdd1870-5b69-49e3-9d9a-d757683eee68-container.json": {
-    "mtime": 1781261318.8598697,
-    "ast_hash": "35a2c499db8e4ec217e61250a8d049a0",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/8da91fae-e3fb-4c21-9b68-d3001f12b877-result.json": {
-    "mtime": 1781261323.848835,
-    "ast_hash": "dd09a7120d63e731455f3da418606079",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/9044c25b-5a67-40bd-9d55-46c9bb8c6051-container.json": {
-    "mtime": 1781544169.730196,
-    "ast_hash": "83576a5687b66462117d57183d185d79",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/910e7d6d-8560-46a9-8650-525621b082fe-container.json": {
-    "mtime": 1781544168.7575035,
-    "ast_hash": "4cd7738cbcd9028d3a8285e0c18ea2c0",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/91d2833a-01f5-4501-83e6-52e621fff2e5-container.json": {
-    "mtime": 1781285621.830785,
-    "ast_hash": "67cd0ff75e9f3fa305837efb436031fd",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/96040350-810a-46d0-9f01-38459fb69dcb-container.json": {
-    "mtime": 1781544169.4058688,
-    "ast_hash": "75572cde78f50ad3c455ba712d7ba6a9",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/966fb450-4e01-4adf-a19a-234ccece795b-container.json": {
-    "mtime": 1781544169.102348,
-    "ast_hash": "3e0696985d9b85bcf31ff23c95f66693",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/968eca61-f27c-4b52-acb6-0862c38b591f-result.json": {
-    "mtime": 1781261321.257768,
-    "ast_hash": "f7cf817b501d83fdf1dced334ab197e7",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/96ec7a76-6700-4333-b650-127ae29ad551-container.json": {
-    "mtime": 1781544169.7692506,
-    "ast_hash": "95834cc0b0579b6dfd581132612a15d4",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/980f8795-65dd-4c33-a145-c1853682c33b-result.json": {
-    "mtime": 1781285621.8597822,
-    "ast_hash": "157c3ac957ca9b784a6a3e6bb06d487e",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/98732807-4557-430a-bd91-5b1eb4ff5fff-result.json": {
-    "mtime": 1781285620.82641,
-    "ast_hash": "d08e735896d88210b96dbc28555e1839",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/9adfa0ea-b60a-49a3-be14-c73e44430316-result.json": {
-    "mtime": 1781544167.7760432,
-    "ast_hash": "b5267f7e49f99bfb0f6b4a0da6c6150c",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/9b909bad-d37c-47cf-bfc5-cbd46078cd98-container.json": {
-    "mtime": 1781544169.5181675,
-    "ast_hash": "c5d5dd2e3bfe888d2d9fbbabadad7a07",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/a1ecc6e5-4797-41ea-acea-45a0e6b54015-container.json": {
-    "mtime": 1781285620.5081453,
-    "ast_hash": "2ab89f194383812ffaa5eda32005f896",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/a3c4d2aa-3e14-4ff4-b179-f410008cd90e-result.json": {
-    "mtime": 1781285621.572512,
-    "ast_hash": "927f31085b7cdcfb1d1c92853d4832e1",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/a467859a-be75-4fe6-9032-5fc3b832b92e-container.json": {
-    "mtime": 1781285622.0044153,
-    "ast_hash": "75c55516f1b7f1f086b6c4ac94725ec8",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/a55aff3e-30a2-4a0b-82d8-cd5f258acfb3-result.json": {
-    "mtime": 1781285621.5185099,
-    "ast_hash": "8350ecd648d5990f4826b13ada851b25",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/a5fce499-4447-4ca9-b40e-072f437b4606-result.json": {
-    "mtime": 1781261323.0667965,
-    "ast_hash": "5c77b22bdb7673d9e60ef16d909b6f26",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/a8cb5395-2589-49c7-abbc-5a6da6d73e6f-container.json": {
-    "mtime": 1781285622.2982564,
-    "ast_hash": "c7576b8f18b432a0d3110f24813a58e4",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/a8d4cdcf-afbc-433b-abff-73c8964fc259-result.json": {
-    "mtime": 1781544168.0556245,
-    "ast_hash": "c03edf749f9e9294e31759ea770b9528",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/aaa847a2-4705-41a2-883a-04252bd0b879-result.json": {
-    "mtime": 1781285621.1741052,
-    "ast_hash": "2cdee00ce5f8bb1f8b48ff2f892a7e28",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/ab71f5fa-0b0b-4b92-b191-5133ea459bf8-container.json": {
-    "mtime": 1781285621.901896,
-    "ast_hash": "0111a85a23f0422d51f32df2b33cf5ac",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/ac8137d6-828a-43e2-914c-c78ae87aa0c4-container.json": {
-    "mtime": 1781261323.8523679,
-    "ast_hash": "378359b7c7b5bff0835e3c75d6b566c1",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/ac96ca04-7b15-464f-b51f-03a0544392f8-result.json": {
-    "mtime": 1781285620.7538939,
-    "ast_hash": "9870c89625380c4c33befc71d627cf27",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/acda23cf-8ebf-4d69-98bc-adb94eb1574c-container.json": {
-    "mtime": 1781544169.6881928,
-    "ast_hash": "ef5e9c05dcbf1fad40710cf2f44a497c",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/ae43ed72-9461-4d5b-adba-38e753c64ca5-result.json": {
-    "mtime": 1781544167.7539754,
-    "ast_hash": "40c4a0d306ca3a76b100bdc77c5359e2",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/afa03feb-d26b-4c2a-88e5-b5208be62f65-result.json": {
-    "mtime": 1781261320.6213105,
-    "ast_hash": "95ff72a881f4d51e89c3b313ee9bce16",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/b043d031-ac07-4f6b-9f3a-d9ec53538235-container.json": {
-    "mtime": 1781261323.6252367,
-    "ast_hash": "314021399c0b341960ef62bbdf1d7918",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/b10587bc-240e-40e2-a057-8a21fa8b4e86-result.json": {
-    "mtime": 1781285620.1786869,
-    "ast_hash": "591205d854c74562936ba8f9af16bf45",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/b135996c-ea00-4c00-b052-5359d4ef3dd0-container.json": {
-    "mtime": 1781285621.148098,
-    "ast_hash": "0048a2c8b7aa7220682a6151434eb8cf",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/b2ebb63f-0c50-47a8-9823-40dd2da89d40-result.json": {
-    "mtime": 1781544168.3998125,
-    "ast_hash": "500dd5f17e4458e9ea3552a80acc4569",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/b3698407-029d-4cc5-bcba-5d06cb218b03-container.json": {
-    "mtime": 1781261320.8652463,
-    "ast_hash": "a92c9fd9a834586908fc8b3f64e4200a",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/b485a6bc-f952-43cc-8045-cd81e113e9bf-container.json": {
-    "mtime": 1781285620.859405,
-    "ast_hash": "05c9cb6c0194c6b8643443b809842881",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/b7f65873-2c55-4721-a8d8-b3c0afc7b492-container.json": {
-    "mtime": 1781261322.1143749,
-    "ast_hash": "5befb6e825837e4031d0fcd351f36c1a",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/b800c86d-39cc-4a6c-933a-b31ced863149-container.json": {
-    "mtime": 1781544167.7669759,
-    "ast_hash": "609a209c36321572de46bba2abb7d70e",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/b8b75313-d33a-4628-bf2f-d82b1a5336e0-container.json": {
-    "mtime": 1781285622.3032615,
-    "ast_hash": "0c2933f6a56e7ab249b2f8cc86b40f73",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/b902f8ca-9b7a-45ed-a037-980ef201eb6d-container.json": {
-    "mtime": 1781285620.8899162,
-    "ast_hash": "be9a639b436bee56cd7320cc73e586c8",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/bba88606-4f3b-45e8-a13b-96a00e325625-container.json": {
-    "mtime": 1781544169.4397142,
-    "ast_hash": "2b2fbd71c9ba4a69c1396967b7cc6172",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/bd1645cb-89ef-488a-b8b2-b31db485d0b1-result.json": {
-    "mtime": 1781285621.4639997,
-    "ast_hash": "ac3952b5047ca1636f7e6d31fbd247c7",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/be316e3a-f6d3-4afa-be07-fa768dcd3b6c-container.json": {
-    "mtime": 1781261319.4719565,
-    "ast_hash": "d3422ea58da0d0cb8cf1e28f55dfb9a7",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/bf3348a6-e26d-4f0b-b678-a0e58583de8a-result.json": {
-    "mtime": 1781261321.3349602,
-    "ast_hash": "17316aa9d29eb7c76fc7e713fa5a0ac3",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/c5f065dd-c6b1-404e-9453-3de04d84e735-result.json": {
-    "mtime": 1781261319.97237,
-    "ast_hash": "f2c3d78d7576560263c321478f745807",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/c6b22005-e225-4ed4-9d38-09285d3bdafc-result.json": {
-    "mtime": 1781544169.6461914,
-    "ast_hash": "18dde4c9245c6bd4f13538d68e6c8dd6",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/c7dba02e-fb83-457a-b055-64281763dead-result.json": {
-    "mtime": 1781261318.0993242,
-    "ast_hash": "1e6e6ea0e858e7eec2f6031e6feba7b3",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/c840febf-d2d3-4fb3-9633-552ccdd09a3c-container.json": {
-    "mtime": 1781285622.1669269,
-    "ast_hash": "81f3d5b9f42071a0e865643e1871017d",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/c8a3e0cb-0b93-47e4-9f91-951aae78b731-result.json": {
-    "mtime": 1781544169.730196,
-    "ast_hash": "77abc42ee0d029c2df686615e850ed4a",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/c949a214-f65e-48b3-8a06-b330e0ae815a-container.json": {
-    "mtime": 1781285621.5195131,
-    "ast_hash": "279698d9a69292263beadf20addbad58",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/ca6513b1-e0b4-45e8-a1da-f687f72b16f7-result.json": {
-    "mtime": 1781261320.0402627,
-    "ast_hash": "36c917fa8ceaf9889b4d26a9e8dc47e2",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/ca9e4875-836b-4cc3-afca-6cb4640142e5-container.json": {
-    "mtime": 1781544168.6711276,
-    "ast_hash": "9ec178799dbcd069621d13a63dcf7b49",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/cb247435-e869-42ae-9a42-a7da8967e9bf-container.json": {
-    "mtime": 1781261321.4137447,
-    "ast_hash": "e3d89778232900b5661533c832cf5b8b",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/cc26d705-a691-44c2-81a3-3b2423783648-result.json": {
-    "mtime": 1781544169.075344,
-    "ast_hash": "70df4e6a9a0ec0c752f56cffca2bd8fb",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/cc575ce7-89e1-412d-8cf8-dfada9e06913-result.json": {
-    "mtime": 1781261320.464224,
-    "ast_hash": "af33abf695b36d2ea2676e532a731a4a",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/cd085bbe-e381-420b-a74f-8d7a523e6471-result.json": {
-    "mtime": 1781261318.6366892,
-    "ast_hash": "a1fc0edaf2135786232bdcccb8aad30e",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/d36f929e-9572-4177-b4eb-9df66c3a92eb-result.json": {
-    "mtime": 1781261323.623728,
-    "ast_hash": "1e088c112675ad33cde0e7c64c4c26bc",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/d501eb23-05e2-4fef-839a-6f7eeab1fbf4-container.json": {
-    "mtime": 1781544168.0091078,
-    "ast_hash": "c6afb9663248898a2bffc79afc348395",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/d54b8cd8-7a34-4c44-8bc6-7cf57a79eea5-container.json": {
-    "mtime": 1781261323.8635197,
-    "ast_hash": "244168a40d28f9c080e88e7c98157431",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/d5af840b-f30a-42db-b7c7-11867cc46f9a-container.json": {
-    "mtime": 1781285622.2150173,
-    "ast_hash": "e6f00de82e60ba6ef12359dd68ef41a0",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/d5d17b01-95a4-4c14-a51f-5ec2bc408663-container.json": {
-    "mtime": 1781285620.1829515,
-    "ast_hash": "0e1dacfcc820bf96653ed8e86bc89afa",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/d60307e9-697a-4cfe-aa59-207661334507-result.json": {
-    "mtime": 1781261317.893776,
-    "ast_hash": "36699ec01b4a9d26e54fec9acd77404d",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/d82a0313-7ac3-4877-a7dc-5acfd3178305-container.json": {
-    "mtime": 1781261321.4035718,
-    "ast_hash": "e073102eacd1f5f172900273dc66e23b",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/da93669c-1504-4635-b565-366fdbfb13f0-result.json": {
-    "mtime": 1781544168.0081086,
-    "ast_hash": "a3a6d83c5092b23b6cea3c5a81f73844",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/db74ba83-41c4-4166-98eb-ec4ca31fc4eb-container.json": {
-    "mtime": 1781261323.0708158,
-    "ast_hash": "3039cdc6ad45bf95c656d09a4f2cc11d",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/db7fe8d6-4b83-417d-af92-9e51dea1a2e3-result.json": {
-    "mtime": 1781544168.293855,
-    "ast_hash": "018697826953f52187a4d3ad91f2abd2",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/dce3b7c7-0f98-4a39-bc9b-6935fc9831c2-result.json": {
-    "mtime": 1781261323.3877416,
-    "ast_hash": "89b78b25ebf708f6dd52b1feb07e4a1e",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/dd69db49-cc49-413e-8abf-38ac6f847121-container.json": {
-    "mtime": 1781285622.0034156,
-    "ast_hash": "08b583f4200b0d2ee35326f7f51e28c6",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/de28428a-2618-4b5e-8fc0-38b47d4ced16-container.json": {
-    "mtime": 1781261321.591022,
-    "ast_hash": "c4631af96c7aa17f484e9c3c3933c397",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/de526dd9-5c32-4b42-9f30-f1185bd75e74-result.json": {
-    "mtime": 1781544167.6924627,
-    "ast_hash": "a623431cde3154fdb0542f92343a31aa",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/de7f3def-7f00-4a1f-9faa-541a6b914d86-result.json": {
-    "mtime": 1781285620.7914093,
-    "ast_hash": "19f455e6d7673108809e4a8cceaf4527",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/de83f35e-9af9-45e0-85d7-73c3398846e6-container.json": {
-    "mtime": 1781544169.1288643,
-    "ast_hash": "2836de5cb099f3f62196a62b0b46f886",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/e1f3a81e-c669-4d7b-b5e3-a8a68ba189ed-container.json": {
-    "mtime": 1781261323.3887398,
-    "ast_hash": "60e079efb47b1925b49825955271c547",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/e27c63bd-33e2-45ba-af9f-d0f39ee57e5c-result.json": {
-    "mtime": 1781285621.1470988,
-    "ast_hash": "3873731485c4ff69916cdf3f3f2d58bc",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/e2bcc1ce-de88-4695-b674-72ff3f192ef8-result.json": {
-    "mtime": 1781285620.8899162,
-    "ast_hash": "8a90c6785ceaf3a7e16c25f0f9a848be",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/e424e24d-e169-4cc2-9895-aefb33c09788-result.json": {
-    "mtime": 1781261319.149858,
-    "ast_hash": "0d0a401a4fca5d64fcd79a82f8cf3c68",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/e52b0491-9183-4218-abb1-4c86795c32a7-result.json": {
-    "mtime": 1781544167.7659757,
-    "ast_hash": "847bb351c437b4b2e82162d31cccd9d1",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/e69b6c7e-8def-4e22-b49c-2800a1aaf870-result.json": {
-    "mtime": 1781261316.7367063,
-    "ast_hash": "e491c7cc15add9d33e26c389411b1961",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/e8fe8820-5d61-4d9f-8f3d-3b91dcc50337-result.json": {
-    "mtime": 1781285620.46263,
-    "ast_hash": "a635d84a9f1005b67c716130e6bc6911",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/e92d1e0f-c5f8-461d-8b10-50162bd8c658-container.json": {
-    "mtime": 1781544168.2948537,
-    "ast_hash": "9619c4cf1ab8c967da67fcc47945dcfa",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/eb79497f-12a7-49c3-9362-803a98815ea9-container.json": {
-    "mtime": 1781261321.2627609,
-    "ast_hash": "df5625597a3a2700299ded6be163a703",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/ebcddeed-c22f-4aff-a82c-b5f3c04a1d6c-result.json": {
-    "mtime": 1781544168.3668122,
-    "ast_hash": "eb44bdc8ccb9d9ddb345d6d7e1f7e8df",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/f2ad7d50-c592-415d-85b7-5644330a7551-container.json": {
-    "mtime": 1781261319.1518567,
-    "ast_hash": "6953dddbc10ed0ba96cb23d634bfa754",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/f5ec4c81-7584-4435-908b-8d9e1258a914-result.json": {
-    "mtime": 1781261321.5900233,
-    "ast_hash": "51da5404ef7f441bfc24d1fc36ff8c03",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/f718aed5-bd50-4622-8669-4eeec5401093-result.json": {
-    "mtime": 1781544169.7682474,
-    "ast_hash": "0077cb6ccdb335c7cee3ad534fbd6850",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/f83e46e0-7dc1-44b7-91ae-e2f829933b8a-result.json": {
-    "mtime": 1781544169.6871905,
-    "ast_hash": "ce9e4c8aca8892ccbc977ad1a23020f0",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/f88a5ccf-0477-43b1-aa47-3bfaf34846c8-container.json": {
-    "mtime": 1781261321.8759024,
-    "ast_hash": "91c01e549943ce8b9132ad3a0cbd6cdf",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/f88b7cb0-4d1e-480a-a561-c04429a8b11e-result.json": {
-    "mtime": 1781285620.5071466,
-    "ast_hash": "191f588234771006592a152ebd1c7c74",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/f9b9fb58-9c6a-4fea-bd30-7b3a5f267958-result.json": {
-    "mtime": 1781285621.20961,
-    "ast_hash": "f91e0ec86c4db82301a6c540b8c416be",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/fb4bf482-0f0c-422c-a15e-4d160e8e92af-result.json": {
-    "mtime": 1781285622.2982564,
-    "ast_hash": "6233ad7f963806728246c52d784f58f7",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/fc635796-57d1-4ef3-abd9-8c4250087d98-container.json": {
-    "mtime": 1781544167.7876568,
-    "ast_hash": "5a096a11112dd775344f1e842fb01afc",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/fe5e46c1-7cde-4eb6-a37a-d21018c6cdbb-container.json": {
-    "mtime": 1781544169.0763514,
-    "ast_hash": "894a83224c25a642e168eb4e83c67772",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/fef526da-e331-4c44-875f-907feb9c7686-container.json": {
-    "mtime": 1781285620.82641,
-    "ast_hash": "e52a3a39c00b1c2f7c5a3089c972b34e",
-    "semantic_hash": ""
-  },
-  "shaft-ai/allure-results/ff510be7-0ffc-41c1-904e-32730bcb6adb-container.json": {
-    "mtime": 1781285621.5735135,
-    "ast_hash": "d4f4ce61d10d5c2f20eb0892d27f1fb7",
+    "mtime": 1781769439.6795676,
+    "ast_hash": "d52dd3c2eb9f5b8ed16d34f192b04e6f",
     "semantic_hash": ""
   },
   "shaft-ai/src/main/java/com/shaft/ai/provider/AbstractHttpAiProvider.java": {
-    "mtime": 1781592922.4454722,
+    "mtime": 1781769439.6825588,
     "ast_hash": "dbb7debe96eaf04ce97677b023010551",
     "semantic_hash": ""
   },
   "shaft-ai/src/main/java/com/shaft/ai/provider/AnthropicProvider.java": {
-    "mtime": 1781592922.4464736,
+    "mtime": 1781769439.6825588,
     "ast_hash": "fd84c714e9fdbcd3adc3e0ebd89c166e",
     "semantic_hash": ""
   },
   "shaft-ai/src/main/java/com/shaft/ai/provider/GeminiProvider.java": {
-    "mtime": 1781592922.4474716,
+    "mtime": 1781769439.6825588,
     "ast_hash": "a15587f8a53841df6ef6c891505f168d",
     "semantic_hash": ""
   },
   "shaft-ai/src/main/java/com/shaft/ai/provider/OllamaProvider.java": {
-    "mtime": 1781592922.4474716,
+    "mtime": 1781769439.6835592,
     "ast_hash": "2a63f2862593c6543ce4b503f462e1f7",
     "semantic_hash": ""
   },
   "shaft-ai/src/main/java/com/shaft/ai/provider/OpenAiProvider.java": {
-    "mtime": 1781592922.4484715,
+    "mtime": 1781769439.6835592,
     "ast_hash": "4c18363c15f720d76033af2df645c929",
     "semantic_hash": ""
   },
   "shaft-ai/src/test/java/com/shaft/ai/provider/ProviderConformanceTest.java": {
-    "mtime": 1781592922.4494712,
+    "mtime": 1781769439.686762,
     "ast_hash": "e7c70c2dfbbbeea72ca0fd26bd3aaf41",
     "semantic_hash": ""
   },
   "shaft-browserstack/src/main/java/com/shaft/integration/browserstack/BrowserStackModule.java": {
-    "mtime": 1781170594.8191445,
+    "mtime": 1781769439.6902404,
     "ast_hash": "72302597cacbdcf22114d39c4a134055",
     "semantic_hash": ""
   },
-  "shaft-capture/allure-results/02080256-27a6-4123-90e1-ac5b822600ba-result.json": {
-    "mtime": 1781285617.926222,
-    "ast_hash": "d69c21b0b84aa61a7506b4fc1578239a",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/0f966bcc-b333-4271-bd07-9973a0fe4bd3-result.json": {
-    "mtime": 1781285617.9342213,
-    "ast_hash": "c9112d26ca3b0e1d1ba86d00437abfd1",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/138bfd01-42a6-4578-9a95-e6685d0b65c0-result.json": {
-    "mtime": 1781285618.014685,
-    "ast_hash": "9cb4501f9acd1b505ca4eb0751ebe7ba",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/1c35d683-56a4-4c04-83ad-b43ca9838e85-result.json": {
-    "mtime": 1781261507.86593,
-    "ast_hash": "d9dd0c1c6f2c634cdc163bd27d16e237",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/26afabb8-574d-41c6-b236-55605471f90c-container.json": {
-    "mtime": 1781285617.9352229,
-    "ast_hash": "1b9a045758f42604d3c69b8f290845c3",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/28c3f9ee-6911-43a7-aeeb-217b093aebd9-result.json": {
-    "mtime": 1781285617.8007152,
-    "ast_hash": "5dd3e0fa34d55bc7787d980c08a835b2",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/36f4e302-d271-4b24-a570-01b6603125a3-container.json": {
-    "mtime": 1781285617.9552212,
-    "ast_hash": "c8cc38e6eff72a03a45c146138a75d00",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/394f6bfe-8dbb-49ce-a006-b1185594ac71-container.json": {
-    "mtime": 1781261496.7214115,
-    "ast_hash": "b04e1d44517e828e06ca330d1805d3bf",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/40be9364-1704-4d81-8442-bf5a6ff87859-container.json": {
-    "mtime": 1781285614.0434146,
-    "ast_hash": "abc42bc9a84532b5fed6ef160a8657bf",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/63d08947-2bd6-48f4-a2ee-d5c8b52fb5ba-result.json": {
-    "mtime": 1781285614.0384142,
-    "ast_hash": "132323edcef00e6db8b1d1c1ef7dc118",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/68568b71-500b-48bf-855d-97e6ab457789-container.json": {
-    "mtime": 1781285617.9412217,
-    "ast_hash": "bb9e0c437bcd7a138bc18876f52aec37",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/7b55b850-9ab8-42af-b942-834918ebc476-result.json": {
-    "mtime": 1781285617.954223,
-    "ast_hash": "a0ff0814f39c36b229d40afce31931ee",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/8ac32e41-2bad-4e04-9ebf-d599a55251aa-container.json": {
-    "mtime": 1781285618.0176845,
-    "ast_hash": "269ea7c1a4c64b0157096941004402de",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/8cf4b6b1-ac6d-446e-a4fc-7897a015ac81-result.json": {
-    "mtime": 1781285617.9612224,
-    "ast_hash": "6d09d576ee65c49d294fe65c92c99124",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/8d8cfe5e-2067-47ee-b63e-0e939a2ffa2f-container.json": {
-    "mtime": 1781285617.9272225,
-    "ast_hash": "6e10d18eadbef9c139065ef7c9f0f74e",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/9829b156-797b-4625-bc37-f6cebbefbaa7-container.json": {
-    "mtime": 1781285616.2367063,
-    "ast_hash": "600db3a2aa7836769d45f5f3cb3a7280",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/a8dd0bd4-08ab-4727-a5d5-b05589135d7f-result.json": {
-    "mtime": 1781285617.8647153,
-    "ast_hash": "df12c50d5bbb5c28f7e8fc7f18d98330",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/a9bafeb5-7699-427f-a123-6641f6279bf9-container.json": {
-    "mtime": 1781261507.8704655,
-    "ast_hash": "adb2c2467ec1d8901d7e7a9907da0708",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/bfc8db7e-be94-4781-8c1e-2af2c736b66e-container.json": {
-    "mtime": 1781285618.0156844,
-    "ast_hash": "01ef880175fb650f4655f61ad3b2864c",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/cae645af-b337-4315-ba8a-1d253d80f36f-result.json": {
-    "mtime": 1781261496.7173471,
-    "ast_hash": "1db9a9320410100b63d068e29a37ffbd",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/d00a11cd-0781-400d-b380-eb51452bad7e-container.json": {
-    "mtime": 1781285617.9622211,
-    "ast_hash": "abbf9da68789b7f61fcc4b8c45557109",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/d2f63775-a6f9-4aa9-8aec-1f784482a53e-container.json": {
-    "mtime": 1781261507.8929243,
-    "ast_hash": "d20f079f59038720400f54939b7d7c39",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/dc16d6dc-cff1-48ac-81da-211159cf61cf-container.json": {
-    "mtime": 1781261507.8812523,
-    "ast_hash": "1711833c99edb3849735c552f4de1820",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/e202b965-c621-4be0-82b4-abda76848446-container.json": {
-    "mtime": 1781285617.8647153,
-    "ast_hash": "5e2c1b0dd80011e6585fb48580b622aa",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/e5b7bfd8-b870-4d9d-9fc0-620befdf2a4d-container.json": {
-    "mtime": 1781285617.801718,
-    "ast_hash": "692e93925c7d812da4cc224b7789113d",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/f14abdcd-829f-4ab6-9b0f-0a49730d0e77-result.json": {
-    "mtime": 1781285616.2357051,
-    "ast_hash": "6e79ddd679bdf41039f2a6c567a63eb5",
-    "semantic_hash": ""
-  },
   "shaft-capture/src/main/java/com/shaft/capture/cli/CaptureCli.java": {
-    "mtime": 1781239583.956422,
+    "mtime": 1781769439.693216,
     "ast_hash": "29b0d698d0703cca371ca8d4c6af8e5e",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/BidiBrowserEventCollector.java": {
-    "mtime": 1781191976.6797588,
+    "mtime": 1781769439.693216,
     "ast_hash": "fc1b266c14707721951af6384c992cf1",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventCollector.java": {
-    "mtime": 1781191976.680761,
+    "mtime": 1781769439.694216,
     "ast_hash": "7bcd665b60a9fdde45a86fd920161935",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventScript.java": {
-    "mtime": 1781191976.680761,
+    "mtime": 1781769439.694216,
     "ast_hash": "3b2670dd6c164b8013f2ffc931a9eacb",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/BrowserSignal.java": {
-    "mtime": 1781191976.6817594,
+    "mtime": 1781769439.694216,
     "ast_hash": "df91d356ff80267cc300bf5a20c14f2d",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/CompositeBrowserEventCollector.java": {
-    "mtime": 1781191976.6827621,
+    "mtime": 1781769439.6952164,
     "ast_hash": "576d60256e891e492f671083c8ada4a6",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/PollingBrowserEventCollector.java": {
-    "mtime": 1781191976.6827621,
+    "mtime": 1781769439.6952164,
     "ast_hash": "fe7d4a13096155124eec6db567f0da56",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlClient.java": {
-    "mtime": 1781191976.6837614,
+    "mtime": 1781769439.6962204,
     "ast_hash": "1104a60eeea8d2368509e6a901fb824b",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlFiles.java": {
-    "mtime": 1781191976.6846788,
+    "mtime": 1781769439.6972158,
     "ast_hash": "e2f3d582e3b02783b4ad6ebae4ad030c",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlServer.java": {
-    "mtime": 1781191976.6851845,
+    "mtime": 1781769439.6972158,
     "ast_hash": "842573fb335554672af12070b09b9c28",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/format/CaptureFormatException.java": {
-    "mtime": 1781186708.9037356,
+    "mtime": 1781769439.6982157,
     "ast_hash": "16dd9ed34b8f5e575980e759908f5c4b",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/format/CaptureJsonCodec.java": {
-    "mtime": 1781186708.9047322,
+    "mtime": 1781769439.6982157,
     "ast_hash": "a805163d5ada4a16614b4c6c033c4347",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/format/CaptureSchemaMigrator.java": {
-    "mtime": 1781186708.9047322,
+    "mtime": 1781769439.6992157,
     "ast_hash": "65b0476a9fc1922aa2d1db391b4988fd",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureEnrichmentPreview.java": {
-    "mtime": 1781239583.9574842,
+    "mtime": 1781769439.6992157,
     "ast_hash": "becc024cd2177b4113f3fc8746ec4354",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureEnrichmentService.java": {
-    "mtime": 1781239583.9580908,
+    "mtime": 1781769439.7002165,
     "ast_hash": "4eb736b3f4f1ed574a280d779994b768",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationReport.java": {
-    "mtime": 1781239583.9591448,
+    "mtime": 1781769439.7002165,
     "ast_hash": "a478402031451dc70abbdb73165486b0",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationRequest.java": {
-    "mtime": 1781239583.9596725,
+    "mtime": 1781769439.7002165,
     "ast_hash": "baf507818de7dc32b660e5163a2a0a67",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationResult.java": {
-    "mtime": 1781239583.9607615,
+    "mtime": 1781769439.7012157,
     "ast_hash": "c1db6c2ab28bc73cbc924e6cc4932ea7",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java": {
-    "mtime": 1781239583.9618275,
+    "mtime": 1781769439.7012157,
     "ast_hash": "ff6f1e064a5ea940a66cd7b26a56cc02",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/GeneratedTestValidator.java": {
-    "mtime": 1781239583.962358,
+    "mtime": 1781769439.702216,
     "ast_hash": "d3a5ba9e076837ea9685c089e1eb2b24",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/LocatorRanker.java": {
-    "mtime": 1781239583.9628859,
+    "mtime": 1781769439.702216,
     "ast_hash": "b8de8d4abc874a48ab234270e224af6e",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/BrowserMetadata.java": {
-    "mtime": 1781186708.905735,
+    "mtime": 1781769439.703219,
     "ast_hash": "aca616578f082355fd0761f58597be5d",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/CaptureEvent.java": {
-    "mtime": 1781186708.906735,
+    "mtime": 1781769439.703219,
     "ast_hash": "36642a12d8b21af2444a67fde759c546",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/CaptureSession.java": {
-    "mtime": 1781186708.906735,
+    "mtime": 1781769439.7042165,
     "ast_hash": "8b231d12ab3791b756caac91cbdb4c10",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/Checkpoint.java": {
-    "mtime": 1781186708.9077318,
+    "mtime": 1781769439.7042165,
     "ast_hash": "2a3ca946a6921b589ae137ecc6f60581",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/ElementSnapshot.java": {
-    "mtime": 1781186708.9077318,
+    "mtime": 1781769439.7052164,
     "ast_hash": "14868c3708fab12f82feb3b9e24d01ec",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/EventContext.java": {
-    "mtime": 1781186708.9077318,
+    "mtime": 1781769439.7052164,
     "ast_hash": "a8a5457d7b613592975c3bc8297ccfee",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/EvidenceReference.java": {
-    "mtime": 1781186708.9087334,
+    "mtime": 1781769439.7062154,
     "ast_hash": "786eef193ba4ca565c23dc1d142ba475",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/ExternalTestDataReference.java": {
-    "mtime": 1781186708.9087334,
+    "mtime": 1781769439.7062154,
     "ast_hash": "fa36b8fb9e646b9d1b51ce0605d33d95",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/LocatorCandidate.java": {
-    "mtime": 1781186708.9097319,
+    "mtime": 1781769439.7062154,
     "ast_hash": "dd66b616e91d7e6fa0abfec2b475a90b",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/ModelSupport.java": {
-    "mtime": 1781186708.9097319,
+    "mtime": 1781769439.7072158,
     "ast_hash": "c54568ab63b584765e027d13eaa6e00b",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/PageContext.java": {
-    "mtime": 1781186708.9107318,
+    "mtime": 1781769439.7072158,
     "ast_hash": "8fa7d63b7d571c010f6c1a1d927e5400",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/RedactionSummary.java": {
-    "mtime": 1781186708.9107318,
+    "mtime": 1781769439.7072158,
     "ast_hash": "7a5a3a53ec8011e51823968f7b2ba6a2",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/privacy/CapturePrivacyClassifier.java": {
-    "mtime": 1781191976.6863136,
+    "mtime": 1781769439.7082162,
     "ast_hash": "0f9d46db745fc5bbe83ece1758401053",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/privacy/CapturePrivacyPolicy.java": {
-    "mtime": 1781186708.91224,
+    "mtime": 1781769439.7082162,
     "ast_hash": "77266ad326a57f7b2cf95ada13f2e221",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/privacy/ClassifiedValue.java": {
-    "mtime": 1781186708.91224,
+    "mtime": 1781769439.7092164,
     "ast_hash": "b8dae78977adf61da8c1a8d42cf8e122",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureBrowser.java": {
-    "mtime": 1781191976.6873732,
+    "mtime": 1781769439.7092164,
     "ast_hash": "60e269599213a8dbedf2be33831594d7",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java": {
-    "mtime": 1781191976.687897,
+    "mtime": 1781769439.7102165,
     "ast_hash": "eb742f395b2e2a63a45e73cf5529ac22",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureManager.java": {
-    "mtime": 1781191976.6889508,
+    "mtime": 1781769439.7102165,
     "ast_hash": "9901a1aa6aff67bf5c3fa1f6d7989db2",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureSingleSessionLock.java": {
-    "mtime": 1781191976.6894794,
+    "mtime": 1781769439.711221,
     "ast_hash": "fc8c18ea3f3fb1449c0545c9fec14b82",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureStartRequest.java": {
-    "mtime": 1781191976.6900036,
+    "mtime": 1781769439.711221,
     "ast_hash": "de0bd8022947565323e9b3c0985e08c4",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureStatus.java": {
-    "mtime": 1781191976.6905365,
+    "mtime": 1781769439.712221,
     "ast_hash": "5a11ea402919f7b1718cd953c4f419a2",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java": {
-    "mtime": 1781191976.6905365,
+    "mtime": 1781769439.712221,
     "ast_hash": "9f3382a0e7a97061698f8c340203d192",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/storage/CaptureSessionStore.java": {
-    "mtime": 1781191976.6916032,
+    "mtime": 1781769439.7132218,
     "ast_hash": "229b38b0e510e0d9c7b9a08bc71db5b9",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/storage/ExternalTestDataWriter.java": {
-    "mtime": 1781186708.913248,
+    "mtime": 1781769439.71373,
     "ast_hash": "e69dc835c53bd61b0e8ccfc34f983185",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/resources/browser/shaft-capture-recorder.js": {
-    "mtime": 1781191976.6921358,
+    "mtime": 1781769439.71373,
     "ast_hash": "35827af755f14c2c2047aee421a4dae5",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/resources/schema/shaft-capture-session-1.0.schema.json": {
-    "mtime": 1781186708.9142494,
+    "mtime": 1781769439.71373,
     "ast_hash": "df85a8de90f01cbb4c980201998901d0",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/CaptureFixtures.java": {
-    "mtime": 1781186708.9172473,
+    "mtime": 1781769439.7162242,
     "ast_hash": "5f889c8fbaec05b6f2741a137700d788",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/format/CaptureJsonCodecTest.java": {
-    "mtime": 1781191976.6932042,
+    "mtime": 1781769439.7172241,
     "ast_hash": "231b3b2f5f283141335c78cf8983c065",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratedReplayBrowserTest.java": {
-    "mtime": 1781239583.964294,
+    "mtime": 1781769439.7172241,
     "ast_hash": "cd1a6080100cbce05841ce7a32757f17",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java": {
-    "mtime": 1781261094.4290085,
-    "ast_hash": "c8e9da40fc8c13aad61e7f689a9cefbc",
+    "mtime": 1781769439.718224,
+    "ast_hash": "6bc89c2778c1292db13e9a52219f2ee4",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/generate/LocatorRankerTest.java": {
-    "mtime": 1781239583.9658804,
+    "mtime": 1781769439.718224,
     "ast_hash": "8c1ad098141cceb54b35c1a35c33d863",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/privacy/CapturePrivacyClassifierTest.java": {
-    "mtime": 1781186708.9192472,
+    "mtime": 1781769439.7192242,
     "ast_hash": "7702332d104ea111fdec6e1fa99d6df3",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java": {
-    "mtime": 1781191976.6937354,
+    "mtime": 1781769439.7192242,
     "ast_hash": "fbbbba609aaaf9755e40d5504a4ecbb9",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureRuntimePortabilityTest.java": {
-    "mtime": 1781191976.69427,
+    "mtime": 1781769439.7202246,
     "ast_hash": "936c97dd1183e639d324197cc433d371",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java": {
-    "mtime": 1781191976.6953354,
+    "mtime": 1781769439.7202246,
     "ast_hash": "c457491fa2232a3b4615fddf737611aa",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/storage/CaptureSessionStoreTest.java": {
-    "mtime": 1781186708.9192472,
+    "mtime": 1781769439.7212946,
     "ast_hash": "cc70993c979f97b8de7554bd34515622",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/resources/fixtures/golden-generated-session-1.java": {
-    "mtime": 1781239583.9664137,
+    "mtime": 1781769439.7223,
     "ast_hash": "2c2e87a33b0615187c76a1698ba0f1ed",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/resources/fixtures/golden-session-1.0.json": {
-    "mtime": 1781186708.9202464,
+    "mtime": 1781769439.7223,
     "ast_hash": "94d6b5e35f7a9d8a12a448178eed460e",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/resources/fixtures/legacy-session-0.9.json": {
-    "mtime": 1781186708.9212468,
+    "mtime": 1781769439.7232995,
     "ast_hash": "fe67510df7883478c930d414d5ad38cc",
     "semantic_hash": ""
   },
-  "shaft-doctor/allure-results/0260a13a-e5ce-42ae-ad37-27f47895cd8f-result.json": {
-    "mtime": 1781261261.1414733,
-    "ast_hash": "c73f76349d9a36017ad9fe677d820e83",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/026bbf97-0017-4b05-a751-b981cbf0b850-result.json": {
-    "mtime": 1781261266.040376,
-    "ast_hash": "b0a5f79b393b764e38206a2d2f20fc5b",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/05a90bb0-5233-4671-9b68-a7c065f7ec1c-container.json": {
-    "mtime": 1781261265.5436075,
-    "ast_hash": "6a88f8260bbcb57b0cb023babb2fcdfd",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/0e21efd1-9724-4869-9ca5-7e9d8c1b0d41-result.json": {
-    "mtime": 1781261261.698724,
-    "ast_hash": "2df00df91e7afe8ab2b6d14282371019",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/124a8481-30fe-45e0-b4eb-6ee202dcce5c-container.json": {
-    "mtime": 1781261279.6304111,
-    "ast_hash": "f6a0db501d013de3fa4cd2792f0032ae",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/136b84ce-6b0f-46d8-a68c-568335ea8423-result.json": {
-    "mtime": 1781261262.6421704,
-    "ast_hash": "650090a1f5984c696d5ef74c89777bd3",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/13abb804-d552-4cc6-831b-b7c8199af0b5-container.json": {
-    "mtime": 1781261261.043728,
-    "ast_hash": "63da4e02d07288eb381f1ee52d257afd",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/158b87b0-c54b-4bf8-8709-02effa07025f-container.json": {
-    "mtime": 1781261261.1434653,
-    "ast_hash": "373e31fc058a70bafb36cd64bdea2d75",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/16c0b0af-33f0-4827-8791-44c90d237bc5-result.json": {
-    "mtime": 1781261260.2308676,
-    "ast_hash": "5e6220d68fd9e49fa87e086a15702fdb",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/195ad5f4-519a-464a-9160-b8f9195db9e7-container.json": {
-    "mtime": 1781261298.5380273,
-    "ast_hash": "929bfa5de4fd5ae02c083d2ffc84a410",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/1ae405b3-cd84-4cf9-ba47-e2f9fbc6d4bd-result.json": {
-    "mtime": 1781261264.878698,
-    "ast_hash": "527c707a039a1e13420b23f509f87ce5",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/1cbb6683-97f6-4a10-b74e-46521b4ffddf-container.json": {
-    "mtime": 1781261263.9449906,
-    "ast_hash": "c9e365063614a8f3a0a30cf1aa92b772",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/1d666875-7b30-4265-8f28-f242a7d19642-result.json": {
-    "mtime": 1781261262.7343946,
-    "ast_hash": "535eaecd12740d87e455b2fcf499e584",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/1d705f61-3a14-4738-ac7c-77e0876e7b7b-result.json": {
-    "mtime": 1781261265.3144486,
-    "ast_hash": "0e643911e679706c45128eacfee6985f",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/2460d56a-a99c-4be9-b61e-be7a296b55bd-container.json": {
-    "mtime": 1781261264.661782,
-    "ast_hash": "7c27714f6b5e4024a91b8454618a98d8",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/25c0d699-bf9b-4b83-a410-d1d2cf3a0742-result.json": {
-    "mtime": 1781261265.5436075,
-    "ast_hash": "22fdf08184e434fa3ffb15443827d5bb",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/27e1c49a-84fe-4d1b-8169-5407a4a3caa4-container.json": {
-    "mtime": 1781261265.4653256,
-    "ast_hash": "7f15f35a2a8113e47e111b9fadab5f87",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/2e564539-b882-41f6-a8e1-d39818ef0b96-result.json": {
-    "mtime": 1781261264.9784477,
-    "ast_hash": "7f9590b5f1314ffa0082dd3ec5c716b3",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/2f6a41b6-b2cf-44a9-b7ff-ceb10ddf6095-container.json": {
-    "mtime": 1781261266.05509,
-    "ast_hash": "8452b7c14d5290ce294facf3b70643ec",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/37efd35a-756b-4ff2-b21a-ffbdaec5fe22-result.json": {
-    "mtime": 1781261263.2160559,
-    "ast_hash": "f2d76f0b1e9ccaf366c649fc6cd48bf2",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/40cdfc2f-6abf-486c-a649-62ea1ca2c682-container.json": {
-    "mtime": 1781261307.8227687,
-    "ast_hash": "d7b27dfb8447c9f77040567194776b26",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/44d97283-4694-4cd7-8808-ace95ea44281-result.json": {
-    "mtime": 1781261263.4367752,
-    "ast_hash": "9ef4be7fd9339a3aaa15f45dc28f3f9d",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/45a10642-202d-4b6e-bb04-c65c7f33a9e4-container.json": {
-    "mtime": 1781261262.6508093,
-    "ast_hash": "68c03f77d06040ee5029a524d7c452fb",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/463d159c-ac5f-4b4d-9591-e51522db7d24-container.json": {
-    "mtime": 1781261265.862764,
-    "ast_hash": "ef38a5738810b0d9a0460535e0f15c7a",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/483e2f84-9fd4-4a8e-b42d-b53caafe481b-container.json": {
-    "mtime": 1781261263.6775522,
-    "ast_hash": "e9c18616c06e674c660bb01dcea0a29a",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/51888fad-e7ba-48ca-abd7-c4b1f62b2214-container.json": {
-    "mtime": 1781261265.3165762,
-    "ast_hash": "54869c0790720e461375ce1075a17ee0",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/526b823c-212d-448f-843b-5af514025177-container.json": {
-    "mtime": 1781261285.8894403,
-    "ast_hash": "fab9b94277f1b782bc7f39defc56e2d1",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/527b0da5-936d-4c29-8915-5b59a188651a-result.json": {
-    "mtime": 1781261265.9544504,
-    "ast_hash": "8e6c0d675d954009f901645216af0b30",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/52f7a9b5-b09e-4102-a667-a67a4392f69a-result.json": {
-    "mtime": 1781261264.6607814,
-    "ast_hash": "36b0b636b47fb80e7bbedea01dcd5cb6",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/54201e1a-fa73-45e1-8d4d-6674537ff27a-container.json": {
-    "mtime": 1781261260.4835567,
-    "ast_hash": "356d4ee550a5fa467a001f5a4b94c44d",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/5a08285c-ea4e-4dc2-8495-7dcea3b1a412-result.json": {
-    "mtime": 1781261261.0734973,
-    "ast_hash": "812258ba3e65ec73ff280188f6bfdedc",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/5b34c213-21f5-4336-8adb-3167b16c2f1b-result.json": {
-    "mtime": 1781261307.8140407,
-    "ast_hash": "2731348b7acd8c31f358819e9fa7b295",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/6153d187-8b87-42b6-a975-49f20f4de762-container.json": {
-    "mtime": 1781261266.0475488,
-    "ast_hash": "bb599dd35fe935f2db4346e5026a732a",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/679b28a7-9ead-4e97-832d-2ab597175ec6-container.json": {
-    "mtime": 1781261263.2174127,
-    "ast_hash": "5e1f0093e0122e024035d303e3ed278e",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/68f9fa71-f32f-438e-ba3f-0617032a60d0-result.json": {
-    "mtime": 1781261279.6242414,
-    "ast_hash": "df5ebe5bb4e14c25c7e470847750444a",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/69804308-72f3-4e7d-977c-8f6814a71f16-result.json": {
-    "mtime": 1781261259.7753065,
-    "ast_hash": "3d22b7fdcfc6acd0c473bf5edf0ac090",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/6b8d12b9-100a-4a24-a522-98be78cbd34c-container.json": {
-    "mtime": 1781261259.7768383,
-    "ast_hash": "5ea5f7fa6eea1a13f40a4156c3f4d141",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/6fe0781a-705e-4c87-a689-2d1127798e78-container.json": {
-    "mtime": 1781261264.8037047,
-    "ast_hash": "7938f5fe897d337477d34a2a7e67b16c",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/71fef425-41ae-4aa5-984a-108c55b4898f-result.json": {
-    "mtime": 1781261261.1915617,
-    "ast_hash": "5c4ea3fbaa538edb16e7d50c05a12ee5",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/766dad63-6ffc-42fc-a6d5-1bc6cb1c0055-container.json": {
-    "mtime": 1781261307.8336813,
-    "ast_hash": "64ea0c9c7ec0338603d0d0f98621ce92",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/769b5df2-b2a1-4f8a-91ed-3ca1398cd1a7-container.json": {
-    "mtime": 1781261262.7359061,
-    "ast_hash": "b2d222c15920c3f151eaae2882b35b69",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/786835ae-ad28-439e-843b-fb506e272283-container.json": {
-    "mtime": 1781261265.2008896,
-    "ast_hash": "963f9fdd080399d403dd56e3d7094aa4",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/798edea5-b051-4f67-880d-426150150ed1-container.json": {
-    "mtime": 1781261263.438791,
-    "ast_hash": "7e3345e4505933e1114f398f636454bd",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/7e75600e-644e-498b-9a77-3f04cd2c81fc-container.json": {
-    "mtime": 1781261262.1275818,
-    "ast_hash": "d9b3ed919e3a66b7edce21ef2086eacf",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/809fc9ec-0b91-4351-b915-bf730cd5587b-result.json": {
-    "mtime": 1781261260.5853212,
-    "ast_hash": "47414068aff470079cdd51ae6b7f66d0",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/8b62baa6-714b-4b5d-a21b-0f33aeee0c40-result.json": {
-    "mtime": 1781261265.0807316,
-    "ast_hash": "40ab145c8dfce00a02429c72fb4ebc4b",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/8bc697e4-2af9-4a28-a90b-66ab6751d801-result.json": {
-    "mtime": 1781261260.135039,
-    "ast_hash": "87e15d531d1cf8bb6e8f38248fd5ec29",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/91ff200a-c863-4ed9-9909-4aa4da612d62-result.json": {
-    "mtime": 1781261261.0387375,
-    "ast_hash": "76818a2e05dd4ab4759fdcc8d5ffc20e",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/92a1b5ee-3e9b-49bf-be44-7dfa4191cc20-container.json": {
-    "mtime": 1781261265.5487998,
-    "ast_hash": "68fe342f36c60b093790cbe3ebc0867e",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/9572e032-9134-427d-9771-483f1bf19fc8-container.json": {
-    "mtime": 1781261260.23187,
-    "ast_hash": "841e70834ca72ea13a71fe95329f4903",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/97b1c9f4-7226-4515-ae07-5739880ecdf6-container.json": {
-    "mtime": 1781261260.4459932,
-    "ast_hash": "ffa9375244e06234cc831af71efd0a3e",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/9a61eff2-99d5-4be3-876e-83a689a0797d-result.json": {
-    "mtime": 1781261263.676544,
-    "ast_hash": "5b68fe649469df32184754db19e0d53e",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/9dd91480-7ef4-4c69-b314-8a7d1024ae40-result.json": {
-    "mtime": 1781261265.9683726,
-    "ast_hash": "bc947fee5bfc1cf32149bae1611ef5ad",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/a10465f7-3143-4e7e-8a85-4fa86a62bf5f-container.json": {
-    "mtime": 1781261265.8525949,
-    "ast_hash": "7481a10ba6e9a402996c01acc7ee5d11",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/a2df3ce9-8c20-474f-8edd-09e6ee618ffd-container.json": {
-    "mtime": 1781261265.9693725,
-    "ast_hash": "d11e6332be9368faa9aec9b98844a83f",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/a3f06925-5386-4c41-98c5-60943569f6cf-container.json": {
-    "mtime": 1781261265.082732,
-    "ast_hash": "fa5425ff0b054d40c15281f79a7c89e3",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/a4bf9e7e-4fec-4492-a9dc-e31c941bcdd1-container.json": {
-    "mtime": 1781261260.146652,
-    "ast_hash": "022a94fed3e8fa7b60c0de372404fa06",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/a61165ad-243f-4481-a877-c43876c5c5b1-result.json": {
-    "mtime": 1781261265.8496058,
-    "ast_hash": "f17d475cc41934030ebec0a9a0666756",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/aa3cb496-e1e9-43c7-9b42-be4ccba44691-container.json": {
-    "mtime": 1781261260.5959175,
-    "ast_hash": "17a96a3e0ac99d531a91addea354d3df",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/ac3f9b8c-763f-4faa-8eaa-7f1c517955c0-result.json": {
-    "mtime": 1781261262.1224751,
-    "ast_hash": "286879f8b5917824a2014cab7dac30a4",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/b564838a-44ad-49a2-b125-32e71bf7dc6b-container.json": {
-    "mtime": 1781261293.377058,
-    "ast_hash": "2afed41cda2439600809ff54463a07f8",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/b7fe856b-fe14-4eaf-93f2-864790578a27-result.json": {
-    "mtime": 1781261261.9532466,
-    "ast_hash": "4b1786247697bd36e4742394bf322b88",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/bbee8c2f-41d6-497d-acd7-2a97653fe5b9-container.json": {
-    "mtime": 1781261260.9633348,
-    "ast_hash": "19d8f53c9fc9c7ab7adf6970dfbeb031",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/c275e8c6-d64a-4e0a-80c9-025d4a10a3b5-result.json": {
-    "mtime": 1781261264.798692,
-    "ast_hash": "886dad62e6571cb8d4a421123f01e32c",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/c7cc5aa3-4352-4fff-99bd-0509b8c4b7dd-result.json": {
-    "mtime": 1781261265.456596,
-    "ast_hash": "5d7e99d6839d7cdf29aa8592b186e6d4",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/c850d6fe-86d0-4d28-ab3c-d55b1306ed98-result.json": {
-    "mtime": 1781261260.960335,
-    "ast_hash": "59e8fab6e7102e14a68dbe8455f7de08",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/cc90cc47-058d-4854-8d38-565f08eb856e-container.json": {
-    "mtime": 1781261261.9598775,
-    "ast_hash": "bd1486584b7ae703ba89a32db0913875",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/ccdae339-3f8b-4c74-883c-3b28441eb606-result.json": {
-    "mtime": 1781261260.480549,
-    "ast_hash": "74fc9dcb57d22e3c9af8f5206f924d3c",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/cf5e499c-1711-4cc6-a4b7-2a0833a8f77d-container.json": {
-    "mtime": 1781261265.663854,
-    "ast_hash": "a7e029d7275585c90625eb1d091b6158",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/d08b8bad-34d3-430c-84ad-d3c3d106d156-result.json": {
-    "mtime": 1781261260.333485,
-    "ast_hash": "96edff47203704385669404b2323ecd4",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/d0fdeeb4-2c82-4e63-8d83-920d27101e13-container.json": {
-    "mtime": 1781261265.9564981,
-    "ast_hash": "8e3959d4bb87100ace1a8d6ca38f0947",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/d2099014-f7d1-479a-b3c4-760c92846940-container.json": {
-    "mtime": 1781261260.3365893,
-    "ast_hash": "7c1454a6730538625614b34ac7a10608",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/d5e43ad2-d3e4-4775-bf8c-a3bf6e628fdb-container.json": {
-    "mtime": 1781261261.2309248,
-    "ast_hash": "174efb5b763e33fef7d3258ab23e0657",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/e13c84b3-026f-4962-a7d7-478145110f1d-result.json": {
-    "mtime": 1781261265.1962416,
-    "ast_hash": "fd03c9e5569a6926d2d7ce0437ecb2f4",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/e333ca58-3efc-446f-988a-e545b48236c0-result.json": {
-    "mtime": 1781261263.0317159,
-    "ast_hash": "94749d3cb19499951354e965c9dd1647",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/e4a1fd9c-bde1-4041-99e3-10f1625a6b61-container.json": {
-    "mtime": 1781261264.879699,
-    "ast_hash": "8283c144641c72e27208056dc3fc920e",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/e83a72d1-b78c-4b58-85b2-d355dc4fe9c4-container.json": {
-    "mtime": 1781261264.9870567,
-    "ast_hash": "b1be9142df1cdb3ca6c333d095b651e4",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/e955453f-35fd-43c5-9104-7c11db687498-container.json": {
-    "mtime": 1781261261.0766895,
-    "ast_hash": "07ed818b8296d76427c3ffbd0a9c7741",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/ec0bb2a0-a35f-4ea6-9488-acfdef55e3b5-container.json": {
-    "mtime": 1781261261.7078385,
-    "ast_hash": "38f35852a497eb30ad6e78e544a6c4ab",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/eefed9c5-9c74-4059-af42-851008e6300c-container.json": {
-    "mtime": 1781261261.193559,
-    "ast_hash": "7a9839edfa7020fd5224213ec2324c02",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/ef2aa79a-37b7-4590-8ea7-5d23c5dd63c5-result.json": {
-    "mtime": 1781261298.5360124,
-    "ast_hash": "7261b719c54a42e73054f8576241f8ee",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/f09b997c-8139-4313-bde6-92d371c3cf21-result.json": {
-    "mtime": 1781261259.6082964,
-    "ast_hash": "5d6f2f5b045c37b6528c19be08939451",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/f3658847-9d50-458e-9e65-3173d28eb5f0-container.json": {
-    "mtime": 1781261263.0389788,
-    "ast_hash": "f6da89f24eeb4ffe51945b6bbad4f94c",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/f3e3617e-6025-4ff5-869b-6b7e9fb6e076-result.json": {
-    "mtime": 1781261263.9420035,
-    "ast_hash": "5896f9f61a76d282e758df198a1edb6f",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/f54d3f10-f12b-4afb-9fd9-120aed7f66eb-result.json": {
-    "mtime": 1781261265.6588435,
-    "ast_hash": "3b7b0fcd8961dc4cf832841f490fabea",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/f66f8135-529b-4da0-81c4-a430704a1233-container.json": {
-    "mtime": 1781261260.5888524,
-    "ast_hash": "62043cb09fdbdbcd9ebe83b4bd7ee4a3",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/fb5f0e30-bb7b-47df-9a33-16067f6763a5-result.json": {
-    "mtime": 1781261260.4429803,
-    "ast_hash": "a0401422194e4fd7f80eb2defa9a39e6",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/fb7bd661-ed65-4649-9b61-66dc8f237de4-result.json": {
-    "mtime": 1781261285.88635,
-    "ast_hash": "e3bbbceff6f67541b0f9c51955f46f9a",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/fbddeed7-f122-494a-93ee-346c127ca8b0-result.json": {
-    "mtime": 1781261293.3760495,
-    "ast_hash": "b2f674f1fcff6c30389c1ff72a9d1568",
-    "semantic_hash": ""
-  },
-  "shaft-doctor/allure-results/fff42249-66f7-4961-982a-a232d921fe79-container.json": {
-    "mtime": 1781261259.6426547,
-    "ast_hash": "8764868f3717b3612a1e93e003936c45",
-    "semantic_hash": ""
-  },
   "shaft-doctor/src/main/java/com/shaft/doctor/DoctorAiAnalysisRequest.java": {
-    "mtime": 1781248762.5662668,
+    "mtime": 1781769439.726218,
     "ast_hash": "55678906c451524f9fb3c48d0d464ff9",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/DoctorAnalysisRequest.java": {
-    "mtime": 1781242397.4406471,
+    "mtime": 1781769439.726218,
     "ast_hash": "6fb3dd5ae5993ce8a61e4cd73d327aa4",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/DoctorAnalyzer.java": {
-    "mtime": 1781248762.5671165,
+    "mtime": 1781769439.726218,
     "ast_hash": "fd86210399d3956a7a343693416c1453",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/ai/DoctorAiAnalysisService.java": {
-    "mtime": 1781248762.569275,
+    "mtime": 1781769439.7272189,
     "ast_hash": "4b1cd2196306a10434d9df255bf01d8d",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/analysis/DeterministicRuleEngine.java": {
-    "mtime": 1781242397.4436736,
+    "mtime": 1781769439.7282178,
     "ast_hash": "732501c3f0664de7f83469e8d9db5a70",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/cli/DoctorCli.java": {
-    "mtime": 1781250350.323748,
-    "ast_hash": "9a926bbd16030b97d64406b481ce369c",
+    "mtime": 1781769439.7291398,
+    "ast_hash": "c7277004cfa5eae27d5f7d1477ec92a4",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/collect/EvidenceCollector.java": {
-    "mtime": 1781242397.4476755,
+    "mtime": 1781769439.7291398,
     "ast_hash": "215b16abacef5aac9558b65d47ef7f79",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/format/DoctorFormatException.java": {
-    "mtime": 1781242397.4496744,
+    "mtime": 1781769439.7301452,
     "ast_hash": "ac49bb5981592a48aed69d5e929e8357",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/format/DoctorJsonCodec.java": {
-    "mtime": 1781248762.5712755,
+    "mtime": 1781769439.7301452,
     "ast_hash": "e37f60eedfbf0c389362d3fcf8884981",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/internal/DoctorHashing.java": {
-    "mtime": 1781242397.4542482,
+    "mtime": 1781769439.7311444,
     "ast_hash": "cbf37af4f45fcd49e34d177a36e7788e",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/internal/DoctorRedactor.java": {
-    "mtime": 1781242397.455244,
+    "mtime": 1781769439.7311444,
     "ast_hash": "50c5ae3ae3589a795ce05bd77aeb022d",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/CauseCategory.java": {
-    "mtime": 1781242397.4572423,
+    "mtime": 1781769439.7321448,
     "ast_hash": "07daed154b031e5c8e8a67f58d60c076",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/Confidence.java": {
-    "mtime": 1781242397.4582422,
+    "mtime": 1781769439.7321448,
     "ast_hash": "58efa214b4b396e5cd16320ecb7f1419",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/Diagnosis.java": {
-    "mtime": 1781242397.4592464,
+    "mtime": 1781769439.7321448,
     "ast_hash": "d5f6f816532eebb1a0ce72949dc26637",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAdvisory.java": {
-    "mtime": 1781248762.5722744,
+    "mtime": 1781769439.7331448,
     "ast_hash": "844eaf9048ab13c94b72ba4145b589f8",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAiAnalysisResult.java": {
-    "mtime": 1781248762.573275,
+    "mtime": 1781769439.7331448,
     "ast_hash": "93cd26759f448a2370ea5a793ccd0ecc",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAnalysisResult.java": {
-    "mtime": 1781242397.4597812,
+    "mtime": 1781769439.7341447,
     "ast_hash": "ae20f4a3cd962138db3be05bd442ef21",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAnalysisSummary.java": {
-    "mtime": 1781242397.4607937,
+    "mtime": 1781769439.7341447,
     "ast_hash": "db1612663a72eceaf8b36d02e4534f99",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorModelSupport.java": {
-    "mtime": 1781242397.4617896,
+    "mtime": 1781769439.7341447,
     "ast_hash": "8e4a6c083ab2a7837d98104a9ce23b8c",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/EvidenceBundle.java": {
-    "mtime": 1781242397.4627907,
+    "mtime": 1781769439.735145,
     "ast_hash": "f1ce8926f044be3bd0652d3b43f91946",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/EvidenceCategory.java": {
-    "mtime": 1781242397.4637942,
+    "mtime": 1781769439.735145,
     "ast_hash": "6976b42e37761f612bdee1f8d2cd8f50",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/EvidenceItem.java": {
-    "mtime": 1781242397.4647908,
+    "mtime": 1781769439.735145,
     "ast_hash": "2a427690ae34f946851017d16c18a5ab",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/EvidenceProvenance.java": {
-    "mtime": 1781242397.465789,
+    "mtime": 1781769439.7361443,
     "ast_hash": "56bd866d04bd1ab56863ab0aa104a31c",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/Finding.java": {
-    "mtime": 1781242397.467299,
+    "mtime": 1781769439.7361443,
     "ast_hash": "ca086338b16ab81a80882d4830254620",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/RedactionSummary.java": {
-    "mtime": 1781242397.4683087,
+    "mtime": 1781769439.7361443,
     "ast_hash": "5fcbb50a506dd9456d5ec76fe90a4ea7",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/Remediation.java": {
-    "mtime": 1781242397.4693093,
+    "mtime": 1781769439.7371442,
     "ast_hash": "45487f78e554324e826976f19b75dadc",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairAiRequest.java": {
-    "mtime": 1781249819.626759,
-    "ast_hash": "1db3826ed2a40416fe73612c7c9f1263",
+    "mtime": 1781769439.7371442,
+    "ast_hash": "cb971f162e01bc90678e0d40e08d0947",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairAiService.java": {
-    "mtime": 1781250947.2086048,
-    "ast_hash": "5b2c35a6a1681055a5820edc7edd319e",
+    "mtime": 1781769439.7381449,
+    "ast_hash": "0d4d59f92ec198022b0e44682359ac82",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairPatchResult.java": {
-    "mtime": 1781249819.626759,
-    "ast_hash": "2f1c809b03ed6d304edcfa1f4a860f37",
+    "mtime": 1781769439.7381449,
+    "ast_hash": "309c6a07dc3145574d2e2bbd54c7b334",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairProposalResult.java": {
-    "mtime": 1781249923.2052782,
-    "ast_hash": "34066d15685c846c0f456f17cf88e020",
+    "mtime": 1781769439.739145,
+    "ast_hash": "6a01cd05b4c6b271ce7ab395d393e396",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairPublicationRequest.java": {
-    "mtime": 1781249250.6281826,
-    "ast_hash": "401dad4dbdc92742130b60e9d9f4b01a",
+    "mtime": 1781769439.739145,
+    "ast_hash": "50162373c4b5f046f867b5d1344816c7",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairRequest.java": {
-    "mtime": 1781250264.468655,
-    "ast_hash": "ee69eb1ff0ce9634ca952f5f9bc964f7",
+    "mtime": 1781769439.739145,
+    "ast_hash": "8afe0727b1629734c1b865c805d613f3",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairService.java": {
-    "mtime": 1781250947.2101405,
-    "ast_hash": "0524a271d058affa012e91cfcda459f7",
+    "mtime": 1781769439.740145,
+    "ast_hash": "3ddd9b9f7ec71452100a891378758166",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposal.java": {
-    "mtime": 1781592922.4534707,
+    "mtime": 1781769439.740145,
     "ast_hash": "72e037d2cc8aac280c799b1f76147c4c",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposalRequest.java": {
-    "mtime": 1781592922.4534707,
+    "mtime": 1781769439.741145,
     "ast_hash": "b53a430ae27cf976040410a97b06a37b",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposalService.java": {
-    "mtime": 1781592922.4534707,
+    "mtime": 1781769439.741145,
     "ast_hash": "1f0ea7387c631ddb9501dc97f144e27b",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/RepairGuard.java": {
-    "mtime": 1781250701.2671933,
-    "ast_hash": "e4e29b1089e8936ff7074e1eb74123d8",
+    "mtime": 1781769439.741145,
+    "ast_hash": "fba5356ab168ee237ee6530712c94f00",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/RepairProcessRunner.java": {
-    "mtime": 1781249367.4139974,
-    "ast_hash": "fea9d2c62c8a39e8148e3c66c1c2ecf2",
+    "mtime": 1781769439.7421443,
+    "ast_hash": "5fe1cd3c8e8b190bcab936fd417b3825",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/RepairProposal.java": {
-    "mtime": 1781249250.6271753,
-    "ast_hash": "6c7358316883e4e90b826092786eab00",
+    "mtime": 1781769439.7421443,
+    "ast_hash": "f1e22305d666390fc499f30d41184bc7",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/RepairProposalStore.java": {
-    "mtime": 1781249367.4129937,
-    "ast_hash": "06b2fa95bc934bf68f4f3bdfe75598e6",
+    "mtime": 1781769439.7431445,
+    "ast_hash": "e94f86295598c8f1ae590214048bd53b",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/RepairPublicationResult.java": {
-    "mtime": 1781249250.6281826,
-    "ast_hash": "3910f02d963ce2570d37c82fdfb42520",
+    "mtime": 1781769439.7431445,
+    "ast_hash": "54b09925ec8f18ec028ba4dec8dfceee",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/report/DoctorReportWriter.java": {
-    "mtime": 1781248762.5742764,
+    "mtime": 1781769439.7431445,
     "ast_hash": "cf246a6dccada6bd2ad38899deed5728",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-doctor-advisory-1.0.schema.json": {
-    "mtime": 1781248762.5757835,
+    "mtime": 1781769439.7441444,
     "ast_hash": "0707502a8d574324252c3e6c9e59b68e",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-doctor-diagnosis-1.0.schema.json": {
-    "mtime": 1781242397.4738364,
+    "mtime": 1781769439.745145,
     "ast_hash": "955b53f8d49daea98d4ac1fc82d40587",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-doctor-evidence-1.0.schema.json": {
-    "mtime": 1781242397.475344,
+    "mtime": 1781769439.745145,
     "ast_hash": "62af20c56b0b7df2415adc87012a03c7",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-doctor-repair-patch-1.0.schema.json": {
-    "mtime": 1781249819.6292794,
-    "ast_hash": "878c94281fdc726b01ccd4c64bce0369",
+    "mtime": 1781769439.7460573,
+    "ast_hash": "0798e219e11cb74541c713d96d2ac2a9",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-heal-locator-proposal-1.0.schema.json": {
-    "mtime": 1781592922.4544709,
+    "mtime": 1781769439.7460573,
     "ast_hash": "ede7581c250a246a7ef50c26116e926b",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/DoctorAnalyzerTest.java": {
-    "mtime": 1781248762.5773132,
+    "mtime": 1781769439.7471528,
     "ast_hash": "97bda547e7be8d60c7186f5819b612dc",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/ai/DoctorAiAnalysisServiceTest.java": {
-    "mtime": 1781248762.5783155,
+    "mtime": 1781769439.748149,
     "ast_hash": "a4275d927157b9dcdca5a983b2cf514a",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/repair/DoctorRepairAiServiceTest.java": {
-    "mtime": 1781250020.8050969,
-    "ast_hash": "3da7790ced82302f6f8dcebc758d8184",
+    "mtime": 1781769439.7491548,
+    "ast_hash": "42a607d9a057330ca195c6cfc9ae7d54",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/repair/DoctorRepairServiceTest.java": {
-    "mtime": 1781250768.8893447,
-    "ast_hash": "d8224442b507b95766e66a8d93251334",
+    "mtime": 1781769439.7491548,
+    "ast_hash": "0de5d211d8c45c9799e1b2487f28106c",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/repair/HealingLocatorProposalServiceTest.java": {
-    "mtime": 1781592922.4556108,
+    "mtime": 1781769439.7501543,
     "ast_hash": "87a964a179a869fd747537abc1dee167",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/ai/contradictory.json": {
-    "mtime": 1781248762.5793135,
+    "mtime": 1781769439.7510228,
     "ast_hash": "9cc3faaf569b9523478d440eac4c31fa",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/ai/hallucinated-evidence.json": {
-    "mtime": 1781248762.5803137,
+    "mtime": 1781769439.7510228,
     "ast_hash": "8392a8f0353b0006ce35cee8a3cd04e4",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/ai/high-quality.json": {
-    "mtime": 1781248762.5813124,
+    "mtime": 1781769439.7520273,
     "ast_hash": "e6f7861bf34853d8e39252b93d0f7ee4",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/ai/malformed.json": {
-    "mtime": 1781248762.5813124,
+    "mtime": 1781769439.7524824,
     "ast_hash": "fb9415fb50bc91677036081513bbc19d",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/ai/unavailable.json": {
-    "mtime": 1781248762.5823126,
+    "mtime": 1781769439.7524824,
     "ast_hash": "4b7fec724f675abb3404bc58a0cd21fd",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/golden/doctor-report.json": {
-    "mtime": 1781242397.4833813,
+    "mtime": 1781769439.7524824,
     "ast_hash": "d19a4cec92c592cf6f3804f87c7d1ac8",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/golden/locator-result.json": {
-    "mtime": 1781242397.4869368,
+    "mtime": 1781769439.7534876,
     "ast_hash": "cc0963373d7ae1eb7e2026ce65f5c16d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/RequestBuilder.java": {
-    "mtime": 1781170594.823144,
+    "mtime": 1781769439.7564874,
     "ast_hash": "08dc261862300eed2b61de741834c62e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/RestActions.java": {
-    "mtime": 1781642509.7758484,
+    "mtime": 1781769439.7574873,
     "ast_hash": "f4ef1f3c58839876c517d8eb061689c6",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/ShaftRestAssuredFilter.java": {
-    "mtime": 1781642509.7758484,
+    "mtime": 1781769439.7574873,
     "ast_hash": "9306e392aada4eeb056b02e8583750ee",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cli/FileActions.java": {
-    "mtime": 1781642509.776848,
-    "ast_hash": "ae9fbf873558cfb7e044ce0da5caa089",
+    "mtime": 1781769623.6765432,
+    "ast_hash": "27527de9390282ca9d6983f3fc2b635d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java": {
-    "mtime": 1781679984.9591107,
-    "ast_hash": "fb714a3745eb9306edb922f8e8e08a4d",
+    "mtime": 1781769574.7727997,
+    "ast_hash": "0fe5b4b9569088d149c45b080214485d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cucumber/AssertionSteps.java": {
-    "mtime": 1781170594.8291447,
+    "mtime": 1781769439.7594872,
     "ast_hash": "5698b91473dd5dca826130e368e03b08",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cucumber/BrowserSteps.java": {
-    "mtime": 1781170594.8301454,
+    "mtime": 1781769439.760488,
     "ast_hash": "ad3b088235e9d348c8563ed46da91944",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cucumber/ElementSteps.java": {
-    "mtime": 1781170594.831144,
+    "mtime": 1781769439.760488,
     "ast_hash": "5174cbfba57ae0fc18a79de0c4491af1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/db/DatabaseActions.java": {
-    "mtime": 1781642509.7788484,
-    "ast_hash": "e94ab6b3d65838a79da1adf16ace4c37",
+    "mtime": 1781769588.8269844,
+    "ast_hash": "57f5d8ec15e26dfef0be157fc9dc9e0c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/DriverFactory.java": {
-    "mtime": 1781642509.7797499,
+    "mtime": 1781769439.761487,
     "ast_hash": "490c0d7f6e99f5c4159608e8486454f0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/SHAFT.java": {
-    "mtime": 1781679984.9601107,
+    "mtime": 1781769439.7624872,
     "ast_hash": "3b091022a995c47b1e1d907e1f79c781",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/$.java": {
-    "mtime": 1781170594.8351498,
+    "mtime": 1781769439.7634873,
     "ast_hash": "f0f29bf4777208e42080bbb8d92c7655",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/BrowserStackHelper.java": {
-    "mtime": 1781642509.7808385,
+    "mtime": 1781769439.7634873,
     "ast_hash": "c84a7c36529d6316eaa5e9d71c767def",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/BrowserStackSdkHelper.java": {
-    "mtime": 1781642509.7808385,
+    "mtime": 1781769439.764488,
     "ast_hash": "85c848b791627a3f81dc6f1499440f48",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java": {
-    "mtime": 1781642509.781836,
+    "mtime": 1781769439.764488,
     "ast_hash": "45499e8468c66155ef7f864ba18e8b23",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/LambdaTestHelper.java": {
-    "mtime": 1781642509.782837,
+    "mtime": 1781769439.7654877,
     "ast_hash": "3f3755d291c98c32cfdd363cee4cf73a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java": {
-    "mtime": 1781170594.8411436,
+    "mtime": 1781769439.7654877,
     "ast_hash": "5b9262d2b474746633c113235894b0f7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/SynchronizationManager.java": {
-    "mtime": 1781170594.8411436,
+    "mtime": 1781769439.7664874,
     "ast_hash": "eb0cff7a79a25b8e6999426d21353757",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/FluentWebDriverAction.java": {
-    "mtime": 1781170594.8421447,
+    "mtime": 1781769439.7664874,
     "ast_hash": "72da0e0b47b4f503c107c7add47ab23a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/WizardHelpers.java": {
-    "mtime": 1781170594.843029,
+    "mtime": 1781769439.7674873,
     "ast_hash": "b8a99168e709824479a851c804b0b407",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/enums/internal/ClipboardAction.java": {
-    "mtime": 1781170594.8446348,
+    "mtime": 1781769439.7674873,
     "ast_hash": "70733b35a3b354ad26cb2293c92e7c1f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/enums/internal/NavigationAction.java": {
-    "mtime": 1781170594.8456452,
+    "mtime": 1781769439.7684875,
     "ast_hash": "c58c8262a7e2348b6984ff75638f997a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/enums/internal/Screenshots.java": {
-    "mtime": 1781170594.846645,
+    "mtime": 1781769439.7684875,
     "ast_hash": "623942ecc89e633c28fa2014876ac552",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java": {
-    "mtime": 1781642509.7838364,
+    "mtime": 1781769439.7694874,
     "ast_hash": "13efb2f925230e3a8929d4771d1dc132",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserActionsHelper.java": {
-    "mtime": 1781642509.784837,
+    "mtime": 1781769439.7704875,
     "ast_hash": "9e93f32f815bc40eb9bad1c1ced6ca25",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/JavaScriptWaitManager.java": {
-    "mtime": 1781423522.436818,
+    "mtime": 1781769439.7704875,
     "ast_hash": "2461e01c04d95924a01f0c83b9ad7029",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/AlertActions.java": {
-    "mtime": 1781170594.8516426,
+    "mtime": 1781769439.7714877,
     "ast_hash": "7f1bcf5298fa358d40eaf5a81aef61ca",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/AsyncElementActions.java": {
-    "mtime": 1781170594.852643,
+    "mtime": 1781769439.7714877,
     "ast_hash": "b127634e4819e21e34a549ba21ca7a03",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/ElementActions.java": {
-    "mtime": 1781642509.784837,
+    "mtime": 1781769439.7724879,
     "ast_hash": "e04a5ad85c759eedd8459f735a453cf3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java": {
-    "mtime": 1781592922.457622,
+    "mtime": 1781769439.7724879,
     "ast_hash": "a4c3cd5c0a9a4e41e0b34363ac272001",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java": {
-    "mtime": 1781735146.2056143,
-    "ast_hash": "731df72482b634b806c3776920c0b3ea",
+    "mtime": 1781769439.7734878,
+    "ast_hash": "95ed51b85934932c7c9c9d0449b98fdd",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java": {
-    "mtime": 1781642509.7868412,
-    "ast_hash": "9140eb65009a9477d80ad0e9f0e92dd1",
+    "mtime": 1781769439.7744956,
+    "ast_hash": "79f74172e4812db312b9248415ddd94c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementInformation.java": {
-    "mtime": 1781170594.8576462,
+    "mtime": 1781769439.7754872,
     "ast_hash": "069e9385670d467fcfd1f7210d9e34cc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/exceptions/MultipleElementsFoundException.java": {
-    "mtime": 1781170594.8596456,
+    "mtime": 1781769439.7759426,
     "ast_hash": "7115d38040575ebf54fb3f543a30290f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingActionOutcome.java": {
-    "mtime": 1781281088.024183,
-    "ast_hash": "1ee3cc4403b70c200185567f8dafb1ed",
+    "mtime": 1781769439.7769446,
+    "ast_hash": "9a99f0ead6650249de18d721129711cc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingExplanation.java": {
-    "mtime": 1781592922.4596236,
+    "mtime": 1781769439.7769446,
     "ast_hash": "ee26d9a41572d22c59b897020537b16e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingManager.java": {
-    "mtime": 1781592922.4606235,
+    "mtime": 1781769439.7769446,
     "ast_hash": "188dfd22939333186c98b7a9749d6aed",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingObservation.java": {
-    "mtime": 1781281088.0231824,
-    "ast_hash": "c319538f9dde6467563ca2a472ab11a5",
+    "mtime": 1781769439.7779496,
+    "ast_hash": "a5423face0fd000d6ecaca3410a7b2e3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingProvider.java": {
-    "mtime": 1781592922.4606235,
+    "mtime": 1781769439.7786136,
     "ast_hash": "ebf8923cd40ade102731421c41f57986",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingProviderRegistry.java": {
-    "mtime": 1781283589.7103984,
-    "ast_hash": "075eecc091cf8573339206b16c1ba4fb",
+    "mtime": 1781769439.7786136,
+    "ast_hash": "3cbe60277c5b519104b46355f11b3849",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingRequest.java": {
-    "mtime": 1781281088.022183,
-    "ast_hash": "6bc56d65ebffff7269cedc421d3ffbdc",
+    "mtime": 1781769439.7786136,
+    "ast_hash": "01fa33edca22567bffb147b7698ef87d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingResolution.java": {
-    "mtime": 1781281088.0231824,
-    "ast_hash": "9dd0741bc8023afb22886d37dace9c97",
+    "mtime": 1781769439.779619,
+    "ast_hash": "53c802fb2320dd3320128019dcb8e965",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingStrategy.java": {
-    "mtime": 1781281088.022183,
-    "ast_hash": "e90dada34ee31a8ed2535c1f10601122",
+    "mtime": 1781769439.779619,
+    "ast_hash": "28500b405d7d843f0099971b196415d1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingVisualProvider.java": {
-    "mtime": 1781281088.024183,
-    "ast_hash": "2a01ea4bf0591763181495effcf8cf4c",
+    "mtime": 1781769439.779619,
+    "ast_hash": "cf4607a228a2c6f37ef287bf95c02905",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/AnimatedGifManager.java": {
-    "mtime": 1781735224.1379743,
-    "ast_hash": "350d7fe3fad69f8aae7df0c857bb3d80",
+    "mtime": 1781769439.7806184,
+    "ast_hash": "e1789eed28ef0ce552ab79f00c6e7730",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java": {
-    "mtime": 1781734857.2339897,
+    "mtime": 1781769439.7816188,
     "ast_hash": "e490e4175f89de91b0ef1a044e87c1e8",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotHelper.java": {
-    "mtime": 1781642509.7880492,
+    "mtime": 1781769439.7816188,
     "ast_hash": "bd9223dc2b3615bddc02e58bc5ec999f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotManager.java": {
-    "mtime": 1781734857.2349873,
+    "mtime": 1781769439.7826188,
     "ast_hash": "b179b6629a5913209c37a39b7929b31e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/VisualProcessingProvider.java": {
-    "mtime": 1781170594.8636441,
+    "mtime": 1781769439.7826188,
     "ast_hash": "518375751922c74491ff164ac733ed45",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/VisualProcessingProviderRegistry.java": {
-    "mtime": 1781170594.8646424,
+    "mtime": 1781769439.7836244,
     "ast_hash": "9b616f64cbbddb4faead5b8f0a9c21b9",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/Locator.java": {
-    "mtime": 1781170594.8656437,
+    "mtime": 1781769439.7836244,
     "ast_hash": "e02bf607fbeff72dd9b178b08bf8d85b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/LocatorBuilder.java": {
-    "mtime": 1781170594.866643,
+    "mtime": 1781769439.7846293,
     "ast_hash": "7cf6d327eb5dcf78e6472b4f3e60efcb",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/Locators.java": {
-    "mtime": 1781170594.8676448,
+    "mtime": 1781769439.7846293,
     "ast_hash": "c75c5f50d1a2cfb34eac7e66c23ddedc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/Role.java": {
-    "mtime": 1781170594.8686466,
+    "mtime": 1781769439.7846293,
     "ast_hash": "7f35dc1a5a395ed93e4c158badb0ec2b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/ShadowLocatorBuilder.java": {
-    "mtime": 1781170594.8686466,
+    "mtime": 1781769439.7856297,
     "ast_hash": "ebec375f08bc01a3b1502aed75f1231d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/SmartLocators.java": {
-    "mtime": 1781592922.461622,
+    "mtime": 1781769439.7856297,
     "ast_hash": "f72837b463f998144bd62dfed96f39f6",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/XpathAxis.java": {
-    "mtime": 1781170594.8706439,
+    "mtime": 1781769439.7856297,
     "ast_hash": "15de5fb7fe4ce1ecbf3fc6b5022ba3df",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/DeterministicNaturalActionPlanner.java": {
-    "mtime": 1781592922.4626224,
+    "mtime": 1781769439.7866292,
     "ast_hash": "95e7f4007bf7fc22f96dfd426ca47ea7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionExecutor.java": {
-    "mtime": 1781592922.4626224,
+    "mtime": 1781769439.7866292,
     "ast_hash": "27f19328ab9d5a45da44797cdce1d2a5",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionKind.java": {
-    "mtime": 1781592922.4636264,
+    "mtime": 1781769439.7876291,
     "ast_hash": "7ab19c76ab5d66cdc94e8183b5c4fe4c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionPlan.java": {
-    "mtime": 1781592922.4636264,
+    "mtime": 1781769439.7876291,
     "ast_hash": "c913e5edcb2b9594946cf5b50362d108",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionPlanner.java": {
-    "mtime": 1781592922.4646237,
+    "mtime": 1781769439.7886298,
     "ast_hash": "544f27ddc74a8a6732e6ad6e2f7da494",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionPlannerRegistry.java": {
-    "mtime": 1781592922.4656246,
+    "mtime": 1781769439.7886298,
     "ast_hash": "8a223a42ffda00a3e13ae108748a8270",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionRequest.java": {
-    "mtime": 1781592922.4656246,
+    "mtime": 1781769439.789629,
     "ast_hash": "51e484221eb6defbd218ade0eb1dea84",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionStep.java": {
-    "mtime": 1781592922.4666228,
+    "mtime": 1781769439.789629,
     "ast_hash": "29b36b4244b122ef2e6dd4c391c99625",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/video/DesktopVideoRecordingProvider.java": {
-    "mtime": 1781170594.871645,
+    "mtime": 1781769439.789629,
     "ast_hash": "b98f55fe150407bba68594b78fb2e5b7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistry.java": {
-    "mtime": 1781170594.872641,
+    "mtime": 1781769439.7906294,
     "ast_hash": "5cb846a30b50df2b01b15bb5abaf362f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/video/RecordManager.java": {
-    "mtime": 1781642509.7891362,
+    "mtime": 1781769439.7906294,
     "ast_hash": "dfb5cd84c87c3415a09edab2814dd043",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/AllureListener.java": {
-    "mtime": 1781170594.8736432,
+    "mtime": 1781769439.7916293,
     "ast_hash": "70c13f53148c23e594bdec7212c7e89c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/CucumberFeatureListener.java": {
-    "mtime": 1781687980.924224,
+    "mtime": 1781769439.7926314,
     "ast_hash": "14d03222afd184a66843e942e8d6c838",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/CucumberTestRunnerListener.java": {
-    "mtime": 1781170594.8756416,
+    "mtime": 1781769439.7926314,
     "ast_hash": "4d4b34169ad6f2440e377838f32554f3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/JunitListener.java": {
-    "mtime": 1781687980.9253013,
+    "mtime": 1781769439.7936294,
     "ast_hash": "8d299e32794a09954a9e9187c17c871f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/TestNGListener.java": {
-    "mtime": 1781687980.9253013,
+    "mtime": 1781769439.7936294,
     "ast_hash": "3d6e8adae0aab2c8529108e04e85ee02",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/ConfigurationHelper.java": {
-    "mtime": 1781170594.8786502,
+    "mtime": 1781769439.7946296,
     "ast_hash": "e96809e943e2adb15f47a9c242a540dc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/CucumberHelper.java": {
-    "mtime": 1781170594.8796513,
+    "mtime": 1781769439.7946296,
     "ast_hash": "b9d9211bd12ac82043f313e415ed8cfc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/JiraHelper.java": {
-    "mtime": 1781170594.880653,
+    "mtime": 1781769439.795629,
     "ast_hash": "4951a365226452bd907fcfa68b627475",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/JunitListenerHelper.java": {
-    "mtime": 1781170594.881653,
+    "mtime": 1781769439.795629,
     "ast_hash": "5a96f15340ee466d71733a4977fab257",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/RetryAnalyzer.java": {
-    "mtime": 1781642509.790136,
+    "mtime": 1781769439.795629,
     "ast_hash": "31c1a3ffc5fd936dd683ec1fd80a1a6d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java": {
-    "mtime": 1781170594.8826504,
+    "mtime": 1781769439.7966292,
     "ast_hash": "8c453af5c660a92beb6086d1b0dd315c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/UpdateChecker.java": {
-    "mtime": 1781642509.7911363,
+    "mtime": 1781769439.7966292,
     "ast_hash": "56edc5784cd56e08113f0d04f51fd25a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/WebDriverListener.java": {
-    "mtime": 1781642509.7921355,
+    "mtime": 1781769439.7976289,
     "ast_hash": "11caa57a58f17da0416933518895efdd",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/performance/internal/LightHouseGenerateReport.java": {
-    "mtime": 1781170594.8866515,
+    "mtime": 1781769439.7976289,
     "ast_hash": "8395aa33dcea0312ab66a82c9fc7eb77",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/API.java": {
-    "mtime": 1781642509.7921355,
+    "mtime": 1781769439.7986293,
     "ast_hash": "ed37de76862455b58cb06ec770ecd159",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Allure.java": {
-    "mtime": 1781687980.926301,
+    "mtime": 1781769439.7996292,
     "ast_hash": "8db3286d4c88e2ad66b8238976ab1f26",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/BrowserStack.java": {
-    "mtime": 1781642509.7941358,
+    "mtime": 1781769439.7996292,
     "ast_hash": "2c4ea1d03ddde366471ab7d371f129c0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Cucumber.java": {
-    "mtime": 1781170594.8906512,
+    "mtime": 1781769439.800629,
     "ast_hash": "563b9ce2f293404c06e4a7a73dab132b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/EngineProperties.java": {
-    "mtime": 1781642509.7941358,
+    "mtime": 1781769439.800629,
     "ast_hash": "d6f1faf5a817917c034462f1593f3851",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Flags.java": {
-    "mtime": 1781642509.7951355,
+    "mtime": 1781769439.800629,
     "ast_hash": "643347d2cdd011d79a7504db2bc868b4",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Healenium.java": {
-    "mtime": 1781642509.7958932,
+    "mtime": 1781769439.8016295,
     "ast_hash": "020bedc94874be8d4f237c2007a9244c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Healing.java": {
-    "mtime": 1781642509.7963178,
+    "mtime": 1781769439.8016295,
     "ast_hash": "385585cc4fe7cc236525dcf28d9cf241",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java": {
-    "mtime": 1781682813.3079863,
-    "ast_hash": "1f9b4559e87b52433275fb6a0e0e63c1",
+    "mtime": 1781769439.8026297,
+    "ast_hash": "548b54bea14f8d32fb82491abe313964",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Jira.java": {
-    "mtime": 1781642509.797395,
+    "mtime": 1781769439.8026297,
     "ast_hash": "69e39c376eb244713a8638e8b682931a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/LambdaTest.java": {
-    "mtime": 1781716075.673954,
-    "ast_hash": "26a22b77a7b40e091d5d3181165b59f4",
+    "mtime": 1781769439.8036292,
+    "ast_hash": "2129d3567c4540656d0f1a70a4b5836e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Log4j.java": {
-    "mtime": 1781642509.7983942,
+    "mtime": 1781769439.8036292,
     "ast_hash": "64f209cc056e8a51110fc91a200d8abc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Mobile.java": {
-    "mtime": 1781642509.7983942,
+    "mtime": 1781769439.8036292,
     "ast_hash": "99c440a93cda95169b39727741055898",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/NaturalActions.java": {
-    "mtime": 1781642509.7993946,
+    "mtime": 1781769439.8046296,
     "ast_hash": "16794b31ca521ab70430850b04a80827",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Paths.java": {
-    "mtime": 1781642509.8003945,
+    "mtime": 1781769439.8046296,
     "ast_hash": "e75d6d00fdd8079a0bc4e51ceec9152d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Pattern.java": {
-    "mtime": 1781642509.8003945,
+    "mtime": 1781769439.8046296,
     "ast_hash": "8002dccd85dcdaafcd7ec207d48f88a5",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Performance.java": {
-    "mtime": 1781642509.8013947,
+    "mtime": 1781769439.80563,
     "ast_hash": "793bb90128693e92514e59175322965c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Pilot.java": {
-    "mtime": 1781642509.8023944,
+    "mtime": 1781769439.80563,
     "ast_hash": "5926e78f43d97233473dd978b9e55623",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Platform.java": {
-    "mtime": 1781642509.8023944,
+    "mtime": 1781769439.806629,
     "ast_hash": "3c8d103672435e69831b1cb1a76cfc2c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Properties.java": {
-    "mtime": 1781592922.4696224,
+    "mtime": 1781769439.806629,
     "ast_hash": "8720a3c4a06dd05b81e1c24b90d92723",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java": {
-    "mtime": 1781642509.8033948,
-    "ast_hash": "b2dc477ed2547d4fe32d8e7e6a4078bc",
+    "mtime": 1781769611.4249923,
+    "ast_hash": "48ce4ac0289abe52ff7930a5535a7406",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/PropertyFileManager.java": {
-    "mtime": 1781712585.9630957,
-    "ast_hash": "2ef0dcb84ab08feb3011d5ffd6b6c85f",
+    "mtime": 1781769439.8076296,
+    "ast_hash": "9d964e84622ad9d18da36a457b424873",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Reporting.java": {
-    "mtime": 1781687980.927301,
+    "mtime": 1781769439.8083756,
     "ast_hash": "8132aca6020e4e06200d956af056225f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/TestNG.java": {
-    "mtime": 1781170594.9027405,
+    "mtime": 1781769439.8083756,
     "ast_hash": "268615541ef0f2d92323fd0edd376740",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/ThreadLocalPropertiesManager.java": {
-    "mtime": 1781170594.903741,
+    "mtime": 1781769439.8083756,
     "ast_hash": "7603bbb7bf6364ce7bf5b9f5e1bba5e1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Timeouts.java": {
-    "mtime": 1781642509.8045712,
+    "mtime": 1781769439.8093808,
     "ast_hash": "70eb072e8b3b383a9391c914ff76950e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Tinkey.java": {
-    "mtime": 1781642509.8056612,
+    "mtime": 1781769439.8093808,
     "ast_hash": "f35fc1565279b0d33b1b76121bf74440",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Visuals.java": {
-    "mtime": 1781642509.8056612,
+    "mtime": 1781769439.8093808,
     "ast_hash": "606feddfa218d572c43882a90f235400",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Web.java": {
-    "mtime": 1781642509.8066607,
+    "mtime": 1781769439.8103862,
     "ast_hash": "20cf2529ea8129f74e8f092bc14cadde",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/FirestoreRestClient.java": {
-    "mtime": 1781170594.9077427,
+    "mtime": 1781769439.8114245,
     "ast_hash": "52adc8b518e5c5ed1246fd4aa8271ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/security/GoogleTink.java": {
-    "mtime": 1781642509.807661,
+    "mtime": 1781769439.8124301,
     "ast_hash": "3d0e1234d2dbab5b9ef7b984cb681088",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/AndroidApkBadgingReader.java": {
-    "mtime": 1781170594.9097402,
+    "mtime": 1781769439.8124301,
     "ast_hash": "eb3f564e4c3e3d2f3ffccaf882ac4b1f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/HTMLHelper.java": {
-    "mtime": 1781340359.3742328,
-    "ast_hash": "8bf3a220a77073ba73fc07e03b389889",
+    "mtime": 1781769439.8134294,
+    "ast_hash": "01aa2d71f05910f2d87ee5cef79416bd",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/JavaHelper.java": {
-    "mtime": 1781170594.9117453,
+    "mtime": 1781769439.8134294,
     "ast_hash": "ed73c5c20483f9571b67d9b340812be8",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/JavaScriptHelper.java": {
-    "mtime": 1781170594.9127493,
+    "mtime": 1781769439.8144293,
     "ast_hash": "ffa7c4c697733f0ba85ac8992acad360",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/PerformanceReportHTMLHelper.java": {
-    "mtime": 1781170594.9127493,
+    "mtime": 1781769439.8144293,
     "ast_hash": "88c165d5f2804d620f65e01921143f9e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/tms/XrayIntegrationHelper.java": {
-    "mtime": 1781170594.9147449,
+    "mtime": 1781769439.8154302,
     "ast_hash": "fb311baa28adbc7f20c468d548dce603",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/CSVFileManager.java": {
-    "mtime": 1781642509.8086605,
+    "mtime": 1781769439.8154302,
     "ast_hash": "bc71c58c04f330dc365d51d576fedec2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/ExcelFileManager.java": {
-    "mtime": 1781642509.8096607,
+    "mtime": 1781769439.8164291,
     "ast_hash": "0af8559f094d68d4e36cb6a9b7c5b9ea",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/JSONFileManager.java": {
-    "mtime": 1781642509.8096607,
+    "mtime": 1781769439.8164291,
     "ast_hash": "dd7a5b8f6f927191caa131280df13a65",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/PdfFileManager.java": {
-    "mtime": 1781170594.9177442,
+    "mtime": 1781769439.8174286,
     "ast_hash": "da672eb4269d3a41533ed1532da0e185",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/ReportManager.java": {
-    "mtime": 1781642509.8106606,
+    "mtime": 1781769439.8174286,
     "ast_hash": "d10eaae43cb3834460d68caa41746193",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/YAMLFileManager.java": {
-    "mtime": 1781642509.8116603,
+    "mtime": 1781769439.8174286,
     "ast_hash": "d5a21b7fac317f8b4e5341c703a0a249",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java": {
-    "mtime": 1781687980.9283013,
-    "ast_hash": "c45a77eaee3092add8cdc250ac04b642",
+    "mtime": 1781769599.1610012,
+    "ast_hash": "2d8021962c6dc8cd161889bd88c7a04c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ApiPerformanceExecutionReport.java": {
-    "mtime": 1781170594.9217446,
+    "mtime": 1781769439.8194292,
     "ast_hash": "0e913480d5e37f16c5547a28cbb78efe",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/AttachmentReporter.java": {
-    "mtime": 1781642509.8129704,
-    "ast_hash": "c3f9ed9269797a1679c4846a740a6273",
+    "mtime": 1781770425.5363648,
+    "ast_hash": "7dd574231ff0fca74042b22d5c581129",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointCounter.java": {
-    "mtime": 1781724033.9928803,
-    "ast_hash": "352c31092dd6b980c294827b636ff158",
+    "mtime": 1781769439.820429,
+    "ast_hash": "34558a6d4d5d49df20017aa63876759f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointStatus.java": {
-    "mtime": 1781170594.923741,
+    "mtime": 1781769439.820429,
     "ast_hash": "02d39d0739d083d1109634c17bb340c1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointType.java": {
-    "mtime": 1781170594.923741,
+    "mtime": 1781769439.820429,
     "ast_hash": "e688c7535844f865f0c179f1f0f7a41b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ExecutionSummaryReport.java": {
-    "mtime": 1781170594.9247413,
+    "mtime": 1781769439.8214288,
     "ast_hash": "85be5b1acb498075ff0ae7394c116e10",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureReporter.java": {
-    "mtime": 1781170594.9247413,
+    "mtime": 1781769439.8214288,
     "ast_hash": "5c3cbaf91f5d1501231b96f95bf6d566",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/IssueReporter.java": {
-    "mtime": 1781170594.9257412,
+    "mtime": 1781769439.8224342,
     "ast_hash": "f165af1bae7b2423b9e90cb95ea6a697",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/LogRedirector.java": {
-    "mtime": 1781642509.8129704,
+    "mtime": 1781769439.8224342,
     "ast_hash": "9734e0985bd24a628cdf0ef67514d8ab",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ProgressBarLogger.java": {
-    "mtime": 1781340262.133359,
+    "mtime": 1781769439.8224342,
     "ast_hash": "1c70b09200a5208dde2ff1f61895e6f9",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ProjectStructureManager.java": {
-    "mtime": 1781642509.814052,
+    "mtime": 1781769439.823429,
     "ast_hash": "d47f93c44ae20c2b7c4a5f9cd7033725",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportHelper.java": {
-    "mtime": 1781642509.815053,
+    "mtime": 1781769439.823429,
     "ast_hash": "eda180c3b95904b507f3afacd5875c9b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java": {
-    "mtime": 1781724033.9938784,
-    "ast_hash": "166d89734ece21da2bb735aa97fcb660",
+    "mtime": 1781769563.5309994,
+    "ast_hash": "f874371c4e31c7f7b1dd6ac197a9c65c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/ValidationEnums.java": {
-    "mtime": 1781170594.9317434,
+    "mtime": 1781769439.8244295,
     "ast_hash": "1a700a8ec5f1bc9a8ad65352a4891e8f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/Validations.java": {
-    "mtime": 1781340262.1079626,
+    "mtime": 1781769439.8254292,
     "ast_hash": "ac6f1f7951b5f8d5f5cc116afc5fc6ce",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/accessibility/AccessibilityActions.java": {
-    "mtime": 1781642509.8160527,
+    "mtime": 1781769439.8254292,
     "ast_hash": "e95213311dd416f0935f0b258beacfb8",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/accessibility/AccessibilityHelper.java": {
-    "mtime": 1781642509.8170524,
+    "mtime": 1781769439.826587,
     "ast_hash": "ef3e9bfa56f456c0c36ed15424404f66",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/CustomSoftAssert.java": {
-    "mtime": 1781170594.936743,
+    "mtime": 1781769439.8275874,
     "ast_hash": "31fefbb06d71c6973972d1c287e1d440",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/FileValidationsBuilder.java": {
-    "mtime": 1781170594.936743,
+    "mtime": 1781769439.8275874,
     "ast_hash": "05b7459be4fb4a2b653dadbac75eed37",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/JSONValidationsBuilder.java": {
-    "mtime": 1781170594.937745,
+    "mtime": 1781769439.8275874,
     "ast_hash": "a9b55ada19e44acdaa2347d81649fb75",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/NativeValidationsBuilder.java": {
-    "mtime": 1781170594.9387453,
+    "mtime": 1781769439.828952,
     "ast_hash": "5a33c1e4af8ab5765db43c7f150c4e40",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/NumberValidationsBuilder.java": {
-    "mtime": 1781170594.9397469,
+    "mtime": 1781769439.828952,
     "ast_hash": "10b25c3ee77eb08878b4e715f70b6ad0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/RestValidationsBuilder.java": {
-    "mtime": 1781170594.9397469,
+    "mtime": 1781769439.828952,
     "ast_hash": "f12120a356a6a4bbb8b2982d8d81fe1a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/TextDirectionValidationsBuilder.java": {
-    "mtime": 1781170594.9407415,
+    "mtime": 1781769439.829958,
     "ast_hash": "05ffa33312d65e6de2953407817bff52",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/TextLanguageValidationsBuilder.java": {
-    "mtime": 1781170594.9417422,
+    "mtime": 1781769439.829958,
     "ast_hash": "6bac35c22470196c40e45b599e57ae03",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsBuilder.java": {
-    "mtime": 1781170594.9417422,
-    "ast_hash": "6122a4c3e506d036dbfa1a8973278f90",
+    "mtime": 1781769439.830957,
+    "ast_hash": "c113fe199e929201df6ef9ad1811a224",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsExecutor.java": {
-    "mtime": 1781170594.942744,
+    "mtime": 1781769439.830957,
     "ast_hash": "d0aebeac488d3cdb6298a92a666db4f0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java": {
-    "mtime": 1781170594.9437442,
+    "mtime": 1781769439.830957,
     "ast_hash": "b73d2ba363ce432761dcf23b2d6cbbdb",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper2.java": {
-    "mtime": 1781170594.9447453,
-    "ast_hash": "12a52744e1822f9b24b6c8587b82dcaa",
+    "mtime": 1781769439.8319576,
+    "ast_hash": "d80bd3af513306a307ac48426ec3dcc9",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverBrowserValidationsBuilder.java": {
-    "mtime": 1781170594.9457433,
+    "mtime": 1781769439.8319576,
     "ast_hash": "926e44dc415130ad5c02fb9fc50d419b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverElementValidationsBuilder.java": {
-    "mtime": 1781170594.9467404,
+    "mtime": 1781769439.832957,
     "ast_hash": "9a4113b857d3acb55598ff2382a72c11",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/javadoc/resources/configuration-manager/jquery-3.5.0.min.js": {
-    "mtime": 1781170594.9527423,
+    "mtime": 1781769439.8369575,
     "ast_hash": "7c5d886a944957e9ed1cc3c5eba023e9",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/javadoc/resources/configuration-manager/main-built.js": {
-    "mtime": 1781170594.9547436,
+    "mtime": 1781769439.8379574,
     "ast_hash": "bfcc66727306f6a7d6db18d89d9cbd8f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/javadoc/resources/configuration-manager/require.js": {
-    "mtime": 1781170594.955746,
+    "mtime": 1781769439.838959,
     "ast_hash": "81692bed77535de23323aed492f56861",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/appium/.appiumrc.json": {
-    "mtime": 1781170594.962741,
+    "mtime": 1781769439.842959,
     "ast_hash": "ae646a89330e08877d9e043741e04a89",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/healenium-backend/db/sql/init.sql": {
-    "mtime": 1781170594.9657407,
+    "mtime": 1781769439.8439574,
     "ast_hash": "68aef48e69eba5aebc7b90883a9928e3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/postgres/client.js": {
-    "mtime": 1781170594.9667435,
+    "mtime": 1781769439.844957,
     "ast_hash": "a14553a735ee0f513a9da43c3e6f352f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/selenoid/browsers.json": {
-    "mtime": 1781170594.970744,
+    "mtime": 1781769439.8469567,
     "ast_hash": "a911d4a4e1c61fbf88ddf25de262ff9b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/start_emu_headless": {
-    "mtime": 1781170594.9717412,
+    "mtime": 1781769439.847957,
     "ast_hash": "70d231d40fb0677a8762c704a4209744",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/src/test/java/testRunners/CucumberTests.java": {
-    "mtime": 1781170594.9947865,
+    "mtime": 1781769439.8633714,
     "ast_hash": "81a52f665b264bd8f06e25ab4029ccc7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1781170595.0017881,
+    "mtime": 1781769439.8673713,
     "ast_hash": "064e08dd978e03c2928244264e946ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1781170595.0157886,
+    "mtime": 1781769439.8762968,
     "ast_hash": "16a9fe15aa00921a0a57426e530b4418",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1781170595.021788,
+    "mtime": 1781769439.8792973,
     "ast_hash": "c3aa96f48b1065e13bb7402b929d9889",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1781170595.0357938,
+    "mtime": 1781769439.8885207,
     "ast_hash": "6be46fd0c9360daf9cc0fe1e489282f1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1781170595.0688288,
+    "mtime": 1781769439.911529,
     "ast_hash": "064e08dd978e03c2928244264e946ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1781170595.0828378,
+    "mtime": 1781769439.920135,
     "ast_hash": "63b5ca0a71c4d5005c7ae9656b9c6c74",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1781170595.087839,
+    "mtime": 1781769439.9231389,
     "ast_hash": "064e08dd978e03c2928244264e946ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1781170595.1028955,
+    "mtime": 1781769439.9326484,
     "ast_hash": "3cbfad60eb5b0316804c448223639228",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1781170595.107895,
+    "mtime": 1781769439.9356503,
     "ast_hash": "c3aa96f48b1065e13bb7402b929d9889",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1781170595.1228967,
+    "mtime": 1781769439.9446487,
     "ast_hash": "6f82df052ec4e4a835b7c2656798bcab",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1781170595.1539001,
+    "mtime": 1781769439.9666483,
     "ast_hash": "064e08dd978e03c2928244264e946ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1781170595.1699018,
+    "mtime": 1781769439.9757185,
     "ast_hash": "89f691f86e06b6ed04028ac322acb53d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1781170595.176897,
+    "mtime": 1781769439.9796875,
     "ast_hash": "064e08dd978e03c2928244264e946ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/ApiPerformanceReportTest.java": {
-    "mtime": 1781170595.2074218,
+    "mtime": 1781769439.9958854,
     "ast_hash": "6b42836ee0a0d8860582c0c3389a6f1c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/LocalApiTestServer.java": {
-    "mtime": 1781170595.2084186,
+    "mtime": 1781769439.9958854,
     "ast_hash": "4b479fde1c2774b1ef0b88fe9bee0047",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/PathParamTest.java": {
-    "mtime": 1781170595.2084186,
+    "mtime": 1781769439.9968855,
     "ast_hash": "6333c55505dba0c7cae8f443c2cc748c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/RequestBuilderTests.java": {
-    "mtime": 1781170595.2094197,
+    "mtime": 1781769439.9968855,
     "ast_hash": "80b1c6e6eb71694a042d15eae4fd884c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/RestActionsCoverageUnitTest.java": {
-    "mtime": 1781170595.210419,
+    "mtime": 1781769439.9978848,
     "ast_hash": "f3e1ec4057bd58ef177c0e274d2000b1",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/SwaggerContractTest.java": {
-    "mtime": 1781170595.211419,
+    "mtime": 1781769439.9978848,
     "ast_hash": "adc4d25a405c2a64c949da6a0c41e232",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/TestUpload.java": {
-    "mtime": 1781170595.2124212,
+    "mtime": 1781769439.9988854,
     "ast_hash": "3f21181377aeac1c34f46b1a7c1cf298",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/testPostRequest.java": {
-    "mtime": 1781170595.2134209,
+    "mtime": 1781769439.9988854,
     "ast_hash": "9de940d6b7dc8e741eb019b9fccba6cd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/cli/FileActionsCoverageUnitTest.java": {
-    "mtime": 1781716716.055573,
-    "ast_hash": "ed96b1f116125b9cb3fd1f630c98d19f",
+    "mtime": 1781769439.9998858,
+    "ast_hash": "4f39d48cdb9f14fd4ecf68a36fb5298e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/cucumber/ElementStepsCoverageUnitTest.java": {
-    "mtime": 1781170595.21542,
+    "mtime": 1781769439.9998858,
     "ast_hash": "68270ddb7b02986ee98f52b2fa8892a7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelperCoverageUnitTest.java": {
-    "mtime": 1781642509.8200521,
+    "mtime": 1781769440.0008857,
     "ast_hash": "6e2afc4eecfe7c90046b6735e48e6f28",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/OptionsManagerCoverageUnitTest.java": {
-    "mtime": 1781170595.2184174,
+    "mtime": 1781769440.0018852,
     "ast_hash": "916846607ca501c107a5b0eb277c0c6a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/AsyncElementActionsCoverageUnitTest.java": {
-    "mtime": 1781170595.2204213,
+    "mtime": 1781769440.0028853,
     "ast_hash": "82de6e0ba9113ac7f63bba70cd5922bf",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java": {
-    "mtime": 1781642509.8208976,
-    "ast_hash": "9379582def3f5b180522127685ef0e4c",
+    "mtime": 1781769440.0315223,
+    "ast_hash": "9f4d311834c058cb0af3888c87dca6bb",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsExceptionDetailsUnitTest.java": {
-    "mtime": 1781170595.2224195,
+    "mtime": 1781769440.032529,
     "ast_hash": "38a470e4ccf528f247d2adb30ee8a480",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ElementInformationCoverageUnitTest.java": {
-    "mtime": 1781170595.2234163,
+    "mtime": 1781769440.0368717,
     "ast_hash": "2683114ad3f10a14f3925a6bd6835400",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ElementsHelperCoverageUnitTest.java": {
-    "mtime": 1781170595.2244203,
+    "mtime": 1781769440.037877,
     "ast_hash": "ac8998c9a0710d11da7322aa09bc268e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/healing/HealingActionsIntegrationTest.java": {
-    "mtime": 1781592922.475854,
+    "mtime": 1781769440.038876,
     "ast_hash": "eef0b6ec55d75db96f4416c65ec0c65f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/healing/HealingStrategyTest.java": {
-    "mtime": 1781281812.3039246,
-    "ast_hash": "35caf909580463e27bae3ad71a6b8325",
+    "mtime": 1781769440.038876,
+    "ast_hash": "c29f55b4622c05fbf066a1a3f5143b88",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/AnimatedGifManagerCoverageUnitTest.java": {
-    "mtime": 1781735191.0089939,
-    "ast_hash": "ab2dd37cd4f996d0c8f5da57677fa92a",
+    "mtime": 1781769440.0398767,
+    "ast_hash": "882ec4b67282b7c73ecc5e94cd455fec",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotHelperCoverageUnitTest.java": {
-    "mtime": 1781170595.2264178,
+    "mtime": 1781769440.0398767,
     "ast_hash": "b0b5269cd3a52b3a438193dcbf99f73f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotManagerCoverageUnitTest.java": {
-    "mtime": 1781734857.2349873,
+    "mtime": 1781769440.0408783,
     "ast_hash": "6629bcf81e4e497359f4e81a78a6c29d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/VisualProcessingProviderRegistryTest.java": {
-    "mtime": 1781170595.22842,
+    "mtime": 1781769440.0408783,
     "ast_hash": "f65e99d62de78111e607e18fd4d6aceb",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/natural/NaturalActionExecutorTest.java": {
-    "mtime": 1781592922.4768524,
+    "mtime": 1781769440.041876,
     "ast_hash": "0461c28b07e551d6c3341b3f69b594df",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistryTest.java": {
-    "mtime": 1781170595.2294185,
+    "mtime": 1781769440.0425146,
     "ast_hash": "a2fa8e0ef33d17122b51f64ba073e670",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/video/RecordManagerCoverageUnitTest.java": {
-    "mtime": 1781170595.2304194,
+    "mtime": 1781769440.0425146,
     "ast_hash": "b728bfab006ff8f0057b22748932c062",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/video/RecordManagerDesktopProviderTest.java": {
-    "mtime": 1781170595.2314198,
+    "mtime": 1781769440.0435202,
     "ast_hash": "828a4807775841ad0cad7855d946637e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/listeners/AllureListenerCoverageUnitTest.java": {
-    "mtime": 1781170595.2324193,
+    "mtime": 1781769440.0435202,
     "ast_hash": "2241a07317bff8346a1bd1c01137e1a7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/listeners/internal/UpdateCheckerUnitTest.java": {
-    "mtime": 1781642509.8224366,
+    "mtime": 1781769440.044525,
     "ast_hash": "a0c400588dc92dc8f84602e923dc34fd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/performance/internal/LightHouseGenerateReportCoverageUnitTest.java": {
-    "mtime": 1781170595.2354183,
+    "mtime": 1781769440.0454779,
     "ast_hash": "d12ef0c4ab02daa11d78b8fa0b0def3e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/test/unitTests/JavaScriptWaitManagerUnitTest.java": {
-    "mtime": 1781170595.2364192,
+    "mtime": 1781769440.046483,
     "ast_hash": "08bea5190a0202d3ca812e9b77ea809e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/internal/security/GoogleTinkApiCoverageUnitTest.java": {
-    "mtime": 1781170595.2394216,
+    "mtime": 1781769440.0474832,
     "ast_hash": "f0c7bd8edaf562770403f311517f050f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/JSONFileManagerTestAccessor.java": {
-    "mtime": 1781170595.2394216,
+    "mtime": 1781769440.048483,
     "ast_hash": "d9ef7d440aa067f73898384896afa5ee",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureManagerCoverageUnitTest.java": {
-    "mtime": 1781642509.8224366,
+    "mtime": 1781769440.048483,
     "ast_hash": "86fb6e7d70e0b4c1d497e1b0792063bf",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/ProgressBarLoggerCoverageUnitTest.java": {
-    "mtime": 1781170595.241422,
+    "mtime": 1781769440.0494833,
     "ast_hash": "2ce47f5f7489a79eba977c69579456c4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/ProgressBarLoggerTestAccessor.java": {
-    "mtime": 1781170595.2424212,
+    "mtime": 1781769440.0494833,
     "ast_hash": "7a536f9d92a15f04078b0d80f4809018",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/accessibility/AccessibilityHelperCoverageUnitTest.java": {
-    "mtime": 1781170595.2444203,
+    "mtime": 1781769440.050483,
     "ast_hash": "3d7d1b7d2ed082209053a1542a01d595",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsExecutorTestAccessor.java": {
-    "mtime": 1781170595.2464209,
+    "mtime": 1781769440.051483,
     "ast_hash": "da15362a3e7a802bad7f5d94ed318c76",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelper2CoverageUnitTest.java": {
-    "mtime": 1781170595.2474208,
-    "ast_hash": "2891fbc844cccc4eee8b7565e3446cc3",
+    "mtime": 1781769440.051483,
+    "ast_hash": "64e74e9b6d94e76fafff3f72abe18918",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelperCoverageUnitTest.java": {
-    "mtime": 1781170595.2484195,
+    "mtime": 1781769440.0524817,
     "ast_hash": "2026c83ad3dbfd873009ccde7ed0bb8e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelperTestAccessor.java": {
-    "mtime": 1781170595.2494192,
+    "mtime": 1781769440.0524817,
     "ast_hash": "74c28fa6c98f3a045aa0c9040114812d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/internal/WebDriverElementValidationsBuilderCoverageUnitTest.java": {
-    "mtime": 1781170595.2494192,
+    "mtime": 1781769440.0534823,
     "ast_hash": "a770a8d13a85afe73c5056fa4299de21",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/cucumberTestRunner/CucumberTests.java": {
-    "mtime": 1781170595.2504182,
+    "mtime": 1781769440.0534823,
     "ast_hash": "74ef6fcb26ae1bf65684240930dd0f66",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/customCucumberSteps/steps.java": {
-    "mtime": 1781183200.121773,
+    "mtime": 1781769440.0544827,
     "ast_hash": "996c5594b17086d3b5b937776f4309db",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/external/FileActionsReflectionInvoker.java": {
-    "mtime": 1781170595.252422,
+    "mtime": 1781769440.0544827,
     "ast_hash": "8251926ce3c459f65681aaf4925cda59",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitParallelizationTests.java": {
-    "mtime": 1781340262.100456,
+    "mtime": 1781769440.0554824,
     "ast_hash": "bd2043877f31e8598752853eb357c9b6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitTest.java": {
-    "mtime": 1781170595.2554197,
+    "mtime": 1781769440.056483,
     "ast_hash": "80e036596d170587890d7947a2b6ee92",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/MoonTests.java": {
-    "mtime": 1781170595.256419,
+    "mtime": 1781769440.056483,
     "ast_hash": "3d4b38081680b77d4ae52f2a4b2219c6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/objectclass/BodyObject.java": {
-    "mtime": 1781170595.2574203,
+    "mtime": 1781769440.0574827,
     "ast_hash": "03f0c5fc69471404fe1e0e603466f818",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/CopilotGeneratedTests/ActionsCoverageTests.java": {
-    "mtime": 1781170595.2604203,
+    "mtime": 1781769440.058483,
     "ast_hash": "4d7fd64afc511b6c060fc9bdd1808db7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/CopilotGeneratedTests/RestActionsComprehensiveTests.java": {
-    "mtime": 1781170595.262421,
+    "mtime": 1781769440.058483,
     "ast_hash": "28f298cd5240a0f802c52f4fc9a4dab3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/CopilotGeneratedTests/UnitTestsRestActions.java": {
-    "mtime": 1781170595.263418,
+    "mtime": 1781769440.0594826,
     "ast_hash": "f7a90e6eae203244b1f50f592b7fdd49",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/CopilotGeneratedTests/UnitTestsSHAFT.java": {
-    "mtime": 1781170595.264418,
+    "mtime": 1781769440.0594826,
     "ast_hash": "1a0f0ce42dfb5df20043a7c64ef5f0f2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/LambdaTestCredentials.java": {
-    "mtime": 1781714797.7896729,
-    "ast_hash": "dc0c5394d7719aee8ae07b7d01563890",
+    "mtime": 1781769440.0604825,
+    "ast_hash": "95942d341f6c15cb5ef9055b1808bcb1",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTDesktopWebMac.java": {
-    "mtime": 1781642509.8244376,
+    "mtime": 1781769440.0604825,
     "ast_hash": "2f3d1140f11fc9b71b0bedc8ecc3da3b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTDesktopWebWindows.java": {
-    "mtime": 1781642509.8244376,
+    "mtime": 1781769440.0614824,
     "ast_hash": "157fb2b3b04bdfea2fe6185cbebf841c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobAPKAPPURL.java": {
-    "mtime": 1781714914.151108,
-    "ast_hash": "d3d6d72207206a3223a8d722faea597e",
+    "mtime": 1781769440.0614824,
+    "ast_hash": "f35e9468c40360b72f8b61adffa1450d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobAPKRelativePath.java": {
-    "mtime": 1781642509.8254383,
+    "mtime": 1781769440.062799,
     "ast_hash": "5789694ff5cfd58a44c97cb7ad1271e0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobIPAAppURL.java": {
-    "mtime": 1781714914.1521146,
-    "ast_hash": "ab5c4eabc51829ec0ffc68deb3a9f901",
+    "mtime": 1781769440.062799,
+    "ast_hash": "8d8bd350aa5b1c3c3a3cf0cd781450c8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobIPARelativePath.java": {
-    "mtime": 1781642509.827437,
+    "mtime": 1781769440.062799,
     "ast_hash": "1647018c30c20b7960074c5ff3bb51b2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTWebAppIOS.java": {
-    "mtime": 1781642509.827437,
+    "mtime": 1781769440.063804,
     "ast_hash": "01affbeef9bd4974c99ca3991af231d3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTWebAppRealme.java": {
-    "mtime": 1781642509.828437,
+    "mtime": 1781769440.063804,
     "ast_hash": "316149ae0962ad94d9a60dbb6fe8cb9d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/APIWizardTests.java": {
-    "mtime": 1781170595.271419,
+    "mtime": 1781769440.0648036,
     "ast_hash": "a05b2dc7d4b2f36e316aa2666f326443",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/CLIWizardTests.java": {
-    "mtime": 1781170595.2724178,
+    "mtime": 1781769440.0648036,
     "ast_hash": "b9df0988ecaad726adc5fea8c897ab88",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/CustomDriverInitializationTests.java": {
-    "mtime": 1781340262.1054568,
+    "mtime": 1781769440.0659585,
     "ast_hash": "df51bb4d82585394c46c30ae675fbc7a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/DBWizardTests.java": {
-    "mtime": 1781170595.2734182,
+    "mtime": 1781769440.0659585,
     "ast_hash": "f578f87a677a9ace374460f653a7a416",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/FluentGuiActionsTest.java": {
-    "mtime": 1781170595.2744193,
+    "mtime": 1781769440.0659585,
     "ast_hash": "ec867d13fcd03e7f0636806479b75168",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/GUIWizardTests.java": {
-    "mtime": 1781183200.1227746,
+    "mtime": 1781769440.066964,
     "ast_hash": "0b390e4118280e1abc7f529f48555de6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/TestHelpers.java": {
-    "mtime": 1781170595.2754195,
+    "mtime": 1781769440.0675447,
     "ast_hash": "8be2574841bdfc32c03cba0a0e2a8dc2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/WizardStandaloneValidationTests.java": {
-    "mtime": 1781170595.2754195,
+    "mtime": 1781769440.0675447,
     "ast_hash": "35f04e8619760f8ebd8814c4d4303ca9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/WizardTestDataTests.java": {
-    "mtime": 1781170595.2764199,
+    "mtime": 1781769440.0675447,
     "ast_hash": "33ac597fd308b12054d8f42f82799d5e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/TestPageServer.java": {
-    "mtime": 1781642509.828437,
+    "mtime": 1781769440.0675447,
     "ast_hash": "2646363db37f021394df4d2e581aebc6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/TestScenario.java": {
-    "mtime": 1781170595.2764199,
+    "mtime": 1781769440.0689673,
     "ast_hash": "1eb22ef127c1db1ae030d5be3d4f1793",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/Tests.java": {
-    "mtime": 1781170595.277429,
+    "mtime": 1781769440.0689673,
     "ast_hash": "57e8f66047ac7beae82ab5c23cc7bf87",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/AndroidBasicInteractionsTests.java": {
-    "mtime": 1781170595.278428,
+    "mtime": 1781769440.0699747,
     "ast_hash": "dd601a01d9c455ec89b2c7160ba4eec8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/AndroidDragAndDropTest.java": {
-    "mtime": 1781170595.278428,
+    "mtime": 1781769440.0699747,
     "ast_hash": "2ffc8e85a4d6c7b23b6912cb87beb2fd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/AndroidTouchActionsTests.java": {
-    "mtime": 1781170595.2794306,
+    "mtime": 1781769440.0709724,
     "ast_hash": "532f29bf0254c1ff8f525a507a1a430a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/FileUploadDownloadTest.java": {
-    "mtime": 1781170595.280429,
+    "mtime": 1781769440.0709724,
     "ast_hash": "7d6ebdfaaf28e3d2b90d22b4ca16e9e9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/FlutterTest.java": {
-    "mtime": 1781170595.280429,
+    "mtime": 1781769440.0709724,
     "ast_hash": "7366c8b69d03e80b2fb4bd19f1d32037",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/IOSBasicInteractionsTest.java": {
-    "mtime": 1781170595.281427,
+    "mtime": 1781769440.0719733,
     "ast_hash": "c14cf8b63c53b19cf5ecb4c7020eaa24",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/MobileTest.java": {
-    "mtime": 1781170595.281427,
+    "mtime": 1781769440.0719733,
     "ast_hash": "9d3c39b310b254b8e46b0787b9863b45",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/MobileWebTest.java": {
-    "mtime": 1781170595.2824275,
+    "mtime": 1781769440.0729735,
     "ast_hash": "1e71bec893b591efdc6ad81c0861de05",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/AssertApiResponseEqualsTests.java": {
-    "mtime": 1781170595.2844281,
+    "mtime": 1781769440.0739734,
     "ast_hash": "6f6b3fc3c46d22b1be2e15c313ae0d4b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/AssertEqualsTests.java": {
-    "mtime": 1781642509.8297362,
+    "mtime": 1781769440.0749729,
     "ast_hash": "ac28053c858948f6c8072ae22ad3cb68",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/BasicAPITests.java": {
-    "mtime": 1781170595.2854283,
+    "mtime": 1781769440.0749729,
     "ast_hash": "04f6e36cc676509fd50bf69cf0f8214e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/BasicAuthenticationTests.java": {
-    "mtime": 1781170595.2864285,
+    "mtime": 1781769440.0749729,
     "ast_hash": "9496029f86d3f528ab13caabb2d0fe8d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/BigPageActionsTest.java": {
-    "mtime": 1781170595.2864285,
+    "mtime": 1781769440.0759733,
     "ast_hash": "5c59782bc79d4c0e169a4a289b802bf4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/CSVFileManagerTest.java": {
-    "mtime": 1781170595.28743,
+    "mtime": 1781769440.0759733,
     "ast_hash": "5bb3c372688c46b067b1b9863e25072d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/ChainableElementActionsTests.java": {
-    "mtime": 1781170595.2884278,
+    "mtime": 1781769440.0769734,
     "ast_hash": "06ae6b54a7d97bc516cc10cf6b99b1b5",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/ChecksumTests.java": {
-    "mtime": 1781170595.2884278,
+    "mtime": 1781769440.0769734,
     "ast_hash": "5906715678d0f232e561110e1ff7a158",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/CookiesTests.java": {
-    "mtime": 1781170595.2894273,
+    "mtime": 1781769440.0769734,
     "ast_hash": "758c6a8df8d6416f380f1d39aac31c06",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/DragAndDropTests.java": {
-    "mtime": 1781170595.290426,
+    "mtime": 1781769440.0779734,
     "ast_hash": "342e71b079c44b808491154c7bd27ba6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/DynamicLoadingTest.java": {
-    "mtime": 1781170595.2919314,
+    "mtime": 1781769440.0779734,
     "ast_hash": "75821892b9db3a83dbec9eb1e6cd2c2a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/FileActionsTests.java": {
-    "mtime": 1781170595.2919314,
+    "mtime": 1781769440.0779734,
     "ast_hash": "b562813a025a45e3fc69064917478f4d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/FrameTests.java": {
-    "mtime": 1781170595.2929406,
+    "mtime": 1781769440.0789735,
     "ast_hash": "2377b86c25ba830a3a62c8eb3673f54b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/GetTableRowsDataTests.java": {
-    "mtime": 1781170595.2929406,
+    "mtime": 1781769440.0789735,
     "ast_hash": "e70588ff08a9232d318ac38de8c922b7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/GraphqlRequestTests.java": {
-    "mtime": 1781170595.2939382,
+    "mtime": 1781769440.0789735,
     "ast_hash": "9dd849ae0967c7a40ef9cf5ae77220b2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/GroupsTests.java": {
-    "mtime": 1781170595.2939382,
+    "mtime": 1781769440.0799727,
     "ast_hash": "5051d79e29fdd758369f62fbb35d8639",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/ImageComparisonTests.java": {
-    "mtime": 1781170595.2959392,
+    "mtime": 1781769440.0799727,
     "ast_hash": "91035161f0c739e3fbfba8ad926e548e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/IsElementClickableTest.java": {
-    "mtime": 1781170595.2959392,
+    "mtime": 1781769440.0809748,
     "ast_hash": "6ef73b0291f982d6a93dc783fe65a7f7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JSAlertBoxTests.java": {
-    "mtime": 1781170595.2969377,
+    "mtime": 1781769440.0809748,
     "ast_hash": "87a6cc3676d62bfdcd5039c55974c99a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JSConfirmBoxTests.java": {
-    "mtime": 1781170595.2979393,
+    "mtime": 1781769440.0809748,
     "ast_hash": "bb2be41715ecadad8c1c352ec2f3edea",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JSONFileManagerTests.java": {
-    "mtime": 1781170595.2979393,
+    "mtime": 1781769440.081973,
     "ast_hash": "06f43c8542a39433d95f396bddc2511e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JSPromptBoxTests.java": {
-    "mtime": 1781170595.2989385,
+    "mtime": 1781769440.081973,
     "ast_hash": "20322607f3abd3ee7b114d7a076640df",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JsonActionsTests.java": {
-    "mtime": 1781170595.2989385,
+    "mtime": 1781769440.081973,
     "ast_hash": "0eeae0f35f4b5d59ce66f3fdc5a43c92",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JsonCompareWithSpecialCharactersTests.java": {
-    "mtime": 1781170595.2999382,
+    "mtime": 1781769440.082973,
     "ast_hash": "8ec3e11aa822c7834ff5c361a6044a57",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/LazyLoadingTests.java": {
-    "mtime": 1781170595.2999382,
+    "mtime": 1781769440.082973,
     "ast_hash": "8bf92aa2961ce3017f8420ea02106885",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/LocalShellTests.java": {
-    "mtime": 1781170595.3019383,
+    "mtime": 1781769440.0839727,
     "ast_hash": "6782d98e60aa0e1f0bcc9999f29d8a6a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/MatchJsonSchemaTests.java": {
-    "mtime": 1781170595.3019383,
+    "mtime": 1781769440.0839727,
     "ast_hash": "3876965c3c4b42b162b09caedef82ec7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/MobileEmulationTests.java": {
-    "mtime": 1781170595.302939,
+    "mtime": 1781769440.0839727,
     "ast_hash": "35929225261df191611b8eb348dcbeb2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/MultipleDriverSessionTerminationTest.java": {
-    "mtime": 1781340262.1142826,
+    "mtime": 1781769440.084973,
     "ast_hash": "ce36ac541579dfd521fb81d744a08eac",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/NetworkInterceptionTest.java": {
-    "mtime": 1781340262.111686,
+    "mtime": 1781769440.0855272,
     "ast_hash": "ba72ceccb80d6563c7d12b2565510a47",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/NewValidationHelperTests.java": {
-    "mtime": 1781170595.3049388,
+    "mtime": 1781769440.0855272,
     "ast_hash": "4bc79fab96f68b8b12d5116587f24479",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/PDFTests.java": {
-    "mtime": 1781170595.3059382,
+    "mtime": 1781769440.0855272,
     "ast_hash": "9ce4274cf95b705c4c628161689a5716",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/PropertiesManagerTests.java": {
-    "mtime": 1781170595.3059382,
+    "mtime": 1781769440.0865324,
     "ast_hash": "43587b77aed4d5722770a6b08ccf019f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/RelativeLocatorsTests.java": {
-    "mtime": 1781170595.3069403,
+    "mtime": 1781769440.0865324,
     "ast_hash": "1c8054013b7ecb201fc5fe98b22daf10",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/RemoteGridVideoAttachmentIT.java": {
-    "mtime": 1781170595.3069403,
+    "mtime": 1781769440.0865324,
     "ast_hash": "dd14e5e72b21522e5be56680c8b3d026",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/SkipDueToIssueTests.java": {
-    "mtime": 1781170595.3079405,
+    "mtime": 1781769440.087532,
     "ast_hash": "99a55a2822f04fdbbcee5cceb276fca8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/SwitchToNewTabTest.java": {
-    "mtime": 1781170595.3089402,
+    "mtime": 1781769440.087532,
     "ast_hash": "006d6c897a4c1d231284dee7fe67d681",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/TableTests.java": {
-    "mtime": 1781170595.3099396,
+    "mtime": 1781769440.088551,
     "ast_hash": "6d478cc94e1a5ee7eab2ab389899f534",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/TestDataTests.java": {
-    "mtime": 1781170595.3099396,
+    "mtime": 1781769440.088551,
     "ast_hash": "95acd877eac50b8434b69adb83cbb977",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/UploadFileTests.java": {
-    "mtime": 1781642509.8297362,
+    "mtime": 1781769440.088551,
     "ast_hash": "5302d25af26787f48deb393f87c23b4f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/ValidationsBuilderTests.java": {
-    "mtime": 1781170595.3109405,
+    "mtime": 1781769440.089569,
     "ast_hash": "fcf11e47db991e3a42aef3210fa2e360",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/VerifyEqualsTests.java": {
-    "mtime": 1781642509.830816,
+    "mtime": 1781769440.089569,
     "ast_hash": "41d8d2fd6427379eb8fc445849b8424f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/YAMLFileManagerTests.java": {
-    "mtime": 1781170595.3119402,
+    "mtime": 1781769440.0905685,
     "ast_hash": "49a9017718260432d1ecf756ed11d4b7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/locator/LocatorBuilderTest.java": {
-    "mtime": 1781716716.0545666,
-    "ast_hash": "121dca8acff0577bd2d1413db53c8180",
+    "mtime": 1781769440.0905685,
+    "ast_hash": "0414482e4f34d9a26b3b4ced958e648f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/locator/ShadowDomTest.java": {
-    "mtime": 1781170595.3139403,
+    "mtime": 1781769440.0915618,
     "ast_hash": "6ed0c59ac8e49a4a7ef06df16c2963d7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/locator/SmartLocatorsPOC1Tests.java": {
-    "mtime": 1781183200.1257722,
+    "mtime": 1781769440.0915618,
     "ast_hash": "c3c8b2620562686f6b5e565535e18b95",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/locator/SmartLocatorsRealisticTests.java": {
-    "mtime": 1781170595.31494,
+    "mtime": 1781769440.0925558,
     "ast_hash": "93bd7e133ff94de29763db556f85ea62",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/locator/SmartLocatorsTests.java": {
-    "mtime": 1781183200.1257722,
+    "mtime": 1781769440.0925558,
     "ast_hash": "20c2cf801bc6adaf91c3a10eedfd305c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/AccessibilityTest.java": {
-    "mtime": 1781642509.8318162,
+    "mtime": 1781769440.0935552,
     "ast_hash": "c3af17b67e19faca4a2eeeffe30545d5",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/ApiActionsMockedTests.java": {
-    "mtime": 1781170595.3169398,
+    "mtime": 1781769440.0935552,
     "ast_hash": "4f4c44851c27057934f2b7b59bc65ab5",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/CoverageTests.java": {
-    "mtime": 1781718321.5629635,
-    "ast_hash": "3ffbafb8be81eb15009c3cb3af85c3bf",
+    "mtime": 1781769440.0945604,
+    "ast_hash": "83c27fc65ab0c865b1cdf29f5866e8f8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/CucumberMockedTests.java": {
-    "mtime": 1781170595.3179395,
+    "mtime": 1781769440.0950155,
     "ast_hash": "7f8a58e869251917ae68bba51332db11",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/DatabaseActionsMockedTests.java": {
-    "mtime": 1781170595.318938,
+    "mtime": 1781769440.0950155,
     "ast_hash": "e2878a0cc73ffd2347f853ef2147cc72",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/DbTests.java": {
-    "mtime": 1781170595.318938,
+    "mtime": 1781769440.0950155,
     "ast_hash": "269cfe45953923e0843780be937a461b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/E2ECoverageTests.java": {
-    "mtime": 1781642509.8328154,
+    "mtime": 1781769440.0960212,
     "ast_hash": "0c5e26b5052de101e116db9802a775d6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/ElementActionsMockedTests.java": {
-    "mtime": 1781170595.3199394,
+    "mtime": 1781769440.0966802,
     "ast_hash": "3ad7b5b6aef55cd46c2f7154f1ae6cda",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/GuiVerificationTests.java": {
-    "mtime": 1781170595.320939,
+    "mtime": 1781769440.0966802,
     "ast_hash": "3d7a334d786337dbde7750cfe5f3fc4a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/HoverTests.java": {
-    "mtime": 1781170595.3219385,
+    "mtime": 1781769440.0966802,
     "ast_hash": "17caa339bfe3e0b97b6a5ffc19bf8b19",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/IOActionsMockedTests.java": {
-    "mtime": 1781170595.3219385,
+    "mtime": 1781769440.0976856,
     "ast_hash": "c56ab69e6038fda5a988bd60c9cfeb22",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/JDK21VirtualThreadsAndAsyncActionsTests.java": {
-    "mtime": 1781170595.3229394,
+    "mtime": 1781769440.0976856,
     "ast_hash": "51f1a029b91897744035cd850b1161a7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/LocatorMockedTests.java": {
-    "mtime": 1781170595.3229394,
+    "mtime": 1781769440.0976856,
     "ast_hash": "dad58a7c56a1467263bfae0f1da9480a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/MultipleBrowserInstancesTest.java": {
-    "mtime": 1781170595.3239381,
+    "mtime": 1781769440.0986853,
     "ast_hash": "809818085b5e32dff077dfb0c656856b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/MultipleElementsFailureTest.java": {
-    "mtime": 1781170595.3249383,
+    "mtime": 1781769440.0986853,
     "ast_hash": "241d67949c16293b2350791d139a82fe",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/MultipleTypeCyclesTest.java": {
-    "mtime": 1781170595.3249383,
+    "mtime": 1781769440.0996852,
     "ast_hash": "b2f43aacacb87d9e96673fe6ec092b31",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/NoSuchElementFailureTest.java": {
-    "mtime": 1781170595.3259375,
+    "mtime": 1781769440.0996852,
     "ast_hash": "03a45eec716f23e232911a3211ee431c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/PageScreenshotTest.java": {
-    "mtime": 1781170595.3259375,
+    "mtime": 1781769440.0996852,
     "ast_hash": "d49c21a61e72ec5469d72f13735e0de6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/SecurityMockedTests.java": {
-    "mtime": 1781170595.326939,
+    "mtime": 1781769440.1006856,
     "ast_hash": "2f5b6a0594b5c0984dbcda5ac7d487c6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/SelectMethodTests.java": {
-    "mtime": 1781170595.326939,
+    "mtime": 1781769440.1006856,
     "ast_hash": "ac0d848f85a4727aee2f0bc8a56bb843",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/SelectedValueTests.java": {
-    "mtime": 1781170595.3279386,
+    "mtime": 1781769440.1016848,
     "ast_hash": "81b968ea8374b0200a005df4f678937a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/ThreadSafeGuiWizardTests.java": {
-    "mtime": 1781170595.3289435,
+    "mtime": 1781769440.1016848,
     "ast_hash": "93278d8c91e0003270e1f37b3f9dbbe0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/TouchActionsTests.java": {
-    "mtime": 1781170595.3289435,
+    "mtime": 1781769440.1016848,
     "ast_hash": "bfec9ae0a72008d85b23f59529b0e9ea",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/ValidationTests.java": {
-    "mtime": 1781642509.833815,
+    "mtime": 1781769440.1026855,
     "ast_hash": "3e7a2b9bbe034d279a5541ae6eab91ea",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/ValidationsMockedTests.java": {
-    "mtime": 1781170595.3299432,
+    "mtime": 1781769440.1026855,
     "ast_hash": "06dceebbaa6cc58e0183baae80e4fb56",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/WaitActionsTest.java": {
-    "mtime": 1781170595.3309386,
+    "mtime": 1781769440.1026855,
     "ast_hash": "a1b4352725f281f3d61dc14699074e4e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/BrowserStackSdkTests.java": {
-    "mtime": 1781170595.3319383,
+    "mtime": 1781769440.1036854,
     "ast_hash": "d9ebd5580bb807c7604e0c74e38f151c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/BrowserStackTests.java": {
-    "mtime": 1781170595.3319383,
+    "mtime": 1781769440.1046858,
     "ast_hash": "7c56e754cf9df72d867793b89e4ce87d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/CucumberTests.java": {
-    "mtime": 1781170595.3329415,
+    "mtime": 1781769440.1046858,
     "ast_hash": "cc49d5bf128f50b8c9b49ee1d3d06b3a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/FlagsTests.java": {
-    "mtime": 1781170595.3329415,
+    "mtime": 1781769440.1046858,
     "ast_hash": "fcc937601e081f5aaed227e0c9be4c09",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/HealeniumTests.java": {
-    "mtime": 1781170595.3339374,
+    "mtime": 1781769440.1056857,
     "ast_hash": "4cbd96dfaa7ecd87d56e8fed846b5e12",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/HealingTests.java": {
-    "mtime": 1781592922.4778535,
+    "mtime": 1781769440.1056857,
     "ast_hash": "36a68b5420d9ac0898076eeafbe3017a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/InternalTests.java": {
-    "mtime": 1781170595.3339374,
+    "mtime": 1781769440.1066856,
     "ast_hash": "c0f069cd9f0d1229bd799d2bbcdd84f1",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/JiraTests.java": {
-    "mtime": 1781170595.3339374,
+    "mtime": 1781769440.1066856,
     "ast_hash": "eeba6ddfce3de33fbe989cc575a9cd90",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/Log4jTests.java": {
-    "mtime": 1781642509.8348174,
+    "mtime": 1781769440.1066856,
     "ast_hash": "ae4540190f998df8d9fb4b0d1a2612fe",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/MobileTests.java": {
-    "mtime": 1781546468.0806026,
-    "ast_hash": "15ccbe4a3ad45ee78745dc33125aacdd",
+    "mtime": 1781769440.1076858,
+    "ast_hash": "6739645c3929d9dceb4adb19a57133b8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/NaturalActionsTests.java": {
-    "mtime": 1781592922.4778535,
+    "mtime": 1781769440.1076858,
     "ast_hash": "2f7204140a4fd39be6c6e336527e4180",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/PathsTests.java": {
-    "mtime": 1781170595.3359387,
+    "mtime": 1781769440.1076858,
     "ast_hash": "9b6e4b923c8fafeb5766479e8ce4e9f7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/PatternTests.java": {
-    "mtime": 1781170595.3359387,
+    "mtime": 1781769440.1086853,
     "ast_hash": "27d780ad9cfb7a965f6b92d28d68de4c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/PerformanceTests.java": {
-    "mtime": 1781170595.3369403,
+    "mtime": 1781769440.1086853,
     "ast_hash": "9309eda06566e65a9f362f67f226dc91",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/PlatformTests.java": {
-    "mtime": 1781170595.3369403,
+    "mtime": 1781769440.1086853,
     "ast_hash": "3258b9a3348d0509056b88b650bf03b5",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/ReportingTests.java": {
-    "mtime": 1781170595.3379407,
+    "mtime": 1781769440.1096852,
     "ast_hash": "77a2d7fa3551e92f26589ee0ca156311",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/TestNGTests.java": {
-    "mtime": 1781170595.3379407,
+    "mtime": 1781769440.1096852,
     "ast_hash": "99bf53de75d7fd1c0db036713c836a50",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/TimeoutsTests.java": {
-    "mtime": 1781170595.3389387,
+    "mtime": 1781769440.1106894,
     "ast_hash": "3a710928604bade367dff3017abd8cd3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/TinkeyTests.java": {
-    "mtime": 1781170595.3389387,
+    "mtime": 1781769440.1106894,
     "ast_hash": "0970c28be5888cba1859beefc65378b3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/VisualsTests.java": {
-    "mtime": 1781170595.3399377,
+    "mtime": 1781769440.1106894,
     "ast_hash": "a0f83862f610862bb8efaf196f707d08",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/WebTests.java": {
-    "mtime": 1781170595.3399377,
+    "mtime": 1781769440.1116917,
     "ast_hash": "9dc7531cd01c41eb8cfab262c6e521fd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/resettingCapabilitiesIssue/ElementMatchesSafariCompatibleTests.java": {
-    "mtime": 1781170595.3409379,
+    "mtime": 1781769440.1126895,
     "ast_hash": "394bbc20f5e93c06cc34ec7c01ff3236",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/resettingCapabilitiesIssue/ShadowDOMTests.java": {
-    "mtime": 1781170595.341938,
+    "mtime": 1781769440.1126895,
     "ast_hash": "43a6596b52c49876b40b6058899198c6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/resettingCapabilitiesIssue/UploadFileTests.java": {
-    "mtime": 1781642509.8348174,
+    "mtime": 1781769440.1126895,
     "ast_hash": "cae1bde8163d22ef380fd6284cd6b0e0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/APIPropertiesUnitTest.java": {
-    "mtime": 1781170595.342938,
+    "mtime": 1781769440.1136901,
     "ast_hash": "2a0cd709eac461a2eca3c1c6202a6d5f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/APITests.java": {
-    "mtime": 1781170595.342938,
+    "mtime": 1781769440.1136901,
     "ast_hash": "2dc9f47b451a8e6b2044fbeabf5fd378",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AccessibilityActionsCoverageUnitTest.java": {
-    "mtime": 1781170595.343937,
+    "mtime": 1781769440.1146903,
     "ast_hash": "90607ccef1dfc5153c1637b8ae62b2bb",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AlertActionsCoverageUnitTest.java": {
-    "mtime": 1781170595.343937,
+    "mtime": 1781769440.1146903,
     "ast_hash": "a5bb393a1cfc1a2e8aa75ae92aff7d81",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AllAttachmentTypesTest.java": {
-    "mtime": 1781340262.1044562,
+    "mtime": 1781769440.1156902,
     "ast_hash": "b1879b9f3fe274f3e93255ad721a717d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/Allure3ReportValidationTests.java": {
-    "mtime": 1781170595.3459392,
+    "mtime": 1781769440.1156902,
     "ast_hash": "da1af4c4422a31104c480df5d2b8651d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AllureManagerUnitTest.java": {
-    "mtime": 1781687980.931302,
+    "mtime": 1781769440.1166916,
     "ast_hash": "d54e040470ae4a6f033f4e57d9e0f06b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AndroidApkBadgingReaderUnitTest.java": {
-    "mtime": 1781170595.3469386,
+    "mtime": 1781769440.1166916,
     "ast_hash": "5bc57b743241b49f0e5257363802a038",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java": {
-    "mtime": 1781170595.347938,
+    "mtime": 1781769440.1176898,
     "ast_hash": "b3f3a0fe35cbb10bb29f822208e50edf",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AssertionStepsCucumberTestsCoverageUnitTest.java": {
-    "mtime": 1781170595.347938,
+    "mtime": 1781769440.1176898,
     "ast_hash": "bd8b8e3e83c0652fbfd4c66dfa54f838",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AttachmentReporterUnitTest.java": {
-    "mtime": 1781642509.836815,
+    "mtime": 1781769440.1186893,
     "ast_hash": "b7b45fa6a8315a75a05ad02459283c16",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsCoverageUnitTest.java": {
-    "mtime": 1781170595.3489387,
+    "mtime": 1781769440.1186893,
     "ast_hash": "cf7b15f970b691655bbb6622b38c1082",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsHelperCoverageUnitTest.java": {
-    "mtime": 1781642509.8375885,
+    "mtime": 1781769440.1186893,
     "ast_hash": "fc971e4b30a7b04491a0d5ef70ff11bc",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsTests.java": {
-    "mtime": 1781183200.1289527,
+    "mtime": 1781769440.1196895,
     "ast_hash": "19b4b4142da458f5e227f0f05c93935f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserStackHelperUnitTest.java": {
-    "mtime": 1781716716.055573,
-    "ast_hash": "4a753e5692ad7bfe803745096d7e4de1",
+    "mtime": 1781769440.1196895,
+    "ast_hash": "002d6838869b0b5afde3a0277f9c4308",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserStackPropertiesUnitTest.java": {
-    "mtime": 1781170595.3509371,
+    "mtime": 1781769440.12069,
     "ast_hash": "dfcbf24cab8e1c327962222c3978b95d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserStackSdkHelperCoverageUnitTest.java": {
-    "mtime": 1781719693.456374,
-    "ast_hash": "1870d80c7e671f04056b947d6aa923b6",
+    "mtime": 1781769440.12069,
+    "ast_hash": "a12447674e5f8ad7c872293f7e5d7906",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CSVFileManagerUnitTest.java": {
-    "mtime": 1781170595.3519409,
+    "mtime": 1781769440.1216898,
     "ast_hash": "e05e9aa7e90379ffff4172edb00a2d6e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CheckpointAndReportingTest.java": {
-    "mtime": 1781724033.9938784,
-    "ast_hash": "2a1b32ecaf5ba27179e8b71ca1d0b173",
+    "mtime": 1781769440.1223512,
+    "ast_hash": "2dc3dbf43634acbc88d895aa348823b7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ClipboardActionUnitTest.java": {
-    "mtime": 1781170595.3529408,
+    "mtime": 1781769440.1223512,
     "ast_hash": "049ed3057c478bf631b973241fdb7e42",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CucumberFeatureListenerUnitTest.java": {
-    "mtime": 1781170595.35394,
+    "mtime": 1781769440.1223512,
     "ast_hash": "40b3bb11667dcc54e4c8eff1e5a9b52b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CucumberTestRunnerListenerUnitTest.java": {
-    "mtime": 1781170595.35394,
+    "mtime": 1781769440.1223512,
     "ast_hash": "af73dc5a35bc20fb91b9540c939aa848",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CucumberTestsHelperCoverageUnitTest.java": {
-    "mtime": 1781170595.3549385,
+    "mtime": 1781769440.1236942,
     "ast_hash": "f5787b288386b7c7d678c839cae81b73",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CustomSoftAssertTest.java": {
-    "mtime": 1781170595.3559387,
+    "mtime": 1781769440.1236942,
     "ast_hash": "79519b2595cb2fef40442f1a10bfd750",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/DriverFactoryCoverageUnitTest.java": {
-    "mtime": 1781170595.3569381,
+    "mtime": 1781769440.1247032,
     "ast_hash": "4947b5e7a73724c6e6fed6d2e64ba6a6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/DriverFactoryHelperAdditionalUnitTest.java": {
-    "mtime": 1781170595.3569381,
+    "mtime": 1781769440.1247032,
     "ast_hash": "ea73d0c88cfce2990fde0325c0c17816",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/DriverFactoryHelperUnitTest.java": {
-    "mtime": 1781170595.357938,
+    "mtime": 1781769440.1258454,
     "ast_hash": "af8f8bcfe3da87db1c2e3407a707ded2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ElementActionsCoverageUnitTest.java": {
-    "mtime": 1781170595.357938,
+    "mtime": 1781769440.1263494,
     "ast_hash": "09bca3254ca231ed2030a7404e2eba95",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ExcelFileManagerCoverageUnitTest.java": {
-    "mtime": 1781170595.3589394,
+    "mtime": 1781769440.1263494,
     "ast_hash": "749454f40c0f999c34073902eb552194",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/FailureReporterUnitTest.java": {
-    "mtime": 1781170595.3599381,
+    "mtime": 1781769440.1263494,
     "ast_hash": "75e0fd7c57c165bef078cdc8ce06fe65",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/FileActionsUnitTest.java": {
-    "mtime": 1781170595.3599381,
+    "mtime": 1781769440.1273556,
     "ast_hash": "8935974e649fa582946d673121cfa696",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/FileHelperUnitTest.java": {
-    "mtime": 1781170595.360939,
+    "mtime": 1781769440.1273556,
     "ast_hash": "ea6d731e57c3aac02a733f7d2a34d941",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/FileValidationsBuilderUnitTest.java": {
-    "mtime": 1781170595.36194,
+    "mtime": 1781769440.1273556,
     "ast_hash": "9d9acc2120910e1276906a2bde8a1e5c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/FlagsSetPropertyCoverageUnitTest.java": {
-    "mtime": 1781170595.36194,
+    "mtime": 1781769440.1283548,
     "ast_hash": "da97292715ec3224bdb79568449c0fc9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/HTMLHelperUnitTest.java": {
-    "mtime": 1781170595.362939,
+    "mtime": 1781769440.129141,
     "ast_hash": "25126e1307dafd29f15749a1bdd60c78",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/IoExcelFileManagerTests.java": {
-    "mtime": 1781170595.3639388,
+    "mtime": 1781769440.129141,
     "ast_hash": "530438883080a086ea007d8375c7a0fa",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/JSONFileManagerUnitTest.java": {
-    "mtime": 1781170595.3639388,
+    "mtime": 1781769440.129141,
     "ast_hash": "df106c976e18caf15348e77c4f5aeb33",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/JavaHelperUnitTest.java": {
-    "mtime": 1781170595.3649387,
+    "mtime": 1781769440.1301465,
     "ast_hash": "c09490944c2173777d187a7ae1ae7898",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/JunitListenerApiCoverageUnitTest.java": {
-    "mtime": 1781687980.9323018,
+    "mtime": 1781769440.1301465,
     "ast_hash": "2cd5bab6620dd77a5d7ad18b3b6c74f6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LambdaTestHelperUnitTest.java": {
-    "mtime": 1781716716.0565753,
-    "ast_hash": "ccf69339692e900d682859b8f58381f2",
+    "mtime": 1781769440.1311462,
+    "ast_hash": "3f11e51672c24653a84fe4fa69f7e797",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LambdaTestSetPropertyCoverageUnitTest.java": {
-    "mtime": 1781170595.3669393,
+    "mtime": 1781769440.1311462,
     "ast_hash": "47e318c7169fd292cc422fdfbb950ff7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LocalApiServer.java": {
-    "mtime": 1781170595.3669393,
+    "mtime": 1781769440.1321466,
     "ast_hash": "e5eaa7660c8c9eff4eccb6cc03bd4721",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LocatorBuilderExtendedUnitTest.java": {
-    "mtime": 1781170595.3679385,
+    "mtime": 1781769440.1321466,
     "ast_hash": "3ffca37941148c7f54ec285739904a5c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LocatorBuilderUnitTest.java": {
-    "mtime": 1781170595.3689373,
+    "mtime": 1781769440.1331468,
     "ast_hash": "70bc98553a43a07567efa654eec320d7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LogRedirectorUnitTest.java": {
-    "mtime": 1781642509.8380358,
+    "mtime": 1781769440.1331468,
     "ast_hash": "25be02ab0943217c6d54155e0c912775",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/MemoryLeakFixTests.java": {
-    "mtime": 1781642509.8380358,
+    "mtime": 1781769440.1331468,
     "ast_hash": "9371b0c88769d68a72bf5c38b4039579",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/NativeValidationsBuilderUnitTest.java": {
-    "mtime": 1781170595.3709376,
+    "mtime": 1781769440.134146,
     "ast_hash": "5eedc36971944b95c5b59dde171347a8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/NavigationActionUnitTest.java": {
-    "mtime": 1781170595.3719385,
+    "mtime": 1781769440.134146,
     "ast_hash": "29ce81485193c40a2ddd60f48f50a622",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/NumberValidationsBuilderUnitTest.java": {
-    "mtime": 1781170595.372941,
+    "mtime": 1781769440.1351466,
     "ast_hash": "c1e5acce43534ba13e1186db85b2c084",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PdfFileManagerUnitTest.java": {
-    "mtime": 1781722416.8372214,
-    "ast_hash": "d4fd88cf6f4a988fecc8d169a429f66a",
+    "mtime": 1781769440.1351466,
+    "ast_hash": "03fffd928746a3fec64c66b559d65b72",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ProjectStructureManagerTest.java": {
-    "mtime": 1781170595.3739405,
+    "mtime": 1781769440.1362844,
     "ast_hash": "cc69031ce2de1686663111c08fa79ea2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertiesHelperCoverageUnitTest.java": {
-    "mtime": 1781642509.8391364,
+    "mtime": 1781769440.1362844,
     "ast_hash": "81ae315c34773c68a536c305b8d42394",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertiesHelperInitializationUnitTest.java": {
-    "mtime": 1781340262.140553,
+    "mtime": 1781769440.1362844,
     "ast_hash": "87009944ae8d143cc5c2422caa5bcd3e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertiesHelperMaximumPerformanceModeUnitTest.java": {
-    "mtime": 1781170595.3759396,
-    "ast_hash": "5661da2130612dd49dc0c83732f5b25e",
+    "mtime": 1781769734.850586,
+    "ast_hash": "1b099d1a92080eb0c26712148bfd4860",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertiesUnitTest.java": {
-    "mtime": 1781642509.8391364,
+    "mtime": 1781769440.1372895,
     "ast_hash": "de5933ec9be13bdfe26c24f28e8a6bd2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertyFileManagerUnitTest.java": {
-    "mtime": 1781724042.904169,
-    "ast_hash": "78f807f8c7d8c16642d4099ba5f57aa2",
+    "mtime": 1781769440.1382892,
+    "ast_hash": "1f6b9ea7df5756b354ea8081215c0f65",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RecordManagerTest.java": {
-    "mtime": 1781170595.379946,
+    "mtime": 1781769440.1382892,
     "ast_hash": "ce611a40d23f72ae66af39cf6a64d561",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ReportManagerHelperAttachmentIoUnitTest.java": {
-    "mtime": 1781340262.1415539,
+    "mtime": 1781769440.1382892,
     "ast_hash": "64662838b757d33cbddfad6e92b39b5f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ReportManagerHelperUnitTests.java": {
-    "mtime": 1781724042.9031703,
-    "ast_hash": "a45cba4c248794ec3e529c0ce71af948",
+    "mtime": 1781769440.1392891,
+    "ast_hash": "398246ec1c6f2392c6f5d655c7e887e9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RestActionsFailureLoggingUnitTest.java": {
-    "mtime": 1781170595.3819458,
+    "mtime": 1781769440.1402893,
     "ast_hash": "94747c6ac6534584011a570704cb7b89",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RestActionsTests.java": {
-    "mtime": 1781170595.3819458,
+    "mtime": 1781769440.1402893,
     "ast_hash": "4a57b2261d8a6f4306b6a189df5c6b93",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RestActionsUtilsUnitTest.java": {
-    "mtime": 1781170595.3829482,
+    "mtime": 1781769440.1402893,
     "ast_hash": "de45f58c799fde431cef74d0e8653c15",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RestValidationsBuilderUnitTest.java": {
-    "mtime": 1781170595.383947,
+    "mtime": 1781769440.1412888,
     "ast_hash": "1c0603f27b12bb4895a9aea5b5e1efa8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ShaftRestAssuredFilterUnitTest.java": {
-    "mtime": 1781170595.383947,
+    "mtime": 1781769440.1412888,
     "ast_hash": "c887597b4f7f620238b76b8614750c27",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/SkippedTestReportingTest.java": {
-    "mtime": 1781170595.3849475,
+    "mtime": 1781769440.142289,
     "ast_hash": "ce8578c3bec220a0e71049bee7331d9a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/SmartLocatorsCoverageUnitTest.java": {
-    "mtime": 1781170595.385946,
+    "mtime": 1781769440.142289,
     "ast_hash": "beb21c33b9ba95b2fb2d42033aef2235",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/StringHelperUnitTest.java": {
-    "mtime": 1781170595.385946,
+    "mtime": 1781769440.143289,
     "ast_hash": "666317424773b8170baaa4f3e65e5630",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TelemetryDeduplicationUnitTest.java": {
-    "mtime": 1781170595.3869493,
+    "mtime": 1781769440.143289,
     "ast_hash": "f63a7c2ce548fa3456264cc95af3a62f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java": {
-    "mtime": 1781679984.9611106,
-    "ast_hash": "d64dd41906c36709648c6be99e331982",
+    "mtime": 1781770043.4198172,
+    "ast_hash": "154d78acd07f01c2e3859fb38ae3d63b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TestClass.java": {
-    "mtime": 1781170595.3889482,
+    "mtime": 1781769440.1442895,
     "ast_hash": "75d5dabdf74b6a0a0ac46395a44852f1",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TestDataUnitTest.java": {
-    "mtime": 1781170595.3889482,
+    "mtime": 1781769440.1442895,
     "ast_hash": "db41e63ea98f715a677d882ac1d4174c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TestNGListenerCoverageUnitTest.java": {
-    "mtime": 1781170595.389948,
+    "mtime": 1781769440.145289,
     "ast_hash": "3d882e129d97dd1f057717be6bf4ee5d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TestNGListenerHelperCoverageUnitTest.java": {
-    "mtime": 1781170595.390947,
+    "mtime": 1781769440.145289,
     "ast_hash": "b3a8afe01d2424e4a0c578302f1c7381",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TextDirectionValidationsBuilderUnitTest.java": {
-    "mtime": 1781170595.390947,
+    "mtime": 1781769440.145289,
     "ast_hash": "60a881ad378ec7cfdfcfa5c81462d2c8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ThreadLocalPropertiesTest.java": {
-    "mtime": 1781642509.8421361,
+    "mtime": 1781769440.1462893,
     "ast_hash": "d3049362792b8831e75e3f53cba81770",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TopUncoveredClassesCoverageUnitTest.java": {
-    "mtime": 1781170595.393031,
+    "mtime": 1781769440.1462893,
     "ast_hash": "00f21d46e9c9345cfb0602c30e74896a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ValidationAndProgressBarTests.java": {
-    "mtime": 1781170595.393031,
+    "mtime": 1781769440.1472888,
     "ast_hash": "8771d0f554d0732fcde4a2c87be3d97b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ValidationEnumsUnitTest.java": {
-    "mtime": 1781170595.3940306,
+    "mtime": 1781769440.1472888,
     "ast_hash": "caccd040fd417216fa761e864fcf4179",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ValidationHelperUnitTest.java": {
-    "mtime": 1781170595.3940306,
+    "mtime": 1781769440.1482885,
     "ast_hash": "5877871d3318bd2685cb6c67d7fa0836",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ValidationsBuilderUnitTest.java": {
-    "mtime": 1781170595.3950307,
+    "mtime": 1781769440.1482885,
     "ast_hash": "cfe79a40a49a8ecba70f2bca1418d697",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ValidationsExecutorCoverageUnitTest.java": {
-    "mtime": 1781170595.3960311,
+    "mtime": 1781769440.1482885,
     "ast_hash": "b4e87dd6decede2ec6a874bf552646b0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/WebDriverListenerCoverageUnitTest.java": {
-    "mtime": 1781170595.3960311,
+    "mtime": 1781769440.1492891,
     "ast_hash": "f768f1fbc6ea4a4afdf1d7f10f537c9e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/XrayIntegrationHelperCoverageUnitTest.java": {
-    "mtime": 1781170595.39703,
+    "mtime": 1781769440.1492891,
     "ast_hash": "1a3f82e3bba50c09c7b5f46d0e17c64b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/YAMLFileManagerUnitTest.java": {
-    "mtime": 1781170595.39703,
+    "mtime": 1781769440.1502895,
     "ast_hash": "657dabafe357030b543ad8b2cc7d37b4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/validationsWizard/BrowserValidationsTests.java": {
-    "mtime": 1781642509.843136,
+    "mtime": 1781769440.1502895,
     "ast_hash": "fae6d2b4edd4c21b783a63e0acfd94bc",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/validationsWizard/ElementValidationsTests.java": {
-    "mtime": 1781170595.398034,
+    "mtime": 1781769440.151288,
     "ast_hash": "74ef4dc7c24e14da3c0a2e956ecaf8d4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/validationsWizard/NegativeValidationsTests.java": {
-    "mtime": 1781340262.1034555,
+    "mtime": 1781769440.151288,
     "ast_hash": "40934347a289ccfcd252c0951162f97d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/validationsWizard/VisualValidationTests.java": {
-    "mtime": 1781340262.101456,
+    "mtime": 1781769440.151288,
     "ast_hash": "3abc625b6272a3bd347ee7bb29d8d3fe",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/JsonFileTest.json": {
-    "mtime": 1781170595.4060302,
+    "mtime": 1781769440.1556714,
     "ast_hash": "34d4c2e8470475605eeb576357fa1a24",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/JsonFileTest2.json": {
-    "mtime": 1781170595.4070303,
+    "mtime": 1781769440.1556714,
     "ast_hash": "0d4aba4457124b501a49b132fc29e7c8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/api/local-api/post-1.json": {
-    "mtime": 1781170595.4090319,
+    "mtime": 1781769440.1577137,
     "ast_hash": "e7f6064672a51be242e522606fe7a874",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/api/local-api/posts.json": {
-    "mtime": 1781170595.4090319,
+    "mtime": 1781769440.1577137,
     "ast_hash": "9b635707c3b1a2033d585b69a6bab819",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/api/local-api/todos.json": {
-    "mtime": 1781170595.4100304,
+    "mtime": 1781769440.1577137,
     "ast_hash": "095e11feade03bc6b7e53dee2486f681",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/api/local-api/users.json": {
-    "mtime": 1781170595.4100304,
+    "mtime": 1781769440.158719,
     "ast_hash": "8b738dc1a52055df6ff5444eb37a1b8f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/api/local-api/zip-90210.json": {
-    "mtime": 1781170595.4110296,
+    "mtime": 1781769440.159228,
     "ast_hash": "6ca2311ae54ce67c7fbd17f118b58cad",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/jsonFileManagerTestData.json": {
-    "mtime": 1781170595.975187,
+    "mtime": 1781769440.5979025,
     "ast_hash": "94537dc7a44a551939fe07da874a6ce9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/jsonToJavaObjectTest.json": {
-    "mtime": 1781170595.97619,
+    "mtime": 1781769440.5979025,
     "ast_hash": "fe787bfecd55bde95846520922954e20",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/post1Response.json": {
-    "mtime": 1781170595.97619,
+    "mtime": 1781769440.5989025,
     "ast_hash": "e7f6064672a51be242e522606fe7a874",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/post1ResponseSchema.json": {
-    "mtime": 1781170595.9771886,
+    "mtime": 1781769440.5989025,
     "ast_hash": "16bf47afb2fa16d9a72bee4aa5090fef",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/restActionsCoverage/containsObject.json": {
-    "mtime": 1781170595.9781976,
+    "mtime": 1781769440.5999026,
     "ast_hash": "caf79d4a9031acee3921b15dcfacd235",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/restActionsCoverage/expectedObject.json": {
-    "mtime": 1781170595.9781976,
+    "mtime": 1781769440.5999026,
     "ast_hash": "fbf3b3e03cf5d05123488de14e150acd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/restActionsCoverage/mismatchObject.json": {
-    "mtime": 1781170595.9791956,
+    "mtime": 1781769440.6009026,
     "ast_hash": "5a250de786cc5579da66cbcdee8f2818",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/restActionsCoverage/orderedArray.json": {
-    "mtime": 1781170595.980197,
+    "mtime": 1781769440.6009026,
     "ast_hash": "0e406c996279efff769b1105dd51448e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/schema.json": {
-    "mtime": 1781170595.9811947,
+    "mtime": 1781769440.6019025,
     "ast_hash": "99a7063f24f77c3fb2c7aea31eec411c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1781170595.9841945,
+    "mtime": 1781769440.6039045,
     "ast_hash": "d896f3512bf493280abf8061c7df1d75",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/specialCharacters.json": {
-    "mtime": 1781170595.9851973,
+    "mtime": 1781769440.6039045,
     "ast_hash": "334064f08b91de55ef30335710dbd8f8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/test_assertResponseEqualsIgnoringOrder.json": {
-    "mtime": 1781170595.9911964,
+    "mtime": 1781769440.6091602,
     "ast_hash": "a679a33772d98b89e77510ad9938a84d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/test_post_withBody_fromFile.json": {
-    "mtime": 1781170595.9921982,
+    "mtime": 1781769440.6091602,
     "ast_hash": "af539d78603bb042feb8be65c20748e8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/unitTestData.json": {
-    "mtime": 1781260105.1371999,
-    "ast_hash": "b161ad90f834d1d27d65808b8908dbd4",
+    "mtime": 1781769440.6091602,
+    "ast_hash": "0e90c1c1a227d7d7c2d2dce740714d82",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/HealingConfiguration.java": {
-    "mtime": 1781592922.4798534,
+    "mtime": 1781769440.613984,
     "ast_hash": "7d540f1d283537631b724e7e903ce765",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/ShaftHeal.java": {
-    "mtime": 1781281643.8746552,
-    "ast_hash": "c103c84c1b074c22b229ddaeb6f9e1e9",
+    "mtime": 1781769440.613984,
+    "ast_hash": "638f827ad267fed1841301e034516d29",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/AiCandidateReranker.java": {
-    "mtime": 1781592922.4808538,
+    "mtime": 1781769440.613984,
     "ast_hash": "be1ab920d6859520e9b7cfde75897288",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/CandidateExtractor.java": {
-    "mtime": 1781592922.4808538,
+    "mtime": 1781769440.615165,
     "ast_hash": "1b8b44bdcf6e32e31917a1e7e43e9735",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/DeterministicScorer.java": {
-    "mtime": 1781592922.4818532,
+    "mtime": 1781769440.615165,
     "ast_hash": "4bf42ea11e26e7869a261270733d628d",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/FingerprintExtractor.java": {
-    "mtime": 1781592922.482854,
+    "mtime": 1781769440.616171,
     "ast_hash": "7f104b32afa9d009c7714e55f453c167",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HealingDecisionEngine.java": {
-    "mtime": 1781592922.482854,
+    "mtime": 1781769440.616171,
     "ast_hash": "4209aed55089ab983f839222d8cf64db",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HealingHistoryStore.java": {
-    "mtime": 1781592922.483853,
+    "mtime": 1781769440.6170366,
     "ast_hash": "75b6488324dfad90e662f9f08c9d7fb4",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HealingReportWriter.java": {
-    "mtime": 1781281643.8736522,
-    "ast_hash": "b60d2e61965203fe591a18d9748eb28a",
+    "mtime": 1781769440.6170366,
+    "ast_hash": "a6807824d69a21cbfde367786dda6459",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HealingSupport.java": {
-    "mtime": 1781592922.483853,
+    "mtime": 1781769440.6170366,
     "ast_hash": "6a5e58df19b9bf605b8d0e529e3b5a9f",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HistoryDocument.java": {
-    "mtime": 1781592922.4848537,
+    "mtime": 1781769440.618042,
     "ast_hash": "e02bfa5e0416eaa97327d7cc30edaaaa",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HistoryRecord.java": {
-    "mtime": 1781592922.485854,
+    "mtime": 1781769440.618042,
     "ast_hash": "affb5533f80ddcf6955cb487de88c5bc",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/PrivacySanitizer.java": {
-    "mtime": 1781281422.7676194,
-    "ast_hash": "1a2c3ef1a661f2b9a562a8de7b397937",
+    "mtime": 1781769440.618042,
+    "ast_hash": "c615c6f4a1781c7a5a2056074b581bb2",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/RankedCandidate.java": {
-    "mtime": 1781281502.085405,
-    "ast_hash": "937c0430a46470f4f99ff1877a5596e0",
+    "mtime": 1781769440.6190417,
+    "ast_hash": "323b41fab8a95e2adce58147b8a7d197",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/ShaftHealingProvider.java": {
-    "mtime": 1781592922.485854,
+    "mtime": 1781769440.6190417,
     "ast_hash": "331a83061fc768e329ef278d3476ca4f",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/VisualEvidenceService.java": {
-    "mtime": 1781281566.6411583,
-    "ast_hash": "130ab5510ab517b457693ad897e70d13",
+    "mtime": 1781769440.6200411,
+    "ast_hash": "743e64057ed3e7ab3111d0ecb9e093c8",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingCandidate.java": {
-    "mtime": 1781281326.6660504,
-    "ast_hash": "6a2fb4057d9b45c64eb4fc63451fb724",
+    "mtime": 1781769440.6200411,
+    "ast_hash": "1617a29056414a87a0f01eea9f3f1e5d",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingContext.java": {
-    "mtime": 1781592922.486855,
+    "mtime": 1781769440.6210425,
     "ast_hash": "3c02c33790e64b5a77b7c6218a0162cf",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingDecision.java": {
-    "mtime": 1781281326.6670487,
-    "ast_hash": "8df72c735e4974d2d5d2c7f9d8ed940e",
+    "mtime": 1781769440.6210425,
+    "ast_hash": "e3cff7de69ac3081e54b05070a9ad923",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingPlatform.java": {
-    "mtime": 1781592922.486855,
+    "mtime": 1781769440.6210425,
     "ast_hash": "d4cc50f5563d27a3d8cadabad3f8c086",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingReport.java": {
-    "mtime": 1781592922.4878528,
+    "mtime": 1781769440.622042,
     "ast_hash": "3d0627a4f1785e21e5403b3685773ca5",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingScore.java": {
-    "mtime": 1781281326.6660504,
-    "ast_hash": "1cec7590eccf09a986e9967521eb32d0",
+    "mtime": 1781769440.622042,
+    "ast_hash": "99e432927182919d5815b3d8d101b6de",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/LocatorFingerprint.java": {
-    "mtime": 1781592922.4878528,
+    "mtime": 1781769440.6230419,
     "ast_hash": "b7f303ee7028dce02f372fe1887fdf27",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/resources/schema/shaft-heal-history-1.0.schema.json": {
-    "mtime": 1781281726.6047819,
-    "ast_hash": "b7907dc6070e857dfabe43f4469d44ec",
+    "mtime": 1781769440.6240425,
+    "ast_hash": "6bd4d6c6c18d1bc0c600792f43232342",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/resources/schema/shaft-heal-history-2.0.schema.json": {
-    "mtime": 1781592922.4888513,
+    "mtime": 1781769440.6250422,
     "ast_hash": "6d71c99cadca42d412c11b50c7131430",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/resources/schema/shaft-heal-report-1.0.schema.json": {
-    "mtime": 1781281726.6037817,
-    "ast_hash": "36b3c7004131c07e5556720ac02f8776",
+    "mtime": 1781769440.6250422,
+    "ast_hash": "f8f5c202b1e0baca184836e2dd42118b",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/resources/schema/shaft-heal-report-2.0.schema.json": {
-    "mtime": 1781592922.4888513,
+    "mtime": 1781769440.6260414,
     "ast_hash": "88e2d8a2767744c1b32faa700466d741",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/AiCandidateRerankerTest.java": {
-    "mtime": 1781592922.4898531,
+    "mtime": 1781769440.6275513,
     "ast_hash": "034bb4a07e1e4c4d8c1ed5d8a31547a2",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/DeterministicScorerTest.java": {
-    "mtime": 1781592922.4898531,
+    "mtime": 1781769440.6275513,
     "ast_hash": "5d36a445e2cae9634e483d80dda345a7",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/HealingHistoryStoreTest.java": {
-    "mtime": 1781592922.4908528,
+    "mtime": 1781769440.6285512,
     "ast_hash": "055d679be0c31247da14c2d2e8305954",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/ShaftHealingProviderTest.java": {
-    "mtime": 1781592922.4918518,
+    "mtime": 1781769440.6285512,
     "ast_hash": "81672bcff803ab1ad507c4c818379381",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/WebDomHealingAcceptanceTest.java": {
-    "mtime": 1781592922.4918518,
+    "mtime": 1781769440.6295505,
     "ast_hash": "54705c408e9415e6e59248f9dc88e76a",
     "semantic_hash": ""
   },
-  "shaft-mcp/allure-report/summary.json": {
-    "mtime": 1781608515.7003586,
-    "ast_hash": "30bd463462f922ad03e2467ce80c4718",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/10ad9586-c871-43a5-9723-a7a8c01669df-container.json": {
-    "mtime": 1781608512.9219787,
-    "ast_hash": "5a571cf8ae9e40a504f67ca933583494",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/1daf4c52-4ef1-43e4-aec3-bf1b781314bb-result.json": {
-    "mtime": 1781608512.9249785,
-    "ast_hash": "769e38fc693b3969a0a16d80fef346a8",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/5c9e959e-fc0a-46e6-bbd1-389a06abbc2a-container.json": {
-    "mtime": 1781608512.9259777,
-    "ast_hash": "3a10adff306912f2e8177c6d2ae286fa",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/60130dc3-04c1-4f84-bfc7-ca7ded42b9ee-container.json": {
-    "mtime": 1781608512.9269848,
-    "ast_hash": "67294bbfdd9079afeba51de488a9f6dd",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/60f13a1f-65cf-4568-bced-a6ae42857f68-container.json": {
-    "mtime": 1781608512.9279826,
-    "ast_hash": "5639281b8e864b425b76263b506a3b4c",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/644f7d26-ab6a-4ad0-be7d-cc7c6f35b02a-result.json": {
-    "mtime": 1781608512.9289775,
-    "ast_hash": "f4e76059b9da54ea924bdfe6cd80623a",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/65deb014-f35b-4253-a9b1-8b95fe798e8a-container.json": {
-    "mtime": 1781608512.9301777,
-    "ast_hash": "cff2481871aa48b06230c9dd2cf124d7",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/778c0ddb-c213-42ac-b90d-8639f8dcf759-container.json": {
-    "mtime": 1781608512.9311717,
-    "ast_hash": "92cda93f40ff87a89c7da07ee5d5008f",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/77ce7073-0dca-4ebb-ac5b-27f6a36a5e96-container.json": {
-    "mtime": 1781608512.9321718,
-    "ast_hash": "4b871784e5b52a44e92e1cd7b80ad2c7",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/8fda8949-e0ee-4fec-802c-dc067341d597-container.json": {
-    "mtime": 1781608512.9331775,
-    "ast_hash": "d843ca6fe5a1bee0daf8f3ac98a62dd3",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/975b6635-8eb2-4a47-88d6-179e4b3f7a2e-result.json": {
-    "mtime": 1781608512.9351714,
-    "ast_hash": "3ef31ca04a6cab2ac39be7bf5e5c4386",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/ba76536b-1696-404e-a5f6-156b7bf14464-result.json": {
-    "mtime": 1781608512.936172,
-    "ast_hash": "c3ad194938ac8cf3f332dd411f29e9e4",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/d3a4ac4f-77fa-43f8-a576-be3543137d2a-result.json": {
-    "mtime": 1781608512.9381723,
-    "ast_hash": "8d22581129943f39e2a8dc723dbc539b",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/de0e9a1a-1262-4c7c-8da7-d2b77de05702-result.json": {
-    "mtime": 1781608512.939172,
-    "ast_hash": "42260fdf27f29332a958460501d77cb9",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/f7f60de8-19c6-41e4-bb58-40ba756db0bd-container.json": {
-    "mtime": 1781608512.9401731,
-    "ast_hash": "8789f460bd2e1b6eb254f92307101cd2",
-    "semantic_hash": ""
-  },
   "shaft-mcp/mvnw": {
-    "mtime": 1781170606.0105639,
+    "mtime": 1781769440.63455,
     "ast_hash": "2fe09837c0b4dfabab4c4b206bcd0850",
     "semantic_hash": ""
   },
   "shaft-mcp/server.json": {
-    "mtime": 1781428152.3297255,
-    "ast_hash": "a61ea4e5c0dca4287429c19492a518c7",
+    "mtime": 1781769440.635551,
+    "ast_hash": "10eafe30f8d30db0f7f5e85b2793e18a",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/BrowserService.java": {
-    "mtime": 1781545294.446959,
-    "ast_hash": "6bb30446a48f56cecd40e993bf2be444",
+    "mtime": 1781769440.6369417,
+    "ast_hash": "93ea09b76d0b4ba803bdf106300b0117",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/BrowserType.java": {
-    "mtime": 1781428208.2655416,
-    "ast_hash": "3063c391de5e72d9aed7f390d98abc11",
+    "mtime": 1781769440.6369417,
+    "ast_hash": "d92c802c46cf7055edd908c22dd983c6",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java": {
-    "mtime": 1781543699.49248,
-    "ast_hash": "6a882ef67dfb376e34a9821475148646",
+    "mtime": 1781769440.637947,
+    "ast_hash": "38279f9216799edc6aceb9a9f1f896d7",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/DoctorService.java": {
-    "mtime": 1781592922.493852,
+    "mtime": 1781769440.637947,
     "ast_hash": "b7f51a7b6e4f50c3bf1f8e50b979b80f",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/ElementService.java": {
-    "mtime": 1781543817.4055016,
-    "ast_hash": "23d4c0d01e69d715eef9c0d14e6126b9",
+    "mtime": 1781769440.6389475,
+    "ast_hash": "da28d51f9b36bd20f20ccd30b4b7badf",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/EngineService.java": {
-    "mtime": 1781642509.8464093,
+    "mtime": 1781769440.6389475,
     "ast_hash": "ab42ce9b45d592f0866870650d27a76b",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpActionRecord.java": {
-    "mtime": 1781543437.230421,
-    "ast_hash": "dc1dd7078f1c7cd256cd186113d3b578",
+    "mtime": 1781769440.639949,
+    "ast_hash": "88f2540004bf2e85e19d1883fa8fd268",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpAnalysisReport.java": {
-    "mtime": 1781543437.230421,
-    "ast_hash": "8db4857fd466007adc9d29b1daa0eb61",
+    "mtime": 1781769440.639949,
+    "ast_hash": "655dc48d9861063302c3874e08fad7bb",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCaptureCodeBlockService.java": {
-    "mtime": 1781543652.6753378,
-    "ast_hash": "31b7daf8a1dc9ae631073660d1e0658d",
+    "mtime": 1781769440.639949,
+    "ast_hash": "5f0fc4cd439b508b2e8d13503d8ed353",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCaptureReplayResult.java": {
-    "mtime": 1781543437.2314246,
-    "ast_hash": "d304161b9515688362dfc5555bf7657d",
+    "mtime": 1781769440.6409473,
+    "ast_hash": "1f81e1e38ef2297955cf5ec2fb2ab5e5",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCodeBlock.java": {
-    "mtime": 1781546139.5036907,
-    "ast_hash": "1255053dcc91180a4981928b297b91ca",
+    "mtime": 1781769440.6409473,
+    "ast_hash": "76ebce9f3db111251b04cf7f5d6a7548",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpDoctorRemediationService.java": {
-    "mtime": 1781547386.5940936,
-    "ast_hash": "4f3e569fb2ca7b332bed7e8f21a2e12e",
+    "mtime": 1781769440.6419468,
+    "ast_hash": "b2237a0a5a7f5bf520bea7dfc3dfc34e",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileAccessibilityTree.java": {
-    "mtime": 1781546635.27418,
-    "ast_hash": "c8e7d71d29e8a9d7c5dca39f72b2c502",
+    "mtime": 1781769440.6419468,
+    "ast_hash": "f3b7b5c23ef3cb6ff05525b718994ff3",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileActionResult.java": {
-    "mtime": 1781546139.5046837,
-    "ast_hash": "54e8a5ef50a8337a24b5a902e8cf38b1",
+    "mtime": 1781769440.6419468,
+    "ast_hash": "29d070e4029d6709b7924ba36735510a",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileContextSnapshot.java": {
-    "mtime": 1781546139.5046837,
-    "ast_hash": "7f829cdadaa47a6452c71ea277116bf0",
+    "mtime": 1781769440.6429467,
+    "ast_hash": "2f654d69dc90ef0def1b8902d14e3bba",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecordedAction.java": {
-    "mtime": 1781546139.5056846,
-    "ast_hash": "0f2cf5ec68237085e3ffd12a18cff796",
+    "mtime": 1781769440.6429467,
+    "ast_hash": "ecfc0758677616c607ba07313a52b729",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecording.java": {
-    "mtime": 1781546139.5056846,
-    "ast_hash": "202795611b8ff6205044079917465320",
+    "mtime": 1781769440.6429467,
+    "ast_hash": "695772cf2e07fcb64d1f38ce531219ba",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecordingService.java": {
-    "mtime": 1781546315.8051121,
-    "ast_hash": "a5392ec480283bf07fe215e170ef5f9e",
+    "mtime": 1781769440.6439474,
+    "ast_hash": "7c71e683a554b3ffae40dc3a30e1d6ba",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecordingStatus.java": {
-    "mtime": 1781546139.5056846,
-    "ast_hash": "7612264671f97e228bef2d30168c8d4c",
+    "mtime": 1781769440.6445272,
+    "ast_hash": "aa275295374a1818f6c109d6ea81b57d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileReplayResult.java": {
-    "mtime": 1781546139.5066829,
-    "ast_hash": "0b7ac923421636a0428881317fc45dd4",
+    "mtime": 1781769440.6445272,
+    "ast_hash": "7865349c5c645027ec9b2ad4140187c1",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileSessionResult.java": {
-    "mtime": 1781546139.5036907,
-    "ast_hash": "ea45d51503e2bf0598750af434e8bf15",
+    "mtime": 1781769440.6445272,
+    "ast_hash": "a7ffeb82413410670bdf8fe1f9c90b53",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpNaturalActionResult.java": {
-    "mtime": 1781592922.493852,
+    "mtime": 1781769440.6455326,
     "ast_hash": "8d9587e9bd285ff5d3066b2afea60733",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpPageDomSnapshot.java": {
-    "mtime": 1781545265.2223327,
-    "ast_hash": "81df7c5455d10e2459b64de89d5f1aae",
+    "mtime": 1781769440.6455326,
+    "ast_hash": "da511c88341bda167180baeac16db366",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpProviderFallback.java": {
-    "mtime": 1781543437.230421,
-    "ast_hash": "630e495bc2a5f861bb3abcbbb31537fd",
+    "mtime": 1781769440.6455326,
+    "ast_hash": "f19ecd97597af4b6374659222d736a68",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpRuntimePaths.java": {
-    "mtime": 1781642509.8464093,
+    "mtime": 1781769440.6465328,
     "ast_hash": "f00355cb2227d6466430c85c224efc30",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpScreenshotResult.java": {
-    "mtime": 1781545265.2223327,
-    "ast_hash": "0fdf3761f3d26db4bdb30de6df8b561e",
+    "mtime": 1781769440.6465328,
+    "ast_hash": "1ed7179791590810783cc71682129cde",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpWorkspacePolicy.java": {
-    "mtime": 1781642509.8475084,
+    "mtime": 1781769440.6465328,
     "ast_hash": "2ea9e2dad8bdfc40515c48cc4f7e644d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/MobileService.java": {
-    "mtime": 1781546635.275178,
-    "ast_hash": "798ad939332863672bfb7ac0d2a4954e",
+    "mtime": 1781769440.6475322,
+    "ast_hash": "564ffbff638cad5e6e1db8b3b7a73cab",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/NaturalActionService.java": {
-    "mtime": 1781592922.494854,
+    "mtime": 1781769440.6475322,
     "ast_hash": "f727c820fb4def0a03ba5eeb1894ca0b",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/ShaftMcpApplication.java": {
-    "mtime": 1781642509.8475084,
+    "mtime": 1781769440.6485324,
     "ast_hash": "12ba4cef4726e7b20fa74a98151b3f0c",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/locatorStrategy.java": {
-    "mtime": 1781546139.5016825,
-    "ast_hash": "9ee085fea07b70359edb54585e0299d6",
+    "mtime": 1781769440.6485324,
+    "ast_hash": "93d35de3c8d385e5eb24574d006934dd",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java": {
-    "mtime": 1781544044.2500532,
-    "ast_hash": "90c9204c0c1afef4588dd2e102f4a189",
+    "mtime": 1781769440.6515317,
+    "ast_hash": "fc1ceb63646044a2288ab0cd7a02d081",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/DoctorServiceTest.java": {
-    "mtime": 1781592922.495854,
+    "mtime": 1781769440.6515317,
     "ast_hash": "bd0ad2f5958c4f0c50599812e270e674",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/EngineServiceRuntimePathTest.java": {
-    "mtime": 1781642509.8485076,
+    "mtime": 1781769440.6525319,
     "ast_hash": "154366ecaabe7f3f564a9350af1e1548",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/EngineServiceTest.java": {
-    "mtime": 1781428208.2769651,
-    "ast_hash": "7a5353e1ed210f95abd5607ea947d076",
+    "mtime": 1781769440.6525319,
+    "ast_hash": "f89abc72a0235fd7a49ee831a0bd3236",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpRuntimePathsTest.java": {
-    "mtime": 1781642509.8485076,
+    "mtime": 1781769440.6535327,
     "ast_hash": "9f50bfbcce915a272d146e4aa509b581",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/MobileRecordingServiceTest.java": {
-    "mtime": 1781546452.4415379,
-    "ast_hash": "9feb9cb47ac2a098067877dcc5ee8cb0",
+    "mtime": 1781769440.6535327,
+    "ast_hash": "4ca682157c293f5e2a2d5ba5d62382ec",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java": {
-    "mtime": 1781592922.496852,
+    "mtime": 1781769440.6535327,
     "ast_hash": "a5588a9b78f3c01a2b0cb09146bbda3c",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/mcp-tool-manifest.json": {
-    "mtime": 1781592922.4978545,
+    "mtime": 1781769440.6575418,
     "ast_hash": "f9b85ed79f3d87dd2f041b11f535afae",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/shaft-pilot/doctor/repair-input.json": {
-    "mtime": 1781258554.4804,
-    "ast_hash": "f8043d2e5e758262372510f206ec629f",
+    "mtime": 1781769440.657987,
+    "ast_hash": "457a81a9ab8bbcd47b4c46fefb9c6ad6",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/claude-desktop.json": {
-    "mtime": 1781691891.4320023,
-    "ast_hash": "788fd4f5d47270de64430ec9cc2fa48a",
+    "mtime": 1781769440.657987,
+    "ast_hash": "544157f8499e7c19c3b6495d7a2de685",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/doctor-analyze-invocations.json": {
-    "mtime": 1781592922.4978545,
+    "mtime": 1781769440.6589923,
     "ast_hash": "b02f7110c14eea4b8a149b5649cb8c1d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/gemini-settings.json": {
-    "mtime": 1781691891.4310033,
-    "ast_hash": "788fd4f5d47270de64430ec9cc2fa48a",
+    "mtime": 1781769440.6589923,
+    "ast_hash": "544157f8499e7c19c3b6495d7a2de685",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/vscode-mcp.json": {
-    "mtime": 1781691891.4300022,
-    "ast_hash": "d30b2cc5c150fb1f8b3ea66df1d68b19",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/0097e684-eef3-40a2-b86a-27e412958f13-container.json": {
-    "mtime": 1781261217.2330937,
-    "ast_hash": "4e6bdf5c3814d7d145014bdc9c675254",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/00e642dc-ff30-4eea-a8a7-d1b7c0938536-container.json": {
-    "mtime": 1781261215.6990986,
-    "ast_hash": "4d4983b32c81ea98b02798683ecb4bcc",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/017a6378-792b-46e6-991e-2ed9349f1602-result.json": {
-    "mtime": 1781261215.2791176,
-    "ast_hash": "5d169349be52b5aac45a0ac3b42bc792",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/0cd3ff8d-e428-41c2-97fc-c3e604f234d7-container.json": {
-    "mtime": 1781285612.0670319,
-    "ast_hash": "1a95b0fcab51391f77069298d2cb79c9",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/0ec42c98-c084-47a6-9cc4-b6700620533b-result.json": {
-    "mtime": 1781261215.1748412,
-    "ast_hash": "490c6f5a7fdc1ade34cdf86c28c4e82c",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/13b773b4-04ad-4a6f-bb9e-7a1a0de6501f-result.json": {
-    "mtime": 1781261215.3258946,
-    "ast_hash": "4c8c19d6b5aaea0cba38405b0ecf5872",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/1464c20b-1131-46ea-8a71-18ff3d6bad3b-container.json": {
-    "mtime": 1781261215.283932,
-    "ast_hash": "0bfeafa84b33419e89fdc97aa5f0af21",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/25761326-c585-4598-b011-b42f100c499a-result.json": {
-    "mtime": 1781261215.1602745,
-    "ast_hash": "fffe264616292e77a5d6f5e70f8f221c",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/2f936883-a63f-4667-a22f-c7317235e46e-container.json": {
-    "mtime": 1781261216.7816508,
-    "ast_hash": "9a7a6188141bb648459aa595afed167c",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/3993c2c7-79bf-42a3-a6fa-c27f35558b96-container.json": {
-    "mtime": 1781261215.6849566,
-    "ast_hash": "c3cee9b2f45b6abe7a3e12187fe1bf25",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/39b2370e-3fd2-4965-b1d9-647cedb994b4-container.json": {
-    "mtime": 1781285612.0290277,
-    "ast_hash": "550059e9bd787ec95a06476887850bdd",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/3ac64c65-dbfb-408a-8a17-5fac56f7109b-result.json": {
-    "mtime": 1781285612.0905423,
-    "ast_hash": "68fdf11f8504d343083290cba34107a6",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/3ace1ed0-be76-4556-9ba3-9948d4f6f132-container.json": {
-    "mtime": 1781285612.0855434,
-    "ast_hash": "d5d52c824bd8f20a0c6e9df3f1743659",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/42a87573-0386-4698-a773-4f92bd66a130-container.json": {
-    "mtime": 1781261216.1192312,
-    "ast_hash": "c956d807a72328637c4fa7beb00a79e7",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/4de63e5f-916a-4588-b581-6b04679c8d92-result.json": {
-    "mtime": 1781261214.9257133,
-    "ast_hash": "f9e4bae73cc5e22aebf981d55bf197a3",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/4e8f43ce-9994-4878-a298-fcb53521a1ed-result.json": {
-    "mtime": 1781285612.0855434,
-    "ast_hash": "d5ee3a0fb3c9518292dc57ab028a82ab",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/56772b04-9703-4ef7-8367-86c6fa54901e-result.json": {
-    "mtime": 1781261216.7735763,
-    "ast_hash": "31ef4673c6135edb55bd4a781b61caa0",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/59915996-8f13-4de6-a913-65a6e56a8997-container.json": {
-    "mtime": 1781261216.723169,
-    "ast_hash": "64a0b30f529a8d51b18c3c946641a465",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/5dd39f8b-bf39-4da5-aeb8-b67b96c005a7-result.json": {
-    "mtime": 1781261216.1148863,
-    "ast_hash": "0ae9bd4ef8ddf9c8a995f8d993cc9339",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/61ddd0df-9fef-45b0-844c-11dd5f5ea51f-container.json": {
-    "mtime": 1781261215.1985016,
-    "ast_hash": "1d8c66537d673f49713097a8497e2a6a",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/65fe3cd1-0131-44a4-b2f0-fb14ec44a87f-container.json": {
-    "mtime": 1781285612.1045432,
-    "ast_hash": "3348ad2283cc588a3ee1e9ee886f7fb4",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/73c5f490-44b1-4fc9-9641-888724049295-container.json": {
-    "mtime": 1781261215.2433052,
-    "ast_hash": "37e06e4f972d60c9a2bc8259c77d459d",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/78d72086-ffde-492f-a222-5249cd80a647-container.json": {
-    "mtime": 1781285612.074033,
-    "ast_hash": "c8c003fd541142ecc32af3f797ba390f",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/79ab8cc0-44a7-4d55-87d1-bd39f9483484-container.json": {
-    "mtime": 1781261216.7319224,
-    "ast_hash": "e6b38759228b6d3319d87fac6ec5d4b3",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/7b091c84-9fb2-48b8-953b-5f677b3b25c6-result.json": {
-    "mtime": 1781261216.7150257,
-    "ast_hash": "a037ceb8c2be0dd4d9eb65f7deda905d",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/9105f6cb-5402-4921-8c47-0b41f0147f5f-result.json": {
-    "mtime": 1781261215.2382941,
-    "ast_hash": "b2adb7b286dbd5da86cac49d6ebdc243",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/92fbdd4a-ed9a-4396-9465-bb068f1429a8-container.json": {
-    "mtime": 1781261215.370334,
-    "ast_hash": "ee98f73da5938d069c56b9c2e150c83a",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/97997138-d58c-49e0-aa62-5d97dd33850b-result.json": {
-    "mtime": 1781285612.0660317,
-    "ast_hash": "89525348bfea46232e383ba5b46d2642",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/9892e03c-63dd-45eb-96fd-d75b98785d50-container.json": {
-    "mtime": 1781261217.2532,
-    "ast_hash": "532ffa8895d48e19003c3c2e21585f08",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/9afb2c9c-2cdc-40fb-bd52-96bdc95fb7c4-result.json": {
-    "mtime": 1781261217.2257154,
-    "ast_hash": "a48fe653501df6b78664a7e4c794fc7e",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/b0797f2e-3a00-4460-957e-8f1a2774754d-result.json": {
-    "mtime": 1781261215.6834476,
-    "ast_hash": "b98dc66ab68ba41d5e761c395910019b",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/b74846e4-999a-437b-9156-204c3e0e88cd-result.json": {
-    "mtime": 1781285612.0590293,
-    "ast_hash": "e0ea0d83442ecd37320bab02a15ee11c",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/ba78e47d-8ef5-4719-b5f7-3994dc3bc744-result.json": {
-    "mtime": 1781261215.3647635,
-    "ast_hash": "4ed8eefb8c931648a3157260be2623f5",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/c27ff294-a6d2-4a03-b513-e50770c09272-result.json": {
-    "mtime": 1781285612.073032,
-    "ast_hash": "82766e77cb0e66df6babea59cb6e8455",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/cef49ac9-a532-4105-8b71-5415dee9a158-container.json": {
-    "mtime": 1781285612.0600274,
-    "ast_hash": "e195e598a605efafa9315806599a8460",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/d35ff8a1-9134-4b2a-bc64-3e9f9f9fcbfa-container.json": {
-    "mtime": 1781261214.9615893,
-    "ast_hash": "3567c564e6a96dfd0a8c9d6e3c8beb16",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/d535b85e-3628-4ee4-8f87-887e99ffb5da-result.json": {
-    "mtime": 1781261215.1948712,
-    "ast_hash": "44586a2536883744a4a482260d05671a",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/dbb4f896-5c62-47cd-a911-cd7845e7ed6a-container.json": {
-    "mtime": 1781285612.080543,
-    "ast_hash": "7ca8c8a247b3e2dccb2c87ae0fa8fcb2",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/df349d3e-0bd5-4935-9565-10b35adef779-result.json": {
-    "mtime": 1781285612.0795453,
-    "ast_hash": "a8bed05da8a1282445f0cb8c2d02eb01",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/e114fa2e-4b5c-413c-95f6-c3a98cb0b16b-container.json": {
-    "mtime": 1781285612.0975418,
-    "ast_hash": "da9d1174abdc478b5fb3a9d9d8502864",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/e3167ad0-2b45-4842-9b26-10426facbde7-result.json": {
-    "mtime": 1781285612.0975418,
-    "ast_hash": "c3eb6ca411ccf1646e7a997ee49f8c2b",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/e775cc03-c54a-4087-b179-f03a9ffbdd9c-result.json": {
-    "mtime": 1781261215.6965744,
-    "ast_hash": "76944edd48675f90f18be494113438cf",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/ed881c94-7407-4390-8f3b-fa78e7bd3c30-container.json": {
-    "mtime": 1781261215.1773648,
-    "ast_hash": "3e08ba27c0ddde74915497ee224974ef",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/f5fbe994-1bf8-4c9a-8916-b0296a7655c5-container.json": {
-    "mtime": 1781261215.3289957,
-    "ast_hash": "2aad3213c5012c6e7fe46b99430c246c",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/f759dfeb-c67f-459d-802b-fa0006281b04-container.json": {
-    "mtime": 1781261215.1622837,
-    "ast_hash": "c6728d8b99348b95e5fefa21085a5961",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/fb7e4fda-64f0-40e1-8116-fcb78596c725-container.json": {
-    "mtime": 1781261215.4039004,
-    "ast_hash": "6966910b14a1cb7441f3d740e09f4d42",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/fc9d6f1b-5a46-44be-aa6f-ccd0391f7000-container.json": {
-    "mtime": 1781285612.0915425,
-    "ast_hash": "6b06fe2acd4bf045b6c9016e8f229a4c",
-    "semantic_hash": ""
-  },
-  "shaft-pilot-core/allure-results/fe309b7a-c2bf-4d8e-ba71-070bb40dad89-result.json": {
-    "mtime": 1781285612.0230303,
-    "ast_hash": "914f41cf610e562778dc73e3ccec74dc",
+    "mtime": 1781769440.6599917,
+    "ast_hash": "069569075ea6158826d8a47b9204fa8b",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiBudget.java": {
-    "mtime": 1781183200.1482356,
+    "mtime": 1781769440.664992,
     "ast_hash": "0f62ae7eb77e7a79164518be64846a07",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiCapabilities.java": {
-    "mtime": 1781183200.1487708,
+    "mtime": 1781769440.664992,
     "ast_hash": "4b0644dd013cb6d45500cd6aa33e2be9",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiExecutionService.java": {
-    "mtime": 1781183200.1492987,
+    "mtime": 1781769440.6659925,
     "ast_hash": "7816da663f1fa8218855158a0ccc5ad6",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiImage.java": {
-    "mtime": 1781183200.1498275,
+    "mtime": 1781769440.6659925,
     "ast_hash": "25716916a48e61fbe6d9d4d1dc1fccaa",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiProvider.java": {
-    "mtime": 1781183200.1503544,
+    "mtime": 1781769440.6659925,
     "ast_hash": "825a0e7f2a2271f176163b67c1155d19",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiProviderAvailability.java": {
-    "mtime": 1781183200.1514192,
+    "mtime": 1781769440.6669922,
     "ast_hash": "f1cd040ecae8e52ad080c5619221e040",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiProviderRegistry.java": {
-    "mtime": 1781183200.151934,
+    "mtime": 1781769440.6669922,
     "ast_hash": "8fdfa42ca06106864f4ec7adb034b70d",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiRequest.java": {
-    "mtime": 1781183200.1524658,
+    "mtime": 1781769440.6679919,
     "ast_hash": "72fcc9f3c38e1ed3d98d57815f995adb",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiResponse.java": {
-    "mtime": 1781183200.1529815,
+    "mtime": 1781769440.6679919,
     "ast_hash": "d62787524d101da0a83d24df33272971",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiResponseStatus.java": {
-    "mtime": 1781183200.1535137,
+    "mtime": 1781769440.6679919,
     "ast_hash": "18ec9401e739a84a451c8125c11152c5",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiUsage.java": {
-    "mtime": 1781183200.1545799,
+    "mtime": 1781769440.6689918,
     "ast_hash": "97a43fdb6c0b590d6c7be89d9fc2d35e",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/ApprovalPolicy.java": {
-    "mtime": 1781592922.499852,
+    "mtime": 1781769440.6689918,
     "ast_hash": "f08f93f0d55ddbbad18efee9cced917b",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/DisabledAiProvider.java": {
-    "mtime": 1781183200.1551106,
+    "mtime": 1781769440.6689918,
     "ast_hash": "522658fda00a6fa05e2132bfc58d9c1d",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/EvidenceCategory.java": {
-    "mtime": 1781183200.1558466,
+    "mtime": 1781769440.669992,
     "ast_hash": "737d4c99daddaa581171170ad47006c7",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/EvidenceReference.java": {
-    "mtime": 1781183200.1569252,
+    "mtime": 1781769440.669992,
     "ast_hash": "cd5fae7467f25e060c2a531eeb44f789",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/ProcessingLocation.java": {
-    "mtime": 1781592922.499852,
+    "mtime": 1781769440.669992,
     "ast_hash": "7106587b9fd1d5573d0c2ba6355e6efa",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/audit/AiAuditEvent.java": {
-    "mtime": 1781183200.1579995,
+    "mtime": 1781769440.670992,
     "ast_hash": "bd2ad33294235bf573acfac7e93da4b3",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/audit/AiAuditSink.java": {
-    "mtime": 1781183200.1585357,
+    "mtime": 1781769440.670992,
     "ast_hash": "460112c404cbd8eb47074b1ce2f714fa",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/audit/ShaftAiAuditSink.java": {
-    "mtime": 1781183200.1590683,
+    "mtime": 1781769440.6719918,
     "ast_hash": "cbab846c3ab872246cbe1e0a861a062e",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/config/PilotConfiguration.java": {
-    "mtime": 1781592922.5008528,
+    "mtime": 1781769440.6719918,
     "ast_hash": "43594a66237b108d080c946819eb7a57",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/config/ProviderConfiguration.java": {
-    "mtime": 1781592922.5018523,
+    "mtime": 1781769440.6729918,
     "ast_hash": "c0d63dcf550dbd563bd77c89c6fcf013",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/json/JsonSchemaValidator.java": {
-    "mtime": 1781183200.162076,
+    "mtime": 1781769440.6729918,
     "ast_hash": "d1136d836e02f9f6022a06cb42acb949",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/natural/PilotNaturalActionPlanner.java": {
-    "mtime": 1781592922.5018523,
+    "mtime": 1781769440.6739924,
     "ast_hash": "fac8097a727ba867caa8d6fe1e3ce385",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/security/RedactionPolicy.java": {
-    "mtime": 1781183200.162076,
+    "mtime": 1781769440.6739924,
     "ast_hash": "b2018496d7f034d57439ad18315fddd8",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/security/RedactionResult.java": {
-    "mtime": 1781183200.1630757,
+    "mtime": 1781769440.6749923,
     "ast_hash": "02d5ee92866f5c7a61fdc20af0d1a282",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/security/Redactor.java": {
-    "mtime": 1781183200.1640754,
+    "mtime": 1781769440.6749923,
     "ast_hash": "ff7d2c45be4f35fb31c789cfb797509e",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiExecutionServiceTest.java": {
-    "mtime": 1781592922.5038521,
+    "mtime": 1781769440.677866,
     "ast_hash": "e741aaaf03847723e489d5255a2848ae",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiProviderRegistryTest.java": {
-    "mtime": 1781183200.1665976,
+    "mtime": 1781769440.677866,
     "ast_hash": "d44cb3d9a96f72e8d169b40215ea9e30",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/ai/PilotTestConfiguration.java": {
-    "mtime": 1781592922.5038521,
+    "mtime": 1781769440.6788714,
     "ast_hash": "b8434bf125093e961295191538deefdd",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/security/RedactorTest.java": {
-    "mtime": 1781183200.1685996,
+    "mtime": 1781769440.6788714,
     "ast_hash": "6b5d2f07eeca23613af246198507f334",
     "semantic_hash": ""
   },
   "shaft-upgrader/upgrade_to_modular_shaft.py": {
-    "mtime": 1781170595.9957213,
+    "mtime": 1781769440.679871,
     "ast_hash": "80ded4b12afff44b6dc194cacea1591a",
     "semantic_hash": ""
   },
-  "shaft-video/allure-results/3a534026-89a3-40f7-bfea-4d15196f084b-result.json": {
-    "mtime": 1781000862.4685662,
-    "ast_hash": "e95cfd018328a3ffd9f8f0de525dbd17",
-    "semantic_hash": ""
-  },
-  "shaft-video/allure-results/6a837d23-d520-4ab5-b516-86f06d76101d-container.json": {
-    "mtime": 1781000862.4906054,
-    "ast_hash": "8de5b971b895dbf4bb2d4e94c8c7dc58",
-    "semantic_hash": ""
-  },
-  "shaft-video/allure-results/fcce4a3f-1d37-4f43-8d0f-f32e34e17c69-container.json": {
-    "mtime": 1781000862.4775186,
-    "ast_hash": "00ebafe3cc6e1ecba0b1ef3292165344",
-    "semantic_hash": ""
-  },
   "shaft-video/src/main/java/com/shaft/gui/internal/video/AutomationRemarksDesktopVideoRecordingProvider.java": {
-    "mtime": 1781170596.0007164,
+    "mtime": 1781769440.6828713,
     "ast_hash": "b92a1245bb8e27b8865cd539c0303677",
     "semantic_hash": ""
   },
   "shaft-video/src/test/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistrationTest.java": {
-    "mtime": 1781170596.0057142,
+    "mtime": 1781769440.6858711,
     "ast_hash": "230af714e6f4cd18f914051600613427",
     "semantic_hash": ""
   },
   "shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvHealingVisualProvider.java": {
-    "mtime": 1781283589.7123978,
-    "ast_hash": "240a60f80622aeb0196b3d5bbfe25d43",
+    "mtime": 1781769440.6888707,
+    "ast_hash": "665a72915a4214f1e86d3f8a315873b9",
     "semantic_hash": ""
   },
   "shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java": {
-    "mtime": 1781423522.4588294,
+    "mtime": 1781769440.6888707,
     "ast_hash": "259423a9d501bc5eb95fee0143b88ea5",
     "semantic_hash": ""
   },
   "shaft-visual/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsCoverageUnitTest.java": {
-    "mtime": 1781170596.0127149,
+    "mtime": 1781769440.6928704,
     "ast_hash": "a010a6f22a177d8030bad70f35d74bab",
     "semantic_hash": ""
   },
   "shaft-visual/src/test/java/com/shaft/gui/internal/image/OpenCvHealingVisualProviderTest.java": {
-    "mtime": 1781282559.6117632,
-    "ast_hash": "fe0fadaaff29fc2f0f4b17105ad42bbc",
+    "mtime": 1781769440.6928704,
+    "ast_hash": "324be73186da5aa43b06e00099a55061",
     "semantic_hash": ""
   },
   "shaft-visual/src/test/java/testPackage/unitTests/ImageProcessingActionsUnitTest.java": {
-    "mtime": 1781734857.235985,
+    "mtime": 1781769440.6938708,
     "ast_hash": "0d61e5d9142b782249cba668a937430f",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/forbidden-coordinates.json": {
-    "mtime": 1781286441.0,
+    "mtime": 1781769440.695956,
     "ast_hash": "05978f92526026f1e72d0cc9333dcd14",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/api.json": {
-    "mtime": 1781286441.0,
+    "mtime": 1781769440.6970847,
     "ast_hash": "33464132b1941069384296fb1a5d0b8c",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/appium-mobile.json": {
-    "mtime": 1781286441.0,
+    "mtime": 1781769440.6970847,
     "ast_hash": "7ae7e1b33592d1ef1428d548f8fac808",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts-bom.json": {
-    "mtime": 1781286441.0,
+    "mtime": 1781769440.69809,
     "ast_hash": "9fbfe22e65e8cfa4e1ffb7b9e6517494",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts-browserstack-sdk.json": {
-    "mtime": 1781286441.0,
+    "mtime": 1781769440.69809,
     "ast_hash": "5af6cde115806a688731572d1ceaa893",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts-combined-modules.json": {
-    "mtime": 1781286441.0,
+    "mtime": 1781769440.69909,
     "ast_hash": "278a1788754fc7bba0fa505cc2baed79",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts-desktop-video.json": {
-    "mtime": 1781286441.0,
+    "mtime": 1781769440.69909,
     "ast_hash": "1543ef994a82a667c3d95688bd778587",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts-opencv-visual.json": {
-    "mtime": 1781286441.0,
+    "mtime": 1781769440.70009,
     "ast_hash": "719a4464d0a58ecde6dba8f9f5233a8d",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts.json": {
-    "mtime": 1781286441.0,
+    "mtime": 1781769440.70009,
     "ast_hash": "d8492b92abaaf1c4d60cd1035a96f8e1",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/bom.json": {
-    "mtime": 1781286441.0,
+    "mtime": 1781769440.70109,
     "ast_hash": "3eabc9ec189bdaf11f14b4c0a45b75c2",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/browserstack-sdk.json": {
-    "mtime": 1781286441.0,
+    "mtime": 1781769440.70109,
     "ast_hash": "44c751b4a87214e0607bd7a018f6bd29",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/combined-modules.json": {
-    "mtime": 1781286441.0,
+    "mtime": 1781769440.70109,
     "ast_hash": "7437bc718bb6526bd5ade48a6dd7a186",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/desktop-video.json": {
-    "mtime": 1781286441.0,
+    "mtime": 1781769440.7020898,
     "ast_hash": "3cd581acddb6c5ab3eb3c5dadfa4dfec",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/junit-web.json": {
-    "mtime": 1781286441.0,
+    "mtime": 1781769440.7020898,
     "ast_hash": "e736aac3ac042dd16518d1f12e5a8689",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/legacy-coordinate.json": {
-    "mtime": 1781286441.0,
+    "mtime": 1781769440.7020898,
     "ast_hash": "e0db222137e456fe8e3563cf5564672a",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/opencv-visual.json": {
-    "mtime": 1781286441.0,
+    "mtime": 1781769440.7030897,
     "ast_hash": "3af8a40b65daa2d45d95d633db37bc0f",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/testng-web.json": {
-    "mtime": 1781286441.0,
+    "mtime": 1781769440.7030897,
     "ast_hash": "476c5a55cf829d939d58c5ee853862b1",
     "semantic_hash": ""
   },
   "tests/scripts/test_assemble_javadocs.py": {
-    "mtime": 1781170596.0137146,
+    "mtime": 1781769440.7040896,
     "ast_hash": "f498990719cf3398e8d85d414f7e27b1",
     "semantic_hash": ""
   },
   "tests/scripts/test_browserstack_module_boundary.py": {
-    "mtime": 1781592922.506853,
+    "mtime": 1781769440.7040896,
     "ast_hash": "7a4db7ced5bb9a8af9942fbed218ad74",
     "semantic_hash": ""
   },
   "tests/scripts/test_check_maven_release_version.py": {
-    "mtime": 1781183200.1695957,
+    "mtime": 1781769440.7040896,
     "ast_hash": "2862600bb50c3c3a62386c49105fa5e8",
     "semantic_hash": ""
   },
   "tests/scripts/test_extract_allure_failures.py": {
-    "mtime": 1781170596.0157156,
+    "mtime": 1781769440.7053216,
     "ast_hash": "40c2706ce602599cfcdd5a7f5da2a01d",
     "semantic_hash": ""
   },
   "tests/scripts/test_pilot_module_boundary.py": {
-    "mtime": 1781186708.9232469,
+    "mtime": 1781769440.7053216,
     "ast_hash": "778d0667f363c9013a98be56f2cdbeeb",
     "semantic_hash": ""
   },
   "tests/scripts/test_upgrade_to_modular_shaft.py": {
-    "mtime": 1781685472.0781667,
-    "ast_hash": "cf47339360edb795c8471b57cd180f83",
+    "mtime": 1781769440.7063265,
+    "ast_hash": "e851a8b7c293fe67f4af91f8884a930e",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_agent_guidance.py": {
-    "mtime": 1781532316.2059915,
-    "ast_hash": "f124b97c4a2e56c42dff819494f51271",
+    "mtime": 1781769440.7063265,
+    "ast_hash": "31f821d43bb135cecff6219df9238139",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_agent_setup.py": {
-    "mtime": 1781532316.206992,
-    "ast_hash": "b9648fbe274ed85e72f0faa41dd1f975",
+    "mtime": 1781769440.707327,
+    "ast_hash": "6897d4657f87cc83c6573b37698c96de",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_maven_publication.py": {
-    "mtime": 1781691782.6085734,
-    "ast_hash": "4333332039ddd39be08d9adb04ceaa3f",
+    "mtime": 1781769440.707327,
+    "ast_hash": "34d6ed7fbe980f3eed372bd1ef5388aa",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_modular_documentation.py": {
-    "mtime": 1781170596.0197139,
+    "mtime": 1781769440.707327,
     "ast_hash": "69686b909a8bfdeabe1443605d5da58d",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_quality_configuration.py": {
-    "mtime": 1781642509.8505077,
+    "mtime": 1781769440.7083268,
     "ast_hash": "9b656c26a1a985cc43fb61fab4912d85",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_reactor_versions.py": {
-    "mtime": 1781170596.0207171,
+    "mtime": 1781769440.7083268,
     "ast_hash": "f9433da24d0218a7361747d407ace39d",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_shaft_pilot_release.py": {
-    "mtime": 1781262757.1185603,
-    "ast_hash": "a165f95c969f4df3a2c77f5373606e17",
+    "mtime": 1781769440.7083268,
+    "ast_hash": "b888b91abba4fa10ff9c8f2aa8c5f6da",
     "semantic_hash": ""
   },
   "tests/scripts/test_verify_maven_central_release.py": {
-    "mtime": 1781186708.9252467,
+    "mtime": 1781769440.7093265,
     "ast_hash": "20d330277e722c391b13833fc79827f1",
     "semantic_hash": ""
   },
   "tests/scripts/test_video_module_boundary.py": {
-    "mtime": 1781340221.2306857,
-    "ast_hash": "55a8ce9bb88548caa2dcc4bf91162b67",
+    "mtime": 1781769440.7093265,
+    "ast_hash": "a3faabe526dd03805678b1c530509398",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/api/src/test/java/fixture/ApiAndRetainedSurfaceConsumer.java": {
-    "mtime": 1781170596.0247152,
+    "mtime": 1781769440.7123308,
     "ast_hash": "5a2e4a6e773299c1000f0d22aaa00d10",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/appium-mobile/src/test/java/fixture/AppiumMobileConsumer.java": {
-    "mtime": 1781170596.0267138,
+    "mtime": 1781769440.7143314,
     "ast_hash": "863352eb82696f373fe94a63f1d22d25",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/bom/src/test/java/fixture/BomConsumer.java": {
-    "mtime": 1781170596.0287173,
+    "mtime": 1781769440.716331,
     "ast_hash": "626d1fe9b8536ed47c4f86a665d8a49e",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/browserstack-sdk/src/test/java/fixture/BrowserStackSdkConsumer.java": {
-    "mtime": 1781170596.031715,
+    "mtime": 1781769440.718331,
     "ast_hash": "0d9caf3b0b7aceb9d9b9f54b6fac92ef",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/desktop-video/src/test/java/fixture/DesktopVideoConsumer.java": {
-    "mtime": 1781170596.0367148,
+    "mtime": 1781769440.7203307,
     "ast_hash": "cf09e09cfb9ccab702d9aa80b3d0e520",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/junit-web/src/test/java/fixture/JUnitWebConsumer.java": {
-    "mtime": 1781170596.039716,
+    "mtime": 1781769440.7219224,
     "ast_hash": "f2e9357367f4c24326005cc9cea1945b",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/legacy-coordinate/src/test/java/fixture/LegacyCoordinateConsumer.java": {
-    "mtime": 1781170596.0427146,
+    "mtime": 1781769440.72434,
     "ast_hash": "2a8f6b59bc40773df7204c2b417ab016",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/opencv-visual/src/test/java/fixture/OpenCvVisualConsumer.java": {
-    "mtime": 1781170596.045717,
+    "mtime": 1781769440.726266,
     "ast_hash": "13a3d033009333c480e8354e11f160f4",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/pilot-core/src/main/java/example/PilotCoreConsumer.java": {
-    "mtime": 1781183200.179595,
+    "mtime": 1781769440.728357,
     "ast_hash": "ecd7041b37e057a1692e0407f2ea8ec9",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/testng-web/src/test/java/fixture/TestNgWebConsumer.java": {
-    "mtime": 1781170596.0497136,
+    "mtime": 1781769440.7303624,
     "ast_hash": "21b95d06a12ca9852e40ec45c506b781",
     "semantic_hash": ""
   },
   ".agents/skills/ci-failure-investigator/SKILL.md": {
-    "mtime": 1781532137.9632666,
-    "ast_hash": "89d886c2c6a34d75f8d35a19df00cb90",
+    "mtime": 1781769439.5542905,
+    "ast_hash": "00b8473e33574eaecd73bc947de97864",
     "semantic_hash": ""
   },
   ".agents/skills/ci-failure-investigator/agents/openai.yaml": {
-    "mtime": 1781532137.9642668,
-    "ast_hash": "2680507633eb794bff8775379a3e1173",
+    "mtime": 1781769439.5542905,
+    "ast_hash": "a655df2d4ee8a6eca2611c26184da4ba",
     "semantic_hash": ""
   },
   ".agents/skills/flaky-test-stabilizer/SKILL.md": {
-    "mtime": 1781532137.9642668,
-    "ast_hash": "6547ebd7b025368cdbf2b4a1cffb3def",
+    "mtime": 1781769439.5552905,
+    "ast_hash": "97f4ea40aaf659bca7200ce9a99279a5",
     "semantic_hash": ""
   },
   ".agents/skills/flaky-test-stabilizer/agents/openai.yaml": {
-    "mtime": 1781532137.965267,
-    "ast_hash": "e58ada167763542b5ba1c7174ff0929f",
+    "mtime": 1781769439.5552905,
+    "ast_hash": "442d85b196270c22a0c71c81c759ede1",
     "semantic_hash": ""
   },
   ".agents/skills/framework-source-rules/SKILL.md": {
-    "mtime": 1781532137.9662676,
-    "ast_hash": "0bf5c74ac26fb12a3ab01f2ee2f23666",
+    "mtime": 1781769439.5562906,
+    "ast_hash": "4e9e9113da43851ebbbadf41ff12070c",
     "semantic_hash": ""
   },
   ".agents/skills/framework-source-rules/agents/openai.yaml": {
-    "mtime": 1781532137.9672675,
-    "ast_hash": "7180da70cb8896b7139fc0f92a1524a5",
+    "mtime": 1781769439.557291,
+    "ast_hash": "fbbaa399dc0f83968bf451e6a53fc96d",
     "semantic_hash": ""
   },
   ".agents/skills/java-test-rules/SKILL.md": {
-    "mtime": 1781532137.9672675,
-    "ast_hash": "2996f3a49f472f7efe5c70ff07d19b80",
+    "mtime": 1781769439.5582392,
+    "ast_hash": "deb7cdd0ce17fa15de3fe89b51b7ee10",
     "semantic_hash": ""
   },
   ".agents/skills/java-test-rules/agents/openai.yaml": {
-    "mtime": 1781532137.968268,
-    "ast_hash": "f7f93d52540f3f087ade5c904a8584c2",
+    "mtime": 1781769439.5582392,
+    "ast_hash": "fd1828b72256991da2926129061bda9c",
     "semantic_hash": ""
   },
   ".agents/skills/release-dependency-guard/SKILL.md": {
-    "mtime": 1781532137.9692676,
-    "ast_hash": "e64c95e938e1488fb3e8ee50d4e25ec1",
+    "mtime": 1781769439.5594406,
+    "ast_hash": "f3653ae639dadae0de32eb6d93abc152",
     "semantic_hash": ""
   },
   ".agents/skills/release-dependency-guard/agents/openai.yaml": {
-    "mtime": 1781532137.970266,
-    "ast_hash": "d05704867008d9efc2cd900173ff3259",
+    "mtime": 1781769439.5594406,
+    "ast_hash": "70df2767596adcc902c526e6f96b9047",
     "semantic_hash": ""
   },
   ".github/FUNDING.yml": {
-    "mtime": 1781170594.7316215,
+    "mtime": 1781769439.561695,
     "ast_hash": "82d0dace0b0b1e5a3113e7483a2c90ef",
     "semantic_hash": ""
   },
   ".github/ISSUE_TEMPLATE/bug_report.md": {
-    "mtime": 1781339935.0496168,
-    "ast_hash": "cec341c1d9265b42d9f76c26bf882b04",
+    "mtime": 1781769439.561695,
+    "ast_hash": "a110b7d54ffa206acc1fc3480d49a8d6",
     "semantic_hash": ""
   },
   ".github/ISSUE_TEMPLATE/config.yml": {
-    "mtime": 1781339935.051615,
-    "ast_hash": "2a010de82884d821d7040381ead26450",
+    "mtime": 1781769439.561695,
+    "ast_hash": "53022d5d3721cee2557e0f2636d269c0",
     "semantic_hash": ""
   },
   ".github/ISSUE_TEMPLATE/feature_request.md": {
-    "mtime": 1781339935.0506198,
-    "ast_hash": "70d4795bb6116b31395fce81fed614b6",
+    "mtime": 1781769439.5627003,
+    "ast_hash": "bc5d7d4577daabff03b33ea9a56f1f19",
     "semantic_hash": ""
   },
   ".github/RELEASE_BODY_TEMPLATE.md": {
-    "mtime": 1781339935.0465865,
-    "ast_hash": "5a2a173746632bca46cdd55393e45c32",
+    "mtime": 1781769439.5627003,
+    "ast_hash": "c99615c1a486cbcc0340c0684f12f1e6",
     "semantic_hash": ""
   },
   ".github/actions/consolidate-test-results/action.yml": {
-    "mtime": 1781170594.7356198,
+    "mtime": 1781769439.5643551,
     "ast_hash": "60f8f12a4f02378cbf50c2e4548ea2d7",
     "semantic_hash": ""
   },
   ".github/actions/post-test-report/action.yml": {
-    "mtime": 1781713808.9173808,
-    "ast_hash": "6df56db29b15a5f32482c72d69890775",
+    "mtime": 1781769439.5643551,
+    "ast_hash": "9bf564486cc3861391c1d52b18f3e442",
     "semantic_hash": ""
   },
   ".github/actions/setup-test-env/action.yml": {
-    "mtime": 1781170594.7376223,
+    "mtime": 1781769439.5653608,
     "ast_hash": "a3ae968f94adf704ec03d1d59c32ca88",
     "semantic_hash": ""
   },
   ".github/actions/upload-jacoco-coverage/action.yml": {
-    "mtime": 1781713808.916381,
-    "ast_hash": "39ed26f9e5b3011504a6b95529f734be",
+    "mtime": 1781769439.5663607,
+    "ast_hash": "f07e2ee4234a17049187c7c7005ee866",
     "semantic_hash": ""
   },
   ".github/codex/prompts/refresh-agent-instructions.md": {
-    "mtime": 1781532283.4642105,
-    "ast_hash": "8aee1da37c980adb82312d3e26d17e5e",
+    "mtime": 1781769439.5673602,
+    "ast_hash": "b917f03c57b15de27300bc05cf7e0929",
     "semantic_hash": ""
   },
   ".github/copilot-instructions.md": {
-    "mtime": 1781532476.8914695,
-    "ast_hash": "c263ef522586d77af53f2fea7fdbb9ce",
+    "mtime": 1781769439.5673602,
+    "ast_hash": "b5a0e7a2af012bf5c687495f6ced2d85",
     "semantic_hash": ""
   },
   ".github/dependabot.yml": {
-    "mtime": 1781282332.2589867,
-    "ast_hash": "9737ee552e1d17cf25dc68c6f846b3e2",
+    "mtime": 1781769439.5673602,
+    "ast_hash": "4f97032a0893c4bd5040a882d83bf7c5",
     "semantic_hash": ""
   },
   ".github/instructions/framework-source.instructions.md": {
-    "mtime": 1781170594.7416215,
+    "mtime": 1781769439.5683608,
     "ast_hash": "5f3adff6cc4aa23c612aa7c02ae9a512",
     "semantic_hash": ""
   },
   ".github/instructions/java-tests.instructions.md": {
-    "mtime": 1781248987.6387072,
-    "ast_hash": "9a26d32e6fb862b4dacefbe277c9fd14",
+    "mtime": 1781769439.5683608,
+    "ast_hash": "c09b9d18f7d372e5713e1ae3a401fe37",
     "semantic_hash": ""
   },
   ".github/pull_request_template.md": {
-    "mtime": 1781339935.0440686,
-    "ast_hash": "70ffa04df08f86a48be623cedb2ae2eb",
+    "mtime": 1781769439.5693607,
+    "ast_hash": "fdc84bd63f4459bb71c5e62770bd36f3",
     "semantic_hash": ""
   },
   ".github/release.yml": {
-    "mtime": 1781170594.74262,
+    "mtime": 1781769439.5693607,
     "ast_hash": "da8b1e52486c7f97f5ef731e57629179",
     "semantic_hash": ""
   },
   ".github/skills/README.md": {
-    "mtime": 1781170594.7436194,
+    "mtime": 1781769439.57036,
     "ast_hash": "378b57e2a6875ef95f91647322cbbc8d",
     "semantic_hash": ""
   },
   ".github/skills/ci-failure-investigator/SKILL.md": {
-    "mtime": 1781339935.05262,
-    "ast_hash": "6110d69776a07bf5684b127e61c9ab69",
+    "mtime": 1781769439.57036,
+    "ast_hash": "8fe1d368f6f874f2d3a1af2c06e1c9a0",
     "semantic_hash": ""
   },
   ".github/skills/flaky-test-stabilizer/SKILL.md": {
-    "mtime": 1781170594.7466238,
+    "mtime": 1781769439.5713606,
     "ast_hash": "8244098e39f5271a9e3d1f8d7ffbd830",
     "semantic_hash": ""
   },
   ".github/skills/release-dependency-guard/SKILL.md": {
-    "mtime": 1781170594.7476196,
+    "mtime": 1781769439.5713606,
     "ast_hash": "4cc087a502ef6bccecd6c52b154b6a58",
     "semantic_hash": ""
   },
   ".github/workflows/copilot-setup-steps.yml": {
-    "mtime": 1781282332.2599888,
-    "ast_hash": "b0a9403b23f220a166df89dde280a2bb",
+    "mtime": 1781769439.5723605,
+    "ast_hash": "da94c0f88734d6efd4a4b5c33d132f94",
     "semantic_hash": ""
   },
   ".github/workflows/deploy-shaft-mcp.yml": {
-    "mtime": 1781428152.3317254,
-    "ast_hash": "a827f59b2c6f2cf4dcd884c34ad40792",
+    "mtime": 1781769439.5723605,
+    "ast_hash": "06c9df39199772862dee0cf2be52c7e9",
     "semantic_hash": ""
   },
   ".github/workflows/e2eTests.yml": {
-    "mtime": 1781720858.4704854,
-    "ast_hash": "9a9c34edf7cad7330cfa52db4c3687a5",
+    "mtime": 1781769439.5733607,
+    "ast_hash": "0576a73454aa047412d7d067a2cec44d",
     "semantic_hash": ""
   },
   ".github/workflows/general-validations.yml": {
-    "mtime": 1781685472.079167,
-    "ast_hash": "3369bf356227a54d852a436e058370d3",
+    "mtime": 1781769439.574361,
+    "ast_hash": "dbd57bb8084b1bf978aa9452ad4005ef",
     "semantic_hash": ""
   },
   ".github/workflows/mavenCentral_cd.yml": {
-    "mtime": 1781710454.1859534,
-    "ast_hash": "106c1f935064e68b3821ce3b1da005b4",
+    "mtime": 1781769439.5753608,
+    "ast_hash": "50bfe791b75127544688c8ec89e6bd34",
     "semantic_hash": ""
   },
   ".github/workflows/publish-shaft-mcp.yml": {
-    "mtime": 1781428152.3317254,
-    "ast_hash": "abc6c0c74a9b3824c783ac3c82e51fa7",
+    "mtime": 1781769439.5753608,
+    "ast_hash": "b3a2c5cfba6d9bda755af7ecf588c00a",
     "semantic_hash": ""
   },
   ".github/workflows/publishJavaDocs.yml": {
-    "mtime": 1781170594.7556207,
+    "mtime": 1781769439.5753608,
     "ast_hash": "15a2dc4f49864cc59b52463aad5b5b7a",
     "semantic_hash": ""
   },
   ".github/workflows/refresh-agent-instructions.yml": {
-    "mtime": 1781532283.4642105,
-    "ast_hash": "4ef2466bc13c45eb5e0f0028c7f33583",
+    "mtime": 1781769439.5763602,
+    "ast_hash": "c011fb69441761e4dba97996325cfed2",
     "semantic_hash": ""
   },
   ".github/workflows/security.yml": {
-    "mtime": 1781592922.4334722,
+    "mtime": 1781769439.5763602,
     "ast_hash": "11d3a03fab9a8f1cca63f05af110aab5",
     "semantic_hash": ""
   },
   ".github/workflows/shaft-mcp.yml": {
-    "mtime": 1781692524.7079005,
-    "ast_hash": "383509b254ad4037205df6b657280037",
+    "mtime": 1781769439.5773609,
+    "ast_hash": "7c95442b585e022f8b0ae690b4b1457b",
     "semantic_hash": ""
   },
   ".github/workflows/shaft-pilot-release.yml": {
-    "mtime": 1781692524.7089026,
-    "ast_hash": "3d8d6332c4719df897ff4d50ced91613",
+    "mtime": 1781769439.5773609,
+    "ast_hash": "1a6c2cf8a590a173c5dd5edf4c65ab29",
     "semantic_hash": ""
   },
   ".github/workflows/sync-sample-projects-version.yml": {
-    "mtime": 1781170594.7576213,
+    "mtime": 1781769439.5773609,
     "ast_hash": "bd4bc36bc3e7b33f6b27e6296636951e",
     "semantic_hash": ""
   },
   ".github/workflows/update-selenium-grid-versions.yml": {
-    "mtime": 1781170594.7586224,
+    "mtime": 1781769439.5783606,
     "ast_hash": "2fc24067ed878081bc3493a8ef88123f",
     "semantic_hash": ""
   },
   ".memory/memory/architecture.md": {
-    "mtime": 1781532411.32092,
-    "ast_hash": "ff236b86e34425995a2350cb346e9ca0",
+    "mtime": 1781769439.5803604,
+    "ast_hash": "6abb2a262830b40886b2283dac6a901a",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/maven-central-version-immutability.md": {
-    "mtime": 1781532411.3109226,
+    "mtime": 1781769439.5823598,
     "ast_hash": "76b0b7fb9ab56f985f3941697647c496",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/paid-agent-work-audit-gated.md": {
-    "mtime": 1781532411.2567608,
+    "mtime": 1781769439.58336,
     "ast_hash": "15666adfbb50db198beb784479ff45e5",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/agent-guidance-progressive-disclosure.md": {
-    "mtime": 1781532411.2507615,
+    "mtime": 1781769439.5843606,
     "ast_hash": "ed6933c3b3e838f473c4445bf251f1f9",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/namespaced-video-capabilities.md": {
-    "mtime": 1781532411.305109,
+    "mtime": 1781769439.5843606,
     "ast_hash": "a5940ade6cab0d926922ca555dab46f6",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/public-docs-external.md": {
-    "mtime": 1781532575.6115012,
+    "mtime": 1781769439.5853598,
     "ast_hash": "49a53c3afc4d4f6fc5142ee47bf913f2",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/utf8-all-runtime-layers.md": {
-    "mtime": 1781532411.2677612,
+    "mtime": 1781769439.5863597,
     "ast_hash": "6bff0142e535940a2c54ed0c96743f81",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/allure-result-population.md": {
-    "mtime": 1781532411.2737603,
+    "mtime": 1781769439.5873601,
     "ast_hash": "d691c887b833eeb2002b91bb55129c8a",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/coverage-constructors-start-browser.md": {
-    "mtime": 1781532411.3000643,
+    "mtime": 1781769439.58786,
     "ast_hash": "bbd92df5c4228f6e626c7a52ed2c16cd",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/java25-isuite-mocking.md": {
-    "mtime": 1781532411.2950633,
+    "mtime": 1781769439.5888653,
     "ast_hash": "a6d1866e880bd6556f12230ff80f75aa",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/surefire-testng-deletes-module.md": {
-    "mtime": 1781687980.9192278,
+    "mtime": 1781769439.5908654,
     "ast_hash": "ba9a3a00d166d03239fed3d5cca8edc3",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/testng-method-parallel-shared-instance-fields.md": {
-    "mtime": 1781532411.283963,
+    "mtime": 1781769439.5908654,
     "ast_hash": "88be0bf5fcebfdb1d579389644c09ebe",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/testng-single-threaded-static-state.md": {
-    "mtime": 1781532411.2899625,
+    "mtime": 1781769439.5918655,
     "ast_hash": "19c314a82618b0fa2e841ecac203734b",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/windows-allure-root-race.md": {
-    "mtime": 1781532411.279534,
+    "mtime": 1781769439.5928652,
     "ast_hash": "2ff9296f2ecf396b5c61f41a0b5be34b",
     "semantic_hash": ""
   },
   ".memory/memory/project.md": {
-    "mtime": 1781532411.315919,
-    "ast_hash": "69f6a40c08085f720131a1c6ad6bc0c7",
+    "mtime": 1781769439.5934837,
+    "ast_hash": "5e4026b5220213b5d05773628cde4269",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/issue-linked-pr-closure-and-focused-tests.md": {
-    "mtime": 1781684453.1663232,
+    "mtime": 1781769439.6005454,
     "ast_hash": "57982dd3a4bdf7d5b1a46259307d1e58",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/low-token-user-guide-work.md": {
-    "mtime": 1781592922.436471,
+    "mtime": 1781769439.6015453,
     "ast_hash": "37fceea4bd25a0a1949e5bc9c28f8f6e",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/proactive-memory-use-when-material.md": {
-    "mtime": 1781592922.4374704,
+    "mtime": 1781769439.6025455,
     "ast_hash": "79312855570c67b7f6e8e0ef5adab2cf",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/start-new-tasks-from-origin-main.md": {
-    "mtime": 1781592922.4384708,
+    "mtime": 1781769439.6055448,
     "ast_hash": "b46e6163b3e010f599cb5d49ecdd8785",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/update-official-user-guide-for-functionality-changes.md": {
-    "mtime": 1781592922.439472,
+    "mtime": 1781769439.6055448,
     "ast_hash": "1d7eaa27ba5737bd22dee4ba51ec3316",
     "semantic_hash": ""
   },
   "AGENTS.md": {
-    "mtime": 1781738026.1626618,
-    "ast_hash": "f543d94a470310b79c93ffbebed4f9fb",
+    "mtime": 1781769439.6135495,
+    "ast_hash": "dfade0f378d9071a1b778e06969a33dd",
     "semantic_hash": ""
   },
   "CLAUDE.md": {
-    "mtime": 1781684270.5428898,
-    "ast_hash": "78b6121596436242f453c70d9361a3d4",
+    "mtime": 1781769439.6135495,
+    "ast_hash": "46953bcbf78e61ab450f3ced5784fc59",
     "semantic_hash": ""
   },
   "CODE_OF_CONDUCT.md": {
-    "mtime": 1781170594.763622,
+    "mtime": 1781769439.6145499,
     "ast_hash": "757dfc14603149dc03182d5c2c0d8ca4",
     "semantic_hash": ""
   },
   "CONTRIBUTING.md": {
-    "mtime": 1781345450.1832082,
-    "ast_hash": "2cec28074348b3a558e0f1efdea1ff29",
+    "mtime": 1781769439.6145499,
+    "ast_hash": "d2a1ed4aae08482811e36535dd3dcba7",
     "semantic_hash": ""
   },
   "README.md": {
-    "mtime": 1781642509.7702153,
+    "mtime": 1781769439.6155496,
     "ast_hash": "e506994b943722dd01c8131d63456fb5",
     "semantic_hash": ""
   },
   "SECURITY.md": {
-    "mtime": 1781170594.7676203,
+    "mtime": 1781769439.6155496,
     "ast_hash": "5968bb1ac2bd3d0b9c04d6789ed99884",
     "semantic_hash": ""
   },
   "codecov.yml": {
-    "mtime": 1781170594.7676203,
+    "mtime": 1781769439.6165495,
     "ast_hash": "a9ee0ae70c7a2817a2dd01759cd007c9",
     "semantic_hash": ""
   },
   "render.yaml": {
-    "mtime": 1781183200.0987692,
+    "mtime": 1781769439.6685631,
     "ast_hash": "852f4c51596f80a6f39c336083b743bd",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/golden/doctor-report.md": {
-    "mtime": 1781242397.485421,
+    "mtime": 1781769439.7534876,
     "ast_hash": "9fd151800fee4024eeb0463f36890866",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/javadoc/resources/configuration-manager/index.html": {
-    "mtime": 1781423522.4528356,
+    "mtime": 1781769439.8359575,
     "ast_hash": "5b4bbf6645ed75cd52c2cab5fea2ed32",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/javadoc/resources/index.html": {
-    "mtime": 1781340296.1164157,
-    "ast_hash": "4c066f72a7440ca24f77c5f4d7371ff2",
+    "mtime": 1781769439.839957,
+    "ast_hash": "c9d34062f3fb9447c352d2b2d7ab8ee1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/healenium-backend.yml": {
-    "mtime": 1781170594.9647408,
+    "mtime": 1781769439.842959,
     "ast_hash": "a5fd654aa0fbea19d0a20fa14e06e86c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/report-portal.yml": {
-    "mtime": 1781170594.9677403,
+    "mtime": 1781769439.8459568,
     "ast_hash": "de7ac23ca6fa7d3eda50bc8ab1aba483",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/selenium3.yml": {
-    "mtime": 1781170594.9687414,
+    "mtime": 1781769439.8459568,
     "ast_hash": "a464e315b9a241886cfef90f787ec99d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/selenium4.yml": {
-    "mtime": 1781642509.8180523,
+    "mtime": 1781769439.8459568,
     "ast_hash": "ef7d53be2865b48d88080466a1002231",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/selenoid.yml": {
-    "mtime": 1781170594.969741,
+    "mtime": 1781769439.8469567,
     "ast_hash": "94b482b90eb7a6c434840950aa7cadad",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/selenoid_setup.yml": {
-    "mtime": 1781170594.970744,
+    "mtime": 1781769439.8469567,
     "ast_hash": "57f474b3e5f66f08f07684ab25568c4e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/zalenium.yml": {
-    "mtime": 1781170594.9727426,
+    "mtime": 1781769439.847957,
     "ast_hash": "cc1f40ca9bb2c913d8ce5c755c1dc525",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/.github/dependabot.yml": {
-    "mtime": 1781170594.9797466,
+    "mtime": 1781769439.8539572,
     "ast_hash": "d967a02218d19254ea8c200b1887b549",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/.github/workflows/api.yml": {
-    "mtime": 1781170594.980747,
+    "mtime": 1781769439.8539572,
     "ast_hash": "d6cebbce56ded32de3f4d49cfdc8e545",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/.github/workflows/web.yml": {
-    "mtime": 1781170594.9817474,
+    "mtime": 1781769439.854957,
     "ast_hash": "698491178af348cb577da4a2bed5f4ce",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/k8s/selenium-grid-chrome-scaledobject.yaml": {
-    "mtime": 1781170595.1964178,
+    "mtime": 1781769439.9898853,
     "ast_hash": "c6d16b2c9bf789f3c38dced54ff50c79",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/k8s/selenium-grid-edge-scaledobject.yaml": {
-    "mtime": 1781170595.1974204,
+    "mtime": 1781769439.9908855,
     "ast_hash": "48291bb39d912826522b2fcaedbd55e9",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/k8s/selenium-grid-firefox-scaledobject.yaml": {
-    "mtime": 1781170595.1984186,
+    "mtime": 1781769439.9908855,
     "ast_hash": "ce8ab2c5f24347cbbe286a358e6e970d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/alertFixture.html": {
-    "mtime": 1781170595.4080312,
+    "mtime": 1781769440.1566708,
     "ast_hash": "ea46500946ec7b72c8d872d5432079dc",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/coverageTestPage.html": {
-    "mtime": 1781716716.053063,
-    "ast_hash": "3d2e0cd255ba51571cf5b777c2c0ad9b",
+    "mtime": 1781769440.5949018,
+    "ast_hash": "1b449bdbd7cbf63f83d0f4c644976730",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/hoverDemo.html": {
-    "mtime": 1781170595.9731855,
+    "mtime": 1781769440.5969028,
     "ast_hash": "017983881c7dcdeb8549122b74fceea3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/hoverDemo_outsideViewPort.html": {
-    "mtime": 1781170595.9741888,
+    "mtime": 1781769440.5969028,
     "ast_hash": "09c6ae4c037396146fb889b9145d77b9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/hoverDemo_outsideViewPort_Horizontal.html": {
-    "mtime": 1781170595.9741888,
+    "mtime": 1781769440.5969028,
     "ast_hash": "3f2864a3f112756f32c047d08d86d033",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/locatorBuilderFixture.html": {
-    "mtime": 1781642509.844136,
+    "mtime": 1781769440.5989025,
     "ast_hash": "274171ae17cb342e543557271079b5a9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/searchFixture.html": {
-    "mtime": 1781170595.9811947,
+    "mtime": 1781769440.6019025,
     "ast_hash": "f807c7d448900de296c1aff8960c0928",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/selectDemo.html": {
-    "mtime": 1781170595.982195,
+    "mtime": 1781769440.602903,
     "ast_hash": "6202e3912db56d54602ad63a94ecbf52",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/selectedValueTests/Advanced_select_with_multiple_features.html": {
-    "mtime": 1781170595.9831939,
+    "mtime": 1781769440.602903,
     "ast_hash": "78d03def935f6591bd4e50812688a7c4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/selectedValueTests/Basic_select.html": {
-    "mtime": 1781170595.9831939,
+    "mtime": 1781769440.6039045,
     "ast_hash": "3868db4101f1dcbb8ed8fc09bad58d65",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/test.html": {
-    "mtime": 1781170595.990198,
+    "mtime": 1781769440.608162,
     "ast_hash": "eca1a30a4647270469873bb77be7d28b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/uploadFixture.html": {
-    "mtime": 1781642509.844136,
+    "mtime": 1781769440.61016,
     "ast_hash": "6afb82db0280c6109713fe98dc1109ea",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/validationTextFixture.html": {
-    "mtime": 1781642509.8451362,
+    "mtime": 1781769440.61016,
     "ast_hash": "bdc4bd2af770c9de828335d6a51e9f75",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/yaml/yaml_test_data.yaml": {
-    "mtime": 1781170595.9927063,
+    "mtime": 1781769440.6111648,
     "ast_hash": "9dbe42fd6d1166db3aefabe7bf52e87b",
     "semantic_hash": ""
   },
   "shaft-mcp/.github/copilot-instructions.md": {
-    "mtime": 1781428152.3287249,
-    "ast_hash": "fb61af62eb776f77de07d05814f5bc7e",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-11_13-32-59-904_AllureReport.html": {
-    "mtime": 1781173979.8387184,
-    "ast_hash": "ba477c79c49710a8ba507896df9b5669",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-11_14-06-30-018_AllureReport.html": {
-    "mtime": 1781175989.9498942,
-    "ast_hash": "d29c178beb3e019cfafc272eb8bb733a",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-11_17-45-42-529_AllureReport.html": {
-    "mtime": 1781189142.471589,
-    "ast_hash": "88958d37a51ee1c17a9ea2c07165ee2a",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-11_18-18-43-337_AllureReport.html": {
-    "mtime": 1781191123.2851233,
-    "ast_hash": "929e1988f71ab97c30496d77b5bbd640",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-11_19-11-58-706_AllureReport.html": {
-    "mtime": 1781194318.6504774,
-    "ast_hash": "488eb3c1b4327091df5beb3bc81278bb",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-11_19-12-45-272_AllureReport.html": {
-    "mtime": 1781194365.2210848,
-    "ast_hash": "030bc6a7b547fa783aa6a1605159e967",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-12_08-18-40-886_AllureReport.html": {
-    "mtime": 1781241520.8228495,
-    "ast_hash": "2d8dc37471b7836a533768484c588c95",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-12_08-21-38-352_AllureReport.html": {
-    "mtime": 1781241698.2931025,
-    "ast_hash": "33aef687d50db76eeb7b17911eaddbe5",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-12_08-27-15-276_AllureReport.html": {
-    "mtime": 1781242035.1866772,
-    "ast_hash": "1f084b41dc4ba4c47264acbd8f9f631c",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-12_08-52-14-358_AllureReport.html": {
-    "mtime": 1781243534.2566926,
-    "ast_hash": "b8c9419f357c9af517168384ea3c9611",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-12_08-53-24-303_AllureReport.html": {
-    "mtime": 1781243604.1996272,
-    "ast_hash": "645d7811ad78b2897a23613706e446fa",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-12_10-09-25-104_AllureReport.html": {
-    "mtime": 1781248165.0299253,
-    "ast_hash": "d02e5281c660d6190d4142934231d96b",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-12_10-42-42-324_AllureReport.html": {
-    "mtime": 1781250162.238273,
-    "ast_hash": "26c380f821091429d21c3f7f56d08b28",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-12_10-49-39-052_AllureReport.html": {
-    "mtime": 1781250578.9644585,
-    "ast_hash": "7203557f34eb940acb0bb736ef7310de",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-12_11-10-02-259_AllureReport.html": {
-    "mtime": 1781251802.1478002,
-    "ast_hash": "12847931a703cad3978f10f9c11f23a0",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-12_13-49-52-104_AllureReport.html": {
-    "mtime": 1781261391.7981026,
-    "ast_hash": "01c56e2f2e2d6a3d73aeb59000771118",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-12_20-33-56-979_AllureReport.html": {
-    "mtime": 1781285636.9299817,
-    "ast_hash": "86b36364e61d054f7181bfabad945983",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-13_11-47-58-214_AllureReport.html": {
-    "mtime": 1781340478.116697,
-    "ast_hash": "8d73401136dff9dbd6f8550f424d7441",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-13_12-06-05-031_AllureReport.html": {
-    "mtime": 1781341564.9455776,
-    "ast_hash": "ce1608ad88005a6fe40a04ccc4beb773",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-14_12-12-03-133_AllureReport.html": {
-    "mtime": 1781428323.070675,
-    "ast_hash": "8b0f7de79be982cfb19dd3e26ec00fe8",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-15_09-53-02-579_AllureReport.html": {
-    "mtime": 1781506382.4898446,
-    "ast_hash": "64257a22583024310937dd2a7dad815d",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-15_10-26-39-636_AllureReport.html": {
-    "mtime": 1781508399.555573,
-    "ast_hash": "a7ad50495c3957c3f73aa9c21e44ad7c",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-15_10-43-53-684_AllureReport.html": {
-    "mtime": 1781509433.558846,
-    "ast_hash": "ef0eab5fd7721f57031ed6037dbe9052",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-15_10-46-19-666_AllureReport.html": {
-    "mtime": 1781509579.5312383,
-    "ast_hash": "6c13b0fba2d5a1ba1d741c2325ef73fd",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-15_10-51-24-628_AllureReport.html": {
-    "mtime": 1781509884.4533951,
-    "ast_hash": "66c1c22cf7b64575495284e8cd2c9222",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-15_11-03-54-687_AllureReport.html": {
-    "mtime": 1781510634.5309048,
-    "ast_hash": "1734153e4dd2004d5859ffe309dcac31",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-15_20-21-46-890_AllureReport.html": {
-    "mtime": 1781544106.8390303,
-    "ast_hash": "1222f33f4d00f1b34ec1f6c492d1e8a9",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-15_20-23-01-036_AllureReport.html": {
-    "mtime": 1781544180.9873579,
-    "ast_hash": "52063b32f53ab9c0cc18f7bbbb8b541e",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-15_20-27-17-908_AllureReport.html": {
-    "mtime": 1781544437.859802,
-    "ast_hash": "a4fcaeaa4dc9bd52ac40d3aaf4cd4da0",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-15_20-41-59-844_AllureReport.html": {
-    "mtime": 1781545319.7909594,
-    "ast_hash": "8f324fd5643ce2bfa29ae46b48962300",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-15_20-42-23-098_AllureReport.html": {
-    "mtime": 1781545343.047819,
-    "ast_hash": "0a39cde6d30eaa9b7d3a6b1f3f07e34a",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-15_21-01-34-336_AllureReport.html": {
-    "mtime": 1781546494.2491639,
-    "ast_hash": "d6d76c5660d35dfdeb7159f3bb17656c",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-15_21-02-59-045_AllureReport.html": {
-    "mtime": 1781546578.995044,
-    "ast_hash": "d219a57f12fd1cd3d5fdb88539028047",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-15_21-04-29-745_AllureReport.html": {
-    "mtime": 1781546669.69612,
-    "ast_hash": "2c66b8e1eee65cf9b2dbb319a923aaab",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-15_21-10-56-167_AllureReport.html": {
-    "mtime": 1781547056.1152642,
-    "ast_hash": "4c91bd5e0e22b5c284c52cea1ddf8c0c",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-15_22-43-25-288_AllureReport.html": {
-    "mtime": 1781552605.2356076,
-    "ast_hash": "198861757f668250634c4fc12711f3ef",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-15_22-45-23-148_AllureReport.html": {
-    "mtime": 1781552723.0983808,
-    "ast_hash": "f38c1e11dd75bbd2066e8dd1950b0cf8",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-16_07-59-05-316_AllureReport.html": {
-    "mtime": 1781585945.2635553,
-    "ast_hash": "be961a1bc3b990beb1289515ec7d5db4",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-16_13-17-53-468_AllureReport.html": {
-    "mtime": 1781605073.4149065,
-    "ast_hash": "7b00d465f886672287ed800d04d4f3d6",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-16_14-15-15-781_AllureReport.html": {
-    "mtime": 1781608515.6973462,
-    "ast_hash": "800f4dbffb6b54485910fa0eb20771fe",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allurerc.yaml": {
-    "mtime": 1781608512.942174,
-    "ast_hash": "1861b0462f0deb9c11c0eea45f2bdab1",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/execution-summary/ExecutionSummaryReport_16-06-2026_14-15-17-7580-PM.html": {
-    "mtime": 1781608517.7628994,
-    "ast_hash": "4699d959eb3c36802c3595677b5c69de",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_11-06-2026_13-33-01-8344-PM.html": {
-    "mtime": 1781173981.8364956,
-    "ast_hash": "41179cc0c05d1f3f6af0e52e4eff53eb",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_11-06-2026_14-06-31-7944-PM.html": {
-    "mtime": 1781175991.7964354,
-    "ast_hash": "3ed8f5e3f94b56adfe273c08e67fc6f0",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_11-06-2026_17-45-44-1405-PM.html": {
-    "mtime": 1781189144.1415412,
-    "ast_hash": "753e68fcdab8a2adf60ad38d108ed3a7",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_11-06-2026_18-18-44-9315-PM.html": {
-    "mtime": 1781191124.9325392,
-    "ast_hash": "58cb4ceb3704e16555bb8a615d836790",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_11-06-2026_19-12-00-4002-PM.html": {
-    "mtime": 1781194320.401218,
-    "ast_hash": "6fbe6ffb752168a14bed14bd159bac38",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_11-06-2026_19-12-46-8787-PM.html": {
-    "mtime": 1781194366.8807504,
-    "ast_hash": "f84ee74d649c72b0ba921d011d007014",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_12-06-2026_08-18-43-0413-AM.html": {
-    "mtime": 1781241523.043386,
-    "ast_hash": "92efdd69cdf1c9e37d424175b693f968",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_12-06-2026_08-21-40-1208-AM.html": {
-    "mtime": 1781241700.1219003,
-    "ast_hash": "90bc90e861561c1bbdc3352d13009f92",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_12-06-2026_08-27-17-1900-AM.html": {
-    "mtime": 1781242037.1920714,
-    "ast_hash": "66475b6d18ac9d6b246a0af3da446978",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_12-06-2026_10-42-45-0071-AM.html": {
-    "mtime": 1781250165.0103464,
-    "ast_hash": "f3d413192811f8c0cc8f49f53130c00c",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_12-06-2026_10-49-41-3756-AM.html": {
-    "mtime": 1781250581.3776658,
-    "ast_hash": "456964105ce244e23234c5515bf3298e",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_12-06-2026_11-10-06-2654-AM.html": {
-    "mtime": 1781251806.2705445,
-    "ast_hash": "115c87d177afe39c6ea1c4e77dcd9d6c",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_12-06-2026_13-49-57-4347-PM.html": {
-    "mtime": 1781261397.4373147,
-    "ast_hash": "7b4d9768df7b8fc678a6de76c590a649",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_12-06-2026_20-33-58-4503-PM.html": {
-    "mtime": 1781285638.451347,
-    "ast_hash": "a8e1e1b0a15944fbe5b9fa65d55f974f",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_13-06-2026_12-06-07-2060-PM.html": {
-    "mtime": 1781341567.2080965,
-    "ast_hash": "f17306f752316593e97d9982f4422f42",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_14-06-2026_12-12-05-1221-PM.html": {
-    "mtime": 1781428325.125807,
-    "ast_hash": "32c509a3d61986e888280ef33a1b593a",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_15-06-2026_09-53-05-1189-AM.html": {
-    "mtime": 1781506385.12865,
-    "ast_hash": "2156477918c29ec9a127cc2bf03818cd",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_15-06-2026_10-26-41-9291-AM.html": {
-    "mtime": 1781508401.930165,
-    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_15-06-2026_10-43-56-9815-AM.html": {
-    "mtime": 1781509436.9845757,
-    "ast_hash": "6ff586fa3a08163c52a87ac1ba20ec67",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_15-06-2026_10-51-30-0927-AM.html": {
-    "mtime": 1781509890.0937881,
-    "ast_hash": "b6d8429b61c2c0e10c1a502b358dd68f",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_15-06-2026_20-21-48-5361-PM.html": {
-    "mtime": 1781544108.5371737,
-    "ast_hash": "f08360b0f14f7d67bacdef973cbeebe0",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_15-06-2026_20-23-02-6154-PM.html": {
-    "mtime": 1781544182.6164806,
-    "ast_hash": "4d08961be1908d4bf9970f6d15f09c4d",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_15-06-2026_20-27-19-5093-PM.html": {
-    "mtime": 1781544439.5103707,
-    "ast_hash": "dc8dcbee31703cef0e92b5bb5e447c29",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_15-06-2026_20-42-01-6531-PM.html": {
-    "mtime": 1781545321.6541135,
-    "ast_hash": "8693323147b4066e25e704a2aea2bdb0",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_15-06-2026_20-42-24-6524-PM.html": {
-    "mtime": 1781545344.6534338,
-    "ast_hash": "ee4e31edf21efe0c0362b4ec280df922",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_15-06-2026_21-01-36-3962-PM.html": {
-    "mtime": 1781546496.3972914,
-    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_15-06-2026_21-03-00-6120-PM.html": {
-    "mtime": 1781546580.613088,
-    "ast_hash": "3dd08d9cc752609080e19edae3e550d2",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_15-06-2026_21-04-31-3254-PM.html": {
-    "mtime": 1781546671.3264897,
-    "ast_hash": "dead25570956446a2f036f5543106306",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_15-06-2026_21-10-57-7660-PM.html": {
-    "mtime": 1781547057.7670097,
-    "ast_hash": "67bc3ae76f31a2d6b5bbe78f54b6333e",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_15-06-2026_22-43-27-4171-PM.html": {
-    "mtime": 1781552607.418114,
-    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_15-06-2026_22-45-24-7248-PM.html": {
-    "mtime": 1781552724.7258124,
-    "ast_hash": "9b09345062974ecff78185a206b2af3a",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_16-06-2026_07-59-06-9036-AM.html": {
-    "mtime": 1781585946.904619,
-    "ast_hash": "3844407f5c6ad6af971668197621bf5a",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_16-06-2026_13-17-55-3141-PM.html": {
-    "mtime": 1781605075.317131,
-    "ast_hash": "29e8048e9663de05116cfe5e83e9a1b6",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_16-06-2026_14-15-17-7699-PM.html": {
-    "mtime": 1781608517.7719014,
-    "ast_hash": "229ff4816273e93cb8945d17c6cd82fb",
+    "mtime": 1781769440.6305506,
+    "ast_hash": "a9759a5bf78204ff863c94480b3aacd7",
     "semantic_hash": ""
   },
   "smithery.yaml": {
-    "mtime": 1781183200.1695957,
+    "mtime": 1781769440.6948712,
     "ast_hash": "38eb9cd9b08dbf6453dfd19693e4f23e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/sample.pdf": {
-    "mtime": 1781170595.980197,
+    "mtime": 1781769440.6009026,
     "ast_hash": "4b41a3475132bd861b30a878e30aa56a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/Android/13_0/a9d70165382980941bed3fe21fcb9aabfc62872fa39658c332505740f4cb3675.png": {
-    "mtime": 1781170594.9747403,
+    "mtime": 1781769439.8499572,
     "ast_hash": "2ef14bf57dfc7ae42b748b506607c891",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/Android/content.png": {
-    "mtime": 1781170594.9747403,
+    "mtime": 1781769439.850957,
     "ast_hash": "ceaf89a99b2f77f7dd7385232bc786a0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/Android/content_local.png": {
-    "mtime": 1781170594.9757419,
+    "mtime": 1781769439.850957,
     "ast_hash": "b404721a09a139fcaf7276b578a5deab",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/Android/content_new.png": {
-    "mtime": 1781170594.9767406,
+    "mtime": 1781769439.8519561,
     "ast_hash": "42815e5383bcc7948c46443793f61dbe",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/linux/chrome/a16413dbaadddad22a2203779b00521b7e5beb3446743fff9b52e1c3308bbfd3.png": {
-    "mtime": 1781170594.9777474,
+    "mtime": 1781769439.8519561,
     "ast_hash": "0ce5cae521647668798fb59240d8163d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/linux/chrome/a16413dbaadddad22a2203779b00521b7e5beb3446743fff9b52e1c3308bbfd3_shutterbug.png": {
-    "mtime": 1781170594.9787488,
+    "mtime": 1781769439.852957,
     "ast_hash": "da6466f773b2b294c96164c351fee9e1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/engine.png": {
-    "mtime": 1781170595.1789105,
+    "mtime": 1781769439.9806933,
     "ast_hash": "9c02074d966c282967abf86a40990952",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/mindmap.png": {
-    "mtime": 1781170595.1849055,
+    "mtime": 1781769439.984691,
     "ast_hash": "09974b1f6d4fe5ef7b8601bb9c08680e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/roi.png": {
-    "mtime": 1781170595.186908,
+    "mtime": 1781769439.98588,
     "ast_hash": "7303a194a3ba55dd3fb2071d8445e31b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft.png": {
-    "mtime": 1781170595.188905,
+    "mtime": 1781769439.9868855,
     "ast_hash": "5df1ce58218a4bae2d031b7faa043c03",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft_white.png": {
-    "mtime": 1781170595.1909056,
+    "mtime": 1781769439.9878852,
     "ast_hash": "877b04c6152af84a64aeb0dcd1ef3198",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft_white_bg.png": {
-    "mtime": 1781170595.192411,
+    "mtime": 1781769439.9888856,
     "ast_hash": "638a800ba4c6c0d597df827fdf7848cf",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft_white_ramadan.png": {
-    "mtime": 1781170595.1934192,
+    "mtime": 1781769439.9898853,
     "ast_hash": "703354878805e8d341e697c75a83b367",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/search.PNG": {
-    "mtime": 1781170595.4050298,
+    "mtime": 1781769440.1546714,
     "ast_hash": "529740c6b227e97ed27fe797406d735f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/youtube.png": {
-    "mtime": 1781170595.9937177,
+    "mtime": 1781769440.6111648,
     "ast_hash": "3cb8adc33ce532807aacf1bfaffbf31b",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/code-conventions.json": {
-    "mtime": 1781684382.095985,
-    "ast_hash": "8ed15e9c1bdbc2b1ea18f3720d49b4d7",
+    "mtime": 1781769439.5813606,
+    "ast_hash": "5c1eb980b386ba44323d9741b8c8ae28",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/powershell-shell-sensitive-args.json": {
-    "mtime": 1781687980.9182289,
+    "mtime": 1781769439.5888653,
     "ast_hash": "8dc62f50fbf74b5780312307bf6d5d19",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/python-script-tests-use-python310.json": {
-    "mtime": 1781685553.5514674,
-    "ast_hash": "540ee6ff20fd15c68447824453ac4618",
+    "mtime": 1781769439.5898657,
+    "ast_hash": "8a32ee6f7da59baada769731840abe4e",
     "semantic_hash": ""
   },
   ".memory/memory/sources/agents.json": {
-    "mtime": 1781684098.2622643,
-    "ast_hash": "0811c4320e35ee265e2de39a49201227",
+    "mtime": 1781769439.5934837,
+    "ast_hash": "6508fe9e7480f2357a840c560ffa010f",
     "semantic_hash": ""
   },
   ".memory/memory/sources/project-readme.json": {
-    "mtime": 1781684290.4149227,
-    "ast_hash": "cf2243c323d7f805b95eba29e0fb3cff",
+    "mtime": 1781769439.5944886,
+    "ast_hash": "ca2b3ea34f094d5d7104225b910a6db5",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/agent-guidance.json": {
-    "mtime": 1781684098.3003013,
-    "ast_hash": "7b2f076247149052750e80184c1b30d1",
+    "mtime": 1781769439.596053,
+    "ast_hash": "eecb6929590febb1e1bcf3cecbdcaae2",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/conventions-quality.json": {
-    "mtime": 1781684382.1029854,
-    "ast_hash": "1c0352498a31fe398609a804c706625c",
+    "mtime": 1781769439.596053,
+    "ast_hash": "e01f337f7d01373f294a3ace9cd11f7f",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/product-intent.json": {
-    "mtime": 1781684382.1059868,
-    "ast_hash": "a075c2bb4ca4063a7e261768869bd55d",
+    "mtime": 1781769439.5975401,
+    "ast_hash": "d4a438fd7d6896393b8026b284735904",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/create-and-report-pr-after-tasks.json": {
-    "mtime": 1781687980.920229,
+    "mtime": 1781769439.5975401,
     "ast_hash": "f0e78a988b71d9deb56e9af992e4e35a",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/minimal-nonredundant-validation.json": {
-    "mtime": 1781687980.9212272,
+    "mtime": 1781769439.6015453,
     "ast_hash": "5834b369159038bc89a34e916e9ad7ee",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/run-local-e2e-jobs-in-a-dedicated-workflow.json": {
-    "mtime": 1781728647.507944,
-    "ast_hash": "768a36735b8d6214dd26cb0267a65295",
+    "mtime": 1781769439.6025455,
+    "ast_hash": "4233688d717e8e7aaaa1b424ce1ebb87",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/share-memory-and-graphify-assets.json": {
-    "mtime": 1781684787.6427805,
-    "ast_hash": "108f26bb922959da9ebda7e448737581",
+    "mtime": 1781769439.6035452,
+    "ast_hash": "270cbf117e0047f707f3eaaae9494195",
     "semantic_hash": ""
   },
   ".memory/relations/constraint-code-conventions-affects-project-shaft-engine.json": {
-    "mtime": 1781684098.3453026,
-    "ast_hash": "25a52d65f56066561a758a23a3fd5ccd",
+    "mtime": 1781769439.6065447,
+    "ast_hash": "a4dd873eb9a3cb41398d92073ddd37a5",
     "semantic_hash": ""
   },
   ".memory/relations/constraint-code-conventions-derived-from-source-agents.json": {
-    "mtime": 1781684098.3232996,
-    "ast_hash": "22251e735c2d0010314523543021e243",
+    "mtime": 1781769439.6065447,
+    "ast_hash": "958da5cacc1ad227cbfc52bdcf3696cd",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-agent-guidance-derived-from-source-agents.json": {
-    "mtime": 1781684098.305306,
-    "ast_hash": "22accdc1ddb6a4011466ea0ef1a032a4",
+    "mtime": 1781769439.6075456,
+    "ast_hash": "ceda73fdfa718f949c1c636e33d993d6",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-agent-guidance-documents-project-shaft-engine.json": {
-    "mtime": 1781684098.3403006,
-    "ast_hash": "f330114779cc37e30bd1d8c02647e7ef",
+    "mtime": 1781769439.6085446,
+    "ast_hash": "c17d6760da1e494ee12d62ea6cdb0e35",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-conventions-quality-derived-from-source-agents.json": {
-    "mtime": 1781684098.2922986,
-    "ast_hash": "a97295391ef26970f1a099bad5f66ced",
+    "mtime": 1781769439.6085446,
+    "ast_hash": "30f6ab1fb433f92e0f1bddb152ae89a9",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-conventions-quality-documents-project-shaft-engine.json": {
-    "mtime": 1781684098.3342998,
-    "ast_hash": "b9bd8b5f82b222d45c7fc3376bb84143",
+    "mtime": 1781769439.6085446,
+    "ast_hash": "7807b3da7440b26c5ffd411d2d58c8f4",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-product-intent-derived-from-source-project-readme.json": {
-    "mtime": 1781684290.4199233,
-    "ast_hash": "ea03f806913a5dfa88c5392cdf984b41",
+    "mtime": 1781769439.609545,
+    "ast_hash": "73f46fd60b629fac27ef5b2bf7edaade",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-product-intent-summarizes-project-shaft-engine.json": {
-    "mtime": 1781684098.3283017,
-    "ast_hash": "b50405629d8f07d139eaf72691cae4c6",
+    "mtime": 1781769439.609545,
+    "ast_hash": "d75f2b943c7caec5bad6edbdd2d3ba42",
     "semantic_hash": ""
   },
   ".memory/relations/workflow-create-and-report-pr-after-tasks-documents-project-shaft-engine.json": {
-    "mtime": 1781684939.5524545,
-    "ast_hash": "ccc0cbce843e513103aa5a28af6851d9",
+    "mtime": 1781769439.609545,
+    "ast_hash": "15037f0f0f4f2072b4ac7452185b7abd",
     "semantic_hash": ""
   },
   ".memory/relations/workflow-share-memory-and-graphify-assets-documents-project-shaft-engine.json": {
-    "mtime": 1781684787.6467845,
-    "ast_hash": "e51c16504a85fc94dc5f9eb795391d38",
+    "mtime": 1781769439.6105502,
+    "ast_hash": "15a6e2ed7ed54d18ca1a9ba283e9997f",
     "semantic_hash": ""
   },
   "tests/scripts/test_install_shaft_mcp.py": {
-    "mtime": 1781724042.904169,
-    "ast_hash": "13573209e54489d2f1a7de7f51129267",
+    "mtime": 1781769440.7053216,
+    "ast_hash": "dcaaa519ea941f2de981f605b53f2de9",
     "semantic_hash": ""
   },
   ".github/workflows/e2eLocalTests.yml": {
-    "mtime": 1781720858.4714866,
-    "ast_hash": "66923b5806ca93e5338523a0c1f849f8",
+    "mtime": 1781769439.5733607,
+    "ast_hash": "30340985a6658d4297859f9ca27d3ad1",
     "semantic_hash": ""
   },
   ".github/workflows/lambdatestTests.yml": {
-    "mtime": 1781716249.5901246,
-    "ast_hash": "b266eb03f3d89406861df12e4cfdf142",
+    "mtime": 1781769439.574361,
+    "ast_hash": "dea80d8a808443d967f2076f071933fd",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/code-conventions.md": {
-    "mtime": 1781684382.091975,
-    "ast_hash": "c36b34485c64a8244d00ba89eb91c01a",
+    "mtime": 1781769439.5813606,
+    "ast_hash": "ebb3f6f7caa3501cab774c1d8e7598a8",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/powershell-shell-sensitive-args.md": {
-    "mtime": 1781687980.9182289,
+    "mtime": 1781769439.5888653,
     "ast_hash": "81604c5c66f8f3f2bc96d6fb9b63e0c5",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/python-script-tests-use-python310.md": {
-    "mtime": 1781685553.547468,
+    "mtime": 1781769439.5898657,
     "ast_hash": "2d9e074325b05036e1e50562a080a785",
     "semantic_hash": ""
   },
   ".memory/memory/sources/agents.md": {
-    "mtime": 1781684098.2582703,
-    "ast_hash": "b2b41f4ae1c12cc97597ca7a5c42611f",
+    "mtime": 1781769439.5944886,
+    "ast_hash": "f4c78cc6fa0107ab0301aaeeaecd5374",
     "semantic_hash": ""
   },
   ".memory/memory/sources/project-readme.md": {
-    "mtime": 1781684290.4119232,
-    "ast_hash": "b3ff8b7489494c5874764abdac766f85",
+    "mtime": 1781769439.5954885,
+    "ast_hash": "1644c82d3ce411b7b776e14e4a3fc832",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/agent-guidance.md": {
-    "mtime": 1781684098.2952988,
-    "ast_hash": "1d79ee60786852a137271b72f188a97b",
+    "mtime": 1781769439.596053,
+    "ast_hash": "a16b079a09d4154707d22265a2167ea1",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/conventions-quality.md": {
-    "mtime": 1781684382.0989828,
-    "ast_hash": "2320275defdf0dd504fd888afc9ab104",
+    "mtime": 1781769439.5970583,
+    "ast_hash": "41403aeb6cfbff5b7ab4193dff8bac41",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/product-intent.md": {
-    "mtime": 1781684098.2732725,
-    "ast_hash": "073bed5e985ebbb1a00b203442b9102d",
+    "mtime": 1781769439.5975401,
+    "ast_hash": "072645010c12d96012e55a07eb8462a9",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/create-and-report-pr-after-tasks.md": {
-    "mtime": 1781687980.9212272,
+    "mtime": 1781769439.5985446,
     "ast_hash": "b549db3f8a5127451e93d3aa34146f8f",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/minimal-nonredundant-validation.md": {
-    "mtime": 1781687980.9222307,
+    "mtime": 1781769439.6015453,
     "ast_hash": "431e4f5cc6afab68b429c36739dce7c3",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/run-local-e2e-jobs-in-a-dedicated-workflow.md": {
-    "mtime": 1781728647.5045564,
+    "mtime": 1781769439.6035452,
     "ast_hash": "e21cf1d1253c1b9d9646050d8437c555",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/share-memory-and-graphify-assets.md": {
-    "mtime": 1781684787.6387825,
+    "mtime": 1781769439.6045456,
     "ast_hash": "44176d6d1036c08d58f9036a56af0a8c",
     "semantic_hash": ""
   },
-  ".codex-remote-attachments/019ed7ba-0189-77f0-863d-15b41df5a4a4/96916f1c-72b7-41ad-81d2-99b584645fd7/1-Photo-1.jpg": {
-    "mtime": 1781735758.4530776,
-    "ast_hash": "440c10e6a33edcf245248d32c37816f4",
-    "semantic_hash": ""
-  },
   ".memory/memory/workflows/delegate-only-when-needed-for-correctness.json": {
-    "mtime": 1781737578.9838536,
-    "ast_hash": "9c0123676a3d7eec70fc712cf1a4de92",
+    "mtime": 1781769439.5985446,
+    "ast_hash": "89452a15b27dbf71a8d319b68e201a4d",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/delegate-only-when-needed-for-correctness.md": {
-    "mtime": 1781737578.9808524,
+    "mtime": 1781769439.5995455,
     "ast_hash": "b07cf652dddba20866b2ecbbe4e06136",
     "semantic_hash": ""
   }

--- a/shaft-engine/src/main/java/com/shaft/cli/FileActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/FileActions.java
@@ -326,7 +326,7 @@ public class FileActions {
         try {
             Path targetFilePath = Paths.get(absoluteFilePath);
             FileUtils.writeByteArrayToFile(targetFilePath.toFile(), content);
-            passAction("Target File Path: \"" + targetFilePath + "\"", Arrays.toString(content));
+            passAction("Target File Path: \"" + targetFilePath + "\"", content.length + " bytes");
         } catch (InvalidPathException | IOException rootCauseException) {
             failAction("Folder Name: \"" + filePath + "\".", rootCauseException);
         }

--- a/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
@@ -779,18 +779,9 @@ public class TerminalActions {
                     exitStatuses.append(localProcess.exitValue());
                 } else {
                     exitStatuses.append("asynchronous");
-                    ScheduledExecutorService asynchronousProcessExecution = Executors.newScheduledThreadPool(1);
-                    asynchronousProcessExecution.schedule(() -> {
-                        try {
-                            pb.start();
-                            asynchronousProcessExecution.shutdown();
-                        } catch (Throwable throwable) {
-                            asynchronousProcessExecution.shutdownNow();
-                        }
-                    }, 0, TimeUnit.SECONDS);
-                    if (!asynchronousProcessExecution.awaitTermination(SHAFT.Properties.timeouts.shellSessionTimeout(), TimeUnit.MINUTES)) {
-                        asynchronousProcessExecution.shutdownNow();
-                    }
+                    pb.redirectOutput(ProcessBuilder.Redirect.DISCARD);
+                    pb.redirectError(ProcessBuilder.Redirect.DISCARD);
+                    pb.start();
                 }
             } catch (IOException exception) {
                 failAction(longCommand, exception);

--- a/shaft-engine/src/main/java/com/shaft/db/DatabaseActions.java
+++ b/shaft-engine/src/main/java/com/shaft/db/DatabaseActions.java
@@ -11,7 +11,7 @@ import java.sql.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.Executors;
+import java.util.concurrent.Executor;
 
 /**
  * Manages database connections and query execution for supported relational
@@ -35,6 +35,7 @@ import java.util.concurrent.Executors;
  */
 @SuppressWarnings("unused")
 public class DatabaseActions {
+    private static final Executor DATABASE_NETWORK_TIMEOUT_EXECUTOR = command -> Thread.ofVirtual().start(command);
     private final ThreadLocal<ResultSet> resultSetThreadLocal = new ThreadLocal<>();
     private final ThreadLocal<Integer> rowCountThreadLocal = new ThreadLocal<>();
     private DatabaseType dbType;
@@ -534,7 +535,7 @@ public class DatabaseActions {
                 DriverManager.setLoginTimeout(SHAFT.Properties.timeouts.databaseLoginTimeout());
                 connection = DriverManager.getConnection(connectionString, username, password);
                 if (!dbType.toString().equals("MY_SQL") && !dbType.toString().equals("POSTGRES_SQL")) {
-                    connection.setNetworkTimeout(Executors.newFixedThreadPool(1), SHAFT.Properties.timeouts.databaseNetworkTimeout() * 60000);
+                    connection.setNetworkTimeout(DATABASE_NETWORK_TIMEOUT_EXECUTOR, SHAFT.Properties.timeouts.databaseNetworkTimeout() * 60000);
                 }
 
             } catch (SQLException rootCauseException) {

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -24,6 +24,7 @@ import com.shaft.tools.io.internal.ReportManagerHelper;
 import io.appium.java_client.AppiumDriver;
 import io.qameta.allure.Allure;
 import io.qameta.allure.Step;
+import io.qameta.allure.model.Parameter;
 import io.qameta.allure.model.Status;
 import io.qameta.allure.model.StatusDetails;
 import lombok.NonNull;
@@ -78,6 +79,7 @@ import java.util.function.Function;
 public class Actions extends ElementActions {
     private static final Duration defaultPauseDuration = Duration.ofMillis(500);
     private static final DateTimeFormatter SCREENSHOT_ATTACHMENT_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss");
+    private static final int TYPED_TEXT_STEP_PREVIEW_LIMIT = 80;
 
     /**
      * Creates a new {@code Actions} instance using the driver managed by the current thread's
@@ -701,13 +703,13 @@ public class Actions extends ElementActions {
                     }
                 }
                 // report broken
-                reportBroken(action.name(), accessibleName.get(), screenshot.get(0), exception);
+                reportBroken(action.name(), accessibleName.get(), screenshot.get(0), exception, locator, data);
             } catch (RuntimeException exception2) {
                 if (exception2.getCause() == null || !exception2.getCause().equals(exception)) {
                     // in case a new exception was thrown while attempting to take a screenshot
                     exception2.addSuppressed(exception);
                     // report broken
-                    reportBroken(action.name(), accessibleName.get(), screenshot.get(0), exception2);
+                    reportBroken(action.name(), accessibleName.get(), screenshot.get(0), exception2, locator, data);
                 } else {
                     // in case no new exceptions where thrown, just the one created by SHAFT for the main issue
                     throw exception2;
@@ -715,7 +717,7 @@ public class Actions extends ElementActions {
             }
         }
         //report pass
-        reportPass(action.name(), accessibleName.get(), screenshot.get(0));
+        reportPass(action.name(), accessibleName.get(), screenshot.get(0), locator, data);
         return output.get();
     }
 
@@ -977,14 +979,30 @@ public class Actions extends ElementActions {
         report(action, elementName, Status.PASSED, screenshot, null);
     }
 
+    private void reportPass(String action, String elementName, byte[] screenshot, By locator, Object data) {
+        report(action, elementName, Status.PASSED, screenshot, null, locator, data);
+    }
+
     private void reportBroken(String action, String elementName, byte[] screenshot, RuntimeException exception) {
         report(action, elementName, Status.BROKEN, screenshot, exception);
     }
 
+    private void reportBroken(String action, String elementName, byte[] screenshot, RuntimeException exception, By locator, Object data) {
+        report(action, elementName, Status.BROKEN, screenshot, exception, locator, data);
+    }
+
     private void report(String action, String elementName, Status status, byte[] screenshot, RuntimeException exception) {
+        report(action, elementName, status, screenshot, exception, null, null);
+    }
+
+    private void report(String action, String elementName, Status status, byte[] screenshot, RuntimeException exception, By locator, Object data) {
+        boolean isTypeAction = ActionType.TYPE.name().equals(action);
+        String typedText = isTypeAction ? getTypedText(data) : "";
+        String reportedSubject = isTypeAction ? getTypedTextPreview(typedText) : elementName;
+
         // update allure step name
         StringBuilder stepName = new StringBuilder();
-        stepName.append(JavaHelper.convertToSentenceCase(action)).append(" \"").append(elementName).append("\"");
+        stepName.append(JavaHelper.convertToSentenceCase(action)).append(" \"").append(reportedSubject).append("\"");
 
         if (!status.equals(Status.PASSED))
             stepName.append(" is ").append(status.name().toLowerCase());
@@ -998,6 +1016,9 @@ public class Actions extends ElementActions {
         }
 
         Allure.getLifecycle().updateStep(update -> update.setName(stepName.toString()));
+        if (isTypeAction) {
+            updateTypeActionStepParameters(elementName, locator, typedText);
+        }
 
         // handle secure typing
         if (ActionType.TYPE_SECURELY.name().equals(action))
@@ -1039,6 +1060,49 @@ public class Actions extends ElementActions {
                 throw new RuntimeException(createFailureMessageWithCausedBy(exception), exception);
             }
         }
+    }
+
+    private static String getTypedText(Object data) {
+        if (data instanceof CharSequence[] text) {
+            StringBuilder typedText = new StringBuilder();
+            for (CharSequence charSequence : text) {
+                if (charSequence != null) {
+                    typedText.append(charSequence);
+                }
+            }
+            return typedText.toString();
+        }
+        return data == null ? "" : String.valueOf(data);
+    }
+
+    private static String getTypedTextPreview(String typedText) {
+        String singleLineText = typedText.replaceAll("\\s+", " ").trim();
+        if (singleLineText.length() <= TYPED_TEXT_STEP_PREVIEW_LIMIT) {
+            return singleLineText;
+        }
+        return singleLineText.substring(0, TYPED_TEXT_STEP_PREVIEW_LIMIT - 3).stripTrailing() + "...";
+    }
+
+    private static void updateTypeActionStepParameters(String elementName, By locator, String typedText) {
+        String elementLocator = JavaHelper.formatLocatorToString(locator);
+        Allure.getLifecycle().updateStep(update -> {
+            var params = update.getParameters();
+            params.removeIf(parameter -> isTypeActionStepParameter(parameter.getName()));
+            if (elementName != null && !elementName.isBlank() && !elementName.equals(elementLocator)) {
+                params.add(new Parameter().setName("Element Name").setValue(elementName));
+            }
+            params.add(new Parameter().setName("Element Locator").setValue(elementLocator));
+            params.add(new Parameter().setName("Full Text").setValue(typedText));
+            update.setParameters(params);
+        });
+    }
+
+    private static boolean isTypeActionStepParameter(String parameterName) {
+        return "locator".equals(parameterName)
+                || "text".equals(parameterName)
+                || "Element Name".equals(parameterName)
+                || "Element Locator".equals(parameterName)
+                || "Full Text".equals(parameterName);
     }
 
     static NoSuchElementException createDragAndDropDestinationNotFoundException(By destinationLocator, NoSuchElementException rootCauseException) {

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
@@ -379,7 +379,7 @@ public class PropertiesHelper {
                 SHAFT.Properties.visuals.set().screenshotParamsHighlightElements(false);
                 SHAFT.Properties.visuals.set().screenshotParamsHighlightMethod("AI");
                 SHAFT.Properties.visuals.set().screenshotParamsScreenshotType(String.valueOf(Screenshots.VIEWPORT));
-                SHAFT.Properties.visuals.set().screenshotParamsWatermark(true);
+                SHAFT.Properties.visuals.set().screenshotParamsWatermark(false);
                 SHAFT.Properties.visuals.set().createAnimatedGif(false);
                 SHAFT.Properties.visuals.set().videoParamsRecordVideo(false);
                 SHAFT.Properties.reporting.set().debugMode(false);

--- a/shaft-engine/src/main/java/com/shaft/tools/internal/support/JavaHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/internal/support/JavaHelper.java
@@ -224,7 +224,10 @@ public class JavaHelper {
         Matcher matcher = WORD_FINDER_PATTERN.matcher(text);
         List<String> words = new ArrayList<>();
         while (matcher.find()) {
-            words.add(matcher.group(0));
+            String word = matcher.group(0);
+            if (!word.isBlank()) {
+                words.add(word);
+            }
         }
         List<String> capitalized = new ArrayList<>();
         for (int i = 0; i < words.size(); i++) {

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java
@@ -495,7 +495,7 @@ public class AllureManager {
                 : new ProcessBuilder("sh", "-c", command);
         processBuilder.directory(getExecutionRootPath().toFile());
 
-        ExecutorService streamReaders = Executors.newFixedThreadPool(2);
+        ExecutorService streamReaders = Executors.newVirtualThreadPerTaskExecutor();
         try {
             Process process = processBuilder.start();
             Future<String> stdout = streamReaders.submit(() -> readProcessStream(process.getInputStream()));

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/AttachmentReporter.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/AttachmentReporter.java
@@ -12,21 +12,19 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.Calendar;
 import java.util.LinkedHashMap;
-import java.util.function.BiConsumer;
 
 /**
  * Internal utility class responsible for attaching test artifacts (screenshots, recordings,
  * GIFs, data files, page snapshots, etc.) to the Allure report and optionally to ReportPortal.
  *
  * <p>Attachment routing is driven by the {@code attachmentType} / {@code attachmentName} strings
- * using a {@link java.util.LinkedHashMap} of named handlers registered in the static initialiser.
- * New content types can be supported by adding entries to {@code attachmentHandlers}.
+ * using a {@link java.util.LinkedHashMap} of named formats registered in the static initialiser.
+ * New content types can be supported by adding entries to {@code attachmentFormats}.
  *
  * <p>This class is not intended for direct use in test code; it is invoked by
  * {@link com.shaft.tools.io.internal.ReportManagerHelper}.
  */
 public class AttachmentReporter {
-    private static final LinkedHashMap<String, BiConsumer<String, ByteArrayOutputStream>> attachmentHandlers = new LinkedHashMap<>();
     private static final LinkedHashMap<String, AttachmentFormat> attachmentFormats = new LinkedHashMap<>();
 
     /**
@@ -39,20 +37,6 @@ public class AttachmentReporter {
     }
 
     static {
-        attachmentHandlers.put("screenshot", AttachmentReporter::handleScreenshot);
-        attachmentHandlers.put("recording", AttachmentReporter::handleRecording);
-        attachmentHandlers.put("gif", AttachmentReporter::handleGif);
-        attachmentHandlers.put("csv", AttachmentReporter::handleCsv);
-        attachmentHandlers.put("xml", AttachmentReporter::handleXml);
-        attachmentHandlers.put("excel", AttachmentReporter::handleExcel);
-        attachmentHandlers.put("json", AttachmentReporter::handleJson);
-        attachmentHandlers.put("properties", AttachmentReporter::handleProperties);
-        attachmentHandlers.put("link", AttachmentReporter::handleLink);
-        attachmentHandlers.put("engine logs", AttachmentReporter::handleEngineLogs);
-        attachmentHandlers.put("page snapshot", AttachmentReporter::handlePageSnapshot);
-        attachmentHandlers.put("html", AttachmentReporter::handleHtml);
-        attachmentHandlers.put("default", AttachmentReporter::handleDefault);
-
         attachmentFormats.put("screenshot", new AttachmentFormat("image/png", ".png"));
         attachmentFormats.put("recording", new AttachmentFormat("video/mp4", ".mp4"));
         attachmentFormats.put("gif", new AttachmentFormat("image/gif", ".gif"));
@@ -71,66 +55,13 @@ public class AttachmentReporter {
     private record AttachmentFormat(String contentType, String fileExtension) {
     }
 
-    private static void handleScreenshot(String attachmentDescription, ByteArrayOutputStream content) {
-        attachFileBased(attachmentDescription, "image/png", content, ".png");
-    }
-
-    private static void handleRecording(String attachmentDescription, ByteArrayOutputStream content) {
-        attachFileBased(attachmentDescription, "video/mp4", content, ".mp4");
-    }
-
-    private static void handleGif(String attachmentDescription, ByteArrayOutputStream content) {
-        attachFileBased(attachmentDescription, "image/gif", content, ".gif");
-    }
-
-    private static void handleCsv(String attachmentDescription, ByteArrayOutputStream content) {
-        attachFileBased(attachmentDescription, "text/csv", content, ".csv");
-    }
-
-    private static void handleXml(String attachmentDescription, ByteArrayOutputStream content) {
-        attachFileBased(attachmentDescription, "text/xml", content, ".xml");
-    }
-
-    @SuppressWarnings("SpellCheckingInspection")
-    private static void handleExcel(String attachmentDescription, ByteArrayOutputStream content) {
-        attachFileBased(attachmentDescription, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", content, ".xlsx");
-    }
-
-    private static void handleJson(String attachmentDescription, ByteArrayOutputStream content) {
-        attachFileBased(attachmentDescription, "application/json", content, ".json");
-    }
-
-    private static void handleProperties(String attachmentDescription, ByteArrayOutputStream content) {
-        attachFileBased(attachmentDescription, "text/plain", content, ".properties");
-    }
-
-    private static void handleLink(String attachmentDescription, ByteArrayOutputStream content) {
-        attachFileBased(attachmentDescription, "text/uri-list", content, ".uri");
-    }
-
-    private static void handleEngineLogs(String attachmentDescription, ByteArrayOutputStream content) {
-        attachFileBased(attachmentDescription, "text/plain", content, ".txt");
-    }
-
-    private static void handlePageSnapshot(String attachmentDescription, ByteArrayOutputStream content) {
-        attachFileBased(attachmentDescription, "multipart/related", content, ".mhtml");
-    }
-
-    private static void handleHtml(String attachmentDescription, ByteArrayOutputStream content) {
-        attachFileBased(attachmentDescription, "text/html", content, ".html");
-    }
-
-    private static void handleDefault(String attachmentDescription, ByteArrayOutputStream content) {
-        attachFileBased(attachmentDescription, "text/plain", content, ".txt");
-    }
-
-    private static void attachFileBased(String attachmentDescription, String contentType, ByteArrayOutputStream content, String fileExtension) {
-        Allure.addAttachment(attachmentDescription, contentType, new ByteArrayInputStream(content.toByteArray()), fileExtension);
+    private static void attachFileBased(String attachmentDescription, String contentType, byte[] content, String fileExtension) {
+        Allure.addAttachment(attachmentDescription, contentType, new ByteArrayInputStream(content), fileExtension);
         if (TestNGListener.isReportPortalEnabled()) {
             File file = null;
             try {
                 file = File.createTempFile("rp-test", fileExtension);
-                Files.write(content.toByteArray(), file);
+                Files.write(content, file);
                 ReportPortal.emitLog(attachmentDescription, "INFO", Calendar.getInstance().getTime(), file);
             } catch (Exception e) {
                 ReportManagerHelper.logDiscrete(e);
@@ -184,10 +115,24 @@ public class AttachmentReporter {
      */
     public static void attachBasedOnFileType(String attachmentType, String attachmentName,
                                              ByteArrayOutputStream attachmentContent, String attachmentDescription) {
-        // Get the appropriate handler based on the attachment type, or use the default handler(resilient in case any changes were to be made to getAttachmentCase)
-        BiConsumer<String, ByteArrayOutputStream> handler = attachmentHandlers.getOrDefault(getAttachmentCase(attachmentType, attachmentName), AttachmentReporter::handleDefault);
-        // Call the handler with the provided parameters
-        handler.accept(attachmentDescription, attachmentContent);
+        attachBasedOnFileType(attachmentType, attachmentName, attachmentContent.toByteArray(), attachmentDescription);
+    }
+
+    /**
+     * Attaches the given content to the Allure report (and ReportPortal if enabled),
+     * automatically selecting the correct MIME type and file extension based on the
+     * attachment type and name strings.
+     *
+     * @param attachmentType        a string describing the content category
+     * @param attachmentName        the file or data name, also inspected for type inference
+     * @param attachmentContent     the raw content to attach
+     * @param attachmentDescription the human-readable label shown in the Allure report attachment panel
+     */
+    public static void attachBasedOnFileType(String attachmentType, String attachmentName,
+                                             byte[] attachmentContent, String attachmentDescription) {
+        String attachmentCase = getAttachmentCase(attachmentType, attachmentName);
+        AttachmentFormat attachmentFormat = attachmentFormats.getOrDefault(attachmentCase, attachmentFormats.get("default"));
+        attachFileBased(attachmentDescription, attachmentFormat.contentType(), attachmentContent, attachmentFormat.fileExtension());
     }
 
     /**
@@ -206,7 +151,7 @@ public class AttachmentReporter {
     }
 
     private static String getAttachmentCase(String attachmentType, String attachmentName) {
-        for (String key : attachmentHandlers.keySet()) {
+        for (String key : attachmentFormats.keySet()) {
             switch (key) {
                 case "screenshot", "properties", "link", "recording", "gif", "page snapshot", "engine logs", "html" -> {
                     if (attachmentType.toLowerCase().contains(key)) {

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
@@ -940,12 +940,13 @@ public class ReportManagerHelper {
             Reporter.log(error, false);
             return;
         }
+        byte[] attachmentBytes = byteArrayOutputStream.toByteArray();
         String attachmentDescription = attachmentType + " - " + attachmentName;
-        AttachmentReporter.attachBasedOnFileType(attachmentType, attachmentName, byteArrayOutputStream, attachmentDescription);
-        logAttachmentAction(attachmentType, attachmentName, byteArrayOutputStream);
+        AttachmentReporter.attachBasedOnFileType(attachmentType, attachmentName, attachmentBytes, attachmentDescription);
+        logAttachmentAction(attachmentType, attachmentName, attachmentBytes);
     }
 
-    private static void logAttachmentAction(String attachmentType, String attachmentName, ByteArrayOutputStream attachmentContent) {
+    private static void logAttachmentAction(String attachmentType, String attachmentName, byte[] attachmentContent) {
         if (attachmentType.contains(SHAFT_ENGINE_LOGS_ATTACHMENT_TYPE)) {
             return;
         }
@@ -959,7 +960,7 @@ public class ReportManagerHelper {
 
             String theString = "";
             try (var br = new BufferedReader(
-                    new InputStreamReader(new ByteArrayInputStream(attachmentContent.toByteArray()), StandardCharsets.UTF_8))) {
+                    new InputStreamReader(new ByteArrayInputStream(attachmentContent), StandardCharsets.UTF_8))) {
                 theString = br.lines().collect(Collectors.joining(System.lineSeparator()));
             } catch (IOException e) {
                 logDiscrete(e);

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
@@ -12,6 +12,7 @@ import com.shaft.properties.internal.Properties;
 import com.shaft.tools.io.ReportManager;
 import io.appium.java_client.AppiumDriver;
 import io.qameta.allure.Allure;
+import io.qameta.allure.model.StepResult;
 import io.qameta.allure.model.Status;
 import io.qameta.allure.model.StatusDetails;
 import org.apache.logging.log4j.Level;
@@ -41,8 +42,11 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -584,6 +588,39 @@ public class ActionsCoverageUnitTest {
             SHAFT.Properties.visuals.set().screenshotParamsHighlightMethod("JavaScript");
             Assert.assertNotNull(invoke(actions, "captureScreenshot", new Class[]{WebElement.class, boolean.class}, element, false));
             verify((JavascriptExecutor) driver, atLeastOnce()).executeScript(anyString(), any(Object[].class));
+        }
+    }
+
+    @Test
+    public void typeReportShouldUseTypedTextPreviewAndStepParameters() throws Exception {
+        Actions actions = new Actions(helperFor(mock(WebDriver.class)));
+        String typedText = "  first line\nsecond line " + "x".repeat(100);
+        String expectedPreview = ("first line second line " + "x".repeat(100))
+                .substring(0, 77)
+                .stripTrailing() + "...";
+        String stepUuid = UUID.randomUUID().toString();
+
+        Allure.getLifecycle().startStep(stepUuid, new StepResult().setName("Type"));
+        try {
+            invoke(actions, "report",
+                    new Class[]{String.class, String.class, Status.class, byte[].class, RuntimeException.class, By.class, Object.class},
+                    Actions.ActionType.TYPE.name(), "Search box", Status.PASSED, null, null, By.id("search"),
+                    new CharSequence[]{typedText});
+
+            AtomicReference<StepResult> capturedStep = new AtomicReference<>();
+            Allure.getLifecycle().updateStep(capturedStep::set);
+            StepResult step = capturedStep.get();
+            Assert.assertEquals(step.getName(), "Type \"" + expectedPreview + "\"");
+
+            Map<String, String> parameters = new HashMap<>();
+            step.getParameters().forEach(parameter -> parameters.put(parameter.getName(), parameter.getValue()));
+            Assert.assertEquals(parameters.get("Element Name"), "Search box");
+            Assert.assertTrue(parameters.get("Element Locator").contains("search"));
+            Assert.assertEquals(parameters.get("Full Text"), typedText);
+            Assert.assertFalse(parameters.containsKey("locator"));
+            Assert.assertFalse(parameters.containsKey("text"));
+        } finally {
+            Allure.getLifecycle().stopStep(stepUuid);
         }
     }
 

--- a/shaft-engine/src/test/java/testPackage/mockedTests/MultipleElementsFailureTest.java
+++ b/shaft-engine/src/test/java/testPackage/mockedTests/MultipleElementsFailureTest.java
@@ -1,7 +1,7 @@
 package testPackage.mockedTests;
 
 import com.shaft.driver.SHAFT;
-import com.shaft.gui.internal.exceptions.MultipleElementsFoundException;
+import com.shaft.properties.internal.Properties;
 import org.openqa.selenium.By;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -33,6 +33,7 @@ public class MultipleElementsFailureTest {
     @BeforeMethod
 
     void beforeMethod() {
+        SHAFT.Properties.flags.set().forceCheckElementLocatorIsUnique(true);
         driver.set(new SHAFT.GUI.WebDriver());
     }
 
@@ -40,5 +41,6 @@ public class MultipleElementsFailureTest {
     @AfterMethod(alwaysRun = true)
     void afterMethod() {
         if (driver.get() != null) driver.get().quit();
+        Properties.clearForCurrentThread();
     }
 }

--- a/shaft-engine/src/test/java/testPackage/unitTests/JavaHelperUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/JavaHelperUnitTest.java
@@ -360,6 +360,12 @@ public class JavaHelperUnitTest {
         Assert.assertEquals(result, "Word", "Single lowercase word should be capitalized");
     }
 
+    @Test(description = "convertToSentenceCase: uppercase underscore input produces a compact sentence")
+    public void convertToSentenceCaseUppercaseUnderscoreShouldProduceCompactSentence() {
+        String result = JavaHelper.convertToSentenceCase("GET_TEXT");
+        Assert.assertEquals(result, "Get text", "Underscore-separated action names should not contain extra spaces");
+    }
+
     // ─── formatLocatorToString ─────────────────────────────────────────────────
 
     @Test(description = "formatLocatorToString: By.id should produce non-null description")

--- a/shaft-engine/src/test/java/testPackage/unitTests/PropertiesHelperMaximumPerformanceModeUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/PropertiesHelperMaximumPerformanceModeUnitTest.java
@@ -40,23 +40,28 @@ public class PropertiesHelperMaximumPerformanceModeUnitTest {
     }
 
     @Test
-    public void maximumPerformanceModeShouldDisableScreenshotHighlightingAndTelemetry() throws Exception {
+    public void maximumPerformanceModeShouldDisableScreenshotEnhancementsAndTelemetry() throws Exception {
         int originalMode = SHAFT.Properties.flags.maximumPerformanceMode();
         boolean originalScreenshotHighlightElements = SHAFT.Properties.visuals.screenshotParamsHighlightElements();
+        boolean originalScreenshotWatermark = SHAFT.Properties.visuals.screenshotParamsWatermark();
         boolean originalTelemetryEnabled = SHAFT.Properties.flags.telemetryEnabled();
 
         try {
             SHAFT.Properties.flags.set().maximumPerformanceMode(1);
             SHAFT.Properties.visuals.set().screenshotParamsHighlightElements(true);
+            SHAFT.Properties.visuals.set().screenshotParamsWatermark(true);
             SHAFT.Properties.flags.set().telemetryEnabled(true);
             invokeMaximumPerformanceModeOverride();
             Assert.assertFalse(SHAFT.Properties.visuals.screenshotParamsHighlightElements(),
                     "maximumPerformanceMode should disable screenshot highlighting to reduce overhead.");
+            Assert.assertFalse(SHAFT.Properties.visuals.screenshotParamsWatermark(),
+                    "maximumPerformanceMode should disable screenshot watermarking to avoid image re-encoding overhead.");
             Assert.assertFalse(SHAFT.Properties.flags.telemetryEnabled(),
                     "maximumPerformanceMode should disable telemetry to avoid complementary overhead.");
         } finally {
             SHAFT.Properties.flags.set().maximumPerformanceMode(originalMode);
             SHAFT.Properties.visuals.set().screenshotParamsHighlightElements(originalScreenshotHighlightElements);
+            SHAFT.Properties.visuals.set().screenshotParamsWatermark(originalScreenshotWatermark);
             SHAFT.Properties.flags.set().telemetryEnabled(originalTelemetryEnabled);
         }
     }

--- a/shaft-engine/src/test/java/testPackage/unitTests/ReportManagerHelperUnitTests.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/ReportManagerHelperUnitTests.java
@@ -229,7 +229,7 @@ public class ReportManagerHelperUnitTests {
     @Test
     public void attachmentMethodsShouldIgnoreNullEmptyAndEngineLogEntries() throws Exception {
         Method logAttachmentActionMethod = ReportManagerHelper.class.getDeclaredMethod(
-                "logAttachmentAction", String.class, String.class, java.io.ByteArrayOutputStream.class);
+                "logAttachmentAction", String.class, String.class, byte[].class);
         logAttachmentActionMethod.setAccessible(true);
 
         ReportManagerHelper.attach("Attachment", "Blank String", "   ");
@@ -238,7 +238,7 @@ public class ReportManagerHelperUnitTests {
         ReportManagerHelper.attach(Collections.emptyList());
         ReportManagerHelper.attach(Collections.singletonList(null));
         ReportManagerHelper.attach(Collections.singletonList(Collections.emptyList()));
-        logAttachmentActionMethod.invoke(null, "SHAFT Engine Logs", "engine", new java.io.ByteArrayOutputStream());
+        logAttachmentActionMethod.invoke(null, "SHAFT Engine Logs", "engine", new byte[0]);
 
         SHAFT.Validations.assertThat().object(ReportManagerHelper.getIssueCounter()).isEqualTo(0).perform();
     }

--- a/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
@@ -344,7 +344,9 @@ public class TerminalActionsUnitTest {
     public void performTerminalCommandsShouldRunFromChangedDirectory() throws Exception {
         Files.createDirectories(TEMP_DIR);
         TerminalActions terminal = TerminalActions.getInstance(false, false, true);
-        String log = terminal.performTerminalCommands(List.of("cd " + TEMP_DIR.toAbsolutePath(), "pwd"));
+        boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
+        String printWorkingDirectoryCommand = isWindows ? "(Get-Location).Path" : "pwd";
+        String log = terminal.performTerminalCommands(List.of("cd " + TEMP_DIR.toAbsolutePath(), printWorkingDirectoryCommand));
         Assert.assertTrue(log.contains(TEMP_DIR.toAbsolutePath().toString()),
                 "Expected command log to include changed working directory.");
     }
@@ -401,8 +403,8 @@ public class TerminalActionsUnitTest {
         }
     }
 
-    @Test(description = "asynchronous execution should force shutdownNow when timeout is zero")
-    public void performTerminalCommandShouldCoverAsyncTimeoutShutdownPath() {
+    @Test(description = "asynchronous execution should return without waiting when timeout is zero")
+    public void performTerminalCommandShouldReturnWithoutWaitingWhenAsyncTimeoutIsZero() {
         long originalTimeout = SHAFT.Properties.timeouts.shellSessionTimeout();
         try {
             SHAFT.Properties.timeouts.set().shellSessionTimeout(0);
@@ -419,6 +421,26 @@ public class TerminalActionsUnitTest {
         TerminalActions terminal = TerminalActions.getInstance(true, false, true);
         String log = terminal.performTerminalCommand("echo async");
         Assert.assertEquals(log, "", "Asynchronous execution should not capture command output.");
+    }
+
+    @Test(description = "asynchronous execution should still start the process")
+    public void performTerminalCommandShouldStartAsynchronousProcess() throws Exception {
+        Files.createDirectories(TEMP_DIR);
+        Path marker = TEMP_DIR.resolve("async-marker.txt").toAbsolutePath();
+        boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
+        String command = isWindows
+                ? "Set-Content -LiteralPath '" + marker + "' -Value async"
+                : "printf async > '" + marker + "'";
+
+        TerminalActions terminal = TerminalActions.getInstance(true, false, true);
+        String log = terminal.performTerminalCommand(command);
+
+        Assert.assertEquals(log, "", "Asynchronous execution should not capture command output.");
+        for (int attempt = 0; attempt < 20 && Files.notExists(marker); attempt++) {
+            Thread.sleep(100);
+        }
+        Assert.assertTrue(Files.exists(marker), "Expected asynchronous command to create marker file.");
+        Assert.assertTrue(Files.readString(marker).contains("async"));
     }
 
     @Test(description = "buildLongCommand should prepend docker exec wrapper for dockerized terminals")


### PR DESCRIPTION
## Summary

This PR applies the performance cleanup plan across the engine:

- starts asynchronous local terminal commands directly without allocating a scheduler per command
- moves small blocking IO helpers to virtual-thread execution where appropriate
- avoids repeated attachment byte-array copies and removes duplicate attachment dispatch code
- logs binary file writes by byte count instead of dumping full byte arrays
- disables screenshot watermarking in maximum performance mode
- refreshes the engine graphify output after source relationship changes

## Impact

The changes reduce avoidable thread allocation, byte-array copying, noisy binary logs, and screenshot re-encoding work in performance-oriented runs while preserving the existing public API surface.

## Validation

- `python scripts/ci/validate_agent_setup.py`
- `mvn -pl shaft-engine '-DskipTests' test-compile`
- focused Surefire run in a disposable copy: `TerminalActionsUnitTest`, `PropertiesHelperMaximumPerformanceModeUnitTest`, `ReportManagerHelperAttachmentIoUnitTest`, `AttachmentReporterUnitTest` (`67` tests, `0` failures)
- `graphify update . --force` for the engine graph after intentional source deletions
- `git diff --check`