### PR TITLE
[codex] Add deterministic AI test lifecycle artifacts

### DIFF
--- a/.memory/events.jsonl
+++ b/.memory/events.jsonl
@@ -55,3 +55,6 @@
 {"actor":"agent","event":"memory.updated","id":"workflow.run-local-e2e-jobs-in-a-dedicated-workflow","timestamp":"2026-06-17T21:30:16+03:00"}
 {"actor":"agent","event":"memory.updated","id":"workflow.run-local-e2e-jobs-in-a-dedicated-workflow","timestamp":"2026-06-17T23:37:27+03:00"}
 {"actor":"agent","event":"memory.created","id":"workflow.delegate-only-when-needed-for-correctness","timestamp":"2026-06-18T02:06:18+03:00"}
+{"actor":"agent","event":"memory.created","id":"fact.deterministic-ai-test-lifecycle-artifacts","timestamp":"2026-06-18T13:59:56+03:00"}
+{"actor":"agent","event":"memory.created","id":"decision.heal-ai-reranking-trigger-gated","timestamp":"2026-06-18T13:59:56+03:00"}
+{"actor":"agent","event":"relation.created","relation_id":"rel.decision-heal-ai-reranking-trigger-gated-affects-fact-deterministic-ai-test-lifecycle-artifacts","timestamp":"2026-06-18T13:59:56+03:00"}

--- a/.memory/memory/decisions/heal-ai-reranking-trigger-gated.json
+++ b/.memory/memory/decisions/heal-ai-reranking-trigger-gated.json
@@ -1,0 +1,38 @@
+{
+  "body_path": "memory/decisions/heal-ai-reranking-trigger-gated.md",
+  "content_hash": "sha256:e6b1d484cee595024f8c9e74784c9284a78cd6d13c6d69dd35e4f013c92b90b0",
+  "created_at": "2026-06-18T13:59:56+03:00",
+  "evidence": [
+    {
+      "id": "shaft-heal/src/main/java/com/shaft/heal/internal/ShaftHealingProvider.java",
+      "kind": "file"
+    },
+    {
+      "id": "shaft-engine/src/main/resources/properties/default/custom.properties",
+      "kind": "file"
+    }
+  ],
+  "facets": {
+    "applies_to": [
+      "shaft-heal/src/main/java/com/shaft/heal/internal/ShaftHealingProvider.java",
+      "shaft-engine/src/main/java/com/shaft/properties/internal/Healing.java"
+    ],
+    "category": "decision-rationale"
+  },
+  "id": "decision.heal-ai-reranking-trigger-gated",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Implement deterministic-first AI enhancement artifacts for SHAFT test lifecycle"
+  },
+  "status": "active",
+  "tags": [],
+  "title": "Heal AI reranking is trigger-gated",
+  "type": "decision",
+  "updated_at": "2026-06-18T13:59:56+03:00"
+}

--- a/.memory/memory/decisions/heal-ai-reranking-trigger-gated.md
+++ b/.memory/memory/decisions/heal-ai-reranking-trigger-gated.md
@@ -1,0 +1,1 @@
+When healing.ai.enabled=true, the default healing.ai.trigger=ambiguous keeps deterministic recovery first and calls AI reranking only for ambiguous or below-threshold candidate sets; other allowed triggers are never, below-threshold, and always.

--- a/.memory/memory/facts/deterministic-ai-test-lifecycle-artifacts.json
+++ b/.memory/memory/facts/deterministic-ai-test-lifecycle-artifacts.json
@@ -1,0 +1,43 @@
+{
+  "body_path": "memory/facts/deterministic-ai-test-lifecycle-artifacts.md",
+  "content_hash": "sha256:eb871d64c60fdd412dbde58813686ae31e3f79b5578d27cfe2a0619e1c8170b7",
+  "created_at": "2026-06-18T13:59:56+03:00",
+  "evidence": [
+    {
+      "id": "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java",
+      "kind": "file"
+    },
+    {
+      "id": "shaft-doctor/src/main/java/com/shaft/doctor/DoctorAnalyzer.java",
+      "kind": "file"
+    },
+    {
+      "id": "shaft-mcp/src/main/java/com/shaft/mcp/McpCaptureReplayResult.java",
+      "kind": "file"
+    }
+  ],
+  "facets": {
+    "applies_to": [
+      "shaft-capture/src/main/java/com/shaft/capture/generate/",
+      "shaft-doctor/src/main/java/com/shaft/doctor/",
+      "shaft-mcp/src/main/java/com/shaft/mcp/"
+    ],
+    "category": "product-feature"
+  },
+  "id": "fact.deterministic-ai-test-lifecycle-artifacts",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Implement deterministic-first AI enhancement artifacts for SHAFT test lifecycle"
+  },
+  "status": "active",
+  "tags": [],
+  "title": "Deterministic AI test lifecycle artifacts",
+  "type": "fact",
+  "updated_at": "2026-06-18T13:59:56+03:00"
+}

--- a/.memory/memory/facts/deterministic-ai-test-lifecycle-artifacts.md
+++ b/.memory/memory/facts/deterministic-ai-test-lifecycle-artifacts.md
@@ -1,0 +1,1 @@
+Capture generation writes capture-review.json with deterministic readiness, blockers, risks, and suggestions; Doctor writes doctor-triage.* and execution-intelligence.* summaries; MCP capture generation exposes reviewPath.

--- a/.memory/relations/decision-heal-ai-reranking-trigger-gated-affects-fact-deterministic-ai-test-lifecycle-artifacts.json
+++ b/.memory/relations/decision-heal-ai-reranking-trigger-gated-affects-fact-deterministic-ai-test-lifecycle-artifacts.json
@@ -1,0 +1,11 @@
+{
+  "confidence": "medium",
+  "content_hash": "sha256:baacfd909f3a3cf707f7c29fa9da8e33933ce43541784e1fbe9f594010e7ae26",
+  "created_at": "2026-06-18T13:59:56+03:00",
+  "from": "decision.heal-ai-reranking-trigger-gated",
+  "id": "rel.decision-heal-ai-reranking-trigger-gated-affects-fact-deterministic-ai-test-lifecycle-artifacts",
+  "predicate": "affects",
+  "status": "active",
+  "to": "fact.deterministic-ai-test-lifecycle-artifacts",
+  "updated_at": "2026-06-18T13:59:56+03:00"
+}

--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -669,5 +669,20 @@
   "667": "Community 667",
   "668": "Community 668",
   "669": "Community 669",
-  "670": "Community 670"
+  "670": "Community 670",
+  "671": "Community 671",
+  "672": "Community 672",
+  "673": "Community 673",
+  "674": "Community 674",
+  "675": "Community 675",
+  "676": "Community 676",
+  "677": "Community 677",
+  "678": "Community 678",
+  "679": "Community 679",
+  "680": "Community 680",
+  "681": "Community 681",
+  "682": "Community 682",
+  "683": "Community 683",
+  "684": "Community 684",
+  "685": "Community 685"
 }

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - SHAFT_ENGINE  (2026-06-18)
 
 ## Corpus Check
-- 1260 files · ~531,007 words
+- 1271 files · ~533,369 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 12006 nodes · 30360 edges · 671 communities (598 shown, 73 thin omitted)
-- Extraction: 80% EXTRACTED · 20% INFERRED · 0% AMBIGUOUS · INFERRED: 6010 edges (avg confidence: 0.8)
+- 12152 nodes · 30636 edges · 686 communities (603 shown, 83 thin omitted)
+- Extraction: 80% EXTRACTED · 20% INFERRED · 0% AMBIGUOUS · INFERRED: 6040 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `0de651f9`
+- Built from commit: `f3c1362f`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -449,6 +449,7 @@
 - [[_COMMUNITY_Community 431|Community 431]]
 - [[_COMMUNITY_Community 432|Community 432]]
 - [[_COMMUNITY_Community 433|Community 433]]
+- [[_COMMUNITY_Community 434|Community 434]]
 - [[_COMMUNITY_Community 435|Community 435]]
 - [[_COMMUNITY_Community 436|Community 436]]
 - [[_COMMUNITY_Community 437|Community 437]]
@@ -571,6 +572,7 @@
 - [[_COMMUNITY_Community 555|Community 555]]
 - [[_COMMUNITY_Community 556|Community 556]]
 - [[_COMMUNITY_Community 557|Community 557]]
+- [[_COMMUNITY_Community 558|Community 558]]
 - [[_COMMUNITY_Community 559|Community 559]]
 - [[_COMMUNITY_Community 560|Community 560]]
 - [[_COMMUNITY_Community 561|Community 561]]
@@ -589,14 +591,24 @@
 - [[_COMMUNITY_Community 578|Community 578]]
 - [[_COMMUNITY_Community 579|Community 579]]
 - [[_COMMUNITY_Community 669|Community 669]]
+- [[_COMMUNITY_Community 671|Community 671]]
+- [[_COMMUNITY_Community 672|Community 672]]
+- [[_COMMUNITY_Community 673|Community 673]]
+- [[_COMMUNITY_Community 674|Community 674]]
+- [[_COMMUNITY_Community 675|Community 675]]
+- [[_COMMUNITY_Community 676|Community 676]]
+- [[_COMMUNITY_Community 677|Community 677]]
+- [[_COMMUNITY_Community 678|Community 678]]
+- [[_COMMUNITY_Community 679|Community 679]]
+- [[_COMMUNITY_Community 680|Community 680]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `SHAFT` - 270 edges
+1. `SHAFT` - 271 edges
 2. `RestActionsComprehensiveTests` - 99 edges
 3. `Test` - 98 edges
 4. `IOException` - 97 edges
 5. `ReportManagerHelper` - 75 edges
-6. `CaptureGenerator` - 66 edges
+6. `CaptureGenerator` - 70 edges
 7. `JavaHelperUnitTest` - 57 edges
 8. `Test` - 57 edges
 9. `Actions` - 53 edges
@@ -617,23 +629,23 @@
 ## Import Cycles
 - None detected.
 
-## Communities (671 total, 73 thin omitted)
+## Communities (686 total, 83 thin omitted)
 
 ### Community 0 - "Community 0"
 Cohesion: 0.04
 Nodes (6): RestActionsComprehensiveTests, ComparisonType, InputStream, SuppressWarnings, BeforeMethod, Test
 
 ### Community 1 - "Community 1"
-Cohesion: 0.05
-Nodes (18): ChannelSftp, TerminalActions, LocalShellTests, ProcessBuilder, Session, SftpTransferDirection, Boolean, BufferedReader (+10 more)
+Cohesion: 0.08
+Nodes (4): AfterMethod, SuppressWarnings, Test, TerminalActionsUnitTest
 
 ### Community 2 - "Community 2"
-Cohesion: 0.06
-Nodes (51): DoctorCli, flag(), optionalPath(), parse(), path(), pathRequired(), paths(), pathsRequired() (+43 more)
+Cohesion: 0.20
+Nodes (12): DoctorAnalyzerTest, Arguments, CauseCategory, DoctorAnalysisRequest, DoctorAnalysisResult, List, MethodSource, ParameterizedTest (+4 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.06
-Nodes (35): $, Cucumber, CucumberHelper, StandaloneAssertions, StandaloneVerifications, WebDriverAssertions, WebDriverVerifications, WizardHelpers (+27 more)
+Nodes (25): Cucumber, CucumberHelper, Mobile, SetProperty, PropertiesManagerTests, CucumberTests, List, Status (+17 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.07
@@ -641,7 +653,7 @@ Nodes (6): Pilot, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 5 - "Community 5"
 Cohesion: 0.06
-Nodes (30): AndroidDriver, FileUploadDownloadTest, getValue(), KeyboardKeys(), TouchActions, ElementActionsHelper, ImmutableMap, IOSDriver (+22 more)
+Nodes (31): AndroidDriver, FileUploadDownloadTest, getValue(), KeyboardKeys(), TouchActions, ElementActionsHelper, ImmutableMap, ScreenOrientation (+23 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.06
@@ -649,27 +661,27 @@ Nodes (14): CSVFileManager, CSVFileManagerTest, List, Map, String, BeforeMethod,
 
 ### Community 7 - "Community 7"
 Cohesion: 0.08
-Nodes (30): ArtifactPaths, AssertionSuggestion, CaptureGenerationReport, CaptureGenerator, failure(), withUnsupported(), GenerationState, Sequence (+22 more)
+Nodes (31): ArtifactPaths, AssertionSuggestion, CaptureGenerationReport, CaptureReview, CaptureGenerator, failure(), withUnsupported(), GenerationState (+23 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.05
 Nodes (25): ApiPerformanceExecutionReport, Paths, SetProperty, Performance, SetProperty, PathsTests, DefaultValue, Key (+17 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.06
-Nodes (16): Jira, SetProperty, Mobile, SetProperty, PropertiesManagerTests, JiraTests, DefaultValue, Key (+8 more)
+Cohesion: 0.27
+Nodes (4): Jira, DefaultValue, Key, SetProperty
 
 ### Community 10 - "Community 10"
 Cohesion: 0.07
 Nodes (23): BrowserStackSdkHelper, BrowserStackSdkTests, List, Map, Object, String, AfterMethod, BeforeMethod (+15 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.08
-Nodes (15): AsyncAppender, ReportManagerHelper, TestCaseStarted, Boolean, ByteArrayOutputStream, CheckpointStatus, InputStream, Level (+7 more)
+Cohesion: 0.10
+Nodes (13): AsyncAppender, ReportManagerHelper, ByteArrayOutputStream, CheckpointStatus, InputStream, Level, List, Object (+5 more)
 
 ### Community 12 - "Community 12"
-Cohesion: 0.09
-Nodes (23): KeyboardKeys, LocatorOperation, MobileService, McpMobileAccessibilityTree, McpMobileActionResult, McpMobileContextSnapshot, McpMobileSessionResult, BrowserType (+15 more)
+Cohesion: 0.08
+Nodes (27): Autowired, KeyboardKeys, LocatorOperation, MobileService, McpMobileAccessibilityTree, McpMobileActionResult, McpMobileContextSnapshot, McpMobileRecordingService (+19 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.07
@@ -688,55 +700,55 @@ Cohesion: 0.10
 Nodes (67): CompletedProcess, adoptium_os_arch(), application_data_root(), architecture(), await_probe_response(), choose_client(), command_path(), configuration_path() (+59 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.08
-Nodes (24): HealingSupport, WebDriverListener, InvocationTargetException, nativePlatform(), Navigation, Alert, By, Method (+16 more)
+Cohesion: 0.14
+Nodes (13): WebDriverListener, Navigation, Alert, By, Method, Object, String, URL (+5 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.07
-Nodes (16): AfterSuite, ApiPerformanceReportTest, SwaggerContractTest, testPostRequest, TestUpload, ParametersType, AfterMethod, BeforeMethod (+8 more)
+Cohesion: 0.14
+Nodes (5): AfterSuite, ApiPerformanceReportTest, AfterMethod, BeforeMethod, Test
 
 ### Community 19 - "Community 19"
-Cohesion: 0.08
-Nodes (21): RequestBuilder, RequestBuilderTests, AuthenticationType, API, ContentType, Exception, Map, Object (+13 more)
+Cohesion: 0.09
+Nodes (20): RequestBuilder, RequestBuilderTests, AuthenticationType, API, ContentType, Exception, Map, Object (+12 more)
 
 ### Community 20 - "Community 20"
 Cohesion: 0.09
-Nodes (29): dataString(), E, LocatorSignal, empty(), merge(), MouseButton, CaptureEventPipeline, SafePage (+21 more)
+Nodes (27): dataString(), E, LocatorSignal, merge(), MouseButton, CaptureEventPipeline, SafePage, SafeTarget (+19 more)
 
 ### Community 21 - "Community 21"
-Cohesion: 0.05
-Nodes (17): WebDriverElementValidationsBuilder, GuiVerificationTests, By, NativeValidationsBuilder, String, StringBuilder, ValidationCategory, ValidationsExecutor (+9 more)
+Cohesion: 0.13
+Nodes (4): AfterMethod, BeforeMethod, Test, NegativeValidationsTests
 
 ### Community 22 - "Community 22"
-Cohesion: 0.06
-Nodes (15): NativeValidationsBuilder, FileValidationsBuilder, Object, Override, RestValidationsBuilder, String, SuppressWarnings, ValidationsBuilder (+7 more)
+Cohesion: 0.10
+Nodes (3): AfterMethod, Test, NativeValidationsBuilderUnitTest
 
 ### Community 23 - "Community 23"
-Cohesion: 0.07
-Nodes (27): empty(), DoctorHashing, disabled(), Metadata, asCacheHit(), disabled(), empty(), defaults() (+19 more)
+Cohesion: 0.08
+Nodes (25): empty(), disabled(), Metadata, asCacheHit(), disabled(), empty(), defaults(), lower() (+17 more)
 
 ### Community 24 - "Community 24"
-Cohesion: 0.07
-Nodes (9): TextDirectionValidationsBuilder, E2ECoverageTests, NativeValidationsBuilder, ValidationsExecutor, AfterMethod, BeforeMethod, Test, TextDirection (+1 more)
+Cohesion: 0.08
+Nodes (5): E2ECoverageTests, AfterMethod, BeforeMethod, Test, TextLanguageValidationsBuilder
 
 ### Community 25 - "Community 25"
-Cohesion: 0.07
-Nodes (16): PathParamTest, BasicAPITests, GraphqlRequestTests, AfterClass, BeforeClass, Test, AfterClass, BeforeClass (+8 more)
+Cohesion: 0.06
+Nodes (19): PathParamTest, SwaggerContractTest, TestUpload, GraphqlRequestTests, AfterClass, BeforeClass, Test, AfterClass (+11 more)
 
 ### Community 26 - "Community 26"
-Cohesion: 0.10
-Nodes (24): AllureSnapshot, AllureVerdict, DoctorRepairPublicationRequest, ExistingPullRequest, PatchManifestEntry, changedSince(), DoctorRepairService, validationPassed() (+16 more)
+Cohesion: 0.05
+Nodes (47): AllureSnapshot, AllureVerdict, DoctorRepairPublicationRequest, ExistingPullRequest, GuardedPatch, PatchManifestEntry, RecordingRunner, changedSince() (+39 more)
 
 ### Community 27 - "Community 27"
 Cohesion: 0.12
-Nodes (14): FileActions, Boolean, Collection, File, InputStream, String, SuppressWarnings, TerminalActions (+6 more)
+Nodes (14): FileActions, Boolean, Collection, File, String, SuppressWarnings, TerminalActions, URL (+6 more)
 
 ### Community 28 - "Community 28"
-Cohesion: 0.08
-Nodes (14): DriverFactoryHelperCoverageUnitTest, TestableDriverFactoryHelper, AfterMethod, AtomicInteger, CountDownLatch, DriverFactoryHelper, DriverType, Method (+6 more)
+Cohesion: 0.06
+Nodes (19): FlutterTest, DriverFactoryHelperCoverageUnitTest, TestableDriverFactoryHelper, OptionsManager, AfterMethod, AtomicInteger, CountDownLatch, DriverFactoryHelper (+11 more)
 
 ### Community 29 - "Community 29"
-Cohesion: 0.10
+Cohesion: 0.11
 Nodes (11): OptionsManagerCoverageUnitTest, MobileRecordingServiceTest, Role, Override, AfterMethod, BeforeMethod, Test, AfterMethod (+3 more)
 
 ### Community 30 - "Community 30"
@@ -744,16 +756,16 @@ Cohesion: 0.08
 Nodes (6): Flags, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 31 - "Community 31"
-Cohesion: 0.09
+Cohesion: 0.10
 Nodes (11): AfterMethod, BeforeMethod, Class, List, Object, Path, String, T (+3 more)
 
 ### Community 33 - "Community 33"
-Cohesion: 0.10
-Nodes (15): AccessibilityConfig, AccessibilityHelper, AccessibilityResult, AxeBuilder, JSONArray, JSONObject, AccessibilityResult, Integer (+7 more)
+Cohesion: 0.12
+Nodes (14): AccessibilityConfig, AccessibilityHelper, AccessibilityResult, JSONArray, JSONObject, AccessibilityResult, Integer, List (+6 more)
 
 ### Community 34 - "Community 34"
-Cohesion: 0.08
-Nodes (11): NumberValidationsBuilder, Number, Object, Override, RestValidationsBuilder, SuppressWarnings, ValidationsBuilder, ValidationsExecutor (+3 more)
+Cohesion: 0.10
+Nodes (6): NumberValidationsBuilder, Number, ValidationsExecutor, AfterMethod, Test, NumberValidationsBuilderUnitTest
 
 ### Community 35 - "Community 35"
 Cohesion: 0.08
@@ -765,11 +777,11 @@ Nodes (28): DataTableArgument, EmbedEvent, HookTestStep, CucumberFeatureListener
 
 ### Community 37 - "Community 37"
 Cohesion: 0.10
-Nodes (7): AfterMethod, Class, Object, Path, String, Test, AllureManagerUnitTest
+Nodes (6): Class, Object, Path, String, Test, AllureManagerUnitTest
 
 ### Community 38 - "Community 38"
-Cohesion: 0.08
-Nodes (14): RestValidationsBuilder, JsonCompareWithSpecialCharactersTests, NativeValidationsBuilder, NumberValidationsBuilder, Object, String, StringBuilder, ValidationCategory (+6 more)
+Cohesion: 0.17
+Nodes (9): RestValidationsBuilder, JsonCompareWithSpecialCharactersTests, NativeValidationsBuilder, Object, String, StringBuilder, ValidationCategory, ValidationsExecutor (+1 more)
 
 ### Community 39 - "Community 39"
 Cohesion: 0.08
@@ -785,39 +797,39 @@ Nodes (13): AssertApiResponseEqualsTests, MatchJsonSchemaTests, ApiActionsMocked
 
 ### Community 42 - "Community 42"
 Cohesion: 0.06
-Nodes (19): SHAFT, FileInputStream, AppiumMobileConsumer, BrowserStackSdkConsumer, JUnitWebConsumer, LegacyCoordinateConsumer, TestNgWebConsumer, IOException (+11 more)
+Nodes (23): testPostRequest, Constructor, SHAFT, AppiumMobileConsumer, BrowserStackSdkConsumer, JUnitWebConsumer, LegacyCoordinateConsumer, TestNgWebConsumer (+15 more)
 
 ### Community 43 - "Community 43"
-Cohesion: 0.08
-Nodes (24): Constructor, IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, IResultListener2 (+16 more)
+Cohesion: 0.09
+Nodes (20): IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, IResultListener2, ISuiteListener (+12 more)
 
 ### Community 44 - "Community 44"
-Cohesion: 0.15
-Nodes (8): AssertionSteps, PDFTests, ValidationsBuilderTests, String, Then, ThreadLocal, WebDriver, String
+Cohesion: 0.22
+Nodes (4): AssertionSteps, String, Then, String
 
 ### Community 45 - "Community 45"
-Cohesion: 0.16
-Nodes (16): CollectionState, EvidenceCollector, FilesSize, CollectionState, DoctorRedactor, DefaultPrettyPrinter, DoctorAnalysisRequest, EvidenceBundle (+8 more)
+Cohesion: 0.17
+Nodes (15): CollectionState, EvidenceCollector, CollectionState, DoctorRedactor, DefaultPrettyPrinter, DoctorAnalysisRequest, EvidenceBundle, EvidenceCategory (+7 more)
 
 ### Community 46 - "Community 46"
-Cohesion: 0.09
-Nodes (19): CaptureFixtures, CaptureJsonCodecTest, CaptureGeneratorTest, PageContext, BrowserMetadata, CaptureEvent, CaptureSession, ElementSnapshot (+11 more)
+Cohesion: 0.11
+Nodes (21): allows(), ApprovalPolicy(), denyAll(), CaptureFixtures, CaptureGeneratorTest, PageContext, BrowserMetadata, CaptureEvent (+13 more)
 
 ### Community 47 - "Community 47"
 Cohesion: 0.09
 Nodes (8): ThreadLocalPropertiesManager, Properties, String, AfterMethod, Path, String, Test, ThreadLocalPropertiesTest
 
 ### Community 48 - "Community 48"
-Cohesion: 0.13
-Nodes (16): RestActions, RequestSpecBuilder, RestAssuredConfig, API, ArrayNode, Boolean, ContentType, List (+8 more)
+Cohesion: 0.11
+Nodes (18): RestActions, RequestSpecBuilder, RestAssuredConfig, RequestType, RestActions, API, ArrayNode, Boolean (+10 more)
 
 ### Community 49 - "Community 49"
-Cohesion: 0.10
-Nodes (12): ImageProcessingActionsCoverageUnitTest, AfterMethod, BeforeMethod, BufferedImage, Color, DataProvider, Map, Method (+4 more)
+Cohesion: 0.07
+Nodes (21): ImageProcessingActions, ImageProcessingActionsCoverageUnitTest, Boolean, By, File, Integer, List, String (+13 more)
 
 ### Community 50 - "Community 50"
-Cohesion: 0.14
-Nodes (4): AllureManager, Path, Process, String
+Cohesion: 0.06
+Nodes (24): BooleanSupplier, Future, AllureManager, Internal, expired(), InstantDeadline(), ManagedCaptureRecorderBrowserTest, Duration (+16 more)
 
 ### Community 51 - "Community 51"
 Cohesion: 0.08
@@ -833,18 +845,18 @@ Nodes (12): AttachmentFormat, AttachmentReporter, ByteArrayOutputStream, Path, S
 
 ### Community 54 - "Community 54"
 Cohesion: 0.09
-Nodes (10): BrowserActions, Cookie, DriverFactoryHelper, Override, Screenshots, Set, String, SuppressWarnings (+2 more)
+Nodes (6): BrowserActions, Cookie, Override, Set, String, SuppressWarnings
 
 ### Community 55 - "Community 55"
 Cohesion: 0.12
-Nodes (14): Capabilities, DriverFactoryHelper, Class, DriverType, List, MutableCapabilities, Object, Runnable (+6 more)
+Nodes (15): Capabilities, DriverFactoryHelper, IOSDriver, Class, DriverType, List, MutableCapabilities, Object (+7 more)
 
 ### Community 56 - "Community 56"
-Cohesion: 0.10
-Nodes (17): ElementLookup, GetElementInformation, Actions, NoSuchElementException, AppiumDriver, DriverFactoryHelper, Duration, Function (+9 more)
+Cohesion: 0.21
+Nodes (5): ElementLookup, GetElementInformation, Actions, JavascriptExecutor, WebElement
 
 ### Community 57 - "Community 57"
-Cohesion: 0.08
+Cohesion: 0.10
 Nodes (4): ValidationTests, AfterMethod, BeforeMethod, Test
 
 ### Community 58 - "Community 58"
@@ -868,16 +880,16 @@ Cohesion: 0.10
 Nodes (23): DoctorRepairProposalResult, DoctorRepairService, HealingLocatorProposalRequest, DoctorService, DoctorServiceTest, McpDoctorRemediationService, ApprovalPolicy, Diagnosis (+15 more)
 
 ### Community 63 - "Community 63"
-Cohesion: 0.15
-Nodes (9): ClipboardAction, GetElementInformation, ActionType, Beta, By, ClipboardAction, Override, Step (+1 more)
+Cohesion: 0.21
+Nodes (7): GetElementInformation, ActionType, Beta, By, Override, Step, String
 
 ### Community 64 - "Community 64"
-Cohesion: 0.12
-Nodes (16): ActionsCoverageUnitTest, RecordingActions, RecordingActions, ActionType, AfterMethod, BeforeMethod, By, Class (+8 more)
+Cohesion: 0.07
+Nodes (22): UnitTestsRestActions, UnitTestsSHAFT, AsyncElementActionsCoverageUnitTest, ActionsCoverageUnitTest, RecordingActions, RecordingActions, Test, ActionType (+14 more)
 
 ### Community 65 - "Community 65"
 Cohesion: 0.12
-Nodes (15): AllureListenerCoverageUnitTest, Throwable, AfterMethod, BeforeMethod, ITestResult, List, Path, String (+7 more)
+Nodes (14): AllureListenerCoverageUnitTest, Throwable, AfterMethod, BeforeMethod, ITestResult, List, Path, String (+6 more)
 
 ### Community 66 - "Community 66"
 Cohesion: 0.15
@@ -904,28 +916,28 @@ Cohesion: 0.05
 Nodes (42): additionalProperties, default, description, examples, $id, title, type, default (+34 more)
 
 ### Community 72 - "Community 72"
-Cohesion: 0.10
-Nodes (11): UnitTestsRestActions, UnitTestsSHAFT, HealingActionsIntegrationTest, AfterMethod, BeforeMethod, DataProvider, Object, String (+3 more)
+Cohesion: 0.18
+Nodes (7): HealingActionsIntegrationTest, AfterMethod, BeforeMethod, DataProvider, Object, String, Test
 
 ### Community 73 - "Community 73"
 Cohesion: 0.11
 Nodes (41): expand_globs(), issue(), local_link_targets(), markdown_body(), normalized_paragraphs(), parse_frontmatter(), quoted_yaml_value(), Keep the consolidated guidance below the approved baseline reduction. (+33 more)
 
 ### Community 74 - "Community 74"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (14): ElementActionsHelper, TextDetectionStrategy(), Boolean, By, Class, ClipboardAction, HealingResolution, List (+6 more)
 
 ### Community 75 - "Community 75"
-Cohesion: 0.15
-Nodes (19): CaptureControlClient, CaptureCli, flag(), parse(), path(), pathRequired(), required(), value() (+11 more)
+Cohesion: 0.14
+Nodes (20): CaptureControlClient, CapturePrivacyClassifier, CaptureCli, flag(), parse(), path(), pathRequired(), required() (+12 more)
 
 ### Community 76 - "Community 76"
 Cohesion: 0.13
 Nodes (15): ShaftHeal, ShaftHealingProviderTest, HealingReport, Optional, AfterMethod, AppiumDriver, BeforeMethod, DataProvider (+7 more)
 
 ### Community 77 - "Community 77"
-Cohesion: 0.11
-Nodes (3): SetProperty, Boolean, String
+Cohesion: 0.08
+Nodes (7): LambdaTest, SetProperty, Boolean, DefaultValue, Key, SetProperty, String
 
 ### Community 78 - "Community 78"
 Cohesion: 0.12
@@ -937,15 +949,15 @@ Nodes (40): additionalProperties, enum, pattern, type, pattern, type, items, typ
 
 ### Community 80 - "Community 80"
 Cohesion: 0.10
-Nodes (12): DriverFactoryHelper, OptionsManager, AfterMethod, AtomicInteger, CountDownLatch, DriverType, Method, MutableCapabilities (+4 more)
+Nodes (11): DriverFactoryHelper, AfterMethod, AtomicInteger, CountDownLatch, DriverType, Method, MutableCapabilities, Override (+3 more)
 
 ### Community 81 - "Community 81"
-Cohesion: 0.10
+Cohesion: 0.11
 Nodes (11): IIOMetadataNode, AnimatedGifManager, GifSession, ImageOutputStream, ImageWriter, getType(), RenderedImage, Screenshots (+3 more)
 
 ### Community 82 - "Community 82"
-Cohesion: 0.23
-Nodes (13): ValidationsHelper2, LinkedHashMap, AssertionError, By, List, Number, NumbersComparativeRelation, Object (+5 more)
+Cohesion: 0.05
+Nodes (45): Actions, CheckpointType, CheckpointCounter, ValidationsExecutor, SilentElementReader, ValidationsHelper2, ValidationsHelper2CoverageUnitTest, ValidationsHelper (+37 more)
 
 ### Community 83 - "Community 83"
 Cohesion: 0.13
@@ -960,8 +972,8 @@ Cohesion: 0.14
 Nodes (14): ClassifiedUpload, CapturePrivacyClassifier, CapturePrivacyClassifierTest, SanitizedAttributes, SanitizedText, CapturePrivacyPolicy, ClassifiedValue, List (+6 more)
 
 ### Community 87 - "Community 87"
-Cohesion: 0.10
-Nodes (15): HasCdp, Image, ScreenshotHelper, ScreenshotHelperCoverageUnitTest, Boolean, BufferedImage, String, SuppressWarnings (+7 more)
+Cohesion: 0.14
+Nodes (10): Image, ScreenshotHelperCoverageUnitTest, BufferedImage, String, AfterMethod, BeforeMethod, Color, Object (+2 more)
 
 ### Community 88 - "Community 88"
 Cohesion: 0.05
@@ -972,12 +984,12 @@ Cohesion: 0.07
 Nodes (14): be(), Bt(), Dt(), $e(), Ee(), ft(), ke(), l() (+6 more)
 
 ### Community 90 - "Community 90"
-Cohesion: 0.14
-Nodes (10): ElementActions, Actions, By, DriverFactoryHelper, List, Map, Override, String (+2 more)
+Cohesion: 0.06
+Nodes (26): ElementActions, FrameTests, Actions, By, DriverFactoryHelper, List, Map, Override (+18 more)
 
 ### Community 91 - "Community 91"
-Cohesion: 0.16
-Nodes (17): CandidateExtractor, LocatorProposal, validateUrl(), SearchContext, String, By, Collection, HealingConfiguration (+9 more)
+Cohesion: 0.15
+Nodes (18): CandidateExtractor, LocatorProposal, nativePlatform(), validateUrl(), SearchContext, String, By, Collection (+10 more)
 
 ### Community 92 - "Community 92"
 Cohesion: 0.09
@@ -992,15 +1004,15 @@ Cohesion: 0.10
 Nodes (4): AfterMethod, BeforeClass, Test, YAMLFileManagerUnitTest
 
 ### Community 95 - "Community 95"
-Cohesion: 0.15
-Nodes (15): AiExecutionServiceTest, StubProvider, denyAll(), AiCapabilities, AiExecutionService, AiProviderAvailability, AiProviderRegistry, AiRequest (+7 more)
+Cohesion: 0.16
+Nodes (14): AiExecutionServiceTest, StubProvider, AiCapabilities, AiExecutionService, AiProviderAvailability, AiProviderRegistry, AiRequest, AiResponse (+6 more)
 
 ### Community 96 - "Community 96"
 Cohesion: 0.17
 Nodes (18): DoctorAiAnalysisServiceTest, EnumSource, from(), DoctorAnalysisResult, DoctorAnalysisSummary, AiRequest, AiResponse, AiResponseStatus (+10 more)
 
 ### Community 97 - "Community 97"
-Cohesion: 0.19
+Cohesion: 0.18
 Nodes (11): AlertActionsContext, AfterMethod, Alert, AlertActions, BeforeMethod, Object, String, Test (+3 more)
 
 ### Community 98 - "Community 98"
@@ -1009,22 +1021,22 @@ Nodes (11): FluentWait, ElementsHelperCoverageUnitTest, MockedStatic, AfterMetho
 
 ### Community 99 - "Community 99"
 Cohesion: 0.11
-Nodes (11): PropertyFileManager, File, HashMap, Map, Object, Properties, String, AfterMethod (+3 more)
+Nodes (11): PropertyFileManager, File, HashMap, Map, MutableCapabilities, Object, Properties, String (+3 more)
 
 ### Community 100 - "Community 100"
-Cohesion: 0.20
+Cohesion: 0.19
 Nodes (9): ElementService, LocatorOperation, By, Deprecated, LocatorOperation, locatorStrategy, String, Tool (+1 more)
 
 ### Community 101 - "Community 101"
-Cohesion: 0.13
-Nodes (17): AbstractHttpAiProvider, AiCapabilities, AiRequest, AiResponse, AiResponseStatus, AiUsage, Function, HttpClient (+9 more)
+Cohesion: 0.14
+Nodes (16): AbstractHttpAiProvider, AiCapabilities, AiRequest, AiResponse, AiResponseStatus, AiUsage, Function, HttpClient (+8 more)
 
 ### Community 102 - "Community 102"
 Cohesion: 0.17
 Nodes (17): DeterministicRuleEngine, Confidence, Finding, Remediation, RetrySummary, RuleMatch, CauseCategory, Diagnosis (+9 more)
 
 ### Community 103 - "Community 103"
-Cohesion: 0.11
+Cohesion: 0.12
 Nodes (14): DriverFactory, DriverType(), DatabaseActions, DatabaseType, DriverFactoryHelper, DriverType, MutableCapabilities, RestActions (+6 more)
 
 ### Community 104 - "Community 104"
@@ -1032,12 +1044,12 @@ Cohesion: 0.13
 Nodes (6): Healing, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 105 - "Community 105"
-Cohesion: 0.15
-Nodes (4): LambdaTest, DefaultValue, Key, SetProperty
+Cohesion: 0.12
+Nodes (12): ChannelSftp, TerminalActions, ProcessBuilder, Session, SftpTransferDirection, Boolean, BufferedReader, Deprecated (+4 more)
 
 ### Community 106 - "Community 106"
-Cohesion: 0.11
-Nodes (10): AfterMethod, BeforeMethod, Issue, Issues, ITestResult, String, Test, TmsLink (+2 more)
+Cohesion: 0.10
+Nodes (11): Method, AfterMethod, BeforeMethod, Issue, Issues, ITestResult, String, Test (+3 more)
 
 ### Community 107 - "Community 107"
 Cohesion: 0.06
@@ -1049,14 +1061,14 @@ Nodes (35): add_text_child(), child_text(), copy_dependency_metadata(), create_d
 
 ### Community 109 - "Community 109"
 Cohesion: 0.13
-Nodes (12): CapturePrivacyClassifier, ManagedCaptureRecorder, BrowserMetadata, CapturePrivacyPolicy, CaptureStartRequest, CaptureStatus, CheckpointKind, Map (+4 more)
+Nodes (11): ManagedCaptureRecorder, BrowserMetadata, CapturePrivacyPolicy, CaptureStartRequest, CaptureStatus, CheckpointKind, Map, MutableCapabilities (+3 more)
 
 ### Community 110 - "Community 110"
 Cohesion: 0.13
 Nodes (3): YAMLFileManagerTests, BeforeMethod, Test
 
 ### Community 111 - "Community 111"
-Cohesion: 0.14
+Cohesion: 0.15
 Nodes (15): LauncherSession, Override, AfterMethod, BeforeMethod, Duration, List, Object, Optional (+7 more)
 
 ### Community 112 - "Community 112"
@@ -1088,8 +1100,8 @@ Cohesion: 0.07
 Nodes (31): deleteObject, deleteRelation, markStale, supersedeObject, additionalProperties, properties, required, type (+23 more)
 
 ### Community 119 - "Community 119"
-Cohesion: 0.18
-Nodes (10): AccessibilityHelperCoverageUnitTest, AfterMethod, List, MockedConstruction, Path, Results, Rule, String (+2 more)
+Cohesion: 0.16
+Nodes (11): AccessibilityHelperCoverageUnitTest, AxeBuilder, AfterMethod, List, MockedConstruction, Path, Results, Rule (+3 more)
 
 ### Community 120 - "Community 120"
 Cohesion: 0.10
@@ -1108,56 +1120,56 @@ Cohesion: 0.16
 Nodes (8): IAssert, CustomSoftAssert, AssertionError, Override, String, Test, SoftAssert, CustomSoftAssertTest
 
 ### Community 124 - "Community 124"
-Cohesion: 0.11
-Nodes (11): TestNGListenerHelper, ISuite, ITestContext, ITestNGMethod, ITestResult, List, Method, String (+3 more)
+Cohesion: 0.13
+Nodes (9): TestNGListenerHelper, ISuite, ITestContext, ITestNGMethod, ITestResult, List, String, XmlSuite (+1 more)
 
 ### Community 125 - "Community 125"
-Cohesion: 0.14
-Nodes (4): AfterMethod, BeforeClass, Test, JSONFileManagerUnitTest
+Cohesion: 0.06
+Nodes (20): DataType, FileReader, JSONFileManager, JSONFileManagerTestAccessor, JSONFileManagerTests, List, Map, Object (+12 more)
 
 ### Community 126 - "Community 126"
 Cohesion: 0.17
 Nodes (12): ITestNGService, AfterMethod, ITestNGMethod, ITestResult, List, Object, String, SuppressWarnings (+4 more)
 
 ### Community 127 - "Community 127"
-Cohesion: 0.19
-Nodes (15): RecordingRunner, DoctorRepairServiceTest, RecordingRunner, RepairProcessRunner, RepositoryFixture, DoctorRepairRequest, Duration, FilePatch (+7 more)
+Cohesion: 0.14
+Nodes (19): DeterministicRuleEngine, DoctorAnalyzer, DoctorAiAnalysisResult, DoctorReportWriter, DoctorTriage, EvidenceCollector, ExecutionIntelligence, Diagnosis (+11 more)
 
 ### Community 128 - "Community 128"
 Cohesion: 0.12
 Nodes (5): AfterMethod, Runnable, String, Test, ValidationHelperUnitTest
 
 ### Community 129 - "Community 129"
-Cohesion: 0.10
-Nodes (20): Autowired, Bean, BrowserService, ElementService, ShaftMcpApplication, ShaftMcpApplicationTests, McpMobileRecordingService, MobileService (+12 more)
+Cohesion: 0.18
+Nodes (12): Bean, BrowserService, ElementService, ShaftMcpApplication, MobileService, NaturalActionService, CaptureService, DoctorService (+4 more)
 
 ### Community 130 - "Community 130"
 Cohesion: 0.13
 Nodes (3): ActionsCoverageTests, BeforeMethod, Test
 
 ### Community 131 - "Community 131"
-Cohesion: 0.13
-Nodes (9): Browser, BasicAuthenticationTests, CoverageTests, Test, AfterClass, AfterMethod, BeforeClass, BeforeMethod (+1 more)
+Cohesion: 0.16
+Nodes (7): Browser, CoverageTests, AfterClass, AfterMethod, BeforeClass, BeforeMethod, Test
 
 ### Community 132 - "Community 132"
 Cohesion: 0.14
 Nodes (14): BadRequestException, CaptureControlServer, Handler, Handler, CaptureControlFiles, CaptureManager, CaptureStatus, Class (+6 more)
 
 ### Community 133 - "Community 133"
-Cohesion: 0.12
-Nodes (13): ImageProcessingActions, VisualProcessingProviderRegistry, Boolean, By, File, Integer, List, String (+5 more)
+Cohesion: 0.33
+Nodes (4): VisualProcessingProviderRegistry, List, Optional, VisualProcessingProvider
 
 ### Community 134 - "Community 134"
-Cohesion: 0.15
-Nodes (13): AlphaProvider, VisualProcessingProviderRegistryTest, ZuluProvider, AfterMethod, Boolean, By, Integer, List (+5 more)
+Cohesion: 0.24
+Nodes (10): AlphaProvider, ZuluProvider, Boolean, By, Integer, List, Override, String (+2 more)
 
 ### Community 135 - "Community 135"
-Cohesion: 0.19
-Nodes (12): ScreenshotManager, Object, Boolean, By, JavascriptExecutor, List, Object, Screenshots (+4 more)
+Cohesion: 0.12
+Nodes (17): ScreenshotManager, ScreenshotManagerCoverageUnitTest, Object, Boolean, By, JavascriptExecutor, List, Object (+9 more)
 
 ### Community 136 - "Community 136"
-Cohesion: 0.14
-Nodes (9): Platform, SetProperty, PlatformTests, DefaultValue, Key, SetProperty, String, BeforeClass (+1 more)
+Cohesion: 0.08
+Nodes (17): ChromiumOptions, DesiredCapabilities, OptionsManager, Platform, SetProperty, LoggingPreferences, PlatformTests, DriverType (+9 more)
 
 ### Community 137 - "Community 137"
 Cohesion: 0.11
@@ -1168,31 +1180,31 @@ Cohesion: 0.20
 Nodes (4): AccessibilityTest, AfterMethod, BeforeMethod, Test
 
 ### Community 139 - "Community 139"
-Cohesion: 0.11
-Nodes (17): builder(), evidenceCategories(), withSanitizedContent(), withTimeout(), AiAuditSink, ShaftAiAuditSink, AiRequest, ApprovalPolicy (+9 more)
+Cohesion: 0.10
+Nodes (18): builder(), evidenceCategories(), withSanitizedContent(), withTimeout(), AiAuditSink, AiImage, ShaftAiAuditSink, AiRequest (+10 more)
 
 ### Community 140 - "Community 140"
 Cohesion: 0.15
 Nodes (7): API, JSON, YAML, List, Object, RequestBuilder, String
 
 ### Community 141 - "Community 141"
-Cohesion: 0.15
-Nodes (18): HealingProvider, ShaftHealingProvider, HealingActionOutcome, HealingCandidate, HealingContext, HealingDecision, HealingExplanation, HealingObservation (+10 more)
+Cohesion: 0.12
+Nodes (22): AiTrigger, HealingProvider, ShaftHealingProvider, HealingActionOutcome, HealingCandidate, HealingConfiguration, HealingContext, HealingDecision (+14 more)
 
 ### Community 142 - "Community 142"
 Cohesion: 0.17
 Nodes (11): HistoryDocument, HistoryRecord, HealingHistoryStore, HealingConfiguration, HealingContext, LocatorFingerprint, Optional, Path (+3 more)
 
 ### Community 143 - "Community 143"
-Cohesion: 0.14
-Nodes (13): FirestoreRestClient, ThrowingInvocation, WebDriverElementValidationsBuilderCoverageUnitTest, Deprecated, String, AfterMethod, NativeValidationsBuilder, String (+5 more)
+Cohesion: 0.18
+Nodes (10): ThrowingInvocation, WebDriverElementValidationsBuilderCoverageUnitTest, AfterMethod, NativeValidationsBuilder, String, Test, ValidationType, VisualValidationEngine (+2 more)
 
 ### Community 144 - "Community 144"
 Cohesion: 0.14
 Nodes (7): BrowserService, McpPageDomSnapshot, McpScreenshotResult, McpWorkspacePolicy, Path, String, Tool
 
 ### Community 145 - "Community 145"
-Cohesion: 0.17
+Cohesion: 0.21
 Nodes (9): ElementSteps, getValue(), LocatorType(), By, String, SuppressWarnings, ThreadLocal, WebDriver (+1 more)
 
 ### Community 146 - "Community 146"
@@ -1208,8 +1220,8 @@ Cohesion: 0.19
 Nodes (7): FluentWebDriverAction, Actions, AlertActions, BrowserActions, DriverFactoryHelper, TouchActions, WebDriver
 
 ### Community 149 - "Community 149"
-Cohesion: 0.12
-Nodes (10): ProgressBarLoggerTestAccessor, ValidationsHelperTestAccessor, ArrayList, By, List, String, SuppressWarnings, AfterMethod (+2 more)
+Cohesion: 0.27
+Nodes (6): ValidationsHelperTestAccessor, ArrayList, By, List, String, SuppressWarnings
 
 ### Community 150 - "Community 150"
 Cohesion: 0.17
@@ -1220,7 +1232,7 @@ Cohesion: 0.27
 Nodes (8): FingerprintExtractor, HealingConfiguration, LocatorFingerprint, Map, String, Supplier, WebDriver, WebElement
 
 ### Community 152 - "Community 152"
-Cohesion: 0.17
+Cohesion: 0.18
 Nodes (10): ManagedCaptureRecorder, CaptureManager, CaptureStartRequest, CaptureStatus, CheckpointKind, Function, Override, State (+2 more)
 
 ### Community 153 - "Community 153"
@@ -1232,28 +1244,24 @@ Cohesion: 0.08
 Nodes (24): enum, additionalProperties, allOf, enum, $id, pattern, type, type (+16 more)
 
 ### Community 155 - "Community 155"
-Cohesion: 0.18
-Nodes (7): AfterClass, AfterMethod, SuppressWarnings, Test, ThreadLocal, WebDriver, RecordManagerTest
+Cohesion: 0.11
+Nodes (13): InputStream, Path, String, SuppressWarnings, WebDriver, AfterClass, AfterMethod, SuppressWarnings (+5 more)
 
 ### Community 156 - "Community 156"
-Cohesion: 0.13
-Nodes (7): AndroidBasicInteractionsTests, AndroidDragAndDropTest, MobileTest, Test, Test, AfterMethod, BeforeMethod
+Cohesion: 0.09
+Nodes (9): AndroidBasicInteractionsTests, AndroidDragAndDropTest, AndroidTouchActionsTests, MobileTest, Test, Test, Test, AfterMethod (+1 more)
 
 ### Community 157 - "Community 157"
 Cohesion: 0.10
 Nodes (15): AsyncElementActions, Async, CLI, GUI, Locator, Properties, TestData, Validations (+7 more)
 
 ### Community 158 - "Community 158"
-Cohesion: 0.12
-Nodes (12): API, SetProperty, Properties, DefaultValue, Key, SetProperty, String, Class (+4 more)
-
-### Community 159 - "Community 159"
-Cohesion: 0.15
-Nodes (3): PropertiesHelper, RunType, String
+Cohesion: 0.19
+Nodes (6): API, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 160 - "Community 160"
-Cohesion: 0.28
-Nodes (12): ValidationsHelper, Boolean, ComparisonType, List, Object, Response, String, Throwable (+4 more)
+Cohesion: 0.10
+Nodes (16): StandaloneAssertions, StandaloneVerifications, WebDriverAssertions, WebDriverVerifications, WizardHelpers, By, DriverFactoryHelper, FileValidationsBuilder (+8 more)
 
 ### Community 161 - "Community 161"
 Cohesion: 0.21
@@ -1264,7 +1272,7 @@ Cohesion: 0.16
 Nodes (3): AfterMethod, Test, ValidationsBuilderUnitTest
 
 ### Community 163 - "Community 163"
-Cohesion: 0.21
+Cohesion: 0.19
 Nodes (8): AlertEvent, DataPlan, EventContext, ExternalTestDataReference, StringBuilder, VerificationKind, WaitEvent, WindowEvent
 
 ### Community 164 - "Community 164"
@@ -1272,12 +1280,12 @@ Cohesion: 0.24
 Nodes (6): Dimension, BrowserActionsHelper, Boolean, SneakyThrows, String, WebDriver
 
 ### Community 165 - "Community 165"
-Cohesion: 0.20
-Nodes (6): CheckpointType, CheckpointCounter, CheckpointStatus, String, Test, CheckpointAndReportingTest
+Cohesion: 0.06
+Nodes (32): additionalProperties, type, items, type, minimum, type, minimum, type (+24 more)
 
 ### Community 166 - "Community 166"
-Cohesion: 0.19
-Nodes (9): ChromiumOptions, DesiredCapabilities, OptionsManager, LoggingPreferences, DriverType, MutableCapabilities, String, SuppressWarnings (+1 more)
+Cohesion: 0.20
+Nodes (20): DoctorCli, flag(), optionalPath(), parse(), path(), pathRequired(), paths(), pathsRequired() (+12 more)
 
 ### Community 167 - "Community 167"
 Cohesion: 0.15
@@ -1288,7 +1296,7 @@ Cohesion: 0.17
 Nodes (10): BrowserEventScript, PollingBrowserEventCollector, String, BrowserSignal, Consumer, Object, Override, Set (+2 more)
 
 ### Community 169 - "Community 169"
-Cohesion: 0.18
+Cohesion: 0.16
 Nodes (5): AsyncElementActions, By, ClipboardAction, DriverFactoryHelper, String
 
 ### Community 170 - "Community 170"
@@ -1308,8 +1316,8 @@ Cohesion: 0.14
 Nodes (23): analyze_project(), collect_ai_context(), coordinates_have_supported_stack(), dependency_coordinates(), detect_markers(), discover_poms(), format_diff(), is_ignored() (+15 more)
 
 ### Community 175 - "Community 175"
-Cohesion: 0.17
-Nodes (13): AiImage, OpenAiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode (+5 more)
+Cohesion: 0.19
+Nodes (12): OpenAiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode, Map (+4 more)
 
 ### Community 176 - "Community 176"
 Cohesion: 0.22
@@ -1333,19 +1341,19 @@ Nodes (7): AnimatedGifManagerCoverageUnitTest, AfterMethod, BeforeMethod, Color,
 
 ### Community 181 - "Community 181"
 Cohesion: 0.20
-Nodes (13): AiCandidateReranker, RerankResult, AiExecutionService, Double, HealingConfiguration, JsonNode, List, Map (+5 more)
+Nodes (13): AiCandidateReranker, AiExecutionService, Double, HealingConfiguration, JsonNode, List, Map, ObjectNode (+5 more)
 
 ### Community 182 - "Community 182"
-Cohesion: 0.21
-Nodes (10): CaptureService, McpCaptureCodeBlockService, McpCaptureReplayResult, PreDestroy, CaptureGenerationResult, CaptureManager, CaptureStatus, McpWorkspacePolicy (+2 more)
+Cohesion: 0.17
+Nodes (12): reviewPath(), CaptureService, McpCaptureCodeBlockService, McpCaptureReplayResult, PreDestroy, Path, CaptureGenerationResult, CaptureManager (+4 more)
 
 ### Community 183 - "Community 183"
 Cohesion: 0.12
 Nodes (22): minLength, type, properties, $ref, $ref, $ref, body, evidence (+14 more)
 
 ### Community 184 - "Community 184"
-Cohesion: 0.19
-Nodes (11): AfterMethod, BeforeMethod, By, ElementActions, List, Object, Runnable, String (+3 more)
+Cohesion: 0.06
+Nodes (30): additionalProperties, type, type, minimum, type, minimum, type, $id (+22 more)
 
 ### Community 185 - "Community 185"
 Cohesion: 0.17
@@ -1364,12 +1372,12 @@ Cohesion: 0.12
 Nodes (4): CommandResult, command_result(), FakeRepairClient, UpgradeToModularShaftTests
 
 ### Community 189 - "Community 189"
-Cohesion: 0.16
-Nodes (8): FileReader, JSONFileManagerTestAccessor, List, Map, SuppressWarnings, AfterMethod, Test, MemoryLeakFixTests
+Cohesion: 0.12
+Nodes (12): NativeValidationsBuilder, FileValidationsBuilder, Object, Override, RestValidationsBuilder, String, SuppressWarnings, ValidationsBuilder (+4 more)
 
 ### Community 190 - "Community 190"
-Cohesion: 0.24
-Nodes (8): GuardedPatch, RepairGuard, FilePatch, List, Path, Set, String, ValidationCommand
+Cohesion: 0.08
+Nodes (27): additionalProperties, items, type, $id, type, properties, blockers, provider (+19 more)
 
 ### Community 191 - "Community 191"
 Cohesion: 0.24
@@ -1384,12 +1392,12 @@ Cohesion: 0.19
 Nodes (6): Healenium, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 194 - "Community 194"
-Cohesion: 0.17
+Cohesion: 0.16
 Nodes (8): KeysetHandle, GoogleTink, GoogleTinkApiCoverageUnitTest, String, AfterMethod, BeforeMethod, Path, Test
 
 ### Community 195 - "Community 195"
-Cohesion: 0.19
-Nodes (10): NaturalActionExecutor, By, CharSequence, DriverFactoryHelper, NaturalActionPlan, Object, Set, String (+2 more)
+Cohesion: 0.12
+Nodes (15): MultipleElementsFoundException, NaturalActionExecutor, String, Throwable, By, CharSequence, DriverFactoryHelper, NaturalActionPlan (+7 more)
 
 ### Community 196 - "Community 196"
 Cohesion: 0.20
@@ -1416,8 +1424,8 @@ Cohesion: 0.38
 Nodes (5): ready(), unavailable(), AiProviderAvailability, AiProviderAvailability, String
 
 ### Community 202 - "Community 202"
-Cohesion: 0.19
-Nodes (8): DataType, JSONFileManager, JSONFileManagerTests, Object, String, Test, Test, WizardTestDataTests
+Cohesion: 0.13
+Nodes (5): NumberValidationsBuilder, AfterMethod, BeforeClass, Test, RestValidationsBuilderUnitTest
 
 ### Community 203 - "Community 203"
 Cohesion: 0.14
@@ -1428,11 +1436,11 @@ Cohesion: 0.24
 Nodes (8): CaptureFormatException, McpWorkspacePolicy, String, Throwable, IllegalArgumentException, List, Path, String
 
 ### Community 205 - "Community 205"
-Cohesion: 0.23
-Nodes (10): OpenCvVisualProcessingProvider, Boolean, By, Integer, List, Mat, Override, String (+2 more)
+Cohesion: 0.27
+Nodes (9): OpenCvVisualProcessingProvider, Boolean, By, Integer, List, Override, String, VisualValidationEngine (+1 more)
 
 ### Community 206 - "Community 206"
-Cohesion: 0.19
+Cohesion: 0.21
 Nodes (6): FailureReporter, Class, String, Throwable, Test, FailureReporterUnitTest
 
 ### Community 207 - "Community 207"
@@ -1444,16 +1452,16 @@ Cohesion: 0.17
 Nodes (6): LightHouseGenerateReport, LightHouseGenerateReportCoverageUnitTest, String, WebDriver, AfterMethod, Test
 
 ### Community 209 - "Community 209"
-Cohesion: 0.18
-Nodes (8): EngineService, PostConstruct, BrowserType, By, Path, String, Tool, WebDriver
+Cohesion: 0.12
+Nodes (12): EngineService, EngineServiceRuntimePathTest, PostConstruct, BrowserType, By, Path, String, Tool (+4 more)
 
 ### Community 210 - "Community 210"
 Cohesion: 0.23
 Nodes (6): McpRuntimePaths, McpRuntimePathsTest, Map, Path, String, Test
 
 ### Community 211 - "Community 211"
-Cohesion: 0.19
-Nodes (12): AnthropicProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode, Map (+4 more)
+Cohesion: 0.17
+Nodes (13): AnthropicProvider, PilotConfiguration, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode (+5 more)
 
 ### Community 212 - "Community 212"
 Cohesion: 0.10
@@ -1464,7 +1472,7 @@ Cohesion: 0.22
 Nodes (11): CaptureEvent, CaptureJsonCodec, CaptureSession, Checkpoint, ExternalTestDataReference, Instant, List, Path (+3 more)
 
 ### Community 214 - "Community 214"
-Cohesion: 0.13
+Cohesion: 0.12
 Nodes (6): Boolean, By, NumbersComparativeRelation, Object, String, JavaHelper
 
 ### Community 215 - "Community 215"
@@ -1472,7 +1480,7 @@ Cohesion: 0.20
 Nodes (4): AfterMethod, BeforeMethod, Test, BrowserActionsTests
 
 ### Community 216 - "Community 216"
-Cohesion: 0.21
+Cohesion: 0.20
 Nodes (4): AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
 
 ### Community 217 - "Community 217"
@@ -1484,23 +1492,23 @@ Cohesion: 0.17
 Nodes (10): PilotTestConfiguration, RedactionPolicy, RedactionResult, Redactor, AiRequest, Set, String, PilotConfiguration (+2 more)
 
 ### Community 219 - "Community 219"
-Cohesion: 0.16
-Nodes (7): AutoCloseable, ProgressBarLogger, ProgressBarLoggerCoverageUnitTest, Override, String, AfterMethod, Test
+Cohesion: 0.09
+Nodes (11): AutoCloseable, ProgressBarLogger, ProgressBarLoggerCoverageUnitTest, ProgressBarLoggerTestAccessor, Override, String, AfterMethod, Test (+3 more)
 
 ### Community 220 - "Community 220"
-Cohesion: 0.28
-Nodes (6): Config, List, String, SuppressWarnings, Test, XrayIntegrationHelper
+Cohesion: 0.27
+Nodes (7): List, String, SuppressWarnings, HttpExchange, Test, XrayIntegrationHelper, XrayIntegrationHelperCoverageUnitTest
 
 ### Community 221 - "Community 221"
 Cohesion: 0.20
 Nodes (8): CucumberFeatureListener, Class, Object, String, SuppressWarnings, Test, TableRow, CucumberFeatureListenerUnitTest
 
 ### Community 222 - "Community 222"
-Cohesion: 0.16
-Nodes (9): DesktopVideoRecordingProvider, AfterMethod, BeforeMethod, InputStream, Override, String, Test, RecordManagerDesktopProviderTest (+1 more)
+Cohesion: 0.18
+Nodes (8): AfterMethod, BeforeMethod, InputStream, Override, String, Test, RecordManagerDesktopProviderTest, StubDesktopVideoRecordingProvider
 
 ### Community 223 - "Community 223"
-Cohesion: 0.29
+Cohesion: 0.27
 Nodes (5): BrowserStackHelper, Boolean, DriverFactoryHelper, MutableCapabilities, String
 
 ### Community 224 - "Community 224"
@@ -1508,7 +1516,7 @@ Cohesion: 0.23
 Nodes (7): DoctorRedactor, RedactorTest, JsonNode, List, ObjectNode, String, Test
 
 ### Community 225 - "Community 225"
-Cohesion: 0.18
+Cohesion: 0.14
 Nodes (7): AssertEqualsTests, VerifyEqualsTests, BeforeMethod, Test, AfterMethod, BeforeMethod, Test
 
 ### Community 226 - "Community 226"
@@ -1517,7 +1525,7 @@ Nodes (6): NaturalActions, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 227 - "Community 227"
 Cohesion: 0.26
-Nodes (4): Visuals, DefaultValue, Key, SetProperty
+Nodes (5): Visuals, DefaultValue, Key, SetProperty, String
 
 ### Community 229 - "Community 229"
 Cohesion: 0.23
@@ -1528,8 +1536,8 @@ Cohesion: 0.22
 Nodes (18): append(), checkpoint(), complete(), ensureIncomplete(), interrupt(), sortedCheckpoints(), sortedEvents(), sortedReferences() (+10 more)
 
 ### Community 231 - "Community 231"
-Cohesion: 0.16
-Nodes (6): AfterTest, BeforeTest, ConfigurationHelper, ReportHelper, ITestContext, Step
+Cohesion: 0.31
+Nodes (5): AfterTest, BeforeTest, ConfigurationHelper, ITestContext, Step
 
 ### Community 232 - "Community 232"
 Cohesion: 0.15
@@ -1551,9 +1559,13 @@ Nodes (7): LocatorRanker, ScoredLocator, ElementSnapshot, EventContext, LocatorC
 Cohesion: 0.19
 Nodes (10): current(), HealingStrategy(), parse(), usesHealenium(), usesShaftHeal(), HealingStrategyTest, String, AfterMethod (+2 more)
 
+### Community 237 - "Community 237"
+Cohesion: 0.13
+Nodes (6): Allure, SetProperty, DefaultValue, Key, SetProperty, String
+
 ### Community 238 - "Community 238"
-Cohesion: 0.27
-Nodes (4): Allure, DefaultValue, Key, SetProperty
+Cohesion: 0.24
+Nodes (9): HealingSupport, By, HealingContext, HealingPlatform, RemoteWebDriver, String, Supplier, WebDriver (+1 more)
 
 ### Community 240 - "Community 240"
 Cohesion: 0.25
@@ -1564,8 +1576,8 @@ Cohesion: 0.20
 Nodes (4): ValidationsMockedTests, AfterMethod, BeforeMethod, Test
 
 ### Community 242 - "Community 242"
-Cohesion: 0.31
-Nodes (5): HealingLocatorProposalService, HealingLocatorProposal, JsonNode, Path, String
+Cohesion: 0.16
+Nodes (11): HealingLocatorProposalService, HealingLocatorProposalServiceTest, HealingLocatorProposal, JsonNode, Path, String, AfterEach, BeforeEach (+3 more)
 
 ### Community 243 - "Community 243"
 Cohesion: 0.21
@@ -1592,7 +1604,7 @@ Cohesion: 0.15
 Nodes (10): AllureCucumber7Jvm, CucumberTestRunnerListener, EventPublisher, Feature, Optional, Override, TestCaseFinished, TestSourceParsed (+2 more)
 
 ### Community 250 - "Community 250"
-Cohesion: 0.23
+Cohesion: 0.21
 Nodes (7): BigInteger, UpdateChecker, UpdateCheckerUnitTest, Optional, String, Supplier, Test
 
 ### Community 251 - "Community 251"
@@ -1624,8 +1636,8 @@ Cohesion: 0.24
 Nodes (8): NaturalActionExecutorTest, AfterMethod, BeforeMethod, By, List, Test, WebDriver, WebElement
 
 ### Community 259 - "Community 259"
-Cohesion: 0.33
-Nodes (6): HealingLocatorProposalServiceTest, AfterEach, BeforeEach, Path, String, Test
+Cohesion: 0.13
+Nodes (4): TextDirectionValidationsBuilder, NativeValidationsBuilder, ValidationsExecutor, TextDirection
 
 ### Community 260 - "Community 260"
 Cohesion: 0.26
@@ -1652,28 +1664,28 @@ Cohesion: 0.23
 Nodes (3): RestActionsCoverageUnitTest, AfterMethod, Test
 
 ### Community 266 - "Community 266"
-Cohesion: 0.22
-Nodes (11): BooleanSupplier, expired(), InstantDeadline(), ManagedCaptureRecorderBrowserTest, Duration, HttpExchange, HttpServer, ParameterizedTest (+3 more)
+Cohesion: 0.17
+Nodes (5): WebDriverElementValidationsBuilder, NativeValidationsBuilder, String, ValidationsExecutor, VisualValidationEngine
 
 ### Community 267 - "Community 267"
-Cohesion: 0.15
-Nodes (6): List, AfterMethod, BeforeMethod, Test, BrowserActionsCoverageUnitTest, Window
+Cohesion: 0.23
+Nodes (5): List, AfterMethod, BeforeMethod, Test, BrowserActionsCoverageUnitTest
 
 ### Community 268 - "Community 268"
 Cohesion: 0.21
 Nodes (9): fixture_commands(), main(), maven_executable(), missing_publication_paths(), publication_paths(), verify_release(), write_settings(), Path (+1 more)
 
 ### Community 269 - "Community 269"
-Cohesion: 0.14
-Nodes (22): BrowsingContextInfo, BidiBrowserEventCollector, copy(), dataBoolean(), dataInt(), dataStrings(), fromJson(), generated() (+14 more)
+Cohesion: 0.29
+Nodes (15): copy(), dataBoolean(), dataInt(), dataStrings(), fromJson(), generated(), longValue(), map() (+7 more)
 
 ### Community 270 - "Community 270"
-Cohesion: 0.24
+Cohesion: 0.27
 Nodes (7): CaptureControlClient, CaptureStatus, CheckpointKind, List, Object, Path, String
 
 ### Community 271 - "Community 271"
-Cohesion: 0.18
-Nodes (5): FrameTests, SuppressWarnings, AfterMethod, BeforeMethod, Test
+Cohesion: 0.22
+Nodes (6): BasicAPITests, AfterClass, BeforeClass, List, Map, String
 
 ### Community 272 - "Community 272"
 Cohesion: 0.25
@@ -1684,8 +1696,8 @@ Cohesion: 0.21
 Nodes (9): AiProvider, DoctorSnippetProvider, AfterEach, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse, Override (+1 more)
 
 ### Community 275 - "Community 275"
-Cohesion: 0.25
-Nodes (6): FileActionsCoverageUnitTest, AfterMethod, BeforeMethod, Path, String, Test
+Cohesion: 0.16
+Nodes (8): FileActionsCoverageUnitTest, FileActionsReflectionInvoker, AfterMethod, BeforeMethod, Path, String, FileActions, String
 
 ### Community 276 - "Community 276"
 Cohesion: 0.21
@@ -1696,16 +1708,16 @@ Cohesion: 0.20
 Nodes (8): FileChannel, FileLock, CaptureRuntimePortabilityTest, CaptureSingleSessionLock, Override, Path, Path, Test
 
 ### Community 278 - "Community 278"
-Cohesion: 0.20
-Nodes (8): DesktopVideoConsumer, IVideoRecorder, File, InputStream, Override, String, SuppressWarnings, AutomationRemarksDesktopVideoRecordingProvider
+Cohesion: 0.15
+Nodes (10): FileInputStream, DesktopVideoConsumer, IOException, IVideoRecorder, File, InputStream, Override, String (+2 more)
 
 ### Community 279 - "Community 279"
 Cohesion: 0.16
 Nodes (9): HealingProvider, HealingActionOutcome, HealingExplanation, HealingObservation, HealingRequest, HealingResolution, Optional, String (+1 more)
 
 ### Community 280 - "Community 280"
-Cohesion: 0.19
-Nodes (7): HealingVisualProvider, OpenCvHealingVisualProvider, OpenCvHealingVisualProviderTest, Override, String, Color, Test
+Cohesion: 0.18
+Nodes (7): OpenCvVisualConsumer, HealingVisualProvider, OpenCvHealingVisualProvider, Override, String, Mat, String
 
 ### Community 281 - "Community 281"
 Cohesion: 0.27
@@ -1732,8 +1744,8 @@ Cohesion: 0.13
 Nodes (14): additionalProperties, $id, required, type, properties, records, schemaVersion, items (+6 more)
 
 ### Community 287 - "Community 287"
-Cohesion: 0.20
-Nodes (7): AfterMethod, InputStream, Override, String, Test, DesktopVideoRecordingProviderRegistryTest, StubDesktopVideoRecordingProvider
+Cohesion: 0.18
+Nodes (8): DesktopVideoRecordingProvider, AfterMethod, InputStream, Override, String, Test, DesktopVideoRecordingProviderRegistryTest, StubDesktopVideoRecordingProvider
 
 ### Community 288 - "Community 288"
 Cohesion: 0.23
@@ -1744,12 +1756,12 @@ Cohesion: 0.21
 Nodes (7): AfterMethod, BeforeClass, BeforeMethod, Override, String, Test, TestClass
 
 ### Community 291 - "Community 291"
-Cohesion: 0.24
-Nodes (3): AndroidTouchActionsTests, ScreenOrientation, Test
+Cohesion: 0.29
+Nodes (8): DoctorJsonCodec, Diagnosis, DoctorAdvisory, EvidenceBundle, JsonNode, Object, Path, String
 
 ### Community 292 - "Community 292"
-Cohesion: 0.25
-Nodes (6): Callable, Path, Test, Test, CaptureSessionStoreTest, RestActionsFailureLoggingUnitTest
+Cohesion: 0.16
+Nodes (8): Callable, FilesSize, Path, Test, DesktopVideoRecordingProvider, Optional, CaptureSessionStoreTest, DesktopVideoRecordingProviderRegistry
 
 ### Community 293 - "Community 293"
 Cohesion: 0.19
@@ -1764,12 +1776,8 @@ Cohesion: 0.32
 Nodes (5): CaptureJsonCodec, CaptureSession, JsonNode, Path, String
 
 ### Community 296 - "Community 296"
-Cohesion: 0.29
-Nodes (5): ScreenshotManagerCoverageUnitTest, AfterMethod, BeforeMethod, Color, Test
-
-### Community 297 - "Community 297"
-Cohesion: 0.30
-Nodes (6): Internal, InternalTests, DefaultValue, Key, String, Test
+Cohesion: 0.26
+Nodes (5): HasCdp, ScreenshotHelper, Boolean, SuppressWarnings, WebDriver
 
 ### Community 298 - "Community 298"
 Cohesion: 0.32
@@ -1786,10 +1794,6 @@ Nodes (6): ModelSupport, JsonNode, List, Map, String, T
 ### Community 301 - "Community 301"
 Cohesion: 0.12
 Nodes (17): items, type, uniqueItems, tags, items, additionalProperties, minLength, pattern (+9 more)
-
-### Community 302 - "Community 302"
-Cohesion: 0.23
-Nodes (6): InputStream, Path, String, SuppressWarnings, WebDriver, RecordManager
 
 ### Community 303 - "Community 303"
 Cohesion: 0.25
@@ -1808,8 +1812,8 @@ Cohesion: 0.14
 Nodes (13): additionalProperties, type, type, properties, body, id, title, userId (+5 more)
 
 ### Community 307 - "Community 307"
-Cohesion: 0.27
-Nodes (7): AccessibilityActions, HttpRequest, HttpResponse, NetworkInterceptionTest, Predicate, Step, Test
+Cohesion: 0.16
+Nodes (10): AccessibilityActions, HttpRequest, HttpResponse, NavigationAction, DriverFactoryHelper, Predicate, Screenshots, Step (+2 more)
 
 ### Community 308 - "Community 308"
 Cohesion: 0.23
@@ -1832,7 +1836,7 @@ Cohesion: 0.21
 Nodes (7): WebDriverBrowserValidationsBuilder, NativeValidationsBuilder, String, StringBuilder, SuppressWarnings, ValidationCategory, WebDriver
 
 ### Community 314 - "Community 314"
-Cohesion: 0.26
+Cohesion: 0.24
 Nodes (8): LauncherSessionListener, JunitListener, Status, String, TestIdentifier, Throwable, StatusIcon, TestExecutionResult
 
 ### Community 315 - "Community 315"
@@ -1872,7 +1876,7 @@ Cohesion: 0.27
 Nodes (4): LocalApiTestServer, HttpExchange, HttpServer, String
 
 ### Community 324 - "Community 324"
-Cohesion: 0.30
+Cohesion: 0.32
 Nodes (5): AlertActions, DriverFactoryHelper, String, SuppressWarnings, WebDriver
 
 ### Community 325 - "Community 325"
@@ -1896,8 +1900,8 @@ Cohesion: 0.29
 Nodes (7): Description, AfterMethod, BeforeClass, BeforeMethod, Step, Test, FluentGuiActionsTest
 
 ### Community 330 - "Community 330"
-Cohesion: 0.17
-Nodes (5): Future, ArrayNode, InputStream, List, ObjectNode
+Cohesion: 0.20
+Nodes (8): AppiumDriver, DriverFactoryHelper, Duration, Function, RuntimeException, Status, WebDriver, StatusDetails
 
 ### Community 331 - "Community 331"
 Cohesion: 0.32
@@ -1907,12 +1911,16 @@ Nodes (6): CaptureGeneratedReplayBrowserTest, CaptureSession, ElementSnapshot, E
 Cohesion: 0.23
 Nodes (8): VisualProcessingProvider, Boolean, By, Integer, List, String, VisualValidationEngine, WebDriver
 
+### Community 333 - "Community 333"
+Cohesion: 0.14
+Nodes (7): ActionsExceptionDetailsUnitTest, NoSuchElementException, List, Map, Object, Rectangle, Test
+
 ### Community 334 - "Community 334"
-Cohesion: 0.18
+Cohesion: 0.14
 Nodes (5): ExecutionSummaryReport, StatusIcon(), CheckpointStatus, String, StringBuilder
 
 ### Community 335 - "Community 335"
-Cohesion: 0.30
+Cohesion: 0.26
 Nodes (6): IssueReporter, Boolean, ITestNGMethod, ITestResult, List, String
 
 ### Community 336 - "Community 336"
@@ -1989,7 +1997,7 @@ Nodes (6): AiProvider, AiCapabilities, AiProviderAvailability, AiRequest, AiResp
 
 ### Community 355 - "Community 355"
 Cohesion: 0.29
-Nodes (4): FlutterTest, AfterMethod, BeforeMethod, Test
+Nodes (4): CaptureJsonCodecTest, Path, String, Test
 
 ### Community 356 - "Community 356"
 Cohesion: 0.25
@@ -2004,19 +2012,19 @@ Cohesion: 0.25
 Nodes (4): DatabaseActions, DB, DatabaseType, ResultSet
 
 ### Community 359 - "Community 359"
-Cohesion: 0.25
+Cohesion: 0.27
 Nodes (6): AiCandidateRerankerTest, AfterMethod, HealingConfiguration, HttpExchange, String, Test
 
 ### Community 360 - "Community 360"
-Cohesion: 0.18
-Nodes (8): ValidationsExecutor, FileValidationsBuilder, NativeValidationsBuilder, NumberValidationsBuilder, RestValidationsBuilder, Step, ValidationsBuilder, WebDriverElementValidationsBuilder
+Cohesion: 0.24
+Nodes (7): BrowsingContextInfo, BidiBrowserEventCollector, BrowserSignal, Consumer, Override, String, WebDriver
 
 ### Community 361 - "Community 361"
 Cohesion: 0.29
 Nodes (5): Test_LTMobAPKAPPURL, AfterMethod, BeforeMethod, String, Test
 
 ### Community 362 - "Community 362"
-Cohesion: 0.29
+Cohesion: 0.27
 Nodes (4): CookiesTests, AfterMethod, BeforeMethod, Test
 
 ### Community 363 - "Community 363"
@@ -2026,10 +2034,6 @@ Nodes (4): GroupsTests, AfterMethod, BeforeMethod, Test
 ### Community 364 - "Community 364"
 Cohesion: 0.29
 Nodes (5): SelectMethodTests, AfterMethod, BeforeMethod, String, Test
-
-### Community 365 - "Community 365"
-Cohesion: 0.31
-Nodes (3): NavigationAction, Test, NavigationActionUnitTest
 
 ### Community 366 - "Community 366"
 Cohesion: 0.29
@@ -2052,8 +2056,8 @@ Cohesion: 0.31
 Nodes (3): AfterMethod, Test, FileValidationsBuilderUnitTest
 
 ### Community 372 - "Community 372"
-Cohesion: 0.27
-Nodes (6): AfterMethod, BeforeMethod, HttpExchange, Object, String, XrayIntegrationHelperCoverageUnitTest
+Cohesion: 0.29
+Nodes (4): AfterMethod, BeforeMethod, Object, String
 
 ### Community 373 - "Community 373"
 Cohesion: 0.18
@@ -2080,8 +2084,8 @@ Cohesion: 0.33
 Nodes (4): HealingProviderRegistry, HealingProvider, List, Optional
 
 ### Community 379 - "Community 379"
-Cohesion: 0.31
-Nodes (5): EngineProperties, SetProperty, Object, SetProperty, String
+Cohesion: 0.23
+Nodes (6): Config, EngineProperties, SetProperty, Object, SetProperty, String
 
 ### Community 381 - "Community 381"
 Cohesion: 0.36
@@ -2163,10 +2167,6 @@ Nodes (4): AfterMethod, Object, Test, LambdaTestSetPropertyCoverageUnitTest
 Cohesion: 0.31
 Nodes (4): AfterMethod, BeforeMethod, Test, VisualValidationTests
 
-### Community 401 - "Community 401"
-Cohesion: 0.31
-Nodes (4): Actions, ValidationsHelper2CoverageUnitTest, AfterMethod, Test
-
 ### Community 402 - "Community 402"
 Cohesion: 0.36
 Nodes (5): assemble_javadocs(), main(), project_version(), Path, AssembleJavadocsTest
@@ -2187,9 +2187,13 @@ Nodes (8): 📝 Additional Notes, 📋 Description, Documentation Site, Evidence
 Cohesion: 0.28
 Nodes (5): JSONValidationsBuilder, NativeValidationsBuilder, Object, RestValidationsBuilder, ValidationsExecutor
 
+### Community 407 - "Community 407"
+Cohesion: 0.24
+Nodes (3): JunitListenerHelper, TestIdentifier, Boolean
+
 ### Community 408 - "Community 408"
-Cohesion: 0.39
-Nodes (4): LogRedirector, Logger, Level, Override
+Cohesion: 0.27
+Nodes (6): LogRedirector, Logger, InputStream, OutputStream, Level, Override
 
 ### Community 409 - "Community 409"
 Cohesion: 0.22
@@ -2215,9 +2219,13 @@ Nodes (6): parse_xml(), Parse XML while preserving comments., Return version pro
 Cohesion: 0.47
 Nodes (4): SmartLocators, PathStrategy, By, String
 
+### Community 415 - "Community 415"
+Cohesion: 0.13
+Nodes (6): NetworkInterceptionTest, SmartLocatorsTests, Test, AfterMethod, BeforeMethod, Tests
+
 ### Community 416 - "Community 416"
-Cohesion: 0.33
-Nodes (4): EngineServiceRuntimePathTest, AfterEach, BeforeEach, Test
+Cohesion: 0.31
+Nodes (4): GuiVerificationTests, AfterMethod, BeforeMethod, Test
 
 ### Community 417 - "Community 417"
 Cohesion: 0.25
@@ -2240,7 +2248,7 @@ Cohesion: 0.42
 Nodes (5): ClassifiedValue, Collection, Path, String, ExternalTestDataWriter
 
 ### Community 423 - "Community 423"
-Cohesion: 0.29
+Cohesion: 0.31
 Nodes (5): AfterEach, BeforeAll, BeforeEach, Test, TestClass
 
 ### Community 424 - "Community 424"
@@ -2267,13 +2275,17 @@ Nodes (5): ClassLoader, OpenCvBlockingClassLoader, Class, Override, String
 Cohesion: 0.25
 Nodes (7): Attribution, Contributor Covenant Code of Conduct, Enforcement, Our Pledge, Our Responsibilities, Our Standards, Scope
 
+### Community 430 - "Community 430"
+Cohesion: 0.31
+Nodes (3): VisualProcessingProviderRegistryTest, AfterMethod, Test
+
 ### Community 431 - "Community 431"
 Cohesion: 0.25
 Nodes (5): DoctorFormatException, ProfileCleanupException, RuntimeException, String, Throwable
 
 ### Community 432 - "Community 432"
-Cohesion: 0.32
-Nodes (4): MutableTargetPlan, ElementSnapshot, LocatorCandidate, LocatorSelection
+Cohesion: 0.17
+Nodes (8): CaptureEnrichmentService, MutableTargetPlan, GeneratedTestValidator, LocatorRanker, CaptureJsonCodec, ElementSnapshot, LocatorCandidate, LocatorSelection
 
 ### Community 433 - "Community 433"
 Cohesion: 0.25
@@ -2284,7 +2296,7 @@ Cohesion: 0.36
 Nodes (4): HealingReportWriter, HealingConfiguration, HealingReport, String
 
 ### Community 436 - "Community 436"
-Cohesion: 0.39
+Cohesion: 0.33
 Nodes (3): ReportManager, Level, String
 
 ### Community 437 - "Community 437"
@@ -2332,7 +2344,7 @@ Cohesion: 0.36
 Nodes (4): RelativeLocatorsTests, AfterMethod, BeforeMethod, Test
 
 ### Community 448 - "Community 448"
-Cohesion: 0.36
+Cohesion: 0.38
 Nodes (4): RemoteGridVideoAttachmentIT, AfterMethod, BeforeMethod, Test
 
 ### Community 449 - "Community 449"
@@ -2356,8 +2368,8 @@ Cohesion: 0.15
 Nodes (13): items, items, type, additionalProperties, minLength, pattern, required, type (+5 more)
 
 ### Community 455 - "Community 455"
-Cohesion: 0.32
-Nodes (3): DesktopVideoRecordingProvider, Optional, DesktopVideoRecordingProviderRegistry
+Cohesion: 0.29
+Nodes (6): Properties, Class, Supplier, SuppressWarnings, T, ThreadLocal
 
 ### Community 456 - "Community 456"
 Cohesion: 0.36
@@ -2380,8 +2392,8 @@ Cohesion: 0.48
 Nodes (6): main(), property_map(), text(), validate(), Element, Path
 
 ### Community 462 - "Community 462"
-Cohesion: 0.43
-Nodes (6): bounded(), current(), split(), HealingConfiguration, List, String
+Cohesion: 0.38
+Nodes (10): aiTrigger(), bounded(), current(), HealingConfiguration(), split(), Duration, List, Path (+2 more)
 
 ### Community 463 - "Community 463"
 Cohesion: 0.43
@@ -2392,8 +2404,8 @@ Cohesion: 0.43
 Nodes (3): MobileEmulationTests, AfterMethod, Test
 
 ### Community 466 - "Community 466"
-Cohesion: 0.38
-Nodes (3): AfterMethod, BeforeMethod, Tests
+Cohesion: 0.50
+Nodes (3): FirestoreRestClient, Deprecated, String
 
 ### Community 467 - "Community 467"
 Cohesion: 0.43
@@ -2420,8 +2432,8 @@ Cohesion: 0.33
 Nodes (3): InputStream, String, DesktopVideoRecordingProvider
 
 ### Community 473 - "Community 473"
-Cohesion: 0.53
-Nodes (5): allows(), ApprovalPolicy(), EvidenceCategory, ProcessingLocation, Set
+Cohesion: 0.48
+Nodes (3): OpenCvHealingVisualProviderTest, Color, Test
 
 ### Community 474 - "Community 474"
 Cohesion: 0.67
@@ -2435,17 +2447,13 @@ Nodes (5): fail(), main(), parse_trusted_pom(), text(), Path
 Cohesion: 0.53
 Nodes (5): option(), ProviderConfiguration(), Map, String, URI
 
-### Community 477 - "Community 477"
-Cohesion: 0.40
-Nodes (4): MultipleElementsFoundException, String, Throwable, WebDriverException
-
 ### Community 478 - "Community 478"
-Cohesion: 0.40
-Nodes (3): FileActionsReflectionInvoker, FileActions, String
+Cohesion: 0.43
+Nodes (4): ShaftMcpApplicationTests, Set, String, Test
 
 ### Community 479 - "Community 479"
-Cohesion: 0.22
-Nodes (6): BomConsumer, OpenCvVisualConsumer, String, Mat, String, VisualProcessingProvider
+Cohesion: 0.43
+Nodes (3): BomConsumer, String, VisualProcessingProvider
 
 ### Community 480 - "Community 480"
 Cohesion: 0.47
@@ -2536,8 +2544,8 @@ Cohesion: 0.60
 Nodes (3): AbstractTestNGCucumberTests, CucumberTests, CucumberTests
 
 ### Community 506 - "Community 506"
-Cohesion: 0.40
-Nodes (4): CaptureEnrichmentService, GeneratedTestValidator, LocatorRanker, CaptureJsonCodec
+Cohesion: 0.43
+Nodes (3): AfterMethod, Test, ProjectStructureManagerTest
 
 ### Community 507 - "Community 507"
 Cohesion: 0.60
@@ -2623,25 +2631,37 @@ Nodes (3): sha256, minLength, type
 Cohesion: 0.67
 Nodes (3): sizeBytes, minimum, type
 
+### Community 558 - "Community 558"
+Cohesion: 0.40
+Nodes (4): By, StringBuilder, ValidationCategory, WebDriver
+
+### Community 671 - "Community 671"
+Cohesion: 0.47
+Nodes (3): JiraTests, BeforeClass, Test
+
+### Community 676 - "Community 676"
+Cohesion: 0.50
+Nodes (3): Object, Override, SuppressWarnings
+
 ## Knowledge Gaps
-- **1225 isolated node(s):** `$id`, `$schema`, `additionalProperties`, `additionalProperties`, `type` (+1220 more)
+- **1280 isolated node(s):** `$id`, `$schema`, `additionalProperties`, `additionalProperties`, `type` (+1275 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **73 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **83 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `SHAFT` connect `Community 42` to `Community 1`, `Community 3`, `Community 5`, `Community 8`, `Community 9`, `Community 10`, `Community 11`, `Community 12`, `Community 13`, `Community 14`, `Community 15`, `Community 17`, `Community 18`, `Community 19`, `Community 21`, `Community 536`, `Community 24`, `Community 25`, `Community 27`, `Community 28`, `Community 29`, `Community 31`, `Community 32`, `Community 35`, `Community 36`, `Community 37`, `Community 38`, `Community 39`, `Community 41`, `Community 43`, `Community 44`, `Community 47`, `Community 48`, `Community 49`, `Community 51`, `Community 53`, `Community 55`, `Community 56`, `Community 57`, `Community 59`, `Community 61`, `Community 64`, `Community 72`, `Community 74`, `Community 76`, `Community 80`, `Community 81`, `Community 83`, `Community 87`, `Community 90`, `Community 92`, `Community 94`, `Community 97`, `Community 98`, `Community 99`, `Community 100`, `Community 103`, `Community 106`, `Community 109`, `Community 110`, `Community 111`, `Community 113`, `Community 117`, `Community 120`, `Community 121`, `Community 124`, `Community 125`, `Community 130`, `Community 131`, `Community 133`, `Community 135`, `Community 136`, `Community 138`, `Community 139`, `Community 144`, `Community 145`, `Community 155`, `Community 156`, `Community 157`, `Community 669`, `Community 160`, `Community 161`, `Community 164`, `Community 166`, `Community 170`, `Community 180`, `Community 184`, `Community 186`, `Community 194`, `Community 195`, `Community 199`, `Community 202`, `Community 203`, `Community 205`, `Community 208`, `Community 209`, `Community 214`, `Community 215`, `Community 216`, `Community 219`, `Community 220`, `Community 222`, `Community 223`, `Community 225`, `Community 229`, `Community 231`, `Community 233`, `Community 236`, `Community 240`, `Community 242`, `Community 243`, `Community 246`, `Community 248`, `Community 249`, `Community 250`, `Community 252`, `Community 253`, `Community 254`, `Community 258`, `Community 259`, `Community 265`, `Community 267`, `Community 271`, `Community 272`, `Community 274`, `Community 275`, `Community 289`, `Community 290`, `Community 292`, `Community 294`, `Community 296`, `Community 297`, `Community 302`, `Community 303`, `Community 307`, `Community 316`, `Community 317`, `Community 318`, `Community 320`, `Community 321`, `Community 329`, `Community 330`, `Community 334`, `Community 336`, `Community 339`, `Community 341`, `Community 342`, `Community 348`, `Community 349`, `Community 350`, `Community 353`, `Community 355`, `Community 356`, `Community 358`, `Community 359`, `Community 361`, `Community 362`, `Community 363`, `Community 364`, `Community 366`, `Community 370`, `Community 380`, `Community 382`, `Community 384`, `Community 387`, `Community 388`, `Community 396`, `Community 397`, `Community 398`, `Community 399`, `Community 400`, `Community 401`, `Community 403`, `Community 404`, `Community 410`, `Community 411`, `Community 420`, `Community 423`, `Community 424`, `Community 426`, `Community 438`, `Community 439`, `Community 440`, `Community 441`, `Community 442`, `Community 443`, `Community 444`, `Community 445`, `Community 446`, `Community 447`, `Community 448`, `Community 450`, `Community 452`, `Community 456`, `Community 457`, `Community 458`, `Community 459`, `Community 460`, `Community 462`, `Community 463`, `Community 464`, `Community 466`, `Community 467`, `Community 468`, `Community 479`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 493`, `Community 494`, `Community 495`, `Community 496`, `Community 497`, `Community 503`, `Community 511`?**
-  _High betweenness centrality (0.133) - this node is a cross-community bridge._
+- **Why does `SHAFT` connect `Community 42` to `Community 1`, `Community 3`, `Community 5`, `Community 8`, `Community 10`, `Community 11`, `Community 12`, `Community 13`, `Community 14`, `Community 15`, `Community 17`, `Community 18`, `Community 19`, `Community 21`, `Community 536`, `Community 25`, `Community 24`, `Community 27`, `Community 28`, `Community 29`, `Community 31`, `Community 35`, `Community 36`, `Community 38`, `Community 39`, `Community 41`, `Community 44`, `Community 47`, `Community 48`, `Community 49`, `Community 50`, `Community 51`, `Community 564`, `Community 53`, `Community 55`, `Community 57`, `Community 59`, `Community 61`, `Community 64`, `Community 72`, `Community 74`, `Community 76`, `Community 80`, `Community 81`, `Community 82`, `Community 83`, `Community 90`, `Community 92`, `Community 94`, `Community 97`, `Community 98`, `Community 100`, `Community 103`, `Community 105`, `Community 106`, `Community 109`, `Community 110`, `Community 111`, `Community 113`, `Community 117`, `Community 120`, `Community 121`, `Community 125`, `Community 130`, `Community 131`, `Community 135`, `Community 136`, `Community 138`, `Community 139`, `Community 144`, `Community 145`, `Community 155`, `Community 156`, `Community 157`, `Community 669`, `Community 159`, `Community 671`, `Community 673`, `Community 161`, `Community 675`, `Community 164`, `Community 677`, `Community 170`, `Community 180`, `Community 186`, `Community 194`, `Community 195`, `Community 199`, `Community 203`, `Community 205`, `Community 208`, `Community 209`, `Community 214`, `Community 215`, `Community 216`, `Community 219`, `Community 220`, `Community 222`, `Community 223`, `Community 225`, `Community 229`, `Community 233`, `Community 236`, `Community 240`, `Community 242`, `Community 243`, `Community 246`, `Community 248`, `Community 249`, `Community 250`, `Community 252`, `Community 253`, `Community 254`, `Community 258`, `Community 265`, `Community 267`, `Community 271`, `Community 272`, `Community 274`, `Community 275`, `Community 278`, `Community 289`, `Community 290`, `Community 294`, `Community 296`, `Community 297`, `Community 303`, `Community 307`, `Community 314`, `Community 316`, `Community 317`, `Community 318`, `Community 320`, `Community 321`, `Community 329`, `Community 330`, `Community 334`, `Community 336`, `Community 339`, `Community 341`, `Community 342`, `Community 348`, `Community 349`, `Community 350`, `Community 353`, `Community 356`, `Community 358`, `Community 359`, `Community 361`, `Community 362`, `Community 363`, `Community 364`, `Community 366`, `Community 370`, `Community 372`, `Community 380`, `Community 382`, `Community 384`, `Community 387`, `Community 388`, `Community 396`, `Community 397`, `Community 398`, `Community 399`, `Community 400`, `Community 403`, `Community 404`, `Community 410`, `Community 411`, `Community 415`, `Community 416`, `Community 420`, `Community 423`, `Community 424`, `Community 426`, `Community 438`, `Community 439`, `Community 440`, `Community 441`, `Community 442`, `Community 443`, `Community 444`, `Community 445`, `Community 446`, `Community 447`, `Community 448`, `Community 450`, `Community 452`, `Community 456`, `Community 457`, `Community 458`, `Community 459`, `Community 460`, `Community 462`, `Community 463`, `Community 464`, `Community 467`, `Community 468`, `Community 477`, `Community 479`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 493`, `Community 494`, `Community 495`, `Community 496`, `Community 497`, `Community 503`, `Community 506`, `Community 511`?**
+  _High betweenness centrality (0.139) - this node is a cross-community bridge._
 - **Why does `ThreadLocalPropertiesManager` connect `Community 47` to `Community 37`, `Community 158`?**
-  _High betweenness centrality (0.047) - this node is a cross-community bridge._
-- **Why does `IOException` connect `Community 42` to `Community 1`, `Community 2`, `Community 5`, `Community 7`, `Community 10`, `Community 12`, `Community 18`, `Community 23`, `Community 26`, `Community 33`, `Community 40`, `Community 45`, `Community 46`, `Community 53`, `Community 56`, `Community 61`, `Community 62`, `Community 65`, `Community 67`, `Community 68`, `Community 76`, `Community 86`, `Community 96`, `Community 101`, `Community 109`, `Community 115`, `Community 117`, `Community 119`, `Community 121`, `Community 122`, `Community 127`, `Community 129`, `Community 132`, `Community 133`, `Community 135`, `Community 142`, `Community 144`, `Community 147`, `Community 153`, `Community 168`, `Community 176`, `Community 180`, `Community 189`, `Community 190`, `Community 204`, `Community 205`, `Community 207`, `Community 209`, `Community 210`, `Community 242`, `Community 246`, `Community 260`, `Community 264`, `Community 266`, `Community 270`, `Community 275`, `Community 276`, `Community 277`, `Community 278`, `Community 282`, `Community 288`, `Community 290`, `Community 295`, `Community 302`, `Community 307`, `Community 322`, `Community 323`, `Community 330`, `Community 350`, `Community 359`, `Community 371`, `Community 386`, `Community 419`, `Community 422`, `Community 431`, `Community 435`, `Community 448`, `Community 498`?**
-  _High betweenness centrality (0.029) - this node is a cross-community bridge._
+  _High betweenness centrality (0.036) - this node is a cross-community bridge._
+- **Why does `IOException` connect `Community 278` to `Community 2`, `Community 5`, `Community 7`, `Community 10`, `Community 12`, `Community 18`, `Community 23`, `Community 25`, `Community 26`, `Community 33`, `Community 40`, `Community 45`, `Community 49`, `Community 50`, `Community 53`, `Community 61`, `Community 62`, `Community 65`, `Community 67`, `Community 68`, `Community 76`, `Community 86`, `Community 96`, `Community 99`, `Community 101`, `Community 105`, `Community 109`, `Community 115`, `Community 117`, `Community 119`, `Community 121`, `Community 122`, `Community 125`, `Community 127`, `Community 129`, `Community 132`, `Community 135`, `Community 142`, `Community 144`, `Community 147`, `Community 153`, `Community 155`, `Community 159`, `Community 673`, `Community 168`, `Community 176`, `Community 180`, `Community 194`, `Community 204`, `Community 205`, `Community 207`, `Community 209`, `Community 210`, `Community 242`, `Community 246`, `Community 260`, `Community 264`, `Community 270`, `Community 271`, `Community 275`, `Community 276`, `Community 277`, `Community 282`, `Community 288`, `Community 290`, `Community 291`, `Community 295`, `Community 296`, `Community 307`, `Community 322`, `Community 323`, `Community 330`, `Community 350`, `Community 355`, `Community 359`, `Community 371`, `Community 372`, `Community 386`, `Community 419`, `Community 422`, `Community 431`, `Community 435`, `Community 448`, `Community 498`, `Community 506`?**
+  _High betweenness centrality (0.027) - this node is a cross-community bridge._
 - **What connects `$id`, `$schema`, `additionalProperties` to the rest of the system?**
-  _1318 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _1373 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.04242424242424243 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.042869057547956634 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.050628610261637785 - nodes in this community are weakly interconnected._
-- **Should `Community 2` be split into smaller, more focused modules?**
-  _Cohesion score 0.05833848690991548 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.08182349503214495 - nodes in this community are weakly interconnected._
+- **Should `Community 3` be split into smaller, more focused modules?**
+  _Cohesion score 0.06295715778474399 - nodes in this community are weakly interconnected._

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1465,13 +1465,13 @@
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationResult.java": {
-    "mtime": 1781239583.9607615,
-    "ast_hash": "c1db6c2ab28bc73cbc924e6cc4932ea7",
+    "mtime": 1781779720.385172,
+    "ast_hash": "9d5fbf61284b1dc832e6bd3aa24422ec",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java": {
-    "mtime": 1781239583.9618275,
-    "ast_hash": "ff6f1e064a5ea940a66cd7b26a56cc02",
+    "mtime": 1781779763.8733683,
+    "ast_hash": "a802c685cb7d96b68268dcb0667c82cb",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/GeneratedTestValidator.java": {
@@ -1630,8 +1630,8 @@
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java": {
-    "mtime": 1781261094.4290085,
-    "ast_hash": "c8e9da40fc8c13aad61e7f689a9cefbc",
+    "mtime": 1781779993.848051,
+    "ast_hash": "ec7c3740176ebf423122c0e469a3024c",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/generate/LocatorRankerTest.java": {
@@ -2140,8 +2140,8 @@
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/DoctorAnalyzer.java": {
-    "mtime": 1781248762.5671165,
-    "ast_hash": "fd86210399d3956a7a343693416c1453",
+    "mtime": 1781779941.0645535,
+    "ast_hash": "bda5e4dba70a79b88fe50bd650e95df6",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/ai/DoctorAiAnalysisService.java": {
@@ -2365,8 +2365,8 @@
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/DoctorAnalyzerTest.java": {
-    "mtime": 1781248762.5773132,
-    "ast_hash": "97bda547e7be8d60c7186f5819b612dc",
+    "mtime": 1781780022.9496322,
+    "ast_hash": "1bb7b5a0dc18fc5e543650ae52a4b999",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/ai/DoctorAiAnalysisServiceTest.java": {
@@ -2575,13 +2575,13 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java": {
-    "mtime": 1781735146.2056143,
-    "ast_hash": "731df72482b634b806c3776920c0b3ea",
+    "mtime": 1781771875.3273664,
+    "ast_hash": "95ed51b85934932c7c9c9d0449b98fdd",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java": {
-    "mtime": 1781642509.7868412,
-    "ast_hash": "9140eb65009a9477d80ad0e9f0e92dd1",
+    "mtime": 1781771875.3283653,
+    "ast_hash": "79f74172e4812db312b9248415ddd94c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementInformation.java": {
@@ -2870,13 +2870,13 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Healing.java": {
-    "mtime": 1781642509.7963178,
-    "ast_hash": "385585cc4fe7cc236525dcf28d9cf241",
+    "mtime": 1781779793.7561965,
+    "ast_hash": "2c3da691e3cd819551b8d2a04e44b6cd",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java": {
-    "mtime": 1781682813.3079863,
-    "ast_hash": "1f9b4559e87b52433275fb6a0e0e63c1",
+    "mtime": 1781771875.329366,
+    "ast_hash": "548b54bea14f8d32fb82491abe313964",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Jira.java": {
@@ -3180,8 +3180,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsBuilder.java": {
-    "mtime": 1781170594.9417422,
-    "ast_hash": "6122a4c3e506d036dbfa1a8973278f90",
+    "mtime": 1781771875.329366,
+    "ast_hash": "c113fe199e929201df6ef9ad1811a224",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsExecutor.java": {
@@ -3195,8 +3195,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper2.java": {
-    "mtime": 1781170594.9447453,
-    "ast_hash": "12a52744e1822f9b24b6c8587b82dcaa",
+    "mtime": 1781771875.3303654,
+    "ast_hash": "d80bd3af513306a307ac48426ec3dcc9",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverBrowserValidationsBuilder.java": {
@@ -3385,8 +3385,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java": {
-    "mtime": 1781642509.8208976,
-    "ast_hash": "9379582def3f5b180522127685ef0e4c",
+    "mtime": 1781771875.3363707,
+    "ast_hash": "9f4d311834c058cb0af3888c87dca6bb",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsExceptionDetailsUnitTest.java": {
@@ -3510,8 +3510,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelper2CoverageUnitTest.java": {
-    "mtime": 1781170595.2474208,
-    "ast_hash": "2891fbc844cccc4eee8b7565e3446cc3",
+    "mtime": 1781771875.3373704,
+    "ast_hash": "64e74e9b6d94e76fafff3f72abe18918",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelperCoverageUnitTest.java": {
@@ -4765,8 +4765,8 @@
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/HealingConfiguration.java": {
-    "mtime": 1781592922.4798534,
-    "ast_hash": "7d540f1d283537631b724e7e903ce765",
+    "mtime": 1781779817.0177398,
+    "ast_hash": "55456f6f26b4f4785903ead93dca9764",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/ShaftHeal.java": {
@@ -4775,8 +4775,8 @@
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/AiCandidateReranker.java": {
-    "mtime": 1781592922.4808538,
-    "ast_hash": "be1ab920d6859520e9b7cfde75897288",
+    "mtime": 1781779842.4433167,
+    "ast_hash": "15cb81409dca9a183cf06fa26d1b1e14",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/CandidateExtractor.java": {
@@ -4835,8 +4835,8 @@
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/ShaftHealingProvider.java": {
-    "mtime": 1781592922.485854,
-    "ast_hash": "331a83061fc768e329ef278d3476ca4f",
+    "mtime": 1781779832.5610223,
+    "ast_hash": "2611967470bd1530c65eff8b9b43b455",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/VisualEvidenceService.java": {
@@ -4915,8 +4915,8 @@
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/ShaftHealingProviderTest.java": {
-    "mtime": 1781592922.4918518,
-    "ast_hash": "81672bcff803ab1ad507c4c818379381",
+    "mtime": 1781780010.0439289,
+    "ast_hash": "58913f4d4e0a5a3ebdf8e3f207c9b7a8",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/WebDomHealingAcceptanceTest.java": {
@@ -5025,8 +5025,8 @@
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java": {
-    "mtime": 1781543699.49248,
-    "ast_hash": "6a882ef67dfb376e34a9821475148646",
+    "mtime": 1781779979.2834768,
+    "ast_hash": "7c4df779fdfa101ce2f160e4fff67646",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/DoctorService.java": {
@@ -5060,8 +5060,8 @@
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCaptureReplayResult.java": {
-    "mtime": 1781543437.2314246,
-    "ast_hash": "d304161b9515688362dfc5555bf7657d",
+    "mtime": 1781779975.4593544,
+    "ast_hash": "e34f3a024d1b050f45b8f2160d74912c",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCodeBlock.java": {
@@ -7062,6 +7062,61 @@
   ".memory/memory/workflows/delegate-only-when-needed-for-correctness.md": {
     "mtime": 1781737578.9808524,
     "ast_hash": "b07cf652dddba20866b2ecbbe4e06136",
+    "semantic_hash": ""
+  },
+  ".memory/memory/decisions/heal-ai-reranking-trigger-gated.json": {
+    "mtime": 1781780396.8516145,
+    "ast_hash": "719229f6c7b2bada51ace6eb701b972e",
+    "semantic_hash": ""
+  },
+  ".memory/memory/facts/deterministic-ai-test-lifecycle-artifacts.json": {
+    "mtime": 1781780396.841604,
+    "ast_hash": "32ca0ce2e4a281714c8abe722a0cd9e6",
+    "semantic_hash": ""
+  },
+  ".memory/relations/decision-heal-ai-reranking-trigger-gated-affects-fact-deterministic-ai-test-lifecycle-artifacts.json": {
+    "mtime": 1781780396.8566122,
+    "ast_hash": "708f894906d6cac3e3ec05afd27ae093",
+    "semantic_hash": ""
+  },
+  "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureReview.java": {
+    "mtime": 1781779714.1101656,
+    "ast_hash": "cae01a20e3a33668c654ac3e2ed6f2d7",
+    "semantic_hash": ""
+  },
+  "shaft-capture/src/main/resources/schema/shaft-capture-review-1.0.schema.json": {
+    "mtime": 1781779772.041079,
+    "ast_hash": "33afab4d67cdaa51061920f467af8e8b",
+    "semantic_hash": ""
+  },
+  "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorTriage.java": {
+    "mtime": 1781779878.6010232,
+    "ast_hash": "0509e7ef19ce71cca5d873721b8918c3",
+    "semantic_hash": ""
+  },
+  "shaft-doctor/src/main/java/com/shaft/doctor/model/ExecutionIntelligence.java": {
+    "mtime": 1781779888.5044975,
+    "ast_hash": "f953d727e98aae2e8324314ad4542ce6",
+    "semantic_hash": ""
+  },
+  "shaft-doctor/src/main/resources/schema/shaft-doctor-triage-1.0.schema.json": {
+    "mtime": 1781779950.7319286,
+    "ast_hash": "8b74d9974899f70eb27656684c67922a",
+    "semantic_hash": ""
+  },
+  "shaft-doctor/src/main/resources/schema/shaft-execution-intelligence-1.0.schema.json": {
+    "mtime": 1781779958.600409,
+    "ast_hash": "6e478de172572cd6de9e4f570a61754d",
+    "semantic_hash": ""
+  },
+  ".memory/memory/decisions/heal-ai-reranking-trigger-gated.md": {
+    "mtime": 1781780396.8466053,
+    "ast_hash": "9e61fd0bec7fb5de29c2d5a2c6500e7c",
+    "semantic_hash": ""
+  },
+  ".memory/memory/facts/deterministic-ai-test-lifecycle-artifacts.md": {
+    "mtime": 1781780396.8356023,
+    "ast_hash": "db58ab1ad8c9a772b56404a0460feb8c",
     "semantic_hash": ""
   }
 }

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationResult.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationResult.java
@@ -25,4 +25,15 @@ public record CaptureGenerationResult(
     public boolean successful() {
         return report != null && report.status() == CaptureGenerationReport.Status.SUCCESS;
     }
+
+    /**
+     * Returns the deterministic review path beside the generation report.
+     *
+     * @return review artifact path
+     */
+    public Path reviewPath() {
+        return reportPath == null || reportPath.getParent() == null
+                ? Path.of("capture-review.json")
+                : reportPath.getParent().resolve("capture-review.json");
+    }
 }

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -204,8 +204,8 @@ public final class CaptureGenerator {
                         CaptureGenerationReport.Validation.skipped("Generation failed before replay."),
                         enrichment);
                 writeReportIfPossible(reportPath, report, request.overwrite());
-                return new CaptureGenerationResult(paths.source(), paths.data(), reportPath,
-                        request.enrichmentPreviewPath(), report);
+                return result(paths.source(), paths.data(), reportPath,
+                        request.enrichmentPreviewPath(), report, request.overwrite());
             }
 
             atomicWrite(paths.source(), source);
@@ -250,12 +250,12 @@ public final class CaptureGenerator {
                         replay,
                         enrichment);
                 atomicWrite(reportPath, writeJson(privacyFailure));
-                return new CaptureGenerationResult(paths.source(), paths.data(), reportPath,
-                        request.enrichmentPreviewPath(), privacyFailure);
+                return result(paths.source(), paths.data(), reportPath,
+                        request.enrichmentPreviewPath(), privacyFailure, request.overwrite());
             }
             atomicWrite(reportPath, reportJson);
-            return new CaptureGenerationResult(paths.source(), paths.data(), reportPath,
-                    request.enrichmentPreviewPath(), report);
+            return result(paths.source(), paths.data(), reportPath,
+                    request.enrichmentPreviewPath(), report, request.overwrite());
         } catch (RuntimeException exception) {
             String sessionId = session == null ? "" : session.sessionId();
             ArtifactPaths safePaths = paths == null
@@ -271,8 +271,8 @@ public final class CaptureGenerator {
                     CaptureGenerationReport.Validation.skipped("Generation failed before replay."),
                     CaptureGenerationReport.Enrichment.notRequested());
             writeReportIfPossible(reportPath, report, request.overwrite());
-            return new CaptureGenerationResult(safePaths.source(), safePaths.data(), reportPath,
-                    request.enrichmentPreviewPath(), report);
+            return result(safePaths.source(), safePaths.data(), reportPath,
+                    request.enrichmentPreviewPath(), report, request.overwrite());
         }
     }
 
@@ -1060,6 +1060,79 @@ public final class CaptureGenerator {
             }
         } catch (RuntimeException ignored) {
             // The returned in-memory report remains available when the filesystem is not writable.
+        }
+    }
+
+    private static CaptureGenerationResult result(
+            Path sourcePath,
+            Path testDataPath,
+            Path reportPath,
+            Path enrichmentPreviewPath,
+            CaptureGenerationReport report,
+            boolean overwrite) {
+        CaptureGenerationResult result = new CaptureGenerationResult(
+                sourcePath, testDataPath, reportPath, enrichmentPreviewPath, report);
+        writeReviewIfPossible(result.reviewPath(), review(report), overwrite);
+        return result;
+    }
+
+    private static void writeReviewIfPossible(Path reviewPath, CaptureReview review, boolean overwrite) {
+        try {
+            if (!Files.exists(reviewPath) || overwrite) {
+                atomicWrite(reviewPath, writeJson(review));
+            }
+        } catch (RuntimeException ignored) {
+            // Review output is additive; generation result remains authoritative.
+        }
+    }
+
+    private static CaptureReview review(CaptureGenerationReport report) {
+        List<String> blockers = new ArrayList<>();
+        blockers.addAll(report.unsupportedEvents());
+        blockers.addAll(report.requiredUserInputs());
+        addValidationBlocker(blockers, "compilation", report.compilation());
+        addValidationBlocker(blockers, "replay", report.replay());
+
+        List<String> risks = new ArrayList<>();
+        risks.addAll(report.flakySteps());
+        risks.addAll(report.fallbackLocators());
+        risks.addAll(report.warnings());
+
+        List<String> suggestions = new ArrayList<>();
+        if (!report.unsupportedEvents().isEmpty()) {
+            suggestions.add("Re-record unsupported events before committing generated source.");
+        }
+        if (!report.requiredUserInputs().isEmpty()) {
+            suggestions.add("Provide the listed external inputs before replay.");
+        }
+        if (!report.flakySteps().isEmpty() || !report.fallbackLocators().isEmpty()) {
+            suggestions.add("Review weak locator and replay-risk diagnostics.");
+        }
+        if (suggestions.isEmpty()) {
+            suggestions.add("Generated test is ready for review.");
+        }
+
+        int score = 100
+                - blockers.size() * 25
+                - report.flakySteps().size() * 10
+                - report.fallbackLocators().size() * 5
+                - report.warnings().size() * 5;
+        return new CaptureReview(
+                CaptureReview.CURRENT_SCHEMA_VERSION,
+                report.sessionId(),
+                score,
+                blockers.stream().distinct().sorted().toList(),
+                risks.stream().distinct().sorted().toList(),
+                suggestions,
+                report.enrichment().provider());
+    }
+
+    private static void addValidationBlocker(
+            List<String> blockers,
+            String label,
+            CaptureGenerationReport.Validation validation) {
+        if (validation.status() == CaptureGenerationReport.Validation.ValidationStatus.FAILED) {
+            blockers.add(label + ": " + String.join("; ", validation.diagnostics()));
         }
     }
 

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureReview.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureReview.java
@@ -1,0 +1,38 @@
+package com.shaft.capture.generate;
+
+import java.util.List;
+
+/**
+ * Deterministic review of generated Capture output.
+ *
+ * @param schemaVersion review schema version
+ * @param sessionId source Capture session
+ * @param readinessScore bounded readiness score from 0 to 100
+ * @param blockers generation blockers that must be fixed first
+ * @param risks replay or locator risks worth reviewing
+ * @param suggestions deterministic next actions
+ * @param provider provider identifier, or {@code none} for deterministic review
+ */
+public record CaptureReview(
+        String schemaVersion,
+        String sessionId,
+        int readinessScore,
+        List<String> blockers,
+        List<String> risks,
+        List<String> suggestions,
+        String provider) {
+    public static final String CURRENT_SCHEMA_VERSION = "1.0";
+
+    /**
+     * Creates an immutable review.
+     */
+    public CaptureReview {
+        schemaVersion = schemaVersion == null ? CURRENT_SCHEMA_VERSION : schemaVersion;
+        sessionId = sessionId == null ? "" : sessionId;
+        readinessScore = Math.max(0, Math.min(100, readinessScore));
+        blockers = blockers == null ? List.of() : List.copyOf(blockers);
+        risks = risks == null ? List.of() : List.copyOf(risks);
+        suggestions = suggestions == null ? List.of() : List.copyOf(suggestions);
+        provider = provider == null || provider.isBlank() ? "none" : provider;
+    }
+}

--- a/shaft-capture/src/main/resources/schema/shaft-capture-review-1.0.schema.json
+++ b/shaft-capture/src/main/resources/schema/shaft-capture-review-1.0.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://shafthq.github.io/schema/shaft-capture-review-1.0.schema.json",
+  "title": "SHAFT Capture Review",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "sessionId",
+    "readinessScore",
+    "blockers",
+    "risks",
+    "suggestions",
+    "provider"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "1.0"},
+    "sessionId": {"type": "string"},
+    "readinessScore": {"type": "integer", "minimum": 0, "maximum": 100},
+    "blockers": {"type": "array", "items": {"type": "string"}},
+    "risks": {"type": "array", "items": {"type": "string"}},
+    "suggestions": {"type": "array", "items": {"type": "string"}},
+    "provider": {"type": "string"}
+  },
+  "additionalProperties": false
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -41,6 +41,12 @@ class CaptureGeneratorTest {
         assertTrue(first.successful(), first.report().unsupportedEvents().toString());
         assertEquals(CaptureGenerationReport.Validation.ValidationStatus.PASSED,
                 first.report().compilation().status());
+        assertTrue(Files.isRegularFile(first.reviewPath()));
+        var review = JSON.readTree(first.reviewPath().toFile());
+        assertEquals("1.0", review.path("schemaVersion").asText());
+        assertEquals(first.report().sessionId(), review.path("sessionId").asText());
+        assertTrue(review.path("readinessScore").asInt() >= 0);
+        assertTrue(review.path("blockers").isEmpty());
         assertEquals(Files.readString(first.sourcePath()), Files.readString(second.sourcePath()));
         assertEquals(Files.readString(first.testDataPath()), Files.readString(second.testDataPath()));
         assertEquals(first.report(), second.report());

--- a/shaft-doctor/src/main/java/com/shaft/doctor/DoctorAnalyzer.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/DoctorAnalyzer.java
@@ -1,26 +1,43 @@
 package com.shaft.doctor;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.shaft.doctor.ai.DoctorAiAnalysisService;
 import com.shaft.doctor.analysis.DeterministicRuleEngine;
 import com.shaft.doctor.collect.EvidenceCollector;
 import com.shaft.doctor.format.DoctorJsonCodec;
+import com.shaft.doctor.model.ExecutionIntelligence;
 import com.shaft.doctor.model.Diagnosis;
 import com.shaft.doctor.model.DoctorAdvisory;
 import com.shaft.doctor.model.DoctorAiAnalysisResult;
 import com.shaft.doctor.model.DoctorAnalysisResult;
 import com.shaft.doctor.model.EvidenceBundle;
+import com.shaft.doctor.model.EvidenceCategory;
+import com.shaft.doctor.model.EvidenceItem;
+import com.shaft.doctor.model.DoctorTriage;
 import com.shaft.doctor.report.DoctorReportWriter;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Offline deterministic SHAFT evidence analyzer.
  */
 public final class DoctorAnalyzer {
+    private static final ObjectMapper JSON = new ObjectMapper()
+            .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
+    private static final Set<String> FAILURE_STATUSES = Set.of("failed", "broken");
+    private static final Set<String> NON_FINAL_ISSUE_STATUSES = Set.of("failed", "broken", "skipped");
+
     private final EvidenceCollector collector;
     private final DeterministicRuleEngine rules;
     private final DoctorJsonCodec codec;
@@ -65,14 +82,21 @@ public final class DoctorAnalyzer {
     public DoctorAnalysisResult analyze(DoctorAnalysisRequest request) {
         DoctorAnalysisRequest resolvedRequest = resolveOutputBoundary(request);
         EvidenceBundle bundle = collector.collect(resolvedRequest);
-        Diagnosis diagnosis = rules.diagnose(bundle, collector.loadHistoricalBundles(resolvedRequest));
+        List<EvidenceBundle> history = collector.loadHistoricalBundles(resolvedRequest);
+        Diagnosis diagnosis = rules.diagnose(bundle, history);
         Path output = resolvedRequest.outputDirectory();
         Path bundlePath = output.resolve("doctor-evidence.json");
         Path jsonReportPath = output.resolve("doctor-report.json");
         Path markdownReportPath = output.resolve("doctor-report.md");
+        DoctorTriage triage = triage(bundle, history, diagnosis);
+        ExecutionIntelligence intelligence = intelligence(triage, diagnosis);
         codec.write(bundlePath, bundle);
         codec.writeReport(jsonReportPath, bundle, diagnosis);
         reports.writeMarkdown(markdownReportPath, bundle, diagnosis);
+        writeJson(output.resolve("doctor-triage.json"), triage);
+        writeMarkdown(output.resolve("doctor-triage.md"), triageMarkdown(triage));
+        writeJson(output.resolve("execution-intelligence.json"), intelligence);
+        writeMarkdown(output.resolve("execution-intelligence.md"), intelligenceMarkdown(intelligence));
         return new DoctorAnalysisResult(
                 bundle,
                 diagnosis,
@@ -169,5 +193,149 @@ public final class DoctorAnalyzer {
         } catch (IOException exception) {
             throw new IllegalArgumentException("Doctor allowed root or output ancestor cannot be resolved.", exception);
         }
+    }
+
+    private static DoctorTriage triage(
+            EvidenceBundle bundle,
+            List<EvidenceBundle> history,
+            Diagnosis diagnosis) {
+        List<EvidenceItem> allure = validAllure(bundle);
+        List<EvidenceItem> failures = allure.stream()
+                .filter(item -> FAILURE_STATUSES.contains(item.attributes().get("status")))
+                .toList();
+        Set<String> historicalSignatures = new LinkedHashSet<>();
+        for (EvidenceBundle historical : history == null ? List.<EvidenceBundle>of() : history) {
+            validAllure(historical).stream()
+                    .filter(item -> FAILURE_STATUSES.contains(item.attributes().get("status")))
+                    .map(item -> item.attributes().getOrDefault("signature", ""))
+                    .filter(signature -> !signature.isBlank())
+                    .forEach(historicalSignatures::add);
+        }
+        int recurring = Math.toIntExact(failures.stream()
+                .map(item -> item.attributes().getOrDefault("signature", ""))
+                .filter(historicalSignatures::contains)
+                .count());
+        String primarySignature = failures.stream()
+                .map(item -> item.attributes().getOrDefault("signature", ""))
+                .filter(signature -> !signature.isBlank())
+                .findFirst()
+                .orElse("");
+        return new DoctorTriage(
+                DoctorTriage.CURRENT_SCHEMA_VERSION,
+                bundle.bundleId(),
+                allure.size(),
+                failures.size(),
+                hiddenRetryFailures(allure),
+                recurring,
+                primarySignature,
+                diagnosis.summary(),
+                citedEvidence(diagnosis));
+    }
+
+    private static ExecutionIntelligence intelligence(DoctorTriage triage, Diagnosis diagnosis) {
+        String summary = triage.failingAttempts() == 0
+                ? "No failed or broken Allure attempt was present."
+                : triage.failingAttempts() + " failing attempt(s); primary cause "
+                        + diagnosis.primaryCause() + " with " + diagnosis.confidence() + " confidence.";
+        if (triage.hiddenRetryFailures() > 0) {
+            summary += " " + triage.hiddenRetryFailures() + " retry-hidden failure group(s) need review.";
+        }
+        if (triage.recurringFailures() > 0) {
+            summary += " " + triage.recurringFailures() + " recurring failure(s) matched historical bundles.";
+        }
+        return new ExecutionIntelligence(
+                ExecutionIntelligence.CURRENT_SCHEMA_VERSION,
+                triage.bundleId(),
+                triage.totalAllureResults(),
+                triage.failingAttempts(),
+                triage.hiddenRetryFailures(),
+                triage.recurringFailures(),
+                diagnosis.primaryCause(),
+                diagnosis.confidence(),
+                summary);
+    }
+
+    private static List<EvidenceItem> validAllure(EvidenceBundle bundle) {
+        return bundle.evidence().stream()
+                .filter(item -> item.category() == EvidenceCategory.ALLURE_RESULT)
+                .filter(item -> !"true".equals(item.attributes().get("invalid")))
+                .toList();
+    }
+
+    private static int hiddenRetryFailures(List<EvidenceItem> attempts) {
+        Map<String, List<EvidenceItem>> groups = new LinkedHashMap<>();
+        for (EvidenceItem attempt : attempts) {
+            String key = attempt.attributes().getOrDefault(
+                    "historyId", attempt.attributes().getOrDefault("name", attempt.id()));
+            groups.computeIfAbsent(key, ignored -> new ArrayList<>()).add(attempt);
+        }
+        int hidden = 0;
+        for (List<EvidenceItem> group : groups.values()) {
+            group.sort(Comparator.comparingLong(DoctorAnalyzer::start).thenComparing(EvidenceItem::id));
+            EvidenceItem last = group.getLast();
+            boolean priorFailure = group.subList(0, Math.max(0, group.size() - 1)).stream()
+                    .anyMatch(item -> NON_FINAL_ISSUE_STATUSES.contains(item.attributes().get("status")));
+            if (group.size() > 1 && priorFailure && "passed".equals(last.attributes().get("status"))) {
+                hidden++;
+            }
+        }
+        return hidden;
+    }
+
+    private static List<String> citedEvidence(Diagnosis diagnosis) {
+        LinkedHashSet<String> ids = new LinkedHashSet<>();
+        diagnosis.findings().forEach(finding -> ids.addAll(finding.evidenceIds()));
+        diagnosis.remediations().forEach(remediation -> ids.addAll(remediation.evidenceIds()));
+        return List.copyOf(ids);
+    }
+
+    private static long start(EvidenceItem item) {
+        try {
+            return Long.parseLong(item.attributes().getOrDefault("start", "0"));
+        } catch (NumberFormatException exception) {
+            return 0;
+        }
+    }
+
+    private static void writeJson(Path path, Object value) {
+        try {
+            Files.createDirectories(path.getParent());
+            Files.writeString(path, JSON.writerWithDefaultPrettyPrinter().writeValueAsString(value) + "\n",
+                    StandardCharsets.UTF_8);
+        } catch (IOException exception) {
+            throw new IllegalStateException("Doctor intelligence artifact could not be written.", exception);
+        }
+    }
+
+    private static void writeMarkdown(Path path, String value) {
+        try {
+            Files.createDirectories(path.getParent());
+            Files.writeString(path, value, StandardCharsets.UTF_8);
+        } catch (IOException exception) {
+            throw new IllegalStateException("Doctor intelligence Markdown could not be written.", exception);
+        }
+    }
+
+    private static String triageMarkdown(DoctorTriage triage) {
+        return "# SHAFT Doctor Triage\n\n"
+                + "- Bundle: `" + triage.bundleId() + "`\n"
+                + "- Valid Allure results: " + triage.totalAllureResults() + "\n"
+                + "- Failing attempts: " + triage.failingAttempts() + "\n"
+                + "- Retry-hidden failures: " + triage.hiddenRetryFailures() + "\n"
+                + "- Recurring failures: " + triage.recurringFailures() + "\n"
+                + "- Primary signature: `" + triage.primarySignature() + "`\n\n"
+                + triage.summary() + "\n";
+    }
+
+    private static String intelligenceMarkdown(ExecutionIntelligence intelligence) {
+        return "# SHAFT Execution Intelligence\n\n"
+                + "- Bundle: `" + intelligence.bundleId() + "`\n"
+                + "- Primary cause: `" + intelligence.primaryCause() + "`\n"
+                + "- Confidence: `" + intelligence.confidence() + "`\n"
+                + "- Valid Allure results: " + intelligence.totalAllureResults() + "\n"
+                + "- Failing attempts: " + intelligence.failingAttempts() + "\n"
+                + "- Retry-hidden failures: " + intelligence.hiddenRetryFailures() + "\n"
+                + "- Recurring failures: " + intelligence.recurringFailures() + "\n\n"
+                + intelligence.summary() + "\n";
     }
 }

--- a/shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorTriage.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorTriage.java
@@ -1,0 +1,44 @@
+package com.shaft.doctor.model;
+
+import java.util.List;
+
+/**
+ * Run-level deterministic failure triage.
+ *
+ * @param schemaVersion triage schema version
+ * @param bundleId evidence bundle identifier
+ * @param totalAllureResults valid Allure result count
+ * @param failingAttempts failed or broken attempt count
+ * @param hiddenRetryFailures retry groups with a prior non-passing attempt and a final pass
+ * @param recurringFailures current failures with signatures seen in historical bundles
+ * @param primarySignature first current failure signature
+ * @param summary concise deterministic triage summary
+ * @param evidenceIds cited evidence identifiers
+ */
+public record DoctorTriage(
+        String schemaVersion,
+        String bundleId,
+        int totalAllureResults,
+        int failingAttempts,
+        int hiddenRetryFailures,
+        int recurringFailures,
+        String primarySignature,
+        String summary,
+        List<String> evidenceIds) {
+    public static final String CURRENT_SCHEMA_VERSION = "1.0";
+
+    /**
+     * Creates immutable triage.
+     */
+    public DoctorTriage {
+        schemaVersion = schemaVersion == null ? CURRENT_SCHEMA_VERSION : schemaVersion;
+        bundleId = DoctorModelSupport.text(bundleId);
+        totalAllureResults = Math.max(0, totalAllureResults);
+        failingAttempts = Math.max(0, failingAttempts);
+        hiddenRetryFailures = Math.max(0, hiddenRetryFailures);
+        recurringFailures = Math.max(0, recurringFailures);
+        primarySignature = DoctorModelSupport.text(primarySignature);
+        summary = DoctorModelSupport.requireText(summary, "Triage summary");
+        evidenceIds = DoctorModelSupport.list(evidenceIds);
+    }
+}

--- a/shaft-doctor/src/main/java/com/shaft/doctor/model/ExecutionIntelligence.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/model/ExecutionIntelligence.java
@@ -1,0 +1,42 @@
+package com.shaft.doctor.model;
+
+/**
+ * Deterministic execution digest for reporting.
+ *
+ * @param schemaVersion digest schema version
+ * @param bundleId evidence bundle identifier
+ * @param totalAllureResults valid Allure result count
+ * @param failingAttempts failed or broken attempt count
+ * @param hiddenRetryFailures retry-hidden failure count
+ * @param recurringFailures recurring failure count
+ * @param primaryCause deterministic primary cause
+ * @param confidence deterministic confidence
+ * @param summary concise execution summary
+ */
+public record ExecutionIntelligence(
+        String schemaVersion,
+        String bundleId,
+        int totalAllureResults,
+        int failingAttempts,
+        int hiddenRetryFailures,
+        int recurringFailures,
+        CauseCategory primaryCause,
+        Confidence confidence,
+        String summary) {
+    public static final String CURRENT_SCHEMA_VERSION = "1.0";
+
+    /**
+     * Creates immutable execution intelligence.
+     */
+    public ExecutionIntelligence {
+        schemaVersion = schemaVersion == null ? CURRENT_SCHEMA_VERSION : schemaVersion;
+        bundleId = DoctorModelSupport.text(bundleId);
+        totalAllureResults = Math.max(0, totalAllureResults);
+        failingAttempts = Math.max(0, failingAttempts);
+        hiddenRetryFailures = Math.max(0, hiddenRetryFailures);
+        recurringFailures = Math.max(0, recurringFailures);
+        primaryCause = primaryCause == null ? CauseCategory.UNKNOWN : primaryCause;
+        confidence = confidence == null ? Confidence.UNKNOWN : confidence;
+        summary = DoctorModelSupport.requireText(summary, "Execution intelligence summary");
+    }
+}

--- a/shaft-doctor/src/main/resources/schema/shaft-doctor-triage-1.0.schema.json
+++ b/shaft-doctor/src/main/resources/schema/shaft-doctor-triage-1.0.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://shafthq.github.io/schema/shaft-doctor-triage-1.0.schema.json",
+  "title": "SHAFT Doctor Triage",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "bundleId",
+    "totalAllureResults",
+    "failingAttempts",
+    "hiddenRetryFailures",
+    "recurringFailures",
+    "primarySignature",
+    "summary",
+    "evidenceIds"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "1.0"},
+    "bundleId": {"type": "string"},
+    "totalAllureResults": {"type": "integer", "minimum": 0},
+    "failingAttempts": {"type": "integer", "minimum": 0},
+    "hiddenRetryFailures": {"type": "integer", "minimum": 0},
+    "recurringFailures": {"type": "integer", "minimum": 0},
+    "primarySignature": {"type": "string"},
+    "summary": {"type": "string", "minLength": 1},
+    "evidenceIds": {"type": "array", "items": {"type": "string"}}
+  },
+  "additionalProperties": false
+}

--- a/shaft-doctor/src/main/resources/schema/shaft-execution-intelligence-1.0.schema.json
+++ b/shaft-doctor/src/main/resources/schema/shaft-execution-intelligence-1.0.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://shafthq.github.io/schema/shaft-execution-intelligence-1.0.schema.json",
+  "title": "SHAFT Execution Intelligence",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "bundleId",
+    "totalAllureResults",
+    "failingAttempts",
+    "hiddenRetryFailures",
+    "recurringFailures",
+    "primaryCause",
+    "confidence",
+    "summary"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "1.0"},
+    "bundleId": {"type": "string"},
+    "totalAllureResults": {"type": "integer", "minimum": 0},
+    "failingAttempts": {"type": "integer", "minimum": 0},
+    "hiddenRetryFailures": {"type": "integer", "minimum": 0},
+    "recurringFailures": {"type": "integer", "minimum": 0},
+    "primaryCause": {"type": "string"},
+    "confidence": {"type": "string"},
+    "summary": {"type": "string", "minLength": 1}
+  },
+  "additionalProperties": false
+}

--- a/shaft-doctor/src/test/java/com/shaft/doctor/DoctorAnalyzerTest.java
+++ b/shaft-doctor/src/test/java/com/shaft/doctor/DoctorAnalyzerTest.java
@@ -98,6 +98,12 @@ class DoctorAnalyzerTest {
         assertEquals(CauseCategory.LOCATOR, firstResult.diagnosis().primaryCause());
         assertTrue(firstResult.diagnosis().findings().stream()
                 .anyMatch(finding -> finding.ruleId().equals("retry-correlation")));
+        var firstTriage = MAPPER.readTree(Path.of(firstResult.jsonReportPath()).getParent()
+                .resolve("doctor-triage.json").toFile());
+        assertEquals(1, firstTriage.path("hiddenRetryFailures").asInt());
+        assertEquals(1, firstTriage.path("failingAttempts").asInt());
+        assertTrue(Files.isRegularFile(Path.of(firstResult.jsonReportPath()).getParent()
+                .resolve("execution-intelligence.md")));
 
         Path second = Files.createDirectories(temp.resolve("second"));
         writeResult(second.resolve("repeat-result.json"), "failed",
@@ -107,6 +113,10 @@ class DoctorAnalyzerTest {
 
         assertTrue(repeated.diagnosis().findings().stream()
                 .anyMatch(finding -> finding.ruleId().equals("historical-signature-correlation")));
+        var repeatedIntelligence = MAPPER.readTree(Path.of(repeated.jsonReportPath()).getParent()
+                .resolve("execution-intelligence.json").toFile());
+        assertEquals(1, repeatedIntelligence.path("recurringFailures").asInt());
+        assertTrue(repeatedIntelligence.path("summary").asText().contains("recurring"));
     }
 
     @Test

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Healing.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Healing.java
@@ -81,6 +81,11 @@ public interface Healing extends EngineProperties<Healing> {
     @DefaultValue("false")
     boolean aiEnabled();
 
+    /** @return when optional provider reranking may run: never, ambiguous, below-threshold, or always */
+    @Key("healing.ai.trigger")
+    @DefaultValue("ambiguous")
+    String aiTrigger();
+
     /** @return whether reviewed source-patch proposals may be emitted */
     @Key("healing.sourcePatch.enabled")
     @DefaultValue("false")
@@ -168,6 +173,12 @@ public interface Healing extends EngineProperties<Healing> {
         /** @param value AI reranking enabled state @return this builder */
         public SetProperty aiEnabled(boolean value) {
             setProperty("healing.ai.enabled", String.valueOf(value));
+            return this;
+        }
+
+        /** @param value AI trigger policy @return this builder */
+        public SetProperty aiTrigger(String value) {
+            setProperty("healing.ai.trigger", value);
             return this;
         }
 

--- a/shaft-engine/src/main/resources/properties/default/custom.properties
+++ b/shaft-engine/src/main/resources/properties/default/custom.properties
@@ -27,6 +27,7 @@ healing.history.maxEntries=500
 healing.history.retentionDays=30
 healing.visual.enabled=false
 healing.ai.enabled=false
+healing.ai.trigger=ambiguous
 healing.sourcePatch.enabled=false
 
 # Optional natural-language GUI actions

--- a/shaft-heal/src/main/java/com/shaft/heal/HealingConfiguration.java
+++ b/shaft-heal/src/main/java/com/shaft/heal/HealingConfiguration.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
  * @param historyRetention history retention
  * @param visualEnabled whether optional visual evidence is enabled
  * @param aiEnabled whether optional provider reranking is enabled
+ * @param aiTrigger when optional provider reranking may run
  * @param sourcePatchEnabled whether reviewed source-patch proposals are permitted
  */
 public record HealingConfiguration(
@@ -36,7 +37,38 @@ public record HealingConfiguration(
         Duration historyRetention,
         boolean visualEnabled,
         boolean aiEnabled,
+        AiTrigger aiTrigger,
         boolean sourcePatchEnabled) {
+    /**
+     * Optional provider reranking trigger.
+     */
+    public enum AiTrigger {
+        NEVER,
+        AMBIGUOUS,
+        BELOW_THRESHOLD,
+        ALWAYS
+    }
+
+    /**
+     * Backward-compatible constructor with the default AI trigger.
+     */
+    public HealingConfiguration(
+            double minimumConfidence,
+            double ambiguityMargin,
+            Set<String> evidenceCategories,
+            List<String> testIdAttributes,
+            boolean historyEnabled,
+            Path historyPath,
+            int historyMaxEntries,
+            Duration historyRetention,
+            boolean visualEnabled,
+            boolean aiEnabled,
+            boolean sourcePatchEnabled) {
+        this(minimumConfidence, ambiguityMargin, evidenceCategories, testIdAttributes,
+                historyEnabled, historyPath, historyMaxEntries, historyRetention,
+                visualEnabled, aiEnabled, AiTrigger.AMBIGUOUS, sourcePatchEnabled);
+    }
+
     /**
      * Reads the effective current-thread configuration.
      *
@@ -60,7 +92,19 @@ public record HealingConfiguration(
                 Duration.ofDays(Math.max(1, properties.historyRetentionDays())),
                 properties.visualEnabled(),
                 properties.aiEnabled(),
+                aiTrigger(properties.aiTrigger()),
                 properties.sourcePatchEnabled());
+    }
+
+    /**
+     * Creates a normalized configuration.
+     */
+    public HealingConfiguration {
+        evidenceCategories = evidenceCategories == null ? Set.of() : Set.copyOf(evidenceCategories);
+        testIdAttributes = testIdAttributes == null ? List.of() : List.copyOf(testIdAttributes);
+        historyPath = historyPath == null ? Path.of("target/shaft-heal/history.json") : historyPath;
+        historyRetention = historyRetention == null ? Duration.ofDays(30) : historyRetention;
+        aiTrigger = aiTrigger == null ? AiTrigger.AMBIGUOUS : aiTrigger;
     }
 
     private static List<String> split(String value) {
@@ -75,5 +119,14 @@ public record HealingConfiguration(
 
     private static double bounded(double value, double fallback) {
         return value >= 0 && value <= 1 ? value : fallback;
+    }
+
+    private static AiTrigger aiTrigger(String value) {
+        String normalized = value == null ? "" : value.trim().replace('-', '_').toUpperCase(Locale.ROOT);
+        try {
+            return normalized.isBlank() ? AiTrigger.AMBIGUOUS : AiTrigger.valueOf(normalized);
+        } catch (IllegalArgumentException ignored) {
+            return AiTrigger.AMBIGUOUS;
+        }
     }
 }

--- a/shaft-heal/src/main/java/com/shaft/heal/internal/AiCandidateReranker.java
+++ b/shaft-heal/src/main/java/com/shaft/heal/internal/AiCandidateReranker.java
@@ -39,7 +39,7 @@ final class AiCandidateReranker {
 
     RerankResult apply(List<RankedCandidate> candidates) {
         if (!configuration.aiEnabled() || candidates.isEmpty()) {
-            return new RerankResult(candidates, HealingReport.ProviderMetadata.disabled(), false);
+            return new RerankResult(candidates, HealingReport.ProviderMetadata.disabled(), false, false);
         }
         PilotConfiguration pilotConfiguration;
         try {
@@ -81,7 +81,7 @@ final class AiCandidateReranker {
                 location.name().toLowerCase(java.util.Locale.ROOT).replace('_', '-'),
                 "Pilot redaction policy applied before provider execution.");
         if (!response.successful()) {
-            return new RerankResult(candidates, metadata, evidenceLeavesProcess(location));
+            return new RerankResult(candidates, metadata, evidenceLeavesProcess(location), true);
         }
         Map<String, Double> providerScores;
         try {
@@ -96,7 +96,7 @@ final class AiCandidateReranker {
                     location.name(),
                     location.name().toLowerCase(java.util.Locale.ROOT).replace('_', '-'),
                     "Pilot redaction policy applied before provider execution.");
-            return new RerankResult(candidates, rejected, evidenceLeavesProcess(location));
+            return new RerankResult(candidates, rejected, evidenceLeavesProcess(location), true);
         }
 
         List<RankedCandidate> updated = candidates.stream().map(candidate -> {
@@ -125,7 +125,7 @@ final class AiCandidateReranker {
                     oldReport.contextMatched());
             return new RankedCandidate(candidate.element(), candidate.locator(), updatedReport);
         }).toList();
-        return new RerankResult(updated, metadata, evidenceLeavesProcess(location));
+        return new RerankResult(updated, metadata, evidenceLeavesProcess(location), true);
     }
 
     private static Map<String, Double> parse(JsonNode payload, List<RankedCandidate> candidates) {
@@ -192,7 +192,8 @@ final class AiCandidateReranker {
         return new RerankResult(
                 candidates,
                 new HealingReport.ProviderMetadata(true, "none", "", "FALLBACK", reason),
-                false);
+                false,
+                true);
     }
 
     private static ProcessingLocation processingLocation(
@@ -213,6 +214,7 @@ final class AiCandidateReranker {
     record RerankResult(
             List<RankedCandidate> candidates,
             HealingReport.ProviderMetadata metadata,
-            boolean remoteEvidenceSent) {
+            boolean remoteEvidenceSent,
+            boolean applied) {
     }
 }

--- a/shaft-heal/src/main/java/com/shaft/heal/internal/ShaftHealingProvider.java
+++ b/shaft-heal/src/main/java/com/shaft/heal/internal/ShaftHealingProvider.java
@@ -82,9 +82,14 @@ public class ShaftHealingProvider implements HealingProvider {
                         request.shadowHostLocator());
         candidates = new VisualEvidenceService(configuration)
                 .apply(candidates, retained.get().visualReference());
-        AiCandidateReranker.RerankResult reranked = new AiCandidateReranker(configuration).apply(candidates);
         HealingDecisionEngine.DecisionResult result = HealingDecisionEngine.decide(
-                reranked.candidates(), configuration, request.visibilityRequired());
+                candidates, configuration, request.visibilityRequired());
+        AiCandidateReranker.RerankResult reranked = rerankIfTriggered(
+                candidates, configuration, result.decision());
+        if (reranked.applied()) {
+            result = HealingDecisionEngine.decide(
+                    reranked.candidates(), configuration, request.visibilityRequired());
+        }
         HealingReport report = report(
                 attemptId,
                 request,
@@ -255,6 +260,45 @@ public class ShaftHealingProvider implements HealingProvider {
                 })
                 .map(RankedCandidate::report)
                 .toList();
+    }
+
+    private static AiCandidateReranker.RerankResult rerankIfTriggered(
+            List<RankedCandidate> candidates,
+            HealingConfiguration configuration,
+            HealingDecision decision) {
+        if (!configuration.aiEnabled()) {
+            return new AiCandidateReranker.RerankResult(
+                    candidates, HealingReport.ProviderMetadata.disabled(), false, false);
+        }
+        if (!aiTriggered(configuration.aiTrigger(), decision.status(), candidates)) {
+            return new AiCandidateReranker.RerankResult(
+                    candidates,
+                    new HealingReport.ProviderMetadata(
+                            true,
+                            "none",
+                            "",
+                            "SKIPPED",
+                            "AI reranking not triggered for " + decision.status() + "."),
+                    false,
+                    false);
+        }
+        return new AiCandidateReranker(configuration).apply(candidates);
+    }
+
+    private static boolean aiTriggered(
+            HealingConfiguration.AiTrigger trigger,
+            HealingDecision.Status status,
+            List<RankedCandidate> candidates) {
+        if (candidates.isEmpty()) {
+            return false;
+        }
+        return switch (trigger) {
+            case ALWAYS -> true;
+            case BELOW_THRESHOLD -> status == HealingDecision.Status.BELOW_THRESHOLD;
+            case AMBIGUOUS -> status == HealingDecision.Status.AMBIGUOUS
+                    || status == HealingDecision.Status.BELOW_THRESHOLD;
+            case NEVER -> false;
+        };
     }
 
     private record PendingRecovery(

--- a/shaft-heal/src/test/java/com/shaft/heal/internal/ShaftHealingProviderTest.java
+++ b/shaft-heal/src/test/java/com/shaft/heal/internal/ShaftHealingProviderTest.java
@@ -170,6 +170,31 @@ public class ShaftHealingProviderTest {
     }
 
     @Test
+    public void enabledAiShouldNotRunForDeterministicRecoveryByDefault() {
+        SHAFT.Properties.healing.set()
+                .aiEnabled(true)
+                .aiTrigger("ambiguous");
+        WebDriver driver = driver();
+        WebElement original = element("old-id", "Username");
+        WebElement candidate = element("new-id", "Username");
+        configureSearch(driver, List.of(candidate));
+        ShaftHealingProvider provider = new ShaftHealingProvider();
+        By originalLocator = By.id("old-id");
+        provider.observe(new HealingObservation(driver, originalLocator, original, "CLICK", null, null, null));
+
+        HealingResolution resolution = provider.resolve(new HealingRequest(
+                        driver, originalLocator, "CLICK", true, null, null, null))
+                .orElseThrow();
+
+        Assert.assertEquals(ShaftHeal.lastReport().orElseThrow().decision().status(),
+                HealingDecision.Status.RECOVERED);
+        Assert.assertEquals(ShaftHeal.lastReport().orElseThrow().provider().status(), "SKIPPED");
+        Assert.assertTrue(ShaftHeal.lastReport().orElseThrow().provider().fallbackReason()
+                .contains("not triggered"));
+        provider.clear(driver);
+    }
+
+    @Test
     public void closingDifferentDriverShouldNotDiscardPendingRecovery() {
         WebDriver driver = driver();
         WebDriver otherDriver = driver();

--- a/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
@@ -297,6 +297,7 @@ public class CaptureService {
                 result.sourcePath(),
                 result.testDataPath(),
                 result.reportPath(),
+                result.reviewPath(),
                 result.successful(),
                 blocks,
                 result.report(),

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpCaptureReplayResult.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpCaptureReplayResult.java
@@ -11,6 +11,7 @@ import java.util.List;
  * @param sourcePath generated source path
  * @param testDataPath generated test-data path
  * @param reportPath generation report path
+ * @param reviewPath deterministic review path
  * @param successful whether generation and requested validations passed
  * @param codeBlocks copy-paste blocks extracted from generated output
  * @param report deterministic generation report
@@ -20,6 +21,7 @@ public record McpCaptureReplayResult(
         Path sourcePath,
         Path testDataPath,
         Path reportPath,
+        Path reviewPath,
         boolean successful,
         List<McpCodeBlock> codeBlocks,
         CaptureGenerationReport report,


### PR DESCRIPTION
## Summary
- Add Capture `capture-review.json` with deterministic readiness score, blockers, risks, suggestions, and schema; expose `reviewPath` through Capture generation and MCP results.
- Add `healing.ai.trigger` with default `ambiguous`, so enabled AI reranking stays deterministic-first and only runs when configured trigger conditions are met.
- Add Doctor `doctor-triage.*` and `execution-intelligence.*` outputs for retry-hidden failures, recurring failures, primary signatures/causes, and concise reporting.
- Save project Memory for the new behavior and refresh root Graphify outputs.

## Companion docs
- https://github.com/ShaftHQ/shafthq.github.io/pull/546

## Validation
- `mvn -pl shaft-capture,shaft-heal,shaft-doctor,shaft-mcp -am '-DskipTests' test-compile`
- `git diff --check`
- `git diff --cached --check`
- `memory check`
- `graphify update .` in SHAFT_ENGINE

## Notes
- I did not run `mvn test` because project memory flags a local Surefire/TestNG gotcha that can delete module worktrees; this pass used `test-compile` instead.
- The docs PR remains draft because docs Graphify semantic refresh is blocked by missing semantic backend credentials and the code-only update refused to overwrite the docs graph.