### PR TITLE
Enforce remote WebDriver session timeout

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -37,6 +37,7 @@ import org.openqa.selenium.edge.EdgeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.remote.*;
+import org.openqa.selenium.remote.http.ClientConfig;
 import org.openqa.selenium.remote.http.ConnectionFailedException;
 import org.openqa.selenium.safari.SafariDriver;
 import org.testng.Reporter;
@@ -45,6 +46,8 @@ import java.io.ByteArrayInputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -321,6 +324,14 @@ public class DriverFactoryHelper {
         return url;
     }
 
+    private static ClientConfig createRemoteWebDriverClientConfig(URL targetExecutionUrl) {
+        var timeout = Duration.ofSeconds(remoteServerInstanceCreationTimeout);
+        return ClientConfig.defaultConfig()
+                .baseUrl(targetExecutionUrl)
+                .connectionTimeout(timeout)
+                .readTimeout(timeout);
+    }
+
     @SneakyThrows({InterruptedException.class, MalformedURLException.class})
     private static WebDriver attemptRemoteServerConnection(Capabilities capabilities) {
         WebDriver driver = null;
@@ -416,15 +427,16 @@ public class DriverFactoryHelper {
         ReportManagerHelper.logDiscrete("Target Execution URI used for remote connection: `" + redactUriCredentials(targetExecutionUrl) + "`.", Level.DEBUG);
         ReportManagerHelper.logDiscrete("Capabilities after processing: `" + capabilities.toString() + "`.", Level.DEBUG);
         try {
+            var targetExecutionUrlObject = URI.create(targetExecutionUrl).toURL();
             //builder code block, has issues in many cases, test it locally via grid before using it
 //            if (isAndroidExecution) return AndroidDriver.builder().address(targetExecutionUrl).oneOf(capabilities).build();
 //            else if (isIosExecution) return IOSDriver.builder().address(targetExecutionUrl).oneOf(capabilities).build();
 //            else return RemoteWebDriver.builder().address(targetExecutionUrl).oneOf(capabilities).build();
             // legacy constructor-based code block
-            if (isAndroidExecution) return new AndroidDriver(new URI(targetExecutionUrl).toURL(), capabilities);
-            else if (isIosExecution) return new IOSDriver(new URI(targetExecutionUrl).toURL(), capabilities);
+            if (isAndroidExecution) return new AndroidDriver(targetExecutionUrlObject, capabilities);
+            else if (isIosExecution) return new IOSDriver(targetExecutionUrlObject, capabilities);
             else {
-                var driver = new RemoteWebDriver(URI.create(targetExecutionUrl).toURL(), capabilities);
+                var driver = new RemoteWebDriver(targetExecutionUrlObject, capabilities, createRemoteWebDriverClientConfig(targetExecutionUrlObject));
                 driver.setFileDetector(new LocalFileDetector());
                 var augmenter = new Augmenter();
                 var targetBrowser = SHAFT.Properties.web.targetBrowserName().toLowerCase();

--- a/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelperCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelperCoverageUnitTest.java
@@ -28,6 +28,7 @@ import org.openqa.selenium.logging.Logs;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.http.HttpResponse;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.http.ClientConfig;
 import org.openqa.selenium.safari.SafariOptions;
 import org.openqa.selenium.safari.SafariDriver;
 import io.github.bonigarcia.wdm.WebDriverManager;
@@ -38,6 +39,7 @@ import org.testng.annotations.Test;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -509,6 +511,31 @@ public class DriverFactoryHelperCoverageUnitTest {
             helper.initializeDriver(com.shaft.driver.DriverFactory.DriverType.CHROME, null);
             SHAFT.Validations.assertThat().object(helper.getDriver()).isNotNull().perform();
         }
+    }
+
+    @Test
+    public void initializeDriverShouldApplyConfiguredTimeoutToRemoteDesktopHttpClient() {
+        SHAFT.Properties.platform.set().targetPlatform("windows");
+        SHAFT.Properties.platform.set().executionAddress("http://localhost:4444");
+        SHAFT.Properties.web.set().targetBrowserName("chrome").headlessExecution(true);
+        SHAFT.Properties.flags.set().autoMaximizeBrowserWindow(false);
+        SHAFT.Properties.healenium.set().healEnabled(false);
+        SHAFT.Properties.timeouts.set().waitForRemoteServerToBeUp(false);
+
+        var constructionArguments = new java.util.ArrayList<List<?>>();
+        DriverFactoryHelper helper = new DriverFactoryHelper();
+        try (MockedConstruction<RemoteWebDriver> ignored = org.mockito.Mockito.mockConstruction(RemoteWebDriver.class,
+                (mock, context) -> {
+                    constructionArguments.add(context.arguments());
+                    org.mockito.Mockito.when(mock.getCapabilities()).thenReturn(new ImmutableCapabilities());
+                })) {
+            helper.initializeDriver(com.shaft.driver.DriverFactory.DriverType.CHROME, null);
+        }
+
+        var clientConfig = (ClientConfig) constructionArguments.get(0).get(2);
+        var expectedTimeout = Duration.ofSeconds(TimeUnit.MINUTES.toSeconds(SHAFT.Properties.timeouts.remoteServerInstanceCreationTimeout()));
+        SHAFT.Validations.assertThat().object(clientConfig.connectionTimeout()).isEqualTo(expectedTimeout).perform();
+        SHAFT.Validations.assertThat().object(clientConfig.readTimeout()).isEqualTo(expectedTimeout).perform();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- apply SHAFT remote server instance creation timeout to Selenium RemoteWebDriver HTTP connection/read timeouts
- keep Android/iOS remote constructors unchanged while reusing the parsed target URL
- add focused constructor coverage that verifies the configured ClientConfig timeouts

## Analysis
The attached Allure report from 2026-06-17 had 2 broken tests, both failing before test logic while creating a remote Chrome session on Moon. SHAFT logged its configured remote instance creation timeout, but Selenium's default HTTP client timeout was still controlling the remote session request.

## Checks
- `git diff --check`
- `mvn -pl shaft-engine -DskipTests compile test-compile`
- JShell reflection smoke check: `createRemoteWebDriverClientConfig(...)` returns connection/read timeout `PT5M`

## Notes
- Surefire/TestNG tests were not run in this worktree because the local repo gotcha says to avoid `mvn test` in SHAFT worktrees.
- Graphify refresh was attempted with `graphify . --update --no-viz`, but this alternate worktree path caused a broad corpus refresh and graphify required an LLM API key for 134 doc/paper/image files. No graphify files were modified.