### PR TITLE
Avoid android-json verifier conflicts after upgrade

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/api/RestActions.java
+++ b/shaft-engine/src/main/java/com/shaft/api/RestActions.java
@@ -313,7 +313,10 @@ public class RestActions {
                     Object jsonValue = JsonPath.compile(jsonPath).read(new JSONObject(jsonObject), confOrgJsonProvider);
                     searchPool = String.valueOf(jsonValue);
                 }
-            } catch (JSONException | PathNotFoundException rootCauseException) {
+            } catch (JSONException rootCauseException) {
+                ReportManager.log(ERROR_FAILED_TO_PARSE_JSON, Level.ERROR);
+                failAction(jsonPath, rootCauseException);
+            } catch (PathNotFoundException rootCauseException) {
                 ReportManager.log(ERROR_FAILED_TO_PARSE_JSON, Level.ERROR);
                 failAction(jsonPath, rootCauseException);
             }
@@ -402,7 +405,10 @@ public class RestActions {
         } catch (ClassCastException rootCauseException) {
             ReportManager.log(ERROR_INCORRECT_JSONPATH + "\"" + jsonPath + "\"", Level.ERROR);
             failAction(jsonPath, rootCauseException);
-        } catch (JsonPathException | JSONException | IllegalArgumentException rootCauseException) {
+        } catch (JSONException rootCauseException) {
+            ReportManager.log(ERROR_FAILED_TO_PARSE_JSON, Level.ERROR);
+            failAction(jsonPath, rootCauseException);
+        } catch (JsonPathException | IllegalArgumentException rootCauseException) {
             ReportManager.log(ERROR_FAILED_TO_PARSE_JSON, Level.ERROR);
             failAction(jsonPath, rootCauseException);
         }

--- a/shaft-upgrader/upgrade_to_modular_shaft.py
+++ b/shaft-upgrader/upgrade_to_modular_shaft.py
@@ -46,6 +46,10 @@ ENGINE_ARTIFACT = "shaft-engine"
 BOM_ARTIFACT = "shaft-bom"
 OPTIONAL_MODULES = ("shaft-browserstack", "shaft-video", "shaft-visual")
 SHAFT_ARTIFACTS = {LEGACY_ARTIFACT, ENGINE_ARTIFACT, BOM_ARTIFACT, *OPTIONAL_MODULES}
+JSONASSERT_GROUP = "org.skyscreamer"
+JSONASSERT_ARTIFACT = "jsonassert"
+ANDROID_JSON_GROUP = "com.vaadin.external.google"
+ANDROID_JSON_ARTIFACT = "android-json"
 MAVEN_CENTRAL = "https://repo.maven.apache.org/maven2"
 DEFAULT_OPENAI_MODEL = "gpt-5.5"
 DEFAULT_OPENAI_KEY_ENV = "OPENAI_API_KEY"
@@ -747,6 +751,38 @@ def remove_shaft_dependencies(container: ET.Element | None) -> None:
             container.remove(dependency)
 
 
+def ensure_android_json_exclusion(dependency: ET.Element, namespace: str) -> None:
+    """Exclude the legacy Android JSON artifact from a dependency."""
+    exclusions = direct_child(dependency, "exclusions")
+    if exclusions is not None:
+        for exclusion in exclusions:
+            if local_name(exclusion.tag) != "exclusion":
+                continue
+            group, artifact = dependency_coordinate(exclusion)
+            if group == ANDROID_JSON_GROUP and artifact == ANDROID_JSON_ARTIFACT:
+                return
+    else:
+        exclusions = ET.SubElement(dependency, qualified(namespace, "exclusions"))
+
+    exclusion = ET.SubElement(exclusions, qualified(namespace, "exclusion"))
+    add_text_child(exclusion, namespace, "groupId", ANDROID_JSON_GROUP)
+    add_text_child(exclusion, namespace, "artifactId", ANDROID_JSON_ARTIFACT)
+
+
+def remove_json_runtime_conflicts(container: ET.Element | None, namespace: str) -> None:
+    """Remove org.json shadowing dependencies from a dependency container."""
+    if container is None:
+        return
+    for dependency in list(container):
+        if local_name(dependency.tag) != "dependency":
+            continue
+        group, artifact = dependency_coordinate(dependency)
+        if group == ANDROID_JSON_GROUP and artifact == ANDROID_JSON_ARTIFACT:
+            container.remove(dependency)
+        elif group == JSONASSERT_GROUP and artifact == JSONASSERT_ARTIFACT:
+            ensure_android_json_exclusion(dependency, namespace)
+
+
 def copy_dependency_metadata(
     destination: ET.Element,
     template: ET.Element | None,
@@ -819,6 +855,7 @@ def transform_pom_bytes(
             qualified(namespace, "dependencies"),
         )
     remove_shaft_dependencies(managed_dependencies)
+    remove_json_runtime_conflicts(managed_dependencies, namespace)
     managed_dependencies.append(
         create_dependency(
             namespace,
@@ -831,6 +868,7 @@ def transform_pom_bytes(
 
     dependencies = ensure_project_child(root, namespace, "dependencies")
     remove_shaft_dependencies(dependencies)
+    remove_json_runtime_conflicts(dependencies, namespace)
     dependencies.append(create_dependency(namespace, ENGINE_ARTIFACT, template=template))
     for module in OPTIONAL_MODULES:
         if module in optional_modules:

--- a/tests/scripts/test_upgrade_to_modular_shaft.py
+++ b/tests/scripts/test_upgrade_to_modular_shaft.py
@@ -86,6 +86,102 @@ class UpgradeToModularShaftTests(unittest.TestCase):
         self.assertEqual(upgrade.child_text(bom, "scope"), "import")
         self.assertNotIn("SHAFT_ENGINE", transformed.decode())
 
+    def test_transform_removes_android_json_and_excludes_jsonassert(self):
+        pom = """<project xmlns="http://maven.apache.org/POM/4.0.0">
+            <modelVersion>4.0.0</modelVersion>
+            <groupId>example</groupId>
+            <artifactId>demo</artifactId>
+            <version>1.0.0</version>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.vaadin.external.google</groupId>
+                        <artifactId>android-json</artifactId>
+                        <version>0.0.20131108.vaadin1</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.skyscreamer</groupId>
+                        <artifactId>jsonassert</artifactId>
+                        <version>1.5.3</version>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+            <dependencies>
+                <dependency>
+                    <groupId>io.github.shafthq</groupId>
+                    <artifactId>SHAFT_ENGINE</artifactId>
+                    <version>9.3.20250928</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.vaadin.external.google</groupId>
+                    <artifactId>android-json</artifactId>
+                    <version>0.0.20131108.vaadin1</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.skyscreamer</groupId>
+                    <artifactId>jsonassert</artifactId>
+                    <version>1.5.3</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </project>
+        """
+
+        transformed = upgrade.transform_pom_bytes(
+            pom.encode(),
+            "10.2.20260609",
+            (),
+        )
+        root = upgrade.parse_xml(transformed)
+        dependency_management = upgrade.direct_child(root, "dependencyManagement")
+        managed = upgrade.direct_child(dependency_management, "dependencies")
+        dependencies = upgrade.direct_child(root, "dependencies")
+        all_dependencies = [
+            dependency
+            for container in (managed, dependencies)
+            for dependency in container
+            if upgrade.local_name(dependency.tag) == "dependency"
+        ]
+        coordinates = {
+            (
+                upgrade.child_text(dependency, "groupId"),
+                upgrade.child_text(dependency, "artifactId"),
+            )
+            for dependency in all_dependencies
+        }
+        self.assertNotIn(
+            (upgrade.ANDROID_JSON_GROUP, upgrade.ANDROID_JSON_ARTIFACT),
+            coordinates,
+        )
+
+        jsonassert_dependencies = [
+            dependency
+            for dependency in all_dependencies
+            if (
+                upgrade.child_text(dependency, "groupId"),
+                upgrade.child_text(dependency, "artifactId"),
+            )
+            == (upgrade.JSONASSERT_GROUP, upgrade.JSONASSERT_ARTIFACT)
+        ]
+        self.assertEqual(len(jsonassert_dependencies), 2)
+        for dependency in jsonassert_dependencies:
+            exclusions = upgrade.direct_child(dependency, "exclusions")
+            self.assertIsNotNone(exclusions)
+            exclusion_coordinates = {
+                (
+                    upgrade.child_text(exclusion, "groupId"),
+                    upgrade.child_text(exclusion, "artifactId"),
+                )
+                for exclusion in exclusions
+                if upgrade.local_name(exclusion.tag) == "exclusion"
+            }
+            self.assertIn(
+                (upgrade.ANDROID_JSON_GROUP, upgrade.ANDROID_JSON_ARTIFACT),
+                exclusion_coordinates,
+            )
+
     def test_scan_optional_modules_records_code_and_property_evidence(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary
- split `RestActions` JSON exception multi-catches so stack-map frames no longer depend on `org.json.JSONException` being a `RuntimeException`
- make the upgrader remove direct/managed `com.vaadin.external.google:android-json`
- add `android-json` exclusions to existing `org.skyscreamer:jsonassert` dependencies during upgrade
- add a focused upgrader regression for the conflicting dependency shape

## Analysis
The reported `VerifyError` is caused by an upgraded project loading `com.vaadin.external.google:android-json` before the normal `org.json:json` jar. SHAFT is compiled against `org.json.JSONException extends RuntimeException`, while Android JSON's class with the same package/name extends `Exception`. The verifier rejected `RestActions.getResponseJSONValue(...)` because the compiled multi-catch stack-map expected a runtime exception.

## Checks
- `python -m unittest tests.scripts.test_upgrade_to_modular_shaft` using local Python 3.13; Python 3.10 was requested by local gotcha but is not installed via `py -3.10`
- `git diff --check`
- `mvn -pl shaft-engine -DskipTests compile test-compile`
- JShell verifier smoke check with `android-json-0.0.20131108.vaadin1.jar` first on the classpath: `Class.forName("com.shaft.api.RestActions")` loads without `VerifyError`

## Notes
- Surefire/TestNG tests were not run in this worktree because the local repo gotcha says to avoid `mvn test` in SHAFT worktrees.
- Graphify refresh was attempted with `graphify . --update --no-viz`, but this alternate worktree path caused a broad corpus refresh and graphify required an LLM API key for 134 doc/paper/image files. No graphify files were modified.