### PR TITLE
Enhance SHAFT upgrader project detection

### DIFF
--- a/scripts/ci/assemble_javadocs.py
+++ b/scripts/ci/assemble_javadocs.py
@@ -50,6 +50,14 @@ def assemble_javadocs(root: Path = ROOT, destination: Path | None = None) -> Pat
         shutil.copytree(sources[module], destination / module)
         links.append(f'<li><a href="{module}/index.html">{html.escape(label)}</a></li>')
 
+    generator_resources = root / "shaft-engine" / "src" / "main" / "javadoc" / "resources"
+    if generator_resources.is_dir():
+        shutil.copytree(
+            generator_resources,
+            destination / "shaft-engine" / "resources",
+            dirs_exist_ok=True,
+        )
+
     version = html.escape(project_version(root))
     (destination / "index.html").write_text(
         "<!doctype html>\n"

--- a/shaft-upgrader/upgrade_to_modular_shaft.py
+++ b/shaft-upgrader/upgrade_to_modular_shaft.py
@@ -85,6 +85,10 @@ TEXT_SCAN_SUFFIXES = {
 }
 
 SUPPORTED_STACK_MARKERS = {
+    "cucumber": (
+        "io.cucumber:",
+        "io.cucumber.",
+    ),
     "selenium": (
         "org.seleniumhq.selenium:",
         "org.openqa.selenium.",
@@ -100,6 +104,10 @@ SUPPORTED_STACK_MARKERS = {
 }
 
 SUPPORTED_RUNNER_MARKERS = {
+    "cucumber": (
+        "io.cucumber:",
+        "io.cucumber.",
+    ),
     "testng": (
         "org.testng:testng",
         "org.testng.",
@@ -501,18 +509,20 @@ def dependency_coordinates(pom: Path) -> set[str]:
 
 
 def coordinates_have_supported_stack(coordinates: set[str]) -> bool:
-    """Return whether dependency coordinates contain a supported native stack."""
+    """Return whether dependency coordinates contain a supported automation stack."""
     return (
-        any(coordinate.startswith("org.seleniumhq.selenium:") for coordinate in coordinates)
+        any(coordinate.startswith("io.cucumber:") for coordinate in coordinates)
+        or any(coordinate.startswith("org.seleniumhq.selenium:") for coordinate in coordinates)
         or "io.appium:java-client" in coordinates
         or "io.rest-assured:rest-assured" in coordinates
     )
 
 
 def coordinates_have_supported_runner(coordinates: set[str]) -> bool:
-    """Return whether dependency coordinates contain TestNG or JUnit."""
+    """Return whether dependency coordinates contain a supported test runner."""
     return any(
-        coordinate == "org.testng:testng"
+        coordinate.startswith("io.cucumber:")
+        or coordinate == "org.testng:testng"
         or coordinate.startswith("org.junit:")
         or coordinate.startswith("org.junit.jupiter:")
         or coordinate == "junit:junit"
@@ -605,7 +615,8 @@ def analyze_project(project_root: Path) -> ProjectAnalysis:
     if not candidate_poms:
         raise UpgradeError(
             "This project is not a supported legacy/modular SHAFT project and no "
-            "Selenium, Appium, or REST Assured project using TestNG/JUnit was detected."
+            "Cucumber, Selenium, Appium, or REST Assured project using "
+            "TestNG/JUnit/Cucumber was detected."
         )
 
     optional_evidence = (
@@ -823,6 +834,9 @@ def create_dependency(
 def set_shaft_version_property(root: ET.Element, namespace: str, version: str) -> None:
     """Create or update the canonical SHAFT version property."""
     properties = ensure_project_child(root, namespace, "properties")
+    legacy_property = direct_child(properties, "shaft_engine.version")
+    if legacy_property is not None:
+        properties.remove(legacy_property)
     property_element = direct_child(properties, "shaft.version")
     if property_element is None:
         property_element = ET.SubElement(properties, qualified(namespace, "shaft.version"))
@@ -977,14 +991,12 @@ def resolve_latest_shaft_version(
 
 def default_compile_command(project_root: Path) -> list[str]:
     """Choose a Maven wrapper when present, then fall back to Maven on PATH."""
-    candidates = (
-        project_root / "mvnw.cmd",
-        project_root / "mvnw",
-    )
+    candidates = (project_root / "mvnw.cmd",) if os.name == "nt" else (project_root / "mvnw",)
     for candidate in candidates:
         if candidate.is_file():
             return [
                 str(candidate.resolve()),
+                "dependency:go-offline",
                 "test-compile",
                 "-DskipTests",
                 "-Dgpg.skip",
@@ -992,7 +1004,7 @@ def default_compile_command(project_root: Path) -> list[str]:
     executable = shutil.which("mvn.cmd" if os.name == "nt" else "mvn") or shutil.which("mvn")
     if not executable:
         raise UpgradeError("Maven or a Maven wrapper was not found.")
-    return [executable, "test-compile", "-DskipTests", "-Dgpg.skip"]
+    return [executable, "dependency:go-offline", "test-compile", "-DskipTests", "-Dgpg.skip"]
 
 
 def parse_compile_command(value: str | None, project_root: Path) -> list[str]:
@@ -1488,6 +1500,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         log("Upgrade interrupted.")
         return 130
     except UpgradeError as exc:
+        log(f"Error: {exc}")
+        return 1
+    except Exception as exc:
         log(f"Error: {exc}")
         return 1
 

--- a/tests/scripts/test_assemble_javadocs.py
+++ b/tests/scripts/test_assemble_javadocs.py
@@ -18,6 +18,9 @@ class AssembleJavadocsTest(unittest.TestCase):
                 source = root / module / "target" / "reports" / "apidocs"
                 source.mkdir(parents=True)
                 (source / "index.html").write_text(module, encoding="utf-8")
+            generator = root / "shaft-engine" / "src" / "main" / "javadoc" / "resources"
+            generator.mkdir(parents=True)
+            (generator / "index.html").write_text("generator", encoding="utf-8")
 
             destination = assemble_javadocs(root)
 
@@ -26,6 +29,10 @@ class AssembleJavadocsTest(unittest.TestCase):
             for module in MODULES:
                 self.assertIn(f'{module}/index.html', index)
                 self.assertEqual((destination / module / "index.html").read_text(encoding="utf-8"), module)
+            self.assertEqual(
+                (destination / "shaft-engine" / "resources" / "index.html").read_text(encoding="utf-8"),
+                "generator",
+            )
 
     def test_rejects_missing_module_javadocs(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/scripts/test_upgrade_to_modular_shaft.py
+++ b/tests/scripts/test_upgrade_to_modular_shaft.py
@@ -86,6 +86,32 @@ class UpgradeToModularShaftTests(unittest.TestCase):
         self.assertEqual(upgrade.child_text(bom, "scope"), "import")
         self.assertNotIn("SHAFT_ENGINE", transformed.decode())
 
+    def test_transform_removes_legacy_shaft_version_property(self):
+        pom = """<project xmlns="http://maven.apache.org/POM/4.0.0">
+            <modelVersion>4.0.0</modelVersion>
+            <groupId>example</groupId>
+            <artifactId>demo</artifactId>
+            <version>1.0.0</version>
+            <properties>
+                <shaft_engine.version>9.3.20250928</shaft_engine.version>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>io.github.shafthq</groupId>
+                    <artifactId>SHAFT_ENGINE</artifactId>
+                    <version>${shaft_engine.version}</version>
+                </dependency>
+            </dependencies>
+        </project>
+        """
+
+        transformed = upgrade.transform_pom_bytes(pom.encode(), "10.2.20260609", ())
+        root = upgrade.parse_xml(transformed)
+        properties = upgrade.direct_child(root, "properties")
+
+        self.assertEqual(upgrade.child_text(properties, "shaft.version"), "10.2.20260609")
+        self.assertIsNone(upgrade.direct_child(properties, "shaft_engine.version"))
+
     def test_transform_removes_android_json_and_excludes_jsonassert(self):
         pom = """<project xmlns="http://maven.apache.org/POM/4.0.0">
             <modelVersion>4.0.0</modelVersion>
@@ -264,6 +290,45 @@ class UpgradeToModularShaftTests(unittest.TestCase):
 
         self.assertEqual(analysis.stacks, ("selenium",))
         self.assertEqual(analysis.runners, ("junit",))
+
+    def test_cucumber_project_is_supported(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pom.xml").write_text(
+                """<project xmlns="http://maven.apache.org/POM/4.0.0">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>example</groupId><artifactId>bdd</artifactId><version>1</version>
+                <dependencies>
+                  <dependency><groupId>io.cucumber</groupId>
+                    <artifactId>cucumber-java</artifactId><version>7.0.0</version></dependency>
+                  <dependency><groupId>io.cucumber</groupId>
+                    <artifactId>cucumber-testng</artifactId><version>7.0.0</version></dependency>
+                </dependencies></project>""",
+                encoding="utf-8",
+            )
+
+            analysis = upgrade.analyze_project(root)
+
+        self.assertEqual(analysis.stacks, ("cucumber",))
+        self.assertEqual(analysis.runners, ("cucumber",))
+        self.assertEqual(len(analysis.candidate_poms), 1)
+
+    def test_runner_only_project_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pom.xml").write_text(
+                """<project xmlns="http://maven.apache.org/POM/4.0.0">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>example</groupId><artifactId>unit-only</artifactId><version>1</version>
+                <dependencies>
+                  <dependency><groupId>org.testng</groupId>
+                    <artifactId>testng</artifactId><version>7.0.0</version></dependency>
+                </dependencies></project>""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(upgrade.UpgradeError, "not a supported"):
+                upgrade.analyze_project(root)
 
     def test_native_third_party_integrations_do_not_add_shaft_optional_modules(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -486,6 +551,30 @@ class UpgradeToModularShaftTests(unittest.TestCase):
             )
         self.assertEqual(command[0], "C:\\Program Files\\Maven\\mvn.cmd")
         self.assertEqual(command[1], "test-compile")
+
+    def test_default_compile_command_resolves_dependencies_before_compile(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            wrapper = root / "mvnw"
+            wrapper.write_text("#!/bin/sh\n", encoding="utf-8")
+
+            with mock.patch.object(upgrade.os, "name", "posix"):
+                command = upgrade.default_compile_command(root)
+
+        self.assertEqual(command[0], str(wrapper.resolve()))
+        self.assertEqual(command[1:3], ["dependency:go-offline", "test-compile"])
+
+    def test_windows_default_compile_command_prefers_cmd_wrapper(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            wrapper = root / "mvnw.cmd"
+            wrapper.write_text("@echo off\n", encoding="utf-8")
+
+            with mock.patch.object(upgrade.os, "name", "nt"):
+                command = upgrade.default_compile_command(root)
+
+        self.assertEqual(command[0], str(wrapper.resolve()))
+        self.assertEqual(command[1:3], ["dependency:go-offline", "test-compile"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expands the SHAFT upgrader project detection to cover Cucumber-native projects alongside Selenium, Appium, REST Assured, TestNG, JUnit, modular SHAFT, and old `SHAFT_ENGINE`
- removes the legacy `shaft_engine.version` property when writing the canonical `shaft.version`
- validates upgrades with `dependency:go-offline test-compile` so dependencies and plugins resolve into the local Maven repository before the transaction is committed
- keeps Maven wrapper selection OS-aware and adds a final generic exception guard so failures are logged cleanly and transactional rollback can still run through the existing path
- publishes the project generator resources into assembled Javadocs so the guide iframe URL resolves

## Validation
- `python -m unittest tests.scripts.test_upgrade_to_modular_shaft tests.scripts.test_assemble_javadocs`
- `python scripts\ci\validate_modular_documentation.py`
- `mvn -q -pl shaft-bom,shaft-engine,shaft-visual -am install '-DskipTests' '-Dgpg.skip'`
- Disposable sample projects all resolved and test-compiled with `mvn -q -U -f <pom> dependency:go-offline test-compile '-DskipTests' '-Dgpg.skip'`:
  - `src/test/resources/testDataFiles/project-templates/Cucumber/shaft-cucumber-web`
  - `src/test/resources/testDataFiles/project-templates/JUnit/shaft-junit-api`
  - `src/test/resources/testDataFiles/project-templates/JUnit/shaft-junit-mobile`
  - `src/test/resources/testDataFiles/project-templates/JUnit/shaft-junit-web`
  - `src/test/resources/testDataFiles/project-templates/TestNG/shaft-testng-api`
  - `src/test/resources/testDataFiles/project-templates/TestNG/shaft-testng-mobile`
  - `src/test/resources/testDataFiles/project-templates/TestNG/shaft-testng-web`

## Graphify
- Attempted `graphify . --update --no-viz`; blocked because no supported LLM API key is configured for semantic extraction. Graphify reported 213 doc/paper/image files requiring semantic extraction.