### PR TITLE
Fix Windows Surefire properties bootstrap on Windows

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/cli/FileActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/FileActions.java
@@ -303,6 +303,12 @@ public class FileActions {
      *                       be deleted
      */
     public void deleteFile(String targetFilePath) {
+        if (isProtectedDeletionTarget(targetFilePath)) {
+            if (!internalInstance) {
+                passAction("Target File Path: \"" + targetFilePath + "\", file was not deleted.");
+            }
+            return;
+        }
         File targetFile;
         targetFile = new File(targetFilePath);
         boolean wasFileDeleted = FileUtils.deleteQuietly(targetFile);
@@ -595,6 +601,23 @@ public class FileActions {
 
     public void deleteFolder(String folderPath) {
         deleteFile(folderPath);
+    }
+
+    private static boolean isProtectedDeletionTarget(String targetFilePath) {
+        if (targetFilePath == null || targetFilePath.isBlank()) {
+            return true;
+        }
+        String trimmedPath = targetFilePath.trim();
+        if (".".equals(trimmedPath) || "..".equals(trimmedPath)) {
+            return true;
+        }
+        try {
+            Path normalizedTarget = Path.of(trimmedPath).toAbsolutePath().normalize();
+            Path userDirectory = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize();
+            return normalizedTarget.equals(userDirectory) || userDirectory.startsWith(normalizedTarget);
+        } catch (Exception ignored) {
+            return true;
+        }
     }
 
     public void createFolder(String folderPath) {

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/EngineProperties.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/EngineProperties.java
@@ -36,6 +36,9 @@ public interface EngineProperties<T> extends Config {
      * @param value property value
      */
     static void logPropertyUpdate(String key, Object value) {
+        if (!Properties.isInitialized()) {
+            return;
+        }
         ReportManager.logDiscrete("Updated property \"" + key + "\" to \""
                 + maskSensitiveValue(key, value) + "\".");
     }

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
@@ -283,13 +283,9 @@ public class PropertiesHelper {
             downloadDefaultProperties();
         } else {
             URL propertiesFolder = PropertyFileManager.class.getResource(DEFAULT_PROPERTIES_FOLDER_PATH.replace("src/main", "") + "/");
-            var propertiesFolderPath = "";
-            if (propertiesFolder != null) {
-                propertiesFolderPath = propertiesFolder.getFile();
-            } else {
-                propertiesFolderPath = DEFAULT_PROPERTIES_FOLDER_PATH;
-            }
-            Properties.paths.set().properties(propertiesFolderPath);
+            var propertiesFolderPath = propertiesFolder != null
+                    ? PropertyFileManager.resolveClasspathResourceLocation(propertiesFolder)
+                    : DEFAULT_PROPERTIES_FOLDER_PATH;
 
             boolean isExternalRun = propertiesFolderPath.contains("file:") && propertiesFolderPath.contains(".jar!");
 
@@ -315,7 +311,7 @@ public class PropertiesHelper {
 
     private static void overrideTargetProperties(boolean aiAgentMode) {
         var fileActions = FileActions.getInstance(true);
-        var propertiesFolderPath = Properties.paths.properties();
+        var propertiesFolderPath = PropertyFileManager.resolveBundledDefaultPropertiesFolderPath();
         boolean isExternalRun = propertiesFolderPath.contains("file:") && propertiesFolderPath.contains(".jar!");
         var targetPropertiesFolderPath = aiAgentMode
                 ? resolveAiAgentPath(TARGET_PROPERTIES_FOLDER_PATH)
@@ -336,7 +332,8 @@ public class PropertiesHelper {
                                 fileActions.copyFile(tempPath + file, targetPropertiesFolderPath + file);
                             }
                         } else {
-                            fileActions.copyFile(propertiesFolderPath + file, targetPropertiesFolderPath + file);
+                            fileActions.copyFile(PropertyFileManager.resolveCustomPropertiesTemplatePath(),
+                                    targetPropertiesFolderPath + file);
                         }
                     }
                 });

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/PropertyFileManager.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/PropertyFileManager.java
@@ -13,6 +13,7 @@ import org.openqa.selenium.MutableCapabilities;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.net.URI;
 import java.net.URL;
 import java.util.*;
@@ -29,6 +30,8 @@ public final class PropertyFileManager {
     private static final String LOG4J_PROPERTIES_FILE = "log4j2.properties";
     private static final String LOG4J_FILE_APPENDER_SYSTEM_PROPERTY = "shaft.log.file";
     private static final String DEFAULT_LOG_FILE_PATH = "target/logs/log4j.log";
+    private static final String DEFAULT_PROPERTIES_CLASSPATH_RESOURCE = "/resources/properties/default/";
+    private static final String CUSTOM_PROPERTIES_FILE = "custom.properties";
 
     private PropertyFileManager() {
         throw new IllegalStateException("Utility class");
@@ -136,7 +139,61 @@ public final class PropertyFileManager {
         if (!new File(log4jConfigPath).isFile()) {
             log4jConfigPath = appendFileName(paths.defaultProperties(), LOG4J_PROPERTIES_FILE);
         }
-        return log4jConfigPath;
+        if (!new File(log4jConfigPath).isFile()) {
+            log4jConfigPath = appendFileName(resolveBundledDefaultPropertiesFolderPath(), LOG4J_PROPERTIES_FILE);
+        }
+        return Path.of(log4jConfigPath).toAbsolutePath().normalize().toString();
+    }
+
+    /**
+     * Resolves the bundled default properties folder from the runtime classpath.
+     *
+     * @return an absolute filesystem path when running from compiled classes, a jar URL for
+     *         external runs, or the module-relative default folder when the resource is absent
+     */
+    public static String resolveBundledDefaultPropertiesFolderPath() {
+        URL propertiesFolder = PropertyFileManager.class.getResource(DEFAULT_PROPERTIES_CLASSPATH_RESOURCE);
+        if (propertiesFolder != null) {
+            return resolveClasspathResourceLocation(propertiesFolder);
+        }
+        return appendFileName(CUSTOM_PROPERTIES_FOLDER_PATH, "default");
+    }
+
+    /**
+     * Resolves the bundled {@code custom.properties} template used during engine bootstrap.
+     *
+     * @return the preferred on-disk template path when present, otherwise the classpath location
+     */
+    public static String resolveCustomPropertiesTemplatePath() {
+        String bundledTemplatePath = appendFileName(
+                appendFileName(CUSTOM_PROPERTIES_FOLDER_PATH, "default"),
+                CUSTOM_PROPERTIES_FILE);
+        if (new File(bundledTemplatePath).isFile()) {
+            return bundledTemplatePath;
+        }
+        return appendFileName(resolveBundledDefaultPropertiesFolderPath(), CUSTOM_PROPERTIES_FILE);
+    }
+
+    /**
+     * Converts a classpath resource URL into a filesystem or jar location string.
+     *
+     * @param resourceUrl classpath resource URL
+     * @return resolved location suitable for {@link FileActions} copy helpers
+     */
+    public static String resolveClasspathResourceLocation(URL resourceUrl) {
+        if (resourceUrl == null) {
+            return appendFileName(CUSTOM_PROPERTIES_FOLDER_PATH, "default");
+        }
+        if ("jar".equalsIgnoreCase(resourceUrl.getProtocol())) {
+            return resourceUrl.toString();
+        }
+        try {
+            return Path.of(resourceUrl.toURI()).toString();
+        } catch (java.net.URISyntaxException uriSyntaxException) {
+            ReportManager.logDiscrete("Could not resolve classpath resource path: "
+                    + resourceUrl + ". Falling back to legacy path resolution.", Level.DEBUG);
+            return resourceUrl.getFile();
+        }
     }
 
     /**

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
@@ -228,10 +228,12 @@ public class ReportManagerHelper {
             FileActions.getInstance(true).deleteFile(logFilePath);
         }
         System.setProperty(LOG4J_LOG_FILE_SYSTEM_PROPERTY, logFilePath);
-        if (legacyLog4jConfigured.compareAndSet(false, true)) {
+        String log4jConfigPath = PropertyFileManager.getLog4jConfigPath();
+        if (new File(log4jConfigPath).isFile()) {
+            Configurator.initialize(null, log4jConfigPath);
+        } else if (legacyLog4jConfigured.compareAndSet(false, true)) {
             BasicConfigurator.configure();
         }
-        Configurator.initialize(null, PropertyFileManager.getLog4jConfigPath());
         configuredLogFilePath.set(logFilePath);
         logger = LogManager.getLogger(ReportManager.class.getName());
     }
@@ -742,10 +744,12 @@ public class ReportManagerHelper {
             String normalizedLogText = normalizeLogText(logText);
             String log = REPORT_MANAGER_PREFIX + normalizedLogText + " @" + timestamp;
             Reporter.log(log, false);
-            if (logger == null) {
+            if (logger == null && com.shaft.properties.internal.Properties.isInitialized()) {
                 initializeLogger();
             }
-            logger.log(loglevel, normalizedLogText);
+            if (logger != null) {
+                logger.log(loglevel, normalizedLogText);
+            }
             createDebugCompanionLogEntry(normalizedLogText, loglevel);
             writeToDebugLogFileIfEnabled(normalizedLogText, loglevel);
         }
@@ -758,10 +762,12 @@ public class ReportManagerHelper {
             String log = REPORT_MANAGER_PREFIX + normalizedLogText + " @" + timestamp;
             Reporter.log(log, false);
             if (addToConsoleLog) {
-                if (logger == null) {
+                if (logger == null && com.shaft.properties.internal.Properties.isInitialized()) {
                     initializeLogger();
                 }
-                logger.log(Level.INFO, normalizedLogText);
+                if (logger != null) {
+                    logger.log(Level.INFO, normalizedLogText);
+                }
                 createDebugCompanionLogEntry(normalizedLogText, Level.INFO);
                 writeToDebugLogFileIfEnabled(normalizedLogText, Level.INFO);
             }
@@ -997,9 +1003,23 @@ public class ReportManagerHelper {
     public static void cleanExecutionSummaryReportDirectory() {
         if (SHAFT.Properties.reporting.cleanSummaryReportsDirectoryBeforeExecution()) {
             ReportManager.logDiscrete("Preparing the execution summary report directory.");
-            String executionSummaryReportFolderPath = SHAFT.Properties.paths.executionSummaryReport();
-            FileActions.getInstance(true).deleteFolder(executionSummaryReportFolderPath.substring(0, executionSummaryReportFolderPath.length() - 1));
+            String normalizedFolderPath = normalizeConfiguredFolderPath(SHAFT.Properties.paths.executionSummaryReport());
+            if (normalizedFolderPath.isBlank()) {
+                return;
+            }
+            FileActions.getInstance(true).deleteFolder(normalizedFolderPath);
         }
+    }
+
+    private static String normalizeConfiguredFolderPath(String folderPath) {
+        if (folderPath == null || folderPath.isBlank()) {
+            return "";
+        }
+        char lastCharacter = folderPath.charAt(folderPath.length() - 1);
+        if (lastCharacter == '/' || lastCharacter == '\\') {
+            return folderPath.substring(0, folderPath.length() - 1);
+        }
+        return folderPath;
     }
 
     public static void openExecutionSummaryReportAfterExecution() {

--- a/shaft-engine/src/test/java/testPackage/unitTests/FileActionsUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/FileActionsUnitTest.java
@@ -92,4 +92,14 @@ public class FileActionsUnitTest {
         testFileActions.deleteFile(TEMP_DIR.resolve("f.txt").toString());
         Assert.assertFalse(testFileActions.doesFileExist(TEMP_DIR.resolve("f.txt").toString()));
     }
+
+    @Test
+    public void deleteFileShouldRejectWorkingDirectoryAndAncestorPaths() {
+        String userDirectory = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize().toString();
+        testFileActions.deleteFile(".");
+        testFileActions.deleteFile("..");
+        testFileActions.deleteFile(userDirectory);
+        Assert.assertTrue(Path.of(userDirectory).toFile().isDirectory(),
+                "Working directory should remain after protected delete attempts.");
+    }
 }

--- a/shaft-engine/src/test/java/testPackage/unitTests/PropertiesHelperInitializationUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/PropertiesHelperInitializationUnitTest.java
@@ -2,11 +2,13 @@ package testPackage.unitTests;
 
 import com.shaft.properties.internal.Properties;
 import com.shaft.properties.internal.PropertiesHelper;
+import com.shaft.properties.internal.PropertyFileManager;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Files;
 import java.util.List;
@@ -59,6 +61,17 @@ public class PropertiesHelperInitializationUnitTest {
                 "screenshotParamsWhenToTakeAScreenshot=ValidationPointsOnly"
         ).forEach(expectedDefault -> Assert.assertTrue(customTemplateContent.contains(expectedDefault),
                 "custom.properties template should include default: " + expectedDefault));
+    }
+
+    @Test
+    public void resolveClasspathResourceLocationShouldResolveClasspathDirectoryUsingUri() {
+        URL resourceUrl = PropertyFileManager.class.getResource("/resources/properties/default/");
+        Assert.assertNotNull(resourceUrl, "Default properties resource should be on the classpath.");
+        String resolvedFolder = PropertyFileManager.resolveClasspathResourceLocation(resourceUrl);
+        Assert.assertFalse(resolvedFolder.contains("%"),
+                "Classpath folder path should not contain URL-encoded segments on Windows.");
+        Assert.assertTrue(Path.of(resolvedFolder, "custom.properties").toFile().isFile(),
+                "Resolved classpath folder should contain custom.properties.");
     }
 
     private void deleteGeneratedPropertyFile(String fileName) {


### PR DESCRIPTION
Fixes #2931

Windows Surefire/TestNG bootstrap failed when copying `custom.properties` because classpath paths used `URL.getFile()`. This also led to misleading `FailureReporter`/Log4j errors and, in some cases, deletion of the `shaft-engine` module tree.

- Resolve bundled properties paths via `URI`/`Path` in `PropertyFileManager`
- Copy `custom.properties` from the resolved bundled template in `PropertiesHelper`
- Guard `FileActions` against deleting the working directory or ancestor paths
- Stabilize Log4j bootstrap and execution-summary cleanup in `ReportManagerHelper`
- Add regression tests for classpath resolution and protected deletion

**Tests:** 50 tests passed and `shaft-engine/pom.xml` intact after run.
[BootStrapIssueTests.html](https://github.com/user-attachments/files/29094259/BootStrapIssueTests.html)
