### PR TITLE
[codex] Preserve jar Log4j config paths

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/properties/internal/PropertyFileManager.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/PropertyFileManager.java
@@ -142,7 +142,7 @@ public final class PropertyFileManager {
         if (!new File(log4jConfigPath).isFile()) {
             log4jConfigPath = appendFileName(resolveBundledDefaultPropertiesFolderPath(), LOG4J_PROPERTIES_FILE);
         }
-        return Path.of(log4jConfigPath).toAbsolutePath().normalize().toString();
+        return normalizeLog4jConfigPath(log4jConfigPath);
     }
 
     /**
@@ -194,6 +194,17 @@ public final class PropertyFileManager {
                     + resourceUrl + ". Falling back to legacy path resolution.", Level.DEBUG);
             return resourceUrl.getFile();
         }
+    }
+
+    static String normalizeLog4jConfigPath(String log4jConfigPath) {
+        if (isJarResourceLocation(log4jConfigPath)) {
+            return log4jConfigPath;
+        }
+        return Path.of(log4jConfigPath).toAbsolutePath().normalize().toString();
+    }
+
+    private static boolean isJarResourceLocation(String path) {
+        return path.startsWith("jar:") || path.contains(".jar!");
     }
 
     /**

--- a/shaft-engine/src/test/java/com/shaft/properties/internal/PropertyFileManagerInternalUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/properties/internal/PropertyFileManagerInternalUnitTest.java
@@ -1,0 +1,13 @@
+package com.shaft.properties.internal;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PropertyFileManagerInternalUnitTest {
+    @Test(description = "Log4j config path normalization should preserve jar resource URLs")
+    public void normalizeLog4jConfigPathPreservesJarResourceUrl() {
+        String jarResourcePath = "jar:file:/C:/test/shaft-engine.jar!/resources/properties/default/log4j2.properties";
+
+        Assert.assertEquals(PropertyFileManager.normalizeLog4jConfigPath(jarResourcePath), jarResourcePath);
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #2945 after it was squash-merged into `main`.

`PropertyFileManager.getLog4jConfigPath()` now preserves `jar:file:...!` resource locations instead of passing them through `Path.of(...)`. On Windows, `Path.of("jar:file:/C:/...")` throws `InvalidPathException`, which can reintroduce bootstrap noise during external jar execution.

## Root cause

PR #2945 correctly added a classpath fallback for bundled `log4j2.properties`, but the final unconditional filesystem normalization treated jar resource URLs as local paths. That is safe for extracted classpath directories, but not for archive resource URLs.

## Changes

- Added an internal `normalizeLog4jConfigPath(...)` guard that only filesystem-normalizes real paths.
- Added a focused same-package regression proving jar resource URLs are preserved unchanged.

## Validation

- `git diff --check`
- `mvn --batch-mode -pl shaft-engine -DskipTests '-Dgpg.skip=true' test-compile`
- In a throwaway copy: `mvn --batch-mode -pl shaft-engine '-Dtest=PropertyFileManagerInternalUnitTest#normalizeLog4jConfigPathPreservesJarResourceUrl' '-Dgpg.skip=true' test`
- Confirmed `shaft-engine/allure-results` contained one populated result JSON with `status=passed`.

## CI note

`release-candidate` is currently red in untouched SHAFT Pilot/Capture paths with the same signature seen on #2945 before merge: `CaptureGeneratorTest.representativeSessionGeneratesDeterministicCompilableSourceAndExternalData`, then missing JaCoCo XML reports for untouched pilot modules. This PR changes only `shaft-engine` path normalization and its regression test.
