### PR TITLE
[codex] Remove typed action txt parameter

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -1087,13 +1087,11 @@ public class Actions extends ElementActions {
                     || "txt".equals(parameter.getName())
                     || "element name".equals(parameter.getName()));
             parameters.add(new Parameter().setName("locator").setValue(context.locator()));
-            parameters.add(new Parameter().setName("txt").setValue(context.detailsValue()));
             if (context.hasElementName()) {
                 parameters.add(new Parameter().setName("element name").setValue(context.elementName()));
             }
             update.setParameters(parameters);
             update.setDescription("locator: " + context.locator()
-                    + System.lineSeparator() + "txt: " + context.detailsValue()
                     + (context.hasElementName() ? System.lineSeparator() + "element name: " + context.elementName() : ""));
         });
     }

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
@@ -157,10 +157,10 @@ public class ActionsCoverageUnitTest {
 
             Assert.assertEquals(step.getName(), "Type \"" + expectedPreview + "\"");
             Assert.assertEquals(parameterValue(step, "locator"), "By.id: target");
-            Assert.assertEquals(parameterValue(step, "txt"), "first line\\n" + "x".repeat(150));
+            Assert.assertFalse(hasParameter(step, "txt"));
             Assert.assertEquals(parameterValue(step, "element name"), "accessible target");
             Assert.assertTrue(step.getDescription().contains("locator: By.id: target"));
-            Assert.assertTrue(step.getDescription().contains("txt: first line\\n"));
+            Assert.assertFalse(step.getDescription().contains("txt:"));
         }
     }
 
@@ -179,7 +179,7 @@ public class ActionsCoverageUnitTest {
             new Actions(helperFor(driver)).typeSecure(LOCATOR, "secret-value");
 
             Assert.assertEquals(step.getName(), "Type securely \"********\"");
-            Assert.assertEquals(parameterValue(step, "txt"), "********");
+            Assert.assertFalse(hasParameter(step, "txt"));
             Assert.assertFalse(step.getName().contains("secret-value"));
             Assert.assertFalse(step.getDescription().contains("secret-value"));
         }
@@ -200,13 +200,13 @@ public class ActionsCoverageUnitTest {
 
             new Actions(helperFor(driver)).typeAppend(LOCATOR, "suffix");
             Assert.assertEquals(step.getName(), "Type append \"suffix\"");
-            Assert.assertEquals(parameterValue(step, "txt"), "suffix");
+            Assert.assertFalse(hasParameter(step, "txt"));
 
             step = captureStepUpdates(lifecycle);
             new Actions(helperFor(driver)).setValueUsingJavaScript(LOCATOR, "js value");
             Assert.assertTrue(step.getName().contains("\"js value\""));
             Assert.assertFalse(step.getName().contains("By.id: target"));
-            Assert.assertEquals(parameterValue(step, "txt"), "js value");
+            Assert.assertFalse(hasParameter(step, "txt"));
         }
     }
 
@@ -708,6 +708,11 @@ public class ActionsCoverageUnitTest {
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("Missing parameter: " + name))
                 .getValue();
+    }
+
+    private boolean hasParameter(StepResult step, String name) {
+        return step.getParameters().stream()
+                .anyMatch(parameter -> name.equals(parameter.getName()));
     }
 
     private boolean hasCause(Throwable throwable, Class<? extends Throwable> expectedCause) {


### PR DESCRIPTION
## Summary
- stop adding the `txt` parameter/details entry to typed action Allure metadata
- keep `locator`, and add `element name` only when the engine resolves a distinct element name
- update focused action reporting tests for type, secure type, append, and JavaScript set value

## Validation
- `mvn test -pl shaft-engine '-Dtest=ActionsCoverageUnitTest#typingActionsShouldShowTypedTextAndKeepTargetMetadataInAllureStep+secureTypingShouldKeepTypedSecretMaskedInAllureStep+appendAndJavascriptSetValueShouldUseValueInAllureStepName' '-Dgpg.skip=true'`
- Allure sanity check: `3` result JSON files, `3` passed, `0` failed/broken
- `mvn package -pl shaft-engine '-DskipTests' '-Dgpg.skip=true'`

## Notes
- Full `ActionsCoverageUnitTest` currently exposes an unrelated existing failure: `silentPassedActionShouldOnlyWriteDebugDiscreteLog` expects `Get text`, while current output is `Get  text`.
- Graphify refresh was attempted with `graphify . --update --no-viz` and blocked because no LLM API key is configured for semantic extraction.