### PR TITLE
[codex] Unify element action failure reporting

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/element/ElementActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/ElementActions.java
@@ -1,26 +1,15 @@
 package com.shaft.gui.element;
 
-import com.shaft.cli.FileActions;
-import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.driver.internal.FluentWebDriverAction;
 import com.shaft.driver.internal.WizardHelpers;
 import com.shaft.gui.element.internal.Actions;
-import com.shaft.gui.element.internal.ElementInformation;
-import com.shaft.gui.internal.image.ScreenshotManager;
-import com.shaft.gui.internal.locator.LocatorBuilder;
-import com.shaft.tools.internal.support.JavaHelper;
 import com.shaft.tools.io.ReportManager;
-import com.shaft.tools.io.internal.ReportManagerHelper;
 import com.shaft.validation.internal.WebDriverElementValidationsBuilder;
 import org.openqa.selenium.*;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.support.locators.RelativeLocator;
 import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.Select;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import java.nio.file.FileSystems;
 import java.time.Duration;
 import java.util.*;
 
@@ -133,14 +122,7 @@ public class ElementActions extends FluentWebDriverAction {
      * @return a self-reference to be used to chain actions
      */
     public Actions executeNativeMobileCommand(String command, Map<String, String> parameters) {
-        try {
-            elementActionsHelper.executeNativeMobileCommandUsingJavascript(driverFactoryHelper.getDriver(), command, parameters);
-            var testData = "Command: " + command + ", Parameters: " + parameters;
-            elementActionsHelper.passAction(driverFactoryHelper.getDriver(), null, Thread.currentThread().getStackTrace()[1].getMethodName(), testData, null, null);
-        } catch (Exception rootCauseException) {
-            elementActionsHelper.failAction(driverFactoryHelper.getDriver(), null, rootCauseException);
-        }
-        return new Actions(driverFactoryHelper);
+        return new Actions(driverFactoryHelper).executeNativeMobileCommand(command, parameters);
     }
 
     /**
@@ -173,17 +155,7 @@ public class ElementActions extends FluentWebDriverAction {
      * @return a self-reference to be used to chain actions
      */
     public Actions scrollToElement(By elementLocator) {
-        // if mobile, call swipeElementIntoView(null, targetElementLocator, swipeDirection); for convenience
-        if (DriverFactoryHelper.isMobileNativeExecution()) {
-            performTouchAction().swipeElementIntoView(elementLocator, TouchActions.SwipeDirection.DOWN);
-        }
-        try {
-            elementActionsHelper.scrollToFindElement(driverFactoryHelper.getDriver(), elementLocator);
-            elementActionsHelper.passAction(driverFactoryHelper.getDriver(), elementLocator, Thread.currentThread().getStackTrace()[1].getMethodName(), null, null, elementActionsHelper.getElementName(driverFactoryHelper.getDriver(), elementLocator));
-        } catch (Exception throwable) {
-            elementActionsHelper.failAction(driverFactoryHelper.getDriver(), elementLocator, throwable);
-        }
-        return new Actions(driverFactoryHelper);
+        return new Actions(driverFactoryHelper).scrollToElement(elementLocator);
     }
 
     /**
@@ -280,68 +252,7 @@ public class ElementActions extends FluentWebDriverAction {
      * @return a self-reference to be used to chain actions
      */
     public Actions select(By elementLocator, String valueOrVisibleText) {
-        ElementInformation elementInformation = ElementInformation.fromList(elementActionsHelper.identifyUniqueElement(driverFactoryHelper.getDriver(), elementLocator));
-
-        //Capture the Element Tag
-        String elementTag = elementInformation.getElementTag();
-
-        //The Logic to Handle non-Select dropDowns
-        if (!elementTag.equals("select")) {
-            if (SHAFT.Properties.flags.handleNonSelectDropDown()) {
-                click(elementInformation.getLocator());
-                elementInformation = ElementInformation.fromList(elementActionsHelper.identifyUniqueElement(driverFactoryHelper.getDriver(), elementLocator));
-                try {
-                    RelativeLocator.RelativeBy relativeBy = SHAFT.GUI.Locator.hasAnyTagName().and().containsText(valueOrVisibleText).byRelation().below(elementInformation.getLocator());
-                    elementInformation = ElementInformation.fromList(elementActionsHelper.identifyUniqueElement(driverFactoryHelper.getDriver(), relativeBy));
-                } catch (Throwable var9) {
-                    ReportManager.logDiscrete("Cannot Find Element with the following Locator in the DropDown Options: " + By.xpath("//*[text()='" + valueOrVisibleText + "']"));
-                    elementActionsHelper.failAction(driverFactoryHelper.getDriver(), By.xpath("//*[text()='" + valueOrVisibleText + "']").toString(), elementLocator, var9);
-                }
-                click(elementInformation.getLocator());
-            } else {
-                ReportManager.logDiscrete("Cannot Find Element with the following Locator in the DropDown Options: " + By.xpath("//*[text()='" + valueOrVisibleText + "']"));
-                elementActionsHelper.failAction(driverFactoryHelper.getDriver(), "Select: ", valueOrVisibleText + "\" from Element : " + " Tag should be <Select, yet it was found to be " + "<" + elementTag, elementLocator, null);
-            }
-
-            //End of non-select DropDowns Logic
-            //================================================================//
-
-        } else {
-
-            try {
-                String elementName = elementInformation.getElementName();
-                if (elementName == null || elementName.isBlank()) {
-                    elementName = JavaHelper.formatLocatorToString(elementLocator);
-                }
-                if (!elementActionsHelper.waitForElementTextToBeNot(driverFactoryHelper.getDriver(), elementLocator, "")) {
-                    elementActionsHelper.failAction(driverFactoryHelper.getDriver(), valueOrVisibleText, elementLocator);
-                }
-
-                elementInformation = ElementInformation.fromList(elementActionsHelper.identifyUniqueElement(driverFactoryHelper.getDriver(), elementLocator));
-                Select selectElement = new Select(elementInformation.getFirstElement());
-                boolean isOptionFound = false;
-                List<WebElement> availableOptionsList = selectElement.getOptions();
-
-                for (int i = 0; i < availableOptionsList.size(); ++i) {
-                    String visibleText = availableOptionsList.get(i).getText();
-                    String value = availableOptionsList.get(i).getDomProperty("value");
-                    if (visibleText.trim().equals(valueOrVisibleText) || Objects.requireNonNull(value).trim().equals(valueOrVisibleText)) {
-                        selectElement.selectByIndex(i);
-                        elementActionsHelper.passAction(driverFactoryHelper.getDriver(), elementLocator, Thread.currentThread().getStackTrace()[1].getMethodName(), valueOrVisibleText, null, elementName);
-                        isOptionFound = true;
-                        break;
-                    }
-                }
-
-                if (!isOptionFound) {
-                    throw new NoSuchElementException("Cannot locate option with Value or Visible text =" + valueOrVisibleText);
-                }
-            } catch (Throwable var9) {
-                elementActionsHelper.failAction(driverFactoryHelper.getDriver(), valueOrVisibleText, elementLocator, var9);
-            }
-
-        }
-        return new Actions(driverFactoryHelper);
+        return new Actions(driverFactoryHelper).select(elementLocator, valueOrVisibleText);
     }
 
     /**
@@ -365,25 +276,7 @@ public class ElementActions extends FluentWebDriverAction {
      * @return a self-reference to be used to chain actions
      */
     public Actions submitFormUsingJavaScript(By elementLocator) {
-        try {
-            var elementName = elementActionsHelper.getElementName(driverFactoryHelper.getDriver(), elementLocator);
-            List<Object> screenshot = null;
-            try {
-                screenshot = elementActionsHelper.takeScreenshot(driverFactoryHelper.getDriver(), elementLocator, "submitFormUsingJavaScript", null, true);
-                elementActionsHelper.submitFormUsingJavascript(driverFactoryHelper.getDriver(), elementLocator);
-                elementActionsHelper.passAction(driverFactoryHelper.getDriver(), elementLocator, Thread.currentThread().getStackTrace()[1].getMethodName(), null, Collections.singletonList(screenshot), elementName);
-            } catch (JavascriptException javascriptException) {
-                if (screenshot == null)
-                    screenshot = elementActionsHelper.takeScreenshot(driverFactoryHelper.getDriver(), elementLocator, "submitFormUsingJavaScript", null, true);
-                driverFactoryHelper.getDriver().findElement(elementLocator).submit();
-                elementActionsHelper.passAction(driverFactoryHelper.getDriver(), elementLocator, Thread.currentThread().getStackTrace()[1].getMethodName(), null, Collections.singletonList(screenshot), elementName);
-            } catch (Exception rootCauseException) {
-                elementActionsHelper.failAction(driverFactoryHelper.getDriver(), elementLocator, rootCauseException);
-            }
-        } catch (Exception throwable) {
-            elementActionsHelper.failAction(driverFactoryHelper.getDriver(), elementLocator, throwable);
-        }
-        return new Actions(driverFactoryHelper);
+        return new Actions(driverFactoryHelper).submitFormUsingJavaScript(elementLocator);
     }
 
     /**
@@ -396,20 +289,7 @@ public class ElementActions extends FluentWebDriverAction {
      * @return a self-reference to be used to chain actions
      */
     public Actions switchToIframe(By elementLocator) {
-        try {
-            var elementInformation = ElementInformation.fromList(elementActionsHelper.identifyUniqueElement(driverFactoryHelper.getDriver(), elementLocator));
-            LocatorBuilder.getIFrameLocator().set(elementInformation.getLocator());
-            // note to self: remove elementLocator in case of bug in screenshot manager
-            driverFactoryHelper.getDriver().switchTo().frame(elementInformation.getFirstElement());
-            boolean discreetLoggingState = ReportManagerHelper.getDiscreteLogging();
-            ReportManagerHelper.setDiscreteLogging(true);
-            elementActionsHelper.passAction(driverFactoryHelper.getDriver(), elementLocator, Thread.currentThread().getStackTrace()[1].getMethodName(), String.valueOf(elementLocator), null, elementInformation.getElementName());
-            ReportManagerHelper.setDiscreteLogging(discreetLoggingState);
-        } catch (Throwable throwable) {
-            // has to be throwable to catch assertion errors in case element was not found
-            elementActionsHelper.failAction(driverFactoryHelper.getDriver(), elementLocator, throwable);
-        }
-        return new Actions(driverFactoryHelper);
+        return new Actions(driverFactoryHelper).switchToIframe(elementLocator);
     }
 
     /**
@@ -421,20 +301,7 @@ public class ElementActions extends FluentWebDriverAction {
      */
     @SuppressWarnings("UnusedReturnValue")
     public Actions switchToDefaultContent() {
-        try {
-            driverFactoryHelper.getDriver().switchTo().defaultContent();
-            LocatorBuilder.getIFrameLocator().remove();
-            boolean discreetLoggingState = ReportManagerHelper.getDiscreteLogging();
-            ReportManagerHelper.setDiscreteLogging(true);
-            elementActionsHelper.passAction(driverFactoryHelper.getDriver(), null, Thread.currentThread().getStackTrace()[1].getMethodName(), null, null, null);
-            ReportManagerHelper.setDiscreteLogging(discreetLoggingState);
-        } catch (Exception rootCauseException) {
-//            failAction(driverFactoryHelper.getDriver(), null, rootCauseException);
-        }
-        // if there is no last used driver or no drivers in the drivers list, do
-        // nothing...
-//        return new ElementActions(Objects.requireNonNull(driver).get());
-        return new Actions(driverFactoryHelper);
+        return new Actions(driverFactoryHelper).switchToDefaultContent();
     }
 
     /**
@@ -497,45 +364,7 @@ public class ElementActions extends FluentWebDriverAction {
      * @return a self-reference to be used to chain actions.
      */
     public Actions typeFileLocationForUpload(By elementLocator, String filePath) {
-        var absoluteFilePath = filePath;
-        if (filePath.startsWith("src")) {
-            absoluteFilePath = FileActions.getInstance(true).getAbsolutePath(filePath);
-        }
-
-        String internalAbsoluteFilePath = absoluteFilePath.replace("/", FileSystems.getDefault().getSeparator());
-        try {
-            var elementName = elementActionsHelper.getElementName(driverFactoryHelper.getDriver(), elementLocator);
-            List<Object> screenshot = elementActionsHelper.takeScreenshot(driverFactoryHelper.getDriver(), elementLocator, "typeFileLocationForUpload", null, true);
-            // takes screenshot before clicking the element out of view
-            try {
-                ((WebElement) elementActionsHelper.identifyUniqueElementIgnoringVisibility(driverFactoryHelper.getDriver(), elementLocator).get(1)).sendKeys(internalAbsoluteFilePath);
-            } catch (InvalidArgumentException e) {
-                //this happens when the file path doesn't exist
-                elementActionsHelper.failAction(driverFactoryHelper.getDriver(), internalAbsoluteFilePath, elementLocator, e);
-            } catch (ElementNotInteractableException | NoSuchElementException exception1) {
-                elementActionsHelper.changeWebElementVisibilityUsingJavascript(driverFactoryHelper.getDriver(), elementLocator, true);
-                try {
-                    ((WebElement) elementActionsHelper.identifyUniqueElement(driverFactoryHelper.getDriver(), elementLocator).get(1)).sendKeys(internalAbsoluteFilePath);
-                } catch (WebDriverException rootCauseException) {
-                    rootCauseException.addSuppressed(exception1);
-                    // happened for the first time on MacOSX due to incorrect file path separator
-                    elementActionsHelper.failAction(driverFactoryHelper.getDriver(), internalAbsoluteFilePath, elementLocator, rootCauseException);
-                }
-                try {
-                    elementActionsHelper.changeWebElementVisibilityUsingJavascript(driverFactoryHelper.getDriver(), elementLocator, false);
-                } catch (NoSuchElementException | StaleElementReferenceException e) {
-                    // this exception is sometimes thrown on firefox after the upload has been
-                    // successful, since we don't have to return the style to what it was, then it's
-                    // okay to do nothing here.
-                    ReportManagerHelper.logDiscrete(e);
-                }
-            }
-            elementActionsHelper.passAction(driverFactoryHelper.getDriver(), elementLocator, internalAbsoluteFilePath, screenshot, elementName);
-        } catch (Throwable throwable) {
-            // has to be throwable to catch assertion errors in case element was not found
-            elementActionsHelper.failAction(driverFactoryHelper.getDriver(), elementLocator, throwable);
-        }
-        return new Actions(driverFactoryHelper);
+        return new Actions(driverFactoryHelper).typeFileLocationForUpload(elementLocator, filePath);
     }
 
     /**
@@ -607,9 +436,7 @@ public class ElementActions extends FluentWebDriverAction {
      * @see <a href="https://shaftengine.netlify.app/">SHAFT User Guide &ndash; Element Actions</a>
      */
     public Actions captureScreenshot(By elementLocator) {
-        var screenshotManager = new ScreenshotManager();
-        ReportManagerHelper.log("Capture element screenshot", Collections.singletonList(screenshotManager.prepareImageForReport(screenshotManager.takeElementScreenshot(driverFactoryHelper.getDriver(), elementLocator), "captureScreenshot")));
-        return new Actions(driverFactoryHelper);
+        return new Actions(driverFactoryHelper).captureScreenshot(elementLocator);
     }
 
 }

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -1,12 +1,14 @@
 package com.shaft.gui.element.internal;
 
 import com.google.common.annotations.Beta;
+import com.shaft.cli.FileActions;
 import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.driver.internal.DriverFactory.SynchronizationManager;
 import com.shaft.enums.internal.Screenshots;
 import com.shaft.gui.browser.internal.JavaScriptWaitManager;
 import com.shaft.gui.element.ElementActions;
+import com.shaft.gui.element.TouchActions;
 import com.shaft.gui.internal.exceptions.MultipleElementsFoundException;
 import com.shaft.gui.internal.healing.HealingManager;
 import com.shaft.gui.internal.healing.HealingResolution;
@@ -262,6 +264,55 @@ public class Actions extends ElementActions {
         return this;
     }
 
+    @Step("Scroll to element")
+    @Override
+    public Actions scrollToElement(By elementLocator) {
+        performAction(ActionType.SCROLL_TO_ELEMENT, elementLocator, null);
+        return this;
+    }
+
+    @Step("Select")
+    @Override
+    public Actions select(By elementLocator, String valueOrVisibleText) {
+        performAction(ActionType.SELECT, elementLocator, valueOrVisibleText);
+        return this;
+    }
+
+    @Step("Submit form using JavaScript")
+    @Override
+    public Actions submitFormUsingJavaScript(By elementLocator) {
+        performAction(ActionType.SUBMIT_FORM_USING_JAVASCRIPT, elementLocator, null);
+        return this;
+    }
+
+    @Step("Switch to iframe")
+    @Override
+    public Actions switchToIframe(By elementLocator) {
+        performAction(ActionType.SWITCH_TO_IFRAME, elementLocator, null);
+        return this;
+    }
+
+    @Step("Type file location for upload")
+    @Override
+    public Actions typeFileLocationForUpload(By elementLocator, String filePath) {
+        String absoluteFilePath = filePath.startsWith("src") ? FileActions.getInstance(true).getAbsolutePath(filePath) : filePath;
+        performAction(ActionType.TYPE_FILE_LOCATION_FOR_UPLOAD, elementLocator, absoluteFilePath.replace("/", File.separator));
+        return this;
+    }
+
+    @Step("Capture screenshot")
+    @Override
+    public Actions captureScreenshot(By elementLocator) {
+        String elementName = JavaHelper.formatLocatorToString(elementLocator);
+        try {
+            byte[] screenshot = new com.shaft.gui.internal.image.ScreenshotManager().takeElementScreenshot(driverFactoryHelper.getDriver(), elementLocator);
+            reportPass(ActionType.CAPTURE_SCREENSHOT.name(), elementName, screenshot);
+        } catch (RuntimeException exception) {
+            reportBroken(ActionType.CAPTURE_SCREENSHOT.name(), elementName, takeFailureScreenshot(null), exception);
+        }
+        return this;
+    }
+
     @Step("Drag and drop")
     @Override
     public Actions dragAndDrop(@NonNull By sourceElementLocator, @NonNull By destinationElementLocator) {
@@ -348,7 +399,7 @@ public class Actions extends ElementActions {
             output = String.valueOf(waitResult);
             if (waitResult == null || Boolean.FALSE.equals(waitResult))
                 throw new TimeoutException("Condition was not met within the timeout period.");
-        } catch (WebDriverException exception) {
+        } catch (RuntimeException exception) {
             if (output.isEmpty())
                 output = "custom lambda expression";
             reportBroken("waitUntil", output, takeFailureScreenshot(null), exception);
@@ -358,6 +409,32 @@ public class Actions extends ElementActions {
         output = description.contains(" ") ? description : "custom lambda expression";
 
         reportPass("waitUntil", output, null);
+        return this;
+    }
+
+    @Step("Execute native mobile command")
+    @Override
+    public Actions executeNativeMobileCommand(String command, Map<String, String> parameters) {
+        String commandDetails = "Command: " + command + ", Parameters: " + parameters;
+        try {
+            elementActionsHelper.executeNativeMobileCommandUsingJavascript(driverFactoryHelper.getDriver(), command, parameters);
+            reportPass(ActionType.EXECUTE_NATIVE_MOBILE_COMMAND.name(), commandDetails, (byte[]) null);
+        } catch (RuntimeException exception) {
+            reportBroken(ActionType.EXECUTE_NATIVE_MOBILE_COMMAND.name(), commandDetails, takeFailureScreenshot(null), exception);
+        }
+        return this;
+    }
+
+    @Step("Switch to default content")
+    @Override
+    public Actions switchToDefaultContent() {
+        try {
+            driverFactoryHelper.getDriver().switchTo().defaultContent();
+            LocatorBuilder.getIFrameLocator().remove();
+            reportPass(ActionType.SWITCH_TO_DEFAULT_CONTENT.name(), "default content", (byte[]) null);
+        } catch (RuntimeException exception) {
+            reportBroken(ActionType.SWITCH_TO_DEFAULT_CONTENT.name(), "default content", takeFailureScreenshot(null), exception);
+        }
         return this;
     }
 
@@ -489,7 +566,7 @@ public class Actions extends ElementActions {
                                 // InvalidElementStateException is normally retryable for visibility-aware waits;
                                 // when JavaScript fallback is disabled, report the native click failure immediately
                                 // so the original Selenium exception is not replaced by a FluentWait timeout.
-                                reportBroken(action.name(), accessibleName.get(), reportContext.get(), screenshot.get(0), exception);
+                                throw exception;
                             }
                         }
                     }
@@ -548,6 +625,24 @@ public class Actions extends ElementActions {
                         if (!"".equals(foundElements.get().getFirst().getDomProperty("value")))
                             executeClearBasedOnClearMode(foundElements.get().getFirst(), "backspace");
                     }
+                    case SCROLL_TO_ELEMENT -> {
+                        if (isMobileNativeExecution) {
+                            performTouchAction().swipeElementIntoView(locator, TouchActions.SwipeDirection.DOWN);
+                        }
+                    }
+                    case SELECT -> selectValue(foundElements.get().getFirst(), locator, String.valueOf(data));
+                    case SUBMIT_FORM_USING_JAVASCRIPT -> {
+                        try {
+                            ((JavascriptExecutor) d).executeScript("arguments[0].submit();", foundElements.get().getFirst());
+                        } catch (JavascriptException javascriptException) {
+                            foundElements.get().getFirst().submit();
+                        }
+                    }
+                    case SWITCH_TO_IFRAME -> {
+                        LocatorBuilder.getIFrameLocator().set(locator);
+                        d.switchTo().frame(foundElements.get().getFirst());
+                    }
+                    case TYPE_FILE_LOCATION_FOR_UPLOAD -> typeFileLocationForUpload(foundElements.get().getFirst(), locator, String.valueOf(data));
                     case DRAG_AND_DROP -> {
                         String currentDragAndDropSubstep = "resolve source element";
                         var sourceElement = chooseDragAndDropElement(foundElements.get(), locator, "source");
@@ -681,7 +776,7 @@ public class Actions extends ElementActions {
                         "");
                 return true;
             });
-        } catch (WebDriverException exception) {
+        } catch (RuntimeException exception) {
             HealingManager.recordOutcome(
                     driverFactoryHelper.getDriver(),
                     healingResolution.get(),
@@ -697,13 +792,11 @@ public class Actions extends ElementActions {
                     false,
                     exception.getClass().getSimpleName());
             try {
-                // take failure screenshot if needed
-                if (screenshot.get(0) == null) {
-                    if (foundElements.get() == null || foundElements.get().size() != 1) {
-                        screenshot.set(0, takeFailureScreenshot(null));
-                    } else {
-                        screenshot.set(0, takeFailureScreenshot(foundElements.get().getFirst()));
-                    }
+                // take failure screenshot
+                if (foundElements.get() == null || foundElements.get().size() != 1) {
+                    screenshot.set(0, takeFailureScreenshot(null));
+                } else {
+                    screenshot.set(0, takeFailureScreenshot(foundElements.get().getFirst()));
                 }
                 // report broken
                 reportBroken(action.name(), accessibleName.get(), reportContext.get(), screenshot.get(0), exception);
@@ -722,6 +815,58 @@ public class Actions extends ElementActions {
         //report pass
         reportPass(action.name(), accessibleName.get(), reportContext.get(), screenshot.get(0));
         return output.get();
+    }
+
+    private void selectValue(WebElement targetElement, By locator, String valueOrVisibleText) {
+        if (!"select".equals(targetElement.getTagName())) {
+            if (!SHAFT.Properties.flags.handleNonSelectDropDown()) {
+                throw new InvalidElementStateException("Tag should be <select>, yet it was found to be <" + targetElement.getTagName() + ">.");
+            }
+            targetElement.click();
+            By optionLocator = SHAFT.GUI.Locator.hasAnyTagName().and().containsText(valueOrVisibleText).byRelation().below(locator);
+            chooseBestEffortDisplayedElement(findAllElements(optionLocator, ActionType.SELECT.name() + "_OPTION").elements()).click();
+            return;
+        }
+
+        Select selectElement = new Select(targetElement);
+        List<WebElement> availableOptions = selectElement.getOptions();
+        for (int index = 0; index < availableOptions.size(); index++) {
+            String visibleText = availableOptions.get(index).getText();
+            String value = availableOptions.get(index).getDomProperty("value");
+            if (visibleText.trim().equals(valueOrVisibleText) || (value != null && value.trim().equals(valueOrVisibleText))) {
+                selectElement.selectByIndex(index);
+                return;
+            }
+        }
+        throw new NoSuchElementException("Cannot locate option with Value or Visible text =" + valueOrVisibleText);
+    }
+
+    private void typeFileLocationForUpload(WebElement targetElement, By locator, String absoluteFilePath) {
+        try {
+            targetElement.sendKeys(absoluteFilePath);
+        } catch (InvalidArgumentException exception) {
+            throw exception;
+        } catch (ElementNotInteractableException | NoSuchElementException firstFailure) {
+            List<WebElement> uploadElements = findAllElements(locator, ActionType.TYPE_FILE_LOCATION_FOR_UPLOAD.name()).elements();
+            if (uploadElements.isEmpty()) {
+                throw new NoSuchElementException("Cannot locate an element using " + JavaHelper.formatLocatorToString(locator));
+            }
+            WebElement visibleElement = uploadElements.getFirst();
+            String originalStyle = visibleElement.getDomProperty("style");
+            try {
+                ((JavascriptExecutor) driverFactoryHelper.getDriver()).executeScript("arguments[0].setAttribute('style', 'display:block !important;');", visibleElement);
+                visibleElement.sendKeys(absoluteFilePath);
+            } catch (WebDriverException secondFailure) {
+                secondFailure.addSuppressed(firstFailure);
+                throw secondFailure;
+            } finally {
+                try {
+                    ((JavascriptExecutor) driverFactoryHelper.getDriver()).executeScript("arguments[0].setAttribute('style', arguments[1]);", visibleElement, originalStyle == null ? "" : originalStyle);
+                } catch (WebDriverException restoreFailure) {
+                    ReportManagerHelper.logDiscrete(restoreFailure);
+                }
+            }
+        }
     }
 
     private void executeClearBasedOnClearMode(WebElement elem, String clearMode) {
@@ -817,23 +962,13 @@ public class Actions extends ElementActions {
     }
 
     private byte[] takeFailureScreenshot(WebElement element) {
-        if (shouldAttachFailureScreenshot())
-            return captureScreenshot(element, false);
-        if (SHAFT.Properties.visuals.createAnimatedGif())
-            captureScreenshot(element, false);
-        return null;
-    }
-
-    private boolean shouldAttachFailureScreenshot() {
-        var whenToTakeAScreenshot = SHAFT.Properties.visuals.screenshotParamsWhenToTakeAScreenshot();
-        return "Always".equalsIgnoreCase(whenToTakeAScreenshot)
-                || "FailuresOnly".equalsIgnoreCase(whenToTakeAScreenshot);
+        return captureScreenshot(element, false);
     }
 
     private byte[] captureScreenshot(WebElement element, boolean isPass) {
         // capture screenshot
         byte[] screenshot;
-        if (element != null && SHAFT.Properties.visuals.screenshotParamsHighlightElements()) {
+        if (element != null && (SHAFT.Properties.visuals.screenshotParamsHighlightElements() || !isPass)) {
             if ("JavaScript".equals(SHAFT.Properties.visuals.screenshotParamsHighlightMethod())) {
                 // take screenshot, apply watermark and append it to gif before removing javascript highlighting
                 screenshot = takeJavaScriptHighlightedScreenshot(element, isPass);
@@ -935,9 +1070,16 @@ public class Actions extends ElementActions {
         if (isPass) {
             color = new Color(67, 176, 42); // selenium-green
         } else {
-            color = new Color(255, 255, 153); // yellow
+            color = new Color(255, 0, 0); // red
         }
-        src = ImageProcessingActions.highlightElementInScreenshot(src, elementLocation, color);
+        try {
+            byte[] highlighted = ImageProcessingActions.highlightElementInScreenshot(src, elementLocation, color);
+            if (highlighted != null && highlighted.length > 0) {
+                src = highlighted;
+            }
+        } catch (Exception highlightFailure) {
+            ReportManagerHelper.logDiscrete(highlightFailure);
+        }
         return src;
     }
 
@@ -981,8 +1123,8 @@ public class Actions extends ElementActions {
             background = "#46aad2";
             backgroundColor = "#A5D2A5";
         } else {
-            background = "#FFFF99";
-            backgroundColor = "#FFFF99";
+            background = "#FF0000";
+            backgroundColor = "#FF0000";
         }
         return "outline-offset:-3px !important; outline:3px solid #808080 !important; background:" + background
                 + " !important; background-color:" + backgroundColor
@@ -1073,11 +1215,12 @@ public class Actions extends ElementActions {
     }
 
     private static String createStepName(String action, String elementName, ActionReportContext context) {
+        String actionName = JavaHelper.convertToSentenceCase(action).replaceAll("\\s+", " ");
         String value = context.stepValue();
         if (context.shouldReportTypedValue() && !value.isBlank()) {
-            return JavaHelper.convertToSentenceCase(action).replaceAll("\\s+", " ") + " \"" + value + "\"";
+            return actionName + " \"" + value + "\"";
         }
-        return JavaHelper.convertToSentenceCase(action) + " \"" + elementName + "\"";
+        return actionName + " \"" + elementName + "\"";
     }
 
     private static void updateTypingStepMetadata(ActionReportContext context) {
@@ -1287,7 +1430,7 @@ public class Actions extends ElementActions {
         return (rootCause + System.lineSeparator() + causedBySection).trim();
     }
 
-    protected enum ActionType {HOVER, CLICK, JAVASCRIPT_CLICK, TYPE, TYPE_SECURELY, TYPE_APPEND, JAVASCRIPT_SET_VALUE, CLEAR, DRAG_AND_DROP, GET_ATTRIBUTE, GET_DOM_ATTRIBUTE, GET_DOM_PROPERTY, GET_NAME, GET_TEXT, GET_CSS_VALUE, GET_IS_DISPLAYED, GET_IS_ENABLED, DRAG_AND_DROP_BY_OFFSET, GET_SELECTED_TEXT, CLICK_AND_HOLD, DOUBLE_CLICK, GET_IS_SELECTED, CLIPBOARD_DELETE, CLIPBOARD_COPY, CLIPBOARD_CUT, CLIPBOARD_PASTE, DROP_FILE_TO_UPLOAD}
+    protected enum ActionType {HOVER, CLICK, JAVASCRIPT_CLICK, TYPE, TYPE_SECURELY, TYPE_APPEND, JAVASCRIPT_SET_VALUE, CLEAR, SCROLL_TO_ELEMENT, SELECT, SUBMIT_FORM_USING_JAVASCRIPT, SWITCH_TO_IFRAME, SWITCH_TO_DEFAULT_CONTENT, TYPE_FILE_LOCATION_FOR_UPLOAD, CAPTURE_SCREENSHOT, EXECUTE_NATIVE_MOBILE_COMMAND, DRAG_AND_DROP, GET_ATTRIBUTE, GET_DOM_ATTRIBUTE, GET_DOM_PROPERTY, GET_NAME, GET_TEXT, GET_CSS_VALUE, GET_IS_DISPLAYED, GET_IS_ENABLED, DRAG_AND_DROP_BY_OFFSET, GET_SELECTED_TEXT, CLICK_AND_HOLD, DOUBLE_CLICK, GET_IS_SELECTED, CLIPBOARD_DELETE, CLIPBOARD_COPY, CLIPBOARD_CUT, CLIPBOARD_PASTE, DROP_FILE_TO_UPLOAD}
 
     /**
      * Provides read-only accessors for querying properties, attributes, and state of a

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java
@@ -18,7 +18,6 @@ import com.shaft.tools.internal.support.JavaHelper;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.FailureReporter;
 import com.shaft.tools.io.internal.ReportManagerHelper;
-import com.shaft.validation.internal.ValidationsHelper;
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.AppiumDriver;
 import lombok.Getter;
@@ -546,7 +545,7 @@ public class ElementActionsHelper {
                 return new ScreenshotManager().takeScreenshot(driver, null, actionName, true);
             }
         } else {
-            return new ScreenshotManager().takeScreenshot(driver, null, actionName, false);
+            return new ScreenshotManager().takeScreenshot(driver, elementLocator, actionName, false);
         }
         return new ArrayList<>();
     }
@@ -805,17 +804,6 @@ public class ElementActionsHelper {
         //TODO: merge all fail actions, make all methods call this one, get elementName where applicable instead of reporting null
         //this condition works if this is the first level of failure, but the first level is usually caught by the calling method
 
-//        boolean skipPageScreenshot = rootCauseException.length >= 1 && (
-//                TimeoutException.class.getName().equals(rootCauseException[0].getClass().getName()) //works to capture fluent wait failure
-//                        || (
-//                        rootCauseException[0].getMessage().contains("Identify unique element")
-//                                && isFoundInStacktrace(ValidationsHelper.class, rootCauseException[0])
-//                )//works to capture calling elementAction failure in case this is an assertion
-//        );
-
-        //don't take a second screenshot in case of validation failure  because the original element action will have always failed first
-        boolean skipPageScreenshot = rootCauseException.length >= 1 && (isFoundInStacktrace(ValidationsHelper.class, rootCauseException[0]) && isFoundInStacktrace(ElementActionsHelper.class, rootCauseException[0]));
-
         String elementName = elementLocator != null ? JavaHelper.formatLocatorToString(elementLocator) : "";
         if (elementLocator != null && (rootCauseException.length >= 1 && Throwables.getRootCause(rootCauseException[0]).getClass() != MultipleElementsFoundException.class && Throwables.getRootCause(rootCauseException[0]).getClass() != NoSuchElementException.class && Throwables.getRootCause(rootCauseException[0]).getClass() != InvalidSelectorException.class)) {
             try {
@@ -835,16 +823,10 @@ public class ElementActionsHelper {
         }
 
         String message;
-        if (skipPageScreenshot) {
-            //don't try to take a screenshot again and set element locator to null in case element was not found by timeout or by nested element actions call
-            message = createReportMessage(actionName, testData, elementName, false);
-            ReportManager.logDiscrete(message);
+        if (rootCauseException.length >= 1) {
+            message = reportActionResult(driver, actionName, testData, elementLocator, screenshots, elementName, false, rootCauseException[0]);
         } else {
-            if (rootCauseException.length >= 1) {
-                message = reportActionResult(driver, actionName, testData, elementLocator, screenshots, elementName, false, rootCauseException[0]);
-            } else {
-                message = reportActionResult(driver, actionName, testData, null, screenshots, elementName, false);
-            }
+            message = reportActionResult(driver, actionName, testData, null, screenshots, elementName, false);
         }
         if (rootCauseException.length >= 1) {
             Assert.fail(message, rootCauseException[0]);

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotManager.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotManager.java
@@ -113,6 +113,9 @@ public class ScreenshotManager {
     }
 
     private boolean shouldAttachScreenshot(String actionName, boolean passFailStatus) {
+        if (!passFailStatus) {
+            return true;
+        }
         var whenToTakeAScreenshot = SHAFT.Properties.visuals.screenshotParamsWhenToTakeAScreenshot();
         if ("Always".equalsIgnoreCase(whenToTakeAScreenshot)) {
             return true;
@@ -218,7 +221,7 @@ public class ScreenshotManager {
     private byte[] takeAIHighlightedScreenshot(WebDriver driver, By elementLocator, boolean isPass) {
         Rectangle elementLocation = null;
         // getElementLocation
-        if (Boolean.TRUE.equals(SHAFT.Properties.visuals.screenshotParamsHighlightElements()) && elementLocator != null) {
+        if ((Boolean.TRUE.equals(SHAFT.Properties.visuals.screenshotParamsHighlightElements()) || !isPass) && elementLocator != null) {
             var elementInformation = ElementInformation.fromList(elementActionsHelper.identifyUniqueElementIgnoringVisibility(driver, elementLocator));
             int elementCount = elementInformation.getNumberOfFoundElements();
             boolean isRelativeLocator = elementLocator instanceof RelativeLocator.RelativeBy;
@@ -245,7 +248,7 @@ public class ScreenshotManager {
                 if (isPass) {
                     color = new Color(67, 176, 42); // selenium-green
                 } else {
-                    color = new Color(255, 255, 153); // yellow
+                    color = new Color(255, 0, 0); // red
                 }
                 byte[] highlighted = ImageProcessingActions.highlightElementInScreenshot(src, elementLocation, color);
                 if (highlighted != null && highlighted.length > 0) {
@@ -265,7 +268,7 @@ public class ScreenshotManager {
         JavascriptExecutor js = null;
         WebElement element = null;
         // get & highlight Element
-        if (Boolean.TRUE.equals(SHAFT.Properties.visuals.screenshotParamsHighlightElements()) && elementLocator != null) {
+        if ((Boolean.TRUE.equals(SHAFT.Properties.visuals.screenshotParamsHighlightElements()) || !isPass) && elementLocator != null) {
             var elementInformation = ElementInformation.fromList(elementActionsHelper.identifyUniqueElementIgnoringVisibility(driver, elementLocator));
             int elementCount = elementInformation.getNumberOfFoundElements();
             boolean isRelativeLocator = elementLocator instanceof RelativeLocator.RelativeBy;
@@ -321,8 +324,8 @@ public class ScreenshotManager {
             background = "#46aad2";
             backgroundColor = "#A5D2A5";
         } else {
-            background = "#FFFF99";
-            backgroundColor = "#FFFF99";
+            background = "#FF0000";
+            backgroundColor = "#FF0000";
         }
         return "outline-offset:-3px !important; outline:3px solid #808080 !important; background:" + background
                 + " !important; background-color:" + backgroundColor

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/locator/SmartLocators.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/locator/SmartLocators.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 public class SmartLocators {
 
     public static By inputField(@NonNull String elementName) {
-        return new ByAll(
+        return new SmartLocator(elementName,
                 // input
                 xpathBuilder(PathStrategy.INPUT_CONTAINS_PLACEHOLDER, elementName),
                 xpathBuilder(PathStrategy.INPUT_CONTAINS_ARIA_LABEL, elementName),
@@ -30,7 +30,7 @@ public class SmartLocators {
     }
 
     public static By clickableField(@NonNull String elementName) {
-        return new ByAll(
+        return new SmartLocator(elementName,
                 xpathBuilder(PathStrategy.BUTTON_CONTAINS_TEXT, elementName),
                 xpathBuilder(PathStrategy.BUTTON_CONTAINS_ID, elementName),
                 xpathBuilder(PathStrategy.BUTTON_CONTAINS_TITLE, elementName),
@@ -60,6 +60,10 @@ public class SmartLocators {
                 xpathBuilder(PathStrategy.ANY_CONTAINS_TEXT_FOLLOWING_BUTTON, elementName),
                 xpathBuilder(PathStrategy.ANY_CONTAINS_TEXT_FOLLOWING_LINK, elementName)
         );
+    }
+
+    public static String format(By locator) {
+        return locator instanceof SmartLocator smartLocator ? "Smart Locator: \"" + smartLocator.elementName + "\"" : null;
     }
 
     private static By xpathBuilder(@NonNull PathStrategy strategy, @NonNull String elementName) {
@@ -312,5 +316,14 @@ public class SmartLocators {
         ROLE_BUTTON_CONTAINS_TEXT, ROLE_LINK_CONTAINS_TEXT, ROLE_TAB_CONTAINS_TEXT, ROLE_MENUITEM_CONTAINS_TEXT,
         // CLICKABLE FIELD, ADDED AFTER REALISTIC TESTING
         ANY_CONTAINS_TEXT_FOLLOWING_BUTTON, ANY_CONTAINS_TEXT_FOLLOWING_LINK
+    }
+
+    private static class SmartLocator extends ByAll {
+        private final String elementName;
+
+        private SmartLocator(String elementName, By... bys) {
+            super(bys);
+            this.elementName = elementName;
+        }
     }
 }

--- a/shaft-engine/src/main/java/com/shaft/tools/internal/support/JavaHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/internal/support/JavaHelper.java
@@ -2,6 +2,7 @@ package com.shaft.tools.internal.support;
 
 import com.shaft.cli.FileActions;
 import com.shaft.driver.SHAFT;
+import com.shaft.gui.internal.locator.SmartLocators;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import com.shaft.validation.ValidationEnums;
 import org.openqa.selenium.By;
@@ -213,6 +214,10 @@ public class JavaHelper {
     }
 
     public static String formatLocatorToString(By locator) {
+        String smartLocator = SmartLocators.format(locator);
+        if (smartLocator != null) {
+            return smartLocator;
+        }
         if (locator instanceof RelativeLocator.RelativeBy relativeLocator) {
             return "Relative Locator: " + relativeLocator.getRemoteParameters().value().toString();
         } else {

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
@@ -112,6 +112,16 @@ public class ActionsCoverageUnitTest {
             assertRecorded(actions, Actions.ActionType.CLEAR, LOCATOR, null);
             Assert.assertSame(actions.dropFileToUpload(LOCATOR, "pom.xml"), actions);
             assertRecorded(actions, Actions.ActionType.DROP_FILE_TO_UPLOAD, LOCATOR, "pom.xml");
+            Assert.assertSame(actions.scrollToElement(LOCATOR), actions);
+            assertRecorded(actions, Actions.ActionType.SCROLL_TO_ELEMENT, LOCATOR, null);
+            Assert.assertSame(actions.select(LOCATOR, "option"), actions);
+            assertRecorded(actions, Actions.ActionType.SELECT, LOCATOR, "option");
+            Assert.assertSame(actions.submitFormUsingJavaScript(LOCATOR), actions);
+            assertRecorded(actions, Actions.ActionType.SUBMIT_FORM_USING_JAVASCRIPT, LOCATOR, null);
+            Assert.assertSame(actions.switchToIframe(LOCATOR), actions);
+            assertRecorded(actions, Actions.ActionType.SWITCH_TO_IFRAME, LOCATOR, null);
+            Assert.assertSame(actions.typeFileLocationForUpload(LOCATOR, "pom.xml"), actions);
+            assertRecorded(actions, Actions.ActionType.TYPE_FILE_LOCATION_FOR_UPLOAD, LOCATOR, "pom.xml");
             Assert.assertSame(actions.dragAndDrop(LOCATOR, By.id("drop")), actions);
             assertRecorded(actions, Actions.ActionType.DRAG_AND_DROP, LOCATOR, By.id("drop"));
             Assert.assertSame(actions.dragAndDropByOffset(LOCATOR, 5, 7), actions);
@@ -456,7 +466,7 @@ public class ActionsCoverageUnitTest {
             when(innerHtmlElement.getDomProperty("innerHTML")).thenReturn("inner-text");
             Assert.assertEquals(invoke(actions, "parseElementText", new Class[]{WebElement.class}, innerHtmlElement), "inner-text");
             Assert.assertTrue(((String) invoke(actions, "setHighlightedElementStyle", new Class[]{boolean.class}, true)).contains("#46aad2"));
-            Assert.assertTrue(((String) invoke(actions, "setHighlightedElementStyle", new Class[]{boolean.class}, false)).contains("#FFFF99"));
+            Assert.assertTrue(((String) invoke(actions, "setHighlightedElementStyle", new Class[]{boolean.class}, false)).contains("#FF0000"));
             byte[] rawScreenshot = new byte[]{1, 2, 3};
             Assert.assertEquals((byte[]) invoke(actions, "appendShaftWatermark", new Class[]{byte[].class}, rawScreenshot), rawScreenshot);
         }
@@ -679,9 +689,11 @@ public class ActionsCoverageUnitTest {
             animatedGif.when(() -> AnimatedGifManager.startOrAppendToAnimatedGif(any(byte[].class), eq(false))).thenAnswer(inv -> null);
 
             Object actionScreenshot = invoke(new Actions(helper), "takeActionScreenshot", new Class[]{WebElement.class}, element);
+            Object failureScreenshot = invoke(new Actions(helper), "takeFailureScreenshot", new Class[]{WebElement.class}, (Object) null);
 
             Assert.assertNull(actionScreenshot, "GIF capture should not attach per-action screenshots by itself");
-            animatedGif.verify(() -> AnimatedGifManager.startOrAppendToAnimatedGif(any(byte[].class), eq(false)));
+            Assert.assertNotNull(failureScreenshot, "failed actions should attach screenshots regardless of policy");
+            animatedGif.verify(() -> AnimatedGifManager.startOrAppendToAnimatedGif(any(byte[].class), eq(false)), org.mockito.Mockito.atLeastOnce());
         }
     }
 

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotManagerCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotManagerCoverageUnitTest.java
@@ -33,6 +33,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -228,9 +229,11 @@ public class ScreenshotManagerCoverageUnitTest {
 
             SHAFT.Properties.visuals.set().screenshotParamsHighlightMethod("AI");
             byte[] aiPass = manager.internalCaptureScreenshot(driver, By.id("x"), true);
+            SHAFT.Properties.visuals.set().screenshotParamsHighlightElements(false);
             byte[] aiFail = manager.internalCaptureScreenshot(driver, RelativeLocator.with(By.tagName("div")).above(By.id("x")), false);
             Assert.assertTrue(aiPass.length > 0);
             Assert.assertTrue(aiFail.length > 0);
+            imageProcessingMocked.verify(() -> ImageProcessingActions.highlightElementInScreenshot(any(byte[].class), any(Rectangle.class), eq(new Color(255, 0, 0))));
 
             SHAFT.Properties.visuals.set().screenshotParamsHighlightMethod("JavaScript");
             byte[] jsShot = manager.internalCaptureScreenshot(driver, By.id("x"), true);
@@ -307,7 +310,7 @@ public class ScreenshotManagerCoverageUnitTest {
 
             SHAFT.Properties.visuals.set().screenshotParamsWhenToTakeAScreenshot("ValidationPointsOnly");
             Assert.assertTrue(manager.takeScreenshot(driver, null, "click", true).isEmpty());
-            Assert.assertTrue(manager.takeScreenshot(driver, null, "click", false).isEmpty());
+            Assert.assertFalse(manager.takeScreenshot(driver, null, "click", false).isEmpty());
             Assert.assertFalse(manager.takeScreenshot(driver, null, "assertEquals", true).isEmpty());
 
             SHAFT.Properties.visuals.set().screenshotParamsWhenToTakeAScreenshot("FailuresOnly");
@@ -318,7 +321,7 @@ public class ScreenshotManagerCoverageUnitTest {
             Assert.assertFalse(manager.takeScreenshot(driver, null, "click", true).isEmpty());
 
             SHAFT.Properties.visuals.set().screenshotParamsWhenToTakeAScreenshot("Never");
-            Assert.assertTrue(manager.takeScreenshot(driver, null, "assertEquals", false).isEmpty());
+            Assert.assertFalse(manager.takeScreenshot(driver, null, "assertEquals", false).isEmpty());
         }
     }
 

--- a/shaft-engine/src/test/java/testPackage/unitTests/ElementActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/ElementActionsCoverageUnitTest.java
@@ -1,42 +1,42 @@
 package testPackage.unitTests;
 
 import com.shaft.driver.SHAFT;
-import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.driver.internal.FluentWebDriverAction;
 import com.shaft.gui.element.ElementActions;
+import com.shaft.gui.element.internal.Actions;
 import com.shaft.gui.element.internal.ElementActionsHelper;
 import com.shaft.properties.internal.Properties;
-import org.mockito.Mockito;
 import org.mockito.MockedConstruction;
-import org.openqa.selenium.*;
+import org.mockito.Mockito;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.Rectangle;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.when;
 
 @Test(singleThreaded = true)
 public class ElementActionsCoverageUnitTest {
+    private static final By LOCATOR = By.id("sample");
+    private static final byte[] PNG = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
+
     private WebDriver driver;
-    private WebDriver.TargetLocator targetLocator;
-    private WebElement element;
     private ElementActions elementActions;
-    private static final byte[] VALID_PNG_BYTES = java.util.Base64.getDecoder().decode(
-            "iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAnSURBVDhPY9Bp+f+fmpgBXYBSPGog5XjUQMrxqIGU41EDKceD30AA+QcwHa2jOdoAAAAASUVORK5CYII=");
 
     @BeforeMethod(alwaysRun = true)
     public void setUp() {
@@ -45,36 +45,9 @@ public class ElementActionsCoverageUnitTest {
         SHAFT.Properties.visuals.set().screenshotParamsWatermark(false);
 
         driver = mock(WebDriver.class, Mockito.withSettings().extraInterfaces(JavascriptExecutor.class, TakesScreenshot.class));
-        targetLocator = mock(WebDriver.TargetLocator.class);
-        element = mock(WebElement.class);
-
-        when(driver.switchTo()).thenReturn(targetLocator);
-        when(targetLocator.frame(any(WebElement.class))).thenReturn(driver);
-        when(targetLocator.defaultContent()).thenReturn(driver);
-
-        when(driver.findElements(any(By.class))).thenReturn(List.of(element));
-        when(driver.findElement(any(By.class))).thenReturn(element);
-
-        when(element.isDisplayed()).thenReturn(true);
-        when(element.isEnabled()).thenReturn(true);
-        when(element.getTagName()).thenReturn("input");
-        when(element.getAccessibleName()).thenReturn("Element");
-        when(element.getDomProperty(any())).thenReturn("opt1");
-        when(element.getRect()).thenReturn(new Rectangle(0, 0, 10, 10));
-
-        when(((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES)).thenReturn(VALID_PNG_BYTES);
-        when(element.getScreenshotAs(OutputType.BYTES)).thenReturn(VALID_PNG_BYTES);
-        when(((JavascriptExecutor) driver).executeScript(any(String.class), any())).thenAnswer(invocation -> {
-            String script = invocation.getArgument(0);
-            if ("return self.name".equals(script)) {
-                return "mainFrame";
-            }
-            if (script.contains("document.readyState")) {
-                return "complete";
-            }
-            return 0;
-        });
-
+        when(((JavascriptExecutor) driver).executeScript(anyString())).thenReturn("complete");
+        when(((JavascriptExecutor) driver).executeScript("return self.name")).thenReturn("mainFrame");
+        when(((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES)).thenReturn(PNG);
         elementActions = new ElementActions(driver, true);
     }
 
@@ -84,121 +57,104 @@ public class ElementActionsCoverageUnitTest {
     }
 
     @Test
-    public void shouldCoverBasicFluentAndActionWrappers() {
-        By locator = By.id("sample");
-
-        Assert.assertNotNull(elementActions.and());
-        Assert.assertNotNull(elementActions.assertThat(locator));
-        Assert.assertNotNull(elementActions.verifyThat(locator));
-        Assert.assertEquals(elementActions.getElementsCount(locator), 1);
-
-        try (MockedConstruction<com.shaft.gui.element.internal.Actions> ignored = mockConstruction(
-                com.shaft.gui.element.internal.Actions.class,
+    public void actionMethodsShouldDelegateToInternalActionsStack() {
+        try (MockedConstruction<Actions> constructedActions = Mockito.mockConstruction(Actions.class,
                 (mock, context) -> {
+                    when(mock.executeNativeMobileCommand(anyString(), anyMap())).thenReturn(mock);
                     when(mock.click(any(By.class))).thenReturn(mock);
                     when(mock.clickUsingJavascript(any(By.class))).thenReturn(mock);
+                    when(mock.scrollToElement(any(By.class))).thenReturn(mock);
                     when(mock.clickAndHold(any(By.class))).thenReturn(mock);
                     when(mock.doubleClick(any(By.class))).thenReturn(mock);
                     when(mock.dragAndDrop(any(By.class), any(By.class))).thenReturn(mock);
                     when(mock.dragAndDropByOffset(any(By.class), any(Integer.class), any(Integer.class))).thenReturn(mock);
                     when(mock.hover(any(By.class))).thenReturn(mock);
-                    when(mock.setValueUsingJavaScript(any(By.class), any(String.class))).thenReturn(mock);
+                    when(mock.select(any(By.class), anyString())).thenReturn(mock);
+                    when(mock.setValueUsingJavaScript(any(By.class), anyString())).thenReturn(mock);
+                    when(mock.submitFormUsingJavaScript(any(By.class))).thenReturn(mock);
+                    when(mock.switchToIframe(any(By.class))).thenReturn(mock);
+                    when(mock.switchToDefaultContent()).thenReturn(mock);
                     when(mock.type(any(By.class), any(CharSequence[].class))).thenReturn(mock);
                     when(mock.clear(any(By.class))).thenReturn(mock);
                     when(mock.typeAppend(any(By.class), any(CharSequence[].class))).thenReturn(mock);
+                    when(mock.typeFileLocationForUpload(any(By.class), anyString())).thenReturn(mock);
                     when(mock.typeSecure(any(By.class), any(CharSequence[].class))).thenReturn(mock);
+                    when(mock.captureScreenshot(any(By.class))).thenReturn(mock);
                 })) {
-            Assert.assertNotNull(elementActions.click(locator));
-            Assert.assertNotNull(elementActions.clickUsingJavascript(locator));
-            Assert.assertNotNull(elementActions.scrollToElement(locator));
-            Assert.assertNotNull(elementActions.clickAndHold(locator));
-            Assert.assertNotNull(elementActions.doubleClick(locator));
-            Assert.assertNotNull(elementActions.dragAndDrop(locator, By.id("destination")));
-            Assert.assertNotNull(elementActions.dragAndDropByOffset(locator, 5, 10));
-            Assert.assertNotNull(elementActions.hover(locator));
-            Assert.assertNotNull(elementActions.hoverAndClick(List.of(locator), By.id("clickable")));
-            Assert.assertNotNull(elementActions.setValueUsingJavaScript(locator, "value"));
-            Assert.assertNotNull(elementActions.type(locator, "text"));
-            Assert.assertNotNull(elementActions.clear(locator));
-            Assert.assertNotNull(elementActions.typeAppend(locator, "append"));
-            Assert.assertNotNull(elementActions.typeSecure(locator, "secret"));
+            Assert.assertNotNull(elementActions.executeNativeMobileCommand("mobile: scroll", Map.of("direction", "down")));
+            Mockito.verify(last(constructedActions)).executeNativeMobileCommand("mobile: scroll", Map.of("direction", "down"));
+
+            Assert.assertNotNull(elementActions.click(LOCATOR));
+            Mockito.verify(last(constructedActions)).click(LOCATOR);
+
+            Assert.assertNotNull(elementActions.clickUsingJavascript(LOCATOR));
+            Mockito.verify(last(constructedActions)).clickUsingJavascript(LOCATOR);
+
+            Assert.assertNotNull(elementActions.scrollToElement(LOCATOR));
+            Mockito.verify(last(constructedActions)).scrollToElement(LOCATOR);
+
+            Assert.assertNotNull(elementActions.clickAndHold(LOCATOR));
+            Mockito.verify(last(constructedActions)).clickAndHold(LOCATOR);
+
+            Assert.assertNotNull(elementActions.doubleClick(LOCATOR));
+            Mockito.verify(last(constructedActions)).doubleClick(LOCATOR);
+
+            Assert.assertNotNull(elementActions.dragAndDrop(LOCATOR, By.id("destination")));
+            Mockito.verify(last(constructedActions)).dragAndDrop(LOCATOR, By.id("destination"));
+
+            Assert.assertNotNull(elementActions.dragAndDropByOffset(LOCATOR, 5, 10));
+            Mockito.verify(last(constructedActions)).dragAndDropByOffset(LOCATOR, 5, 10);
+
+            Assert.assertNotNull(elementActions.hover(LOCATOR));
+            Mockito.verify(last(constructedActions)).hover(LOCATOR);
+
+            Assert.assertNotNull(elementActions.select(LOCATOR, "Option"));
+            Mockito.verify(last(constructedActions)).select(LOCATOR, "Option");
+
+            Assert.assertNotNull(elementActions.setValueUsingJavaScript(LOCATOR, "value"));
+            Mockito.verify(last(constructedActions)).setValueUsingJavaScript(LOCATOR, "value");
+
+            Assert.assertNotNull(elementActions.submitFormUsingJavaScript(LOCATOR));
+            Mockito.verify(last(constructedActions)).submitFormUsingJavaScript(LOCATOR);
+
+            Assert.assertNotNull(elementActions.switchToIframe(LOCATOR));
+            Mockito.verify(last(constructedActions)).switchToIframe(LOCATOR);
+
+            Assert.assertNotNull(elementActions.switchToDefaultContent());
+            Mockito.verify(last(constructedActions)).switchToDefaultContent();
+
+            Assert.assertNotNull(elementActions.type(LOCATOR, "text"));
+            Mockito.verify(last(constructedActions)).type(LOCATOR, "text");
+
+            Assert.assertNotNull(elementActions.clear(LOCATOR));
+            Mockito.verify(last(constructedActions)).clear(LOCATOR);
+
+            Assert.assertNotNull(elementActions.typeAppend(LOCATOR, "append"));
+            Mockito.verify(last(constructedActions)).typeAppend(LOCATOR, "append");
+
+            Assert.assertNotNull(elementActions.typeFileLocationForUpload(LOCATOR, "/tmp/file.txt"));
+            Mockito.verify(last(constructedActions)).typeFileLocationForUpload(LOCATOR, "/tmp/file.txt");
+
+            Assert.assertNotNull(elementActions.typeSecure(LOCATOR, "secret"));
+            Mockito.verify(last(constructedActions)).typeSecure(LOCATOR, "secret");
+
+            Assert.assertNotNull(elementActions.captureScreenshot(LOCATOR));
+            Mockito.verify(last(constructedActions)).captureScreenshot(LOCATOR);
         }
-
-        Assert.assertNotNull(elementActions.captureScreenshot(locator));
     }
 
     @Test
-    public void shouldCoverSelectSubmitSwitchAndFrameMethods() throws Exception {
-        var helper = mock(ElementActionsHelper.class);
-        var helperDriverFactory = mock(DriverFactoryHelper.class);
-        By locator = By.id("dropdown");
-
-        when(helperDriverFactory.getDriver()).thenReturn(driver);
-        setField(elementActions, "driverFactoryHelper", helperDriverFactory);
+    public void nonActionHelpersShouldRemainLocal() throws Exception {
+        ElementActionsHelper helper = mock(ElementActionsHelper.class);
         setField(elementActions, "elementActionsHelper", helper);
+        when(helper.getElementsCount(driver, LOCATOR)).thenReturn(3);
 
-        SHAFT.Properties.flags.set().handleNonSelectDropDown(true);
-        when(helper.identifyUniqueElement(eq(driver), any(By.class))).thenReturn(
-                buildElementInfo("div", locator, element, "dropdown"),
-                buildElementInfo("div", locator, element, "dropdown"),
-                buildElementInfo("li", By.xpath("//*[text()='Div 2']"), element, "option")
-        );
-        invokeAndIgnoreFailures(() -> elementActions.select(locator, "Div 2"));
-
-        WebElement option = mock(WebElement.class);
-        when(option.getText()).thenReturn("Option 2");
-        when(option.getDomProperty("value")).thenReturn("opt2");
-        when(option.isDisplayed()).thenReturn(true);
-        when(option.isEnabled()).thenReturn(true);
-        when(element.getTagName()).thenReturn("select");
-        when(element.findElements(By.tagName("option"))).thenReturn(List.of(option));
-
-        when(helper.identifyUniqueElement(eq(driver), any(By.class))).thenReturn(buildElementInfo("select", locator, element, "select"));
-        when(helper.waitForElementTextToBeNot(driver, locator, "")).thenReturn(true);
-        when(helper.getElementName(driver, locator)).thenReturn("select");
-        invokeAndIgnoreFailures(() -> elementActions.select(locator, "Option 2"));
-
-        when(helper.takeScreenshot(driver, locator, "submitFormUsingJavaScript", null, true)).thenReturn(Collections.emptyList());
-        when(helper.getElementName(driver, locator)).thenReturn("form");
-        doNothing().when(helper).submitFormUsingJavascript(driver, locator);
-        invokeAndIgnoreFailures(() -> elementActions.submitFormUsingJavaScript(locator));
-
-        doThrow(new JavascriptException("js fallback")).when(helper).submitFormUsingJavascript(driver, locator);
-        doNothing().when(element).submit();
-        invokeAndIgnoreFailures(() -> elementActions.submitFormUsingJavaScript(locator));
-
-        when(helper.identifyUniqueElement(driver, locator)).thenReturn(buildElementInfo("iframe", locator, element, "frame"));
-        invokeAndIgnoreFailures(() -> elementActions.switchToIframe(locator));
-        invokeAndIgnoreFailures(elementActions::switchToDefaultContent);
-
-        invokeAndIgnoreFailures(elementActions::getCurrentFrame);
+        Assert.assertEquals(elementActions.getElementsCount(LOCATOR), 3);
+        Assert.assertEquals(elementActions.getCurrentFrame(), "mainFrame");
     }
 
     @Test
-    public void shouldCoverNativeCommandUploadAndTableExtraction() throws Exception {
-        var helper = mock(ElementActionsHelper.class);
-        var helperDriverFactory = mock(DriverFactoryHelper.class);
-        By locator = By.id("upload");
-
-        when(helperDriverFactory.getDriver()).thenReturn(driver);
-        setField(elementActions, "driverFactoryHelper", helperDriverFactory);
-        setField(elementActions, "elementActionsHelper", helper);
-
-        doNothing().when(helper).executeNativeMobileCommandUsingJavascript(driver, "mobile: scroll", Map.of("direction", "down"));
-        invokeAndIgnoreFailures(() -> elementActions.executeNativeMobileCommand("mobile: scroll", Map.of("direction", "down")));
-
-        doThrow(new RuntimeException("forced")).when(helper).executeNativeMobileCommandUsingJavascript(driver, "mobile: fail", Map.of());
-        invokeAndIgnoreFailures(() -> elementActions.executeNativeMobileCommand("mobile: fail", Map.of()));
-
-        when(helper.scrollToFindElement(driver, locator)).thenReturn(Collections.emptyList());
-        invokeAndIgnoreFailures(() -> elementActions.scrollToElement(locator));
-
-        when(helper.getElementName(driver, locator)).thenReturn("upload");
-        when(helper.takeScreenshot(driver, locator, "typeFileLocationForUpload", null, true)).thenReturn(Collections.emptyList());
-        when(helper.identifyUniqueElementIgnoringVisibility(driver, locator)).thenReturn(buildElementInfo("input", locator, element, "upload"));
-        doNothing().when(element).sendKeys(any(CharSequence.class));
-        invokeAndIgnoreFailures(() -> elementActions.typeFileLocationForUpload(locator, "/tmp/file.txt"));
-
+    public void getTableRowsDataShouldExtractSimpleTableRows() {
         WebElement table = mock(WebElement.class);
         WebElement tbody = mock(WebElement.class);
         WebElement thead = mock(WebElement.class);
@@ -219,133 +175,29 @@ public class ElementActionsCoverageUnitTest {
         when(cell.getText()).thenReturn("Value");
 
         List<Map<String, String>> tableData = elementActions.getTableRowsData(By.id("table"));
-        Assert.assertNotNull(tableData);
+
         Assert.assertEquals(tableData.size(), 1);
         Assert.assertEquals(tableData.getFirst().get("Column"), "Value");
     }
 
     @Test
-    public void shouldCoverFailureBranchesForSelectSubmitAndSwitching() throws Exception {
-        var helper = mock(ElementActionsHelper.class);
-        var helperDriverFactory = mock(DriverFactoryHelper.class);
-        By locator = By.id("complex");
-
-        when(helperDriverFactory.getDriver()).thenReturn(driver);
-        setField(elementActions, "driverFactoryHelper", helperDriverFactory);
-        setField(elementActions, "elementActionsHelper", helper);
-
-        SHAFT.Properties.flags.set().handleNonSelectDropDown(true);
-        when(helper.identifyUniqueElement(eq(driver), any(By.class)))
-                .thenReturn(buildElementInfo("div", locator, element, "dropdown"))
-                .thenReturn(buildElementInfo("div", locator, element, "dropdown"))
-                .thenThrow(new RuntimeException("relative option not found"));
-        invokeAndIgnoreFailures(() -> elementActions.select(locator, "Missing Option"));
-
-        SHAFT.Properties.flags.set().handleNonSelectDropDown(false);
-        when(helper.identifyUniqueElement(eq(driver), any(By.class)))
-                .thenReturn(buildElementInfo("div", locator, element, "dropdown"));
-        invokeAndIgnoreFailures(() -> elementActions.select(locator, "Missing Option"));
-
-        when(element.getTagName()).thenReturn("select");
-        when(element.findElements(By.tagName("option"))).thenReturn(Collections.emptyList());
-        when(helper.identifyUniqueElement(eq(driver), any(By.class))).thenReturn(buildElementInfo("select", locator, element, "select"));
-        when(helper.waitForElementTextToBeNot(driver, locator, "")).thenReturn(false);
-        invokeAndIgnoreFailures(() -> elementActions.select(locator, "Option"));
-
-        doThrow(new RuntimeException("name failed")).when(helper).getElementName(driver, locator);
-        invokeAndIgnoreFailures(() -> elementActions.submitFormUsingJavaScript(locator));
-
-        doReturn("form").when(helper).getElementName(driver, locator);
-        when(helper.takeScreenshot(driver, locator, "submitFormUsingJavaScript", null, true))
-                .thenThrow(new JavascriptException("no screenshot first"))
-                .thenReturn(Collections.emptyList());
-        doThrow(new JavascriptException("js submit")).when(helper).submitFormUsingJavascript(driver, locator);
-        invokeAndIgnoreFailures(() -> elementActions.submitFormUsingJavaScript(locator));
-
-        when(helper.takeScreenshot(driver, locator, "submitFormUsingJavaScript", null, true))
-                .thenReturn(Collections.emptyList());
-        doThrow(new RuntimeException("submit failed")).when(helper).submitFormUsingJavascript(driver, locator);
-        invokeAndIgnoreFailures(() -> elementActions.submitFormUsingJavaScript(locator));
-
-        when(helper.identifyUniqueElement(driver, locator)).thenThrow(new RuntimeException("iframe missing"));
-        invokeAndIgnoreFailures(() -> elementActions.switchToIframe(locator));
-
-        WebDriver failingDefaultContentDriver = mock(WebDriver.class);
-        WebDriver.TargetLocator failingTarget = mock(WebDriver.TargetLocator.class);
-        when(helperDriverFactory.getDriver()).thenReturn(failingDefaultContentDriver);
-        when(failingDefaultContentDriver.switchTo()).thenReturn(failingTarget);
-        when(failingTarget.defaultContent()).thenThrow(new RuntimeException("default content failed"));
-        invokeAndIgnoreFailures(elementActions::switchToDefaultContent);
-    }
-
-    @Test
-    public void shouldCoverUploadAndTableFailureBranches() throws Exception {
-        var helper = mock(ElementActionsHelper.class);
-        var helperDriverFactory = mock(DriverFactoryHelper.class);
-        By uploadLocator = By.id("uploadFailure");
-
-        when(helperDriverFactory.getDriver()).thenReturn(driver);
-        setField(elementActions, "driverFactoryHelper", helperDriverFactory);
-        setField(elementActions, "elementActionsHelper", helper);
-        when(helper.getElementName(driver, uploadLocator)).thenReturn("upload");
-        when(helper.takeScreenshot(driver, uploadLocator, "typeFileLocationForUpload", null, true)).thenReturn(Collections.emptyList());
-
-        WebElement firstAttemptElement = mock(WebElement.class);
-        doThrow(new InvalidArgumentException("bad path")).when(firstAttemptElement).sendKeys(any(CharSequence.class));
-        when(helper.identifyUniqueElementIgnoringVisibility(driver, uploadLocator))
-                .thenReturn(buildElementInfo("input", uploadLocator, firstAttemptElement, "upload"));
-        invokeAndIgnoreFailures(() -> elementActions.typeFileLocationForUpload(uploadLocator, "/tmp/missing-file.txt"));
-
-        WebElement hiddenElement = mock(WebElement.class);
-        WebElement visibleElement = mock(WebElement.class);
-        doThrow(new ElementNotInteractableException("hidden")).when(hiddenElement).sendKeys(any(CharSequence.class));
-        doThrow(new WebDriverException("send keys failed")).when(visibleElement).sendKeys(any(CharSequence.class));
-        when(helper.identifyUniqueElementIgnoringVisibility(driver, uploadLocator))
-                .thenReturn(buildElementInfo("input", uploadLocator, hiddenElement, "upload"));
-        when(helper.identifyUniqueElement(driver, uploadLocator))
-                .thenReturn(buildElementInfo("input", uploadLocator, visibleElement, "upload"));
-        doThrow(new NoSuchElementException("style reset failed"))
-                .when(helper).changeWebElementVisibilityUsingJavascript(driver, uploadLocator, false);
-        invokeAndIgnoreFailures(() -> elementActions.typeFileLocationForUpload(uploadLocator, "/tmp/missing-file.txt"));
-
-        By tableLocator = By.id("missingTable");
-        when(driver.findElement(tableLocator)).thenThrow(new RuntimeException("table missing"));
-        Assert.assertNull(elementActions.getTableRowsData(tableLocator));
-
-        By emptyTableLocator = By.id("emptyTable");
+    public void getTableRowsDataShouldReturnEmptyRowsWhenTableHasNoLoadedRows() {
         WebElement table = mock(WebElement.class);
         when(table.isDisplayed()).thenReturn(true);
-        when(driver.findElement(emptyTableLocator)).thenReturn(table);
-        when(driver.findElement(By.cssSelector("tbody tr"))).thenThrow(new RuntimeException("no rows loaded"));
-        List<Map<String, String>> emptyRows = elementActions.getTableRowsData(emptyTableLocator);
-        Assert.assertNotNull(emptyRows);
-        Assert.assertTrue(emptyRows.isEmpty());
+        when(driver.findElement(By.id("emptyTable"))).thenReturn(table);
+        when(driver.findElement(By.cssSelector("tbody tr"))).thenThrow(new org.openqa.selenium.NoSuchElementException("empty"));
+
+        Assert.assertTrue(elementActions.getTableRowsData(By.id("emptyTable")).isEmpty());
     }
 
-    private static void invokeAndIgnoreFailures(Runnable action) {
-        try {
-            action.run();
-        } catch (Exception ignored) {
-            // coverage-only invocation
-        }
+    private static Actions last(MockedConstruction<Actions> constructedActions) {
+        List<Actions> actions = constructedActions.constructed();
+        return actions.get(actions.size() - 1);
     }
 
     private static void setField(ElementActions target, String fieldName, Object value) throws Exception {
         Field field = FluentWebDriverAction.class.getDeclaredField(fieldName);
         field.setAccessible(true);
         field.set(target, value);
-    }
-
-    private static List<Object> buildElementInfo(String tagName, By locator, WebElement webElement, String elementName) {
-        return Arrays.asList(
-                1,
-                webElement,
-                locator,
-                "<" + tagName + ">value</" + tagName + ">",
-                "value",
-                elementName,
-                "",
-                new Rectangle(0, 0, 10, 10)
-        );
     }
 }

--- a/shaft-engine/src/test/java/testPackage/unitTests/JavaHelperUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/JavaHelperUnitTest.java
@@ -2,6 +2,7 @@ package testPackage.unitTests;
 
 import com.shaft.tools.internal.support.JavaHelper;
 import com.shaft.driver.SHAFT;
+import com.shaft.gui.internal.locator.SmartLocators;
 import com.shaft.validation.ValidationEnums;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.locators.RelativeLocator;
@@ -390,6 +391,13 @@ public class JavaHelperUnitTest {
         String result = JavaHelper.formatLocatorToString(relativeBy);
         Assert.assertTrue(result.startsWith("Relative Locator:"),
                 "Relative locators should use dedicated formatting");
+    }
+
+    @Test(description = "formatLocatorToString: smart locators should report user text only")
+    public void formatLocatorToStringSmartLocatorShouldUseUserTextOnly() {
+        String result = JavaHelper.formatLocatorToString(SmartLocators.clickableField("Login"));
+        Assert.assertEquals(result, "Smart Locator: \"Login\"");
+        Assert.assertFalse(result.contains("//"), "Smart locator report text should not include generated xpath details");
     }
 
     @Test(description = "appendTestDataToRelativePath: single-slash relative path should be prefixed with test data folder")


### PR DESCRIPTION
## Summary
- Route remaining `ElementActions` action methods through the `internal.Actions` stack.
- Always attach screenshot evidence when element actions fail, independent of screenshot policy.
- Highlight found elements in red on failure and fall back to page screenshots when the locator is missing or not uniquely found.
- Shorten smart locator reporting to the user-provided text instead of the full generated locator chain.

## Root Cause
Legacy `ElementActions` methods still used `ElementActionsHelper` reporting directly, so failure evidence and Allure labels were inconsistent with the newer action stack. Failure screenshot attachment also still respected the configured screenshot policy in some paths.

## Validation
- Refreshed graphify for the code worktree; generated graphify output was left out of the commit per repository rules.
- `mvn test -pl shaft-engine -am '-Dtest=JavaHelperUnitTest,ActionsCoverageUnitTest,ScreenshotManagerCoverageUnitTest,ElementActionsCoverageUnitTest' '-Dgpg.skip=true'`
- Verified Allure output: 89 result JSON files, 89 passed, 0 failed/broken/skipped.

## Docs
- Companion docs PR: https://github.com/ShaftHQ/shafthq.github.io/pull/557
