### PR TITLE
[codex] Add coverage tests

### DIFF
--- a/shaft-browserstack/src/test/java/com/shaft/integration/browserstack/BrowserStackModuleTest.java
+++ b/shaft-browserstack/src/test/java/com/shaft/integration/browserstack/BrowserStackModuleTest.java
@@ -1,0 +1,22 @@
+package com.shaft.integration.browserstack;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class BrowserStackModuleTest {
+    @Test
+    void constructorRejectsInstantiation() throws Exception {
+        Constructor<BrowserStackModule> constructor = BrowserStackModule.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+
+        InvocationTargetException thrown = assertThrows(InvocationTargetException.class, constructor::newInstance);
+
+        assertEquals(IllegalStateException.class, thrown.getCause().getClass());
+        assertEquals("Utility class", thrown.getCause().getMessage());
+    }
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/cli/CaptureCliTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/cli/CaptureCliTest.java
@@ -1,0 +1,152 @@
+package com.shaft.capture.cli;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CaptureCliTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void argumentsParserHandlesValuesFlagsPathsAndValidation() throws Exception {
+        Class<?> argumentsClass = Class.forName("com.shaft.capture.cli.CaptureCli$Arguments");
+        Object options = invokeStatic(
+                argumentsClass,
+                "parse",
+                new Class<?>[] {String[].class},
+                (Object) new String[] {
+                        "--runtime-dir", temp.toString(),
+                        "--session", "capture.json",
+                        "--headless",
+                        "--replay"
+                });
+
+        assertEquals(temp.toString(), invoke(
+                options,
+                "required",
+                new Class<?>[] {String.class},
+                "runtime-dir"));
+        assertEquals("fallback", invoke(
+                options,
+                "value",
+                new Class<?>[] {String.class, String.class},
+                "missing",
+                "fallback"));
+        assertEquals(temp, invoke(
+                options,
+                "path",
+                new Class<?>[] {String.class, Path.class},
+                "runtime-dir",
+                Path.of("fallback")));
+        assertEquals(Path.of("capture.json"), invoke(
+                options,
+                "pathRequired",
+                new Class<?>[] {String.class},
+                "session"));
+        assertEquals(true, invoke(
+                options,
+                "flag",
+                new Class<?>[] {String.class},
+                "headless"));
+
+        InvocationTargetException missingValue = assertThrows(InvocationTargetException.class,
+                () -> invokeStatic(
+                        argumentsClass,
+                        "parse",
+                        new Class<?>[] {String[].class},
+                        (Object) new String[] {"--runtime-dir"}));
+        InvocationTargetException unexpectedArgument = assertThrows(InvocationTargetException.class,
+                () -> invokeStatic(
+                        argumentsClass,
+                        "parse",
+                        new Class<?>[] {String[].class},
+                        (Object) new String[] {"runtime-dir"}));
+        InvocationTargetException missingRequired = assertThrows(InvocationTargetException.class,
+                () -> invoke(
+                        options,
+                        "required",
+                        new Class<?>[] {String.class},
+                        "url"));
+
+        assertInstanceOf(IllegalArgumentException.class, missingValue.getCause());
+        assertInstanceOf(IllegalArgumentException.class, unexpectedArgument.getCause());
+        assertInstanceOf(IllegalArgumentException.class, missingRequired.getCause());
+    }
+
+    @Test
+    void privateHelpersNormalizeClasspathTokensAndRejectInvalidNumbers() throws Exception {
+        Constructor<CaptureCli> constructor = CaptureCli.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        InvocationTargetException constructorFailure =
+                assertThrows(InvocationTargetException.class, constructor::newInstance);
+
+        String normalized = (String) invokeStatic(
+                "absoluteClassPath",
+                new Class<?>[] {String.class},
+                "target/classes" + File.pathSeparator + ".");
+        String token = (String) invokeStatic("token", new Class<?>[] {});
+        String usage = (String) invokeStatic("usage", new Class<?>[] {});
+        String fallbackMessage = (String) invokeStatic(
+                "safeMessage",
+                new Class<?>[] {RuntimeException.class},
+                new IllegalStateException(""));
+        boolean running = (boolean) invokeStatic(
+                "isRunning",
+                new Class<?>[] {com.shaft.capture.runtime.CaptureStatus.State.class},
+                com.shaft.capture.runtime.CaptureStatus.State.ACTIVE);
+        long parsed = (long) invokeStatic(
+                "parsePositiveLong",
+                new Class<?>[] {String.class, String.class},
+                "12",
+                "timeout");
+        InvocationTargetException invalidNumber = assertThrows(InvocationTargetException.class,
+                () -> invokeStatic(
+                        "parsePositiveLong",
+                        new Class<?>[] {String.class, String.class},
+                        "-1",
+                        "timeout"));
+
+        assertInstanceOf(IllegalStateException.class, constructorFailure.getCause());
+        for (String entry : normalized.split(java.util.regex.Pattern.quote(File.pathSeparator))) {
+            assertTrue(Path.of(entry).isAbsolute(), entry);
+        }
+        assertTrue(token.length() >= 32);
+        assertFalse(token.contains("="));
+        assertTrue(usage.contains("capture start"));
+        assertEquals("operation failed.", fallbackMessage);
+        assertTrue(running);
+        assertEquals(12L, parsed);
+        assertInstanceOf(IllegalArgumentException.class, invalidNumber.getCause());
+    }
+
+    private static Object invokeStatic(String methodName, Class<?>[] parameterTypes, Object... arguments)
+            throws Exception {
+        return invokeStatic(CaptureCli.class, methodName, parameterTypes, arguments);
+    }
+
+    private static Object invokeStatic(Class<?> type, String methodName, Class<?>[] parameterTypes, Object... arguments)
+            throws Exception {
+        Method method = type.getDeclaredMethod(methodName, parameterTypes);
+        method.setAccessible(true);
+        return method.invoke(null, arguments);
+    }
+
+    private static Object invoke(Object target, String methodName, Class<?>[] parameterTypes, Object... arguments)
+            throws Exception {
+        Method method = target.getClass().getDeclaredMethod(methodName, parameterTypes);
+        method.setAccessible(true);
+        return method.invoke(target, arguments);
+    }
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/collector/CaptureCollectorUtilityTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/collector/CaptureCollectorUtilityTest.java
@@ -1,0 +1,108 @@
+package com.shaft.capture.collector;
+
+import com.shaft.capture.format.CaptureFormatException;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CaptureCollectorUtilityTest {
+    @Test
+    void browserSignalParsesJsonAndGeneratedSignalsDefensively() {
+        BrowserSignal parsed = BrowserSignal.fromJson("""
+                {
+                  "kind": "Input",
+                  "timestamp": "1700000000000",
+                  "page": {"url": "https://example.test", "width": 1440},
+                  "target": {"id": "username"},
+                  "data": {
+                    "text": "alice",
+                    "count": "7",
+                    "checked": "true",
+                    "keys": ["CONTROL", "", "A"]
+                  }
+                }
+                """, "window-1");
+        BrowserSignal generated = BrowserSignal.generated(
+                "navigation",
+                "window-2",
+                Map.of("url", "https://example.test/home"),
+                Map.of("action", "OPEN"));
+
+        assertEquals("input", parsed.kind());
+        assertEquals(Instant.ofEpochMilli(1_700_000_000_000L), parsed.timestamp());
+        assertEquals("window-1", parsed.browsingContextId());
+        assertEquals("alice", parsed.dataString("text"));
+        assertEquals(7, parsed.dataInt("count", 0));
+        assertTrue(parsed.dataBoolean("checked"));
+        assertEquals(List.of("CONTROL", "A"), parsed.dataStrings("keys"));
+        assertEquals("navigation", generated.kind());
+        assertEquals("OPEN", generated.dataString("action"));
+        assertThrows(CaptureFormatException.class, () -> BrowserSignal.fromJson("{", "window-1"));
+    }
+
+    @Test
+    void browserEventScriptExposesBundledInstallAndDrainSnippets() throws Exception {
+        String preload = BrowserEventScript.preloadFunction();
+
+        assertTrue(preload.contains("shaft"));
+        assertTrue(BrowserEventScript.fallbackInstallation().contains("return ("));
+        assertTrue(BrowserEventScript.fallbackDrain().contains("__shaftCaptureQueue"));
+
+        Constructor<BrowserEventScript> constructor = BrowserEventScript.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        InvocationTargetException failure = assertThrows(InvocationTargetException.class, constructor::newInstance);
+        assertInstanceOf(IllegalStateException.class, failure.getCause());
+    }
+
+    @Test
+    void compositeCollectorStartsAndClosesInOrderAndCleansStartedCollectorsOnFailure() {
+        List<String> calls = new ArrayList<>();
+        RecordingCollector first = new RecordingCollector("first", calls, false);
+        RecordingCollector second = new RecordingCollector("second", calls, false);
+        CompositeBrowserEventCollector composite = new CompositeBrowserEventCollector(List.of(first, second));
+
+        composite.start(signal -> { }, warning -> { });
+        composite.close();
+
+        assertEquals(List.of("start:first", "start:second", "close:second", "close:first"), calls);
+
+        List<String> failureCalls = new ArrayList<>();
+        RecordingCollector started = new RecordingCollector("started", failureCalls, false);
+        RecordingCollector failing = new RecordingCollector("failing", failureCalls, true);
+        CompositeBrowserEventCollector failingComposite = new CompositeBrowserEventCollector(List.of(started, failing));
+
+        assertThrows(IllegalStateException.class, () -> failingComposite.start(signal -> { }, warning -> { }));
+        assertEquals(List.of("start:started", "start:failing", "close:started"), failureCalls);
+        assertThrows(IllegalArgumentException.class, () -> new CompositeBrowserEventCollector(List.of()));
+    }
+
+    private record RecordingCollector(String name, List<String> calls, boolean failOnStart)
+            implements BrowserEventCollector {
+        @Override
+        public void start(
+                java.util.function.Consumer<BrowserSignal> signalConsumer,
+                java.util.function.Consumer<String> warningConsumer) {
+            calls.add("start:" + name);
+            signalConsumer.accept(BrowserSignal.generated("test", "context", Map.of(), Map.of()));
+            if (failOnStart) {
+                throw new IllegalStateException("start failed");
+            }
+        }
+
+        @Override
+        public void close() {
+            calls.add("close:" + name);
+        }
+    }
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/control/CaptureControlFilesTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/control/CaptureControlFilesTest.java
@@ -1,0 +1,75 @@
+package com.shaft.capture.control;
+
+import com.shaft.capture.runtime.CaptureBrowser;
+import com.shaft.capture.runtime.CaptureStartRequest;
+import com.shaft.capture.runtime.CaptureStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CaptureControlFilesTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void controlFilesRoundTripStatusDescriptorTokenAndLaunchRequest() {
+        CaptureControlFiles files = new CaptureControlFiles(temp);
+        CaptureStatus status = new CaptureStatus(
+                CaptureStatus.State.STARTING,
+                "session",
+                "chrome",
+                "https://example.test",
+                3,
+                List.of("warning"),
+                temp.resolve("capture.json").toString(),
+                false,
+                ProcessHandle.current().pid(),
+                Instant.parse("2026-01-02T03:04:05Z"));
+        CaptureControlFiles.ControlDescriptor descriptor =
+                new CaptureControlFiles.ControlDescriptor(12345, ProcessHandle.current().pid());
+        CaptureStartRequest request = new CaptureStartRequest(
+                "https://example.test",
+                CaptureBrowser.CHROME,
+                temp.resolve("recordings/capture.json"),
+                temp,
+                true);
+
+        files.writeStatus(status);
+        files.writeDescriptor(descriptor);
+        files.writeToken("secret-token");
+        Path launchRequest = files.writeLaunchRequest(request);
+
+        assertEquals(temp.toAbsolutePath().normalize(), files.runtimeDirectory());
+        assertEquals(status, files.readStatus());
+        assertEquals(descriptor, files.readDescriptor());
+        assertEquals("secret-token", files.readToken());
+        assertTrue(files.hasActiveControl());
+        assertEquals(request, files.consumeLaunchRequest(launchRequest));
+        assertFalse(Files.exists(launchRequest));
+
+        files.clearActiveControl();
+        assertFalse(files.hasActiveControl());
+        assertEquals(CaptureStatus.State.STARTING, files.readStatus().state());
+    }
+
+    @Test
+    void controlFilesRejectInvalidRuntimeAndLaunchMetadata() throws Exception {
+        CaptureControlFiles files = new CaptureControlFiles(temp);
+        Path outside = Files.createTempFile("capture-launch", ".json");
+
+        assertThrows(IllegalArgumentException.class, () -> new CaptureControlFiles(null));
+        assertThrows(IllegalArgumentException.class,
+                () -> new CaptureControlFiles.ControlDescriptor(0, ProcessHandle.current().pid()));
+        assertThrows(IllegalArgumentException.class, () -> files.consumeLaunchRequest(outside));
+        assertThrows(IllegalStateException.class, files::readToken);
+    }
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/control/CaptureControlServerClientTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/control/CaptureControlServerClientTest.java
@@ -1,0 +1,95 @@
+package com.shaft.capture.control;
+
+import com.shaft.capture.model.Checkpoint;
+import com.shaft.capture.runtime.CaptureManager;
+import com.shaft.capture.runtime.CaptureStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CaptureControlServerClientTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void clientTalksToAuthorizedLoopbackServerAndFallsBackToLocalStatus() throws Exception {
+        CaptureManager manager = new CaptureManager();
+        CaptureControlFiles files = new CaptureControlFiles(temp);
+        AtomicBoolean stopped = new AtomicBoolean(false);
+        CaptureControlServer server = new CaptureControlServer(manager, files, "token", () -> stopped.set(true));
+        int port = server.start();
+        files.writeToken("token");
+        files.writeDescriptor(new CaptureControlFiles.ControlDescriptor(port, ProcessHandle.current().pid()));
+
+        try {
+            CaptureControlClient client = new CaptureControlClient(temp);
+
+            assertEquals(CaptureStatus.State.NOT_RUNNING, client.status().state());
+            assertEquals(CaptureStatus.State.NOT_RUNNING, client.stop(false).state());
+            assertTrue(stopped.get());
+            assertThrows(IllegalStateException.class,
+                    () -> client.checkpoint("mark", Checkpoint.CheckpointKind.ASSERTION));
+
+            HttpClient http = HttpClient.newHttpClient();
+            HttpResponse<String> unauthorized = http.send(HttpRequest.newBuilder()
+                    .uri(URI.create("http://127.0.0.1:" + port + "/status"))
+                    .GET()
+                    .build(), HttpResponse.BodyHandlers.ofString());
+            HttpResponse<String> badMethod = http.send(HttpRequest.newBuilder()
+                    .uri(URI.create("http://127.0.0.1:" + port + "/stop"))
+                    .header("Authorization", "Bearer token")
+                    .GET()
+                    .build(), HttpResponse.BodyHandlers.ofString());
+            HttpResponse<String> badCheckpoint = http.send(HttpRequest.newBuilder()
+                    .uri(URI.create("http://127.0.0.1:" + port + "/checkpoint"))
+                    .header("Authorization", "Bearer token")
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString("{\"description\":\"mark\",\"kind\":\"bad\"}"))
+                    .build(), HttpResponse.BodyHandlers.ofString());
+
+            assertEquals(401, unauthorized.statusCode());
+            assertEquals(400, badMethod.statusCode());
+            assertEquals(400, badCheckpoint.statusCode());
+        } finally {
+            server.close();
+            manager.close();
+        }
+
+        files.clearActiveControl();
+        files.writeStatus(new CaptureStatus(
+                CaptureStatus.State.ACTIVE,
+                "session",
+                "chrome",
+                "",
+                0,
+                java.util.List.of(),
+                "",
+                false,
+                ProcessHandle.current().pid(),
+                null));
+
+        CaptureStatus incomplete = new CaptureControlClient(temp).status();
+        assertEquals(CaptureStatus.State.INCOMPLETE, incomplete.state());
+        assertTrue(incomplete.warnings().stream().anyMatch(warning -> warning.contains("no longer reachable")));
+    }
+
+    @Test
+    void serverRejectsMissingDependencies() {
+        CaptureControlFiles files = new CaptureControlFiles(temp);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> new CaptureControlServer(null, files, "token", () -> { }));
+        assertThrows(IllegalArgumentException.class,
+                () -> new CaptureControlServer(new CaptureManager(), files, "", () -> { }));
+    }
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -46,7 +46,14 @@ class CaptureGeneratorTest {
         assertEquals("1.0", review.path("schemaVersion").asText());
         assertEquals(first.report().sessionId(), review.path("sessionId").asText());
         assertTrue(review.path("readinessScore").asInt() >= 0);
-        assertTrue(review.path("blockers").isEmpty());
+        List<String> blockers = new java.util.ArrayList<>();
+        review.path("blockers").forEach(blocker -> blockers.add(blocker.asText()));
+        assertTrue(blockers.stream()
+                .anyMatch(blocker -> blocker.contains("data.password")
+                        && blocker.contains("environment variable")));
+        assertTrue(blockers.stream()
+                .anyMatch(blocker -> blocker.contains("upload.avatar")
+                        && blocker.contains("fixture")));
         assertEquals(Files.readString(first.sourcePath()), Files.readString(second.sourcePath()));
         assertEquals(Files.readString(first.testDataPath()), Files.readString(second.testDataPath()));
         assertEquals(first.report(), second.report());

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureManagerLifecycleTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureManagerLifecycleTest.java
@@ -1,0 +1,144 @@
+package com.shaft.capture.runtime;
+
+import com.shaft.capture.model.Checkpoint;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CaptureManagerLifecycleTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void managerRunsLifecycleThroughInjectedRecorder() {
+        AtomicReference<FakeRecorder> recorderRef = new AtomicReference<>();
+        CaptureManager manager = new CaptureManager(request -> {
+            FakeRecorder recorder = new FakeRecorder(request);
+            recorderRef.set(recorder);
+            return recorder;
+        });
+        CaptureStartRequest request = request("capture.json");
+
+        assertEquals(CaptureStatus.State.ACTIVE, manager.start(request).state());
+        assertThrows(IllegalStateException.class, () -> manager.start(request));
+        assertEquals(CaptureStatus.State.ACTIVE, manager.status().state());
+        assertEquals(CaptureStatus.State.ACTIVE,
+                manager.checkpoint("review", Checkpoint.CheckpointKind.USER_MARKER).state());
+        assertEquals(1, recorderRef.get().checkpointCount);
+        assertEquals(CaptureStatus.State.COMPLETED, manager.stop(false).state());
+        assertEquals(CaptureStatus.State.COMPLETED, manager.stop(false).state());
+        manager.close();
+    }
+
+    @Test
+    void managerRejectsInactiveCheckpointAndInterruptsActiveRecorderOnClose() {
+        AtomicReference<FakeRecorder> recorderRef = new AtomicReference<>();
+        CaptureManager inactive = new CaptureManager(FakeRecorder::new);
+
+        assertThrows(IllegalStateException.class,
+                () -> inactive.checkpoint("review", Checkpoint.CheckpointKind.USER_MARKER));
+        inactive.close();
+
+        CaptureManager active = new CaptureManager(request -> {
+            FakeRecorder recorder = new FakeRecorder(request);
+            recorderRef.set(recorder);
+            return recorder;
+        });
+        active.start(request("active.json"));
+        active.close();
+
+        assertEquals(1, recorderRef.get().interruptCount);
+    }
+
+    @Test
+    void managerRejectsNullFactoryAndReleasesLockWhenRecorderStartFails() {
+        assertThrows(IllegalArgumentException.class, () -> new CaptureManager(null));
+
+        CaptureManager manager = new CaptureManager(FailingRecorder::new);
+        assertThrows(IllegalStateException.class, () -> manager.start(request("failed.json")));
+        assertEquals(CaptureStatus.State.STARTING, manager.status().state());
+        manager.close();
+    }
+
+    private CaptureStartRequest request(String outputName) {
+        return new CaptureStartRequest(
+                "https://example.test",
+                CaptureBrowser.CHROME,
+                temp.resolve(outputName),
+                temp.resolve("runtime"),
+                true);
+    }
+
+    private static class FakeRecorder extends ManagedCaptureRecorder {
+        private final CaptureStartRequest request;
+        private CaptureStatus.State state = CaptureStatus.State.STARTING;
+        private int checkpointCount;
+        private int interruptCount;
+
+        FakeRecorder(CaptureStartRequest request) {
+            super(request);
+            this.request = request;
+        }
+
+        @Override
+        void start() {
+            state = CaptureStatus.State.ACTIVE;
+        }
+
+        @Override
+        CaptureStatus status() {
+            return new CaptureStatus(
+                    state,
+                    "fake-session",
+                    request.browser().name().toLowerCase(),
+                    request.targetUrl(),
+                    checkpointCount,
+                    List.of(),
+                    request.outputPath().toString(),
+                    false,
+                    ProcessHandle.current().pid(),
+                    Instant.parse("2026-01-02T03:04:05Z"));
+        }
+
+        @Override
+        void checkpoint(String description, Checkpoint.CheckpointKind kind) {
+            checkpointCount++;
+        }
+
+        @Override
+        CaptureStatus stop(boolean discard) {
+            state = discard ? CaptureStatus.State.DISCARDED : CaptureStatus.State.COMPLETED;
+            return status();
+        }
+
+        @Override
+        CaptureStatus interrupt() {
+            interruptCount++;
+            state = CaptureStatus.State.INCOMPLETE;
+            return status();
+        }
+
+        @Override
+        boolean isBrowserAlive() {
+            return state == CaptureStatus.State.ACTIVE;
+        }
+    }
+
+    private static final class FailingRecorder extends FakeRecorder {
+        FailingRecorder(CaptureStartRequest request) {
+            super(request);
+        }
+
+        @Override
+        void start() {
+            throw new IllegalStateException("boom");
+        }
+    }
+}

--- a/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java
@@ -1,6 +1,7 @@
 package com.shaft.mcp;
 
 import com.shaft.capture.runtime.CaptureManager;
+import com.shaft.capture.runtime.CaptureStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -60,6 +61,17 @@ class CaptureServiceTest {
     }
 
     @Test
+    void statusAndStopReturnIdleCaptureStateWhenNoSessionIsActive() {
+        CaptureService service = service();
+        try {
+            assertEquals(CaptureStatus.State.NOT_RUNNING, service.status().state());
+            assertEquals(CaptureStatus.State.NOT_RUNNING, service.stop(false).state());
+        } finally {
+            service.close();
+        }
+    }
+
+    @Test
     void codeBlocksRejectSessionOutsideWorkspace() throws Exception {
         Path outside = Files.createTempFile("outside-capture", ".json");
         Files.writeString(outside, "{}");
@@ -80,6 +92,65 @@ class CaptureServiceTest {
         }
 
         assertTrue(failure.getMessage().contains("workspace"));
+    }
+
+    @Test
+    void startRejectsOutputPathOutsideWorkspaceBeforeLaunchingBrowser() throws Exception {
+        Path outside = Files.createTempFile("outside-capture-output", ".json");
+
+        CaptureService service = service();
+        IllegalArgumentException failure;
+        try {
+            failure = assertThrows(IllegalArgumentException.class,
+                    () -> service.start("https://example.test", "chrome", outside.toString(), true));
+        } finally {
+            service.close();
+        }
+
+        assertTrue(failure.getMessage().contains("workspace"));
+    }
+
+    @Test
+    void replayGenerationRejectsSessionOutsideWorkspaceBeforeRunningGenerator() throws Exception {
+        Path outside = Files.createTempFile("outside-capture-session", ".json");
+        Files.writeString(outside, "{}");
+
+        CaptureService service = service();
+        IllegalArgumentException replayFailure;
+        IllegalArgumentException generateFailure;
+        try {
+            replayFailure = assertThrows(IllegalArgumentException.class,
+                    () -> service.generateReplay(
+                            outside.toString(),
+                            temp.resolve("generated-replay").toString(),
+                            "generated.capture",
+                            "ReplayTest",
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                            "driver"));
+            generateFailure = assertThrows(IllegalArgumentException.class,
+                    () -> service.generate(
+                            outside.toString(),
+                            temp.resolve("generated").toString(),
+                            "generated.capture",
+                            "GeneratedTest",
+                            false,
+                            false,
+                            false,
+                            "",
+                            false,
+                            false,
+                            false,
+                            false));
+        } finally {
+            service.close();
+        }
+
+        assertTrue(replayFailure.getMessage().contains("workspace"));
+        assertTrue(generateFailure.getMessage().contains("workspace"));
     }
 
     private CaptureService service() {

--- a/shaft-mcp/src/test/java/com/shaft/mcp/DoctorServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/DoctorServiceTest.java
@@ -156,6 +156,24 @@ class DoctorServiceTest {
     }
 
     @Test
+    void suggestFixRejectsMalformedWorkspaceReport(@TempDir Path temp) throws Exception {
+        Path report = temp.resolve("doctor-report.json");
+        Files.writeString(report, "not-json", StandardCharsets.UTF_8);
+
+        IllegalArgumentException failure = assertThrows(IllegalArgumentException.class,
+                () -> service(temp).suggestFix(
+                        report.toString(),
+                        "",
+                        List.of(),
+                        false,
+                        false,
+                        false,
+                        "driver"));
+
+        assertTrue(failure.getMessage().contains("Doctor report could not be read"));
+    }
+
+    @Test
     void draftPublicationRequiresExplicitApprovalBeforeReadingManifest() {
         IllegalArgumentException failure = assertThrows(IllegalArgumentException.class,
                 () -> new DoctorService().publishDraftPr(

--- a/shaft-mcp/src/test/java/com/shaft/mcp/McpNoDriverServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/McpNoDriverServiceTest.java
@@ -1,0 +1,112 @@
+package com.shaft.mcp;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class McpNoDriverServiceTest {
+    @TempDir
+    Path temp;
+
+    private EngineService engineService;
+
+    @BeforeEach
+    void resetDriver() {
+        engineService = new EngineService();
+        engineService.quitDriver();
+    }
+
+    @Test
+    void browserToolsShouldFailWhenNoDriverSessionExists() {
+        BrowserService service = new BrowserService(McpWorkspacePolicy.of(temp));
+
+        assertNoDriver(() -> service.navigate("https://example.test"));
+        assertNoDriver(() -> service.navigateWithBasicAuth("https://example.test", "u", "p", "https://example.test"));
+        assertNoDriver(service::refreshPage);
+        assertNoDriver(service::navigateBack);
+        assertNoDriver(service::navigateForward);
+        assertNoDriver(service::maximizeWindow);
+        assertNoDriver(() -> service.setWindowSize(800, 600));
+        assertNoDriver(service::fullscreenWindow);
+        assertNoDriver(service::deleteAllCookies);
+        assertNoDriver(() -> service.deleteCookie("sid"));
+        assertNoDriver(() -> service.addCookie("sid", "value"));
+        assertNoDriver(() -> service.getCookie("sid"));
+        assertNoDriver(service::getAllCookies);
+        assertNoDriver(service::getCurrentUrl);
+        assertNoDriver(service::getTitle);
+        assertNoDriver(() -> service.getPageDom(10));
+        assertNoDriver(() -> service.takeScreenshot("shot.png", false));
+    }
+
+    @Test
+    void elementToolsShouldFailWhenNoDriverSessionExists() {
+        ElementService service = new ElementService();
+
+        assertNoDriver(() -> service.hover(locatorStrategy.ID, "submit"));
+        assertNoDriver(() -> service.click(locatorStrategy.ID, "submit"));
+        assertNoDriver(() -> service.clickSemantic("Submit"));
+        assertNoDriver(() -> service.clickUsingAI("Submit"));
+        assertNoDriver(() -> service.clickUsingJavaScript(locatorStrategy.ID, "submit"));
+        assertNoDriver(() -> service.doubleClick(locatorStrategy.ID, "submit"));
+        assertNoDriver(() -> service.clickAndHold(locatorStrategy.ID, "submit"));
+        assertNoDriver(() -> service.type(locatorStrategy.ID, "name", "value"));
+        assertNoDriver(() -> service.appendText(locatorStrategy.ID, "name", "value"));
+        assertNoDriver(() -> service.typeSemantic("Name", "value"));
+        assertNoDriver(() -> service.typeUsingAI("Name", "value"));
+        assertNoDriver(() -> service.setValueUsingJavaScript(locatorStrategy.ID, "name", "value"));
+        assertNoDriver(() -> service.clear(locatorStrategy.ID, "name"));
+        assertNoDriver(() -> service.dropFileToUpload(locatorStrategy.ID, "upload", "file.txt"));
+        assertNoDriver(() -> service.dragAndDrop(locatorStrategy.ID, "source", locatorStrategy.ID, "target"));
+        assertNoDriver(() -> service.dragAndDropByOffset(locatorStrategy.ID, "source", 1, 2));
+        assertNoDriver(() -> service.getText(locatorStrategy.ID, "message"));
+        assertNoDriver(() -> service.getDomAttribute(locatorStrategy.ID, "message", "data-id"));
+        assertNoDriver(() -> service.getDomProperty(locatorStrategy.ID, "message", "value"));
+        assertNoDriver(() -> service.getCssValue(locatorStrategy.ID, "message", "color"));
+        assertNoDriver(() -> service.isDisplayed(locatorStrategy.ID, "message"));
+        assertNoDriver(() -> service.isEnabled(locatorStrategy.ID, "message"));
+        assertNoDriver(() -> service.isSelected(locatorStrategy.ID, "message"));
+    }
+
+    @Test
+    void mobileAndNaturalToolsShouldFailWhenNoDriverSessionExists() {
+        MobileService mobile = new MobileService(engineService, McpWorkspacePolicy.of(temp));
+        NaturalActionService natural = new NaturalActionService();
+
+        assertNoDriver(() -> natural.act("click submit", List.of(), 50, "deterministic", false, "element"));
+        assertNoDriver(() -> mobile.getContexts(10));
+        assertNoDriver(() -> mobile.getAccessibilityTree(10));
+        assertNoDriver(() -> mobile.takeScreenshot("mobile.png", false));
+        assertNoDriver(() -> mobile.switchContext("NATIVE_APP"));
+        assertNoDriver(() -> mobile.tap(locatorStrategy.ID, "submit"));
+        assertNoDriver(() -> mobile.doubleTap(locatorStrategy.ID, "submit"));
+        assertNoDriver(() -> mobile.longTap(locatorStrategy.ID, "submit"));
+        assertNoDriver(() -> mobile.type(locatorStrategy.ID, "name", "value"));
+        assertNoDriver(() -> mobile.clear(locatorStrategy.ID, "name"));
+        assertNoDriver(() -> mobile.swipeByOffset(locatorStrategy.ID, "list", 1, 2));
+        assertNoDriver(() -> mobile.swipeElementIntoView(locatorStrategy.ID, "target", "DOWN"));
+        assertNoDriver(() -> mobile.swipeTextIntoView("target", "VERTICAL"));
+        assertNoDriver(() -> mobile.tapCoordinates(1, 2));
+        assertNoDriver(() -> mobile.swipeCoordinates(1, 2, 3, 4, 100));
+        assertNoDriver(() -> mobile.rotate("PORTRAIT"));
+        assertNoDriver(mobile::hideKeyboard);
+        assertNoDriver(() -> mobile.keyboardKey("DONE"));
+        assertNoDriver(() -> mobile.backgroundApp(1));
+        assertNoDriver(() -> mobile.activateApp("com.example"));
+    }
+
+    @Test
+    void engineSupportMethodsShouldFailWhenNoDriverSessionExists() {
+        assertNoDriver(engineService::getPageSource);
+    }
+
+    private static void assertNoDriver(Executable executable) {
+        assertThrows(IllegalStateException.class, executable);
+    }
+}

--- a/shaft-mcp/src/test/java/com/shaft/mcp/McpResultRecordsTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/McpResultRecordsTest.java
@@ -1,0 +1,105 @@
+package com.shaft.mcp;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class McpResultRecordsTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void mobileResultRecordsNormalizeNullsAndCopyLists() {
+        List<String> warnings = new ArrayList<>(List.of("one"));
+        McpCodeBlock block = new McpCodeBlock(
+                " id ", " title ", null, " ", warnings, " code ", " placement ",
+                true, warnings, warnings);
+
+        McpMobileAccessibilityTree tree = new McpMobileAccessibilityTree(" WEBVIEW ", null, 5, false, warnings);
+        McpMobileActionResult action = new McpMobileActionResult(" tap ", true, block, warnings);
+        McpMobileContextSnapshot context = new McpMobileContextSnapshot(" NATIVE_APP ", warnings, null, 0,
+                false, warnings);
+        McpMobileSessionResult session = new McpMobileSessionResult(" web ", null, " device ", null,
+                true, List.of(block), warnings);
+
+        warnings.add("two");
+
+        assertEquals("id", block.id());
+        assertEquals(McpCodeBlock.Kind.INVESTIGATION, block.kind());
+        assertEquals("java", block.language());
+        assertEquals("WEBVIEW", tree.currentContext());
+        assertEquals("", tree.source());
+        assertEquals("tap", action.action());
+        assertEquals("NATIVE_APP", context.currentContext());
+        assertEquals("", context.pageSource());
+        assertEquals("web", session.mode());
+        assertEquals("", session.platformName());
+        assertEquals("", session.browserName());
+        assertEquals(List.of("one"), session.warnings());
+        assertThrows(UnsupportedOperationException.class, () -> session.warnings().add("three"));
+    }
+
+    @Test
+    void browserAndNaturalResultsKeepBoundedValues() {
+        McpNaturalActionResult natural = new McpNaturalActionResult(-1, -2, 120, " pilot ", false, " web ");
+        McpPageDomSnapshot dom = new McpPageDomSnapshot("url", "title", "<html/>", 7, false, List.of());
+        McpScreenshotResult screenshot = new McpScreenshotResult("image/png", 4, "abcd", "out.png", List.of());
+
+        assertEquals(0, natural.intentLength());
+        assertEquals(0, natural.argumentCount());
+        assertEquals(100, natural.minimumTrustPercentage());
+        assertEquals("pilot", natural.planner());
+        assertEquals("web", natural.allowedActions());
+        assertEquals("<html/>", dom.dom());
+        assertEquals("image/png", screenshot.mediaType());
+    }
+
+    @Test
+    void captureReplayResultCopiesLists() {
+        List<String> warnings = new ArrayList<>(List.of("warn"));
+        McpCaptureReplayResult result = new McpCaptureReplayResult(
+                temp.resolve("GeneratedTest.java"),
+                temp.resolve("test-data.json"),
+                temp.resolve("report.json"),
+                temp.resolve("review.json"),
+                true,
+                null,
+                null,
+                warnings);
+
+        warnings.add("later");
+
+        assertTrue(result.successful());
+        assertEquals(List.of(), result.codeBlocks());
+        assertEquals(List.of("warn"), result.warnings());
+        assertThrows(UnsupportedOperationException.class, () -> result.warnings().add("x"));
+    }
+
+    @Test
+    void workspacePolicyResolvesOutputsListsAndSourceAllowlist() throws Exception {
+        Path root = Files.createDirectories(temp.resolve("workspace"));
+        Path repository = Files.createDirectories(root.resolve("repo"));
+        Path existing = Files.writeString(repository.resolve("build.log"), "ok");
+        McpWorkspacePolicy policy = McpWorkspacePolicy.of(root);
+
+        assertEquals(existing.toRealPath(), policy.existing("repo/build.log", "Evidence"));
+        assertEquals(root.resolve("repo/out/report.json").toAbsolutePath().normalize(),
+                policy.output("repo/out/report.json", "Report").toAbsolutePath().normalize());
+        assertEquals(List.of(existing.toRealPath()), policy.existingList(List.of("repo/build.log"), "Evidence"));
+        assertEquals(List.of("src/test/AppTest.java"),
+                policy.sourceAllowlist(repository, List.of("src\\test\\AppTest.java")));
+        assertThrows(IllegalArgumentException.class, () -> policy.existing(null, "Evidence"));
+        assertThrows(IllegalArgumentException.class, () -> policy.output("../outside.txt", "Report"));
+        assertThrows(IllegalArgumentException.class,
+                () -> policy.sourceAllowlist(repository, List.of("../outside.java")));
+    }
+
+}

--- a/shaft-mcp/src/test/java/com/shaft/mcp/McpServiceHelperTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/McpServiceHelperTest.java
@@ -1,0 +1,262 @@
+package com.shaft.mcp;
+
+import com.shaft.driver.SHAFT;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class McpServiceHelperTest {
+    @TempDir
+    Path temp;
+
+    @AfterEach
+    void cleanup() {
+        SHAFT.Properties.clearForCurrentThread();
+        new EngineService().quitDriver();
+    }
+
+    @Test
+    void mobileActionResultHelperRecordsSnippetWhenRecorderIsActive() throws Exception {
+        MobileService service = new MobileService(mock(EngineService.class), McpWorkspacePolicy.of(temp));
+        service.recordStart(temp.resolve("mobile-actions.json").toString(), "native", true);
+
+        McpMobileActionResult result = (McpMobileActionResult) invoke(
+                service,
+                "actionResult",
+                new Class<?>[] {
+                        String.class,
+                        locatorStrategy.class,
+                        String.class,
+                        Map.class,
+                        String.class,
+                        String.class,
+                        boolean.class
+                },
+                "custom",
+                locatorStrategy.ID,
+                "submit",
+                Map.of("key", "value"),
+                "driver.touch().tap(By.id(\"submit\"));",
+                "driver.touch().tap(By.id(\"submit\"));",
+                false);
+
+        assertEquals("custom", result.action());
+        assertTrue(result.recorded());
+        assertTrue(result.codeBlock().code().contains("driver.touch().tap"));
+        assertTrue(service.recordStop(false).actionCount() > 0);
+    }
+
+    @Test
+    void mobileHelperWritesScreenshotsAndBuildsCoordinateSnippets() throws Exception {
+        MobileService service = new MobileService(mock(EngineService.class), McpWorkspacePolicy.of(temp));
+        byte[] png = {1, 2, 3};
+
+        Path written = (Path) invoke(
+                service,
+                "writeScreenshot",
+                new Class<?>[] {String.class, byte[].class},
+                "screens/mobile.png",
+                png);
+        String tapCode = (String) invokeStatic(
+                MobileService.class,
+                "tapCoordinatesCode",
+                new Class<?>[] {int.class, int.class},
+                10,
+                20);
+        String swipeCode = (String) invokeStatic(
+                MobileService.class,
+                "swipeCoordinatesCode",
+                new Class<?>[] {int.class, int.class, int.class, int.class, int.class},
+                1,
+                2,
+                3,
+                4,
+                1);
+        int parsed = (int) invokeStatic(
+                MobileService.class,
+                "integer",
+                new Class<?>[] {Map.class, String.class},
+                Map.of("durationMillis", "125"),
+                "durationMillis");
+
+        assertArrayEquals(png, Files.readAllBytes(written));
+        assertTrue(tapCode.contains("10, 20"));
+        assertTrue(swipeCode.contains("Duration.ofMillis(100)"));
+        assertEquals(125, parsed);
+    }
+
+    @Test
+    void mobileHelperRejectsReplayWhenSensitiveValueWasRedacted() {
+        McpMobileRecordedAction action = new McpMobileRecordedAction(
+                1,
+                "",
+                "type",
+                "ID",
+                "username",
+                Map.of("value", "<redacted>"),
+                "driver.element().type(By.id(\"username\"), \"<redacted>\");",
+                false,
+                null);
+
+        InvocationTargetException failure = assertThrows(InvocationTargetException.class,
+                () -> invokeStatic(
+                        MobileService.class,
+                        "requireSensitive",
+                        new Class<?>[] {McpMobileRecordedAction.class},
+                        action));
+
+        assertInstanceOf(IllegalArgumentException.class, failure.getCause());
+        assertTrue(failure.getCause().getMessage().contains("omitted sensitive values"));
+    }
+
+    @Test
+    void browserScreenshotHelperWritesInsideWorkspaceAndSkipsBlankPath() throws Exception {
+        BrowserService service = new BrowserService(McpWorkspacePolicy.of(temp));
+        byte[] png = {9, 8, 7};
+
+        Path written = (Path) invoke(
+                service,
+                "writeScreenshot",
+                new Class<?>[] {String.class, byte[].class},
+                "screens/browser.png",
+                png);
+        Object blank = invoke(
+                service,
+                "writeScreenshot",
+                new Class<?>[] {String.class, byte[].class},
+                "",
+                png);
+
+        assertArrayEquals(png, Files.readAllBytes(written));
+        assertNull(blank);
+    }
+
+    @Test
+    void elementHelperMethodsHandleNullAndMixedTextValues() throws Exception {
+        assertEquals(0, invokeStatic(
+                ElementService.class,
+                "safeLength",
+                new Class<?>[] {String.class},
+                new Object[] {null}));
+        assertEquals(5, invokeStatic(
+                ElementService.class,
+                "safeLength",
+                new Class<?>[] {String.class},
+                "value"));
+        assertEquals(6, invokeStatic(
+                ElementService.class,
+                "totalLength",
+                new Class<?>[] {CharSequence[].class},
+                (Object) new CharSequence[] {"one", null, "two"}));
+    }
+
+    @Test
+    void naturalActionSettingsApplyBoundedOverridesAndRestorePreviousValues() throws Exception {
+        SHAFT.Properties.naturalActions.set()
+                .enabled(false)
+                .minimumTrustPercentage(25)
+                .planner("deterministic")
+                .aiFallbackEnabled(false)
+                .allowedActions("browser");
+        Class<?> settings = Class.forName("com.shaft.mcp.NaturalActionService$NaturalActionSettings");
+        Object previous = invokeStatic(settings, "current", new Class<?>[] {});
+        Object overridden = invoke(
+                previous,
+                "withOverrides",
+                new Class<?>[] {Integer.class, String.class, Boolean.class, String.class},
+                150,
+                " auto ",
+                true,
+                " element ");
+
+        invoke(overridden, "applyEnabled", new Class<?>[] {});
+        assertTrue(SHAFT.Properties.naturalActions.enabled());
+        assertEquals(100, SHAFT.Properties.naturalActions.minimumTrustPercentage());
+        assertEquals("auto", SHAFT.Properties.naturalActions.planner());
+        assertTrue(SHAFT.Properties.naturalActions.aiFallbackEnabled());
+        assertEquals("element", SHAFT.Properties.naturalActions.allowedActions());
+
+        invoke(previous, "apply", new Class<?>[] {});
+        assertFalse(SHAFT.Properties.naturalActions.enabled());
+        assertEquals(25, SHAFT.Properties.naturalActions.minimumTrustPercentage());
+        assertEquals("deterministic", SHAFT.Properties.naturalActions.planner());
+        assertEquals("fallback", invokeStatic(
+                settings,
+                "textOrDefault",
+                new Class<?>[] {String.class, String.class},
+                " ",
+                "fallback"));
+        assertEquals(0, invokeStatic(
+                NaturalActionService.class,
+                "safeLength",
+                new Class<?>[] {String.class},
+                new Object[] {null}));
+    }
+
+    @Test
+    void runtimePathsConstructorKeepsUtilityClassClosed() throws Exception {
+        Constructor<McpRuntimePaths> constructor = McpRuntimePaths.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+
+        InvocationTargetException failure = assertThrows(InvocationTargetException.class, constructor::newInstance);
+
+        assertInstanceOf(IllegalStateException.class, failure.getCause());
+        assertTrue(failure.getCause().getMessage().contains("Utility class"));
+    }
+
+    @Test
+    void doctorHelpersResolvePathListsAndRejectMalformedDiagnosis() throws Exception {
+        @SuppressWarnings("unchecked")
+        List<Path> paths = (List<Path>) invokeStatic(
+                DoctorService.class,
+                "paths",
+                new Class<?>[] {List.class},
+                List.of("target/report.json", "allure-results"));
+        Object configuration = invokeStatic(DoctorService.class, "currentConfiguration", new Class<?>[] {});
+        Path malformed = temp.resolve("diagnosis.json");
+        Files.writeString(malformed, "not-json");
+
+        InvocationTargetException failure = assertThrows(InvocationTargetException.class,
+                () -> invokeStatic(
+                        DoctorService.class,
+                        "readDiagnosis",
+                        new Class<?>[] {Path.class},
+                        malformed));
+
+        assertEquals(List.of(Path.of("target/report.json"), Path.of("allure-results")), paths);
+        assertTrue(configuration == null || configuration instanceof com.shaft.pilot.config.PilotConfiguration);
+        assertInstanceOf(IllegalArgumentException.class, failure.getCause());
+        assertTrue(failure.getCause().getMessage().contains("Doctor diagnosis could not be read"));
+    }
+
+    private static Object invoke(Object target, String methodName, Class<?>[] parameterTypes, Object... arguments)
+            throws Exception {
+        Method method = target.getClass().getDeclaredMethod(methodName, parameterTypes);
+        method.setAccessible(true);
+        return method.invoke(target, arguments);
+    }
+
+    private static Object invokeStatic(Class<?> type, String methodName, Class<?>[] parameterTypes, Object... arguments)
+            throws Exception {
+        Method method = type.getDeclaredMethod(methodName, parameterTypes);
+        method.setAccessible(true);
+        return method.invoke(null, arguments);
+    }
+}

--- a/shaft-mcp/src/test/java/com/shaft/mcp/MobileServiceConfigurationTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/MobileServiceConfigurationTest.java
@@ -1,0 +1,170 @@
+package com.shaft.mcp;
+
+import com.shaft.driver.SHAFT;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class MobileServiceConfigurationTest {
+    @TempDir
+    Path temp;
+
+    @AfterEach
+    void cleanup() {
+        SHAFT.Properties.clearForCurrentThread();
+        new EngineService().quitDriver();
+    }
+
+    @Test
+    void webEmulationSetupBuildsCustomDeviceWithoutStartingRealDriver() {
+        EngineService engineService = mock(EngineService.class);
+        MobileService service = new MobileService(engineService, McpWorkspacePolicy.of(temp));
+
+        McpMobileSessionResult result = service.initializeWebEmulation(
+                "",
+                "edge",
+                "",
+                390,
+                844,
+                3.0,
+                "agent\"mobile",
+                true);
+
+        assertEquals("web-emulation", result.mode());
+        assertEquals("390x844", result.deviceName());
+        assertEquals("EDGE", result.browserName());
+        assertTrue(result.active());
+        assertTrue(result.warnings().isEmpty());
+        String code = result.codeBlocks().getFirst().code();
+        assertTrue(code.contains(".targetBrowserName(\"EDGE\")"));
+        assertTrue(code.contains(".mobileEmulationIsCustomDevice(true)"));
+        assertTrue(code.contains(".mobileEmulationWidth(390)"));
+        assertTrue(code.contains(".mobileEmulationUserAgent(\"agent\\\"mobile\")"));
+        verify(engineService).quitDriver();
+        verify(engineService).initializeConfiguredDriver("mobile web emulation");
+    }
+
+    @Test
+    void webEmulationSetupUsesDefaultDeviceAndRejectsUnsupportedBrowser() {
+        EngineService engineService = mock(EngineService.class);
+        MobileService service = new MobileService(engineService, McpWorkspacePolicy.of(temp));
+
+        McpMobileSessionResult result = service.initializeWebEmulation(
+                "",
+                null,
+                " ",
+                0,
+                0,
+                0,
+                null,
+                false);
+
+        assertEquals("Pixel 5", result.deviceName());
+        assertEquals("CHROME", result.browserName());
+        assertFalse(result.warnings().isEmpty());
+        assertTrue(result.codeBlocks().getFirst().code().contains(".mobileEmulationDeviceName(\"Pixel 5\")"));
+        assertThrows(IllegalArgumentException.class,
+                () -> service.initializeWebEmulation("", "firefox", "", 0, 0, 0, "", false));
+    }
+
+    @Test
+    void nativeSetupBuildsPlatformDefaultsAndWarningsWithoutStartingAppium() {
+        EngineService androidEngine = mock(EngineService.class);
+        MobileService android = new MobileService(androidEngine, McpWorkspacePolicy.of(temp));
+
+        McpMobileSessionResult androidResult = android.initializeNative(
+                " android ",
+                "Pixel",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "");
+
+        assertEquals("native", androidResult.mode());
+        assertEquals("Android", androidResult.platformName());
+        assertTrue(androidResult.warnings().stream().anyMatch(warning -> warning.contains("appPackage")));
+        String androidCode = androidResult.codeBlocks().getFirst().code();
+        assertTrue(androidCode.contains(".targetPlatform(\"Android\")"));
+        assertTrue(androidCode.contains(".executionAddress(\"http://127.0.0.1:4723\")"));
+        assertTrue(androidCode.contains(".automationName(\"UiAutomator2\")"));
+        verify(androidEngine).initializeConfiguredDriver("mobile native Android");
+
+        EngineService iosEngine = mock(EngineService.class);
+        MobileService ios = new MobileService(iosEngine, McpWorkspacePolicy.of(temp));
+        McpMobileSessionResult iosResult = ios.initializeNative(
+                "ios",
+                "iPhone",
+                "http://appium.local",
+                "",
+                "18.0",
+                "udid-1",
+                "",
+                "",
+                "",
+                "");
+
+        assertEquals("iOS", iosResult.platformName());
+        assertTrue(iosResult.warnings().stream().anyMatch(warning -> warning.contains("bundleId")));
+        assertTrue(iosResult.codeBlocks().getFirst().code().contains(".automationName(\"XCUITest\")"));
+        verify(iosEngine).initializeConfiguredDriver("mobile native iOS");
+        assertThrows(IllegalArgumentException.class,
+                () -> ios.initializeNative("windows", "", "", "", "", "", "", "", "", ""));
+    }
+
+    @Test
+    void recordingToolsDelegateToRecorderAndGenerateReplayCode() {
+        McpMobileRecordingService recorder = new McpMobileRecordingService(McpWorkspacePolicy.of(temp));
+        MobileService service = new MobileService(mock(EngineService.class), recorder);
+        Path recording = temp.resolve("journey.json");
+
+        McpMobileRecordingStatus started = service.recordStart(recording.toString(), "native", true);
+        recorder.record(
+                "tap",
+                locatorStrategy.ACCESSIBILITY_ID,
+                "login",
+                Map.of(),
+                "driver.touch().tap(AppiumBy.accessibilityId(\"login\"));",
+                "driver.touch().tap(AppiumBy.accessibilityId(\"login\"));",
+                false);
+        McpMobileRecordingStatus active = service.recordStatus();
+        McpMobileRecordingStatus stopped = service.recordStop(false);
+        McpMobileReplayResult blocks = service.recordingCodeBlocks(recording.toString(), "mobileDriver");
+
+        assertTrue(started.active());
+        assertEquals("native", active.mode());
+        assertEquals(1, active.actionCount());
+        assertFalse(stopped.active());
+        assertEquals(1, stopped.actionCount());
+        assertTrue(blocks.codeBlocks().getFirst().code()
+                .contains("mobileDriver.touch().tap(AppiumBy.accessibilityId(\"login\"));"));
+    }
+
+    @Test
+    void replayRecordingRejectsUnsupportedRecordedAction() {
+        McpMobileRecordingService recorder = new McpMobileRecordingService(McpWorkspacePolicy.of(temp));
+        MobileService service = new MobileService(mock(EngineService.class), recorder);
+        Path recording = temp.resolve("unsupported.json");
+        service.recordStart(recording.toString(), "native", true);
+        recorder.record("unsupported", null, "", Map.of(), "driver.unsupported();", "driver.unsupported();", false);
+        service.recordStop(false);
+
+        IllegalArgumentException failure = assertThrows(IllegalArgumentException.class,
+                () -> service.replayRecording(recording.toString(), "driver"));
+
+        assertTrue(failure.getMessage().contains("Unsupported mobile recording action"));
+    }
+}

--- a/shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java
@@ -7,6 +7,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.io.File;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -22,7 +24,7 @@ class ShaftMcpApplicationTests {
     private ApplicationContext context;
 
 	@Test
-	void contextRegistersExpectedLeanMcpToolApi() throws Exception {
+    void contextRegistersExpectedLeanMcpToolApi() throws Exception {
         Object bean = context.getBean("shaftTools");
         assertTrue(bean instanceof List<?>);
         List<?> callbacks = (List<?>) bean;
@@ -54,6 +56,31 @@ class ShaftMcpApplicationTests {
         assertTrue(!toolNames.contains("browser_get_page_source"));
         assertTrue(!toolNames.contains("browser_get_cookie"));
         assertTrue(!toolNames.contains("element_click_ai"));
+    }
+
+    @Test
+    void captureLaunchPrefixBuildsRunnableCaptureCommand() throws Exception {
+        Method method = ShaftMcpApplication.class.getDeclaredMethod("captureLaunchPrefix");
+        method.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        List<String> prefix = (List<String>) method.invoke(null);
+
+        assertTrue(prefix.size() >= 3);
+        assertTrue(prefix.contains("capture")
+                || prefix.contains(com.shaft.capture.cli.CaptureCli.class.getName()));
+    }
+
+    @Test
+    void absoluteClassPathNormalizesRelativeEntries() throws Exception {
+        Method method = ShaftMcpApplication.class.getDeclaredMethod("absoluteClassPath", String.class);
+        method.setAccessible(true);
+
+        String normalized = (String) method.invoke(null, "target/classes" + File.pathSeparator + ".");
+
+        for (String entry : normalized.split(java.util.regex.Pattern.quote(File.pathSeparator))) {
+            assertTrue(Path.of(entry).isAbsolute(), entry);
+        }
     }
 
     private static Set<String> expectedTools() throws Exception {

--- a/shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiValueObjectsTest.java
+++ b/shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiValueObjectsTest.java
@@ -1,0 +1,124 @@
+package com.shaft.pilot.ai;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.EnumSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AiValueObjectsTest {
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    @Test
+    void aiImageDefensivelyCopiesDataAndDefaultsMediaType() {
+        byte[] bytes = {1, 2, 3};
+        AiImage image = new AiImage(EvidenceCategory.SCREENSHOT, null, bytes);
+
+        bytes[0] = 9;
+        byte[] returned = image.data();
+        returned[1] = 8;
+
+        assertEquals("image/png", image.mediaType());
+        assertArrayEquals(new byte[]{1, 2, 3}, image.data());
+    }
+
+    @Test
+    void availabilityFactoriesNormalizeReasons() {
+        assertTrue(AiProviderAvailability.ready().available());
+        assertEquals("", AiProviderAvailability.ready().reason());
+        assertFalse(AiProviderAvailability.unavailable(null).available());
+        assertEquals("Provider unavailable", AiProviderAvailability.unavailable(null).reason());
+    }
+
+    @Test
+    void disabledProviderReturnsDeterministicFallback() {
+        var fallback = JSON.createObjectNode().put("answer", "deterministic");
+        AiRequest request = AiRequest.builder("disabled-provider", JSON.createObjectNode())
+                .deterministicFallback(fallback)
+                .build();
+
+        AiResponse response = new DisabledAiProvider().execute(request);
+
+        assertEquals("none", new DisabledAiProvider().id());
+        assertFalse(new DisabledAiProvider().capabilities().structuredOutput());
+        assertFalse(new DisabledAiProvider().availability().available());
+        assertEquals(AiResponseStatus.DISABLED, response.status());
+        assertEquals("deterministic", response.structuredPayload().path("answer").asText());
+    }
+
+    @Test
+    void approvalPolicyRequiresLocationAndAllCategories() {
+        ApprovalPolicy policy = new ApprovalPolicy(true, true, false, EnumSet.of(EvidenceCategory.TEXT));
+
+        assertTrue(policy.allows(ProcessingLocation.LOCAL, Set.of(EvidenceCategory.TEXT)));
+        assertTrue(policy.allows(ProcessingLocation.ON_PREM, Set.of(EvidenceCategory.TEXT)));
+        assertFalse(policy.allows(ProcessingLocation.REMOTE, Set.of(EvidenceCategory.TEXT)));
+        assertFalse(policy.allows(ProcessingLocation.NONE, Set.of()));
+        assertFalse(policy.allows(ProcessingLocation.LOCAL, Set.of(EvidenceCategory.TEXT, EvidenceCategory.DOM)));
+    }
+
+    @Test
+    void requestBuilderCopiesEvidenceAndCollectsCategories() {
+        var schema = JSON.createObjectNode().put("type", "object");
+        var fallback = JSON.createObjectNode().put("answer", "deterministic");
+        AiRequest request = AiRequest.builder("request-builder", schema)
+                .requestId("req-1")
+                .text("body")
+                .evidence(new EvidenceReference("e1", EvidenceCategory.DOM, "text/html", "<main/>"))
+                .image(new AiImage(EvidenceCategory.SCREENSHOT, "image/png", new byte[]{1}))
+                .timeout(Duration.ofSeconds(2))
+                .budget(new AiBudget(10, 1, BigDecimal.ONE))
+                .approvalPolicy(new ApprovalPolicy(true, false, false, EnumSet.allOf(EvidenceCategory.class)))
+                .deterministicFallback(fallback)
+                .build();
+
+        schema.put("extra", true);
+        fallback.put("answer", "mutated");
+
+        assertEquals("req-1", request.requestId());
+        assertEquals(Set.of(EvidenceCategory.TEXT, EvidenceCategory.DOM, EvidenceCategory.SCREENSHOT),
+                request.evidenceCategories());
+        assertFalse(request.desiredResponseSchema().has("extra"));
+        assertEquals("deterministic", request.deterministicFallback().path("answer").asText());
+        assertThrows(UnsupportedOperationException.class,
+                () -> request.evidence().add(new EvidenceReference("x", EvidenceCategory.TEXT, "text/plain", "x")));
+    }
+
+    @Test
+    void requestRejectsBlankPurposeAndNonPositiveTimeout() {
+        assertThrows(IllegalArgumentException.class,
+                () -> AiRequest.builder(" ", JSON.createObjectNode()).build());
+        assertThrows(IllegalArgumentException.class,
+                () -> AiRequest.builder("bad-timeout", JSON.createObjectNode())
+                        .timeout(Duration.ZERO)
+                        .build());
+    }
+
+    @Test
+    void responseDefaultsAndCopiesPayloads() {
+        var payload = JSON.createObjectNode().put("answer", "ok");
+        AiResponse response = AiResponse.success("provider", "model", payload, null, null, payload);
+
+        payload.put("answer", "mutated");
+
+        assertTrue(response.successful());
+        assertEquals("ok", response.structuredPayload().path("answer").asText());
+        assertEquals(Duration.ZERO, response.duration());
+        assertEquals(AiUsage.empty(), response.usage());
+        assertThrows(UnsupportedOperationException.class, () -> response.warnings().add("x"));
+    }
+
+    @Test
+    void enumValueOfAndNamesRemainStable() {
+        assertEquals(AiResponseStatus.SUCCESS, AiResponseStatus.valueOf("SUCCESS"));
+        assertEquals("REMOTE", ProcessingLocation.REMOTE.name());
+    }
+}

--- a/shaft-pilot-core/src/test/java/com/shaft/pilot/config/ProviderConfigurationTest.java
+++ b/shaft-pilot-core/src/test/java/com/shaft/pilot/config/ProviderConfigurationTest.java
@@ -1,0 +1,53 @@
+package com.shaft.pilot.config;
+
+import com.shaft.pilot.ai.ProcessingLocation;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ProviderConfigurationTest {
+    @Test
+    void compactConstructorDefaultsLocationByProviderId() {
+        ProviderConfiguration local = new ProviderConfiguration(
+                "ollama", URI.create("http://localhost:11434"), " model ", "", Map.of("header", "value"));
+        ProviderConfiguration remote = new ProviderConfiguration(
+                "openai", URI.create("https://example.test"), null, null, null);
+
+        assertEquals(ProcessingLocation.LOCAL, local.processingLocation());
+        assertEquals("model", local.model());
+        assertEquals("value", local.option("header"));
+        assertEquals("", local.option("missing"));
+        assertEquals(ProcessingLocation.REMOTE, remote.processingLocation());
+        assertEquals("", remote.model());
+        assertEquals("", remote.apiKeyEnvironmentVariable());
+    }
+
+    @Test
+    void canonicalConstructorDefaultsNullLocationAndCopiesOptions() {
+        Map<String, String> options = new HashMap<>();
+        options.put("base", "one");
+
+        ProviderConfiguration configuration = new ProviderConfiguration(
+                "custom", URI.create("https://example.test"), "model", " API_KEY ",
+                null, options);
+        options.put("base", "two");
+
+        assertEquals(ProcessingLocation.NONE, configuration.processingLocation());
+        assertEquals("API_KEY", configuration.apiKeyEnvironmentVariable());
+        assertEquals("one", configuration.option("base"));
+        assertThrows(UnsupportedOperationException.class, () -> configuration.options().put("x", "y"));
+    }
+
+    @Test
+    void requiredFieldsRejectNulls() {
+        assertThrows(NullPointerException.class,
+                () -> new ProviderConfiguration(null, URI.create("https://example.test"), "", "", Map.of()));
+        assertThrows(NullPointerException.class,
+                () -> new ProviderConfiguration("id", null, "", "", Map.of()));
+    }
+}

--- a/shaft-pilot-core/src/test/java/com/shaft/pilot/json/JsonSchemaValidatorTest.java
+++ b/shaft-pilot-core/src/test/java/com/shaft/pilot/json/JsonSchemaValidatorTest.java
@@ -1,0 +1,105 @@
+package com.shaft.pilot.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JsonSchemaValidatorTest {
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    @Test
+    void acceptsValidObjectWithArrayAndNumberRules() throws Exception {
+        JsonNode schema = JSON.readTree("""
+                {
+                  "type": "object",
+                  "required": ["name", "scores"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {"type": ["string", "null"], "enum": ["Sam", null]},
+                    "scores": {
+                      "type": "array",
+                      "minItems": 1,
+                      "maxItems": 2,
+                      "items": {"type": "number", "minimum": 0, "maximum": 10}
+                    }
+                  }
+                }
+                """);
+        JsonNode payload = JSON.readTree("{\"name\":\"Sam\",\"scores\":[3,10]}");
+
+        assertTrue(JsonSchemaValidator.validate(schema, payload).isEmpty());
+    }
+
+    @Test
+    void reportsRequiredAdditionalArrayNumberAndEnumErrors() throws Exception {
+        JsonNode schema = JSON.readTree("""
+                {
+                  "type": "object",
+                  "required": ["name", "scores"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {"type": "string", "enum": ["Sam"]},
+                    "scores": {
+                      "type": "array",
+                      "minItems": 1,
+                      "maxItems": 2,
+                      "items": {"type": "integer", "minimum": 0, "maximum": 10}
+                    }
+                  }
+                }
+                """);
+        JsonNode payload = JSON.readTree("{\"name\":\"Ana\",\"scores\":[-1,11,1.5],\"extra\":true}");
+
+        List<String> errors = JsonSchemaValidator.validate(schema, payload);
+
+        assertEquals(List.of(
+                "$.name is not an allowed enum value.",
+                "$.scores has more items than allowed.",
+                "$.scores[0] is below the minimum.",
+                "$.scores[1] is above the maximum.",
+                "$.scores[2] does not match the required type.",
+                "$.extra is not allowed."), errors);
+    }
+
+    @Test
+    void reportsMissingRequiredAndRootTypeMismatch() throws Exception {
+        JsonNode schema = JSON.readTree("""
+                {
+                  "type": "object",
+                  "required": ["name"],
+                  "properties": {"name": {"type": "string"}}
+                }
+                """);
+
+        assertEquals(List.of("$.name is required."),
+                JsonSchemaValidator.validate(schema, JSON.readTree("{}")));
+        assertEquals(List.of("$ does not match the required type."),
+                JsonSchemaValidator.validate(schema, JSON.readTree("[]")));
+    }
+
+    @Test
+    void ignoresUnsupportedOrMissingSchema() throws Exception {
+        assertTrue(JsonSchemaValidator.validate(null, JSON.readTree("{}")).isEmpty());
+        assertTrue(JsonSchemaValidator.validate(JSON.readTree("\"schema\""), JSON.readTree("{}")).isEmpty());
+        assertTrue(JsonSchemaValidator.validate(JSON.readTree("{\"type\":\"custom\"}"), JSON.readTree("1")).isEmpty());
+    }
+
+    @Test
+    void constructorRejectsInstantiation() throws Exception {
+        Constructor<JsonSchemaValidator> constructor = JsonSchemaValidator.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+
+        InvocationTargetException thrown = assertThrows(InvocationTargetException.class, constructor::newInstance);
+
+        assertEquals(IllegalStateException.class, thrown.getCause().getClass());
+        assertEquals("Utility class", thrown.getCause().getMessage());
+    }
+}

--- a/shaft-video/src/test/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistrationTest.java
+++ b/shaft-video/src/test/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistrationTest.java
@@ -2,10 +2,20 @@ package com.shaft.gui.internal.video;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class DesktopVideoRecordingProviderRegistrationTest {
+    @TempDir
+    Path temp;
+
     @AfterEach
     public void tearDown() {
         DesktopVideoRecordingProviderRegistry.resetProviderForTesting();
@@ -15,5 +25,25 @@ public class DesktopVideoRecordingProviderRegistrationTest {
     public void serviceLoaderFindsAutomationRemarksProvider() {
         assertEquals(AutomationRemarksDesktopVideoRecordingProvider.class,
                 DesktopVideoRecordingProviderRegistry.findProvider().orElseThrow().getClass());
+    }
+
+    @Test
+    public void idleProviderShouldNotStopOrReportRecording() {
+        AutomationRemarksDesktopVideoRecordingProvider provider = new AutomationRemarksDesktopVideoRecordingProvider();
+
+        assertFalse(provider.isRecording());
+        assertNull(provider.stopRecording(true, "idle"));
+    }
+
+    @Test
+    public void encodeRecordingShouldReturnMp4TargetWhenEncoderCannotReadSource() throws Exception {
+        AutomationRemarksDesktopVideoRecordingProvider provider = new AutomationRemarksDesktopVideoRecordingProvider();
+        Method method = AutomationRemarksDesktopVideoRecordingProvider.class
+                .getDeclaredMethod("encodeRecording", String.class);
+        method.setAccessible(true);
+
+        File target = (File) method.invoke(provider, temp.resolve("missing.avi").toString());
+
+        assertEquals("missing.mp4", target.getName());
     }
 }


### PR DESCRIPTION
## Summary
- add focused unit coverage for shaft-capture runtime, control, collector, and CLI paths, including the updated capture review-blocker assertion
- add MCP service, helper, result, and configuration coverage without opening browser sessions
- add small value/helper coverage for browserstack, pilot-core, and video modules

## Validation
- `mvn -pl shaft-browserstack,shaft-pilot-core,shaft-video,shaft-mcp,shaft-capture -am test-compile '-DskipTests' '-Dgpg.skip'`
- disposable Surefire/Jacoco: `shaft-capture` 39 tests passed, method coverage 81.99%
- disposable Surefire/Jacoco: `shaft-mcp` 44 tests passed, method coverage 80.59%
- disposable targeted coverage: `shaft-pilot-core` 31 tests passed, method coverage 81.89%; `shaft-video` 3 tests passed, method coverage 80%; `shaft-browserstack` 1 test passed, method coverage 100%

## Notes
- full repository 80% coverage was not proven in one aggregate run
- line/instruction coverage remains below 80% in some affected modules
- no checked-in business-use-case catalog exists to quantify the requested 80% E2E business-flow target