### PR TITLE
Fix Android pulled file byte assertion

### DIFF
--- a/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -94,7 +95,7 @@ public class AndroidTouchActionsCoverageUnitTest {
         SHAFT.Validations.assertThat().object(Files.exists(pulledFilePath)).isTrue().perform();
         SHAFT.Validations.assertThat().object(Files.exists(ROOT_PULL_PATH)).isTrue().perform();
         SHAFT.Validations.assertThat().object(Files.exists(TEMP_DIR.resolve("existing-result.txt"))).isTrue().perform();
-        SHAFT.Validations.assertThat().object(Files.readAllBytes(pulledFilePath)).isEqualTo(pulledContent).perform();
+        SHAFT.Validations.assertThat().object(Arrays.equals(Files.readAllBytes(pulledFilePath), pulledContent)).isTrue().perform();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Fix Android pulled-file coverage test to compare pulled `byte[]` content instead of byte-array object identity.

## CI failure analyzed
- Run: https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/27842945475
- Failed job: `Android_Native_BrowserStack`
- Failed result: `testPackage.unitTests.AndroidTouchActionsCoverageUnitTest.androidLifecycleAndFileTransferApisShouldExecuteAndPersistPulledFile`
- Signature: Allure reported `expected [B@... but found [B@...` at `AndroidTouchActionsCoverageUnitTest.java:97`.

## Validation
- `mvn -pl shaft-engine -am -e test '-DretryMaximumNumberOfAttempts=1' '-DgenerateAllureReportArchive=false' '-DsetParallelMode=NONE' '-Dtest=testPackage.unitTests.AndroidTouchActionsCoverageUnitTest#androidLifecycleAndFileTransferApisShouldExecuteAndPersistPulledFile'`
- `mvn -pl shaft-engine -am package '-DskipTests' '-Dgpg.skip'`
- `git diff --check`

## Graphify
- Attempted: `graphify . --update --no-viz`
- Blocked: graphify detected 1154 code, 364 docs, 1 paper, and 15 images as changed and required an LLM API key for semantic extraction. No tracked graphify files were modified.