### PR TITLE
[codex] Optimize CLI action reporting and execution

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/cli/FileActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/FileActions.java
@@ -21,6 +21,7 @@ import java.nio.file.*;
 import java.util.*;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
@@ -120,43 +121,47 @@ public class FileActions {
     }
 
     public String listFilesInDirectory(String targetDirectory) {
-        StringBuilder files = new StringBuilder();
-        try {
-            Collection<File> filesList = FileUtils.listFiles(new File(targetDirectory), TrueFileFilter.TRUE,
-                    TrueFileFilter.TRUE);
-            filesList.forEach(file -> files.append(file.getName()).append(System.lineSeparator()));
-        } catch (IllegalArgumentException rootCauseException) {
-            failAction("Could not list files in directory \"" + targetDirectory + "\".", rootCauseException);
-        }
-        passAction("Target Directory: \"" + targetDirectory + "\"", files.toString().trim());
-        return files.toString().trim();
+        String files = listFiles(targetDirectory, true).stream()
+                .map(File::getName)
+                .collect(Collectors.joining(System.lineSeparator()));
+        passAction("Target Directory: \"" + targetDirectory + "\"", files.trim());
+        return files.trim();
     }
 
     public String listFilesInDirectory(String targetDirectory, TrueFileFilter recursively) {
-        StringBuilder files = new StringBuilder();
-        try {
-            Collection<File> filesList = FileUtils.listFiles(new File(targetDirectory), TrueFileFilter.TRUE,
-                    recursively);
-            filesList.forEach(file -> files.append(file.getName()).append(System.lineSeparator()));
-        } catch (IllegalArgumentException rootCauseException) {
-            failAction("Could not list files in directory \"" + targetDirectory + "\".", rootCauseException);
-        }
-        passAction("Target Directory: \"" + targetDirectory + "\"", files.toString().trim());
-        return files.toString().trim();
+        String files = listFiles(targetDirectory, TrueFileFilter.TRUE.equals(recursively)).stream()
+                .map(File::getName)
+                .collect(Collectors.joining(System.lineSeparator()));
+        passAction("Target Directory: \"" + targetDirectory + "\"", files.trim());
+        return files.trim();
     }
 
     public Collection<File> getFileList(String targetDirectory) {
-        StringBuilder files = new StringBuilder();
-        Collection<File> filesList = new ArrayList<>();
-        try {
-            filesList = FileUtils.listFiles(new File(targetDirectory), TrueFileFilter.TRUE,
-                    TrueFileFilter.TRUE);
-            filesList.forEach(file -> files.append(file.getAbsolutePath()).append(System.lineSeparator()));
-        } catch (IllegalArgumentException rootCauseException) {
-            failAction("Could not list absolute file paths in directory \"" + targetDirectory + "\".", rootCauseException);
-        }
-        passAction("Target Directory: \"" + targetDirectory + "\"", files.toString().trim());
+        Collection<File> filesList = listFiles(targetDirectory, true);
+        passAction("Target Directory: \"" + targetDirectory + "\" | Files Found: \"" + filesList.size() + "\"");
         return filesList;
+    }
+
+    private List<File> listFiles(String targetDirectory, boolean recursive) {
+        try {
+            Path targetPath = Path.of(targetDirectory);
+            if (!Files.exists(targetPath)) {
+                return Collections.emptyList();
+            }
+            if (Files.isRegularFile(targetPath)) {
+                return List.of(targetPath.toFile());
+            }
+            int depth = recursive ? Integer.MAX_VALUE : 1;
+            try (var paths = Files.walk(targetPath, depth)) {
+                return paths.filter(Files::isRegularFile)
+                        .sorted()
+                        .map(Path::toFile)
+                        .toList();
+            }
+        } catch (Exception rootCauseException) {
+            failAction("Could not list files in directory \"" + targetDirectory + "\".", rootCauseException);
+            return Collections.emptyList();
+        }
     }
 
     /**
@@ -332,7 +337,7 @@ public class FileActions {
         try {
             Path targetFilePath = Paths.get(absoluteFilePath);
             FileUtils.writeByteArrayToFile(targetFilePath.toFile(), content);
-            passAction("Target File Path: \"" + targetFilePath + "\"", Arrays.toString(content));
+            passAction("Target File Path: \"" + targetFilePath + "\" | Bytes Written: \"" + content.length + "\"");
         } catch (InvalidPathException | IOException rootCauseException) {
             failAction("Folder Name: \"" + filePath + "\".", rootCauseException);
         }
@@ -749,8 +754,16 @@ public class FileActions {
     }
 
     private void failAction(String actionName, String testData, Exception... rootCauseException) {
-        String message = reportActionResult(actionName, testData, null, false, rootCauseException);
-        FailureReporter.fail(FileActions.class, message, rootCauseException[0]);
+        Exception cause = getRootCauseException(testData, rootCauseException);
+        String message = reportActionResult(actionName, testData, null, false, cause);
+        FailureReporter.fail(FileActions.class, message, cause);
+    }
+
+    private Exception getRootCauseException(String testData, Exception... rootCauseException) {
+        if (rootCauseException != null && rootCauseException.length > 0 && rootCauseException[0] != null) {
+            return rootCauseException[0];
+        }
+        return new IllegalStateException(testData == null || testData.isBlank() ? "File action failed." : testData);
     }
 
     private String reportActionResult(String actionName, String testData, String log, Boolean passFailStatus, Exception... rootCauseException) {
@@ -782,7 +795,7 @@ public class FileActions {
         }
 
         // Minimize File Action log steps and move them to discrete logs if called
-        // within shaft-engine itself
+        // within shaft-engine itself.
         StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
         StackTraceElement parentMethod = stackTrace[4];
         if (parentMethod.getClassName().contains("shaft")) {

--- a/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
@@ -11,6 +11,7 @@ import org.apache.commons.lang3.SystemUtils;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.file.Files;
@@ -312,21 +313,16 @@ public class TerminalActions {
      * @return the command output log
      */
     public String performTerminalCommands(List<String> commands, Map<String, String> environmentVariables) {
-        var internalCommands = commands;
+        List<String> internalCommands = getValidCommands(commands);
 
         // Build long command and refactor for dockerized execution if needed
         String longCommand = buildLongCommand(internalCommands);
-
-        if (internalCommands.size() == 1) {
-            if (internalCommands.getFirst().contains(" && ")) {
-                internalCommands = List.of(internalCommands.getFirst().split(" && "));
-            } else if (internalCommands.getFirst().contains(" ; ")) {
-                internalCommands = List.of(internalCommands.getFirst().split(" ; "));
-            }
-        }
+        List<String> commandsToExecute = isDockerizedTerminal() && !isRemoteTerminal()
+                ? Collections.singletonList(longCommand)
+                : internalCommands;
 
         // Perform command
-        List<String> exitLogs = isRemoteTerminal() ? executeRemoteCommand(internalCommands, longCommand, environmentVariables) : executeLocalCommand(internalCommands, longCommand, environmentVariables);
+        List<String> exitLogs = isRemoteTerminal() ? executeRemoteCommand(commandsToExecute, longCommand, environmentVariables) : executeLocalCommand(commandsToExecute, longCommand, environmentVariables);
         String log = exitLogs.get(0);
         String exitStatus = exitLogs.get(1);
 
@@ -368,6 +364,20 @@ public class TerminalActions {
      */
     public String performTerminalCommand(String command, Map<String, String> environmentVariables) {
         return performTerminalCommands(Collections.singletonList(command), environmentVariables);
+    }
+
+    private List<String> getValidCommands(List<String> commands) {
+        if (commands == null || commands.isEmpty()) {
+            failAction("Terminal command", new IllegalArgumentException("At least one terminal command must be provided."));
+        }
+        return commands.stream()
+                .map(command -> {
+                    if (command == null || command.isBlank()) {
+                        failAction("Terminal command", new IllegalArgumentException("Terminal command must not be blank."));
+                    }
+                    return command;
+                })
+                .toList();
     }
 
     /**
@@ -506,13 +516,21 @@ public class TerminalActions {
     }
 
     private void failAction(String actionName, String testData, Exception... rootCauseException) {
-        String message = reportActionResult(actionName, testData, null, false, rootCauseException);
-        FailureReporter.fail(TerminalActions.class, message, rootCauseException[0]);
+        Exception cause = getRootCauseException(testData, rootCauseException);
+        String message = reportActionResult(actionName, testData, null, false, cause);
+        FailureReporter.fail(TerminalActions.class, message, cause);
     }
 
     private void failAction(String testData, Exception... rootCauseException) {
         String actionName = Thread.currentThread().getStackTrace()[2].getMethodName();
         failAction(actionName, testData, rootCauseException);
+    }
+
+    private Exception getRootCauseException(String testData, Exception... rootCauseException) {
+        if (rootCauseException != null && rootCauseException.length > 0 && rootCauseException[0] != null) {
+            return rootCauseException[0];
+        }
+        return new IllegalStateException(testData == null || testData.isBlank() ? "Terminal action failed." : testData);
     }
 
     private Session createSSHsession() {
@@ -757,48 +775,12 @@ public class TerminalActions {
                 ProcessBuilder pb = getProcessBuilder(command, finalDirectory, isWindows);
                 applyLocalProcessEnvironment(pb, environmentVariables);
                 if (!asynchronous) {
-                    pb.redirectErrorStream(true);
-                    Process localProcess = pb.start();
-                    // output logs
-                    String line;
-                    try (InputStreamReader isr = new InputStreamReader(localProcess.getInputStream());
-                         BufferedReader rdr = new BufferedReader(isr)) {
-                        while ((line = rdr.readLine()) != null) {
-                            if (Boolean.TRUE.equals(verbose)) {
-                                ReportManager.logDiscrete(redactTerminalLogForReporting(line));
-                            }
-                            logs.append(line);
-                            logs.append("\n");
-                        }
-                    }
-                    try (InputStreamReader isr = new InputStreamReader(localProcess.getErrorStream());
-                         BufferedReader rdr = new BufferedReader(isr)) {
-                        while ((line = rdr.readLine()) != null) {
-                            if (Boolean.TRUE.equals(verbose)) {
-                                ReportManager.logDiscrete(redactTerminalLogForReporting(line));
-                            }
-                            logs.append("\n");
-                            logs.append(line);
-                        }
-                    }
-                    // Wait for the process to complete
-                    localProcess.waitFor(SHAFT.Properties.timeouts.shellSessionTimeout(), TimeUnit.MINUTES);
-                    // Retrieve the exit status of the executed command and destroy open sessions
-                    exitStatuses.append(localProcess.exitValue());
+                    executeSynchronousLocalCommand(command, longCommand, logs, exitStatuses, pb);
                 } else {
+                    pb.redirectOutput(ProcessBuilder.Redirect.DISCARD);
+                    pb.redirectError(ProcessBuilder.Redirect.DISCARD);
+                    pb.start();
                     exitStatuses.append("asynchronous");
-                    ScheduledExecutorService asynchronousProcessExecution = Executors.newScheduledThreadPool(1);
-                    asynchronousProcessExecution.schedule(() -> {
-                        try {
-                            pb.start();
-                            asynchronousProcessExecution.shutdown();
-                        } catch (Throwable throwable) {
-                            asynchronousProcessExecution.shutdownNow();
-                        }
-                    }, 0, TimeUnit.SECONDS);
-                    if (!asynchronousProcessExecution.awaitTermination(SHAFT.Properties.timeouts.shellSessionTimeout(), TimeUnit.MINUTES)) {
-                        asynchronousProcessExecution.shutdownNow();
-                    }
                 }
             } catch (IOException exception) {
                 failAction(longCommand, exception);
@@ -808,6 +790,46 @@ public class TerminalActions {
             }
         });
         return Arrays.asList(logs.toString().trim(), exitStatuses.toString());
+    }
+
+    private void executeSynchronousLocalCommand(String command, String longCommand, StringBuilder logs,
+                                                StringBuilder exitStatuses, ProcessBuilder pb)
+            throws IOException, InterruptedException {
+        pb.redirectErrorStream(true);
+        ExecutorService streamReader = Executors.newSingleThreadExecutor();
+        Process localProcess = pb.start();
+        try {
+            Future<String> output = streamReader.submit(() -> readProcessStream(localProcess.getInputStream()));
+            boolean completed = localProcess.waitFor(SHAFT.Properties.timeouts.shellSessionTimeout(), TimeUnit.MINUTES);
+            if (!completed) {
+                localProcess.destroyForcibly();
+                logs.append(getCompletedOutput(output));
+                failAction(longCommand, new TimeoutException("Terminal command timed out after "
+                        + SHAFT.Properties.timeouts.shellSessionTimeout() + " minute(s): " + command));
+            }
+            logs.append(getCompletedOutput(output));
+            exitStatuses.append(localProcess.exitValue());
+        } finally {
+            streamReader.shutdownNow();
+        }
+    }
+
+    private String readProcessStream(InputStream stream) throws IOException {
+        try (InputStreamReader isr = new InputStreamReader(stream);
+             BufferedReader reader = new BufferedReader(isr)) {
+            return readConsoleLogs(reader);
+        }
+    }
+
+    private String getCompletedOutput(Future<String> output) {
+        try {
+            return output.get(1, TimeUnit.SECONDS);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            return "";
+        } catch (ExecutionException | TimeoutException exception) {
+            return "";
+        }
     }
 
     private ProcessBuilder getProcessBuilder(String command, String finalDirectory, boolean isWindows) {

--- a/shaft-engine/src/test/java/com/shaft/cli/FileActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/cli/FileActionsCoverageUnitTest.java
@@ -95,8 +95,12 @@ public class FileActionsCoverageUnitTest {
         Assert.assertFalse(actions.doesFileExist(sourceFolderPrefix, "missing.txt", 0));
         Assert.assertEquals(actions.readFile(sourceFolderPrefix, "alpha.txt"), String.join(System.lineSeparator(), "first", "second"));
         Assert.assertEquals(new String(actions.readFileAsByteArray(nestedFolder.resolve("bytes.bin").toString()), StandardCharsets.UTF_8), "bytes");
-        Assert.assertTrue(actions.listFilesInDirectory(sourceFolder.toString()).contains("alpha.txt"));
-        Assert.assertTrue(actions.listFilesInDirectory(sourceFolder.toString(), (TrueFileFilter) null).contains("alpha.txt"));
+        String recursiveList = actions.listFilesInDirectory(sourceFolder.toString());
+        String topLevelList = actions.listFilesInDirectory(sourceFolder.toString(), (TrueFileFilter) null);
+        Assert.assertTrue(recursiveList.contains("alpha.txt"));
+        Assert.assertTrue(recursiveList.contains("bytes.bin"));
+        Assert.assertTrue(topLevelList.contains("alpha.txt"));
+        Assert.assertFalse(topLevelList.contains("bytes.bin"));
         Assert.assertEquals(actions.getFileList(sourceFolder.toString()).size(), 5);
 
         Path destinationFolder = tempDirectory.resolve("destination");
@@ -313,6 +317,10 @@ public class FileActionsCoverageUnitTest {
         InvocationTargetException namedFailure = Assert.expectThrows(InvocationTargetException.class,
                 () -> failWithActionName.invoke(actions, "customFailure", "forced data", new Exception[]{new IOException("forced named")}));
         Assert.assertTrue(namedFailure.getCause() instanceof RuntimeException);
+
+        InvocationTargetException noCauseFailure = Assert.expectThrows(InvocationTargetException.class,
+                () -> failWithData.invoke(actions, "forced data without cause", new Exception[0]));
+        Assert.assertTrue(noCauseFailure.getCause().getMessage().contains("forced data without cause"));
     }
 
     @Test
@@ -344,7 +352,9 @@ public class FileActionsCoverageUnitTest {
         Assert.expectThrows(RuntimeException.class, () -> actions.zipFiles(missing.toString(), tempDirectory.resolve("missing.zip").toString()));
         Assert.expectThrows(RuntimeException.class, () -> actions.unpackArchive(missing.toUri().toURL(), tempDirectory.resolve("unpack-missing").toString()));
         Assert.expectThrows(RuntimeException.class, () -> actions.downloadFile(missing.toUri().toURL().toString(), tempDirectory.resolve("download.txt").toString()));
-        Assert.expectThrows(RuntimeException.class, () -> actions.downloadFile(null, tempDirectory.resolve("download.txt").toString()));
+        RuntimeException nullDownloadFailure = Assert.expectThrows(RuntimeException.class,
+                () -> actions.downloadFile(null, tempDirectory.resolve("download.txt").toString()));
+        Assert.assertTrue(nullDownloadFailure.getMessage().contains("Target File URL"));
         String missingJarResourceUrl = missing.toUri().toURL() + "!/assets/";
         Assert.expectThrows(RuntimeException.class, () -> actions.copyFolderFromJar(missingJarResourceUrl, tempDirectory.resolve("jar").toString()));
         Assert.expectThrows(RuntimeException.class, () -> actions.copyFileFromJar(missingJarResourceUrl, tempDirectory.resolve("jar").toString(), "one.txt"));

--- a/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
@@ -345,8 +345,8 @@ public class TerminalActionsUnitTest {
         return directory;
     }
 
-    @Test(description = "performTerminalCommands should execute split commands and capture logs")
-    public void performTerminalCommandsShouldExecuteSplitCommands() {
+    @Test(description = "performTerminalCommands should execute command chains and capture logs")
+    public void performTerminalCommandsShouldExecuteCommandChains() {
         TerminalActions terminal = TerminalActions.getInstance(false, false, true);
         String log = terminal.performTerminalCommand("echo first && echo second");
         Assert.assertTrue(log.contains("first"), "Expected first command output in logs.");
@@ -362,12 +362,31 @@ public class TerminalActionsUnitTest {
                 "Expected command log to include changed working directory.");
     }
 
-    @Test(description = "performTerminalCommands should split semicolon-separated command chains")
-    public void performTerminalCommandsShouldSplitSemicolonCommands() {
+    @Test(description = "performTerminalCommands should execute semicolon-separated command chains")
+    public void performTerminalCommandsShouldExecuteSemicolonCommands() {
         TerminalActions terminal = TerminalActions.getInstance(false, false, true);
         String log = terminal.performTerminalCommand("echo alpha ; echo beta");
         Assert.assertTrue(log.contains("alpha"));
         Assert.assertTrue(log.contains("beta"));
+    }
+
+    @Test(description = "performTerminalCommand should keep quoted command separators in the same command")
+    public void performTerminalCommandShouldNotSplitQuotedSeparators() {
+        TerminalActions terminal = TerminalActions.getInstance(false, false, true);
+        String log = terminal.performTerminalCommand("echo \"alpha && beta ; gamma\"");
+
+        Assert.assertTrue(log.contains("alpha && beta ; gamma"),
+                "Quoted command separators should remain literal output.");
+    }
+
+    @Test(description = "performTerminalCommand should reject blank commands")
+    public void performTerminalCommandShouldRejectBlankCommands() {
+        TerminalActions terminal = TerminalActions.getInstance(false, false, true);
+
+        RuntimeException failure = Assert.expectThrows(RuntimeException.class,
+                () -> terminal.performTerminalCommand(" "));
+
+        Assert.assertTrue(failure.getMessage().contains("must not be blank"));
     }
 
     @Test(description = "performTerminalCommand with env vars should expose them to the local process")
@@ -411,6 +430,24 @@ public class TerminalActionsUnitTest {
                     () -> terminal.performTerminalCommand("echo interrupted"));
         } finally {
             Thread.interrupted();
+        }
+    }
+
+    @Test(description = "synchronous execution should fail and destroy timed-out local commands")
+    public void performTerminalCommandShouldFailWhenLocalCommandTimesOut() {
+        long originalTimeout = SHAFT.Properties.timeouts.shellSessionTimeout();
+        try {
+            SHAFT.Properties.timeouts.set().shellSessionTimeout(0);
+            TerminalActions terminal = TerminalActions.getInstance(false, false, true);
+            boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
+            String command = isWindows ? "Start-Sleep -Seconds 5" : "sleep 5";
+
+            RuntimeException failure = Assert.expectThrows(RuntimeException.class,
+                    () -> terminal.performTerminalCommand(command));
+
+            Assert.assertTrue(failure.getMessage().contains("timed out"));
+        } finally {
+            SHAFT.Properties.timeouts.set().shellSessionTimeout(originalTimeout);
         }
     }
 


### PR DESCRIPTION
## Summary

- Execute local terminal commands with concurrent output draining, explicit timeout failure, and simpler async process startup.
- Preserve quoted shell separators instead of pre-splitting single command strings, while keeping command chains delegated to the shell.
- Reduce noisy file-action reporting by listing with NIO, reporting file counts for `getFileList`, and reporting byte counts for binary writes.
- Harden private failure helpers so no-cause failures report cleanly instead of indexing an empty exception array.
- Add focused coverage for quoted separators, blank commands, timeout handling, file listing/reporting behavior, and no-cause file action failures.

Companion docs PR: https://github.com/ShaftHQ/shafthq.github.io/pull/569

## Validation

- `py -3 scripts\ci\validate_agent_setup.py` passed.
- `mvn test -pl shaft-engine -am '-Dtest=TerminalActionsUnitTest,FileActionsCoverageUnitTest,FileActionsUnitTest' '-Dgpg.skip=true'` passed: 63 tests, 0 failures/errors/skips; Allure results: 63 passed.
- `mvn package -pl shaft-engine -am '-DskipTests' '-Dgpg.skip=true' '-Dallure.automaticallyOpen=false' '-Dallure.open=false'` passed.
- Graphify refresh attempted with `graphify . --update --no-viz`, but it was blocked because no LLM API key was available for semantic extraction of changed docs/images.