### PR TITLE
[codex] Add MCP mobile Inspector recording

### DIFF
--- a/.memory/events.jsonl
+++ b/.memory/events.jsonl
@@ -73,3 +73,5 @@
 {"actor":"agent","event":"memory.created","id":"workflow.run-local-validation-without-opening-reports","timestamp":"2026-06-19T13:52:01+03:00"}
 {"actor":"agent","event":"memory.created","id":"decision.use-official-docs-search-index-for-shaft-mcp-guide-search","timestamp":"2026-06-19T20:01:52+03:00"}
 {"actor":"agent","event":"memory.created","id":"decision.prefer-shaft-api-builder-facade-for-rest-work","timestamp":"2026-06-20T09:44:36+03:00"}
+{"actor":"agent","event":"memory.created","id":"gotcha.memory-saves-use-intent-first-json-on-stdin","timestamp":"2026-06-20T12:08:49+03:00"}
+{"actor":"agent","event":"memory.created","id":"gotcha.graphify-updates-use-installed-cli-subcommands","timestamp":"2026-06-20T12:08:49+03:00"}

--- a/.memory/memory/gotchas/graphify-updates-use-installed-cli-subcommands.json
+++ b/.memory/memory/gotchas/graphify-updates-use-installed-cli-subcommands.json
@@ -1,0 +1,32 @@
+{
+  "body_path": "memory/gotchas/graphify-updates-use-installed-cli-subcommands.md",
+  "content_hash": "sha256:e72a6e1b6f66a4b00e9e6e283ce5acf9327b369adbfda70ac8a5ccd6c29a5782",
+  "created_at": "2026-06-20T12:08:49+03:00",
+  "evidence": [],
+  "facets": {
+    "applies_to": [
+      "graphify-out/",
+      "AGENTS.md"
+    ],
+    "category": "gotcha"
+  },
+  "id": "gotcha.graphify-updates-use-installed-cli-subcommands",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Record agent workflow corrections for Memory and Graphify CLI usage"
+  },
+  "status": "active",
+  "tags": [
+    "agent-workflow",
+    "graphify"
+  ],
+  "title": "Graphify updates use installed CLI subcommands",
+  "type": "gotcha",
+  "updated_at": "2026-06-20T12:08:49+03:00"
+}

--- a/.memory/memory/gotchas/graphify-updates-use-installed-cli-subcommands.md
+++ b/.memory/memory/gotchas/graphify-updates-use-installed-cli-subcommands.md
@@ -1,0 +1,1 @@
+Use the installed Graphify CLI syntax before trying slash-command forms: `graphify update .` refreshes the code graph without an LLM. Full semantic docs, paper, or image refreshes require an LLM backend key such as `GEMINI_API_KEY` or `GOOGLE_API_KEY`; report that blocker instead of retrying equivalent commands.

--- a/.memory/memory/gotchas/memory-saves-use-intent-first-json-on-stdin.json
+++ b/.memory/memory/gotchas/memory-saves-use-intent-first-json-on-stdin.json
@@ -1,0 +1,32 @@
+{
+  "body_path": "memory/gotchas/memory-saves-use-intent-first-json-on-stdin.md",
+  "content_hash": "sha256:6dcfefd025203a3fa0105c3343b05d88312a002acaf163af0a5ecddc49b1f228",
+  "created_at": "2026-06-20T12:08:49+03:00",
+  "evidence": [],
+  "facets": {
+    "applies_to": [
+      "AGENTS.md",
+      ".memory/"
+    ],
+    "category": "gotcha"
+  },
+  "id": "gotcha.memory-saves-use-intent-first-json-on-stdin",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Record agent workflow corrections for Memory and Graphify CLI usage"
+  },
+  "status": "active",
+  "tags": [
+    "agent-workflow",
+    "memory"
+  ],
+  "title": "Memory saves use intent-first JSON on stdin",
+  "type": "gotcha",
+  "updated_at": "2026-06-20T12:08:49+03:00"
+}

--- a/.memory/memory/gotchas/memory-saves-use-intent-first-json-on-stdin.md
+++ b/.memory/memory/gotchas/memory-saves-use-intent-first-json-on-stdin.md
@@ -1,0 +1,1 @@
+For routine project memory updates, use `memory remember --stdin` with intent-first JSON shaped as `{task, memories}`. `memory save --stdin` is for advanced structured patches, and this installed CLI does not support `memory save --dry-run`, `memory save --id`, or free-form text arguments.

--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -718,5 +718,16 @@
   "716": "Community 716",
   "717": "Community 717",
   "718": "Community 718",
-  "719": "Community 719"
+  "719": "Community 719",
+  "720": "Community 720",
+  "721": "Community 721",
+  "722": "Community 722",
+  "723": "Community 723",
+  "724": "Community 724",
+  "725": "Community 725",
+  "726": "Community 726",
+  "727": "Community 727",
+  "728": "Community 728",
+  "729": "Community 729",
+  "730": "Community 730"
 }

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - SHAFT_ENGINE  (2026-06-20)
 
 ## Corpus Check
-- 1219 files · ~570,540 words
+- 1240 files · ~582,809 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 12792 nodes · 32691 edges · 720 communities (649 shown, 71 thin omitted)
-- Extraction: 80% EXTRACTED · 20% INFERRED · 0% AMBIGUOUS · INFERRED: 6586 edges (avg confidence: 0.8)
+- 13097 nodes · 33781 edges · 731 communities (647 shown, 84 thin omitted)
+- Extraction: 80% EXTRACTED · 20% INFERRED · 0% AMBIGUOUS · INFERRED: 6873 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `470a5602`
+- Built from commit: `0f84d905`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -626,14 +626,24 @@
 - [[_COMMUNITY_Community 714|Community 714]]
 - [[_COMMUNITY_Community 715|Community 715]]
 - [[_COMMUNITY_Community 719|Community 719]]
+- [[_COMMUNITY_Community 720|Community 720]]
+- [[_COMMUNITY_Community 721|Community 721]]
+- [[_COMMUNITY_Community 722|Community 722]]
+- [[_COMMUNITY_Community 723|Community 723]]
+- [[_COMMUNITY_Community 724|Community 724]]
+- [[_COMMUNITY_Community 725|Community 725]]
+- [[_COMMUNITY_Community 726|Community 726]]
+- [[_COMMUNITY_Community 727|Community 727]]
+- [[_COMMUNITY_Community 728|Community 728]]
+- [[_COMMUNITY_Community 729|Community 729]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `SHAFT` - 279 edges
-2. `IOException` - 104 edges
+1. `SHAFT` - 280 edges
+2. `IOException` - 108 edges
 3. `RestActionsComprehensiveTests` - 99 edges
 4. `Test` - 98 edges
-5. `ReportManagerHelper` - 76 edges
-6. `ArrayList` - 73 edges
+5. `ArrayList` - 78 edges
+6. `ReportManagerHelper` - 76 edges
 7. `CaptureGenerator` - 71 edges
 8. `Actions` - 63 edges
 9. `JavaHelperUnitTest` - 58 edges
@@ -654,19 +664,19 @@
 ## Import Cycles
 - None detected.
 
-## Communities (720 total, 71 thin omitted)
+## Communities (731 total, 84 thin omitted)
 
 ### Community 0 - "Community 0"
 Cohesion: 0.04
-Nodes (5): RestActionsComprehensiveTests, ComparisonType, InputStream, SuppressWarnings, Test
+Nodes (4): RestActionsComprehensiveTests, ComparisonType, InputStream, Test
 
 ### Community 1 - "Community 1"
-Cohesion: 0.08
+Cohesion: 0.07
 Nodes (6): AfterMethod, Path, String, SuppressWarnings, Test, TerminalActionsUnitTest
 
 ### Community 2 - "Community 2"
-Cohesion: 0.19
-Nodes (13): DoctorAnalyzerTest, DoctorAiAnalysisResult, Arguments, CauseCategory, DoctorAnalysisRequest, DoctorAnalysisResult, List, MethodSource (+5 more)
+Cohesion: 0.10
+Nodes (26): DoctorAnalyzerTest, empty(), McpAppiumCommandRecorderTest, reviewUiPath(), disabled(), defaults(), lower(), normalizePath() (+18 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.13
@@ -677,8 +687,8 @@ Cohesion: 0.07
 Nodes (6): Pilot, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 5 - "Community 5"
-Cohesion: 0.13
-Nodes (13): TouchActions, By, DriverFactoryHelper, HashMap, List, Object, Override, String (+5 more)
+Cohesion: 0.10
+Nodes (19): getValue(), KeyboardKeys(), TouchActions, ImmutableMap, viewport(), By, DriverFactoryHelper, File (+11 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.06
@@ -697,24 +707,24 @@ Cohesion: 0.19
 Nodes (15): CandidateExtractor, LocatorProposal, SearchContext, By, Collection, HealingConfiguration, HealingPlatform, List (+7 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.17
-Nodes (8): BrowserStackSdkTests, AfterMethod, BeforeMethod, Map, Object, String, SuppressWarnings, Test
+Cohesion: 0.07
+Nodes (23): BrowserStackSdkHelper, BrowserStackSdkTests, List, Map, Object, String, AfterMethod, BeforeMethod (+15 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.11
-Nodes (11): ReportManagerHelper, TestCaseStarted, ByteArrayOutputStream, CheckpointStatus, InputStream, Level, List, Object (+3 more)
+Cohesion: 0.08
+Nodes (16): AsyncAppender, ReportManagerHelper, ReportManager, ByteArrayOutputStream, CheckpointStatus, InputStream, Level, List (+8 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.07
-Nodes (30): Autowired, KeyboardKeys, LocatorOperation, MobileService, MobileServiceConfigurationTest, McpMobileAccessibilityTree, McpMobileActionResult, McpMobileContextSnapshot (+22 more)
+Nodes (29): KeyboardKeys, LocatorOperation, MobileService, MobileServiceConfigurationTest, McpMobileAccessibilityTree, McpMobileActionResult, McpMobileContextSnapshot, McpMobileSessionResult (+21 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.07
 Nodes (11): BrowserStack, SetProperty, DefaultValue, Key, SetProperty, String, AfterMethod, Object (+3 more)
 
 ### Community 14 - "Community 14"
-Cohesion: 0.06
-Nodes (25): Connection, DatabaseActions, ApiAndRetainedSurfaceConsumer, JunitDatabaseSmokeTest, DatabaseActionsMockedTests, DbTests, Boolean, DatabaseType (+17 more)
+Cohesion: 0.14
+Nodes (8): DatabaseActionsMockedTests, AfterMethod, BeforeMethod, DatabaseActions, Object, ResultSet, String, Test
 
 ### Community 15 - "Community 15"
 Cohesion: 0.08
@@ -725,16 +735,16 @@ Cohesion: 0.09
 Nodes (72): CompletedProcess, activation_hint(), adoptium_os_arch(), application_data_root(), architecture(), await_probe_response(), choose_client(), command_path() (+64 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.09
-Nodes (18): BrowserStackModuleTest, WebDriverListener, InvocationTargetException, JsonSchemaValidatorTest, Navigation, Test, Alert, By (+10 more)
+Cohesion: 0.06
+Nodes (28): BrowserStackModuleTest, HealingSupport, WebDriverListener, InvocationTargetException, JsonSchemaValidatorTest, nativePlatform(), Navigation, Test (+20 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.11
-Nodes (9): ApiPerformanceReportTest, TestUpload, Object, ParametersType, AfterMethod, AfterSuite, BeforeMethod, Test (+1 more)
+Cohesion: 0.10
+Nodes (10): ApiPerformanceReportTest, SwaggerContractTest, AfterMethod, AfterSuite, BeforeMethod, Test, AfterClass, AfterMethod (+2 more)
 
 ### Community 19 - "Community 19"
 Cohesion: 0.12
-Nodes (20): ActionReportContext, abbreviate(), empty(), from(), hasElementName(), hasLocator(), hasStepValue(), shouldUseDataInStepName() (+12 more)
+Nodes (20): ActionReportContext, ElementActions, abbreviate(), empty(), from(), hasElementName(), hasLocator(), hasStepValue() (+12 more)
 
 ### Community 20 - "Community 20"
 Cohesion: 0.08
@@ -742,47 +752,51 @@ Nodes (30): dataString(), E, LocatorSignal, empty(), merge(), MouseButton, Captu
 
 ### Community 21 - "Community 21"
 Cohesion: 0.12
-Nodes (8): AndroidTouchActionsTests, viewport(), Test, Runnable, Test, AndroidTouchActionsCoverageUnitTest, Window, ZoomDirection
+Nodes (10): AndroidDriver, FileUploadDownloadTest, Test, AfterMethod, BeforeMethod, RemoteWebDriver, Runnable, Test (+2 more)
 
 ### Community 22 - "Community 22"
-Cohesion: 0.08
-Nodes (7): Object, Override, SuppressWarnings, ValidationsExecutor, AfterMethod, Test, NativeValidationsBuilderUnitTest
+Cohesion: 0.10
+Nodes (3): AfterMethod, Test, NativeValidationsBuilderUnitTest
 
 ### Community 23 - "Community 23"
-Cohesion: 0.06
-Nodes (25): empty(), DoctorHashing, reviewUiPath(), disabled(), McpResultRecordsTest, defaults(), lower(), normalizePath() (+17 more)
+Cohesion: 0.24
+Nodes (5): List, Set, String, Test, TelemetryDeduplicationUnitTest
 
 ### Community 24 - "Community 24"
-Cohesion: 0.05
-Nodes (17): NativeValidationsBuilder, TextDirectionValidationsBuilder, E2ECoverageTests, FileValidationsBuilder, RestValidationsBuilder, String, ValidationsBuilder, WebDriverBrowserValidationsBuilder (+9 more)
+Cohesion: 0.07
+Nodes (9): TextDirectionValidationsBuilder, E2ECoverageTests, NativeValidationsBuilder, ValidationsExecutor, AfterMethod, BeforeMethod, Test, TextDirection (+1 more)
 
 ### Community 25 - "Community 25"
-Cohesion: 0.06
-Nodes (20): PathParamTest, SwaggerContractTest, AssertApiResponseEqualsTests, GraphqlRequestTests, Map, AfterClass, BeforeClass, Test (+12 more)
+Cohesion: 0.05
+Nodes (27): PathParamTest, TestUpload, AssertApiResponseEqualsTests, BasicAPITests, GraphqlRequestTests, Map, Object, ParametersType (+19 more)
 
 ### Community 26 - "Community 26"
-Cohesion: 0.19
-Nodes (8): DoctorRepairPublicationRequest, ExistingPullRequest, DoctorRepairService, DoctorRepairRequest, Path, RepairProposal, RepairPublicationResult, String
+Cohesion: 0.05
+Nodes (47): AllureVerdict, DoctorRepairPublicationRequest, ExistingPullRequest, GuardedPatch, PatchManifestEntry, RecordingRunner, changedSince(), DoctorRepairService (+39 more)
 
 ### Community 27 - "Community 27"
 Cohesion: 0.09
-Nodes (18): FileActions, FileActionsCoverageUnitTest, Boolean, Collection, File, String, SuppressWarnings, TerminalActions (+10 more)
+Nodes (20): FileActions, FileActionsCoverageUnitTest, JarEntry, Boolean, Collection, Exception, File, String (+12 more)
 
 ### Community 28 - "Community 28"
 Cohesion: 0.07
 Nodes (14): DriverFactoryHelperCoverageUnitTest, TestableDriverFactoryHelper, AfterMethod, AtomicInteger, CountDownLatch, DriverFactoryHelper, DriverType, Method (+6 more)
 
 ### Community 29 - "Community 29"
-Cohesion: 0.12
-Nodes (8): XpathAxis, Role, LocatorBuilder, String, Override, AfterMethod, Test, LocatorBuilderExtendedUnitTest
+Cohesion: 0.11
+Nodes (8): JunitCoreAssertionMigrationTest, MobileRecordingServiceTest, Role, Test, AfterMethod, Test, Test, LocatorBuilderExtendedUnitTest
 
 ### Community 30 - "Community 30"
 Cohesion: 0.08
 Nodes (6): Flags, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 31 - "Community 31"
-Cohesion: 0.10
+Cohesion: 0.09
 Nodes (12): Boolean, AfterMethod, BeforeMethod, Class, List, Object, Path, String (+4 more)
+
+### Community 32 - "Community 32"
+Cohesion: 0.07
+Nodes (7): Boolean, NumbersComparativeRelation, Object, String, Test, JavaHelper, JavaHelperUnitTest
 
 ### Community 33 - "Community 33"
 Cohesion: 0.13
@@ -790,71 +804,71 @@ Nodes (13): AccessibilityConfig, AccessibilityHelper, JSONArray, JSONObject, Acc
 
 ### Community 34 - "Community 34"
 Cohesion: 0.08
-Nodes (11): NumberValidationsBuilder, Number, Object, Override, RestValidationsBuilder, SuppressWarnings, ValidationsBuilder, ValidationsExecutor (+3 more)
+Nodes (12): NumberValidationsBuilder, Number, Object, Override, RestValidationsBuilder, SuppressWarnings, ValidationsBuilder, ValidationsExecutor (+4 more)
 
 ### Community 35 - "Community 35"
-Cohesion: 0.11
-Nodes (15): ArtifactPaths, CaptureGenerator, CaptureEnrichmentPreview, CaptureGenerationReport, CaptureGenerationRequest, CaptureGenerationResult, CaptureReview, CaptureSession (+7 more)
+Cohesion: 0.06
+Nodes (43): AlertEvent, ArtifactPaths, AssertionSuggestion, DataPlan, CaptureGenerator, failure(), MutableTargetPlan, withUnsupported() (+35 more)
 
 ### Community 36 - "Community 36"
 Cohesion: 0.07
-Nodes (29): DataTableArgument, EmbedEvent, HookTestStep, CucumberFeatureListener, PickleStepTestStep, Result, Scenario, AllureLifecycle (+21 more)
+Nodes (27): DataTableArgument, EmbedEvent, HookTestStep, CucumberFeatureListener, Parameter, PickleStepTestStep, Result, Scenario (+19 more)
 
 ### Community 37 - "Community 37"
-Cohesion: 0.09
+Cohesion: 0.10
 Nodes (7): AfterMethod, Class, Object, Path, String, Test, AllureManagerUnitTest
 
 ### Community 38 - "Community 38"
-Cohesion: 0.13
-Nodes (5): NumberValidationsBuilder, AfterMethod, BeforeClass, Test, RestValidationsBuilderUnitTest
+Cohesion: 0.15
+Nodes (4): AfterMethod, BeforeClass, Test, RestValidationsBuilderUnitTest
 
 ### Community 39 - "Community 39"
-Cohesion: 0.15
-Nodes (4): LocatorMockedTests, ShadowLocatorBuilder, Test, XpathAxis
+Cohesion: 0.10
+Nodes (6): LocatorMockedTests, ShadowLocatorBuilder, Test, Test, LocatorBuilderUnitTest, XpathAxis
 
 ### Community 40 - "Community 40"
-Cohesion: 0.10
-Nodes (29): DoctorAiAnalysisService, ConfigurationIdentity, Metadata, asCacheHit(), disabled(), empty(), AiRequest, AiResponse (+21 more)
+Cohesion: 0.12
+Nodes (23): DoctorAiAnalysisService, ConfigurationIdentity, AiRequest, AiResponse, AiResponseStatus, AiUsage, CauseCategory, Diagnosis (+15 more)
 
 ### Community 41 - "Community 41"
-Cohesion: 0.09
-Nodes (9): ApiActionsMockedTests, RequestBuilder, AfterMethod, BeforeMethod, Test, AfterClass, BeforeClass, Test (+1 more)
+Cohesion: 0.08
+Nodes (11): MatchJsonSchemaTests, ApiActionsMockedTests, RequestBuilder, Test, AfterMethod, BeforeMethod, Test, AfterClass (+3 more)
 
 ### Community 42 - "Community 42"
 Cohesion: 0.20
 Nodes (8): DesktopVideoConsumer, IVideoRecorder, File, InputStream, Override, String, SuppressWarnings, AutomationRemarksDesktopVideoRecordingProvider
 
 ### Community 43 - "Community 43"
-Cohesion: 0.08
-Nodes (27): Constructor, IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, IResultListener2 (+19 more)
+Cohesion: 0.07
+Nodes (28): Constructor, IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, IResultListener2 (+20 more)
 
 ### Community 44 - "Community 44"
-Cohesion: 0.16
-Nodes (8): AssertionSteps, PDFTests, ValidationsBuilderTests, String, Then, ThreadLocal, WebDriver, String
+Cohesion: 0.17
+Nodes (6): AssertionSteps, PDFTests, ValidationsBuilderTests, String, Then, String
 
 ### Community 45 - "Community 45"
-Cohesion: 0.17
-Nodes (15): CollectionState, EvidenceCollector, CollectionState, DoctorRedactor, DefaultPrettyPrinter, DoctorAnalysisRequest, EvidenceBundle, EvidenceCategory (+7 more)
+Cohesion: 0.16
+Nodes (16): CollectionState, EvidenceCollector, FilesSize, CollectionState, DoctorRedactor, DefaultPrettyPrinter, DoctorAnalysisRequest, EvidenceBundle (+8 more)
 
 ### Community 46 - "Community 46"
-Cohesion: 0.09
-Nodes (24): allows(), ApprovalPolicy(), denyAll(), CaptureFixtures, defaults(), CaptureGeneratorTest, PageContext, CaptureGenerationRequest (+16 more)
+Cohesion: 0.11
+Nodes (19): denyAll(), CaptureFixtures, defaults(), CaptureGeneratorTest, PageContext, CaptureGenerationRequest, Path, BrowserMetadata (+11 more)
 
 ### Community 47 - "Community 47"
-Cohesion: 0.10
-Nodes (7): AsyncElementActionsCoverageUnitTest, Test, AfterMethod, Path, String, Test, ThreadLocalPropertiesTest
+Cohesion: 0.13
+Nodes (5): AfterMethod, Path, String, Test, ThreadLocalPropertiesTest
 
 ### Community 48 - "Community 48"
 Cohesion: 0.13
-Nodes (17): RestActions, RequestSpecBuilder, RestAssuredConfig, API, ArrayNode, Boolean, ContentType, Deprecated (+9 more)
+Nodes (18): RestActions, RequestSpecBuilder, RestAssuredConfig, API, ArrayNode, Boolean, ContentType, Deprecated (+10 more)
 
 ### Community 49 - "Community 49"
-Cohesion: 0.06
-Nodes (26): ClassLoader, ImageProcessingActions, ImageProcessingActionsCoverageUnitTest, OpenCvBlockingClassLoader, Boolean, By, File, Integer (+18 more)
+Cohesion: 0.11
+Nodes (14): ImageProcessingActionsCoverageUnitTest, List, Override, AfterMethod, BeforeMethod, BufferedImage, Color, DataProvider (+6 more)
 
 ### Community 50 - "Community 50"
-Cohesion: 0.09
-Nodes (10): BooleanSupplier, Future, AllureManager, ArrayNode, InputStream, List, ObjectNode, Path (+2 more)
+Cohesion: 0.10
+Nodes (10): AllureManager, BooleanSupplier, ArrayNode, Future, InputStream, List, ObjectNode, Path (+2 more)
 
 ### Community 51 - "Community 51"
 Cohesion: 0.08
@@ -865,20 +879,20 @@ Cohesion: 0.04
 Nodes (47): additionalProperties, minLength, type, maximum, minimum, type, type, minLength (+39 more)
 
 ### Community 53 - "Community 53"
-Cohesion: 0.08
-Nodes (23): AttachmentFormat, CaptureJsonCodec, InputStream, AttachmentReporter, CaptureSession, JsonNode, Path, String (+15 more)
+Cohesion: 0.39
+Nodes (6): ByteArrayOutputStream, Severity, Story, String, Test, AllAttachmentTypesTest
 
 ### Community 54 - "Community 54"
-Cohesion: 0.10
-Nodes (7): BrowserActions, Cookie, Override, Screenshots, Set, String, SuppressWarnings
+Cohesion: 0.09
+Nodes (8): BrowserActions, Cookie, Override, Screenshots, Set, String, SuppressWarnings, Window
 
 ### Community 55 - "Community 55"
 Cohesion: 0.12
 Nodes (16): Capabilities, ClientConfig, DriverFactoryHelper, Class, DriverType, List, MutableCapabilities, Object (+8 more)
 
 ### Community 56 - "Community 56"
-Cohesion: 0.14
-Nodes (7): Mobile, SetProperty, PropertiesManagerTests, DefaultValue, Key, SetProperty, String
+Cohesion: 0.06
+Nodes (16): Jira, SetProperty, Mobile, SetProperty, PropertiesManagerTests, JiraTests, DefaultValue, Key (+8 more)
 
 ### Community 57 - "Community 57"
 Cohesion: 0.08
@@ -889,35 +903,35 @@ Cohesion: 0.11
 Nodes (34): AllureFailure, _clean_cell(), extract_failures(), extract_surefire_failures(), _failure_group_key(), _first_trace_line(), _is_allure_test_result_payload(), _is_generated_report_non_test_result() (+26 more)
 
 ### Community 59 - "Community 59"
-Cohesion: 0.10
-Nodes (15): ImageComparisonTests, List, Color, Rectangle, Test, AfterMethod, BeforeMethod, Color (+7 more)
+Cohesion: 0.08
+Nodes (21): ImageProcessingActions, Boolean, By, Color, File, Integer, List, Rectangle (+13 more)
 
 ### Community 60 - "Community 60"
-Cohesion: 0.15
-Nodes (3): SetProperty, Deprecated, String
+Cohesion: 0.09
+Nodes (8): SetProperty, Timeouts, Boolean, DefaultValue, Deprecated, Key, SetProperty, String
 
 ### Community 61 - "Community 61"
 Cohesion: 0.13
 Nodes (21): ExchangeHandler, FailureCase, ExchangeHandler, ProviderConformanceTest, AfterEach, AiProvider, AiRequest, AiResponse (+13 more)
 
 ### Community 62 - "Community 62"
-Cohesion: 0.16
-Nodes (17): DoctorRepairProposalResult, DoctorRepairService, HealingLocatorProposalRequest, DoctorService, ApprovalPolicy, Diagnosis, DoctorAnalysisResult, DoctorAnalysisSummary (+9 more)
+Cohesion: 0.10
+Nodes (23): DoctorRepairProposalResult, DoctorRepairService, HealingLocatorProposalRequest, DoctorService, DoctorServiceTest, McpDoctorRemediationService, ApprovalPolicy, Diagnosis (+15 more)
 
 ### Community 63 - "Community 63"
-Cohesion: 0.17
-Nodes (6): ClipboardAction, GetElementInformation, By, ClipboardAction, Override, Step
+Cohesion: 0.10
+Nodes (16): ElementLookup, GetElementInformation, Actions, ClipboardAction, GetElementInformation, Beta, By, ClipboardAction (+8 more)
 
 ### Community 64 - "Community 64"
-Cohesion: 0.09
-Nodes (22): UnitTestsRestActions, ActionsCoverageUnitTest, RecordingActions, Parameter, RecordingActions, ActionType, AfterMethod, AllureLifecycle (+14 more)
+Cohesion: 0.16
+Nodes (12): ActionsCoverageUnitTest, RecordingActions, ActionType, By, Class, Object, Override, StepResult (+4 more)
 
 ### Community 65 - "Community 65"
 Cohesion: 0.12
-Nodes (15): AllureListenerCoverageUnitTest, Throwable, AfterMethod, BeforeMethod, ITestResult, List, Path, String (+7 more)
+Nodes (15): AllureListenerCoverageUnitTest, Throwable, Status, AfterMethod, BeforeMethod, ITestResult, List, Path (+7 more)
 
 ### Community 66 - "Community 66"
-Cohesion: 0.14
+Cohesion: 0.15
 Nodes (11): ContainerLifecycleListener, FixtureLifecycleListener, FixtureResult, AllureListener, AllureLifecycle, Override, StepResult, TestResult (+3 more)
 
 ### Community 67 - "Community 67"
@@ -925,8 +939,8 @@ Cohesion: 0.11
 Nodes (11): COSDocument, DeleteFileAfterValidationStatus, PdfFileManager, PDFParser, RandomAccessReadBufferedFile, File, String, AfterMethod (+3 more)
 
 ### Community 68 - "Community 68"
-Cohesion: 0.15
-Nodes (19): McpDoctorRemediationService, McpActionRecord, ProviderBlocks, AiRequest, AiResponse, ApprovalPolicy, Diagnosis, DoctorAnalysisResult (+11 more)
+Cohesion: 0.14
+Nodes (20): McpDoctorRemediationService, McpActionRecord, ProviderBlocks, AiRequest, AiResponse, ApprovalPolicy, Diagnosis, DoctorAnalysisResult (+12 more)
 
 ### Community 69 - "Community 69"
 Cohesion: 0.05
@@ -949,19 +963,19 @@ Cohesion: 0.11
 Nodes (41): expand_globs(), issue(), local_link_targets(), markdown_body(), normalized_paragraphs(), parse_frontmatter(), quoted_yaml_value(), Keep the consolidated guidance below the approved baseline reduction. (+33 more)
 
 ### Community 74 - "Community 74"
-Cohesion: 0.16
-Nodes (14): ElementActionsHelper, TextDetectionStrategy(), Boolean, By, Class, ClipboardAction, HealingResolution, List (+6 more)
+Cohesion: 0.15
+Nodes (15): ElementActionsHelper, TextDetectionStrategy(), Boolean, By, Class, ClipboardAction, HealingResolution, List (+7 more)
 
 ### Community 75 - "Community 75"
 Cohesion: 0.14
 Nodes (20): CaptureControlClient, CaptureCli, flag(), parse(), path(), pathRequired(), required(), value() (+12 more)
 
 ### Community 76 - "Community 76"
-Cohesion: 0.13
-Nodes (15): ShaftHeal, ShaftHealingProviderTest, HealingReport, Optional, AfterMethod, AppiumDriver, BeforeMethod, DataProvider (+7 more)
+Cohesion: 0.09
+Nodes (21): ShaftHeal, ShaftHealingProviderTest, WebDomHealingAcceptanceTest, HealingReport, Optional, AfterMethod, AppiumDriver, BeforeMethod (+13 more)
 
 ### Community 77 - "Community 77"
-Cohesion: 0.07
+Cohesion: 0.08
 Nodes (7): LambdaTest, SetProperty, Boolean, DefaultValue, Key, SetProperty, String
 
 ### Community 78 - "Community 78"
@@ -977,15 +991,15 @@ Cohesion: 0.10
 Nodes (12): DriverFactoryHelper, OptionsManager, AfterMethod, AtomicInteger, CountDownLatch, DriverType, Method, MutableCapabilities (+4 more)
 
 ### Community 81 - "Community 81"
-Cohesion: 0.13
-Nodes (9): IIOMetadataNode, AnimatedGifManager, ImageOutputStream, ImageWriter, getType(), RenderedImage, Screenshots, BufferedImage (+1 more)
+Cohesion: 0.12
+Nodes (9): IIOMetadataNode, AnimatedGifManager, GifSession, ImageOutputStream, ImageWriter, RenderedImage, BufferedImage, String (+1 more)
 
 ### Community 82 - "Community 82"
 Cohesion: 0.20
 Nodes (6): CheckpointType, CheckpointCounter, CheckpointStatus, String, Test, CheckpointAndReportingTest
 
 ### Community 83 - "Community 83"
-Cohesion: 0.20
+Cohesion: 0.19
 Nodes (4): LocatorBuilderTest, AfterMethod, BeforeMethod, Test
 
 ### Community 84 - "Community 84"
@@ -997,8 +1011,8 @@ Cohesion: 0.14
 Nodes (14): ClassifiedUpload, CapturePrivacyClassifier, CapturePrivacyClassifierTest, SanitizedAttributes, SanitizedText, CapturePrivacyPolicy, ClassifiedValue, List (+6 more)
 
 ### Community 87 - "Community 87"
-Cohesion: 0.10
-Nodes (15): HasCdp, Image, ScreenshotHelper, ScreenshotHelperCoverageUnitTest, Boolean, BufferedImage, String, SuppressWarnings (+7 more)
+Cohesion: 0.13
+Nodes (11): HasCdp, Image, ScreenshotHelperCoverageUnitTest, BufferedImage, String, AfterMethod, BeforeMethod, Color (+3 more)
 
 ### Community 88 - "Community 88"
 Cohesion: 0.05
@@ -1009,16 +1023,16 @@ Cohesion: 0.07
 Nodes (14): be(), Bt(), Dt(), $e(), Ee(), ft(), ke(), l() (+6 more)
 
 ### Community 90 - "Community 90"
-Cohesion: 0.12
-Nodes (11): ElementActions, Actions, By, DriverFactoryHelper, List, Map, Override, String (+3 more)
+Cohesion: 0.13
+Nodes (9): ElementActions, Actions, By, DriverFactoryHelper, Override, String, SuppressWarnings, WebDriver (+1 more)
 
 ### Community 91 - "Community 91"
-Cohesion: 0.19
-Nodes (8): EngineService, PostConstruct, BrowserType, By, Path, String, Tool, WebDriver
+Cohesion: 0.11
+Nodes (12): Executable, EngineService, McpNoDriverServiceTest, PostConstruct, BrowserType, Path, String, Tool (+4 more)
 
 ### Community 92 - "Community 92"
-Cohesion: 0.11
-Nodes (7): ArrayList, LocatorBuilder, RelativeBy, By, Role, String, SuppressWarnings
+Cohesion: 0.06
+Nodes (18): ArrayList, LocatorBuilder, ShadowDomTest, JDK21VirtualThreadsAndAsyncActionsTests, MultipleBrowserInstancesTest, RelativeBy, By, Role (+10 more)
 
 ### Community 93 - "Community 93"
 Cohesion: 0.06
@@ -1033,24 +1047,24 @@ Cohesion: 0.16
 Nodes (14): AiExecutionServiceTest, StubProvider, AiCapabilities, AiExecutionService, AiProviderAvailability, AiProviderRegistry, AiRequest, AiResponse (+6 more)
 
 ### Community 96 - "Community 96"
-Cohesion: 0.16
-Nodes (19): DoctorAiAnalysisServiceTest, AiBudget, EnumSource, from(), DoctorAnalysisResult, DoctorAnalysisSummary, AiRequest, AiResponse (+11 more)
+Cohesion: 0.17
+Nodes (18): DoctorAiAnalysisServiceTest, EnumSource, from(), DoctorAnalysisResult, DoctorAnalysisSummary, AiRequest, AiResponse, AiResponseStatus (+10 more)
 
 ### Community 97 - "Community 97"
 Cohesion: 0.13
 Nodes (16): AlertActionsContext, AlertActions, DriverFactoryHelper, String, SuppressWarnings, WebDriver, AfterMethod, Alert (+8 more)
 
 ### Community 98 - "Community 98"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (11): FluentWait, ElementsHelperCoverageUnitTest, MockedStatic, AfterMethod, BeforeMethod, DriverFactoryHelper, MockedConstruction, RuntimeException (+3 more)
 
 ### Community 99 - "Community 99"
-Cohesion: 0.17
-Nodes (16): RecordingRunner, DoctorRepairServiceTest, RecordingRunner, validationPassed(), RepairProcessRunner, RepositoryFixture, DoctorRepairRequest, Duration (+8 more)
+Cohesion: 0.11
+Nodes (13): McpMobileToolchainService, McpAndroidEmulatorProposal, Duration, List, Map, McpMobileDevice, McpMobileToolchainStatus, McpProcessRunner (+5 more)
 
 ### Community 100 - "Community 100"
-Cohesion: 0.19
-Nodes (9): ElementService, LocatorOperation, By, Deprecated, LocatorOperation, locatorStrategy, String, Tool (+1 more)
+Cohesion: 0.18
+Nodes (10): ElementService, LocatorOperation, By, Deprecated, LocatorOperation, locatorStrategy, String, Tool (+2 more)
 
 ### Community 101 - "Community 101"
 Cohesion: 0.12
@@ -1069,8 +1083,8 @@ Cohesion: 0.13
 Nodes (6): Healing, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 105 - "Community 105"
-Cohesion: 0.13
-Nodes (11): ChannelSftp, TerminalActions, ProcessBuilder, Session, SftpTransferDirection, Boolean, Deprecated, List (+3 more)
+Cohesion: 0.10
+Nodes (16): ChannelSftp, TerminalActions, ProcessBuilder, SftpTransferDirection, Boolean, BufferedReader, Deprecated, Exception (+8 more)
 
 ### Community 106 - "Community 106"
 Cohesion: 0.11
@@ -1085,16 +1099,16 @@ Cohesion: 0.13
 Nodes (38): add_text_child(), child_text(), copy_dependency_metadata(), create_dependency(), dependency_coordinate(), dependency_template(), direct_child(), elements_named() (+30 more)
 
 ### Community 109 - "Community 109"
-Cohesion: 0.15
-Nodes (8): ManagedCaptureRecorder, BrowserSignal, CaptureStatus, CheckpointKind, Map, Object, String, WebDriver
+Cohesion: 0.11
+Nodes (15): CaptureEventPipeline, CapturePrivacyClassifier, ManagedCaptureRecorder, BrowserMetadata, BrowserSignal, CapturePrivacyPolicy, CaptureSessionStore, CaptureStartRequest (+7 more)
 
 ### Community 110 - "Community 110"
 Cohesion: 0.16
 Nodes (3): YAMLFileManagerTests, BeforeMethod, Test
 
 ### Community 111 - "Community 111"
-Cohesion: 0.15
-Nodes (15): LauncherSession, Override, AfterMethod, BeforeMethod, Duration, List, Object, Optional (+7 more)
+Cohesion: 0.13
+Nodes (17): getType(), LauncherSession, Screenshots, Override, AfterMethod, BeforeMethod, Duration, List (+9 more)
 
 ### Community 112 - "Community 112"
 Cohesion: 0.18
@@ -1105,8 +1119,8 @@ Cohesion: 0.19
 Nodes (7): Log4j, Log4jTests, DefaultValue, Key, String, BeforeClass, Test
 
 ### Community 114 - "Community 114"
-Cohesion: 0.18
-Nodes (12): YAMLFileManager, Boolean, Class, Date, Double, Integer, List, Long (+4 more)
+Cohesion: 0.16
+Nodes (13): FileInputStream, YAMLFileManager, Boolean, Class, Date, Double, Integer, List (+5 more)
 
 ### Community 115 - "Community 115"
 Cohesion: 0.15
@@ -1129,28 +1143,28 @@ Cohesion: 0.14
 Nodes (12): AccessibilityResult, AccessibilityHelperCoverageUnitTest, AxeBuilder, AfterMethod, List, MockedConstruction, Path, Results (+4 more)
 
 ### Community 120 - "Community 120"
-Cohesion: 0.11
-Nodes (12): CSVFileManager, API, CSV, Report, YAML, InputStream, List, Object (+4 more)
+Cohesion: 0.14
+Nodes (16): McpMobileInspectorRecordingService, Session, Duration, List, Map, McpCodeBlock, McpMobileDevice, McpMobileInspectorPlan (+8 more)
 
 ### Community 121 - "Community 121"
 Cohesion: 0.21
 Nodes (4): Path, String, Test, AttachmentReporterUnitTest
 
 ### Community 122 - "Community 122"
-Cohesion: 0.15
-Nodes (11): CaptureControlFiles, CaptureControlFilesTest, ControlDescriptor, CaptureStartRequest, CaptureStatus, Class, Object, Path (+3 more)
+Cohesion: 0.18
+Nodes (9): CaptureControlFiles, ControlDescriptor, CaptureStartRequest, CaptureStatus, Class, Object, Path, String (+1 more)
 
 ### Community 123 - "Community 123"
 Cohesion: 0.16
 Nodes (8): IAssert, CustomSoftAssert, AssertionError, Override, String, Test, SoftAssert, CustomSoftAssertTest
 
 ### Community 124 - "Community 124"
-Cohesion: 0.12
-Nodes (9): TestNGListenerHelper, ISuite, ITestContext, ITestNGMethod, ITestResult, List, Method, String (+1 more)
+Cohesion: 0.11
+Nodes (8): TestNGListenerHelper, ISuite, ITestContext, ITestNGMethod, ITestResult, List, Method, String
 
 ### Community 125 - "Community 125"
-Cohesion: 0.14
-Nodes (4): AfterMethod, BeforeClass, Test, JSONFileManagerUnitTest
+Cohesion: 0.06
+Nodes (20): DataType, FileReader, JSONFileManager, JSONFileManagerTestAccessor, JSONFileManagerTests, List, Map, Object (+12 more)
 
 ### Community 126 - "Community 126"
 Cohesion: 0.16
@@ -1158,7 +1172,7 @@ Nodes (12): ITestNGService, AfterMethod, ITestNGMethod, ITestResult, List, Objec
 
 ### Community 127 - "Community 127"
 Cohesion: 0.14
-Nodes (18): DeterministicRuleEngine, DoctorAnalyzer, DoctorReportWriter, DoctorTriage, EvidenceCollector, ExecutionIntelligence, Diagnosis, DoctorAiAnalysisRequest (+10 more)
+Nodes (19): DeterministicRuleEngine, DoctorAnalyzer, DoctorAiAnalysisResult, DoctorReportWriter, DoctorTriage, EvidenceCollector, ExecutionIntelligence, Diagnosis (+11 more)
 
 ### Community 128 - "Community 128"
 Cohesion: 0.12
@@ -1173,28 +1187,28 @@ Cohesion: 0.13
 Nodes (3): ActionsCoverageTests, BeforeMethod, Test
 
 ### Community 131 - "Community 131"
-Cohesion: 0.11
-Nodes (11): Browser, ShadowDomTest, CoverageTests, AfterMethod, BeforeMethod, Test, AfterClass, AfterMethod (+3 more)
+Cohesion: 0.12
+Nodes (11): Browser, CoverageTests, HoverTests, AfterClass, AfterMethod, BeforeClass, BeforeMethod, Test (+3 more)
 
 ### Community 132 - "Community 132"
 Cohesion: 0.14
 Nodes (14): BadRequestException, CaptureControlServer, Handler, Handler, CaptureControlFiles, CaptureManager, CaptureStatus, Class (+6 more)
 
 ### Community 133 - "Community 133"
-Cohesion: 0.16
+Cohesion: 0.15
 Nodes (12): Config, List, String, SuppressWarnings, AfterMethod, BeforeMethod, HttpExchange, Object (+4 more)
 
 ### Community 134 - "Community 134"
-Cohesion: 0.07
-Nodes (26): BomConsumer, OpenCvVisualProcessingProvider, AlphaProvider, VisualProcessingProviderRegistryTest, ZuluProvider, AfterMethod, Boolean, By (+18 more)
+Cohesion: 0.06
+Nodes (26): BomConsumer, OpenCvVisualConsumer, HealingVisualProvider, OpenCvHealingVisualProvider, OpenCvHealingVisualProviderTest, AlphaProvider, VisualProcessingProviderRegistryTest, ZuluProvider (+18 more)
 
 ### Community 135 - "Community 135"
 Cohesion: 0.18
 Nodes (12): ScreenshotManager, Object, Boolean, By, JavascriptExecutor, List, Object, Screenshots (+4 more)
 
 ### Community 136 - "Community 136"
-Cohesion: 0.14
-Nodes (9): Platform, SetProperty, PlatformTests, DefaultValue, Key, SetProperty, String, BeforeClass (+1 more)
+Cohesion: 0.20
+Nodes (6): Platform, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 137 - "Community 137"
 Cohesion: 0.12
@@ -1206,23 +1220,23 @@ Nodes (4): AccessibilityTest, AfterMethod, BeforeMethod, Test
 
 ### Community 139 - "Community 139"
 Cohesion: 0.09
-Nodes (19): ready(), unavailable(), builder(), evidenceCategories(), withSanitizedContent(), withTimeout(), AiValueObjectsTest, AiProviderAvailability (+11 more)
+Nodes (18): builder(), evidenceCategories(), withSanitizedContent(), withTimeout(), AiValueObjectsTest, AiImage, AiRequest, ApprovalPolicy (+10 more)
 
 ### Community 140 - "Community 140"
 Cohesion: 0.33
 Nodes (3): Validations, StandaloneAssertions, StandaloneVerifications
 
 ### Community 141 - "Community 141"
-Cohesion: 0.11
-Nodes (25): AiTrigger, HealingProvider, ShaftHealingProvider, safe(), stableKey(), HealingActionOutcome, HealingCandidate, HealingConfiguration (+17 more)
+Cohesion: 0.12
+Nodes (22): AiTrigger, HealingProvider, ShaftHealingProvider, HealingActionOutcome, HealingCandidate, HealingConfiguration, HealingContext, HealingDecision (+14 more)
 
 ### Community 142 - "Community 142"
 Cohesion: 0.23
 Nodes (7): HealingHistoryStoreTest, AfterMethod, HealingConfiguration, Map, Object, String, Test
 
 ### Community 143 - "Community 143"
-Cohesion: 0.10
-Nodes (14): AndroidDriver, AndroidBasicInteractionsTests, getValue(), KeyboardKeys(), ElementActionsHelper, ImmutableMap, IOSDriver, ScreenOrientation (+6 more)
+Cohesion: 0.13
+Nodes (7): AndroidBasicInteractionsTests, AndroidDragAndDropTest, MobileTest, Test, Test, AfterMethod, BeforeMethod
 
 ### Community 144 - "Community 144"
 Cohesion: 0.15
@@ -1233,52 +1247,52 @@ Cohesion: 0.17
 Nodes (9): ElementSteps, getValue(), LocatorType(), By, String, SuppressWarnings, ThreadLocal, WebDriver (+1 more)
 
 ### Community 146 - "Community 146"
-Cohesion: 0.19
-Nodes (6): ElementLookup, GetElementInformation, Actions, JavascriptExecutor, String, WebElement
+Cohesion: 0.13
+Nodes (15): Builder, Controller, Headers, Controller, McpAppiumInspectorProxy, McpAppiumCommandRecorder, HttpExchange, HttpResponse (+7 more)
 
 ### Community 147 - "Community 147"
-Cohesion: 0.18
-Nodes (13): DoctorRepairPatchResult, DoctorRepairAiService, AiRequest, AiResponse, AiResponseStatus, Diagnosis, DoctorRepairAiRequest, EvidenceReference (+5 more)
+Cohesion: 0.19
+Nodes (11): LocatorRef, McpAppiumCommandRecorder, PointerGesture, BooleanSupplier, JsonNode, locatorStrategy, Map, McpMobileRecordedAction (+3 more)
 
 ### Community 148 - "Community 148"
 Cohesion: 0.12
 Nodes (11): FluentWebDriverAction, SelectedValueTests, Actions, AlertActions, BrowserActions, DriverFactoryHelper, TouchActions, WebDriver (+3 more)
 
 ### Community 149 - "Community 149"
-Cohesion: 0.07
-Nodes (20): Async, AsyncElementActions, Async, CLI, GUI, Locator, Properties, TestData (+12 more)
+Cohesion: 0.04
+Nodes (36): Async, AsyncElementActions, CSVFileManager, DatabaseActions, API, Async, CLI, CSV (+28 more)
 
 ### Community 150 - "Community 150"
 Cohesion: 0.17
 Nodes (15): CaptureEnrichmentService, AiRequest, AiResponse, ApprovalPolicy, CaptureEnrichmentPreview, CaptureEvent, CaptureSession, ElementSnapshot (+7 more)
 
 ### Community 151 - "Community 151"
-Cohesion: 0.28
+Cohesion: 0.27
 Nodes (8): FingerprintExtractor, HealingConfiguration, LocatorFingerprint, Map, String, Supplier, WebDriver, WebElement
 
 ### Community 152 - "Community 152"
-Cohesion: 0.19
+Cohesion: 0.18
 Nodes (11): ManagedCaptureRecorder, CaptureManager, CaptureStartRequest, CaptureStatus, CheckpointKind, Function, ManagedCaptureRecorder, Override (+3 more)
 
 ### Community 153 - "Community 153"
-Cohesion: 0.15
-Nodes (13): McpMobileRecordingService, McpMobileRecording, McpProviderFallback, List, locatorStrategy, Map, McpCodeBlock, McpMobileRecordedAction (+5 more)
+Cohesion: 0.16
+Nodes (12): McpMobileRecordingService, McpMobileRecording, List, locatorStrategy, Map, McpCodeBlock, McpMobileRecordedAction, McpMobileRecordingStatus (+4 more)
 
 ### Community 154 - "Community 154"
 Cohesion: 0.08
 Nodes (24): enum, additionalProperties, allOf, enum, $id, pattern, type, type (+16 more)
 
 ### Community 155 - "Community 155"
-Cohesion: 0.18
-Nodes (7): AfterClass, AfterMethod, SuppressWarnings, Test, ThreadLocal, WebDriver, RecordManagerTest
+Cohesion: 0.17
+Nodes (8): IOSDriver, AfterClass, AfterMethod, SuppressWarnings, Test, ThreadLocal, WebDriver, RecordManagerTest
 
 ### Community 156 - "Community 156"
-Cohesion: 0.18
-Nodes (6): Map, BeforeMethod, AfterMethod, String, Test, PropertyFileManagerUnitTest
+Cohesion: 0.20
+Nodes (5): BeforeMethod, AfterMethod, String, Test, PropertyFileManagerUnitTest
 
 ### Community 157 - "Community 157"
-Cohesion: 0.08
-Nodes (8): PropertiesHelper, RunType, String, String, AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
+Cohesion: 0.20
+Nodes (4): AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
 
 ### Community 158 - "Community 158"
 Cohesion: 0.19
@@ -1289,11 +1303,11 @@ Cohesion: 0.20
 Nodes (7): Actions, SilentElementReader, ValidationsHelper, By, List, String, WebDriver
 
 ### Community 160 - "Community 160"
-Cohesion: 0.10
-Nodes (6): Boolean, By, NumbersComparativeRelation, Object, String, JavaHelper
+Cohesion: 0.14
+Nodes (12): NativeValidationsBuilder, FileValidationsBuilder, Object, Override, RestValidationsBuilder, String, SuppressWarnings, ValidationsBuilder (+4 more)
 
 ### Community 161 - "Community 161"
-Cohesion: 0.09
+Cohesion: 0.08
 Nodes (20): RequestBuilder, RequestBuilderTests, AuthenticationType, API, ContentType, Deprecated, Exception, RequestSpecification (+12 more)
 
 ### Community 162 - "Community 162"
@@ -1301,20 +1315,20 @@ Cohesion: 0.16
 Nodes (3): AfterMethod, Test, ValidationsBuilderUnitTest
 
 ### Community 163 - "Community 163"
-Cohesion: 0.07
-Nodes (26): BigInteger, FirestoreRestClient, Internal, UpdateChecker, UpdateCheckerUnitTest, ThrowingInvocation, WebDriverElementValidationsBuilderCoverageUnitTest, InternalTests (+18 more)
+Cohesion: 0.14
+Nodes (13): FirestoreRestClient, ThrowingInvocation, WebDriverElementValidationsBuilderCoverageUnitTest, Deprecated, String, AfterMethod, NativeValidationsBuilder, String (+5 more)
 
 ### Community 164 - "Community 164"
-Cohesion: 0.14
-Nodes (10): Dimension, BrowserActionsHelper, Boolean, SneakyThrows, String, WebDriver, AfterMethod, BeforeMethod (+2 more)
+Cohesion: 0.24
+Nodes (6): Dimension, BrowserActionsHelper, Boolean, SneakyThrows, String, WebDriver
 
 ### Community 165 - "Community 165"
 Cohesion: 0.06
 Nodes (32): additionalProperties, type, items, type, minimum, type, minimum, type (+24 more)
 
 ### Community 166 - "Community 166"
-Cohesion: 0.20
-Nodes (20): DoctorCli, flag(), optionalPath(), parse(), path(), pathRequired(), paths(), pathsRequired() (+12 more)
+Cohesion: 0.10
+Nodes (33): DoctorCli, flag(), optionalPath(), parse(), path(), pathRequired(), paths(), pathsRequired() (+25 more)
 
 ### Community 167 - "Community 167"
 Cohesion: 0.15
@@ -1325,7 +1339,7 @@ Cohesion: 0.28
 Nodes (9): PollingBrowserEventCollector, BrowserSignal, Consumer, List, Object, Override, Set, String (+1 more)
 
 ### Community 169 - "Community 169"
-Cohesion: 0.18
+Cohesion: 0.16
 Nodes (5): AsyncElementActions, By, ClipboardAction, DriverFactoryHelper, String
 
 ### Community 170 - "Community 170"
@@ -1345,8 +1359,8 @@ Cohesion: 0.12
 Nodes (25): analyze_project(), collect_ai_context(), coordinates_have_supported_runner(), coordinates_have_supported_stack(), dependency_coordinates(), detect_markers(), discover_poms(), format_diff() (+17 more)
 
 ### Community 175 - "Community 175"
-Cohesion: 0.17
-Nodes (13): AiImage, OpenAiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode (+5 more)
+Cohesion: 0.19
+Nodes (12): OpenAiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode, Map (+4 more)
 
 ### Community 176 - "Community 176"
 Cohesion: 0.23
@@ -1361,16 +1375,16 @@ Cohesion: 0.21
 Nodes (18): A(), ba(), c(), D(), E(), G(), i(), j() (+10 more)
 
 ### Community 179 - "Community 179"
-Cohesion: 0.21
-Nodes (10): HealingManager, By, HealingExplanation, HealingProvider, HealingResolution, List, Optional, String (+2 more)
+Cohesion: 0.07
+Nodes (30): HealingManager, current(), HealingStrategy(), parse(), usesHealenium(), usesShaftHeal(), HealingStrategyTest, NaturalActionExecutor (+22 more)
 
 ### Community 180 - "Community 180"
-Cohesion: 0.13
-Nodes (10): GifSession, AnimatedGifManagerCoverageUnitTest, String, TestCaseFinished, AfterMethod, BeforeMethod, Color, Method (+2 more)
+Cohesion: 0.19
+Nodes (7): AnimatedGifManagerCoverageUnitTest, AfterMethod, BeforeMethod, Color, Method, String, Test
 
 ### Community 181 - "Community 181"
-Cohesion: 0.12
-Nodes (10): PropertyFileManager, ThreadLocalPropertiesManager, File, HashMap, MutableCapabilities, Object, Properties, String (+2 more)
+Cohesion: 0.10
+Nodes (12): PropertyFileManager, ThreadLocalPropertiesManager, File, HashMap, Map, MutableCapabilities, Object, Properties (+4 more)
 
 ### Community 182 - "Community 182"
 Cohesion: 0.13
@@ -1389,12 +1403,12 @@ Cohesion: 0.17
 Nodes (3): AfterMethod, Test, TextDirectionValidationsBuilderUnitTest
 
 ### Community 186 - "Community 186"
-Cohesion: 0.17
-Nodes (7): AndroidDragAndDropTest, FileUploadDownloadTest, MobileTest, Test, Test, AfterMethod, BeforeMethod
+Cohesion: 0.23
+Nodes (6): Internal, InternalTests, DefaultValue, Key, String, Test
 
 ### Community 187 - "Community 187"
-Cohesion: 0.19
-Nodes (10): NaturalActionExecutor, By, CharSequence, DriverFactoryHelper, NaturalActionPlan, Object, Set, String (+2 more)
+Cohesion: 0.25
+Nodes (6): AttachmentFormat, AttachmentReporter, ByteArrayOutputStream, Path, String, SuppressWarnings
 
 ### Community 188 - "Community 188"
 Cohesion: 0.09
@@ -1409,8 +1423,8 @@ Cohesion: 0.08
 Nodes (27): additionalProperties, items, type, $id, type, properties, blockers, provider (+19 more)
 
 ### Community 191 - "Community 191"
-Cohesion: 0.22
-Nodes (11): AllureSummary, Diagnostic, GeneratedTestValidator, JarEntry, JarFile, JavaFileObject, Duration, List (+3 more)
+Cohesion: 0.23
+Nodes (10): AllureSummary, Diagnostic, GeneratedTestValidator, JarFile, JavaFileObject, Duration, List, Path (+2 more)
 
 ### Community 192 - "Community 192"
 Cohesion: 0.18
@@ -1421,12 +1435,12 @@ Cohesion: 0.19
 Nodes (6): Healenium, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 194 - "Community 194"
-Cohesion: 0.17
+Cohesion: 0.16
 Nodes (8): KeysetHandle, GoogleTink, GoogleTinkApiCoverageUnitTest, String, AfterMethod, BeforeMethod, Path, Test
 
 ### Community 195 - "Community 195"
-Cohesion: 0.18
-Nodes (10): AfterMethod, Map, Object, String, SuppressWarnings, Test, Throwable, ThrowingRunnable (+2 more)
+Cohesion: 0.30
+Nodes (11): McpProcessRunner, SystemProcessRunner, Duration, InputStream, List, Map, Override, Path (+3 more)
 
 ### Community 196 - "Community 196"
 Cohesion: 0.20
@@ -1437,8 +1451,8 @@ Cohesion: 0.32
 Nodes (9): CaptureEventPipelineTest, BrowserSignal, CaptureSessionStore, Instant, Map, Object, Path, String (+1 more)
 
 ### Community 198 - "Community 198"
-Cohesion: 0.12
-Nodes (9): JunitCoreAssertionMigrationTest, LocalShellTests, MobileRecordingServiceTest, Method, Test, Test, Test, Test (+1 more)
+Cohesion: 0.21
+Nodes (3): Method, Test, JavaScriptWaitManagerUnitTest
 
 ### Community 199 - "Community 199"
 Cohesion: 0.18
@@ -1449,11 +1463,11 @@ Cohesion: 0.18
 Nodes (3): AfterMethod, Test, RestActionsUtilsUnitTest
 
 ### Community 201 - "Community 201"
-Cohesion: 0.18
-Nodes (7): RestValidationsBuilder, JSONValidationsBuilder, JsonCompareWithSpecialCharactersTests, NativeValidationsBuilder, String, ValidationsExecutor, Test
+Cohesion: 0.29
+Nodes (5): RestValidationsBuilder, JSONValidationsBuilder, NativeValidationsBuilder, String, ValidationsExecutor
 
 ### Community 202 - "Community 202"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (12): ChromiumOptions, DesiredCapabilities, OptionsManager, OptionsManagerCoverageUnitTest, LoggingPreferences, DriverType, MutableCapabilities, String (+4 more)
 
 ### Community 203 - "Community 203"
@@ -1461,31 +1475,31 @@ Cohesion: 0.14
 Nodes (10): Session1Test, SwitchToNewTabTest, AfterMethod, BeforeMethod, String, Test, AfterMethod, BeforeMethod (+2 more)
 
 ### Community 204 - "Community 204"
-Cohesion: 0.38
-Nodes (4): McpWorkspacePolicy, List, Path, String
+Cohesion: 0.16
+Nodes (10): CaptureFormatException, McpResultRecordsTest, McpWorkspacePolicy, String, Throwable, IllegalArgumentException, List, Path (+2 more)
 
 ### Community 205 - "Community 205"
 Cohesion: 0.15
 Nodes (8): ReportContext, JunitReportContextTest, Consumer, List, String, TestExecutionInfo, AfterEach, Test
 
 ### Community 206 - "Community 206"
-Cohesion: 0.19
+Cohesion: 0.21
 Nodes (6): FailureReporter, Class, String, Throwable, Test, FailureReporterUnitTest
 
 ### Community 208 - "Community 208"
-Cohesion: 0.18
-Nodes (6): LightHouseGenerateReport, LightHouseGenerateReportCoverageUnitTest, String, WebDriver, AfterMethod, Test
+Cohesion: 0.30
+Nodes (3): LightHouseGenerateReport, String, WebDriver
 
 ### Community 209 - "Community 209"
-Cohesion: 0.60
-Nodes (4): defaults(), disabled(), ApprovalPolicy, DoctorAiAnalysisRequest
+Cohesion: 0.27
+Nodes (8): AiBudget, defaults(), disabled(), defaults(), ApprovalPolicy, DoctorAiAnalysisRequest, ApprovalPolicy, DoctorRepairAiRequest
 
 ### Community 210 - "Community 210"
 Cohesion: 0.22
 Nodes (6): McpRuntimePaths, McpRuntimePathsTest, Map, Path, String, Test
 
 ### Community 211 - "Community 211"
-Cohesion: 0.19
+Cohesion: 0.18
 Nodes (12): AnthropicProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode, Map (+4 more)
 
 ### Community 212 - "Community 212"
@@ -1493,16 +1507,16 @@ Cohesion: 0.10
 Nodes (20): pattern, type, pattern, type, properties, body_path, created_at, status (+12 more)
 
 ### Community 213 - "Community 213"
-Cohesion: 0.22
-Nodes (11): CaptureEvent, CaptureJsonCodec, CaptureSession, Checkpoint, ExternalTestDataReference, Instant, List, Path (+3 more)
+Cohesion: 0.11
+Nodes (29): append(), checkpoint(), complete(), ensureIncomplete(), interrupt(), sortedCheckpoints(), sortedEvents(), sortedReferences() (+21 more)
 
 ### Community 214 - "Community 214"
 Cohesion: 0.22
 Nodes (7): ManagedCaptureRecorderControlTest, CaptureBrowser, CaptureStartOptions, CaptureStartRequest, Object, SuppressWarnings, Test
 
 ### Community 215 - "Community 215"
-Cohesion: 0.07
-Nodes (15): BrowserSteps, Given, String, ThreadLocal, WebDriver, When, AfterEach, BeforeAll (+7 more)
+Cohesion: 0.20
+Nodes (4): AfterMethod, BeforeMethod, Test, BrowserActionsTests
 
 ### Community 216 - "Community 216"
 Cohesion: 0.29
@@ -1518,23 +1532,23 @@ Nodes (10): PilotTestConfiguration, RedactionPolicy, RedactionResult, Redactor, 
 
 ### Community 219 - "Community 219"
 Cohesion: 0.21
-Nodes (5): Timeouts, Boolean, DefaultValue, Key, SetProperty
+Nodes (5): Connection, DbTests, String, BeforeClass, Test
 
 ### Community 220 - "Community 220"
 Cohesion: 0.29
 Nodes (4): CaptureJsonCodecTest, Path, String, Test
 
 ### Community 221 - "Community 221"
-Cohesion: 0.22
-Nodes (7): CucumberFeatureListener, Class, Object, String, SuppressWarnings, Test, CucumberFeatureListenerUnitTest
+Cohesion: 0.20
+Nodes (8): CucumberFeatureListener, Class, Object, String, SuppressWarnings, Test, TableRow, CucumberFeatureListenerUnitTest
 
 ### Community 222 - "Community 222"
-Cohesion: 0.31
-Nodes (4): AfterMethod, BeforeMethod, Test, RecordManagerDesktopProviderTest
+Cohesion: 0.18
+Nodes (8): AfterMethod, BeforeMethod, InputStream, Override, String, Test, RecordManagerDesktopProviderTest, StubDesktopVideoRecordingProvider
 
 ### Community 223 - "Community 223"
-Cohesion: 0.20
-Nodes (8): ExecutionLifecycleHelper, List, Method, RunType, Status, StatusIcon, String, TestExecutionInfo
+Cohesion: 0.24
+Nodes (7): ExecutionLifecycleHelper, List, Method, Status, StatusIcon, String, TestExecutionInfo
 
 ### Community 224 - "Community 224"
 Cohesion: 0.23
@@ -1549,12 +1563,12 @@ Cohesion: 0.20
 Nodes (6): NaturalActions, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 227 - "Community 227"
-Cohesion: 0.13
-Nodes (6): SetProperty, Visuals, DefaultValue, Key, SetProperty, String
+Cohesion: 0.26
+Nodes (4): Visuals, DefaultValue, Key, SetProperty
 
 ### Community 228 - "Community 228"
-Cohesion: 0.07
-Nodes (30): HealingScore, AiCandidateReranker, DeterministicScorer, HealingSupport, nativePlatform(), AiExecutionService, Double, HealingConfiguration (+22 more)
+Cohesion: 0.20
+Nodes (13): AiCandidateReranker, AiExecutionService, Double, HealingConfiguration, JsonNode, List, Map, ObjectNode (+5 more)
 
 ### Community 229 - "Community 229"
 Cohesion: 0.23
@@ -1562,7 +1576,7 @@ Nodes (5): ThreadSafeGuiWizardTests, AfterMethod, BeforeMethod, SuppressWarnings
 
 ### Community 230 - "Community 230"
 Cohesion: 0.24
-Nodes (8): GuardedPatch, RepairGuard, FilePatch, List, Path, Set, String, ValidationCommand
+Nodes (7): HealingScore, DeterministicScorer, Double, HealingConfiguration, LocatorFingerprint, Map, String
 
 ### Community 231 - "Community 231"
 Cohesion: 0.31
@@ -1573,8 +1587,8 @@ Cohesion: 0.15
 Nodes (11): BrowserEventCollector, CompositeBrowserEventCollector, BrowserSignal, Consumer, Override, String, BrowserSignal, Consumer (+3 more)
 
 ### Community 233 - "Community 233"
-Cohesion: 0.21
-Nodes (6): AssertionSuggestion, List, Map, Pattern, String, TargetPlan
+Cohesion: 0.14
+Nodes (8): AndroidTouchActionsTests, Autowired, ScreenOrientation, Test, EngineService, McpMobileInspectorRecordingService, McpMobileRecordingService, McpWorkspacePolicy
 
 ### Community 234 - "Community 234"
 Cohesion: 0.22
@@ -1585,8 +1599,8 @@ Cohesion: 0.28
 Nodes (7): LocatorRanker, ScoredLocator, ElementSnapshot, EventContext, LocatorCandidate, LocatorSelection, String
 
 ### Community 236 - "Community 236"
-Cohesion: 0.19
-Nodes (10): current(), HealingStrategy(), parse(), usesHealenium(), usesShaftHeal(), HealingStrategyTest, String, AfterMethod (+2 more)
+Cohesion: 0.27
+Nodes (5): DatabaseActions, Boolean, DatabaseType, ResultSet, StringBuilder
 
 ### Community 237 - "Community 237"
 Cohesion: 0.13
@@ -1597,8 +1611,8 @@ Cohesion: 0.22
 Nodes (8): ChromeOptions, MoonTests, AfterEach, BeforeEach, String, Test, WebDriver, TestInfo
 
 ### Community 239 - "Community 239"
-Cohesion: 0.16
-Nodes (5): ActionsExceptionDetailsUnitTest, NoSuchElementException, List, Rectangle, Test
+Cohesion: 0.11
+Nodes (10): RecordingActions, ActionsExceptionDetailsUnitTest, NoSuchElementException, AfterMethod, AllureLifecycle, BeforeMethod, DriverFactoryHelper, WebDriver (+2 more)
 
 ### Community 240 - "Community 240"
 Cohesion: 0.25
@@ -1609,8 +1623,12 @@ Cohesion: 0.20
 Nodes (4): ValidationsMockedTests, AfterMethod, BeforeMethod, Test
 
 ### Community 242 - "Community 242"
-Cohesion: 0.16
-Nodes (11): HealingLocatorProposalService, HealingLocatorProposalServiceTest, HealingLocatorProposal, JsonNode, Path, String, AfterEach, BeforeEach (+3 more)
+Cohesion: 0.31
+Nodes (5): HealingLocatorProposalService, HealingLocatorProposal, JsonNode, Path, String
+
+### Community 243 - "Community 243"
+Cohesion: 0.23
+Nodes (10): OpenCvVisualProcessingProvider, Boolean, By, Integer, List, Mat, Override, String (+2 more)
 
 ### Community 244 - "Community 244"
 Cohesion: 0.19
@@ -1625,12 +1643,12 @@ Cohesion: 0.21
 Nodes (6): AfterMethod, Class, Object, String, Test, BrowserStackHelperUnitTest
 
 ### Community 248 - "Community 248"
-Cohesion: 0.17
-Nodes (11): AiProviderRegistryTest, availability(), capabilities(), execute(), AfterEach, AiCapabilities, AiProviderAvailability, AiRequest (+3 more)
+Cohesion: 0.16
+Nodes (12): AiProviderRegistryTest, availability(), capabilities(), execute(), CompletableFuture, AfterEach, AiCapabilities, AiProviderAvailability (+4 more)
 
 ### Community 249 - "Community 249"
-Cohesion: 0.18
-Nodes (9): AllureCucumber7Jvm, CucumberTestRunnerListener, EventPublisher, Feature, Optional, Override, TestSourceParsed, TestStepStarted (+1 more)
+Cohesion: 0.11
+Nodes (12): AllureCucumber7Jvm, CucumberTestRunnerListener, TestCaseStarted, EventPublisher, Feature, Optional, Override, TestCaseFinished (+4 more)
 
 ### Community 250 - "Community 250"
 Cohesion: 0.15
@@ -1639,6 +1657,10 @@ Nodes (14): Bean, BrowserService, ElementService, GuideService, ShaftMcpApplicat
 ### Community 251 - "Community 251"
 Cohesion: 0.24
 Nodes (9): main(), text(), validate_maven_jvm_configuration(), validate_quality_configuration(), validate_surefire_jacoco_arg_lines(), validate_workflow_coverage_policy(), Element, Path (+1 more)
+
+### Community 252 - "Community 252"
+Cohesion: 0.25
+Nodes (9): DeterministicNaturalActionPlanner, unsupported(), List, NaturalActionPlan, NaturalActionRequest, Override, String, NaturalActionPlan (+1 more)
 
 ### Community 253 - "Community 253"
 Cohesion: 0.16
@@ -1661,8 +1683,8 @@ Cohesion: 0.24
 Nodes (8): NaturalActionExecutorTest, AfterMethod, BeforeMethod, By, List, Test, WebDriver, WebElement
 
 ### Community 259 - "Community 259"
-Cohesion: 0.18
-Nodes (9): Actions, AfterMethod, BeforeMethod, ElementActions, MockedConstruction, Object, String, Test (+1 more)
+Cohesion: 0.15
+Nodes (11): List, Map, Actions, AfterMethod, BeforeMethod, ElementActions, MockedConstruction, Object (+3 more)
 
 ### Community 260 - "Community 260"
 Cohesion: 0.26
@@ -1685,7 +1707,7 @@ Cohesion: 0.21
 Nodes (4): AfterClass, BeforeClass, Test, FileHelperUnitTest
 
 ### Community 265 - "Community 265"
-Cohesion: 0.17
+Cohesion: 0.19
 Nodes (3): RestActionsCoverageUnitTest, AfterMethod, Test
 
 ### Community 266 - "Community 266"
@@ -1713,20 +1735,16 @@ Cohesion: 0.24
 Nodes (10): expired(), InstantDeadline(), ManagedCaptureRecorderBrowserTest, Duration, HttpExchange, HttpServer, ParameterizedTest, Path (+2 more)
 
 ### Community 272 - "Community 272"
-Cohesion: 0.24
-Nodes (5): EXCEL, ExcelFileManager, TestDataTests, String, Test
-
-### Community 274 - "Community 274"
-Cohesion: 0.33
-Nodes (4): HoverTests, AfterMethod, BeforeMethod, Test
+Cohesion: 0.20
+Nodes (12): McpMobileInspectorRecordingServiceTest, NoopRunner, Duration, List, Map, McpMobileInspectorRecordingService, Override, Path (+4 more)
 
 ### Community 275 - "Community 275"
-Cohesion: 0.17
-Nodes (6): DriverFactory, DriverType, WebDriver, AfterMethod, Test, DriverFactoryCoverageUnitTest
+Cohesion: 0.11
+Nodes (16): DriverFactory, DriverType(), DatabaseActions, DatabaseType, Deprecated, DriverFactoryHelper, DriverType, MutableCapabilities (+8 more)
 
 ### Community 276 - "Community 276"
-Cohesion: 0.39
-Nodes (4): Executable, McpNoDriverServiceTest, BeforeEach, Test
+Cohesion: 0.19
+Nodes (12): FakeRunner, McpMobileToolchainServiceTest, McpProcessRunner, Duration, List, Map, Override, Path (+4 more)
 
 ### Community 277 - "Community 277"
 Cohesion: 0.33
@@ -1745,7 +1763,7 @@ Cohesion: 0.30
 Nodes (4): CaptureServiceTest, CaptureService, Path, Test
 
 ### Community 281 - "Community 281"
-Cohesion: 0.27
+Cohesion: 0.25
 Nodes (5): ValidationsHelperCoverageUnitTest, AssertionError, AfterMethod, SuppressWarnings, Test
 
 ### Community 282 - "Community 282"
@@ -1753,8 +1771,8 @@ Cohesion: 0.23
 Nodes (9): VisualEvidenceService, Double, HealingConfiguration, HealingVisualProvider, List, Optional, RankedCandidate, String (+1 more)
 
 ### Community 283 - "Community 283"
-Cohesion: 0.17
-Nodes (12): enum, additionalProperties, properties, required, type, enum, items, type (+4 more)
+Cohesion: 0.13
+Nodes (15): type, uniqueItems, enum, additionalProperties, properties, required, type, enum (+7 more)
 
 ### Community 284 - "Community 284"
 Cohesion: 0.17
@@ -1773,27 +1791,27 @@ Cohesion: 0.13
 Nodes (14): BrowserEventScript, CaptureCollectorUtilityTest, close(), start(), List, String, BrowserSignal, Class (+6 more)
 
 ### Community 288 - "Community 288"
-Cohesion: 0.23
-Nodes (5): AfterMethod, BeforeMethod, Path, Test, ExcelFileManagerCoverageUnitTest
+Cohesion: 0.10
+Nodes (12): ExcelFileManager, TestDataTests, String, Test, AfterMethod, BeforeMethod, Path, Test (+4 more)
 
 ### Community 290 - "Community 290"
-Cohesion: 0.22
-Nodes (18): append(), checkpoint(), complete(), ensureIncomplete(), interrupt(), sortedCheckpoints(), sortedEvents(), sortedReferences() (+10 more)
+Cohesion: 0.23
+Nodes (7): BigInteger, UpdateChecker, UpdateCheckerUnitTest, Optional, String, Supplier, Test
 
 ### Community 291 - "Community 291"
 Cohesion: 0.38
 Nodes (5): Locator, Beta, By, LocatorBuilder, String
 
 ### Community 292 - "Community 292"
-Cohesion: 0.11
-Nodes (10): FilesSize, HealingProviderRegistry, HealingProvider, List, Optional, DesktopVideoRecordingProvider, Optional, Test (+2 more)
+Cohesion: 0.14
+Nodes (9): Callable, Path, Test, DesktopVideoRecordingProvider, Optional, Test, CaptureSessionStoreTest, RestActionsFailureLoggingUnitTest (+1 more)
 
 ### Community 293 - "Community 293"
 Cohesion: 0.19
 Nodes (14): A(), Ae(), b(), ce(), ge(), le(), pe(), qe() (+6 more)
 
 ### Community 294 - "Community 294"
-Cohesion: 0.16
+Cohesion: 0.21
 Nodes (5): List, AfterMethod, BeforeMethod, Test, BrowserActionsCoverageUnitTest
 
 ### Community 295 - "Community 295"
@@ -1809,12 +1827,12 @@ Cohesion: 0.35
 Nodes (5): CaptureWorkbenchHtml, CaptureGenerationReport, CaptureReview, Path, String
 
 ### Community 298 - "Community 298"
-Cohesion: 0.32
-Nodes (4): Reporting, DefaultValue, Key, SetProperty
+Cohesion: 0.13
+Nodes (6): Reporting, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 299 - "Community 299"
-Cohesion: 0.22
-Nodes (7): DataType, JSON, JSONFileManager, List, Map, Object, String
+Cohesion: 0.18
+Nodes (6): BrowserSteps, Given, String, ThreadLocal, WebDriver, When
 
 ### Community 300 - "Community 300"
 Cohesion: 0.26
@@ -1845,8 +1863,8 @@ Cohesion: 0.14
 Nodes (13): additionalProperties, type, type, properties, body, id, title, userId (+5 more)
 
 ### Community 307 - "Community 307"
-Cohesion: 0.25
-Nodes (6): McpServiceHelperTest, AfterEach, Class, Object, String, Test
+Cohesion: 0.30
+Nodes (5): McpServiceHelperTest, Class, Object, String, Test
 
 ### Community 308 - "Community 308"
 Cohesion: 0.23
@@ -1865,20 +1883,20 @@ Cohesion: 0.26
 Nodes (6): Pattern, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 312 - "Community 312"
-Cohesion: 0.05
-Nodes (36): ByAll, SmartLocator, SmartLocators, SmartLocatorsPOC1Tests, DeterministicNaturalActionPlanner, unsupported(), NaturalActionPlannerRegistry, PilotNaturalActionPlanner (+28 more)
+Cohesion: 0.19
+Nodes (12): PilotNaturalActionPlanner, NaturalActionKind, NaturalActionPlanner, NaturalActionStep, AiExecutionService, By, JsonNode, NaturalActionPlan (+4 more)
 
 ### Community 313 - "Community 313"
 Cohesion: 0.21
 Nodes (7): WebDriverBrowserValidationsBuilder, NativeValidationsBuilder, String, StringBuilder, SuppressWarnings, ValidationCategory, WebDriver
 
 ### Community 314 - "Community 314"
-Cohesion: 0.23
-Nodes (10): LauncherSessionListener, JunitListener, Method, Status, StatusIcon, String, TestExecutionInfo, TestIdentifier (+2 more)
+Cohesion: 0.14
+Nodes (14): ExecutionCountsTracker, LauncherSessionListener, JunitListener, String, TestExecutionInfo, Counts, Method, Status (+6 more)
 
 ### Community 315 - "Community 315"
-Cohesion: 0.47
-Nodes (5): CaptureStartRequest(), validateUrl(), CaptureBrowser, Path, String
+Cohesion: 0.33
+Nodes (6): HealingLocatorProposalServiceTest, AfterEach, BeforeEach, Path, String, Test
 
 ### Community 316 - "Community 316"
 Cohesion: 0.24
@@ -1892,29 +1910,21 @@ Nodes (4): MultipleTypeCyclesTest, AfterMethod, BeforeMethod, Test
 Cohesion: 0.26
 Nodes (4): WaitActionsTest, AfterMethod, BeforeMethod, Test
 
-### Community 319 - "Community 319"
-Cohesion: 0.29
-Nodes (6): Properties, Class, Supplier, SuppressWarnings, T, ThreadLocal
-
 ### Community 320 - "Community 320"
 Cohesion: 0.29
 Nodes (4): AfterMethod, Object, Test, APIPropertiesUnitTest
-
-### Community 321 - "Community 321"
-Cohesion: 0.20
-Nodes (6): FileReader, JSONFileManagerTestAccessor, SuppressWarnings, AfterMethod, Test, MemoryLeakFixTests
 
 ### Community 322 - "Community 322"
 Cohesion: 0.29
 Nodes (8): DoctorJsonCodec, Diagnosis, DoctorAdvisory, EvidenceBundle, JsonNode, Object, Path, String
 
 ### Community 323 - "Community 323"
-Cohesion: 0.31
+Cohesion: 0.32
 Nodes (7): LocatorRankerTest, ElementSnapshot, List, LocatorCandidate, LocatorStrategy, String, Test
 
 ### Community 324 - "Community 324"
-Cohesion: 0.28
-Nodes (5): AlertEvent, DataPlan, StringBuilder, WaitEvent, WindowEvent
+Cohesion: 0.31
+Nodes (4): ScreenshotHelper, Boolean, SuppressWarnings, WebDriver
 
 ### Community 325 - "Community 325"
 Cohesion: 0.25
@@ -1957,12 +1967,12 @@ Cohesion: 0.17
 Nodes (5): ExecutionSummaryReport, StatusIcon(), CheckpointStatus, String, StringBuilder
 
 ### Community 335 - "Community 335"
-Cohesion: 0.15
+Cohesion: 0.29
 Nodes (8): IssueReporter, Boolean, ITestNGMethod, ITestResult, List, Method, String, TestExecutionInfo
 
 ### Community 336 - "Community 336"
-Cohesion: 0.15
-Nodes (6): Jira, SetProperty, DefaultValue, Key, SetProperty, String
+Cohesion: 0.27
+Nodes (5): McpMobileCode, List, locatorStrategy, McpCodeBlock, String
 
 ### Community 337 - "Community 337"
 Cohesion: 0.17
@@ -1981,7 +1991,7 @@ Cohesion: 0.29
 Nodes (3): EngineServiceTest, AfterEach, Test
 
 ### Community 341 - "Community 341"
-Cohesion: 0.22
+Cohesion: 0.20
 Nodes (4): ProgressBarLoggerTestAccessor, AfterMethod, Test, ValidationAndProgressBarTests
 
 ### Community 342 - "Community 342"
@@ -1993,8 +2003,8 @@ Cohesion: 0.29
 Nodes (5): DoctorModelSupport, List, Map, String, T
 
 ### Community 344 - "Community 344"
-Cohesion: 0.17
-Nodes (12): items, type, minLength, pattern, type, additionalProperties, properties, required (+4 more)
+Cohesion: 0.29
+Nodes (7): minLength, pattern, type, properties, enum, id, kind
 
 ### Community 345 - "Community 345"
 Cohesion: 0.17
@@ -2017,12 +2027,12 @@ Cohesion: 0.26
 Nodes (5): AfterMethod, BeforeClass, BeforeMethod, Test, TestClass
 
 ### Community 350 - "Community 350"
-Cohesion: 0.18
-Nodes (3): AsyncAppender, Path, Status
+Cohesion: 0.29
+Nodes (6): ByAll, SmartLocator, SmartLocators, PathStrategy, By, String
 
 ### Community 352 - "Community 352"
-Cohesion: 0.31
-Nodes (5): BrowserStackSdkHelper, List, Map, Object, String
+Cohesion: 0.32
+Nodes (5): CaptureJsonCodec, CaptureSession, JsonNode, Path, String
 
 ### Community 353 - "Community 353"
 Cohesion: 0.26
@@ -2033,8 +2043,8 @@ Cohesion: 0.18
 Nodes (6): AiProvider, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse, String
 
 ### Community 355 - "Community 355"
-Cohesion: 0.18
-Nodes (11): AllureVerdict, PatchManifestEntry, changedSince(), AllureSnapshot, Diagnosis, Duration, EvidenceBundle, FilePatch (+3 more)
+Cohesion: 0.23
+Nodes (6): InputStream, Override, Path, Test, CloseTrackingInputStream, ReportManagerHelperAttachmentIoUnitTest
 
 ### Community 356 - "Community 356"
 Cohesion: 0.25
@@ -2045,7 +2055,7 @@ Cohesion: 0.49
 Nodes (10): create_bundle(), main(), _parse(), _text(), validate_jar_contents(), validate_publication(), validate_sbom(), _version() (+2 more)
 
 ### Community 358 - "Community 358"
-Cohesion: 0.27
+Cohesion: 0.28
 Nodes (5): JSONValidationsBuilder, NativeValidationsBuilder, Object, RestValidationsBuilder, ValidationsExecutor
 
 ### Community 359 - "Community 359"
@@ -2113,8 +2123,8 @@ Cohesion: 0.33
 Nodes (8): failure(), success(), AiResponse, AiResponseStatus, AiUsage, Duration, JsonNode, String
 
 ### Community 376 - "Community 376"
-Cohesion: 0.25
-Nodes (6): WebDomHealingAcceptanceTest, AfterMethod, BeforeMethod, Path, String, Test
+Cohesion: 0.26
+Nodes (3): SmartLocatorsPOC1Tests, CharSequence, String
 
 ### Community 377 - "Community 377"
 Cohesion: 0.20
@@ -2125,12 +2135,12 @@ Cohesion: 0.25
 Nodes (13): apply(), applyEnabled(), current(), NaturalActionService, textOrDefault(), withOverrides(), McpNaturalActionResult, NaturalActionSettings (+5 more)
 
 ### Community 379 - "Community 379"
-Cohesion: 0.28
-Nodes (5): ScreenshotManagerCoverageUnitTest, AfterMethod, BeforeMethod, Color, Test
+Cohesion: 0.24
+Nodes (6): ElementActionsHelper, ScreenshotManagerCoverageUnitTest, AfterMethod, BeforeMethod, Color, Test
 
 ### Community 381 - "Community 381"
-Cohesion: 0.21
-Nodes (7): DisabledAiProvider, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse, Override, String
+Cohesion: 0.14
+Nodes (11): ready(), unavailable(), DisabledAiProvider, AiProviderAvailability, String, AiCapabilities, AiProviderAvailability, AiRequest (+3 more)
 
 ### Community 382 - "Community 382"
 Cohesion: 0.31
@@ -2141,8 +2151,8 @@ Cohesion: 0.32
 Nodes (4): CodegenFeatureCatalog, Feature, List, String
 
 ### Community 384 - "Community 384"
-Cohesion: 0.17
-Nodes (9): CaptureControlServerClientTest, HttpRequest, HttpResponse, Test, DriverFactoryHelper, Predicate, Step, WebDriver (+1 more)
+Cohesion: 0.21
+Nodes (8): HttpRequest, NavigationAction, DriverFactoryHelper, HttpResponse, Predicate, Step, WebDriver, WebDriverBrowserValidationsBuilder
 
 ### Community 385 - "Community 385"
 Cohesion: 0.22
@@ -2197,8 +2207,8 @@ Cohesion: 0.27
 Nodes (4): LocalApiTestServer, HttpExchange, HttpServer, String
 
 ### Community 398 - "Community 398"
-Cohesion: 0.18
-Nodes (10): DriverType(), DatabaseActions, DatabaseType, Deprecated, DriverFactoryHelper, MutableCapabilities, RestActions, String (+2 more)
+Cohesion: 0.26
+Nodes (4): AfterMethod, BeforeMethod, Test, BrowserActionsHelperCoverageUnitTest
 
 ### Community 399 - "Community 399"
 Cohesion: 0.31
@@ -2217,8 +2227,8 @@ Cohesion: 0.36
 Nodes (5): assemble_javadocs(), main(), project_version(), Path, AssembleJavadocsTest
 
 ### Community 403 - "Community 403"
-Cohesion: 0.10
-Nodes (15): IOSBasicInteractionsTest, ElementActions, Test_LTMobIPAAppURL, Test_LTMobIPARelativePath, AfterMethod, BeforeMethod, SuppressWarnings, Test (+7 more)
+Cohesion: 0.15
+Nodes (9): IOSBasicInteractionsTest, Test_LTMobIPARelativePath, AfterMethod, BeforeMethod, SuppressWarnings, Test, AfterMethod, BeforeMethod (+1 more)
 
 ### Community 404 - "Community 404"
 Cohesion: 0.33
@@ -2233,8 +2243,8 @@ Cohesion: 0.21
 Nodes (7): ApiPerformanceExecutionReport, String, Double, List, Map, String, PerformanceReportHTMLHelper
 
 ### Community 408 - "Community 408"
-Cohesion: 0.07
-Nodes (19): testPostRequest, SHAFT, FileInputStream, AppiumMobileConsumer, BrowserStackSdkConsumer, LegacyCoordinateConsumer, IOException, JunitProjectStructureManagerTest (+11 more)
+Cohesion: 0.06
+Nodes (19): AiAuditSink, testPostRequest, ShaftAiAuditSink, SHAFT, AppiumMobileConsumer, BrowserStackSdkConsumer, LegacyCoordinateConsumer, IOException (+11 more)
 
 ### Community 409 - "Community 409"
 Cohesion: 0.22
@@ -2257,8 +2267,8 @@ Cohesion: 0.29
 Nodes (7): parse_xml(), Parse XML while preserving comments., Return a POM with the modular SHAFT BOM and selected dependencies., Return version property, direct SHAFT dependencies, and managed BOM version., Enforce the modular SHAFT dependency contract after every repair., shaft_dependency_state(), validate_upgraded_poms()
 
 ### Community 414 - "Community 414"
-Cohesion: 0.31
-Nodes (3): ProgressBarLoggerCoverageUnitTest, AfterMethod, Test
+Cohesion: 0.17
+Nodes (7): AutoCloseable, ProgressBarLogger, ProgressBarLoggerCoverageUnitTest, Override, String, AfterMethod, Test
 
 ### Community 415 - "Community 415"
 Cohesion: 0.08
@@ -2276,10 +2286,6 @@ Nodes (4): CaptureEvent, ElementSnapshot, EventContext, ExternalTestDataReferenc
 Cohesion: 0.25
 Nodes (4): NaturalActionPlanner, NaturalActionPlan, NaturalActionRequest, String
 
-### Community 419 - "Community 419"
-Cohesion: 0.31
-Nodes (3): NavigationAction, Test, NavigationActionUnitTest
-
 ### Community 420 - "Community 420"
 Cohesion: 0.31
 Nodes (5): ElementMatchesSafariCompatibleTests, AfterMethod, BeforeMethod, SuppressWarnings, Test
@@ -2293,7 +2299,7 @@ Cohesion: 0.29
 Nodes (5): AfterEach, BeforeAll, BeforeEach, Test, TestClass
 
 ### Community 424 - "Community 424"
-Cohesion: 0.31
+Cohesion: 0.29
 Nodes (5): AfterMethod, BeforeClass, BeforeMethod, Test, TestClass
 
 ### Community 425 - "Community 425"
@@ -2309,7 +2315,7 @@ Cohesion: 0.22
 Nodes (7): Completion, Memory, New Task Flow, Repository, Routing, Validation, Working Rules
 
 ### Community 428 - "Community 428"
-Cohesion: 0.38
+Cohesion: 0.36
 Nodes (4): JunitApiSmokeTest, AfterAll, BeforeAll, Test
 
 ### Community 429 - "Community 429"
@@ -2321,8 +2327,8 @@ Cohesion: 0.29
 Nodes (5): AfterEach, BeforeAll, BeforeEach, Test, TestClass
 
 ### Community 432 - "Community 432"
-Cohesion: 0.33
-Nodes (3): BeforeClass, Test, IoExcelFileManagerTests
+Cohesion: 0.36
+Nodes (3): XpathAxis, LocatorBuilder, String
 
 ### Community 433 - "Community 433"
 Cohesion: 0.25
@@ -2337,8 +2343,8 @@ Cohesion: 0.36
 Nodes (3): TestNgWebConsumer, AfterSuite, Test
 
 ### Community 436 - "Community 436"
-Cohesion: 0.39
-Nodes (3): ReportManager, Level, String
+Cohesion: 0.29
+Nodes (6): NaturalActionPlannerRegistry, List, NaturalActionPlan, NaturalActionPlanner, NaturalActionRequest, String
 
 ### Community 437 - "Community 437"
 Cohesion: 0.32
@@ -2381,8 +2387,8 @@ Cohesion: 0.36
 Nodes (4): LazyLoadingTests, AfterMethod, BeforeMethod, Test
 
 ### Community 447 - "Community 447"
-Cohesion: 0.25
-Nodes (4): DatabaseActions, DB, DatabaseType, ResultSet
+Cohesion: 0.26
+Nodes (5): AfterEach, BeforeAll, BeforeEach, Test, TestClass
 
 ### Community 448 - "Community 448"
 Cohesion: 0.36
@@ -2405,8 +2411,8 @@ Cohesion: 0.36
 Nodes (4): ShadowDOMTests, AfterMethod, BeforeMethod, Test
 
 ### Community 453 - "Community 453"
-Cohesion: 0.18
-Nodes (11): items, type, uniqueItems, minLength, pattern, type, applies_to, tags (+3 more)
+Cohesion: 0.15
+Nodes (13): items, items, type, additionalProperties, minLength, pattern, required, type (+5 more)
 
 ### Community 455 - "Community 455"
 Cohesion: 0.47
@@ -2437,7 +2443,7 @@ Cohesion: 0.38
 Nodes (10): aiTrigger(), bounded(), current(), HealingConfiguration(), split(), Duration, List, Path (+2 more)
 
 ### Community 463 - "Community 463"
-Cohesion: 0.07
+Cohesion: 0.06
 Nodes (30): AfterAllCallback, AfterTestExecutionCallback, BeforeAllCallback, BeforeEachCallback, RetryAnalyzer, SupportingEvidenceState, Invocation, InvocationInterceptor (+22 more)
 
 ### Community 464 - "Community 464"
@@ -2476,10 +2482,6 @@ Nodes (7): adapter, originalSha256, provenance, sourceReference, properties, req
 Cohesion: 0.33
 Nodes (3): InputStream, String, DesktopVideoRecordingProvider
 
-### Community 473 - "Community 473"
-Cohesion: 0.31
-Nodes (6): BasicAPITests, AfterClass, BeforeClass, List, Map, String
-
 ### Community 474 - "Community 474"
 Cohesion: 0.67
 Nodes (5): is_allowed(), main(), tracked_markdown(), validate_repository(), Path
@@ -2489,8 +2491,8 @@ Cohesion: 0.53
 Nodes (5): fail(), main(), parse_trusted_pom(), text(), Path
 
 ### Community 476 - "Community 476"
-Cohesion: 0.27
-Nodes (7): option(), ProviderConfiguration(), ProviderConfigurationTest, Map, String, URI, Test
+Cohesion: 0.11
+Nodes (18): option(), ProviderConfiguration(), ProviderConfigurationTest, Properties, CaptureStartRequest(), validateUrl(), CaptureBrowser, Path (+10 more)
 
 ### Community 477 - "Community 477"
 Cohesion: 0.32
@@ -2501,8 +2503,8 @@ Cohesion: 0.36
 Nodes (5): TextLanguageValidationsBuilder, NativeValidationsBuilder, String, ValidationsExecutor, TextLanguage
 
 ### Community 479 - "Community 479"
-Cohesion: 0.37
-Nodes (4): DoctorServiceTest, DoctorService, Path, Test
+Cohesion: 0.29
+Nodes (5): Test_LTMobIPAAppURL, AfterMethod, BeforeMethod, String, Test
 
 ### Community 480 - "Community 480"
 Cohesion: 0.47
@@ -2517,8 +2519,8 @@ Cohesion: 0.70
 Nodes (4): HistoryRecord(), withChecksum(), LocatorFingerprint, String
 
 ### Community 483 - "Community 483"
-Cohesion: 0.11
-Nodes (12): CaptureEventPipeline, CapturePrivacyClassifier, DoctorFormatException, ProfileCleanupException, RuntimeException, BrowserMetadata, CapturePrivacyPolicy, CaptureSessionStore (+4 more)
+Cohesion: 0.25
+Nodes (5): DoctorFormatException, ProfileCleanupException, RuntimeException, String, Throwable
 
 ### Community 484 - "Community 484"
 Cohesion: 0.33
@@ -2577,7 +2579,7 @@ Cohesion: 0.40
 Nodes (4): CaptureBrowser(), parse(), DriverType, String
 
 ### Community 501 - "Community 501"
-Cohesion: 0.33
+Cohesion: 0.40
 Nodes (3): FileActionsReflectionInvoker, FileActions, String
 
 ### Community 502 - "Community 502"
@@ -2621,8 +2623,8 @@ Cohesion: 0.40
 Nodes (4): Allowed Work, Constraints, Refresh Agent Guidance, Validation
 
 ### Community 515 - "Community 515"
-Cohesion: 0.29
-Nodes (4): ExecutionCountsTracker, String, TestExecutionInfo, Counts
+Cohesion: 0.33
+Nodes (4): HealingProviderRegistry, HealingProvider, List, Optional
 
 ### Community 516 - "Community 516"
 Cohesion: 0.29
@@ -2709,20 +2711,20 @@ Cohesion: 0.36
 Nodes (4): ShaftMcpApplicationTests, Set, String, Test
 
 ### Community 669 - "Community 669"
-Cohesion: 0.15
-Nodes (9): LogRedirector, ProjectStructureManager, Logger, InputStream, OutputStream, Level, Override, Path (+1 more)
+Cohesion: 0.27
+Nodes (6): LogRedirector, Logger, InputStream, OutputStream, Level, Override
 
 ### Community 671 - "Community 671"
 Cohesion: 0.47
 Nodes (3): MobileTests, BeforeClass, Test
 
 ### Community 672 - "Community 672"
-Cohesion: 0.32
-Nodes (4): AutoCloseable, ProgressBarLogger, Override, String
+Cohesion: 0.29
+Nodes (4): AfterMethod, String, Test, PropertiesHelperInitializationUnitTest
 
 ### Community 673 - "Community 673"
-Cohesion: 0.46
-Nodes (4): Callable, Path, Test, CaptureSessionStoreTest
+Cohesion: 0.36
+Nodes (3): ProjectStructureManager, Path, RunType
 
 ### Community 674 - "Community 674"
 Cohesion: 0.39
@@ -2733,8 +2735,8 @@ Cohesion: 0.36
 Nodes (4): RelativeLocatorsTests, AfterMethod, BeforeMethod, Test
 
 ### Community 676 - "Community 676"
-Cohesion: 0.09
-Nodes (21): CaptureEnrichmentService, failure(), MutableTargetPlan, withUnsupported(), GeneratedTestValidator, GenerationState, LocatorRanker, Sequence (+13 more)
+Cohesion: 0.40
+Nodes (4): CaptureEnrichmentService, GeneratedTestValidator, LocatorRanker, CaptureJsonCodec
 
 ### Community 677 - "Community 677"
 Cohesion: 0.43
@@ -2745,20 +2747,20 @@ Cohesion: 0.36
 Nodes (4): Test_LTWebAppIOS, AfterMethod, BeforeMethod, Test
 
 ### Community 680 - "Community 680"
-Cohesion: 0.38
-Nodes (4): InputStream, Override, String, StubDesktopVideoRecordingProvider
+Cohesion: 0.43
+Nodes (5): ClassLoader, OpenCvBlockingClassLoader, Class, Override, String
 
 ### Community 686 - "Community 686"
 Cohesion: 0.31
 Nodes (4): AfterMethod, BeforeMethod, Test, VisualValidationTests
 
 ### Community 690 - "Community 690"
-Cohesion: 0.13
-Nodes (10): OpenCvVisualConsumer, HealingVisualProvider, OpenCvHealingVisualProvider, OpenCvHealingVisualProviderTest, Override, String, Color, Test (+2 more)
+Cohesion: 0.39
+Nodes (3): LightHouseGenerateReportCoverageUnitTest, AfterMethod, Test
 
 ### Community 691 - "Community 691"
-Cohesion: 0.33
-Nodes (4): AiAuditSink, ShaftAiAuditSink, AiAuditEvent, Override
+Cohesion: 0.38
+Nodes (4): JunitDatabaseSmokeTest, AfterAll, BeforeAll, Test
 
 ### Community 692 - "Community 692"
 Cohesion: 0.40
@@ -2766,15 +2768,11 @@ Nodes (4): MultipleElementsFoundException, String, Throwable, WebDriverException
 
 ### Community 693 - "Community 693"
 Cohesion: 0.33
-Nodes (4): CaptureFormatException, String, Throwable, IllegalArgumentException
+Nodes (6): Metadata, asCacheHit(), disabled(), empty(), DoctorAdvisory, ProviderAnalysis
 
 ### Community 694 - "Community 694"
-Cohesion: 0.47
-Nodes (3): MultipleBrowserInstancesTest, AfterMethod, Test
-
-### Community 695 - "Community 695"
-Cohesion: 0.47
-Nodes (3): JiraTests, BeforeClass, Test
+Cohesion: 0.53
+Nodes (5): allows(), ApprovalPolicy(), EvidenceCategory, ProcessingLocation, Set
 
 ### Community 697 - "Community 697"
 Cohesion: 0.40
@@ -2785,16 +2783,12 @@ Cohesion: 0.33
 Nodes (5): $id, required, $schema, title, type
 
 ### Community 699 - "Community 699"
-Cohesion: 0.31
-Nodes (4): JDK21VirtualThreadsAndAsyncActionsTests, AfterMethod, BeforeMethod, Test
+Cohesion: 0.47
+Nodes (3): PlatformTests, BeforeClass, Test
 
 ### Community 700 - "Community 700"
 Cohesion: 0.47
 Nodes (3): ReportingTests, BeforeClass, Test
-
-### Community 702 - "Community 702"
-Cohesion: 0.40
-Nodes (4): RepairGuard, RepairProposalStore, DoctorJsonCodec, RepairProcessRunner
 
 ### Community 704 - "Community 704"
 Cohesion: 0.53
@@ -2804,10 +2798,6 @@ Nodes (3): RepairProposalStore, Path, RepairProposal
 Cohesion: 0.50
 Nodes (3): Object, StringBuilder, ValidationCategory
 
-### Community 709 - "Community 709"
-Cohesion: 0.67
-Nodes (3): defaults(), ApprovalPolicy, DoctorRepairAiRequest
-
 ### Community 713 - "Community 713"
 Cohesion: 0.67
 Nodes (3): minLength, type, mediaType
@@ -2816,25 +2806,33 @@ Nodes (3): minLength, type, mediaType
 Cohesion: 0.67
 Nodes (3): sha256, minLength, type
 
+### Community 721 - "Community 721"
+Cohesion: 0.50
+Nodes (3): McpMobileToolchainService, McpMobileRecordingService, McpWorkspacePolicy
+
+### Community 722 - "Community 722"
+Cohesion: 0.67
+Nodes (3): safe(), stableKey(), String
+
 ## Knowledge Gaps
-- **1325 isolated node(s):** `$id`, `$schema`, `additionalProperties`, `additionalProperties`, `type` (+1320 more)
+- **1361 isolated node(s):** `$id`, `$schema`, `additionalProperties`, `additionalProperties`, `type` (+1356 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **71 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **84 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `SHAFT` connect `Community 408` to `Community 512`, `Community 1`, `Community 3`, `Community 8`, `Community 10`, `Community 523`, `Community 12`, `Community 525`, `Community 14`, `Community 13`, `Community 15`, `Community 17`, `Community 18`, `Community 19`, `Community 24`, `Community 25`, `Community 536`, `Community 27`, `Community 28`, `Community 31`, `Community 544`, `Community 32`, `Community 36`, `Community 37`, `Community 39`, `Community 43`, `Community 44`, `Community 47`, `Community 48`, `Community 49`, `Community 50`, `Community 51`, `Community 53`, `Community 55`, `Community 56`, `Community 57`, `Community 59`, `Community 61`, `Community 64`, `Community 72`, `Community 74`, `Community 76`, `Community 80`, `Community 81`, `Community 83`, `Community 87`, `Community 90`, `Community 91`, `Community 92`, `Community 94`, `Community 97`, `Community 98`, `Community 100`, `Community 103`, `Community 106`, `Community 110`, `Community 111`, `Community 113`, `Community 117`, `Community 121`, `Community 124`, `Community 125`, `Community 130`, `Community 131`, `Community 133`, `Community 134`, `Community 135`, `Community 136`, `Community 138`, `Community 143`, `Community 144`, `Community 145`, `Community 148`, `Community 149`, `Community 155`, `Community 156`, `Community 157`, `Community 159`, `Community 672`, `Community 161`, `Community 674`, `Community 163`, `Community 164`, `Community 675`, `Community 678`, `Community 671`, `Community 160`, `Community 677`, `Community 170`, `Community 686`, `Community 176`, `Community 691`, `Community 180`, `Community 694`, `Community 695`, `Community 696`, `Community 186`, `Community 699`, `Community 187`, `Community 700`, `Community 706`, `Community 194`, `Community 195`, `Community 710`, `Community 199`, `Community 712`, `Community 201`, `Community 202`, `Community 203`, `Community 208`, `Community 215`, `Community 222`, `Community 223`, `Community 225`, `Community 229`, `Community 236`, `Community 238`, `Community 240`, `Community 242`, `Community 246`, `Community 247`, `Community 248`, `Community 249`, `Community 254`, `Community 258`, `Community 259`, `Community 265`, `Community 266`, `Community 267`, `Community 272`, `Community 274`, `Community 275`, `Community 289`, `Community 292`, `Community 294`, `Community 296`, `Community 307`, `Community 312`, `Community 314`, `Community 316`, `Community 317`, `Community 318`, `Community 320`, `Community 329`, `Community 330`, `Community 334`, `Community 339`, `Community 342`, `Community 348`, `Community 349`, `Community 350`, `Community 352`, `Community 353`, `Community 356`, `Community 359`, `Community 361`, `Community 362`, `Community 363`, `Community 364`, `Community 366`, `Community 370`, `Community 376`, `Community 378`, `Community 379`, `Community 380`, `Community 382`, `Community 384`, `Community 385`, `Community 387`, `Community 388`, `Community 399`, `Community 401`, `Community 403`, `Community 404`, `Community 406`, `Community 410`, `Community 411`, `Community 415`, `Community 416`, `Community 420`, `Community 422`, `Community 423`, `Community 424`, `Community 426`, `Community 428`, `Community 430`, `Community 431`, `Community 432`, `Community 435`, `Community 438`, `Community 439`, `Community 440`, `Community 441`, `Community 443`, `Community 444`, `Community 445`, `Community 446`, `Community 447`, `Community 448`, `Community 449`, `Community 450`, `Community 452`, `Community 455`, `Community 456`, `Community 457`, `Community 458`, `Community 459`, `Community 460`, `Community 462`, `Community 463`, `Community 464`, `Community 466`, `Community 467`, `Community 468`, `Community 473`, `Community 481`, `Community 483`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 492`, `Community 493`, `Community 495`, `Community 497`, `Community 503`, `Community 506`?**
-  _High betweenness centrality (0.107) - this node is a cross-community bridge._
-- **Why does `ThreadLocalPropertiesManager` connect `Community 181` to `Community 156`, `Community 157`, `Community 158`?**
-  _High betweenness centrality (0.042) - this node is a cross-community bridge._
+- **Why does `SHAFT` connect `Community 408` to `Community 512`, `Community 1`, `Community 3`, `Community 5`, `Community 8`, `Community 10`, `Community 11`, `Community 12`, `Community 523`, `Community 525`, `Community 13`, `Community 15`, `Community 17`, `Community 18`, `Community 19`, `Community 21`, `Community 24`, `Community 25`, `Community 536`, `Community 27`, `Community 28`, `Community 31`, `Community 544`, `Community 32`, `Community 36`, `Community 37`, `Community 39`, `Community 41`, `Community 43`, `Community 44`, `Community 47`, `Community 48`, `Community 49`, `Community 50`, `Community 51`, `Community 53`, `Community 55`, `Community 56`, `Community 57`, `Community 59`, `Community 61`, `Community 72`, `Community 74`, `Community 76`, `Community 80`, `Community 81`, `Community 83`, `Community 87`, `Community 90`, `Community 92`, `Community 94`, `Community 97`, `Community 98`, `Community 99`, `Community 100`, `Community 103`, `Community 105`, `Community 106`, `Community 109`, `Community 110`, `Community 111`, `Community 113`, `Community 117`, `Community 121`, `Community 124`, `Community 125`, `Community 130`, `Community 131`, `Community 133`, `Community 134`, `Community 135`, `Community 138`, `Community 143`, `Community 144`, `Community 145`, `Community 148`, `Community 149`, `Community 155`, `Community 156`, `Community 157`, `Community 159`, `Community 671`, `Community 161`, `Community 674`, `Community 675`, `Community 164`, `Community 677`, `Community 678`, `Community 170`, `Community 686`, `Community 176`, `Community 690`, `Community 179`, `Community 180`, `Community 691`, `Community 696`, `Community 186`, `Community 699`, `Community 700`, `Community 706`, `Community 194`, `Community 199`, `Community 712`, `Community 202`, `Community 203`, `Community 208`, `Community 215`, `Community 729`, `Community 222`, `Community 223`, `Community 225`, `Community 229`, `Community 238`, `Community 239`, `Community 240`, `Community 242`, `Community 243`, `Community 246`, `Community 247`, `Community 248`, `Community 249`, `Community 254`, `Community 258`, `Community 259`, `Community 265`, `Community 266`, `Community 267`, `Community 275`, `Community 288`, `Community 289`, `Community 290`, `Community 292`, `Community 294`, `Community 296`, `Community 299`, `Community 307`, `Community 312`, `Community 314`, `Community 315`, `Community 316`, `Community 317`, `Community 318`, `Community 320`, `Community 329`, `Community 330`, `Community 334`, `Community 339`, `Community 342`, `Community 348`, `Community 349`, `Community 353`, `Community 356`, `Community 359`, `Community 361`, `Community 362`, `Community 363`, `Community 364`, `Community 366`, `Community 370`, `Community 378`, `Community 379`, `Community 380`, `Community 382`, `Community 384`, `Community 385`, `Community 387`, `Community 388`, `Community 398`, `Community 399`, `Community 401`, `Community 403`, `Community 404`, `Community 406`, `Community 410`, `Community 411`, `Community 414`, `Community 415`, `Community 416`, `Community 420`, `Community 422`, `Community 423`, `Community 424`, `Community 426`, `Community 428`, `Community 430`, `Community 431`, `Community 435`, `Community 436`, `Community 438`, `Community 439`, `Community 440`, `Community 441`, `Community 443`, `Community 444`, `Community 445`, `Community 446`, `Community 447`, `Community 448`, `Community 449`, `Community 450`, `Community 452`, `Community 455`, `Community 456`, `Community 457`, `Community 458`, `Community 459`, `Community 460`, `Community 462`, `Community 463`, `Community 464`, `Community 466`, `Community 467`, `Community 468`, `Community 479`, `Community 481`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 492`, `Community 493`, `Community 495`, `Community 497`, `Community 503`, `Community 506`?**
+  _High betweenness centrality (0.115) - this node is a cross-community bridge._
+- **Why does `IOException` connect `Community 408` to `Community 2`, `Community 5`, `Community 7`, `Community 10`, `Community 12`, `Community 18`, `Community 19`, `Community 21`, `Community 25`, `Community 26`, `Community 27`, `Community 544`, `Community 33`, `Community 35`, `Community 40`, `Community 42`, `Community 45`, `Community 50`, `Community 53`, `Community 59`, `Community 61`, `Community 62`, `Community 65`, `Community 67`, `Community 68`, `Community 76`, `Community 86`, `Community 96`, `Community 99`, `Community 101`, `Community 105`, `Community 109`, `Community 114`, `Community 115`, `Community 117`, `Community 119`, `Community 120`, `Community 122`, `Community 125`, `Community 127`, `Community 129`, `Community 132`, `Community 135`, `Community 142`, `Community 144`, `Community 146`, `Community 153`, `Community 672`, `Community 673`, `Community 166`, `Community 180`, `Community 181`, `Community 191`, `Community 704`, `Community 194`, `Community 195`, `Community 204`, `Community 210`, `Community 220`, `Community 242`, `Community 243`, `Community 246`, `Community 250`, `Community 253`, `Community 260`, `Community 264`, `Community 270`, `Community 271`, `Community 277`, `Community 282`, `Community 287`, `Community 288`, `Community 297`, `Community 322`, `Community 352`, `Community 355`, `Community 365`, `Community 371`, `Community 386`, `Community 396`, `Community 397`, `Community 448`, `Community 449`, `Community 465`, `Community 483`, `Community 484`, `Community 486`, `Community 497`, `Community 498`, `Community 506`?**
+  _High betweenness centrality (0.018) - this node is a cross-community bridge._
+- **Why does `ArrayList` connect `Community 92` to `Community 129`, `Community 386`, `Community 135`, `Community 7`, `Community 9`, `Community 139`, `Community 12`, `Community 19`, `Community 404`, `Community 147`, `Community 150`, `Community 276`, `Community 408`, `Community 153`, `Community 26`, `Community 20`, `Community 23`, `Community 287`, `Community 31`, `Community 35`, `Community 292`, `Community 166`, `Community 40`, `Community 169`, `Community 43`, `Community 45`, `Community 303`, `Community 176`, `Community 695`, `Community 55`, `Community 312`, `Community 314`, `Community 191`, `Community 192`, `Community 323`, `Community 68`, `Community 67`, `Community 74`, `Community 75`, `Community 204`, `Community 205`, `Community 334`, `Community 335`, `Community 336`, `Community 82`, `Community 338`, `Community 213`, `Community 86`, `Community 218`, `Community 223`, `Community 224`, `Community 99`, `Community 102`, `Community 106`, `Community 235`, `Community 493`, `Community 109`, `Community 239`, `Community 242`, `Community 379`, `Community 252`, `Community 125`, `Community 244`, `Community 119`, `Community 120`, `Community 123`, `Community 124`, `Community 253`, `Community 127`?**
+  _High betweenness centrality (0.011) - this node is a cross-community bridge._
 - **What connects `$id`, `$schema`, `additionalProperties` to the rest of the system?**
-  _1419 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _1455 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.04395984769816545 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.04373126432727914 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.07868852459016394 - nodes in this community are weakly interconnected._
-- **Should `Community 3` be split into smaller, more focused modules?**
-  _Cohesion score 0.1349206349206349 - nodes in this community are weakly interconnected._
-- **Should `Community 4` be split into smaller, more focused modules?**
-  _Cohesion score 0.06890756302521009 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.07365967365967366 - nodes in this community are weakly interconnected._
+- **Should `Community 2` be split into smaller, more focused modules?**
+  _Cohesion score 0.1012987012987013 - nodes in this community are weakly interconnected._

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -865,13 +865,13 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/RequestBuilder.java": {
-    "mtime": 1781937470.4874096,
-    "ast_hash": "4caa4ad0fe142e3034472acfa165ae6d",
+    "mtime": 1781940318.5842266,
+    "ast_hash": "d42a461c60e080f37268fc6ad09e2b52",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/RestActions.java": {
-    "mtime": 1781937473.5160592,
-    "ast_hash": "c4f5857375706f317f2ed417b6755a1f",
+    "mtime": 1781940318.5852242,
+    "ast_hash": "68793a14906978a031f3598859df4a06",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/ShaftRestAssuredFilter.java": {
@@ -880,13 +880,13 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cli/FileActions.java": {
-    "mtime": 1781791521.2176075,
-    "ast_hash": "c5db66ebe372532e7334a4c5819ab582",
+    "mtime": 1781944667.790053,
+    "ast_hash": "a1d907444ba2bc35977265503c7c916d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java": {
-    "mtime": 1781844357.9471421,
-    "ast_hash": "71d6b39ffdc8ac37416fd3ab223a42f9",
+    "mtime": 1781944667.791053,
+    "ast_hash": "c7bf3c6c81a85d681faa3a2756728587",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cucumber/AssertionSteps.java": {
@@ -910,13 +910,13 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/DriverFactory.java": {
-    "mtime": 1781937291.7601967,
-    "ast_hash": "02ceffa9794f31ec98e4404eac1c178d",
+    "mtime": 1781940318.5862248,
+    "ast_hash": "8ee0caf3a105473f413b00ac8f1f9adf",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/SHAFT.java": {
-    "mtime": 1781937229.4369595,
-    "ast_hash": "50531e0f6eb68cfc2e6423f06020da09",
+    "mtime": 1781940318.5872242,
+    "ast_hash": "56b24361ff5a3be5b222c16bf0f1a08b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/$.java": {
@@ -925,8 +925,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/BrowserStackHelper.java": {
-    "mtime": 1781937298.007171,
-    "ast_hash": "71890d87fb4016c0ecfa7eeddd0127cc",
+    "mtime": 1781940318.5872242,
+    "ast_hash": "8269be54fd38e960b0e7acb0b3009e21",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/BrowserStackSdkHelper.java": {
@@ -1315,8 +1315,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java": {
-    "mtime": 1781937097.5622923,
-    "ast_hash": "ba8d7be40651c9281869d63922498517",
+    "mtime": 1781944986.4916005,
+    "ast_hash": "110d58ed49742a381585d8ee2e79e7fb",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Jira.java": {
@@ -1770,13 +1770,13 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/RequestBuilderTests.java": {
-    "mtime": 1781937329.2081864,
-    "ast_hash": "60f13ae49550363c4aab5812129136e4",
+    "mtime": 1781940318.5882251,
+    "ast_hash": "08d7b254049cc8daac555e9f2f9f2aa9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/RestActionsCoverageUnitTest.java": {
-    "mtime": 1781937346.4310806,
-    "ast_hash": "e20a7c1663b9389494090f73e9e477fe",
+    "mtime": 1781940318.589224,
+    "ast_hash": "877020d57c0804f606df907214862a25",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/SwaggerContractTest.java": {
@@ -1795,8 +1795,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/cli/FileActionsCoverageUnitTest.java": {
-    "mtime": 1781788245.5372522,
-    "ast_hash": "4f39d48cdb9f14fd4ecf68a36fb5298e",
+    "mtime": 1781944667.7920532,
+    "ast_hash": "c45c9550223fe7dcd993697eacf00c6b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/cucumber/ElementStepsCoverageUnitTest.java": {
@@ -2985,8 +2985,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java": {
-    "mtime": 1781858843.5829759,
-    "ast_hash": "af6a1ea86c3daab6d5cc9bdd1b3ad15a",
+    "mtime": 1781944667.7930536,
+    "ast_hash": "0ce15abe7ff432e30ff79ff6e2e6dfff",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TestClass.java": {
@@ -3445,8 +3445,8 @@
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecordingService.java": {
-    "mtime": 1781546315.8051121,
-    "ast_hash": "a5392ec480283bf07fe215e170ef5f9e",
+    "mtime": 1781945277.5619767,
+    "ast_hash": "030a081417878e0e8e412d4726a47468",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecordingStatus.java": {
@@ -3480,8 +3480,8 @@
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpRuntimePaths.java": {
-    "mtime": 1781853107.4607408,
-    "ast_hash": "a8e8a55f38ce76480344e14b2cbcb892",
+    "mtime": 1781944986.492597,
+    "ast_hash": "061f637c0b9cfdaf145423bc368a7295",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpScreenshotResult.java": {
@@ -3495,8 +3495,8 @@
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/MobileService.java": {
-    "mtime": 1781546635.275178,
-    "ast_hash": "798ad939332863672bfb7ac0d2a4954e",
+    "mtime": 1781945498.422192,
+    "ast_hash": "639c2b4c39c5728dc59e54a2ac897a39",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/NaturalActionService.java": {
@@ -4920,8 +4920,8 @@
     "semantic_hash": ""
   },
   "shaft-mcp/allure-report/summary.json": {
-    "mtime": 1781888935.9161203,
-    "ast_hash": "840cdb837ee805d8b00001273a10244d",
+    "mtime": 1781946119.6758664,
+    "ast_hash": "299c602746307f735bca95f9386920ed",
     "semantic_hash": ""
   },
   "shaft-video/allure-results/3a534026-89a3-40f7-bfea-4d15196f084b-result.json": {
@@ -5150,7 +5150,7 @@
     "semantic_hash": ""
   },
   "shaft-mcp/allurerc.yaml": {
-    "mtime": 1781888933.6406257,
+    "mtime": 1781946116.922835,
     "ast_hash": "1861b0462f0deb9c11c0eea45f2bdab1",
     "semantic_hash": ""
   },
@@ -7419,86 +7419,6 @@
     "ast_hash": "c8e6f3300e0e04126abcd31241609c0e",
     "semantic_hash": ""
   },
-  "shaft-mcp/allure-results/015e8e8d-543f-472f-967f-ae31327329e7-container.json": {
-    "mtime": 1781888933.624616,
-    "ast_hash": "c911d85483c9b10fdd0250e1f281568a",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/09f316fc-aa3e-45b1-a87f-7ccfa8610b9b-result.json": {
-    "mtime": 1781888933.6266236,
-    "ast_hash": "09d0fd5a705b555fe8aeca385714e3b1",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/295374d9-600c-4a8e-be0f-ab8a26e6270b-result.json": {
-    "mtime": 1781888933.6276224,
-    "ast_hash": "6c83461dde4255de30e1b21bb4feb14e",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/406e5db1-877c-4eae-a165-af2e1413d1bb-result.json": {
-    "mtime": 1781888933.628622,
-    "ast_hash": "207cb211c2dbf72e6e1f27c792237627",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/5fd6b8bd-c0e7-4750-858a-9a0bbea06186-container.json": {
-    "mtime": 1781888933.629622,
-    "ast_hash": "83a7b5a2e61d6741d26b6ea7197936bb",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/669c260f-4d59-460d-83d9-e0966e413095-container.json": {
-    "mtime": 1781888933.6306229,
-    "ast_hash": "2b30ae6da9cde07c0900ce0f97f89c9f",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/7cbc499c-802d-4825-8d0e-ce92e388dee0-result.json": {
-    "mtime": 1781888933.6316218,
-    "ast_hash": "5512f12efc5f0f2bb3b4c1e984d69eff",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/9d558d2f-5a1e-46e2-b1ed-9a7f98dfef6f-container.json": {
-    "mtime": 1781888933.6326222,
-    "ast_hash": "11f01938c67570517ce05b9058bcd47f",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/a1577f7b-a9ad-4eb0-bcb7-a68381388786-result.json": {
-    "mtime": 1781888933.6326222,
-    "ast_hash": "ef3a85384ec7852d2c1bbfd80c6b6bd4",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/b18d8935-9790-47c8-bb8a-0e5d9a360967-container.json": {
-    "mtime": 1781888933.6336224,
-    "ast_hash": "e56ecaafed554981d8a8e6276fbf4a25",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/bd85b917-de16-45bc-9fec-ee72d7469f41-container.json": {
-    "mtime": 1781888933.634623,
-    "ast_hash": "0b9a5c0baa7b367e22f9d5f67485511a",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/c65f5c52-6260-41d5-a934-6ef4f1bb1e78-result.json": {
-    "mtime": 1781888933.6356227,
-    "ast_hash": "8f4f1800f0854aca01b32df2c6ae35e0",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/d50d37b1-fcf8-4d26-8eec-755ad69f9606-container.json": {
-    "mtime": 1781888933.6366239,
-    "ast_hash": "75d6f3d0b7c03084756ec8ffb9861789",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/d816702d-c8ba-49de-b451-45b270eecea0-result.json": {
-    "mtime": 1781888933.637624,
-    "ast_hash": "e416ce99a6f62d4d7a91713a873fc15c",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/eb3c8173-0979-4240-bae8-5fa59064390d-container.json": {
-    "mtime": 1781888933.637624,
-    "ast_hash": "b48b160a24f995c4f4d58e772499533f",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/f04ad1af-2bd4-466e-8b7f-87dcc2b81447-container.json": {
-    "mtime": 1781888933.638627,
-    "ast_hash": "14e71fd5d6d79d5ec75d345501b6bd06",
-    "semantic_hash": ""
-  },
   "shaft-mcp/src/main/java/com/shaft/mcp/GuideService.java": {
     "mtime": 1781892033.7500644,
     "ast_hash": "26c2ee77f1e0c5943e7d43c3d0f60c27",
@@ -7594,46 +7514,6 @@
     "ast_hash": "6a166c073ae794654ad52e445d7e4d94",
     "semantic_hash": ""
   },
-  "shaft-mcp/allure-results/1f6dbb8f-2cdc-4e2b-8bb2-9038401bb13c-attachment.txt": {
-    "mtime": 1781888933.600101,
-    "ast_hash": "3584b728ffad3c1481e236b4408eca74",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/6e25a4ef-2973-4b2e-a9dc-4d55ba9df518-attachment.txt": {
-    "mtime": 1781888930.4937003,
-    "ast_hash": "300720a9145e91e0d210beac1fcd7e2f",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/83655841-a6a9-4ac8-a00d-7f27ef0a8c73-attachment.txt": {
-    "mtime": 1781888933.5801015,
-    "ast_hash": "625608347e839bedaab36e304acba286",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/b4669c2a-9e5c-465f-9a00-30591557d1cb-attachment.txt": {
-    "mtime": 1781888930.2027235,
-    "ast_hash": "6cd03edfda7db710f62e771ff2877a61",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/cabfc200-eb3e-43dd-a224-e0ece576f971-attachment.txt": {
-    "mtime": 1781888930.4747043,
-    "ast_hash": "2ac70a09d036fd20f73970cac94fe9a6",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/dd8a9519-d0c7-42b8-bb03-95e888effb10-attachment.txt": {
-    "mtime": 1781888930.3311727,
-    "ast_hash": "58bcd5f147009a23b79edd08586e5267",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/e03f6574-4899-4879-9c6d-bfe97927d64b-attachment.txt": {
-    "mtime": 1781888933.5921063,
-    "ast_hash": "ee4e20cf638a0aa6bb37ff8ea80cfc91",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/execution-summary/ExecutionSummaryReport_19-06-2026_20-08-53-6130-PM.html": {
-    "mtime": 1781888933.619109,
-    "ast_hash": "458dc525e443c5b9db3a33ae71835097",
-    "semantic_hash": ""
-  },
   "shaft-mcp/performanceReport/PerformanceReport_19-06-2026_19-04-15-5069-PM.html": {
     "mtime": 1781885055.507979,
     "ast_hash": "658058b81c94c0dd7e065b172d2ead1b",
@@ -7667,6 +7547,281 @@
   "shaft-mcp/performanceReport/PerformanceReport_19-06-2026_20-08-53-6181-PM.html": {
     "mtime": 1781888933.619109,
     "ast_hash": "dab43fc2110c1e8b7ab4805a515f0d59",
+    "semantic_hash": ""
+  },
+  ".memory/memory/decisions/prefer-shaft-api-builder-facade-for-rest-work.json": {
+    "mtime": 1781940318.5287135,
+    "ast_hash": "6c5f689fe277f7670d815e22bb7a6fdf",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/11b9d6e7-b10b-4784-89ea-27d5db7da3c8-result.json": {
+    "mtime": 1781946116.8968375,
+    "ast_hash": "568565e8244cdb0d7ebb8f8f08049fcb",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/14dab5f7-c950-476a-9674-673edff9791c-container.json": {
+    "mtime": 1781946116.8988357,
+    "ast_hash": "f6e80a85b4cb85bf885275778190cb3b",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/1ef51832-e8a1-484f-9621-4a6ec0418bc8-container.json": {
+    "mtime": 1781946116.899838,
+    "ast_hash": "e53511bfa5aedc2a9872df32296b4fcb",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/2a3415de-4e2c-468a-970a-6285ea968b03-container.json": {
+    "mtime": 1781946116.9008367,
+    "ast_hash": "13f0c3080581566e62ca433d0595c081",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/2a4c5074-bfbb-4e94-b994-6a06d82ddf19-container.json": {
+    "mtime": 1781946116.9018376,
+    "ast_hash": "6c1ecd8c096faeaa6c78c5936ab656f3",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/316fbf73-fb5e-4b3c-a6d9-98fd625c6db7-container.json": {
+    "mtime": 1781946116.9028356,
+    "ast_hash": "4d3670839a5c6021795efc569f43ab7a",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/398e92e2-b222-43ae-a000-647468df9a60-container.json": {
+    "mtime": 1781946116.9038339,
+    "ast_hash": "ec7ad2592844597617e603728581657e",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/5b713e50-e935-4960-ab1e-532157288a74-result.json": {
+    "mtime": 1781946116.9058356,
+    "ast_hash": "5ebbdbc1b6811aa34876ae0cf8d6d377",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/5e9a4351-7a93-4909-af11-18e1bd4a4fb3-container.json": {
+    "mtime": 1781946116.9068363,
+    "ast_hash": "7c9ed8519b016995b56d48e9885ad9c5",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/6538701c-26da-486b-8005-35247ab79df5-result.json": {
+    "mtime": 1781946116.9078324,
+    "ast_hash": "6fb0640915983da7d9dc94fbc0c80a79",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/67b7a43c-358b-4e6b-95aa-921aa3da8d8d-result.json": {
+    "mtime": 1781946116.908835,
+    "ast_hash": "da0e036058693142268d7a8db521b040",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/6ff6c4f0-056d-43e3-8fb8-a10809a576b4-result.json": {
+    "mtime": 1781946116.9108381,
+    "ast_hash": "bfd0b34eea34c643636ac790c5e6ab68",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/76c17eb5-7baf-42e4-98d4-fda9dac4dc76-container.json": {
+    "mtime": 1781946116.9118354,
+    "ast_hash": "1b10c013e2c0b9e643960c28ba88b8c6",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/7c79a69a-5248-4e35-83d3-88cb51c2a875-container.json": {
+    "mtime": 1781946116.9128337,
+    "ast_hash": "be3b43cf408bf5cf9d1576d535005f0d",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/7d987975-e1f0-46ea-8355-58c90a0e1d8d-result.json": {
+    "mtime": 1781946116.914835,
+    "ast_hash": "34d1c29dc6f3a97b8ee6184e9ff20531",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/8cc33d3e-ed24-4b60-8f6e-285c2969b931-container.json": {
+    "mtime": 1781946116.9158342,
+    "ast_hash": "6db9eb41aa76b0454a99e84cf2fd2e05",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/a0650288-bab3-4f4c-8981-c6adef623be0-container.json": {
+    "mtime": 1781946116.916834,
+    "ast_hash": "7ebc9992697e831c66a2b0ca8c8a3d48",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/b12264b0-075a-4b35-958d-623652fc705c-result.json": {
+    "mtime": 1781946116.9178345,
+    "ast_hash": "d1d69c18f57a1bd68dd1843469ba1716",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/b82187c8-b198-4a52-8df7-877e39b04a3c-container.json": {
+    "mtime": 1781946116.9178345,
+    "ast_hash": "75c140f1150ec561fc59a552524663e4",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/b85f86e6-14ee-4de1-b670-c895493d8a80-result.json": {
+    "mtime": 1781946116.9198353,
+    "ast_hash": "10c941cad2a12e719df8b558d7ec1ca9",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/c3e50db4-c323-4ab4-8e45-7286120ddf13-result.json": {
+    "mtime": 1781946116.9208333,
+    "ast_hash": "44daee94030f67dfe6da26826f6e381f",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/src/main/java/com/shaft/mcp/McpAndroidEmulatorProposal.java": {
+    "mtime": 1781945018.6783564,
+    "ast_hash": "988ae0b97b259a30649c44f934f09cd8",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/src/main/java/com/shaft/mcp/McpAppiumCommandRecorder.java": {
+    "mtime": 1781945268.2229078,
+    "ast_hash": "df3d6a77504795f8a971624abe983cda",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/src/main/java/com/shaft/mcp/McpAppiumInspectorProxy.java": {
+    "mtime": 1781945508.2117178,
+    "ast_hash": "45401318f5b88be7b3c875db5a091a4a",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileCode.java": {
+    "mtime": 1781945052.6058066,
+    "ast_hash": "3d9e68b279b6ce8e87a8b40a58ab8964",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileDevice.java": {
+    "mtime": 1781945018.6773565,
+    "ast_hash": "abfe9d904fad08f787f85b9a417cef5a",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInspectorPlan.java": {
+    "mtime": 1781945018.6793573,
+    "ast_hash": "8f87bc3bd23007a6ffd90140ebc975ce",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInspectorRecordingService.java": {
+    "mtime": 1781945838.047227,
+    "ast_hash": "fa34f7f236dbe2150e3e7de2e79cd19e",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInspectorRecordingStatus.java": {
+    "mtime": 1781945018.6793573,
+    "ast_hash": "80dd2dad7f450b28fa45c0df0e31a78c",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainService.java": {
+    "mtime": 1781945823.8655055,
+    "ast_hash": "6bbc465e8c127c82725978af70fe4d51",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainStatus.java": {
+    "mtime": 1781945018.6793573,
+    "ast_hash": "79b0b76536c4570e9b06652f27385578",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/src/main/java/com/shaft/mcp/McpProcessRunner.java": {
+    "mtime": 1781945815.7217858,
+    "ast_hash": "338c868473c19dd1e9c0c6cf09e1d51f",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/src/test/java/com/shaft/mcp/McpAppiumCommandRecorderTest.java": {
+    "mtime": 1781945667.723387,
+    "ast_hash": "8869fe9954e3d8e823a2c9ba90f22a98",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/src/test/java/com/shaft/mcp/McpMobileInspectorRecordingServiceTest.java": {
+    "mtime": 1781945731.274139,
+    "ast_hash": "7981e06d3eee03758c00f6f943f06e5e",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/src/test/java/com/shaft/mcp/McpMobileToolchainServiceTest.java": {
+    "mtime": 1781945853.7513647,
+    "ast_hash": "e42ae27ee79b2a8ea263acb41a55101a",
+    "semantic_hash": ""
+  },
+  ".memory/memory/decisions/prefer-shaft-api-builder-facade-for-rest-work.md": {
+    "mtime": 1781940318.5287135,
+    "ast_hash": "1e26526229bf60c93d0d4a1302628d55",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-report/2026-06-20_11-55-19-374_AllureReport.html": {
+    "mtime": 1781945719.320581,
+    "ast_hash": "f1a438bfda9043b054706ee1564e8198",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-report/2026-06-20_11-55-57-442_AllureReport.html": {
+    "mtime": 1781945757.3903947,
+    "ast_hash": "305109533cd7fa21d026da44775bb17f",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-report/2026-06-20_11-58-07-205_AllureReport.html": {
+    "mtime": 1781945887.1532252,
+    "ast_hash": "95df955e6170bf8529175931d8adfe24",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-report/2026-06-20_12-01-59-732_AllureReport.html": {
+    "mtime": 1781946119.674866,
+    "ast_hash": "79bb1709eacba627a1ccd988a6f6a1f9",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/06fe7ae8-5f6f-4798-8491-f4a31fef9f1f-attachment.txt": {
+    "mtime": 1781946116.7610505,
+    "ast_hash": "9d2f9902bcc3e273cd45b6d5b6de6b02",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/0f14e855-9f41-479b-8dd1-b8d2a54350da-attachment.txt": {
+    "mtime": 1781946116.8043182,
+    "ast_hash": "9e1357b1c24ecfbdd6a2d2e982086e9d",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/18653a85-4426-4305-bead-3087e7a8c6ab-attachment.txt": {
+    "mtime": 1781946116.5309353,
+    "ast_hash": "aa82b39493b7ddbb85b4aa5ab55515df",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/3cc44e1a-d784-4351-a0d4-cb6f4cb7e57d-attachment.txt": {
+    "mtime": 1781946116.5789332,
+    "ast_hash": "4f6245d723250cfb92789fc4624d7861",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/7da86075-a0aa-42d6-bbfd-023c0363f0d8-attachment.txt": {
+    "mtime": 1781946116.7840595,
+    "ast_hash": "1ed8b1903a75d59834a9231515b85bd8",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/7f7f3f1b-3012-4274-b883-cccf7270f242-attachment.txt": {
+    "mtime": 1781946116.8643222,
+    "ast_hash": "5889193668cb9d6b27a1eda107db65fc",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/890c7736-ae5d-4d14-b5f2-58346c377ddc-attachment.txt": {
+    "mtime": 1781946116.8263202,
+    "ast_hash": "88e1438f6c55d9f64f54937aebbf90d7",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/d5dbb248-fed5-4d50-a0cb-201186408a8c-attachment.txt": {
+    "mtime": 1781946116.3739011,
+    "ast_hash": "51846fa333096c792201278b5a10b65e",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/ec295a0e-6bfe-42ae-b218-8e27f35c24cd-attachment.txt": {
+    "mtime": 1781946116.8823195,
+    "ast_hash": "64ff207c68ad6c228022fcf163197f43",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/execution-summary/ExecutionSummaryReport_20-06-2026_12-01-56-8920-PM.html": {
+    "mtime": 1781946116.8978372,
+    "ast_hash": "66ac0c6e0ec35bfa36f41b3deeeff908",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/performanceReport/PerformanceReport_20-06-2026_11-55-16-1836-AM.html": {
+    "mtime": 1781945716.184606,
+    "ast_hash": "4ee1cca4420f6b1d0f50ea8e05823656",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/performanceReport/PerformanceReport_20-06-2026_11-55-54-8196-AM.html": {
+    "mtime": 1781945754.8206334,
+    "ast_hash": "b05644029568a880ab6f3d9b18e8f6a9",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/performanceReport/PerformanceReport_20-06-2026_11-58-04-6273-AM.html": {
+    "mtime": 1781945884.6283813,
+    "ast_hash": "b9b7d3e89affb40a9b28463a85e9b707",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/performanceReport/PerformanceReport_20-06-2026_12-01-56-8968-PM.html": {
+    "mtime": 1781946116.8978372,
+    "ast_hash": "15a7274ce1ba6859fea755025c6a19fd",
     "semantic_hash": ""
   }
 }

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java
@@ -47,6 +47,80 @@ public interface Internal extends EngineProperties<Internal> {
     String nodeLtsVersion();
 
     /**
+     * Appium server npm package version used by SHAFT MCP when it needs to bootstrap
+     * a local Appium server without requiring administrator-installed tools.
+     */
+    @Key("appiumServerVersion")
+    @DefaultValue("3.5.2")
+    String appiumServerVersion();
+
+    /**
+     * Appium Inspector plugin npm package version used by SHAFT MCP for wrapped
+     * mobile recording sessions.
+     */
+    @Key("appiumInspectorPluginVersion")
+    @DefaultValue("2026.5.1")
+    String appiumInspectorPluginVersion();
+
+    /**
+     * Appium UiAutomator2 driver npm package version used by SHAFT MCP for Android.
+     */
+    @Key("appiumUiAutomator2DriverVersion")
+    @DefaultValue("7.6.2")
+    String appiumUiAutomator2DriverVersion();
+
+    /**
+     * Appium XCUITest driver npm package version used by SHAFT MCP for iOS attach
+     * and recording flows on macOS.
+     */
+    @Key("appiumXcuitestDriverVersion")
+    @DefaultValue("11.12.2")
+    String appiumXcuitestDriverVersion();
+
+    /**
+     * Android command-line tools build number used by SHAFT MCP when no Android SDK
+     * tools are already available on the machine.
+     */
+    @Key("androidCommandLineToolsVersion")
+    @DefaultValue("14742923")
+    String androidCommandLineToolsVersion();
+
+    /**
+     * Default Android API level proposed for SHAFT-managed emulator creation.
+     */
+    @Key("androidEmulatorApiLevel")
+    @DefaultValue("36")
+    int androidEmulatorApiLevel();
+
+    /**
+     * Default Android virtual device profile proposed for SHAFT-managed emulators.
+     */
+    @Key("androidEmulatorDeviceProfile")
+    @DefaultValue("pixel_8")
+    String androidEmulatorDeviceProfile();
+
+    /**
+     * Default Android system image tag proposed for SHAFT-managed emulators.
+     */
+    @Key("androidEmulatorImageTag")
+    @DefaultValue("google_apis")
+    String androidEmulatorImageTag();
+
+    /**
+     * Default Android emulator memory size in MB.
+     */
+    @Key("androidEmulatorRamMb")
+    @DefaultValue("4096")
+    int androidEmulatorRamMb();
+
+    /**
+     * Default Android emulator CPU core count.
+     */
+    @Key("androidEmulatorCores")
+    @DefaultValue("2")
+    int androidEmulatorCores();
+
+    /**
      * Google Analytics 4 Measurement ID used for anonymous telemetry.
      * Found in the GA4 console under Admin &gt; Data Streams &gt; choose your stream &gt; Measurement ID.
      * Override in {@code internal.properties} to route telemetry to a different GA4 property.

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpAndroidEmulatorProposal.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpAndroidEmulatorProposal.java
@@ -1,0 +1,41 @@
+package com.shaft.mcp;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * User-confirmable Android emulator provisioning proposal.
+ */
+public record McpAndroidEmulatorProposal(
+        String avdName,
+        String deviceProfile,
+        int apiLevel,
+        String imageTag,
+        String abi,
+        int ramMb,
+        int cores,
+        Path sdkRoot,
+        Path avdHome,
+        List<String> sdkPackages,
+        List<String> commands,
+        List<String> warnings) {
+    /**
+     * Creates an immutable Android emulator proposal.
+     */
+    public McpAndroidEmulatorProposal {
+        avdName = text(avdName);
+        deviceProfile = text(deviceProfile);
+        apiLevel = Math.max(apiLevel, 1);
+        imageTag = text(imageTag);
+        abi = text(abi);
+        ramMb = Math.max(ramMb, 512);
+        cores = Math.max(cores, 1);
+        sdkPackages = sdkPackages == null ? List.of() : List.copyOf(sdkPackages);
+        commands = commands == null ? List.of() : List.copyOf(commands);
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpAppiumCommandRecorder.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpAppiumCommandRecorder.java
@@ -1,0 +1,315 @@
+package com.shaft.mcp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BooleanSupplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Converts Appium WebDriver commands from Inspector traffic into MCP mobile actions.
+ */
+final class McpAppiumCommandRecorder {
+    private static final Pattern FIND_ELEMENT = Pattern.compile(".*/session/[^/]+/element$");
+    private static final Pattern FIND_ELEMENTS = Pattern.compile(".*/session/[^/]+/elements$");
+    private static final Pattern ELEMENT_COMMAND = Pattern.compile(".*/session/[^/]+/element/([^/]+)/([^/]+)$");
+    private static final Pattern ACTIONS = Pattern.compile(".*/session/[^/]+/actions$");
+    private static final Pattern ORIENTATION = Pattern.compile(".*/session/[^/]+/orientation$");
+    private static final Pattern HIDE_KEYBOARD = Pattern.compile(".*/session/[^/]+/appium/device/hide_keyboard$");
+    private static final Pattern BACKGROUND_APP = Pattern.compile(".*/session/[^/]+/appium/app/background$");
+    private static final Pattern ACTIVATE_APP = Pattern.compile(".*/session/[^/]+/appium/device/activate_app$");
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final McpMobileRecordingService recorder;
+    private final BooleanSupplier paused;
+    private final Map<String, LocatorRef> elementLocators = new ConcurrentHashMap<>();
+
+    McpAppiumCommandRecorder(McpMobileRecordingService recorder, BooleanSupplier paused) {
+        this.recorder = recorder;
+        this.paused = paused == null ? () -> false : paused;
+    }
+
+    void capture(String method, String path, String requestBody, int responseStatus, String responseBody) {
+        if (!"POST".equalsIgnoreCase(method) || paused.getAsBoolean() || responseStatus / 100 != 2) {
+            return;
+        }
+        try {
+            if (FIND_ELEMENT.matcher(path).matches()) {
+                captureFoundElement(requestBody, responseBody, false);
+                return;
+            }
+            if (FIND_ELEMENTS.matcher(path).matches()) {
+                captureFoundElement(requestBody, responseBody, true);
+                return;
+            }
+            Matcher element = ELEMENT_COMMAND.matcher(path);
+            if (element.matches()) {
+                captureElementCommand(element.group(1), element.group(2), requestBody);
+                return;
+            }
+            if (ACTIONS.matcher(path).matches()) {
+                captureActions(requestBody);
+                return;
+            }
+            if (ORIENTATION.matcher(path).matches()) {
+                captureOrientation(requestBody);
+                return;
+            }
+            if (HIDE_KEYBOARD.matcher(path).matches()) {
+                record("hideKeyboard", null, "", Map.of(),
+                        "driver.touch().hideNativeKeyboard();",
+                        "driver.touch().hideNativeKeyboard();",
+                        false);
+                return;
+            }
+            if (BACKGROUND_APP.matcher(path).matches()) {
+                captureBackgroundApp(requestBody);
+                return;
+            }
+            if (ACTIVATE_APP.matcher(path).matches()) {
+                captureActivateApp(requestBody);
+            }
+        } catch (Exception exception) {
+            recorder.recordWarning("Inspector command was not recorded: " + exception.getMessage());
+        }
+    }
+
+    private void captureFoundElement(String requestBody, String responseBody, boolean multiple) throws Exception {
+        JsonNode request = mapper.readTree(blankJson(requestBody));
+        Optional<LocatorRef> locator = locator(request.path("using").asText(), request.path("value").asText());
+        if (locator.isEmpty()) {
+            recorder.recordWarning("Inspector locator strategy is not replayable by SHAFT: "
+                    + request.path("using").asText());
+            return;
+        }
+        JsonNode value = mapper.readTree(blankJson(responseBody)).path("value");
+        if (multiple && value.isArray()) {
+            for (JsonNode element : value) {
+                elementId(element).ifPresent(id -> elementLocators.put(id, locator.get()));
+            }
+        } else {
+            elementId(value).ifPresent(id -> elementLocators.put(id, locator.get()));
+        }
+    }
+
+    private void captureElementCommand(String elementId, String command, String requestBody) throws Exception {
+        LocatorRef locator = elementLocators.get(elementId);
+        if (locator == null) {
+            recorder.recordWarning("Inspector " + command
+                    + " command used an element that was not found through this recording proxy.");
+            return;
+        }
+        String locatorCode = McpMobileCode.locatorCode(locator.strategy(), locator.value());
+        switch (command) {
+            case "click" -> record("tap", locator.strategy(), locator.value(), Map.of(),
+                    "driver.touch().tap(" + locatorCode + ");",
+                    "driver.touch().tap(" + locatorCode + ");",
+                    false);
+            case "clear" -> record("clear", locator.strategy(), locator.value(), Map.of(),
+                    "driver.element().clear(" + locatorCode + ");",
+                    "driver.element().clear(" + locatorCode + ");",
+                    false);
+            case "value" -> {
+                String value = textValue(mapper.readTree(blankJson(requestBody)));
+                record("type", locator.strategy(), locator.value(), Map.of("value", value),
+                        "driver.element().type(" + locatorCode + ", " + McpMobileCode.java(value) + ");",
+                        "driver.element().type(" + locatorCode + ", \"<redacted>\");",
+                        true);
+            }
+            default -> recorder.recordWarning("Inspector element command is not yet replayable: " + command);
+        }
+    }
+
+    private void captureActions(String requestBody) throws Exception {
+        JsonNode actions = mapper.readTree(blankJson(requestBody)).path("actions");
+        if (!actions.isArray()) {
+            recorder.recordWarning("Inspector W3C actions payload did not include an actions array.");
+            return;
+        }
+        for (JsonNode source : actions) {
+            if (!"pointer".equals(source.path("type").asText())) {
+                continue;
+            }
+            String pointerType = source.path("parameters").path("pointerType").asText();
+            if (!pointerType.isBlank() && !"touch".equals(pointerType) && !"pen".equals(pointerType)) {
+                continue;
+            }
+            Optional<PointerGesture> gesture = pointerGesture(source.path("actions"));
+            if (gesture.isPresent()) {
+                recordGesture(gesture.get());
+                return;
+            }
+        }
+        recorder.recordWarning("Inspector W3C actions payload did not contain a replayable touch gesture.");
+    }
+
+    private void recordGesture(PointerGesture gesture) {
+        if (gesture.swipe()) {
+            int duration = Math.max(gesture.durationMillis(), 100);
+            Map<String, String> params = Map.of(
+                    "startX", String.valueOf(gesture.startX()),
+                    "startY", String.valueOf(gesture.startY()),
+                    "endX", String.valueOf(gesture.endX()),
+                    "endY", String.valueOf(gesture.endY()),
+                    "durationMillis", String.valueOf(duration));
+            String code = McpMobileCode.swipeCoordinatesCode(
+                    gesture.startX(), gesture.startY(), gesture.endX(), gesture.endY(), duration);
+            record("swipeCoordinates", null, "", params, code, code, false);
+        } else {
+            Map<String, String> params = Map.of(
+                    "x", String.valueOf(gesture.startX()),
+                    "y", String.valueOf(gesture.startY()));
+            String code = McpMobileCode.tapCoordinatesCode(gesture.startX(), gesture.startY());
+            record("tapCoordinates", null, "", params, code, code, false);
+        }
+    }
+
+    private void captureOrientation(String requestBody) throws Exception {
+        String orientation = mapper.readTree(blankJson(requestBody)).path("orientation").asText("PORTRAIT")
+                .toUpperCase(java.util.Locale.ROOT);
+        String code = "driver.touch().rotate(ScreenOrientation." + orientation + ");";
+        record("rotate", null, "", Map.of("orientation", orientation), code, code, false);
+    }
+
+    private void captureBackgroundApp(String requestBody) throws Exception {
+        JsonNode request = mapper.readTree(blankJson(requestBody));
+        int seconds = request.has("seconds") ? request.path("seconds").asInt() : request.path("duration").asInt(1);
+        String code = "driver.touch().sendAppToBackground(" + seconds + ");";
+        record("backgroundApp", null, "", Map.of("seconds", String.valueOf(seconds)), code, code, false);
+    }
+
+    private void captureActivateApp(String requestBody) throws Exception {
+        JsonNode request = mapper.readTree(blankJson(requestBody));
+        String appId = firstText(request, "appId", "bundleId");
+        if (appId.isBlank()) {
+            recorder.recordWarning("Inspector activate app command did not include appId or bundleId.");
+            return;
+        }
+        String code = "driver.touch().activateAppFromBackground(" + McpMobileCode.java(appId) + ");";
+        record("activateApp", null, "", Map.of("appId", appId), code, code, false);
+    }
+
+    private Optional<PointerGesture> pointerGesture(JsonNode events) {
+        if (!events.isArray()) {
+            return Optional.empty();
+        }
+        int lastX = 0;
+        int lastY = 0;
+        int startX = 0;
+        int startY = 0;
+        int endX = 0;
+        int endY = 0;
+        int duration = 0;
+        boolean hasPosition = false;
+        boolean pointerDown = false;
+        boolean sawDown = false;
+        boolean movedWhileDown = false;
+        for (JsonNode event : events) {
+            String type = event.path("type").asText();
+            if ("pointerMove".equals(type)) {
+                lastX = event.path("x").asInt(lastX);
+                lastY = event.path("y").asInt(lastY);
+                hasPosition = true;
+                if (pointerDown) {
+                    endX = lastX;
+                    endY = lastY;
+                    duration += event.path("duration").asInt(0);
+                    movedWhileDown = true;
+                }
+            } else if ("pointerDown".equals(type) && hasPosition) {
+                pointerDown = true;
+                sawDown = true;
+                startX = lastX;
+                startY = lastY;
+                endX = lastX;
+                endY = lastY;
+            } else if ("pointerUp".equals(type) && pointerDown) {
+                pointerDown = false;
+            } else if ("pause".equals(type) && pointerDown) {
+                duration += event.path("duration").asInt(0);
+            }
+        }
+        if (!sawDown) {
+            return Optional.empty();
+        }
+        return Optional.of(new PointerGesture(startX, startY, endX, endY, duration, movedWhileDown
+                && (startX != endX || startY != endY)));
+    }
+
+    private Optional<LocatorRef> locator(String using, String value) {
+        String normalized = using == null ? "" : using.trim().toLowerCase(java.util.Locale.ROOT);
+        if (value == null || value.isBlank()) {
+            return Optional.empty();
+        }
+        return switch (normalized) {
+            case "accessibility id" -> Optional.of(new LocatorRef(locatorStrategy.ACCESSIBILITY_ID, value));
+            case "id" -> Optional.of(new LocatorRef(locatorStrategy.ID, value));
+            case "xpath" -> Optional.of(new LocatorRef(locatorStrategy.XPATH, value));
+            case "name" -> Optional.of(new LocatorRef(locatorStrategy.NAME, value));
+            case "class name" -> Optional.of(new LocatorRef(locatorStrategy.CLASSNAME, value));
+            case "css selector" -> Optional.of(new LocatorRef(locatorStrategy.CSSSELECTOR, value));
+            case "-android uiautomator" -> Optional.of(new LocatorRef(locatorStrategy.ANDROID_UIAUTOMATOR, value));
+            case "-ios predicate string" -> Optional.of(new LocatorRef(locatorStrategy.IOS_PREDICATE, value));
+            case "-ios class chain" -> Optional.of(new LocatorRef(locatorStrategy.IOS_CLASS_CHAIN, value));
+            default -> Optional.empty();
+        };
+    }
+
+    private Optional<String> elementId(JsonNode element) {
+        if (element == null || element.isMissingNode() || element.isNull()) {
+            return Optional.empty();
+        }
+        String w3c = element.path("element-6066-11e4-a52e-4f735466cecf").asText();
+        if (!w3c.isBlank()) {
+            return Optional.of(w3c);
+        }
+        String legacy = element.path("ELEMENT").asText();
+        return legacy.isBlank() ? Optional.empty() : Optional.of(legacy);
+    }
+
+    private String textValue(JsonNode request) {
+        String text = request.path("text").asText();
+        if (!text.isBlank()) {
+            return text;
+        }
+        JsonNode value = request.path("value");
+        if (value.isArray()) {
+            List<String> characters = new ArrayList<>();
+            value.forEach(node -> characters.add(node.asText()));
+            return String.join("", characters);
+        }
+        return value.asText("");
+    }
+
+    private String firstText(JsonNode request, String first, String second) {
+        String value = request.path(first).asText();
+        return value.isBlank() ? request.path(second).asText("") : value;
+    }
+
+    private McpMobileRecordedAction record(
+            String action,
+            locatorStrategy strategy,
+            String locatorValue,
+            Map<String, String> parameters,
+            String javaCode,
+            String redactedJavaCode,
+            boolean sensitive) {
+        return recorder.record(action, strategy, locatorValue, parameters, javaCode, redactedJavaCode, sensitive);
+    }
+
+    private static String blankJson(String body) {
+        return body == null || body.isBlank() ? "{}" : body;
+    }
+
+    private record LocatorRef(locatorStrategy strategy, String value) {
+    }
+
+    private record PointerGesture(int startX, int startY, int endX, int endY, int durationMillis, boolean swipe) {
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpAppiumInspectorProxy.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpAppiumInspectorProxy.java
@@ -1,0 +1,278 @@
+package com.shaft.mcp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Local Appium Inspector wrapper and reverse proxy.
+ */
+final class McpAppiumInspectorProxy implements AutoCloseable {
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final HttpClient client = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(15))
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
+    private final URI backend;
+    private final McpAppiumCommandRecorder commandRecorder;
+    private final Controller controller;
+    private final String capabilitiesJson;
+    private final ExecutorService executor;
+    private HttpServer server;
+
+    McpAppiumInspectorProxy(
+            URI backend,
+            McpAppiumCommandRecorder commandRecorder,
+            Controller controller,
+            String capabilitiesJson) {
+        this.backend = backend;
+        this.commandRecorder = commandRecorder;
+        this.controller = controller;
+        this.capabilitiesJson = capabilitiesJson == null ? "{}" : capabilitiesJson;
+        this.executor = Executors.newCachedThreadPool(task -> {
+            Thread thread = new Thread(task, "shaft-appium-inspector-proxy");
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
+
+    String start(int port) {
+        try {
+            server = HttpServer.create(new InetSocketAddress("127.0.0.1", port), 0);
+            server.createContext("/shaft-inspector/control", this::handleControl);
+            server.createContext("/shaft-inspector/status", this::handleStatus);
+            server.createContext("/shaft-inspector", this::handleWrapper);
+            server.createContext("/", this::handleProxy);
+            server.setExecutor(executor);
+            server.start();
+            return "http://127.0.0.1:" + server.getAddress().getPort() + "/shaft-inspector";
+        } catch (IOException exception) {
+            throw new IllegalStateException("Appium Inspector proxy could not start.", exception);
+        }
+    }
+
+    private void handleWrapper(HttpExchange exchange) throws IOException {
+        if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+            send(exchange, 405, "text/plain", "Method not allowed");
+            return;
+        }
+        send(exchange, 200, "text/html; charset=utf-8", wrapperHtml());
+    }
+
+    private void handleStatus(HttpExchange exchange) throws IOException {
+        sendJson(exchange, controller.control("status", ""));
+    }
+
+    private void handleControl(HttpExchange exchange) throws IOException {
+        if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+            send(exchange, 405, "text/plain", "Method not allowed");
+            return;
+        }
+        JsonNode body = mapper.readTree(exchange.getRequestBody());
+        String action = body.path("action").asText("status");
+        String checkpoint = body.path("checkpoint").asText("");
+        McpMobileInspectorRecordingStatus status = controller.control(action, checkpoint);
+        sendJson(exchange, status);
+        if ("stop".equalsIgnoreCase(action) || "discard".equalsIgnoreCase(action)) {
+            CompletableFuture.runAsync(() -> {
+                sleep();
+                close();
+            });
+        }
+    }
+
+    private void handleProxy(HttpExchange exchange) throws IOException {
+        byte[] requestBody = exchange.getRequestBody().readAllBytes();
+        URI target = backend.resolve(exchange.getRequestURI().toString());
+        HttpRequest.Builder request = HttpRequest.newBuilder(target)
+                .timeout(Duration.ofMinutes(3))
+                .method(exchange.getRequestMethod(), HttpRequest.BodyPublishers.ofByteArray(requestBody));
+        copyRequestHeaders(exchange.getRequestHeaders(), request);
+        try {
+            HttpResponse<byte[]> response = client.send(request.build(), HttpResponse.BodyHandlers.ofByteArray());
+            copyResponseHeaders(response.headers().map(), exchange.getResponseHeaders());
+            exchange.sendResponseHeaders(response.statusCode(), response.body().length);
+            exchange.getResponseBody().write(response.body());
+            capture(exchange, requestBody, response);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            send(exchange, 502, "text/plain", "Appium proxy interrupted.");
+        } catch (Exception exception) {
+            send(exchange, 502, "text/plain", "Appium proxy failed: " + exception.getMessage());
+        } finally {
+            exchange.close();
+        }
+    }
+
+    private void capture(HttpExchange exchange, byte[] requestBody, HttpResponse<byte[]> response) {
+        String requestText = new String(requestBody, StandardCharsets.UTF_8);
+        String responseText = new String(response.body(), StandardCharsets.UTF_8);
+        commandRecorder.capture(
+                exchange.getRequestMethod(),
+                exchange.getRequestURI().getPath(),
+                requestText,
+                response.statusCode(),
+                responseText);
+    }
+
+    private void copyRequestHeaders(Headers source, HttpRequest.Builder request) {
+        for (Map.Entry<String, List<String>> entry : source.entrySet()) {
+            String name = entry.getKey();
+            if (skipRequestHeader(name)) {
+                continue;
+            }
+            for (String value : entry.getValue()) {
+                request.header(name, value);
+            }
+        }
+    }
+
+    private void copyResponseHeaders(Map<String, List<String>> source, Headers target) {
+        for (Map.Entry<String, List<String>> entry : source.entrySet()) {
+            String name = entry.getKey();
+            if (skipResponseHeader(name)) {
+                continue;
+            }
+            target.put(name, entry.getValue());
+        }
+    }
+
+    private boolean skipRequestHeader(String name) {
+        String normalized = name.toLowerCase(java.util.Locale.ROOT);
+        return normalized.equals("host")
+                || normalized.equals("content-length")
+                || normalized.equals("connection")
+                || normalized.equals("accept-encoding");
+    }
+
+    private boolean skipResponseHeader(String name) {
+        String normalized = name.toLowerCase(java.util.Locale.ROOT);
+        return normalized.equals("content-length")
+                || normalized.equals("transfer-encoding")
+                || normalized.equals("connection")
+                || normalized.equals("content-encoding")
+                || normalized.equals("x-frame-options")
+                || normalized.equals("content-security-policy");
+    }
+
+    private void sendJson(HttpExchange exchange, Object value) throws IOException {
+        send(exchange, 200, "application/json; charset=utf-8",
+                mapper.writerWithDefaultPrettyPrinter().writeValueAsString(value));
+    }
+
+    private void send(HttpExchange exchange, int statusCode, String contentType, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", contentType);
+        exchange.sendResponseHeaders(statusCode, bytes.length);
+        exchange.getResponseBody().write(bytes);
+        exchange.close();
+    }
+
+    private String wrapperHtml() {
+        String escapedCapabilities = capabilitiesJson
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;");
+        return """
+                <!doctype html>
+                <html lang="en">
+                <head>
+                  <meta charset="utf-8">
+                  <meta name="viewport" content="width=device-width, initial-scale=1">
+                  <title>SHAFT Appium Inspector Recorder</title>
+                  <style>
+                    :root { color-scheme: light dark; font-family: Inter, Segoe UI, Arial, sans-serif; }
+                    body { margin: 0; height: 100vh; display: grid; grid-template-rows: auto 1fr; background: #101418; color: #f7f7f2; }
+                    header { display: flex; align-items: center; gap: 8px; padding: 8px 10px; background: #1b2026; border-bottom: 1px solid #303840; }
+                    button { min-width: 34px; height: 32px; border: 1px solid #55606b; border-radius: 6px; background: #252c33; color: #f7f7f2; cursor: pointer; }
+                    button:hover { background: #303944; }
+                    .spacer { flex: 1; }
+                    .status { font-size: 12px; color: #cbd2d9; }
+                    details { max-width: min(680px, 45vw); font-size: 12px; }
+                    summary { cursor: pointer; color: #cbd2d9; }
+                    pre { max-height: 120px; overflow: auto; margin: 4px 0 0; padding: 8px; background: #0b0e11; border: 1px solid #303840; border-radius: 6px; }
+                    iframe { width: 100%; height: 100%; border: 0; background: #fff; }
+                  </style>
+                </head>
+                <body>
+                  <header>
+                    <button id="pause" title="Pause recording" aria-label="Pause recording">||</button>
+                    <button id="resume" title="Resume recording" aria-label="Resume recording">&gt;</button>
+                    <button id="checkpoint" title="Add checkpoint" aria-label="Add checkpoint">*</button>
+                    <button id="stop" title="Stop recording" aria-label="Stop recording">[]</button>
+                    <button id="discard" title="Discard recording" aria-label="Discard recording">x</button>
+                    <span class="status" id="status">Recorder ready</span>
+                    <span class="spacer"></span>
+                    <details>
+                      <summary>Capabilities</summary>
+                      <pre>%s</pre>
+                    </details>
+                  </header>
+                  <iframe src="/inspector" title="Appium Inspector"></iframe>
+                  <script>
+                    async function control(action) {
+                      const checkpoint = action === 'checkpoint' ? prompt('Checkpoint name', '') || '' : '';
+                      const response = await fetch('/shaft-inspector/control', {
+                        method: 'POST',
+                        headers: {'Content-Type': 'application/json'},
+                        body: JSON.stringify({action, checkpoint})
+                      });
+                      const status = await response.json();
+                      document.getElementById('status').textContent =
+                        status.active ? (status.paused ? 'Paused' : 'Recording') + ' - ' + status.actionCount + ' actions'
+                                      : 'Stopped - ' + status.actionCount + ' actions';
+                    }
+                    for (const action of ['pause', 'resume', 'checkpoint', 'stop', 'discard']) {
+                      document.getElementById(action).addEventListener('click', () => control(action));
+                    }
+                    setInterval(async () => {
+                      try {
+                        const response = await fetch('/shaft-inspector/status');
+                        const status = await response.json();
+                        document.getElementById('status').textContent =
+                          status.active ? (status.paused ? 'Paused' : 'Recording') + ' - ' + status.actionCount + ' actions'
+                                        : 'Stopped - ' + status.actionCount + ' actions';
+                      } catch {}
+                    }, 2500);
+                  </script>
+                </body>
+                </html>
+                """.formatted(escapedCapabilities);
+    }
+
+    @Override
+    public void close() {
+        if (server != null) {
+            server.stop(0);
+        }
+        executor.shutdownNow();
+    }
+
+    private static void sleep() {
+        try {
+            Thread.sleep(250);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    interface Controller {
+        McpMobileInspectorRecordingStatus control(String action, String checkpoint);
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileCode.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileCode.java
@@ -1,0 +1,148 @@
+package com.shaft.mcp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Shared Java snippet generation for mobile MCP tools.
+ */
+final class McpMobileCode {
+    private McpMobileCode() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static McpCodeBlock nativeSetupBlock(
+            String platform,
+            String deviceName,
+            String server,
+            String automation,
+            String platformVersion,
+            String udid,
+            String app,
+            String appPackage,
+            String appActivity,
+            String bundleId) {
+        StringBuilder code = new StringBuilder();
+        code.append("SHAFT.Properties.platform.set()\n");
+        code.append("        .targetPlatform(").append(java(platform)).append(")\n");
+        code.append("        .executionAddress(").append(java(server)).append(");\n");
+        code.append("SHAFT.Properties.web.set().isMobileEmulation(false);\n");
+        code.append("SHAFT.Properties.mobile.set()\n");
+        code.append("        .platformName(").append(java(platform)).append(")\n");
+        code.append("        .automationName(").append(java(automation)).append(")\n");
+        code.append("        .deviceName(").append(java(deviceName)).append(")\n");
+        code.append("        .platformVersion(").append(java(platformVersion)).append(")\n");
+        code.append("        .udid(").append(java(udid)).append(")\n");
+        code.append("        .browserName(\"\")\n");
+        code.append("        .app(").append(java(app)).append(")\n");
+        code.append("        .appPackage(").append(java(appPackage)).append(")\n");
+        code.append("        .appActivity(").append(java(appActivity)).append(")\n");
+        code.append("        .bundleId(").append(java(bundleId)).append(");\n");
+        code.append("SHAFT.GUI.WebDriver driver = new SHAFT.GUI.WebDriver();\n");
+        return new McpCodeBlock(
+                "mobile-native-setup",
+                "Native mobile Appium setup",
+                McpCodeBlock.Kind.SETUP,
+                "java",
+                List.of("com.shaft.driver.SHAFT"),
+                code.toString(),
+                "Paste into setup before native mobile actions.",
+                true,
+                List.of(),
+                nativeWarnings(platform, app, appPackage, appActivity, bundleId));
+    }
+
+    static McpCodeBlock actionBlock(String action, String javaCode) {
+        return new McpCodeBlock(
+                "mobile-action-" + text(action),
+                "Mobile action snippet",
+                McpCodeBlock.Kind.ACTION,
+                "java",
+                List.of(
+                        "com.shaft.driver.SHAFT",
+                        "com.shaft.gui.element.TouchActions",
+                        "io.appium.java_client.AppiumBy",
+                        "org.openqa.selenium.By",
+                        "org.openqa.selenium.ScreenOrientation",
+                        "org.openqa.selenium.interactions.Pause",
+                        "org.openqa.selenium.interactions.PointerInput",
+                        "org.openqa.selenium.interactions.Sequence",
+                        "org.openqa.selenium.remote.RemoteWebDriver",
+                        "java.time.Duration",
+                        "java.util.List"),
+                javaCode + System.lineSeparator(),
+                "Paste inside a method that already owns a SHAFT.GUI.WebDriver named driver.",
+                true,
+                List.of(),
+                List.of());
+    }
+
+    static String locatorCode(locatorStrategy strategy, String value) {
+        String literal = java(value);
+        if (strategy == null) {
+            return "By.xpath(" + literal + ")";
+        }
+        return switch (strategy) {
+            case ID -> "SHAFT.GUI.Locator.hasAnyTagName().hasId(" + literal + ").build()";
+            case CSSSELECTOR, CSS, SELECTOR -> "By.cssSelector(" + literal + ")";
+            case XPATH -> "By.xpath(" + literal + ")";
+            case NAME -> "SHAFT.GUI.Locator.hasAnyTagName().hasAttribute(\"name\", " + literal + ").build()";
+            case TAGNAME -> "SHAFT.GUI.Locator.hasTagName(" + literal + ").build()";
+            case CLASSNAME -> "SHAFT.GUI.Locator.hasAnyTagName().hasAttribute(\"class\", " + literal + ").build()";
+            case ACCESSIBILITY_ID -> "AppiumBy.accessibilityId(" + literal + ")";
+            case ANDROID_UIAUTOMATOR -> "AppiumBy.androidUIAutomator(" + literal + ")";
+            case IOS_PREDICATE -> "AppiumBy.iOSNsPredicateString(" + literal + ")";
+            case IOS_CLASS_CHAIN -> "AppiumBy.iOSClassChain(" + literal + ")";
+        };
+    }
+
+    static String tapCoordinatesCode(int x, int y) {
+        return """
+                PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, "finger");
+                Sequence tap = new Sequence(finger, 0);
+                tap.addAction(finger.createPointerMove(Duration.ZERO, PointerInput.Origin.viewport(), %d, %d));
+                tap.addAction(finger.createPointerDown(PointerInput.MouseButton.LEFT.asArg()));
+                tap.addAction(new Pause(finger, Duration.ofMillis(100)));
+                tap.addAction(finger.createPointerUp(PointerInput.MouseButton.LEFT.asArg()));
+                ((RemoteWebDriver) driver.getDriver()).perform(List.of(tap));""".formatted(x, y);
+    }
+
+    static String swipeCoordinatesCode(int startX, int startY, int endX, int endY, int durationMillis) {
+        return """
+                PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, "finger");
+                Sequence swipe = new Sequence(finger, 0);
+                swipe.addAction(finger.createPointerMove(Duration.ZERO, PointerInput.Origin.viewport(), %d, %d));
+                swipe.addAction(finger.createPointerDown(PointerInput.MouseButton.LEFT.asArg()));
+                swipe.addAction(finger.createPointerMove(Duration.ofMillis(%d), PointerInput.Origin.viewport(), %d, %d));
+                swipe.addAction(finger.createPointerUp(PointerInput.MouseButton.LEFT.asArg()));
+                ((RemoteWebDriver) driver.getDriver()).perform(List.of(swipe));"""
+                .formatted(startX, startY, Math.max(durationMillis, 100), endX, endY);
+    }
+
+    static List<String> nativeWarnings(String platform, String app, String appPackage, String appActivity,
+            String bundleId) {
+        List<String> warnings = new ArrayList<>();
+        if ("Android".equals(platform) && text(app).isBlank()
+                && (text(appPackage).isBlank() || text(appActivity).isBlank())) {
+            warnings.add("For installed Android apps, provide appPackage and appActivity when app is blank.");
+        }
+        if ("iOS".equals(platform) && text(app).isBlank() && text(bundleId).isBlank()) {
+            warnings.add("For installed iOS apps, provide bundleId when app is blank.");
+        }
+        return List.copyOf(warnings);
+    }
+
+    static String java(String value) {
+        String text = value == null ? "" : value;
+        return "\"" + text
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t") + "\"";
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileDevice.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileDevice.java
@@ -1,0 +1,29 @@
+package com.shaft.mcp;
+
+import java.util.List;
+
+/**
+ * Mobile device discovered by local platform tooling.
+ */
+public record McpMobileDevice(
+        String id,
+        String name,
+        String platformName,
+        String state,
+        boolean emulator,
+        List<String> warnings) {
+    /**
+     * Creates an immutable mobile device descriptor.
+     */
+    public McpMobileDevice {
+        id = text(id);
+        name = text(name);
+        platformName = text(platformName);
+        state = text(state);
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInspectorPlan.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInspectorPlan.java
@@ -1,0 +1,44 @@
+package com.shaft.mcp;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Confirmation-ready plan for a wrapped Appium Inspector recording session.
+ */
+public record McpMobileInspectorPlan(
+        String confirmationToken,
+        String platformName,
+        boolean readyToStart,
+        boolean confirmationRequired,
+        boolean willProvisionAndroidEmulator,
+        boolean realDeviceAvailable,
+        String selectedDeviceId,
+        String selectedAndroidAvdName,
+        String outputPath,
+        boolean includeSensitiveValues,
+        Map<String, Object> appiumCapabilities,
+        McpMobileToolchainStatus toolchainStatus,
+        McpAndroidEmulatorProposal androidEmulatorProposal,
+        List<McpCodeBlock> codeBlocks,
+        List<String> nextSteps,
+        List<String> warnings) {
+    /**
+     * Creates an immutable inspector recording plan.
+     */
+    public McpMobileInspectorPlan {
+        confirmationToken = text(confirmationToken);
+        platformName = text(platformName);
+        selectedDeviceId = text(selectedDeviceId);
+        selectedAndroidAvdName = text(selectedAndroidAvdName);
+        outputPath = text(outputPath);
+        appiumCapabilities = appiumCapabilities == null ? Map.of() : Map.copyOf(appiumCapabilities);
+        codeBlocks = codeBlocks == null ? List.of() : List.copyOf(codeBlocks);
+        nextSteps = nextSteps == null ? List.of() : List.copyOf(nextSteps);
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInspectorRecordingService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInspectorRecordingService.java
@@ -1,0 +1,552 @@
+package com.shaft.mcp;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.awt.Desktop;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Orchestrates wrapped Appium Inspector recording sessions.
+ */
+final class McpMobileInspectorRecordingService {
+    private static final String DEFAULT_APPIUM_SERVER = "http://127.0.0.1:4723";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final McpWorkspacePolicy workspacePolicy;
+    private final McpMobileRecordingService recorder;
+    private final McpMobileToolchainService toolchain;
+    private final Map<String, McpMobileInspectorPlan> preparedPlans = new ConcurrentHashMap<>();
+    private Session activeSession;
+
+    McpMobileInspectorRecordingService(McpWorkspacePolicy workspacePolicy, McpMobileRecordingService recorder) {
+        this(workspacePolicy, recorder, new McpMobileToolchainService());
+    }
+
+    McpMobileInspectorRecordingService(
+            McpWorkspacePolicy workspacePolicy,
+            McpMobileRecordingService recorder,
+            McpMobileToolchainService toolchain) {
+        this.workspacePolicy = workspacePolicy;
+        this.recorder = recorder;
+        this.toolchain = toolchain;
+    }
+
+    synchronized McpMobileToolchainStatus toolchainStatus(String platformName) {
+        return toolchain.status(platformName);
+    }
+
+    synchronized McpMobileInspectorPlan prepare(
+            String platformName,
+            String outputPath,
+            boolean includeSensitiveValues,
+            String app,
+            String appPackage,
+            String appActivity,
+            String bundleId,
+            String udid,
+            String deviceName,
+            String platformVersion,
+            String selectedAndroidAvdName,
+            int androidApiLevel,
+            String androidDeviceProfile,
+            String androidImageTag,
+            String androidAbi,
+            int androidRamMb,
+            int androidCores,
+            boolean provisionAndroidEmulator) {
+        String platform = platform(platformName);
+        String automation = "Android".equals(platform) ? "UiAutomator2" : "XCUITest";
+        McpMobileToolchainStatus status = toolchain.status(platform);
+        List<String> warnings = new ArrayList<>(status.warnings());
+        warnings.addAll(McpMobileCode.nativeWarnings(platform, app, appPackage, appActivity, bundleId));
+        List<String> nextSteps = new ArrayList<>();
+
+        boolean appReady = appDetailsReady(platform, app, appPackage, appActivity, bundleId);
+        String deviceId = text(udid);
+        if (deviceId.isBlank()) {
+            deviceId = readyAndroidDevice(status).map(McpMobileDevice::id).orElse("");
+        }
+        String plannedDeviceId = deviceId;
+        boolean realDeviceAvailable = !plannedDeviceId.isBlank()
+                && status.androidDevices().stream().anyMatch(device -> device.id().equals(plannedDeviceId)
+                && !device.emulator()
+                && "device".equals(device.state()));
+        String selectedAvd = text(selectedAndroidAvdName);
+        boolean willProvision = false;
+        McpAndroidEmulatorProposal proposal = null;
+        boolean readyToStart = appReady;
+
+        if ("Android".equals(platform)) {
+            boolean androidReadyDevice = !plannedDeviceId.isBlank()
+                    && status.androidDevices().stream().anyMatch(device -> device.id().equals(plannedDeviceId)
+                    && "device".equals(device.state()));
+            if (!androidReadyDevice) {
+                if (!selectedAvd.isBlank()) {
+                    nextSteps.add("Confirm this plan to start cached Android emulator `" + selectedAvd + "`.");
+                } else if (!status.cachedAndroidEmulators().isEmpty()) {
+                    readyToStart = false;
+                    nextSteps.add("Choose one cached Android emulator and call prepare again with selectedAndroidAvdName.");
+                    warnings.add("No connected Android devices were found. Cached emulators are available.");
+                } else if (provisionAndroidEmulator) {
+                    willProvision = true;
+                    proposal = toolchain.defaultAndroidProposal("", androidApiLevel, androidDeviceProfile,
+                            androidImageTag, androidAbi, androidRamMb, androidCores);
+                    nextSteps.add("Review the Android emulator proposal, then call start with this confirmation token.");
+                } else {
+                    readyToStart = false;
+                    warnings.add("No connected Android devices were found. Enable provisionAndroidEmulator or choose a cached AVD.");
+                }
+            }
+            if (status.adbAvailable()) {
+                nextSteps.add("Connected Android devices were checked with `adb devices -l`.");
+            } else {
+                nextSteps.add("adb is missing; start can install Android platform-tools under the SHAFT MCP cache.");
+            }
+        } else {
+            if (!System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("mac")) {
+                warnings.add("iOS Appium recording requires macOS with Xcode command-line tools and a reachable iOS target.");
+            }
+            if (text(udid).isBlank() && text(deviceName).isBlank()) {
+                warnings.add("Provide udid or deviceName for iOS Inspector sessions.");
+            }
+        }
+        if (!appReady) {
+            readyToStart = false;
+        }
+
+        String token = toolchain.newConfirmationToken();
+        String plannedOutput = outputPath == null || outputPath.isBlank()
+                ? "recordings/mobile-inspector-" + platform.toLowerCase(Locale.ROOT) + ".json"
+                : outputPath;
+        Map<String, Object> capabilities = capabilities(platform, automation, app, appPackage, appActivity, bundleId,
+                deviceId, deviceName, platformVersion, selectedAvd);
+        McpMobileInspectorPlan plan = new McpMobileInspectorPlan(
+                token,
+                platform,
+                readyToStart,
+                true,
+                willProvision,
+                realDeviceAvailable,
+                deviceId,
+                selectedAvd,
+                plannedOutput,
+                includeSensitiveValues,
+                capabilities,
+                status,
+                proposal,
+                List.of(McpMobileCode.nativeSetupBlock(platform, deviceName, DEFAULT_APPIUM_SERVER, automation,
+                        platformVersion, deviceId, app, appPackage, appActivity, bundleId)),
+                nextSteps,
+                warnings);
+        preparedPlans.put(token, plan);
+        return plan;
+    }
+
+    synchronized McpMobileInspectorRecordingStatus start(String confirmationToken, String selectedAndroidAvdName,
+            boolean openInspector) {
+        if (activeSession != null) {
+            throw new IllegalStateException("A mobile Inspector recording session is already active.");
+        }
+        McpMobileInspectorPlan plan = preparedPlans.get(text(confirmationToken));
+        if (plan == null) {
+            throw new IllegalArgumentException("Unknown mobile Inspector confirmation token. Call prepare first.");
+        }
+        if (!plan.readyToStart()) {
+            throw new IllegalStateException("Mobile Inspector plan is not ready to start: "
+                    + String.join(" ", plan.warnings()));
+        }
+
+        List<String> warnings = new ArrayList<>(plan.warnings());
+        Process emulatorProcess = null;
+        boolean managedEmulator = false;
+        String androidAvdName = text(selectedAndroidAvdName).isBlank()
+                ? plan.selectedAndroidAvdName()
+                : text(selectedAndroidAvdName);
+        String deviceId = plan.selectedDeviceId();
+        try {
+            toolchain.ensureAppium(plan.platformName());
+            if ("Android".equals(plan.platformName()) && deviceId.isBlank()) {
+                if (plan.willProvisionAndroidEmulator()) {
+                    toolchain.ensureAndroidEmulator(plan.androidEmulatorProposal());
+                    androidAvdName = plan.androidEmulatorProposal().avdName();
+                } else if (androidAvdName.isBlank()) {
+                    throw new IllegalArgumentException(
+                            "selectedAndroidAvdName is required when no real Android device is connected.");
+                }
+                emulatorProcess = toolchain.startAndroidEmulator(androidAvdName, plan.androidEmulatorProposal());
+                managedEmulator = true;
+                if (!toolchain.waitForAndroidDevice(Duration.ofMinutes(3))) {
+                    throw new IllegalStateException("Android emulator did not become ready within 3 minutes.");
+                }
+                McpMobileToolchainStatus status = toolchain.status("Android");
+                deviceId = status.androidDevices().stream()
+                        .filter(device -> device.emulator() && "device".equals(device.state()))
+                        .map(McpMobileDevice::id)
+                        .findFirst()
+                        .orElse("");
+            }
+
+            int appiumPort = freePort();
+            recorder.start(plan.outputPath(), "mobile-inspector-" + plan.platformName().toLowerCase(Locale.ROOT),
+                    plan.includeSensitiveValues());
+            Process appiumProcess = toolchain.startAppiumServer(appiumPort);
+            URI backend = URI.create("http://127.0.0.1:" + appiumPort);
+            waitForAppium(backend, warnings);
+            Session session = new Session(
+                    plan,
+                    appiumProcess,
+                    emulatorProcess,
+                    managedEmulator,
+                    deviceId,
+                    androidAvdName,
+                    backend.toString(),
+                    List.of(setupBlock(plan, backend.toString(), deviceId)));
+            activeSession = session;
+            McpAppiumCommandRecorder commandRecorder = new McpAppiumCommandRecorder(recorder, () -> session.paused);
+            session.proxy = new McpAppiumInspectorProxy(backend, commandRecorder, this::controlFromProxy,
+                    capabilitiesJson(plan));
+            session.inspectorUrl = session.proxy.start(freePort());
+            if (openInspector) {
+                openBrowser(session.inspectorUrl, warnings);
+            }
+            warnings.add("Set Appium Inspector's remote server URL to " + session.inspectorUrl
+                    + " if the embedded Inspector asks for a server endpoint.");
+            return status(session, warnings, session.setupBlocks);
+        } catch (RuntimeException exception) {
+            cleanupFailedStart(emulatorProcess, managedEmulator, deviceId);
+            activeSession = null;
+            throw exception;
+        }
+    }
+
+    synchronized McpMobileInspectorRecordingStatus status() {
+        if (activeSession == null) {
+            McpMobileRecordingStatus recordingStatus = recorder.status();
+            return new McpMobileInspectorRecordingStatus(false, false, "", "", "", false,
+                    recordingStatus.outputPath(), "", "", recordingStatus.actionCount(), List.of(),
+                    recordingStatus.warnings());
+        }
+        return status(activeSession, List.of(), activeSession.setupBlocks);
+    }
+
+    synchronized McpMobileInspectorRecordingStatus control(String action, String checkpointName) {
+        return control(action, checkpointName, true);
+    }
+
+    synchronized McpMobileInspectorRecordingStatus stop(boolean discard) {
+        return stop(discard, true);
+    }
+
+    private McpMobileInspectorRecordingStatus controlFromProxy(String action, String checkpointName) {
+        return control(action, checkpointName, false);
+    }
+
+    private synchronized McpMobileInspectorRecordingStatus control(String action, String checkpointName,
+            boolean closeProxy) {
+        if (activeSession == null) {
+            return status();
+        }
+        String normalized = text(action).toLowerCase(Locale.ROOT);
+        return switch (normalized) {
+            case "", "status" -> status(activeSession, List.of(), activeSession.setupBlocks);
+            case "pause" -> {
+                activeSession.paused = true;
+                yield status(activeSession, List.of("Recording paused."), activeSession.setupBlocks);
+            }
+            case "resume", "play" -> {
+                activeSession.paused = false;
+                yield status(activeSession, List.of("Recording resumed."), activeSession.setupBlocks);
+            }
+            case "checkpoint" -> {
+                String checkpoint = text(checkpointName).isBlank() ? "Checkpoint" : text(checkpointName);
+                recorder.recordWarning("Checkpoint: " + checkpoint);
+                yield status(activeSession, List.of("Checkpoint recorded: " + checkpoint), activeSession.setupBlocks);
+            }
+            case "stop" -> stop(false, closeProxy);
+            case "discard" -> stop(true, closeProxy);
+            default -> throw new IllegalArgumentException(
+                    "Unsupported Inspector recording control action: " + action);
+        };
+    }
+
+    private synchronized McpMobileInspectorRecordingStatus stop(boolean discard, boolean closeProxy) {
+        if (activeSession == null) {
+            return status();
+        }
+        Session session = activeSession;
+        McpMobileRecordingStatus stopped = recorder.stop(discard);
+        List<String> warnings = new ArrayList<>(stopped.warnings());
+        List<McpCodeBlock> blocks = new ArrayList<>(session.setupBlocks);
+        if (!discard && stopped.outputPath() != null) {
+            McpMobileReplayResult replay = recorder.codeBlocks(stopped.outputPath().toString(), "driver");
+            blocks.addAll(replay.codeBlocks());
+            warnings.addAll(replay.warnings());
+            warnings.add("Session-managed Appium and emulator processes were stopped. Update executionAddress "
+                    + "before replaying against a different Appium server.");
+        }
+        destroy(session.appiumProcess);
+        if (session.managedEmulator) {
+            toolchain.stopAndroidEmulator(session.deviceId);
+            destroy(session.emulatorProcess);
+        }
+        if (closeProxy && session.proxy != null) {
+            session.proxy.close();
+        }
+        activeSession = null;
+        return new McpMobileInspectorRecordingStatus(
+                false,
+                false,
+                session.plan.platformName(),
+                session.deviceId,
+                session.androidAvdName,
+                session.managedEmulator,
+                stopped.outputPath(),
+                session.inspectorUrl,
+                session.appiumServerUrl,
+                stopped.actionCount(),
+                blocks,
+                warnings);
+    }
+
+    private McpMobileInspectorRecordingStatus status(Session session, List<String> extraWarnings,
+            List<McpCodeBlock> blocks) {
+        McpMobileRecordingStatus recordingStatus = recorder.status();
+        List<String> warnings = new ArrayList<>(recordingStatus.warnings());
+        warnings.addAll(extraWarnings);
+        return new McpMobileInspectorRecordingStatus(
+                true,
+                session.paused,
+                session.plan.platformName(),
+                session.deviceId,
+                session.androidAvdName,
+                session.managedEmulator,
+                recordingStatus.outputPath(),
+                session.inspectorUrl,
+                session.appiumServerUrl,
+                recordingStatus.actionCount(),
+                blocks,
+                warnings);
+    }
+
+    private McpCodeBlock setupBlock(McpMobileInspectorPlan plan, String appiumServerUrl, String deviceId) {
+        String automation = "Android".equals(plan.platformName()) ? "UiAutomator2" : "XCUITest";
+        String deviceName = value(plan.appiumCapabilities(), "appium:deviceName");
+        String platformVersion = value(plan.appiumCapabilities(), "appium:platformVersion");
+        String app = value(plan.appiumCapabilities(), "appium:app");
+        String appPackage = value(plan.appiumCapabilities(), "appium:appPackage");
+        String appActivity = value(plan.appiumCapabilities(), "appium:appActivity");
+        String bundleId = value(plan.appiumCapabilities(), "appium:bundleId");
+        return McpMobileCode.nativeSetupBlock(plan.platformName(), deviceName, appiumServerUrl, automation,
+                platformVersion, deviceId, app, appPackage, appActivity, bundleId);
+    }
+
+    private Map<String, Object> capabilities(
+            String platform,
+            String automation,
+            String app,
+            String appPackage,
+            String appActivity,
+            String bundleId,
+            String udid,
+            String deviceName,
+            String platformVersion,
+            String selectedAvd) {
+        Map<String, Object> caps = new LinkedHashMap<>();
+        caps.put("platformName", platform);
+        caps.put("appium:automationName", automation);
+        putIfPresent(caps, "appium:deviceName", defaultText(deviceName, selectedAvd));
+        putIfPresent(caps, "appium:platformVersion", platformVersion);
+        putIfPresent(caps, "appium:udid", udid);
+        putIfPresent(caps, "appium:app", app);
+        putIfPresent(caps, "appium:appPackage", appPackage);
+        putIfPresent(caps, "appium:appActivity", appActivity);
+        putIfPresent(caps, "appium:bundleId", bundleId);
+        caps.put("appium:noReset", true);
+        return Map.copyOf(caps);
+    }
+
+    private String capabilitiesJson(McpMobileInspectorPlan plan) {
+        try {
+            return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(plan.appiumCapabilities());
+        } catch (JsonProcessingException exception) {
+            return "{}";
+        }
+    }
+
+    private java.util.Optional<McpMobileDevice> readyAndroidDevice(McpMobileToolchainStatus status) {
+        return status.androidDevices().stream()
+                .filter(device -> "device".equals(device.state()))
+                .findFirst();
+    }
+
+    private boolean appDetailsReady(String platform, String app, String appPackage, String appActivity,
+            String bundleId) {
+        if (!text(app).isBlank()) {
+            return true;
+        }
+        if ("Android".equals(platform)) {
+            return !text(appPackage).isBlank() && !text(appActivity).isBlank();
+        }
+        return !text(bundleId).isBlank();
+    }
+
+    private String platform(String platformName) {
+        String platform = text(platformName).toLowerCase(Locale.ROOT);
+        return switch (platform) {
+            case "", "android" -> "Android";
+            case "ios" -> "iOS";
+            default -> throw new IllegalArgumentException("platformName must be Android or iOS.");
+        };
+    }
+
+    private void cleanupFailedStart(Process emulatorProcess, boolean managedEmulator, String deviceId) {
+        if (managedEmulator) {
+            toolchain.stopAndroidEmulator(deviceId);
+            destroy(emulatorProcess);
+        }
+        try {
+            if (recorder.status().active()) {
+                recorder.stop(true);
+            }
+        } catch (RuntimeException ignored) {
+            // Failed start cleanup is best effort.
+        }
+    }
+
+    private void openBrowser(String url, List<String> warnings) {
+        try {
+            if (!Desktop.isDesktopSupported()) {
+                warnings.add("Desktop browser launch is not supported in this environment.");
+                return;
+            }
+            Desktop.getDesktop().browse(URI.create(url));
+        } catch (IOException | RuntimeException exception) {
+            warnings.add("Inspector URL could not be opened automatically: " + exception.getMessage());
+        }
+    }
+
+    private void waitForAppium(URI backend, List<String> warnings) {
+        HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(2))
+                .build();
+        HttpRequest request = HttpRequest.newBuilder(backend.resolve("/status"))
+                .timeout(Duration.ofSeconds(2))
+                .GET()
+                .build();
+        long deadline = System.nanoTime() + Duration.ofSeconds(30).toNanos();
+        while (System.nanoTime() < deadline) {
+            try {
+                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+                if (response.statusCode() / 100 == 2) {
+                    return;
+                }
+            } catch (IOException ignored) {
+                // Appium is still starting.
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                warnings.add("Interrupted while waiting for Appium server readiness.");
+                return;
+            }
+            sleep(Duration.ofMillis(500));
+        }
+        warnings.add("Appium server did not answer /status within 30 seconds; the Inspector may need a browser refresh.");
+    }
+
+    private int freePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
+        } catch (IOException exception) {
+            throw new IllegalStateException("Free local port could not be reserved.", exception);
+        }
+    }
+
+    private void destroy(Process process) {
+        if (process != null && process.isAlive()) {
+            process.destroy();
+            try {
+                if (!process.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)) {
+                    process.destroyForcibly();
+                }
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                process.destroyForcibly();
+            }
+        }
+    }
+
+    private void sleep(Duration duration) {
+        try {
+            Thread.sleep(duration.toMillis());
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void putIfPresent(Map<String, Object> map, String key, String value) {
+        if (!text(value).isBlank()) {
+            map.put(key, text(value));
+        }
+    }
+
+    private String value(Map<String, Object> map, String key) {
+        Object value = map.get(key);
+        return value == null ? "" : value.toString();
+    }
+
+    private static String defaultText(String value, String fallback) {
+        String text = text(value);
+        return text.isBlank() ? text(fallback) : text;
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private static final class Session {
+        private final McpMobileInspectorPlan plan;
+        private final Process appiumProcess;
+        private final Process emulatorProcess;
+        private final boolean managedEmulator;
+        private final String deviceId;
+        private final String androidAvdName;
+        private final String appiumServerUrl;
+        private final List<McpCodeBlock> setupBlocks;
+        private volatile boolean paused;
+        private McpAppiumInspectorProxy proxy;
+        private String inspectorUrl = "";
+
+        private Session(
+                McpMobileInspectorPlan plan,
+                Process appiumProcess,
+                Process emulatorProcess,
+                boolean managedEmulator,
+                String deviceId,
+                String androidAvdName,
+                String appiumServerUrl,
+                List<McpCodeBlock> setupBlocks) {
+            this.plan = plan;
+            this.appiumProcess = appiumProcess;
+            this.emulatorProcess = emulatorProcess;
+            this.managedEmulator = managedEmulator;
+            this.deviceId = text(deviceId);
+            this.androidAvdName = text(androidAvdName);
+            this.appiumServerUrl = text(appiumServerUrl);
+            this.setupBlocks = List.copyOf(setupBlocks);
+        }
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInspectorRecordingStatus.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInspectorRecordingStatus.java
@@ -1,0 +1,38 @@
+package com.shaft.mcp;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Runtime status for a wrapped Appium Inspector recording session.
+ */
+public record McpMobileInspectorRecordingStatus(
+        boolean active,
+        boolean paused,
+        String platformName,
+        String deviceId,
+        String androidAvdName,
+        boolean managedEmulator,
+        Path outputPath,
+        String inspectorUrl,
+        String appiumServerUrl,
+        int actionCount,
+        List<McpCodeBlock> codeBlocks,
+        List<String> warnings) {
+    /**
+     * Creates an immutable inspector recording status.
+     */
+    public McpMobileInspectorRecordingStatus {
+        platformName = text(platformName);
+        deviceId = text(deviceId);
+        androidAvdName = text(androidAvdName);
+        inspectorUrl = text(inspectorUrl);
+        appiumServerUrl = text(appiumServerUrl);
+        codeBlocks = codeBlocks == null ? List.of() : List.copyOf(codeBlocks);
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecordingService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecordingService.java
@@ -129,6 +129,23 @@ final class McpMobileRecordingService {
         return recorded;
     }
 
+    synchronized void recordWarning(String warning) {
+        if (recording == null || warning == null || warning.isBlank()) {
+            return;
+        }
+        List<String> warnings = new ArrayList<>(recording.warnings());
+        warnings.add(warning.trim());
+        recording = new McpMobileRecording(
+                recording.schemaVersion(),
+                recording.mode(),
+                recording.startedAt(),
+                recording.stoppedAt(),
+                recording.includeSensitiveValues(),
+                recording.actions(),
+                warnings);
+        persist();
+    }
+
     McpMobileReplayResult codeBlocks(String recordingPath, String driverVariableName) {
         Path path = workspacePolicy.existing(recordingPath, "Mobile recording path");
         McpMobileRecording stored = read(path);

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainService.java
@@ -1,0 +1,697 @@
+package com.shaft.mcp;
+
+import com.shaft.driver.SHAFT;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * Discovers and bootstraps the local Appium and Android toolchain for MCP sessions.
+ */
+final class McpMobileToolchainService {
+    private static final Duration QUICK_TIMEOUT = Duration.ofSeconds(12);
+    private static final Duration INSTALL_TIMEOUT = Duration.ofMinutes(20);
+    private static final Pattern DEVICE_NAME = Pattern.compile("\\bmodel:([^\\s]+)");
+
+    private final McpProcessRunner runner;
+    private final Map<String, String> environment;
+    private final Path toolRoot;
+    private final String osName;
+    private final String osArch;
+    private final HttpClient httpClient;
+
+    McpMobileToolchainService() {
+        this(McpProcessRunner.system(), System.getenv(), McpRuntimePaths.applicationDataRoot().resolve("tools"),
+                System.getProperty("os.name", ""), System.getProperty("os.arch", ""));
+    }
+
+    McpMobileToolchainService(
+            McpProcessRunner runner,
+            Map<String, String> environment,
+            Path toolRoot,
+            String osName,
+            String osArch) {
+        this.runner = runner;
+        this.environment = environment == null ? Map.of() : Map.copyOf(environment);
+        this.toolRoot = toolRoot.toAbsolutePath().normalize();
+        this.osName = osName == null ? "" : osName;
+        this.osArch = osArch == null ? "" : osArch;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(30))
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build();
+    }
+
+    McpMobileToolchainStatus status(String platformName) {
+        String platform = normalizePlatform(platformName);
+        Path androidSdkRoot = androidSdkRoot();
+        Path androidAvdHome = androidAvdHome();
+        Path appiumRoot = appiumRoot();
+        List<String> warnings = new ArrayList<>();
+
+        Optional<Path> node = resolveExecutable("node", List.of(nodeBin()));
+        Optional<Path> npm = resolveExecutable("npm", List.of(nodeBin()));
+        Optional<Path> appium = resolveExecutable("appium", List.of(appiumBin()));
+        Optional<Path> adb = resolveExecutable("adb", List.of(androidSdkRoot.resolve("platform-tools")));
+        Optional<Path> emulator = resolveExecutable("emulator", List.of(androidSdkRoot.resolve("emulator")));
+        Optional<Path> sdkManager = resolveExecutable("sdkmanager", List.of(androidSdkRoot.resolve("cmdline-tools")
+                .resolve("latest").resolve("bin")));
+        Optional<Path> avdManager = resolveExecutable("avdmanager", List.of(androidSdkRoot.resolve("cmdline-tools")
+                .resolve("latest").resolve("bin")));
+
+        List<McpMobileDevice> devices = adb.map(this::androidDevices).orElseGet(() -> {
+            warnings.add("adb was not found on PATH or in the SHAFT-managed Android SDK cache.");
+            return List.of();
+        });
+        List<String> avds = cachedAndroidEmulators(emulator.orElse(null), androidAvdHome);
+        boolean inspector = appium.filter(this::hasInspectorPlugin).isPresent()
+                || Files.isDirectory(appiumRoot.resolve("node_modules").resolve("appium-inspector-plugin"));
+
+        List<String> missing = new ArrayList<>();
+        if (node.isEmpty()) {
+            missing.add("node");
+        }
+        if (npm.isEmpty()) {
+            missing.add("npm");
+        }
+        if (appium.isEmpty()) {
+            missing.add("appium@" + SHAFT.Properties.internal.appiumServerVersion());
+        }
+        if (!inspector) {
+            missing.add("appium-inspector-plugin@" + SHAFT.Properties.internal.appiumInspectorPluginVersion());
+        }
+        if ("Android".equals(platform)) {
+            if (adb.isEmpty()) {
+                missing.add("android platform-tools");
+            }
+            if (emulator.isEmpty()) {
+                missing.add("android emulator");
+            }
+            if (sdkManager.isEmpty()) {
+                missing.add("android sdkmanager");
+            }
+            if (avdManager.isEmpty()) {
+                missing.add("android avdmanager");
+            }
+        }
+
+        return new McpMobileToolchainStatus(
+                platform,
+                node.isPresent(),
+                npm.isPresent(),
+                appium.isPresent(),
+                inspector,
+                adb.isPresent(),
+                emulator.isPresent(),
+                sdkManager.isPresent(),
+                avdManager.isPresent(),
+                toolRoot,
+                androidSdkRoot,
+                androidAvdHome,
+                appiumRoot,
+                appiumVersion(appium.orElse(null)),
+                SHAFT.Properties.internal.appiumInspectorPluginVersion(),
+                devices,
+                avds,
+                missing,
+                warnings);
+    }
+
+    McpAndroidEmulatorProposal defaultAndroidProposal(
+            String avdName,
+            int apiLevel,
+            String deviceProfile,
+            String imageTag,
+            String abi,
+            int ramMb,
+            int cores) {
+        int resolvedApiLevel = apiLevel > 0 ? apiLevel : SHAFT.Properties.internal.androidEmulatorApiLevel();
+        String resolvedDevice = defaultText(deviceProfile, SHAFT.Properties.internal.androidEmulatorDeviceProfile());
+        String resolvedTag = defaultText(imageTag, SHAFT.Properties.internal.androidEmulatorImageTag());
+        String resolvedAbi = defaultText(abi, hostAndroidAbi());
+        String resolvedName = defaultText(avdName, "shaft_pixel_8_api_" + resolvedApiLevel + "_"
+                + resolvedAbi.replace('-', '_'));
+        int resolvedRam = ramMb > 0 ? ramMb : SHAFT.Properties.internal.androidEmulatorRamMb();
+        int resolvedCores = cores > 0 ? cores : SHAFT.Properties.internal.androidEmulatorCores();
+        Path sdkRoot = androidSdkRoot();
+        Path avdHome = androidAvdHome();
+        String imagePackage = "system-images;android-" + resolvedApiLevel + ";" + resolvedTag + ";" + resolvedAbi;
+        List<String> packages = List.of(
+                "platform-tools",
+                "emulator",
+                "platforms;android-" + resolvedApiLevel,
+                imagePackage);
+        List<String> commands = List.of(
+                commandLineToolsUrl(),
+                "sdkmanager --sdk_root=" + sdkRoot + " " + String.join(" ", quotePackages(packages)),
+                "avdmanager create avd --force --name " + resolvedName + " --package " + quote(imagePackage)
+                        + " --device " + resolvedDevice,
+                "emulator -avd " + resolvedName + " -no-snapshot-save");
+        return new McpAndroidEmulatorProposal(
+                resolvedName,
+                resolvedDevice,
+                resolvedApiLevel,
+                resolvedTag,
+                resolvedAbi,
+                resolvedRam,
+                resolvedCores,
+                sdkRoot,
+                avdHome,
+                packages,
+                commands,
+                List.of(
+                        "The Android SDK and AVD are installed under the current user's SHAFT MCP cache.",
+                        "Confirming this proposal lets SHAFT pass Android SDK package license prompts for these packages."));
+    }
+
+    void ensureAppium(String platformName) {
+        String platform = normalizePlatform(platformName);
+        Path npm = ensureNpm();
+        try {
+            Files.createDirectories(appiumRoot());
+            runChecked(List.of(npm.toString(), "--prefix", appiumRoot().toString(), "install",
+                    "appium@" + SHAFT.Properties.internal.appiumServerVersion(),
+                    "appium-inspector-plugin@" + SHAFT.Properties.internal.appiumInspectorPluginVersion()),
+                    appiumRoot(), appiumEnvironment(), INSTALL_TIMEOUT, "Appium npm install failed.");
+            Path appium = appiumCommand();
+            runChecked(List.of(appium.toString(), "driver", "install", "--source=npm",
+                    "appium-uiautomator2-driver@" + SHAFT.Properties.internal.appiumUiAutomator2DriverVersion()),
+                    appiumRoot(), appiumEnvironment(), INSTALL_TIMEOUT, "UiAutomator2 driver install failed.");
+            if ("iOS".equals(platform) && isMac()) {
+                runChecked(List.of(appium.toString(), "driver", "install", "--source=npm",
+                        "appium-xcuitest-driver@" + SHAFT.Properties.internal.appiumXcuitestDriverVersion()),
+                        appiumRoot(), appiumEnvironment(), INSTALL_TIMEOUT, "XCUITest driver install failed.");
+            }
+            runChecked(List.of(appium.toString(), "plugin", "install", "--source=npm",
+                    "appium-inspector-plugin@" + SHAFT.Properties.internal.appiumInspectorPluginVersion()),
+                    appiumRoot(), appiumEnvironment(), INSTALL_TIMEOUT, "Appium Inspector plugin install failed.");
+        } catch (IOException exception) {
+            throw new IllegalStateException("Appium tool cache could not be prepared.", exception);
+        }
+    }
+
+    void ensureAndroidEmulator(McpAndroidEmulatorProposal proposal) {
+        if (proposal == null) {
+            throw new IllegalArgumentException("Android emulator proposal is required.");
+        }
+        ensureAndroidCommandLineTools();
+        Path sdkManager = sdkManagerCommand();
+        Path avdManager = avdManagerCommand();
+        try {
+            Files.createDirectories(proposal.avdHome());
+        } catch (IOException exception) {
+            throw new IllegalStateException("Android AVD home could not be created.", exception);
+        }
+        runner.runWithInput(List.of(sdkManager.toString(), "--sdk_root=" + androidSdkRoot(), "--licenses"),
+                androidSdkRoot(), androidEnvironment(), INSTALL_TIMEOUT, "y\n".repeat(80));
+        List<String> sdkCommand = new ArrayList<>(List.of(sdkManager.toString(), "--sdk_root=" + androidSdkRoot()));
+        sdkCommand.addAll(proposal.sdkPackages());
+        runChecked(sdkCommand, androidSdkRoot(), androidEnvironment(), INSTALL_TIMEOUT,
+                "Android SDK package installation failed.");
+        runChecked(List.of(avdManager.toString(), "create", "avd", "--force",
+                "--name", proposal.avdName(),
+                "--package", "system-images;android-" + proposal.apiLevel() + ";" + proposal.imageTag() + ";"
+                        + proposal.abi(),
+                "--device", proposal.deviceProfile()),
+                androidSdkRoot(), androidEnvironment(), INSTALL_TIMEOUT, "Android AVD creation failed.");
+    }
+
+    Process startAndroidEmulator(String avdName, McpAndroidEmulatorProposal proposal) {
+        String name = defaultText(avdName, proposal == null ? "" : proposal.avdName());
+        if (name.isBlank()) {
+            throw new IllegalArgumentException("Android AVD name is required.");
+        }
+        Path emulator = emulatorCommand();
+        List<String> command = new ArrayList<>(List.of(
+                emulator.toString(),
+                "-avd",
+                name,
+                "-no-snapshot-save",
+                "-no-boot-anim"));
+        if (proposal != null) {
+            command.addAll(List.of(
+                    "-memory", String.valueOf(proposal.ramMb()),
+                    "-cores", String.valueOf(proposal.cores())));
+        }
+        return runner.start(command, androidSdkRoot(), androidEnvironment());
+    }
+
+    Process startAppiumServer(int port) {
+        Path appium = appiumCommand();
+        return runner.start(List.of(
+                appium.toString(),
+                "--address", "127.0.0.1",
+                "--port", String.valueOf(port),
+                "--use-plugins=inspector",
+                "--relaxed-security"),
+                appiumRoot(), appiumEnvironment());
+    }
+
+    boolean waitForAndroidDevice(Duration timeout) {
+        Optional<Path> adb = resolveExecutable("adb", List.of(androidSdkRoot().resolve("platform-tools")));
+        if (adb.isEmpty()) {
+            return false;
+        }
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (System.nanoTime() < deadline) {
+            if (androidDevices(adb.get()).stream().anyMatch(device -> "device".equals(device.state()))) {
+                return true;
+            }
+            sleep(Duration.ofSeconds(2));
+        }
+        return false;
+    }
+
+    void stopAndroidEmulator(String deviceId) {
+        Optional<Path> adb = resolveExecutable("adb", List.of(androidSdkRoot().resolve("platform-tools")));
+        if (adb.isEmpty() || text(deviceId).isBlank()) {
+            return;
+        }
+        runner.run(List.of(adb.get().toString(), "-s", deviceId, "emu", "kill"),
+                androidSdkRoot(), androidEnvironment(), Duration.ofSeconds(8));
+    }
+
+    String newConfirmationToken() {
+        return UUID.randomUUID().toString();
+    }
+
+    Path appiumCommand() {
+        return resolveExecutable("appium", List.of(appiumBin()))
+                .orElse(appiumBin().resolve(isWindows() ? "appium.cmd" : "appium"));
+    }
+
+    private Path ensureNpm() {
+        Optional<Path> npm = resolveExecutable("npm", List.of(nodeBin()));
+        if (npm.isPresent()) {
+            return npm.get();
+        }
+        downloadPortableNode();
+        return resolveExecutable("npm", List.of(nodeBin()))
+                .orElseThrow(() -> new IllegalStateException("npm was not found after portable Node.js setup."));
+    }
+
+    private void ensureAndroidCommandLineTools() {
+        if (Files.isRegularFile(sdkManagerCommand()) || Files.isRegularFile(sdkManagerCommand().resolveSibling(
+                sdkManagerCommand().getFileName().toString() + ".bat"))) {
+            return;
+        }
+        Path zip = toolRoot.resolve("downloads").resolve("android-commandlinetools.zip");
+        Path temp = toolRoot.resolve("downloads").resolve("android-commandlinetools-" + System.nanoTime());
+        try {
+            Files.createDirectories(zip.getParent());
+            download(commandLineToolsUrl(), zip);
+            unzip(zip, temp);
+            Path extracted = temp.resolve("cmdline-tools");
+            Path target = androidSdkRoot().resolve("cmdline-tools").resolve("latest");
+            deleteIfExists(target);
+            Files.createDirectories(target.getParent());
+            Files.move(extracted, target, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException exception) {
+            throw new IllegalStateException("Android command-line tools could not be prepared.", exception);
+        } finally {
+            deleteIfExists(temp);
+        }
+    }
+
+    private void downloadPortableNode() {
+        String archiveName = nodeArchiveName();
+        String extension = isWindows() ? ".zip" : isMac() ? ".tar.gz" : ".tar.xz";
+        Path archive = toolRoot.resolve("downloads").resolve(archiveName + extension);
+        Path target = toolRoot.resolve("node").resolve(archiveName);
+        if (Files.isDirectory(target)) {
+            return;
+        }
+        try {
+            Files.createDirectories(archive.getParent());
+            download("https://nodejs.org/dist/v" + SHAFT.Properties.internal.nodeLtsVersion() + "/"
+                    + archiveName + extension, archive);
+            Files.createDirectories(target.getParent());
+            if (isWindows()) {
+                Path temp = target.getParent().resolve(archiveName + "-extract");
+                unzip(archive, temp);
+                deleteIfExists(target);
+                Files.move(temp.resolve(archiveName), target, StandardCopyOption.REPLACE_EXISTING);
+                deleteIfExists(temp);
+            } else {
+                runChecked(List.of("tar", "-xf", archive.toString(), "-C", target.getParent().toString()),
+                        target.getParent(), environment, INSTALL_TIMEOUT, "Portable Node.js archive extraction failed.");
+            }
+        } catch (IOException exception) {
+            throw new IllegalStateException("Portable Node.js could not be downloaded.", exception);
+        }
+    }
+
+    private void download(String url, Path target) throws IOException {
+        if (Files.isRegularFile(target) && Files.size(target) > 0) {
+            return;
+        }
+        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+                .timeout(Duration.ofMinutes(5))
+                .GET()
+                .build();
+        try {
+            HttpResponse<Path> response = httpClient.send(request, HttpResponse.BodyHandlers.ofFile(target));
+            if (response.statusCode() / 100 != 2) {
+                Files.deleteIfExists(target);
+                throw new IOException("Download failed with HTTP " + response.statusCode() + ": " + url);
+            }
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Download interrupted: " + url, exception);
+        }
+    }
+
+    private void unzip(Path zip, Path target) throws IOException {
+        Files.createDirectories(target);
+        try (ZipInputStream input = new ZipInputStream(Files.newInputStream(zip))) {
+            ZipEntry entry;
+            while ((entry = input.getNextEntry()) != null) {
+                Path output = target.resolve(entry.getName()).normalize();
+                if (!output.startsWith(target)) {
+                    throw new IOException("Zip entry escapes target: " + entry.getName());
+                }
+                if (entry.isDirectory()) {
+                    Files.createDirectories(output);
+                } else {
+                    Files.createDirectories(output.getParent());
+                    Files.copy(input, output, StandardCopyOption.REPLACE_EXISTING);
+                }
+            }
+        }
+    }
+
+    private void runChecked(
+            List<String> command,
+            Path workingDirectory,
+            Map<String, String> commandEnvironment,
+            Duration timeout,
+            String failureMessage) {
+        McpProcessRunner.ProcessResult result = runner.run(command, workingDirectory, commandEnvironment, timeout);
+        if (result.timedOut() || result.exitCode() != 0) {
+            throw new IllegalStateException(failureMessage + " Exit code: " + result.exitCode()
+                    + ". Output: " + safeOutput(result.stdout(), result.stderr()));
+        }
+    }
+
+    private List<McpMobileDevice> androidDevices(Path adb) {
+        McpProcessRunner.ProcessResult result = runner.run(List.of(adb.toString(), "devices", "-l"),
+                androidSdkRoot(), androidEnvironment(), QUICK_TIMEOUT);
+        if (result.exitCode() != 0 || result.timedOut()) {
+            return List.of(new McpMobileDevice("", "", "Android", "unavailable", false,
+                    List.of("adb devices failed: " + safeOutput(result.stdout(), result.stderr()))));
+        }
+        List<McpMobileDevice> devices = new ArrayList<>();
+        for (String line : result.stdout().split("\\R")) {
+            String trimmed = line.trim();
+            if (trimmed.isBlank() || trimmed.startsWith("List of devices")) {
+                continue;
+            }
+            String[] parts = trimmed.split("\\s+", 3);
+            if (parts.length < 2) {
+                continue;
+            }
+            String id = parts[0];
+            String state = parts[1];
+            List<String> warnings = "device".equals(state) ? List.of()
+                    : List.of("Android device is not ready: " + state);
+            devices.add(new McpMobileDevice(
+                    id,
+                    androidModel(trimmed, id),
+                    "Android",
+                    state,
+                    id.startsWith("emulator-"),
+                    warnings));
+        }
+        return List.copyOf(devices);
+    }
+
+    private List<String> cachedAndroidEmulators(Path emulator, Path androidAvdHome) {
+        Set<String> avds = new LinkedHashSet<>();
+        if (emulator != null) {
+            McpProcessRunner.ProcessResult result = runner.run(List.of(emulator.toString(), "-list-avds"),
+                    androidSdkRoot(), androidEnvironment(), QUICK_TIMEOUT);
+            if (result.exitCode() == 0 && !result.timedOut()) {
+                Arrays.stream(result.stdout().split("\\R"))
+                        .map(String::trim)
+                        .filter(line -> !line.isBlank())
+                        .forEach(avds::add);
+            }
+        }
+        scanAvdHome(androidAvdHome, avds);
+        scanAvdHome(defaultUserAvdHome(), avds);
+        return List.copyOf(avds);
+    }
+
+    private void scanAvdHome(Path avdHome, Set<String> avds) {
+        if (!Files.isDirectory(avdHome)) {
+            return;
+        }
+        try (var stream = Files.list(avdHome)) {
+            stream.filter(path -> path.getFileName().toString().endsWith(".avd"))
+                    .map(path -> path.getFileName().toString().replaceFirst("\\.avd$", ""))
+                    .forEach(avds::add);
+        } catch (IOException ignored) {
+            // Directory scans are best effort; emulator -list-avds remains authoritative.
+        }
+    }
+
+    private boolean hasInspectorPlugin(Path appium) {
+        McpProcessRunner.ProcessResult result = runner.run(List.of(appium.toString(), "plugin", "list", "--installed"),
+                appiumRoot(), appiumEnvironment(), QUICK_TIMEOUT);
+        return result.exitCode() == 0 && result.stdout().toLowerCase(Locale.ROOT).contains("inspector");
+    }
+
+    private String appiumVersion(Path appium) {
+        if (appium == null) {
+            return "";
+        }
+        McpProcessRunner.ProcessResult result = runner.run(List.of(appium.toString(), "--version"),
+                appiumRoot(), appiumEnvironment(), QUICK_TIMEOUT);
+        return result.exitCode() == 0 ? result.stdout().trim() : "";
+    }
+
+    private Optional<Path> resolveExecutable(String name, List<Path> additionalDirectories) {
+        List<Path> candidates = new ArrayList<>();
+        if (additionalDirectories != null) {
+            for (Path directory : additionalDirectories) {
+                if (directory != null) {
+                    candidates.addAll(executableCandidates(directory, name));
+                }
+            }
+        }
+        String path = environment.getOrDefault("PATH", System.getenv("PATH"));
+        if (path != null) {
+            for (String entry : path.split(Pattern.quote(java.io.File.pathSeparator))) {
+                if (!entry.isBlank()) {
+                    candidates.addAll(executableCandidates(Path.of(entry), name));
+                }
+            }
+        }
+        return candidates.stream()
+                .filter(Files::isRegularFile)
+                .findFirst()
+                .map(pathValue -> pathValue.toAbsolutePath().normalize());
+    }
+
+    private List<Path> executableCandidates(Path directory, String name) {
+        if (isWindows()) {
+            return List.of(directory.resolve(name + ".cmd"), directory.resolve(name + ".bat"),
+                    directory.resolve(name + ".exe"), directory.resolve(name));
+        }
+        return List.of(directory.resolve(name));
+    }
+
+    private Map<String, String> androidEnvironment() {
+        return mergedEnvironment(Map.of(
+                "ANDROID_HOME", androidSdkRoot().toString(),
+                "ANDROID_SDK_ROOT", androidSdkRoot().toString(),
+                "ANDROID_AVD_HOME", androidAvdHome().toString()));
+    }
+
+    private Map<String, String> appiumEnvironment() {
+        return mergedEnvironment(Map.of(
+                "APPIUM_HOME", appiumRoot().resolve("home").toString(),
+                "ANDROID_HOME", androidSdkRoot().toString(),
+                "ANDROID_SDK_ROOT", androidSdkRoot().toString(),
+                "ANDROID_AVD_HOME", androidAvdHome().toString()));
+    }
+
+    private Map<String, String> mergedEnvironment(Map<String, String> additions) {
+        java.util.HashMap<String, String> merged = new java.util.HashMap<>(environment);
+        merged.putAll(additions);
+        String path = environment.getOrDefault("PATH", System.getenv("PATH"));
+        String extraPath = String.join(java.io.File.pathSeparator,
+                nodeBin().toString(),
+                appiumBin().toString(),
+                androidSdkRoot().resolve("platform-tools").toString(),
+                androidSdkRoot().resolve("emulator").toString(),
+                androidSdkRoot().resolve("cmdline-tools").resolve("latest").resolve("bin").toString());
+        merged.put("PATH", path == null || path.isBlank() ? extraPath : extraPath + java.io.File.pathSeparator + path);
+        return Map.copyOf(merged);
+    }
+
+    private Path androidSdkRoot() {
+        String configured = firstNonBlank(environment.get("ANDROID_SDK_ROOT"), environment.get("ANDROID_HOME"));
+        return configured == null ? toolRoot.resolve("android-sdk") : Path.of(configured);
+    }
+
+    private Path androidAvdHome() {
+        String configured = environment.get("ANDROID_AVD_HOME");
+        return configured == null || configured.isBlank() ? toolRoot.resolve("android-avd") : Path.of(configured);
+    }
+
+    private Path defaultUserAvdHome() {
+        return Path.of(System.getProperty("user.home", ".")).resolve(".android").resolve("avd");
+    }
+
+    private Path appiumRoot() {
+        return toolRoot.resolve("appium");
+    }
+
+    private Path appiumBin() {
+        return appiumRoot().resolve("node_modules").resolve(".bin");
+    }
+
+    private Path nodeBin() {
+        return toolRoot.resolve("node").resolve(nodeArchiveName()).resolve(isWindows() ? "" : "bin");
+    }
+
+    private Path sdkManagerCommand() {
+        Path bin = androidSdkRoot().resolve("cmdline-tools").resolve("latest").resolve("bin");
+        return bin.resolve(isWindows() ? "sdkmanager.bat" : "sdkmanager");
+    }
+
+    private Path avdManagerCommand() {
+        Path bin = androidSdkRoot().resolve("cmdline-tools").resolve("latest").resolve("bin");
+        return bin.resolve(isWindows() ? "avdmanager.bat" : "avdmanager");
+    }
+
+    private Path emulatorCommand() {
+        return resolveExecutable("emulator", List.of(androidSdkRoot().resolve("emulator")))
+                .orElseThrow(() -> new IllegalStateException("Android emulator executable was not found."));
+    }
+
+    private String commandLineToolsUrl() {
+        String platform = isWindows() ? "win" : isMac() ? "mac" : "linux";
+        return "https://dl.google.com/android/repository/commandlinetools-" + platform + "-"
+                + SHAFT.Properties.internal.androidCommandLineToolsVersion() + "_latest.zip";
+    }
+
+    private String nodeArchiveName() {
+        String platform = isWindows() ? "win" : isMac() ? "darwin" : "linux";
+        String arch = osArch.toLowerCase(Locale.ROOT).contains("aarch64")
+                || osArch.toLowerCase(Locale.ROOT).contains("arm64") ? "arm64" : "x64";
+        return "node-v" + SHAFT.Properties.internal.nodeLtsVersion() + "-" + platform + "-" + arch;
+    }
+
+    private String hostAndroidAbi() {
+        String arch = osArch.toLowerCase(Locale.ROOT);
+        return arch.contains("aarch64") || arch.contains("arm64") ? "arm64-v8a" : "x86_64";
+    }
+
+    private String normalizePlatform(String platformName) {
+        String platform = text(platformName).toLowerCase(Locale.ROOT);
+        return switch (platform) {
+            case "", "android" -> "Android";
+            case "ios" -> "iOS";
+            default -> throw new IllegalArgumentException("platformName must be Android or iOS.");
+        };
+    }
+
+    private String androidModel(String line, String fallback) {
+        Matcher matcher = DEVICE_NAME.matcher(line);
+        return matcher.find() ? matcher.group(1).replace('_', ' ') : fallback;
+    }
+
+    private boolean isWindows() {
+        return osName.toLowerCase(Locale.ROOT).contains("win");
+    }
+
+    private boolean isMac() {
+        String os = osName.toLowerCase(Locale.ROOT);
+        return os.contains("mac") || os.contains("darwin");
+    }
+
+    private static String firstNonBlank(String first, String second) {
+        if (first != null && !first.isBlank()) {
+            return first;
+        }
+        return second == null || second.isBlank() ? null : second;
+    }
+
+    private static String defaultText(String value, String fallback) {
+        String text = text(value);
+        return text.isBlank() ? fallback : text;
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private static String quote(String value) {
+        return "\"" + value + "\"";
+    }
+
+    private static List<String> quotePackages(List<String> packages) {
+        return packages.stream().map(McpMobileToolchainService::quote).toList();
+    }
+
+    private static String safeOutput(String stdout, String stderr) {
+        String combined = (stdout == null ? "" : stdout) + "\n" + (stderr == null ? "" : stderr);
+        return combined.length() > 4000 ? combined.substring(0, 4000) : combined.trim();
+    }
+
+    private static void sleep(Duration duration) {
+        try {
+            Thread.sleep(duration.toMillis());
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static void deleteIfExists(Path path) {
+        if (path == null || !Files.exists(path)) {
+            return;
+        }
+        try {
+            Files.walkFileTree(path, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.deleteIfExists(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    Files.deleteIfExists(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException ignored) {
+            // Best-effort cleanup only.
+        }
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainStatus.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainStatus.java
@@ -1,0 +1,45 @@
+package com.shaft.mcp;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Local mobile toolchain discovery status.
+ */
+public record McpMobileToolchainStatus(
+        String platformName,
+        boolean nodeAvailable,
+        boolean npmAvailable,
+        boolean appiumAvailable,
+        boolean appiumInspectorAvailable,
+        boolean adbAvailable,
+        boolean emulatorAvailable,
+        boolean sdkManagerAvailable,
+        boolean avdManagerAvailable,
+        Path toolRoot,
+        Path androidSdkRoot,
+        Path androidAvdHome,
+        Path appiumRoot,
+        String appiumVersion,
+        String appiumInspectorPluginVersion,
+        List<McpMobileDevice> androidDevices,
+        List<String> cachedAndroidEmulators,
+        List<String> missingDependencies,
+        List<String> warnings) {
+    /**
+     * Creates an immutable toolchain status.
+     */
+    public McpMobileToolchainStatus {
+        platformName = text(platformName);
+        appiumVersion = text(appiumVersion);
+        appiumInspectorPluginVersion = text(appiumInspectorPluginVersion);
+        androidDevices = androidDevices == null ? List.of() : List.copyOf(androidDevices);
+        cachedAndroidEmulators = cachedAndroidEmulators == null ? List.of() : List.copyOf(cachedAndroidEmulators);
+        missingDependencies = missingDependencies == null ? List.of() : List.copyOf(missingDependencies);
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpProcessRunner.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpProcessRunner.java
@@ -1,0 +1,129 @@
+package com.shaft.mcp;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Thin process boundary for MCP toolchain commands.
+ */
+interface McpProcessRunner {
+    ProcessResult run(List<String> command, Path workingDirectory, Map<String, String> environment, Duration timeout);
+
+    default ProcessResult runWithInput(
+            List<String> command,
+            Path workingDirectory,
+            Map<String, String> environment,
+            Duration timeout,
+            String input) {
+        return run(command, workingDirectory, environment, timeout);
+    }
+
+    Process start(List<String> command, Path workingDirectory, Map<String, String> environment);
+
+    /**
+     * Completed process result.
+     */
+    record ProcessResult(int exitCode, String stdout, String stderr, boolean timedOut) {
+        public ProcessResult {
+            stdout = stdout == null ? "" : stdout;
+            stderr = stderr == null ? "" : stderr;
+        }
+    }
+
+    /**
+     * Returns the real local process runner.
+     */
+    static McpProcessRunner system() {
+        return new SystemProcessRunner();
+    }
+
+    final class SystemProcessRunner implements McpProcessRunner {
+        @Override
+        public ProcessResult run(
+                List<String> command,
+                Path workingDirectory,
+                Map<String, String> environment,
+                Duration timeout) {
+            Process process = start(command, workingDirectory, environment);
+            closeInput(process, "");
+            return waitFor(process, timeout);
+        }
+
+        @Override
+        public ProcessResult runWithInput(
+                List<String> command,
+                Path workingDirectory,
+                Map<String, String> environment,
+                Duration timeout,
+                String input) {
+            Process process = start(command, workingDirectory, environment);
+            closeInput(process, input);
+            return waitFor(process, timeout);
+        }
+
+        private ProcessResult waitFor(Process process, Duration timeout) {
+            CompletableFuture<String> stdout = read(process.getInputStream());
+            CompletableFuture<String> stderr = read(process.getErrorStream());
+            try {
+                boolean finished = process.waitFor(Math.max(timeout.toMillis(), 1), TimeUnit.MILLISECONDS);
+                if (!finished) {
+                    process.destroyForcibly();
+                    return new ProcessResult(-1, stdout.join(), stderr.join(), true);
+                }
+                return new ProcessResult(process.exitValue(), stdout.join(), stderr.join(), false);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                process.destroyForcibly();
+                return new ProcessResult(-1, stdout.join(), stderr.join(), true);
+            }
+        }
+
+        private static void closeInput(Process process, String input) {
+            try (var output = process.getOutputStream()) {
+                if (input != null && !input.isBlank()) {
+                    output.write(input.getBytes(StandardCharsets.UTF_8));
+                    output.flush();
+                }
+            } catch (IOException ignored) {
+                // Some commands close stdin immediately.
+            }
+        }
+
+        @Override
+        public Process start(List<String> command, Path workingDirectory, Map<String, String> environment) {
+            if (command == null || command.isEmpty()) {
+                throw new IllegalArgumentException("Process command is required.");
+            }
+            ProcessBuilder builder = new ProcessBuilder(command);
+            if (workingDirectory != null) {
+                builder.directory(workingDirectory.toFile());
+            }
+            if (environment != null) {
+                builder.environment().putAll(environment);
+            }
+            try {
+                return builder.start();
+            } catch (IOException exception) {
+                throw new IllegalStateException("Process could not be started: " + String.join(" ", command),
+                        exception);
+            }
+        }
+
+        private static CompletableFuture<String> read(InputStream stream) {
+            return CompletableFuture.supplyAsync(() -> {
+                try (stream) {
+                    return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+                } catch (IOException exception) {
+                    return "";
+                }
+            });
+        }
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpRuntimePaths.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpRuntimePaths.java
@@ -31,6 +31,13 @@ final class McpRuntimePaths {
                 Path.of(System.getProperty("user.home")).toAbsolutePath().normalize());
     }
 
+    static Path applicationDataRoot() {
+        return applicationDataRoot(
+                System.getenv(),
+                System.getProperty("os.name", ""),
+                Path.of(System.getProperty("user.home")).toAbsolutePath().normalize());
+    }
+
     static Path resolveRoot(
             Map<String, String> environment,
             Path currentDirectory,

--- a/shaft-mcp/src/main/java/com/shaft/mcp/MobileService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/MobileService.java
@@ -43,6 +43,7 @@ public class MobileService {
 
     private final EngineService engineService;
     private final McpMobileRecordingService recorder;
+    private final McpMobileInspectorRecordingService inspectorRecorder;
     private final McpWorkspacePolicy workspacePolicy;
 
     @Autowired
@@ -59,9 +60,19 @@ public class MobileService {
     }
 
     MobileService(EngineService engineService, McpMobileRecordingService recorder, McpWorkspacePolicy workspacePolicy) {
+        this(engineService, recorder, workspacePolicy,
+                new McpMobileInspectorRecordingService(workspacePolicy, recorder));
+    }
+
+    MobileService(
+            EngineService engineService,
+            McpMobileRecordingService recorder,
+            McpWorkspacePolicy workspacePolicy,
+            McpMobileInspectorRecordingService inspectorRecorder) {
         this.engineService = engineService;
         this.recorder = recorder;
         this.workspacePolicy = workspacePolicy;
+        this.inspectorRecorder = inspectorRecorder;
     }
 
     /**
@@ -218,6 +229,121 @@ public class MobileService {
             description = "stops MCP mobile recording and optionally discards the JSON file")
     public McpMobileRecordingStatus recordStop(boolean discard) {
         return recorder.stop(discard);
+    }
+
+    /**
+     * Returns local Appium/Android/iOS toolchain discovery status.
+     *
+     * @param platformName Android or iOS; blank defaults to Android
+     * @return local mobile toolchain status
+     */
+    @Tool(name = "mobile_toolchain_status",
+            description = "checks local Appium, Inspector, adb, emulator, and SDK tooling status")
+    public McpMobileToolchainStatus toolchainStatus(String platformName) {
+        return inspectorRecorder.toolchainStatus(platformName);
+    }
+
+    /**
+     * Prepares a user-confirmable wrapped Appium Inspector recording session.
+     *
+     * @param platformName Android or iOS
+     * @param outputPath workspace-contained recording JSON output path
+     * @param includeSensitiveValues whether typed values should be stored for exact replay
+     * @param app optional app path or remote app URL
+     * @param appPackage optional Android app package
+     * @param appActivity optional Android app activity
+     * @param bundleId optional iOS bundle identifier
+     * @param udid optional device UDID
+     * @param deviceName optional device or simulator name
+     * @param platformVersion optional mobile OS version
+     * @param selectedAndroidAvdName cached Android AVD name to start when no real device is connected
+     * @param androidApiLevel Android API level for new emulator proposal; non-positive uses SHAFT default
+     * @param androidDeviceProfile Android device profile for new emulator proposal
+     * @param androidImageTag Android image tag for new emulator proposal
+     * @param androidAbi Android emulator image ABI
+     * @param androidRamMb Android emulator RAM in MB
+     * @param androidCores Android emulator CPU cores
+     * @param provisionAndroidEmulator whether to propose creating a fresh Android emulator when needed
+     * @return confirmation-ready recording plan
+     */
+    @Tool(name = "mobile_inspector_record_prepare",
+            description = "prepares a wrapped Appium Inspector mobile recording plan with device and dependency details")
+    public McpMobileInspectorPlan inspectorRecordPrepare(
+            String platformName,
+            String outputPath,
+            boolean includeSensitiveValues,
+            String app,
+            String appPackage,
+            String appActivity,
+            String bundleId,
+            String udid,
+            String deviceName,
+            String platformVersion,
+            String selectedAndroidAvdName,
+            int androidApiLevel,
+            String androidDeviceProfile,
+            String androidImageTag,
+            String androidAbi,
+            int androidRamMb,
+            int androidCores,
+            boolean provisionAndroidEmulator) {
+        return inspectorRecorder.prepare(platformName, outputPath, includeSensitiveValues, app, appPackage,
+                appActivity, bundleId, udid, deviceName, platformVersion, selectedAndroidAvdName, androidApiLevel,
+                androidDeviceProfile, androidImageTag, androidAbi, androidRamMb, androidCores,
+                provisionAndroidEmulator);
+    }
+
+    /**
+     * Starts a previously prepared wrapped Appium Inspector recording session.
+     *
+     * @param confirmationToken token returned by mobile_inspector_record_prepare
+     * @param selectedAndroidAvdName optional cached Android AVD override
+     * @param openInspector whether to open the wrapped Inspector URL in the user's browser
+     * @return active recording status and Inspector URL
+     */
+    @Tool(name = "mobile_inspector_record_start",
+            description = "starts a confirmed wrapped Appium Inspector recording session")
+    public McpMobileInspectorRecordingStatus inspectorRecordStart(
+            String confirmationToken,
+            String selectedAndroidAvdName,
+            boolean openInspector) {
+        return inspectorRecorder.start(confirmationToken, selectedAndroidAvdName, openInspector);
+    }
+
+    /**
+     * Returns wrapped Appium Inspector recording status.
+     *
+     * @return current Inspector recording status
+     */
+    @Tool(name = "mobile_inspector_record_status",
+            description = "returns the wrapped Appium Inspector recording status")
+    public McpMobileInspectorRecordingStatus inspectorRecordStatus() {
+        return inspectorRecorder.status();
+    }
+
+    /**
+     * Controls a wrapped Appium Inspector recording.
+     *
+     * @param action status, pause, resume, checkpoint, stop, or discard
+     * @param checkpointName optional checkpoint name
+     * @return updated recording status
+     */
+    @Tool(name = "mobile_inspector_record_control",
+            description = "pauses, resumes, checkpoints, stops, or discards a wrapped Appium Inspector recording")
+    public McpMobileInspectorRecordingStatus inspectorRecordControl(String action, String checkpointName) {
+        return inspectorRecorder.control(action, checkpointName);
+    }
+
+    /**
+     * Stops a wrapped Appium Inspector recording and returns generated replay snippets.
+     *
+     * @param discard whether to delete the recording output
+     * @return final recording status
+     */
+    @Tool(name = "mobile_inspector_record_stop",
+            description = "stops a wrapped Appium Inspector recording and returns generated replay code")
+    public McpMobileInspectorRecordingStatus inspectorRecordStop(boolean discard) {
+        return inspectorRecorder.stop(discard);
     }
 
     /**

--- a/shaft-mcp/src/test/java/com/shaft/mcp/McpAppiumCommandRecorderTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/McpAppiumCommandRecorderTest.java
@@ -1,0 +1,96 @@
+package com.shaft.mcp;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class McpAppiumCommandRecorderTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void recordsElementClickAndRedactsTypedValueWhenConfigured() {
+        Path output = temp.resolve("inspector.json");
+        McpMobileRecordingService recorder = new McpMobileRecordingService(McpWorkspacePolicy.of(temp));
+        recorder.start(output.toString(), "mobile-inspector-android", false);
+        McpAppiumCommandRecorder commandRecorder = new McpAppiumCommandRecorder(recorder, () -> false);
+
+        commandRecorder.capture("POST", "/session/abc/element",
+                "{\"using\":\"accessibility id\",\"value\":\"login\"}",
+                200,
+                "{\"value\":{\"element-6066-11e4-a52e-4f735466cecf\":\"el-1\"}}");
+        commandRecorder.capture("POST", "/session/abc/element/el-1/click", "{}", 200, "{\"value\":null}");
+        commandRecorder.capture("POST", "/session/abc/element/el-1/value",
+                "{\"text\":\"secret\"}", 200, "{\"value\":null}");
+
+        McpMobileRecordingStatus stopped = recorder.stop(false);
+        McpMobileReplayResult replay = recorder.codeBlocks(output.toString(), "mobileDriver");
+        String code = replay.codeBlocks().getFirst().code();
+
+        assertEquals(2, stopped.actionCount());
+        assertTrue(code.contains("mobileDriver.touch().tap(AppiumBy.accessibilityId(\"login\"));"));
+        assertTrue(code.contains("mobileDriver.element().type(AppiumBy.accessibilityId(\"login\"), \"<redacted>\");"));
+        assertFalse(code.contains("secret"));
+        assertTrue(replay.warnings().stream().anyMatch(warning -> warning.contains("redacted")));
+    }
+
+    @Test
+    void recordsPointerTapAndSwipeActions() {
+        Path output = temp.resolve("gestures.json");
+        McpMobileRecordingService recorder = new McpMobileRecordingService(McpWorkspacePolicy.of(temp));
+        recorder.start(output.toString(), "mobile-inspector-android", true);
+        McpAppiumCommandRecorder commandRecorder = new McpAppiumCommandRecorder(recorder, () -> false);
+
+        commandRecorder.capture("POST", "/session/abc/actions", """
+                {"actions":[{"type":"pointer","id":"finger","parameters":{"pointerType":"touch"},"actions":[
+                {"type":"pointerMove","duration":0,"x":10,"y":20},
+                {"type":"pointerDown","button":0},
+                {"type":"pointerUp","button":0}
+                ]}]}""", 200, "{\"value\":null}");
+        commandRecorder.capture("POST", "/session/abc/actions", """
+                {"actions":[{"type":"pointer","id":"finger","parameters":{"pointerType":"touch"},"actions":[
+                {"type":"pointerMove","duration":0,"x":10,"y":20},
+                {"type":"pointerDown","button":0},
+                {"type":"pointerMove","duration":450,"x":110,"y":220},
+                {"type":"pointerUp","button":0}
+                ]}]}""", 200, "{\"value\":null}");
+
+        recorder.stop(false);
+        McpMobileRecording recording = recorder.readRecording(output.toString());
+
+        assertEquals("tapCoordinates", recording.actions().getFirst().action());
+        assertEquals(Map.of("x", "10", "y", "20"), recording.actions().getFirst().parameters());
+        assertEquals("swipeCoordinates", recording.actions().get(1).action());
+        assertEquals("450", recording.actions().get(1).parameters().get("durationMillis"));
+    }
+
+    @Test
+    void ignoresInspectorCommandsWhilePaused() {
+        Path output = temp.resolve("paused.json");
+        AtomicBoolean paused = new AtomicBoolean(true);
+        McpMobileRecordingService recorder = new McpMobileRecordingService(McpWorkspacePolicy.of(temp));
+        recorder.start(output.toString(), "mobile-inspector-android", true);
+        McpAppiumCommandRecorder commandRecorder = new McpAppiumCommandRecorder(recorder, paused::get);
+
+        commandRecorder.capture("POST", "/session/abc/actions", """
+                {"actions":[{"type":"pointer","parameters":{"pointerType":"touch"},"actions":[
+                {"type":"pointerMove","x":1,"y":2},{"type":"pointerDown"},{"type":"pointerUp"}
+                ]}]}""", 200, "{\"value\":null}");
+        paused.set(false);
+        commandRecorder.capture("POST", "/session/abc/actions", """
+                {"actions":[{"type":"pointer","parameters":{"pointerType":"touch"},"actions":[
+                {"type":"pointerMove","x":1,"y":2},{"type":"pointerDown"},{"type":"pointerUp"}
+                ]}]}""", 200, "{\"value\":null}");
+
+        McpMobileRecordingStatus stopped = recorder.stop(false);
+
+        assertEquals(1, stopped.actionCount());
+    }
+}

--- a/shaft-mcp/src/test/java/com/shaft/mcp/McpMobileInspectorRecordingServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/McpMobileInspectorRecordingServiceTest.java
@@ -1,0 +1,119 @@
+package com.shaft.mcp;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class McpMobileInspectorRecordingServiceTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void prepareRequiresAppDetailsBeforeStart() {
+        McpMobileInspectorRecordingService service = service();
+
+        McpMobileInspectorPlan plan = service.prepare(
+                "Android",
+                "recordings/native.json",
+                true,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                0,
+                "",
+                "",
+                "",
+                0,
+                0,
+                true);
+
+        assertFalse(plan.readyToStart());
+        assertTrue(plan.warnings().stream().anyMatch(warning -> warning.contains("appPackage")));
+        assertTrue(plan.toolchainStatus().missingDependencies().contains("android platform-tools"));
+        assertThrows(IllegalStateException.class,
+                () -> service.start(plan.confirmationToken(), "", false));
+    }
+
+    @Test
+    void prepareBuildsProvisioningProposalWhenNoAndroidDeviceExists() {
+        String originalHome = System.getProperty("user.home");
+        System.setProperty("user.home", temp.toString());
+        try {
+            McpMobileInspectorRecordingService service = service();
+
+            McpMobileInspectorPlan plan = service.prepare(
+                    "Android",
+                    "recordings/native.json",
+                    false,
+                    "",
+                    "com.example",
+                    ".MainActivity",
+                    "",
+                    "",
+                    "Pixel 8",
+                    "",
+                    "",
+                    36,
+                    "",
+                    "",
+                    "",
+                    0,
+                    0,
+                    true);
+
+            assertTrue(plan.readyToStart());
+            assertTrue(plan.willProvisionAndroidEmulator());
+            assertTrue(plan.confirmationRequired());
+            assertTrue(plan.androidEmulatorProposal().sdkPackages().contains("platform-tools"));
+            assertTrue(plan.appiumCapabilities().containsKey("appium:appPackage"));
+            assertTrue(plan.nextSteps().stream().anyMatch(step -> step.contains("confirmation token")));
+        } finally {
+            System.setProperty("user.home", originalHome);
+        }
+    }
+
+    @Test
+    void rejectsUnknownConfirmationToken() {
+        McpMobileInspectorRecordingService service = service();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.start("missing", "", false));
+    }
+
+    private McpMobileInspectorRecordingService service() {
+        McpMobileRecordingService recorder = new McpMobileRecordingService(McpWorkspacePolicy.of(temp));
+        McpMobileToolchainService toolchain = new McpMobileToolchainService(new NoopRunner(),
+                Map.of("PATH", "", "ANDROID_AVD_HOME", temp.resolve("avd").toString()),
+                temp.resolve("tools"), "Windows 11", "amd64");
+        return new McpMobileInspectorRecordingService(McpWorkspacePolicy.of(temp), recorder, toolchain);
+    }
+
+    private static final class NoopRunner implements McpProcessRunner {
+        @Override
+        public ProcessResult run(
+                List<String> command,
+                Path workingDirectory,
+                Map<String, String> environment,
+                Duration timeout) {
+            return new ProcessResult(0, "", "", false);
+        }
+
+        @Override
+        public Process start(List<String> command, Path workingDirectory, Map<String, String> environment) {
+            throw new UnsupportedOperationException("No process starts in unit tests.");
+        }
+    }
+}

--- a/shaft-mcp/src/test/java/com/shaft/mcp/McpMobileToolchainServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/McpMobileToolchainServiceTest.java
@@ -1,0 +1,146 @@
+package com.shaft.mcp;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class McpMobileToolchainServiceTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void statusDiscoversAndroidDevicesCachedAvdsAndInspector() throws Exception {
+        Path toolRoot = Files.createDirectories(temp.resolve("tools"));
+        Path sdk = Files.createDirectories(temp.resolve("android-sdk"));
+        Path avdHome = Files.createDirectories(temp.resolve("avd-home"));
+        create(sdk.resolve("platform-tools"), "adb.exe");
+        create(sdk.resolve("emulator"), "emulator.exe");
+        create(sdk.resolve("cmdline-tools/latest/bin"), "sdkmanager.bat");
+        create(sdk.resolve("cmdline-tools/latest/bin"), "avdmanager.bat");
+        create(toolRoot.resolve("node/node-v24.17.0-win-x64"), "node.exe");
+        create(toolRoot.resolve("node/node-v24.17.0-win-x64"), "npm.cmd");
+        create(toolRoot.resolve("appium/node_modules/.bin"), "appium.cmd");
+        Files.createDirectories(avdHome.resolve("Cached_Pixel.avd"));
+
+        FakeRunner runner = new FakeRunner();
+        runner.adbOutput = """
+                List of devices attached
+                emulator-5554 device product:sdk_gphone64_x86_64 model:Pixel_8 device:emu64
+                R58M123 unauthorized
+                """;
+        runner.emulatorOutput = "Pixel_API_36\n";
+        runner.appiumPluginOutput = "inspector\n";
+        runner.appiumVersionOutput = "3.5.2\n";
+
+        McpMobileToolchainService service = new McpMobileToolchainService(runner,
+                Map.of("ANDROID_SDK_ROOT", sdk.toString(), "ANDROID_AVD_HOME", avdHome.toString(), "PATH", ""),
+                toolRoot, "Windows 11", "amd64");
+
+        McpMobileToolchainStatus status = service.status("Android");
+
+        assertTrue(status.adbAvailable());
+        assertTrue(status.appiumAvailable());
+        assertTrue(status.appiumInspectorAvailable());
+        assertEquals("3.5.2", status.appiumVersion());
+        assertEquals(2, status.androidDevices().size());
+        assertEquals("Pixel 8", status.androidDevices().getFirst().name());
+        assertFalse(status.androidDevices().get(1).warnings().isEmpty());
+        assertTrue(status.cachedAndroidEmulators().contains("Pixel_API_36"));
+        assertTrue(status.cachedAndroidEmulators().contains("Cached_Pixel"));
+        assertFalse(status.missingDependencies().contains("adb"));
+    }
+
+    @Test
+    void defaultAndroidProposalUsesPortableCacheAndHostAbi() {
+        Path toolRoot = temp.resolve("tools");
+        McpMobileToolchainService service = new McpMobileToolchainService(new FakeRunner(),
+                Map.of(), toolRoot, "Linux", "amd64");
+
+        McpAndroidEmulatorProposal proposal = service.defaultAndroidProposal("", 0, "", "", "", 0, 0);
+
+        assertEquals("pixel_8", proposal.deviceProfile());
+        assertEquals(36, proposal.apiLevel());
+        assertEquals("x86_64", proposal.abi());
+        assertEquals(4096, proposal.ramMb());
+        assertTrue(proposal.sdkRoot().toString().contains("android-sdk"));
+        assertTrue(proposal.sdkPackages().contains("platforms;android-36"));
+        assertTrue(proposal.commands().stream().anyMatch(command -> command.contains("sdkmanager")));
+    }
+
+    @Test
+    void ensureAppiumInstallsPinnedPackagesWithCurrentCliSyntax() throws Exception {
+        Path toolRoot = Files.createDirectories(temp.resolve("tools"));
+        create(toolRoot.resolve("node/node-v24.17.0-win-x64"), "npm.cmd");
+        create(toolRoot.resolve("appium/node_modules/.bin"), "appium.cmd");
+        FakeRunner runner = new FakeRunner();
+        McpMobileToolchainService service = new McpMobileToolchainService(runner,
+                Map.of("PATH", ""), toolRoot, "Windows 11", "amd64");
+
+        service.ensureAppium("Android");
+
+        assertTrue(runner.commands.stream().anyMatch(command -> command.contains("appium@3.5.2")));
+        assertTrue(runner.commands.stream().anyMatch(command -> command.equals(List.of(
+                toolRoot.resolve("appium/node_modules/.bin/appium.cmd").toString(),
+                "driver",
+                "install",
+                "--source=npm",
+                "appium-uiautomator2-driver@7.6.2"))));
+        assertTrue(runner.commands.stream().anyMatch(command -> command.equals(List.of(
+                toolRoot.resolve("appium/node_modules/.bin/appium.cmd").toString(),
+                "plugin",
+                "install",
+                "--source=npm",
+                "appium-inspector-plugin@2026.5.1"))));
+    }
+
+    private static void create(Path directory, String fileName) throws Exception {
+        Files.createDirectories(directory);
+        Files.writeString(directory.resolve(fileName), "");
+    }
+
+    private static final class FakeRunner implements McpProcessRunner {
+        private String adbOutput = "";
+        private String emulatorOutput = "";
+        private String appiumPluginOutput = "";
+        private String appiumVersionOutput = "";
+        private final List<List<String>> commands = new ArrayList<>();
+
+        @Override
+        public ProcessResult run(
+                List<String> command,
+                Path workingDirectory,
+                Map<String, String> environment,
+                Duration timeout) {
+            commands.add(command);
+            String joined = String.join(" ", command);
+            if (joined.contains("adb") && joined.contains("devices")) {
+                return new ProcessResult(0, adbOutput, "", false);
+            }
+            if (joined.contains("emulator") && joined.contains("-list-avds")) {
+                return new ProcessResult(0, emulatorOutput, "", false);
+            }
+            if (joined.contains("plugin") && joined.contains("list")) {
+                return new ProcessResult(0, appiumPluginOutput, "", false);
+            }
+            if (joined.contains("appium") && joined.contains("--version")) {
+                return new ProcessResult(0, appiumVersionOutput, "", false);
+            }
+            return new ProcessResult(0, "", "", false);
+        }
+
+        @Override
+        public Process start(List<String> command, Path workingDirectory, Map<String, String> environment) {
+            throw new UnsupportedOperationException("No process starts in unit tests.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add MCP tools for wrapped Appium Inspector mobile recording: toolchain status, prepare/confirm, start, status/control, and stop.
- Add user-cache Appium and Android SDK provisioning, cached AVD detection, Android emulator proposal/start/stop, and iOS attach-only planning.
- Record successful Inspector WebDriver traffic through a local proxy into the existing MCP mobile JSON/replay format, including tap/type/clear/gesture/orientation/app commands.
- Add focused tests for toolchain planning, Appium command mapping, redaction, pause handling, and plan validation.
- Refresh tracked Graphify code outputs and save Memory gotchas for Memory/Graphify CLI usage.

## Docs
- Companion docs PR: https://github.com/ShaftHQ/shafthq.github.io/pull/570

## Validation
- `mvn -pl shaft-mcp -am test-compile -DskipTests -Dallure.automaticallyOpen=false -Dallure.open=false`
- `mvn -pl shaft-mcp -am -Dtest=McpMobileToolchainServiceTest,McpAppiumCommandRecorderTest,McpMobileInspectorRecordingServiceTest test -Dallure.automaticallyOpen=false -Dallure.open=false`
- `mvn -pl shaft-mcp -am package -DskipTests -Dallure.automaticallyOpen=false -Dallure.open=false`
- `memory check`
- `graphify update .`

## Notes
- Full semantic Graphify refresh is blocked without an LLM backend key; `graphify update .` refreshed the code graph and reported that docs/paper/image semantic extraction requires `GEMINI_API_KEY` or `GOOGLE_API_KEY`.
- Graphify skipped `graph.html` in SHAFT_ENGINE because the graph has more than 5,000 nodes.