### PR TITLE
Add touch end-scroll and image invisibility actions

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java
@@ -51,9 +51,6 @@ import static java.util.Arrays.asList;
  */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class TouchActions extends FluentWebDriverAction {
-    private static final int DEFAULT_NUMBER_OF_ATTEMPTS_TO_SCROLL_TO_ELEMENT = 5;
-    private static final boolean CAPTURE_CLICKED_ELEMENT_TEXT = SHAFT.Properties.reporting.captureElementName();
-
     public TouchActions() {
         initialize();
     }
@@ -428,8 +425,33 @@ public class TouchActions extends FluentWebDriverAction {
         return swipeElementIntoView(null, targetElementLocator, swipeDirection);
     }
 
-    //TODO: swipeToEndOfView(SwipeDirection swipeDirection)
-    //TODO: waitUntilElementIsNotVisible(String elementReferenceScreenshot)
+    /**
+     * Swipes until the current view can no longer scroll in the requested direction.
+     *
+     * @param swipeDirection SwipeDirection.DOWN, UP, RIGHT, or LEFT
+     * @return a self-reference to be used to chain actions
+     */
+    public TouchActions swipeToEndOfView(SwipeDirection swipeDirection) {
+        return swipeToEndOfView(null, swipeDirection);
+    }
+
+    /**
+     * Swipes inside a scrollable element until it can no longer scroll in the requested direction.
+     *
+     * @param scrollableElementLocator the locator of the scrollable element, or {@code null} for the whole view
+     * @param swipeDirection SwipeDirection.DOWN, UP, RIGHT, or LEFT
+     * @return a self-reference to be used to chain actions
+     */
+    public TouchActions swipeToEndOfView(By scrollableElementLocator, SwipeDirection swipeDirection) {
+        try {
+            swipeToEndOfViewInternal(scrollableElementLocator, swipeDirection);
+            elementActionsHelper.passAction(driverFactoryHelper.getDriver(), scrollableElementLocator,
+                    Thread.currentThread().getStackTrace()[1].getMethodName(), null, null, null);
+        } catch (Throwable throwable) {
+            elementActionsHelper.failAction(driverFactoryHelper.getDriver(), scrollableElementLocator, throwable);
+        }
+        return this;
+    }
 
     /**
      * Waits until a specific element is now visible on the current screen
@@ -456,6 +478,38 @@ public class TouchActions extends FluentWebDriverAction {
             elementActionsHelper.passAction(driverFactoryHelper.getDriver(), null, Thread.currentThread().getStackTrace()[1].getMethodName(), null, attachments, null);
         } else {
             elementActionsHelper.failAction(driverFactoryHelper.getDriver(), "Couldn't find reference element on the current screen. If you can see it in the attached image then kindly consider cropping it and updating your reference image under this path \"" + elementReferenceScreenshot + "\".", null, attachments);
+        }
+        return this;
+    }
+
+    /**
+     * Waits until a specific reference image is no longer visible on the current screen.
+     *
+     * @param elementReferenceScreenshot relative path to the reference image from the local object repository
+     * @return a self-reference to be used to chain actions
+     */
+    @SuppressWarnings("unchecked")
+    public TouchActions waitUntilElementIsNotVisible(String elementReferenceScreenshot) {
+        var visualIdentificationObjects = elementActionsHelper.waitForElementInvisibility(driverFactoryHelper.getDriver(), elementReferenceScreenshot);
+        byte[] currentScreenImage = (byte[]) visualIdentificationObjects.get(0);
+        byte[] referenceImage = (byte[]) visualIdentificationObjects.get(1);
+        List<Integer> coordinates = (List<Integer>) visualIdentificationObjects.get(2);
+
+        var screenshotManager = new ScreenshotManager();
+        var screenshot = screenshotManager.prepareImageForReport(currentScreenImage, "waitUntilElementIsNotVisible - Current Screen Image");
+        var referenceScreenshot = screenshotManager.prepareImageForReport(referenceImage, "waitUntilElementIsNotVisible - Reference Screenshot");
+        List<List<Object>> attachments = new LinkedList<>();
+        attachments.add(referenceScreenshot);
+        attachments.add(screenshot);
+
+        if (Collections.emptyList().equals(coordinates)) {
+            elementActionsHelper.passAction(driverFactoryHelper.getDriver(), null,
+                    Thread.currentThread().getStackTrace()[1].getMethodName(), null, attachments, null);
+        } else {
+            elementActionsHelper.failAction(driverFactoryHelper.getDriver(),
+                    "Reference element is still visible on the current screen or the reference image is missing: \""
+                            + elementReferenceScreenshot + "\".",
+                    null, attachments);
         }
         return this;
     }
@@ -643,20 +697,10 @@ public class TouchActions extends FluentWebDriverAction {
             // element is already on screen
             ReportManager.logDiscrete("Element found on screen.");
         } else {
-            attemptW3cCompliantActionsScroll(swipeDirection, scrollableElementLocator, null);
+            swipeToEndOfViewInternal(scrollableElementLocator, swipeDirection);
+            visualIdentificationObjects = elementActionsHelper.waitForElementPresence(driverFactoryHelper.getDriver(), targetElementImage);
         }
         return visualIdentificationObjects;
-    }
-
-    private void attemptUISelectorScroll(SwipeDirection swipeDirection, int scrollableElementInstanceNumber) {
-        ReportManager.logDiscrete("Swiping to find Element using UiSelector.");
-        int scrollingSpeed = 100;
-        String scrollDirection = "Forward";
-        ReportManager.logDiscrete("Swiping to find Element using UiSelector.");
-        By androidUIAutomator = AppiumBy
-                .androidUIAutomator("new UiScrollable(new UiSelector().scrollable(true).instance("
-                        + scrollableElementInstanceNumber + ")).scroll" + scrollDirection + "(" + scrollingSpeed + ")");
-        elementActionsHelper.getElementsCount(driverFactoryHelper.getDriver(), androidUIAutomator);
     }
 
     private HashMap<Object, Object> prepareParameters(SwipeDirection swipeDirection, By scrollableElementLocator, By targetElementLocator) {
@@ -720,6 +764,19 @@ public class TouchActions extends FluentWebDriverAction {
             canScrollMore = ret == null || (Boolean) ret;
         }
         return canScrollMore;
+    }
+
+    private void swipeToEndOfViewInternal(By scrollableElementLocator, SwipeDirection swipeDirection) {
+        if (!(driverFactoryHelper.getDriver() instanceof AppiumDriver)) {
+            throw new UnsupportedCommandException("swipeToEndOfView is supported only for Appium drivers.");
+        }
+        var scrollParameters = prepareParameters(swipeDirection, scrollableElementLocator, null);
+        AtomicBoolean canScrollMore = new AtomicBoolean(true);
+        new SynchronizationManager(driverFactoryHelper.getDriver()).fluentWait().until(f -> {
+            elementActionsHelper.takeScreenshot(driverFactoryHelper.getDriver(), null, "swipeToEndOfView", null, true);
+            canScrollMore.set(performW3cCompliantScroll(scrollParameters));
+            return !canScrollMore.get();
+        });
     }
 
     private boolean attemptW3cCompliantActionsScroll(SwipeDirection swipeDirection, By scrollableElementLocator, By targetElementLocator) {

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java
@@ -175,6 +175,47 @@ public class ElementActionsHelper {
         return returnedValue;
     }
 
+    /**
+     * Waits for an on-screen image reference to disappear from the current viewport.
+     *
+     * @param driver the active WebDriver instance
+     * @param elementReferenceScreenshot path to the reference image file
+     * @return list containing current screenshot, reference screenshot bytes, and matched coordinates
+     */
+    public List<Object> waitForElementInvisibility(WebDriver driver, String elementReferenceScreenshot) {
+        long startTime = System.currentTimeMillis();
+        long elapsedTime;
+        List<Integer> coordinates = Collections.emptyList();
+        byte[] currentScreenImage;
+
+        List<Object> returnedValue = new LinkedList<>();
+        if (FileActions.getInstance(true).doesFileExist(elementReferenceScreenshot)) {
+            do {
+                try {
+                    //noinspection BusyWait
+                    Thread.sleep(ELEMENT_IDENTIFICATION_POLLING_DELAY);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    ReportManagerHelper.logDiscrete(e);
+                }
+                currentScreenImage = new ScreenshotManager().takeScreenshot(driver, null);
+                coordinates = ImageProcessingActions.findImageWithinCurrentPage(elementReferenceScreenshot, currentScreenImage);
+                elapsedTime = System.currentTimeMillis() - startTime;
+            } while (!Collections.emptyList().equals(coordinates)
+                    && elapsedTime < SHAFT.Properties.timeouts.defaultElementIdentificationTimeout() * 1000L);
+            returnedValue.add(currentScreenImage);
+            returnedValue.add(FileActions.getInstance(true).readFileAsByteArray(elementReferenceScreenshot));
+            returnedValue.add(coordinates);
+        } else {
+            ReportManager.log("Reference screenshot not found. Kindly confirm the image exists under this path: \"" + elementReferenceScreenshot + "\"");
+            currentScreenImage = new ScreenshotManager().takeScreenshot(driver, null);
+            returnedValue.add(currentScreenImage);
+            returnedValue.add(new byte[0]);
+            returnedValue.add(List.of(-1));
+        }
+        return returnedValue;
+    }
+
     private boolean isValidToCheckForVisibility(By elementLocator, boolean checkForVisibility) {
         var locatorString = JavaHelper.formatLocatorToString(elementLocator).toLowerCase();
         return checkForVisibility && !locatorString.contains("type='file'") && !locatorString.contains("type=\"file\"") && !locatorString.contains("frame") && !elementLocator.equals(By.tagName("html"));

--- a/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
@@ -210,16 +210,17 @@ public class AndroidTouchActionsCoverageUnitTest {
         byte[] validPng = getValidPngBytes();
 
         AndroidDriver androidDriver = createMockAndroidDriver();
-        when(androidDriver.findElements(isNull())).thenReturn(List.of(mock(WebElement.class)));
+        doReturn(true).doReturn(false).when(androidDriver).executeScript(eq("mobile: scrollGesture"), anyMap());
         TouchActions nativeTouchActions = new TouchActions(androidDriver);
         ElementActionsHelper nativeElementActionsHelper = mock(ElementActionsHelper.class);
         when(nativeElementActionsHelper.waitForElementPresence(androidDriver, "native-missing.png"))
-                .thenReturn(List.of(validPng, validPng, List.of()));
+                .thenReturn(List.of(validPng, validPng, List.of()))
+                .thenReturn(List.of(validPng, validPng, List.of(30, 40)));
         when(nativeElementActionsHelper.takeScreenshot(any(), any(), anyString(), any(), eq(true))).thenReturn(List.of());
         injectElementActionsHelper(nativeTouchActions, nativeElementActionsHelper);
 
         nativeTouchActions.swipeElementIntoView(null, "native-missing.png", TouchActions.SwipeDirection.DOWN);
-        verify(nativeElementActionsHelper).failAction(eq(androidDriver), anyString(), isNull(By.class), any(List.class));
+        verify(nativeElementActionsHelper, never()).failAction(eq(androidDriver), anyString(), isNull(By.class), any(List.class));
 
         RemoteWebDriver webDriver = createMockRemoteWebDriver();
         TouchActions webTouchActions = new TouchActions(webDriver);
@@ -330,12 +331,18 @@ public class AndroidTouchActionsCoverageUnitTest {
                 .thenReturn(List.of(validPng, validPng, List.of(120, 240)));
         when(elementActionsHelper.waitForElementPresence(driver, "missing.png"))
                 .thenReturn(List.of(validPng, validPng, List.of()));
+        when(elementActionsHelper.waitForElementInvisibility(driver, "not-visible.png"))
+                .thenReturn(List.of(validPng, validPng, List.of()));
+        when(elementActionsHelper.waitForElementInvisibility(driver, "still-visible.png"))
+                .thenReturn(List.of(validPng, validPng, List.of(120, 240)));
         injectElementActionsHelper(touchActions, elementActionsHelper);
 
         touchActions.tap("present.png")
                 .waitUntilElementIsVisible("present.png")
+                .waitUntilElementIsNotVisible("not-visible.png")
                 .tap("missing.png")
-                .waitUntilElementIsVisible("missing.png");
+                .waitUntilElementIsVisible("missing.png")
+                .waitUntilElementIsNotVisible("still-visible.png");
 
         verify(driver).perform(any());
     }
@@ -425,10 +432,6 @@ public class AndroidTouchActionsCoverageUnitTest {
         Map<Object, Object> elementScrollParameters = (Map<Object, Object>) prepareParameters.invoke(touchActions, TouchActions.SwipeDirection.RIGHT, By.id("container"), By.id("target"));
         SHAFT.Validations.assertThat().object(elementScrollParameters.containsKey("width")).isTrue().perform();
 
-        Method attemptUISelectorScroll = TouchActions.class.getDeclaredMethod("attemptUISelectorScroll", TouchActions.SwipeDirection.class, int.class);
-        attemptUISelectorScroll.setAccessible(true);
-        attemptUISelectorScroll.invoke(touchActions, TouchActions.SwipeDirection.DOWN, 0);
-
         Method attemptW3cCompliantActionsScroll = TouchActions.class.getDeclaredMethod("attemptW3cCompliantActionsScroll", TouchActions.SwipeDirection.class, By.class, By.class);
         attemptW3cCompliantActionsScroll.setAccessible(true);
         Object isFound = attemptW3cCompliantActionsScroll.invoke(touchActions, TouchActions.SwipeDirection.DOWN, null, By.id("target"));
@@ -439,6 +442,27 @@ public class AndroidTouchActionsCoverageUnitTest {
         executeWrapperForCoverage(() -> touchActions.longTap(By.id("target")));
         executeWrapperForCoverage(() -> touchActions.swipeToElement(By.id("source"), By.id("target")));
         executeWrapperForCoverage(() -> touchActions.swipeByOffset(By.id("target"), 10, 10));
+    }
+
+    @Test
+    public void swipeToEndOfViewShouldScrollUntilAppiumReportsEnd() throws Exception {
+        AndroidDriver driver = createMockAndroidDriver();
+        doReturn(true).doReturn(false).when(driver).executeScript(eq("mobile: scrollGesture"), anyMap());
+
+        TouchActions touchActions = new TouchActions(driver);
+        ElementActionsHelper elementActionsHelper = mock(ElementActionsHelper.class);
+        when(elementActionsHelper.takeScreenshot(any(), any(), anyString(), any(), eq(true))).thenReturn(List.of());
+        WebElement scrollableElement = mock(WebElement.class);
+        when(scrollableElement.getRect()).thenReturn(new org.openqa.selenium.Rectangle(10, 20, 300, 500));
+        when(elementActionsHelper.identifyUniqueElement(any(), eq(By.id("container"))))
+                .thenReturn(List.of("container", scrollableElement));
+        injectElementActionsHelper(touchActions, elementActionsHelper);
+
+        touchActions.swipeToEndOfView(TouchActions.SwipeDirection.DOWN)
+                .swipeToEndOfView(By.id("container"), TouchActions.SwipeDirection.UP);
+
+        verify(driver, times(3)).executeScript(eq("mobile: scrollGesture"), anyMap());
+        verify(driver, never()).findElements(isNull());
     }
 
     private AndroidDriver createMockAndroidDriver() {


### PR DESCRIPTION
## Summary
- add Appium-backed `swipeToEndOfView(...)` overloads for whole-view and container scrolling
- add image-reference invisibility waiting/reporting support
- cover the new touch flows and native image re-check path in `AndroidTouchActionsCoverageUnitTest`

## Validation
- `mvn -pl shaft-engine '-DskipTests' '-Dgpg.skip=true' test-compile`
- `mvn -pl shaft-engine '-Dtest=AndroidTouchActionsCoverageUnitTest' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' '-DheadlessExecution=true' '-Dgpg.skip=true' test`

## Notes
- Graphify refresh intentionally skipped per branch-conflict instruction.