### PR TITLE
Add natural action planner coverage

### DIFF
--- a/shaft-engine/src/test/java/com/shaft/gui/internal/natural/DeterministicNaturalActionPlannerTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/natural/DeterministicNaturalActionPlannerTest.java
@@ -1,0 +1,77 @@
+package com.shaft.gui.internal.natural;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.pagefactory.ByAll;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+
+public class DeterministicNaturalActionPlannerTest {
+    private final DeterministicNaturalActionPlanner planner = new DeterministicNaturalActionPlanner();
+
+    @Test
+    public void blankIntentShouldReturnUnsupportedPlan() {
+        NaturalActionPlan plan = planner.plan(request("   "));
+
+        Assert.assertEquals(plan.plannerId(), "deterministic");
+        Assert.assertTrue(plan.steps().isEmpty());
+        Assert.assertEquals(plan.trust(), 0.0);
+        Assert.assertTrue(plan.explanation().contains("blank"));
+    }
+
+    @Test
+    public void browserNavigationShouldUseSuppliedUrlArgument() {
+        NaturalActionPlan plan = planner.plan(request("open the application", "https://example.test"));
+
+        Assert.assertEquals(plan.steps().size(), 1);
+        Assert.assertEquals(plan.steps().getFirst().kind(), NaturalActionKind.BROWSER_NAVIGATE);
+        Assert.assertEquals(plan.steps().getFirst().data(), "https://example.test");
+        Assert.assertTrue(plan.trust() > 0.8);
+    }
+
+    @Test
+    public void loginIntentShouldProduceUsernamePasswordAndSubmitSteps() {
+        NaturalActionPlan plan = planner.plan(request("Log in", "user@example.test", "secret"));
+
+        Assert.assertEquals(plan.steps().size(), 3);
+        Assert.assertEquals(plan.steps().get(0).kind(), NaturalActionKind.ELEMENT_TYPE);
+        Assert.assertEquals(plan.steps().get(1).kind(), NaturalActionKind.ELEMENT_TYPE_SECURELY);
+        Assert.assertEquals(plan.steps().get(2).kind(), NaturalActionKind.ELEMENT_CLICK);
+        Assert.assertTrue(plan.steps().get(0).locator() instanceof ByAll);
+        Assert.assertEquals(plan.steps().get(1).data(), "secret");
+    }
+
+    @Test
+    public void elementAndTouchIntentsShouldResolveSemanticLocators() {
+        Assert.assertEquals(
+                planner.plan(request("click Submit")).steps().getFirst().kind(),
+                NaturalActionKind.ELEMENT_CLICK);
+        Assert.assertEquals(
+                planner.plan(request("type into Email", "user@example.test")).steps().getFirst().kind(),
+                NaturalActionKind.ELEMENT_TYPE);
+        Assert.assertEquals(
+                planner.plan(request("enter Password", "secret")).steps().getFirst().kind(),
+                NaturalActionKind.ELEMENT_TYPE);
+        Assert.assertEquals(
+                planner.plan(request("clear Search")).steps().getFirst().kind(),
+                NaturalActionKind.ELEMENT_CLEAR);
+        Assert.assertEquals(
+                planner.plan(request("tap Continue")).steps().getFirst().kind(),
+                NaturalActionKind.TOUCH_TAP);
+    }
+
+    @Test
+    public void missingRequiredArgumentsShouldKeepPlansUnsupported() {
+        Assert.assertTrue(planner.plan(request("login")).steps().isEmpty());
+        Assert.assertTrue(planner.plan(request("open settings")).steps().isEmpty());
+        Assert.assertTrue(planner.plan(request("type into Email")).steps().isEmpty());
+        Assert.assertTrue(planner.plan(request("unknown intent")).steps().isEmpty());
+    }
+
+    private NaturalActionRequest request(String intent, Object... args) {
+        return new NaturalActionRequest(mock(WebDriver.class), intent, List.of(args), false, false);
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/natural/NaturalActionExecutorTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/natural/NaturalActionExecutorTest.java
@@ -115,6 +115,59 @@ public class NaturalActionExecutorTest {
         verify(button, never()).click();
     }
 
+    @Test
+    public void disallowedTargetShouldRejectPlanBeforeBrowserExecution() {
+        SHAFT.Properties.naturalActions.set()
+                .enabled(true)
+                .minimumTrustPercentage(85)
+                .allowedActions("element,touch");
+        DriverFactoryHelper helper = mock(DriverFactoryHelper.class);
+        WebDriver driver = driver();
+        when(helper.getDriver()).thenReturn(driver);
+
+        RuntimeException exception = Assert.expectThrows(
+                RuntimeException.class,
+                () -> NaturalActionExecutor.perform(helper, "refresh page"));
+
+        Assert.assertTrue(exception.getMessage().contains("below the configured threshold"));
+        verify(driver, never()).navigate();
+    }
+
+    @Test
+    public void rejectedIntentShouldRedactSecretsFromFailureMessage() {
+        SHAFT.Properties.naturalActions.set().enabled(true).minimumTrustPercentage(85);
+        DriverFactoryHelper helper = mock(DriverFactoryHelper.class);
+        WebDriver driver = driver();
+        when(helper.getDriver()).thenReturn(driver);
+        when(driver.findElements(any(By.class))).thenReturn(List.of());
+
+        RuntimeException exception = Assert.expectThrows(
+                RuntimeException.class,
+                () -> NaturalActionExecutor.perform(
+                        helper,
+                        "click Login password=hunter2 token=abcdefghijklmnopqrstuvwxyz123456"));
+
+        Assert.assertTrue(exception.getMessage().contains("password=[REDACTED]"));
+        Assert.assertTrue(exception.getMessage().contains("token=[REDACTED]"));
+        Assert.assertFalse(exception.getMessage().contains("hunter2"));
+        Assert.assertFalse(exception.getMessage().contains("abcdefghijklmnopqrstuvwxyz123456"));
+    }
+
+    @Test
+    public void unavailableConfiguredPlannerShouldReturnUnsupportedPlan() {
+        SHAFT.Properties.naturalActions.set().planner("missing-provider");
+        NaturalActionPlan plan = NaturalActionPlannerRegistry.plan(new NaturalActionRequest(
+                mock(WebDriver.class),
+                "refresh page",
+                List.of(),
+                false,
+                false));
+
+        Assert.assertEquals(plan.plannerId(), "missing-provider");
+        Assert.assertTrue(plan.steps().isEmpty());
+        Assert.assertTrue(plan.explanation().contains("unavailable"));
+    }
+
     private WebDriver driver() {
         WebDriver driver = mock(WebDriver.class,
                 org.mockito.Mockito.withSettings().extraInterfaces(JavascriptExecutor.class));


### PR DESCRIPTION
## Summary
- add deterministic natural-action planner unit coverage for browser, element, touch, login, and unsupported intents
- cover unavailable planner selection, disallowed action targets, and secret redaction on rejected natural actions

## Validation
- `mvn -pl shaft-engine '-DskipTests' '-Dgpg.skip=true' test-compile`
- `mvn -pl shaft-engine '-Dtest=NaturalActionExecutorTest,DeterministicNaturalActionPlannerTest,NaturalActionsTests' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' '-DheadlessExecution=true' '-Dgpg.skip=true' test`

## Notes
- Graphify refresh intentionally skipped per branch-conflict instruction.