### PR TITLE
Fix E2E API and checkout tests

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/api/RestActions.java
+++ b/shaft-engine/src/main/java/com/shaft/api/RestActions.java
@@ -1245,9 +1245,14 @@ public class RestActions {
 
         builder.setUrlEncodingEnabled(urlEncodingEnabled);
 
+        boolean hasParameters = paramsList != null && !paramsList.isEmpty() && !String.valueOf(paramsList.getFirst().getFirst()).isEmpty();
+        if (hasParameters && parametersType == ParametersType.QUERY) {
+            prepareRequestBody(builder, paramsList, parametersType);
+        }
+
         if (body != null && contentType != null && !body.toString().isEmpty()) {
             prepareRequestBody(builder, body, contentType);
-        } else if (paramsList != null && !paramsList.isEmpty() && !String.valueOf(paramsList.getFirst().getFirst()).isEmpty()) {
+        } else if (hasParameters && parametersType != ParametersType.QUERY) {
             boolean containsFile = paramsList.stream().anyMatch(p -> p.get(1) instanceof File);
             boolean useMultipart = (parametersType == ParametersType.MULTIPART) || containsFile;
 

--- a/shaft-engine/src/test/java/testPackage/locator/SmartLocatorsRealisticTests.java
+++ b/shaft-engine/src/test/java/testPackage/locator/SmartLocatorsRealisticTests.java
@@ -14,6 +14,7 @@ public class SmartLocatorsRealisticTests extends TestScenario {
                     "/ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' shop-item ')][1]" +
                     "//button[contains(concat(' ', normalize-space(@class), ' '), ' shop-item-button ')])[1]");
     private static final By CART_TOTAL_PRICE = By.cssSelector(".cart-total-price");
+    private static final By PROCEED_TO_CHECKOUT_BUTTON = By.cssSelector(".btn-purchase");
 
     // Realistic test scenario for an e-commerce website
     // Fluent design, mixing regular locators with smart locators, performing assertions, reporting.
@@ -39,7 +40,7 @@ public class SmartLocatorsRealisticTests extends TestScenario {
 
     @Test(dependsOnMethods = {"login", "addProductToCart"})
     public void proceedToCheckout() {
-        driver.element().click("PROCEED TO CHECKOUT")
+        driver.element().click(PROCEED_TO_CHECKOUT_BUTTON)
                 .and().assertThat(By.cssSelector("#shipping-address>h2")).text().isEqualTo("Shipping Details");
     }
 


### PR DESCRIPTION
## Summary
- Preserve `ParametersType.QUERY` parameters when a request body is also configured.
- Use the live checkout page's stable purchase button selector in `SmartLocatorsRealisticTests`.
- Docs: https://github.com/ShaftHQ/shafthq.github.io/pull/575

## CI Root Cause
- `Ubuntu_APIs` broke in `BasicAPITests.apiTest2` and `BasicAPITests.apiTest3` because the request body path lookup expected `args.FirstName`, but query parameters were skipped whenever a body was present.
- `Ubuntu_Chrome_Grid` broke in `SmartLocatorsRealisticTests.proceedToCheckout` because the smart locator did not resolve the `PROCEED TO CHECKOUT` button on the live ecommerce page.

## Validation
- `mvn -pl shaft-engine -am -e test '-DdefaultElementIdentificationTimeout=5' '-DretryMaximumNumberOfAttempts=1' '-DgenerateAllureReportArchive=true' '-Dtest=BasicAPITests' '-Dgpg.skip=true'`
- Allure JSON check after `BasicAPITests`: 10 result files, 10 passed.
- `mvn -pl shaft-engine -am -e test-compile '-Dgpg.skip=true'`
- `mvn -pl shaft-engine -am -e test '-DincludeVisualTestRuntime' '-DdefaultElementIdentificationTimeout=5' '-DretryMaximumNumberOfAttempts=1' '-DexecutionAddress=local' '-DtargetOperatingSystem=WINDOWS' '-DtargetBrowserName=chrome' '-DheadlessExecution=true' '-DgenerateAllureReportArchive=true' '-Dtest=SmartLocatorsRealisticTests' '-Dgpg.skip=true'`
- Allure JSON check after `SmartLocatorsRealisticTests`: 4 result files, 4 passed.
- `py -3 scripts\ci\validate_agent_setup.py`

## Notes
- `graphify . --update --no-viz` is blocked locally because no `GEMINI_API_KEY` or `GOOGLE_API_KEY` is configured for semantic extraction.
