### PR TITLE
[codex] release 10.2.20260621

### DIFF
--- a/legacy-shaft-engine/pom.xml
+++ b/legacy-shaft-engine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260620</version>
+        <version>10.2.20260621</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>SHAFT_ENGINE</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.shafthq</groupId>
     <artifactId>shaft-parent</artifactId>
-    <version>10.2.20260620</version>
+    <version>10.2.20260621</version>
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Build parent and reactor aggregator for SHAFT modules.</description>

--- a/report-aggregate/pom.xml
+++ b/report-aggregate/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260620</version>
+        <version>10.2.20260621</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>report-aggregate</artifactId>

--- a/shaft-ai/pom.xml
+++ b/shaft-ai/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260620</version>
+        <version>10.2.20260621</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shaft-bom/pom.xml
+++ b/shaft-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260620</version>
+        <version>10.2.20260621</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>shaft-bom</artifactId>

--- a/shaft-browserstack/pom.xml
+++ b/shaft-browserstack/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260620</version>
+        <version>10.2.20260621</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>shaft-browserstack</artifactId>

--- a/shaft-capture/pom.xml
+++ b/shaft-capture/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260620</version>
+        <version>10.2.20260621</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shaft-doctor/pom.xml
+++ b/shaft-doctor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260620</version>
+        <version>10.2.20260621</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shaft-engine/pom.xml
+++ b/shaft-engine/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260620</version>
+        <version>10.2.20260621</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>shaft-engine</artifactId>

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java
@@ -18,7 +18,7 @@ import org.aeonbits.owner.Config.Sources;
 })
 public interface Internal extends EngineProperties<Internal> {
     @Key("shaftEngineVersion")
-    @DefaultValue("10.2.20260620")
+    @DefaultValue("10.2.20260621")
     String shaftEngineVersion();
 
     @Key("watermarkImagePath")

--- a/shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260620</shaft.version>
+        <shaft.version>10.2.20260621</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260620</shaft.version>
+        <shaft.version>10.2.20260621</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260620</shaft.version>
+        <shaft.version>10.2.20260621</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260620</shaft.version>
+        <shaft.version>10.2.20260621</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260620</shaft.version>
+        <shaft.version>10.2.20260621</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260620</shaft.version>
+        <shaft.version>10.2.20260621</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <!-- Make sure you point to the latest release version: https://github.com/ShaftHQ/SHAFT_ENGINE/releases -->
-        <shaft.version>10.2.20260620</shaft.version>
+        <shaft.version>10.2.20260621</shaft.version>
         <jdk.version>25</jdk.version>
         <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/shaft-heal/pom.xml
+++ b/shaft-heal/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260620</version>
+        <version>10.2.20260621</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shaft-mcp/pom.xml
+++ b/shaft-mcp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260620</version>
+        <version>10.2.20260621</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shaft-pilot-core/pom.xml
+++ b/shaft-pilot-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260620</version>
+        <version>10.2.20260621</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shaft-video/pom.xml
+++ b/shaft-video/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260620</version>
+        <version>10.2.20260621</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>shaft-video</artifactId>

--- a/shaft-visual/pom.xml
+++ b/shaft-visual/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.shafthq</groupId>
         <artifactId>shaft-parent</artifactId>
-        <version>10.2.20260620</version>
+        <version>10.2.20260621</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>shaft-visual</artifactId>

--- a/tools/modularization/consumer-fixtures/api/pom.xml
+++ b/tools/modularization/consumer-fixtures/api/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260620</shaft.version>
+        <shaft.version>10.2.20260621</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/appium-mobile/pom.xml
+++ b/tools/modularization/consumer-fixtures/appium-mobile/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260620</shaft.version>
+        <shaft.version>10.2.20260621</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/bom/pom.xml
+++ b/tools/modularization/consumer-fixtures/bom/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260620</shaft.version>
+        <shaft.version>10.2.20260621</shaft.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/tools/modularization/consumer-fixtures/browserstack-sdk/pom.xml
+++ b/tools/modularization/consumer-fixtures/browserstack-sdk/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260620</shaft.version>
+        <shaft.version>10.2.20260621</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/combined-modules/pom.xml
+++ b/tools/modularization/consumer-fixtures/combined-modules/pom.xml
@@ -10,7 +10,7 @@
     <description>Validates the published BOM and all optional modules as one consumer graph.</description>
 
     <properties>
-        <shaft.version>10.2.20260620</shaft.version>
+        <shaft.version>10.2.20260621</shaft.version>
     </properties>
 
     <dependencyManagement>

--- a/tools/modularization/consumer-fixtures/desktop-video/pom.xml
+++ b/tools/modularization/consumer-fixtures/desktop-video/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260620</shaft.version>
+        <shaft.version>10.2.20260621</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/junit-web/pom.xml
+++ b/tools/modularization/consumer-fixtures/junit-web/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260620</shaft.version>
+        <shaft.version>10.2.20260621</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/legacy-coordinate/pom.xml
+++ b/tools/modularization/consumer-fixtures/legacy-coordinate/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260620</shaft.version>
+        <shaft.version>10.2.20260621</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/mcp/pom.xml
+++ b/tools/modularization/consumer-fixtures/mcp/pom.xml
@@ -9,7 +9,7 @@
     <description>Resolves the shaft-mcp executable coordinate through the SHAFT BOM.</description>
 
     <properties>
-        <shaft.version>10.2.20260620</shaft.version>
+        <shaft.version>10.2.20260621</shaft.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/tools/modularization/consumer-fixtures/opencv-visual/pom.xml
+++ b/tools/modularization/consumer-fixtures/opencv-visual/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260620</shaft.version>
+        <shaft.version>10.2.20260621</shaft.version>
     </properties>
     <dependencies>
         <dependency>

--- a/tools/modularization/consumer-fixtures/pilot-core/pom.xml
+++ b/tools/modularization/consumer-fixtures/pilot-core/pom.xml
@@ -9,7 +9,7 @@
     <description>Compiles against Pilot contracts without the optional direct-provider module.</description>
 
     <properties>
-        <shaft.version>10.2.20260620</shaft.version>
+        <shaft.version>10.2.20260621</shaft.version>
         <maven.compiler.release>25</maven.compiler.release>
     </properties>
 

--- a/tools/modularization/consumer-fixtures/testng-web/pom.xml
+++ b/tools/modularization/consumer-fixtures/testng-web/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shaft.version>10.2.20260620</shaft.version>
+        <shaft.version>10.2.20260621</shaft.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
## Changed
- Bumped the SHAFT release version from `10.2.20260620` to `10.2.20260621` for the June 21, 2026 release.
- Updated reactor module parent versions, example/consumer fixture `<shaft.version>` values, and `Internal.shaftEngineVersion`.
- Refreshed root graphify outputs after the core/release metadata change.

## Why
- Prepares the daily Maven release coordinate using the repository release format `{major}.{quarter}.{YYYYMMDD}`.
- Keeps release metadata aligned before the Maven Central workflow publishes from `main`.

## Validation
- `py -3 scripts/ci/validate_agent_setup.py`
- `python scripts/ci/validate_reactor_versions.py`
- `python scripts/ci/check_maven_release_version.py`
- `python scripts/ci/validate_maven_publication.py`
- `python scripts/ci/validate_shaft_pilot_release.py`
- `python scripts/ci/validate_modular_documentation.py`
- `python scripts/ci/validate_documentation_boundaries.py`
- `python scripts/ci/validate_shaft_mcp_configuration.py`
- `mvn -pl shaft-engine,shaft-pilot-core,shaft-capture,shaft-doctor,shaft-ai,shaft-heal,shaft-browserstack,shaft-video,shaft-visual,shaft-mcp -am versions:display-dependency-updates '-Dgpg.skip=true'`
- `mvn -pl shaft-engine,shaft-pilot-core,shaft-capture,shaft-doctor,shaft-ai,shaft-heal,shaft-browserstack,shaft-video,shaft-visual,shaft-mcp -am versions:display-plugin-updates '-Dgpg.skip=true'`
- `mvn -pl shaft-engine,shaft-pilot-core,shaft-capture,shaft-doctor,shaft-ai,shaft-heal,shaft-browserstack,shaft-video,shaft-visual,shaft-mcp -am versions:display-property-updates '-Dgpg.skip=true'`
- `mvn --batch-mode package '-DskipTests' '-Dgpg.skip=true'`
- `python scripts/ci/validate_maven_publication.py --check-build-outputs`
- `python scripts/ci/validate_shaft_pilot_release.py --check-build-outputs`
- `mvn --batch-mode install '-DskipTests' '-Dgpg.skip=true'`
- `mvn --batch-mode -pl shaft-mcp dependency:copy-dependencies '-DincludeScope=runtime' '-DoutputDirectory=${maven.multiModuleProjectDirectory}/shaft-mcp/target/dependency' '-DskipTests' '-Dgpg.skip=true'`
- `python scripts/ci/validate_shaft_mcp_transports.py`
- `mvn --batch-mode -f tools/modularization/consumer-fixtures/api/pom.xml test-compile '-Dshaft.version=10.2.20260621' '-Dgpg.skip=true'`
- `mvn --batch-mode -f tools/modularization/consumer-fixtures/combined-modules/pom.xml verify '-Dshaft.version=10.2.20260621' '-Dgpg.skip=true'`
- `mvn --batch-mode -f tools/modularization/consumer-fixtures/legacy-coordinate/pom.xml test-compile '-Dshaft.version=10.2.20260621' '-Dgpg.skip=true'`
- `mvn --batch-mode -f tools/modularization/consumer-fixtures/pilot-core/pom.xml verify '-Dshaft.version=10.2.20260621' '-Dgpg.skip=true'`
- `mvn --batch-mode -f tools/modularization/consumer-fixtures/mcp/pom.xml verify '-Dshaft.version=10.2.20260621' '-Dgpg.skip=true'`
- `graphify update .`
- `git diff --check`

## Source Checks
- npm registry `allure` latest dist-tag is `3.12.0`: https://registry.npmjs.org/allure/latest
- Node.js Latest LTS is `v24.17.0`: https://nodejs.org/en/download

## Notes
- Maven Central preflight reports `io.github.shafthq:shaft-parent:10.2.20260621` is available.
- Dependency/plugin/property scans were run; stable dependency candidates were not applied to keep this PR release-date scoped pending compatibility review.
- `graphify update .` completed and skipped `graph.html` because the graph has 13,259 nodes, above the default 5,000-node HTML limit.
- No local deploy, publish, or GitHub release command was run. Local `install` was used only to smoke consumer fixtures before publication.
