### PR TITLE
[codex] clarify engine contributor onboarding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,88 +1,161 @@
-Contribution is easy!
+# Contributing To SHAFT Engine
 
-Just join our Slack channel linked in the readme.md, tell us your idea, and we'll help you implement it yourself.
-The more you contribute, the more you'll get the hang of how things are done.
+This repository contains the Java 25 Maven reactor for SHAFT Engine. The public
+user guide lives in
+[ShaftHQ/shafthq.github.io](https://github.com/ShaftHQ/shafthq.github.io).
 
-## Requirements
+## 1. Check Out The Code
 
-For fixes, provide focused evidence that reproduces the problem and proves the
-result on the affected path. Add tests for behavior changes and JavaDocs for
-new public APIs.
-
-Nothing fancy... Just keep it clear and simple.
-
-## Code Quality Standards
-
-### JavaDocs
-- Every `public` class and method **must** have a JavaDoc comment.
-- Include `@param`, `@return`, and `@throws` tags where applicable.
-- Add `@see` links to related classes and the [SHAFT User Guide](https://shaftengine.netlify.app/docs/start/overview) where appropriate.
-- Use `{@code ...}` for inline code references and `{@link ...}` for type references.
-- Validate JavaDoc output locally with `mvn -pl shaft-engine javadoc:javadoc` before opening a PR when JavaDocs were changed.
-
-### Logging
-- Use Log4j (`LogManager.getLogger(ClassName.class)`) or SHAFT's `ReportManager` for all logging.
-- **Never** use `System.out.println` or `System.err.println` in production code.
-- Use `ReportManager.log()` for user-visible report steps and `ReportManager.logDiscrete()` for diagnostic messages.
-
-### Testing
-- All tests should use SHAFT's fluent assertion API (`driver.assertThat()`, `Validations.assertThat()`).
-- Use `@BeforeMethod` / `@AfterMethod(alwaysRun = true)` for driver lifecycle.
-- Follow the naming convention: `[Feature]Tests` for classes, `shouldExpectedBehaviorWhenCondition` for methods.
-- Store test data in JSON files under `shaft-engine/src/test/resources/testDataFiles/`.
-
-### Complexity
-- Keep methods short and focused (ideally under 30 lines).
-- Prefer extracting helper methods over deep nesting.
-- Use meaningful, descriptive names for variables and methods.
-- Prefer direct boolean expressions over multi-branch temporary flags when readability is improved.
-
-## Validation By Risk
-
-- **Documentation or agent guidance:** run the relevant deterministic validator
-  plus `python3 scripts/ci/validate_documentation_boundaries.py`
-  (`py -3 ...` on Windows) and
-  `git diff --check`; no Maven build is needed.
-- **Localized code:** run the affected tests, then compile/package once before
-  finalizing the change.
-- **Shared API, concurrency, build, or release changes:** run targeted tests,
-  relevant module checks, and the full compile/package command.
-- **Visual behavior:** include image or browser evidence. Console output and
-  test reports are sufficient for non-visual changes.
-- **External/cloud E2E:** run only when the required infrastructure is
-  available and the result is necessary to prove the change.
-
-Keep simplifications local, clear `ThreadLocal` state at lifecycle boundaries,
-and preserve readable non-interactive logging.
-
-## Documentation
-
-The Docusaurus site is the canonical location for product, usage,
-architecture, migration, and maintainer documentation. Do not add public
-guides, module READMEs, or a local `docs/` tree to this repository.
-
-When a change affects users:
-
-1. Update [ShaftHQ/shafthq.github.io](https://github.com/ShaftHQ/shafthq.github.io).
-2. Verify the documentation deploy preview and its affected canonical routes.
-3. Link the documentation pull request in the engine pull request.
-4. Merge and deploy the documentation first. Confirm the production routes
-   return HTTP 200 before merging dependent engine documentation cleanup.
-5. If documentation is not required, provide a concrete reason in the pull
-   request template.
-
-Operational Markdown remains allowed for agent instructions, governance,
-GitHub templates, skills, and test fixtures.
-
-## Build & Test
+Fork the repository if you are not a maintainer. Then clone your fork:
 
 ```bash
-# Build without tests
-mvn clean install -DskipTests -Dgpg.skip
+git clone https://github.com/<your-user>/SHAFT_ENGINE.git
+cd SHAFT_ENGINE
+git remote add upstream https://github.com/ShaftHQ/SHAFT_ENGINE.git
+```
 
-# Run a specific test class
-mvn -pl shaft-engine -am test -Dtest=TestClassName
+Maintainers can clone the canonical repository directly:
 
-# Generate JavaDocs
+```bash
+git clone https://github.com/ShaftHQ/SHAFT_ENGINE.git
+cd SHAFT_ENGINE
+```
+
+Start every change from current `main`:
+
+```bash
+git fetch --prune origin
+git switch main
+git pull --ff-only origin main
+git switch -c <short-topic-branch>
+```
+
+If you work from a fork, replace the pull command with:
+
+```bash
+git fetch --prune upstream
+git switch main
+git merge --ff-only upstream/main
+git push origin main
+git switch -c <short-topic-branch>
+```
+
+## 2. Install The Toolchain
+
+Required:
+
+- JDK 25.x only.
+- Maven 3.9.0 or newer.
+- Git.
+
+The repository includes `.java-version` and `.sdkmanrc` for version managers.
+With SDKMAN:
+
+```bash
+sdk env install
+sdk env
+```
+
+Verify the active tools before building:
+
+```bash
+java -version
+mvn -version
+```
+
+Expected: Java reports version `25.x`, and Maven reports `3.9.0` or newer.
+
+## 3. Build Locally
+
+PowerShell users should keep Maven `-D` arguments quoted as shown.
+
+```bash
+mvn clean install "-DskipTests" "-Dgpg.skip"
+```
+
+This compiles the reactor and installs local artifacts without running the test
+suite.
+
+## 4. Make The Change
+
+- Keep the scope tight and follow existing package and module boundaries.
+- Preserve public API compatibility. Deprecate before removing or renaming a
+  public API.
+- Add JavaDocs for every new public class or public method.
+- Use Log4j or SHAFT `ReportManager`; do not use `System.out.println` or
+  `System.err.println` in production code.
+- Use SHAFT fluent assertions in tests where applicable.
+- Do not commit generated reports, binaries, secrets, `target/`, or local
+  credential files.
+
+The Docusaurus user guide is the canonical location for product, usage,
+architecture, migration, and maintainer documentation. Do not add public guides
+or module READMEs to this repository.
+
+## 5. Validate By Risk
+
+For documentation or agent-guidance changes:
+
+```bash
+py -3 scripts/ci/validate_agent_setup.py
+py -3 scripts/ci/validate_documentation_boundaries.py
+git diff --check
+```
+
+For localized code changes, run the affected test first:
+
+```bash
+mvn -pl shaft-engine -am test "-Dtest=TestClassName"
+```
+
+Then run one compile/package pass appropriate to the change. For broad API,
+concurrency, build, or release changes, run targeted tests and the full
+compile/package command before opening a pull request.
+
+When public JavaDocs change, also run:
+
+```bash
 mvn -pl shaft-engine javadoc:javadoc
 ```
+
+For visual behavior changes, include image or browser evidence. Run external or
+credentialed cloud suites only when the required infrastructure is available and
+the result is necessary.
+
+## 6. Update Documentation When Needed
+
+If the change affects public behavior, update the user guide in
+[ShaftHQ/shafthq.github.io](https://github.com/ShaftHQ/shafthq.github.io) in
+the same delivery.
+
+Before the engine PR is ready:
+
+1. Open the documentation PR.
+2. Verify the documentation deploy preview and affected canonical routes.
+3. Link the documentation PR from the engine PR.
+4. If documentation is not required, state the concrete reason in the engine PR.
+
+## 7. Open The Pull Request
+
+Push your branch:
+
+```bash
+git push -u origin <short-topic-branch>
+```
+
+Open a pull request against `ShaftHQ/SHAFT_ENGINE:main`.
+
+The PR is ready for review when it includes:
+
+- A clear problem statement and solution summary.
+- Focused tests or evidence for the changed path.
+- Validation commands and results copied into the PR description.
+- JavaDocs for new public APIs.
+- Compatibility preserved, or deprecations added before removals.
+- A linked user-guide PR for user-facing behavior changes, or a clear reason no
+  docs change is needed.
+- No generated reports, binaries, secrets, `target/`, or credentialed cloud
+  output.
+
+Reviewers should be able to check out the branch, run the listed commands, and
+see the same result.

--- a/README.md
+++ b/README.md
@@ -4,91 +4,48 @@
 
 # SHAFT
 
-### One Java 25 engine for Web, Mobile, API, CLI, and Database testing.
+### Java 25 automation framework for Web, Mobile, API, CLI, and Database testing.
 
-Fluent automation, synchronized actions, built-in assertions, rich evidence,
-and optional agent tools without rebuilding the framework for every surface.
+SHAFT is a Maven-published test automation engine with one fluent API for
+synchronized actions, assertions, configuration, test data, reporting, evidence,
+and optional agent-assisted workflows.
 
 [![GitHub Stars](https://img.shields.io/github/stars/ShaftHQ/SHAFT_ENGINE?style=flat-square&logo=github)](https://github.com/ShaftHQ/SHAFT_ENGINE/stargazers)
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.shafthq/shaft-engine?style=flat-square&logo=apachemaven)](https://central.sonatype.com/artifact/io.github.shafthq/shaft-engine)
 [![Build](https://img.shields.io/github/actions/workflow/status/ShaftHQ/SHAFT_ENGINE/e2eTests.yml?branch=main&style=flat-square&label=tests)](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/workflows/e2eTests.yml)
 [![Docs](https://img.shields.io/badge/docs-live-5b4bff?style=flat-square)](https://shaftengine.netlify.app/docs/start/overview)
 
-[Start](https://shaftengine.netlify.app/docs/start/quick-start) ·
-[Connect an AI agent](https://shaftengine.netlify.app/docs/agentic/mcp) ·
-[Explore features](https://shaftengine.netlify.app/docs/features/modules) ·
-[Star SHAFT](https://github.com/ShaftHQ/SHAFT_ENGINE)
+[User Guide](https://shaftengine.netlify.app/docs/start/overview) ·
+[Quick Start](https://shaftengine.netlify.app/docs/start/quick-start) ·
+[Architecture](https://shaftengine.netlify.app/docs/features/architecture) ·
+[Contribute](CONTRIBUTING.md)
 
 </div>
 
-## Launch shaft-mcp
+## What SHAFT Provides
 
-Connect Codex to SHAFT browser automation, Capture, and Doctor:
+- Web, mobile, API, CLI, database, validation, test data, and reporting APIs.
+- Built-in synchronization, assertions, screenshots, logs, and Allure evidence.
+- TestNG, JUnit 5, and Cucumber integration.
+- Required `shaft-engine` runtime plus optional modules for MCP, Capture,
+  Doctor, Heal, AI providers, BrowserStack, local video, and visual processing.
+- Deterministic agent workflows through SHAFT MCP, Capture, Doctor, and Heal,
+  with provider-backed AI features kept optional.
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/scripts/mcp/install-shaft-mcp.sh | sh -s -- --codex
-```
+## Go Straight To The Guide
 
-Windows PowerShell:
-
-```powershell
-irm https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/scripts/mcp/install-shaft-mcp.ps1 | iex; Install-ShaftMcp -Client codex
-```
-
-Then ask:
-
-> Use SHAFT to open `https://example.com`, verify the page title, and summarize
-> the generated test evidence.
-
-[Copilot / IntelliJ IDEA setup](https://shaftengine.netlify.app/docs/agentic/mcp) ·
-[Doctor command](https://shaftengine.netlify.app/docs/agentic/doctor) ·
-[Heal command](https://shaftengine.netlify.app/docs/agentic/heal)
-
-## A Complete Web Test
-
-```java
-import com.shaft.driver.SHAFT;
-import org.openqa.selenium.By;
-import org.testng.annotations.*;
-
-public class SearchTest {
-    private SHAFT.GUI.WebDriver driver;
-
-    @BeforeMethod
-    public void openBrowser() {
-        driver = new SHAFT.GUI.WebDriver();
-    }
-
-    @Test
-    public void search() {
-        driver.browser().navigateToURL("https://duckduckgo.com/")
-                .and().element().type(By.name("q"), "SHAFT Engine")
-                .and().assertThat().title().contains("DuckDuckGo");
-    }
-
-    @AfterMethod(alwaysRun = true)
-    public void closeBrowser() {
-        driver.quit();
-    }
-}
-```
-
-[Install SHAFT](https://shaftengine.netlify.app/docs/start/installation) ·
-[Web guide](https://shaftengine.netlify.app/docs/testing/web)
-
-## Go Straight to Your Goal
-
-| I want to... | Open |
+| Goal | Open |
 |---|---|
-| Test a browser | [Web testing](https://shaftengine.netlify.app/docs/testing/web) |
-| Test Android, iOS, or Flutter | [Mobile testing](https://shaftengine.netlify.app/docs/testing/mobile) |
+| Evaluate SHAFT quickly | [SHAFT at a glance](https://shaftengine.netlify.app/docs/start/overview) |
+| Create and run a project | [Quick start](https://shaftengine.netlify.app/docs/start/quick-start) |
+| Install or generate a project | [Installation](https://shaftengine.netlify.app/docs/start/installation) |
+| Understand artifacts and boundaries | [Architecture and modules](https://shaftengine.netlify.app/docs/features/architecture) |
+| Test browsers | [Web testing](https://shaftengine.netlify.app/docs/testing/web) |
+| Test mobile apps | [Mobile testing](https://shaftengine.netlify.app/docs/testing/mobile) |
 | Test REST or GraphQL APIs | [API testing](https://shaftengine.netlify.app/docs/testing/api) |
-| Run terminal or file actions | [CLI testing](https://shaftengine.netlify.app/docs/testing/cli) |
-| Query and validate databases | [Database testing](https://shaftengine.netlify.app/docs/testing/database) |
-| Diagnose a failed run | [SHAFT Doctor](https://shaftengine.netlify.app/docs/agentic/doctor) |
-| Recover an eligible locator | [SHAFT Heal](https://shaftengine.netlify.app/docs/agentic/heal) |
-| Upgrade from `SHAFT_ENGINE` | [Upgrade guide](https://shaftengine.netlify.app/docs/start/upgrade) |
-| Understand the modules | [Architecture and modules](https://shaftengine.netlify.app/docs/features/architecture) |
+| Use agent tools | [SHAFT MCP](https://shaftengine.netlify.app/docs/agentic/mcp) |
+| Diagnose or recover failed runs | [Doctor](https://shaftengine.netlify.app/docs/agentic/doctor) and [Heal](https://shaftengine.netlify.app/docs/agentic/heal) |
+| Upgrade an existing project | [Upgrade guide](https://shaftengine.netlify.app/docs/start/upgrade) |
 
 ## Evidence
 
@@ -101,13 +58,12 @@ recognized through the
 
 ## Contribute
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md), open an
-[issue](https://github.com/ShaftHQ/SHAFT_ENGINE/issues), or join the
-[community](https://shaftengine.netlify.app/docs/start/overview#community).
+Read [CONTRIBUTING.md](CONTRIBUTING.md) for the full local setup, validation,
+documentation, and pull request checklist.
 
-Public documentation is maintained in
+Public product documentation is maintained in
 [ShaftHQ/shafthq.github.io](https://github.com/ShaftHQ/shafthq.github.io).
-Engine changes that affect users must include a linked documentation-site pull
-request or explain why documentation is not required.
+User-facing engine changes need a linked documentation pull request or a clear
+reason why documentation is not required.
 
 MIT licensed. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
- Replace the engine README with a concise technical gateway to the SHAFT user guide.
- Rewrite CONTRIBUTING.md as a checkout-to-approved-PR workflow for engine contributors.
- Link the coordinated guide documentation PR: https://github.com/ShaftHQ/shafthq.github.io/pull/588

## Validation
- `py -3 scripts/ci/validate_agent_setup.py`
- `py -3 scripts/ci/validate_documentation_boundaries.py`
- `git diff --check`

The engine validation commands passed after temporarily moving the pre-existing untracked `.codex/security-scans` directory outside the checkout; it was restored afterward and is not staged.

## Graphify
- `graphify update .` was attempted.
- It refused to overwrite `graphify-out/graph.json`: new graph had 14,126 nodes while the existing graph has 14,128 nodes.
- I did not force overwrite the graph because the tool warned that chunk files may be missing from a previous session.

Draft until the Graphify refresh decision is resolved.