### PR TITLE
[codex] Add gstack routing guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,13 @@
 - Keep plans and final responses proportional to the task and stop when the
   requested behavior is verified.
 
+## gstack
+
+Use matching gstack workflow skills when available: `/browse` for browser work
+(never `mcp__claude-in-chrome__*`), `/investigate` for bugs, `/review` for
+diff review, `/qa` for browser validation, `/cso` for security, and `/ship`
+for PR/release flow.
+
 <!-- memory:start -->
 ## Memory
 


### PR DESCRIPTION
## Summary

- Add a compact `gstack` note to `CLAUDE.md` so Claude-hosted sessions route browser, bug, review, QA, security, and ship workflows to matching gstack skills when available.
- Keep `AGENTS.md` canonical by adding only a short adapter note instead of duplicating the full routing table.

## Validation

- `py -3 scripts/ci/validate_agent_setup.py` passed.
- `git diff --check` passed, with Git warning only that `CLAUDE.md` will use CRLF when Git next touches it on Windows.

## Notes

- Graphify refresh was attempted before PR creation, but the existing graph manifest reported 1,707 changed files and 7 deletions, including images and a paper, unrelated to this one-file change. No graph artifacts are staged in this PR.
- Existing artifact-heavy branch `codex/push-branch-from-main` was left untouched; this PR uses a clean branch from `origin/main`.