### PR TITLE
codex: fix visual validation screenshot attachments

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java
@@ -510,7 +510,7 @@ public class ValidationsHelper {
             byte[] referenceImage = ImageProcessingActions.getReferenceImage(locator);
             if (referenceImage !=null && !Arrays.equals(new byte[0], referenceImage)) {
                 ReportManagerHelper.logDiscrete("Reference image found.", Level.INFO);
-                List<Object> expectedValueAttachment = Arrays.asList("Validation Test Data", "Reference Screenshot",
+                List<Object> expectedValueAttachment = Arrays.asList("Screenshot", "Reference Screenshot",
                         referenceImage);
                 attachments.add(expectedValueAttachment);
             } else {
@@ -535,7 +535,7 @@ public class ValidationsHelper {
                 }
                 actualResult = ImageProcessingActions.compareAgainstBaseline(driver, locator, elementScreenshot, ImageProcessingActions.VisualValidationEngine.valueOf(visualValidationEngine.name()));
 
-                List<Object> actualValueAttachment = Arrays.asList("Validation Test Data", "Actual Screenshot",
+                List<Object> actualValueAttachment = Arrays.asList("Screenshot", "Actual Screenshot",
                         elementScreenshot);
                 attachments.add(actualValueAttachment);
 
@@ -549,7 +549,7 @@ public class ValidationsHelper {
                     //if shutterbug and failed, get differences screenshot
                     shutterbugDifferencesImage = ImageProcessingActions.getShutterbugDifferencesImage(locator);
                     if (!Arrays.equals(new byte[0], shutterbugDifferencesImage)) {
-                        List<Object> differencesAttachment = Arrays.asList("Validation Test Data", "Differences",
+                        List<Object> differencesAttachment = Arrays.asList("Screenshot", "Differences",
                                 shutterbugDifferencesImage);
                         attachments.add(differencesAttachment);
                     }

--- a/shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelperNewPatternCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelperNewPatternCoverageUnitTest.java
@@ -7,7 +7,9 @@ import com.shaft.gui.browser.internal.JavaScriptWaitManager;
 import com.shaft.gui.internal.image.ImageProcessingActions;
 import com.shaft.gui.internal.image.ScreenshotManager;
 import com.shaft.properties.internal.Properties;
+import com.shaft.tools.io.internal.ReportManagerHelper;
 import com.shaft.validation.ValidationEnums;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -162,6 +164,39 @@ public class ValidationsHelperNewPatternCoverageUnitTest {
         Assert.assertFalse(elementBuilder.reportMessageBuilder.toString().contains("By.id: message"));
     }
 
+    @Test(description = "Visual validation screenshot bytes should be routed as screenshot attachments")
+    public void visualValidationImageBytesShouldUseScreenshotAttachmentType() {
+        ValidationsHelper helper = new ValidationsHelper(ValidationEnums.ValidationCategory.HARD_ASSERT);
+        By locator = By.id("logo");
+        WebDriver driver = mock(WebDriver.class);
+        WebElement element = mock(WebElement.class);
+        byte[] referenceScreenshot = new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47};
+        byte[] actualScreenshot = new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47, 1};
+        SHAFT.Properties.visuals.set().whenToTakePageSourceSnapshot("Never");
+        when(driver.findElement(any(By.class))).thenReturn(element);
+        when(element.getScreenshotAs(any())).thenReturn(actualScreenshot);
+
+        try (MockedStatic<ImageProcessingActions> imageProcessingMocked = Mockito.mockStatic(ImageProcessingActions.class);
+             MockedStatic<ReportManagerHelper> reportManagerHelperMocked = Mockito.mockStatic(ReportManagerHelper.class)) {
+            imageProcessingMocked.when(() -> ImageProcessingActions.getReferenceImage(any(By.class)))
+                    .thenReturn(referenceScreenshot);
+            imageProcessingMocked.when(() -> ImageProcessingActions.compareAgainstBaseline(any(), any(By.class), any(byte[].class), any()))
+                    .thenReturn(true);
+            @SuppressWarnings({"rawtypes", "unchecked"})
+            ArgumentCaptor<List<List<Object>>> attachmentsCaptor = (ArgumentCaptor) ArgumentCaptor.forClass(List.class);
+
+            helper.validateElementMatches(driver, locator, ValidationEnums.VisualValidationEngine.EXACT_OPENCV,
+                    ValidationEnums.ValidationType.POSITIVE);
+
+            reportManagerHelperMocked.verify(() -> ReportManagerHelper.attach(attachmentsCaptor.capture()));
+            List<List<Object>> attachments = attachmentsCaptor.getValue();
+            Assert.assertTrue(hasAttachment(attachments, "Screenshot", "Reference Screenshot", referenceScreenshot));
+            Assert.assertTrue(hasAttachment(attachments, "Screenshot", "Actual Screenshot", actualScreenshot));
+            Assert.assertFalse(attachments.stream().anyMatch(attachment ->
+                    "Validation Test Data".equals(attachment.get(0)) && attachment.get(1).toString().contains("Screenshot")));
+        }
+    }
+
     @Test(description = "Covers private utility methods used by validation reporting")
     public void privateUtilityMethodsShouldReturnExpectedValues() throws Exception {
         Method normalizeDirection = ValidationsHelper.class.getDeclaredMethod("normalizeDirection", String.class);
@@ -200,5 +235,10 @@ public class ValidationsHelperNewPatternCoverageUnitTest {
 
         Assert.assertEquals(performValidation.invoke(helper, "a", "b", ValidationEnums.ValidationComparisonType.EQUALS, ValidationEnums.ValidationType.POSITIVE), false);
         Assert.assertEquals(performValidation.invoke(helper, 3, 3, ValidationEnums.NumbersComparativeRelation.EQUALS, ValidationEnums.ValidationType.POSITIVE), true);
+    }
+
+    private boolean hasAttachment(List<List<Object>> attachments, String type, String name, byte[] content) {
+        return attachments.stream().anyMatch(attachment ->
+                type.equals(attachment.get(0)) && name.equals(attachment.get(1)) && attachment.get(2) == content);
     }
 }


### PR DESCRIPTION
This PR was created by Codex, not manually by the maintainer whose token opened it.

## Summary
- Routes visual validation reference, actual, and diff image byte arrays through the existing `Screenshot` attachment handler.
- Adds a focused regression that captures visual validation attachments and verifies screenshot bytes are no longer labeled as `Validation Test Data`.

## Validation
- `mvn -pl shaft-engine '-Dtest=com.shaft.validation.internal.ValidationsHelperNewPatternCoverageUnitTest#visualValidationImageBytesShouldUseScreenshotAttachmentType' test`
- `mvn -pl shaft-engine '-DskipTests' package`
- `git diff --check` passed with only CRLF normalization warnings.

## Notes
- Ran `graphify update .`; it completed, skipped graph.html because the graph exceeds the visualization node limit, and produced broad generated graph churn. Those generated graphify diffs were intentionally not included in this fix PR.