### PR TITLE
test: harden shaft-mcp stability contracts

### DIFF
--- a/.codex/superpowers/plans/2026-06-23-stability-first-mcp-engine-implementation.txt
+++ b/.codex/superpowers/plans/2026-06-23-stability-first-mcp-engine-implementation.txt
@@ -1,0 +1,292 @@
+# Stability-First MCP and Engine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the accepted stability-first design true in code, starting with MCP contract drift and workspace safety before broader runtime or installer changes.
+
+**Architecture:** Keep `shaft-engine` independent from `shaft-mcp`. Strengthen existing `shaft-mcp` tests and validators first; add production changes only where a failing stability test proves that a path-taking MCP service or contract invariant is not protected.
+
+**Tech Stack:** Java 25, Maven, JUnit 5, Spring AI MCP tool callbacks, Python validation scripts, existing SHAFT CI scripts.
+
+---
+
+## Files
+
+- Modify: `shaft-mcp/src/test/java/com/shaft/mcp/DoctorServiceTest.java`
+- Modify: `shaft-mcp/src/main/java/com/shaft/mcp/DoctorService.java`
+- Modify: `shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java`
+- Modify: `scripts/ci/validate_shaft_mcp_configuration.py`
+- Optional after evidence: `tests/scripts/test_install_shaft_mcp.py`
+- Optional after evidence: `shaft-engine/src/main/java/...`
+
+## Task 1: Harden Doctor Healed-Locator Workspace Paths
+
+**Files:**
+- Modify: `shaft-mcp/src/test/java/com/shaft/mcp/DoctorServiceTest.java`
+- Modify: `shaft-mcp/src/main/java/com/shaft/mcp/DoctorService.java`
+
+- [ ] **Step 1: Write the failing outside-workspace test**
+
+Add this test to `DoctorServiceTest`:
+
+```java
+@Test
+void proposeHealedLocatorRejectsRepositoryOutsideWorkspace(@TempDir Path temp) throws Exception {
+    Path workspace = Files.createDirectories(temp.resolve("workspace"));
+    Path outside = Files.createDirectories(temp.resolve("outside"));
+    Path source = Files.createDirectories(outside.resolve("src/test/java/example"))
+            .resolve("LoginTest.java");
+    Files.writeString(source, """
+            package example;
+
+            class LoginTest {
+                void login() {
+                    driver.element().click(By.id("old-login"));
+                }
+            }
+            """, StandardCharsets.UTF_8);
+    Path report = Files.writeString(workspace.resolve("healing-report.json"), """
+            {
+              "schemaVersion": "1.0",
+              "suiteId": "suite",
+              "testId": "test",
+              "failedLocator": "By.id(\\"old-login\\")",
+              "candidates": [{
+                "id": "candidate-1",
+                "locator": "By.id(\\"new-login\\")",
+                "score": 0.94,
+                "evidence": ["test-id exact match"],
+                "unique": true,
+                "contextMatched": true
+              }],
+              "decision": {"status": "RECOVERED", "selectedCandidateId": "candidate-1", "confidence": 0.94},
+              "action": {"outcome": "PASSED", "postActionVerification": "ELEMENT_INTERACTABLE"}
+            }
+            """, StandardCharsets.UTF_8);
+
+    IllegalArgumentException failure = assertThrows(IllegalArgumentException.class,
+            () -> service(workspace).proposeHealedLocator(
+                    outside.toString(),
+                    report.toString(),
+                    "src/test/java/example/LoginTest.java",
+                    true,
+                    "target/proposals"));
+
+    assertTrue(failure.getMessage().contains("Repository root is outside the MCP workspace"));
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```powershell
+mvn -pl shaft-mcp -Dtest=DoctorServiceTest#proposeHealedLocatorRejectsRepositoryOutsideWorkspace test
+```
+
+Expected: FAIL because `DoctorService.proposeHealedLocator(...)` currently uses raw `Path.of(repositoryRoot)`.
+
+- [ ] **Step 3: Route healed-locator paths through `McpWorkspacePolicy`**
+
+Replace `DoctorService.proposeHealedLocator(...)` with:
+
+```java
+@Tool(name = "doctor_propose_healed_locator",
+        description = "maps a verified SHAFT Heal report to one reviewable locator patch"
+                + " without editing source or publishing")
+public HealingLocatorProposal proposeHealedLocator(
+        String repositoryRoot,
+        String healingReportPath,
+        String sourcePath,
+        boolean sourcePatchConsent,
+        String outputDirectory) {
+    Path repository = workspacePolicy.existing(repositoryRoot, "Repository root");
+    Path healingReport = workspacePolicy.existing(healingReportPath, "Healing report path");
+    String approvedSourcePath = workspacePolicy.sourceAllowlist(repository, List.of(sourcePath)).getFirst();
+    Path output = outputDirectory == null || outputDirectory.isBlank()
+            ? workspacePolicy.output("target/shaft-doctor/healing-proposals", "Doctor healing proposal output directory")
+            : workspacePolicy.output(outputDirectory, "Doctor healing proposal output directory");
+    return new HealingLocatorProposalService().propose(new HealingLocatorProposalRequest(
+            repository,
+            healingReport,
+            approvedSourcePath,
+            sourcePatchConsent,
+            output));
+}
+```
+
+- [ ] **Step 4: Update existing healed-locator happy path to use scoped service**
+
+In `DoctorServiceTest.proposeHealedLocatorCreatesReviewOnlyPatch`, replace:
+
+```java
+var proposal = new DoctorService().proposeHealedLocator(
+```
+
+with:
+
+```java
+var proposal = service(temp).proposeHealedLocator(
+```
+
+- [ ] **Step 5: Run focused Doctor tests and verify GREEN**
+
+Run:
+
+```powershell
+mvn -pl shaft-mcp -Dtest=DoctorServiceTest#proposeHealedLocatorRejectsRepositoryOutsideWorkspace,DoctorServiceTest#proposeHealedLocatorCreatesReviewOnlyPatch test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 1**
+
+```powershell
+git add shaft-mcp/src/test/java/com/shaft/mcp/DoctorServiceTest.java shaft-mcp/src/main/java/com/shaft/mcp/DoctorService.java
+git commit -m "test: harden doctor healed locator workspace paths"
+```
+
+## Task 2: Tighten Shared Workspace Policy Regression Coverage
+
+**Files:**
+- Modify: `shaft-mcp/src/test/java/com/shaft/mcp/McpResultRecordsTest.java`
+
+- [ ] **Step 1: Write focused policy regressions**
+
+Add tests that assert `McpWorkspacePolicy` rejects blank allowlist entries, missing output ancestors, and symlink escapes when the platform supports symbolic links.
+
+```java
+@Test
+void workspacePolicyRejectsBlankAllowlistAndMissingOutputAncestor() throws Exception {
+    Path root = Files.createDirectories(temp.resolve("workspace"));
+    Path repository = Files.createDirectories(root.resolve("repo"));
+    McpWorkspacePolicy policy = McpWorkspacePolicy.of(root);
+
+    assertThrows(IllegalArgumentException.class,
+            () -> policy.sourceAllowlist(repository, List.of(" ")));
+    assertThrows(IllegalArgumentException.class,
+            () -> policy.output(root.resolve("missing-parent/report.json").toString(), "Report"));
+}
+```
+
+- [ ] **Step 2: Run RED, then keep or minimally adjust policy**
+
+Run:
+
+```powershell
+mvn -pl shaft-mcp -Dtest=McpResultRecordsTest#workspacePolicyRejectsBlankAllowlistAndMissingOutputAncestor test
+```
+
+Expected: If it passes, keep the test as coverage and do not change production code. If it fails because missing ancestors are accepted, update only `McpWorkspacePolicy.output(...)` to preserve the documented nearest-existing-ancestor rule.
+
+- [ ] **Step 3: Commit Task 2**
+
+```powershell
+git add shaft-mcp/src/test/java/com/shaft/mcp/McpResultRecordsTest.java shaft-mcp/src/main/java/com/shaft/mcp/McpWorkspacePolicy.java
+git commit -m "test: cover mcp workspace policy edge cases"
+```
+
+## Task 3: Strengthen MCP Tool Contract Checks
+
+**Files:**
+- Modify: `shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java`
+- Modify: `scripts/ci/validate_shaft_mcp_configuration.py`
+
+- [ ] **Step 1: Add manifest metadata assertions**
+
+Extend `ShaftMcpApplicationTests.contextRegistersExpectedLeanMcpToolApi()` so every fixture tool has unique `name`, boolean `mutation`, boolean `sensitive`, and boolean `deprecated` fields. Replace the generic `arg0`/`arg1` check with a regex check for `"arg\\d+"`.
+
+- [ ] **Step 2: Run focused contract test**
+
+```powershell
+mvn -pl shaft-mcp -Dtest=ShaftMcpApplicationTests#contextRegistersExpectedLeanMcpToolApi test
+```
+
+Expected: PASS after only test-side contract tightening unless the manifest has real metadata drift.
+
+- [ ] **Step 3: Add equivalent lightweight Python validator coverage**
+
+In `scripts/ci/validate_shaft_mcp_configuration.py`, after loading `manifest`, assert:
+
+```python
+if manifest.get("schemaVersion") != "1.0":
+    errors.append("MCP tool manifest schemaVersion must remain 1.0")
+seen_tools = set()
+for tool in manifest.get("tools", []):
+    name = tool.get("name")
+    if not name:
+        errors.append("MCP tool manifest contains a tool without a name")
+        continue
+    if name in seen_tools:
+        errors.append(f"MCP tool manifest contains duplicate tool: {name}")
+    seen_tools.add(name)
+    for key in ("mutation", "sensitive", "deprecated"):
+        if not isinstance(tool.get(key), bool):
+            errors.append(f"MCP tool manifest tool {name} must define boolean {key}")
+```
+
+- [ ] **Step 4: Run Python validator**
+
+```powershell
+py -3 scripts\ci\validate_shaft_mcp_configuration.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 3**
+
+```powershell
+git add shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java scripts/ci/validate_shaft_mcp_configuration.py
+git commit -m "test: lock mcp tool manifest metadata"
+```
+
+## Task 4: Final Focused Validation
+
+**Files:**
+- No planned source edits.
+
+- [ ] **Step 1: Run smallest non-redundant checks**
+
+```powershell
+py -3 scripts\ci\validate_documentation_boundaries.py
+py -3 scripts\ci\validate_agent_setup.py
+py -3 scripts\ci\validate_shaft_mcp_configuration.py
+mvn -pl shaft-mcp -Dtest=DoctorServiceTest,McpResultRecordsTest,ShaftMcpApplicationTests test
+mvn -pl shaft-engine,shaft-mcp -am test-compile
+```
+
+- [ ] **Step 2: Refresh graphify or report blocker**
+
+Run:
+
+```powershell
+graphify . --update
+```
+
+If unavailable or too slow, report the blocker and the existing graph freshness.
+
+- [ ] **Step 3: Update PR body and mark ready only if implementation is complete**
+
+```powershell
+$body = @'
+## Summary
+- Adds stability-first MCP contract and workspace-safety hardening.
+- Keeps WebDriver as the default MCP browser surface and Playwright opt-in.
+- Tightens existing validators instead of adding a new validation layer.
+
+## Validation
+- py -3 scripts\ci\validate_documentation_boundaries.py
+- py -3 scripts\ci\validate_agent_setup.py
+- py -3 scripts\ci\validate_shaft_mcp_configuration.py
+- mvn -pl shaft-mcp -Dtest=DoctorServiceTest,McpResultRecordsTest,ShaftMcpApplicationTests test
+- mvn -pl shaft-engine,shaft-mcp -am test-compile
+
+## Risk
+- Transport smoke requires packaged runtime dependencies and is listed if not run locally.
+'@
+$body | Set-Content -Encoding UTF8 .codex\superpowers\plans\pr-3015-body.txt
+gh pr edit 3015 --body-file .codex\superpowers\plans\pr-3015-body.txt
+gh pr ready 3015
+```
+
+Expected: PR lists changed files, validation commands, and residual risks.

--- a/.codex/superpowers/plans/2026-06-23-stability-first-mcp-engine-implementation.txt
+++ b/.codex/superpowers/plans/2026-06-23-stability-first-mcp-engine-implementation.txt
@@ -16,6 +16,7 @@
 - Modify: `shaft-mcp/src/main/java/com/shaft/mcp/DoctorService.java`
 - Modify: `shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java`
 - Modify: `scripts/ci/validate_shaft_mcp_configuration.py`
+- Create: `tests/scripts/test_validate_shaft_mcp_configuration.py`
 - Optional after evidence: `tests/scripts/test_install_shaft_mcp.py`
 - Optional after evidence: `shaft-engine/src/main/java/...`
 
@@ -201,20 +202,30 @@ git commit -m "test: cover mcp workspace policy edge cases"
 **Files:**
 - Modify: `shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java`
 - Modify: `scripts/ci/validate_shaft_mcp_configuration.py`
+- Create: `tests/scripts/test_validate_shaft_mcp_configuration.py`
 
-- [ ] **Step 1: Add manifest metadata assertions**
+- [ ] **Step 1: Add a failing Python validator test**
+
+Create `tests/scripts/test_validate_shaft_mcp_configuration.py` with a unittest that calls `validate_tool_manifest(...)` using an invalid manifest containing schema drift, duplicate names, missing names, and non-boolean metadata.
+
+- [ ] **Step 2: Implement manifest metadata validator helper**
+
+Add `validate_tool_manifest(manifest)` to `scripts/ci/validate_shaft_mcp_configuration.py` and call it from `validate(...)` after loading `mcp-tool-manifest.json`.
+
+- [ ] **Step 3: Add Java manifest metadata assertions**
 
 Extend `ShaftMcpApplicationTests.contextRegistersExpectedLeanMcpToolApi()` so every fixture tool has unique `name`, boolean `mutation`, boolean `sensitive`, and boolean `deprecated` fields. Replace the generic `arg0`/`arg1` check with a regex check for `"arg\\d+"`.
 
-- [ ] **Step 2: Run focused contract test**
+- [ ] **Step 4: Run focused contract tests**
 
 ```powershell
+py -3 -m unittest tests.scripts.test_validate_shaft_mcp_configuration
 mvn -pl shaft-mcp -Dtest=ShaftMcpApplicationTests#contextRegistersExpectedLeanMcpToolApi test
 ```
 
-Expected: PASS after only test-side contract tightening unless the manifest has real metadata drift.
+Expected: PASS.
 
-- [ ] **Step 3: Add equivalent lightweight Python validator coverage**
+- [ ] **Step 5: Add equivalent lightweight Python validator coverage**
 
 In `scripts/ci/validate_shaft_mcp_configuration.py`, after loading `manifest`, assert:
 
@@ -235,7 +246,7 @@ for tool in manifest.get("tools", []):
             errors.append(f"MCP tool manifest tool {name} must define boolean {key}")
 ```
 
-- [ ] **Step 4: Run Python validator**
+- [ ] **Step 6: Run Python validator**
 
 ```powershell
 py -3 scripts\ci\validate_shaft_mcp_configuration.py
@@ -243,10 +254,10 @@ py -3 scripts\ci\validate_shaft_mcp_configuration.py
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit Task 3**
+- [ ] **Step 7: Commit Task 3**
 
 ```powershell
-git add shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java scripts/ci/validate_shaft_mcp_configuration.py
+git add shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java scripts/ci/validate_shaft_mcp_configuration.py tests/scripts/test_validate_shaft_mcp_configuration.py
 git commit -m "test: lock mcp tool manifest metadata"
 ```
 

--- a/.codex/superpowers/plans/2026-06-23-stability-first-mcp-engine-implementation.txt
+++ b/.codex/superpowers/plans/2026-06-23-stability-first-mcp-engine-implementation.txt
@@ -153,31 +153,41 @@ git commit -m "test: harden doctor healed locator workspace paths"
 
 - [ ] **Step 1: Write focused policy regressions**
 
-Add tests that assert `McpWorkspacePolicy` rejects blank allowlist entries, missing output ancestors, and symlink escapes when the platform supports symbolic links.
+Add tests that assert `McpWorkspacePolicy` rejects blank allowlist entries and symlink escapes. Missing output parents inside the workspace remain valid because the policy only requires the nearest existing ancestor to resolve inside the workspace.
 
 ```java
 @Test
-void workspacePolicyRejectsBlankAllowlistAndMissingOutputAncestor() throws Exception {
+void workspacePolicyRejectsBlankAllowlistAndSymlinkEscapes() throws Exception {
     Path root = Files.createDirectories(temp.resolve("workspace"));
     Path repository = Files.createDirectories(root.resolve("repo"));
+    Path outside = Files.createDirectories(temp.resolve("outside"));
+    Path secret = Files.writeString(outside.resolve("secret.txt"), "secret");
+    Path link = root.resolve("link");
     McpWorkspacePolicy policy = McpWorkspacePolicy.of(root);
 
     assertThrows(IllegalArgumentException.class,
             () -> policy.sourceAllowlist(repository, List.of(" ")));
-    assertThrows(IllegalArgumentException.class,
-            () -> policy.output(root.resolve("missing-parent/report.json").toString(), "Report"));
+    assertEquals(root.resolve("repo/out/report.json").toAbsolutePath().normalize(),
+            policy.output("repo/out/report.json", "Report").toAbsolutePath().normalize());
+    try {
+        Files.createSymbolicLink(link, outside);
+    } catch (UnsupportedOperationException | IOException exception) {
+        return;
+    }
+    assertThrows(IllegalArgumentException.class, () -> policy.existing("link/secret.txt", "Evidence"));
+    assertThrows(IllegalArgumentException.class, () -> policy.output("link/report.txt", "Report"));
 }
 ```
 
-- [ ] **Step 2: Run RED, then keep or minimally adjust policy**
+- [ ] **Step 2: Run focused policy coverage**
 
 Run:
 
 ```powershell
-mvn -pl shaft-mcp -Dtest=McpResultRecordsTest#workspacePolicyRejectsBlankAllowlistAndMissingOutputAncestor test
+mvn -pl shaft-mcp -Dtest=McpResultRecordsTest#workspacePolicyRejectsBlankAllowlistAndSymlinkEscapes test
 ```
 
-Expected: If it passes, keep the test as coverage and do not change production code. If it fails because missing ancestors are accepted, update only `McpWorkspacePolicy.output(...)` to preserve the documented nearest-existing-ancestor rule.
+Expected: PASS with existing policy. If symlink creation is unsupported, the test returns after covering blank allowlist and missing-parent output behavior.
 
 - [ ] **Step 3: Commit Task 2**
 

--- a/.codex/superpowers/specs/2026-06-23-stability-first-mcp-engine-design.txt
+++ b/.codex/superpowers/specs/2026-06-23-stability-first-mcp-engine-design.txt
@@ -1,0 +1,120 @@
+# Stability-First MCP and Engine Solidification Design
+
+**Goal:** Make `shaft-mcp` and the core `shaft-engine` hooks it depends on harder to regress without expanding the public feature surface.
+
+**Decision:** Start with stability-first work: contract checks, workspace-path safety, validation coverage, installer/config reliability, and only the minimal `shaft-engine` hooks needed to make MCP behavior deterministic.
+
+## Context
+
+`shaft-mcp` already exposes a broad tool surface for WebDriver browser and element actions, capture, Doctor, Heal, guide search, mobile, natural actions, test automation guidance, and opt-in Playwright. The current risk is not a lack of tools. The risk is drift between `@Tool` methods, fixture manifests, installer expectations, transport smoke tests, and the global runtime behavior inherited from `shaft-engine`.
+
+The core engine must remain independent of `shaft-mcp`. Any `shaft-engine` change in this track must support existing runtime/reporting/driver behavior directly and must not add an MCP dependency.
+
+## Scope
+
+1. Lock the MCP tool contract.
+2. Harden workspace path handling for MCP services that accept user-supplied files or directories.
+3. Make MCP runtime lifecycle behavior deterministic enough to test without launching real browsers unless the test explicitly owns that scope.
+4. Keep installer, transport, Docker, workflow, and registry metadata in sync through existing validation scripts.
+5. Add only minimal core engine hooks where MCP currently has to depend on global behavior.
+
+## Non-Goals
+
+1. No new MCP feature families.
+2. No default switch from WebDriver to Playwright.
+3. No new installer framework.
+4. No release, deploy, publish, or credentialed cloud validation.
+5. No broad `shaft-engine` refactor.
+
+## Design
+
+### MCP Tool Contract
+
+Add a generated-contract check that compares live Spring AI tool callbacks against `shaft-mcp/src/test/resources/fixtures/mcp-tool-manifest.json`.
+
+The check must verify:
+
+1. Required tools stay present.
+2. Removed or sensitive tools stay absent.
+3. Parameter names are real names, not `arg0` or `arg1`.
+4. WebDriver tools remain the default browser automation surface.
+5. Playwright tools remain opt-in and prefixed with `playwright_`.
+6. Result records keep `schemaVersion` fields where records already expose them.
+
+The existing fixture remains the reviewed public contract. If a tool changes intentionally, the implementation updates the fixture and the focused contract test in the same commit.
+
+### Workspace Safety
+
+Every MCP service method that accepts paths must resolve them through `McpWorkspacePolicy` before reading or writing. Tests must cover the shared policy instead of duplicating path checks in every service.
+
+The policy contract is:
+
+1. Existing input paths must resolve to real paths inside the workspace root.
+2. Output paths may not exist, but their nearest existing ancestor must resolve inside the workspace root.
+3. Repository-relative allowlist paths must stay relative, non-blank, and inside the repository.
+4. Symlinks, `..`, absolute paths, and missing ancestors must not escape the workspace.
+5. Error messages must name the rejected input category without leaking secrets.
+
+### Runtime Lifecycle
+
+MCP runtime setup should be deterministic and narrow:
+
+1. `EngineService.configureRuntimePaths(...)` owns MCP runtime folders and `user.dir` setup.
+2. `EngineService.ensureEngineInitialized()` remains idempotent.
+3. Driver lifecycle tests use mock-backed or no-driver paths unless they explicitly validate browser startup.
+4. Report generation keeps using the existing Allure manager entry point and avoids deleting the `allure-results` root.
+5. Static state cleanup must be explicit in tests that mutate driver or runtime state.
+
+Any needed `shaft-engine` hook should be a small public or package-private behavior that is useful outside MCP too, such as clearer runtime path resolution or report lifecycle error handling.
+
+### Installer and Transport Reliability
+
+Keep the thin JAR plus runtime dependency argfile model. Strengthen existing validators instead of adding another installer layer.
+
+The validation surface is:
+
+1. `scripts/ci/validate_shaft_mcp_configuration.py` remains the packaging, metadata, Docker, workflow, and installer drift gate.
+2. `scripts/ci/validate_shaft_mcp_transports.py` remains the packaged stdio and HTTP smoke gate.
+3. `tests/scripts/test_install_shaft_mcp.py` remains the installer unit test surface.
+4. The installer must continue to verify Java 25, checksum downloaded artifacts, write an argfile with `shaft.mcp.workspaceRoot`, and probe stdio before editing client config.
+5. Client config writes must stay atomic or rollback-backed.
+
+### Documentation Boundary
+
+Implementation changes that alter user-visible behavior need a public docs PR in `C:\Users\Mohab\IdeaProjects\shafthq.github.io`. Contract-only tests and internal validators do not need public docs unless they change setup, tool names, or user-facing guidance.
+
+## Testing Strategy
+
+Use the smallest check that proves the edited surface:
+
+1. Contract drift: focused `shaft-mcp` contract test plus `py -3 scripts/ci/validate_shaft_mcp_configuration.py`.
+2. Transport behavior: package `shaft-mcp`, copy runtime dependencies, then run `py -3 scripts/ci/validate_shaft_mcp_transports.py`.
+3. Workspace safety: focused `McpWorkspacePolicyTest` and service tests for any touched path-taking service.
+4. Installer behavior: focused `py -3 -m pytest tests/scripts/test_install_shaft_mcp.py`.
+5. Core engine hooks: affected unit tests, then `mvn -pl shaft-engine,shaft-mcp -am test-compile` or a package pass only when the change touches shared build/runtime behavior.
+
+Avoid `mvn test` until the active Surefire/TestNG gotchas are checked. Browser tests stay headless.
+
+## Acceptance Criteria
+
+1. MCP tools cannot drift from the reviewed fixture without a failing test or validator.
+2. Path-taking MCP services have a shared policy-backed safety boundary with focused tests.
+3. Installer, transport, Docker, workflow, registry metadata, and thin-classpath assumptions are covered by existing validators with any missing assertions added in place.
+4. WebDriver stays the default MCP browser backend; Playwright remains opt-in.
+5. `shaft-engine` still has no dependency on `shaft-mcp`.
+6. Validation commands and any remaining risks are reported in the implementation PR.
+
+## Implementation Order
+
+1. Add or tighten MCP tool contract tests.
+2. Audit path-taking MCP service methods and route any misses through `McpWorkspacePolicy`.
+3. Add missing workspace policy/service regression tests.
+4. Tighten installer/config/transport validators only where they fail to cover an accepted invariant above.
+5. Add minimal `shaft-engine` hook fixes only if a stability test proves the need.
+6. Refresh graphify after core/docs relationship changes, or report why it could not run.
+
+## Risks
+
+1. Full transport validation requires a packaged MCP jar and runtime dependencies, so it is slower than unit tests.
+2. Some runtime behavior depends on static SHAFT state; tests must restore state explicitly.
+3. Public docs live in a separate repository, so behavior changes may need a second PR.

--- a/scripts/ci/validate_shaft_mcp_configuration.py
+++ b/scripts/ci/validate_shaft_mcp_configuration.py
@@ -28,6 +28,31 @@ def property_map(path: Path) -> dict[str, str]:
     return properties
 
 
+def validate_tool_manifest(manifest: dict[str, object]) -> list[str]:
+    errors: list[str] = []
+    if manifest.get("schemaVersion") != "1.0":
+        errors.append("MCP tool manifest schemaVersion must remain 1.0")
+    seen_tools: set[str] = set()
+    tools = manifest.get("tools", [])
+    if not isinstance(tools, list):
+        return errors + ["MCP tool manifest tools must be a list"]
+    for tool in tools:
+        if not isinstance(tool, dict):
+            errors.append("MCP tool manifest contains a non-object tool entry")
+            continue
+        name = tool.get("name")
+        if not isinstance(name, str) or not name:
+            errors.append("MCP tool manifest contains a tool without a name")
+            continue
+        if name in seen_tools:
+            errors.append(f"MCP tool manifest contains duplicate tool: {name}")
+        seen_tools.add(name)
+        for key in ("mutation", "sensitive", "deprecated"):
+            if not isinstance(tool.get(key), bool):
+                errors.append(f"MCP tool manifest tool {name} must define boolean {key}")
+    return errors
+
+
 def validate(root: Path = ROOT) -> list[str]:
     errors: list[str] = []
     parent = ET.parse(root / "pom.xml").getroot()
@@ -118,6 +143,7 @@ def validate(root: Path = ROOT) -> list[str]:
 
     manifest_path = root / "shaft-mcp/src/test/resources/fixtures/mcp-tool-manifest.json"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    errors.extend(validate_tool_manifest(manifest))
     tools = {tool["name"] for tool in manifest.get("tools", [])}
     required_tools = {
         "doctor_analyze_failed_allure",

--- a/shaft-mcp/src/main/java/com/shaft/mcp/DoctorService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/DoctorService.java
@@ -391,14 +391,19 @@ public class DoctorService {
             String sourcePath,
             boolean sourcePatchConsent,
             String outputDirectory) {
+        Path repository = workspacePolicy.existing(repositoryRoot, "Repository root");
+        Path healingReport = workspacePolicy.existing(healingReportPath, "Healing report path");
+        String approvedSourcePath = workspacePolicy.sourceAllowlist(repository, List.of(sourcePath)).getFirst();
+        Path output = outputDirectory == null || outputDirectory.isBlank()
+                ? workspacePolicy.output("target/shaft-doctor/healing-proposals",
+                        "Doctor healing proposal output directory")
+                : workspacePolicy.output(outputDirectory, "Doctor healing proposal output directory");
         return new HealingLocatorProposalService().propose(new HealingLocatorProposalRequest(
-                Path.of(repositoryRoot),
-                Path.of(healingReportPath),
-                sourcePath,
+                repository,
+                healingReport,
+                approvedSourcePath,
                 sourcePatchConsent,
-                outputDirectory == null || outputDirectory.isBlank()
-                        ? Path.of("target", "shaft-doctor", "healing-proposals")
-                        : Path.of(outputDirectory)));
+                output));
     }
 
     /**

--- a/shaft-mcp/src/test/java/com/shaft/mcp/DoctorServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/DoctorServiceTest.java
@@ -217,6 +217,56 @@ class DoctorServiceTest {
     }
 
     @Test
+    void healedLocatorToolRejectsRepositoryOutsideWorkspace(@TempDir Path temp) throws Exception {
+        SHAFT.Properties.healing.set().sourcePatchEnabled(true);
+        Path workspace = Files.createDirectories(temp.resolve("workspace"));
+        Path outside = Files.createDirectories(temp.resolve("outside"));
+        Path source = outside.resolve("src/test/java/example/LoginTest.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(source, """
+                package example;
+                import org.openqa.selenium.By;
+                class LoginTest {
+                    private static final By LOGIN = By.id("old-login");
+                }
+                """, StandardCharsets.UTF_8);
+        Path report = workspace.resolve("healing-report.json");
+        Files.writeString(report, """
+                {
+                  "schemaVersion": "2.0",
+                  "attemptId": "attempt-mcp",
+                  "originalLocator": "By.id: old-login",
+                  "candidates": [{
+                    "candidateId": "candidate-1",
+                    "proposedLocator": "By.id: new-login",
+                    "evidence": ["test-id exact match"],
+                    "unique": true,
+                    "contextMatched": true
+                  }],
+                  "decision": {
+                    "status": "RECOVERED",
+                    "selectedCandidateId": "candidate-1",
+                    "confidence": 0.94
+                  },
+                  "action": {
+                    "outcome": "PASSED",
+                    "postActionVerification": "ELEMENT_INTERACTABLE"
+                  }
+                }
+                """, StandardCharsets.UTF_8);
+
+        IllegalArgumentException failure = assertThrows(IllegalArgumentException.class,
+                () -> service(workspace).proposeHealedLocator(
+                        outside.toString(),
+                        report.toString(),
+                        "src/test/java/example/LoginTest.java",
+                        true,
+                        "target/proposals"));
+
+        assertTrue(failure.getMessage().contains("Repository root is outside the MCP workspace"));
+    }
+
+    @Test
     void healedLocatorToolCreatesProposalWithoutChangingSource(@TempDir Path temp) throws Exception {
         SHAFT.Properties.healing.set().sourcePatchEnabled(true);
         Path source = temp.resolve("src/test/java/example/LoginTest.java");
@@ -254,7 +304,7 @@ class DoctorServiceTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        var proposal = new DoctorService().proposeHealedLocator(
+        var proposal = service(temp).proposeHealedLocator(
                 temp.toString(),
                 report.toString(),
                 "src/test/java/example/LoginTest.java",

--- a/shaft-mcp/src/test/java/com/shaft/mcp/McpResultRecordsTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/McpResultRecordsTest.java
@@ -3,6 +3,7 @@ package com.shaft.mcp;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -120,6 +121,28 @@ class McpResultRecordsTest {
         assertThrows(IllegalArgumentException.class, () -> policy.output("../outside.txt", "Report"));
         assertThrows(IllegalArgumentException.class,
                 () -> policy.sourceAllowlist(repository, List.of("../outside.java")));
+    }
+
+    @Test
+    void workspacePolicyRejectsBlankAllowlistAndSymlinkEscapes() throws Exception {
+        Path root = Files.createDirectories(temp.resolve("workspace"));
+        Path repository = Files.createDirectories(root.resolve("repo"));
+        Path outside = Files.createDirectories(temp.resolve("outside"));
+        Files.writeString(outside.resolve("secret.txt"), "secret");
+        Path link = root.resolve("link");
+        McpWorkspacePolicy policy = McpWorkspacePolicy.of(root);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> policy.sourceAllowlist(repository, List.of(" ")));
+        assertEquals(root.resolve("repo/out/report.json").toAbsolutePath().normalize(),
+                policy.output("repo/out/report.json", "Report").toAbsolutePath().normalize());
+        try {
+            Files.createSymbolicLink(link, outside);
+        } catch (UnsupportedOperationException | IOException exception) {
+            return;
+        }
+        assertThrows(IllegalArgumentException.class, () -> policy.existing("link/secret.txt", "Evidence"));
+        assertThrows(IllegalArgumentException.class, () -> policy.output("link/report.txt", "Report"));
     }
 
 }

--- a/shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java
@@ -1,6 +1,7 @@
 package com.shaft.mcp;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -21,6 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest(properties = "spring.ai.mcp.server.enabled=false")
 class ShaftMcpApplicationTests {
+    private static final Pattern GENERIC_PARAMETER_NAME = Pattern.compile("\"arg\\d+\"");
+
     @Autowired
     private ApplicationContext context;
 
@@ -40,7 +44,7 @@ class ShaftMcpApplicationTests {
                 .map(ToolCallback.class::cast)
                 .forEach(callback -> {
                     String schema = callback.getToolDefinition().inputSchema();
-                    assertFalse(schema.contains("\"arg0\"") || schema.contains("\"arg1\""),
+                    assertFalse(GENERIC_PARAMETER_NAME.matcher(schema).find(),
                             callback.getToolDefinition().name() + " exposes generic parameter names: " + schema);
                 });
         assertTrue(toolNames.contains("doctor_analyze_failed_allure"));
@@ -104,10 +108,23 @@ class ShaftMcpApplicationTests {
     }
 
     private static Set<String> expectedTools() throws Exception {
-        var root = new ObjectMapper().readTree(Files.readString(Path.of(
+        JsonNode root = new ObjectMapper().readTree(Files.readString(Path.of(
                 "src/test/resources/fixtures/mcp-tool-manifest.json")));
-        return java.util.stream.StreamSupport.stream(root.path("tools").spliterator(), false)
-                .map(node -> node.path("name").asText())
-                .collect(Collectors.toCollection(java.util.TreeSet::new));
+        assertEquals("1.0", root.path("schemaVersion").asText());
+        Set<String> tools = new java.util.TreeSet<>();
+        Set<String> duplicates = new java.util.TreeSet<>();
+        for (JsonNode tool : root.path("tools")) {
+            String name = tool.path("name").asText();
+            assertFalse(name.isBlank(), "MCP tool manifest contains a tool without a name");
+            if (!tools.add(name)) {
+                duplicates.add(name);
+            }
+            for (String metadata : List.of("mutation", "sensitive", "deprecated")) {
+                assertTrue(tool.path(metadata).isBoolean(),
+                        "MCP tool manifest tool " + name + " must define boolean " + metadata);
+            }
+        }
+        assertTrue(duplicates.isEmpty(), "MCP tool manifest contains duplicate tools: " + duplicates);
+        return tools;
     }
 }

--- a/tests/scripts/test_validate_shaft_mcp_configuration.py
+++ b/tests/scripts/test_validate_shaft_mcp_configuration.py
@@ -1,0 +1,34 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "validate_shaft_mcp_configuration.py"
+SPEC = importlib.util.spec_from_file_location("validate_shaft_mcp_configuration", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+if SPEC.loader is None:
+    raise ImportError(f"Unable to load {MODULE_PATH}")
+SPEC.loader.exec_module(MODULE)
+
+
+class ValidateShaftMcpConfigurationTest(unittest.TestCase):
+    def test_tool_manifest_metadata_errors_are_reported(self):
+        errors = MODULE.validate_tool_manifest({
+            "schemaVersion": "2.0",
+            "tools": [
+                {"name": "driver_initialize", "mutation": True, "sensitive": False, "deprecated": False},
+                {"name": "driver_initialize", "mutation": True, "sensitive": False, "deprecated": False},
+                {"name": "browser_get_page_dom", "mutation": False, "sensitive": "yes"},
+                {"mutation": False, "sensitive": False, "deprecated": False},
+            ],
+        })
+
+        self.assertIn("MCP tool manifest schemaVersion must remain 1.0", errors)
+        self.assertIn("MCP tool manifest contains duplicate tool: driver_initialize", errors)
+        self.assertIn("MCP tool manifest tool browser_get_page_dom must define boolean sensitive", errors)
+        self.assertIn("MCP tool manifest tool browser_get_page_dom must define boolean deprecated", errors)
+        self.assertIn("MCP tool manifest contains a tool without a name", errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds the Superpowers stability-first design and implementation plan under `.codex/superpowers/` because this repository forbids a local `docs/` tree.
- Hardens `DoctorService.proposeHealedLocator` so repository root, healing report, source path, and output directory are all enforced through `McpWorkspacePolicy`.
- Adds workspace-policy regression coverage for blank allowlists, allowed in-workspace output creation, and symlink escape rejection.
- Locks the shaft-mcp tool manifest contract in Java and CI validation: schema version, unique names, and boolean `mutation` / `sensitive` / `deprecated` metadata.

## Validation
- `py -3 scripts\ci\validate_documentation_boundaries.py`
- `py -3 scripts\ci\validate_agent_setup.py`
- `py -3 scripts\ci\validate_shaft_mcp_configuration.py`
- `py -3 -m unittest tests.scripts.test_validate_shaft_mcp_configuration`
- `py -3 -m unittest tests.scripts.test_install_shaft_mcp`
- `mvn -pl shaft-mcp '-Dtest=DoctorServiceTest,McpResultRecordsTest,ShaftMcpApplicationTests' test`
- `mvn -pl shaft-engine,shaft-mcp -am test-compile`
- `mvn -pl shaft-mcp -am package '-DskipTests' '-Dgpg.skip'`
- `mvn -pl shaft-mcp dependency:copy-dependencies '-DincludeScope=runtime' '-DoutputDirectory=C:\Users\Mohab\IdeaProjects\SHAFT_ENGINE-codex-stability-first\shaft-mcp\target\dependency'`
- `py -3 scripts\ci\validate_shaft_mcp_transports.py`
- `git diff --check`

## Graphify
- `graphify . --update` was attempted from the isolated worktree and blocked because no LLM API key is available for semantic extraction of doc/paper/image files. The CLI reported that one of `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `MOONSHOT_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `DEEPSEEK_API_KEY` is required.