### PR TITLE
chore: add SHAFT marketing ad producer skill

### DIFF
--- a/.agents/skills/shaft-marketing-ad-producer/SKILL.md
+++ b/.agents/skills/shaft-marketing-ad-producer/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: shaft-marketing-ad-producer
+description: Use when planning or producing SHAFT marketing ads; scripts, scenes, demo capture, captions, music direction, code snippets, video editing, reusable assets.
+---
+
+# SHAFT Marketing Ad Producer
+
+Read and follow the [canonical SHAFT marketing ad producer playbook](../../../.github/skills/shaft-marketing-ad-producer/SKILL.md).

--- a/.agents/skills/shaft-marketing-ad-producer/agents/openai.yaml
+++ b/.agents/skills/shaft-marketing-ad-producer/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "SHAFT Marketing Ad Producer"
+  short_description: "Plan and produce reusable SHAFT ads"
+  default_prompt: "Use $shaft-marketing-ad-producer to plan and produce this SHAFT marketing ad."
+policy:
+  allow_implicit_invocation: true

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -5,5 +5,6 @@ Load only the playbook matching the task:
 - [CI failure investigator](ci-failure-investigator/SKILL.md)
 - [Flaky test stabilizer](flaky-test-stabilizer/SKILL.md)
 - [Release and dependency guard](release-dependency-guard/SKILL.md)
+- [SHAFT marketing ad producer](shaft-marketing-ad-producer/SKILL.md)
 
 Each skill is intentionally self-contained and is not global repository policy.

--- a/.github/skills/shaft-marketing-ad-producer/SKILL.md
+++ b/.github/skills/shaft-marketing-ad-producer/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: shaft-marketing-ad-producer
+description: Use when planning or producing SHAFT ads needing scripts, scenes, demo capture, Allure or MCP recorder footage, captions, music, code visuals, edits, and reusable assets.
+---
+
+# SHAFT Marketing Ad Producer
+
+Plan SHAFT ads without fake claims.
+
+## Stack
+
+- Strategy/routes/scenes: `creative-production:positioning-explorer`, `creative-production:offer-explorer`, `creative-production:ads-explorer`, `creative-production:scene-explorer`, `creative-production:moodboard-explorer`.
+- Visual polish: `creative-production:generative-polish`, `imagegen`. Keep exact copy, code, logos, and UI screenshots deterministic.
+- Browser capture: `browse` or `playwright`; use `chrome:control-chrome` only for current Chrome state.
+- Desktop capture: `computer-use:computer-use`; use OBS, Windows capture, or `ffmpeg` only if installed.
+- SHAFT proof: MCP recorder/report tools such as `capture_start`, `capture_stop`, `capture_code_blocks`, `playwright_record_start`, `playwright_record_stop`, `playwright_recording_code_blocks`, mobile recording, `generate_test_report`, and Doctor/Allure tools.
+- Editing/audio: existing video tools plus approved audio-generation or licensed music. If no generator exists, write a music brief and ask for or reuse an approved track.
+
+## Workflow
+
+1. Brief: audience, channel, duration, feature, proof, aspect ratio, and planning-only vs production.
+2. Evidence: read SHAFT README/docs or MCP guidance. Use real Allure, Capture, MCP recorder, Doctor, or code surfaces for production; label mockups.
+3. Script/scenes: make a timestamped table with visual/action, text, voiceover, source, animation, music beat, and asset path.
+4. Assets: render code snippets as deterministic HTML/CSS screenshots. Never use generated-image text for final copy or code.
+5. Capture: avoid secrets and private browser data. Record approved tabs/windows, preferably demo projects or sanitized reports.
+6. Edit: assemble clips, captions, overlays, snippets, music, and exports with the smallest existing toolchain. Save commands/projects.
+7. Reuse: save reusable output in the marketing repo, not SHAFT_ENGINE. If no repo path is given, ask first. Use `brand/theme.json`, `brand/assets/`, `snippets/`, `music/`, and `campaigns/<yyyy-mm>-<slug>/{brief.md,script.md,storyboard.md,captures/,renders/,exports/,manifest.json}`.
+
+## Output
+
+Planning: campaign slate, storyboard table, asset checklist, capture plan, and theme notes.
+
+Production: scripts/storyboards, captures, code-card renders, captions, music source/brief, edit manifest, final exports, and marketing-repo paths.
+
+Guardrails: no unsupported benchmarks, 3rd-party logos, security claims, generated final code text, secrets, or tokens.

--- a/.memory/events.jsonl
+++ b/.memory/events.jsonl
@@ -83,3 +83,4 @@
 {"actor":"agent","event":"memory.created","id":"decision.keep-shaft-mcp-webdriver-default-with-opt-in-playwright-tools","timestamp":"2026-06-21T13:16:01+03:00"}
 {"actor":"agent","event":"memory.updated","id":"gotcha.graphify-updates-use-installed-cli-subcommands","timestamp":"2026-06-21T15:23:04+03:00"}
 {"actor":"agent","event":"memory.updated","id":"constraint.delegate-broadly-to-spark","timestamp":"2026-06-21T20:33:51+03:00"}
+{"actor":"agent","event":"memory.updated","id":"decision.agent-guidance-progressive-disclosure","timestamp":"2026-06-23T11:42:44+03:00"}

--- a/.memory/memory/decisions/agent-guidance-progressive-disclosure.json
+++ b/.memory/memory/decisions/agent-guidance-progressive-disclosure.json
@@ -1,14 +1,18 @@
 {
   "body_path": "memory/decisions/agent-guidance-progressive-disclosure.md",
-  "content_hash": "sha256:b80a257f34df4e8931e9316109043fc889dd5b90cf98bbbb508c7551faad4f53",
+  "content_hash": "sha256:58addec188b150aa87de77e6ccf48d514428e2df140880e32553f57553cac8df",
   "created_at": "2026-06-15T17:06:51+03:00",
   "evidence": [
     {
-      "id": "AGENTS.md",
+      "id": "scripts/ci/agent_guidance_budget.json",
       "kind": "file"
     },
     {
-      "id": "scripts/ci/validate_agent_guidance.py",
+      "id": ".agents/skills/shaft-marketing-ad-producer/SKILL.md",
+      "kind": "file"
+    },
+    {
+      "id": ".github/skills/shaft-marketing-ad-producer/SKILL.md",
       "kind": "file"
     }
   ],
@@ -40,5 +44,5 @@
   ],
   "title": "Use progressive disclosure for agent guidance",
   "type": "decision",
-  "updated_at": "2026-06-15T17:06:51+03:00"
+  "updated_at": "2026-06-23T11:42:44+03:00"
 }

--- a/.memory/memory/decisions/agent-guidance-progressive-disclosure.md
+++ b/.memory/memory/decisions/agent-guidance-progressive-disclosure.md
@@ -1,1 +1,1 @@
-Keep global guidance compact. Route task-specific rules through exactly five thin Codex bridge skills to canonical scoped rules or playbooks. Deterministic validators enforce budgets, routing, and duplicate-content limits.
+Keep global guidance compact. Route task-specific rules through allowlisted thin Codex bridge skills to canonical scoped rules or playbooks. The current skill allowlist lives in scripts/ci/agent_guidance_budget.json. Deterministic validators enforce budgets, routing, and duplicate-content limits.

--- a/scripts/ci/agent_guidance_budget.json
+++ b/scripts/ci/agent_guidance_budget.json
@@ -68,12 +68,14 @@
       "flaky-test-stabilizer",
       "framework-source-rules",
       "java-test-rules",
-      "release-dependency-guard"
+      "release-dependency-guard",
+      "shaft-marketing-ad-producer"
     ],
     ".github/skills": [
       "ci-failure-investigator",
       "flaky-test-stabilizer",
-      "release-dependency-guard"
+      "release-dependency-guard",
+      "shaft-marketing-ad-producer"
     ]
   },
   "skill_budgets": {


### PR DESCRIPTION
## Summary
- add a discoverable Codex bridge skill for SHAFT marketing ad planning and production
- add the canonical playbook with the selected skill stack for scripts, scenes, capture, code visuals, music, editing, and reusable marketing assets
- update the agent guidance allowlist and Memory note from a fixed five-skill rule to the validator-backed allowlist

## Validation
- py -3 scripts/ci/validate_agent_guidance.py
- py -3 scripts/ci/validate_agent_setup.py
- py -3 C:\Users\Mohab\.codex\skills\.system\skill-creator\scripts\quick_validate.py .agents\skills\shaft-marketing-ad-producer
- py -3 C:\Users\Mohab\.codex\skills\.system\skill-creator\scripts\quick_validate.py .github\skills\shaft-marketing-ad-producer
- memory check (passed; reported pre-existing Memory warnings for delegate-only-when-needed-for-correctness, powershell-shell-sensitive-args, and minimal-nonredundant-validation)