### PR TITLE
Enhance modular upgrader project coverage

### DIFF
--- a/shaft-upgrader/upgrade_to_modular_shaft.py
+++ b/shaft-upgrader/upgrade_to_modular_shaft.py
@@ -59,6 +59,36 @@ MAX_AI_FILE_CHARS = 80_000
 MAX_AI_CHANGE_CHARS = 500_000
 MAVEN_NAMESPACE = "http://maven.apache.org/POM/4.0.0"
 XSI_NAMESPACE = "http://www.w3.org/2001/XMLSchema-instance"
+UPGRADE_TYPES = ("basic", "session", "full")
+SOURCE_UPGRADE_TYPES = {"session", "full"}
+SOURCE_UPGRADE_STACKS = {"selenium", "appium"}
+SELENIUM_APPIUM_DRIVER_TYPES = (
+    "ChromeDriver",
+    "FirefoxDriver",
+    "EdgeDriver",
+    "SafariDriver",
+    "RemoteWebDriver",
+    "AndroidDriver",
+    "IOSDriver",
+    "AppiumDriver",
+)
+DRIVER_TYPE_PATTERN = "|".join(re.escape(driver_type) for driver_type in SELENIUM_APPIUM_DRIVER_TYPES)
+DRIVER_CONSTRUCTOR_PATTERN = re.compile(
+    rf"new\s+(?P<driver>{DRIVER_TYPE_PATTERN})\s*\((?P<args>[^;\n]*)\)"
+)
+WEBDRIVER_DECLARATION_PATTERNS = (
+    re.compile(r"(?<![\w.])WebDriver(?=\s+[A-Za-z_$][\w$]*\s*(?:[=;,\)]|\())"),
+    re.compile(r"(?<![\w.])WebDriver(?=\s*[>,])"),
+    re.compile(r"\borg\.openqa\.selenium\.WebDriver\b"),
+)
+SHAFT_DRIVER_VARIABLE_PATTERN = re.compile(r"\bSHAFT\.GUI\.WebDriver\s+([A-Za-z_$][\w$]*)")
+UNSUPPORTED_FULL_UPGRADE_PATTERNS = (
+    ("WebElement variables need manual element/action migration", re.compile(r"\bWebElement\s+")),
+    ("findElements collection handling needs manual migration", re.compile(r"\.findElements\s*\(")),
+    ("JavascriptExecutor calls need manual migration", re.compile(r"\bJavascriptExecutor\b|\.executeScript\s*\(")),
+    ("Selenium Actions chains need manual migration", re.compile(r"\bnew\s+Actions\s*\(")),
+    ("explicit Selenium waits need manual migration", re.compile(r"\bWebDriverWait\b|ExpectedConditions\s*\.")),
+)
 
 IGNORED_DIRECTORIES = {
     ".git",
@@ -249,6 +279,20 @@ class ProjectAnalysis:
 
 
 @dataclasses.dataclass(frozen=True)
+class SourceMigration:
+    """Source-file rewrites prepared for session or full upgrades."""
+
+    transformed_files: Mapping[Path, str] = dataclasses.field(default_factory=dict)
+    changes_by_file: Mapping[Path, tuple[str, ...]] = dataclasses.field(default_factory=dict)
+    unsupported_by_file: Mapping[Path, tuple[str, ...]] = dataclasses.field(default_factory=dict)
+
+    @property
+    def changed_files(self) -> tuple[Path, ...]:
+        """Return source files whose contents should be replaced."""
+        return tuple(self.transformed_files)
+
+
+@dataclasses.dataclass(frozen=True)
 class UpgradeExecution:
     """Final transaction outcome."""
 
@@ -257,6 +301,8 @@ class UpgradeExecution:
     compile_attempts: int
     ai_attempts: int
     final_result: CommandResult
+    upgrade_type: str = "basic"
+    source_migration: SourceMigration = dataclasses.field(default_factory=SourceMigration)
 
 
 @dataclasses.dataclass
@@ -1201,6 +1247,264 @@ def format_diff(path: Path, before: bytes, after: bytes, project_root: Path) -> 
     )
 
 
+def source_upgrade_supported(analysis: ProjectAnalysis) -> bool:
+    """Return whether source rewrites are eligible for this project."""
+    return bool(SOURCE_UPGRADE_STACKS.intersection(analysis.stacks))
+
+
+def validate_upgrade_type(analysis: ProjectAnalysis, upgrade_type: str) -> None:
+    """Validate the requested upgrade type against the detected project shape."""
+    if upgrade_type not in UPGRADE_TYPES:
+        raise UpgradeError(f"Unsupported upgrade type: {upgrade_type}.")
+    if upgrade_type in SOURCE_UPGRADE_TYPES and not source_upgrade_supported(analysis):
+        detected = ", ".join(analysis.stacks) if analysis.stacks else "none"
+        raise UpgradeError(
+            f"{upgrade_type.capitalize()} upgrade requires a Selenium/Appium project. "
+            f"Detected stacks: {detected}."
+        )
+
+
+def agent_upgrade_plan(
+    analysis: ProjectAnalysis,
+    version: str,
+    script_path: str = "shaft-upgrader/upgrade_to_modular_shaft.py",
+) -> dict[str, object]:
+    """Return a machine-readable upgrade menu for AI agents."""
+    source_eligible = source_upgrade_supported(analysis)
+    source_reason = (
+        "Selenium/Appium project detected."
+        if source_eligible
+        else "Requires a Selenium/Appium project; detected stacks: "
+        + (", ".join(analysis.stacks) if analysis.stacks else "none")
+        + "."
+    )
+
+    def command(upgrade_type: str) -> str:
+        return (
+            f"python {shlex.quote(script_path)} --project "
+            f"{shlex.quote(str(analysis.project_root))} --upgrade-type {upgrade_type} --yes"
+        )
+
+    return {
+        "schemaVersion": 1,
+        "project": str(analysis.project_root),
+        "shaftVersion": version,
+        "detected": {
+            "stacks": list(analysis.stacks),
+            "runners": list(analysis.runners),
+            "candidatePoms": [
+                str(path.relative_to(analysis.project_root)) for path in analysis.candidate_poms
+            ],
+            "optionalModules": list(analysis.optional_modules),
+        },
+        "upgradeTypes": [
+            {
+                "id": "basic",
+                "risk": "low",
+                "eligible": True,
+                "reason": "Supported Maven automation project detected.",
+                "description": (
+                    "Upgrade the POM to modular SHAFT, enable SHAFT for new tests, "
+                    "and preserve existing test source."
+                ),
+                "recommendedCommand": command("basic"),
+            },
+            {
+                "id": "session",
+                "risk": "medium",
+                "eligible": source_eligible,
+                "reason": source_reason,
+                "description": (
+                    "Run the basic upgrade, then wrap Selenium/Appium driver session "
+                    "creation with SHAFT.GUI.WebDriver."
+                ),
+                "recommendedCommand": command("session"),
+            },
+            {
+                "id": "full",
+                "risk": "high",
+                "eligible": source_eligible,
+                "reason": source_reason,
+                "description": (
+                    "Run the session upgrade, then replace simple Selenium browser "
+                    "and element actions with SHAFT engine calls."
+                ),
+                "manualFollowUp": "Element and browser assertions remain manual.",
+                "recommendedCommand": command("full"),
+            },
+        ],
+    }
+
+
+def ensure_shaft_import(text: str) -> str:
+    """Add the SHAFT import required by rewritten Java source."""
+    if "import com.shaft.driver.SHAFT;" in text:
+        return text
+    newline = "\r\n" if "\r\n" in text else "\n"
+    import_line = f"import com.shaft.driver.SHAFT;{newline}"
+    lines = text.splitlines(keepends=True)
+
+    last_import_index = -1
+    for index, line in enumerate(lines):
+        if line.strip().startswith("import "):
+            last_import_index = index
+    if last_import_index >= 0:
+        lines.insert(last_import_index + 1, import_line)
+        return "".join(lines)
+
+    for index, line in enumerate(lines):
+        if line.strip().startswith("package ") and line.strip().endswith(";"):
+            lines.insert(index + 1, import_line)
+            return "".join(lines)
+
+    return import_line + text
+
+
+def migrate_session_source(text: str) -> tuple[str, tuple[str, ...]]:
+    """Wrap basic Selenium/Appium driver construction with SHAFT's driver session."""
+    changes: list[str] = []
+    lines = text.splitlines(keepends=True)
+    migrated_lines: list[str] = []
+    declaration_count = 0
+    constructor_count = 0
+
+    for line in lines:
+        migrated = line
+        stripped = line.strip()
+        if not stripped.startswith("import "):
+            for pattern in WEBDRIVER_DECLARATION_PATTERNS:
+                migrated, count = pattern.subn("SHAFT.GUI.WebDriver", migrated)
+                declaration_count += count
+        if "new SHAFT.GUI.WebDriver(" not in migrated:
+            migrated, count = DRIVER_CONSTRUCTOR_PATTERN.subn(
+                lambda match: (
+                    f"new SHAFT.GUI.WebDriver(new {match.group('driver')}"
+                    f"({match.group('args')}))"
+                ),
+                migrated,
+            )
+            constructor_count += count
+        migrated_lines.append(migrated)
+
+    migrated_text = "".join(migrated_lines)
+    if declaration_count or constructor_count:
+        migrated_text = ensure_shaft_import(migrated_text)
+        changes.append("driver session")
+        close_count = 0
+        for variable in shaft_driver_variables(migrated_text):
+            migrated_text, count = re.subn(
+                rf"\b{re.escape(variable)}\.close\(\)",
+                f"{variable}.quit()",
+                migrated_text,
+            )
+            close_count += count
+        if close_count:
+            changes.append("driver termination")
+    return migrated_text, tuple(changes)
+
+
+def shaft_driver_variables(text: str) -> tuple[str, ...]:
+    """Return SHAFT driver variable names from rewritten Java source."""
+    return tuple(dict.fromkeys(SHAFT_DRIVER_VARIABLE_PATTERN.findall(text)))
+
+
+def migrate_full_source(text: str) -> tuple[str, tuple[str, ...], tuple[str, ...]]:
+    """Replace simple Selenium actions with SHAFT engine action calls."""
+    changes: list[str] = []
+    migrated = text
+    driver_variables = shaft_driver_variables(migrated)
+
+    for variable in driver_variables:
+        variable_pattern = re.escape(variable)
+        replacements: tuple[tuple[str, re.Pattern[str], str], ...] = (
+            (
+                "browser navigation",
+                re.compile(rf"\b{variable_pattern}\.navigate\(\)\.to\((?P<url>[^;\n]+)\)"),
+                rf"{variable}.browser().navigateToURL(\g<url>)",
+            ),
+            (
+                "browser navigation",
+                re.compile(rf"\b{variable_pattern}\.get\((?P<url>[^;\n]+)\)"),
+                rf"{variable}.browser().navigateToURL(\g<url>)",
+            ),
+            (
+                "element type",
+                re.compile(
+                    rf"\b{variable_pattern}\.findElement\((?P<locator>[^;\n]+)\)"
+                    rf"\.sendKeys\((?P<text>[^;\n]*)\)"
+                ),
+                rf"{variable}.element().type(\g<locator>, \g<text>)",
+            ),
+            (
+                "element click",
+                re.compile(
+                    rf"\b{variable_pattern}\.findElement\((?P<locator>[^;\n]+)\)\.click\(\)"
+                ),
+                rf"{variable}.element().click(\g<locator>)",
+            ),
+            (
+                "element text",
+                re.compile(
+                    rf"\b{variable_pattern}\.findElement\((?P<locator>[^;\n]+)\)\.getText\(\)"
+                ),
+                rf"{variable}.element().get().text(\g<locator>)",
+            ),
+            (
+                "element visibility",
+                re.compile(
+                    rf"\b{variable_pattern}\.findElement\((?P<locator>[^;\n]+)\)"
+                    rf"\.isDisplayed\(\)"
+                ),
+                rf"{variable}.element().get().isDisplayed(\g<locator>)",
+            ),
+            (
+                "element attribute",
+                re.compile(
+                    rf"\b{variable_pattern}\.findElement\((?P<locator>[^;\n]+)\)"
+                    rf"\.getAttribute\((?P<name>[^;\n]+)\)"
+                ),
+                rf"{variable}.element().get().attribute(\g<locator>, \g<name>)",
+            ),
+        )
+        for label, pattern, replacement in replacements:
+            migrated, count = pattern.subn(replacement, migrated)
+            if count and label not in changes:
+                changes.append(label)
+
+    unsupported = tuple(
+        reason for reason, pattern in UNSUPPORTED_FULL_UPGRADE_PATTERNS if pattern.search(migrated)
+    )
+    return migrated, tuple(changes), unsupported
+
+
+def collect_source_migration(analysis: ProjectAnalysis, upgrade_type: str) -> SourceMigration:
+    """Prepare Java source changes for the requested upgrade type."""
+    validate_upgrade_type(analysis, upgrade_type)
+    if upgrade_type == "basic":
+        return SourceMigration()
+
+    transformed_files: dict[Path, str] = {}
+    changes_by_file: dict[Path, tuple[str, ...]] = {}
+    unsupported_by_file: dict[Path, tuple[str, ...]] = {}
+    for path in sorted(iter_scan_files(analysis.project_root), key=lambda item: str(item)):
+        if path.suffix.lower() != ".java":
+            continue
+        original = path.read_text(encoding="utf-8", errors="replace")
+        migrated, session_changes = migrate_session_source(original)
+        changes = list(session_changes)
+        unsupported: tuple[str, ...] = ()
+        if upgrade_type == "full":
+            migrated, full_changes, unsupported = migrate_full_source(migrated)
+            changes.extend(label for label in full_changes if label not in changes)
+        if migrated != original:
+            transformed_files[path] = migrated
+            changes_by_file[path] = tuple(changes)
+        if unsupported:
+            unsupported_by_file[path] = unsupported
+
+    return SourceMigration(transformed_files, changes_by_file, unsupported_by_file)
+
+
 def execute_upgrade_transaction(
     analysis: ProjectAnalysis,
     version: str,
@@ -1209,11 +1513,12 @@ def execute_upgrade_transaction(
     compile_runner: Callable[[Sequence[str], Path, int], CommandResult] = run_command,
     repair_client: OpenAIRepairClient | None = None,
     skip_baseline_compile: bool = False,
+    upgrade_type: str = "basic",
 ) -> UpgradeExecution:
     """Apply, compile, optionally repair, and commit or rollback the migration."""
+    source_migration = collect_source_migration(analysis, upgrade_type)
     compile_attempts = 0
     ai_attempts = 0
-    successful_result = CommandResult(tuple(compile_command), 0, "", "")
 
     if not skip_baseline_compile:
         log("Compiling the unchanged project to establish a valid baseline...")
@@ -1237,6 +1542,8 @@ def execute_upgrade_transaction(
     try:
         for pom, content in transformed.items():
             transaction.write_bytes(pom, content)
+        for source_file, content in source_migration.transformed_files.items():
+            transaction.write_text(source_file, content)
         validate_upgraded_poms(analysis.candidate_poms, version, analysis.optional_modules)
 
         log("Compiling the upgraded project...")
@@ -1244,11 +1551,27 @@ def execute_upgrade_transaction(
         compile_attempts += 1
         if result.returncode == 0:
             transaction.commit()
-            return UpgradeExecution(True, False, compile_attempts, ai_attempts, result)
+            return UpgradeExecution(
+                True,
+                False,
+                compile_attempts,
+                ai_attempts,
+                result,
+                upgrade_type,
+                source_migration,
+            )
 
         if repair_client is None:
             transaction.rollback()
-            return UpgradeExecution(False, True, compile_attempts, ai_attempts, result)
+            return UpgradeExecution(
+                False,
+                True,
+                compile_attempts,
+                ai_attempts,
+                result,
+                upgrade_type,
+                source_migration,
+            )
 
         for attempt in range(1, MAX_AI_REPAIR_ATTEMPTS + 1):
             ai_attempts += 1
@@ -1299,10 +1622,26 @@ def execute_upgrade_transaction(
                     analysis.optional_modules,
                 )
                 transaction.commit()
-                return UpgradeExecution(True, False, compile_attempts, ai_attempts, result)
+                return UpgradeExecution(
+                    True,
+                    False,
+                    compile_attempts,
+                    ai_attempts,
+                    result,
+                    upgrade_type,
+                    source_migration,
+                )
 
         transaction.rollback()
-        return UpgradeExecution(False, True, compile_attempts, ai_attempts, result)
+        return UpgradeExecution(
+            False,
+            True,
+            compile_attempts,
+            ai_attempts,
+            result,
+            upgrade_type,
+            source_migration,
+        )
     except BaseException:
         transaction.rollback()
         raise
@@ -1344,10 +1683,14 @@ def write_report(
     execution: UpgradeExecution,
 ) -> None:
     """Write an optional machine-readable migration report."""
+    def relative(path: Path) -> str:
+        return path.relative_to(analysis.project_root).as_posix()
+
     payload = {
         "schemaVersion": 1,
         "project": str(analysis.project_root),
         "shaftVersion": version,
+        "upgradeType": execution.upgrade_type,
         "legacyProject": analysis.legacy_project,
         "existingModularProject": analysis.existing_modular_project,
         "stacks": list(analysis.stacks),
@@ -1363,6 +1706,17 @@ def write_report(
         "rolledBack": execution.rolled_back,
         "compileAttempts": execution.compile_attempts,
         "aiAttempts": execution.ai_attempts,
+        "sourceMigration": {
+            "changedFiles": [relative(path) for path in execution.source_migration.changed_files],
+            "changesByFile": {
+                relative(path): list(items)
+                for path, items in execution.source_migration.changes_by_file.items()
+            },
+            "unsupportedByFile": {
+                relative(path): list(items)
+                for path, items in execution.source_migration.unsupported_by_file.items()
+            },
+        },
     }
     atomic_write(report_path.resolve(), (json.dumps(payload, indent=2) + "\n").encode("utf-8"))
 
@@ -1387,6 +1741,9 @@ def build_parser() -> argparse.ArgumentParser:
   python shaft-upgrader/upgrade_to_modular_shaft.py --project .
   python shaft-upgrader/upgrade_to_modular_shaft.py --project . --yes
   python shaft-upgrader/upgrade_to_modular_shaft.py --project . --dry-run
+  python shaft-upgrader/upgrade_to_modular_shaft.py --project . --agent-plan
+  python shaft-upgrader/upgrade_to_modular_shaft.py --project . --upgrade-type session --yes
+  python shaft-upgrader/upgrade_to_modular_shaft.py --project . --upgrade-type full --yes
   python shaft-upgrader/upgrade_to_modular_shaft.py --project . --shaft-version 10.2.20260609 --yes
 
 Optional AI repair:
@@ -1419,11 +1776,25 @@ Optional AI repair:
         help="Compilation timeout in seconds. Default: 900.",
     )
     parser.add_argument(
+        "--upgrade-type",
+        choices=UPGRADE_TYPES,
+        default="basic",
+        help=(
+            "Upgrade depth: basic updates POMs only; session also wraps Selenium/Appium "
+            "driver sessions; full also rewrites simple Selenium actions. Default: basic."
+        ),
+    )
+    parser.add_argument(
+        "--agent-plan",
+        action="store_true",
+        help="Print JSON describing the basic/session/full options for AI agents, then exit.",
+    )
+    parser.add_argument(
         "--skip-baseline-compile",
         action="store_true",
         help="Skip compilation before editing. Not recommended.",
     )
-    parser.add_argument("--dry-run", action="store_true", help="Print POM diffs without writing or compiling.")
+    parser.add_argument("--dry-run", action="store_true", help="Print diffs without writing or compiling.")
     parser.add_argument("--yes", action="store_true", help="Apply without interactive confirmation.")
     parser.add_argument(
         "--report",
@@ -1459,15 +1830,40 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         analysis = analyze_project(args.project)
         version = args.shaft_version or resolve_latest_shaft_version()
+        if args.agent_plan:
+            print(
+                json.dumps(
+                    agent_upgrade_plan(
+                        analysis,
+                        version,
+                        "shaft-upgrader/upgrade_to_modular_shaft.py",
+                    ),
+                    indent=2,
+                )
+            )
+            return 0
+
+        validate_upgrade_type(analysis, args.upgrade_type)
         print_analysis(analysis, version)
+        log(f"Upgrade type: {args.upgrade_type}")
 
         transformed = {
             pom: transform_pom_bytes(pom.read_bytes(), version, analysis.optional_modules)
             for pom in analysis.candidate_poms
         }
+        source_migration = collect_source_migration(analysis, args.upgrade_type)
         if args.dry_run:
             for pom, after in transformed.items():
                 print(format_diff(pom, pom.read_bytes(), after, analysis.project_root))
+            for source_file, after in source_migration.transformed_files.items():
+                print(
+                    format_diff(
+                        source_file,
+                        source_file.read_bytes(),
+                        after.encode("utf-8"),
+                        analysis.project_root,
+                    )
+                )
             return 0
 
         if not args.yes and not confirm_upgrade():
@@ -1498,6 +1894,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             args.compile_timeout,
             repair_client=repair_client,
             skip_baseline_compile=args.skip_baseline_compile,
+            upgrade_type=args.upgrade_type,
         )
         if args.report:
             write_report(args.report, analysis, version, execution)

--- a/shaft-upgrader/upgrade_to_modular_shaft.py
+++ b/shaft-upgrader/upgrade_to_modular_shaft.py
@@ -98,7 +98,7 @@ SUPPORTED_STACK_MARKERS = {
         "io.appium.java_client.",
     ),
     "rest-assured": (
-        "io.rest-assured:rest-assured",
+        "io.rest-assured:",
         "io.restassured.",
     ),
 }
@@ -114,9 +114,11 @@ SUPPORTED_RUNNER_MARKERS = {
     ),
     "junit": (
         "org.junit.jupiter:",
+        "org.junit.platform:",
         "org.junit:",
         "junit:junit",
         "org.junit.jupiter.",
+        "org.junit.platform.",
         "org.junit.",
     ),
 }
@@ -171,9 +173,8 @@ OPTIONAL_PATTERNS: dict[str, tuple[tuple[str, re.Pattern[str]], ...]] = {
         (
             "BrowserStack SDK property",
             re.compile(
-                r"(?:SHAFT\.Properties\.browserStack\b|browserStack\.|"
-                r"(?:platformsList|parallelsPerPlatform|"
-                r"browserstackAutomation|customBrowserStackYmlPath))"
+                r"(?:(?:SHAFT\.Properties\.browserStack(?:\.set\(\))?\s*\.\s*|browserStack\.)?"
+                r"(?:platformsList|parallelsPerPlatform|browserstackAutomation|customBrowserStackYmlPath))"
             ),
         ),
         (
@@ -518,7 +519,7 @@ def coordinates_have_supported_stack(coordinates: set[str]) -> bool:
         any(coordinate.startswith("io.cucumber:") for coordinate in coordinates)
         or any(coordinate.startswith("org.seleniumhq.selenium:") for coordinate in coordinates)
         or "io.appium:java-client" in coordinates
-        or "io.rest-assured:rest-assured" in coordinates
+        or any(coordinate.startswith("io.rest-assured:") for coordinate in coordinates)
     )
 
 
@@ -529,6 +530,7 @@ def coordinates_have_supported_runner(coordinates: set[str]) -> bool:
         or coordinate == "org.testng:testng"
         or coordinate.startswith("org.junit:")
         or coordinate.startswith("org.junit.jupiter:")
+        or coordinate.startswith("org.junit.platform:")
         or coordinate == "junit:junit"
         for coordinate in coordinates
     )
@@ -595,7 +597,7 @@ def analyze_project(project_root: Path) -> ProjectAnalysis:
         for coordinates in pom_coordinates.values()
     )
     existing_modular_project = any(
-        any(f"{SHAFT_GROUP}:{artifact}" in coordinates for artifact in {ENGINE_ARTIFACT, *OPTIONAL_MODULES})
+        any(f"{SHAFT_GROUP}:{artifact}" in coordinates for artifact in {ENGINE_ARTIFACT, BOM_ARTIFACT, *OPTIONAL_MODULES})
         for coordinates in pom_coordinates.values()
     )
     stacks, runners, _ = detect_markers(project_root, all_poms)
@@ -609,7 +611,7 @@ def analyze_project(project_root: Path) -> ProjectAnalysis:
         )
         or (
             coordinates_have_supported_stack(coordinates)
-            and coordinates_have_supported_runner(coordinates)
+            and (coordinates_have_supported_runner(coordinates) or runners)
         )
     ]
 
@@ -751,7 +753,7 @@ def dependency_template(root: ET.Element) -> ET.Element | None:
         if local_name(dependency.tag) != "dependency":
             continue
         group, artifact = dependency_coordinate(dependency)
-        if group == SHAFT_GROUP and artifact in SHAFT_ARTIFACTS:
+        if group == SHAFT_GROUP and artifact in SHAFT_ARTIFACTS and artifact != BOM_ARTIFACT:
             return dependency
     return None
 
@@ -948,6 +950,11 @@ def validate_upgraded_poms(
             raise UpgradeError(f"{pom}: shaft-bom import must use ${{shaft.version}}.")
 
 
+def is_stable_release(version: str) -> bool:
+    """Return whether a Maven version is a stable release, not preview metadata."""
+    return bool(version) and not re.search(r"(?i)(?:[-.](?:alpha|beta|rc|m)\d*|snapshot)$", version)
+
+
 def metadata_release(xml_text: str) -> str:
     """Extract the latest release from Maven metadata."""
     try:
@@ -957,18 +964,20 @@ def metadata_release(xml_text: str) -> str:
     versioning = direct_child(root, "versioning")
     if versioning is None:
         raise UpgradeError("Maven metadata has no <versioning> section.")
-    release = child_text(versioning, "release") or child_text(versioning, "latest")
-    if not release:
-        versions = direct_child(versioning, "versions")
-        available = [
-            (child.text or "").strip()
-            for child in list(versions or [])
-            if local_name(child.tag) == "version" and (child.text or "").strip()
-        ]
-        release = available[-1] if available else ""
-    if not release or release.endswith("-SNAPSHOT"):
-        raise UpgradeError("No stable modular SHAFT release was found in Maven metadata.")
-    return release
+    versions = direct_child(versioning, "versions")
+    available = [
+        (child.text or "").strip()
+        for child in (list(versions) if versions is not None else [])
+        if local_name(child.tag) == "version" and (child.text or "").strip()
+    ]
+    for release in (
+        child_text(versioning, "release"),
+        child_text(versioning, "latest"),
+        *reversed(available),
+    ):
+        if is_stable_release(release):
+            return release
+    raise UpgradeError("No stable modular SHAFT release was found in Maven metadata.")
 
 
 def resolve_latest_shaft_version(
@@ -1060,6 +1069,9 @@ def run_command(command: Sequence[str], cwd: Path, timeout_seconds: int) -> Comm
 
 def extract_response_output_text(response: Mapping[str, object]) -> str:
     """Extract the assistant output text from a Responses API payload."""
+    output_text = response.get("output_text")
+    if isinstance(output_text, str):
+        return output_text
     for item in response.get("output", []):
         if not isinstance(item, Mapping) or item.get("type") != "message":
             continue

--- a/shaft-upgrader/upgrade_to_modular_shaft.py
+++ b/shaft-upgrader/upgrade_to_modular_shaft.py
@@ -150,7 +150,10 @@ OPTIONAL_PATTERNS: dict[str, tuple[tuple[str, re.Pattern[str]], ...]] = {
     "shaft-video": (
         (
             "desktop recording enabled",
-            re.compile(r"(?:videoParamsRecordVideo|videoParams\.recordVideo)\s*[=:]\s*true", re.IGNORECASE),
+            re.compile(
+                r"(?:videoParamsRecordVideo|videoParams[._]recordVideo)\s*(?:[=:]|\()\s*true",
+                re.IGNORECASE,
+            ),
         ),
         (
             "desktop recording API",
@@ -168,8 +171,9 @@ OPTIONAL_PATTERNS: dict[str, tuple[tuple[str, re.Pattern[str]], ...]] = {
         (
             "BrowserStack SDK property",
             re.compile(
-                r"(?:browserStack\.)?(?:platformsList|parallelsPerPlatform|"
-                r"browserstackAutomation|customBrowserStackYmlPath)"
+                r"(?:SHAFT\.Properties\.browserStack\b|browserStack\.|"
+                r"(?:platformsList|parallelsPerPlatform|"
+                r"browserstackAutomation|customBrowserStackYmlPath))"
             ),
         ),
         (
@@ -564,6 +568,8 @@ def scan_optional_modules(project_root: Path) -> dict[str, tuple[str, ...]]:
         text = read_text(path)
         if not text:
             continue
+        if path.name == "pom.xml":
+            text = f"{text}\n" + "\n".join(sorted(dependency_coordinates(path)))
         relative = path.relative_to(project_root).as_posix()
         for module, patterns in OPTIONAL_PATTERNS.items():
             for reason, pattern in patterns:

--- a/tests/scripts/test_upgrade_to_modular_shaft.py
+++ b/tests/scripts/test_upgrade_to_modular_shaft.py
@@ -56,6 +56,18 @@ class UpgradeToModularShaftTests(unittest.TestCase):
         </versioning></metadata>"""
         self.assertEqual(upgrade.metadata_release(metadata), "1.9")
 
+    def test_metadata_release_falls_back_when_release_is_snapshot(self):
+        metadata = """<metadata><versioning><latest>2.1-SNAPSHOT</latest><release>2.1-SNAPSHOT</release>
+        <versions><version>2.0</version><version>2.1-SNAPSHOT</version></versions>
+        </versioning></metadata>"""
+        self.assertEqual(upgrade.metadata_release(metadata), "2.0")
+
+    def test_metadata_release_ignores_unstable_qualifiers(self):
+        metadata = """<metadata><versioning>
+        <versions><version>2.0</version><version>2.1-rc1</version><version>2.2-M1</version></versions>
+        </versioning></metadata>"""
+        self.assertEqual(upgrade.metadata_release(metadata), "2.0")
+
     def test_transform_replaces_legacy_dependency_and_imports_bom(self):
         transformed = upgrade.transform_pom_bytes(
             SIMPLE_POM.encode(),
@@ -273,7 +285,7 @@ class UpgradeToModularShaftTests(unittest.TestCase):
             java.write_text(
                 """class Demo {
                     void configure() {
-                        SHAFT.Properties.browserStack.set().deviceName("Pixel 9");
+                        SHAFT.Properties.browserStack.set().platformsList("[{}]");
                         SHAFT.Properties.visuals.set().videoParamsRecordVideo(true);
                     }
                 }""",
@@ -284,6 +296,24 @@ class UpgradeToModularShaftTests(unittest.TestCase):
 
         self.assertTrue(evidence["shaft-video"])
         self.assertTrue(evidence["shaft-browserstack"])
+
+    def test_direct_browserstack_settings_do_not_trigger_sdk_module(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            java = root / "src/test/java/Demo.java"
+            java.parent.mkdir(parents=True)
+            java.write_text(
+                """class Demo {
+                    void configure() {
+                        SHAFT.Properties.browserStack.set().deviceName("Pixel 9");
+                    }
+                }""",
+                encoding="utf-8",
+            )
+
+            evidence = upgrade.scan_optional_modules(root)
+
+        self.assertFalse(evidence["shaft-browserstack"])
 
     def test_all_supported_native_stack_and_runner_combinations_are_detected(self):
         stacks = {
@@ -340,6 +370,153 @@ class UpgradeToModularShaftTests(unittest.TestCase):
 
         self.assertEqual(analysis.stacks, ("selenium",))
         self.assertEqual(analysis.runners, ("junit",))
+
+    def test_rest_assured_family_coordinate_is_supported(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pom.xml").write_text(
+                """<project xmlns="http://maven.apache.org/POM/4.0.0">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>example</groupId><artifactId>api</artifactId><version>1</version>
+                <dependencies>
+                  <dependency><groupId>io.rest-assured</groupId>
+                    <artifactId>json-schema-validator</artifactId><version>1</version></dependency>
+                  <dependency><groupId>org.testng</groupId>
+                    <artifactId>testng</artifactId><version>1</version></dependency>
+                </dependencies></project>""",
+                encoding="utf-8",
+            )
+
+            analysis = upgrade.analyze_project(root)
+
+        self.assertEqual(analysis.stacks, ("rest-assured",))
+        self.assertEqual(analysis.runners, ("testng",))
+
+    def test_bom_only_modular_project_is_supported(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pom.xml").write_text(
+                """<project xmlns="http://maven.apache.org/POM/4.0.0">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>example</groupId><artifactId>modular</artifactId><version>1</version>
+                <dependencyManagement><dependencies>
+                  <dependency><groupId>io.github.shafthq</groupId>
+                    <artifactId>shaft-bom</artifactId><version>10.2.20260623</version>
+                    <type>pom</type><scope>import</scope></dependency>
+                </dependencies></dependencyManagement>
+                </project>""",
+                encoding="utf-8",
+            )
+
+            analysis = upgrade.analyze_project(root)
+
+        self.assertTrue(analysis.existing_modular_project)
+
+    def test_native_child_pom_inherits_runner_detection_from_parent(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pom.xml").write_text(
+                """<project xmlns="http://maven.apache.org/POM/4.0.0">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>example</groupId><artifactId>parent</artifactId><version>1</version>
+                <packaging>pom</packaging>
+                <modules><module>web-tests</module></modules>
+                <dependencies>
+                  <dependency><groupId>org.testng</groupId>
+                    <artifactId>testng</artifactId><version>1</version></dependency>
+                </dependencies></project>""",
+                encoding="utf-8",
+            )
+            child = root / "web-tests"
+            child.mkdir()
+            (child / "pom.xml").write_text(
+                """<project xmlns="http://maven.apache.org/POM/4.0.0">
+                <modelVersion>4.0.0</modelVersion>
+                <parent><groupId>example</groupId><artifactId>parent</artifactId><version>1</version></parent>
+                <artifactId>web-tests</artifactId>
+                <dependencies>
+                  <dependency><groupId>org.seleniumhq.selenium</groupId>
+                    <artifactId>selenium-java</artifactId><version>1</version></dependency>
+                </dependencies></project>""",
+                encoding="utf-8",
+            )
+
+            analysis = upgrade.analyze_project(root)
+
+        self.assertEqual(
+            [pom.relative_to(root).as_posix() for pom in analysis.candidate_poms],
+            ["web-tests/pom.xml"],
+        )
+
+    def test_native_child_with_junit_platform_coordinate_is_candidate(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pom.xml").write_text(
+                """<project xmlns="http://maven.apache.org/POM/4.0.0">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>example</groupId><artifactId>parent</artifactId><version>1</version>
+                <packaging>pom</packaging>
+                <modules><module>web-tests</module></modules></project>""",
+                encoding="utf-8",
+            )
+            child = root / "web-tests"
+            child.mkdir()
+            (child / "pom.xml").write_text(
+                """<project xmlns="http://maven.apache.org/POM/4.0.0">
+                <modelVersion>4.0.0</modelVersion>
+                <parent><groupId>example</groupId><artifactId>parent</artifactId><version>1</version></parent>
+                <artifactId>web-tests</artifactId>
+                <dependencies>
+                  <dependency><groupId>org.seleniumhq.selenium</groupId>
+                    <artifactId>selenium-java</artifactId><version>1</version></dependency>
+                  <dependency><groupId>org.junit.platform</groupId>
+                    <artifactId>junit-platform-suite-api</artifactId><version>1</version></dependency>
+                </dependencies></project>""",
+                encoding="utf-8",
+            )
+
+            analysis = upgrade.analyze_project(root)
+
+        self.assertEqual(
+            [pom.relative_to(root).as_posix() for pom in analysis.candidate_poms],
+            ["web-tests/pom.xml"],
+        )
+
+    def test_native_rest_assured_family_child_inherits_runner_from_parent(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pom.xml").write_text(
+                """<project xmlns="http://maven.apache.org/POM/4.0.0">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>example</groupId><artifactId>parent</artifactId><version>1</version>
+                <packaging>pom</packaging>
+                <modules><module>api-tests</module></modules>
+                <dependencies>
+                  <dependency><groupId>org.testng</groupId>
+                    <artifactId>testng</artifactId><version>1</version></dependency>
+                </dependencies></project>""",
+                encoding="utf-8",
+            )
+            child = root / "api-tests"
+            child.mkdir()
+            (child / "pom.xml").write_text(
+                """<project xmlns="http://maven.apache.org/POM/4.0.0">
+                <modelVersion>4.0.0</modelVersion>
+                <parent><groupId>example</groupId><artifactId>parent</artifactId><version>1</version></parent>
+                <artifactId>api-tests</artifactId>
+                <dependencies>
+                  <dependency><groupId>io.rest-assured</groupId>
+                    <artifactId>json-schema-validator</artifactId><version>1</version></dependency>
+                </dependencies></project>""",
+                encoding="utf-8",
+            )
+
+            analysis = upgrade.analyze_project(root)
+
+        self.assertEqual(
+            [pom.relative_to(root).as_posix() for pom in analysis.candidate_poms],
+            ["api-tests/pom.xml"],
+        )
 
     def test_cucumber_project_is_supported(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -403,6 +580,36 @@ class UpgradeToModularShaftTests(unittest.TestCase):
             analysis = upgrade.analyze_project(root)
 
         self.assertEqual(analysis.optional_modules, ())
+
+    def test_transform_does_not_copy_bom_import_metadata_to_engine_dependency(self):
+        pom = """<project xmlns="http://maven.apache.org/POM/4.0.0">
+            <modelVersion>4.0.0</modelVersion>
+            <groupId>example</groupId>
+            <artifactId>demo</artifactId>
+            <version>1.0.0</version>
+            <dependencies>
+                <dependency>
+                    <groupId>io.github.shafthq</groupId>
+                    <artifactId>shaft-bom</artifactId>
+                    <version>10.2.20260623</version>
+                    <type>pom</type>
+                    <scope>import</scope>
+                </dependency>
+            </dependencies>
+        </project>
+        """
+
+        transformed = upgrade.transform_pom_bytes(pom.encode(), "10.2.20260623", ())
+        root = upgrade.parse_xml(transformed)
+        dependencies = upgrade.direct_child(root, "dependencies")
+        engine = next(
+            dependency
+            for dependency in dependencies
+            if upgrade.child_text(dependency, "artifactId") == "shaft-engine"
+        )
+
+        self.assertEqual(upgrade.child_text(engine, "type"), "")
+        self.assertEqual(upgrade.child_text(engine, "scope"), "")
 
     def test_failed_compile_restores_original_pom(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -575,6 +782,10 @@ class UpgradeToModularShaftTests(unittest.TestCase):
                 }
             ]
         }
+        self.assertIn('"summary": "ok"', upgrade.extract_response_output_text(payload))
+
+    def test_extract_response_output_text_reads_top_level_text(self):
+        payload = {"output_text": json.dumps({"summary": "ok", "changes": []})}
         self.assertIn('"summary": "ok"', upgrade.extract_response_output_text(payload))
 
     def test_file_transaction_restores_created_and_existing_files(self):

--- a/tests/scripts/test_upgrade_to_modular_shaft.py
+++ b/tests/scripts/test_upgrade_to_modular_shaft.py
@@ -235,6 +235,56 @@ class UpgradeToModularShaftTests(unittest.TestCase):
         self.assertTrue(evidence["shaft-video"])
         self.assertTrue(evidence["shaft-browserstack"])
 
+    def test_legacy_pom_dependency_coordinates_trigger_optional_modules(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pom.xml").write_text(
+                """<project xmlns="http://maven.apache.org/POM/4.0.0">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>example</groupId><artifactId>legacy</artifactId><version>1</version>
+                <dependencies>
+                  <dependency><groupId>io.github.shafthq</groupId>
+                    <artifactId>SHAFT_ENGINE</artifactId><version>9.3.20250928</version></dependency>
+                  <dependency><groupId>com.browserstack</groupId>
+                    <artifactId>browserstack-java-sdk</artifactId><version>1</version></dependency>
+                  <dependency><groupId>com.automation-remarks</groupId>
+                    <artifactId>video-recorder-junit5</artifactId><version>1</version></dependency>
+                  <dependency><groupId>org.openpnp</groupId>
+                    <artifactId>opencv</artifactId><version>1</version></dependency>
+                </dependencies></project>""",
+                encoding="utf-8",
+            )
+
+            analysis = upgrade.analyze_project(root)
+
+        self.assertEqual(
+            analysis.optional_modules,
+            ("shaft-browserstack", "shaft-video", "shaft-visual"),
+        )
+
+    def test_scan_optional_modules_accepts_current_shaft_property_styles(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            properties = root / "src/test/resources/custom.properties"
+            properties.parent.mkdir(parents=True)
+            properties.write_text("videoParams_recordVideo=true\n", encoding="utf-8")
+            java = root / "src/test/java/Demo.java"
+            java.parent.mkdir(parents=True)
+            java.write_text(
+                """class Demo {
+                    void configure() {
+                        SHAFT.Properties.browserStack.set().deviceName("Pixel 9");
+                        SHAFT.Properties.visuals.set().videoParamsRecordVideo(true);
+                    }
+                }""",
+                encoding="utf-8",
+            )
+
+            evidence = upgrade.scan_optional_modules(root)
+
+        self.assertTrue(evidence["shaft-video"])
+        self.assertTrue(evidence["shaft-browserstack"])
+
     def test_all_supported_native_stack_and_runner_combinations_are_detected(self):
         stacks = {
             "selenium": ("org.seleniumhq.selenium", "selenium-chrome-driver"),

--- a/tests/scripts/test_upgrade_to_modular_shaft.py
+++ b/tests/scripts/test_upgrade_to_modular_shaft.py
@@ -1,4 +1,5 @@
 import importlib.util
+import io
 import json
 import sys
 import tempfile
@@ -26,6 +27,50 @@ SIMPLE_POM = """<project xmlns="http://maven.apache.org/POM/4.0.0">
             <groupId>io.github.shafthq</groupId>
             <artifactId>SHAFT_ENGINE</artifactId>
             <version>9.3.20250928</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>
+"""
+
+SELENIUM_TESTNG_POM = """<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>example</groupId>
+    <artifactId>selenium-demo</artifactId>
+    <version>1.0.0</version>
+    <dependencies>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>4.29.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>7.11.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>
+"""
+
+REST_ASSURED_TESTNG_POM = """<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>example</groupId>
+    <artifactId>api-demo</artifactId>
+    <version>1.0.0</version>
+    <dependencies>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>5.5.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>7.11.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -610,6 +655,298 @@ class UpgradeToModularShaftTests(unittest.TestCase):
 
         self.assertEqual(upgrade.child_text(engine, "type"), "")
         self.assertEqual(upgrade.child_text(engine, "scope"), "")
+
+    def test_agent_plan_lists_three_upgrade_types_for_selenium_projects(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pom.xml").write_text(SELENIUM_TESTNG_POM, encoding="utf-8")
+            analysis = upgrade.analyze_project(root)
+
+            plan = upgrade.agent_upgrade_plan(
+                analysis,
+                "10.2.20260623",
+                "shaft-upgrader/upgrade_to_modular_shaft.py",
+            )
+
+        options = plan["upgradeTypes"]
+        self.assertEqual([option["id"] for option in options], ["basic", "session", "full"])
+        self.assertEqual([option["risk"] for option in options], ["low", "medium", "high"])
+        self.assertTrue(options[0]["eligible"])
+        self.assertTrue(options[1]["eligible"])
+        self.assertTrue(options[2]["eligible"])
+        self.assertIn("--upgrade-type basic", options[0]["recommendedCommand"])
+        self.assertIn("--upgrade-type session", options[1]["recommendedCommand"])
+        self.assertIn("--upgrade-type full", options[2]["recommendedCommand"])
+
+    def test_agent_plan_marks_source_upgrades_ineligible_for_api_projects(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pom.xml").write_text(REST_ASSURED_TESTNG_POM, encoding="utf-8")
+            analysis = upgrade.analyze_project(root)
+
+            plan = upgrade.agent_upgrade_plan(
+                analysis,
+                "10.2.20260623",
+                "shaft-upgrader/upgrade_to_modular_shaft.py",
+            )
+
+        options = {option["id"]: option for option in plan["upgradeTypes"]}
+        self.assertTrue(options["basic"]["eligible"])
+        self.assertFalse(options["session"]["eligible"])
+        self.assertFalse(options["full"]["eligible"])
+        self.assertIn("Selenium/Appium", options["session"]["reason"])
+
+    def test_agent_plan_cli_prints_json_without_running_upgrade(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pom.xml").write_text(SELENIUM_TESTNG_POM, encoding="utf-8")
+            stdout = io.StringIO()
+
+            with mock.patch.object(sys, "stdout", stdout):
+                exit_code = upgrade.main(
+                    [
+                        "--project",
+                        str(root),
+                        "--shaft-version",
+                        "10.2.20260623",
+                        "--agent-plan",
+                    ]
+                )
+
+            payload = json.loads(stdout.getvalue())
+            pom_text = (root / "pom.xml").read_text(encoding="utf-8")
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["shaftVersion"], "10.2.20260623")
+        self.assertEqual([option["id"] for option in payload["upgradeTypes"]], ["basic", "session", "full"])
+        self.assertEqual(pom_text, SELENIUM_TESTNG_POM)
+
+    def test_session_upgrade_rewrites_driver_creation_transactionally(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pom = root / "pom.xml"
+            pom.write_text(SELENIUM_TESTNG_POM, encoding="utf-8")
+            java = root / "src/test/java/demo/DemoTest.java"
+            java.parent.mkdir(parents=True)
+            java.write_text(
+                """package demo;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+
+class DemoTest {
+    private WebDriver driver;
+
+    void opens() {
+        driver = new ChromeDriver();
+        driver.close();
+    }
+}
+""",
+                encoding="utf-8",
+            )
+            analysis = upgrade.analyze_project(root)
+            results = iter((command_result(0), command_result(0)))
+
+            execution = upgrade.execute_upgrade_transaction(
+                analysis,
+                "10.2.20260623",
+                ("mvn", "test-compile"),
+                30,
+                compile_runner=lambda *_: next(results),
+                upgrade_type="session",
+            )
+
+            updated = java.read_text(encoding="utf-8")
+            self.assertTrue(execution.succeeded)
+            self.assertEqual(execution.upgrade_type, "session")
+            self.assertIn("import com.shaft.driver.SHAFT;", updated)
+            self.assertIn("private SHAFT.GUI.WebDriver driver;", updated)
+            self.assertIn("driver = new SHAFT.GUI.WebDriver(new ChromeDriver());", updated)
+            self.assertIn("driver.quit();", updated)
+            self.assertNotIn("driver.close();", updated)
+            self.assertIn("<artifactId>shaft-engine</artifactId>", pom.read_text(encoding="utf-8"))
+
+    def test_session_upgrade_rewrites_driver_factory_types(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pom.xml").write_text(SELENIUM_TESTNG_POM, encoding="utf-8")
+            java = root / "src/test/java/demo/DriverFactory.java"
+            java.parent.mkdir(parents=True)
+            java.write_text(
+                """package demo;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+
+class DriverFactory {
+    private static final ThreadLocal<WebDriver> DRIVER = new ThreadLocal<>();
+
+    static WebDriver createDriver() {
+        return new ChromeDriver();
+    }
+
+    static void setDriver(WebDriver driver) {
+        DRIVER.set(driver);
+    }
+}
+""",
+                encoding="utf-8",
+            )
+            analysis = upgrade.analyze_project(root)
+            results = iter((command_result(0), command_result(0)))
+
+            upgrade.execute_upgrade_transaction(
+                analysis,
+                "10.2.20260623",
+                ("mvn", "test-compile"),
+                30,
+                compile_runner=lambda *_: next(results),
+                upgrade_type="session",
+            )
+
+            updated = java.read_text(encoding="utf-8")
+            self.assertIn("ThreadLocal<SHAFT.GUI.WebDriver> DRIVER", updated)
+            self.assertIn("static SHAFT.GUI.WebDriver createDriver()", updated)
+            self.assertIn("return new SHAFT.GUI.WebDriver(new ChromeDriver());", updated)
+            self.assertIn("static void setDriver(SHAFT.GUI.WebDriver driver)", updated)
+
+    def test_full_upgrade_rewrites_simple_selenium_actions(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pom.xml").write_text(SELENIUM_TESTNG_POM, encoding="utf-8")
+            java = root / "src/test/java/demo/DemoTest.java"
+            java.parent.mkdir(parents=True)
+            java.write_text(
+                """package demo;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+
+class DemoTest {
+    void login(String url, String nextUrl) {
+        WebDriver driver = new ChromeDriver();
+        driver.get(url);
+        driver.navigate().to(nextUrl);
+        driver.findElement(By.id("username")).sendKeys("demo");
+        driver.findElement(By.id("login")).click();
+        String message = driver.findElement(By.id("message")).getText();
+        boolean visible = driver.findElement(By.cssSelector(".toast")).isDisplayed();
+    }
+}
+""",
+                encoding="utf-8",
+            )
+            analysis = upgrade.analyze_project(root)
+            results = iter((command_result(0), command_result(0)))
+
+            execution = upgrade.execute_upgrade_transaction(
+                analysis,
+                "10.2.20260623",
+                ("mvn", "test-compile"),
+                30,
+                compile_runner=lambda *_: next(results),
+                upgrade_type="full",
+            )
+
+            updated = java.read_text(encoding="utf-8")
+            self.assertTrue(execution.succeeded)
+            self.assertIn("SHAFT.GUI.WebDriver driver = new SHAFT.GUI.WebDriver(new ChromeDriver());", updated)
+            self.assertIn("driver.browser().navigateToURL(url);", updated)
+            self.assertIn("driver.browser().navigateToURL(nextUrl);", updated)
+            self.assertIn('driver.element().type(By.id("username"), "demo");', updated)
+            self.assertIn('driver.element().click(By.id("login"));', updated)
+            self.assertIn('driver.element().get().text(By.id("message"));', updated)
+            self.assertIn('driver.element().get().isDisplayed(By.cssSelector(".toast"));', updated)
+            self.assertNotIn("driver.findElement(", updated)
+
+    def test_source_upgrade_rejects_non_selenium_appium_project(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pom.xml").write_text(REST_ASSURED_TESTNG_POM, encoding="utf-8")
+            analysis = upgrade.analyze_project(root)
+
+            with self.assertRaisesRegex(upgrade.UpgradeError, "Selenium/Appium"):
+                upgrade.execute_upgrade_transaction(
+                    analysis,
+                    "10.2.20260623",
+                    ("mvn", "test-compile"),
+                    30,
+                    compile_runner=lambda *_: command_result(0),
+                    upgrade_type="session",
+                )
+
+    def test_source_rewrites_roll_back_when_upgraded_compile_fails(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pom = root / "pom.xml"
+            pom.write_text(SELENIUM_TESTNG_POM, encoding="utf-8")
+            java = root / "src/test/java/demo/DemoTest.java"
+            java.parent.mkdir(parents=True)
+            original_java = """package demo;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+
+class DemoTest {
+    WebDriver driver = new ChromeDriver();
+}
+"""
+            java.write_text(original_java, encoding="utf-8")
+            analysis = upgrade.analyze_project(root)
+            results = iter((command_result(0), command_result(1, "compile failure")))
+
+            execution = upgrade.execute_upgrade_transaction(
+                analysis,
+                "10.2.20260623",
+                ("mvn", "test-compile"),
+                30,
+                compile_runner=lambda *_: next(results),
+                upgrade_type="session",
+            )
+
+            self.assertFalse(execution.succeeded)
+            self.assertTrue(execution.rolled_back)
+            self.assertEqual(pom.read_text(encoding="utf-8"), SELENIUM_TESTNG_POM)
+            self.assertEqual(java.read_text(encoding="utf-8"), original_java)
+
+    def test_report_includes_upgrade_type_and_source_migration(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "pom.xml").write_text(SELENIUM_TESTNG_POM, encoding="utf-8")
+            java = root / "src/test/java/demo/DemoTest.java"
+            java.parent.mkdir(parents=True)
+            java.write_text(
+                """package demo;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+
+class DemoTest {
+    WebDriver driver = new ChromeDriver();
+}
+""",
+                encoding="utf-8",
+            )
+            analysis = upgrade.analyze_project(root)
+            results = iter((command_result(0), command_result(0)))
+            execution = upgrade.execute_upgrade_transaction(
+                analysis,
+                "10.2.20260623",
+                ("mvn", "test-compile"),
+                30,
+                compile_runner=lambda *_: next(results),
+                upgrade_type="session",
+            )
+            report = root / "upgrade-report.json"
+
+            upgrade.write_report(report, analysis, "10.2.20260623", execution)
+            payload = json.loads(report.read_text(encoding="utf-8"))
+
+        self.assertEqual(payload["upgradeType"], "session")
+        self.assertEqual(payload["sourceMigration"]["changedFiles"], ["src/test/java/demo/DemoTest.java"])
+        self.assertIn("driver session", payload["sourceMigration"]["changesByFile"]["src/test/java/demo/DemoTest.java"])
 
     def test_failed_compile_restores_original_pom(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- broaden modular upgrader detection for REST Assured family artifacts, JUnit Platform runner coordinates, BOM-only modular projects, and multi-module native projects with inherited runner declarations
- add agent-facing upgrade planning via `--agent-plan`, with `basic`, `session`, and `full` options, risk labels, eligibility, reasons, and recommended commands
- add `--upgrade-type basic|session|full`; `basic` keeps existing source intact, `session` wraps Selenium/Appium driver sessions with `SHAFT.GUI.WebDriver`, and `full` also rewrites simple Selenium browser/element actions to SHAFT engine calls
- keep source rewrites inside the existing compile-validated transaction so POM and Java changes roll back together on validation failure
- report upgrade type, source migration changes, and unsupported source patterns in the optional JSON report

## Validation
- `py -3 tests\\scripts\\test_upgrade_to_modular_shaft.py` (41 tests)
- `py -3 -m py_compile shaft-upgrader\\upgrade_to_modular_shaft.py tests\\scripts\\test_upgrade_to_modular_shaft.py`
- `py -3 scripts\\ci\\validate_agent_setup.py`
- `git diff --check`

## Documentation
- Companion user-guide PR: https://github.com/ShaftHQ/shafthq.github.io/pull/603

## Graphify
- Attempted `graphify . --update --no-viz`; blocked because no LLM API key is configured for semantic extraction. No graphify output files changed.