### PR TITLE
[codex] Add mobile toolchain diagnostics

### DIFF
--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInspectorRecordingService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInspectorRecordingService.java
@@ -72,6 +72,10 @@ final class McpMobileInspectorRecordingService {
         String automation = "Android".equals(platform) ? "UiAutomator2" : "XCUITest";
         McpMobileToolchainStatus status = toolchain.status(platform);
         List<String> warnings = new ArrayList<>(status.warnings());
+        status.diagnostics().stream()
+                .filter(diagnostic -> !diagnostic.available())
+                .map(McpMobileInspectorRecordingService::diagnosticWarning)
+                .forEach(warnings::add);
         warnings.addAll(McpMobileCode.nativeWarnings(platform, app, appPackage, appActivity, bundleId));
         List<String> nextSteps = new ArrayList<>();
 
@@ -89,6 +93,9 @@ final class McpMobileInspectorRecordingService {
         boolean willProvision = false;
         McpAndroidEmulatorProposal proposal = null;
         boolean readyToStart = appReady;
+        if (status.diagnostics().stream().anyMatch(McpMobileInspectorRecordingService::blocksInspectorStart)) {
+            readyToStart = false;
+        }
 
         if ("Android".equals(platform)) {
             boolean androidReadyDevice = !plannedDeviceId.isBlank()
@@ -340,6 +347,23 @@ final class McpMobileInspectorRecordingService {
                 recordingStatus.actionCount(),
                 blocks,
                 warnings);
+    }
+
+    private static String diagnosticWarning(McpMobileToolchainDiagnostic diagnostic) {
+        StringBuilder warning = new StringBuilder("Toolchain dependency `")
+                .append(diagnostic.dependencyId())
+                .append("` is not ready");
+        if (!diagnostic.failureCause().isBlank()) {
+            warning.append(": ").append(diagnostic.failureCause());
+        }
+        if (!diagnostic.repairGuidance().isBlank()) {
+            warning.append(" Repair: ").append(diagnostic.repairGuidance());
+        }
+        return warning.toString();
+    }
+
+    private static boolean blocksInspectorStart(McpMobileToolchainDiagnostic diagnostic) {
+        return "ios-host".equals(diagnostic.dependencyId()) && !diagnostic.available();
     }
 
     private McpCodeBlock setupBlock(McpMobileInspectorPlan plan, String appiumServerUrl, String deviceId) {

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainDiagnostic.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainDiagnostic.java
@@ -1,0 +1,34 @@
+package com.shaft.mcp;
+
+/**
+ * Diagnostic details for one local mobile toolchain dependency.
+ *
+ * @param dependencyId stable machine-readable dependency identifier
+ * @param available whether the dependency is ready for use
+ * @param detectedPath resolved executable or installation path when available
+ * @param detectedVersion detected version when the tool reports one
+ * @param failureCause human-readable explanation when the dependency is unavailable
+ * @param repairGuidance command or manual action that can make the dependency available
+ */
+public record McpMobileToolchainDiagnostic(
+        String dependencyId,
+        boolean available,
+        String detectedPath,
+        String detectedVersion,
+        String failureCause,
+        String repairGuidance) {
+    /**
+     * Creates an immutable dependency diagnostic.
+     */
+    public McpMobileToolchainDiagnostic {
+        dependencyId = text(dependencyId);
+        detectedPath = text(detectedPath);
+        detectedVersion = text(detectedVersion);
+        failureCause = text(failureCause);
+        repairGuidance = text(repairGuidance);
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainService.java
@@ -81,6 +81,7 @@ final class McpMobileToolchainService {
                 .resolve("latest").resolve("bin")));
         Optional<Path> avdManager = resolveExecutable("avdmanager", List.of(androidSdkRoot.resolve("cmdline-tools")
                 .resolve("latest").resolve("bin")));
+        Path inspectorPluginPath = appiumRoot.resolve("node_modules").resolve("appium-inspector-plugin");
 
         List<McpMobileDevice> devices = adb.map(this::androidDevices).orElseGet(() -> {
             warnings.add("adb was not found on PATH or in the SHAFT-managed Android SDK cache.");
@@ -88,7 +89,10 @@ final class McpMobileToolchainService {
         });
         List<String> avds = cachedAndroidEmulators(emulator.orElse(null), androidAvdHome);
         boolean inspector = appium.filter(this::hasInspectorPlugin).isPresent()
-                || Files.isDirectory(appiumRoot.resolve("node_modules").resolve("appium-inspector-plugin"));
+                || Files.isDirectory(inspectorPluginPath);
+        String detectedAppiumVersion = appiumVersion(appium.orElse(null));
+        List<McpMobileToolchainDiagnostic> diagnostics = diagnostics(platform, androidSdkRoot, appiumRoot, node, npm,
+                appium, inspector, inspectorPluginPath, adb, emulator, sdkManager, avdManager, detectedAppiumVersion);
 
         List<String> missing = new ArrayList<>();
         if (node.isEmpty()) {
@@ -132,12 +136,101 @@ final class McpMobileToolchainService {
                 androidSdkRoot,
                 androidAvdHome,
                 appiumRoot,
-                appiumVersion(appium.orElse(null)),
+                detectedAppiumVersion,
                 SHAFT.Properties.internal.appiumInspectorPluginVersion(),
                 devices,
                 avds,
                 missing,
-                warnings);
+                warnings,
+                diagnostics);
+    }
+
+    private List<McpMobileToolchainDiagnostic> diagnostics(
+            String platform,
+            Path androidSdkRoot,
+            Path appiumRoot,
+            Optional<Path> node,
+            Optional<Path> npm,
+            Optional<Path> appium,
+            boolean inspector,
+            Path inspectorPluginPath,
+            Optional<Path> adb,
+            Optional<Path> emulator,
+            Optional<Path> sdkManager,
+            Optional<Path> avdManager,
+            String detectedAppiumVersion) {
+        List<McpMobileToolchainDiagnostic> diagnostics = new ArrayList<>();
+        diagnostics.add(dependency("node", node, "",
+                "node was not found on PATH or in the SHAFT-managed Node.js cache.",
+                "Install Node.js " + SHAFT.Properties.internal.nodeLtsVersion()
+                        + " and ensure `node` is on PATH, or let SHAFT prepare its portable Node.js cache."));
+        diagnostics.add(dependency("npm", npm, "",
+                "npm was not found on PATH or in the SHAFT-managed Node.js cache.",
+                "Install npm with Node.js " + SHAFT.Properties.internal.nodeLtsVersion()
+                        + " and ensure `npm` is on PATH."));
+        diagnostics.add(dependency("appium", appium, detectedAppiumVersion,
+                "Appium was not found on PATH or in the SHAFT-managed Appium cache.",
+                "Run `npm --prefix " + appiumRoot + " install appium@"
+                        + SHAFT.Properties.internal.appiumServerVersion() + " appium-inspector-plugin@"
+                        + SHAFT.Properties.internal.appiumInspectorPluginVersion() + "`."));
+        String inspectorPath = Files.isDirectory(inspectorPluginPath)
+                ? inspectorPluginPath.toString()
+                : appium.map(Path::toString).orElse("");
+        diagnostics.add(new McpMobileToolchainDiagnostic(
+                "appium-inspector-plugin",
+                inspector,
+                inspector ? inspectorPath : "",
+                "",
+                inspector ? "" : "Appium Inspector plugin was not reported by Appium or found in the SHAFT cache.",
+                inspector ? "" : "Run `appium plugin install --source=npm appium-inspector-plugin@"
+                        + SHAFT.Properties.internal.appiumInspectorPluginVersion() + "`."));
+        if ("Android".equals(platform)) {
+            diagnostics.add(dependency("adb", adb, "",
+                    "adb was not found on PATH or under " + androidSdkRoot.resolve("platform-tools") + ".",
+                    "Install Android platform-tools with `sdkmanager --sdk_root=" + androidSdkRoot
+                            + " platform-tools`."));
+            diagnostics.add(dependency("android-emulator", emulator, "",
+                    "Android emulator was not found on PATH or under " + androidSdkRoot.resolve("emulator") + ".",
+                    "Install Android Emulator with `sdkmanager --sdk_root=" + androidSdkRoot + " emulator`."));
+            diagnostics.add(dependency("android-sdkmanager", sdkManager, "",
+                    "Android sdkmanager was not found on PATH or under "
+                            + androidSdkRoot.resolve("cmdline-tools").resolve("latest").resolve("bin") + ".",
+                    "Install Android command-line tools under " + androidSdkRoot.resolve("cmdline-tools")
+                            .resolve("latest") + " so sdkmanager is available."));
+            diagnostics.add(dependency("android-avdmanager", avdManager, "",
+                    "Android avdmanager was not found on PATH or under "
+                            + androidSdkRoot.resolve("cmdline-tools").resolve("latest").resolve("bin") + ".",
+                    "Install Android command-line tools under " + androidSdkRoot.resolve("cmdline-tools")
+                            .resolve("latest") + " so avdmanager is available."));
+        }
+        if ("iOS".equals(platform)) {
+            boolean mac = isMac();
+            diagnostics.add(new McpMobileToolchainDiagnostic(
+                    "ios-host",
+                    mac,
+                    "",
+                    mac ? text(osName) : "",
+                    mac ? "" : "iOS Appium recording requires macOS; current OS is " + text(osName) + ".",
+                    mac ? "" : "Run iOS Inspector recording on macOS with Xcode command-line tools and a reachable "
+                            + "iOS simulator or device."));
+        }
+        return List.copyOf(diagnostics);
+    }
+
+    private McpMobileToolchainDiagnostic dependency(
+            String dependencyId,
+            Optional<Path> executable,
+            String detectedVersion,
+            String failureCause,
+            String repairGuidance) {
+        boolean available = executable.isPresent();
+        return new McpMobileToolchainDiagnostic(
+                dependencyId,
+                available,
+                available ? executable.get().toString() : "",
+                available ? detectedVersion : "",
+                available ? "" : failureCause,
+                available ? "" : repairGuidance);
     }
 
     McpAndroidEmulatorProposal defaultAndroidProposal(

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainStatus.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainStatus.java
@@ -25,7 +25,8 @@ public record McpMobileToolchainStatus(
         List<McpMobileDevice> androidDevices,
         List<String> cachedAndroidEmulators,
         List<String> missingDependencies,
-        List<String> warnings) {
+        List<String> warnings,
+        List<McpMobileToolchainDiagnostic> diagnostics) {
     /**
      * Creates an immutable toolchain status.
      */
@@ -37,6 +38,56 @@ public record McpMobileToolchainStatus(
         cachedAndroidEmulators = cachedAndroidEmulators == null ? List.of() : List.copyOf(cachedAndroidEmulators);
         missingDependencies = missingDependencies == null ? List.of() : List.copyOf(missingDependencies);
         warnings = warnings == null ? List.of() : List.copyOf(warnings);
+        diagnostics = diagnostics == null ? List.of() : List.copyOf(diagnostics);
+    }
+
+    /**
+     * Creates an immutable toolchain status without structured dependency diagnostics.
+     *
+     * @param platformName normalized mobile platform name
+     * @param nodeAvailable whether Node.js was found
+     * @param npmAvailable whether npm was found
+     * @param appiumAvailable whether Appium was found
+     * @param appiumInspectorAvailable whether the Appium Inspector plugin was found
+     * @param adbAvailable whether adb was found
+     * @param emulatorAvailable whether the Android emulator binary was found
+     * @param sdkManagerAvailable whether sdkmanager was found
+     * @param avdManagerAvailable whether avdmanager was found
+     * @param toolRoot SHAFT-managed tool cache root
+     * @param androidSdkRoot Android SDK root
+     * @param androidAvdHome Android AVD home
+     * @param appiumRoot SHAFT-managed Appium root
+     * @param appiumVersion detected Appium version
+     * @param appiumInspectorPluginVersion configured Appium Inspector plugin version
+     * @param androidDevices detected Android devices
+     * @param cachedAndroidEmulators cached Android AVD names
+     * @param missingDependencies missing dependency labels
+     * @param warnings readiness warnings
+     */
+    public McpMobileToolchainStatus(
+            String platformName,
+            boolean nodeAvailable,
+            boolean npmAvailable,
+            boolean appiumAvailable,
+            boolean appiumInspectorAvailable,
+            boolean adbAvailable,
+            boolean emulatorAvailable,
+            boolean sdkManagerAvailable,
+            boolean avdManagerAvailable,
+            Path toolRoot,
+            Path androidSdkRoot,
+            Path androidAvdHome,
+            Path appiumRoot,
+            String appiumVersion,
+            String appiumInspectorPluginVersion,
+            List<McpMobileDevice> androidDevices,
+            List<String> cachedAndroidEmulators,
+            List<String> missingDependencies,
+            List<String> warnings) {
+        this(platformName, nodeAvailable, npmAvailable, appiumAvailable, appiumInspectorAvailable, adbAvailable,
+                emulatorAvailable, sdkManagerAvailable, avdManagerAvailable, toolRoot, androidSdkRoot, androidAvdHome,
+                appiumRoot, appiumVersion, appiumInspectorPluginVersion, androidDevices, cachedAndroidEmulators,
+                missingDependencies, warnings, List.of());
     }
 
     private static String text(String value) {

--- a/shaft-mcp/src/main/java/com/shaft/mcp/MobileService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/MobileService.java
@@ -232,13 +232,13 @@ public class MobileService {
     }
 
     /**
-     * Returns local Appium/Android/iOS toolchain discovery status.
+     * Returns local Appium/Android/iOS toolchain discovery status and repair diagnostics.
      *
      * @param platformName Android or iOS; blank defaults to Android
      * @return local mobile toolchain status
      */
     @Tool(name = "mobile_toolchain_status",
-            description = "checks local Appium, Inspector, adb, emulator, and SDK tooling status")
+            description = "checks local Appium, Inspector, adb, emulator, and SDK tooling status with repair diagnostics")
     public McpMobileToolchainStatus toolchainStatus(String platformName) {
         return inspectorRecorder.toolchainStatus(platformName);
     }

--- a/shaft-mcp/src/test/java/com/shaft/mcp/McpMobileInspectorRecordingServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/McpMobileInspectorRecordingServiceTest.java
@@ -86,6 +86,66 @@ class McpMobileInspectorRecordingServiceTest {
     }
 
     @Test
+    void prepareSurfacesToolchainDiagnosticWarnings() {
+        McpMobileInspectorRecordingService service = service();
+
+        McpMobileInspectorPlan plan = service.prepare(
+                "Android",
+                "recordings/native.json",
+                false,
+                "",
+                "com.example",
+                ".MainActivity",
+                "",
+                "",
+                "Pixel 8",
+                "",
+                "",
+                0,
+                "",
+                "",
+                "",
+                0,
+                0,
+                false);
+
+        assertFalse(plan.readyToStart());
+        assertTrue(plan.warnings().stream().anyMatch(warning -> warning.contains("adb was not found")
+                && warning.contains("platform-tools")));
+        assertTrue(plan.warnings().stream().anyMatch(warning -> warning.contains("Android emulator")
+                && warning.contains("sdkmanager")));
+    }
+
+    @Test
+    void prepareBlocksIosInspectorOnNonMacHost() {
+        McpMobileInspectorRecordingService service = service();
+
+        McpMobileInspectorPlan plan = service.prepare(
+                "iOS",
+                "recordings/native-ios.json",
+                false,
+                "",
+                "",
+                "",
+                "com.example.ios",
+                "",
+                "iPhone 15",
+                "",
+                "",
+                0,
+                "",
+                "",
+                "",
+                0,
+                0,
+                false);
+
+        assertFalse(plan.readyToStart());
+        assertTrue(plan.warnings().stream().anyMatch(warning -> warning.contains("ios-host")
+                && warning.contains("requires macOS")));
+    }
+
+    @Test
     void rejectsUnknownConfirmationToken() {
         McpMobileInspectorRecordingService service = service();
 

--- a/shaft-mcp/src/test/java/com/shaft/mcp/McpMobileToolchainServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/McpMobileToolchainServiceTest.java
@@ -58,6 +58,55 @@ class McpMobileToolchainServiceTest {
         assertTrue(status.cachedAndroidEmulators().contains("Pixel_API_36"));
         assertTrue(status.cachedAndroidEmulators().contains("Cached_Pixel"));
         assertFalse(status.missingDependencies().contains("adb"));
+        assertTrue(diagnostic(status, "appium").available());
+        assertTrue(diagnostic(status, "appium").detectedPath().endsWith("appium.cmd"));
+        assertEquals("3.5.2", diagnostic(status, "appium").detectedVersion());
+        assertTrue(diagnostic(status, "appium-inspector-plugin").available());
+        assertEquals("", diagnostic(status, "appium-inspector-plugin").detectedVersion());
+    }
+
+    @Test
+    void statusReportsRepairableDiagnosticsForMissingAndroidToolchain() {
+        Path toolRoot = temp.resolve("tools");
+        McpMobileToolchainService service = new McpMobileToolchainService(new FakeRunner(),
+                Map.of("PATH", "", "ANDROID_SDK_ROOT", temp.resolve("android-sdk").toString()),
+                toolRoot, "Windows 11", "amd64");
+
+        McpMobileToolchainStatus status = service.status("Android");
+
+        McpMobileToolchainDiagnostic adb = diagnostic(status, "adb");
+        assertFalse(adb.available());
+        assertEquals("", adb.detectedPath());
+        assertTrue(adb.failureCause().contains("adb was not found"));
+        assertTrue(adb.repairGuidance().contains("platform-tools"));
+        assertTrue(status.missingDependencies().contains("android platform-tools"));
+        assertFalse(diagnostic(status, "node").available());
+        assertFalse(diagnostic(status, "npm").available());
+        assertFalse(diagnostic(status, "appium").available());
+        assertFalse(diagnostic(status, "appium-inspector-plugin").available());
+
+        McpMobileToolchainDiagnostic emulator = diagnostic(status, "android-emulator");
+        assertFalse(emulator.available());
+        assertTrue(emulator.failureCause().contains("Android emulator"));
+        assertTrue(emulator.repairGuidance().contains("sdkmanager"));
+
+        McpMobileToolchainDiagnostic sdkManager = diagnostic(status, "android-sdkmanager");
+        assertFalse(sdkManager.available());
+        assertTrue(sdkManager.repairGuidance().contains("cmdline-tools"));
+        assertFalse(diagnostic(status, "android-avdmanager").available());
+    }
+
+    @Test
+    void statusReportsIosHostConstraintOnNonMac() {
+        McpMobileToolchainService service = new McpMobileToolchainService(new FakeRunner(),
+                Map.of("PATH", ""), temp.resolve("tools"), "Windows 11", "amd64");
+
+        McpMobileToolchainStatus status = service.status("iOS");
+
+        McpMobileToolchainDiagnostic iosHost = diagnostic(status, "ios-host");
+        assertFalse(iosHost.available());
+        assertTrue(iosHost.failureCause().contains("requires macOS"));
+        assertTrue(iosHost.repairGuidance().contains("Xcode"));
     }
 
     @Test
@@ -106,6 +155,13 @@ class McpMobileToolchainServiceTest {
     private static void create(Path directory, String fileName) throws Exception {
         Files.createDirectories(directory);
         Files.writeString(directory.resolve(fileName), "");
+    }
+
+    private static McpMobileToolchainDiagnostic diagnostic(McpMobileToolchainStatus status, String dependencyId) {
+        return status.diagnostics().stream()
+                .filter(diagnostic -> dependencyId.equals(diagnostic.dependencyId()))
+                .findFirst()
+                .orElseThrow();
     }
 
     private static final class FakeRunner implements McpProcessRunner {


### PR DESCRIPTION
## Summary
- Add structured mobile toolchain diagnostics with dependency id, availability, detected path/version, failure cause, and repair guidance.
- Cover Node.js, npm, Appium, Appium Inspector plugin, Android adb/emulator/sdkmanager/avdmanager, and iOS host constraints.
- Surface unavailable dependency guidance in `mobile_inspector_record_prepare` warnings and block iOS Inspector readiness on non-macOS hosts.
- Update `mobile_toolchain_status` tool description.

## Docs
- Companion docs PR: https://github.com/ShaftHQ/shafthq.github.io/pull/609

## Validation
- `mvn -pl shaft-mcp '-Dtest=McpMobileToolchainServiceTest,McpMobileInspectorRecordingServiceTest' test` (10 tests, 0 failures)
- `mvn -pl shaft-mcp test-compile`
- `git diff --check`
- Graphify: `graphify update .` succeeded for code-only relationships; full semantic refresh for docs/images is blocked locally by missing LLM API key.

Closes #3034.