### PR TITLE
Add Selenium Grid preflight

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -85,6 +85,7 @@ public class DriverFactoryHelper {
     @Getter
     private WebDriver driver;
     private BrowserNetworkInterceptor browserNetworkInterceptor;
+    private RemoteGridPreflight.SessionPermit remoteGridPreflightPermit = RemoteGridPreflight.SessionPermit.noop();
 
     /**
      * Creates a helper instance without an attached WebDriver.
@@ -176,6 +177,10 @@ public class DriverFactoryHelper {
 
     private static RuntimeException createSessionInitializationTimeoutFailure(String sessionDescription, long timeoutInSeconds, long startTimeInMillis, Throwable primaryCause, List<Throwable> priorFailures, String targetEndpoint) {
         var message = "Timed out while " + sessionDescription + ".";
+        var failureCategory = RemoteGridPreflight.classifyRemoteSessionFailure(primaryCause);
+        if (isActionableRemoteFailureCategory(failureCategory)) {
+            message = message + " Category: " + failureCategory + ".";
+        }
         if (timeoutInSeconds > 0) {
             message = message + " Configured timeout: " + timeoutInSeconds + "s.";
         }
@@ -196,6 +201,10 @@ public class DriverFactoryHelper {
 
     private static RuntimeException createSessionInitializationFailure(String sessionDescription, long startTimeInMillis, Throwable primaryCause, List<Throwable> priorFailures, String targetEndpoint) {
         var message = "Failed to initialize " + sessionDescription + " session. Elapsed time: " + (System.currentTimeMillis() - startTimeInMillis) + "ms.";
+        var failureCategory = RemoteGridPreflight.classifyRemoteSessionFailure(primaryCause);
+        if (isActionableRemoteFailureCategory(failureCategory)) {
+            message = message + " Category: " + failureCategory + ".";
+        }
         var redactedTarget = redactUriCredentials(targetEndpoint);
         if (!redactedTarget.isBlank()) {
             message = message + " Target: `" + redactedTarget + "`.";
@@ -226,6 +235,12 @@ public class DriverFactoryHelper {
                 failureTarget.addSuppressed(candidateFailure);
             }
         }
+    }
+
+    private static boolean isActionableRemoteFailureCategory(String failureCategory) {
+        return failureCategory != null
+                && !failureCategory.isBlank()
+                && !"unclassified remote failure".equals(failureCategory);
     }
 
     private static boolean isCausedBy(Throwable throwable, Class<? extends Throwable> expectedCauseType) {
@@ -338,7 +353,7 @@ public class DriverFactoryHelper {
      * @param url the URI string that may contain embedded credentials
      * @return the URI with user-info replaced by {@code ***:***}, or the original string on parse failure
      */
-    private static String redactUriCredentials(String url) {
+    static String redactUriCredentials(String url) {
         if (url == null) {
             return "";
         }
@@ -504,6 +519,25 @@ public class DriverFactoryHelper {
                 : "http://" + executionAddress);
     }
 
+    /**
+     * Performs configured Selenium Grid preflight during framework suite startup.
+     */
+    public static void preflightRemoteGridIfConfigured() {
+        initializeSystemProperties();
+        var executionAddress = SHAFT.Properties.platform.executionAddress();
+        if (executionAddress == null
+                || executionAddress.equalsIgnoreCase("local")
+                || executionAddress.equalsIgnoreCase("dockerized")) {
+            return;
+        }
+        var capabilities = new MutableCapabilities();
+        var browserName = SHAFT.Properties.web.targetBrowserName();
+        if (browserName != null && !browserName.isBlank()) {
+            capabilities.setCapability("browserName", browserName);
+        }
+        RemoteGridPreflight.beforeSuite(getTargetHubUrl(), capabilities);
+    }
+
     private static String getTargetHubUrl() {
         return TARGET_HUB_URL.get();
     }
@@ -572,13 +606,22 @@ public class DriverFactoryHelper {
             } finally {
                 HealingManager.clear(driver);
                 browserNetworkInterceptor = null;
+                releaseRemoteGridPreflightPermit();
                 seleniumWebSocketLogger.setLevel(previousWebSocketLoggerLevel);
                 clearThreadLocalDriverState();
                 ReportManager.log("Closed the WebDriver session.");
             }
         } else {
+            releaseRemoteGridPreflightPermit();
             clearThreadLocalDriverState();
             ReportManager.log("WebDriver session was already closed.");
+        }
+    }
+
+    private void releaseRemoteGridPreflightPermit() {
+        if (remoteGridPreflightPermit != null) {
+            remoteGridPreflightPermit.close();
+            remoteGridPreflightPermit = RemoteGridPreflight.SessionPermit.noop();
         }
     }
 
@@ -883,8 +926,12 @@ public class DriverFactoryHelper {
         // stage 2: create remote driver instance (requires some time with dockerized appium)
         ReportManager.logDiscrete("Creating the remote WebDriver session. Timeout: " + TimeUnit.SECONDS.toMinutes(remoteServerInstanceCreationTimeout) + " minute(s).");
         var remoteCreationStart = System.currentTimeMillis();
+        var preflightPermit = RemoteGridPreflight.SessionPermit.noop();
         try (ProgressBarLogger pblogger = new ProgressBarLogger("Instantiating...", (int) remoteServerInstanceCreationTimeout)) {
+            preflightPermit = RemoteGridPreflight.beforeSession(getTargetHubUrl(), capabilities);
             setDriver(attemptRemoteServerConnection(capabilities));
+            remoteGridPreflightPermit = preflightPermit;
+            preflightPermit = RemoteGridPreflight.SessionPermit.noop();
             if (driver instanceof RemoteWebDriver remoteWebDriver)
                 remoteWebDriver.setFileDetector(new LocalFileDetector());
             if (!isNotMobileExecution()
@@ -922,6 +969,8 @@ public class DriverFactoryHelper {
                     throwable1,
                     null,
                     getTargetHubUrl()));
+        } finally {
+            preflightPermit.close();
         }
     }
 

--- a/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/RemoteGridPreflight.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/RemoteGridPreflight.java
@@ -1,0 +1,359 @@
+package com.shaft.driver.internal.DriverFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shaft.driver.SHAFT;
+import com.shaft.properties.internal.Properties;
+import com.shaft.tools.io.internal.ReportManagerHelper;
+import org.apache.logging.log4j.Level;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.SessionNotCreatedException;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+final class RemoteGridPreflight {
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final int UNKNOWN = -1;
+    private static final ConcurrentMap<String, SessionLimiter> LIMITERS = new ConcurrentHashMap<>();
+    private static final Set<String> ATTACHED_SUMMARIES = ConcurrentHashMap.newKeySet();
+
+    private RemoteGridPreflight() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static SessionPermit beforeSession(String targetHubUrl, Capabilities capabilities) {
+        if (!SHAFT.Properties.platform.remotePreflightEnabled()) {
+            return SessionPermit.noop();
+        }
+
+        var report = inspect(targetHubUrl, capabilities);
+        warnOrFail(report);
+        if (SHAFT.Properties.platform.remoteAdaptiveSessionThrottling() && report.matchingSlots() > 0) {
+            return acquirePermit(report.limiterKey(), report.matchingSlots());
+        }
+        return SessionPermit.noop();
+    }
+
+    static void beforeSuite(String targetHubUrl, Capabilities capabilities) {
+        if (!SHAFT.Properties.platform.remotePreflightEnabled()) {
+            return;
+        }
+        warnOrFail(inspect(targetHubUrl, capabilities));
+    }
+
+    static PreflightReport inspect(String targetHubUrl, Capabilities capabilities) {
+        var requestedBrowserName = requestedBrowserName(capabilities);
+        var endpoint = targetHubUrl == null ? "" : targetHubUrl.trim();
+        var redactedEndpoint = DriverFactoryHelper.redactUriCredentials(endpoint);
+        StatusSnapshot statusSnapshot = StatusSnapshot.unavailable();
+        int queueDepth = UNKNOWN;
+        String source = "unavailable";
+
+        try {
+            var gridRoot = gridRoot(endpoint);
+            statusSnapshot = readStatus(gridRoot.resolve("/status"), requestedBrowserName);
+            queueDepth = readQueueDepth(gridRoot.resolve("/graphql"));
+            source = statusSnapshot.available() ? "status+graphql" : (queueDepth >= 0 ? "graphql" : "unavailable");
+        } catch (Throwable throwable) {
+            ReportManagerHelper.logDiscrete(throwable, Level.DEBUG);
+        }
+
+        var report = new PreflightReport(
+                statusSnapshot.available() || queueDepth >= 0,
+                redactedEndpoint,
+                requestedBrowserName,
+                statusSnapshot.totalSlots(),
+                statusSnapshot.availableSlots(),
+                statusSnapshot.matchingSlots(),
+                statusSnapshot.matchingAvailableSlots(),
+                queueDepth,
+                source);
+        attachSummary(report);
+        return report;
+    }
+
+    static String classifyRemoteSessionFailure(Throwable throwable) {
+        var failureText = collectFailureText(throwable);
+        if (failureText.contains("no selenium grid slot matches")
+                || failureText.contains("cannot find a matching set of capabilities")
+                || failureText.contains("couldn't find a node")
+                || failureText.contains("couldnt find a node")
+                || failureText.contains("missing in the capabilities")) {
+            return "incompatible capabilities";
+        }
+        if (failureText.contains("has been exhausted")
+                || failureText.contains("not allowed on your current plan")
+                || failureText.contains("capacity")
+                || failureText.contains("quota")
+                || failureText.contains("max session")) {
+            return "remote capacity exhausted";
+        }
+        if (failureText.contains("timeout")) {
+            return "remote session timeout";
+        }
+        if (failureText.contains("connection refused")
+                || failureText.contains("connectionfailedexception")
+                || failureText.contains("unable to connect")
+                || failureText.contains("unreachable")) {
+            return "remote endpoint unavailable";
+        }
+        if (failureText.contains("invalid remote server url")
+                || failureText.contains("urisyntax")
+                || failureText.contains("numberformatexception")) {
+            return "invalid remote endpoint";
+        }
+        return "unclassified remote failure";
+    }
+
+    static void resetForTests() {
+        LIMITERS.clear();
+        ATTACHED_SUMMARIES.clear();
+    }
+
+    private static void warnOrFail(PreflightReport report) {
+        if (report.matchingSlots() == 0 && !report.requestedBrowserName().isBlank()) {
+            var message = "No Selenium Grid slot matches requested browser/platform `" + report.requestedBrowserName()
+                    + "/" + Properties.platform.targetPlatform()
+                    + "` at `" + report.redactedEndpoint() + "`.";
+            ReportManagerHelper.logDiscrete(message, Level.WARN);
+            if (SHAFT.Properties.platform.remotePreflightFailFast()) {
+                throw new SessionNotCreatedException(message);
+            }
+        }
+        if (report.matchingSlots() > 0 && report.matchingAvailableSlots() == 0) {
+            var message = "Selenium Grid has no currently available `" + report.requestedBrowserName()
+                    + "` slots at `" + report.redactedEndpoint() + "`.";
+            ReportManagerHelper.logDiscrete(message, Level.WARN);
+            if (SHAFT.Properties.platform.remotePreflightFailFast()
+                    && !SHAFT.Properties.platform.remoteAdaptiveSessionThrottling()) {
+                throw new SessionNotCreatedException(message);
+            }
+        }
+    }
+
+    private static SessionPermit acquirePermit(String limiterKey, int capacity) {
+        var limiter = LIMITERS.computeIfAbsent(limiterKey,
+                ignored -> new SessionLimiter(capacity, new Semaphore(capacity, true)));
+        if (limiter.capacity() != capacity) {
+            // ponytail: keep the first detected capacity per endpoint/browser; restart the JVM if Grid capacity changes mid-suite.
+            ReportManagerHelper.logDiscrete("Selenium Grid preflight limiter already uses capacity "
+                    + limiter.capacity() + " for `" + limiterKey + "`.", Level.DEBUG);
+        }
+        try {
+            limiter.semaphore().acquire();
+            return new SessionPermit(limiter.semaphore());
+        } catch (InterruptedException interruptedException) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while waiting for Selenium Grid capacity.", interruptedException);
+        }
+    }
+
+    private static StatusSnapshot readStatus(URI statusUri, String requestedBrowserName) throws IOException, InterruptedException {
+        var responseBody = get(statusUri);
+        var root = JSON.readTree(responseBody);
+        var nodes = root.path("value").path("nodes");
+        if (!nodes.isArray()) {
+            return StatusSnapshot.unavailable();
+        }
+
+        var totalSlots = 0;
+        var availableSlots = 0;
+        var matchingSlots = 0;
+        var matchingAvailableSlots = 0;
+        for (JsonNode node : nodes) {
+            if ("DOWN".equalsIgnoreCase(node.path("status").asText())) {
+                continue;
+            }
+            var slots = node.path("slots");
+            if (!slots.isArray()) {
+                continue;
+            }
+            for (JsonNode slot : slots) {
+                totalSlots++;
+                var available = isSlotAvailable(slot);
+                if (available) {
+                    availableSlots++;
+                }
+                if (matchesRequestedSlot(slot.path("stereotype"), requestedBrowserName)) {
+                    matchingSlots++;
+                    if (available) {
+                        matchingAvailableSlots++;
+                    }
+                }
+            }
+        }
+        return new StatusSnapshot(true, totalSlots, availableSlots, matchingSlots, matchingAvailableSlots);
+    }
+
+    private static int readQueueDepth(URI graphqlUri) {
+        try {
+            var requestBody = "{\"query\":\"{ grid { sessionQueueSize } }\"}";
+            var responseBody = post(graphqlUri, requestBody);
+            var queueDepth = JSON.readTree(responseBody).at("/data/grid/sessionQueueSize");
+            return queueDepth.isMissingNode() ? UNKNOWN : queueDepth.asInt(UNKNOWN);
+        } catch (Throwable throwable) {
+            ReportManagerHelper.logDiscrete(throwable, Level.DEBUG);
+            return UNKNOWN;
+        }
+    }
+
+    private static String get(URI uri) throws IOException, InterruptedException {
+        var request = HttpRequest.newBuilder(uri)
+                .timeout(preflightTimeout())
+                .GET()
+                .build();
+        return send(request);
+    }
+
+    private static String post(URI uri, String body) throws IOException, InterruptedException {
+        var request = HttpRequest.newBuilder(uri)
+                .timeout(preflightTimeout())
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+        return send(request);
+    }
+
+    private static String send(HttpRequest request) throws IOException, InterruptedException {
+        var response = HttpClient.newBuilder()
+                .connectTimeout(preflightTimeout())
+                .build()
+                .send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new IOException("Selenium Grid preflight endpoint returned HTTP " + response.statusCode());
+        }
+        return response.body();
+    }
+
+    private static Duration preflightTimeout() {
+        return Duration.ofSeconds(Math.max(1, SHAFT.Properties.platform.remotePreflightTimeoutSeconds()));
+    }
+
+    private static URI gridRoot(String targetHubUrl) throws URISyntaxException {
+        if (targetHubUrl == null || targetHubUrl.isBlank()) {
+            throw new URISyntaxException("", "Remote server URL must not be null or blank.");
+        }
+        var normalizedUrl = targetHubUrl.trim();
+        if (!normalizedUrl.toLowerCase(Locale.ROOT).startsWith("http")) {
+            normalizedUrl = "http://" + normalizedUrl;
+        }
+        var uri = URI.create(normalizedUrl);
+        return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), "/", null, null);
+    }
+
+    private static boolean matchesRequestedSlot(JsonNode stereotype, String requestedBrowserName) {
+        if (requestedBrowserName == null || requestedBrowserName.isBlank()) {
+            return true;
+        }
+        var slotBrowserName = stereotype.path("browserName").asText("");
+        if (!requestedBrowserName.equalsIgnoreCase(slotBrowserName)) {
+            return false;
+        }
+        var slotPlatformName = stereotype.path("platformName").asText("");
+        var requestedPlatformName = Properties.platform.targetPlatform();
+        return slotPlatformName.isBlank()
+                || requestedPlatformName == null
+                || requestedPlatformName.isBlank()
+                || slotPlatformName.equalsIgnoreCase(requestedPlatformName);
+    }
+
+    private static boolean isSlotAvailable(JsonNode slot) {
+        var session = slot.get("session");
+        return session == null || session.isNull();
+    }
+
+    private static String requestedBrowserName(Capabilities capabilities) {
+        var browserName = capabilities == null ? "" : capabilities.getBrowserName();
+        if (browserName == null || browserName.isBlank()) {
+            browserName = SHAFT.Properties.web.targetBrowserName();
+        }
+        return browserName == null ? "" : browserName.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private static void attachSummary(PreflightReport report) {
+        if (!ATTACHED_SUMMARIES.add(report.limiterKey())) {
+            return;
+        }
+        var summary = "endpoint=" + report.redactedEndpoint() + "\n"
+                + "requestedBrowser=" + report.requestedBrowserName() + "\n"
+                + "gridMetadataAvailable=" + report.gridMetadataAvailable() + "\n"
+                + "source=" + report.source() + "\n"
+                + "totalSlots=" + report.totalSlots() + "\n"
+                + "availableSlots=" + report.availableSlots() + "\n"
+                + "matchingSlots=" + report.matchingSlots() + "\n"
+                + "matchingAvailableSlots=" + report.matchingAvailableSlots() + "\n"
+                + "queueDepth=" + report.queueDepth() + "\n";
+        ReportManagerHelper.attach("Text", "Selenium Grid Preflight", summary);
+        ReportManagerHelper.logDiscrete("Selenium Grid preflight summary: "
+                + summary.replace("\n", ", "), Level.INFO);
+    }
+
+    private static String collectFailureText(Throwable throwable) {
+        if (throwable == null) {
+            return "";
+        }
+        var text = new StringBuilder();
+        var current = throwable;
+        while (current != null) {
+            text.append(current.getClass().getName()).append(' ')
+                    .append(current.getMessage()).append(' ');
+            for (var suppressed : current.getSuppressed()) {
+                text.append(suppressed.getClass().getName()).append(' ')
+                        .append(suppressed.getMessage()).append(' ');
+            }
+            current = current.getCause();
+        }
+        return text.toString().toLowerCase(Locale.ROOT);
+    }
+
+    record PreflightReport(boolean gridMetadataAvailable, String redactedEndpoint, String requestedBrowserName,
+                           int totalSlots, int availableSlots, int matchingSlots, int matchingAvailableSlots,
+                           int queueDepth, String source) {
+        private String limiterKey() {
+            return redactedEndpoint + "|" + requestedBrowserName;
+        }
+    }
+
+    private record StatusSnapshot(boolean available, int totalSlots, int availableSlots, int matchingSlots,
+                                  int matchingAvailableSlots) {
+        private static StatusSnapshot unavailable() {
+            return new StatusSnapshot(false, UNKNOWN, UNKNOWN, UNKNOWN, UNKNOWN);
+        }
+    }
+
+    private record SessionLimiter(int capacity, Semaphore semaphore) {
+    }
+
+    static final class SessionPermit implements AutoCloseable {
+        private static final SessionPermit NOOP = new SessionPermit(null);
+        private final Semaphore semaphore;
+        private final AtomicBoolean released = new AtomicBoolean(false);
+
+        private SessionPermit(Semaphore semaphore) {
+            this.semaphore = semaphore;
+        }
+
+        static SessionPermit noop() {
+            return NOOP;
+        }
+
+        @Override
+        public void close() {
+            if (semaphore != null && released.compareAndSet(false, true)) {
+                semaphore.release();
+            }
+        }
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/listeners/JunitExtension.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/JunitExtension.java
@@ -33,6 +33,7 @@ public class JunitExtension implements BeforeAllCallback, AfterAllCallback, Befo
     public void beforeAll(ExtensionContext context) {
         suiteStartTime.compareAndSet(0, System.currentTimeMillis());
         Properties.clearForCurrentThread();
+        DriverFactoryHelper.preflightRemoteGridIfConfigured();
     }
 
     @Override

--- a/shaft-engine/src/main/java/com/shaft/listeners/TestNGListener.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/TestNGListener.java
@@ -6,6 +6,7 @@ import com.epam.reportportal.testng.ITestNGService;
 import com.epam.reportportal.testng.TestNGService;
 import com.epam.reportportal.utils.MemoizingSupplier;
 import com.shaft.driver.SHAFT;
+import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.listeners.internal.*;
 import com.shaft.properties.internal.Properties;
 import com.shaft.properties.internal.ThreadLocalPropertiesManager;
@@ -143,6 +144,7 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
     @Override
     public void onStart(ISuite suite) {
         TestNGListenerHelper.setTotalNumberOfTests(suite);
+        DriverFactoryHelper.preflightRemoteGridIfConfigured();
         executionStartTime = System.currentTimeMillis();
         if (this.isReportPortalEnabledForListener) this.reportPortalTestNGService.startTestSuite(suite);
     }

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Platform.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Platform.java
@@ -52,6 +52,42 @@ public interface Platform extends EngineProperties<Platform> {
     @DefaultValue("true")
     boolean enableBiDi();
 
+    /**
+     * Enables Selenium Grid status and GraphQL preflight checks before remote session creation.
+     *
+     * @return {@code true} when remote Grid preflight checks are enabled
+     */
+    @Key("remotePreflightEnabled")
+    @DefaultValue("false")
+    boolean remotePreflightEnabled();
+
+    /**
+     * Enables per-endpoint session throttling based on detected Selenium Grid slot capacity.
+     *
+     * @return {@code true} when SHAFT should throttle local remote-session creation
+     */
+    @Key("remoteAdaptiveSessionThrottling")
+    @DefaultValue("false")
+    boolean remoteAdaptiveSessionThrottling();
+
+    /**
+     * Fails remote session startup when Grid preflight proves the requested capabilities cannot run.
+     *
+     * @return {@code true} when incompatible Grid capacity should fail before session creation
+     */
+    @Key("remotePreflightFailFast")
+    @DefaultValue("false")
+    boolean remotePreflightFailFast();
+
+    /**
+     * Timeout, in seconds, for each Selenium Grid preflight endpoint call.
+     *
+     * @return preflight HTTP timeout in seconds
+     */
+    @Key("remotePreflightTimeoutSeconds")
+    @DefaultValue("5")
+    int remotePreflightTimeoutSeconds();
+
     default SetProperty set() {
         return new SetProperty();
     }
@@ -93,6 +129,26 @@ public interface Platform extends EngineProperties<Platform> {
 
         public SetProperty enableBiDi(boolean value) {
             setProperty("enableBiDi", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty remotePreflightEnabled(boolean value) {
+            setProperty("remotePreflightEnabled", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty remoteAdaptiveSessionThrottling(boolean value) {
+            setProperty("remoteAdaptiveSessionThrottling", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty remotePreflightFailFast(boolean value) {
+            setProperty("remotePreflightFailFast", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty remotePreflightTimeoutSeconds(int value) {
+            setProperty("remotePreflightTimeoutSeconds", String.valueOf(value));
             return this;
         }
     }

--- a/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/RemoteGridPreflightUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/RemoteGridPreflightUnitTest.java
@@ -1,0 +1,155 @@
+package com.shaft.driver.internal.DriverFactory;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.properties.internal.Properties;
+import com.shaft.tools.io.internal.ReportManagerHelper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.SessionNotCreatedException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+@Test(singleThreaded = true)
+public class RemoteGridPreflightUnitTest {
+    private final String savedExecutionAddress = SHAFT.Properties.platform.executionAddress();
+    private final String savedTargetBrowserName = SHAFT.Properties.web.targetBrowserName();
+
+    @AfterMethod(alwaysRun = true)
+    public void cleanup() {
+        SHAFT.Properties.platform.set()
+                .executionAddress(savedExecutionAddress)
+                .remotePreflightEnabled(false)
+                .remoteAdaptiveSessionThrottling(false)
+                .remotePreflightFailFast(false)
+                .remotePreflightTimeoutSeconds(5);
+        SHAFT.Properties.web.set().targetBrowserName(savedTargetBrowserName);
+        RemoteGridPreflight.resetForTests();
+        Properties.clearForCurrentThread();
+    }
+
+    @Test
+    public void inspectShouldReadStatusAndGraphqlCapacityAndAttachSummary() throws Exception {
+        HttpServer server = gridServer(statusWithChromeSlots(), graphqlQueue(3));
+        server.start();
+        try (MockedStatic<ReportManagerHelper> reportManagerHelper = Mockito.mockStatic(ReportManagerHelper.class)) {
+            var report = RemoteGridPreflight.inspect(gridUrl(server), chromeCapabilities());
+
+            SHAFT.Validations.assertThat().object(report.gridMetadataAvailable()).isEqualTo(true).perform();
+            SHAFT.Validations.assertThat().object(report.matchingSlots()).isEqualTo(2).perform();
+            SHAFT.Validations.assertThat().object(report.matchingAvailableSlots()).isEqualTo(1).perform();
+            SHAFT.Validations.assertThat().object(report.queueDepth()).isEqualTo(3).perform();
+            reportManagerHelper.verify(() -> ReportManagerHelper.attach(
+                    Mockito.eq("Text"),
+                    Mockito.eq("Selenium Grid Preflight"),
+                    Mockito.contains("matchingAvailableSlots=1")));
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void beforeSessionShouldFailFastWhenGridHasNoMatchingSlots() throws Exception {
+        HttpServer server = gridServer(statusWithOnlyFirefoxSlot(), graphqlQueue(0));
+        server.start();
+        SHAFT.Properties.platform.set()
+                .remotePreflightEnabled(true)
+                .remotePreflightFailFast(true)
+                .remotePreflightTimeoutSeconds(1);
+        try (MockedStatic<ReportManagerHelper> ignored = Mockito.mockStatic(ReportManagerHelper.class)) {
+            SessionNotCreatedException failure = org.testng.Assert.expectThrows(SessionNotCreatedException.class,
+                    () -> RemoteGridPreflight.beforeSession(gridUrl(server), chromeCapabilities()));
+
+            SHAFT.Validations.assertThat().object(failure.getMessage()).contains("No Selenium Grid slot matches").perform();
+            SHAFT.Validations.assertThat().object(RemoteGridPreflight.classifyRemoteSessionFailure(failure))
+                    .isEqualTo("incompatible capabilities").perform();
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void beforeSessionShouldThrottleConcurrentLocalSessionCreationToMatchingGridCapacity() throws Exception {
+        HttpServer server = gridServer(statusWithOneFreeChromeSlot(), graphqlQueue(0));
+        server.start();
+        SHAFT.Properties.platform.set()
+                .remotePreflightEnabled(true)
+                .remoteAdaptiveSessionThrottling(true)
+                .remotePreflightTimeoutSeconds(1);
+        var executor = Executors.newSingleThreadExecutor();
+        try (MockedStatic<ReportManagerHelper> ignored = Mockito.mockStatic(ReportManagerHelper.class);
+             var firstPermit = RemoteGridPreflight.beforeSession(gridUrl(server), chromeCapabilities())) {
+            var secondPermit = executor.submit(() -> RemoteGridPreflight.beforeSession(gridUrl(server), chromeCapabilities()));
+
+            SHAFT.Validations.assertThat().object(secondPermit.isDone()).isEqualTo(false).perform();
+            firstPermit.close();
+
+            try (var acquiredSecondPermit = secondPermit.get(2, TimeUnit.SECONDS)) {
+                SHAFT.Validations.assertThat().object(acquiredSecondPermit).isNotNull().perform();
+            }
+        } finally {
+            executor.shutdownNow();
+            server.stop(0);
+        }
+    }
+
+    private static MutableCapabilities chromeCapabilities() {
+        var capabilities = new MutableCapabilities();
+        capabilities.setCapability("browserName", "chrome");
+        return capabilities;
+    }
+
+    private static String gridUrl(HttpServer server) {
+        return "http://127.0.0.1:" + server.getAddress().getPort() + "/wd/hub";
+    }
+
+    private static HttpServer gridServer(String statusBody, String graphqlBody) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/status", exchange -> sendJson(exchange, statusBody));
+        server.createContext("/graphql", exchange -> sendJson(exchange, graphqlBody));
+        return server;
+    }
+
+    private static void sendJson(HttpExchange exchange, String body) throws IOException {
+        byte[] response = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, response.length);
+        exchange.getResponseBody().write(response);
+        exchange.close();
+    }
+
+    private static String statusWithChromeSlots() {
+        return """
+                {"value":{"ready":true,"nodes":[{"status":"UP","slots":[
+                {"stereotype":{"browserName":"chrome"},"session":null},
+                {"stereotype":{"browserName":"chrome"},"session":{"id":"busy"}},
+                {"stereotype":{"browserName":"firefox"},"session":null}
+                ]}]}}""";
+    }
+
+    private static String statusWithOneFreeChromeSlot() {
+        return """
+                {"value":{"ready":true,"nodes":[{"status":"UP","slots":[
+                {"stereotype":{"browserName":"chrome"},"session":null}
+                ]}]}}""";
+    }
+
+    private static String statusWithOnlyFirefoxSlot() {
+        return """
+                {"value":{"ready":true,"nodes":[{"status":"UP","slots":[
+                {"stereotype":{"browserName":"firefox"},"session":null}
+                ]}]}}""";
+    }
+
+    private static String graphqlQueue(int queueDepth) {
+        return "{\"data\":{\"grid\":{\"sessionQueueSize\":" + queueDepth + "}}}";
+    }
+}


### PR DESCRIPTION
Closes #3056

## Summary
- Add opt-in Selenium Grid `/status` and `/graphql` preflight checks with a report attachment.
- Add fail-fast diagnostics and remote failure classification for actionable Grid problems.
- Add adaptive local session throttling and release permits when remote drivers close.
- Run suite-start preflight hooks for TestNG and JUnit.

## Validation
- `py -3 scripts/ci/validate_agent_setup.py`
- `mvn -pl shaft-engine -DskipTests test-compile`
- `mvn test -pl shaft-engine '-Dtest=RemoteGridPreflightUnitTest,DriverFactoryHelperCoverageUnitTest#createSessionInitializationFailureShouldPreserveRootCauseAndSuppressedFailures+createSessionInitializationTimeoutFailureShouldPreserveRootCauseAndSuppressedFailures' '-Dgpg.skip=true'` (5 passed, 0 failed/skipped; Allure 5 passed JSON)
- `mvn -pl shaft-engine '-DskipTests' '-Dgpg.skip=true' package`

## Notes
- Graphify refresh was attempted but blocked by a missing LLM API key; no `graphify-out` files changed.
- Docs PR: https://github.com/ShaftHQ/shafthq.github.io/pull/613