### PR TITLE
feat: bridge API and browser auth state

### DIFF
--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -806,12 +806,5 @@
   "804": "Community 804",
   "805": "Community 805",
   "806": "Community 806",
-  "807": "Community 807",
-  "808": "Community 808",
-  "809": "Community 809",
-  "810": "Community 810",
-  "811": "Community 811",
-  "812": "Community 812",
-  "813": "Community 813",
-  "815": "Community 815"
+  "809": "Community 809"
 }

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
-# Graph Report - fix-e2e-workflows-3046  (2026-06-24)
+# Graph Report - auth-cookie-bridge-3053  (2026-06-25)
 
 ## Corpus Check
-- 1052 files · ~574,249 words
+- 1035 files · ~576,084 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 14395 nodes · 37146 edges · 815 communities (715 shown, 100 thin omitted)
-- Extraction: 81% EXTRACTED · 19% INFERRED · 0% AMBIGUOUS · INFERRED: 7120 edges (avg confidence: 0.8)
+- 14506 nodes · 37488 edges · 808 communities (717 shown, 91 thin omitted)
+- Extraction: 81% EXTRACTED · 19% INFERRED · 0% AMBIGUOUS · INFERRED: 7164 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `278bcb26`
+- Built from commit: `d17ea129`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -703,17 +703,10 @@
 - [[_COMMUNITY_Community 804|Community 804]]
 - [[_COMMUNITY_Community 805|Community 805]]
 - [[_COMMUNITY_Community 806|Community 806]]
-- [[_COMMUNITY_Community 807|Community 807]]
-- [[_COMMUNITY_Community 808|Community 808]]
-- [[_COMMUNITY_Community 810|Community 810]]
-- [[_COMMUNITY_Community 811|Community 811]]
-- [[_COMMUNITY_Community 812|Community 812]]
-- [[_COMMUNITY_Community 813|Community 813]]
-- [[_COMMUNITY_Community 815|Community 815]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `SHAFT` - 289 edges
-2. `IOException` - 113 edges
+1. `SHAFT` - 291 edges
+2. `IOException` - 115 edges
 3. `RestActionsComprehensiveTests` - 99 edges
 4. `Test` - 98 edges
 5. `ArrayList` - 85 edges
@@ -738,11 +731,11 @@
 ## Import Cycles
 - None detected.
 
-## Communities (815 total, 100 thin omitted)
+## Communities (808 total, 91 thin omitted)
 
 ### Community 0 - "Community 0"
 Cohesion: 0.04
-Nodes (5): RestActionsComprehensiveTests, ComparisonType, Deprecated, BeforeMethod, Test
+Nodes (6): RestActionsComprehensiveTests, ComparisonType, InputStream, SuppressWarnings, BeforeMethod, Test
 
 ### Community 1 - "Community 1"
 Cohesion: 0.06
@@ -754,31 +747,35 @@ Nodes (19): NativeValidationsBuilder, AssertEqualsTests, VerifyEqualsTests, File
 
 ### Community 3 - "Community 3"
 Cohesion: 0.12
-Nodes (16): LocatorAssertions, Outcome, PageAssertions, Parameter, LinkedHashMap, List, Locator, Object (+8 more)
+Nodes (15): LocatorAssertions, Outcome, PageAssertions, LinkedHashMap, List, Locator, Object, Override (+7 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.07
 Nodes (6): Pilot, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 5 - "Community 5"
-Cohesion: 0.14
-Nodes (9): ScreenOrientation, AfterMethod, AndroidDriver, BeforeMethod, RemoteWebDriver, Runnable, Test, TouchActions (+1 more)
+Cohesion: 0.10
+Nodes (14): FileUploadDownloadTest, viewport(), ScreenOrientation, Test, AfterMethod, AndroidDriver, BeforeMethod, RemoteWebDriver (+6 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.06
 Nodes (14): CSVFileManager, CSVFileManagerTest, List, Map, String, BeforeMethod, Test, AfterMethod (+6 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.07
-Nodes (29): KeyboardKeys, LocatorOperation, MobileService, MobileServiceConfigurationTest, McpMobileAccessibilityTree, McpMobileContextSnapshot, McpMobileSessionResult, BrowserType (+21 more)
+Cohesion: 0.09
+Nodes (25): KeyboardKeys, LocatorOperation, MobileService, McpMobileAccessibilityTree, McpMobileContextSnapshot, McpMobileSessionResult, BrowserType, By (+17 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.17
 Nodes (8): BrowserStackSdkTests, AfterMethod, BeforeMethod, Map, Object, String, SuppressWarnings, Test
 
 ### Community 9 - "Community 9"
-Cohesion: 0.08
-Nodes (7): LambdaTest, SetProperty, Boolean, DefaultValue, Key, SetProperty, String
+Cohesion: 0.11
+Nodes (3): SetProperty, Boolean, String
+
+### Community 10 - "Community 10"
+Cohesion: 0.07
+Nodes (7): Boolean, NumbersComparativeRelation, Object, String, Test, JavaHelper, JavaHelperUnitTest
 
 ### Community 11 - "Community 11"
 Cohesion: 0.09
@@ -797,128 +794,132 @@ Cohesion: 0.08
 Nodes (30): dataString(), E, LocatorSignal, empty(), merge(), MouseButton, CaptureEventPipeline, SafePage (+22 more)
 
 ### Community 15 - "Community 15"
-Cohesion: 0.05
-Nodes (25): ShaftRestAssuredFilter, Builder, Controller, FilterableRequestSpecification, FilterableResponseSpecification, FilterContext, Headers, Controller (+17 more)
+Cohesion: 0.07
+Nodes (12): ShaftRestAssuredFilter, FilterableRequestSpecification, FilterableResponseSpecification, FilterContext, JsonElement, Object, Override, Response (+4 more)
+
+### Community 16 - "Community 16"
+Cohesion: 0.07
+Nodes (6): AfterMethod, Path, String, SuppressWarnings, Test, TerminalActionsUnitTest
 
 ### Community 17 - "Community 17"
-Cohesion: 0.11
-Nodes (8): AsyncAppender, ReportManagerHelper, ByteArrayOutputStream, Level, Path, Status, String, Throwable
+Cohesion: 0.13
+Nodes (5): ReportManagerHelper, ByteArrayOutputStream, InputStream, Level, String
 
 ### Community 18 - "Community 18"
-Cohesion: 0.12
-Nodes (14): FileActions, Boolean, Collection, Exception, File, String, SuppressWarnings, TerminalActions (+6 more)
+Cohesion: 0.09
+Nodes (20): FileActions, FileActionsCoverageUnitTest, JarEntry, Boolean, Collection, Exception, File, String (+12 more)
 
 ### Community 19 - "Community 19"
-Cohesion: 0.13
-Nodes (10): McpMobileToolchainService, McpAndroidEmulatorProposal, List, Map, McpMobileToolchainStatus, McpProcessRunner, Path, Process (+2 more)
+Cohesion: 0.11
+Nodes (14): McpMobileToolchainService, McpAndroidEmulatorProposal, Duration, List, Map, McpMobileDevice, McpMobileToolchainDiagnostic, McpMobileToolchainStatus (+6 more)
 
 ### Community 20 - "Community 20"
-Cohesion: 0.09
-Nodes (12): TestNGListenerHelper, Browser, ISuite, ITestContext, ITestNGMethod, ITestResult, List, Method (+4 more)
+Cohesion: 0.15
+Nodes (6): Jira, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 21 - "Community 21"
-Cohesion: 0.14
-Nodes (13): WebDriverListener, Navigation, Alert, By, Method, Object, String, URL (+5 more)
+Cohesion: 0.07
+Nodes (23): BrowserStackModuleTest, CaptureCliTest, WebDriverListener, InvocationTargetException, JsonSchemaValidatorTest, Navigation, Test, Class (+15 more)
 
 ### Community 22 - "Community 22"
 Cohesion: 0.19
 Nodes (12): AfterAllCallback, AfterTestExecutionCallback, BeforeAllCallback, BeforeEachCallback, LifecycleMethodExecutionExceptionHandler, JunitExtension, ExtensionContext, Method (+4 more)
 
 ### Community 23 - "Community 23"
-Cohesion: 0.09
-Nodes (18): ClassLoader, ImageProcessingActionsCoverageUnitTest, OpenCvBlockingClassLoader, List, AfterMethod, BeforeMethod, BufferedImage, Class (+10 more)
+Cohesion: 0.10
+Nodes (14): ImageProcessingActionsCoverageUnitTest, List, Override, AfterMethod, BeforeMethod, BufferedImage, Color, DataProvider (+6 more)
 
 ### Community 24 - "Community 24"
-Cohesion: 0.09
-Nodes (10): AllureManager, BooleanSupplier, ArrayNode, Future, InputStream, List, ObjectNode, Path (+2 more)
+Cohesion: 0.07
+Nodes (15): skipped(), AllureManager, expired(), String, Validation, BooleanSupplier, Counts, ArrayNode (+7 more)
 
 ### Community 25 - "Community 25"
 Cohesion: 0.05
 Nodes (47): AllureVerdict, DoctorRepairPublicationRequest, ExistingPullRequest, GuardedPatch, PatchManifestEntry, RecordingRunner, changedSince(), DoctorRepairService (+39 more)
 
 ### Community 26 - "Community 26"
-Cohesion: 0.07
-Nodes (15): DriverFactoryHelperCoverageUnitTest, TestableDriverFactoryHelper, OptionsManager, AfterMethod, AtomicInteger, CountDownLatch, DriverFactoryHelper, DriverType (+7 more)
+Cohesion: 0.08
+Nodes (14): DriverFactoryHelperCoverageUnitTest, TestableDriverFactoryHelper, AfterMethod, AtomicInteger, CountDownLatch, DriverFactoryHelper, DriverType, Method (+6 more)
 
 ### Community 27 - "Community 27"
 Cohesion: 0.08
 Nodes (4): ValidationTests, AfterMethod, BeforeMethod, Test
 
 ### Community 28 - "Community 28"
-Cohesion: 0.13
-Nodes (5): AfterMethod, Path, String, Test, ThreadLocalPropertiesTest
+Cohesion: 0.09
+Nodes (9): ThreadLocalPropertiesManager, Properties, String, BeforeMethod, AfterMethod, Path, String, Test (+1 more)
 
 ### Community 29 - "Community 29"
-Cohesion: 0.11
-Nodes (15): AccessibilityConfig, AccessibilityHelper, AccessibilityResult, AxeBuilder, AccessibilityResult, Integer, JSONArray, JSONObject (+7 more)
+Cohesion: 0.17
+Nodes (10): AccessibilityConfig, AccessibilityHelper, AccessibilityResult, Integer, JSONArray, JSONObject, Map, Results (+2 more)
 
 ### Community 30 - "Community 30"
 Cohesion: 0.17
 Nodes (4): AfterClass, BeforeClass, Test, APITests
 
 ### Community 31 - "Community 31"
-Cohesion: 0.16
-Nodes (11): TerminalActions, ProcessBuilder, Boolean, BufferedReader, Exception, Future, InputStream, List (+3 more)
+Cohesion: 0.10
+Nodes (16): ChannelSftp, TerminalActions, ProcessBuilder, SftpTransferDirection, Boolean, BufferedReader, Deprecated, Exception (+8 more)
 
 ### Community 32 - "Community 32"
 Cohesion: 0.10
 Nodes (7): AfterMethod, Class, Object, Path, String, Test, AllureManagerUnitTest
 
 ### Community 33 - "Community 33"
-Cohesion: 0.17
-Nodes (11): AlertEvent, DataPlan, MutableTargetPlan, CodegenBackend, EventContext, ExternalTestDataReference, LocatorSelection, StringBuilder (+3 more)
+Cohesion: 0.19
+Nodes (9): AlertEvent, DataPlan, CodegenBackend, EventContext, ExternalTestDataReference, StringBuilder, VerificationKind, WaitEvent (+1 more)
 
 ### Community 34 - "Community 34"
-Cohesion: 0.19
-Nodes (12): PilotNaturalActionPlanner, NaturalActionKind, NaturalActionPlanner, NaturalActionStep, AiExecutionService, By, JsonNode, NaturalActionPlan (+4 more)
+Cohesion: 0.08
+Nodes (27): DeterministicNaturalActionPlanner, unsupported(), NaturalActionPlannerRegistry, PilotNaturalActionPlanner, NaturalActionKind, NaturalActionPlanner, NaturalActionStep, List (+19 more)
 
 ### Community 35 - "Community 35"
-Cohesion: 0.07
-Nodes (30): Constructor, skipped(), IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor (+22 more)
+Cohesion: 0.05
+Nodes (37): Constructor, IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, StatusIcon() (+29 more)
 
 ### Community 36 - "Community 36"
-Cohesion: 0.07
-Nodes (27): DataTableArgument, EmbedEvent, HookTestStep, CucumberFeatureListener, PickleStepTestStep, Result, Scenario, AllureLifecycle (+19 more)
+Cohesion: 0.08
+Nodes (25): DataTableArgument, HookTestStep, CucumberFeatureListener, PickleStepTestStep, Result, Scenario, AllureLifecycle, EventPublisher (+17 more)
 
 ### Community 37 - "Community 37"
-Cohesion: 0.09
-Nodes (16): ApiPerformanceExecutionReport, Paths, SetProperty, PathsTests, DefaultValue, Key, SetProperty, String (+8 more)
+Cohesion: 0.13
+Nodes (9): Paths, SetProperty, PathsTests, DefaultValue, Key, SetProperty, String, BeforeClass (+1 more)
 
 ### Community 38 - "Community 38"
-Cohesion: 0.10
-Nodes (18): BrowserNetworkInterceptor, Capabilities, ClientConfig, DriverFactoryHelper, BrowserNetworkInterceptionRule, Class, DriverType, List (+10 more)
+Cohesion: 0.09
+Nodes (18): BrowserNetworkInterceptor, ClientConfig, DriverFactoryHelper, BrowserNetworkInterceptionRule, Capabilities, Class, DriverType, List (+10 more)
 
 ### Community 39 - "Community 39"
 Cohesion: 0.09
-Nodes (11): AfterMethod, BeforeMethod, Class, List, Object, Path, String, T (+3 more)
+Nodes (12): Boolean, AfterMethod, BeforeMethod, Class, List, Object, Path, String (+4 more)
 
 ### Community 40 - "Community 40"
-Cohesion: 0.10
-Nodes (12): NavigationAction, BrowserActions, Cookie, List, NetworkInterceptionRequestBuilder, Override, Set, String (+4 more)
+Cohesion: 0.08
+Nodes (13): NavigationAction, API, BrowserActions, Cookie, List, NetworkInterceptionRequestBuilder, Override, Screenshots (+5 more)
 
 ### Community 41 - "Community 41"
-Cohesion: 0.17
-Nodes (15): CollectionState, EvidenceCollector, CollectionState, DoctorRedactor, DefaultPrettyPrinter, DoctorAnalysisRequest, EvidenceBundle, EvidenceCategory (+7 more)
+Cohesion: 0.16
+Nodes (16): CollectionState, EvidenceCollector, FilesSize, CollectionState, DoctorRedactor, DefaultPrettyPrinter, DoctorAnalysisRequest, EvidenceBundle (+8 more)
 
 ### Community 42 - "Community 42"
-Cohesion: 0.12
-Nodes (11): ElementLookup, GetElementInformation, Actions, GetElementInformation, By, JavascriptExecutor, List, Override (+3 more)
+Cohesion: 0.15
+Nodes (8): ClipboardAction, GetElementInformation, Beta, By, ClipboardAction, Override, Step, String
 
 ### Community 43 - "Community 43"
 Cohesion: 0.07
 Nodes (9): TextDirectionValidationsBuilder, E2ECoverageTests, NativeValidationsBuilder, ValidationsExecutor, AfterMethod, BeforeMethod, Test, TextDirection (+1 more)
 
 ### Community 44 - "Community 44"
-Cohesion: 0.18
-Nodes (5): BeforeMethod, AfterMethod, String, Test, PropertyFileManagerUnitTest
+Cohesion: 0.15
+Nodes (4): LambdaTest, DefaultValue, Key, SetProperty
 
 ### Community 45 - "Community 45"
 Cohesion: 0.10
-Nodes (20): ActionsCoverageUnitTest, RecordingActions, RecordingActions, ActionType, AfterMethod, AllureLifecycle, BeforeMethod, By (+12 more)
+Nodes (20): ActionsCoverageUnitTest, RecordingActions, Parameter, RecordingActions, ActionType, AfterMethod, AllureLifecycle, BeforeMethod (+12 more)
 
 ### Community 46 - "Community 46"
-Cohesion: 0.15
-Nodes (8): AssertionSteps, PDFTests, ValidationsBuilderTests, String, Then, ThreadLocal, WebDriver, String
+Cohesion: 0.18
+Nodes (6): AssertionSteps, PDFTests, ValidationsBuilderTests, String, Then, String
 
 ### Community 47 - "Community 47"
 Cohesion: 0.08
@@ -937,48 +938,48 @@ Cohesion: 0.04
 Nodes (47): additionalProperties, minLength, type, maximum, minimum, type, type, minLength (+39 more)
 
 ### Community 51 - "Community 51"
-Cohesion: 0.09
-Nodes (11): AssertApiResponseEqualsTests, ApiActionsMockedTests, RequestBuilder, Test, AfterMethod, BeforeMethod, Test, AfterClass (+3 more)
+Cohesion: 0.06
+Nodes (15): AssertApiResponseEqualsTests, MatchJsonSchemaTests, ApiActionsMockedTests, RequestBuilder, RequestType, Test, Test, AfterMethod (+7 more)
 
 ### Community 52 - "Community 52"
-Cohesion: 0.11
-Nodes (11): AccessibilityActions, AccessibilityConfig, AccessibilityTest, AccessibilityResult, BrowserActions, List, String, WebDriver (+3 more)
+Cohesion: 0.16
+Nodes (4): AccessibilityTest, AfterMethod, BeforeMethod, Test
 
 ### Community 53 - "Community 53"
 Cohesion: 0.11
-Nodes (19): RestActions, GraphqlRequestTests, RequestSpecBuilder, RestAssuredConfig, API, ArrayNode, Boolean, ContentType (+11 more)
+Nodes (15): RestActions, RequestSpecBuilder, API, ArrayNode, Boolean, Cookie, Deprecated, List (+7 more)
 
 ### Community 54 - "Community 54"
 Cohesion: 0.11
 Nodes (34): AllureFailure, _clean_cell(), extract_failures(), extract_surefire_failures(), _failure_group_key(), _first_trace_line(), _is_allure_test_result_payload(), _is_generated_report_non_test_result() (+26 more)
 
 ### Community 55 - "Community 55"
-Cohesion: 0.19
-Nodes (11): ElementActionsHelper, TextDetectionStrategy(), Boolean, By, HealingResolution, List, Map, Object (+3 more)
+Cohesion: 0.17
+Nodes (13): ElementActionsHelper, TextDetectionStrategy(), Boolean, By, ClipboardAction, HealingResolution, List, Map (+5 more)
 
 ### Community 56 - "Community 56"
-Cohesion: 0.14
-Nodes (14): McpMobileInspectorRecordingService, Session, Duration, List, Map, McpCodeBlock, McpMobileInspectorPlan, McpMobileInspectorRecordingStatus (+6 more)
+Cohesion: 0.13
+Nodes (17): McpMobileInspectorRecordingService, Session, Duration, List, Map, McpCodeBlock, McpMobileDevice, McpMobileInspectorPlan (+9 more)
 
 ### Community 57 - "Community 57"
 Cohesion: 0.13
 Nodes (21): ExchangeHandler, FailureCase, ExchangeHandler, ProviderConformanceTest, AfterEach, AiProvider, AiRequest, AiResponse (+13 more)
 
 ### Community 58 - "Community 58"
-Cohesion: 0.10
-Nodes (13): MockedResponseBuilder, NetworkInterceptionRequestBuilder, HttpMethod, MockedResponseBuilder, BrowserActions, Consumer, HttpRequest, HttpResponse (+5 more)
+Cohesion: 0.15
+Nodes (5): MockedResponseBuilder, NetworkInterceptionRequestBuilder, MockedResponseBuilder, Map, String
 
 ### Community 59 - "Community 59"
 Cohesion: 0.14
 Nodes (20): CaptureControlClient, CaptureCli, flag(), parse(), path(), pathRequired(), required(), value() (+12 more)
 
 ### Community 60 - "Community 60"
-Cohesion: 0.12
+Cohesion: 0.11
 Nodes (19): Document, GuideHttpClient, GuideIndex, GuideHttpClient, GuideService, JdkGuideHttpClient, McpGuideMatch, McpGuideSearchResult (+11 more)
 
 ### Community 61 - "Community 61"
-Cohesion: 0.13
-Nodes (14): AllureListenerCoverageUnitTest, Throwable, AfterMethod, BeforeMethod, ITestResult, List, Path, String (+6 more)
+Cohesion: 0.12
+Nodes (15): AllureListenerCoverageUnitTest, Throwable, Status, AfterMethod, BeforeMethod, ITestResult, List, Path (+7 more)
 
 ### Community 62 - "Community 62"
 Cohesion: 0.14
@@ -1010,23 +1011,27 @@ Nodes (42): additionalProperties, default, description, examples, $id, title, ty
 
 ### Community 69 - "Community 69"
 Cohesion: 0.10
-Nodes (11): DriverFactoryHelper, AfterMethod, AtomicInteger, CountDownLatch, DriverType, Method, MutableCapabilities, Override (+3 more)
+Nodes (12): DriverFactoryHelper, OptionsManager, AfterMethod, AtomicInteger, CountDownLatch, DriverType, Method, MutableCapabilities (+4 more)
 
 ### Community 70 - "Community 70"
 Cohesion: 0.10
 Nodes (43): expand_globs(), issue(), load_budget(), local_link_targets(), markdown_body(), normalized_paragraphs(), parse_frontmatter(), quoted_yaml_value() (+35 more)
 
 ### Community 71 - "Community 71"
-Cohesion: 0.09
-Nodes (21): ShaftHeal, ShaftHealingProviderTest, WebDomHealingAcceptanceTest, HealingReport, Optional, AfterMethod, AppiumDriver, BeforeMethod (+13 more)
+Cohesion: 0.13
+Nodes (15): ShaftHeal, ShaftHealingProviderTest, HealingReport, Optional, AfterMethod, AppiumDriver, BeforeMethod, DataProvider (+7 more)
+
+### Community 72 - "Community 72"
+Cohesion: 0.19
+Nodes (13): DoctorAnalyzerTest, DoctorAiAnalysisResult, Arguments, CauseCategory, DoctorAnalysisRequest, DoctorAnalysisResult, List, MethodSource (+5 more)
 
 ### Community 73 - "Community 73"
 Cohesion: 0.13
-Nodes (15): CaptureFixtures, CaptureGeneratorTest, PageContext, BrowserMetadata, CaptureEvent, CaptureSession, ElementSnapshot, EventContext (+7 more)
+Nodes (16): denyAll(), CaptureFixtures, CaptureGeneratorTest, PageContext, BrowserMetadata, CaptureEvent, CaptureSession, ElementSnapshot (+8 more)
 
 ### Community 74 - "Community 74"
-Cohesion: 0.10
-Nodes (16): CaptureEventPipeline, CapturePrivacyClassifier, ManagedCaptureRecorder, ProfileCleanupException, BrowserMetadata, BrowserSignal, CapturePrivacyPolicy, CaptureSessionStore (+8 more)
+Cohesion: 0.11
+Nodes (15): CaptureEventPipeline, CapturePrivacyClassifier, ManagedCaptureRecorder, BrowserMetadata, BrowserSignal, CapturePrivacyPolicy, CaptureSessionStore, CaptureStartRequest (+7 more)
 
 ### Community 75 - "Community 75"
 Cohesion: 0.15
@@ -1037,44 +1042,44 @@ Cohesion: 0.08
 Nodes (26): Session1Test, LocatorOperation, PlaywrightService, AfterMethod, BeforeMethod, String, Test, By (+18 more)
 
 ### Community 77 - "Community 77"
-Cohesion: 0.24
-Nodes (4): Web, DefaultValue, Key, SetProperty
+Cohesion: 0.12
+Nodes (6): SetProperty, Web, DefaultValue, Key, SetProperty, String
 
 ### Community 78 - "Community 78"
 Cohesion: 0.05
 Nodes (40): additionalProperties, enum, pattern, type, pattern, type, items, type (+32 more)
 
 ### Community 79 - "Community 79"
-Cohesion: 0.13
-Nodes (13): CaptureControlFiles, CaptureControlFilesTest, CaptureControlServerClientTest, ControlDescriptor, CaptureStartRequest, CaptureStatus, Class, Object (+5 more)
+Cohesion: 0.18
+Nodes (9): CaptureControlFiles, ControlDescriptor, CaptureStartRequest, CaptureStatus, Class, Object, Path, String (+1 more)
 
 ### Community 80 - "Community 80"
-Cohesion: 0.18
-Nodes (10): ElementService, LocatorOperation, By, Deprecated, LocatorOperation, locatorStrategy, String, Tool (+2 more)
+Cohesion: 0.17
+Nodes (11): ElementService, LocatorOperation, By, Deprecated, LocatorOperation, locatorStrategy, String, Tool (+3 more)
 
 ### Community 81 - "Community 81"
-Cohesion: 0.17
-Nodes (9): IOSDriver, AfterClass, AfterMethod, Boolean, SuppressWarnings, Test, ThreadLocal, WebDriver (+1 more)
+Cohesion: 0.18
+Nodes (8): AfterClass, AfterMethod, Boolean, SuppressWarnings, Test, ThreadLocal, WebDriver, RecordManagerTest
 
 ### Community 82 - "Community 82"
 Cohesion: 0.05
 Nodes (39): additionalProperties, type, maximum, minimum, type, additionalProperties, properties, required (+31 more)
 
 ### Community 84 - "Community 84"
-Cohesion: 0.06
-Nodes (26): RestActionsCoverageUnitTest, option(), ProviderConfiguration(), ProviderConfigurationTest, FirestoreRestClient, SetProperty, Properties, CaptureStartRequest() (+18 more)
+Cohesion: 0.09
+Nodes (21): option(), ProviderConfiguration(), ProviderConfigurationTest, FirestoreRestClient, Properties, CaptureStartRequest(), validateUrl(), CaptureBrowser (+13 more)
 
 ### Community 85 - "Community 85"
 Cohesion: 0.14
 Nodes (14): ClassifiedUpload, CapturePrivacyClassifier, CapturePrivacyClassifierTest, SanitizedAttributes, SanitizedText, CapturePrivacyPolicy, ClassifiedValue, List (+6 more)
 
 ### Community 86 - "Community 86"
-Cohesion: 0.13
-Nodes (11): EngineService, EngineServiceRuntimePathTest, PostConstruct, BrowserType, Path, String, Tool, WebDriver (+3 more)
+Cohesion: 0.07
+Nodes (21): EngineService, EngineServiceRuntimePathTest, McpServiceHelperTest, MobileServiceConfigurationTest, PostConstruct, BrowserType, Path, String (+13 more)
 
 ### Community 87 - "Community 87"
-Cohesion: 0.11
-Nodes (19): getValue(), KeyboardKeys(), TouchActions, ImmutableMap, viewport(), By, DriverFactoryHelper, File (+11 more)
+Cohesion: 0.13
+Nodes (17): getValue(), KeyboardKeys(), TouchActions, ImmutableMap, By, DriverFactoryHelper, File, HashMap (+9 more)
 
 ### Community 88 - "Community 88"
 Cohesion: 0.18
@@ -1085,8 +1090,8 @@ Cohesion: 0.23
 Nodes (6): WebDriverElementValidationsBuilder, NativeValidationsBuilder, Override, String, ValidationsExecutor, VisualValidationEngine
 
 ### Community 90 - "Community 90"
-Cohesion: 0.22
-Nodes (11): CaptureEvent, CaptureJsonCodec, CaptureSession, Checkpoint, ExternalTestDataReference, Instant, List, Path (+3 more)
+Cohesion: 0.11
+Nodes (29): append(), checkpoint(), complete(), ensureIncomplete(), interrupt(), sortedCheckpoints(), sortedEvents(), sortedReferences() (+21 more)
 
 ### Community 91 - "Community 91"
 Cohesion: 0.10
@@ -1109,20 +1114,20 @@ Cohesion: 0.09
 Nodes (19): builder(), evidenceCategories(), withSanitizedContent(), withTimeout(), AiValueObjectsTest, AiAuditSink, ShaftAiAuditSink, AiRequest (+11 more)
 
 ### Community 96 - "Community 96"
-Cohesion: 0.11
-Nodes (16): DriverFactory, DriverType(), DatabaseActions, DatabaseType, Deprecated, DriverFactoryHelper, DriverType, MutableCapabilities (+8 more)
+Cohesion: 0.06
+Nodes (28): DriverFactory, DriverType(), LambdaTestHelper, DatabaseActions, DatabaseType, Deprecated, DriverFactoryHelper, DriverType (+20 more)
 
 ### Community 97 - "Community 97"
 Cohesion: 0.07
 Nodes (14): be(), Bt(), Dt(), $e(), Ee(), ft(), ke(), l() (+6 more)
 
 ### Community 98 - "Community 98"
-Cohesion: 0.26
-Nodes (4): Healing, DefaultValue, Key, SetProperty
+Cohesion: 0.13
+Nodes (6): Healing, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 99 - "Community 99"
-Cohesion: 0.26
-Nodes (5): SilentElementReader, By, String, ValidationComparisonType, WebDriver
+Cohesion: 0.32
+Nodes (3): ValidationsHelper, String, WebDriver
 
 ### Community 100 - "Community 100"
 Cohesion: 0.13
@@ -1133,15 +1138,15 @@ Cohesion: 0.06
 Nodes (36): additionalProperties, minLength, type, type, type, type, $id, additionalProperties (+28 more)
 
 ### Community 102 - "Community 102"
-Cohesion: 0.16
-Nodes (19): DoctorAiAnalysisServiceTest, EnumSource, from(), DoctorAnalysisResult, DoctorAnalysisSummary, AiRequest, AiResponse, AiResponseStatus (+11 more)
+Cohesion: 0.17
+Nodes (18): DoctorAiAnalysisServiceTest, EnumSource, from(), DoctorAnalysisResult, DoctorAnalysisSummary, AiRequest, AiResponse, AiResponseStatus (+10 more)
 
 ### Community 103 - "Community 103"
 Cohesion: 0.18
 Nodes (11): AlertActionsContext, AfterMethod, Alert, AlertActions, BeforeMethod, Object, String, Test (+3 more)
 
 ### Community 104 - "Community 104"
-Cohesion: 0.24
+Cohesion: 0.22
 Nodes (6): Dimension, BrowserActionsHelper, Boolean, SneakyThrows, String, WebDriver
 
 ### Community 105 - "Community 105"
@@ -1149,8 +1154,8 @@ Cohesion: 0.14
 Nodes (14): BadRequestException, CaptureControlServer, Handler, Handler, CaptureControlFiles, CaptureManager, CaptureStatus, Class (+6 more)
 
 ### Community 106 - "Community 106"
-Cohesion: 0.13
-Nodes (11): FluentWait, ElementsHelperCoverageUnitTest, MockedStatic, AfterMethod, BeforeMethod, DriverFactoryHelper, MockedConstruction, RuntimeException (+3 more)
+Cohesion: 0.12
+Nodes (13): FluentWait, ElementsHelperCoverageUnitTest, MockedStatic, Class, Throwable, AfterMethod, BeforeMethod, DriverFactoryHelper (+5 more)
 
 ### Community 107 - "Community 107"
 Cohesion: 0.13
@@ -1161,24 +1166,24 @@ Cohesion: 0.13
 Nodes (5): YAMLFileManagerTests, BeforeMethod, Date, String, Test
 
 ### Community 109 - "Community 109"
-Cohesion: 0.16
-Nodes (6): AfterTest, BeforeTest, ConfigurationHelper, ReportHelper, ITestContext, Step
+Cohesion: 0.31
+Nodes (5): AfterTest, BeforeTest, ConfigurationHelper, ITestContext, Step
 
 ### Community 110 - "Community 110"
-Cohesion: 0.15
-Nodes (15): AiExecutionServiceTest, StubProvider, denyAll(), AiCapabilities, AiExecutionService, AiProviderAvailability, AiProviderRegistry, AiRequest (+7 more)
+Cohesion: 0.16
+Nodes (14): AiExecutionServiceTest, StubProvider, AiCapabilities, AiExecutionService, AiProviderAvailability, AiProviderRegistry, AiRequest, AiResponse (+6 more)
 
 ### Community 111 - "Community 111"
 Cohesion: 0.17
 Nodes (17): DeterministicRuleEngine, Confidence, Finding, Remediation, RetrySummary, RuleMatch, CauseCategory, Diagnosis (+9 more)
 
 ### Community 112 - "Community 112"
-Cohesion: 0.10
-Nodes (17): CSVFileManager, API, CSV, GUI, Locator, Properties, Report, TestData (+9 more)
+Cohesion: 0.08
+Nodes (20): CSVFileManager, API, CSV, GUI, Locator, Properties, Report, TestData (+12 more)
 
 ### Community 113 - "Community 113"
-Cohesion: 0.10
-Nodes (13): MobileRecordingServiceTest, Role, Override, AfterMethod, Test, Class, Object, String (+5 more)
+Cohesion: 0.24
+Nodes (6): Class, Object, String, SuppressWarnings, Test, SmartLocatorsCoverageUnitTest
 
 ### Community 114 - "Community 114"
 Cohesion: 0.15
@@ -1190,11 +1195,11 @@ Nodes (34): enum, type, items, type, items, type, $id, required (+26 more)
 
 ### Community 116 - "Community 116"
 Cohesion: 0.11
-Nodes (22): ActionReportContext, abbreviate(), empty(), from(), hasElementName(), hasLocator(), hasStepTarget(), hasStepValue() (+14 more)
+Nodes (20): ActionReportContext, abbreviate(), empty(), from(), hasElementName(), hasLocator(), hasStepTarget(), hasStepValue() (+12 more)
 
 ### Community 117 - "Community 117"
-Cohesion: 0.17
-Nodes (19): AllureFile, changedSince(), HealerService, ProcessExecutor, successful(), McpHealerAttemptResult, McpHealerRunResult, AllureSnapshot (+11 more)
+Cohesion: 0.15
+Nodes (21): AllureFile, changedSince(), HealerService, ProcessExecutor, successful(), McpHealerAttemptResult, McpHealerRunResult, ProcessExecutor (+13 more)
 
 ### Community 118 - "Community 118"
 Cohesion: 0.18
@@ -1205,8 +1210,8 @@ Cohesion: 0.08
 Nodes (19): Async, Driver, Playwright, WebDriver, PlaywrightDriverAssertions, PlaywrightDriverVerifications, Actions, AlertActions (+11 more)
 
 ### Community 120 - "Community 120"
-Cohesion: 0.20
-Nodes (12): YAMLFileManager, Boolean, Class, Date, Double, Integer, List, Long (+4 more)
+Cohesion: 0.18
+Nodes (13): EmbedEvent, YAMLFileManager, Boolean, Class, Date, Double, Integer, List (+5 more)
 
 ### Community 121 - "Community 121"
 Cohesion: 0.15
@@ -1225,8 +1230,8 @@ Cohesion: 0.11
 Nodes (25): AiTrigger, HealingProvider, ShaftHealingProvider, safe(), stableKey(), HealingActionOutcome, HealingCandidate, HealingConfiguration (+17 more)
 
 ### Community 125 - "Community 125"
-Cohesion: 0.14
-Nodes (14): ExecutionCountsTracker, LauncherSessionListener, JunitListener, String, TestExecutionInfo, Counts, Method, Status (+6 more)
+Cohesion: 0.23
+Nodes (10): LauncherSessionListener, JunitListener, Method, Status, StatusIcon, String, TestExecutionInfo, TestIdentifier (+2 more)
 
 ### Community 126 - "Community 126"
 Cohesion: 0.18
@@ -1241,16 +1246,16 @@ Cohesion: 0.18
 Nodes (14): AiExecutionService, CircuitState, AiAuditSink, AiProvider, AiProviderRegistry, AiRequest, AiResponse, AiResponseStatus (+6 more)
 
 ### Community 129 - "Community 129"
-Cohesion: 0.17
-Nodes (6): Platform, SetProperty, DefaultValue, Key, SetProperty, String
+Cohesion: 0.13
+Nodes (15): Builder, Controller, Headers, Controller, McpAppiumInspectorProxy, McpAppiumCommandRecorder, HttpExchange, HttpResponse (+7 more)
 
 ### Community 130 - "Community 130"
-Cohesion: 0.15
-Nodes (12): Config, List, String, SuppressWarnings, AfterMethod, BeforeMethod, HttpExchange, Object (+4 more)
+Cohesion: 0.18
+Nodes (11): Config, List, String, SuppressWarnings, BeforeMethod, HttpExchange, Object, String (+3 more)
 
 ### Community 131 - "Community 131"
 Cohesion: 0.09
-Nodes (26): DoctorRepairProposalResult, DoctorRepairService, HealingLocatorProposalRequest, DoctorService, McpResultRecordsTest, McpWorkspacePolicy, McpDoctorRemediationService, ApprovalPolicy (+18 more)
+Nodes (28): DoctorRepairProposalResult, DoctorRepairService, CaptureFormatException, HealingLocatorProposalRequest, DoctorService, McpWorkspacePolicy, McpDoctorRemediationService, String (+20 more)
 
 ### Community 132 - "Community 132"
 Cohesion: 0.15
@@ -1261,8 +1266,8 @@ Cohesion: 0.15
 Nodes (10): PackageActivity, BufferedReader, File, Optional, String, Path, String, Test (+2 more)
 
 ### Community 134 - "Community 134"
-Cohesion: 0.06
-Nodes (16): Jira, SetProperty, Mobile, SetProperty, PropertiesManagerTests, JiraTests, DefaultValue, Key (+8 more)
+Cohesion: 0.14
+Nodes (7): Mobile, SetProperty, PropertiesManagerTests, DefaultValue, Key, SetProperty, String
 
 ### Community 135 - "Community 135"
 Cohesion: 0.10
@@ -1273,8 +1278,8 @@ Cohesion: 0.16
 Nodes (27): ut(), _(), a(), b(), c(), d(), f(), g() (+19 more)
 
 ### Community 137 - "Community 137"
-Cohesion: 0.10
-Nodes (12): IIOMetadataNode, AnimatedGifManager, GifSession, ImageOutputStream, ImageWriter, getType(), RenderedImage, Screenshots (+4 more)
+Cohesion: 0.12
+Nodes (9): IIOMetadataNode, AnimatedGifManager, GifSession, ImageOutputStream, ImageWriter, RenderedImage, BufferedImage, String (+1 more)
 
 ### Community 138 - "Community 138"
 Cohesion: 0.17
@@ -1289,8 +1294,8 @@ Cohesion: 0.06
 Nodes (30): additionalProperties, type, type, minimum, type, minimum, type, $id (+22 more)
 
 ### Community 141 - "Community 141"
-Cohesion: 0.18
-Nodes (10): AccessibilityHelperCoverageUnitTest, AfterMethod, List, MockedConstruction, Path, Results, Rule, String (+2 more)
+Cohesion: 0.14
+Nodes (13): AccessibilityHelperCoverageUnitTest, AxeBuilder, List, Rule, AfterMethod, List, MockedConstruction, Path (+5 more)
 
 ### Community 142 - "Community 142"
 Cohesion: 0.13
@@ -1305,43 +1310,43 @@ Cohesion: 0.12
 Nodes (5): AfterMethod, Runnable, String, Test, ValidationHelperUnitTest
 
 ### Community 145 - "Community 145"
-Cohesion: 0.17
-Nodes (9): DataType, JSON, JSONFileManager, JSONFileManagerTests, List, Map, Object, String (+1 more)
+Cohesion: 0.14
+Nodes (11): DataType, JSON, JSONFileManager, JSONFileManagerTests, List, Map, Object, String (+3 more)
 
 ### Community 146 - "Community 146"
 Cohesion: 0.15
 Nodes (16): CaptureCodegenStartRequest, CaptureCodegenStartRequest, CaptureService, McpCaptureCodeBlockService, McpCaptureReplayResult, PreDestroy, CaptureGenerationResult, CaptureManager (+8 more)
 
 ### Community 147 - "Community 147"
-Cohesion: 0.13
-Nodes (14): BrowserEventScript, CaptureCollectorUtilityTest, close(), start(), List, String, BrowserSignal, Class (+6 more)
+Cohesion: 0.35
+Nodes (3): BrowserEventScript, List, String
 
 ### Community 148 - "Community 148"
-Cohesion: 0.11
-Nodes (24): DeterministicRuleEngine, DoctorAnalyzer, DoctorAiAnalysisResult, DoctorReportWriter, DoctorTriage, EvidenceCollector, ExecutionIntelligence, Diagnosis (+16 more)
+Cohesion: 0.14
+Nodes (18): DeterministicRuleEngine, DoctorAnalyzer, DoctorReportWriter, DoctorTriage, EvidenceCollector, ExecutionIntelligence, Diagnosis, DoctorAiAnalysisRequest (+10 more)
 
 ### Community 149 - "Community 149"
-Cohesion: 0.18
-Nodes (4): Flags, DefaultValue, Key, SetProperty
+Cohesion: 0.08
+Nodes (6): Flags, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 150 - "Community 150"
 Cohesion: 0.20
 Nodes (20): DoctorCli, flag(), optionalPath(), parse(), path(), pathRequired(), paths(), pathsRequired() (+12 more)
 
 ### Community 151 - "Community 151"
-Cohesion: 0.08
-Nodes (21): ImageProcessingActions, Boolean, By, Color, File, Integer, List, Rectangle (+13 more)
+Cohesion: 0.11
+Nodes (12): Color, Rectangle, AfterMethod, BeforeMethod, Color, Map, Method, Path (+4 more)
 
 ### Community 152 - "Community 152"
-Cohesion: 0.19
+Cohesion: 0.20
 Nodes (11): LocatorRef, McpAppiumCommandRecorder, PointerGesture, BooleanSupplier, JsonNode, locatorStrategy, Map, McpMobileRecordedAction (+3 more)
 
 ### Community 153 - "Community 153"
 Cohesion: 0.08
-Nodes (15): RestValidationsBuilder, JSONValidationsBuilder, JsonCompareWithSpecialCharactersTests, NativeValidationsBuilder, NumberValidationsBuilder, Object, String, StringBuilder (+7 more)
+Nodes (14): RestValidationsBuilder, JSONValidationsBuilder, JsonCompareWithSpecialCharactersTests, NativeValidationsBuilder, NumberValidationsBuilder, Object, String, StringBuilder (+6 more)
 
 ### Community 154 - "Community 154"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (11): HistoryDocument, HistoryRecord, HealingHistoryStore, HealingConfiguration, HealingContext, LocatorFingerprint, Optional, Path (+3 more)
 
 ### Community 155 - "Community 155"
@@ -1349,20 +1354,20 @@ Cohesion: 0.07
 Nodes (28): BomConsumer, CapturingProvider, ImageProcessingActionsPlaywrightVisualTest, AlphaProvider, VisualProcessingProviderRegistryTest, ZuluProvider, AfterMethod, Boolean (+20 more)
 
 ### Community 156 - "Community 156"
-Cohesion: 0.20
-Nodes (11): ScreenshotManager, Boolean, By, JavascriptExecutor, List, Object, Screenshots, SneakyThrows (+3 more)
+Cohesion: 0.18
+Nodes (12): ScreenshotManager, Object, Boolean, By, JavascriptExecutor, List, Object, Screenshots (+4 more)
 
 ### Community 157 - "Community 157"
 Cohesion: 0.18
 Nodes (12): By, ElementActions, ElementAssertions, List, Locator, Map, Override, PlaywrightSession (+4 more)
 
 ### Community 158 - "Community 158"
-Cohesion: 0.13
-Nodes (7): LocatorBuilderTest, XpathAxis, LocatorBuilder, String, AfterMethod, BeforeMethod, Test
+Cohesion: 0.08
+Nodes (11): LocatorBuilderTest, XpathAxis, Role, LocatorBuilder, String, AfterMethod, BeforeMethod, Test (+3 more)
 
 ### Community 159 - "Community 159"
-Cohesion: 0.21
-Nodes (9): AiProvider, DoctorSnippetProvider, AfterEach, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse, Override (+1 more)
+Cohesion: 0.15
+Nodes (3): RestActionsCoverageUnitTest, AfterMethod, Test
 
 ### Community 160 - "Community 160"
 Cohesion: 0.08
@@ -1373,7 +1378,7 @@ Cohesion: 0.13
 Nodes (4): AfterMethod, BeforeMethod, Test, NegativeValidationsTests
 
 ### Community 162 - "Community 162"
-Cohesion: 0.18
+Cohesion: 0.16
 Nodes (5): AfterMethod, BeforeMethod, Test, WebDriver, BrowserActionsCoverageUnitTest
 
 ### Community 164 - "Community 164"
@@ -1381,11 +1386,11 @@ Cohesion: 0.24
 Nodes (7): Connection, DatabaseActions, Boolean, DatabaseType, ResultSet, String, StringBuilder
 
 ### Community 165 - "Community 165"
-Cohesion: 0.10
-Nodes (13): PlaywrightBrowserValidationsBuilder, AccessibilityActions, BrowserContext, Cookie, HttpRequest, HttpResponse, Locator, NetworkInterceptionRequestBuilder (+5 more)
+Cohesion: 0.11
+Nodes (12): AccessibilityActions, BrowserContext, Cookie, HttpRequest, HttpResponse, Locator, NetworkInterceptionRequestBuilder, PlaywrightSession (+4 more)
 
 ### Community 166 - "Community 166"
-Cohesion: 0.14
+Cohesion: 0.15
 Nodes (6): BrowserActions, List, Override, Page, String, WindowType
 
 ### Community 167 - "Community 167"
@@ -1393,12 +1398,12 @@ Cohesion: 0.19
 Nodes (7): Log4j, Log4jTests, DefaultValue, Key, String, BeforeClass, Test
 
 ### Community 168 - "Community 168"
-Cohesion: 0.32
-Nodes (4): Reporting, DefaultValue, Key, SetProperty
+Cohesion: 0.15
+Nodes (6): Reporting, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 169 - "Community 169"
-Cohesion: 0.06
-Nodes (31): AttachmentFormat, CaptureJsonCodec, DoctorJsonCodec, InputStream, AttachmentReporter, CaptureSession, JsonNode, Path (+23 more)
+Cohesion: 0.39
+Nodes (6): ByteArrayOutputStream, Severity, Story, String, Test, AllAttachmentTypesTest
 
 ### Community 170 - "Community 170"
 Cohesion: 0.15
@@ -1406,7 +1411,7 @@ Nodes (7): BrowserService, McpPageDomSnapshot, McpScreenshotResult, McpWorkspace
 
 ### Community 171 - "Community 171"
 Cohesion: 0.25
-Nodes (6): McpServiceHelperTest, AfterEach, Class, Object, String, Test
+Nodes (6): AttachmentFormat, AttachmentReporter, ByteArrayOutputStream, Path, String, SuppressWarnings
 
 ### Community 172 - "Community 172"
 Cohesion: 0.17
@@ -1417,24 +1422,24 @@ Cohesion: 0.14
 Nodes (8): DatabaseActionsMockedTests, AfterMethod, BeforeMethod, DatabaseActions, Object, ResultSet, String, Test
 
 ### Community 174 - "Community 174"
-Cohesion: 0.20
-Nodes (4): AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
+Cohesion: 0.10
+Nodes (6): PropertiesHelper, String, AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
 
 ### Community 175 - "Community 175"
-Cohesion: 0.15
-Nodes (9): PropertyFileManager, File, HashMap, Map, MutableCapabilities, Object, Properties, String (+1 more)
+Cohesion: 0.08
+Nodes (15): PropertyFileManager, PropertyFileManagerInternalUnitTest, File, HashMap, Map, MutableCapabilities, Object, Properties (+7 more)
 
 ### Community 176 - "Community 176"
-Cohesion: 0.16
+Cohesion: 0.18
 Nodes (5): AsyncElementActions, By, ClipboardAction, DriverFactoryHelper, String
 
 ### Community 177 - "Community 177"
-Cohesion: 0.18
-Nodes (11): ManagedCaptureRecorder, CaptureManager, CaptureStartRequest, CaptureStatus, CheckpointKind, Function, ManagedCaptureRecorder, Override (+3 more)
+Cohesion: 0.07
+Nodes (25): FileChannel, FileLock, ManagedCaptureRecorder, CaptureManager, CaptureManagerLifecycleTest, FailingRecorder, FakeRecorder, CaptureSingleSessionLock (+17 more)
 
 ### Community 178 - "Community 178"
 Cohesion: 0.20
-Nodes (8): TestAutomationService, McpCodeGuardrailViolation, McpScenarioCatalogResult, McpTestAutomationScenario, List, Pattern, String, Tool
+Nodes (9): TestAutomationService, McpCodeGuardrailResult, McpCodeGuardrailViolation, McpScenarioCatalogResult, McpTestAutomationScenario, List, Pattern, String (+1 more)
 
 ### Community 179 - "Community 179"
 Cohesion: 0.12
@@ -1445,8 +1450,8 @@ Cohesion: 0.17
 Nodes (15): CaptureEnrichmentService, AiRequest, AiResponse, ApprovalPolicy, CaptureEnrichmentPreview, CaptureEvent, CaptureSession, ElementSnapshot (+7 more)
 
 ### Community 181 - "Community 181"
-Cohesion: 0.19
-Nodes (6): API, SetProperty, DefaultValue, Key, SetProperty, String
+Cohesion: 0.13
+Nodes (8): API, SetProperty, SetProperty, DefaultValue, Key, SetProperty, String, String
 
 ### Community 182 - "Community 182"
 Cohesion: 0.11
@@ -1457,7 +1462,7 @@ Cohesion: 0.27
 Nodes (8): FingerprintExtractor, HealingConfiguration, LocatorFingerprint, Map, String, Supplier, WebDriver, WebElement
 
 ### Community 184 - "Community 184"
-Cohesion: 0.23
+Cohesion: 0.21
 Nodes (6): Internal, InternalTests, DefaultValue, Key, String, Test
 
 ### Community 185 - "Community 185"
@@ -1465,8 +1470,8 @@ Cohesion: 0.16
 Nodes (12): McpMobileRecordingService, List, locatorStrategy, Map, McpCodeBlock, McpMobileRecordedAction, McpMobileRecording, McpMobileRecordingStatus (+4 more)
 
 ### Community 186 - "Community 186"
-Cohesion: 0.19
-Nodes (9): CaptureManagerLifecycleTest, FailingRecorder, FakeRecorder, CaptureStartRequest, CaptureStatus, CheckpointKind, Override, String (+1 more)
+Cohesion: 0.23
+Nodes (7): AccessibilityActions, AccessibilityConfig, AccessibilityResult, BrowserActions, List, String, WebDriver
 
 ### Community 187 - "Community 187"
 Cohesion: 0.08
@@ -1477,12 +1482,12 @@ Cohesion: 0.15
 Nodes (23): analyze_project(), collect_ai_context(), coordinates_have_supported_runner(), coordinates_have_supported_stack(), dependency_coordinates(), detect_markers(), discover_poms(), is_ignored() (+15 more)
 
 ### Community 189 - "Community 189"
-Cohesion: 0.14
-Nodes (15): Bean, BrowserService, ElementService, GuideService, ShaftMcpApplication, MobileService, NaturalActionService, PlaywrightService (+7 more)
+Cohesion: 0.13
+Nodes (16): Bean, BrowserService, ElementService, GuideService, ShaftMcpApplication, MobileService, NaturalActionService, PlaywrightService (+8 more)
 
 ### Community 190 - "Community 190"
-Cohesion: 0.19
-Nodes (13): Actions, ValidationsHelper, Boolean, ComparisonType, LinkedHashMap, List, Number, NumbersComparativeRelation (+5 more)
+Cohesion: 0.24
+Nodes (11): Boolean, ComparisonType, LinkedHashMap, Number, NumbersComparativeRelation, Object, Response, ValidationCategory (+3 more)
 
 ### Community 191 - "Community 191"
 Cohesion: 0.18
@@ -1497,8 +1502,8 @@ Cohesion: 0.17
 Nodes (7): ElementActionsContract, By, ElementAssertions, List, Map, ShaftLocator, String
 
 ### Community 194 - "Community 194"
-Cohesion: 0.25
-Nodes (3): ActionsExceptionDetailsUnitTest, NoSuchElementException, Test
+Cohesion: 0.11
+Nodes (10): ElementLookup, GetElementInformation, Actions, ActionsExceptionDetailsUnitTest, NoSuchElementException, JavascriptExecutor, List, Rectangle (+2 more)
 
 ### Community 195 - "Community 195"
 Cohesion: 0.17
@@ -1513,16 +1518,16 @@ Cohesion: 0.24
 Nodes (4): ElementActionsMockedTests, AfterMethod, BeforeMethod, Test
 
 ### Community 198 - "Community 198"
-Cohesion: 0.17
-Nodes (7): ElementInformation, ElementInformationCoverageUnitTest, Element, List, Object, String, Test
+Cohesion: 0.18
+Nodes (6): ElementInformation, ElementInformationCoverageUnitTest, Element, List, String, Test
 
 ### Community 199 - "Community 199"
-Cohesion: 0.07
-Nodes (24): RequestBuilder, RequestBuilderTests, AuthenticationType, Performance, API, ContentType, Deprecated, Exception (+16 more)
+Cohesion: 0.08
+Nodes (23): RequestBuilder, RequestBuilderTests, AuthenticationType, RestAssuredConfig, API, ContentType, Deprecated, Exception (+15 more)
 
 ### Community 200 - "Community 200"
-Cohesion: 0.14
-Nodes (9): ReportContext, JunitReportContextTest, Consumer, List, Status, String, TestExecutionInfo, AfterEach (+1 more)
+Cohesion: 0.15
+Nodes (8): ReportContext, JunitReportContextTest, Consumer, List, String, TestExecutionInfo, AfterEach, Test
 
 ### Community 201 - "Community 201"
 Cohesion: 0.11
@@ -1533,16 +1538,16 @@ Cohesion: 0.19
 Nodes (13): GeminiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode, Map (+5 more)
 
 ### Community 204 - "Community 204"
-Cohesion: 0.17
-Nodes (13): AiImage, OpenAiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode (+5 more)
+Cohesion: 0.19
+Nodes (12): OpenAiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode, Map (+4 more)
 
 ### Community 205 - "Community 205"
-Cohesion: 0.22
-Nodes (11): AllureSummary, Diagnostic, GeneratedTestValidator, JarEntry, JarFile, JavaFileObject, Duration, List (+3 more)
+Cohesion: 0.23
+Nodes (10): AllureSummary, Diagnostic, GeneratedTestValidator, JarFile, JavaFileObject, Duration, List, Path (+2 more)
 
 ### Community 206 - "Community 206"
 Cohesion: 0.24
-Nodes (5): List, Set, String, Test, TelemetryDeduplicationUnitTest
+Nodes (7): RemoteGridPreflightUnitTest, AfterMethod, HttpExchange, HttpServer, MutableCapabilities, String, Test
 
 ### Community 207 - "Community 207"
 Cohesion: 0.23
@@ -1554,19 +1559,19 @@ Nodes (18): A(), ba(), c(), D(), E(), G(), i(), j() (+10 more)
 
 ### Community 209 - "Community 209"
 Cohesion: 0.06
-Nodes (37): ArtifactPaths, AssertionSuggestion, CaptureGenerator, CodegenBackend(), driverClassName(), failure(), from(), withUnsupported() (+29 more)
+Nodes (39): ArtifactPaths, AssertionSuggestion, CaptureGenerator, CodegenBackend(), driverClassName(), failure(), from(), MutableTargetPlan (+31 more)
 
 ### Community 210 - "Community 210"
 Cohesion: 0.28
 Nodes (12): CompletableFuture, McpProcessRunner, SystemProcessRunner, Duration, InputStream, List, Map, Override (+4 more)
 
 ### Community 211 - "Community 211"
-Cohesion: 0.07
-Nodes (30): HealingManager, current(), HealingStrategy(), parse(), usesHealenium(), usesShaftHeal(), HealingStrategyTest, NaturalActionExecutor (+22 more)
+Cohesion: 0.21
+Nodes (10): HealingManager, By, HealingExplanation, HealingProvider, HealingResolution, List, Optional, String (+2 more)
 
 ### Community 212 - "Community 212"
-Cohesion: 0.26
-Nodes (5): AfterClass, BeforeClass, List, Map, String
+Cohesion: 0.28
+Nodes (6): BasicAPITests, AfterClass, BeforeClass, List, Map, String
 
 ### Community 213 - "Community 213"
 Cohesion: 0.16
@@ -1585,7 +1590,7 @@ Cohesion: 0.17
 Nodes (3): AfterMethod, Test, TextDirectionValidationsBuilderUnitTest
 
 ### Community 217 - "Community 217"
-Cohesion: 0.23
+Cohesion: 0.20
 Nodes (8): AccessibilityResult, AfterMethod, BeforeMethod, List, Rule, String, Test, AccessibilityActionsCoverageUnitTest
 
 ### Community 218 - "Community 218"
@@ -1605,8 +1610,8 @@ Cohesion: 0.20
 Nodes (13): AiCandidateReranker, AiExecutionService, Double, HealingConfiguration, JsonNode, List, Map, ObjectNode (+5 more)
 
 ### Community 222 - "Community 222"
-Cohesion: 0.20
-Nodes (8): ExecutionLifecycleHelper, List, Method, RunType, Status, StatusIcon, String, TestExecutionInfo
+Cohesion: 0.24
+Nodes (7): ExecutionLifecycleHelper, List, Method, Status, StatusIcon, String, TestExecutionInfo
 
 ### Community 223 - "Community 223"
 Cohesion: 0.19
@@ -1614,15 +1619,15 @@ Nodes (6): Healenium, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 224 - "Community 224"
 Cohesion: 0.06
-Nodes (23): ApiPerformanceReportTest, PathParamTest, SwaggerContractTest, TestUpload, BasicAPITests, Map, Object, ParametersType (+15 more)
+Nodes (24): ApiPerformanceReportTest, PathParamTest, SwaggerContractTest, TestUpload, Map, Object, ParametersType, AfterMethod (+16 more)
 
 ### Community 225 - "Community 225"
 Cohesion: 0.17
 Nodes (8): KeysetHandle, GoogleTink, GoogleTinkApiCoverageUnitTest, String, AfterMethod, BeforeMethod, Path, Test
 
 ### Community 226 - "Community 226"
-Cohesion: 0.33
-Nodes (6): Cucumber, CucumberTests, DefaultValue, Key, String, Test
+Cohesion: 0.42
+Nodes (4): Cucumber, DefaultValue, Key, String
 
 ### Community 227 - "Community 227"
 Cohesion: 0.20
@@ -1653,12 +1658,12 @@ Cohesion: 0.18
 Nodes (13): DoctorRepairPatchResult, DoctorRepairAiService, AiRequest, AiResponse, AiResponseStatus, Diagnosis, DoctorRepairAiRequest, EvidenceReference (+5 more)
 
 ### Community 235 - "Community 235"
-Cohesion: 0.15
-Nodes (3): PropertiesHelper, RunType, String
+Cohesion: 0.19
+Nodes (10): NaturalActionExecutor, By, CharSequence, DriverFactoryHelper, NaturalActionPlan, Object, Set, String (+2 more)
 
 ### Community 236 - "Community 236"
-Cohesion: 0.20
-Nodes (7): AnimatedGifManagerCoverageUnitTest, AfterMethod, BeforeMethod, Color, Method, String, Test
+Cohesion: 0.17
+Nodes (8): AnimatedGifManagerCoverageUnitTest, TestCaseFinished, AfterMethod, BeforeMethod, Color, Method, String, Test
 
 ### Community 237 - "Community 237"
 Cohesion: 0.24
@@ -1669,7 +1674,7 @@ Cohesion: 0.23
 Nodes (7): HealingHistoryStoreTest, AfterMethod, HealingConfiguration, Map, Object, String, Test
 
 ### Community 240 - "Community 240"
-Cohesion: 0.17
+Cohesion: 0.18
 Nodes (6): LightHouseGenerateReport, LightHouseGenerateReportCoverageUnitTest, String, WebDriver, AfterMethod, Test
 
 ### Community 241 - "Community 241"
@@ -1678,19 +1683,19 @@ Nodes (13): apply(), applyEnabled(), current(), NaturalActionService, textOrDefa
 
 ### Community 242 - "Community 242"
 Cohesion: 0.12
-Nodes (9): AlertActionsContract, BrowserActionsContract, DriverContract, ElementActionsContract, DriverAssertions, DriverVerifications, Object, String (+1 more)
+Nodes (9): AlertActionsContract, DriverContract, ElementActionsContract, BrowserActionsContract, DriverAssertions, DriverVerifications, Object, String (+1 more)
 
 ### Community 243 - "Community 243"
-Cohesion: 0.18
-Nodes (13): McpMobileInspectorRecordingServiceTest, NoopRunner, McpProcessRunner, Duration, List, Map, McpMobileInspectorRecordingService, Override (+5 more)
+Cohesion: 0.20
+Nodes (11): McpMobileInspectorRecordingServiceTest, Duration, List, Map, McpMobileInspectorRecordingService, Override, Path, Process (+3 more)
 
 ### Community 244 - "Community 244"
 Cohesion: 0.22
 Nodes (6): McpRuntimePaths, McpRuntimePathsTest, Map, Path, String, Test
 
 ### Community 245 - "Community 245"
-Cohesion: 0.19
-Nodes (12): AnthropicProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode, Map (+4 more)
+Cohesion: 0.17
+Nodes (13): AiImage, AnthropicProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode (+5 more)
 
 ### Community 246 - "Community 246"
 Cohesion: 0.10
@@ -1713,20 +1718,20 @@ Cohesion: 0.08
 Nodes (42): agent_upgrade_plan(), build_parser(), collect_source_migration(), confirm_upgrade(), ensure_shaft_import(), format_diff(), is_stable_release(), log() (+34 more)
 
 ### Community 251 - "Community 251"
-Cohesion: 0.20
-Nodes (6): TestCaseStarted, CheckpointStatus, InputStream, List, Object, Step
+Cohesion: 0.36
+Nodes (5): CheckpointStatus, List, Object, Step, Throwable
 
 ### Community 252 - "Community 252"
-Cohesion: 0.27
-Nodes (5): FileActionsCoverageUnitTest, AfterMethod, Path, String, Test
+Cohesion: 0.29
+Nodes (8): DoctorJsonCodec, Diagnosis, DoctorAdvisory, EvidenceBundle, JsonNode, Object, Path, String
 
 ### Community 253 - "Community 253"
 Cohesion: 0.20
 Nodes (8): CucumberFeatureListener, Class, Object, String, SuppressWarnings, Test, TableRow, CucumberFeatureListenerUnitTest
 
 ### Community 254 - "Community 254"
-Cohesion: 0.12
-Nodes (9): AfterMethod, BeforeMethod, Issue, Issues, ITestResult, String, Test, TmsLinks (+1 more)
+Cohesion: 0.09
+Nodes (13): Browser, Method, AfterMethod, BeforeMethod, Issue, Issues, ITestResult, String (+5 more)
 
 ### Community 255 - "Community 255"
 Cohesion: 0.23
@@ -1769,8 +1774,8 @@ Cohesion: 0.20
 Nodes (6): CheckpointType, CheckpointCounter, CheckpointStatus, String, Test, CheckpointAndReportingTest
 
 ### Community 265 - "Community 265"
-Cohesion: 0.10
-Nodes (20): BrowserEventCollector, CompositeBrowserEventCollector, PollingBrowserEventCollector, BrowserSignal, Consumer, Override, String, BrowserSignal (+12 more)
+Cohesion: 0.09
+Nodes (19): BrowsingContextInfo, BidiBrowserEventCollector, BrowserEventCollector, CompositeBrowserEventCollector, BrowserSignal, Consumer, List, Override (+11 more)
 
 ### Community 266 - "Community 266"
 Cohesion: 0.25
@@ -1783,6 +1788,10 @@ Nodes (7): CucumberTestRunnerListener, AfterMethod, Class, Object, String, Test,
 ### Community 268 - "Community 268"
 Cohesion: 0.28
 Nodes (7): LocatorRanker, ScoredLocator, ElementSnapshot, EventContext, LocatorCandidate, LocatorSelection, String
+
+### Community 269 - "Community 269"
+Cohesion: 0.19
+Nodes (10): current(), HealingStrategy(), parse(), usesHealenium(), usesShaftHeal(), HealingStrategyTest, String, AfterMethod (+2 more)
 
 ### Community 270 - "Community 270"
 Cohesion: 0.25
@@ -1797,16 +1806,16 @@ Cohesion: 0.20
 Nodes (4): ValidationsMockedTests, AfterMethod, BeforeMethod, Test
 
 ### Community 273 - "Community 273"
-Cohesion: 0.16
-Nodes (11): HealingLocatorProposalService, HealingLocatorProposalServiceTest, HealingLocatorProposal, JsonNode, Path, String, AfterEach, BeforeEach (+3 more)
+Cohesion: 0.31
+Nodes (5): HealingLocatorProposalService, HealingLocatorProposal, JsonNode, Path, String
 
 ### Community 274 - "Community 274"
 Cohesion: 0.14
 Nodes (12): AtomicReference, AfterMethod, AndroidDriver, BeforeMethod, CountDownLatch, InputStream, Override, String (+4 more)
 
 ### Community 275 - "Community 275"
-Cohesion: 0.25
-Nodes (9): DeterministicNaturalActionPlanner, unsupported(), List, NaturalActionPlan, NaturalActionRequest, Override, String, NaturalActionPlan (+1 more)
+Cohesion: 0.20
+Nodes (8): HttpMethod, BrowserActions, Consumer, HttpRequest, HttpResponse, Predicate, Response, RestValidationsBuilder
 
 ### Community 276 - "Community 276"
 Cohesion: 0.18
@@ -1833,16 +1842,16 @@ Cohesion: 0.24
 Nodes (9): main(), text(), validate_maven_jvm_configuration(), validate_quality_configuration(), validate_surefire_jacoco_arg_lines(), validate_workflow_coverage_policy(), Element, Path (+1 more)
 
 ### Community 283 - "Community 283"
-Cohesion: 0.29
-Nodes (15): copy(), dataBoolean(), dataInt(), dataStrings(), fromJson(), generated(), longValue(), map() (+7 more)
+Cohesion: 0.12
+Nodes (26): copy(), dataBoolean(), dataInt(), dataStrings(), fromJson(), generated(), longValue(), map() (+18 more)
 
 ### Community 284 - "Community 284"
 Cohesion: 0.18
 Nodes (6): BrowserSteps, Given, String, ThreadLocal, WebDriver, When
 
 ### Community 285 - "Community 285"
-Cohesion: 0.28
-Nodes (7): LambdaTestHelper, Boolean, DriverFactoryHelper, HashMap, MutableCapabilities, Object, String
+Cohesion: 0.33
+Nodes (6): HealingLocatorProposalServiceTest, AfterEach, BeforeEach, Path, String, Test
 
 ### Community 286 - "Community 286"
 Cohesion: 0.18
@@ -1893,16 +1902,16 @@ Cohesion: 0.12
 Nodes (17): additionalProperties, required, type, $defs, createObject, evidence, objectId, relationId (+9 more)
 
 ### Community 299 - "Community 299"
-Cohesion: 0.12
-Nodes (8): HoverTests, AfterMethod, BeforeMethod, Test, AfterClass, BeforeClass, Test, FileHelperUnitTest
+Cohesion: 0.21
+Nodes (4): AfterClass, BeforeClass, Test, FileHelperUnitTest
 
 ### Community 300 - "Community 300"
 Cohesion: 0.22
 Nodes (7): ManagedCaptureRecorderControlTest, CaptureBrowser, CaptureStartOptions, CaptureStartRequest, Object, SuppressWarnings, Test
 
 ### Community 301 - "Community 301"
-Cohesion: 0.31
-Nodes (3): Class, Test, GUIInterfaceCompatibilityCoverageUnitTest
+Cohesion: 0.27
+Nodes (4): ElementActions, Class, Test, GUIInterfaceCompatibilityCoverageUnitTest
 
 ### Community 302 - "Community 302"
 Cohesion: 0.21
@@ -1913,48 +1922,48 @@ Cohesion: 0.17
 Nodes (9): InterceptorFactory, BrowserNetworkInterceptor, InterceptorFactory, BrowserNetworkInterceptionRule, Filter, HttpRequest, HttpResponse, Response (+1 more)
 
 ### Community 305 - "Community 305"
-Cohesion: 0.20
-Nodes (7): AfterMethod, InputStream, Override, String, Test, DesktopVideoRecordingProviderRegistryTest, StubDesktopVideoRecordingProvider
+Cohesion: 0.18
+Nodes (8): DesktopVideoRecordingProvider, AfterMethod, InputStream, Override, String, Test, DesktopVideoRecordingProviderRegistryTest, StubDesktopVideoRecordingProvider
 
 ### Community 306 - "Community 306"
-Cohesion: 0.24
-Nodes (6): ElementActionsHelper, ScreenshotManagerCoverageUnitTest, AfterMethod, BeforeMethod, Color, Test
+Cohesion: 0.28
+Nodes (5): ScreenshotManagerCoverageUnitTest, AfterMethod, BeforeMethod, Color, Test
 
 ### Community 307 - "Community 307"
-Cohesion: 0.31
-Nodes (3): ProgressBarLoggerCoverageUnitTest, AfterMethod, Test
+Cohesion: 0.18
+Nodes (6): ProgressBarLogger, ProgressBarLoggerCoverageUnitTest, Override, String, AfterMethod, Test
 
 ### Community 308 - "Community 308"
 Cohesion: 0.30
 Nodes (4): CaptureServiceTest, CaptureService, Path, Test
 
 ### Community 309 - "Community 309"
-Cohesion: 0.23
+Cohesion: 0.27
 Nodes (5): ValidationsHelperCoverageUnitTest, AssertionError, AfterMethod, SuppressWarnings, Test
 
 ### Community 311 - "Community 311"
-Cohesion: 0.18
-Nodes (9): AllureCucumber7Jvm, CucumberTestRunnerListener, EventPublisher, Feature, Optional, Override, TestSourceParsed, TestStepStarted (+1 more)
+Cohesion: 0.14
+Nodes (10): AllureCucumber7Jvm, CucumberTestRunnerListener, EventPublisher, Feature, Optional, Override, TestCaseStarted, TestSourceParsed (+2 more)
 
 ### Community 312 - "Community 312"
-Cohesion: 0.31
-Nodes (5): ShaftMcpApplicationTests, Set, String, Test, ToolCallback
+Cohesion: 0.18
+Nodes (9): Autowired, ShaftMcpApplicationTests, EngineService, McpMobileInspectorRecordingService, McpMobileRecordingService, McpWorkspacePolicy, Set, String (+1 more)
 
 ### Community 313 - "Community 313"
 Cohesion: 0.27
 Nodes (7): CaptureControlClient, CaptureStatus, CheckpointKind, List, Object, Path, String
 
 ### Community 314 - "Community 314"
-Cohesion: 0.18
-Nodes (9): DesktopVideoRecordingProvider, DesktopVideoConsumer, IVideoRecorder, File, InputStream, Override, String, SuppressWarnings (+1 more)
+Cohesion: 0.20
+Nodes (8): DesktopVideoConsumer, IVideoRecorder, File, InputStream, Override, String, SuppressWarnings, AutomationRemarksDesktopVideoRecordingProvider
 
 ### Community 315 - "Community 315"
 Cohesion: 0.16
 Nodes (9): HealingProvider, HealingActionOutcome, HealingExplanation, HealingObservation, HealingRequest, HealingResolution, Optional, String (+1 more)
 
 ### Community 316 - "Community 316"
-Cohesion: 0.16
-Nodes (4): ChannelSftp, SftpTransferDirection, Session, ThreadFactory
+Cohesion: 0.28
+Nodes (9): PollingBrowserEventCollector, BrowserSignal, Consumer, List, Object, Override, Set, String (+1 more)
 
 ### Community 317 - "Community 317"
 Cohesion: 0.20
@@ -1981,8 +1990,8 @@ Cohesion: 0.27
 Nodes (5): McpMobileCode, List, locatorStrategy, McpCodeBlock, String
 
 ### Community 323 - "Community 323"
-Cohesion: 0.17
-Nodes (12): enum, additionalProperties, properties, required, type, enum, items, type (+4 more)
+Cohesion: 0.13
+Nodes (15): type, uniqueItems, enum, additionalProperties, properties, required, type, enum (+7 more)
 
 ### Community 324 - "Community 324"
 Cohesion: 0.17
@@ -2017,12 +2026,20 @@ Cohesion: 0.19
 Nodes (14): A(), Ae(), b(), ce(), ge(), le(), pe(), qe() (+6 more)
 
 ### Community 333 - "Community 333"
-Cohesion: 0.09
-Nodes (25): DoctorAnalyzerTest, empty(), McpAppiumCommandRecorderTest, reviewUiPath(), disabled(), defaults(), lower(), normalizePath() (+17 more)
+Cohesion: 0.05
+Nodes (33): empty(), McpAppiumCommandRecorderTest, reviewUiPath(), disabled(), McpResultRecordsTest, MobileRecordingServiceTest, Metadata, asCacheHit() (+25 more)
 
 ### Community 334 - "Community 334"
-Cohesion: 0.22
-Nodes (18): append(), checkpoint(), complete(), ensureIncomplete(), interrupt(), sortedCheckpoints(), sortedEvents(), sortedReferences() (+10 more)
+Cohesion: 0.25
+Nodes (8): notRequested(), McpCaptureCodeBlockServiceTest, Enrichment, List, McpCodeBlock, Path, String, Test
+
+### Community 335 - "Community 335"
+Cohesion: 0.21
+Nodes (7): ApiPerformanceExecutionReport, String, Double, List, Map, String, PerformanceReportHTMLHelper
+
+### Community 336 - "Community 336"
+Cohesion: 0.32
+Nodes (5): CaptureJsonCodec, CaptureSession, JsonNode, Path, String
 
 ### Community 337 - "Community 337"
 Cohesion: 0.15
@@ -2065,12 +2082,12 @@ Cohesion: 0.17
 Nodes (11): AiProviderRegistryTest, availability(), capabilities(), execute(), AfterEach, AiCapabilities, AiProviderAvailability, AiRequest (+3 more)
 
 ### Community 347 - "Community 347"
-Cohesion: 0.11
-Nodes (18): notRequested(), McpCaptureCodeBlockServiceTest, PlaywrightServiceTest, DoctorReportWriter, Enrichment, Diagnosis, DoctorAdvisory, EvidenceBundle (+10 more)
+Cohesion: 0.19
+Nodes (11): PlaywrightServiceTest, DoctorReportWriter, Diagnosis, DoctorAdvisory, EvidenceBundle, List, Path, String (+3 more)
 
 ### Community 348 - "Community 348"
-Cohesion: 0.18
-Nodes (6): Image, ScreenshotHelper, Boolean, BufferedImage, SuppressWarnings, WebDriver
+Cohesion: 0.10
+Nodes (15): HasCdp, Image, ScreenshotHelper, ScreenshotHelperCoverageUnitTest, Boolean, BufferedImage, String, SuppressWarnings (+7 more)
 
 ### Community 349 - "Community 349"
 Cohesion: 0.26
@@ -2081,8 +2098,8 @@ Cohesion: 0.40
 Nodes (12): configuration_path(), expected_java(), installed_args(), installed_dependencies(), installed_jar(), installer_command(), main(), sha256() (+4 more)
 
 ### Community 351 - "Community 351"
-Cohesion: 0.15
-Nodes (10): Callable, DeterministicNaturalActionPlannerTest, Path, Test, NaturalActionRequest, String, Test, Test (+2 more)
+Cohesion: 0.36
+Nodes (4): DeterministicNaturalActionPlannerTest, NaturalActionRequest, String, Test
 
 ### Community 352 - "Community 352"
 Cohesion: 0.24
@@ -2129,7 +2146,7 @@ Cohesion: 0.29
 Nodes (5): HttpExchange, HttpServer, Override, String, LocalApiServer
 
 ### Community 364 - "Community 364"
-Cohesion: 0.27
+Cohesion: 0.31
 Nodes (4): LocalApiTestServer, HttpExchange, HttpServer, String
 
 ### Community 365 - "Community 365"
@@ -2145,32 +2162,24 @@ Cohesion: 0.29
 Nodes (7): Description, AfterMethod, BeforeClass, BeforeMethod, Step, Test, FluentGuiActionsTest
 
 ### Community 368 - "Community 368"
-Cohesion: 0.18
-Nodes (11): CaptureGeneratedReplayBrowserTest, ClassifiedValue, Collection, Path, String, CaptureSession, ElementSnapshot, ExternalTestDataReference (+3 more)
+Cohesion: 0.32
+Nodes (6): CaptureGeneratedReplayBrowserTest, CaptureSession, ElementSnapshot, ExternalTestDataReference, String, Test
 
 ### Community 369 - "Community 369"
-Cohesion: 0.33
-Nodes (4): VisualProcessingProviderRegistry, List, Optional, VisualProcessingProvider
+Cohesion: 0.13
+Nodes (13): ImageProcessingActions, VisualProcessingProviderRegistry, Boolean, By, File, Integer, List, String (+5 more)
 
 ### Community 370 - "Community 370"
-Cohesion: 0.16
-Nodes (9): HasCdp, ScreenshotHelperCoverageUnitTest, String, AfterMethod, BeforeMethod, Color, Object, String (+1 more)
+Cohesion: 0.23
+Nodes (6): InputStream, Override, Path, Test, CloseTrackingInputStream, ReportManagerHelperAttachmentIoUnitTest
 
 ### Community 371 - "Community 371"
 Cohesion: 0.23
 Nodes (8): VisualProcessingProvider, Boolean, By, Integer, List, String, VisualValidationEngine, WebDriver
 
-### Community 372 - "Community 372"
-Cohesion: 0.33
-Nodes (3): TestAutomationServiceTest, McpCodeGuardrailResult, Test
-
 ### Community 373 - "Community 373"
 Cohesion: 0.31
 Nodes (4): GuiVerificationTests, AfterMethod, BeforeMethod, Test
-
-### Community 374 - "Community 374"
-Cohesion: 0.25
-Nodes (5): McpMobileDevice, McpMobileToolchainStatus, Optional, Duration, McpMobileDevice
 
 ### Community 375 - "Community 375"
 Cohesion: 0.23
@@ -2193,8 +2202,12 @@ Cohesion: 0.29
 Nodes (3): EngineServiceTest, AfterEach, Test
 
 ### Community 380 - "Community 380"
-Cohesion: 0.30
-Nodes (3): ThreadLocalPropertiesManager, Properties, String
+Cohesion: 0.27
+Nodes (4): Actions, SilentElementReader, By, List
+
+### Community 381 - "Community 381"
+Cohesion: 0.27
+Nodes (4): ExecutionCountsTracker, String, TestExecutionInfo, Counts
 
 ### Community 382 - "Community 382"
 Cohesion: 0.32
@@ -2217,12 +2230,12 @@ Cohesion: 0.17
 Nodes (12): type, scope, pattern, type, branch, project, task, additionalProperties (+4 more)
 
 ### Community 387 - "Community 387"
-Cohesion: 0.13
-Nodes (10): OpenCvVisualConsumer, HealingVisualProvider, OpenCvHealingVisualProvider, OpenCvHealingVisualProviderTest, Override, String, Color, Test (+2 more)
+Cohesion: 0.19
+Nodes (7): HealingVisualProvider, OpenCvHealingVisualProvider, OpenCvHealingVisualProviderTest, Override, String, Color, Test
 
 ### Community 388 - "Community 388"
 Cohesion: 0.17
-Nodes (12): type, properties, minLength, type, content, mediaType, redacted, relativePath (+4 more)
+Nodes (12): type, items, properties, required, type, content, redacted, relativePath (+4 more)
 
 ### Community 389 - "Community 389"
 Cohesion: 0.26
@@ -2233,8 +2246,8 @@ Cohesion: 0.26
 Nodes (5): AfterMethod, BeforeClass, BeforeMethod, Test, TestClass
 
 ### Community 391 - "Community 391"
-Cohesion: 0.13
-Nodes (12): ChromiumOptions, DesiredCapabilities, OptionsManager, OptionsManagerCoverageUnitTest, LoggingPreferences, DriverType, MutableCapabilities, String (+4 more)
+Cohesion: 0.06
+Nodes (21): ChromiumOptions, DesiredCapabilities, OptionsManager, OptionsManagerCoverageUnitTest, Platform, SetProperty, LoggingPreferences, PlatformTests (+13 more)
 
 ### Community 392 - "Community 392"
 Cohesion: 0.36
@@ -2317,8 +2330,8 @@ Cohesion: 0.29
 Nodes (5): UploadFileTests, AfterMethod, BeforeMethod, String, Test
 
 ### Community 413 - "Community 413"
-Cohesion: 0.31
-Nodes (11): ArrayList, addIfSet(), addIfTrue(), defaults(), normalize(), testIdAttributes(), text(), warnings() (+3 more)
+Cohesion: 0.40
+Nodes (10): addIfSet(), addIfTrue(), defaults(), normalize(), testIdAttributes(), text(), warnings(), CaptureStartOptions (+2 more)
 
 ### Community 414 - "Community 414"
 Cohesion: 0.18
@@ -2358,7 +2371,7 @@ Nodes (8): 1. Check Out The Code, 2. Install The Toolchain, 3. Build Locally, 4.
 
 ### Community 424 - "Community 424"
 Cohesion: 0.33
-Nodes (5): FileChannel, FileLock, CaptureSingleSessionLock, Override, Path
+Nodes (4): HoverTests, AfterMethod, BeforeMethod, Test
 
 ### Community 425 - "Community 425"
 Cohesion: 0.29
@@ -2401,8 +2414,8 @@ Cohesion: 0.47
 Nodes (3): MobileTests, BeforeClass, Test
 
 ### Community 436 - "Community 436"
-Cohesion: 0.19
-Nodes (7): FluentWebDriverAction, Actions, AlertActions, BrowserActions, DriverFactoryHelper, TouchActions, WebDriver
+Cohesion: 0.12
+Nodes (11): FluentWebDriverAction, SelectedValueTests, Actions, AlertActions, BrowserActions, DriverFactoryHelper, TouchActions, WebDriver (+3 more)
 
 ### Community 437 - "Community 437"
 Cohesion: 0.20
@@ -2433,12 +2446,12 @@ Cohesion: 0.20
 Nodes (9): Alternative: Email, Dependency Security, Disclosure Policy, Preferred: GitHub Private Security Advisory, Reporting a Vulnerability, Response Timeline, Scope, Security Policy (+1 more)
 
 ### Community 444 - "Community 444"
-Cohesion: 0.22
-Nodes (9): AccessibilityActions, BrowserNetworkInterceptionRule, DriverFactoryHelper, HttpRequest, HttpResponse, Predicate, Screenshots, Step (+1 more)
+Cohesion: 0.24
+Nodes (9): AccessibilityActions, BrowserNetworkInterceptionRule, DriverFactoryHelper, HttpRequest, HttpResponse, Predicate, Step, URI (+1 more)
 
 ### Community 445 - "Community 445"
 Cohesion: 0.24
-Nodes (8): BrowsingContextInfo, BidiBrowserEventCollector, BrowserSignal, Consumer, List, Override, String, WebDriver
+Nodes (5): OpenCvVisualConsumer, getType(), Screenshots, Mat, String
 
 ### Community 446 - "Community 446"
 Cohesion: 0.31
@@ -2497,8 +2510,8 @@ Cohesion: 0.33
 Nodes (4): JunitTest, AfterEach, BeforeEach, Test
 
 ### Community 461 - "Community 461"
-Cohesion: 0.33
-Nodes (4): Test_LTWebAppRealme, AfterMethod, BeforeMethod, Test
+Cohesion: 0.12
+Nodes (9): Test_LTWebAppRealme, DesktopVideoRecordingProvider, Optional, AfterMethod, BeforeMethod, Test, Test, RestActionsFailureLoggingUnitTest (+1 more)
 
 ### Community 462 - "Community 462"
 Cohesion: 0.36
@@ -2530,11 +2543,11 @@ Nodes (5): ElementMatchesSafariCompatibleTests, AfterMethod, BeforeMethod, Suppr
 
 ### Community 470 - "Community 470"
 Cohesion: 0.27
-Nodes (3): AfterMethod, Test, LambdaTestHelperUnitTest
+Nodes (5): IOSBasicInteractionsTest, AfterMethod, BeforeMethod, SuppressWarnings, Test
 
 ### Community 471 - "Community 471"
-Cohesion: 0.24
-Nodes (10): expired(), InstantDeadline(), ManagedCaptureRecorderBrowserTest, Duration, HttpExchange, HttpServer, ParameterizedTest, Path (+2 more)
+Cohesion: 0.27
+Nodes (9): InstantDeadline(), ManagedCaptureRecorderBrowserTest, Duration, HttpExchange, HttpServer, ParameterizedTest, Path, String (+1 more)
 
 ### Community 472 - "Community 472"
 Cohesion: 0.33
@@ -2553,8 +2566,8 @@ Cohesion: 0.29
 Nodes (6): Deletion Checklist, Generated PR Workflows, GitHub Actions Workflows, Relationship Map, Shared Composite Actions, Workflow Inventory
 
 ### Community 476 - "Community 476"
-Cohesion: 0.10
-Nodes (15): IOSBasicInteractionsTest, ElementActions, Test_LTMobIPAAppURL, Test_LTMobIPARelativePath, AfterMethod, BeforeMethod, SuppressWarnings, Test (+7 more)
+Cohesion: 0.29
+Nodes (5): Test_LTMobIPAAppURL, AfterMethod, BeforeMethod, String, Test
 
 ### Community 477 - "Community 477"
 Cohesion: 0.25
@@ -2625,8 +2638,8 @@ Cohesion: 0.36
 Nodes (4): LazyLoadingTests, AfterMethod, BeforeMethod, Test
 
 ### Community 494 - "Community 494"
-Cohesion: 0.23
-Nodes (5): BrowserStackModuleTest, InvocationTargetException, JsonSchemaValidatorTest, Test, Test
+Cohesion: 0.20
+Nodes (4): AsyncAppender, Path, Status, StatusDetails
 
 ### Community 495 - "Community 495"
 Cohesion: 0.43
@@ -2645,8 +2658,8 @@ Cohesion: 0.36
 Nodes (4): ShadowDOMTests, AfterMethod, BeforeMethod, Test
 
 ### Community 499 - "Community 499"
-Cohesion: 0.18
-Nodes (11): items, type, uniqueItems, minLength, pattern, type, applies_to, tags (+3 more)
+Cohesion: 0.25
+Nodes (8): items, minLength, pattern, type, tags, items, type, uniqueItems
 
 ### Community 501 - "Community 501"
 Cohesion: 0.36
@@ -2694,7 +2707,7 @@ Nodes (5): SynchronizationManager, Class, Exception, List, WebDriver
 
 ### Community 513 - "Community 513"
 Cohesion: 0.06
-Nodes (18): testPostRequest, SHAFT, FileInputStream, AppiumMobileConsumer, BrowserStackSdkConsumer, LegacyCoordinateConsumer, IOException, JunitProjectStructureManagerTest (+10 more)
+Nodes (20): testPostRequest, ArrayList, SHAFT, ElementActionsHelper, FileInputStream, AppiumMobileConsumer, BrowserStackSdkConsumer, LegacyCoordinateConsumer (+12 more)
 
 ### Community 514 - "Community 514"
 Cohesion: 0.43
@@ -2709,7 +2722,7 @@ Cohesion: 0.29
 Nodes (6): additionalProperties, allOf, $id, required, $schema, type
 
 ### Community 517 - "Community 517"
-Cohesion: 0.31
+Cohesion: 0.29
 Nodes (5): AfterEach, BeforeAll, BeforeEach, Test, TestClass
 
 ### Community 518 - "Community 518"
@@ -2725,7 +2738,7 @@ Cohesion: 0.33
 Nodes (3): InputStream, String, DesktopVideoRecordingProvider
 
 ### Community 523 - "Community 523"
-Cohesion: 0.38
+Cohesion: 0.36
 Nodes (4): RemoteGridVideoAttachmentIT, AfterMethod, BeforeMethod, Test
 
 ### Community 524 - "Community 524"
@@ -2741,12 +2754,12 @@ Cohesion: 0.39
 Nodes (3): BrowserAssertions, NativeValidationsBuilder, String
 
 ### Community 527 - "Community 527"
-Cohesion: 0.13
-Nodes (14): items, type, $id, required, type, properties, evidence, redaction (+6 more)
+Cohesion: 0.17
+Nodes (12): minLength, type, type, properties, bundleId, evidence, redaction, schemaVersion (+4 more)
 
 ### Community 528 - "Community 528"
-Cohesion: 0.23
-Nodes (6): InputStream, Path, String, SuppressWarnings, WebDriver, RecordManager
+Cohesion: 0.21
+Nodes (7): IOSDriver, InputStream, Path, String, SuppressWarnings, WebDriver, RecordManager
 
 ### Community 529 - "Community 529"
 Cohesion: 0.33
@@ -2797,8 +2810,8 @@ Cohesion: 0.47
 Nodes (3): HealeniumTests, BeforeClass, Test
 
 ### Community 543 - "Community 543"
-Cohesion: 0.18
-Nodes (8): ElementStepsCoverageUnitTest, ClipboardAction, BeforeMethod, By, DataProvider, Object, String, Test
+Cohesion: 0.22
+Nodes (7): ElementStepsCoverageUnitTest, BeforeMethod, By, DataProvider, Object, String, Test
 
 ### Community 544 - "Community 544"
 Cohesion: 0.47
@@ -2833,8 +2846,8 @@ Cohesion: 0.40
 Nodes (4): CaptureBrowser(), parse(), DriverType, String
 
 ### Community 553 - "Community 553"
-Cohesion: 0.67
-Nodes (3): minLength, type, bundleId
+Cohesion: 0.42
+Nodes (5): ClassifiedValue, Collection, Path, String, ExternalTestDataWriter
 
 ### Community 555 - "Community 555"
 Cohesion: 0.25
@@ -2853,24 +2866,28 @@ Cohesion: 0.60
 Nodes (4): defaults(), DoctorAnalysisRequest, List, Path
 
 ### Community 561 - "Community 561"
-Cohesion: 0.18
-Nodes (5): ExecutionSummaryReport, StatusIcon(), CheckpointStatus, String, StringBuilder
+Cohesion: 0.22
+Nodes (3): ExecutionSummaryReport, CheckpointStatus, StringBuilder
+
+### Community 562 - "Community 562"
+Cohesion: 0.36
+Nodes (5): ready(), unavailable(), AiProviderAvailability, AiProviderAvailability, String
 
 ### Community 563 - "Community 563"
 Cohesion: 0.43
 Nodes (3): HealingTests, AfterMethod, Test
 
 ### Community 564 - "Community 564"
-Cohesion: 0.32
-Nodes (3): DesktopVideoRecordingProvider, Optional, DesktopVideoRecordingProviderRegistry
+Cohesion: 0.46
+Nodes (4): Callable, Path, Test, CaptureSessionStoreTest
 
 ### Community 565 - "Community 565"
 Cohesion: 0.36
 Nodes (4): RelativeLocatorsTests, AfterMethod, BeforeMethod, Test
 
 ### Community 566 - "Community 566"
-Cohesion: 0.22
-Nodes (8): ChromeOptions, MoonTests, AfterEach, BeforeEach, String, Test, WebDriver, TestInfo
+Cohesion: 0.11
+Nodes (14): ChromeOptions, WebDomHealingAcceptanceTest, MoonTests, AfterEach, BeforeEach, String, Test, WebDriver (+6 more)
 
 ### Community 567 - "Community 567"
 Cohesion: 0.40
@@ -2881,8 +2898,8 @@ Cohesion: 0.60
 Nodes (4): copy(), text(), List, String
 
 ### Community 569 - "Community 569"
-Cohesion: 0.37
-Nodes (4): DoctorServiceTest, DoctorService, Path, Test
+Cohesion: 0.16
+Nodes (12): DoctorServiceTest, DoctorSnippetProvider, AfterEach, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse, DoctorService (+4 more)
 
 ### Community 570 - "Community 570"
 Cohesion: 0.60
@@ -2909,7 +2926,7 @@ Cohesion: 0.50
 Nodes (4): build_parser(), main(), Build the command-line parser., ArgumentParser
 
 ### Community 578 - "Community 578"
-Cohesion: 0.32
+Cohesion: 0.19
 Nodes (8): IssueReporter, Boolean, ITestNGMethod, ITestResult, List, Method, String, TestExecutionInfo
 
 ### Community 580 - "Community 580"
@@ -2924,6 +2941,10 @@ Nodes (3): Release And Dependency Guard, Output, Workflow
 Cohesion: 0.53
 Nodes (3): RepairProposalStore, Path, RepairProposal
 
+### Community 587 - "Community 587"
+Cohesion: 0.43
+Nodes (5): ClassLoader, OpenCvBlockingClassLoader, Class, Override, String
+
 ### Community 588 - "Community 588"
 Cohesion: 0.36
 Nodes (3): ProjectStructureManager, Path, RunType
@@ -2933,8 +2954,8 @@ Cohesion: 0.50
 Nodes (3): { Client }, pgclient, values
 
 ### Community 597 - "Community 597"
-Cohesion: 0.21
-Nodes (6): Boolean, By, NumbersComparativeRelation, Object, String, JavaHelper
+Cohesion: 0.32
+Nodes (4): Performance, DefaultValue, Key, SetProperty
 
 ### Community 599 - "Community 599"
 Cohesion: 0.27
@@ -2969,12 +2990,12 @@ Cohesion: 0.67
 Nodes (3): sizeBytes, minimum, type
 
 ### Community 628 - "Community 628"
-Cohesion: 0.33
-Nodes (4): DoctorFormatException, RuntimeException, String, Throwable
+Cohesion: 0.25
+Nodes (5): DoctorFormatException, ProfileCleanupException, RuntimeException, String, Throwable
 
 ### Community 757 - "Community 757"
-Cohesion: 0.13
-Nodes (12): ready(), unavailable(), DisabledAiProvider, AiProviderAvailability, AiProviderAvailability, String, AiCapabilities, AiProviderAvailability (+4 more)
+Cohesion: 0.19
+Nodes (8): DisabledAiProvider, AiProvider, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse, Override, String
 
 ### Community 759 - "Community 759"
 Cohesion: 0.36
@@ -2989,16 +3010,16 @@ Cohesion: 0.41
 Nodes (7): BrowserNetworkInterceptionRule, Consumer, Function, HttpRequest, HttpResponse, Predicate, Response
 
 ### Community 764 - "Community 764"
-Cohesion: 0.50
+Cohesion: 0.52
 Nodes (3): CaptureRuntimePortabilityTest, Path, Test
 
 ### Community 766 - "Community 766"
-Cohesion: 0.29
-Nodes (6): NaturalActionPlannerRegistry, List, NaturalActionPlan, NaturalActionPlanner, NaturalActionRequest, String
+Cohesion: 0.39
+Nodes (4): JunitProjectStructureManagerTest, AfterEach, Path, Test
 
 ### Community 768 - "Community 768"
-Cohesion: 0.17
-Nodes (13): FakeRunner, McpMobileToolchainServiceTest, Duration, List, Map, McpMobileToolchainDiagnostic, McpMobileToolchainStatus, Override (+5 more)
+Cohesion: 0.15
+Nodes (15): NoopRunner, FakeRunner, McpMobileToolchainServiceTest, McpProcessRunner, Duration, List, Map, McpMobileToolchainDiagnostic (+7 more)
 
 ### Community 769 - "Community 769"
 Cohesion: 0.50
@@ -3013,8 +3034,8 @@ Cohesion: 0.70
 Nodes (3): reviewPath(), reviewUiPath(), Path
 
 ### Community 772 - "Community 772"
-Cohesion: 0.38
-Nodes (5): CaptureCliTest, Class, Object, String, Test
+Cohesion: 0.36
+Nodes (4): Test_LTMobIPARelativePath, AfterMethod, BeforeMethod, Test
 
 ### Community 773 - "Community 773"
 Cohesion: 0.36
@@ -3024,28 +3045,28 @@ Nodes (3): GalaxyS26UltraPlaywrightActionsE2ETest, Override, String
 Cohesion: 0.25
 Nodes (4): DatabaseActions, DB, DatabaseType, ResultSet
 
+### Community 776 - "Community 776"
+Cohesion: 0.47
+Nodes (3): JiraTests, BeforeClass, Test
+
 ### Community 777 - "Community 777"
 Cohesion: 0.36
 Nodes (3): IPhone17ProMaxPlaywrightActionsE2ETest, Override, String
 
 ### Community 778 - "Community 778"
-Cohesion: 0.31
-Nodes (4): SelectedValueTests, AfterMethod, BeforeMethod, Test
+Cohesion: 0.33
+Nodes (5): $id, required, $schema, title, type
 
 ### Community 779 - "Community 779"
 Cohesion: 0.31
 Nodes (4): MultipleElementsFailureTest, AfterMethod, BeforeMethod, Test
-
-### Community 780 - "Community 780"
-Cohesion: 0.22
-Nodes (3): AfterMethod, Path, String
 
 ### Community 781 - "Community 781"
 Cohesion: 0.31
 Nodes (6): RepairProcessRunner, Duration, List, Path, ProcessResult, String
 
 ### Community 782 - "Community 782"
-Cohesion: 0.31
+Cohesion: 0.29
 Nodes (5): AfterMethod, BeforeClass, BeforeMethod, Test, TestClass
 
 ### Community 783 - "Community 783"
@@ -3056,24 +3077,16 @@ Nodes (3): ReportManager, Level, String
 Cohesion: 0.38
 Nodes (4): JunitApiSmokeTest, AfterAll, BeforeAll, Test
 
-### Community 785 - "Community 785"
-Cohesion: 0.33
-Nodes (6): Metadata, asCacheHit(), disabled(), empty(), DoctorAdvisory, ProviderAnalysis
-
-### Community 786 - "Community 786"
-Cohesion: 0.33
-Nodes (5): Autowired, EngineService, McpMobileInspectorRecordingService, McpMobileRecordingService, McpWorkspacePolicy
-
 ### Community 787 - "Community 787"
-Cohesion: 0.33
-Nodes (4): ProgressBarLogger, AutoCloseable, Override, String
+Cohesion: 0.13
+Nodes (17): limiterKey(), RemoteGridPreflight, SessionPermit, unavailable(), PreflightReport, Semaphore, SessionPermit, Capabilities (+9 more)
 
 ### Community 788 - "Community 788"
 Cohesion: 0.33
 Nodes (3): Validations, StandaloneAssertions, StandaloneVerifications
 
 ### Community 789 - "Community 789"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (3): FileActionsReflectionInvoker, FileActions, String
 
 ### Community 790 - "Community 790"
@@ -3083,18 +3096,6 @@ Nodes (4): MultipleElementsFoundException, String, Throwable, WebDriverException
 ### Community 791 - "Community 791"
 Cohesion: 0.08
 Nodes (12): BasicAuthenticationTests, NetworkInterceptionTest, TableTests, SmartLocatorsTests, Test, Test, String, Test (+4 more)
-
-### Community 794 - "Community 794"
-Cohesion: 0.33
-Nodes (4): CaptureFormatException, String, Throwable, IllegalArgumentException
-
-### Community 795 - "Community 795"
-Cohesion: 0.47
-Nodes (3): MultipleBrowserInstancesTest, AfterMethod, Test
-
-### Community 797 - "Community 797"
-Cohesion: 0.47
-Nodes (3): PlatformTests, BeforeClass, Test
 
 ### Community 800 - "Community 800"
 Cohesion: 0.47
@@ -3116,29 +3117,29 @@ Nodes (3): FirefoxPlaywrightActionsE2ETest, Override, String
 Cohesion: 0.40
 Nodes (3): WebKitPlaywrightActionsE2ETest, Override, String
 
-### Community 812 - "Community 812"
+### Community 806 - "Community 806"
 Cohesion: 0.67
-Nodes (3): schemaVersion, enum, type
+Nodes (3): minLength, type, mediaType
 
 ## Knowledge Gaps
-- **1443 isolated node(s):** `$id`, `$schema`, `additionalProperties`, `additionalProperties`, `type` (+1438 more)
+- **1447 isolated node(s):** `$id`, `$schema`, `additionalProperties`, `additionalProperties`, `type` (+1442 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **100 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **91 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `SHAFT` connect `Community 513` to `Community 512`, `Community 2`, `Community 514`, `Community 3`, `Community 517`, `Community 5`, `Community 7`, `Community 8`, `Community 10`, `Community 523`, `Community 12`, `Community 13`, `Community 15`, `Community 528`, `Community 17`, `Community 18`, `Community 529`, `Community 20`, `Community 21`, `Community 22`, `Community 23`, `Community 24`, `Community 19`, `Community 26`, `Community 538`, `Community 27`, `Community 540`, `Community 541`, `Community 31`, `Community 543`, `Community 542`, `Community 34`, `Community 35`, `Community 36`, `Community 37`, `Community 38`, `Community 544`, `Community 545`, `Community 546`, `Community 547`, `Community 43`, `Community 548`, `Community 45`, `Community 46`, `Community 47`, `Community 44`, `Community 561`, `Community 562`, `Community 563`, `Community 52`, `Community 53`, `Community 566`, `Community 55`, `Community 565`, `Community 57`, `Community 65`, `Community 579`, `Community 69`, `Community 71`, `Community 74`, `Community 76`, `Community 80`, `Community 81`, `Community 84`, `Community 597`, `Community 87`, `Community 88`, `Community 93`, `Community 95`, `Community 96`, `Community 103`, `Community 104`, `Community 106`, `Community 108`, `Community 109`, `Community 112`, `Community 114`, `Community 116`, `Community 121`, `Community 123`, `Community 125`, `Community 130`, `Community 132`, `Community 134`, `Community 137`, `Community 138`, `Community 28`, `Community 142`, `Community 145`, `Community 151`, `Community 30`, `Community 153`, `Community 539`, `Community 155`, `Community 156`, `Community 158`, `Community 159`, `Community 161`, `Community 32`, `Community 162`, `Community 165`, `Community 167`, `Community 169`, `Community 170`, `Community 171`, `Community 172`, `Community 174`, `Community 184`, `Community 190`, `Community 191`, `Community 39`, `Community 199`, `Community 549`, `Community 550`, `Community 211`, `Community 212`, `Community 214`, `Community 218`, `Community 219`, `Community 222`, `Community 224`, `Community 225`, `Community 226`, `Community 230`, `Community 236`, `Community 240`, `Community 241`, `Community 758`, `Community 247`, `Community 759`, `Community 252`, `Community 766`, `Community 254`, `Community 257`, `Community 261`, `Community 774`, `Community 266`, `Community 779`, `Community 778`, `Community 780`, `Community 270`, `Community 271`, `Community 784`, `Community 782`, `Community 274`, `Community 787`, `Community 276`, `Community 273`, `Community 791`, `Community 279`, `Community 795`, `Community 284`, `Community 285`, `Community 286`, `Community 796`, `Community 288`, `Community 287`, `Community 290`, `Community 797`, `Community 293`, `Community 295`, `Community 808`, `Community 299`, `Community 301`, `Community 815`, `Community 306`, `Community 311`, `Community 326`, `Community 327`, `Community 328`, `Community 329`, `Community 335`, `Community 337`, `Community 340`, `Community 346`, `Community 348`, `Community 351`, `Community 352`, `Community 354`, `Community 358`, `Community 359`, `Community 360`, `Community 362`, `Community 367`, `Community 370`, `Community 373`, `Community 378`, `Community 382`, `Community 389`, `Community 390`, `Community 391`, `Community 395`, `Community 398`, `Community 399`, `Community 401`, `Community 403`, `Community 405`, `Community 407`, `Community 408`, `Community 409`, `Community 411`, `Community 412`, `Community 413`, `Community 417`, `Community 427`, `Community 428`, `Community 429`, `Community 431`, `Community 432`, `Community 435`, `Community 444`, `Community 446`, `Community 450`, `Community 451`, `Community 454`, `Community 455`, `Community 456`, `Community 460`, `Community 461`, `Community 468`, `Community 470`, `Community 473`, `Community 476`, `Community 480`, `Community 483`, `Community 484`, `Community 485`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 493`, `Community 496`, `Community 498`, `Community 501`, `Community 502`, `Community 503`, `Community 504`, `Community 505`, `Community 506`, `Community 509`, `Community 511`?**
-  _High betweenness centrality (0.115) - this node is a cross-community bridge._
-- **Why does `ArrayList` connect `Community 413` to `Community 512`, `Community 513`, `Community 3`, `Community 7`, `Community 14`, `Community 19`, `Community 20`, `Community 25`, `Community 34`, `Community 35`, `Community 38`, `Community 551`, `Community 39`, `Community 41`, `Community 45`, `Community 561`, `Community 52`, `Community 56`, `Community 59`, `Community 60`, `Community 62`, `Community 64`, `Community 578`, `Community 74`, `Community 76`, `Community 597`, `Community 85`, `Community 93`, `Community 95`, `Community 109`, `Community 111`, `Community 116`, `Community 117`, `Community 118`, `Community 125`, `Community 130`, `Community 131`, `Community 132`, `Community 141`, `Community 143`, `Community 145`, `Community 147`, `Community 148`, `Community 150`, `Community 152`, `Community 154`, `Community 156`, `Community 157`, `Community 162`, `Community 176`, `Community 178`, `Community 179`, `Community 180`, `Community 185`, `Community 198`, `Community 200`, `Community 205`, `Community 206`, `Community 209`, `Community 217`, `Community 222`, `Community 232`, `Community 233`, `Community 254`, `Community 255`, `Community 768`, `Community 264`, `Community 268`, `Community 273`, `Community 275`, `Community 795`, `Community 294`, `Community 306`, `Community 322`, `Community 334`, `Community 351`, `Community 377`, `Community 410`, `Community 453`?**
-  _High betweenness centrality (0.020) - this node is a cross-community bridge._
-- **Why does `IOException` connect `Community 513` to `Community 7`, `Community 8`, `Community 523`, `Community 15`, `Community 528`, `Community 19`, `Community 535`, `Community 24`, `Community 25`, `Community 29`, `Community 31`, `Community 41`, `Community 557`, `Community 562`, `Community 56`, `Community 57`, `Community 60`, `Community 61`, `Community 62`, `Community 64`, `Community 71`, `Community 584`, `Community 74`, `Community 588`, `Community 76`, `Community 79`, `Community 85`, `Community 87`, `Community 102`, `Community 105`, `Community 116`, `Community 117`, `Community 122`, `Community 130`, `Community 131`, `Community 133`, `Community 138`, `Community 141`, `Community 145`, `Community 147`, `Community 148`, `Community 151`, `Community 154`, `Community 156`, `Community 169`, `Community 170`, `Community 175`, `Community 179`, `Community 185`, `Community 189`, `Community 205`, `Community 209`, `Community 210`, `Community 212`, `Community 233`, `Community 236`, `Community 239`, `Community 244`, `Community 252`, `Community 781`, `Community 273`, `Community 279`, `Community 294`, `Community 299`, `Community 313`, `Community 314`, `Community 317`, `Community 319`, `Community 321`, `Community 326`, `Community 328`, `Community 333`, `Community 340`, `Community 347`, `Community 348`, `Community 363`, `Community 364`, `Community 368`, `Community 375`, `Community 402`, `Community 410`, `Community 418`, `Community 424`, `Community 428`, `Community 455`, `Community 467`, `Community 471`, `Community 506`?**
-  _High betweenness centrality (0.018) - this node is a cross-community bridge._
+- **Why does `SHAFT` connect `Community 513` to `Community 512`, `Community 2`, `Community 514`, `Community 3`, `Community 5`, `Community 517`, `Community 7`, `Community 8`, `Community 10`, `Community 523`, `Community 12`, `Community 13`, `Community 15`, `Community 16`, `Community 529`, `Community 18`, `Community 19`, `Community 528`, `Community 21`, `Community 22`, `Community 23`, `Community 24`, `Community 26`, `Community 538`, `Community 27`, `Community 540`, `Community 541`, `Community 31`, `Community 543`, `Community 542`, `Community 34`, `Community 35`, `Community 36`, `Community 37`, `Community 38`, `Community 544`, `Community 545`, `Community 546`, `Community 547`, `Community 43`, `Community 548`, `Community 45`, `Community 46`, `Community 47`, `Community 39`, `Community 51`, `Community 52`, `Community 53`, `Community 566`, `Community 55`, `Community 565`, `Community 569`, `Community 563`, `Community 57`, `Community 65`, `Community 579`, `Community 69`, `Community 71`, `Community 74`, `Community 76`, `Community 80`, `Community 81`, `Community 86`, `Community 87`, `Community 88`, `Community 93`, `Community 95`, `Community 96`, `Community 103`, `Community 104`, `Community 106`, `Community 108`, `Community 112`, `Community 114`, `Community 116`, `Community 121`, `Community 123`, `Community 125`, `Community 130`, `Community 132`, `Community 134`, `Community 137`, `Community 138`, `Community 28`, `Community 142`, `Community 145`, `Community 30`, `Community 151`, `Community 153`, `Community 539`, `Community 155`, `Community 158`, `Community 159`, `Community 161`, `Community 32`, `Community 162`, `Community 165`, `Community 167`, `Community 169`, `Community 170`, `Community 172`, `Community 174`, `Community 175`, `Community 184`, `Community 186`, `Community 191`, `Community 199`, `Community 549`, `Community 206`, `Community 550`, `Community 212`, `Community 214`, `Community 218`, `Community 219`, `Community 222`, `Community 224`, `Community 225`, `Community 230`, `Community 235`, `Community 236`, `Community 240`, `Community 241`, `Community 758`, `Community 247`, `Community 759`, `Community 766`, `Community 254`, `Community 257`, `Community 772`, `Community 261`, `Community 774`, `Community 776`, `Community 266`, `Community 779`, `Community 269`, `Community 270`, `Community 271`, `Community 784`, `Community 782`, `Community 274`, `Community 787`, `Community 276`, `Community 273`, `Community 791`, `Community 279`, `Community 284`, `Community 796`, `Community 286`, `Community 287`, `Community 288`, `Community 797`, `Community 290`, `Community 285`, `Community 293`, `Community 295`, `Community 301`, `Community 306`, `Community 307`, `Community 311`, `Community 326`, `Community 327`, `Community 328`, `Community 329`, `Community 335`, `Community 337`, `Community 340`, `Community 346`, `Community 348`, `Community 352`, `Community 354`, `Community 358`, `Community 359`, `Community 360`, `Community 362`, `Community 367`, `Community 369`, `Community 373`, `Community 378`, `Community 380`, `Community 382`, `Community 389`, `Community 390`, `Community 391`, `Community 395`, `Community 398`, `Community 399`, `Community 401`, `Community 403`, `Community 405`, `Community 407`, `Community 408`, `Community 409`, `Community 411`, `Community 412`, `Community 417`, `Community 424`, `Community 427`, `Community 428`, `Community 429`, `Community 431`, `Community 432`, `Community 435`, `Community 436`, `Community 444`, `Community 445`, `Community 446`, `Community 450`, `Community 451`, `Community 454`, `Community 455`, `Community 456`, `Community 460`, `Community 461`, `Community 468`, `Community 470`, `Community 473`, `Community 476`, `Community 480`, `Community 483`, `Community 484`, `Community 485`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 493`, `Community 494`, `Community 496`, `Community 498`, `Community 501`, `Community 502`, `Community 503`, `Community 504`, `Community 505`, `Community 506`, `Community 509`, `Community 511`?**
+  _High betweenness centrality (0.133) - this node is a cross-community bridge._
+- **Why does `ArrayList` connect `Community 513` to `Community 768`, `Community 512`, `Community 3`, `Community 132`, `Community 7`, `Community 264`, `Community 268`, `Community 141`, `Community 14`, `Community 143`, `Community 145`, `Community 273`, `Community 19`, `Community 148`, `Community 150`, `Community 152`, `Community 25`, `Community 154`, `Community 410`, `Community 283`, `Community 413`, `Community 157`, `Community 34`, `Community 35`, `Community 162`, `Community 38`, `Community 551`, `Community 39`, `Community 41`, `Community 294`, `Community 45`, `Community 176`, `Community 178`, `Community 179`, `Community 180`, `Community 564`, `Community 56`, `Community 185`, `Community 186`, `Community 59`, `Community 60`, `Community 62`, `Community 64`, `Community 578`, `Community 322`, `Community 453`, `Community 198`, `Community 200`, `Community 74`, `Community 76`, `Community 333`, `Community 205`, `Community 209`, `Community 85`, `Community 217`, `Community 90`, `Community 93`, `Community 222`, `Community 95`, `Community 232`, `Community 233`, `Community 111`, `Community 116`, `Community 117`, `Community 118`, `Community 377`, `Community 125`, `Community 254`, `Community 255`?**
+  _High betweenness centrality (0.023) - this node is a cross-community bridge._
+- **Why does `IOException` connect `Community 513` to `Community 5`, `Community 7`, `Community 8`, `Community 523`, `Community 528`, `Community 18`, `Community 19`, `Community 535`, `Community 24`, `Community 25`, `Community 29`, `Community 31`, `Community 41`, `Community 553`, `Community 557`, `Community 566`, `Community 56`, `Community 57`, `Community 60`, `Community 61`, `Community 62`, `Community 64`, `Community 71`, `Community 72`, `Community 584`, `Community 74`, `Community 588`, `Community 76`, `Community 79`, `Community 85`, `Community 87`, `Community 102`, `Community 105`, `Community 116`, `Community 117`, `Community 628`, `Community 122`, `Community 129`, `Community 131`, `Community 133`, `Community 138`, `Community 141`, `Community 145`, `Community 147`, `Community 148`, `Community 154`, `Community 169`, `Community 170`, `Community 175`, `Community 177`, `Community 179`, `Community 185`, `Community 189`, `Community 205`, `Community 206`, `Community 209`, `Community 210`, `Community 212`, `Community 224`, `Community 233`, `Community 236`, `Community 239`, `Community 244`, `Community 252`, `Community 766`, `Community 781`, `Community 273`, `Community 787`, `Community 279`, `Community 294`, `Community 299`, `Community 313`, `Community 314`, `Community 317`, `Community 319`, `Community 321`, `Community 326`, `Community 328`, `Community 333`, `Community 336`, `Community 340`, `Community 347`, `Community 363`, `Community 364`, `Community 369`, `Community 370`, `Community 375`, `Community 402`, `Community 410`, `Community 418`, `Community 428`, `Community 455`, `Community 467`, `Community 471`, `Community 506`?**
+  _High betweenness centrality (0.022) - this node is a cross-community bridge._
 - **What connects `$id`, `$schema`, `additionalProperties` to the rest of the system?**
-  _1556 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _1560 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.04242424242424243 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
   _Cohesion score 0.05764411027568922 - nodes in this community are weakly interconnected._
 - **Should `Community 2` be split into smaller, more focused modules?**
-  _Cohesion score 0.0851063829787234 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.08599033816425121 - nodes in this community are weakly interconnected._

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1,5722 +1,5577 @@
 {
   ".memory/config.json": {
-    "mtime": 1782297664.0100386,
+    "mtime": 1782336090.7889457,
     "ast_hash": "4ece894daf076c559889cf9afe6211e8",
     "semantic_hash": ""
   },
   ".memory/memory/architecture.json": {
-    "mtime": 1782297664.011038,
+    "mtime": 1782336090.7899442,
     "ast_hash": "cfc3c045ead7b74d483c04bc6746ea4e",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/maven-central-version-immutability.json": {
-    "mtime": 1782297664.0140386,
+    "mtime": 1782336090.7929437,
     "ast_hash": "434d7f5918634bb78e5a7abc8d7bf7ce",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/paid-agent-work-audit-gated.json": {
-    "mtime": 1782297664.0150385,
+    "mtime": 1782336090.7939434,
     "ast_hash": "61f81f00078da8d614a21373fd7e8089",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/agent-guidance-progressive-disclosure.json": {
-    "mtime": 1782297664.0160377,
+    "mtime": 1782336090.7949433,
     "ast_hash": "d112f6080b24b67628173736e69c67e0",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/namespaced-video-capabilities.json": {
-    "mtime": 1782297664.0201619,
+    "mtime": 1782336090.799945,
     "ast_hash": "38736f88f73b401031d168040fb2e609",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/public-docs-external.json": {
-    "mtime": 1782297664.0231597,
+    "mtime": 1782336090.8029437,
     "ast_hash": "dad3f0a3b650c5264d8dd7e4e4e366df",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/utf8-all-runtime-layers.json": {
-    "mtime": 1782297664.0258276,
+    "mtime": 1782336090.8059437,
     "ast_hash": "0537ffa6937eab44bf326e9a2af4eca9",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/allure-result-population.json": {
-    "mtime": 1782297664.0289195,
+    "mtime": 1782336090.8079457,
     "ast_hash": "0b408e349588a98b38afad0c067e86da",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/coverage-constructors-start-browser.json": {
-    "mtime": 1782297664.02992,
+    "mtime": 1782336090.808944,
     "ast_hash": "c26c533a52af00631104647ed120e846",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/java25-isuite-mocking.json": {
-    "mtime": 1782297664.0309193,
+    "mtime": 1782336090.809944,
     "ast_hash": "172391dc5cc831f90c86f7f71b305c19",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/testng-method-parallel-shared-instance-fields.json": {
-    "mtime": 1782297664.033836,
+    "mtime": 1782336090.812944,
     "ast_hash": "1d489c077df56ae50e23e4b41f6da2f3",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/testng-single-threaded-static-state.json": {
-    "mtime": 1782297664.0349715,
+    "mtime": 1782336090.813944,
     "ast_hash": "41ae606ccc9cebd6325667da85ac2392",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/windows-allure-root-race.json": {
-    "mtime": 1782297664.0359716,
+    "mtime": 1782336090.813944,
     "ast_hash": "2f12b8774174d36ad6dd9f7375c9ebca",
     "semantic_hash": ""
   },
   ".memory/memory/project.json": {
-    "mtime": 1782297664.0369704,
+    "mtime": 1782336090.814944,
     "ast_hash": "f0a00de79160381997ea0562bcea283c",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/issue-linked-pr-closure-and-focused-tests.json": {
-    "mtime": 1782297664.0452487,
+    "mtime": 1782336090.821944,
     "ast_hash": "ec46aa71d095fface3f1692bde6926b1",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/low-token-user-guide-work.json": {
-    "mtime": 1782297664.0452487,
+    "mtime": 1782336090.822944,
     "ast_hash": "b4fd7b27d046eccd67b552fac5f7d31c",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/proactive-memory-use-when-material.json": {
-    "mtime": 1782297664.0472536,
+    "mtime": 1782336090.823944,
     "ast_hash": "dcc3243cb2aef6624523d32b6a2ec027",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/start-new-tasks-from-origin-main.json": {
-    "mtime": 1782297664.0502539,
+    "mtime": 1782336090.8269455,
     "ast_hash": "20f6aadf28b59bac7d81d77b252caa72",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/update-official-user-guide-for-functionality-changes.json": {
-    "mtime": 1782297664.0522535,
+    "mtime": 1782336090.8291495,
     "ast_hash": "25cd51397aafa8823d00734801c3b62f",
     "semantic_hash": ""
   },
   ".memory/relations/project-shaft-engine-related-to-architecture-current.json": {
-    "mtime": 1782297664.0542533,
+    "mtime": 1782336090.8311496,
     "ast_hash": "61f899057083188f3c611b1207e86344",
     "semantic_hash": ""
   },
   ".memory/schema/config.schema.json": {
-    "mtime": 1782297664.0582533,
+    "mtime": 1782336090.83515,
     "ast_hash": "a9df65611183adc20ed4598acd8c8496",
     "semantic_hash": ""
   },
   ".memory/schema/event.schema.json": {
-    "mtime": 1782297664.0592546,
+    "mtime": 1782336090.83515,
     "ast_hash": "b48fe7cc7267789e3f05371800d2572f",
     "semantic_hash": ""
   },
   ".memory/schema/object.schema.json": {
-    "mtime": 1782297664.0592546,
+    "mtime": 1782336090.83615,
     "ast_hash": "df0c4608282c91449d7445ca2109376f",
     "semantic_hash": ""
   },
   ".memory/schema/patch.schema.json": {
-    "mtime": 1782297664.0592546,
+    "mtime": 1782336090.83615,
     "ast_hash": "5476dea56f653fe6ae9b3237c911dc6a",
     "semantic_hash": ""
   },
   ".memory/schema/relation.schema.json": {
-    "mtime": 1782297664.0602531,
+    "mtime": 1782336090.83615,
     "ast_hash": "05342c9eb8c7b7bdc8ef3a73d3eedc5a",
     "semantic_hash": ""
   },
   "scripts/ci/agent_guidance_budget.json": {
-    "mtime": 1782297664.1365037,
+    "mtime": 1782336090.9095297,
     "ast_hash": "d52de49ceeebd519a79a94e140ceee41",
     "semantic_hash": ""
   },
   "scripts/ci/assemble_javadocs.py": {
-    "mtime": 1782297664.1375039,
+    "mtime": 1782336090.9095297,
     "ast_hash": "6fe67ccde798d4838393acaf16b87261",
     "semantic_hash": ""
   },
   "scripts/ci/check_maven_release_version.py": {
-    "mtime": 1782297664.1375039,
+    "mtime": 1782336090.910529,
     "ast_hash": "e92141a897e15092ed65fcd13f36fa6d",
     "semantic_hash": ""
   },
   "scripts/ci/extract_allure_failures.py": {
-    "mtime": 1782297664.1385036,
+    "mtime": 1782336090.910529,
     "ast_hash": "1392425a815e5e3d6c98a0a07531a282",
     "semantic_hash": ""
   },
   "scripts/ci/github-auth-env.sh": {
-    "mtime": 1782297664.1385036,
+    "mtime": 1782336090.911529,
     "ast_hash": "2f1a16109a60700251b2b1e8b204a331",
     "semantic_hash": ""
   },
   "scripts/ci/validate_agent_guidance.py": {
-    "mtime": 1782297664.1385036,
+    "mtime": 1782336090.911529,
     "ast_hash": "6efb73d9c1754b06f29ff45b3d15f6ad",
     "semantic_hash": ""
   },
   "scripts/ci/validate_agent_setup.py": {
-    "mtime": 1782297664.1395037,
+    "mtime": 1782336090.9125288,
     "ast_hash": "510d4cb0ac7e970d1e485e0798690b22",
     "semantic_hash": ""
   },
   "scripts/ci/validate_documentation_boundaries.py": {
-    "mtime": 1782297664.1395037,
+    "mtime": 1782336090.9125288,
     "ast_hash": "1f04136b5b8395cd6bda836ba3243523",
     "semantic_hash": ""
   },
   "scripts/ci/validate_maven_publication.py": {
-    "mtime": 1782297664.140504,
+    "mtime": 1782336090.9125288,
     "ast_hash": "b30a099549e23dba6a1c00877649c186",
     "semantic_hash": ""
   },
   "scripts/ci/validate_modular_documentation.py": {
-    "mtime": 1782297664.140504,
+    "mtime": 1782336090.9135294,
     "ast_hash": "230b7753f6e3140d6bdcebed25aeb688",
     "semantic_hash": ""
   },
   "scripts/ci/validate_quality_configuration.py": {
-    "mtime": 1782297664.141504,
+    "mtime": 1782336090.9135294,
     "ast_hash": "7ea8e7c413b65535474333a58f004843",
     "semantic_hash": ""
   },
   "scripts/ci/validate_reactor_versions.py": {
-    "mtime": 1782297664.141504,
+    "mtime": 1782336090.9135294,
     "ast_hash": "7ada71bfaf0bf09a2a118f3a172169e4",
     "semantic_hash": ""
   },
   "scripts/ci/validate_shaft_mcp_configuration.py": {
-    "mtime": 1782297664.1424134,
+    "mtime": 1782336090.914529,
     "ast_hash": "9a27dc403a9decdc4287c451f3303386",
     "semantic_hash": ""
   },
   "scripts/ci/validate_shaft_mcp_transports.py": {
-    "mtime": 1782297664.1424134,
+    "mtime": 1782336090.914529,
     "ast_hash": "cef307194198823949632cf1c0510543",
     "semantic_hash": ""
   },
   "scripts/ci/validate_shaft_pilot_release.py": {
-    "mtime": 1782297664.1424134,
+    "mtime": 1782336090.915529,
     "ast_hash": "b9f4064afb31d843b66fa3323ca29d6f",
     "semantic_hash": ""
   },
   "scripts/ci/verify_maven_central_release.py": {
-    "mtime": 1782297664.1435697,
+    "mtime": 1782336090.915529,
     "ast_hash": "f50ff9221963b55f6cd5355dcf077516",
     "semantic_hash": ""
   },
   "scripts/ci/verify_shaft_mcp_installer_release.py": {
-    "mtime": 1782297664.1435697,
+    "mtime": 1782336090.915529,
     "ast_hash": "61eb62b67b294cb5da719bb315bf6cde",
     "semantic_hash": ""
   },
   "scripts/maintenance/flatten-history.sh": {
-    "mtime": 1782297664.14457,
+    "mtime": 1782336090.9165297,
     "ast_hash": "dde238359c6206f7dd16219757f04f07",
     "semantic_hash": ""
   },
   "scripts/mcp/install-shaft-mcp.ps1": {
-    "mtime": 1782297664.14457,
+    "mtime": 1782336090.9165297,
     "ast_hash": "68f7dfc58bde866c56e5b69b36c1a8f8",
     "semantic_hash": ""
   },
   "scripts/mcp/install-shaft-mcp.sh": {
-    "mtime": 1782297664.145569,
+    "mtime": 1782336090.917529,
     "ast_hash": "9d9c90cba847ab57ab90a08ea0c19560",
     "semantic_hash": ""
   },
   "scripts/mcp/install_shaft_mcp.py": {
-    "mtime": 1782297664.146573,
+    "mtime": 1782336090.9185297,
     "ast_hash": "09f2d0f568b7bac3d7adf8a36534d61b",
     "semantic_hash": ""
   },
   "shaft-ai/src/main/java/com/shaft/ai/provider/AbstractHttpAiProvider.java": {
-    "mtime": 1782297664.149573,
+    "mtime": 1782336090.9205809,
     "ast_hash": "dbb7debe96eaf04ce97677b023010551",
     "semantic_hash": ""
   },
   "shaft-ai/src/main/java/com/shaft/ai/provider/AnthropicProvider.java": {
-    "mtime": 1782297664.14988,
+    "mtime": 1782336090.9219275,
     "ast_hash": "fd84c714e9fdbcd3adc3e0ebd89c166e",
     "semantic_hash": ""
   },
   "shaft-ai/src/main/java/com/shaft/ai/provider/GeminiProvider.java": {
-    "mtime": 1782297664.150665,
+    "mtime": 1782336090.9219275,
     "ast_hash": "a15587f8a53841df6ef6c891505f168d",
     "semantic_hash": ""
   },
   "shaft-ai/src/main/java/com/shaft/ai/provider/OllamaProvider.java": {
-    "mtime": 1782297664.150665,
+    "mtime": 1782336090.9229321,
     "ast_hash": "2a63f2862593c6543ce4b503f462e1f7",
     "semantic_hash": ""
   },
   "shaft-ai/src/main/java/com/shaft/ai/provider/OpenAiProvider.java": {
-    "mtime": 1782297664.150665,
+    "mtime": 1782336090.9229321,
     "ast_hash": "4c18363c15f720d76033af2df645c929",
     "semantic_hash": ""
   },
   "shaft-ai/src/test/java/com/shaft/ai/provider/ProviderConformanceTest.java": {
-    "mtime": 1782297664.1538382,
+    "mtime": 1782336090.9259324,
     "ast_hash": "e7c70c2dfbbbeea72ca0fd26bd3aaf41",
     "semantic_hash": ""
   },
   "shaft-browserstack/src/main/java/com/shaft/integration/browserstack/BrowserStackModule.java": {
-    "mtime": 1782297664.1582234,
+    "mtime": 1782336090.9279325,
     "ast_hash": "72302597cacbdcf22114d39c4a134055",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/cli/CaptureCli.java": {
-    "mtime": 1782297664.1631181,
+    "mtime": 1782336090.9329324,
     "ast_hash": "22e81755fd9b65ed25577032a321eee3",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/BidiBrowserEventCollector.java": {
-    "mtime": 1782297664.164119,
+    "mtime": 1782336090.9329324,
     "ast_hash": "47e8063cd21021bc1b40d9b0e5b4d083",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventCollector.java": {
-    "mtime": 1782297664.164119,
+    "mtime": 1782336090.9339328,
     "ast_hash": "7bcd665b60a9fdde45a86fd920161935",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventScript.java": {
-    "mtime": 1782297664.165119,
+    "mtime": 1782336090.9339328,
     "ast_hash": "8755a9e0ae74e3e95a65bc66e5125d05",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/BrowserSignal.java": {
-    "mtime": 1782297664.165119,
+    "mtime": 1782336090.9349322,
     "ast_hash": "df91d356ff80267cc300bf5a20c14f2d",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/CompositeBrowserEventCollector.java": {
-    "mtime": 1782297664.165119,
+    "mtime": 1782336090.9349322,
     "ast_hash": "576d60256e891e492f671083c8ada4a6",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/PollingBrowserEventCollector.java": {
-    "mtime": 1782297664.1661172,
+    "mtime": 1782336090.9349322,
     "ast_hash": "cc6e3c91b88b9be048d380224b8ca08f",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlClient.java": {
-    "mtime": 1782297664.166607,
+    "mtime": 1782336090.9359322,
     "ast_hash": "1104a60eeea8d2368509e6a901fb824b",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlFiles.java": {
-    "mtime": 1782297664.1679118,
+    "mtime": 1782336090.9359322,
     "ast_hash": "e2f3d582e3b02783b4ad6ebae4ad030c",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlServer.java": {
-    "mtime": 1782297664.1679118,
+    "mtime": 1782336090.9369328,
     "ast_hash": "842573fb335554672af12070b09b9c28",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/format/CaptureFormatException.java": {
-    "mtime": 1782297664.168911,
+    "mtime": 1782336090.9369328,
     "ast_hash": "16dd9ed34b8f5e575980e759908f5c4b",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/format/CaptureJsonCodec.java": {
-    "mtime": 1782297664.168911,
+    "mtime": 1782336090.9379325,
     "ast_hash": "a805163d5ada4a16614b4c6c033c4347",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/format/CaptureSchemaMigrator.java": {
-    "mtime": 1782297664.169911,
+    "mtime": 1782336090.9379325,
     "ast_hash": "65b0476a9fc1922aa2d1db391b4988fd",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureEnrichmentPreview.java": {
-    "mtime": 1782297664.1709096,
+    "mtime": 1782336090.9389324,
     "ast_hash": "becc024cd2177b4113f3fc8746ec4354",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureEnrichmentService.java": {
-    "mtime": 1782297664.1709096,
+    "mtime": 1782336090.9399326,
     "ast_hash": "4eb736b3f4f1ed574a280d779994b768",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationReport.java": {
-    "mtime": 1782297664.1709096,
+    "mtime": 1782336090.9399326,
     "ast_hash": "a478402031451dc70abbdb73165486b0",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationRequest.java": {
-    "mtime": 1782297664.1719098,
+    "mtime": 1782336090.9409325,
     "ast_hash": "baf507818de7dc32b660e5163a2a0a67",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationResult.java": {
-    "mtime": 1782297664.1719098,
+    "mtime": 1782336090.9409325,
     "ast_hash": "64235aa1fa46ab5857e3057e452eccab",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java": {
-    "mtime": 1782297664.1729105,
+    "mtime": 1782336090.9419332,
     "ast_hash": "07d5fd247851111b76dcf02412758df4",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/GeneratedTestValidator.java": {
-    "mtime": 1782297664.1749103,
+    "mtime": 1782336090.9439437,
     "ast_hash": "d3a5ba9e076837ea9685c089e1eb2b24",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/LocatorRanker.java": {
-    "mtime": 1782297664.1749103,
+    "mtime": 1782336090.9439437,
     "ast_hash": "b8de8d4abc874a48ab234270e224af6e",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/BrowserMetadata.java": {
-    "mtime": 1782297664.175914,
+    "mtime": 1782336090.944949,
     "ast_hash": "aca616578f082355fd0761f58597be5d",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/CaptureEvent.java": {
-    "mtime": 1782297664.175914,
+    "mtime": 1782336090.944949,
     "ast_hash": "36642a12d8b21af2444a67fde759c546",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/CaptureSession.java": {
-    "mtime": 1782297664.1769109,
+    "mtime": 1782336090.944949,
     "ast_hash": "8b231d12ab3791b756caac91cbdb4c10",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/Checkpoint.java": {
-    "mtime": 1782297664.1769109,
+    "mtime": 1782336090.9459486,
     "ast_hash": "2a3ca946a6921b589ae137ecc6f60581",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/ElementSnapshot.java": {
-    "mtime": 1782297664.1779108,
+    "mtime": 1782336090.9459486,
     "ast_hash": "14868c3708fab12f82feb3b9e24d01ec",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/EventContext.java": {
-    "mtime": 1782297664.1779108,
+    "mtime": 1782336090.9459486,
     "ast_hash": "a8a5457d7b613592975c3bc8297ccfee",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/EvidenceReference.java": {
-    "mtime": 1782297664.1779108,
+    "mtime": 1782336090.9469488,
     "ast_hash": "786eef193ba4ca565c23dc1d142ba475",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/ExternalTestDataReference.java": {
-    "mtime": 1782297664.1789114,
+    "mtime": 1782336090.9469488,
     "ast_hash": "fa36b8fb9e646b9d1b51ce0605d33d95",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/LocatorCandidate.java": {
-    "mtime": 1782297664.1789114,
+    "mtime": 1782336090.9469488,
     "ast_hash": "dd66b616e91d7e6fa0abfec2b475a90b",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/ModelSupport.java": {
-    "mtime": 1782297664.179911,
+    "mtime": 1782336090.9479485,
     "ast_hash": "c54568ab63b584765e027d13eaa6e00b",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/PageContext.java": {
-    "mtime": 1782297664.179911,
+    "mtime": 1782336090.9479485,
     "ast_hash": "8fa7d63b7d571c010f6c1a1d927e5400",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/RedactionSummary.java": {
-    "mtime": 1782297664.179911,
+    "mtime": 1782336090.9489484,
     "ast_hash": "7a5a3a53ec8011e51823968f7b2ba6a2",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/privacy/CapturePrivacyClassifier.java": {
-    "mtime": 1782297664.1809103,
+    "mtime": 1782336090.9489484,
     "ast_hash": "0f9d46db745fc5bbe83ece1758401053",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/privacy/CapturePrivacyPolicy.java": {
-    "mtime": 1782297664.1819098,
+    "mtime": 1782336090.9489484,
     "ast_hash": "77266ad326a57f7b2cf95ada13f2e221",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/privacy/ClassifiedValue.java": {
-    "mtime": 1782297664.1819098,
+    "mtime": 1782336090.9499488,
     "ast_hash": "b8dae78977adf61da8c1a8d42cf8e122",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureBrowser.java": {
-    "mtime": 1782297664.1829102,
+    "mtime": 1782336090.9509578,
     "ast_hash": "f1ca5592cf996f4503417bbc4c2c356b",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java": {
-    "mtime": 1782297664.183221,
+    "mtime": 1782336090.9509578,
     "ast_hash": "eb742f395b2e2a63a45e73cf5529ac22",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureManager.java": {
-    "mtime": 1782297664.1837504,
+    "mtime": 1782336090.9509578,
     "ast_hash": "469574f4d08f284372ba708dd1e7a177",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureSingleSessionLock.java": {
-    "mtime": 1782297664.1837504,
+    "mtime": 1782336090.9519498,
     "ast_hash": "fc8c18ea3f3fb1449c0545c9fec14b82",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureStartRequest.java": {
-    "mtime": 1782297664.1848805,
+    "mtime": 1782336090.9519498,
     "ast_hash": "b0b6151d075c56dc07fb266a8b18b316",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureStatus.java": {
-    "mtime": 1782297664.1848805,
+    "mtime": 1782336090.9529486,
     "ast_hash": "5a11ea402919f7b1718cd953c4f419a2",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java": {
-    "mtime": 1782297664.1858802,
+    "mtime": 1782336090.9529486,
     "ast_hash": "bdf8eb306437199c02934d7815300ce7",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/storage/CaptureSessionStore.java": {
-    "mtime": 1782297664.1858802,
+    "mtime": 1782336090.9539485,
     "ast_hash": "229b38b0e510e0d9c7b9a08bc71db5b9",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/storage/ExternalTestDataWriter.java": {
-    "mtime": 1782297664.1868796,
+    "mtime": 1782336090.9539485,
     "ast_hash": "e69dc835c53bd61b0e8ccfc34f983185",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/resources/browser/shaft-capture-recorder.js": {
-    "mtime": 1782297664.1878803,
+    "mtime": 1782336090.9549487,
     "ast_hash": "6332eb239c5b09d577317d9933b5f8fb",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/resources/schema/shaft-capture-session-1.0.schema.json": {
-    "mtime": 1782297664.18888,
+    "mtime": 1782336090.955956,
     "ast_hash": "df85a8de90f01cbb4c980201998901d0",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/CaptureFixtures.java": {
-    "mtime": 1782297664.1898801,
+    "mtime": 1782336090.9569492,
     "ast_hash": "5f889c8fbaec05b6f2741a137700d788",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/format/CaptureJsonCodecTest.java": {
-    "mtime": 1782297664.1933365,
+    "mtime": 1782336090.9604578,
     "ast_hash": "231b3b2f5f283141335c78cf8983c065",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratedReplayBrowserTest.java": {
-    "mtime": 1782297664.1943364,
+    "mtime": 1782336090.9604578,
     "ast_hash": "cd1a6080100cbce05841ce7a32757f17",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java": {
-    "mtime": 1782297664.1943364,
+    "mtime": 1782336090.9614582,
     "ast_hash": "e95db718ca4958bd6673750fd8a9dab2",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/generate/LocatorRankerTest.java": {
-    "mtime": 1782297664.195336,
+    "mtime": 1782336090.9614582,
     "ast_hash": "8c1ad098141cceb54b35c1a35c33d863",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/privacy/CapturePrivacyClassifierTest.java": {
-    "mtime": 1782297664.195336,
+    "mtime": 1782336090.962458,
     "ast_hash": "7702332d104ea111fdec6e1fa99d6df3",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java": {
-    "mtime": 1782297664.1963358,
+    "mtime": 1782336090.962458,
     "ast_hash": "fbbbba609aaaf9755e40d5504a4ecbb9",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureRuntimePortabilityTest.java": {
-    "mtime": 1782297664.197336,
+    "mtime": 1782336090.9634578,
     "ast_hash": "b4774a5bc9b7d84591360de0f8482164",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java": {
-    "mtime": 1782297664.197336,
+    "mtime": 1782336090.9634578,
     "ast_hash": "c457491fa2232a3b4615fddf737611aa",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/storage/CaptureSessionStoreTest.java": {
-    "mtime": 1782297664.198336,
+    "mtime": 1782336090.9644582,
     "ast_hash": "cc70993c979f97b8de7554bd34515622",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/resources/fixtures/golden-generated-session-1.java": {
-    "mtime": 1782297664.1998205,
+    "mtime": 1782336090.9654582,
     "ast_hash": "15d1969da9a2e6a0bc6efdee6f4c590d",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/resources/fixtures/golden-session-1.0.json": {
-    "mtime": 1782297664.2004573,
+    "mtime": 1782336090.9664586,
     "ast_hash": "94d6b5e35f7a9d8a12a448178eed460e",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/resources/fixtures/legacy-session-0.9.json": {
-    "mtime": 1782297664.2004573,
+    "mtime": 1782336090.9664586,
     "ast_hash": "fe67510df7883478c930d414d5ad38cc",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/DoctorAiAnalysisRequest.java": {
-    "mtime": 1782297664.2035618,
+    "mtime": 1782336090.968458,
     "ast_hash": "55678906c451524f9fb3c48d0d464ff9",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/DoctorAnalysisRequest.java": {
-    "mtime": 1782297664.2035618,
+    "mtime": 1782336090.9694583,
     "ast_hash": "6fb3dd5ae5993ce8a61e4cd73d327aa4",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/DoctorAnalyzer.java": {
-    "mtime": 1782297664.2045615,
+    "mtime": 1782336090.9694583,
     "ast_hash": "30b31bc51979d3f990c15ad91b5f4f4f",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/ai/DoctorAiAnalysisService.java": {
-    "mtime": 1782297664.2045615,
+    "mtime": 1782336090.9704578,
     "ast_hash": "4b1cd2196306a10434d9df255bf01d8d",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/analysis/DeterministicRuleEngine.java": {
-    "mtime": 1782297664.2055612,
+    "mtime": 1782336090.971458,
     "ast_hash": "732501c3f0664de7f83469e8d9db5a70",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/cli/DoctorCli.java": {
-    "mtime": 1782297664.206561,
+    "mtime": 1782336090.971458,
     "ast_hash": "c7277004cfa5eae27d5f7d1477ec92a4",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/collect/EvidenceCollector.java": {
-    "mtime": 1782297664.2075613,
+    "mtime": 1782336090.9724584,
     "ast_hash": "215b16abacef5aac9558b65d47ef7f79",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/format/DoctorFormatException.java": {
-    "mtime": 1782297664.2082052,
+    "mtime": 1782336090.9724584,
     "ast_hash": "ac49bb5981592a48aed69d5e929e8357",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/format/DoctorJsonCodec.java": {
-    "mtime": 1782297664.208927,
+    "mtime": 1782336090.9734583,
     "ast_hash": "e37f60eedfbf0c389362d3fcf8884981",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/internal/DoctorHashing.java": {
-    "mtime": 1782297664.208927,
+    "mtime": 1782336090.9734583,
     "ast_hash": "cbf37af4f45fcd49e34d177a36e7788e",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/internal/DoctorRedactor.java": {
-    "mtime": 1782297664.2100382,
+    "mtime": 1782336090.9744582,
     "ast_hash": "50c5ae3ae3589a795ce05bd77aeb022d",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/CauseCategory.java": {
-    "mtime": 1782297664.2100382,
+    "mtime": 1782336090.9744582,
     "ast_hash": "07daed154b031e5c8e8a67f58d60c076",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/Confidence.java": {
-    "mtime": 1782297664.211038,
+    "mtime": 1782336090.975458,
     "ast_hash": "58efa214b4b396e5cd16320ecb7f1419",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/Diagnosis.java": {
-    "mtime": 1782297664.211038,
+    "mtime": 1782336090.975458,
     "ast_hash": "d5f6f816532eebb1a0ce72949dc26637",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAdvisory.java": {
-    "mtime": 1782297664.211038,
+    "mtime": 1782336090.975458,
     "ast_hash": "844eaf9048ab13c94b72ba4145b589f8",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAiAnalysisResult.java": {
-    "mtime": 1782297664.2120376,
+    "mtime": 1782336090.9764585,
     "ast_hash": "93cd26759f448a2370ea5a793ccd0ecc",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAnalysisResult.java": {
-    "mtime": 1782297664.2120376,
+    "mtime": 1782336090.9764585,
     "ast_hash": "ae20f4a3cd962138db3be05bd442ef21",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAnalysisSummary.java": {
-    "mtime": 1782297664.213037,
+    "mtime": 1782336090.9764585,
     "ast_hash": "db1612663a72eceaf8b36d02e4534f99",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorModelSupport.java": {
-    "mtime": 1782297664.213037,
+    "mtime": 1782336090.977458,
     "ast_hash": "8e4a6c083ab2a7837d98104a9ce23b8c",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/EvidenceBundle.java": {
-    "mtime": 1782297664.214037,
+    "mtime": 1782336090.977458,
     "ast_hash": "f1ce8926f044be3bd0652d3b43f91946",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/EvidenceCategory.java": {
-    "mtime": 1782297664.214037,
+    "mtime": 1782336090.9784582,
     "ast_hash": "6976b42e37761f612bdee1f8d2cd8f50",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/EvidenceItem.java": {
-    "mtime": 1782297664.214037,
+    "mtime": 1782336090.9784582,
     "ast_hash": "2a427690ae34f946851017d16c18a5ab",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/EvidenceProvenance.java": {
-    "mtime": 1782297664.2150369,
+    "mtime": 1782336090.9784582,
     "ast_hash": "56bd866d04bd1ab56863ab0aa104a31c",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/Finding.java": {
-    "mtime": 1782297664.2160368,
+    "mtime": 1782336090.9794583,
     "ast_hash": "ca086338b16ab81a80882d4830254620",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/RedactionSummary.java": {
-    "mtime": 1782297664.2160368,
+    "mtime": 1782336090.9794583,
     "ast_hash": "5fcbb50a506dd9456d5ec76fe90a4ea7",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/Remediation.java": {
-    "mtime": 1782297664.2165618,
+    "mtime": 1782336090.9804585,
     "ast_hash": "45487f78e554324e826976f19b75dadc",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairAiRequest.java": {
-    "mtime": 1782297664.2176707,
+    "mtime": 1782336090.9804585,
     "ast_hash": "cb971f162e01bc90678e0d40e08d0947",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairAiService.java": {
-    "mtime": 1782297664.2176707,
+    "mtime": 1782336090.98146,
     "ast_hash": "0d4d59f92ec198022b0e44682359ac82",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairPatchResult.java": {
-    "mtime": 1782297664.2186685,
+    "mtime": 1782336090.98146,
     "ast_hash": "309c6a07dc3145574d2e2bbd54c7b334",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairProposalResult.java": {
-    "mtime": 1782297664.2186685,
+    "mtime": 1782336090.9824579,
     "ast_hash": "6a01cd05b4c6b271ce7ab395d393e396",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairPublicationRequest.java": {
-    "mtime": 1782297664.2186685,
+    "mtime": 1782336090.9824579,
     "ast_hash": "50162373c4b5f046f867b5d1344816c7",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairRequest.java": {
-    "mtime": 1782297664.2196674,
+    "mtime": 1782336090.9824579,
     "ast_hash": "8afe0727b1629734c1b865c805d613f3",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairService.java": {
-    "mtime": 1782297664.2196674,
+    "mtime": 1782336090.9834583,
     "ast_hash": "3ddd9b9f7ec71452100a891378758166",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposal.java": {
-    "mtime": 1782297664.2206671,
+    "mtime": 1782336090.9834583,
     "ast_hash": "72e037d2cc8aac280c799b1f76147c4c",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposalRequest.java": {
-    "mtime": 1782297664.2206671,
+    "mtime": 1782336090.9834583,
     "ast_hash": "b53a430ae27cf976040410a97b06a37b",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposalService.java": {
-    "mtime": 1782297664.2206671,
+    "mtime": 1782336090.984458,
     "ast_hash": "1f0ea7387c631ddb9501dc97f144e27b",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/RepairGuard.java": {
-    "mtime": 1782297664.2216673,
+    "mtime": 1782336090.984458,
     "ast_hash": "fba5356ab168ee237ee6530712c94f00",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/RepairProcessRunner.java": {
-    "mtime": 1782297664.2216673,
+    "mtime": 1782336090.9854577,
     "ast_hash": "5fe1cd3c8e8b190bcab936fd417b3825",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/RepairProposal.java": {
-    "mtime": 1782297664.2226672,
+    "mtime": 1782336090.9854577,
     "ast_hash": "f1e22305d666390fc499f30d41184bc7",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/RepairProposalStore.java": {
-    "mtime": 1782297664.2226672,
+    "mtime": 1782336090.9854577,
     "ast_hash": "e94f86295598c8f1ae590214048bd53b",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/RepairPublicationResult.java": {
-    "mtime": 1782297664.2226672,
+    "mtime": 1782336090.9864583,
     "ast_hash": "54b09925ec8f18ec028ba4dec8dfceee",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/report/DoctorReportWriter.java": {
-    "mtime": 1782297664.2236679,
+    "mtime": 1782336090.9864583,
     "ast_hash": "cf246a6dccada6bd2ad38899deed5728",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-doctor-advisory-1.0.schema.json": {
-    "mtime": 1782297664.2246675,
+    "mtime": 1782336090.9874582,
     "ast_hash": "0707502a8d574324252c3e6c9e59b68e",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-doctor-diagnosis-1.0.schema.json": {
-    "mtime": 1782297664.2256684,
+    "mtime": 1782336090.9874582,
     "ast_hash": "955b53f8d49daea98d4ac1fc82d40587",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-doctor-evidence-1.0.schema.json": {
-    "mtime": 1782297664.2266676,
+    "mtime": 1782336090.9884577,
     "ast_hash": "62af20c56b0b7df2415adc87012a03c7",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-doctor-repair-patch-1.0.schema.json": {
-    "mtime": 1782297664.2266676,
+    "mtime": 1782336090.9884577,
     "ast_hash": "0798e219e11cb74541c713d96d2ac2a9",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-heal-locator-proposal-1.0.schema.json": {
-    "mtime": 1782297664.2276683,
+    "mtime": 1782336090.9894586,
     "ast_hash": "ede7581c250a246a7ef50c26116e926b",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/DoctorAnalyzerTest.java": {
-    "mtime": 1782297664.2296674,
+    "mtime": 1782336090.9904583,
     "ast_hash": "576320b25fa1fbf85a7cc21a2f337230",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/ai/DoctorAiAnalysisServiceTest.java": {
-    "mtime": 1782297664.2306674,
+    "mtime": 1782336090.9914582,
     "ast_hash": "a4275d927157b9dcdca5a983b2cf514a",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/repair/DoctorRepairAiServiceTest.java": {
-    "mtime": 1782297664.2306674,
+    "mtime": 1782336090.992458,
     "ast_hash": "42a607d9a057330ca195c6cfc9ae7d54",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/repair/DoctorRepairServiceTest.java": {
-    "mtime": 1782297664.2316673,
+    "mtime": 1782336090.992458,
     "ast_hash": "0de5d211d8c45c9799e1b2487f28106c",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/repair/HealingLocatorProposalServiceTest.java": {
-    "mtime": 1782297664.232667,
+    "mtime": 1782336090.992458,
     "ast_hash": "87a964a179a869fd747537abc1dee167",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/ai/contradictory.json": {
-    "mtime": 1782297664.2339168,
+    "mtime": 1782336090.9934583,
     "ast_hash": "9cc3faaf569b9523478d440eac4c31fa",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/ai/hallucinated-evidence.json": {
-    "mtime": 1782297664.2339168,
+    "mtime": 1782336090.9944584,
     "ast_hash": "8392a8f0353b0006ce35cee8a3cd04e4",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/ai/high-quality.json": {
-    "mtime": 1782297664.2339168,
+    "mtime": 1782336090.9944584,
     "ast_hash": "e6f7861bf34853d8e39252b93d0f7ee4",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/ai/malformed.json": {
-    "mtime": 1782297664.2350273,
+    "mtime": 1782336090.9944584,
     "ast_hash": "fb9415fb50bc91677036081513bbc19d",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/ai/unavailable.json": {
-    "mtime": 1782297664.2350273,
+    "mtime": 1782336090.9954576,
     "ast_hash": "4b7fec724f675abb3404bc58a0cd21fd",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/golden/doctor-report.json": {
-    "mtime": 1782297664.2360272,
+    "mtime": 1782336090.9954576,
     "ast_hash": "d19a4cec92c592cf6f3804f87c7d1ac8",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/golden/locator-result.json": {
-    "mtime": 1782297664.2370272,
+    "mtime": 1782336090.9964585,
     "ast_hash": "cc0963373d7ae1eb7e2026ce65f5c16d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/RequestBuilder.java": {
-    "mtime": 1782297664.2390265,
+    "mtime": 1782336090.9984584,
     "ast_hash": "d42a461c60e080f37268fc6ad09e2b52",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/RestActions.java": {
-    "mtime": 1782297664.2400272,
-    "ast_hash": "7edefb8035ba8502bb851eda14518a18",
+    "mtime": 1782337660.919889,
+    "ast_hash": "4248abe2452144c8f9b3b062543ade1b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/ShaftRestAssuredFilter.java": {
-    "mtime": 1782297664.2400272,
-    "ast_hash": "9306e392aada4eeb056b02e8583750ee",
+    "mtime": 1782337645.4675508,
+    "ast_hash": "097fc6e6133ca9907707809344d67e46",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cli/FileActions.java": {
-    "mtime": 1782297664.2415361,
+    "mtime": 1782336091.000458,
     "ast_hash": "a1d907444ba2bc35977265503c7c916d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java": {
-    "mtime": 1782297664.2422116,
+    "mtime": 1782336091.000458,
     "ast_hash": "c7bf3c6c81a85d681faa3a2756728587",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cucumber/AssertionSteps.java": {
-    "mtime": 1782297664.2433214,
+    "mtime": 1782336091.0023098,
     "ast_hash": "5698b91473dd5dca826130e368e03b08",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cucumber/BrowserSteps.java": {
-    "mtime": 1782297664.2433214,
+    "mtime": 1782336091.0023098,
     "ast_hash": "ad3b088235e9d348c8563ed46da91944",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cucumber/ElementSteps.java": {
-    "mtime": 1782297664.2443209,
+    "mtime": 1782336091.0033152,
     "ast_hash": "5174cbfba57ae0fc18a79de0c4491af1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/db/DatabaseActions.java": {
-    "mtime": 1782297664.2443209,
+    "mtime": 1782336091.0033152,
     "ast_hash": "e94ab6b3d65838a79da1adf16ace4c37",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/DriverFactory.java": {
-    "mtime": 1782297664.2453225,
+    "mtime": 1782336091.0043151,
     "ast_hash": "8ee0caf3a105473f413b00ac8f1f9adf",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/SHAFT.java": {
-    "mtime": 1782297664.2463264,
-    "ast_hash": "1d1c4f18ed0ed16cf35cb625f1a2101b",
+    "mtime": 1782336954.973454,
+    "ast_hash": "254f367de95ac0251b22517ed4fdb7d3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/$.java": {
-    "mtime": 1782297664.2463264,
+    "mtime": 1782336091.0053146,
     "ast_hash": "f0f29bf4777208e42080bbb8d92c7655",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/BrowserStackHelper.java": {
-    "mtime": 1782297664.2473266,
+    "mtime": 1782336091.006315,
     "ast_hash": "8269be54fd38e960b0e7acb0b3009e21",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/BrowserStackSdkHelper.java": {
-    "mtime": 1782297664.2473266,
+    "mtime": 1782336091.0072987,
     "ast_hash": "85c848b791627a3f81dc6f1499440f48",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java": {
-    "mtime": 1782297664.2483263,
-    "ast_hash": "4005d2a0d26ba11948f02429832ab439",
+    "mtime": 1782336091.0072987,
+    "ast_hash": "85fa6ce0eac0e926f0d1c3ac5105a711",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/LambdaTestHelper.java": {
-    "mtime": 1782297664.2493255,
+    "mtime": 1782336091.0084617,
     "ast_hash": "3f3755d291c98c32cfdd363cee4cf73a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java": {
-    "mtime": 1782297664.2498724,
+    "mtime": 1782336091.0096393,
     "ast_hash": "5b9262d2b474746633c113235894b0f7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/SynchronizationManager.java": {
-    "mtime": 1782297664.2507322,
+    "mtime": 1782336091.0106452,
     "ast_hash": "eb0cff7a79a25b8e6999426d21353757",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/FluentWebDriverAction.java": {
-    "mtime": 1782297664.2507322,
+    "mtime": 1782336091.0106452,
     "ast_hash": "72da0e0b47b4f503c107c7add47ab23a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/WizardHelpers.java": {
-    "mtime": 1782297664.251891,
+    "mtime": 1782336091.0116448,
     "ast_hash": "f6788d05f21d1f430ac6325b5aa234c6",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/enums/internal/ClipboardAction.java": {
-    "mtime": 1782297664.25289,
+    "mtime": 1782336091.0116448,
     "ast_hash": "70733b35a3b354ad26cb2293c92e7c1f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/enums/internal/NavigationAction.java": {
-    "mtime": 1782297664.25289,
+    "mtime": 1782336091.012644,
     "ast_hash": "c58c8262a7e2348b6984ff75638f997a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/enums/internal/Screenshots.java": {
-    "mtime": 1782297664.2538886,
+    "mtime": 1782336091.012644,
     "ast_hash": "623942ecc89e633c28fa2014876ac552",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java": {
-    "mtime": 1782297664.2548888,
-    "ast_hash": "be46b32fb3e2f9a4838c9f42a7ec16d6",
+    "mtime": 1782337669.1063592,
+    "ast_hash": "7aa1843d8a8eacefaba695e69187ec42",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserActionsHelper.java": {
-    "mtime": 1782297664.2558901,
+    "mtime": 1782336091.0156443,
     "ast_hash": "9e93f32f815bc40eb9bad1c1ced6ca25",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/JavaScriptWaitManager.java": {
-    "mtime": 1782297664.2568898,
+    "mtime": 1782336091.0176485,
     "ast_hash": "2461e01c04d95924a01f0c83b9ad7029",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/AlertActions.java": {
-    "mtime": 1782297664.2624824,
+    "mtime": 1782336091.0226438,
     "ast_hash": "07eae43bbdcd7ae2c04955c35798d538",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/AsyncElementActions.java": {
-    "mtime": 1782297664.2624824,
+    "mtime": 1782336091.0226438,
     "ast_hash": "b127634e4819e21e34a549ba21ca7a03",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/ElementActions.java": {
-    "mtime": 1782297664.2634826,
+    "mtime": 1782336091.0226438,
     "ast_hash": "be3bc856752a3cdaed67fc1f0bccdbc4",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java": {
-    "mtime": 1782297664.264482,
+    "mtime": 1782336091.0236468,
     "ast_hash": "392baacd1c81e9a7ca9f1d3650fff6c6",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java": {
-    "mtime": 1782297664.2654815,
+    "mtime": 1782336091.0246456,
     "ast_hash": "126e6747f72d69df17723106294a20e5",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java": {
-    "mtime": 1782297664.2654815,
+    "mtime": 1782336091.0246456,
     "ast_hash": "54cef5b5d584f55f1b826ae8d4982074",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementInformation.java": {
-    "mtime": 1782297664.2664816,
+    "mtime": 1782336091.0260553,
     "ast_hash": "069e9385670d467fcfd1f7210d9e34cc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/exceptions/MultipleElementsFoundException.java": {
-    "mtime": 1782297664.2673154,
+    "mtime": 1782336091.0269206,
     "ast_hash": "7115d38040575ebf54fb3f543a30290f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingActionOutcome.java": {
-    "mtime": 1782297664.2685165,
+    "mtime": 1782336091.0269206,
     "ast_hash": "9a99f0ead6650249de18d721129711cc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingExplanation.java": {
-    "mtime": 1782297664.2685165,
+    "mtime": 1782336091.0279262,
     "ast_hash": "ee26d9a41572d22c59b897020537b16e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingManager.java": {
-    "mtime": 1782297664.2695162,
+    "mtime": 1782336091.0279262,
     "ast_hash": "188dfd22939333186c98b7a9749d6aed",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingObservation.java": {
-    "mtime": 1782297664.2695162,
+    "mtime": 1782336091.028926,
     "ast_hash": "a5423face0fd000d6ecaca3410a7b2e3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingProvider.java": {
-    "mtime": 1782297664.2705164,
+    "mtime": 1782336091.028926,
     "ast_hash": "ebf8923cd40ade102731421c41f57986",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingProviderRegistry.java": {
-    "mtime": 1782297664.2705164,
+    "mtime": 1782336091.028926,
     "ast_hash": "3cbe60277c5b519104b46355f11b3849",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingRequest.java": {
-    "mtime": 1782297664.2705164,
+    "mtime": 1782336091.029926,
     "ast_hash": "01fa33edca22567bffb147b7698ef87d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingResolution.java": {
-    "mtime": 1782297664.2715154,
+    "mtime": 1782336091.029926,
     "ast_hash": "53c802fb2320dd3320128019dcb8e965",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingStrategy.java": {
-    "mtime": 1782297664.2715154,
+    "mtime": 1782336091.029926,
     "ast_hash": "28500b405d7d843f0099971b196415d1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingVisualProvider.java": {
-    "mtime": 1782297664.272516,
+    "mtime": 1782336091.0309272,
     "ast_hash": "cf4607a228a2c6f37ef287bf95c02905",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/AnimatedGifManager.java": {
-    "mtime": 1782297664.272516,
+    "mtime": 1782336091.0319257,
     "ast_hash": "820ea16bfa9e8397fcc97592f8dc1515",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java": {
-    "mtime": 1782297664.2735157,
+    "mtime": 1782336091.0324397,
     "ast_hash": "6f8d5aee259e1deff9612cfa8e94db9c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotHelper.java": {
-    "mtime": 1782297664.2745159,
+    "mtime": 1782336091.0324397,
     "ast_hash": "bd9223dc2b3615bddc02e58bc5ec999f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotManager.java": {
-    "mtime": 1782297664.2749054,
+    "mtime": 1782336091.0336478,
     "ast_hash": "423c79c8b0dfa060ed50f9a03b2b96e6",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/VisualProcessingProvider.java": {
-    "mtime": 1782297664.2749054,
+    "mtime": 1782336091.03466,
     "ast_hash": "b82bb32f7bba8fd5bce43c64dd8451a7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/VisualProcessingProviderRegistry.java": {
-    "mtime": 1782297664.2756734,
+    "mtime": 1782336091.03466,
     "ast_hash": "9b616f64cbbddb4faead5b8f0a9c21b9",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/Locator.java": {
-    "mtime": 1782297664.2767975,
+    "mtime": 1782336091.0356536,
     "ast_hash": "e02bf607fbeff72dd9b178b08bf8d85b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/LocatorBuilder.java": {
-    "mtime": 1782297664.2767975,
+    "mtime": 1782336091.0356536,
     "ast_hash": "5cfd4d2b383e696367b5d1d0070bee58",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/Locators.java": {
-    "mtime": 1782297664.2767975,
+    "mtime": 1782336091.0356536,
     "ast_hash": "c75c5f50d1a2cfb34eac7e66c23ddedc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/Role.java": {
-    "mtime": 1782297664.277799,
+    "mtime": 1782336091.0366535,
     "ast_hash": "7f35dc1a5a395ed93e4c158badb0ec2b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/ShadowLocatorBuilder.java": {
-    "mtime": 1782297664.277799,
+    "mtime": 1782336091.0366535,
     "ast_hash": "ebec375f08bc01a3b1502aed75f1231d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/SmartLocators.java": {
-    "mtime": 1782297664.2787986,
+    "mtime": 1782336091.0376549,
     "ast_hash": "3a133af568d904b275980e47c8862aaf",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/XpathAxis.java": {
-    "mtime": 1782297664.2787986,
+    "mtime": 1782336091.0376549,
     "ast_hash": "15de5fb7fe4ce1ecbf3fc6b5022ba3df",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/DeterministicNaturalActionPlanner.java": {
-    "mtime": 1782297664.2797985,
+    "mtime": 1782336091.038653,
     "ast_hash": "95e7f4007bf7fc22f96dfd426ca47ea7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionExecutor.java": {
-    "mtime": 1782297664.2797985,
+    "mtime": 1782336091.038653,
     "ast_hash": "27f19328ab9d5a45da44797cdce1d2a5",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionKind.java": {
-    "mtime": 1782297664.2807987,
+    "mtime": 1782336091.039653,
     "ast_hash": "7ab19c76ab5d66cdc94e8183b5c4fe4c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionPlan.java": {
-    "mtime": 1782297664.2807987,
+    "mtime": 1782336091.039653,
     "ast_hash": "c913e5edcb2b9594946cf5b50362d108",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionPlanner.java": {
-    "mtime": 1782297664.281798,
+    "mtime": 1782336091.039653,
     "ast_hash": "544f27ddc74a8a6732e6ad6e2f7da494",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionPlannerRegistry.java": {
-    "mtime": 1782297664.281798,
+    "mtime": 1782336091.0406537,
     "ast_hash": "8a223a42ffda00a3e13ae108748a8270",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionRequest.java": {
-    "mtime": 1782297664.281798,
+    "mtime": 1782336091.0406537,
     "ast_hash": "51e484221eb6defbd218ade0eb1dea84",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionStep.java": {
-    "mtime": 1782297664.282798,
+    "mtime": 1782336091.0406537,
     "ast_hash": "29b36b4244b122ef2e6dd4c391c99625",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/video/DesktopVideoRecordingProvider.java": {
-    "mtime": 1782297664.2832365,
+    "mtime": 1782336091.0416536,
     "ast_hash": "b98f55fe150407bba68594b78fb2e5b7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistry.java": {
-    "mtime": 1782297664.2842908,
+    "mtime": 1782336091.0416536,
     "ast_hash": "5cb846a30b50df2b01b15bb5abaf362f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/video/RecordManager.java": {
-    "mtime": 1782297664.2846737,
+    "mtime": 1782336091.0426536,
     "ast_hash": "ee83db977f0369f56d0b5074c791b6d0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/AllureListener.java": {
-    "mtime": 1782297664.2937355,
+    "mtime": 1782336091.051683,
     "ast_hash": "641101e959b09cf49e071682e194a87e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/CucumberFeatureListener.java": {
-    "mtime": 1782297664.294736,
+    "mtime": 1782336091.0526834,
     "ast_hash": "14d03222afd184a66843e942e8d6c838",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/CucumberTestRunnerListener.java": {
-    "mtime": 1782297664.294736,
+    "mtime": 1782336091.0526834,
     "ast_hash": "4d4b34169ad6f2440e377838f32554f3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/JunitListener.java": {
-    "mtime": 1782297664.2957351,
+    "mtime": 1782336091.0536819,
     "ast_hash": "5ee42ad81ad16c397bcb172a39bb8206",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/TestNGListener.java": {
-    "mtime": 1782297664.296736,
-    "ast_hash": "bd2663bf77a9af09e4a0dd5e53c7ecdf",
+    "mtime": 1782336091.054682,
+    "ast_hash": "ac3491b7e5589609fbf0485fdfbd56e5",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/ConfigurationHelper.java": {
-    "mtime": 1782297664.296736,
+    "mtime": 1782336091.0552664,
     "ast_hash": "e96809e943e2adb15f47a9c242a540dc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/CucumberHelper.java": {
-    "mtime": 1782297664.2977357,
+    "mtime": 1782336091.0552664,
     "ast_hash": "b9d9211bd12ac82043f313e415ed8cfc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/JiraHelper.java": {
-    "mtime": 1782297664.299735,
+    "mtime": 1782336091.0572715,
     "ast_hash": "a4ef92cd147ecdaf44ef9f805da98c73",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/JunitListenerHelper.java": {
-    "mtime": 1782297664.299735,
+    "mtime": 1782336091.0572715,
     "ast_hash": "5a96f15340ee466d71733a4977fab257",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/RetryAnalyzer.java": {
-    "mtime": 1782297664.3006544,
+    "mtime": 1782336091.0572715,
     "ast_hash": "d2aa20e8d03ceba6f29aa9b88a773366",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java": {
-    "mtime": 1782297664.3006544,
+    "mtime": 1782336091.0582714,
     "ast_hash": "a3100fa64409d706a04a7b4a6baeeb99",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/UpdateChecker.java": {
-    "mtime": 1782297664.3018432,
+    "mtime": 1782336091.0592718,
     "ast_hash": "56edc5784cd56e08113f0d04f51fd25a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/WebDriverListener.java": {
-    "mtime": 1782297664.3018432,
+    "mtime": 1782336091.0592718,
     "ast_hash": "11caa57a58f17da0416933518895efdd",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/performance/internal/LightHouseGenerateReport.java": {
-    "mtime": 1782297664.3028433,
+    "mtime": 1782336091.0597765,
     "ast_hash": "8395aa33dcea0312ab66a82c9fc7eb77",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/API.java": {
-    "mtime": 1782297664.303843,
+    "mtime": 1782336091.0607824,
     "ast_hash": "ed37de76862455b58cb06ec770ecd159",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Allure.java": {
-    "mtime": 1782297664.304843,
+    "mtime": 1782336091.0607824,
     "ast_hash": "8db3286d4c88e2ad66b8238976ab1f26",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/BrowserStack.java": {
-    "mtime": 1782297664.304843,
+    "mtime": 1782336091.0617824,
     "ast_hash": "2c4ea1d03ddde366471ab7d371f129c0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Cucumber.java": {
-    "mtime": 1782297664.3058436,
+    "mtime": 1782336091.0627818,
     "ast_hash": "563b9ce2f293404c06e4a7a73dab132b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/EngineProperties.java": {
-    "mtime": 1782297664.3058436,
+    "mtime": 1782336091.0627818,
     "ast_hash": "e7d9d408bcf36812505cd26632b45ccc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Flags.java": {
-    "mtime": 1782297664.306843,
+    "mtime": 1782336091.0637827,
     "ast_hash": "643347d2cdd011d79a7504db2bc868b4",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Healenium.java": {
-    "mtime": 1782297664.306843,
+    "mtime": 1782336091.0637827,
     "ast_hash": "020bedc94874be8d4f237c2007a9244c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Healing.java": {
-    "mtime": 1782297664.306843,
+    "mtime": 1782336091.0637827,
     "ast_hash": "d6b881dfe76fe2145f6a3f21096896cd",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java": {
-    "mtime": 1782297664.3082323,
+    "mtime": 1782336091.0647826,
     "ast_hash": "0dcc9d873618f00473caca1408d915b1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Jira.java": {
-    "mtime": 1782297664.3082323,
+    "mtime": 1782336091.0647826,
     "ast_hash": "69e39c376eb244713a8638e8b682931a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/LambdaTest.java": {
-    "mtime": 1782297664.3089314,
+    "mtime": 1782336091.0657818,
     "ast_hash": "2129d3567c4540656d0f1a70a4b5836e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Log4j.java": {
-    "mtime": 1782297664.3089314,
+    "mtime": 1782336091.0657818,
     "ast_hash": "64f209cc056e8a51110fc91a200d8abc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Mobile.java": {
-    "mtime": 1782297664.3089314,
+    "mtime": 1782336091.066782,
     "ast_hash": "99c440a93cda95169b39727741055898",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/NaturalActions.java": {
-    "mtime": 1782297664.3100324,
+    "mtime": 1782336091.066782,
     "ast_hash": "16794b31ca521ab70430850b04a80827",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Paths.java": {
-    "mtime": 1782297664.3100324,
+    "mtime": 1782336091.066782,
     "ast_hash": "e75d6d00fdd8079a0bc4e51ceec9152d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Pattern.java": {
-    "mtime": 1782297664.3110323,
+    "mtime": 1782336091.0677829,
     "ast_hash": "8002dccd85dcdaafcd7ec207d48f88a5",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Performance.java": {
-    "mtime": 1782297664.3110323,
+    "mtime": 1782336091.0677829,
     "ast_hash": "793bb90128693e92514e59175322965c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Pilot.java": {
-    "mtime": 1782297664.3120327,
+    "mtime": 1782336091.0677829,
     "ast_hash": "5926e78f43d97233473dd978b9e55623",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Platform.java": {
-    "mtime": 1782297664.3120327,
-    "ast_hash": "3c8d103672435e69831b1cb1a76cfc2c",
+    "mtime": 1782336091.068783,
+    "ast_hash": "ba6e6ce752e51b47b72229aa04fd4fe3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Properties.java": {
-    "mtime": 1782297664.3130324,
+    "mtime": 1782336091.0697825,
     "ast_hash": "f2a5ec5f2f57f7b18d68808b3f0a9e91",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java": {
-    "mtime": 1782297664.3140326,
+    "mtime": 1782336091.0697825,
     "ast_hash": "c0717daa3daf5746c0b60f83876c8880",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/PropertyFileManager.java": {
-    "mtime": 1782297664.3140326,
+    "mtime": 1782336091.0697825,
     "ast_hash": "2ab8de326fa8ddb7229618022678ed9e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Reporting.java": {
-    "mtime": 1782297664.3150313,
+    "mtime": 1782336091.0707824,
     "ast_hash": "8132aca6020e4e06200d956af056225f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/TestNG.java": {
-    "mtime": 1782297664.3150313,
+    "mtime": 1782336091.0707824,
     "ast_hash": "268615541ef0f2d92323fd0edd376740",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/ThreadLocalPropertiesManager.java": {
-    "mtime": 1782297664.3150313,
+    "mtime": 1782336091.0721424,
     "ast_hash": "7603bbb7bf6364ce7bf5b9f5e1bba5e1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Timeouts.java": {
-    "mtime": 1782297664.316032,
+    "mtime": 1782336091.0721424,
     "ast_hash": "01ef9ffeba24462276fb15dc4a4d373f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Tinkey.java": {
-    "mtime": 1782297664.3169224,
+    "mtime": 1782336091.0732634,
     "ast_hash": "f35fc1565279b0d33b1b76121bf74440",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Visuals.java": {
-    "mtime": 1782297664.3169224,
+    "mtime": 1782336091.0732634,
     "ast_hash": "606feddfa218d572c43882a90f235400",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Web.java": {
-    "mtime": 1782297664.3176725,
+    "mtime": 1782336091.0732634,
     "ast_hash": "20cf2529ea8129f74e8f092bc14cadde",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/FirestoreRestClient.java": {
-    "mtime": 1782297664.3187957,
+    "mtime": 1782336091.074268,
     "ast_hash": "52adc8b518e5c5ed1246fd4aa8271ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/security/GoogleTink.java": {
-    "mtime": 1782297664.3197954,
+    "mtime": 1782336091.0752685,
     "ast_hash": "3d0e1234d2dbab5b9ef7b984cb681088",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/AndroidApkBadgingReader.java": {
-    "mtime": 1782297664.3197954,
+    "mtime": 1782336091.0752685,
     "ast_hash": "eb3f564e4c3e3d2f3ffccaf882ac4b1f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/HTMLHelper.java": {
-    "mtime": 1782297664.3207946,
+    "mtime": 1782336091.0762682,
     "ast_hash": "057fe001f1e4b25c8f7229cde35c7d16",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/JavaHelper.java": {
-    "mtime": 1782297664.3207946,
+    "mtime": 1782336091.0762682,
     "ast_hash": "3de9ea3f98b99d20eeeb148de402cfed",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/JavaScriptHelper.java": {
-    "mtime": 1782297664.3217947,
+    "mtime": 1782336091.0772684,
     "ast_hash": "ffa7c4c697733f0ba85ac8992acad360",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/PerformanceReportHTMLHelper.java": {
-    "mtime": 1782297664.3217947,
+    "mtime": 1782336091.0772684,
     "ast_hash": "88c165d5f2804d620f65e01921143f9e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/tms/XrayIntegrationHelper.java": {
-    "mtime": 1782297664.322795,
+    "mtime": 1782336091.0782683,
     "ast_hash": "eb849fadba51320243f21ab56502a88a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/CSVFileManager.java": {
-    "mtime": 1782297664.3237958,
+    "mtime": 1782336091.0790946,
     "ast_hash": "bc71c58c04f330dc365d51d576fedec2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/ExcelFileManager.java": {
-    "mtime": 1782297664.3237958,
+    "mtime": 1782336091.0790946,
     "ast_hash": "0af8559f094d68d4e36cb6a9b7c5b9ea",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/JSONFileManager.java": {
-    "mtime": 1782297664.3247955,
+    "mtime": 1782336091.0800993,
     "ast_hash": "dd7a5b8f6f927191caa131280df13a65",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/PdfFileManager.java": {
-    "mtime": 1782297664.3247955,
+    "mtime": 1782336091.0800993,
     "ast_hash": "da672eb4269d3a41533ed1532da0e185",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/ReportManager.java": {
-    "mtime": 1782297664.3256142,
+    "mtime": 1782336091.0800993,
     "ast_hash": "e658122a017e7931fced4022a1d53bae",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/YAMLFileManager.java": {
-    "mtime": 1782297664.3256142,
+    "mtime": 1782336091.0811002,
     "ast_hash": "d5a21b7fac317f8b4e5341c703a0a249",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java": {
-    "mtime": 1782297664.3267517,
+    "mtime": 1782336091.0820994,
     "ast_hash": "c45a77eaee3092add8cdc250ac04b642",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ApiPerformanceExecutionReport.java": {
-    "mtime": 1782297664.3277519,
+    "mtime": 1782336091.0820994,
     "ast_hash": "0e913480d5e37f16c5547a28cbb78efe",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/AttachmentReporter.java": {
-    "mtime": 1782297664.3277519,
+    "mtime": 1782336091.0820994,
     "ast_hash": "c3f9ed9269797a1679c4846a740a6273",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointCounter.java": {
-    "mtime": 1782297664.3287525,
+    "mtime": 1782336091.0830998,
     "ast_hash": "34558a6d4d5d49df20017aa63876759f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointStatus.java": {
-    "mtime": 1782297664.3287525,
+    "mtime": 1782336091.0830998,
     "ast_hash": "02d39d0739d083d1109634c17bb340c1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointType.java": {
-    "mtime": 1782297664.329751,
+    "mtime": 1782336091.0830998,
     "ast_hash": "e688c7535844f865f0c179f1f0f7a41b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ExecutionSummaryReport.java": {
-    "mtime": 1782297664.329751,
+    "mtime": 1782336091.0841,
     "ast_hash": "85be5b1acb498075ff0ae7394c116e10",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureReporter.java": {
-    "mtime": 1782297664.3307512,
+    "mtime": 1782336091.0848436,
     "ast_hash": "5c3cbaf91f5d1501231b96f95bf6d566",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/IssueReporter.java": {
-    "mtime": 1782297664.3307512,
+    "mtime": 1782336091.0848436,
     "ast_hash": "4eba0030e5188396323aab843b0747fa",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/LogRedirector.java": {
-    "mtime": 1782297664.3307512,
+    "mtime": 1782336091.0848436,
     "ast_hash": "9734e0985bd24a628cdf0ef67514d8ab",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ProgressBarLogger.java": {
-    "mtime": 1782297664.331751,
+    "mtime": 1782336091.0858488,
     "ast_hash": "16a68f6e5312e085724d41c9576aa1b4",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ProjectStructureManager.java": {
-    "mtime": 1782297664.331751,
+    "mtime": 1782336091.0858488,
     "ast_hash": "b8f74461b5c086f8941e6cb3ef9555b1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportHelper.java": {
-    "mtime": 1782297664.3327506,
+    "mtime": 1782336091.0868485,
     "ast_hash": "807338ec8f08ec6d82804254656ed806",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java": {
-    "mtime": 1782297664.3337524,
+    "mtime": 1782336091.0878484,
     "ast_hash": "39ffee2f7642885e95f8a4dedf0e808d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/ValidationEnums.java": {
-    "mtime": 1782297664.3337524,
+    "mtime": 1782336091.0878484,
     "ast_hash": "1a700a8ec5f1bc9a8ad65352a4891e8f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/Validations.java": {
-    "mtime": 1782297664.3347502,
+    "mtime": 1782336091.0878484,
     "ast_hash": "eb127c87713ca57986c7aa799e13dd29",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/accessibility/AccessibilityActions.java": {
-    "mtime": 1782297664.335751,
+    "mtime": 1782336091.0888488,
     "ast_hash": "e95213311dd416f0935f0b258beacfb8",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/accessibility/AccessibilityHelper.java": {
-    "mtime": 1782297664.335751,
+    "mtime": 1782336091.089849,
     "ast_hash": "ef3e9bfa56f456c0c36ed15424404f66",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/CustomSoftAssert.java": {
-    "mtime": 1782297664.3367496,
+    "mtime": 1782336091.0908484,
     "ast_hash": "d4d79fea9924eca6d094dcf8d77694cc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/FileValidationsBuilder.java": {
-    "mtime": 1782297664.3377512,
+    "mtime": 1782336091.0908484,
     "ast_hash": "05b7459be4fb4a2b653dadbac75eed37",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/JSONValidationsBuilder.java": {
-    "mtime": 1782297664.3377512,
+    "mtime": 1782336091.0908484,
     "ast_hash": "e7961b1a51db674dd615bedc29eb4793",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/NativeValidationsBuilder.java": {
-    "mtime": 1782297664.3387487,
+    "mtime": 1782336091.0918505,
     "ast_hash": "35c20b2f52ab5f62588ac9d1f999b9d5",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/NumberValidationsBuilder.java": {
-    "mtime": 1782297664.3387487,
+    "mtime": 1782336091.0928488,
     "ast_hash": "10b25c3ee77eb08878b4e715f70b6ad0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/RestValidationsBuilder.java": {
-    "mtime": 1782297664.339749,
+    "mtime": 1782336091.0928488,
     "ast_hash": "58553b6f5f4c8f13d9044cacc581fa61",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/TextDirectionValidationsBuilder.java": {
-    "mtime": 1782297664.339749,
+    "mtime": 1782336091.093849,
     "ast_hash": "05ffa33312d65e6de2953407817bff52",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/TextLanguageValidationsBuilder.java": {
-    "mtime": 1782297664.340751,
+    "mtime": 1782336091.093849,
     "ast_hash": "6bac35c22470196c40e45b599e57ae03",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsBuilder.java": {
-    "mtime": 1782297664.340751,
+    "mtime": 1782336091.093849,
     "ast_hash": "c113fe199e929201df6ef9ad1811a224",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsExecutor.java": {
-    "mtime": 1782297664.341535,
+    "mtime": 1782336091.0948503,
     "ast_hash": "21dd8e866bad20db3d2ec0b697850330",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java": {
-    "mtime": 1782297664.3421614,
+    "mtime": 1782336091.095848,
     "ast_hash": "10e9b75c1ea7c953cb05b9a5ab912159",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverBrowserValidationsBuilder.java": {
-    "mtime": 1782297664.3421614,
+    "mtime": 1782336091.095848,
     "ast_hash": "e19e7ddf982160476c7e6b70c672d943",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverElementValidationsBuilder.java": {
-    "mtime": 1782297664.3421614,
+    "mtime": 1782336091.095848,
     "ast_hash": "09807c77d90f9f809a8ae0f9287a8d8f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/javadoc/resources/configuration-manager/jquery-3.5.0.min.js": {
-    "mtime": 1782297664.347356,
+    "mtime": 1782336091.1008494,
     "ast_hash": "7c5d886a944957e9ed1cc3c5eba023e9",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/javadoc/resources/configuration-manager/main-built.js": {
-    "mtime": 1782297664.3483565,
+    "mtime": 1782336091.1028488,
     "ast_hash": "bfcc66727306f6a7d6db18d89d9cbd8f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/javadoc/resources/configuration-manager/require.js": {
-    "mtime": 1782297664.3493562,
+    "mtime": 1782336091.1028488,
     "ast_hash": "81692bed77535de23323aed492f56861",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/appium/.appiumrc.json": {
-    "mtime": 1782297664.3537104,
+    "mtime": 1782336091.1068487,
     "ast_hash": "ae646a89330e08877d9e043741e04a89",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/healenium-backend/db/sql/init.sql": {
-    "mtime": 1782297664.3557105,
+    "mtime": 1782336091.1078486,
     "ast_hash": "68aef48e69eba5aebc7b90883a9928e3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/postgres/client.js": {
-    "mtime": 1782297664.35671,
+    "mtime": 1782336091.108849,
     "ast_hash": "a14553a735ee0f513a9da43c3e6f352f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/selenoid/browsers.json": {
-    "mtime": 1782297664.358844,
+    "mtime": 1782336091.110849,
     "ast_hash": "a911d4a4e1c61fbf88ddf25de262ff9b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/start_emu_headless": {
-    "mtime": 1782297664.3600042,
+    "mtime": 1782336091.1118484,
     "ast_hash": "70d231d40fb0677a8762c704a4209744",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/src/test/java/testRunners/CucumberTests.java": {
-    "mtime": 1782297664.3775134,
+    "mtime": 1782336091.1268487,
     "ast_hash": "81a52f665b264bd8f06e25ab4029ccc7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782297664.3815143,
+    "mtime": 1782336091.1308486,
     "ast_hash": "064e08dd978e03c2928244264e946ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1782297664.3921554,
+    "mtime": 1782336091.1388485,
     "ast_hash": "16a9fe15aa00921a0a57426e530b4418",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782297664.3952389,
+    "mtime": 1782336091.1418488,
     "ast_hash": "c3aa96f48b1065e13bb7402b929d9889",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1782297664.4048939,
+    "mtime": 1782336091.149854,
     "ast_hash": "6be46fd0c9360daf9cc0fe1e489282f1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782297664.4289472,
+    "mtime": 1782336091.17627,
     "ast_hash": "064e08dd978e03c2928244264e946ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1782297664.4392686,
+    "mtime": 1782336091.1852708,
     "ast_hash": "63b5ca0a71c4d5005c7ae9656b9c6c74",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782297664.4422703,
+    "mtime": 1782336091.1882703,
     "ast_hash": "064e08dd978e03c2928244264e946ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1782297664.452274,
+    "mtime": 1782336091.1962705,
     "ast_hash": "3cbfad60eb5b0316804c448223639228",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782297664.4552717,
+    "mtime": 1782336091.1992705,
     "ast_hash": "c3aa96f48b1065e13bb7402b929d9889",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1782297664.4647865,
+    "mtime": 1782336091.2072706,
     "ast_hash": "6f82df052ec4e4a835b7c2656798bcab",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782297664.4887855,
+    "mtime": 1782336091.229271,
     "ast_hash": "064e08dd978e03c2928244264e946ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1782297664.4997804,
+    "mtime": 1782336091.238271,
     "ast_hash": "89f691f86e06b6ed04028ac322acb53d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782297664.5027838,
+    "mtime": 1782336091.2402701,
     "ast_hash": "064e08dd978e03c2928244264e946ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/ApiPerformanceReportTest.java": {
-    "mtime": 1782297664.5217793,
+    "mtime": 1782336091.259663,
     "ast_hash": "6b42836ee0a0d8860582c0c3389a6f1c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/LocalApiTestServer.java": {
-    "mtime": 1782297664.522779,
+    "mtime": 1782336091.259663,
     "ast_hash": "4b479fde1c2774b1ef0b88fe9bee0047",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/PathParamTest.java": {
-    "mtime": 1782297664.522779,
+    "mtime": 1782336091.2606697,
     "ast_hash": "6333c55505dba0c7cae8f443c2cc748c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/RequestBuilderTests.java": {
-    "mtime": 1782297664.522779,
+    "mtime": 1782336091.2606697,
     "ast_hash": "08d7b254049cc8daac555e9f2f9f2aa9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/RestActionsCoverageUnitTest.java": {
-    "mtime": 1782297664.5237792,
-    "ast_hash": "877020d57c0804f606df907214862a25",
+    "mtime": 1782337689.5297372,
+    "ast_hash": "bc2a0389a9a8ef9943d834ede0cee7d0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/SwaggerContractTest.java": {
-    "mtime": 1782297664.5237792,
+    "mtime": 1782336091.2616706,
     "ast_hash": "adc4d25a405c2a64c949da6a0c41e232",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/TestUpload.java": {
-    "mtime": 1782297664.5247793,
+    "mtime": 1782336091.2616706,
     "ast_hash": "3f21181377aeac1c34f46b1a7c1cf298",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/testPostRequest.java": {
-    "mtime": 1782297664.5247793,
+    "mtime": 1782336091.2616706,
     "ast_hash": "9de940d6b7dc8e741eb019b9fccba6cd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/cli/FileActionsCoverageUnitTest.java": {
-    "mtime": 1782297664.5257814,
+    "mtime": 1782336091.2626705,
     "ast_hash": "c45c9550223fe7dcd993697eacf00c6b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/cucumber/ElementStepsCoverageUnitTest.java": {
-    "mtime": 1782297664.5257814,
+    "mtime": 1782336091.2637544,
     "ast_hash": "68270ddb7b02986ee98f52b2fa8892a7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelperCoverageUnitTest.java": {
-    "mtime": 1782297664.5277798,
+    "mtime": 1782336091.2647595,
     "ast_hash": "e92058dc8a463d5bc611a1b4ea514e3c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/OptionsManagerCoverageUnitTest.java": {
-    "mtime": 1782297664.5277798,
+    "mtime": 1782336091.265759,
     "ast_hash": "916846607ca501c107a5b0eb277c0c6a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/AsyncElementActionsCoverageUnitTest.java": {
-    "mtime": 1782297664.5287807,
+    "mtime": 1782336091.2667594,
     "ast_hash": "82de6e0ba9113ac7f63bba70cd5922bf",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java": {
-    "mtime": 1782297664.52978,
+    "mtime": 1782336091.2667594,
     "ast_hash": "b6730949f0a84dc5d66a4329a854e012",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsExceptionDetailsUnitTest.java": {
-    "mtime": 1782297664.52978,
+    "mtime": 1782336091.2677593,
     "ast_hash": "38a470e4ccf528f247d2adb30ee8a480",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ElementInformationCoverageUnitTest.java": {
-    "mtime": 1782297664.5307794,
+    "mtime": 1782336091.2677593,
     "ast_hash": "2683114ad3f10a14f3925a6bd6835400",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ElementsHelperCoverageUnitTest.java": {
-    "mtime": 1782297664.5307794,
+    "mtime": 1782336091.2687595,
     "ast_hash": "76f70bb8df336467105fc9ab7964a074",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/healing/HealingActionsIntegrationTest.java": {
-    "mtime": 1782297664.5317786,
+    "mtime": 1782336091.2687595,
     "ast_hash": "eef0b6ec55d75db96f4416c65ec0c65f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/healing/HealingStrategyTest.java": {
-    "mtime": 1782297664.5327792,
+    "mtime": 1782336091.269759,
     "ast_hash": "c29f55b4622c05fbf066a1a3f5143b88",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/AnimatedGifManagerCoverageUnitTest.java": {
-    "mtime": 1782297664.5327792,
+    "mtime": 1782336091.270759,
     "ast_hash": "bf0671ff4c59d2d23ff75bd13e8c5743",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotHelperCoverageUnitTest.java": {
-    "mtime": 1782297664.5347798,
+    "mtime": 1782336091.2717595,
     "ast_hash": "b0b5269cd3a52b3a438193dcbf99f73f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotManagerCoverageUnitTest.java": {
-    "mtime": 1782297664.5347798,
+    "mtime": 1782336091.2717595,
     "ast_hash": "1b53acb9faec7f11548e0198dca8e680",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/VisualProcessingProviderRegistryTest.java": {
-    "mtime": 1782297664.5347798,
+    "mtime": 1782336091.2727597,
     "ast_hash": "f65e99d62de78111e607e18fd4d6aceb",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/natural/NaturalActionExecutorTest.java": {
-    "mtime": 1782297664.5367792,
+    "mtime": 1782336091.2737596,
     "ast_hash": "aa28815755a0f28bd7343de86b58bee7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistryTest.java": {
-    "mtime": 1782297664.5367792,
+    "mtime": 1782336091.2737596,
     "ast_hash": "a2fa8e0ef33d17122b51f64ba073e670",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/video/RecordManagerCoverageUnitTest.java": {
-    "mtime": 1782297664.537779,
+    "mtime": 1782336091.2747595,
     "ast_hash": "b728bfab006ff8f0057b22748932c062",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/video/RecordManagerDesktopProviderTest.java": {
-    "mtime": 1782297664.537779,
+    "mtime": 1782336091.2747595,
     "ast_hash": "badd24f271266d3b1385ed7f93bbecd7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/listeners/AllureListenerCoverageUnitTest.java": {
-    "mtime": 1782297664.5397794,
+    "mtime": 1782336091.2777216,
     "ast_hash": "2241a07317bff8346a1bd1c01137e1a7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/listeners/internal/UpdateCheckerUnitTest.java": {
-    "mtime": 1782297664.5407794,
+    "mtime": 1782336091.2787266,
     "ast_hash": "a0c400588dc92dc8f84602e923dc34fd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/performance/internal/LightHouseGenerateReportCoverageUnitTest.java": {
-    "mtime": 1782297664.542781,
+    "mtime": 1782336091.2797267,
     "ast_hash": "d12ef0c4ab02daa11d78b8fa0b0def3e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/test/unitTests/JavaScriptWaitManagerUnitTest.java": {
-    "mtime": 1782297664.5447783,
+    "mtime": 1782336091.2817268,
     "ast_hash": "08bea5190a0202d3ca812e9b77ea809e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/internal/security/GoogleTinkApiCoverageUnitTest.java": {
-    "mtime": 1782297664.54678,
+    "mtime": 1782336091.282727,
     "ast_hash": "f0c7bd8edaf562770403f311517f050f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/JSONFileManagerTestAccessor.java": {
-    "mtime": 1782297664.5477853,
+    "mtime": 1782336091.282727,
     "ast_hash": "d9ef7d440aa067f73898384896afa5ee",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureManagerCoverageUnitTest.java": {
-    "mtime": 1782297664.5477853,
+    "mtime": 1782336091.2837267,
     "ast_hash": "86fb6e7d70e0b4c1d497e1b0792063bf",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/ProgressBarLoggerCoverageUnitTest.java": {
-    "mtime": 1782297664.5487852,
+    "mtime": 1782336091.2837267,
     "ast_hash": "2ce47f5f7489a79eba977c69579456c4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/ProgressBarLoggerTestAccessor.java": {
-    "mtime": 1782297664.5487852,
+    "mtime": 1782336091.2847266,
     "ast_hash": "7a536f9d92a15f04078b0d80f4809018",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/accessibility/AccessibilityHelperCoverageUnitTest.java": {
-    "mtime": 1782297664.549785,
+    "mtime": 1782336091.2857268,
     "ast_hash": "3d7d1b7d2ed082209053a1542a01d595",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsExecutorTestAccessor.java": {
-    "mtime": 1782297664.550785,
+    "mtime": 1782336091.2857268,
     "ast_hash": "da15362a3e7a802bad7f5d94ed318c76",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelperCoverageUnitTest.java": {
-    "mtime": 1782297664.550785,
+    "mtime": 1782336091.2867262,
     "ast_hash": "d22b363eae55211786a325255bfd197e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/internal/WebDriverElementValidationsBuilderCoverageUnitTest.java": {
-    "mtime": 1782297664.5517845,
+    "mtime": 1782336091.2867262,
     "ast_hash": "a770a8d13a85afe73c5056fa4299de21",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/cucumberTestRunner/CucumberTests.java": {
-    "mtime": 1782297664.5527844,
+    "mtime": 1782336091.2877266,
     "ast_hash": "74ef6fcb26ae1bf65684240930dd0f66",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/customCucumberSteps/steps.java": {
-    "mtime": 1782297664.5527844,
+    "mtime": 1782336091.2887266,
     "ast_hash": "996c5594b17086d3b5b937776f4309db",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/external/FileActionsReflectionInvoker.java": {
-    "mtime": 1782297664.5537848,
+    "mtime": 1782336091.2887266,
     "ast_hash": "8251926ce3c459f65681aaf4925cda59",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitParallelizationTests.java": {
-    "mtime": 1782297664.5557847,
+    "mtime": 1782336091.290727,
     "ast_hash": "c213b41fd84d475acbdef117917bb2b2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitTest.java": {
-    "mtime": 1782297664.5577838,
+    "mtime": 1782336091.2927272,
     "ast_hash": "80e036596d170587890d7947a2b6ee92",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/MoonTests.java": {
-    "mtime": 1782297664.5577838,
+    "mtime": 1782336091.2937262,
     "ast_hash": "3d4b38081680b77d4ae52f2a4b2219c6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/objectclass/BodyObject.java": {
-    "mtime": 1782297664.5587852,
+    "mtime": 1782336091.2937262,
     "ast_hash": "03f0c5fc69471404fe1e0e603466f818",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/CopilotGeneratedTests/ActionsCoverageTests.java": {
-    "mtime": 1782297664.5597856,
+    "mtime": 1782336091.294727,
     "ast_hash": "4d7fd64afc511b6c060fc9bdd1808db7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/CopilotGeneratedTests/RestActionsComprehensiveTests.java": {
-    "mtime": 1782297664.5597856,
+    "mtime": 1782336091.294727,
     "ast_hash": "28f298cd5240a0f802c52f4fc9a4dab3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/CopilotGeneratedTests/UnitTestsRestActions.java": {
-    "mtime": 1782297664.5607836,
+    "mtime": 1782336091.295727,
     "ast_hash": "f7a90e6eae203244b1f50f592b7fdd49",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/CopilotGeneratedTests/UnitTestsSHAFT.java": {
-    "mtime": 1782297664.5607836,
+    "mtime": 1782336091.295727,
     "ast_hash": "1a0f0ce42dfb5df20043a7c64ef5f0f2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/LambdaTestCredentials.java": {
-    "mtime": 1782297664.5617845,
+    "mtime": 1782336091.2967267,
     "ast_hash": "95942d341f6c15cb5ef9055b1808bcb1",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTDesktopWebMac.java": {
-    "mtime": 1782297664.5617845,
+    "mtime": 1782336091.2967267,
     "ast_hash": "2f3d1140f11fc9b71b0bedc8ecc3da3b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTDesktopWebWindows.java": {
-    "mtime": 1782297664.5628128,
+    "mtime": 1782336091.2967267,
     "ast_hash": "157fb2b3b04bdfea2fe6185cbebf841c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobAPKAPPURL.java": {
-    "mtime": 1782297664.5628128,
+    "mtime": 1782336091.2977266,
     "ast_hash": "f35e9468c40360b72f8b61adffa1450d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobAPKRelativePath.java": {
-    "mtime": 1782297664.5638132,
+    "mtime": 1782336091.2977266,
     "ast_hash": "5789694ff5cfd58a44c97cb7ad1271e0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobIPAAppURL.java": {
-    "mtime": 1782297664.5638132,
+    "mtime": 1782336091.2977266,
     "ast_hash": "8d8bd350aa5b1c3c3a3cf0cd781450c8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobIPARelativePath.java": {
-    "mtime": 1782297664.5638132,
+    "mtime": 1782336091.2987263,
     "ast_hash": "1647018c30c20b7960074c5ff3bb51b2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTWebAppIOS.java": {
-    "mtime": 1782297664.5648131,
+    "mtime": 1782336091.2987263,
     "ast_hash": "01affbeef9bd4974c99ca3991af231d3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTWebAppRealme.java": {
-    "mtime": 1782297664.5648131,
+    "mtime": 1782336091.2987263,
     "ast_hash": "316149ae0962ad94d9a60dbb6fe8cb9d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/APIWizardTests.java": {
-    "mtime": 1782297664.565812,
+    "mtime": 1782336091.2997265,
     "ast_hash": "a660856536f3395e80893fab6604f552",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/CLIWizardTests.java": {
-    "mtime": 1782297664.5664947,
+    "mtime": 1782336091.2997265,
     "ast_hash": "b9df0988ecaad726adc5fea8c897ab88",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/CustomDriverInitializationTests.java": {
-    "mtime": 1782297664.5664947,
+    "mtime": 1782336091.300727,
     "ast_hash": "9b4a204a9f376bf9172a75b7a83ff3ac",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/DBWizardTests.java": {
-    "mtime": 1782297664.5672686,
+    "mtime": 1782336091.300727,
     "ast_hash": "f578f87a677a9ace374460f653a7a416",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/FluentGuiActionsTest.java": {
-    "mtime": 1782297664.5672686,
+    "mtime": 1782336091.300727,
     "ast_hash": "ec867d13fcd03e7f0636806479b75168",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/GUIWizardTests.java": {
-    "mtime": 1782297664.5672686,
+    "mtime": 1782336091.301727,
     "ast_hash": "0b390e4118280e1abc7f529f48555de6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/TestHelpers.java": {
-    "mtime": 1782297664.5683856,
+    "mtime": 1782336091.301727,
     "ast_hash": "8be2574841bdfc32c03cba0a0e2a8dc2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/WizardStandaloneValidationTests.java": {
-    "mtime": 1782297664.5683856,
+    "mtime": 1782336091.301727,
     "ast_hash": "35f04e8619760f8ebd8814c4d4303ca9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/WizardTestDataTests.java": {
-    "mtime": 1782297664.5683856,
+    "mtime": 1782336091.3027265,
     "ast_hash": "33ac597fd308b12054d8f42f82799d5e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/TestPageServer.java": {
-    "mtime": 1782297664.5693848,
+    "mtime": 1782336091.3027265,
     "ast_hash": "2646363db37f021394df4d2e581aebc6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/TestScenario.java": {
-    "mtime": 1782297664.5693848,
+    "mtime": 1782336091.3027265,
     "ast_hash": "1eb22ef127c1db1ae030d5be3d4f1793",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/Tests.java": {
-    "mtime": 1782297664.5693848,
+    "mtime": 1782336091.3037267,
     "ast_hash": "57e8f66047ac7beae82ab5c23cc7bf87",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/AndroidBasicInteractionsTests.java": {
-    "mtime": 1782297664.5703855,
+    "mtime": 1782336091.3037267,
     "ast_hash": "dd601a01d9c455ec89b2c7160ba4eec8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/AndroidDragAndDropTest.java": {
-    "mtime": 1782297664.5713842,
+    "mtime": 1782336091.3047268,
     "ast_hash": "2ffc8e85a4d6c7b23b6912cb87beb2fd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/AndroidTouchActionsTests.java": {
-    "mtime": 1782297664.5713842,
+    "mtime": 1782336091.3047268,
     "ast_hash": "532f29bf0254c1ff8f525a507a1a430a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/FileUploadDownloadTest.java": {
-    "mtime": 1782297664.5713842,
+    "mtime": 1782336091.3047268,
     "ast_hash": "7d6ebdfaaf28e3d2b90d22b4ca16e9e9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/FlutterTest.java": {
-    "mtime": 1782297664.5723848,
+    "mtime": 1782336091.3057268,
     "ast_hash": "7366c8b69d03e80b2fb4bd19f1d32037",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/IOSBasicInteractionsTest.java": {
-    "mtime": 1782297664.5723848,
+    "mtime": 1782336091.3057268,
     "ast_hash": "c14cf8b63c53b19cf5ecb4c7020eaa24",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/MobileTest.java": {
-    "mtime": 1782297664.5733852,
+    "mtime": 1782336091.3057268,
     "ast_hash": "9d3c39b310b254b8e46b0787b9863b45",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/MobileWebTest.java": {
-    "mtime": 1782297664.5733852,
+    "mtime": 1782336091.3067265,
     "ast_hash": "1e71bec893b591efdc6ad81c0861de05",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/AssertApiResponseEqualsTests.java": {
-    "mtime": 1782297664.575624,
+    "mtime": 1782336091.3077266,
     "ast_hash": "6f6b3fc3c46d22b1be2e15c313ae0d4b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/AssertEqualsTests.java": {
-    "mtime": 1782297664.575624,
+    "mtime": 1782336091.308727,
     "ast_hash": "ac28053c858948f6c8072ae22ad3cb68",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/BasicAPITests.java": {
-    "mtime": 1782297664.575624,
+    "mtime": 1782336091.308727,
     "ast_hash": "04f6e36cc676509fd50bf69cf0f8214e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/BasicAuthenticationTests.java": {
-    "mtime": 1782297664.5767713,
+    "mtime": 1782336091.308727,
     "ast_hash": "9496029f86d3f528ab13caabb2d0fe8d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/BigPageActionsTest.java": {
-    "mtime": 1782297664.5767713,
+    "mtime": 1782336091.3097272,
     "ast_hash": "5c59782bc79d4c0e169a4a289b802bf4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/CSVFileManagerTest.java": {
-    "mtime": 1782297664.577771,
+    "mtime": 1782336091.3097272,
     "ast_hash": "5bb3c372688c46b067b1b9863e25072d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/ChainableElementActionsTests.java": {
-    "mtime": 1782297664.577771,
+    "mtime": 1782336091.3097272,
     "ast_hash": "06ae6b54a7d97bc516cc10cf6b99b1b5",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/ChecksumTests.java": {
-    "mtime": 1782297664.577771,
+    "mtime": 1782336091.3107266,
     "ast_hash": "5906715678d0f232e561110e1ff7a158",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/CookiesTests.java": {
-    "mtime": 1782297664.5787714,
+    "mtime": 1782336091.3107266,
     "ast_hash": "758c6a8df8d6416f380f1d39aac31c06",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/DragAndDropTests.java": {
-    "mtime": 1782297664.5787714,
+    "mtime": 1782336091.3107266,
     "ast_hash": "342e71b079c44b808491154c7bd27ba6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/DynamicLoadingTest.java": {
-    "mtime": 1782297664.5787714,
+    "mtime": 1782336091.311727,
     "ast_hash": "75821892b9db3a83dbec9eb1e6cd2c2a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/FileActionsTests.java": {
-    "mtime": 1782297664.5797713,
+    "mtime": 1782336091.311727,
     "ast_hash": "b562813a025a45e3fc69064917478f4d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/FrameTests.java": {
-    "mtime": 1782297664.5797713,
+    "mtime": 1782336091.311727,
     "ast_hash": "2377b86c25ba830a3a62c8eb3673f54b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/GetTableRowsDataTests.java": {
-    "mtime": 1782297664.5807698,
+    "mtime": 1782336091.3127265,
     "ast_hash": "e70588ff08a9232d318ac38de8c922b7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/GraphqlRequestTests.java": {
-    "mtime": 1782297664.5807698,
+    "mtime": 1782336091.3127265,
     "ast_hash": "9dd849ae0967c7a40ef9cf5ae77220b2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/GroupsTests.java": {
-    "mtime": 1782297664.5807698,
+    "mtime": 1782336091.3127265,
     "ast_hash": "5051d79e29fdd758369f62fbb35d8639",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/IsElementClickableTest.java": {
-    "mtime": 1782297664.5817702,
+    "mtime": 1782336091.313727,
     "ast_hash": "6ef73b0291f982d6a93dc783fe65a7f7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JSAlertBoxTests.java": {
-    "mtime": 1782297664.5817702,
+    "mtime": 1782336091.313727,
     "ast_hash": "87a6cc3676d62bfdcd5039c55974c99a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JSConfirmBoxTests.java": {
-    "mtime": 1782297664.5827713,
+    "mtime": 1782336091.313727,
     "ast_hash": "bb2be41715ecadad8c1c352ec2f3edea",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JSONFileManagerTests.java": {
-    "mtime": 1782297664.5832958,
+    "mtime": 1782336091.3147264,
     "ast_hash": "06f43c8542a39433d95f396bddc2511e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JSPromptBoxTests.java": {
-    "mtime": 1782297664.584226,
+    "mtime": 1782336091.3147264,
     "ast_hash": "20322607f3abd3ee7b114d7a076640df",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JsonActionsTests.java": {
-    "mtime": 1782297664.5845265,
+    "mtime": 1782336091.3147264,
     "ast_hash": "0eeae0f35f4b5d59ce66f3fdc5a43c92",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JsonCompareWithSpecialCharactersTests.java": {
-    "mtime": 1782297664.5845265,
+    "mtime": 1782336091.3157268,
     "ast_hash": "8ec3e11aa822c7834ff5c361a6044a57",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/LazyLoadingTests.java": {
-    "mtime": 1782297664.5845265,
+    "mtime": 1782336091.3157268,
     "ast_hash": "2da719cae7f75db7d3f4b5282365ce88",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/LocalShellTests.java": {
-    "mtime": 1782297664.5855322,
+    "mtime": 1782336091.3157268,
     "ast_hash": "6782d98e60aa0e1f0bcc9999f29d8a6a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/MatchJsonSchemaTests.java": {
-    "mtime": 1782297664.5855322,
+    "mtime": 1782336091.3167272,
     "ast_hash": "3876965c3c4b42b162b09caedef82ec7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/MobileEmulationTests.java": {
-    "mtime": 1782297664.586532,
+    "mtime": 1782336091.3167272,
     "ast_hash": "35929225261df191611b8eb348dcbeb2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/MultipleDriverSessionTerminationTest.java": {
-    "mtime": 1782297664.586532,
+    "mtime": 1782336091.3167272,
     "ast_hash": "ebf545317e8990b561fb94cb7f13ceb6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/NetworkInterceptionTest.java": {
-    "mtime": 1782298495.627249,
-    "ast_hash": "45bb382d0111916454669f7416fe6a2a",
+    "mtime": 1782336091.3177266,
+    "ast_hash": "f2098df0f4316d8fc9ff0149cd7f8227",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/NewValidationHelperTests.java": {
-    "mtime": 1782297664.5875325,
+    "mtime": 1782336091.318727,
     "ast_hash": "4bc79fab96f68b8b12d5116587f24479",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/PDFTests.java": {
-    "mtime": 1782297664.5875325,
+    "mtime": 1782336091.318727,
     "ast_hash": "9ce4274cf95b705c4c628161689a5716",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/PropertiesManagerTests.java": {
-    "mtime": 1782297664.5885322,
+    "mtime": 1782336091.318727,
     "ast_hash": "43587b77aed4d5722770a6b08ccf019f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/RelativeLocatorsTests.java": {
-    "mtime": 1782297664.5885322,
+    "mtime": 1782336091.3197267,
     "ast_hash": "1c8054013b7ecb201fc5fe98b22daf10",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/RemoteGridVideoAttachmentIT.java": {
-    "mtime": 1782297664.5895326,
+    "mtime": 1782336091.3197267,
     "ast_hash": "dd14e5e72b21522e5be56680c8b3d026",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/SkipDueToIssueTests.java": {
-    "mtime": 1782297664.5895326,
+    "mtime": 1782336091.3207262,
     "ast_hash": "99a55a2822f04fdbbcee5cceb276fca8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/SwitchToNewTabTest.java": {
-    "mtime": 1782297664.5895326,
+    "mtime": 1782336091.3207262,
     "ast_hash": "006d6c897a4c1d231284dee7fe67d681",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/TableTests.java": {
-    "mtime": 1782297664.5905323,
+    "mtime": 1782336091.3207262,
     "ast_hash": "6d478cc94e1a5ee7eab2ab389899f534",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/TestDataTests.java": {
-    "mtime": 1782297664.5905323,
+    "mtime": 1782336091.321726,
     "ast_hash": "95acd877eac50b8434b69adb83cbb977",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/UploadFileTests.java": {
-    "mtime": 1782297664.5915327,
+    "mtime": 1782336091.321726,
     "ast_hash": "5302d25af26787f48deb393f87c23b4f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/ValidationsBuilderTests.java": {
-    "mtime": 1782297664.5915327,
+    "mtime": 1782336091.321726,
     "ast_hash": "fcf11e47db991e3a42aef3210fa2e360",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/VerifyEqualsTests.java": {
-    "mtime": 1782297664.592661,
+    "mtime": 1782336091.3227265,
     "ast_hash": "41d8d2fd6427379eb8fc445849b8424f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/YAMLFileManagerTests.java": {
-    "mtime": 1782297664.593661,
+    "mtime": 1782336091.3233817,
     "ast_hash": "3230789cecccce6618d4d1803676627d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/locator/LocatorBuilderTest.java": {
-    "mtime": 1782297664.593661,
+    "mtime": 1782336091.3233817,
     "ast_hash": "0414482e4f34d9a26b3b4ced958e648f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/locator/ShadowDomTest.java": {
-    "mtime": 1782297664.5946612,
+    "mtime": 1782336091.3233817,
     "ast_hash": "6ed0c59ac8e49a4a7ef06df16c2963d7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/locator/SmartLocatorsPOC1Tests.java": {
-    "mtime": 1782297664.5946612,
+    "mtime": 1782336091.3247306,
     "ast_hash": "c3c8b2620562686f6b5e565535e18b95",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/locator/SmartLocatorsRealisticTests.java": {
-    "mtime": 1782298495.627249,
-    "ast_hash": "00c3c323353689b3c01fd52d66b748bf",
+    "mtime": 1782336091.3257363,
+    "ast_hash": "f43ba034e46306636cf2938d5c917eb9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/locator/SmartLocatorsTests.java": {
-    "mtime": 1782297664.5956607,
+    "mtime": 1782336091.3257363,
     "ast_hash": "20c2cf801bc6adaf91c3a10eedfd305c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/AccessibilityTest.java": {
-    "mtime": 1782297664.596661,
+    "mtime": 1782336091.3257363,
     "ast_hash": "99d0232aa92b8d70edc1df791001873c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/ApiActionsMockedTests.java": {
-    "mtime": 1782297664.596661,
+    "mtime": 1782336091.3267357,
     "ast_hash": "4f4c44851c27057934f2b7b59bc65ab5",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/CoverageTests.java": {
-    "mtime": 1782297664.5976608,
+    "mtime": 1782336091.3267357,
     "ast_hash": "83c27fc65ab0c865b1cdf29f5866e8f8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/CucumberMockedTests.java": {
-    "mtime": 1782297664.5976608,
+    "mtime": 1782336091.3277364,
     "ast_hash": "7f8a58e869251917ae68bba51332db11",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/DatabaseActionsMockedTests.java": {
-    "mtime": 1782297664.5986602,
+    "mtime": 1782336091.3277364,
     "ast_hash": "e2878a0cc73ffd2347f853ef2147cc72",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/DbTests.java": {
-    "mtime": 1782297664.5986602,
+    "mtime": 1782336091.3277364,
     "ast_hash": "269cfe45953923e0843780be937a461b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/E2ECoverageTests.java": {
-    "mtime": 1782297664.5986602,
+    "mtime": 1782336091.3287368,
     "ast_hash": "ca5993c2c426f5edafe4ce6625f48c17",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/ElementActionsMockedTests.java": {
-    "mtime": 1782297664.5996594,
+    "mtime": 1782336091.3287368,
     "ast_hash": "3ad7b5b6aef55cd46c2f7154f1ae6cda",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/GuiVerificationTests.java": {
-    "mtime": 1782297664.5996594,
+    "mtime": 1782336091.3297358,
     "ast_hash": "3d7a334d786337dbde7750cfe5f3fc4a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/HoverTests.java": {
-    "mtime": 1782297664.600665,
+    "mtime": 1782336091.3297358,
     "ast_hash": "17caa339bfe3e0b97b6a5ffc19bf8b19",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/IOActionsMockedTests.java": {
-    "mtime": 1782297664.600665,
+    "mtime": 1782336091.3297358,
     "ast_hash": "c56ab69e6038fda5a988bd60c9cfeb22",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/JDK21VirtualThreadsAndAsyncActionsTests.java": {
-    "mtime": 1782297664.6016607,
+    "mtime": 1782336091.330736,
     "ast_hash": "51f1a029b91897744035cd850b1161a7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/LocatorMockedTests.java": {
-    "mtime": 1782297664.6016607,
+    "mtime": 1782336091.330736,
     "ast_hash": "dad58a7c56a1467263bfae0f1da9480a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/MultipleBrowserInstancesTest.java": {
-    "mtime": 1782297664.6026604,
+    "mtime": 1782336091.330736,
     "ast_hash": "809818085b5e32dff077dfb0c656856b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/MultipleElementsFailureTest.java": {
-    "mtime": 1782297664.6026604,
+    "mtime": 1782336091.3317358,
     "ast_hash": "241d67949c16293b2350791d139a82fe",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/MultipleTypeCyclesTest.java": {
-    "mtime": 1782297664.6026604,
+    "mtime": 1782336091.3317358,
     "ast_hash": "b2f43aacacb87d9e96673fe6ec092b31",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/NoSuchElementFailureTest.java": {
-    "mtime": 1782297664.6036627,
+    "mtime": 1782336091.3317358,
     "ast_hash": "03a45eec716f23e232911a3211ee431c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/PageScreenshotTest.java": {
-    "mtime": 1782297664.6036627,
+    "mtime": 1782336091.3327365,
     "ast_hash": "d49c21a61e72ec5469d72f13735e0de6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/SecurityMockedTests.java": {
-    "mtime": 1782297664.6046598,
+    "mtime": 1782336091.3327365,
     "ast_hash": "2f5b6a0594b5c0984dbcda5ac7d487c6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/SelectMethodTests.java": {
-    "mtime": 1782297664.6046598,
+    "mtime": 1782336091.3327365,
     "ast_hash": "ac0d848f85a4727aee2f0bc8a56bb843",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/SelectedValueTests.java": {
-    "mtime": 1782297664.6046598,
+    "mtime": 1782336091.3337362,
     "ast_hash": "81b968ea8374b0200a005df4f678937a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/ThreadSafeGuiWizardTests.java": {
-    "mtime": 1782297664.6056602,
+    "mtime": 1782336091.3337362,
     "ast_hash": "93278d8c91e0003270e1f37b3f9dbbe0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/TouchActionsTests.java": {
-    "mtime": 1782297664.6056602,
+    "mtime": 1782336091.3337362,
     "ast_hash": "bfec9ae0a72008d85b23f59529b0e9ea",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/ValidationTests.java": {
-    "mtime": 1782297664.6066606,
+    "mtime": 1782336091.3347363,
     "ast_hash": "fd0f34e2c216022700d6967480b9a911",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/ValidationsMockedTests.java": {
-    "mtime": 1782297664.6066606,
+    "mtime": 1782336091.3347363,
     "ast_hash": "06dceebbaa6cc58e0183baae80e4fb56",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/WaitActionsTest.java": {
-    "mtime": 1782297664.6076632,
+    "mtime": 1782336091.3357358,
     "ast_hash": "a1b4352725f281f3d61dc14699074e4e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/BrowserStackSdkTests.java": {
-    "mtime": 1782297664.6122782,
+    "mtime": 1782336091.3387368,
     "ast_hash": "d9ebd5580bb807c7604e0c74e38f151c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/BrowserStackTests.java": {
-    "mtime": 1782297664.6122782,
+    "mtime": 1782336091.3397367,
     "ast_hash": "7c56e754cf9df72d867793b89e4ce87d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/CucumberTests.java": {
-    "mtime": 1782297664.6122782,
+    "mtime": 1782336091.3397367,
     "ast_hash": "cc49d5bf128f50b8c9b49ee1d3d06b3a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/FlagsTests.java": {
-    "mtime": 1782297664.6132782,
+    "mtime": 1782336091.3397367,
     "ast_hash": "fcc937601e081f5aaed227e0c9be4c09",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/HealeniumTests.java": {
-    "mtime": 1782297664.6132782,
+    "mtime": 1782336091.3407364,
     "ast_hash": "4cbd96dfaa7ecd87d56e8fed846b5e12",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/HealingTests.java": {
-    "mtime": 1782297664.6142786,
+    "mtime": 1782336091.3407364,
     "ast_hash": "36a68b5420d9ac0898076eeafbe3017a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/InternalTests.java": {
-    "mtime": 1782297664.6142786,
+    "mtime": 1782336091.3407364,
     "ast_hash": "c0f069cd9f0d1229bd799d2bbcdd84f1",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/JiraTests.java": {
-    "mtime": 1782297664.6142786,
+    "mtime": 1782336091.3417363,
     "ast_hash": "eeba6ddfce3de33fbe989cc575a9cd90",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/Log4jTests.java": {
-    "mtime": 1782297664.615279,
+    "mtime": 1782336091.3417363,
     "ast_hash": "ae4540190f998df8d9fb4b0d1a2612fe",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/MobileTests.java": {
-    "mtime": 1782297664.615279,
+    "mtime": 1782336091.3417363,
     "ast_hash": "6739645c3929d9dceb4adb19a57133b8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/NaturalActionsTests.java": {
-    "mtime": 1782297664.6162772,
+    "mtime": 1782336091.3427365,
     "ast_hash": "2f7204140a4fd39be6c6e336527e4180",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/PathsTests.java": {
-    "mtime": 1782297664.6168122,
+    "mtime": 1782336091.3427365,
     "ast_hash": "9b6e4b923c8fafeb5766479e8ce4e9f7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/PatternTests.java": {
-    "mtime": 1782297664.617496,
+    "mtime": 1782336091.3427365,
     "ast_hash": "27d780ad9cfb7a965f6b92d28d68de4c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/PerformanceTests.java": {
-    "mtime": 1782297664.617496,
+    "mtime": 1782336091.3437364,
     "ast_hash": "9309eda06566e65a9f362f67f226dc91",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/PlatformTests.java": {
-    "mtime": 1782297664.617496,
+    "mtime": 1782336091.3437364,
     "ast_hash": "3258b9a3348d0509056b88b650bf03b5",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/ReportingTests.java": {
-    "mtime": 1782297664.618629,
+    "mtime": 1782336091.3437364,
     "ast_hash": "77a2d7fa3551e92f26589ee0ca156311",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/TestNGTests.java": {
-    "mtime": 1782297664.618629,
+    "mtime": 1782336091.344741,
     "ast_hash": "99bf53de75d7fd1c0db036713c836a50",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/TimeoutsTests.java": {
-    "mtime": 1782297664.6196294,
+    "mtime": 1782336091.344741,
     "ast_hash": "1bad239440e6f2e516dc99d4a0772476",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/TinkeyTests.java": {
-    "mtime": 1782297664.6196294,
+    "mtime": 1782336091.344741,
     "ast_hash": "0970c28be5888cba1859beefc65378b3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/VisualsTests.java": {
-    "mtime": 1782297664.6206288,
+    "mtime": 1782336091.3457413,
     "ast_hash": "a0f83862f610862bb8efaf196f707d08",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/WebTests.java": {
-    "mtime": 1782297664.6206288,
+    "mtime": 1782336091.3457413,
     "ast_hash": "9dc7531cd01c41eb8cfab262c6e521fd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/resettingCapabilitiesIssue/ElementMatchesSafariCompatibleTests.java": {
-    "mtime": 1782297664.6216304,
+    "mtime": 1782336091.3467412,
     "ast_hash": "394bbc20f5e93c06cc34ec7c01ff3236",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/resettingCapabilitiesIssue/ShadowDOMTests.java": {
-    "mtime": 1782297664.6216304,
+    "mtime": 1782336091.3467412,
     "ast_hash": "43a6596b52c49876b40b6058899198c6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/resettingCapabilitiesIssue/UploadFileTests.java": {
-    "mtime": 1782297664.6226308,
+    "mtime": 1782336091.3467412,
     "ast_hash": "cae1bde8163d22ef380fd6284cd6b0e0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/APIPropertiesUnitTest.java": {
-    "mtime": 1782297664.6226308,
+    "mtime": 1782336091.3477411,
     "ast_hash": "2a0cd709eac461a2eca3c1c6202a6d5f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/APITests.java": {
-    "mtime": 1782297664.623629,
+    "mtime": 1782336091.3487408,
     "ast_hash": "2dc9f47b451a8e6b2044fbeabf5fd378",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AccessibilityActionsCoverageUnitTest.java": {
-    "mtime": 1782297664.623629,
+    "mtime": 1782336091.3487408,
     "ast_hash": "90607ccef1dfc5153c1637b8ae62b2bb",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AlertActionsCoverageUnitTest.java": {
-    "mtime": 1782297664.6249585,
+    "mtime": 1782336091.3487408,
     "ast_hash": "a5bb393a1cfc1a2e8aa75ae92aff7d81",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AllAttachmentTypesTest.java": {
-    "mtime": 1782297664.6255348,
+    "mtime": 1782336091.3497427,
     "ast_hash": "47114f2bc9566ca56c6f65aaf85bd36a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/Allure3ReportValidationTests.java": {
-    "mtime": 1782297664.6255348,
+    "mtime": 1782336091.3497427,
     "ast_hash": "da1af4c4422a31104c480df5d2b8651d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AllureManagerUnitTest.java": {
-    "mtime": 1782297664.6266255,
+    "mtime": 1782336091.350741,
     "ast_hash": "2d6824d67beb2fe53b62ab7e7ab872cb",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AndroidApkBadgingReaderUnitTest.java": {
-    "mtime": 1782297664.6266255,
+    "mtime": 1782336091.350741,
     "ast_hash": "5bc57b743241b49f0e5257363802a038",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java": {
-    "mtime": 1782297664.627625,
+    "mtime": 1782336091.3517413,
     "ast_hash": "49d211907c0ca598f8d3aea229d5c1f3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AssertionStepsCucumberTestsCoverageUnitTest.java": {
-    "mtime": 1782297664.627625,
+    "mtime": 1782336091.3517413,
     "ast_hash": "bd8b8e3e83c0652fbfd4c66dfa54f838",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AttachmentReporterUnitTest.java": {
-    "mtime": 1782297664.627625,
+    "mtime": 1782336091.352741,
     "ast_hash": "b7b45fa6a8315a75a05ad02459283c16",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsCoverageUnitTest.java": {
-    "mtime": 1782297664.628625,
-    "ast_hash": "e0b8515dd1e2532f644a399aabb4fe40",
+    "mtime": 1782337177.5693443,
+    "ast_hash": "ee6a94e08c109c142e3e4f4b2c0a423e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsHelperCoverageUnitTest.java": {
-    "mtime": 1782297664.628625,
+    "mtime": 1782336091.352741,
     "ast_hash": "fc971e4b30a7b04491a0d5ef70ff11bc",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsTests.java": {
-    "mtime": 1782297664.6296253,
+    "mtime": 1782336091.3537414,
     "ast_hash": "66b7b6266723ff45765b60ac7c3074e3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserStackHelperUnitTest.java": {
-    "mtime": 1782297664.6296253,
+    "mtime": 1782336091.354324,
     "ast_hash": "7ae11ad14db90e20fe82c9c907507c7b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserStackPropertiesUnitTest.java": {
-    "mtime": 1782297664.6306252,
+    "mtime": 1782336091.354324,
     "ast_hash": "dfcbf24cab8e1c327962222c3978b95d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserStackSdkHelperCoverageUnitTest.java": {
-    "mtime": 1782297664.6306252,
+    "mtime": 1782336091.3553293,
     "ast_hash": "a12447674e5f8ad7c872293f7e5d7906",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CSVFileManagerUnitTest.java": {
-    "mtime": 1782297664.6316254,
+    "mtime": 1782336091.3553293,
     "ast_hash": "e05e9aa7e90379ffff4172edb00a2d6e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CheckpointAndReportingTest.java": {
-    "mtime": 1782297664.6316254,
+    "mtime": 1782336091.3553293,
     "ast_hash": "35dd2ea229bf8692dfa60aa240d47c78",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ClipboardActionUnitTest.java": {
-    "mtime": 1782297664.6316254,
+    "mtime": 1782336091.3563287,
     "ast_hash": "049ed3057c478bf631b973241fdb7e42",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CucumberFeatureListenerUnitTest.java": {
-    "mtime": 1782297664.6326258,
+    "mtime": 1782336091.3563287,
     "ast_hash": "40b3bb11667dcc54e4c8eff1e5a9b52b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CucumberTestRunnerListenerUnitTest.java": {
-    "mtime": 1782297664.6331663,
+    "mtime": 1782336091.3563287,
     "ast_hash": "af73dc5a35bc20fb91b9540c939aa848",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CucumberTestsHelperCoverageUnitTest.java": {
-    "mtime": 1782297664.6339326,
+    "mtime": 1782336091.357329,
     "ast_hash": "f5787b288386b7c7d678c839cae81b73",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CustomSoftAssertTest.java": {
-    "mtime": 1782297664.6339326,
+    "mtime": 1782336091.357329,
     "ast_hash": "79519b2595cb2fef40442f1a10bfd750",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/DriverFactoryCoverageUnitTest.java": {
-    "mtime": 1782297664.635071,
+    "mtime": 1782336091.3583286,
     "ast_hash": "4947b5e7a73724c6e6fed6d2e64ba6a6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/DriverFactoryHelperAdditionalUnitTest.java": {
-    "mtime": 1782297664.635071,
+    "mtime": 1782336091.35933,
     "ast_hash": "ea73d0c88cfce2990fde0325c0c17816",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/DriverFactoryHelperUnitTest.java": {
-    "mtime": 1782297664.6360707,
+    "mtime": 1782336091.359835,
     "ast_hash": "df5ed77d6a7a0c26406fe212157eaff2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ElementActionsCoverageUnitTest.java": {
-    "mtime": 1782297664.6360707,
+    "mtime": 1782336091.359835,
     "ast_hash": "c25acf7125038b78ded022107f6cebb4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ExcelFileManagerCoverageUnitTest.java": {
-    "mtime": 1782297664.6360707,
+    "mtime": 1782336091.359835,
     "ast_hash": "749454f40c0f999c34073902eb552194",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/FailureReporterUnitTest.java": {
-    "mtime": 1782297664.6370707,
+    "mtime": 1782336091.3608406,
     "ast_hash": "75e0fd7c57c165bef078cdc8ce06fe65",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/FileActionsUnitTest.java": {
-    "mtime": 1782297664.6370707,
+    "mtime": 1782336091.3608406,
     "ast_hash": "1a119fe7b09aa44da193163a82d2e9e6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/FileHelperUnitTest.java": {
-    "mtime": 1782297664.6380706,
+    "mtime": 1782336091.3618402,
     "ast_hash": "ea6d731e57c3aac02a733f7d2a34d941",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/FileValidationsBuilderUnitTest.java": {
-    "mtime": 1782297664.6380706,
+    "mtime": 1782336091.3618402,
     "ast_hash": "9d9acc2120910e1276906a2bde8a1e5c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/FlagsSetPropertyCoverageUnitTest.java": {
-    "mtime": 1782297664.6390703,
+    "mtime": 1782336091.3618402,
     "ast_hash": "da97292715ec3224bdb79568449c0fc9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/HTMLHelperUnitTest.java": {
-    "mtime": 1782297664.6390703,
+    "mtime": 1782336091.362841,
     "ast_hash": "25126e1307dafd29f15749a1bdd60c78",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/IoExcelFileManagerTests.java": {
-    "mtime": 1782297664.6400707,
+    "mtime": 1782336091.362841,
     "ast_hash": "530438883080a086ea007d8375c7a0fa",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/JSONFileManagerUnitTest.java": {
-    "mtime": 1782297664.6400707,
+    "mtime": 1782336091.363841,
     "ast_hash": "df106c976e18caf15348e77c4f5aeb33",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/JavaHelperUnitTest.java": {
-    "mtime": 1782297664.6410704,
+    "mtime": 1782336091.363841,
     "ast_hash": "fdeef69d7094cb58b69c4765005ba6f4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/JunitListenerApiCoverageUnitTest.java": {
-    "mtime": 1782297664.6415246,
+    "mtime": 1782336091.3648398,
     "ast_hash": "eb8ea18add13bf5b439a526123934cfc",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LambdaTestHelperUnitTest.java": {
-    "mtime": 1782297664.642339,
+    "mtime": 1782336091.3648398,
     "ast_hash": "3f11e51672c24653a84fe4fa69f7e797",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LambdaTestSetPropertyCoverageUnitTest.java": {
-    "mtime": 1782297664.642339,
+    "mtime": 1782336091.3648398,
     "ast_hash": "47e318c7169fd292cc422fdfbb950ff7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LocalApiServer.java": {
-    "mtime": 1782297664.6434195,
+    "mtime": 1782336091.3658402,
     "ast_hash": "1994c60fb9cbca49689490cc09afaac7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LocatorBuilderExtendedUnitTest.java": {
-    "mtime": 1782297664.6434195,
+    "mtime": 1782336091.3658402,
     "ast_hash": "3ffca37941148c7f54ec285739904a5c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LocatorBuilderUnitTest.java": {
-    "mtime": 1782297664.6434195,
+    "mtime": 1782336091.3668404,
     "ast_hash": "70bc98553a43a07567efa654eec320d7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LogRedirectorUnitTest.java": {
-    "mtime": 1782297664.6444192,
+    "mtime": 1782336091.3668404,
     "ast_hash": "25be02ab0943217c6d54155e0c912775",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/MemoryLeakFixTests.java": {
-    "mtime": 1782297664.6444192,
+    "mtime": 1782336091.3668404,
     "ast_hash": "9371b0c88769d68a72bf5c38b4039579",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/NativeValidationsBuilderUnitTest.java": {
-    "mtime": 1782297664.6454191,
+    "mtime": 1782336091.3678412,
     "ast_hash": "5eedc36971944b95c5b59dde171347a8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/NavigationActionUnitTest.java": {
-    "mtime": 1782297664.6454191,
+    "mtime": 1782336091.3678412,
     "ast_hash": "29ce81485193c40a2ddd60f48f50a622",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/NumberValidationsBuilderUnitTest.java": {
-    "mtime": 1782297664.6464188,
+    "mtime": 1782336091.3688414,
     "ast_hash": "c1e5acce43534ba13e1186db85b2c084",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PdfFileManagerUnitTest.java": {
-    "mtime": 1782297664.6464188,
+    "mtime": 1782336091.3688414,
     "ast_hash": "03fffd928746a3fec64c66b559d65b72",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ProjectStructureManagerTest.java": {
-    "mtime": 1782297664.6474228,
+    "mtime": 1782336091.3688414,
     "ast_hash": "6d2a66b21a274d7829cb5d2f93f416d9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertiesHelperCoverageUnitTest.java": {
-    "mtime": 1782297664.6474228,
+    "mtime": 1782336091.369841,
     "ast_hash": "81ae315c34773c68a536c305b8d42394",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertiesHelperInitializationUnitTest.java": {
-    "mtime": 1782297664.6474228,
+    "mtime": 1782336091.369841,
     "ast_hash": "ea9d6467f8ef25e941d62698c46bfdd8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertiesHelperMaximumPerformanceModeUnitTest.java": {
-    "mtime": 1782297664.6484237,
+    "mtime": 1782336091.371167,
     "ast_hash": "5661da2130612dd49dc0c83732f5b25e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertiesUnitTest.java": {
-    "mtime": 1782297664.6484237,
+    "mtime": 1782336091.371167,
     "ast_hash": "de5933ec9be13bdfe26c24f28e8a6bd2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertyFileManagerUnitTest.java": {
-    "mtime": 1782297664.6494262,
+    "mtime": 1782336091.371167,
     "ast_hash": "1f6b9ea7df5756b354ea8081215c0f65",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RecordManagerTest.java": {
-    "mtime": 1782298495.6252491,
-    "ast_hash": "71e02bcac3b12f41d762272b8357dfb0",
+    "mtime": 1782336091.3724303,
+    "ast_hash": "70cd848c481fbb5c2d081ede904fc7e4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ReportManagerHelperAttachmentIoUnitTest.java": {
-    "mtime": 1782297664.6506183,
+    "mtime": 1782336091.3724303,
     "ast_hash": "3559c3b9d7b73f3fc87daa4b19e7d031",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ReportManagerHelperUnitTests.java": {
-    "mtime": 1782297664.6506183,
+    "mtime": 1782336091.3734355,
     "ast_hash": "398246ec1c6f2392c6f5d655c7e887e9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RestActionsFailureLoggingUnitTest.java": {
-    "mtime": 1782297664.6517363,
+    "mtime": 1782336091.3734355,
     "ast_hash": "94747c6ac6534584011a570704cb7b89",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RestActionsTests.java": {
-    "mtime": 1782297664.6517363,
+    "mtime": 1782336091.3744354,
     "ast_hash": "4a57b2261d8a6f4306b6a189df5c6b93",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RestActionsUtilsUnitTest.java": {
-    "mtime": 1782297664.6517363,
+    "mtime": 1782336091.3744354,
     "ast_hash": "de45f58c799fde431cef74d0e8653c15",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RestValidationsBuilderUnitTest.java": {
-    "mtime": 1782297664.652736,
+    "mtime": 1782336091.3744354,
     "ast_hash": "1c0603f27b12bb4895a9aea5b5e1efa8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ShaftRestAssuredFilterUnitTest.java": {
-    "mtime": 1782297664.652736,
-    "ast_hash": "c887597b4f7f620238b76b8614750c27",
+    "mtime": 1782337680.6776543,
+    "ast_hash": "c85ab9b7aa3bdc89842b14eb0617e5db",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/SkippedTestReportingTest.java": {
-    "mtime": 1782297664.6537356,
+    "mtime": 1782336091.375435,
     "ast_hash": "ce8578c3bec220a0e71049bee7331d9a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/SmartLocatorsCoverageUnitTest.java": {
-    "mtime": 1782297664.6537356,
+    "mtime": 1782336091.3764355,
     "ast_hash": "beb21c33b9ba95b2fb2d42033aef2235",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/StringHelperUnitTest.java": {
-    "mtime": 1782297664.6547358,
+    "mtime": 1782336091.3764355,
     "ast_hash": "666317424773b8170baaa4f3e65e5630",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TelemetryDeduplicationUnitTest.java": {
-    "mtime": 1782297664.6547358,
+    "mtime": 1782336091.3764355,
     "ast_hash": "f63a7c2ce548fa3456264cc95af3a62f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java": {
-    "mtime": 1782297664.6557357,
+    "mtime": 1782336091.3774354,
     "ast_hash": "0ce15abe7ff432e30ff79ff6e2e6dfff",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TestClass.java": {
-    "mtime": 1782297664.6557357,
+    "mtime": 1782336091.3774354,
     "ast_hash": "75d5dabdf74b6a0a0ac46395a44852f1",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TestDataUnitTest.java": {
-    "mtime": 1782297664.6557357,
+    "mtime": 1782336091.3784351,
     "ast_hash": "db41e63ea98f715a677d882ac1d4174c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TestNGListenerCoverageUnitTest.java": {
-    "mtime": 1782298495.6252491,
-    "ast_hash": "9bd85ca6eef825793e3f1349930c73d5",
+    "mtime": 1782336091.379435,
+    "ast_hash": "867f529e47e1c6d624f7250dad54433e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TestNGListenerHelperCoverageUnitTest.java": {
-    "mtime": 1782297664.6567354,
+    "mtime": 1782336091.379435,
     "ast_hash": "b3a8afe01d2424e4a0c578302f1c7381",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TextDirectionValidationsBuilderUnitTest.java": {
-    "mtime": 1782297664.6577356,
+    "mtime": 1782336091.379435,
     "ast_hash": "60a881ad378ec7cfdfcfa5c81462d2c8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ThreadLocalPropertiesTest.java": {
-    "mtime": 1782297664.658168,
+    "mtime": 1782336091.3804355,
     "ast_hash": "3b8c3ba881bf96883437c5ff46e2a879",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TopUncoveredClassesCoverageUnitTest.java": {
-    "mtime": 1782297664.658168,
+    "mtime": 1782336091.3804355,
     "ast_hash": "00f21d46e9c9345cfb0602c30e74896a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ValidationAndProgressBarTests.java": {
-    "mtime": 1782297664.6593103,
+    "mtime": 1782336091.3804355,
     "ast_hash": "2cd823215ca19d7111f2d7092e71bda1",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ValidationEnumsUnitTest.java": {
-    "mtime": 1782297664.6593103,
+    "mtime": 1782336091.3814356,
     "ast_hash": "caccd040fd417216fa761e864fcf4179",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ValidationHelperUnitTest.java": {
-    "mtime": 1782297664.6603093,
+    "mtime": 1782336091.3814356,
     "ast_hash": "5877871d3318bd2685cb6c67d7fa0836",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ValidationsBuilderUnitTest.java": {
-    "mtime": 1782297664.6603093,
+    "mtime": 1782336091.3824356,
     "ast_hash": "cfe79a40a49a8ecba70f2bca1418d697",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ValidationsExecutorCoverageUnitTest.java": {
-    "mtime": 1782297664.6603093,
+    "mtime": 1782336091.3824356,
     "ast_hash": "b4e87dd6decede2ec6a874bf552646b0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/WebDriverListenerCoverageUnitTest.java": {
-    "mtime": 1782297664.6603093,
+    "mtime": 1782336091.3824356,
     "ast_hash": "f768f1fbc6ea4a4afdf1d7f10f537c9e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/XrayIntegrationHelperCoverageUnitTest.java": {
-    "mtime": 1782297664.6618145,
+    "mtime": 1782336091.3834355,
     "ast_hash": "1a3f82e3bba50c09c7b5f46d0e17c64b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/YAMLFileManagerUnitTest.java": {
-    "mtime": 1782297664.6618145,
+    "mtime": 1782336091.3834355,
     "ast_hash": "657dabafe357030b543ad8b2cc7d37b4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/validationsWizard/BrowserValidationsTests.java": {
-    "mtime": 1782297664.6628194,
+    "mtime": 1782336091.3844366,
     "ast_hash": "fae6d2b4edd4c21b783a63e0acfd94bc",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/validationsWizard/ElementValidationsTests.java": {
-    "mtime": 1782297664.6628194,
+    "mtime": 1782336091.3844366,
     "ast_hash": "74ef4dc7c24e14da3c0a2e956ecaf8d4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/validationsWizard/NegativeValidationsTests.java": {
-    "mtime": 1782297664.6638198,
+    "mtime": 1782336091.3854358,
     "ast_hash": "80deb29d4d240573803b2e4e4e6e1edb",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/validationsWizard/VisualValidationTests.java": {
-    "mtime": 1782298495.6282475,
-    "ast_hash": "4f467c4d866aef50677759980bb05072",
+    "mtime": 1782336091.3865564,
+    "ast_hash": "7065560f7c00f644e716055dfa8c8060",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/JsonFileTest.json": {
-    "mtime": 1782297664.6681209,
+    "mtime": 1782336091.3935618,
     "ast_hash": "34d4c2e8470475605eeb576357fa1a24",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/JsonFileTest2.json": {
-    "mtime": 1782297664.6681209,
+    "mtime": 1782336091.3935618,
     "ast_hash": "0d4aba4457124b501a49b132fc29e7c8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/api/local-api/post-1.json": {
-    "mtime": 1782297664.67012,
+    "mtime": 1782336091.3955605,
     "ast_hash": "e7f6064672a51be242e522606fe7a874",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/api/local-api/posts.json": {
-    "mtime": 1782297664.67012,
+    "mtime": 1782336091.396562,
     "ast_hash": "9b635707c3b1a2033d585b69a6bab819",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/api/local-api/todos.json": {
-    "mtime": 1782297664.6711206,
+    "mtime": 1782336091.396562,
     "ast_hash": "095e11feade03bc6b7e53dee2486f681",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/api/local-api/users.json": {
-    "mtime": 1782297664.6711206,
+    "mtime": 1782336091.3975613,
     "ast_hash": "8b738dc1a52055df6ff5444eb37a1b8f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/api/local-api/zip-90210.json": {
-    "mtime": 1782297664.6721203,
+    "mtime": 1782336091.3975613,
     "ast_hash": "6ca2311ae54ce67c7fbd17f118b58cad",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/jsonFileManagerTestData.json": {
-    "mtime": 1782297665.1689055,
+    "mtime": 1782336091.9038622,
     "ast_hash": "94537dc7a44a551939fe07da874a6ce9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/jsonToJavaObjectTest.json": {
-    "mtime": 1782297665.1699052,
+    "mtime": 1782336091.9048538,
     "ast_hash": "fe787bfecd55bde95846520922954e20",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/post1Response.json": {
-    "mtime": 1782297665.1709058,
+    "mtime": 1782336091.9058456,
     "ast_hash": "e7f6064672a51be242e522606fe7a874",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/post1ResponseSchema.json": {
-    "mtime": 1782297665.1709058,
+    "mtime": 1782336091.9058456,
     "ast_hash": "16bf47afb2fa16d9a72bee4aa5090fef",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/restActionsCoverage/containsObject.json": {
-    "mtime": 1782297665.171906,
+    "mtime": 1782336091.9068456,
     "ast_hash": "caf79d4a9031acee3921b15dcfacd235",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/restActionsCoverage/expectedObject.json": {
-    "mtime": 1782297665.171906,
+    "mtime": 1782336091.9068456,
     "ast_hash": "fbf3b3e03cf5d05123488de14e150acd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/restActionsCoverage/mismatchObject.json": {
-    "mtime": 1782297665.1729064,
+    "mtime": 1782336091.907848,
     "ast_hash": "5a250de786cc5579da66cbcdee8f2818",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/restActionsCoverage/orderedArray.json": {
-    "mtime": 1782297665.1729064,
+    "mtime": 1782336091.907848,
     "ast_hash": "0e406c996279efff769b1105dd51448e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/schema.json": {
-    "mtime": 1782297665.1739056,
+    "mtime": 1782336091.9088464,
     "ast_hash": "99a7063f24f77c3fb2c7aea31eec411c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782297665.1754985,
+    "mtime": 1782336091.9108458,
     "ast_hash": "d896f3512bf493280abf8061c7df1d75",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/specialCharacters.json": {
-    "mtime": 1782297665.176622,
+    "mtime": 1782336091.9108458,
     "ast_hash": "334064f08b91de55ef30335710dbd8f8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/test_assertResponseEqualsIgnoringOrder.json": {
-    "mtime": 1782297665.1806216,
+    "mtime": 1782336091.9148462,
     "ast_hash": "a679a33772d98b89e77510ad9938a84d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/test_post_withBody_fromFile.json": {
-    "mtime": 1782297665.1816213,
+    "mtime": 1782336091.9158459,
     "ast_hash": "af539d78603bb042feb8be65c20748e8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/unitTestData.json": {
-    "mtime": 1782297665.1816213,
+    "mtime": 1782336091.9158459,
     "ast_hash": "0e90c1c1a227d7d7c2d2dce740714d82",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/HealingConfiguration.java": {
-    "mtime": 1782297665.18632,
+    "mtime": 1782336091.9198475,
     "ast_hash": "b5f311bae11ad11dd0deed6b9921fade",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/ShaftHeal.java": {
-    "mtime": 1782297665.18632,
+    "mtime": 1782336091.9198475,
     "ast_hash": "638f827ad267fed1841301e034516d29",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/AiCandidateReranker.java": {
-    "mtime": 1782297665.1873155,
+    "mtime": 1782336091.9208455,
     "ast_hash": "37bae89f609e94e33b6291765bec4746",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/CandidateExtractor.java": {
-    "mtime": 1782297665.1883154,
+    "mtime": 1782336091.9208455,
     "ast_hash": "1b8b44bdcf6e32e31917a1e7e43e9735",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/DeterministicScorer.java": {
-    "mtime": 1782297665.1883154,
+    "mtime": 1782336091.921846,
     "ast_hash": "4bf42ea11e26e7869a261270733d628d",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/FingerprintExtractor.java": {
-    "mtime": 1782297665.1883154,
+    "mtime": 1782336091.921846,
     "ast_hash": "7f104b32afa9d009c7714e55f453c167",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HealingDecisionEngine.java": {
-    "mtime": 1782297665.189315,
+    "mtime": 1782336091.921846,
     "ast_hash": "4209aed55089ab983f839222d8cf64db",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HealingHistoryStore.java": {
-    "mtime": 1782297665.189315,
+    "mtime": 1782336091.9228463,
     "ast_hash": "75b6488324dfad90e662f9f08c9d7fb4",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HealingReportWriter.java": {
-    "mtime": 1782297665.1903167,
+    "mtime": 1782336091.9228463,
     "ast_hash": "a6807824d69a21cbfde367786dda6459",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HealingSupport.java": {
-    "mtime": 1782297665.1903167,
+    "mtime": 1782336091.9228463,
     "ast_hash": "6a5e58df19b9bf605b8d0e529e3b5a9f",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HistoryDocument.java": {
-    "mtime": 1782297665.1903167,
+    "mtime": 1782336091.9238462,
     "ast_hash": "e02bfa5e0416eaa97327d7cc30edaaaa",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HistoryRecord.java": {
-    "mtime": 1782297665.1913152,
+    "mtime": 1782336091.9238462,
     "ast_hash": "affb5533f80ddcf6955cb487de88c5bc",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/PrivacySanitizer.java": {
-    "mtime": 1782297665.1913152,
+    "mtime": 1782336091.9238462,
     "ast_hash": "c615c6f4a1781c7a5a2056074b581bb2",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/RankedCandidate.java": {
-    "mtime": 1782297665.1923158,
+    "mtime": 1782336091.9248462,
     "ast_hash": "323b41fab8a95e2adce58147b8a7d197",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/ShaftHealingProvider.java": {
-    "mtime": 1782297665.1923158,
+    "mtime": 1782336091.9248462,
     "ast_hash": "bd1cbb989de7e55d8ee1b04746442788",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/VisualEvidenceService.java": {
-    "mtime": 1782297665.1923158,
+    "mtime": 1782336091.9248462,
     "ast_hash": "743e64057ed3e7ab3111d0ecb9e093c8",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingCandidate.java": {
-    "mtime": 1782297665.1933165,
+    "mtime": 1782336091.925846,
     "ast_hash": "1617a29056414a87a0f01eea9f3f1e5d",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingContext.java": {
-    "mtime": 1782297665.1933165,
+    "mtime": 1782336091.925846,
     "ast_hash": "3c02c33790e64b5a77b7c6218a0162cf",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingDecision.java": {
-    "mtime": 1782297665.1943161,
+    "mtime": 1782336091.9268448,
     "ast_hash": "e3cff7de69ac3081e54b05070a9ad923",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingPlatform.java": {
-    "mtime": 1782297665.1943161,
+    "mtime": 1782336091.9268448,
     "ast_hash": "d4cc50f5563d27a3d8cadabad3f8c086",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingReport.java": {
-    "mtime": 1782297665.1953166,
+    "mtime": 1782336091.9268448,
     "ast_hash": "3d0627a4f1785e21e5403b3685773ca5",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingScore.java": {
-    "mtime": 1782297665.1953166,
+    "mtime": 1782336091.9278455,
     "ast_hash": "99e432927182919d5815b3d8d101b6de",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/LocatorFingerprint.java": {
-    "mtime": 1782297665.1953166,
+    "mtime": 1782336091.9278455,
     "ast_hash": "b7f303ee7028dce02f372fe1887fdf27",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/resources/schema/shaft-heal-history-1.0.schema.json": {
-    "mtime": 1782297665.197316,
+    "mtime": 1782336091.9288456,
     "ast_hash": "6bd4d6c6c18d1bc0c600792f43232342",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/resources/schema/shaft-heal-history-2.0.schema.json": {
-    "mtime": 1782297665.197316,
+    "mtime": 1782336091.929846,
     "ast_hash": "6d71c99cadca42d412c11b50c7131430",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/resources/schema/shaft-heal-report-1.0.schema.json": {
-    "mtime": 1782297665.198316,
+    "mtime": 1782336091.929846,
     "ast_hash": "f8f5c202b1e0baca184836e2dd42118b",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/resources/schema/shaft-heal-report-2.0.schema.json": {
-    "mtime": 1782297665.198316,
+    "mtime": 1782336091.929846,
     "ast_hash": "88e2d8a2767744c1b32faa700466d741",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/AiCandidateRerankerTest.java": {
-    "mtime": 1782297665.200317,
+    "mtime": 1782336091.9318454,
     "ast_hash": "034bb4a07e1e4c4d8c1ed5d8a31547a2",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/DeterministicScorerTest.java": {
-    "mtime": 1782297665.200317,
+    "mtime": 1782336091.9318454,
     "ast_hash": "5d36a445e2cae9634e483d80dda345a7",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/HealingHistoryStoreTest.java": {
-    "mtime": 1782297665.2013173,
+    "mtime": 1782336091.9328454,
     "ast_hash": "055d679be0c31247da14c2d2e8305954",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/ShaftHealingProviderTest.java": {
-    "mtime": 1782297665.2013173,
+    "mtime": 1782336091.9328454,
     "ast_hash": "62b7fa589374d302bc095a85630668cb",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/WebDomHealingAcceptanceTest.java": {
-    "mtime": 1782297665.2023149,
+    "mtime": 1782336091.9328454,
     "ast_hash": "54705c408e9415e6e59248f9dc88e76a",
     "semantic_hash": ""
   },
   "shaft-mcp/mvnw": {
-    "mtime": 1782297665.2073154,
+    "mtime": 1782336091.9378457,
     "ast_hash": "2fe09837c0b4dfabab4c4b206bcd0850",
     "semantic_hash": ""
   },
   "shaft-mcp/server.json": {
-    "mtime": 1782297665.2093165,
+    "mtime": 1782336091.9388459,
     "ast_hash": "10eafe30f8d30db0f7f5e85b2793e18a",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/BrowserService.java": {
-    "mtime": 1782297665.2103164,
+    "mtime": 1782336091.9408462,
     "ast_hash": "825d8b126501b736bb968ed530b127ab",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/BrowserType.java": {
-    "mtime": 1782297665.2113156,
+    "mtime": 1782336091.9408462,
     "ast_hash": "d92c802c46cf7055edd908c22dd983c6",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java": {
-    "mtime": 1782297665.2123158,
+    "mtime": 1782336091.9418454,
     "ast_hash": "d64d47ce7e08b3e0e1f0675a072da341",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/DoctorService.java": {
-    "mtime": 1782297665.2123158,
+    "mtime": 1782336091.9418454,
     "ast_hash": "fdac0a63aa8e73797a7d58596eb727c1",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/ElementService.java": {
-    "mtime": 1782298495.6222456,
-    "ast_hash": "6021cea09821f16dbb63aedc71d0602b",
+    "mtime": 1782336091.9433022,
+    "ast_hash": "15840a8b150fb2a4988a9041336bf528",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/EngineService.java": {
-    "mtime": 1782297665.2133157,
+    "mtime": 1782336091.9433022,
     "ast_hash": "f75ea21cc4747ba8b46f0983950fc5e6",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpActionRecord.java": {
-    "mtime": 1782297665.2143164,
+    "mtime": 1782336091.9443076,
     "ast_hash": "88f2540004bf2e85e19d1883fa8fd268",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpAnalysisReport.java": {
-    "mtime": 1782297665.2153158,
+    "mtime": 1782336091.9453125,
     "ast_hash": "655dc48d9861063302c3874e08fad7bb",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCaptureCodeBlockService.java": {
-    "mtime": 1782297665.2172577,
+    "mtime": 1782336091.947312,
     "ast_hash": "ba9b31e164fa47d38f4a5bf16f824aee",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCaptureReplayResult.java": {
-    "mtime": 1782297665.2172577,
+    "mtime": 1782336091.947312,
     "ast_hash": "c1566317b1a57ccbf142a1a4e6dc3f69",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCodeBlock.java": {
-    "mtime": 1782297665.2183993,
+    "mtime": 1782336091.947312,
     "ast_hash": "76ebce9f3db111251b04cf7f5d6a7548",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpDoctorRemediationService.java": {
-    "mtime": 1782297665.2193987,
+    "mtime": 1782336091.9493124,
     "ast_hash": "9acf1196703c766700346892ebc0037e",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileAccessibilityTree.java": {
-    "mtime": 1782297665.2213988,
+    "mtime": 1782336091.951312,
     "ast_hash": "f3b7b5c23ef3cb6ff05525b718994ff3",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileActionResult.java": {
-    "mtime": 1782297665.222398,
+    "mtime": 1782336091.951312,
     "ast_hash": "29d070e4029d6709b7924ba36735510a",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileContextSnapshot.java": {
-    "mtime": 1782297665.2233987,
+    "mtime": 1782336091.9526577,
     "ast_hash": "2f654d69dc90ef0def1b8902d14e3bba",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecordedAction.java": {
-    "mtime": 1782297665.225763,
+    "mtime": 1782336091.9546628,
     "ast_hash": "ecfc0758677616c607ba07313a52b729",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecording.java": {
-    "mtime": 1782297665.225763,
+    "mtime": 1782336091.9546628,
     "ast_hash": "695772cf2e07fcb64d1f38ce531219ba",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecordingService.java": {
-    "mtime": 1782297665.22687,
+    "mtime": 1782336091.9546628,
     "ast_hash": "0399934cf57d42b9db9e71f92d59d731",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecordingStatus.java": {
-    "mtime": 1782297665.22687,
+    "mtime": 1782336091.9556632,
     "ast_hash": "aa275295374a1818f6c109d6ea81b57d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileReplayResult.java": {
-    "mtime": 1782297665.22687,
+    "mtime": 1782336091.9556632,
     "ast_hash": "7865349c5c645027ec9b2ad4140187c1",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileSessionResult.java": {
-    "mtime": 1782297665.2278705,
+    "mtime": 1782336091.9556632,
     "ast_hash": "a7ffeb82413410670bdf8fe1f9c90b53",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpNaturalActionResult.java": {
-    "mtime": 1782297665.2298694,
+    "mtime": 1782336091.9572487,
     "ast_hash": "8d9587e9bd285ff5d3066b2afea60733",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpPageDomSnapshot.java": {
-    "mtime": 1782297665.2298694,
+    "mtime": 1782336091.9583158,
     "ast_hash": "da511c88341bda167180baeac16db366",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpProviderFallback.java": {
-    "mtime": 1782297665.23187,
+    "mtime": 1782336091.9593203,
     "ast_hash": "f19ecd97597af4b6374659222d736a68",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpRuntimePaths.java": {
-    "mtime": 1782297665.23187,
+    "mtime": 1782336091.9593203,
     "ast_hash": "7508e81382cca0830263f0477c96731e",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpScreenshotResult.java": {
-    "mtime": 1782297665.2331953,
+    "mtime": 1782336091.9603252,
     "ast_hash": "1ed7179791590810783cc71682129cde",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpWorkspacePolicy.java": {
-    "mtime": 1782297665.2331953,
+    "mtime": 1782336091.9613369,
     "ast_hash": "2ea9e2dad8bdfc40515c48cc4f7e644d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/MobileService.java": {
-    "mtime": 1782297665.2342849,
+    "mtime": 1782336091.9613369,
     "ast_hash": "4c6282d267d11426b0d37f40d3fc2e72",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/NaturalActionService.java": {
-    "mtime": 1782297665.2352836,
+    "mtime": 1782336091.962326,
     "ast_hash": "f727c820fb4def0a03ba5eeb1894ca0b",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/ShaftMcpApplication.java": {
-    "mtime": 1782297665.236284,
+    "mtime": 1782336091.963325,
     "ast_hash": "5b9df6ac6c32c2a0ef93658ad16d4b81",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/locatorStrategy.java": {
-    "mtime": 1782297665.236284,
+    "mtime": 1782336091.964326,
     "ast_hash": "93d35de3c8d385e5eb24574d006934dd",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java": {
-    "mtime": 1782297665.2402844,
+    "mtime": 1782336091.9673257,
     "ast_hash": "b08594c320497b0daf857f366f591ed2",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/DoctorServiceTest.java": {
-    "mtime": 1782297665.2402844,
+    "mtime": 1782336091.9673257,
     "ast_hash": "2b447d8c91aeee9224855926acd98644",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/EngineServiceRuntimePathTest.java": {
-    "mtime": 1782297665.2412844,
+    "mtime": 1782336091.9673257,
     "ast_hash": "45a98645e7e2f4203be7278baadb2f66",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/EngineServiceTest.java": {
-    "mtime": 1782297665.2412844,
+    "mtime": 1782336091.968325,
     "ast_hash": "90a0eb091a6ac3d9480fc327f6712241",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpRuntimePathsTest.java": {
-    "mtime": 1782297665.2452836,
+    "mtime": 1782336091.9723253,
     "ast_hash": "3df7775db4987c2453ab16758e62a7ce",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/MobileRecordingServiceTest.java": {
-    "mtime": 1782297665.246284,
+    "mtime": 1782336091.9733255,
     "ast_hash": "4ca682157c293f5e2a2d5ba5d62382ec",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java": {
-    "mtime": 1782298495.6232493,
-    "ast_hash": "e3de4112c4a0dff82d7b7e96ae8a8e2b",
+    "mtime": 1782336091.97438,
+    "ast_hash": "4d07ac006a317a1e69127f88cf627573",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/mcp-tool-manifest.json": {
-    "mtime": 1782298495.6242447,
-    "ast_hash": "a5982a99ea1722a856956f2f7c60e119",
+    "mtime": 1782336091.9783902,
+    "ast_hash": "0e6f2f2161875e369a0ee1567f60eb7b",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/shaft-pilot/doctor/repair-input.json": {
-    "mtime": 1782297665.252788,
+    "mtime": 1782336091.9793851,
     "ast_hash": "457a81a9ab8bbcd47b4c46fefb9c6ad6",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/claude-desktop.json": {
-    "mtime": 1782297665.25379,
+    "mtime": 1782336091.980386,
     "ast_hash": "544157f8499e7c19c3b6495d7a2de685",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/doctor-analyze-invocations.json": {
-    "mtime": 1782297665.2547886,
+    "mtime": 1782336091.9813857,
     "ast_hash": "b02f7110c14eea4b8a149b5649cb8c1d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/gemini-settings.json": {
-    "mtime": 1782297665.2547886,
+    "mtime": 1782336091.9813857,
     "ast_hash": "544157f8499e7c19c3b6495d7a2de685",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/vscode-mcp.json": {
-    "mtime": 1782297665.2547886,
+    "mtime": 1782336091.9823868,
     "ast_hash": "069569075ea6158826d8a47b9204fa8b",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiBudget.java": {
-    "mtime": 1782297665.2603798,
+    "mtime": 1782336091.9873857,
     "ast_hash": "0f62ae7eb77e7a79164518be64846a07",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiCapabilities.java": {
-    "mtime": 1782297665.2613797,
+    "mtime": 1782336091.9883854,
     "ast_hash": "4b0644dd013cb6d45500cd6aa33e2be9",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiExecutionService.java": {
-    "mtime": 1782297665.2613797,
+    "mtime": 1782336091.9883854,
     "ast_hash": "a0595a80fb9dc84f4159fbd5e96ecb2a",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiImage.java": {
-    "mtime": 1782297665.2623794,
+    "mtime": 1782336091.9883854,
     "ast_hash": "25716916a48e61fbe6d9d4d1dc1fccaa",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiProvider.java": {
-    "mtime": 1782297665.2623794,
+    "mtime": 1782336091.989385,
     "ast_hash": "825a0e7f2a2271f176163b67c1155d19",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiProviderAvailability.java": {
-    "mtime": 1782297665.2623794,
+    "mtime": 1782336091.989385,
     "ast_hash": "f1cd040ecae8e52ad080c5619221e040",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiProviderRegistry.java": {
-    "mtime": 1782297665.263762,
+    "mtime": 1782336091.9903855,
     "ast_hash": "462385cec9e86f110b0f5e975368df2d",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiRequest.java": {
-    "mtime": 1782297665.263762,
+    "mtime": 1782336091.9903855,
     "ast_hash": "72fcc9f3c38e1ed3d98d57815f995adb",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiResponse.java": {
-    "mtime": 1782297665.263762,
+    "mtime": 1782336091.9903855,
     "ast_hash": "d62787524d101da0a83d24df33272971",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiResponseStatus.java": {
-    "mtime": 1782297665.2647624,
+    "mtime": 1782336091.9913852,
     "ast_hash": "18ec9401e739a84a451c8125c11152c5",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiUsage.java": {
-    "mtime": 1782297665.2647624,
+    "mtime": 1782336091.9913852,
     "ast_hash": "97a43fdb6c0b590d6c7be89d9fc2d35e",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/ApprovalPolicy.java": {
-    "mtime": 1782297665.2657611,
+    "mtime": 1782336091.9923854,
     "ast_hash": "f08f93f0d55ddbbad18efee9cced917b",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/DisabledAiProvider.java": {
-    "mtime": 1782297665.2657611,
+    "mtime": 1782336091.9923854,
     "ast_hash": "522658fda00a6fa05e2132bfc58d9c1d",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/EvidenceCategory.java": {
-    "mtime": 1782297665.266541,
+    "mtime": 1782336091.9923854,
     "ast_hash": "737d4c99daddaa581171170ad47006c7",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/EvidenceReference.java": {
-    "mtime": 1782297665.266541,
+    "mtime": 1782336091.9933858,
     "ast_hash": "cd5fae7467f25e060c2a531eeb44f789",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/ProcessingLocation.java": {
-    "mtime": 1782297665.2674904,
+    "mtime": 1782336091.9933858,
     "ast_hash": "7106587b9fd1d5573d0c2ba6355e6efa",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/audit/AiAuditEvent.java": {
-    "mtime": 1782297665.2674904,
+    "mtime": 1782336091.9943855,
     "ast_hash": "bd2ad33294235bf573acfac7e93da4b3",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/audit/AiAuditSink.java": {
-    "mtime": 1782297665.268633,
+    "mtime": 1782336091.9943855,
     "ast_hash": "460112c404cbd8eb47074b1ce2f714fa",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/audit/ShaftAiAuditSink.java": {
-    "mtime": 1782297665.268633,
+    "mtime": 1782336091.9943855,
     "ast_hash": "cbab846c3ab872246cbe1e0a861a062e",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/config/PilotConfiguration.java": {
-    "mtime": 1782297665.269633,
+    "mtime": 1782336091.9953861,
     "ast_hash": "43594a66237b108d080c946819eb7a57",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/config/ProviderConfiguration.java": {
-    "mtime": 1782297665.269633,
+    "mtime": 1782336091.9953861,
     "ast_hash": "c0d63dcf550dbd563bd77c89c6fcf013",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/json/JsonSchemaValidator.java": {
-    "mtime": 1782297665.2706325,
+    "mtime": 1782336091.996385,
     "ast_hash": "d1136d836e02f9f6022a06cb42acb949",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/natural/PilotNaturalActionPlanner.java": {
-    "mtime": 1782297665.2706325,
+    "mtime": 1782336091.996385,
     "ast_hash": "fac8097a727ba867caa8d6fe1e3ce385",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/security/RedactionPolicy.java": {
-    "mtime": 1782297665.2716331,
+    "mtime": 1782336091.9973855,
     "ast_hash": "b2018496d7f034d57439ad18315fddd8",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/security/RedactionResult.java": {
-    "mtime": 1782297665.2716331,
+    "mtime": 1782336091.9973855,
     "ast_hash": "02d5ee92866f5c7a61fdc20af0d1a282",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/security/Redactor.java": {
-    "mtime": 1782297665.272632,
+    "mtime": 1782336091.9983857,
     "ast_hash": "ff7d2c45be4f35fb31c789cfb797509e",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiExecutionServiceTest.java": {
-    "mtime": 1782297665.2757447,
+    "mtime": 1782336092.0003858,
     "ast_hash": "18f32509d9954005e10259839e4c6a26",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiProviderRegistryTest.java": {
-    "mtime": 1782297665.277044,
+    "mtime": 1782336092.0013855,
     "ast_hash": "d44cb3d9a96f72e8d169b40215ea9e30",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/ai/PilotTestConfiguration.java": {
-    "mtime": 1782297665.278044,
+    "mtime": 1782336092.002385,
     "ast_hash": "b8434bf125093e961295191538deefdd",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/security/RedactorTest.java": {
-    "mtime": 1782297665.2800438,
+    "mtime": 1782336092.003385,
     "ast_hash": "6b5d2f07eeca23613af246198507f334",
     "semantic_hash": ""
   },
   "shaft-upgrader/upgrade_to_modular_shaft.py": {
-    "mtime": 1782297665.281045,
+    "mtime": 1782336092.004385,
     "ast_hash": "bc99e69d0f35ccce8d811cd92031aee4",
     "semantic_hash": ""
   },
   "shaft-video/src/main/java/com/shaft/gui/internal/video/AutomationRemarksDesktopVideoRecordingProvider.java": {
-    "mtime": 1782297665.283874,
+    "mtime": 1782336092.0073853,
     "ast_hash": "b92a1245bb8e27b8865cd539c0303677",
     "semantic_hash": ""
   },
   "shaft-video/src/test/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistrationTest.java": {
-    "mtime": 1782297665.286997,
+    "mtime": 1782336092.010385,
     "ast_hash": "b86fe9a695cb45dd47af814176c0d207",
     "semantic_hash": ""
   },
   "shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvHealingVisualProvider.java": {
-    "mtime": 1782297665.2899964,
+    "mtime": 1782336092.0133853,
     "ast_hash": "665a72915a4214f1e86d3f8a315873b9",
     "semantic_hash": ""
   },
   "shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java": {
-    "mtime": 1782297665.290996,
+    "mtime": 1782336092.0133853,
     "ast_hash": "f34d4ea0f2f879ddb05d88e8fa163257",
     "semantic_hash": ""
   },
   "shaft-visual/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsCoverageUnitTest.java": {
-    "mtime": 1782297665.294175,
+    "mtime": 1782336092.0173855,
     "ast_hash": "a010a6f22a177d8030bad70f35d74bab",
     "semantic_hash": ""
   },
   "shaft-visual/src/test/java/com/shaft/gui/internal/image/OpenCvHealingVisualProviderTest.java": {
-    "mtime": 1782297665.294175,
+    "mtime": 1782336092.0173855,
     "ast_hash": "324be73186da5aa43b06e00099a55061",
     "semantic_hash": ""
   },
   "shaft-visual/src/test/java/testPackage/unitTests/ImageProcessingActionsUnitTest.java": {
-    "mtime": 1782297665.2951748,
+    "mtime": 1782336092.018385,
     "ast_hash": "c2a218aa630dedbe91eae5c572944fd7",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/forbidden-coordinates.json": {
-    "mtime": 1782297665.2961745,
+    "mtime": 1782336092.0203853,
     "ast_hash": "05978f92526026f1e72d0cc9333dcd14",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/api.json": {
-    "mtime": 1782297665.2971745,
+    "mtime": 1782336092.0203853,
     "ast_hash": "33464132b1941069384296fb1a5d0b8c",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/appium-mobile.json": {
-    "mtime": 1782297665.2971745,
+    "mtime": 1782336092.0203853,
     "ast_hash": "7ae7e1b33592d1ef1428d548f8fac808",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts-bom.json": {
-    "mtime": 1782297665.2981768,
+    "mtime": 1782336092.0223856,
     "ast_hash": "9fbfe22e65e8cfa4e1ffb7b9e6517494",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts-browserstack-sdk.json": {
-    "mtime": 1782297665.2991745,
+    "mtime": 1782336092.0223856,
     "ast_hash": "5af6cde115806a688731572d1ceaa893",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts-combined-modules.json": {
-    "mtime": 1782297665.2998495,
+    "mtime": 1782336092.0233853,
     "ast_hash": "278a1788754fc7bba0fa505cc2baed79",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts-desktop-video.json": {
-    "mtime": 1782297665.3005128,
+    "mtime": 1782336092.0233853,
     "ast_hash": "1543ef994a82a667c3d95688bd778587",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts-opencv-visual.json": {
-    "mtime": 1782297665.3005128,
+    "mtime": 1782336092.0243855,
     "ast_hash": "719a4464d0a58ecde6dba8f9f5233a8d",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts.json": {
-    "mtime": 1782297665.3005128,
+    "mtime": 1782336092.0243855,
     "ast_hash": "d8492b92abaaf1c4d60cd1035a96f8e1",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/bom.json": {
-    "mtime": 1782297665.301641,
+    "mtime": 1782336092.0243855,
     "ast_hash": "3eabc9ec189bdaf11f14b4c0a45b75c2",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/browserstack-sdk.json": {
-    "mtime": 1782297665.301641,
+    "mtime": 1782336092.025385,
     "ast_hash": "44c751b4a87214e0607bd7a018f6bd29",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/combined-modules.json": {
-    "mtime": 1782297665.301641,
+    "mtime": 1782336092.025385,
     "ast_hash": "7437bc718bb6526bd5ade48a6dd7a186",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/desktop-video.json": {
-    "mtime": 1782297665.3026402,
+    "mtime": 1782336092.025385,
     "ast_hash": "3cd581acddb6c5ab3eb3c5dadfa4dfec",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/junit-web.json": {
-    "mtime": 1782297665.3026402,
+    "mtime": 1782336092.0263846,
     "ast_hash": "e736aac3ac042dd16518d1f12e5a8689",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/legacy-coordinate.json": {
-    "mtime": 1782297665.3026402,
+    "mtime": 1782336092.0263846,
     "ast_hash": "e0db222137e456fe8e3563cf5564672a",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/opencv-visual.json": {
-    "mtime": 1782297665.3036418,
+    "mtime": 1782336092.0273857,
     "ast_hash": "3af8a40b65daa2d45d95d633db37bc0f",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/testng-web.json": {
-    "mtime": 1782297665.3036418,
+    "mtime": 1782336092.0273857,
     "ast_hash": "476c5a55cf829d939d58c5ee853862b1",
     "semantic_hash": ""
   },
   "tests/scripts/test_assemble_javadocs.py": {
-    "mtime": 1782297665.3046408,
+    "mtime": 1782336092.028386,
     "ast_hash": "f3502852bcff0fab528ccb2995644628",
     "semantic_hash": ""
   },
   "tests/scripts/test_browserstack_module_boundary.py": {
-    "mtime": 1782297665.3046408,
+    "mtime": 1782336092.028386,
     "ast_hash": "f4671e1c6ca54b6e02497afefa3d79c9",
     "semantic_hash": ""
   },
   "tests/scripts/test_check_maven_release_version.py": {
-    "mtime": 1782297665.3056395,
+    "mtime": 1782336092.0293846,
     "ast_hash": "2862600bb50c3c3a62386c49105fa5e8",
     "semantic_hash": ""
   },
   "tests/scripts/test_extract_allure_failures.py": {
-    "mtime": 1782297665.3056395,
+    "mtime": 1782336092.0293846,
     "ast_hash": "40c2706ce602599cfcdd5a7f5da2a01d",
     "semantic_hash": ""
   },
   "tests/scripts/test_pilot_module_boundary.py": {
-    "mtime": 1782297665.3066409,
+    "mtime": 1782336092.0303853,
     "ast_hash": "778d0667f363c9013a98be56f2cdbeeb",
     "semantic_hash": ""
   },
   "tests/scripts/test_upgrade_to_modular_shaft.py": {
-    "mtime": 1782297665.3066409,
+    "mtime": 1782336092.0303853,
     "ast_hash": "27bd864221869f4f751ffebe14240ba7",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_agent_guidance.py": {
-    "mtime": 1782297665.3076406,
+    "mtime": 1782336092.0313852,
     "ast_hash": "31f821d43bb135cecff6219df9238139",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_agent_setup.py": {
-    "mtime": 1782297665.3076406,
+    "mtime": 1782336092.0313852,
     "ast_hash": "6897d4657f87cc83c6573b37698c96de",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_maven_publication.py": {
-    "mtime": 1782297665.3081937,
+    "mtime": 1782336092.0323846,
     "ast_hash": "34d6ed7fbe980f3eed372bd1ef5388aa",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_modular_documentation.py": {
-    "mtime": 1782297665.3094907,
+    "mtime": 1782336092.0323846,
     "ast_hash": "69686b909a8bfdeabe1443605d5da58d",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_quality_configuration.py": {
-    "mtime": 1782297665.3094907,
+    "mtime": 1782336092.0323846,
     "ast_hash": "9b656c26a1a985cc43fb61fab4912d85",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_reactor_versions.py": {
-    "mtime": 1782297665.3094907,
+    "mtime": 1782336092.033386,
     "ast_hash": "f9433da24d0218a7361747d407ace39d",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_shaft_pilot_release.py": {
-    "mtime": 1782297665.3104923,
+    "mtime": 1782336092.033386,
     "ast_hash": "b888b91abba4fa10ff9c8f2aa8c5f6da",
     "semantic_hash": ""
   },
   "tests/scripts/test_verify_maven_central_release.py": {
-    "mtime": 1782297665.3114908,
+    "mtime": 1782336092.0343852,
     "ast_hash": "20d330277e722c391b13833fc79827f1",
     "semantic_hash": ""
   },
   "tests/scripts/test_video_module_boundary.py": {
-    "mtime": 1782297665.3114908,
+    "mtime": 1782336092.0343852,
     "ast_hash": "a3faabe526dd03805678b1c530509398",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/api/src/test/java/fixture/ApiAndRetainedSurfaceConsumer.java": {
-    "mtime": 1782297665.3144903,
+    "mtime": 1782336092.037385,
     "ast_hash": "5a2e4a6e773299c1000f0d22aaa00d10",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/appium-mobile/src/test/java/fixture/AppiumMobileConsumer.java": {
-    "mtime": 1782297665.315491,
+    "mtime": 1782336092.0383844,
     "ast_hash": "863352eb82696f373fe94a63f1d22d25",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/bom/src/test/java/fixture/BomConsumer.java": {
-    "mtime": 1782297665.317491,
+    "mtime": 1782336092.0403852,
     "ast_hash": "626d1fe9b8536ed47c4f86a665d8a49e",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/browserstack-sdk/src/test/java/fixture/BrowserStackSdkConsumer.java": {
-    "mtime": 1782297665.3194904,
+    "mtime": 1782336092.042385,
     "ast_hash": "0d9caf3b0b7aceb9d9b9f54b6fac92ef",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/desktop-video/src/test/java/fixture/DesktopVideoConsumer.java": {
-    "mtime": 1782297665.3224893,
+    "mtime": 1782336092.0443847,
     "ast_hash": "cf09e09cfb9ccab702d9aa80b3d0e520",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/junit-web/src/test/java/fixture/JUnitWebConsumer.java": {
-    "mtime": 1782297665.3248756,
+    "mtime": 1782336092.04639,
     "ast_hash": "cd14091ae4d1d91102878e1b1d41d1fc",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/legacy-coordinate/src/test/java/fixture/LegacyCoordinateConsumer.java": {
-    "mtime": 1782297665.3267243,
+    "mtime": 1782336092.04839,
     "ast_hash": "2a8f6b59bc40773df7204c2b417ab016",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/opencv-visual/src/test/java/fixture/OpenCvVisualConsumer.java": {
-    "mtime": 1782297665.3287241,
+    "mtime": 1782336092.0503893,
     "ast_hash": "13a3d033009333c480e8354e11f160f4",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/pilot-core/src/main/java/example/PilotCoreConsumer.java": {
-    "mtime": 1782297665.3307238,
+    "mtime": 1782336092.05239,
     "ast_hash": "ecd7041b37e057a1692e0407f2ea8ec9",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/testng-web/src/test/java/fixture/TestNgWebConsumer.java": {
-    "mtime": 1782297665.3332343,
+    "mtime": 1782336092.05339,
     "ast_hash": "f5374b99aa6ede6b828689f13963196f",
     "semantic_hash": ""
   },
   ".agents/skills/ci-failure-investigator/SKILL.md": {
-    "mtime": 1782297663.9810383,
+    "mtime": 1782336090.7583516,
     "ast_hash": "00b8473e33574eaecd73bc947de97864",
     "semantic_hash": ""
   },
   ".agents/skills/ci-failure-investigator/agents/openai.yaml": {
-    "mtime": 1782297663.9820404,
+    "mtime": 1782336090.7593517,
     "ast_hash": "a655df2d4ee8a6eca2611c26184da4ba",
     "semantic_hash": ""
   },
   ".agents/skills/flaky-test-stabilizer/SKILL.md": {
-    "mtime": 1782297663.9820404,
+    "mtime": 1782336090.7593517,
     "ast_hash": "97f4ea40aaf659bca7200ce9a99279a5",
     "semantic_hash": ""
   },
   ".agents/skills/flaky-test-stabilizer/agents/openai.yaml": {
-    "mtime": 1782297663.9830384,
+    "mtime": 1782336090.7603943,
     "ast_hash": "442d85b196270c22a0c71c81c759ede1",
     "semantic_hash": ""
   },
   ".agents/skills/framework-source-rules/SKILL.md": {
-    "mtime": 1782297663.984039,
+    "mtime": 1782336090.7603943,
     "ast_hash": "4e9e9113da43851ebbbadf41ff12070c",
     "semantic_hash": ""
   },
   ".agents/skills/framework-source-rules/agents/openai.yaml": {
-    "mtime": 1782297663.9850385,
+    "mtime": 1782336090.7613945,
     "ast_hash": "fbbaa399dc0f83968bf451e6a53fc96d",
     "semantic_hash": ""
   },
   ".agents/skills/java-test-rules/SKILL.md": {
-    "mtime": 1782297663.9850385,
+    "mtime": 1782336090.7613945,
     "ast_hash": "deb7cdd0ce17fa15de3fe89b51b7ee10",
     "semantic_hash": ""
   },
   ".agents/skills/java-test-rules/agents/openai.yaml": {
-    "mtime": 1782297663.9860382,
+    "mtime": 1782336090.762394,
     "ast_hash": "fd1828b72256991da2926129061bda9c",
     "semantic_hash": ""
   },
   ".agents/skills/release-dependency-guard/SKILL.md": {
-    "mtime": 1782297663.9860382,
+    "mtime": 1782336090.762394,
     "ast_hash": "f3653ae639dadae0de32eb6d93abc152",
     "semantic_hash": ""
   },
   ".agents/skills/release-dependency-guard/agents/openai.yaml": {
-    "mtime": 1782297663.9870381,
+    "mtime": 1782336090.763394,
     "ast_hash": "70df2767596adcc902c526e6f96b9047",
     "semantic_hash": ""
   },
   ".github/FUNDING.yml": {
-    "mtime": 1782297663.9910388,
+    "mtime": 1782336090.7684019,
     "ast_hash": "82d0dace0b0b1e5a3113e7483a2c90ef",
     "semantic_hash": ""
   },
   ".github/ISSUE_TEMPLATE/bug_report.md": {
-    "mtime": 1782297663.9920385,
+    "mtime": 1782336090.7684019,
     "ast_hash": "ef466e19961514f451c8c0bccc9be819",
     "semantic_hash": ""
   },
   ".github/ISSUE_TEMPLATE/config.yml": {
-    "mtime": 1782297663.9920385,
+    "mtime": 1782336090.7693942,
     "ast_hash": "78c7c4c344a237f1a770009306505fa0",
     "semantic_hash": ""
   },
   ".github/ISSUE_TEMPLATE/feature_request.md": {
-    "mtime": 1782297663.9930375,
+    "mtime": 1782336090.7693942,
     "ast_hash": "2374f7b498fad3e41590d9d0aa6bd116",
     "semantic_hash": ""
   },
   ".github/RELEASE_BODY_TEMPLATE.md": {
-    "mtime": 1782297663.9930375,
+    "mtime": 1782336090.7693942,
     "ast_hash": "311edf8e9db9d277067a4166d1e2e453",
     "semantic_hash": ""
   },
   ".github/actions/consolidate-test-results/action.yml": {
-    "mtime": 1782297663.9940374,
+    "mtime": 1782336090.770394,
     "ast_hash": "60f8f12a4f02378cbf50c2e4548ea2d7",
     "semantic_hash": ""
   },
   ".github/actions/post-test-report/action.yml": {
-    "mtime": 1782297663.9950395,
+    "mtime": 1782336090.771394,
     "ast_hash": "9bf564486cc3861391c1d52b18f3e442",
     "semantic_hash": ""
   },
   ".github/actions/setup-test-env/action.yml": {
-    "mtime": 1782297663.9950395,
+    "mtime": 1782336090.7725737,
     "ast_hash": "a3ae968f94adf704ec03d1d59c32ca88",
     "semantic_hash": ""
   },
   ".github/actions/upload-jacoco-coverage/action.yml": {
-    "mtime": 1782297663.9960375,
+    "mtime": 1782336090.7725737,
     "ast_hash": "235863f5fbb33ba3564051d6570d6ed2",
     "semantic_hash": ""
   },
   ".github/codex/prompts/refresh-agent-instructions.md": {
-    "mtime": 1782297663.9970374,
+    "mtime": 1782336090.7735791,
     "ast_hash": "b917f03c57b15de27300bc05cf7e0929",
     "semantic_hash": ""
   },
   ".github/copilot-instructions.md": {
-    "mtime": 1782297663.9970374,
+    "mtime": 1782336090.7735791,
     "ast_hash": "b5a0e7a2af012bf5c687495f6ced2d85",
     "semantic_hash": ""
   },
   ".github/dependabot.yml": {
-    "mtime": 1782297663.9970374,
+    "mtime": 1782336090.7745788,
     "ast_hash": "4f97032a0893c4bd5040a882d83bf7c5",
     "semantic_hash": ""
   },
   ".github/instructions/framework-source.instructions.md": {
-    "mtime": 1782297663.9980392,
+    "mtime": 1782336090.7755787,
     "ast_hash": "5f3adff6cc4aa23c612aa7c02ae9a512",
     "semantic_hash": ""
   },
   ".github/instructions/java-tests.instructions.md": {
-    "mtime": 1782297663.9980392,
+    "mtime": 1782336090.7755787,
     "ast_hash": "c09b9d18f7d372e5713e1ae3a401fe37",
     "semantic_hash": ""
   },
   ".github/pull_request_template.md": {
-    "mtime": 1782297663.9990377,
+    "mtime": 1782336090.7755787,
     "ast_hash": "fdc84bd63f4459bb71c5e62770bd36f3",
     "semantic_hash": ""
   },
   ".github/release.yml": {
-    "mtime": 1782297663.9990377,
+    "mtime": 1782336090.7765791,
     "ast_hash": "da8b1e52486c7f97f5ef731e57629179",
     "semantic_hash": ""
   },
   ".github/skills/README.md": {
-    "mtime": 1782297664.0000374,
+    "mtime": 1782336090.777579,
     "ast_hash": "d0a0719e4039d1faae74c98994763c5f",
     "semantic_hash": ""
   },
   ".github/skills/ci-failure-investigator/SKILL.md": {
-    "mtime": 1782297664.0000374,
+    "mtime": 1782336090.7783346,
     "ast_hash": "c96ae3cf1ca3bab8b9d4bb034be8c1d5",
     "semantic_hash": ""
   },
   ".github/skills/flaky-test-stabilizer/SKILL.md": {
-    "mtime": 1782297664.001038,
+    "mtime": 1782336090.7790105,
     "ast_hash": "8244098e39f5271a9e3d1f8d7ffbd830",
     "semantic_hash": ""
   },
   ".github/skills/release-dependency-guard/SKILL.md": {
-    "mtime": 1782297664.0020375,
+    "mtime": 1782336090.7790105,
     "ast_hash": "4cc087a502ef6bccecd6c52b154b6a58",
     "semantic_hash": ""
   },
   ".github/workflows/copilot-setup-steps.yml": {
-    "mtime": 1782297664.0030382,
+    "mtime": 1782336090.7809389,
     "ast_hash": "0c3d73a2b49a51c9d86e5a5f4c76bbcf",
     "semantic_hash": ""
   },
   ".github/workflows/deploy-shaft-mcp.yml": {
-    "mtime": 1782297664.0040379,
+    "mtime": 1782336090.7819438,
     "ast_hash": "c9d64c29897a5dae860640eaf1622981",
     "semantic_hash": ""
   },
   ".github/workflows/e2eTests.yml": {
-    "mtime": 1782297664.0050387,
+    "mtime": 1782336090.782944,
     "ast_hash": "1951482fcb77a99eaaaf3a3f0a3acc90",
     "semantic_hash": ""
   },
   ".github/workflows/general-validations.yml": {
-    "mtime": 1782297664.0050387,
+    "mtime": 1782336090.782944,
     "ast_hash": "13ad2f42460649f6ee90432f5bb07f85",
     "semantic_hash": ""
   },
   ".github/workflows/mavenCentral_cd.yml": {
-    "mtime": 1782297664.0060382,
+    "mtime": 1782336090.7839441,
     "ast_hash": "12c1819ee10a8a1bc43b26956af4b6f0",
     "semantic_hash": ""
   },
   ".github/workflows/publish-shaft-mcp.yml": {
-    "mtime": 1782297664.0060382,
+    "mtime": 1782336090.7849443,
     "ast_hash": "7ece85f30a603b746cb901af35c9d0f2",
     "semantic_hash": ""
   },
   ".github/workflows/publishJavaDocs.yml": {
-    "mtime": 1782297664.007038,
+    "mtime": 1782336090.7849443,
     "ast_hash": "e68ab97713f70c88ae293f7e814985cf",
     "semantic_hash": ""
   },
   ".github/workflows/refresh-agent-instructions.yml": {
-    "mtime": 1782297664.007038,
+    "mtime": 1782336090.7849443,
     "ast_hash": "792e62e3a612accd91287508154b6a07",
     "semantic_hash": ""
   },
   ".github/workflows/security.yml": {
-    "mtime": 1782297664.007038,
+    "mtime": 1782336090.7859457,
     "ast_hash": "6d096cbb458e77fc21fbb1557d99cfa5",
     "semantic_hash": ""
   },
   ".github/workflows/shaft-mcp.yml": {
-    "mtime": 1782297664.0080369,
+    "mtime": 1782336090.7859457,
     "ast_hash": "7c6f65310c3b9bc52c3139e0d9dd5b0d",
     "semantic_hash": ""
   },
   ".github/workflows/shaft-pilot-release.yml": {
-    "mtime": 1782297664.0080369,
+    "mtime": 1782336090.7869442,
     "ast_hash": "6cdfddcdb0047dffb1407eaa6b60ab7e",
     "semantic_hash": ""
   },
   ".github/workflows/sync-sample-projects-version.yml": {
-    "mtime": 1782297664.0090404,
+    "mtime": 1782336090.7869442,
     "ast_hash": "dfebf14b9c11eca07877c2083cde5be4",
     "semantic_hash": ""
   },
   ".github/workflows/update-selenium-grid-versions.yml": {
-    "mtime": 1782297664.0090404,
+    "mtime": 1782336090.7879443,
     "ast_hash": "d3bc67a9f9e52eed58c9151431cded9d",
     "semantic_hash": ""
   },
   ".memory/memory/architecture.md": {
-    "mtime": 1782297664.0120385,
+    "mtime": 1782336090.790944,
     "ast_hash": "6abb2a262830b40886b2283dac6a901a",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/maven-central-version-immutability.md": {
-    "mtime": 1782297664.0150385,
+    "mtime": 1782336090.7939434,
     "ast_hash": "76b0b7fb9ab56f985f3941697647c496",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/paid-agent-work-audit-gated.md": {
-    "mtime": 1782297664.0150385,
+    "mtime": 1782336090.7939434,
     "ast_hash": "15666adfbb50db198beb784479ff45e5",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/agent-guidance-progressive-disclosure.md": {
-    "mtime": 1782297664.016505,
+    "mtime": 1782336090.7949433,
     "ast_hash": "9675efebffd6956a72dbe25b6e39591f",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/namespaced-video-capabilities.md": {
-    "mtime": 1782297664.0211606,
+    "mtime": 1782336090.799945,
     "ast_hash": "a5940ade6cab0d926922ca555dab46f6",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/public-docs-external.md": {
-    "mtime": 1782297664.0231597,
+    "mtime": 1782336090.8029437,
     "ast_hash": "3d4a3061ddfb0b5f6ee8049012f4d664",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/utf8-all-runtime-layers.md": {
-    "mtime": 1782297664.0269196,
+    "mtime": 1782336090.8059437,
     "ast_hash": "6bff0142e535940a2c54ed0c96743f81",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/allure-result-population.md": {
-    "mtime": 1782297664.0289195,
+    "mtime": 1782336090.808944,
     "ast_hash": "d691c887b833eeb2002b91bb55129c8a",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/coverage-constructors-start-browser.md": {
-    "mtime": 1782297664.02992,
+    "mtime": 1782336090.808944,
     "ast_hash": "bbd92df5c4228f6e626c7a52ed2c16cd",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/java25-isuite-mocking.md": {
-    "mtime": 1782297664.031919,
+    "mtime": 1782336090.8109438,
     "ast_hash": "a6d1866e880bd6556f12230ff80f75aa",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/testng-method-parallel-shared-instance-fields.md": {
-    "mtime": 1782297664.0349715,
+    "mtime": 1782336090.812944,
     "ast_hash": "88be0bf5fcebfdb1d579389644c09ebe",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/testng-single-threaded-static-state.md": {
-    "mtime": 1782297664.0359716,
+    "mtime": 1782336090.813944,
     "ast_hash": "19c314a82618b0fa2e841ecac203734b",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/windows-allure-root-race.md": {
-    "mtime": 1782297664.0359716,
+    "mtime": 1782336090.814944,
     "ast_hash": "2ff9296f2ecf396b5c61f41a0b5be34b",
     "semantic_hash": ""
   },
   ".memory/memory/project.md": {
-    "mtime": 1782297664.0369704,
+    "mtime": 1782336090.815945,
     "ast_hash": "5e4026b5220213b5d05773628cde4269",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/issue-linked-pr-closure-and-focused-tests.md": {
-    "mtime": 1782297664.0452487,
+    "mtime": 1782336090.821944,
     "ast_hash": "57982dd3a4bdf7d5b1a46259307d1e58",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/low-token-user-guide-work.md": {
-    "mtime": 1782297664.0462532,
+    "mtime": 1782336090.822944,
     "ast_hash": "37fceea4bd25a0a1949e5bc9c28f8f6e",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/proactive-memory-use-when-material.md": {
-    "mtime": 1782297664.0472536,
+    "mtime": 1782336090.823944,
     "ast_hash": "79312855570c67b7f6e8e0ef5adab2cf",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/start-new-tasks-from-origin-main.md": {
-    "mtime": 1782297664.0502539,
+    "mtime": 1782336090.8281448,
     "ast_hash": "c20c771d71712f59dba2081edda454d0",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/update-official-user-guide-for-functionality-changes.md": {
-    "mtime": 1782297664.0522535,
+    "mtime": 1782336090.8291495,
     "ast_hash": "1d7eaa27ba5737bd22dee4ba51ec3316",
     "semantic_hash": ""
   },
   "AGENTS.md": {
-    "mtime": 1782297664.0612533,
+    "mtime": 1782336090.8384287,
     "ast_hash": "90ff26c44a457cbe712e85238a37aa0d",
     "semantic_hash": ""
   },
   "CLAUDE.md": {
-    "mtime": 1782297664.0612533,
+    "mtime": 1782336090.8384287,
     "ast_hash": "109fba9e5bd24a6c1ae37e799818c59b",
     "semantic_hash": ""
   },
   "CODE_OF_CONDUCT.md": {
-    "mtime": 1782297664.0623436,
+    "mtime": 1782336090.8394282,
     "ast_hash": "757dfc14603149dc03182d5c2c0d8ca4",
     "semantic_hash": ""
   },
   "CONTRIBUTING.md": {
-    "mtime": 1782297664.0623436,
+    "mtime": 1782336090.8394282,
     "ast_hash": "86f86dcdb3102ee7fe5192f2c131c3b3",
     "semantic_hash": ""
   },
   "README.md": {
-    "mtime": 1782297664.063344,
+    "mtime": 1782336090.840428,
     "ast_hash": "49f5f56feb5a4bf0323c9a36a5b0647b",
     "semantic_hash": ""
   },
   "SECURITY.md": {
-    "mtime": 1782297664.063344,
+    "mtime": 1782336090.840428,
     "ast_hash": "5968bb1ac2bd3d0b9c04d6789ed99884",
     "semantic_hash": ""
   },
   "codecov.yml": {
-    "mtime": 1782297664.063344,
+    "mtime": 1782336090.840428,
     "ast_hash": "6ad852993fbc1adc8ffa7e42bbd2ce9f",
     "semantic_hash": ""
   },
   "render.yaml": {
-    "mtime": 1782297664.135504,
+    "mtime": 1782336090.9075294,
     "ast_hash": "852f4c51596f80a6f39c336083b743bd",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/golden/doctor-report.md": {
-    "mtime": 1782297664.2360272,
+    "mtime": 1782336090.9964585,
     "ast_hash": "9fd151800fee4024eeb0463f36890866",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/javadoc/resources/configuration-manager/index.html": {
-    "mtime": 1782297664.3463516,
+    "mtime": 1782336091.0998483,
     "ast_hash": "ca5f4b8eaa155e369d244982a42c248a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/healenium-backend.yml": {
-    "mtime": 1782297664.3547096,
+    "mtime": 1782336091.1068487,
     "ast_hash": "a5fd654aa0fbea19d0a20fa14e06e86c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/report-portal.yml": {
-    "mtime": 1782297664.35671,
+    "mtime": 1782336091.108849,
     "ast_hash": "de7ac23ca6fa7d3eda50bc8ab1aba483",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/selenium3.yml": {
-    "mtime": 1782297664.357711,
+    "mtime": 1782336091.1098487,
     "ast_hash": "a464e315b9a241886cfef90f787ec99d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/selenium4.yml": {
-    "mtime": 1782297664.3582077,
+    "mtime": 1782336091.1098487,
     "ast_hash": "ef7d53be2865b48d88080466a1002231",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/selenoid.yml": {
-    "mtime": 1782297664.3582077,
+    "mtime": 1782336091.1098487,
     "ast_hash": "94b482b90eb7a6c434840950aa7cadad",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/selenoid_setup.yml": {
-    "mtime": 1782297664.358844,
+    "mtime": 1782336091.110849,
     "ast_hash": "57f474b3e5f66f08f07684ab25568c4e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/zalenium.yml": {
-    "mtime": 1782297664.3600042,
+    "mtime": 1782336091.1118484,
     "ast_hash": "cc1f40ca9bb2c913d8ce5c755c1dc525",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/.github/dependabot.yml": {
-    "mtime": 1782297664.365513,
+    "mtime": 1782336091.1178484,
     "ast_hash": "d967a02218d19254ea8c200b1887b549",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/.github/workflows/api.yml": {
-    "mtime": 1782297664.3665195,
+    "mtime": 1782336091.1178484,
     "ast_hash": "d6cebbce56ded32de3f4d49cfdc8e545",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/.github/workflows/web.yml": {
-    "mtime": 1782297664.3675153,
+    "mtime": 1782336091.1188493,
     "ast_hash": "698491178af348cb577da4a2bed5f4ce",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/k8s/selenium-grid-chrome-scaledobject.yaml": {
-    "mtime": 1782297664.5167806,
+    "mtime": 1782336091.2541897,
     "ast_hash": "c6d16b2c9bf789f3c38dced54ff50c79",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/k8s/selenium-grid-edge-scaledobject.yaml": {
-    "mtime": 1782297664.5167806,
+    "mtime": 1782336091.2541897,
     "ast_hash": "48291bb39d912826522b2fcaedbd55e9",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/k8s/selenium-grid-firefox-scaledobject.yaml": {
-    "mtime": 1782297664.5177803,
+    "mtime": 1782336091.25519,
     "ast_hash": "ce8ab2c5f24347cbbe286a358e6e970d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/alertFixture.html": {
-    "mtime": 1782297664.6691208,
+    "mtime": 1782336091.394562,
     "ast_hash": "ea46500946ec7b72c8d872d5432079dc",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/coverageTestPage.html": {
-    "mtime": 1782297665.167731,
+    "mtime": 1782336091.9028463,
     "ast_hash": "1b449bdbd7cbf63f83d0f4c644976730",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/hoverDemo.html": {
-    "mtime": 1782297665.167731,
+    "mtime": 1782336091.9028463,
     "ast_hash": "017983881c7dcdeb8549122b74fceea3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/hoverDemo_outsideViewPort.html": {
-    "mtime": 1782297665.1689055,
+    "mtime": 1782336091.9038622,
     "ast_hash": "09c6ae4c037396146fb889b9145d77b9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/hoverDemo_outsideViewPort_Horizontal.html": {
-    "mtime": 1782297665.1689055,
+    "mtime": 1782336091.9038622,
     "ast_hash": "3f2864a3f112756f32c047d08d86d033",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/locatorBuilderFixture.html": {
-    "mtime": 1782297665.1699052,
+    "mtime": 1782336091.9048538,
     "ast_hash": "274171ae17cb342e543557271079b5a9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/searchFixture.html": {
-    "mtime": 1782297665.1739056,
+    "mtime": 1782336091.9088464,
     "ast_hash": "f807c7d448900de296c1aff8960c0928",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/selectDemo.html": {
-    "mtime": 1782297665.1748476,
+    "mtime": 1782336091.9098465,
     "ast_hash": "6202e3912db56d54602ad63a94ecbf52",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/selectedValueTests/Advanced_select_with_multiple_features.html": {
-    "mtime": 1782297665.1754985,
+    "mtime": 1782336091.9098465,
     "ast_hash": "78d03def935f6591bd4e50812688a7c4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/selectedValueTests/Basic_select.html": {
-    "mtime": 1782297665.1754985,
+    "mtime": 1782336091.9108458,
     "ast_hash": "3868db4101f1dcbb8ed8fc09bad58d65",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/test.html": {
-    "mtime": 1782297665.1796215,
+    "mtime": 1782336091.913846,
     "ast_hash": "eca1a30a4647270469873bb77be7d28b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/uploadFixture.html": {
-    "mtime": 1782297665.1826222,
+    "mtime": 1782336091.9158459,
     "ast_hash": "6afb82db0280c6109713fe98dc1109ea",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/validationTextFixture.html": {
-    "mtime": 1782297665.1826222,
+    "mtime": 1782336091.916846,
     "ast_hash": "bdc4bd2af770c9de828335d6a51e9f75",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/yaml/yaml_test_data.yaml": {
-    "mtime": 1782297665.1832104,
+    "mtime": 1782336091.916846,
     "ast_hash": "9dbe42fd6d1166db3aefabe7bf52e87b",
     "semantic_hash": ""
   },
   "shaft-mcp/.github/copilot-instructions.md": {
-    "mtime": 1782297665.2033162,
+    "mtime": 1782336091.9348462,
     "ast_hash": "687a29b7080f6e1548c6470c3924b291",
     "semantic_hash": ""
   },
   "smithery.yaml": {
-    "mtime": 1782297665.2951748,
+    "mtime": 1782336092.018385,
     "ast_hash": "38eb9cd9b08dbf6453dfd19693e4f23e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/sample.pdf": {
-    "mtime": 1782297665.1739056,
+    "mtime": 1782336091.907848,
     "ast_hash": "4b41a3475132bd861b30a878e30aa56a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/Android/13_0/a9d70165382980941bed3fe21fcb9aabfc62872fa39658c332505740f4cb3675.png": {
-    "mtime": 1782297664.3615088,
+    "mtime": 1782336091.1138482,
     "ast_hash": "2ef14bf57dfc7ae42b748b506607c891",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/Android/content.png": {
-    "mtime": 1782297664.3625145,
+    "mtime": 1782336091.1138482,
     "ast_hash": "ceaf89a99b2f77f7dd7385232bc786a0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/Android/content_local.png": {
-    "mtime": 1782297664.363514,
+    "mtime": 1782336091.1148489,
     "ast_hash": "b404721a09a139fcaf7276b578a5deab",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/Android/content_new.png": {
-    "mtime": 1782297664.363514,
+    "mtime": 1782336091.115849,
     "ast_hash": "42815e5383bcc7948c46443793f61dbe",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/linux/chrome/a16413dbaadddad22a2203779b00521b7e5beb3446743fff9b52e1c3308bbfd3.png": {
-    "mtime": 1782297664.364515,
+    "mtime": 1782336091.115849,
     "ast_hash": "0ce5cae521647668798fb59240d8163d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/linux/chrome/a16413dbaadddad22a2203779b00521b7e5beb3446743fff9b52e1c3308bbfd3_shutterbug.png": {
-    "mtime": 1782297664.364515,
+    "mtime": 1782336091.1168487,
     "ast_hash": "da6466f773b2b294c96164c351fee9e1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/engine.png": {
-    "mtime": 1782297664.5047817,
+    "mtime": 1782336091.2422705,
     "ast_hash": "9c02074d966c282967abf86a40990952",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/mindmap.png": {
-    "mtime": 1782297664.5087807,
+    "mtime": 1782336091.2471895,
     "ast_hash": "09974b1f6d4fe5ef7b8601bb9c08680e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/roi.png": {
-    "mtime": 1782297664.509781,
+    "mtime": 1782336091.2471895,
     "ast_hash": "7303a194a3ba55dd3fb2071d8445e31b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft.png": {
-    "mtime": 1782297664.5107815,
+    "mtime": 1782336091.2491894,
     "ast_hash": "d476641cef7c2f5c13f2da06eee7913a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft_white.png": {
-    "mtime": 1782297664.5137796,
+    "mtime": 1782336091.25119,
     "ast_hash": "877b04c6152af84a64aeb0dcd1ef3198",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft_white_bg.png": {
-    "mtime": 1782297664.5147798,
+    "mtime": 1782336091.2531888,
     "ast_hash": "638a800ba4c6c0d597df827fdf7848cf",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft_white_ramadan.png": {
-    "mtime": 1782297664.51578,
+    "mtime": 1782336091.2531888,
     "ast_hash": "703354878805e8d341e697c75a83b367",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/search.PNG": {
-    "mtime": 1782297664.6668212,
+    "mtime": 1782336091.3935618,
     "ast_hash": "529740c6b227e97ed27fe797406d735f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/youtube.png": {
-    "mtime": 1782297665.1843174,
+    "mtime": 1782336091.9178467,
     "ast_hash": "3cb8adc33ce532807aacf1bfaffbf31b",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/code-conventions.json": {
-    "mtime": 1782297664.0120385,
+    "mtime": 1782336090.791944,
     "ast_hash": "5c1eb980b386ba44323d9741b8c8ae28",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/powershell-shell-sensitive-args.json": {
-    "mtime": 1782297664.032919,
+    "mtime": 1782336090.811944,
     "ast_hash": "8dc62f50fbf74b5780312307bf6d5d19",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/python-script-tests-use-python310.json": {
-    "mtime": 1782297664.033836,
+    "mtime": 1782336090.811944,
     "ast_hash": "8a32ee6f7da59baada769731840abe4e",
     "semantic_hash": ""
   },
   ".memory/memory/sources/agents.json": {
-    "mtime": 1782297664.0379694,
+    "mtime": 1782336090.815945,
     "ast_hash": "8b0ad0f82cc956b5c4a05f5413c6bd8e",
     "semantic_hash": ""
   },
   ".memory/memory/sources/project-readme.json": {
-    "mtime": 1782297664.0379694,
+    "mtime": 1782336090.8169446,
     "ast_hash": "ca2b3ea34f094d5d7104225b910a6db5",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/agent-guidance.json": {
-    "mtime": 1782297664.0389693,
+    "mtime": 1782336090.8179443,
     "ast_hash": "d47a35a97e29fa13de28e5ddd1170621",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/conventions-quality.json": {
-    "mtime": 1782297664.0399694,
+    "mtime": 1782336090.8179443,
     "ast_hash": "e01f337f7d01373f294a3ace9cd11f7f",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/product-intent.json": {
-    "mtime": 1782297664.0409694,
+    "mtime": 1782336090.8189442,
     "ast_hash": "d4a438fd7d6896393b8026b284735904",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/create-and-report-pr-after-tasks.json": {
-    "mtime": 1782297664.0422184,
+    "mtime": 1782336090.8199441,
     "ast_hash": "b1ce8ac2e98f89838415a25fa522171b",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/minimal-nonredundant-validation.json": {
-    "mtime": 1782297664.0462532,
+    "mtime": 1782336090.822944,
     "ast_hash": "5834b369159038bc89a34e916e9ad7ee",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/run-local-e2e-jobs-in-a-dedicated-workflow.json": {
-    "mtime": 1782297664.0482535,
+    "mtime": 1782336090.8249443,
     "ast_hash": "4233688d717e8e7aaaa1b424ce1ebb87",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/share-memory-and-graphify-assets.json": {
-    "mtime": 1782297664.0492537,
+    "mtime": 1782336090.8259442,
     "ast_hash": "270cbf117e0047f707f3eaaae9494195",
     "semantic_hash": ""
   },
   ".memory/relations/constraint-code-conventions-affects-project-shaft-engine.json": {
-    "mtime": 1782297664.0532534,
+    "mtime": 1782336090.8301494,
     "ast_hash": "a4dd873eb9a3cb41398d92073ddd37a5",
     "semantic_hash": ""
   },
   ".memory/relations/constraint-code-conventions-derived-from-source-agents.json": {
-    "mtime": 1782297664.0542533,
+    "mtime": 1782336090.8311496,
     "ast_hash": "958da5cacc1ad227cbfc52bdcf3696cd",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-agent-guidance-derived-from-source-agents.json": {
-    "mtime": 1782297664.055253,
+    "mtime": 1782336090.8321493,
     "ast_hash": "ceda73fdfa718f949c1c636e33d993d6",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-agent-guidance-documents-project-shaft-engine.json": {
-    "mtime": 1782297664.055253,
+    "mtime": 1782336090.8321493,
     "ast_hash": "c17d6760da1e494ee12d62ea6cdb0e35",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-conventions-quality-derived-from-source-agents.json": {
-    "mtime": 1782297664.0562537,
+    "mtime": 1782336090.8321493,
     "ast_hash": "30f6ab1fb433f92e0f1bddb152ae89a9",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-conventions-quality-documents-project-shaft-engine.json": {
-    "mtime": 1782297664.0562537,
+    "mtime": 1782336090.83315,
     "ast_hash": "7807b3da7440b26c5ffd411d2d58c8f4",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-product-intent-derived-from-source-project-readme.json": {
-    "mtime": 1782297664.0562537,
+    "mtime": 1782336090.83315,
     "ast_hash": "73f46fd60b629fac27ef5b2bf7edaade",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-product-intent-summarizes-project-shaft-engine.json": {
-    "mtime": 1782297664.0572538,
+    "mtime": 1782336090.83315,
     "ast_hash": "d75f2b943c7caec5bad6edbdd2d3ba42",
     "semantic_hash": ""
   },
   ".memory/relations/workflow-create-and-report-pr-after-tasks-documents-project-shaft-engine.json": {
-    "mtime": 1782297664.0572538,
+    "mtime": 1782336090.8341496,
     "ast_hash": "15037f0f0f4f2072b4ac7452185b7abd",
     "semantic_hash": ""
   },
   ".memory/relations/workflow-share-memory-and-graphify-assets-documents-project-shaft-engine.json": {
-    "mtime": 1782297664.0572538,
+    "mtime": 1782336090.8341496,
     "ast_hash": "15a6e2ed7ed54d18ca1a9ba283e9997f",
     "semantic_hash": ""
   },
   "tests/scripts/test_install_shaft_mcp.py": {
-    "mtime": 1782297665.3056395,
+    "mtime": 1782336092.0293846,
     "ast_hash": "60ad6539ba363c9a02ad6f85bf1660e3",
     "semantic_hash": ""
   },
   ".github/workflows/e2eLocalTests.yml": {
-    "mtime": 1782297664.0040379,
+    "mtime": 1782336090.7819438,
     "ast_hash": "1327238970e80758934fe016c4e51854",
     "semantic_hash": ""
   },
   ".github/workflows/lambdatestTests.yml": {
-    "mtime": 1782297664.0050387,
+    "mtime": 1782336090.7839441,
     "ast_hash": "89d31b06f66ca3f0545f6d5268710de3",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/code-conventions.md": {
-    "mtime": 1782297664.013038,
+    "mtime": 1782336090.791944,
     "ast_hash": "ebb3f6f7caa3501cab774c1d8e7598a8",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/powershell-shell-sensitive-args.md": {
-    "mtime": 1782297664.0332594,
+    "mtime": 1782336090.811944,
     "ast_hash": "81604c5c66f8f3f2bc96d6fb9b63e0c5",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/python-script-tests-use-python310.md": {
-    "mtime": 1782297664.033836,
+    "mtime": 1782336090.812944,
     "ast_hash": "2d9e074325b05036e1e50562a080a785",
     "semantic_hash": ""
   },
   ".memory/memory/sources/agents.md": {
-    "mtime": 1782297664.0379694,
+    "mtime": 1782336090.815945,
     "ast_hash": "19d8593d2fbf9941204ff6257b7bbcce",
     "semantic_hash": ""
   },
   ".memory/memory/sources/project-readme.md": {
-    "mtime": 1782297664.0389693,
+    "mtime": 1782336090.8169446,
     "ast_hash": "1644c82d3ce411b7b776e14e4a3fc832",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/agent-guidance.md": {
-    "mtime": 1782297664.0399694,
+    "mtime": 1782336090.8179443,
     "ast_hash": "d4ab69ed6a4ee277d2f623592f5aa503",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/conventions-quality.md": {
-    "mtime": 1782297664.0409694,
+    "mtime": 1782336090.8189442,
     "ast_hash": "41403aeb6cfbff5b7ab4193dff8bac41",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/product-intent.md": {
-    "mtime": 1782297664.041555,
+    "mtime": 1782336090.8189442,
     "ast_hash": "072645010c12d96012e55a07eb8462a9",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/create-and-report-pr-after-tasks.md": {
-    "mtime": 1782297664.04325,
+    "mtime": 1782336090.8199441,
     "ast_hash": "1bcb51f3f1e5269b61bba6ea8533ea49",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/minimal-nonredundant-validation.md": {
-    "mtime": 1782297664.0472536,
+    "mtime": 1782336090.823944,
     "ast_hash": "431e4f5cc6afab68b429c36739dce7c3",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/run-local-e2e-jobs-in-a-dedicated-workflow.md": {
-    "mtime": 1782297664.0482535,
+    "mtime": 1782336090.8249443,
     "ast_hash": "e21cf1d1253c1b9d9646050d8437c555",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/share-memory-and-graphify-assets.md": {
-    "mtime": 1782297664.0502539,
+    "mtime": 1782336090.8269455,
     "ast_hash": "44176d6d1036c08d58f9036a56af0a8c",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/delegate-only-when-needed-for-correctness.json": {
-    "mtime": 1782297664.04325,
+    "mtime": 1782336090.8209438,
     "ast_hash": "89452a15b27dbf71a8d319b68e201a4d",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/delegate-only-when-needed-for-correctness.md": {
-    "mtime": 1782297664.0442495,
+    "mtime": 1782336090.8209438,
     "ast_hash": "b07cf652dddba20866b2ecbbe4e06136",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/heal-ai-reranking-trigger-gated.json": {
-    "mtime": 1782297664.019159,
+    "mtime": 1782336090.7979457,
     "ast_hash": "7fcb87f0b2bfa2530bca51fdb28c07cb",
     "semantic_hash": ""
   },
   ".memory/memory/facts/deterministic-ai-test-lifecycle-artifacts.json": {
-    "mtime": 1782297664.0269196,
+    "mtime": 1782336090.8069441,
     "ast_hash": "59d40c4f3bdb5eccd637c1a59cfc7abf",
     "semantic_hash": ""
   },
   ".memory/relations/decision-heal-ai-reranking-trigger-gated-affects-fact-deterministic-ai-test-lifecycle-artifacts.json": {
-    "mtime": 1782297664.0542533,
+    "mtime": 1782336090.8311496,
     "ast_hash": "a31117254d3ebfc8e782e8a3b3a3808d",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureReview.java": {
-    "mtime": 1782297664.1729105,
+    "mtime": 1782336090.9419332,
     "ast_hash": "edf1b9f86131db1f54975d4d21953670",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/resources/schema/shaft-capture-review-1.0.schema.json": {
-    "mtime": 1782297664.1878803,
+    "mtime": 1782336090.955956,
     "ast_hash": "df3ea8b3fa2bdeb83db359e221a56e29",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorTriage.java": {
-    "mtime": 1782297664.213037,
+    "mtime": 1782336090.977458,
     "ast_hash": "9c84db99fd873d863313e37404fda544",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/ExecutionIntelligence.java": {
-    "mtime": 1782297664.2150369,
+    "mtime": 1782336090.9794583,
     "ast_hash": "69b01ed194ab82a4e2163acfc9907648",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-doctor-triage-1.0.schema.json": {
-    "mtime": 1782297664.2266676,
+    "mtime": 1782336090.9884577,
     "ast_hash": "76dc165df20999b05b4f8e442e90490f",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-execution-intelligence-1.0.schema.json": {
-    "mtime": 1782297664.2276683,
+    "mtime": 1782336090.9894586,
     "ast_hash": "533f56c3ee115ce73ed329d13851b7cd",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/heal-ai-reranking-trigger-gated.md": {
-    "mtime": 1782297664.019159,
+    "mtime": 1782336090.7979457,
     "ast_hash": "9e61fd0bec7fb5de29c2d5a2c6500e7c",
     "semantic_hash": ""
   },
   ".memory/memory/facts/deterministic-ai-test-lifecycle-artifacts.md": {
-    "mtime": 1782297664.02792,
+    "mtime": 1782336090.8069441,
     "ast_hash": "db58ab1ad8c9a772b56404a0460feb8c",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/surefire-testng-bootstrap-validation-after-pr2947.json": {
-    "mtime": 1782297664.0512536,
+    "mtime": 1782336090.8281448,
     "ast_hash": "d381b7c66b8e42deb7eea0e7e7daf39e",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/use-memory-and-graphify-through-cli-in-codex.json": {
-    "mtime": 1782297664.0522535,
+    "mtime": 1782336090.8291495,
     "ast_hash": "58123f0adb9df1766a0ab999904f3cfa",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/properties/internal/PropertyFileManagerInternalUnitTest.java": {
-    "mtime": 1782297664.5437808,
+    "mtime": 1782336091.2807267,
     "ast_hash": "2bf9ff6704809d4685a9b285f3feff6b",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/surefire-testng-bootstrap-validation-after-pr2947.md": {
-    "mtime": 1782297664.0512536,
+    "mtime": 1782336090.8291495,
     "ast_hash": "e6782b8247772991081386a66f9a7e36",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/use-memory-and-graphify-through-cli-in-codex.md": {
-    "mtime": 1782297664.0532534,
+    "mtime": 1782336090.8301494,
     "ast_hash": "e251c9a4a352674f9088647ddf3b1478",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/delegate-when-unable.json": {
-    "mtime": 1782297664.0170503,
+    "mtime": 1782336090.7959466,
     "ast_hash": "07b7ba8f381ec4cc14777d7ac55c9e78",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/delegate-when-unable.md": {
-    "mtime": 1782297664.0170503,
+    "mtime": 1782336090.7959466,
     "ast_hash": "c593eb7cd55c53cb9369998a0173f6d5",
     "semantic_hash": ""
   },
   "shaft-browserstack/src/test/java/com/shaft/integration/browserstack/BrowserStackModuleTest.java": {
-    "mtime": 1782297664.1600761,
+    "mtime": 1782336090.9299326,
     "ast_hash": "1b4f4b227bd1f4fa0f362a15c970a8d5",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/cli/CaptureCliTest.java": {
-    "mtime": 1782297664.1908803,
+    "mtime": 1782336090.9579484,
     "ast_hash": "cb0124fcb58676542f14eb61f60dc874",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/collector/CaptureCollectorUtilityTest.java": {
-    "mtime": 1782297664.1915076,
+    "mtime": 1782336090.9579484,
     "ast_hash": "aafe9ad32e00bfaa8447cc2f3f006a9d",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/control/CaptureControlFilesTest.java": {
-    "mtime": 1782297664.1920755,
+    "mtime": 1782336090.959453,
     "ast_hash": "7531aa93c2d32105644864a1e152c070",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/control/CaptureControlServerClientTest.java": {
-    "mtime": 1782297664.1920755,
+    "mtime": 1782336090.959453,
     "ast_hash": "c64a81e01083fbb8214913c60a910a80",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureManagerLifecycleTest.java": {
-    "mtime": 1782297664.1963358,
+    "mtime": 1782336090.9634578,
     "ast_hash": "848dbc7ec058d8787c4e36506f75dc3c",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpNoDriverServiceTest.java": {
-    "mtime": 1782297665.244284,
+    "mtime": 1782336091.9713256,
     "ast_hash": "eb49f23fde252c361ff9cae194f9d52a",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpResultRecordsTest.java": {
-    "mtime": 1782297665.2452836,
+    "mtime": 1782336091.9723253,
     "ast_hash": "29c8c0b77c7458ee2ff5092bb54d82ba",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpServiceHelperTest.java": {
-    "mtime": 1782297665.2452836,
+    "mtime": 1782336091.9723253,
     "ast_hash": "067f1647636d500429d01c8469ada10e",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/MobileServiceConfigurationTest.java": {
-    "mtime": 1782297665.246284,
+    "mtime": 1782336091.9733255,
     "ast_hash": "a43da559c47669d1dccf212f39c1bc1f",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiValueObjectsTest.java": {
-    "mtime": 1782297665.278044,
+    "mtime": 1782336092.002385,
     "ast_hash": "a16fbefe28c40b65f9c55f41c0ba9e98",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/config/ProviderConfigurationTest.java": {
-    "mtime": 1782297665.2790434,
+    "mtime": 1782336092.002385,
     "ast_hash": "70d00166ef741dd25140bb1036308a87",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/json/JsonSchemaValidatorTest.java": {
-    "mtime": 1782297665.2790434,
+    "mtime": 1782336092.003385,
     "ast_hash": "2fd93ff273c685e80b68615e7dd0a1ba",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/element-actions-normalize-allure-locator-metadata.json": {
-    "mtime": 1782297664.0170503,
+    "mtime": 1782336090.7969437,
     "ast_hash": "c4534782cf2b7fccd3489053bb267f1d",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/element-actions-normalize-allure-locator-metadata.md": {
-    "mtime": 1782297664.0181627,
+    "mtime": 1782336090.7969437,
     "ast_hash": "ad0b39840f727ef91570221e283b668c",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/run-local-validation-without-opening-reports.json": {
-    "mtime": 1782297664.0482535,
+    "mtime": 1782336090.8259442,
     "ast_hash": "15d81102c128be197dc774dfdfc4ff37",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/JunitExtension.java": {
-    "mtime": 1782297664.2957351,
-    "ast_hash": "614017a78aa8b3ff0ba96684f704199d",
+    "mtime": 1782336091.0526834,
+    "ast_hash": "b3d96b8b526edf1e5571f94a3f43c9ee",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/ExecutionCountsTracker.java": {
-    "mtime": 1782297664.2977357,
+    "mtime": 1782336091.0562718,
     "ast_hash": "ca195dba6330c14afb2e1f42c85be2d6",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/ExecutionFailureContext.java": {
-    "mtime": 1782297664.2987356,
+    "mtime": 1782336091.0562718,
     "ast_hash": "713f781253d014b50ab39c2d5e3dff20",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/ExecutionLifecycleHelper.java": {
-    "mtime": 1782297664.2987356,
+    "mtime": 1782336091.0562718,
     "ast_hash": "1c6223b9a17c44a26f566ddbb26b7dfc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/TestExecutionInfo.java": {
-    "mtime": 1782297664.3006544,
+    "mtime": 1782336091.0582714,
     "ast_hash": "4dc45054b39710f3e47d2c2dd511d0be",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportContext.java": {
-    "mtime": 1782297664.3327506,
+    "mtime": 1782336091.0868485,
     "ast_hash": "bae703d75cdc2080ca566d3889121c0f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/AssertionFailureFormatter.java": {
-    "mtime": 1782297664.3367496,
+    "mtime": 1782336091.089849,
     "ast_hash": "93f73d44c5ada84c4d39cb3c8d02e6ad",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitApiSmokeTest.java": {
-    "mtime": 1782297664.5547845,
+    "mtime": 1782336091.2897263,
     "ast_hash": "7f1c4d2d140d35d6dab9ffb286095937",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitCoreAssertionDependencyGuardTest.java": {
-    "mtime": 1782297664.5547845,
+    "mtime": 1782336091.2897263,
     "ast_hash": "6fdc9b27e9c39b43169a4187d2540f89",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitCoreAssertionMigrationTest.java": {
-    "mtime": 1782297664.5557847,
+    "mtime": 1782336091.290727,
     "ast_hash": "60e0a7f567ab6e030106b5cdd4e86f4c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitDatabaseSmokeTest.java": {
-    "mtime": 1782297664.5557847,
+    "mtime": 1782336091.290727,
     "ast_hash": "6914346d28a229d411da8e85825e73d9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitProjectStructureManagerTest.java": {
-    "mtime": 1782297664.5567849,
+    "mtime": 1782336091.2917392,
     "ast_hash": "42fc75d8ff6752aff87a5c0509af87d6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitReportContextTest.java": {
-    "mtime": 1782297664.5567849,
+    "mtime": 1782336091.2917392,
     "ast_hash": "972a21792ad81f9c9d71f3499659970b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitWebGuiSmokeTest.java": {
-    "mtime": 1782297664.5577838,
+    "mtime": 1782336091.2927272,
     "ast_hash": "1d9608b8cc22fe144bb55acffca129de",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/run-local-validation-without-opening-reports.md": {
-    "mtime": 1782297664.0492537,
+    "mtime": 1782336090.8259442,
     "ast_hash": "3bc1e6a92cc0abd9587fbef7f1b389b7",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureWorkbenchHtml.java": {
-    "mtime": 1782297664.1739097,
+    "mtime": 1782336090.942943,
     "ast_hash": "59b413fb0057eadd1c6607fc570c92a2",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CodegenFeatureCatalog.java": {
-    "mtime": 1782297664.1739097,
+    "mtime": 1782336090.942943,
     "ast_hash": "c96dc1481b8eb2e4876301542c73040d",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureStartOptions.java": {
-    "mtime": 1782297664.1848805,
+    "mtime": 1782336090.9519498,
     "ast_hash": "08bdd33c70c75a9c693eae92d4e613af",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderControlTest.java": {
-    "mtime": 1782297664.198336,
+    "mtime": 1782336090.9644582,
     "ast_hash": "93adf57550a29b8c7f4ed7e4f1d1c1a6",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/use-official-docs-search-index-for-shaft-mcp-guide-search.json": {
-    "mtime": 1782297664.0248985,
+    "mtime": 1782336090.8039436,
     "ast_hash": "0f6b8cc0ea6f5f8ef37b0c0c2ab043f6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelperNewPatternCoverageUnitTest.java": {
-    "mtime": 1782297664.5517845,
+    "mtime": 1782336091.2867262,
     "ast_hash": "7873aebb355497dd20a035a224681d59",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/GuideService.java": {
-    "mtime": 1782297665.2133157,
+    "mtime": 1782336091.9443076,
     "ast_hash": "c2b2a7d31dd0c42a0c11b578785f4a22",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/HealerService.java": {
-    "mtime": 1782297665.2143164,
+    "mtime": 1782336091.9443076,
     "ast_hash": "b47a582f8b342bc3d3fdbf6d6c054b6c",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpGuideMatch.java": {
-    "mtime": 1782297665.2204,
+    "mtime": 1782336091.9493124,
     "ast_hash": "e594a2f11a16113954bbf865aec5dc04",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpGuideSearchResult.java": {
-    "mtime": 1782297665.2204,
+    "mtime": 1782336091.9503124,
     "ast_hash": "7c67b9c8caa6eb0e292f3cf578a26ec4",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpHealerAttemptResult.java": {
-    "mtime": 1782297665.2204,
+    "mtime": 1782336091.9503124,
     "ast_hash": "ae920e7e3a41435e15a8065dfa005012",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpHealerRunResult.java": {
-    "mtime": 1782297665.2213988,
+    "mtime": 1782336091.951312,
     "ast_hash": "053e897a9732fd3a4bd32f64ce7bc67a",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/GuideServiceTest.java": {
-    "mtime": 1782297665.2422862,
+    "mtime": 1782336091.968325,
     "ast_hash": "18508bf8f31805be0dc13aed25dde251",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/HealerServiceTest.java": {
-    "mtime": 1782297665.2422862,
+    "mtime": 1782336091.9693258,
     "ast_hash": "7fc7b412d1226508622d107eb735a350",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/use-official-docs-search-index-for-shaft-mcp-guide-search.md": {
-    "mtime": 1782297664.025245,
+    "mtime": 1782336090.804944,
     "ast_hash": "3ef2a346dc83ce9efb7c84684d1122ff",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/NetworkInterceptionRequestBuilder.java": {
-    "mtime": 1782297664.2548888,
+    "mtime": 1782336091.0146444,
     "ast_hash": "ca69b6efe17fef8a8fd976978f5b0564",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserNetworkInterceptionRule.java": {
-    "mtime": 1782297664.2558901,
+    "mtime": 1782336091.016644,
     "ast_hash": "5d5037cd2ee0dddd957a7cbbad537ce8",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserNetworkInterceptor.java": {
-    "mtime": 1782297664.2568898,
+    "mtime": 1782336091.016644,
     "ast_hash": "a1b2edd6510698c0981b1156b7c9414b",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/prefer-shaft-api-builder-facade-for-rest-work.json": {
-    "mtime": 1782297664.0221603,
+    "mtime": 1782336090.801944,
     "ast_hash": "6c5f689fe277f7670d815e22bb7a6fdf",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpAndroidEmulatorProposal.java": {
-    "mtime": 1782297665.2153158,
+    "mtime": 1782336091.9453125,
     "ast_hash": "c7c477a347aff6fa27cec866efffb105",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpAppiumCommandRecorder.java": {
-    "mtime": 1782297665.2163146,
+    "mtime": 1782336091.9453125,
     "ast_hash": "83ee39e10ac7764d6353da3484b07ac4",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpAppiumInspectorProxy.java": {
-    "mtime": 1782297665.2163146,
+    "mtime": 1782336091.9463127,
     "ast_hash": "8dae6bce980636bfd5096bc546e09f1a",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileCode.java": {
-    "mtime": 1782297665.222398,
+    "mtime": 1782336091.9526577,
     "ast_hash": "84fa9fe33b12aa2b45a47c4c02901b49",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileDevice.java": {
-    "mtime": 1782297665.2233987,
+    "mtime": 1782336091.9526577,
     "ast_hash": "95ab5c7a8108a17cc4b795be825ca465",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInspectorPlan.java": {
-    "mtime": 1782297665.2233987,
+    "mtime": 1782336091.953663,
     "ast_hash": "e12fc9a2d07a08597ec6bf1400658e16",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInspectorRecordingService.java": {
-    "mtime": 1782297665.224846,
+    "mtime": 1782336091.953663,
     "ast_hash": "756fff2b3865bf7cd73eeacdb4edcc40",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInspectorRecordingStatus.java": {
-    "mtime": 1782297665.2251685,
+    "mtime": 1782336091.953663,
     "ast_hash": "b5e65cd7d3d46e313d788ae3bd017617",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainService.java": {
-    "mtime": 1782297665.22887,
+    "mtime": 1782336091.9572487,
     "ast_hash": "620a83d2cfbb35eaf8cf1ddb848a3fe5",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainStatus.java": {
-    "mtime": 1782297665.22887,
+    "mtime": 1782336091.9572487,
     "ast_hash": "14c3c586d9e84bef7eca75197de48e83",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpProcessRunner.java": {
-    "mtime": 1782297665.2308702,
+    "mtime": 1782336091.9593203,
     "ast_hash": "c2fbbd25f86523263ea6ee980a280f79",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpAppiumCommandRecorderTest.java": {
-    "mtime": 1782297665.2422862,
+    "mtime": 1782336091.9693258,
     "ast_hash": "193aea409a6adf4968070c82ac9a575d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpMobileInspectorRecordingServiceTest.java": {
-    "mtime": 1782297665.2432845,
+    "mtime": 1782336091.9703252,
     "ast_hash": "debd3764c9cd0a897ae1861c565006d9",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpMobileToolchainServiceTest.java": {
-    "mtime": 1782297665.244284,
+    "mtime": 1782336091.9703252,
     "ast_hash": "0be311e4c93392ece2f42dbc7ae5ef4a",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/prefer-shaft-api-builder-facade-for-rest-work.md": {
-    "mtime": 1782297664.0221603,
+    "mtime": 1782336090.801944,
     "ast_hash": "1e26526229bf60c93d0d4a1302628d55",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/graphify-updates-use-installed-cli-subcommands.json": {
-    "mtime": 1782297664.0309193,
+    "mtime": 1782336090.809944,
     "ast_hash": "3777cfe2bfe0c47a8179ecf78953affc",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/memory-saves-use-intent-first-json-on-stdin.json": {
-    "mtime": 1782297664.031919,
+    "mtime": 1782336090.8109438,
     "ast_hash": "09006716c9b359bb2c0a5376fe86d6b4",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCodeGuardrailResult.java": {
-    "mtime": 1782297665.2183993,
+    "mtime": 1782336091.948313,
     "ast_hash": "54ee97ffb919ff90d02c8897f95b2322",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCodeGuardrailViolation.java": {
-    "mtime": 1782297665.2193987,
+    "mtime": 1782336091.9493124,
     "ast_hash": "7c8ee205d8b5b7883c0975f388f0ebfb",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpScenarioCatalogResult.java": {
-    "mtime": 1782297665.23187,
+    "mtime": 1782336091.9603252,
     "ast_hash": "c32b97f036cfd501afe6d92133a405b4",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpTestAutomationScenario.java": {
-    "mtime": 1782297665.2331953,
+    "mtime": 1782336091.9603252,
     "ast_hash": "b7cb78f776b05d338755f7eea2b17463",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/TestAutomationService.java": {
-    "mtime": 1782297665.236284,
+    "mtime": 1782336091.963325,
     "ast_hash": "e72f8c898f4fad220abd3edee838ad88",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/TestAutomationServiceTest.java": {
-    "mtime": 1782297665.2482867,
+    "mtime": 1782336091.9753847,
     "ast_hash": "22fa5ffdff7d7e8c5b272dc4a567abd8",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/graphify-updates-use-installed-cli-subcommands.md": {
-    "mtime": 1782297664.0309193,
+    "mtime": 1782336090.809944,
     "ast_hash": "019a7f4d72491d045dd5b85ed6c9a0bc",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/memory-saves-use-intent-first-json-on-stdin.md": {
-    "mtime": 1782297664.031919,
+    "mtime": 1782336090.8109438,
     "ast_hash": "1af84800821947fd0ed9d3998cd81d34",
     "semantic_hash": ""
   },
   ".memory/memory/facts/mcp-test-automation-scenario-catalog.json": {
-    "mtime": 1782297664.02792,
+    "mtime": 1782336090.8069441,
     "ast_hash": "b69ee2103915fbfbf63a6b84e7ea7cb4",
     "semantic_hash": ""
   },
   ".memory/memory/facts/mcp-test-automation-scenario-catalog.md": {
-    "mtime": 1782297664.02792,
+    "mtime": 1782336090.8079457,
     "ast_hash": "d5b6dadc1f57217744225be57c50dcd8",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/BrowserAssertions.java": {
-    "mtime": 1782297664.2592444,
+    "mtime": 1782336091.0196457,
     "ast_hash": "b4726dd624bfff061eed882a42302cd1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/DriverAssertions.java": {
-    "mtime": 1782297664.2592444,
+    "mtime": 1782336091.0196457,
     "ast_hash": "d36427b7494516943c576a3be5a3b835",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/DriverVerifications.java": {
-    "mtime": 1782297664.2603757,
+    "mtime": 1782336091.0206468,
     "ast_hash": "3e5ab02944577b455432aa6428a6de83",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/ElementAssertions.java": {
-    "mtime": 1782297664.261376,
+    "mtime": 1782336091.0216446,
     "ast_hash": "b7023bb7c5a5e8c4ede970cedec1f658",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/ShaftLocator.java": {
-    "mtime": 1782297664.261376,
+    "mtime": 1782336091.0216446,
     "ast_hash": "288258c16fbeb6c7685c7c07f1864c7c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/browser/BrowserActions.java": {
-    "mtime": 1782297664.2856746,
+    "mtime": 1782336091.0436532,
     "ast_hash": "dbf7845b6462bcc2f2af63e7f706e381",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/element/AlertActions.java": {
-    "mtime": 1782297664.2866738,
+    "mtime": 1782336091.0436532,
     "ast_hash": "fef3e09be9ac657711933a837b50ab7b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/element/ElementActions.java": {
-    "mtime": 1782297664.2866738,
+    "mtime": 1782336091.0446594,
     "ast_hash": "03f8230f6ca0d6bf117592f2f51429a4",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSession.java": {
-    "mtime": 1782297664.2876732,
+    "mtime": 1782336091.045658,
     "ast_hash": "3fb54fd5efb353a3f7093a2852baef82",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSessionFactory.java": {
-    "mtime": 1782297664.2886736,
+    "mtime": 1782336091.045658,
     "ast_hash": "3814686ba83cf9db8028599f03a98aa2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSessionManager.java": {
-    "mtime": 1782297664.2886736,
+    "mtime": 1782336091.0466578,
     "ast_hash": "e6a93da7a78633257ba11063eb38de16",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightTraceManager.java": {
-    "mtime": 1782297664.2896736,
+    "mtime": 1782336091.0466578,
     "ast_hash": "971e323f2d97caa717c84b8b94d144e8",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightBrowserValidationsBuilder.java": {
-    "mtime": 1782297664.2906728,
+    "mtime": 1782336091.047658,
     "ast_hash": "45d289f3218bfe3c37216172b9d25551",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightDriverAssertions.java": {
-    "mtime": 1782297664.2906728,
+    "mtime": 1782336091.047658,
     "ast_hash": "aa1a8b02b65be2902eefa6a73a442468",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightDriverVerifications.java": {
-    "mtime": 1782297664.2915635,
+    "mtime": 1782336091.0486577,
     "ast_hash": "10f477a754e6e569d3fc2352f603a64f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightElementValidationsBuilder.java": {
-    "mtime": 1782297664.2915635,
+    "mtime": 1782336091.049678,
     "ast_hash": "aab82c30ce43aa221e89926d4f68615f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Playwright.java": {
-    "mtime": 1782297664.3130324,
+    "mtime": 1782336091.068783,
     "ast_hash": "98c4cd280789a493e2cc63fc112d8b4d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/natural/DeterministicNaturalActionPlannerTest.java": {
-    "mtime": 1782297664.5357795,
+    "mtime": 1782336091.2727597,
     "ast_hash": "a090df735279f758b04583c539c80cd9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/GUIInterfaceCompatibilityCoverageUnitTest.java": {
-    "mtime": 1782297664.6390703,
+    "mtime": 1782336091.362841,
     "ast_hash": "a11d2c0437461819d815b6bada986ee9",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/delegate-broadly-to-spark.json": {
-    "mtime": 1782297664.013038,
+    "mtime": 1782336090.7929437,
     "ast_hash": "064879ac7229a1eeeb1646bf93fb6140",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/use-override-annotations.json": {
-    "mtime": 1782297664.0258276,
+    "mtime": 1782336090.804944,
     "ast_hash": "977907829a63b92ea89922f1550c2c7e",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/delegate-broadly-to-spark.md": {
-    "mtime": 1782297664.0140386,
+    "mtime": 1782336090.7929437,
     "ast_hash": "cce72bac4ae644a5bcf286e117c6fb90",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/use-override-annotations.md": {
-    "mtime": 1782297664.0258276,
+    "mtime": 1782336090.8059437,
     "ast_hash": "d7a5198a2f5eb752cee7fc2fad6b545b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/AlertActionsContract.java": {
-    "mtime": 1782297664.2582524,
+    "mtime": 1782336091.018644,
     "ast_hash": "0f7aa759db4842f82d61b19dfa68301a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/BrowserActionsContract.java": {
-    "mtime": 1782297664.2585878,
+    "mtime": 1782336091.018644,
     "ast_hash": "fe638f221c529e25949a39c187b30a49",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/ElementActionsContract.java": {
-    "mtime": 1782297664.261376,
+    "mtime": 1782336091.0206468,
     "ast_hash": "c0254142e8a4ee94e8d439d10853e0f1",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/gui-driver-facade-alias.json": {
-    "mtime": 1782297664.0181627,
+    "mtime": 1782336090.7969437,
     "ast_hash": "112ffef31b2e7dcb5a67b10e4f252bcb",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/playwright-entrypoint-casing.json": {
-    "mtime": 1782297664.0211606,
+    "mtime": 1782336090.8009462,
     "ast_hash": "faaf90924ddd4bfa4d6d5ddf68f8a956",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/DriverContract.java": {
-    "mtime": 1782297664.2603757,
+    "mtime": 1782336091.0206468,
     "ast_hash": "4c8a0740e8dadf4b4ea33022614f731c",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/gui-driver-facade-alias.md": {
-    "mtime": 1782297664.019159,
+    "mtime": 1782336090.7979457,
     "ast_hash": "1d08f73622a67f46dd47f80a88936c27",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/playwright-entrypoint-casing.md": {
-    "mtime": 1782297664.0211606,
+    "mtime": 1782336090.801944,
     "ast_hash": "c02315cea77a741aa8857863c3ae432a",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/keep-shaft-mcp-webdriver-default-with-opt-in-playwright-tools.json": {
-    "mtime": 1782297664.0201619,
+    "mtime": 1782336090.7989438,
     "ast_hash": "5fa44d4831d7aa7b8e7ef2eb5bb9faa9",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightDeviceDescriptor.java": {
-    "mtime": 1782297664.2876732,
+    "mtime": 1782336091.0446594,
     "ast_hash": "67c0996090cdbbda2d949a57a8c3db07",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/playwright/internal/PlaywrightDeviceDescriptorTest.java": {
-    "mtime": 1782297664.5387795,
+    "mtime": 1782336091.2757595,
     "ast_hash": "08d00d520b346162b36ac4c36ba1bd88",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/ChromePlaywrightActionsE2ETest.java": {
-    "mtime": 1782297664.6082146,
+    "mtime": 1782336091.3357358,
     "ast_hash": "aa83f62d13d9b32c804f9669207c5e13",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/EdgePlaywrightActionsE2ETest.java": {
-    "mtime": 1782297664.6091204,
+    "mtime": 1782336091.3357358,
     "ast_hash": "ed3fad31e9488da5adfaf259443d8ede",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/FirefoxPlaywrightActionsE2ETest.java": {
-    "mtime": 1782297664.6091204,
+    "mtime": 1782336091.336736,
     "ast_hash": "bcbdf4bb9f4467776b4d3463a8c7951c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/GalaxyS26UltraPlaywrightActionsE2ETest.java": {
-    "mtime": 1782297664.6091204,
+    "mtime": 1782336091.336736,
     "ast_hash": "4a474a6aa1007ba5af607d82b71831cc",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/IPhone17ProMaxPlaywrightActionsE2ETest.java": {
-    "mtime": 1782297664.610279,
+    "mtime": 1782336091.337736,
     "ast_hash": "8d331269ccb27a6b7e064ea85bf7990d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/PlaywrightActionsE2ETestBase.java": {
-    "mtime": 1782297664.610279,
+    "mtime": 1782336091.337736,
     "ast_hash": "7f8415867f52f4e848568a3c9f935860",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/PlaywrightMobileWebE2ETestBase.java": {
-    "mtime": 1782297664.610279,
+    "mtime": 1782336091.337736,
     "ast_hash": "3f68d06f2c61c24f184c5b17baab7054",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/WebKitPlaywrightActionsE2ETest.java": {
-    "mtime": 1782297664.6112785,
+    "mtime": 1782336091.3387368,
     "ast_hash": "f3d37b40410e79d9e42714583965241b",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpPlaywrightRecordingService.java": {
-    "mtime": 1782297665.2308702,
+    "mtime": 1782336091.9583158,
     "ast_hash": "4a4d95b97c572ad3433ceebc3bc02d3b",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/PlaywrightService.java": {
-    "mtime": 1782297665.2352836,
+    "mtime": 1782336091.963325,
     "ast_hash": "9f62abbb4a18edf9103d71503468d98d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/PlaywrightServiceTest.java": {
-    "mtime": 1782297665.2472832,
+    "mtime": 1782336091.97438,
     "ast_hash": "83323568e4bc8f319bea7e387d498f3b",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/keep-shaft-mcp-webdriver-default-with-opt-in-playwright-tools.md": {
-    "mtime": 1782297664.0201619,
+    "mtime": 1782336090.799945,
     "ast_hash": "950eec0b85d5d4997e4760869b654fe5",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/mobileViewportFixture.html": {
-    "mtime": 1782297665.1699052,
+    "mtime": 1782336091.9048538,
     "ast_hash": "8077d707d3ea303dbb6c342debf4d056",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightNativeValidationsBuilder.java": {
-    "mtime": 1782297664.2925794,
+    "mtime": 1782336091.050688,
     "ast_hash": "24fe26210c4236f7eb3ca4da2592a314",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightValidationsExecutor.java": {
-    "mtime": 1782297664.2925794,
+    "mtime": 1782336091.050688,
     "ast_hash": "c9d5522d2e07ebf4722554e4eddae4c1",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_documentation_boundaries.py": {
-    "mtime": 1782297665.3081937,
+    "mtime": 1782336092.0313852,
     "ast_hash": "931d4c107349f89419e24eb8a54bc12a",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_shaft_mcp_configuration.py": {
-    "mtime": 1782297665.3104923,
+    "mtime": 1782336092.033386,
     "ast_hash": "595a0f83f71c9019bd43f91982ee7ec0",
     "semantic_hash": ""
   },
   ".agents/skills/shaft-marketing-ad-producer/SKILL.md": {
-    "mtime": 1782297663.9870381,
+    "mtime": 1782336090.763394,
     "ast_hash": "85e6b59cd7192b33185172d1e2737e3a",
     "semantic_hash": ""
   },
   ".agents/skills/shaft-marketing-ad-producer/agents/openai.yaml": {
-    "mtime": 1782297663.988038,
+    "mtime": 1782336090.764394,
     "ast_hash": "5e1f289ca493111b43c4b5fb5c149083",
     "semantic_hash": ""
   },
   ".codex/superpowers/plans/2026-06-23-stability-first-mcp-engine-implementation.txt": {
-    "mtime": 1782297663.9890375,
+    "mtime": 1782336090.7663934,
     "ast_hash": "767575f3fdfbc71c447912068f5506ef",
     "semantic_hash": ""
   },
   ".codex/superpowers/specs/2026-06-23-stability-first-mcp-engine-design.txt": {
-    "mtime": 1782297663.9900372,
+    "mtime": 1782336090.7663934,
     "ast_hash": "bd7f87426277e00520d3fbbbb4eda3d1",
     "semantic_hash": ""
   },
   ".github/skills/shaft-marketing-ad-producer/SKILL.md": {
-    "mtime": 1782297664.0020375,
+    "mtime": 1782336090.780016,
     "ast_hash": "35e3e4692f2e57fe41eaf6b7239d28c6",
     "semantic_hash": ""
   },
   ".github/workflows/README.md": {
-    "mtime": 1782297664.0030382,
+    "mtime": 1782336090.7809389,
     "ast_hash": "d91faaff0281d6f723a4647f7e8d07b2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft_standard.png": {
-    "mtime": 1782297664.5127804,
+    "mtime": 1782336091.2501903,
     "ast_hash": "5df1ce58218a4bae2d031b7faa043c03",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/do-not-wait-for-ci-unless-explicitly-requested.json": {
-    "mtime": 1782297664.0442495,
+    "mtime": 1782336090.8209438,
     "ast_hash": "e50b709e98cdd4c0a3a3af527af6d24e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/listeners/JunitExtensionLifecycleTest.java": {
-    "mtime": 1782298495.6262488,
-    "ast_hash": "106def69613a2fa7cca340d41f685784",
+    "mtime": 1782336091.2787266,
+    "ast_hash": "329dbfb8c69dc8eb155d1d5f78f2f724",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/do-not-wait-for-ci-unless-explicitly-requested.md": {
-    "mtime": 1782297664.0442495,
+    "mtime": 1782336090.821944,
     "ast_hash": "080b95f36a86f347d063dbaf3df05bed",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/talk-less-outside-planning.json": {
-    "mtime": 1782297664.0231597,
+    "mtime": 1782336090.8029437,
     "ast_hash": "347efbcab49046c0b2e1954ab867a9d8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsPlaywrightVisualTest.java": {
-    "mtime": 1782297664.5337806,
+    "mtime": 1782336091.270759,
     "ast_hash": "cf497152d7890a07d978712aee364d85",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/playwright/validation/PlaywrightElementVisualValidationTest.java": {
-    "mtime": 1782297664.5397794,
+    "mtime": 1782336091.2769551,
     "ast_hash": "4c54447746535a5444e41f037e90745d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainDiagnostic.java": {
-    "mtime": 1782297665.2278705,
+    "mtime": 1782336091.956663,
     "ast_hash": "439cee60e23d196ca8026950a7c498c3",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpCaptureCodeBlockServiceTest.java": {
-    "mtime": 1782297665.2432845,
+    "mtime": 1782336091.9703252,
     "ast_hash": "8e633fbf2210bc193b6d3b8e22aa3baa",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/talk-less-outside-planning.md": {
-    "mtime": 1782297664.0241601,
+    "mtime": 1782336090.8039436,
     "ast_hash": "5415bf34405c6f4d13a76060ed778328",
     "semantic_hash": ""
   },
-  "shaft-mcp/allure-report/summary.json": {
-    "mtime": 1782298745.7197478,
-    "ast_hash": "83c03f5079803b203779076507fdad95",
+  "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/RemoteGridPreflight.java": {
+    "mtime": 1782336091.0096393,
+    "ast_hash": "76b2a413fa9d60ce891121d6ce49e1de",
     "semantic_hash": ""
   },
-  "shaft-mcp/allurerc.yaml": {
-    "mtime": 1782298742.9673052,
-    "ast_hash": "6ea2583aa1ef52cf49c9f7d94796f069",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/0deab90b-f002-4bb3-a976-6f2bb7e6af2c-container.json": {
-    "mtime": 1782298742.817394,
-    "ast_hash": "65475174037a245c31fcb5e0d617581c",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/102f54a2-c0ad-49d1-8a11-d524a5141087-result.json": {
-    "mtime": 1782298742.8265173,
-    "ast_hash": "564c89ea0bcb31d2d438fb4569718d0c",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/225f56d5-c8d6-46e4-9ce8-d2321244540e-container.json": {
-    "mtime": 1782298742.833925,
-    "ast_hash": "53ddc17d158a19f61ff0208156eb4be1",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/23d6c339-6b2a-4936-8c25-daf797bd2e5e-container.json": {
-    "mtime": 1782298742.842328,
-    "ast_hash": "1ccfa950ac011f436ecb158365de1727",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/2992b9b3-fa3c-4ce5-8b71-85e5e609e416-container.json": {
-    "mtime": 1782298742.8493285,
-    "ast_hash": "070262bda935118f6923e5329601cd38",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/4a3e3ea5-3b0f-48dc-8b05-8ba29c746e3c-container.json": {
-    "mtime": 1782298742.857033,
-    "ast_hash": "dcaf146e7126e2a2ac3adea22caa2ca8",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/4fa35c94-afb3-4009-82c2-da72c11a647f-container.json": {
-    "mtime": 1782298742.865225,
-    "ast_hash": "1a4d91566c9d48b95b30daa8ccfdc4aa",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/5e1e5405-149a-4251-9167-1a1c3db51afa-result.json": {
-    "mtime": 1782298742.8729815,
-    "ast_hash": "c6c090e5f8ecfa62cf9497f09eac178a",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/63aee051-2b2e-43be-9bbf-783196759471-result.json": {
-    "mtime": 1782298742.8819869,
-    "ast_hash": "3557a77ed062e1020ac5ae31410aa82c",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/641e8715-a13f-4fcc-8060-ce1d9247f7b1-container.json": {
-    "mtime": 1782298742.8903108,
-    "ast_hash": "a1799ec0b710f762becbb13d1c50baa0",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/77d7676d-b53e-47d4-b237-9be9a9e78af0-result.json": {
-    "mtime": 1782298742.8989303,
-    "ast_hash": "d7b8a79eb061a75f23f8f3400dd94665",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/8278d92c-eb77-41d6-b70d-38a5c2eccabd-container.json": {
-    "mtime": 1782298742.9082167,
-    "ast_hash": "d55506cf7116cb6d29f62c5dc31958c5",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/8e2ec7a7-8e78-4409-9176-9d70872f65f8-result.json": {
-    "mtime": 1782298742.9209597,
-    "ast_hash": "0936e16662214ecc5938ba555003b3e4",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/9285b754-48c4-44d5-b896-fd579bd7e61d-container.json": {
-    "mtime": 1782298742.9289355,
-    "ast_hash": "82ca4391b8057bfc494bbde3a1a58926",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/b6080e76-8cdb-4e76-939f-9f9e2adb56a4-result.json": {
-    "mtime": 1782298742.9383729,
-    "ast_hash": "6ba3c7a96962f1f4336727a58bdf20f8",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/c675f2e8-89ab-4bb4-aa1a-84d93088f470-result.json": {
-    "mtime": 1782298742.9470108,
-    "ast_hash": "1a34657a89f862ea80199ff11cedb000",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/d3657628-1532-4ffc-8156-b38ad054ceaf-container.json": {
-    "mtime": 1782298742.9560113,
-    "ast_hash": "b2e63f08a1b74d9ea1e48c50f9561bd9",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/d573b77a-e5b8-4376-915c-c1086da21603-result.json": {
-    "mtime": 1782298742.965304,
-    "ast_hash": "a435f6d107ab1dbaef93651283a8846e",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-24_13-59-05-771_AllureReport.html": {
-    "mtime": 1782298745.7180479,
-    "ast_hash": "9a4bda772bfbc6919f7de9f24398d636",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/0fe8caf1-5a73-41d0-b534-841d36d01a65-attachment.txt": {
-    "mtime": 1782298742.7764664,
-    "ast_hash": "3584b728ffad3c1481e236b4408eca74",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/1d63f39a-b64b-4537-97c5-a24e462f5aa9-attachment.txt": {
-    "mtime": 1782298738.2469592,
-    "ast_hash": "ed78e93453136b944f796acc14734392",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/460825f2-eb72-4fb3-a6c8-63fdb02a6ded-attachment.txt": {
-    "mtime": 1782298738.7337043,
-    "ast_hash": "8b86d168496e0f9328ac2ca748331b02",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/6681e124-64e3-4f10-92dd-8420aff61344-attachment.txt": {
-    "mtime": 1782298742.767462,
-    "ast_hash": "ee4e20cf638a0aa6bb37ff8ea80cfc91",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/8dd621aa-3eec-4a38-be36-c30868c0f19d-attachment.txt": {
-    "mtime": 1782298738.7779818,
-    "ast_hash": "210120a17ac685bcac287506c6932e2d",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/cd24dcc8-d0da-479a-9621-dec07d202c34-attachment.txt": {
-    "mtime": 1782298742.7314844,
-    "ast_hash": "625608347e839bedaab36e304acba286",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/e2006a6f-7412-4b8b-8b20-aa60f32d255d-attachment.txt": {
-    "mtime": 1782298738.7498357,
-    "ast_hash": "8e1f50f606b9e99a354c431ef2426b34",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/f964585c-e5a6-4737-9494-05c164bddefe-attachment.txt": {
-    "mtime": 1782298738.822259,
-    "ast_hash": "9d37ac9834c1612b4d65a73c467760f6",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/execution-summary/ExecutionSummaryReport_24-06-2026_13-59-02-7910-PM.html": {
-    "mtime": 1782298742.7969773,
-    "ast_hash": "b3ea89ad212a6ade42a079ef6087bee1",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_24-06-2026_13-59-02-7979-PM.html": {
-    "mtime": 1782298742.7989807,
-    "ast_hash": "9b44a948ae21c8d1374999b821eb60b1",
+  "shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/RemoteGridPreflightUnitTest.java": {
+    "mtime": 1782336091.265759,
+    "ast_hash": "8c86158cab9438008c9ecfa8f76fe1fa",
     "semantic_hash": ""
   }
 }

--- a/shaft-engine/src/main/java/com/shaft/api/RestActions.java
+++ b/shaft-engine/src/main/java/com/shaft/api/RestActions.java
@@ -52,6 +52,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import java.io.*;
+import java.net.URI;
 import java.net.URLConnection;
 import java.nio.file.Files;
 import java.util.*;
@@ -102,6 +103,7 @@ public class RestActions {
     private final String serviceURI;
     private final Map<String, String> sessionHeaders;
     private final Map<String, Object> sessionCookies;
+    private final Map<String, Cookie> sessionDetailedCookies;
     private final RestAssuredConfig sessionConfig;
     private SHAFT.API driver;
 
@@ -121,8 +123,9 @@ public class RestActions {
         initializeSystemProperties();
         headerAuthorization = "";
         this.serviceURI = serviceURI;
-        sessionCookies = new HashMap<>();
-        sessionHeaders = new HashMap<>();
+        sessionCookies = new LinkedHashMap<>();
+        sessionDetailedCookies = new LinkedHashMap<>();
+        sessionHeaders = new LinkedHashMap<>();
         sessionConfig = config();
         this.driver = driver;
     }
@@ -159,8 +162,9 @@ public class RestActions {
         initializeSystemProperties();
         headerAuthorization = "";
         this.serviceURI = serviceURI;
-        sessionCookies = new HashMap<>();
-        sessionHeaders = new HashMap<>();
+        sessionCookies = new LinkedHashMap<>();
+        sessionDetailedCookies = new LinkedHashMap<>();
+        sessionHeaders = new LinkedHashMap<>();
         sessionConfig = config();
     }
 
@@ -1116,6 +1120,47 @@ public class RestActions {
         return sessionCookies;
     }
 
+    /**
+     * Returns an immutable snapshot of the cookies currently attached to this API session.
+     *
+     * @return session cookies keyed by cookie name
+     */
+    public Map<String, Cookie> getCookies() {
+        Map<String, Cookie> cookies = new LinkedHashMap<>(sessionDetailedCookies);
+        sessionCookies.forEach((name, value) -> {
+            if (name != null && !cookies.containsKey(name)) {
+                cookies.put(name, new Cookie.Builder(name, value == null ? "" : String.valueOf(value)).build());
+            }
+        });
+        return Collections.unmodifiableMap(cookies);
+    }
+
+    /**
+     * Returns an immutable snapshot of the headers currently attached to this API session.
+     *
+     * @return session headers keyed by header name
+     */
+    public Map<String, String> getHeaders() {
+        return Collections.unmodifiableMap(new LinkedHashMap<>(sessionHeaders));
+    }
+
+    /**
+     * Imports browser cookies into this API session.
+     *
+     * @param cookies      browser cookies to import
+     * @param domainFilter optional exact domain filter; pass {@code null} or blank to import every domain
+     * @param pathFilter   optional exact path filter; pass {@code null} or blank to import every path
+     * @return self-reference to be used for chaining actions
+     */
+    public RestActions importCookiesFrom(Set<org.openqa.selenium.Cookie> cookies, String domainFilter, String pathFilter) {
+        Objects.requireNonNull(cookies, "cookies");
+        cookies.stream()
+                .filter(cookie -> matchesBrowserCookieFilter(cookie, domainFilter, pathFilter))
+                .map(RestActions::toRestAssuredCookie)
+                .forEach(this::putSessionCookie);
+        return this;
+    }
+
     protected RestAssuredConfig getSessionConfig() {
         return sessionConfig;
     }
@@ -1181,6 +1226,9 @@ public class RestActions {
     @Deprecated(since = "10.2.20260620", forRemoval = false)
     public RestActions addCookieVariable(String key, String value) {
         sessionCookies.put(key, value);
+        if (key != null && value != null) {
+            sessionDetailedCookies.put(key, new Cookie.Builder(key, value).build());
+        }
         return this;
     }
 
@@ -1372,10 +1420,10 @@ public class RestActions {
         return null;
     }
 
-    private void extractCookiesFromResponse(Response response) {
+    private void extractCookiesFromResponse(Response response, String originHost) {
         if (response.getDetailedCookies().size() > 0) {
             for (Cookie cookie : response.getDetailedCookies()) {
-                sessionCookies.put(cookie.getName(), cookie.getValue());
+                putSessionCookie(withOriginHost(cookie, originHost));
                 if (cookie.getName().equals("XSRF-TOKEN")) {
                     sessionHeaders.put("X-XSRF-TOKEN", cookie.getValue());
                 }
@@ -1438,7 +1486,7 @@ public class RestActions {
     String prepareReportMessage(Response response, int targetStatusCode, RequestType requestType,
                                 String serviceName, ContentType contentType, String urlArguments) {
         if (response != null) {
-            extractCookiesFromResponse(response);
+            extractCookiesFromResponse(response, resolveRequestHost(serviceName));
             extractHeadersFromResponse(response);
             StringBuilder reportMessage = new StringBuilder();
             reportMessage.append(requestType);
@@ -1451,6 +1499,85 @@ public class RestActions {
             return reportMessage.toString().trim();
         }
         return "";
+    }
+
+    private void putSessionCookie(Cookie cookie) {
+        sessionCookies.put(cookie.getName(), cookie.getValue());
+        sessionDetailedCookies.put(cookie.getName(), cookie);
+    }
+
+    private static Cookie withOriginHost(Cookie cookie, String originHost) {
+        if (cookie.hasDomain() || originHost == null || originHost.isBlank()) {
+            return cookie;
+        }
+        Cookie.Builder builder = new Cookie.Builder(cookie.getName(), cookie.hasValue() ? cookie.getValue() : "");
+        builder.setDomain(originHost);
+        if (cookie.hasPath()) {
+            builder.setPath(cookie.getPath());
+        }
+        if (cookie.hasExpiryDate()) {
+            builder.setExpiryDate(cookie.getExpiryDate());
+        }
+        builder.setSecured(cookie.isSecured());
+        builder.setHttpOnly(cookie.isHttpOnly());
+        if (cookie.hasSameSite()) {
+            builder.setSameSite(cookie.getSameSite());
+        }
+        return builder.build();
+    }
+
+    private String resolveRequestHost(String serviceName) {
+        try {
+            URI baseUri = URI.create(serviceURI);
+            URI requestUri = baseUri.resolve(serviceName == null ? "" : serviceName);
+            return requestUri.getHost();
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+
+    private static Cookie toRestAssuredCookie(org.openqa.selenium.Cookie cookie) {
+        Cookie.Builder builder = new Cookie.Builder(cookie.getName(), cookie.getValue());
+        if (cookie.getDomain() != null) {
+            builder.setDomain(cookie.getDomain());
+        }
+        if (cookie.getPath() != null) {
+            builder.setPath(cookie.getPath());
+        }
+        if (cookie.getExpiry() != null) {
+            builder.setExpiryDate(cookie.getExpiry());
+        }
+        builder.setSecured(cookie.isSecure());
+        builder.setHttpOnly(cookie.isHttpOnly());
+        if (cookie.getSameSite() != null) {
+            builder.setSameSite(cookie.getSameSite());
+        }
+        return builder.build();
+    }
+
+    private static boolean matchesBrowserCookieFilter(org.openqa.selenium.Cookie cookie, String domainFilter, String pathFilter) {
+        return matchesFilter(cookie.getDomain(), domainFilter, true)
+                && matchesFilter(cookie.getPath(), pathFilter, false);
+    }
+
+    private static boolean matchesFilter(String actual, String filter, boolean domain) {
+        if (filter == null || filter.isBlank()) {
+            return true;
+        }
+        if (actual == null || actual.isBlank()) {
+            return false;
+        }
+        String normalizedActual = domain ? normalizeDomain(actual) : actual;
+        String normalizedFilter = domain ? normalizeDomain(filter) : filter;
+        return normalizedActual.equals(normalizedFilter);
+    }
+
+    private static String normalizeDomain(String domain) {
+        String normalized = domain.toLowerCase(Locale.ROOT);
+        while (normalized.startsWith(".")) {
+            normalized = normalized.substring(1);
+        }
+        return normalized;
     }
 
 

--- a/shaft-engine/src/main/java/com/shaft/api/ShaftRestAssuredFilter.java
+++ b/shaft-engine/src/main/java/com/shaft/api/ShaftRestAssuredFilter.java
@@ -2,8 +2,12 @@ package com.shaft.api;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
 import io.qameta.allure.Allure;
 import io.restassured.filter.Filter;
 import io.restassured.filter.FilterContext;
@@ -13,6 +17,8 @@ import io.restassured.specification.FilterableResponseSpecification;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * A SHAFT-native Allure filter for REST Assured that replaces the default
@@ -50,6 +56,11 @@ import java.nio.charset.StandardCharsets;
  */
 public class ShaftRestAssuredFilter implements Filter {
     private static final Gson PRETTY_GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final String MASKED_VALUE = "********";
+    private static final Pattern SENSITIVE_KEY_VALUE_PATTERN = Pattern.compile(
+            "(?i)(\\b[\\w-]*(?:authorization|cookie|password|passwd|secret|token|apikey|api-key)[\\w-]*\\b\\s*[:=]\\s*)(\"[^\"]*\"|'[^']*'|[^&\\s,;]+)");
+    private static final Pattern SENSITIVE_XML_ELEMENT_PATTERN = Pattern.compile(
+            "(?is)(<([\\w:-]*(?:authorization|cookie|password|passwd|secret|token|apikey|api-key)[\\w:-]*)\\b[^>]*>)(.*?)(</\\2>)");
 
     /**
      * Intercepts every REST Assured request, attaches the request and response
@@ -93,21 +104,22 @@ public class ShaftRestAssuredFilter implements Filter {
         if (requestSpec.getHeaders().size() > 0) {
             info.append("\nHeaders:\n");
             requestSpec.getHeaders().forEach(h ->
-                    info.append("  ").append(h.getName()).append(": ").append(h.getValue()).append("\n"));
+                    info.append("  ").append(h.getName()).append(": ")
+                            .append(redactForReport(h.getName(), h.getValue())).append("\n"));
         }
 
         // Cookies
         if (requestSpec.getCookies().size() > 0) {
             info.append("\nCookies:\n");
             requestSpec.getCookies().forEach(c ->
-                    info.append("  ").append(c.getName()).append("=").append(c.getValue()).append("\n"));
+                    info.append("  ").append(c.getName()).append("=").append(MASKED_VALUE).append("\n"));
         }
 
         // Form params
         if (!requestSpec.getFormParams().isEmpty()) {
             info.append("\nForm Params:\n");
             requestSpec.getFormParams().forEach((k, v) ->
-                    info.append("  ").append(k).append("=").append(v).append("\n"));
+                    info.append("  ").append(k).append("=").append(redactForReport(k, v)).append("\n"));
         }
 
         Allure.addAttachment("Request", "text/plain",
@@ -131,7 +143,7 @@ public class ShaftRestAssuredFilter implements Filter {
                 if (!bodyStr.isEmpty()) {
                     String contentType = detectContentType(bodyStr,
                             requestSpec.getContentType() != null ? requestSpec.getContentType() : "");
-                    String formatted = formatBody(bodyStr, contentType);
+                    String formatted = formatBody(redactBodyForReport(bodyStr, contentType), contentType);
                     Allure.addAttachment("Request Body", contentType,
                             new ByteArrayInputStream(formatted.getBytes(StandardCharsets.UTF_8)),
                             getFileExtension(contentType));
@@ -162,7 +174,8 @@ public class ShaftRestAssuredFilter implements Filter {
         if (response.getHeaders().size() > 0) {
             info.append("\nHeaders:\n");
             response.getHeaders().forEach(h ->
-                    info.append("  ").append(h.getName()).append(": ").append(h.getValue()).append("\n"));
+                    info.append("  ").append(h.getName()).append(": ")
+                            .append(redactForReport(h.getName(), h.getValue())).append("\n"));
         }
 
         Allure.addAttachment("Response", "text/plain",
@@ -183,7 +196,7 @@ public class ShaftRestAssuredFilter implements Filter {
             String body = response.getBody().asString();
             if (body != null && !body.isEmpty()) {
                 String detectedContentType = detectContentType(body, declaredContentType);
-                String formatted = formatBody(body, detectedContentType);
+                String formatted = formatBody(redactBodyForReport(body, detectedContentType), detectedContentType);
                 Allure.addAttachment("Response Body", detectedContentType,
                         new ByteArrayInputStream(formatted.getBytes(StandardCharsets.UTF_8)),
                         getFileExtension(detectedContentType));
@@ -192,6 +205,60 @@ public class ShaftRestAssuredFilter implements Filter {
     }
 
     // ─── helpers ──────────────────────────────────────────────────────────────
+
+    private static String redactForReport(String key, Object value) {
+        return isSensitiveKey(key) ? MASKED_VALUE : String.valueOf(value);
+    }
+
+    private static boolean isSensitiveKey(String key) {
+        String normalizedKey = key == null ? "" : key.toLowerCase();
+        return normalizedKey.contains("authorization")
+                || normalizedKey.contains("cookie")
+                || normalizedKey.contains("password")
+                || normalizedKey.contains("passwd")
+                || normalizedKey.contains("secret")
+                || normalizedKey.contains("token")
+                || normalizedKey.contains("apikey")
+                || normalizedKey.contains("api-key");
+    }
+
+    private String redactBodyForReport(String body, String contentType) {
+        if (body == null || body.isEmpty()) {
+            return body;
+        }
+        if ("application/json".equals(contentType) || looksLikeJson(body)) {
+            try {
+                return PRETTY_GSON.toJson(redactJson(JsonParser.parseString(body)));
+            } catch (JsonParseException ignored) {
+                // Fall back to text redaction if the body only looks like JSON.
+            }
+        }
+        String redacted = SENSITIVE_KEY_VALUE_PATTERN.matcher(body).replaceAll("$1" + MASKED_VALUE);
+        return SENSITIVE_XML_ELEMENT_PATTERN.matcher(redacted).replaceAll("$1" + MASKED_VALUE + "$4");
+    }
+
+    private static JsonElement redactJson(JsonElement element) {
+        if (element == null || element.isJsonNull()) {
+            return element;
+        }
+        if (element.isJsonObject()) {
+            JsonObject redacted = new JsonObject();
+            for (Map.Entry<String, JsonElement> entry : element.getAsJsonObject().entrySet()) {
+                redacted.add(entry.getKey(), isSensitiveKey(entry.getKey())
+                        ? new JsonPrimitive(MASKED_VALUE)
+                        : redactJson(entry.getValue()));
+            }
+            return redacted;
+        }
+        if (element.isJsonArray()) {
+            JsonArray redacted = new JsonArray();
+            for (JsonElement child : element.getAsJsonArray()) {
+                redacted.add(redactJson(child));
+            }
+            return redacted;
+        }
+        return element.deepCopy();
+    }
 
     /**
      * Determines the best MIME type for an attachment body.

--- a/shaft-engine/src/main/java/com/shaft/driver/SHAFT.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/SHAFT.java
@@ -8,6 +8,7 @@ import com.shaft.db.DatabaseActions;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.driver.internal.WizardHelpers;
 import com.shaft.gui.browser.BrowserActions;
+import com.shaft.gui.driver.BrowserActionsContract;
 import com.shaft.gui.element.AlertActions;
 import com.shaft.gui.element.AsyncElementActions;
 import com.shaft.gui.element.TouchActions;
@@ -576,6 +577,48 @@ public class SHAFT {
          */
         public void addCookie(String key, String value) {
             session.addCookieVariable(key, value);
+        }
+
+        /**
+         * Imports all browser cookies into this API session.
+         *
+         * @param browserActions browser actions facade to read cookies from
+         * @return this API session for fluent chaining
+         */
+        public API importCookiesFrom(BrowserActionsContract browserActions) {
+            return importCookiesFrom(browserActions, null, null);
+        }
+
+        /**
+         * Imports browser cookies that match the optional domain and path filters into this API session.
+         *
+         * @param browserActions browser actions facade to read cookies from
+         * @param domainFilter   optional exact domain filter; pass {@code null} or blank to import every domain
+         * @param pathFilter     optional exact path filter; pass {@code null} or blank to import every path
+         * @return this API session for fluent chaining
+         */
+        public API importCookiesFrom(BrowserActionsContract browserActions, String domainFilter, String pathFilter) {
+            java.util.Objects.requireNonNull(browserActions, "browserActions");
+            session.importCookiesFrom(browserActions.getAllCookies(), domainFilter, pathFilter);
+            return this;
+        }
+
+        /**
+         * Returns an immutable snapshot of cookies attached to this API session.
+         *
+         * @return API session cookies keyed by cookie name
+         */
+        public Map<String, io.restassured.http.Cookie> getCookies() {
+            return session.getCookies();
+        }
+
+        /**
+         * Returns an immutable snapshot of headers attached to this API session.
+         *
+         * @return API session headers keyed by header name
+         */
+        public Map<String, String> getHeaders() {
+            return session.getHeaders();
         }
 
         /**

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -812,7 +812,78 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
     @Override
     public BrowserActions addCookie(String key, String value) {
         driverFactoryHelper.getDriver().manage().addCookie(new Cookie(key, value));
-        browserActionsHelper.passAction(driverFactoryHelper.getDriver(), "Add Cookie", "Key: " + key + " | Value: " + value);
+        browserActionsHelper.passAction(driverFactoryHelper.getDriver(), "Add Cookie", "Key: " + key + " | Value: ********");
+        return this;
+    }
+
+    /**
+     * Imports API session cookies into the current browser context.
+     *
+     * @param api the API session to read cookies from
+     * @return a self-reference to be used to chain actions
+     */
+    public BrowserActions importCookiesFrom(SHAFT.API api) {
+        return importCookiesFrom(api, null, null);
+    }
+
+    /**
+     * Imports matching API session cookies into the current browser context.
+     *
+     * @param api          the API session to read cookies from
+     * @param domainFilter optional exact cookie domain filter; pass {@code null} or blank to import every domain
+     * @param pathFilter   optional exact cookie path filter; pass {@code null} or blank to import every path
+     * @return a self-reference to be used to chain actions
+     */
+    public BrowserActions importCookiesFrom(SHAFT.API api, String domainFilter, String pathFilter) {
+        WebDriver driver = driverFactoryHelper.getDriver();
+        try {
+            Objects.requireNonNull(api, "api");
+            URI currentUri = requireHttpBrowserUri(driver.getCurrentUrl());
+            List<Cookie> cookiesToImport = new ArrayList<>();
+            for (io.restassured.http.Cookie apiCookie : api.getCookies().values()) {
+                if (matchesApiCookieFilter(apiCookie, domainFilter, pathFilter)) {
+                    cookiesToImport.add(toSeleniumCookie(apiCookie, currentUri.getHost()));
+                }
+            }
+            cookiesToImport.forEach(cookie -> driver.manage().addCookie(cookie));
+            browserActionsHelper.passAction(driver, "Import Cookies From API", "Imported Cookies: " + cookiesToImport.size());
+        } catch (Exception rootCauseException) {
+            browserActionsHelper.failAction(driver, "Import Cookies From API",
+                    "Could not import API cookies. Cause: " + rootCauseException.getClass().getSimpleName());
+        }
+        return this;
+    }
+
+    /**
+     * Copies a selected API session header into {@code localStorage}.
+     *
+     * @param api        the API session to read headers from
+     * @param headerName the header name to copy
+     * @param storageKey the localStorage key to write
+     * @return a self-reference to be used to chain actions
+     */
+    public BrowserActions importHeaderToLocalStorage(SHAFT.API api, String headerName, String storageKey) {
+        WebDriver driver = driverFactoryHelper.getDriver();
+        try {
+            Objects.requireNonNull(api, "api");
+            requireNonBlank(headerName, "headerName");
+            requireNonBlank(storageKey, "storageKey");
+            requireHttpBrowserUri(driver.getCurrentUrl());
+            String headerValue = api.getHeaders().get(headerName);
+            if (headerValue == null) {
+                throw new IllegalArgumentException("API session does not contain header \"" + headerName + "\".");
+            }
+            if (!(driver instanceof JavascriptExecutor javascriptExecutor)) {
+                throw new IllegalStateException("The active WebDriver does not support JavaScript execution.");
+            }
+            javascriptExecutor.executeScript("window.localStorage.setItem(arguments[0], arguments[1]);",
+                    storageKey, headerValue);
+            browserActionsHelper.passAction(driver, "Import Header To Local Storage",
+                    "Header: " + headerName + " | Storage Key: " + storageKey);
+        } catch (Exception rootCauseException) {
+            browserActionsHelper.failAction(driver, "Import Header To Local Storage",
+                    "Could not import API header to localStorage. Cause: " + rootCauseException.getClass().getSimpleName());
+        }
         return this;
     }
 
@@ -865,7 +936,7 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
     @Override
     public String getCookieValue(String cookieName) {
         String cookieValue = getCookie(cookieName).getValue();
-        browserActionsHelper.passAction(driverFactoryHelper.getDriver(), "Get Cookie Value with name: " + cookieName, cookieValue);
+        browserActionsHelper.passAction(driverFactoryHelper.getDriver(), "Get Cookie Value with name: " + cookieName, "********");
         return cookieValue;
     }
 
@@ -1081,5 +1152,76 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
         return new AccessibilityActions(rawDriver, this);
     }
 
+    private static Cookie toSeleniumCookie(io.restassured.http.Cookie apiCookie, String currentHost) {
+        Cookie.Builder builder = new Cookie.Builder(apiCookie.getName(), apiCookie.hasValue() ? apiCookie.getValue() : "");
+        if (apiCookie.hasDomain()) {
+            String cookieDomain = normalizeDomain(apiCookie.getDomain());
+            if (!hostMatchesDomain(currentHost, cookieDomain)) {
+                throw new IllegalArgumentException("Current browser host \"" + currentHost
+                        + "\" is not compatible with cookie domain \"" + apiCookie.getDomain() + "\".");
+            }
+            builder.domain(cookieDomain);
+        }
+        builder.path(apiCookie.hasPath() ? apiCookie.getPath() : "/");
+        if (apiCookie.hasExpiryDate()) {
+            builder.expiresOn(apiCookie.getExpiryDate());
+        }
+        builder.isSecure(apiCookie.isSecured());
+        builder.isHttpOnly(apiCookie.isHttpOnly());
+        if (apiCookie.hasSameSite()) {
+            builder.sameSite(apiCookie.getSameSite());
+        }
+        return builder.build();
+    }
+
+    private static URI requireHttpBrowserUri(String currentUrl) {
+        if (currentUrl == null || currentUrl.isBlank()) {
+            throw new IllegalStateException("Navigate to an HTTP or HTTPS page before importing auth state.");
+        }
+        URI currentUri = URI.create(currentUrl);
+        String scheme = currentUri.getScheme();
+        if (currentUri.getHost() == null
+                || scheme == null
+                || (!scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https"))) {
+            throw new IllegalStateException("Navigate to an HTTP or HTTPS page before importing auth state.");
+        }
+        return currentUri;
+    }
+
+    private static void requireNonBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank.");
+        }
+    }
+
+    private static boolean matchesApiCookieFilter(io.restassured.http.Cookie cookie, String domainFilter, String pathFilter) {
+        return matchesFilter(cookie.hasDomain() ? cookie.getDomain() : null, domainFilter, true)
+                && matchesFilter(cookie.hasPath() ? cookie.getPath() : null, pathFilter, false);
+    }
+
+    private static boolean matchesFilter(String actual, String filter, boolean domain) {
+        if (filter == null || filter.isBlank()) {
+            return true;
+        }
+        if (actual == null || actual.isBlank()) {
+            return false;
+        }
+        String normalizedActual = domain ? normalizeDomain(actual) : actual;
+        String normalizedFilter = domain ? normalizeDomain(filter) : filter;
+        return normalizedActual.equals(normalizedFilter);
+    }
+
+    private static boolean hostMatchesDomain(String host, String domain) {
+        String normalizedHost = normalizeDomain(host);
+        return normalizedHost.equals(domain) || normalizedHost.endsWith("." + domain);
+    }
+
+    private static String normalizeDomain(String domain) {
+        String normalized = domain.toLowerCase(Locale.ROOT);
+        while (normalized.startsWith(".")) {
+            normalized = normalized.substring(1);
+        }
+        return normalized;
+    }
 
 }

--- a/shaft-engine/src/test/java/com/shaft/api/RestActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/api/RestActionsCoverageUnitTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.shaft.driver.SHAFT;
+import com.shaft.gui.driver.BrowserActionsContract;
 import com.shaft.properties.internal.Properties;
 import com.shaft.validation.Validations;
 import com.sun.net.httpserver.HttpServer;
@@ -34,6 +35,7 @@ import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 public class RestActionsCoverageUnitTest {
@@ -281,6 +283,40 @@ public class RestActionsCoverageUnitTest {
         Validations.assertThat().object(actions.getSessionHeaders().get("Authorization")).isEqualTo("Bearer abc123").perform();
         Validations.assertThat().object(actions.getSessionHeaders().get("X-XSRF-TOKEN")).isEqualTo("csrf-header").perform();
         Validations.assertThat().object(actions.getSessionCookies().get("XSRF-TOKEN")).isEqualTo("csrf-value").perform();
+        Assert.assertEquals(actions.getCookies().get("XSRF-TOKEN").getDomain(), "localhost");
+    }
+
+    @Test
+    public void apiShouldImportBrowserCookiesWithDomainAndPathFilter() {
+        BrowserActionsContract browser = Mockito.mock(BrowserActionsContract.class);
+        org.openqa.selenium.Cookie sessionCookie = new org.openqa.selenium.Cookie.Builder("session", "secret")
+                .domain(".example.com")
+                .path("/app")
+                .isSecure(true)
+                .isHttpOnly(true)
+                .sameSite("Strict")
+                .build();
+        org.openqa.selenium.Cookie skippedCookie = new org.openqa.selenium.Cookie.Builder("other", "value")
+                .domain("other.example.com")
+                .path("/")
+                .build();
+        Mockito.when(browser.getAllCookies()).thenReturn(Set.of(sessionCookie, skippedCookie));
+
+        SHAFT.API api = new SHAFT.API("https://api.example.com/");
+        api.importCookiesFrom(browser, "example.com", "/app");
+
+        Map<String, Cookie> cookies = api.getCookies();
+        Cookie imported = cookies.get("session");
+        Assert.assertNotNull(imported);
+        Assert.assertEquals(imported.getValue(), "secret");
+        Assert.assertEquals(imported.getDomain(), ".example.com");
+        Assert.assertEquals(imported.getPath(), "/app");
+        Assert.assertTrue(imported.isSecured());
+        Assert.assertTrue(imported.isHttpOnly());
+        Assert.assertEquals(imported.getSameSite(), "Strict");
+        Assert.assertFalse(cookies.containsKey("other"));
+        Assert.assertThrows(UnsupportedOperationException.class,
+                () -> cookies.put("new", new Cookie.Builder("new", "value").build()));
     }
 
     @Test

--- a/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsCoverageUnitTest.java
@@ -179,6 +179,71 @@ public class BrowserActionsCoverageUnitTest {
     }
 
     @Test
+    public void shouldImportApiCookiesIntoCompatibleBrowserDomain() {
+        com.shaft.gui.driver.BrowserActionsContract sourceBrowser = Mockito.mock(com.shaft.gui.driver.BrowserActionsContract.class);
+        Cookie sourceCookie = new Cookie.Builder("session", "secret")
+                .domain(".example.com")
+                .path("/app")
+                .isSecure(true)
+                .isHttpOnly(true)
+                .sameSite("Strict")
+                .build();
+        Cookie skippedCookie = new Cookie.Builder("other", "value")
+                .domain("other.example.com")
+                .path("/")
+                .build();
+        Mockito.when(sourceBrowser.getAllCookies()).thenReturn(Set.of(sourceCookie, skippedCookie));
+        SHAFT.API api = new SHAFT.API("https://api.example.com/");
+        api.importCookiesFrom(sourceBrowser);
+        when(driver.getCurrentUrl()).thenReturn("https://app.example.com/app/dashboard");
+
+        browserActions.importCookiesFrom(api, "example.com", "/app");
+
+        org.mockito.ArgumentCaptor<Cookie> cookieCaptor = org.mockito.ArgumentCaptor.forClass(Cookie.class);
+        Mockito.verify(options).addCookie(cookieCaptor.capture());
+        Cookie imported = cookieCaptor.getValue();
+        Assert.assertEquals(imported.getName(), "session");
+        Assert.assertEquals(imported.getValue(), "secret");
+        Assert.assertEquals(imported.getDomain(), "example.com");
+        Assert.assertEquals(imported.getPath(), "/app");
+        Assert.assertTrue(imported.isSecure());
+        Assert.assertTrue(imported.isHttpOnly());
+        Assert.assertEquals(imported.getSameSite(), "Strict");
+    }
+
+    @Test
+    public void shouldImportApiHeaderIntoLocalStorage() {
+        SHAFT.API api = new SHAFT.API("https://api.example.com/");
+        api.addHeader("Authorization", "Bearer secret");
+        when(driver.getCurrentUrl()).thenReturn("https://example.com/app");
+
+        browserActions.importHeaderToLocalStorage(api, "Authorization", "authToken");
+
+        Mockito.verify((JavascriptExecutor) driver)
+                .executeScript("window.localStorage.setItem(arguments[0], arguments[1]);", "authToken", "Bearer secret");
+    }
+
+    @Test
+    public void shouldValidateApiCookieDomainsBeforeImportingAnyCookie() {
+        com.shaft.gui.driver.BrowserActionsContract sourceBrowser = Mockito.mock(com.shaft.gui.driver.BrowserActionsContract.class);
+        Cookie compatibleCookie = new Cookie.Builder("session", "secret")
+                .domain(".example.com")
+                .path("/")
+                .build();
+        Cookie incompatibleCookie = new Cookie.Builder("admin", "secret")
+                .domain("admin.example.org")
+                .path("/")
+                .build();
+        Mockito.when(sourceBrowser.getAllCookies()).thenReturn(Set.of(compatibleCookie, incompatibleCookie));
+        SHAFT.API api = new SHAFT.API("https://api.example.com/");
+        api.importCookiesFrom(sourceBrowser);
+        when(driver.getCurrentUrl()).thenReturn("https://app.example.com/");
+
+        Assert.assertThrows(RuntimeException.class, () -> browserActions.importCookiesFrom(api));
+        Mockito.verify(options, Mockito.never()).addCookie(any(Cookie.class));
+    }
+
+    @Test
     public void shouldCoverConstructorsAndExtraControlPaths() {
         BrowserActions browserActionsWithDriver = new BrowserActions(driver);
         BrowserActions browserActionsWithHelper = new BrowserActions(new DriverFactoryHelper(driver));

--- a/shaft-engine/src/test/java/testPackage/unitTests/ShaftRestAssuredFilterUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/ShaftRestAssuredFilterUnitTest.java
@@ -2,6 +2,7 @@ package testPackage.unitTests;
 
 import com.shaft.api.ShaftRestAssuredFilter;
 import com.shaft.driver.SHAFT;
+import io.qameta.allure.Allure;
 import io.restassured.filter.FilterContext;
 import io.restassured.http.Cookie;
 import io.restassured.http.Cookies;
@@ -11,10 +12,14 @@ import io.restassured.response.Response;
 import io.restassured.response.ResponseBody;
 import io.restassured.specification.FilterableRequestSpecification;
 import io.restassured.specification.FilterableResponseSpecification;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -68,6 +73,70 @@ public class ShaftRestAssuredFilterUnitTest {
 
         SHAFT.Validations.assertThat().object(actual).isEqualTo(response).perform();
         Mockito.verify(filterContext).next(requestSpec, responseSpec);
+    }
+
+    @Test(description = "filter redacts auth headers and cookies from request and response metadata")
+    public void filterShouldRedactSensitiveHeadersAndCookies() throws Exception {
+        FilterableRequestSpecification requestSpec = Mockito.mock(FilterableRequestSpecification.class);
+        FilterableResponseSpecification responseSpec = Mockito.mock(FilterableResponseSpecification.class);
+        FilterContext filterContext = Mockito.mock(FilterContext.class);
+        Response response = Mockito.mock(Response.class);
+        ResponseBody<?> responseBody = Mockito.mock(ResponseBody.class);
+
+        Mockito.when(requestSpec.getMethod()).thenReturn("GET");
+        Mockito.when(requestSpec.getURI()).thenReturn("https://example.test/api");
+        Mockito.when(requestSpec.getHeaders()).thenReturn(new Headers(
+                new Header("Authorization", "Bearer request-secret"),
+                new Header("X-Trace", "trace-1")));
+        Mockito.when(requestSpec.getCookies())
+                .thenReturn(new Cookies(new Cookie.Builder("session", "cookie-secret").build()));
+        Mockito.when(requestSpec.getFormParams()).thenReturn(new LinkedHashMap<>());
+        Mockito.when(requestSpec.getBody()).thenReturn("{\"username\":\"shaft\",\"password\":\"request-password\"}");
+        Mockito.when(requestSpec.getContentType()).thenReturn("application/json");
+
+        Mockito.when(filterContext.next(requestSpec, responseSpec)).thenReturn(response);
+        Mockito.when(response.getStatusLine()).thenReturn("HTTP/1.1 200 OK");
+        Mockito.when(response.getTime()).thenReturn(10L);
+        Mockito.when(response.getHeaders()).thenReturn(new Headers(
+                new Header("Set-Cookie", "session=response-secret"),
+                new Header("Content-Type", "application/json")));
+        Mockito.when(response.getContentType()).thenReturn("application/json");
+        Mockito.when(response.getBody()).thenReturn(responseBody);
+        Mockito.when(responseBody.asString()).thenReturn("{\"type\":\"bearer\",\"token\":\"response-token\"}");
+
+        try (MockedStatic<Allure> allure = Mockito.mockStatic(Allure.class)) {
+            filter.filter(requestSpec, responseSpec, filterContext);
+
+            ArgumentCaptor<InputStream> requestStream = ArgumentCaptor.forClass(InputStream.class);
+            allure.verify(() -> Allure.addAttachment(Mockito.eq("Request"), Mockito.eq("text/plain"),
+                    requestStream.capture(), Mockito.eq(".txt")));
+            String requestMetadata = new String(requestStream.getValue().readAllBytes(), StandardCharsets.UTF_8);
+            org.testng.Assert.assertFalse(requestMetadata.contains("request-secret"));
+            org.testng.Assert.assertFalse(requestMetadata.contains("cookie-secret"));
+            org.testng.Assert.assertTrue(requestMetadata.contains("Authorization: ********"));
+            org.testng.Assert.assertTrue(requestMetadata.contains("session=********"));
+
+            ArgumentCaptor<InputStream> responseStream = ArgumentCaptor.forClass(InputStream.class);
+            allure.verify(() -> Allure.addAttachment(Mockito.eq("Response"), Mockito.eq("text/plain"),
+                    responseStream.capture(), Mockito.eq(".txt")));
+            String responseMetadata = new String(responseStream.getValue().readAllBytes(), StandardCharsets.UTF_8);
+            org.testng.Assert.assertFalse(responseMetadata.contains("response-secret"));
+            org.testng.Assert.assertTrue(responseMetadata.contains("Set-Cookie: ********"));
+
+            ArgumentCaptor<InputStream> requestBodyStream = ArgumentCaptor.forClass(InputStream.class);
+            allure.verify(() -> Allure.addAttachment(Mockito.eq("Request Body"), Mockito.eq("application/json"),
+                    requestBodyStream.capture(), Mockito.eq(".json")));
+            String requestBody = new String(requestBodyStream.getValue().readAllBytes(), StandardCharsets.UTF_8);
+            org.testng.Assert.assertFalse(requestBody.contains("request-password"));
+            org.testng.Assert.assertTrue(requestBody.contains("\"password\": \"********\""));
+
+            ArgumentCaptor<InputStream> responseBodyStream = ArgumentCaptor.forClass(InputStream.class);
+            allure.verify(() -> Allure.addAttachment(Mockito.eq("Response Body"), Mockito.eq("application/json"),
+                    responseBodyStream.capture(), Mockito.eq(".json")));
+            String responseBodyText = new String(responseBodyStream.getValue().readAllBytes(), StandardCharsets.UTF_8);
+            org.testng.Assert.assertFalse(responseBodyText.contains("response-token"));
+            org.testng.Assert.assertTrue(responseBodyText.contains("\"token\": \"********\""));
+        }
     }
 
     @Test(description = "filter handles binary request and binary response bodies with normalized MIME types")


### PR DESCRIPTION
## Summary
- Adds API/browser auth-state bridge methods for importing cookies both directions.
- Preserves cookie metadata for API exports, supports domain/path filters, and validates browser HTTP(S) domain context before cookie import.
- Adds selected API header to browser `localStorage` support without logging header values.
- Redacts sensitive headers, cookies, form params, and JSON/text auth body fields from REST Assured Allure attachments.
- Refreshes graphify after core relationship changes.

## Validation
- `py -3 scripts/ci/validate_agent_setup.py`
- `mvn -pl shaft-engine '-Dtest=RestActionsCoverageUnitTest,BrowserActionsCoverageUnitTest,ShaftRestAssuredFilterUnitTest' test`
- Confirmed `shaft-engine/target/surefire-reports/TestSuite.txt`: 76 run, 0 failures, 0 errors
- `mvn -pl shaft-engine '-DskipTests' package`
- `graphify update .`

Docs PR: https://github.com/ShaftHQ/shafthq.github.io/pull/615

Closes #3053.