### PR TITLE
[codex] Suppress AspectJ Unsafe warnings in samples

### DIFF
--- a/scripts/ci/validate_modular_documentation.py
+++ b/scripts/ci/validate_modular_documentation.py
@@ -12,6 +12,11 @@ EXAMPLES = ROOT / "shaft-engine/src/main/resources/examples"
 MCP_FIXTURES = ROOT / "shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp"
 NS = {"m": "http://maven.apache.org/POM/4.0.0"}
 DOCS_BASE = "https://shafthq.github.io/docs"
+EXAMPLE_SUREFIRE_ARG_LINE = (
+    "-XX:+IgnoreUnrecognizedVMOptions --enable-native-access=ALL-UNNAMED "
+    "--sun-misc-unsafe-memory-access=allow -Xshare:off -Dfile.encoding=UTF-8 "
+    "-Dsun.jnu.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8"
+)
 EXPECTED_OPTIONAL = {
     "shaft-cucumber-web": "shaft-visual",
     "shaft-junit-web": "shaft-visual",
@@ -98,6 +103,8 @@ def main() -> None:
             fail(f"{pom}: use <shaft.version> only")
         if text(props, "m:shaft.version") != reactor_version:
             fail(f"{pom}: shaft.version must match reactor version {reactor_version}")
+        if text(props, "m:surefireArgLine") != EXAMPLE_SUREFIRE_ARG_LINE:
+            fail(f"{pom}: surefireArgLine must suppress Java 25 AspectJ Unsafe warnings")
         managed = {
             text(dependency, "m:artifactId")
             for dependency in root.findall(

--- a/shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/pom.xml
@@ -16,7 +16,7 @@
         <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
         <surefire-testng.version>3.5.5</surefire-testng.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <surefireArgLine></surefireArgLine>
+        <surefireArgLine>-XX:+IgnoreUnrecognizedVMOptions --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Xshare:off -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8</surefireArgLine>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/pom.xml
@@ -15,7 +15,7 @@
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <surefireArgLine></surefireArgLine>
+        <surefireArgLine>-XX:+IgnoreUnrecognizedVMOptions --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Xshare:off -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8</surefireArgLine>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/pom.xml
@@ -15,7 +15,7 @@
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <surefireArgLine></surefireArgLine>
+        <surefireArgLine>-XX:+IgnoreUnrecognizedVMOptions --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Xshare:off -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8</surefireArgLine>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/pom.xml
@@ -15,7 +15,7 @@
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <surefireArgLine></surefireArgLine>
+        <surefireArgLine>-XX:+IgnoreUnrecognizedVMOptions --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Xshare:off -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8</surefireArgLine>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/pom.xml
@@ -16,7 +16,7 @@
         <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
         <surefire-testng.version>3.5.5</surefire-testng.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <surefireArgLine></surefireArgLine>
+        <surefireArgLine>-XX:+IgnoreUnrecognizedVMOptions --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Xshare:off -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8</surefireArgLine>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/pom.xml
@@ -16,7 +16,7 @@
         <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
         <surefire-testng.version>3.5.5</surefire-testng.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <surefireArgLine></surefireArgLine>
+        <surefireArgLine>-XX:+IgnoreUnrecognizedVMOptions --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Xshare:off -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8</surefireArgLine>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/pom.xml
@@ -16,7 +16,7 @@
         <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
         <surefire-testng.version>3.5.5</surefire-testng.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <surefireArgLine></surefireArgLine>
+        <surefireArgLine>-XX:+IgnoreUnrecognizedVMOptions --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Xshare:off -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8</surefireArgLine>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/shaft-upgrader/upgrade_to_modular_shaft.py
+++ b/shaft-upgrader/upgrade_to_modular_shaft.py
@@ -59,6 +59,11 @@ ANDROID_JSON_ARTIFACT = "android-json"
 GENERATOR_ASPECTJ_VERSION = "1.9.25.1"
 GENERATOR_SUREFIRE_PLUGIN_VERSION = "3.5.5"
 GENERATOR_SUREFIRE_TESTNG_VERSION = "3.5.5"
+DEFAULT_SUREFIRE_ARG_LINE = (
+    "-XX:+IgnoreUnrecognizedVMOptions --enable-native-access=ALL-UNNAMED "
+    "--sun-misc-unsafe-memory-access=allow -Xshare:off -Dfile.encoding=UTF-8 "
+    "-Dsun.jnu.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8"
+)
 MAVEN_CENTRAL = "https://repo.maven.apache.org/maven2"
 DEFAULT_OPENAI_MODEL = "gpt-5.5"
 DEFAULT_OPENAI_KEY_ENV = "OPENAI_API_KEY"
@@ -976,7 +981,7 @@ def set_generator_properties(root: ET.Element, namespace: str, version: str, run
     if runner == "testng":
         set_text_child(properties, namespace, "surefire-testng.version", GENERATOR_SUREFIRE_TESTNG_VERSION)
     set_text_child(properties, namespace, "maven-surefire-plugin.version", GENERATOR_SUREFIRE_PLUGIN_VERSION)
-    set_text_child(properties, namespace, "surefireArgLine", "")
+    set_text_child(properties, namespace, "surefireArgLine", DEFAULT_SUREFIRE_ARG_LINE)
 
 
 def infer_runner_from_pom(root: ET.Element) -> str:

--- a/tests/scripts/test_upgrade_to_modular_shaft.py
+++ b/tests/scripts/test_upgrade_to_modular_shaft.py
@@ -200,6 +200,7 @@ class UpgradeToModularShaftTests(unittest.TestCase):
 
         self.assertEqual(upgrade.child_text(properties, "aspectjweaver.version"), "1.9.25.1")
         self.assertEqual(upgrade.child_text(properties, "surefire-testng.version"), "3.5.5")
+        self.assertEqual(upgrade.child_text(properties, "surefireArgLine"), upgrade.DEFAULT_SUREFIRE_ARG_LINE)
         self.assertIn((upgrade.SHAFT_GROUP, upgrade.ENGINE_ARTIFACT), dependency_artifacts)
         self.assertIn(("org.aspectj", "aspectjweaver"), dependency_artifacts)
         self.assertIn(("org.apache.maven.surefire", "surefire-testng"), dependency_artifacts)
@@ -238,6 +239,7 @@ class UpgradeToModularShaftTests(unittest.TestCase):
 
         transformed = upgrade.transform_pom_bytes(pom.encode(), "10.2.20260623", ())
         root = upgrade.parse_xml(transformed)
+        properties = upgrade.direct_child(root, "properties")
         dependencies = upgrade.direct_child(root, "dependencies")
         dependency_artifacts = [
             (
@@ -250,6 +252,7 @@ class UpgradeToModularShaftTests(unittest.TestCase):
         profile = upgrade.direct_child(upgrade.direct_child(root, "profiles"), "profile")
 
         self.assertEqual(upgrade.child_text(profile, "id"), "junit")
+        self.assertEqual(upgrade.child_text(properties, "surefireArgLine"), upgrade.DEFAULT_SUREFIRE_ARG_LINE)
         self.assertIn(("org.aspectj", "aspectjweaver"), dependency_artifacts)
         self.assertNotIn(("org.apache.maven.surefire", "surefire-testng"), dependency_artifacts)
         self.assertNotIn(("org.seleniumhq.selenium", "selenium-java"), dependency_artifacts)


### PR DESCRIPTION
## Summary
- Seed bundled sample POMs with the guarded Surefire JVM arg line that suppresses Java 25 AspectJ `sun.misc.Unsafe` warnings.
- Make the modular upgrader emit the same default for generated projects.
- Add validation/test coverage so sample POMs do not drift back to an empty `surefireArgLine`.

## Root cause
Consumer/sample POMs launch `aspectjweaver` as a Surefire `-javaagent`. AspectJ 1.9.25.1 calls `sun.misc.Unsafe::objectFieldOffset` during agent startup, which Java 25 warns about unless `--sun-misc-unsafe-memory-access=allow` is present.

## Validation
- Direct Java 25 launch reproduced the warning without the flag.
- Direct Java 25 launch with the guarded arg line emitted no Unsafe warning.
- Direct Java 21 launch accepted the guarded arg line because `-XX:+IgnoreUnrecognizedVMOptions` is first.
- `py -3 -m unittest tests.scripts.test_upgrade_to_modular_shaft tests.scripts.test_validate_modular_documentation tests.scripts.test_validate_quality_configuration`
- `py -3 scripts\ci\validate_modular_documentation.py`
- `py -3 scripts\ci\validate_quality_configuration.py`
- `py -3 scripts\ci\validate_reactor_versions.py`
- `mvn help:evaluate -f shaft-engine\src\main\resources\examples\TestNG\shaft-testng-api\pom.xml '-Dexpression=surefireArgLine' -q '-DforceStdout'`