### PR TITLE
Fix Allure report text and visual comparison attachments

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/cucumber/AssertionSteps.java
+++ b/shaft-engine/src/main/java/com/shaft/cucumber/AssertionSteps.java
@@ -32,6 +32,14 @@ public class AssertionSteps {
         this.driver = Objects.requireNonNullElseGet(driver, ThreadLocal::new);
     }
 
+    private static String quoteForReport(String value) {
+        return "\"" + String.valueOf(value).replace("\"", "\\\"") + "\"";
+    }
+
+    private static String locatorForReport(String locatorType, String locatorValue) {
+        return quoteForReport(locatorType + ": " + locatorValue);
+    }
+
     /**
      * Asserts browser attribute equals expectedValue. Supports
      * CurrentUrl, PageSource, Title, WindowHandle, WindowPosition, WindowSize.
@@ -45,7 +53,7 @@ public class AssertionSteps {
         driver.get().assertThat().browser()
                 .attribute(browserAttribute)
                 .isEqualTo(expectedValue)
-                .withCustomReportMessage("I Assert that the [" + browserAttribute + "] attribute of the browser, equals [" + expectedValue + "]")
+                .withCustomReportMessage("I Assert that the " + quoteForReport(browserAttribute) + " attribute of the browser, equals " + quoteForReport(expectedValue))
                 .perform();
     }
 
@@ -62,7 +70,7 @@ public class AssertionSteps {
         driver.get().assertThat().browser()
                 .attribute(browserAttribute)
                 .doesNotEqual(expectedValue)
-                .withCustomReportMessage("I Assert that the [" + browserAttribute + "] attribute of the browser, does not equal [" + expectedValue + "]")
+                .withCustomReportMessage("I Assert that the " + quoteForReport(browserAttribute) + " attribute of the browser, does not equal " + quoteForReport(expectedValue))
                 .perform();
     }
 
@@ -79,7 +87,7 @@ public class AssertionSteps {
         driver.get().assertThat().browser()
                 .attribute(browserAttribute)
                 .contains(expectedValue)
-                .withCustomReportMessage("I Assert that the [" + browserAttribute + "] attribute of the browser, contains [" + expectedValue + "]")
+                .withCustomReportMessage("I Assert that the " + quoteForReport(browserAttribute) + " attribute of the browser, contains " + quoteForReport(expectedValue))
                 .perform();
     }
 
@@ -96,7 +104,7 @@ public class AssertionSteps {
         driver.get().assertThat().browser()
                 .attribute(browserAttribute)
                 .doesNotContain(expectedValue)
-                .withCustomReportMessage("I Assert that the [" + browserAttribute + "] attribute of the browser, does not contain [" + expectedValue + "]")
+                .withCustomReportMessage("I Assert that the " + quoteForReport(browserAttribute) + " attribute of the browser, does not contain " + quoteForReport(expectedValue))
                 .perform();
     }
 
@@ -113,7 +121,7 @@ public class AssertionSteps {
         driver.get().assertThat().browser()
                 .attribute(browserAttribute)
                 .matchesRegex(expectedValue)
-                .withCustomReportMessage("I Assert that the [" + browserAttribute + "] attribute of the browser, matches the regular expression [" + expectedValue + "]")
+                .withCustomReportMessage("I Assert that the " + quoteForReport(browserAttribute) + " attribute of the browser, matches the regular expression " + quoteForReport(expectedValue))
                 .perform();
     }
 
@@ -130,7 +138,7 @@ public class AssertionSteps {
         driver.get().assertThat().browser()
                 .attribute(browserAttribute)
                 .doesNotMatchRegex(expectedValue)
-                .withCustomReportMessage("I Assert that the [" + browserAttribute + "] attribute of the browser, does not match the regular expression [" + expectedValue + "]")
+                .withCustomReportMessage("I Assert that the " + quoteForReport(browserAttribute) + " attribute of the browser, does not match the regular expression " + quoteForReport(expectedValue))
                 .perform();
     }
 
@@ -149,7 +157,7 @@ public class AssertionSteps {
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .attribute(elementAttribute)
                 .isEqualTo(expectedValue)
-                .withCustomReportMessage("I Assert that the [" + elementAttribute + "] attribute of the element found by [" + locatorType + ": " + locatorValue + "], equals [" + expectedValue + "]")
+                .withCustomReportMessage("I Assert that the " + quoteForReport(elementAttribute) + " attribute of the element found by " + locatorForReport(locatorType, locatorValue) + ", equals " + quoteForReport(expectedValue))
                 .perform();
     }
 
@@ -167,7 +175,7 @@ public class AssertionSteps {
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .attribute(elementAttribute)
                 .doesNotEqual(expectedValue)
-                .withCustomReportMessage("I Assert that the [" + elementAttribute + "] attribute of the element found by [" + locatorType + ": " + locatorValue + "], does not equal [" + expectedValue + "]")
+                .withCustomReportMessage("I Assert that the " + quoteForReport(elementAttribute) + " attribute of the element found by " + locatorForReport(locatorType, locatorValue) + ", does not equal " + quoteForReport(expectedValue))
                 .perform();
     }
 
@@ -185,7 +193,7 @@ public class AssertionSteps {
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .attribute(elementAttribute)
                 .contains(expectedValue)
-                .withCustomReportMessage("I Assert that the [" + elementAttribute + "] attribute of the element found by [" + locatorType + ": " + locatorValue + "], contains [" + expectedValue + "]")
+                .withCustomReportMessage("I Assert that the " + quoteForReport(elementAttribute) + " attribute of the element found by " + locatorForReport(locatorType, locatorValue) + ", contains " + quoteForReport(expectedValue))
                 .perform();
     }
 
@@ -203,7 +211,7 @@ public class AssertionSteps {
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .attribute(elementAttribute)
                 .doesNotContain(expectedValue)
-                .withCustomReportMessage("I Assert that the [" + elementAttribute + "] attribute of the element found by [" + locatorType + ": " + locatorValue + "], does not contain [" + expectedValue + "]")
+                .withCustomReportMessage("I Assert that the " + quoteForReport(elementAttribute) + " attribute of the element found by " + locatorForReport(locatorType, locatorValue) + ", does not contain " + quoteForReport(expectedValue))
                 .perform();
     }
 
@@ -221,7 +229,7 @@ public class AssertionSteps {
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .attribute(elementAttribute)
                 .matchesRegex(expectedValue)
-                .withCustomReportMessage("I Assert that the [" + elementAttribute + "] attribute of the element found by [" + locatorType + ": " + locatorValue + "], matches the regular expression [" + expectedValue + "]")
+                .withCustomReportMessage("I Assert that the " + quoteForReport(elementAttribute) + " attribute of the element found by " + locatorForReport(locatorType, locatorValue) + ", matches the regular expression " + quoteForReport(expectedValue))
                 .perform();
     }
 
@@ -239,7 +247,7 @@ public class AssertionSteps {
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .attribute(elementAttribute)
                 .doesNotMatchRegex(expectedValue)
-                .withCustomReportMessage("I Assert that the [" + elementAttribute + "] attribute of the element found by [" + locatorType + ": " + locatorValue + "], does not match the regular expression [" + expectedValue + "]")
+                .withCustomReportMessage("I Assert that the " + quoteForReport(elementAttribute) + " attribute of the element found by " + locatorForReport(locatorType, locatorValue) + ", does not match the regular expression " + quoteForReport(expectedValue))
                 .perform();
     }
 
@@ -255,7 +263,7 @@ public class AssertionSteps {
         driver.get().assertThat()
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .exists()
-                .withCustomReportMessage("I Assert that the element found by [" + locatorType + ": " + locatorValue + "], does exist")
+                .withCustomReportMessage("I Assert that the element found by " + locatorForReport(locatorType, locatorValue) + ", does exist")
                 .perform();
     }
 
@@ -271,7 +279,7 @@ public class AssertionSteps {
         driver.get().assertThat()
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .doesNotExist()
-                .withCustomReportMessage("I Assert that the element found by [" + locatorType + ": " + locatorValue + "], does not exist")
+                .withCustomReportMessage("I Assert that the element found by " + locatorForReport(locatorType, locatorValue) + ", does not exist")
                 .perform();
     }
 
@@ -289,7 +297,7 @@ public class AssertionSteps {
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .cssProperty(elementCSSProperty)
                 .isEqualTo(expectedValue)
-                .withCustomReportMessage("I Assert that the [" + elementCSSProperty + "] CSS property of the element found by [" + locatorType + ": " + locatorValue + "], equals [" + expectedValue + "]")
+                .withCustomReportMessage("I Assert that the " + quoteForReport(elementCSSProperty) + " CSS property of the element found by " + locatorForReport(locatorType, locatorValue) + ", equals " + quoteForReport(expectedValue))
                 .perform();
     }
 
@@ -307,7 +315,7 @@ public class AssertionSteps {
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .cssProperty(elementCSSProperty)
                 .doesNotEqual(expectedValue)
-                .withCustomReportMessage("I Assert that the [" + elementCSSProperty + "] CSS property of the element found by [" + locatorType + ": " + locatorValue + "], does not equal [" + expectedValue + "]")
+                .withCustomReportMessage("I Assert that the " + quoteForReport(elementCSSProperty) + " CSS property of the element found by " + locatorForReport(locatorType, locatorValue) + ", does not equal " + quoteForReport(expectedValue))
                 .perform();
     }
 
@@ -325,7 +333,7 @@ public class AssertionSteps {
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .cssProperty(elementCSSProperty)
                 .contains(expectedValue)
-                .withCustomReportMessage("I Assert that the [" + elementCSSProperty + "] CSS property of the element found by [" + locatorType + ": " + locatorValue + "], contains [" + expectedValue + "]")
+                .withCustomReportMessage("I Assert that the " + quoteForReport(elementCSSProperty) + " CSS property of the element found by " + locatorForReport(locatorType, locatorValue) + ", contains " + quoteForReport(expectedValue))
                 .perform();
     }
 
@@ -343,7 +351,7 @@ public class AssertionSteps {
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .cssProperty(elementCSSProperty)
                 .doesNotContain(expectedValue)
-                .withCustomReportMessage("I Assert that the [" + elementCSSProperty + "] CSS property of the element found by [" + locatorType + ": " + locatorValue + "], does not contain [" + expectedValue + "]")
+                .withCustomReportMessage("I Assert that the " + quoteForReport(elementCSSProperty) + " CSS property of the element found by " + locatorForReport(locatorType, locatorValue) + ", does not contain " + quoteForReport(expectedValue))
                 .perform();
     }
 
@@ -361,7 +369,7 @@ public class AssertionSteps {
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .cssProperty(elementCSSProperty)
                 .matchesRegex(expectedValue)
-                .withCustomReportMessage("I Assert that the [" + elementCSSProperty + "] CSS property of the element found by [" + locatorType + ": " + locatorValue + "], matches the regular expression [" + expectedValue + "]")
+                .withCustomReportMessage("I Assert that the " + quoteForReport(elementCSSProperty) + " CSS property of the element found by " + locatorForReport(locatorType, locatorValue) + ", matches the regular expression " + quoteForReport(expectedValue))
                 .perform();
     }
 
@@ -379,7 +387,7 @@ public class AssertionSteps {
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .cssProperty(elementCSSProperty)
                 .doesNotMatchRegex(expectedValue)
-                .withCustomReportMessage("I Assert that the [" + elementCSSProperty + "] CSS property of the element found by [" + locatorType + ": " + locatorValue + "], does not match the regular expression [" + expectedValue + "]")
+                .withCustomReportMessage("I Assert that the " + quoteForReport(elementCSSProperty) + " CSS property of the element found by " + locatorForReport(locatorType, locatorValue) + ", does not match the regular expression " + quoteForReport(expectedValue))
                 .perform();
     }
 
@@ -395,7 +403,7 @@ public class AssertionSteps {
         driver.get().assertThat()
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .matchesReferenceImage()
-                .withCustomReportMessage("I Assert that the element found by [" + locatorType + ": " + locatorValue + "], exactly matches with the expected reference image using AI (OpenCV)")
+                .withCustomReportMessage("I Assert that the element found by " + locatorForReport(locatorType, locatorValue) + ", matches the expected reference image")
                 .perform();
     }
 
@@ -411,7 +419,7 @@ public class AssertionSteps {
         driver.get().assertThat()
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .doesNotMatchReferenceImage()
-                .withCustomReportMessage("I Assert that the element found by [" + locatorType + ": " + locatorValue + "], does not exactly match with the expected reference image using AI (OpenCV)")
+                .withCustomReportMessage("I Assert that the element found by " + locatorForReport(locatorType, locatorValue) + ", does not match the expected reference image")
                 .perform();
     }
 
@@ -427,7 +435,7 @@ public class AssertionSteps {
         driver.get().assertThat()
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .matchesReferenceImage(ValidationEnums.VisualValidationEngine.EXACT_EYES)
-                .withCustomReportMessage("I Assert that the element found by [" + locatorType + ": " + locatorValue + "], exactly matches with the expected reference image using AI (Applitools Eyes)")
+                .withCustomReportMessage("I Assert that the element found by " + locatorForReport(locatorType, locatorValue) + ", matches the expected reference image")
                 .perform();
     }
 
@@ -443,7 +451,7 @@ public class AssertionSteps {
         driver.get().assertThat()
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .doesNotMatchReferenceImage(ValidationEnums.VisualValidationEngine.EXACT_EYES)
-                .withCustomReportMessage("I Assert that the element found by [" + locatorType + ": " + locatorValue + "], does not exactly match with the expected reference image using AI (Applitools Eyes)")
+                .withCustomReportMessage("I Assert that the element found by " + locatorForReport(locatorType, locatorValue) + ", does not match the expected reference image")
                 .perform();
     }
 
@@ -459,7 +467,7 @@ public class AssertionSteps {
         driver.get().assertThat()
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .matchesReferenceImage(ValidationEnums.VisualValidationEngine.STRICT_EYES)
-                .withCustomReportMessage("I Assert that the element found by [" + locatorType + ": " + locatorValue + "], strictly matches with the expected reference image using AI (Applitools Eyes)")
+                .withCustomReportMessage("I Assert that the element found by " + locatorForReport(locatorType, locatorValue) + ", matches the expected reference image")
                 .perform();
     }
 
@@ -475,7 +483,7 @@ public class AssertionSteps {
         driver.get().assertThat()
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .doesNotMatchReferenceImage(ValidationEnums.VisualValidationEngine.STRICT_EYES)
-                .withCustomReportMessage("I Assert that the element found by [" + locatorType + ": " + locatorValue + "], does not strictly match with the expected reference image using AI (Applitools Eyes)")
+                .withCustomReportMessage("I Assert that the element found by " + locatorForReport(locatorType, locatorValue) + ", does not match the expected reference image")
                 .perform();
     }
 
@@ -491,7 +499,7 @@ public class AssertionSteps {
         driver.get().assertThat()
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .matchesReferenceImage(ValidationEnums.VisualValidationEngine.CONTENT_EYES)
-                .withCustomReportMessage("I Assert that the element found by [" + locatorType + ": " + locatorValue + "], matches the content of the expected reference image using AI (Applitools Eyes)")
+                .withCustomReportMessage("I Assert that the element found by " + locatorForReport(locatorType, locatorValue) + ", matches the expected reference image")
                 .perform();
     }
 
@@ -507,7 +515,7 @@ public class AssertionSteps {
         driver.get().assertThat()
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .doesNotMatchReferenceImage(ValidationEnums.VisualValidationEngine.CONTENT_EYES)
-                .withCustomReportMessage("I Assert that the element found by [" + locatorType + ": " + locatorValue + "], does not match the content of the expected reference image using AI (Applitools Eyes)")
+                .withCustomReportMessage("I Assert that the element found by " + locatorForReport(locatorType, locatorValue) + ", does not match the expected reference image")
                 .perform();
     }
 
@@ -523,7 +531,7 @@ public class AssertionSteps {
         driver.get().assertThat()
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .matchesReferenceImage(ValidationEnums.VisualValidationEngine.LAYOUT_EYES)
-                .withCustomReportMessage("I Assert that the element found by [" + locatorType + ": " + locatorValue + "], matches the layout of the expected reference image using AI (Applitools Eyes)")
+                .withCustomReportMessage("I Assert that the element found by " + locatorForReport(locatorType, locatorValue) + ", matches the expected reference image")
                 .perform();
     }
 
@@ -539,7 +547,7 @@ public class AssertionSteps {
         driver.get().assertThat()
                 .element(ElementSteps.getLocatorFromTypeAndValue(locatorType, locatorValue))
                 .doesNotMatchReferenceImage(ValidationEnums.VisualValidationEngine.LAYOUT_EYES)
-                .withCustomReportMessage("I Assert that the element found by [" + locatorType + ": " + locatorValue + "], does not match the layout of the expected reference image using AI (Applitools Eyes)")
+                .withCustomReportMessage("I Assert that the element found by " + locatorForReport(locatorType, locatorValue) + ", does not match the expected reference image")
                 .perform();
     }
 }

--- a/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -1031,7 +1031,7 @@ public class DriverFactoryHelper {
                 return Arrays.asList("Screenshot", "App Launch Screenshot", new ByteArrayInputStream(screenshot));
             }
         } catch (Exception e) {
-            ReportManager.logDiscrete("Could not capture launch screenshot [" + e.getClass().getSimpleName() + "]: " + e.getMessage());
+            ReportManager.logDiscrete("Could not capture launch screenshot \"" + e.getClass().getSimpleName() + "\": " + e.getMessage());
         }
         return null;
     }

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -412,7 +412,7 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
                     browserActionsHelper.checkNavigationWasSuccessful(driverFactoryHelper.getDriver(), initialURL, targetUrl, targetUrlAfterRedirection);
                 }
             }
-            browserActionsHelper.passAction(driverFactoryHelper.getDriver(), modifiedTargetUrlForLogging);
+            browserActionsHelper.passAction(driverFactoryHelper.getDriver(), "navigateToUrl", modifiedTargetUrlForLogging);
         } catch (Exception rootCauseException) {
             browserActionsHelper.failAction(driverFactoryHelper.getDriver(), modifiedTargetUrlForLogging, rootCauseException);
         }

--- a/shaft-engine/src/main/java/com/shaft/gui/element/AlertActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/AlertActions.java
@@ -182,7 +182,7 @@ public class AlertActions extends FluentWebDriverAction implements com.shaft.gui
         try {
             waitForAlertToBePresent();
             var alertText = driverFactoryHelper.getDriver().switchTo().alert().getText();
-            ReportManager.logDiscrete("Alert Text is: [" + alertText + "]");
+            ReportManager.logDiscrete("Alert Text is \"" + alertText + "\".");
             elementActionsHelper.passAction(driverFactoryHelper.getDriver(), null, Thread.currentThread().getStackTrace()[1].getMethodName(), null, null, null);
             return alertText;
         } catch (Exception rootCauseException) {
@@ -209,7 +209,7 @@ public class AlertActions extends FluentWebDriverAction implements com.shaft.gui
         try {
             waitForAlertToBePresent();
             driverFactoryHelper.getDriver().switchTo().alert().sendKeys(text);
-            ReportManager.logDiscrete("Text typed into Alert is: [" + text + "]");
+            ReportManager.logDiscrete("Text typed into Alert is \"" + text + "\".");
             elementActionsHelper.passAction(driverFactoryHelper.getDriver(), null, Thread.currentThread().getStackTrace()[1].getMethodName(), null, null, null);
         } catch (Exception rootCauseException) {
             elementActionsHelper.failAction(driverFactoryHelper.getDriver(), null, rootCauseException);

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
@@ -51,9 +51,9 @@ public class ImageProcessingActions {
             File[] referenceFiles = referenceFolder.listFiles();
             File[] testFiles = testFolder.listFiles();
 
-            ReportManager.log("Comparing [" + Objects.requireNonNull(testFiles).length + "] image files from the testFolder ["
-                    + testFolder.getPath() + "] against [" + Objects.requireNonNull(referenceFiles).length
-                    + "] image files from the referenceFolder [" + referenceFolder.getPath() + "]");
+            ReportManager.log("Comparing \"" + Objects.requireNonNull(testFiles).length + "\" image files from the testFolder \""
+                    + testFolder.getPath() + "\" against \"" + Objects.requireNonNull(referenceFiles).length
+                    + "\" image files from the referenceFolder \"" + referenceFolder.getPath() + "\".");
 
             // sorting objects for files by fileName
             Arrays.sort(referenceFiles);
@@ -195,7 +195,7 @@ public class ImageProcessingActions {
                     .replaceAll("_{2}", "_").replaceAll("contains", "_contains").replaceAll("_$", "");
             // https://github.com/ShaftHQ/SHAFT_ENGINE/issues/1604
             hashedFileName = Hashing.sha256().hashString(key, StandardCharsets.UTF_8).toString();
-            ReportManager.log("Element Locator: " + locatorLogText + " was formatted to: " + key, Level.INFO);
+            ReportManager.logDiscrete("Element Locator \"" + locatorLogText + "\" was formatted to \"" + key + "\".", Level.DEBUG);
             return hashedFileName;
         });
     }
@@ -325,8 +325,8 @@ public class ImageProcessingActions {
                 List<Object> testScreenshotAttachment = Arrays.asList(
                         "Test Screenshot", relatedTestFileName, testIn);
                 ReportManagerHelper.log(
-                        "Test Screenshot [" + relatedTestFileName + "] and related Reference Image ["
-                                + relatedReferenceFileName + "] match by [" + percentage + "] percent.",
+                        "Test Screenshot \"" + relatedTestFileName + "\" and related Reference Image \""
+                                + relatedReferenceFileName + "\" match by \"" + percentage + "\" percent.",
                         Arrays.asList(referenceScreenshotAttachment, testScreenshotAttachment));
             } catch (IOException ioEx) {
                 ReportManagerHelper.logDiscrete(ioEx);
@@ -345,11 +345,11 @@ public class ImageProcessingActions {
             }
         }
 
-        ReportManager.log("[" + passedImagesCount + "] images passed, and [" + failedImagesCount
-                + "] images failed the threshold of [" + threshold + "%] matching.");
+        ReportManager.log("\"" + passedImagesCount + "\" images passed, and \"" + failedImagesCount
+                + "\" images failed the threshold of \"" + threshold + "%\" matching.");
         if (failedImagesCount > 0) {
-            FailureReporter.fail("[" + failedImagesCount + "] images failed the threshold of ["
-                    + threshold + "%] matching.");
+            FailureReporter.fail("\"" + failedImagesCount + "\" images failed the threshold of \""
+                    + threshold + "%\" matching.");
         }
 
     }

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/browser/BrowserActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/browser/BrowserActions.java
@@ -97,7 +97,7 @@ public class BrowserActions implements com.shaft.gui.driver.BrowserActionsContra
     @Override
     public BrowserActions navigateToURL(String targetUrl) {
         page().navigate(targetUrl);
-        ReportManager.log("Navigated Playwright page to URL: " + targetUrl);
+        ReportManager.log("Navigate to url \"" + targetUrl + "\".");
         return this;
     }
 

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightElementValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightElementValidationsBuilder.java
@@ -163,12 +163,30 @@ public class PlaywrightElementValidationsBuilder implements ElementAssertions {
 
     private ValidationsExecutor visualValidation(ValidationEnums.ValidationType validationType,
                                                  ValidationEnums.VisualValidationEngine visualValidationEngine) {
+        appendShaftElementNameIfAvailable();
         reportMessageBuilder.append(validationType.getValue() ? "matches" : "does not match")
-                .append(" the reference image \"").append(visualValidationEngine).append("\".");
+                .append(" the reference image.");
         var executor = builder("elementMatches", null, null)
                 .createVisualExecutor(validationType, visualValidationEngine);
         executor.internalPerform();
         return executor;
+    }
+
+    private void appendShaftElementNameIfAvailable() {
+        var elementName = extractSmartLocatorName();
+        if (!elementName.isBlank()) {
+            reportMessageBuilder.append("\"").append(elementName).append("\" ");
+        }
+    }
+
+    private String extractSmartLocatorName() {
+        if (locatorDescription == null) {
+            return "";
+        }
+        var prefix = "Smart Locator: \"";
+        return locatorDescription.startsWith(prefix) && locatorDescription.endsWith("\"")
+                ? locatorDescription.substring(prefix.length(), locatorDescription.length() - 1)
+                : "";
     }
 
     private ValidationsExecutor expectedState(String validationMethod, ValidationEnums.ValidationType validationType) {

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightValidationsExecutor.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightValidationsExecutor.java
@@ -20,9 +20,12 @@ import com.shaft.validation.internal.ValidationsHelper;
 import io.qameta.allure.Allure;
 import io.qameta.allure.Step;
 import io.qameta.allure.model.Parameter;
+import org.apache.logging.log4j.Level;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -30,6 +33,7 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 final class PlaywrightValidationsExecutor extends ValidationsExecutor {
+    private static final String VISUAL_COMPARISON_ATTACHMENT_NAME = "Visual Comparison";
     private final ValidationEnums.ValidationCategory validationCategory;
     private final PlaywrightSession session;
     private final Locator locator;
@@ -243,25 +247,39 @@ final class PlaywrightValidationsExecutor extends ValidationsExecutor {
         boolean expected = validationType.getValue();
         List<List<Object>> visualAttachments = new ArrayList<>();
         byte[] referenceImage = ImageProcessingActions.getReferenceImage(locatorDescription);
-        if (referenceImage != null && !Arrays.equals(new byte[0], referenceImage)) {
-            visualAttachments.add(Arrays.asList("Screenshot", "Reference Screenshot", referenceImage));
-        }
+        boolean hasReferenceImage = referenceImage != null && referenceImage.length > 0;
 
         byte[] elementScreenshot = locator.screenshot();
         Boolean actualResult = ImageProcessingActions.compareAgainstBaseline(locatorDescription, elementScreenshot,
                 ImageProcessingActions.VisualValidationEngine.valueOf(visualValidationEngine.name()));
-        visualAttachments.add(Arrays.asList("Screenshot", "Actual Screenshot", elementScreenshot));
 
+        byte[] shutterbugDifferencesImage = new byte[0];
         if (visualValidationEngine.equals(ValidationEnums.VisualValidationEngine.EXACT_SHUTTERBUG)
                 && !Boolean.TRUE.equals(actualResult)) {
-            byte[] shutterbugDifferencesImage = ImageProcessingActions.getShutterbugDifferencesImage(locatorDescription);
-            if (!Arrays.equals(new byte[0], shutterbugDifferencesImage)) {
-                visualAttachments.add(Arrays.asList("Screenshot", "Differences", shutterbugDifferencesImage));
-            }
+            shutterbugDifferencesImage = ImageProcessingActions.getShutterbugDifferencesImage(locatorDescription);
         }
 
+        boolean visualComparisonAttached = hasReferenceImage
+                && attachVisualComparison(referenceImage, elementScreenshot, shutterbugDifferencesImage);
         boolean actual = Boolean.TRUE.equals(actualResult);
-        return new Outcome(expected == actual, expected, actual, commonParameters(expected, actual), visualAttachments);
+        return new Outcome(expected == actual, expected, actual, commonParameters(expected, actual),
+                visualAttachments, visualComparisonAttached);
+    }
+
+    private static boolean attachVisualComparison(byte[] expectedImage, byte[] actualImage, byte[] differenceImage) {
+        try {
+            var content = new JSONObject()
+                    .put("expected", "data:image/png;base64," + Base64.getEncoder().encodeToString(expectedImage))
+                    .put("actual", "data:image/png;base64," + Base64.getEncoder().encodeToString(actualImage));
+            if (differenceImage != null && differenceImage.length > 0) {
+                content.put("diff", "data:image/png;base64," + Base64.getEncoder().encodeToString(differenceImage));
+            }
+            Allure.addAttachment(VISUAL_COMPARISON_ATTACHMENT_NAME, "application/vnd.allure.image.diff", content.toString());
+            return true;
+        } catch (JSONException jsonException) {
+            ReportManagerHelper.logDiscrete(jsonException, Level.DEBUG);
+            return false;
+        }
     }
 
     private Object readActual() {
@@ -417,7 +435,7 @@ final class PlaywrightValidationsExecutor extends ValidationsExecutor {
 
     private List<List<Object>> attachments(Outcome outcome) {
         List<List<Object>> attachments = new ArrayList<>(outcome.attachments());
-        if (shouldAttachScreenshot(outcome.passed())) {
+        if (!outcome.visualComparisonAttached() && shouldAttachScreenshot(outcome.passed())) {
             try {
                 byte[] screenshot = session.page().screenshot(new Page.ScreenshotOptions().setFullPage(true));
                 List<Object> screenshotAttachment = new ScreenshotManager()
@@ -459,7 +477,12 @@ final class PlaywrightValidationsExecutor extends ValidationsExecutor {
                            Object expected,
                            Object actual,
                            LinkedHashMap<String, String> parameters,
-                           List<List<Object>> attachments) {
+                           List<List<Object>> attachments,
+                           boolean visualComparisonAttached) {
+        private Outcome(boolean passed, Object expected, Object actual, LinkedHashMap<String, String> parameters,
+                        List<List<Object>> attachments) {
+            this(passed, expected, actual, parameters, attachments, false);
+        }
     }
 
     private static final class SeedBuilder extends ValidationsBuilder {

--- a/shaft-engine/src/main/java/com/shaft/tools/io/CSVFileManager.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/CSVFileManager.java
@@ -53,10 +53,10 @@ public class CSVFileManager {
             records = CSVFormat.DEFAULT.withFirstRecordAsHeader().parse(reader);
             RowReader = new FileReader(csvFilePath);
             RowRecords = CSVFormat.DEFAULT.withFirstRecordAsHeader().parse(RowReader);
-            ReportManager.logDiscrete("Reading CSV test data from [" + this.csvFilePath + "].", Level.DEBUG);
+            ReportManager.logDiscrete("Reading CSV test data from \"" + this.csvFilePath + "\".", Level.DEBUG);
         } catch (IOException | OutOfMemoryError e) {
-            FailureReporter.fail(this.getClass(), "Could not find the desired file. [" + this.csvFilePath + "] ", e);
-            ReportManager.logDiscrete("Could not find the desired file. [" + this.csvFilePath + "] ", Level.ERROR);
+            FailureReporter.fail(this.getClass(), "Could not find the desired file \"" + this.csvFilePath + "\".", e);
+            ReportManager.logDiscrete("Could not find the desired file \"" + this.csvFilePath + "\".", Level.ERROR);
         }
 
     }
@@ -77,7 +77,7 @@ public class CSVFileManager {
                 }
                 rows.add(row);
             }
-            ReportManager.logDiscrete("Read all CSV rows from [" + csvFilePath + "].", Level.DEBUG);
+            ReportManager.logDiscrete("Read all CSV rows from \"" + csvFilePath + "\".", Level.DEBUG);
         } catch (Exception e) {
             ReportManager.logDiscrete("Could not retrieve rows: " + e.getMessage(), Level.ERROR);
         }
@@ -92,7 +92,7 @@ public class CSVFileManager {
     public List<String> getColumns() {
         try {
             List<String> columns = new ArrayList<>(records.getHeaderNames());
-            ReportManager.logDiscrete("Read CSV column names from [" + csvFilePath + "].", Level.DEBUG);
+            ReportManager.logDiscrete("Read CSV column names from \"" + csvFilePath + "\".", Level.DEBUG);
             return columns;
         } catch (Exception e) {
             ReportManager.logDiscrete("Could not retrieve columns: " + e.getMessage(), Level.ERROR);
@@ -230,7 +230,7 @@ public class CSVFileManager {
     public String getFirstColumn() {
         try {
             List<String> columns = getColumns();
-            ReportManager.logDiscrete("Read first CSV column name from [" + csvFilePath + "].", Level.DEBUG);
+            ReportManager.logDiscrete("Read first CSV column name from \"" + csvFilePath + "\".", Level.DEBUG);
             return columns.getFirst();
         } catch (Exception e) {
             ReportManager.logDiscrete("Could not retrieve the first column: " + e.getMessage(), Level.ERROR);

--- a/shaft-engine/src/main/java/com/shaft/tools/io/ExcelFileManager.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/ExcelFileManager.java
@@ -65,11 +65,11 @@ public class ExcelFileManager {
             fis = new FileInputStream(excelFilePath);
             workbook = new XSSFWorkbook(fis);
             fis.close();
-            ReportManager.logDiscrete("Reading Excel test data from [" + excelFilePath + "].", Level.DEBUG);
+            ReportManager.logDiscrete("Reading Excel test data from \"" + excelFilePath + "\".", Level.DEBUG);
         } catch (IOException | OutOfMemoryError e) {
-            FailureReporter.fail(this.getClass(), "Couldn't find the desired file. [" + excelFilePath + "].", e);
+            FailureReporter.fail(this.getClass(), "Couldn't find the desired file \"" + excelFilePath + "\".", e);
         } catch (EmptyFileException e) {
-            FailureReporter.fail(this.getClass(), "Please check the target file, as it may be corrupted. [" + excelFilePath + "].", e);
+            FailureReporter.fail(this.getClass(), "Please check the target file, as it may be corrupted. \"" + excelFilePath + "\".", e);
         }
 
         List<List<Object>> attachments = new ArrayList<>();

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java
@@ -41,6 +41,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchema;
 
 public class ValidationsHelper {
+    private static final String VISUAL_COMPARISON_ATTACHMENT_NAME = "Visual Comparison";
     protected static final ThreadLocal<List<String>> verificationFailuresList = ThreadLocal.withInitial(ArrayList::new);
     protected static final ThreadLocal<AssertionError> verificationError = new ThreadLocal<>();
     private final ValidationEnums.ValidationCategory validationCategory;
@@ -499,6 +500,7 @@ public class ValidationsHelper {
         AtomicInteger elementCount = new AtomicInteger();
         AtomicReference<ValidationEnums.VisualValidationEngine> internalVisualEngine = new AtomicReference<>(visualValidationEngine);
         List<List<Object>> attachments = new ArrayList<>();
+        AtomicBoolean visualComparisonAttached = new AtomicBoolean(false);
 
         try {
             //https://github.com/assertthat/selenium-shutterbug/issues/105
@@ -510,9 +512,6 @@ public class ValidationsHelper {
             byte[] referenceImage = ImageProcessingActions.getReferenceImage(locator);
             if (referenceImage !=null && !Arrays.equals(new byte[0], referenceImage)) {
                 ReportManagerHelper.logDiscrete("Reference image found.", Level.INFO);
-                List<Object> expectedValueAttachment = Arrays.asList("Screenshot", "Reference Screenshot",
-                        referenceImage);
-                attachments.add(expectedValueAttachment);
             } else {
                 ReportManagerHelper.logDiscrete("Reference image not found, attempting to capture new reference.", Level.INFO);
             }
@@ -535,12 +534,7 @@ public class ValidationsHelper {
                 }
                 actualResult = ImageProcessingActions.compareAgainstBaseline(driver, locator, elementScreenshot, ImageProcessingActions.VisualValidationEngine.valueOf(visualValidationEngine.name()));
 
-                List<Object> actualValueAttachment = Arrays.asList("Screenshot", "Actual Screenshot",
-                        elementScreenshot);
-                attachments.add(actualValueAttachment);
-
                 // prepare content for allure attachment
-                var content = new JSONObject();
                 byte[] shutterbugDifferencesImage = new byte[0];
 
                 // compare actual and reference screenshots
@@ -548,28 +542,10 @@ public class ValidationsHelper {
                 if (isDifferencesImageApplicable) {
                     //if shutterbug and failed, get differences screenshot
                     shutterbugDifferencesImage = ImageProcessingActions.getShutterbugDifferencesImage(locator);
-                    if (!Arrays.equals(new byte[0], shutterbugDifferencesImage)) {
-                        List<Object> differencesAttachment = Arrays.asList("Screenshot", "Differences",
-                                shutterbugDifferencesImage);
-                        attachments.add(differencesAttachment);
-                    }
                 }
 
                 if (referenceImage != null) {
-                    try {
-                        // prepare content for allure attachment
-                        content.put("expected", "data:image/png;base64,"
-                                + Base64.getEncoder().encodeToString(referenceImage))
-                                .put("actual", "data:image/png;base64,"
-                                + Base64.getEncoder().encodeToString(elementScreenshot));
-                        if (isDifferencesImageApplicable && !Arrays.equals(new byte[0], shutterbugDifferencesImage))
-                            content.put("diff", "data:image/png;base64,"
-                                    + Base64.getEncoder().encodeToString(shutterbugDifferencesImage));
-
-                        Allure.addAttachment("Screenshot diff", "application/vnd.allure.image.diff", content.toString());
-                    } catch (JSONException jsonException) {
-                        //failed to add differences image to allure attachment, ignore it
-                    }
+                    visualComparisonAttached.set(attachVisualComparison(referenceImage, elementScreenshot, shutterbugDifferencesImage));
                 }
 
                 // if found set value to 1, else set value to zero
@@ -592,7 +568,23 @@ public class ValidationsHelper {
         parameters.put("Actual value", String.valueOf(actual.get()));
         updateAllureParameters(parameters);
         // force take page screenshot, (rather than element highlighted screenshot)
-        reportValidationState(validationState.get(), expected, actual, driver, elementCount.get() == 0 ? null : locator, attachments);
+        reportValidationState(validationState.get(), expected, actual, driver, elementCount.get() == 0 ? null : locator, attachments, visualComparisonAttached.get());
+    }
+
+    private static boolean attachVisualComparison(byte[] expectedImage, byte[] actualImage, byte[] differenceImage) {
+        try {
+            var content = new JSONObject()
+                    .put("expected", "data:image/png;base64," + Base64.getEncoder().encodeToString(expectedImage))
+                    .put("actual", "data:image/png;base64," + Base64.getEncoder().encodeToString(actualImage));
+            if (differenceImage != null && differenceImage.length > 0) {
+                content.put("diff", "data:image/png;base64," + Base64.getEncoder().encodeToString(differenceImage));
+            }
+            Allure.addAttachment(VISUAL_COMPARISON_ATTACHMENT_NAME, "application/vnd.allure.image.diff", content.toString());
+            return true;
+        } catch (JSONException jsonException) {
+            ReportManagerHelper.logDiscrete(jsonException, Level.DEBUG);
+            return false;
+        }
     }
 
     private String getPageText(WebDriver driver) {
@@ -759,13 +751,17 @@ public class ValidationsHelper {
     }
 
     private void reportValidationState(boolean validationState, Object expected, Object actual, WebDriver driver, By locator, List<List<Object>> attachments) {
+        reportValidationState(validationState, expected, actual, driver, locator, attachments, false);
+    }
+
+    private void reportValidationState(boolean validationState, Object expected, Object actual, WebDriver driver, By locator, List<List<Object>> attachments, boolean skipDefaultScreenshot) {
         //initialize attachments object if no attachments were already prepared
         attachments = attachments == null ? new ArrayList<>() : attachments;
 
         // prepare WebDriver attachments
         if (driver != null) {
             // prepare screenshot with element highlighting
-            if (attachments.isEmpty())
+            if (!skipDefaultScreenshot && attachments.isEmpty())
                 attachments.add(new ScreenshotManager().takeScreenshot(driver, locator, this.validationCategoryString, validationState));
             // prepare page snapshot mhtml/html
             var whenToTakePageSourceSnapshot = SHAFT.Properties.visuals.whenToTakePageSourceSnapshot().toLowerCase();

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverElementValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverElementValidationsBuilder.java
@@ -1,5 +1,6 @@
 package com.shaft.validation.internal;
 
+import com.shaft.tools.internal.support.JavaHelper;
 import com.shaft.validation.ValidationEnums;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
@@ -66,7 +67,7 @@ public class WebDriverElementValidationsBuilder implements com.shaft.gui.driver.
         this.validationType = ValidationEnums.ValidationType.POSITIVE;
         this.validationMethod = "elementMatches";
         this.visualValidationEngine = ValidationEnums.VisualValidationEngine.EXACT_SHUTTERBUG;
-        reportMessageBuilder.append("matches the reference image \"").append(ValidationEnums.VisualValidationEngine.EXACT_SHUTTERBUG).append("\".");
+        appendVisualValidationMessage(true);
         var executor = new ValidationsExecutor(this);
         executor.internalPerform();
         return executor;
@@ -83,7 +84,7 @@ public class WebDriverElementValidationsBuilder implements com.shaft.gui.driver.
         this.validationType = ValidationEnums.ValidationType.POSITIVE;
         this.validationMethod = "elementMatches";
         this.visualValidationEngine = visualValidationEngine;
-        reportMessageBuilder.append("matches the reference image \"").append(visualValidationEngine).append("\".");
+        appendVisualValidationMessage(true);
         var executor = new ValidationsExecutor(this);
         executor.internalPerform();
         return executor;
@@ -101,7 +102,7 @@ public class WebDriverElementValidationsBuilder implements com.shaft.gui.driver.
         this.validationType = ValidationEnums.ValidationType.NEGATIVE;
         this.validationMethod = "elementMatches";
         this.visualValidationEngine = ValidationEnums.VisualValidationEngine.EXACT_OPENCV;
-        reportMessageBuilder.append("does not match the reference image \"").append(ValidationEnums.VisualValidationEngine.EXACT_OPENCV).append("\".");
+        appendVisualValidationMessage(false);
         var executor = new ValidationsExecutor(this);
         executor.internalPerform();
         return executor;
@@ -118,10 +119,33 @@ public class WebDriverElementValidationsBuilder implements com.shaft.gui.driver.
         this.validationType = ValidationEnums.ValidationType.NEGATIVE;
         this.validationMethod = "elementMatches";
         this.visualValidationEngine = visualValidationEngine;
-        reportMessageBuilder.append("does not match the reference image \"").append(visualValidationEngine).append("\".");
+        appendVisualValidationMessage(false);
         var executor = new ValidationsExecutor(this);
         executor.internalPerform();
         return executor;
+    }
+
+    private void appendVisualValidationMessage(boolean shouldMatch) {
+        appendShaftElementNameIfAvailable();
+        reportMessageBuilder.append(shouldMatch ? "matches" : "does not match").append(" the reference image.");
+    }
+
+    private void appendShaftElementNameIfAvailable() {
+        var elementName = extractSmartLocatorName();
+        if (!elementName.isBlank()) {
+            reportMessageBuilder.append("\"").append(elementName).append("\" ");
+        }
+    }
+
+    private String extractSmartLocatorName() {
+        if (locator == null) {
+            return "";
+        }
+        var formattedLocator = JavaHelper.formatLocatorToString(locator);
+        var prefix = "Smart Locator: \"";
+        return formattedLocator.startsWith(prefix) && formattedLocator.endsWith("\"")
+                ? formattedLocator.substring(prefix.length(), formattedLocator.length() - 1)
+                : "";
     }
 
     /**

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsReportingUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsReportingUnitTest.java
@@ -1,0 +1,29 @@
+package com.shaft.gui.internal.image;
+
+import com.shaft.tools.io.ReportManager;
+import org.apache.logging.log4j.Level;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.openqa.selenium.By;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+
+public class ImageProcessingActionsReportingUnitTest {
+    @Test
+    public void formatElementLocatorToImagePathShouldLogAsDebugOnly() {
+        By locator = By.id("visual-" + System.nanoTime());
+
+        try (MockedStatic<ReportManager> reportManager = Mockito.mockStatic(ReportManager.class)) {
+            ImageProcessingActions.formatElementLocatorToImagePath(locator);
+
+            reportManager.verify(() -> ReportManager.logDiscrete(
+                    contains("Element Locator \"By.id: visual-"), eq(Level.DEBUG)));
+            reportManager.verify(() -> ReportManager.log(anyString(), any(Level.class)), never());
+        }
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/gui/playwright/validation/PlaywrightElementVisualValidationTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/playwright/validation/PlaywrightElementVisualValidationTest.java
@@ -5,14 +5,23 @@ import com.shaft.driver.SHAFT;
 import com.shaft.gui.internal.image.ImageProcessingActions;
 import com.shaft.gui.playwright.internal.PlaywrightSession;
 import com.shaft.properties.internal.Properties;
+import com.shaft.tools.io.ReportManager;
+import com.shaft.tools.io.internal.ReportManagerHelper;
 import com.shaft.validation.ValidationEnums;
 import com.shaft.validation.internal.ValidationsHelper;
+import io.qameta.allure.Allure;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -46,6 +55,63 @@ public class PlaywrightElementVisualValidationTest {
             verify(locator).screenshot();
             imageProcessingActions.verify(() -> ImageProcessingActions.compareAgainstBaseline("CSS:#login", screenshot,
                     ImageProcessingActions.VisualValidationEngine.EXACT_OPENCV));
+        }
+    }
+
+    @Test
+    public void matchesReferenceImageShouldNotReportVisualEngineInStepTitle() {
+        PlaywrightSession session = mock(PlaywrightSession.class);
+        Locator locator = mock(Locator.class);
+        byte[] screenshot = new byte[]{1, 2, 3};
+        when(locator.screenshot()).thenReturn(screenshot);
+        SHAFT.Properties.visuals.set().screenshotParamsWhenToTakeAScreenshot("Never");
+        SHAFT.Properties.visuals.set().whenToTakePageSourceSnapshot("Never");
+
+        try (MockedStatic<ImageProcessingActions> imageProcessingActions = Mockito.mockStatic(ImageProcessingActions.class);
+             MockedStatic<ReportManager> reportManager = Mockito.mockStatic(ReportManager.class)) {
+            imageProcessingActions.when(() -> ImageProcessingActions.getReferenceImage(anyString()))
+                    .thenReturn(null);
+            imageProcessingActions.when(() -> ImageProcessingActions.compareAgainstBaseline("Smart Locator: \"Login\"", screenshot,
+                            ImageProcessingActions.VisualValidationEngine.EXACT_OPENCV))
+                    .thenReturn(true);
+
+            new PlaywrightElementValidationsBuilder(ValidationEnums.ValidationCategory.HARD_ASSERT,
+                    session, locator, "Smart Locator: \"Login\"").matchesReferenceImage();
+
+            reportManager.verify(() -> ReportManager.logDiscrete(
+                    "Assert that the element \"Login\" matches the reference image."));
+        }
+    }
+
+    @Test
+    public void matchesReferenceImageShouldAttachOnlyVisualComparisonWhenReferenceExists() {
+        PlaywrightSession session = mock(PlaywrightSession.class);
+        Locator locator = mock(Locator.class);
+        byte[] referenceScreenshot = new byte[]{1, 2, 3};
+        byte[] actualScreenshot = new byte[]{1, 2, 4};
+        when(locator.screenshot()).thenReturn(actualScreenshot);
+        SHAFT.Properties.visuals.set().screenshotParamsWhenToTakeAScreenshot("Never");
+        SHAFT.Properties.visuals.set().whenToTakePageSourceSnapshot("Never");
+
+        try (MockedStatic<ImageProcessingActions> imageProcessingActions = Mockito.mockStatic(ImageProcessingActions.class);
+             MockedStatic<Allure> allureMocked = Mockito.mockStatic(Allure.class);
+             MockedStatic<ReportManagerHelper> reportManagerHelperMocked = Mockito.mockStatic(ReportManagerHelper.class)) {
+            allureMocked.when(Allure::getLifecycle).thenCallRealMethod();
+            imageProcessingActions.when(() -> ImageProcessingActions.getReferenceImage("CSS:#login"))
+                    .thenReturn(referenceScreenshot);
+            imageProcessingActions.when(() -> ImageProcessingActions.compareAgainstBaseline("CSS:#login", actualScreenshot,
+                            ImageProcessingActions.VisualValidationEngine.EXACT_OPENCV))
+                    .thenReturn(true);
+            @SuppressWarnings({"rawtypes", "unchecked"})
+            ArgumentCaptor<List<List<Object>>> attachmentsCaptor = (ArgumentCaptor) ArgumentCaptor.forClass(List.class);
+
+            new PlaywrightElementValidationsBuilder(ValidationEnums.ValidationCategory.HARD_ASSERT,
+                    session, locator, "CSS:#login").matchesReferenceImage();
+
+            reportManagerHelperMocked.verify(() -> ReportManagerHelper.attach(attachmentsCaptor.capture()));
+            Assert.assertTrue(attachmentsCaptor.getValue().isEmpty());
+            allureMocked.verify(() -> Allure.addAttachment(eq("Visual Comparison"),
+                    eq("application/vnd.allure.image.diff"), anyString()));
         }
     }
 }

--- a/shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelperNewPatternCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelperNewPatternCoverageUnitTest.java
@@ -9,6 +9,7 @@ import com.shaft.gui.internal.image.ScreenshotManager;
 import com.shaft.properties.internal.Properties;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import com.shaft.validation.ValidationEnums;
+import io.qameta.allure.Allure;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
@@ -26,6 +27,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -164,8 +166,8 @@ public class ValidationsHelperNewPatternCoverageUnitTest {
         Assert.assertFalse(elementBuilder.reportMessageBuilder.toString().contains("By.id: message"));
     }
 
-    @Test(description = "Visual validation screenshot bytes should be routed as screenshot attachments")
-    public void visualValidationImageBytesShouldUseScreenshotAttachmentType() {
+    @Test(description = "Visual validation should attach one Allure visual comparison artifact")
+    public void visualValidationImageBytesShouldUseVisualComparisonAttachmentOnly() {
         ValidationsHelper helper = new ValidationsHelper(ValidationEnums.ValidationCategory.HARD_ASSERT);
         By locator = By.id("logo");
         WebDriver driver = mock(WebDriver.class);
@@ -177,7 +179,9 @@ public class ValidationsHelperNewPatternCoverageUnitTest {
         when(element.getScreenshotAs(any())).thenReturn(actualScreenshot);
 
         try (MockedStatic<ImageProcessingActions> imageProcessingMocked = Mockito.mockStatic(ImageProcessingActions.class);
-             MockedStatic<ReportManagerHelper> reportManagerHelperMocked = Mockito.mockStatic(ReportManagerHelper.class)) {
+             MockedStatic<ReportManagerHelper> reportManagerHelperMocked = Mockito.mockStatic(ReportManagerHelper.class);
+             MockedStatic<Allure> allureMocked = Mockito.mockStatic(Allure.class)) {
+            allureMocked.when(Allure::getLifecycle).thenCallRealMethod();
             imageProcessingMocked.when(() -> ImageProcessingActions.getReferenceImage(any(By.class)))
                     .thenReturn(referenceScreenshot);
             imageProcessingMocked.when(() -> ImageProcessingActions.compareAgainstBaseline(any(), any(By.class), any(byte[].class), any()))
@@ -190,10 +194,9 @@ public class ValidationsHelperNewPatternCoverageUnitTest {
 
             reportManagerHelperMocked.verify(() -> ReportManagerHelper.attach(attachmentsCaptor.capture()));
             List<List<Object>> attachments = attachmentsCaptor.getValue();
-            Assert.assertTrue(hasAttachment(attachments, "Screenshot", "Reference Screenshot", referenceScreenshot));
-            Assert.assertTrue(hasAttachment(attachments, "Screenshot", "Actual Screenshot", actualScreenshot));
-            Assert.assertFalse(attachments.stream().anyMatch(attachment ->
-                    "Validation Test Data".equals(attachment.get(0)) && attachment.get(1).toString().contains("Screenshot")));
+            Assert.assertTrue(attachments.isEmpty());
+            allureMocked.verify(() -> Allure.addAttachment(eq("Visual Comparison"),
+                    eq("application/vnd.allure.image.diff"), anyString()));
         }
     }
 
@@ -235,10 +238,5 @@ public class ValidationsHelperNewPatternCoverageUnitTest {
 
         Assert.assertEquals(performValidation.invoke(helper, "a", "b", ValidationEnums.ValidationComparisonType.EQUALS, ValidationEnums.ValidationType.POSITIVE), false);
         Assert.assertEquals(performValidation.invoke(helper, 3, 3, ValidationEnums.NumbersComparativeRelation.EQUALS, ValidationEnums.ValidationType.POSITIVE), true);
-    }
-
-    private boolean hasAttachment(List<List<Object>> attachments, String type, String name, byte[] content) {
-        return attachments.stream().anyMatch(attachment ->
-                type.equals(attachment.get(0)) && name.equals(attachment.get(1)) && attachment.get(2) == content);
     }
 }

--- a/shaft-engine/src/test/java/com/shaft/validation/internal/WebDriverElementValidationsBuilderCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/validation/internal/WebDriverElementValidationsBuilderCoverageUnitTest.java
@@ -1,5 +1,6 @@
 package com.shaft.validation.internal;
 
+import com.shaft.gui.internal.locator.SmartLocators;
 import com.shaft.validation.ValidationEnums;
 import org.openqa.selenium.By;
 import org.testng.Assert;
@@ -37,18 +38,38 @@ public class WebDriverElementValidationsBuilderCoverageUnitTest {
                 ValidationEnums.ValidationType.NEGATIVE, "elementExists", null, null, "does not exist.");
         assertExecutorInvocationState(newBuilder(), WebDriverElementValidationsBuilder::matchesReferenceImage,
                 ValidationEnums.ValidationType.POSITIVE, "elementMatches",
-                ValidationEnums.VisualValidationEngine.EXACT_SHUTTERBUG, null, "matches the reference image");
+                ValidationEnums.VisualValidationEngine.EXACT_SHUTTERBUG, null, "matches the reference image.");
         assertExecutorInvocationState(newBuilder(),
                 builder -> builder.matchesReferenceImage(ValidationEnums.VisualValidationEngine.EXACT_OPENCV),
                 ValidationEnums.ValidationType.POSITIVE, "elementMatches",
-                ValidationEnums.VisualValidationEngine.EXACT_OPENCV, null, "matches the reference image");
+                ValidationEnums.VisualValidationEngine.EXACT_OPENCV, null, "matches the reference image.");
         assertExecutorInvocationState(newBuilder(), WebDriverElementValidationsBuilder::doesNotMatchReferenceImage,
                 ValidationEnums.ValidationType.NEGATIVE, "elementMatches",
-                ValidationEnums.VisualValidationEngine.EXACT_OPENCV, null, "does not match the reference image");
+                ValidationEnums.VisualValidationEngine.EXACT_OPENCV, null, "does not match the reference image.");
         assertExecutorInvocationState(newBuilder(),
                 builder -> builder.doesNotMatchReferenceImage(ValidationEnums.VisualValidationEngine.EXACT_EYES),
                 ValidationEnums.ValidationType.NEGATIVE, "elementMatches",
-                ValidationEnums.VisualValidationEngine.EXACT_EYES, null, "does not match the reference image");
+                ValidationEnums.VisualValidationEngine.EXACT_EYES, null, "does not match the reference image.");
+    }
+
+    @Test(description = "visual assertion messages should include smart locator names but not visual engines")
+    public void visualAssertionMessagesShouldUseSmartLocatorNameWithoutEngine() {
+        WebDriverElementValidationsBuilder builder = new WebDriverElementValidationsBuilder(
+                ValidationEnums.ValidationCategory.HARD_ASSERT,
+                null,
+                SmartLocators.clickableField("Login"),
+                new StringBuilder("the element "));
+
+        try {
+            builder.matchesReferenceImage(ValidationEnums.VisualValidationEngine.EXACT_OPENCV);
+            Assert.fail("Expected invocation to fail without a live WebDriver session.");
+        } catch (Throwable ignored) {
+            // expected in unit context without a browser session
+        }
+
+        Assert.assertEquals(builder.reportMessageBuilder.toString(),
+                "the element \"Login\" matches the reference image.");
+        Assert.assertFalse(builder.reportMessageBuilder.toString().contains("EXACT_OPENCV"));
     }
 
     @Test(description = "boolean-like element helpers should configure selected/checked/hidden/disabled assertions")
@@ -102,6 +123,7 @@ public class WebDriverElementValidationsBuilderCoverageUnitTest {
         Assert.assertEquals(builder.visualValidationEngine, expectedVisualEngine);
         Assert.assertEquals(builder.elementAttribute, expectedElementAttribute);
         Assert.assertTrue(builder.reportMessageBuilder.toString().contains(expectedReportSnippet));
+        Assert.assertFalse(builder.reportMessageBuilder.toString().contains("EXACT_"));
     }
 
     @FunctionalInterface

--- a/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsHelperCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsHelperCoverageUnitTest.java
@@ -2,7 +2,9 @@ package testPackage.unitTests;
 
 import com.shaft.driver.SHAFT;
 import com.shaft.gui.browser.internal.BrowserActionsHelper;
+import com.shaft.tools.io.ReportManager;
 import com.shaft.properties.internal.Properties;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.openqa.selenium.*;
 import org.openqa.selenium.chromium.ChromiumDriver;
@@ -135,5 +137,10 @@ public class BrowserActionsHelperCoverageUnitTest {
         BrowserActionsHelper nonSilentHelper = new BrowserActionsHelper(false);
         nonSilentHelper.passAction((WebDriver) null, "customAction", "<html></html>");
         nonSilentHelper.passAction((WebDriver) null, "customAction", "short value");
+
+        try (MockedStatic<ReportManager> reportManager = Mockito.mockStatic(ReportManager.class)) {
+            nonSilentHelper.passAction((WebDriver) null, "navigateToUrl", "https://example.com/path");
+            reportManager.verify(() -> ReportManager.log("Navigate to url \"https://example.com/path\"."));
+        }
     }
 }

--- a/shaft-engine/src/test/java/testPackage/unitTests/WebDriverListenerCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/WebDriverListenerCoverageUnitTest.java
@@ -2,11 +2,14 @@ package testPackage.unitTests;
 
 import com.shaft.driver.SHAFT;
 import com.shaft.listeners.internal.WebDriverListener;
+import com.shaft.tools.io.ReportManager;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -82,6 +85,22 @@ public class WebDriverListenerCoverageUnitTest {
         listener.afterQuit(driver);
 
         verify(driver, atLeastOnce()).findElement(any(By.class));
+    }
+
+    @Test
+    public void navigationHooksShouldQuoteUrls() throws Exception {
+        WebDriverListener listener = new WebDriverListener();
+        WebDriver driver = mock(WebDriver.class);
+        WebDriver.Navigation navigation = mock(WebDriver.Navigation.class);
+
+        try (MockedStatic<ReportManager> reportManager = Mockito.mockStatic(ReportManager.class)) {
+            listener.afterGet(driver, "https://example.com/");
+            listener.afterTo(navigation, "https://example.com/");
+            listener.afterTo(navigation, new URL("https://example.com/"));
+
+            reportManager.verify(() -> ReportManager.log("Navigate to \"https://example.com/\"."));
+            reportManager.verify(() -> ReportManager.log("Navigate to url \"https://example.com/\"."), Mockito.times(2));
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Normalize SHAFT-authored report text so dynamic values are wrapped in balanced double quotes, including Selenium/Playwright navigation and built-in Cucumber assertion messages.
- Remove visual engine names from Selenium and Playwright visual assertion step titles while keeping the `Visual engine` Allure parameter.
- Replace separate visual expected/actual/diff screenshot attachments with one Allure image-diff attachment named `Visual Comparison`; demote locator image-path formatting to debug-only logging.

## Validation
- `py -3 scripts\ci\validate_agent_setup.py`
- `mvn -pl shaft-engine '-Dtest=WebDriverListenerCoverageUnitTest,BrowserActionsCoverageUnitTest,BrowserActionsHelperCoverageUnitTest,ActionsCoverageUnitTest,ElementsHelperCoverageUnitTest,WebDriverElementValidationsBuilderCoverageUnitTest,ValidationsHelperNewPatternCoverageUnitTest,PlaywrightElementVisualValidationTest,ImageProcessingActionsReportingUnitTest,AlertActionsCoverageUnitTest' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test`
- Confirmed `shaft-engine/allure-results` had 86 populated `*-result.json` files after the focused run.
- Searched focused Allure result JSON for old broken navigation/visual strings; no matches.
- `mvn -pl shaft-engine '-DskipTests' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' package`

## Notes
- Public docs search found no exact old visual/navigation wording requiring a docs update.
- Graphify refresh was attempted with `graphify . --update --no-viz`, but it is blocked because 159 doc/paper/image files require semantic extraction and no supported LLM API key is configured in this environment.
