### PR TITLE
[codex] Add failure diagnostics bundle

### DIFF
--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -811,5 +811,6 @@
   "809": "Community 809",
   "810": "Community 810",
   "811": "Community 811",
-  "812": "Community 812"
+  "812": "Community 812",
+  "813": "Community 813"
 }

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - SHAFT_ENGINE  (2026-06-25)
 
 ## Corpus Check
-- 1041 files · ~584,627 words
+- 1046 files · ~587,073 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 14744 nodes · 38236 edges · 813 communities (714 shown, 99 thin omitted)
-- Extraction: 81% EXTRACTED · 19% INFERRED · 0% AMBIGUOUS · INFERRED: 7308 edges (avg confidence: 0.8)
+- 14821 nodes · 38648 edges · 814 communities (713 shown, 101 thin omitted)
+- Extraction: 81% EXTRACTED · 19% INFERRED · 0% AMBIGUOUS · INFERRED: 7467 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `6e68f2e1`
+- Built from commit: `e555f563`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -709,13 +709,14 @@
 - [[_COMMUNITY_Community 810|Community 810]]
 - [[_COMMUNITY_Community 811|Community 811]]
 - [[_COMMUNITY_Community 812|Community 812]]
+- [[_COMMUNITY_Community 813|Community 813]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `SHAFT` - 296 edges
-2. `IOException` - 117 edges
+1. `SHAFT` - 298 edges
+2. `IOException` - 118 edges
 3. `RestActionsComprehensiveTests` - 99 edges
 4. `Test` - 98 edges
-5. `ArrayList` - 88 edges
+5. `ArrayList` - 90 edges
 6. `CaptureGenerator` - 77 edges
 7. `ReportManagerHelper` - 76 edges
 8. `Actions` - 64 edges
@@ -723,6 +724,8 @@
 10. `JavaHelperUnitTest` - 60 edges
 
 ## Surprising Connections (you probably didn't know these)
+- `defaults()` --calls--> `denyAll()`  [INFERRED]
+  shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationRequest.java → shaft-pilot-core/src/main/java/com/shaft/pilot/ai/ApprovalPolicy.java
 - `sortedEvents()` --calls--> `Sequence`  [INFERRED]
   shaft-capture/src/main/java/com/shaft/capture/model/CaptureSession.java → shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
 - `disabled()` --calls--> `denyAll()`  [INFERRED]
@@ -731,37 +734,35 @@
   shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventCollector.java → shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserNetworkInterceptor.java
 - `CaptureControlServer` --implements--> `AutoCloseable`  [EXTRACTED]
   shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlServer.java → shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserNetworkInterceptor.java
-- `defaults()` --calls--> `denyAll()`  [INFERRED]
-  shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationRequest.java → shaft-pilot-core/src/main/java/com/shaft/pilot/ai/ApprovalPolicy.java
 
 ## Import Cycles
 - None detected.
 
-## Communities (813 total, 99 thin omitted)
+## Communities (814 total, 101 thin omitted)
 
 ### Community 0 - "Community 0"
 Cohesion: 0.04
-Nodes (7): RestActionsComprehensiveTests, API, ComparisonType, Deprecated, SuppressWarnings, BeforeMethod, Test
+Nodes (6): RestActionsComprehensiveTests, ComparisonType, InputStream, SuppressWarnings, BeforeMethod, Test
 
 ### Community 1 - "Community 1"
 Cohesion: 0.06
 Nodes (13): BrowserActionsContract, AccessibilityActions, BrowserAssertions, Cookie, HttpRequest, HttpResponse, List, NetworkInterceptionRequestBuilder (+5 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.11
-Nodes (15): NativeValidationsBuilder, AssertEqualsTests, FileValidationsBuilder, Object, Override, RestValidationsBuilder, String, SuppressWarnings (+7 more)
+Cohesion: 0.09
+Nodes (19): NativeValidationsBuilder, AssertEqualsTests, VerifyEqualsTests, FileValidationsBuilder, Object, Override, RestValidationsBuilder, String (+11 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.19
-Nodes (6): Outcome, Object, Override, String, Supplier, PlaywrightValidationsExecutor
+Cohesion: 0.11
+Nodes (17): LocatorAssertions, Outcome, PageAssertions, LinkedHashMap, List, Locator, Object, Override (+9 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.07
 Nodes (6): Pilot, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 5 - "Community 5"
-Cohesion: 0.11
-Nodes (19): getValue(), KeyboardKeys(), TouchActions, ImmutableMap, viewport(), By, DriverFactoryHelper, File (+11 more)
+Cohesion: 0.06
+Nodes (33): FileUploadDownloadTest, getValue(), KeyboardKeys(), TouchActions, ElementActionsHelper, ImmutableMap, IOSDriver, KeyboardKeys (+25 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.06
@@ -769,11 +770,11 @@ Nodes (14): CSVFileManager, CSVFileManagerTest, List, Map, String, BeforeMethod,
 
 ### Community 7 - "Community 7"
 Cohesion: 0.07
-Nodes (29): KeyboardKeys, LocatorOperation, MobileService, MobileServiceConfigurationTest, McpMobileAccessibilityTree, McpMobileContextSnapshot, McpMobileSessionResult, BrowserType (+21 more)
+Nodes (29): LocatorOperation, MobileService, MobileServiceConfigurationTest, McpMobileAccessibilityTree, McpMobileContextSnapshot, McpMobileSessionResult, BrowserType, By (+21 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.17
-Nodes (8): BrowserStackSdkTests, AfterMethod, BeforeMethod, Map, Object, String, SuppressWarnings, Test
+Cohesion: 0.07
+Nodes (23): BrowserStackSdkHelper, BrowserStackSdkTests, List, Map, Object, String, AfterMethod, BeforeMethod (+15 more)
 
 ### Community 9 - "Community 9"
 Cohesion: 0.14
@@ -792,8 +793,8 @@ Cohesion: 0.07
 Nodes (11): BrowserStack, SetProperty, DefaultValue, Key, SetProperty, String, AfterMethod, Object (+3 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.10
-Nodes (10): DataType, JSONFileManager, List, Map, Object, String, AfterMethod, BeforeClass (+2 more)
+Cohesion: 0.06
+Nodes (20): DataType, FileReader, JSONFileManager, JSONFileManagerTestAccessor, JSONFileManagerTests, List, Map, Object (+12 more)
 
 ### Community 14 - "Community 14"
 Cohesion: 0.09
@@ -804,20 +805,20 @@ Cohesion: 0.07
 Nodes (12): ShaftRestAssuredFilter, FilterableRequestSpecification, FilterableResponseSpecification, FilterContext, JsonElement, Object, Override, Response (+4 more)
 
 ### Community 16 - "Community 16"
-Cohesion: 0.08
-Nodes (6): AfterMethod, Path, String, SuppressWarnings, Test, TerminalActionsUnitTest
+Cohesion: 0.07
+Nodes (10): JunitCoreAssertionMigrationTest, LocalShellTests, Test, Test, AfterMethod, Path, String, SuppressWarnings (+2 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.09
-Nodes (9): AsyncAppender, ReportManagerHelper, TestCaseStarted, RunType, Boolean, Level, Path, Status (+1 more)
+Cohesion: 0.10
+Nodes (7): ReportManagerHelper, StringBuilder, ByteArrayOutputStream, InputStream, Level, String, Throwable
 
 ### Community 18 - "Community 18"
-Cohesion: 0.09
-Nodes (20): FileActions, FileActionsCoverageUnitTest, Boolean, Collection, Exception, File, InputStream, String (+12 more)
+Cohesion: 0.11
+Nodes (15): FileActions, Boolean, Collection, Exception, File, InputStream, String, SuppressWarnings (+7 more)
 
 ### Community 19 - "Community 19"
-Cohesion: 0.11
-Nodes (14): McpMobileToolchainService, McpAndroidEmulatorProposal, Duration, List, Map, McpMobileDevice, McpMobileToolchainDiagnostic, McpMobileToolchainStatus (+6 more)
+Cohesion: 0.12
+Nodes (12): McpMobileToolchainService, McpAndroidEmulatorProposal, Duration, List, Map, McpMobileDevice, McpMobileToolchainStatus, McpProcessRunner (+4 more)
 
 ### Community 20 - "Community 20"
 Cohesion: 0.10
@@ -828,40 +829,40 @@ Cohesion: 0.14
 Nodes (13): WebDriverListener, Navigation, Alert, By, Method, Object, String, URL (+5 more)
 
 ### Community 22 - "Community 22"
-Cohesion: 0.06
-Nodes (27): AfterAllCallback, AfterTestExecutionCallback, BeforeAllCallback, BeforeEachCallback, ExecutableInvoker, RetryAnalyzer, SupportingEvidenceState, IRetryAnalyzer (+19 more)
+Cohesion: 0.05
+Nodes (30): AfterAllCallback, AfterTestExecutionCallback, BeforeAllCallback, BeforeEachCallback, ExecutableInvoker, RetryAnalyzer, SupportingEvidenceState, IRetryAnalyzer (+22 more)
 
 ### Community 23 - "Community 23"
-Cohesion: 0.09
-Nodes (18): ClassLoader, ImageProcessingActionsCoverageUnitTest, OpenCvBlockingClassLoader, List, AfterMethod, BeforeMethod, BufferedImage, Class (+10 more)
+Cohesion: 0.10
+Nodes (13): ImageProcessingActionsCoverageUnitTest, List, AfterMethod, BeforeMethod, BufferedImage, Color, DataProvider, Map (+5 more)
 
 ### Community 24 - "Community 24"
-Cohesion: 0.08
-Nodes (10): AllureManager, BooleanSupplier, ArrayNode, Future, InputStream, List, ObjectNode, Path (+2 more)
+Cohesion: 0.09
+Nodes (9): AllureManager, ArrayNode, Future, InputStream, List, ObjectNode, Path, Process (+1 more)
 
 ### Community 25 - "Community 25"
-Cohesion: 0.05
-Nodes (48): AllureVerdict, DoctorRepairPublicationRequest, ExistingPullRequest, GuardedPatch, Operation, PatchManifestEntry, RecordingRunner, changedSince() (+40 more)
+Cohesion: 0.12
+Nodes (20): AllureVerdict, DoctorRepairPublicationRequest, ExistingPullRequest, Operation, PatchManifestEntry, changedSince(), DoctorRepairService, AllureSnapshot (+12 more)
 
 ### Community 26 - "Community 26"
 Cohesion: 0.07
-Nodes (14): DriverFactoryHelperCoverageUnitTest, TestableDriverFactoryHelper, AfterMethod, AtomicInteger, CountDownLatch, DriverFactoryHelper, DriverType, Method (+6 more)
+Nodes (15): DriverFactoryHelperCoverageUnitTest, TestableDriverFactoryHelper, OptionsManager, AfterMethod, AtomicInteger, CountDownLatch, DriverFactoryHelper, DriverType (+7 more)
 
 ### Community 27 - "Community 27"
 Cohesion: 0.08
 Nodes (4): ValidationTests, AfterMethod, BeforeMethod, Test
 
 ### Community 28 - "Community 28"
-Cohesion: 0.10
-Nodes (8): AsyncElementActionsCoverageUnitTest, BeforeMethod, Test, AfterMethod, Path, String, Test, ThreadLocalPropertiesTest
+Cohesion: 0.08
+Nodes (11): ThreadLocalPropertiesManager, Properties, String, BeforeMethod, Test, AfterMethod, AfterMethod, Path (+3 more)
 
 ### Community 29 - "Community 29"
 Cohesion: 0.14
-Nodes (11): AccessibilityConfig, AccessibilityHelper, AccessibilityResult, Integer, JSONArray, JSONObject, Map, Path (+3 more)
+Nodes (14): AccessibilityConfig, AccessibilityHelper, AxeBuilder, AccessibilityResult, Integer, JSONArray, JSONObject, List (+6 more)
 
 ### Community 30 - "Community 30"
-Cohesion: 0.08
-Nodes (15): PathParamTest, TestUpload, JunitApiSmokeTest, GraphqlRequestTests, AfterClass, BeforeClass, Test, Test (+7 more)
+Cohesion: 0.05
+Nodes (23): PathParamTest, AssertApiResponseEqualsTests, BasicAPITests, GraphqlRequestTests, Map, AfterClass, BeforeClass, Test (+15 more)
 
 ### Community 31 - "Community 31"
 Cohesion: 0.10
@@ -872,48 +873,48 @@ Cohesion: 0.10
 Nodes (7): AfterMethod, Class, Object, Path, String, Test, AllureManagerUnitTest
 
 ### Community 33 - "Community 33"
-Cohesion: 0.07
-Nodes (14): ApiPerformanceReportTest, SwaggerContractTest, AfterMethod, AfterSuite, BeforeMethod, Test, AfterClass, AfterMethod (+6 more)
+Cohesion: 0.08
+Nodes (15): ApiPerformanceReportTest, SwaggerContractTest, testPostRequest, TestUpload, Object, ParametersType, AfterMethod, AfterSuite (+7 more)
 
 ### Community 34 - "Community 34"
-Cohesion: 0.08
-Nodes (27): DeterministicNaturalActionPlanner, unsupported(), NaturalActionPlannerRegistry, PilotNaturalActionPlanner, NaturalActionKind, NaturalActionPlanner, NaturalActionStep, List (+19 more)
+Cohesion: 0.14
+Nodes (15): DeterministicNaturalActionPlanner, unsupported(), NaturalActionPlannerRegistry, List, NaturalActionPlan, NaturalActionRequest, Override, String (+7 more)
 
 ### Community 35 - "Community 35"
-Cohesion: 0.06
-Nodes (31): Constructor, IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, StatusIcon() (+23 more)
+Cohesion: 0.08
+Nodes (22): IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, ExecutionSummaryReport, StatusIcon() (+14 more)
 
 ### Community 36 - "Community 36"
-Cohesion: 0.08
-Nodes (26): DataTableArgument, HookTestStep, CucumberFeatureListener, PickleStepTestStep, Result, Scenario, AllureLifecycle, EventPublisher (+18 more)
+Cohesion: 0.07
+Nodes (27): DataTableArgument, EmbedEvent, HookTestStep, CucumberFeatureListener, Parameter, PickleStepTestStep, Result, Scenario (+19 more)
 
 ### Community 37 - "Community 37"
-Cohesion: 0.13
-Nodes (9): Paths, SetProperty, PathsTests, DefaultValue, Key, SetProperty, String, BeforeClass (+1 more)
+Cohesion: 0.09
+Nodes (16): ApiPerformanceExecutionReport, Paths, SetProperty, PathsTests, DefaultValue, Key, SetProperty, String (+8 more)
 
 ### Community 38 - "Community 38"
-Cohesion: 0.10
+Cohesion: 0.09
 Nodes (18): BrowserNetworkInterceptor, ClientConfig, DriverFactoryHelper, BrowserNetworkInterceptionRule, Capabilities, Class, DriverType, List (+10 more)
 
 ### Community 39 - "Community 39"
-Cohesion: 0.09
-Nodes (11): AfterMethod, BeforeMethod, Class, List, Object, Path, String, T (+3 more)
+Cohesion: 0.10
+Nodes (9): AfterMethod, BeforeMethod, Class, Object, Path, String, T, Test (+1 more)
 
 ### Community 40 - "Community 40"
-Cohesion: 0.09
-Nodes (14): NavigationAction, API, BrowserActions, Cookie, List, NetworkInterceptionRequestBuilder, Override, Set (+6 more)
+Cohesion: 0.12
+Nodes (10): API, BrowserActions, Cookie, List, NetworkInterceptionRequestBuilder, Override, Set, String (+2 more)
 
 ### Community 41 - "Community 41"
-Cohesion: 0.17
-Nodes (15): CollectionState, EvidenceCollector, CollectionState, DoctorRedactor, DefaultPrettyPrinter, DoctorAnalysisRequest, EvidenceBundle, EvidenceCategory (+7 more)
+Cohesion: 0.15
+Nodes (17): CollectionState, EvidenceCollector, FilesSize, CollectionState, DoctorRedactor, DefaultPrettyPrinter, DoctorAnalysisRequest, EvidenceBundle (+9 more)
 
 ### Community 42 - "Community 42"
 Cohesion: 0.10
-Nodes (14): ElementLookup, GetElementInformation, Actions, ClipboardAction, GetElementInformation, Beta, By, ClipboardAction (+6 more)
+Nodes (15): ElementLookup, GetElementInformation, Actions, ClipboardAction, GetElementInformation, Beta, By, ClipboardAction (+7 more)
 
 ### Community 43 - "Community 43"
-Cohesion: 0.08
-Nodes (5): E2ECoverageTests, AfterMethod, BeforeMethod, Test, TextLanguageValidationsBuilder
+Cohesion: 0.07
+Nodes (9): TextDirectionValidationsBuilder, E2ECoverageTests, NativeValidationsBuilder, ValidationsExecutor, AfterMethod, BeforeMethod, Test, TextDirection (+1 more)
 
 ### Community 44 - "Community 44"
 Cohesion: 0.08
@@ -921,7 +922,7 @@ Nodes (7): LambdaTest, SetProperty, Boolean, DefaultValue, Key, SetProperty, Str
 
 ### Community 45 - "Community 45"
 Cohesion: 0.11
-Nodes (16): ActionsCoverageUnitTest, RecordingActions, RecordingActions, ActionType, AfterMethod, BeforeMethod, By, Class (+8 more)
+Nodes (19): ActionsCoverageUnitTest, RecordingActions, RecordingActions, ActionType, AfterMethod, AllureLifecycle, BeforeMethod, By (+11 more)
 
 ### Community 46 - "Community 46"
 Cohesion: 0.29
@@ -932,40 +933,40 @@ Cohesion: 0.08
 Nodes (4): NewValidationHelperTests, AfterMethod, BeforeMethod, Test
 
 ### Community 48 - "Community 48"
-Cohesion: 0.11
-Nodes (5): NumberValidationsBuilder, Number, ValidationsExecutor, Test, NumberValidationsBuilderUnitTest
+Cohesion: 0.08
+Nodes (12): NumberValidationsBuilder, Number, Object, Override, RestValidationsBuilder, SuppressWarnings, ValidationsBuilder, ValidationsExecutor (+4 more)
 
 ### Community 49 - "Community 49"
 Cohesion: 0.15
-Nodes (11): FailureTraceReporter, List, Path, String, StringBuilder, TestExecutionInfo, Throwable, ZipOutputStream (+3 more)
+Nodes (11): FailureTraceReporter, List, Path, SourceContext, StackTraceElement, String, StringBuilder, TestExecutionInfo (+3 more)
 
 ### Community 50 - "Community 50"
 Cohesion: 0.04
 Nodes (47): additionalProperties, minLength, type, maximum, minimum, type, type, minLength (+39 more)
 
 ### Community 51 - "Community 51"
-Cohesion: 0.07
-Nodes (13): AssertApiResponseEqualsTests, MatchJsonSchemaTests, ApiActionsMockedTests, RequestBuilder, Test, Test, AfterMethod, BeforeMethod (+5 more)
+Cohesion: 0.08
+Nodes (10): ApiActionsMockedTests, RequestBuilder, RequestType, AfterMethod, BeforeMethod, Test, AfterClass, BeforeClass (+2 more)
 
 ### Community 52 - "Community 52"
-Cohesion: 0.13
-Nodes (8): AccessibilityActions, AccessibilityConfig, AccessibilityTest, AccessibilityResult, String, AfterMethod, BeforeMethod, Test
+Cohesion: 0.17
+Nodes (4): AccessibilityTest, AfterMethod, BeforeMethod, Test
 
 ### Community 53 - "Community 53"
 Cohesion: 0.11
-Nodes (16): RestActions, RequestSpecBuilder, ArrayNode, Boolean, ContentType, Cookie, InputStream, List (+8 more)
+Nodes (14): RestActions, RequestSpecBuilder, API, ArrayNode, Boolean, Cookie, Deprecated, List (+6 more)
 
 ### Community 54 - "Community 54"
 Cohesion: 0.10
 Nodes (34): AllureFailure, _clean_cell(), extract_failures(), extract_surefire_failures(), _failure_group_key(), _first_trace_line(), _is_allure_test_result_payload(), _is_generated_report_non_test_result() (+26 more)
 
 ### Community 55 - "Community 55"
-Cohesion: 0.15
-Nodes (15): ElementActionsHelper, TextDetectionStrategy(), AtomicInteger, Boolean, By, Class, HealingResolution, List (+7 more)
+Cohesion: 0.17
+Nodes (13): ElementActionsHelper, TextDetectionStrategy(), AtomicInteger, Boolean, By, ClipboardAction, HealingResolution, List (+5 more)
 
 ### Community 56 - "Community 56"
-Cohesion: 0.11
-Nodes (20): McpMobileInspectorRecordingService, Session, McpMobileToolchainService, Duration, List, Map, McpCodeBlock, McpMobileDevice (+12 more)
+Cohesion: 0.13
+Nodes (17): McpMobileInspectorRecordingService, Session, Duration, List, Map, McpCodeBlock, McpMobileDevice, McpMobileInspectorPlan (+9 more)
 
 ### Community 57 - "Community 57"
 Cohesion: 0.13
@@ -980,12 +981,12 @@ Cohesion: 0.14
 Nodes (20): CaptureControlClient, CaptureCli, flag(), parse(), path(), pathRequired(), required(), value() (+12 more)
 
 ### Community 60 - "Community 60"
-Cohesion: 0.08
-Nodes (27): Document, GuideHttpClient, GuideIndex, GuideHttpClient, GuideService, JdkGuideHttpClient, FakeGuideHttpClient, GuideServiceTest (+19 more)
+Cohesion: 0.11
+Nodes (19): Document, GuideHttpClient, GuideIndex, GuideHttpClient, GuideService, JdkGuideHttpClient, McpGuideMatch, McpGuideSearchResult (+11 more)
 
 ### Community 61 - "Community 61"
 Cohesion: 0.12
-Nodes (16): AllureListenerCoverageUnitTest, Throwable, Status, AfterMethod, BeforeMethod, ITestResult, List, Path (+8 more)
+Nodes (15): AllureListenerCoverageUnitTest, Throwable, Status, AfterMethod, BeforeMethod, ITestResult, List, Path (+7 more)
 
 ### Community 62 - "Community 62"
 Cohesion: 0.14
@@ -1000,8 +1001,8 @@ Cohesion: 0.11
 Nodes (11): COSDocument, DeleteFileAfterValidationStatus, PdfFileManager, PDFParser, RandomAccessReadBufferedFile, File, String, AfterMethod (+3 more)
 
 ### Community 65 - "Community 65"
-Cohesion: 0.17
-Nodes (4): LocatorMockedTests, ShadowLocatorBuilder, Test, XpathAxis
+Cohesion: 0.08
+Nodes (11): Locator, LocatorMockedTests, ShadowLocatorBuilder, Beta, By, LocatorBuilder, String, Test (+3 more)
 
 ### Community 66 - "Community 66"
 Cohesion: 0.05
@@ -1016,32 +1017,32 @@ Cohesion: 0.05
 Nodes (42): additionalProperties, default, description, examples, $id, title, type, default (+34 more)
 
 ### Community 69 - "Community 69"
-Cohesion: 0.10
-Nodes (11): OptionsManager, AfterMethod, AtomicInteger, CountDownLatch, DriverType, Method, MutableCapabilities, Override (+3 more)
+Cohesion: 0.11
+Nodes (10): AfterMethod, AtomicInteger, CountDownLatch, DriverType, Method, MutableCapabilities, Override, Test (+2 more)
 
 ### Community 70 - "Community 70"
 Cohesion: 0.11
 Nodes (41): expand_globs(), issue(), local_link_targets(), markdown_body(), normalized_paragraphs(), parse_frontmatter(), quoted_yaml_value(), Keep the consolidated guidance below the approved baseline reduction. (+33 more)
 
 ### Community 71 - "Community 71"
-Cohesion: 0.13
-Nodes (15): ShaftHeal, ShaftHealingProviderTest, HealingReport, Optional, AfterMethod, AppiumDriver, BeforeMethod, DataProvider (+7 more)
+Cohesion: 0.09
+Nodes (21): ShaftHeal, ShaftHealingProviderTest, WebDomHealingAcceptanceTest, HealingReport, Optional, AfterMethod, AppiumDriver, BeforeMethod (+13 more)
 
 ### Community 72 - "Community 72"
-Cohesion: 0.26
-Nodes (7): DoctorAnalyzerTest, DoctorAnalysisRequest, DoctorAnalysisResult, Path, Stream, String, Test
+Cohesion: 0.19
+Nodes (13): DoctorAnalyzerTest, DoctorAiAnalysisResult, Arguments, CauseCategory, DoctorAnalysisRequest, DoctorAnalysisResult, List, MethodSource (+5 more)
 
 ### Community 73 - "Community 73"
-Cohesion: 0.11
-Nodes (19): denyAll(), CaptureFixtures, defaults(), CaptureGeneratorTest, PageContext, CaptureGenerationRequest, Path, BrowserMetadata (+11 more)
+Cohesion: 0.13
+Nodes (16): denyAll(), CaptureFixtures, CaptureGeneratorTest, PageContext, BrowserMetadata, CaptureEvent, CaptureSession, ElementSnapshot (+8 more)
 
 ### Community 74 - "Community 74"
-Cohesion: 0.12
+Cohesion: 0.11
 Nodes (13): CapturePrivacyClassifier, ManagedCaptureRecorder, BrowserMetadata, BrowserSignal, CapturePrivacyPolicy, CaptureStartRequest, CaptureStatus, CheckpointKind (+5 more)
 
 ### Community 75 - "Community 75"
-Cohesion: 0.17
-Nodes (9): Actions, By, ElementActions, List, Map, Override, String, SuppressWarnings (+1 more)
+Cohesion: 0.19
+Nodes (8): Actions, By, ElementActions, List, Map, Override, String, SuppressWarnings
 
 ### Community 76 - "Community 76"
 Cohesion: 0.08
@@ -1056,48 +1057,48 @@ Cohesion: 0.05
 Nodes (40): additionalProperties, enum, pattern, type, pattern, type, items, type (+32 more)
 
 ### Community 79 - "Community 79"
-Cohesion: 0.18
-Nodes (9): CaptureControlFiles, ControlDescriptor, CaptureStartRequest, CaptureStatus, Class, Object, Path, String (+1 more)
+Cohesion: 0.15
+Nodes (11): CaptureControlFiles, CaptureControlFilesTest, ControlDescriptor, CaptureStartRequest, CaptureStatus, Class, Object, Path (+3 more)
 
 ### Community 80 - "Community 80"
-Cohesion: 0.18
-Nodes (10): ElementService, LocatorOperation, By, Deprecated, LocatorOperation, locatorStrategy, String, Tool (+2 more)
+Cohesion: 0.19
+Nodes (9): ElementService, LocatorOperation, By, Deprecated, LocatorOperation, locatorStrategy, String, Tool (+1 more)
 
 ### Community 81 - "Community 81"
-Cohesion: 0.12
-Nodes (13): IOSDriver, InputStream, Path, String, AfterClass, AfterMethod, Boolean, SuppressWarnings (+5 more)
+Cohesion: 0.18
+Nodes (8): AfterClass, AfterMethod, Boolean, SuppressWarnings, Test, ThreadLocal, WebDriver, RecordManagerTest
 
 ### Community 82 - "Community 82"
 Cohesion: 0.05
 Nodes (39): additionalProperties, type, maximum, minimum, type, additionalProperties, properties, required (+31 more)
 
 ### Community 84 - "Community 84"
-Cohesion: 0.11
-Nodes (16): ProviderConfigurationTest, FirestoreRestClient, Properties, CaptureStartRequest(), validateUrl(), CaptureBrowser, Path, String (+8 more)
+Cohesion: 0.09
+Nodes (21): option(), ProviderConfiguration(), ProviderConfigurationTest, FirestoreRestClient, Properties, CaptureStartRequest(), validateUrl(), CaptureBrowser (+13 more)
 
 ### Community 85 - "Community 85"
 Cohesion: 0.14
 Nodes (14): ClassifiedUpload, CapturePrivacyClassifier, CapturePrivacyClassifierTest, SanitizedAttributes, SanitizedText, CapturePrivacyPolicy, ClassifiedValue, List (+6 more)
 
 ### Community 86 - "Community 86"
-Cohesion: 0.13
-Nodes (11): EngineService, EngineServiceRuntimePathTest, PostConstruct, BrowserType, Path, String, Tool, WebDriver (+3 more)
+Cohesion: 0.12
+Nodes (12): EngineService, EngineServiceRuntimePathTest, PostConstruct, BrowserType, By, Path, String, Tool (+4 more)
 
 ### Community 87 - "Community 87"
-Cohesion: 0.14
-Nodes (9): ElementActionsHelper, AfterMethod, AndroidDriver, BeforeMethod, RemoteWebDriver, Runnable, Test, TouchActions (+1 more)
+Cohesion: 0.15
+Nodes (13): ArtifactReference, FailureDiagnosticsReporter, Redactor, Redactor, List, Path, SourceContext, StackTraceElement (+5 more)
 
 ### Community 88 - "Community 88"
-Cohesion: 0.13
-Nodes (16): LauncherSession, Counts, Override, AfterMethod, BeforeMethod, Duration, List, Object (+8 more)
+Cohesion: 0.14
+Nodes (15): LauncherSession, Override, AfterMethod, BeforeMethod, Duration, List, Object, Optional (+7 more)
 
 ### Community 89 - "Community 89"
 Cohesion: 0.20
 Nodes (6): WebDriverElementValidationsBuilder, NativeValidationsBuilder, Override, String, ValidationsExecutor, VisualValidationEngine
 
 ### Community 90 - "Community 90"
-Cohesion: 0.22
-Nodes (11): CaptureEvent, CaptureJsonCodec, CaptureSession, Checkpoint, ExternalTestDataReference, Instant, List, Path (+3 more)
+Cohesion: 0.11
+Nodes (29): append(), checkpoint(), complete(), ensureIncomplete(), interrupt(), sortedCheckpoints(), sortedEvents(), sortedReferences() (+21 more)
 
 ### Community 91 - "Community 91"
 Cohesion: 0.10
@@ -1108,8 +1109,8 @@ Cohesion: 0.09
 Nodes (49): child_text(), dependency_coordinate(), dependency_template(), direct_child(), elements_named(), ensure_android_json_exclusion(), ensure_dependency(), ensure_generator_dependency_set() (+41 more)
 
 ### Community 93 - "Community 93"
-Cohesion: 0.11
-Nodes (9): LocatorBuilder, RelativeBy, By, Locator, Page, Role, ShaftLocator, String (+1 more)
+Cohesion: 0.08
+Nodes (13): LocatorBuilder, ShadowDomTest, RelativeBy, By, Locator, Page, Role, ShaftLocator (+5 more)
 
 ### Community 94 - "Community 94"
 Cohesion: 0.05
@@ -1117,11 +1118,11 @@ Nodes (37): type, additionalProperties, minLength, type, items, type, type, requ
 
 ### Community 95 - "Community 95"
 Cohesion: 0.09
-Nodes (20): builder(), evidenceCategories(), withSanitizedContent(), withTimeout(), AiValueObjectsTest, allows(), ApprovalPolicy(), AiRequest (+12 more)
+Nodes (19): builder(), evidenceCategories(), withSanitizedContent(), withTimeout(), AiValueObjectsTest, AiAuditSink, ShaftAiAuditSink, AiRequest (+11 more)
 
 ### Community 96 - "Community 96"
-Cohesion: 0.10
-Nodes (16): DriverFactory, DriverType(), DatabaseActions, DatabaseType, Deprecated, DriverFactoryHelper, DriverType, MutableCapabilities (+8 more)
+Cohesion: 0.15
+Nodes (13): DriverFactory, DriverType(), DatabaseActions, DatabaseType, Deprecated, DriverFactoryHelper, DriverType, MutableCapabilities (+5 more)
 
 ### Community 97 - "Community 97"
 Cohesion: 0.07
@@ -1132,8 +1133,8 @@ Cohesion: 0.19
 Nodes (9): CaptureManagerLifecycleTest, FailingRecorder, FakeRecorder, CaptureStartRequest, CaptureStatus, CheckpointKind, Override, String (+1 more)
 
 ### Community 99 - "Community 99"
-Cohesion: 0.14
-Nodes (10): LambdaTestHelper, Boolean, DriverFactoryHelper, HashMap, MutableCapabilities, Object, String, AfterMethod (+2 more)
+Cohesion: 0.28
+Nodes (7): LambdaTestHelper, Boolean, DriverFactoryHelper, HashMap, MutableCapabilities, Object, String
 
 ### Community 100 - "Community 100"
 Cohesion: 0.13
@@ -1152,32 +1153,32 @@ Cohesion: 0.18
 Nodes (11): AlertActionsContext, AfterMethod, Alert, AlertActions, BeforeMethod, Object, String, Test (+3 more)
 
 ### Community 104 - "Community 104"
-Cohesion: 0.14
-Nodes (10): Dimension, BrowserActionsHelper, Boolean, SneakyThrows, String, WebDriver, AfterMethod, BeforeMethod (+2 more)
+Cohesion: 0.21
+Nodes (6): Dimension, BrowserActionsHelper, Boolean, SneakyThrows, String, WebDriver
 
 ### Community 105 - "Community 105"
 Cohesion: 0.14
 Nodes (14): BadRequestException, CaptureControlServer, Handler, Handler, CaptureControlFiles, CaptureManager, CaptureStatus, Class (+6 more)
 
 ### Community 106 - "Community 106"
-Cohesion: 0.11
-Nodes (15): FluentWait, ElementsHelperCoverageUnitTest, MockedStatic, NoSuchElementException, AllureLifecycle, DriverFactoryHelper, WebElement, AfterMethod (+7 more)
+Cohesion: 0.14
+Nodes (10): FluentWait, ElementsHelperCoverageUnitTest, AfterMethod, BeforeMethod, DriverFactoryHelper, MockedConstruction, RuntimeException, SuppressWarnings (+2 more)
 
 ### Community 107 - "Community 107"
-Cohesion: 0.06
-Nodes (12): Allure, SetProperty, Healing, SetProperty, DefaultValue, Key, SetProperty, String (+4 more)
+Cohesion: 0.07
+Nodes (12): Allure, SetProperty, Platform, SetProperty, DefaultValue, Key, SetProperty, String (+4 more)
 
 ### Community 108 - "Community 108"
 Cohesion: 0.13
 Nodes (5): YAMLFileManagerTests, BeforeMethod, Date, String, Test
 
 ### Community 109 - "Community 109"
-Cohesion: 0.31
-Nodes (5): AfterTest, BeforeTest, ConfigurationHelper, ITestContext, Step
+Cohesion: 0.18
+Nodes (6): AfterTest, BeforeTest, ConfigurationHelper, ReportHelper, ITestContext, Step
 
 ### Community 110 - "Community 110"
 Cohesion: 0.16
-Nodes (14): AiExecutionServiceTest, StubProvider, AiCapabilities, AiExecutionService, AiProviderAvailability, AiProviderRegistry, AiRequest, AiResponse (+6 more)
+Nodes (15): AiExecutionServiceTest, StubProvider, AtomicReference, AiCapabilities, AiExecutionService, AiProviderAvailability, AiProviderRegistry, AiRequest (+7 more)
 
 ### Community 111 - "Community 111"
 Cohesion: 0.17
@@ -1188,19 +1189,19 @@ Cohesion: 0.12
 Nodes (9): API, JSON, YAML, Cookie, List, Map, Object, RequestBuilder (+1 more)
 
 ### Community 113 - "Community 113"
-Cohesion: 0.24
-Nodes (10): expired(), InstantDeadline(), ManagedCaptureRecorderBrowserTest, Duration, HttpExchange, HttpServer, ParameterizedTest, Path (+2 more)
+Cohesion: 0.22
+Nodes (11): expired(), InstantDeadline(), ManagedCaptureRecorderBrowserTest, BooleanSupplier, Duration, HttpExchange, HttpServer, ParameterizedTest (+3 more)
 
 ### Community 114 - "Community 114"
-Cohesion: 0.11
-Nodes (11): IIOMetadataNode, AnimatedGifManager, GifSession, ImageOutputStream, ImageWriter, getType(), RenderedImage, Screenshots (+3 more)
+Cohesion: 0.07
+Nodes (18): IIOMetadataNode, AnimatedGifManager, GifSession, AnimatedGifManagerCoverageUnitTest, ImageOutputStream, ImageWriter, getType(), RenderedImage (+10 more)
 
 ### Community 115 - "Community 115"
 Cohesion: 0.06
 Nodes (34): enum, type, items, type, items, type, $id, required (+26 more)
 
 ### Community 116 - "Community 116"
-Cohesion: 0.11
+Cohesion: 0.12
 Nodes (21): ActionReportContext, abbreviate(), empty(), from(), hasElementName(), hasLocator(), hasStepTarget(), hasStepValue() (+13 more)
 
 ### Community 117 - "Community 117"
@@ -1216,19 +1217,19 @@ Cohesion: 0.08
 Nodes (17): Async, Driver, Playwright, WebDriver, PlaywrightDriverAssertions, PlaywrightDriverVerifications, Actions, AlertActions (+9 more)
 
 ### Community 120 - "Community 120"
-Cohesion: 0.20
+Cohesion: 0.17
 Nodes (12): YAMLFileManager, Boolean, Class, Date, Double, Integer, List, Long (+4 more)
 
 ### Community 121 - "Community 121"
-Cohesion: 0.15
-Nodes (11): AccessibilityActions, BrowserContext, HttpRequest, HttpResponse, Locator, NetworkInterceptionRequestBuilder, PlaywrightSession, Predicate (+3 more)
+Cohesion: 0.11
+Nodes (11): PlaywrightBrowserValidationsBuilder, AccessibilityActions, BrowserContext, HttpRequest, HttpResponse, Locator, NetworkInterceptionRequestBuilder, PlaywrightSession (+3 more)
 
 ### Community 122 - "Community 122"
-Cohesion: 0.12
-Nodes (18): AbstractHttpAiProvider, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse, AiResponseStatus, AiUsage, Function (+10 more)
+Cohesion: 0.13
+Nodes (17): AbstractHttpAiProvider, AiCapabilities, AiRequest, AiResponse, AiResponseStatus, AiUsage, Function, HttpClient (+9 more)
 
 ### Community 123 - "Community 123"
-Cohesion: 0.10
+Cohesion: 0.11
 Nodes (4): AfterMethod, BeforeClass, Test, YAMLFileManagerUnitTest
 
 ### Community 124 - "Community 124"
@@ -1248,20 +1249,20 @@ Cohesion: 0.06
 Nodes (32): additionalProperties, type, items, type, minimum, type, minimum, type (+24 more)
 
 ### Community 128 - "Community 128"
-Cohesion: 0.18
-Nodes (14): AiExecutionService, CircuitState, AiAuditSink, AiProvider, AiProviderRegistry, AiRequest, AiResponse, AiResponseStatus (+6 more)
+Cohesion: 0.17
+Nodes (15): AiExecutionService, CircuitState, RedactionResult, AiAuditSink, AiProvider, AiProviderRegistry, AiRequest, AiResponse (+7 more)
 
 ### Community 129 - "Community 129"
-Cohesion: 0.18
-Nodes (10): AfterMethod, Map, Object, String, SuppressWarnings, Test, Throwable, ThrowingRunnable (+2 more)
+Cohesion: 0.13
+Nodes (6): Healing, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 130 - "Community 130"
 Cohesion: 0.15
 Nodes (12): Config, List, String, SuppressWarnings, AfterMethod, BeforeMethod, HttpExchange, Object (+4 more)
 
 ### Community 131 - "Community 131"
-Cohesion: 0.09
-Nodes (28): DoctorRepairProposalResult, DoctorRepairService, CaptureFormatException, HealingLocatorProposalRequest, DoctorService, McpWorkspacePolicy, McpDoctorRemediationService, String (+20 more)
+Cohesion: 0.08
+Nodes (31): DoctorRepairProposalResult, HealingLocatorProposalRequest, DoctorService, DoctorServiceTest, DoctorSnippetProvider, McpDoctorRemediationService, ApprovalPolicy, Diagnosis (+23 more)
 
 ### Community 132 - "Community 132"
 Cohesion: 0.15
@@ -1272,36 +1273,36 @@ Cohesion: 0.15
 Nodes (10): PackageActivity, BufferedReader, File, Optional, String, Path, String, Test (+2 more)
 
 ### Community 134 - "Community 134"
-Cohesion: 0.12
-Nodes (9): Jira, SetProperty, JiraTests, DefaultValue, Key, SetProperty, String, BeforeClass (+1 more)
+Cohesion: 0.06
+Nodes (16): Jira, SetProperty, Mobile, SetProperty, PropertiesManagerTests, JiraTests, DefaultValue, Key (+8 more)
 
 ### Community 135 - "Community 135"
-Cohesion: 0.10
-Nodes (18): Locator, Object, Override, PlaywrightSession, PlaywrightValidationsExecutor, String, StringBuilder, ValidationCategory (+10 more)
+Cohesion: 0.09
+Nodes (19): NativeValidationsBuilder, Locator, Object, Override, PlaywrightSession, PlaywrightValidationsExecutor, String, StringBuilder (+11 more)
 
 ### Community 136 - "Community 136"
 Cohesion: 0.16
 Nodes (27): ut(), _(), a(), b(), c(), d(), f(), g() (+19 more)
 
 ### Community 137 - "Community 137"
-Cohesion: 0.17
-Nodes (8): AnimatedGifManagerCoverageUnitTest, TestCaseFinished, AfterMethod, BeforeMethod, Color, Method, String, Test
+Cohesion: 0.16
+Nodes (17): DoctorRepairService, RecordingRunner, DoctorRepairServiceTest, RecordingRunner, validationPassed(), RepairProcessRunner, RepositoryFixture, DoctorRepairRequest (+9 more)
 
 ### Community 138 - "Community 138"
 Cohesion: 0.16
 Nodes (9): AllureManagerCoverageUnitTest, AfterMethod, BeforeMethod, Class, Method, Object, Path, String (+1 more)
 
 ### Community 139 - "Community 139"
-Cohesion: 0.07
-Nodes (31): deleteObject, deleteRelation, markStale, supersedeObject, additionalProperties, properties, required, type (+23 more)
+Cohesion: 0.10
+Nodes (23): deleteObject, deleteRelation, additionalProperties, properties, required, type, additionalProperties, properties (+15 more)
 
 ### Community 140 - "Community 140"
 Cohesion: 0.06
 Nodes (30): additionalProperties, type, type, minimum, type, minimum, type, $id (+22 more)
 
 ### Community 141 - "Community 141"
-Cohesion: 0.17
-Nodes (11): AccessibilityHelperCoverageUnitTest, AxeBuilder, AfterMethod, List, MockedConstruction, Path, Results, Rule (+3 more)
+Cohesion: 0.18
+Nodes (10): AccessibilityHelperCoverageUnitTest, AfterMethod, List, MockedConstruction, Path, Results, Rule, String (+2 more)
 
 ### Community 142 - "Community 142"
 Cohesion: 0.13
@@ -1328,8 +1329,8 @@ Cohesion: 0.19
 Nodes (11): CaptureCollectorUtilityTest, close(), start(), BrowserSignal, Class, Consumer, Object, Override (+3 more)
 
 ### Community 148 - "Community 148"
-Cohesion: 0.11
-Nodes (24): DeterministicRuleEngine, DoctorAnalyzer, DoctorAiAnalysisResult, DoctorReportWriter, DoctorTriage, EvidenceCollector, ExecutionIntelligence, Diagnosis (+16 more)
+Cohesion: 0.14
+Nodes (18): DeterministicRuleEngine, DoctorAnalyzer, DoctorReportWriter, DoctorTriage, EvidenceCollector, ExecutionIntelligence, Diagnosis, DoctorAiAnalysisRequest (+10 more)
 
 ### Community 149 - "Community 149"
 Cohesion: 0.08
@@ -1340,19 +1341,19 @@ Cohesion: 0.20
 Nodes (20): DoctorCli, flag(), optionalPath(), parse(), path(), pathRequired(), paths(), pathsRequired() (+12 more)
 
 ### Community 151 - "Community 151"
-Cohesion: 0.11
-Nodes (12): Color, Rectangle, AfterMethod, BeforeMethod, Color, Map, Method, Path (+4 more)
+Cohesion: 0.08
+Nodes (21): ImageProcessingActions, Boolean, By, Color, File, Integer, List, Rectangle (+13 more)
 
 ### Community 152 - "Community 152"
-Cohesion: 0.20
+Cohesion: 0.19
 Nodes (11): LocatorRef, McpAppiumCommandRecorder, PointerGesture, BooleanSupplier, JsonNode, locatorStrategy, Map, McpMobileRecordedAction (+3 more)
 
 ### Community 153 - "Community 153"
-Cohesion: 0.14
-Nodes (11): RestValidationsBuilder, JSONValidationsBuilder, JsonCompareWithSpecialCharactersTests, NativeValidationsBuilder, NumberValidationsBuilder, Object, String, StringBuilder (+3 more)
+Cohesion: 0.29
+Nodes (5): RestValidationsBuilder, JSONValidationsBuilder, NativeValidationsBuilder, String, ValidationsExecutor
 
 ### Community 154 - "Community 154"
-Cohesion: 0.16
+Cohesion: 0.17
 Nodes (11): HistoryDocument, HistoryRecord, HealingHistoryStore, HealingConfiguration, HealingContext, LocatorFingerprint, Optional, Path (+3 more)
 
 ### Community 155 - "Community 155"
@@ -1360,20 +1361,20 @@ Cohesion: 0.16
 Nodes (12): CapturingProvider, ImageProcessingActionsPlaywrightVisualTest, AfterMethod, Boolean, By, Integer, List, Override (+4 more)
 
 ### Community 156 - "Community 156"
-Cohesion: 0.18
-Nodes (12): ScreenshotManager, Object, Boolean, By, JavascriptExecutor, List, Object, Screenshots (+4 more)
+Cohesion: 0.20
+Nodes (11): ScreenshotManager, Boolean, By, JavascriptExecutor, List, Object, Screenshots, SneakyThrows (+3 more)
 
 ### Community 157 - "Community 157"
-Cohesion: 0.19
+Cohesion: 0.18
 Nodes (12): By, ElementActions, ElementAssertions, List, Locator, Map, Override, PlaywrightSession (+4 more)
 
 ### Community 158 - "Community 158"
-Cohesion: 0.12
-Nodes (8): XpathAxis, Role, LocatorBuilder, String, Override, AfterMethod, Test, LocatorBuilderExtendedUnitTest
+Cohesion: 0.10
+Nodes (10): XpathAxis, MobileRecordingServiceTest, Role, LocatorBuilder, String, Override, AfterMethod, Test (+2 more)
 
 ### Community 159 - "Community 159"
-Cohesion: 0.15
-Nodes (4): RestActionsCoverageUnitTest, Map, AfterMethod, Test
+Cohesion: 0.22
+Nodes (12): Boolean, ComparisonType, LinkedHashMap, List, Number, NumbersComparativeRelation, Object, Response (+4 more)
 
 ### Community 160 - "Community 160"
 Cohesion: 0.08
@@ -1393,11 +1394,11 @@ Nodes (7): Connection, DatabaseActions, Boolean, DatabaseType, ResultSet, String
 
 ### Community 165 - "Community 165"
 Cohesion: 0.10
-Nodes (15): ChromiumOptions, DesiredCapabilities, OptionsManager, OptionsManagerCoverageUnitTest, LoggingPreferences, PlatformTests, DriverType, MutableCapabilities (+7 more)
+Nodes (13): OptionsManager, OptionsManagerCoverageUnitTest, LoggingPreferences, PlatformTests, DriverType, MutableCapabilities, String, SuppressWarnings (+5 more)
 
 ### Community 166 - "Community 166"
-Cohesion: 0.11
-Nodes (8): PlaywrightBrowserValidationsBuilder, BrowserActions, Cookie, List, Override, Page, Set, String
+Cohesion: 0.15
+Nodes (6): BrowserActions, List, Override, Page, String, WindowType
 
 ### Community 167 - "Community 167"
 Cohesion: 0.19
@@ -1424,8 +1425,8 @@ Cohesion: 0.17
 Nodes (9): ElementSteps, getValue(), LocatorType(), By, String, SuppressWarnings, ThreadLocal, WebDriver (+1 more)
 
 ### Community 173 - "Community 173"
-Cohesion: 0.06
-Nodes (35): Actions, CheckpointType, CheckpointCounter, ValidationsExecutor, SilentElementReader, ValidationsHelper, ValidationsHelperNewPatternCoverageUnitTest, CheckpointStatus (+27 more)
+Cohesion: 0.19
+Nodes (6): Actions, SilentElementReader, ValidationsHelper, By, String, WebDriver
 
 ### Community 174 - "Community 174"
 Cohesion: 0.20
@@ -1433,14 +1434,14 @@ Nodes (4): Path, String, Test, AttachmentReporterUnitTest
 
 ### Community 175 - "Community 175"
 Cohesion: 0.09
-Nodes (14): PropertyFileManager, PropertyFileManagerInternalUnitTest, ThreadLocalPropertiesManager, File, HashMap, Map, MutableCapabilities, Object (+6 more)
+Nodes (14): PropertyFileManager, PropertyFileManagerInternalUnitTest, File, HashMap, Map, MutableCapabilities, Object, Properties (+6 more)
 
 ### Community 176 - "Community 176"
 Cohesion: 0.18
 Nodes (5): AsyncElementActions, By, ClipboardAction, DriverFactoryHelper, String
 
 ### Community 177 - "Community 177"
-Cohesion: 0.18
+Cohesion: 0.19
 Nodes (11): ManagedCaptureRecorder, CaptureManager, CaptureStartRequest, CaptureStatus, CheckpointKind, Function, ManagedCaptureRecorder, Override (+3 more)
 
 ### Community 178 - "Community 178"
@@ -1464,11 +1465,11 @@ Cohesion: 0.11
 Nodes (7): Playwright, PlaywrightSetProperty, PlaywrightSetProperty, DefaultValue, Key, Override, String
 
 ### Community 183 - "Community 183"
-Cohesion: 0.27
+Cohesion: 0.25
 Nodes (8): FingerprintExtractor, HealingConfiguration, LocatorFingerprint, Map, String, Supplier, WebDriver, WebElement
 
 ### Community 184 - "Community 184"
-Cohesion: 0.23
+Cohesion: 0.22
 Nodes (6): Internal, InternalTests, DefaultValue, Key, String, Test
 
 ### Community 185 - "Community 185"
@@ -1476,8 +1477,8 @@ Cohesion: 0.16
 Nodes (12): McpMobileRecordingService, List, locatorStrategy, Map, McpCodeBlock, McpMobileRecordedAction, McpMobileRecording, McpMobileRecordingStatus (+4 more)
 
 ### Community 186 - "Community 186"
-Cohesion: 0.21
-Nodes (8): TestNG, TestNGTests, Browser, DefaultValue, Integer, Key, String, Test
+Cohesion: 0.16
+Nodes (11): TestNG, TestNGTests, Browser, XmlSuite, List, XmlSuite, DefaultValue, Integer (+3 more)
 
 ### Community 187 - "Community 187"
 Cohesion: 0.08
@@ -1508,8 +1509,8 @@ Cohesion: 0.17
 Nodes (7): ElementActionsContract, By, ElementAssertions, List, Map, ShaftLocator, String
 
 ### Community 194 - "Community 194"
-Cohesion: 0.14
-Nodes (10): TestNGListenerHelper, ISuite, ITestContext, ITestNGMethod, ITestResult, List, String, TestExecutionInfo (+2 more)
+Cohesion: 0.15
+Nodes (12): RequestBuilder, MatchJsonSchemaTests, API, ContentType, Deprecated, Exception, RequestSpecification, Response (+4 more)
 
 ### Community 195 - "Community 195"
 Cohesion: 0.15
@@ -1520,16 +1521,16 @@ Cohesion: 0.16
 Nodes (13): ElementAssertions, Locator, NativeValidationsBuilder, Override, PlaywrightNativeValidationsBuilder, PlaywrightSession, PlaywrightValidationsExecutor, String (+5 more)
 
 ### Community 197 - "Community 197"
-Cohesion: 0.24
-Nodes (4): ElementActionsMockedTests, AfterMethod, BeforeMethod, Test
+Cohesion: 0.22
+Nodes (5): ElementActions, ElementActionsMockedTests, AfterMethod, BeforeMethod, Test
 
 ### Community 198 - "Community 198"
-Cohesion: 0.18
-Nodes (6): ElementInformation, ElementInformationCoverageUnitTest, Element, List, String, Test
+Cohesion: 0.17
+Nodes (7): ElementInformation, ElementInformationCoverageUnitTest, Element, List, Object, String, Test
 
 ### Community 199 - "Community 199"
-Cohesion: 0.09
-Nodes (22): RequestBuilder, RequestBuilderTests, AuthenticationType, RestAssuredConfig, API, ContentType, Deprecated, Exception (+14 more)
+Cohesion: 0.08
+Nodes (17): RequestBuilderTests, RestActionsCoverageUnitTest, AuthenticationType, RestAssuredConfig, RequestType, RestActions, ContentType, Map (+9 more)
 
 ### Community 200 - "Community 200"
 Cohesion: 0.15
@@ -1547,6 +1548,10 @@ Nodes (13): GeminiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpCl
 Cohesion: 0.19
 Nodes (12): OpenAiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode, Map (+4 more)
 
+### Community 205 - "Community 205"
+Cohesion: 0.16
+Nodes (10): CaptureFormatException, McpResultRecordsTest, McpWorkspacePolicy, String, Throwable, IllegalArgumentException, List, Path (+2 more)
+
 ### Community 206 - "Community 206"
 Cohesion: 0.15
 Nodes (4): AfterMethod, BeforeClass, Test, RestValidationsBuilderUnitTest
@@ -1561,35 +1566,39 @@ Nodes (18): A(), ba(), c(), D(), E(), G(), i(), j() (+10 more)
 
 ### Community 209 - "Community 209"
 Cohesion: 0.07
-Nodes (35): AlertEvent, ArtifactPaths, AssertionSuggestion, DataPlan, CaptureGenerator, failure(), withUnsupported(), GenerationState (+27 more)
+Nodes (34): AlertEvent, ArtifactPaths, AssertionSuggestion, DataPlan, CaptureGenerator, failure(), withUnsupported(), GenerationState (+26 more)
 
 ### Community 210 - "Community 210"
 Cohesion: 0.20
 Nodes (4): LocatorBuilderTest, AfterMethod, BeforeMethod, Test
 
 ### Community 211 - "Community 211"
-Cohesion: 0.07
-Nodes (30): HealingManager, current(), HealingStrategy(), parse(), usesHealenium(), usesShaftHeal(), HealingStrategyTest, NaturalActionExecutor (+22 more)
+Cohesion: 0.06
+Nodes (34): MultipleElementsFoundException, HealingManager, current(), HealingStrategy(), parse(), usesHealenium(), usesShaftHeal(), HealingStrategyTest (+26 more)
 
 ### Community 212 - "Community 212"
-Cohesion: 0.22
-Nodes (11): AllureSummary, Diagnostic, GeneratedTestValidator, JarEntry, JarFile, JavaFileObject, Duration, List (+3 more)
+Cohesion: 0.23
+Nodes (10): AllureSummary, Diagnostic, GeneratedTestValidator, JarFile, JavaFileObject, Duration, List, Path (+2 more)
 
 ### Community 213 - "Community 213"
 Cohesion: 0.16
 Nodes (5): ElementAssertions, NativeValidationsBuilder, String, ValidationsExecutor, VisualValidationEngine
 
 ### Community 214 - "Community 214"
-Cohesion: 0.09
-Nodes (8): SetProperty, Timeouts, Boolean, DefaultValue, Deprecated, Key, SetProperty, String
+Cohesion: 0.15
+Nodes (3): SetProperty, Deprecated, String
 
 ### Community 215 - "Community 215"
-Cohesion: 0.12
-Nodes (22): minLength, type, properties, $ref, $ref, $ref, body, evidence (+14 more)
+Cohesion: 0.14
+Nodes (18): minLength, type, properties, $ref, $ref, body, facets, origin (+10 more)
 
 ### Community 216 - "Community 216"
 Cohesion: 0.17
 Nodes (3): AfterMethod, Test, TextDirectionValidationsBuilderUnitTest
+
+### Community 217 - "Community 217"
+Cohesion: 0.21
+Nodes (5): Timeouts, Boolean, DefaultValue, Key, SetProperty
 
 ### Community 218 - "Community 218"
 Cohesion: 0.24
@@ -1599,33 +1608,29 @@ Nodes (7): RemoteGridPreflightUnitTest, AfterMethod, HttpExchange, HttpServer, M
 Cohesion: 0.29
 Nodes (5): AfterEach, BeforeAll, BeforeEach, Test, TestClass
 
-### Community 220 - "Community 220"
-Cohesion: 0.10
-Nodes (6): PropertiesHelper, String, AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
-
 ### Community 221 - "Community 221"
 Cohesion: 0.20
 Nodes (13): AiCandidateReranker, AiExecutionService, Double, HealingConfiguration, JsonNode, List, Map, ObjectNode (+5 more)
 
 ### Community 222 - "Community 222"
-Cohesion: 0.20
-Nodes (8): ExecutionLifecycleHelper, List, Method, RunType, Status, StatusIcon, String, TestExecutionInfo
+Cohesion: 0.27
+Nodes (6): ExecutionLifecycleHelper, Method, Status, StatusIcon, String, TestExecutionInfo
 
 ### Community 223 - "Community 223"
-Cohesion: 0.20
-Nodes (6): FileReader, JSONFileManagerTestAccessor, SuppressWarnings, AfterMethod, Test, MemoryLeakFixTests
+Cohesion: 0.19
+Nodes (12): PilotNaturalActionPlanner, NaturalActionKind, NaturalActionPlanner, NaturalActionStep, AiExecutionService, By, JsonNode, NaturalActionPlan (+4 more)
 
 ### Community 224 - "Community 224"
 Cohesion: 0.19
 Nodes (6): Healenium, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 225 - "Community 225"
-Cohesion: 0.17
+Cohesion: 0.16
 Nodes (8): KeysetHandle, GoogleTink, GoogleTinkApiCoverageUnitTest, String, AfterMethod, BeforeMethod, Path, Test
 
 ### Community 226 - "Community 226"
-Cohesion: 0.15
-Nodes (8): RemoteGridVideoAttachmentIT, AfterMethod, BeforeMethod, Test, AfterMethod, String, Test, PropertyFileManagerUnitTest
+Cohesion: 0.36
+Nodes (4): RemoteGridVideoAttachmentIT, AfterMethod, BeforeMethod, Test
 
 ### Community 227 - "Community 227"
 Cohesion: 0.20
@@ -1636,8 +1641,8 @@ Cohesion: 0.32
 Nodes (9): CaptureEventPipelineTest, BrowserSignal, CaptureSessionStore, Instant, Map, Object, Path, String (+1 more)
 
 ### Community 229 - "Community 229"
-Cohesion: 0.11
-Nodes (10): JunitCoreAssertionMigrationTest, UploadFileTests, MobileRecordingServiceTest, Method, Test, Test, String, Test (+2 more)
+Cohesion: 0.21
+Nodes (3): Method, Test, JavaScriptWaitManagerUnitTest
 
 ### Community 230 - "Community 230"
 Cohesion: 0.18
@@ -1648,8 +1653,8 @@ Cohesion: 0.18
 Nodes (3): AfterMethod, Test, RestActionsUtilsUnitTest
 
 ### Community 232 - "Community 232"
-Cohesion: 0.17
-Nodes (10): PilotTestConfiguration, RedactionPolicy, RedactionResult, Redactor, AiRequest, Set, String, PilotConfiguration (+2 more)
+Cohesion: 0.19
+Nodes (9): PilotTestConfiguration, RedactionPolicy, Redactor, AiRequest, Set, String, PilotConfiguration, ProcessingLocation (+1 more)
 
 ### Community 233 - "Community 233"
 Cohesion: 0.18
@@ -1664,7 +1669,7 @@ Cohesion: 0.20
 Nodes (8): CucumberFeatureListener, Class, Object, String, SuppressWarnings, Test, TableRow, CucumberFeatureListenerUnitTest
 
 ### Community 236 - "Community 236"
-Cohesion: 0.17
+Cohesion: 0.19
 Nodes (8): AccessibilityResult, AfterMethod, BeforeMethod, List, Rule, String, Test, AccessibilityActionsCoverageUnitTest
 
 ### Community 237 - "Community 237"
@@ -1688,8 +1693,8 @@ Cohesion: 0.12
 Nodes (9): AlertActionsContract, DriverContract, ElementActionsContract, BrowserActionsContract, DriverAssertions, DriverVerifications, Object, String (+1 more)
 
 ### Community 243 - "Community 243"
-Cohesion: 0.18
-Nodes (13): McpMobileInspectorRecordingServiceTest, NoopRunner, McpProcessRunner, Duration, List, Map, McpMobileInspectorRecordingService, Override (+5 more)
+Cohesion: 0.27
+Nodes (10): NoopRunner, McpProcessRunner, Duration, List, Map, Override, Path, Process (+2 more)
 
 ### Community 244 - "Community 244"
 Cohesion: 0.22
@@ -1719,28 +1724,32 @@ Nodes (14): apply_ai_changes(), atomic_write(), FileTransaction, OriginalFile, R
 Cohesion: 0.16
 Nodes (15): build_parser(), coordinates_have_supported_runner(), coordinates_have_supported_stack(), ensure_shaft_import(), migrate_full_source(), migrate_session_source(), ArgumentParser, Add the SHAFT import required by rewritten Java source. (+7 more)
 
-### Community 252 - "Community 252"
+### Community 251 - "Community 251"
 Cohesion: 0.20
+Nodes (4): AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
+
+### Community 252 - "Community 252"
+Cohesion: 0.23
 Nodes (11): AlphaProvider, ZuluProvider, Boolean, By, Integer, List, Override, String (+3 more)
 
 ### Community 253 - "Community 253"
-Cohesion: 0.17
-Nodes (6): ProgressBarLogger, ProgressBarLoggerCoverageUnitTest, Override, String, AfterMethod, Test
+Cohesion: 0.24
+Nodes (8): GuardedPatch, RepairGuard, FilePatch, List, Path, Set, String, ValidationCommand
 
 ### Community 254 - "Community 254"
-Cohesion: 0.10
-Nodes (10): AfterMethod, BeforeMethod, Issue, Issues, ITestResult, String, Test, TmsLink (+2 more)
+Cohesion: 0.06
+Nodes (17): TestNGListenerHelper, ISuite, ITestContext, ITestNGMethod, ITestResult, List, Method, String (+9 more)
 
 ### Community 255 - "Community 255"
 Cohesion: 0.23
 Nodes (7): DoctorRedactor, RedactorTest, JsonNode, List, ObjectNode, String, Test
 
 ### Community 256 - "Community 256"
-Cohesion: 0.21
+Cohesion: 0.19
 Nodes (6): FailureReporter, Class, String, Throwable, Test, FailureReporterUnitTest
 
 ### Community 257 - "Community 257"
-Cohesion: 0.29
+Cohesion: 0.27
 Nodes (5): BrowserStackHelper, Boolean, DriverFactoryHelper, MutableCapabilities, String
 
 ### Community 258 - "Community 258"
@@ -1764,12 +1773,12 @@ Cohesion: 0.09
 Nodes (25): CommandResult, confirm_upgrade(), default_compile_command(), extract_response_output_text(), is_stable_release(), metadata_release(), parse_compile_command(), Enforce the modular SHAFT dependency contract after every repair. (+17 more)
 
 ### Community 263 - "Community 263"
-Cohesion: 0.13
+Cohesion: 0.14
 Nodes (9): PlaywrightSession, PlaywrightTraceManager, Browser, BrowserContext, Object, Override, Page, Playwright (+1 more)
 
 ### Community 264 - "Community 264"
-Cohesion: 0.22
-Nodes (18): append(), checkpoint(), complete(), ensureIncomplete(), interrupt(), sortedCheckpoints(), sortedEvents(), sortedReferences() (+10 more)
+Cohesion: 0.27
+Nodes (5): CheckpointType, CheckpointStatus, String, Test, CheckpointAndReportingTest
 
 ### Community 265 - "Community 265"
 Cohesion: 0.15
@@ -1788,12 +1797,16 @@ Cohesion: 0.28
 Nodes (7): LocatorRanker, ScoredLocator, ElementSnapshot, EventContext, LocatorCandidate, LocatorSelection, String
 
 ### Community 269 - "Community 269"
-Cohesion: 0.33
-Nodes (5): Locator, Beta, By, LocatorBuilder, String
+Cohesion: 0.23
+Nodes (8): FakeGuideHttpClient, GuideServiceTest, List, Map, Override, String, Test, URI
 
 ### Community 270 - "Community 270"
 Cohesion: 0.25
 Nodes (4): MultipleDriverSessionTerminationTest, AfterMethod, BeforeMethod, Test
+
+### Community 271 - "Community 271"
+Cohesion: 0.25
+Nodes (3): ActionsExceptionDetailsUnitTest, NoSuchElementException, Test
 
 ### Community 272 - "Community 272"
 Cohesion: 0.20
@@ -1804,12 +1817,12 @@ Cohesion: 0.31
 Nodes (5): HealingLocatorProposalService, HealingLocatorProposal, JsonNode, Path, String
 
 ### Community 274 - "Community 274"
-Cohesion: 0.12
-Nodes (13): SuppressWarnings, WebDriver, AfterMethod, AndroidDriver, BeforeMethod, CountDownLatch, InputStream, Override (+5 more)
+Cohesion: 0.14
+Nodes (11): AfterMethod, AndroidDriver, BeforeMethod, CountDownLatch, InputStream, Override, String, Test (+3 more)
 
 ### Community 275 - "Community 275"
-Cohesion: 0.37
-Nodes (4): DoctorServiceTest, DoctorService, Path, Test
+Cohesion: 0.20
+Nodes (7): skipped(), finalPassed(), String, Validation, Counts, ITestNGMethod, TestExecutionCounts
 
 ### Community 276 - "Community 276"
 Cohesion: 0.17
@@ -1829,7 +1842,7 @@ Nodes (5): TextLanguageValidationsBuilder, NativeValidationsBuilder, String, Val
 
 ### Community 281 - "Community 281"
 Cohesion: 0.06
-Nodes (25): Cucumber, CucumberHelper, Mobile, SetProperty, PropertiesManagerTests, CucumberTests, List, Status (+17 more)
+Nodes (27): Cucumber, CucumberHelper, ProgressBarLogger, ProgressBarLoggerCoverageUnitTest, ProgressBarLoggerTestAccessor, CucumberTests, List, Status (+19 more)
 
 ### Community 282 - "Community 282"
 Cohesion: 0.21
@@ -1844,16 +1857,16 @@ Cohesion: 0.18
 Nodes (6): BrowserSteps, Given, String, ThreadLocal, WebDriver, When
 
 ### Community 285 - "Community 285"
-Cohesion: 0.21
-Nodes (7): ApiPerformanceExecutionReport, String, Double, List, Map, String, PerformanceReportHTMLHelper
+Cohesion: 0.20
+Nodes (9): FailureDiagnosticsReporterTest, Attachment, List, RuntimeException, String, SuppressWarnings, Test, TestExecutionInfo (+1 more)
 
 ### Community 286 - "Community 286"
 Cohesion: 0.18
 Nodes (7): HealingActionsIntegrationTest, AfterMethod, BeforeMethod, DataProvider, Object, String, Test
 
 ### Community 287 - "Community 287"
-Cohesion: 0.25
-Nodes (6): McpServiceHelperTest, AfterEach, Class, Object, String, Test
+Cohesion: 0.32
+Nodes (5): McpServiceHelperTest, Class, Object, String, Test
 
 ### Community 288 - "Community 288"
 Cohesion: 0.19
@@ -1880,8 +1893,8 @@ Cohesion: 0.16
 Nodes (12): McpPlaywrightRecordingService, List, locatorStrategy, Map, McpCodeBlock, McpMobileRecordedAction, McpMobileRecording, McpMobileRecordingStatus (+4 more)
 
 ### Community 295 - "Community 295"
-Cohesion: 0.07
-Nodes (20): AsyncElementActions, Async, CLI, GUI, Locator, Properties, Report, TestData (+12 more)
+Cohesion: 0.08
+Nodes (18): AsyncElementActions, Async, CLI, GUI, Locator, Properties, TestData, Validations (+10 more)
 
 ### Community 296 - "Community 296"
 Cohesion: 0.12
@@ -1892,8 +1905,8 @@ Cohesion: 0.12
 Nodes (17): pattern, type, origin, pattern, type, minLength, type, minLength (+9 more)
 
 ### Community 298 - "Community 298"
-Cohesion: 0.12
-Nodes (17): additionalProperties, required, type, $defs, createObject, evidence, objectId, relationId (+9 more)
+Cohesion: 0.10
+Nodes (21): additionalProperties, required, type, additionalProperties, required, type, $defs, createObject (+13 more)
 
 ### Community 299 - "Community 299"
 Cohesion: 0.21
@@ -1932,12 +1945,12 @@ Cohesion: 0.30
 Nodes (4): CaptureServiceTest, CaptureService, Path, Test
 
 ### Community 309 - "Community 309"
-Cohesion: 0.21
-Nodes (6): ValidationsHelperCoverageUnitTest, AssertionError, AfterMethod, SuppressWarnings, Test, AfterMethod
+Cohesion: 0.24
+Nodes (5): ValidationsHelperCoverageUnitTest, AssertionError, AfterMethod, SuppressWarnings, Test
 
 ### Community 311 - "Community 311"
-Cohesion: 0.18
-Nodes (9): AllureCucumber7Jvm, CucumberTestRunnerListener, EventPublisher, Feature, Optional, Override, TestSourceParsed, TestStepStarted (+1 more)
+Cohesion: 0.15
+Nodes (10): AllureCucumber7Jvm, CucumberTestRunnerListener, EventPublisher, Feature, Optional, Override, TestCaseFinished, TestSourceParsed (+2 more)
 
 ### Community 312 - "Community 312"
 Cohesion: 0.17
@@ -2004,8 +2017,8 @@ Cohesion: 0.21
 Nodes (7): AfterMethod, BeforeClass, BeforeMethod, Override, String, Test, TestClass
 
 ### Community 329 - "Community 329"
-Cohesion: 0.08
-Nodes (13): AndroidBasicInteractionsTests, AndroidTouchActionsTests, MultipleElementsFailureTest, NoSuchElementFailureTest, ScreenOrientation, Test, Test, AfterMethod (+5 more)
+Cohesion: 0.16
+Nodes (6): AndroidBasicInteractionsTests, MultipleElementsFailureTest, Test, AfterMethod, BeforeMethod, Test
 
 ### Community 330 - "Community 330"
 Cohesion: 0.29
@@ -2020,12 +2033,12 @@ Cohesion: 0.19
 Nodes (14): A(), Ae(), b(), ce(), ge(), le(), pe(), qe() (+6 more)
 
 ### Community 333 - "Community 333"
-Cohesion: 0.05
-Nodes (35): empty(), McpAppiumCommandRecorderTest, reviewUiPath(), McpMobileToolchainServiceTest, disabled(), McpResultRecordsTest, Metadata, asCacheHit() (+27 more)
+Cohesion: 0.06
+Nodes (31): empty(), DoctorHashing, McpAppiumCommandRecorderTest, reviewUiPath(), disabled(), Metadata, asCacheHit(), disabled() (+23 more)
 
 ### Community 334 - "Community 334"
-Cohesion: 0.20
-Nodes (11): notRequested(), skipped(), McpCaptureCodeBlockServiceTest, Enrichment, String, Validation, List, McpCodeBlock (+3 more)
+Cohesion: 0.25
+Nodes (8): notRequested(), McpCaptureCodeBlockServiceTest, Enrichment, List, McpCodeBlock, Path, String, Test
 
 ### Community 335 - "Community 335"
 Cohesion: 0.17
@@ -2036,11 +2049,11 @@ Cohesion: 0.21
 Nodes (4): AlertActions, Override, PlaywrightSession, String
 
 ### Community 337 - "Community 337"
-Cohesion: 0.15
-Nodes (8): EXCEL, ExcelFileManager, TestDataTests, String, Test, BeforeClass, Test, IoExcelFileManagerTests
+Cohesion: 0.24
+Nodes (5): EXCEL, ExcelFileManager, TestDataTests, String, Test
 
 ### Community 338 - "Community 338"
-Cohesion: 0.25
+Cohesion: 0.27
 Nodes (6): AiCandidateRerankerTest, AfterMethod, HealingConfiguration, HttpExchange, String, Test
 
 ### Community 339 - "Community 339"
@@ -2048,16 +2061,16 @@ Cohesion: 0.26
 Nodes (6): ModelSupport, JsonNode, List, Map, String, T
 
 ### Community 340 - "Community 340"
-Cohesion: 0.17
-Nodes (7): OpenApiCoverageReporter, AssertionError, HttpMethod, RequestType, String, Throwable, SpecCoverage
+Cohesion: 0.08
+Nodes (20): OpenApiCoverageReporter, OperationCoverage, SpecCoverage, OpenApiCoverageReporterUnitTest, OpenAPI, OpenApiValidationException, OpenApiValidationFilter, OperationCoverage (+12 more)
 
 ### Community 341 - "Community 341"
 Cohesion: 0.12
 Nodes (17): items, type, uniqueItems, tags, items, additionalProperties, minLength, pattern (+9 more)
 
 ### Community 342 - "Community 342"
-Cohesion: 0.18
-Nodes (8): ElementStepsCoverageUnitTest, ClipboardAction, BeforeMethod, By, DataProvider, Object, String, Test
+Cohesion: 0.22
+Nodes (7): ElementStepsCoverageUnitTest, BeforeMethod, By, DataProvider, Object, String, Test
 
 ### Community 343 - "Community 343"
 Cohesion: 0.25
@@ -2072,16 +2085,16 @@ Cohesion: 0.23
 Nodes (12): ActionMetadata, disabled(), HealingReport(), minimized(), pending(), ProviderMetadata(), PrivacyMetadata, HealingCandidate (+4 more)
 
 ### Community 346 - "Community 346"
-Cohesion: 0.31
-Nodes (3): Class, Test, GUIInterfaceCompatibilityCoverageUnitTest
+Cohesion: 0.19
+Nodes (5): RunType, RunType, AfterMethod, Test, DriverFactoryCoverageUnitTest
 
 ### Community 347 - "Community 347"
-Cohesion: 0.20
-Nodes (8): OperationCoverage, SpecCoverage, OpenAPI, OpenApiValidationFilter, OperationCoverage, List, ObjectNode, StringBuilder
+Cohesion: 0.23
+Nodes (6): InputStream, Path, String, SuppressWarnings, WebDriver, RecordManager
 
 ### Community 348 - "Community 348"
 Cohesion: 0.10
-Nodes (15): HasCdp, Image, ScreenshotHelper, ScreenshotHelperCoverageUnitTest, Boolean, BufferedImage, String, SuppressWarnings (+7 more)
+Nodes (14): Image, ScreenshotHelper, ScreenshotHelperCoverageUnitTest, Boolean, BufferedImage, String, SuppressWarnings, WebDriver (+6 more)
 
 ### Community 349 - "Community 349"
 Cohesion: 0.23
@@ -2104,8 +2117,8 @@ Cohesion: 0.18
 Nodes (7): FileValidationsBuilder, NativeValidationsBuilder, String, StringBuilder, SuppressWarnings, ValidationCategory, ValidationsExecutor
 
 ### Community 354 - "Community 354"
-Cohesion: 0.31
-Nodes (4): VerifyEqualsTests, AfterMethod, BeforeMethod, Test
+Cohesion: 0.21
+Nodes (5): ReportManager, Level, String, List, InternalshaftCaller
 
 ### Community 356 - "Community 356"
 Cohesion: 0.22
@@ -2117,11 +2130,11 @@ Nodes (3): SmartLocatorsPOC1Tests, CharSequence, String
 
 ### Community 358 - "Community 358"
 Cohesion: 0.26
-Nodes (5): SmartLocatorsRealisticTests, Test, AfterClass, BeforeClass, TestScenario
+Nodes (3): AfterMethod, Test, LambdaTestHelperUnitTest
 
 ### Community 359 - "Community 359"
-Cohesion: 0.26
-Nodes (4): MultipleTypeCyclesTest, AfterMethod, BeforeMethod, Test
+Cohesion: 0.06
+Nodes (19): SmartLocatorsRealisticTests, MultipleTypeCyclesTest, SelectMethodTests, UploadFileTests, Test, AfterMethod, BeforeMethod, Test (+11 more)
 
 ### Community 360 - "Community 360"
 Cohesion: 0.26
@@ -2136,12 +2149,12 @@ Cohesion: 0.27
 Nodes (4): AfterMethod, Object, Test, APIPropertiesUnitTest
 
 ### Community 363 - "Community 363"
-Cohesion: 0.29
-Nodes (5): HttpExchange, HttpServer, Override, String, LocalApiServer
+Cohesion: 0.14
+Nodes (11): FileChannel, FileLock, CaptureSingleSessionLock, Override, Path, AutoCloseable, HttpExchange, HttpServer (+3 more)
 
 ### Community 364 - "Community 364"
-Cohesion: 0.13
-Nodes (6): NetworkInterceptionTest, SmartLocatorsTests, Test, AfterMethod, BeforeMethod, Tests
+Cohesion: 0.08
+Nodes (12): BasicAuthenticationTests, NetworkInterceptionTest, TableTests, SmartLocatorsTests, Test, Test, String, Test (+4 more)
 
 ### Community 365 - "Community 365"
 Cohesion: 0.27
@@ -2160,12 +2173,12 @@ Cohesion: 0.32
 Nodes (6): CaptureGeneratedReplayBrowserTest, CaptureSession, ElementSnapshot, ExternalTestDataReference, String, Test
 
 ### Community 369 - "Community 369"
-Cohesion: 0.10
-Nodes (16): ImageProcessingActions, VisualProcessingProviderRegistry, Boolean, By, File, Integer, List, String (+8 more)
+Cohesion: 0.33
+Nodes (4): VisualProcessingProviderRegistry, List, Optional, VisualProcessingProvider
 
 ### Community 370 - "Community 370"
 Cohesion: 0.27
-Nodes (4): ShadowDomTest, AfterMethod, BeforeMethod, Test
+Nodes (4): AfterMethod, BeforeMethod, Test, BrowserActionsHelperCoverageUnitTest
 
 ### Community 371 - "Community 371"
 Cohesion: 0.23
@@ -2176,12 +2189,12 @@ Cohesion: 0.29
 Nodes (4): LocatorHealthReporterUnitTest, AfterMethod, BeforeMethod, Test
 
 ### Community 374 - "Community 374"
-Cohesion: 0.31
+Cohesion: 0.33
 Nodes (4): JDK21VirtualThreadsAndAsyncActionsTests, AfterMethod, BeforeMethod, Test
 
 ### Community 375 - "Community 375"
-Cohesion: 0.34
-Nodes (5): BrowserStackSdkHelper, List, Map, Object, String
+Cohesion: 0.18
+Nodes (8): ValidationsExecutor, FileValidationsBuilder, NativeValidationsBuilder, NumberValidationsBuilder, RestValidationsBuilder, Step, ValidationsBuilder, WebDriverElementValidationsBuilder
 
 ### Community 376 - "Community 376"
 Cohesion: 0.17
@@ -2197,11 +2210,11 @@ Nodes (4): DragAndDropTests, AfterMethod, BeforeMethod, Test
 
 ### Community 379 - "Community 379"
 Cohesion: 0.23
-Nodes (7): Attachment, FailureTraceReporterTest, List, RuntimeException, SuppressWarnings, Test, TestExecutionInfo
+Nodes (7): FailureTraceReporterTest, Attachment, List, RuntimeException, SuppressWarnings, Test, TestExecutionInfo
 
 ### Community 380 - "Community 380"
-Cohesion: 0.25
-Nodes (13): apply(), applyEnabled(), current(), NaturalActionService, textOrDefault(), withOverrides(), McpNaturalActionResult, NaturalActionSettings (+5 more)
+Cohesion: 0.15
+Nodes (17): LogRedirector, Logger, apply(), applyEnabled(), current(), NaturalActionService, textOrDefault(), withOverrides() (+9 more)
 
 ### Community 381 - "Community 381"
 Cohesion: 0.36
@@ -2243,17 +2256,13 @@ Nodes (5): AfterEach, BeforeAll, BeforeEach, Test, TestClass
 Cohesion: 0.26
 Nodes (5): AfterMethod, BeforeClass, BeforeMethod, Test, TestClass
 
-### Community 391 - "Community 391"
-Cohesion: 0.15
-Nodes (6): Platform, SetProperty, DefaultValue, Key, SetProperty, String
-
 ### Community 392 - "Community 392"
-Cohesion: 0.35
-Nodes (4): HttpExchange, Path, String, TestPageServer
+Cohesion: 0.15
+Nodes (9): LocalApiTestServer, OutputStream, HttpExchange, HttpServer, String, HttpExchange, Path, String (+1 more)
 
 ### Community 394 - "Community 394"
-Cohesion: 0.28
-Nodes (5): JSONValidationsBuilder, NativeValidationsBuilder, Object, RestValidationsBuilder, ValidationsExecutor
+Cohesion: 0.31
+Nodes (4): JSONValidationsBuilder, Object, RestValidationsBuilder, ValidationsExecutor
 
 ### Community 395 - "Community 395"
 Cohesion: 0.26
@@ -2284,8 +2293,8 @@ Cohesion: 0.26
 Nodes (4): DbTests, BeforeClass, Test, DBWizardTests
 
 ### Community 402 - "Community 402"
-Cohesion: 0.35
-Nodes (5): CaptureWorkbenchHtml, CaptureGenerationReport, CaptureReview, Path, String
+Cohesion: 0.13
+Nodes (10): CaptureWorkbenchHtml, CheckpointCounter, JunitCoreAssertionDependencyGuardTest, CaptureGenerationReport, CaptureReview, Path, String, Pattern (+2 more)
 
 ### Community 403 - "Community 403"
 Cohesion: 0.38
@@ -2300,8 +2309,8 @@ Cohesion: 0.29
 Nodes (5): Test_LTMobAPKAPPURL, AfterMethod, BeforeMethod, String, Test
 
 ### Community 406 - "Community 406"
-Cohesion: 0.19
-Nodes (8): SessionPermit, FileChannel, FileLock, CaptureSingleSessionLock, Override, Path, Override, AutoCloseable
+Cohesion: 0.40
+Nodes (3): UploadFileTests, String, Test
 
 ### Community 407 - "Community 407"
 Cohesion: 0.27
@@ -2320,20 +2329,20 @@ Cohesion: 0.16
 Nodes (11): ActionCandidate, LocatorDecision, McpCaptureCodeBlockService, PomCandidates, CaptureGenerationReport, List, LocatorCandidate, McpCodeBlock (+3 more)
 
 ### Community 411 - "Community 411"
-Cohesion: 0.29
-Nodes (5): SelectMethodTests, AfterMethod, BeforeMethod, String, Test
+Cohesion: 0.31
+Nodes (4): NoSuchElementFailureTest, AfterMethod, BeforeMethod, Test
 
 ### Community 412 - "Community 412"
-Cohesion: 0.29
-Nodes (5): UploadFileTests, AfterMethod, BeforeMethod, String, Test
+Cohesion: 0.33
+Nodes (3): BeforeClass, Test, IoExcelFileManagerTests
 
 ### Community 413 - "Community 413"
 Cohesion: 0.40
 Nodes (10): addIfSet(), addIfTrue(), defaults(), normalize(), testIdAttributes(), text(), warnings(), CaptureStartOptions (+2 more)
 
 ### Community 414 - "Community 414"
-Cohesion: 0.18
-Nodes (11): additionalProperties, properties, required, type, createRelation, $ref, enum, from (+3 more)
+Cohesion: 0.12
+Nodes (18): enum, properties, updateRelation, $ref, $ref, enum, confidence, evidence (+10 more)
 
 ### Community 416 - "Community 416"
 Cohesion: 0.24
@@ -2372,24 +2381,24 @@ Cohesion: 0.33
 Nodes (4): HoverTests, AfterMethod, BeforeMethod, Test
 
 ### Community 425 - "Community 425"
-Cohesion: 0.29
-Nodes (7): enum, updateRelation, confidence, additionalProperties, properties, required, type
+Cohesion: 0.36
+Nodes (3): ValidationsHelperNewPatternCoverageUnitTest, AfterMethod, Test
 
 ### Community 426 - "Community 426"
 Cohesion: 0.26
 Nodes (6): Pattern, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 427 - "Community 427"
-Cohesion: 0.20
-Nodes (5): ProgressBarLoggerTestAccessor, AfterMethod, Test, ValidationAndProgressBarTests, ValidationsExecutor
+Cohesion: 0.47
+Nodes (3): McpMobileInspectorRecordingServiceTest, McpMobileInspectorRecordingService, Test
 
 ### Community 428 - "Community 428"
-Cohesion: 0.52
+Cohesion: 0.43
 Nodes (3): PlaywrightTraceManager, BrowserContext, Path
 
 ### Community 430 - "Community 430"
 Cohesion: 0.23
-Nodes (6): InputStream, Override, Path, Test, CloseTrackingInputStream, ReportManagerHelperAttachmentIoUnitTest
+Nodes (5): Override, Path, Test, CloseTrackingInputStream, ReportManagerHelperAttachmentIoUnitTest
 
 ### Community 431 - "Community 431"
 Cohesion: 0.31
@@ -2400,8 +2409,8 @@ Cohesion: 0.29
 Nodes (4): FlutterTest, AfterMethod, BeforeMethod, Test
 
 ### Community 433 - "Community 433"
-Cohesion: 0.25
-Nodes (6): WebDomHealingAcceptanceTest, AfterMethod, BeforeMethod, Path, String, Test
+Cohesion: 0.36
+Nodes (5): ready(), unavailable(), AiProviderAvailability, AiProviderAvailability, String
 
 ### Community 434 - "Community 434"
 Cohesion: 0.33
@@ -2444,8 +2453,8 @@ Cohesion: 0.20
 Nodes (9): Alternative: Email, Dependency Security, Disclosure Policy, Preferred: GitHub Private Security Advisory, Reporting a Vulnerability, Response Timeline, Scope, Security Policy (+1 more)
 
 ### Community 444 - "Community 444"
-Cohesion: 0.24
-Nodes (9): AccessibilityActions, BrowserNetworkInterceptionRule, DriverFactoryHelper, HttpRequest, HttpResponse, Predicate, Screenshots, Step (+1 more)
+Cohesion: 0.14
+Nodes (11): AccessibilityActions, BrowserNetworkInterceptionRule, DriverFactoryHelper, HttpRequest, HttpResponse, Predicate, Screenshots, Step (+3 more)
 
 ### Community 445 - "Community 445"
 Cohesion: 0.32
@@ -2467,13 +2476,9 @@ Nodes (5): assemble_javadocs(), main(), project_version(), Path, AssembleJavadoc
 Cohesion: 0.33
 Nodes (5): steps, Given, String, Then, When
 
-### Community 451 - "Community 451"
-Cohesion: 0.23
-Nodes (4): UnitTestsSHAFT, CSVFileManager, CSV, Test
-
 ### Community 452 - "Community 452"
-Cohesion: 0.24
-Nodes (5): OpenApiCoverageReporterUnitTest, OpenApiValidationException, AfterMethod, String, Test
+Cohesion: 0.39
+Nodes (3): AfterMethod, Test, PlaywrightElementVisualValidationTest
 
 ### Community 453 - "Community 453"
 Cohesion: 0.32
@@ -2484,8 +2489,8 @@ Cohesion: 0.31
 Nodes (4): AfterMethod, BeforeMethod, Test, VisualValidationTests
 
 ### Community 455 - "Community 455"
-Cohesion: 0.30
-Nodes (4): PlaywrightActionsE2ETestBase, AfterMethod, Playwright, Test
+Cohesion: 0.20
+Nodes (6): PlaywrightActionsE2ETestBase, AfterMethod, BeforeMethod, Playwright, String, Test
 
 ### Community 456 - "Community 456"
 Cohesion: 0.36
@@ -2516,8 +2521,8 @@ Cohesion: 0.36
 Nodes (4): ChecksumTests, Path, String, Test
 
 ### Community 463 - "Community 463"
-Cohesion: 0.36
-Nodes (3): Locator, Pattern, Runnable
+Cohesion: 0.43
+Nodes (3): AfterMethod, Test, PropertiesHelperMaximumPerformanceModeUnitTest
 
 ### Community 464 - "Community 464"
 Cohesion: 0.35
@@ -2548,7 +2553,7 @@ Cohesion: 0.36
 Nodes (4): HealingReportWriter, HealingConfiguration, HealingReport, String
 
 ### Community 472 - "Community 472"
-Cohesion: 0.36
+Cohesion: 0.33
 Nodes (4): AfterMethod, BeforeMethod, Test, TopUncoveredClassesCoverageUnitTest
 
 ### Community 473 - "Community 473"
@@ -2565,7 +2570,7 @@ Nodes (6): Deletion Checklist, Generated PR Workflows, GitHub Actions Workflows,
 
 ### Community 476 - "Community 476"
 Cohesion: 0.15
-Nodes (10): IOSBasicInteractionsTest, ElementActions, Test_LTMobIPARelativePath, AfterMethod, BeforeMethod, SuppressWarnings, Test, AfterMethod (+2 more)
+Nodes (9): IOSBasicInteractionsTest, Test_LTMobIPARelativePath, AfterMethod, BeforeMethod, SuppressWarnings, Test, AfterMethod, BeforeMethod (+1 more)
 
 ### Community 477 - "Community 477"
 Cohesion: 0.25
@@ -2580,16 +2585,12 @@ Cohesion: 0.25
 Nodes (7): Diagnosis, Evidence Index, Findings, Missing Evidence, Privacy, Remediation, SHAFT Doctor Report
 
 ### Community 480 - "Community 480"
-Cohesion: 0.13
-Nodes (9): Performance, SetProperty, DefaultValue, Key, SetProperty, String, AfterMethod, Test (+1 more)
+Cohesion: 0.20
+Nodes (6): Performance, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 481 - "Community 481"
 Cohesion: 0.32
 Nodes (4): ValidationsExecutorTestAccessor, Object, ValidationsExecutor, WebDriver
-
-### Community 482 - "Community 482"
-Cohesion: 0.23
-Nodes (5): BrowserStackModuleTest, InvocationTargetException, JsonSchemaValidatorTest, Test, Test
 
 ### Community 483 - "Community 483"
 Cohesion: 0.38
@@ -2704,8 +2705,8 @@ Cohesion: 0.33
 Nodes (5): SynchronizationManager, Class, Exception, List, WebDriver
 
 ### Community 513 - "Community 513"
-Cohesion: 0.06
-Nodes (21): testPostRequest, ArrayList, SHAFT, DriverFactoryHelper, FileInputStream, AppiumMobileConsumer, BrowserStackSdkConsumer, LegacyCoordinateConsumer (+13 more)
+Cohesion: 0.07
+Nodes (23): ArrayList, BrowserStackModuleTest, Constructor, SHAFT, DriverFactoryHelper, FileInputStream, HasCdp, InputStream (+15 more)
 
 ### Community 514 - "Community 514"
 Cohesion: 0.43
@@ -2780,8 +2781,8 @@ Cohesion: 0.33
 Nodes (3): PrivacySanitizer, SanitizedValue, String
 
 ### Community 535 - "Community 535"
-Cohesion: 0.47
-Nodes (3): JunitCoreAssertionDependencyGuardTest, Path, Test
+Cohesion: 0.43
+Nodes (5): ClassLoader, OpenCvBlockingClassLoader, Class, Override, String
 
 ### Community 536 - "Community 536"
 Cohesion: 0.24
@@ -2792,8 +2793,8 @@ Cohesion: 0.36
 Nodes (4): SwitchToNewTabTest, AfterMethod, BeforeMethod, Test
 
 ### Community 539 - "Community 539"
-Cohesion: 0.17
-Nodes (7): AndroidDragAndDropTest, FileUploadDownloadTest, MobileTest, Test, Test, AfterMethod, BeforeMethod
+Cohesion: 0.14
+Nodes (7): AndroidDragAndDropTest, AndroidTouchActionsTests, MobileTest, Test, Test, AfterMethod, BeforeMethod
 
 ### Community 540 - "Community 540"
 Cohesion: 0.47
@@ -2816,8 +2817,8 @@ Cohesion: 0.47
 Nodes (3): PatternTests, BeforeClass, Test
 
 ### Community 545 - "Community 545"
-Cohesion: 0.40
-Nodes (4): MultipleElementsFoundException, String, Throwable, WebDriverException
+Cohesion: 0.38
+Nodes (4): JunitApiSmokeTest, AfterAll, BeforeAll, Test
 
 ### Community 546 - "Community 546"
 Cohesion: 0.47
@@ -2841,7 +2842,7 @@ Nodes (3): WebTests, BeforeClass, Test
 
 ### Community 551 - "Community 551"
 Cohesion: 0.19
-Nodes (7): FilesSize, DeterministicNaturalActionPlannerTest, NaturalActionRequest, String, Test, Test, RestActionsFailureLoggingUnitTest
+Nodes (8): Callable, DeterministicNaturalActionPlannerTest, Path, Test, NaturalActionRequest, String, Test, CaptureSessionStoreTest
 
 ### Community 552 - "Community 552"
 Cohesion: 0.40
@@ -2858,10 +2859,6 @@ Nodes (3): Source-file rewrites prepared for session or full upgrades., Return s
 ### Community 556 - "Community 556"
 Cohesion: 0.60
 Nodes (3): AbstractTestNGCucumberTests, CucumberTests, CucumberTests
-
-### Community 557 - "Community 557"
-Cohesion: 0.33
-Nodes (4): TextDirectionValidationsBuilder, NativeValidationsBuilder, ValidationsExecutor, TextDirection
 
 ### Community 558 - "Community 558"
 Cohesion: 0.60
@@ -2884,8 +2881,8 @@ Cohesion: 0.70
 Nodes (3): reviewPath(), reviewUiPath(), Path
 
 ### Community 566 - "Community 566"
-Cohesion: 0.22
-Nodes (8): ChromeOptions, MoonTests, AfterEach, BeforeEach, String, Test, WebDriver, TestInfo
+Cohesion: 0.17
+Nodes (10): ChromeOptions, ChromiumOptions, DesiredCapabilities, MoonTests, AfterEach, BeforeEach, String, Test (+2 more)
 
 ### Community 567 - "Community 567"
 Cohesion: 0.40
@@ -2896,8 +2893,8 @@ Cohesion: 0.60
 Nodes (4): copy(), text(), List, String
 
 ### Community 569 - "Community 569"
-Cohesion: 0.09
-Nodes (20): ready(), unavailable(), DisabledAiProvider, AiProvider, DoctorSnippetProvider, AfterEach, AiCapabilities, AiProviderAvailability (+12 more)
+Cohesion: 0.19
+Nodes (8): DisabledAiProvider, AiProvider, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse, Override, String
 
 ### Community 570 - "Community 570"
 Cohesion: 0.60
@@ -2928,8 +2925,8 @@ Cohesion: 0.32
 Nodes (8): IssueReporter, Boolean, ITestNGMethod, ITestResult, List, Method, String, TestExecutionInfo
 
 ### Community 579 - "Community 579"
-Cohesion: 0.16
-Nodes (10): ReportManager, ByteArrayOutputStream, CheckpointStatus, InputStream, List, Object, Step, Throwable (+2 more)
+Cohesion: 0.14
+Nodes (9): AsyncAppender, TestCaseStarted, TestCaseStarted, CheckpointStatus, List, Object, Path, Status (+1 more)
 
 ### Community 580 - "Community 580"
 Cohesion: 0.50
@@ -2948,24 +2945,16 @@ Cohesion: 0.27
 Nodes (9): agent_upgrade_plan(), ProjectAnalysis, Return whether source rewrites are eligible for this project., Validate the requested upgrade type against the detected project shape., Return a machine-readable upgrade menu for AI agents., Detected Maven project shape and requested SHAFT migration., Return optional modules supported by scan evidence., source_upgrade_supported() (+1 more)
 
 ### Community 587 - "Community 587"
-Cohesion: 0.39
-Nodes (4): LogRedirector, Logger, Level, Override
+Cohesion: 0.53
+Nodes (5): allows(), ApprovalPolicy(), EvidenceCategory, ProcessingLocation, Set
 
 ### Community 588 - "Community 588"
-Cohesion: 0.22
-Nodes (3): ExecutionSummaryReport, CheckpointStatus, StringBuilder
+Cohesion: 0.47
+Nodes (3): MultipleBrowserInstancesTest, AfterMethod, Test
 
 ### Community 591 - "Community 591"
 Cohesion: 0.50
 Nodes (3): { Client }, pgclient, values
-
-### Community 597 - "Community 597"
-Cohesion: 0.33
-Nodes (3): AccessibilityResult, List, Rule
-
-### Community 599 - "Community 599"
-Cohesion: 0.31
-Nodes (4): LocalApiTestServer, HttpExchange, HttpServer, String
 
 ### Community 609 - "Community 609"
 Cohesion: 0.43
@@ -2991,17 +2980,21 @@ Nodes (3): sha256, minLength, type
 Cohesion: 0.67
 Nodes (3): sizeBytes, minimum, type
 
-### Community 621 - "Community 621"
-Cohesion: 0.39
-Nodes (5): AtomicReference, Callable, Path, Test, CaptureSessionStoreTest
-
 ### Community 628 - "Community 628"
 Cohesion: 0.25
 Nodes (5): DoctorFormatException, ProfileCleanupException, RuntimeException, String, Throwable
 
+### Community 650 - "Community 650"
+Cohesion: 0.40
+Nodes (4): RepairGuard, RepairProposalStore, DoctorJsonCodec, RepairProcessRunner
+
 ### Community 651 - "Community 651"
-Cohesion: 0.28
-Nodes (7): LocatorAssertions, PageAssertions, Parameter, LinkedHashMap, List, Step, Outcome()
+Cohesion: 0.67
+Nodes (3): defaults(), CaptureGenerationRequest, Path
+
+### Community 652 - "Community 652"
+Cohesion: 0.20
+Nodes (3): JunitListenerHelper, TestIdentifier, Boolean
 
 ### Community 653 - "Community 653"
 Cohesion: 0.36
@@ -3015,13 +3008,9 @@ Nodes (6): RepairProcessRunner, Duration, List, Path, ProcessResult, String
 Cohesion: 0.36
 Nodes (4): RelativeLocatorsTests, AfterMethod, BeforeMethod, Test
 
-### Community 658 - "Community 658"
-Cohesion: 0.33
-Nodes (4): AiAuditSink, ShaftAiAuditSink, AiAuditEvent, Override
-
 ### Community 676 - "Community 676"
-Cohesion: 0.50
-Nodes (3): BrowserActions, List, WebDriver
+Cohesion: 0.21
+Nodes (7): AccessibilityActions, AccessibilityConfig, AccessibilityResult, BrowserActions, List, String, WebDriver
 
 ### Community 758 - "Community 758"
 Cohesion: 0.33
@@ -3036,16 +3025,16 @@ Cohesion: 0.33
 Nodes (4): JunitDatabaseSmokeTest, AfterAll, BeforeAll, Test
 
 ### Community 763 - "Community 763"
-Cohesion: 0.39
-Nodes (4): JunitProjectStructureManagerTest, AfterEach, Path, Test
+Cohesion: 0.53
+Nodes (3): JunitProjectStructureManagerTest, AfterEach, Path
 
 ### Community 766 - "Community 766"
 Cohesion: 0.50
 Nodes (3): CaptureRuntimePortabilityTest, Path, Test
 
 ### Community 768 - "Community 768"
-Cohesion: 0.30
-Nodes (9): FakeRunner, Duration, List, Map, Override, Path, Process, ProcessResult (+1 more)
+Cohesion: 0.17
+Nodes (13): FakeRunner, McpMobileToolchainServiceTest, Duration, List, Map, McpMobileToolchainDiagnostic, McpMobileToolchainStatus, Override (+5 more)
 
 ### Community 769 - "Community 769"
 Cohesion: 0.40
@@ -3069,31 +3058,31 @@ Nodes (3): IPhone17ProMaxPlaywrightActionsE2ETest, Override, String
 
 ### Community 780 - "Community 780"
 Cohesion: 0.10
-Nodes (17): CaptureEnrichmentService, CodegenBackend(), driverClassName(), from(), MutableTargetPlan, GeneratedTestValidator, LocatorRanker, CaptureJsonCodec (+9 more)
+Nodes (18): CaptureEnrichmentService, CodegenBackend(), driverClassName(), from(), MutableTargetPlan, GeneratedTestValidator, LocatorRanker, CaptureJsonCodec (+10 more)
 
 ### Community 781 - "Community 781"
 Cohesion: 0.53
 Nodes (3): Path, Test, ExecutionLifecycleHelperSourceUnitTest
 
 ### Community 782 - "Community 782"
-Cohesion: 0.29
+Cohesion: 0.31
 Nodes (5): AfterMethod, BeforeClass, BeforeMethod, Test, TestClass
 
-### Community 784 - "Community 784"
-Cohesion: 0.14
-Nodes (9): BasicAPITests, Map, ParametersType, AfterClass, BeforeClass, List, Map, String (+1 more)
-
 ### Community 787 - "Community 787"
-Cohesion: 0.16
-Nodes (14): limiterKey(), RemoteGridPreflight, unavailable(), PreflightReport, Semaphore, SessionPermit, Capabilities, Duration (+6 more)
+Cohesion: 0.14
+Nodes (16): limiterKey(), RemoteGridPreflight, SessionPermit, unavailable(), PreflightReport, Semaphore, SessionPermit, Capabilities (+8 more)
 
 ### Community 789 - "Community 789"
-Cohesion: 0.33
-Nodes (3): FileActionsReflectionInvoker, FileActions, String
+Cohesion: 0.15
+Nodes (9): FileActionsCoverageUnitTest, FileActionsReflectionInvoker, JarEntry, AfterMethod, Path, String, FileActions, String (+1 more)
 
 ### Community 798 - "Community 798"
-Cohesion: 0.53
-Nodes (5): option(), ProviderConfiguration(), Map, String, URI
+Cohesion: 0.50
+Nodes (3): Object, StringBuilder, ValidationCategory
+
+### Community 799 - "Community 799"
+Cohesion: 0.50
+Nodes (3): McpMobileToolchainService, McpMobileRecordingService, McpWorkspacePolicy
 
 ### Community 800 - "Community 800"
 Cohesion: 0.47
@@ -3111,33 +3100,41 @@ Nodes (3): FirefoxPlaywrightActionsE2ETest, Override, String
 Cohesion: 0.40
 Nodes (3): WebKitPlaywrightActionsE2ETest, Override, String
 
+### Community 807 - "Community 807"
+Cohesion: 0.50
+Nodes (4): markStale, additionalProperties, required, type
+
 ### Community 808 - "Community 808"
 Cohesion: 0.50
-Nodes (3): Object, Override, SuppressWarnings
+Nodes (4): supersedeObject, additionalProperties, required, type
 
 ### Community 810 - "Community 810"
 Cohesion: 0.67
 Nodes (3): minLength, type, mediaType
 
+### Community 811 - "Community 811"
+Cohesion: 0.40
+Nodes (3): DriverFactoryHelper, WebDriver, WebDriverElementValidationsBuilder
+
 ## Knowledge Gaps
-- **1457 isolated node(s):** `$id`, `$schema`, `additionalProperties`, `additionalProperties`, `type` (+1452 more)
+- **1462 isolated node(s):** `$id`, `$schema`, `additionalProperties`, `additionalProperties`, `type` (+1457 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **99 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **101 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `SHAFT` connect `Community 513` to `Community 512`, `Community 514`, `Community 5`, `Community 517`, `Community 7`, `Community 8`, `Community 9`, `Community 10`, `Community 523`, `Community 12`, `Community 13`, `Community 15`, `Community 528`, `Community 17`, `Community 18`, `Community 529`, `Community 16`, `Community 21`, `Community 22`, `Community 19`, `Community 536`, `Community 23`, `Community 26`, `Community 539`, `Community 538`, `Community 27`, `Community 30`, `Community 31`, `Community 540`, `Community 33`, `Community 34`, `Community 35`, `Community 36`, `Community 541`, `Community 542`, `Community 37`, `Community 544`, `Community 547`, `Community 549`, `Community 43`, `Community 550`, `Community 39`, `Community 46`, `Community 47`, `Community 551`, `Community 49`, `Community 562`, `Community 51`, `Community 52`, `Community 53`, `Community 566`, `Community 55`, `Community 563`, `Community 57`, `Community 569`, `Community 65`, `Community 69`, `Community 71`, `Community 74`, `Community 76`, `Community 80`, `Community 81`, `Community 86`, `Community 87`, `Community 88`, `Community 96`, `Community 99`, `Community 103`, `Community 104`, `Community 106`, `Community 108`, `Community 114`, `Community 116`, `Community 121`, `Community 24`, `Community 123`, `Community 125`, `Community 129`, `Community 130`, `Community 134`, `Community 137`, `Community 138`, `Community 651`, `Community 28`, `Community 142`, `Community 656`, `Community 658`, `Community 151`, `Community 153`, `Community 156`, `Community 159`, `Community 161`, `Community 32`, `Community 162`, `Community 676`, `Community 165`, `Community 167`, `Community 169`, `Community 170`, `Community 172`, `Community 173`, `Community 174`, `Community 179`, `Community 184`, `Community 186`, `Community 546`, `Community 191`, `Community 38`, `Community 199`, `Community 205`, `Community 210`, `Community 211`, `Community 218`, `Community 219`, `Community 220`, `Community 222`, `Community 225`, `Community 226`, `Community 230`, `Community 240`, `Community 241`, `Community 247`, `Community 760`, `Community 763`, `Community 252`, `Community 253`, `Community 254`, `Community 257`, `Community 770`, `Community 771`, `Community 260`, `Community 261`, `Community 772`, `Community 775`, `Community 266`, `Community 781`, `Community 782`, `Community 270`, `Community 784`, `Community 273`, `Community 274`, `Community 787`, `Community 276`, `Community 277`, `Community 788`, `Community 279`, `Community 281`, `Community 284`, `Community 285`, `Community 286`, `Community 287`, `Community 290`, `Community 803`, `Community 293`, `Community 806`, `Community 295`, `Community 807`, `Community 306`, `Community 311`, `Community 327`, `Community 328`, `Community 329`, `Community 337`, `Community 338`, `Community 342`, `Community 346`, `Community 348`, `Community 354`, `Community 358`, `Community 359`, `Community 360`, `Community 362`, `Community 364`, `Community 367`, `Community 369`, `Community 370`, `Community 373`, `Community 374`, `Community 378`, `Community 379`, `Community 380`, `Community 381`, `Community 382`, `Community 389`, `Community 390`, `Community 392`, `Community 395`, `Community 398`, `Community 399`, `Community 401`, `Community 403`, `Community 405`, `Community 407`, `Community 408`, `Community 409`, `Community 411`, `Community 412`, `Community 417`, `Community 424`, `Community 428`, `Community 429`, `Community 431`, `Community 432`, `Community 433`, `Community 435`, `Community 444`, `Community 446`, `Community 450`, `Community 451`, `Community 454`, `Community 456`, `Community 460`, `Community 461`, `Community 468`, `Community 470`, `Community 473`, `Community 476`, `Community 480`, `Community 484`, `Community 485`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 493`, `Community 494`, `Community 496`, `Community 498`, `Community 502`, `Community 503`, `Community 504`, `Community 505`, `Community 506`, `Community 509`, `Community 511`?**
-  _High betweenness centrality (0.133) - this node is a cross-community bridge._
-- **Why does `IOException` connect `Community 513` to `Community 5`, `Community 7`, `Community 8`, `Community 13`, `Community 18`, `Community 19`, `Community 535`, `Community 24`, `Community 25`, `Community 539`, `Community 29`, `Community 31`, `Community 33`, `Community 553`, `Community 41`, `Community 49`, `Community 56`, `Community 57`, `Community 60`, `Community 61`, `Community 62`, `Community 64`, `Community 71`, `Community 584`, `Community 74`, `Community 76`, `Community 79`, `Community 81`, `Community 85`, `Community 86`, `Community 599`, `Community 102`, `Community 105`, `Community 113`, `Community 116`, `Community 117`, `Community 628`, `Community 122`, `Community 131`, `Community 133`, `Community 137`, `Community 138`, `Community 653`, `Community 141`, `Community 654`, `Community 148`, `Community 154`, `Community 156`, `Community 169`, `Community 170`, `Community 175`, `Community 179`, `Community 185`, `Community 189`, `Community 212`, `Community 218`, `Community 223`, `Community 226`, `Community 233`, `Community 239`, `Community 241`, `Community 244`, `Community 763`, `Community 780`, `Community 784`, `Community 273`, `Community 787`, `Community 277`, `Community 279`, `Community 288`, `Community 294`, `Community 299`, `Community 301`, `Community 307`, `Community 313`, `Community 314`, `Community 321`, `Community 328`, `Community 333`, `Community 338`, `Community 363`, `Community 369`, `Community 392`, `Community 402`, `Community 404`, `Community 406`, `Community 410`, `Community 418`, `Community 428`, `Community 430`, `Community 433`, `Community 464`, `Community 467`, `Community 471`, `Community 506`?**
-  _High betweenness centrality (0.022) - this node is a cross-community bridge._
-- **Why does `ReportManagerHelper` connect `Community 17` to `Community 579`, `Community 39`, `Community 652`, `Community 588`, `Community 88`?**
-  _High betweenness centrality (0.017) - this node is a cross-community bridge._
+- **Why does `SHAFT` connect `Community 513` to `Community 512`, `Community 2`, `Community 3`, `Community 514`, `Community 5`, `Community 517`, `Community 7`, `Community 8`, `Community 9`, `Community 523`, `Community 12`, `Community 13`, `Community 15`, `Community 528`, `Community 529`, `Community 18`, `Community 16`, `Community 19`, `Community 21`, `Community 22`, `Community 536`, `Community 24`, `Community 26`, `Community 539`, `Community 538`, `Community 27`, `Community 30`, `Community 31`, `Community 540`, `Community 33`, `Community 34`, `Community 35`, `Community 36`, `Community 37`, `Community 545`, `Community 542`, `Community 544`, `Community 547`, `Community 549`, `Community 43`, `Community 550`, `Community 45`, `Community 46`, `Community 47`, `Community 562`, `Community 563`, `Community 52`, `Community 53`, `Community 566`, `Community 55`, `Community 565`, `Community 57`, `Community 65`, `Community 579`, `Community 69`, `Community 71`, `Community 74`, `Community 76`, `Community 588`, `Community 80`, `Community 86`, `Community 599`, `Community 88`, `Community 87`, `Community 93`, `Community 95`, `Community 99`, `Community 615`, `Community 104`, `Community 103`, `Community 106`, `Community 108`, `Community 114`, `Community 116`, `Community 121`, `Community 123`, `Community 125`, `Community 130`, `Community 131`, `Community 134`, `Community 138`, `Community 28`, `Community 142`, `Community 656`, `Community 657`, `Community 658`, `Community 151`, `Community 156`, `Community 161`, `Community 541`, `Community 32`, `Community 676`, `Community 165`, `Community 162`, `Community 167`, `Community 169`, `Community 170`, `Community 172`, `Community 173`, `Community 174`, `Community 179`, `Community 184`, `Community 186`, `Community 546`, `Community 191`, `Community 38`, `Community 194`, `Community 199`, `Community 210`, `Community 211`, `Community 218`, `Community 219`, `Community 220`, `Community 223`, `Community 225`, `Community 226`, `Community 240`, `Community 241`, `Community 247`, `Community 760`, `Community 763`, `Community 251`, `Community 257`, `Community 770`, `Community 771`, `Community 260`, `Community 261`, `Community 772`, `Community 775`, `Community 266`, `Community 781`, `Community 782`, `Community 270`, `Community 784`, `Community 273`, `Community 274`, `Community 787`, `Community 276`, `Community 789`, `Community 277`, `Community 279`, `Community 788`, `Community 281`, `Community 284`, `Community 285`, `Community 286`, `Community 290`, `Community 803`, `Community 293`, `Community 806`, `Community 295`, `Community 813`, `Community 306`, `Community 311`, `Community 327`, `Community 328`, `Community 329`, `Community 337`, `Community 338`, `Community 340`, `Community 342`, `Community 347`, `Community 359`, `Community 360`, `Community 362`, `Community 364`, `Community 367`, `Community 370`, `Community 373`, `Community 374`, `Community 378`, `Community 379`, `Community 380`, `Community 381`, `Community 382`, `Community 389`, `Community 390`, `Community 392`, `Community 395`, `Community 399`, `Community 401`, `Community 403`, `Community 405`, `Community 407`, `Community 408`, `Community 409`, `Community 411`, `Community 412`, `Community 417`, `Community 424`, `Community 425`, `Community 428`, `Community 429`, `Community 431`, `Community 432`, `Community 435`, `Community 444`, `Community 446`, `Community 450`, `Community 452`, `Community 454`, `Community 455`, `Community 456`, `Community 460`, `Community 461`, `Community 463`, `Community 468`, `Community 470`, `Community 473`, `Community 476`, `Community 484`, `Community 485`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 493`, `Community 494`, `Community 496`, `Community 498`, `Community 502`, `Community 503`, `Community 504`, `Community 505`, `Community 506`, `Community 509`, `Community 511`?**
+  _High betweenness centrality (0.127) - this node is a cross-community bridge._
+- **Why does `IOException` connect `Community 513` to `Community 5`, `Community 7`, `Community 8`, `Community 13`, `Community 19`, `Community 24`, `Community 25`, `Community 29`, `Community 30`, `Community 31`, `Community 33`, `Community 553`, `Community 41`, `Community 56`, `Community 57`, `Community 60`, `Community 61`, `Community 62`, `Community 64`, `Community 71`, `Community 72`, `Community 584`, `Community 74`, `Community 76`, `Community 79`, `Community 85`, `Community 86`, `Community 599`, `Community 87`, `Community 102`, `Community 105`, `Community 113`, `Community 114`, `Community 116`, `Community 117`, `Community 628`, `Community 122`, `Community 131`, `Community 133`, `Community 137`, `Community 138`, `Community 653`, `Community 141`, `Community 654`, `Community 148`, `Community 151`, `Community 154`, `Community 156`, `Community 169`, `Community 170`, `Community 175`, `Community 179`, `Community 185`, `Community 189`, `Community 205`, `Community 212`, `Community 218`, `Community 220`, `Community 225`, `Community 226`, `Community 233`, `Community 239`, `Community 241`, `Community 244`, `Community 763`, `Community 253`, `Community 780`, `Community 269`, `Community 273`, `Community 787`, `Community 789`, `Community 277`, `Community 279`, `Community 288`, `Community 294`, `Community 299`, `Community 301`, `Community 307`, `Community 313`, `Community 314`, `Community 321`, `Community 328`, `Community 333`, `Community 338`, `Community 340`, `Community 347`, `Community 363`, `Community 392`, `Community 402`, `Community 404`, `Community 410`, `Community 418`, `Community 428`, `Community 430`, `Community 455`, `Community 464`, `Community 467`, `Community 471`, `Community 506`?**
+  _High betweenness centrality (0.019) - this node is a cross-community bridge._
 - **What connects `$id`, `$schema`, `additionalProperties` to the rest of the system?**
-  _1568 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _1573 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.04198841698841699 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.04242424242424243 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
   _Cohesion score 0.05764411027568922 - nodes in this community are weakly interconnected._
 - **Should `Community 2` be split into smaller, more focused modules?**
-  _Cohesion score 0.11261261261261261 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.08599033816425121 - nodes in this community are weakly interconnected._
+- **Should `Community 3` be split into smaller, more focused modules?**
+  _Cohesion score 0.10980392156862745 - nodes in this community are weakly interconnected._

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -600,8 +600,8 @@
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/collect/EvidenceCollector.java": {
-    "mtime": 1781242397.4476755,
-    "ast_hash": "215b16abacef5aac9558b65d47ef7f79",
+    "mtime": 1782378657.7966466,
+    "ast_hash": "84dc792fdb8d315c4218a804d9f61082",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/format/DoctorFormatException.java": {
@@ -805,8 +805,8 @@
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/DoctorAnalyzerTest.java": {
-    "mtime": 1781788245.510158,
-    "ast_hash": "576320b25fa1fbf85a7cc21a2f337230",
+    "mtime": 1782378376.9343908,
+    "ast_hash": "93366fd3b071988e38c09281f676d26d",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/ai/DoctorAiAnalysisServiceTest.java": {
@@ -935,7 +935,7 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java": {
-    "mtime": 1782377571.493302,
+    "mtime": 1782378124.4338515,
     "ast_hash": "b6a6700eaab6d2dd65134b25a9fe4621",
     "semantic_hash": ""
   },
@@ -1255,8 +1255,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java": {
-    "mtime": 1782377571.4973035,
-    "ast_hash": "db8b8351e67b74f98db631341139b0ae",
+    "mtime": 1782378626.6404614,
+    "ast_hash": "b7db73a1c5016000dc5dcdc49e95ec68",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/UpdateChecker.java": {
@@ -1385,8 +1385,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Reporting.java": {
-    "mtime": 1782377571.4983032,
-    "ast_hash": "b4437bdec4c21f85de105fd1fd259358",
+    "mtime": 1782378626.6384616,
+    "ast_hash": "faaadb551ee6ab2afbf0881331e14f36",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/TestNG.java": {
@@ -1490,8 +1490,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java": {
-    "mtime": 1782373954.6253874,
-    "ast_hash": "5f46b2348204ee74851a25d4276357f1",
+    "mtime": 1782378124.437851,
+    "ast_hash": "96298012fb506f7f8ee9043cc3a1a8f3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ApiPerformanceExecutionReport.java": {
@@ -1500,7 +1500,7 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/AttachmentReporter.java": {
-    "mtime": 1782377571.4993029,
+    "mtime": 1782378124.4388506,
     "ast_hash": "90dfc19115b429c7c97749fcd123237c",
     "semantic_hash": ""
   },
@@ -1920,8 +1920,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureManagerCoverageUnitTest.java": {
-    "mtime": 1782374430.2577329,
-    "ast_hash": "3850400fd5bbf6efff90538f61e68c22",
+    "mtime": 1782378124.4418511,
+    "ast_hash": "8e16f9c749c62d33e891be8ee0dafad8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/ProgressBarLoggerCoverageUnitTest.java": {
@@ -2595,8 +2595,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/ReportingTests.java": {
-    "mtime": 1782377571.5023026,
-    "ast_hash": "71b6a4206d44143293e9854fb46f0d75",
+    "mtime": 1782378626.6414616,
+    "ast_hash": "2689cf0e5c18f1d3691e33b1257f91b0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/TestNGTests.java": {
@@ -2690,7 +2690,7 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AttachmentReporterUnitTest.java": {
-    "mtime": 1782377571.5043025,
+    "mtime": 1782378124.4438505,
     "ast_hash": "229dcbca9c2a919d35a9b79e6c6e1345",
     "semantic_hash": ""
   },
@@ -4055,8 +4055,8 @@
     "semantic_hash": ""
   },
   ".github/actions/post-test-report/action.yml": {
-    "mtime": 1782371414.2918622,
-    "ast_hash": "4ea3584523933c5d89eda857b3fb1539",
+    "mtime": 1782378124.362333,
+    "ast_hash": "682df808ffdefb6178d20bce9dba6668",
     "semantic_hash": ""
   },
   ".github/actions/setup-test-env/action.yml": {
@@ -4925,8 +4925,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/ExecutionLifecycleHelper.java": {
-    "mtime": 1782377571.4963036,
-    "ast_hash": "1eac1a123648683df72b8f43ec26e621",
+    "mtime": 1782378626.639462,
+    "ast_hash": "d6e603c9c7051b06eaabc25b6b7be128",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/TestExecutionInfo.java": {
@@ -5270,7 +5270,7 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightTraceManager.java": {
-    "mtime": 1782377571.494302,
+    "mtime": 1782378124.4348516,
     "ast_hash": "8edde0e8b06e9b67806e0b779051976a",
     "semantic_hash": ""
   },
@@ -5495,7 +5495,7 @@
     "semantic_hash": ""
   },
   ".github/workflows/README.md": {
-    "mtime": 1782372953.6509464,
+    "mtime": 1782378124.3633323,
     "ast_hash": "c6956e8a0cc38af6f8800ff3b36ca3b5",
     "semantic_hash": ""
   },
@@ -5590,18 +5590,48 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft_report_logo.png": {
-    "mtime": 1782373833.74218,
+    "mtime": 1782378124.4408517,
     "ast_hash": "987c93b372f4f797f601da520d349930",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureTraceReporter.java": {
-    "mtime": 1782377571.5003035,
+    "mtime": 1782378124.4388506,
     "ast_hash": "6aa99a3e255442d655077fdc648726fe",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/FailureTraceReporterTest.java": {
-    "mtime": 1782377571.5013034,
+    "mtime": 1782378124.44285,
     "ast_hash": "90d20a7d15d470c750f2fd426ff61ce9",
+    "semantic_hash": ""
+  },
+  "shaft-doctor/allure-results/27493508-7014-4df8-b1e2-827d04f7b58a-container.json": {
+    "mtime": 1782378720.0125911,
+    "ast_hash": "90656029398986892aa9a4ddd27e9c6c",
+    "semantic_hash": ""
+  },
+  "shaft-doctor/allure-results/b596fb1b-780d-4532-8070-9dff7d7a16ab-container.json": {
+    "mtime": 1782378720.0145843,
+    "ast_hash": "218bba2da8dcdcf4d3117ccdb2df9d97",
+    "semantic_hash": ""
+  },
+  "shaft-doctor/allure-results/d9f65eba-268d-47f1-b6a8-3d69f652909d-result.json": {
+    "mtime": 1782378720.0175898,
+    "ast_hash": "eece206c20ae24da40a2c364ad82651d",
+    "semantic_hash": ""
+  },
+  "shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureDiagnosticsReporter.java": {
+    "mtime": 1782378626.6424615,
+    "ast_hash": "a55fec71cb539c7f60d6abcc3c5ccdb9",
+    "semantic_hash": ""
+  },
+  "shaft-engine/src/test/java/com/shaft/tools/io/internal/FailureDiagnosticsReporterTest.java": {
+    "mtime": 1782378376.9343908,
+    "ast_hash": "0f0afa00f3eeac4457210404e365fc86",
+    "semantic_hash": ""
+  },
+  "shaft-doctor/allure-results/1079b947-9f92-4113-87e6-2b4088c0ea6e-attachment.txt": {
+    "mtime": 1782378719.8405232,
+    "ast_hash": "70524e41adaa390f239432c99a4d0d9b",
     "semantic_hash": ""
   }
 }

--- a/shaft-doctor/src/main/java/com/shaft/doctor/collect/EvidenceCollector.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/collect/EvidenceCollector.java
@@ -31,6 +31,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 /**
  * Collects bounded local evidence through explicit allowlisted adapter boundaries.
@@ -130,6 +132,14 @@ public final class EvidenceCollector {
         String lowerName = file.getFileName().toString().toLowerCase(Locale.ROOT);
         String extension = extension(lowerName);
 
+        if (isDiagnosticsJson(lowerName)) {
+            collectDiagnosticsText(file, sourceReference, request, redactor, items, state);
+            return;
+        }
+        if (isDiagnosticsZip(lowerName, "", extension)) {
+            collectDiagnosticsZip(file, sourceReference, request, redactor, items, state);
+            return;
+        }
         if (looksLikeBundle(file, lowerName)) {
             try {
                 EvidenceBundle bundle = codec.readBundle(file);
@@ -289,6 +299,7 @@ public final class EvidenceCollector {
                 String type = attachment.path("type").asText("").toLowerCase(Locale.ROOT);
                 String extension = extension(artifact.getFileName().toString().toLowerCase(Locale.ROOT));
                 String reference = portableReference(artifact, roots);
+                String diagnosticName = name + " " + source.toLowerCase(Locale.ROOT);
                 if (type.startsWith("image/") || SCREENSHOT_EXTENSIONS.contains(extension)) {
                     if (request.includeScreenshots()) {
                         collectBinary(artifact, reference, EvidenceCategory.SCREENSHOT,
@@ -305,6 +316,8 @@ public final class EvidenceCollector {
                     } else {
                         state.omittedItems++;
                     }
+                } else if (isDiagnosticsZip(diagnosticName, type, extension)) {
+                    collectDiagnosticsZip(artifact, reference, request, redactor, items, state);
                 } else if (name.contains("log") || name.contains("action history")
                         || name.contains("shaft")) {
                     collectText(artifact, reference, EvidenceCategory.SHAFT_LOG,
@@ -318,6 +331,88 @@ public final class EvidenceCollector {
                 collectAllureAttachments(child, resultFile, roots, request, redactor, items, state);
             }
         }
+    }
+
+    private void collectDiagnosticsText(
+            Path file,
+            String sourceReference,
+            DoctorAnalysisRequest request,
+            DoctorRedactor redactor,
+            Map<String, EvidenceItem> items,
+            CollectionState state) {
+        byte[] source = readBounded(file, request.maxItemBytes());
+        collectDiagnosticsBytes(sourceReference, source, FilesSize.size(file) > source.length,
+                false, request, redactor, items, state);
+    }
+
+    private void collectDiagnosticsZip(
+            Path file,
+            String sourceReference,
+            DoctorAnalysisRequest request,
+            DoctorRedactor redactor,
+            Map<String, EvidenceItem> items,
+            CollectionState state) {
+        try {
+            ZipText diagnostics = readDiagnosticsEntry(file, request.maxItemBytes());
+            if (diagnostics == null) {
+                state.omittedItems++;
+                return;
+            }
+            collectDiagnosticsBytes(sourceReference + "!/diagnostics.json", diagnostics.bytes(), diagnostics.truncated(),
+                    false, request, redactor, items, state);
+        } catch (IOException exception) {
+            collectDiagnosticsBytes(sourceReference, "Malformed SHAFT diagnostics zip."
+                            .getBytes(StandardCharsets.UTF_8), false, true, request, redactor, items, state);
+        }
+    }
+
+    private void collectDiagnosticsBytes(
+            String sourceReference,
+            byte[] source,
+            boolean sourceTruncated,
+            boolean invalid,
+            DoctorAnalysisRequest request,
+            DoctorRedactor redactor,
+            Map<String, EvidenceItem> items,
+            CollectionState state) {
+        String text = new String(source, StandardCharsets.UTF_8);
+        String schemaVersion = "";
+        String sanitized;
+        try {
+            JsonNode redacted = redactor.redact(mapper.readTree(text));
+            schemaVersion = redacted.path("schemaVersion").asText("");
+            sanitized = mapper.writer(printer).writeValueAsString(redacted);
+        } catch (JsonProcessingException exception) {
+            sanitized = redactor.redact(text);
+            invalid = true;
+        }
+        byte[] retained = limit(sanitized.getBytes(StandardCharsets.UTF_8), request.maxItemBytes());
+        Map<String, String> attributes = new TreeMap<>();
+        attributes.put("diagnostics", "true");
+        attributes.put("invalid", Boolean.toString(invalid));
+        if (!schemaVersion.isBlank()) {
+            attributes.put("schemaVersion", schemaVersion);
+        }
+        addTextItem(sourceReference, EvidenceCategory.SHAFT_LOG, "application/json",
+                retained,
+                sourceTruncated || retained.length < sanitized.getBytes(StandardCharsets.UTF_8).length,
+                attributes, "shaft-diagnostics-json", items, state, request.maxBundleBytes());
+    }
+
+    private static ZipText readDiagnosticsEntry(Path file, long maxBytes) throws IOException {
+        int limit = Math.toIntExact(Math.min(maxBytes, Integer.MAX_VALUE - 1));
+        try (ZipInputStream zip = new ZipInputStream(Files.newInputStream(file))) {
+            ZipEntry entry;
+            while ((entry = zip.getNextEntry()) != null) {
+                String name = entry.getName().replace('\\', '/');
+                if (!entry.isDirectory() && (name.equals("diagnostics.json") || name.endsWith("/diagnostics.json"))) {
+                    byte[] bytes = zip.readNBytes(limit + 1);
+                    boolean truncated = bytes.length > limit;
+                    return new ZipText(limit(bytes, limit), truncated);
+                }
+            }
+        }
+        return null;
     }
 
     private void collectBinary(
@@ -553,6 +648,16 @@ public final class EvidenceCollector {
         return prefix.contains("\"bundleId\"") && prefix.contains("\"evidence\"");
     }
 
+    private static boolean isDiagnosticsJson(String lowerName) {
+        return lowerName.equals("diagnostics.json") || lowerName.endsWith("-diagnostics.json");
+    }
+
+    private static boolean isDiagnosticsZip(String lowerName, String type, String extension) {
+        return ".zip".equals(extension)
+                && (type.isBlank() || type.contains("zip"))
+                && lowerName.contains("diagnostics");
+    }
+
     private static EvidenceCategory inferCategory(String lowerName, String extension) {
         if (isPageSnapshot(lowerName, extension)) {
             return EvidenceCategory.PAGE_SNAPSHOT;
@@ -682,5 +787,8 @@ public final class EvidenceCollector {
                 throw new IllegalArgumentException("Doctor evidence size could not be read.", exception);
             }
         }
+    }
+
+    private record ZipText(byte[] bytes, boolean truncated) {
     }
 }

--- a/shaft-doctor/src/test/java/com/shaft/doctor/DoctorAnalyzerTest.java
+++ b/shaft-doctor/src/test/java/com/shaft/doctor/DoctorAnalyzerTest.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.EnumSet;
 import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static org.junit.jupiter.api.Assumptions.abort;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -358,6 +360,38 @@ class DoctorAnalyzerTest {
     }
 
     @Test
+    void allureDiagnosticsZipAttachmentFeedsDoctorRules(@TempDir Path temp) throws IOException {
+        Path input = Files.createDirectories(temp.resolve("diagnostics-input"));
+        Path zip = input.resolve("shaft-diagnostics.zip");
+        writeZip(zip, "diagnostics.json", """
+                {
+                  "schemaVersion": 1,
+                  "failure": {
+                    "type": "org.openqa.selenium.NoSuchElementException",
+                    "message": "Unable to locate element token=DO-NOT-RETAIN-DIAGNOSTICS-SECRET",
+                    "stacktrace": "NoSuchElementException: unable to locate element"
+                  }
+                }
+                """);
+        Path resultPath = input.resolve("diagnostics-result.json");
+        writeResult(resultPath, "failed", "", "", "diagnostics", 1);
+        var tree = (com.fasterxml.jackson.databind.node.ObjectNode) MAPPER.readTree(resultPath.toFile());
+        tree.set("attachments", MAPPER.valueToTree(List.of(Map.of(
+                "name", "shaft-diagnostics",
+                "source", "shaft-diagnostics.zip",
+                "type", "application/zip"))));
+        Files.writeString(resultPath, MAPPER.writeValueAsString(tree), StandardCharsets.UTF_8);
+
+        DoctorAnalysisResult result = analyze(temp, input, "diagnostics-output", 1, false, false, List.of());
+
+        assertEquals(CauseCategory.LOCATOR, result.diagnosis().primaryCause());
+        assertTrue(result.bundle().evidence().stream()
+                .anyMatch(item -> item.category() == EvidenceCategory.SHAFT_LOG
+                        && "true".equals(item.attributes().get("diagnostics"))));
+        assertOutputDoesNotContain(result, "DO-NOT-RETAIN-DIAGNOSTICS-SECRET");
+    }
+
+    @Test
     void enforcesAllowedRootsAndArtifactLimits(@TempDir Path temp) throws IOException {
         Path allowed = Files.createDirectories(temp.resolve("allowed"));
         Path outside = Files.createDirectories(temp.resolve("outside"));
@@ -528,8 +562,16 @@ class DoctorAnalyzerTest {
                 "statusDetails", Map.of("message", message, "trace", trace),
                 "labels", List.of(
                         Map.of("name", "testClass", "value", "example.Test"),
-                        Map.of("name", "testMethod", "value", "test-" + historyId)));
+                Map.of("name", "testMethod", "value", "test-" + historyId)));
         Files.writeString(path, MAPPER.writeValueAsString(result), StandardCharsets.UTF_8);
+    }
+
+    private static void writeZip(Path path, String entryName, String content) throws IOException {
+        try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(path))) {
+            zip.putNextEntry(new ZipEntry(entryName));
+            zip.write(content.getBytes(StandardCharsets.UTF_8));
+            zip.closeEntry();
+        }
     }
 
     private static void assertOutputDoesNotContain(

--- a/shaft-engine/src/main/java/com/shaft/listeners/internal/ExecutionLifecycleHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/internal/ExecutionLifecycleHelper.java
@@ -12,6 +12,7 @@ import com.shaft.tools.internal.security.GoogleTink;
 import com.shaft.tools.io.internal.AllureManager;
 import com.shaft.tools.io.internal.ApiPerformanceExecutionReport;
 import com.shaft.tools.io.internal.ExecutionSummaryReport;
+import com.shaft.tools.io.internal.FailureDiagnosticsReporter;
 import com.shaft.tools.io.internal.FailureTraceReporter;
 import com.shaft.tools.io.internal.ProjectStructureManager;
 import com.shaft.tools.io.internal.ReportContext;
@@ -102,6 +103,7 @@ public final class ExecutionLifecycleHelper {
         String logText = createTestLog(ReportContext.snapshotOutput());
         ReportManagerHelper.attachTestLog(valueOrBlank(info.methodName()), logText);
         FailureTraceReporter.attachOnFailure(info, logText, attachments);
+        FailureDiagnosticsReporter.attachOnFailure(info, logText, attachments);
         JiraHelper.reportBugsToJIRA(attachments, logText, info);
     }
 

--- a/shaft-engine/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java
@@ -7,6 +7,7 @@ import com.shaft.gui.internal.image.AnimatedGifManager;
 import com.shaft.gui.internal.locator.LocatorBuilder;
 import com.shaft.gui.internal.video.RecordManager;
 import com.shaft.properties.internal.ThreadLocalPropertiesManager;
+import com.shaft.tools.io.internal.FailureDiagnosticsReporter;
 import com.shaft.tools.io.internal.FailureTraceReporter;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import io.qameta.allure.Issue;
@@ -303,7 +304,9 @@ public class TestNGListenerHelper {
 
             String logText = TestNGListenerHelper.createTestLog(getReporterOutput(iTestResult));
             ReportManagerHelper.attachTestLog(iTestNGMethod.getMethodName(), logText);
-            FailureTraceReporter.attachOnFailure(toTestExecutionInfo(iTestResult), logText, attachments);
+            TestExecutionInfo info = toTestExecutionInfo(iTestResult);
+            FailureTraceReporter.attachOnFailure(info, logText, attachments);
+            FailureDiagnosticsReporter.attachOnFailure(info, logText, attachments);
             JiraHelper.reportBugsToJIRA(attachments, logText, iTestResult, iTestNGMethod);
         }
     }

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Reporting.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Reporting.java
@@ -70,6 +70,14 @@ public interface Reporting extends EngineProperties<Reporting> {
     @DefaultValue("false")
     boolean failOnLocatorHealthWarnings();
 
+    @Key("shaft.diagnostics.enabled")
+    @DefaultValue("true")
+    boolean diagnosticsBundleEnabled();
+
+    @Key("shaft.diagnostics.maxArtifactMb")
+    @DefaultValue("50")
+    int diagnosticsMaxArtifactMb();
+
     @Key("shaft.trace.enabled")
     @DefaultValue("true")
     boolean traceEnabled();
@@ -165,6 +173,16 @@ public interface Reporting extends EngineProperties<Reporting> {
 
         public SetProperty failOnLocatorHealthWarnings(boolean value) {
             setProperty("failOnLocatorHealthWarnings", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty diagnosticsBundleEnabled(boolean value) {
+            setProperty("shaft.diagnostics.enabled", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty diagnosticsMaxArtifactMb(int value) {
+            setProperty("shaft.diagnostics.maxArtifactMb", String.valueOf(value));
             return this;
         }
 

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureDiagnosticsReporter.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureDiagnosticsReporter.java
@@ -1,0 +1,457 @@
+package com.shaft.tools.io.internal;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.gui.playwright.internal.PlaywrightTraceManager;
+import com.shaft.listeners.internal.TestExecutionInfo;
+import io.qameta.allure.model.Status;
+import org.apache.logging.log4j.Level;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * Builds the agent-readable failure diagnostics bundle attached to failed tests.
+ */
+public final class FailureDiagnosticsReporter {
+    private static final Pattern AUTHORIZATION_PATTERN = Pattern.compile(
+            "(?i)(authorization|proxy-authorization)(\\s*[:=]\\s*)[^\\r\\n]+");
+    private static final Pattern COOKIE_PATTERN = Pattern.compile(
+            "(?i)(cookie|set-cookie)(\\s*[:=]\\s*)[^\\r\\n]+");
+    private static final Pattern SECRET_ASSIGNMENT_PATTERN = Pattern.compile(
+            "(?i)(password|passwd|pwd|secret|token|access[_-]?key|api[_-]?key)(\\s*[:=]\\s*)[^\\s,;&\"'<>]+");
+    private static final Pattern SECRET_QUERY_PATTERN = Pattern.compile(
+            "(?i)([?&](?:password|passwd|pwd|secret|token|access[_-]?key|api[_-]?key)=)[^&#\\s]+");
+    private static final int SNIPPET_RADIUS = 2;
+    // ponytail: bounded log list, make configurable if agent handoff needs deeper local history.
+    private static final int MAX_LOG_LINES = 200;
+
+    private FailureDiagnosticsReporter() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Attaches {@code shaft-diagnostics.zip} for failed or broken tests.
+     *
+     * @param info        current test metadata
+     * @param logText     current test log
+     * @param attachments generated artifact file paths already known to SHAFT
+     */
+    public static void attachOnFailure(TestExecutionInfo info, String logText, List<String> attachments) {
+        if (!shouldAttachDiagnostics(info)) {
+            return;
+        }
+        try {
+            attach("zip", "shaft-diagnostics.zip",
+                    renderDiagnosticsZip(renderDiagnosticsJson(info, logText, attachments)),
+                    "shaft-diagnostics");
+        } catch (RuntimeException e) {
+            ReportManagerHelper.logDiscrete("Could not attach SHAFT diagnostics bundle: " + e.getMessage(), Level.WARN);
+        }
+    }
+
+    static String renderDiagnosticsJson(TestExecutionInfo info, String logText, List<String> attachments) {
+        Redactor redactor = new Redactor();
+        Throwable throwable = info == null ? null : info.throwable();
+        SourceContext source = sourceContext(throwable);
+        List<String> logLines = logLines(logText, redactor);
+        List<ArtifactReference> artifactReferences = artifactReferences(attachments, redactor, info);
+
+        StringBuilder json = new StringBuilder();
+        json.append("{\n");
+        numberField(json, 1, "schemaVersion", 1, true);
+        stringField(json, 1, "generatedAt", Instant.now().toString(), true, redactor);
+        objectStart(json, 1, "test");
+        stringField(json, 2, "className", value(info == null ? null : info.className()), true, redactor);
+        stringField(json, 2, "methodName", value(info == null ? null : info.methodName()), true, redactor);
+        stringField(json, 2, "displayName", value(info == null ? null : info.displayName()), true, redactor);
+        stringField(json, 2, "description", value(info == null ? null : info.description()), true, redactor);
+        numberField(json, 2, "retryAttempt", info != null && info.retried() ? 1 : 0, true);
+        booleanField(json, 2, "retried", info != null && info.retried(), true);
+        stringField(json, 2, "thread", Thread.currentThread().getName(), false, redactor);
+        objectEnd(json, 1, true);
+        objectStart(json, 1, "failure");
+        stringField(json, 2, "status", status(), true, redactor);
+        stringField(json, 2, "type", throwable == null ? "" : throwable.getClass().getName(), true, redactor);
+        stringField(json, 2, "message", throwable == null ? "" : throwable.getMessage(), true, redactor);
+        stringField(json, 2, "stacktrace", ReportManagerHelper.formatStackTraceToLogEntry(throwable), true, redactor);
+        stringField(json, 2, "topProjectFrame", source.frame(), true, redactor);
+        stringArray(json, 2, "causes", causes(throwable), false, redactor);
+        objectEnd(json, 1, true);
+        objectStart(json, 1, "codeContext");
+        stringField(json, 2, "file", source.file(), true, redactor);
+        stringField(json, 2, "line", source.line(), true, redactor);
+        stringField(json, 2, "snippet", source.snippet(), false, redactor);
+        objectEnd(json, 1, true);
+        objectStart(json, 1, "configuration");
+        booleanField(json, 2, "diagnosticsBundleEnabled", SHAFT.Properties.reporting.diagnosticsBundleEnabled(), true);
+        numberField(json, 2, "diagnosticsMaxArtifactMb", SHAFT.Properties.reporting.diagnosticsMaxArtifactMb(), true);
+        booleanField(json, 2, "traceEnabled", SHAFT.Properties.reporting.traceEnabled(), true);
+        stringField(json, 2, "traceMode", SHAFT.Properties.reporting.traceMode(), false, redactor);
+        objectEnd(json, 1, true);
+        objectStart(json, 1, "environment");
+        stringField(json, 2, "javaRuntime", Runtime.version().toString(), true, redactor);
+        numberField(json, 2, "availableProcessors", Runtime.getRuntime().availableProcessors(), false);
+        objectEnd(json, 1, true);
+        objectStart(json, 1, "limits");
+        numberField(json, 2, "maxArtifactMb", SHAFT.Properties.reporting.diagnosticsMaxArtifactMb(), true);
+        numberField(json, 2, "logLinesIncluded", logLines.size(), true);
+        numberField(json, 2, "logLinesOmitted", omittedLogLines(logText, logLines.size()), false);
+        objectEnd(json, 1, true);
+        stringArray(json, 1, "logs", logLines, true, redactor);
+        artifacts(json, 1, artifactReferences, true);
+        stringArray(json, 1, "nextCommands", List.of(
+                "shaft-doctor analyze --input allure-results --allowed-root . --output-dir target/shaft-doctor",
+                "doctor_analyze_failed_allure(allureResultPaths=[\"allure-results\"])"), true, redactor);
+        objectStart(json, 1, "redaction");
+        stringArray(json, 2, "rulesApplied", redactor.rulesApplied(), false, null);
+        objectEnd(json, 1, false);
+        json.append("}\n");
+        return json.toString();
+    }
+
+    static byte[] renderDiagnosticsZip(String diagnosticsJson) {
+        int maxBytes = Math.max(1, SHAFT.Properties.reporting.diagnosticsMaxArtifactMb()) * 1024 * 1024;
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream();
+             ZipOutputStream zip = new ZipOutputStream(output)) {
+            addZipEntry(zip, "diagnostics.json", diagnosticsJson.getBytes(StandardCharsets.UTF_8), maxBytes);
+            zip.finish();
+            return output.toByteArray();
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not create SHAFT diagnostics zip.", e);
+        }
+    }
+
+    static boolean shouldAttachDiagnostics(TestExecutionInfo info) {
+        if (SHAFT.Properties.reporting == null
+                || !SHAFT.Properties.reporting.diagnosticsBundleEnabled()
+                || info == null
+                || info.throwable() == null) {
+            return false;
+        }
+        Status status = ReportContext.getStatus();
+        return status == null || Status.FAILED.equals(status) || Status.BROKEN.equals(status);
+    }
+
+    private static void addZipEntry(ZipOutputStream zip, String name, byte[] bytes, int maxBytes) throws IOException {
+        zip.putNextEntry(new ZipEntry(name));
+        if (bytes.length <= maxBytes) {
+            zip.write(bytes);
+        } else {
+            zip.write(("Omitted because artifact exceeded shaft.diagnostics.maxArtifactMb="
+                    + SHAFT.Properties.reporting.diagnosticsMaxArtifactMb()).getBytes(StandardCharsets.UTF_8));
+        }
+        zip.closeEntry();
+    }
+
+    private static void attach(String type, String name, byte[] bytes, String description) {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try {
+            output.write(bytes);
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not buffer diagnostics attachment.", e);
+        }
+        AttachmentReporter.attachBasedOnFileType(type, name, output, description);
+    }
+
+    private static List<String> causes(Throwable throwable) {
+        List<String> causes = new ArrayList<>();
+        for (Throwable current = throwable == null ? null : throwable.getCause();
+             current != null;
+             current = current.getCause()) {
+            causes.add(current.getClass().getName() + ": " + value(current.getMessage()));
+        }
+        return causes;
+    }
+
+    private static List<String> logLines(String logText, Redactor redactor) {
+        if (logText == null || logText.isBlank()) {
+            return List.of();
+        }
+        List<String> lines = new ArrayList<>();
+        for (String line : logText.split("\\R")) {
+            if (!line.isBlank()) {
+                lines.add(redactor.redact(line));
+                if (lines.size() == MAX_LOG_LINES) {
+                    break;
+                }
+            }
+        }
+        return List.copyOf(lines);
+    }
+
+    private static int omittedLogLines(String logText, int included) {
+        if (logText == null || logText.isBlank()) {
+            return 0;
+        }
+        long total = logText.lines().filter(line -> !line.isBlank()).count();
+        return Math.toIntExact(Math.max(0, total - included));
+    }
+
+    private static List<ArtifactReference> artifactReferences(
+            List<String> attachments,
+            Redactor redactor,
+            TestExecutionInfo info) {
+        List<ArtifactReference> references = new ArrayList<>();
+        if (attachments != null) {
+            for (String attachment : attachments) {
+                if (attachment != null && !attachment.isBlank()) {
+                    references.add(new ArtifactReference("artifact-" + (references.size() + 1),
+                            mediaType(attachment), redactor.redact(attachment)));
+                }
+            }
+        }
+        if (FailureTraceReporter.shouldAttachTrace(info)) {
+            references.add(new ArtifactReference("trace-report", "text/html", "SHAFT Trace Report.html"));
+            references.add(new ArtifactReference("trace-json", "application/json", "shaft-trace.json"));
+            references.add(new ArtifactReference("trace-zip", "application/zip", "shaft-trace.zip"));
+        }
+        Path playwrightTrace = PlaywrightTraceManager.getLastTracePath();
+        if (playwrightTrace != null) {
+            references.add(new ArtifactReference("playwright-trace", "application/zip",
+                    redactor.redact(playwrightTrace.toString())));
+        }
+        return List.copyOf(references);
+    }
+
+    private static String mediaType(String path) {
+        String lower = path.toLowerCase();
+        if (lower.endsWith(".png")) {
+            return "image/png";
+        }
+        if (lower.endsWith(".gif")) {
+            return "image/gif";
+        }
+        if (lower.endsWith(".mp4")) {
+            return "video/mp4";
+        }
+        if (lower.endsWith(".zip")) {
+            return "application/zip";
+        }
+        if (lower.endsWith(".json")) {
+            return "application/json";
+        }
+        if (lower.endsWith(".html") || lower.endsWith(".htm")) {
+            return "text/html";
+        }
+        return "text/plain";
+    }
+
+    private static SourceContext sourceContext(Throwable throwable) {
+        StackTraceElement frame = relevantFrame(throwable);
+        if (frame == null) {
+            return new SourceContext("", "", "", "");
+        }
+        Path sourceFile = findSourceFile(frame);
+        if (sourceFile == null) {
+            return new SourceContext(frame.toString(), "", String.valueOf(frame.getLineNumber()), frame.toString());
+        }
+        return new SourceContext(frame.toString(), relative(sourceFile), String.valueOf(frame.getLineNumber()),
+                snippet(sourceFile, frame.getLineNumber()));
+    }
+
+    private static StackTraceElement relevantFrame(Throwable throwable) {
+        for (Throwable current = throwable; current != null; current = current.getCause()) {
+            for (StackTraceElement frame : current.getStackTrace()) {
+                String className = frame.getClassName();
+                if (!className.startsWith("com.shaft.")
+                        && !className.startsWith("org.testng.")
+                        && !className.startsWith("org.junit.")
+                        && !className.startsWith("io.qameta.")
+                        && !className.startsWith("java.")
+                        && !className.startsWith("jdk.")) {
+                    return frame;
+                }
+            }
+        }
+        return throwable == null || throwable.getStackTrace().length == 0 ? null : throwable.getStackTrace()[0];
+    }
+
+    private static Path findSourceFile(StackTraceElement frame) {
+        String classPath = frame.getClassName().replace('.', '/') + ".java";
+        int nestedClassIndex = classPath.indexOf('$');
+        if (nestedClassIndex > -1) {
+            classPath = classPath.substring(0, nestedClassIndex) + ".java";
+        }
+        List<Path> candidates = List.of(
+                Path.of("src/test/java", classPath),
+                Path.of("src/main/java", classPath),
+                Path.of("shaft-engine/src/test/java", classPath),
+                Path.of("shaft-engine/src/main/java", classPath));
+        for (Path candidate : candidates) {
+            if (Files.isRegularFile(candidate)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private static String snippet(Path sourceFile, int lineNumber) {
+        if (lineNumber < 1) {
+            return "";
+        }
+        try {
+            List<String> lines = Files.readAllLines(sourceFile, StandardCharsets.UTF_8);
+            int start = Math.max(1, lineNumber - SNIPPET_RADIUS);
+            int end = Math.min(lines.size(), lineNumber + SNIPPET_RADIUS);
+            StringBuilder snippet = new StringBuilder();
+            for (int line = start; line <= end; line++) {
+                snippet.append(line == lineNumber ? "> " : "  ")
+                        .append(line)
+                        .append(": ")
+                        .append(lines.get(line - 1))
+                        .append(System.lineSeparator());
+            }
+            return snippet.toString().trim();
+        } catch (IOException e) {
+            return sourceFile + ":" + lineNumber;
+        }
+    }
+
+    private static String status() {
+        Status status = ReportContext.getStatus();
+        if (Status.BROKEN.equals(status)) {
+            return "broken";
+        }
+        return "failed";
+    }
+
+    private static void objectStart(StringBuilder json, int indent, String key) {
+        indent(json, indent).append("\"").append(key).append("\": {\n");
+    }
+
+    private static void objectEnd(StringBuilder json, int indent, boolean comma) {
+        indent(json, indent).append("}").append(comma ? "," : "").append("\n");
+    }
+
+    private static void stringField(
+            StringBuilder json,
+            int indent,
+            String key,
+            String value,
+            boolean comma,
+            Redactor redactor) {
+        String safe = redactor == null ? value(value) : redactor.redact(value);
+        indent(json, indent).append("\"").append(key).append("\": \"")
+                .append(escapeJson(safe))
+                .append("\"")
+                .append(comma ? "," : "")
+                .append("\n");
+    }
+
+    private static void numberField(StringBuilder json, int indent, String key, int value, boolean comma) {
+        indent(json, indent).append("\"").append(key).append("\": ")
+                .append(value)
+                .append(comma ? "," : "")
+                .append("\n");
+    }
+
+    private static void booleanField(StringBuilder json, int indent, String key, boolean value, boolean comma) {
+        indent(json, indent).append("\"").append(key).append("\": ")
+                .append(value)
+                .append(comma ? "," : "")
+                .append("\n");
+    }
+
+    private static void stringArray(
+            StringBuilder json,
+            int indent,
+            String key,
+            List<String> values,
+            boolean comma,
+            Redactor redactor) {
+        indent(json, indent).append("\"").append(key).append("\": [");
+        for (int i = 0; i < values.size(); i++) {
+            if (i > 0) {
+                json.append(", ");
+            }
+            String safe = redactor == null ? value(values.get(i)) : redactor.redact(values.get(i));
+            json.append("\"").append(escapeJson(safe)).append("\"");
+        }
+        json.append("]").append(comma ? "," : "").append("\n");
+    }
+
+    private static void artifacts(
+            StringBuilder json,
+            int indent,
+            List<ArtifactReference> references,
+            boolean comma) {
+        indent(json, indent).append("\"artifacts\": [");
+        for (int i = 0; i < references.size(); i++) {
+            ArtifactReference reference = references.get(i);
+            if (i > 0) {
+                json.append(", ");
+            }
+            json.append("{\"id\": \"").append(escapeJson(reference.id())).append("\", ")
+                    .append("\"type\": \"").append(escapeJson(reference.type())).append("\", ")
+                    .append("\"path\": \"").append(escapeJson(reference.path())).append("\"}");
+        }
+        json.append("]").append(comma ? "," : "").append("\n");
+    }
+
+    private static StringBuilder indent(StringBuilder builder, int level) {
+        return builder.append("  ".repeat(level));
+    }
+
+    private static String escapeJson(String value) {
+        return value(value)
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t");
+    }
+
+    private static String relative(Path path) {
+        Path absolute = path.toAbsolutePath().normalize();
+        Path current = Path.of("").toAbsolutePath().normalize();
+        if (absolute.startsWith(current)) {
+            return current.relativize(absolute).toString().replace('\\', '/');
+        }
+        return path.getFileName().toString();
+    }
+
+    private static String value(String value) {
+        return value == null ? "" : value;
+    }
+
+    private record SourceContext(String frame, String file, String line, String snippet) {
+    }
+
+    private record ArtifactReference(String id, String type, String path) {
+    }
+
+    private static final class Redactor {
+        private final Set<String> rulesApplied = new LinkedHashSet<>();
+
+        private String redact(String value) {
+            String redacted = value(value);
+            redacted = replace(redacted, AUTHORIZATION_PATTERN, "$1$2********", "authorization-header");
+            redacted = replace(redacted, COOKIE_PATTERN, "$1$2********", "cookie-header");
+            redacted = replace(redacted, SECRET_ASSIGNMENT_PATTERN, "$1$2********", "secret-assignment");
+            return replace(redacted, SECRET_QUERY_PATTERN, "$1********", "secret-url-query");
+        }
+
+        private String replace(String input, Pattern pattern, String replacement, String rule) {
+            String output = pattern.matcher(input).replaceAll(replacement);
+            if (!output.equals(input)) {
+                rulesApplied.add(rule);
+            }
+            return output;
+        }
+
+        private List<String> rulesApplied() {
+            return rulesApplied.stream().sorted().toList();
+        }
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/FailureDiagnosticsReporterTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/FailureDiagnosticsReporterTest.java
@@ -1,0 +1,133 @@
+package com.shaft.tools.io.internal;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.listeners.internal.TestExecutionInfo;
+import com.shaft.properties.internal.Properties;
+import io.qameta.allure.Allure;
+import io.qameta.allure.model.Attachment;
+import io.qameta.allure.model.Status;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+public class FailureDiagnosticsReporterTest {
+
+    @Test(description = "Failed tests should attach one diagnostics zip with sanitized diagnostics JSON")
+    public void failedTestsShouldAttachDiagnosticsZip() throws Exception {
+        try {
+            SHAFT.Properties.reporting.set()
+                    .diagnosticsBundleEnabled(true)
+                    .diagnosticsMaxArtifactMb(1)
+                    .traceEnabled(true)
+                    .traceMode("failure");
+            ReportContext.start(info("failingScenario", failure()));
+            ReportContext.setStatus(Status.FAILED);
+            int before = attachments().size();
+
+            FailureDiagnosticsReporter.attachOnFailure(
+                    info("failingScenario", failure()),
+                    "Authorization: Bearer raw-token\ncookie: session=raw-cookie\npassword=raw-password",
+                    List.of("target/raw-secret-video.mp4"));
+
+            List<Attachment> added = attachments().subList(before, attachments().size());
+            Assert.assertEquals(added.size(), 1);
+            Assert.assertEquals(added.getFirst().getName(), "shaft-diagnostics");
+            Assert.assertEquals(added.getFirst().getType(), "application/zip");
+
+            String json = unzipDiagnostics(FailureDiagnosticsReporter.renderDiagnosticsZip(
+                    FailureDiagnosticsReporter.renderDiagnosticsJson(
+                            info("failingScenario", failure()),
+                            "Authorization: Bearer raw-token\ncookie: session=raw-cookie\npassword=raw-password",
+                            List.of("target/raw-secret-video.mp4"))));
+            Assert.assertTrue(json.contains("\"schemaVersion\": 1"), json);
+            Assert.assertTrue(json.contains("\"className\": \"customer.LoginTest\""), json);
+            Assert.assertTrue(json.contains("\"status\": \"failed\""), json);
+            Assert.assertTrue(json.contains("\"topProjectFrame\": \"customer.LoginTest.failingScenario(LoginTest.java:27)\""), json);
+            Assert.assertTrue(json.contains("\"path\": \"shaft-trace.zip\""), json);
+            Assert.assertTrue(json.contains("\"authorization-header\""), json);
+            Assert.assertFalse(json.contains("raw-token"), json);
+            Assert.assertFalse(json.contains("raw-cookie"), json);
+            Assert.assertFalse(json.contains("raw-password"), json);
+        } finally {
+            ReportContext.clear();
+            Properties.clearForCurrentThread();
+        }
+    }
+
+    @Test(description = "Skipped tests with throwables should not attach diagnostics")
+    public void skippedTestsShouldNotAttachDiagnosticsZip() throws Exception {
+        try {
+            SHAFT.Properties.reporting.set().diagnosticsBundleEnabled(true);
+            ReportContext.start(info("skippedScenario", failure()));
+            ReportContext.setStatus(Status.SKIPPED);
+            int before = attachments().size();
+
+            FailureDiagnosticsReporter.attachOnFailure(info("skippedScenario", failure()), "skip log", List.of());
+
+            Assert.assertEquals(attachments().size(), before);
+        } finally {
+            ReportContext.clear();
+            Properties.clearForCurrentThread();
+        }
+    }
+
+    @Test(description = "Diagnostics reporting properties should have failure-safe defaults and setters")
+    public void diagnosticsReportingPropertiesShouldHaveDefaultsAndSetters() {
+        try {
+            Assert.assertTrue(SHAFT.Properties.reporting.diagnosticsBundleEnabled());
+            Assert.assertEquals(SHAFT.Properties.reporting.diagnosticsMaxArtifactMb(), 50);
+
+            SHAFT.Properties.reporting.set()
+                    .diagnosticsBundleEnabled(false)
+                    .diagnosticsMaxArtifactMb(3);
+
+            Assert.assertFalse(SHAFT.Properties.reporting.diagnosticsBundleEnabled());
+            Assert.assertEquals(SHAFT.Properties.reporting.diagnosticsMaxArtifactMb(), 3);
+        } finally {
+            Properties.clearForCurrentThread();
+        }
+    }
+
+    private static TestExecutionInfo info(String methodName, Throwable throwable) throws Exception {
+        Method method = FailureDiagnosticsReporterTest.class.getDeclaredMethod("failingScenario");
+        return new TestExecutionInfo("id-" + methodName, "customer.LoginTest", methodName, methodName,
+                "diagnostics test", method, throwable, false);
+    }
+
+    private static RuntimeException failure() {
+        RuntimeException throwable = new RuntimeException("boom password=raw-password");
+        throwable.setStackTrace(new StackTraceElement[]{
+                new StackTraceElement("customer.LoginTest", "failingScenario", "LoginTest.java", 27),
+                new StackTraceElement("com.shaft.listeners.internal.ExecutionLifecycleHelper", "attach", "ExecutionLifecycleHelper.java", 1)
+        });
+        return throwable;
+    }
+
+    @SuppressWarnings("unused")
+    private static void failingScenario() {
+        throw new UnsupportedOperationException("test marker");
+    }
+
+    private static String unzipDiagnostics(byte[] zipBytes) throws Exception {
+        try (ZipInputStream zip = new ZipInputStream(new java.io.ByteArrayInputStream(zipBytes))) {
+            ZipEntry entry;
+            while ((entry = zip.getNextEntry()) != null) {
+                if ("diagnostics.json".equals(entry.getName())) {
+                    return new String(zip.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+                }
+            }
+        }
+        throw new AssertionError("diagnostics.json was not present in shaft-diagnostics.zip");
+    }
+
+    private static List<Attachment> attachments() {
+        List<Attachment> attachments = new ArrayList<>();
+        Allure.getLifecycle().updateTestCase(result -> attachments.addAll(result.getAttachments()));
+        return attachments;
+    }
+}

--- a/shaft-engine/src/test/java/testPackage/properties/ReportingTests.java
+++ b/shaft-engine/src/test/java/testPackage/properties/ReportingTests.java
@@ -13,6 +13,8 @@ public class ReportingTests {
     boolean openExecutionSummaryReportAfterExecution;
     boolean disableLogging;
     boolean attachFullLog;
+    boolean diagnosticsBundleEnabled;
+    int diagnosticsMaxArtifactMb;
     boolean traceEnabled;
     String traceMode;
     boolean traceIncludeCodeContext;
@@ -32,6 +34,8 @@ public class ReportingTests {
         openExecutionSummaryReportAfterExecution = SHAFT.Properties.reporting.openExecutionSummaryReportAfterExecution();
         disableLogging = SHAFT.Properties.reporting.disableLogging();
         attachFullLog = SHAFT.Properties.reporting.attachFullLog();
+        diagnosticsBundleEnabled = SHAFT.Properties.reporting.diagnosticsBundleEnabled();
+        diagnosticsMaxArtifactMb = SHAFT.Properties.reporting.diagnosticsMaxArtifactMb();
         traceEnabled = SHAFT.Properties.reporting.traceEnabled();
         traceMode = SHAFT.Properties.reporting.traceMode();
         traceIncludeCodeContext = SHAFT.Properties.reporting.traceIncludeCodeContext();
@@ -53,6 +57,8 @@ public class ReportingTests {
         SHAFT.Properties.reporting.set().openExecutionSummaryReportAfterExecution(openExecutionSummaryReportAfterExecution);
         SHAFT.Properties.reporting.set().disableLogging(disableLogging);
         SHAFT.Properties.reporting.set().attachFullLog(attachFullLog);
+        SHAFT.Properties.reporting.set().diagnosticsBundleEnabled(diagnosticsBundleEnabled);
+        SHAFT.Properties.reporting.set().diagnosticsMaxArtifactMb(diagnosticsMaxArtifactMb);
         SHAFT.Properties.reporting.set().traceEnabled(traceEnabled);
         SHAFT.Properties.reporting.set().traceMode(traceMode);
         SHAFT.Properties.reporting.set().traceIncludeCodeContext(traceIncludeCodeContext);


### PR DESCRIPTION
## Summary
- Attach `shaft-diagnostics.zip` with sanitized `diagnostics.json` for failed and broken TestNG/JUnit test artifacts.
- Add reporting controls `shaft.diagnostics.enabled` and `shaft.diagnostics.maxArtifactMb`.
- Teach Doctor to read `diagnostics.json` from `shaft-diagnostics.zip` as sanitized SHAFT log evidence for Doctor/MCP handoff.
- Refresh Graphify structural assets.

## Docs
- Guide PR: https://github.com/ShaftHQ/shafthq.github.io/pull/624

## Validation
- Red first: `mvn -pl shaft-engine '-Dtest=com.shaft.tools.io.internal.FailureDiagnosticsReporterTest' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test` failed before implementation for missing reporter/properties.
- Red first: `mvn -pl shaft-doctor '-Dtest=com.shaft.doctor.DoctorAnalyzerTest#allureDiagnosticsZipAttachmentFeedsDoctorRules' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test` failed before implementation with `expected: <LOCATOR> but was: <UNKNOWN>`.
- `mvn -pl shaft-engine '-Dtest=com.shaft.tools.io.internal.FailureDiagnosticsReporterTest' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test`
- `mvn -pl shaft-doctor '-Dtest=com.shaft.doctor.DoctorAnalyzerTest#allureDiagnosticsZipAttachmentFeedsDoctorRules' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test`
- `mvn -pl shaft-mcp '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test-compile`
- `mvn -pl shaft-engine,shaft-doctor,shaft-mcp '-DskipTests' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' package`
- `graphify update .`

## Graphify
- Structural refresh completed.
- Semantic docs refresh for the guide PR is blocked because `GEMINI_API_KEY`/`GOOGLE_API_KEY` is not configured and this session cannot spawn Graphify subagents without explicit delegation.

Closes #3063.
