### PR TITLE
[codex] Add Playwright parity pack

### DIFF
--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -783,11 +783,9 @@
   "781": "Community 781",
   "782": "Community 782",
   "783": "Community 783",
-  "784": "Community 784",
   "785": "Community 785",
   "786": "Community 786",
   "787": "Community 787",
-  "788": "Community 788",
   "789": "Community 789",
   "790": "Community 790",
   "791": "Community 791",
@@ -796,14 +794,11 @@
   "794": "Community 794",
   "796": "Community 796",
   "797": "Community 797",
-  "799": "Community 799",
   "800": "Community 800",
   "801": "Community 801",
-  "802": "Community 802",
   "804": "Community 804",
   "805": "Community 805",
   "809": "Community 809",
   "810": "Community 810",
-  "812": "Community 812",
-  "815": "Community 815"
+  "812": "Community 812"
 }

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - SHAFT_ENGINE  (2026-06-25)
 
 ## Corpus Check
-- 1046 files · ~587,985 words
+- 1092 files · ~598,998 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 14840 nodes · 38727 edges · 807 communities (711 shown, 96 thin omitted)
-- Extraction: 81% EXTRACTED · 19% INFERRED · 0% AMBIGUOUS · INFERRED: 7478 edges (avg confidence: 0.8)
+- 15066 nodes · 39601 edges · 802 communities (717 shown, 85 thin omitted)
+- Extraction: 81% EXTRACTED · 19% INFERRED · 0% AMBIGUOUS · INFERRED: 7705 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `d2508403`
+- Built from commit: `39adf160`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -554,6 +554,7 @@
 - [[_COMMUNITY_Community 536|Community 536]]
 - [[_COMMUNITY_Community 537|Community 537]]
 - [[_COMMUNITY_Community 538|Community 538]]
+- [[_COMMUNITY_Community 539|Community 539]]
 - [[_COMMUNITY_Community 540|Community 540]]
 - [[_COMMUNITY_Community 541|Community 541]]
 - [[_COMMUNITY_Community 542|Community 542]]
@@ -668,6 +669,7 @@
 - [[_COMMUNITY_Community 657|Community 657]]
 - [[_COMMUNITY_Community 658|Community 658]]
 - [[_COMMUNITY_Community 676|Community 676]]
+- [[_COMMUNITY_Community 753|Community 753]]
 - [[_COMMUNITY_Community 758|Community 758]]
 - [[_COMMUNITY_Community 759|Community 759]]
 - [[_COMMUNITY_Community 760|Community 760]]
@@ -681,34 +683,28 @@
 - [[_COMMUNITY_Community 771|Community 771]]
 - [[_COMMUNITY_Community 772|Community 772]]
 - [[_COMMUNITY_Community 773|Community 773]]
-- [[_COMMUNITY_Community 775|Community 775]]
 - [[_COMMUNITY_Community 777|Community 777]]
 - [[_COMMUNITY_Community 780|Community 780]]
 - [[_COMMUNITY_Community 781|Community 781]]
 - [[_COMMUNITY_Community 782|Community 782]]
-- [[_COMMUNITY_Community 784|Community 784]]
 - [[_COMMUNITY_Community 785|Community 785]]
 - [[_COMMUNITY_Community 786|Community 786]]
 - [[_COMMUNITY_Community 787|Community 787]]
-- [[_COMMUNITY_Community 788|Community 788]]
 - [[_COMMUNITY_Community 789|Community 789]]
-- [[_COMMUNITY_Community 799|Community 799]]
 - [[_COMMUNITY_Community 800|Community 800]]
 - [[_COMMUNITY_Community 801|Community 801]]
-- [[_COMMUNITY_Community 802|Community 802]]
 - [[_COMMUNITY_Community 804|Community 804]]
 - [[_COMMUNITY_Community 805|Community 805]]
 - [[_COMMUNITY_Community 809|Community 809]]
 - [[_COMMUNITY_Community 810|Community 810]]
 - [[_COMMUNITY_Community 812|Community 812]]
-- [[_COMMUNITY_Community 815|Community 815]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `SHAFT` - 298 edges
+1. `SHAFT` - 303 edges
 2. `IOException` - 118 edges
 3. `RestActionsComprehensiveTests` - 99 edges
 4. `Test` - 98 edges
-5. `ArrayList` - 91 edges
+5. `ArrayList` - 92 edges
 6. `CaptureGenerator` - 77 edges
 7. `ReportManagerHelper` - 76 edges
 8. `Actions` - 64 edges
@@ -730,63 +726,63 @@
 ## Import Cycles
 - None detected.
 
-## Communities (807 total, 96 thin omitted)
+## Communities (802 total, 85 thin omitted)
 
 ### Community 0 - "Community 0"
 Cohesion: 0.04
-Nodes (7): RestActionsComprehensiveTests, GraphqlRequestTests, ComparisonType, InputStream, SuppressWarnings, BeforeMethod, Test
+Nodes (6): RestActionsComprehensiveTests, ComparisonType, InputStream, SuppressWarnings, BeforeMethod, Test
 
 ### Community 1 - "Community 1"
 Cohesion: 0.06
 Nodes (13): BrowserActionsContract, AccessibilityActions, BrowserAssertions, Cookie, HttpRequest, HttpResponse, List, NetworkInterceptionRequestBuilder (+5 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.09
-Nodes (19): NativeValidationsBuilder, AssertEqualsTests, VerifyEqualsTests, FileValidationsBuilder, Object, Override, RestValidationsBuilder, String (+11 more)
+Cohesion: 0.31
+Nodes (4): VerifyEqualsTests, AfterMethod, BeforeMethod, Test
 
 ### Community 3 - "Community 3"
 Cohesion: 0.12
-Nodes (15): LocatorAssertions, PageAssertions, LinkedHashMap, List, Locator, Object, Override, Pattern (+7 more)
+Nodes (16): LocatorAssertions, Outcome, PageAssertions, LinkedHashMap, List, Locator, Object, Override (+8 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.07
 Nodes (6): Pilot, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 5 - "Community 5"
-Cohesion: 0.06
-Nodes (29): FileUploadDownloadTest, getValue(), KeyboardKeys(), TouchActions, ImmutableMap, viewport(), By, DriverFactoryHelper (+21 more)
+Cohesion: 0.11
+Nodes (13): FileUploadDownloadTest, ElementActionsHelper, IOSDriver, Test, AfterMethod, AndroidDriver, BeforeMethod, RemoteWebDriver (+5 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.06
-Nodes (14): CSVFileManager, CSVFileManagerTest, List, Map, String, BeforeMethod, Test, AfterMethod (+6 more)
+Cohesion: 0.10
+Nodes (4): Object, String, Test, CSVFileManagerUnitTest
 
 ### Community 7 - "Community 7"
-Cohesion: 0.07
-Nodes (29): KeyboardKeys, LocatorOperation, MobileService, MobileServiceConfigurationTest, McpMobileAccessibilityTree, McpMobileContextSnapshot, McpMobileSessionResult, BrowserType (+21 more)
+Cohesion: 0.09
+Nodes (22): KeyboardKeys, MobileService, McpMobileAccessibilityTree, McpMobileContextSnapshot, McpMobileSessionResult, BrowserType, Class, LocatorOperation (+14 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.07
-Nodes (23): BrowserStackSdkHelper, BrowserStackSdkTests, List, Map, Object, String, AfterMethod, BeforeMethod (+15 more)
+Cohesion: 0.17
+Nodes (8): BrowserStackSdkTests, AfterMethod, BeforeMethod, Map, Object, String, SuppressWarnings, Test
 
 ### Community 9 - "Community 9"
 Cohesion: 0.14
 Nodes (8): LocatorHealthReporter, LocatorStats, LocatorStats, AssertionError, By, List, ObjectNode, String
 
 ### Community 10 - "Community 10"
-Cohesion: 0.06
+Cohesion: 0.07
 Nodes (8): Boolean, By, NumbersComparativeRelation, Object, String, Test, JavaHelper, JavaHelperUnitTest
 
 ### Community 11 - "Community 11"
 Cohesion: 0.09
-Nodes (72): CompletedProcess, activation_hint(), adoptium_os_arch(), application_data_root(), architecture(), await_probe_response(), choose_client(), command_path() (+64 more)
+Nodes (71): CompletedProcess, activation_hint(), adoptium_os_arch(), application_data_root(), architecture(), await_probe_response(), choose_client(), command_path() (+63 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.07
 Nodes (11): BrowserStack, SetProperty, DefaultValue, Key, SetProperty, String, AfterMethod, Object (+3 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.10
-Nodes (10): DataType, JSONFileManager, List, Map, Object, String, AfterMethod, BeforeClass (+2 more)
+Cohesion: 0.14
+Nodes (4): AfterMethod, BeforeClass, Test, JSONFileManagerUnitTest
 
 ### Community 14 - "Community 14"
 Cohesion: 0.09
@@ -798,11 +794,11 @@ Nodes (6): AfterMethod, Path, String, SuppressWarnings, Test, TerminalActionsUni
 
 ### Community 17 - "Community 17"
 Cohesion: 0.08
-Nodes (14): AsyncAppender, ReportManagerHelper, TestCaseStarted, ByteArrayOutputStream, CheckpointStatus, InputStream, Level, List (+6 more)
+Nodes (15): AsyncAppender, ReportManagerHelper, TestCaseStarted, Boolean, ByteArrayOutputStream, CheckpointStatus, InputStream, Level (+7 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.11
-Nodes (15): FileActions, Boolean, Collection, Exception, File, InputStream, String, SuppressWarnings (+7 more)
+Cohesion: 0.08
+Nodes (23): FileActions, FileActionsCoverageUnitTest, ReportHelper, JarEntry, Boolean, Collection, Exception, File (+15 more)
 
 ### Community 19 - "Community 19"
 Cohesion: 0.11
@@ -813,72 +809,72 @@ Cohesion: 0.10
 Nodes (17): StandaloneAssertions, StandaloneVerifications, WebDriverAssertions, WebDriverVerifications, WizardHelpers, By, DriverFactoryHelper, FileValidationsBuilder (+9 more)
 
 ### Community 21 - "Community 21"
-Cohesion: 0.13
-Nodes (14): WebDriverListener, InvocationTargetException, Navigation, Alert, By, Method, Object, String (+6 more)
+Cohesion: 0.14
+Nodes (13): WebDriverListener, Navigation, Alert, By, Method, Object, String, URL (+5 more)
 
 ### Community 22 - "Community 22"
-Cohesion: 0.20
-Nodes (12): AfterAllCallback, AfterTestExecutionCallback, BeforeAllCallback, BeforeEachCallback, LifecycleMethodExecutionExceptionHandler, JunitExtension, ExtensionContext, Method (+4 more)
+Cohesion: 0.05
+Nodes (30): AfterAllCallback, AfterTestExecutionCallback, BeforeAllCallback, BeforeEachCallback, ExecutableInvoker, RetryAnalyzer, SupportingEvidenceState, IRetryAnalyzer (+22 more)
 
 ### Community 23 - "Community 23"
-Cohesion: 0.11
-Nodes (13): ImageProcessingActionsCoverageUnitTest, List, AfterMethod, BeforeMethod, BufferedImage, Color, DataProvider, Map (+5 more)
+Cohesion: 0.09
+Nodes (18): ClassLoader, ImageProcessingActionsCoverageUnitTest, OpenCvBlockingClassLoader, List, AfterMethod, BeforeMethod, BufferedImage, Class (+10 more)
 
 ### Community 24 - "Community 24"
 Cohesion: 0.09
-Nodes (9): AllureManager, ArrayNode, Future, InputStream, List, ObjectNode, Path, Process (+1 more)
+Nodes (10): AllureManager, BooleanSupplier, ArrayNode, Future, InputStream, List, ObjectNode, Path (+2 more)
 
 ### Community 25 - "Community 25"
-Cohesion: 0.19
-Nodes (8): DoctorRepairPublicationRequest, ExistingPullRequest, DoctorRepairService, DoctorRepairRequest, Path, RepairProposal, RepairPublicationResult, String
+Cohesion: 0.05
+Nodes (48): AllureVerdict, DoctorRepairPublicationRequest, ExistingPullRequest, GuardedPatch, Operation, PatchManifestEntry, RecordingRunner, changedSince() (+40 more)
 
 ### Community 26 - "Community 26"
 Cohesion: 0.07
-Nodes (14): DriverFactoryHelperCoverageUnitTest, TestableDriverFactoryHelper, AfterMethod, AtomicInteger, CountDownLatch, DriverFactoryHelper, DriverType, Method (+6 more)
+Nodes (15): DriverFactoryHelperCoverageUnitTest, TestableDriverFactoryHelper, OptionsManager, AfterMethod, AtomicInteger, CountDownLatch, DriverFactoryHelper, DriverType (+7 more)
 
 ### Community 27 - "Community 27"
-Cohesion: 0.08
-Nodes (4): ValidationTests, AfterMethod, BeforeMethod, Test
+Cohesion: 0.06
+Nodes (8): TextDirectionValidationsBuilder, ValidationTests, NativeValidationsBuilder, ValidationsExecutor, AfterMethod, BeforeMethod, Test, TextDirection
 
 ### Community 28 - "Community 28"
-Cohesion: 0.10
-Nodes (8): AsyncElementActionsCoverageUnitTest, BeforeMethod, Test, AfterMethod, Path, String, Test, ThreadLocalPropertiesTest
+Cohesion: 0.08
+Nodes (8): ThreadLocalPropertiesManager, Properties, String, AfterMethod, Path, String, Test, ThreadLocalPropertiesTest
 
 ### Community 29 - "Community 29"
-Cohesion: 0.14
-Nodes (14): AccessibilityConfig, AccessibilityHelper, AxeBuilder, AccessibilityResult, Integer, JSONArray, JSONObject, List (+6 more)
+Cohesion: 0.10
+Nodes (18): AccessibilityConfig, AccessibilityHelper, AccessibilityResult, AxeBuilder, AccessibilityResult, Integer, JSONArray, JSONObject (+10 more)
 
 ### Community 30 - "Community 30"
-Cohesion: 0.26
-Nodes (5): AfterClass, BeforeClass, List, Map, String
+Cohesion: 0.12
+Nodes (10): BasicAPITests, Map, Object, ParametersType, AfterClass, BeforeClass, List, Map (+2 more)
 
 ### Community 31 - "Community 31"
 Cohesion: 0.10
 Nodes (16): ChannelSftp, TerminalActions, ProcessBuilder, SftpTransferDirection, Boolean, BufferedReader, Deprecated, Exception (+8 more)
 
 ### Community 32 - "Community 32"
-Cohesion: 0.10
-Nodes (7): AfterMethod, Class, Object, Path, String, Test, AllureManagerUnitTest
+Cohesion: 0.09
+Nodes (11): EngineServiceRuntimePathTest, Override, Class, Object, Path, String, Test, AfterEach (+3 more)
 
 ### Community 33 - "Community 33"
-Cohesion: 0.05
-Nodes (28): ApiPerformanceReportTest, PathParamTest, SwaggerContractTest, TestUpload, BasicAPITests, ContentType, Map, Object (+20 more)
+Cohesion: 0.07
+Nodes (16): ApiPerformanceReportTest, SwaggerContractTest, TestUpload, AfterMethod, AfterSuite, BeforeMethod, Test, AfterClass (+8 more)
 
 ### Community 34 - "Community 34"
-Cohesion: 0.14
-Nodes (15): DeterministicNaturalActionPlanner, unsupported(), NaturalActionPlannerRegistry, List, NaturalActionPlan, NaturalActionRequest, Override, String (+7 more)
+Cohesion: 0.08
+Nodes (27): DeterministicNaturalActionPlanner, unsupported(), NaturalActionPlannerRegistry, PilotNaturalActionPlanner, NaturalActionKind, NaturalActionPlanner, NaturalActionStep, List (+19 more)
 
 ### Community 35 - "Community 35"
-Cohesion: 0.07
-Nodes (28): Constructor, IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, IResultListener2 (+20 more)
+Cohesion: 0.06
+Nodes (28): IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, IResultListener2, ISuiteListener (+20 more)
 
 ### Community 36 - "Community 36"
 Cohesion: 0.07
-Nodes (27): DataTableArgument, EmbedEvent, HookTestStep, CucumberFeatureListener, PickleStepTestStep, Result, Scenario, AllureLifecycle (+19 more)
+Nodes (28): DataTableArgument, EmbedEvent, HookTestStep, CucumberFeatureListener, Parameter, PickleStepTestStep, Result, Scenario (+20 more)
 
 ### Community 37 - "Community 37"
-Cohesion: 0.09
-Nodes (16): ApiPerformanceExecutionReport, Paths, SetProperty, PathsTests, DefaultValue, Key, SetProperty, String (+8 more)
+Cohesion: 0.17
+Nodes (6): Paths, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 38 - "Community 38"
 Cohesion: 0.10
@@ -889,44 +885,44 @@ Cohesion: 0.09
 Nodes (11): AfterMethod, BeforeMethod, Class, List, Object, Path, String, T (+3 more)
 
 ### Community 40 - "Community 40"
-Cohesion: 0.12
-Nodes (10): API, BrowserActions, Cookie, List, NetworkInterceptionRequestBuilder, Override, Set, String (+2 more)
+Cohesion: 0.07
+Nodes (21): AccessibilityActions, API, BrowserActions, BrowserNetworkInterceptionRule, Cookie, DriverFactoryHelper, HttpRequest, HttpResponse (+13 more)
 
 ### Community 41 - "Community 41"
 Cohesion: 0.16
 Nodes (16): CollectionState, EvidenceCollector, CollectionState, DoctorRedactor, DefaultPrettyPrinter, DoctorAnalysisRequest, EvidenceBundle, EvidenceCategory (+8 more)
 
 ### Community 42 - "Community 42"
-Cohesion: 0.10
-Nodes (15): ElementLookup, GetElementInformation, Actions, ClipboardAction, GetElementInformation, Beta, By, ClipboardAction (+7 more)
+Cohesion: 0.06
+Nodes (38): ActionReportContext, ElementLookup, GetElementInformation, abbreviate(), Actions, ClipboardAction, empty(), from() (+30 more)
 
 ### Community 43 - "Community 43"
-Cohesion: 0.07
-Nodes (9): TextDirectionValidationsBuilder, E2ECoverageTests, NativeValidationsBuilder, ValidationsExecutor, AfterMethod, BeforeMethod, Test, TextDirection (+1 more)
+Cohesion: 0.08
+Nodes (5): E2ECoverageTests, AfterMethod, BeforeMethod, Test, TextLanguageValidationsBuilder
 
 ### Community 44 - "Community 44"
-Cohesion: 0.08
+Cohesion: 0.07
 Nodes (7): LambdaTest, SetProperty, Boolean, DefaultValue, Key, SetProperty, String
 
 ### Community 45 - "Community 45"
-Cohesion: 0.10
-Nodes (20): ActionsCoverageUnitTest, RecordingActions, Parameter, RecordingActions, ActionType, AfterMethod, AllureLifecycle, BeforeMethod (+12 more)
+Cohesion: 0.11
+Nodes (19): ActionsCoverageUnitTest, RecordingActions, RecordingActions, ActionType, AfterMethod, AllureLifecycle, BeforeMethod, By (+11 more)
 
 ### Community 46 - "Community 46"
 Cohesion: 0.21
 Nodes (7): AssertionSteps, PDFTests, String, Then, ThreadLocal, WebDriver, String
 
 ### Community 47 - "Community 47"
-Cohesion: 0.07
-Nodes (5): NewValidationHelperTests, ValidationsBuilderTests, AfterMethod, BeforeMethod, Test
+Cohesion: 0.08
+Nodes (4): NewValidationHelperTests, AfterMethod, BeforeMethod, Test
 
 ### Community 48 - "Community 48"
-Cohesion: 0.08
-Nodes (11): NumberValidationsBuilder, Number, Object, Override, RestValidationsBuilder, SuppressWarnings, ValidationsBuilder, ValidationsExecutor (+3 more)
+Cohesion: 0.07
+Nodes (13): NumberValidationsBuilder, ValidationsBuilderTests, Number, Object, Override, RestValidationsBuilder, SuppressWarnings, ValidationsBuilder (+5 more)
 
 ### Community 49 - "Community 49"
-Cohesion: 0.15
-Nodes (11): FailureTraceReporter, List, Path, SourceContext, StackTraceElement, String, StringBuilder, TestExecutionInfo (+3 more)
+Cohesion: 0.13
+Nodes (12): FailureTraceReporter, PlaywrightTraceManager, List, Path, SourceContext, StackTraceElement, String, StringBuilder (+4 more)
 
 ### Community 50 - "Community 50"
 Cohesion: 0.04
@@ -953,32 +949,32 @@ Cohesion: 0.15
 Nodes (15): ElementActionsHelper, TextDetectionStrategy(), AtomicInteger, Boolean, By, Class, ClipboardAction, HealingResolution (+7 more)
 
 ### Community 56 - "Community 56"
-Cohesion: 0.13
-Nodes (17): McpMobileInspectorRecordingService, Session, Duration, List, Map, McpCodeBlock, McpMobileDevice, McpMobileInspectorPlan (+9 more)
+Cohesion: 0.07
+Nodes (33): McpMobileInspectorRecordingService, Session, McpMobileInspectorRecordingServiceTest, NoopRunner, McpMobileToolchainService, McpProcessRunner, Duration, List (+25 more)
 
 ### Community 57 - "Community 57"
 Cohesion: 0.13
 Nodes (21): ExchangeHandler, FailureCase, ExchangeHandler, ProviderConformanceTest, AfterEach, AiProvider, AiRequest, AiResponse (+13 more)
 
 ### Community 58 - "Community 58"
-Cohesion: 0.10
-Nodes (13): MockedResponseBuilder, NetworkInterceptionRequestBuilder, MockedResponseBuilder, BrowserActions, Consumer, HttpMethod, HttpRequest, HttpResponse (+5 more)
+Cohesion: 0.14
+Nodes (12): BiFunction, NetworkInterceptionRequestBuilder, MockedResponseBuilder, BrowserNetworkInterceptionRule, Consumer, HttpMethod, HttpRequest, Predicate (+4 more)
 
 ### Community 59 - "Community 59"
 Cohesion: 0.14
 Nodes (20): CaptureControlClient, CaptureCli, flag(), parse(), path(), pathRequired(), required(), value() (+12 more)
 
 ### Community 60 - "Community 60"
-Cohesion: 0.07
-Nodes (22): Document, GuideHttpClient, GuideIndex, GuideHttpClient, GuideService, JdkGuideHttpClient, McpGuideMatch, McpGuideSearchResult (+14 more)
+Cohesion: 0.12
+Nodes (19): Document, GuideHttpClient, GuideIndex, GuideHttpClient, GuideService, JdkGuideHttpClient, McpGuideMatch, McpGuideSearchResult (+11 more)
 
 ### Community 61 - "Community 61"
 Cohesion: 0.12
-Nodes (14): AllureListenerCoverageUnitTest, Throwable, AfterMethod, BeforeMethod, ITestResult, List, Path, String (+6 more)
+Nodes (16): AllureListenerCoverageUnitTest, Throwable, Status, AfterMethod, BeforeMethod, ITestResult, List, Path (+8 more)
 
 ### Community 62 - "Community 62"
 Cohesion: 0.14
-Nodes (21): McpDoctorRemediationService, McpActionRecord, ProviderBlocks, AiRequest, AiResponse, ApprovalPolicy, CodegenBackend, Diagnosis (+13 more)
+Nodes (22): McpDoctorRemediationService, McpActionRecord, ProviderBlocks, AiRequest, AiResponse, ApprovalPolicy, CodegenBackend, Diagnosis (+14 more)
 
 ### Community 63 - "Community 63"
 Cohesion: 0.15
@@ -989,8 +985,8 @@ Cohesion: 0.11
 Nodes (11): COSDocument, DeleteFileAfterValidationStatus, PdfFileManager, PDFParser, RandomAccessReadBufferedFile, File, String, AfterMethod (+3 more)
 
 ### Community 65 - "Community 65"
-Cohesion: 0.08
-Nodes (11): Locator, LocatorMockedTests, ShadowLocatorBuilder, Beta, By, LocatorBuilder, String, Test (+3 more)
+Cohesion: 0.10
+Nodes (6): LocatorMockedTests, ShadowLocatorBuilder, Test, Test, LocatorBuilderUnitTest, XpathAxis
 
 ### Community 66 - "Community 66"
 Cohesion: 0.05
@@ -1006,19 +1002,19 @@ Nodes (42): additionalProperties, default, description, examples, $id, title, ty
 
 ### Community 69 - "Community 69"
 Cohesion: 0.10
-Nodes (12): DriverFactoryHelper, OptionsManager, AfterMethod, AtomicInteger, CountDownLatch, DriverType, Method, MutableCapabilities (+4 more)
+Nodes (11): DriverFactoryHelper, AfterMethod, AtomicInteger, CountDownLatch, DriverType, Method, MutableCapabilities, Override (+3 more)
 
 ### Community 70 - "Community 70"
 Cohesion: 0.11
 Nodes (41): expand_globs(), issue(), local_link_targets(), markdown_body(), normalized_paragraphs(), parse_frontmatter(), quoted_yaml_value(), Keep the consolidated guidance below the approved baseline reduction. (+33 more)
 
 ### Community 71 - "Community 71"
-Cohesion: 0.17
-Nodes (13): ShaftHealingProviderTest, Outcome, AfterMethod, AppiumDriver, BeforeMethod, DataProvider, HealingPlatform, List (+5 more)
+Cohesion: 0.09
+Nodes (21): ShaftHeal, ShaftHealingProviderTest, WebDomHealingAcceptanceTest, HealingReport, Optional, AfterMethod, AppiumDriver, BeforeMethod (+13 more)
 
 ### Community 72 - "Community 72"
-Cohesion: 0.20
-Nodes (12): DoctorAnalyzerTest, Arguments, CauseCategory, DoctorAnalysisRequest, DoctorAnalysisResult, List, MethodSource, ParameterizedTest (+4 more)
+Cohesion: 0.09
+Nodes (29): DoctorAnalyzerTest, empty(), McpAppiumCommandRecorderTest, reviewUiPath(), disabled(), PlaywrightServiceTest, PrintWriter, defaults() (+21 more)
 
 ### Community 73 - "Community 73"
 Cohesion: 0.11
@@ -1026,15 +1022,15 @@ Nodes (19): denyAll(), CaptureFixtures, defaults(), CaptureGeneratorTest, PageCo
 
 ### Community 74 - "Community 74"
 Cohesion: 0.11
-Nodes (14): CaptureEventPipeline, ManagedCaptureRecorder, BrowserMetadata, BrowserSignal, CapturePrivacyPolicy, CaptureSessionStore, CaptureStartRequest, CaptureStatus (+6 more)
+Nodes (15): CaptureEventPipeline, CapturePrivacyClassifier, ManagedCaptureRecorder, BrowserMetadata, BrowserSignal, CapturePrivacyPolicy, CaptureSessionStore, CaptureStartRequest (+7 more)
 
 ### Community 75 - "Community 75"
-Cohesion: 0.19
-Nodes (8): Actions, By, ElementActions, List, Map, Override, String, SuppressWarnings
+Cohesion: 0.15
+Nodes (11): Actions, By, DriverFactoryHelper, ElementActions, List, Map, Override, String (+3 more)
 
 ### Community 76 - "Community 76"
-Cohesion: 0.08
-Nodes (26): Session1Test, LocatorOperation, PlaywrightService, AfterMethod, BeforeMethod, String, Test, By (+18 more)
+Cohesion: 0.10
+Nodes (21): LocatorOperation, PlaywrightService, By, List, Locator, LocatorOperation, locatorStrategy, Map (+13 more)
 
 ### Community 77 - "Community 77"
 Cohesion: 0.12
@@ -1045,12 +1041,12 @@ Cohesion: 0.05
 Nodes (40): additionalProperties, enum, pattern, type, pattern, type, items, type (+32 more)
 
 ### Community 79 - "Community 79"
-Cohesion: 0.15
-Nodes (11): CaptureControlFiles, CaptureControlFilesTest, ControlDescriptor, CaptureStartRequest, CaptureStatus, Class, Object, Path (+3 more)
+Cohesion: 0.18
+Nodes (9): CaptureControlFiles, ControlDescriptor, CaptureStartRequest, CaptureStatus, Class, Object, Path, String (+1 more)
 
 ### Community 80 - "Community 80"
-Cohesion: 0.23
-Nodes (7): ElementService, Deprecated, LocatorOperation, locatorStrategy, String, Tool, locatorStrategy
+Cohesion: 0.19
+Nodes (9): ElementService, LocatorOperation, By, Deprecated, LocatorOperation, locatorStrategy, String, Tool (+1 more)
 
 ### Community 81 - "Community 81"
 Cohesion: 0.18
@@ -1061,16 +1057,16 @@ Cohesion: 0.05
 Nodes (39): additionalProperties, type, maximum, minimum, type, additionalProperties, properties, required (+31 more)
 
 ### Community 84 - "Community 84"
-Cohesion: 0.09
-Nodes (21): option(), ProviderConfiguration(), ProviderConfigurationTest, FirestoreRestClient, Properties, CaptureStartRequest(), validateUrl(), CaptureBrowser (+13 more)
+Cohesion: 0.08
+Nodes (21): option(), ProviderConfiguration(), ProviderConfigurationTest, AiCandidateRerankerTest, FirestoreRestClient, CaptureStartRequest(), validateUrl(), CaptureBrowser (+13 more)
 
 ### Community 85 - "Community 85"
-Cohesion: 0.13
-Nodes (15): CapturePrivacyClassifier, ClassifiedUpload, CapturePrivacyClassifier, CapturePrivacyClassifierTest, SanitizedAttributes, SanitizedText, CapturePrivacyPolicy, ClassifiedValue (+7 more)
+Cohesion: 0.14
+Nodes (14): ClassifiedUpload, CapturePrivacyClassifier, CapturePrivacyClassifierTest, SanitizedAttributes, SanitizedText, CapturePrivacyPolicy, ClassifiedValue, List (+6 more)
 
 ### Community 86 - "Community 86"
-Cohesion: 0.19
-Nodes (8): EngineService, PostConstruct, BrowserType, By, Path, String, Tool, WebDriver
+Cohesion: 0.13
+Nodes (11): EngineService, MobileServiceConfigurationTest, PostConstruct, BrowserType, By, Path, String, Tool (+3 more)
 
 ### Community 87 - "Community 87"
 Cohesion: 0.15
@@ -1078,7 +1074,7 @@ Nodes (13): ArtifactReference, FailureDiagnosticsReporter, Redactor, Redactor, L
 
 ### Community 88 - "Community 88"
 Cohesion: 0.10
-Nodes (9): AfterMethod, BeforeMethod, Issue, Issues, ITestResult, String, Test, TmsLinks (+1 more)
+Nodes (10): AfterMethod, BeforeMethod, Issue, Issues, ITestResult, String, Test, TmsLink (+2 more)
 
 ### Community 89 - "Community 89"
 Cohesion: 0.10
@@ -1089,12 +1085,12 @@ Cohesion: 0.11
 Nodes (29): append(), checkpoint(), complete(), ensureIncomplete(), interrupt(), sortedCheckpoints(), sortedEvents(), sortedReferences() (+21 more)
 
 ### Community 91 - "Community 91"
-Cohesion: 0.10
-Nodes (3): AfterMethod, Test, NativeValidationsBuilderUnitTest
+Cohesion: 0.06
+Nodes (15): NativeValidationsBuilder, FileValidationsBuilder, Object, Override, RestValidationsBuilder, String, SuppressWarnings, ValidationsBuilder (+7 more)
 
 ### Community 92 - "Community 92"
-Cohesion: 0.09
-Nodes (49): child_text(), dependency_coordinate(), dependency_template(), direct_child(), elements_named(), ensure_android_json_exclusion(), ensure_dependency(), ensure_generator_dependency_set() (+41 more)
+Cohesion: 0.08
+Nodes (55): child_text(), copy_dependency_metadata(), create_dependency(), create_external_dependency(), dependency_coordinate(), dependency_template(), direct_child(), elements_named() (+47 more)
 
 ### Community 93 - "Community 93"
 Cohesion: 0.07
@@ -1105,24 +1101,24 @@ Cohesion: 0.05
 Nodes (37): type, additionalProperties, minLength, type, items, type, type, required (+29 more)
 
 ### Community 95 - "Community 95"
-Cohesion: 0.09
-Nodes (19): builder(), evidenceCategories(), withSanitizedContent(), withTimeout(), AiValueObjectsTest, AiAuditSink, ShaftAiAuditSink, AiRequest (+11 more)
+Cohesion: 0.11
+Nodes (17): builder(), evidenceCategories(), withSanitizedContent(), withTimeout(), AiAuditSink, ShaftAiAuditSink, AiRequest, ApprovalPolicy (+9 more)
 
 ### Community 96 - "Community 96"
-Cohesion: 0.09
-Nodes (18): DriverFactory, DriverType(), DatabaseActions, DatabaseType, Deprecated, DriverFactoryHelper, DriverType, MutableCapabilities (+10 more)
+Cohesion: 0.06
+Nodes (28): DriverFactory, DriverType(), LambdaTestHelper, DatabaseActions, DatabaseType, Deprecated, DriverFactoryHelper, DriverType (+20 more)
 
 ### Community 97 - "Community 97"
 Cohesion: 0.07
 Nodes (14): be(), Bt(), Dt(), $e(), Ee(), ft(), ke(), l() (+6 more)
 
 ### Community 98 - "Community 98"
-Cohesion: 0.14
-Nodes (14): ExecutionCountsTracker, LauncherSessionListener, JunitListener, String, TestExecutionInfo, Counts, Method, Status (+6 more)
+Cohesion: 0.23
+Nodes (10): LauncherSessionListener, JunitListener, Method, Status, StatusIcon, String, TestExecutionInfo, TestIdentifier (+2 more)
 
 ### Community 99 - "Community 99"
-Cohesion: 0.28
-Nodes (7): LambdaTestHelper, Boolean, DriverFactoryHelper, HashMap, MutableCapabilities, Object, String
+Cohesion: 0.15
+Nodes (15): appendJson(), BrowserPerformanceExecutionReport, budgetStatus(), budgetViolationMessage(), from(), percentile(), toHtmlRow(), MetricStats (+7 more)
 
 ### Community 100 - "Community 100"
 Cohesion: 0.13
@@ -1141,8 +1137,8 @@ Cohesion: 0.18
 Nodes (11): AlertActionsContext, AfterMethod, Alert, AlertActions, BeforeMethod, Object, String, Test (+3 more)
 
 ### Community 104 - "Community 104"
-Cohesion: 0.21
-Nodes (6): Dimension, BrowserActionsHelper, Boolean, SneakyThrows, String, WebDriver
+Cohesion: 0.14
+Nodes (10): Dimension, BrowserActionsHelper, Boolean, SneakyThrows, String, WebDriver, AfterMethod, BeforeMethod (+2 more)
 
 ### Community 105 - "Community 105"
 Cohesion: 0.12
@@ -1161,8 +1157,8 @@ Cohesion: 0.13
 Nodes (5): YAMLFileManagerTests, BeforeMethod, Date, String, Test
 
 ### Community 109 - "Community 109"
-Cohesion: 0.16
-Nodes (6): AfterTest, BeforeTest, ConfigurationHelper, ReportHelper, ITestContext, Step
+Cohesion: 0.31
+Nodes (5): AfterTest, BeforeTest, ConfigurationHelper, ITestContext, Step
 
 ### Community 110 - "Community 110"
 Cohesion: 0.16
@@ -1173,44 +1169,44 @@ Cohesion: 0.17
 Nodes (17): DeterministicRuleEngine, Confidence, Finding, Remediation, RetrySummary, RuleMatch, CauseCategory, Diagnosis (+9 more)
 
 ### Community 112 - "Community 112"
-Cohesion: 0.12
-Nodes (9): API, JSON, YAML, Cookie, List, Map, Object, RequestBuilder (+1 more)
+Cohesion: 0.13
+Nodes (10): API, YAML, BrowserActionsContract, Cookie, List, Map, Object, RequestBuilder (+2 more)
 
 ### Community 113 - "Community 113"
 Cohesion: 0.15
 Nodes (6): Platform, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 114 - "Community 114"
-Cohesion: 0.11
-Nodes (11): IIOMetadataNode, AnimatedGifManager, GifSession, ImageOutputStream, ImageWriter, getType(), RenderedImage, Screenshots (+3 more)
+Cohesion: 0.12
+Nodes (10): IIOMetadataNode, AnimatedGifManager, ImageOutputStream, ImageWriter, getType(), RenderedImage, Screenshots, BufferedImage (+2 more)
 
 ### Community 115 - "Community 115"
 Cohesion: 0.06
 Nodes (34): enum, type, items, type, items, type, $id, required (+26 more)
 
 ### Community 116 - "Community 116"
-Cohesion: 0.11
-Nodes (21): ActionReportContext, abbreviate(), empty(), from(), hasElementName(), hasLocator(), hasStepTarget(), hasStepValue() (+13 more)
+Cohesion: 0.10
+Nodes (20): getValue(), KeyboardKeys(), TouchActions, ImmutableMap, viewport(), ScreenOrientation, By, DriverFactoryHelper (+12 more)
 
 ### Community 117 - "Community 117"
 Cohesion: 0.15
 Nodes (21): AllureFile, changedSince(), HealerService, ProcessExecutor, successful(), McpHealerAttemptResult, McpHealerRunResult, ProcessExecutor (+13 more)
 
 ### Community 118 - "Community 118"
-Cohesion: 0.18
-Nodes (15): CandidateExtractor, LocatorProposal, SearchContext, By, Collection, HealingConfiguration, HealingPlatform, List (+7 more)
+Cohesion: 0.17
+Nodes (16): CandidateExtractor, LocatorProposal, nativePlatform(), SearchContext, By, Collection, HealingConfiguration, HealingPlatform (+8 more)
 
 ### Community 119 - "Community 119"
 Cohesion: 0.08
 Nodes (17): Async, Driver, Playwright, WebDriver, PlaywrightDriverAssertions, PlaywrightDriverVerifications, Actions, AlertActions (+9 more)
 
 ### Community 120 - "Community 120"
-Cohesion: 0.18
+Cohesion: 0.20
 Nodes (12): YAMLFileManager, Boolean, Class, Date, Double, Integer, List, Long (+4 more)
 
 ### Community 121 - "Community 121"
 Cohesion: 0.13
-Nodes (10): PlaywrightBrowserValidationsBuilder, BrowserContext, Cookie, HttpRequest, HttpResponse, Locator, PlaywrightSession, Predicate (+2 more)
+Nodes (11): PlaywrightBrowserValidationsBuilder, BrowserContext, BrowserNetworkInterceptionRule, Cookie, HttpRequest, HttpResponse, Locator, PlaywrightSession (+3 more)
 
 ### Community 122 - "Community 122"
 Cohesion: 0.12
@@ -1221,12 +1217,12 @@ Cohesion: 0.10
 Nodes (4): AfterMethod, BeforeClass, Test, YAMLFileManagerUnitTest
 
 ### Community 124 - "Community 124"
-Cohesion: 0.11
-Nodes (25): AiTrigger, HealingProvider, ShaftHealingProvider, safe(), stableKey(), HealingActionOutcome, HealingCandidate, HealingConfiguration (+17 more)
+Cohesion: 0.12
+Nodes (22): AiTrigger, HealingProvider, ShaftHealingProvider, HealingActionOutcome, HealingCandidate, HealingConfiguration, HealingContext, HealingDecision (+14 more)
 
 ### Community 125 - "Community 125"
-Cohesion: 0.11
-Nodes (19): skipped(), LauncherSession, String, Validation, Counts, Override, AfterMethod, BeforeMethod (+11 more)
+Cohesion: 0.15
+Nodes (15): LauncherSession, Override, AfterMethod, BeforeMethod, Duration, List, Object, Optional (+7 more)
 
 ### Community 126 - "Community 126"
 Cohesion: 0.18
@@ -1241,16 +1237,16 @@ Cohesion: 0.18
 Nodes (14): AiExecutionService, CircuitState, AiAuditSink, AiProvider, AiProviderRegistry, AiRequest, AiResponse, AiResponseStatus (+6 more)
 
 ### Community 129 - "Community 129"
-Cohesion: 0.26
-Nodes (4): Healing, DefaultValue, Key, SetProperty
+Cohesion: 0.13
+Nodes (6): Healing, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 130 - "Community 130"
-Cohesion: 0.08
-Nodes (26): Config, EngineProperties, SetProperty, JiraHelper, Class, IInvokedMethod, ITestNGMethod, ITestResult (+18 more)
+Cohesion: 0.17
+Nodes (12): Config, List, String, SuppressWarnings, AfterMethod, BeforeMethod, HttpExchange, Object (+4 more)
 
 ### Community 131 - "Community 131"
 Cohesion: 0.09
-Nodes (27): DoctorRepairProposalResult, CaptureFormatException, HealingLocatorProposalRequest, DoctorService, McpWorkspacePolicy, McpDoctorRemediationService, String, Throwable (+19 more)
+Nodes (25): DoctorRepairProposalResult, HealingLocatorProposalRequest, DoctorService, McpResultRecordsTest, McpWorkspacePolicy, McpDoctorRemediationService, ApprovalPolicy, Diagnosis (+17 more)
 
 ### Community 132 - "Community 132"
 Cohesion: 0.15
@@ -1261,12 +1257,12 @@ Cohesion: 0.15
 Nodes (10): PackageActivity, BufferedReader, File, Optional, String, Path, String, Test (+2 more)
 
 ### Community 134 - "Community 134"
-Cohesion: 0.06
-Nodes (16): Jira, SetProperty, Mobile, SetProperty, PropertiesManagerTests, JiraTests, DefaultValue, Key (+8 more)
+Cohesion: 0.12
+Nodes (9): Jira, SetProperty, JiraTests, DefaultValue, Key, SetProperty, String, BeforeClass (+1 more)
 
 ### Community 135 - "Community 135"
-Cohesion: 0.09
-Nodes (19): NativeValidationsBuilder, Locator, Object, Override, PlaywrightSession, PlaywrightValidationsExecutor, String, StringBuilder (+11 more)
+Cohesion: 0.10
+Nodes (18): Locator, Object, Override, PlaywrightSession, PlaywrightValidationsExecutor, String, StringBuilder, ValidationCategory (+10 more)
 
 ### Community 136 - "Community 136"
 Cohesion: 0.16
@@ -1274,7 +1270,7 @@ Nodes (27): ut(), _(), a(), b(), c(), d(), f(), g() (+19 more)
 
 ### Community 137 - "Community 137"
 Cohesion: 0.17
-Nodes (16): RecordingRunner, DoctorRepairServiceTest, RecordingRunner, validationPassed(), RepairProcessRunner, RepositoryFixture, DoctorRepairRequest, Duration (+8 more)
+Nodes (16): EndpointStats, ApiPerformanceExecutionReport, appendJson(), budgetStatus(), budgetViolationMessage(), from(), percentile(), toHtmlRow() (+8 more)
 
 ### Community 138 - "Community 138"
 Cohesion: 0.16
@@ -1309,32 +1305,36 @@ Cohesion: 0.14
 Nodes (8): DatabaseActionsMockedTests, AfterMethod, BeforeMethod, DatabaseActions, Object, ResultSet, String, Test
 
 ### Community 146 - "Community 146"
-Cohesion: 0.15
-Nodes (16): CaptureCodegenStartRequest, CaptureCodegenStartRequest, CaptureService, McpCaptureCodeBlockService, McpCaptureReplayResult, PreDestroy, CaptureGenerationResult, CaptureManager (+8 more)
+Cohesion: 0.12
+Nodes (19): CaptureCodegenStartRequest, reviewPath(), reviewUiPath(), CaptureCodegenStartRequest, CaptureService, McpCaptureCodeBlockService, McpCaptureReplayResult, PreDestroy (+11 more)
 
 ### Community 147 - "Community 147"
-Cohesion: 0.13
-Nodes (14): BrowserEventScript, CaptureCollectorUtilityTest, close(), start(), List, String, BrowserSignal, Class (+6 more)
+Cohesion: 0.19
+Nodes (11): CaptureCollectorUtilityTest, close(), start(), BrowserSignal, Class, Consumer, Object, Override (+3 more)
 
 ### Community 148 - "Community 148"
 Cohesion: 0.14
-Nodes (18): DeterministicRuleEngine, DoctorAnalyzer, DoctorReportWriter, DoctorTriage, EvidenceCollector, ExecutionIntelligence, Diagnosis, DoctorAiAnalysisRequest (+10 more)
+Nodes (19): DeterministicRuleEngine, DoctorAnalyzer, DoctorAiAnalysisResult, DoctorReportWriter, DoctorTriage, EvidenceCollector, ExecutionIntelligence, Diagnosis (+11 more)
 
 ### Community 149 - "Community 149"
-Cohesion: 0.18
-Nodes (4): Flags, DefaultValue, Key, SetProperty
+Cohesion: 0.08
+Nodes (6): Flags, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 150 - "Community 150"
-Cohesion: 0.18
-Nodes (22): DoctorCli, flag(), optionalPath(), parse(), path(), pathRequired(), paths(), pathsRequired() (+14 more)
+Cohesion: 0.19
+Nodes (20): DoctorCli, flag(), optionalPath(), parse(), path(), pathRequired(), paths(), pathsRequired() (+12 more)
 
 ### Community 151 - "Community 151"
-Cohesion: 0.11
-Nodes (12): Color, Rectangle, AfterMethod, BeforeMethod, Color, Map, Method, Path (+4 more)
+Cohesion: 0.07
+Nodes (24): ImageProcessingActions, Boolean, By, Color, File, Integer, List, Rectangle (+16 more)
 
 ### Community 152 - "Community 152"
-Cohesion: 0.20
+Cohesion: 0.19
 Nodes (11): LocatorRef, McpAppiumCommandRecorder, PointerGesture, BooleanSupplier, JsonNode, locatorStrategy, Map, McpMobileRecordedAction (+3 more)
+
+### Community 153 - "Community 153"
+Cohesion: 0.12
+Nodes (16): APIResponse, FulfillOptions, PlaywrightNetworkInterceptor, PlaywrightNetworkInterceptorTest, Request, BrowserContext, BrowserNetworkInterceptionRule, HttpMethod (+8 more)
 
 ### Community 154 - "Community 154"
 Cohesion: 0.16
@@ -1345,20 +1345,20 @@ Cohesion: 0.16
 Nodes (12): CapturingProvider, ImageProcessingActionsPlaywrightVisualTest, AfterMethod, Boolean, By, Integer, List, Override (+4 more)
 
 ### Community 156 - "Community 156"
-Cohesion: 0.18
-Nodes (12): ScreenshotManager, Object, Boolean, By, JavascriptExecutor, List, Object, Screenshots (+4 more)
+Cohesion: 0.11
+Nodes (17): ScreenshotManager, ScreenshotManagerCoverageUnitTest, Object, Boolean, By, JavascriptExecutor, List, Object (+9 more)
 
 ### Community 157 - "Community 157"
 Cohesion: 0.19
-Nodes (12): By, ElementActions, ElementAssertions, List, Locator, Map, Override, PlaywrightSession (+4 more)
+Nodes (13): By, ElementActions, ElementAssertions, List, Locator, Map, Override, PlaywrightSession (+5 more)
 
 ### Community 158 - "Community 158"
-Cohesion: 0.09
-Nodes (15): McpAppiumCommandRecorderTest, MobileRecordingServiceTest, Role, Override, AfterMethod, Test, Class, Object (+7 more)
+Cohesion: 0.11
+Nodes (8): JunitCoreAssertionMigrationTest, MobileRecordingServiceTest, Role, Test, AfterMethod, Test, Test, LocatorBuilderExtendedUnitTest
 
 ### Community 159 - "Community 159"
-Cohesion: 0.22
-Nodes (12): Boolean, ComparisonType, LinkedHashMap, List, Number, NumbersComparativeRelation, Object, Response (+4 more)
+Cohesion: 0.23
+Nodes (11): Boolean, ComparisonType, LinkedHashMap, List, Number, NumbersComparativeRelation, Object, Response (+3 more)
 
 ### Community 160 - "Community 160"
 Cohesion: 0.08
@@ -1373,36 +1373,36 @@ Cohesion: 0.16
 Nodes (5): AfterMethod, BeforeMethod, Test, WebDriver, BrowserActionsCoverageUnitTest
 
 ### Community 164 - "Community 164"
-Cohesion: 0.29
-Nodes (5): Connection, DatabaseActions, Boolean, ResultSet, StringBuilder
+Cohesion: 0.22
+Nodes (7): Connection, DatabaseActions, Boolean, DatabaseType, ResultSet, String, StringBuilder
 
 ### Community 165 - "Community 165"
-Cohesion: 0.13
-Nodes (12): ChromiumOptions, DesiredCapabilities, OptionsManager, OptionsManagerCoverageUnitTest, LoggingPreferences, DriverType, MutableCapabilities, String (+4 more)
+Cohesion: 0.11
+Nodes (15): ChromiumOptions, DesiredCapabilities, OptionsManager, OptionsManagerCoverageUnitTest, LoggingPreferences, PlatformTests, DriverType, MutableCapabilities (+7 more)
 
 ### Community 166 - "Community 166"
-Cohesion: 0.15
-Nodes (6): BrowserActions, List, Override, Page, String, WindowType
+Cohesion: 0.14
+Nodes (7): BrowserActions, List, Override, Page, Runnable, Screenshots, String
 
 ### Community 167 - "Community 167"
 Cohesion: 0.19
 Nodes (7): Log4j, Log4jTests, DefaultValue, Key, String, BeforeClass, Test
 
 ### Community 168 - "Community 168"
-Cohesion: 0.17
-Nodes (4): Reporting, DefaultValue, Key, SetProperty
+Cohesion: 0.08
+Nodes (6): Reporting, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 169 - "Community 169"
-Cohesion: 0.09
-Nodes (16): AttachmentFormat, AttachmentReporter, ByteArrayOutputStream, Path, String, SuppressWarnings, ByteArrayOutputStream, Severity (+8 more)
+Cohesion: 0.06
+Nodes (31): AttachmentFormat, CaptureJsonCodec, DoctorJsonCodec, InputStream, AttachmentReporter, CaptureSession, JsonNode, Path (+23 more)
 
 ### Community 170 - "Community 170"
-Cohesion: 0.16
-Nodes (9): BrowserService, String, Throwable, McpPageDomSnapshot, McpScreenshotResult, McpWorkspacePolicy, Path, String (+1 more)
+Cohesion: 0.11
+Nodes (12): BrowserService, EngineServiceTest, String, Throwable, McpPageDomSnapshot, McpScreenshotResult, McpWorkspacePolicy, Path (+4 more)
 
 ### Community 171 - "Community 171"
-Cohesion: 0.21
-Nodes (10): HealingSupport, nativePlatform(), By, HealingContext, HealingPlatform, RemoteWebDriver, String, Supplier (+2 more)
+Cohesion: 0.24
+Nodes (9): HealingSupport, By, HealingContext, HealingPlatform, RemoteWebDriver, String, Supplier, WebDriver (+1 more)
 
 ### Community 172 - "Community 172"
 Cohesion: 0.17
@@ -1410,19 +1410,19 @@ Nodes (9): ElementSteps, getValue(), LocatorType(), By, String, SuppressWarnings
 
 ### Community 173 - "Community 173"
 Cohesion: 0.19
-Nodes (6): Actions, SilentElementReader, ValidationsHelper, By, String, WebDriver
+Nodes (7): Actions, SilentElementReader, ValidationsHelper, By, String, ValidationComparisonType, WebDriver
 
 ### Community 174 - "Community 174"
-Cohesion: 0.16
-Nodes (9): ShaftRestAssuredFilter, FilterableRequestSpecification, FilterableResponseSpecification, FilterContext, JsonElement, Object, Override, Response (+1 more)
+Cohesion: 0.14
+Nodes (10): ShaftRestAssuredFilter, FilterableRequestSpecification, FilterableResponseSpecification, FilterContext, JsonElement, Object, Override, Response (+2 more)
 
 ### Community 175 - "Community 175"
 Cohesion: 0.10
-Nodes (12): PropertyFileManager, PropertyFileManagerInternalUnitTest, String, File, HashMap, Map, MutableCapabilities, Object (+4 more)
+Nodes (11): PropertyFileManager, PropertyFileManagerInternalUnitTest, HashMap, Map, Object, Properties, String, Test (+3 more)
 
 ### Community 176 - "Community 176"
-Cohesion: 0.18
-Nodes (5): AsyncElementActions, By, ClipboardAction, DriverFactoryHelper, String
+Cohesion: 0.12
+Nodes (7): AsyncElementActions, AsyncElementActionsCoverageUnitTest, By, ClipboardAction, DriverFactoryHelper, String, Test
 
 ### Community 177 - "Community 177"
 Cohesion: 0.09
@@ -1433,8 +1433,8 @@ Cohesion: 0.20
 Nodes (9): TestAutomationService, McpCodeGuardrailResult, McpCodeGuardrailViolation, McpScenarioCatalogResult, McpTestAutomationScenario, List, Pattern, String (+1 more)
 
 ### Community 179 - "Community 179"
-Cohesion: 0.12
-Nodes (23): DoctorAiAnalysisService, ConfigurationIdentity, AiRequest, AiResponse, AiResponseStatus, AiUsage, CauseCategory, Diagnosis (+15 more)
+Cohesion: 0.07
+Nodes (29): DoctorAiAnalysisService, ConfigurationIdentity, CoverageTests, AiRequest, AiResponse, AiResponseStatus, AiUsage, CauseCategory (+21 more)
 
 ### Community 180 - "Community 180"
 Cohesion: 0.17
@@ -1449,11 +1449,11 @@ Cohesion: 0.11
 Nodes (7): Playwright, PlaywrightSetProperty, PlaywrightSetProperty, DefaultValue, Key, Override, String
 
 ### Community 183 - "Community 183"
-Cohesion: 0.27
+Cohesion: 0.25
 Nodes (8): FingerprintExtractor, HealingConfiguration, LocatorFingerprint, Map, String, Supplier, WebDriver, WebElement
 
 ### Community 184 - "Community 184"
-Cohesion: 0.22
+Cohesion: 0.23
 Nodes (6): Internal, InternalTests, DefaultValue, Key, String, Test
 
 ### Community 185 - "Community 185"
@@ -1461,24 +1461,24 @@ Cohesion: 0.16
 Nodes (12): McpMobileRecordingService, List, locatorStrategy, Map, McpCodeBlock, McpMobileRecordedAction, McpMobileRecording, McpMobileRecordingStatus (+4 more)
 
 ### Community 186 - "Community 186"
-Cohesion: 0.19
-Nodes (8): TestNG, TestNGTests, XmlSuite, DefaultValue, Integer, Key, String, Test
+Cohesion: 0.23
+Nodes (7): TestNG, TestNGTests, DefaultValue, Integer, Key, String, Test
 
 ### Community 187 - "Community 187"
 Cohesion: 0.08
 Nodes (24): enum, additionalProperties, allOf, enum, $id, pattern, type, type (+16 more)
 
 ### Community 188 - "Community 188"
-Cohesion: 0.08
-Nodes (41): analyze_project(), collect_ai_context(), collect_source_migration(), dependency_coordinates(), detect_markers(), discover_poms(), execute_upgrade_transaction(), format_diff() (+33 more)
+Cohesion: 0.12
+Nodes (23): build_parser(), collect_ai_context(), execute_upgrade_transaction(), log(), main(), OpenAIRepairClient, preferred_runner(), print_analysis() (+15 more)
 
 ### Community 189 - "Community 189"
 Cohesion: 0.13
 Nodes (16): Bean, BrowserService, ElementService, GuideService, ShaftMcpApplication, MobileService, NaturalActionService, PlaywrightService (+8 more)
 
 ### Community 190 - "Community 190"
-Cohesion: 0.37
-Nodes (4): DoctorServiceTest, DoctorService, Path, Test
+Cohesion: 0.26
+Nodes (6): DoctorServiceTest, DoctorService, McpAnalysisReport, Path, String, Test
 
 ### Community 191 - "Community 191"
 Cohesion: 0.18
@@ -1492,13 +1492,17 @@ Nodes (3): AfterMethod, Test, ValidationsBuilderUnitTest
 Cohesion: 0.08
 Nodes (21): DriverAssertions, DriverVerifications, ElementActionsContract, BrowserAssertions, By, ElementAssertions, NativeValidationsBuilder, Object (+13 more)
 
+### Community 194 - "Community 194"
+Cohesion: 0.18
+Nodes (12): PlaywrightNaturalActionExecutor, By, CharSequence, List, Locator, NaturalActionPlan, Object, Page (+4 more)
+
 ### Community 195 - "Community 195"
 Cohesion: 0.15
 Nodes (21): load_budget(), Load the JSON guidance budget., build_parser(), collect_metrics(), issue(), main(), Run one external check and return a concise issue on failure., Collect stable context and memory size metrics. (+13 more)
 
 ### Community 196 - "Community 196"
-Cohesion: 0.28
-Nodes (6): Override, PlaywrightValidationsExecutor, ValidationsExecutor, ValidationType, VisualValidationEngine, PlaywrightElementValidationsBuilder
+Cohesion: 0.16
+Nodes (13): ElementAssertions, Locator, NativeValidationsBuilder, Override, PlaywrightNativeValidationsBuilder, PlaywrightSession, PlaywrightValidationsExecutor, String (+5 more)
 
 ### Community 197 - "Community 197"
 Cohesion: 0.24
@@ -1509,12 +1513,12 @@ Cohesion: 0.18
 Nodes (6): ElementInformation, ElementInformationCoverageUnitTest, Element, List, String, Test
 
 ### Community 199 - "Community 199"
-Cohesion: 0.08
-Nodes (19): RequestBuilder, RequestBuilderTests, AuthenticationType, API, Deprecated, Exception, RequestSpecification, RequestType (+11 more)
+Cohesion: 0.09
+Nodes (20): RequestBuilder, RequestBuilderTests, AuthenticationType, API, ContentType, Deprecated, Exception, RequestSpecification (+12 more)
 
 ### Community 200 - "Community 200"
-Cohesion: 0.14
-Nodes (9): ReportContext, JunitReportContextTest, Consumer, List, Status, String, TestExecutionInfo, AfterEach (+1 more)
+Cohesion: 0.15
+Nodes (8): ReportContext, JunitReportContextTest, Consumer, List, String, TestExecutionInfo, AfterEach, Test
 
 ### Community 201 - "Community 201"
 Cohesion: 0.11
@@ -1529,12 +1533,12 @@ Cohesion: 0.19
 Nodes (12): OpenAiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode, Map (+4 more)
 
 ### Community 205 - "Community 205"
-Cohesion: 0.15
-Nodes (9): ExecutableInvoker, JunitExtensionLifecycleTest, LauncherRetryFixture, AfterEach, ExtensionContext, Issue, Method, String (+1 more)
+Cohesion: 0.18
+Nodes (10): AfterMethod, Map, Object, String, SuppressWarnings, Test, Throwable, ThrowingRunnable (+2 more)
 
 ### Community 206 - "Community 206"
-Cohesion: 0.09
-Nodes (13): RestValidationsBuilder, JSONValidationsBuilder, NativeValidationsBuilder, NumberValidationsBuilder, Object, String, StringBuilder, ValidationCategory (+5 more)
+Cohesion: 0.08
+Nodes (14): RestValidationsBuilder, JSONValidationsBuilder, JsonCompareWithSpecialCharactersTests, NativeValidationsBuilder, Object, String, StringBuilder, ValidationCategory (+6 more)
 
 ### Community 207 - "Community 207"
 Cohesion: 0.23
@@ -1545,16 +1549,20 @@ Cohesion: 0.21
 Nodes (18): A(), ba(), c(), D(), E(), G(), i(), j() (+10 more)
 
 ### Community 209 - "Community 209"
-Cohesion: 0.06
-Nodes (42): AlertEvent, ArtifactPaths, AssertionSuggestion, DataPlan, CaptureGenerator, CodegenBackend(), driverClassName(), failure() (+34 more)
+Cohesion: 0.05
+Nodes (48): AlertEvent, ArtifactPaths, AssertionSuggestion, DataPlan, CaptureGenerator, CodegenBackend(), driverClassName(), failure() (+40 more)
 
 ### Community 210 - "Community 210"
-Cohesion: 0.13
-Nodes (7): LocatorBuilderTest, XpathAxis, LocatorBuilder, String, AfterMethod, BeforeMethod, Test
+Cohesion: 0.20
+Nodes (4): LocatorBuilderTest, AfterMethod, BeforeMethod, Test
 
 ### Community 211 - "Community 211"
-Cohesion: 0.19
-Nodes (10): NaturalActionExecutor, By, CharSequence, DriverFactoryHelper, NaturalActionPlan, Object, Set, String (+2 more)
+Cohesion: 0.20
+Nodes (4): Path, String, Test, AttachmentReporterUnitTest
+
+### Community 212 - "Community 212"
+Cohesion: 0.17
+Nodes (9): DataType, JSON, JSONFileManager, JSONFileManagerTests, List, Map, Object, String (+1 more)
 
 ### Community 213 - "Community 213"
 Cohesion: 0.16
@@ -1569,12 +1577,12 @@ Cohesion: 0.12
 Nodes (22): minLength, type, properties, $ref, $ref, $ref, body, evidence (+14 more)
 
 ### Community 216 - "Community 216"
-Cohesion: 0.13
-Nodes (17): RepairProcessRunner, expired(), InstantDeadline(), ManagedCaptureRecorderBrowserTest, BooleanSupplier, Duration, HttpExchange, HttpServer (+9 more)
+Cohesion: 0.24
+Nodes (10): expired(), InstantDeadline(), ManagedCaptureRecorderBrowserTest, Duration, HttpExchange, HttpServer, ParameterizedTest, Path (+2 more)
 
 ### Community 217 - "Community 217"
-Cohesion: 0.19
-Nodes (12): PilotNaturalActionPlanner, NaturalActionKind, NaturalActionPlanner, NaturalActionStep, AiExecutionService, By, JsonNode, NaturalActionPlan (+4 more)
+Cohesion: 0.14
+Nodes (7): AndroidDragAndDropTest, AndroidTouchActionsTests, MobileTest, Test, Test, AfterMethod, BeforeMethod
 
 ### Community 218 - "Community 218"
 Cohesion: 0.24
@@ -1594,11 +1602,11 @@ Nodes (13): AiCandidateReranker, AiExecutionService, Double, HealingConfiguratio
 
 ### Community 222 - "Community 222"
 Cohesion: 0.20
-Nodes (8): ExecutionLifecycleHelper, List, Method, Status, StatusIcon, String, TestExecutionInfo, TmsLink
+Nodes (8): ArrayList, ExecutionLifecycleHelper, List, Method, Status, StatusIcon, String, TestExecutionInfo
 
 ### Community 223 - "Community 223"
-Cohesion: 0.29
-Nodes (8): DoctorJsonCodec, Diagnosis, DoctorAdvisory, EvidenceBundle, JsonNode, Object, Path, String
+Cohesion: 0.28
+Nodes (12): CompletableFuture, McpProcessRunner, SystemProcessRunner, Duration, InputStream, List, Map, Override (+4 more)
 
 ### Community 224 - "Community 224"
 Cohesion: 0.19
@@ -1648,17 +1656,13 @@ Nodes (10): ThrowingInvocation, WebDriverElementValidationsBuilderCoverageUnitTe
 Cohesion: 0.20
 Nodes (8): CucumberFeatureListener, Class, Object, String, SuppressWarnings, Test, TableRow, CucumberFeatureListenerUnitTest
 
-### Community 236 - "Community 236"
-Cohesion: 0.16
-Nodes (8): AccessibilityResult, AfterMethod, BeforeMethod, List, Rule, String, Test, AccessibilityActionsCoverageUnitTest
-
 ### Community 237 - "Community 237"
 Cohesion: 0.24
 Nodes (7): HealingScore, DeterministicScorer, Double, HealingConfiguration, LocatorFingerprint, Map, String
 
 ### Community 238 - "Community 238"
-Cohesion: 0.11
-Nodes (10): FakeGuideHttpClient, GuideServiceTest, CucumberMockedTests, Test, List, Map, Override, String (+2 more)
+Cohesion: 0.10
+Nodes (11): FakeGuideHttpClient, GuideServiceTest, AfterMethod, Test, List, Map, Override, String (+3 more)
 
 ### Community 239 - "Community 239"
 Cohesion: 0.23
@@ -1677,11 +1681,11 @@ Cohesion: 0.12
 Nodes (9): AlertActionsContract, DriverContract, ElementActionsContract, BrowserActionsContract, DriverAssertions, DriverVerifications, Object, String (+1 more)
 
 ### Community 243 - "Community 243"
-Cohesion: 0.18
-Nodes (13): McpMobileInspectorRecordingServiceTest, NoopRunner, McpProcessRunner, Duration, List, Map, McpMobileInspectorRecordingService, Override (+5 more)
+Cohesion: 0.20
+Nodes (3): CSVFileManagerTest, BeforeMethod, Test
 
 ### Community 244 - "Community 244"
-Cohesion: 0.22
+Cohesion: 0.24
 Nodes (6): McpRuntimePaths, McpRuntimePathsTest, Map, Path, String, Test
 
 ### Community 245 - "Community 245"
@@ -1705,23 +1709,23 @@ Cohesion: 0.12
 Nodes (14): apply_ai_changes(), atomic_write(), FileTransaction, OriginalFile, Resolve and validate an AI-proposed editable path., Apply validated full-file replacements through the main transaction., Original state for one transaction-managed file., Track file writes and restore their original bytes on failure. (+6 more)
 
 ### Community 250 - "Community 250"
-Cohesion: 0.16
-Nodes (15): build_parser(), coordinates_have_supported_runner(), coordinates_have_supported_stack(), ensure_shaft_import(), migrate_full_source(), migrate_session_source(), ArgumentParser, Add the SHAFT import required by rewritten Java source. (+7 more)
+Cohesion: 0.12
+Nodes (24): analyze_project(), coordinates_have_supported_runner(), coordinates_have_supported_stack(), dependency_coordinates(), detect_markers(), discover_poms(), format_diff(), is_ignored() (+16 more)
 
 ### Community 251 - "Community 251"
-Cohesion: 0.12
-Nodes (5): PropertiesHelper, AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
+Cohesion: 0.09
+Nodes (6): PropertiesHelper, String, AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
 
 ### Community 252 - "Community 252"
-Cohesion: 0.23
-Nodes (11): AlphaProvider, ZuluProvider, Boolean, By, Integer, List, Override, String (+3 more)
+Cohesion: 0.26
+Nodes (10): AlphaProvider, ZuluProvider, Boolean, By, Integer, List, Override, String (+2 more)
 
 ### Community 253 - "Community 253"
-Cohesion: 0.24
-Nodes (8): GuardedPatch, RepairGuard, FilePatch, List, Path, Set, String, ValidationCommand
+Cohesion: 0.32
+Nodes (4): CSVFileManager, List, Map, String
 
 ### Community 254 - "Community 254"
-Cohesion: 0.12
+Cohesion: 0.11
 Nodes (11): TestNGListenerHelper, Browser, ISuite, ITestContext, ITestNGMethod, ITestResult, List, Method (+3 more)
 
 ### Community 255 - "Community 255"
@@ -1733,20 +1737,20 @@ Cohesion: 0.21
 Nodes (6): FailureReporter, Class, String, Throwable, Test, FailureReporterUnitTest
 
 ### Community 257 - "Community 257"
-Cohesion: 0.15
-Nodes (8): BrowserStackHelper, JunitListenerHelper, Boolean, DriverFactoryHelper, MutableCapabilities, String, TestIdentifier, Boolean
+Cohesion: 0.27
+Nodes (5): BrowserStackHelper, Boolean, DriverFactoryHelper, MutableCapabilities, String
 
 ### Community 258 - "Community 258"
 Cohesion: 0.20
 Nodes (6): NaturalActions, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 259 - "Community 259"
-Cohesion: 0.17
-Nodes (6): ShaftLocator, CheckpointCounter, Override, String, Pattern, Strategy
+Cohesion: 0.13
+Nodes (10): ShaftLocator, CaptureWorkbenchHtml, CaptureGenerationReport, CaptureReview, Path, String, Override, String (+2 more)
 
 ### Community 260 - "Community 260"
-Cohesion: 0.14
-Nodes (8): EngineServiceRuntimePathTest, AfterMethod, String, Test, AfterEach, BeforeEach, Test, PropertyFileManagerUnitTest
+Cohesion: 0.17
+Nodes (11): AiProviderRegistryTest, availability(), capabilities(), execute(), AfterEach, AiCapabilities, AiProviderAvailability, AiRequest (+3 more)
 
 ### Community 261 - "Community 261"
 Cohesion: 0.23
@@ -1754,15 +1758,15 @@ Nodes (5): ThreadSafeGuiWizardTests, AfterMethod, BeforeMethod, SuppressWarnings
 
 ### Community 262 - "Community 262"
 Cohesion: 0.09
-Nodes (25): CommandResult, confirm_upgrade(), default_compile_command(), extract_response_output_text(), is_stable_release(), metadata_release(), parse_compile_command(), Enforce the modular SHAFT dependency contract after every repair. (+17 more)
+Nodes (24): RuntimeError, CommandResult, confirm_upgrade(), default_compile_command(), extract_response_output_text(), is_stable_release(), metadata_release(), parse_compile_command() (+16 more)
 
 ### Community 263 - "Community 263"
 Cohesion: 0.16
 Nodes (8): PlaywrightSession, Browser, BrowserContext, Object, Override, Page, Playwright, String
 
 ### Community 264 - "Community 264"
-Cohesion: 0.27
-Nodes (5): CheckpointType, CheckpointStatus, String, Test, CheckpointAndReportingTest
+Cohesion: 0.21
+Nodes (6): CheckpointType, CheckpointCounter, CheckpointStatus, String, Test, CheckpointAndReportingTest
 
 ### Community 265 - "Community 265"
 Cohesion: 0.15
@@ -1773,7 +1777,7 @@ Cohesion: 0.25
 Nodes (17): current(), decimal(), normalize(), parseCategories(), parseLocation(), positive(), provider(), split() (+9 more)
 
 ### Community 267 - "Community 267"
-Cohesion: 0.22
+Cohesion: 0.23
 Nodes (7): CucumberTestRunnerListener, AfterMethod, Class, Object, String, Test, CucumberTestRunnerListenerUnitTest
 
 ### Community 268 - "Community 268"
@@ -1781,40 +1785,40 @@ Cohesion: 0.28
 Nodes (7): LocatorRanker, ScoredLocator, ElementSnapshot, EventContext, LocatorCandidate, LocatorSelection, String
 
 ### Community 269 - "Community 269"
-Cohesion: 0.23
-Nodes (10): Cucumber, CucumberHelper, CucumberTests, List, Status, XmlSuite, DefaultValue, Key (+2 more)
+Cohesion: 0.38
+Nodes (4): Cucumber, DefaultValue, Key, String
 
 ### Community 270 - "Community 270"
 Cohesion: 0.25
 Nodes (4): MultipleDriverSessionTerminationTest, AfterMethod, BeforeMethod, Test
 
 ### Community 271 - "Community 271"
-Cohesion: 0.25
-Nodes (3): ActionsExceptionDetailsUnitTest, NoSuchElementException, Test
+Cohesion: 0.33
+Nodes (6): HealingLocatorProposalServiceTest, AfterEach, BeforeEach, Path, String, Test
 
 ### Community 272 - "Community 272"
 Cohesion: 0.20
 Nodes (4): ValidationsMockedTests, AfterMethod, BeforeMethod, Test
 
 ### Community 273 - "Community 273"
-Cohesion: 0.16
-Nodes (11): HealingLocatorProposalService, HealingLocatorProposalServiceTest, HealingLocatorProposal, JsonNode, Path, String, AfterEach, BeforeEach (+3 more)
+Cohesion: 0.31
+Nodes (5): HealingLocatorProposalService, HealingLocatorProposal, JsonNode, Path, String
 
 ### Community 274 - "Community 274"
-Cohesion: 0.18
-Nodes (9): AtomicReference, SuppressWarnings, AfterMethod, AndroidDriver, BeforeMethod, CountDownLatch, Test, Throwable (+1 more)
+Cohesion: 0.14
+Nodes (12): AtomicReference, AfterMethod, AndroidDriver, BeforeMethod, CountDownLatch, InputStream, Override, String (+4 more)
 
 ### Community 275 - "Community 275"
-Cohesion: 0.14
-Nodes (6): CoverageTests, AfterClass, AfterMethod, BeforeClass, BeforeMethod, Test
+Cohesion: 0.31
+Nodes (5): BrowserStackSdkHelper, List, Map, Object, String
 
 ### Community 276 - "Community 276"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (9): Actions, AfterMethod, BeforeMethod, ElementActions, MockedConstruction, Object, String, Test (+1 more)
 
 ### Community 277 - "Community 277"
-Cohesion: 0.06
-Nodes (38): AiProviderRegistryTest, availability(), capabilities(), execute(), Builder, CompletableFuture, Controller, Headers (+30 more)
+Cohesion: 0.13
+Nodes (15): Builder, Controller, Headers, Controller, McpAppiumInspectorProxy, McpAppiumCommandRecorder, HttpExchange, HttpResponse (+7 more)
 
 ### Community 279 - "Community 279"
 Cohesion: 0.20
@@ -1825,8 +1829,8 @@ Cohesion: 0.36
 Nodes (5): TextLanguageValidationsBuilder, NativeValidationsBuilder, String, ValidationsExecutor, TextLanguage
 
 ### Community 281 - "Community 281"
-Cohesion: 0.16
-Nodes (9): $, String, AfterMethod, AtomicInteger, Set, String, SuppressWarnings, Test (+1 more)
+Cohesion: 0.19
+Nodes (8): String, AfterMethod, AtomicInteger, Set, String, SuppressWarnings, Test, CucumberTestsHelperCoverageUnitTest
 
 ### Community 282 - "Community 282"
 Cohesion: 0.21
@@ -1849,12 +1853,12 @@ Cohesion: 0.18
 Nodes (7): HealingActionsIntegrationTest, AfterMethod, BeforeMethod, DataProvider, Object, String, Test
 
 ### Community 287 - "Community 287"
-Cohesion: 0.25
-Nodes (6): McpServiceHelperTest, AfterEach, Class, Object, String, Test
+Cohesion: 0.32
+Nodes (5): McpServiceHelperTest, Class, Object, String, Test
 
 ### Community 288 - "Community 288"
-Cohesion: 0.19
-Nodes (11): PlaywrightServiceTest, DoctorReportWriter, Diagnosis, DoctorAdvisory, EvidenceBundle, List, Path, String (+3 more)
+Cohesion: 0.26
+Nodes (9): DoctorReportWriter, Diagnosis, DoctorAdvisory, EvidenceBundle, List, Path, String, StringBuilder (+1 more)
 
 ### Community 289 - "Community 289"
 Cohesion: 0.25
@@ -1877,8 +1881,8 @@ Cohesion: 0.16
 Nodes (12): McpPlaywrightRecordingService, List, locatorStrategy, Map, McpCodeBlock, McpMobileRecordedAction, McpMobileRecording, McpMobileRecordingStatus (+4 more)
 
 ### Community 295 - "Community 295"
-Cohesion: 0.07
-Nodes (20): AsyncElementActions, Async, CLI, GUI, Locator, Properties, Report, TestData (+12 more)
+Cohesion: 0.08
+Nodes (18): AsyncElementActions, Async, CLI, GUI, Locator, Properties, Report, TestData (+10 more)
 
 ### Community 296 - "Community 296"
 Cohesion: 0.12
@@ -1901,8 +1905,8 @@ Cohesion: 0.22
 Nodes (7): ManagedCaptureRecorderControlTest, CaptureBrowser, CaptureStartOptions, CaptureStartRequest, Object, SuppressWarnings, Test
 
 ### Community 301 - "Community 301"
-Cohesion: 0.11
-Nodes (20): HealingManager, current(), HealingStrategy(), parse(), usesHealenium(), usesShaftHeal(), HealingStrategyTest, By (+12 more)
+Cohesion: 0.07
+Nodes (30): HealingManager, current(), HealingStrategy(), parse(), usesHealenium(), usesShaftHeal(), HealingStrategyTest, NaturalActionExecutor (+22 more)
 
 ### Community 302 - "Community 302"
 Cohesion: 0.21
@@ -1912,17 +1916,13 @@ Nodes (9): fixture_commands(), main(), maven_executable(), missing_publication_p
 Cohesion: 0.17
 Nodes (9): InterceptorFactory, BrowserNetworkInterceptor, InterceptorFactory, BrowserNetworkInterceptionRule, Filter, HttpRequest, HttpResponse, Response (+1 more)
 
-### Community 304 - "Community 304"
-Cohesion: 0.11
-Nodes (8): UnitTestsRestActions, InputStream, Test, Override, Path, Test, CloseTrackingInputStream, ReportManagerHelperAttachmentIoUnitTest
-
 ### Community 305 - "Community 305"
-Cohesion: 0.12
-Nodes (12): DesktopVideoRecordingProvider, AfterMethod, InputStream, Override, String, Test, InputStream, Override (+4 more)
+Cohesion: 0.18
+Nodes (8): DesktopVideoRecordingProvider, AfterMethod, InputStream, Override, String, Test, DesktopVideoRecordingProviderRegistryTest, StubDesktopVideoRecordingProvider
 
 ### Community 306 - "Community 306"
-Cohesion: 0.28
-Nodes (5): ScreenshotManagerCoverageUnitTest, AfterMethod, BeforeMethod, Color, Test
+Cohesion: 0.26
+Nodes (4): Mobile, DefaultValue, Key, SetProperty
 
 ### Community 307 - "Community 307"
 Cohesion: 0.23
@@ -1941,8 +1941,8 @@ Cohesion: 0.15
 Nodes (10): AllureCucumber7Jvm, CucumberTestRunnerListener, EventPublisher, Feature, Optional, Override, TestCaseFinished, TestSourceParsed (+2 more)
 
 ### Community 312 - "Community 312"
-Cohesion: 0.18
-Nodes (9): Autowired, ShaftMcpApplicationTests, EngineService, McpMobileInspectorRecordingService, McpMobileRecordingService, McpWorkspacePolicy, Set, String (+1 more)
+Cohesion: 0.09
+Nodes (17): Autowired, LogRedirector, Logger, LocatorOperation, ShaftMcpApplicationTests, Level, Override, By (+9 more)
 
 ### Community 313 - "Community 313"
 Cohesion: 0.27
@@ -1985,8 +1985,8 @@ Cohesion: 0.27
 Nodes (5): McpMobileCode, List, locatorStrategy, McpCodeBlock, String
 
 ### Community 323 - "Community 323"
-Cohesion: 0.17
-Nodes (12): enum, additionalProperties, properties, required, type, enum, items, type (+4 more)
+Cohesion: 0.13
+Nodes (15): type, uniqueItems, enum, additionalProperties, properties, required, type, enum (+7 more)
 
 ### Community 324 - "Community 324"
 Cohesion: 0.17
@@ -2005,8 +2005,8 @@ Cohesion: 0.21
 Nodes (7): AfterMethod, BeforeClass, BeforeMethod, Override, String, Test, TestClass
 
 ### Community 329 - "Community 329"
-Cohesion: 0.06
-Nodes (18): AndroidBasicInteractionsTests, AndroidDragAndDropTest, AndroidTouchActionsTests, MobileTest, MultipleElementsFailureTest, NoSuchElementFailureTest, ScreenOrientation, Test (+10 more)
+Cohesion: 0.16
+Nodes (6): AndroidBasicInteractionsTests, MultipleElementsFailureTest, Test, AfterMethod, BeforeMethod, Test
 
 ### Community 330 - "Community 330"
 Cohesion: 0.29
@@ -2021,20 +2021,20 @@ Cohesion: 0.19
 Nodes (14): A(), Ae(), b(), ce(), ge(), le(), pe(), qe() (+6 more)
 
 ### Community 333 - "Community 333"
-Cohesion: 0.06
-Nodes (29): empty(), reviewUiPath(), disabled(), McpResultRecordsTest, Metadata, asCacheHit(), disabled(), empty() (+21 more)
+Cohesion: 0.24
+Nodes (5): List, Set, String, Test, TelemetryDeduplicationUnitTest
 
 ### Community 334 - "Community 334"
 Cohesion: 0.25
 Nodes (8): notRequested(), McpCaptureCodeBlockServiceTest, Enrichment, List, McpCodeBlock, Path, String, Test
 
 ### Community 335 - "Community 335"
-Cohesion: 0.17
-Nodes (18): add_text_child(), append_plugin_dependency(), copy_dependency_metadata(), create_dependency(), create_external_dependency(), create_plugin(), create_property(), create_surefire_profile() (+10 more)
+Cohesion: 0.27
+Nodes (10): add_text_child(), append_plugin_dependency(), create_plugin(), create_property(), create_surefire_profile(), Create a Maven plugin shell., Append one plugin dependency., Create one Surefire property element. (+2 more)
 
 ### Community 336 - "Community 336"
-Cohesion: 0.10
-Nodes (10): ProgressBarLogger, ProgressBarLoggerCoverageUnitTest, ProgressBarLoggerTestAccessor, Override, String, AfterMethod, Test, AfterMethod (+2 more)
+Cohesion: 0.17
+Nodes (6): ProgressBarLogger, ProgressBarLoggerCoverageUnitTest, Override, String, AfterMethod, Test
 
 ### Community 337 - "Community 337"
 Cohesion: 0.15
@@ -2045,16 +2045,16 @@ Cohesion: 0.26
 Nodes (6): ModelSupport, JsonNode, List, Map, String, T
 
 ### Community 340 - "Community 340"
-Cohesion: 0.08
-Nodes (20): OpenApiCoverageReporter, OperationCoverage, SpecCoverage, OpenApiCoverageReporterUnitTest, OpenAPI, OpenApiValidationException, OpenApiValidationFilter, OperationCoverage (+12 more)
+Cohesion: 0.06
+Nodes (25): LocalApiTestServer, OpenApiCoverageReporter, OperationCoverage, SpecCoverage, OpenApiCoverageReporterUnitTest, OpenAPI, OpenApiValidationException, OpenApiValidationFilter (+17 more)
 
 ### Community 341 - "Community 341"
 Cohesion: 0.12
 Nodes (17): items, type, uniqueItems, tags, items, additionalProperties, minLength, pattern (+9 more)
 
 ### Community 342 - "Community 342"
-Cohesion: 0.18
-Nodes (8): ElementStepsCoverageUnitTest, ElementActionsHelper, BeforeMethod, By, DataProvider, Object, String, Test
+Cohesion: 0.22
+Nodes (7): ElementStepsCoverageUnitTest, BeforeMethod, By, DataProvider, Object, String, Test
 
 ### Community 343 - "Community 343"
 Cohesion: 0.25
@@ -2069,16 +2069,16 @@ Cohesion: 0.23
 Nodes (12): ActionMetadata, disabled(), HealingReport(), minimized(), pending(), ProviderMetadata(), PrivacyMetadata, HealingCandidate (+4 more)
 
 ### Community 346 - "Community 346"
-Cohesion: 0.21
-Nodes (9): AiProvider, DoctorSnippetProvider, AfterEach, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse, Override (+1 more)
+Cohesion: 0.11
+Nodes (15): DisabledAiProvider, AiProvider, DoctorSnippetProvider, AfterEach, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse (+7 more)
 
 ### Community 347 - "Community 347"
-Cohesion: 0.22
-Nodes (6): IOSDriver, InputStream, Path, String, WebDriver, RecordManager
+Cohesion: 0.23
+Nodes (6): InputStream, Path, String, SuppressWarnings, WebDriver, RecordManager
 
 ### Community 348 - "Community 348"
-Cohesion: 0.13
-Nodes (11): HasCdp, Image, ScreenshotHelperCoverageUnitTest, BufferedImage, String, AfterMethod, BeforeMethod, Color (+3 more)
+Cohesion: 0.16
+Nodes (9): Image, ScreenshotHelperCoverageUnitTest, BufferedImage, AfterMethod, BeforeMethod, Color, Object, String (+1 more)
 
 ### Community 349 - "Community 349"
 Cohesion: 0.23
@@ -2089,11 +2089,11 @@ Cohesion: 0.40
 Nodes (12): configuration_path(), expected_java(), installed_args(), installed_dependencies(), installed_jar(), installer_command(), main(), sha256() (+4 more)
 
 ### Community 351 - "Community 351"
-Cohesion: 0.32
-Nodes (5): CaptureJsonCodec, CaptureSession, JsonNode, Path, String
+Cohesion: 0.22
+Nodes (7): BrowserPerformanceExecutionReportUnitTest, AfterMethod, BeforeMethod, CapturedFile, List, String, Test
 
 ### Community 352 - "Community 352"
-Cohesion: 0.31
+Cohesion: 0.27
 Nodes (3): VisualProcessingProviderRegistryTest, AfterMethod, Test
 
 ### Community 353 - "Community 353"
@@ -2101,7 +2101,7 @@ Cohesion: 0.18
 Nodes (7): FileValidationsBuilder, NativeValidationsBuilder, String, StringBuilder, SuppressWarnings, ValidationCategory, ValidationsExecutor
 
 ### Community 354 - "Community 354"
-Cohesion: 0.33
+Cohesion: 0.39
 Nodes (3): ReportManager, Level, String
 
 ### Community 356 - "Community 356"
@@ -2113,8 +2113,8 @@ Cohesion: 0.26
 Nodes (3): SmartLocatorsPOC1Tests, CharSequence, String
 
 ### Community 358 - "Community 358"
-Cohesion: 0.25
-Nodes (3): AfterMethod, Test, LambdaTestHelperUnitTest
+Cohesion: 0.35
+Nodes (3): BrowserEventScript, List, String
 
 ### Community 359 - "Community 359"
 Cohesion: 0.26
@@ -2133,12 +2133,12 @@ Cohesion: 0.27
 Nodes (4): AfterMethod, Object, Test, APIPropertiesUnitTest
 
 ### Community 363 - "Community 363"
-Cohesion: 0.26
-Nodes (6): OutputStream, HttpExchange, HttpServer, Override, String, LocalApiServer
+Cohesion: 0.29
+Nodes (5): HttpExchange, HttpServer, Override, String, LocalApiServer
 
 ### Community 364 - "Community 364"
-Cohesion: 0.13
-Nodes (6): NetworkInterceptionTest, SmartLocatorsTests, Test, AfterMethod, BeforeMethod, Tests
+Cohesion: 0.08
+Nodes (12): BasicAuthenticationTests, NetworkInterceptionTest, TableTests, SmartLocatorsTests, Test, Test, String, Test (+4 more)
 
 ### Community 365 - "Community 365"
 Cohesion: 0.27
@@ -2161,8 +2161,8 @@ Cohesion: 0.21
 Nodes (4): AlertActions, Override, PlaywrightSession, String
 
 ### Community 370 - "Community 370"
-Cohesion: 0.20
-Nodes (7): AnimatedGifManagerCoverageUnitTest, AfterMethod, BeforeMethod, Color, Method, String, Test
+Cohesion: 0.14
+Nodes (9): GifSession, AnimatedGifManagerCoverageUnitTest, String, AfterMethod, BeforeMethod, Color, Method, String (+1 more)
 
 ### Community 371 - "Community 371"
 Cohesion: 0.23
@@ -2225,8 +2225,8 @@ Cohesion: 0.17
 Nodes (12): type, scope, pattern, type, branch, project, task, additionalProperties (+4 more)
 
 ### Community 387 - "Community 387"
-Cohesion: 0.18
-Nodes (7): OpenCvVisualConsumer, HealingVisualProvider, OpenCvHealingVisualProvider, Override, String, Mat, String
+Cohesion: 0.19
+Nodes (7): HealingVisualProvider, OpenCvHealingVisualProvider, OpenCvHealingVisualProviderTest, Override, String, Color, Test
 
 ### Community 388 - "Community 388"
 Cohesion: 0.17
@@ -2249,8 +2249,8 @@ Cohesion: 0.35
 Nodes (4): HttpExchange, Path, String, TestPageServer
 
 ### Community 394 - "Community 394"
-Cohesion: 0.31
-Nodes (4): JSONValidationsBuilder, Object, RestValidationsBuilder, ValidationsExecutor
+Cohesion: 0.27
+Nodes (5): JSONValidationsBuilder, NativeValidationsBuilder, Object, RestValidationsBuilder, ValidationsExecutor
 
 ### Community 395 - "Community 395"
 Cohesion: 0.26
@@ -2277,20 +2277,20 @@ Cohesion: 0.49
 Nodes (10): create_bundle(), main(), _parse(), _text(), validate_jar_contents(), validate_publication(), validate_sbom(), _version() (+2 more)
 
 ### Community 401 - "Community 401"
-Cohesion: 0.31
-Nodes (3): DbTests, BeforeClass, Test
+Cohesion: 0.26
+Nodes (4): DbTests, BeforeClass, Test, DBWizardTests
 
 ### Community 402 - "Community 402"
-Cohesion: 0.35
-Nodes (5): CaptureWorkbenchHtml, CaptureGenerationReport, CaptureReview, Path, String
+Cohesion: 0.27
+Nodes (4): ExecutionCountsTracker, String, TestExecutionInfo, Counts
 
 ### Community 403 - "Community 403"
 Cohesion: 0.38
 Nodes (10): aiTrigger(), bounded(), current(), HealingConfiguration(), split(), Duration, List, Path (+2 more)
 
 ### Community 404 - "Community 404"
-Cohesion: 0.18
-Nodes (5): ExecutionSummaryReport, StatusIcon(), CheckpointStatus, String, StringBuilder
+Cohesion: 0.13
+Nodes (9): skipped(), ExecutionSummaryReport, StatusIcon(), String, Validation, Counts, CheckpointStatus, String (+1 more)
 
 ### Community 405 - "Community 405"
 Cohesion: 0.29
@@ -2313,20 +2313,20 @@ Cohesion: 0.29
 Nodes (4): GroupsTests, AfterMethod, BeforeMethod, Test
 
 ### Community 410 - "Community 410"
-Cohesion: 0.16
-Nodes (11): ActionCandidate, LocatorDecision, McpCaptureCodeBlockService, PomCandidates, CaptureGenerationReport, List, LocatorCandidate, McpCodeBlock (+3 more)
+Cohesion: 0.14
+Nodes (13): ActionCandidate, safe(), LocatorDecision, McpCaptureCodeBlockService, PomCandidates, CaptureGenerationReport, List, LocatorCandidate (+5 more)
 
 ### Community 411 - "Community 411"
-Cohesion: 0.27
-Nodes (4): AfterMethod, BeforeMethod, Test, BrowserActionsHelperCoverageUnitTest
+Cohesion: 0.24
+Nodes (9): JiraHelper, Class, IInvokedMethod, ITestNGMethod, ITestResult, List, String, SuppressWarnings (+1 more)
 
 ### Community 412 - "Community 412"
-Cohesion: 0.27
-Nodes (6): AiCandidateRerankerTest, AfterMethod, HealingConfiguration, HttpExchange, String, Test
+Cohesion: 0.22
+Nodes (4): ProgressBarLoggerTestAccessor, AfterMethod, Test, ValidationAndProgressBarTests
 
 ### Community 413 - "Community 413"
-Cohesion: 0.19
-Nodes (14): ArrayList, MultipleBrowserInstancesTest, addIfSet(), addIfTrue(), defaults(), normalize(), testIdAttributes(), text() (+6 more)
+Cohesion: 0.40
+Nodes (10): addIfSet(), addIfTrue(), defaults(), normalize(), testIdAttributes(), text(), warnings(), CaptureStartOptions (+2 more)
 
 ### Community 414 - "Community 414"
 Cohesion: 0.18
@@ -2353,8 +2353,8 @@ Cohesion: 0.33
 Nodes (8): failure(), success(), AiResponse, AiResponseStatus, AiUsage, Duration, JsonNode, String
 
 ### Community 421 - "Community 421"
-Cohesion: 0.20
-Nodes (11): DriverAssertions, BrowserAssertions, By, ElementAssertions, Locator, NativeValidationsBuilder, Object, Override (+3 more)
+Cohesion: 0.14
+Nodes (14): DriverAssertions, By, Locator, Page, BrowserAssertions, By, ElementAssertions, Locator (+6 more)
 
 ### Community 422 - "Community 422"
 Cohesion: 0.20
@@ -2376,13 +2376,17 @@ Nodes (3): ValidationsHelperNewPatternCoverageUnitTest, AfterMethod, Test
 Cohesion: 0.26
 Nodes (6): Pattern, SetProperty, DefaultValue, Key, SetProperty, String
 
+### Community 427 - "Community 427"
+Cohesion: 0.26
+Nodes (7): ApiPerformanceExecutionReportUnitTest, AfterMethod, CapturedFile, JsonNode, List, String, Test
+
 ### Community 428 - "Community 428"
-Cohesion: 0.27
-Nodes (4): PlaywrightTraceManager, PlaywrightTraceManager, BrowserContext, Path
+Cohesion: 0.52
+Nodes (3): PlaywrightTraceManager, BrowserContext, Path
 
 ### Community 430 - "Community 430"
-Cohesion: 0.20
-Nodes (6): RetryAnalyzer, SupportingEvidenceState, IRetryAnalyzer, ITestResult, Override, String
+Cohesion: 0.29
+Nodes (6): RequestBuilderPerformanceTest, AfterMethod, RequestType, RestActions, String, Test
 
 ### Community 431 - "Community 431"
 Cohesion: 0.31
@@ -2393,20 +2397,20 @@ Cohesion: 0.29
 Nodes (4): FlutterTest, AfterMethod, BeforeMethod, Test
 
 ### Community 433 - "Community 433"
-Cohesion: 0.53
-Nodes (5): allows(), ApprovalPolicy(), EvidenceCategory, ProcessingLocation, Set
+Cohesion: 0.15
+Nodes (11): ready(), unavailable(), AiValueObjectsTest, allows(), ApprovalPolicy(), AiProviderAvailability, String, EvidenceCategory (+3 more)
 
 ### Community 434 - "Community 434"
-Cohesion: 0.38
-Nodes (5): CaptureCliTest, Class, Object, String, Test
+Cohesion: 0.09
+Nodes (15): BrowserStackModuleTest, CaptureCliTest, Constructor, InvocationTargetException, JsonSchemaValidatorTest, Test, Class, Object (+7 more)
 
 ### Community 435 - "Community 435"
-Cohesion: 0.42
-Nodes (3): NativeValidationsBuilder, PlaywrightNativeValidationsBuilder, String
+Cohesion: 0.36
+Nodes (3): XpathAxis, LocatorBuilder, String
 
 ### Community 436 - "Community 436"
-Cohesion: 0.13
-Nodes (10): FluentWebDriverAction, Actions, AlertActions, BrowserActions, DriverFactoryHelper, TouchActions, WebDriver, DriverFactoryHelper (+2 more)
+Cohesion: 0.09
+Nodes (17): FluentWebDriverAction, SelectedValueTests, Actions, AlertActions, BrowserActions, DriverFactoryHelper, TouchActions, WebDriver (+9 more)
 
 ### Community 437 - "Community 437"
 Cohesion: 0.20
@@ -2437,8 +2441,8 @@ Cohesion: 0.20
 Nodes (9): Alternative: Email, Dependency Security, Disclosure Policy, Preferred: GitHub Private Security Advisory, Reporting a Vulnerability, Response Timeline, Scope, Security Policy (+1 more)
 
 ### Community 444 - "Community 444"
-Cohesion: 0.14
-Nodes (11): AccessibilityActions, BrowserNetworkInterceptionRule, DriverFactoryHelper, HttpRequest, HttpResponse, Predicate, Screenshots, Step (+3 more)
+Cohesion: 0.24
+Nodes (6): Class, Object, String, SuppressWarnings, Test, SmartLocatorsCoverageUnitTest
 
 ### Community 445 - "Community 445"
 Cohesion: 0.32
@@ -2447,6 +2451,10 @@ Nodes (3): DesktopVideoRecordingProvider, Optional, DesktopVideoRecordingProvide
 ### Community 446 - "Community 446"
 Cohesion: 0.31
 Nodes (4): AfterMethod, Object, Test, LambdaTestSetPropertyCoverageUnitTest
+
+### Community 447 - "Community 447"
+Cohesion: 0.31
+Nodes (3): NavigationAction, Test, NavigationActionUnitTest
 
 ### Community 448 - "Community 448"
 Cohesion: 0.22
@@ -2465,16 +2473,16 @@ Cohesion: 0.23
 Nodes (4): UnitTestsSHAFT, CSVFileManager, CSV, Test
 
 ### Community 452 - "Community 452"
-Cohesion: 0.10
-Nodes (16): ImageProcessingActions, VisualProcessingProviderRegistry, Boolean, By, File, Integer, List, String (+8 more)
+Cohesion: 0.33
+Nodes (4): VisualProcessingProviderRegistry, List, Optional, VisualProcessingProvider
 
 ### Community 453 - "Community 453"
-Cohesion: 0.21
-Nodes (8): SessionPermit, FileChannel, FileLock, CaptureSingleSessionLock, Override, Path, Override, AutoCloseable
+Cohesion: 0.29
+Nodes (6): FileChannel, FileLock, CaptureSingleSessionLock, Override, Path, AutoCloseable
 
 ### Community 454 - "Community 454"
-Cohesion: 0.31
-Nodes (4): AfterMethod, BeforeMethod, Test, VisualValidationTests
+Cohesion: 0.24
+Nodes (5): String, AfterMethod, BeforeMethod, Test, VisualValidationTests
 
 ### Community 455 - "Community 455"
 Cohesion: 0.20
@@ -2512,6 +2520,10 @@ Nodes (4): ChecksumTests, Path, String, Test
 Cohesion: 0.43
 Nodes (3): AfterMethod, Test, PropertiesHelperMaximumPerformanceModeUnitTest
 
+### Community 464 - "Community 464"
+Cohesion: 0.27
+Nodes (3): MockedResponseBuilder, HttpResponse, Map
+
 ### Community 465 - "Community 465"
 Cohesion: 0.25
 Nodes (4): CaptureEvent, ElementSnapshot, EventContext, ExternalTestDataReference
@@ -2533,11 +2545,11 @@ Cohesion: 0.36
 Nodes (4): AfterMethod, BeforeMethod, Test, RecordManagerCoverageUnitTest
 
 ### Community 471 - "Community 471"
-Cohesion: 0.26
-Nodes (3): ThreadLocalPropertiesManager, Properties, String
+Cohesion: 0.27
+Nodes (5): Session1Test, AfterMethod, BeforeMethod, String, Test
 
 ### Community 472 - "Community 472"
-Cohesion: 0.33
+Cohesion: 0.31
 Nodes (4): AfterMethod, BeforeMethod, Test, TopUncoveredClassesCoverageUnitTest
 
 ### Community 473 - "Community 473"
@@ -2553,8 +2565,8 @@ Cohesion: 0.29
 Nodes (6): Deletion Checklist, Generated PR Workflows, GitHub Actions Workflows, Relationship Map, Shared Composite Actions, Workflow Inventory
 
 ### Community 476 - "Community 476"
-Cohesion: 0.27
-Nodes (5): IOSBasicInteractionsTest, AfterMethod, BeforeMethod, SuppressWarnings, Test
+Cohesion: 0.10
+Nodes (14): IOSBasicInteractionsTest, ElementActions, Test_LTMobIPARelativePath, DynamicLoadingTest, AfterMethod, BeforeMethod, SuppressWarnings, Test (+6 more)
 
 ### Community 477 - "Community 477"
 Cohesion: 0.25
@@ -2569,7 +2581,7 @@ Cohesion: 0.25
 Nodes (7): Diagnosis, Evidence Index, Findings, Missing Evidence, Privacy, Remediation, SHAFT Doctor Report
 
 ### Community 480 - "Community 480"
-Cohesion: 0.20
+Cohesion: 0.17
 Nodes (6): Performance, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 481 - "Community 481"
@@ -2577,8 +2589,8 @@ Cohesion: 0.32
 Nodes (4): ValidationsExecutorTestAccessor, Object, ValidationsExecutor, WebDriver
 
 ### Community 482 - "Community 482"
-Cohesion: 0.31
-Nodes (4): ScreenshotHelper, Boolean, SuppressWarnings, WebDriver
+Cohesion: 0.26
+Nodes (5): HasCdp, ScreenshotHelper, Boolean, SuppressWarnings, WebDriver
 
 ### Community 483 - "Community 483"
 Cohesion: 0.33
@@ -2645,16 +2657,16 @@ Cohesion: 0.36
 Nodes (4): ShadowDOMTests, AfterMethod, BeforeMethod, Test
 
 ### Community 499 - "Community 499"
-Cohesion: 0.18
-Nodes (11): items, type, uniqueItems, minLength, pattern, type, applies_to, tags (+3 more)
+Cohesion: 0.25
+Nodes (8): items, minLength, pattern, type, tags, items, type, uniqueItems
 
 ### Community 501 - "Community 501"
-Cohesion: 0.48
-Nodes (3): OpenCvHealingVisualProviderTest, Color, Test
+Cohesion: 0.29
+Nodes (4): PlaywrightNaturalActionExecutorTest, AfterMethod, BeforeMethod, Test
 
 ### Community 502 - "Community 502"
-Cohesion: 0.25
-Nodes (6): WebDomHealingAcceptanceTest, AfterMethod, BeforeMethod, Path, String, Test
+Cohesion: 0.38
+Nodes (5): Locator, Beta, By, LocatorBuilder, String
 
 ### Community 504 - "Community 504"
 Cohesion: 0.36
@@ -2693,8 +2705,8 @@ Cohesion: 0.33
 Nodes (5): SynchronizationManager, Class, Exception, List, WebDriver
 
 ### Community 513 - "Community 513"
-Cohesion: 0.04
-Nodes (33): testPostRequest, SHAFT, FileInputStream, ApiAndRetainedSurfaceConsumer, AppiumMobileConsumer, BrowserStackSdkConsumer, LegacyCoordinateConsumer, IOException (+25 more)
+Cohesion: 0.07
+Nodes (19): testPostRequest, SHAFT, FileInputStream, AppiumMobileConsumer, BrowserStackSdkConsumer, LegacyCoordinateConsumer, $, IOException (+11 more)
 
 ### Community 514 - "Community 514"
 Cohesion: 0.43
@@ -2702,15 +2714,15 @@ Nodes (3): NaturalActionsTests, AfterMethod, Test
 
 ### Community 515 - "Community 515"
 Cohesion: 0.31
-Nodes (6): DriverFactoryHelper, AlertActions, Override, String, SuppressWarnings, WebDriver
+Nodes (5): EngineProperties, SetProperty, Object, SetProperty, String
 
 ### Community 516 - "Community 516"
 Cohesion: 0.29
 Nodes (6): additionalProperties, allOf, $id, required, $schema, type
 
 ### Community 517 - "Community 517"
-Cohesion: 0.29
-Nodes (5): AfterEach, BeforeAll, BeforeEach, Test, TestClass
+Cohesion: 0.07
+Nodes (18): PathParamTest, JunitApiSmokeTest, GraphqlRequestTests, AfterEach, BeforeAll, BeforeEach, Test, TestClass (+10 more)
 
 ### Community 518 - "Community 518"
 Cohesion: 0.29
@@ -2725,7 +2737,7 @@ Cohesion: 0.33
 Nodes (3): InputStream, String, DesktopVideoRecordingProvider
 
 ### Community 523 - "Community 523"
-Cohesion: 0.29
+Cohesion: 0.25
 Nodes (4): DatabaseActions, DB, DatabaseType, ResultSet
 
 ### Community 524 - "Community 524"
@@ -2744,12 +2756,16 @@ Nodes (3): BrowserAssertions, NativeValidationsBuilder, String
 Cohesion: 0.17
 Nodes (12): minLength, type, type, properties, bundleId, evidence, redaction, schemaVersion (+4 more)
 
+### Community 528 - "Community 528"
+Cohesion: 0.29
+Nodes (6): Properties, Class, Supplier, SuppressWarnings, T, ThreadLocal
+
 ### Community 529 - "Community 529"
-Cohesion: 0.33
-Nodes (4): DynamicLoadingTest, AfterMethod, BeforeMethod, Test
+Cohesion: 0.31
+Nodes (4): NoSuchElementFailureTest, AfterMethod, BeforeMethod, Test
 
 ### Community 530 - "Community 530"
-Cohesion: 0.40
+Cohesion: 0.39
 Nodes (5): HealerServiceTest, HealerService, Path, String, Test
 
 ### Community 531 - "Community 531"
@@ -2765,8 +2781,8 @@ Cohesion: 0.33
 Nodes (3): PrivacySanitizer, SanitizedValue, String
 
 ### Community 535 - "Community 535"
-Cohesion: 0.43
-Nodes (5): ClassLoader, OpenCvBlockingClassLoader, Class, Override, String
+Cohesion: 0.29
+Nodes (4): AfterMethod, String, Test, PropertiesHelperInitializationUnitTest
 
 ### Community 536 - "Community 536"
 Cohesion: 0.36
@@ -2775,6 +2791,10 @@ Nodes (4): HealingReportWriter, HealingConfiguration, HealingReport, String
 ### Community 538 - "Community 538"
 Cohesion: 0.36
 Nodes (4): SwitchToNewTabTest, AfterMethod, BeforeMethod, Test
+
+### Community 539 - "Community 539"
+Cohesion: 0.36
+Nodes (4): McpMobileToolchainServiceTest, McpMobileToolchainDiagnostic, McpMobileToolchainStatus, Test
 
 ### Community 540 - "Community 540"
 Cohesion: 0.47
@@ -2789,16 +2809,16 @@ Cohesion: 0.26
 Nodes (5): SmartLocatorsRealisticTests, Test, AfterClass, BeforeClass, TestScenario
 
 ### Community 543 - "Community 543"
-Cohesion: 0.38
-Nodes (4): JunitApiSmokeTest, AfterAll, BeforeAll, Test
+Cohesion: 0.31
+Nodes (6): RepairProcessRunner, Duration, List, Path, ProcessResult, String
 
 ### Community 544 - "Community 544"
 Cohesion: 0.47
 Nodes (3): PatternTests, BeforeClass, Test
 
 ### Community 545 - "Community 545"
-Cohesion: 0.31
-Nodes (3): Class, Test, GUIInterfaceCompatibilityCoverageUnitTest
+Cohesion: 0.39
+Nodes (4): JunitProjectStructureManagerTest, AfterEach, Path, Test
 
 ### Community 546 - "Community 546"
 Cohesion: 0.47
@@ -2813,16 +2833,16 @@ Cohesion: 0.41
 Nodes (7): BrowserNetworkInterceptionRule, Consumer, Function, HttpRequest, HttpResponse, Predicate, Response
 
 ### Community 549 - "Community 549"
-Cohesion: 0.29
-Nodes (3): EngineServiceTest, AfterEach, Test
+Cohesion: 0.39
+Nodes (3): AssertEqualsTests, BeforeMethod, Test
 
 ### Community 550 - "Community 550"
 Cohesion: 0.47
 Nodes (3): WebTests, BeforeClass, Test
 
 ### Community 551 - "Community 551"
-Cohesion: 0.13
-Nodes (11): Callable, FilesSize, DeterministicNaturalActionPlannerTest, Path, Test, NaturalActionRequest, String, Test (+3 more)
+Cohesion: 0.17
+Nodes (9): Callable, FilesSize, DeterministicNaturalActionPlannerTest, Path, Test, NaturalActionRequest, String, Test (+1 more)
 
 ### Community 552 - "Community 552"
 Cohesion: 0.40
@@ -2833,16 +2853,16 @@ Cohesion: 0.42
 Nodes (5): ClassifiedValue, Collection, Path, String, ExternalTestDataWriter
 
 ### Community 555 - "Community 555"
-Cohesion: 0.50
-Nodes (3): Source-file rewrites prepared for session or full upgrades., Return source files whose contents should be replaced., SourceMigration
+Cohesion: 0.36
+Nodes (4): AfterMethod, BeforeMethod, Test, FlagsSetPropertyCoverageUnitTest
 
 ### Community 556 - "Community 556"
 Cohesion: 0.60
 Nodes (3): AbstractTestNGCucumberTests, CucumberTests, CucumberTests
 
 ### Community 557 - "Community 557"
-Cohesion: 0.31
-Nodes (4): LocalApiTestServer, HttpExchange, HttpServer, String
+Cohesion: 0.38
+Nodes (3): PlaywrightBrowserActionsUnitTest, PlaywrightNetworkInterceptor, Test
 
 ### Community 558 - "Community 558"
 Cohesion: 0.60
@@ -2853,16 +2873,20 @@ Cohesion: 0.27
 Nodes (8): AiBudget, defaults(), disabled(), defaults(), ApprovalPolicy, DoctorAiAnalysisRequest, ApprovalPolicy, DoctorRepairAiRequest
 
 ### Community 562 - "Community 562"
-Cohesion: 0.31
-Nodes (4): SelectedValueTests, AfterMethod, BeforeMethod, Test
+Cohesion: 0.33
+Nodes (6): Metadata, asCacheHit(), disabled(), empty(), DoctorAdvisory, ProviderAnalysis
 
 ### Community 563 - "Community 563"
 Cohesion: 0.43
 Nodes (3): HealingTests, AfterMethod, Test
 
 ### Community 564 - "Community 564"
-Cohesion: 0.17
-Nodes (9): reviewPath(), reviewUiPath(), Path, CaptureGenerationReport, CaptureGenerationResult, CaptureReview, JsonNode, Object (+1 more)
+Cohesion: 0.33
+Nodes (4): CaptureFormatException, String, Throwable, IllegalArgumentException
+
+### Community 565 - "Community 565"
+Cohesion: 0.24
+Nodes (5): BomConsumer, OpenCvVisualConsumer, String, String, VisualProcessingProvider
 
 ### Community 566 - "Community 566"
 Cohesion: 0.22
@@ -2877,8 +2901,8 @@ Cohesion: 0.60
 Nodes (4): copy(), text(), List, String
 
 ### Community 569 - "Community 569"
-Cohesion: 0.14
-Nodes (11): ready(), unavailable(), DisabledAiProvider, AiProviderAvailability, String, AiCapabilities, AiProviderAvailability, AiRequest (+3 more)
+Cohesion: 0.33
+Nodes (4): CucumberHelper, List, Status, XmlSuite
 
 ### Community 570 - "Community 570"
 Cohesion: 0.60
@@ -2909,8 +2933,8 @@ Cohesion: 0.32
 Nodes (8): IssueReporter, Boolean, ITestNGMethod, ITestResult, List, Method, String, TestExecutionInfo
 
 ### Community 579 - "Community 579"
-Cohesion: 0.40
-Nodes (4): ElementAssertions, Locator, PlaywrightSession, ValidationCategory
+Cohesion: 0.47
+Nodes (3): MultipleBrowserInstancesTest, AfterMethod, Test
 
 ### Community 580 - "Community 580"
 Cohesion: 0.50
@@ -2925,8 +2949,8 @@ Cohesion: 0.47
 Nodes (3): JunitCoreAssertionDependencyGuardTest, Path, Test
 
 ### Community 586 - "Community 586"
-Cohesion: 0.27
-Nodes (9): agent_upgrade_plan(), ProjectAnalysis, Return whether source rewrites are eligible for this project., Validate the requested upgrade type against the detected project shape., Return a machine-readable upgrade menu for AI agents., Detected Maven project shape and requested SHAFT migration., Return optional modules supported by scan evidence., source_upgrade_supported() (+1 more)
+Cohesion: 0.15
+Nodes (21): agent_upgrade_plan(), collect_source_migration(), ensure_shaft_import(), migrate_full_source(), migrate_session_source(), ProjectAnalysis, Return whether source rewrites are eligible for this project., Validate the requested upgrade type against the detected project shape. (+13 more)
 
 ### Community 587 - "Community 587"
 Cohesion: 0.29
@@ -2940,9 +2964,13 @@ Nodes (3): HealeniumTests, BeforeClass, Test
 Cohesion: 0.50
 Nodes (3): { Client }, pgclient, values
 
+### Community 594 - "Community 594"
+Cohesion: 0.47
+Nodes (3): PathsTests, BeforeClass, Test
+
 ### Community 597 - "Community 597"
 Cohesion: 0.47
-Nodes (3): PlatformTests, BeforeClass, Test
+Nodes (3): TinkeyTests, BeforeClass, Test
 
 ### Community 599 - "Community 599"
 Cohesion: 0.47
@@ -2964,6 +2992,10 @@ Nodes (3): enum, type, category
 Cohesion: 0.67
 Nodes (3): minLength, type, id
 
+### Community 615 - "Community 615"
+Cohesion: 0.33
+Nodes (3): AfterMethod, BeforeMethod, CSVFileManager
+
 ### Community 616 - "Community 616"
 Cohesion: 0.67
 Nodes (3): sha256, minLength, type
@@ -2981,32 +3013,28 @@ Cohesion: 0.40
 Nodes (3): DoctorFormatException, String, Throwable
 
 ### Community 650 - "Community 650"
-Cohesion: 0.12
-Nodes (16): AllureVerdict, Operation, PatchManifestEntry, changedSince(), RepairGuard, RepairProposalStore, AllureSnapshot, Diagnosis (+8 more)
+Cohesion: 0.47
+Nodes (3): MobileTests, BeforeClass, Test
 
 ### Community 651 - "Community 651"
-Cohesion: 0.50
-Nodes (3): By, Locator, Page
+Cohesion: 0.53
+Nodes (3): RepairProposalStore, Path, RepairProposal
 
 ### Community 653 - "Community 653"
 Cohesion: 0.36
 Nodes (3): ProjectStructureManager, Path, RunType
 
-### Community 654 - "Community 654"
-Cohesion: 0.24
-Nodes (6): LogRedirector, Logger, LocatorOperation, Level, Override, By
-
 ### Community 656 - "Community 656"
-Cohesion: 0.31
-Nodes (5): ElementActions, RelativeLocatorsTests, AfterMethod, BeforeMethod, Test
+Cohesion: 0.36
+Nodes (4): RelativeLocatorsTests, AfterMethod, BeforeMethod, Test
 
 ### Community 658 - "Community 658"
-Cohesion: 0.36
-Nodes (4): Test_LTMobIPARelativePath, AfterMethod, BeforeMethod, Test
+Cohesion: 0.67
+Nodes (3): safe(), stableKey(), String
 
 ### Community 676 - "Community 676"
-Cohesion: 0.21
-Nodes (7): AccessibilityActions, AccessibilityConfig, AccessibilityResult, BrowserActions, List, String, WebDriver
+Cohesion: 0.11
+Nodes (17): AccessibilityActions, AccessibilityConfig, AccessibilityResult, BrowserActions, BrowserActionsContract, List, Page, String (+9 more)
 
 ### Community 758 - "Community 758"
 Cohesion: 0.33
@@ -3017,16 +3045,20 @@ Cohesion: 0.36
 Nodes (3): PlaywrightMobileWebE2ETestBase, String, Test
 
 ### Community 760 - "Community 760"
-Cohesion: 0.20
-Nodes (6): JunitDatabaseSmokeTest, DatabaseType, String, AfterAll, BeforeAll, Test
+Cohesion: 0.33
+Nodes (4): JunitDatabaseSmokeTest, AfterAll, BeforeAll, Test
+
+### Community 763 - "Community 763"
+Cohesion: 0.50
+Nodes (4): parse_xml(), Enforce the modular SHAFT dependency contract after every repair., Parse XML while preserving comments., validate_upgraded_poms()
 
 ### Community 766 - "Community 766"
-Cohesion: 0.50
+Cohesion: 0.52
 Nodes (3): CaptureRuntimePortabilityTest, Path, Test
 
 ### Community 768 - "Community 768"
-Cohesion: 0.17
-Nodes (13): FakeRunner, McpMobileToolchainServiceTest, Duration, List, Map, McpMobileToolchainDiagnostic, McpMobileToolchainStatus, Override (+5 more)
+Cohesion: 0.30
+Nodes (9): FakeRunner, Duration, List, Map, Override, Path, Process, ProcessResult (+1 more)
 
 ### Community 771 - "Community 771"
 Cohesion: 0.47
@@ -3052,10 +3084,6 @@ Nodes (3): Path, Test, ExecutionLifecycleHelperSourceUnitTest
 Cohesion: 0.29
 Nodes (5): AfterMethod, BeforeClass, BeforeMethod, Test, TestClass
 
-### Community 784 - "Community 784"
-Cohesion: 0.33
-Nodes (3): ShaftHeal, HealingReport, Optional
-
 ### Community 785 - "Community 785"
 Cohesion: 0.29
 Nodes (7): enum, updateRelation, confidence, additionalProperties, properties, required, type
@@ -3065,16 +3093,12 @@ Cohesion: 0.40
 Nodes (4): MultipleElementsFoundException, String, Throwable, WebDriverException
 
 ### Community 787 - "Community 787"
-Cohesion: 0.16
-Nodes (14): limiterKey(), RemoteGridPreflight, unavailable(), PreflightReport, Semaphore, SessionPermit, Capabilities, Duration (+6 more)
+Cohesion: 0.14
+Nodes (16): limiterKey(), RemoteGridPreflight, SessionPermit, unavailable(), PreflightReport, Semaphore, SessionPermit, Capabilities (+8 more)
 
 ### Community 789 - "Community 789"
-Cohesion: 0.15
-Nodes (9): FileActionsCoverageUnitTest, FileActionsReflectionInvoker, JarEntry, AfterMethod, Path, String, Test, FileActions (+1 more)
-
-### Community 799 - "Community 799"
-Cohesion: 0.50
-Nodes (3): McpMobileToolchainService, McpMobileRecordingService, McpWorkspacePolicy
+Cohesion: 0.33
+Nodes (3): FileActionsReflectionInvoker, FileActions, String
 
 ### Community 800 - "Community 800"
 Cohesion: 0.47
@@ -3097,24 +3121,24 @@ Cohesion: 0.67
 Nodes (3): minLength, type, mediaType
 
 ## Knowledge Gaps
-- **1461 isolated node(s):** `$id`, `$schema`, `additionalProperties`, `additionalProperties`, `type` (+1456 more)
+- **1470 isolated node(s):** `$id`, `$schema`, `additionalProperties`, `additionalProperties`, `type` (+1465 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **96 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **85 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `SHAFT` connect `Community 513` to `Community 512`, `Community 2`, `Community 3`, `Community 514`, `Community 5`, `Community 517`, `Community 7`, `Community 8`, `Community 9`, `Community 10`, `Community 12`, `Community 13`, `Community 16`, `Community 17`, `Community 18`, `Community 529`, `Community 19`, `Community 21`, `Community 22`, `Community 23`, `Community 24`, `Community 26`, `Community 538`, `Community 27`, `Community 540`, `Community 30`, `Community 31`, `Community 543`, `Community 33`, `Community 34`, `Community 35`, `Community 36`, `Community 37`, `Community 547`, `Community 544`, `Community 550`, `Community 32`, `Community 545`, `Community 43`, `Community 39`, `Community 45`, `Community 46`, `Community 47`, `Community 551`, `Community 49`, `Community 562`, `Community 51`, `Community 52`, `Community 53`, `Community 566`, `Community 55`, `Community 563`, `Community 57`, `Community 565`, `Community 65`, `Community 69`, `Community 71`, `Community 74`, `Community 587`, `Community 76`, `Community 588`, `Community 81`, `Community 597`, `Community 86`, `Community 599`, `Community 88`, `Community 89`, `Community 87`, `Community 93`, `Community 95`, `Community 96`, `Community 98`, `Community 99`, `Community 615`, `Community 104`, `Community 103`, `Community 106`, `Community 108`, `Community 109`, `Community 621`, `Community 114`, `Community 116`, `Community 121`, `Community 123`, `Community 125`, `Community 130`, `Community 134`, `Community 138`, `Community 28`, `Community 142`, `Community 654`, `Community 656`, `Community 657`, `Community 658`, `Community 151`, `Community 156`, `Community 161`, `Community 541`, `Community 162`, `Community 676`, `Community 165`, `Community 167`, `Community 542`, `Community 169`, `Community 170`, `Community 172`, `Community 173`, `Community 174`, `Community 184`, `Community 186`, `Community 546`, `Community 191`, `Community 38`, `Community 199`, `Community 205`, `Community 210`, `Community 211`, `Community 212`, `Community 217`, `Community 218`, `Community 219`, `Community 222`, `Community 225`, `Community 226`, `Community 230`, `Community 240`, `Community 241`, `Community 247`, `Community 760`, `Community 251`, `Community 254`, `Community 257`, `Community 770`, `Community 771`, `Community 260`, `Community 261`, `Community 266`, `Community 269`, `Community 782`, `Community 270`, `Community 781`, `Community 273`, `Community 274`, `Community 787`, `Community 788`, `Community 789`, `Community 275`, `Community 276`, `Community 279`, `Community 281`, `Community 277`, `Community 284`, `Community 285`, `Community 286`, `Community 287`, `Community 290`, `Community 293`, `Community 295`, `Community 812`, `Community 301`, `Community 815`, `Community 306`, `Community 311`, `Community 327`, `Community 328`, `Community 329`, `Community 336`, `Community 337`, `Community 340`, `Community 342`, `Community 346`, `Community 347`, `Community 348`, `Community 358`, `Community 359`, `Community 360`, `Community 362`, `Community 364`, `Community 367`, `Community 370`, `Community 373`, `Community 378`, `Community 379`, `Community 380`, `Community 381`, `Community 382`, `Community 389`, `Community 390`, `Community 391`, `Community 392`, `Community 395`, `Community 398`, `Community 399`, `Community 401`, `Community 403`, `Community 404`, `Community 405`, `Community 407`, `Community 408`, `Community 409`, `Community 411`, `Community 412`, `Community 413`, `Community 417`, `Community 424`, `Community 425`, `Community 428`, `Community 429`, `Community 430`, `Community 431`, `Community 432`, `Community 444`, `Community 446`, `Community 450`, `Community 451`, `Community 452`, `Community 454`, `Community 455`, `Community 456`, `Community 460`, `Community 461`, `Community 463`, `Community 468`, `Community 470`, `Community 473`, `Community 476`, `Community 484`, `Community 485`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 493`, `Community 494`, `Community 496`, `Community 498`, `Community 502`, `Community 503`, `Community 504`, `Community 506`, `Community 509`, `Community 510`, `Community 511`?**
-  _High betweenness centrality (0.129) - this node is a cross-community bridge._
-- **Why does `IOException` connect `Community 513` to `Community 5`, `Community 7`, `Community 8`, `Community 13`, `Community 19`, `Community 24`, `Community 536`, `Community 29`, `Community 30`, `Community 31`, `Community 553`, `Community 41`, `Community 557`, `Community 49`, `Community 56`, `Community 57`, `Community 60`, `Community 61`, `Community 62`, `Community 64`, `Community 71`, `Community 584`, `Community 72`, `Community 74`, `Community 76`, `Community 79`, `Community 85`, `Community 86`, `Community 87`, `Community 102`, `Community 105`, `Community 116`, `Community 117`, `Community 122`, `Community 130`, `Community 131`, `Community 133`, `Community 137`, `Community 138`, `Community 650`, `Community 653`, `Community 141`, `Community 147`, `Community 148`, `Community 154`, `Community 156`, `Community 169`, `Community 170`, `Community 175`, `Community 179`, `Community 185`, `Community 189`, `Community 209`, `Community 216`, `Community 218`, `Community 220`, `Community 223`, `Community 226`, `Community 233`, `Community 238`, `Community 239`, `Community 241`, `Community 244`, `Community 253`, `Community 273`, `Community 787`, `Community 789`, `Community 277`, `Community 279`, `Community 288`, `Community 294`, `Community 299`, `Community 304`, `Community 307`, `Community 313`, `Community 314`, `Community 321`, `Community 328`, `Community 333`, `Community 340`, `Community 347`, `Community 351`, `Community 363`, `Community 370`, `Community 392`, `Community 402`, `Community 406`, `Community 410`, `Community 412`, `Community 418`, `Community 428`, `Community 452`, `Community 453`, `Community 455`, `Community 467`, `Community 502`, `Community 506`?**
-  _High betweenness centrality (0.027) - this node is a cross-community bridge._
-- **Why does `ArrayList` connect `Community 413` to `Community 512`, `Community 513`, `Community 3`, `Community 7`, `Community 9`, `Community 10`, `Community 13`, `Community 14`, `Community 19`, `Community 28`, `Community 34`, `Community 35`, `Community 38`, `Community 551`, `Community 39`, `Community 41`, `Community 45`, `Community 49`, `Community 56`, `Community 59`, `Community 60`, `Community 62`, `Community 64`, `Community 578`, `Community 74`, `Community 76`, `Community 85`, `Community 87`, `Community 88`, `Community 90`, `Community 93`, `Community 95`, `Community 98`, `Community 109`, `Community 111`, `Community 116`, `Community 117`, `Community 118`, `Community 130`, `Community 132`, `Community 137`, `Community 650`, `Community 141`, `Community 143`, `Community 147`, `Community 148`, `Community 150`, `Community 152`, `Community 154`, `Community 156`, `Community 157`, `Community 162`, `Community 676`, `Community 176`, `Community 178`, `Community 179`, `Community 180`, `Community 185`, `Community 198`, `Community 200`, `Community 209`, `Community 217`, `Community 220`, `Community 222`, `Community 232`, `Community 233`, `Community 236`, `Community 253`, `Community 254`, `Community 255`, `Community 768`, `Community 259`, `Community 268`, `Community 273`, `Community 285`, `Community 294`, `Community 322`, `Community 333`, `Community 340`, `Community 342`, `Community 374`, `Community 377`, `Community 379`, `Community 404`, `Community 410`?**
-  _High betweenness centrality (0.011) - this node is a cross-community bridge._
+- **Why does `SHAFT` connect `Community 513` to `Community 512`, `Community 2`, `Community 514`, `Community 3`, `Community 517`, `Community 5`, `Community 8`, `Community 9`, `Community 10`, `Community 523`, `Community 12`, `Community 13`, `Community 16`, `Community 17`, `Community 18`, `Community 529`, `Community 19`, `Community 21`, `Community 22`, `Community 23`, `Community 24`, `Community 26`, `Community 538`, `Community 27`, `Community 540`, `Community 30`, `Community 31`, `Community 541`, `Community 33`, `Community 34`, `Community 35`, `Community 36`, `Community 545`, `Community 547`, `Community 544`, `Community 550`, `Community 39`, `Community 42`, `Community 43`, `Community 555`, `Community 45`, `Community 46`, `Community 47`, `Community 48`, `Community 49`, `Community 51`, `Community 52`, `Community 53`, `Community 566`, `Community 55`, `Community 563`, `Community 57`, `Community 569`, `Community 565`, `Community 65`, `Community 579`, `Community 69`, `Community 71`, `Community 74`, `Community 587`, `Community 588`, `Community 76`, `Community 80`, `Community 81`, `Community 594`, `Community 84`, `Community 597`, `Community 86`, `Community 599`, `Community 88`, `Community 89`, `Community 87`, `Community 93`, `Community 95`, `Community 96`, `Community 98`, `Community 99`, `Community 103`, `Community 104`, `Community 106`, `Community 108`, `Community 621`, `Community 114`, `Community 116`, `Community 121`, `Community 123`, `Community 125`, `Community 130`, `Community 134`, `Community 137`, `Community 138`, `Community 650`, `Community 28`, `Community 142`, `Community 656`, `Community 657`, `Community 151`, `Community 156`, `Community 161`, `Community 162`, `Community 676`, `Community 165`, `Community 167`, `Community 542`, `Community 169`, `Community 170`, `Community 172`, `Community 173`, `Community 174`, `Community 179`, `Community 184`, `Community 186`, `Community 546`, `Community 191`, `Community 38`, `Community 194`, `Community 199`, `Community 40`, `Community 205`, `Community 206`, `Community 210`, `Community 211`, `Community 212`, `Community 217`, `Community 218`, `Community 219`, `Community 222`, `Community 225`, `Community 226`, `Community 230`, `Community 240`, `Community 241`, `Community 753`, `Community 247`, `Community 760`, `Community 251`, `Community 254`, `Community 257`, `Community 770`, `Community 771`, `Community 772`, `Community 261`, `Community 260`, `Community 266`, `Community 781`, `Community 782`, `Community 271`, `Community 270`, `Community 273`, `Community 274`, `Community 275`, `Community 787`, `Community 276`, `Community 279`, `Community 284`, `Community 285`, `Community 286`, `Community 290`, `Community 293`, `Community 295`, `Community 812`, `Community 301`, `Community 311`, `Community 312`, `Community 327`, `Community 328`, `Community 329`, `Community 336`, `Community 337`, `Community 340`, `Community 342`, `Community 346`, `Community 347`, `Community 348`, `Community 351`, `Community 359`, `Community 360`, `Community 362`, `Community 364`, `Community 367`, `Community 370`, `Community 373`, `Community 378`, `Community 379`, `Community 380`, `Community 381`, `Community 382`, `Community 389`, `Community 390`, `Community 391`, `Community 392`, `Community 395`, `Community 398`, `Community 399`, `Community 401`, `Community 403`, `Community 404`, `Community 405`, `Community 407`, `Community 408`, `Community 409`, `Community 411`, `Community 417`, `Community 424`, `Community 425`, `Community 427`, `Community 428`, `Community 429`, `Community 430`, `Community 431`, `Community 432`, `Community 434`, `Community 436`, `Community 446`, `Community 450`, `Community 451`, `Community 454`, `Community 455`, `Community 456`, `Community 460`, `Community 461`, `Community 463`, `Community 468`, `Community 470`, `Community 471`, `Community 473`, `Community 476`, `Community 482`, `Community 484`, `Community 485`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 493`, `Community 494`, `Community 496`, `Community 498`, `Community 503`, `Community 504`, `Community 506`, `Community 509`, `Community 510`, `Community 511`?**
+  _High betweenness centrality (0.122) - this node is a cross-community bridge._
+- **Why does `IOException` connect `Community 513` to `Community 517`, `Community 5`, `Community 8`, `Community 18`, `Community 19`, `Community 535`, `Community 24`, `Community 536`, `Community 25`, `Community 29`, `Community 30`, `Community 31`, `Community 543`, `Community 33`, `Community 545`, `Community 553`, `Community 42`, `Community 41`, `Community 49`, `Community 56`, `Community 57`, `Community 60`, `Community 61`, `Community 62`, `Community 64`, `Community 71`, `Community 584`, `Community 72`, `Community 74`, `Community 76`, `Community 79`, `Community 84`, `Community 85`, `Community 86`, `Community 87`, `Community 102`, `Community 105`, `Community 116`, `Community 117`, `Community 122`, `Community 130`, `Community 131`, `Community 133`, `Community 138`, `Community 651`, `Community 653`, `Community 141`, `Community 148`, `Community 151`, `Community 154`, `Community 156`, `Community 169`, `Community 170`, `Community 179`, `Community 185`, `Community 189`, `Community 209`, `Community 212`, `Community 216`, `Community 218`, `Community 220`, `Community 223`, `Community 226`, `Community 233`, `Community 238`, `Community 239`, `Community 241`, `Community 244`, `Community 251`, `Community 259`, `Community 273`, `Community 275`, `Community 787`, `Community 277`, `Community 279`, `Community 288`, `Community 294`, `Community 299`, `Community 307`, `Community 312`, `Community 313`, `Community 314`, `Community 321`, `Community 328`, `Community 340`, `Community 347`, `Community 358`, `Community 363`, `Community 370`, `Community 392`, `Community 406`, `Community 410`, `Community 418`, `Community 428`, `Community 453`, `Community 455`, `Community 467`, `Community 482`, `Community 506`?**
+  _High betweenness centrality (0.024) - this node is a cross-community bridge._
+- **Why does `ArrayList` connect `Community 222` to `Community 512`, `Community 513`, `Community 3`, `Community 5`, `Community 9`, `Community 10`, `Community 14`, `Community 18`, `Community 19`, `Community 25`, `Community 34`, `Community 35`, `Community 38`, `Community 551`, `Community 39`, `Community 41`, `Community 42`, `Community 45`, `Community 49`, `Community 56`, `Community 59`, `Community 60`, `Community 62`, `Community 64`, `Community 578`, `Community 579`, `Community 74`, `Community 76`, `Community 85`, `Community 87`, `Community 88`, `Community 90`, `Community 93`, `Community 95`, `Community 98`, `Community 99`, `Community 111`, `Community 117`, `Community 118`, `Community 130`, `Community 131`, `Community 132`, `Community 141`, `Community 143`, `Community 147`, `Community 148`, `Community 150`, `Community 152`, `Community 154`, `Community 156`, `Community 157`, `Community 162`, `Community 676`, `Community 176`, `Community 178`, `Community 179`, `Community 180`, `Community 185`, `Community 198`, `Community 200`, `Community 209`, `Community 212`, `Community 220`, `Community 232`, `Community 233`, `Community 254`, `Community 255`, `Community 768`, `Community 264`, `Community 268`, `Community 273`, `Community 285`, `Community 294`, `Community 312`, `Community 322`, `Community 333`, `Community 340`, `Community 374`, `Community 377`, `Community 379`, `Community 404`, `Community 410`, `Community 413`?**
+  _High betweenness centrality (0.024) - this node is a cross-community bridge._
 - **What connects `$id`, `$schema`, `additionalProperties` to the rest of the system?**
-  _1572 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _1581 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.04067691352274492 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.042869057547956634 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
   _Cohesion score 0.05764411027568922 - nodes in this community are weakly interconnected._
-- **Should `Community 2` be split into smaller, more focused modules?**
-  _Cohesion score 0.08599033816425121 - nodes in this community are weakly interconnected._
+- **Should `Community 3` be split into smaller, more focused modules?**
+  _Cohesion score 0.11734693877551021 - nodes in this community are weakly interconnected._

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -865,8 +865,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/RequestBuilder.java": {
-    "mtime": 1782366241.6864882,
-    "ast_hash": "a391eb6cd3477dbd7e94671df3345627",
+    "mtime": 1782390774.1024733,
+    "ast_hash": "026e5a96dea31eefdd2f1b7cb462dce3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/RestActions.java": {
@@ -915,8 +915,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/SHAFT.java": {
-    "mtime": 1782366241.6924882,
-    "ast_hash": "9344ce8732a32bde8190cbc5ab5a330a",
+    "mtime": 1782390779.3318734,
+    "ast_hash": "c7b3d0ecd58d95e96a22c90b49cedc1c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/$.java": {
@@ -980,8 +980,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java": {
-    "mtime": 1782370828.8744853,
-    "ast_hash": "db64884deecb156551da6da667717135",
+    "mtime": 1782391052.9710565,
+    "ast_hash": "5886142b6aa60d1535af92ee6de6880c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserActionsHelper.java": {
@@ -1045,8 +1045,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingManager.java": {
-    "mtime": 1782387711.7418075,
-    "ast_hash": "1ff051e7a494337aa08650d7e0eefb41",
+    "mtime": 1782390195.7892954,
+    "ast_hash": "c5e38dd4184e53deeccad977f263fb31",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingObservation.java": {
@@ -1180,8 +1180,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionRequest.java": {
-    "mtime": 1781592922.4656246,
-    "ast_hash": "51e484221eb6defbd218ade0eb1dea84",
+    "mtime": 1782390773.1657667,
+    "ast_hash": "2ad307bad42953fdd05d99a5bf731d83",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionStep.java": {
@@ -1355,8 +1355,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Performance.java": {
-    "mtime": 1781642509.8013947,
-    "ast_hash": "793bb90128693e92514e59175322965c",
+    "mtime": 1782391691.8826587,
+    "ast_hash": "73236560ea0e5920cdae7f1c4e72320c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Pilot.java": {
@@ -1385,8 +1385,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Reporting.java": {
-    "mtime": 1782387615.2501464,
-    "ast_hash": "d11252b0f2bd76c5d938d34a9d86b520",
+    "mtime": 1782390195.7912948,
+    "ast_hash": "beedf3b260a46f82e2edf4643e9cbd44",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/TestNG.java": {
@@ -1450,8 +1450,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/PerformanceReportHTMLHelper.java": {
-    "mtime": 1781170594.9127493,
-    "ast_hash": "88c165d5f2804d620f65e01921143f9e",
+    "mtime": 1782390774.1044676,
+    "ast_hash": "08d2c3d963bce92b0831e4090cc10d28",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/tms/XrayIntegrationHelper.java": {
@@ -1495,8 +1495,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ApiPerformanceExecutionReport.java": {
-    "mtime": 1781170594.9217446,
-    "ast_hash": "0e913480d5e37f16c5547a28cbb78efe",
+    "mtime": 1782390865.2850778,
+    "ast_hash": "b658cb318e031bfffb318b359985de78",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/AttachmentReporter.java": {
@@ -1570,13 +1570,13 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/accessibility/AccessibilityActions.java": {
-    "mtime": 1782031831.366623,
-    "ast_hash": "e95213311dd416f0935f0b258beacfb8",
+    "mtime": 1782391326.6258557,
+    "ast_hash": "b9a0cd12e9e42adeeb7f199d3cc81bf1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/accessibility/AccessibilityHelper.java": {
-    "mtime": 1781642509.8170524,
-    "ast_hash": "ef3e9bfa56f456c0c36ed15424404f66",
+    "mtime": 1782390994.6844823,
+    "ast_hash": "1f2f6e4889de51fb551d23ba846398d7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/CustomSoftAssert.java": {
@@ -2650,8 +2650,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AccessibilityActionsCoverageUnitTest.java": {
-    "mtime": 1782031831.379134,
-    "ast_hash": "90607ccef1dfc5153c1637b8ae62b2bb",
+    "mtime": 1782391007.0779462,
+    "ast_hash": "5ef524e7af8b423ad5dcc021440b1178",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AlertActionsCoverageUnitTest.java": {
@@ -3410,8 +3410,8 @@
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpDoctorRemediationService.java": {
-    "mtime": 1782034559.0407577,
-    "ast_hash": "76eae279c2d20a8b511e21c2bace8e5d",
+    "mtime": 1782390711.8490458,
+    "ast_hash": "c0b4fb6dbbf7de341b423e0014028885",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileAccessibilityTree.java": {
@@ -3515,8 +3515,8 @@
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/DoctorServiceTest.java": {
-    "mtime": 1782366241.9015481,
-    "ast_hash": "2b447d8c91aeee9224855926acd98644",
+    "mtime": 1782390620.9390602,
+    "ast_hash": "bf9e0898d1bbda43759939baf1b91f7c",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/EngineServiceRuntimePathTest.java": {
@@ -4925,8 +4925,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/ExecutionLifecycleHelper.java": {
-    "mtime": 1782387338.7194672,
-    "ast_hash": "2f8575b322aa6a689d2192d5fbdddf85",
+    "mtime": 1782391703.3535008,
+    "ast_hash": "7a6076418250b9be54b0447a0ff60857",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/TestExecutionInfo.java": {
@@ -5050,8 +5050,8 @@
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/HealerServiceTest.java": {
-    "mtime": 1781887374.8212037,
-    "ast_hash": "7fc7b412d1226508622d107eb735a350",
+    "mtime": 1782390625.7876518,
+    "ast_hash": "a0ecf984348492f8d718d3bf38e2ca14",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/use-official-docs-search-index-for-shaft-mcp-guide-search.md": {
@@ -5060,8 +5060,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/NetworkInterceptionRequestBuilder.java": {
-    "mtime": 1782031831.4071338,
-    "ast_hash": "ca69b6efe17fef8a8fd976978f5b0564",
+    "mtime": 1782391257.0299006,
+    "ast_hash": "e96f8dbc4f73cf4028eb21c2d7903aac",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserNetworkInterceptionRule.java": {
@@ -5240,8 +5240,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/browser/BrowserActions.java": {
-    "mtime": 1782370828.8764803,
-    "ast_hash": "2c028893ccf6c5825464e545ab079836",
+    "mtime": 1782391735.6521275,
+    "ast_hash": "6780c491232e64a9e9b2f7bef838eeb2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/element/AlertActions.java": {
@@ -5250,13 +5250,13 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/element/ElementActions.java": {
-    "mtime": 1782366241.709482,
-    "ast_hash": "03f8230f6ca0d6bf117592f2f51429a4",
+    "mtime": 1782391769.3275943,
+    "ast_hash": "406faf00211b31ff5d43d201f9d3ab5c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSession.java": {
-    "mtime": 1782033944.5476525,
-    "ast_hash": "3fb54fd5efb353a3f7093a2852baef82",
+    "mtime": 1782390821.7855246,
+    "ast_hash": "70aea2a7bb2d51a57cbcdeec8b3d032f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSessionFactory.java": {
@@ -5455,8 +5455,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightValidationsExecutor.java": {
-    "mtime": 1782370828.8784857,
-    "ast_hash": "7ba92ec52f259752bb2c7d3a2d6924d7",
+    "mtime": 1782391777.5052974,
+    "ast_hash": "1ac6aa58d118ca6a9b324f7992f37281",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_documentation_boundaries.py": {
@@ -5570,13 +5570,13 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/LocatorHealthReporter.java": {
-    "mtime": 1782388252.291893,
-    "ast_hash": "5453e2322cc281eafdbdff39ce3002ff",
+    "mtime": 1782390195.7902973,
+    "ast_hash": "05da6d02f7407a0794e31b06594e2fb7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/locator/LocatorHealthReporterUnitTest.java": {
-    "mtime": 1782387538.6601994,
-    "ast_hash": "000e62d76d496630140e9844cd5ea049",
+    "mtime": 1782390195.792295,
+    "ast_hash": "15b91fc645796993b379e7a73a3998ae",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ExecutionLifecycleHelperSourceUnitTest.java": {
@@ -5595,13 +5595,13 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureTraceReporter.java": {
-    "mtime": 1782388252.2928977,
-    "ast_hash": "c9be015fffbaa442a556ce81fc2ab32d",
+    "mtime": 1782390195.7912948,
+    "ast_hash": "141c28662dbd79cbab6ab4011c9f1340",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/FailureTraceReporterTest.java": {
-    "mtime": 1782388194.0539734,
-    "ast_hash": "70174e37f9aeaa49cf5879aafae4c608",
+    "mtime": 1782390195.7932951,
+    "ast_hash": "56741505fb3243c3e401c773d6f44f04",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureDiagnosticsReporter.java": {
@@ -5632,6 +5632,371 @@
   "shaft-doctor/allure-results/0f2c181c-7932-465a-bb44-58634e8d3275-attachment.txt": {
     "mtime": 1782379219.0352633,
     "ast_hash": "70524e41adaa390f239432c99a4d0d9b",
+    "semantic_hash": ""
+  },
+  "shaft-engine/src/main/java/com/shaft/gui/browser/internal/PlaywrightNetworkInterceptor.java": {
+    "mtime": 1782390814.2865374,
+    "ast_hash": "9d48a4680b53d71ff10a7cfb0f16582b",
+    "semantic_hash": ""
+  },
+  "shaft-engine/src/main/java/com/shaft/gui/internal/natural/PlaywrightNaturalActionExecutor.java": {
+    "mtime": 1782391785.1608503,
+    "ast_hash": "436d23e8309b569fab861eae0d63bdef",
+    "semantic_hash": ""
+  },
+  "shaft-engine/src/main/java/com/shaft/tools/io/internal/BrowserPerformanceExecutionReport.java": {
+    "mtime": 1782391676.2416444,
+    "ast_hash": "6088162d77c0efd6cbb9025b88730f4d",
+    "semantic_hash": ""
+  },
+  "shaft-engine/src/test/java/com/shaft/api/RequestBuilderPerformanceTest.java": {
+    "mtime": 1782390647.515623,
+    "ast_hash": "4939b26736a23734773e4dec0a862526",
+    "semantic_hash": ""
+  },
+  "shaft-engine/src/test/java/com/shaft/gui/browser/internal/PlaywrightNetworkInterceptorTest.java": {
+    "mtime": 1782390698.0809205,
+    "ast_hash": "247af7a12e04cc46c11c87a916381387",
+    "semantic_hash": ""
+  },
+  "shaft-engine/src/test/java/com/shaft/gui/internal/natural/PlaywrightNaturalActionExecutorTest.java": {
+    "mtime": 1782390698.0789213,
+    "ast_hash": "d0f94478647b2d5ad9221622cc60862e",
+    "semantic_hash": ""
+  },
+  "shaft-engine/src/test/java/com/shaft/gui/playwright/browser/PlaywrightBrowserActionsUnitTest.java": {
+    "mtime": 1782391326.6268551,
+    "ast_hash": "74ae0ba0ab9131629b1a97439a929342",
+    "semantic_hash": ""
+  },
+  "shaft-engine/src/test/java/com/shaft/tools/io/internal/ApiPerformanceExecutionReportUnitTest.java": {
+    "mtime": 1782390647.5146246,
+    "ast_hash": "7fa8f22fe2d1aaa7ac0475a47974c4f4",
+    "semantic_hash": ""
+  },
+  "shaft-engine/src/test/java/com/shaft/tools/io/internal/BrowserPerformanceExecutionReportUnitTest.java": {
+    "mtime": 1782391817.4911437,
+    "ast_hash": "9a9e00212df7d5789f27227cc835a5ef",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-report/summary.json": {
+    "mtime": 1782391904.3081694,
+    "ast_hash": "832b19adf2ee8f4e5fbf2db95eac3404",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/0533b76d-9bd6-47b1-9a6d-36662017a049-container.json": {
+    "mtime": 1782391900.6403205,
+    "ast_hash": "98c13e82ea6d62ed3aae1ae1028fcdaa",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/1949bdce-cec9-422c-ad34-1dcc7fd5b9b2-result.json": {
+    "mtime": 1782391900.6433208,
+    "ast_hash": "ff317d25a1c62edef6a7047b544600b3",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/1d1c42a6-0e25-45a2-888b-f8335c490708-container.json": {
+    "mtime": 1782391900.6463323,
+    "ast_hash": "5dcc26f1060fc8377c6f3c80d18c948f",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/1eea324c-2261-40fe-9398-65b1092ccd27-container.json": {
+    "mtime": 1782391900.6473234,
+    "ast_hash": "f03df26263579b1749c01a0d433baf26",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/203925a0-020b-4d1e-ac34-8e40089b77e6-container.json": {
+    "mtime": 1782391900.648322,
+    "ast_hash": "84f1cc78681e489aa4f325470130812b",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/29dabde5-986e-4cde-af19-af368ff755a9-result.json": {
+    "mtime": 1782391900.6493204,
+    "ast_hash": "6660782d9d22dbbe54491ffb422f05eb",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/36825efb-e7a8-4134-bcdf-36cc9391aab2-result.json": {
+    "mtime": 1782391900.6513212,
+    "ast_hash": "9784f940c9f70b688abc5de48dd0d027",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/3c16359a-4a45-4233-8e09-bbdedb2f8e50-container.json": {
+    "mtime": 1782391900.6533237,
+    "ast_hash": "45676b5993653243a2610fe458de133d",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/3f295d81-fe9b-4ce7-8ec7-a72625b3ed4c-container.json": {
+    "mtime": 1782391900.65532,
+    "ast_hash": "b82642e6ed89abfa3245193df46a49ea",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/4237d119-f4cb-47f6-8c5d-71dcb3ff9d07-container.json": {
+    "mtime": 1782391900.65532,
+    "ast_hash": "6de02aa53bdf9f6ee2d419dae7cecfc6",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/4deab61a-e385-423a-8a0b-9b6beeb65650-result.json": {
+    "mtime": 1782391900.6563225,
+    "ast_hash": "c7f8d4e13ba39babf8843761b38d7c9c",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/4fd0a627-a50a-48ef-9b21-4e8b69cbe389-result.json": {
+    "mtime": 1782391900.6573195,
+    "ast_hash": "dd50b6dda5928fe108006d0851992e86",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/5f1500ce-fe7f-43ea-af30-9651859201bd-container.json": {
+    "mtime": 1782391900.6593263,
+    "ast_hash": "47cab2e0fe89f797e747a67e7ae4cb41",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/6d5327ef-4426-4d38-a598-ad31196dc755-container.json": {
+    "mtime": 1782391900.66133,
+    "ast_hash": "dc27772d9e6d30034c03aacc0195f6db",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/71f391de-9ef9-468e-94f3-7782bcb01332-result.json": {
+    "mtime": 1782391900.662328,
+    "ast_hash": "530d28402bc652077f21c26a00ede4ec",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/76938466-33d5-46cf-bb6b-05da04c91b67-result.json": {
+    "mtime": 1782391900.6643245,
+    "ast_hash": "6a8613e0501bb466a512e720ec480e52",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/7f5be44d-2f83-406d-b842-0eeb6836925b-result.json": {
+    "mtime": 1782391900.6653247,
+    "ast_hash": "f6919725a23eaaa2c94fbf31ceb9df74",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/82680ef6-0b18-46f2-a08a-aba19ba0a70d-result.json": {
+    "mtime": 1782391900.6673431,
+    "ast_hash": "3d9d73bd1269347c82ca2fcc6f390468",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/8509b8d4-0b85-48dd-b194-878b15079def-container.json": {
+    "mtime": 1782391900.6693413,
+    "ast_hash": "ed71bd89945e4050dd3cfd08538fa379",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/8aac795c-6ebb-45ef-9d46-04b31587134d-container.json": {
+    "mtime": 1782391900.6713395,
+    "ast_hash": "bf14b19ba693fa7473c3e6af69cdf917",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/900875e6-16d7-4c12-9de6-f0a086115003-result.json": {
+    "mtime": 1782391900.6723387,
+    "ast_hash": "b22ea1af94fea53e38cdf6ce2df06180",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/a93c750f-6a6f-4fb0-b1b3-da4eb9b7e3ef-container.json": {
+    "mtime": 1782391900.67434,
+    "ast_hash": "25a7837d38b2fa39481e1c6e9d7792e2",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/a9d271c8-6878-440e-810e-2cf01ae50806-container.json": {
+    "mtime": 1782391900.6773396,
+    "ast_hash": "875d37cd30ee063bf1716c85bd92cecc",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/ada6bbb7-fae7-4fd1-9259-959af343972f-container.json": {
+    "mtime": 1782391900.679339,
+    "ast_hash": "94ee6c4ae00083fd9567f9ed796b60b9",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/ae911317-a245-43df-8bd1-d05de7925294-result.json": {
+    "mtime": 1782391900.6803353,
+    "ast_hash": "0d9a8f5af046b8214c908f5a3f0d4a6b",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/afae9a27-c204-4065-acda-7454817c43fe-result.json": {
+    "mtime": 1782391900.6818454,
+    "ast_hash": "a3ea1b752b77f028f609f06f54f8157a",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/b93133c9-5907-492d-aaac-c3489bc898da-container.json": {
+    "mtime": 1782391900.683865,
+    "ast_hash": "b681e2d32b533cac0bf56dd9fd93235c",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/c05003a9-fa1c-4129-b527-e38a58e5077c-result.json": {
+    "mtime": 1782391900.6858587,
+    "ast_hash": "6e4ea97e29c39e43ca3321bc79d22e11",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/c5edfcdf-3a18-469a-b368-90253fbc1461-container.json": {
+    "mtime": 1782391900.6878555,
+    "ast_hash": "143abc77af86f28360ef583b67fb920b",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/ca492495-cf2c-4215-a8d6-22022180c2a7-container.json": {
+    "mtime": 1782391900.688856,
+    "ast_hash": "368a931134c253748eca294d3d1f6e3c",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/cb5fd54d-1971-4af7-aeb0-eaebf83f7dee-result.json": {
+    "mtime": 1782391900.6898546,
+    "ast_hash": "6baea8d6263831786f408b11e9283ab9",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/cf3c033b-ea76-4a2c-9d7a-d4fa8c702ade-result.json": {
+    "mtime": 1782391900.6918623,
+    "ast_hash": "9ae7a663cff385366b0ad51e2d290506",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/d6ca20a9-6885-4968-8d1d-0adaa1128524-container.json": {
+    "mtime": 1782391900.6948721,
+    "ast_hash": "a41bd81c261c1c24e9dd8abb633cffaa",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/d8fbe77b-be53-4041-b00e-6669c46f9a8b-result.json": {
+    "mtime": 1782391900.6968563,
+    "ast_hash": "146bed7128f889806839d0c0e212e8d4",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/f014a031-5f22-4e97-8b38-c5643ec9b398-container.json": {
+    "mtime": 1782391900.6978598,
+    "ast_hash": "93807c4bb1ec36fd73dcd3235d9ca4d6",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/f1aad88c-4d66-4f8e-82ed-b01d5886041c-result.json": {
+    "mtime": 1782391900.6998582,
+    "ast_hash": "d0c622a357f9f49576fbf23c1b24cee7",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-report/2026-06-25_15-30-07-205_AllureReport.html": {
+    "mtime": 1782390607.0761907,
+    "ast_hash": "155a9e3e54cbdf961c75ca5dc638a63b",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-report/2026-06-25_15-30-55-774_AllureReport.html": {
+    "mtime": 1782390655.7062273,
+    "ast_hash": "f4d64a82b6c17ada6e119c11e4176faf",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-report/2026-06-25_15-32-25-790_AllureReport.html": {
+    "mtime": 1782390745.7256522,
+    "ast_hash": "d900659e3c3e191ddbc25b720c17a739",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-report/2026-06-25_15-51-44-380_AllureReport.html": {
+    "mtime": 1782391904.3051665,
+    "ast_hash": "eff72a4a57c34f243a002ea988ebb1b8",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/0254ae0c-6448-4a7c-ae85-2792c9c89d47-attachment.txt": {
+    "mtime": 1782391899.9051764,
+    "ast_hash": "9cb8f44e00988b6eac617b4683bbca7b",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/13d9aa8f-ccfc-4d50-9176-13bfbf30390d-attachment.txt": {
+    "mtime": 1782391899.0769863,
+    "ast_hash": "36abb3bb7765791a37979fbac30d2203",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/14d101ad-04c5-4f4f-b3ca-526e95c75504-attachment.txt": {
+    "mtime": 1782391900.567806,
+    "ast_hash": "26938ff42599a54cb98fa2b9fa0012d5",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/1b1f11f3-062b-4807-8df2-5b2f3761d155-attachment.txt": {
+    "mtime": 1782391900.4455583,
+    "ast_hash": "5a9a73ec7be304bd016f7f2108a88cb8",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/22903426-fad5-4429-a23d-dc7349a2f0fc-attachment.txt": {
+    "mtime": 1782391899.7034423,
+    "ast_hash": "291fcc7cca9b6e1bb4253ffe712974c4",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/4e433ddb-9f95-486d-9b87-6dc8d48c41e6-attachment.txt": {
+    "mtime": 1782391899.5486174,
+    "ast_hash": "a09d3890e31816a6f89860f70ea00abf",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/54d9b0cd-0394-4f7d-8955-d4676d947391-attachment.txt": {
+    "mtime": 1782391900.4725733,
+    "ast_hash": "7ac3dc5d5e30492e6301a447be79e42c",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/5df0a4e7-4293-482d-982b-632ea26b7f07-attachment.txt": {
+    "mtime": 1782391899.8379588,
+    "ast_hash": "1b810e9d8db8f2623ea724c95ad5065f",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/62614a31-5bca-477b-a13d-c7b63665eead-attachment.txt": {
+    "mtime": 1782391899.5316143,
+    "ast_hash": "e02a7ede7ed51951cd5ac9e50c269003",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/7ae04a75-1dd2-44b9-b5d5-a9f7bd409ee6-attachment.txt": {
+    "mtime": 1782391899.4180927,
+    "ast_hash": "b899a88c8efeedefb83257db1c2b336f",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/8a8e7ae0-bbdb-42ab-a153-7cc52eda56a5-attachment.txt": {
+    "mtime": 1782391900.6143203,
+    "ast_hash": "aaaca5cf86996a18372bdb27bbffceae",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/99424c90-95d6-4a40-9919-63d358a26d51-attachment.txt": {
+    "mtime": 1782391899.4540956,
+    "ast_hash": "904f793aaa7fcd4987e15276cda9100b",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/a2dbb476-96c3-4c37-984d-0495f64e6a62-attachment.txt": {
+    "mtime": 1782391899.9651806,
+    "ast_hash": "8ba63d3e93a7be2b4c9fe6c908e5078f",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/ae8fb98e-3b56-4d57-b1ed-7ca56fca40aa-attachment.txt": {
+    "mtime": 1782391900.0823777,
+    "ast_hash": "3df44641cbd9b06ef5044d2febd91ced",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/bb7c126f-fb08-43a4-9248-3497f0d5cb7a-attachment.txt": {
+    "mtime": 1782391898.7144108,
+    "ast_hash": "2408fde389822422c701a10e2b4001ca",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/e7981bda-d2df-4444-9e88-6d4f4ea5a7f9-attachment.txt": {
+    "mtime": 1782391899.5716195,
+    "ast_hash": "5dfc22bf79aa78cf4406a3822f602623",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/faf5fba4-73de-4757-b8b9-87f1be747427-attachment.txt": {
+    "mtime": 1782391900.097382,
+    "ast_hash": "dee23ce0ce895d22c971756131fb586f",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allurerc.yaml": {
+    "mtime": 1782391900.703861,
+    "ast_hash": "1861b0462f0deb9c11c0eea45f2bdab1",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/execution-summary/ExecutionSummaryReport_25-06-2026_15-51-40-6350-PM.html": {
+    "mtime": 1782391900.6433208,
+    "ast_hash": "8af89f2e8345e35990beb72d11eac08e",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/performanceReport/PerformanceReport_25-06-2026_15-29-59-9359-PM.html": {
+    "mtime": 1782390599.93792,
+    "ast_hash": "1712cbcacb7fbf78ada0f64fb7bfd963",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/performanceReport/PerformanceReport_25-06-2026_15-30-50-7401-PM.html": {
+    "mtime": 1782390650.7421875,
+    "ast_hash": "8eaf6e97287c7c73fb009fa258388e87",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/performanceReport/PerformanceReport_25-06-2026_15-32-22-0590-PM.html": {
+    "mtime": 1782390742.0610294,
+    "ast_hash": "a62d5f77d353dbaa39be434df78ed186",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/performanceReport/PerformanceReport_25-06-2026_15-51-40-6453-PM.html": {
+    "mtime": 1782391900.6463323,
+    "ast_hash": "6396c38972793586124fb73d779dde84",
     "semantic_hash": ""
   }
 }

--- a/shaft-engine/src/main/java/com/shaft/api/RequestBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/api/RequestBuilder.java
@@ -339,7 +339,8 @@ public class RequestBuilder {
                 openApiInteractionRecorded = true;
             }
             long endTime = System.currentTimeMillis();
-            if (SHAFT.Properties.performance.isEnablePerformanceReport()) {
+            if (SHAFT.Properties.performance.isEnablePerformanceReport()
+                    || !SHAFT.Properties.performance.apiEndpointPerformanceBudgets().isBlank()) {
                 double responseTime = endTime - startTime;
                 String normalizedEndpoint = normalizeEndpoint(serviceName);
                 logResponseTime(normalizedEndpoint, responseTime);

--- a/shaft-engine/src/main/java/com/shaft/driver/SHAFT.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/SHAFT.java
@@ -14,6 +14,7 @@ import com.shaft.gui.element.AsyncElementActions;
 import com.shaft.gui.element.TouchActions;
 import com.shaft.gui.element.internal.Actions;
 import com.shaft.gui.internal.natural.NaturalActionExecutor;
+import com.shaft.gui.internal.natural.PlaywrightNaturalActionExecutor;
 import com.shaft.listeners.internal.WebDriverListener;
 import com.shaft.tools.io.*;
 import com.shaft.tools.io.internal.ReportManagerHelper;
@@ -366,7 +367,8 @@ public class SHAFT {
 
             @Override
             public Playwright act(String intent, Object... args) {
-                throw new UnsupportedOperationException("Natural GUI actions currently execute through WebDriver and are not available through the Playwright backend.");
+                PlaywrightNaturalActionExecutor.perform(session, intent, args);
+                return this;
             }
 
             @Override

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -700,8 +700,8 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
      * @return a browser network interception request builder
      */
     @Override
-    public NetworkInterceptionRequestBuilder interceptRequest() {
-        return new NetworkInterceptionRequestBuilder(this);
+    public NetworkInterceptionRequestBuilder<BrowserActions> interceptRequest() {
+        return new NetworkInterceptionRequestBuilder<>(this, this::registerNetworkInterceptionRule);
     }
 
     /**

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/NetworkInterceptionRequestBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/NetworkInterceptionRequestBuilder.java
@@ -2,6 +2,7 @@ package com.shaft.gui.browser;
 
 import com.shaft.cli.FileActions;
 import com.shaft.gui.browser.internal.BrowserNetworkInterceptionRule;
+import com.shaft.gui.driver.BrowserActionsContract;
 import com.shaft.validation.Validations;
 import com.shaft.validation.internal.RestValidationsBuilder;
 import org.openqa.selenium.remote.http.Contents;
@@ -13,6 +14,7 @@ import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
@@ -20,13 +22,22 @@ import java.util.regex.Pattern;
 /**
  * Fluent builder for browser network request interception.
  */
-public class NetworkInterceptionRequestBuilder {
-    private final BrowserActions browserActions;
+public class NetworkInterceptionRequestBuilder<T extends BrowserActionsContract> {
+    private final T browserActions;
+    private final BiFunction<BrowserNetworkInterceptionRule, String, T> ruleRegistrar;
     private final List<Predicate<HttpRequest>> predicates = new ArrayList<>();
     private HttpMethod method;
 
-    NetworkInterceptionRequestBuilder(BrowserActions browserActions) {
-        this.browserActions = browserActions;
+    /**
+     * Creates a request builder backed by the supplied interception rule registrar.
+     *
+     * @param browserActions owning browser actions instance
+     * @param ruleRegistrar callback that registers built rules on the owning backend
+     */
+    public NetworkInterceptionRequestBuilder(T browserActions,
+                                             BiFunction<BrowserNetworkInterceptionRule, String, T> ruleRegistrar) {
+        this.browserActions = Objects.requireNonNull(browserActions, "browserActions");
+        this.ruleRegistrar = Objects.requireNonNull(ruleRegistrar, "ruleRegistrar");
     }
 
     /**
@@ -35,33 +46,33 @@ public class NetworkInterceptionRequestBuilder {
      * @param method HTTP method to match
      * @return this builder
      */
-    public NetworkInterceptionRequestBuilder method(HttpMethod method) {
+    public NetworkInterceptionRequestBuilder<T> method(HttpMethod method) {
         this.method = Objects.requireNonNull(method, "method");
         return this;
     }
 
     /** @return this builder configured to match GET requests */
-    public NetworkInterceptionRequestBuilder get() {
+    public NetworkInterceptionRequestBuilder<T> get() {
         return method(HttpMethod.GET);
     }
 
     /** @return this builder configured to match POST requests */
-    public NetworkInterceptionRequestBuilder post() {
+    public NetworkInterceptionRequestBuilder<T> post() {
         return method(HttpMethod.POST);
     }
 
     /** @return this builder configured to match PUT requests */
-    public NetworkInterceptionRequestBuilder put() {
+    public NetworkInterceptionRequestBuilder<T> put() {
         return method(HttpMethod.PUT);
     }
 
     /** @return this builder configured to match PATCH requests */
-    public NetworkInterceptionRequestBuilder patch() {
+    public NetworkInterceptionRequestBuilder<T> patch() {
         return method(HttpMethod.PATCH);
     }
 
     /** @return this builder configured to match DELETE requests */
-    public NetworkInterceptionRequestBuilder delete() {
+    public NetworkInterceptionRequestBuilder<T> delete() {
         return method(HttpMethod.DELETE);
     }
 
@@ -71,7 +82,7 @@ public class NetworkInterceptionRequestBuilder {
      * @param text URL fragment
      * @return this builder
      */
-    public NetworkInterceptionRequestBuilder urlContains(String text) {
+    public NetworkInterceptionRequestBuilder<T> urlContains(String text) {
         predicates.add(request -> request.getUri().contains(text));
         return this;
     }
@@ -82,7 +93,7 @@ public class NetworkInterceptionRequestBuilder {
      * @param regex URL regular expression
      * @return this builder
      */
-    public NetworkInterceptionRequestBuilder urlMatches(String regex) {
+    public NetworkInterceptionRequestBuilder<T> urlMatches(String regex) {
         Pattern pattern = Pattern.compile(regex);
         predicates.add(request -> pattern.matcher(request.getUri()).matches());
         return this;
@@ -94,7 +105,7 @@ public class NetworkInterceptionRequestBuilder {
      * @param path expected URL path
      * @return this builder
      */
-    public NetworkInterceptionRequestBuilder pathEquals(String path) {
+    public NetworkInterceptionRequestBuilder<T> pathEquals(String path) {
         predicates.add(request -> path.equals(pathOf(request)));
         return this;
     }
@@ -105,7 +116,7 @@ public class NetworkInterceptionRequestBuilder {
      * @param text path fragment
      * @return this builder
      */
-    public NetworkInterceptionRequestBuilder pathContains(String text) {
+    public NetworkInterceptionRequestBuilder<T> pathContains(String text) {
         predicates.add(request -> pathOf(request).contains(text));
         return this;
     }
@@ -117,7 +128,7 @@ public class NetworkInterceptionRequestBuilder {
      * @param value expected value
      * @return this builder
      */
-    public NetworkInterceptionRequestBuilder queryParam(String name, String value) {
+    public NetworkInterceptionRequestBuilder<T> queryParam(String name, String value) {
         predicates.add(request -> value.equals(queryParamsOf(request).get(name)));
         return this;
     }
@@ -129,7 +140,7 @@ public class NetworkInterceptionRequestBuilder {
      * @param value expected value
      * @return this builder
      */
-    public NetworkInterceptionRequestBuilder header(String name, String value) {
+    public NetworkInterceptionRequestBuilder<T> header(String name, String value) {
         predicates.add(request -> value.equals(request.getHeader(name)));
         return this;
     }
@@ -140,7 +151,7 @@ public class NetworkInterceptionRequestBuilder {
      * @param text body fragment
      * @return this builder
      */
-    public NetworkInterceptionRequestBuilder bodyContains(String text) {
+    public NetworkInterceptionRequestBuilder<T> bodyContains(String text) {
         predicates.add(request -> request.contentAsString().contains(text));
         return this;
     }
@@ -151,7 +162,7 @@ public class NetworkInterceptionRequestBuilder {
      * @param predicate predicate to apply
      * @return this builder
      */
-    public NetworkInterceptionRequestBuilder matching(Predicate<HttpRequest> predicate) {
+    public NetworkInterceptionRequestBuilder<T> matching(Predicate<HttpRequest> predicate) {
         predicates.add(Objects.requireNonNull(predicate, "predicate"));
         return this;
     }
@@ -161,8 +172,8 @@ public class NetworkInterceptionRequestBuilder {
      *
      * @return mocked response builder
      */
-    public MockedResponseBuilder respond() {
-        return new MockedResponseBuilder(this);
+    public MockedResponseBuilder<T> respond() {
+        return new MockedResponseBuilder<>(this);
     }
 
     /**
@@ -171,7 +182,7 @@ public class NetworkInterceptionRequestBuilder {
      * @param validation response validation callback
      * @return the owning browser actions object
      */
-    public BrowserActions assertResponse(Consumer<RestValidationsBuilder> validation) {
+    public T assertResponse(Consumer<RestValidationsBuilder> validation) {
         return registerValidation(response -> validation.accept(Validations.assertThat().response(response)),
                 "Configured network response assertion.");
     }
@@ -182,14 +193,14 @@ public class NetworkInterceptionRequestBuilder {
      * @param validation response validation callback
      * @return the owning browser actions object
      */
-    public BrowserActions verifyResponse(Consumer<RestValidationsBuilder> validation) {
+    public T verifyResponse(Consumer<RestValidationsBuilder> validation) {
         return registerValidation(response -> validation.accept(Validations.verifyThat().response(response)),
                 "Configured network response verification.");
     }
 
-    private BrowserActions registerValidation(Consumer<io.restassured.response.Response> validation,
-                                              String successMessage) {
-        return browserActions.registerNetworkInterceptionRule(
+    private T registerValidation(Consumer<io.restassured.response.Response> validation,
+                                 String successMessage) {
+        return ruleRegistrar.apply(
                 BrowserNetworkInterceptionRule.validate(buildPredicate(), validation), successMessage);
     }
 
@@ -241,13 +252,13 @@ public class NetworkInterceptionRequestBuilder {
     /**
      * Fluent mocked response builder.
      */
-    public static class MockedResponseBuilder {
-        private final NetworkInterceptionRequestBuilder requestBuilder;
+    public static class MockedResponseBuilder<T extends BrowserActionsContract> {
+        private final NetworkInterceptionRequestBuilder<T> requestBuilder;
         private final Map<String, String> headers = new LinkedHashMap<>();
         private int statusCode = 200;
         private byte[] body;
 
-        private MockedResponseBuilder(NetworkInterceptionRequestBuilder requestBuilder) {
+        private MockedResponseBuilder(NetworkInterceptionRequestBuilder<T> requestBuilder) {
             this.requestBuilder = requestBuilder;
         }
 
@@ -342,8 +353,8 @@ public class NetworkInterceptionRequestBuilder {
          *
          * @return the owning browser actions object
          */
-        public BrowserActions perform() {
-            return requestBuilder.browserActions.registerNetworkInterceptionRule(
+        public T perform() {
+            return requestBuilder.ruleRegistrar.apply(
                     BrowserNetworkInterceptionRule.mock(requestBuilder.buildPredicate(), request -> toResponse()),
                     "Configured network response mock.");
         }

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/NetworkInterceptionRequestBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/NetworkInterceptionRequestBuilder.java
@@ -23,7 +23,6 @@ import java.util.regex.Pattern;
  * Fluent builder for browser network request interception.
  */
 public class NetworkInterceptionRequestBuilder<T extends BrowserActionsContract> {
-    private final T browserActions;
     private final BiFunction<BrowserNetworkInterceptionRule, String, T> ruleRegistrar;
     private final List<Predicate<HttpRequest>> predicates = new ArrayList<>();
     private HttpMethod method;
@@ -36,7 +35,7 @@ public class NetworkInterceptionRequestBuilder<T extends BrowserActionsContract>
      */
     public NetworkInterceptionRequestBuilder(T browserActions,
                                              BiFunction<BrowserNetworkInterceptionRule, String, T> ruleRegistrar) {
-        this.browserActions = Objects.requireNonNull(browserActions, "browserActions");
+        Objects.requireNonNull(browserActions, "browserActions");
         this.ruleRegistrar = Objects.requireNonNull(ruleRegistrar, "ruleRegistrar");
     }
 

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/internal/PlaywrightNetworkInterceptor.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/internal/PlaywrightNetworkInterceptor.java
@@ -1,0 +1,142 @@
+package com.shaft.gui.browser.internal;
+
+import com.microsoft.playwright.APIResponse;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.Request;
+import com.microsoft.playwright.Route;
+import io.restassured.builder.ResponseBuilder;
+import io.restassured.response.Response;
+import org.openqa.selenium.remote.http.Contents;
+import org.openqa.selenium.remote.http.HttpMethod;
+import org.openqa.selenium.remote.http.HttpRequest;
+import org.openqa.selenium.remote.http.HttpResponse;
+
+import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Owns browser network interception rules for one Playwright browser context.
+ */
+public class PlaywrightNetworkInterceptor {
+    private static final String ALL_REQUESTS = "**/*";
+    private final BrowserContext browserContext;
+    private final List<BrowserNetworkInterceptionRule> rules = new CopyOnWriteArrayList<>();
+    private AutoCloseable activeRoute;
+
+    /**
+     * Creates a Playwright network interceptor backed by BrowserContext routing.
+     *
+     * @param browserContext active Playwright browser context
+     */
+    public PlaywrightNetworkInterceptor(BrowserContext browserContext) {
+        this.browserContext = browserContext;
+    }
+
+    /**
+     * Adds a rule and activates routing for the current browser context.
+     *
+     * @param rule rule to add
+     */
+    public synchronized void addRule(BrowserNetworkInterceptionRule rule) {
+        rules.add(rule);
+        if (activeRoute == null) {
+            activeRoute = browserContext.route(ALL_REQUESTS, this::handle);
+        }
+    }
+
+    /**
+     * Clears all registered rules and removes the Playwright route handler.
+     */
+    public synchronized void clear() {
+        rules.clear();
+        closeActiveRoute();
+    }
+
+    private void handle(Route route) {
+        HttpRequest request = toSeleniumRequest(route.request());
+        BrowserNetworkInterceptionRule rule = findMatchingRule(request);
+        if (rule == null) {
+            route.resume();
+            return;
+        }
+        if (rule.mocksResponse()) {
+            route.fulfill(toFulfillOptions(rule.createResponse(request)));
+            return;
+        }
+
+        APIResponse response = route.fetch();
+        rule.validate(toRestAssuredResponse(response));
+        route.fulfill(new Route.FulfillOptions().setResponse(response));
+    }
+
+    private BrowserNetworkInterceptionRule findMatchingRule(HttpRequest request) {
+        for (int i = rules.size() - 1; i >= 0; i--) {
+            BrowserNetworkInterceptionRule rule = rules.get(i);
+            if (rule.matches(request)) {
+                return rule;
+            }
+        }
+        return null;
+    }
+
+    private HttpRequest toSeleniumRequest(Request request) {
+        HttpRequest converted = new HttpRequest(toHttpMethod(request.method()), request.url());
+        request.headers().forEach(converted::addHeader);
+        byte[] body = request.postDataBuffer();
+        if (body != null) {
+            converted.setContent(Contents.bytes(body));
+        }
+        return converted;
+    }
+
+    private HttpMethod toHttpMethod(String method) {
+        return HttpMethod.valueOf(method.toUpperCase(Locale.ROOT));
+    }
+
+    private Route.FulfillOptions toFulfillOptions(HttpResponse response) {
+        Route.FulfillOptions options = new Route.FulfillOptions().setStatus(response.getStatus());
+        Map<String, String> headers = new LinkedHashMap<>();
+        response.forEachHeader(headers::put);
+        if (!headers.isEmpty()) {
+            options.setHeaders(headers);
+        }
+        if (response.getContentType() != null) {
+            options.setContentType(response.getContentType());
+        }
+        byte[] body = Contents.bytes(response.getContent());
+        if (body.length > 0) {
+            options.setBodyBytes(body);
+        }
+        return options;
+    }
+
+    private Response toRestAssuredResponse(APIResponse response) {
+        ResponseBuilder builder = new ResponseBuilder()
+                .setStatusCode(response.status())
+                .setBody(response.body());
+        response.headers().forEach(builder::setHeader);
+        String contentType = response.headers().get("content-type");
+        if (contentType == null) {
+            contentType = response.headers().get("Content-Type");
+        }
+        if (contentType != null) {
+            builder.setContentType(contentType);
+        }
+        return builder.build();
+    }
+
+    private void closeActiveRoute() {
+        if (activeRoute != null) {
+            try {
+                activeRoute.close();
+            } catch (Exception ignored) {
+                // Closing an already-reset Playwright route is harmless during teardown.
+            } finally {
+                activeRoute = null;
+            }
+        }
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/locator/CompositeLocator.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/locator/CompositeLocator.java
@@ -1,0 +1,12 @@
+package com.shaft.gui.internal.locator;
+
+import org.openqa.selenium.By;
+
+import java.util.List;
+
+/**
+ * Internal marker for locator implementations that wrap multiple fallback candidates.
+ */
+public interface CompositeLocator {
+    List<By> alternatives();
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/locator/SmartLocators.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/locator/SmartLocators.java
@@ -6,6 +6,7 @@ import org.openqa.selenium.support.locators.RelativeLocator;
 import org.openqa.selenium.support.pagefactory.ByAll;
 
 import java.util.Arrays;
+import java.util.List;
 
 public class SmartLocators {
 
@@ -318,12 +319,19 @@ public class SmartLocators {
         ANY_CONTAINS_TEXT_FOLLOWING_BUTTON, ANY_CONTAINS_TEXT_FOLLOWING_LINK
     }
 
-    private static class SmartLocator extends ByAll {
+    private static class SmartLocator extends ByAll implements CompositeLocator {
         private final String elementName;
+        private final List<By> alternatives;
 
         private SmartLocator(String elementName, By... bys) {
             super(bys);
             this.elementName = elementName;
+            this.alternatives = List.copyOf(Arrays.asList(bys));
+        }
+
+        @Override
+        public List<By> alternatives() {
+            return alternatives;
         }
     }
 }

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/natural/DeterministicNaturalActionPlanner.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/natural/DeterministicNaturalActionPlanner.java
@@ -2,7 +2,6 @@ package com.shaft.gui.internal.natural;
 
 import com.shaft.gui.internal.locator.SmartLocators;
 import org.openqa.selenium.By;
-import org.openqa.selenium.support.pagefactory.ByAll;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -92,7 +91,7 @@ public class DeterministicNaturalActionPlanner implements NaturalActionPlanner {
         List<NaturalActionStep> steps = new ArrayList<>();
         steps.add(new NaturalActionStep(
                 NaturalActionKind.ELEMENT_TYPE,
-                new ByAll(
+                new NaturalActionCompositeLocator(
                         SmartLocators.inputField("username"),
                         SmartLocators.inputField("email"),
                         SmartLocators.inputField("login")),
@@ -101,13 +100,13 @@ public class DeterministicNaturalActionPlanner implements NaturalActionPlanner {
                 "Type the first argument into the username, email, or login field."));
         steps.add(new NaturalActionStep(
                 NaturalActionKind.ELEMENT_TYPE_SECURELY,
-                new ByAll(By.cssSelector("input[type='password']"), SmartLocators.inputField("password")),
+                new NaturalActionCompositeLocator(By.cssSelector("input[type='password']"), SmartLocators.inputField("password")),
                 request.arguments().get(1),
                 HIGH_TRUST,
                 "Type the second argument into the password field securely."));
         steps.add(new NaturalActionStep(
                 NaturalActionKind.ELEMENT_CLICK,
-                new ByAll(
+                new NaturalActionCompositeLocator(
                         SmartLocators.clickableField("login"),
                         SmartLocators.clickableField("log in"),
                         SmartLocators.clickableField("sign in"),

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionCompositeLocator.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionCompositeLocator.java
@@ -1,0 +1,22 @@
+package com.shaft.gui.internal.natural;
+
+import com.shaft.gui.internal.locator.CompositeLocator;
+import org.openqa.selenium.By;
+import org.openqa.selenium.support.pagefactory.ByAll;
+
+import java.util.Arrays;
+import java.util.List;
+
+final class NaturalActionCompositeLocator extends ByAll implements CompositeLocator {
+    private final List<By> alternatives;
+
+    NaturalActionCompositeLocator(By... locators) {
+        super(locators);
+        this.alternatives = List.copyOf(Arrays.asList(locators));
+    }
+
+    @Override
+    public List<By> alternatives() {
+        return alternatives;
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionRequest.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionRequest.java
@@ -3,12 +3,11 @@ package com.shaft.gui.internal.natural;
 import org.openqa.selenium.WebDriver;
 
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Natural-language GUI action request supplied to planners.
  *
- * @param driver active Selenium driver
+ * @param driver active Selenium driver, or {@code null} when the backend does not expose Selenium
  * @param intent user intent
  * @param arguments user-provided action arguments
  * @param mobileNativeExecution whether the active session is a mobile native session
@@ -24,8 +23,7 @@ public record NaturalActionRequest(
      * Creates an immutable request.
      */
     public NaturalActionRequest {
-        driver = Objects.requireNonNull(driver, "driver");
-        intent = Objects.requireNonNullElse(intent, "").trim();
+        intent = java.util.Objects.requireNonNullElse(intent, "").trim();
         arguments = arguments == null ? List.of() : List.copyOf(arguments);
     }
 }

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/natural/PlaywrightNaturalActionExecutor.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/natural/PlaywrightNaturalActionExecutor.java
@@ -4,6 +4,7 @@ import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 import com.shaft.driver.SHAFT;
 import com.shaft.gui.driver.ShaftLocator;
+import com.shaft.gui.internal.locator.CompositeLocator;
 import com.shaft.gui.playwright.browser.BrowserActions;
 import com.shaft.gui.playwright.element.ElementActions;
 import com.shaft.gui.playwright.internal.PlaywrightSession;
@@ -11,9 +12,7 @@ import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.FailureReporter;
 import org.apache.logging.log4j.Level;
 import org.openqa.selenium.By;
-import org.openqa.selenium.support.pagefactory.ByAll;
 
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -111,14 +110,8 @@ public final class PlaywrightNaturalActionExecutor {
         if (locator == null) {
             return List.of();
         }
-        if (locator instanceof ByAll byAll) {
-            try {
-                Field bys = ByAll.class.getDeclaredField("bys");
-                bys.setAccessible(true);
-                return Arrays.asList((By[]) bys.get(byAll));
-            } catch (ReflectiveOperationException e) {
-                return List.of();
-            }
+        if (locator instanceof CompositeLocator compositeLocator) {
+            return compositeLocator.alternatives();
         }
         return List.of(locator);
     }
@@ -141,6 +134,7 @@ public final class PlaywrightNaturalActionExecutor {
                 case BROWSER_REFRESH -> (browser = browser == null ? new BrowserActions(session) : browser).refreshCurrentPage();
                 case BROWSER_BACK -> (browser = browser == null ? new BrowserActions(session) : browser).navigateBack();
                 case BROWSER_FORWARD -> (browser = browser == null ? new BrowserActions(session) : browser).navigateForward();
+                default -> FailureReporter.fail("Unsupported Playwright natural action kind: " + step.kind());
             }
         }
     }

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/natural/PlaywrightNaturalActionExecutor.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/natural/PlaywrightNaturalActionExecutor.java
@@ -1,0 +1,207 @@
+package com.shaft.gui.internal.natural;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.shaft.driver.SHAFT;
+import com.shaft.gui.driver.ShaftLocator;
+import com.shaft.gui.playwright.browser.BrowserActions;
+import com.shaft.gui.playwright.element.ElementActions;
+import com.shaft.gui.playwright.internal.PlaywrightSession;
+import com.shaft.tools.io.ReportManager;
+import com.shaft.tools.io.internal.FailureReporter;
+import org.apache.logging.log4j.Level;
+import org.openqa.selenium.By;
+import org.openqa.selenium.support.pagefactory.ByAll;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Validates and executes natural-language action plans through Playwright SHAFT actions.
+ */
+public final class PlaywrightNaturalActionExecutor {
+    private static final Pattern SECRET_ASSIGNMENT = Pattern.compile(
+            "(?i)(password|passwd|secret|token|api[-_]?key|authorization|cookie)\\s*[:=]\\s*[^\\s,;]+");
+    private static final Pattern LONG_TOKEN = Pattern.compile("\\b[a-zA-Z0-9_-]{32,}\\b");
+
+    private PlaywrightNaturalActionExecutor() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Plans, validates, and executes a natural-language Playwright action.
+     *
+     * @param session active Playwright session
+     * @param intent  user intent
+     * @param args    user-provided action arguments
+     */
+    public static void perform(PlaywrightSession session, String intent, Object... args) {
+        if (!SHAFT.Properties.naturalActions.enabled()) {
+            FailureReporter.fail("Natural actions are disabled. Set `naturalActions.enabled=true` to use driver.act(...).");
+        }
+        NaturalActionRequest request = new NaturalActionRequest(
+                null,
+                intent,
+                args == null ? List.of() : Arrays.asList(args),
+                false,
+                false);
+        NaturalActionPlan planned = NaturalActionPlannerRegistry.plan(request);
+        NaturalActionPlan validated = validate(session.page(), planned, allowedTargets());
+        double threshold = threshold();
+        if (validated.steps().isEmpty() || validated.trust() < threshold) {
+            String message = "Natural action was not executed because trust "
+                    + percent(validated.trust()) + " is below the configured threshold "
+                    + percent(threshold) + ". Intent: \"" + safe(intent) + "\". Reason: "
+                    + safe(validated.explanation());
+            ReportManager.log(message, Level.WARN);
+            FailureReporter.fail(message);
+        }
+
+        ReportManager.log("Natural action accepted with trust " + percent(validated.trust())
+                + " using planner \"" + safe(validated.plannerId()) + "\" for intent \""
+                + safe(intent) + "\".", Level.INFO);
+        execute(session, validated);
+    }
+
+    private static NaturalActionPlan validate(
+            Page page,
+            NaturalActionPlan plan,
+            Set<NaturalActionKind.Target> allowedTargets) {
+        double aggregateTrust = plan.trust();
+        for (NaturalActionStep step : plan.steps()) {
+            double stepTrust = step.trust();
+            if (!allowedTargets.contains(step.kind().target())) {
+                stepTrust = 0;
+            } else if (step.kind() == NaturalActionKind.BROWSER_NAVIGATE && isBlank(step.data())) {
+                stepTrust = 0;
+            } else if (step.kind().target() == NaturalActionKind.Target.ELEMENT
+                    || step.kind().target() == NaturalActionKind.Target.TOUCH) {
+                stepTrust = Math.min(stepTrust, locatorTrust(page, step.locator()));
+            }
+            aggregateTrust = Math.min(aggregateTrust, stepTrust);
+        }
+        return new NaturalActionPlan(
+                plan.plannerId(),
+                plan.intent(),
+                plan.steps(),
+                aggregateTrust,
+                plan.explanation());
+    }
+
+    private static double locatorTrust(Page page, By locator) {
+        for (By candidate : expand(locator)) {
+            try {
+                Locator playwrightLocator = ShaftLocator.from(candidate).toPlaywrightLocator(page);
+                if (playwrightLocator.count() == 1 && playwrightLocator.isVisible() && playwrightLocator.isEnabled()) {
+                    return 1.0;
+                }
+            } catch (RuntimeException ignored) {
+                // Unsupported candidates in composite locators do not make later portable candidates invalid.
+            }
+        }
+        return 0;
+    }
+
+    private static List<By> expand(By locator) {
+        if (locator == null) {
+            return List.of();
+        }
+        if (locator instanceof ByAll byAll) {
+            try {
+                Field bys = ByAll.class.getDeclaredField("bys");
+                bys.setAccessible(true);
+                return Arrays.asList((By[]) bys.get(byAll));
+            } catch (ReflectiveOperationException e) {
+                return List.of();
+            }
+        }
+        return List.of(locator);
+    }
+
+    private static void execute(PlaywrightSession session, NaturalActionPlan plan) {
+        ElementActions elements = null;
+        BrowserActions browser = null;
+        for (NaturalActionStep step : plan.steps()) {
+            switch (step.kind()) {
+                case ELEMENT_CLICK -> (elements = elements == null ? new ElementActions(session) : elements).click(resolve(session.page(), step.locator()));
+                case ELEMENT_TYPE ->
+                        (elements = elements == null ? new ElementActions(session) : elements).type(resolve(session.page(), step.locator()), asCharSequence(step.data()));
+                case ELEMENT_TYPE_SECURELY ->
+                        (elements = elements == null ? new ElementActions(session) : elements).typeSecure(resolve(session.page(), step.locator()), asCharSequence(step.data()));
+                case ELEMENT_CLEAR -> (elements = elements == null ? new ElementActions(session) : elements).clear(resolve(session.page(), step.locator()));
+                case TOUCH_TAP, TOUCH_DOUBLE_TAP, TOUCH_LONG_TAP ->
+                        FailureReporter.fail("Touch natural actions are not available through the Playwright backend. Use WebDriver/Appium touch actions for native gestures.");
+                case BROWSER_NAVIGATE ->
+                        (browser = browser == null ? new BrowserActions(session) : browser).navigateToURL(String.valueOf(step.data()));
+                case BROWSER_REFRESH -> (browser = browser == null ? new BrowserActions(session) : browser).refreshCurrentPage();
+                case BROWSER_BACK -> (browser = browser == null ? new BrowserActions(session) : browser).navigateBack();
+                case BROWSER_FORWARD -> (browser = browser == null ? new BrowserActions(session) : browser).navigateForward();
+            }
+        }
+    }
+
+    private static Locator resolve(Page page, By locator) {
+        for (By candidate : expand(locator)) {
+            try {
+                Locator playwrightLocator = ShaftLocator.from(candidate).toPlaywrightLocator(page);
+                if (playwrightLocator.count() == 1) {
+                    return playwrightLocator;
+                }
+            } catch (RuntimeException ignored) {
+                // Unsupported candidates in composite locators do not make later portable candidates invalid.
+            }
+        }
+        throw new IllegalArgumentException("No unique Playwright element matched natural-action locator: " + locator);
+    }
+
+    private static CharSequence[] asCharSequence(Object value) {
+        if (value instanceof CharSequence[] sequences) {
+            return sequences;
+        }
+        if (value instanceof CharSequence sequence) {
+            return new CharSequence[]{sequence};
+        }
+        return new CharSequence[]{String.valueOf(value)};
+    }
+
+    private static Set<NaturalActionKind.Target> allowedTargets() {
+        return Arrays.stream(SHAFT.Properties.naturalActions.allowedActions().split(","))
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .map(value -> value.toUpperCase(Locale.ROOT))
+                .map(value -> {
+                    try {
+                        return NaturalActionKind.Target.valueOf(value);
+                    } catch (IllegalArgumentException ignored) {
+                        return null;
+                    }
+                })
+                .filter(java.util.Objects::nonNull)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private static double threshold() {
+        int configured = SHAFT.Properties.naturalActions.minimumTrustPercentage();
+        return Math.max(0, Math.min(100, configured)) / 100.0;
+    }
+
+    private static boolean isBlank(Object value) {
+        return value == null || String.valueOf(value).isBlank();
+    }
+
+    private static String percent(double value) {
+        return String.format(Locale.ROOT, "%.0f%%", value * 100);
+    }
+
+    private static String safe(String value) {
+        String sanitized = value == null ? "" : value;
+        sanitized = SECRET_ASSIGNMENT.matcher(sanitized).replaceAll("$1=[REDACTED]");
+        sanitized = LONG_TOKEN.matcher(sanitized).replaceAll("[REDACTED]");
+        return sanitized.replaceAll("[\\p{Cntrl}&&[^\\r\\n\\t]]", "").trim();
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/browser/BrowserActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/browser/BrowserActions.java
@@ -8,8 +8,10 @@ import com.microsoft.playwright.options.LoadState;
 import com.shaft.driver.SHAFT;
 import com.shaft.enums.internal.Screenshots;
 import com.shaft.gui.browser.NetworkInterceptionRequestBuilder;
+import com.shaft.gui.browser.internal.BrowserNetworkInterceptionRule;
 import com.shaft.gui.playwright.internal.PlaywrightSession;
 import com.shaft.gui.playwright.validation.PlaywrightBrowserValidationsBuilder;
+import com.shaft.tools.io.internal.BrowserPerformanceExecutionReport;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import com.shaft.validation.ValidationEnums;
@@ -49,9 +51,10 @@ public class BrowserActions implements com.shaft.gui.driver.BrowserActionsContra
 
     @Override
     public BrowserActions capturePageSnapshot() {
-        ReportManagerHelper.attach("Playwright Page Snapshot", "page.html", page().content());
-        ReportManager.log("Captured Playwright page snapshot.");
-        return this;
+        return timedBrowserAction("playwright.browser.capturePageSnapshot", () -> {
+            ReportManagerHelper.attach("Playwright Page Snapshot", "page.html", page().content());
+            ReportManager.log("Captured Playwright page snapshot.");
+        });
     }
 
     @Override
@@ -96,9 +99,10 @@ public class BrowserActions implements com.shaft.gui.driver.BrowserActionsContra
 
     @Override
     public BrowserActions navigateToURL(String targetUrl) {
-        page().navigate(targetUrl);
-        ReportManager.log("Navigate to url \"" + targetUrl + "\".");
-        return this;
+        return timedPageLoad("playwright.browser.navigateToURL", targetUrl, () -> {
+            page().navigate(targetUrl);
+            ReportManager.log("Navigate to url \"" + targetUrl + "\".");
+        });
     }
 
     @Override
@@ -114,7 +118,8 @@ public class BrowserActions implements com.shaft.gui.driver.BrowserActionsContra
     public BrowserActions navigateToURL(String targetUrl, String targetUrlAfterRedirection) {
         navigateToURL(targetUrl);
         if (targetUrlAfterRedirection != null && !targetUrlAfterRedirection.isBlank()) {
-            page().waitForURL(targetUrlAfterRedirection);
+            timedPageLoad("playwright.browser.waitForURL", targetUrlAfterRedirection,
+                    () -> page().waitForURL(targetUrlAfterRedirection));
         }
         return this;
     }
@@ -130,28 +135,32 @@ public class BrowserActions implements com.shaft.gui.driver.BrowserActionsContra
 
     @Override
     public BrowserActions navigateBack() {
-        page().goBack();
-        return this;
+        return timedBrowserAction("playwright.browser.navigateBack", () -> page().goBack());
     }
 
     @Override
     public BrowserActions navigateForward() {
-        page().goForward();
-        return this;
+        return timedBrowserAction("playwright.browser.navigateForward", () -> page().goForward());
     }
 
     @Override
     public BrowserActions refreshCurrentPage() {
-        page().reload();
-        return this;
+        return timedPageLoad("playwright.browser.refreshCurrentPage", page().url(), () -> page().reload());
     }
 
     @Override
     public void closeCurrentWindow() {
-        page().close();
-        List<Page> pages = session.browserContext().pages();
-        if (!pages.isEmpty()) {
-            session.setPage(pages.getFirst());
+        long start = System.nanoTime();
+        try {
+            page().close();
+            List<Page> pages = session.browserContext().pages();
+            if (!pages.isEmpty()) {
+                session.setPage(pages.getFirst());
+            }
+        } finally {
+            BrowserPerformanceExecutionReport.recordBrowserAction(
+                    "playwright.browser.closeCurrentWindow",
+                    System.nanoTime() - start);
         }
     }
 
@@ -162,27 +171,28 @@ public class BrowserActions implements com.shaft.gui.driver.BrowserActionsContra
 
     @Override
     public BrowserActions setWindowSize(int width, int height) {
-        page().setViewportSize(width, height);
-        return this;
+        return timedBrowserAction("playwright.browser.setWindowSize", () -> page().setViewportSize(width, height));
     }
 
     @Override
     public BrowserActions mock(Predicate<HttpRequest> requestPredicate, HttpResponse mockedResponse) {
-        throw unsupported("Selenium HttpRequest/HttpResponse mocking");
+        return internalIntercept(requestPredicate, mockedResponse, "Configured Playwright network response mock.");
     }
 
     @Override
-    public NetworkInterceptionRequestBuilder interceptRequest() {
-        throw unsupported("Selenium network interception builder");
+    public NetworkInterceptionRequestBuilder<BrowserActions> interceptRequest() {
+        return new NetworkInterceptionRequestBuilder<>(this, this::registerNetworkInterceptionRule);
     }
 
     @Override
     public BrowserActions intercept(Predicate<HttpRequest> requestPredicate, HttpResponse mockedResponse) {
-        throw unsupported("Selenium HttpRequest/HttpResponse interception");
+        return internalIntercept(requestPredicate, mockedResponse, "Configured Playwright network interceptor.");
     }
 
     @Override
     public BrowserActions clearNetworkInterceptors() {
+        session.networkInterceptor().clear();
+        ReportManager.log("Cleared Playwright network interceptors.");
         return this;
     }
 
@@ -276,12 +286,13 @@ public class BrowserActions implements com.shaft.gui.driver.BrowserActionsContra
 
     @Override
     public BrowserActions captureScreenshot(Screenshots type) {
-        boolean fullPage = type == Screenshots.FULL;
-        byte[] screenshot = page().screenshot(new Page.ScreenshotOptions().setFullPage(fullPage));
-        ReportManagerHelper.attach("Playwright Screenshot", type.name().toLowerCase(Locale.ROOT) + ".png",
-                new ByteArrayInputStream(screenshot));
-        ReportManager.log("Captured Playwright page screenshot.");
-        return this;
+        return timedBrowserAction("playwright.browser.captureScreenshot", () -> {
+            boolean fullPage = type == Screenshots.FULL;
+            byte[] screenshot = page().screenshot(new Page.ScreenshotOptions().setFullPage(fullPage));
+            ReportManagerHelper.attach("Playwright Screenshot", type.name().toLowerCase(Locale.ROOT) + ".png",
+                    new ByteArrayInputStream(screenshot));
+            ReportManager.log("Captured Playwright page screenshot.");
+        });
     }
 
     @Override
@@ -296,8 +307,8 @@ public class BrowserActions implements com.shaft.gui.driver.BrowserActionsContra
 
     @Override
     public BrowserActions waitForLazyLoading() {
-        page().waitForLoadState(LoadState.LOAD);
-        return this;
+        return timedPageLoad("playwright.browser.waitForLazyLoading", page().url(),
+                () -> page().waitForLoadState(LoadState.LOAD));
     }
 
     @Override
@@ -325,7 +336,7 @@ public class BrowserActions implements com.shaft.gui.driver.BrowserActionsContra
 
     @Override
     public AccessibilityActions accessibility() {
-        throw unsupported("Selenium axe accessibility actions");
+        return new AccessibilityActions(page(), this);
     }
 
     public BrowserContext getNativeContext() {
@@ -342,6 +353,44 @@ public class BrowserActions implements com.shaft.gui.driver.BrowserActionsContra
 
     private Page page() {
         return session.page();
+    }
+
+    private BrowserActions internalIntercept(Predicate<HttpRequest> requestPredicate,
+                                             HttpResponse mockedResponse,
+                                             String successMessage) {
+        ReportManager.logDiscrete("Configuring Playwright network interceptor for \"" + requestPredicate + "\".");
+        ReportManagerHelper.attach("HTTP Response", "Mocked HTTP Response", String.valueOf(mockedResponse));
+        return registerNetworkInterceptionRule(
+                BrowserNetworkInterceptionRule.mock(requestPredicate, request -> mockedResponse),
+                successMessage);
+    }
+
+    public BrowserActions registerNetworkInterceptionRule(BrowserNetworkInterceptionRule rule, String successMessage) {
+        session.networkInterceptor().addRule(rule);
+        ReportManager.log(successMessage);
+        return this;
+    }
+
+    private BrowserActions timedBrowserAction(String actionName, Runnable action) {
+        long start = System.nanoTime();
+        try {
+            action.run();
+            return this;
+        } finally {
+            BrowserPerformanceExecutionReport.recordBrowserAction(actionName, System.nanoTime() - start);
+        }
+    }
+
+    private BrowserActions timedPageLoad(String actionName, String pageName, Runnable action) {
+        long start = System.nanoTime();
+        try {
+            action.run();
+            return this;
+        } finally {
+            long durationNanos = System.nanoTime() - start;
+            BrowserPerformanceExecutionReport.recordBrowserAction(actionName, durationNanos);
+            BrowserPerformanceExecutionReport.recordPageLoad(pageName, durationNanos);
+        }
     }
 
     private org.openqa.selenium.Cookie toSeleniumCookie(Cookie cookie) {

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/element/ElementActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/element/ElementActions.java
@@ -7,6 +7,7 @@ import com.shaft.gui.driver.ShaftLocator;
 import com.shaft.gui.playwright.internal.PlaywrightSession;
 import com.shaft.gui.playwright.validation.PlaywrightElementValidationsBuilder;
 import com.shaft.tools.io.ReportManager;
+import com.shaft.tools.io.internal.BrowserPerformanceExecutionReport;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import com.shaft.validation.ValidationEnums;
 import org.openqa.selenium.By;
@@ -92,9 +93,10 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     public ElementActions click(Locator elementLocator) {
-        elementLocator.click();
-        ReportManager.log("Clicked Playwright element.");
-        return this;
+        return timed("playwright.element.click", () -> {
+            elementLocator.click();
+            ReportManager.log("Clicked Playwright element.");
+        });
     }
 
     @Override
@@ -108,8 +110,8 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     public ElementActions clickUsingJavascript(Locator elementLocator) {
-        elementLocator.evaluate("element => element.click()");
-        return this;
+        return timed("playwright.element.clickUsingJavascript",
+                () -> elementLocator.evaluate("element => element.click()"));
     }
 
     @Override
@@ -123,8 +125,7 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     public ElementActions scrollToElement(Locator elementLocator) {
-        elementLocator.scrollIntoViewIfNeeded();
-        return this;
+        return timed("playwright.element.scrollToElement", elementLocator::scrollIntoViewIfNeeded);
     }
 
     @Override
@@ -138,10 +139,11 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     public ElementActions clickAndHold(Locator elementLocator) {
-        BoundingBox box = elementLocator.boundingBox();
-        session.page().mouse().move(box.x + box.width / 2, box.y + box.height / 2);
-        session.page().mouse().down();
-        return this;
+        return timed("playwright.element.clickAndHold", () -> {
+            BoundingBox box = elementLocator.boundingBox();
+            session.page().mouse().move(box.x + box.width / 2, box.y + box.height / 2);
+            session.page().mouse().down();
+        });
     }
 
     @Override
@@ -155,8 +157,7 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     public ElementActions doubleClick(Locator elementLocator) {
-        elementLocator.dblclick();
-        return this;
+        return timed("playwright.element.doubleClick", elementLocator::dblclick);
     }
 
     @Override
@@ -170,8 +171,7 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     public ElementActions dragAndDrop(Locator sourceElementLocator, Locator destinationElementLocator) {
-        sourceElementLocator.dragTo(destinationElementLocator);
-        return this;
+        return timed("playwright.element.dragAndDrop", () -> sourceElementLocator.dragTo(destinationElementLocator));
     }
 
     @Override
@@ -185,14 +185,15 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     public ElementActions dragAndDropByOffset(Locator sourceElementLocator, int xOffset, int yOffset) {
-        BoundingBox box = sourceElementLocator.boundingBox();
-        double x = box.x + box.width / 2;
-        double y = box.y + box.height / 2;
-        session.page().mouse().move(x, y);
-        session.page().mouse().down();
-        session.page().mouse().move(x + xOffset, y + yOffset);
-        session.page().mouse().up();
-        return this;
+        return timed("playwright.element.dragAndDropByOffset", () -> {
+            BoundingBox box = sourceElementLocator.boundingBox();
+            double x = box.x + box.width / 2;
+            double y = box.y + box.height / 2;
+            session.page().mouse().move(x, y);
+            session.page().mouse().down();
+            session.page().mouse().move(x + xOffset, y + yOffset);
+            session.page().mouse().up();
+        });
     }
 
     @Override
@@ -206,8 +207,7 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     public ElementActions hover(Locator elementLocator) {
-        elementLocator.hover();
-        return this;
+        return timed("playwright.element.hover", elementLocator::hover);
     }
 
     @Override
@@ -227,8 +227,7 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     public ElementActions select(Locator elementLocator, String valueOrVisibleText) {
-        elementLocator.selectOption(valueOrVisibleText);
-        return this;
+        return timed("playwright.element.select", () -> elementLocator.selectOption(valueOrVisibleText));
     }
 
     @Override
@@ -242,9 +241,9 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     public ElementActions setValueUsingJavaScript(Locator elementLocator, String value) {
-        elementLocator.evaluate("(element, value) => { element.value = value; element.dispatchEvent(new Event('input', {bubbles: true})); element.dispatchEvent(new Event('change', {bubbles: true})); }",
-                value);
-        return this;
+        return timed("playwright.element.setValueUsingJavaScript",
+                () -> elementLocator.evaluate("(element, value) => { element.value = value; element.dispatchEvent(new Event('input', {bubbles: true})); element.dispatchEvent(new Event('change', {bubbles: true})); }",
+                        value));
     }
 
     @Override
@@ -258,8 +257,8 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     public ElementActions submitFormUsingJavaScript(Locator elementLocator) {
-        elementLocator.evaluate("element => element.form ? element.form.submit() : element.submit()");
-        return this;
+        return timed("playwright.element.submitFormUsingJavaScript",
+                () -> elementLocator.evaluate("element => element.form ? element.form.submit() : element.submit()"));
     }
 
     @Override
@@ -288,8 +287,7 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     public ElementActions type(Locator elementLocator, CharSequence... text) {
-        elementLocator.fill(join(text));
-        return this;
+        return timed("playwright.element.type", () -> elementLocator.fill(join(text)));
     }
 
     @Override
@@ -303,8 +301,7 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     public ElementActions clear(Locator elementLocator) {
-        elementLocator.clear();
-        return this;
+        return timed("playwright.element.clear", elementLocator::clear);
     }
 
     @Override
@@ -318,8 +315,7 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     public ElementActions typeAppend(Locator elementLocator, CharSequence... text) {
-        elementLocator.pressSequentially(join(text));
-        return this;
+        return timed("playwright.element.typeAppend", () -> elementLocator.pressSequentially(join(text)));
     }
 
     @Override
@@ -333,8 +329,8 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     public ElementActions typeFileLocationForUpload(Locator elementLocator, String filePath) {
-        elementLocator.setInputFiles(Path.of(filePath));
-        return this;
+        return timed("playwright.element.typeFileLocationForUpload",
+                () -> elementLocator.setInputFiles(Path.of(filePath)));
     }
 
     @Override
@@ -348,9 +344,10 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     public ElementActions typeSecure(Locator elementLocator, CharSequence... text) {
-        elementLocator.fill(join(text));
-        ReportManager.log("Typed secure text into Playwright element.");
-        return this;
+        return timed("playwright.element.typeSecure", () -> {
+            elementLocator.fill(join(text));
+            ReportManager.log("Typed secure text into Playwright element.");
+        });
     }
 
     @Override
@@ -397,10 +394,11 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     public ElementActions captureScreenshot(Locator elementLocator) {
-        byte[] screenshot = elementLocator.screenshot();
-        ReportManagerHelper.attach("Playwright Screenshot", "element.png", new ByteArrayInputStream(screenshot));
-        ReportManager.log("Captured Playwright element screenshot.");
-        return this;
+        return timed("playwright.element.captureScreenshot", () -> {
+            byte[] screenshot = elementLocator.screenshot();
+            ReportManagerHelper.attach("Playwright Screenshot", "element.png", new ByteArrayInputStream(screenshot));
+            ReportManager.log("Captured Playwright element screenshot.");
+        });
     }
 
     private Locator resolve(By locator) {
@@ -417,6 +415,16 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
             builder.append(value);
         }
         return builder.toString();
+    }
+
+    private ElementActions timed(String actionName, Runnable action) {
+        long start = System.nanoTime();
+        try {
+            action.run();
+            return this;
+        } finally {
+            BrowserPerformanceExecutionReport.recordBrowserAction(actionName, System.nanoTime() - start);
+        }
     }
 
     private UnsupportedOperationException unsupported(String capability) {

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSession.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSession.java
@@ -5,6 +5,7 @@ import com.microsoft.playwright.BrowserContext;
 import com.microsoft.playwright.Dialog;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
+import com.shaft.gui.browser.internal.PlaywrightNetworkInterceptor;
 import com.shaft.tools.io.ReportManager;
 import org.apache.logging.log4j.Level;
 
@@ -22,6 +23,7 @@ public final class PlaywrightSession implements AutoCloseable {
     private final BrowserContext browserContext;
     private Page page;
     private final PlaywrightTraceManager traceManager;
+    private final PlaywrightNetworkInterceptor networkInterceptor;
     private final AtomicReference<String> lastDialogText = new AtomicReference<>();
     private final AtomicBoolean dialogSeen = new AtomicBoolean();
     private final AtomicReference<DialogAction> nextDialogAction = new AtomicReference<>();
@@ -36,6 +38,7 @@ public final class PlaywrightSession implements AutoCloseable {
         this.browserContext = browserContext;
         this.page = page;
         this.traceManager = traceManager;
+        this.networkInterceptor = new PlaywrightNetworkInterceptor(browserContext);
         registerDialogBridge(page);
     }
 
@@ -62,6 +65,10 @@ public final class PlaywrightSession implements AutoCloseable {
 
     public PlaywrightTraceManager traceManager() {
         return traceManager;
+    }
+
+    public PlaywrightNetworkInterceptor networkInterceptor() {
+        return networkInterceptor;
     }
 
     public boolean isDialogSeen() {
@@ -103,6 +110,7 @@ public final class PlaywrightSession implements AutoCloseable {
 
     @Override
     public void close() {
+        networkInterceptor.clear();
         if (traceManager != null) {
             traceManager.stopAndAttach();
         }

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightValidationsExecutor.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightValidationsExecutor.java
@@ -9,6 +9,7 @@ import com.shaft.driver.SHAFT;
 import com.shaft.gui.internal.image.ImageProcessingActions;
 import com.shaft.gui.internal.image.ScreenshotManager;
 import com.shaft.gui.playwright.internal.PlaywrightSession;
+import com.shaft.tools.io.internal.BrowserPerformanceExecutionReport;
 import com.shaft.tools.internal.support.JavaHelper;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.ProgressBarLogger;
@@ -88,11 +89,15 @@ final class PlaywrightValidationsExecutor extends ValidationsExecutor {
         validationCategoryString = validationCategory == ValidationEnums.ValidationCategory.HARD_ASSERT ? "Assert" : "Verify";
         ReportManager.logDiscrete(validationCategoryString + " that " + customReportMessage);
         String progressTaskName = validationCategoryString.equals("Assert") ? "Asserting..." : "Verifying...";
+        long start = System.nanoTime();
         try {
             try (ProgressBarLogger ignored = new ProgressBarLogger(progressTaskName)) {
                 performPlaywrightValidation();
             }
         } finally {
+            BrowserPerformanceExecutionReport.recordBrowserAction(
+                    "playwright.validation." + validationMethod,
+                    System.nanoTime() - start);
             if (generatedCustomReportMessage) {
                 customReportMessage = "";
             }

--- a/shaft-engine/src/main/java/com/shaft/listeners/internal/ExecutionLifecycleHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/internal/ExecutionLifecycleHelper.java
@@ -11,6 +11,7 @@ import com.shaft.tools.internal.FirestoreRestClient;
 import com.shaft.tools.internal.security.GoogleTink;
 import com.shaft.tools.io.internal.AllureManager;
 import com.shaft.tools.io.internal.ApiPerformanceExecutionReport;
+import com.shaft.tools.io.internal.BrowserPerformanceExecutionReport;
 import com.shaft.tools.io.internal.ExecutionSummaryReport;
 import com.shaft.tools.io.internal.FailureDiagnosticsReporter;
 import com.shaft.tools.io.internal.FailureTraceReporter;
@@ -43,6 +44,7 @@ public final class ExecutionLifecycleHelper {
      */
     public static void engineSetup(ProjectStructureManager.RunType runType) {
         LocatorHealthReporter.reset();
+        BrowserPerformanceExecutionReport.reset();
         PropertiesHelper.bootstrapEngine(runType);
     }
 
@@ -146,6 +148,11 @@ public final class ExecutionLifecycleHelper {
         AssertionError openApiCoverageFailure = OpenApiCoverageReporter.reportAndGetThresholdFailure();
         AssertionError locatorHealthFailure = LocatorHealthReporter.reportAndGetFailure();
         long executionEndTime = System.currentTimeMillis();
+        Map<String, List<Double>> performanceData = RequestBuilder.getPerformanceData();
+        AssertionError apiPerformanceFailure = ApiPerformanceExecutionReport.generatePerformanceReportAndGetFailure(
+                performanceData, executionStartTime, executionEndTime);
+        AssertionError browserPerformanceFailure = BrowserPerformanceExecutionReport.generatePerformanceReportAndGetFailure(
+                executionStartTime, executionEndTime);
         ExecutionSummaryReport.generateExecutionSummaryReport(
                 counts.finalPassed(), counts.failed(), counts.skipped(), executionStartTime, executionEndTime);
         Thread.ofVirtual().start(JiraHelper::reportExecutionStatusToJira);
@@ -153,20 +160,37 @@ public final class ExecutionLifecycleHelper {
         Thread.ofVirtual().start(() -> FirestoreRestClient.sendTelemetry(
                 executionStartTime, executionEndTime, counts.passed(), counts.failed(), counts.skipped(), counts.flaky()));
         ReportManagerHelper.logEngineClosure();
-        Thread.ofVirtual().start(() -> {
-            Map<String, List<Double>> performanceData = RequestBuilder.getPerformanceData();
-            ApiPerformanceExecutionReport.generatePerformanceReport(performanceData, executionStartTime, System.currentTimeMillis());
-        });
         AllureManager.openAllureReportAfterExecution();
         AllureManager.generateAllureReportArchive();
         if (openApiCoverageFailure != null && locatorHealthFailure != null) {
             openApiCoverageFailure.addSuppressed(locatorHealthFailure);
         }
+        if (openApiCoverageFailure != null && apiPerformanceFailure != null) {
+            openApiCoverageFailure.addSuppressed(apiPerformanceFailure);
+        }
+        if (openApiCoverageFailure != null && browserPerformanceFailure != null) {
+            openApiCoverageFailure.addSuppressed(browserPerformanceFailure);
+        }
         if (openApiCoverageFailure != null) {
             throw openApiCoverageFailure;
         }
+        if (locatorHealthFailure != null && apiPerformanceFailure != null) {
+            locatorHealthFailure.addSuppressed(apiPerformanceFailure);
+        }
+        if (locatorHealthFailure != null && browserPerformanceFailure != null) {
+            locatorHealthFailure.addSuppressed(browserPerformanceFailure);
+        }
         if (locatorHealthFailure != null) {
             throw locatorHealthFailure;
+        }
+        if (apiPerformanceFailure != null && browserPerformanceFailure != null) {
+            apiPerformanceFailure.addSuppressed(browserPerformanceFailure);
+        }
+        if (apiPerformanceFailure != null) {
+            throw apiPerformanceFailure;
+        }
+        if (browserPerformanceFailure != null) {
+            throw browserPerformanceFailure;
         }
     }
 

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Performance.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Performance.java
@@ -38,6 +38,60 @@ public interface Performance extends EngineProperties<Performance> {
         // Default is enabled
     boolean isEnablePerformanceReport();
 
+    /**
+     * Returns comma-separated per-endpoint API p95 performance budgets in milliseconds.
+     *
+     * <p>Use normalized endpoint names as report keys, for example
+     * {@code users=500,orders/{id}=750}. Blank means no endpoint budgets are configured.
+     *
+     * @return configured API endpoint budgets, or a blank string
+     */
+    @Key("apiEndpointPerformanceBudgets")
+    @DefaultValue("")
+    String apiEndpointPerformanceBudgets();
+
+    /**
+     * Returns whether API p95 budget violations should fail the run instead of warning only.
+     *
+     * @return {@code true} when budget violations should fail the run
+     */
+    @Key("failOnApiPerformanceBudgetViolation")
+    @DefaultValue("false")
+    boolean failOnApiPerformanceBudgetViolation();
+
+    /**
+     * Returns comma-separated Playwright browser action p95 performance budgets in milliseconds.
+     *
+     * <p>Use metric names such as {@code playwright.element.click=750} or {@code *=1000}
+     * to apply a default budget to every recorded browser action.
+     *
+     * @return configured browser action budgets, or a blank string
+     */
+    @Key("browserActionPerformanceBudgets")
+    @DefaultValue("")
+    String browserActionPerformanceBudgets();
+
+    /**
+     * Returns comma-separated Playwright page-load p95 performance budgets in milliseconds.
+     *
+     * <p>Use navigated URLs as keys, for example {@code https://example.com=3000}, or
+     * {@code *=3000} to apply one default budget to every recorded page load.
+     *
+     * @return configured page-load budgets, or a blank string
+     */
+    @Key("pageLoadPerformanceBudgets")
+    @DefaultValue("")
+    String pageLoadPerformanceBudgets();
+
+    /**
+     * Returns whether browser p95 budget violations should fail the run instead of warning only.
+     *
+     * @return {@code true} when browser budget violations should fail the run
+     */
+    @Key("failOnBrowserPerformanceBudgetViolation")
+    @DefaultValue("false")
+    boolean failOnBrowserPerformanceBudgetViolation();
+
     default SetProperty set() {
         return new SetProperty();
     }
@@ -56,6 +110,61 @@ public interface Performance extends EngineProperties<Performance> {
 
         public SetProperty generatePerformanceReport(boolean value) {
             setProperty("generatePerformanceReport", String.valueOf(value));
+            return this;
+        }
+
+        /**
+         * Overrides comma-separated per-endpoint API p95 performance budgets in milliseconds.
+         *
+         * @param value budgets formatted as {@code endpoint=millis,endpoint=millis}
+         * @return self-reference for fluent property overrides
+         */
+        public SetProperty apiEndpointPerformanceBudgets(String value) {
+            setProperty("apiEndpointPerformanceBudgets", value);
+            return this;
+        }
+
+        /**
+         * Overrides whether API p95 budget violations should fail the run.
+         *
+         * @param value {@code true} to fail the run on budget violations
+         * @return self-reference for fluent property overrides
+         */
+        public SetProperty failOnApiPerformanceBudgetViolation(boolean value) {
+            setProperty("failOnApiPerformanceBudgetViolation", String.valueOf(value));
+            return this;
+        }
+
+        /**
+         * Overrides comma-separated Playwright browser action p95 performance budgets in milliseconds.
+         *
+         * @param value budgets formatted as {@code action=millis,action=millis}
+         * @return self-reference for fluent property overrides
+         */
+        public SetProperty browserActionPerformanceBudgets(String value) {
+            setProperty("browserActionPerformanceBudgets", value);
+            return this;
+        }
+
+        /**
+         * Overrides comma-separated Playwright page-load p95 performance budgets in milliseconds.
+         *
+         * @param value budgets formatted as {@code page=millis,page=millis}
+         * @return self-reference for fluent property overrides
+         */
+        public SetProperty pageLoadPerformanceBudgets(String value) {
+            setProperty("pageLoadPerformanceBudgets", value);
+            return this;
+        }
+
+        /**
+         * Overrides whether browser budget violations should fail the run.
+         *
+         * @param value {@code true} to fail the run on budget violations
+         * @return self-reference for fluent property overrides
+         */
+        public SetProperty failOnBrowserPerformanceBudgetViolation(boolean value) {
+            setProperty("failOnBrowserPerformanceBudgetViolation", String.valueOf(value));
             return this;
         }
     }

--- a/shaft-engine/src/main/java/com/shaft/tools/internal/support/PerformanceReportHTMLHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/internal/support/PerformanceReportHTMLHelper.java
@@ -106,7 +106,7 @@ public class PerformanceReportHTMLHelper {
 
         // Start of the performance table with pagination
         html.append("<table id='performanceTable'><thead>");
-        html.append("<tr><th>Endpoint</th><th>Requests</th><th>Max Response Time (ms)</th><th>Min Response Time (ms)</th><th>Average Response Time (ms)</th></tr>");
+        html.append("<tr><th>Endpoint</th><th>Requests</th><th>Max Response Time (ms)</th><th>Min Response Time (ms)</th><th>Average Response Time (ms)</th><th>P50 Response Time (ms)</th><th>P90 Response Time (ms)</th><th>P95 Response Time (ms)</th><th>P99 Response Time (ms)</th><th>Budget (p95 ms)</th><th>Budget Status</th></tr>");
         html.append("</thead><tbody>");
 
         // Insert the performance data rows

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/ApiPerformanceExecutionReport.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/ApiPerformanceExecutionReport.java
@@ -33,17 +33,17 @@ import java.util.Objects;
  * API performance-tracking infrastructure.
  */
 public class ApiPerformanceExecutionReport {
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+    private static final String BUDGET_METRIC = "p95";
+    private static final DateTimeFormatter READABLE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault());
+    private static final DateTimeFormatter FILENAME_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy_HH-mm-ss-SSSS-a").withZone(ZoneId.systemDefault());
+
     /**
      * Creates a new API performance execution report helper instance.
      */
     public ApiPerformanceExecutionReport() {
         super();
     }
-
-    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
-    private static final String BUDGET_METRIC = "p95";
-    private static final DateTimeFormatter READABLE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault());
-    private static final DateTimeFormatter FILENAME_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy_HH-mm-ss-SSSS-a").withZone(ZoneId.systemDefault());
 
     // Fetch properties from the Reporting interface
 

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/ApiPerformanceExecutionReport.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/ApiPerformanceExecutionReport.java
@@ -1,21 +1,28 @@
 package com.shaft.tools.io.internal;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.shaft.cli.FileActions;
 import com.shaft.driver.SHAFT;
 import com.shaft.tools.internal.support.PerformanceReportHTMLHelper;
 import com.shaft.tools.io.ReportManager;
+import org.apache.logging.log4j.Level;
 
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
 import java.util.DoubleSummaryStatistics;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.LinkedHashMap;
+import java.util.Objects;
 
 /**
  * Utility class for generating HTML-based API performance execution reports.
- * Aggregates per-endpoint response-time statistics (count, min, max, average) collected during
+ * Aggregates per-endpoint response-time statistics collected during
  * a test run and writes a self-contained HTML report file to the path configured by
  * {@code SHAFT.Properties.paths.performanceReportPath()}.
  *
@@ -32,6 +39,9 @@ public class ApiPerformanceExecutionReport {
     public ApiPerformanceExecutionReport() {
         super();
     }
+
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+    private static final String BUDGET_METRIC = "p95";
     private static final DateTimeFormatter READABLE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault());
     private static final DateTimeFormatter FILENAME_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy_HH-mm-ss-SSSS-a").withZone(ZoneId.systemDefault());
 
@@ -60,12 +70,44 @@ public class ApiPerformanceExecutionReport {
      * @param endTime         the epoch-millisecond timestamp when the test suite finished
      */
     public static void generatePerformanceReport(Map<String, List<Double>> performanceData, long startTime, long endTime) {
-        // Check if performance report generation is enabled
-        if (!SHAFT.Properties.performance.isEnablePerformanceReport()) {
+        AssertionError failure = generatePerformanceReportAndGetFailure(performanceData, startTime, endTime);
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    /**
+     * Calculates per-endpoint performance statistics, writes enabled reports, and returns the
+     * configured budget failure without throwing it.
+     *
+     * @param performanceData a map where each key is a normalized API endpoint path and each value
+     *                        is a list of individual response times in milliseconds
+     * @param startTime       the epoch-millisecond timestamp when the test suite began
+     * @param endTime         the epoch-millisecond timestamp when the test suite finished
+     * @return assertion error when API performance budgets should fail the run; otherwise {@code null}
+     */
+    public static AssertionError generatePerformanceReportAndGetFailure(
+            Map<String, List<Double>> performanceData, long startTime, long endTime) {
+        boolean reportEnabled = SHAFT.Properties.performance.isEnablePerformanceReport();
+        Map<String, Double> endpointBudgets = parseEndpointBudgets(SHAFT.Properties.performance.apiEndpointPerformanceBudgets());
+        if (!reportEnabled && endpointBudgets.isEmpty()) {
             ReportManager.logDiscrete("Performance report generation is disabled.");
-            return;
+            return null;
         }
 
+        boolean failOnBudgetViolation = SHAFT.Properties.performance.failOnApiPerformanceBudgetViolation();
+        List<EndpointStats> endpointStats = buildEndpointStats(performanceData, endpointBudgets, failOnBudgetViolation);
+        logBudgetViolations(endpointStats);
+        AssertionError failure = budgetFailure(endpointStats);
+
+        if (reportEnabled) {
+            writeReports(endpointStats, startTime, endTime, failOnBudgetViolation);
+        }
+        return failure;
+    }
+
+    private static void writeReports(List<EndpointStats> endpointStats, long startTime, long endTime,
+                                     boolean failOnBudgetViolation) {
         var fileActionsSession = FileActions.getInstance(true);
 
         fileActionsSession.createFolder(SHAFT.Properties.paths.performanceReportPath());
@@ -82,26 +124,113 @@ public class ApiPerformanceExecutionReport {
 
         // Generate performance summary statistics for each endpoint
         StringBuilder performanceSummary = new StringBuilder();
-        performanceData.forEach((endpoint, times) -> {
-            DoubleSummaryStatistics stats = times.stream().mapToDouble(Double::doubleValue).summaryStatistics();
-            performanceSummary.append("<tr>");
-            performanceSummary.append("<td>").append(endpoint).append("</td>");
-            performanceSummary.append("<td>").append(stats.getCount()).append("</td>");
-            performanceSummary.append("<td>").append(String.format("%.2f", stats.getMax())).append("</td>");
-            performanceSummary.append("<td>").append(String.format("%.2f", stats.getMin())).append("</td>");
-            performanceSummary.append("<td>").append(String.format("%.2f", stats.getAverage())).append("</td>");
-            performanceSummary.append("</tr>");
-        });
+        endpointStats.forEach(stats -> performanceSummary.append(stats.toHtmlRow()));
 
         // Generate the final HTML content using the buildHtml method
         String htmlReport = PerformanceReportHTMLHelper.buildHtml(formattedStartTime, formattedEndTime, formattedExecutionTime, performanceSummary.toString());
+        String jsonReport = buildJsonReport(formattedStartTime, formattedEndTime, formattedExecutionTime,
+                endpointStats, failOnBudgetViolation);
 
         // Define the path where the report will be saved
         //String reportPath = SHAFT.Properties.paths.performanceReport() + "/PerformanceReport_" + getTimestamp() + ".html";
         //saveHtmlToFile(reportPath, htmlReport);
-        fileActionsSession.writeToFile(SHAFT.Properties.paths.performanceReportPath(), "PerformanceReport_" + getTimestamp() + ".html", htmlReport);
+        String timestamp = getTimestamp();
+        fileActionsSession.writeToFile(SHAFT.Properties.paths.performanceReportPath(), "PerformanceReport_" + timestamp + ".html", htmlReport);
+        fileActionsSession.writeToFile(SHAFT.Properties.paths.performanceReportPath(), "PerformanceReport_" + timestamp + ".json", jsonReport);
         // Pass the formatted data to PHTMLHelper for HTML generation
         //PHTMLHelper.generateHtmlReport(formattedStartTime, formattedEndTime, formattedExecutionTime, performanceSummary.toString(), reportPath);
+    }
+
+    private static List<EndpointStats> buildEndpointStats(Map<String, List<Double>> performanceData,
+                                                          Map<String, Double> endpointBudgets,
+                                                          boolean failOnBudgetViolation) {
+        if (performanceData == null || performanceData.isEmpty()) {
+            return List.of();
+        }
+        return performanceData.entrySet().stream()
+                .filter(entry -> entry.getKey() != null)
+                .map(entry -> EndpointStats.from(entry.getKey(), copyAndSort(entry.getValue()),
+                        endpointBudgets.get(entry.getKey()), failOnBudgetViolation))
+                .sorted(Comparator.comparing(EndpointStats::endpoint))
+                .toList();
+    }
+
+    private static List<Double> copyAndSort(List<Double> times) {
+        if (times == null || times.isEmpty()) {
+            return List.of();
+        }
+        synchronized (times) {
+            return times.stream()
+                    .filter(Objects::nonNull)
+                    .sorted()
+                    .toList();
+        }
+    }
+
+    private static Map<String, Double> parseEndpointBudgets(String configuredBudgets) {
+        if (configuredBudgets == null || configuredBudgets.isBlank()) {
+            return Map.of();
+        }
+        Map<String, Double> budgets = new LinkedHashMap<>();
+        for (String entry : configuredBudgets.split("[,;\\r\\n]+")) {
+            String trimmedEntry = entry.trim();
+            if (trimmedEntry.isEmpty()) {
+                continue;
+            }
+            int separator = trimmedEntry.lastIndexOf('=');
+            if (separator <= 0 || separator == trimmedEntry.length() - 1) {
+                ReportManager.logDiscrete("Ignoring invalid API performance budget entry: \"" + trimmedEntry + "\".", Level.WARN);
+                continue;
+            }
+
+            String endpoint = trimmedEntry.substring(0, separator).trim();
+            String budgetValue = trimmedEntry.substring(separator + 1).trim();
+            try {
+                double budgetMillis = Double.parseDouble(budgetValue);
+                if (endpoint.isBlank() || budgetMillis < 0 || !Double.isFinite(budgetMillis)) {
+                    ReportManager.logDiscrete("Ignoring invalid API performance budget entry: \"" + trimmedEntry + "\".", Level.WARN);
+                    continue;
+                }
+                budgets.put(endpoint, budgetMillis);
+            } catch (NumberFormatException e) {
+                ReportManager.logDiscrete("Ignoring invalid API performance budget entry: \"" + trimmedEntry + "\".", Level.WARN);
+            }
+        }
+        return budgets;
+    }
+
+    private static void logBudgetViolations(List<EndpointStats> endpointStats) {
+        endpointStats.stream()
+                .filter(EndpointStats::hasBudgetViolation)
+                .forEach(stats -> ReportManager.logDiscrete(
+                        "API performance budget " + stats.budgetStatus().name().toLowerCase(Locale.ROOT)
+                                + ": " + stats.budgetViolationMessage() + ".",
+                        Level.WARN));
+    }
+
+    private static AssertionError budgetFailure(List<EndpointStats> endpointStats) {
+        List<String> failures = endpointStats.stream()
+                .filter(stats -> stats.budgetStatus() == BudgetStatus.FAIL)
+                .map(EndpointStats::budgetViolationMessage)
+                .toList();
+        if (failures.isEmpty()) {
+            return null;
+        }
+        return new AssertionError("API performance budget violations: " + String.join("; ", failures) + ".");
+    }
+
+    private static String buildJsonReport(String formattedStartTime, String formattedEndTime,
+                                          String formattedExecutionTime, List<EndpointStats> endpointStats,
+                                          boolean failOnBudgetViolation) {
+        ObjectNode root = JSON_MAPPER.createObjectNode();
+        root.put("startTime", formattedStartTime);
+        root.put("endTime", formattedEndTime);
+        root.put("executionTime", formattedExecutionTime);
+        root.put("budgetMetric", BUDGET_METRIC);
+        root.put("failOnBudgetViolation", failOnBudgetViolation);
+        var endpoints = root.putArray("endpoints");
+        endpointStats.forEach(stats -> stats.appendJson(endpoints.addObject()));
+        return root.toPrettyString();
     }
 
     // Helper method to format the timestamp into a readable date
@@ -119,5 +248,103 @@ public class ApiPerformanceExecutionReport {
     // Method to generate a timestamp for the report filename
     private static String getTimestamp() {
         return FILENAME_FORMATTER.format(ZonedDateTime.now());
+    }
+
+    private static String formatMillis(double millis) {
+        return String.format(Locale.ROOT, "%.2f", millis);
+    }
+
+    private static String htmlEscape(String value) {
+        return value.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+
+    private record EndpointStats(String endpoint, long requests, double minMillis, double maxMillis,
+                                 double averageMillis, double p50Millis, double p90Millis,
+                                 double p95Millis, double p99Millis, Double budgetMillis,
+                                 BudgetStatus budgetStatus) {
+        private static EndpointStats from(String endpoint, List<Double> sortedTimes, Double budgetMillis,
+                                          boolean failOnBudgetViolation) {
+            DoubleSummaryStatistics stats = sortedTimes.stream().mapToDouble(Double::doubleValue).summaryStatistics();
+            long requests = stats.getCount();
+            double minMillis = requests == 0 ? 0 : stats.getMin();
+            double maxMillis = requests == 0 ? 0 : stats.getMax();
+            double averageMillis = requests == 0 ? 0 : stats.getAverage();
+            double p50Millis = percentile(sortedTimes, 50);
+            double p90Millis = percentile(sortedTimes, 90);
+            double p95Millis = percentile(sortedTimes, 95);
+            double p99Millis = percentile(sortedTimes, 99);
+            BudgetStatus budgetStatus = budgetStatus(p95Millis, budgetMillis, failOnBudgetViolation);
+            return new EndpointStats(endpoint, requests, minMillis, maxMillis, averageMillis, p50Millis,
+                    p90Millis, p95Millis, p99Millis, budgetMillis, budgetStatus);
+        }
+
+        private static double percentile(List<Double> sortedTimes, int percentile) {
+            if (sortedTimes.isEmpty()) {
+                return 0;
+            }
+            int index = (int) Math.ceil(percentile / 100d * sortedTimes.size()) - 1;
+            return sortedTimes.get(Math.max(0, Math.min(index, sortedTimes.size() - 1)));
+        }
+
+        private static BudgetStatus budgetStatus(double p95Millis, Double budgetMillis,
+                                                 boolean failOnBudgetViolation) {
+            if (budgetMillis == null) {
+                return BudgetStatus.NOT_CONFIGURED;
+            }
+            if (p95Millis <= budgetMillis) {
+                return BudgetStatus.PASS;
+            }
+            return failOnBudgetViolation ? BudgetStatus.FAIL : BudgetStatus.WARN;
+        }
+
+        private boolean hasBudgetViolation() {
+            return budgetStatus == BudgetStatus.WARN || budgetStatus == BudgetStatus.FAIL;
+        }
+
+        private String budgetViolationMessage() {
+            return endpoint + " p95 " + formatMillis(p95Millis) + "ms exceeded budget "
+                    + formatMillis(budgetMillis) + "ms";
+        }
+
+        private String toHtmlRow() {
+            return "<tr><td>" + htmlEscape(endpoint) + "</td>"
+                    + "<td>" + requests + "</td>"
+                    + "<td>" + formatMillis(maxMillis) + "</td>"
+                    + "<td>" + formatMillis(minMillis) + "</td>"
+                    + "<td>" + formatMillis(averageMillis) + "</td>"
+                    + "<td>" + formatMillis(p50Millis) + "</td>"
+                    + "<td>" + formatMillis(p90Millis) + "</td>"
+                    + "<td>" + formatMillis(p95Millis) + "</td>"
+                    + "<td>" + formatMillis(p99Millis) + "</td>"
+                    + "<td>" + (budgetMillis == null ? "" : formatMillis(budgetMillis)) + "</td>"
+                    + "<td>" + budgetStatus + "</td></tr>";
+        }
+
+        private void appendJson(ObjectNode endpointNode) {
+            endpointNode.put("endpoint", endpoint);
+            endpointNode.put("requests", requests);
+            endpointNode.put("minMillis", minMillis);
+            endpointNode.put("maxMillis", maxMillis);
+            endpointNode.put("averageMillis", averageMillis);
+            endpointNode.put("p50Millis", p50Millis);
+            endpointNode.put("p90Millis", p90Millis);
+            endpointNode.put("p95Millis", p95Millis);
+            endpointNode.put("p99Millis", p99Millis);
+            if (budgetMillis == null) {
+                endpointNode.putNull("budgetMillis");
+            } else {
+                endpointNode.put("budgetMillis", budgetMillis);
+            }
+            endpointNode.put("budgetMetric", BUDGET_METRIC);
+            endpointNode.put("budgetStatus", budgetStatus.name());
+        }
+    }
+
+    private enum BudgetStatus {
+        PASS, WARN, FAIL, NOT_CONFIGURED
     }
 }

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/BrowserPerformanceExecutionReport.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/BrowserPerformanceExecutionReport.java
@@ -1,0 +1,376 @@
+package com.shaft.tools.io.internal;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.shaft.cli.FileActions;
+import com.shaft.driver.SHAFT;
+import com.shaft.tools.io.ReportManager;
+import org.apache.logging.log4j.Level;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.DoubleSummaryStatistics;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Aggregates Playwright browser action and page-load timings into performance budget reports.
+ */
+public final class BrowserPerformanceExecutionReport {
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+    private static final String BUDGET_METRIC = "p95";
+    private static final DateTimeFormatter READABLE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault());
+    private static final DateTimeFormatter FILENAME_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy_HH-mm-ss-SSSS-a").withZone(ZoneId.systemDefault());
+    private static final Map<String, List<Double>> BROWSER_ACTION_DATA = new ConcurrentHashMap<>();
+    private static final Map<String, List<Double>> PAGE_LOAD_DATA = new ConcurrentHashMap<>();
+
+    private BrowserPerformanceExecutionReport() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static Map<String, List<Double>> getBrowserActionPerformanceData() {
+        return BROWSER_ACTION_DATA;
+    }
+
+    public static Map<String, List<Double>> getPageLoadPerformanceData() {
+        return PAGE_LOAD_DATA;
+    }
+
+    public static void reset() {
+        BROWSER_ACTION_DATA.clear();
+        PAGE_LOAD_DATA.clear();
+    }
+
+    public static void recordBrowserAction(String actionName, long durationNanos) {
+        record(BROWSER_ACTION_DATA, actionName, durationNanos);
+    }
+
+    public static void recordPageLoad(String pageName, long durationNanos) {
+        record(PAGE_LOAD_DATA, pageName, durationNanos);
+    }
+
+    public static boolean shouldRecord() {
+        return SHAFT.Properties.performance.isEnablePerformanceReport()
+                || !isBlank(SHAFT.Properties.performance.browserActionPerformanceBudgets())
+                || !isBlank(SHAFT.Properties.performance.pageLoadPerformanceBudgets());
+    }
+
+    public static void generatePerformanceReport(long startTime, long endTime) {
+        AssertionError failure = generatePerformanceReportAndGetFailure(startTime, endTime);
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    public static AssertionError generatePerformanceReportAndGetFailure(long startTime, long endTime) {
+        Map<String, Double> actionBudgets = parseBudgets(
+                SHAFT.Properties.performance.browserActionPerformanceBudgets(),
+                "browser action");
+        Map<String, Double> pageLoadBudgets = parseBudgets(
+                SHAFT.Properties.performance.pageLoadPerformanceBudgets(),
+                "page-load");
+        boolean hasData = !BROWSER_ACTION_DATA.isEmpty() || !PAGE_LOAD_DATA.isEmpty();
+        if (!hasData && actionBudgets.isEmpty() && pageLoadBudgets.isEmpty()) {
+            return null;
+        }
+
+        boolean failOnBudgetViolation = SHAFT.Properties.performance.failOnBrowserPerformanceBudgetViolation();
+        List<MetricStats> actionStats = buildStats(BROWSER_ACTION_DATA, actionBudgets, failOnBudgetViolation);
+        List<MetricStats> pageLoadStats = buildStats(PAGE_LOAD_DATA, pageLoadBudgets, failOnBudgetViolation);
+        logBudgetViolations("browser action", actionStats);
+        logBudgetViolations("page-load", pageLoadStats);
+        AssertionError failure = budgetFailure(actionStats, pageLoadStats);
+
+        if (SHAFT.Properties.performance.isEnablePerformanceReport()) {
+            writeReports(actionStats, pageLoadStats, startTime, endTime, failOnBudgetViolation);
+        }
+        return failure;
+    }
+
+    private static void record(Map<String, List<Double>> data, String key, long durationNanos) {
+        if (!shouldRecord() || isBlank(key)) {
+            return;
+        }
+        double durationMillis = Math.max(0, durationNanos) / 1_000_000d;
+        data.computeIfAbsent(key, ignored -> Collections.synchronizedList(new ArrayList<>()))
+                .add(durationMillis);
+    }
+
+    private static List<MetricStats> buildStats(Map<String, List<Double>> data, Map<String, Double> budgets,
+                                                boolean failOnBudgetViolation) {
+        return data.entrySet().stream()
+                .filter(entry -> !isBlank(entry.getKey()))
+                .map(entry -> MetricStats.from(entry.getKey(), copyAndSort(entry.getValue()),
+                        budgetFor(budgets, entry.getKey()), failOnBudgetViolation))
+                .sorted(Comparator.comparing(MetricStats::metric))
+                .toList();
+    }
+
+    private static List<Double> copyAndSort(List<Double> times) {
+        if (times == null || times.isEmpty()) {
+            return List.of();
+        }
+        synchronized (times) {
+            return times.stream()
+                    .filter(Objects::nonNull)
+                    .sorted()
+                    .toList();
+        }
+    }
+
+    private static Double budgetFor(Map<String, Double> budgets, String key) {
+        Double exact = budgets.get(key);
+        return exact == null ? budgets.get("*") : exact;
+    }
+
+    private static Map<String, Double> parseBudgets(String configuredBudgets, String budgetType) {
+        if (configuredBudgets == null || configuredBudgets.isBlank()) {
+            return Map.of();
+        }
+        Map<String, Double> budgets = new LinkedHashMap<>();
+        for (String entry : configuredBudgets.split("[,;\\r\\n]+")) {
+            String trimmedEntry = entry.trim();
+            if (trimmedEntry.isEmpty()) {
+                continue;
+            }
+            int separator = trimmedEntry.lastIndexOf('=');
+            if (separator <= 0 || separator == trimmedEntry.length() - 1) {
+                logInvalidBudget(trimmedEntry, budgetType);
+                continue;
+            }
+
+            String metric = trimmedEntry.substring(0, separator).trim();
+            String budgetValue = trimmedEntry.substring(separator + 1).trim();
+            try {
+                double budgetMillis = Double.parseDouble(budgetValue);
+                if (metric.isBlank() || budgetMillis < 0 || !Double.isFinite(budgetMillis)) {
+                    logInvalidBudget(trimmedEntry, budgetType);
+                    continue;
+                }
+                budgets.put(metric, budgetMillis);
+            } catch (NumberFormatException e) {
+                logInvalidBudget(trimmedEntry, budgetType);
+            }
+        }
+        return budgets;
+    }
+
+    private static void logInvalidBudget(String entry, String budgetType) {
+        ReportManager.logDiscrete("Ignoring invalid " + budgetType + " performance budget entry: \"" + entry + "\".", Level.WARN);
+    }
+
+    private static void logBudgetViolations(String budgetType, List<MetricStats> stats) {
+        stats.stream()
+                .filter(MetricStats::hasBudgetViolation)
+                .forEach(metricStats -> ReportManager.logDiscrete(
+                        budgetType + " performance budget " + metricStats.budgetStatus().name().toLowerCase(Locale.ROOT)
+                                + ": " + metricStats.budgetViolationMessage() + ".",
+                        Level.WARN));
+    }
+
+    private static AssertionError budgetFailure(List<MetricStats> actionStats, List<MetricStats> pageLoadStats) {
+        List<String> failures = new ArrayList<>();
+        actionStats.stream()
+                .filter(stats -> stats.budgetStatus() == BudgetStatus.FAIL)
+                .map(MetricStats::budgetViolationMessage)
+                .forEach(failures::add);
+        pageLoadStats.stream()
+                .filter(stats -> stats.budgetStatus() == BudgetStatus.FAIL)
+                .map(MetricStats::budgetViolationMessage)
+                .forEach(failures::add);
+        if (failures.isEmpty()) {
+            return null;
+        }
+        return new AssertionError("Browser performance budget violations: " + String.join("; ", failures) + ".");
+    }
+
+    private static void writeReports(List<MetricStats> actionStats, List<MetricStats> pageLoadStats,
+                                     long startTime, long endTime, boolean failOnBudgetViolation) {
+        FileActions fileActionsSession = FileActions.getInstance(true);
+        fileActionsSession.createFolder(SHAFT.Properties.paths.performanceReportPath());
+
+        String formattedStartTime = formatTimestamp(startTime);
+        String formattedEndTime = formatTimestamp(endTime);
+        String formattedExecutionTime = formatExecutionTime(endTime - startTime);
+        String htmlReport = buildHtmlReport(formattedStartTime, formattedEndTime, formattedExecutionTime,
+                actionStats, pageLoadStats);
+        String jsonReport = buildJsonReport(formattedStartTime, formattedEndTime, formattedExecutionTime,
+                actionStats, pageLoadStats, failOnBudgetViolation);
+        String timestamp = getTimestamp();
+        fileActionsSession.writeToFile(SHAFT.Properties.paths.performanceReportPath(), "BrowserPerformanceReport_" + timestamp + ".html", htmlReport);
+        fileActionsSession.writeToFile(SHAFT.Properties.paths.performanceReportPath(), "BrowserPerformanceReport_" + timestamp + ".json", jsonReport);
+    }
+
+    private static String buildJsonReport(String formattedStartTime, String formattedEndTime,
+                                          String formattedExecutionTime, List<MetricStats> actionStats,
+                                          List<MetricStats> pageLoadStats, boolean failOnBudgetViolation) {
+        ObjectNode root = JSON_MAPPER.createObjectNode();
+        root.put("reportType", "browser");
+        root.put("startTime", formattedStartTime);
+        root.put("endTime", formattedEndTime);
+        root.put("executionTime", formattedExecutionTime);
+        root.put("budgetMetric", BUDGET_METRIC);
+        root.put("failOnBudgetViolation", failOnBudgetViolation);
+        appendStats(root.putArray("browserActions"), actionStats);
+        appendStats(root.putArray("pageLoads"), pageLoadStats);
+        return root.toPrettyString();
+    }
+
+    private static void appendStats(ArrayNode target, List<MetricStats> stats) {
+        stats.forEach(metricStats -> metricStats.appendJson(target.addObject()));
+    }
+
+    private static String buildHtmlReport(String formattedStartTime, String formattedEndTime,
+                                          String formattedExecutionTime, List<MetricStats> actionStats,
+                                          List<MetricStats> pageLoadStats) {
+        return "<!DOCTYPE html><html><head><meta charset=\"UTF-8\"><title>SHAFT Browser Performance Report</title>"
+                + "<style>body{font-family:Arial,sans-serif;margin:24px;color:#1f2933}"
+                + "table{border-collapse:collapse;width:100%;margin:16px 0 32px}"
+                + "th,td{border:1px solid #d5d9e0;padding:8px;text-align:left}"
+                + "th{background:#eef2f7}</style></head><body>"
+                + "<h1>SHAFT Browser Performance Report</h1>"
+                + "<p><strong>Start:</strong> " + htmlEscape(formattedStartTime)
+                + " <strong>End:</strong> " + htmlEscape(formattedEndTime)
+                + " <strong>Duration:</strong> " + htmlEscape(formattedExecutionTime) + "</p>"
+                + table("Browser Actions", actionStats)
+                + table("Page Loads", pageLoadStats)
+                + "</body></html>";
+    }
+
+    private static String table(String title, List<MetricStats> stats) {
+        StringBuilder rows = new StringBuilder();
+        stats.forEach(metricStats -> rows.append(metricStats.toHtmlRow()));
+        return "<h2>" + htmlEscape(title) + "</h2><table><thead><tr>"
+                + "<th>Metric</th><th>Samples</th><th>Max (ms)</th><th>Min (ms)</th><th>Average (ms)</th>"
+                + "<th>P50 (ms)</th><th>P90 (ms)</th><th>P95 (ms)</th><th>P99 (ms)</th>"
+                + "<th>Budget (ms)</th><th>Budget Status</th></tr></thead><tbody>"
+                + rows
+                + "</tbody></table>";
+    }
+
+    private static String formatTimestamp(long timestamp) {
+        return READABLE_FORMATTER.format(Instant.ofEpochMilli(timestamp));
+    }
+
+    private static String formatExecutionTime(long executionTimeMillis) {
+        long seconds = (executionTimeMillis / 1000) % 60;
+        long minutes = (executionTimeMillis / (1000 * 60)) % 60;
+        return String.format("%d minutes, %d seconds", minutes, seconds);
+    }
+
+    private static String getTimestamp() {
+        return FILENAME_FORMATTER.format(ZonedDateTime.now());
+    }
+
+    private static String formatMillis(double millis) {
+        return String.format(Locale.ROOT, "%.2f", millis);
+    }
+
+    private static String htmlEscape(String value) {
+        return value.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private record MetricStats(String metric, long samples, double minMillis, double maxMillis,
+                               double averageMillis, double p50Millis, double p90Millis,
+                               double p95Millis, double p99Millis, Double budgetMillis,
+                               BudgetStatus budgetStatus) {
+        private static MetricStats from(String metric, List<Double> sortedTimes, Double budgetMillis,
+                                        boolean failOnBudgetViolation) {
+            DoubleSummaryStatistics stats = sortedTimes.stream().mapToDouble(Double::doubleValue).summaryStatistics();
+            long samples = stats.getCount();
+            double minMillis = samples == 0 ? 0 : stats.getMin();
+            double maxMillis = samples == 0 ? 0 : stats.getMax();
+            double averageMillis = samples == 0 ? 0 : stats.getAverage();
+            double p50Millis = percentile(sortedTimes, 50);
+            double p90Millis = percentile(sortedTimes, 90);
+            double p95Millis = percentile(sortedTimes, 95);
+            double p99Millis = percentile(sortedTimes, 99);
+            BudgetStatus budgetStatus = budgetStatus(p95Millis, budgetMillis, failOnBudgetViolation);
+            return new MetricStats(metric, samples, minMillis, maxMillis, averageMillis, p50Millis,
+                    p90Millis, p95Millis, p99Millis, budgetMillis, budgetStatus);
+        }
+
+        private static double percentile(List<Double> sortedTimes, int percentile) {
+            if (sortedTimes.isEmpty()) {
+                return 0;
+            }
+            int index = (int) Math.ceil(percentile / 100d * sortedTimes.size()) - 1;
+            return sortedTimes.get(Math.max(0, Math.min(index, sortedTimes.size() - 1)));
+        }
+
+        private static BudgetStatus budgetStatus(double p95Millis, Double budgetMillis,
+                                                 boolean failOnBudgetViolation) {
+            if (budgetMillis == null) {
+                return BudgetStatus.NOT_CONFIGURED;
+            }
+            if (p95Millis <= budgetMillis) {
+                return BudgetStatus.PASS;
+            }
+            return failOnBudgetViolation ? BudgetStatus.FAIL : BudgetStatus.WARN;
+        }
+
+        private boolean hasBudgetViolation() {
+            return budgetStatus == BudgetStatus.WARN || budgetStatus == BudgetStatus.FAIL;
+        }
+
+        private String budgetViolationMessage() {
+            return metric + " p95 " + formatMillis(p95Millis) + "ms exceeded budget "
+                    + formatMillis(budgetMillis) + "ms";
+        }
+
+        private String toHtmlRow() {
+            return "<tr><td>" + htmlEscape(metric) + "</td>"
+                    + "<td>" + samples + "</td>"
+                    + "<td>" + formatMillis(maxMillis) + "</td>"
+                    + "<td>" + formatMillis(minMillis) + "</td>"
+                    + "<td>" + formatMillis(averageMillis) + "</td>"
+                    + "<td>" + formatMillis(p50Millis) + "</td>"
+                    + "<td>" + formatMillis(p90Millis) + "</td>"
+                    + "<td>" + formatMillis(p95Millis) + "</td>"
+                    + "<td>" + formatMillis(p99Millis) + "</td>"
+                    + "<td>" + (budgetMillis == null ? "" : formatMillis(budgetMillis)) + "</td>"
+                    + "<td>" + budgetStatus + "</td></tr>";
+        }
+
+        private void appendJson(ObjectNode node) {
+            node.put("metric", metric);
+            node.put("samples", samples);
+            node.put("minMillis", minMillis);
+            node.put("maxMillis", maxMillis);
+            node.put("averageMillis", averageMillis);
+            node.put("p50Millis", p50Millis);
+            node.put("p90Millis", p90Millis);
+            node.put("p95Millis", p95Millis);
+            node.put("p99Millis", p99Millis);
+            if (budgetMillis == null) {
+                node.putNull("budgetMillis");
+            } else {
+                node.put("budgetMillis", budgetMillis);
+            }
+            node.put("budgetMetric", BUDGET_METRIC);
+            node.put("budgetStatus", budgetStatus.name());
+        }
+    }
+
+    private enum BudgetStatus {
+        PASS, WARN, FAIL, NOT_CONFIGURED
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/validation/accessibility/AccessibilityActions.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/accessibility/AccessibilityActions.java
@@ -1,7 +1,10 @@
 package com.shaft.validation.accessibility;
 
+import com.microsoft.playwright.Page;
 import com.shaft.driver.SHAFT;
 import com.shaft.gui.browser.BrowserActions;
+import com.shaft.gui.driver.BrowserActionsContract;
+import com.shaft.validation.Validations;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.WebDriver;
@@ -48,6 +51,8 @@ import static com.shaft.validation.accessibility.AccessibilityHelper.attachRepor
 public class AccessibilityActions {
     private final SHAFT.GUI.WebDriver driver;
     private final BrowserActions browserActions;
+    private final BrowserActionsContract browserActionsContract;
+    private final Page playwrightPage;
 
     /**
      * Thread-safe cache keyed by a composed string (pageName + configHash + saveReport flag).
@@ -69,6 +74,22 @@ public class AccessibilityActions {
     public AccessibilityActions(WebDriver rawDriver, BrowserActions browserActions) {
         this.driver = new SHAFT.GUI.WebDriver(rawDriver);
         this.browserActions = browserActions;
+        this.browserActionsContract = browserActions;
+        this.playwrightPage = null;
+    }
+
+    /**
+     * Constructs an {@code AccessibilityActions} instance backed by a Playwright
+     * {@link Page}.
+     *
+     * @param page           Playwright page used to run axe-core scripts
+     * @param browserActions browser action facade that created this instance
+     */
+    public AccessibilityActions(Page page, BrowserActionsContract browserActions) {
+        this.driver = null;
+        this.browserActions = null;
+        this.browserActionsContract = browserActions;
+        this.playwrightPage = java.util.Objects.requireNonNull(page, "page");
     }
 
     private static final Logger logger = LogManager.getLogger(AccessibilityActions.class);
@@ -96,7 +117,7 @@ public class AccessibilityActions {
     public AccessibilityActions analyzePage(String pageName) {
         // Always save report for explicit analysis call
         String key = buildCacheKey(pageName, null, true);
-        cacheResult(key, AccessibilityHelper.analyzePageAccessibilityAndSave(driver.getDriver(), pageName, true));
+        cacheResult(key, analyze(pageName, null, true));
         attachReportToAllure(pageName);
         return this;
     }
@@ -122,7 +143,7 @@ public class AccessibilityActions {
     public AccessibilityActions analyzePage(String pageName, AccessibilityHelper.AccessibilityConfig config) {
         // Always save report for explicit analysis call, even with custom config
         String key = buildCacheKey(pageName, config, true);
-        cacheResult(key, AccessibilityHelper.analyzePageAccessibilityAndSave(driver.getDriver(), pageName, config, true));
+        cacheResult(key, analyze(pageName, config, true));
         attachReportToAllure(pageName);
         return this;
     }
@@ -213,8 +234,7 @@ public class AccessibilityActions {
      */
     public AccessibilityHelper.AccessibilityResult analyzeAndReturn(String pageName, AccessibilityHelper.AccessibilityConfig config, boolean saveReport) {
         String key = buildCacheKey(pageName, config, saveReport);
-        return cachedResults.computeIfAbsent(key, k ->
-                AccessibilityHelper.analyzePageAccessibilityAndSave(driver.getDriver(), pageName, config, saveReport));
+        return cachedResults.computeIfAbsent(key, k -> analyze(pageName, config, saveReport));
     }
 
     /**
@@ -246,7 +266,7 @@ public class AccessibilityActions {
         List<com.deque.html.axecore.results.Rule> originalViolations = new ArrayList<>(result.getViolations());
         try {
             result.getViolations().removeIf(rule -> ignoredRuleIds.contains(rule.getId()));
-            attachFilteredReportToAllure(pageName, result, driver.getDriver());
+            attachFilteredReportToAllure(pageName, result, rawDriver());
         } finally {
             // restore original violations so cached result remains unchanged for other callers
             result.getViolations().clear();
@@ -284,11 +304,7 @@ public class AccessibilityActions {
         boolean noViolations = analyzeAndReturn(pageName, true).getViolations().stream()
                 .noneMatch(rule -> "critical".equalsIgnoreCase(rule.getImpact()));
 
-        driver.assertThat()
-                .object(noViolations)
-                .isTrue()
-                .withCustomReportMessage("Assert no critical accessibility violations found on page: " + pageName)
-                .perform();
+        assertCondition(noViolations, "Assert no critical accessibility violations found on page: " + pageName);
         return this;
     }
 
@@ -316,11 +332,7 @@ public class AccessibilityActions {
         boolean noViolations = analyzeAndReturn(pageName, true).getViolations().stream()
                 .noneMatch(rule -> "critical".equalsIgnoreCase(rule.getImpact()));
 
-        driver.verifyThat()
-                .object(noViolations)
-                .isTrue()
-                .withCustomReportMessage("Verify no critical accessibility violations found on page: " + pageName)
-                .perform();
+        verifyCondition(noViolations, "Verify no critical accessibility violations found on page: " + pageName);
         return this;
     }
 
@@ -336,12 +348,8 @@ public class AccessibilityActions {
      * @return this {@code AccessibilityActions} instance for method chaining
      */
     public AccessibilityActions assertIsAccessible() {
-        boolean accessible = AccessibilityHelper.isAccessible(driver.getDriver());
-        driver.assertThat()
-                .object(accessible)
-                .isTrue()
-                .withCustomReportMessage("Assert the page is accessible")
-                .perform();
+        boolean accessible = isAccessible();
+        assertCondition(accessible, "Assert the page is accessible");
         return this;
     }
 
@@ -359,12 +367,8 @@ public class AccessibilityActions {
      * @return this {@code AccessibilityActions} instance for method chaining
      */
     public AccessibilityActions verifyIsAccessible() {
-        boolean accessible = AccessibilityHelper.isAccessible(driver.getDriver());
-        driver.verifyThat()
-                .object(accessible)
-                .isTrue()
-                .withCustomReportMessage("Verify the page is accessible")
-                .perform();
+        boolean accessible = isAccessible();
+        verifyCondition(accessible, "Verify the page is accessible");
         return this;
     }
 
@@ -397,13 +401,9 @@ public class AccessibilityActions {
         boolean noViolations = result.getViolations().stream()
                 .noneMatch(rule -> impacts.contains(rule.getImpact().toLowerCase()));
 
-        attachFilteredReportToAllure(pageName, result, driver.getDriver());
+        attachFilteredReportToAllure(pageName, result, rawDriver());
 
-        driver.assertThat()
-                .object(noViolations)
-                .isTrue()
-                .withCustomReportMessage("No " + String.join("/", impactLevels) + " violations found on page: " + pageName)
-                .perform();
+        assertCondition(noViolations, "No " + String.join("/", impactLevels) + " violations found on page: " + pageName);
         return this;
     }
 
@@ -430,7 +430,7 @@ public class AccessibilityActions {
     public AccessibilityActions failIfViolationsExist(String pageName) {
         // saveReport=false: base analysis already done, no need to save another report
         AccessibilityHelper.AccessibilityResult result = analyzeAndReturn(pageName, false);
-        attachFilteredReportToAllure(pageName, result, driver.getDriver());
+        attachFilteredReportToAllure(pageName, result, rawDriver());
         if (!result.getViolations().isEmpty()) {
             throw new AssertionError("Accessibility violations found on page '" + pageName + "'");
         }
@@ -594,6 +594,67 @@ public class AccessibilityActions {
      */
     public BrowserActions backToBrowser() {
         return browserActions;
+    }
+
+    /**
+     * Returns the browser action contract that created this accessibility facade.
+     *
+     * @return originating browser actions facade
+     */
+    public BrowserActionsContract backToBrowserContract() {
+        return browserActionsContract;
+    }
+
+    private AccessibilityHelper.AccessibilityResult analyze(String pageName,
+                                                            AccessibilityHelper.AccessibilityConfig config,
+                                                            boolean saveReport) {
+        if (playwrightPage != null) {
+            return AccessibilityHelper.analyzePlaywrightPageAccessibilityAndSave(playwrightPage, pageName, config, saveReport);
+        }
+        return AccessibilityHelper.analyzePageAccessibilityAndSave(driver.getDriver(), pageName, config, saveReport);
+    }
+
+    private boolean isAccessible() {
+        if (playwrightPage != null) {
+            return !analyzeAndReturn("CurrentPage", false).hasViolations();
+        }
+        return AccessibilityHelper.isAccessible(driver.getDriver());
+    }
+
+    private WebDriver rawDriver() {
+        return driver == null ? null : driver.getDriver();
+    }
+
+    private void assertCondition(boolean condition, String message) {
+        if (driver != null) {
+            driver.assertThat()
+                    .object(condition)
+                    .isTrue()
+                    .withCustomReportMessage(message)
+                    .perform();
+            return;
+        }
+        Validations.assertThat()
+                .object(condition)
+                .isTrue()
+                .withCustomReportMessage(message)
+                .perform();
+    }
+
+    private void verifyCondition(boolean condition, String message) {
+        if (driver != null) {
+            driver.verifyThat()
+                    .object(condition)
+                    .isTrue()
+                    .withCustomReportMessage(message)
+                    .perform();
+            return;
+        }
+        Validations.verifyThat()
+                .object(condition)
+                .isTrue()
+                .withCustomReportMessage(message)
+                .perform();
     }
 
     private void cacheResult(String key, AccessibilityHelper.AccessibilityResult result) {

--- a/shaft-engine/src/main/java/com/shaft/validation/accessibility/AccessibilityHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/accessibility/AccessibilityHelper.java
@@ -643,8 +643,8 @@ public class AccessibilityHelper {
 
             logger.info("Playwright accessibility score for page '{}' is {}%.", pageName, accessibilityScore);
             return result;
-        } catch (Exception e) {
-            throw new RuntimeException("Accessibility analysis failed for Playwright page '" + pageName + "'.", e);
+        } catch (IOException | RuntimeException e) {
+            throw new IllegalStateException("Accessibility analysis failed for Playwright page '" + pageName + "'.", e);
         }
     }
 

--- a/shaft-engine/src/main/java/com/shaft/validation/accessibility/AccessibilityHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/accessibility/AccessibilityHelper.java
@@ -3,6 +3,8 @@ package com.shaft.validation.accessibility;
 import com.deque.html.axecore.results.Results;
 import com.deque.html.axecore.results.Rule;
 import com.deque.html.axecore.selenium.AxeBuilder;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.LoadState;
 import io.qameta.allure.Allure;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -17,6 +19,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -574,6 +577,77 @@ public class AccessibilityHelper {
         }
     }
 
+    /**
+     * Full-control overload for Playwright pages: runs an axe scan in the current
+     * page, optionally saves reports, and returns a structured result.
+     *
+     * @param page       active Playwright page
+     * @param pageName   label for the report and Allure attachment
+     * @param config     scan configuration; a default instance is used when {@code null}
+     * @param saveReport {@code true} to write JSON/HTML reports and attach them to Allure
+     * @return an {@link AccessibilityResult} containing violation details and score
+     */
+    public static AccessibilityResult analyzePlaywrightPageAccessibilityAndSave(Page page, String pageName,
+                                                                                AccessibilityConfig config,
+                                                                                boolean saveReport) {
+        if (page == null) throw new IllegalArgumentException("Playwright page cannot be null");
+        if (pageName == null || pageName.trim().isEmpty()) throw new IllegalArgumentException("Page name cannot be empty");
+        if (config == null) config = new AccessibilityConfig();
+
+        try {
+            page.waitForLoadState(LoadState.LOAD);
+            page.addScriptTag(new Page.AddScriptTagOptions().setContent(readAxeScript()));
+            Object rawResults = page.evaluate("""
+                    async ({ context, tags, includePasses }) => {
+                      const options = {
+                        resultTypes: includePasses
+                          ? ['violations', 'incomplete', 'inapplicable', 'passes']
+                          : ['violations', 'incomplete', 'inapplicable']
+                      };
+                      if (tags && tags.length) {
+                        options.runOnly = { type: 'tag', values: tags };
+                      }
+                      return await window.axe.run(context || document, options);
+                    }
+                    """, Map.of(
+                    "context", config.getContext(),
+                    "tags", config.getTags(),
+                    "includePasses", config.isIncludePasses()));
+
+            JSONObject responseJSON = normalizePlaywrightAxeJson(rawResults);
+            int violationsCount = responseJSON.getInt("totalViolations");
+            int passesCount = responseJSON.getInt("totalPassed");
+            int totalChecks = violationsCount + passesCount;
+            double accessibilityScore = totalChecks > 0 ? ((double) passesCount / totalChecks) * 100.0 : 0.0;
+            AccessibilityResult result = new AccessibilityResult()
+                    .setPageName(pageName)
+                    .setViolations(rulesFrom(responseJSON.optJSONArray("violations")))
+                    .setPasses(rulesFrom(responseJSON.optJSONArray("passes")))
+                    .setViolationsCount(violationsCount)
+                    .setPassesCount(passesCount)
+                    .setScore(accessibilityScore)
+                    .setTimestamp(LocalDateTime.now().toString());
+
+            if (saveReport) {
+                String timestamp = DATE_FORMAT.format(ZonedDateTime.now());
+                String reportsDir = config.getReportsDir();
+                Files.createDirectories(Paths.get(reportsDir));
+                String jsonPath = reportsDir + "AccessibilityJSON_" + pageName + "_" + timestamp + ".json";
+                String htmlPath = reportsDir + "AccessibilityReport_" + pageName + "_" + timestamp + ".html";
+                writeJsonResults(jsonPath, responseJSON);
+                generateEnhancedHTMLReport(responseJSON, pageName, htmlPath, config, null);
+                try (FileInputStream fis = new FileInputStream(htmlPath)) {
+                    Allure.addAttachment("Accessibility Report - " + pageName, "text/html", fis, ".html");
+                }
+            }
+
+            logger.info("Playwright accessibility score for page '{}' is {}%.", pageName, accessibilityScore);
+            return result;
+        } catch (Exception e) {
+            throw new RuntimeException("Accessibility analysis failed for Playwright page '" + pageName + "'.", e);
+        }
+    }
+
 
     /**
      * Value object returned by
@@ -781,6 +855,83 @@ public class AccessibilityHelper {
                     ", timestamp='" + timestamp + '\'' +
                     '}';
         }
+    }
+
+    private static String readAxeScript() throws IOException {
+        try (InputStream stream = AccessibilityHelper.class.getClassLoader().getResourceAsStream("axe.min.js")) {
+            if (stream == null) {
+                throw new IOException("axe.min.js was not found on the classpath.");
+            }
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static JSONObject normalizePlaywrightAxeJson(Object rawResults) {
+        JSONObject json = rawResults instanceof Map<?, ?> map
+                ? new JSONObject((Map<String, Object>) map)
+                : new JSONObject(String.valueOf(rawResults));
+        normalizeRuleArray(json, "violations", "Violation");
+        normalizeRuleArray(json, "incomplete", "Needs Review");
+        normalizeRuleArray(json, "inapplicable", "Not Applicable");
+        normalizeRuleArray(json, "passes", "Passed");
+        json.put("totalViolations", length(json, "violations"));
+        json.put("totalIncomplete", length(json, "incomplete"));
+        json.put("totalInapplicable", length(json, "inapplicable"));
+        json.put("totalPassed", length(json, "passes"));
+        return json;
+    }
+
+    private static void normalizeRuleArray(JSONObject json, String key, String category) {
+        JSONArray rules = json.optJSONArray(key);
+        if (rules == null) {
+            json.put(key, new JSONArray());
+            return;
+        }
+        for (int i = 0; i < rules.length(); i++) {
+            JSONObject rule = rules.getJSONObject(i);
+            rule.put("category", category);
+            rule.put("wcagModel", getWcagModelFromTags(toStringList(rule.optJSONArray("tags"))));
+            if (!rule.has("nodes")) {
+                rule.put("nodes", new JSONArray());
+            }
+        }
+    }
+
+    private static List<Rule> rulesFrom(JSONArray rules) {
+        if (rules == null) {
+            return new ArrayList<>();
+        }
+        List<Rule> converted = new ArrayList<>();
+        for (int i = 0; i < rules.length(); i++) {
+            JSONObject object = rules.getJSONObject(i);
+            Rule rule = new Rule();
+            rule.setId(object.optString("id"));
+            rule.setDescription(object.optString("description"));
+            rule.setHelp(object.optString("help"));
+            rule.setHelpUrl(object.optString("helpUrl"));
+            rule.setImpact(object.optString("impact", "none"));
+            rule.setTags(toStringList(object.optJSONArray("tags")));
+            rule.setNodes(new ArrayList<>());
+            converted.add(rule);
+        }
+        return converted;
+    }
+
+    private static List<String> toStringList(JSONArray values) {
+        if (values == null) {
+            return new ArrayList<>();
+        }
+        List<String> result = new ArrayList<>();
+        for (int i = 0; i < values.length(); i++) {
+            result.add(values.optString(i));
+        }
+        return result;
+    }
+
+    private static int length(JSONObject json, String key) {
+        JSONArray values = json.optJSONArray(key);
+        return values == null ? 0 : values.length();
     }
 
     private static JSONObject convertResultsToJSON(Results results) {

--- a/shaft-engine/src/test/java/com/shaft/api/RequestBuilderPerformanceTest.java
+++ b/shaft-engine/src/test/java/com/shaft/api/RequestBuilderPerformanceTest.java
@@ -1,0 +1,75 @@
+package com.shaft.api;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.properties.internal.Properties;
+import io.restassured.config.RestAssuredConfig;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.util.LinkedHashMap;
+
+@Test(singleThreaded = true)
+public class RequestBuilderPerformanceTest {
+    @AfterMethod(alwaysRun = true)
+    public void cleanup() {
+        RequestBuilder.getPerformanceData().clear();
+        Properties.clearForCurrentThread();
+    }
+
+    @Test
+    public void performShouldRecordEndpointTimingWhenBudgetIsConfiguredAndReportIsDisabled() {
+        SHAFT.Properties.performance.set()
+                .generatePerformanceReport(false)
+                .apiEndpointPerformanceBudgets("users=1");
+        RestActions session = createSessionMock();
+        prepareSuccessfulPerformRequestMocks(session, "users/123/", RestActions.RequestType.GET);
+
+        new RequestBuilder(session, "users/123/", RestActions.RequestType.GET).perform();
+
+        Assert.assertTrue(RequestBuilder.getPerformanceData().containsKey("users"));
+        Assert.assertFalse(RequestBuilder.getPerformanceData().get("users").isEmpty());
+    }
+
+    @Test
+    public void performShouldSkipEndpointTimingWhenReportAndBudgetsAreDisabled() {
+        SHAFT.Properties.performance.set().generatePerformanceReport(false);
+        RestActions session = createSessionMock();
+        prepareSuccessfulPerformRequestMocks(session, "users/123/", RestActions.RequestType.GET);
+
+        new RequestBuilder(session, "users/123/", RestActions.RequestType.GET).perform();
+
+        Assert.assertTrue(RequestBuilder.getPerformanceData().isEmpty());
+    }
+
+    private RestActions createSessionMock() {
+        RestActions session = Mockito.mock(RestActions.class);
+        Mockito.when(session.getServiceURI()).thenReturn("http://localhost/");
+        Mockito.when(session.getSessionCookies()).thenReturn(new LinkedHashMap<>());
+        Mockito.when(session.getSessionHeaders()).thenReturn(new LinkedHashMap<>());
+        Mockito.when(session.getSessionConfig()).thenReturn(RestAssuredConfig.config());
+        Mockito.when(session.getDriver()).thenReturn(Mockito.mock(SHAFT.API.class));
+        return session;
+    }
+
+    private void prepareSuccessfulPerformRequestMocks(RestActions session, String serviceName,
+                                                      RestActions.RequestType requestType) {
+        RequestSpecification specs = Mockito.mock(RequestSpecification.class, Mockito.RETURNS_DEEP_STUBS);
+        Response response = Mockito.mock(Response.class);
+
+        Mockito.when(session.prepareRequestURL("http://localhost/", null, serviceName))
+                .thenReturn("http://localhost/" + serviceName);
+        Mockito.when(session.prepareRequestSpecs(Mockito.isNull(), Mockito.isNull(), Mockito.isNull(),
+                        Mockito.eq(ContentType.ANY), Mockito.anyMap(), Mockito.anyMap(), Mockito.any(),
+                        Mockito.eq(true), Mockito.eq(true)))
+                .thenReturn(specs);
+        Mockito.when(session.sendRequest(requestType, "http://localhost/" + serviceName, specs)).thenReturn(response);
+        Mockito.when(session.evaluateResponseStatusCode(response, 0)).thenReturn(true);
+        Mockito.when(session.prepareReportMessage(response, 0, requestType, serviceName, ContentType.ANY, null))
+                .thenReturn("ok");
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/gui/browser/internal/PlaywrightNetworkInterceptorTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/browser/internal/PlaywrightNetworkInterceptorTest.java
@@ -6,7 +6,6 @@ import com.microsoft.playwright.Request;
 import com.microsoft.playwright.Route;
 import org.openqa.selenium.remote.http.Contents;
 import org.openqa.selenium.remote.http.HttpMethod;
-import org.openqa.selenium.remote.http.HttpRequest;
 import org.openqa.selenium.remote.http.HttpResponse;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/shaft-engine/src/test/java/com/shaft/gui/browser/internal/PlaywrightNetworkInterceptorTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/browser/internal/PlaywrightNetworkInterceptorTest.java
@@ -1,0 +1,101 @@
+package com.shaft.gui.browser.internal;
+
+import com.microsoft.playwright.APIResponse;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.Request;
+import com.microsoft.playwright.Route;
+import org.openqa.selenium.remote.http.Contents;
+import org.openqa.selenium.remote.http.HttpMethod;
+import org.openqa.selenium.remote.http.HttpRequest;
+import org.openqa.selenium.remote.http.HttpResponse;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class PlaywrightNetworkInterceptorTest {
+    @Test
+    public void shouldFulfillMatchingMockedResponsesAndClearRoute() throws Exception {
+        BrowserContext context = mock(BrowserContext.class);
+        AtomicReference<Consumer<Route>> handler = new AtomicReference<>();
+        AtomicBoolean routeClosed = new AtomicBoolean(false);
+        when(context.route(eq("**/*"), any())).thenAnswer(invocation -> {
+            handler.set(invocation.getArgument(1));
+            return (AutoCloseable) () -> routeClosed.set(true);
+        });
+        PlaywrightNetworkInterceptor interceptor = new PlaywrightNetworkInterceptor(context);
+        HttpResponse mocked = new HttpResponse()
+                .setStatus(201)
+                .addHeader("Content-Type", "application/json");
+        mocked.setContent(Contents.utf8String("{\"ok\":true}"));
+
+        interceptor.addRule(BrowserNetworkInterceptionRule.mock(
+                request -> request.getMethod() == HttpMethod.GET && request.getUri().contains("/api/users"),
+                request -> mocked));
+
+        Route route = route("GET", "https://example.test/api/users", null);
+        handler.get().accept(route);
+
+        var optionsCaptor = org.mockito.ArgumentCaptor.forClass(Route.FulfillOptions.class);
+        verify(route).fulfill(optionsCaptor.capture());
+        Assert.assertEquals(optionsCaptor.getValue().status, Integer.valueOf(201));
+        Assert.assertEquals(optionsCaptor.getValue().contentType, "application/json");
+        Assert.assertEquals(new String(optionsCaptor.getValue().bodyBytes), "{\"ok\":true}");
+
+        interceptor.clear();
+        Assert.assertTrue(routeClosed.get());
+    }
+
+    @Test
+    public void shouldValidateRealResponsesAndFulfillOriginalResponse() {
+        BrowserContext context = mock(BrowserContext.class);
+        AtomicReference<Consumer<Route>> handler = new AtomicReference<>();
+        when(context.route(eq("**/*"), any())).thenAnswer(invocation -> {
+            handler.set(invocation.getArgument(1));
+            return (AutoCloseable) () -> { };
+        });
+        PlaywrightNetworkInterceptor interceptor = new PlaywrightNetworkInterceptor(context);
+        AtomicBoolean validated = new AtomicBoolean(false);
+        interceptor.addRule(BrowserNetworkInterceptionRule.validate(
+                request -> request.getUri().contains("/api/status"),
+                response -> {
+                    validated.set(true);
+                    Assert.assertEquals(response.getStatusCode(), 200);
+                    Assert.assertTrue(response.asString().contains("\"ok\":true"));
+                }));
+
+        Route route = route("GET", "https://example.test/api/status", null);
+        APIResponse response = mock(APIResponse.class);
+        when(response.status()).thenReturn(200);
+        when(response.headers()).thenReturn(Map.of("Content-Type", "application/json"));
+        when(response.body()).thenReturn("{\"ok\":true}".getBytes());
+        when(route.fetch()).thenReturn(response);
+
+        handler.get().accept(route);
+
+        Assert.assertTrue(validated.get());
+        var optionsCaptor = org.mockito.ArgumentCaptor.forClass(Route.FulfillOptions.class);
+        verify(route).fulfill(optionsCaptor.capture());
+        Assert.assertSame(optionsCaptor.getValue().response, response);
+    }
+
+    private Route route(String method, String url, byte[] body) {
+        Request request = mock(Request.class);
+        when(request.method()).thenReturn(method);
+        when(request.url()).thenReturn(url);
+        when(request.headers()).thenReturn(Map.of());
+        when(request.postDataBuffer()).thenReturn(body);
+        Route route = mock(Route.class);
+        when(route.request()).thenReturn(request);
+        return route;
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/natural/PlaywrightNaturalActionExecutorTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/natural/PlaywrightNaturalActionExecutorTest.java
@@ -1,0 +1,71 @@
+package com.shaft.gui.internal.natural;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.shaft.gui.playwright.internal.PlaywrightSession;
+import com.shaft.properties.internal.Properties;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class PlaywrightNaturalActionExecutorTest {
+    private PlaywrightSession session;
+    private Page page;
+    private Locator locator;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        SHAFTProperties();
+        session = mock(PlaywrightSession.class);
+        page = mock(Page.class);
+        locator = mock(Locator.class);
+        when(session.page()).thenReturn(page);
+        when(page.locator(anyString())).thenReturn(locator);
+        when(locator.count()).thenReturn(1);
+        when(locator.isVisible()).thenReturn(true);
+        when(locator.isEnabled()).thenReturn(true);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() {
+        Properties.clearForCurrentThread();
+    }
+
+    @Test
+    public void enabledBrowserIntentShouldExecuteThroughPlaywright() {
+        PlaywrightNaturalActionExecutor.perform(session, "refresh page");
+
+        verify(page).reload();
+    }
+
+    @Test
+    public void enabledElementIntentShouldExecuteThroughPlaywrightLocator() {
+        PlaywrightNaturalActionExecutor.perform(session, "click Submit");
+
+        verify(locator).click();
+    }
+
+    @Test
+    public void touchIntentShouldFailWithSpecificUnsupportedReason() {
+        RuntimeException exception = Assert.expectThrows(
+                RuntimeException.class,
+                () -> PlaywrightNaturalActionExecutor.perform(session, "tap Submit"));
+
+        Assert.assertTrue(exception.getMessage().contains("Touch natural actions are not available"));
+        verify(locator, never()).click();
+    }
+
+    private void SHAFTProperties() {
+        com.shaft.driver.SHAFT.Properties.naturalActions.set()
+                .enabled(true)
+                .minimumTrustPercentage(85)
+                .allowedActions("browser,element,touch");
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/natural/PlaywrightNaturalActionExecutorTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/natural/PlaywrightNaturalActionExecutorTest.java
@@ -22,7 +22,7 @@ public class PlaywrightNaturalActionExecutorTest {
 
     @BeforeMethod(alwaysRun = true)
     public void setUp() {
-        SHAFTProperties();
+        setShaftProperties();
         session = mock(PlaywrightSession.class);
         page = mock(Page.class);
         locator = mock(Locator.class);
@@ -62,7 +62,7 @@ public class PlaywrightNaturalActionExecutorTest {
         verify(locator, never()).click();
     }
 
-    private void SHAFTProperties() {
+    private void setShaftProperties() {
         com.shaft.driver.SHAFT.Properties.naturalActions.set()
                 .enabled(true)
                 .minimumTrustPercentage(85)

--- a/shaft-engine/src/test/java/com/shaft/gui/playwright/browser/PlaywrightBrowserActionsUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/playwright/browser/PlaywrightBrowserActionsUnitTest.java
@@ -1,0 +1,44 @@
+package com.shaft.gui.playwright.browser;
+
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Route;
+import com.shaft.gui.browser.internal.PlaywrightNetworkInterceptor;
+import com.shaft.gui.playwright.internal.PlaywrightSession;
+import com.shaft.validation.accessibility.AccessibilityActions;
+import org.openqa.selenium.remote.http.HttpResponse;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PlaywrightBrowserActionsUnitTest {
+    @Test
+    public void shouldWireNetworkInterceptionAndAccessibilityEntryPoints() {
+        PlaywrightSession session = mock(PlaywrightSession.class);
+        BrowserContext context = mock(BrowserContext.class);
+        Page page = mock(Page.class);
+        AtomicReference<Consumer<Route>> handler = new AtomicReference<>();
+        when(session.browserContext()).thenReturn(context);
+        when(session.page()).thenReturn(page);
+        when(session.networkInterceptor()).thenReturn(new PlaywrightNetworkInterceptor(context));
+        when(context.route(eq("**/*"), any())).thenAnswer(invocation -> {
+            handler.set(invocation.getArgument(1));
+            return (AutoCloseable) () -> { };
+        });
+        BrowserActions actions = new BrowserActions(session);
+
+        Assert.assertSame(actions.mock(request -> true, new HttpResponse()), actions);
+        Assert.assertNotNull(handler.get());
+        Assert.assertNotNull(actions.interceptRequest());
+        AccessibilityActions accessibility = actions.accessibility();
+
+        Assert.assertNotNull(accessibility);
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/ApiPerformanceExecutionReportUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/ApiPerformanceExecutionReportUnitTest.java
@@ -1,0 +1,122 @@
+package com.shaft.tools.io.internal;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shaft.cli.FileActions;
+import com.shaft.driver.SHAFT;
+import com.shaft.properties.internal.Properties;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+@Test(singleThreaded = true)
+public class ApiPerformanceExecutionReportUnitTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @AfterMethod(alwaysRun = true)
+    public void cleanup() {
+        Properties.clearForCurrentThread();
+    }
+
+    @Test
+    public void generatePerformanceReportShouldWriteHtmlAndStableJsonWithPercentilesAndBudgetStatus() throws Exception {
+        SHAFT.Properties.performance.set()
+                .generatePerformanceReport(true)
+                .apiEndpointPerformanceBudgets("orders=500,users=650")
+                .failOnApiPerformanceBudgetViolation(false);
+        FileActions fileActions = Mockito.mock(FileActions.class);
+
+        try (MockedStatic<FileActions> fileActionsMock = Mockito.mockStatic(FileActions.class)) {
+            fileActionsMock.when(() -> FileActions.getInstance(true)).thenReturn(fileActions);
+
+            ApiPerformanceExecutionReport.generatePerformanceReport(Map.of(
+                    "users", List.of(100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1000.0),
+                    "orders", List.of(40.0, 50.0, 60.0, 70.0)
+            ), 1000L, 2500L);
+        }
+
+        ArgumentCaptor<String> fileNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> contentCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(fileActions).createFolder(SHAFT.Properties.paths.performanceReportPath());
+        Mockito.verify(fileActions, Mockito.times(2)).writeToFile(
+                Mockito.eq(SHAFT.Properties.paths.performanceReportPath()),
+                fileNameCaptor.capture(),
+                contentCaptor.capture());
+
+        String htmlFileName = capturedContent(fileNameCaptor.getAllValues(), contentCaptor.getAllValues(), ".html").fileName();
+        CapturedFile jsonFile = capturedContent(fileNameCaptor.getAllValues(), contentCaptor.getAllValues(), ".json");
+        Assert.assertEquals(htmlFileName.replace(".html", ""), jsonFile.fileName().replace(".json", ""),
+                "HTML and JSON reports should share one timestamped basename.");
+
+        JsonNode root = MAPPER.readTree(jsonFile.content());
+        Assert.assertEquals(root.get("budgetMetric").asText(), "p95");
+        Assert.assertFalse(root.get("failOnBudgetViolation").asBoolean());
+        Assert.assertEquals(root.get("endpoints").get(0).get("endpoint").asText(), "orders");
+
+        JsonNode users = endpoint(root, "users");
+        Assert.assertEquals(users.get("requests").asLong(), 10);
+        Assert.assertEquals(users.get("minMillis").asDouble(), 100.0);
+        Assert.assertEquals(users.get("maxMillis").asDouble(), 1000.0);
+        Assert.assertEquals(users.get("averageMillis").asDouble(), 550.0);
+        Assert.assertEquals(users.get("p50Millis").asDouble(), 500.0);
+        Assert.assertEquals(users.get("p90Millis").asDouble(), 900.0);
+        Assert.assertEquals(users.get("p95Millis").asDouble(), 1000.0);
+        Assert.assertEquals(users.get("p99Millis").asDouble(), 1000.0);
+        Assert.assertEquals(users.get("budgetMillis").asDouble(), 650.0);
+        Assert.assertEquals(users.get("budgetStatus").asText(), "WARN");
+
+        String html = capturedContent(fileNameCaptor.getAllValues(), contentCaptor.getAllValues(), ".html").content();
+        Assert.assertTrue(html.contains("<th>P50 Response Time (ms)</th>"));
+        Assert.assertTrue(html.contains("<td>WARN</td>"));
+    }
+
+    @Test
+    public void generatePerformanceReportShouldReturnFailureWhenBudgetViolationIsConfiguredToFail() {
+        SHAFT.Properties.performance.set()
+                .generatePerformanceReport(true)
+                .apiEndpointPerformanceBudgets("users=650")
+                .failOnApiPerformanceBudgetViolation(true);
+        FileActions fileActions = Mockito.mock(FileActions.class);
+
+        AssertionError failure;
+        try (MockedStatic<FileActions> fileActionsMock = Mockito.mockStatic(FileActions.class)) {
+            fileActionsMock.when(() -> FileActions.getInstance(true)).thenReturn(fileActions);
+
+            failure = ApiPerformanceExecutionReport.generatePerformanceReportAndGetFailure(Map.of(
+                    "users", List.of(100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1000.0)
+            ), 1000L, 2500L);
+        }
+
+        Assert.assertNotNull(failure);
+        Assert.assertTrue(failure.getMessage().contains("users"));
+    }
+
+    private JsonNode endpoint(JsonNode root, String endpoint) {
+        for (JsonNode candidate : root.get("endpoints")) {
+            if (endpoint.equals(candidate.get("endpoint").asText())) {
+                return candidate;
+            }
+        }
+        Assert.fail("Endpoint not found: " + endpoint);
+        return null;
+    }
+
+    private CapturedFile capturedContent(List<String> fileNames, List<String> contents, String extension) {
+        for (int i = 0; i < fileNames.size(); i++) {
+            if (fileNames.get(i).endsWith(extension)) {
+                return new CapturedFile(fileNames.get(i), contents.get(i));
+            }
+        }
+        Assert.fail("No captured report file ended with " + extension);
+        return null;
+    }
+
+    private record CapturedFile(String fileName, String content) {
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/BrowserPerformanceExecutionReportUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/BrowserPerformanceExecutionReportUnitTest.java
@@ -1,0 +1,108 @@
+package com.shaft.tools.io.internal;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shaft.cli.FileActions;
+import com.shaft.driver.SHAFT;
+import com.shaft.properties.internal.Properties;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Test(singleThreaded = true)
+public class BrowserPerformanceExecutionReportUnitTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @BeforeMethod(alwaysRun = true)
+    public void setup() {
+        BrowserPerformanceExecutionReport.reset();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void cleanup() {
+        BrowserPerformanceExecutionReport.reset();
+        Properties.clearForCurrentThread();
+    }
+
+    @Test
+    public void generatePerformanceReportShouldWriteHtmlAndJsonForBrowserActionsAndPageLoads() throws Exception {
+        SHAFT.Properties.performance.set()
+                .generatePerformanceReport(true)
+                .browserActionPerformanceBudgets("playwright.element.click=3")
+                .pageLoadPerformanceBudgets("https://example.test=20")
+                .failOnBrowserPerformanceBudgetViolation(false);
+        BrowserPerformanceExecutionReport.recordBrowserAction("playwright.element.click", TimeUnit.MILLISECONDS.toNanos(5));
+        BrowserPerformanceExecutionReport.recordPageLoad("https://example.test", TimeUnit.MILLISECONDS.toNanos(10));
+        FileActions fileActions = Mockito.mock(FileActions.class);
+
+        try (MockedStatic<FileActions> fileActionsMock = Mockito.mockStatic(FileActions.class)) {
+            fileActionsMock.when(() -> FileActions.getInstance(true)).thenReturn(fileActions);
+
+            BrowserPerformanceExecutionReport.generatePerformanceReport(1000L, 2000L);
+        }
+
+        ArgumentCaptor<String> fileNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> contentCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(fileActions).createFolder(SHAFT.Properties.paths.performanceReportPath());
+        Mockito.verify(fileActions, Mockito.times(2)).writeToFile(
+                Mockito.eq(SHAFT.Properties.paths.performanceReportPath()),
+                fileNameCaptor.capture(),
+                contentCaptor.capture());
+
+        CapturedFile jsonFile = capturedContent(fileNameCaptor.getAllValues(), contentCaptor.getAllValues(), ".json");
+        JsonNode root = MAPPER.readTree(jsonFile.content());
+        Assert.assertEquals(root.get("reportType").asText(), "browser");
+        Assert.assertEquals(root.get("budgetMetric").asText(), "p95");
+        Assert.assertEquals(root.get("browserActions").get(0).get("metric").asText(), "playwright.element.click");
+        Assert.assertEquals(root.get("browserActions").get(0).get("budgetStatus").asText(), "WARN");
+        Assert.assertEquals(root.get("pageLoads").get(0).get("metric").asText(), "https://example.test");
+        Assert.assertEquals(root.get("pageLoads").get(0).get("budgetStatus").asText(), "PASS");
+
+        String html = capturedContent(fileNameCaptor.getAllValues(), contentCaptor.getAllValues(), ".html").content();
+        Assert.assertTrue(html.contains("Browser Actions"));
+        Assert.assertTrue(html.contains("Page Loads"));
+    }
+
+    @Test
+    public void generatePerformanceReportShouldReturnFailureWhenBrowserBudgetViolationIsConfiguredToFail() {
+        SHAFT.Properties.performance.set()
+                .generatePerformanceReport(false)
+                .browserActionPerformanceBudgets("playwright.element.click=1")
+                .failOnBrowserPerformanceBudgetViolation(true);
+        BrowserPerformanceExecutionReport.recordBrowserAction("playwright.element.click", TimeUnit.MILLISECONDS.toNanos(2));
+
+        AssertionError failure = BrowserPerformanceExecutionReport.generatePerformanceReportAndGetFailure(1000L, 2000L);
+
+        Assert.assertNotNull(failure);
+        Assert.assertTrue(failure.getMessage().contains("playwright.element.click"));
+    }
+
+    @Test
+    public void recordShouldSkipTimingWhenReportsAndBudgetsAreDisabled() {
+        SHAFT.Properties.performance.set().generatePerformanceReport(false);
+
+        BrowserPerformanceExecutionReport.recordBrowserAction("playwright.element.click", TimeUnit.MILLISECONDS.toNanos(2));
+
+        Assert.assertTrue(BrowserPerformanceExecutionReport.getBrowserActionPerformanceData().isEmpty());
+    }
+
+    private CapturedFile capturedContent(List<String> fileNames, List<String> contents, String extension) {
+        for (int i = 0; i < fileNames.size(); i++) {
+            if (fileNames.get(i).endsWith(extension)) {
+                return new CapturedFile(fileNames.get(i), contents.get(i));
+            }
+        }
+        Assert.fail("No captured report file ended with " + extension);
+        return null;
+    }
+
+    private record CapturedFile(String fileName, String content) {
+    }
+}

--- a/shaft-engine/src/test/java/testPackage/unitTests/AccessibilityActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/AccessibilityActionsCoverageUnitTest.java
@@ -1,7 +1,9 @@
 package testPackage.unitTests;
 
 import com.deque.html.axecore.results.Rule;
+import com.microsoft.playwright.Page;
 import com.shaft.gui.browser.BrowserActions;
+import com.shaft.gui.driver.BrowserActionsContract;
 import com.shaft.properties.internal.Properties;
 import com.shaft.validation.accessibility.AccessibilityActions;
 import com.shaft.validation.accessibility.AccessibilityHelper;
@@ -65,6 +67,26 @@ public class AccessibilityActionsCoverageUnitTest {
 
             helper.verify(() -> AccessibilityHelper.attachReportToAllure("Home"), times(1));
             helper.verify(() -> AccessibilityHelper.attachReportToAllure("Custom"), times(1));
+        }
+    }
+
+    @Test
+    public void shouldDelegatePlaywrightAccessibilityAnalysisToPlaywrightHelper() {
+        Page page = Mockito.mock(Page.class);
+        BrowserActionsContract playwrightBrowser = Mockito.mock(BrowserActionsContract.class);
+        AccessibilityActions playwrightActions = new AccessibilityActions(page, playwrightBrowser);
+        AccessibilityHelper.AccessibilityResult result = resultWithViolations(List.of(), 100.0);
+
+        try (MockedStatic<AccessibilityHelper> helper = Mockito.mockStatic(AccessibilityHelper.class)) {
+            helper.when(() -> AccessibilityHelper.analyzePlaywrightPageAccessibilityAndSave(
+                            Mockito.eq(page),
+                            Mockito.eq("Playwright"),
+                            (AccessibilityHelper.AccessibilityConfig) Mockito.isNull(),
+                            Mockito.eq(true)))
+                    .thenReturn(result);
+
+            Assert.assertSame(playwrightActions.analyzeAndReturn("Playwright"), result);
+            Assert.assertSame(playwrightActions.backToBrowserContract(), playwrightBrowser);
         }
     }
 

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpDoctorRemediationService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpDoctorRemediationService.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -45,6 +46,9 @@ final class McpDoctorRemediationService {
     private static final int MAX_SOURCE_BYTES = 20_000;
     private static final Pattern SECRET_LIKE = Pattern.compile(
             "(?i)(authorization\\s*[:=]|bearer\\s+[a-z0-9._\\-]{8,}|api[_-]?key\\s*[:=]|sk-[a-z0-9]{8,})");
+    private static final Pattern FAILED_LOCATOR = Pattern.compile(
+            "(?i)(By\\.(?:id|name|cssSelector|xpath|className|tagName|linkText|partialLinkText)\\s*:?\\s*[^\\r\\n,;]+"
+                    + "|locator\\([^\\r\\n]+?\\)|selector\\s*[:=]\\s*[^\\r\\n,;]+)");
 
     private final Function<AiRequest, AiResponse> executor;
 
@@ -102,7 +106,11 @@ final class McpDoctorRemediationService {
             String driverVariableName,
             CodegenBackend backend) {
         CodegenBackend targetBackend = backend == null ? CodegenBackend.WEBDRIVER : backend;
-        List<McpCodeBlock> blocks = deterministicBlocks(result.diagnosis(), driverVariableName, targetBackend);
+        List<McpCodeBlock> blocks = new ArrayList<>(
+                deterministicBlocks(result.diagnosis(), driverVariableName, targetBackend));
+        if (targetBackend == CodegenBackend.PLAYWRIGHT) {
+            blocks.add(playwrightReplayEvidenceBlock(result));
+        }
         List<McpActionRecord> actions = actions(result.diagnosis(), blocks);
         ProviderBlocks providerBlocks = useAi
                 ? providerBlocks(result, repositoryRoot, allowedSourcePaths, approvalPolicy, blocks)
@@ -526,6 +534,62 @@ final class McpDoctorRemediationService {
                 true,
                 evidenceIds,
                 List.of());
+    }
+
+    private static McpCodeBlock playwrightReplayEvidenceBlock(DoctorAnalysisResult result) {
+        List<String> evidenceIds = evidenceIds(result.diagnosis());
+        String failedLocator = failedLocator(result.bundle(), evidenceIds);
+        String locatorLine = failedLocator.isBlank()
+                ? "Failed locator: unavailable in retained Doctor evidence; identify it from the failing step before changing locators."
+                : "Failed locator: " + failedLocator + ".";
+        String evidenceLine = evidenceIds.isEmpty()
+                ? "Cited evidence: unavailable in retained Doctor evidence."
+                : "Cited evidence: " + String.join(", ", evidenceIds) + ".";
+        return new McpCodeBlock(
+                "playwright-replay-evidence-checklist",
+                "Playwright replay evidence checklist",
+                McpCodeBlock.Kind.INVESTIGATION,
+                "text",
+                List.of(),
+                """
+                        Playwright replay evidence checklist:
+                        1. Use playwright_replay_recording for any retained recording that covers the failed step.
+                        2. Use playwright_browser_get_page_dom to capture the current DOM before changing the locator.
+                        3. Use playwright_browser_take_screenshot to capture visible state at the same point.
+                        4. Use playwright_element_is_displayed and playwright_element_is_enabled on the failed locator before retrying the action.
+                        5. Compare replay evidence to the cited Doctor evidence and make only the smallest supported locator, wait, assertion, or data change.
+
+                        %s
+                        %s
+                        """.formatted(locatorLine, evidenceLine),
+                "Use before editing a Playwright locator, wait, assertion, or test data dependency.",
+                true,
+                evidenceIds,
+                List.of("Do not invent replacement locators without replay evidence."));
+    }
+
+    private static String failedLocator(EvidenceBundle bundle, List<String> evidenceIds) {
+        Set<String> cited = Set.copyOf(evidenceIds);
+        return bundle.evidence().stream()
+                .filter(item -> cited.isEmpty() || cited.contains(item.id()))
+                .map(McpDoctorRemediationService::failedLocator)
+                .filter(locator -> !locator.isBlank())
+                .findFirst()
+                .orElse("");
+    }
+
+    private static String failedLocator(EvidenceItem item) {
+        List<String> texts = List.of(
+                item.attributes().getOrDefault("failureMessage", ""),
+                item.attributes().getOrDefault("traceTop", ""),
+                item.content() == null ? "" : item.content());
+        for (String text : texts) {
+            Matcher matcher = FAILED_LOCATOR.matcher(text);
+            if (matcher.find()) {
+                return matcher.group(1).replaceAll("\\s+", " ").trim();
+            }
+        }
+        return "";
     }
 
     private static List<String> evidenceIds(Diagnosis diagnosis) {

--- a/shaft-mcp/src/test/java/com/shaft/mcp/DoctorServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/DoctorServiceTest.java
@@ -149,6 +149,81 @@ class DoctorServiceTest {
     }
 
     @Test
+    void playwrightDoctorIncludesReplayEvidenceChecklistWithLocatorContext(@TempDir Path temp) throws Exception {
+        Path input = Files.createDirectories(temp.resolve("playwright-allure-results"));
+        Files.writeString(input.resolve("playwright-result.json"), new ObjectMapper().writeValueAsString(Map.of(
+                "uuid", "playwright",
+                "historyId", "playwright",
+                "name", "playwright",
+                "fullName", "example.Playwright.test",
+                "status", "failed",
+                "start", 1,
+                "stop", 2,
+                "statusDetails", Map.of(
+                        "message", "NoSuchElementException: unable to locate element: By.cssSelector: #login-button",
+                        "trace", "trace"))), StandardCharsets.UTF_8);
+
+        var analysis = service(temp).analyzeFailedPlaywrightAllure(
+                List.of(input.toString()),
+                List.of(),
+                temp.resolve("playwright-doctor-output").toString(),
+                false,
+                false,
+                1,
+                "",
+                List.of(),
+                false,
+                false,
+                false,
+                "driver");
+
+        String checklist = blockCode(analysis, "playwright-replay-evidence-checklist");
+        String evidenceId = analysis.diagnosis().findings().stream()
+                .flatMap(finding -> finding.evidenceIds().stream())
+                .findFirst()
+                .orElseThrow();
+        assertTrue(checklist.contains("By.cssSelector: #login-button"), checklist);
+        assertTrue(checklist.contains(evidenceId), checklist);
+        assertPlaywrightReplayTools(checklist);
+    }
+
+    @Test
+    void webdriverDoctorDoesNotIncludePlaywrightReplayGuidance(@TempDir Path temp) throws Exception {
+        Path input = Files.createDirectories(temp.resolve("webdriver-allure-results"));
+        Files.writeString(input.resolve("webdriver-result.json"), new ObjectMapper().writeValueAsString(Map.of(
+                "uuid", "webdriver",
+                "historyId", "webdriver",
+                "name", "webdriver",
+                "fullName", "example.WebDriver.test",
+                "status", "failed",
+                "start", 1,
+                "stop", 2,
+                "statusDetails", Map.of(
+                        "message", "NoSuchElementException: unable to locate element: By.cssSelector: #login-button",
+                        "trace", "trace"))), StandardCharsets.UTF_8);
+
+        var analysis = service(temp).analyzeFailedAllure(
+                List.of(input.toString()),
+                List.of(),
+                temp.resolve("webdriver-doctor-output").toString(),
+                false,
+                false,
+                1,
+                "",
+                List.of(),
+                false,
+                false,
+                false,
+                "driver");
+
+        String output = analysis.codeBlocks().stream()
+                .map(block -> block.title() + "\n" + block.code() + "\n" + block.placement())
+                .reduce("", (left, right) -> left + "\n" + right);
+        assertTrue(!output.contains("playwright_browser_get_page_dom"), output);
+        assertTrue(!output.contains("playwright_replay_recording"), output);
+    }
+
+    @Test
     void documentedExternalClientsInvokeDoctorAnalyzeWithoutCredentials() throws Exception {
         Path root = repositoryRoot();
         String json = Files.readString(root.resolve(
@@ -331,6 +406,22 @@ class DoctorServiceTest {
 
     private static DoctorService service(Path root) {
         return new DoctorService(McpWorkspacePolicy.of(root), new McpDoctorRemediationService());
+    }
+
+    private static String blockCode(McpAnalysisReport analysis, String blockId) {
+        return analysis.codeBlocks().stream()
+                .filter(block -> block.id().equals(blockId))
+                .findFirst()
+                .map(McpCodeBlock::code)
+                .orElse("");
+    }
+
+    private static void assertPlaywrightReplayTools(String text) {
+        assertTrue(text.contains("playwright_browser_get_page_dom"), text);
+        assertTrue(text.contains("playwright_browser_take_screenshot"), text);
+        assertTrue(text.contains("playwright_element_is_displayed"), text);
+        assertTrue(text.contains("playwright_element_is_enabled"), text);
+        assertTrue(text.contains("playwright_replay_recording"), text);
     }
 
     private static final class DoctorSnippetProvider implements AiProvider {

--- a/shaft-mcp/src/test/java/com/shaft/mcp/HealerServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/HealerServiceTest.java
@@ -81,6 +81,38 @@ class HealerServiceTest {
     }
 
     @Test
+    void failedPlaywrightRerunIncludesReplayEvidenceChecklistFallback(@TempDir Path tempDir) throws Exception {
+        Path repository = fakeRepository(tempDir);
+
+        McpHealerRunResult result = service(
+                tempDir, 1, "failed", "NoSuchElementException: missing login").runFailedPlaywrightTest(
+                repository.toString(),
+                List.of("mvn", "test", "-Dtest=LoginTest"),
+                tempDir.resolve("target/healer").toString(),
+                1,
+                false,
+                false,
+                List.of(),
+                false,
+                false,
+                false,
+                false,
+                "driver");
+
+        String checklist = result.codeBlocks().stream()
+                .filter(block -> block.id().equals("playwright-replay-evidence-checklist"))
+                .findFirst()
+                .map(McpCodeBlock::code)
+                .orElse("");
+        assertTrue(checklist.contains("Failed locator: unavailable in retained Doctor evidence"), checklist);
+        assertTrue(checklist.contains("playwright_browser_get_page_dom"), checklist);
+        assertTrue(checklist.contains("playwright_browser_take_screenshot"), checklist);
+        assertTrue(checklist.contains("playwright_element_is_displayed"), checklist);
+        assertTrue(checklist.contains("playwright_element_is_enabled"), checklist);
+        assertTrue(checklist.contains("playwright_replay_recording"), checklist);
+    }
+
+    @Test
     void noAllureChangesStopsAtGuardrail(@TempDir Path tempDir) throws Exception {
         Path repository = fakeRepository(tempDir);
 


### PR DESCRIPTION
## Summary
- Add Playwright natural action execution through the trust-gated planner, with Appium touch intents kept as explicit unsupported cases.
- Add Playwright network mock/intercept/validate/clear support through `BrowserContext` routing while preserving SHAFT's Selenium HTTP contract.
- Add Playwright-backed accessibility scans using bundled axe-core and shared SHAFT accessibility reporting.
- Expand performance reporting with API percentiles, budget warn/fail gates, JSON exports, and Playwright browser action/page-load budget reports.
- Add Playwright Doctor/Healer replay evidence guidance and refresh graphify artifacts.
- Address static-analysis findings by exposing internal composite locator alternatives without reflection.

## Docs
- Docs PR: https://github.com/ShaftHQ/shafthq.github.io/pull/627

## Validation
- `mvn -pl shaft-engine '-Dtest=PlaywrightNaturalActionExecutorTest,DeterministicNaturalActionPlannerTest,PlaywrightNetworkInterceptorTest,PlaywrightBrowserActionsUnitTest,AccessibilityActionsCoverageUnitTest,ApiPerformanceExecutionReportUnitTest,BrowserPerformanceExecutionReportUnitTest,RequestBuilderPerformanceTest,BrowserActionsCoverageUnitTest' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test` — 38 passed, 0 failed, 0 skipped.
- `mvn -pl shaft-mcp '-Dtest=DoctorServiceTest,HealerServiceTest' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test` — 17 passed, 0 failed, 0 skipped.
- `mvn -pl shaft-engine,shaft-mcp '-DskipTests' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test-compile` — passed.
- `graphify update .` — passed; graph HTML skipped because the engine graph exceeds the visualization node limit.

Refs #3066
Refs #3062
Closes #3027
Closes #3028
Closes #3029
Closes #3035
Closes #3048