### PR TITLE
[codex] Add API request retry policies

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/api/RequestBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/api/RequestBuilder.java
@@ -3,6 +3,7 @@ package com.shaft.api;
 import com.shaft.api.internal.OpenApiCoverageReporter;
 import com.shaft.cli.FileActions;
 import com.shaft.driver.SHAFT;
+import com.shaft.tools.io.ReportManager;
 import io.qameta.allure.Step;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.config.SSLConfig;
@@ -11,7 +12,9 @@ import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import lombok.AccessLevel;
 import lombok.Getter;
+import org.apache.logging.log4j.Level;
 
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -41,6 +44,7 @@ public class RequestBuilder {
     private String authenticationPassword;
     private boolean appendDefaultContentCharsetToContentTypeIfUndefined;
     private boolean urlEncodingEnabled;
+    private RetryPolicy retryPolicy;
 
     /**
      * Start building a new API request from an existing RestActions session.
@@ -313,6 +317,18 @@ public class RequestBuilder {
     }
 
     /**
+     * Applies an opt-in retry policy to this request.
+     *
+     * @param retryPolicy retry policy to apply
+     * @return a self-reference to be used to continue building your API request
+     * @throws NullPointerException if {@code retryPolicy} is null
+     */
+    public RequestBuilder withRetry(RetryPolicy retryPolicy) {
+        this.retryPolicy = Objects.requireNonNull(retryPolicy, "retryPolicy");
+        return this;
+    }
+
+    /**
      * After you finish building your request, use this method to trigger the request and get back the response object.
      *
      * @return the current {@link SHAFT.API} session for response inspection and assertions
@@ -331,9 +347,10 @@ public class RequestBuilder {
 
         long startTime = System.currentTimeMillis();
         Response response = null;
+        RetryState retryState = RetryState.forPolicy(retryPolicy);
         boolean openApiInteractionRecorded = false;
         try {
-            response = sendRequest(request, specs);
+            response = sendRequestWithRetry(request, specs, retryState);
             if (openApiCoverageEnabled) {
                 OpenApiCoverageReporter.recordInteraction(openApiSpec, requestType, serviceName, null);
                 openApiInteractionRecorded = true;
@@ -346,12 +363,12 @@ public class RequestBuilder {
                 logResponseTime(normalizedEndpoint, responseTime);
             }
 
-            handleResponse(response, specs);
+            handleResponse(response, specs, retryState);
         } catch (Exception e) {
             if (openApiCoverageEnabled && !openApiInteractionRecorded) {
                 OpenApiCoverageReporter.recordInteraction(openApiSpec, requestType, serviceName, e);
             }
-            handleException(request, specs, response, e);
+            handleException(request, specs, response, e, retryState);
         }
 
         session.setLastResponse(response);
@@ -404,11 +421,65 @@ public class RequestBuilder {
         return session.sendRequest(requestType, request, specs);
     }
 
-    private void handleResponse(Response response, RequestSpecification specs) {
+    private Response sendRequestWithRetry(String request, RequestSpecification specs, RetryState retryState) {
+        if (retryPolicy == null || !retryPolicy.canRetry(requestType)) {
+            retryState.markAttempt();
+            Response response = sendRequest(request, specs);
+            retryState.recordResponse(response);
+            return response;
+        }
+
+        for (int attempt = 1; attempt <= retryPolicy.maxAttempts(); attempt++) {
+            retryState.markAttempt();
+            try {
+                Response response = sendRequest(request, specs);
+                retryState.recordResponse(response);
+                if (shouldRetryResponse(response, attempt)) {
+                    sleepBeforeRetry(attempt + 1, retryState);
+                    continue;
+                }
+                return response;
+            } catch (RuntimeException e) {
+                retryState.recordException(e);
+                if (shouldRetryException(e, attempt)) {
+                    sleepBeforeRetry(attempt + 1, retryState);
+                    continue;
+                }
+                throw e;
+            }
+        }
+        return null;
+    }
+
+    private boolean shouldRetryResponse(Response response, int attempt) {
+        return attempt < retryPolicy.maxAttempts()
+                && response != null
+                && retryPolicy.shouldRetryStatus(response.getStatusCode());
+    }
+
+    private boolean shouldRetryException(RuntimeException exception, int attempt) {
+        return attempt < retryPolicy.maxAttempts() && retryPolicy.shouldRetry(exception);
+    }
+
+    private void sleepBeforeRetry(int nextAttempt, RetryState retryState) {
+        Duration delay = retryPolicy.delayBeforeAttempt(nextAttempt);
+        ReportManager.logDiscrete("Retrying API request. " + retryState.reportDetails(), Level.DEBUG);
+        if (delay.isZero()) {
+            return;
+        }
+        try {
+            Thread.sleep(delay.toMillis());
+        } catch (InterruptedException interruptedException) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while waiting to retry API request.", interruptedException);
+        }
+    }
+
+    private void handleResponse(Response response, RequestSpecification specs, RetryState retryState) {
         boolean responseStatus = session.evaluateResponseStatusCode(Objects.requireNonNull(response), targetStatusCode);
-        String reportMessage = session.prepareReportMessage(response, targetStatusCode, requestType, serviceName, contentType, urlArguments);
+        String reportMessage = appendRetryDetails(session.prepareReportMessage(response, targetStatusCode, requestType, serviceName, contentType, urlArguments), retryState);
         if (!Boolean.TRUE.equals(responseStatus)) {
-            throw new AssertionError("Invalid response status code; Expected " + targetStatusCode + " but found " + response.getStatusCode() + ".");
+            throw new AssertionError("Invalid response status code; Expected " + targetStatusCode + " but found " + response.getStatusCode() + "." + retryState.reportSuffix());
         }
 
         if (!reportMessage.isEmpty()) {
@@ -418,11 +489,18 @@ public class RequestBuilder {
         }
     }
 
-    private void handleException(String request, RequestSpecification specs, Response response, Exception e) {
+    private String appendRetryDetails(String reportMessage, RetryState retryState) {
+        if (reportMessage == null || reportMessage.isEmpty()) {
+            return reportMessage;
+        }
+        return reportMessage + retryState.reportSuffix();
+    }
+
+    private void handleException(String request, RequestSpecification specs, Response response, Exception e, RetryState retryState) {
         if (response != null) {
-            RestActions.failAction(request + ", Response Time: " + response.timeIn(TimeUnit.MILLISECONDS) + "ms", requestBody, specs, response, e);
+            RestActions.failAction(request + ", Response Time: " + response.timeIn(TimeUnit.MILLISECONDS) + "ms" + retryState.reportSuffix(), requestBody, specs, response, e);
         } else {
-            RestActions.failAction(request, e);
+            RestActions.failAction(request + retryState.reportSuffix(), e);
         }
     }
 
@@ -439,5 +517,43 @@ public class RequestBuilder {
      */
     public enum AuthenticationType {
         BASIC, FORM, NONE
+    }
+
+    private static final class RetryState {
+        private final boolean enabled;
+        private final int maxAttempts;
+        private int attempts;
+        private String finalOutcome = "";
+
+        private RetryState(boolean enabled, int maxAttempts) {
+            this.enabled = enabled;
+            this.maxAttempts = maxAttempts;
+        }
+
+        private static RetryState forPolicy(RetryPolicy retryPolicy) {
+            return new RetryState(retryPolicy != null, retryPolicy == null ? 1 : retryPolicy.maxAttempts());
+        }
+
+        private void markAttempt() {
+            attempts++;
+        }
+
+        private void recordResponse(Response response) {
+            if (response != null) {
+                finalOutcome = "HTTP " + response.getStatusCode();
+            }
+        }
+
+        private void recordException(Exception exception) {
+            finalOutcome = exception.getClass().getSimpleName();
+        }
+
+        private String reportSuffix() {
+            return enabled ? " | Retry Attempts: " + attempts + "/" + maxAttempts + " | Final Outcome: " + finalOutcome : "";
+        }
+
+        private String reportDetails() {
+            return "Retry Attempts: " + attempts + "/" + maxAttempts + " | Last Outcome: " + finalOutcome;
+        }
     }
 }

--- a/shaft-engine/src/main/java/com/shaft/api/RequestBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/api/RequestBuilder.java
@@ -471,7 +471,7 @@ public class RequestBuilder {
             Thread.sleep(delay.toMillis());
         } catch (InterruptedException interruptedException) {
             Thread.currentThread().interrupt();
-            throw new RuntimeException("Interrupted while waiting to retry API request.", interruptedException);
+            throw new IllegalStateException("Interrupted while waiting to retry API request.", interruptedException);
         }
     }
 

--- a/shaft-engine/src/main/java/com/shaft/api/RetryPolicy.java
+++ b/shaft-engine/src/main/java/com/shaft/api/RetryPolicy.java
@@ -1,0 +1,229 @@
+package com.shaft.api;
+
+import java.io.InterruptedIOException;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Opt-in retry policy for {@link RequestBuilder#perform()}.
+ *
+ * <p>Retries are limited to idempotent HTTP methods by default. Use
+ * {@link #allowNonIdempotentRequests()} only when retrying POST or PATCH is safe
+ * for the target API.</p>
+ */
+public final class RetryPolicy {
+    private static final Set<Integer> DEFAULT_TRANSIENT_STATUS_CODES = Set.of(408, 429, 500, 502, 503, 504);
+    private static final int DEFAULT_MAX_ATTEMPTS = 3;
+
+    private final Set<Integer> retryStatusCodes;
+    private final boolean retryNetworkFailures;
+    private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
+    private boolean allowNonIdempotentRequests;
+    private BackoffType backoffType = BackoffType.FIXED;
+    private Duration initialDelay = Duration.ZERO;
+    private Duration maxDelay = Duration.ZERO;
+
+    private RetryPolicy(Set<Integer> retryStatusCodes, boolean retryNetworkFailures) {
+        this.retryStatusCodes = new LinkedHashSet<>(retryStatusCodes);
+        this.retryNetworkFailures = retryNetworkFailures;
+    }
+
+    /**
+     * Retries transient network failures and common transient HTTP statuses:
+     * 408, 429, 500, 502, 503, and 504.
+     *
+     * @return a retry policy with safe transient defaults
+     */
+    public static RetryPolicy transientFailures() {
+        return new RetryPolicy(DEFAULT_TRANSIENT_STATUS_CODES, true);
+    }
+
+    /**
+     * Retries the supplied HTTP status codes.
+     *
+     * @param statusCodes HTTP statuses to retry
+     * @return a retry policy for the supplied statuses
+     * @throws IllegalArgumentException if no status codes are supplied or a code is outside 100-599
+     */
+    public static RetryPolicy statusCodes(int... statusCodes) {
+        if (statusCodes == null || statusCodes.length == 0) {
+            throw new IllegalArgumentException("At least one retry status code is required.");
+        }
+        LinkedHashSet<Integer> codes = new LinkedHashSet<>();
+        Arrays.stream(statusCodes).forEach(code -> {
+            if (code < 100 || code > 599) {
+                throw new IllegalArgumentException("Retry status code must be between 100 and 599: " + code);
+            }
+            codes.add(code);
+        });
+        return new RetryPolicy(codes, false);
+    }
+
+    /**
+     * Sets the total number of attempts, including the first request.
+     *
+     * @param maxAttempts total attempts; must be greater than zero
+     * @return this retry policy
+     */
+    public RetryPolicy maxAttempts(int maxAttempts) {
+        if (maxAttempts < 1) {
+            throw new IllegalArgumentException("maxAttempts must be greater than zero.");
+        }
+        this.maxAttempts = maxAttempts;
+        return this;
+    }
+
+    /**
+     * Allows retries for POST and PATCH requests.
+     *
+     * @return this retry policy
+     */
+    public RetryPolicy allowNonIdempotentRequests() {
+        this.allowNonIdempotentRequests = true;
+        return this;
+    }
+
+    /**
+     * Uses the same delay before each retry.
+     *
+     * @param delay delay before the next attempt
+     * @return this retry policy
+     */
+    public RetryPolicy fixedBackoff(Duration delay) {
+        this.initialDelay = requireNonNegative(delay, "delay");
+        this.maxDelay = this.initialDelay;
+        this.backoffType = BackoffType.FIXED;
+        return this;
+    }
+
+    /**
+     * Doubles the delay after each failed attempt until {@code maxDelay}.
+     *
+     * @param initialDelay delay before the first retry
+     * @param maxDelay     upper delay bound
+     * @return this retry policy
+     */
+    public RetryPolicy exponentialBackoff(Duration initialDelay, Duration maxDelay) {
+        this.initialDelay = requireNonNegative(initialDelay, "initialDelay");
+        this.maxDelay = requireMaxDelay(maxDelay, this.initialDelay);
+        this.backoffType = BackoffType.EXPONENTIAL;
+        return this;
+    }
+
+    /**
+     * Uses exponential backoff with a random delay between zero and the current
+     * exponential delay.
+     *
+     * @param initialDelay maximum delay before the first retry
+     * @param maxDelay     upper delay bound
+     * @return this retry policy
+     */
+    public RetryPolicy jitteredBackoff(Duration initialDelay, Duration maxDelay) {
+        this.initialDelay = requireNonNegative(initialDelay, "initialDelay");
+        this.maxDelay = requireMaxDelay(maxDelay, this.initialDelay);
+        this.backoffType = BackoffType.JITTERED;
+        return this;
+    }
+
+    int maxAttempts() {
+        return maxAttempts;
+    }
+
+    boolean canRetry(RestActions.RequestType requestType) {
+        return maxAttempts > 1 && (allowNonIdempotentRequests || isIdempotent(requestType));
+    }
+
+    boolean shouldRetryStatus(int statusCode) {
+        return retryStatusCodes.contains(statusCode);
+    }
+
+    boolean shouldRetry(Throwable throwable) {
+        return retryNetworkFailures && isTransientNetworkFailure(throwable);
+    }
+
+    Duration delayBeforeAttempt(int nextAttempt) {
+        Duration calculatedDelay = switch (backoffType) {
+            case FIXED -> initialDelay;
+            case EXPONENTIAL -> exponentialDelay(nextAttempt);
+            case JITTERED -> jitteredDelay(exponentialDelay(nextAttempt));
+        };
+        return calculatedDelay.compareTo(maxDelay) > 0 ? maxDelay : calculatedDelay;
+    }
+
+    private static boolean isIdempotent(RestActions.RequestType requestType) {
+        return requestType == RestActions.RequestType.GET
+                || requestType == RestActions.RequestType.PUT
+                || requestType == RestActions.RequestType.DELETE;
+    }
+
+    private static boolean isTransientNetworkFailure(Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause != null) {
+            if (cause instanceof SocketTimeoutException
+                    || cause instanceof ConnectException
+                    || cause instanceof NoRouteToHostException
+                    || cause instanceof UnknownHostException
+                    || cause instanceof SocketException
+                    || cause instanceof InterruptedIOException) {
+                return true;
+            }
+            String simpleName = cause.getClass().getSimpleName();
+            if ("ConnectTimeoutException".equals(simpleName)
+                    || "ConnectionClosedException".equals(simpleName)
+                    || "HttpHostConnectException".equals(simpleName)
+                    || "NoHttpResponseException".equals(simpleName)) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
+    }
+
+    private Duration exponentialDelay(int nextAttempt) {
+        Duration delay = initialDelay;
+        for (int attempt = 2; attempt < nextAttempt; attempt++) {
+            delay = delay.multipliedBy(2);
+            if (delay.compareTo(maxDelay) >= 0) {
+                return maxDelay;
+            }
+        }
+        return delay;
+    }
+
+    private static Duration jitteredDelay(Duration upperBound) {
+        long upperBoundMillis = upperBound.toMillis();
+        if (upperBoundMillis <= 0) {
+            return Duration.ZERO;
+        }
+        return Duration.ofMillis(ThreadLocalRandom.current().nextLong(upperBoundMillis + 1));
+    }
+
+    private static Duration requireNonNegative(Duration duration, String name) {
+        Objects.requireNonNull(duration, name);
+        if (duration.isNegative()) {
+            throw new IllegalArgumentException(name + " must not be negative.");
+        }
+        return duration;
+    }
+
+    private static Duration requireMaxDelay(Duration maxDelay, Duration initialDelay) {
+        Duration checkedMaxDelay = requireNonNegative(maxDelay, "maxDelay");
+        if (checkedMaxDelay.compareTo(initialDelay) < 0) {
+            throw new IllegalArgumentException("maxDelay must be greater than or equal to initialDelay.");
+        }
+        return checkedMaxDelay;
+    }
+
+    private enum BackoffType {
+        FIXED, EXPONENTIAL, JITTERED
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/api/RequestBuilderTests.java
+++ b/shaft-engine/src/test/java/com/shaft/api/RequestBuilderTests.java
@@ -11,8 +11,10 @@ import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
+import java.net.SocketTimeoutException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -198,6 +200,123 @@ public class RequestBuilderTests {
                 .performRequest();
 
         Mockito.verify(specs.auth()).form("formUser", "formPass");
+    }
+
+    @Test
+    public void performShouldRetryRetryableStatusForIdempotentRequests() {
+        RestActions mockSession = createSessionMock();
+        RequestSpecification specs = Mockito.mock(RequestSpecification.class, Mockito.RETURNS_DEEP_STUBS);
+        Response unavailable = Mockito.mock(Response.class);
+        Response ok = Mockito.mock(Response.class);
+        SHAFT.API existingDriver = Mockito.mock(SHAFT.API.class);
+
+        Mockito.when(mockSession.prepareRequestURL("http://localhost/", null, "users")).thenReturn("http://localhost/users");
+        Mockito.when(mockSession.prepareRequestSpecs(Mockito.isNull(), Mockito.isNull(), Mockito.isNull(), Mockito.eq(ContentType.ANY), Mockito.anyMap(), Mockito.anyMap(), Mockito.any(), Mockito.eq(true), Mockito.eq(true))).thenReturn(specs);
+        Mockito.when(mockSession.sendRequest(RestActions.RequestType.GET, "http://localhost/users", specs)).thenReturn(unavailable, ok);
+        Mockito.when(unavailable.getStatusCode()).thenReturn(503);
+        Mockito.when(ok.getStatusCode()).thenReturn(200);
+        Mockito.when(mockSession.evaluateResponseStatusCode(ok, 0)).thenReturn(true);
+        Mockito.when(mockSession.prepareReportMessage(ok, 0, RestActions.RequestType.GET, "users", ContentType.ANY, null)).thenReturn("ok");
+        Mockito.when(mockSession.getDriver()).thenReturn(existingDriver);
+
+        SHAFT.API returnedDriver = new RequestBuilder(mockSession, "users", RestActions.RequestType.GET)
+                .withRetry(RetryPolicy.statusCodes(503).maxAttempts(2).fixedBackoff(Duration.ZERO))
+                .perform();
+
+        Assert.assertSame(returnedDriver, existingDriver);
+        Mockito.verify(mockSession, Mockito.times(2)).sendRequest(RestActions.RequestType.GET, "http://localhost/users", specs);
+        Mockito.verify(mockSession, Mockito.never()).evaluateResponseStatusCode(unavailable, 0);
+        Mockito.verify(mockSession).setLastResponse(ok);
+    }
+
+    @Test
+    public void performShouldRetryTransientNetworkFailures() {
+        RestActions mockSession = createSessionMock();
+        RequestSpecification specs = Mockito.mock(RequestSpecification.class, Mockito.RETURNS_DEEP_STUBS);
+        Response ok = Mockito.mock(Response.class);
+
+        Mockito.when(mockSession.prepareRequestURL("http://localhost/", null, "users")).thenReturn("http://localhost/users");
+        Mockito.when(mockSession.prepareRequestSpecs(Mockito.isNull(), Mockito.isNull(), Mockito.isNull(), Mockito.eq(ContentType.ANY), Mockito.anyMap(), Mockito.anyMap(), Mockito.any(), Mockito.eq(true), Mockito.eq(true))).thenReturn(specs);
+        Mockito.when(mockSession.sendRequest(RestActions.RequestType.GET, "http://localhost/users", specs))
+                .thenThrow(new RuntimeException(new SocketTimeoutException("read timed out")))
+                .thenReturn(ok);
+        Mockito.when(ok.getStatusCode()).thenReturn(200);
+        Mockito.when(mockSession.evaluateResponseStatusCode(ok, 0)).thenReturn(true);
+        Mockito.when(mockSession.prepareReportMessage(ok, 0, RestActions.RequestType.GET, "users", ContentType.ANY, null)).thenReturn("ok");
+        Mockito.when(mockSession.getDriver()).thenReturn(Mockito.mock(SHAFT.API.class));
+
+        new RequestBuilder(mockSession, "users", RestActions.RequestType.GET)
+                .withRetry(RetryPolicy.transientFailures().maxAttempts(2).fixedBackoff(Duration.ZERO))
+                .perform();
+
+        Mockito.verify(mockSession, Mockito.times(2)).sendRequest(RestActions.RequestType.GET, "http://localhost/users", specs);
+        Mockito.verify(mockSession).setLastResponse(ok);
+    }
+
+    @Test
+    public void performShouldNotRetryNonIdempotentRequestsByDefault() {
+        RestActions mockSession = createSessionMock();
+        RequestSpecification specs = Mockito.mock(RequestSpecification.class, Mockito.RETURNS_DEEP_STUBS);
+        Response unavailable = Mockito.mock(Response.class);
+
+        Mockito.when(mockSession.prepareRequestURL("http://localhost/", null, "orders")).thenReturn("http://localhost/orders");
+        Mockito.when(mockSession.prepareRequestSpecs(Mockito.isNull(), Mockito.isNull(), Mockito.isNull(), Mockito.eq(ContentType.ANY), Mockito.anyMap(), Mockito.anyMap(), Mockito.any(), Mockito.eq(true), Mockito.eq(true))).thenReturn(specs);
+        Mockito.when(mockSession.sendRequest(RestActions.RequestType.POST, "http://localhost/orders", specs)).thenReturn(unavailable);
+        Mockito.when(unavailable.getStatusCode()).thenReturn(503);
+        Mockito.when(unavailable.timeIn(TimeUnit.MILLISECONDS)).thenReturn(25L);
+        Mockito.when(mockSession.evaluateResponseStatusCode(unavailable, 0)).thenReturn(false);
+        Mockito.when(mockSession.prepareReportMessage(unavailable, 0, RestActions.RequestType.POST, "orders", ContentType.ANY, null)).thenReturn("failed");
+
+        Assert.assertThrows(AssertionError.class, () -> new RequestBuilder(mockSession, "orders", RestActions.RequestType.POST)
+                .withRetry(RetryPolicy.statusCodes(503).maxAttempts(2).fixedBackoff(Duration.ZERO))
+                .perform());
+
+        Mockito.verify(mockSession, Mockito.times(1)).sendRequest(RestActions.RequestType.POST, "http://localhost/orders", specs);
+    }
+
+    @Test
+    public void performShouldRetryNonIdempotentRequestsAfterOptIn() {
+        RestActions mockSession = createSessionMock();
+        RequestSpecification specs = Mockito.mock(RequestSpecification.class, Mockito.RETURNS_DEEP_STUBS);
+        Response unavailable = Mockito.mock(Response.class);
+        Response ok = Mockito.mock(Response.class);
+
+        Mockito.when(mockSession.prepareRequestURL("http://localhost/", null, "orders")).thenReturn("http://localhost/orders");
+        Mockito.when(mockSession.prepareRequestSpecs(Mockito.isNull(), Mockito.isNull(), Mockito.isNull(), Mockito.eq(ContentType.ANY), Mockito.anyMap(), Mockito.anyMap(), Mockito.any(), Mockito.eq(true), Mockito.eq(true))).thenReturn(specs);
+        Mockito.when(mockSession.sendRequest(RestActions.RequestType.POST, "http://localhost/orders", specs)).thenReturn(unavailable, ok);
+        Mockito.when(unavailable.getStatusCode()).thenReturn(503);
+        Mockito.when(ok.getStatusCode()).thenReturn(201);
+        Mockito.when(mockSession.evaluateResponseStatusCode(ok, 0)).thenReturn(true);
+        Mockito.when(mockSession.prepareReportMessage(ok, 0, RestActions.RequestType.POST, "orders", ContentType.ANY, null)).thenReturn("ok");
+        Mockito.when(mockSession.getDriver()).thenReturn(Mockito.mock(SHAFT.API.class));
+
+        new RequestBuilder(mockSession, "orders", RestActions.RequestType.POST)
+                .withRetry(RetryPolicy.statusCodes(503).maxAttempts(2).fixedBackoff(Duration.ZERO).allowNonIdempotentRequests())
+                .perform();
+
+        Mockito.verify(mockSession, Mockito.times(2)).sendRequest(RestActions.RequestType.POST, "http://localhost/orders", specs);
+        Mockito.verify(mockSession).setLastResponse(ok);
+    }
+
+    @Test
+    public void retryPolicyShouldValidateInputsAndCalculateBackoff() {
+        Assert.assertThrows(IllegalArgumentException.class, RetryPolicy::statusCodes);
+        Assert.assertThrows(IllegalArgumentException.class, () -> RetryPolicy.statusCodes(99));
+        Assert.assertThrows(IllegalArgumentException.class, () -> RetryPolicy.statusCodes(503).maxAttempts(0));
+        Assert.assertThrows(IllegalArgumentException.class, () -> RetryPolicy.statusCodes(503).fixedBackoff(Duration.ofMillis(-1)));
+        Assert.assertThrows(IllegalArgumentException.class, () -> RetryPolicy.statusCodes(503).exponentialBackoff(Duration.ofMillis(200), Duration.ofMillis(100)));
+
+        RetryPolicy fixed = RetryPolicy.statusCodes(503).fixedBackoff(Duration.ofMillis(100));
+        RetryPolicy exponential = RetryPolicy.statusCodes(503).exponentialBackoff(Duration.ofMillis(100), Duration.ofMillis(250));
+        RetryPolicy jittered = RetryPolicy.statusCodes(503).jitteredBackoff(Duration.ofMillis(100), Duration.ofMillis(250));
+
+        Assert.assertEquals(fixed.delayBeforeAttempt(4), Duration.ofMillis(100));
+        Assert.assertEquals(exponential.delayBeforeAttempt(2), Duration.ofMillis(100));
+        Assert.assertEquals(exponential.delayBeforeAttempt(3), Duration.ofMillis(200));
+        Assert.assertEquals(exponential.delayBeforeAttempt(4), Duration.ofMillis(250));
+        Assert.assertFalse(RetryPolicy.statusCodes(503).canRetry(RestActions.RequestType.POST));
+        Assert.assertTrue(RetryPolicy.statusCodes(503).allowNonIdempotentRequests().canRetry(RestActions.RequestType.POST));
+        Assert.assertTrue(jittered.delayBeforeAttempt(4).compareTo(Duration.ofMillis(250)) <= 0);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Adds `RetryPolicy` for opt-in request-level retries on transient failures and selected HTTP status codes.
- Wires `RequestBuilder.withRetry(...)` into `perform()` with idempotent defaults and explicit POST/PATCH opt-in.
- Reports retry attempt counts and final outcomes in API request reporting, with focused unit coverage for status, network, idempotency, and backoff behavior.

## Validation
- `mvn test -pl shaft-engine -am '-Dtest=RequestBuilderTests' '-Dgpg.skip=true' '-Dallure.automaticallyOpen=false' '-Dallure.open=false'` - 18 passed, 0 failed, 0 skipped.
- Allure verification: 18 result JSON files, 18 passed.
- `mvn package -pl shaft-engine -am '-DskipTests' '-Dgpg.skip=true' '-Dallure.automaticallyOpen=false' '-Dallure.open=false'` - build success.
- Docs companion PR: https://github.com/ShaftHQ/shafthq.github.io/pull/631

## Graphify
- Attempted `graphify update .` from disposable clean worktrees. The installed updater repeatedly omitted the new `RetryPolicy.java` file even when staged, forced, and added to the temporary manifest, so no generated graph files were committed.

Closes #3049
