### PR TITLE
Add flake profiler reporting

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -15,6 +15,7 @@ import com.shaft.gui.internal.locator.ShadowLocatorBuilder;
 import com.shaft.performance.internal.LightHouseGenerateReport;
 import com.shaft.tools.internal.support.JavaScriptHelper;
 import com.shaft.tools.io.ReportManager;
+import com.shaft.tools.io.internal.FlakeProfiler;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import com.shaft.validation.accessibility.AccessibilityActions;
 import com.shaft.validation.internal.WebDriverBrowserValidationsBuilder;
@@ -32,6 +33,7 @@ import org.openqa.selenium.remote.http.HttpResponse;
 import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -1001,7 +1003,18 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
     public BrowserActions captureScreenshot(Screenshots type) {
         var logText = "Capture " + type.name().toLowerCase() + " screenshot";
         var screenshotManager = new ScreenshotManager();
-        ReportManagerHelper.log(logText, Collections.singletonList(screenshotManager.prepareImageForReport(screenshotManager.takeScreenshot(driverFactoryHelper.getDriver(), null), "captureScreenshot")));
+        long profilerScreenshotStart = FlakeProfiler.isEnabled() ? System.nanoTime() : 0L;
+        byte[] screenshot = screenshotManager.takeScreenshot(driverFactoryHelper.getDriver(), null);
+        if (profilerScreenshotStart != 0L) {
+            FlakeProfiler.recordEvidenceCapture("screenshot", logText,
+                    TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - profilerScreenshotStart));
+        }
+        long profilerAttachmentStart = FlakeProfiler.isEnabled() ? System.nanoTime() : 0L;
+        ReportManagerHelper.log(logText, Collections.singletonList(screenshotManager.prepareImageForReport(screenshot, "captureScreenshot")));
+        if (profilerAttachmentStart != 0L) {
+            FlakeProfiler.recordEvidenceCapture("report attachment", logText,
+                    TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - profilerAttachmentStart));
+        }
         return this;
     }
 
@@ -1015,13 +1028,23 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
     @Override
     public BrowserActions captureSnapshot() {
         var logMessage = "";
+        long profilerSnapshotStart = FlakeProfiler.isEnabled() ? System.nanoTime() : 0L;
         var pageSnapshot = browserActionsHelper.capturePageSnapshot(driverFactoryHelper.getDriver());
+        if (profilerSnapshotStart != 0L) {
+            FlakeProfiler.recordEvidenceCapture("page snapshot", "Capture page snapshot",
+                    TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - profilerSnapshotStart));
+        }
         if (pageSnapshot.startsWith("From: <Saved by Blink>")) {
             logMessage = "Capture page snapshot";
         } else if (pageSnapshot.startsWith("<html")) {
             logMessage = "Capture page HTML";
         }
+        long profilerAttachmentStart = FlakeProfiler.isEnabled() ? System.nanoTime() : 0L;
         ReportManagerHelper.log(logMessage, List.of(Arrays.asList(logMessage, new ScreenshotManager().generateAttachmentFileName("captureSnapshot"), new ByteArrayInputStream(pageSnapshot.getBytes()))));
+        if (profilerAttachmentStart != 0L) {
+            FlakeProfiler.recordEvidenceCapture("report attachment", logMessage,
+                    TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - profilerAttachmentStart));
+        }
         return this;
     }
 

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserActionsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserActionsHelper.java
@@ -9,6 +9,7 @@ import com.shaft.tools.internal.support.JavaHelper;
 import com.shaft.tools.internal.support.JavaScriptHelper;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.FailureReporter;
+import com.shaft.tools.io.internal.FlakeProfiler;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import lombok.SneakyThrows;
 import org.apache.logging.log4j.Level;
@@ -31,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.*;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Internal helper class for browser actions within the SHAFT framework.
@@ -206,14 +208,23 @@ public class BrowserActionsHelper {
         if (!isSilent) {
             if (driver != null && !message.equals("Capture page snapshot.")) {
                 attachments.add(new ScreenshotManager().takeScreenshot(driver, null, actionName, passFailStatus));
-                ReportManagerHelper.log(message, attachments);
+                logWithProfiledAttachments(actionName, message, attachments);
             } else if (!attachments.isEmpty()) {
-                ReportManagerHelper.log(message, attachments);
+                logWithProfiledAttachments(actionName, message, attachments);
             } else {
                 ReportManager.log(message);
             }
         }
         return message;
+    }
+
+    private void logWithProfiledAttachments(String actionName, String message, List<List<Object>> attachments) {
+        long profilerStart = FlakeProfiler.isEnabled() ? System.nanoTime() : 0L;
+        ReportManagerHelper.log(message, attachments);
+        if (profilerStart != 0L) {
+            FlakeProfiler.recordEvidenceCapture("report attachment", actionName,
+                    TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - profilerStart));
+        }
     }
 
     /**

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -22,6 +22,7 @@ import com.shaft.tools.internal.support.JavaHelper;
 import com.shaft.tools.internal.support.JavaScriptHelper;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.FailureReporter;
+import com.shaft.tools.io.internal.FlakeProfiler;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import io.appium.java_client.AppiumDriver;
 import io.qameta.allure.Allure;
@@ -54,6 +55,10 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.Function;
@@ -83,6 +88,8 @@ public class Actions extends ElementActions {
     private static final DateTimeFormatter SCREENSHOT_ATTACHMENT_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss");
     private static final int TYPED_VALUE_STEP_TEXT_LIMIT = 120;
     private static final String MASKED_TYPED_VALUE = "********";
+    private static final ThreadLocal<AtomicLong> ACTION_EVIDENCE_NANOS = ThreadLocal.withInitial(AtomicLong::new);
+    private static final ThreadLocal<AtomicInteger> ACTION_STALE_RETRIES = ThreadLocal.withInitial(AtomicInteger::new);
 
     /**
      * Creates a new {@code Actions} instance using the driver managed by the current thread's
@@ -439,21 +446,36 @@ public class Actions extends ElementActions {
     }
 
     protected String performAction(ActionType action, By locator, Object data) {
+        long profilerStart = FlakeProfiler.isEnabled() ? System.nanoTime() : 0L;
+        if (profilerStart != 0L) {
+            ACTION_EVIDENCE_NANOS.get().set(0L);
+            ACTION_STALE_RETRIES.get().set(0);
+        }
         AtomicReference<String> output = new AtomicReference<>("");
         AtomicReference<String> accessibleName = new AtomicReference<>(JavaHelper.formatLocatorToString(locator));
         AtomicReference<ActionReportContext> reportContext = new AtomicReference<>(ActionReportContext.from(action, locator, data, accessibleName.get()));
         AtomicReferenceArray<byte[]> screenshot = new AtomicReferenceArray<>(1);
         AtomicReference<List<WebElement>> foundElements = new AtomicReference<>();
+        FlakeProfileContext flakeProfile = new FlakeProfileContext(action, locator, profilerStart, foundElements);
         AtomicReference<HealingResolution> healingResolution = new AtomicReference<>();
         AtomicReference<HealingResolution> secondaryHealingResolution = new AtomicReference<>();
         AtomicReference<By> secondaryLocator = new AtomicReference<>();
 
         try {
             new SynchronizationManager(driverFactoryHelper.getDriver()).fluentWait(true).until(d -> {
+                flakeProfile.waitLoops.incrementAndGet();
+                flakeProfile.locatorLookups.incrementAndGet();
                 // find all elements matching the target locator
+                long profilerLocateStart = profilerStart != 0L ? System.nanoTime() : 0L;
                 ElementLookup lookup = findAllElements(locator, action.name());
+                if (profilerLocateStart != 0L) {
+                    flakeProfile.locateNanos.addAndGet(System.nanoTime() - profilerLocateStart);
+                }
                 foundElements.set(lookup.elements());
                 healingResolution.set(lookup.healingResolution());
+                if (lookup.healingAttempted()) {
+                    flakeProfile.healingAttempted.set(true);
+                }
 
                 // fail fast if no elements were found
                 if (foundElements.get().isEmpty())
@@ -548,7 +570,10 @@ public class Actions extends ElementActions {
                 //wait for lazy loading
                 JavaScriptWaitManager.waitForLazyLoading(d);
                 // perform action
-                switch (action) {
+                long profilerActionStart = profilerStart != 0L ? System.nanoTime() : 0L;
+                long profilerEvidenceBeforeAction = profilerStart != 0L ? ACTION_EVIDENCE_NANOS.get().get() : 0L;
+                try {
+                    switch (action) {
                     case HOVER ->
                             (new org.openqa.selenium.interactions.Actions(d)).pause(defaultPauseDuration).moveToElement(foundElements.get().getFirst()).perform();
                     case CLICK -> {
@@ -656,11 +681,19 @@ public class Actions extends ElementActions {
 
                             By destinationLocator = (By) data;
                             currentDragAndDropSubstep = "resolve destination element";
+                            flakeProfile.locatorLookups.incrementAndGet();
+                            long profilerDestinationLocateStart = profilerStart != 0L ? System.nanoTime() : 0L;
                             ElementLookup destinationLookup = findAllElements(
                                     destinationLocator,
                                     action.name() + "_DESTINATION");
+                            if (profilerDestinationLocateStart != 0L) {
+                                flakeProfile.locateNanos.addAndGet(System.nanoTime() - profilerDestinationLocateStart);
+                            }
                             List<WebElement> destinationElements = destinationLookup.elements();
                             secondaryHealingResolution.set(destinationLookup.healingResolution());
+                            if (destinationLookup.healingAttempted()) {
+                                flakeProfile.secondaryHealingAttempted.set(true);
+                            }
                             secondaryLocator.set(destinationLocator);
                             if (destinationLookup.healingResolution() == null) {
                                 HealingManager.observe(
@@ -760,6 +793,12 @@ public class Actions extends ElementActions {
                 // take screenshot if not already taken before action
                 if (screenshot.get(0) == null)
                     screenshot.set(0, takeActionScreenshot(foundElements.get().getFirst()));
+                } finally {
+                    if (profilerActionStart != 0L) {
+                        long evidenceDuringAction = ACTION_EVIDENCE_NANOS.get().get() - profilerEvidenceBeforeAction;
+                        flakeProfile.actionNanos.addAndGet(Math.max(0L, System.nanoTime() - profilerActionStart - evidenceDuringAction));
+                    }
+                }
                 HealingManager.recordOutcome(
                         d,
                         healingResolution.get(),
@@ -798,12 +837,14 @@ public class Actions extends ElementActions {
                 } else {
                     screenshot.set(0, takeFailureScreenshot(foundElements.get().getFirst()));
                 }
+                recordFlakeProfile(flakeProfile, false);
                 // report broken
                 reportBroken(action.name(), accessibleName.get(), reportContext.get(), screenshot.get(0), exception);
             } catch (RuntimeException exception2) {
                 if (exception2.getCause() == null || !exception2.getCause().equals(exception)) {
                     // in case a new exception was thrown while attempting to take a screenshot
                     exception2.addSuppressed(exception);
+                    recordFlakeProfile(flakeProfile, false);
                     // report broken
                     reportBroken(action.name(), accessibleName.get(), reportContext.get(), screenshot.get(0), exception2);
                 } else {
@@ -813,8 +854,70 @@ public class Actions extends ElementActions {
             }
         }
         //report pass
+        recordFlakeProfile(flakeProfile, true);
         reportPass(action.name(), accessibleName.get(), reportContext.get(), screenshot.get(0));
         return output.get();
+    }
+
+    private static void recordFlakeProfile(FlakeProfileContext profile, boolean successful) {
+        if (profile.startNanos == 0L) {
+            return;
+        }
+        long evidenceNanos = ACTION_EVIDENCE_NANOS.get().get();
+        long waitNanos = Math.max(0L, System.nanoTime() - profile.startNanos
+                - evidenceNanos
+                - profile.locateNanos.get()
+                - profile.actionNanos.get());
+        List<WebElement> elements = profile.foundElements.get();
+        int matchCount = elements == null ? 0 : elements.size();
+        int healingAttempts = (profile.healingAttempted.get() ? 1 : 0)
+                + (profile.secondaryHealingAttempted.get() ? 1 : 0);
+        String target = JavaHelper.formatLocatorToString(profile.locator);
+        FlakeProfiler.recordAction(FlakeProfiler.ActionSample.of("locate", profile.action.name())
+                .target(target)
+                .durationMillis(TimeUnit.NANOSECONDS.toMillis(profile.locateNanos.get()))
+                .locatorLookupCount(profile.locatorLookups.get())
+                .matchCount(matchCount)
+                .staleElementRetries(ACTION_STALE_RETRIES.get().get())
+                .healingAttempts(healingAttempts)
+                .successful(successful));
+        FlakeProfiler.recordAction(FlakeProfiler.ActionSample.of("wait", profile.action.name())
+                .target(target)
+                .durationMillis(TimeUnit.NANOSECONDS.toMillis(waitNanos))
+                .waitLoopCount(profile.waitLoops.get())
+                .successful(successful));
+        FlakeProfiler.recordAction(FlakeProfiler.ActionSample.of("action", profile.action.name())
+                .target(target)
+                .durationMillis(TimeUnit.NANOSECONDS.toMillis(profile.actionNanos.get()))
+                .locatorLookupCount(profile.locatorLookups.get())
+                .matchCount(matchCount)
+                .staleElementRetries(ACTION_STALE_RETRIES.get().get())
+                .healingAttempts(healingAttempts)
+                .waitLoopCount(profile.waitLoops.get())
+                .successful(successful));
+        ACTION_EVIDENCE_NANOS.remove();
+        ACTION_STALE_RETRIES.remove();
+    }
+
+    private static final class FlakeProfileContext {
+        private final ActionType action;
+        private final By locator;
+        private final long startNanos;
+        private final AtomicReference<List<WebElement>> foundElements;
+        private final AtomicInteger waitLoops = new AtomicInteger();
+        private final AtomicInteger locatorLookups = new AtomicInteger();
+        private final AtomicLong locateNanos = new AtomicLong();
+        private final AtomicLong actionNanos = new AtomicLong();
+        private final AtomicBoolean healingAttempted = new AtomicBoolean(false);
+        private final AtomicBoolean secondaryHealingAttempted = new AtomicBoolean(false);
+
+        private FlakeProfileContext(ActionType action, By locator, long startNanos,
+                                    AtomicReference<List<WebElement>> foundElements) {
+            this.action = action;
+            this.locator = locator;
+            this.startNanos = startNanos;
+            this.foundElements = foundElements;
+        }
     }
 
     private void selectValue(WebElement targetElement, By locator, String valueOrVisibleText) {
@@ -930,12 +1033,18 @@ public class Actions extends ElementActions {
                 //normal case, just find the elements
                 foundElements = ElementActionsHelper.safeFindElements(driverFactoryHelper.getDriver(), locator);
             }
-        } catch (NoSuchElementException | NoSuchFrameException | StaleElementReferenceException exception) {
+        } catch (StaleElementReferenceException exception) {
+            if (FlakeProfiler.isEnabled()) {
+                ACTION_STALE_RETRIES.get().incrementAndGet();
+            }
+            foundElements = List.of();
+        } catch (NoSuchElementException | NoSuchFrameException exception) {
             foundElements = List.of();
         }
         if (!foundElements.isEmpty()) {
-            return new ElementLookup(foundElements, null);
+            return new ElementLookup(foundElements, null, false);
         }
+        boolean healingAttempted = true;
         HealingResolution resolution = HealingManager.resolve(
                         driverFactoryHelper.getDriver(),
                         locator,
@@ -946,11 +1055,12 @@ public class Actions extends ElementActions {
                         cssSelector)
                 .orElse(null);
         return resolution == null
-                ? new ElementLookup(foundElements, null)
-                : new ElementLookup(resolution.elements(), resolution);
+                ? new ElementLookup(foundElements, null, healingAttempted)
+                : new ElementLookup(resolution.elements(), resolution, healingAttempted);
     }
 
-    private record ElementLookup(List<WebElement> elements, HealingResolution healingResolution) {
+    private record ElementLookup(List<WebElement> elements, HealingResolution healingResolution,
+                                 boolean healingAttempted) {
     }
 
     private byte[] takeActionScreenshot(WebElement element) {
@@ -966,24 +1076,33 @@ public class Actions extends ElementActions {
     }
 
     private byte[] captureScreenshot(WebElement element, boolean isPass) {
-        // capture screenshot
-        byte[] screenshot;
-        if (element != null && (SHAFT.Properties.visuals.screenshotParamsHighlightElements() || !isPass)) {
-            if ("JavaScript".equals(SHAFT.Properties.visuals.screenshotParamsHighlightMethod())) {
-                // take screenshot, apply watermark and append it to gif before removing javascript highlighting
-                screenshot = takeJavaScriptHighlightedScreenshot(element, isPass);
+        long profilerStart = FlakeProfiler.isEnabled() ? System.nanoTime() : 0L;
+        try {
+            // capture screenshot
+            byte[] screenshot;
+            if (element != null && (SHAFT.Properties.visuals.screenshotParamsHighlightElements() || !isPass)) {
+                if ("JavaScript".equals(SHAFT.Properties.visuals.screenshotParamsHighlightMethod())) {
+                    // take screenshot, apply watermark and append it to gif before removing javascript highlighting
+                    screenshot = takeJavaScriptHighlightedScreenshot(element, isPass);
+                } else {
+                    screenshot = takeAIHighlightedScreenshot(element, isPass);
+                    // append screenshot to animated gif
+                    AnimatedGifManager.startOrAppendToAnimatedGif(screenshot, SHAFT.Properties.visuals.screenshotParamsWatermark());
+                }
             } else {
-                screenshot = takeAIHighlightedScreenshot(element, isPass);
+                screenshot = takeScreenshot(element);
                 // append screenshot to animated gif
                 AnimatedGifManager.startOrAppendToAnimatedGif(screenshot, SHAFT.Properties.visuals.screenshotParamsWatermark());
             }
-        } else {
-            screenshot = takeScreenshot(element);
-            // append screenshot to animated gif
-            AnimatedGifManager.startOrAppendToAnimatedGif(screenshot, SHAFT.Properties.visuals.screenshotParamsWatermark());
+            return screenshot;
+        } finally {
+            if (profilerStart != 0L) {
+                long evidenceNanos = System.nanoTime() - profilerStart;
+                ACTION_EVIDENCE_NANOS.get().addAndGet(evidenceNanos);
+                FlakeProfiler.recordEvidenceCapture("screenshot", isPass ? "action" : "failure",
+                        TimeUnit.NANOSECONDS.toMillis(evidenceNanos));
+            }
         }
-
-        return screenshot;
     }
 
     private byte[] appendShaftWatermark(byte[] screenshot) {
@@ -1185,8 +1304,14 @@ public class Actions extends ElementActions {
             });
 
         // attach screenshot
-        if (screenshot != null)
+        if (screenshot != null) {
+            long profilerStart = FlakeProfiler.isEnabled() ? System.nanoTime() : 0L;
             Allure.addAttachment(SCREENSHOT_ATTACHMENT_FORMATTER.format(ZonedDateTime.now()) + "_" + JavaHelper.convertToSentenceCase(action) + "_" + JavaHelper.removeSpecialCharacters(elementName), "image/png", new ByteArrayInputStream(screenshot), ".png");
+            if (profilerStart != 0L) {
+                FlakeProfiler.recordEvidenceCapture("report attachment", action,
+                        TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - profilerStart));
+            }
+        }
 
         // handle reporting based on status
         if (Status.PASSED.equals(status)) {

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java
@@ -18,6 +18,7 @@ import com.shaft.gui.internal.locator.ShadowLocatorBuilder;
 import com.shaft.tools.internal.support.JavaHelper;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.FailureReporter;
+import com.shaft.tools.io.internal.FlakeProfiler;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.AppiumDriver;
@@ -1035,7 +1036,12 @@ public class ElementActionsHelper {
 
         if (driver != null && (Boolean.FALSE.equals(passFailStatus)
                 || SHAFT.Properties.visuals.whenToTakePageSourceSnapshot().equalsIgnoreCase("always"))) {
+            long profilerStart = FlakeProfiler.isEnabled() ? System.nanoTime() : 0L;
             var pageSnapshot = new BrowserActionsHelper(false).capturePageSnapshot(driver);
+            if (profilerStart != 0L) {
+                FlakeProfiler.recordEvidenceCapture("page snapshot", actionName,
+                        TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - profilerStart));
+            }
             var attachmentType = "";
             if (pageSnapshot.startsWith("From: <Saved by Blink>")) {
                 attachmentType = PAGE_SNAPSHOT_ATTACHMENT_TYPE;
@@ -1086,7 +1092,12 @@ public class ElementActionsHelper {
         }
         if (!isSilent || actionName.equals("identifyUniqueElement")) {
             if (attachments != null && !attachments.isEmpty()) {
+                long profilerStart = FlakeProfiler.isEnabled() ? System.nanoTime() : 0L;
                 ReportManagerHelper.log(message, attachments);
+                if (profilerStart != 0L) {
+                    FlakeProfiler.recordEvidenceCapture("report attachment", actionName,
+                            TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - profilerStart));
+                }
             } else {
                 ReportManager.log(message);
             }

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotManager.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotManager.java
@@ -7,6 +7,7 @@ import com.shaft.enums.internal.Screenshots;
 import com.shaft.gui.browser.internal.JavaScriptWaitManager;
 import com.shaft.gui.element.internal.ElementActionsHelper;
 import com.shaft.gui.element.internal.ElementInformation;
+import com.shaft.tools.io.internal.FlakeProfiler;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import lombok.SneakyThrows;
 import org.openqa.selenium.*;
@@ -24,6 +25,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 public class ScreenshotManager {
@@ -201,10 +203,20 @@ public class ScreenshotManager {
     }
 
     private List<Object> internalCaptureScreenShot(WebDriver driver, By elementLocator, String actionName, boolean shouldAttachScreenshot, boolean shouldCaptureAnimatedGifFrame, boolean isPass) {
+        long profilerStart = (shouldAttachScreenshot || shouldCaptureAnimatedGifFrame) && FlakeProfiler.isEnabled()
+                ? System.nanoTime()
+                : 0L;
         if (shouldAttachScreenshot || shouldCaptureAnimatedGifFrame) {
-            byte[] src = internalCaptureScreenshot(driver, elementLocator, isPass);
-            if (shouldAttachScreenshot) {
-                return prepareImageForReport(src, actionName);
+            try {
+                byte[] src = internalCaptureScreenshot(driver, elementLocator, isPass);
+                if (shouldAttachScreenshot) {
+                    return prepareImageForReport(src, actionName);
+                }
+            } finally {
+                if (profilerStart != 0L) {
+                    FlakeProfiler.recordEvidenceCapture("screenshot", actionName,
+                            TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - profilerStart));
+                }
             }
         }
         return new ArrayList<>();

--- a/shaft-engine/src/main/java/com/shaft/listeners/JunitExtension.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/JunitExtension.java
@@ -8,6 +8,7 @@ import com.shaft.listeners.internal.RetryAnalyzer;
 import com.shaft.listeners.internal.TestExecutionInfo;
 import com.shaft.properties.internal.Properties;
 import com.shaft.tools.io.ReportManager;
+import com.shaft.tools.io.internal.FlakeProfiler;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import com.shaft.validation.internal.ValidationsHelper;
 import org.junit.jupiter.api.extension.AfterAllCallback;
@@ -138,6 +139,8 @@ public class JunitExtension implements BeforeAllCallback, AfterAllCallback, Befo
         ReportManager.logDiscrete("Retry #" + attempt + "/" + maxRetryCount
                 + " for test: " + method.getName()
                 + ", on thread: " + Thread.currentThread().getName());
+        FlakeProfiler.recordRetryAttempt(method.getName(), attempt, maxRetryCount,
+                SHAFT.Properties.flags.forceCaptureSupportingEvidenceOnRetry());
     }
 
     private static TestExecutionInfo toTestExecutionInfo(ExtensionContext context, Method method, Throwable throwable) {

--- a/shaft-engine/src/main/java/com/shaft/listeners/JunitListener.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/JunitListener.java
@@ -92,7 +92,6 @@ public class JunitListener implements LauncherSessionListener {
                     TestExecutionInfo info = toTestExecutionInfo(testIdentifier, throwable);
                     ReportContext.update(info);
                     ReportContext.setStatus(toAllureStatus(testExecutionResult));
-                    afterInvocation(info);
                     switch (testExecutionResult.getStatus()) {
                         case SUCCESSFUL -> {
                             AssertionError verificationError = ValidationsHelper.getVerificationErrorToForceFail();
@@ -101,12 +100,17 @@ public class JunitListener implements LauncherSessionListener {
                                 TestExecutionInfo failedInfo = toTestExecutionInfo(testIdentifier, verificationError);
                                 ReportContext.update(failedInfo);
                                 ReportContext.setStatus(Status.FAILED);
+                                afterInvocation(failedInfo);
                                 onTestFailure(testIdentifier, verificationError, failedInfo);
                             } else {
+                                afterInvocation(info);
                                 onTestSuccess(testIdentifier, info);
                             }
                         }
-                        case FAILED, ABORTED -> onTestFailure(testIdentifier, throwable, info);
+                        case FAILED, ABORTED -> {
+                            afterInvocation(info);
+                            onTestFailure(testIdentifier, throwable, info);
+                        }
                     }
                     ReportContext.clear();
                 }

--- a/shaft-engine/src/main/java/com/shaft/listeners/internal/ExecutionLifecycleHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/internal/ExecutionLifecycleHelper.java
@@ -16,6 +16,7 @@ import com.shaft.tools.io.internal.ExecutionSummaryReport;
 import com.shaft.tools.io.internal.FailureBriefReporter;
 import com.shaft.tools.io.internal.FailureDiagnosticsReporter;
 import com.shaft.tools.io.internal.FailureTraceReporter;
+import com.shaft.tools.io.internal.FlakeProfiler;
 import com.shaft.tools.io.internal.ProjectStructureManager;
 import com.shaft.tools.io.internal.ReportContext;
 import com.shaft.tools.io.internal.ReportManagerHelper;
@@ -45,6 +46,7 @@ public final class ExecutionLifecycleHelper {
      */
     public static void engineSetup(ProjectStructureManager.RunType runType) {
         LocatorHealthReporter.reset();
+        FlakeProfiler.reset();
         BrowserPerformanceExecutionReport.reset();
         PropertiesHelper.bootstrapEngine(runType);
     }
@@ -56,6 +58,7 @@ public final class ExecutionLifecycleHelper {
      */
     public static void logTestInformation(TestExecutionInfo info) {
         if (info != null) {
+            FlakeProfiler.startTest(info);
             ReportManagerHelper.logTestInformation(
                     valueOrBlank(info.className()),
                     valueOrBlank(info.methodName()),
@@ -105,6 +108,7 @@ public final class ExecutionLifecycleHelper {
 
         String logText = createTestLog(ReportContext.snapshotOutput());
         ReportManagerHelper.attachTestLog(valueOrBlank(info.methodName()), logText);
+        FlakeProfiler.finishTest(info, info.throwable() == null ? "Passed" : "Failed");
         FailureTraceReporter.attachOnFailure(info, logText, attachments);
         FailureDiagnosticsReporter.attachOnFailure(info, logText, attachments);
         FailureBriefReporter.attachOnFailure(info, logText, attachments);
@@ -149,6 +153,7 @@ public final class ExecutionLifecycleHelper {
         ReportManagerHelper.setDiscreteLogging(true);
         AssertionError openApiCoverageFailure = OpenApiCoverageReporter.reportAndGetThresholdFailure();
         AssertionError locatorHealthFailure = LocatorHealthReporter.reportAndGetFailure();
+        AssertionError flakeProfilerFailure = FlakeProfiler.reportAndGetFailure();
         long executionEndTime = System.currentTimeMillis();
         Map<String, List<Double>> performanceData = RequestBuilder.getPerformanceData();
         AssertionError apiPerformanceFailure = ApiPerformanceExecutionReport.generatePerformanceReportAndGetFailure(
@@ -164,35 +169,23 @@ public final class ExecutionLifecycleHelper {
         ReportManagerHelper.logEngineClosure();
         AllureManager.openAllureReportAfterExecution();
         AllureManager.generateAllureReportArchive();
-        if (openApiCoverageFailure != null && locatorHealthFailure != null) {
-            openApiCoverageFailure.addSuppressed(locatorHealthFailure);
+        List<AssertionError> failures = new ArrayList<>();
+        AssertionError[] possibleFailures = {
+                openApiCoverageFailure,
+                locatorHealthFailure,
+                flakeProfilerFailure,
+                apiPerformanceFailure,
+                browserPerformanceFailure
+        };
+        for (AssertionError failure : possibleFailures) {
+            if (failure != null) {
+                failures.add(failure);
+            }
         }
-        if (openApiCoverageFailure != null && apiPerformanceFailure != null) {
-            openApiCoverageFailure.addSuppressed(apiPerformanceFailure);
-        }
-        if (openApiCoverageFailure != null && browserPerformanceFailure != null) {
-            openApiCoverageFailure.addSuppressed(browserPerformanceFailure);
-        }
-        if (openApiCoverageFailure != null) {
-            throw openApiCoverageFailure;
-        }
-        if (locatorHealthFailure != null && apiPerformanceFailure != null) {
-            locatorHealthFailure.addSuppressed(apiPerformanceFailure);
-        }
-        if (locatorHealthFailure != null && browserPerformanceFailure != null) {
-            locatorHealthFailure.addSuppressed(browserPerformanceFailure);
-        }
-        if (locatorHealthFailure != null) {
-            throw locatorHealthFailure;
-        }
-        if (apiPerformanceFailure != null && browserPerformanceFailure != null) {
-            apiPerformanceFailure.addSuppressed(browserPerformanceFailure);
-        }
-        if (apiPerformanceFailure != null) {
-            throw apiPerformanceFailure;
-        }
-        if (browserPerformanceFailure != null) {
-            throw browserPerformanceFailure;
+        if (!failures.isEmpty()) {
+            AssertionError firstFailure = failures.getFirst();
+            failures.stream().skip(1).forEach(firstFailure::addSuppressed);
+            throw firstFailure;
         }
     }
 

--- a/shaft-engine/src/main/java/com/shaft/listeners/internal/RetryAnalyzer.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/internal/RetryAnalyzer.java
@@ -3,6 +3,7 @@ package com.shaft.listeners.internal;
 import com.shaft.driver.SHAFT;
 import com.shaft.properties.internal.ThreadLocalPropertiesManager;
 import com.shaft.tools.io.ReportManager;
+import com.shaft.tools.io.internal.FlakeProfiler;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import org.apache.logging.log4j.Level;
 import org.testng.IRetryAnalyzer;
@@ -39,6 +40,8 @@ public class RetryAnalyzer implements IRetryAnalyzer {
                         + ", on thread: " + Thread.currentThread().getName();
                 ReportManagerHelper.enableDebugFileLogging();
                 ReportManager.logDiscrete(message);
+                FlakeProfiler.recordRetryAttempt(iTestResult.getMethod().getMethodName(), counter, maxRetryCount,
+                        SHAFT.Properties.flags.forceCaptureSupportingEvidenceOnRetry());
                 enableSupportingEvidenceCaptureForRetryAttempt();
                 return true;
             }

--- a/shaft-engine/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java
@@ -9,6 +9,7 @@ import com.shaft.gui.internal.video.RecordManager;
 import com.shaft.properties.internal.ThreadLocalPropertiesManager;
 import com.shaft.tools.io.internal.FailureDiagnosticsReporter;
 import com.shaft.tools.io.internal.FailureTraceReporter;
+import com.shaft.tools.io.internal.FlakeProfiler;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import io.qameta.allure.Issue;
 import io.qameta.allure.Issues;
@@ -305,6 +306,7 @@ public class TestNGListenerHelper {
             String logText = TestNGListenerHelper.createTestLog(getReporterOutput(iTestResult));
             ReportManagerHelper.attachTestLog(iTestNGMethod.getMethodName(), logText);
             TestExecutionInfo info = toTestExecutionInfo(iTestResult);
+            FlakeProfiler.finishTest(info, testStatus(iTestResult));
             FailureTraceReporter.attachOnFailure(info, logText, attachments);
             FailureDiagnosticsReporter.attachOnFailure(info, logText, attachments);
             JiraHelper.reportBugsToJIRA(attachments, logText, iTestResult, iTestNGMethod);
@@ -458,6 +460,7 @@ public class TestNGListenerHelper {
 
         if (!iTestNGMethod.getQualifiedName().contains("AbstractTestNGCucumberTests")) {
             if (iTestNGMethod.isTest()) {
+                FlakeProfiler.startTest(toTestExecutionInfo(iTestResult));
                 className = ReportManagerHelper.getTestClassName();
                 methodName = ReportManagerHelper.getTestMethodName();
                 if (iTestNGMethod.getDescription() != null) {
@@ -498,5 +501,14 @@ public class TestNGListenerHelper {
                 ReportManagerHelper.logFinishedTestInformation(className, methodName, methodDescription, methodStatus);
             }
         }
+    }
+
+    private static String testStatus(ITestResult testResult) {
+        return switch (testResult.getStatus()) {
+            case ITestResult.SUCCESS -> "Passed";
+            case ITestResult.FAILURE -> "Failed";
+            case ITestResult.SKIP -> "Skipped";
+            default -> "";
+        };
     }
 }

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Reporting.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Reporting.java
@@ -126,6 +126,22 @@ public interface Reporting extends EngineProperties<Reporting> {
     @DefaultValue("50")
     int traceMaxArtifactMb();
 
+    @Key("shaft.flakeProfiler.enabled")
+    @DefaultValue("false")
+    boolean flakeProfilerEnabled();
+
+    @Key("shaft.flakeProfiler.attachPerTest")
+    @DefaultValue("true")
+    boolean flakeProfilerAttachPerTest();
+
+    @Key("shaft.flakeProfiler.failOnSevereFlakeRisk")
+    @DefaultValue("false")
+    boolean flakeProfilerFailOnSevereFlakeRisk();
+
+    @Key("shaft.flakeProfiler.slowActionThresholdMs")
+    @DefaultValue("2000")
+    int flakeProfilerSlowActionThresholdMs();
+
     default SetProperty set() {
         return new SetProperty();
     }
@@ -259,6 +275,26 @@ public interface Reporting extends EngineProperties<Reporting> {
 
         public SetProperty traceMaxArtifactMb(int value) {
             setProperty("shaft.trace.maxArtifactMb", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty flakeProfilerEnabled(boolean value) {
+            setProperty("shaft.flakeProfiler.enabled", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty flakeProfilerAttachPerTest(boolean value) {
+            setProperty("shaft.flakeProfiler.attachPerTest", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty flakeProfilerFailOnSevereFlakeRisk(boolean value) {
+            setProperty("shaft.flakeProfiler.failOnSevereFlakeRisk", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty flakeProfilerSlowActionThresholdMs(int value) {
+            setProperty("shaft.flakeProfiler.slowActionThresholdMs", String.valueOf(value));
             return this;
         }
 

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/FlakeProfiler.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/FlakeProfiler.java
@@ -1,0 +1,559 @@
+package com.shaft.tools.io.internal;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.shaft.driver.SHAFT;
+import com.shaft.listeners.internal.TestExecutionInfo;
+import com.shaft.tools.io.ReportManager;
+import org.apache.logging.log4j.Level;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+/**
+ * Collects opt-in action timing, wait, retry, locator, healing, and evidence-cost signals.
+ */
+public final class FlakeProfiler {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ThreadLocal<TestProfile> CURRENT_TEST = new ThreadLocal<>();
+    private static final Queue<TestProfile> TESTS = new ConcurrentLinkedQueue<>();
+    private static final int TOP_LIMIT = 10;
+    private static final Pattern SECRET_ASSIGNMENT = Pattern.compile(
+            "(?i)(password|passwd|secret|token|api[-_]?key|authorization|cookie)\\s*[:=]\\s*[^\\s,;]+");
+    private static final Pattern LONG_TOKEN = Pattern.compile("\\b[a-zA-Z0-9_-]{32,}\\b");
+
+    private FlakeProfiler() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Returns whether flake profiling is enabled for the current thread.
+     *
+     * @return {@code true} when profiler collection is enabled
+     */
+    public static boolean isEnabled() {
+        return SHAFT.Properties.reporting.flakeProfilerEnabled();
+    }
+
+    /**
+     * Clears all profiler state.
+     */
+    public static void reset() {
+        CURRENT_TEST.remove();
+        TESTS.clear();
+    }
+
+    /**
+     * Starts a test-scoped profile.
+     *
+     * @param info test metadata
+     */
+    public static void startTest(TestExecutionInfo info) {
+        if (!isEnabled()) {
+            CURRENT_TEST.remove();
+            return;
+        }
+        runSafely(() -> CURRENT_TEST.set(new TestProfile(info)));
+    }
+
+    /**
+     * Finishes and optionally attaches the current test profile.
+     *
+     * @param info test metadata
+     * @param status final test status text
+     */
+    public static void finishTest(TestExecutionInfo info, String status) {
+        if (!isEnabled()) {
+            CURRENT_TEST.remove();
+            return;
+        }
+        runSafely(() -> {
+            TestProfile profile = currentProfile(info);
+            profile.status.set(valueOrBlank(status));
+            if (profile.hasSignals()) {
+                TESTS.add(profile);
+                if (SHAFT.Properties.reporting.flakeProfilerAttachPerTest()) {
+                    attachProfile(profile);
+                }
+            }
+            CURRENT_TEST.remove();
+        });
+    }
+
+    /**
+     * Records one completed action boundary.
+     *
+     * @param sample action sample to add to the current test profile
+     */
+    public static void recordAction(ActionSample sample) {
+        if (!isEnabled()) {
+            return;
+        }
+        runSafely(() -> currentProfile(null).recordAction(new ActionEvent(
+                sample.category(), sample.name(), sample.target(), sample.durationMillis(),
+                sample.locatorLookupCount(), sample.matchCount(), sample.staleElementRetries(),
+                sample.healingAttempts(), sample.waitLoopCount(), sample.successful())));
+    }
+
+    /**
+     * Records the time spent capturing a report artifact.
+     *
+     * @param category evidence category
+     * @param name evidence name
+     * @param durationMillis elapsed capture duration
+     */
+    public static void recordEvidenceCapture(String category, String name, long durationMillis) {
+        if (!isEnabled()) {
+            return;
+        }
+        runSafely(() -> currentProfile(null).recordEvidence(new EvidenceEvent(category, name, durationMillis)));
+    }
+
+    /**
+     * Records a retry attempt and supporting-evidence state.
+     *
+     * @param testName test method name
+     * @param attempt retry attempt number
+     * @param maxAttempts configured maximum retry attempts
+     * @param supportingEvidenceEnabled whether enhanced evidence capture is enabled
+     */
+    public static void recordRetryAttempt(String testName, int attempt, int maxAttempts, boolean supportingEvidenceEnabled) {
+        if (!isEnabled()) {
+            return;
+        }
+        runSafely(() -> currentProfile(null).recordRetry(
+                new RetryEvent(testName, attempt, maxAttempts, supportingEvidenceEnabled)));
+    }
+
+    /**
+     * Writes the suite-level report and returns a configured severe-risk failure.
+     *
+     * @return assertion error when severe flake risk should fail the run; otherwise {@code null}
+     */
+    public static AssertionError reportAndGetFailure() {
+        if (!isEnabled() || TESTS.isEmpty()) {
+            reset();
+            return null;
+        }
+        try {
+            String json = buildSummaryJson();
+            String html = buildSummaryHtml();
+            ReportManager.log(buildSummaryText());
+            ReportManagerHelper.attach("json", "flake-profile.json", json);
+            ReportManagerHelper.attach("html", "Flake Profile", html);
+            int severeRiskCount = severeRiskCount();
+            reset();
+            if (severeRiskCount > 0 && SHAFT.Properties.reporting.flakeProfilerFailOnSevereFlakeRisk()) {
+                return new AssertionError("Severe flake risk actions were found: " + severeRiskCount + ".");
+            }
+        } catch (RuntimeException exception) {
+            ReportManagerHelper.logDiscrete("Could not attach SHAFT flake profile: " + exception.getMessage(), Level.WARN);
+            reset();
+        }
+        return null;
+    }
+
+    static String buildSummaryJson() {
+        ObjectNode root = MAPPER.createObjectNode();
+        List<TestProfile> profiles = TESTS.stream().toList();
+        root.put("totalTests", profiles.size());
+        root.put("totalActions", profiles.stream().mapToInt(TestProfile::actionCount).sum());
+        root.put("retryAttempts", profiles.stream().mapToInt(TestProfile::retryCount).sum());
+        root.put("evidenceCaptureMillis", profiles.stream().mapToLong(TestProfile::evidenceCaptureMillis).sum());
+        root.put("severeRiskCount", severeRiskCount());
+        ArrayNode tests = root.putArray("tests");
+        profiles.forEach(profile -> profile.appendJson(tests.addObject()));
+        appendActions(root.putArray("topSlowActions"), topSlowActions(profiles));
+        appendActions(root.putArray("waitHeavyActions"), waitHeavyActions(profiles));
+        return root.toPrettyString();
+    }
+
+    private static TestProfile currentProfile(TestExecutionInfo info) {
+        TestProfile profile = CURRENT_TEST.get();
+        if (profile == null) {
+            profile = new TestProfile(info);
+            CURRENT_TEST.set(profile);
+        }
+        return profile;
+    }
+
+    private static void attachProfile(TestProfile profile) {
+        try {
+            ReportManagerHelper.attach("json", "flake-profile.json", profile.toJson().toPrettyString());
+            ReportManagerHelper.attach("html", "Flake Profile", profile.toHtml());
+        } catch (RuntimeException exception) {
+            ReportManagerHelper.logDiscrete("Could not attach per-test SHAFT flake profile: "
+                    + exception.getMessage(), Level.WARN);
+        }
+    }
+
+    private static String buildSummaryText() {
+        return "Flake profile summary: tests=" + TESTS.size()
+                + ", actions=" + TESTS.stream().mapToInt(TestProfile::actionCount).sum()
+                + ", retries=" + TESTS.stream().mapToInt(TestProfile::retryCount).sum()
+                + ", severeRiskActions=" + severeRiskCount() + ".";
+    }
+
+    private static String buildSummaryHtml() {
+        StringBuilder rows = new StringBuilder();
+        TESTS.forEach(profile -> rows.append("<tr><td>")
+                .append(htmlEscape(profile.test.get()))
+                .append("</td><td>")
+                .append(profile.actionCount())
+                .append("</td><td>")
+                .append(profile.retryCount())
+                .append("</td><td>")
+                .append(profile.evidenceCaptureMillis())
+                .append("</td><td>")
+                .append(profile.severeRiskCount())
+                .append("</td></tr>"));
+        return """
+                <!doctype html>
+                <html lang="en">
+                <head><meta charset="utf-8"><title>SHAFT Flake Profile</title></head>
+                <body>
+                <h1>SHAFT Flake Profile</h1>
+                <table>
+                <thead><tr><th>Test</th><th>Actions</th><th>Retries</th><th>Evidence ms</th><th>Severe risk</th></tr></thead>
+                <tbody>%s</tbody>
+                </table>
+                </body>
+                </html>
+                """.formatted(rows);
+    }
+
+    private static int severeRiskCount() {
+        return TESTS.stream().mapToInt(TestProfile::severeRiskCount).sum();
+    }
+
+    private static List<ActionEvent> topSlowActions(List<TestProfile> profiles) {
+        return profiles.stream()
+                .flatMap(profile -> profile.actions.stream())
+                .sorted(Comparator.comparingLong(ActionEvent::durationMillis).reversed())
+                .limit(TOP_LIMIT)
+                .toList();
+    }
+
+    private static List<ActionEvent> waitHeavyActions(List<TestProfile> profiles) {
+        return profiles.stream()
+                .flatMap(profile -> profile.actions.stream())
+                .filter(ActionEvent::isWaitHeavy)
+                .sorted(Comparator.comparingInt(ActionEvent::waitLoopCount).reversed()
+                        .thenComparing(Comparator.comparingLong(ActionEvent::durationMillis).reversed()))
+                .limit(TOP_LIMIT)
+                .toList();
+    }
+
+    private static void appendActions(ArrayNode array, List<ActionEvent> actions) {
+        actions.forEach(action -> action.appendJson(array.addObject()));
+    }
+
+    private static String testId(TestExecutionInfo info) {
+        if (info == null) {
+            return "unknown";
+        }
+        if (info.stableId() != null && !info.stableId().isBlank()) {
+            return safe(info.stableId());
+        }
+        if (info.className() != null && !info.className().isBlank() && info.methodName() != null && !info.methodName().isBlank()) {
+            return safe(info.className() + "." + info.methodName());
+        }
+        return safe(valueOrBlank(info.displayName()));
+    }
+
+    private static String safe(String value) {
+        String sanitized = value == null ? "" : value;
+        sanitized = SECRET_ASSIGNMENT.matcher(sanitized).replaceAll("$1=[REDACTED]");
+        sanitized = LONG_TOKEN.matcher(sanitized).replaceAll("[REDACTED]");
+        return sanitized.replaceAll("[\\p{Cntrl}&&[^\\r\\n\\t]]", "").trim();
+    }
+
+    private static String valueOrBlank(String value) {
+        return value == null ? "" : value;
+    }
+
+    private static String htmlEscape(String value) {
+        return value.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+
+    private static void runSafely(Runnable runnable) {
+        try {
+            runnable.run();
+        } catch (RuntimeException exception) {
+            ReportManagerHelper.logDiscrete("SHAFT flake profiler ignored an internal error: "
+                    + exception.getMessage(), Level.DEBUG);
+        }
+    }
+
+    private static final class TestProfile {
+        private final AtomicReference<String> test;
+        private final AtomicReference<String> className;
+        private final AtomicReference<String> methodName;
+        private final AtomicReference<String> status = new AtomicReference<>("");
+        private final Queue<ActionEvent> actions = new ConcurrentLinkedQueue<>();
+        private final Queue<EvidenceEvent> evidence = new ConcurrentLinkedQueue<>();
+        private final Queue<RetryEvent> retries = new ConcurrentLinkedQueue<>();
+        private final AtomicLong evidenceCaptureMillis = new AtomicLong();
+
+        private TestProfile(TestExecutionInfo info) {
+            this.test = new AtomicReference<>(testId(info));
+            this.className = new AtomicReference<>(safe(info == null ? "" : info.className()));
+            this.methodName = new AtomicReference<>(safe(info == null ? "" : info.methodName()));
+        }
+
+        private void recordAction(ActionEvent action) {
+            actions.add(action);
+        }
+
+        private void recordEvidence(EvidenceEvent event) {
+            evidence.add(event);
+            evidenceCaptureMillis.addAndGet(event.durationMillis());
+        }
+
+        private void recordRetry(RetryEvent retry) {
+            retries.add(retry);
+        }
+
+        private boolean hasSignals() {
+            return !actions.isEmpty() || !evidence.isEmpty() || !retries.isEmpty();
+        }
+
+        private int actionCount() {
+            return actions.size();
+        }
+
+        private int retryCount() {
+            return retries.size();
+        }
+
+        private long evidenceCaptureMillis() {
+            return evidenceCaptureMillis.get();
+        }
+
+        private int severeRiskCount() {
+            return (int) actions.stream().filter(ActionEvent::isSevereRisk).count();
+        }
+
+        private ObjectNode toJson() {
+            ObjectNode node = MAPPER.createObjectNode();
+            appendJson(node);
+            return node;
+        }
+
+        private void appendJson(ObjectNode node) {
+            node.put("test", test.get());
+            node.put("className", className.get());
+            node.put("methodName", methodName.get());
+            node.put("status", status.get());
+            node.put("totalActions", actionCount());
+            node.put("retryAttempts", retryCount());
+            node.put("evidenceCaptureMillis", evidenceCaptureMillis());
+            node.put("severeRiskCount", severeRiskCount());
+            ArrayNode actionNodes = node.putArray("actions");
+            actions.forEach(action -> action.appendJson(actionNodes.addObject()));
+            appendActions(node.putArray("topSlowActions"), actions.stream()
+                    .sorted(Comparator.comparingLong(ActionEvent::durationMillis).reversed())
+                    .limit(TOP_LIMIT)
+                    .toList());
+            appendActions(node.putArray("waitHeavyActions"), actions.stream()
+                    .filter(ActionEvent::isWaitHeavy)
+                    .sorted(Comparator.comparingInt(ActionEvent::waitLoopCount).reversed()
+                            .thenComparing(Comparator.comparingLong(ActionEvent::durationMillis).reversed()))
+                    .limit(TOP_LIMIT)
+                    .toList());
+            ArrayNode evidenceNodes = node.putArray("evidence");
+            evidence.forEach(event -> event.appendJson(evidenceNodes.addObject()));
+            ArrayNode retryNodes = node.putArray("retryHistory");
+            retries.forEach(retry -> retry.appendJson(retryNodes.addObject()));
+        }
+
+        private String toHtml() {
+            return """
+                    <!doctype html>
+                    <html lang="en">
+                    <head><meta charset="utf-8"><title>SHAFT Flake Profile</title></head>
+                    <body><h1>SHAFT Flake Profile</h1><pre>%s</pre></body>
+                    </html>
+                    """.formatted(htmlEscape(toJson().toPrettyString()));
+        }
+    }
+
+    public static final class ActionSample {
+        private final String category;
+        private final String name;
+        private String target = "";
+        private long durationMillis;
+        private int locatorLookupCount;
+        private int matchCount;
+        private int staleElementRetries;
+        private int healingAttempts;
+        private int waitLoopCount;
+        private boolean successful = true;
+
+        private ActionSample(String category, String name) {
+            this.category = category;
+            this.name = name;
+        }
+
+        public static ActionSample of(String category, String name) {
+            return new ActionSample(category, name);
+        }
+
+        public ActionSample target(String target) {
+            this.target = target;
+            return this;
+        }
+
+        public ActionSample durationMillis(long durationMillis) {
+            this.durationMillis = durationMillis;
+            return this;
+        }
+
+        public ActionSample locatorLookupCount(int locatorLookupCount) {
+            this.locatorLookupCount = locatorLookupCount;
+            return this;
+        }
+
+        public ActionSample matchCount(int matchCount) {
+            this.matchCount = matchCount;
+            return this;
+        }
+
+        public ActionSample staleElementRetries(int staleElementRetries) {
+            this.staleElementRetries = staleElementRetries;
+            return this;
+        }
+
+        public ActionSample healingAttempts(int healingAttempts) {
+            this.healingAttempts = healingAttempts;
+            return this;
+        }
+
+        public ActionSample waitLoopCount(int waitLoopCount) {
+            this.waitLoopCount = waitLoopCount;
+            return this;
+        }
+
+        public ActionSample successful(boolean successful) {
+            this.successful = successful;
+            return this;
+        }
+
+        private String category() {
+            return category;
+        }
+
+        private String name() {
+            return name;
+        }
+
+        private String target() {
+            return target;
+        }
+
+        private long durationMillis() {
+            return durationMillis;
+        }
+
+        private int locatorLookupCount() {
+            return locatorLookupCount;
+        }
+
+        private int matchCount() {
+            return matchCount;
+        }
+
+        private int staleElementRetries() {
+            return staleElementRetries;
+        }
+
+        private int healingAttempts() {
+            return healingAttempts;
+        }
+
+        private int waitLoopCount() {
+            return waitLoopCount;
+        }
+
+        private boolean successful() {
+            return successful;
+        }
+    }
+
+    private record ActionEvent(String category, String name, String target, long durationMillis,
+                               int locatorLookupCount, int matchCount, int staleElementRetries,
+                               int healingAttempts, int waitLoopCount, boolean successful) {
+        private ActionEvent {
+            category = safe(category);
+            name = safe(name);
+            target = safe(target);
+            durationMillis = Math.max(0, durationMillis);
+            locatorLookupCount = Math.max(0, locatorLookupCount);
+            matchCount = Math.max(0, matchCount);
+            staleElementRetries = Math.max(0, staleElementRetries);
+            healingAttempts = Math.max(0, healingAttempts);
+            waitLoopCount = Math.max(0, waitLoopCount);
+        }
+
+        private boolean isWaitHeavy() {
+            return waitLoopCount > 1;
+        }
+
+        private boolean isSevereRisk() {
+            return durationMillis >= SHAFT.Properties.reporting.flakeProfilerSlowActionThresholdMs()
+                    && (waitLoopCount > 1 || staleElementRetries > 0 || healingAttempts > 0 || !successful);
+        }
+
+        private void appendJson(ObjectNode node) {
+            node.put("category", category);
+            node.put("name", name);
+            node.put("target", target);
+            node.put("durationMillis", durationMillis);
+            node.put("locatorLookupCount", locatorLookupCount);
+            node.put("matchCount", matchCount);
+            node.put("staleElementRetries", staleElementRetries);
+            node.put("healingAttempts", healingAttempts);
+            node.put("waitLoopCount", waitLoopCount);
+            node.put("successful", successful);
+        }
+    }
+
+    private record EvidenceEvent(String category, String name, long durationMillis) {
+        private EvidenceEvent {
+            category = safe(category);
+            name = safe(name);
+            durationMillis = Math.max(0, durationMillis);
+        }
+
+        private void appendJson(ObjectNode node) {
+            node.put("category", category);
+            node.put("name", name);
+            node.put("durationMillis", durationMillis);
+        }
+    }
+
+    private record RetryEvent(String testName, int attempt, int maxAttempts, boolean supportingEvidenceEnabled) {
+        private RetryEvent {
+            testName = safe(testName);
+            attempt = Math.max(0, attempt);
+            maxAttempts = Math.max(0, maxAttempts);
+        }
+
+        private void appendJson(ObjectNode node) {
+            node.put("testName", testName);
+            node.put("attempt", attempt);
+            node.put("maxAttempts", maxAttempts);
+            node.put("supportingEvidenceEnabled", supportingEvidenceEnabled);
+        }
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsExecutor.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsExecutor.java
@@ -6,6 +6,7 @@ import com.shaft.cli.TerminalActions;
 import com.shaft.gui.browser.internal.JavaScriptWaitManager;
 import com.shaft.tools.io.PdfFileManager;
 import com.shaft.tools.io.ReportManager;
+import com.shaft.tools.io.internal.FlakeProfiler;
 import com.shaft.tools.io.internal.ProgressBarLogger;
 import com.shaft.validation.ValidationEnums;
 import io.qameta.allure.Step;
@@ -14,6 +15,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 public class ValidationsExecutor {
     protected final StringBuilder reportMessageBuilder;
@@ -167,8 +169,12 @@ public class ValidationsExecutor {
 
     @Step(" {this.validationCategoryString} that {this.customReportMessage}")
     private void performValidation() {
+        long profilerStart = FlakeProfiler.isEnabled() ? System.nanoTime() : 0L;
+        boolean successful = false;
         var validationsHelper = new ValidationsHelper(validationCategory);
-        switch (validationMethod) {
+        ValidationsHelper.beginProfiledValidation();
+        try {
+            switch (validationMethod) {
             case "forceFail" -> validationsHelper.validateFail(customReportMessage);
             case "objectsAreEqual" ->
                     validationsHelper.validateEquals(expectedValue, actualValue, validationComparisonType, validationType);
@@ -228,6 +234,18 @@ public class ValidationsExecutor {
             }
             default -> {
             }
+            }
+            successful = ValidationsHelper.profiledValidationSuccessful();
+        } finally {
+            if (profilerStart != 0L) {
+                FlakeProfiler.recordAction(FlakeProfiler.ActionSample.of(
+                        validationCategory.equals(ValidationEnums.ValidationCategory.HARD_ASSERT) ? "assertion" : "verification",
+                        validationMethod)
+                        .target(customReportMessage)
+                        .durationMillis(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - profilerStart))
+                        .successful(successful));
+            }
+            ValidationsHelper.clearProfiledValidation();
         }
     }
 }

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java
@@ -18,6 +18,7 @@ import com.shaft.tools.io.internal.CheckpointStatus;
 import com.shaft.tools.io.internal.CheckpointType;
 import com.shaft.tools.io.internal.ExecutionSummaryReport;
 import com.shaft.tools.io.internal.FailureReporter;
+import com.shaft.tools.io.internal.FlakeProfiler;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import com.shaft.validation.ValidationEnums;
 import io.qameta.allure.Allure;
@@ -34,6 +35,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import java.io.File;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -44,6 +46,7 @@ public class ValidationsHelper {
     private static final String VISUAL_COMPARISON_ATTACHMENT_NAME = "Visual Comparison";
     protected static final ThreadLocal<List<String>> verificationFailuresList = ThreadLocal.withInitial(ArrayList::new);
     protected static final ThreadLocal<AssertionError> verificationError = new ThreadLocal<>();
+    private static final ThreadLocal<Boolean> profiledValidationSuccessful = new ThreadLocal<>();
     private final ValidationEnums.ValidationCategory validationCategory;
     private final String validationCategoryString;
 
@@ -69,6 +72,25 @@ public class ValidationsHelper {
     public static void recordVerificationFailure(String failureMessage) {
         verificationFailuresList.get().add(failureMessage);
         verificationError.set(new AssertionError(String.join("\nAND ", verificationFailuresList.get())));
+    }
+
+    static void beginProfiledValidation() {
+        profiledValidationSuccessful.set(true);
+    }
+
+    static boolean profiledValidationSuccessful() {
+        return Boolean.TRUE.equals(profiledValidationSuccessful.get());
+    }
+
+    static void clearProfiledValidation() {
+        profiledValidationSuccessful.remove();
+    }
+
+    private static void recordProfiledValidationState(boolean validationState) {
+        Boolean currentState = profiledValidationSuccessful.get();
+        if (currentState != null) {
+            profiledValidationSuccessful.set(currentState && validationState);
+        }
     }
 
     /**
@@ -755,6 +777,7 @@ public class ValidationsHelper {
     }
 
     private void reportValidationState(boolean validationState, Object expected, Object actual, WebDriver driver, By locator, List<List<Object>> attachments, boolean skipDefaultScreenshot) {
+        recordProfiledValidationState(validationState);
         //initialize attachments object if no attachments were already prepared
         attachments = attachments == null ? new ArrayList<>() : attachments;
 
@@ -768,7 +791,12 @@ public class ValidationsHelper {
             if (!validationState
                     || Arrays.asList("always", "validationpointsonly").contains(whenToTakePageSourceSnapshot)) {
                 var logMessage = "";
+                long profilerStart = FlakeProfiler.isEnabled() ? System.nanoTime() : 0L;
                 var pageSnapshot = new BrowserActionsHelper(true).capturePageSnapshot(driver);
+                if (profilerStart != 0L) {
+                    FlakeProfiler.recordEvidenceCapture("page snapshot", this.validationCategoryString,
+                            TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - profilerStart));
+                }
                 if (pageSnapshot.startsWith("From: <Saved by Blink>")) {
                     logMessage = "page snapshot";
                 } else if (pageSnapshot.startsWith("<html")) {
@@ -790,7 +818,12 @@ public class ValidationsHelper {
             }
         }
         // add attachments
+        long profilerAttachmentStart = !attachments.isEmpty() && FlakeProfiler.isEnabled() ? System.nanoTime() : 0L;
         ReportManagerHelper.attach(attachments);
+        if (profilerAttachmentStart != 0L) {
+            FlakeProfiler.recordEvidenceCapture("report attachment", this.validationCategoryString,
+                    TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - profilerAttachmentStart));
+        }
         // determine checkpoint type
         CheckpointType checkpointType = this.validationCategory.equals(ValidationEnums.ValidationCategory.HARD_ASSERT)
                 ? CheckpointType.ASSERTION : CheckpointType.VERIFICATION;

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
@@ -1,5 +1,7 @@
 package com.shaft.gui.element.internal;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.driver.internal.DriverFactory.SynchronizationManager;
@@ -9,8 +11,10 @@ import com.shaft.gui.internal.image.ImageProcessingActions;
 import com.shaft.gui.internal.image.ScreenshotHelper;
 import com.shaft.gui.internal.locator.LocatorBuilder;
 import com.shaft.gui.internal.locator.ShadowLocatorBuilder;
+import com.shaft.listeners.internal.TestExecutionInfo;
 import com.shaft.properties.internal.Properties;
 import com.shaft.tools.io.ReportManager;
+import com.shaft.tools.io.internal.FlakeProfiler;
 import io.appium.java_client.AppiumDriver;
 import io.qameta.allure.Allure;
 import io.qameta.allure.AllureLifecycle;
@@ -62,6 +66,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ActionsCoverageUnitTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final By LOCATOR = By.id("target");
     private static final byte[] PNG = new byte[]{(byte) 0x89, 'P', 'N', 'G'};
 
@@ -79,12 +84,14 @@ public class ActionsCoverageUnitTest {
         SHAFT.Properties.mobile.set().browserName("chrome");
         LocatorBuilder.cleanup();
         ShadowLocatorBuilder.cleanup();
+        FlakeProfiler.reset();
     }
 
     @AfterMethod(alwaysRun = true)
     public void cleanupThreadLocalState() {
         LocatorBuilder.cleanup();
         ShadowLocatorBuilder.cleanup();
+        FlakeProfiler.reset();
         Properties.clearForCurrentThread();
     }
 
@@ -444,6 +451,63 @@ public class ActionsCoverageUnitTest {
             verify(element, atLeastOnce()).sendKeys(any(CharSequence[].class));
             verify((JavascriptExecutor) driver, atLeastOnce()).executeScript(anyString(), any(Object[].class));
         }
+    }
+
+    @Test
+    public void flakeProfilerShouldSeparateElementActionDurationFromScreenshotEvidence() throws Exception {
+        SHAFT.Properties.reporting.set()
+                .flakeProfilerEnabled(true)
+                .flakeProfilerAttachPerTest(false);
+        SHAFT.Properties.visuals.set()
+                .screenshotParamsWhenToTakeAScreenshot("Always")
+                .screenshotParamsScreenshotType("VIEWPORT")
+                .screenshotParamsHighlightElements(false);
+
+        WebDriver driver = mock(WebDriver.class, org.mockito.Mockito.withSettings().extraInterfaces(TakesScreenshot.class));
+        WebElement element = standardElement();
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+        when(((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES)).thenAnswer(invocation -> {
+            Thread.sleep(120);
+            return PNG;
+        });
+        TestExecutionInfo info = new TestExecutionInfo(
+                "com.shaft.gui.element.internal.ActionsCoverageUnitTest.flakeProfilerShouldSeparateElementActionDurationFromScreenshotEvidence",
+                "com.shaft.gui.element.internal.ActionsCoverageUnitTest",
+                "flakeProfilerShouldSeparateElementActionDurationFromScreenshotEvidence",
+                "Element action profiler timing",
+                "Element action profiler timing",
+                null,
+                null,
+                false);
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            FlakeProfiler.startTest(info);
+            new Actions(helperFor(driver)).click(LOCATOR);
+            FlakeProfiler.finishTest(info, "Passed");
+        }
+
+        JsonNode testProfile = MAPPER.readTree(profilerSummaryJson()).path("tests").get(0);
+        JsonNode locateAction = actionEvent(testProfile, "locate", "CLICK");
+        JsonNode waitAction = actionEvent(testProfile, "wait", "CLICK");
+        JsonNode clickAction = actionEvent(testProfile, "action", "CLICK");
+        JsonNode screenshotEvidence = testProfile.path("evidence").get(0);
+        boolean hasReportAttachmentTiming = false;
+        for (JsonNode evidence : testProfile.path("evidence")) {
+            hasReportAttachmentTiming |= "report attachment".equals(evidence.path("category").asText());
+        }
+
+        Assert.assertNotNull(locateAction, testProfile.toPrettyString());
+        Assert.assertNotNull(waitAction, testProfile.toPrettyString());
+        Assert.assertNotNull(clickAction, testProfile.toPrettyString());
+        Assert.assertEquals(clickAction.path("category").asText(), "action");
+        Assert.assertEquals(clickAction.path("name").asText(), "CLICK");
+        Assert.assertEquals(locateAction.path("locatorLookupCount").asInt(), 1);
+        Assert.assertEquals(waitAction.path("waitLoopCount").asInt(), 1);
+        Assert.assertEquals(screenshotEvidence.path("category").asText(), "screenshot");
+        Assert.assertTrue(hasReportAttachmentTiming, testProfile.toPrettyString());
+        Assert.assertTrue(screenshotEvidence.path("durationMillis").asLong() >= 100, testProfile.toPrettyString());
+        Assert.assertTrue(clickAction.path("durationMillis").asLong()
+                < screenshotEvidence.path("durationMillis").asLong(), testProfile.toPrettyString());
     }
 
     @Test
@@ -890,6 +954,21 @@ public class ActionsCoverageUnitTest {
         Method method = Actions.class.getDeclaredMethod(methodName, parameterTypes);
         method.setAccessible(true);
         return method.invoke(null, args);
+    }
+
+    private String profilerSummaryJson() throws Exception {
+        Method method = FlakeProfiler.class.getDeclaredMethod("buildSummaryJson");
+        method.setAccessible(true);
+        return (String) method.invoke(null);
+    }
+
+    private JsonNode actionEvent(JsonNode testProfile, String category, String name) {
+        for (JsonNode action : testProfile.path("actions")) {
+            if (category.equals(action.path("category").asText()) && name.equals(action.path("name").asText())) {
+                return action;
+            }
+        }
+        return null;
     }
 
     private static final class RecordingActions extends Actions {

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/FlakeProfilerUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/FlakeProfilerUnitTest.java
@@ -1,0 +1,138 @@
+package com.shaft.tools.io.internal;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.listeners.internal.TestExecutionInfo;
+import com.shaft.properties.internal.Properties;
+import com.shaft.validation.internal.ValidationsHelper;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(singleThreaded = true)
+public class FlakeProfilerUnitTest {
+    private static final TestExecutionInfo TEST_INFO = new TestExecutionInfo(
+            "example.FlakeProfilerUnitTest.shouldProfile",
+            "example.FlakeProfilerUnitTest",
+            "shouldProfile",
+            "shouldProfile",
+            "",
+            null,
+            null,
+            false);
+
+    @BeforeMethod(alwaysRun = true)
+    public void setup() {
+        Properties.clearForCurrentThread();
+        FlakeProfiler.reset();
+        SHAFT.Properties.reporting.set()
+                .flakeProfilerEnabled(true)
+                .flakeProfilerAttachPerTest(true)
+                .flakeProfilerFailOnSevereFlakeRisk(false)
+                .flakeProfilerSlowActionThresholdMs(100);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void teardown() {
+        ValidationsHelper.resetVerificationStateAfterFailing();
+        FlakeProfiler.reset();
+        Properties.clearForCurrentThread();
+    }
+
+    @Test(description = "Flake profiler aggregates action, wait, evidence, locator, healing, and retry signals")
+    public void flakeProfilerAggregatesCoreSignals() {
+        FlakeProfiler.startTest(TEST_INFO);
+        FlakeProfiler.recordAction(FlakeProfiler.ActionSample.of("action", "CLICK")
+                .target("By.id: submit")
+                .durationMillis(250)
+                .locatorLookupCount(2)
+                .matchCount(1)
+                .staleElementRetries(1)
+                .healingAttempts(1)
+                .waitLoopCount(3)
+                .successful(true));
+        FlakeProfiler.recordEvidenceCapture("screenshot", "CLICK", 80);
+        FlakeProfiler.recordRetryAttempt("shouldProfile", 1, 2, true);
+        FlakeProfiler.finishTest(TEST_INFO, "Failed");
+
+        String json = FlakeProfiler.buildSummaryJson();
+
+        Assert.assertTrue(json.contains("\"test\" : \"example.FlakeProfilerUnitTest.shouldProfile\""));
+        Assert.assertTrue(json.contains("\"topSlowActions\""));
+        Assert.assertTrue(json.contains("\"waitHeavyActions\""));
+        Assert.assertTrue(json.contains("\"category\" : \"action\""));
+        Assert.assertTrue(json.contains("\"name\" : \"CLICK\""));
+        Assert.assertTrue(json.contains("\"durationMillis\" : 250"));
+        Assert.assertTrue(json.contains("\"locatorLookupCount\" : 2"));
+        Assert.assertTrue(json.contains("\"matchCount\" : 1"));
+        Assert.assertTrue(json.contains("\"staleElementRetries\" : 1"));
+        Assert.assertTrue(json.contains("\"healingAttempts\" : 1"));
+        Assert.assertTrue(json.contains("\"waitLoopCount\" : 3"));
+        Assert.assertTrue(json.contains("\"evidenceCaptureMillis\" : 80"));
+        Assert.assertTrue(json.contains("\"retryAttempts\" : 1"));
+        Assert.assertTrue(json.contains("\"supportingEvidenceEnabled\" : true"));
+    }
+
+    @Test(description = "Flake profiler stays off by default and ignores events while disabled")
+    public void flakeProfilerDoesNotRecordWhenDisabled() {
+        SHAFT.Properties.reporting.set().flakeProfilerEnabled(false);
+
+        FlakeProfiler.startTest(TEST_INFO);
+        FlakeProfiler.recordAction(FlakeProfiler.ActionSample.of("action", "CLICK")
+                .target("By.id: disabled")
+                .durationMillis(250)
+                .locatorLookupCount(1)
+                .matchCount(1)
+                .waitLoopCount(1)
+                .successful(true));
+        FlakeProfiler.finishTest(TEST_INFO, "Passed");
+
+        String json = FlakeProfiler.buildSummaryJson();
+
+        Assert.assertTrue(json.contains("\"tests\" : [ ]"));
+        Assert.assertTrue(json.contains("\"totalActions\" : 0"));
+    }
+
+    @Test(description = "Flake profiler records standalone assertion duration as an assertion action")
+    public void flakeProfilerRecordsStandaloneAssertionDuration() {
+        FlakeProfiler.startTest(TEST_INFO);
+
+        SHAFT.Validations.assertThat().object("actual").isEqualTo("actual").perform();
+        FlakeProfiler.finishTest(TEST_INFO, "Passed");
+
+        String json = FlakeProfiler.buildSummaryJson();
+
+        Assert.assertTrue(json.contains("\"category\" : \"assertion\""));
+        Assert.assertTrue(json.contains("\"name\" : \"objectsAreEqual\""));
+        Assert.assertTrue(json.contains("\"successful\" : true"));
+    }
+
+    @Test(description = "Flake profiler records failed soft verifications as unsuccessful verification actions")
+    public void flakeProfilerRecordsSoftVerificationFailure() {
+        FlakeProfiler.startTest(TEST_INFO);
+
+        SHAFT.Validations.verifyThat().object("actual").isEqualTo("expected").perform();
+        FlakeProfiler.finishTest(TEST_INFO, "Failed");
+
+        String json = FlakeProfiler.buildSummaryJson();
+
+        Assert.assertTrue(json.contains("\"category\" : \"verification\""));
+        Assert.assertTrue(json.contains("\"name\" : \"objectsAreEqual\""));
+        Assert.assertTrue(json.contains("\"successful\" : false"));
+        ValidationsHelper.resetVerificationStateAfterFailing();
+    }
+
+    @Test(description = "Flake profiler proposed reporting configuration keys can be set programmatically")
+    public void flakeProfilerConfigurationKeysAreSupported() {
+        SHAFT.Properties.reporting.set()
+                .flakeProfilerEnabled(true)
+                .flakeProfilerAttachPerTest(false)
+                .flakeProfilerFailOnSevereFlakeRisk(true)
+                .flakeProfilerSlowActionThresholdMs(321);
+
+        Assert.assertTrue(SHAFT.Properties.reporting.flakeProfilerEnabled());
+        Assert.assertFalse(SHAFT.Properties.reporting.flakeProfilerAttachPerTest());
+        Assert.assertTrue(SHAFT.Properties.reporting.flakeProfilerFailOnSevereFlakeRisk());
+        Assert.assertEquals(SHAFT.Properties.reporting.flakeProfilerSlowActionThresholdMs(), 321);
+    }
+}


### PR DESCRIPTION
## Summary
- Add an opt-in flake profiler that attaches per-test and suite JSON/HTML reports to Allure
- Track locate, wait, action, assertion/verification, screenshot, page snapshot, report attachment, retry, stale, and healing signals
- Keep element and assertion/verification durations accurate by recording evidence/reporting overhead as separate profiler evidence events
- Add reporting properties for enabling the profiler, per-test attachments, severe-risk fail mode, and slow-action threshold

## Validation
- mvn -pl shaft-engine '-Dtest=ActionsCoverageUnitTest#flakeProfilerShouldSeparateElementActionDurationFromScreenshotEvidence' test
- mvn -pl shaft-engine '-Dtest=FlakeProfilerUnitTest' test
- mvn -pl shaft-engine '-DskipTests' package
- py -3 scripts/ci/validate_agent_setup.py
- git diff --check
- Parsed Surefire XML: no failures/errors
- Parsed Allure root result JSON: no failed/broken test results
- graphify update . (generated graphify-out restored, not committed)

Docs: ShaftHQ/shafthq.github.io#632

Closes #3064