### PR TITLE
[codex] Fix JUnit retry lifecycle isolation

### DIFF
--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -832,9 +832,15 @@
   "830": "Community 830",
   "831": "Community 831",
   "832": "Community 832",
+  "833": "Community 833",
   "834": "Community 834",
+  "835": "Community 835",
   "836": "Community 836",
+  "837": "Community 837",
+  "838": "Community 838",
   "839": "Community 839",
+  "840": "Community 840",
   "841": "Community 841",
+  "842": "Community 842",
   "843": "Community 843"
 }

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
-# Graph Report - SHAFT_ENGINE_codex_3094_mobile_trace_enrichment  (2026-06-26)
+# Graph Report - SHAFT_ENGINE_codex_3100_junit_retry_isolation  (2026-06-26)
 
 ## Corpus Check
-- 1088 files · ~621,279 words
+- 1071 files · ~615,165 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 15633 nodes · 41498 edges · 838 communities (740 shown, 98 thin omitted)
-- Extraction: 81% EXTRACTED · 19% INFERRED · 0% AMBIGUOUS · INFERRED: 8040 edges (avg confidence: 0.8)
+- 15667 nodes · 41592 edges · 844 communities (744 shown, 100 thin omitted)
+- Extraction: 81% EXTRACTED · 19% INFERRED · 0% AMBIGUOUS · INFERRED: 8044 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `9af6e033`
+- Built from commit: `aeb0e624`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -678,6 +678,7 @@
 - [[_COMMUNITY_Community 666|Community 666]]
 - [[_COMMUNITY_Community 667|Community 667]]
 - [[_COMMUNITY_Community 668|Community 668]]
+- [[_COMMUNITY_Community 669|Community 669]]
 - [[_COMMUNITY_Community 670|Community 670]]
 - [[_COMMUNITY_Community 671|Community 671]]
 - [[_COMMUNITY_Community 672|Community 672]]
@@ -728,10 +729,16 @@
 - [[_COMMUNITY_Community 817|Community 817]]
 - [[_COMMUNITY_Community 831|Community 831]]
 - [[_COMMUNITY_Community 832|Community 832]]
+- [[_COMMUNITY_Community 833|Community 833]]
 - [[_COMMUNITY_Community 834|Community 834]]
+- [[_COMMUNITY_Community 835|Community 835]]
 - [[_COMMUNITY_Community 836|Community 836]]
+- [[_COMMUNITY_Community 837|Community 837]]
+- [[_COMMUNITY_Community 838|Community 838]]
 - [[_COMMUNITY_Community 839|Community 839]]
+- [[_COMMUNITY_Community 840|Community 840]]
 - [[_COMMUNITY_Community 841|Community 841]]
+- [[_COMMUNITY_Community 842|Community 842]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `SHAFT` - 308 edges
@@ -746,12 +753,12 @@
 10. `AllureManager` - 63 edges
 
 ## Surprising Connections (you probably didn't know these)
-- `defaults()` --calls--> `denyAll()`  [INFERRED]
-  shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationRequest.java → shaft-pilot-core/src/main/java/com/shaft/pilot/ai/ApprovalPolicy.java
 - `sortedEvents()` --calls--> `Sequence`  [INFERRED]
   shaft-capture/src/main/java/com/shaft/capture/model/CaptureSession.java → shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
 - `disabled()` --calls--> `denyAll()`  [INFERRED]
   shaft-doctor/src/main/java/com/shaft/doctor/DoctorAiAnalysisRequest.java → shaft-pilot-core/src/main/java/com/shaft/pilot/ai/ApprovalPolicy.java
+- `defaults()` --calls--> `denyAll()`  [INFERRED]
+  shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationRequest.java → shaft-pilot-core/src/main/java/com/shaft/pilot/ai/ApprovalPolicy.java
 - `generated()` --calls--> `start()`  [INFERRED]
   shaft-capture/src/main/java/com/shaft/capture/collector/BrowserSignal.java → shaft-capture/src/test/java/com/shaft/capture/collector/CaptureCollectorUtilityTest.java
 - `CaptureFormatException` --inherits--> `IllegalArgumentException`  [EXTRACTED]
@@ -760,11 +767,11 @@
 ## Import Cycles
 - None detected.
 
-## Communities (838 total, 98 thin omitted)
+## Communities (844 total, 100 thin omitted)
 
 ### Community 0 - "Community 0"
 Cohesion: 0.04
-Nodes (8): RestActionsComprehensiveTests, GraphqlRequestTests, ComparisonType, Deprecated, InputStream, SuppressWarnings, BeforeMethod, Test
+Nodes (9): RestActionsComprehensiveTests, GraphqlRequestTests, API, ComparisonType, Deprecated, InputStream, SuppressWarnings, BeforeMethod (+1 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.06
@@ -775,8 +782,8 @@ Cohesion: 0.12
 Nodes (6): SetProperty, Web, DefaultValue, Key, SetProperty, String
 
 ### Community 3 - "Community 3"
-Cohesion: 0.11
-Nodes (17): LocatorAssertions, PageAssertions, Parameter, LinkedHashMap, List, Locator, Object, Override (+9 more)
+Cohesion: 0.12
+Nodes (16): LocatorAssertions, Outcome, PageAssertions, LinkedHashMap, List, Locator, Object, Override (+8 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.07
@@ -787,20 +794,24 @@ Cohesion: 0.13
 Nodes (14): ConsoleEvent, BrowserObservabilityRecorder, disabled(), NetworkEvent, NetworkExchange, NetworkObservation, HttpRequest, HttpResponse (+6 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.16
-Nodes (3): Map, Test, CSVFileManagerUnitTest
+Cohesion: 0.06
+Nodes (14): CSVFileManager, CSVFileManagerTest, List, Map, String, BeforeMethod, Test, AfterMethod (+6 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.09
-Nodes (20): MobileService, McpMobileAccessibilityTree, McpMobileContextSnapshot, BrowserType, Class, LocatorOperation, locatorStrategy, Map (+12 more)
+Nodes (22): KeyboardKeys, MobileService, McpMobileAccessibilityTree, McpMobileContextSnapshot, McpMobileSessionResult, BrowserType, Class, LocatorOperation (+14 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.17
-Nodes (8): BrowserStackSdkTests, AfterMethod, BeforeMethod, Map, Object, String, SuppressWarnings, Test
+Cohesion: 0.05
+Nodes (29): BrowserStackSdkHelper, FileReader, JSONFileManagerTestAccessor, BrowserStackSdkTests, List, Map, Object, String (+21 more)
 
 ### Community 9 - "Community 9"
 Cohesion: 0.14
 Nodes (8): LocatorHealthReporter, LocatorStats, LocatorStats, AssertionError, By, List, ObjectNode, String
+
+### Community 10 - "Community 10"
+Cohesion: 0.07
+Nodes (7): Boolean, NumbersComparativeRelation, Object, String, Test, JavaHelper, JavaHelperUnitTest
 
 ### Community 11 - "Community 11"
 Cohesion: 0.09
@@ -811,28 +822,28 @@ Cohesion: 0.07
 Nodes (11): BrowserStack, SetProperty, DefaultValue, Key, SetProperty, String, AfterMethod, Object (+3 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.12
-Nodes (6): List, Map, AfterMethod, BeforeClass, Test, JSONFileManagerUnitTest
+Cohesion: 0.10
+Nodes (10): DataType, JSONFileManager, List, Map, Object, String, AfterMethod, BeforeClass (+2 more)
 
 ### Community 14 - "Community 14"
 Cohesion: 0.09
 Nodes (29): E, LocatorSignal, empty(), merge(), MouseButton, CaptureEventPipeline, SafePage, SafeTarget (+21 more)
 
 ### Community 15 - "Community 15"
-Cohesion: 0.06
-Nodes (19): requestTarget(), ShaftRestAssuredFilter, ApiEvidenceLabels, FilterableRequestSpecification, FilterableResponseSpecification, FilterContext, JsonElement, Object (+11 more)
+Cohesion: 0.07
+Nodes (14): requestTarget(), ShaftRestAssuredFilter, ApiEvidenceLabels, FilterableRequestSpecification, FilterableResponseSpecification, FilterContext, JsonElement, Object (+6 more)
 
 ### Community 16 - "Community 16"
 Cohesion: 0.07
 Nodes (6): AfterMethod, Path, String, SuppressWarnings, Test, TerminalActionsUnitTest
 
 ### Community 17 - "Community 17"
-Cohesion: 0.07
-Nodes (18): AsyncAppender, ReportManagerHelper, ReportManager, TestCaseStarted, Boolean, ByteArrayOutputStream, CheckpointStatus, InputStream (+10 more)
+Cohesion: 0.13
+Nodes (4): AsyncAppender, ReportManagerHelper, Level, String
 
 ### Community 18 - "Community 18"
 Cohesion: 0.09
-Nodes (21): FileActions, ImageProcessingActions, Boolean, Collection, Exception, File, String, SuppressWarnings (+13 more)
+Nodes (21): FileActions, FileActionsCoverageUnitTest, Boolean, Collection, Exception, File, InputStream, String (+13 more)
 
 ### Community 19 - "Community 19"
 Cohesion: 0.11
@@ -843,56 +854,56 @@ Cohesion: 0.13
 Nodes (6): Healing, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 21 - "Community 21"
-Cohesion: 0.15
-Nodes (12): WebDriverListener, Navigation, Alert, By, Method, Object, String, URL (+4 more)
+Cohesion: 0.07
+Nodes (23): BrowserStackModuleTest, CaptureCliTest, WebDriverListener, InvocationTargetException, JsonSchemaValidatorTest, Navigation, Test, Class (+15 more)
 
 ### Community 22 - "Community 22"
-Cohesion: 0.19
-Nodes (12): AfterAllCallback, AfterTestExecutionCallback, BeforeAllCallback, BeforeEachCallback, LifecycleMethodExecutionExceptionHandler, JunitExtension, ExtensionContext, Method (+4 more)
+Cohesion: 0.10
+Nodes (16): NativeValidationsBuilder, TextDirectionValidationsBuilder, FileValidationsBuilder, Object, Override, RestValidationsBuilder, String, SuppressWarnings (+8 more)
 
 ### Community 23 - "Community 23"
-Cohesion: 0.10
-Nodes (12): ImageProcessingActionsCoverageUnitTest, AfterMethod, BeforeMethod, BufferedImage, Color, DataProvider, Map, Method (+4 more)
+Cohesion: 0.06
+Nodes (26): ImageProcessingActionsCoverageUnitTest, List, Color, Rectangle, Override, AfterMethod, BeforeMethod, BufferedImage (+18 more)
 
 ### Community 24 - "Community 24"
-Cohesion: 0.08
-Nodes (11): AllureManager, BooleanSupplier, Counts, ArrayNode, Future, InputStream, List, ObjectNode (+3 more)
+Cohesion: 0.07
+Nodes (13): skipped(), AllureManager, String, Validation, Counts, ArrayNode, Future, InputStream (+5 more)
 
 ### Community 25 - "Community 25"
-Cohesion: 0.19
-Nodes (8): DoctorRepairPublicationRequest, ExistingPullRequest, DoctorRepairService, DoctorRepairRequest, Path, RepairProposal, RepairPublicationResult, String
+Cohesion: 0.10
+Nodes (25): AllureVerdict, DoctorRepairPublicationRequest, ExistingPullRequest, Operation, PatchManifestEntry, changedSince(), DoctorRepairService, validationPassed() (+17 more)
 
 ### Community 26 - "Community 26"
-Cohesion: 0.08
-Nodes (14): DriverFactoryHelperCoverageUnitTest, TestableDriverFactoryHelper, AfterMethod, AtomicInteger, CountDownLatch, DriverFactoryHelper, DriverType, Method (+6 more)
+Cohesion: 0.07
+Nodes (15): DesiredCapabilities, DriverFactoryHelperCoverageUnitTest, TestableDriverFactoryHelper, AfterMethod, AtomicInteger, CountDownLatch, DriverFactoryHelper, DriverType (+7 more)
 
 ### Community 27 - "Community 27"
 Cohesion: 0.08
 Nodes (4): ValidationTests, AfterMethod, BeforeMethod, Test
 
 ### Community 28 - "Community 28"
-Cohesion: 0.10
-Nodes (12): PropertyFileManager, ThreadLocalPropertiesManager, File, HashMap, Map, MutableCapabilities, Object, Properties (+4 more)
+Cohesion: 0.08
+Nodes (15): PropertyFileManager, PropertyFileManagerInternalUnitTest, File, HashMap, Map, MutableCapabilities, Object, Properties (+7 more)
 
 ### Community 29 - "Community 29"
 Cohesion: 0.10
-Nodes (17): AccessibilityConfig, AccessibilityHelper, AccessibilityResult, AccessibilityResult, Integer, JSONArray, JSONObject, List (+9 more)
+Nodes (18): AccessibilityConfig, AccessibilityHelper, AccessibilityResult, AxeBuilder, AccessibilityResult, Integer, JSONArray, JSONObject (+10 more)
 
 ### Community 30 - "Community 30"
-Cohesion: 0.17
-Nodes (16): RecordingRunner, DoctorRepairServiceTest, RecordingRunner, validationPassed(), RepairProcessRunner, RepositoryFixture, DoctorRepairRequest, Duration (+8 more)
+Cohesion: 0.11
+Nodes (17): ArtifactPaths, failure(), withUnsupported(), GenerationState, CaptureEnrichmentPreview, CaptureGenerationReport, CaptureGenerationRequest, CaptureGenerationResult (+9 more)
 
 ### Community 31 - "Community 31"
 Cohesion: 0.10
 Nodes (16): ChannelSftp, TerminalActions, ProcessBuilder, SftpTransferDirection, Boolean, BufferedReader, Deprecated, Exception (+8 more)
 
 ### Community 32 - "Community 32"
-Cohesion: 0.06
-Nodes (13): EngineServiceRuntimePathTest, Class, Object, Path, String, Test, String, Test (+5 more)
+Cohesion: 0.08
+Nodes (11): EngineServiceRuntimePathTest, AfterMethod, Class, Object, Path, String, Test, AfterEach (+3 more)
 
 ### Community 33 - "Community 33"
-Cohesion: 0.04
-Nodes (29): ApiPerformanceReportTest, PathParamTest, SwaggerContractTest, TestUpload, BasicAPITests, ContentType, Object, ParametersType (+21 more)
+Cohesion: 0.05
+Nodes (26): ApiPerformanceReportTest, PathParamTest, SwaggerContractTest, TestUpload, BasicAPITests, ContentType, Map, Object (+18 more)
 
 ### Community 34 - "Community 34"
 Cohesion: 0.08
@@ -900,22 +911,22 @@ Nodes (27): DeterministicNaturalActionPlanner, unsupported(), NaturalActionPlann
 
 ### Community 35 - "Community 35"
 Cohesion: 0.07
-Nodes (27): IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, IResultListener2, ISuiteListener (+19 more)
+Nodes (28): Constructor, IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, IResultListener2 (+20 more)
 
 ### Community 36 - "Community 36"
 Cohesion: 0.07
-Nodes (27): DataTableArgument, EmbedEvent, HookTestStep, CucumberFeatureListener, PickleStepTestStep, Result, Scenario, AllureLifecycle (+19 more)
+Nodes (27): DataTableArgument, EmbedEvent, HookTestStep, CucumberFeatureListener, Parameter, PickleStepTestStep, Result, Scenario (+19 more)
 
 ### Community 37 - "Community 37"
-Cohesion: 0.17
-Nodes (6): Paths, SetProperty, DefaultValue, Key, SetProperty, String
+Cohesion: 0.16
+Nodes (7): Paths, SetProperty, DefaultValue, Key, SetProperty, String, BeforeClass
 
 ### Community 38 - "Community 38"
 Cohesion: 0.09
 Nodes (18): BrowserNetworkInterceptor, ClientConfig, DriverFactoryHelper, BrowserNetworkInterceptionRule, Capabilities, Class, DriverType, List (+10 more)
 
 ### Community 39 - "Community 39"
-Cohesion: 0.09
+Cohesion: 0.11
 Nodes (11): AfterMethod, BeforeMethod, Class, List, Object, Path, String, T (+3 more)
 
 ### Community 40 - "Community 40"
@@ -927,20 +938,20 @@ Cohesion: 0.16
 Nodes (16): CollectionState, EvidenceCollector, CollectionState, DoctorRedactor, DefaultPrettyPrinter, DoctorAnalysisRequest, EvidenceBundle, EvidenceCategory (+8 more)
 
 ### Community 42 - "Community 42"
-Cohesion: 0.10
-Nodes (15): ElementLookup, FlakeProfileContext, GetElementInformation, Actions, ClipboardAction, GetElementInformation, Beta, By (+7 more)
+Cohesion: 0.15
+Nodes (8): ClipboardAction, GetElementInformation, Beta, By, ClipboardAction, Override, Step, String
 
 ### Community 43 - "Community 43"
-Cohesion: 0.05
-Nodes (17): NativeValidationsBuilder, TextDirectionValidationsBuilder, E2ECoverageTests, FileValidationsBuilder, RestValidationsBuilder, String, ValidationsBuilder, WebDriverBrowserValidationsBuilder (+9 more)
+Cohesion: 0.08
+Nodes (5): E2ECoverageTests, AfterMethod, BeforeMethod, Test, TextLanguageValidationsBuilder
 
 ### Community 44 - "Community 44"
-Cohesion: 0.08
-Nodes (7): LambdaTest, SetProperty, Boolean, DefaultValue, Key, SetProperty, String
+Cohesion: 0.12
+Nodes (3): SetProperty, Boolean, String
 
 ### Community 45 - "Community 45"
 Cohesion: 0.10
-Nodes (21): ActionsCoverageUnitTest, RecordingActions, RecordingActions, ActionType, AfterMethod, AllureLifecycle, BeforeMethod, By (+13 more)
+Nodes (20): ActionsCoverageUnitTest, RecordingActions, RecordingActions, ActionType, AfterMethod, AllureLifecycle, BeforeMethod, By (+12 more)
 
 ### Community 46 - "Community 46"
 Cohesion: 0.24
@@ -955,32 +966,32 @@ Cohesion: 0.08
 Nodes (11): NumberValidationsBuilder, Number, Object, Override, RestValidationsBuilder, SuppressWarnings, ValidationsBuilder, ValidationsExecutor (+3 more)
 
 ### Community 49 - "Community 49"
-Cohesion: 0.14
-Nodes (11): FailureTraceReporter, List, Path, SourceContext, StackTraceElement, String, StringBuilder, TestExecutionInfo (+3 more)
+Cohesion: 0.13
+Nodes (12): FailureTraceReporter, PlaywrightTraceManager, List, Path, SourceContext, StackTraceElement, String, StringBuilder (+4 more)
 
 ### Community 50 - "Community 50"
 Cohesion: 0.04
 Nodes (47): additionalProperties, minLength, type, maximum, minimum, type, type, minLength (+39 more)
 
 ### Community 51 - "Community 51"
-Cohesion: 0.08
-Nodes (12): AssertApiResponseEqualsTests, ApiActionsMockedTests, RequestBuilder, RequestType, Test, AfterMethod, BeforeMethod, Test (+4 more)
+Cohesion: 0.07
+Nodes (13): AssertApiResponseEqualsTests, ApiActionsMockedTests, RequestBuilder, RequestType, Test, AfterMethod, BeforeMethod, Test (+5 more)
 
 ### Community 52 - "Community 52"
-Cohesion: 0.10
-Nodes (15): AsyncElementActions, CSVFileManager, Async, CLI, CSV, GUI, Locator, Properties (+7 more)
+Cohesion: 0.07
+Nodes (20): AsyncElementActions, Async, CLI, GUI, Locator, Properties, Report, TestData (+12 more)
 
 ### Community 53 - "Community 53"
 Cohesion: 0.10
-Nodes (17): RestActions, RequestSpecBuilder, API, ArrayNode, Boolean, Class, Cookie, List (+9 more)
+Nodes (17): RestActions, RequestSpecBuilder, RestAssuredConfig, ArrayNode, Boolean, Class, Cookie, List (+9 more)
 
 ### Community 54 - "Community 54"
 Cohesion: 0.10
 Nodes (39): AllureFailure, _attachment_source_candidates(), _clean_cell(), extract_failures(), extract_surefire_failures(), _failure_brief_open_first(), _failure_group_key(), _first_trace_line() (+31 more)
 
 ### Community 55 - "Community 55"
-Cohesion: 0.15
-Nodes (14): ElementActionsHelper, TextDetectionStrategy(), AtomicInteger, Boolean, By, Class, HealingResolution, List (+6 more)
+Cohesion: 0.13
+Nodes (16): ElementActionsHelper, TextDetectionStrategy(), AtomicInteger, Boolean, By, Class, ClipboardAction, HealingResolution (+8 more)
 
 ### Community 56 - "Community 56"
 Cohesion: 0.11
@@ -999,12 +1010,12 @@ Cohesion: 0.14
 Nodes (20): CaptureControlClient, CaptureCli, flag(), parse(), path(), pathRequired(), required(), value() (+12 more)
 
 ### Community 60 - "Community 60"
-Cohesion: 0.12
+Cohesion: 0.11
 Nodes (19): Document, GuideHttpClient, GuideIndex, GuideHttpClient, GuideService, JdkGuideHttpClient, McpGuideMatch, McpGuideSearchResult (+11 more)
 
 ### Community 61 - "Community 61"
 Cohesion: 0.12
-Nodes (14): AllureListenerCoverageUnitTest, Throwable, AfterMethod, BeforeMethod, ITestResult, List, Path, String (+6 more)
+Nodes (15): AllureListenerCoverageUnitTest, Throwable, Status, AfterMethod, BeforeMethod, ITestResult, List, Path (+7 more)
 
 ### Community 62 - "Community 62"
 Cohesion: 0.14
@@ -1019,8 +1030,8 @@ Cohesion: 0.11
 Nodes (11): COSDocument, DeleteFileAfterValidationStatus, PdfFileManager, PDFParser, RandomAccessReadBufferedFile, File, String, AfterMethod (+3 more)
 
 ### Community 65 - "Community 65"
-Cohesion: 0.25
-Nodes (12): ElementActionabilityDiagnostics, By, List, Map, Object, Rectangle, String, Supplier (+4 more)
+Cohesion: 0.15
+Nodes (4): LambdaTest, DefaultValue, Key, SetProperty
 
 ### Community 66 - "Community 66"
 Cohesion: 0.05
@@ -1035,7 +1046,7 @@ Cohesion: 0.05
 Nodes (42): additionalProperties, default, description, examples, $id, title, type, default (+34 more)
 
 ### Community 69 - "Community 69"
-Cohesion: 0.10
+Cohesion: 0.11
 Nodes (12): DriverFactoryHelper, OptionsManager, AfterMethod, AtomicInteger, CountDownLatch, DriverType, Method, MutableCapabilities (+4 more)
 
 ### Community 70 - "Community 70"
@@ -1043,32 +1054,32 @@ Cohesion: 0.10
 Nodes (43): expand_globs(), issue(), load_budget(), local_link_targets(), markdown_body(), normalized_paragraphs(), parse_frontmatter(), quoted_yaml_value() (+35 more)
 
 ### Community 71 - "Community 71"
-Cohesion: 0.09
-Nodes (22): ShaftHeal, ShaftHealingProviderTest, WebDomHealingAcceptanceTest, Outcome, HealingReport, Optional, AfterMethod, AppiumDriver (+14 more)
+Cohesion: 0.07
+Nodes (29): ChromeOptions, ShaftHeal, ShaftHealingProviderTest, WebDomHealingAcceptanceTest, MoonTests, AfterEach, BeforeEach, String (+21 more)
 
 ### Community 72 - "Community 72"
-Cohesion: 0.19
-Nodes (13): DoctorAnalyzerTest, DoctorAiAnalysisResult, Arguments, CauseCategory, DoctorAnalysisRequest, DoctorAnalysisResult, List, MethodSource (+5 more)
+Cohesion: 0.09
+Nodes (29): DoctorAnalyzerTest, DoctorAiAnalysisResult, empty(), reviewUiPath(), disabled(), defaults(), lower(), normalizePath() (+21 more)
 
 ### Community 73 - "Community 73"
-Cohesion: 0.13
-Nodes (16): denyAll(), CaptureFixtures, CaptureGeneratorTest, PageContext, BrowserMetadata, CaptureEvent, CaptureSession, ElementSnapshot (+8 more)
+Cohesion: 0.11
+Nodes (19): denyAll(), CaptureFixtures, defaults(), CaptureGeneratorTest, PageContext, CaptureGenerationRequest, Path, BrowserMetadata (+11 more)
 
 ### Community 74 - "Community 74"
 Cohesion: 0.11
-Nodes (15): CaptureEventPipeline, CapturePrivacyClassifier, ManagedCaptureRecorder, BrowserMetadata, BrowserSignal, CapturePrivacyPolicy, CaptureSessionStore, CaptureStartRequest (+7 more)
+Nodes (13): ManagedCaptureRecorder, BrowserMetadata, BrowserSignal, CapturePrivacyPolicy, CaptureSessionStore, CaptureStartRequest, CaptureStatus, CheckpointKind (+5 more)
 
 ### Community 75 - "Community 75"
-Cohesion: 0.19
-Nodes (8): Actions, By, ElementActions, List, Map, Override, String, SuppressWarnings
+Cohesion: 0.17
+Nodes (9): Actions, By, ElementActions, List, Map, Override, String, SuppressWarnings (+1 more)
 
 ### Community 76 - "Community 76"
 Cohesion: 0.08
 Nodes (26): Session1Test, LocatorOperation, PlaywrightService, AfterMethod, BeforeMethod, String, Test, By (+18 more)
 
 ### Community 77 - "Community 77"
-Cohesion: 0.11
-Nodes (13): appendJson(), FlakeProfiler, TestProfile, RetryEvent, ActionEvent, ArrayNode, AssertionError, List (+5 more)
+Cohesion: 0.09
+Nodes (15): ActionSample, EvidenceEvent, appendJson(), FlakeProfiler, TestProfile, RetryEvent, ActionEvent, ArrayNode (+7 more)
 
 ### Community 78 - "Community 78"
 Cohesion: 0.05
@@ -1092,15 +1103,15 @@ Nodes (39): additionalProperties, type, maximum, minimum, type, additionalProper
 
 ### Community 84 - "Community 84"
 Cohesion: 0.09
-Nodes (21): option(), ProviderConfiguration(), ProviderConfigurationTest, FirestoreRestClient, Properties, CaptureStartRequest(), validateUrl(), CaptureBrowser (+13 more)
+Nodes (22): option(), ProviderConfiguration(), ProviderConfigurationTest, FirestoreRestClient, Properties, CaptureStartRequest(), validateUrl(), CaptureBrowser (+14 more)
 
 ### Community 85 - "Community 85"
-Cohesion: 0.14
-Nodes (14): ClassifiedUpload, CapturePrivacyClassifier, CapturePrivacyClassifierTest, SanitizedAttributes, SanitizedText, CapturePrivacyPolicy, ClassifiedValue, List (+6 more)
+Cohesion: 0.13
+Nodes (15): CapturePrivacyClassifier, ClassifiedUpload, CapturePrivacyClassifier, CapturePrivacyClassifierTest, SanitizedAttributes, SanitizedText, CapturePrivacyPolicy, ClassifiedValue (+7 more)
 
 ### Community 86 - "Community 86"
-Cohesion: 0.13
-Nodes (12): EngineService, MobileServiceConfigurationTest, McpMobileSessionResult, PostConstruct, BrowserType, By, Path, String (+4 more)
+Cohesion: 0.11
+Nodes (12): EngineService, MobileServiceConfigurationTest, PostConstruct, BrowserType, By, Path, String, Tool (+4 more)
 
 ### Community 87 - "Community 87"
 Cohesion: 0.14
@@ -1111,8 +1122,8 @@ Cohesion: 0.10
 Nodes (10): AfterMethod, BeforeMethod, Issue, Issues, ITestResult, String, Test, TmsLink (+2 more)
 
 ### Community 89 - "Community 89"
-Cohesion: 0.10
-Nodes (14): WebDriverElementValidationsBuilder, GuiVerificationTests, By, NativeValidationsBuilder, Override, String, StringBuilder, ValidationCategory (+6 more)
+Cohesion: 0.20
+Nodes (6): WebDriverElementValidationsBuilder, NativeValidationsBuilder, Override, String, ValidationsExecutor, VisualValidationEngine
 
 ### Community 90 - "Community 90"
 Cohesion: 0.11
@@ -1127,20 +1138,20 @@ Cohesion: 0.09
 Nodes (49): child_text(), dependency_coordinate(), dependency_template(), direct_child(), elements_named(), ensure_android_json_exclusion(), ensure_dependency(), ensure_generator_dependency_set() (+41 more)
 
 ### Community 93 - "Community 93"
-Cohesion: 0.07
-Nodes (17): LocatorBuilder, ShadowDomTest, JDK21VirtualThreadsAndAsyncActionsTests, RelativeBy, By, Locator, Page, Role (+9 more)
+Cohesion: 0.11
+Nodes (9): LocatorBuilder, RelativeBy, By, Locator, Page, Role, ShaftLocator, String (+1 more)
 
 ### Community 94 - "Community 94"
 Cohesion: 0.05
 Nodes (37): type, additionalProperties, minLength, type, items, type, type, required (+29 more)
 
 ### Community 95 - "Community 95"
-Cohesion: 0.16
-Nodes (13): builder(), evidenceCategories(), withSanitizedContent(), withTimeout(), AiRequest, ApprovalPolicy, Duration, EvidenceCategory (+5 more)
+Cohesion: 0.12
+Nodes (16): builder(), evidenceCategories(), withSanitizedContent(), withTimeout(), AiImage, AiRequest, ApprovalPolicy, Duration (+8 more)
 
 ### Community 96 - "Community 96"
-Cohesion: 0.10
-Nodes (16): DriverFactory, DriverType(), DatabaseActions, DatabaseType, Deprecated, DriverFactoryHelper, DriverType, MutableCapabilities (+8 more)
+Cohesion: 0.09
+Nodes (18): DriverFactory, DriverType(), MatchJsonSchemaTests, DatabaseActions, DatabaseType, Deprecated, DriverFactoryHelper, DriverType (+10 more)
 
 ### Community 97 - "Community 97"
 Cohesion: 0.07
@@ -1167,20 +1178,20 @@ Cohesion: 0.16
 Nodes (19): DoctorAiAnalysisServiceTest, AiBudget, EnumSource, from(), DoctorAnalysisResult, DoctorAnalysisSummary, AiRequest, AiResponse (+11 more)
 
 ### Community 103 - "Community 103"
-Cohesion: 0.22
-Nodes (8): ChromeOptions, MoonTests, AfterEach, BeforeEach, String, Test, WebDriver, TestInfo
+Cohesion: 0.17
+Nodes (3): Reporting, DefaultValue, Key
 
 ### Community 104 - "Community 104"
-Cohesion: 0.11
-Nodes (14): Dimension, BrowserActionsHelper, Boolean, Exception, List, Object, SneakyThrows, String (+6 more)
+Cohesion: 0.17
+Nodes (10): Dimension, BrowserActionsHelper, Boolean, Exception, List, Object, SneakyThrows, String (+2 more)
 
 ### Community 105 - "Community 105"
 Cohesion: 0.14
 Nodes (14): BadRequestException, CaptureControlServer, Handler, Handler, CaptureControlFiles, CaptureManager, CaptureStatus, Class (+6 more)
 
 ### Community 106 - "Community 106"
-Cohesion: 0.13
-Nodes (11): FluentWait, ElementsHelperCoverageUnitTest, MockedStatic, AfterMethod, BeforeMethod, DriverFactoryHelper, MockedConstruction, RuntimeException (+3 more)
+Cohesion: 0.11
+Nodes (13): FluentWait, ImageProcessingActionsReportingUnitTest, ElementsHelperCoverageUnitTest, MockedStatic, AfterMethod, BeforeMethod, DriverFactoryHelper, MockedConstruction (+5 more)
 
 ### Community 107 - "Community 107"
 Cohesion: 0.12
@@ -1191,8 +1202,8 @@ Cohesion: 0.13
 Nodes (5): YAMLFileManagerTests, BeforeMethod, Date, String, Test
 
 ### Community 109 - "Community 109"
-Cohesion: 0.16
-Nodes (6): AfterTest, BeforeTest, ConfigurationHelper, ReportHelper, ITestContext, Step
+Cohesion: 0.31
+Nodes (5): AfterTest, BeforeTest, ConfigurationHelper, ITestContext, Step
 
 ### Community 110 - "Community 110"
 Cohesion: 0.16
@@ -1204,30 +1215,30 @@ Nodes (17): DeterministicRuleEngine, Confidence, Finding, Remediation, RetrySumm
 
 ### Community 112 - "Community 112"
 Cohesion: 0.11
-Nodes (14): API, YAML, BrowserActionsContract, Class, Cookie, List, Map, Object (+6 more)
+Nodes (12): API, JSON, YAML, Class, Cookie, List, Map, Object (+4 more)
 
 ### Community 113 - "Community 113"
 Cohesion: 0.15
 Nodes (6): Platform, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 114 - "Community 114"
-Cohesion: 0.08
-Nodes (16): IIOMetadataNode, AnimatedGifManager, GifSession, AnimatedGifManagerCoverageUnitTest, ImageOutputStream, ImageWriter, RenderedImage, BufferedImage (+8 more)
+Cohesion: 0.09
+Nodes (14): IIOMetadataNode, AnimatedGifManager, GifSession, AnimatedGifManagerCoverageUnitTest, ImageOutputStream, ImageWriter, RenderedImage, BufferedImage (+6 more)
 
 ### Community 115 - "Community 115"
 Cohesion: 0.06
 Nodes (34): enum, type, items, type, items, type, $id, required (+26 more)
 
 ### Community 116 - "Community 116"
-Cohesion: 0.15
-Nodes (8): AfterMethod, AndroidDriver, BeforeMethod, RemoteWebDriver, Runnable, Test, TouchActions, AndroidTouchActionsCoverageUnitTest
+Cohesion: 0.14
+Nodes (10): ElementActionsHelper, AfterMethod, AndroidDriver, BeforeMethod, RemoteWebDriver, Runnable, Test, TouchActions (+2 more)
 
 ### Community 117 - "Community 117"
 Cohesion: 0.15
 Nodes (21): AllureFile, changedSince(), HealerService, ProcessExecutor, successful(), McpHealerAttemptResult, McpHealerRunResult, ProcessExecutor (+13 more)
 
 ### Community 118 - "Community 118"
-Cohesion: 0.19
+Cohesion: 0.18
 Nodes (15): CandidateExtractor, LocatorProposal, SearchContext, By, Collection, HealingConfiguration, HealingPlatform, List (+7 more)
 
 ### Community 119 - "Community 119"
@@ -1235,12 +1246,12 @@ Cohesion: 0.08
 Nodes (17): Async, Driver, Playwright, WebDriver, PlaywrightDriverAssertions, PlaywrightDriverVerifications, Actions, AlertActions (+9 more)
 
 ### Community 120 - "Community 120"
-Cohesion: 0.20
+Cohesion: 0.18
 Nodes (12): YAMLFileManager, Boolean, Class, Date, Double, Integer, List, Long (+4 more)
 
 ### Community 121 - "Community 121"
-Cohesion: 0.18
-Nodes (10): AfterMethod, Map, Object, String, SuppressWarnings, Test, Throwable, ThrowingRunnable (+2 more)
+Cohesion: 0.17
+Nodes (11): AccessibilityActions, BrowserContext, BrowserNetworkInterceptionRule, HttpRequest, HttpResponse, Locator, NetworkInterceptionRequestBuilder, PlaywrightSession (+3 more)
 
 ### Community 122 - "Community 122"
 Cohesion: 0.12
@@ -1251,12 +1262,12 @@ Cohesion: 0.10
 Nodes (4): AfterMethod, BeforeClass, Test, YAMLFileManagerUnitTest
 
 ### Community 124 - "Community 124"
-Cohesion: 0.08
-Nodes (29): AiTrigger, HealingProvider, HealingReportWriter, ShaftHealingProvider, safe(), stableKey(), HealingConfiguration, HealingReport (+21 more)
+Cohesion: 0.11
+Nodes (25): AiTrigger, HealingProvider, ShaftHealingProvider, safe(), stableKey(), HealingActionOutcome, HealingCandidate, HealingConfiguration (+17 more)
 
 ### Community 125 - "Community 125"
-Cohesion: 0.13
-Nodes (17): getType(), LauncherSession, Screenshots, Override, AfterMethod, BeforeMethod, Duration, List (+9 more)
+Cohesion: 0.15
+Nodes (15): LauncherSession, Override, AfterMethod, BeforeMethod, Duration, List, Object, Optional (+7 more)
 
 ### Community 126 - "Community 126"
 Cohesion: 0.18
@@ -1275,12 +1286,12 @@ Cohesion: 0.19
 Nodes (7): FluentWebDriverAction, Actions, AlertActions, BrowserActions, DriverFactoryHelper, TouchActions, WebDriver
 
 ### Community 130 - "Community 130"
-Cohesion: 0.27
+Cohesion: 0.30
 Nodes (6): Config, List, String, SuppressWarnings, Test, XrayIntegrationHelper
 
 ### Community 131 - "Community 131"
 Cohesion: 0.09
-Nodes (28): DoctorRepairProposalResult, DoctorRepairService, CaptureFormatException, HealingLocatorProposalRequest, DoctorService, McpWorkspacePolicy, McpDoctorRemediationService, String (+20 more)
+Nodes (26): DoctorRepairProposalResult, DoctorRepairService, HealingLocatorProposalRequest, DoctorService, DoctorServiceTest, McpDoctorRemediationService, ApprovalPolicy, Diagnosis (+18 more)
 
 ### Community 132 - "Community 132"
 Cohesion: 0.15
@@ -1291,8 +1302,8 @@ Cohesion: 0.15
 Nodes (10): PackageActivity, BufferedReader, File, Optional, String, Path, String, Test (+2 more)
 
 ### Community 134 - "Community 134"
-Cohesion: 0.14
-Nodes (7): Mobile, SetProperty, PropertiesManagerTests, DefaultValue, Key, SetProperty, String
+Cohesion: 0.06
+Nodes (16): Jira, SetProperty, Mobile, SetProperty, PropertiesManagerTests, JiraTests, DefaultValue, Key (+8 more)
 
 ### Community 135 - "Community 135"
 Cohesion: 0.09
@@ -1303,24 +1314,24 @@ Cohesion: 0.16
 Nodes (27): ut(), _(), a(), b(), c(), d(), f(), g() (+19 more)
 
 ### Community 137 - "Community 137"
-Cohesion: 0.19
-Nodes (15): EndpointStats, ApiPerformanceExecutionReport, appendJson(), budgetStatus(), budgetViolationMessage(), from(), percentile(), toHtmlRow() (+7 more)
+Cohesion: 0.16
+Nodes (16): EndpointStats, ApiPerformanceExecutionReport, appendJson(), budgetStatus(), budgetViolationMessage(), from(), percentile(), toHtmlRow() (+8 more)
 
 ### Community 138 - "Community 138"
 Cohesion: 0.16
 Nodes (9): AllureManagerCoverageUnitTest, AfterMethod, BeforeMethod, Class, Method, Object, Path, String (+1 more)
 
 ### Community 139 - "Community 139"
-Cohesion: 0.07
-Nodes (31): deleteObject, deleteRelation, markStale, supersedeObject, additionalProperties, properties, required, type (+23 more)
+Cohesion: 0.10
+Nodes (23): deleteObject, deleteRelation, additionalProperties, properties, required, type, additionalProperties, properties (+15 more)
 
 ### Community 140 - "Community 140"
 Cohesion: 0.06
 Nodes (30): additionalProperties, type, type, minimum, type, minimum, type, $id (+22 more)
 
 ### Community 141 - "Community 141"
-Cohesion: 0.17
-Nodes (11): AccessibilityHelperCoverageUnitTest, AxeBuilder, AfterMethod, List, MockedConstruction, Path, Results, Rule (+3 more)
+Cohesion: 0.18
+Nodes (10): AccessibilityHelperCoverageUnitTest, AfterMethod, List, MockedConstruction, Path, Results, Rule, String (+2 more)
 
 ### Community 142 - "Community 142"
 Cohesion: 0.13
@@ -1339,8 +1350,8 @@ Cohesion: 0.19
 Nodes (9): CaptureManagerLifecycleTest, FailingRecorder, FakeRecorder, CaptureStartRequest, CaptureStatus, CheckpointKind, Override, String (+1 more)
 
 ### Community 146 - "Community 146"
-Cohesion: 0.15
-Nodes (16): CaptureCodegenStartRequest, CaptureCodegenStartRequest, CaptureService, McpCaptureCodeBlockService, McpCaptureReplayResult, PreDestroy, CaptureGenerationResult, CaptureManager (+8 more)
+Cohesion: 0.12
+Nodes (19): CaptureCodegenStartRequest, reviewPath(), reviewUiPath(), CaptureCodegenStartRequest, CaptureService, McpCaptureCodeBlockService, McpCaptureReplayResult, PreDestroy (+11 more)
 
 ### Community 147 - "Community 147"
 Cohesion: 0.19
@@ -1359,15 +1370,15 @@ Cohesion: 0.20
 Nodes (20): DoctorCli, flag(), optionalPath(), parse(), path(), pathRequired(), paths(), pathsRequired() (+12 more)
 
 ### Community 151 - "Community 151"
-Cohesion: 0.11
-Nodes (13): List, Color, Rectangle, AfterMethod, BeforeMethod, Color, Map, Method (+5 more)
+Cohesion: 0.14
+Nodes (8): ElementLookup, GetElementInformation, Actions, DriverFactoryHelper, JavascriptExecutor, Rectangle, WebDriver, WebElement
 
 ### Community 152 - "Community 152"
 Cohesion: 0.19
 Nodes (11): LocatorRef, McpAppiumCommandRecorder, PointerGesture, BooleanSupplier, JsonNode, locatorStrategy, Map, McpMobileRecordedAction (+3 more)
 
 ### Community 153 - "Community 153"
-Cohesion: 0.11
+Cohesion: 0.12
 Nodes (16): APIResponse, FulfillOptions, PlaywrightNetworkInterceptor, PlaywrightNetworkInterceptorTest, Request, BrowserContext, BrowserNetworkInterceptionRule, HttpMethod (+8 more)
 
 ### Community 154 - "Community 154"
@@ -1375,24 +1386,24 @@ Cohesion: 0.17
 Nodes (11): HistoryDocument, HistoryRecord, HealingHistoryStore, HealingConfiguration, HealingContext, LocatorFingerprint, Optional, Path (+3 more)
 
 ### Community 155 - "Community 155"
-Cohesion: 0.07
-Nodes (28): BomConsumer, CapturingProvider, ImageProcessingActionsPlaywrightVisualTest, AlphaProvider, VisualProcessingProviderRegistryTest, ZuluProvider, AfterMethod, Boolean (+20 more)
+Cohesion: 0.16
+Nodes (12): CapturingProvider, ImageProcessingActionsPlaywrightVisualTest, AfterMethod, Boolean, By, Integer, List, Override (+4 more)
 
 ### Community 156 - "Community 156"
 Cohesion: 0.18
 Nodes (12): ScreenshotManager, Object, Boolean, By, JavascriptExecutor, List, Object, Screenshots (+4 more)
 
 ### Community 157 - "Community 157"
-Cohesion: 0.18
+Cohesion: 0.19
 Nodes (13): By, ElementActions, ElementAssertions, List, Locator, Map, Override, PlaywrightSession (+5 more)
 
 ### Community 158 - "Community 158"
 Cohesion: 0.08
-Nodes (17): JunitCoreAssertionMigrationTest, CaptureServiceTest, Role, Override, Test, AfterMethod, Test, Class (+9 more)
+Nodes (11): LocatorBuilderTest, XpathAxis, Role, LocatorBuilder, String, AfterMethod, BeforeMethod, Test (+3 more)
 
 ### Community 159 - "Community 159"
-Cohesion: 0.10
-Nodes (24): ActionReportContext, abbreviate(), empty(), FlakeProfileContext, from(), hasElementName(), hasLocator(), hasStepTarget() (+16 more)
+Cohesion: 0.11
+Nodes (23): ActionReportContext, abbreviate(), empty(), FlakeProfileContext, from(), hasElementName(), hasLocator(), hasStepTarget() (+15 more)
 
 ### Community 160 - "Community 160"
 Cohesion: 0.08
@@ -1403,7 +1414,7 @@ Cohesion: 0.13
 Nodes (4): AfterMethod, BeforeMethod, Test, NegativeValidationsTests
 
 ### Community 162 - "Community 162"
-Cohesion: 0.15
+Cohesion: 0.13
 Nodes (5): AfterMethod, BeforeMethod, Test, WebDriver, BrowserActionsCoverageUnitTest
 
 ### Community 164 - "Community 164"
@@ -1411,20 +1422,16 @@ Cohesion: 0.24
 Nodes (7): Connection, DatabaseActions, Boolean, DatabaseType, ResultSet, String, StringBuilder
 
 ### Community 165 - "Community 165"
-Cohesion: 0.10
-Nodes (15): ChromiumOptions, DesiredCapabilities, OptionsManager, OptionsManagerCoverageUnitTest, LoggingPreferences, PlatformTests, DriverType, MutableCapabilities (+7 more)
+Cohesion: 0.13
+Nodes (11): ChromiumOptions, OptionsManager, OptionsManagerCoverageUnitTest, LoggingPreferences, DriverType, MutableCapabilities, String, SuppressWarnings (+3 more)
 
 ### Community 166 - "Community 166"
-Cohesion: 0.08
-Nodes (21): PlaywrightBrowserValidationsBuilder, AccessibilityActions, BrowserActions, BrowserContext, BrowserNetworkInterceptionRule, Cookie, HttpRequest, HttpResponse (+13 more)
+Cohesion: 0.10
+Nodes (10): PlaywrightBrowserValidationsBuilder, BrowserActions, Cookie, List, Override, Page, Runnable, Set (+2 more)
 
 ### Community 167 - "Community 167"
 Cohesion: 0.19
 Nodes (7): Log4j, Log4jTests, DefaultValue, Key, String, BeforeClass, Test
-
-### Community 168 - "Community 168"
-Cohesion: 0.07
-Nodes (6): Reporting, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 169 - "Community 169"
 Cohesion: 0.18
@@ -1435,40 +1442,40 @@ Cohesion: 0.11
 Nodes (13): BrowserService, EngineServiceTest, String, TestExecutionInfo, Throwable, McpPageDomSnapshot, McpScreenshotResult, McpWorkspacePolicy (+5 more)
 
 ### Community 171 - "Community 171"
-Cohesion: 0.20
-Nodes (3): ActionSample, EvidenceEvent, ActionSample
+Cohesion: 0.18
+Nodes (12): PlaywrightNaturalActionExecutor, By, CharSequence, List, Locator, NaturalActionPlan, Object, Page (+4 more)
 
 ### Community 172 - "Community 172"
 Cohesion: 0.17
 Nodes (9): ElementSteps, getValue(), LocatorType(), By, String, SuppressWarnings, ThreadLocal, WebDriver (+1 more)
 
 ### Community 173 - "Community 173"
-Cohesion: 0.16
-Nodes (12): ValidationsHelper, Boolean, ComparisonType, LinkedHashMap, List, Number, NumbersComparativeRelation, Object (+4 more)
+Cohesion: 0.20
+Nodes (12): Boolean, ComparisonType, LinkedHashMap, List, Number, NumbersComparativeRelation, Object, Response (+4 more)
 
 ### Community 174 - "Community 174"
-Cohesion: 0.15
-Nodes (7): AttachmentSnapshot, DataProvider, Object, Path, String, Test, AttachmentReporterUnitTest
+Cohesion: 0.14
+Nodes (9): AttachmentSnapshot, getType(), Screenshots, DataProvider, Object, Path, String, Test (+1 more)
 
 ### Community 175 - "Community 175"
-Cohesion: 0.13
-Nodes (12): TouchActions, viewport(), By, HashMap, Object, Override, String, SuppressWarnings (+4 more)
+Cohesion: 0.11
+Nodes (19): getValue(), KeyboardKeys(), TouchActions, ImmutableMap, viewport(), By, DriverFactoryHelper, File (+11 more)
 
 ### Community 176 - "Community 176"
 Cohesion: 0.18
 Nodes (5): AsyncElementActions, By, ClipboardAction, DriverFactoryHelper, String
 
 ### Community 177 - "Community 177"
-Cohesion: 0.05
-Nodes (40): CookieState, BrowserStorageStateManager, CookieState, OriginStorage, StorageState, disabled(), TraceEventRecorder, Iterable (+32 more)
+Cohesion: 0.08
+Nodes (28): CookieState, BrowserStorageStateManager, CookieState, OriginStorage, StorageState, disabled(), TraceEventRecorder, Iterable (+20 more)
 
 ### Community 178 - "Community 178"
-Cohesion: 0.20
-Nodes (9): TestAutomationService, McpCodeGuardrailResult, McpCodeGuardrailViolation, McpScenarioCatalogResult, McpTestAutomationScenario, List, Pattern, String (+1 more)
+Cohesion: 0.24
+Nodes (6): TestAutomationService, McpCodeGuardrailViolation, McpTestAutomationScenario, List, Pattern, String
 
 ### Community 179 - "Community 179"
-Cohesion: 0.12
-Nodes (23): DoctorAiAnalysisService, ConfigurationIdentity, AiRequest, AiResponse, AiResponseStatus, AiUsage, CauseCategory, Diagnosis (+15 more)
+Cohesion: 0.07
+Nodes (29): DoctorAiAnalysisService, ConfigurationIdentity, CoverageTests, AiRequest, AiResponse, AiResponseStatus, AiUsage, CauseCategory (+21 more)
 
 ### Community 180 - "Community 180"
 Cohesion: 0.17
@@ -1483,11 +1490,11 @@ Cohesion: 0.11
 Nodes (7): Playwright, PlaywrightSetProperty, PlaywrightSetProperty, DefaultValue, Key, Override, String
 
 ### Community 183 - "Community 183"
-Cohesion: 0.27
+Cohesion: 0.28
 Nodes (8): FingerprintExtractor, HealingConfiguration, LocatorFingerprint, Map, String, Supplier, WebDriver, WebElement
 
 ### Community 184 - "Community 184"
-Cohesion: 0.23
+Cohesion: 0.22
 Nodes (6): Internal, InternalTests, DefaultValue, Key, String, Test
 
 ### Community 185 - "Community 185"
@@ -1495,8 +1502,8 @@ Cohesion: 0.39
 Nodes (6): ByteArrayOutputStream, Severity, Story, String, Test, AllAttachmentTypesTest
 
 ### Community 186 - "Community 186"
-Cohesion: 0.19
-Nodes (8): TestNG, TestNGTests, XmlSuite, DefaultValue, Integer, Key, String, Test
+Cohesion: 0.13
+Nodes (13): TestNG, TestNGTests, Browser, ISuite, ITestNGMethod, List, Method, XmlSuite (+5 more)
 
 ### Community 187 - "Community 187"
 Cohesion: 0.08
@@ -1511,8 +1518,8 @@ Cohesion: 0.13
 Nodes (16): Bean, BrowserService, ElementService, GuideService, ShaftMcpApplication, MobileService, NaturalActionService, PlaywrightService (+8 more)
 
 ### Community 190 - "Community 190"
-Cohesion: 0.32
-Nodes (7): LocatorRankerTest, ElementSnapshot, List, LocatorCandidate, LocatorStrategy, String, Test
+Cohesion: 0.12
+Nodes (19): ActiveRetryAttempt, AfterAllCallback, AfterEachCallback, AfterTestExecutionCallback, BeforeAllCallback, BeforeEachCallback, DiscoverySelector, LauncherDiscoveryRequest (+11 more)
 
 ### Community 191 - "Community 191"
 Cohesion: 0.18
@@ -1535,24 +1542,24 @@ Cohesion: 0.17
 Nodes (19): build_parser(), collect_metrics(), issue(), main(), Run one external check and return a concise issue on failure., Collect stable context and memory size metrics., Run all agent setup checks., Build the command-line parser. (+11 more)
 
 ### Community 196 - "Community 196"
-Cohesion: 0.08
-Nodes (18): FileValidationsBuilder, AssertEqualsTests, VerifyEqualsTests, NativeValidationsBuilder, String, StringBuilder, SuppressWarnings, ValidationCategory (+10 more)
+Cohesion: 0.18
+Nodes (7): AssertEqualsTests, VerifyEqualsTests, BeforeMethod, Test, AfterMethod, BeforeMethod, Test
 
 ### Community 197 - "Community 197"
-Cohesion: 0.22
-Nodes (5): ElementActions, ElementActionsMockedTests, AfterMethod, BeforeMethod, Test
+Cohesion: 0.24
+Nodes (4): ElementActionsMockedTests, AfterMethod, BeforeMethod, Test
 
 ### Community 198 - "Community 198"
 Cohesion: 0.18
 Nodes (6): ElementInformation, ElementInformationCoverageUnitTest, Element, List, String, Test
 
 ### Community 199 - "Community 199"
-Cohesion: 0.11
-Nodes (16): RequestBuilderPerformanceTest, RequestBuilderTests, RestAssuredConfig, ContentType, ParametersType, AfterMethod, RequestType, RestActions (+8 more)
+Cohesion: 0.13
+Nodes (15): RequestBuilderPerformanceTest, RequestBuilderTests, ContentType, ParametersType, AfterMethod, RequestType, RestActions, String (+7 more)
 
 ### Community 200 - "Community 200"
-Cohesion: 0.05
-Nodes (33): AiAuditSink, ShaftAiAuditSink, FailureBriefReporter, FailureBriefReporterTest, ReportContext, JunitReportContextTest, AttachmentRecord, List (+25 more)
+Cohesion: 0.06
+Nodes (28): FailureBriefReporter, FailureBriefReporterTest, ReportContext, JunitReportContextTest, AttachmentRecord, List, Redactor, SourceContext (+20 more)
 
 ### Community 201 - "Community 201"
 Cohesion: 0.11
@@ -1567,12 +1574,12 @@ Cohesion: 0.19
 Nodes (12): OpenAiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode, Map (+4 more)
 
 ### Community 205 - "Community 205"
-Cohesion: 0.13
-Nodes (6): Boolean, By, NumbersComparativeRelation, Object, String, JavaHelper
+Cohesion: 0.18
+Nodes (9): AccessibilityActions, AccessibilityConfig, AccessibilityResult, BrowserActions, BrowserActionsContract, List, Page, String (+1 more)
 
 ### Community 206 - "Community 206"
-Cohesion: 0.09
-Nodes (8): SetProperty, Timeouts, Boolean, DefaultValue, Deprecated, Key, SetProperty, String
+Cohesion: 0.15
+Nodes (3): SetProperty, Deprecated, String
 
 ### Community 207 - "Community 207"
 Cohesion: 0.23
@@ -1583,20 +1590,20 @@ Cohesion: 0.21
 Nodes (18): A(), ba(), c(), D(), E(), G(), i(), j() (+10 more)
 
 ### Community 209 - "Community 209"
-Cohesion: 0.05
-Nodes (48): AlertEvent, ArtifactPaths, AssertionSuggestion, DataPlan, CaptureGenerator, CodegenBackend(), driverClassName(), failure() (+40 more)
+Cohesion: 0.08
+Nodes (31): AlertEvent, AssertionSuggestion, DataPlan, CaptureGenerator, CodegenBackend(), driverClassName(), from(), MutableTargetPlan (+23 more)
 
 ### Community 210 - "Community 210"
-Cohesion: 0.13
-Nodes (7): LocatorBuilderTest, XpathAxis, LocatorBuilder, String, AfterMethod, BeforeMethod, Test
+Cohesion: 0.15
+Nodes (10): CaptureFormatException, McpResultRecordsTest, McpWorkspacePolicy, String, Throwable, IllegalArgumentException, List, Path (+2 more)
 
 ### Community 211 - "Community 211"
 Cohesion: 0.18
 Nodes (13): DoctorRepairPatchResult, DoctorRepairAiService, AiRequest, AiResponse, AiResponseStatus, Diagnosis, DoctorRepairAiRequest, EvidenceReference (+5 more)
 
 ### Community 212 - "Community 212"
-Cohesion: 0.24
-Nodes (8): GuardedPatch, RepairGuard, FilePatch, List, Path, Set, String, ValidationCommand
+Cohesion: 0.16
+Nodes (12): McpPlaywrightRecordingService, List, locatorStrategy, Map, McpCodeBlock, McpMobileRecordedAction, McpMobileRecording, McpMobileRecordingStatus (+4 more)
 
 ### Community 213 - "Community 213"
 Cohesion: 0.16
@@ -1607,16 +1614,16 @@ Cohesion: 0.17
 Nodes (7): RetryPolicy, Duration, Integer, RequestType, Set, String, Throwable
 
 ### Community 215 - "Community 215"
-Cohesion: 0.12
-Nodes (22): minLength, type, properties, $ref, $ref, $ref, body, evidence (+14 more)
+Cohesion: 0.14
+Nodes (18): minLength, type, properties, $ref, $ref, body, facets, origin (+10 more)
 
 ### Community 216 - "Community 216"
-Cohesion: 0.24
-Nodes (10): expired(), InstantDeadline(), ManagedCaptureRecorderBrowserTest, Duration, HttpExchange, HttpServer, ParameterizedTest, Path (+2 more)
+Cohesion: 0.20
+Nodes (11): expired(), InstantDeadline(), ManagedCaptureRecorderBrowserTest, BooleanSupplier, Duration, HttpExchange, HttpServer, ParameterizedTest (+3 more)
 
 ### Community 217 - "Community 217"
-Cohesion: 0.25
-Nodes (5): AndroidDragAndDropTest, MobileTest, Test, AfterMethod, BeforeMethod
+Cohesion: 0.17
+Nodes (7): AndroidDragAndDropTest, FileUploadDownloadTest, MobileTest, Test, Test, AfterMethod, BeforeMethod
 
 ### Community 218 - "Community 218"
 Cohesion: 0.24
@@ -1639,19 +1646,19 @@ Cohesion: 0.20
 Nodes (8): ExecutionLifecycleHelper, List, Method, RunType, Status, StatusIcon, String, TestExecutionInfo
 
 ### Community 223 - "Community 223"
-Cohesion: 0.12
-Nodes (16): AllureVerdict, Operation, PatchManifestEntry, changedSince(), RepairGuard, RepairProposalStore, AllureSnapshot, Diagnosis (+8 more)
+Cohesion: 0.38
+Nodes (3): AfterMethod, BeforeMethod, Method
 
 ### Community 224 - "Community 224"
 Cohesion: 0.19
 Nodes (6): Healenium, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 225 - "Community 225"
-Cohesion: 0.16
+Cohesion: 0.17
 Nodes (8): KeysetHandle, GoogleTink, GoogleTinkApiCoverageUnitTest, String, AfterMethod, BeforeMethod, Path, Test
 
 ### Community 226 - "Community 226"
-Cohesion: 0.18
+Cohesion: 0.19
 Nodes (11): ManagedCaptureRecorder, CaptureManager, CaptureStartRequest, CaptureStatus, CheckpointKind, Function, ManagedCaptureRecorder, Override (+3 more)
 
 ### Community 227 - "Community 227"
@@ -1667,8 +1674,8 @@ Cohesion: 0.21
 Nodes (3): Method, Test, JavaScriptWaitManagerUnitTest
 
 ### Community 230 - "Community 230"
-Cohesion: 0.15
-Nodes (3): CSVFileManager, List, String
+Cohesion: 0.17
+Nodes (4): AfterClass, BeforeClass, Test, APITests
 
 ### Community 231 - "Community 231"
 Cohesion: 0.18
@@ -1677,10 +1684,6 @@ Nodes (3): AfterMethod, Test, RestActionsUtilsUnitTest
 ### Community 232 - "Community 232"
 Cohesion: 0.17
 Nodes (10): PilotTestConfiguration, RedactionPolicy, RedactionResult, Redactor, AiRequest, Set, String, PilotConfiguration (+2 more)
-
-### Community 233 - "Community 233"
-Cohesion: 0.08
-Nodes (7): PropertiesHelper, RunType, String, AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
 
 ### Community 234 - "Community 234"
 Cohesion: 0.18
@@ -1699,12 +1702,12 @@ Cohesion: 0.17
 Nodes (3): AfterMethod, Test, TextDirectionValidationsBuilderUnitTest
 
 ### Community 239 - "Community 239"
-Cohesion: 0.11
-Nodes (20): HealingManager, current(), HealingStrategy(), parse(), usesHealenium(), usesShaftHeal(), HealingStrategyTest, By (+12 more)
+Cohesion: 0.22
+Nodes (10): HealingManager, By, HealingExplanation, HealingProvider, HealingResolution, List, Optional, String (+2 more)
 
 ### Community 240 - "Community 240"
-Cohesion: 0.26
-Nodes (5): RestValidationsBuilder, JSONValidationsBuilder, NativeValidationsBuilder, String, ValidationsExecutor
+Cohesion: 0.19
+Nodes (15): RecordingRunner, DoctorRepairServiceTest, RecordingRunner, RepairProcessRunner, RepositoryFixture, DoctorRepairRequest, Duration, FilePatch (+7 more)
 
 ### Community 241 - "Community 241"
 Cohesion: 0.23
@@ -1719,12 +1722,12 @@ Cohesion: 0.18
 Nodes (9): Actions, AfterMethod, BeforeMethod, ElementActions, MockedConstruction, Object, String, Test (+1 more)
 
 ### Community 244 - "Community 244"
-Cohesion: 0.22
+Cohesion: 0.24
 Nodes (6): McpRuntimePaths, McpRuntimePathsTest, Map, Path, String, Test
 
 ### Community 245 - "Community 245"
-Cohesion: 0.17
-Nodes (13): AiImage, AnthropicProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode (+5 more)
+Cohesion: 0.19
+Nodes (12): AnthropicProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode, Map (+4 more)
 
 ### Community 246 - "Community 246"
 Cohesion: 0.10
@@ -1747,28 +1750,28 @@ Cohesion: 0.50
 Nodes (3): Source-file rewrites prepared for session or full upgrades., Return source files whose contents should be replaced., SourceMigration
 
 ### Community 251 - "Community 251"
-Cohesion: 0.14
-Nodes (6): CoverageTests, AfterClass, AfterMethod, BeforeClass, BeforeMethod, Test
+Cohesion: 0.21
+Nodes (10): HealingSupport, nativePlatform(), By, HealingContext, HealingPlatform, RemoteWebDriver, String, Supplier (+2 more)
 
 ### Community 252 - "Community 252"
-Cohesion: 0.16
-Nodes (10): FileUploadDownloadTest, getValue(), KeyboardKeys(), ImmutableMap, KeyboardKeys, DriverFactoryHelper, File, List (+2 more)
+Cohesion: 0.21
+Nodes (4): AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
 
 ### Community 253 - "Community 253"
-Cohesion: 0.06
-Nodes (31): ByAll, CompositeLocator, SmartLocator, SmartLocators, DeterministicNaturalActionPlannerTest, NaturalActionCompositeLocator, PlaywrightNaturalActionExecutor, PathStrategy (+23 more)
+Cohesion: 0.23
+Nodes (8): ByAll, SmartLocator, SmartLocators, PathStrategy, By, List, Override, String
 
 ### Community 254 - "Community 254"
-Cohesion: 0.09
-Nodes (14): ExecutionSummaryReport, StatusIcon(), TestNGListenerHelper, Browser, ISuite, ITestContext, ITestNGMethod, ITestResult (+6 more)
+Cohesion: 0.13
+Nodes (6): TestNGListenerHelper, ITestContext, ITestResult, String, TestExecutionInfo, XmlTest
 
 ### Community 255 - "Community 255"
 Cohesion: 0.23
 Nodes (7): DoctorRedactor, RedactorTest, JsonNode, List, ObjectNode, String, Test
 
 ### Community 256 - "Community 256"
-Cohesion: 0.18
-Nodes (7): ElementActionsHelper, FailureReporter, Class, String, Throwable, Test, FailureReporterUnitTest
+Cohesion: 0.21
+Nodes (6): FailureReporter, Class, String, Throwable, Test, FailureReporterUnitTest
 
 ### Community 257 - "Community 257"
 Cohesion: 0.27
@@ -1783,8 +1786,8 @@ Cohesion: 0.19
 Nodes (7): ShaftLocator, By, Locator, Override, Page, String, Strategy
 
 ### Community 260 - "Community 260"
-Cohesion: 0.25
-Nodes (4): Jira, DefaultValue, Key, SetProperty
+Cohesion: 0.19
+Nodes (8): String, AfterMethod, AtomicInteger, Set, String, SuppressWarnings, Test, CucumberTestsHelperCoverageUnitTest
 
 ### Community 261 - "Community 261"
 Cohesion: 0.23
@@ -1796,15 +1799,15 @@ Nodes (25): CommandResult, confirm_upgrade(), default_compile_command(), extract
 
 ### Community 263 - "Community 263"
 Cohesion: 0.08
-Nodes (16): PlaywrightBrowserActionsUnitTest, PlaywrightSession, PlaywrightNetworkInterceptor, PlaywrightTraceManager, AlertActions, Override, PlaywrightSession, String (+8 more)
+Nodes (15): PlaywrightBrowserActionsUnitTest, PlaywrightSession, PlaywrightNetworkInterceptor, AlertActions, Override, PlaywrightSession, String, Browser (+7 more)
 
 ### Community 264 - "Community 264"
-Cohesion: 0.13
-Nodes (5): NumberValidationsBuilder, AfterMethod, BeforeClass, Test, RestValidationsBuilderUnitTest
+Cohesion: 0.08
+Nodes (14): RestValidationsBuilder, JSONValidationsBuilder, JsonCompareWithSpecialCharactersTests, NativeValidationsBuilder, NumberValidationsBuilder, Object, String, StringBuilder (+6 more)
 
 ### Community 265 - "Community 265"
-Cohesion: 0.09
-Nodes (19): BrowsingContextInfo, BidiBrowserEventCollector, BrowserEventCollector, CompositeBrowserEventCollector, BrowserSignal, Consumer, List, Override (+11 more)
+Cohesion: 0.15
+Nodes (11): BrowserEventCollector, CompositeBrowserEventCollector, BrowserSignal, Consumer, Override, String, BrowserSignal, Consumer (+3 more)
 
 ### Community 266 - "Community 266"
 Cohesion: 0.25
@@ -1819,16 +1822,16 @@ Cohesion: 0.28
 Nodes (7): LocatorRanker, ScoredLocator, ElementSnapshot, EventContext, LocatorCandidate, LocatorSelection, String
 
 ### Community 269 - "Community 269"
-Cohesion: 0.10
-Nodes (17): StandaloneAssertions, StandaloneVerifications, WebDriverAssertions, WebDriverVerifications, WizardHelpers, By, DriverFactoryHelper, FileValidationsBuilder (+9 more)
+Cohesion: 0.19
+Nodes (10): WebDriverAssertions, WebDriverVerifications, WizardHelpers, By, DriverFactoryHelper, NativeValidationsBuilder, Object, Override (+2 more)
 
 ### Community 270 - "Community 270"
 Cohesion: 0.25
 Nodes (4): MultipleDriverSessionTerminationTest, AfterMethod, BeforeMethod, Test
 
 ### Community 271 - "Community 271"
-Cohesion: 0.33
-Nodes (6): HealingLocatorProposalServiceTest, AfterEach, BeforeEach, Path, String, Test
+Cohesion: 0.16
+Nodes (6): FlakeProfileContext, ActionSample, FlakeProfilerUnitTest, AfterMethod, BeforeMethod, Test
 
 ### Community 272 - "Community 272"
 Cohesion: 0.20
@@ -1839,12 +1842,12 @@ Cohesion: 0.31
 Nodes (5): HealingLocatorProposalService, HealingLocatorProposal, JsonNode, Path, String
 
 ### Community 274 - "Community 274"
-Cohesion: 0.14
-Nodes (12): AfterMethod, AndroidDriver, AtomicReference, BeforeMethod, CountDownLatch, InputStream, Override, String (+4 more)
+Cohesion: 0.11
+Nodes (16): IOSDriver, InputStream, Path, String, SuppressWarnings, WebDriver, AfterMethod, AndroidDriver (+8 more)
 
 ### Community 275 - "Community 275"
-Cohesion: 0.20
-Nodes (3): CSVFileManagerTest, BeforeMethod, Test
+Cohesion: 0.19
+Nodes (10): current(), HealingStrategy(), parse(), usesHealenium(), usesShaftHeal(), HealingStrategyTest, String, AfterMethod (+2 more)
 
 ### Community 276 - "Community 276"
 Cohesion: 0.19
@@ -1863,8 +1866,8 @@ Cohesion: 0.17
 Nodes (8): FailureTraceReporterTest, AndroidDriver, Attachment, List, Path, RuntimeException, SuppressWarnings, Test
 
 ### Community 281 - "Community 281"
-Cohesion: 0.26
-Nodes (5): CheckpointStatus, CheckpointType, String, Test, CheckpointAndReportingTest
+Cohesion: 0.19
+Nodes (6): CheckpointCounter, CheckpointStatus, CheckpointType, String, Test, CheckpointAndReportingTest
 
 ### Community 282 - "Community 282"
 Cohesion: 0.24
@@ -1879,16 +1882,16 @@ Cohesion: 0.18
 Nodes (6): BrowserSteps, Given, String, ThreadLocal, WebDriver, When
 
 ### Community 285 - "Community 285"
-Cohesion: 0.31
-Nodes (5): BrowserStackSdkHelper, List, Map, Object, String
+Cohesion: 0.13
+Nodes (14): AlphaProvider, VisualProcessingProviderRegistryTest, ZuluProvider, AfterMethod, Boolean, By, Integer, List (+6 more)
 
 ### Community 286 - "Community 286"
 Cohesion: 0.18
 Nodes (7): HealingActionsIntegrationTest, AfterMethod, BeforeMethod, DataProvider, Object, String, Test
 
 ### Community 287 - "Community 287"
-Cohesion: 0.15
-Nodes (9): McpAppiumCommandRecorderTest, McpServiceHelperTest, MobileRecordingServiceTest, Test, Class, Object, String, Test (+1 more)
+Cohesion: 0.25
+Nodes (6): McpServiceHelperTest, AfterEach, Class, Object, String, Test
 
 ### Community 288 - "Community 288"
 Cohesion: 0.16
@@ -1910,6 +1913,10 @@ Nodes (4): IOActionsMockedTests, AfterMethod, BeforeMethod, Test
 Cohesion: 0.22
 Nodes (8): NaturalActionExecutorTest, AfterMethod, BeforeMethod, By, List, Test, WebDriver, WebElement
 
+### Community 294 - "Community 294"
+Cohesion: 0.21
+Nodes (5): Timeouts, Boolean, DefaultValue, Key, SetProperty
+
 ### Community 295 - "Community 295"
 Cohesion: 0.19
 Nodes (11): PlaywrightServiceTest, DoctorReportWriter, Diagnosis, DoctorAdvisory, EvidenceBundle, List, Path, String (+3 more)
@@ -1923,84 +1930,84 @@ Cohesion: 0.12
 Nodes (17): pattern, type, origin, pattern, type, minLength, type, minLength (+9 more)
 
 ### Community 298 - "Community 298"
-Cohesion: 0.12
-Nodes (17): additionalProperties, required, type, $defs, createObject, evidence, objectId, relationId (+9 more)
+Cohesion: 0.10
+Nodes (21): additionalProperties, required, type, $defs, createObject, evidence, objectId, relationId (+13 more)
 
 ### Community 299 - "Community 299"
 Cohesion: 0.21
 Nodes (4): AfterClass, BeforeClass, Test, FileHelperUnitTest
 
 ### Community 300 - "Community 300"
-Cohesion: 0.22
-Nodes (7): ManagedCaptureRecorderControlTest, CaptureBrowser, CaptureStartOptions, CaptureStartRequest, Object, SuppressWarnings, Test
+Cohesion: 0.18
+Nodes (8): CaptureEventPipeline, ManagedCaptureRecorderControlTest, CaptureBrowser, CaptureStartOptions, CaptureStartRequest, Object, SuppressWarnings, Test
 
 ### Community 301 - "Community 301"
-Cohesion: 0.21
-Nodes (10): HealingSupport, nativePlatform(), By, HealingContext, HealingPlatform, RemoteWebDriver, String, Supplier (+2 more)
+Cohesion: 0.30
+Nodes (4): CaptureServiceTest, CaptureService, Path, Test
 
 ### Community 302 - "Community 302"
 Cohesion: 0.21
 Nodes (9): fixture_commands(), main(), maven_executable(), missing_publication_paths(), publication_paths(), verify_release(), write_settings(), Path (+1 more)
 
 ### Community 303 - "Community 303"
-Cohesion: 0.18
-Nodes (9): InterceptorFactory, BrowserNetworkInterceptor, InterceptorFactory, BrowserNetworkInterceptionRule, HttpRequest, HttpResponse, Override, Response (+1 more)
+Cohesion: 0.16
+Nodes (10): InterceptorFactory, BrowserNetworkInterceptor, InterceptorFactory, BrowserNetworkInterceptionRule, Filter, HttpRequest, HttpResponse, Override (+2 more)
 
 ### Community 305 - "Community 305"
-Cohesion: 0.20
-Nodes (7): AfterMethod, InputStream, Override, String, Test, DesktopVideoRecordingProviderRegistryTest, StubDesktopVideoRecordingProvider
+Cohesion: 0.13
+Nodes (11): DesktopVideoRecordingProvider, AfterMethod, InputStream, Override, String, Test, Override, String (+3 more)
 
 ### Community 306 - "Community 306"
 Cohesion: 0.22
 Nodes (8): AccessibilityResult, AfterMethod, BeforeMethod, List, Rule, String, Test, AccessibilityActionsCoverageUnitTest
 
 ### Community 307 - "Community 307"
-Cohesion: 0.23
-Nodes (9): VisualEvidenceService, Double, HealingConfiguration, HealingVisualProvider, List, Optional, RankedCandidate, String (+1 more)
+Cohesion: 0.11
+Nodes (15): DisabledAiProvider, AiProvider, DoctorSnippetProvider, AfterEach, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse (+7 more)
 
 ### Community 308 - "Community 308"
-Cohesion: 0.25
-Nodes (6): FileActionsCoverageUnitTest, AfterMethod, BeforeMethod, Path, String, Test
+Cohesion: 0.33
+Nodes (3): FileActionsReflectionInvoker, FileActions, String
 
 ### Community 309 - "Community 309"
-Cohesion: 0.24
+Cohesion: 0.23
 Nodes (5): ValidationsHelperCoverageUnitTest, AssertionError, AfterMethod, SuppressWarnings, Test
 
 ### Community 311 - "Community 311"
-Cohesion: 0.14
-Nodes (10): AllureCucumber7Jvm, CucumberTestRunnerListener, EventPublisher, Feature, Optional, Override, TestCaseFinished, TestSourceParsed (+2 more)
+Cohesion: 0.18
+Nodes (9): AllureCucumber7Jvm, CucumberTestRunnerListener, EventPublisher, Feature, Optional, Override, TestSourceParsed, TestStepStarted (+1 more)
 
 ### Community 312 - "Community 312"
-Cohesion: 0.21
-Nodes (6): VisualProcessingProviderRegistry, Integer, List, List, Optional, VisualProcessingProvider
+Cohesion: 0.14
+Nodes (12): ImageProcessingActions, Boolean, By, File, Integer, List, String, VisualValidationEngine (+4 more)
 
 ### Community 313 - "Community 313"
 Cohesion: 0.27
 Nodes (7): CaptureControlClient, CaptureStatus, CheckpointKind, List, Object, Path, String
 
 ### Community 314 - "Community 314"
-Cohesion: 0.09
-Nodes (16): DesktopVideoRecordingProvider, FileInputStream, DesktopVideoConsumer, IOException, IVideoRecorder, JsonActionsTests, RepairProposalStore, Path (+8 more)
+Cohesion: 0.29
+Nodes (6): File, InputStream, Override, String, SuppressWarnings, AutomationRemarksDesktopVideoRecordingProvider
 
 ### Community 315 - "Community 315"
 Cohesion: 0.16
 Nodes (9): HealingProvider, HealingActionOutcome, HealingExplanation, HealingObservation, HealingRequest, HealingResolution, Optional, String (+1 more)
 
 ### Community 316 - "Community 316"
-Cohesion: 0.10
-Nodes (16): ArrayList, Callable, FilesSize, CheckpointCounter, FailureDiagnosticsReporterTest, Path, Test, Attachment (+8 more)
+Cohesion: 0.20
+Nodes (9): FailureDiagnosticsReporterTest, Attachment, List, RuntimeException, String, SuppressWarnings, Test, TestExecutionInfo (+1 more)
 
 ### Community 317 - "Community 317"
-Cohesion: 0.29
-Nodes (4): SilentElementReader, By, String, WebDriver
+Cohesion: 0.16
+Nodes (8): Actions, SilentElementReader, ValidationsHelper, By, CheckpointType, Map, String, WebDriver
 
 ### Community 318 - "Community 318"
 Cohesion: 0.14
 Nodes (14): DecisionResult, DeterministicScorerTest, HealingDecisionEngine, HealingConfiguration, List, RankedCandidate, Status, String (+6 more)
 
 ### Community 319 - "Community 319"
-Cohesion: 0.06
-Nodes (28): Cucumber, CucumberHelper, ProgressBarLogger, ProgressBarLoggerCoverageUnitTest, ProgressBarLoggerTestAccessor, CucumberTests, List, Status (+20 more)
+Cohesion: 0.42
+Nodes (4): Cucumber, DefaultValue, Key, String
 
 ### Community 320 - "Community 320"
 Cohesion: 0.31
@@ -2035,8 +2042,8 @@ Cohesion: 0.21
 Nodes (7): AfterMethod, BeforeClass, BeforeMethod, Override, String, Test, TestClass
 
 ### Community 329 - "Community 329"
-Cohesion: 0.16
-Nodes (6): AndroidBasicInteractionsTests, NoSuchElementFailureTest, Test, AfterMethod, BeforeMethod, Test
+Cohesion: 0.08
+Nodes (13): AndroidBasicInteractionsTests, AndroidTouchActionsTests, MultipleElementsFailureTest, NoSuchElementFailureTest, ScreenOrientation, Test, Test, AfterMethod (+5 more)
 
 ### Community 330 - "Community 330"
 Cohesion: 0.18
@@ -2051,12 +2058,12 @@ Cohesion: 0.19
 Nodes (14): A(), Ae(), b(), ce(), ge(), le(), pe(), qe() (+6 more)
 
 ### Community 333 - "Community 333"
-Cohesion: 0.06
-Nodes (27): empty(), reviewUiPath(), McpMobileToolchainServiceTest, disabled(), McpResultRecordsTest, defaults(), lower(), normalizePath() (+19 more)
+Cohesion: 0.24
+Nodes (5): List, Set, String, Test, TelemetryDeduplicationUnitTest
 
 ### Community 334 - "Community 334"
-Cohesion: 0.20
-Nodes (11): notRequested(), skipped(), McpCaptureCodeBlockServiceTest, Enrichment, String, Validation, List, McpCodeBlock (+3 more)
+Cohesion: 0.25
+Nodes (8): notRequested(), McpCaptureCodeBlockServiceTest, Enrichment, List, McpCodeBlock, Path, String, Test
 
 ### Community 335 - "Community 335"
 Cohesion: 0.17
@@ -2071,24 +2078,24 @@ Cohesion: 0.15
 Nodes (8): EXCEL, ExcelFileManager, TestDataTests, String, Test, BeforeClass, Test, IoExcelFileManagerTests
 
 ### Community 338 - "Community 338"
-Cohesion: 0.19
-Nodes (8): DisabledAiProvider, AiProvider, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse, Override, String
+Cohesion: 0.15
+Nodes (11): ready(), unavailable(), AiValueObjectsTest, allows(), ApprovalPolicy(), AiProviderAvailability, String, EvidenceCategory (+3 more)
 
 ### Community 339 - "Community 339"
 Cohesion: 0.26
 Nodes (6): ModelSupport, JsonNode, List, Map, String, T
 
 ### Community 340 - "Community 340"
-Cohesion: 0.20
-Nodes (6): OpenApiCoverageReporter, HttpMethod, RequestType, String, Throwable, SpecCoverage
+Cohesion: 0.08
+Nodes (20): OpenApiCoverageReporter, OperationCoverage, SpecCoverage, OpenApiCoverageReporterUnitTest, OpenAPI, OpenApiValidationException, OpenApiValidationFilter, OperationCoverage (+12 more)
 
 ### Community 341 - "Community 341"
 Cohesion: 0.14
 Nodes (14): items, tags, items, additionalProperties, minLength, pattern, properties, required (+6 more)
 
 ### Community 342 - "Community 342"
-Cohesion: 0.18
-Nodes (8): ElementStepsCoverageUnitTest, ClipboardAction, BeforeMethod, By, DataProvider, Object, String, Test
+Cohesion: 0.22
+Nodes (7): ElementStepsCoverageUnitTest, BeforeMethod, By, DataProvider, Object, String, Test
 
 ### Community 343 - "Community 343"
 Cohesion: 0.25
@@ -2103,16 +2110,16 @@ Cohesion: 0.23
 Nodes (12): ActionMetadata, disabled(), HealingReport(), minimized(), pending(), ProviderMetadata(), PrivacyMetadata, HealingCandidate (+4 more)
 
 ### Community 346 - "Community 346"
-Cohesion: 0.35
-Nodes (3): BrowserEventScript, List, String
+Cohesion: 0.24
+Nodes (8): BrowsingContextInfo, BidiBrowserEventCollector, BrowserSignal, Consumer, List, Override, String, WebDriver
 
 ### Community 347 - "Community 347"
-Cohesion: 0.14
-Nodes (11): MultipleElementsFoundException, IOSDriver, String, Throwable, InputStream, Path, String, SuppressWarnings (+3 more)
+Cohesion: 0.18
+Nodes (7): FileValidationsBuilder, NativeValidationsBuilder, String, StringBuilder, SuppressWarnings, ValidationCategory, ValidationsExecutor
 
 ### Community 348 - "Community 348"
-Cohesion: 0.17
-Nodes (8): ScreenshotHelperCoverageUnitTest, String, AfterMethod, BeforeMethod, Color, Object, String, Test
+Cohesion: 0.15
+Nodes (10): HasCdp, Image, ScreenshotHelperCoverageUnitTest, BufferedImage, AfterMethod, BeforeMethod, Color, Object (+2 more)
 
 ### Community 349 - "Community 349"
 Cohesion: 0.26
@@ -2135,8 +2142,8 @@ Cohesion: 0.23
 Nodes (5): AfterMethod, BeforeMethod, Path, Test, ExcelFileManagerCoverageUnitTest
 
 ### Community 354 - "Community 354"
-Cohesion: 0.08
-Nodes (11): Locator, LocatorMockedTests, ShadowLocatorBuilder, Beta, By, LocatorBuilder, String, Test (+3 more)
+Cohesion: 0.06
+Nodes (23): ElementActionabilityDiagnostics, Locator, LocatorMockedTests, ShadowLocatorBuilder, By, List, Map, Object (+15 more)
 
 ### Community 356 - "Community 356"
 Cohesion: 0.22
@@ -2171,8 +2178,8 @@ Cohesion: 0.29
 Nodes (5): HttpExchange, HttpServer, Override, String, LocalApiServer
 
 ### Community 364 - "Community 364"
-Cohesion: 0.13
-Nodes (6): NetworkInterceptionTest, SmartLocatorsTests, Test, AfterMethod, BeforeMethod, Tests
+Cohesion: 0.14
+Nodes (9): BasicAuthenticationTests, NetworkInterceptionTest, TableTests, Test, Test, String, AfterMethod, BeforeMethod (+1 more)
 
 ### Community 365 - "Community 365"
 Cohesion: 0.29
@@ -2211,12 +2218,12 @@ Cohesion: 0.11
 Nodes (7): RestActionsCoverageUnitTest, JSONValidationsBuilder, Object, RestValidationsBuilder, ValidationsExecutor, AfterMethod, Test
 
 ### Community 374 - "Community 374"
-Cohesion: 0.15
-Nodes (9): ExecutableInvoker, JunitExtensionLifecycleTest, LauncherRetryFixture, AfterEach, ExtensionContext, Issue, Method, String (+1 more)
+Cohesion: 0.10
+Nodes (14): ExhaustedLauncherRetryFixture, JunitExtensionLifecycleTest, LauncherRetryFixture, OuterSessionStateRetryFixture, Order, AfterEach, BeforeAll, BeforeEach (+6 more)
 
 ### Community 375 - "Community 375"
-Cohesion: 0.24
-Nodes (9): AccessibilityActions, BrowserNetworkInterceptionRule, DriverFactoryHelper, HttpRequest, HttpResponse, Predicate, Step, URI (+1 more)
+Cohesion: 0.22
+Nodes (8): AccessibilityActions, BrowserNetworkInterceptionRule, DriverFactoryHelper, HttpRequest, HttpResponse, Predicate, Step, WebDriver
 
 ### Community 376 - "Community 376"
 Cohesion: 0.17
@@ -2237,6 +2244,10 @@ Nodes (6): MobileTraceMetadata, Capabilities, JavascriptExecutor, Map, String, W
 ### Community 380 - "Community 380"
 Cohesion: 0.25
 Nodes (13): apply(), applyEnabled(), current(), NaturalActionService, textOrDefault(), withOverrides(), McpNaturalActionResult, NaturalActionSettings (+5 more)
+
+### Community 381 - "Community 381"
+Cohesion: 0.11
+Nodes (15): Autowired, LogRedirector, Logger, LocatorOperation, Level, Override, By, EngineService (+7 more)
 
 ### Community 382 - "Community 382"
 Cohesion: 0.32
@@ -2264,7 +2275,7 @@ Nodes (7): HealingVisualProvider, OpenCvHealingVisualProvider, OpenCvHealingVisu
 
 ### Community 388 - "Community 388"
 Cohesion: 0.17
-Nodes (12): type, properties, minLength, type, content, mediaType, redacted, relativePath (+4 more)
+Nodes (12): type, items, properties, required, type, content, redacted, relativePath (+4 more)
 
 ### Community 389 - "Community 389"
 Cohesion: 0.26
@@ -2279,12 +2290,12 @@ Cohesion: 0.26
 Nodes (4): LocatorHealthReporterUnitTest, AfterMethod, BeforeMethod, Test
 
 ### Community 392 - "Community 392"
-Cohesion: 0.35
+Cohesion: 0.36
 Nodes (4): HttpExchange, Path, String, TestPageServer
 
 ### Community 394 - "Community 394"
-Cohesion: 0.18
-Nodes (8): LocatorOperation, ScreenOrientation, By, List, Path, RuntimeException, WebDriver, SupportsContextSwitching
+Cohesion: 0.24
+Nodes (6): Class, Object, String, SuppressWarnings, Test, SmartLocatorsCoverageUnitTest
 
 ### Community 395 - "Community 395"
 Cohesion: 0.26
@@ -2311,11 +2322,11 @@ Cohesion: 0.49
 Nodes (10): create_bundle(), main(), _parse(), _text(), validate_jar_contents(), validate_publication(), validate_sbom(), _version() (+2 more)
 
 ### Community 401 - "Community 401"
-Cohesion: 0.27
-Nodes (6): AfterMethod, BeforeMethod, HttpExchange, Object, String, XrayIntegrationHelperCoverageUnitTest
+Cohesion: 0.24
+Nodes (8): GuardedPatch, RepairGuard, FilePatch, List, Path, Set, String, ValidationCommand
 
 ### Community 402 - "Community 402"
-Cohesion: 0.25
+Cohesion: 0.24
 Nodes (3): ActionsExceptionDetailsUnitTest, NoSuchElementException, Test
 
 ### Community 403 - "Community 403"
@@ -2331,8 +2342,8 @@ Cohesion: 0.29
 Nodes (5): Test_LTMobAPKAPPURL, AfterMethod, BeforeMethod, String, Test
 
 ### Community 406 - "Community 406"
-Cohesion: 0.19
-Nodes (8): AutoCloseable, SessionPermit, FileChannel, FileLock, CaptureSingleSessionLock, Override, Path, Override
+Cohesion: 0.17
+Nodes (9): AutoCloseable, SessionPermit, FileChannel, FileLock, CaptureSingleSessionLock, Semaphore, Override, Path (+1 more)
 
 ### Community 407 - "Community 407"
 Cohesion: 0.27
@@ -2347,12 +2358,12 @@ Cohesion: 0.29
 Nodes (4): GroupsTests, AfterMethod, BeforeMethod, Test
 
 ### Community 410 - "Community 410"
-Cohesion: 0.16
-Nodes (11): ActionCandidate, LocatorDecision, McpCaptureCodeBlockService, PomCandidates, CaptureGenerationReport, List, LocatorCandidate, McpCodeBlock (+3 more)
+Cohesion: 0.15
+Nodes (13): ActionCandidate, safe(), LocatorDecision, McpCaptureCodeBlockService, PomCandidates, CaptureGenerationReport, List, LocatorCandidate (+5 more)
 
 ### Community 411 - "Community 411"
-Cohesion: 0.19
-Nodes (6): OpenApiCoverageReporterUnitTest, OpenApiValidationException, AssertionError, AfterMethod, String, Test
+Cohesion: 0.23
+Nodes (8): FakeGuideHttpClient, GuideServiceTest, List, Map, Override, String, Test, URI
 
 ### Community 412 - "Community 412"
 Cohesion: 0.32
@@ -2363,8 +2374,8 @@ Cohesion: 0.40
 Nodes (10): addIfSet(), addIfTrue(), defaults(), normalize(), testIdAttributes(), text(), warnings(), CaptureStartOptions (+2 more)
 
 ### Community 414 - "Community 414"
-Cohesion: 0.18
-Nodes (11): additionalProperties, properties, required, type, createRelation, $ref, enum, from (+3 more)
+Cohesion: 0.10
+Nodes (22): enum, additionalProperties, properties, required, type, createRelation, updateRelation, $ref (+14 more)
 
 ### Community 416 - "Community 416"
 Cohesion: 0.24
@@ -2407,20 +2418,20 @@ Cohesion: 0.12
 Nodes (23): AiProviderRegistryTest, availability(), capabilities(), execute(), CompletableFuture, McpProcessRunner, SystemProcessRunner, Duration (+15 more)
 
 ### Community 426 - "Community 426"
-Cohesion: 0.38
-Nodes (5): CaptureCliTest, Class, Object, String, Test
+Cohesion: 0.17
+Nodes (6): ProgressBarLogger, ProgressBarLoggerCoverageUnitTest, Override, String, AfterMethod, Test
 
 ### Community 427 - "Community 427"
 Cohesion: 0.26
 Nodes (7): ApiPerformanceExecutionReportUnitTest, AfterMethod, CapturedFile, JsonNode, List, String, Test
 
 ### Community 428 - "Community 428"
-Cohesion: 0.30
+Cohesion: 0.29
 Nodes (3): PlaywrightTraceManager, BrowserContext, Path
 
 ### Community 430 - "Community 430"
-Cohesion: 0.22
-Nodes (7): DriverAssertions, BrowserAssertions, By, ElementAssertions, NativeValidationsBuilder, Object, ShaftLocator
+Cohesion: 0.18
+Nodes (4): TestCaseStarted, TestCaseStarted, RunType, Boolean
 
 ### Community 431 - "Community 431"
 Cohesion: 0.31
@@ -2435,16 +2446,16 @@ Cohesion: 0.25
 Nodes (4): DatabaseActions, DB, DatabaseType, ResultSet
 
 ### Community 434 - "Community 434"
-Cohesion: 0.13
-Nodes (5): AfterMethod, Path, String, Test, ThreadLocalPropertiesTest
+Cohesion: 0.09
+Nodes (8): ThreadLocalPropertiesManager, Properties, String, AfterMethod, Path, String, Test, ThreadLocalPropertiesTest
 
 ### Community 435 - "Community 435"
 Cohesion: 0.23
 Nodes (6): InputStream, Override, Path, Test, CloseTrackingInputStream, ReportManagerHelperAttachmentIoUnitTest
 
 ### Community 436 - "Community 436"
-Cohesion: 0.18
-Nodes (5): AfterMethod, BeforeMethod, CSVFileManager, Object, String
+Cohesion: 0.33
+Nodes (6): HealingLocatorProposalServiceTest, AfterEach, BeforeEach, Path, String, Test
 
 ### Community 437 - "Community 437"
 Cohesion: 0.20
@@ -2503,20 +2514,20 @@ Cohesion: 0.33
 Nodes (5): steps, Given, String, Then, When
 
 ### Community 451 - "Community 451"
-Cohesion: 0.22
-Nodes (7): DriverVerifications, BrowserAssertions, By, ElementAssertions, NativeValidationsBuilder, Object, ShaftLocator
+Cohesion: 0.31
+Nodes (4): ScreenshotHelper, Boolean, SuppressWarnings, WebDriver
 
 ### Community 452 - "Community 452"
 Cohesion: 0.38
 Nodes (4): Executable, McpNoDriverServiceTest, BeforeEach, Test
 
 ### Community 453 - "Community 453"
-Cohesion: 0.29
-Nodes (3): UnitTestsSHAFT, TerminalActions, Test
+Cohesion: 0.23
+Nodes (4): UnitTestsSHAFT, CSVFileManager, CSV, Test
 
 ### Community 454 - "Community 454"
-Cohesion: 0.31
-Nodes (4): AfterMethod, BeforeMethod, Test, VisualValidationTests
+Cohesion: 0.24
+Nodes (5): String, AfterMethod, BeforeMethod, Test, VisualValidationTests
 
 ### Community 455 - "Community 455"
 Cohesion: 0.20
@@ -2531,8 +2542,8 @@ Cohesion: 0.22
 Nodes (8): 📝 Additional Notes, 📋 Description, Documentation Site, Evidence, 🧪 How to Test, ✅ Pre-Submission Checklist, 🔗 Related Issue(s), 🗂️ Type of Change
 
 ### Community 458 - "Community 458"
-Cohesion: 0.20
-Nodes (6): FileReader, JSONFileManagerTestAccessor, SuppressWarnings, AfterMethod, Test, MemoryLeakFixTests
+Cohesion: 0.23
+Nodes (9): VisualEvidenceService, Double, HealingConfiguration, HealingVisualProvider, List, Optional, RankedCandidate, String (+1 more)
 
 ### Community 459 - "Community 459"
 Cohesion: 0.22
@@ -2555,8 +2566,8 @@ Cohesion: 0.43
 Nodes (3): AfterMethod, Test, PropertiesHelperMaximumPerformanceModeUnitTest
 
 ### Community 464 - "Community 464"
-Cohesion: 0.35
-Nodes (5): CaptureWorkbenchHtml, CaptureGenerationReport, CaptureReview, Path, String
+Cohesion: 0.21
+Nodes (7): StandaloneAssertions, StandaloneVerifications, FileValidationsBuilder, Number, NumberValidationsBuilder, String, ValidationsExecutor
 
 ### Community 465 - "Community 465"
 Cohesion: 0.25
@@ -2583,7 +2594,7 @@ Cohesion: 0.31
 Nodes (4): JunitDatabaseSmokeTest, AfterAll, BeforeAll, Test
 
 ### Community 472 - "Community 472"
-Cohesion: 0.33
+Cohesion: 0.36
 Nodes (4): AfterMethod, BeforeMethod, Test, TopUncoveredClassesCoverageUnitTest
 
 ### Community 473 - "Community 473"
@@ -2592,15 +2603,15 @@ Nodes (4): AfterMethod, BeforeMethod, Test, BrowserValidationsTests
 
 ### Community 474 - "Community 474"
 Cohesion: 0.31
-Nodes (4): FlakeProfilerUnitTest, AfterMethod, BeforeMethod, Test
+Nodes (7): LocatorRankerTest, ElementSnapshot, List, LocatorCandidate, LocatorStrategy, String, Test
 
 ### Community 475 - "Community 475"
 Cohesion: 0.29
 Nodes (6): Deletion Checklist, Generated PR Workflows, GitHub Actions Workflows, Relationship Map, Shared Composite Actions, Workflow Inventory
 
 ### Community 476 - "Community 476"
-Cohesion: 0.21
-Nodes (8): OperationCoverage, SpecCoverage, OpenAPI, OpenApiValidationFilter, OperationCoverage, List, ObjectNode, StringBuilder
+Cohesion: 0.35
+Nodes (3): BrowserEventScript, List, String
 
 ### Community 477 - "Community 477"
 Cohesion: 0.25
@@ -2671,8 +2682,8 @@ Cohesion: 0.36
 Nodes (4): LazyLoadingTests, AfterMethod, BeforeMethod, Test
 
 ### Community 494 - "Community 494"
-Cohesion: 0.23
-Nodes (8): FakeGuideHttpClient, GuideServiceTest, List, Map, Override, String, Test, URI
+Cohesion: 0.39
+Nodes (3): ReportManager, Level, String
 
 ### Community 495 - "Community 495"
 Cohesion: 0.43
@@ -2699,16 +2710,16 @@ Cohesion: 0.29
 Nodes (4): PlaywrightNaturalActionExecutorTest, AfterMethod, BeforeMethod, Test
 
 ### Community 502 - "Community 502"
-Cohesion: 0.27
-Nodes (10): FakeRunner, McpProcessRunner, Duration, List, Map, Override, Path, Process (+2 more)
+Cohesion: 0.30
+Nodes (9): FakeRunner, Duration, List, Map, Override, Path, Process, ProcessResult (+1 more)
 
 ### Community 504 - "Community 504"
 Cohesion: 0.36
 Nodes (4): AfterMethod, BeforeMethod, Test, AssertionStepsCucumberTestsCoverageUnitTest
 
 ### Community 505 - "Community 505"
-Cohesion: 0.31
-Nodes (4): MultipleElementsFailureTest, AfterMethod, BeforeMethod, Test
+Cohesion: 0.22
+Nodes (4): ProgressBarLoggerTestAccessor, AfterMethod, Test, ValidationAndProgressBarTests
 
 ### Community 506 - "Community 506"
 Cohesion: 0.36
@@ -2731,16 +2742,16 @@ Cohesion: 0.36
 Nodes (4): AfterMethod, BeforeMethod, Test, CustomDriverInitializationTests
 
 ### Community 511 - "Community 511"
-Cohesion: 0.27
-Nodes (6): LogRedirector, Logger, InputStream, OutputStream, Level, Override
+Cohesion: 0.26
+Nodes (4): AfterMethod, BeforeMethod, Test, BrowserActionsHelperCoverageUnitTest
 
 ### Community 512 - "Community 512"
-Cohesion: 0.31
-Nodes (5): BrowserActions, BrowserActionsContract, List, Page, WebDriver
+Cohesion: 0.24
+Nodes (7): CompositeLocator, NaturalActionCompositeLocator, By, List, By, List, Override
 
 ### Community 513 - "Community 513"
-Cohesion: 0.06
-Nodes (21): testPostRequest, BrowserStackModuleTest, Constructor, SHAFT, AppiumMobileConsumer, BrowserStackSdkConsumer, LegacyCoordinateConsumer, $ (+13 more)
+Cohesion: 0.05
+Nodes (24): AiAuditSink, testPostRequest, ArrayList, ShaftAiAuditSink, SHAFT, FileInputStream, AppiumMobileConsumer, BrowserStackSdkConsumer (+16 more)
 
 ### Community 514 - "Community 514"
 Cohesion: 0.43
@@ -2755,8 +2766,8 @@ Cohesion: 0.29
 Nodes (6): additionalProperties, allOf, $id, required, $schema, type
 
 ### Community 517 - "Community 517"
-Cohesion: 0.26
-Nodes (5): AfterClass, BeforeClass, List, Map, String
+Cohesion: 0.47
+Nodes (3): List, Map, String
 
 ### Community 518 - "Community 518"
 Cohesion: 0.29
@@ -2795,7 +2806,7 @@ Cohesion: 0.42
 Nodes (5): ClassifiedValue, Collection, Path, String, ExternalTestDataWriter
 
 ### Community 529 - "Community 529"
-Cohesion: 0.20
+Cohesion: 0.21
 Nodes (6): RetryAnalyzer, SupportingEvidenceState, IRetryAnalyzer, ITestResult, Override, String
 
 ### Community 530 - "Community 530"
@@ -2815,8 +2826,8 @@ Cohesion: 0.33
 Nodes (3): PrivacySanitizer, SanitizedValue, String
 
 ### Community 535 - "Community 535"
-Cohesion: 0.43
-Nodes (4): JunitProjectStructureManagerTest, AfterEach, Path, Test
+Cohesion: 0.22
+Nodes (7): DriverAssertions, BrowserAssertions, By, ElementAssertions, NativeValidationsBuilder, Object, ShaftLocator
 
 ### Community 536 - "Community 536"
 Cohesion: 0.24
@@ -2825,10 +2836,6 @@ Nodes (9): JiraHelper, Class, IInvokedMethod, ITestNGMethod, ITestResult, List, 
 ### Community 538 - "Community 538"
 Cohesion: 0.36
 Nodes (4): SwitchToNewTabTest, AfterMethod, BeforeMethod, Test
-
-### Community 539 - "Community 539"
-Cohesion: 0.70
-Nodes (3): reviewPath(), reviewUiPath(), Path
 
 ### Community 540 - "Community 540"
 Cohesion: 0.47
@@ -2851,8 +2858,8 @@ Cohesion: 0.47
 Nodes (3): PatternTests, BeforeClass, Test
 
 ### Community 545 - "Community 545"
-Cohesion: 0.32
-Nodes (3): DesktopVideoRecordingProvider, Optional, DesktopVideoRecordingProviderRegistry
+Cohesion: 0.13
+Nodes (11): Callable, FilesSize, DeterministicNaturalActionPlannerTest, Path, Test, NaturalActionRequest, String, Test (+3 more)
 
 ### Community 546 - "Community 546"
 Cohesion: 0.47
@@ -2867,8 +2874,8 @@ Cohesion: 0.41
 Nodes (7): BrowserNetworkInterceptionRule, Consumer, Function, HttpRequest, HttpResponse, Predicate, Response
 
 ### Community 549 - "Community 549"
-Cohesion: 0.18
-Nodes (9): Autowired, ShaftMcpApplicationTests, EngineService, McpMobileInspectorRecordingService, McpMobileRecordingService, McpWorkspacePolicy, Set, String (+1 more)
+Cohesion: 0.33
+Nodes (5): $id, required, $schema, title, type
 
 ### Community 550 - "Community 550"
 Cohesion: 0.47
@@ -2894,6 +2901,10 @@ Nodes (4): AfterMethod, BeforeMethod, Test, FlagsSetPropertyCoverageUnitTest
 Cohesion: 0.60
 Nodes (3): AbstractTestNGCucumberTests, CucumberTests, CucumberTests
 
+### Community 557 - "Community 557"
+Cohesion: 0.14
+Nodes (8): ShadowDomTest, JDK21VirtualThreadsAndAsyncActionsTests, AfterMethod, BeforeMethod, Test, AfterMethod, BeforeMethod, Test
+
 ### Community 558 - "Community 558"
 Cohesion: 0.60
 Nodes (4): defaults(), DoctorAnalysisRequest, List, Path
@@ -2903,8 +2914,8 @@ Cohesion: 0.60
 Nodes (4): defaults(), disabled(), ApprovalPolicy, DoctorAiAnalysisRequest
 
 ### Community 562 - "Community 562"
-Cohesion: 0.39
-Nodes (3): AfterMethod, Test, PlaywrightElementVisualValidationTest
+Cohesion: 0.22
+Nodes (7): DriverVerifications, BrowserAssertions, By, ElementAssertions, NativeValidationsBuilder, Object, ShaftLocator
 
 ### Community 563 - "Community 563"
 Cohesion: 0.43
@@ -2915,11 +2926,11 @@ Cohesion: 0.18
 Nodes (8): ValidationsExecutor, FileValidationsBuilder, NativeValidationsBuilder, NumberValidationsBuilder, RestValidationsBuilder, Step, ValidationsBuilder, WebDriverElementValidationsBuilder
 
 ### Community 565 - "Community 565"
-Cohesion: 0.47
-Nodes (3): OpenCvVisualConsumer, Mat, String
+Cohesion: 0.35
+Nodes (5): CaptureWorkbenchHtml, CaptureGenerationReport, CaptureReview, Path, String
 
 ### Community 566 - "Community 566"
-Cohesion: 0.25
+Cohesion: 0.36
 Nodes (4): DevTools, BrowserNetworkProfileManager, String, WebDriver
 
 ### Community 567 - "Community 567"
@@ -2959,12 +2970,12 @@ Cohesion: 0.50
 Nodes (4): build_parser(), main(), Build the command-line parser., ArgumentParser
 
 ### Community 578 - "Community 578"
-Cohesion: 0.16
+Cohesion: 0.14
 Nodes (8): IssueReporter, Boolean, ITestNGMethod, ITestResult, List, Method, String, TestExecutionInfo
 
 ### Community 579 - "Community 579"
 Cohesion: 0.33
-Nodes (4): Actions, CheckpointType, Map, Response
+Nodes (4): VisualProcessingProviderRegistry, List, Optional, VisualProcessingProvider
 
 ### Community 580 - "Community 580"
 Cohesion: 0.50
@@ -2986,17 +2997,17 @@ Nodes (9): agent_upgrade_plan(), ProjectAnalysis, Return whether source rewrites
 Cohesion: 0.29
 Nodes (5): SelectMethodTests, AfterMethod, BeforeMethod, String, Test
 
+### Community 588 - "Community 588"
+Cohesion: 0.31
+Nodes (4): GuiVerificationTests, AfterMethod, BeforeMethod, Test
+
 ### Community 591 - "Community 591"
 Cohesion: 0.50
 Nodes (3): { Client }, pgclient, values
 
-### Community 594 - "Community 594"
-Cohesion: 0.47
-Nodes (3): PathsTests, BeforeClass, Test
-
 ### Community 597 - "Community 597"
-Cohesion: 0.21
-Nodes (7): HasCdp, Image, ScreenshotHelper, Boolean, BufferedImage, SuppressWarnings, WebDriver
+Cohesion: 0.42
+Nodes (4): Severity, Story, Test, Allure3ReportValidationTests
 
 ### Community 599 - "Community 599"
 Cohesion: 0.47
@@ -3046,36 +3057,44 @@ Nodes (5): DoctorFormatException, ProfileCleanupException, RuntimeException, Str
 Cohesion: 0.47
 Nodes (3): MobileTests, BeforeClass, Test
 
+### Community 652 - "Community 652"
+Cohesion: 0.16
+Nodes (10): CheckpointStatus, ByteArrayOutputStream, CheckpointStatus, InputStream, List, Object, Path, Status (+2 more)
+
 ### Community 653 - "Community 653"
 Cohesion: 0.33
 Nodes (6): Metadata, asCacheHit(), disabled(), empty(), DoctorAdvisory, ProviderAnalysis
 
 ### Community 654 - "Community 654"
-Cohesion: 0.36
-Nodes (5): TextLanguageValidationsBuilder, NativeValidationsBuilder, String, ValidationsExecutor, TextLanguage
+Cohesion: 0.67
+Nodes (3): minLength, type, mediaType
 
 ### Community 655 - "Community 655"
-Cohesion: 0.29
-Nodes (7): enum, updateRelation, confidence, additionalProperties, properties, required, type
+Cohesion: 0.27
+Nodes (6): AfterMethod, BeforeMethod, HttpExchange, Object, String, XrayIntegrationHelperCoverageUnitTest
 
 ### Community 656 - "Community 656"
 Cohesion: 0.47
 Nodes (3): HealeniumTests, BeforeClass, Test
 
 ### Community 657 - "Community 657"
-Cohesion: 0.33
-Nodes (3): Validations, StandaloneAssertions, StandaloneVerifications
+Cohesion: 0.36
+Nodes (5): TextLanguageValidationsBuilder, NativeValidationsBuilder, String, ValidationsExecutor, TextLanguage
 
 ### Community 658 - "Community 658"
-Cohesion: 0.14
-Nodes (13): DoctorServiceTest, DoctorSnippetProvider, AfterEach, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse, DoctorService (+5 more)
+Cohesion: 0.36
+Nodes (4): McpMobileToolchainServiceTest, McpMobileToolchainDiagnostic, McpMobileToolchainStatus, Test
+
+### Community 659 - "Community 659"
+Cohesion: 0.22
+Nodes (5): TestAutomationServiceTest, McpCodeGuardrailResult, McpScenarioCatalogResult, Tool, Test
 
 ### Community 661 - "Community 661"
 Cohesion: 0.47
 Nodes (3): TinkeyTests, BeforeClass, Test
 
 ### Community 664 - "Community 664"
-Cohesion: 0.38
+Cohesion: 0.36
 Nodes (4): RemoteGridVideoAttachmentIT, AfterMethod, BeforeMethod, Test
 
 ### Community 665 - "Community 665"
@@ -3087,76 +3106,80 @@ Cohesion: 0.36
 Nodes (4): AfterMethod, BeforeMethod, Test, RecordManagerCoverageUnitTest
 
 ### Community 667 - "Community 667"
-Cohesion: 0.47
-Nodes (3): MultipleBrowserInstancesTest, AfterMethod, Test
+Cohesion: 0.36
+Nodes (4): ShaftMcpApplicationTests, Set, String, Test
+
+### Community 669 - "Community 669"
+Cohesion: 0.36
+Nodes (3): OpenCvVisualConsumer, Mat, String
 
 ### Community 670 - "Community 670"
 Cohesion: 0.33
 Nodes (4): DynamicLoadingTest, AfterMethod, BeforeMethod, Test
 
-### Community 672 - "Community 672"
+### Community 671 - "Community 671"
 Cohesion: 0.36
-Nodes (4): RelativeLocatorsTests, AfterMethod, BeforeMethod, Test
+Nodes (4): HealingReportWriter, HealingConfiguration, HealingReport, String
+
+### Community 672 - "Community 672"
+Cohesion: 0.31
+Nodes (5): ElementActions, RelativeLocatorsTests, AfterMethod, BeforeMethod, Test
 
 ### Community 673 - "Community 673"
-Cohesion: 0.50
-Nodes (3): JiraTests, BeforeClass, Test
+Cohesion: 0.39
+Nodes (4): JunitProjectStructureManagerTest, AfterEach, Path, Test
 
 ### Community 674 - "Community 674"
-Cohesion: 0.13
-Nodes (14): items, type, $id, required, type, properties, evidence, redaction (+6 more)
+Cohesion: 0.17
+Nodes (12): minLength, type, type, properties, bundleId, evidence, redaction, schemaVersion (+4 more)
 
 ### Community 676 - "Community 676"
-Cohesion: 0.12
-Nodes (8): AccessibilityActions, AccessibilityConfig, AccessibilityTest, AccessibilityResult, String, AfterMethod, BeforeMethod, Test
+Cohesion: 0.16
+Nodes (4): AccessibilityTest, AfterMethod, BeforeMethod, Test
 
 ### Community 677 - "Community 677"
-Cohesion: 0.15
-Nodes (11): ready(), unavailable(), AiValueObjectsTest, allows(), ApprovalPolicy(), AiProviderAvailability, String, EvidenceCategory (+3 more)
+Cohesion: 0.36
+Nodes (4): Test_LTMobIPARelativePath, AfterMethod, BeforeMethod, Test
 
 ### Community 679 - "Community 679"
-Cohesion: 0.50
-Nodes (3): Object, StringBuilder, ValidationCategory
+Cohesion: 0.32
+Nodes (3): DesktopVideoRecordingProvider, Optional, DesktopVideoRecordingProviderRegistry
 
 ### Community 685 - "Community 685"
-Cohesion: 0.67
-Nodes (3): minLength, type, bundleId
+Cohesion: 0.33
+Nodes (5): $, CucumberHelper, List, Status, XmlSuite
 
 ### Community 686 - "Community 686"
-Cohesion: 0.47
-Nodes (3): JunitCoreAssertionDependencyGuardTest, Path, Test
-
-### Community 687 - "Community 687"
 Cohesion: 0.40
-Nodes (3): DriverFactoryHelper, WebDriver, WebDriverElementValidationsBuilder
+Nodes (4): MultipleElementsFoundException, String, Throwable, WebDriverException
 
 ### Community 708 - "Community 708"
 Cohesion: 0.50
 Nodes (4): McpMobileSessionResult(), List, McpCodeBlock, String
 
 ### Community 753 - "Community 753"
-Cohesion: 0.33
+Cohesion: 0.29
 Nodes (3): Class, Test, GUIInterfaceCompatibilityCoverageUnitTest
-
-### Community 758 - "Community 758"
-Cohesion: 0.67
-Nodes (3): defaults(), CaptureGenerationRequest, Path
 
 ### Community 759 - "Community 759"
 Cohesion: 0.36
 Nodes (3): PlaywrightMobileWebE2ETestBase, String, Test
 
 ### Community 763 - "Community 763"
-Cohesion: 0.15
-Nodes (9): IOSBasicInteractionsTest, Test_LTMobIPARelativePath, AfterMethod, BeforeMethod, SuppressWarnings, Test, AfterMethod, BeforeMethod (+1 more)
+Cohesion: 0.27
+Nodes (5): IOSBasicInteractionsTest, AfterMethod, BeforeMethod, SuppressWarnings, Test
 
 ### Community 766 - "Community 766"
 Cohesion: 0.36
 Nodes (3): JUnitWebConsumer, AfterAll, Test
 
 ### Community 768 - "Community 768"
-Cohesion: 0.20
-Nodes (12): McpMobileInspectorRecordingServiceTest, NoopRunner, Duration, List, Map, McpMobileInspectorRecordingService, Override, Path (+4 more)
+Cohesion: 0.18
+Nodes (13): McpMobileInspectorRecordingServiceTest, NoopRunner, McpProcessRunner, Duration, List, Map, McpMobileInspectorRecordingService, Override (+5 more)
+
+### Community 769 - "Community 769"
+Cohesion: 0.40
+Nodes (4): By, StringBuilder, ValidationCategory, WebDriver
 
 ### Community 771 - "Community 771"
 Cohesion: 0.47
@@ -3179,20 +3202,24 @@ Cohesion: 0.53
 Nodes (3): Path, Test, ExecutionLifecycleHelperSourceUnitTest
 
 ### Community 782 - "Community 782"
-Cohesion: 0.31
+Cohesion: 0.29
 Nodes (5): AfterMethod, BeforeClass, BeforeMethod, Test, TestClass
 
+### Community 785 - "Community 785"
+Cohesion: 0.47
+Nodes (3): JunitCoreAssertionDependencyGuardTest, Path, Test
+
 ### Community 787 - "Community 787"
-Cohesion: 0.16
-Nodes (14): limiterKey(), RemoteGridPreflight, unavailable(), PreflightReport, Semaphore, SessionPermit, Capabilities, Duration (+6 more)
+Cohesion: 0.17
+Nodes (13): limiterKey(), RemoteGridPreflight, unavailable(), PreflightReport, SessionPermit, Capabilities, Duration, HttpRequest (+5 more)
 
 ### Community 788 - "Community 788"
 Cohesion: 0.16
 Nodes (15): build_parser(), coordinates_have_supported_runner(), coordinates_have_supported_stack(), ensure_shaft_import(), migrate_full_source(), migrate_session_source(), ArgumentParser, Add the SHAFT import required by rewritten Java source. (+7 more)
 
 ### Community 789 - "Community 789"
-Cohesion: 0.40
-Nodes (3): FileActionsReflectionInvoker, FileActions, String
+Cohesion: 0.47
+Nodes (3): PlatformTests, BeforeClass, Test
 
 ### Community 795 - "Community 795"
 Cohesion: 0.52
@@ -3219,43 +3246,43 @@ Cohesion: 0.40
 Nodes (3): WebKitPlaywrightActionsE2ETest, Override, String
 
 ### Community 807 - "Community 807"
-Cohesion: 0.67
-Nodes (3): defaults(), ApprovalPolicy, DoctorRepairAiRequest
-
-### Community 812 - "Community 812"
-Cohesion: 0.67
-Nodes (3): schemaVersion, enum, type
+Cohesion: 0.53
+Nodes (3): RepairProposalStore, Path, RepairProposal
 
 ### Community 817 - "Community 817"
-Cohesion: 0.09
-Nodes (17): RequestBuilder, RetryState, AuthenticationType, RetryPolicy, RetryState, API, Deprecated, Exception (+9 more)
+Cohesion: 0.10
+Nodes (16): RequestBuilder, RetryState, AuthenticationType, RetryPolicy, RetryState, API, Deprecated, Exception (+8 more)
 
 ### Community 831 - "Community 831"
 Cohesion: 0.70
 Nodes (4): HistoryRecord(), withChecksum(), LocatorFingerprint, String
 
-### Community 836 - "Community 836"
-Cohesion: 0.16
-Nodes (9): DataType, JSON, JSONFileManager, JSONFileManagerTests, Object, String, Test, Test (+1 more)
+### Community 837 - "Community 837"
+Cohesion: 0.67
+Nodes (3): defaults(), ApprovalPolicy, DoctorRepairAiRequest
+
+### Community 838 - "Community 838"
+Cohesion: 0.50
+Nodes (4): markStale, additionalProperties, required, type
 
 ## Knowledge Gaps
-- **1506 isolated node(s):** `$id`, `$schema`, `additionalProperties`, `additionalProperties`, `type` (+1501 more)
+- **1510 isolated node(s):** `$id`, `$schema`, `additionalProperties`, `additionalProperties`, `type` (+1505 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **98 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **100 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `SHAFT` connect `Community 513` to `Community 512`, `Community 514`, `Community 3`, `Community 5`, `Community 517`, `Community 8`, `Community 9`, `Community 12`, `Community 13`, `Community 527`, `Community 15`, `Community 17`, `Community 18`, `Community 529`, `Community 19`, `Community 21`, `Community 22`, `Community 23`, `Community 536`, `Community 24`, `Community 26`, `Community 535`, `Community 538`, `Community 27`, `Community 540`, `Community 31`, `Community 541`, `Community 33`, `Community 34`, `Community 547`, `Community 36`, `Community 35`, `Community 38`, `Community 544`, `Community 546`, `Community 550`, `Community 39`, `Community 43`, `Community 555`, `Community 45`, `Community 46`, `Community 47`, `Community 49`, `Community 562`, `Community 563`, `Community 52`, `Community 53`, `Community 55`, `Community 569`, `Community 57`, `Community 572`, `Community 579`, `Community 69`, `Community 71`, `Community 584`, `Community 74`, `Community 587`, `Community 76`, `Community 77`, `Community 588`, `Community 80`, `Community 81`, `Community 594`, `Community 16`, `Community 597`, `Community 86`, `Community 87`, `Community 599`, `Community 89`, `Community 88`, `Community 93`, `Community 96`, `Community 98`, `Community 99`, `Community 103`, `Community 104`, `Community 615`, `Community 106`, `Community 108`, `Community 109`, `Community 621`, `Community 114`, `Community 116`, `Community 121`, `Community 123`, `Community 125`, `Community 130`, `Community 134`, `Community 137`, `Community 138`, `Community 650`, `Community 142`, `Community 656`, `Community 658`, `Community 661`, `Community 151`, `Community 664`, `Community 665`, `Community 666`, `Community 155`, `Community 156`, `Community 668`, `Community 670`, `Community 159`, `Community 672`, `Community 667`, `Community 673`, `Community 162`, `Community 676`, `Community 165`, `Community 678`, `Community 167`, `Community 166`, `Community 542`, `Community 170`, `Community 172`, `Community 174`, `Community 177`, `Community 184`, `Community 185`, `Community 186`, `Community 191`, `Community 196`, `Community 199`, `Community 200`, `Community 205`, `Community 210`, `Community 217`, `Community 218`, `Community 219`, `Community 222`, `Community 225`, `Community 233`, `Community 239`, `Community 241`, `Community 243`, `Community 247`, `Community 760`, `Community 763`, `Community 252`, `Community 251`, `Community 254`, `Community 766`, `Community 253`, `Community 257`, `Community 770`, `Community 771`, `Community 261`, `Community 266`, `Community 781`, `Community 270`, `Community 271`, `Community 782`, `Community 273`, `Community 786`, `Community 787`, `Community 276`, `Community 274`, `Community 279`, `Community 280`, `Community 284`, `Community 285`, `Community 286`, `Community 290`, `Community 293`, `Community 161`, `Community 817`, `Community 308`, `Community 311`, `Community 314`, `Community 316`, `Community 319`, `Community 836`, `Community 839`, `Community 327`, `Community 329`, `Community 330`, `Community 328`, `Community 337`, `Community 342`, `Community 347`, `Community 351`, `Community 352`, `Community 354`, `Community 359`, `Community 360`, `Community 362`, `Community 364`, `Community 367`, `Community 369`, `Community 373`, `Community 374`, `Community 375`, `Community 378`, `Community 379`, `Community 380`, `Community 382`, `Community 389`, `Community 390`, `Community 391`, `Community 392`, `Community 394`, `Community 395`, `Community 398`, `Community 399`, `Community 401`, `Community 403`, `Community 404`, `Community 405`, `Community 407`, `Community 408`, `Community 409`, `Community 411`, `Community 417`, `Community 424`, `Community 425`, `Community 427`, `Community 428`, `Community 429`, `Community 431`, `Community 432`, `Community 433`, `Community 434`, `Community 444`, `Community 446`, `Community 450`, `Community 454`, `Community 455`, `Community 456`, `Community 460`, `Community 461`, `Community 463`, `Community 467`, `Community 468`, `Community 471`, `Community 473`, `Community 474`, `Community 482`, `Community 484`, `Community 485`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 493`, `Community 496`, `Community 498`, `Community 503`, `Community 504`, `Community 505`, `Community 506`, `Community 509`, `Community 510`?**
-  _High betweenness centrality (0.144) - this node is a cross-community bridge._
-- **Why does `IOException` connect `Community 314` to `Community 515`, `Community 517`, `Community 8`, `Community 523`, `Community 13`, `Community 528`, `Community 18`, `Community 19`, `Community 535`, `Community 24`, `Community 28`, `Community 29`, `Community 30`, `Community 31`, `Community 543`, `Community 33`, `Community 41`, `Community 49`, `Community 56`, `Community 57`, `Community 60`, `Community 61`, `Community 62`, `Community 64`, `Community 71`, `Community 72`, `Community 74`, `Community 76`, `Community 79`, `Community 597`, `Community 86`, `Community 87`, `Community 85`, `Community 102`, `Community 105`, `Community 114`, `Community 628`, `Community 117`, `Community 122`, `Community 124`, `Community 131`, `Community 133`, `Community 138`, `Community 141`, `Community 148`, `Community 664`, `Community 154`, `Community 156`, `Community 159`, `Community 170`, `Community 686`, `Community 177`, `Community 179`, `Community 185`, `Community 189`, `Community 200`, `Community 209`, `Community 211`, `Community 212`, `Community 216`, `Community 218`, `Community 220`, `Community 223`, `Community 225`, `Community 233`, `Community 241`, `Community 244`, `Community 252`, `Community 273`, `Community 787`, `Community 277`, `Community 279`, `Community 285`, `Community 288`, `Community 295`, `Community 299`, `Community 307`, `Community 308`, `Community 313`, `Community 321`, `Community 328`, `Community 333`, `Community 346`, `Community 347`, `Community 353`, `Community 358`, `Community 363`, `Community 392`, `Community 394`, `Community 401`, `Community 406`, `Community 410`, `Community 411`, `Community 412`, `Community 417`, `Community 418`, `Community 425`, `Community 428`, `Community 435`, `Community 445`, `Community 455`, `Community 458`, `Community 464`, `Community 494`, `Community 506`?**
+- **Why does `SHAFT` connect `Community 513` to `Community 514`, `Community 3`, `Community 5`, `Community 8`, `Community 9`, `Community 10`, `Community 12`, `Community 13`, `Community 527`, `Community 15`, `Community 529`, `Community 18`, `Community 19`, `Community 16`, `Community 21`, `Community 23`, `Community 24`, `Community 536`, `Community 26`, `Community 538`, `Community 27`, `Community 540`, `Community 541`, `Community 31`, `Community 544`, `Community 33`, `Community 34`, `Community 547`, `Community 36`, `Community 35`, `Community 38`, `Community 546`, `Community 550`, `Community 32`, `Community 39`, `Community 43`, `Community 555`, `Community 45`, `Community 46`, `Community 47`, `Community 557`, `Community 49`, `Community 563`, `Community 52`, `Community 53`, `Community 55`, `Community 569`, `Community 57`, `Community 572`, `Community 69`, `Community 71`, `Community 584`, `Community 74`, `Community 587`, `Community 76`, `Community 77`, `Community 588`, `Community 80`, `Community 81`, `Community 594`, `Community 597`, `Community 86`, `Community 87`, `Community 599`, `Community 88`, `Community 96`, `Community 98`, `Community 99`, `Community 615`, `Community 104`, `Community 106`, `Community 108`, `Community 621`, `Community 114`, `Community 116`, `Community 121`, `Community 123`, `Community 125`, `Community 130`, `Community 134`, `Community 137`, `Community 138`, `Community 650`, `Community 652`, `Community 651`, `Community 142`, `Community 28`, `Community 656`, `Community 661`, `Community 664`, `Community 665`, `Community 666`, `Community 156`, `Community 670`, `Community 159`, `Community 672`, `Community 673`, `Community 158`, `Community 162`, `Community 676`, `Community 165`, `Community 678`, `Community 677`, `Community 167`, `Community 542`, `Community 170`, `Community 171`, `Community 172`, `Community 685`, `Community 174`, `Community 175`, `Community 177`, `Community 179`, `Community 545`, `Community 184`, `Community 185`, `Community 186`, `Community 190`, `Community 191`, `Community 196`, `Community 199`, `Community 205`, `Community 217`, `Community 218`, `Community 219`, `Community 222`, `Community 223`, `Community 225`, `Community 230`, `Community 241`, `Community 753`, `Community 243`, `Community 247`, `Community 760`, `Community 763`, `Community 252`, `Community 766`, `Community 257`, `Community 770`, `Community 771`, `Community 261`, `Community 264`, `Community 266`, `Community 781`, `Community 270`, `Community 271`, `Community 782`, `Community 273`, `Community 274`, `Community 275`, `Community 787`, `Community 276`, `Community 789`, `Community 279`, `Community 280`, `Community 284`, `Community 285`, `Community 286`, `Community 287`, `Community 290`, `Community 293`, `Community 161`, `Community 817`, `Community 307`, `Community 311`, `Community 312`, `Community 316`, `Community 317`, `Community 836`, `Community 839`, `Community 327`, `Community 329`, `Community 841`, `Community 330`, `Community 328`, `Community 337`, `Community 342`, `Community 348`, `Community 351`, `Community 352`, `Community 354`, `Community 359`, `Community 360`, `Community 362`, `Community 364`, `Community 367`, `Community 369`, `Community 373`, `Community 374`, `Community 375`, `Community 378`, `Community 379`, `Community 380`, `Community 381`, `Community 382`, `Community 389`, `Community 390`, `Community 391`, `Community 395`, `Community 398`, `Community 399`, `Community 403`, `Community 404`, `Community 405`, `Community 407`, `Community 408`, `Community 409`, `Community 417`, `Community 424`, `Community 425`, `Community 426`, `Community 427`, `Community 428`, `Community 429`, `Community 431`, `Community 432`, `Community 433`, `Community 434`, `Community 436`, `Community 444`, `Community 446`, `Community 450`, `Community 453`, `Community 454`, `Community 455`, `Community 456`, `Community 460`, `Community 461`, `Community 463`, `Community 467`, `Community 468`, `Community 471`, `Community 473`, `Community 482`, `Community 484`, `Community 485`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 493`, `Community 496`, `Community 498`, `Community 503`, `Community 504`, `Community 506`, `Community 509`, `Community 510`, `Community 511`?**
+  _High betweenness centrality (0.139) - this node is a cross-community bridge._
+- **Why does `IOException` connect `Community 513` to `Community 515`, `Community 8`, `Community 523`, `Community 13`, `Community 528`, `Community 18`, `Community 19`, `Community 24`, `Community 25`, `Community 28`, `Community 29`, `Community 31`, `Community 543`, `Community 33`, `Community 41`, `Community 49`, `Community 565`, `Community 56`, `Community 57`, `Community 60`, `Community 61`, `Community 62`, `Community 64`, `Community 71`, `Community 72`, `Community 74`, `Community 76`, `Community 79`, `Community 85`, `Community 86`, `Community 87`, `Community 102`, `Community 105`, `Community 628`, `Community 117`, `Community 122`, `Community 131`, `Community 133`, `Community 138`, `Community 141`, `Community 148`, `Community 664`, `Community 154`, `Community 156`, `Community 159`, `Community 671`, `Community 673`, `Community 170`, `Community 175`, `Community 177`, `Community 179`, `Community 185`, `Community 189`, `Community 200`, `Community 209`, `Community 210`, `Community 211`, `Community 212`, `Community 216`, `Community 217`, `Community 218`, `Community 220`, `Community 223`, `Community 240`, `Community 241`, `Community 244`, `Community 785`, `Community 273`, `Community 787`, `Community 274`, `Community 277`, `Community 279`, `Community 288`, `Community 807`, `Community 295`, `Community 299`, `Community 312`, `Community 313`, `Community 321`, `Community 328`, `Community 353`, `Community 358`, `Community 363`, `Community 381`, `Community 401`, `Community 406`, `Community 410`, `Community 411`, `Community 412`, `Community 417`, `Community 418`, `Community 425`, `Community 428`, `Community 435`, `Community 445`, `Community 455`, `Community 458`, `Community 476`, `Community 506`?**
+  _High betweenness centrality (0.031) - this node is a cross-community bridge._
+- **Why does `ArrayList` connect `Community 513` to `Community 3`, `Community 5`, `Community 9`, `Community 13`, `Community 14`, `Community 527`, `Community 19`, `Community 25`, `Community 545`, `Community 34`, `Community 35`, `Community 38`, `Community 39`, `Community 41`, `Community 45`, `Community 49`, `Community 56`, `Community 59`, `Community 60`, `Community 62`, `Community 64`, `Community 578`, `Community 74`, `Community 76`, `Community 85`, `Community 87`, `Community 88`, `Community 90`, `Community 93`, `Community 95`, `Community 98`, `Community 99`, `Community 111`, `Community 116`, `Community 117`, `Community 118`, `Community 132`, `Community 141`, `Community 143`, `Community 147`, `Community 148`, `Community 150`, `Community 152`, `Community 154`, `Community 668`, `Community 156`, `Community 157`, `Community 159`, `Community 162`, `Community 176`, `Community 177`, `Community 178`, `Community 179`, `Community 180`, `Community 186`, `Community 198`, `Community 200`, `Community 205`, `Community 209`, `Community 210`, `Community 211`, `Community 212`, `Community 220`, `Community 222`, `Community 232`, `Community 240`, `Community 255`, `Community 268`, `Community 273`, `Community 280`, `Community 281`, `Community 288`, `Community 306`, `Community 316`, `Community 322`, `Community 333`, `Community 340`, `Community 354`, `Community 377`, `Community 381`, `Community 401`, `Community 410`, `Community 413`, `Community 474`, `Community 502`?**
   _High betweenness centrality (0.029) - this node is a cross-community bridge._
-- **Why does `ArrayList` connect `Community 316` to `Community 512`, `Community 3`, `Community 5`, `Community 9`, `Community 13`, `Community 14`, `Community 527`, `Community 19`, `Community 30`, `Community 34`, `Community 35`, `Community 38`, `Community 39`, `Community 41`, `Community 557`, `Community 45`, `Community 49`, `Community 56`, `Community 59`, `Community 60`, `Community 62`, `Community 64`, `Community 65`, `Community 578`, `Community 74`, `Community 76`, `Community 85`, `Community 87`, `Community 88`, `Community 90`, `Community 93`, `Community 95`, `Community 98`, `Community 99`, `Community 109`, `Community 111`, `Community 117`, `Community 118`, `Community 132`, `Community 141`, `Community 143`, `Community 147`, `Community 148`, `Community 150`, `Community 152`, `Community 154`, `Community 667`, `Community 156`, `Community 157`, `Community 159`, `Community 162`, `Community 176`, `Community 177`, `Community 178`, `Community 179`, `Community 180`, `Community 190`, `Community 198`, `Community 200`, `Community 205`, `Community 209`, `Community 211`, `Community 212`, `Community 220`, `Community 222`, `Community 223`, `Community 232`, `Community 254`, `Community 255`, `Community 256`, `Community 268`, `Community 273`, `Community 280`, `Community 288`, `Community 306`, `Community 314`, `Community 322`, `Community 333`, `Community 377`, `Community 394`, `Community 401`, `Community 410`, `Community 413`, `Community 476`, `Community 502`?**
-  _High betweenness centrality (0.027) - this node is a cross-community bridge._
 - **What connects `$id`, `$schema`, `additionalProperties` to the rest of the system?**
-  _1617 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _1621 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.040179910044977514 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.03896856439229321 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
   _Cohesion score 0.05764411027568922 - nodes in this community are weakly interconnected._
 - **Should `Community 2` be split into smaller, more focused modules?**

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1,5917 +1,5757 @@
 {
   ".memory/config.json": {
-    "mtime": 1782488208.0333686,
+    "mtime": 1782494199.8647711,
     "ast_hash": "4ece894daf076c559889cf9afe6211e8",
     "semantic_hash": ""
   },
   ".memory/memory/architecture.json": {
-    "mtime": 1782488208.0343683,
+    "mtime": 1782494199.865771,
     "ast_hash": "cfc3c045ead7b74d483c04bc6746ea4e",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/maven-central-version-immutability.json": {
-    "mtime": 1782488208.0373685,
+    "mtime": 1782494199.8677711,
     "ast_hash": "434d7f5918634bb78e5a7abc8d7bf7ce",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/paid-agent-work-audit-gated.json": {
-    "mtime": 1782488208.0373685,
+    "mtime": 1782494199.868771,
     "ast_hash": "61f81f00078da8d614a21373fd7e8089",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/agent-guidance-progressive-disclosure.json": {
-    "mtime": 1782488208.0383685,
+    "mtime": 1782494199.8697715,
     "ast_hash": "d112f6080b24b67628173736e69c67e0",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/namespaced-video-capabilities.json": {
-    "mtime": 1782488208.0433667,
+    "mtime": 1782494199.8737707,
     "ast_hash": "38736f88f73b401031d168040fb2e609",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/public-docs-external.json": {
-    "mtime": 1782488208.0453672,
+    "mtime": 1782494199.8757708,
     "ast_hash": "dad3f0a3b650c5264d8dd7e4e4e366df",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/utf8-all-runtime-layers.json": {
-    "mtime": 1782488208.0473678,
+    "mtime": 1782494199.87877,
     "ast_hash": "0537ffa6937eab44bf326e9a2af4eca9",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/allure-result-population.json": {
-    "mtime": 1782488208.050367,
+    "mtime": 1782494199.8807712,
     "ast_hash": "0b408e349588a98b38afad0c067e86da",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/coverage-constructors-start-browser.json": {
-    "mtime": 1782488208.050367,
+    "mtime": 1782494199.8817706,
     "ast_hash": "c26c533a52af00631104647ed120e846",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/java25-isuite-mocking.json": {
-    "mtime": 1782488208.0523672,
+    "mtime": 1782494199.8827703,
     "ast_hash": "172391dc5cc831f90c86f7f71b305c19",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/testng-method-parallel-shared-instance-fields.json": {
-    "mtime": 1782488208.054367,
+    "mtime": 1782494199.884771,
     "ast_hash": "1d489c077df56ae50e23e4b41f6da2f3",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/testng-single-threaded-static-state.json": {
-    "mtime": 1782488208.0553682,
+    "mtime": 1782494199.8857715,
     "ast_hash": "41ae606ccc9cebd6325667da85ac2392",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/windows-allure-root-race.json": {
-    "mtime": 1782488208.0553682,
+    "mtime": 1782494199.886772,
     "ast_hash": "2f12b8774174d36ad6dd9f7375c9ebca",
     "semantic_hash": ""
   },
   ".memory/memory/project.json": {
-    "mtime": 1782488208.056373,
+    "mtime": 1782494199.8877711,
     "ast_hash": "f0a00de79160381997ea0562bcea283c",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/issue-linked-pr-closure-and-focused-tests.json": {
-    "mtime": 1782488208.0643728,
+    "mtime": 1782494199.8957758,
     "ast_hash": "ec46aa71d095fface3f1692bde6926b1",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/low-token-user-guide-work.json": {
-    "mtime": 1782488208.0653722,
+    "mtime": 1782494199.8967762,
     "ast_hash": "b4fd7b27d046eccd67b552fac5f7d31c",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/proactive-memory-use-when-material.json": {
-    "mtime": 1782488208.0663722,
+    "mtime": 1782494199.897776,
     "ast_hash": "dcc3243cb2aef6624523d32b6a2ec027",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/start-new-tasks-from-origin-main.json": {
-    "mtime": 1782488208.0693715,
+    "mtime": 1782494199.900776,
     "ast_hash": "20f6aadf28b59bac7d81d77b252caa72",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/update-official-user-guide-for-functionality-changes.json": {
-    "mtime": 1782488208.070876,
+    "mtime": 1782494199.902776,
     "ast_hash": "25cd51397aafa8823d00734801c3b62f",
     "semantic_hash": ""
   },
   ".memory/relations/project-shaft-engine-related-to-architecture-current.json": {
-    "mtime": 1782488208.0738811,
+    "mtime": 1782494199.9048736,
     "ast_hash": "61f899057083188f3c611b1207e86344",
     "semantic_hash": ""
   },
   ".memory/schema/config.schema.json": {
-    "mtime": 1782488208.0768797,
+    "mtime": 1782494199.907875,
     "ast_hash": "a9df65611183adc20ed4598acd8c8496",
     "semantic_hash": ""
   },
   ".memory/schema/event.schema.json": {
-    "mtime": 1782488208.0768797,
+    "mtime": 1782494199.9088733,
     "ast_hash": "b48fe7cc7267789e3f05371800d2572f",
     "semantic_hash": ""
   },
   ".memory/schema/object.schema.json": {
-    "mtime": 1782488208.0778823,
+    "mtime": 1782494199.9088733,
     "ast_hash": "df0c4608282c91449d7445ca2109376f",
     "semantic_hash": ""
   },
   ".memory/schema/patch.schema.json": {
-    "mtime": 1782488208.0778823,
+    "mtime": 1782494199.9098732,
     "ast_hash": "5476dea56f653fe6ae9b3237c911dc6a",
     "semantic_hash": ""
   },
   ".memory/schema/relation.schema.json": {
-    "mtime": 1782488208.0788813,
+    "mtime": 1782494199.9098732,
     "ast_hash": "05342c9eb8c7b7bdc8ef3a73d3eedc5a",
     "semantic_hash": ""
   },
   "scripts/ci/agent_guidance_budget.json": {
-    "mtime": 1782488208.1538267,
+    "mtime": 1782494199.9841118,
     "ast_hash": "d52de49ceeebd519a79a94e140ceee41",
     "semantic_hash": ""
   },
   "scripts/ci/assemble_javadocs.py": {
-    "mtime": 1782488208.1538267,
+    "mtime": 1782494199.9841118,
     "ast_hash": "6fe67ccde798d4838393acaf16b87261",
     "semantic_hash": ""
   },
   "scripts/ci/check_maven_release_version.py": {
-    "mtime": 1782488208.1538267,
+    "mtime": 1782494199.9851124,
     "ast_hash": "e92141a897e15092ed65fcd13f36fa6d",
     "semantic_hash": ""
   },
   "scripts/ci/extract_allure_failures.py": {
-    "mtime": 1782488208.1548274,
+    "mtime": 1782494199.9851124,
     "ast_hash": "7985bdc62c1954d07b62c01ae71fb039",
     "semantic_hash": ""
   },
   "scripts/ci/github-auth-env.sh": {
-    "mtime": 1782488208.1548274,
+    "mtime": 1782494199.9861128,
     "ast_hash": "2f1a16109a60700251b2b1e8b204a331",
     "semantic_hash": ""
   },
   "scripts/ci/validate_agent_guidance.py": {
-    "mtime": 1782488208.1558325,
+    "mtime": 1782494199.9861128,
     "ast_hash": "6efb73d9c1754b06f29ff45b3d15f6ad",
     "semantic_hash": ""
   },
   "scripts/ci/validate_agent_setup.py": {
-    "mtime": 1782488208.1558325,
+    "mtime": 1782494199.9861128,
     "ast_hash": "510d4cb0ac7e970d1e485e0798690b22",
     "semantic_hash": ""
   },
   "scripts/ci/validate_documentation_boundaries.py": {
-    "mtime": 1782488208.1568344,
+    "mtime": 1782494199.9871123,
     "ast_hash": "1f04136b5b8395cd6bda836ba3243523",
     "semantic_hash": ""
   },
   "scripts/ci/validate_maven_publication.py": {
-    "mtime": 1782488208.1568344,
+    "mtime": 1782494199.9871123,
     "ast_hash": "b30a099549e23dba6a1c00877649c186",
     "semantic_hash": ""
   },
   "scripts/ci/validate_modular_documentation.py": {
-    "mtime": 1782488208.1568344,
+    "mtime": 1782494199.9871123,
     "ast_hash": "39118b4d72384749ca3a7e768389ba13",
     "semantic_hash": ""
   },
   "scripts/ci/validate_quality_configuration.py": {
-    "mtime": 1782488208.1578345,
+    "mtime": 1782494199.988112,
     "ast_hash": "7ea8e7c413b65535474333a58f004843",
     "semantic_hash": ""
   },
   "scripts/ci/validate_reactor_versions.py": {
-    "mtime": 1782488208.1578345,
+    "mtime": 1782494199.988112,
     "ast_hash": "7ada71bfaf0bf09a2a118f3a172169e4",
     "semantic_hash": ""
   },
   "scripts/ci/validate_shaft_mcp_configuration.py": {
-    "mtime": 1782488208.1588326,
+    "mtime": 1782494199.989117,
     "ast_hash": "9a27dc403a9decdc4287c451f3303386",
     "semantic_hash": ""
   },
   "scripts/ci/validate_shaft_mcp_transports.py": {
-    "mtime": 1782488208.1588326,
+    "mtime": 1782494199.989117,
     "ast_hash": "cef307194198823949632cf1c0510543",
     "semantic_hash": ""
   },
   "scripts/ci/validate_shaft_pilot_release.py": {
-    "mtime": 1782488208.1588326,
+    "mtime": 1782494199.989117,
     "ast_hash": "b9f4064afb31d843b66fa3323ca29d6f",
     "semantic_hash": ""
   },
   "scripts/ci/verify_maven_central_release.py": {
-    "mtime": 1782488208.159832,
+    "mtime": 1782494199.9901173,
     "ast_hash": "f50ff9221963b55f6cd5355dcf077516",
     "semantic_hash": ""
   },
   "scripts/ci/verify_shaft_mcp_installer_release.py": {
-    "mtime": 1782488208.159832,
+    "mtime": 1782494199.9901173,
     "ast_hash": "61eb62b67b294cb5da719bb315bf6cde",
     "semantic_hash": ""
   },
   "scripts/maintenance/flatten-history.sh": {
-    "mtime": 1782488208.1608324,
+    "mtime": 1782494199.9911168,
     "ast_hash": "dde238359c6206f7dd16219757f04f07",
     "semantic_hash": ""
   },
   "scripts/mcp/install-shaft-mcp.ps1": {
-    "mtime": 1782488208.1608324,
+    "mtime": 1782494199.9911168,
     "ast_hash": "68f7dfc58bde866c56e5b69b36c1a8f8",
     "semantic_hash": ""
   },
   "scripts/mcp/install-shaft-mcp.sh": {
-    "mtime": 1782488208.1618319,
+    "mtime": 1782494199.992117,
     "ast_hash": "9d9c90cba847ab57ab90a08ea0c19560",
     "semantic_hash": ""
   },
   "scripts/mcp/install_shaft_mcp.py": {
-    "mtime": 1782488208.1618319,
+    "mtime": 1782494199.992117,
     "ast_hash": "09f2d0f568b7bac3d7adf8a36534d61b",
     "semantic_hash": ""
   },
   "shaft-ai/src/main/java/com/shaft/ai/provider/AbstractHttpAiProvider.java": {
-    "mtime": 1782488208.164832,
+    "mtime": 1782494199.9951162,
     "ast_hash": "dbb7debe96eaf04ce97677b023010551",
     "semantic_hash": ""
   },
   "shaft-ai/src/main/java/com/shaft/ai/provider/AnthropicProvider.java": {
-    "mtime": 1782488208.164832,
+    "mtime": 1782494199.9951162,
     "ast_hash": "fd84c714e9fdbcd3adc3e0ebd89c166e",
     "semantic_hash": ""
   },
   "shaft-ai/src/main/java/com/shaft/ai/provider/GeminiProvider.java": {
-    "mtime": 1782488208.1658318,
+    "mtime": 1782494199.9961164,
     "ast_hash": "a15587f8a53841df6ef6c891505f168d",
     "semantic_hash": ""
   },
   "shaft-ai/src/main/java/com/shaft/ai/provider/OllamaProvider.java": {
-    "mtime": 1782488208.1658318,
+    "mtime": 1782494199.9961164,
     "ast_hash": "2a63f2862593c6543ce4b503f462e1f7",
     "semantic_hash": ""
   },
   "shaft-ai/src/main/java/com/shaft/ai/provider/OpenAiProvider.java": {
-    "mtime": 1782488208.1668346,
+    "mtime": 1782494199.9971168,
     "ast_hash": "4c18363c15f720d76033af2df645c929",
     "semantic_hash": ""
   },
   "shaft-ai/src/test/java/com/shaft/ai/provider/ProviderConformanceTest.java": {
-    "mtime": 1782488208.1688344,
+    "mtime": 1782494199.999117,
     "ast_hash": "e7c70c2dfbbbeea72ca0fd26bd3aaf41",
     "semantic_hash": ""
   },
   "shaft-browserstack/src/main/java/com/shaft/integration/browserstack/BrowserStackModule.java": {
-    "mtime": 1782488208.1723516,
+    "mtime": 1782494200.0021162,
     "ast_hash": "72302597cacbdcf22114d39c4a134055",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/cli/CaptureCli.java": {
-    "mtime": 1782488208.1763518,
+    "mtime": 1782494200.0066247,
     "ast_hash": "22e81755fd9b65ed25577032a321eee3",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/BidiBrowserEventCollector.java": {
-    "mtime": 1782488208.1763518,
+    "mtime": 1782494200.0066247,
     "ast_hash": "47e8063cd21021bc1b40d9b0e5b4d083",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventCollector.java": {
-    "mtime": 1782488208.177352,
+    "mtime": 1782494200.0076246,
     "ast_hash": "7bcd665b60a9fdde45a86fd920161935",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventScript.java": {
-    "mtime": 1782488208.177352,
+    "mtime": 1782494200.0076246,
     "ast_hash": "8755a9e0ae74e3e95a65bc66e5125d05",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/BrowserSignal.java": {
-    "mtime": 1782488208.177352,
+    "mtime": 1782494200.0076246,
     "ast_hash": "df91d356ff80267cc300bf5a20c14f2d",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/CompositeBrowserEventCollector.java": {
-    "mtime": 1782488208.1783524,
+    "mtime": 1782494200.0086265,
     "ast_hash": "576d60256e891e492f671083c8ada4a6",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/PollingBrowserEventCollector.java": {
-    "mtime": 1782488208.1783524,
+    "mtime": 1782494200.0086265,
     "ast_hash": "cc6e3c91b88b9be048d380224b8ca08f",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlClient.java": {
-    "mtime": 1782488208.1793513,
+    "mtime": 1782494200.0096247,
     "ast_hash": "1104a60eeea8d2368509e6a901fb824b",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlFiles.java": {
-    "mtime": 1782488208.1793513,
+    "mtime": 1782494200.0096247,
     "ast_hash": "e2f3d582e3b02783b4ad6ebae4ad030c",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlServer.java": {
-    "mtime": 1782488208.1803486,
+    "mtime": 1782494200.010625,
     "ast_hash": "842573fb335554672af12070b09b9c28",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/format/CaptureFormatException.java": {
-    "mtime": 1782488208.1803486,
+    "mtime": 1782494200.010625,
     "ast_hash": "16dd9ed34b8f5e575980e759908f5c4b",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/format/CaptureJsonCodec.java": {
-    "mtime": 1782488208.1813488,
+    "mtime": 1782494200.0116253,
     "ast_hash": "a805163d5ada4a16614b4c6c033c4347",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/format/CaptureSchemaMigrator.java": {
-    "mtime": 1782488208.1813488,
+    "mtime": 1782494200.0116253,
     "ast_hash": "65b0476a9fc1922aa2d1db391b4988fd",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureEnrichmentPreview.java": {
-    "mtime": 1782488208.182348,
+    "mtime": 1782494200.0126252,
     "ast_hash": "becc024cd2177b4113f3fc8746ec4354",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureEnrichmentService.java": {
-    "mtime": 1782488208.182348,
+    "mtime": 1782494200.0126252,
     "ast_hash": "4eb736b3f4f1ed574a280d779994b768",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationReport.java": {
-    "mtime": 1782488208.182348,
+    "mtime": 1782494200.013625,
     "ast_hash": "a478402031451dc70abbdb73165486b0",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationRequest.java": {
-    "mtime": 1782488208.1833487,
+    "mtime": 1782494200.013625,
     "ast_hash": "baf507818de7dc32b660e5163a2a0a67",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationResult.java": {
-    "mtime": 1782488208.1833487,
+    "mtime": 1782494200.013625,
     "ast_hash": "64235aa1fa46ab5857e3057e452eccab",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java": {
-    "mtime": 1782488208.1843493,
+    "mtime": 1782494200.0146255,
     "ast_hash": "07d5fd247851111b76dcf02412758df4",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/GeneratedTestValidator.java": {
-    "mtime": 1782488208.1853504,
+    "mtime": 1782494200.0156255,
     "ast_hash": "d3a5ba9e076837ea9685c089e1eb2b24",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/LocatorRanker.java": {
-    "mtime": 1782488208.1863496,
+    "mtime": 1782494200.0166252,
     "ast_hash": "b8de8d4abc874a48ab234270e224af6e",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/BrowserMetadata.java": {
-    "mtime": 1782488208.1863496,
+    "mtime": 1782494200.0176249,
     "ast_hash": "aca616578f082355fd0761f58597be5d",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/CaptureEvent.java": {
-    "mtime": 1782488208.187348,
+    "mtime": 1782494200.0176249,
     "ast_hash": "36642a12d8b21af2444a67fde759c546",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/CaptureSession.java": {
-    "mtime": 1782488208.187348,
+    "mtime": 1782494200.0176249,
     "ast_hash": "8b231d12ab3791b756caac91cbdb4c10",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/Checkpoint.java": {
-    "mtime": 1782488208.187348,
+    "mtime": 1782494200.0186255,
     "ast_hash": "2a3ca946a6921b589ae137ecc6f60581",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/ElementSnapshot.java": {
-    "mtime": 1782488208.1883473,
+    "mtime": 1782494200.0186255,
     "ast_hash": "14868c3708fab12f82feb3b9e24d01ec",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/EventContext.java": {
-    "mtime": 1782488208.1883473,
+    "mtime": 1782494200.0186255,
     "ast_hash": "a8a5457d7b613592975c3bc8297ccfee",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/EvidenceReference.java": {
-    "mtime": 1782488208.1893475,
+    "mtime": 1782494200.0196254,
     "ast_hash": "786eef193ba4ca565c23dc1d142ba475",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/ExternalTestDataReference.java": {
-    "mtime": 1782488208.1893475,
+    "mtime": 1782494200.0196254,
     "ast_hash": "fa36b8fb9e646b9d1b51ce0605d33d95",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/LocatorCandidate.java": {
-    "mtime": 1782488208.1893475,
+    "mtime": 1782494200.0196254,
     "ast_hash": "dd66b616e91d7e6fa0abfec2b475a90b",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/ModelSupport.java": {
-    "mtime": 1782488208.190347,
+    "mtime": 1782494200.020625,
     "ast_hash": "c54568ab63b584765e027d13eaa6e00b",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/PageContext.java": {
-    "mtime": 1782488208.190347,
+    "mtime": 1782494200.020625,
     "ast_hash": "8fa7d63b7d571c010f6c1a1d927e5400",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/RedactionSummary.java": {
-    "mtime": 1782488208.190347,
+    "mtime": 1782494200.0216253,
     "ast_hash": "7a5a3a53ec8011e51823968f7b2ba6a2",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/privacy/CapturePrivacyClassifier.java": {
-    "mtime": 1782488208.191349,
+    "mtime": 1782494200.0216253,
     "ast_hash": "0f9d46db745fc5bbe83ece1758401053",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/privacy/CapturePrivacyPolicy.java": {
-    "mtime": 1782488208.191349,
+    "mtime": 1782494200.0226257,
     "ast_hash": "77266ad326a57f7b2cf95ada13f2e221",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/privacy/ClassifiedValue.java": {
-    "mtime": 1782488208.1923473,
+    "mtime": 1782494200.0226257,
     "ast_hash": "b8dae78977adf61da8c1a8d42cf8e122",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureBrowser.java": {
-    "mtime": 1782488208.1923473,
+    "mtime": 1782494200.0236254,
     "ast_hash": "f1ca5592cf996f4503417bbc4c2c356b",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java": {
-    "mtime": 1782488208.1933465,
+    "mtime": 1782494200.0236254,
     "ast_hash": "eb742f395b2e2a63a45e73cf5529ac22",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureManager.java": {
-    "mtime": 1782488208.1933465,
+    "mtime": 1782494200.0236254,
     "ast_hash": "469574f4d08f284372ba708dd1e7a177",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureSingleSessionLock.java": {
-    "mtime": 1782488208.194347,
+    "mtime": 1782494200.0246248,
     "ast_hash": "fc8c18ea3f3fb1449c0545c9fec14b82",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureStartRequest.java": {
-    "mtime": 1782488208.1953492,
+    "mtime": 1782494200.0256248,
     "ast_hash": "b0b6151d075c56dc07fb266a8b18b316",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureStatus.java": {
-    "mtime": 1782488208.1953492,
+    "mtime": 1782494200.0256248,
     "ast_hash": "5a11ea402919f7b1718cd953c4f419a2",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java": {
-    "mtime": 1782488208.1953492,
+    "mtime": 1782494200.026626,
     "ast_hash": "bdf8eb306437199c02934d7815300ce7",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/storage/CaptureSessionStore.java": {
-    "mtime": 1782488208.1963475,
+    "mtime": 1782494200.026626,
     "ast_hash": "229b38b0e510e0d9c7b9a08bc71db5b9",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/storage/ExternalTestDataWriter.java": {
-    "mtime": 1782488208.1963475,
+    "mtime": 1782494200.027625,
     "ast_hash": "e69dc835c53bd61b0e8ccfc34f983185",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/resources/browser/shaft-capture-recorder.js": {
-    "mtime": 1782488208.1973486,
+    "mtime": 1782494200.0286238,
     "ast_hash": "6332eb239c5b09d577317d9933b5f8fb",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/resources/schema/shaft-capture-session-1.0.schema.json": {
-    "mtime": 1782488208.198349,
+    "mtime": 1782494200.0286238,
     "ast_hash": "df85a8de90f01cbb4c980201998901d0",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/CaptureFixtures.java": {
-    "mtime": 1782488208.1993494,
+    "mtime": 1782494200.0306256,
     "ast_hash": "5f889c8fbaec05b6f2741a137700d788",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/format/CaptureJsonCodecTest.java": {
-    "mtime": 1782488208.2023487,
+    "mtime": 1782494200.033626,
     "ast_hash": "231b3b2f5f283141335c78cf8983c065",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratedReplayBrowserTest.java": {
-    "mtime": 1782488208.2033472,
+    "mtime": 1782494200.033626,
     "ast_hash": "cd1a6080100cbce05841ce7a32757f17",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java": {
-    "mtime": 1782488208.2033472,
+    "mtime": 1782494200.034626,
     "ast_hash": "e95db718ca4958bd6673750fd8a9dab2",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/generate/LocatorRankerTest.java": {
-    "mtime": 1782488208.204347,
+    "mtime": 1782494200.034626,
     "ast_hash": "8c1ad098141cceb54b35c1a35c33d863",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/privacy/CapturePrivacyClassifierTest.java": {
-    "mtime": 1782488208.204347,
+    "mtime": 1782494200.0356255,
     "ast_hash": "7702332d104ea111fdec6e1fa99d6df3",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java": {
-    "mtime": 1782488208.2053487,
+    "mtime": 1782494200.0356255,
     "ast_hash": "fbbbba609aaaf9755e40d5504a4ecbb9",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureRuntimePortabilityTest.java": {
-    "mtime": 1782488208.2063472,
+    "mtime": 1782494200.036625,
     "ast_hash": "b4774a5bc9b7d84591360de0f8482164",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java": {
-    "mtime": 1782488208.2063472,
+    "mtime": 1782494200.0376298,
     "ast_hash": "c457491fa2232a3b4615fddf737611aa",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/storage/CaptureSessionStoreTest.java": {
-    "mtime": 1782488208.2073488,
+    "mtime": 1782494200.0386293,
     "ast_hash": "cc70993c979f97b8de7554bd34515622",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/resources/fixtures/golden-generated-session-1.java": {
-    "mtime": 1782488208.2083466,
+    "mtime": 1782494200.0386293,
     "ast_hash": "15d1969da9a2e6a0bc6efdee6f4c590d",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/resources/fixtures/golden-session-1.0.json": {
-    "mtime": 1782488208.2083466,
+    "mtime": 1782494200.0396297,
     "ast_hash": "94d6b5e35f7a9d8a12a448178eed460e",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/resources/fixtures/legacy-session-0.9.json": {
-    "mtime": 1782488208.209347,
+    "mtime": 1782494200.0396297,
     "ast_hash": "fe67510df7883478c930d414d5ad38cc",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/DoctorAiAnalysisRequest.java": {
-    "mtime": 1782488208.2113478,
+    "mtime": 1782494200.0426292,
     "ast_hash": "55678906c451524f9fb3c48d0d464ff9",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/DoctorAnalysisRequest.java": {
-    "mtime": 1782488208.2113478,
+    "mtime": 1782494200.0426292,
     "ast_hash": "6fb3dd5ae5993ce8a61e4cd73d327aa4",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/DoctorAnalyzer.java": {
-    "mtime": 1782488208.2123468,
+    "mtime": 1782494200.0437608,
     "ast_hash": "30b31bc51979d3f990c15ad91b5f4f4f",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/ai/DoctorAiAnalysisService.java": {
-    "mtime": 1782488208.2133467,
+    "mtime": 1782494200.0437608,
     "ast_hash": "4b1cd2196306a10434d9df255bf01d8d",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/analysis/DeterministicRuleEngine.java": {
-    "mtime": 1782488208.2133467,
+    "mtime": 1782494200.0447655,
     "ast_hash": "732501c3f0664de7f83469e8d9db5a70",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/cli/DoctorCli.java": {
-    "mtime": 1782488208.2143462,
+    "mtime": 1782494200.0457654,
     "ast_hash": "c7277004cfa5eae27d5f7d1477ec92a4",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/collect/EvidenceCollector.java": {
-    "mtime": 1782488208.215347,
+    "mtime": 1782494200.0457654,
     "ast_hash": "3e05599d12a2c4e9999260e249e53e71",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/format/DoctorFormatException.java": {
-    "mtime": 1782488208.215347,
+    "mtime": 1782494200.0467656,
     "ast_hash": "ac49bb5981592a48aed69d5e929e8357",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/format/DoctorJsonCodec.java": {
-    "mtime": 1782488208.215347,
+    "mtime": 1782494200.0467656,
     "ast_hash": "e37f60eedfbf0c389362d3fcf8884981",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/internal/DoctorHashing.java": {
-    "mtime": 1782488208.216346,
+    "mtime": 1782494200.047766,
     "ast_hash": "cbf37af4f45fcd49e34d177a36e7788e",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/internal/DoctorRedactor.java": {
-    "mtime": 1782488208.216346,
+    "mtime": 1782494200.047766,
     "ast_hash": "50c5ae3ae3589a795ce05bd77aeb022d",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/CauseCategory.java": {
-    "mtime": 1782488208.2173462,
+    "mtime": 1782494200.0487654,
     "ast_hash": "07daed154b031e5c8e8a67f58d60c076",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/Confidence.java": {
-    "mtime": 1782488208.2173462,
+    "mtime": 1782494200.0487654,
     "ast_hash": "58efa214b4b396e5cd16320ecb7f1419",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/Diagnosis.java": {
-    "mtime": 1782488208.2173462,
+    "mtime": 1782494200.0487654,
     "ast_hash": "d5f6f816532eebb1a0ce72949dc26637",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAdvisory.java": {
-    "mtime": 1782488208.218346,
+    "mtime": 1782494200.04977,
     "ast_hash": "844eaf9048ab13c94b72ba4145b589f8",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAiAnalysisResult.java": {
-    "mtime": 1782488208.218346,
+    "mtime": 1782494200.04977,
     "ast_hash": "93cd26759f448a2370ea5a793ccd0ecc",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAnalysisResult.java": {
-    "mtime": 1782488208.2193472,
+    "mtime": 1782494200.04977,
     "ast_hash": "ae20f4a3cd962138db3be05bd442ef21",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAnalysisSummary.java": {
-    "mtime": 1782488208.2193472,
+    "mtime": 1782494200.050766,
     "ast_hash": "db1612663a72eceaf8b36d02e4534f99",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorModelSupport.java": {
-    "mtime": 1782488208.2193472,
+    "mtime": 1782494200.050766,
     "ast_hash": "8e4a6c083ab2a7837d98104a9ce23b8c",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/EvidenceBundle.java": {
-    "mtime": 1782488208.2203462,
+    "mtime": 1782494200.050766,
     "ast_hash": "f1ce8926f044be3bd0652d3b43f91946",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/EvidenceCategory.java": {
-    "mtime": 1782488208.2203462,
+    "mtime": 1782494200.050766,
     "ast_hash": "6976b42e37761f612bdee1f8d2cd8f50",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/EvidenceItem.java": {
-    "mtime": 1782488208.2213461,
+    "mtime": 1782494200.0522704,
     "ast_hash": "2a427690ae34f946851017d16c18a5ab",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/EvidenceProvenance.java": {
-    "mtime": 1782488208.2213461,
+    "mtime": 1782494200.052827,
     "ast_hash": "56bd866d04bd1ab56863ab0aa104a31c",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/Finding.java": {
-    "mtime": 1782488208.2223468,
+    "mtime": 1782494200.0533462,
     "ast_hash": "ca086338b16ab81a80882d4830254620",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/RedactionSummary.java": {
-    "mtime": 1782488208.2223468,
+    "mtime": 1782494200.0533462,
     "ast_hash": "5fcbb50a506dd9456d5ec76fe90a4ea7",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/Remediation.java": {
-    "mtime": 1782488208.2223468,
+    "mtime": 1782494200.0543516,
     "ast_hash": "45487f78e554324e826976f19b75dadc",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairAiRequest.java": {
-    "mtime": 1782488208.2233455,
+    "mtime": 1782494200.0543516,
     "ast_hash": "cb971f162e01bc90678e0d40e08d0947",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairAiService.java": {
-    "mtime": 1782488208.2233455,
+    "mtime": 1782494200.0543516,
     "ast_hash": "0d4d59f92ec198022b0e44682359ac82",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairPatchResult.java": {
-    "mtime": 1782488208.2243469,
+    "mtime": 1782494200.0553515,
     "ast_hash": "309c6a07dc3145574d2e2bbd54c7b334",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairProposalResult.java": {
-    "mtime": 1782488208.2243469,
+    "mtime": 1782494200.0553515,
     "ast_hash": "6a01cd05b4c6b271ce7ab395d393e396",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairPublicationRequest.java": {
-    "mtime": 1782488208.2243469,
+    "mtime": 1782494200.0563517,
     "ast_hash": "50162373c4b5f046f867b5d1344816c7",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairRequest.java": {
-    "mtime": 1782488208.2253456,
+    "mtime": 1782494200.0563517,
     "ast_hash": "8afe0727b1629734c1b865c805d613f3",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairService.java": {
-    "mtime": 1782488208.2253456,
+    "mtime": 1782494200.0573523,
     "ast_hash": "3ddd9b9f7ec71452100a891378758166",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposal.java": {
-    "mtime": 1782488208.2253456,
+    "mtime": 1782494200.0573523,
     "ast_hash": "72e037d2cc8aac280c799b1f76147c4c",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposalRequest.java": {
-    "mtime": 1782488208.2263472,
+    "mtime": 1782494200.0573523,
     "ast_hash": "b53a430ae27cf976040410a97b06a37b",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposalService.java": {
-    "mtime": 1782488208.2263472,
+    "mtime": 1782494200.058352,
     "ast_hash": "1f0ea7387c631ddb9501dc97f144e27b",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/RepairGuard.java": {
-    "mtime": 1782488208.2273455,
+    "mtime": 1782494200.058352,
     "ast_hash": "fba5356ab168ee237ee6530712c94f00",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/RepairProcessRunner.java": {
-    "mtime": 1782488208.2273455,
+    "mtime": 1782494200.058352,
     "ast_hash": "5fe1cd3c8e8b190bcab936fd417b3825",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/RepairProposal.java": {
-    "mtime": 1782488208.2273455,
+    "mtime": 1782494200.0593517,
     "ast_hash": "f1e22305d666390fc499f30d41184bc7",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/RepairProposalStore.java": {
-    "mtime": 1782488208.228347,
+    "mtime": 1782494200.0593517,
     "ast_hash": "e94f86295598c8f1ae590214048bd53b",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/RepairPublicationResult.java": {
-    "mtime": 1782488208.228347,
+    "mtime": 1782494200.0603516,
     "ast_hash": "54b09925ec8f18ec028ba4dec8dfceee",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/report/DoctorReportWriter.java": {
-    "mtime": 1782488208.228347,
+    "mtime": 1782494200.0603516,
     "ast_hash": "cf246a6dccada6bd2ad38899deed5728",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-doctor-advisory-1.0.schema.json": {
-    "mtime": 1782488208.2293465,
+    "mtime": 1782494200.0613518,
     "ast_hash": "0707502a8d574324252c3e6c9e59b68e",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-doctor-diagnosis-1.0.schema.json": {
-    "mtime": 1782488208.2303455,
+    "mtime": 1782494200.0613518,
     "ast_hash": "955b53f8d49daea98d4ac1fc82d40587",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-doctor-evidence-1.0.schema.json": {
-    "mtime": 1782488208.231323,
+    "mtime": 1782494200.0623517,
     "ast_hash": "62af20c56b0b7df2415adc87012a03c7",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-doctor-repair-patch-1.0.schema.json": {
-    "mtime": 1782488208.231323,
+    "mtime": 1782494200.0623517,
     "ast_hash": "0798e219e11cb74541c713d96d2ac2a9",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-heal-locator-proposal-1.0.schema.json": {
-    "mtime": 1782488208.2323308,
+    "mtime": 1782494200.0633523,
     "ast_hash": "ede7581c250a246a7ef50c26116e926b",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/DoctorAnalyzerTest.java": {
-    "mtime": 1782488208.2343304,
+    "mtime": 1782494200.065351,
     "ast_hash": "1e2c4f9eaed66529617181aba1349bc0",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/ai/DoctorAiAnalysisServiceTest.java": {
-    "mtime": 1782488208.235328,
+    "mtime": 1782494200.065351,
     "ast_hash": "a4275d927157b9dcdca5a983b2cf514a",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/repair/DoctorRepairAiServiceTest.java": {
-    "mtime": 1782488208.2363298,
+    "mtime": 1782494200.0663514,
     "ast_hash": "42a607d9a057330ca195c6cfc9ae7d54",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/repair/DoctorRepairServiceTest.java": {
-    "mtime": 1782488208.2363298,
+    "mtime": 1782494200.0663514,
     "ast_hash": "0de5d211d8c45c9799e1b2487f28106c",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/repair/HealingLocatorProposalServiceTest.java": {
-    "mtime": 1782488208.237329,
+    "mtime": 1782494200.067351,
     "ast_hash": "87a964a179a869fd747537abc1dee167",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/ai/contradictory.json": {
-    "mtime": 1782488208.23833,
+    "mtime": 1782494200.068352,
     "ast_hash": "9cc3faaf569b9523478d440eac4c31fa",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/ai/hallucinated-evidence.json": {
-    "mtime": 1782488208.23833,
+    "mtime": 1782494200.068352,
     "ast_hash": "8392a8f0353b0006ce35cee8a3cd04e4",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/ai/high-quality.json": {
-    "mtime": 1782488208.2393286,
+    "mtime": 1782494200.0693512,
     "ast_hash": "e6f7861bf34853d8e39252b93d0f7ee4",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/ai/malformed.json": {
-    "mtime": 1782488208.2393286,
+    "mtime": 1782494200.0693512,
     "ast_hash": "fb9415fb50bc91677036081513bbc19d",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/ai/unavailable.json": {
-    "mtime": 1782488208.2393286,
+    "mtime": 1782494200.0693512,
     "ast_hash": "4b7fec724f675abb3404bc58a0cd21fd",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/golden/doctor-report.json": {
-    "mtime": 1782488208.2403295,
+    "mtime": 1782494200.0703514,
     "ast_hash": "d19a4cec92c592cf6f3804f87c7d1ac8",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/golden/locator-result.json": {
-    "mtime": 1782488208.2413282,
+    "mtime": 1782494200.0713513,
     "ast_hash": "cc0963373d7ae1eb7e2026ce65f5c16d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/RequestBuilder.java": {
-    "mtime": 1782488208.2443314,
+    "mtime": 1782494200.0733516,
     "ast_hash": "34c8e423e16aa9e147db977d27b95247",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/RestActions.java": {
-    "mtime": 1782488208.2453313,
+    "mtime": 1782494200.0743518,
     "ast_hash": "bb4110145f033982f6cf53c82a029933",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/ShaftRestAssuredFilter.java": {
-    "mtime": 1782488208.2463276,
+    "mtime": 1782494200.0753517,
     "ast_hash": "0e271de5a8f7a30068f6ddad09c63554",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cli/FileActions.java": {
-    "mtime": 1782488208.2473283,
+    "mtime": 1782494200.0773518,
     "ast_hash": "a1d907444ba2bc35977265503c7c916d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java": {
-    "mtime": 1782488208.2483273,
+    "mtime": 1782494200.0773518,
     "ast_hash": "c7bf3c6c81a85d681faa3a2756728587",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cucumber/AssertionSteps.java": {
-    "mtime": 1782488208.2483273,
+    "mtime": 1782494200.0783525,
     "ast_hash": "2ff1069e84fc689b831cdddc2098f1ee",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cucumber/BrowserSteps.java": {
-    "mtime": 1782488208.249328,
+    "mtime": 1782494200.0793521,
     "ast_hash": "ad3b088235e9d348c8563ed46da91944",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cucumber/ElementSteps.java": {
-    "mtime": 1782488208.249328,
+    "mtime": 1782494200.0793521,
     "ast_hash": "5174cbfba57ae0fc18a79de0c4491af1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/db/DatabaseActions.java": {
-    "mtime": 1782488208.2503304,
+    "mtime": 1782494200.0803516,
     "ast_hash": "e94ab6b3d65838a79da1adf16ace4c37",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/DriverFactory.java": {
-    "mtime": 1782488208.2513306,
+    "mtime": 1782494200.0803516,
     "ast_hash": "8ee0caf3a105473f413b00ac8f1f9adf",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/SHAFT.java": {
-    "mtime": 1782488208.2513306,
+    "mtime": 1782494200.0813503,
     "ast_hash": "5feaeca4aedf6340314e3075ca856152",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/$.java": {
-    "mtime": 1782488208.2523303,
+    "mtime": 1782494200.0823505,
     "ast_hash": "f0f29bf4777208e42080bbb8d92c7655",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/BrowserStackHelper.java": {
-    "mtime": 1782488208.2523303,
+    "mtime": 1782494200.0823505,
     "ast_hash": "8269be54fd38e960b0e7acb0b3009e21",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/BrowserStackSdkHelper.java": {
-    "mtime": 1782488208.2533312,
+    "mtime": 1782494200.0833507,
     "ast_hash": "85c848b791627a3f81dc6f1499440f48",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java": {
-    "mtime": 1782488208.2543302,
+    "mtime": 1782494200.0833507,
     "ast_hash": "0b7dbedb2be78d716c8464ab5c74b235",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/LambdaTestHelper.java": {
-    "mtime": 1782488208.2543302,
+    "mtime": 1782494200.084351,
     "ast_hash": "3f3755d291c98c32cfdd363cee4cf73a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java": {
-    "mtime": 1782488825.0553293,
-    "ast_hash": "8f373a5860df8a0bc37fd9f42bac4756",
+    "mtime": 1782494200.0853512,
+    "ast_hash": "dcdc8189ab5888b9875e4e1be4fe7b02",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/SynchronizationManager.java": {
-    "mtime": 1782488208.2553308,
+    "mtime": 1782494200.0853512,
     "ast_hash": "eb0cff7a79a25b8e6999426d21353757",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/FluentWebDriverAction.java": {
-    "mtime": 1782488208.2563393,
+    "mtime": 1782494200.0863519,
     "ast_hash": "72da0e0b47b4f503c107c7add47ab23a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/WizardHelpers.java": {
-    "mtime": 1782488208.2563393,
+    "mtime": 1782494200.0863519,
     "ast_hash": "f6788d05f21d1f430ac6325b5aa234c6",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/enums/internal/ClipboardAction.java": {
-    "mtime": 1782488208.257339,
+    "mtime": 1782494200.0883524,
     "ast_hash": "70733b35a3b354ad26cb2293c92e7c1f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/enums/internal/NavigationAction.java": {
-    "mtime": 1782488208.257339,
+    "mtime": 1782494200.0883524,
     "ast_hash": "c58c8262a7e2348b6984ff75638f997a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/enums/internal/Screenshots.java": {
-    "mtime": 1782488208.2583394,
+    "mtime": 1782494200.0893588,
     "ast_hash": "623942ecc89e633c28fa2014876ac552",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java": {
-    "mtime": 1782488809.837684,
-    "ast_hash": "48365c48ead2c8d26ef2aedfe77f03ed",
+    "mtime": 1782494200.0903578,
+    "ast_hash": "c97eaeac6bbe972c3b497459cb88b492",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserActionsHelper.java": {
-    "mtime": 1782488208.2603393,
+    "mtime": 1782494200.092357,
     "ast_hash": "075368ab4db20c113dd0ffe77c9bdaec",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/JavaScriptWaitManager.java": {
-    "mtime": 1782488208.262892,
+    "mtime": 1782494200.094357,
     "ast_hash": "2461e01c04d95924a01f0c83b9ad7029",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/AlertActions.java": {
-    "mtime": 1782488208.2668908,
+    "mtime": 1782494200.0993564,
     "ast_hash": "c2ff4367374c900d0bc60c4902faa451",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/AsyncElementActions.java": {
-    "mtime": 1782488208.26789,
+    "mtime": 1782494200.0993564,
     "ast_hash": "b127634e4819e21e34a549ba21ca7a03",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/ElementActions.java": {
-    "mtime": 1782488208.26789,
+    "mtime": 1782494200.0993564,
     "ast_hash": "be3bc856752a3cdaed67fc1f0bccdbc4",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java": {
-    "mtime": 1782489844.1409533,
-    "ast_hash": "1254c287590125cecab0a17421c30a6a",
+    "mtime": 1782494200.1003568,
+    "ast_hash": "ac223f9bf39a8c2391c01154cfc361d7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java": {
-    "mtime": 1782488783.4249754,
-    "ast_hash": "7faa72cc0b4556ccf554cef454d325cd",
+    "mtime": 1782494200.101357,
+    "ast_hash": "d750ce1041311d1ada17c796175a92ae",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java": {
-    "mtime": 1782488770.9709353,
-    "ast_hash": "9a8a0805705b3e2d23b56e21505b4b21",
+    "mtime": 1782494200.102357,
+    "ast_hash": "23ca8f8d0a49d388f8f1841c67fa751a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementInformation.java": {
-    "mtime": 1782488208.2712376,
+    "mtime": 1782494200.1038618,
     "ast_hash": "069e9385670d467fcfd1f7210d9e34cc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/exceptions/MultipleElementsFoundException.java": {
-    "mtime": 1782488208.2722423,
+    "mtime": 1782494200.1049764,
     "ast_hash": "7115d38040575ebf54fb3f543a30290f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingActionOutcome.java": {
-    "mtime": 1782488208.2722423,
+    "mtime": 1782494200.1049764,
     "ast_hash": "9a99f0ead6650249de18d721129711cc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingExplanation.java": {
-    "mtime": 1782488208.273243,
+    "mtime": 1782494200.1059818,
     "ast_hash": "ee26d9a41572d22c59b897020537b16e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingManager.java": {
-    "mtime": 1782488208.273243,
+    "mtime": 1782494200.1059818,
     "ast_hash": "c5e38dd4184e53deeccad977f263fb31",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingObservation.java": {
-    "mtime": 1782488208.2742424,
+    "mtime": 1782494200.1059818,
     "ast_hash": "a5423face0fd000d6ecaca3410a7b2e3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingProvider.java": {
-    "mtime": 1782488208.2742424,
+    "mtime": 1782494200.1069803,
     "ast_hash": "ebf8923cd40ade102731421c41f57986",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingProviderRegistry.java": {
-    "mtime": 1782488208.2742424,
+    "mtime": 1782494200.1069803,
     "ast_hash": "3cbe60277c5b519104b46355f11b3849",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingRequest.java": {
-    "mtime": 1782488208.2752423,
+    "mtime": 1782494200.1069803,
     "ast_hash": "01fa33edca22567bffb147b7698ef87d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingResolution.java": {
-    "mtime": 1782488208.2752423,
+    "mtime": 1782494200.107983,
     "ast_hash": "53c802fb2320dd3320128019dcb8e965",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingStrategy.java": {
-    "mtime": 1782488208.2752423,
+    "mtime": 1782494200.107983,
     "ast_hash": "28500b405d7d843f0099971b196415d1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingVisualProvider.java": {
-    "mtime": 1782488208.276242,
+    "mtime": 1782494200.107983,
     "ast_hash": "cf4607a228a2c6f37ef287bf95c02905",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/AnimatedGifManager.java": {
-    "mtime": 1782488208.276242,
+    "mtime": 1782494200.1089814,
     "ast_hash": "820ea16bfa9e8397fcc97592f8dc1515",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java": {
-    "mtime": 1782488208.277243,
+    "mtime": 1782494200.1089814,
     "ast_hash": "565b9fd29ad4d7772d5ea0ff92a49361",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotHelper.java": {
-    "mtime": 1782488208.277243,
+    "mtime": 1782494200.1099803,
     "ast_hash": "bd9223dc2b3615bddc02e58bc5ec999f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotManager.java": {
-    "mtime": 1782488208.2782426,
+    "mtime": 1782494200.1099803,
     "ast_hash": "240f2b556c600521967063f1217b1c16",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/VisualProcessingProvider.java": {
-    "mtime": 1782488208.2782426,
+    "mtime": 1782494200.1109805,
     "ast_hash": "b82bb32f7bba8fd5bce43c64dd8451a7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/VisualProcessingProviderRegistry.java": {
-    "mtime": 1782488208.279242,
+    "mtime": 1782494200.1109805,
     "ast_hash": "9b616f64cbbddb4faead5b8f0a9c21b9",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/Locator.java": {
-    "mtime": 1782488208.280242,
+    "mtime": 1782494200.1119807,
     "ast_hash": "e02bf607fbeff72dd9b178b08bf8d85b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/LocatorBuilder.java": {
-    "mtime": 1782488208.280242,
+    "mtime": 1782494200.1129808,
     "ast_hash": "5cfd4d2b383e696367b5d1d0070bee58",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/Locators.java": {
-    "mtime": 1782488208.2812426,
+    "mtime": 1782494200.1129808,
     "ast_hash": "c75c5f50d1a2cfb34eac7e66c23ddedc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/Role.java": {
-    "mtime": 1782488208.2812426,
+    "mtime": 1782494200.1139808,
     "ast_hash": "7f35dc1a5a395ed93e4c158badb0ec2b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/ShadowLocatorBuilder.java": {
-    "mtime": 1782488208.2812426,
+    "mtime": 1782494200.1139808,
     "ast_hash": "ebec375f08bc01a3b1502aed75f1231d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/SmartLocators.java": {
-    "mtime": 1782488208.2822423,
+    "mtime": 1782494200.1139808,
     "ast_hash": "ac3f2f53dff343d16473fb990039b2d4",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/XpathAxis.java": {
-    "mtime": 1782488208.2822423,
+    "mtime": 1782494200.1149802,
     "ast_hash": "15de5fb7fe4ce1ecbf3fc6b5022ba3df",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/DeterministicNaturalActionPlanner.java": {
-    "mtime": 1782488208.2832417,
+    "mtime": 1782494200.1159804,
     "ast_hash": "3442170386262904fcec37a0a4de984a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionExecutor.java": {
-    "mtime": 1782488208.2842424,
+    "mtime": 1782494200.1159804,
     "ast_hash": "27f19328ab9d5a45da44797cdce1d2a5",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionKind.java": {
-    "mtime": 1782488208.2842424,
+    "mtime": 1782494200.1169803,
     "ast_hash": "7ab19c76ab5d66cdc94e8183b5c4fe4c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionPlan.java": {
-    "mtime": 1782488208.2842424,
+    "mtime": 1782494200.1169803,
     "ast_hash": "c913e5edcb2b9594946cf5b50362d108",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionPlanner.java": {
-    "mtime": 1782488208.2852418,
+    "mtime": 1782494200.1179807,
     "ast_hash": "544f27ddc74a8a6732e6ad6e2f7da494",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionPlannerRegistry.java": {
-    "mtime": 1782488208.2852418,
+    "mtime": 1782494200.1179807,
     "ast_hash": "8a223a42ffda00a3e13ae108748a8270",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionRequest.java": {
-    "mtime": 1782488208.286242,
+    "mtime": 1782494200.1189816,
     "ast_hash": "2398af5cb7efdca4f0b32d129bb361e4",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionStep.java": {
-    "mtime": 1782488208.286242,
+    "mtime": 1782494200.1189816,
     "ast_hash": "29b36b4244b122ef2e6dd4c391c99625",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/video/DesktopVideoRecordingProvider.java": {
-    "mtime": 1782488208.2872417,
+    "mtime": 1782494200.119981,
     "ast_hash": "b98f55fe150407bba68594b78fb2e5b7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistry.java": {
-    "mtime": 1782488208.2872417,
+    "mtime": 1782494200.119981,
     "ast_hash": "5cb846a30b50df2b01b15bb5abaf362f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/video/RecordManager.java": {
-    "mtime": 1782488208.2882416,
+    "mtime": 1782494200.1209805,
     "ast_hash": "ee83db977f0369f56d0b5074c791b6d0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/AllureListener.java": {
-    "mtime": 1782488208.2962406,
+    "mtime": 1782494200.127982,
     "ast_hash": "641101e959b09cf49e071682e194a87e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/CucumberFeatureListener.java": {
-    "mtime": 1782488208.2962406,
+    "mtime": 1782494200.1289809,
     "ast_hash": "14d03222afd184a66843e942e8d6c838",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/CucumberTestRunnerListener.java": {
-    "mtime": 1782488208.2972414,
+    "mtime": 1782494200.1289809,
     "ast_hash": "4d4b34169ad6f2440e377838f32554f3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/JunitListener.java": {
-    "mtime": 1782488208.2982416,
+    "mtime": 1782494200.1299798,
     "ast_hash": "38e6748586de2a4c89b9e0420b19adcf",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/TestNGListener.java": {
-    "mtime": 1782488208.2982416,
+    "mtime": 1782494200.1309803,
     "ast_hash": "fe806f53d06c128da2a60a1b72d5efa6",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/ConfigurationHelper.java": {
-    "mtime": 1782488208.2992413,
+    "mtime": 1782494200.1309803,
     "ast_hash": "e96809e943e2adb15f47a9c242a540dc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/CucumberHelper.java": {
-    "mtime": 1782488208.2992413,
+    "mtime": 1782494200.1319802,
     "ast_hash": "7f583d0c5e8b9445b007f08fb0ba6488",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/JiraHelper.java": {
-    "mtime": 1782488208.3012412,
+    "mtime": 1782494200.1329806,
     "ast_hash": "a4ef92cd147ecdaf44ef9f805da98c73",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/JunitListenerHelper.java": {
-    "mtime": 1782488208.3012412,
+    "mtime": 1782494200.1339848,
     "ast_hash": "5a96f15340ee466d71733a4977fab257",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/RetryAnalyzer.java": {
-    "mtime": 1782488208.3022406,
+    "mtime": 1782494200.1339848,
     "ast_hash": "fdd8846beddec616e3655b207196f8c2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java": {
-    "mtime": 1782488208.3022406,
+    "mtime": 1782494200.13498,
     "ast_hash": "ac43ab8deccc14de30e3f0f3f4b93fdf",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/UpdateChecker.java": {
-    "mtime": 1782488208.3032408,
+    "mtime": 1782494200.13498,
     "ast_hash": "56edc5784cd56e08113f0d04f51fd25a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/WebDriverListener.java": {
-    "mtime": 1782488208.3032408,
+    "mtime": 1782494200.1359804,
     "ast_hash": "11caa57a58f17da0416933518895efdd",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/performance/internal/LightHouseGenerateReport.java": {
-    "mtime": 1782488208.3042405,
+    "mtime": 1782494200.1369803,
     "ast_hash": "8395aa33dcea0312ab66a82c9fc7eb77",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/API.java": {
-    "mtime": 1782488208.3052406,
+    "mtime": 1782494200.1369803,
     "ast_hash": "3cdf98e461d7ea0238964504b7281fa7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Allure.java": {
-    "mtime": 1782488208.3052406,
+    "mtime": 1782494200.1379802,
     "ast_hash": "b7daa2d86513e1304c39f664df81aeb3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/BrowserStack.java": {
-    "mtime": 1782488208.306241,
+    "mtime": 1782494200.1379802,
     "ast_hash": "2c4ea1d03ddde366471ab7d371f129c0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Cucumber.java": {
-    "mtime": 1782488208.306241,
+    "mtime": 1782494200.1389802,
     "ast_hash": "563b9ce2f293404c06e4a7a73dab132b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/EngineProperties.java": {
-    "mtime": 1782488208.306241,
+    "mtime": 1782494200.1389802,
     "ast_hash": "e7d9d408bcf36812505cd26632b45ccc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Flags.java": {
-    "mtime": 1782488208.3072405,
+    "mtime": 1782494200.13998,
     "ast_hash": "643347d2cdd011d79a7504db2bc868b4",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Healenium.java": {
-    "mtime": 1782488208.3072405,
+    "mtime": 1782494200.13998,
     "ast_hash": "020bedc94874be8d4f237c2007a9244c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Healing.java": {
-    "mtime": 1782488208.308241,
+    "mtime": 1782494200.13998,
     "ast_hash": "d6b881dfe76fe2145f6a3f21096896cd",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java": {
-    "mtime": 1782488208.308241,
+    "mtime": 1782494200.14098,
     "ast_hash": "0dcc9d873618f00473caca1408d915b1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Jira.java": {
-    "mtime": 1782488208.30924,
+    "mtime": 1782494200.14098,
     "ast_hash": "69e39c376eb244713a8638e8b682931a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/LambdaTest.java": {
-    "mtime": 1782488208.30924,
+    "mtime": 1782494200.14098,
     "ast_hash": "2129d3567c4540656d0f1a70a4b5836e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Log4j.java": {
-    "mtime": 1782488208.30924,
+    "mtime": 1782494200.1419797,
     "ast_hash": "64f209cc056e8a51110fc91a200d8abc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Mobile.java": {
-    "mtime": 1782488208.31024,
+    "mtime": 1782494200.1419797,
     "ast_hash": "99c440a93cda95169b39727741055898",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/NaturalActions.java": {
-    "mtime": 1782488208.31024,
+    "mtime": 1782494200.1419797,
     "ast_hash": "16794b31ca521ab70430850b04a80827",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Paths.java": {
-    "mtime": 1782488208.31124,
+    "mtime": 1782494200.14298,
     "ast_hash": "e75d6d00fdd8079a0bc4e51ceec9152d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Pattern.java": {
-    "mtime": 1782488208.31124,
+    "mtime": 1782494200.14298,
     "ast_hash": "8002dccd85dcdaafcd7ec207d48f88a5",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Performance.java": {
-    "mtime": 1782488208.31124,
+    "mtime": 1782494200.1439803,
     "ast_hash": "8dbd8e97cf8b7f777b1f20aef1630a52",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Pilot.java": {
-    "mtime": 1782488208.3122406,
+    "mtime": 1782494200.1439803,
     "ast_hash": "5926e78f43d97233473dd978b9e55623",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Platform.java": {
-    "mtime": 1782488208.3122406,
+    "mtime": 1782494200.1439803,
     "ast_hash": "ba6e6ce752e51b47b72229aa04fd4fe3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Properties.java": {
-    "mtime": 1782488208.3132398,
+    "mtime": 1782494200.1449845,
     "ast_hash": "f2a5ec5f2f57f7b18d68808b3f0a9e91",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java": {
-    "mtime": 1782488208.3142397,
+    "mtime": 1782494200.1459801,
     "ast_hash": "322d6ce15493bbfa7ddfe90af768da21",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/PropertyFileManager.java": {
-    "mtime": 1782488208.3142397,
+    "mtime": 1782494200.1459801,
     "ast_hash": "2ab8de326fa8ddb7229618022678ed9e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Reporting.java": {
-    "mtime": 1782488208.3142397,
+    "mtime": 1782494200.1469798,
     "ast_hash": "3c776912a22f41ada8e6ba8143e2d589",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/TestNG.java": {
-    "mtime": 1782488208.3152397,
+    "mtime": 1782494200.1469798,
     "ast_hash": "1adc422ea00e7c51988bc02d45281486",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/ThreadLocalPropertiesManager.java": {
-    "mtime": 1782488208.3152397,
+    "mtime": 1782494200.1469798,
     "ast_hash": "7603bbb7bf6364ce7bf5b9f5e1bba5e1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Timeouts.java": {
-    "mtime": 1782488208.3162394,
+    "mtime": 1782494200.1479802,
     "ast_hash": "01ef9ffeba24462276fb15dc4a4d373f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Tinkey.java": {
-    "mtime": 1782488208.3162394,
+    "mtime": 1782494200.1479802,
     "ast_hash": "f35fc1565279b0d33b1b76121bf74440",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Visuals.java": {
-    "mtime": 1782488208.3162394,
+    "mtime": 1782494200.1479802,
     "ast_hash": "606feddfa218d572c43882a90f235400",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Web.java": {
-    "mtime": 1782488208.31724,
+    "mtime": 1782494200.1489801,
     "ast_hash": "20cf2529ea8129f74e8f092bc14cadde",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/FirestoreRestClient.java": {
-    "mtime": 1782488208.3182397,
+    "mtime": 1782494200.1499813,
     "ast_hash": "52adc8b518e5c5ed1246fd4aa8271ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/security/GoogleTink.java": {
-    "mtime": 1782488208.3182397,
+    "mtime": 1782494200.1499813,
     "ast_hash": "3d0e1234d2dbab5b9ef7b984cb681088",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/AndroidApkBadgingReader.java": {
-    "mtime": 1782488208.31924,
+    "mtime": 1782494200.1509807,
     "ast_hash": "eb3f564e4c3e3d2f3ffccaf882ac4b1f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/HTMLHelper.java": {
-    "mtime": 1782488208.31924,
+    "mtime": 1782494200.1509807,
     "ast_hash": "057fe001f1e4b25c8f7229cde35c7d16",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/JavaHelper.java": {
-    "mtime": 1782488208.3202386,
+    "mtime": 1782494200.15198,
     "ast_hash": "3de9ea3f98b99d20eeeb148de402cfed",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/JavaScriptHelper.java": {
-    "mtime": 1782488208.3202386,
+    "mtime": 1782494200.15198,
     "ast_hash": "ffa7c4c697733f0ba85ac8992acad360",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/PerformanceReportHTMLHelper.java": {
-    "mtime": 1782488208.3212395,
+    "mtime": 1782494200.1529806,
     "ast_hash": "dac9a665ae8b1ec2ec6773a23a0c921c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/tms/XrayIntegrationHelper.java": {
-    "mtime": 1782488208.3212395,
+    "mtime": 1782494200.1539807,
     "ast_hash": "eb849fadba51320243f21ab56502a88a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/CSVFileManager.java": {
-    "mtime": 1782488208.3222399,
+    "mtime": 1782494200.1539807,
     "ast_hash": "cc3031fcc8e920871577f8dec0b42805",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/ExcelFileManager.java": {
-    "mtime": 1782488208.3222399,
+    "mtime": 1782494200.1549802,
     "ast_hash": "77c92476b59d21096ff6f14788089dd9",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/JSONFileManager.java": {
-    "mtime": 1782488208.323239,
+    "mtime": 1782494200.1549802,
     "ast_hash": "dd7a5b8f6f927191caa131280df13a65",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/PdfFileManager.java": {
-    "mtime": 1782488208.323239,
+    "mtime": 1782494200.1549802,
     "ast_hash": "da672eb4269d3a41533ed1532da0e185",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/ReportManager.java": {
-    "mtime": 1782488208.3242397,
+    "mtime": 1782494200.1559796,
     "ast_hash": "e658122a017e7931fced4022a1d53bae",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/YAMLFileManager.java": {
-    "mtime": 1782488208.3242397,
+    "mtime": 1782494200.1559796,
     "ast_hash": "d5a21b7fac317f8b4e5341c703a0a249",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java": {
-    "mtime": 1782488208.3252394,
+    "mtime": 1782494200.1569808,
     "ast_hash": "73a56b098e311ecbbea558b287bdbef8",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ApiPerformanceExecutionReport.java": {
-    "mtime": 1782488208.3262396,
+    "mtime": 1782494200.1579804,
     "ast_hash": "833e6f15ddd03a4dc3f70a15a011a4af",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/AttachmentReporter.java": {
-    "mtime": 1782488208.3262396,
+    "mtime": 1782494200.1579804,
     "ast_hash": "ee4e194c669dd4c064f871706770af38",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointCounter.java": {
-    "mtime": 1782488208.3282397,
+    "mtime": 1782494200.1599805,
     "ast_hash": "34558a6d4d5d49df20017aa63876759f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointStatus.java": {
-    "mtime": 1782488208.3282397,
+    "mtime": 1782494200.1599805,
     "ast_hash": "02d39d0739d083d1109634c17bb340c1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointType.java": {
-    "mtime": 1782488208.3282397,
+    "mtime": 1782494200.1599805,
     "ast_hash": "e688c7535844f865f0c179f1f0f7a41b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ExecutionSummaryReport.java": {
-    "mtime": 1782488208.3292394,
+    "mtime": 1782494200.1609807,
     "ast_hash": "85be5b1acb498075ff0ae7394c116e10",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureReporter.java": {
-    "mtime": 1782488208.330239,
+    "mtime": 1782494200.16198,
     "ast_hash": "5c3cbaf91f5d1501231b96f95bf6d566",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/IssueReporter.java": {
-    "mtime": 1782488208.3322394,
+    "mtime": 1782494200.1639802,
     "ast_hash": "4eba0030e5188396323aab843b0747fa",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/LogRedirector.java": {
-    "mtime": 1782488208.3322394,
+    "mtime": 1782494200.1639802,
     "ast_hash": "9734e0985bd24a628cdf0ef67514d8ab",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ProgressBarLogger.java": {
-    "mtime": 1782488208.3322394,
+    "mtime": 1782494200.16498,
     "ast_hash": "4de6b992fac957b71005dcdaae5d3bde",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ProjectStructureManager.java": {
-    "mtime": 1782488208.3332386,
+    "mtime": 1782494200.16498,
     "ast_hash": "b8f74461b5c086f8941e6cb3ef9555b1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportHelper.java": {
-    "mtime": 1782488208.3342383,
+    "mtime": 1782494200.1659808,
     "ast_hash": "807338ec8f08ec6d82804254656ed806",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java": {
-    "mtime": 1782488208.3342383,
+    "mtime": 1782494200.1669798,
     "ast_hash": "5b18563f42da482dfa592f29524ba798",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/ValidationEnums.java": {
-    "mtime": 1782488208.3352385,
+    "mtime": 1782494200.1679804,
     "ast_hash": "1a700a8ec5f1bc9a8ad65352a4891e8f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/Validations.java": {
-    "mtime": 1782488208.3352385,
+    "mtime": 1782494200.1679804,
     "ast_hash": "eb127c87713ca57986c7aa799e13dd29",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/accessibility/AccessibilityActions.java": {
-    "mtime": 1782488208.3362384,
+    "mtime": 1782494200.1689801,
     "ast_hash": "e669af2150be68c403f6276c12a4f0db",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/accessibility/AccessibilityHelper.java": {
-    "mtime": 1782488208.3372388,
+    "mtime": 1782494200.1699805,
     "ast_hash": "b80970635b3028c37497648e0fa82902",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/CustomSoftAssert.java": {
-    "mtime": 1782488208.3382373,
+    "mtime": 1782494200.1709807,
     "ast_hash": "d4d79fea9924eca6d094dcf8d77694cc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/FileValidationsBuilder.java": {
-    "mtime": 1782488208.3392382,
+    "mtime": 1782494200.1709807,
     "ast_hash": "05b7459be4fb4a2b653dadbac75eed37",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/JSONValidationsBuilder.java": {
-    "mtime": 1782488208.3392382,
+    "mtime": 1782494200.1709807,
     "ast_hash": "e7961b1a51db674dd615bedc29eb4793",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/NativeValidationsBuilder.java": {
-    "mtime": 1782488208.3402395,
+    "mtime": 1782494200.17198,
     "ast_hash": "35c20b2f52ab5f62588ac9d1f999b9d5",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/NumberValidationsBuilder.java": {
-    "mtime": 1782488208.3402395,
+    "mtime": 1782494200.17198,
     "ast_hash": "10b25c3ee77eb08878b4e715f70b6ad0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/RestValidationsBuilder.java": {
-    "mtime": 1782488208.3412378,
+    "mtime": 1782494200.1729815,
     "ast_hash": "58553b6f5f4c8f13d9044cacc581fa61",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/TextDirectionValidationsBuilder.java": {
-    "mtime": 1782488208.3412378,
+    "mtime": 1782494200.1729815,
     "ast_hash": "05ffa33312d65e6de2953407817bff52",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/TextLanguageValidationsBuilder.java": {
-    "mtime": 1782488208.3412378,
+    "mtime": 1782494200.1729815,
     "ast_hash": "6bac35c22470196c40e45b599e57ae03",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsBuilder.java": {
-    "mtime": 1782488208.3422384,
+    "mtime": 1782494200.17398,
     "ast_hash": "c113fe199e929201df6ef9ad1811a224",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsExecutor.java": {
-    "mtime": 1782488208.3422384,
+    "mtime": 1782494200.17398,
     "ast_hash": "d074cf33a934e4b588baefb70a4577e0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java": {
-    "mtime": 1782488208.343238,
+    "mtime": 1782494200.17498,
     "ast_hash": "600af09278c60901b734cdedf335d3da",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverBrowserValidationsBuilder.java": {
-    "mtime": 1782488208.343238,
+    "mtime": 1782494200.17498,
     "ast_hash": "e19e7ddf982160476c7e6b70c672d943",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverElementValidationsBuilder.java": {
-    "mtime": 1782488208.343238,
+    "mtime": 1782494200.17498,
     "ast_hash": "2caa9ef6dab6194ef71966119f0ed4de",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/javadoc/resources/configuration-manager/jquery-3.5.0.min.js": {
-    "mtime": 1782488208.3482375,
+    "mtime": 1782494200.1799843,
     "ast_hash": "7c5d886a944957e9ed1cc3c5eba023e9",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/javadoc/resources/configuration-manager/main-built.js": {
-    "mtime": 1782488208.3492382,
+    "mtime": 1782494200.1809826,
     "ast_hash": "bfcc66727306f6a7d6db18d89d9cbd8f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/javadoc/resources/configuration-manager/require.js": {
-    "mtime": 1782488208.3492382,
+    "mtime": 1782494200.1809826,
     "ast_hash": "81692bed77535de23323aed492f56861",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/appium/.appiumrc.json": {
-    "mtime": 1782488208.3532379,
+    "mtime": 1782494200.1849818,
     "ast_hash": "ae646a89330e08877d9e043741e04a89",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/healenium-backend/db/sql/init.sql": {
-    "mtime": 1782488208.3542376,
+    "mtime": 1782494200.1859796,
     "ast_hash": "68aef48e69eba5aebc7b90883a9928e3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/postgres/client.js": {
-    "mtime": 1782488208.3552375,
+    "mtime": 1782494200.1869798,
     "ast_hash": "a14553a735ee0f513a9da43c3e6f352f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/selenoid/browsers.json": {
-    "mtime": 1782488208.3572412,
+    "mtime": 1782494200.1889796,
     "ast_hash": "a911d4a4e1c61fbf88ddf25de262ff9b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/start_emu_headless": {
-    "mtime": 1782488208.358242,
+    "mtime": 1782494200.1899834,
     "ast_hash": "70d231d40fb0677a8762c704a4209744",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/src/test/java/testRunners/CucumberTests.java": {
-    "mtime": 1782488208.3737226,
+    "mtime": 1782494200.2050643,
     "ast_hash": "81a52f665b264bd8f06e25ab4029ccc7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782488208.3767223,
+    "mtime": 1782494200.2080646,
     "ast_hash": "064e08dd978e03c2928244264e946ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1782488208.3857222,
+    "mtime": 1782494200.2170641,
     "ast_hash": "16a9fe15aa00921a0a57426e530b4418",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782488208.388722,
+    "mtime": 1782494200.2200644,
     "ast_hash": "c3aa96f48b1065e13bb7402b929d9889",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1782488208.3977213,
+    "mtime": 1782494200.229064,
     "ast_hash": "6be46fd0c9360daf9cc0fe1e489282f1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782488208.4207225,
+    "mtime": 1782494200.2520638,
     "ast_hash": "064e08dd978e03c2928244264e946ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1782488208.429719,
+    "mtime": 1782494200.2600641,
     "ast_hash": "63b5ca0a71c4d5005c7ae9656b9c6c74",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782488208.4327202,
+    "mtime": 1782494200.263068,
     "ast_hash": "064e08dd978e03c2928244264e946ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1782488208.4417183,
+    "mtime": 1782494200.2720633,
     "ast_hash": "3cbfad60eb5b0316804c448223639228",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782488208.4447181,
+    "mtime": 1782494200.2740638,
     "ast_hash": "c3aa96f48b1065e13bb7402b929d9889",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1782488208.4537177,
+    "mtime": 1782494200.283064,
     "ast_hash": "6f82df052ec4e4a835b7c2656798bcab",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782488208.4752285,
+    "mtime": 1782494200.3045726,
     "ast_hash": "064e08dd978e03c2928244264e946ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1782488208.484227,
+    "mtime": 1782494200.313579,
     "ast_hash": "89f691f86e06b6ed04028ac322acb53d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782488208.4872265,
+    "mtime": 1782494200.316578,
     "ast_hash": "064e08dd978e03c2928244264e946ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/ApiPerformanceReportTest.java": {
-    "mtime": 1782488208.5052254,
+    "mtime": 1782494200.334577,
     "ast_hash": "6b42836ee0a0d8860582c0c3389a6f1c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/LocalApiTestServer.java": {
-    "mtime": 1782488208.5052254,
+    "mtime": 1782494200.3355763,
     "ast_hash": "4b479fde1c2774b1ef0b88fe9bee0047",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/PathParamTest.java": {
-    "mtime": 1782488208.5062256,
+    "mtime": 1782494200.3355763,
     "ast_hash": "6333c55505dba0c7cae8f443c2cc748c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/RequestBuilderTests.java": {
-    "mtime": 1782488208.507225,
+    "mtime": 1782494200.3365786,
     "ast_hash": "9b1d812122f7dce4fb77dd47d6b26f90",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/RestActionsCoverageUnitTest.java": {
-    "mtime": 1782488208.507225,
+    "mtime": 1782494200.3375773,
     "ast_hash": "6194394f7de5a5a618699b1289ab388b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/SwaggerContractTest.java": {
-    "mtime": 1782488208.5082254,
+    "mtime": 1782494200.3375773,
     "ast_hash": "adc4d25a405c2a64c949da6a0c41e232",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/TestUpload.java": {
-    "mtime": 1782488208.5082254,
+    "mtime": 1782494200.3385773,
     "ast_hash": "3f21181377aeac1c34f46b1a7c1cf298",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/testPostRequest.java": {
-    "mtime": 1782488208.509225,
+    "mtime": 1782494200.3385773,
     "ast_hash": "9de940d6b7dc8e741eb019b9fccba6cd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/cli/FileActionsCoverageUnitTest.java": {
-    "mtime": 1782488208.5102248,
+    "mtime": 1782494200.339577,
     "ast_hash": "c45c9550223fe7dcd993697eacf00c6b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/cucumber/ElementStepsCoverageUnitTest.java": {
-    "mtime": 1782488208.5102248,
+    "mtime": 1782494200.3405766,
     "ast_hash": "68270ddb7b02986ee98f52b2fa8892a7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelperCoverageUnitTest.java": {
-    "mtime": 1782488208.5112245,
+    "mtime": 1782494200.341579,
     "ast_hash": "e92058dc8a463d5bc611a1b4ea514e3c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/OptionsManagerCoverageUnitTest.java": {
-    "mtime": 1782490235.183254,
-    "ast_hash": "64a44ad2613f231fc5196116a70ee545",
+    "mtime": 1782494200.341579,
+    "ast_hash": "183120984e8fe511cf50731e958ad64d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/AsyncElementActionsCoverageUnitTest.java": {
-    "mtime": 1782488208.5142252,
+    "mtime": 1782494200.3445768,
     "ast_hash": "82de6e0ba9113ac7f63bba70cd5922bf",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java": {
-    "mtime": 1782488208.5152254,
+    "mtime": 1782494200.345577,
     "ast_hash": "626231bc69664d907ebc9c43997a6fa0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsExceptionDetailsUnitTest.java": {
-    "mtime": 1782488208.5152254,
+    "mtime": 1782494200.345577,
     "ast_hash": "38a470e4ccf528f247d2adb30ee8a480",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ElementInformationCoverageUnitTest.java": {
-    "mtime": 1782488208.5162244,
+    "mtime": 1782494200.3465774,
     "ast_hash": "2683114ad3f10a14f3925a6bd6835400",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ElementsHelperCoverageUnitTest.java": {
-    "mtime": 1782488208.5172248,
+    "mtime": 1782494200.3465774,
     "ast_hash": "76f70bb8df336467105fc9ab7964a074",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/healing/HealingActionsIntegrationTest.java": {
-    "mtime": 1782488208.5182242,
+    "mtime": 1782494200.3475766,
     "ast_hash": "eef0b6ec55d75db96f4416c65ec0c65f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/healing/HealingStrategyTest.java": {
-    "mtime": 1782488208.5182242,
+    "mtime": 1782494200.3475766,
     "ast_hash": "c29f55b4622c05fbf066a1a3f5143b88",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/AnimatedGifManagerCoverageUnitTest.java": {
-    "mtime": 1782488208.5192242,
+    "mtime": 1782494200.3485768,
     "ast_hash": "bf0671ff4c59d2d23ff75bd13e8c5743",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotHelperCoverageUnitTest.java": {
-    "mtime": 1782488208.5202248,
+    "mtime": 1782494200.3495767,
     "ast_hash": "b0b5269cd3a52b3a438193dcbf99f73f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotManagerCoverageUnitTest.java": {
-    "mtime": 1782488208.5202248,
+    "mtime": 1782494200.3505766,
     "ast_hash": "1b53acb9faec7f11548e0198dca8e680",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/VisualProcessingProviderRegistryTest.java": {
-    "mtime": 1782488208.5212247,
+    "mtime": 1782494200.3505766,
     "ast_hash": "f65e99d62de78111e607e18fd4d6aceb",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/natural/NaturalActionExecutorTest.java": {
-    "mtime": 1782488208.522224,
+    "mtime": 1782494200.3515766,
     "ast_hash": "aa28815755a0f28bd7343de86b58bee7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistryTest.java": {
-    "mtime": 1782488208.5232246,
+    "mtime": 1782494200.3535767,
     "ast_hash": "a2fa8e0ef33d17122b51f64ba073e670",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/video/RecordManagerCoverageUnitTest.java": {
-    "mtime": 1782488208.5242245,
+    "mtime": 1782494200.3535767,
     "ast_hash": "b728bfab006ff8f0057b22748932c062",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/video/RecordManagerDesktopProviderTest.java": {
-    "mtime": 1782488208.5242245,
+    "mtime": 1782494200.3535767,
     "ast_hash": "badd24f271266d3b1385ed7f93bbecd7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/listeners/AllureListenerCoverageUnitTest.java": {
-    "mtime": 1782488208.5272243,
+    "mtime": 1782494200.356577,
     "ast_hash": "2241a07317bff8346a1bd1c01137e1a7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/listeners/internal/UpdateCheckerUnitTest.java": {
-    "mtime": 1782488208.5282278,
+    "mtime": 1782494200.357577,
     "ast_hash": "a0c400588dc92dc8f84602e923dc34fd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/performance/internal/LightHouseGenerateReportCoverageUnitTest.java": {
-    "mtime": 1782488208.5292249,
+    "mtime": 1782494200.358578,
     "ast_hash": "d12ef0c4ab02daa11d78b8fa0b0def3e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/test/unitTests/JavaScriptWaitManagerUnitTest.java": {
-    "mtime": 1782488208.5302234,
+    "mtime": 1782494200.3595772,
     "ast_hash": "08bea5190a0202d3ca812e9b77ea809e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/internal/security/GoogleTinkApiCoverageUnitTest.java": {
-    "mtime": 1782488208.5312233,
+    "mtime": 1782494200.3605764,
     "ast_hash": "f0c7bd8edaf562770403f311517f050f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/JSONFileManagerTestAccessor.java": {
-    "mtime": 1782488208.5322232,
+    "mtime": 1782494200.3615768,
     "ast_hash": "d9ef7d440aa067f73898384896afa5ee",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureManagerCoverageUnitTest.java": {
-    "mtime": 1782488208.533223,
+    "mtime": 1782494200.3625767,
     "ast_hash": "8e16f9c749c62d33e891be8ee0dafad8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/ProgressBarLoggerCoverageUnitTest.java": {
-    "mtime": 1782488208.5362227,
+    "mtime": 1782494200.3655758,
     "ast_hash": "cfadf25f42514ed4fecbe14029ed0c48",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/ProgressBarLoggerTestAccessor.java": {
-    "mtime": 1782488208.5362227,
+    "mtime": 1782494200.3655758,
     "ast_hash": "7a536f9d92a15f04078b0d80f4809018",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/accessibility/AccessibilityHelperCoverageUnitTest.java": {
-    "mtime": 1782488208.537223,
+    "mtime": 1782494200.3665771,
     "ast_hash": "be5900d466782caed69ee8da01b2dd45",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsExecutorTestAccessor.java": {
-    "mtime": 1782488208.538223,
+    "mtime": 1782494200.3675766,
     "ast_hash": "da15362a3e7a802bad7f5d94ed318c76",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelperCoverageUnitTest.java": {
-    "mtime": 1782488208.538223,
+    "mtime": 1782494200.3675766,
     "ast_hash": "d22b363eae55211786a325255bfd197e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/internal/WebDriverElementValidationsBuilderCoverageUnitTest.java": {
-    "mtime": 1782488208.5392237,
+    "mtime": 1782494200.3685777,
     "ast_hash": "a30dd92879b097ff5853dbb8999cf147",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/cucumberTestRunner/CucumberTests.java": {
-    "mtime": 1782488208.5402236,
+    "mtime": 1782494200.3685777,
     "ast_hash": "74ef6fcb26ae1bf65684240930dd0f66",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/customCucumberSteps/steps.java": {
-    "mtime": 1782488208.5402236,
+    "mtime": 1782494200.3695767,
     "ast_hash": "996c5594b17086d3b5b937776f4309db",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/external/FileActionsReflectionInvoker.java": {
-    "mtime": 1782488208.5412233,
+    "mtime": 1782494200.3695767,
     "ast_hash": "8251926ce3c459f65681aaf4925cda59",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitParallelizationTests.java": {
-    "mtime": 1782488208.5432231,
+    "mtime": 1782494200.3715768,
     "ast_hash": "c213b41fd84d475acbdef117917bb2b2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitTest.java": {
-    "mtime": 1782488208.5442226,
+    "mtime": 1782494200.3735769,
     "ast_hash": "80e036596d170587890d7947a2b6ee92",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/MoonTests.java": {
-    "mtime": 1782488208.5452225,
+    "mtime": 1782494200.3735769,
     "ast_hash": "3d4b38081680b77d4ae52f2a4b2219c6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/objectclass/BodyObject.java": {
-    "mtime": 1782488208.5452225,
+    "mtime": 1782494200.3745773,
     "ast_hash": "03f0c5fc69471404fe1e0e603466f818",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/CopilotGeneratedTests/ActionsCoverageTests.java": {
-    "mtime": 1782488208.5462224,
+    "mtime": 1782494200.375577,
     "ast_hash": "4d7fd64afc511b6c060fc9bdd1808db7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/CopilotGeneratedTests/RestActionsComprehensiveTests.java": {
-    "mtime": 1782488208.5472229,
+    "mtime": 1782494200.375577,
     "ast_hash": "28f298cd5240a0f802c52f4fc9a4dab3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/CopilotGeneratedTests/UnitTestsRestActions.java": {
-    "mtime": 1782488208.5472229,
+    "mtime": 1782494200.3765762,
     "ast_hash": "f7a90e6eae203244b1f50f592b7fdd49",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/CopilotGeneratedTests/UnitTestsSHAFT.java": {
-    "mtime": 1782488208.5482225,
+    "mtime": 1782494200.3765762,
     "ast_hash": "1a0f0ce42dfb5df20043a7c64ef5f0f2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/LambdaTestCredentials.java": {
-    "mtime": 1782488208.5482225,
+    "mtime": 1782494200.3775773,
     "ast_hash": "95942d341f6c15cb5ef9055b1808bcb1",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTDesktopWebMac.java": {
-    "mtime": 1782488208.5482225,
+    "mtime": 1782494200.3775773,
     "ast_hash": "2f3d1140f11fc9b71b0bedc8ecc3da3b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTDesktopWebWindows.java": {
-    "mtime": 1782488208.549222,
+    "mtime": 1782494200.3775773,
     "ast_hash": "157fb2b3b04bdfea2fe6185cbebf841c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobAPKAPPURL.java": {
-    "mtime": 1782488208.549222,
+    "mtime": 1782494200.3785768,
     "ast_hash": "f35e9468c40360b72f8b61adffa1450d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobAPKRelativePath.java": {
-    "mtime": 1782488208.550222,
+    "mtime": 1782494200.3785768,
     "ast_hash": "5789694ff5cfd58a44c97cb7ad1271e0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobIPAAppURL.java": {
-    "mtime": 1782488208.550222,
+    "mtime": 1782494200.3785768,
     "ast_hash": "8d8bd350aa5b1c3c3a3cf0cd781450c8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobIPARelativePath.java": {
-    "mtime": 1782488208.550222,
+    "mtime": 1782494200.379578,
     "ast_hash": "1647018c30c20b7960074c5ff3bb51b2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTWebAppIOS.java": {
-    "mtime": 1782488208.5512226,
+    "mtime": 1782494200.379578,
     "ast_hash": "01affbeef9bd4974c99ca3991af231d3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTWebAppRealme.java": {
-    "mtime": 1782488208.5512226,
+    "mtime": 1782494200.379578,
     "ast_hash": "316149ae0962ad94d9a60dbb6fe8cb9d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/APIWizardTests.java": {
-    "mtime": 1782488208.5522223,
+    "mtime": 1782494200.3805764,
     "ast_hash": "a660856536f3395e80893fab6604f552",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/CLIWizardTests.java": {
-    "mtime": 1782488208.5522223,
+    "mtime": 1782494200.3805764,
     "ast_hash": "b9df0988ecaad726adc5fea8c897ab88",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/CustomDriverInitializationTests.java": {
-    "mtime": 1782488208.5522223,
+    "mtime": 1782494200.3815765,
     "ast_hash": "9b4a204a9f376bf9172a75b7a83ff3ac",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/DBWizardTests.java": {
-    "mtime": 1782488208.5532227,
+    "mtime": 1782494200.3815765,
     "ast_hash": "f578f87a677a9ace374460f653a7a416",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/FluentGuiActionsTest.java": {
-    "mtime": 1782488208.5532227,
+    "mtime": 1782494200.3815765,
     "ast_hash": "ec867d13fcd03e7f0636806479b75168",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/GUIWizardTests.java": {
-    "mtime": 1782488208.5532227,
+    "mtime": 1782494200.3825767,
     "ast_hash": "0b390e4118280e1abc7f529f48555de6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/TestHelpers.java": {
-    "mtime": 1782488208.5542226,
+    "mtime": 1782494200.3825767,
     "ast_hash": "8be2574841bdfc32c03cba0a0e2a8dc2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/WizardStandaloneValidationTests.java": {
-    "mtime": 1782488208.5542226,
+    "mtime": 1782494200.3825767,
     "ast_hash": "35f04e8619760f8ebd8814c4d4303ca9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/WizardTestDataTests.java": {
-    "mtime": 1782488208.5542226,
+    "mtime": 1782494200.3835766,
     "ast_hash": "33ac597fd308b12054d8f42f82799d5e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/TestPageServer.java": {
-    "mtime": 1782488208.5552225,
+    "mtime": 1782494200.3835766,
     "ast_hash": "2646363db37f021394df4d2e581aebc6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/TestScenario.java": {
-    "mtime": 1782488208.5552225,
+    "mtime": 1782494200.3835766,
     "ast_hash": "1eb22ef127c1db1ae030d5be3d4f1793",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/Tests.java": {
-    "mtime": 1782488208.5552225,
+    "mtime": 1782494200.384577,
     "ast_hash": "57e8f66047ac7beae82ab5c23cc7bf87",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/AndroidBasicInteractionsTests.java": {
-    "mtime": 1782488208.5562272,
+    "mtime": 1782494200.384577,
     "ast_hash": "dd601a01d9c455ec89b2c7160ba4eec8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/AndroidDragAndDropTest.java": {
-    "mtime": 1782488208.5562272,
+    "mtime": 1782494200.3855767,
     "ast_hash": "2ffc8e85a4d6c7b23b6912cb87beb2fd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/AndroidTouchActionsTests.java": {
-    "mtime": 1782488208.5572274,
+    "mtime": 1782494200.3855767,
     "ast_hash": "532f29bf0254c1ff8f525a507a1a430a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/FileUploadDownloadTest.java": {
-    "mtime": 1782488208.5572274,
+    "mtime": 1782494200.3855767,
     "ast_hash": "7d6ebdfaaf28e3d2b90d22b4ca16e9e9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/FlutterTest.java": {
-    "mtime": 1782488208.5572274,
+    "mtime": 1782494200.3865764,
     "ast_hash": "7366c8b69d03e80b2fb4bd19f1d32037",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/IOSBasicInteractionsTest.java": {
-    "mtime": 1782488208.5582268,
+    "mtime": 1782494200.3865764,
     "ast_hash": "c14cf8b63c53b19cf5ecb4c7020eaa24",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/MobileTest.java": {
-    "mtime": 1782488208.5582268,
+    "mtime": 1782494200.3865764,
     "ast_hash": "9d3c39b310b254b8e46b0787b9863b45",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/MobileWebTest.java": {
-    "mtime": 1782488208.5592265,
+    "mtime": 1782494200.387578,
     "ast_hash": "1e71bec893b591efdc6ad81c0861de05",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/AssertApiResponseEqualsTests.java": {
-    "mtime": 1782488208.560227,
+    "mtime": 1782494200.388577,
     "ast_hash": "6f6b3fc3c46d22b1be2e15c313ae0d4b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/AssertEqualsTests.java": {
-    "mtime": 1782488208.5612276,
+    "mtime": 1782494200.3895812,
     "ast_hash": "ac28053c858948f6c8072ae22ad3cb68",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/BasicAPITests.java": {
-    "mtime": 1782488208.5612276,
+    "mtime": 1782494200.3895812,
     "ast_hash": "04f6e36cc676509fd50bf69cf0f8214e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/BasicAuthenticationTests.java": {
-    "mtime": 1782488208.5612276,
+    "mtime": 1782494200.3895812,
     "ast_hash": "9496029f86d3f528ab13caabb2d0fe8d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/BigPageActionsTest.java": {
-    "mtime": 1782488208.562227,
+    "mtime": 1782494200.3905826,
     "ast_hash": "5c59782bc79d4c0e169a4a289b802bf4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/CSVFileManagerTest.java": {
-    "mtime": 1782488208.562227,
+    "mtime": 1782494200.3905826,
     "ast_hash": "5bb3c372688c46b067b1b9863e25072d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/ChainableElementActionsTests.java": {
-    "mtime": 1782488208.562227,
+    "mtime": 1782494200.3905826,
     "ast_hash": "06ae6b54a7d97bc516cc10cf6b99b1b5",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/ChecksumTests.java": {
-    "mtime": 1782488208.5632267,
+    "mtime": 1782494200.3915813,
     "ast_hash": "5906715678d0f232e561110e1ff7a158",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/CookiesTests.java": {
-    "mtime": 1782488208.5632267,
+    "mtime": 1782494200.3915813,
     "ast_hash": "758c6a8df8d6416f380f1d39aac31c06",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/DragAndDropTests.java": {
-    "mtime": 1782488208.5632267,
+    "mtime": 1782494200.3925824,
     "ast_hash": "342e71b079c44b808491154c7bd27ba6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/DynamicLoadingTest.java": {
-    "mtime": 1782488208.5642264,
+    "mtime": 1782494200.3925824,
     "ast_hash": "75821892b9db3a83dbec9eb1e6cd2c2a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/FileActionsTests.java": {
-    "mtime": 1782488208.5642264,
+    "mtime": 1782494200.3925824,
     "ast_hash": "b562813a025a45e3fc69064917478f4d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/FrameTests.java": {
-    "mtime": 1782488208.5652266,
+    "mtime": 1782494200.393581,
     "ast_hash": "2377b86c25ba830a3a62c8eb3673f54b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/GetTableRowsDataTests.java": {
-    "mtime": 1782488208.5652266,
+    "mtime": 1782494200.393581,
     "ast_hash": "e70588ff08a9232d318ac38de8c922b7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/GraphqlRequestTests.java": {
-    "mtime": 1782488208.5652266,
+    "mtime": 1782494200.393581,
     "ast_hash": "9dd849ae0967c7a40ef9cf5ae77220b2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/GroupsTests.java": {
-    "mtime": 1782488208.5662262,
+    "mtime": 1782494200.3945835,
     "ast_hash": "5051d79e29fdd758369f62fbb35d8639",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/IsElementClickableTest.java": {
-    "mtime": 1782488208.5662262,
+    "mtime": 1782494200.3945835,
     "ast_hash": "6ef73b0291f982d6a93dc783fe65a7f7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JSAlertBoxTests.java": {
-    "mtime": 1782488208.5662262,
+    "mtime": 1782494200.3945835,
     "ast_hash": "87a6cc3676d62bfdcd5039c55974c99a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JSConfirmBoxTests.java": {
-    "mtime": 1782488208.5672266,
+    "mtime": 1782494200.395581,
     "ast_hash": "bb2be41715ecadad8c1c352ec2f3edea",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JSONFileManagerTests.java": {
-    "mtime": 1782488208.5672266,
+    "mtime": 1782494200.395581,
     "ast_hash": "06f43c8542a39433d95f396bddc2511e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JSPromptBoxTests.java": {
-    "mtime": 1782488208.5672266,
+    "mtime": 1782494200.395581,
     "ast_hash": "20322607f3abd3ee7b114d7a076640df",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JsonActionsTests.java": {
-    "mtime": 1782488208.5682266,
+    "mtime": 1782494200.3965812,
     "ast_hash": "0eeae0f35f4b5d59ce66f3fdc5a43c92",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JsonCompareWithSpecialCharactersTests.java": {
-    "mtime": 1782488208.5682266,
+    "mtime": 1782494200.3965812,
     "ast_hash": "8ec3e11aa822c7834ff5c361a6044a57",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/LazyLoadingTests.java": {
-    "mtime": 1782488208.5682266,
+    "mtime": 1782494200.3965812,
     "ast_hash": "2da719cae7f75db7d3f4b5282365ce88",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/LocalShellTests.java": {
-    "mtime": 1782488208.5692267,
+    "mtime": 1782494200.3975818,
     "ast_hash": "6782d98e60aa0e1f0bcc9999f29d8a6a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/MatchJsonSchemaTests.java": {
-    "mtime": 1782488208.5692267,
+    "mtime": 1782494200.3975818,
     "ast_hash": "3876965c3c4b42b162b09caedef82ec7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/MobileEmulationTests.java": {
-    "mtime": 1782488208.5702262,
+    "mtime": 1782494200.3975818,
     "ast_hash": "35929225261df191611b8eb348dcbeb2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/MultipleDriverSessionTerminationTest.java": {
-    "mtime": 1782488208.5702262,
+    "mtime": 1782494200.398581,
     "ast_hash": "ebf545317e8990b561fb94cb7f13ceb6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/NetworkInterceptionTest.java": {
-    "mtime": 1782488208.5702262,
+    "mtime": 1782494200.398581,
     "ast_hash": "ce74294d08a4c05fdbf214d30224f871",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/NewValidationHelperTests.java": {
-    "mtime": 1782488208.571292,
+    "mtime": 1782494200.398581,
     "ast_hash": "4bc79fab96f68b8b12d5116587f24479",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/PDFTests.java": {
-    "mtime": 1782488208.571292,
+    "mtime": 1782494200.399581,
     "ast_hash": "9ce4274cf95b705c4c628161689a5716",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/PropertiesManagerTests.java": {
-    "mtime": 1782488208.571292,
+    "mtime": 1782494200.399581,
     "ast_hash": "43587b77aed4d5722770a6b08ccf019f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/RelativeLocatorsTests.java": {
-    "mtime": 1782488208.5722919,
+    "mtime": 1782494200.399581,
     "ast_hash": "1c8054013b7ecb201fc5fe98b22daf10",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/RemoteGridVideoAttachmentIT.java": {
-    "mtime": 1782488208.5722919,
+    "mtime": 1782494200.4005826,
     "ast_hash": "dd14e5e72b21522e5be56680c8b3d026",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/SkipDueToIssueTests.java": {
-    "mtime": 1782488208.5722919,
+    "mtime": 1782494200.4005826,
     "ast_hash": "99a55a2822f04fdbbcee5cceb276fca8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/SwitchToNewTabTest.java": {
-    "mtime": 1782488208.573292,
+    "mtime": 1782494200.4015813,
     "ast_hash": "006d6c897a4c1d231284dee7fe67d681",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/TableTests.java": {
-    "mtime": 1782488208.573292,
+    "mtime": 1782494200.4015813,
     "ast_hash": "6d478cc94e1a5ee7eab2ab389899f534",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/TestDataTests.java": {
-    "mtime": 1782488208.573292,
+    "mtime": 1782494200.4015813,
     "ast_hash": "95acd877eac50b8434b69adb83cbb977",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/UploadFileTests.java": {
-    "mtime": 1782488208.5742922,
+    "mtime": 1782494200.4025846,
     "ast_hash": "5302d25af26787f48deb393f87c23b4f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/ValidationsBuilderTests.java": {
-    "mtime": 1782488208.5742922,
+    "mtime": 1782494200.4025846,
     "ast_hash": "fcf11e47db991e3a42aef3210fa2e360",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/VerifyEqualsTests.java": {
-    "mtime": 1782488208.5752919,
+    "mtime": 1782494200.4025846,
     "ast_hash": "41d8d2fd6427379eb8fc445849b8424f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/YAMLFileManagerTests.java": {
-    "mtime": 1782488208.5752919,
+    "mtime": 1782494200.4025846,
     "ast_hash": "3230789cecccce6618d4d1803676627d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/locator/LocatorBuilderTest.java": {
-    "mtime": 1782488208.5762916,
+    "mtime": 1782494200.4040904,
     "ast_hash": "0414482e4f34d9a26b3b4ced958e648f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/locator/ShadowDomTest.java": {
-    "mtime": 1782488208.5762916,
+    "mtime": 1782494200.4040904,
     "ast_hash": "6ed0c59ac8e49a4a7ef06df16c2963d7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/locator/SmartLocatorsPOC1Tests.java": {
-    "mtime": 1782488208.5772922,
+    "mtime": 1782494200.4050972,
     "ast_hash": "c3c8b2620562686f6b5e565535e18b95",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/locator/SmartLocatorsRealisticTests.java": {
-    "mtime": 1782488208.5772922,
+    "mtime": 1782494200.4050972,
     "ast_hash": "f43ba034e46306636cf2938d5c917eb9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/locator/SmartLocatorsTests.java": {
-    "mtime": 1782488208.5772922,
+    "mtime": 1782494200.4050972,
     "ast_hash": "20c2cf801bc6adaf91c3a10eedfd305c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/AccessibilityTest.java": {
-    "mtime": 1782488208.5782926,
+    "mtime": 1782494200.4060948,
     "ast_hash": "99d0232aa92b8d70edc1df791001873c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/ApiActionsMockedTests.java": {
-    "mtime": 1782488208.5782926,
+    "mtime": 1782494200.4060948,
     "ast_hash": "4f4c44851c27057934f2b7b59bc65ab5",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/CoverageTests.java": {
-    "mtime": 1782488208.5792916,
+    "mtime": 1782494200.407097,
     "ast_hash": "83c27fc65ab0c865b1cdf29f5866e8f8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/CucumberMockedTests.java": {
-    "mtime": 1782488208.5792916,
+    "mtime": 1782494200.407097,
     "ast_hash": "7f8a58e869251917ae68bba51332db11",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/DatabaseActionsMockedTests.java": {
-    "mtime": 1782488208.580292,
+    "mtime": 1782494200.407097,
     "ast_hash": "e2878a0cc73ffd2347f853ef2147cc72",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/DbTests.java": {
-    "mtime": 1782488208.580292,
+    "mtime": 1782494200.4080958,
     "ast_hash": "269cfe45953923e0843780be937a461b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/E2ECoverageTests.java": {
-    "mtime": 1782488208.580292,
+    "mtime": 1782494200.4080958,
     "ast_hash": "ca5993c2c426f5edafe4ce6625f48c17",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/ElementActionsMockedTests.java": {
-    "mtime": 1782488208.5812917,
+    "mtime": 1782494200.4090948,
     "ast_hash": "3ad7b5b6aef55cd46c2f7154f1ae6cda",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/GuiVerificationTests.java": {
-    "mtime": 1782488208.5812917,
+    "mtime": 1782494200.4090948,
     "ast_hash": "3d7a334d786337dbde7750cfe5f3fc4a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/HoverTests.java": {
-    "mtime": 1782488208.5812917,
+    "mtime": 1782494200.4090948,
     "ast_hash": "17caa339bfe3e0b97b6a5ffc19bf8b19",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/IOActionsMockedTests.java": {
-    "mtime": 1782488208.5822918,
+    "mtime": 1782494200.4100976,
     "ast_hash": "c56ab69e6038fda5a988bd60c9cfeb22",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/JDK21VirtualThreadsAndAsyncActionsTests.java": {
-    "mtime": 1782488208.5822918,
+    "mtime": 1782494200.4100976,
     "ast_hash": "51f1a029b91897744035cd850b1161a7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/LocatorMockedTests.java": {
-    "mtime": 1782488208.5822918,
+    "mtime": 1782494200.4100976,
     "ast_hash": "dad58a7c56a1467263bfae0f1da9480a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/MultipleBrowserInstancesTest.java": {
-    "mtime": 1782488208.5832915,
+    "mtime": 1782494200.4110951,
     "ast_hash": "809818085b5e32dff077dfb0c656856b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/MultipleElementsFailureTest.java": {
-    "mtime": 1782488208.5832915,
+    "mtime": 1782494200.4110951,
     "ast_hash": "241d67949c16293b2350791d139a82fe",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/MultipleTypeCyclesTest.java": {
-    "mtime": 1782488208.5832915,
+    "mtime": 1782494200.4110951,
     "ast_hash": "b2f43aacacb87d9e96673fe6ec092b31",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/NoSuchElementFailureTest.java": {
-    "mtime": 1782488208.5842912,
+    "mtime": 1782494200.4120948,
     "ast_hash": "03a45eec716f23e232911a3211ee431c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/PageScreenshotTest.java": {
-    "mtime": 1782488208.5842912,
+    "mtime": 1782494200.4120948,
     "ast_hash": "d49c21a61e72ec5469d72f13735e0de6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/SecurityMockedTests.java": {
-    "mtime": 1782488208.585291,
+    "mtime": 1782494200.4120948,
     "ast_hash": "2f5b6a0594b5c0984dbcda5ac7d487c6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/SelectMethodTests.java": {
-    "mtime": 1782488208.585291,
+    "mtime": 1782494200.4130962,
     "ast_hash": "ac0d848f85a4727aee2f0bc8a56bb843",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/SelectedValueTests.java": {
-    "mtime": 1782488208.585291,
+    "mtime": 1782494200.4130962,
     "ast_hash": "81b968ea8374b0200a005df4f678937a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/ThreadSafeGuiWizardTests.java": {
-    "mtime": 1782488208.586291,
+    "mtime": 1782494200.4130962,
     "ast_hash": "93278d8c91e0003270e1f37b3f9dbbe0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/TouchActionsTests.java": {
-    "mtime": 1782488208.586291,
+    "mtime": 1782494200.4140954,
     "ast_hash": "bfec9ae0a72008d85b23f59529b0e9ea",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/ValidationTests.java": {
-    "mtime": 1782488208.586291,
+    "mtime": 1782494200.4140954,
     "ast_hash": "fd0f34e2c216022700d6967480b9a911",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/ValidationsMockedTests.java": {
-    "mtime": 1782488208.5872915,
+    "mtime": 1782494200.415095,
     "ast_hash": "06dceebbaa6cc58e0183baae80e4fb56",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/WaitActionsTest.java": {
-    "mtime": 1782488208.5872915,
+    "mtime": 1782494200.415095,
     "ast_hash": "a1b4352725f281f3d61dc14699074e4e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/BrowserStackSdkTests.java": {
-    "mtime": 1782488208.5912914,
+    "mtime": 1782494200.418094,
     "ast_hash": "d9ebd5580bb807c7604e0c74e38f151c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/BrowserStackTests.java": {
-    "mtime": 1782488208.5912914,
+    "mtime": 1782494200.4190972,
     "ast_hash": "7c56e754cf9df72d867793b89e4ce87d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/CucumberTests.java": {
-    "mtime": 1782488208.5912914,
+    "mtime": 1782494200.4190972,
     "ast_hash": "cc49d5bf128f50b8c9b49ee1d3d06b3a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/FlagsTests.java": {
-    "mtime": 1782488208.5922909,
+    "mtime": 1782494200.4200957,
     "ast_hash": "fcc937601e081f5aaed227e0c9be4c09",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/HealeniumTests.java": {
-    "mtime": 1782488208.5922909,
+    "mtime": 1782494200.4200957,
     "ast_hash": "4cbd96dfaa7ecd87d56e8fed846b5e12",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/HealingTests.java": {
-    "mtime": 1782488208.5932908,
+    "mtime": 1782494200.4200957,
     "ast_hash": "36a68b5420d9ac0898076eeafbe3017a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/InternalTests.java": {
-    "mtime": 1782488208.5932908,
+    "mtime": 1782494200.4210954,
     "ast_hash": "c0f069cd9f0d1229bd799d2bbcdd84f1",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/JiraTests.java": {
-    "mtime": 1782488208.5932908,
+    "mtime": 1782494200.4210954,
     "ast_hash": "eeba6ddfce3de33fbe989cc575a9cd90",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/Log4jTests.java": {
-    "mtime": 1782488208.5942905,
+    "mtime": 1782494200.4210954,
     "ast_hash": "ae4540190f998df8d9fb4b0d1a2612fe",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/MobileTests.java": {
-    "mtime": 1782488208.5942905,
+    "mtime": 1782494200.4220948,
     "ast_hash": "6739645c3929d9dceb4adb19a57133b8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/NaturalActionsTests.java": {
-    "mtime": 1782488208.5942905,
+    "mtime": 1782494200.4220948,
     "ast_hash": "2f7204140a4fd39be6c6e336527e4180",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/PathsTests.java": {
-    "mtime": 1782488208.5952907,
+    "mtime": 1782494200.4220948,
     "ast_hash": "9b6e4b923c8fafeb5766479e8ce4e9f7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/PatternTests.java": {
-    "mtime": 1782488208.5952907,
+    "mtime": 1782494200.4230955,
     "ast_hash": "27d780ad9cfb7a965f6b92d28d68de4c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/PerformanceTests.java": {
-    "mtime": 1782488208.5952907,
+    "mtime": 1782494200.4230955,
     "ast_hash": "9309eda06566e65a9f362f67f226dc91",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/PlatformTests.java": {
-    "mtime": 1782488208.5962906,
+    "mtime": 1782494200.4230955,
     "ast_hash": "3258b9a3348d0509056b88b650bf03b5",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/ReportingTests.java": {
-    "mtime": 1782488208.5962906,
+    "mtime": 1782494200.4240944,
     "ast_hash": "1f1adefb9483330e293ad674101ad4a2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/TestNGTests.java": {
-    "mtime": 1782488208.5962906,
+    "mtime": 1782494200.4240944,
     "ast_hash": "99bf53de75d7fd1c0db036713c836a50",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/TimeoutsTests.java": {
-    "mtime": 1782488208.5972905,
+    "mtime": 1782494200.4240944,
     "ast_hash": "1bad239440e6f2e516dc99d4a0772476",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/TinkeyTests.java": {
-    "mtime": 1782488208.5972905,
+    "mtime": 1782494200.4250946,
     "ast_hash": "0970c28be5888cba1859beefc65378b3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/VisualsTests.java": {
-    "mtime": 1782488208.5972905,
+    "mtime": 1782494200.4250946,
     "ast_hash": "a0f83862f610862bb8efaf196f707d08",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/WebTests.java": {
-    "mtime": 1782488208.5982907,
+    "mtime": 1782494200.4250946,
     "ast_hash": "9dc7531cd01c41eb8cfab262c6e521fd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/resettingCapabilitiesIssue/ElementMatchesSafariCompatibleTests.java": {
-    "mtime": 1782488208.5982907,
+    "mtime": 1782494200.4260948,
     "ast_hash": "394bbc20f5e93c06cc34ec7c01ff3236",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/resettingCapabilitiesIssue/ShadowDOMTests.java": {
-    "mtime": 1782488208.5992901,
+    "mtime": 1782494200.4260948,
     "ast_hash": "43a6596b52c49876b40b6058899198c6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/resettingCapabilitiesIssue/UploadFileTests.java": {
-    "mtime": 1782488208.5992901,
+    "mtime": 1782494200.4270976,
     "ast_hash": "cae1bde8163d22ef380fd6284cd6b0e0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/APIPropertiesUnitTest.java": {
-    "mtime": 1782488208.60029,
+    "mtime": 1782494200.4270976,
     "ast_hash": "05bd219643f1dc3028c6a12e8e6f478f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/APITests.java": {
-    "mtime": 1782488208.60029,
+    "mtime": 1782494200.428095,
     "ast_hash": "2dc9f47b451a8e6b2044fbeabf5fd378",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AccessibilityActionsCoverageUnitTest.java": {
-    "mtime": 1782488208.6012912,
+    "mtime": 1782494200.428095,
     "ast_hash": "299d8accaa92a18b359d20a9b499d18d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AlertActionsCoverageUnitTest.java": {
-    "mtime": 1782488208.6012912,
+    "mtime": 1782494200.4290967,
     "ast_hash": "a5bb393a1cfc1a2e8aa75ae92aff7d81",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AllAttachmentTypesTest.java": {
-    "mtime": 1782488208.6012912,
+    "mtime": 1782494200.4290967,
     "ast_hash": "f79dff9fc7994d2065d35844cc915ad8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/Allure3ReportValidationTests.java": {
-    "mtime": 1782488208.60229,
+    "mtime": 1782494200.4290967,
     "ast_hash": "da1af4c4422a31104c480df5d2b8651d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AllureManagerUnitTest.java": {
-    "mtime": 1782488208.6032898,
+    "mtime": 1782494200.4300961,
     "ast_hash": "5217c24ae1c6cf0e14b8915e9e0fb00a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AndroidApkBadgingReaderUnitTest.java": {
-    "mtime": 1782488208.6032898,
+    "mtime": 1782494200.4300961,
     "ast_hash": "5bc57b743241b49f0e5257363802a038",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java": {
-    "mtime": 1782488208.6032898,
+    "mtime": 1782494200.4310951,
     "ast_hash": "49d211907c0ca598f8d3aea229d5c1f3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AssertionStepsCucumberTestsCoverageUnitTest.java": {
-    "mtime": 1782488208.604289,
+    "mtime": 1782494200.4310951,
     "ast_hash": "bd8b8e3e83c0652fbfd4c66dfa54f838",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AttachmentReporterUnitTest.java": {
-    "mtime": 1782488208.604289,
+    "mtime": 1782494200.4320946,
     "ast_hash": "158336712eee3f638ec0ef43295735aa",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsCoverageUnitTest.java": {
-    "mtime": 1782488208.6052904,
+    "mtime": 1782494200.4320946,
     "ast_hash": "d161c034134040f8f87c0e33d9a97391",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsHelperCoverageUnitTest.java": {
-    "mtime": 1782488208.6052904,
+    "mtime": 1782494200.433095,
     "ast_hash": "eee65cf685894e3a7520908f46d77937",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsTests.java": {
-    "mtime": 1782488208.6062899,
+    "mtime": 1782494200.433095,
     "ast_hash": "66b7b6266723ff45765b60ac7c3074e3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserStackHelperUnitTest.java": {
-    "mtime": 1782488208.6062899,
+    "mtime": 1782494200.434095,
     "ast_hash": "7ae11ad14db90e20fe82c9c907507c7b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserStackPropertiesUnitTest.java": {
-    "mtime": 1782488208.6062899,
+    "mtime": 1782494200.434095,
     "ast_hash": "dfcbf24cab8e1c327962222c3978b95d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserStackSdkHelperCoverageUnitTest.java": {
-    "mtime": 1782488208.6072903,
+    "mtime": 1782494200.434095,
     "ast_hash": "a12447674e5f8ad7c872293f7e5d7906",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CSVFileManagerUnitTest.java": {
-    "mtime": 1782488208.6072903,
+    "mtime": 1782494200.4350946,
     "ast_hash": "e05e9aa7e90379ffff4172edb00a2d6e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CheckpointAndReportingTest.java": {
-    "mtime": 1782488208.6082914,
+    "mtime": 1782494200.4350946,
     "ast_hash": "35dd2ea229bf8692dfa60aa240d47c78",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ClipboardActionUnitTest.java": {
-    "mtime": 1782488208.6082914,
+    "mtime": 1782494200.4360971,
     "ast_hash": "049ed3057c478bf631b973241fdb7e42",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CucumberFeatureListenerUnitTest.java": {
-    "mtime": 1782488208.609289,
+    "mtime": 1782494200.4360971,
     "ast_hash": "40b3bb11667dcc54e4c8eff1e5a9b52b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CucumberTestRunnerListenerUnitTest.java": {
-    "mtime": 1782488208.609289,
+    "mtime": 1782494200.4360971,
     "ast_hash": "af73dc5a35bc20fb91b9540c939aa848",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CucumberTestsHelperCoverageUnitTest.java": {
-    "mtime": 1782488208.6102896,
+    "mtime": 1782494200.437095,
     "ast_hash": "f5787b288386b7c7d678c839cae81b73",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CustomSoftAssertTest.java": {
-    "mtime": 1782488208.6102896,
+    "mtime": 1782494200.437095,
     "ast_hash": "79519b2595cb2fef40442f1a10bfd750",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/DriverFactoryCoverageUnitTest.java": {
-    "mtime": 1782488208.611291,
+    "mtime": 1782494200.4380949,
     "ast_hash": "4947b5e7a73724c6e6fed6d2e64ba6a6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/DriverFactoryHelperAdditionalUnitTest.java": {
-    "mtime": 1782488208.611291,
+    "mtime": 1782494200.4380949,
     "ast_hash": "ea73d0c88cfce2990fde0325c0c17816",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/DriverFactoryHelperUnitTest.java": {
-    "mtime": 1782488208.611291,
+    "mtime": 1782494200.4380949,
     "ast_hash": "df5ed77d6a7a0c26406fe212157eaff2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ElementActionsCoverageUnitTest.java": {
-    "mtime": 1782488208.6122887,
+    "mtime": 1782494200.4390945,
     "ast_hash": "c25acf7125038b78ded022107f6cebb4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ExcelFileManagerCoverageUnitTest.java": {
-    "mtime": 1782488208.6122887,
+    "mtime": 1782494200.4390945,
     "ast_hash": "749454f40c0f999c34073902eb552194",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/FailureReporterUnitTest.java": {
-    "mtime": 1782488208.6132886,
+    "mtime": 1782494200.440095,
     "ast_hash": "75e0fd7c57c165bef078cdc8ce06fe65",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/FileActionsUnitTest.java": {
-    "mtime": 1782488208.6132886,
+    "mtime": 1782494200.440095,
     "ast_hash": "1a119fe7b09aa44da193163a82d2e9e6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/FileHelperUnitTest.java": {
-    "mtime": 1782488208.61429,
+    "mtime": 1782494200.4410946,
     "ast_hash": "ea6d731e57c3aac02a733f7d2a34d941",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/FileValidationsBuilderUnitTest.java": {
-    "mtime": 1782488208.61429,
+    "mtime": 1782494200.4410946,
     "ast_hash": "9d9acc2120910e1276906a2bde8a1e5c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/FlagsSetPropertyCoverageUnitTest.java": {
-    "mtime": 1782488208.6152897,
+    "mtime": 1782494200.4410946,
     "ast_hash": "da97292715ec3224bdb79568449c0fc9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/HTMLHelperUnitTest.java": {
-    "mtime": 1782488208.6152897,
+    "mtime": 1782494200.4420946,
     "ast_hash": "25126e1307dafd29f15749a1bdd60c78",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/IoExcelFileManagerTests.java": {
-    "mtime": 1782488208.6162896,
+    "mtime": 1782494200.4420946,
     "ast_hash": "530438883080a086ea007d8375c7a0fa",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/JSONFileManagerUnitTest.java": {
-    "mtime": 1782488208.6162896,
+    "mtime": 1782494200.4430945,
     "ast_hash": "df106c976e18caf15348e77c4f5aeb33",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/JavaHelperUnitTest.java": {
-    "mtime": 1782488208.617289,
+    "mtime": 1782494200.4430945,
     "ast_hash": "fdeef69d7094cb58b69c4765005ba6f4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/JunitListenerApiCoverageUnitTest.java": {
-    "mtime": 1782488208.617289,
+    "mtime": 1782494200.444095,
     "ast_hash": "eb8ea18add13bf5b439a526123934cfc",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LambdaTestHelperUnitTest.java": {
-    "mtime": 1782488208.617289,
+    "mtime": 1782494200.444095,
     "ast_hash": "3f11e51672c24653a84fe4fa69f7e797",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LambdaTestSetPropertyCoverageUnitTest.java": {
-    "mtime": 1782488208.6182895,
+    "mtime": 1782494200.4450946,
     "ast_hash": "47e318c7169fd292cc422fdfbb950ff7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LocalApiServer.java": {
-    "mtime": 1782488208.6182895,
+    "mtime": 1782494200.4450946,
     "ast_hash": "1994c60fb9cbca49689490cc09afaac7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LocatorBuilderExtendedUnitTest.java": {
-    "mtime": 1782488208.619289,
+    "mtime": 1782494200.4450946,
     "ast_hash": "3ffca37941148c7f54ec285739904a5c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LocatorBuilderUnitTest.java": {
-    "mtime": 1782488208.619289,
+    "mtime": 1782494200.446099,
     "ast_hash": "70bc98553a43a07567efa654eec320d7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LogRedirectorUnitTest.java": {
-    "mtime": 1782488208.619289,
+    "mtime": 1782494200.446099,
     "ast_hash": "25be02ab0943217c6d54155e0c912775",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/MemoryLeakFixTests.java": {
-    "mtime": 1782488208.6202896,
+    "mtime": 1782494200.446099,
     "ast_hash": "9371b0c88769d68a72bf5c38b4039579",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/NativeValidationsBuilderUnitTest.java": {
-    "mtime": 1782488208.6202896,
+    "mtime": 1782494200.4470942,
     "ast_hash": "5eedc36971944b95c5b59dde171347a8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/NavigationActionUnitTest.java": {
-    "mtime": 1782488208.6202896,
+    "mtime": 1782494200.4470942,
     "ast_hash": "29ce81485193c40a2ddd60f48f50a622",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/NumberValidationsBuilderUnitTest.java": {
-    "mtime": 1782488208.6212888,
+    "mtime": 1782494200.4480946,
     "ast_hash": "c1e5acce43534ba13e1186db85b2c084",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PdfFileManagerUnitTest.java": {
-    "mtime": 1782488208.6212888,
+    "mtime": 1782494200.4480946,
     "ast_hash": "03fffd928746a3fec64c66b559d65b72",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ProjectStructureManagerTest.java": {
-    "mtime": 1782488208.6222887,
+    "mtime": 1782494200.4480946,
     "ast_hash": "6d2a66b21a274d7829cb5d2f93f416d9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertiesHelperCoverageUnitTest.java": {
-    "mtime": 1782488208.6222887,
+    "mtime": 1782494200.4490945,
     "ast_hash": "81ae315c34773c68a536c305b8d42394",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertiesHelperInitializationUnitTest.java": {
-    "mtime": 1782488208.623289,
+    "mtime": 1782494200.4500945,
     "ast_hash": "ea9d6467f8ef25e941d62698c46bfdd8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertiesHelperMaximumPerformanceModeUnitTest.java": {
-    "mtime": 1782488208.623289,
+    "mtime": 1782494200.4500945,
     "ast_hash": "5661da2130612dd49dc0c83732f5b25e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertiesUnitTest.java": {
-    "mtime": 1782488208.6242893,
+    "mtime": 1782494200.4500945,
     "ast_hash": "602487e1fabc0a78b778248bf0275372",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertyFileManagerUnitTest.java": {
-    "mtime": 1782488208.6242893,
+    "mtime": 1782494200.4510944,
     "ast_hash": "1f6b9ea7df5756b354ea8081215c0f65",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RecordManagerTest.java": {
-    "mtime": 1782488208.6252887,
+    "mtime": 1782494200.4510944,
     "ast_hash": "70cd848c481fbb5c2d081ede904fc7e4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ReportManagerHelperAttachmentIoUnitTest.java": {
-    "mtime": 1782488208.6252887,
+    "mtime": 1782494200.4520943,
     "ast_hash": "3559c3b9d7b73f3fc87daa4b19e7d031",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ReportManagerHelperUnitTests.java": {
-    "mtime": 1782488208.6252887,
+    "mtime": 1782494200.4520943,
     "ast_hash": "76ee387cb25dbcc34a94a172c61ff6a0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RestActionsFailureLoggingUnitTest.java": {
-    "mtime": 1782488208.626289,
+    "mtime": 1782494200.4520943,
     "ast_hash": "94747c6ac6534584011a570704cb7b89",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RestActionsTests.java": {
-    "mtime": 1782488208.626289,
+    "mtime": 1782494200.4530947,
     "ast_hash": "4a57b2261d8a6f4306b6a189df5c6b93",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RestActionsUtilsUnitTest.java": {
-    "mtime": 1782488208.6272886,
+    "mtime": 1782494200.4530947,
     "ast_hash": "de45f58c799fde431cef74d0e8653c15",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RestValidationsBuilderUnitTest.java": {
-    "mtime": 1782488208.6272886,
+    "mtime": 1782494200.4540956,
     "ast_hash": "1c0603f27b12bb4895a9aea5b5e1efa8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ShaftRestAssuredFilterUnitTest.java": {
-    "mtime": 1782488208.6282904,
+    "mtime": 1782494200.4540956,
     "ast_hash": "42bd55f4074df77459dec78903d4f560",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/SkippedTestReportingTest.java": {
-    "mtime": 1782488208.6282904,
+    "mtime": 1782494200.4540956,
     "ast_hash": "ce8578c3bec220a0e71049bee7331d9a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/SmartLocatorsCoverageUnitTest.java": {
-    "mtime": 1782488208.6282904,
+    "mtime": 1782494200.4550972,
     "ast_hash": "beb21c33b9ba95b2fb2d42033aef2235",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/StringHelperUnitTest.java": {
-    "mtime": 1782488208.6292877,
+    "mtime": 1782494200.4550972,
     "ast_hash": "666317424773b8170baaa4f3e65e5630",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TelemetryDeduplicationUnitTest.java": {
-    "mtime": 1782488208.6292877,
+    "mtime": 1782494200.456095,
     "ast_hash": "f63a7c2ce548fa3456264cc95af3a62f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java": {
-    "mtime": 1782488208.630289,
+    "mtime": 1782494200.456095,
     "ast_hash": "0ce15abe7ff432e30ff79ff6e2e6dfff",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TestClass.java": {
-    "mtime": 1782488208.630289,
+    "mtime": 1782494200.456095,
     "ast_hash": "75d5dabdf74b6a0a0ac46395a44852f1",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TestDataUnitTest.java": {
-    "mtime": 1782488208.630289,
+    "mtime": 1782494200.4570947,
     "ast_hash": "db41e63ea98f715a677d882ac1d4174c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TestNGListenerCoverageUnitTest.java": {
-    "mtime": 1782488208.631288,
+    "mtime": 1782494200.4570947,
     "ast_hash": "9e9510f0450a708edccb84a8ddd183cc",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TestNGListenerHelperCoverageUnitTest.java": {
-    "mtime": 1782488208.631288,
+    "mtime": 1782494200.4580982,
     "ast_hash": "9a5af4a09a68b32816599214788557b7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TextDirectionValidationsBuilderUnitTest.java": {
-    "mtime": 1782488208.6322887,
+    "mtime": 1782494200.4580982,
     "ast_hash": "60a881ad378ec7cfdfcfa5c81462d2c8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ThreadLocalPropertiesTest.java": {
-    "mtime": 1782488208.6322887,
+    "mtime": 1782494200.4580982,
     "ast_hash": "3b8c3ba881bf96883437c5ff46e2a879",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TopUncoveredClassesCoverageUnitTest.java": {
-    "mtime": 1782488208.6322887,
+    "mtime": 1782494200.459096,
     "ast_hash": "00f21d46e9c9345cfb0602c30e74896a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ValidationAndProgressBarTests.java": {
-    "mtime": 1782488208.6332886,
+    "mtime": 1782494200.459096,
     "ast_hash": "2cd823215ca19d7111f2d7092e71bda1",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ValidationEnumsUnitTest.java": {
-    "mtime": 1782488208.6332886,
+    "mtime": 1782494200.4600952,
     "ast_hash": "caccd040fd417216fa761e864fcf4179",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ValidationHelperUnitTest.java": {
-    "mtime": 1782488208.6342885,
+    "mtime": 1782494200.4600952,
     "ast_hash": "5877871d3318bd2685cb6c67d7fa0836",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ValidationsBuilderUnitTest.java": {
-    "mtime": 1782488208.6342885,
+    "mtime": 1782494200.4600952,
     "ast_hash": "cfe79a40a49a8ecba70f2bca1418d697",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ValidationsExecutorCoverageUnitTest.java": {
-    "mtime": 1782488208.6342885,
+    "mtime": 1782494200.461096,
     "ast_hash": "b4e87dd6decede2ec6a874bf552646b0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/WebDriverListenerCoverageUnitTest.java": {
-    "mtime": 1782488208.635288,
+    "mtime": 1782494200.461096,
     "ast_hash": "99675a25fb42770a1f0fe32b6056ec93",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/XrayIntegrationHelperCoverageUnitTest.java": {
-    "mtime": 1782488208.635288,
+    "mtime": 1782494200.462096,
     "ast_hash": "1a3f82e3bba50c09c7b5f46d0e17c64b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/YAMLFileManagerUnitTest.java": {
-    "mtime": 1782488208.636288,
+    "mtime": 1782494200.462096,
     "ast_hash": "657dabafe357030b543ad8b2cc7d37b4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/validationsWizard/BrowserValidationsTests.java": {
-    "mtime": 1782488208.636288,
+    "mtime": 1782494200.462096,
     "ast_hash": "fae6d2b4edd4c21b783a63e0acfd94bc",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/validationsWizard/ElementValidationsTests.java": {
-    "mtime": 1782488208.636288,
+    "mtime": 1782494200.4630966,
     "ast_hash": "74ef4dc7c24e14da3c0a2e956ecaf8d4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/validationsWizard/NegativeValidationsTests.java": {
-    "mtime": 1782488208.6372876,
+    "mtime": 1782494200.4630966,
     "ast_hash": "80deb29d4d240573803b2e4e4e6e1edb",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/validationsWizard/VisualValidationTests.java": {
-    "mtime": 1782488208.6372876,
+    "mtime": 1782494200.4640944,
     "ast_hash": "1eec1a809ea772c21ef54c6c277a0a9b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/JsonFileTest.json": {
-    "mtime": 1782488208.6412885,
+    "mtime": 1782494200.4670942,
     "ast_hash": "34d4c2e8470475605eeb576357fa1a24",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/JsonFileTest2.json": {
-    "mtime": 1782488208.6412885,
+    "mtime": 1782494200.4680946,
     "ast_hash": "0d4aba4457124b501a49b132fc29e7c8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/api/local-api/post-1.json": {
-    "mtime": 1782488208.643288,
+    "mtime": 1782494200.4690943,
     "ast_hash": "e7f6064672a51be242e522606fe7a874",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/api/local-api/posts.json": {
-    "mtime": 1782488208.643288,
+    "mtime": 1782494200.4700954,
     "ast_hash": "9b635707c3b1a2033d585b69a6bab819",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/api/local-api/todos.json": {
-    "mtime": 1782488208.643288,
+    "mtime": 1782494200.4700954,
     "ast_hash": "095e11feade03bc6b7e53dee2486f681",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/api/local-api/users.json": {
-    "mtime": 1782488208.6442876,
+    "mtime": 1782494200.4700954,
     "ast_hash": "8b738dc1a52055df6ff5444eb37a1b8f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/api/local-api/zip-90210.json": {
-    "mtime": 1782488208.6442876,
+    "mtime": 1782494200.471096,
     "ast_hash": "6ca2311ae54ce67c7fbd17f118b58cad",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/jsonFileManagerTestData.json": {
-    "mtime": 1782488209.089399,
+    "mtime": 1782494200.9160566,
     "ast_hash": "94537dc7a44a551939fe07da874a6ce9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/jsonToJavaObjectTest.json": {
-    "mtime": 1782488209.089399,
+    "mtime": 1782494200.9160566,
     "ast_hash": "fe787bfecd55bde95846520922954e20",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/post1Response.json": {
-    "mtime": 1782488209.0903962,
+    "mtime": 1782494200.9170542,
     "ast_hash": "e7f6064672a51be242e522606fe7a874",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/post1ResponseSchema.json": {
-    "mtime": 1782488209.0913951,
+    "mtime": 1782494200.918056,
     "ast_hash": "16bf47afb2fa16d9a72bee4aa5090fef",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/restActionsCoverage/containsObject.json": {
-    "mtime": 1782488209.0913951,
+    "mtime": 1782494200.918056,
     "ast_hash": "caf79d4a9031acee3921b15dcfacd235",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/restActionsCoverage/expectedObject.json": {
-    "mtime": 1782488209.092397,
+    "mtime": 1782494200.918056,
     "ast_hash": "fbf3b3e03cf5d05123488de14e150acd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/restActionsCoverage/mismatchObject.json": {
-    "mtime": 1782488209.0930378,
+    "mtime": 1782494200.919544,
     "ast_hash": "5a250de786cc5579da66cbcdee8f2818",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/restActionsCoverage/orderedArray.json": {
-    "mtime": 1782488209.0930378,
+    "mtime": 1782494200.919544,
     "ast_hash": "0e406c996279efff769b1105dd51448e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/schema.json": {
-    "mtime": 1782488209.0940428,
+    "mtime": 1782494200.9205513,
     "ast_hash": "99a7063f24f77c3fb2c7aea31eec411c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782488209.0960429,
+    "mtime": 1782494200.9225492,
     "ast_hash": "d896f3512bf493280abf8061c7df1d75",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/specialCharacters.json": {
-    "mtime": 1782488209.0960429,
+    "mtime": 1782494200.9225492,
     "ast_hash": "334064f08b91de55ef30335710dbd8f8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/test_assertResponseEqualsIgnoringOrder.json": {
-    "mtime": 1782488209.101043,
+    "mtime": 1782494200.9265487,
     "ast_hash": "a679a33772d98b89e77510ad9938a84d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/test_post_withBody_fromFile.json": {
-    "mtime": 1782488209.102043,
+    "mtime": 1782494200.9275496,
     "ast_hash": "af539d78603bb042feb8be65c20748e8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/unitTestData.json": {
-    "mtime": 1782488209.102043,
+    "mtime": 1782494200.9275496,
     "ast_hash": "0e90c1c1a227d7d7c2d2dce740714d82",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/HealingConfiguration.java": {
-    "mtime": 1782488209.106041,
+    "mtime": 1782494200.9315498,
     "ast_hash": "b5f311bae11ad11dd0deed6b9921fade",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/ShaftHeal.java": {
-    "mtime": 1782488209.106041,
+    "mtime": 1782494200.9315498,
     "ast_hash": "638f827ad267fed1841301e034516d29",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/AiCandidateReranker.java": {
-    "mtime": 1782488209.1070418,
+    "mtime": 1782494200.9325488,
     "ast_hash": "37bae89f609e94e33b6291765bec4746",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/CandidateExtractor.java": {
-    "mtime": 1782488209.1070418,
+    "mtime": 1782494200.9325488,
     "ast_hash": "1b8b44bdcf6e32e31917a1e7e43e9735",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/DeterministicScorer.java": {
-    "mtime": 1782488209.1080415,
+    "mtime": 1782494200.9335492,
     "ast_hash": "4bf42ea11e26e7869a261270733d628d",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/FingerprintExtractor.java": {
-    "mtime": 1782488209.1080415,
+    "mtime": 1782494200.9335492,
     "ast_hash": "7f104b32afa9d009c7714e55f453c167",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HealingDecisionEngine.java": {
-    "mtime": 1782488209.1080415,
+    "mtime": 1782494200.9335492,
     "ast_hash": "4209aed55089ab983f839222d8cf64db",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HealingHistoryStore.java": {
-    "mtime": 1782488209.109041,
+    "mtime": 1782494200.9345498,
     "ast_hash": "75b6488324dfad90e662f9f08c9d7fb4",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HealingReportWriter.java": {
-    "mtime": 1782488209.109041,
+    "mtime": 1782494200.9345498,
     "ast_hash": "a6807824d69a21cbfde367786dda6459",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HealingSupport.java": {
-    "mtime": 1782488209.110041,
+    "mtime": 1782494200.9345498,
     "ast_hash": "6a5e58df19b9bf605b8d0e529e3b5a9f",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HistoryDocument.java": {
-    "mtime": 1782488209.110041,
+    "mtime": 1782494200.9355493,
     "ast_hash": "e02bfa5e0416eaa97327d7cc30edaaaa",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HistoryRecord.java": {
-    "mtime": 1782488209.110041,
+    "mtime": 1782494200.9355493,
     "ast_hash": "affb5533f80ddcf6955cb487de88c5bc",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/PrivacySanitizer.java": {
-    "mtime": 1782488209.111042,
+    "mtime": 1782494200.9355493,
     "ast_hash": "c615c6f4a1781c7a5a2056074b581bb2",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/RankedCandidate.java": {
-    "mtime": 1782488209.111042,
+    "mtime": 1782494200.936549,
     "ast_hash": "323b41fab8a95e2adce58147b8a7d197",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/ShaftHealingProvider.java": {
-    "mtime": 1782488209.111042,
+    "mtime": 1782494200.936549,
     "ast_hash": "bd1cbb989de7e55d8ee1b04746442788",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/VisualEvidenceService.java": {
-    "mtime": 1782488209.1120415,
+    "mtime": 1782494200.936549,
     "ast_hash": "743e64057ed3e7ab3111d0ecb9e093c8",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingCandidate.java": {
-    "mtime": 1782488209.1120415,
+    "mtime": 1782494200.9375503,
     "ast_hash": "1617a29056414a87a0f01eea9f3f1e5d",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingContext.java": {
-    "mtime": 1782488209.1130426,
+    "mtime": 1782494200.9375503,
     "ast_hash": "3c02c33790e64b5a77b7c6218a0162cf",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingDecision.java": {
-    "mtime": 1782488209.1130426,
+    "mtime": 1782494200.938549,
     "ast_hash": "e3cff7de69ac3081e54b05070a9ad923",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingPlatform.java": {
-    "mtime": 1782488209.1130426,
+    "mtime": 1782494200.938549,
     "ast_hash": "d4cc50f5563d27a3d8cadabad3f8c086",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingReport.java": {
-    "mtime": 1782488209.1140409,
+    "mtime": 1782494200.938549,
     "ast_hash": "3d0627a4f1785e21e5403b3685773ca5",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingScore.java": {
-    "mtime": 1782488209.1140409,
+    "mtime": 1782494200.939549,
     "ast_hash": "99e432927182919d5815b3d8d101b6de",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/LocatorFingerprint.java": {
-    "mtime": 1782488209.1140409,
+    "mtime": 1782494200.939549,
     "ast_hash": "b7f303ee7028dce02f372fe1887fdf27",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/resources/schema/shaft-heal-history-1.0.schema.json": {
-    "mtime": 1782488209.1160429,
+    "mtime": 1782494200.941551,
     "ast_hash": "6bd4d6c6c18d1bc0c600792f43232342",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/resources/schema/shaft-heal-history-2.0.schema.json": {
-    "mtime": 1782488209.1160429,
+    "mtime": 1782494200.9425504,
     "ast_hash": "6d71c99cadca42d412c11b50c7131430",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/resources/schema/shaft-heal-report-1.0.schema.json": {
-    "mtime": 1782488209.1170425,
+    "mtime": 1782494200.9425504,
     "ast_hash": "f8f5c202b1e0baca184836e2dd42118b",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/resources/schema/shaft-heal-report-2.0.schema.json": {
-    "mtime": 1782488209.1170425,
+    "mtime": 1782494200.9425504,
     "ast_hash": "88e2d8a2767744c1b32faa700466d741",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/AiCandidateRerankerTest.java": {
-    "mtime": 1782488209.1190407,
+    "mtime": 1782494200.9445486,
     "ast_hash": "034bb4a07e1e4c4d8c1ed5d8a31547a2",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/DeterministicScorerTest.java": {
-    "mtime": 1782488209.1190407,
+    "mtime": 1782494200.9445486,
     "ast_hash": "5d36a445e2cae9634e483d80dda345a7",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/HealingHistoryStoreTest.java": {
-    "mtime": 1782488209.1200404,
+    "mtime": 1782494200.9455485,
     "ast_hash": "055d679be0c31247da14c2d2e8305954",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/ShaftHealingProviderTest.java": {
-    "mtime": 1782488209.1200404,
+    "mtime": 1782494200.9455485,
     "ast_hash": "62b7fa589374d302bc095a85630668cb",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/WebDomHealingAcceptanceTest.java": {
-    "mtime": 1782488209.1200404,
+    "mtime": 1782494200.9455485,
     "ast_hash": "54705c408e9415e6e59248f9dc88e76a",
     "semantic_hash": ""
   },
   "shaft-mcp/mvnw": {
-    "mtime": 1782488209.1250398,
+    "mtime": 1782494200.9505484,
     "ast_hash": "2fe09837c0b4dfabab4c4b206bcd0850",
     "semantic_hash": ""
   },
   "shaft-mcp/server.json": {
-    "mtime": 1782488209.1260395,
+    "mtime": 1782494200.951548,
     "ast_hash": "10eafe30f8d30db0f7f5e85b2793e18a",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/BrowserService.java": {
-    "mtime": 1782488209.1280403,
+    "mtime": 1782494200.9535494,
     "ast_hash": "825d8b126501b736bb968ed530b127ab",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/BrowserType.java": {
-    "mtime": 1782488209.1280403,
+    "mtime": 1782494200.9535494,
     "ast_hash": "d92c802c46cf7055edd908c22dd983c6",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java": {
-    "mtime": 1782488209.1292007,
+    "mtime": 1782494200.9545493,
     "ast_hash": "d64d47ce7e08b3e0e1f0675a072da341",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/DoctorService.java": {
-    "mtime": 1782488209.1292007,
+    "mtime": 1782494200.9545493,
     "ast_hash": "fdac0a63aa8e73797a7d58596eb727c1",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/ElementService.java": {
-    "mtime": 1782488209.1292007,
+    "mtime": 1782494200.9545493,
     "ast_hash": "15840a8b150fb2a4988a9041336bf528",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/EngineService.java": {
-    "mtime": 1782488209.1302056,
+    "mtime": 1782494200.9555492,
     "ast_hash": "f75ea21cc4747ba8b46f0983950fc5e6",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpActionRecord.java": {
-    "mtime": 1782488209.1312053,
+    "mtime": 1782494200.9565487,
     "ast_hash": "88f2540004bf2e85e19d1883fa8fd268",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpAnalysisReport.java": {
-    "mtime": 1782488209.1322055,
+    "mtime": 1782494200.9565487,
     "ast_hash": "655dc48d9861063302c3874e08fad7bb",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCaptureCodeBlockService.java": {
-    "mtime": 1782488209.133206,
+    "mtime": 1782494200.9585505,
     "ast_hash": "ba9b31e164fa47d38f4a5bf16f824aee",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCaptureReplayResult.java": {
-    "mtime": 1782488209.133206,
+    "mtime": 1782494200.9585505,
     "ast_hash": "c1566317b1a57ccbf142a1a4e6dc3f69",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCodeBlock.java": {
-    "mtime": 1782488209.1342058,
+    "mtime": 1782494200.959548,
     "ast_hash": "76ebce9f3db111251b04cf7f5d6a7548",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpDoctorRemediationService.java": {
-    "mtime": 1782488209.135205,
+    "mtime": 1782494200.9605484,
     "ast_hash": "bf301fb33655d33748d844a9106ab67e",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileAccessibilityTree.java": {
-    "mtime": 1782488209.1372051,
+    "mtime": 1782494200.9625494,
     "ast_hash": "f3b7b5c23ef3cb6ff05525b718994ff3",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileActionResult.java": {
-    "mtime": 1782488209.1372051,
+    "mtime": 1782494200.9625494,
     "ast_hash": "29d070e4029d6709b7924ba36735510a",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileContextSnapshot.java": {
-    "mtime": 1782488209.1381907,
+    "mtime": 1782494200.9635494,
     "ast_hash": "2f654d69dc90ef0def1b8902d14e3bba",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecordedAction.java": {
-    "mtime": 1782488209.1401956,
+    "mtime": 1782494200.9655485,
     "ast_hash": "ecfc0758677616c607ba07313a52b729",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecording.java": {
-    "mtime": 1782488209.1401956,
+    "mtime": 1782494200.9655485,
     "ast_hash": "695772cf2e07fcb64d1f38ce531219ba",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecordingService.java": {
-    "mtime": 1782488209.1411953,
+    "mtime": 1782494200.9655485,
     "ast_hash": "0399934cf57d42b9db9e71f92d59d731",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecordingStatus.java": {
-    "mtime": 1782488209.1411953,
+    "mtime": 1782494200.9665515,
     "ast_hash": "aa275295374a1818f6c109d6ea81b57d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileReplayResult.java": {
-    "mtime": 1782488209.1411953,
+    "mtime": 1782494200.9665515,
     "ast_hash": "7865349c5c645027ec9b2ad4140187c1",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileSessionResult.java": {
-    "mtime": 1782488838.2915254,
-    "ast_hash": "b0aed6120c3ce4958f457814b24416af",
+    "mtime": 1782494200.9665515,
+    "ast_hash": "e79607edd99c46b3382c1ddc7461c931",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpNaturalActionResult.java": {
-    "mtime": 1782488209.143195,
+    "mtime": 1782494200.9682655,
     "ast_hash": "8d9587e9bd285ff5d3066b2afea60733",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpPageDomSnapshot.java": {
-    "mtime": 1782488209.1441953,
+    "mtime": 1782494200.969271,
     "ast_hash": "da511c88341bda167180baeac16db366",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpProviderFallback.java": {
-    "mtime": 1782488209.145196,
+    "mtime": 1782494200.970271,
     "ast_hash": "f19ecd97597af4b6374659222d736a68",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpRuntimePaths.java": {
-    "mtime": 1782488209.145196,
+    "mtime": 1782494200.970271,
     "ast_hash": "7508e81382cca0830263f0477c96731e",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpScreenshotResult.java": {
-    "mtime": 1782488209.1461954,
+    "mtime": 1782494200.9712703,
     "ast_hash": "1ed7179791590810783cc71682129cde",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpWorkspacePolicy.java": {
-    "mtime": 1782488209.1471972,
+    "mtime": 1782494200.9712703,
     "ast_hash": "2ea9e2dad8bdfc40515c48cc4f7e644d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/MobileService.java": {
-    "mtime": 1782490218.3610268,
-    "ast_hash": "977b3ba6f9d17d0c539fd1440fc1f888",
+    "mtime": 1782494200.972271,
+    "ast_hash": "9b9288e7adcff17860464a92541e9293",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/NaturalActionService.java": {
-    "mtime": 1782488209.1481965,
+    "mtime": 1782494200.9732728,
     "ast_hash": "f727c820fb4def0a03ba5eeb1894ca0b",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/ShaftMcpApplication.java": {
-    "mtime": 1782488209.149195,
+    "mtime": 1782494200.9742734,
     "ast_hash": "5b9df6ac6c32c2a0ef93658ad16d4b81",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/locatorStrategy.java": {
-    "mtime": 1782488209.1501944,
+    "mtime": 1782494200.9742734,
     "ast_hash": "93d35de3c8d385e5eb24574d006934dd",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java": {
-    "mtime": 1782488209.1531944,
+    "mtime": 1782494200.9772704,
     "ast_hash": "b08594c320497b0daf857f366f591ed2",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/DoctorServiceTest.java": {
-    "mtime": 1782488209.1531944,
+    "mtime": 1782494200.97827,
     "ast_hash": "ab0aa38061072f9696c211f5c370e9a4",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/EngineServiceRuntimePathTest.java": {
-    "mtime": 1782488209.1541944,
+    "mtime": 1782494200.97827,
     "ast_hash": "45a98645e7e2f4203be7278baadb2f66",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/EngineServiceTest.java": {
-    "mtime": 1782488209.1541944,
+    "mtime": 1782494200.97827,
     "ast_hash": "90a0eb091a6ac3d9480fc327f6712241",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpRuntimePathsTest.java": {
-    "mtime": 1782488209.1572,
+    "mtime": 1782494200.9822712,
     "ast_hash": "3df7775db4987c2453ab16758e62a7ce",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/MobileRecordingServiceTest.java": {
-    "mtime": 1782488209.1581998,
+    "mtime": 1782494200.9832706,
     "ast_hash": "4ca682157c293f5e2a2d5ba5d62382ec",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java": {
-    "mtime": 1782488209.1591992,
+    "mtime": 1782494200.9842708,
     "ast_hash": "4d07ac006a317a1e69127f88cf627573",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/mcp-tool-manifest.json": {
-    "mtime": 1782488209.163199,
+    "mtime": 1782494200.9872708,
     "ast_hash": "0e6f2f2161875e369a0ee1567f60eb7b",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/shaft-pilot/doctor/repair-input.json": {
-    "mtime": 1782488209.163199,
+    "mtime": 1782494200.9882708,
     "ast_hash": "457a81a9ab8bbcd47b4c46fefb9c6ad6",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/claude-desktop.json": {
-    "mtime": 1782488209.1641996,
+    "mtime": 1782494200.9882708,
     "ast_hash": "544157f8499e7c19c3b6495d7a2de685",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/doctor-analyze-invocations.json": {
-    "mtime": 1782488209.1651988,
+    "mtime": 1782494200.9892707,
     "ast_hash": "b02f7110c14eea4b8a149b5649cb8c1d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/gemini-settings.json": {
-    "mtime": 1782488209.1651988,
+    "mtime": 1782494200.9902756,
     "ast_hash": "544157f8499e7c19c3b6495d7a2de685",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/vscode-mcp.json": {
-    "mtime": 1782488209.1651988,
+    "mtime": 1782494200.9902756,
     "ast_hash": "069569075ea6158826d8a47b9204fa8b",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiBudget.java": {
-    "mtime": 1782488209.169199,
+    "mtime": 1782494201.025314,
     "ast_hash": "0f62ae7eb77e7a79164518be64846a07",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiCapabilities.java": {
-    "mtime": 1782488209.1707041,
+    "mtime": 1782494201.025314,
     "ast_hash": "4b0644dd013cb6d45500cd6aa33e2be9",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiExecutionService.java": {
-    "mtime": 1782488209.1707041,
+    "mtime": 1782494201.0317879,
     "ast_hash": "a0595a80fb9dc84f4159fbd5e96ecb2a",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiImage.java": {
-    "mtime": 1782488209.1707041,
+    "mtime": 1782494201.0317879,
     "ast_hash": "25716916a48e61fbe6d9d4d1dc1fccaa",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiProvider.java": {
-    "mtime": 1782488209.1717103,
+    "mtime": 1782494201.0330348,
     "ast_hash": "825a0e7f2a2271f176163b67c1155d19",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiProviderAvailability.java": {
-    "mtime": 1782488209.1717103,
+    "mtime": 1782494201.0330348,
     "ast_hash": "f1cd040ecae8e52ad080c5619221e040",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiProviderRegistry.java": {
-    "mtime": 1782488209.1717103,
+    "mtime": 1782494201.0330348,
     "ast_hash": "462385cec9e86f110b0f5e975368df2d",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiRequest.java": {
-    "mtime": 1782488209.1727097,
+    "mtime": 1782494201.034034,
     "ast_hash": "72fcc9f3c38e1ed3d98d57815f995adb",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiResponse.java": {
-    "mtime": 1782488209.1727097,
+    "mtime": 1782494201.034034,
     "ast_hash": "d62787524d101da0a83d24df33272971",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiResponseStatus.java": {
-    "mtime": 1782488209.1727097,
+    "mtime": 1782494201.034034,
     "ast_hash": "18ec9401e739a84a451c8125c11152c5",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiUsage.java": {
-    "mtime": 1782488209.1737096,
+    "mtime": 1782494201.0350358,
     "ast_hash": "97a43fdb6c0b590d6c7be89d9fc2d35e",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/ApprovalPolicy.java": {
-    "mtime": 1782488209.1737096,
+    "mtime": 1782494201.0350358,
     "ast_hash": "f08f93f0d55ddbbad18efee9cced917b",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/DisabledAiProvider.java": {
-    "mtime": 1782488209.1737096,
+    "mtime": 1782494201.0350358,
     "ast_hash": "522658fda00a6fa05e2132bfc58d9c1d",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/EvidenceCategory.java": {
-    "mtime": 1782488209.1747093,
+    "mtime": 1782494201.0350358,
     "ast_hash": "737d4c99daddaa581171170ad47006c7",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/EvidenceReference.java": {
-    "mtime": 1782488209.1747093,
+    "mtime": 1782494201.0360334,
     "ast_hash": "cd5fae7467f25e060c2a531eeb44f789",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/ProcessingLocation.java": {
-    "mtime": 1782488209.1747093,
+    "mtime": 1782494201.0360334,
     "ast_hash": "7106587b9fd1d5573d0c2ba6355e6efa",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/audit/AiAuditEvent.java": {
-    "mtime": 1782488209.1757097,
+    "mtime": 1782494201.0370347,
     "ast_hash": "bd2ad33294235bf573acfac7e93da4b3",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/audit/AiAuditSink.java": {
-    "mtime": 1782488209.1757097,
+    "mtime": 1782494201.0370347,
     "ast_hash": "460112c404cbd8eb47074b1ce2f714fa",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/audit/ShaftAiAuditSink.java": {
-    "mtime": 1782488209.1767101,
+    "mtime": 1782494201.0370347,
     "ast_hash": "cbab846c3ab872246cbe1e0a861a062e",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/config/PilotConfiguration.java": {
-    "mtime": 1782488209.1767101,
+    "mtime": 1782494201.0380344,
     "ast_hash": "43594a66237b108d080c946819eb7a57",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/config/ProviderConfiguration.java": {
-    "mtime": 1782488209.1777098,
+    "mtime": 1782494201.0380344,
     "ast_hash": "c0d63dcf550dbd563bd77c89c6fcf013",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/json/JsonSchemaValidator.java": {
-    "mtime": 1782488209.1777098,
+    "mtime": 1782494201.0390346,
     "ast_hash": "d1136d836e02f9f6022a06cb42acb949",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/natural/PilotNaturalActionPlanner.java": {
-    "mtime": 1782488209.1787097,
+    "mtime": 1782494201.0390346,
     "ast_hash": "fac8097a727ba867caa8d6fe1e3ce385",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/security/RedactionPolicy.java": {
-    "mtime": 1782488209.1797097,
+    "mtime": 1782494201.0400345,
     "ast_hash": "b2018496d7f034d57439ad18315fddd8",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/security/RedactionResult.java": {
-    "mtime": 1782488209.1797097,
+    "mtime": 1782494201.0400345,
     "ast_hash": "02d5ee92866f5c7a61fdc20af0d1a282",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/security/Redactor.java": {
-    "mtime": 1782488209.1797097,
+    "mtime": 1782494201.041035,
     "ast_hash": "ff7d2c45be4f35fb31c789cfb797509e",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiExecutionServiceTest.java": {
-    "mtime": 1782488209.1827092,
+    "mtime": 1782494201.0430343,
     "ast_hash": "18f32509d9954005e10259839e4c6a26",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiProviderRegistryTest.java": {
-    "mtime": 1782488209.1827092,
+    "mtime": 1782494201.0440345,
     "ast_hash": "d44cb3d9a96f72e8d169b40215ea9e30",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/ai/PilotTestConfiguration.java": {
-    "mtime": 1782488209.1837094,
+    "mtime": 1782494201.0450373,
     "ast_hash": "b8434bf125093e961295191538deefdd",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/security/RedactorTest.java": {
-    "mtime": 1782488209.185709,
+    "mtime": 1782494201.0460353,
     "ast_hash": "6b5d2f07eeca23613af246198507f334",
     "semantic_hash": ""
   },
   "shaft-upgrader/upgrade_to_modular_shaft.py": {
-    "mtime": 1782488209.1867087,
+    "mtime": 1782494201.0470345,
     "ast_hash": "d6645aac8e4ec7162ed2a8a81f9d4d5b",
     "semantic_hash": ""
   },
   "shaft-video/src/main/java/com/shaft/gui/internal/video/AutomationRemarksDesktopVideoRecordingProvider.java": {
-    "mtime": 1782488209.1897073,
+    "mtime": 1782494201.0500338,
     "ast_hash": "b92a1245bb8e27b8865cd539c0303677",
     "semantic_hash": ""
   },
   "shaft-video/src/test/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistrationTest.java": {
-    "mtime": 1782488209.1917083,
+    "mtime": 1782494201.0530343,
     "ast_hash": "b86fe9a695cb45dd47af814176c0d207",
     "semantic_hash": ""
   },
   "shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvHealingVisualProvider.java": {
-    "mtime": 1782488209.1947098,
+    "mtime": 1782494201.0550342,
     "ast_hash": "665a72915a4214f1e86d3f8a315873b9",
     "semantic_hash": ""
   },
   "shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java": {
-    "mtime": 1782488209.1957076,
+    "mtime": 1782494201.0550342,
     "ast_hash": "f34d4ea0f2f879ddb05d88e8fa163257",
     "semantic_hash": ""
   },
   "shaft-visual/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsCoverageUnitTest.java": {
-    "mtime": 1782488209.1987078,
+    "mtime": 1782494201.0590334,
     "ast_hash": "a010a6f22a177d8030bad70f35d74bab",
     "semantic_hash": ""
   },
   "shaft-visual/src/test/java/com/shaft/gui/internal/image/OpenCvHealingVisualProviderTest.java": {
-    "mtime": 1782488209.1987078,
+    "mtime": 1782494201.0590334,
     "ast_hash": "324be73186da5aa43b06e00099a55061",
     "semantic_hash": ""
   },
   "shaft-visual/src/test/java/testPackage/unitTests/ImageProcessingActionsUnitTest.java": {
-    "mtime": 1782488209.199709,
+    "mtime": 1782494201.0600355,
     "ast_hash": "c2a218aa630dedbe91eae5c572944fd7",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/forbidden-coordinates.json": {
-    "mtime": 1782488209.2007072,
+    "mtime": 1782494201.061035,
     "ast_hash": "05978f92526026f1e72d0cc9333dcd14",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/api.json": {
-    "mtime": 1782488209.2017074,
+    "mtime": 1782494201.0620344,
     "ast_hash": "33464132b1941069384296fb1a5d0b8c",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/appium-mobile.json": {
-    "mtime": 1782488209.2017074,
+    "mtime": 1782494201.0620344,
     "ast_hash": "7ae7e1b33592d1ef1428d548f8fac808",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts-bom.json": {
-    "mtime": 1782488209.2027082,
+    "mtime": 1782494201.0633328,
     "ast_hash": "9fbfe22e65e8cfa4e1ffb7b9e6517494",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts-browserstack-sdk.json": {
-    "mtime": 1782488209.2037082,
+    "mtime": 1782494201.0633328,
     "ast_hash": "5af6cde115806a688731572d1ceaa893",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts-combined-modules.json": {
-    "mtime": 1782488209.2037082,
+    "mtime": 1782494201.0643375,
     "ast_hash": "278a1788754fc7bba0fa505cc2baed79",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts-desktop-video.json": {
-    "mtime": 1782488209.2047074,
+    "mtime": 1782494201.0643375,
     "ast_hash": "1543ef994a82a667c3d95688bd778587",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts-opencv-visual.json": {
-    "mtime": 1782488209.2047074,
+    "mtime": 1782494201.0653367,
     "ast_hash": "719a4464d0a58ecde6dba8f9f5233a8d",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts.json": {
-    "mtime": 1782488209.2057073,
+    "mtime": 1782494201.0653367,
     "ast_hash": "d8492b92abaaf1c4d60cd1035a96f8e1",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/bom.json": {
-    "mtime": 1782488209.2057073,
+    "mtime": 1782494201.0653367,
     "ast_hash": "3eabc9ec189bdaf11f14b4c0a45b75c2",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/browserstack-sdk.json": {
-    "mtime": 1782488209.2057073,
+    "mtime": 1782494201.0663376,
     "ast_hash": "44c751b4a87214e0607bd7a018f6bd29",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/combined-modules.json": {
-    "mtime": 1782488209.2067075,
+    "mtime": 1782494201.0663376,
     "ast_hash": "7437bc718bb6526bd5ade48a6dd7a186",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/desktop-video.json": {
-    "mtime": 1782488209.2067075,
+    "mtime": 1782494201.0663376,
     "ast_hash": "3cd581acddb6c5ab3eb3c5dadfa4dfec",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/junit-web.json": {
-    "mtime": 1782488209.2067075,
+    "mtime": 1782494201.0663376,
     "ast_hash": "e736aac3ac042dd16518d1f12e5a8689",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/legacy-coordinate.json": {
-    "mtime": 1782488209.2067075,
+    "mtime": 1782494201.0673387,
     "ast_hash": "e0db222137e456fe8e3563cf5564672a",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/opencv-visual.json": {
-    "mtime": 1782488209.2077074,
+    "mtime": 1782494201.0673387,
     "ast_hash": "3af8a40b65daa2d45d95d633db37bc0f",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/testng-web.json": {
-    "mtime": 1782488209.2077074,
+    "mtime": 1782494201.0673387,
     "ast_hash": "476c5a55cf829d939d58c5ee853862b1",
     "semantic_hash": ""
   },
   "tests/scripts/test_assemble_javadocs.py": {
-    "mtime": 1782488209.2087076,
+    "mtime": 1782494201.0683403,
     "ast_hash": "f3502852bcff0fab528ccb2995644628",
     "semantic_hash": ""
   },
   "tests/scripts/test_browserstack_module_boundary.py": {
-    "mtime": 1782488209.2087076,
+    "mtime": 1782494201.0683403,
     "ast_hash": "f4671e1c6ca54b6e02497afefa3d79c9",
     "semantic_hash": ""
   },
   "tests/scripts/test_check_maven_release_version.py": {
-    "mtime": 1782488209.2087076,
+    "mtime": 1782494201.06934,
     "ast_hash": "2862600bb50c3c3a62386c49105fa5e8",
     "semantic_hash": ""
   },
   "tests/scripts/test_extract_allure_failures.py": {
-    "mtime": 1782488209.2097075,
+    "mtime": 1782494201.06934,
     "ast_hash": "5f15f6321ea15ae0b440221512563c41",
     "semantic_hash": ""
   },
   "tests/scripts/test_pilot_module_boundary.py": {
-    "mtime": 1782488209.210709,
+    "mtime": 1782494201.0703397,
     "ast_hash": "778d0667f363c9013a98be56f2cdbeeb",
     "semantic_hash": ""
   },
   "tests/scripts/test_upgrade_to_modular_shaft.py": {
-    "mtime": 1782488209.211709,
+    "mtime": 1782494201.0703397,
     "ast_hash": "67bdad010b94f24614daaa65e2297e9b",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_agent_guidance.py": {
-    "mtime": 1782488209.211709,
+    "mtime": 1782494201.0713415,
     "ast_hash": "31f821d43bb135cecff6219df9238139",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_agent_setup.py": {
-    "mtime": 1782488209.211709,
+    "mtime": 1782494201.0713415,
     "ast_hash": "6897d4657f87cc83c6573b37698c96de",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_maven_publication.py": {
-    "mtime": 1782488209.212708,
+    "mtime": 1782494201.0723395,
     "ast_hash": "34d6ed7fbe980f3eed372bd1ef5388aa",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_modular_documentation.py": {
-    "mtime": 1782488209.212708,
+    "mtime": 1782494201.0723395,
     "ast_hash": "69686b909a8bfdeabe1443605d5da58d",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_quality_configuration.py": {
-    "mtime": 1782488209.2137077,
+    "mtime": 1782494201.0733397,
     "ast_hash": "9b656c26a1a985cc43fb61fab4912d85",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_reactor_versions.py": {
-    "mtime": 1782488209.2137077,
+    "mtime": 1782494201.0733397,
     "ast_hash": "f9433da24d0218a7361747d407ace39d",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_shaft_pilot_release.py": {
-    "mtime": 1782488209.2147074,
+    "mtime": 1782494201.074339,
     "ast_hash": "b888b91abba4fa10ff9c8f2aa8c5f6da",
     "semantic_hash": ""
   },
   "tests/scripts/test_verify_maven_central_release.py": {
-    "mtime": 1782488209.2147074,
+    "mtime": 1782494201.074339,
     "ast_hash": "20d330277e722c391b13833fc79827f1",
     "semantic_hash": ""
   },
   "tests/scripts/test_video_module_boundary.py": {
-    "mtime": 1782488209.2157075,
+    "mtime": 1782494201.074339,
     "ast_hash": "a3faabe526dd03805678b1c530509398",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/api/src/test/java/fixture/ApiAndRetainedSurfaceConsumer.java": {
-    "mtime": 1782488209.2177067,
+    "mtime": 1782494201.077339,
     "ast_hash": "5a2e4a6e773299c1000f0d22aaa00d10",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/appium-mobile/src/test/java/fixture/AppiumMobileConsumer.java": {
-    "mtime": 1782488209.219707,
+    "mtime": 1782494201.0783372,
     "ast_hash": "863352eb82696f373fe94a63f1d22d25",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/bom/src/test/java/fixture/BomConsumer.java": {
-    "mtime": 1782488209.2217069,
+    "mtime": 1782494201.080337,
     "ast_hash": "626d1fe9b8536ed47c4f86a665d8a49e",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/browserstack-sdk/src/test/java/fixture/BrowserStackSdkConsumer.java": {
-    "mtime": 1782488209.2227063,
+    "mtime": 1782494201.082338,
     "ast_hash": "0d9caf3b0b7aceb9d9b9f54b6fac92ef",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/desktop-video/src/test/java/fixture/DesktopVideoConsumer.java": {
-    "mtime": 1782488209.2257066,
+    "mtime": 1782494201.0853379,
     "ast_hash": "cf09e09cfb9ccab702d9aa80b3d0e520",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/junit-web/src/test/java/fixture/JUnitWebConsumer.java": {
-    "mtime": 1782488209.2277064,
+    "mtime": 1782494201.0873377,
     "ast_hash": "cd14091ae4d1d91102878e1b1d41d1fc",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/legacy-coordinate/src/test/java/fixture/LegacyCoordinateConsumer.java": {
-    "mtime": 1782488209.228706,
+    "mtime": 1782494201.089337,
     "ast_hash": "2a8f6b59bc40773df7204c2b417ab016",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/opencv-visual/src/test/java/fixture/OpenCvVisualConsumer.java": {
-    "mtime": 1782488209.231706,
+    "mtime": 1782494201.0913415,
     "ast_hash": "13a3d033009333c480e8354e11f160f4",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/pilot-core/src/main/java/example/PilotCoreConsumer.java": {
-    "mtime": 1782488209.2327063,
+    "mtime": 1782494201.093341,
     "ast_hash": "ecd7041b37e057a1692e0407f2ea8ec9",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/testng-web/src/test/java/fixture/TestNgWebConsumer.java": {
-    "mtime": 1782488209.2347054,
+    "mtime": 1782494201.0953403,
     "ast_hash": "f5374b99aa6ede6b828689f13963196f",
     "semantic_hash": ""
   },
   ".agents/skills/ci-failure-investigator/SKILL.md": {
-    "mtime": 1782488208.0083697,
+    "mtime": 1782494199.8387709,
     "ast_hash": "00b8473e33574eaecd73bc947de97864",
     "semantic_hash": ""
   },
   ".agents/skills/ci-failure-investigator/agents/openai.yaml": {
-    "mtime": 1782488208.0083697,
+    "mtime": 1782494199.8397713,
     "ast_hash": "a655df2d4ee8a6eca2611c26184da4ba",
     "semantic_hash": ""
   },
   ".agents/skills/flaky-test-stabilizer/SKILL.md": {
-    "mtime": 1782488208.009371,
+    "mtime": 1782494199.8397713,
     "ast_hash": "97f4ea40aaf659bca7200ce9a99279a5",
     "semantic_hash": ""
   },
   ".agents/skills/flaky-test-stabilizer/agents/openai.yaml": {
-    "mtime": 1782488208.009371,
+    "mtime": 1782494199.840771,
     "ast_hash": "442d85b196270c22a0c71c81c759ede1",
     "semantic_hash": ""
   },
   ".agents/skills/framework-source-rules/SKILL.md": {
-    "mtime": 1782488208.0103693,
+    "mtime": 1782494199.8417716,
     "ast_hash": "4e9e9113da43851ebbbadf41ff12070c",
     "semantic_hash": ""
   },
   ".agents/skills/framework-source-rules/agents/openai.yaml": {
-    "mtime": 1782488208.0103693,
+    "mtime": 1782494199.8417716,
     "ast_hash": "fbbaa399dc0f83968bf451e6a53fc96d",
     "semantic_hash": ""
   },
   ".agents/skills/java-test-rules/SKILL.md": {
-    "mtime": 1782488208.0113702,
+    "mtime": 1782494199.8427718,
     "ast_hash": "deb7cdd0ce17fa15de3fe89b51b7ee10",
     "semantic_hash": ""
   },
   ".agents/skills/java-test-rules/agents/openai.yaml": {
-    "mtime": 1782488208.0113702,
+    "mtime": 1782494199.8427718,
     "ast_hash": "fd1828b72256991da2926129061bda9c",
     "semantic_hash": ""
   },
   ".agents/skills/release-dependency-guard/SKILL.md": {
-    "mtime": 1782488208.0123696,
+    "mtime": 1782494199.8437717,
     "ast_hash": "f3653ae639dadae0de32eb6d93abc152",
     "semantic_hash": ""
   },
   ".agents/skills/release-dependency-guard/agents/openai.yaml": {
-    "mtime": 1782488208.0123696,
+    "mtime": 1782494199.8437717,
     "ast_hash": "70df2767596adcc902c526e6f96b9047",
     "semantic_hash": ""
   },
   ".github/FUNDING.yml": {
-    "mtime": 1782488208.01737,
+    "mtime": 1782494199.8477714,
     "ast_hash": "82d0dace0b0b1e5a3113e7483a2c90ef",
     "semantic_hash": ""
   },
   ".github/ISSUE_TEMPLATE/bug_report.md": {
-    "mtime": 1782488208.01737,
+    "mtime": 1782494199.848771,
     "ast_hash": "ef466e19961514f451c8c0bccc9be819",
     "semantic_hash": ""
   },
   ".github/ISSUE_TEMPLATE/config.yml": {
-    "mtime": 1782488208.01737,
+    "mtime": 1782494199.848771,
     "ast_hash": "78c7c4c344a237f1a770009306505fa0",
     "semantic_hash": ""
   },
   ".github/ISSUE_TEMPLATE/feature_request.md": {
-    "mtime": 1782488208.0183692,
+    "mtime": 1782494199.848771,
     "ast_hash": "2374f7b498fad3e41590d9d0aa6bd116",
     "semantic_hash": ""
   },
   ".github/RELEASE_BODY_TEMPLATE.md": {
-    "mtime": 1782488208.0183692,
+    "mtime": 1782494199.8497713,
     "ast_hash": "311edf8e9db9d277067a4166d1e2e453",
     "semantic_hash": ""
   },
   ".github/actions/consolidate-test-results/action.yml": {
-    "mtime": 1782488208.019369,
+    "mtime": 1782494199.8497713,
     "ast_hash": "60f8f12a4f02378cbf50c2e4548ea2d7",
     "semantic_hash": ""
   },
   ".github/actions/post-test-report/action.yml": {
-    "mtime": 1782488208.0203688,
+    "mtime": 1782494199.8507712,
     "ast_hash": "682df808ffdefb6178d20bce9dba6668",
     "semantic_hash": ""
   },
   ".github/actions/setup-test-env/action.yml": {
-    "mtime": 1782488208.0203688,
+    "mtime": 1782494199.851771,
     "ast_hash": "a3ae968f94adf704ec03d1d59c32ca88",
     "semantic_hash": ""
   },
   ".github/actions/upload-jacoco-coverage/action.yml": {
-    "mtime": 1782488208.0213692,
+    "mtime": 1782494199.851771,
     "ast_hash": "235863f5fbb33ba3564051d6570d6ed2",
     "semantic_hash": ""
   },
   ".github/codex/prompts/refresh-agent-instructions.md": {
-    "mtime": 1782488208.0213692,
+    "mtime": 1782494199.8527715,
     "ast_hash": "b917f03c57b15de27300bc05cf7e0929",
     "semantic_hash": ""
   },
   ".github/copilot-instructions.md": {
-    "mtime": 1782488208.022369,
+    "mtime": 1782494199.8527715,
     "ast_hash": "b5a0e7a2af012bf5c687495f6ced2d85",
     "semantic_hash": ""
   },
   ".github/dependabot.yml": {
-    "mtime": 1782488208.022369,
+    "mtime": 1782494199.8537705,
     "ast_hash": "4f97032a0893c4bd5040a882d83bf7c5",
     "semantic_hash": ""
   },
   ".github/instructions/framework-source.instructions.md": {
-    "mtime": 1782488208.02337,
+    "mtime": 1782494199.8537705,
     "ast_hash": "5f3adff6cc4aa23c612aa7c02ae9a512",
     "semantic_hash": ""
   },
   ".github/instructions/java-tests.instructions.md": {
-    "mtime": 1782488208.02337,
+    "mtime": 1782494199.854772,
     "ast_hash": "c09b9d18f7d372e5713e1ae3a401fe37",
     "semantic_hash": ""
   },
   ".github/pull_request_template.md": {
-    "mtime": 1782488208.02337,
+    "mtime": 1782494199.854772,
     "ast_hash": "fdc84bd63f4459bb71c5e62770bd36f3",
     "semantic_hash": ""
   },
   ".github/release.yml": {
-    "mtime": 1782488208.024369,
+    "mtime": 1782494199.854772,
     "ast_hash": "da8b1e52486c7f97f5ef731e57629179",
     "semantic_hash": ""
   },
   ".github/skills/README.md": {
-    "mtime": 1782488208.024369,
+    "mtime": 1782494199.8557713,
     "ast_hash": "d0a0719e4039d1faae74c98994763c5f",
     "semantic_hash": ""
   },
   ".github/skills/ci-failure-investigator/SKILL.md": {
-    "mtime": 1782488208.0253687,
+    "mtime": 1782494199.8557713,
     "ast_hash": "c96ae3cf1ca3bab8b9d4bb034be8c1d5",
     "semantic_hash": ""
   },
   ".github/skills/flaky-test-stabilizer/SKILL.md": {
-    "mtime": 1782488208.0253687,
+    "mtime": 1782494199.856771,
     "ast_hash": "8244098e39f5271a9e3d1f8d7ffbd830",
     "semantic_hash": ""
   },
   ".github/skills/release-dependency-guard/SKILL.md": {
-    "mtime": 1782488208.0263703,
+    "mtime": 1782494199.856771,
     "ast_hash": "77995cc9b84d3555f73936d32309985b",
     "semantic_hash": ""
   },
   ".github/workflows/copilot-setup-steps.yml": {
-    "mtime": 1782488208.0273685,
+    "mtime": 1782494199.8587725,
     "ast_hash": "0c3d73a2b49a51c9d86e5a5f4c76bbcf",
     "semantic_hash": ""
   },
   ".github/workflows/deploy-shaft-mcp.yml": {
-    "mtime": 1782488208.028369,
+    "mtime": 1782494199.8587725,
     "ast_hash": "c9d64c29897a5dae860640eaf1622981",
     "semantic_hash": ""
   },
   ".github/workflows/e2eTests.yml": {
-    "mtime": 1782488208.029369,
+    "mtime": 1782494199.8597715,
     "ast_hash": "1951482fcb77a99eaaaf3a3f0a3acc90",
     "semantic_hash": ""
   },
   ".github/workflows/mavenCentral_cd.yml": {
-    "mtime": 1782488208.029369,
+    "mtime": 1782494199.8607712,
     "ast_hash": "12c1819ee10a8a1bc43b26956af4b6f0",
     "semantic_hash": ""
   },
   ".github/workflows/publish-shaft-mcp.yml": {
-    "mtime": 1782488208.0303688,
+    "mtime": 1782494199.8607712,
     "ast_hash": "7ece85f30a603b746cb901af35c9d0f2",
     "semantic_hash": ""
   },
   ".github/workflows/publishJavaDocs.yml": {
-    "mtime": 1782488208.0303688,
+    "mtime": 1782494199.8617725,
     "ast_hash": "e68ab97713f70c88ae293f7e814985cf",
     "semantic_hash": ""
   },
   ".github/workflows/refresh-agent-instructions.yml": {
-    "mtime": 1782488208.0303688,
+    "mtime": 1782494199.8617725,
     "ast_hash": "792e62e3a612accd91287508154b6a07",
     "semantic_hash": ""
   },
   ".github/workflows/security.yml": {
-    "mtime": 1782488208.0313683,
+    "mtime": 1782494199.8617725,
     "ast_hash": "6d096cbb458e77fc21fbb1557d99cfa5",
     "semantic_hash": ""
   },
   ".github/workflows/shaft-mcp.yml": {
-    "mtime": 1782488208.0313683,
+    "mtime": 1782494199.8627713,
     "ast_hash": "7c6f65310c3b9bc52c3139e0d9dd5b0d",
     "semantic_hash": ""
   },
   ".github/workflows/shaft-pilot-release.yml": {
-    "mtime": 1782488208.0323682,
+    "mtime": 1782494199.8627713,
     "ast_hash": "8d01f7212ab5fcfd7d743537b89279b1",
     "semantic_hash": ""
   },
   ".github/workflows/sync-sample-projects-version.yml": {
-    "mtime": 1782488208.0323682,
+    "mtime": 1782494199.8627713,
     "ast_hash": "dfebf14b9c11eca07877c2083cde5be4",
     "semantic_hash": ""
   },
   ".github/workflows/update-selenium-grid-versions.yml": {
-    "mtime": 1782488208.0323682,
+    "mtime": 1782494199.8637714,
     "ast_hash": "d3bc67a9f9e52eed58c9151431cded9d",
     "semantic_hash": ""
   },
   ".memory/memory/architecture.md": {
-    "mtime": 1782488208.0353682,
+    "mtime": 1782494199.865771,
     "ast_hash": "6abb2a262830b40886b2283dac6a901a",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/maven-central-version-immutability.md": {
-    "mtime": 1782488208.0373685,
+    "mtime": 1782494199.8677711,
     "ast_hash": "76b0b7fb9ab56f985f3941697647c496",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/paid-agent-work-audit-gated.md": {
-    "mtime": 1782488208.0383685,
+    "mtime": 1782494199.868771,
     "ast_hash": "15666adfbb50db198beb784479ff45e5",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/agent-guidance-progressive-disclosure.md": {
-    "mtime": 1782488208.0393677,
+    "mtime": 1782494199.8697715,
     "ast_hash": "9675efebffd6956a72dbe25b6e39591f",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/namespaced-video-capabilities.md": {
-    "mtime": 1782488208.0433667,
+    "mtime": 1782494199.8737707,
     "ast_hash": "a5940ade6cab0d926922ca555dab46f6",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/public-docs-external.md": {
-    "mtime": 1782488208.0453672,
+    "mtime": 1782494199.8757708,
     "ast_hash": "3d4a3061ddfb0b5f6ee8049012f4d664",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/utf8-all-runtime-layers.md": {
-    "mtime": 1782488208.0483675,
+    "mtime": 1782494199.87877,
     "ast_hash": "6bff0142e535940a2c54ed0c96743f81",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/allure-result-population.md": {
-    "mtime": 1782488208.050367,
+    "mtime": 1782494199.8817706,
     "ast_hash": "d691c887b833eeb2002b91bb55129c8a",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/coverage-constructors-start-browser.md": {
-    "mtime": 1782488208.051367,
+    "mtime": 1782494199.8817706,
     "ast_hash": "bbd92df5c4228f6e626c7a52ed2c16cd",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/java25-isuite-mocking.md": {
-    "mtime": 1782488208.0523672,
+    "mtime": 1782494199.88377,
     "ast_hash": "a6d1866e880bd6556f12230ff80f75aa",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/testng-method-parallel-shared-instance-fields.md": {
-    "mtime": 1782488208.054367,
+    "mtime": 1782494199.8857715,
     "ast_hash": "88be0bf5fcebfdb1d579389644c09ebe",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/testng-single-threaded-static-state.md": {
-    "mtime": 1782488208.0553682,
+    "mtime": 1782494199.8857715,
     "ast_hash": "19c314a82618b0fa2e841ecac203734b",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/windows-allure-root-race.md": {
-    "mtime": 1782488208.056373,
+    "mtime": 1782494199.886772,
     "ast_hash": "2ff9296f2ecf396b5c61f41a0b5be34b",
     "semantic_hash": ""
   },
   ".memory/memory/project.md": {
-    "mtime": 1782488208.057372,
+    "mtime": 1782494199.8877711,
     "ast_hash": "5e4026b5220213b5d05773628cde4269",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/issue-linked-pr-closure-and-focused-tests.md": {
-    "mtime": 1782488208.0643728,
+    "mtime": 1782494199.8957758,
     "ast_hash": "57982dd3a4bdf7d5b1a46259307d1e58",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/low-token-user-guide-work.md": {
-    "mtime": 1782488208.0653722,
+    "mtime": 1782494199.8967762,
     "ast_hash": "37fceea4bd25a0a1949e5bc9c28f8f6e",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/proactive-memory-use-when-material.md": {
-    "mtime": 1782488208.0663722,
+    "mtime": 1782494199.8987763,
     "ast_hash": "79312855570c67b7f6e8e0ef5adab2cf",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/start-new-tasks-from-origin-main.md": {
-    "mtime": 1782488208.0693715,
+    "mtime": 1782494199.9017751,
     "ast_hash": "c20c771d71712f59dba2081edda454d0",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/update-official-user-guide-for-functionality-changes.md": {
-    "mtime": 1782488208.070876,
+    "mtime": 1782494199.902776,
     "ast_hash": "1d7eaa27ba5737bd22dee4ba51ec3316",
     "semantic_hash": ""
   },
   "AGENTS.md": {
-    "mtime": 1782488208.0798807,
+    "mtime": 1782494199.910874,
     "ast_hash": "90ff26c44a457cbe712e85238a37aa0d",
     "semantic_hash": ""
   },
   "CLAUDE.md": {
-    "mtime": 1782488208.0798807,
+    "mtime": 1782494199.910874,
     "ast_hash": "109fba9e5bd24a6c1ae37e799818c59b",
     "semantic_hash": ""
   },
   "CODE_OF_CONDUCT.md": {
-    "mtime": 1782488208.0798807,
+    "mtime": 1782494199.9118726,
     "ast_hash": "757dfc14603149dc03182d5c2c0d8ca4",
     "semantic_hash": ""
   },
   "CONTRIBUTING.md": {
-    "mtime": 1782488208.0808809,
+    "mtime": 1782494199.9118726,
     "ast_hash": "86f86dcdb3102ee7fe5192f2c131c3b3",
     "semantic_hash": ""
   },
   "README.md": {
-    "mtime": 1782488208.0808809,
+    "mtime": 1782494199.9128728,
     "ast_hash": "49f5f56feb5a4bf0323c9a36a5b0647b",
     "semantic_hash": ""
   },
   "SECURITY.md": {
-    "mtime": 1782488208.0818806,
+    "mtime": 1782494199.9128728,
     "ast_hash": "5968bb1ac2bd3d0b9c04d6789ed99884",
     "semantic_hash": ""
   },
   "codecov.yml": {
-    "mtime": 1782488208.0818806,
+    "mtime": 1782494199.9128728,
     "ast_hash": "6ad852993fbc1adc8ffa7e42bbd2ce9f",
     "semantic_hash": ""
   },
   "render.yaml": {
-    "mtime": 1782488208.151826,
+    "mtime": 1782494199.9831116,
     "ast_hash": "852f4c51596f80a6f39c336083b743bd",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/golden/doctor-report.md": {
-    "mtime": 1782488208.2403295,
+    "mtime": 1782494200.0703514,
     "ast_hash": "9fd151800fee4024eeb0463f36890866",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/javadoc/resources/configuration-manager/index.html": {
-    "mtime": 1782488208.3472378,
+    "mtime": 1782494200.1789846,
     "ast_hash": "03dab7003a8ceed930851cc4718af1ff",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/healenium-backend.yml": {
-    "mtime": 1782488208.3532379,
+    "mtime": 1782494200.1859796,
     "ast_hash": "a5fd654aa0fbea19d0a20fa14e06e86c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/report-portal.yml": {
-    "mtime": 1782488208.3562424,
+    "mtime": 1782494200.1879802,
     "ast_hash": "de7ac23ca6fa7d3eda50bc8ab1aba483",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/selenium3.yml": {
-    "mtime": 1782488208.3562424,
+    "mtime": 1782494200.1879802,
     "ast_hash": "a464e315b9a241886cfef90f787ec99d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/selenium4.yml": {
-    "mtime": 1782488208.3572412,
+    "mtime": 1782494200.1879802,
     "ast_hash": "ef7d53be2865b48d88080466a1002231",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/selenoid.yml": {
-    "mtime": 1782488208.3572412,
+    "mtime": 1782494200.1889796,
     "ast_hash": "94b482b90eb7a6c434840950aa7cadad",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/selenoid_setup.yml": {
-    "mtime": 1782488208.358242,
+    "mtime": 1782494200.1889796,
     "ast_hash": "57f474b3e5f66f08f07684ab25568c4e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/zalenium.yml": {
-    "mtime": 1782488208.3592424,
+    "mtime": 1782494200.1899834,
     "ast_hash": "cc1f40ca9bb2c913d8ce5c755c1dc525",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/.github/dependabot.yml": {
-    "mtime": 1782488208.364242,
+    "mtime": 1782494200.194983,
     "ast_hash": "d967a02218d19254ea8c200b1887b549",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/.github/workflows/api.yml": {
-    "mtime": 1782488208.364242,
+    "mtime": 1782494200.195983,
     "ast_hash": "d6cebbce56ded32de3f4d49cfdc8e545",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/.github/workflows/web.yml": {
-    "mtime": 1782488208.3652413,
+    "mtime": 1782494200.195983,
     "ast_hash": "698491178af348cb577da4a2bed5f4ce",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/k8s/selenium-grid-chrome-scaledobject.yaml": {
-    "mtime": 1782488208.500225,
+    "mtime": 1782494200.3295777,
     "ast_hash": "c6d16b2c9bf789f3c38dced54ff50c79",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/k8s/selenium-grid-edge-scaledobject.yaml": {
-    "mtime": 1782488208.500225,
+    "mtime": 1782494200.3295777,
     "ast_hash": "48291bb39d912826522b2fcaedbd55e9",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/k8s/selenium-grid-firefox-scaledobject.yaml": {
-    "mtime": 1782488208.5012262,
+    "mtime": 1782494200.3305767,
     "ast_hash": "ce8ab2c5f24347cbbe286a358e6e970d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/alertFixture.html": {
-    "mtime": 1782488208.6422873,
+    "mtime": 1782494200.4680946,
     "ast_hash": "ea46500946ec7b72c8d872d5432079dc",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/coverageTestPage.html": {
-    "mtime": 1782488209.0873957,
+    "mtime": 1782494200.9140532,
     "ast_hash": "1b449bdbd7cbf63f83d0f4c644976730",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/hoverDemo.html": {
-    "mtime": 1782488209.0883994,
+    "mtime": 1782494200.9150586,
     "ast_hash": "017983881c7dcdeb8549122b74fceea3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/hoverDemo_outsideViewPort.html": {
-    "mtime": 1782488209.0883994,
+    "mtime": 1782494200.9150586,
     "ast_hash": "09c6ae4c037396146fb889b9145d77b9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/hoverDemo_outsideViewPort_Horizontal.html": {
-    "mtime": 1782488209.089399,
+    "mtime": 1782494200.9160566,
     "ast_hash": "3f2864a3f112756f32c047d08d86d033",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/locatorBuilderFixture.html": {
-    "mtime": 1782488209.0903962,
+    "mtime": 1782494200.9170542,
     "ast_hash": "274171ae17cb342e543557271079b5a9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/searchFixture.html": {
-    "mtime": 1782488209.0940428,
+    "mtime": 1782494200.9205513,
     "ast_hash": "f807c7d448900de296c1aff8960c0928",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/selectDemo.html": {
-    "mtime": 1782488209.0940428,
+    "mtime": 1782494200.9215605,
     "ast_hash": "6202e3912db56d54602ad63a94ecbf52",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/selectedValueTests/Advanced_select_with_multiple_features.html": {
-    "mtime": 1782488209.0950427,
+    "mtime": 1782494200.9215605,
     "ast_hash": "78d03def935f6591bd4e50812688a7c4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/selectedValueTests/Basic_select.html": {
-    "mtime": 1782488209.0950427,
+    "mtime": 1782494200.9225492,
     "ast_hash": "3868db4101f1dcbb8ed8fc09bad58d65",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/test.html": {
-    "mtime": 1782488209.1000423,
+    "mtime": 1782494200.9255493,
     "ast_hash": "eca1a30a4647270469873bb77be7d28b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/uploadFixture.html": {
-    "mtime": 1782488209.102043,
+    "mtime": 1782494200.9275496,
     "ast_hash": "6afb82db0280c6109713fe98dc1109ea",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/validationTextFixture.html": {
-    "mtime": 1782488209.1030438,
+    "mtime": 1782494200.9285514,
     "ast_hash": "bdc4bd2af770c9de828335d6a51e9f75",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/yaml/yaml_test_data.yaml": {
-    "mtime": 1782488209.1030438,
+    "mtime": 1782494200.9285514,
     "ast_hash": "9dbe42fd6d1166db3aefabe7bf52e87b",
     "semantic_hash": ""
   },
   "shaft-mcp/.github/copilot-instructions.md": {
-    "mtime": 1782488209.12104,
+    "mtime": 1782494200.9465504,
     "ast_hash": "687a29b7080f6e1548c6470c3924b291",
     "semantic_hash": ""
   },
   "smithery.yaml": {
-    "mtime": 1782488209.199709,
+    "mtime": 1782494201.0600355,
     "ast_hash": "38eb9cd9b08dbf6453dfd19693e4f23e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/sample.pdf": {
-    "mtime": 1782488209.0930378,
+    "mtime": 1782494200.9205513,
     "ast_hash": "4b41a3475132bd861b30a878e30aa56a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/Android/13_0/a9d70165382980941bed3fe21fcb9aabfc62872fa39658c332505740f4cb3675.png": {
-    "mtime": 1782488208.3602421,
+    "mtime": 1782494200.191983,
     "ast_hash": "2ef14bf57dfc7ae42b748b506607c891",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/Android/content.png": {
-    "mtime": 1782488208.3612423,
+    "mtime": 1782494200.191983,
     "ast_hash": "ceaf89a99b2f77f7dd7385232bc786a0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/Android/content_local.png": {
-    "mtime": 1782488208.3612423,
+    "mtime": 1782494200.1929832,
     "ast_hash": "b404721a09a139fcaf7276b578a5deab",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/Android/content_new.png": {
-    "mtime": 1782488208.362242,
+    "mtime": 1782494200.1929832,
     "ast_hash": "42815e5383bcc7948c46443793f61dbe",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/linux/chrome/a16413dbaadddad22a2203779b00521b7e5beb3446743fff9b52e1c3308bbfd3.png": {
-    "mtime": 1782488208.362242,
+    "mtime": 1782494200.1939826,
     "ast_hash": "0ce5cae521647668798fb59240d8163d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/linux/chrome/a16413dbaadddad22a2203779b00521b7e5beb3446743fff9b52e1c3308bbfd3_shutterbug.png": {
-    "mtime": 1782488208.3632417,
+    "mtime": 1782494200.1939826,
     "ast_hash": "da6466f773b2b294c96164c351fee9e1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/engine.png": {
-    "mtime": 1782488208.4882276,
+    "mtime": 1782494200.3175774,
     "ast_hash": "9c02074d966c282967abf86a40990952",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/mindmap.png": {
-    "mtime": 1782488208.4922252,
+    "mtime": 1782494200.321577,
     "ast_hash": "09974b1f6d4fe5ef7b8601bb9c08680e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/roi.png": {
-    "mtime": 1782488208.493225,
+    "mtime": 1782494200.322577,
     "ast_hash": "7303a194a3ba55dd3fb2071d8445e31b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft.png": {
-    "mtime": 1782488208.4942272,
+    "mtime": 1782494200.3235767,
     "ast_hash": "d476641cef7c2f5c13f2da06eee7913a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft_white.png": {
-    "mtime": 1782488208.4972267,
+    "mtime": 1782494200.326577,
     "ast_hash": "877b04c6152af84a64aeb0dcd1ef3198",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft_white_bg.png": {
-    "mtime": 1782488208.4992256,
+    "mtime": 1782494200.3285775,
     "ast_hash": "638a800ba4c6c0d597df827fdf7848cf",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft_white_ramadan.png": {
-    "mtime": 1782488208.4992256,
+    "mtime": 1782494200.3285775,
     "ast_hash": "703354878805e8d341e697c75a83b367",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/search.PNG": {
-    "mtime": 1782488208.6402879,
+    "mtime": 1782494200.4670942,
     "ast_hash": "529740c6b227e97ed27fe797406d735f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/youtube.png": {
-    "mtime": 1782488209.1040425,
+    "mtime": 1782494200.9295504,
     "ast_hash": "3cb8adc33ce532807aacf1bfaffbf31b",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/code-conventions.json": {
-    "mtime": 1782488208.0353682,
+    "mtime": 1782494199.866771,
     "ast_hash": "5c1eb980b386ba44323d9741b8c8ae28",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/powershell-shell-sensitive-args.json": {
-    "mtime": 1782488208.0533674,
+    "mtime": 1782494199.884771,
     "ast_hash": "8dc62f50fbf74b5780312307bf6d5d19",
     "semantic_hash": ""
   },
   ".memory/memory/sources/agents.json": {
-    "mtime": 1782488208.057372,
+    "mtime": 1782494199.8877711,
     "ast_hash": "8b0ad0f82cc956b5c4a05f5413c6bd8e",
     "semantic_hash": ""
   },
   ".memory/memory/sources/project-readme.json": {
-    "mtime": 1782488208.0583732,
+    "mtime": 1782494199.8887715,
     "ast_hash": "ca2b3ea34f094d5d7104225b910a6db5",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/agent-guidance.json": {
-    "mtime": 1782488208.059373,
+    "mtime": 1782494199.8897753,
     "ast_hash": "d47a35a97e29fa13de28e5ddd1170621",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/conventions-quality.json": {
-    "mtime": 1782488208.0603724,
+    "mtime": 1782494199.8907773,
     "ast_hash": "e01f337f7d01373f294a3ace9cd11f7f",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/product-intent.json": {
-    "mtime": 1782488208.0603724,
+    "mtime": 1782494199.8907773,
     "ast_hash": "d4a438fd7d6896393b8026b284735904",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/create-and-report-pr-after-tasks.json": {
-    "mtime": 1782488208.0613735,
+    "mtime": 1782494199.8917756,
     "ast_hash": "b1ce8ac2e98f89838415a25fa522171b",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/minimal-nonredundant-validation.json": {
-    "mtime": 1782488208.0653722,
+    "mtime": 1782494199.897776,
     "ast_hash": "5834b369159038bc89a34e916e9ad7ee",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/run-local-e2e-jobs-in-a-dedicated-workflow.json": {
-    "mtime": 1782488208.067372,
+    "mtime": 1782494199.8987763,
     "ast_hash": "4233688d717e8e7aaaa1b424ce1ebb87",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/share-memory-and-graphify-assets.json": {
-    "mtime": 1782488208.0683722,
+    "mtime": 1782494199.900776,
     "ast_hash": "270cbf117e0047f707f3eaaae9494195",
     "semantic_hash": ""
   },
   ".memory/relations/constraint-code-conventions-affects-project-shaft-engine.json": {
-    "mtime": 1782488208.0728817,
+    "mtime": 1782494199.9037747,
     "ast_hash": "a4dd873eb9a3cb41398d92073ddd37a5",
     "semantic_hash": ""
   },
   ".memory/relations/constraint-code-conventions-derived-from-source-agents.json": {
-    "mtime": 1782488208.0728817,
+    "mtime": 1782494199.9048736,
     "ast_hash": "958da5cacc1ad227cbfc52bdcf3696cd",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-agent-guidance-derived-from-source-agents.json": {
-    "mtime": 1782488208.0738811,
+    "mtime": 1782494199.905874,
     "ast_hash": "ceda73fdfa718f949c1c636e33d993d6",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-agent-guidance-documents-project-shaft-engine.json": {
-    "mtime": 1782488208.0748808,
+    "mtime": 1782494199.905874,
     "ast_hash": "c17d6760da1e494ee12d62ea6cdb0e35",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-conventions-quality-derived-from-source-agents.json": {
-    "mtime": 1782488208.0748808,
+    "mtime": 1782494199.905874,
     "ast_hash": "30f6ab1fb433f92e0f1bddb152ae89a9",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-conventions-quality-documents-project-shaft-engine.json": {
-    "mtime": 1782488208.0748808,
+    "mtime": 1782494199.9068727,
     "ast_hash": "7807b3da7440b26c5ffd411d2d58c8f4",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-product-intent-derived-from-source-project-readme.json": {
-    "mtime": 1782488208.075881,
+    "mtime": 1782494199.9068727,
     "ast_hash": "73f46fd60b629fac27ef5b2bf7edaade",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-product-intent-summarizes-project-shaft-engine.json": {
-    "mtime": 1782488208.075881,
+    "mtime": 1782494199.9068727,
     "ast_hash": "d75f2b943c7caec5bad6edbdd2d3ba42",
     "semantic_hash": ""
   },
   ".memory/relations/workflow-create-and-report-pr-after-tasks-documents-project-shaft-engine.json": {
-    "mtime": 1782488208.075881,
+    "mtime": 1782494199.907875,
     "ast_hash": "15037f0f0f4f2072b4ac7452185b7abd",
     "semantic_hash": ""
   },
   ".memory/relations/workflow-share-memory-and-graphify-assets-documents-project-shaft-engine.json": {
-    "mtime": 1782488208.0768797,
+    "mtime": 1782494199.907875,
     "ast_hash": "15a6e2ed7ed54d18ca1a9ba283e9997f",
     "semantic_hash": ""
   },
   "tests/scripts/test_install_shaft_mcp.py": {
-    "mtime": 1782488209.210709,
+    "mtime": 1782494201.0703397,
     "ast_hash": "60ad6539ba363c9a02ad6f85bf1660e3",
     "semantic_hash": ""
   },
   ".github/workflows/e2eLocalTests.yml": {
-    "mtime": 1782488208.028369,
+    "mtime": 1782494199.8597715,
     "ast_hash": "1327238970e80758934fe016c4e51854",
     "semantic_hash": ""
   },
   ".github/workflows/lambdatestTests.yml": {
-    "mtime": 1782488208.029369,
+    "mtime": 1782494199.8597715,
     "ast_hash": "89d31b06f66ca3f0545f6d5268710de3",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/code-conventions.md": {
-    "mtime": 1782488208.0363686,
+    "mtime": 1782494199.866771,
     "ast_hash": "ebb3f6f7caa3501cab774c1d8e7598a8",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/powershell-shell-sensitive-args.md": {
-    "mtime": 1782488208.0533674,
+    "mtime": 1782494199.884771,
     "ast_hash": "81604c5c66f8f3f2bc96d6fb9b63e0c5",
     "semantic_hash": ""
   },
   ".memory/memory/sources/agents.md": {
-    "mtime": 1782488208.0583732,
+    "mtime": 1782494199.8887715,
     "ast_hash": "19d8593d2fbf9941204ff6257b7bbcce",
     "semantic_hash": ""
   },
   ".memory/memory/sources/project-readme.md": {
-    "mtime": 1782488208.0583732,
+    "mtime": 1782494199.8897753,
     "ast_hash": "1644c82d3ce411b7b776e14e4a3fc832",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/agent-guidance.md": {
-    "mtime": 1782488208.059373,
+    "mtime": 1782494199.8897753,
     "ast_hash": "d4ab69ed6a4ee277d2f623592f5aa503",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/conventions-quality.md": {
-    "mtime": 1782488208.0603724,
+    "mtime": 1782494199.8907773,
     "ast_hash": "41403aeb6cfbff5b7ab4193dff8bac41",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/product-intent.md": {
-    "mtime": 1782488208.0613735,
+    "mtime": 1782494199.8917756,
     "ast_hash": "072645010c12d96012e55a07eb8462a9",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/create-and-report-pr-after-tasks.md": {
-    "mtime": 1782488208.0623724,
+    "mtime": 1782494199.8927758,
     "ast_hash": "1bcb51f3f1e5269b61bba6ea8533ea49",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/minimal-nonredundant-validation.md": {
-    "mtime": 1782488208.0663722,
+    "mtime": 1782494199.897776,
     "ast_hash": "431e4f5cc6afab68b429c36739dce7c3",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/run-local-e2e-jobs-in-a-dedicated-workflow.md": {
-    "mtime": 1782488208.067372,
+    "mtime": 1782494199.8987763,
     "ast_hash": "e21cf1d1253c1b9d9646050d8437c555",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/share-memory-and-graphify-assets.md": {
-    "mtime": 1782488208.0693715,
+    "mtime": 1782494199.900776,
     "ast_hash": "44176d6d1036c08d58f9036a56af0a8c",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/delegate-only-when-needed-for-correctness.json": {
-    "mtime": 1782488208.0623724,
+    "mtime": 1782494199.8927758,
     "ast_hash": "89452a15b27dbf71a8d319b68e201a4d",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/delegate-only-when-needed-for-correctness.md": {
-    "mtime": 1782488208.0623724,
+    "mtime": 1782494199.8927758,
     "ast_hash": "b07cf652dddba20866b2ecbbe4e06136",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/heal-ai-reranking-trigger-gated.json": {
-    "mtime": 1782488208.041367,
+    "mtime": 1782494199.8727736,
     "ast_hash": "7fcb87f0b2bfa2530bca51fdb28c07cb",
     "semantic_hash": ""
   },
   ".memory/memory/facts/deterministic-ai-test-lifecycle-artifacts.json": {
-    "mtime": 1782488208.0483675,
+    "mtime": 1782494199.8797717,
     "ast_hash": "59d40c4f3bdb5eccd637c1a59cfc7abf",
     "semantic_hash": ""
   },
   ".memory/relations/decision-heal-ai-reranking-trigger-gated-affects-fact-deterministic-ai-test-lifecycle-artifacts.json": {
-    "mtime": 1782488208.0738811,
+    "mtime": 1782494199.9048736,
     "ast_hash": "a31117254d3ebfc8e782e8a3b3a3808d",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureReview.java": {
-    "mtime": 1782488208.1843493,
+    "mtime": 1782494200.0146255,
     "ast_hash": "edf1b9f86131db1f54975d4d21953670",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/resources/schema/shaft-capture-review-1.0.schema.json": {
-    "mtime": 1782488208.198349,
+    "mtime": 1782494200.0286238,
     "ast_hash": "df3ea8b3fa2bdeb83db359e221a56e29",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorTriage.java": {
-    "mtime": 1782488208.2203462,
+    "mtime": 1782494200.050766,
     "ast_hash": "9c84db99fd873d863313e37404fda544",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/ExecutionIntelligence.java": {
-    "mtime": 1782488208.2213461,
+    "mtime": 1782494200.052827,
     "ast_hash": "69b01ed194ab82a4e2163acfc9907648",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-doctor-triage-1.0.schema.json": {
-    "mtime": 1782488208.2323308,
+    "mtime": 1782494200.0623517,
     "ast_hash": "76dc165df20999b05b4f8e442e90490f",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-execution-intelligence-1.0.schema.json": {
-    "mtime": 1782488208.2323308,
+    "mtime": 1782494200.0633523,
     "ast_hash": "533f56c3ee115ce73ed329d13851b7cd",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/heal-ai-reranking-trigger-gated.md": {
-    "mtime": 1782488208.042367,
+    "mtime": 1782494199.8727736,
     "ast_hash": "9e61fd0bec7fb5de29c2d5a2c6500e7c",
     "semantic_hash": ""
   },
   ".memory/memory/facts/deterministic-ai-test-lifecycle-artifacts.md": {
-    "mtime": 1782488208.0493674,
+    "mtime": 1782494199.8797717,
     "ast_hash": "db58ab1ad8c9a772b56404a0460feb8c",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/surefire-testng-bootstrap-validation-after-pr2947.json": {
-    "mtime": 1782488208.0703716,
+    "mtime": 1782494199.9017751,
     "ast_hash": "d381b7c66b8e42deb7eea0e7e7daf39e",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/use-memory-and-graphify-through-cli-in-codex.json": {
-    "mtime": 1782488208.0718813,
+    "mtime": 1782494199.902776,
     "ast_hash": "58123f0adb9df1766a0ab999904f3cfa",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/properties/internal/PropertyFileManagerInternalUnitTest.java": {
-    "mtime": 1782488208.5302234,
+    "mtime": 1782494200.3595772,
     "ast_hash": "2bf9ff6704809d4685a9b285f3feff6b",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/surefire-testng-bootstrap-validation-after-pr2947.md": {
-    "mtime": 1782488208.070876,
+    "mtime": 1782494199.9017751,
     "ast_hash": "e6782b8247772991081386a66f9a7e36",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/use-memory-and-graphify-through-cli-in-codex.md": {
-    "mtime": 1782488208.0718813,
+    "mtime": 1782494199.9037747,
     "ast_hash": "e251c9a4a352674f9088647ddf3b1478",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/delegate-when-unable.json": {
-    "mtime": 1782488208.0393677,
+    "mtime": 1782494199.870771,
     "ast_hash": "07b7ba8f381ec4cc14777d7ac55c9e78",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/delegate-when-unable.md": {
-    "mtime": 1782488208.0403683,
+    "mtime": 1782494199.870771,
     "ast_hash": "c593eb7cd55c53cb9369998a0173f6d5",
     "semantic_hash": ""
   },
   "shaft-browserstack/src/test/java/com/shaft/integration/browserstack/BrowserStackModuleTest.java": {
-    "mtime": 1782488208.1733515,
+    "mtime": 1782494200.0036201,
     "ast_hash": "1b4f4b227bd1f4fa0f362a15c970a8d5",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/cli/CaptureCliTest.java": {
-    "mtime": 1782488208.2003472,
+    "mtime": 1782494200.0306256,
     "ast_hash": "cb0124fcb58676542f14eb61f60dc874",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/collector/CaptureCollectorUtilityTest.java": {
-    "mtime": 1782488208.201347,
+    "mtime": 1782494200.0316238,
     "ast_hash": "aafe9ad32e00bfaa8447cc2f3f006a9d",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/control/CaptureControlFilesTest.java": {
-    "mtime": 1782488208.201347,
+    "mtime": 1782494200.0316238,
     "ast_hash": "7531aa93c2d32105644864a1e152c070",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/control/CaptureControlServerClientTest.java": {
-    "mtime": 1782488208.2023487,
+    "mtime": 1782494200.0326252,
     "ast_hash": "c64a81e01083fbb8214913c60a910a80",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureManagerLifecycleTest.java": {
-    "mtime": 1782488208.2053487,
+    "mtime": 1782494200.036625,
     "ast_hash": "848dbc7ec058d8787c4e36506f75dc3c",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpNoDriverServiceTest.java": {
-    "mtime": 1782488209.1572,
+    "mtime": 1782494200.9812703,
     "ast_hash": "eb49f23fde252c361ff9cae194f9d52a",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpResultRecordsTest.java": {
-    "mtime": 1782488209.1572,
+    "mtime": 1782494200.9822712,
     "ast_hash": "29c8c0b77c7458ee2ff5092bb54d82ba",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpServiceHelperTest.java": {
-    "mtime": 1782488209.1581998,
+    "mtime": 1782494200.9822712,
     "ast_hash": "067f1647636d500429d01c8469ada10e",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/MobileServiceConfigurationTest.java": {
-    "mtime": 1782488627.8116455,
-    "ast_hash": "f9e002d9986382c4da4e3f591cf27604",
+    "mtime": 1782494200.9832706,
+    "ast_hash": "66e2b61a1f6b5a9bbd36168990a7e8d8",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiValueObjectsTest.java": {
-    "mtime": 1782488209.1837094,
+    "mtime": 1782494201.0440345,
     "ast_hash": "a16fbefe28c40b65f9c55f41c0ba9e98",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/config/ProviderConfigurationTest.java": {
-    "mtime": 1782488209.184709,
+    "mtime": 1782494201.0450373,
     "ast_hash": "70d00166ef741dd25140bb1036308a87",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/json/JsonSchemaValidatorTest.java": {
-    "mtime": 1782488209.184709,
+    "mtime": 1782494201.0460353,
     "ast_hash": "2fd93ff273c685e80b68615e7dd0a1ba",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/element-actions-normalize-allure-locator-metadata.json": {
-    "mtime": 1782488208.0403683,
+    "mtime": 1782494199.870771,
     "ast_hash": "c4534782cf2b7fccd3489053bb267f1d",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/element-actions-normalize-allure-locator-metadata.md": {
-    "mtime": 1782488208.0403683,
+    "mtime": 1782494199.8717706,
     "ast_hash": "ad0b39840f727ef91570221e283b668c",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/run-local-validation-without-opening-reports.json": {
-    "mtime": 1782488208.067372,
+    "mtime": 1782494199.8997765,
     "ast_hash": "15d81102c128be197dc774dfdfc4ff37",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/JunitExtension.java": {
-    "mtime": 1782488208.2972414,
-    "ast_hash": "b3c9fb72ab23b12b6919e38a98d39694",
+    "mtime": 1782495309.6453702,
+    "ast_hash": "7a8498ec4613e8aeb6e6bb7b869b834a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/ExecutionCountsTracker.java": {
-    "mtime": 1782488208.2992413,
+    "mtime": 1782494200.1319802,
     "ast_hash": "ca195dba6330c14afb2e1f42c85be2d6",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/ExecutionFailureContext.java": {
-    "mtime": 1782488208.3002408,
+    "mtime": 1782494200.1319802,
     "ast_hash": "713f781253d014b50ab39c2d5e3dff20",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/ExecutionLifecycleHelper.java": {
-    "mtime": 1782488208.3002408,
+    "mtime": 1782494200.1329806,
     "ast_hash": "cab481402d02eddd743805c911080712",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/TestExecutionInfo.java": {
-    "mtime": 1782488208.3022406,
+    "mtime": 1782494200.1339848,
     "ast_hash": "4dc45054b39710f3e47d2c2dd511d0be",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportContext.java": {
-    "mtime": 1782488208.3332386,
+    "mtime": 1782494200.1659808,
     "ast_hash": "2ae3267e31eb1bb32289daeac90a9716",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/AssertionFailureFormatter.java": {
-    "mtime": 1782488208.3382373,
+    "mtime": 1782494200.1699805,
     "ast_hash": "93f73d44c5ada84c4d39cb3c8d02e6ad",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitApiSmokeTest.java": {
-    "mtime": 1782488208.5412233,
+    "mtime": 1782494200.3705769,
     "ast_hash": "7f1c4d2d140d35d6dab9ffb286095937",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitCoreAssertionDependencyGuardTest.java": {
-    "mtime": 1782488208.5422232,
+    "mtime": 1782494200.3705769,
     "ast_hash": "6fdc9b27e9c39b43169a4187d2540f89",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitCoreAssertionMigrationTest.java": {
-    "mtime": 1782488208.5422232,
+    "mtime": 1782494200.3715768,
     "ast_hash": "60e0a7f567ab6e030106b5cdd4e86f4c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitDatabaseSmokeTest.java": {
-    "mtime": 1782488208.5422232,
+    "mtime": 1782494200.3715768,
     "ast_hash": "6914346d28a229d411da8e85825e73d9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitProjectStructureManagerTest.java": {
-    "mtime": 1782488208.5432231,
+    "mtime": 1782494200.3725767,
     "ast_hash": "42fc75d8ff6752aff87a5c0509af87d6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitReportContextTest.java": {
-    "mtime": 1782488208.5432231,
+    "mtime": 1782494200.3725767,
     "ast_hash": "31a71b30583f9afa0bf0022084a390a1",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitWebGuiSmokeTest.java": {
-    "mtime": 1782488208.5442226,
+    "mtime": 1782494200.3735769,
     "ast_hash": "1d9608b8cc22fe144bb55acffca129de",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/run-local-validation-without-opening-reports.md": {
-    "mtime": 1782488208.0683722,
+    "mtime": 1782494199.8997765,
     "ast_hash": "3bc1e6a92cc0abd9587fbef7f1b389b7",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureWorkbenchHtml.java": {
-    "mtime": 1782488208.1853504,
+    "mtime": 1782494200.0156255,
     "ast_hash": "59b413fb0057eadd1c6607fc570c92a2",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CodegenFeatureCatalog.java": {
-    "mtime": 1782488208.1853504,
+    "mtime": 1782494200.0156255,
     "ast_hash": "c96dc1481b8eb2e4876301542c73040d",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureStartOptions.java": {
-    "mtime": 1782488208.194347,
+    "mtime": 1782494200.0246248,
     "ast_hash": "08bdd33c70c75a9c693eae92d4e613af",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderControlTest.java": {
-    "mtime": 1782488208.2063472,
+    "mtime": 1782494200.0376298,
     "ast_hash": "93adf57550a29b8c7f4ed7e4f1d1c1a6",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/use-official-docs-search-index-for-shaft-mcp-guide-search.json": {
-    "mtime": 1782488208.0463688,
+    "mtime": 1782494199.8767712,
     "ast_hash": "0f6b8cc0ea6f5f8ef37b0c0c2ab043f6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelperNewPatternCoverageUnitTest.java": {
-    "mtime": 1782488208.5392237,
+    "mtime": 1782494200.3675766,
     "ast_hash": "c98119a9f1a96e8fb4dd7f72ed70d11d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/GuideService.java": {
-    "mtime": 1782488209.1302056,
+    "mtime": 1782494200.9555492,
     "ast_hash": "c2b2a7d31dd0c42a0c11b578785f4a22",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/HealerService.java": {
-    "mtime": 1782488209.1312053,
+    "mtime": 1782494200.9565487,
     "ast_hash": "b47a582f8b342bc3d3fdbf6d6c054b6c",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpGuideMatch.java": {
-    "mtime": 1782488209.135205,
+    "mtime": 1782494200.9605484,
     "ast_hash": "e594a2f11a16113954bbf865aec5dc04",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpGuideSearchResult.java": {
-    "mtime": 1782488209.1362054,
+    "mtime": 1782494200.9615486,
     "ast_hash": "7c67b9c8caa6eb0e292f3cf578a26ec4",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpHealerAttemptResult.java": {
-    "mtime": 1782488209.1362054,
+    "mtime": 1782494200.9615486,
     "ast_hash": "ae920e7e3a41435e15a8065dfa005012",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpHealerRunResult.java": {
-    "mtime": 1782488209.1362054,
+    "mtime": 1782494200.9615486,
     "ast_hash": "053e897a9732fd3a4bd32f64ce7bc67a",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/GuideServiceTest.java": {
-    "mtime": 1782488209.1541944,
+    "mtime": 1782494200.9792714,
     "ast_hash": "18508bf8f31805be0dc13aed25dde251",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/HealerServiceTest.java": {
-    "mtime": 1782488209.155195,
+    "mtime": 1782494200.9792714,
     "ast_hash": "99ca3e342a4e3327469eedfaeaab1ac4",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/use-official-docs-search-index-for-shaft-mcp-guide-search.md": {
-    "mtime": 1782488208.0463688,
+    "mtime": 1782494199.8777707,
     "ast_hash": "3ef2a346dc83ce9efb7c84684d1122ff",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/NetworkInterceptionRequestBuilder.java": {
-    "mtime": 1782488208.2593389,
+    "mtime": 1782494200.091356,
     "ast_hash": "b86818b00a3065ca48701567a1317112",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserNetworkInterceptionRule.java": {
-    "mtime": 1782488208.2613373,
+    "mtime": 1782494200.092357,
     "ast_hash": "5d5037cd2ee0dddd957a7cbbad537ce8",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserNetworkInterceptor.java": {
-    "mtime": 1782488208.2618861,
+    "mtime": 1782494200.0933614,
     "ast_hash": "6948767d4346fce4950b90d660e010eb",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/prefer-shaft-api-builder-facade-for-rest-work.json": {
-    "mtime": 1782488208.044369,
+    "mtime": 1782494199.8747709,
     "ast_hash": "6c5f689fe277f7670d815e22bb7a6fdf",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpAndroidEmulatorProposal.java": {
-    "mtime": 1782488209.1322055,
+    "mtime": 1782494200.9575486,
     "ast_hash": "c7c477a347aff6fa27cec866efffb105",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpAppiumCommandRecorder.java": {
-    "mtime": 1782488209.1322055,
+    "mtime": 1782494200.9575486,
     "ast_hash": "83ee39e10ac7764d6353da3484b07ac4",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpAppiumInspectorProxy.java": {
-    "mtime": 1782488209.133206,
+    "mtime": 1782494200.9575486,
     "ast_hash": "8dae6bce980636bfd5096bc546e09f1a",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileCode.java": {
-    "mtime": 1782488209.1381907,
+    "mtime": 1782494200.9625494,
     "ast_hash": "84fa9fe33b12aa2b45a47c4c02901b49",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileDevice.java": {
-    "mtime": 1782488209.1381907,
+    "mtime": 1782494200.9635494,
     "ast_hash": "95ab5c7a8108a17cc4b795be825ca465",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInspectorPlan.java": {
-    "mtime": 1782488209.1391962,
+    "mtime": 1782494200.9645483,
     "ast_hash": "e12fc9a2d07a08597ec6bf1400658e16",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInspectorRecordingService.java": {
-    "mtime": 1782488209.1391962,
+    "mtime": 1782494200.9645483,
     "ast_hash": "756fff2b3865bf7cd73eeacdb4edcc40",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInspectorRecordingStatus.java": {
-    "mtime": 1782488209.1391962,
+    "mtime": 1782494200.9645483,
     "ast_hash": "b5e65cd7d3d46e313d788ae3bd017617",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainService.java": {
-    "mtime": 1782488209.143195,
+    "mtime": 1782494200.9682655,
     "ast_hash": "620a83d2cfbb35eaf8cf1ddb848a3fe5",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainStatus.java": {
-    "mtime": 1782488209.143195,
+    "mtime": 1782494200.9682655,
     "ast_hash": "14c3c586d9e84bef7eca75197de48e83",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpProcessRunner.java": {
-    "mtime": 1782488209.1441953,
+    "mtime": 1782494200.969271,
     "ast_hash": "c2fbbd25f86523263ea6ee980a280f79",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpAppiumCommandRecorderTest.java": {
-    "mtime": 1782488209.155195,
+    "mtime": 1782494200.9802709,
     "ast_hash": "193aea409a6adf4968070c82ac9a575d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpMobileInspectorRecordingServiceTest.java": {
-    "mtime": 1782488209.1561992,
+    "mtime": 1782494200.9802709,
     "ast_hash": "debd3764c9cd0a897ae1861c565006d9",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpMobileToolchainServiceTest.java": {
-    "mtime": 1782488209.1561992,
+    "mtime": 1782494200.9812703,
     "ast_hash": "0be311e4c93392ece2f42dbc7ae5ef4a",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/prefer-shaft-api-builder-facade-for-rest-work.md": {
-    "mtime": 1782488208.044369,
+    "mtime": 1782494199.8757708,
     "ast_hash": "1e26526229bf60c93d0d4a1302628d55",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/graphify-updates-use-installed-cli-subcommands.json": {
-    "mtime": 1782488208.051367,
+    "mtime": 1782494199.8827703,
     "ast_hash": "3777cfe2bfe0c47a8179ecf78953affc",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/memory-saves-use-intent-first-json-on-stdin.json": {
-    "mtime": 1782488208.0523672,
+    "mtime": 1782494199.88377,
     "ast_hash": "09006716c9b359bb2c0a5376fe86d6b4",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCodeGuardrailResult.java": {
-    "mtime": 1782488209.1342058,
+    "mtime": 1782494200.959548,
     "ast_hash": "54ee97ffb919ff90d02c8897f95b2322",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCodeGuardrailViolation.java": {
-    "mtime": 1782488209.1342058,
+    "mtime": 1782494200.959548,
     "ast_hash": "7c8ee205d8b5b7883c0975f388f0ebfb",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpScenarioCatalogResult.java": {
-    "mtime": 1782488209.145196,
+    "mtime": 1782494200.970271,
     "ast_hash": "c32b97f036cfd501afe6d92133a405b4",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpTestAutomationScenario.java": {
-    "mtime": 1782488209.1471972,
+    "mtime": 1782494200.9712703,
     "ast_hash": "b7cb78f776b05d338755f7eea2b17463",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/TestAutomationService.java": {
-    "mtime": 1782488209.149195,
+    "mtime": 1782494200.9742734,
     "ast_hash": "e72f8c898f4fad220abd3edee838ad88",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/TestAutomationServiceTest.java": {
-    "mtime": 1782488209.160199,
+    "mtime": 1782494200.9842708,
     "ast_hash": "22fa5ffdff7d7e8c5b272dc4a567abd8",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/graphify-updates-use-installed-cli-subcommands.md": {
-    "mtime": 1782488208.051367,
+    "mtime": 1782494199.8827703,
     "ast_hash": "019a7f4d72491d045dd5b85ed6c9a0bc",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/memory-saves-use-intent-first-json-on-stdin.md": {
-    "mtime": 1782488208.0533674,
+    "mtime": 1782494199.88377,
     "ast_hash": "1af84800821947fd0ed9d3998cd81d34",
     "semantic_hash": ""
   },
   ".memory/memory/facts/mcp-test-automation-scenario-catalog.json": {
-    "mtime": 1782488208.0493674,
+    "mtime": 1782494199.8797717,
     "ast_hash": "b69ee2103915fbfbf63a6b84e7ea7cb4",
     "semantic_hash": ""
   },
   ".memory/memory/facts/mcp-test-automation-scenario-catalog.md": {
-    "mtime": 1782488208.0493674,
+    "mtime": 1782494199.8807712,
     "ast_hash": "d5b6dadc1f57217744225be57c50dcd8",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/BrowserAssertions.java": {
-    "mtime": 1782488208.264891,
+    "mtime": 1782494200.096356,
     "ast_hash": "b4726dd624bfff061eed882a42302cd1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/DriverAssertions.java": {
-    "mtime": 1782488208.264891,
+    "mtime": 1782494200.096356,
     "ast_hash": "d36427b7494516943c576a3be5a3b835",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/DriverVerifications.java": {
-    "mtime": 1782488208.26589,
+    "mtime": 1782494200.0973573,
     "ast_hash": "3e5ab02944577b455432aa6428a6de83",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/ElementAssertions.java": {
-    "mtime": 1782488208.26589,
+    "mtime": 1782494200.0983572,
     "ast_hash": "b7023bb7c5a5e8c4ede970cedec1f658",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/ShaftLocator.java": {
-    "mtime": 1782488208.2668908,
+    "mtime": 1782494200.0983572,
     "ast_hash": "288258c16fbeb6c7685c7c07f1864c7c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/browser/BrowserActions.java": {
-    "mtime": 1782488208.2892418,
+    "mtime": 1782494200.1219802,
     "ast_hash": "a4dab38718ef6273748c261e11bac0b5",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/element/AlertActions.java": {
-    "mtime": 1782488208.2892418,
+    "mtime": 1782494200.1219802,
     "ast_hash": "fef3e09be9ac657711933a837b50ab7b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/element/ElementActions.java": {
-    "mtime": 1782488208.2902415,
+    "mtime": 1782494200.1229808,
     "ast_hash": "b211eeff2aa63b94465c57b783eb008d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSession.java": {
-    "mtime": 1782488208.2912414,
+    "mtime": 1782494200.1239803,
     "ast_hash": "a834f2fb9fc40a6c472b47e2c8d67257",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSessionFactory.java": {
-    "mtime": 1782488208.2912414,
+    "mtime": 1782494200.1239803,
     "ast_hash": "3814686ba83cf9db8028599f03a98aa2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSessionManager.java": {
-    "mtime": 1782488208.2922416,
+    "mtime": 1782494200.1249804,
     "ast_hash": "e6a93da7a78633257ba11063eb38de16",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightTraceManager.java": {
-    "mtime": 1782488208.2922416,
+    "mtime": 1782494200.1249804,
     "ast_hash": "6475596d52a3b2ea3316f94b5f90c5c0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightBrowserValidationsBuilder.java": {
-    "mtime": 1782488208.293241,
+    "mtime": 1782494200.1259804,
     "ast_hash": "45d289f3218bfe3c37216172b9d25551",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightDriverAssertions.java": {
-    "mtime": 1782488208.293241,
+    "mtime": 1782494200.1259804,
     "ast_hash": "aa1a8b02b65be2902eefa6a73a442468",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightDriverVerifications.java": {
-    "mtime": 1782488208.2942412,
+    "mtime": 1782494200.1259804,
     "ast_hash": "10f477a754e6e569d3fc2352f603a64f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightElementValidationsBuilder.java": {
-    "mtime": 1782488208.2942412,
+    "mtime": 1782494200.1269815,
     "ast_hash": "cbed8cd855cf7132f98d80e3deccf14e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Playwright.java": {
-    "mtime": 1782488208.3132398,
+    "mtime": 1782494200.1449845,
     "ast_hash": "98c4cd280789a493e2cc63fc112d8b4d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/natural/DeterministicNaturalActionPlannerTest.java": {
-    "mtime": 1782488208.522224,
+    "mtime": 1782494200.3515766,
     "ast_hash": "a090df735279f758b04583c539c80cd9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/GUIInterfaceCompatibilityCoverageUnitTest.java": {
-    "mtime": 1782488208.6152897,
+    "mtime": 1782494200.4420946,
     "ast_hash": "a11d2c0437461819d815b6bada986ee9",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/delegate-broadly-to-spark.json": {
-    "mtime": 1782488208.0363686,
+    "mtime": 1782494199.866771,
     "ast_hash": "064879ac7229a1eeeb1646bf93fb6140",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/use-override-annotations.json": {
-    "mtime": 1782488208.0473678,
+    "mtime": 1782494199.8777707,
     "ast_hash": "977907829a63b92ea89922f1550c2c7e",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/delegate-broadly-to-spark.md": {
-    "mtime": 1782488208.0363686,
+    "mtime": 1782494199.8677711,
     "ast_hash": "cce72bac4ae644a5bcf286e117c6fb90",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/use-override-annotations.md": {
-    "mtime": 1782488208.0473678,
+    "mtime": 1782494199.8777707,
     "ast_hash": "d7a5198a2f5eb752cee7fc2fad6b545b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/AlertActionsContract.java": {
-    "mtime": 1782488208.263892,
+    "mtime": 1782494200.0953567,
     "ast_hash": "0f7aa759db4842f82d61b19dfa68301a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/BrowserActionsContract.java": {
-    "mtime": 1782488208.263892,
+    "mtime": 1782494200.096356,
     "ast_hash": "fe638f221c529e25949a39c187b30a49",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/ElementActionsContract.java": {
-    "mtime": 1782488208.26589,
+    "mtime": 1782494200.0973573,
     "ast_hash": "c0254142e8a4ee94e8d439d10853e0f1",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/gui-driver-facade-alias.json": {
-    "mtime": 1782488208.041367,
+    "mtime": 1782494199.8717706,
     "ast_hash": "112ffef31b2e7dcb5a67b10e4f252bcb",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/playwright-entrypoint-casing.json": {
-    "mtime": 1782488208.0433667,
+    "mtime": 1782494199.8747709,
     "ast_hash": "faaf90924ddd4bfa4d6d5ddf68f8a956",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/DriverContract.java": {
-    "mtime": 1782488208.264891,
+    "mtime": 1782494200.0973573,
     "ast_hash": "4c8a0740e8dadf4b4ea33022614f731c",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/gui-driver-facade-alias.md": {
-    "mtime": 1782488208.041367,
+    "mtime": 1782494199.8717706,
     "ast_hash": "1d08f73622a67f46dd47f80a88936c27",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/playwright-entrypoint-casing.md": {
-    "mtime": 1782488208.044369,
+    "mtime": 1782494199.8747709,
     "ast_hash": "c02315cea77a741aa8857863c3ae432a",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/keep-shaft-mcp-webdriver-default-with-opt-in-playwright-tools.json": {
-    "mtime": 1782488208.042367,
+    "mtime": 1782494199.8727736,
     "ast_hash": "5fa44d4831d7aa7b8e7ef2eb5bb9faa9",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightDeviceDescriptor.java": {
-    "mtime": 1782488208.2902415,
+    "mtime": 1782494200.1229808,
     "ast_hash": "67c0996090cdbbda2d949a57a8c3db07",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/playwright/internal/PlaywrightDeviceDescriptorTest.java": {
-    "mtime": 1782488208.5252235,
+    "mtime": 1782494200.3555772,
     "ast_hash": "08d00d520b346162b36ac4c36ba1bd88",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/ChromePlaywrightActionsE2ETest.java": {
-    "mtime": 1782488208.5882914,
+    "mtime": 1782494200.415095,
     "ast_hash": "aa83f62d13d9b32c804f9669207c5e13",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/EdgePlaywrightActionsE2ETest.java": {
-    "mtime": 1782488208.5882914,
+    "mtime": 1782494200.4160957,
     "ast_hash": "ed3fad31e9488da5adfaf259443d8ede",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/FirefoxPlaywrightActionsE2ETest.java": {
-    "mtime": 1782488208.5882914,
+    "mtime": 1782494200.4160957,
     "ast_hash": "bcbdf4bb9f4467776b4d3463a8c7951c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/GalaxyS26UltraPlaywrightActionsE2ETest.java": {
-    "mtime": 1782488208.5892913,
+    "mtime": 1782494200.4160957,
     "ast_hash": "4a474a6aa1007ba5af607d82b71831cc",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/IPhone17ProMaxPlaywrightActionsE2ETest.java": {
-    "mtime": 1782488208.5892913,
+    "mtime": 1782494200.4170947,
     "ast_hash": "8d331269ccb27a6b7e064ea85bf7990d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/PlaywrightActionsE2ETestBase.java": {
-    "mtime": 1782488208.5892913,
+    "mtime": 1782494200.4170947,
     "ast_hash": "7f8415867f52f4e848568a3c9f935860",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/PlaywrightMobileWebE2ETestBase.java": {
-    "mtime": 1782488208.5902913,
+    "mtime": 1782494200.4170947,
     "ast_hash": "3f68d06f2c61c24f184c5b17baab7054",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/WebKitPlaywrightActionsE2ETest.java": {
-    "mtime": 1782488208.5902913,
+    "mtime": 1782494200.418094,
     "ast_hash": "f3d37b40410e79d9e42714583965241b",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpPlaywrightRecordingService.java": {
-    "mtime": 1782488209.1441953,
+    "mtime": 1782494200.969271,
     "ast_hash": "4a4d95b97c572ad3433ceebc3bc02d3b",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/PlaywrightService.java": {
-    "mtime": 1782488209.1481965,
+    "mtime": 1782494200.9732728,
     "ast_hash": "9f62abbb4a18edf9103d71503468d98d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/PlaywrightServiceTest.java": {
-    "mtime": 1782488209.1591992,
+    "mtime": 1782494200.9842708,
     "ast_hash": "83323568e4bc8f319bea7e387d498f3b",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/keep-shaft-mcp-webdriver-default-with-opt-in-playwright-tools.md": {
-    "mtime": 1782488208.042367,
+    "mtime": 1782494199.8737707,
     "ast_hash": "950eec0b85d5d4997e4760869b654fe5",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/mobileViewportFixture.html": {
-    "mtime": 1782488209.0903962,
+    "mtime": 1782494200.9170542,
     "ast_hash": "8077d707d3ea303dbb6c342debf4d056",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightNativeValidationsBuilder.java": {
-    "mtime": 1782488208.2952409,
+    "mtime": 1782494200.1269815,
     "ast_hash": "24fe26210c4236f7eb3ca4da2592a314",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightValidationsExecutor.java": {
-    "mtime": 1782488208.2952409,
+    "mtime": 1782494200.127982,
     "ast_hash": "c6c0e7de7fda83abfddf1f1d0ab67901",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_documentation_boundaries.py": {
-    "mtime": 1782488209.212708,
+    "mtime": 1782494201.0723395,
     "ast_hash": "931d4c107349f89419e24eb8a54bc12a",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_shaft_mcp_configuration.py": {
-    "mtime": 1782488209.2137077,
+    "mtime": 1782494201.0733397,
     "ast_hash": "595a0f83f71c9019bd43f91982ee7ec0",
     "semantic_hash": ""
   },
   ".agents/skills/shaft-marketing-ad-producer/SKILL.md": {
-    "mtime": 1782488208.0133693,
+    "mtime": 1782494199.8447716,
     "ast_hash": "85e6b59cd7192b33185172d1e2737e3a",
     "semantic_hash": ""
   },
   ".agents/skills/shaft-marketing-ad-producer/agents/openai.yaml": {
-    "mtime": 1782488208.0143695,
+    "mtime": 1782494199.8447716,
     "ast_hash": "5e1f289ca493111b43c4b5fb5c149083",
     "semantic_hash": ""
   },
   ".codex/superpowers/plans/2026-06-23-stability-first-mcp-engine-implementation.txt": {
-    "mtime": 1782488208.0153697,
+    "mtime": 1782494199.8457718,
     "ast_hash": "767575f3fdfbc71c447912068f5506ef",
     "semantic_hash": ""
   },
   ".codex/superpowers/specs/2026-06-23-stability-first-mcp-engine-design.txt": {
-    "mtime": 1782488208.0153697,
+    "mtime": 1782494199.846772,
     "ast_hash": "bd7f87426277e00520d3fbbbb4eda3d1",
     "semantic_hash": ""
   },
   ".github/skills/shaft-marketing-ad-producer/SKILL.md": {
-    "mtime": 1782488208.0263703,
+    "mtime": 1782494199.857771,
     "ast_hash": "35e3e4692f2e57fe41eaf6b7239d28c6",
     "semantic_hash": ""
   },
   ".github/workflows/README.md": {
-    "mtime": 1782488208.0273685,
+    "mtime": 1782494199.857771,
     "ast_hash": "c6956e8a0cc38af6f8800ff3b36ca3b5",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft_standard.png": {
-    "mtime": 1782488208.4962246,
+    "mtime": 1782494200.3255775,
     "ast_hash": "5df1ce58218a4bae2d031b7faa043c03",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/do-not-wait-for-ci-unless-explicitly-requested.json": {
-    "mtime": 1782488208.0633729,
+    "mtime": 1782494199.8937757,
     "ast_hash": "e50b709e98cdd4c0a3a3af527af6d24e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/listeners/JunitExtensionLifecycleTest.java": {
-    "mtime": 1782488208.5272243,
-    "ast_hash": "329dbfb8c69dc8eb155d1d5f78f2f724",
+    "mtime": 1782495576.9230683,
+    "ast_hash": "33d365e7835c702fa4f4a888ee4544e2",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/do-not-wait-for-ci-unless-explicitly-requested.md": {
-    "mtime": 1782488208.0633729,
+    "mtime": 1782494199.8937757,
     "ast_hash": "080b95f36a86f347d063dbaf3df05bed",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/talk-less-outside-planning.json": {
-    "mtime": 1782488208.0453672,
+    "mtime": 1782494199.8767712,
     "ast_hash": "347efbcab49046c0b2e1954ab867a9d8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsPlaywrightVisualTest.java": {
-    "mtime": 1782488208.5192242,
+    "mtime": 1782494200.3485768,
     "ast_hash": "cf497152d7890a07d978712aee364d85",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/playwright/validation/PlaywrightElementVisualValidationTest.java": {
-    "mtime": 1782488208.5262241,
+    "mtime": 1782494200.3555772,
     "ast_hash": "bc4649c93d093c2a601e8f7f6cc26568",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainDiagnostic.java": {
-    "mtime": 1782488209.142201,
+    "mtime": 1782494200.967548,
     "ast_hash": "439cee60e23d196ca8026950a7c498c3",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpCaptureCodeBlockServiceTest.java": {
-    "mtime": 1782488209.1561992,
+    "mtime": 1782494200.9802709,
     "ast_hash": "8e633fbf2210bc193b6d3b8e22aa3baa",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/talk-less-outside-planning.md": {
-    "mtime": 1782488208.0463688,
+    "mtime": 1782494199.8767712,
     "ast_hash": "5415bf34405c6f4d13a76060ed778328",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/RemoteGridPreflight.java": {
-    "mtime": 1782488208.2553308,
+    "mtime": 1782494200.0853512,
     "ast_hash": "76b2a413fa9d60ce891121d6ce49e1de",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/RemoteGridPreflightUnitTest.java": {
-    "mtime": 1782488208.5122254,
+    "mtime": 1782494200.3425765,
     "ast_hash": "8c86158cab9438008c9ecfa8f76fe1fa",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/internal/OpenApiCoverageReporter.java": {
-    "mtime": 1782488208.2473283,
+    "mtime": 1782494200.0763516,
     "ast_hash": "1346bcb62d2558db35ce9b880108305e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/internal/OpenApiCoverageReporterUnitTest.java": {
-    "mtime": 1782488208.509225,
+    "mtime": 1782494200.3385773,
     "ast_hash": "568aa0017a286bb0ede8194b19217519",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/LocatorHealthReporter.java": {
-    "mtime": 1782488208.280242,
+    "mtime": 1782494200.1129808,
     "ast_hash": "05da6d02f7407a0794e31b06594e2fb7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/locator/LocatorHealthReporterUnitTest.java": {
-    "mtime": 1782488208.5212247,
+    "mtime": 1782494200.3515766,
     "ast_hash": "15b91fc645796993b379e7a73a3998ae",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ExecutionLifecycleHelperSourceUnitTest.java": {
-    "mtime": 1782488208.6122887,
+    "mtime": 1782494200.4390945,
     "ast_hash": "64397aafb905ef4ae1defd73a4016e30",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsReportingUnitTest.java": {
-    "mtime": 1782488208.5192242,
+    "mtime": 1782494200.3495767,
     "ast_hash": "a67ef8c418bf9b0a4c50e180c95d2eec",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft_report_logo.png": {
-    "mtime": 1782488208.4952269,
+    "mtime": 1782494200.3245766,
     "ast_hash": "987c93b372f4f797f601da520d349930",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureTraceReporter.java": {
-    "mtime": 1782489017.5711038,
-    "ast_hash": "734624e1ba3b50b21430219b4eacd30a",
+    "mtime": 1782494200.1629806,
+    "ast_hash": "26012d437225fef830e2ce8bcb04b076",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/FailureTraceReporterTest.java": {
-    "mtime": 1782489497.6174207,
-    "ast_hash": "7f3d4bb7aaffcaf8df7283775c524c57",
+    "mtime": 1782494200.3645766,
+    "ast_hash": "438675103b6f814b8316e5d0cf85a0ed",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureDiagnosticsReporter.java": {
-    "mtime": 1782488208.330239,
+    "mtime": 1782494200.16198,
     "ast_hash": "b42398cb7bca0a1f3068b9bb05551522",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/FailureDiagnosticsReporterTest.java": {
-    "mtime": 1782488208.5352237,
+    "mtime": 1782494200.3645766,
     "ast_hash": "0ae1c9f864ba886cbb1d9121238104c5",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/PlaywrightNetworkInterceptor.java": {
-    "mtime": 1782488208.262892,
+    "mtime": 1782494200.0953567,
     "ast_hash": "680fe6d71d1b4c15988d4cf7650986a4",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/PlaywrightNaturalActionExecutor.java": {
-    "mtime": 1782488208.286242,
+    "mtime": 1782494200.1189816,
     "ast_hash": "580e7a8e63d84599ad544362d069fe47",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/BrowserPerformanceExecutionReport.java": {
-    "mtime": 1782488208.3272398,
+    "mtime": 1782494200.1589808,
     "ast_hash": "e8c11826ea27b008503b317a7d883f25",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/RequestBuilderPerformanceTest.java": {
-    "mtime": 1782488208.5062256,
+    "mtime": 1782494200.3365786,
     "ast_hash": "2191ebf4bdd2e8e7196f0250ebdf30d9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/browser/internal/PlaywrightNetworkInterceptorTest.java": {
-    "mtime": 1782488208.5132248,
+    "mtime": 1782494200.3435771,
     "ast_hash": "108dbc96ba77bae8a5522dd0fa9b8bde",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/natural/PlaywrightNaturalActionExecutorTest.java": {
-    "mtime": 1782488208.5232246,
+    "mtime": 1782494200.3525767,
     "ast_hash": "224a7cea785bb42c47501ecd2e056ecb",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/playwright/browser/PlaywrightBrowserActionsUnitTest.java": {
-    "mtime": 1782488208.5252235,
+    "mtime": 1782494200.3545773,
     "ast_hash": "501d45447f122f7bb84022f904af07fb",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/ApiPerformanceExecutionReportUnitTest.java": {
-    "mtime": 1782488208.533223,
+    "mtime": 1782494200.3625767,
     "ast_hash": "2b28c44dcabcf2f670a6b7cf8fce5e6f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/BrowserPerformanceExecutionReportUnitTest.java": {
-    "mtime": 1782488208.5342226,
+    "mtime": 1782494200.3635788,
     "ast_hash": "1111beffdc1950a57cab0b2ce29df73c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/CompositeLocator.java": {
-    "mtime": 1782488208.279242,
+    "mtime": 1782494200.1119807,
     "ast_hash": "d77b647548e25d65efcd1bbf7c6acdea",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionCompositeLocator.java": {
-    "mtime": 1782488208.2832417,
+    "mtime": 1782494200.1159804,
     "ast_hash": "f62837ef7588732dc6655fbadc781d43",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureBriefReporter.java": {
-    "mtime": 1782488208.3292394,
+    "mtime": 1782494200.1609807,
     "ast_hash": "1457920445a559d0140435fa74931347",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/FailureBriefReporterTest.java": {
-    "mtime": 1782488208.5342226,
+    "mtime": 1782494200.3635788,
     "ast_hash": "a195e239bd8aa4e32bc14ea0c66b5293",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/RetryPolicy.java": {
-    "mtime": 1782488208.2453313,
+    "mtime": 1782494200.0753517,
     "ast_hash": "9858ba53964a3a12369d1472ef8ed15b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/FlakeProfiler.java": {
-    "mtime": 1782488208.3312395,
+    "mtime": 1782494200.1629806,
     "ast_hash": "1040af4916b6c65d4b52160d3928204f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/FlakeProfilerUnitTest.java": {
-    "mtime": 1782488208.5362227,
+    "mtime": 1782494200.3655758,
     "ast_hash": "7fe9f1b86d4099a71f5501fde912fd90",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertiesHelperEvidenceLevelUnitTest.java": {
-    "mtime": 1782488208.6222887,
+    "mtime": 1782494200.4490945,
     "ast_hash": "f01472e56b66ea3645c3f2d0725d7d40",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/include-examples-or-screenshots-in-prs.json": {
-    "mtime": 1782488208.0633729,
+    "mtime": 1782494199.894776,
     "ast_hash": "cec767873686daec7cd28b6bd61dd7f0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/TraceEventRecorder.java": {
-    "mtime": 1782488208.3352385,
+    "mtime": 1782494200.1669798,
     "ast_hash": "6c86ae9844a8519075ea96c3416902be",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/include-examples-or-screenshots-in-prs.md": {
-    "mtime": 1782488208.0643728,
+    "mtime": 1782494199.8957758,
     "ast_hash": "f445be3526e0ecc1d8c93ecd8818e673",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionabilityDiagnostics.java": {
-    "mtime": 1782488208.270395,
+    "mtime": 1782494200.102357,
     "ast_hash": "7408177624edd24821b01ea3243bacdd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ElementActionabilityDiagnosticsTest.java": {
-    "mtime": 1782488208.5162244,
+    "mtime": 1782494200.345577,
     "ast_hash": "4bafb168615164fd5768bc9e05150c4c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserNetworkProfileManager.java": {
-    "mtime": 1782488208.2618861,
+    "mtime": 1782494200.0933614,
     "ast_hash": "73d20c538670d0558de855a38fbddf83",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserStorageStateManager.java": {
-    "mtime": 1782488208.262892,
+    "mtime": 1782494200.094357,
     "ast_hash": "381a5f7dba5d6eecc1857e12ee344e4f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/BrowserObservabilityRecorder.java": {
-    "mtime": 1782488208.3272398,
+    "mtime": 1782494200.1589808,
     "ast_hash": "50aa9558461b188e595e4b1d07e3fcd4",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/include-concrete-evidence-in-shaft-pr-bodies.json": {
-    "mtime": 1782488217.3783884,
-    "ast_hash": "c1336228b1226de739411c9b562d3541",
+    "mtime": 1782494199.894776,
+    "ast_hash": "f016cde4de254a63c746a1f706097452",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/MobileTraceMetadata.java": {
-    "mtime": 1782490198.4981618,
-    "ast_hash": "4dc5c0fb2958c0a371e7739a49565ad8",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/summary.json": {
-    "mtime": 1782490311.1437826,
-    "ast_hash": "5181417d41e7fe01dd3648c6d7a17ea3",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/categories.json": {
-    "mtime": 1782490308.675455,
-    "ast_hash": "bbc6f20af79864d58750116e43d3d312",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_26-06-2026_18-53-48-3183-PM.json": {
-    "mtime": 1782489228.3213031,
-    "ast_hash": "3ce66a7ceb73b99e9ed44064fbb29099",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_26-06-2026_19-00-09-7169-PM.json": {
-    "mtime": 1782489609.7209942,
-    "ast_hash": "fb64d93c04f548d53b2f0ffa16ae4705",
+    "mtime": 1782494200.16498,
+    "ast_hash": "84c7ec31787c8850783b52d33933ac52",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/include-concrete-evidence-in-shaft-pr-bodies.md": {
-    "mtime": 1782488217.3753672,
+    "mtime": 1782494199.894776,
     "ast_hash": "be33dd34e200039f50617556815feb51",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-26_18-53-51-333_AllureReport.html": {
-    "mtime": 1782489231.326822,
-    "ast_hash": "e785c69a5b7a575821e8a0fac2511fc5",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-26_19-00-12-588_AllureReport.html": {
-    "mtime": 1782489612.5797005,
-    "ast_hash": "5719386e9e91d8412d7c8652fa027ee0",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allurerc.yaml": {
-    "mtime": 1782490308.6774554,
-    "ast_hash": "ae321a5041b4f8c6197e96f9660ccbe1",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_26-06-2026_18-53-48-3183-PM.html": {
-    "mtime": 1782489228.3203104,
-    "ast_hash": "d34a6fc31e1fc59a0ccb34d8537deac7",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_26-06-2026_19-00-09-7169-PM.html": {
-    "mtime": 1782489609.7189963,
-    "ast_hash": "d158014169580e7eef76da97d7f38e68",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_26-06-2026_19-05-07-3848-PM.json": {
-    "mtime": 1782489907.388357,
-    "ast_hash": "7b0af29aaf26284f65773010ebadebdf",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-26_19-05-10-182_AllureReport.html": {
-    "mtime": 1782489910.1729202,
-    "ast_hash": "f9d3484bd132450d3b11041d7136fd4e",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_26-06-2026_19-05-07-3848-PM.html": {
-    "mtime": 1782489907.3868475,
-    "ast_hash": "8870428052abdd777509183735f7886a",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/24f5e152-c563-4483-9bec-8eec90f96825-container.json": {
-    "mtime": 1782490308.5549197,
-    "ast_hash": "e46923ba711a250a9b4edcfea87ece08",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/29920cfc-b7c9-461a-a482-e34620cfcbfd-container.json": {
-    "mtime": 1782490308.5679245,
-    "ast_hash": "1ab6f07a9c951a5065ba4e20f773b39d",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/2e4c74ba-bccb-42ec-989a-e7a7f3c580f5-container.json": {
-    "mtime": 1782490308.5789218,
-    "ast_hash": "6aaf2ec55a44d986e535e11f0916e6ee",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/3d592bdf-ad78-4ea4-8991-0002e5b7b8c2-result.json": {
-    "mtime": 1782490308.5939245,
-    "ast_hash": "54517edb43555554a67fd1877c9008d4",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/474a09b4-e021-4b9e-b826-dd5b23da1a13-result.json": {
-    "mtime": 1782490308.6064582,
-    "ast_hash": "d9535ae8ca73b19a38930d51adaae1d0",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/4a7cd3c9-01d6-4e2d-b1f1-f4df1b0795d2-result.json": {
-    "mtime": 1782490308.6204581,
-    "ast_hash": "13c918c96a099091b0b2e84155645f22",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/5bbeeb6a-43ed-4f07-b5e4-e330caf18c55-result.json": {
-    "mtime": 1782490308.6324582,
-    "ast_hash": "c97274e2f83549b88df93cab7570eb2d",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/5bda8cec-40b8-4f69-92ad-26c71e1ceec2-result.json": {
-    "mtime": 1782490308.6434565,
-    "ast_hash": "e397433b53d365614590c9ca633bb4b2",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/6bf76f07-e3e1-4eb5-990e-627498bd6d78-container.json": {
-    "mtime": 1782490308.653454,
-    "ast_hash": "bec0655a396ba669a9dc3e440f8e5f5e",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/bc9b0c28-41cb-4762-8c7d-63a4d07e64d0-container.json": {
-    "mtime": 1782490308.6644537,
-    "ast_hash": "67854f8ea0d661f2d281cc3d9bb520c9",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/d38bfe4e-9196-40c3-870f-06d440ba1f4a-container.json": {
-    "mtime": 1782490308.6744542,
-    "ast_hash": "bcce5263dda26e1937a70c0656bcacbe",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_26-06-2026_19-11-48-5189-PM.json": {
-    "mtime": 1782490308.521918,
-    "ast_hash": "779b58edb5a65fd4ed0c3b10ecd92f82",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-report/2026-06-26_19-11-51-334_AllureReport.html": {
-    "mtime": 1782490311.326804,
-    "ast_hash": "7dd303624d17841dbe7f8a40f6616cd1",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/05a9da54-e013-4d3a-a673-39a88b9b5d05-attachment.txt": {
-    "mtime": 1782490308.4533873,
-    "ast_hash": "0af5c03da320437e0ec96bc6099cf703",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/3b925d8e-36dd-49b8-9458-96a77e03a0b7-attachment.txt": {
-    "mtime": 1782490308.414389,
-    "ast_hash": "15ae9178eb0478aef1e7dd1a16864626",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/9edeb2e0-c38e-406f-bc68-9798719fe174-attachment.txt": {
-    "mtime": 1782490307.7920525,
-    "ast_hash": "6f4a527f721f697f04f83c95bbcc9448",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/execution-summary/ExecutionSummaryReport_26-06-2026_19-11-48-5250-PM.html": {
-    "mtime": 1782490308.530921,
-    "ast_hash": "6e8ca1e8c7af89d788ba9225c1265c6e",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/performanceReport/PerformanceReport_26-06-2026_19-11-48-5189-PM.html": {
-    "mtime": 1782490308.5199175,
-    "ast_hash": "72c12528f291ace71cf67e41f1561963",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/4efb582e-a9f9-40a1-a14a-40346849f3ce-attachment.mp4": {
-    "mtime": 1782490308.3688602,
-    "ast_hash": "a3195fc8f567739dc9541c384c739b14",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/a8b85750-d089-4839-afe1-c4872bcb68f1-attachment.mp4": {
-    "mtime": 1782490308.3158634,
-    "ast_hash": "5d552f0393e434637a8230035bd6c3b9",
     "semantic_hash": ""
   }
 }

--- a/shaft-engine/src/main/java/com/shaft/listeners/JunitExtension.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/JunitExtension.java
@@ -12,23 +12,43 @@ import com.shaft.tools.io.internal.FlakeProfiler;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import com.shaft.validation.internal.ValidationsHelper;
 import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.LifecycleMethodExecutionExceptionHandler;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherConfig;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
 import org.opentest4j.TestAbortedException;
 
 import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Jupiter extension for SHAFT execution behavior that cannot be provided by a launcher listener.
  */
 public class JunitExtension implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback,
-        AfterTestExecutionCallback, TestExecutionExceptionHandler, LifecycleMethodExecutionExceptionHandler {
+        AfterEachCallback, AfterTestExecutionCallback, TestExecutionExceptionHandler,
+        LifecycleMethodExecutionExceptionHandler {
     private static final AtomicLong suiteStartTime = new AtomicLong(0);
+    private static final ExtensionContext.Namespace RETRY_NAMESPACE =
+            ExtensionContext.Namespace.create(JunitExtension.class, "retry");
+    private static final String PENDING_RETRY_KEY = "pendingRetry";
+    private static final ConcurrentMap<String, ActiveRetryAttempt> activeRetryAttempts = new ConcurrentHashMap<>();
 
     @Override
     public void beforeAll(ExtensionContext context) {
@@ -44,6 +64,13 @@ public class JunitExtension implements BeforeAllCallback, AfterAllCallback, Befo
 
     @Override
     public void beforeEach(ExtensionContext context) {
+        ActiveRetryAttempt retryAttempt = activeRetryAttempt(context);
+        if (retryAttempt != null) {
+            Method method = context.getRequiredTestMethod();
+            logRetryAttempt(method, retryAttempt.attempt(), retryAttempt.maxRetryCount());
+            RetryAnalyzer.enableSupportingEvidenceCaptureForRetryAttempt();
+            RetryAnalyzer.activateSupportingEvidenceCaptureForRetryAttempt();
+        }
         enforceSuiteTimeout();
         failFast(context);
         skipLinkedIssues(context);
@@ -51,35 +78,33 @@ public class JunitExtension implements BeforeAllCallback, AfterAllCallback, Befo
 
     @Override
     public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
-        int maxRetryCount = RetryAnalyzer.retryMaximumNumberOfAttempts();
-        Throwable lastFailure = throwable;
-        Method method = context.getRequiredTestMethod();
-        Object target = context.getTestInstance().orElse(null);
-        for (int attempt = 1; attempt <= maxRetryCount; attempt++) {
-            JunitListener.recordRetriedFailure(toTestExecutionInfo(context, method, lastFailure));
-            try {
-                logRetryAttempt(method, attempt, maxRetryCount);
-                RetryAnalyzer.enableSupportingEvidenceCaptureForRetryAttempt();
-                RetryAnalyzer.activateSupportingEvidenceCaptureForRetryAttempt();
-                context.getExecutableInvoker().invoke(method, target);
-                return;
-            } catch (Throwable retryFailure) {
-                lastFailure = retryFailure;
-            } finally {
-                RetryAnalyzer.restoreSupportingEvidenceCaptureForRetryAttempt();
-            }
+        if (isActiveRetry(context) || !scheduleRetry(context, throwable)) {
+            throw throwable;
         }
-        throw lastFailure;
     }
 
     @Override
-    public void afterTestExecution(ExtensionContext context) {
+    public void afterTestExecution(ExtensionContext context) throws Exception {
         AssertionError verificationError = ValidationsHelper.getVerificationErrorToForceFail();
         if (verificationError != null) {
             ValidationsHelper.resetVerificationStateAfterFailing();
             if (context.getExecutionException().isEmpty()) {
-                throw verificationError;
+                if (isActiveRetry(context) || !scheduleRetry(context, verificationError)) {
+                    throw verificationError;
+                }
             }
+        }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        if (isActiveRetry(context)) {
+            RetryAnalyzer.restoreSupportingEvidenceCaptureForRetryAttempt();
+            return;
+        }
+        PendingRetry pendingRetry = context.getStore(RETRY_NAMESPACE).remove(PENDING_RETRY_KEY, PendingRetry.class);
+        if (pendingRetry != null) {
+            executeScheduledRetry(context, pendingRetry);
         }
     }
 
@@ -134,6 +159,116 @@ public class JunitExtension implements BeforeAllCallback, AfterAllCallback, Befo
         }
     }
 
+    private static boolean scheduleRetry(ExtensionContext context, Throwable throwable) {
+        int maxRetryCount = RetryAnalyzer.retryMaximumNumberOfAttempts();
+        if (maxRetryCount <= 0) {
+            return false;
+        }
+        ExtensionContext.Store store = context.getStore(RETRY_NAMESPACE);
+        if (store.get(PENDING_RETRY_KEY, PendingRetry.class) == null) {
+            store.put(PENDING_RETRY_KEY,
+                    new PendingRetry(context.getRequiredTestMethod(), throwable, maxRetryCount));
+        }
+        return true;
+    }
+
+    private static void executeScheduledRetry(ExtensionContext context, PendingRetry pendingRetry) throws Exception {
+        Throwable lastFailure = pendingRetry.failure();
+        for (int attempt = 1; attempt <= pendingRetry.maxRetryCount(); attempt++) {
+            JunitListener.recordRetriedFailure(toTestExecutionInfo(context, pendingRetry.method(), lastFailure));
+            TestExecutionSummary summary = executeRetryAttempt(context, pendingRetry.method(), attempt,
+                    pendingRetry.maxRetryCount());
+            if (isSuccessfulRetry(summary)) {
+                return;
+            }
+            lastFailure = failureFrom(summary)
+                    .orElseGet(() -> new AssertionError("Retry attempt did not execute test: "
+                            + context.getDisplayName()));
+        }
+        throwAsException(lastFailure);
+    }
+
+    private static TestExecutionSummary executeRetryAttempt(ExtensionContext context, Method method, int attempt,
+                                                           int maxRetryCount) throws Exception {
+        String uniqueId = context.getUniqueId();
+        activeRetryAttempts.put(uniqueId, new ActiveRetryAttempt(attempt, maxRetryCount));
+        try {
+            TestExecutionSummary summary = executeRetryRequest(
+                    retryRequest(DiscoverySelectors.selectUniqueId(uniqueId)));
+            if (summary.getTestsFoundCount() == 0 && method != null) {
+                summary = executeRetryRequest(
+                        retryRequest(DiscoverySelectors.selectMethod(context.getRequiredTestClass(), method)));
+            }
+            return summary;
+        } finally {
+            activeRetryAttempts.remove(uniqueId);
+        }
+    }
+
+    private static LauncherDiscoveryRequest retryRequest(DiscoverySelector selector) {
+        return LauncherDiscoveryRequestBuilder.request()
+                .selectors(selector)
+                .configurationParameter("junit.jupiter.extensions.autodetection.enabled", "true")
+                .configurationParameter("junit.jupiter.execution.parallel.enabled", "false")
+                .build();
+    }
+
+    private static TestExecutionSummary executeRetryRequest(LauncherDiscoveryRequest request) throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "shaft-junit-retry");
+            thread.setDaemon(false);
+            return thread;
+        });
+        try {
+            return executor.submit(() -> {
+                SummaryGeneratingListener summaryListener = new SummaryGeneratingListener();
+                LauncherFactory.create(LauncherConfig.builder()
+                        .enableLauncherSessionListenerAutoRegistration(false)
+                        .build()).execute(request, summaryListener);
+                return summaryListener.getSummary();
+            }).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw e;
+        } catch (ExecutionException e) {
+            throwAsException(e.getCause() == null ? e : e.getCause());
+            throw e;
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static boolean isSuccessfulRetry(TestExecutionSummary summary) {
+        return summary.getTestsSucceededCount() > 0
+                && summary.getTestsFailedCount() == 0
+                && summary.getFailures().isEmpty();
+    }
+
+    private static Optional<Throwable> failureFrom(TestExecutionSummary summary) {
+        return summary.getFailures().stream()
+                .findFirst()
+                .map(TestExecutionSummary.Failure::getException);
+    }
+
+    private static boolean isActiveRetry(ExtensionContext context) {
+        return activeRetryAttempt(context) != null;
+    }
+
+    private static ActiveRetryAttempt activeRetryAttempt(ExtensionContext context) {
+        String uniqueId = context.getUniqueId();
+        return uniqueId == null ? null : activeRetryAttempts.get(uniqueId);
+    }
+
+    private static void throwAsException(Throwable throwable) throws Exception {
+        if (throwable instanceof Error error) {
+            throw error;
+        }
+        if (throwable instanceof Exception exception) {
+            throw exception;
+        }
+        throw new RuntimeException(throwable);
+    }
+
     private static void logRetryAttempt(Method method, int attempt, int maxRetryCount) {
         ReportManagerHelper.enableDebugFileLogging();
         ReportManager.logDiscrete("Retry #" + attempt + "/" + maxRetryCount
@@ -148,5 +283,11 @@ public class JunitExtension implements BeforeAllCallback, AfterAllCallback, Befo
         String methodName = method == null ? context.getDisplayName() : method.getName();
         return new TestExecutionInfo(context.getUniqueId(), className, methodName, context.getDisplayName(),
                 context.getDisplayName(), method, throwable, true);
+    }
+
+    private record PendingRetry(Method method, Throwable failure, int maxRetryCount) {
+    }
+
+    private record ActiveRetryAttempt(int attempt, int maxRetryCount) {
     }
 }

--- a/shaft-engine/src/test/java/com/shaft/listeners/JunitExtensionLifecycleTest.java
+++ b/shaft-engine/src/test/java/com/shaft/listeners/JunitExtensionLifecycleTest.java
@@ -6,8 +6,12 @@ import com.shaft.properties.internal.Properties;
 import com.shaft.validation.internal.ValidationsHelper;
 import io.qameta.allure.Issue;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExecutableInvoker;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
@@ -26,10 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class JunitExtensionLifecycleTest {
@@ -50,6 +51,7 @@ class JunitExtensionLifecycleTest {
 
     @Test
     void afterTestExecutionShouldFailJunitTestWhenSoftVerificationFailed() {
+        SHAFT.Properties.flags.set().retryMaximumNumberOfAttempts(0);
         ExtensionContext context = mock(ExtensionContext.class);
         when(context.getExecutionException()).thenReturn(Optional.empty());
 
@@ -86,75 +88,83 @@ class JunitExtensionLifecycleTest {
     void handleTestExecutionExceptionShouldRethrowOriginalFailureWhenRetriesAreDisabled() throws Throwable {
         SHAFT.Properties.flags.set().retryMaximumNumberOfAttempts(0);
         AssertionError failure = new AssertionError("first attempt");
-        ExecutableInvoker invoker = mock(ExecutableInvoker.class);
-        ExtensionContext context = mockRetryContext("handleTestExecutionExceptionShouldRethrowOriginalFailureWhenRetriesAreDisabled", invoker);
+        ExtensionContext context = mockExtensionContext("handleTestExecutionExceptionShouldRethrowOriginalFailureWhenRetriesAreDisabled");
 
         AssertionError thrown = assertThrows(AssertionError.class,
                 () -> extension.handleTestExecutionException(context, failure));
 
         assertSame(failure, thrown);
-        verifyNoInteractions(invoker);
     }
 
     @Test
-    void handleTestExecutionExceptionShouldRetryFailedTestMethodOnce() throws Throwable {
+    void junitLauncherShouldRetryWithFreshBeforeEachAndAfterEachLifecycle() {
         SHAFT.Properties.flags.set().retryMaximumNumberOfAttempts(1);
-        AtomicInteger attempts = new AtomicInteger(1);
-        ExecutableInvoker invoker = mock(ExecutableInvoker.class);
-        Method method = JunitExtensionLifecycleTest.class.getDeclaredMethod("retryFixture");
-        ExtensionContext context = mockRetryContext("handleTestExecutionExceptionShouldRetryFailedTestMethodOnce", invoker, method);
+        LauncherRetryFixture.reset();
 
-        doAnswer(invocation -> {
-            attempts.incrementAndGet();
-            return null;
-        }).when(invoker).invoke(method, this);
+        TestExecutionSummary summary = executeFixture(LauncherRetryFixture.class);
 
-        extension.handleTestExecutionException(context, new AssertionError("first attempt"));
-
-        assertEquals(2, attempts.get());
+        assertEquals(2, LauncherRetryFixture.attempts.get());
+        assertEquals(2, LauncherRetryFixture.beforeEachCalls.get());
+        assertEquals(2, LauncherRetryFixture.afterEachCalls.get());
+        assertEquals(0, summary.getFailures().size(), () -> summary.getFailures().toString());
+        assertTrue(summary.getTestsSucceededCount() > 0);
     }
 
     @Test
-    void handleTestExecutionExceptionShouldThrowRetryFailureWhenRetriesAreExhausted() throws Throwable {
+    void junitLauncherShouldKeepOuterSessionStateIsolatedFromRetryLifecycle() {
         SHAFT.Properties.flags.set().retryMaximumNumberOfAttempts(1);
-        AssertionError retryFailure = new AssertionError("retry attempt");
-        ExecutableInvoker invoker = mock(ExecutableInvoker.class);
-        Method method = JunitExtensionLifecycleTest.class.getDeclaredMethod("retryFixture");
-        ExtensionContext context = mockRetryContext("handleTestExecutionExceptionShouldThrowRetryFailureWhenRetriesAreExhausted", invoker, method);
-        doThrow(retryFailure).when(invoker).invoke(method, this);
+        OuterSessionStateRetryFixture.reset();
 
-        AssertionError thrown = assertThrows(AssertionError.class,
-                () -> extension.handleTestExecutionException(context, new AssertionError("first attempt")));
+        TestExecutionSummary summary = executeFixture(OuterSessionStateRetryFixture.class);
 
-        assertSame(retryFailure, thrown);
+        assertEquals(2, OuterSessionStateRetryFixture.attempts.get());
+        assertEquals(0, summary.getFailures().size(), () -> summary.getFailures().toString());
+        assertEquals(2, summary.getTestsSucceededCount());
+    }
+
+    @Test
+    void junitLauncherShouldReportRetryFailureWhenRetriesAreExhausted() {
+        SHAFT.Properties.flags.set().retryMaximumNumberOfAttempts(1);
+        ExhaustedLauncherRetryFixture.reset();
+
+        TestExecutionSummary summary = executeFixture(ExhaustedLauncherRetryFixture.class);
+
+        assertEquals(2, ExhaustedLauncherRetryFixture.attempts.get());
+        assertEquals(2, ExhaustedLauncherRetryFixture.beforeEachCalls.get());
+        assertEquals(2, ExhaustedLauncherRetryFixture.afterEachCalls.get());
+        assertEquals(1, summary.getFailures().size());
+        assertEquals("retry attempt", summary.getFailures().get(0).getException().getMessage());
     }
 
     @Test
     void junitLauncherShouldRetryWithoutInvocationInterceptorChainFailure() {
         SHAFT.Properties.flags.set().retryMaximumNumberOfAttempts(1);
-        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
-                .selectors(DiscoverySelectors.selectClass(LauncherRetryFixture.class))
-                .configurationParameter("junit.jupiter.extensions.autodetection.enabled", "true")
-                .build();
-        SummaryGeneratingListener summaryListener = new SummaryGeneratingListener();
-        LauncherRetryFixture.attempts.set(0);
+        LauncherRetryFixture.reset();
 
-        LauncherFactory.create(LauncherConfig.builder()
-                .enableLauncherSessionListenerAutoRegistration(false)
-                .build()).execute(request, summaryListener);
+        TestExecutionSummary summary = executeFixture(LauncherRetryFixture.class);
 
-        TestExecutionSummary summary = summaryListener.getSummary();
         assertEquals(2, LauncherRetryFixture.attempts.get());
         assertEquals(0, summary.getFailures().size(), () -> summary.getFailures().toString());
         assertTrue(summary.getTestsSucceededCount() > 0);
     }
 
-    @Issue("SHAFT-123")
-    private void linkedIssueFixture() {
-        // Used by reflection.
+    private static TestExecutionSummary executeFixture(Class<?> fixtureClass) {
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+                .selectors(DiscoverySelectors.selectClass(fixtureClass))
+                .configurationParameter("junit.jupiter.extensions.autodetection.enabled", "true")
+                .configurationParameter("junit.jupiter.execution.parallel.enabled", "false")
+                .build();
+        SummaryGeneratingListener summaryListener = new SummaryGeneratingListener();
+
+        LauncherFactory.create(LauncherConfig.builder()
+                .enableLauncherSessionListenerAutoRegistration(false)
+                .build()).execute(request, summaryListener);
+
+        return summaryListener.getSummary();
     }
 
-    private void retryFixture() {
+    @Issue("SHAFT-123")
+    private void linkedIssueFixture() {
         // Used by reflection.
     }
 
@@ -165,22 +175,28 @@ class JunitExtensionLifecycleTest {
         when(context.getDisplayName()).thenReturn(displayName);
         return context;
     }
-
-    private ExtensionContext mockRetryContext(String displayName, ExecutableInvoker invoker) throws Exception {
-        return mockRetryContext(displayName, invoker, JunitExtensionLifecycleTest.class.getDeclaredMethod("retryFixture"));
-    }
-
-    private ExtensionContext mockRetryContext(String displayName, ExecutableInvoker invoker, Method method) {
-        ExtensionContext context = mockExtensionContext(displayName);
-        when(context.getRequiredTestMethod()).thenReturn(method);
-        when(context.getTestInstance()).thenReturn(Optional.of(this));
-        when(context.getExecutableInvoker()).thenReturn(invoker);
-        return context;
-    }
 }
 
 class LauncherRetryFixture {
     static final AtomicInteger attempts = new AtomicInteger();
+    static final AtomicInteger beforeEachCalls = new AtomicInteger();
+    static final AtomicInteger afterEachCalls = new AtomicInteger();
+
+    static void reset() {
+        attempts.set(0);
+        beforeEachCalls.set(0);
+        afterEachCalls.set(0);
+    }
+
+    @BeforeEach
+    void setup() {
+        beforeEachCalls.incrementAndGet();
+    }
+
+    @AfterEach
+    void teardown() {
+        afterEachCalls.incrementAndGet();
+    }
 
     @Test
     void failsOnceThenPasses() {
@@ -189,5 +205,71 @@ class LauncherRetryFixture {
             throw new AssertionError("first attempt");
         }
         assertEquals(2, currentAttempt);
+        assertEquals(2, beforeEachCalls.get(), "retry should run with a fresh setup call");
+        assertEquals(1, afterEachCalls.get(), "failed attempt teardown should run before retry");
+    }
+}
+
+class ExhaustedLauncherRetryFixture {
+    static final AtomicInteger attempts = new AtomicInteger();
+    static final AtomicInteger beforeEachCalls = new AtomicInteger();
+    static final AtomicInteger afterEachCalls = new AtomicInteger();
+
+    static void reset() {
+        attempts.set(0);
+        beforeEachCalls.set(0);
+        afterEachCalls.set(0);
+    }
+
+    @BeforeEach
+    void setup() {
+        beforeEachCalls.incrementAndGet();
+    }
+
+    @AfterEach
+    void teardown() {
+        afterEachCalls.incrementAndGet();
+    }
+
+    @Test
+    void alwaysFails() {
+        int currentAttempt = attempts.incrementAndGet();
+        if (currentAttempt == 2) {
+            assertEquals(2, beforeEachCalls.get(), "retry should run with a fresh setup call");
+            assertEquals(1, afterEachCalls.get(), "failed attempt teardown should run before retry");
+            throw new AssertionError("retry attempt");
+        }
+        throw new AssertionError("first attempt");
+    }
+}
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class OuterSessionStateRetryFixture {
+    static final AtomicInteger attempts = new AtomicInteger();
+
+    static void reset() {
+        attempts.set(0);
+    }
+
+    @BeforeAll
+    static void setupClass() {
+        SHAFT.Properties.web.set().baseURL("https://class-session.example");
+    }
+
+    @Test
+    @Order(1)
+    void failsOnceThenPasses() {
+        int currentAttempt = attempts.incrementAndGet();
+        assertEquals("https://class-session.example", SHAFT.Properties.web.baseURL());
+        if (currentAttempt == 1) {
+            throw new AssertionError("first attempt");
+        }
+        assertEquals(2, currentAttempt);
+    }
+
+    @Test
+    @Order(2)
+    void classSessionStateSurvivesRetryLifecycle() {
+        assertEquals("https://class-session.example", SHAFT.Properties.web.baseURL());
     }
 }


### PR DESCRIPTION
## Summary
- Replace JUnit's direct retry method invocation with a lifecycle-safe retry scheduled after the failed attempt finishes teardown.
- Run each JUnit retry through a separate JUnit Platform launcher invocation on an isolated single thread, keyed by the original unique id.
- Preserve retry evidence behavior and retry failure accounting while avoiding recursive retry scheduling for nested retry attempts.
- Add launcher-level regressions for setup/teardown, exhausted retries, interceptor-chain safety, and outer session state isolation.
- Refresh Graphify output for the engine repo.

## Root Cause
`JunitExtension.handleTestExecutionException()` retried with `context.getExecutableInvoker().invoke(method, target)`. That re-entered only the test method inside the same Jupiter invocation. It did not let the failed attempt's `@AfterEach` run before retrying, and it did not run `@BeforeEach` for the retry attempt, so browser/session state created during setup could be reused.

Restoring the old `InvocationInterceptor.proceed()` retry loop would violate JUnit's exactly-once invocation contract, which is the interceptor-chain failure fixed previously. This PR keeps that contract intact by scheduling retries after teardown and launching retries as separate JUnit executions.

## Retry Behavior
`retryMaximumNumberOfAttempts` is the number of additional attempts after the original failure. When a test method or soft verification fails and retries remain, SHAFT stores the failure in the method-scoped extension store and lets JUnit finish the original lifecycle. After user `@AfterEach` completes, SHAFT launches the retry against the original JUnit unique id with parallel execution disabled.

Each retry attempt receives normal JUnit setup/test/teardown behavior. Retry failures are rethrown inside the nested attempt so the retry summary sees the real outcome. If the retry budget is exhausted, SHAFT rethrows the last retry failure to the original JUnit run.

## Validation
- Reproduced the bug first with the lifecycle regression: one setup call instead of two under the old implementation.
- `mvn -pl shaft-engine '-Dtest=com.shaft.listeners.JunitExtensionLifecycleTest' '-DskipTestNG' '-DforkCount=1' '-DreuseForks=false' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test`
  - Surefire XML: 8 tests, 0 failures, 0 errors, 0 skipped.
  - Latest Allure result files for the 8 test methods all passed.
- `mvn -pl shaft-engine '-DskipTests' '-DskipITs' package`
- `mvn -pl shaft-engine '-DskipTests' '-DskipITs' test-compile` after final import cleanup.
- `graphify update .` refreshed the engine graph; HTML visualization was skipped because the graph exceeds the 5,000-node visualization limit.

Fixes #3100
