### PR TITLE
Add deterministic Capture generated-code review

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -40,6 +40,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -61,6 +62,9 @@ public final class CaptureGenerator {
     private static final Pattern NAMED_SECRET = Pattern.compile(
             "(?i)(?:password|authorization|cookie|api[-_]?key|access[-_]?token)"
                     + "\\s*[:=]\\s*[\"']?[^\\s\"']{6,}");
+    private static final Pattern INDEXED_LOCATOR = Pattern.compile("\\[\\d+]|:nth-(?:child|of-type)\\(");
+    private static final Pattern EVIDENCE_ID = Pattern.compile(
+            "\\b(?:event-\\d+|checkpoint-[A-Za-z0-9._-]+|action-\\d+)\\b");
     private static final ObjectMapper JSON = new ObjectMapper()
             .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
     private static final DefaultPrettyPrinter PRINTER = printer();
@@ -360,8 +364,12 @@ public final class CaptureGenerator {
                         + selected.strategy() + " locator has score "
                         + target.selection().selected().score() + ".");
             }
+            brittleLocatorWarning(target).ifPresent(warnings::add);
         }
         DataPlan data = data(session, sessionPath, required, unsupported);
+        warnings.addAll(missingAssertionWarnings(session, verificationSequences));
+        warnings.addAll(waitReviewWarnings(session.events()));
+        warnings.addAll(testDataReviewWarnings(data.references()));
         if (session.status() != CaptureSession.SessionStatus.COMPLETED) {
             warnings.add("The source Capture session is incomplete.");
         }
@@ -474,6 +482,113 @@ public final class CaptureGenerator {
                 && extensionText(context, "attributeName").isBlank()) {
             unsupported.add(eventId + ": ATTRIBUTE_EQUALS requires context.extensions.attributeName.");
         }
+    }
+
+    private static Optional<String> brittleLocatorWarning(TargetPlan target) {
+        LocatorCandidate candidate = target.selection().selected().candidate();
+        String expression = candidate.expression();
+        boolean xpath = candidate.strategy() == LocatorCandidate.LocatorStrategy.XPATH;
+        boolean brittle = (xpath && isAbsoluteXpath(expression)) || INDEXED_LOCATOR.matcher(expression).find();
+        if (!brittle) {
+            return Optional.empty();
+        }
+        String evidence = String.join(",", target.eventIds());
+        String summary = "Brittle " + candidate.strategy() + " locator selected for "
+                + target.logicalElementId() + ": " + expression + ".";
+        return Optional.of(reviewWarning(
+                "LOCATOR",
+                "WARNING",
+                evidence.isBlank() ? target.logicalElementId() : evidence,
+                summary,
+                semanticLocatorRecommendation(target.target())));
+    }
+
+    private static List<String> missingAssertionWarnings(CaptureSession session, Set<Long> verificationSequences) {
+        Set<Long> assertionSequences = new HashSet<>(verificationSequences);
+        session.checkpoints().stream()
+                .filter(checkpoint -> checkpoint.kind() == Checkpoint.CheckpointKind.ASSERTION)
+                .map(Checkpoint::sequence)
+                .forEach(assertionSequences::add);
+        List<String> warnings = new ArrayList<>();
+        for (CaptureEvent event : session.events()) {
+            if (!needsPostActionAssertion(event) || hasLaterAssertion(event.context().sequence(), assertionSequences)) {
+                continue;
+            }
+            warnings.add(reviewWarning(
+                    "ASSERTION",
+                    "WARNING",
+                    eventId(event),
+                    "No assertion or ASSERTION checkpoint follows a navigation or form-submission action.",
+                    "Record a verification for the post-action page state."));
+        }
+        return warnings;
+    }
+
+    private static boolean hasLaterAssertion(long sequence, Set<Long> assertionSequences) {
+        return assertionSequences.stream().anyMatch(assertion -> assertion > sequence);
+    }
+
+    private static boolean needsPostActionAssertion(CaptureEvent event) {
+        if (event instanceof CaptureEvent.NavigationEvent) {
+            return true;
+        }
+        if (!(event instanceof CaptureEvent.ClickEvent)) {
+            return false;
+        }
+        return target(event).map(CaptureGenerator::looksLikeFormSubmission).orElse(false);
+    }
+
+    private static boolean looksLikeFormSubmission(ElementSnapshot target) {
+        String type = target.normalizedAttributes().getOrDefault("type", "");
+        String text = (target.accessibleName() + " " + target.label() + " "
+                + target.normalizedAttributes().getOrDefault("value", "")).toLowerCase(Locale.ROOT);
+        return "submit".equalsIgnoreCase(type)
+                || text.contains("submit")
+                || text.contains("pay")
+                || text.contains("checkout")
+                || text.contains("place order")
+                || text.contains("confirm")
+                || text.contains("sign in")
+                || text.contains("log in")
+                || text.contains("continue");
+    }
+
+    private static List<String> waitReviewWarnings(List<CaptureEvent> events) {
+        List<String> warnings = new ArrayList<>();
+        for (CaptureEvent event : events) {
+            if (event instanceof CaptureEvent.WaitEvent value
+                    && value.condition() == CaptureEvent.WaitCondition.FIXED_DURATION) {
+                warnings.add(reviewWarning(
+                        "WAIT",
+                        "WARNING",
+                        eventId(event),
+                        "Generated replay uses a fixed-duration wait of " + value.timeout().toMillis() + " ms.",
+                        "Replace it with a SHAFT action, wait condition, or assertion tied to page state."));
+            }
+        }
+        return warnings;
+    }
+
+    private static List<String> testDataReviewWarnings(Map<String, ExternalTestDataReference> references) {
+        List<String> warnings = new ArrayList<>();
+        for (ExternalTestDataReference reference : references.values()) {
+            if (reference.source() == ExternalTestDataReference.DataSource.JSON
+                    && isSecret(reference)) {
+                warnings.add(reviewWarning(
+                        "TEST_DATA",
+                        "WARNING",
+                        reference.id(),
+                        "Sensitive data reference " + reference.id()
+                                + " is written to generated JSON test data.",
+                        "Use an environment variable, secret provider, or masked fixture before committing."));
+            }
+        }
+        return warnings;
+    }
+
+    private static boolean isAbsoluteXpath(String value) {
+        String locator = value == null ? "" : value.trim();
+        return (locator.startsWith("/") && !locator.startsWith("//")) || locator.startsWith("(/");
     }
 
     private static DataPlan data(
@@ -1093,10 +1208,19 @@ public final class CaptureGenerator {
                 state.flaky().stream().distinct().sorted().toList(),
                 state.fallback().stream().distinct().sorted().toList(),
                 state.required().stream().distinct().sorted().toList(),
-                state.warnings().stream().distinct().sorted().toList(),
+                reportWarnings(paths, state, replay),
                 compilation,
                 replay,
                 enrichment);
+    }
+
+    private static List<String> reportWarnings(
+            ArtifactPaths paths,
+            GenerationState state,
+            CaptureGenerationReport.Validation replay) {
+        List<String> warnings = new ArrayList<>(state.warnings());
+        warnings.addAll(replayReviewWarnings(paths.root(), paths.source(), replay));
+        return warnings.stream().distinct().sorted().toList();
     }
 
     private static void validateOutputs(
@@ -1180,6 +1304,7 @@ public final class CaptureGenerator {
         risks.addAll(report.flakySteps());
         risks.addAll(report.fallbackLocators());
         risks.addAll(report.warnings());
+        List<CaptureReviewFinding> findings = reviewFindings(report.warnings());
 
         List<String> suggestions = new ArrayList<>();
         if (!report.unsupportedEvents().isEmpty()) {
@@ -1191,6 +1316,9 @@ public final class CaptureGenerator {
         if (!report.flakySteps().isEmpty() || !report.fallbackLocators().isEmpty()) {
             suggestions.add("Review weak locator and replay-risk diagnostics.");
         }
+        if (!findings.isEmpty()) {
+            suggestions.add("Resolve deterministic generated-code review findings before committing the test.");
+        }
         if (suggestions.isEmpty()) {
             suggestions.add("Generated test is ready for review.");
         }
@@ -1199,13 +1327,15 @@ public final class CaptureGenerator {
                 - blockers.size() * 25
                 - report.flakySteps().size() * 10
                 - report.fallbackLocators().size() * 5
-                - report.warnings().size() * 5;
+                - report.warnings().size() * 5
+                - findings.size() * 5;
         return new CaptureReview(
                 CaptureReview.CURRENT_SCHEMA_VERSION,
                 report.sessionId(),
                 score,
                 blockers.stream().distinct().sorted().toList(),
                 risks.stream().distinct().sorted().toList(),
+                findings,
                 suggestions,
                 report.enrichment().provider());
     }
@@ -1217,6 +1347,184 @@ public final class CaptureGenerator {
         if (validation.status() == CaptureGenerationReport.Validation.ValidationStatus.FAILED) {
             blockers.add(label + ": " + String.join("; ", validation.diagnostics()));
         }
+    }
+
+    private static List<String> replayReviewWarnings(
+            Path outputRoot,
+            Path sourcePath,
+            CaptureGenerationReport.Validation replay) {
+        if (replay.status() != CaptureGenerationReport.Validation.ValidationStatus.FAILED) {
+            return List.of();
+        }
+        Path traceRoot = outputRoot.resolve("target/shaft-traces").toAbsolutePath().normalize();
+        if (!Files.isDirectory(traceRoot)) {
+            return List.of();
+        }
+        try (java.util.stream.Stream<Path> paths = Files.walk(traceRoot, 4)) {
+            List<String> warnings = new ArrayList<>();
+            for (Path trace : paths
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName() != null
+                            && "shaft-trace.json".equals(path.getFileName().toString()))
+                    .sorted(Comparator.comparing(Path::toString))
+                    .toList()) {
+                warnings.addAll(traceReviewWarnings(sourcePath, trace));
+            }
+            return warnings.stream().distinct().toList();
+        } catch (IOException exception) {
+            return List.of();
+        }
+    }
+
+    private static List<String> traceReviewWarnings(Path sourcePath, Path tracePath) {
+        try {
+            JsonNode trace = JSON.readTree(Files.readString(tracePath, StandardCharsets.UTF_8));
+            List<String> warnings = new ArrayList<>();
+            failedAction(trace.path("actions")).ifPresent(action -> warnings.add(reviewWarning(
+                    "REPLAY_TRACE",
+                    "ERROR",
+                    "trace action " + text(action.path("id")),
+                    "Replay failure maps to generated step " + sourceStep(sourcePath, trace.path("source"))
+                            + " and trace action " + text(action.path("id")) + " "
+                            + text(action.path("name")) + " using " + text(action.path("locator")) + ".",
+                    "Inspect the mapped generated step and trace action before committing the replay.")));
+            warnings.addAll(networkDependencyWarnings(trace.path("network")));
+            return warnings;
+        } catch (IOException | RuntimeException exception) {
+            return List.of();
+        }
+    }
+
+    private static Optional<JsonNode> failedAction(JsonNode actions) {
+        if (!actions.isArray()) {
+            return Optional.empty();
+        }
+        for (JsonNode action : actions) {
+            if ("failed".equalsIgnoreCase(text(action.path("status")))) {
+                return Optional.of(action);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static List<String> networkDependencyWarnings(JsonNode network) {
+        if (!network.isArray()) {
+            return List.of();
+        }
+        List<String> warnings = new ArrayList<>();
+        for (JsonNode entry : network) {
+            int status = entry.path("status").asInt(-1);
+            String failure = text(entry.path("failureReason"));
+            if (status >= 400 || status <= 0 || !failure.isBlank()) {
+                String detail = (text(entry.path("method")) + " " + status + " " + text(entry.path("url"))
+                        + (failure.isBlank() ? "" : " " + failure)).trim();
+                warnings.add(reviewWarning(
+                        "NETWORK_DEPENDENCY",
+                        "WARNING",
+                        "network",
+                        "Network/API dependency failed during replay: " + detail + ".",
+                        "Record/replay this dependency through #3065 HTTP contract replay."));
+            }
+        }
+        return warnings;
+    }
+
+    private static String sourceStep(Path sourcePath, JsonNode source) {
+        String lineText = text(source.path("line"));
+        String snippet = text(source.path("snippet"));
+        if (!lineText.isBlank() && Files.isRegularFile(sourcePath)) {
+            try {
+                int line = Integer.parseInt(lineText);
+                List<String> lines = Files.readAllLines(sourcePath, StandardCharsets.UTF_8);
+                if (line > 0 && line <= lines.size()) {
+                    snippet = lines.get(line - 1).trim();
+                }
+            } catch (IOException | NumberFormatException ignored) {
+                // Trace source snippets are best-effort.
+            }
+        }
+        return lineText.isBlank()
+                ? safeReviewText(snippet)
+                : "line " + lineText + (snippet.isBlank() ? "" : " (" + safeReviewText(snippet) + ")");
+    }
+
+    private static List<CaptureReviewFinding> reviewFindings(List<String> warnings) {
+        List<CaptureReviewFinding> findings = new ArrayList<>();
+        for (String warning : warnings) {
+            if (warning == null || !warning.startsWith("review/")) {
+                continue;
+            }
+            int space = warning.indexOf(' ');
+            if (space < 0) {
+                continue;
+            }
+            String[] header = warning.substring("review/".length(), space).split("/");
+            String category = header.length > 0 ? header[0] : "";
+            String severity = header.length > 1 ? header[1] : "WARNING";
+            String body = warning.substring(space + 1);
+            int colon = body.indexOf(':');
+            if (category.isBlank() || colon < 0) {
+                continue;
+            }
+            String evidence = body.substring(0, colon).trim();
+            String summary = body.substring(colon + 1).trim();
+            String recommendation = "";
+            int recommendationIndex = summary.indexOf(" Recommendation: ");
+            if (recommendationIndex >= 0) {
+                recommendation = summary.substring(recommendationIndex + " Recommendation: ".length()).trim();
+                summary = summary.substring(0, recommendationIndex).trim();
+            }
+            findings.add(new CaptureReviewFinding(
+                    category.toLowerCase(Locale.ROOT) + "-" + (findings.size() + 1),
+                    category,
+                    severity,
+                    summary,
+                    evidenceIds(evidence),
+                    recommendation));
+        }
+        return List.copyOf(findings);
+    }
+
+    private static List<String> evidenceIds(String evidence) {
+        List<String> ids = new ArrayList<>();
+        Matcher matcher = EVIDENCE_ID.matcher(evidence == null ? "" : evidence);
+        while (matcher.find()) {
+            ids.add(matcher.group());
+        }
+        return ids.stream().distinct().toList();
+    }
+
+    private static String semanticLocatorRecommendation(ElementSnapshot target) {
+        String semantic = target.accessibleName().isBlank() ? target.label() : target.accessibleName();
+        if (!semantic.isBlank()) {
+            return "Prefer semantic locator text \"" + safeReviewText(semantic) + "\" when unique.";
+        }
+        if (target.normalizedAttributes().containsKey("data-testid")) {
+            return "Prefer the captured data-testid locator when unique.";
+        }
+        return "Prefer role, label, test-id, or stable CSS locator evidence.";
+    }
+
+    private static String reviewWarning(
+            String category,
+            String severity,
+            String evidence,
+            String summary,
+            String recommendation) {
+        return "review/" + safeReviewText(category).toUpperCase(Locale.ROOT)
+                + "/" + safeReviewText(severity).toUpperCase(Locale.ROOT)
+                + " " + safeReviewText(evidence)
+                + ": " + safeReviewText(summary)
+                + " Recommendation: " + safeReviewText(recommendation);
+    }
+
+    private static String text(JsonNode node) {
+        return node == null || node.isMissingNode() || node.isNull() ? "" : node.asText("");
+    }
+
+    private static String safeReviewText(String value) {
+        String normalized = value == null ? "" : value.replaceAll("\\s+", " ").trim();
+        return normalized.length() <= 240 ? normalized : normalized.substring(0, 237) + "...";
     }
 
     private static List<String> privacyFindings(String content) {

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureReview.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureReview.java
@@ -10,6 +10,7 @@ import java.util.List;
  * @param readinessScore bounded readiness score from 0 to 100
  * @param blockers generation blockers that must be fixed first
  * @param risks replay or locator risks worth reviewing
+ * @param findings deterministic generated-code review findings
  * @param suggestions deterministic next actions
  * @param provider provider identifier, or {@code none} for deterministic review
  */
@@ -19,6 +20,7 @@ public record CaptureReview(
         int readinessScore,
         List<String> blockers,
         List<String> risks,
+        List<CaptureReviewFinding> findings,
         List<String> suggestions,
         String provider) {
     public static final String CURRENT_SCHEMA_VERSION = "1.0";
@@ -32,6 +34,7 @@ public record CaptureReview(
         readinessScore = Math.max(0, Math.min(100, readinessScore));
         blockers = blockers == null ? List.of() : List.copyOf(blockers);
         risks = risks == null ? List.of() : List.copyOf(risks);
+        findings = findings == null ? List.of() : List.copyOf(findings);
         suggestions = suggestions == null ? List.of() : List.copyOf(suggestions);
         provider = provider == null || provider.isBlank() ? "none" : provider;
     }

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureReviewFinding.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureReviewFinding.java
@@ -1,0 +1,37 @@
+package com.shaft.capture.generate;
+
+import java.util.List;
+
+/**
+ * One deterministic generated-code review finding.
+ *
+ * @param id stable finding identifier
+ * @param category review category
+ * @param severity review severity
+ * @param summary safe finding summary
+ * @param evidenceIds related capture events or trace actions
+ * @param recommendation deterministic remediation
+ */
+public record CaptureReviewFinding(
+        String id,
+        String category,
+        String severity,
+        String summary,
+        List<String> evidenceIds,
+        String recommendation) {
+    /**
+     * Creates an immutable review finding.
+     */
+    public CaptureReviewFinding {
+        id = text(id);
+        category = text(category);
+        severity = text(severity).isBlank() ? "WARNING" : text(severity);
+        summary = text(summary);
+        evidenceIds = evidenceIds == null ? List.of() : List.copyOf(evidenceIds);
+        recommendation = text(recommendation);
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -6,6 +6,9 @@ import com.shaft.capture.CaptureFixtures;
 import com.shaft.capture.format.CaptureJsonCodec;
 import com.shaft.capture.model.CaptureEvent;
 import com.shaft.capture.model.CaptureSession;
+import com.shaft.capture.model.ElementSnapshot;
+import com.shaft.capture.model.ExternalTestDataReference;
+import com.shaft.capture.model.LocatorCandidate;
 import com.shaft.pilot.ai.AiResponse;
 import com.shaft.pilot.ai.AiUsage;
 import com.shaft.pilot.ai.ApprovalPolicy;
@@ -148,6 +151,168 @@ class CaptureGeneratorTest {
         assertTrue(source.contains("driver.element().click(USERNAME_INPUT_LOCATOR);"));
         assertFalse(source.contains("DriverFactory"));
         assertFalse(source.contains("ExpectedConditions"));
+    }
+
+    @Test
+    void deterministicReviewFlagsGeneratedCodeRisks() throws Exception {
+        ExternalTestDataReference card = new ExternalTestDataReference(
+                "data.card",
+                "card number",
+                ExternalTestDataReference.DataSource.JSON,
+                "capture-data.json",
+                "/values/data.card",
+                ExternalTestDataReference.DataClassification.SENSITIVE);
+        ElementSnapshot cardInput = new ElementSnapshot(
+                "card-input",
+                "input",
+                "textbox",
+                "Card number",
+                "Card number",
+                Map.of("name", "card"),
+                List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.XPATH,
+                        "/html/body/div[3]/form/input[1]", 1, true, false,
+                        java.util.Set.of(LocatorCandidate.LocatorSignal.POSITIONAL))),
+                true,
+                true,
+                false);
+        ElementSnapshot payButton = new ElementSnapshot(
+                "pay-button",
+                "button",
+                "button",
+                "Pay now",
+                "",
+                Map.of("type", "submit"),
+                List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.XPATH,
+                        "/html/body/div[3]/form/button[2]", 1, true, false,
+                        java.util.Set.of(LocatorCandidate.LocatorSignal.POSITIONAL))),
+                true,
+                true,
+                false);
+        CaptureSession reviewSession = new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "review-session",
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(5),
+                CaptureFixtures.browser(),
+                List.of(
+                        new CaptureEvent.NavigationEvent(CaptureFixtures.context(1),
+                                CaptureEvent.NavigationAction.OPEN, "https://shop.example/checkout"),
+                        new CaptureEvent.TypeEvent(CaptureFixtures.context(2), cardInput, card),
+                        new CaptureEvent.WaitEvent(CaptureFixtures.context(3),
+                                CaptureEvent.WaitCondition.FIXED_DURATION, Duration.ofSeconds(2), null, null),
+                        new CaptureEvent.ClickEvent(CaptureFixtures.context(4), payButton,
+                                CaptureEvent.MouseButton.PRIMARY, 1)),
+                List.of(),
+                List.of(card),
+                com.shaft.capture.model.RedactionSummary.empty(),
+                Map.of());
+        Path session = session(reviewSession);
+        ObjectNode root = JSON.createObjectNode();
+        root.put("schemaVersion", "1.0");
+        root.putObject("values").put("data.card", "test-card-value");
+        Files.writeString(temp.resolve("capture-data.json"),
+                JSON.writerWithDefaultPrettyPrinter().writeValueAsString(root), StandardCharsets.UTF_8);
+
+        CaptureGenerationResult result =
+                new CaptureGenerator().generate(request(session, temp.resolve("review")));
+
+        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        var review = JSON.readTree(result.reviewPath().toFile());
+        List<String> categories = new java.util.ArrayList<>();
+        review.path("findings").forEach(finding -> categories.add(finding.path("category").asText()));
+        assertTrue(categories.contains("LOCATOR"), review.toString());
+        assertTrue(categories.contains("ASSERTION"), review.toString());
+        assertTrue(categories.contains("WAIT"), review.toString());
+        assertTrue(categories.contains("TEST_DATA"), review.toString());
+        assertTrue(result.report().warnings().stream().anyMatch(warning -> warning.contains("review/LOCATOR")));
+    }
+
+    @Test
+    void deterministicReviewMapsReplayFailureTraceAndNetworkDependency() throws Exception {
+        Path session = session(new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "trace-review-session",
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(3),
+                CaptureFixtures.browser(),
+                List.of(
+                        new CaptureEvent.NavigationEvent(CaptureFixtures.context(1),
+                                CaptureEvent.NavigationAction.OPEN, "https://shop.example/checkout"),
+                        new CaptureEvent.ClickEvent(CaptureFixtures.context(2), CaptureFixtures.target(),
+                                CaptureEvent.MouseButton.PRIMARY, 1)),
+                List.of(),
+                List.of(),
+                com.shaft.capture.model.RedactionSummary.empty(),
+                Map.of()));
+        GeneratedTestValidator validator = new GeneratedTestValidator() {
+            @Override
+            public CaptureGenerationReport.Validation compile(Path source, Path classesDirectory) {
+                return new CaptureGenerationReport.Validation(
+                        CaptureGenerationReport.Validation.ValidationStatus.PASSED,
+                        List.of(),
+                        0);
+            }
+
+            @Override
+            public CaptureGenerationReport.Validation replay(
+                    String fullyQualifiedClassName,
+                    Path classesDirectory,
+                    Path resourcesDirectory,
+                    Path workDirectory,
+                    Duration timeout) {
+                Path trace = workDirectory.resolve("target/shaft-traces/trace-review/shaft-trace.json");
+                try {
+                    Files.createDirectories(trace.getParent());
+                    Files.writeString(trace, """
+                            {
+                              "schemaVersion": "1.0",
+                              "source": {
+                                "file": "src/test/java/generated/capture/TraceReviewTest.java",
+                                "line": "31",
+                                "snippet": "driver.element().click(USERNAME_INPUT_LOCATOR);"
+                              },
+                              "actions": [
+                                {"id": "action-2", "category": "element", "name": "CLICK", "status": "failed",
+                                 "locator": "By.xpath: /html/body/div[3]/form/button[2]",
+                                 "url": "https://shop.example/checkout", "message": "Click failed",
+                                 "exception": {"type": "org.openqa.selenium.NoSuchElementException", "message": "missing"},
+                                 "attachments": [], "metadata": {}}
+                              ],
+                              "network": [
+                                {"url": "https://shop.example/api/pay", "status": 500, "method": "POST"}
+                              ]
+                            }
+                            """, StandardCharsets.UTF_8);
+                } catch (java.io.IOException exception) {
+                    throw new IllegalStateException(exception);
+                }
+                return new CaptureGenerationReport.Validation(
+                        CaptureGenerationReport.Validation.ValidationStatus.FAILED,
+                        List.of("Replay produced 1 non-passing Allure result file(s)."),
+                        1);
+            }
+        };
+
+        CaptureGenerationResult result = new CaptureGenerator(
+                new CaptureJsonCodec(), new LocatorRanker(), validator, new CaptureEnrichmentService())
+                .generate(new CaptureGenerationRequest(
+                        session, temp.resolve("trace-review"), "generated.capture", "TraceReviewTest", false,
+                        true, true, Duration.ofMinutes(1),
+                        CaptureGenerationRequest.EnrichmentMode.NONE, null, false,
+                        ApprovalPolicy.denyAll()));
+
+        assertFalse(result.successful());
+        var review = JSON.readTree(result.reviewPath().toFile());
+        List<String> categories = new java.util.ArrayList<>();
+        review.path("findings").forEach(finding -> categories.add(finding.path("category").asText()));
+        assertTrue(categories.contains("REPLAY_TRACE"), review.toString());
+        assertTrue(categories.contains("NETWORK_DEPENDENCY"), review.toString());
+        assertTrue(result.report().warnings().stream()
+                .anyMatch(warning -> warning.contains("trace action action-2")), result.report().warnings().toString());
+        assertTrue(result.report().warnings().stream()
+                .anyMatch(warning -> warning.contains("#3065")), result.report().warnings().toString());
     }
 
     @Test

--- a/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java
@@ -1,5 +1,14 @@
 package com.shaft.mcp;
 
+import com.shaft.capture.format.CaptureJsonCodec;
+import com.shaft.capture.model.BrowserMetadata;
+import com.shaft.capture.model.CaptureEvent;
+import com.shaft.capture.model.CaptureSession;
+import com.shaft.capture.model.ElementSnapshot;
+import com.shaft.capture.model.EventContext;
+import com.shaft.capture.model.LocatorCandidate;
+import com.shaft.capture.model.PageContext;
+import com.shaft.capture.model.RedactionSummary;
 import com.shaft.capture.runtime.CaptureManager;
 import com.shaft.capture.runtime.CaptureStatus;
 import org.junit.jupiter.api.Test;
@@ -7,6 +16,10 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -83,6 +96,32 @@ class CaptureServiceTest {
         assertTrue(result.codeBlocks().stream()
                 .anyMatch(block -> block.id().equals("capture-pom-manual-mapping-warning")
                         && block.warnings().stream().anyMatch(message -> message.contains("manual mapping"))));
+    }
+
+    @Test
+    void codeBlocksToolReturnsDeterministicReviewWarnings() throws Exception {
+        Path session = temp.resolve("capture-review.json");
+        new CaptureJsonCodec().write(session, reviewWarningSession());
+
+        CaptureService service = service();
+        McpCaptureReplayResult result;
+        try {
+            result = service.codeBlocks(
+                    session.toString(),
+                    temp.resolve("generated-review").toString(),
+                    "generated.capture",
+                    "ReviewWarningTest",
+                    false,
+                    "driver");
+        } finally {
+            service.close();
+        }
+
+        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertTrue(result.warnings().stream().anyMatch(warning -> warning.contains("review/LOCATOR")),
+                result.warnings().toString());
+        assertTrue(result.warnings().stream().anyMatch(warning -> warning.contains("review/ASSERTION")),
+                result.warnings().toString());
     }
 
     @Test
@@ -251,6 +290,45 @@ class CaptureServiceTest {
             current = current.getParent();
         }
         throw new IllegalStateException("Repository root could not be resolved.");
+    }
+
+    private static CaptureSession reviewWarningSession() {
+        Instant started = Instant.parse("2026-01-02T03:04:05Z");
+        BrowserMetadata browser = new BrowserMetadata("chrome", "137", "Windows 11", "browser-1", Map.of());
+        PageContext page = new PageContext("https://shop.example/checkout", "Checkout", "window-1",
+                List.of(), 1280, 720);
+        ElementSnapshot pay = new ElementSnapshot(
+                "pay-button",
+                "button",
+                "button",
+                "Pay now",
+                "",
+                Map.of("type", "submit"),
+                List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.XPATH,
+                        "/html/body/div[3]/form/button[2]", 1, true, false,
+                        Set.of(LocatorCandidate.LocatorSignal.POSITIONAL))),
+                true,
+                true,
+                false);
+        EventContext navigation = new EventContext(1, started.plusSeconds(1), page,
+                EventContext.ReplayStatus.NOT_REPLAYED, List.of(), Map.of());
+        EventContext click = new EventContext(2, started.plusSeconds(2), page,
+                EventContext.ReplayStatus.NOT_REPLAYED, List.of(), Map.of());
+        return new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "mcp-review-session",
+                CaptureSession.SessionStatus.COMPLETED,
+                started,
+                started.plusSeconds(3),
+                browser,
+                List.of(
+                        new CaptureEvent.NavigationEvent(navigation,
+                                CaptureEvent.NavigationAction.OPEN, "https://shop.example/checkout"),
+                        new CaptureEvent.ClickEvent(click, pay, CaptureEvent.MouseButton.PRIMARY, 1)),
+                List.of(),
+                List.of(),
+                RedactionSummary.empty(),
+                Map.of());
     }
 
 }


### PR DESCRIPTION
## Summary
- Add deterministic Capture generated-code review findings for brittle/index-heavy locators, missing post-action assertions, fixed waits, and sensitive JSON-backed test data.
- Map failed replay trace evidence back to generated steps and failed trace actions when `shaft-trace.json` is present.
- Surface failing replay network/API dependencies as #3065 contract replay candidates through `McpCaptureReplayResult.warnings` and `capture-review.json` typed findings.

Fixes https://github.com/ShaftHQ/SHAFT_ENGINE/issues/3095
Docs PR: https://github.com/ShaftHQ/shafthq.github.io/pull/644

## Example output

`capture_code_blocks` / `capture_generate_replay` now return review warnings such as:

```text
review/LOCATOR/WARNING event-4: Brittle XPATH locator selected for pay-button: /html/body/div[3]/form/button[2]. Recommendation: Prefer semantic locator text "Pay now" when unique.
```

The generated `capture-review.json` includes typed findings:

```json
{
  "category": "REPLAY_TRACE",
  "severity": "ERROR",
  "summary": "Replay failure maps to generated step line 31 and trace action action-2 CLICK using By.xpath: /html/body/div[3]/form/button[2].",
  "evidenceIds": ["action-2"],
  "recommendation": "Inspect the mapped generated step and trace action before committing the replay."
}
```

## Validation
- `py -3 scripts/ci/validate_agent_setup.py`
- Red first: `mvn -pl shaft-capture '-Dtest=CaptureGeneratorTest#deterministicReviewFlagsGeneratedCodeRisks+deterministicReviewMapsReplayFailureTraceAndNetworkDependency' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test` failed before implementation for missing findings/trace mappings.
- `mvn -pl shaft-capture '-Dtest=CaptureGeneratorTest#deterministicReviewFlagsGeneratedCodeRisks+deterministicReviewMapsReplayFailureTraceAndNetworkDependency' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test`
- `mvn -pl shaft-mcp -am '-Dtest=CaptureServiceTest#codeBlocksToolReturnsDeterministicReviewWarnings' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test`
- `mvn -pl shaft-capture '-Dtest=CaptureGeneratorTest' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test`
- `mvn -pl shaft-mcp -am '-Dtest=CaptureServiceTest' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test`
- `mvn -pl shaft-mcp -am '-DskipTests' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' package`
- `mvn -pl shaft-capture '-DskipTests' compile`

## Notes
- `mvn -pl shaft-mcp ...` without `-am` failed because the installed local `shaft-engine` artifact is older than current `origin/main`; rerun with `-am` passed.
- Graphify refresh attempted with `graphify . --update`, but it is blocked in this environment because no semantic extraction backend key is configured (`GEMINI_API_KEY`, `GOOGLE_API_KEY`, etc.).
- No screenshots: this PR changes JSON/report data, not rendered UI.
