### PR TITLE
[codex] Respect disabled Allure auto-open

### DIFF
--- a/.memory/events.jsonl
+++ b/.memory/events.jsonl
@@ -91,3 +91,4 @@
 {"actor":"agent","event":"memory.created","id":"workflow.include-examples-or-screenshots-in-prs","timestamp":"2026-06-26T13:02:36+03:00"}
 {"actor":"agent","event":"memory.updated","id":"workflow.include-examples-or-screenshots-in-prs","timestamp":"2026-06-26T16:17:32+03:00"}
 {"actor":"agent","event":"memory.created","id":"workflow.include-concrete-evidence-in-shaft-pr-bodies","timestamp":"2026-06-26T18:36:57+03:00"}
+{"actor":"agent","event":"memory.created","id":"workflow.resolve-pr-base-conflicts-before-opening-prs","timestamp":"2026-06-27T09:00:09+03:00"}

--- a/.memory/memory/workflows/resolve-pr-base-conflicts-before-opening-prs.json
+++ b/.memory/memory/workflows/resolve-pr-base-conflicts-before-opening-prs.json
@@ -1,0 +1,33 @@
+{
+  "body_path": "memory/workflows/resolve-pr-base-conflicts-before-opening-prs.md",
+  "content_hash": "sha256:d1977758303cf6392e58cf2507f1d8cef955d865a00c71d145b76b5cb4d71d0f",
+  "created_at": "2026-06-27T09:00:09+03:00",
+  "evidence": [],
+  "facets": {
+    "applies_to": [
+      "AGENTS.md",
+      ".github/pull_request_template.md"
+    ],
+    "category": "workflow"
+  },
+  "id": "workflow.resolve-pr-base-conflicts-before-opening-prs",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Remember PR conflict workflow"
+  },
+  "status": "active",
+  "tags": [
+    "git",
+    "pr",
+    "workflow"
+  ],
+  "title": "Resolve PR base conflicts before opening PRs",
+  "type": "workflow",
+  "updated_at": "2026-06-27T09:00:09+03:00"
+}

--- a/.memory/memory/workflows/resolve-pr-base-conflicts-before-opening-prs.md
+++ b/.memory/memory/workflows/resolve-pr-base-conflicts-before-opening-prs.md
@@ -1,0 +1,1 @@
+Before opening a SHAFT_ENGINE PR, fetch/prune and verify the branch is based on the latest origin/main. If origin/main moved, rebase or merge locally, resolve all conflicts in the local checkout, rerun the relevant validation after conflict resolution, then push/open the PR. Do not rely on GitHub to surface or resolve merge conflicts after the PR is opened.

--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -837,6 +837,12 @@
   "835": "Community 835",
   "836": "Community 836",
   "837": "Community 837",
+  "838": "Community 838",
+  "839": "Community 839",
+  "840": "Community 840",
+  "841": "Community 841",
   "842": "Community 842",
-  "843": "Community 843"
+  "843": "Community 843",
+  "844": "Community 844",
+  "845": "Community 845"
 }

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
-# Graph Report - SHAFT_ENGINE_codex_ui_design_skill  (2026-06-27)
+# Graph Report - SHAFT_ENGINE_graphify_tmp_allure_conflict  (2026-06-27)
 
 ## Corpus Check
-- 1081 files · ~675,128 words
+- 1081 files · ~675,186 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 15931 nodes · 42635 edges · 840 communities (740 shown, 100 thin omitted)
+- 15932 nodes · 42637 edges · 846 communities (755 shown, 91 thin omitted)
 - Extraction: 81% EXTRACTED · 19% INFERRED · 0% AMBIGUOUS · INFERRED: 8203 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `418eec9b`
+- Built from commit: `171b362b`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -734,7 +734,13 @@
 - [[_COMMUNITY_Community 835|Community 835]]
 - [[_COMMUNITY_Community 836|Community 836]]
 - [[_COMMUNITY_Community 837|Community 837]]
+- [[_COMMUNITY_Community 838|Community 838]]
+- [[_COMMUNITY_Community 839|Community 839]]
+- [[_COMMUNITY_Community 840|Community 840]]
+- [[_COMMUNITY_Community 841|Community 841]]
 - [[_COMMUNITY_Community 842|Community 842]]
+- [[_COMMUNITY_Community 844|Community 844]]
+- [[_COMMUNITY_Community 845|Community 845]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `SHAFT` - 311 edges
@@ -763,11 +769,11 @@
 ## Import Cycles
 - None detected.
 
-## Communities (840 total, 100 thin omitted)
+## Communities (846 total, 91 thin omitted)
 
 ### Community 0 - "Community 0"
 Cohesion: 0.04
-Nodes (8): RestActionsComprehensiveTests, API, ComparisonType, Deprecated, InputStream, SuppressWarnings, BeforeMethod, Test
+Nodes (7): RestActionsComprehensiveTests, ComparisonType, Deprecated, InputStream, SuppressWarnings, BeforeMethod, Test
 
 ### Community 1 - "Community 1"
 Cohesion: 0.05
@@ -782,8 +788,8 @@ Cohesion: 0.12
 Nodes (16): LocatorAssertions, Outcome, PageAssertions, LinkedHashMap, List, Locator, Object, Override (+8 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.07
-Nodes (6): Pilot, SetProperty, DefaultValue, Key, SetProperty, String
+Cohesion: 0.13
+Nodes (4): Pilot, DefaultValue, Key, SetProperty
 
 ### Community 5 - "Community 5"
 Cohesion: 0.13
@@ -794,16 +800,20 @@ Cohesion: 0.06
 Nodes (14): CSVFileManager, CSVFileManagerTest, List, Map, String, BeforeMethod, Test, AfterMethod (+6 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.08
-Nodes (27): LocatorOperation, MobileService, McpMobileAccessibilityTree, McpMobileContextSnapshot, McpMobileSessionResult, BrowserType, By, Class (+19 more)
+Cohesion: 0.07
+Nodes (29): KeyboardKeys, LocatorOperation, MobileService, McpMobileAccessibilityTree, McpMobileContextSnapshot, McpMobileSessionResult, BrowserType, By (+21 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.07
-Nodes (23): BrowserStackSdkHelper, BrowserStackSdkTests, List, Map, Object, String, AfterMethod, BeforeMethod (+15 more)
+Cohesion: 0.17
+Nodes (8): BrowserStackSdkTests, AfterMethod, BeforeMethod, Map, Object, String, SuppressWarnings, Test
 
 ### Community 9 - "Community 9"
-Cohesion: 0.14
-Nodes (8): LocatorHealthReporter, LocatorStats, LocatorStats, AssertionError, By, List, ObjectNode, String
+Cohesion: 0.07
+Nodes (16): CheckpointCounter, LocatorHealthReporter, LocatorStats, LocatorStats, AssertionError, By, List, ObjectNode (+8 more)
+
+### Community 10 - "Community 10"
+Cohesion: 0.07
+Nodes (7): Boolean, NumbersComparativeRelation, Object, String, Test, JavaHelper, JavaHelperUnitTest
 
 ### Community 11 - "Community 11"
 Cohesion: 0.09
@@ -814,28 +824,24 @@ Cohesion: 0.07
 Nodes (11): BrowserStack, SetProperty, DefaultValue, Key, SetProperty, String, AfterMethod, Object (+3 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.06
-Nodes (20): DataType, FileReader, JSONFileManager, JSONFileManagerTestAccessor, JSONFileManagerTests, List, Map, Object (+12 more)
+Cohesion: 0.10
+Nodes (10): DataType, JSONFileManager, List, Map, Object, String, AfterMethod, BeforeClass (+2 more)
 
 ### Community 14 - "Community 14"
 Cohesion: 0.09
 Nodes (30): dataString(), E, LocatorSignal, empty(), merge(), MouseButton, CaptureEventPipeline, SafePage (+22 more)
 
-### Community 15 - "Community 15"
-Cohesion: 0.07
-Nodes (14): requestTarget(), ShaftRestAssuredFilter, ApiEvidenceLabels, FilterableResponseSpecification, FilterContext, JsonElement, FilterableRequestSpecification, Object (+6 more)
-
 ### Community 16 - "Community 16"
 Cohesion: 0.08
-Nodes (7): Deprecated, AfterMethod, Path, String, SuppressWarnings, Test, TerminalActionsUnitTest
+Nodes (6): AfterMethod, Path, String, SuppressWarnings, Test, TerminalActionsUnitTest
 
 ### Community 17 - "Community 17"
-Cohesion: 0.08
-Nodes (16): AsyncAppender, ReportManagerHelper, TestCaseStarted, RunType, Boolean, ByteArrayOutputStream, CheckpointStatus, InputStream (+8 more)
+Cohesion: 0.09
+Nodes (14): AsyncAppender, ReportManagerHelper, TestCaseStarted, ByteArrayOutputStream, CheckpointStatus, InputStream, Level, List (+6 more)
 
 ### Community 18 - "Community 18"
 Cohesion: 0.08
-Nodes (22): FileActions, FileActionsCoverageUnitTest, ReportHelper, JarEntry, Boolean, Collection, Exception, File (+14 more)
+Nodes (20): FileActions, FileActionsCoverageUnitTest, ReportHelper, Boolean, Collection, Exception, File, String (+12 more)
 
 ### Community 19 - "Community 19"
 Cohesion: 0.11
@@ -846,12 +852,12 @@ Cohesion: 0.13
 Nodes (6): Healing, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 21 - "Community 21"
-Cohesion: 0.13
-Nodes (14): WebDriverListener, InvocationTargetException, Navigation, Alert, By, Method, Object, String (+6 more)
+Cohesion: 0.09
+Nodes (18): BrowserStackModuleTest, WebDriverListener, InvocationTargetException, JsonSchemaValidatorTest, Navigation, Test, Alert, By (+10 more)
 
 ### Community 22 - "Community 22"
-Cohesion: 0.07
-Nodes (24): JSONValidationsBuilder, NativeValidationsBuilder, AssertEqualsTests, VerifyEqualsTests, NativeValidationsBuilder, Object, RestValidationsBuilder, ValidationsExecutor (+16 more)
+Cohesion: 0.12
+Nodes (12): TextLanguageValidationsBuilder, AssertEqualsTests, VerifyEqualsTests, NativeValidationsBuilder, String, ValidationsExecutor, BeforeMethod, Test (+4 more)
 
 ### Community 23 - "Community 23"
 Cohesion: 0.09
@@ -862,39 +868,39 @@ Cohesion: 0.08
 Nodes (10): AllureManager, BooleanSupplier, ArrayNode, Future, InputStream, List, ObjectNode, Path (+2 more)
 
 ### Community 25 - "Community 25"
-Cohesion: 0.07
-Nodes (32): AllureVerdict, DoctorRepairPublicationRequest, ExistingPullRequest, GuardedPatch, Operation, PatchManifestEntry, changedSince(), DoctorRepairService (+24 more)
+Cohesion: 0.11
+Nodes (24): AllureVerdict, DoctorRepairPublicationRequest, ExistingPullRequest, Operation, PatchManifestEntry, changedSince(), DoctorRepairService, RepairGuard (+16 more)
 
 ### Community 26 - "Community 26"
-Cohesion: 0.07
-Nodes (15): DriverFactoryHelperCoverageUnitTest, TestableDriverFactoryHelper, OptionsManager, AfterMethod, AtomicInteger, CountDownLatch, DriverFactoryHelper, DriverType (+7 more)
+Cohesion: 0.08
+Nodes (14): DriverFactoryHelperCoverageUnitTest, TestableDriverFactoryHelper, AfterMethod, AtomicInteger, CountDownLatch, DriverFactoryHelper, DriverType, Method (+6 more)
 
 ### Community 27 - "Community 27"
 Cohesion: 0.08
 Nodes (4): ValidationTests, AfterMethod, BeforeMethod, Test
 
 ### Community 28 - "Community 28"
-Cohesion: 0.08
-Nodes (15): PropertyFileManager, PropertyFileManagerInternalUnitTest, File, HashMap, Map, MutableCapabilities, Object, Properties (+7 more)
+Cohesion: 0.14
+Nodes (10): PropertyFileManager, PropertyFileManagerInternalUnitTest, File, HashMap, Map, Object, Properties, String (+2 more)
 
 ### Community 29 - "Community 29"
-Cohesion: 0.10
-Nodes (18): AccessibilityConfig, AccessibilityHelper, AccessibilityResult, AxeBuilder, AccessibilityResult, Integer, JSONArray, JSONObject (+10 more)
+Cohesion: 0.12
+Nodes (14): AccessibilityConfig, AccessibilityHelper, AccessibilityResult, AccessibilityResult, JSONArray, JSONObject, List, Object (+6 more)
 
 ### Community 30 - "Community 30"
-Cohesion: 0.11
-Nodes (17): RequestBuilderPerformanceTest, RequestBuilderTests, AuthenticationType, RestAssuredConfig, ContentType, ParametersType, AfterMethod, RequestType (+9 more)
+Cohesion: 0.13
+Nodes (15): RequestBuilderPerformanceTest, RequestBuilderTests, ContentType, ParametersType, AfterMethod, RequestType, RestActions, String (+7 more)
 
 ### Community 31 - "Community 31"
-Cohesion: 0.11
-Nodes (15): ChannelSftp, TerminalActions, ProcessBuilder, SftpTransferDirection, Boolean, BufferedReader, Exception, Future (+7 more)
+Cohesion: 0.10
+Nodes (16): ChannelSftp, TerminalActions, ProcessBuilder, SftpTransferDirection, Boolean, BufferedReader, Deprecated, Exception (+8 more)
 
 ### Community 32 - "Community 32"
-Cohesion: 0.08
-Nodes (11): EngineServiceRuntimePathTest, AfterMethod, Class, Object, Path, String, Test, AfterEach (+3 more)
+Cohesion: 0.06
+Nodes (21): EngineService, EngineServiceRuntimePathTest, PostConstruct, Override, BeforeMethod, AfterMethod, Class, Object (+13 more)
 
 ### Community 33 - "Community 33"
-Cohesion: 0.11
+Cohesion: 0.12
 Nodes (11): TestNGListenerHelper, Browser, ISuite, ITestContext, ITestNGMethod, ITestResult, List, Method (+3 more)
 
 ### Community 34 - "Community 34"
@@ -902,8 +908,8 @@ Cohesion: 0.08
 Nodes (27): DeterministicNaturalActionPlanner, unsupported(), NaturalActionPlannerRegistry, PilotNaturalActionPlanner, NaturalActionKind, NaturalActionPlanner, NaturalActionStep, List (+19 more)
 
 ### Community 35 - "Community 35"
-Cohesion: 0.08
-Nodes (26): BrowserStackModuleTest, Constructor, IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor (+18 more)
+Cohesion: 0.07
+Nodes (27): Constructor, IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, StatusIcon() (+19 more)
 
 ### Community 36 - "Community 36"
 Cohesion: 0.07
@@ -922,16 +928,16 @@ Cohesion: 0.09
 Nodes (11): AfterMethod, BeforeMethod, Class, List, Object, Path, String, T (+3 more)
 
 ### Community 40 - "Community 40"
-Cohesion: 0.08
-Nodes (12): NavigationAction, API, BrowserActions, Cookie, List, NetworkInterceptionRequestBuilder, Override, RuntimeException (+4 more)
+Cohesion: 0.07
+Nodes (15): NavigationAction, API, BrowserActions, Cookie, List, NetworkInterceptionRequestBuilder, Override, RuntimeException (+7 more)
 
 ### Community 41 - "Community 41"
-Cohesion: 0.15
-Nodes (17): CollectionState, EvidenceCollector, FilesSize, CollectionState, DoctorRedactor, DefaultPrettyPrinter, DoctorAnalysisRequest, EvidenceBundle (+9 more)
+Cohesion: 0.16
+Nodes (16): CollectionState, EvidenceCollector, CollectionState, DoctorRedactor, DefaultPrettyPrinter, DoctorAnalysisRequest, EvidenceBundle, EvidenceCategory (+8 more)
 
 ### Community 42 - "Community 42"
-Cohesion: 0.11
-Nodes (14): ElementLookup, FlakeProfileContext, GetElementInformation, Actions, ClipboardAction, GetElementInformation, Beta, By (+6 more)
+Cohesion: 0.10
+Nodes (15): ElementLookup, FlakeProfileContext, GetElementInformation, Actions, ClipboardAction, GetElementInformation, Beta, By (+7 more)
 
 ### Community 43 - "Community 43"
 Cohesion: 0.07
@@ -942,23 +948,23 @@ Cohesion: 0.08
 Nodes (7): LambdaTest, SetProperty, Boolean, DefaultValue, Key, SetProperty, String
 
 ### Community 45 - "Community 45"
-Cohesion: 0.10
-Nodes (22): ActionsCoverageUnitTest, RecordingActions, Parameter, RecordingActions, ActionType, AfterMethod, AllureLifecycle, BeforeMethod (+14 more)
+Cohesion: 0.09
+Nodes (22): Actions, ActionsCoverageUnitTest, RecordingActions, RecordingActions, ActionType, AfterMethod, AllureLifecycle, BeforeMethod (+14 more)
 
 ### Community 46 - "Community 46"
-Cohesion: 0.21
-Nodes (7): AssertionSteps, PDFTests, String, Then, ThreadLocal, WebDriver, String
+Cohesion: 0.18
+Nodes (8): AssertionSteps, PDFTests, ValidationsBuilderTests, String, Then, ThreadLocal, WebDriver, String
 
 ### Community 47 - "Community 47"
-Cohesion: 0.09
+Cohesion: 0.08
 Nodes (4): NewValidationHelperTests, AfterMethod, BeforeMethod, Test
 
 ### Community 48 - "Community 48"
-Cohesion: 0.07
+Cohesion: 0.08
 Nodes (11): NumberValidationsBuilder, Number, Object, Override, RestValidationsBuilder, SuppressWarnings, ValidationsBuilder, ValidationsExecutor (+3 more)
 
 ### Community 49 - "Community 49"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (11): FailureTraceReporter, List, Path, SourceContext, StackTraceElement, String, StringBuilder, TestExecutionInfo (+3 more)
 
 ### Community 50 - "Community 50"
@@ -967,27 +973,27 @@ Nodes (47): additionalProperties, minLength, type, maximum, minimum, type, type,
 
 ### Community 51 - "Community 51"
 Cohesion: 0.08
-Nodes (12): AssertApiResponseEqualsTests, ApiActionsMockedTests, RequestBuilder, RequestType, Test, AfterMethod, BeforeMethod, Test (+4 more)
+Nodes (12): MatchJsonSchemaTests, ApiActionsMockedTests, RequestBuilder, RequestType, Test, AfterMethod, BeforeMethod, Test (+4 more)
 
 ### Community 52 - "Community 52"
-Cohesion: 0.10
-Nodes (10): ApiPerformanceReportTest, SwaggerContractTest, AfterMethod, AfterSuite, BeforeMethod, Test, AfterClass, AfterMethod (+2 more)
+Cohesion: 0.07
+Nodes (16): ApiPerformanceReportTest, SwaggerContractTest, testPostRequest, TestUpload, ContentType, Object, ParametersType, AfterMethod (+8 more)
 
 ### Community 53 - "Community 53"
-Cohesion: 0.11
-Nodes (16): RestActions, RequestSpecBuilder, ArrayNode, Boolean, Class, Cookie, List, Map (+8 more)
+Cohesion: 0.10
+Nodes (18): RestActions, RequestSpecBuilder, RestAssuredConfig, API, ArrayNode, Boolean, Class, Cookie (+10 more)
 
 ### Community 54 - "Community 54"
 Cohesion: 0.13
 Nodes (28): _attachment_source_candidates(), _clean_cell(), _failure_brief_open_first(), _failure_group_key(), _first_trace_line(), _format_open_first(), _is_allure_test_result_payload(), _is_generated_report_non_test_result() (+20 more)
 
 ### Community 55 - "Community 55"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (16): ElementActionsHelper, TextDetectionStrategy(), AtomicInteger, Boolean, By, Class, ClipboardAction, HealingResolution (+8 more)
 
 ### Community 56 - "Community 56"
-Cohesion: 0.11
-Nodes (20): McpMobileInspectorRecordingService, Session, McpMobileToolchainService, Duration, List, Map, McpCodeBlock, McpMobileDevice (+12 more)
+Cohesion: 0.12
+Nodes (17): McpMobileInspectorRecordingService, Session, Duration, List, Map, McpCodeBlock, McpMobileDevice, McpMobileInspectorPlan (+9 more)
 
 ### Community 57 - "Community 57"
 Cohesion: 0.13
@@ -1002,16 +1008,16 @@ Cohesion: 0.14
 Nodes (20): CaptureControlClient, CaptureCli, flag(), parse(), path(), pathRequired(), required(), value() (+12 more)
 
 ### Community 60 - "Community 60"
-Cohesion: 0.12
+Cohesion: 0.11
 Nodes (19): Document, GuideHttpClient, GuideIndex, GuideHttpClient, GuideService, JdkGuideHttpClient, McpGuideMatch, McpGuideSearchResult (+11 more)
 
 ### Community 61 - "Community 61"
-Cohesion: 0.13
-Nodes (14): AllureListenerCoverageUnitTest, Throwable, AfterMethod, BeforeMethod, ITestResult, List, Path, String (+6 more)
+Cohesion: 0.11
+Nodes (16): FulfillOptions, AllureListenerCoverageUnitTest, Throwable, Status, AfterMethod, BeforeMethod, ITestResult, List (+8 more)
 
 ### Community 62 - "Community 62"
 Cohesion: 0.14
-Nodes (21): McpDoctorRemediationService, McpActionRecord, ProviderBlocks, AiRequest, AiResponse, ApprovalPolicy, CodegenBackend, Diagnosis (+13 more)
+Nodes (22): McpDoctorRemediationService, McpActionRecord, ProviderBlocks, AiRequest, AiResponse, ApprovalPolicy, CodegenBackend, Diagnosis (+14 more)
 
 ### Community 63 - "Community 63"
 Cohesion: 0.15
@@ -1022,8 +1028,8 @@ Cohesion: 0.11
 Nodes (11): COSDocument, DeleteFileAfterValidationStatus, PdfFileManager, PDFParser, RandomAccessReadBufferedFile, File, String, AfterMethod (+3 more)
 
 ### Community 65 - "Community 65"
-Cohesion: 0.05
-Nodes (24): PathParamTest, TestUpload, BasicAPITests, GraphqlRequestTests, Map, ParametersType, AfterClass, BeforeClass (+16 more)
+Cohesion: 0.07
+Nodes (17): PathParamTest, AssertApiResponseEqualsTests, GraphqlRequestTests, Map, AfterClass, BeforeClass, Test, Test (+9 more)
 
 ### Community 66 - "Community 66"
 Cohesion: 0.05
@@ -1038,32 +1044,32 @@ Cohesion: 0.05
 Nodes (42): additionalProperties, default, description, examples, $id, title, type, default (+34 more)
 
 ### Community 69 - "Community 69"
-Cohesion: 0.11
-Nodes (11): DriverFactoryHelper, AfterMethod, AtomicInteger, CountDownLatch, DriverType, Method, MutableCapabilities, Override (+3 more)
+Cohesion: 0.10
+Nodes (12): DriverFactoryHelper, OptionsManager, AfterMethod, AtomicInteger, CountDownLatch, DriverType, Method, MutableCapabilities (+4 more)
 
 ### Community 70 - "Community 70"
 Cohesion: 0.10
 Nodes (43): expand_globs(), issue(), load_budget(), local_link_targets(), markdown_body(), normalized_paragraphs(), parse_frontmatter(), quoted_yaml_value() (+35 more)
 
 ### Community 71 - "Community 71"
-Cohesion: 0.09
-Nodes (21): ShaftHeal, ShaftHealingProviderTest, WebDomHealingAcceptanceTest, HealingReport, Optional, AfterMethod, AppiumDriver, BeforeMethod (+13 more)
+Cohesion: 0.13
+Nodes (15): ShaftHeal, ShaftHealingProviderTest, HealingReport, Optional, AfterMethod, AppiumDriver, BeforeMethod, DataProvider (+7 more)
 
 ### Community 72 - "Community 72"
-Cohesion: 0.10
-Nodes (28): DoctorAnalyzerTest, empty(), reviewUiPath(), disabled(), disabled(), empty(), defaults(), lower() (+20 more)
+Cohesion: 0.20
+Nodes (12): DoctorAnalyzerTest, Arguments, CauseCategory, DoctorAnalysisRequest, DoctorAnalysisResult, List, MethodSource, ParameterizedTest (+4 more)
 
 ### Community 73 - "Community 73"
-Cohesion: 0.11
-Nodes (19): denyAll(), CaptureFixtures, reviewPath(), reviewUiPath(), CaptureGeneratorTest, PageContext, Path, BrowserMetadata (+11 more)
+Cohesion: 0.20
+Nodes (10): denyAll(), reviewPath(), reviewUiPath(), CaptureGeneratorTest, Path, CaptureGenerationRequest, CaptureSession, Path (+2 more)
 
 ### Community 74 - "Community 74"
 Cohesion: 0.11
-Nodes (14): CaptureEventPipeline, ManagedCaptureRecorder, BrowserMetadata, BrowserSignal, CapturePrivacyPolicy, CaptureSessionStore, CaptureStartRequest, CaptureStatus (+6 more)
+Nodes (13): CapturePrivacyClassifier, ManagedCaptureRecorder, BrowserMetadata, BrowserSignal, CapturePrivacyPolicy, CaptureStartRequest, CaptureStatus, CheckpointKind (+5 more)
 
 ### Community 75 - "Community 75"
-Cohesion: 0.15
-Nodes (11): Actions, By, DriverFactoryHelper, ElementActions, List, Map, Override, String (+3 more)
+Cohesion: 0.19
+Nodes (8): Actions, By, ElementActions, List, Map, Override, String, SuppressWarnings
 
 ### Community 76 - "Community 76"
 Cohesion: 0.08
@@ -1078,12 +1084,12 @@ Cohesion: 0.05
 Nodes (40): additionalProperties, enum, pattern, type, pattern, type, items, type (+32 more)
 
 ### Community 79 - "Community 79"
-Cohesion: 0.18
-Nodes (9): CaptureControlFiles, ControlDescriptor, CaptureStartRequest, CaptureStatus, Class, Object, Path, String (+1 more)
+Cohesion: 0.15
+Nodes (11): CaptureControlFiles, CaptureControlFilesTest, ControlDescriptor, CaptureStartRequest, CaptureStatus, Class, Object, Path (+3 more)
 
 ### Community 80 - "Community 80"
-Cohesion: 0.19
-Nodes (9): ElementService, LocatorOperation, By, Deprecated, LocatorOperation, locatorStrategy, String, Tool (+1 more)
+Cohesion: 0.16
+Nodes (11): ElementActionabilityDiagnosticsTest, ElementService, LocatorOperation, Test, By, Deprecated, LocatorOperation, locatorStrategy (+3 more)
 
 ### Community 81 - "Community 81"
 Cohesion: 0.18
@@ -1098,40 +1104,36 @@ Cohesion: 0.09
 Nodes (21): option(), ProviderConfiguration(), ProviderConfigurationTest, FirestoreRestClient, Properties, CaptureStartRequest(), validateUrl(), CaptureBrowser (+13 more)
 
 ### Community 85 - "Community 85"
-Cohesion: 0.13
-Nodes (15): CapturePrivacyClassifier, ClassifiedUpload, CapturePrivacyClassifier, CapturePrivacyClassifierTest, SanitizedAttributes, SanitizedText, CapturePrivacyPolicy, ClassifiedValue (+7 more)
-
-### Community 86 - "Community 86"
-Cohesion: 0.19
-Nodes (8): EngineService, PostConstruct, BrowserType, By, Path, String, Tool, WebDriver
+Cohesion: 0.14
+Nodes (14): ClassifiedUpload, CapturePrivacyClassifier, CapturePrivacyClassifierTest, SanitizedAttributes, SanitizedText, CapturePrivacyPolicy, ClassifiedValue, List (+6 more)
 
 ### Community 87 - "Community 87"
-Cohesion: 0.15
-Nodes (13): ArtifactReference, FailureDiagnosticsReporter, Redactor, List, Path, Redactor, SourceContext, StackTraceElement (+5 more)
+Cohesion: 0.14
+Nodes (14): ArtifactReference, FailureDiagnosticsReporter, Redactor, List, Path, Pattern, Redactor, SourceContext (+6 more)
 
 ### Community 88 - "Community 88"
-Cohesion: 0.14
-Nodes (9): ElementActionsHelper, AfterMethod, AndroidDriver, BeforeMethod, RemoteWebDriver, Runnable, Test, TouchActions (+1 more)
+Cohesion: 0.11
+Nodes (11): FileUploadDownloadTest, ElementActionsHelper, Test, AfterMethod, AndroidDriver, BeforeMethod, RemoteWebDriver, Runnable (+3 more)
 
 ### Community 89 - "Community 89"
 Cohesion: 0.10
 Nodes (14): WebDriverElementValidationsBuilder, GuiVerificationTests, By, NativeValidationsBuilder, Override, String, StringBuilder, ValidationCategory (+6 more)
 
 ### Community 90 - "Community 90"
-Cohesion: 0.11
-Nodes (29): append(), checkpoint(), complete(), ensureIncomplete(), interrupt(), sortedCheckpoints(), sortedEvents(), sortedReferences() (+21 more)
+Cohesion: 0.22
+Nodes (11): CaptureEvent, CaptureJsonCodec, CaptureSession, Checkpoint, ExternalTestDataReference, Instant, List, Path (+3 more)
 
 ### Community 91 - "Community 91"
-Cohesion: 0.10
-Nodes (3): AfterMethod, Test, NativeValidationsBuilderUnitTest
+Cohesion: 0.06
+Nodes (15): NativeValidationsBuilder, FileValidationsBuilder, Object, Override, RestValidationsBuilder, String, SuppressWarnings, ValidationsBuilder (+7 more)
 
 ### Community 92 - "Community 92"
 Cohesion: 0.09
 Nodes (49): child_text(), dependency_coordinate(), dependency_template(), direct_child(), elements_named(), ensure_android_json_exclusion(), ensure_dependency(), ensure_generator_dependency_set() (+41 more)
 
 ### Community 93 - "Community 93"
-Cohesion: 0.08
-Nodes (13): LocatorBuilder, ShadowDomTest, RelativeBy, By, Locator, Page, Role, ShaftLocator (+5 more)
+Cohesion: 0.06
+Nodes (17): LocatorBuilder, ShadowDomTest, JDK21VirtualThreadsAndAsyncActionsTests, RelativeBy, By, Locator, Page, Role (+9 more)
 
 ### Community 94 - "Community 94"
 Cohesion: 0.05
@@ -1142,8 +1144,8 @@ Cohesion: 0.11
 Nodes (15): builder(), evidenceCategories(), withSanitizedContent(), withTimeout(), AiValueObjectsTest, AiRequest, ApprovalPolicy, Duration (+7 more)
 
 ### Community 96 - "Community 96"
-Cohesion: 0.15
-Nodes (13): DriverFactory, DriverType(), DatabaseActions, DatabaseType, Deprecated, DriverFactoryHelper, DriverType, MutableCapabilities (+5 more)
+Cohesion: 0.10
+Nodes (16): DriverFactory, DriverType(), DatabaseActions, DatabaseType, Deprecated, DriverFactoryHelper, DriverType, MutableCapabilities (+8 more)
 
 ### Community 97 - "Community 97"
 Cohesion: 0.07
@@ -1166,24 +1168,24 @@ Cohesion: 0.06
 Nodes (36): additionalProperties, minLength, type, type, type, type, $id, additionalProperties (+28 more)
 
 ### Community 102 - "Community 102"
-Cohesion: 0.16
-Nodes (19): DoctorAiAnalysisServiceTest, EnumSource, from(), DoctorAnalysisResult, DoctorAnalysisSummary, AiRequest, AiResponse, AiResponseStatus (+11 more)
+Cohesion: 0.17
+Nodes (18): DoctorAiAnalysisServiceTest, EnumSource, from(), DoctorAnalysisResult, DoctorAnalysisSummary, AiRequest, AiResponse, AiResponseStatus (+10 more)
 
 ### Community 103 - "Community 103"
-Cohesion: 0.08
-Nodes (23): Contract, Interaction, HttpContractRecorder, HttpContractRecorderTest, AtomicInteger, BrowserNetworkInterceptionRule, FilterableRequestSpecification, HttpRequest (+15 more)
+Cohesion: 0.17
+Nodes (5): HttpContractRecorder, JsonNode, Map, String, ValidationMode
 
 ### Community 104 - "Community 104"
-Cohesion: 0.11
-Nodes (15): Dimension, BrowserActionsHelper, Boolean, Exception, List, Object, SneakyThrows, String (+7 more)
+Cohesion: 0.16
+Nodes (11): Dimension, BrowserActionsHelper, WindowType, Boolean, Exception, List, Object, SneakyThrows (+3 more)
 
 ### Community 105 - "Community 105"
 Cohesion: 0.14
 Nodes (14): BadRequestException, CaptureControlServer, Handler, Handler, CaptureControlFiles, CaptureManager, CaptureStatus, Class (+6 more)
 
 ### Community 106 - "Community 106"
-Cohesion: 0.13
-Nodes (11): FluentWait, ElementsHelperCoverageUnitTest, MockedStatic, AfterMethod, BeforeMethod, DriverFactoryHelper, MockedConstruction, RuntimeException (+3 more)
+Cohesion: 0.11
+Nodes (13): FluentWait, ImageProcessingActionsReportingUnitTest, ElementsHelperCoverageUnitTest, MockedStatic, AfterMethod, BeforeMethod, DriverFactoryHelper, MockedConstruction (+5 more)
 
 ### Community 107 - "Community 107"
 Cohesion: 0.12
@@ -1206,16 +1208,16 @@ Cohesion: 0.17
 Nodes (17): DeterministicRuleEngine, Confidence, Finding, Remediation, RetrySummary, RuleMatch, CauseCategory, Diagnosis (+9 more)
 
 ### Community 112 - "Community 112"
-Cohesion: 0.04
-Nodes (39): AsyncElementActions, UnitTestsSHAFT, CSVFileManager, DatabaseActions, API, Async, CLI, Contracts (+31 more)
+Cohesion: 0.09
+Nodes (12): API, Contracts, YAML, Class, Cookie, List, Map, Object (+4 more)
 
 ### Community 113 - "Community 113"
-Cohesion: 0.24
+Cohesion: 0.30
 Nodes (4): Platform, DefaultValue, Key, SetProperty
 
 ### Community 114 - "Community 114"
-Cohesion: 0.08
-Nodes (17): IIOMetadataNode, AnimatedGifManager, GifSession, AnimatedGifManagerCoverageUnitTest, ImageOutputStream, ImageWriter, RenderedImage, BufferedImage (+9 more)
+Cohesion: 0.14
+Nodes (8): IIOMetadataNode, AnimatedGifManager, ImageOutputStream, ImageWriter, RenderedImage, BufferedImage, Throwable, Mat
 
 ### Community 115 - "Community 115"
 Cohesion: 0.06
@@ -1223,27 +1225,27 @@ Nodes (34): enum, type, items, type, items, type, $id, required (+26 more)
 
 ### Community 116 - "Community 116"
 Cohesion: 0.10
-Nodes (20): getValue(), KeyboardKeys(), TouchActions, ImmutableMap, KeyboardKeys, viewport(), By, DriverFactoryHelper (+12 more)
+Nodes (20): getValue(), KeyboardKeys(), TouchActions, ImmutableMap, viewport(), ScreenOrientation, By, DriverFactoryHelper (+12 more)
 
 ### Community 117 - "Community 117"
 Cohesion: 0.15
 Nodes (21): AllureFile, changedSince(), HealerService, ProcessExecutor, successful(), McpHealerAttemptResult, McpHealerRunResult, ProcessExecutor (+13 more)
 
 ### Community 118 - "Community 118"
-Cohesion: 0.17
-Nodes (16): CandidateExtractor, LocatorProposal, nativePlatform(), SearchContext, By, Collection, HealingConfiguration, HealingPlatform (+8 more)
+Cohesion: 0.18
+Nodes (15): CandidateExtractor, LocatorProposal, SearchContext, By, Collection, HealingConfiguration, HealingPlatform, List (+7 more)
 
 ### Community 119 - "Community 119"
 Cohesion: 0.08
-Nodes (19): Async, Driver, Playwright, WebDriver, PlaywrightDriverAssertions, PlaywrightDriverVerifications, Actions, AlertActions (+11 more)
+Nodes (17): Async, Driver, Playwright, WebDriver, PlaywrightDriverAssertions, PlaywrightDriverVerifications, Actions, AlertActions (+9 more)
 
 ### Community 120 - "Community 120"
-Cohesion: 0.20
-Nodes (12): YAMLFileManager, Boolean, Class, Date, Double, Integer, List, Long (+4 more)
+Cohesion: 0.18
+Nodes (13): FileInputStream, YAMLFileManager, Boolean, Class, Date, Double, Integer, List (+5 more)
 
 ### Community 121 - "Community 121"
 Cohesion: 0.11
-Nodes (12): PlaywrightBrowserValidationsBuilder, AccessibilityActions, BrowserContext, BrowserNetworkInterceptionRule, HttpRequest, HttpResponse, Locator, NetworkInterceptionRequestBuilder (+4 more)
+Nodes (13): AccessibilityActions, BrowserContext, BrowserNetworkInterceptionRule, Cookie, HttpRequest, HttpResponse, Locator, NetworkInterceptionRequestBuilder (+5 more)
 
 ### Community 122 - "Community 122"
 Cohesion: 0.12
@@ -1254,12 +1256,12 @@ Cohesion: 0.10
 Nodes (4): AfterMethod, BeforeClass, Test, YAMLFileManagerUnitTest
 
 ### Community 124 - "Community 124"
-Cohesion: 0.11
-Nodes (25): AiTrigger, HealingProvider, ShaftHealingProvider, safe(), stableKey(), HealingActionOutcome, HealingCandidate, HealingConfiguration (+17 more)
+Cohesion: 0.12
+Nodes (22): AiTrigger, HealingProvider, ShaftHealingProvider, HealingActionOutcome, HealingCandidate, HealingConfiguration, HealingContext, HealingDecision (+14 more)
 
 ### Community 125 - "Community 125"
-Cohesion: 0.09
-Nodes (23): skipped(), LauncherSession, finalPassed(), String, Validation, Counts, Override, ITestNGMethod (+15 more)
+Cohesion: 0.13
+Nodes (17): getType(), LauncherSession, Screenshots, Override, AfterMethod, BeforeMethod, Duration, List (+9 more)
 
 ### Community 126 - "Community 126"
 Cohesion: 0.18
@@ -1274,16 +1276,16 @@ Cohesion: 0.18
 Nodes (14): AiExecutionService, CircuitState, AiAuditSink, AiProvider, AiProviderRegistry, AiRequest, AiResponse, AiResponseStatus (+6 more)
 
 ### Community 129 - "Community 129"
-Cohesion: 0.11
-Nodes (10): FakeGuideHttpClient, GuideServiceTest, CucumberMockedTests, Test, List, Map, Override, String (+2 more)
+Cohesion: 0.23
+Nodes (8): FakeGuideHttpClient, GuideServiceTest, List, Map, Override, String, Test, URI
 
 ### Community 130 - "Community 130"
 Cohesion: 0.15
 Nodes (12): Config, List, String, SuppressWarnings, AfterMethod, BeforeMethod, HttpExchange, Object (+4 more)
 
 ### Community 131 - "Community 131"
-Cohesion: 0.09
-Nodes (26): DoctorRepairProposalResult, DoctorRepairService, HealingLocatorProposalRequest, DoctorService, McpResultRecordsTest, McpWorkspacePolicy, ApprovalPolicy, Diagnosis (+18 more)
+Cohesion: 0.08
+Nodes (30): DoctorRepairProposalResult, DoctorRepairService, HealingLocatorProposalRequest, DoctorService, DoctorServiceTest, McpWorkspacePolicy, ApprovalPolicy, Diagnosis (+22 more)
 
 ### Community 132 - "Community 132"
 Cohesion: 0.15
@@ -1298,32 +1300,32 @@ Cohesion: 0.06
 Nodes (16): Jira, SetProperty, Mobile, SetProperty, PropertiesManagerTests, JiraTests, DefaultValue, Key (+8 more)
 
 ### Community 135 - "Community 135"
-Cohesion: 0.10
-Nodes (18): Locator, Object, Override, PlaywrightSession, PlaywrightValidationsExecutor, String, StringBuilder, ValidationCategory (+10 more)
+Cohesion: 0.09
+Nodes (19): NativeValidationsBuilder, Locator, Object, Override, PlaywrightSession, PlaywrightValidationsExecutor, String, StringBuilder (+11 more)
 
 ### Community 136 - "Community 136"
 Cohesion: 0.16
 Nodes (27): ut(), _(), a(), b(), c(), d(), f(), g() (+19 more)
 
 ### Community 137 - "Community 137"
-Cohesion: 0.20
-Nodes (14): EndpointStats, ApiPerformanceExecutionReport, appendJson(), budgetStatus(), budgetViolationMessage(), from(), percentile(), toHtmlRow() (+6 more)
+Cohesion: 0.17
+Nodes (16): EndpointStats, ApiPerformanceExecutionReport, appendJson(), budgetStatus(), budgetViolationMessage(), from(), percentile(), toHtmlRow() (+8 more)
 
 ### Community 138 - "Community 138"
 Cohesion: 0.16
 Nodes (9): AllureManagerCoverageUnitTest, AfterMethod, BeforeMethod, Class, Method, Object, Path, String (+1 more)
 
 ### Community 139 - "Community 139"
-Cohesion: 0.07
-Nodes (31): deleteObject, deleteRelation, markStale, supersedeObject, additionalProperties, properties, required, type (+23 more)
+Cohesion: 0.10
+Nodes (23): deleteObject, deleteRelation, additionalProperties, properties, required, type, additionalProperties, properties (+15 more)
 
 ### Community 140 - "Community 140"
 Cohesion: 0.06
 Nodes (30): additionalProperties, type, type, minimum, type, minimum, type, $id (+22 more)
 
 ### Community 141 - "Community 141"
-Cohesion: 0.18
-Nodes (10): AccessibilityHelperCoverageUnitTest, AfterMethod, List, MockedConstruction, Path, Results, Rule, String (+2 more)
+Cohesion: 0.17
+Nodes (11): AccessibilityHelperCoverageUnitTest, AxeBuilder, AfterMethod, List, MockedConstruction, Path, Results, Rule (+3 more)
 
 ### Community 142 - "Community 142"
 Cohesion: 0.13
@@ -1338,16 +1340,16 @@ Cohesion: 0.12
 Nodes (5): AfterMethod, Runnable, String, Test, ValidationHelperUnitTest
 
 ### Community 145 - "Community 145"
-Cohesion: 0.07
-Nodes (24): ImageProcessingActions, Boolean, By, Color, File, Integer, List, Rectangle (+16 more)
+Cohesion: 0.11
+Nodes (12): Color, Rectangle, AfterMethod, BeforeMethod, Color, Map, Method, Path (+4 more)
 
 ### Community 146 - "Community 146"
 Cohesion: 0.15
 Nodes (16): CaptureCodegenStartRequest, CaptureCodegenStartRequest, CaptureService, McpCaptureCodeBlockService, McpCaptureReplayResult, PreDestroy, CaptureGenerationResult, CaptureManager (+8 more)
 
 ### Community 147 - "Community 147"
-Cohesion: 0.19
-Nodes (11): CaptureCollectorUtilityTest, close(), start(), BrowserSignal, Class, Consumer, Object, Override (+3 more)
+Cohesion: 0.13
+Nodes (14): BrowserEventScript, CaptureCollectorUtilityTest, close(), start(), List, String, BrowserSignal, Class (+6 more)
 
 ### Community 148 - "Community 148"
 Cohesion: 0.14
@@ -1358,20 +1360,20 @@ Cohesion: 0.08
 Nodes (6): Flags, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 150 - "Community 150"
-Cohesion: 0.20
-Nodes (20): DoctorCli, flag(), optionalPath(), parse(), path(), pathRequired(), paths(), pathsRequired() (+12 more)
+Cohesion: 0.10
+Nodes (33): DoctorCli, flag(), optionalPath(), parse(), path(), pathRequired(), paths(), pathsRequired() (+25 more)
 
 ### Community 151 - "Community 151"
-Cohesion: 0.09
-Nodes (8): ThreadLocalPropertiesManager, Properties, String, AfterMethod, Path, String, Test, ThreadLocalPropertiesTest
+Cohesion: 0.13
+Nodes (5): AfterMethod, Path, String, Test, ThreadLocalPropertiesTest
 
 ### Community 152 - "Community 152"
 Cohesion: 0.19
 Nodes (11): LocatorRef, McpAppiumCommandRecorder, PointerGesture, BooleanSupplier, JsonNode, locatorStrategy, Map, McpMobileRecordedAction (+3 more)
 
 ### Community 153 - "Community 153"
-Cohesion: 0.12
-Nodes (16): APIResponse, FulfillOptions, PlaywrightNetworkInterceptor, PlaywrightNetworkInterceptorTest, Request, BrowserContext, BrowserNetworkInterceptionRule, HttpMethod (+8 more)
+Cohesion: 0.16
+Nodes (11): APIResponse, PlaywrightNetworkInterceptor, Request, BrowserContext, BrowserNetworkInterceptionRule, HttpMethod, HttpRequest, HttpResponse (+3 more)
 
 ### Community 154 - "Community 154"
 Cohesion: 0.17
@@ -1390,12 +1392,12 @@ Cohesion: 0.18
 Nodes (13): By, ElementActions, ElementAssertions, List, Locator, Map, Override, PlaywrightSession (+5 more)
 
 ### Community 158 - "Community 158"
-Cohesion: 0.10
-Nodes (10): XpathAxis, McpAppiumCommandRecorderTest, Role, LocatorBuilder, String, Override, AfterMethod, Test (+2 more)
+Cohesion: 0.13
+Nodes (6): JunitCoreAssertionMigrationTest, Role, Test, AfterMethod, Test, LocatorBuilderExtendedUnitTest
 
 ### Community 159 - "Community 159"
 Cohesion: 0.09
-Nodes (25): ActionReportContext, abbreviate(), empty(), FlakeProfileContext, from(), hasElementName(), hasLocator(), hasStepTarget() (+17 more)
+Nodes (26): ActionReportContext, ElementActions, abbreviate(), empty(), FlakeProfileContext, from(), hasElementName(), hasLocator() (+18 more)
 
 ### Community 160 - "Community 160"
 Cohesion: 0.08
@@ -1410,64 +1412,64 @@ Cohesion: 0.13
 Nodes (5): AfterMethod, BeforeMethod, Test, WebDriver, BrowserActionsCoverageUnitTest
 
 ### Community 164 - "Community 164"
-Cohesion: 0.24
+Cohesion: 0.21
 Nodes (7): Connection, DatabaseActions, Boolean, DatabaseType, ResultSet, String, StringBuilder
 
 ### Community 165 - "Community 165"
-Cohesion: 0.23
-Nodes (8): ChromiumOptions, DesiredCapabilities, OptionsManager, LoggingPreferences, DriverType, MutableCapabilities, String, SuppressWarnings
+Cohesion: 0.19
+Nodes (9): ChromiumOptions, DesiredCapabilities, OptionsManager, LoggingPreferences, DriverType, MutableCapabilities, String, SuppressWarnings (+1 more)
 
 ### Community 166 - "Community 166"
 Cohesion: 0.13
 Nodes (7): BrowserActions, List, Override, Page, Runnable, String, WindowType
 
 ### Community 167 - "Community 167"
-Cohesion: 0.19
-Nodes (7): Log4j, Log4jTests, DefaultValue, Key, String, BeforeClass, Test
+Cohesion: 0.25
+Nodes (4): Log4j, DefaultValue, Key, String
 
 ### Community 168 - "Community 168"
 Cohesion: 0.07
 Nodes (6): Reporting, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 169 - "Community 169"
-Cohesion: 0.17
-Nodes (6): AttachmentFormat, AttachmentReporter, ByteArrayOutputStream, Path, String, SuppressWarnings
+Cohesion: 0.07
+Nodes (19): AttachmentFormat, AttachmentSnapshot, AttachmentReporter, ByteArrayOutputStream, Path, String, SuppressWarnings, ByteArrayOutputStream (+11 more)
 
 ### Community 170 - "Community 170"
-Cohesion: 0.12
-Nodes (10): BrowserService, EngineServiceTest, McpPageDomSnapshot, McpScreenshotResult, McpWorkspacePolicy, Path, String, Tool (+2 more)
+Cohesion: 0.07
+Nodes (21): FailureTraceReporterTest, BrowserService, EngineServiceTest, AndroidDriver, Attachment, List, Path, RuntimeException (+13 more)
 
 ### Community 171 - "Community 171"
-Cohesion: 0.18
-Nodes (12): PlaywrightNaturalActionExecutor, By, CharSequence, List, Locator, NaturalActionPlan, Object, Page (+4 more)
+Cohesion: 0.06
+Nodes (31): ByAll, CompositeLocator, SmartLocator, SmartLocators, DeterministicNaturalActionPlannerTest, NaturalActionCompositeLocator, PlaywrightNaturalActionExecutor, PathStrategy (+23 more)
 
 ### Community 172 - "Community 172"
 Cohesion: 0.17
 Nodes (9): ElementSteps, getValue(), LocatorType(), By, String, SuppressWarnings, ThreadLocal, WebDriver (+1 more)
 
 ### Community 173 - "Community 173"
-Cohesion: 0.18
-Nodes (11): ValidationsHelper, Boolean, ComparisonType, LinkedHashMap, List, Number, NumbersComparativeRelation, Object (+3 more)
+Cohesion: 0.08
+Nodes (30): ValidationsExecutor, SilentElementReader, ValidationsHelper, ValidationsHelperNewPatternCoverageUnitTest, FileValidationsBuilder, NativeValidationsBuilder, NumberValidationsBuilder, RestValidationsBuilder (+22 more)
 
 ### Community 174 - "Community 174"
-Cohesion: 0.13
-Nodes (9): AttachmentSnapshot, getType(), Screenshots, DataProvider, Object, Path, String, Test (+1 more)
+Cohesion: 0.07
+Nodes (21): AsyncElementActions, Async, CLI, GUI, JSON, Locator, Properties, Report (+13 more)
 
 ### Community 175 - "Community 175"
 Cohesion: 0.17
 Nodes (7): RetryPolicy, Duration, Integer, RequestType, Set, String, Throwable
 
 ### Community 176 - "Community 176"
-Cohesion: 0.12
-Nodes (7): AsyncElementActions, AsyncElementActionsCoverageUnitTest, By, ClipboardAction, DriverFactoryHelper, String, Test
+Cohesion: 0.18
+Nodes (5): AsyncElementActions, By, ClipboardAction, DriverFactoryHelper, String
 
 ### Community 177 - "Community 177"
 Cohesion: 0.06
 Nodes (42): disabled(), TraceEventRecorder, Iterable, empty(), TraceService, TraceServiceTest, McpTraceActionSummary, McpTraceLatestResult (+34 more)
 
 ### Community 178 - "Community 178"
-Cohesion: 0.05
-Nodes (36): HistoryDocument, HistoryRecord, HealingHistoryStore, HealingHistoryStoreTest, HistoryRecord(), withChecksum(), PrivacySanitizer, TestAutomationService (+28 more)
+Cohesion: 0.22
+Nodes (8): TestAutomationService, McpCodeGuardrailResult, McpCodeGuardrailViolation, McpTestAutomationScenario, List, Pattern, String, Tool
 
 ### Community 179 - "Community 179"
 Cohesion: 0.11
@@ -1490,16 +1492,16 @@ Cohesion: 0.27
 Nodes (8): FingerprintExtractor, HealingConfiguration, LocatorFingerprint, Map, String, Supplier, WebDriver, WebElement
 
 ### Community 184 - "Community 184"
-Cohesion: 0.22
+Cohesion: 0.21
 Nodes (6): Internal, InternalTests, DefaultValue, Key, String, Test
 
 ### Community 185 - "Community 185"
-Cohesion: 0.25
-Nodes (12): ElementActionabilityDiagnostics, By, List, Map, Object, Rectangle, String, Supplier (+4 more)
+Cohesion: 0.12
+Nodes (21): ElementActionabilityDiagnostics, NaturalActionExecutorTest, ShadowLocatorBuilder, By, List, Map, Object, Rectangle (+13 more)
 
 ### Community 186 - "Community 186"
-Cohesion: 0.20
-Nodes (8): TestNG, TestNGTests, XmlSuite, DefaultValue, Integer, Key, String, Test
+Cohesion: 0.23
+Nodes (7): TestNG, TestNGTests, DefaultValue, Integer, Key, String, Test
 
 ### Community 187 - "Community 187"
 Cohesion: 0.08
@@ -1511,7 +1513,7 @@ Nodes (41): analyze_project(), collect_ai_context(), collect_source_migration(),
 
 ### Community 189 - "Community 189"
 Cohesion: 0.13
-Nodes (16): Bean, BrowserService, ElementService, GuideService, ShaftMcpApplication, MobileService, NaturalActionService, PlaywrightService (+8 more)
+Nodes (17): Bean, BrowserService, ElementService, GuideService, ShaftMcpApplication, MobileService, NaturalActionService, PlaywrightService (+9 more)
 
 ### Community 190 - "Community 190"
 Cohesion: 0.12
@@ -1538,24 +1540,24 @@ Cohesion: 0.17
 Nodes (19): build_parser(), collect_metrics(), issue(), main(), Run one external check and return a concise issue on failure., Collect stable context and memory size metrics., Run all agent setup checks., Build the command-line parser. (+11 more)
 
 ### Community 196 - "Community 196"
-Cohesion: 0.05
-Nodes (28): ActionSample, EvidenceEvent, ExecutionLifecycleHelper, ActionSample, appendJson(), FlakeProfiler, TestProfile, FlakeProfilerUnitTest (+20 more)
+Cohesion: 0.10
+Nodes (14): EvidenceEvent, appendJson(), FlakeProfiler, TestProfile, RetryEvent, ActionEvent, ArrayNode, AssertionError (+6 more)
 
 ### Community 197 - "Community 197"
-Cohesion: 0.22
-Nodes (5): ElementActions, ElementActionsMockedTests, AfterMethod, BeforeMethod, Test
+Cohesion: 0.24
+Nodes (4): ElementActionsMockedTests, AfterMethod, BeforeMethod, Test
 
 ### Community 198 - "Community 198"
 Cohesion: 0.18
 Nodes (6): ElementInformation, ElementInformationCoverageUnitTest, Element, List, String, Test
 
 ### Community 199 - "Community 199"
-Cohesion: 0.27
-Nodes (5): RestValidationsBuilder, JSONValidationsBuilder, NativeValidationsBuilder, String, ValidationsExecutor
+Cohesion: 0.14
+Nodes (6): ActionSample, ActionSample, FlakeProfilerUnitTest, AfterMethod, BeforeMethod, Test
 
 ### Community 200 - "Community 200"
-Cohesion: 0.20
-Nodes (7): FailureBriefReporter, AttachmentRecord, List, Redactor, String, StringBuilder, TestExecutionInfo
+Cohesion: 0.06
+Nodes (32): AiAuditSink, ShaftAiAuditSink, FailureBriefReporter, FailureBriefReporterTest, ReportContext, JunitReportContextTest, AttachmentRecord, List (+24 more)
 
 ### Community 201 - "Community 201"
 Cohesion: 0.11
@@ -1586,16 +1588,16 @@ Cohesion: 0.21
 Nodes (18): A(), ba(), c(), D(), E(), G(), i(), j() (+10 more)
 
 ### Community 209 - "Community 209"
-Cohesion: 0.05
-Nodes (49): AlertEvent, ArtifactPaths, AssertionSuggestion, CaptureReviewFinding, DataPlan, CaptureGenerator, CodegenBackend(), driverClassName() (+41 more)
+Cohesion: 0.06
+Nodes (40): AlertEvent, ArtifactPaths, AssertionSuggestion, CaptureReviewFinding, DataPlan, CaptureGenerator, driverClassName(), failure() (+32 more)
 
 ### Community 210 - "Community 210"
 Cohesion: 0.20
 Nodes (4): LocatorBuilderTest, AfterMethod, BeforeMethod, Test
 
 ### Community 211 - "Community 211"
-Cohesion: 0.18
-Nodes (13): DoctorRepairPatchResult, DoctorRepairAiService, AiRequest, AiResponse, AiResponseStatus, Diagnosis, DoctorRepairAiRequest, EvidenceReference (+5 more)
+Cohesion: 0.17
+Nodes (11): HistoryDocument, HistoryRecord, HealingHistoryStore, HealingConfiguration, HealingContext, LocatorFingerprint, Optional, Path (+3 more)
 
 ### Community 212 - "Community 212"
 Cohesion: 0.16
@@ -1606,20 +1608,20 @@ Cohesion: 0.16
 Nodes (5): ElementAssertions, NativeValidationsBuilder, String, ValidationsExecutor, VisualValidationEngine
 
 ### Community 214 - "Community 214"
-Cohesion: 0.13
-Nodes (10): ReportContext, JunitReportContextTest, AttachmentRecord, Consumer, List, Status, String, TestExecutionInfo (+2 more)
+Cohesion: 0.14
+Nodes (12): ImageProcessingActions, Boolean, By, File, Integer, List, String, VisualValidationEngine (+4 more)
 
 ### Community 215 - "Community 215"
-Cohesion: 0.12
-Nodes (22): minLength, type, properties, $ref, $ref, $ref, body, evidence (+14 more)
+Cohesion: 0.14
+Nodes (18): minLength, type, properties, $ref, $ref, body, facets, origin (+10 more)
 
 ### Community 216 - "Community 216"
 Cohesion: 0.24
 Nodes (10): expired(), InstantDeadline(), ManagedCaptureRecorderBrowserTest, Duration, HttpExchange, HttpServer, ParameterizedTest, Path (+2 more)
 
 ### Community 217 - "Community 217"
-Cohesion: 0.17
-Nodes (7): AndroidDragAndDropTest, FileUploadDownloadTest, MobileTest, Test, Test, AfterMethod, BeforeMethod
+Cohesion: 0.25
+Nodes (5): AndroidDragAndDropTest, MobileTest, Test, AfterMethod, BeforeMethod
 
 ### Community 218 - "Community 218"
 Cohesion: 0.24
@@ -1630,31 +1632,31 @@ Cohesion: 0.33
 Nodes (4): DynamicLoadingTest, AfterMethod, BeforeMethod, Test
 
 ### Community 220 - "Community 220"
-Cohesion: 0.23
-Nodes (10): AllureSummary, Diagnostic, GeneratedTestValidator, JarFile, JavaFileObject, Duration, List, Path (+2 more)
+Cohesion: 0.22
+Nodes (11): AllureSummary, Diagnostic, GeneratedTestValidator, JarEntry, JarFile, JavaFileObject, Duration, List (+3 more)
 
 ### Community 221 - "Community 221"
 Cohesion: 0.20
 Nodes (13): AiCandidateReranker, AiExecutionService, Double, HealingConfiguration, JsonNode, List, Map, ObjectNode (+5 more)
 
 ### Community 222 - "Community 222"
-Cohesion: 0.29
-Nodes (4): SilentElementReader, By, String, WebDriver
+Cohesion: 0.18
+Nodes (10): AfterMethod, Map, Object, String, SuppressWarnings, Test, Throwable, ThrowingRunnable (+2 more)
 
 ### Community 223 - "Community 223"
-Cohesion: 0.13
-Nodes (5): NumberValidationsBuilder, AfterMethod, BeforeClass, Test, RestValidationsBuilderUnitTest
+Cohesion: 0.08
+Nodes (15): RestValidationsBuilder, JSONValidationsBuilder, JsonCompareWithSpecialCharactersTests, NativeValidationsBuilder, NumberValidationsBuilder, Object, String, StringBuilder (+7 more)
 
 ### Community 224 - "Community 224"
 Cohesion: 0.19
 Nodes (6): Healenium, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 225 - "Community 225"
-Cohesion: 0.17
+Cohesion: 0.16
 Nodes (8): KeysetHandle, GoogleTink, GoogleTinkApiCoverageUnitTest, String, AfterMethod, BeforeMethod, Path, Test
 
 ### Community 226 - "Community 226"
-Cohesion: 0.18
+Cohesion: 0.19
 Nodes (11): ManagedCaptureRecorder, CaptureManager, CaptureStartRequest, CaptureStatus, CheckpointKind, Function, ManagedCaptureRecorder, Override (+3 more)
 
 ### Community 227 - "Community 227"
@@ -1680,10 +1682,6 @@ Nodes (3): AfterMethod, Test, RestActionsUtilsUnitTest
 ### Community 232 - "Community 232"
 Cohesion: 0.17
 Nodes (10): PilotTestConfiguration, RedactionPolicy, RedactionResult, Redactor, AiRequest, Set, String, PilotConfiguration (+2 more)
-
-### Community 233 - "Community 233"
-Cohesion: 0.09
-Nodes (6): PropertiesHelper, String, AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
 
 ### Community 234 - "Community 234"
 Cohesion: 0.18
@@ -1758,8 +1756,8 @@ Cohesion: 0.22
 Nodes (8): ChromeOptions, MoonTests, AfterEach, BeforeEach, String, Test, WebDriver, TestInfo
 
 ### Community 252 - "Community 252"
-Cohesion: 0.24
-Nodes (9): HealingSupport, By, HealingContext, HealingPlatform, RemoteWebDriver, String, Supplier, WebDriver (+1 more)
+Cohesion: 0.21
+Nodes (10): HealingSupport, nativePlatform(), By, HealingContext, HealingPlatform, RemoteWebDriver, String, Supplier (+2 more)
 
 ### Community 253 - "Community 253"
 Cohesion: 0.28
@@ -1778,7 +1776,7 @@ Cohesion: 0.21
 Nodes (6): FailureReporter, Class, String, Throwable, Test, FailureReporterUnitTest
 
 ### Community 257 - "Community 257"
-Cohesion: 0.19
+Cohesion: 0.17
 Nodes (6): OpenApiCoverageReporterUnitTest, OpenApiValidationException, AssertionError, AfterMethod, String, Test
 
 ### Community 258 - "Community 258"
@@ -1786,8 +1784,8 @@ Cohesion: 0.20
 Nodes (6): NaturalActions, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 259 - "Community 259"
-Cohesion: 0.18
-Nodes (8): ShaftLocator, By, Locator, Override, Page, String, Pattern, Strategy
+Cohesion: 0.19
+Nodes (7): ShaftLocator, By, Locator, Override, Page, String, Strategy
 
 ### Community 260 - "Community 260"
 Cohesion: 0.13
@@ -1802,12 +1800,12 @@ Cohesion: 0.09
 Nodes (25): CommandResult, confirm_upgrade(), default_compile_command(), extract_response_output_text(), is_stable_release(), metadata_release(), parse_compile_command(), Enforce the modular SHAFT dependency contract after every repair. (+17 more)
 
 ### Community 263 - "Community 263"
-Cohesion: 0.15
-Nodes (9): PlaywrightSession, PlaywrightTraceManager, Browser, BrowserContext, Object, Override, Page, Playwright (+1 more)
+Cohesion: 0.17
+Nodes (8): PlaywrightSession, Browser, BrowserContext, Object, Override, Page, Playwright, String
 
 ### Community 264 - "Community 264"
-Cohesion: 0.17
-Nodes (13): McpMobileInspectorRecordingServiceTest, NoopRunner, McpProcessRunner, Duration, List, Map, McpMobileInspectorRecordingService, Override (+5 more)
+Cohesion: 0.19
+Nodes (12): McpMobileInspectorRecordingServiceTest, NoopRunner, Duration, List, Map, McpMobileInspectorRecordingService, Override, Path (+4 more)
 
 ### Community 265 - "Community 265"
 Cohesion: 0.15
@@ -1834,8 +1832,8 @@ Cohesion: 0.25
 Nodes (4): MultipleDriverSessionTerminationTest, AfterMethod, BeforeMethod, Test
 
 ### Community 271 - "Community 271"
-Cohesion: 0.27
-Nodes (7): SmartLocator, SmartLocators, PathStrategy, By, List, Override, String
+Cohesion: 0.17
+Nodes (4): AccessibilityTest, AfterMethod, BeforeMethod, Test
 
 ### Community 272 - "Community 272"
 Cohesion: 0.20
@@ -1858,20 +1856,20 @@ Cohesion: 0.19
 Nodes (10): NaturalActionExecutor, By, CharSequence, DriverFactoryHelper, NaturalActionPlan, Object, Set, String (+2 more)
 
 ### Community 277 - "Community 277"
-Cohesion: 0.39
-Nodes (6): ByteArrayOutputStream, Severity, Story, String, Test, AllAttachmentTypesTest
+Cohesion: 0.11
+Nodes (13): CaptureEnrichmentService, CodegenBackend(), from(), MutableTargetPlan, GeneratedTestValidator, LocatorRanker, CaptureJsonCodec, Checkpoint (+5 more)
 
 ### Community 279 - "Community 279"
 Cohesion: 0.20
 Nodes (3): BeforeClass, Test, TestDataUnitTest
 
 ### Community 280 - "Community 280"
-Cohesion: 0.14
-Nodes (11): FailureTraceReporterTest, AndroidDriver, Attachment, List, Path, RuntimeException, String, SuppressWarnings (+3 more)
+Cohesion: 0.19
+Nodes (7): AnimatedGifManagerCoverageUnitTest, AfterMethod, BeforeMethod, Color, Method, String, Test
 
 ### Community 281 - "Community 281"
-Cohesion: 0.26
-Nodes (5): CheckpointStatus, CheckpointType, String, Test, CheckpointAndReportingTest
+Cohesion: 0.20
+Nodes (8): ExecutionLifecycleHelper, List, Method, RunType, Status, StatusIcon, String, TestExecutionInfo
 
 ### Community 282 - "Community 282"
 Cohesion: 0.24
@@ -1910,20 +1908,20 @@ Cohesion: 0.23
 Nodes (7): BigInteger, UpdateChecker, UpdateCheckerUnitTest, Optional, String, Supplier, Test
 
 ### Community 291 - "Community 291"
-Cohesion: 0.21
-Nodes (8): ByAll, CompositeLocator, NaturalActionCompositeLocator, By, List, By, List, Override
+Cohesion: 0.24
+Nodes (8): GuardedPatch, RepairGuard, FilePatch, List, Path, Set, String, ValidationCommand
 
 ### Community 293 - "Community 293"
 Cohesion: 0.22
-Nodes (8): NaturalActionExecutorTest, AfterMethod, BeforeMethod, By, List, Test, WebDriver, WebElement
+Nodes (9): AtomicInteger, BrowserNetworkInterceptionRule, FilterableRequestSpecification, HttpRequest, HttpResponse, List, Response, Set (+1 more)
 
 ### Community 294 - "Community 294"
-Cohesion: 0.30
+Cohesion: 0.29
 Nodes (8): IssueReporter, Boolean, ITestNGMethod, ITestResult, List, Method, String, TestExecutionInfo
 
 ### Community 295 - "Community 295"
-Cohesion: 0.11
-Nodes (19): notRequested(), McpCaptureCodeBlockServiceTest, PlaywrightServiceTest, DoctorReportWriter, Enrichment, Diagnosis, DoctorAdvisory, EvidenceBundle (+11 more)
+Cohesion: 0.25
+Nodes (8): notRequested(), McpCaptureCodeBlockServiceTest, Enrichment, List, McpCodeBlock, Path, String, Test
 
 ### Community 296 - "Community 296"
 Cohesion: 0.12
@@ -1934,39 +1932,39 @@ Cohesion: 0.12
 Nodes (17): pattern, type, origin, pattern, type, minLength, type, minLength (+9 more)
 
 ### Community 298 - "Community 298"
-Cohesion: 0.12
-Nodes (17): additionalProperties, required, type, $defs, createObject, evidence, objectId, relationId (+9 more)
+Cohesion: 0.10
+Nodes (21): additionalProperties, required, type, additionalProperties, required, type, $defs, createObject (+13 more)
 
 ### Community 299 - "Community 299"
 Cohesion: 0.21
 Nodes (4): AfterClass, BeforeClass, Test, FileHelperUnitTest
 
 ### Community 300 - "Community 300"
-Cohesion: 0.22
-Nodes (7): ManagedCaptureRecorderControlTest, CaptureBrowser, CaptureStartOptions, CaptureStartRequest, Object, SuppressWarnings, Test
+Cohesion: 0.17
+Nodes (9): CaptureEventPipeline, ManagedCaptureRecorderControlTest, CaptureSessionStore, CaptureBrowser, CaptureStartOptions, CaptureStartRequest, Object, SuppressWarnings (+1 more)
 
 ### Community 301 - "Community 301"
-Cohesion: 0.12
-Nodes (11): FluentWebDriverAction, SelectedValueTests, Actions, AlertActions, BrowserActions, DriverFactoryHelper, TouchActions, WebDriver (+3 more)
+Cohesion: 0.17
+Nodes (7): FluentWebDriverAction, Actions, AlertActions, BrowserActions, DriverFactoryHelper, TouchActions, WebDriver
 
 ### Community 302 - "Community 302"
 Cohesion: 0.21
 Nodes (9): fixture_commands(), main(), maven_executable(), missing_publication_paths(), publication_paths(), verify_release(), write_settings(), Path (+1 more)
 
 ### Community 303 - "Community 303"
-Cohesion: 0.17
-Nodes (10): InterceptorFactory, BrowserNetworkInterceptor, InterceptorFactory, BrowserNetworkInterceptionRule, Filter, HttpRequest, HttpResponse, Override (+2 more)
+Cohesion: 0.18
+Nodes (9): InterceptorFactory, BrowserNetworkInterceptor, InterceptorFactory, BrowserNetworkInterceptionRule, HttpRequest, HttpResponse, Override, Response (+1 more)
 
 ### Community 305 - "Community 305"
 Cohesion: 0.18
 Nodes (8): DesktopVideoRecordingProvider, AfterMethod, InputStream, Override, String, Test, DesktopVideoRecordingProviderRegistryTest, StubDesktopVideoRecordingProvider
 
 ### Community 306 - "Community 306"
-Cohesion: 0.22
-Nodes (8): AccessibilityResult, AfterMethod, BeforeMethod, List, Rule, String, Test, AccessibilityActionsCoverageUnitTest
+Cohesion: 0.15
+Nodes (9): WebDriver, AccessibilityResult, AfterMethod, BeforeMethod, List, Rule, String, Test (+1 more)
 
 ### Community 307 - "Community 307"
-Cohesion: 0.21
+Cohesion: 0.19
 Nodes (8): OperationCoverage, SpecCoverage, OpenAPI, OpenApiValidationFilter, OperationCoverage, List, ObjectNode, StringBuilder
 
 ### Community 308 - "Community 308"
@@ -1974,16 +1972,16 @@ Cohesion: 0.33
 Nodes (3): FileActionsReflectionInvoker, FileActions, String
 
 ### Community 309 - "Community 309"
-Cohesion: 0.24
-Nodes (5): ValidationsHelperCoverageUnitTest, AssertionError, AfterMethod, SuppressWarnings, Test
+Cohesion: 0.08
+Nodes (17): JUnitWebConsumer, TestNgWebConsumer, ValidationsHelperCoverageUnitTest, AssertionError, AfterMethod, SuppressWarnings, Test, AfterMethod (+9 more)
 
 ### Community 311 - "Community 311"
-Cohesion: 0.18
-Nodes (9): AllureCucumber7Jvm, CucumberTestRunnerListener, EventPublisher, Feature, Optional, Override, TestSourceParsed, TestStepStarted (+1 more)
+Cohesion: 0.15
+Nodes (10): AllureCucumber7Jvm, CucumberTestRunnerListener, EventPublisher, Feature, Optional, Override, TestCaseFinished, TestSourceParsed (+2 more)
 
 ### Community 312 - "Community 312"
-Cohesion: 0.14
-Nodes (13): DoctorServiceTest, DoctorSnippetProvider, AfterEach, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse, DoctorService (+5 more)
+Cohesion: 0.23
+Nodes (8): AiProvider, DoctorSnippetProvider, AfterEach, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse, Override
 
 ### Community 313 - "Community 313"
 Cohesion: 0.27
@@ -2046,8 +2044,8 @@ Cohesion: 0.21
 Nodes (7): AfterMethod, BeforeClass, BeforeMethod, Override, String, Test, TestClass
 
 ### Community 329 - "Community 329"
-Cohesion: 0.08
-Nodes (13): AndroidBasicInteractionsTests, AndroidTouchActionsTests, MultipleElementsFailureTest, NoSuchElementFailureTest, ScreenOrientation, Test, Test, AfterMethod (+5 more)
+Cohesion: 0.16
+Nodes (4): AndroidBasicInteractionsTests, AndroidTouchActionsTests, Test, Test
 
 ### Community 330 - "Community 330"
 Cohesion: 0.18
@@ -2062,12 +2060,12 @@ Cohesion: 0.19
 Nodes (14): A(), Ae(), b(), ce(), ge(), le(), pe(), qe() (+6 more)
 
 ### Community 333 - "Community 333"
-Cohesion: 0.24
-Nodes (5): List, Set, String, Test, TelemetryDeduplicationUnitTest
+Cohesion: 0.06
+Nodes (34): empty(), LocatorRankerTest, reviewUiPath(), disabled(), McpResultRecordsTest, disabled(), empty(), defaults() (+26 more)
 
 ### Community 334 - "Community 334"
-Cohesion: 0.22
-Nodes (3): AfterMethod, Test, DriverFactoryCoverageUnitTest
+Cohesion: 0.13
+Nodes (10): skipped(), finalPassed(), String, Validation, Counts, ITestNGMethod, Throwable, RunType (+2 more)
 
 ### Community 335 - "Community 335"
 Cohesion: 0.17
@@ -2078,8 +2076,8 @@ Cohesion: 0.26
 Nodes (6): Pattern, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 337 - "Community 337"
-Cohesion: 0.21
-Nodes (7): IOSDriver, InputStream, Path, String, SuppressWarnings, WebDriver, RecordManager
+Cohesion: 0.13
+Nodes (11): IOSDriver, InputStream, Path, String, SuppressWarnings, WebDriver, AfterMethod, BeforeMethod (+3 more)
 
 ### Community 338 - "Community 338"
 Cohesion: 0.53
@@ -2090,7 +2088,7 @@ Cohesion: 0.26
 Nodes (6): ModelSupport, JsonNode, List, Map, String, T
 
 ### Community 340 - "Community 340"
-Cohesion: 0.20
+Cohesion: 0.22
 Nodes (6): OpenApiCoverageReporter, HttpMethod, RequestType, String, Throwable, SpecCoverage
 
 ### Community 341 - "Community 341"
@@ -2098,8 +2096,8 @@ Cohesion: 0.12
 Nodes (17): items, type, uniqueItems, tags, items, additionalProperties, minLength, pattern (+9 more)
 
 ### Community 342 - "Community 342"
-Cohesion: 0.24
-Nodes (4): MobileServiceConfigurationTest, McpMobileRecordingStatus, AfterEach, Test
+Cohesion: 0.12
+Nodes (9): McpAppiumCommandRecorderTest, MobileRecordingServiceTest, MobileServiceConfigurationTest, PlaywrightServiceTest, Test, Test, AfterEach, Test (+1 more)
 
 ### Community 343 - "Community 343"
 Cohesion: 0.25
@@ -2142,12 +2140,12 @@ Cohesion: 0.18
 Nodes (6): AfterMethod, DataProvider, Object, String, Test, DriverFactoryHelperUnitTest
 
 ### Community 353 - "Community 353"
-Cohesion: 0.09
-Nodes (13): EXCEL, ExcelFileManager, TestDataTests, String, Test, AfterMethod, BeforeMethod, Path (+5 more)
+Cohesion: 0.15
+Nodes (8): EXCEL, ExcelFileManager, TestDataTests, String, Test, BeforeClass, Test, IoExcelFileManagerTests
 
 ### Community 354 - "Community 354"
-Cohesion: 0.08
-Nodes (11): Locator, LocatorMockedTests, ShadowLocatorBuilder, Beta, By, LocatorBuilder, String, Test (+3 more)
+Cohesion: 0.10
+Nodes (5): LocatorMockedTests, Test, Test, LocatorBuilderUnitTest, XpathAxis
 
 ### Community 356 - "Community 356"
 Cohesion: 0.22
@@ -2182,8 +2180,8 @@ Cohesion: 0.29
 Nodes (5): HttpExchange, HttpServer, Override, String, LocalApiServer
 
 ### Community 364 - "Community 364"
-Cohesion: 0.11
-Nodes (8): BasicAuthenticationTests, NetworkInterceptionTest, SmartLocatorsTests, Test, Test, AfterMethod, BeforeMethod, Tests
+Cohesion: 0.08
+Nodes (12): BasicAuthenticationTests, NetworkInterceptionTest, TableTests, SmartLocatorsTests, Test, Test, String, Test (+4 more)
 
 ### Community 365 - "Community 365"
 Cohesion: 0.29
@@ -2214,8 +2212,8 @@ Cohesion: 0.23
 Nodes (8): VisualProcessingProvider, Boolean, By, Integer, List, String, VisualValidationEngine, WebDriver
 
 ### Community 372 - "Community 372"
-Cohesion: 0.14
-Nodes (5): Boolean, NumbersComparativeRelation, Object, String, JavaHelper
+Cohesion: 0.21
+Nodes (4): AfterMethod, String, Test, PropertyFileManagerUnitTest
 
 ### Community 373 - "Community 373"
 Cohesion: 0.16
@@ -2226,8 +2224,8 @@ Cohesion: 0.10
 Nodes (14): ExhaustedLauncherRetryFixture, JunitExtensionLifecycleTest, LauncherRetryFixture, OuterSessionStateRetryFixture, Order, AfterEach, BeforeAll, BeforeEach (+6 more)
 
 ### Community 375 - "Community 375"
-Cohesion: 0.24
-Nodes (9): AccessibilityActions, BrowserNetworkInterceptionRule, DriverFactoryHelper, HttpRequest, HttpResponse, Predicate, Step, URI (+1 more)
+Cohesion: 0.22
+Nodes (8): AccessibilityActions, BrowserNetworkInterceptionRule, DriverFactoryHelper, HttpRequest, HttpResponse, Predicate, Step, WebDriver
 
 ### Community 376 - "Community 376"
 Cohesion: 0.17
@@ -2274,12 +2272,12 @@ Cohesion: 0.17
 Nodes (12): type, scope, pattern, type, branch, project, task, additionalProperties (+4 more)
 
 ### Community 387 - "Community 387"
-Cohesion: 0.12
-Nodes (10): OpenCvVisualConsumer, HealingVisualProvider, OpenCvHealingVisualProvider, OpenCvHealingVisualProviderTest, Override, String, Color, Test (+2 more)
+Cohesion: 0.19
+Nodes (7): HealingVisualProvider, OpenCvHealingVisualProvider, OpenCvHealingVisualProviderTest, Override, String, Color, Test
 
 ### Community 388 - "Community 388"
 Cohesion: 0.17
-Nodes (12): type, items, properties, required, type, content, redacted, relativePath (+4 more)
+Nodes (12): type, properties, minLength, type, content, mediaType, redacted, relativePath (+4 more)
 
 ### Community 389 - "Community 389"
 Cohesion: 0.26
@@ -2302,8 +2300,8 @@ Cohesion: 0.26
 Nodes (4): OptionsManagerCoverageUnitTest, AfterMethod, BeforeMethod, Test
 
 ### Community 395 - "Community 395"
-Cohesion: 0.26
-Nodes (6): AfterMethod, Object, String, Test, ValidationsExecutor, ValidationsExecutorCoverageUnitTest
+Cohesion: 0.21
+Nodes (4): AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
 
 ### Community 396 - "Community 396"
 Cohesion: 0.18
@@ -2326,7 +2324,7 @@ Cohesion: 0.25
 Nodes (6): McpServiceHelperTest, AfterEach, Class, Object, String, Test
 
 ### Community 402 - "Community 402"
-Cohesion: 0.24
+Cohesion: 0.25
 Nodes (3): ActionsExceptionDetailsUnitTest, NoSuchElementException, Test
 
 ### Community 403 - "Community 403"
@@ -2358,24 +2356,24 @@ Cohesion: 0.29
 Nodes (4): GroupsTests, AfterMethod, BeforeMethod, Test
 
 ### Community 410 - "Community 410"
-Cohesion: 0.14
+Cohesion: 0.15
 Nodes (13): ActionCandidate, safe(), LocatorDecision, McpCaptureCodeBlockService, PomCandidates, CaptureGenerationReport, List, LocatorCandidate (+5 more)
 
 ### Community 411 - "Community 411"
-Cohesion: 0.25
+Cohesion: 0.27
 Nodes (3): AfterMethod, Test, LambdaTestHelperUnitTest
 
 ### Community 412 - "Community 412"
-Cohesion: 0.36
-Nodes (4): DeterministicNaturalActionPlannerTest, NaturalActionRequest, String, Test
+Cohesion: 0.23
+Nodes (7): HealingHistoryStoreTest, AfterMethod, HealingConfiguration, Map, Object, String, Test
 
 ### Community 413 - "Community 413"
 Cohesion: 0.40
 Nodes (10): addIfSet(), addIfTrue(), defaults(), normalize(), testIdAttributes(), text(), warnings(), CaptureStartOptions (+2 more)
 
 ### Community 414 - "Community 414"
-Cohesion: 0.18
-Nodes (11): additionalProperties, properties, required, type, createRelation, $ref, enum, from (+3 more)
+Cohesion: 0.12
+Nodes (18): enum, properties, updateRelation, $ref, $ref, enum, confidence, evidence (+10 more)
 
 ### Community 416 - "Community 416"
 Cohesion: 0.24
@@ -2398,8 +2396,8 @@ Cohesion: 0.33
 Nodes (8): failure(), success(), AiResponse, AiResponseStatus, AiUsage, Duration, JsonNode, String
 
 ### Community 421 - "Community 421"
-Cohesion: 0.20
-Nodes (11): DriverAssertions, BrowserAssertions, By, ElementAssertions, Locator, NativeValidationsBuilder, Object, Override (+3 more)
+Cohesion: 0.21
+Nodes (10): BrowserAssertions, By, ElementAssertions, Locator, NativeValidationsBuilder, Object, Override, PlaywrightSession (+2 more)
 
 ### Community 422 - "Community 422"
 Cohesion: 0.20
@@ -2418,16 +2416,16 @@ Cohesion: 0.13
 Nodes (15): Controller, Headers, Controller, McpAppiumInspectorProxy, McpAppiumCommandRecorder, Builder, HttpExchange, HttpResponse (+7 more)
 
 ### Community 426 - "Community 426"
-Cohesion: 0.14
-Nodes (14): AlphaProvider, VisualProcessingProviderRegistryTest, ZuluProvider, AfterMethod, Boolean, By, Integer, List (+6 more)
+Cohesion: 0.15
+Nodes (13): AlphaProvider, VisualProcessingProviderRegistryTest, ZuluProvider, AfterMethod, Boolean, By, Integer, List (+5 more)
 
 ### Community 427 - "Community 427"
 Cohesion: 0.26
 Nodes (7): ApiPerformanceExecutionReportUnitTest, AfterMethod, CapturedFile, JsonNode, List, String, Test
 
 ### Community 428 - "Community 428"
-Cohesion: 0.30
-Nodes (3): PlaywrightTraceManager, BrowserContext, Path
+Cohesion: 0.24
+Nodes (4): PlaywrightTraceManager, PlaywrightTraceManager, BrowserContext, Path
 
 ### Community 430 - "Community 430"
 Cohesion: 0.22
@@ -2438,24 +2436,20 @@ Cohesion: 0.31
 Nodes (4): BigPageActionsTest, AfterMethod, BeforeMethod, Test
 
 ### Community 432 - "Community 432"
-Cohesion: 0.33
-Nodes (3): Class, Test, GUIInterfaceCompatibilityCoverageUnitTest
-
-### Community 433 - "Community 433"
-Cohesion: 0.35
-Nodes (3): BrowserEventScript, List, String
+Cohesion: 0.29
+Nodes (4): DriverAssertions, Class, Test, GUIInterfaceCompatibilityCoverageUnitTest
 
 ### Community 434 - "Community 434"
 Cohesion: 0.21
 Nodes (6): AfterMethod, Class, Object, String, Test, BrowserStackHelperUnitTest
 
 ### Community 435 - "Community 435"
-Cohesion: 0.32
-Nodes (7): LocatorRankerTest, ElementSnapshot, List, LocatorCandidate, LocatorStrategy, String, Test
+Cohesion: 0.22
+Nodes (18): append(), checkpoint(), complete(), ensureIncomplete(), interrupt(), sortedCheckpoints(), sortedEvents(), sortedReferences() (+10 more)
 
 ### Community 436 - "Community 436"
-Cohesion: 0.22
-Nodes (9): FailureBriefReporterTest, AssertionError, Attachment, List, String, SuppressWarnings, Test, TestExecutionInfo (+1 more)
+Cohesion: 0.19
+Nodes (9): CaptureFixtures, PageContext, BrowserMetadata, CaptureEvent, CaptureSession, ElementSnapshot, EventContext, ExternalTestDataReference (+1 more)
 
 ### Community 437 - "Community 437"
 Cohesion: 0.20
@@ -2510,7 +2504,7 @@ Cohesion: 0.33
 Nodes (5): steps, Given, String, Then, When
 
 ### Community 451 - "Community 451"
-Cohesion: 0.17
+Cohesion: 0.21
 Nodes (4): AlertActions, Override, PlaywrightSession, String
 
 ### Community 452 - "Community 452"
@@ -2518,16 +2512,16 @@ Cohesion: 0.40
 Nodes (3): UploadFileTests, String, Test
 
 ### Community 453 - "Community 453"
-Cohesion: 0.24
-Nodes (4): ValidationsHelperNewPatternCoverageUnitTest, VisualValidationEngine, AfterMethod, Test
+Cohesion: 0.16
+Nodes (13): requestTarget(), ShaftRestAssuredFilter, ApiEvidenceLabels, FilterableResponseSpecification, FilterContext, JsonElement, FilterableRequestSpecification, Object (+5 more)
 
 ### Community 454 - "Community 454"
 Cohesion: 0.31
 Nodes (4): AfterMethod, BeforeMethod, Test, VisualValidationTests
 
 ### Community 455 - "Community 455"
-Cohesion: 0.30
-Nodes (4): PlaywrightActionsE2ETestBase, AfterMethod, Playwright, Test
+Cohesion: 0.20
+Nodes (6): PlaywrightActionsE2ETestBase, AfterMethod, BeforeMethod, Playwright, String, Test
 
 ### Community 456 - "Community 456"
 Cohesion: 0.27
@@ -2558,8 +2552,8 @@ Cohesion: 0.36
 Nodes (4): ChecksumTests, Path, String, Test
 
 ### Community 463 - "Community 463"
-Cohesion: 0.13
-Nodes (12): ready(), unavailable(), DisabledAiProvider, AiProvider, AiProviderAvailability, String, AiCapabilities, AiProviderAvailability (+4 more)
+Cohesion: 0.14
+Nodes (11): ready(), unavailable(), DisabledAiProvider, AiProviderAvailability, String, AiCapabilities, AiProviderAvailability, AiRequest (+3 more)
 
 ### Community 464 - "Community 464"
 Cohesion: 0.21
@@ -2586,19 +2580,19 @@ Cohesion: 0.17
 Nodes (6): Performance, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 471 - "Community 471"
-Cohesion: 0.31
+Cohesion: 0.36
 Nodes (4): JunitDatabaseSmokeTest, AfterAll, BeforeAll, Test
 
 ### Community 472 - "Community 472"
-Cohesion: 0.33
-Nodes (4): AfterMethod, BeforeMethod, Test, TopUncoveredClassesCoverageUnitTest
+Cohesion: 0.21
+Nodes (6): Integer, Map, AfterMethod, BeforeMethod, Test, TopUncoveredClassesCoverageUnitTest
 
 ### Community 473 - "Community 473"
 Cohesion: 0.36
 Nodes (4): AfterMethod, BeforeMethod, Test, BrowserValidationsTests
 
 ### Community 474 - "Community 474"
-Cohesion: 0.36
+Cohesion: 0.41
 Nodes (7): BrowserNetworkInterceptionRule, Consumer, Function, HttpRequest, HttpResponse, Predicate, Response
 
 ### Community 475 - "Community 475"
@@ -2606,7 +2600,7 @@ Cohesion: 0.29
 Nodes (6): Deletion Checklist, Generated PR Workflows, GitHub Actions Workflows, Relationship Map, Shared Composite Actions, Workflow Inventory
 
 ### Community 476 - "Community 476"
-Cohesion: 0.29
+Cohesion: 0.21
 Nodes (7): HttpContractBrowserReplayTest, AfterMethod, HttpMethod, HttpRequest, HttpResponse, String, Test
 
 ### Community 477 - "Community 477"
@@ -2622,8 +2616,8 @@ Cohesion: 0.25
 Nodes (7): Diagnosis, Evidence Index, Findings, Missing Evidence, Privacy, Remediation, SHAFT Doctor Report
 
 ### Community 480 - "Community 480"
-Cohesion: 0.29
-Nodes (4): VisualProcessingProviderRegistry, List, Optional, VisualProcessingProvider
+Cohesion: 0.11
+Nodes (10): FilesSize, VisualProcessingProviderRegistry, List, Optional, VisualProcessingProvider, DesktopVideoRecordingProvider, Optional, Test (+2 more)
 
 ### Community 481 - "Community 481"
 Cohesion: 0.32
@@ -2634,8 +2628,8 @@ Cohesion: 0.27
 Nodes (7): DecisionResult, HealingDecisionEngine, HealingConfiguration, List, RankedCandidate, Status, String
 
 ### Community 483 - "Community 483"
-Cohesion: 0.31
-Nodes (3): DbTests, BeforeClass, Test
+Cohesion: 0.26
+Nodes (4): DbTests, BeforeClass, Test, DBWizardTests
 
 ### Community 484 - "Community 484"
 Cohesion: 0.36
@@ -2682,8 +2676,8 @@ Cohesion: 0.38
 Nodes (4): Executable, McpNoDriverServiceTest, BeforeEach, Test
 
 ### Community 495 - "Community 495"
-Cohesion: 0.36
-Nodes (5): TextLanguageValidationsBuilder, NativeValidationsBuilder, String, ValidationsExecutor, TextLanguage
+Cohesion: 0.20
+Nodes (6): FileReader, JSONFileManagerTestAccessor, SuppressWarnings, AfterMethod, Test, MemoryLeakFixTests
 
 ### Community 496 - "Community 496"
 Cohesion: 0.36
@@ -2710,8 +2704,8 @@ Cohesion: 0.29
 Nodes (4): PlaywrightNaturalActionExecutorTest, AfterMethod, BeforeMethod, Test
 
 ### Community 502 - "Community 502"
-Cohesion: 0.30
-Nodes (9): FakeRunner, Duration, List, Map, Override, Path, Process, ProcessResult (+1 more)
+Cohesion: 0.16
+Nodes (14): FakeRunner, McpMobileToolchainServiceTest, McpProcessRunner, Duration, List, Map, McpMobileToolchainDiagnostic, McpMobileToolchainStatus (+6 more)
 
 ### Community 504 - "Community 504"
 Cohesion: 0.36
@@ -2722,7 +2716,7 @@ Cohesion: 0.50
 Nodes (3): PlaywrightBrowserActionsUnitTest, PlaywrightNetworkInterceptor, Test
 
 ### Community 506 - "Community 506"
-Cohesion: 0.36
+Cohesion: 0.39
 Nodes (4): AfterMethod, Path, Test, ProjectStructureManagerTest
 
 ### Community 507 - "Community 507"
@@ -2742,8 +2736,8 @@ Cohesion: 0.36
 Nodes (4): AfterMethod, BeforeMethod, Test, CustomDriverInitializationTests
 
 ### Community 511 - "Community 511"
-Cohesion: 0.17
-Nodes (10): Autowired, ShaftMcpApplicationTests, EngineService, McpMobileInspectorRecordingService, McpMobileRecordingService, McpWorkspacePolicy, Set, String (+2 more)
+Cohesion: 0.36
+Nodes (4): ShaftMcpApplicationTests, Set, String, Test
 
 ### Community 512 - "Community 512"
 Cohesion: 0.31
@@ -2751,7 +2745,7 @@ Nodes (4): LocalApiTestServer, HttpExchange, HttpServer, String
 
 ### Community 513 - "Community 513"
 Cohesion: 0.06
-Nodes (18): testPostRequest, ArrayList, SHAFT, FileInputStream, AppiumMobileConsumer, BrowserStackSdkConsumer, LegacyCoordinateConsumer, IOException (+10 more)
+Nodes (20): ArrayList, SHAFT, AppiumMobileConsumer, BrowserStackSdkConsumer, LegacyCoordinateConsumer, IOException, JunitProjectStructureManagerTest, JsonActionsTests (+12 more)
 
 ### Community 514 - "Community 514"
 Cohesion: 0.43
@@ -2778,8 +2772,8 @@ Cohesion: 0.29
 Nodes (7): adapter, originalSha256, provenance, sourceReference, properties, required, type
 
 ### Community 520 - "Community 520"
-Cohesion: 0.18
-Nodes (8): ValidationsExecutor, FileValidationsBuilder, NativeValidationsBuilder, NumberValidationsBuilder, RestValidationsBuilder, Step, ValidationsBuilder, WebDriverElementValidationsBuilder
+Cohesion: 0.34
+Nodes (5): BrowserStackSdkHelper, List, Map, Object, String
 
 ### Community 521 - "Community 521"
 Cohesion: 0.33
@@ -2802,8 +2796,8 @@ Cohesion: 0.39
 Nodes (3): BrowserAssertions, NativeValidationsBuilder, String
 
 ### Community 527 - "Community 527"
-Cohesion: 0.36
-Nodes (4): McpMobileToolchainServiceTest, McpMobileToolchainDiagnostic, McpMobileToolchainStatus, Test
+Cohesion: 0.23
+Nodes (3): ThreadLocalPropertiesManager, Properties, String
 
 ### Community 528 - "Community 528"
 Cohesion: 0.25
@@ -2866,8 +2860,8 @@ Cohesion: 0.47
 Nodes (3): PatternTests, BeforeClass, Test
 
 ### Community 545 - "Community 545"
-Cohesion: 0.32
-Nodes (3): DesktopVideoRecordingProvider, Optional, DesktopVideoRecordingProviderRegistry
+Cohesion: 0.28
+Nodes (6): BasicAPITests, AfterClass, BeforeClass, List, Map, String
 
 ### Community 546 - "Community 546"
 Cohesion: 0.47
@@ -2882,8 +2876,8 @@ Cohesion: 0.47
 Nodes (3): PlatformTests, BeforeClass, Test
 
 ### Community 549 - "Community 549"
-Cohesion: 0.33
-Nodes (5): $id, required, $schema, title, type
+Cohesion: 0.13
+Nodes (14): items, type, $id, required, type, properties, evidence, redaction (+6 more)
 
 ### Community 550 - "Community 550"
 Cohesion: 0.47
@@ -2918,8 +2912,8 @@ Cohesion: 0.27
 Nodes (8): AiBudget, defaults(), disabled(), defaults(), ApprovalPolicy, DoctorAiAnalysisRequest, ApprovalPolicy, DoctorRepairAiRequest
 
 ### Community 562 - "Community 562"
-Cohesion: 0.29
-Nodes (4): AfterMethod, String, Test, PropertiesHelperInitializationUnitTest
+Cohesion: 0.27
+Nodes (9): DoctorReportWriter, Diagnosis, DoctorAdvisory, EvidenceBundle, List, Path, String, StringBuilder (+1 more)
 
 ### Community 563 - "Community 563"
 Cohesion: 0.43
@@ -2946,7 +2940,7 @@ Cohesion: 0.60
 Nodes (4): copy(), text(), List, String
 
 ### Community 569 - "Community 569"
-Cohesion: 0.36
+Cohesion: 0.38
 Nodes (4): JunitApiSmokeTest, AfterAll, BeforeAll, Test
 
 ### Community 570 - "Community 570"
@@ -2958,8 +2952,8 @@ Cohesion: 0.40
 Nodes (4): Allowed Work, Constraints, Refresh Agent Guidance, Validation
 
 ### Community 572 - "Community 572"
-Cohesion: 0.10
-Nodes (14): IOSBasicInteractionsTest, Test_LTMobIPAAppURL, Test_LTMobIPARelativePath, AfterMethod, BeforeMethod, SuppressWarnings, Test, AfterMethod (+6 more)
+Cohesion: 0.29
+Nodes (5): Test_LTMobIPAAppURL, AfterMethod, BeforeMethod, String, Test
 
 ### Community 573 - "Community 573"
 Cohesion: 0.40
@@ -2972,6 +2966,10 @@ Nodes (3): Output, Workflow, CI Failure Investigator
 ### Community 576 - "Community 576"
 Cohesion: 0.50
 Nodes (4): build_parser(), main(), Build the command-line parser., ArgumentParser
+
+### Community 578 - "Community 578"
+Cohesion: 0.23
+Nodes (5): AfterMethod, BeforeMethod, Path, Test, ExcelFileManagerCoverageUnitTest
 
 ### Community 580 - "Community 580"
 Cohesion: 0.50
@@ -2994,8 +2992,8 @@ Cohesion: 0.36
 Nodes (4): HealingReportWriter, HealingConfiguration, HealingReport, String
 
 ### Community 588 - "Community 588"
-Cohesion: 0.36
-Nodes (3): JUnitWebConsumer, AfterAll, Test
+Cohesion: 0.23
+Nodes (4): UnitTestsSHAFT, CSVFileManager, CSV, Test
 
 ### Community 591 - "Community 591"
 Cohesion: 0.50
@@ -3030,7 +3028,7 @@ Cohesion: 0.67
 Nodes (3): minLength, type, id
 
 ### Community 615 - "Community 615"
-Cohesion: 0.29
+Cohesion: 0.31
 Nodes (5): AfterEach, BeforeAll, BeforeEach, Test, TestClass
 
 ### Community 616 - "Community 616"
@@ -3046,28 +3044,32 @@ Cohesion: 0.47
 Nodes (3): VisualsTests, BeforeClass, Test
 
 ### Community 626 - "Community 626"
-Cohesion: 0.50
-Nodes (3): Object, StringBuilder, ValidationCategory
+Cohesion: 0.31
+Nodes (6): HttpContractRecorderTest, AfterMethod, FilterableRequestSpecification, Response, String, Test
+
+### Community 628 - "Community 628"
+Cohesion: 0.25
+Nodes (6): WebDomHealingAcceptanceTest, AfterMethod, BeforeMethod, Path, String, Test
 
 ### Community 650 - "Community 650"
 Cohesion: 0.47
 Nodes (3): MobileTests, BeforeClass, Test
 
 ### Community 651 - "Community 651"
-Cohesion: 0.36
-Nodes (3): TestNgWebConsumer, AfterSuite, Test
+Cohesion: 0.24
+Nodes (3): TestAutomationServiceTest, McpScenarioCatalogResult, Test
 
 ### Community 652 - "Community 652"
 Cohesion: 0.43
 Nodes (3): AfterMethod, Test, PropertiesHelperMaximumPerformanceModeUnitTest
 
 ### Community 653 - "Community 653"
-Cohesion: 0.33
-Nodes (4): JDK21VirtualThreadsAndAsyncActionsTests, AfterMethod, BeforeMethod, Test
+Cohesion: 0.26
+Nodes (4): AfterMethod, BeforeMethod, Test, BrowserActionsHelperCoverageUnitTest
 
 ### Community 654 - "Community 654"
-Cohesion: 0.67
-Nodes (3): minLength, type, mediaType
+Cohesion: 0.36
+Nodes (3): XpathAxis, LocatorBuilder, String
 
 ### Community 655 - "Community 655"
 Cohesion: 0.32
@@ -3086,20 +3088,24 @@ Cohesion: 0.31
 Nodes (6): RepairProcessRunner, Duration, List, Path, ProcessResult, String
 
 ### Community 659 - "Community 659"
-Cohesion: 0.20
+Cohesion: 0.18
 Nodes (7): ReportManager, SkipDueToIssueTests, Level, String, Issue, Issues, Test
 
 ### Community 660 - "Community 660"
-Cohesion: 0.10
-Nodes (13): AccessibilityActions, AccessibilityConfig, AccessibilityTest, AccessibilityResult, BrowserActions, BrowserActionsContract, List, Page (+5 more)
+Cohesion: 0.24
+Nodes (4): AccessibilityActions, AccessibilityConfig, AccessibilityResult, String
 
 ### Community 661 - "Community 661"
 Cohesion: 0.47
 Nodes (3): TinkeyTests, BeforeClass, Test
 
 ### Community 662 - "Community 662"
-Cohesion: 0.29
-Nodes (7): enum, updateRelation, confidence, additionalProperties, properties, required, type
+Cohesion: 0.38
+Nodes (3): Contract, Interaction, Path
+
+### Community 663 - "Community 663"
+Cohesion: 0.25
+Nodes (4): DatabaseActions, DB, DatabaseType, ResultSet
 
 ### Community 664 - "Community 664"
 Cohesion: 0.42
@@ -3110,24 +3116,36 @@ Cohesion: 0.42
 Nodes (5): ClassifiedValue, Collection, Path, String, ExternalTestDataWriter
 
 ### Community 666 - "Community 666"
-Cohesion: 0.36
-Nodes (4): AfterMethod, BeforeMethod, Test, RecordManagerCoverageUnitTest
+Cohesion: 0.31
+Nodes (4): SelectedValueTests, AfterMethod, BeforeMethod, Test
+
+### Community 668 - "Community 668"
+Cohesion: 0.38
+Nodes (5): Locator, Beta, By, LocatorBuilder, String
 
 ### Community 669 - "Community 669"
-Cohesion: 0.39
-Nodes (4): JunitProjectStructureManagerTest, AfterEach, Path, Test
+Cohesion: 0.31
+Nodes (4): MultipleElementsFailureTest, AfterMethod, BeforeMethod, Test
+
+### Community 670 - "Community 670"
+Cohesion: 0.31
+Nodes (4): NoSuchElementFailureTest, AfterMethod, BeforeMethod, Test
 
 ### Community 671 - "Community 671"
 Cohesion: 0.36
 Nodes (4): RelativeLocatorsTests, AfterMethod, BeforeMethod, Test
 
+### Community 672 - "Community 672"
+Cohesion: 0.31
+Nodes (4): JSONValidationsBuilder, Object, RestValidationsBuilder, ValidationsExecutor
+
 ### Community 673 - "Community 673"
-Cohesion: 0.33
-Nodes (4): Actions, CheckpointType, Map, Response
+Cohesion: 0.31
+Nodes (5): IOSBasicInteractionsTest, AfterMethod, BeforeMethod, SuppressWarnings, Test
 
 ### Community 674 - "Community 674"
-Cohesion: 0.17
-Nodes (12): minLength, type, type, properties, bundleId, evidence, redaction, schemaVersion (+4 more)
+Cohesion: 0.67
+Nodes (3): minLength, type, bundleId
 
 ### Community 675 - "Community 675"
 Cohesion: 0.67
@@ -3141,9 +3159,9 @@ Nodes (4): CaptureFormatException, String, Throwable, IllegalArgumentException
 Cohesion: 0.36
 Nodes (4): LazyLoadingTests, AfterMethod, BeforeMethod, Test
 
-### Community 679 - "Community 679"
-Cohesion: 0.15
-Nodes (5): CheckpointCounter, String, String, PerformanceReportHTMLHelper, ReportHtmlTheme
+### Community 685 - "Community 685"
+Cohesion: 0.43
+Nodes (4): PlaywrightNetworkInterceptorTest, Route, String, Test
 
 ### Community 686 - "Community 686"
 Cohesion: 0.40
@@ -3165,13 +3183,25 @@ Nodes (4): defaults(), DoctorAnalysisRequest, List, Path
 Cohesion: 0.36
 Nodes (3): PlaywrightMobileWebE2ETestBase, String, Test
 
+### Community 760 - "Community 760"
+Cohesion: 0.36
+Nodes (4): Test_LTMobIPARelativePath, AfterMethod, BeforeMethod, Test
+
+### Community 763 - "Community 763"
+Cohesion: 0.43
+Nodes (5): BrowserActions, BrowserActionsContract, List, Page, WebDriver
+
 ### Community 768 - "Community 768"
 Cohesion: 0.33
-Nodes (4): AiAuditSink, ShaftAiAuditSink, AiAuditEvent, Override
+Nodes (5): Autowired, EngineService, McpMobileInspectorRecordingService, McpMobileRecordingService, McpWorkspacePolicy
 
 ### Community 769 - "Community 769"
 Cohesion: 0.38
 Nodes (5): CaptureCliTest, Class, Object, String, Test
+
+### Community 770 - "Community 770"
+Cohesion: 0.24
+Nodes (5): BomConsumer, OpenCvVisualConsumer, String, String, VisualProcessingProvider
 
 ### Community 771 - "Community 771"
 Cohesion: 0.47
@@ -3186,15 +3216,15 @@ Cohesion: 0.36
 Nodes (3): IPhone17ProMaxPlaywrightActionsE2ETest, Override, String
 
 ### Community 780 - "Community 780"
-Cohesion: 0.20
-Nodes (5): ExecutionSummaryReport, StatusIcon(), CheckpointStatus, String, StringBuilder
+Cohesion: 0.22
+Nodes (3): ExecutionSummaryReport, CheckpointStatus, StringBuilder
 
 ### Community 781 - "Community 781"
 Cohesion: 0.53
 Nodes (3): Path, Test, ExecutionLifecycleHelperSourceUnitTest
 
 ### Community 782 - "Community 782"
-Cohesion: 0.29
+Cohesion: 0.31
 Nodes (5): AfterMethod, BeforeClass, BeforeMethod, Test, TestClass
 
 ### Community 787 - "Community 787"
@@ -3205,13 +3235,17 @@ Nodes (14): limiterKey(), RemoteGridPreflight, unavailable(), PreflightReport, S
 Cohesion: 0.16
 Nodes (15): build_parser(), coordinates_have_supported_runner(), coordinates_have_supported_stack(), ensure_shaft_import(), migrate_full_source(), migrate_session_source(), ArgumentParser, Add the SHAFT import required by rewritten Java source. (+7 more)
 
+### Community 789 - "Community 789"
+Cohesion: 0.40
+Nodes (4): ElementAssertions, Locator, PlaywrightSession, ValidationCategory
+
 ### Community 795 - "Community 795"
 Cohesion: 0.52
 Nodes (3): CaptureRuntimePortabilityTest, Path, Test
 
 ### Community 799 - "Community 799"
-Cohesion: 0.16
-Nodes (13): ElementAssertions, Locator, NativeValidationsBuilder, Override, PlaywrightNativeValidationsBuilder, PlaywrightSession, PlaywrightValidationsExecutor, String (+5 more)
+Cohesion: 0.20
+Nodes (9): NativeValidationsBuilder, Override, PlaywrightNativeValidationsBuilder, PlaywrightValidationsExecutor, String, ValidationsExecutor, ValidationType, VisualValidationEngine (+1 more)
 
 ### Community 800 - "Community 800"
 Cohesion: 0.47
@@ -3234,35 +3268,67 @@ Cohesion: 0.53
 Nodes (3): RepairProposalStore, Path, RepairProposal
 
 ### Community 809 - "Community 809"
-Cohesion: 0.22
-Nodes (8): Callable, CaptureEnrichmentService, GeneratedTestValidator, LocatorRanker, CaptureJsonCodec, Path, Test, CaptureSessionStoreTest
+Cohesion: 0.46
+Nodes (4): Callable, Path, Test, CaptureSessionStoreTest
 
 ### Community 812 - "Community 812"
-Cohesion: 0.50
-Nodes (3): SourceContext, StackTraceElement, Throwable
+Cohesion: 0.33
+Nodes (3): PrivacySanitizer, SanitizedValue, String
 
 ### Community 817 - "Community 817"
-Cohesion: 0.10
-Nodes (17): RequestBuilder, RetryState, RetryPolicy, RetryState, API, ContentType, Deprecated, Exception (+9 more)
+Cohesion: 0.09
+Nodes (16): RequestBuilder, RetryState, AuthenticationType, RetryPolicy, RetryState, API, Deprecated, Exception (+8 more)
+
+### Community 831 - "Community 831"
+Cohesion: 0.70
+Nodes (4): HistoryRecord(), withChecksum(), LocatorFingerprint, String
+
+### Community 832 - "Community 832"
+Cohesion: 0.50
+Nodes (3): Log4jTests, BeforeClass, Test
+
+### Community 833 - "Community 833"
+Cohesion: 0.40
+Nodes (3): DriverFactoryHelper, WebDriver, WebDriverElementValidationsBuilder
+
+### Community 835 - "Community 835"
+Cohesion: 0.50
+Nodes (3): McpMobileToolchainService, McpMobileRecordingService, McpWorkspacePolicy
+
+### Community 838 - "Community 838"
+Cohesion: 0.67
+Nodes (3): safe(), stableKey(), String
+
+### Community 839 - "Community 839"
+Cohesion: 0.50
+Nodes (4): markStale, additionalProperties, required, type
+
+### Community 840 - "Community 840"
+Cohesion: 0.50
+Nodes (4): supersedeObject, additionalProperties, required, type
+
+### Community 845 - "Community 845"
+Cohesion: 0.67
+Nodes (3): schemaVersion, enum, type
 
 ## Knowledge Gaps
 - **1523 isolated node(s):** `$id`, `$schema`, `additionalProperties`, `additionalProperties`, `type` (+1518 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **100 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **91 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `SHAFT` connect `Community 513` to `Community 514`, `Community 3`, `Community 5`, `Community 7`, `Community 8`, `Community 9`, `Community 10`, `Community 12`, `Community 13`, `Community 15`, `Community 16`, `Community 17`, `Community 18`, `Community 529`, `Community 19`, `Community 21`, `Community 22`, `Community 23`, `Community 24`, `Community 536`, `Community 26`, `Community 538`, `Community 27`, `Community 540`, `Community 30`, `Community 31`, `Community 543`, `Community 33`, `Community 34`, `Community 547`, `Community 36`, `Community 35`, `Community 38`, `Community 544`, `Community 548`, `Community 546`, `Community 550`, `Community 43`, `Community 553`, `Community 45`, `Community 46`, `Community 47`, `Community 555`, `Community 49`, `Community 563`, `Community 52`, `Community 53`, `Community 55`, `Community 569`, `Community 57`, `Community 572`, `Community 65`, `Community 69`, `Community 71`, `Community 584`, `Community 74`, `Community 588`, `Community 76`, `Community 77`, `Community 80`, `Community 81`, `Community 594`, `Community 597`, `Community 86`, `Community 87`, `Community 599`, `Community 89`, `Community 88`, `Community 93`, `Community 98`, `Community 99`, `Community 103`, `Community 104`, `Community 615`, `Community 106`, `Community 108`, `Community 621`, `Community 112`, `Community 114`, `Community 116`, `Community 121`, `Community 123`, `Community 125`, `Community 130`, `Community 134`, `Community 137`, `Community 138`, `Community 650`, `Community 651`, `Community 653`, `Community 142`, `Community 655`, `Community 656`, `Community 145`, `Community 657`, `Community 652`, `Community 660`, `Community 661`, `Community 28`, `Community 151`, `Community 539`, `Community 664`, `Community 666`, `Community 156`, `Community 669`, `Community 159`, `Community 671`, `Community 673`, `Community 541`, `Community 32`, `Community 162`, `Community 165`, `Community 678`, `Community 677`, `Community 167`, `Community 542`, `Community 170`, `Community 171`, `Community 172`, `Community 174`, `Community 177`, `Community 184`, `Community 186`, `Community 190`, `Community 191`, `Community 196`, `Community 39`, `Community 210`, `Community 217`, `Community 218`, `Community 219`, `Community 225`, `Community 230`, `Community 233`, `Community 235`, `Community 241`, `Community 243`, `Community 247`, `Community 760`, `Community 251`, `Community 254`, `Community 766`, `Community 768`, `Community 257`, `Community 770`, `Community 771`, `Community 260`, `Community 261`, `Community 266`, `Community 781`, `Community 270`, `Community 782`, `Community 785`, `Community 786`, `Community 275`, `Community 787`, `Community 276`, `Community 273`, `Community 277`, `Community 280`, `Community 279`, `Community 274`, `Community 284`, `Community 286`, `Community 287`, `Community 290`, `Community 293`, `Community 161`, `Community 301`, `Community 817`, `Community 311`, `Community 312`, `Community 316`, `Community 317`, `Community 831`, `Community 833`, `Community 834`, `Community 327`, `Community 328`, `Community 329`, `Community 330`, `Community 334`, `Community 337`, `Community 342`, `Community 348`, `Community 351`, `Community 352`, `Community 353`, `Community 354`, `Community 358`, `Community 359`, `Community 360`, `Community 362`, `Community 364`, `Community 367`, `Community 373`, `Community 374`, `Community 375`, `Community 378`, `Community 379`, `Community 380`, `Community 389`, `Community 390`, `Community 391`, `Community 392`, `Community 394`, `Community 395`, `Community 399`, `Community 401`, `Community 403`, `Community 404`, `Community 405`, `Community 407`, `Community 408`, `Community 409`, `Community 411`, `Community 424`, `Community 427`, `Community 428`, `Community 429`, `Community 430`, `Community 431`, `Community 432`, `Community 434`, `Community 444`, `Community 446`, `Community 450`, `Community 453`, `Community 454`, `Community 456`, `Community 460`, `Community 461`, `Community 467`, `Community 468`, `Community 471`, `Community 473`, `Community 476`, `Community 484`, `Community 485`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 496`, `Community 498`, `Community 503`, `Community 504`, `Community 506`, `Community 509`, `Community 510`?**
-  _High betweenness centrality (0.160) - this node is a cross-community bridge._
-- **Why does `IOException` connect `Community 513` to `Community 512`, `Community 517`, `Community 7`, `Community 8`, `Community 523`, `Community 13`, `Community 18`, `Community 530`, `Community 19`, `Community 535`, `Community 24`, `Community 25`, `Community 28`, `Community 29`, `Community 31`, `Community 41`, `Community 558`, `Community 49`, `Community 562`, `Community 52`, `Community 565`, `Community 56`, `Community 57`, `Community 60`, `Community 61`, `Community 62`, `Community 64`, `Community 65`, `Community 71`, `Community 72`, `Community 74`, `Community 587`, `Community 76`, `Community 79`, `Community 597`, `Community 86`, `Community 87`, `Community 85`, `Community 102`, `Community 103`, `Community 105`, `Community 114`, `Community 116`, `Community 117`, `Community 122`, `Community 129`, `Community 131`, `Community 133`, `Community 138`, `Community 141`, `Community 145`, `Community 658`, `Community 148`, `Community 665`, `Community 154`, `Community 155`, `Community 156`, `Community 669`, `Community 159`, `Community 170`, `Community 174`, `Community 177`, `Community 178`, `Community 179`, `Community 189`, `Community 200`, `Community 209`, `Community 211`, `Community 212`, `Community 216`, `Community 217`, `Community 218`, `Community 220`, `Community 241`, `Community 244`, `Community 253`, `Community 257`, `Community 273`, `Community 787`, `Community 277`, `Community 279`, `Community 288`, `Community 807`, `Community 295`, `Community 299`, `Community 313`, `Community 314`, `Community 328`, `Community 337`, `Community 353`, `Community 363`, `Community 381`, `Community 392`, `Community 410`, `Community 417`, `Community 418`, `Community 425`, `Community 428`, `Community 433`, `Community 445`, `Community 456`, `Community 458`, `Community 506`?**
+- **Why does `SHAFT` connect `Community 513` to `Community 514`, `Community 3`, `Community 5`, `Community 7`, `Community 8`, `Community 9`, `Community 10`, `Community 12`, `Community 13`, `Community 16`, `Community 17`, `Community 18`, `Community 529`, `Community 19`, `Community 21`, `Community 22`, `Community 23`, `Community 24`, `Community 536`, `Community 26`, `Community 538`, `Community 27`, `Community 540`, `Community 30`, `Community 31`, `Community 32`, `Community 543`, `Community 33`, `Community 545`, `Community 547`, `Community 36`, `Community 38`, `Community 35`, `Community 34`, `Community 544`, `Community 548`, `Community 43`, `Community 550`, `Community 45`, `Community 46`, `Community 47`, `Community 553`, `Community 49`, `Community 555`, `Community 51`, `Community 52`, `Community 53`, `Community 563`, `Community 55`, `Community 569`, `Community 57`, `Community 572`, `Community 65`, `Community 69`, `Community 71`, `Community 584`, `Community 74`, `Community 588`, `Community 76`, `Community 77`, `Community 80`, `Community 81`, `Community 594`, `Community 597`, `Community 87`, `Community 88`, `Community 89`, `Community 599`, `Community 93`, `Community 96`, `Community 98`, `Community 99`, `Community 615`, `Community 104`, `Community 106`, `Community 108`, `Community 621`, `Community 114`, `Community 626`, `Community 116`, `Community 628`, `Community 121`, `Community 123`, `Community 125`, `Community 130`, `Community 134`, `Community 137`, `Community 138`, `Community 650`, `Community 652`, `Community 653`, `Community 142`, `Community 655`, `Community 656`, `Community 657`, `Community 145`, `Community 661`, `Community 663`, `Community 539`, `Community 664`, `Community 666`, `Community 151`, `Community 156`, `Community 669`, `Community 670`, `Community 159`, `Community 671`, `Community 673`, `Community 541`, `Community 162`, `Community 161`, `Community 165`, `Community 678`, `Community 677`, `Community 542`, `Community 169`, `Community 170`, `Community 171`, `Community 172`, `Community 173`, `Community 174`, `Community 177`, `Community 184`, `Community 185`, `Community 186`, `Community 546`, `Community 190`, `Community 191`, `Community 196`, `Community 39`, `Community 199`, `Community 200`, `Community 210`, `Community 214`, `Community 217`, `Community 218`, `Community 219`, `Community 222`, `Community 223`, `Community 225`, `Community 230`, `Community 235`, `Community 241`, `Community 243`, `Community 247`, `Community 760`, `Community 763`, `Community 251`, `Community 254`, `Community 257`, `Community 770`, `Community 771`, `Community 260`, `Community 261`, `Community 266`, `Community 781`, `Community 270`, `Community 271`, `Community 782`, `Community 785`, `Community 786`, `Community 275`, `Community 787`, `Community 276`, `Community 273`, `Community 279`, `Community 280`, `Community 281`, `Community 274`, `Community 284`, `Community 286`, `Community 287`, `Community 290`, `Community 293`, `Community 817`, `Community 309`, `Community 311`, `Community 312`, `Community 316`, `Community 317`, `Community 832`, `Community 834`, `Community 327`, `Community 328`, `Community 329`, `Community 841`, `Community 330`, `Community 337`, `Community 342`, `Community 348`, `Community 351`, `Community 352`, `Community 353`, `Community 354`, `Community 358`, `Community 359`, `Community 360`, `Community 362`, `Community 364`, `Community 367`, `Community 372`, `Community 373`, `Community 374`, `Community 375`, `Community 378`, `Community 379`, `Community 380`, `Community 389`, `Community 390`, `Community 391`, `Community 392`, `Community 394`, `Community 395`, `Community 399`, `Community 401`, `Community 403`, `Community 404`, `Community 405`, `Community 407`, `Community 408`, `Community 409`, `Community 411`, `Community 424`, `Community 427`, `Community 428`, `Community 429`, `Community 430`, `Community 431`, `Community 432`, `Community 434`, `Community 444`, `Community 446`, `Community 450`, `Community 453`, `Community 454`, `Community 455`, `Community 456`, `Community 460`, `Community 461`, `Community 467`, `Community 468`, `Community 471`, `Community 473`, `Community 476`, `Community 480`, `Community 483`, `Community 484`, `Community 485`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 496`, `Community 498`, `Community 503`, `Community 504`, `Community 506`, `Community 509`, `Community 510`?**
+  _High betweenness centrality (0.159) - this node is a cross-community bridge._
+- **Why does `IOException` connect `Community 513` to `Community 512`, `Community 517`, `Community 7`, `Community 8`, `Community 523`, `Community 13`, `Community 18`, `Community 530`, `Community 19`, `Community 535`, `Community 24`, `Community 25`, `Community 28`, `Community 29`, `Community 31`, `Community 32`, `Community 545`, `Community 41`, `Community 558`, `Community 49`, `Community 562`, `Community 52`, `Community 565`, `Community 56`, `Community 57`, `Community 60`, `Community 61`, `Community 62`, `Community 64`, `Community 578`, `Community 71`, `Community 72`, `Community 74`, `Community 587`, `Community 76`, `Community 79`, `Community 597`, `Community 85`, `Community 87`, `Community 88`, `Community 102`, `Community 105`, `Community 116`, `Community 628`, `Community 117`, `Community 120`, `Community 122`, `Community 129`, `Community 131`, `Community 133`, `Community 138`, `Community 141`, `Community 658`, `Community 147`, `Community 148`, `Community 150`, `Community 665`, `Community 154`, `Community 155`, `Community 156`, `Community 159`, `Community 169`, `Community 170`, `Community 177`, `Community 179`, `Community 189`, `Community 200`, `Community 211`, `Community 212`, `Community 214`, `Community 216`, `Community 218`, `Community 220`, `Community 225`, `Community 241`, `Community 244`, `Community 253`, `Community 257`, `Community 273`, `Community 787`, `Community 277`, `Community 279`, `Community 280`, `Community 288`, `Community 291`, `Community 293`, `Community 807`, `Community 299`, `Community 313`, `Community 314`, `Community 328`, `Community 333`, `Community 337`, `Community 348`, `Community 363`, `Community 381`, `Community 392`, `Community 410`, `Community 412`, `Community 417`, `Community 418`, `Community 425`, `Community 428`, `Community 445`, `Community 455`, `Community 456`, `Community 458`, `Community 495`, `Community 506`?**
   _High betweenness centrality (0.029) - this node is a cross-community bridge._
-- **Why does `ZipFile` connect `Community 500` to `Community 11`, `Community 366`, `Community 400`, `Community 240`, `Community 18`, `Community 54`, `Community 280`?**
+- **Why does `ZipFile` connect `Community 500` to `Community 170`, `Community 11`, `Community 366`, `Community 400`, `Community 240`, `Community 18`, `Community 54`?**
   _High betweenness centrality (0.029) - this node is a cross-community bridge._
 - **What connects `$id`, `$schema`, `additionalProperties` to the rest of the system?**
   _1634 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.040179910044977514 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.04231016731016731 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
   _Cohesion score 0.0546448087431694 - nodes in this community are weakly interconnected._
 - **Should `Community 2` be split into smaller, more focused modules?**

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1,5827 +1,5827 @@
 {
   ".memory/config.json": {
-    "mtime": 1782538948.6766622,
+    "mtime": 1782540713.72781,
     "ast_hash": "4ece894daf076c559889cf9afe6211e8",
     "semantic_hash": ""
   },
   ".memory/memory/architecture.json": {
-    "mtime": 1782538948.6786628,
+    "mtime": 1782540713.728811,
     "ast_hash": "cfc3c045ead7b74d483c04bc6746ea4e",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/maven-central-version-immutability.json": {
-    "mtime": 1782538948.6816626,
+    "mtime": 1782540713.7338116,
     "ast_hash": "434d7f5918634bb78e5a7abc8d7bf7ce",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/paid-agent-work-audit-gated.json": {
-    "mtime": 1782538948.6816626,
+    "mtime": 1782540713.7338116,
     "ast_hash": "61f81f00078da8d614a21373fd7e8089",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/agent-guidance-progressive-disclosure.json": {
-    "mtime": 1782538948.6836636,
+    "mtime": 1782540713.735927,
     "ast_hash": "d112f6080b24b67628173736e69c67e0",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/namespaced-video-capabilities.json": {
-    "mtime": 1782538948.6896617,
+    "mtime": 1782540713.7484248,
     "ast_hash": "38736f88f73b401031d168040fb2e609",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/public-docs-external.json": {
-    "mtime": 1782538948.692662,
+    "mtime": 1782540713.75142,
     "ast_hash": "dad3f0a3b650c5264d8dd7e4e4e366df",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/utf8-all-runtime-layers.json": {
-    "mtime": 1782538948.6976619,
+    "mtime": 1782540713.7554681,
     "ast_hash": "0537ffa6937eab44bf326e9a2af4eca9",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/allure-result-population.json": {
-    "mtime": 1782538948.7016625,
+    "mtime": 1782540713.7594693,
     "ast_hash": "0b408e349588a98b38afad0c067e86da",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/coverage-constructors-start-browser.json": {
-    "mtime": 1782538948.702662,
+    "mtime": 1782540713.7604692,
     "ast_hash": "c26c533a52af00631104647ed120e846",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/java25-isuite-mocking.json": {
-    "mtime": 1782538948.7046616,
+    "mtime": 1782540713.7624688,
     "ast_hash": "172391dc5cc831f90c86f7f71b305c19",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/testng-method-parallel-shared-instance-fields.json": {
-    "mtime": 1782538948.7076619,
+    "mtime": 1782540713.765172,
     "ast_hash": "1d489c077df56ae50e23e4b41f6da2f3",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/testng-single-threaded-static-state.json": {
-    "mtime": 1782538948.7086635,
+    "mtime": 1782540713.7655015,
     "ast_hash": "41ae606ccc9cebd6325667da85ac2392",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/windows-allure-root-race.json": {
-    "mtime": 1782538948.7096615,
+    "mtime": 1782540713.7665005,
     "ast_hash": "2f12b8774174d36ad6dd9f7375c9ebca",
     "semantic_hash": ""
   },
   ".memory/memory/project.json": {
-    "mtime": 1782538948.7116623,
+    "mtime": 1782540713.7675023,
     "ast_hash": "f0a00de79160381997ea0562bcea283c",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/issue-linked-pr-closure-and-focused-tests.json": {
-    "mtime": 1782538948.7236617,
+    "mtime": 1782540713.7825396,
     "ast_hash": "ec46aa71d095fface3f1692bde6926b1",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/low-token-user-guide-work.json": {
-    "mtime": 1782538948.7256625,
+    "mtime": 1782540713.7847083,
     "ast_hash": "b4fd7b27d046eccd67b552fac5f7d31c",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/proactive-memory-use-when-material.json": {
-    "mtime": 1782538948.7276628,
+    "mtime": 1782540713.7878263,
     "ast_hash": "dcc3243cb2aef6624523d32b6a2ec027",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/start-new-tasks-from-origin-main.json": {
-    "mtime": 1782538948.7316608,
+    "mtime": 1782540713.7938247,
     "ast_hash": "20f6aadf28b59bac7d81d77b252caa72",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/update-official-user-guide-for-functionality-changes.json": {
-    "mtime": 1782538948.7336614,
+    "mtime": 1782540713.796344,
     "ast_hash": "25cd51397aafa8823d00734801c3b62f",
     "semantic_hash": ""
   },
   ".memory/relations/project-shaft-engine-related-to-architecture-current.json": {
-    "mtime": 1782538948.7386627,
+    "mtime": 1782540713.7993436,
     "ast_hash": "61f899057083188f3c611b1207e86344",
     "semantic_hash": ""
   },
   ".memory/schema/config.schema.json": {
-    "mtime": 1782538948.7426627,
+    "mtime": 1782540713.8049738,
     "ast_hash": "a9df65611183adc20ed4598acd8c8496",
     "semantic_hash": ""
   },
   ".memory/schema/event.schema.json": {
-    "mtime": 1782538948.7426627,
+    "mtime": 1782540713.8049738,
     "ast_hash": "b48fe7cc7267789e3f05371800d2572f",
     "semantic_hash": ""
   },
   ".memory/schema/object.schema.json": {
-    "mtime": 1782538948.743664,
+    "mtime": 1782540713.806006,
     "ast_hash": "df0c4608282c91449d7445ca2109376f",
     "semantic_hash": ""
   },
   ".memory/schema/patch.schema.json": {
-    "mtime": 1782538948.743664,
+    "mtime": 1782540713.806006,
     "ast_hash": "5476dea56f653fe6ae9b3237c911dc6a",
     "semantic_hash": ""
   },
   ".memory/schema/relation.schema.json": {
-    "mtime": 1782538948.743664,
+    "mtime": 1782540713.8070076,
     "ast_hash": "05342c9eb8c7b7bdc8ef3a73d3eedc5a",
     "semantic_hash": ""
   },
   "scripts/ci/agent_guidance_budget.json": {
-    "mtime": 1782539395.9945378,
-    "ast_hash": "fe1749286b2b1a8e60b7bebb111a1fee",
+    "mtime": 1782540713.9294388,
+    "ast_hash": "7888f39a7d89d850aaeaf0a1903e23f7",
     "semantic_hash": ""
   },
   "scripts/ci/assemble_javadocs.py": {
-    "mtime": 1782538948.8349593,
+    "mtime": 1782540713.9294388,
     "ast_hash": "6fe67ccde798d4838393acaf16b87261",
     "semantic_hash": ""
   },
   "scripts/ci/check_maven_release_version.py": {
-    "mtime": 1782538948.83596,
+    "mtime": 1782540713.9304354,
     "ast_hash": "e92141a897e15092ed65fcd13f36fa6d",
     "semantic_hash": ""
   },
   "scripts/ci/extract_allure_failures.py": {
-    "mtime": 1782538948.83596,
+    "mtime": 1782540713.9304354,
     "ast_hash": "7985bdc62c1954d07b62c01ae71fb039",
     "semantic_hash": ""
   },
   "scripts/ci/github-auth-env.sh": {
-    "mtime": 1782538948.8369603,
+    "mtime": 1782540713.9314349,
     "ast_hash": "2f1a16109a60700251b2b1e8b204a331",
     "semantic_hash": ""
   },
   "scripts/ci/validate_agent_guidance.py": {
-    "mtime": 1782538948.8379602,
+    "mtime": 1782540713.9324348,
     "ast_hash": "6efb73d9c1754b06f29ff45b3d15f6ad",
     "semantic_hash": ""
   },
   "scripts/ci/validate_agent_setup.py": {
-    "mtime": 1782538948.8379602,
+    "mtime": 1782540713.9324348,
     "ast_hash": "510d4cb0ac7e970d1e485e0798690b22",
     "semantic_hash": ""
   },
   "scripts/ci/validate_documentation_boundaries.py": {
-    "mtime": 1782538948.8379602,
+    "mtime": 1782540713.9339397,
     "ast_hash": "1f04136b5b8395cd6bda836ba3243523",
     "semantic_hash": ""
   },
   "scripts/ci/validate_maven_publication.py": {
-    "mtime": 1782538948.8389595,
+    "mtime": 1782540713.934454,
     "ast_hash": "b30a099549e23dba6a1c00877649c186",
     "semantic_hash": ""
   },
   "scripts/ci/validate_modular_documentation.py": {
-    "mtime": 1782538948.8389595,
+    "mtime": 1782540713.9354615,
     "ast_hash": "39118b4d72384749ca3a7e768389ba13",
     "semantic_hash": ""
   },
   "scripts/ci/validate_quality_configuration.py": {
-    "mtime": 1782538948.8399599,
+    "mtime": 1782540713.9354615,
     "ast_hash": "7ea8e7c413b65535474333a58f004843",
     "semantic_hash": ""
   },
   "scripts/ci/validate_reactor_versions.py": {
-    "mtime": 1782538948.8399599,
+    "mtime": 1782540713.9364617,
     "ast_hash": "7ada71bfaf0bf09a2a118f3a172169e4",
     "semantic_hash": ""
   },
   "scripts/ci/validate_shaft_mcp_configuration.py": {
-    "mtime": 1782538948.8409598,
+    "mtime": 1782540713.9364617,
     "ast_hash": "9a27dc403a9decdc4287c451f3303386",
     "semantic_hash": ""
   },
   "scripts/ci/validate_shaft_mcp_transports.py": {
-    "mtime": 1782538948.8409598,
+    "mtime": 1782540713.9374619,
     "ast_hash": "cef307194198823949632cf1c0510543",
     "semantic_hash": ""
   },
   "scripts/ci/validate_shaft_pilot_release.py": {
-    "mtime": 1782538948.8419602,
+    "mtime": 1782540713.9374619,
     "ast_hash": "b9f4064afb31d843b66fa3323ca29d6f",
     "semantic_hash": ""
   },
   "scripts/ci/verify_maven_central_release.py": {
-    "mtime": 1782538948.8419602,
+    "mtime": 1782540713.9384608,
     "ast_hash": "f50ff9221963b55f6cd5355dcf077516",
     "semantic_hash": ""
   },
   "scripts/ci/verify_shaft_mcp_installer_release.py": {
-    "mtime": 1782538948.8419602,
+    "mtime": 1782540713.9384608,
     "ast_hash": "61eb62b67b294cb5da719bb315bf6cde",
     "semantic_hash": ""
   },
   "scripts/maintenance/flatten-history.sh": {
-    "mtime": 1782538948.84296,
+    "mtime": 1782540713.9394605,
     "ast_hash": "dde238359c6206f7dd16219757f04f07",
     "semantic_hash": ""
   },
   "scripts/mcp/install-shaft-mcp.ps1": {
-    "mtime": 1782538948.8439624,
+    "mtime": 1782540713.9409761,
     "ast_hash": "68f7dfc58bde866c56e5b69b36c1a8f8",
     "semantic_hash": ""
   },
   "scripts/mcp/install-shaft-mcp.sh": {
-    "mtime": 1782538948.8449602,
+    "mtime": 1782540713.9419868,
     "ast_hash": "9d9c90cba847ab57ab90a08ea0c19560",
     "semantic_hash": ""
   },
   "scripts/mcp/install_shaft_mcp.py": {
-    "mtime": 1782538948.8449602,
+    "mtime": 1782540713.9429903,
     "ast_hash": "09f2d0f568b7bac3d7adf8a36534d61b",
     "semantic_hash": ""
   },
   "shaft-ai/src/main/java/com/shaft/ai/provider/AbstractHttpAiProvider.java": {
-    "mtime": 1782538948.84896,
+    "mtime": 1782540713.9515927,
     "ast_hash": "dbb7debe96eaf04ce97677b023010551",
     "semantic_hash": ""
   },
   "shaft-ai/src/main/java/com/shaft/ai/provider/AnthropicProvider.java": {
-    "mtime": 1782538948.84896,
+    "mtime": 1782540713.9525888,
     "ast_hash": "fd84c714e9fdbcd3adc3e0ebd89c166e",
     "semantic_hash": ""
   },
   "shaft-ai/src/main/java/com/shaft/ai/provider/GeminiProvider.java": {
-    "mtime": 1782538948.8499596,
+    "mtime": 1782540713.9525888,
     "ast_hash": "a15587f8a53841df6ef6c891505f168d",
     "semantic_hash": ""
   },
   "shaft-ai/src/main/java/com/shaft/ai/provider/OllamaProvider.java": {
-    "mtime": 1782538948.8499596,
+    "mtime": 1782540713.9540944,
     "ast_hash": "2a63f2862593c6543ce4b503f462e1f7",
     "semantic_hash": ""
   },
   "shaft-ai/src/main/java/com/shaft/ai/provider/OpenAiProvider.java": {
-    "mtime": 1782538948.85096,
+    "mtime": 1782540713.9546106,
     "ast_hash": "4c18363c15f720d76033af2df645c929",
     "semantic_hash": ""
   },
   "shaft-ai/src/test/java/com/shaft/ai/provider/ProviderConformanceTest.java": {
-    "mtime": 1782538948.8539658,
+    "mtime": 1782540713.957617,
     "ast_hash": "e7c70c2dfbbbeea72ca0fd26bd3aaf41",
     "semantic_hash": ""
   },
   "shaft-browserstack/src/main/java/com/shaft/integration/browserstack/BrowserStackModule.java": {
-    "mtime": 1782538948.8569655,
+    "mtime": 1782540713.9616177,
     "ast_hash": "72302597cacbdcf22114d39c4a134055",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/cli/CaptureCli.java": {
-    "mtime": 1782538948.8619654,
+    "mtime": 1782540713.9676545,
     "ast_hash": "22e81755fd9b65ed25577032a321eee3",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/BidiBrowserEventCollector.java": {
-    "mtime": 1782538948.8629646,
+    "mtime": 1782540713.9686549,
     "ast_hash": "47e8063cd21021bc1b40d9b0e5b4d083",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventCollector.java": {
-    "mtime": 1782538948.8639662,
+    "mtime": 1782540713.9686549,
     "ast_hash": "7bcd665b60a9fdde45a86fd920161935",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventScript.java": {
-    "mtime": 1782538948.8639662,
+    "mtime": 1782540713.9696543,
     "ast_hash": "8755a9e0ae74e3e95a65bc66e5125d05",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/BrowserSignal.java": {
-    "mtime": 1782538948.8639662,
+    "mtime": 1782540713.9706604,
     "ast_hash": "df91d356ff80267cc300bf5a20c14f2d",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/CompositeBrowserEventCollector.java": {
-    "mtime": 1782538948.864966,
+    "mtime": 1782540713.9706604,
     "ast_hash": "576d60256e891e492f671083c8ada4a6",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/PollingBrowserEventCollector.java": {
-    "mtime": 1782538948.8659658,
+    "mtime": 1782540713.9716606,
     "ast_hash": "cc6e3c91b88b9be048d380224b8ca08f",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlClient.java": {
-    "mtime": 1782538948.866966,
+    "mtime": 1782540713.9726613,
     "ast_hash": "1104a60eeea8d2368509e6a901fb824b",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlFiles.java": {
-    "mtime": 1782538948.866966,
+    "mtime": 1782540713.9726613,
     "ast_hash": "e2f3d582e3b02783b4ad6ebae4ad030c",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlServer.java": {
-    "mtime": 1782538948.8679714,
+    "mtime": 1782540713.973661,
     "ast_hash": "842573fb335554672af12070b09b9c28",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/format/CaptureFormatException.java": {
-    "mtime": 1782538948.8679714,
+    "mtime": 1782540713.973661,
     "ast_hash": "16dd9ed34b8f5e575980e759908f5c4b",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/format/CaptureJsonCodec.java": {
-    "mtime": 1782538948.8689692,
+    "mtime": 1782540713.9748096,
     "ast_hash": "a805163d5ada4a16614b4c6c033c4347",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/format/CaptureSchemaMigrator.java": {
-    "mtime": 1782538948.870064,
+    "mtime": 1782540713.9753973,
     "ast_hash": "65b0476a9fc1922aa2d1db391b4988fd",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureEnrichmentPreview.java": {
-    "mtime": 1782538948.8710625,
+    "mtime": 1782540713.9768157,
     "ast_hash": "becc024cd2177b4113f3fc8746ec4354",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureEnrichmentService.java": {
-    "mtime": 1782538948.8710625,
+    "mtime": 1782540713.980479,
     "ast_hash": "4eb736b3f4f1ed574a280d779994b768",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationReport.java": {
-    "mtime": 1782538948.872062,
+    "mtime": 1782540713.9814887,
     "ast_hash": "a478402031451dc70abbdb73165486b0",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationRequest.java": {
-    "mtime": 1782538948.872062,
+    "mtime": 1782540713.9814887,
     "ast_hash": "baf507818de7dc32b660e5163a2a0a67",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationResult.java": {
-    "mtime": 1782538948.8730624,
+    "mtime": 1782540713.9824896,
     "ast_hash": "64235aa1fa46ab5857e3057e452eccab",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java": {
-    "mtime": 1782539890.0736566,
+    "mtime": 1782540713.983997,
     "ast_hash": "6c22eaf0bc62348e3392e831aca1fa4c",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/GeneratedTestValidator.java": {
-    "mtime": 1782538948.876062,
+    "mtime": 1782540713.9865236,
     "ast_hash": "d3a5ba9e076837ea9685c089e1eb2b24",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/LocatorRanker.java": {
-    "mtime": 1782538948.8770633,
+    "mtime": 1782540713.98752,
     "ast_hash": "b8de8d4abc874a48ab234270e224af6e",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/BrowserMetadata.java": {
-    "mtime": 1782538948.8780625,
+    "mtime": 1782540713.98852,
     "ast_hash": "aca616578f082355fd0761f58597be5d",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/CaptureEvent.java": {
-    "mtime": 1782538948.8780625,
+    "mtime": 1782540713.98852,
     "ast_hash": "36642a12d8b21af2444a67fde759c546",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/CaptureSession.java": {
-    "mtime": 1782538948.8780625,
+    "mtime": 1782540713.9895167,
     "ast_hash": "8b231d12ab3791b756caac91cbdb4c10",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/Checkpoint.java": {
-    "mtime": 1782538948.8790617,
+    "mtime": 1782540713.9895167,
     "ast_hash": "2a3ca946a6921b589ae137ecc6f60581",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/ElementSnapshot.java": {
-    "mtime": 1782538948.8790617,
+    "mtime": 1782540713.990523,
     "ast_hash": "14868c3708fab12f82feb3b9e24d01ec",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/EventContext.java": {
-    "mtime": 1782538948.880062,
+    "mtime": 1782540713.990523,
     "ast_hash": "a8a5457d7b613592975c3bc8297ccfee",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/EvidenceReference.java": {
-    "mtime": 1782538948.880062,
+    "mtime": 1782540713.9915237,
     "ast_hash": "786eef193ba4ca565c23dc1d142ba475",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/ExternalTestDataReference.java": {
-    "mtime": 1782538948.880062,
+    "mtime": 1782540713.9915237,
     "ast_hash": "fa36b8fb9e646b9d1b51ce0605d33d95",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/LocatorCandidate.java": {
-    "mtime": 1782538948.8810625,
+    "mtime": 1782540713.9915237,
     "ast_hash": "dd66b616e91d7e6fa0abfec2b475a90b",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/ModelSupport.java": {
-    "mtime": 1782538948.8810625,
+    "mtime": 1782540713.9925249,
     "ast_hash": "c54568ab63b584765e027d13eaa6e00b",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/PageContext.java": {
-    "mtime": 1782538948.8810625,
+    "mtime": 1782540713.9925249,
     "ast_hash": "8fa7d63b7d571c010f6c1a1d927e5400",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/RedactionSummary.java": {
-    "mtime": 1782538948.8820622,
+    "mtime": 1782540713.9925249,
     "ast_hash": "7a5a3a53ec8011e51823968f7b2ba6a2",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/privacy/CapturePrivacyClassifier.java": {
-    "mtime": 1782538948.8830621,
+    "mtime": 1782540713.994546,
     "ast_hash": "0f9d46db745fc5bbe83ece1758401053",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/privacy/CapturePrivacyPolicy.java": {
-    "mtime": 1782538948.8830621,
+    "mtime": 1782540713.994546,
     "ast_hash": "77266ad326a57f7b2cf95ada13f2e221",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/privacy/ClassifiedValue.java": {
-    "mtime": 1782538948.8840628,
+    "mtime": 1782540713.9951458,
     "ast_hash": "b8dae78977adf61da8c1a8d42cf8e122",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureBrowser.java": {
-    "mtime": 1782538948.8840628,
+    "mtime": 1782540713.9961796,
     "ast_hash": "f1ca5592cf996f4503417bbc4c2c356b",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java": {
-    "mtime": 1782539890.0756578,
+    "mtime": 1782540713.9961796,
     "ast_hash": "4b5df33054db0435c1e29e5f3078def7",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureManager.java": {
-    "mtime": 1782538948.885064,
+    "mtime": 1782540713.9971797,
     "ast_hash": "469574f4d08f284372ba708dd1e7a177",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureSingleSessionLock.java": {
-    "mtime": 1782538948.8860621,
+    "mtime": 1782540713.9971797,
     "ast_hash": "fc8c18ea3f3fb1449c0545c9fec14b82",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureStartRequest.java": {
-    "mtime": 1782538948.8870625,
+    "mtime": 1782540713.9981792,
     "ast_hash": "b0b6151d075c56dc07fb266a8b18b316",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureStatus.java": {
-    "mtime": 1782538948.8870625,
+    "mtime": 1782540713.9981792,
     "ast_hash": "5a11ea402919f7b1718cd953c4f419a2",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java": {
-    "mtime": 1782538948.8880632,
+    "mtime": 1782540713.9991777,
     "ast_hash": "bdf8eb306437199c02934d7815300ce7",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/storage/CaptureSessionStore.java": {
-    "mtime": 1782538948.8880632,
+    "mtime": 1782540714.0006845,
     "ast_hash": "229b38b0e510e0d9c7b9a08bc71db5b9",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/storage/ExternalTestDataWriter.java": {
-    "mtime": 1782538948.889063,
+    "mtime": 1782540714.0006845,
     "ast_hash": "e69dc835c53bd61b0e8ccfc34f983185",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/resources/browser/shaft-capture-recorder.js": {
-    "mtime": 1782539890.0776596,
+    "mtime": 1782540714.002694,
     "ast_hash": "20b06f04f0508ec89e4ba4ef0f16dd40",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/resources/schema/shaft-capture-session-1.0.schema.json": {
-    "mtime": 1782538948.8910625,
+    "mtime": 1782540714.0036924,
     "ast_hash": "df85a8de90f01cbb4c980201998901d0",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/CaptureFixtures.java": {
-    "mtime": 1782538948.8920612,
+    "mtime": 1782540714.0060885,
     "ast_hash": "5f889c8fbaec05b6f2741a137700d788",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/format/CaptureJsonCodecTest.java": {
-    "mtime": 1782538948.8960626,
+    "mtime": 1782540714.009089,
     "ast_hash": "231b3b2f5f283141335c78cf8983c065",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratedReplayBrowserTest.java": {
-    "mtime": 1782538948.8970616,
+    "mtime": 1782540714.009089,
     "ast_hash": "cd1a6080100cbce05841ce7a32757f17",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java": {
-    "mtime": 1782539890.0791888,
+    "mtime": 1782540714.010596,
     "ast_hash": "d78e267b49ed609be121a4428dc0f582",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/generate/LocatorRankerTest.java": {
-    "mtime": 1782538948.898062,
+    "mtime": 1782540714.0145354,
     "ast_hash": "8c1ad098141cceb54b35c1a35c33d863",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/privacy/CapturePrivacyClassifierTest.java": {
-    "mtime": 1782538948.898062,
+    "mtime": 1782540714.0161593,
     "ast_hash": "7702332d104ea111fdec6e1fa99d6df3",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java": {
-    "mtime": 1782539890.081203,
+    "mtime": 1782540714.0171947,
     "ast_hash": "1c919ba8102c050581e66057030e2814",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureRuntimePortabilityTest.java": {
-    "mtime": 1782538948.901062,
+    "mtime": 1782540714.0181985,
     "ast_hash": "b4774a5bc9b7d84591360de0f8482164",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java": {
-    "mtime": 1782538948.901062,
+    "mtime": 1782540714.0191958,
     "ast_hash": "c457491fa2232a3b4615fddf737611aa",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/storage/CaptureSessionStoreTest.java": {
-    "mtime": 1782538948.9030643,
+    "mtime": 1782540714.0207074,
     "ast_hash": "cc70993c979f97b8de7554bd34515622",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/resources/fixtures/golden-generated-session-1.java": {
-    "mtime": 1782538948.9040637,
+    "mtime": 1782540714.0227191,
     "ast_hash": "15d1969da9a2e6a0bc6efdee6f4c590d",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/resources/fixtures/golden-session-1.0.json": {
-    "mtime": 1782538948.9050617,
+    "mtime": 1782540714.0237172,
     "ast_hash": "94d6b5e35f7a9d8a12a448178eed460e",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/resources/fixtures/legacy-session-0.9.json": {
-    "mtime": 1782538948.9050617,
+    "mtime": 1782540714.0248032,
     "ast_hash": "fe67510df7883478c930d414d5ad38cc",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/DoctorAiAnalysisRequest.java": {
-    "mtime": 1782538948.909062,
+    "mtime": 1782540714.0278156,
     "ast_hash": "55678906c451524f9fb3c48d0d464ff9",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/DoctorAnalysisRequest.java": {
-    "mtime": 1782538948.9100623,
+    "mtime": 1782540714.0278156,
     "ast_hash": "6fb3dd5ae5993ce8a61e4cd73d327aa4",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/DoctorAnalyzer.java": {
-    "mtime": 1782538948.9100623,
+    "mtime": 1782540714.0288162,
     "ast_hash": "30b31bc51979d3f990c15ad91b5f4f4f",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/ai/DoctorAiAnalysisService.java": {
-    "mtime": 1782538948.9110641,
+    "mtime": 1782540714.0298169,
     "ast_hash": "4b1cd2196306a10434d9df255bf01d8d",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/analysis/DeterministicRuleEngine.java": {
-    "mtime": 1782538948.9120626,
+    "mtime": 1782540714.0308168,
     "ast_hash": "732501c3f0664de7f83469e8d9db5a70",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/cli/DoctorCli.java": {
-    "mtime": 1782538948.913062,
+    "mtime": 1782540714.0318122,
     "ast_hash": "c7277004cfa5eae27d5f7d1477ec92a4",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/collect/EvidenceCollector.java": {
-    "mtime": 1782538948.914062,
+    "mtime": 1782540714.0328112,
     "ast_hash": "3e05599d12a2c4e9999260e249e53e71",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/format/DoctorFormatException.java": {
-    "mtime": 1782538948.9150627,
+    "mtime": 1782540714.0338118,
     "ast_hash": "ac49bb5981592a48aed69d5e929e8357",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/format/DoctorJsonCodec.java": {
-    "mtime": 1782538948.9160626,
+    "mtime": 1782540714.0338118,
     "ast_hash": "e37f60eedfbf0c389362d3fcf8884981",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/internal/DoctorHashing.java": {
-    "mtime": 1782538948.9170616,
+    "mtime": 1782540714.0349774,
     "ast_hash": "cbf37af4f45fcd49e34d177a36e7788e",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/internal/DoctorRedactor.java": {
-    "mtime": 1782538948.9170616,
+    "mtime": 1782540714.035988,
     "ast_hash": "50c5ae3ae3589a795ce05bd77aeb022d",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/CauseCategory.java": {
-    "mtime": 1782538948.9180613,
+    "mtime": 1782540714.035988,
     "ast_hash": "07daed154b031e5c8e8a67f58d60c076",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/Confidence.java": {
-    "mtime": 1782538948.9190638,
+    "mtime": 1782540714.0369883,
     "ast_hash": "58efa214b4b396e5cd16320ecb7f1419",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/Diagnosis.java": {
-    "mtime": 1782538948.9190638,
+    "mtime": 1782540714.0369883,
     "ast_hash": "d5f6f816532eebb1a0ce72949dc26637",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAdvisory.java": {
-    "mtime": 1782538948.9200628,
+    "mtime": 1782540714.037989,
     "ast_hash": "844eaf9048ab13c94b72ba4145b589f8",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAiAnalysisResult.java": {
-    "mtime": 1782538948.9200628,
+    "mtime": 1782540714.037989,
     "ast_hash": "93cd26759f448a2370ea5a793ccd0ecc",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAnalysisResult.java": {
-    "mtime": 1782538948.921062,
+    "mtime": 1782540714.0389862,
     "ast_hash": "ae20f4a3cd962138db3be05bd442ef21",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAnalysisSummary.java": {
-    "mtime": 1782538948.921062,
+    "mtime": 1782540714.0389862,
     "ast_hash": "db1612663a72eceaf8b36d02e4534f99",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorModelSupport.java": {
-    "mtime": 1782538948.921062,
+    "mtime": 1782540714.0389862,
     "ast_hash": "8e4a6c083ab2a7837d98104a9ce23b8c",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/EvidenceBundle.java": {
-    "mtime": 1782538948.922063,
+    "mtime": 1782540714.0404956,
     "ast_hash": "f1ce8926f044be3bd0652d3b43f91946",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/EvidenceCategory.java": {
-    "mtime": 1782538948.923064,
+    "mtime": 1782540714.0415099,
     "ast_hash": "6976b42e37761f612bdee1f8d2cd8f50",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/EvidenceItem.java": {
-    "mtime": 1782538948.923064,
+    "mtime": 1782540714.0415099,
     "ast_hash": "2a427690ae34f946851017d16c18a5ab",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/EvidenceProvenance.java": {
-    "mtime": 1782538948.923064,
+    "mtime": 1782540714.0415099,
     "ast_hash": "56bd866d04bd1ab56863ab0aa104a31c",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/Finding.java": {
-    "mtime": 1782538948.9240623,
+    "mtime": 1782540714.042508,
     "ast_hash": "ca086338b16ab81a80882d4830254620",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/RedactionSummary.java": {
-    "mtime": 1782538948.9250617,
+    "mtime": 1782540714.042508,
     "ast_hash": "5fcbb50a506dd9456d5ec76fe90a4ea7",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/Remediation.java": {
-    "mtime": 1782538948.9250617,
+    "mtime": 1782540714.0440154,
     "ast_hash": "45487f78e554324e826976f19b75dadc",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairAiRequest.java": {
-    "mtime": 1782538948.9260616,
+    "mtime": 1782540714.0445406,
     "ast_hash": "cb971f162e01bc90678e0d40e08d0947",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairAiService.java": {
-    "mtime": 1782538948.9270637,
+    "mtime": 1782540714.0505736,
     "ast_hash": "0d4d59f92ec198022b0e44682359ac82",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairPatchResult.java": {
-    "mtime": 1782538948.9270637,
+    "mtime": 1782540714.0510902,
     "ast_hash": "309c6a07dc3145574d2e2bbd54c7b334",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairProposalResult.java": {
-    "mtime": 1782538948.9280634,
+    "mtime": 1782540714.0520978,
     "ast_hash": "6a01cd05b4c6b271ce7ab395d393e396",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairPublicationRequest.java": {
-    "mtime": 1782538948.9280634,
+    "mtime": 1782540714.0530994,
     "ast_hash": "50162373c4b5f046f867b5d1344816c7",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairRequest.java": {
-    "mtime": 1782538948.9280634,
+    "mtime": 1782540714.0530994,
     "ast_hash": "8afe0727b1629734c1b865c805d613f3",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/DoctorRepairService.java": {
-    "mtime": 1782538948.9290626,
+    "mtime": 1782540714.0540967,
     "ast_hash": "3ddd9b9f7ec71452100a891378758166",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposal.java": {
-    "mtime": 1782538948.9290626,
+    "mtime": 1782540714.0546017,
     "ast_hash": "72e037d2cc8aac280c799b1f76147c4c",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposalRequest.java": {
-    "mtime": 1782538948.9300618,
+    "mtime": 1782540714.0556092,
     "ast_hash": "b53a430ae27cf976040410a97b06a37b",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposalService.java": {
-    "mtime": 1782538948.9310615,
+    "mtime": 1782540714.0556092,
     "ast_hash": "1f0ea7387c631ddb9501dc97f144e27b",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/RepairGuard.java": {
-    "mtime": 1782538948.9310615,
+    "mtime": 1782540714.0566108,
     "ast_hash": "fba5356ab168ee237ee6530712c94f00",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/RepairProcessRunner.java": {
-    "mtime": 1782538948.9310615,
+    "mtime": 1782540714.0566108,
     "ast_hash": "5fe1cd3c8e8b190bcab936fd417b3825",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/RepairProposal.java": {
-    "mtime": 1782538948.9320626,
+    "mtime": 1782540714.0576105,
     "ast_hash": "f1e22305d666390fc499f30d41184bc7",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/RepairProposalStore.java": {
-    "mtime": 1782538948.9320626,
+    "mtime": 1782540714.0576105,
     "ast_hash": "e94f86295598c8f1ae590214048bd53b",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/repair/RepairPublicationResult.java": {
-    "mtime": 1782538948.9330623,
+    "mtime": 1782540714.0586104,
     "ast_hash": "54b09925ec8f18ec028ba4dec8dfceee",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/report/DoctorReportWriter.java": {
-    "mtime": 1782538948.9330623,
+    "mtime": 1782540714.0596097,
     "ast_hash": "cf246a6dccada6bd2ad38899deed5728",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-doctor-advisory-1.0.schema.json": {
-    "mtime": 1782538948.9340615,
+    "mtime": 1782540714.060609,
     "ast_hash": "0707502a8d574324252c3e6c9e59b68e",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-doctor-diagnosis-1.0.schema.json": {
-    "mtime": 1782538948.935063,
+    "mtime": 1782540714.0616088,
     "ast_hash": "955b53f8d49daea98d4ac1fc82d40587",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-doctor-evidence-1.0.schema.json": {
-    "mtime": 1782538948.935063,
+    "mtime": 1782540714.0616088,
     "ast_hash": "62af20c56b0b7df2415adc87012a03c7",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-doctor-repair-patch-1.0.schema.json": {
-    "mtime": 1782538948.9360633,
+    "mtime": 1782540714.0616088,
     "ast_hash": "0798e219e11cb74541c713d96d2ac2a9",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-heal-locator-proposal-1.0.schema.json": {
-    "mtime": 1782538948.9370623,
+    "mtime": 1782540714.062608,
     "ast_hash": "ede7581c250a246a7ef50c26116e926b",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/DoctorAnalyzerTest.java": {
-    "mtime": 1782538948.939062,
+    "mtime": 1782540714.0657203,
     "ast_hash": "1e2c4f9eaed66529617181aba1349bc0",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/ai/DoctorAiAnalysisServiceTest.java": {
-    "mtime": 1782538948.9400623,
+    "mtime": 1782540714.0667222,
     "ast_hash": "a4275d927157b9dcdca5a983b2cf514a",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/repair/DoctorRepairAiServiceTest.java": {
-    "mtime": 1782538948.941062,
+    "mtime": 1782540714.0667222,
     "ast_hash": "42a607d9a057330ca195c6cfc9ae7d54",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/repair/DoctorRepairServiceTest.java": {
-    "mtime": 1782538948.9420624,
+    "mtime": 1782540714.0677202,
     "ast_hash": "0de5d211d8c45c9799e1b2487f28106c",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/java/com/shaft/doctor/repair/HealingLocatorProposalServiceTest.java": {
-    "mtime": 1782538948.9420624,
+    "mtime": 1782540714.0687203,
     "ast_hash": "87a964a179a869fd747537abc1dee167",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/ai/contradictory.json": {
-    "mtime": 1782538948.9440658,
+    "mtime": 1782540714.0697215,
     "ast_hash": "9cc3faaf569b9523478d440eac4c31fa",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/ai/hallucinated-evidence.json": {
-    "mtime": 1782538948.9450624,
+    "mtime": 1782540714.0707223,
     "ast_hash": "8392a8f0353b0006ce35cee8a3cd04e4",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/ai/high-quality.json": {
-    "mtime": 1782538948.9450624,
+    "mtime": 1782540714.0707223,
     "ast_hash": "e6f7861bf34853d8e39252b93d0f7ee4",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/ai/malformed.json": {
-    "mtime": 1782538948.9460633,
+    "mtime": 1782540714.0717242,
     "ast_hash": "fb9415fb50bc91677036081513bbc19d",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/ai/unavailable.json": {
-    "mtime": 1782538948.9460633,
+    "mtime": 1782540714.0717242,
     "ast_hash": "4b7fec724f675abb3404bc58a0cd21fd",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/golden/doctor-report.json": {
-    "mtime": 1782538948.9470623,
+    "mtime": 1782540714.072722,
     "ast_hash": "d19a4cec92c592cf6f3804f87c7d1ac8",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/golden/locator-result.json": {
-    "mtime": 1782538948.948063,
+    "mtime": 1782540714.0737207,
     "ast_hash": "cc0963373d7ae1eb7e2026ce65f5c16d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/RequestBuilder.java": {
-    "mtime": 1782538948.9520636,
+    "mtime": 1782540714.0758104,
     "ast_hash": "34c8e423e16aa9e147db977d27b95247",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/RestActions.java": {
-    "mtime": 1782538948.9540613,
+    "mtime": 1782540714.0768108,
     "ast_hash": "bb4110145f033982f6cf53c82a029933",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/ShaftRestAssuredFilter.java": {
-    "mtime": 1782538948.9560666,
+    "mtime": 1782540714.0778108,
     "ast_hash": "8321f05c06cb481114837f8cfc87cb00",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cli/FileActions.java": {
-    "mtime": 1782538948.9570653,
+    "mtime": 1782540714.0788102,
     "ast_hash": "a1d907444ba2bc35977265503c7c916d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java": {
-    "mtime": 1782538948.9580653,
+    "mtime": 1782540714.0849361,
     "ast_hash": "c7bf3c6c81a85d681faa3a2756728587",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cucumber/AssertionSteps.java": {
-    "mtime": 1782538948.959066,
+    "mtime": 1782540714.0869737,
     "ast_hash": "2ff1069e84fc689b831cdddc2098f1ee",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cucumber/BrowserSteps.java": {
-    "mtime": 1782538948.9600692,
+    "mtime": 1782540714.087963,
     "ast_hash": "ad3b088235e9d348c8563ed46da91944",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/cucumber/ElementSteps.java": {
-    "mtime": 1782538948.9610677,
+    "mtime": 1782540714.0889647,
     "ast_hash": "5174cbfba57ae0fc18a79de0c4491af1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/db/DatabaseActions.java": {
-    "mtime": 1782538948.9620655,
+    "mtime": 1782540714.0904734,
     "ast_hash": "e94ab6b3d65838a79da1adf16ace4c37",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/DriverFactory.java": {
-    "mtime": 1782538948.963066,
+    "mtime": 1782540714.091484,
     "ast_hash": "8ee0caf3a105473f413b00ac8f1f9adf",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/SHAFT.java": {
-    "mtime": 1782538948.9640715,
+    "mtime": 1782540714.091484,
     "ast_hash": "8f47c38bf6a58f4541bce49edcc58709",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/$.java": {
-    "mtime": 1782538948.9650655,
+    "mtime": 1782540714.0924847,
     "ast_hash": "f0f29bf4777208e42080bbb8d92c7655",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/BrowserStackHelper.java": {
-    "mtime": 1782538948.966066,
+    "mtime": 1782540714.0939908,
     "ast_hash": "8269be54fd38e960b0e7acb0b3009e21",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/BrowserStackSdkHelper.java": {
-    "mtime": 1782538948.9670663,
+    "mtime": 1782540714.0945098,
     "ast_hash": "85c848b791627a3f81dc6f1499440f48",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java": {
-    "mtime": 1782538948.9680648,
+    "mtime": 1782540714.095519,
     "ast_hash": "6033ad4038f306a93c6e7e170546eab7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/LambdaTestHelper.java": {
-    "mtime": 1782538948.9690676,
+    "mtime": 1782540714.0965185,
     "ast_hash": "3f3755d291c98c32cfdd363cee4cf73a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java": {
-    "mtime": 1782538948.970412,
+    "mtime": 1782540714.0975187,
     "ast_hash": "dcdc8189ab5888b9875e4e1be4fe7b02",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/SynchronizationManager.java": {
-    "mtime": 1782538948.9714124,
+    "mtime": 1782540714.098515,
     "ast_hash": "eb0cff7a79a25b8e6999426d21353757",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/FluentWebDriverAction.java": {
-    "mtime": 1782538948.972412,
+    "mtime": 1782540714.0995154,
     "ast_hash": "72da0e0b47b4f503c107c7add47ab23a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/WizardHelpers.java": {
-    "mtime": 1782538948.972412,
+    "mtime": 1782540714.0995154,
     "ast_hash": "f6788d05f21d1f430ac6325b5aa234c6",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/enums/internal/ClipboardAction.java": {
-    "mtime": 1782538948.9744122,
+    "mtime": 1782540714.1005166,
     "ast_hash": "70733b35a3b354ad26cb2293c92e7c1f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/enums/internal/NavigationAction.java": {
-    "mtime": 1782538948.9744122,
+    "mtime": 1782540714.1015196,
     "ast_hash": "c58c8262a7e2348b6984ff75638f997a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/enums/internal/Screenshots.java": {
-    "mtime": 1782538948.975412,
+    "mtime": 1782540714.1025186,
     "ast_hash": "623942ecc89e633c28fa2014876ac552",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java": {
-    "mtime": 1782538948.9764109,
+    "mtime": 1782540714.1025186,
     "ast_hash": "478103e7de10a2aed4828cd193989492",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserActionsHelper.java": {
-    "mtime": 1782538948.980412,
+    "mtime": 1782540714.1045382,
     "ast_hash": "075368ab4db20c113dd0ffe77c9bdaec",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/JavaScriptWaitManager.java": {
-    "mtime": 1782538948.9844117,
+    "mtime": 1782540714.1072276,
     "ast_hash": "2461e01c04d95924a01f0c83b9ad7029",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/AlertActions.java": {
-    "mtime": 1782538948.9894118,
+    "mtime": 1782540714.116644,
     "ast_hash": "c2ff4367374c900d0bc60c4902faa451",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/AsyncElementActions.java": {
-    "mtime": 1782538948.990412,
+    "mtime": 1782540714.119575,
     "ast_hash": "b127634e4819e21e34a549ba21ca7a03",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/ElementActions.java": {
-    "mtime": 1782538948.990412,
+    "mtime": 1782540714.1205733,
     "ast_hash": "be3bc856752a3cdaed67fc1f0bccdbc4",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java": {
-    "mtime": 1782538948.992412,
+    "mtime": 1782540714.1205733,
     "ast_hash": "ac223f9bf39a8c2391c01154cfc361d7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java": {
-    "mtime": 1782538948.9934149,
+    "mtime": 1782540714.1225743,
     "ast_hash": "d750ce1041311d1ada17c796175a92ae",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java": {
-    "mtime": 1782538948.9964132,
+    "mtime": 1782540714.1246107,
     "ast_hash": "23ca8f8d0a49d388f8f1841c67fa751a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementInformation.java": {
-    "mtime": 1782538948.997411,
+    "mtime": 1782540714.125317,
     "ast_hash": "069e9385670d467fcfd1f7210d9e34cc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/exceptions/MultipleElementsFoundException.java": {
-    "mtime": 1782538948.9984124,
+    "mtime": 1782540714.1266162,
     "ast_hash": "7115d38040575ebf54fb3f543a30290f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingActionOutcome.java": {
-    "mtime": 1782538948.9984124,
+    "mtime": 1782540714.127618,
     "ast_hash": "9a99f0ead6650249de18d721129711cc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingExplanation.java": {
-    "mtime": 1782538948.999412,
+    "mtime": 1782540714.127618,
     "ast_hash": "ee26d9a41572d22c59b897020537b16e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingManager.java": {
-    "mtime": 1782538948.999412,
+    "mtime": 1782540714.128618,
     "ast_hash": "c5e38dd4184e53deeccad977f263fb31",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingObservation.java": {
-    "mtime": 1782538949.0004117,
+    "mtime": 1782540714.1296158,
     "ast_hash": "a5423face0fd000d6ecaca3410a7b2e3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingProvider.java": {
-    "mtime": 1782538949.0004117,
+    "mtime": 1782540714.1296158,
     "ast_hash": "ebf8923cd40ade102731421c41f57986",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingProviderRegistry.java": {
-    "mtime": 1782538949.0014105,
+    "mtime": 1782540714.1296158,
     "ast_hash": "3cbe60277c5b519104b46355f11b3849",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingRequest.java": {
-    "mtime": 1782538949.0014105,
+    "mtime": 1782540714.130618,
     "ast_hash": "01fa33edca22567bffb147b7698ef87d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingResolution.java": {
-    "mtime": 1782538949.0024137,
+    "mtime": 1782540714.130618,
     "ast_hash": "53c802fb2320dd3320128019dcb8e965",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingStrategy.java": {
-    "mtime": 1782538949.0024137,
+    "mtime": 1782540714.1316166,
     "ast_hash": "28500b405d7d843f0099971b196415d1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingVisualProvider.java": {
-    "mtime": 1782538949.003412,
+    "mtime": 1782540714.1326158,
     "ast_hash": "cf4607a228a2c6f37ef287bf95c02905",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/AnimatedGifManager.java": {
-    "mtime": 1782538949.004412,
+    "mtime": 1782540714.1341207,
     "ast_hash": "820ea16bfa9e8397fcc97592f8dc1515",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java": {
-    "mtime": 1782538949.0054116,
+    "mtime": 1782540714.1346383,
     "ast_hash": "565b9fd29ad4d7772d5ea0ff92a49361",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotHelper.java": {
-    "mtime": 1782538949.0064125,
+    "mtime": 1782540714.135646,
     "ast_hash": "bd9223dc2b3615bddc02e58bc5ec999f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotManager.java": {
-    "mtime": 1782538949.0074134,
+    "mtime": 1782540714.1366522,
     "ast_hash": "240f2b556c600521967063f1217b1c16",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/VisualProcessingProvider.java": {
-    "mtime": 1782538949.0074134,
+    "mtime": 1782540714.1366522,
     "ast_hash": "b82bb32f7bba8fd5bce43c64dd8451a7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/image/VisualProcessingProviderRegistry.java": {
-    "mtime": 1782538949.0074134,
+    "mtime": 1782540714.1376522,
     "ast_hash": "9b616f64cbbddb4faead5b8f0a9c21b9",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/Locator.java": {
-    "mtime": 1782538949.0094118,
+    "mtime": 1782540714.1386526,
     "ast_hash": "e02bf607fbeff72dd9b178b08bf8d85b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/LocatorBuilder.java": {
-    "mtime": 1782538949.010415,
+    "mtime": 1782540714.1396523,
     "ast_hash": "5cfd4d2b383e696367b5d1d0070bee58",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/Locators.java": {
-    "mtime": 1782538949.011412,
+    "mtime": 1782540714.1406536,
     "ast_hash": "c75c5f50d1a2cfb34eac7e66c23ddedc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/Role.java": {
-    "mtime": 1782538949.011412,
+    "mtime": 1782540714.14116,
     "ast_hash": "7f35dc1a5a395ed93e4c158badb0ec2b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/ShadowLocatorBuilder.java": {
-    "mtime": 1782538949.0124135,
+    "mtime": 1782540714.14116,
     "ast_hash": "ebec375f08bc01a3b1502aed75f1231d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/SmartLocators.java": {
-    "mtime": 1782538949.0134108,
+    "mtime": 1782540714.1421669,
     "ast_hash": "ac3f2f53dff343d16473fb990039b2d4",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/XpathAxis.java": {
-    "mtime": 1782538949.0134108,
+    "mtime": 1782540714.143166,
     "ast_hash": "15de5fb7fe4ce1ecbf3fc6b5022ba3df",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/DeterministicNaturalActionPlanner.java": {
-    "mtime": 1782538949.0144126,
+    "mtime": 1782540714.1441672,
     "ast_hash": "3442170386262904fcec37a0a4de984a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionExecutor.java": {
-    "mtime": 1782538949.015412,
+    "mtime": 1782540714.1452997,
     "ast_hash": "27f19328ab9d5a45da44797cdce1d2a5",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionKind.java": {
-    "mtime": 1782538949.015412,
+    "mtime": 1782540714.1456795,
     "ast_hash": "7ab19c76ab5d66cdc94e8183b5c4fe4c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionPlan.java": {
-    "mtime": 1782538949.0164123,
+    "mtime": 1782540714.1456795,
     "ast_hash": "c913e5edcb2b9594946cf5b50362d108",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionPlanner.java": {
-    "mtime": 1782538949.0164123,
+    "mtime": 1782540714.1466806,
     "ast_hash": "544f27ddc74a8a6732e6ad6e2f7da494",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionPlannerRegistry.java": {
-    "mtime": 1782538949.0174117,
+    "mtime": 1782540714.1466806,
     "ast_hash": "8a223a42ffda00a3e13ae108748a8270",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionRequest.java": {
-    "mtime": 1782538949.0174117,
+    "mtime": 1782540714.1476805,
     "ast_hash": "2398af5cb7efdca4f0b32d129bb361e4",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionStep.java": {
-    "mtime": 1782538949.0184116,
+    "mtime": 1782540714.1523285,
     "ast_hash": "29b36b4244b122ef2e6dd4c391c99625",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/video/DesktopVideoRecordingProvider.java": {
-    "mtime": 1782538949.0194123,
+    "mtime": 1782540714.1555417,
     "ast_hash": "b98f55fe150407bba68594b78fb2e5b7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistry.java": {
-    "mtime": 1782538949.0204115,
+    "mtime": 1782540714.1555417,
     "ast_hash": "5cb846a30b50df2b01b15bb5abaf362f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/video/RecordManager.java": {
-    "mtime": 1782538949.0204115,
+    "mtime": 1782540714.1565518,
     "ast_hash": "ee83db977f0369f56d0b5074c791b6d0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/AllureListener.java": {
-    "mtime": 1782538949.0314116,
+    "mtime": 1782540714.1715996,
     "ast_hash": "641101e959b09cf49e071682e194a87e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/CucumberFeatureListener.java": {
-    "mtime": 1782538949.0314116,
+    "mtime": 1782540714.172595,
     "ast_hash": "14d03222afd184a66843e942e8d6c838",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/CucumberTestRunnerListener.java": {
-    "mtime": 1782538949.0324116,
+    "mtime": 1782540714.172595,
     "ast_hash": "4d4b34169ad6f2440e377838f32554f3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/JunitListener.java": {
-    "mtime": 1782538949.033411,
+    "mtime": 1782540714.1741004,
     "ast_hash": "38e6748586de2a4c89b9e0420b19adcf",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/TestNGListener.java": {
-    "mtime": 1782538949.0344121,
+    "mtime": 1782540714.1746762,
     "ast_hash": "fe806f53d06c128da2a60a1b72d5efa6",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/ConfigurationHelper.java": {
-    "mtime": 1782538949.0354142,
+    "mtime": 1782540714.1756861,
     "ast_hash": "e96809e943e2adb15f47a9c242a540dc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/CucumberHelper.java": {
-    "mtime": 1782538949.0364125,
+    "mtime": 1782540714.176689,
     "ast_hash": "7f583d0c5e8b9445b007f08fb0ba6488",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/JiraHelper.java": {
-    "mtime": 1782538949.038411,
+    "mtime": 1782540714.178686,
     "ast_hash": "a4ef92cd147ecdaf44ef9f805da98c73",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/JunitListenerHelper.java": {
-    "mtime": 1782538949.038411,
+    "mtime": 1782540714.178686,
     "ast_hash": "5a96f15340ee466d71733a4977fab257",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/RetryAnalyzer.java": {
-    "mtime": 1782538949.0394115,
+    "mtime": 1782540714.179684,
     "ast_hash": "fdd8846beddec616e3655b207196f8c2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java": {
-    "mtime": 1782538949.040411,
+    "mtime": 1782540714.1826847,
     "ast_hash": "ac43ab8deccc14de30e3f0f3f4b93fdf",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/UpdateChecker.java": {
-    "mtime": 1782538949.041412,
+    "mtime": 1782540714.1877947,
     "ast_hash": "56edc5784cd56e08113f0d04f51fd25a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/WebDriverListener.java": {
-    "mtime": 1782538949.041412,
+    "mtime": 1782540714.1877947,
     "ast_hash": "11caa57a58f17da0416933518895efdd",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/performance/internal/LightHouseGenerateReport.java": {
-    "mtime": 1782538949.0424125,
+    "mtime": 1782540714.1905682,
     "ast_hash": "8395aa33dcea0312ab66a82c9fc7eb77",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/API.java": {
-    "mtime": 1782538949.0434127,
+    "mtime": 1782540714.1925771,
     "ast_hash": "f39cb02169c7fd20213c691b2c3f4d34",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Allure.java": {
-    "mtime": 1782538949.0444112,
+    "mtime": 1782540714.1940877,
     "ast_hash": "b7daa2d86513e1304c39f664df81aeb3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/BrowserStack.java": {
-    "mtime": 1782538949.0444112,
+    "mtime": 1782540714.194627,
     "ast_hash": "2c4ea1d03ddde366471ab7d371f129c0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Cucumber.java": {
-    "mtime": 1782538949.0454123,
+    "mtime": 1782540714.1956348,
     "ast_hash": "563b9ce2f293404c06e4a7a73dab132b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/EngineProperties.java": {
-    "mtime": 1782538949.0464113,
+    "mtime": 1782540714.196634,
     "ast_hash": "e7d9d408bcf36812505cd26632b45ccc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Flags.java": {
-    "mtime": 1782538949.0464113,
+    "mtime": 1782540714.1976347,
     "ast_hash": "643347d2cdd011d79a7504db2bc868b4",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Healenium.java": {
-    "mtime": 1782538949.0464113,
+    "mtime": 1782540714.1986346,
     "ast_hash": "020bedc94874be8d4f237c2007a9244c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Healing.java": {
-    "mtime": 1782538949.0474124,
+    "mtime": 1782540714.199635,
     "ast_hash": "d6b881dfe76fe2145f6a3f21096896cd",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java": {
-    "mtime": 1782538949.0474124,
+    "mtime": 1782540714.199635,
     "ast_hash": "0dcc9d873618f00473caca1408d915b1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Jira.java": {
-    "mtime": 1782538949.0484118,
+    "mtime": 1782540714.2006345,
     "ast_hash": "69e39c376eb244713a8638e8b682931a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/LambdaTest.java": {
-    "mtime": 1782538949.0484118,
+    "mtime": 1782540714.2016354,
     "ast_hash": "2129d3567c4540656d0f1a70a4b5836e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Log4j.java": {
-    "mtime": 1782538949.0494127,
+    "mtime": 1782540714.2026362,
     "ast_hash": "64f209cc056e8a51110fc91a200d8abc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Mobile.java": {
-    "mtime": 1782538949.0494127,
+    "mtime": 1782540714.2041426,
     "ast_hash": "99c440a93cda95169b39727741055898",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/NaturalActions.java": {
-    "mtime": 1782538949.0504117,
+    "mtime": 1782540714.2046683,
     "ast_hash": "16794b31ca521ab70430850b04a80827",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Paths.java": {
-    "mtime": 1782538949.0504117,
+    "mtime": 1782540714.2046683,
     "ast_hash": "e75d6d00fdd8079a0bc4e51ceec9152d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Pattern.java": {
-    "mtime": 1782538949.0504117,
+    "mtime": 1782540714.205677,
     "ast_hash": "8002dccd85dcdaafcd7ec207d48f88a5",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Performance.java": {
-    "mtime": 1782538949.0524135,
+    "mtime": 1782540714.2066782,
     "ast_hash": "8dbd8e97cf8b7f777b1f20aef1630a52",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Pilot.java": {
-    "mtime": 1782538949.0524135,
+    "mtime": 1782540714.2066782,
     "ast_hash": "5926e78f43d97233473dd978b9e55623",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Platform.java": {
-    "mtime": 1782538949.0534132,
+    "mtime": 1782540714.2076774,
     "ast_hash": "ba6e6ce752e51b47b72229aa04fd4fe3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Properties.java": {
-    "mtime": 1782538949.0534132,
+    "mtime": 1782540714.208678,
     "ast_hash": "f2a5ec5f2f57f7b18d68808b3f0a9e91",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java": {
-    "mtime": 1782538949.0544178,
+    "mtime": 1782540714.2096775,
     "ast_hash": "322d6ce15493bbfa7ddfe90af768da21",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/PropertyFileManager.java": {
-    "mtime": 1782538949.0554175,
+    "mtime": 1782540714.2106788,
     "ast_hash": "2ab8de326fa8ddb7229618022678ed9e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Reporting.java": {
-    "mtime": 1782538949.0554175,
+    "mtime": 1782540714.2106788,
     "ast_hash": "3c776912a22f41ada8e6ba8143e2d589",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/TestNG.java": {
-    "mtime": 1782538949.0564184,
+    "mtime": 1782540714.2116761,
     "ast_hash": "1adc422ea00e7c51988bc02d45281486",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/ThreadLocalPropertiesManager.java": {
-    "mtime": 1782538949.0564184,
+    "mtime": 1782540714.212678,
     "ast_hash": "7603bbb7bf6364ce7bf5b9f5e1bba5e1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Timeouts.java": {
-    "mtime": 1782538949.057419,
+    "mtime": 1782540714.212678,
     "ast_hash": "01ef9ffeba24462276fb15dc4a4d373f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Tinkey.java": {
-    "mtime": 1782538949.057419,
+    "mtime": 1782540714.212678,
     "ast_hash": "f35fc1565279b0d33b1b76121bf74440",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Visuals.java": {
-    "mtime": 1782538949.0584166,
+    "mtime": 1782540714.2141852,
     "ast_hash": "606feddfa218d572c43882a90f235400",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Web.java": {
-    "mtime": 1782538949.0584166,
+    "mtime": 1782540714.2147086,
     "ast_hash": "20cf2529ea8129f74e8f092bc14cadde",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/FirestoreRestClient.java": {
-    "mtime": 1782538949.0604193,
+    "mtime": 1782540714.2207284,
     "ast_hash": "52adc8b518e5c5ed1246fd4aa8271ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/security/GoogleTink.java": {
-    "mtime": 1782538949.0614178,
+    "mtime": 1782540714.221735,
     "ast_hash": "3d0e1234d2dbab5b9ef7b984cb681088",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/AndroidApkBadgingReader.java": {
-    "mtime": 1782538949.0614178,
+    "mtime": 1782540714.222739,
     "ast_hash": "eb3f564e4c3e3d2f3ffccaf882ac4b1f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/HTMLHelper.java": {
-    "mtime": 1782538949.0624185,
+    "mtime": 1782540714.2247813,
     "ast_hash": "f0a56363f56a0ca50bf0013a441c5633",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/JavaHelper.java": {
-    "mtime": 1782538949.0624185,
+    "mtime": 1782540714.226794,
     "ast_hash": "3de9ea3f98b99d20eeeb148de402cfed",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/JavaScriptHelper.java": {
-    "mtime": 1782538949.0634181,
+    "mtime": 1782540714.227795,
     "ast_hash": "ffa7c4c697733f0ba85ac8992acad360",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/PerformanceReportHTMLHelper.java": {
-    "mtime": 1782538949.0634181,
+    "mtime": 1782540714.2287953,
     "ast_hash": "2aa68a99c366eb8ed98b7828a04e6616",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/tms/XrayIntegrationHelper.java": {
-    "mtime": 1782538949.0644174,
+    "mtime": 1782540714.229798,
     "ast_hash": "eb849fadba51320243f21ab56502a88a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/CSVFileManager.java": {
-    "mtime": 1782538949.065418,
+    "mtime": 1782540714.2307973,
     "ast_hash": "cc3031fcc8e920871577f8dec0b42805",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/ExcelFileManager.java": {
-    "mtime": 1782538949.065418,
+    "mtime": 1782540714.2317986,
     "ast_hash": "77c92476b59d21096ff6f14788089dd9",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/JSONFileManager.java": {
-    "mtime": 1782538949.0664182,
+    "mtime": 1782540714.2317986,
     "ast_hash": "dd7a5b8f6f927191caa131280df13a65",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/PdfFileManager.java": {
-    "mtime": 1782538949.0664182,
+    "mtime": 1782540714.2327957,
     "ast_hash": "da672eb4269d3a41533ed1532da0e185",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/ReportManager.java": {
-    "mtime": 1782538949.067418,
+    "mtime": 1782540714.2327957,
     "ast_hash": "e658122a017e7931fced4022a1d53bae",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/YAMLFileManager.java": {
-    "mtime": 1782538949.067418,
+    "mtime": 1782540714.2337976,
     "ast_hash": "d5a21b7fac317f8b4e5341c703a0a249",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java": {
-    "mtime": 1782538949.0689225,
-    "ast_hash": "970a0897b74378c45d27fdecad4f20c3",
+    "mtime": 1782540698.2474942,
+    "ast_hash": "c2bc00c1a17c5a90da645af4ce12e30b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ApiPerformanceExecutionReport.java": {
-    "mtime": 1782538949.069928,
+    "mtime": 1782540714.2356377,
     "ast_hash": "833e6f15ddd03a4dc3f70a15a011a4af",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/AttachmentReporter.java": {
-    "mtime": 1782538949.069928,
+    "mtime": 1782540714.2368426,
     "ast_hash": "2dbb5e268695b9d68607752314001f5b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointCounter.java": {
-    "mtime": 1782538949.0719283,
+    "mtime": 1782540714.2388444,
     "ast_hash": "a1a02948e84774c8b13b7b56b5d6f254",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointStatus.java": {
-    "mtime": 1782538949.0729277,
+    "mtime": 1782540714.239841,
     "ast_hash": "02d39d0739d083d1109634c17bb340c1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointType.java": {
-    "mtime": 1782538949.0729277,
+    "mtime": 1782540714.239841,
     "ast_hash": "e688c7535844f865f0c179f1f0f7a41b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ExecutionSummaryReport.java": {
-    "mtime": 1782538949.073928,
+    "mtime": 1782540714.2408442,
     "ast_hash": "aba05a8383ad5ccc5fecd05473359e56",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureReporter.java": {
-    "mtime": 1782538949.0759275,
+    "mtime": 1782540714.2438827,
     "ast_hash": "5c3cbaf91f5d1501231b96f95bf6d566",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/IssueReporter.java": {
-    "mtime": 1782538949.0779293,
+    "mtime": 1782540714.2463963,
     "ast_hash": "4eba0030e5188396323aab843b0747fa",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/LogRedirector.java": {
-    "mtime": 1782538949.0779293,
+    "mtime": 1782540714.2463963,
     "ast_hash": "9734e0985bd24a628cdf0ef67514d8ab",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ProgressBarLogger.java": {
-    "mtime": 1782538949.0789278,
+    "mtime": 1782540714.2473958,
     "ast_hash": "4de6b992fac957b71005dcdaae5d3bde",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ProjectStructureManager.java": {
-    "mtime": 1782538949.0799305,
+    "mtime": 1782540714.2483976,
     "ast_hash": "b8f74461b5c086f8941e6cb3ef9555b1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportHelper.java": {
-    "mtime": 1782538949.0809278,
+    "mtime": 1782540714.249396,
     "ast_hash": "807338ec8f08ec6d82804254656ed806",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java": {
-    "mtime": 1782538949.081929,
+    "mtime": 1782540714.2551901,
     "ast_hash": "5b18563f42da482dfa592f29524ba798",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/ValidationEnums.java": {
-    "mtime": 1782538949.082928,
+    "mtime": 1782540714.2571926,
     "ast_hash": "1a700a8ec5f1bc9a8ad65352a4891e8f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/Validations.java": {
-    "mtime": 1782538949.082928,
+    "mtime": 1782540714.2581913,
     "ast_hash": "eb127c87713ca57986c7aa799e13dd29",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/accessibility/AccessibilityActions.java": {
-    "mtime": 1782538949.0849285,
+    "mtime": 1782540714.2591915,
     "ast_hash": "e669af2150be68c403f6276c12a4f0db",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/accessibility/AccessibilityHelper.java": {
-    "mtime": 1782538949.0859282,
+    "mtime": 1782540714.2607014,
     "ast_hash": "40926f3fea91935ab7dbfb93bc675af7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/CustomSoftAssert.java": {
-    "mtime": 1782538949.0869281,
+    "mtime": 1782540714.2627106,
     "ast_hash": "d4d79fea9924eca6d094dcf8d77694cc",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/FileValidationsBuilder.java": {
-    "mtime": 1782538949.0869281,
+    "mtime": 1782540714.2627106,
     "ast_hash": "05b7459be4fb4a2b653dadbac75eed37",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/JSONValidationsBuilder.java": {
-    "mtime": 1782538949.0879278,
+    "mtime": 1782540714.2647445,
     "ast_hash": "e7961b1a51db674dd615bedc29eb4793",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/NativeValidationsBuilder.java": {
-    "mtime": 1782538949.0879278,
+    "mtime": 1782540714.2647445,
     "ast_hash": "35c20b2f52ab5f62588ac9d1f999b9d5",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/NumberValidationsBuilder.java": {
-    "mtime": 1782538949.0889285,
+    "mtime": 1782540714.2657554,
     "ast_hash": "10b25c3ee77eb08878b4e715f70b6ad0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/RestValidationsBuilder.java": {
-    "mtime": 1782538949.089928,
+    "mtime": 1782540714.2667508,
     "ast_hash": "58553b6f5f4c8f13d9044cacc581fa61",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/TextDirectionValidationsBuilder.java": {
-    "mtime": 1782538949.0909293,
+    "mtime": 1782540714.267751,
     "ast_hash": "05ffa33312d65e6de2953407817bff52",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/TextLanguageValidationsBuilder.java": {
-    "mtime": 1782538949.0909293,
+    "mtime": 1782540714.267751,
     "ast_hash": "6bac35c22470196c40e45b599e57ae03",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsBuilder.java": {
-    "mtime": 1782538949.0919282,
+    "mtime": 1782540714.2687533,
     "ast_hash": "c113fe199e929201df6ef9ad1811a224",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsExecutor.java": {
-    "mtime": 1782538949.0929296,
+    "mtime": 1782540714.269751,
     "ast_hash": "d074cf33a934e4b588baefb70a4577e0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java": {
-    "mtime": 1782538949.0939293,
+    "mtime": 1782540714.2707603,
     "ast_hash": "600af09278c60901b734cdedf335d3da",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverBrowserValidationsBuilder.java": {
-    "mtime": 1782538949.094929,
+    "mtime": 1782540714.2707603,
     "ast_hash": "e19e7ddf982160476c7e6b70c672d943",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverElementValidationsBuilder.java": {
-    "mtime": 1782538949.094929,
+    "mtime": 1782540714.271757,
     "ast_hash": "2caa9ef6dab6194ef71966119f0ed4de",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/javadoc/resources/configuration-manager/jquery-3.5.0.min.js": {
-    "mtime": 1782538949.1009295,
+    "mtime": 1782540714.2797713,
     "ast_hash": "7c5d886a944957e9ed1cc3c5eba023e9",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/javadoc/resources/configuration-manager/main-built.js": {
-    "mtime": 1782538949.102929,
+    "mtime": 1782540714.2817776,
     "ast_hash": "bfcc66727306f6a7d6db18d89d9cbd8f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/javadoc/resources/configuration-manager/require.js": {
-    "mtime": 1782538949.102929,
+    "mtime": 1782540714.2827768,
     "ast_hash": "81692bed77535de23323aed492f56861",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/appium/.appiumrc.json": {
-    "mtime": 1782538949.1089284,
+    "mtime": 1782540714.2969606,
     "ast_hash": "ae646a89330e08877d9e043741e04a89",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/healenium-backend/db/sql/init.sql": {
-    "mtime": 1782538949.110928,
+    "mtime": 1782540714.298958,
     "ast_hash": "68aef48e69eba5aebc7b90883a9928e3",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/postgres/client.js": {
-    "mtime": 1782538949.1119306,
+    "mtime": 1782540714.3014781,
     "ast_hash": "a14553a735ee0f513a9da43c3e6f352f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/selenoid/browsers.json": {
-    "mtime": 1782538949.1149297,
+    "mtime": 1782540714.3045037,
     "ast_hash": "a911d4a4e1c61fbf88ddf25de262ff9b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/start_emu_headless": {
-    "mtime": 1782538949.1159294,
+    "mtime": 1782540714.30551,
     "ast_hash": "70d231d40fb0677a8762c704a4209744",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/src/test/java/testRunners/CucumberTests.java": {
-    "mtime": 1782538949.1389284,
+    "mtime": 1782540714.3375902,
     "ast_hash": "81a52f665b264bd8f06e25ab4029ccc7",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/Cucumber/shaft-cucumber-web/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782538949.1439295,
+    "mtime": 1782540714.3431146,
     "ast_hash": "064e08dd978e03c2928244264e946ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1782538949.155934,
+    "mtime": 1782540714.3616168,
     "ast_hash": "16a9fe15aa00921a0a57426e530b4418",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782538949.158934,
+    "mtime": 1782540714.3666635,
     "ast_hash": "c3aa96f48b1065e13bb7402b929d9889",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1782538949.1760888,
+    "mtime": 1782540714.3827147,
     "ast_hash": "6be46fd0c9360daf9cc0fe1e489282f1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-mobile/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782538949.2100897,
+    "mtime": 1782540714.418792,
     "ast_hash": "064e08dd978e03c2928244264e946ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1782538949.2220893,
+    "mtime": 1782540714.4384685,
     "ast_hash": "63b5ca0a71c4d5005c7ae9656b9c6c74",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/JUnit/shaft-junit-web/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782538949.2270916,
+    "mtime": 1782540714.4429884,
     "ast_hash": "064e08dd978e03c2928244264e946ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1782538949.2400887,
+    "mtime": 1782540714.4566412,
     "ast_hash": "3cbfad60eb5b0316804c448223639228",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782538949.244092,
+    "mtime": 1782540714.4657028,
     "ast_hash": "c3aa96f48b1065e13bb7402b929d9889",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1782538949.2620938,
+    "mtime": 1782540714.479257,
     "ast_hash": "6f82df052ec4e4a835b7c2656798bcab",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-mobile/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782538949.2861803,
+    "mtime": 1782540714.5140646,
     "ast_hash": "064e08dd978e03c2928244264e946ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/src/test/java/testPackage/TestClass.java": {
-    "mtime": 1782538949.3011794,
+    "mtime": 1782540714.5351286,
     "ast_hash": "89f691f86e06b6ed04028ac322acb53d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/TestNG/shaft-testng-web/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782538949.306181,
+    "mtime": 1782540714.5394096,
     "ast_hash": "064e08dd978e03c2928244264e946ed2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/ApiPerformanceReportTest.java": {
-    "mtime": 1782538949.33118,
+    "mtime": 1782540714.572917,
     "ast_hash": "6b42836ee0a0d8860582c0c3389a6f1c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/LocalApiTestServer.java": {
-    "mtime": 1782538949.33118,
+    "mtime": 1782540714.572917,
     "ast_hash": "4b479fde1c2774b1ef0b88fe9bee0047",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/PathParamTest.java": {
-    "mtime": 1782538949.3321793,
+    "mtime": 1782540714.5744221,
     "ast_hash": "6333c55505dba0c7cae8f443c2cc748c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/RequestBuilderTests.java": {
-    "mtime": 1782538949.3341806,
+    "mtime": 1782540714.5754285,
     "ast_hash": "9b1d812122f7dce4fb77dd47d6b26f90",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/RestActionsCoverageUnitTest.java": {
-    "mtime": 1782538949.33618,
+    "mtime": 1782540714.5754285,
     "ast_hash": "6194394f7de5a5a618699b1289ab388b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/SwaggerContractTest.java": {
-    "mtime": 1782538949.33618,
+    "mtime": 1782540714.5764284,
     "ast_hash": "adc4d25a405c2a64c949da6a0c41e232",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/TestUpload.java": {
-    "mtime": 1782538949.3371797,
+    "mtime": 1782540714.5774293,
     "ast_hash": "3f21181377aeac1c34f46b1a7c1cf298",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/testPostRequest.java": {
-    "mtime": 1782538949.3381817,
+    "mtime": 1782540714.5784295,
     "ast_hash": "9de940d6b7dc8e741eb019b9fccba6cd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/cli/FileActionsCoverageUnitTest.java": {
-    "mtime": 1782538949.33918,
+    "mtime": 1782540714.5794284,
     "ast_hash": "c45c9550223fe7dcd993697eacf00c6b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/cucumber/ElementStepsCoverageUnitTest.java": {
-    "mtime": 1782538949.3401797,
+    "mtime": 1782540714.5814314,
     "ast_hash": "68270ddb7b02986ee98f52b2fa8892a7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelperCoverageUnitTest.java": {
-    "mtime": 1782538949.3421805,
+    "mtime": 1782540714.582429,
     "ast_hash": "e92058dc8a463d5bc611a1b4ea514e3c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/OptionsManagerCoverageUnitTest.java": {
-    "mtime": 1782538949.343179,
+    "mtime": 1782540714.5839353,
     "ast_hash": "183120984e8fe511cf50731e958ad64d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/AsyncElementActionsCoverageUnitTest.java": {
-    "mtime": 1782538949.3471794,
+    "mtime": 1782540714.5884707,
     "ast_hash": "82de6e0ba9113ac7f63bba70cd5922bf",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java": {
-    "mtime": 1782538949.3491802,
+    "mtime": 1782540714.5894654,
     "ast_hash": "626231bc69664d907ebc9c43997a6fa0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsExceptionDetailsUnitTest.java": {
-    "mtime": 1782538949.3501794,
+    "mtime": 1782540714.5904686,
     "ast_hash": "38a470e4ccf528f247d2adb30ee8a480",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ElementInformationCoverageUnitTest.java": {
-    "mtime": 1782538949.3511798,
+    "mtime": 1782540714.5940979,
     "ast_hash": "2683114ad3f10a14f3925a6bd6835400",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ElementsHelperCoverageUnitTest.java": {
-    "mtime": 1782538949.3521829,
+    "mtime": 1782540714.596603,
     "ast_hash": "76f70bb8df336467105fc9ab7964a074",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/healing/HealingActionsIntegrationTest.java": {
-    "mtime": 1782538949.3541794,
+    "mtime": 1782540714.5983078,
     "ast_hash": "eef0b6ec55d75db96f4416c65ec0c65f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/healing/HealingStrategyTest.java": {
-    "mtime": 1782538949.355185,
+    "mtime": 1782540714.5993066,
     "ast_hash": "c29f55b4622c05fbf066a1a3f5143b88",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/AnimatedGifManagerCoverageUnitTest.java": {
-    "mtime": 1782538949.3561857,
+    "mtime": 1782540714.6008136,
     "ast_hash": "bf0671ff4c59d2d23ff75bd13e8c5743",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotHelperCoverageUnitTest.java": {
-    "mtime": 1782538949.3581865,
+    "mtime": 1782540714.6038206,
     "ast_hash": "b0b5269cd3a52b3a438193dcbf99f73f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotManagerCoverageUnitTest.java": {
-    "mtime": 1782538949.3591838,
+    "mtime": 1782540714.6043258,
     "ast_hash": "1b53acb9faec7f11548e0198dca8e680",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/VisualProcessingProviderRegistryTest.java": {
-    "mtime": 1782538949.3591838,
+    "mtime": 1782540714.6053317,
     "ast_hash": "f65e99d62de78111e607e18fd4d6aceb",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/natural/NaturalActionExecutorTest.java": {
-    "mtime": 1782538949.3631854,
+    "mtime": 1782540714.6083343,
     "ast_hash": "aa28815755a0f28bd7343de86b58bee7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistryTest.java": {
-    "mtime": 1782538949.365184,
+    "mtime": 1782540714.6093311,
     "ast_hash": "a2fa8e0ef33d17122b51f64ba073e670",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/video/RecordManagerCoverageUnitTest.java": {
-    "mtime": 1782538949.3661838,
+    "mtime": 1782540714.6108372,
     "ast_hash": "b728bfab006ff8f0057b22748932c062",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/video/RecordManagerDesktopProviderTest.java": {
-    "mtime": 1782538949.3661838,
+    "mtime": 1782540714.6118443,
     "ast_hash": "badd24f271266d3b1385ed7f93bbecd7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/listeners/AllureListenerCoverageUnitTest.java": {
-    "mtime": 1782538949.371473,
+    "mtime": 1782540714.61636,
     "ast_hash": "2241a07317bff8346a1bd1c01137e1a7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/listeners/internal/UpdateCheckerUnitTest.java": {
-    "mtime": 1782538949.372473,
+    "mtime": 1782540714.6183603,
     "ast_hash": "a0c400588dc92dc8f84602e923dc34fd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/performance/internal/LightHouseGenerateReportCoverageUnitTest.java": {
-    "mtime": 1782538949.3744733,
+    "mtime": 1782540714.621884,
     "ast_hash": "d12ef0c4ab02daa11d78b8fa0b0def3e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/test/unitTests/JavaScriptWaitManagerUnitTest.java": {
-    "mtime": 1782538949.3774726,
+    "mtime": 1782540714.6274343,
     "ast_hash": "08bea5190a0202d3ca812e9b77ea809e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/internal/security/GoogleTinkApiCoverageUnitTest.java": {
-    "mtime": 1782538949.379473,
+    "mtime": 1782540714.63042,
     "ast_hash": "f0c7bd8edaf562770403f311517f050f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/JSONFileManagerTestAccessor.java": {
-    "mtime": 1782538949.3804731,
+    "mtime": 1782540714.631428,
     "ast_hash": "d9ef7d440aa067f73898384896afa5ee",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureManagerCoverageUnitTest.java": {
-    "mtime": 1782538949.3804731,
+    "mtime": 1782540714.6324284,
     "ast_hash": "8e16f9c749c62d33e891be8ee0dafad8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/ProgressBarLoggerCoverageUnitTest.java": {
-    "mtime": 1782538949.3854773,
+    "mtime": 1782540714.6384666,
     "ast_hash": "cfadf25f42514ed4fecbe14029ed0c48",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/ProgressBarLoggerTestAccessor.java": {
-    "mtime": 1782538949.3854773,
+    "mtime": 1782540714.6394656,
     "ast_hash": "7a536f9d92a15f04078b0d80f4809018",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/accessibility/AccessibilityHelperCoverageUnitTest.java": {
-    "mtime": 1782538949.3864734,
+    "mtime": 1782540714.6409771,
     "ast_hash": "a07263ddc69e8bfc0ac90038e5caafb5",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsExecutorTestAccessor.java": {
-    "mtime": 1782538949.387472,
+    "mtime": 1782540714.6419861,
     "ast_hash": "da15362a3e7a802bad7f5d94ed318c76",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelperCoverageUnitTest.java": {
-    "mtime": 1782538949.3884728,
+    "mtime": 1782540714.6429942,
     "ast_hash": "d22b363eae55211786a325255bfd197e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/internal/WebDriverElementValidationsBuilderCoverageUnitTest.java": {
-    "mtime": 1782538949.389473,
+    "mtime": 1782540714.6445,
     "ast_hash": "a30dd92879b097ff5853dbb8999cf147",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/cucumberTestRunner/CucumberTests.java": {
-    "mtime": 1782538949.390472,
+    "mtime": 1782540714.6455102,
     "ast_hash": "74ef6fcb26ae1bf65684240930dd0f66",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/customCucumberSteps/steps.java": {
-    "mtime": 1782538949.390472,
+    "mtime": 1782540714.6455102,
     "ast_hash": "996c5594b17086d3b5b937776f4309db",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/external/FileActionsReflectionInvoker.java": {
-    "mtime": 1782538949.3914733,
+    "mtime": 1782540714.6465073,
     "ast_hash": "8251926ce3c459f65681aaf4925cda59",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitParallelizationTests.java": {
-    "mtime": 1782538949.3944724,
+    "mtime": 1782540714.6495075,
     "ast_hash": "c213b41fd84d475acbdef117917bb2b2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitTest.java": {
-    "mtime": 1782538949.3954718,
+    "mtime": 1782540714.6515086,
     "ast_hash": "80e036596d170587890d7947a2b6ee92",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/MoonTests.java": {
-    "mtime": 1782538949.3974726,
+    "mtime": 1782540714.6525068,
     "ast_hash": "3d4b38081680b77d4ae52f2a4b2219c6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/objectclass/BodyObject.java": {
-    "mtime": 1782538949.3974726,
+    "mtime": 1782540714.6545558,
     "ast_hash": "03f0c5fc69471404fe1e0e603466f818",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/CopilotGeneratedTests/ActionsCoverageTests.java": {
-    "mtime": 1782538949.3984728,
+    "mtime": 1782540714.656565,
     "ast_hash": "4d7fd64afc511b6c060fc9bdd1808db7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/CopilotGeneratedTests/RestActionsComprehensiveTests.java": {
-    "mtime": 1782538949.3994799,
+    "mtime": 1782540714.657568,
     "ast_hash": "28f298cd5240a0f802c52f4fc9a4dab3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/CopilotGeneratedTests/UnitTestsRestActions.java": {
-    "mtime": 1782538949.3994799,
+    "mtime": 1782540714.6626112,
     "ast_hash": "f7a90e6eae203244b1f50f592b7fdd49",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/CopilotGeneratedTests/UnitTestsSHAFT.java": {
-    "mtime": 1782538949.4004793,
+    "mtime": 1782540714.6626112,
     "ast_hash": "1a0f0ce42dfb5df20043a7c64ef5f0f2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/LambdaTestCredentials.java": {
-    "mtime": 1782538949.4004793,
+    "mtime": 1782540714.6648204,
     "ast_hash": "95942d341f6c15cb5ef9055b1808bcb1",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTDesktopWebMac.java": {
-    "mtime": 1782538949.4014733,
+    "mtime": 1782540714.6648204,
     "ast_hash": "2f3d1140f11fc9b71b0bedc8ecc3da3b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTDesktopWebWindows.java": {
-    "mtime": 1782538949.4014733,
+    "mtime": 1782540714.6658275,
     "ast_hash": "157fb2b3b04bdfea2fe6185cbebf841c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobAPKAPPURL.java": {
-    "mtime": 1782538949.4024732,
+    "mtime": 1782540714.666828,
     "ast_hash": "f35e9468c40360b72f8b61adffa1450d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobAPKRelativePath.java": {
-    "mtime": 1782538949.4024732,
+    "mtime": 1782540714.666828,
     "ast_hash": "5789694ff5cfd58a44c97cb7ad1271e0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobIPAAppURL.java": {
-    "mtime": 1782538949.4024732,
+    "mtime": 1782540714.666828,
     "ast_hash": "8d8bd350aa5b1c3c3a3cf0cd781450c8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobIPARelativePath.java": {
-    "mtime": 1782538949.4034748,
+    "mtime": 1782540714.6678264,
     "ast_hash": "1647018c30c20b7960074c5ff3bb51b2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTWebAppIOS.java": {
-    "mtime": 1782538949.4034748,
+    "mtime": 1782540714.668828,
     "ast_hash": "01affbeef9bd4974c99ca3991af231d3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTWebAppRealme.java": {
-    "mtime": 1782538949.4044735,
+    "mtime": 1782540714.668828,
     "ast_hash": "316149ae0962ad94d9a60dbb6fe8cb9d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/APIWizardTests.java": {
-    "mtime": 1782538949.4054747,
+    "mtime": 1782540714.6698287,
     "ast_hash": "a660856536f3395e80893fab6604f552",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/CLIWizardTests.java": {
-    "mtime": 1782538949.4054747,
+    "mtime": 1782540714.670828,
     "ast_hash": "b9df0988ecaad726adc5fea8c897ab88",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/CustomDriverInitializationTests.java": {
-    "mtime": 1782538949.4064744,
+    "mtime": 1782540714.6718295,
     "ast_hash": "9b4a204a9f376bf9172a75b7a83ff3ac",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/DBWizardTests.java": {
-    "mtime": 1782538949.4064744,
+    "mtime": 1782540714.6718295,
     "ast_hash": "f578f87a677a9ace374460f653a7a416",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/FluentGuiActionsTest.java": {
-    "mtime": 1782538949.4074738,
+    "mtime": 1782540714.6728296,
     "ast_hash": "ec867d13fcd03e7f0636806479b75168",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/GUIWizardTests.java": {
-    "mtime": 1782538949.4074738,
+    "mtime": 1782540714.6728296,
     "ast_hash": "0b390e4118280e1abc7f529f48555de6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/TestHelpers.java": {
-    "mtime": 1782538949.4084735,
+    "mtime": 1782540714.6738281,
     "ast_hash": "8be2574841bdfc32c03cba0a0e2a8dc2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/WizardStandaloneValidationTests.java": {
-    "mtime": 1782538949.4084735,
+    "mtime": 1782540714.674334,
     "ast_hash": "35f04e8619760f8ebd8814c4d4303ca9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/SHAFTWizard/WizardTestDataTests.java": {
-    "mtime": 1782538949.4094777,
+    "mtime": 1782540714.675342,
     "ast_hash": "33ac597fd308b12054d8f42f82799d5e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/TestPageServer.java": {
-    "mtime": 1782538949.4104757,
+    "mtime": 1782540714.675342,
     "ast_hash": "2646363db37f021394df4d2e581aebc6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/TestScenario.java": {
-    "mtime": 1782538949.4104757,
+    "mtime": 1782540714.675342,
     "ast_hash": "1eb22ef127c1db1ae030d5be3d4f1793",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/Tests.java": {
-    "mtime": 1782538949.411476,
+    "mtime": 1782540714.676343,
     "ast_hash": "57e8f66047ac7beae82ab5c23cc7bf87",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/AndroidBasicInteractionsTests.java": {
-    "mtime": 1782538949.4124763,
+    "mtime": 1782540714.677343,
     "ast_hash": "dd601a01d9c455ec89b2c7160ba4eec8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/AndroidDragAndDropTest.java": {
-    "mtime": 1782538949.4124763,
+    "mtime": 1782540714.677343,
     "ast_hash": "2ffc8e85a4d6c7b23b6912cb87beb2fd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/AndroidTouchActionsTests.java": {
-    "mtime": 1782538949.413474,
+    "mtime": 1782540714.6783423,
     "ast_hash": "532f29bf0254c1ff8f525a507a1a430a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/FileUploadDownloadTest.java": {
-    "mtime": 1782538949.413474,
+    "mtime": 1782540714.6783423,
     "ast_hash": "7d6ebdfaaf28e3d2b90d22b4ca16e9e9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/FlutterTest.java": {
-    "mtime": 1782538949.414474,
+    "mtime": 1782540714.6793406,
     "ast_hash": "7366c8b69d03e80b2fb4bd19f1d32037",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/IOSBasicInteractionsTest.java": {
-    "mtime": 1782538949.414474,
+    "mtime": 1782540714.6793406,
     "ast_hash": "c14cf8b63c53b19cf5ecb4c7020eaa24",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/MobileTest.java": {
-    "mtime": 1782538949.4154766,
+    "mtime": 1782540714.6808507,
     "ast_hash": "9d3c39b310b254b8e46b0787b9863b45",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/appium/MobileWebTest.java": {
-    "mtime": 1782538949.4154766,
+    "mtime": 1782540714.6808507,
     "ast_hash": "1e71bec893b591efdc6ad81c0861de05",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/AssertApiResponseEqualsTests.java": {
-    "mtime": 1782538949.4174738,
+    "mtime": 1782540714.6843703,
     "ast_hash": "6f6b3fc3c46d22b1be2e15c313ae0d4b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/AssertEqualsTests.java": {
-    "mtime": 1782538949.4184742,
+    "mtime": 1782540714.6843703,
     "ast_hash": "ac28053c858948f6c8072ae22ad3cb68",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/BasicAPITests.java": {
-    "mtime": 1782538949.4184742,
+    "mtime": 1782540714.6853786,
     "ast_hash": "04f6e36cc676509fd50bf69cf0f8214e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/BasicAuthenticationTests.java": {
-    "mtime": 1782538949.4194756,
+    "mtime": 1782540714.6863797,
     "ast_hash": "9496029f86d3f528ab13caabb2d0fe8d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/BigPageActionsTest.java": {
-    "mtime": 1782538949.4194756,
+    "mtime": 1782540714.6873803,
     "ast_hash": "5c59782bc79d4c0e169a4a289b802bf4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/CSVFileManagerTest.java": {
-    "mtime": 1782538949.4204755,
+    "mtime": 1782540714.688379,
     "ast_hash": "5bb3c372688c46b067b1b9863e25072d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/ChainableElementActionsTests.java": {
-    "mtime": 1782538949.421477,
+    "mtime": 1782540714.689379,
     "ast_hash": "06ae6b54a7d97bc516cc10cf6b99b1b5",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/ChecksumTests.java": {
-    "mtime": 1782538949.421477,
+    "mtime": 1782540714.6908903,
     "ast_hash": "5906715678d0f232e561110e1ff7a158",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/CookiesTests.java": {
-    "mtime": 1782538949.4224782,
+    "mtime": 1782540714.6908903,
     "ast_hash": "758c6a8df8d6416f380f1d39aac31c06",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/DragAndDropTests.java": {
-    "mtime": 1782538949.4224782,
+    "mtime": 1782540714.6919017,
     "ast_hash": "342e71b079c44b808491154c7bd27ba6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/DynamicLoadingTest.java": {
-    "mtime": 1782538949.4234734,
+    "mtime": 1782540714.6919017,
     "ast_hash": "75821892b9db3a83dbec9eb1e6cd2c2a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/FileActionsTests.java": {
-    "mtime": 1782538949.4234734,
+    "mtime": 1782540714.6971917,
     "ast_hash": "b562813a025a45e3fc69064917478f4d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/FrameTests.java": {
-    "mtime": 1782538949.4244726,
+    "mtime": 1782540714.6990814,
     "ast_hash": "2377b86c25ba830a3a62c8eb3673f54b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/GetTableRowsDataTests.java": {
-    "mtime": 1782538949.4244726,
+    "mtime": 1782540714.6990814,
     "ast_hash": "e70588ff08a9232d318ac38de8c922b7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/GraphqlRequestTests.java": {
-    "mtime": 1782538949.4254727,
+    "mtime": 1782540714.6990814,
     "ast_hash": "9dd849ae0967c7a40ef9cf5ae77220b2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/GroupsTests.java": {
-    "mtime": 1782538949.4254727,
+    "mtime": 1782540714.7005916,
     "ast_hash": "5051d79e29fdd758369f62fbb35d8639",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/IsElementClickableTest.java": {
-    "mtime": 1782538949.4264734,
+    "mtime": 1782540714.7016008,
     "ast_hash": "6ef73b0291f982d6a93dc783fe65a7f7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JSAlertBoxTests.java": {
-    "mtime": 1782538949.4264734,
+    "mtime": 1782540714.7026007,
     "ast_hash": "87a6cc3676d62bfdcd5039c55974c99a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JSConfirmBoxTests.java": {
-    "mtime": 1782538949.4274733,
+    "mtime": 1782540714.7026007,
     "ast_hash": "bb2be41715ecadad8c1c352ec2f3edea",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JSONFileManagerTests.java": {
-    "mtime": 1782538949.4274733,
+    "mtime": 1782540714.7046237,
     "ast_hash": "06f43c8542a39433d95f396bddc2511e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JSPromptBoxTests.java": {
-    "mtime": 1782538949.4284742,
+    "mtime": 1782540714.7052903,
     "ast_hash": "20322607f3abd3ee7b114d7a076640df",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JsonActionsTests.java": {
-    "mtime": 1782538949.4284742,
+    "mtime": 1782540714.7056298,
     "ast_hash": "0eeae0f35f4b5d59ce66f3fdc5a43c92",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/JsonCompareWithSpecialCharactersTests.java": {
-    "mtime": 1782538949.429473,
+    "mtime": 1782540714.7056298,
     "ast_hash": "8ec3e11aa822c7834ff5c361a6044a57",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/LazyLoadingTests.java": {
-    "mtime": 1782538949.429473,
+    "mtime": 1782540714.706631,
     "ast_hash": "2da719cae7f75db7d3f4b5282365ce88",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/LocalShellTests.java": {
-    "mtime": 1782538949.429473,
+    "mtime": 1782540714.7076292,
     "ast_hash": "6782d98e60aa0e1f0bcc9999f29d8a6a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/MatchJsonSchemaTests.java": {
-    "mtime": 1782538949.4304726,
+    "mtime": 1782540714.7086298,
     "ast_hash": "3876965c3c4b42b162b09caedef82ec7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/MobileEmulationTests.java": {
-    "mtime": 1782538949.4304726,
+    "mtime": 1782540714.7086298,
     "ast_hash": "35929225261df191611b8eb348dcbeb2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/MultipleDriverSessionTerminationTest.java": {
-    "mtime": 1782538949.4314728,
+    "mtime": 1782540714.709631,
     "ast_hash": "ebf545317e8990b561fb94cb7f13ceb6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/NetworkInterceptionTest.java": {
-    "mtime": 1782538949.4314728,
+    "mtime": 1782540714.710638,
     "ast_hash": "ce74294d08a4c05fdbf214d30224f871",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/NewValidationHelperTests.java": {
-    "mtime": 1782538949.4314728,
+    "mtime": 1782540714.7116385,
     "ast_hash": "4bc79fab96f68b8b12d5116587f24479",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/PDFTests.java": {
-    "mtime": 1782538949.4324727,
+    "mtime": 1782540714.7116385,
     "ast_hash": "9ce4274cf95b705c4c628161689a5716",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/PropertiesManagerTests.java": {
-    "mtime": 1782538949.4324727,
+    "mtime": 1782540714.7126367,
     "ast_hash": "43587b77aed4d5722770a6b08ccf019f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/RelativeLocatorsTests.java": {
-    "mtime": 1782538949.4334726,
+    "mtime": 1782540714.7126367,
     "ast_hash": "1c8054013b7ecb201fc5fe98b22daf10",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/RemoteGridVideoAttachmentIT.java": {
-    "mtime": 1782538949.4334726,
+    "mtime": 1782540714.7141416,
     "ast_hash": "dd14e5e72b21522e5be56680c8b3d026",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/SkipDueToIssueTests.java": {
-    "mtime": 1782538949.4344728,
+    "mtime": 1782540714.7146637,
     "ast_hash": "99a55a2822f04fdbbcee5cceb276fca8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/SwitchToNewTabTest.java": {
-    "mtime": 1782538949.4344728,
+    "mtime": 1782540714.7156725,
     "ast_hash": "006d6c897a4c1d231284dee7fe67d681",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/TableTests.java": {
-    "mtime": 1782538949.4354737,
+    "mtime": 1782540714.7156725,
     "ast_hash": "6d478cc94e1a5ee7eab2ab389899f534",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/TestDataTests.java": {
-    "mtime": 1782538949.4354737,
+    "mtime": 1782540714.7166708,
     "ast_hash": "95acd877eac50b8434b69adb83cbb977",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/UploadFileTests.java": {
-    "mtime": 1782538949.4364743,
+    "mtime": 1782540714.7166708,
     "ast_hash": "5302d25af26787f48deb393f87c23b4f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/ValidationsBuilderTests.java": {
-    "mtime": 1782538949.4374743,
+    "mtime": 1782540714.717671,
     "ast_hash": "fcf11e47db991e3a42aef3210fa2e360",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/VerifyEqualsTests.java": {
-    "mtime": 1782538949.4374743,
+    "mtime": 1782540714.718673,
     "ast_hash": "41d8d2fd6427379eb8fc445849b8424f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/legacy/YAMLFileManagerTests.java": {
-    "mtime": 1782538949.4384773,
+    "mtime": 1782540714.7196722,
     "ast_hash": "3230789cecccce6618d4d1803676627d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/locator/LocatorBuilderTest.java": {
-    "mtime": 1782538949.439473,
+    "mtime": 1782540714.721671,
     "ast_hash": "0414482e4f34d9a26b3b4ced958e648f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/locator/ShadowDomTest.java": {
-    "mtime": 1782538949.439473,
+    "mtime": 1782540714.721671,
     "ast_hash": "6ed0c59ac8e49a4a7ef06df16c2963d7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/locator/SmartLocatorsPOC1Tests.java": {
-    "mtime": 1782538949.440473,
+    "mtime": 1782540714.722671,
     "ast_hash": "c3c8b2620562686f6b5e565535e18b95",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/locator/SmartLocatorsRealisticTests.java": {
-    "mtime": 1782538949.440473,
+    "mtime": 1782540714.722671,
     "ast_hash": "f43ba034e46306636cf2938d5c917eb9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/locator/SmartLocatorsTests.java": {
-    "mtime": 1782538949.441473,
+    "mtime": 1782540714.7241752,
     "ast_hash": "20c2cf801bc6adaf91c3a10eedfd305c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/AccessibilityTest.java": {
-    "mtime": 1782538949.4424727,
+    "mtime": 1782540714.72469,
     "ast_hash": "99d0232aa92b8d70edc1df791001873c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/ApiActionsMockedTests.java": {
-    "mtime": 1782538949.4424727,
+    "mtime": 1782540714.7256956,
     "ast_hash": "4f4c44851c27057934f2b7b59bc65ab5",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/CoverageTests.java": {
-    "mtime": 1782538949.443474,
+    "mtime": 1782540714.7256956,
     "ast_hash": "83c27fc65ab0c865b1cdf29f5866e8f8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/CucumberMockedTests.java": {
-    "mtime": 1782538949.443474,
+    "mtime": 1782540714.7277913,
     "ast_hash": "7f8a58e869251917ae68bba51332db11",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/DatabaseActionsMockedTests.java": {
-    "mtime": 1782538949.4444723,
+    "mtime": 1782540714.7306955,
     "ast_hash": "e2878a0cc73ffd2347f853ef2147cc72",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/DbTests.java": {
-    "mtime": 1782538949.4444723,
+    "mtime": 1782540714.7311995,
     "ast_hash": "269cfe45953923e0843780be937a461b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/E2ECoverageTests.java": {
-    "mtime": 1782538949.4454744,
+    "mtime": 1782540714.7311995,
     "ast_hash": "ca5993c2c426f5edafe4ce6625f48c17",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/ElementActionsMockedTests.java": {
-    "mtime": 1782538949.4454744,
+    "mtime": 1782540714.7327073,
     "ast_hash": "3ad7b5b6aef55cd46c2f7154f1ae6cda",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/GuiVerificationTests.java": {
-    "mtime": 1782538949.4464724,
+    "mtime": 1782540714.7327073,
     "ast_hash": "3d7a334d786337dbde7750cfe5f3fc4a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/HoverTests.java": {
-    "mtime": 1782538949.4464724,
+    "mtime": 1782540714.7337153,
     "ast_hash": "17caa339bfe3e0b97b6a5ffc19bf8b19",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/IOActionsMockedTests.java": {
-    "mtime": 1782538949.4464724,
+    "mtime": 1782540714.734723,
     "ast_hash": "c56ab69e6038fda5a988bd60c9cfeb22",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/JDK21VirtualThreadsAndAsyncActionsTests.java": {
-    "mtime": 1782538949.4474733,
+    "mtime": 1782540714.734723,
     "ast_hash": "51f1a029b91897744035cd850b1161a7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/LocatorMockedTests.java": {
-    "mtime": 1782538949.448474,
+    "mtime": 1782540714.735953,
     "ast_hash": "dad58a7c56a1467263bfae0f1da9480a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/MultipleBrowserInstancesTest.java": {
-    "mtime": 1782538949.4494717,
+    "mtime": 1782540714.735953,
     "ast_hash": "809818085b5e32dff077dfb0c656856b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/MultipleElementsFailureTest.java": {
-    "mtime": 1782538949.4494717,
+    "mtime": 1782540714.7369547,
     "ast_hash": "241d67949c16293b2350791d139a82fe",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/MultipleTypeCyclesTest.java": {
-    "mtime": 1782538949.4504724,
+    "mtime": 1782540714.737955,
     "ast_hash": "b2f43aacacb87d9e96673fe6ec092b31",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/NoSuchElementFailureTest.java": {
-    "mtime": 1782538949.4504724,
+    "mtime": 1782540714.737955,
     "ast_hash": "03a45eec716f23e232911a3211ee431c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/PageScreenshotTest.java": {
-    "mtime": 1782538949.451474,
+    "mtime": 1782540714.7389536,
     "ast_hash": "d49c21a61e72ec5469d72f13735e0de6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/SecurityMockedTests.java": {
-    "mtime": 1782538949.452475,
+    "mtime": 1782540714.7389536,
     "ast_hash": "2f5b6a0594b5c0984dbcda5ac7d487c6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/SelectMethodTests.java": {
-    "mtime": 1782538949.452475,
+    "mtime": 1782540714.7389536,
     "ast_hash": "ac0d848f85a4727aee2f0bc8a56bb843",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/SelectedValueTests.java": {
-    "mtime": 1782538949.4534752,
+    "mtime": 1782540714.7409673,
     "ast_hash": "81b968ea8374b0200a005df4f678937a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/ThreadSafeGuiWizardTests.java": {
-    "mtime": 1782538949.4534752,
+    "mtime": 1782540714.7409673,
     "ast_hash": "93278d8c91e0003270e1f37b3f9dbbe0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/TouchActionsTests.java": {
-    "mtime": 1782538949.4544733,
+    "mtime": 1782540714.7414858,
     "ast_hash": "bfec9ae0a72008d85b23f59529b0e9ea",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/ValidationTests.java": {
-    "mtime": 1782538949.4544733,
+    "mtime": 1782540714.742493,
     "ast_hash": "fd0f34e2c216022700d6967480b9a911",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/ValidationsMockedTests.java": {
-    "mtime": 1782538949.4554787,
+    "mtime": 1782540714.742493,
     "ast_hash": "06dceebbaa6cc58e0183baae80e4fb56",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/mockedTests/WaitActionsTest.java": {
-    "mtime": 1782538949.4554787,
+    "mtime": 1782540714.742493,
     "ast_hash": "a1b4352725f281f3d61dc14699074e4e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/BrowserStackSdkTests.java": {
-    "mtime": 1782538949.4594784,
+    "mtime": 1782540714.748523,
     "ast_hash": "d9ebd5580bb807c7604e0c74e38f151c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/BrowserStackTests.java": {
-    "mtime": 1782538949.460479,
+    "mtime": 1782540714.748523,
     "ast_hash": "7c56e754cf9df72d867793b89e4ce87d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/CucumberTests.java": {
-    "mtime": 1782538949.4614785,
+    "mtime": 1782540714.7495246,
     "ast_hash": "cc49d5bf128f50b8c9b49ee1d3d06b3a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/FlagsTests.java": {
-    "mtime": 1782538949.4614785,
+    "mtime": 1782540714.7525303,
     "ast_hash": "fcc937601e081f5aaed227e0c9be4c09",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/HealeniumTests.java": {
-    "mtime": 1782538949.4624786,
+    "mtime": 1782540714.7525303,
     "ast_hash": "4cbd96dfaa7ecd87d56e8fed846b5e12",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/HealingTests.java": {
-    "mtime": 1782538949.4624786,
+    "mtime": 1782540714.7540374,
     "ast_hash": "36a68b5420d9ac0898076eeafbe3017a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/InternalTests.java": {
-    "mtime": 1782538949.463482,
+    "mtime": 1782540714.755572,
     "ast_hash": "c0f069cd9f0d1229bd799d2bbcdd84f1",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/JiraTests.java": {
-    "mtime": 1782538949.463482,
+    "mtime": 1782540714.755572,
     "ast_hash": "eeba6ddfce3de33fbe989cc575a9cd90",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/Log4jTests.java": {
-    "mtime": 1782538949.464479,
+    "mtime": 1782540714.756579,
     "ast_hash": "ae4540190f998df8d9fb4b0d1a2612fe",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/MobileTests.java": {
-    "mtime": 1782538949.464479,
+    "mtime": 1782540714.756579,
     "ast_hash": "6739645c3929d9dceb4adb19a57133b8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/NaturalActionsTests.java": {
-    "mtime": 1782538949.465478,
+    "mtime": 1782540714.7575796,
     "ast_hash": "2f7204140a4fd39be6c6e336527e4180",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/PathsTests.java": {
-    "mtime": 1782538949.465478,
+    "mtime": 1782540714.7575796,
     "ast_hash": "9b6e4b923c8fafeb5766479e8ce4e9f7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/PatternTests.java": {
-    "mtime": 1782538949.4664788,
+    "mtime": 1782540714.7585812,
     "ast_hash": "27d780ad9cfb7a965f6b92d28d68de4c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/PerformanceTests.java": {
-    "mtime": 1782538949.4664788,
+    "mtime": 1782540714.7585812,
     "ast_hash": "9309eda06566e65a9f362f67f226dc91",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/PlatformTests.java": {
-    "mtime": 1782538949.4664788,
+    "mtime": 1782540714.7595792,
     "ast_hash": "3258b9a3348d0509056b88b650bf03b5",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/ReportingTests.java": {
-    "mtime": 1782538949.46748,
+    "mtime": 1782540714.7654674,
     "ast_hash": "1f1adefb9483330e293ad674101ad4a2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/TestNGTests.java": {
-    "mtime": 1782538949.4684808,
+    "mtime": 1782540714.7662005,
     "ast_hash": "99bf53de75d7fd1c0db036713c836a50",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/TimeoutsTests.java": {
-    "mtime": 1782538949.4684808,
+    "mtime": 1782540714.7673943,
     "ast_hash": "1bad239440e6f2e516dc99d4a0772476",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/TinkeyTests.java": {
-    "mtime": 1782538949.4699845,
+    "mtime": 1782540714.7683933,
     "ast_hash": "0970c28be5888cba1859beefc65378b3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/VisualsTests.java": {
-    "mtime": 1782538949.4729888,
+    "mtime": 1782540714.7683933,
     "ast_hash": "a0f83862f610862bb8efaf196f707d08",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/properties/WebTests.java": {
-    "mtime": 1782538949.4729888,
+    "mtime": 1782540714.7693925,
     "ast_hash": "9dc7531cd01c41eb8cfab262c6e521fd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/resettingCapabilitiesIssue/ElementMatchesSafariCompatibleTests.java": {
-    "mtime": 1782538949.4739907,
+    "mtime": 1782540714.7693925,
     "ast_hash": "394bbc20f5e93c06cc34ec7c01ff3236",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/resettingCapabilitiesIssue/ShadowDOMTests.java": {
-    "mtime": 1782538949.4739907,
+    "mtime": 1782540714.7709022,
     "ast_hash": "43a6596b52c49876b40b6058899198c6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/resettingCapabilitiesIssue/UploadFileTests.java": {
-    "mtime": 1782538949.4749906,
+    "mtime": 1782540714.7719142,
     "ast_hash": "cae1bde8163d22ef380fd6284cd6b0e0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/APIPropertiesUnitTest.java": {
-    "mtime": 1782538949.475989,
+    "mtime": 1782540714.772912,
     "ast_hash": "05bd219643f1dc3028c6a12e8e6f478f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/APITests.java": {
-    "mtime": 1782538949.475989,
+    "mtime": 1782540714.773912,
     "ast_hash": "2dc9f47b451a8e6b2044fbeabf5fd378",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AccessibilityActionsCoverageUnitTest.java": {
-    "mtime": 1782538949.4769912,
+    "mtime": 1782540714.7744155,
     "ast_hash": "299d8accaa92a18b359d20a9b499d18d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AlertActionsCoverageUnitTest.java": {
-    "mtime": 1782538949.4779897,
+    "mtime": 1782540714.7744155,
     "ast_hash": "a5bb393a1cfc1a2e8aa75ae92aff7d81",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AllAttachmentTypesTest.java": {
-    "mtime": 1782538949.4789896,
+    "mtime": 1782540714.775421,
     "ast_hash": "f79dff9fc7994d2065d35844cc915ad8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/Allure3ReportValidationTests.java": {
-    "mtime": 1782538949.4789896,
+    "mtime": 1782540714.7764263,
     "ast_hash": "da1af4c4422a31104c480df5d2b8651d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AllureManagerUnitTest.java": {
-    "mtime": 1782538949.4799895,
-    "ast_hash": "06483dcd28a8f6ea0b365c0d6c22e7e4",
+    "mtime": 1782540698.248496,
+    "ast_hash": "ee2cfc8fd615309bb030afd1567e47a8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AndroidApkBadgingReaderUnitTest.java": {
-    "mtime": 1782538949.4799895,
+    "mtime": 1782540714.7774303,
     "ast_hash": "5bc57b743241b49f0e5257363802a038",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java": {
-    "mtime": 1782538949.4809897,
+    "mtime": 1782540714.7784262,
     "ast_hash": "49d211907c0ca598f8d3aea229d5c1f3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AssertionStepsCucumberTestsCoverageUnitTest.java": {
-    "mtime": 1782538949.4809897,
+    "mtime": 1782540714.7784262,
     "ast_hash": "bd8b8e3e83c0652fbfd4c66dfa54f838",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/AttachmentReporterUnitTest.java": {
-    "mtime": 1782538949.4809897,
+    "mtime": 1782540714.7794254,
     "ast_hash": "1aa4d028192aced4bfa1e387d1c70663",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsCoverageUnitTest.java": {
-    "mtime": 1782538949.48299,
+    "mtime": 1782540714.7814355,
     "ast_hash": "d161c034134040f8f87c0e33d9a97391",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsHelperCoverageUnitTest.java": {
-    "mtime": 1782538949.48299,
+    "mtime": 1782540714.7824347,
     "ast_hash": "eee65cf685894e3a7520908f46d77937",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsTests.java": {
-    "mtime": 1782538949.4839895,
+    "mtime": 1782540714.7824347,
     "ast_hash": "66b7b6266723ff45765b60ac7c3074e3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserStackHelperUnitTest.java": {
-    "mtime": 1782538949.48499,
+    "mtime": 1782540714.7839434,
     "ast_hash": "7ae11ad14db90e20fe82c9c907507c7b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserStackPropertiesUnitTest.java": {
-    "mtime": 1782538949.4859898,
+    "mtime": 1782540714.785243,
     "ast_hash": "dfcbf24cab8e1c327962222c3978b95d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/BrowserStackSdkHelperCoverageUnitTest.java": {
-    "mtime": 1782538949.4859898,
+    "mtime": 1782540714.785243,
     "ast_hash": "a12447674e5f8ad7c872293f7e5d7906",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CSVFileManagerUnitTest.java": {
-    "mtime": 1782538949.4859898,
+    "mtime": 1782540714.786481,
     "ast_hash": "e05e9aa7e90379ffff4172edb00a2d6e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CheckpointAndReportingTest.java": {
-    "mtime": 1782538949.48699,
+    "mtime": 1782540714.7874813,
     "ast_hash": "35dd2ea229bf8692dfa60aa240d47c78",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ClipboardActionUnitTest.java": {
-    "mtime": 1782538949.48699,
+    "mtime": 1782540714.7884786,
     "ast_hash": "049ed3057c478bf631b973241fdb7e42",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CucumberFeatureListenerUnitTest.java": {
-    "mtime": 1782538949.487989,
+    "mtime": 1782540714.7894783,
     "ast_hash": "40b3bb11667dcc54e4c8eff1e5a9b52b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CucumberTestRunnerListenerUnitTest.java": {
-    "mtime": 1782538949.48899,
+    "mtime": 1782540714.7894783,
     "ast_hash": "af73dc5a35bc20fb91b9540c939aa848",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CucumberTestsHelperCoverageUnitTest.java": {
-    "mtime": 1782538949.48899,
+    "mtime": 1782540714.7904804,
     "ast_hash": "f5787b288386b7c7d678c839cae81b73",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/CustomSoftAssertTest.java": {
-    "mtime": 1782538949.4899907,
+    "mtime": 1782540714.7914815,
     "ast_hash": "79519b2595cb2fef40442f1a10bfd750",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/DriverFactoryCoverageUnitTest.java": {
-    "mtime": 1782538949.490992,
+    "mtime": 1782540714.7924767,
     "ast_hash": "4947b5e7a73724c6e6fed6d2e64ba6a6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/DriverFactoryHelperAdditionalUnitTest.java": {
-    "mtime": 1782538949.490992,
+    "mtime": 1782540714.7924767,
     "ast_hash": "ea73d0c88cfce2990fde0325c0c17816",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/DriverFactoryHelperUnitTest.java": {
-    "mtime": 1782538949.4919896,
+    "mtime": 1782540714.7939813,
     "ast_hash": "df5ed77d6a7a0c26406fe212157eaff2",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ElementActionsCoverageUnitTest.java": {
-    "mtime": 1782538949.4919896,
+    "mtime": 1782540714.7944937,
     "ast_hash": "c25acf7125038b78ded022107f6cebb4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ExcelFileManagerCoverageUnitTest.java": {
-    "mtime": 1782538949.4919896,
+    "mtime": 1782540714.7954998,
     "ast_hash": "749454f40c0f999c34073902eb552194",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/FailureReporterUnitTest.java": {
-    "mtime": 1782538949.4939947,
+    "mtime": 1782540714.8015924,
     "ast_hash": "75e0fd7c57c165bef078cdc8ce06fe65",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/FileActionsUnitTest.java": {
-    "mtime": 1782538949.4939947,
+    "mtime": 1782540714.8025897,
     "ast_hash": "1a119fe7b09aa44da193163a82d2e9e6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/FileHelperUnitTest.java": {
-    "mtime": 1782538949.4949903,
+    "mtime": 1782540714.8025897,
     "ast_hash": "ea6d731e57c3aac02a733f7d2a34d941",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/FileValidationsBuilderUnitTest.java": {
-    "mtime": 1782538949.4949903,
+    "mtime": 1782540714.8040972,
     "ast_hash": "9d9acc2120910e1276906a2bde8a1e5c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/FlagsSetPropertyCoverageUnitTest.java": {
-    "mtime": 1782538949.4959893,
+    "mtime": 1782540714.8046136,
     "ast_hash": "da97292715ec3224bdb79568449c0fc9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/HTMLHelperUnitTest.java": {
-    "mtime": 1782538949.49699,
+    "mtime": 1782540714.8055499,
     "ast_hash": "9c1bdc00767832a40fd7d9178ae369c9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/IoExcelFileManagerTests.java": {
-    "mtime": 1782538949.49799,
+    "mtime": 1782540714.806621,
     "ast_hash": "530438883080a086ea007d8375c7a0fa",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/JSONFileManagerUnitTest.java": {
-    "mtime": 1782538949.4989886,
+    "mtime": 1782540714.8076222,
     "ast_hash": "df106c976e18caf15348e77c4f5aeb33",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/JavaHelperUnitTest.java": {
-    "mtime": 1782538949.4989886,
+    "mtime": 1782540714.8086207,
     "ast_hash": "fdeef69d7094cb58b69c4765005ba6f4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/JunitListenerApiCoverageUnitTest.java": {
-    "mtime": 1782538949.4999905,
+    "mtime": 1782540714.8086207,
     "ast_hash": "eb8ea18add13bf5b439a526123934cfc",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LambdaTestHelperUnitTest.java": {
-    "mtime": 1782538949.5009918,
+    "mtime": 1782540714.8096235,
     "ast_hash": "3f11e51672c24653a84fe4fa69f7e797",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LambdaTestSetPropertyCoverageUnitTest.java": {
-    "mtime": 1782538949.5009918,
+    "mtime": 1782540714.8106244,
     "ast_hash": "47e318c7169fd292cc422fdfbb950ff7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LocalApiServer.java": {
-    "mtime": 1782538949.5019915,
+    "mtime": 1782540714.8116217,
     "ast_hash": "1994c60fb9cbca49689490cc09afaac7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LocatorBuilderExtendedUnitTest.java": {
-    "mtime": 1782538949.5019915,
+    "mtime": 1782540714.8126247,
     "ast_hash": "3ffca37941148c7f54ec285739904a5c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LocatorBuilderUnitTest.java": {
-    "mtime": 1782538949.5029907,
+    "mtime": 1782540714.8126247,
     "ast_hash": "70bc98553a43a07567efa654eec320d7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/LogRedirectorUnitTest.java": {
-    "mtime": 1782538949.5039895,
+    "mtime": 1782540714.8126247,
     "ast_hash": "25be02ab0943217c6d54155e0c912775",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/MemoryLeakFixTests.java": {
-    "mtime": 1782538949.5039895,
+    "mtime": 1782540714.814133,
     "ast_hash": "9371b0c88769d68a72bf5c38b4039579",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/NativeValidationsBuilderUnitTest.java": {
-    "mtime": 1782538949.5049903,
+    "mtime": 1782540714.8146558,
     "ast_hash": "5eedc36971944b95c5b59dde171347a8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/NavigationActionUnitTest.java": {
-    "mtime": 1782538949.5059938,
+    "mtime": 1782540714.8156686,
     "ast_hash": "29ce81485193c40a2ddd60f48f50a622",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/NumberValidationsBuilderUnitTest.java": {
-    "mtime": 1782538949.5059938,
+    "mtime": 1782540714.8166635,
     "ast_hash": "c1e5acce43534ba13e1186db85b2c084",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PdfFileManagerUnitTest.java": {
-    "mtime": 1782538949.5069907,
+    "mtime": 1782540714.8166635,
     "ast_hash": "03fffd928746a3fec64c66b559d65b72",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ProjectStructureManagerTest.java": {
-    "mtime": 1782538949.5069907,
+    "mtime": 1782540714.8176653,
     "ast_hash": "6d2a66b21a274d7829cb5d2f93f416d9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertiesHelperCoverageUnitTest.java": {
-    "mtime": 1782538949.5079896,
+    "mtime": 1782540714.8176653,
     "ast_hash": "81ae315c34773c68a536c305b8d42394",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertiesHelperInitializationUnitTest.java": {
-    "mtime": 1782538949.50899,
+    "mtime": 1782540714.8206666,
     "ast_hash": "ea9d6467f8ef25e941d62698c46bfdd8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertiesHelperMaximumPerformanceModeUnitTest.java": {
-    "mtime": 1782538949.50999,
+    "mtime": 1782540714.822667,
     "ast_hash": "5661da2130612dd49dc0c83732f5b25e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertiesUnitTest.java": {
-    "mtime": 1782538949.50999,
+    "mtime": 1782540714.822667,
     "ast_hash": "602487e1fabc0a78b778248bf0275372",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertyFileManagerUnitTest.java": {
-    "mtime": 1782538949.510991,
+    "mtime": 1782540714.824173,
     "ast_hash": "1f6b9ea7df5756b354ea8081215c0f65",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RecordManagerTest.java": {
-    "mtime": 1782538949.510991,
+    "mtime": 1782540714.8246956,
     "ast_hash": "70cd848c481fbb5c2d081ede904fc7e4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ReportManagerHelperAttachmentIoUnitTest.java": {
-    "mtime": 1782538949.5119898,
+    "mtime": 1782540714.825603,
     "ast_hash": "3559c3b9d7b73f3fc87daa4b19e7d031",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ReportManagerHelperUnitTests.java": {
-    "mtime": 1782538949.5129893,
+    "mtime": 1782540714.8267016,
     "ast_hash": "76ee387cb25dbcc34a94a172c61ff6a0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RestActionsFailureLoggingUnitTest.java": {
-    "mtime": 1782538949.5129893,
+    "mtime": 1782540714.8267016,
     "ast_hash": "94747c6ac6534584011a570704cb7b89",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RestActionsTests.java": {
-    "mtime": 1782538949.5139902,
+    "mtime": 1782540714.8277023,
     "ast_hash": "4a57b2261d8a6f4306b6a189df5c6b93",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RestActionsUtilsUnitTest.java": {
-    "mtime": 1782538949.5149906,
+    "mtime": 1782540714.828703,
     "ast_hash": "de45f58c799fde431cef74d0e8653c15",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/RestValidationsBuilderUnitTest.java": {
-    "mtime": 1782538949.5149906,
+    "mtime": 1782540714.828703,
     "ast_hash": "1c0603f27b12bb4895a9aea5b5e1efa8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ShaftRestAssuredFilterUnitTest.java": {
-    "mtime": 1782538949.5159895,
+    "mtime": 1782540714.8328462,
     "ast_hash": "42bd55f4074df77459dec78903d4f560",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/SkippedTestReportingTest.java": {
-    "mtime": 1782538949.5169895,
+    "mtime": 1782540714.8343332,
     "ast_hash": "ce8578c3bec220a0e71049bee7331d9a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/SmartLocatorsCoverageUnitTest.java": {
-    "mtime": 1782538949.5169895,
+    "mtime": 1782540714.835343,
     "ast_hash": "beb21c33b9ba95b2fb2d42033aef2235",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/StringHelperUnitTest.java": {
-    "mtime": 1782538949.5179913,
+    "mtime": 1782540714.8363504,
     "ast_hash": "666317424773b8170baaa4f3e65e5630",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TelemetryDeduplicationUnitTest.java": {
-    "mtime": 1782538949.5179913,
+    "mtime": 1782540714.8363504,
     "ast_hash": "f63a7c2ce548fa3456264cc95af3a62f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java": {
-    "mtime": 1782538949.5189905,
+    "mtime": 1782540714.8373492,
     "ast_hash": "0ce15abe7ff432e30ff79ff6e2e6dfff",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TestClass.java": {
-    "mtime": 1782538949.5199904,
+    "mtime": 1782540714.838348,
     "ast_hash": "75d5dabdf74b6a0a0ac46395a44852f1",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TestDataUnitTest.java": {
-    "mtime": 1782538949.5199904,
+    "mtime": 1782540714.8393476,
     "ast_hash": "db41e63ea98f715a677d882ac1d4174c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TestNGListenerCoverageUnitTest.java": {
-    "mtime": 1782538949.5209897,
+    "mtime": 1782540714.8393476,
     "ast_hash": "9e9510f0450a708edccb84a8ddd183cc",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TestNGListenerHelperCoverageUnitTest.java": {
-    "mtime": 1782538949.521991,
+    "mtime": 1782540714.8408558,
     "ast_hash": "9a5af4a09a68b32816599214788557b7",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TextDirectionValidationsBuilderUnitTest.java": {
-    "mtime": 1782538949.521991,
+    "mtime": 1782540714.8418636,
     "ast_hash": "60a881ad378ec7cfdfcfa5c81462d2c8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ThreadLocalPropertiesTest.java": {
-    "mtime": 1782538949.5229976,
+    "mtime": 1782540714.842863,
     "ast_hash": "3b8c3ba881bf96883437c5ff46e2a879",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/TopUncoveredClassesCoverageUnitTest.java": {
-    "mtime": 1782538949.5229976,
+    "mtime": 1782540714.842863,
     "ast_hash": "00f21d46e9c9345cfb0602c30e74896a",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ValidationAndProgressBarTests.java": {
-    "mtime": 1782538949.5239978,
+    "mtime": 1782540714.844372,
     "ast_hash": "2cd823215ca19d7111f2d7092e71bda1",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ValidationEnumsUnitTest.java": {
-    "mtime": 1782538949.5239978,
+    "mtime": 1782540714.8453815,
     "ast_hash": "caccd040fd417216fa761e864fcf4179",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ValidationHelperUnitTest.java": {
-    "mtime": 1782538949.5249977,
+    "mtime": 1782540714.8453815,
     "ast_hash": "5877871d3318bd2685cb6c67d7fa0836",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ValidationsBuilderUnitTest.java": {
-    "mtime": 1782538949.5249977,
+    "mtime": 1782540714.8463805,
     "ast_hash": "cfe79a40a49a8ecba70f2bca1418d697",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ValidationsExecutorCoverageUnitTest.java": {
-    "mtime": 1782538949.5259964,
+    "mtime": 1782540714.8463805,
     "ast_hash": "b4e87dd6decede2ec6a874bf552646b0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/WebDriverListenerCoverageUnitTest.java": {
-    "mtime": 1782538949.5269978,
+    "mtime": 1782540714.8473797,
     "ast_hash": "99675a25fb42770a1f0fe32b6056ec93",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/XrayIntegrationHelperCoverageUnitTest.java": {
-    "mtime": 1782538949.5269978,
+    "mtime": 1782540714.8473797,
     "ast_hash": "1a3f82e3bba50c09c7b5f46d0e17c64b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/YAMLFileManagerUnitTest.java": {
-    "mtime": 1782538949.5279968,
+    "mtime": 1782540714.8483825,
     "ast_hash": "657dabafe357030b543ad8b2cc7d37b4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/validationsWizard/BrowserValidationsTests.java": {
-    "mtime": 1782538949.5279968,
+    "mtime": 1782540714.8493803,
     "ast_hash": "fae6d2b4edd4c21b783a63e0acfd94bc",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/validationsWizard/ElementValidationsTests.java": {
-    "mtime": 1782538949.5289962,
+    "mtime": 1782540714.8493803,
     "ast_hash": "74ef4dc7c24e14da3c0a2e956ecaf8d4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/validationsWizard/NegativeValidationsTests.java": {
-    "mtime": 1782538949.5289962,
+    "mtime": 1782540714.8493803,
     "ast_hash": "80deb29d4d240573803b2e4e4e6e1edb",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/validationsWizard/VisualValidationTests.java": {
-    "mtime": 1782538949.5299966,
+    "mtime": 1782540714.850886,
     "ast_hash": "1eec1a809ea772c21ef54c6c277a0a9b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/JsonFileTest.json": {
-    "mtime": 1782538949.5359967,
+    "mtime": 1782540714.8580554,
     "ast_hash": "34d4c2e8470475605eeb576357fa1a24",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/JsonFileTest2.json": {
-    "mtime": 1782538949.5359967,
+    "mtime": 1782540714.8580554,
     "ast_hash": "0d4aba4457124b501a49b132fc29e7c8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/api/local-api/post-1.json": {
-    "mtime": 1782538949.5385077,
+    "mtime": 1782540714.860562,
     "ast_hash": "e7f6064672a51be242e522606fe7a874",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/api/local-api/posts.json": {
-    "mtime": 1782538949.5395079,
+    "mtime": 1782540714.8615696,
     "ast_hash": "9b635707c3b1a2033d585b69a6bab819",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/api/local-api/todos.json": {
-    "mtime": 1782538949.5405068,
+    "mtime": 1782540714.8625703,
     "ast_hash": "095e11feade03bc6b7e53dee2486f681",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/api/local-api/users.json": {
-    "mtime": 1782538949.5405068,
+    "mtime": 1782540714.8625703,
     "ast_hash": "8b738dc1a52055df6ff5444eb37a1b8f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/api/local-api/zip-90210.json": {
-    "mtime": 1782538949.5405068,
+    "mtime": 1782540714.8640745,
     "ast_hash": "6ca2311ae54ce67c7fbd17f118b58cad",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/jsonFileManagerTestData.json": {
-    "mtime": 1782538950.12124,
+    "mtime": 1782540715.5539932,
     "ast_hash": "94537dc7a44a551939fe07da874a6ce9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/jsonToJavaObjectTest.json": {
-    "mtime": 1782538950.122242,
+    "mtime": 1782540715.5545802,
     "ast_hash": "fe787bfecd55bde95846520922954e20",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/post1Response.json": {
-    "mtime": 1782538950.1232457,
+    "mtime": 1782540715.5571659,
     "ast_hash": "e7f6064672a51be242e522606fe7a874",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/post1ResponseSchema.json": {
-    "mtime": 1782538950.1232457,
+    "mtime": 1782540715.558164,
     "ast_hash": "16bf47afb2fa16d9a72bee4aa5090fef",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/restActionsCoverage/containsObject.json": {
-    "mtime": 1782538950.1242406,
+    "mtime": 1782540715.5591633,
     "ast_hash": "caf79d4a9031acee3921b15dcfacd235",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/restActionsCoverage/expectedObject.json": {
-    "mtime": 1782538950.1242406,
+    "mtime": 1782540715.560668,
     "ast_hash": "fbf3b3e03cf5d05123488de14e150acd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/restActionsCoverage/mismatchObject.json": {
-    "mtime": 1782538950.1252408,
+    "mtime": 1782540715.5616763,
     "ast_hash": "5a250de786cc5579da66cbcdee8f2818",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/restActionsCoverage/orderedArray.json": {
-    "mtime": 1782538950.1252408,
+    "mtime": 1782540715.5626738,
     "ast_hash": "0e406c996279efff769b1105dd51448e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/schema.json": {
-    "mtime": 1782538950.1272442,
+    "mtime": 1782540715.564687,
     "ast_hash": "99a7063f24f77c3fb2c7aea31eec411c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/simpleJSON.json": {
-    "mtime": 1782538950.13124,
+    "mtime": 1782540715.5696945,
     "ast_hash": "d896f3512bf493280abf8061c7df1d75",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/specialCharacters.json": {
-    "mtime": 1782538950.1322393,
+    "mtime": 1782540715.570694,
     "ast_hash": "334064f08b91de55ef30335710dbd8f8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/test_assertResponseEqualsIgnoringOrder.json": {
-    "mtime": 1782538950.137241,
+    "mtime": 1782540715.5797884,
     "ast_hash": "a679a33772d98b89e77510ad9938a84d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/test_post_withBody_fromFile.json": {
-    "mtime": 1782538950.1382408,
+    "mtime": 1782540715.5797884,
     "ast_hash": "af539d78603bb042feb8be65c20748e8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/unitTestData.json": {
-    "mtime": 1782538950.1382408,
+    "mtime": 1782540715.5817873,
     "ast_hash": "0e90c1c1a227d7d7c2d2dce740714d82",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/HealingConfiguration.java": {
-    "mtime": 1782538950.1442442,
+    "mtime": 1782540715.5976171,
     "ast_hash": "b5f311bae11ad11dd0deed6b9921fade",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/ShaftHeal.java": {
-    "mtime": 1782538950.145244,
+    "mtime": 1782540715.5976171,
     "ast_hash": "638f827ad267fed1841301e034516d29",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/AiCandidateReranker.java": {
-    "mtime": 1782538950.1462429,
+    "mtime": 1782540715.598616,
     "ast_hash": "37bae89f609e94e33b6291765bec4746",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/CandidateExtractor.java": {
-    "mtime": 1782538950.1472409,
+    "mtime": 1782540715.5996141,
     "ast_hash": "1b8b44bdcf6e32e31917a1e7e43e9735",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/DeterministicScorer.java": {
-    "mtime": 1782538950.1472409,
+    "mtime": 1782540715.600622,
     "ast_hash": "4bf42ea11e26e7869a261270733d628d",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/FingerprintExtractor.java": {
-    "mtime": 1782538950.148243,
+    "mtime": 1782540715.600622,
     "ast_hash": "7f104b32afa9d009c7714e55f453c167",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HealingDecisionEngine.java": {
-    "mtime": 1782538950.1492429,
+    "mtime": 1782540715.601622,
     "ast_hash": "4209aed55089ab983f839222d8cf64db",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HealingHistoryStore.java": {
-    "mtime": 1782538950.1492429,
+    "mtime": 1782540715.6026206,
     "ast_hash": "75b6488324dfad90e662f9f08c9d7fb4",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HealingReportWriter.java": {
-    "mtime": 1782538950.1502402,
+    "mtime": 1782540715.6026206,
     "ast_hash": "a6807824d69a21cbfde367786dda6459",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HealingSupport.java": {
-    "mtime": 1782538950.1502402,
+    "mtime": 1782540715.6026206,
     "ast_hash": "6a5e58df19b9bf605b8d0e529e3b5a9f",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HistoryDocument.java": {
-    "mtime": 1782538950.1512406,
+    "mtime": 1782540715.6041276,
     "ast_hash": "e02bfa5e0416eaa97327d7cc30edaaaa",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/HistoryRecord.java": {
-    "mtime": 1782538950.152244,
+    "mtime": 1782540715.6046486,
     "ast_hash": "affb5533f80ddcf6955cb487de88c5bc",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/PrivacySanitizer.java": {
-    "mtime": 1782538950.1532407,
+    "mtime": 1782540715.6046486,
     "ast_hash": "c615c6f4a1781c7a5a2056074b581bb2",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/RankedCandidate.java": {
-    "mtime": 1782538950.1542435,
+    "mtime": 1782540715.6056592,
     "ast_hash": "323b41fab8a95e2adce58147b8a7d197",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/ShaftHealingProvider.java": {
-    "mtime": 1782538950.1542435,
+    "mtime": 1782540715.6056592,
     "ast_hash": "bd1cbb989de7e55d8ee1b04746442788",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/internal/VisualEvidenceService.java": {
-    "mtime": 1782538950.1552408,
+    "mtime": 1782540715.606657,
     "ast_hash": "743e64057ed3e7ab3111d0ecb9e093c8",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingCandidate.java": {
-    "mtime": 1782538950.156247,
+    "mtime": 1782540715.607656,
     "ast_hash": "1617a29056414a87a0f01eea9f3f1e5d",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingContext.java": {
-    "mtime": 1782538950.157246,
+    "mtime": 1782540715.607656,
     "ast_hash": "3c02c33790e64b5a77b7c6218a0162cf",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingDecision.java": {
-    "mtime": 1782538950.157246,
+    "mtime": 1782540715.6086555,
     "ast_hash": "e3cff7de69ac3081e54b05070a9ad923",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingPlatform.java": {
-    "mtime": 1782538950.158247,
+    "mtime": 1782540715.6086555,
     "ast_hash": "d4cc50f5563d27a3d8cadabad3f8c086",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingReport.java": {
-    "mtime": 1782538950.158247,
+    "mtime": 1782540715.6096559,
     "ast_hash": "3d0627a4f1785e21e5403b3685773ca5",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/HealingScore.java": {
-    "mtime": 1782538950.159248,
+    "mtime": 1782540715.6096559,
     "ast_hash": "99e432927182919d5815b3d8d101b6de",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/java/com/shaft/heal/model/LocatorFingerprint.java": {
-    "mtime": 1782538950.160249,
+    "mtime": 1782540715.6096559,
     "ast_hash": "b7f303ee7028dce02f372fe1887fdf27",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/resources/schema/shaft-heal-history-1.0.schema.json": {
-    "mtime": 1782538950.1632485,
+    "mtime": 1782540715.6126602,
     "ast_hash": "6bd4d6c6c18d1bc0c600792f43232342",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/resources/schema/shaft-heal-history-2.0.schema.json": {
-    "mtime": 1782538950.1642458,
+    "mtime": 1782540715.6126602,
     "ast_hash": "6d71c99cadca42d412c11b50c7131430",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/resources/schema/shaft-heal-report-1.0.schema.json": {
-    "mtime": 1782538950.1642458,
+    "mtime": 1782540715.6126602,
     "ast_hash": "f8f5c202b1e0baca184836e2dd42118b",
     "semantic_hash": ""
   },
   "shaft-heal/src/main/resources/schema/shaft-heal-report-2.0.schema.json": {
-    "mtime": 1782538950.165246,
+    "mtime": 1782540715.6141658,
     "ast_hash": "88e2d8a2767744c1b32faa700466d741",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/AiCandidateRerankerTest.java": {
-    "mtime": 1782538950.1682477,
+    "mtime": 1782540715.6156988,
     "ast_hash": "034bb4a07e1e4c4d8c1ed5d8a31547a2",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/DeterministicScorerTest.java": {
-    "mtime": 1782538950.169249,
+    "mtime": 1782540715.620696,
     "ast_hash": "5d36a445e2cae9634e483d80dda345a7",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/HealingHistoryStoreTest.java": {
-    "mtime": 1782538950.170247,
+    "mtime": 1782540715.6217027,
     "ast_hash": "055d679be0c31247da14c2d2e8305954",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/ShaftHealingProviderTest.java": {
-    "mtime": 1782538950.170247,
+    "mtime": 1782540715.6227052,
     "ast_hash": "62b7fa589374d302bc095a85630668cb",
     "semantic_hash": ""
   },
   "shaft-heal/src/test/java/com/shaft/heal/internal/WebDomHealingAcceptanceTest.java": {
-    "mtime": 1782538950.1712685,
+    "mtime": 1782540715.6237068,
     "ast_hash": "54705c408e9415e6e59248f9dc88e76a",
     "semantic_hash": ""
   },
   "shaft-mcp/mvnw": {
-    "mtime": 1782538950.180269,
+    "mtime": 1782540715.6337414,
     "ast_hash": "2fe09837c0b4dfabab4c4b206bcd0850",
     "semantic_hash": ""
   },
   "shaft-mcp/server.json": {
-    "mtime": 1782538950.1822677,
+    "mtime": 1782540715.6348746,
     "ast_hash": "10eafe30f8d30db0f7f5e85b2793e18a",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/BrowserService.java": {
-    "mtime": 1782538950.1842678,
+    "mtime": 1782540715.6376314,
     "ast_hash": "825d8b126501b736bb968ed530b127ab",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/BrowserType.java": {
-    "mtime": 1782538950.1852682,
+    "mtime": 1782540715.6376314,
     "ast_hash": "d92c802c46cf7055edd908c22dd983c6",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java": {
-    "mtime": 1782538950.186267,
+    "mtime": 1782540715.6386316,
     "ast_hash": "d64d47ce7e08b3e0e1f0675a072da341",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/DoctorService.java": {
-    "mtime": 1782538950.186267,
+    "mtime": 1782540715.6396308,
     "ast_hash": "fdac0a63aa8e73797a7d58596eb727c1",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/ElementService.java": {
-    "mtime": 1782538950.187268,
+    "mtime": 1782540715.6396308,
     "ast_hash": "15840a8b150fb2a4988a9041336bf528",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/EngineService.java": {
-    "mtime": 1782538950.188268,
+    "mtime": 1782540715.640633,
     "ast_hash": "f75ea21cc4747ba8b46f0983950fc5e6",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpActionRecord.java": {
-    "mtime": 1782538950.190269,
+    "mtime": 1782540715.6431403,
     "ast_hash": "88f2540004bf2e85e19d1883fa8fd268",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpAnalysisReport.java": {
-    "mtime": 1782538950.190269,
+    "mtime": 1782540715.6431403,
     "ast_hash": "655dc48d9861063302c3874e08fad7bb",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCaptureCodeBlockService.java": {
-    "mtime": 1782538950.1932683,
+    "mtime": 1782540715.6466973,
     "ast_hash": "ba9b31e164fa47d38f4a5bf16f824aee",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCaptureReplayResult.java": {
-    "mtime": 1782538950.1932683,
+    "mtime": 1782540715.6466973,
     "ast_hash": "c1566317b1a57ccbf142a1a4e6dc3f69",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCodeBlock.java": {
-    "mtime": 1782538950.1942687,
+    "mtime": 1782540715.6476977,
     "ast_hash": "76ebce9f3db111251b04cf7f5d6a7548",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpDoctorRemediationService.java": {
-    "mtime": 1782538950.1962688,
+    "mtime": 1782540715.653761,
     "ast_hash": "bf301fb33655d33748d844a9106ab67e",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileAccessibilityTree.java": {
-    "mtime": 1782538950.1992674,
+    "mtime": 1782540715.6615243,
     "ast_hash": "f3b7b5c23ef3cb6ff05525b718994ff3",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileActionResult.java": {
-    "mtime": 1782538950.1992674,
+    "mtime": 1782540715.6625254,
     "ast_hash": "29d070e4029d6709b7924ba36735510a",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileContextSnapshot.java": {
-    "mtime": 1782538950.2002676,
+    "mtime": 1782540715.6645522,
     "ast_hash": "2f654d69dc90ef0def1b8902d14e3bba",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecordedAction.java": {
-    "mtime": 1782538950.203268,
+    "mtime": 1782540715.6685646,
     "ast_hash": "ecfc0758677616c607ba07313a52b729",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecording.java": {
-    "mtime": 1782538950.203268,
+    "mtime": 1782540715.6685646,
     "ast_hash": "695772cf2e07fcb64d1f38ce531219ba",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecordingService.java": {
-    "mtime": 1782538950.2042677,
+    "mtime": 1782540715.6695592,
     "ast_hash": "0399934cf57d42b9db9e71f92d59d731",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecordingStatus.java": {
-    "mtime": 1782538950.2042677,
+    "mtime": 1782540715.6695592,
     "ast_hash": "aa275295374a1818f6c109d6ea81b57d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileReplayResult.java": {
-    "mtime": 1782538950.2052708,
+    "mtime": 1782540715.6705658,
     "ast_hash": "7865349c5c645027ec9b2ad4140187c1",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileSessionResult.java": {
-    "mtime": 1782538950.2062697,
+    "mtime": 1782540715.6715672,
     "ast_hash": "e79607edd99c46b3382c1ddc7461c931",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpNaturalActionResult.java": {
-    "mtime": 1782538950.2082696,
+    "mtime": 1782540715.6740735,
     "ast_hash": "8d9587e9bd285ff5d3066b2afea60733",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpPageDomSnapshot.java": {
-    "mtime": 1782538950.2082696,
+    "mtime": 1782540715.6745918,
     "ast_hash": "da511c88341bda167180baeac16db366",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpProviderFallback.java": {
-    "mtime": 1782538950.2092676,
+    "mtime": 1782540715.6766002,
     "ast_hash": "f19ecd97597af4b6374659222d736a68",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpRuntimePaths.java": {
-    "mtime": 1782538950.2102697,
+    "mtime": 1782540715.6776032,
     "ast_hash": "7508e81382cca0830263f0477c96731e",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpScreenshotResult.java": {
-    "mtime": 1782538950.211271,
+    "mtime": 1782540715.6796,
     "ast_hash": "1ed7179791590810783cc71682129cde",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpWorkspacePolicy.java": {
-    "mtime": 1782538950.212269,
+    "mtime": 1782540715.6816008,
     "ast_hash": "2ea9e2dad8bdfc40515c48cc4f7e644d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/MobileService.java": {
-    "mtime": 1782538950.2132678,
+    "mtime": 1782540715.6816008,
     "ast_hash": "9b9288e7adcff17860464a92541e9293",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/NaturalActionService.java": {
-    "mtime": 1782538950.2132678,
+    "mtime": 1782540715.6826007,
     "ast_hash": "f727c820fb4def0a03ba5eeb1894ca0b",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/ShaftMcpApplication.java": {
-    "mtime": 1782538950.2152672,
+    "mtime": 1782540715.684106,
     "ast_hash": "e646390e101487c7a2bc0eec61ef6ffd",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/locatorStrategy.java": {
-    "mtime": 1782538950.2182682,
+    "mtime": 1782540715.6916723,
     "ast_hash": "93d35de3c8d385e5eb24574d006934dd",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java": {
-    "mtime": 1782538950.2232683,
+    "mtime": 1782540715.698257,
     "ast_hash": "d5b9d021533c0d88d36cb4361cb5c53a",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/DoctorServiceTest.java": {
-    "mtime": 1782538950.2252672,
+    "mtime": 1782540715.698257,
     "ast_hash": "ab0aa38061072f9696c211f5c370e9a4",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/EngineServiceRuntimePathTest.java": {
-    "mtime": 1782538950.2262669,
+    "mtime": 1782540715.6992533,
     "ast_hash": "45a98645e7e2f4203be7278baadb2f66",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/EngineServiceTest.java": {
-    "mtime": 1782538950.2272718,
+    "mtime": 1782540715.6992533,
     "ast_hash": "90a0eb091a6ac3d9480fc327f6712241",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpRuntimePathsTest.java": {
-    "mtime": 1782538950.2342706,
+    "mtime": 1782540715.7057886,
     "ast_hash": "3df7775db4987c2453ab16758e62a7ce",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/MobileRecordingServiceTest.java": {
-    "mtime": 1782538950.2362697,
+    "mtime": 1782540715.706788,
     "ast_hash": "4ca682157c293f5e2a2d5ba5d62382ec",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java": {
-    "mtime": 1782538950.2392676,
+    "mtime": 1782540715.70879,
     "ast_hash": "3117b6aa14fd9be0d75abd123a8a7cfa",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/mcp-tool-manifest.json": {
-    "mtime": 1782538950.2462685,
+    "mtime": 1782540715.7143,
     "ast_hash": "52c163296ad5edb95c0422735cf56614",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/shaft-pilot/doctor/repair-input.json": {
-    "mtime": 1782538950.2482681,
+    "mtime": 1782540715.7148037,
     "ast_hash": "457a81a9ab8bbcd47b4c46fefb9c6ad6",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/claude-desktop.json": {
-    "mtime": 1782538950.2492683,
+    "mtime": 1782540715.7158096,
     "ast_hash": "544157f8499e7c19c3b6495d7a2de685",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/doctor-analyze-invocations.json": {
-    "mtime": 1782538950.2502677,
+    "mtime": 1782540715.7178175,
     "ast_hash": "b02f7110c14eea4b8a149b5649cb8c1d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/gemini-settings.json": {
-    "mtime": 1782538950.2512681,
+    "mtime": 1782540715.7178175,
     "ast_hash": "544157f8499e7c19c3b6495d7a2de685",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp/vscode-mcp.json": {
-    "mtime": 1782538950.2512681,
+    "mtime": 1782540715.721168,
     "ast_hash": "069569075ea6158826d8a47b9204fa8b",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiBudget.java": {
-    "mtime": 1782538950.258273,
+    "mtime": 1782540715.7338276,
     "ast_hash": "0f62ae7eb77e7a79164518be64846a07",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiCapabilities.java": {
-    "mtime": 1782538950.2592745,
+    "mtime": 1782540715.734333,
     "ast_hash": "4b0644dd013cb6d45500cd6aa33e2be9",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiExecutionService.java": {
-    "mtime": 1782538950.2602782,
+    "mtime": 1782540715.7353406,
     "ast_hash": "a0595a80fb9dc84f4159fbd5e96ecb2a",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiImage.java": {
-    "mtime": 1782538950.2612746,
+    "mtime": 1782540715.7353406,
     "ast_hash": "25716916a48e61fbe6d9d4d1dc1fccaa",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiProvider.java": {
-    "mtime": 1782538950.2612746,
+    "mtime": 1782540715.7363503,
     "ast_hash": "825a0e7f2a2271f176163b67c1155d19",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiProviderAvailability.java": {
-    "mtime": 1782538950.2622764,
+    "mtime": 1782540715.7363503,
     "ast_hash": "f1cd040ecae8e52ad080c5619221e040",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiProviderRegistry.java": {
-    "mtime": 1782538950.2622764,
+    "mtime": 1782540715.7373474,
     "ast_hash": "462385cec9e86f110b0f5e975368df2d",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiRequest.java": {
-    "mtime": 1782538950.2632754,
+    "mtime": 1782540715.73835,
     "ast_hash": "72fcc9f3c38e1ed3d98d57815f995adb",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiResponse.java": {
-    "mtime": 1782538950.2632754,
+    "mtime": 1782540715.73835,
     "ast_hash": "d62787524d101da0a83d24df33272971",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiResponseStatus.java": {
-    "mtime": 1782538950.264276,
+    "mtime": 1782540715.7393475,
     "ast_hash": "18ec9401e739a84a451c8125c11152c5",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiUsage.java": {
-    "mtime": 1782538950.264276,
+    "mtime": 1782540715.7393475,
     "ast_hash": "97a43fdb6c0b590d6c7be89d9fc2d35e",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/ApprovalPolicy.java": {
-    "mtime": 1782538950.2652757,
+    "mtime": 1782540715.740855,
     "ast_hash": "f08f93f0d55ddbbad18efee9cced917b",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/DisabledAiProvider.java": {
-    "mtime": 1782538950.2662752,
+    "mtime": 1782540715.740855,
     "ast_hash": "522658fda00a6fa05e2132bfc58d9c1d",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/EvidenceCategory.java": {
-    "mtime": 1782538950.2662752,
+    "mtime": 1782540715.7418666,
     "ast_hash": "737d4c99daddaa581171170ad47006c7",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/EvidenceReference.java": {
-    "mtime": 1782538950.2662752,
+    "mtime": 1782540715.7418666,
     "ast_hash": "cd5fae7467f25e060c2a531eeb44f789",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/ai/ProcessingLocation.java": {
-    "mtime": 1782538950.2672749,
+    "mtime": 1782540715.7418666,
     "ast_hash": "7106587b9fd1d5573d0c2ba6355e6efa",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/audit/AiAuditEvent.java": {
-    "mtime": 1782538950.2682745,
+    "mtime": 1782540715.7438996,
     "ast_hash": "bd2ad33294235bf573acfac7e93da4b3",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/audit/AiAuditSink.java": {
-    "mtime": 1782538950.2682745,
+    "mtime": 1782540715.7444117,
     "ast_hash": "460112c404cbd8eb47074b1ce2f714fa",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/audit/ShaftAiAuditSink.java": {
-    "mtime": 1782538950.2692742,
+    "mtime": 1782540715.745072,
     "ast_hash": "cbab846c3ab872246cbe1e0a861a062e",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/config/PilotConfiguration.java": {
-    "mtime": 1782538950.272478,
+    "mtime": 1782540715.7464192,
     "ast_hash": "43594a66237b108d080c946819eb7a57",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/config/ProviderConfiguration.java": {
-    "mtime": 1782538950.272478,
+    "mtime": 1782540715.747419,
     "ast_hash": "c0d63dcf550dbd563bd77c89c6fcf013",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/json/JsonSchemaValidator.java": {
-    "mtime": 1782538950.273479,
+    "mtime": 1782540715.747419,
     "ast_hash": "d1136d836e02f9f6022a06cb42acb949",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/natural/PilotNaturalActionPlanner.java": {
-    "mtime": 1782538950.274482,
+    "mtime": 1782540715.7484188,
     "ast_hash": "fac8097a727ba867caa8d6fe1e3ce385",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/security/RedactionPolicy.java": {
-    "mtime": 1782538950.2754798,
+    "mtime": 1782540715.7494202,
     "ast_hash": "b2018496d7f034d57439ad18315fddd8",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/security/RedactionResult.java": {
-    "mtime": 1782538950.2764783,
+    "mtime": 1782540715.7494202,
     "ast_hash": "02d5ee92866f5c7a61fdc20af0d1a282",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/main/java/com/shaft/pilot/security/Redactor.java": {
-    "mtime": 1782538950.2774818,
+    "mtime": 1782540715.750419,
     "ast_hash": "ff7d2c45be4f35fb31c789cfb797509e",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiExecutionServiceTest.java": {
-    "mtime": 1782538950.282481,
+    "mtime": 1782540715.760573,
     "ast_hash": "18f32509d9954005e10259839e4c6a26",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiProviderRegistryTest.java": {
-    "mtime": 1782538950.282481,
+    "mtime": 1782540715.7615871,
     "ast_hash": "d44cb3d9a96f72e8d169b40215ea9e30",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/ai/PilotTestConfiguration.java": {
-    "mtime": 1782538950.2834804,
+    "mtime": 1782540715.762586,
     "ast_hash": "b8434bf125093e961295191538deefdd",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/security/RedactorTest.java": {
-    "mtime": 1782538950.2864807,
+    "mtime": 1782540715.7666247,
     "ast_hash": "6b5d2f07eeca23613af246198507f334",
     "semantic_hash": ""
   },
   "shaft-upgrader/upgrade_to_modular_shaft.py": {
-    "mtime": 1782538950.2884789,
+    "mtime": 1782540715.767626,
     "ast_hash": "d6645aac8e4ec7162ed2a8a81f9d4d5b",
     "semantic_hash": ""
   },
   "shaft-video/src/main/java/com/shaft/gui/internal/video/AutomationRemarksDesktopVideoRecordingProvider.java": {
-    "mtime": 1782538950.2934797,
+    "mtime": 1782540715.772634,
     "ast_hash": "b92a1245bb8e27b8865cd539c0303677",
     "semantic_hash": ""
   },
   "shaft-video/src/test/java/com/shaft/gui/internal/video/DesktopVideoRecordingProviderRegistrationTest.java": {
-    "mtime": 1782538950.2984788,
+    "mtime": 1782540715.777676,
     "ast_hash": "b86fe9a695cb45dd47af814176c0d207",
     "semantic_hash": ""
   },
   "shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvHealingVisualProvider.java": {
-    "mtime": 1782538950.304484,
+    "mtime": 1782540715.781689,
     "ast_hash": "665a72915a4214f1e86d3f8a315873b9",
     "semantic_hash": ""
   },
   "shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java": {
-    "mtime": 1782538950.304484,
+    "mtime": 1782540715.7826848,
     "ast_hash": "f34d4ea0f2f879ddb05d88e8fa163257",
     "semantic_hash": ""
   },
   "shaft-visual/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsCoverageUnitTest.java": {
-    "mtime": 1782538950.3114808,
+    "mtime": 1782540715.7947576,
     "ast_hash": "a010a6f22a177d8030bad70f35d74bab",
     "semantic_hash": ""
   },
   "shaft-visual/src/test/java/com/shaft/gui/internal/image/OpenCvHealingVisualProviderTest.java": {
-    "mtime": 1782538950.3124816,
+    "mtime": 1782540715.7947576,
     "ast_hash": "324be73186da5aa43b06e00099a55061",
     "semantic_hash": ""
   },
   "shaft-visual/src/test/java/testPackage/unitTests/ImageProcessingActionsUnitTest.java": {
-    "mtime": 1782538950.3134835,
+    "mtime": 1782540715.796768,
     "ast_hash": "c2a218aa630dedbe91eae5c572944fd7",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/forbidden-coordinates.json": {
-    "mtime": 1782538950.3174808,
+    "mtime": 1782540715.7997663,
     "ast_hash": "05978f92526026f1e72d0cc9333dcd14",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/api.json": {
-    "mtime": 1782538950.318482,
+    "mtime": 1782540715.8007753,
     "ast_hash": "33464132b1941069384296fb1a5d0b8c",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/appium-mobile.json": {
-    "mtime": 1782538950.3194823,
+    "mtime": 1782540715.8017735,
     "ast_hash": "7ae7e1b33592d1ef1428d548f8fac808",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts-bom.json": {
-    "mtime": 1782538950.3214831,
+    "mtime": 1782540715.802773,
     "ast_hash": "9fbfe22e65e8cfa4e1ffb7b9e6517494",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts-browserstack-sdk.json": {
-    "mtime": 1782538950.322482,
+    "mtime": 1782540715.8037724,
     "ast_hash": "5af6cde115806a688731572d1ceaa893",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts-combined-modules.json": {
-    "mtime": 1782538950.3234825,
+    "mtime": 1782540715.8037724,
     "ast_hash": "278a1788754fc7bba0fa505cc2baed79",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts-desktop-video.json": {
-    "mtime": 1782538950.3244822,
+    "mtime": 1782540715.805073,
     "ast_hash": "1543ef994a82a667c3d95688bd778587",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts-opencv-visual.json": {
-    "mtime": 1782538950.3254795,
+    "mtime": 1782540715.806082,
     "ast_hash": "719a4464d0a58ecde6dba8f9f5233a8d",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/artifacts.json": {
-    "mtime": 1782538950.3264794,
+    "mtime": 1782540715.806082,
     "ast_hash": "d8492b92abaaf1c4d60cd1035a96f8e1",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/bom.json": {
-    "mtime": 1782538950.3274808,
+    "mtime": 1782540715.8070817,
     "ast_hash": "3eabc9ec189bdaf11f14b4c0a45b75c2",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/browserstack-sdk.json": {
-    "mtime": 1782538950.3284805,
+    "mtime": 1782540715.8070817,
     "ast_hash": "44c751b4a87214e0607bd7a018f6bd29",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/combined-modules.json": {
-    "mtime": 1782538950.3294816,
+    "mtime": 1782540715.8080826,
     "ast_hash": "7437bc718bb6526bd5ade48a6dd7a186",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/desktop-video.json": {
-    "mtime": 1782538950.3294816,
+    "mtime": 1782540715.8080826,
     "ast_hash": "3cd581acddb6c5ab3eb3c5dadfa4dfec",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/junit-web.json": {
-    "mtime": 1782538950.3304808,
+    "mtime": 1782540715.8090825,
     "ast_hash": "e736aac3ac042dd16518d1f12e5a8689",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/legacy-coordinate.json": {
-    "mtime": 1782538950.3304808,
+    "mtime": 1782540715.8090825,
     "ast_hash": "e0db222137e456fe8e3563cf5564672a",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/opencv-visual.json": {
-    "mtime": 1782538950.331482,
+    "mtime": 1782540715.8090825,
     "ast_hash": "3af8a40b65daa2d45d95d633db37bc0f",
     "semantic_hash": ""
   },
   "tests/fixtures/modularization/dependency-baseline/manifests/testng-web.json": {
-    "mtime": 1782538950.3324869,
+    "mtime": 1782540715.8105881,
     "ast_hash": "476c5a55cf829d939d58c5ee853862b1",
     "semantic_hash": ""
   },
   "tests/scripts/test_assemble_javadocs.py": {
-    "mtime": 1782538950.3334832,
+    "mtime": 1782540715.8116004,
     "ast_hash": "f3502852bcff0fab528ccb2995644628",
     "semantic_hash": ""
   },
   "tests/scripts/test_browserstack_module_boundary.py": {
-    "mtime": 1782538950.3344808,
+    "mtime": 1782540715.8125987,
     "ast_hash": "f4671e1c6ca54b6e02497afefa3d79c9",
     "semantic_hash": ""
   },
   "tests/scripts/test_check_maven_release_version.py": {
-    "mtime": 1782538950.3354795,
+    "mtime": 1782540715.8125987,
     "ast_hash": "2862600bb50c3c3a62386c49105fa5e8",
     "semantic_hash": ""
   },
   "tests/scripts/test_extract_allure_failures.py": {
-    "mtime": 1782538950.3364823,
+    "mtime": 1782540715.8146243,
     "ast_hash": "5f15f6321ea15ae0b440221512563c41",
     "semantic_hash": ""
   },
   "tests/scripts/test_pilot_module_boundary.py": {
-    "mtime": 1782538950.3384807,
+    "mtime": 1782540715.8154058,
     "ast_hash": "778d0667f363c9013a98be56f2cdbeeb",
     "semantic_hash": ""
   },
   "tests/scripts/test_upgrade_to_modular_shaft.py": {
-    "mtime": 1782538950.3384807,
+    "mtime": 1782540715.8154058,
     "ast_hash": "67bdad010b94f24614daaa65e2297e9b",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_agent_guidance.py": {
-    "mtime": 1782538950.3394818,
+    "mtime": 1782540715.816633,
     "ast_hash": "31f821d43bb135cecff6219df9238139",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_agent_setup.py": {
-    "mtime": 1782538950.3404813,
+    "mtime": 1782540715.817633,
     "ast_hash": "6897d4657f87cc83c6573b37698c96de",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_maven_publication.py": {
-    "mtime": 1782538950.3414812,
+    "mtime": 1782540715.8216522,
     "ast_hash": "34d6ed7fbe980f3eed372bd1ef5388aa",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_modular_documentation.py": {
-    "mtime": 1782538950.3424802,
+    "mtime": 1782540715.8226483,
     "ast_hash": "69686b909a8bfdeabe1443605d5da58d",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_quality_configuration.py": {
-    "mtime": 1782538950.343481,
+    "mtime": 1782540715.8241682,
     "ast_hash": "9b656c26a1a985cc43fb61fab4912d85",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_reactor_versions.py": {
-    "mtime": 1782538950.3444853,
+    "mtime": 1782540715.8257287,
     "ast_hash": "f9433da24d0218a7361747d407ace39d",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_shaft_pilot_release.py": {
-    "mtime": 1782538950.3464828,
+    "mtime": 1782540715.8277283,
     "ast_hash": "b888b91abba4fa10ff9c8f2aa8c5f6da",
     "semantic_hash": ""
   },
   "tests/scripts/test_verify_maven_central_release.py": {
-    "mtime": 1782538950.3464828,
+    "mtime": 1782540715.8287275,
     "ast_hash": "20d330277e722c391b13833fc79827f1",
     "semantic_hash": ""
   },
   "tests/scripts/test_video_module_boundary.py": {
-    "mtime": 1782538950.3474796,
+    "mtime": 1782540715.8287275,
     "ast_hash": "a3faabe526dd03805678b1c530509398",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/api/src/test/java/fixture/ApiAndRetainedSurfaceConsumer.java": {
-    "mtime": 1782538950.3504796,
+    "mtime": 1782540715.833727,
     "ast_hash": "5a2e4a6e773299c1000f0d22aaa00d10",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/appium-mobile/src/test/java/fixture/AppiumMobileConsumer.java": {
-    "mtime": 1782538950.3534794,
+    "mtime": 1782540715.8380322,
     "ast_hash": "863352eb82696f373fe94a63f1d22d25",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/bom/src/test/java/fixture/BomConsumer.java": {
-    "mtime": 1782538950.3564847,
+    "mtime": 1782540715.8405375,
     "ast_hash": "626d1fe9b8536ed47c4f86a665d8a49e",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/browserstack-sdk/src/test/java/fixture/BrowserStackSdkConsumer.java": {
-    "mtime": 1782538950.3594863,
+    "mtime": 1782540715.844579,
     "ast_hash": "0d9caf3b0b7aceb9d9b9f54b6fac92ef",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/desktop-video/src/test/java/fixture/DesktopVideoConsumer.java": {
-    "mtime": 1782538950.3644865,
+    "mtime": 1782540715.8485942,
     "ast_hash": "cf09e09cfb9ccab702d9aa80b3d0e520",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/junit-web/src/test/java/fixture/JUnitWebConsumer.java": {
-    "mtime": 1782538950.3674843,
+    "mtime": 1782540715.852593,
     "ast_hash": "cd14091ae4d1d91102878e1b1d41d1fc",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/legacy-coordinate/src/test/java/fixture/LegacyCoordinateConsumer.java": {
-    "mtime": 1782538950.3704858,
+    "mtime": 1782540715.8610377,
     "ast_hash": "2a8f6b59bc40773df7204c2b417ab016",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/opencv-visual/src/test/java/fixture/OpenCvVisualConsumer.java": {
-    "mtime": 1782538950.373735,
+    "mtime": 1782540715.8665566,
     "ast_hash": "13a3d033009333c480e8354e11f160f4",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/pilot-core/src/main/java/example/PilotCoreConsumer.java": {
-    "mtime": 1782538950.3767374,
+    "mtime": 1782540715.8695545,
     "ast_hash": "ecd7041b37e057a1692e0407f2ea8ec9",
     "semantic_hash": ""
   },
   "tools/modularization/consumer-fixtures/testng-web/src/test/java/fixture/TestNgWebConsumer.java": {
-    "mtime": 1782538950.3817377,
+    "mtime": 1782540715.8725555,
     "ast_hash": "f5374b99aa6ede6b828689f13963196f",
     "semantic_hash": ""
   },
   ".agents/skills/ci-failure-investigator/SKILL.md": {
-    "mtime": 1782538948.6251407,
+    "mtime": 1782540713.6517723,
     "ast_hash": "00b8473e33574eaecd73bc947de97864",
     "semantic_hash": ""
   },
   ".agents/skills/ci-failure-investigator/agents/openai.yaml": {
-    "mtime": 1782538948.6261425,
+    "mtime": 1782540713.652772,
     "ast_hash": "a655df2d4ee8a6eca2611c26184da4ba",
     "semantic_hash": ""
   },
   ".agents/skills/flaky-test-stabilizer/SKILL.md": {
-    "mtime": 1782538948.6271398,
+    "mtime": 1782540713.653783,
     "ast_hash": "97f4ea40aaf659bca7200ce9a99279a5",
     "semantic_hash": ""
   },
   ".agents/skills/flaky-test-stabilizer/agents/openai.yaml": {
-    "mtime": 1782538948.6281404,
+    "mtime": 1782540713.6548579,
     "ast_hash": "442d85b196270c22a0c71c81c759ede1",
     "semantic_hash": ""
   },
   ".agents/skills/framework-source-rules/SKILL.md": {
-    "mtime": 1782538948.629143,
+    "mtime": 1782540713.6556895,
     "ast_hash": "4e9e9113da43851ebbbadf41ff12070c",
     "semantic_hash": ""
   },
   ".agents/skills/framework-source-rules/agents/openai.yaml": {
-    "mtime": 1782538948.629143,
+    "mtime": 1782540713.656865,
     "ast_hash": "fbbaa399dc0f83968bf451e6a53fc96d",
     "semantic_hash": ""
   },
   ".agents/skills/java-test-rules/SKILL.md": {
-    "mtime": 1782538948.6301415,
+    "mtime": 1782540713.6578639,
     "ast_hash": "deb7cdd0ce17fa15de3fe89b51b7ee10",
     "semantic_hash": ""
   },
   ".agents/skills/java-test-rules/agents/openai.yaml": {
-    "mtime": 1782538948.6311421,
+    "mtime": 1782540713.6588638,
     "ast_hash": "fd1828b72256991da2926129061bda9c",
     "semantic_hash": ""
   },
   ".agents/skills/release-dependency-guard/SKILL.md": {
-    "mtime": 1782538948.6311421,
+    "mtime": 1782540713.6588638,
     "ast_hash": "f3653ae639dadae0de32eb6d93abc152",
     "semantic_hash": ""
   },
   ".agents/skills/release-dependency-guard/agents/openai.yaml": {
-    "mtime": 1782538948.6321423,
+    "mtime": 1782540713.6598637,
     "ast_hash": "70df2767596adcc902c526e6f96b9047",
     "semantic_hash": ""
   },
   ".github/FUNDING.yml": {
-    "mtime": 1782538948.6381392,
+    "mtime": 1782540713.6683867,
     "ast_hash": "82d0dace0b0b1e5a3113e7483a2c90ef",
     "semantic_hash": ""
   },
   ".github/ISSUE_TEMPLATE/bug_report.md": {
-    "mtime": 1782538948.6391418,
+    "mtime": 1782540713.6703966,
     "ast_hash": "ef466e19961514f451c8c0bccc9be819",
     "semantic_hash": ""
   },
   ".github/ISSUE_TEMPLATE/config.yml": {
-    "mtime": 1782538948.6391418,
+    "mtime": 1782540713.671388,
     "ast_hash": "78c7c4c344a237f1a770009306505fa0",
     "semantic_hash": ""
   },
   ".github/ISSUE_TEMPLATE/feature_request.md": {
-    "mtime": 1782538948.6401417,
+    "mtime": 1782540713.671388,
     "ast_hash": "2374f7b498fad3e41590d9d0aa6bd116",
     "semantic_hash": ""
   },
   ".github/RELEASE_BODY_TEMPLATE.md": {
-    "mtime": 1782538948.6401417,
+    "mtime": 1782540713.6761897,
     "ast_hash": "311edf8e9db9d277067a4166d1e2e453",
     "semantic_hash": ""
   },
   ".github/actions/consolidate-test-results/action.yml": {
-    "mtime": 1782538948.6411424,
+    "mtime": 1782540713.6788893,
     "ast_hash": "60f8f12a4f02378cbf50c2e4548ea2d7",
     "semantic_hash": ""
   },
   ".github/actions/post-test-report/action.yml": {
-    "mtime": 1782538948.6421425,
+    "mtime": 1782540713.6804078,
     "ast_hash": "682df808ffdefb6178d20bce9dba6668",
     "semantic_hash": ""
   },
   ".github/actions/setup-test-env/action.yml": {
-    "mtime": 1782538948.6431382,
+    "mtime": 1782540713.6814153,
     "ast_hash": "a3ae968f94adf704ec03d1d59c32ca88",
     "semantic_hash": ""
   },
   ".github/actions/upload-jacoco-coverage/action.yml": {
-    "mtime": 1782538948.6441464,
+    "mtime": 1782540713.6824152,
     "ast_hash": "235863f5fbb33ba3564051d6570d6ed2",
     "semantic_hash": ""
   },
   ".github/codex/prompts/refresh-agent-instructions.md": {
-    "mtime": 1782538948.6451416,
+    "mtime": 1782540713.6844451,
     "ast_hash": "b917f03c57b15de27300bc05cf7e0929",
     "semantic_hash": ""
   },
   ".github/copilot-instructions.md": {
-    "mtime": 1782539161.2569218,
-    "ast_hash": "8289eddbdcb210a520f825db3d026d60",
+    "mtime": 1782540713.6844451,
+    "ast_hash": "747adf26a2c30504bab5946ccb300b29",
     "semantic_hash": ""
   },
   ".github/dependabot.yml": {
-    "mtime": 1782538948.646143,
+    "mtime": 1782540713.6854503,
     "ast_hash": "4f97032a0893c4bd5040a882d83bf7c5",
     "semantic_hash": ""
   },
   ".github/instructions/framework-source.instructions.md": {
-    "mtime": 1782538948.6471426,
+    "mtime": 1782540713.6854503,
     "ast_hash": "5f3adff6cc4aa23c612aa7c02ae9a512",
     "semantic_hash": ""
   },
   ".github/instructions/java-tests.instructions.md": {
-    "mtime": 1782538948.6471426,
+    "mtime": 1782540713.6864583,
     "ast_hash": "c09b9d18f7d372e5713e1ae3a401fe37",
     "semantic_hash": ""
   },
   ".github/pull_request_template.md": {
-    "mtime": 1782538948.6601503,
+    "mtime": 1782540713.7014902,
     "ast_hash": "fdc84bd63f4459bb71c5e62770bd36f3",
     "semantic_hash": ""
   },
   ".github/release.yml": {
-    "mtime": 1782538948.6611476,
+    "mtime": 1782540713.70249,
     "ast_hash": "da8b1e52486c7f97f5ef731e57629179",
     "semantic_hash": ""
   },
   ".github/skills/README.md": {
-    "mtime": 1782539365.332105,
-    "ast_hash": "6af4b25637d29d0df715cd1e78d609f2",
+    "mtime": 1782540713.70249,
+    "ast_hash": "86c50b54b4d19507dac7bbb2dca49520",
     "semantic_hash": ""
   },
   ".github/skills/ci-failure-investigator/SKILL.md": {
-    "mtime": 1782538948.6631484,
+    "mtime": 1782540713.7039952,
     "ast_hash": "c96ae3cf1ca3bab8b9d4bb034be8c1d5",
     "semantic_hash": ""
   },
   ".github/skills/flaky-test-stabilizer/SKILL.md": {
-    "mtime": 1782538948.664148,
+    "mtime": 1782540713.7045095,
     "ast_hash": "8244098e39f5271a9e3d1f8d7ffbd830",
     "semantic_hash": ""
   },
   ".github/skills/release-dependency-guard/SKILL.md": {
-    "mtime": 1782538948.6651483,
+    "mtime": 1782540713.7055166,
     "ast_hash": "77995cc9b84d3555f73936d32309985b",
     "semantic_hash": ""
   },
   ".github/workflows/copilot-setup-steps.yml": {
-    "mtime": 1782538948.6671486,
+    "mtime": 1782540713.7156494,
     "ast_hash": "0c3d73a2b49a51c9d86e5a5f4c76bbcf",
     "semantic_hash": ""
   },
   ".github/workflows/deploy-shaft-mcp.yml": {
-    "mtime": 1782538948.6671486,
+    "mtime": 1782540713.7156494,
     "ast_hash": "c9d64c29897a5dae860640eaf1622981",
     "semantic_hash": ""
   },
   ".github/workflows/e2eTests.yml": {
-    "mtime": 1782538948.6686556,
+    "mtime": 1782540713.7177887,
     "ast_hash": "1951482fcb77a99eaaaf3a3f0a3acc90",
     "semantic_hash": ""
   },
   ".github/workflows/mavenCentral_cd.yml": {
-    "mtime": 1782538948.6706617,
+    "mtime": 1782540713.7187877,
     "ast_hash": "12c1819ee10a8a1bc43b26956af4b6f0",
     "semantic_hash": ""
   },
   ".github/workflows/publish-shaft-mcp.yml": {
-    "mtime": 1782538948.6706617,
+    "mtime": 1782540713.7197926,
     "ast_hash": "7ece85f30a603b746cb901af35c9d0f2",
     "semantic_hash": ""
   },
   ".github/workflows/publishJavaDocs.yml": {
-    "mtime": 1782538948.671662,
+    "mtime": 1782540713.7197926,
     "ast_hash": "e68ab97713f70c88ae293f7e814985cf",
     "semantic_hash": ""
   },
   ".github/workflows/refresh-agent-instructions.yml": {
-    "mtime": 1782538948.671662,
+    "mtime": 1782540713.7207892,
     "ast_hash": "792e62e3a612accd91287508154b6a07",
     "semantic_hash": ""
   },
   ".github/workflows/security.yml": {
-    "mtime": 1782538948.6726623,
+    "mtime": 1782540713.7217915,
     "ast_hash": "6d096cbb458e77fc21fbb1557d99cfa5",
     "semantic_hash": ""
   },
   ".github/workflows/shaft-mcp.yml": {
-    "mtime": 1782538948.6726623,
+    "mtime": 1782540713.7217915,
     "ast_hash": "7c6f65310c3b9bc52c3139e0d9dd5b0d",
     "semantic_hash": ""
   },
   ".github/workflows/shaft-pilot-release.yml": {
-    "mtime": 1782538948.673663,
+    "mtime": 1782540713.723793,
     "ast_hash": "8d01f7212ab5fcfd7d743537b89279b1",
     "semantic_hash": ""
   },
   ".github/workflows/sync-sample-projects-version.yml": {
-    "mtime": 1782538948.673663,
+    "mtime": 1782540713.7242987,
     "ast_hash": "dfebf14b9c11eca07877c2083cde5be4",
     "semantic_hash": ""
   },
   ".github/workflows/update-selenium-grid-versions.yml": {
-    "mtime": 1782538948.674662,
+    "mtime": 1782540713.7248044,
     "ast_hash": "d3bc67a9f9e52eed58c9151431cded9d",
     "semantic_hash": ""
   },
   ".memory/memory/architecture.md": {
-    "mtime": 1782538948.6786628,
+    "mtime": 1782540713.728811,
     "ast_hash": "6abb2a262830b40886b2283dac6a901a",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/maven-central-version-immutability.md": {
-    "mtime": 1782538948.6816626,
+    "mtime": 1782540713.7338116,
     "ast_hash": "76b0b7fb9ab56f985f3941697647c496",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/paid-agent-work-audit-gated.md": {
-    "mtime": 1782538948.6826622,
+    "mtime": 1782540713.7349215,
     "ast_hash": "15666adfbb50db198beb784479ff45e5",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/agent-guidance-progressive-disclosure.md": {
-    "mtime": 1782538948.6836636,
+    "mtime": 1782540713.735927,
     "ast_hash": "9675efebffd6956a72dbe25b6e39591f",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/namespaced-video-capabilities.md": {
-    "mtime": 1782538948.6896617,
+    "mtime": 1782540713.7484248,
     "ast_hash": "a5940ade6cab0d926922ca555dab46f6",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/public-docs-external.md": {
-    "mtime": 1782538948.692662,
+    "mtime": 1782540713.75142,
     "ast_hash": "3d4a3061ddfb0b5f6ee8049012f4d664",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/utf8-all-runtime-layers.md": {
-    "mtime": 1782538948.6976619,
+    "mtime": 1782540713.7564702,
     "ast_hash": "6bff0142e535940a2c54ed0c96743f81",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/allure-result-population.md": {
-    "mtime": 1782538948.702662,
+    "mtime": 1782540713.7594693,
     "ast_hash": "d691c887b833eeb2002b91bb55129c8a",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/coverage-constructors-start-browser.md": {
-    "mtime": 1782538948.7036617,
+    "mtime": 1782540713.7604692,
     "ast_hash": "bbd92df5c4228f6e626c7a52ed2c16cd",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/java25-isuite-mocking.md": {
-    "mtime": 1782538948.7056623,
+    "mtime": 1782540713.7624688,
     "ast_hash": "a6d1866e880bd6556f12230ff80f75aa",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/testng-method-parallel-shared-instance-fields.md": {
-    "mtime": 1782538948.7086635,
+    "mtime": 1782540713.7655015,
     "ast_hash": "88be0bf5fcebfdb1d579389644c09ebe",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/testng-single-threaded-static-state.md": {
-    "mtime": 1782538948.7096615,
+    "mtime": 1782540713.7665005,
     "ast_hash": "19c314a82618b0fa2e841ecac203734b",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/windows-allure-root-race.md": {
-    "mtime": 1782538948.7106652,
+    "mtime": 1782540713.7665005,
     "ast_hash": "2ff9296f2ecf396b5c61f41a0b5be34b",
     "semantic_hash": ""
   },
   ".memory/memory/project.md": {
-    "mtime": 1782538948.7116623,
+    "mtime": 1782540713.7675023,
     "ast_hash": "5e4026b5220213b5d05773628cde4269",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/issue-linked-pr-closure-and-focused-tests.md": {
-    "mtime": 1782538948.7246628,
+    "mtime": 1782540713.7840447,
     "ast_hash": "57982dd3a4bdf7d5b1a46259307d1e58",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/low-token-user-guide-work.md": {
-    "mtime": 1782538948.7256625,
+    "mtime": 1782540713.7856028,
     "ast_hash": "37fceea4bd25a0a1949e5bc9c28f8f6e",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/proactive-memory-use-when-material.md": {
-    "mtime": 1782538948.728665,
+    "mtime": 1782540713.7888243,
     "ast_hash": "79312855570c67b7f6e8e0ef5adab2cf",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/start-new-tasks-from-origin-main.md": {
-    "mtime": 1782538948.732661,
+    "mtime": 1782540713.79433,
     "ast_hash": "c20c771d71712f59dba2081edda454d0",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/update-official-user-guide-for-functionality-changes.md": {
-    "mtime": 1782538948.7346625,
+    "mtime": 1782540713.796344,
     "ast_hash": "1d7eaa27ba5737bd22dee4ba51ec3316",
     "semantic_hash": ""
   },
   "AGENTS.md": {
-    "mtime": 1782538948.7466614,
+    "mtime": 1782540713.8080072,
     "ast_hash": "90ff26c44a457cbe712e85238a37aa0d",
     "semantic_hash": ""
   },
   "CLAUDE.md": {
-    "mtime": 1782538948.7466614,
+    "mtime": 1782540713.8128083,
     "ast_hash": "109fba9e5bd24a6c1ae37e799818c59b",
     "semantic_hash": ""
   },
   "CODE_OF_CONDUCT.md": {
-    "mtime": 1782538948.7476618,
+    "mtime": 1782540713.814869,
     "ast_hash": "757dfc14603149dc03182d5c2c0d8ca4",
     "semantic_hash": ""
   },
   "CONTRIBUTING.md": {
-    "mtime": 1782538948.7476618,
+    "mtime": 1782540713.8158784,
     "ast_hash": "86f86dcdb3102ee7fe5192f2c131c3b3",
     "semantic_hash": ""
   },
   "README.md": {
-    "mtime": 1782538948.7486625,
+    "mtime": 1782540713.81688,
     "ast_hash": "49f5f56feb5a4bf0323c9a36a5b0647b",
     "semantic_hash": ""
   },
   "SECURITY.md": {
-    "mtime": 1782538948.7496617,
+    "mtime": 1782540713.8178754,
     "ast_hash": "5968bb1ac2bd3d0b9c04d6789ed99884",
     "semantic_hash": ""
   },
   "codecov.yml": {
-    "mtime": 1782538948.7496617,
+    "mtime": 1782540713.8178754,
     "ast_hash": "6ad852993fbc1adc8ffa7e42bbd2ce9f",
     "semantic_hash": ""
   },
   "render.yaml": {
-    "mtime": 1782538948.8329594,
+    "mtime": 1782540713.9274344,
     "ast_hash": "852f4c51596f80a6f39c336083b743bd",
     "semantic_hash": ""
   },
   "shaft-doctor/src/test/resources/fixtures/golden/doctor-report.md": {
-    "mtime": 1782538948.9470623,
+    "mtime": 1782540714.072722,
     "ast_hash": "9fd151800fee4024eeb0463f36890866",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/javadoc/resources/configuration-manager/index.html": {
-    "mtime": 1782538949.0999296,
+    "mtime": 1782540714.2777715,
     "ast_hash": "03dab7003a8ceed930851cc4718af1ff",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/healenium-backend.yml": {
-    "mtime": 1782538949.1099281,
+    "mtime": 1782540714.2979589,
     "ast_hash": "a5fd654aa0fbea19d0a20fa14e06e86c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/report-portal.yml": {
-    "mtime": 1782538949.1129274,
+    "mtime": 1782540714.3014781,
     "ast_hash": "de7ac23ca6fa7d3eda50bc8ab1aba483",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/selenium3.yml": {
-    "mtime": 1782538949.1129274,
+    "mtime": 1782540714.3024752,
     "ast_hash": "a464e315b9a241886cfef90f787ec99d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/selenium4.yml": {
-    "mtime": 1782538949.113929,
+    "mtime": 1782540714.3024752,
     "ast_hash": "ef7d53be2865b48d88080466a1002231",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/selenoid.yml": {
-    "mtime": 1782538949.1149297,
+    "mtime": 1782540714.3039825,
     "ast_hash": "94b482b90eb7a6c434840950aa7cadad",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/selenoid_setup.yml": {
-    "mtime": 1782538949.1159294,
+    "mtime": 1782540714.3045037,
     "ast_hash": "57f474b3e5f66f08f07684ab25568c4e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/docker-compose/zalenium.yml": {
-    "mtime": 1782538949.1169283,
+    "mtime": 1782540714.30551,
     "ast_hash": "cc1f40ca9bb2c913d8ce5c755c1dc525",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/.github/dependabot.yml": {
-    "mtime": 1782538949.1249278,
+    "mtime": 1782540714.3154075,
     "ast_hash": "d967a02218d19254ea8c200b1887b549",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/.github/workflows/api.yml": {
-    "mtime": 1782538949.1259277,
+    "mtime": 1782540714.3165603,
     "ast_hash": "d6cebbce56ded32de3f4d49cfdc8e545",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/examples/.github/workflows/web.yml": {
-    "mtime": 1782538949.1259277,
+    "mtime": 1782540714.3175585,
     "ast_hash": "698491178af348cb577da4a2bed5f4ce",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/k8s/selenium-grid-chrome-scaledobject.yaml": {
-    "mtime": 1782538949.3231795,
+    "mtime": 1782540714.5643902,
     "ast_hash": "c6d16b2c9bf789f3c38dced54ff50c79",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/k8s/selenium-grid-edge-scaledobject.yaml": {
-    "mtime": 1782538949.3231795,
+    "mtime": 1782540714.5654013,
     "ast_hash": "48291bb39d912826522b2fcaedbd55e9",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/k8s/selenium-grid-firefox-scaledobject.yaml": {
-    "mtime": 1782538949.3241804,
+    "mtime": 1782540714.5654013,
     "ast_hash": "ce8ab2c5f24347cbbe286a358e6e970d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/alertFixture.html": {
-    "mtime": 1782538949.5375023,
+    "mtime": 1782540714.8590553,
     "ast_hash": "ea46500946ec7b72c8d872d5432079dc",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/coverageTestPage.html": {
-    "mtime": 1782538950.1192434,
+    "mtime": 1782540715.54569,
     "ast_hash": "1b449bdbd7cbf63f83d0f4c644976730",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/hoverDemo.html": {
-    "mtime": 1782538950.120242,
+    "mtime": 1782540715.54669,
     "ast_hash": "017983881c7dcdeb8549122b74fceea3",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/hoverDemo_outsideViewPort.html": {
-    "mtime": 1782538950.120242,
+    "mtime": 1782540715.547692,
     "ast_hash": "09c6ae4c037396146fb889b9145d77b9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/hoverDemo_outsideViewPort_Horizontal.html": {
-    "mtime": 1782538950.12124,
+    "mtime": 1782540715.5524867,
     "ast_hash": "3f2864a3f112756f32c047d08d86d033",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/locatorBuilderFixture.html": {
-    "mtime": 1782538950.122242,
+    "mtime": 1782540715.5555866,
     "ast_hash": "274171ae17cb342e543557271079b5a9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/searchFixture.html": {
-    "mtime": 1782538950.128246,
+    "mtime": 1782540715.564687,
     "ast_hash": "f807c7d448900de296c1aff8960c0928",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/selectDemo.html": {
-    "mtime": 1782538950.1292405,
+    "mtime": 1782540715.5656977,
     "ast_hash": "6202e3912db56d54602ad63a94ecbf52",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/selectedValueTests/Advanced_select_with_multiple_features.html": {
-    "mtime": 1782538950.1302397,
+    "mtime": 1782540715.5676932,
     "ast_hash": "78d03def935f6591bd4e50812688a7c4",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/selectedValueTests/Basic_select.html": {
-    "mtime": 1782538950.13124,
+    "mtime": 1782540715.5686934,
     "ast_hash": "3868db4101f1dcbb8ed8fc09bad58d65",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/test.html": {
-    "mtime": 1782538950.136243,
+    "mtime": 1782540715.5767875,
     "ast_hash": "eca1a30a4647270469873bb77be7d28b",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/uploadFixture.html": {
-    "mtime": 1782538950.13924,
+    "mtime": 1782540715.5817873,
     "ast_hash": "6afb82db0280c6109713fe98dc1109ea",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/validationTextFixture.html": {
-    "mtime": 1782538950.13924,
+    "mtime": 1782540715.5861504,
     "ast_hash": "bdc4bd2af770c9de828335d6a51e9f75",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/yaml/yaml_test_data.yaml": {
-    "mtime": 1782538950.1402423,
+    "mtime": 1782540715.5895503,
     "ast_hash": "9dbe42fd6d1166db3aefabe7bf52e87b",
     "semantic_hash": ""
   },
   "shaft-mcp/.github/copilot-instructions.md": {
-    "mtime": 1782538950.1732686,
+    "mtime": 1782540715.6257367,
     "ast_hash": "687a29b7080f6e1548c6470c3924b291",
     "semantic_hash": ""
   },
   "smithery.yaml": {
-    "mtime": 1782538950.315482,
+    "mtime": 1782540715.7977655,
     "ast_hash": "38eb9cd9b08dbf6453dfd19693e4f23e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/sample.pdf": {
-    "mtime": 1782538950.1262412,
+    "mtime": 1782540715.5636747,
     "ast_hash": "4b41a3475132bd861b30a878e30aa56a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/Android/13_0/a9d70165382980941bed3fe21fcb9aabfc62872fa39658c332505740f4cb3675.png": {
-    "mtime": 1782538949.1199286,
+    "mtime": 1782540714.3085115,
     "ast_hash": "2ef14bf57dfc7ae42b748b506607c891",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/Android/content.png": {
-    "mtime": 1782538949.1199286,
+    "mtime": 1782540714.3095102,
     "ast_hash": "ceaf89a99b2f77f7dd7385232bc786a0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/Android/content_local.png": {
-    "mtime": 1782538949.1209278,
+    "mtime": 1782540714.3105216,
     "ast_hash": "b404721a09a139fcaf7276b578a5deab",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/Android/content_new.png": {
-    "mtime": 1782538949.121932,
+    "mtime": 1782540714.31152,
     "ast_hash": "42815e5383bcc7948c46443793f61dbe",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/linux/chrome/a16413dbaadddad22a2203779b00521b7e5beb3446743fff9b52e1c3308bbfd3.png": {
-    "mtime": 1782538949.1229303,
+    "mtime": 1782540714.3125174,
     "ast_hash": "0ce5cae521647668798fb59240d8163d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/dynamicObjectRepository/linux/chrome/a16413dbaadddad22a2203779b00521b7e5beb3446743fff9b52e1c3308bbfd3_shutterbug.png": {
-    "mtime": 1782538949.1239278,
+    "mtime": 1782540714.3125174,
     "ast_hash": "da6466f773b2b294c96164c351fee9e1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/engine.png": {
-    "mtime": 1782538949.307179,
+    "mtime": 1782540714.540917,
     "ast_hash": "9c02074d966c282967abf86a40990952",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/mindmap.png": {
-    "mtime": 1782538949.313181,
+    "mtime": 1782540714.5474474,
     "ast_hash": "09974b1f6d4fe5ef7b8601bb9c08680e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/roi.png": {
-    "mtime": 1782538949.3141816,
+    "mtime": 1782540714.5484486,
     "ast_hash": "7303a194a3ba55dd3fb2071d8445e31b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft.png": {
-    "mtime": 1782538949.3151786,
+    "mtime": 1782540714.550444,
     "ast_hash": "d476641cef7c2f5c13f2da06eee7913a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft_white.png": {
-    "mtime": 1782538949.3191793,
+    "mtime": 1782540714.554484,
     "ast_hash": "877b04c6152af84a64aeb0dcd1ef3198",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft_white_bg.png": {
-    "mtime": 1782538949.3211784,
+    "mtime": 1782540714.5573106,
     "ast_hash": "638a800ba4c6c0d597df827fdf7848cf",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft_white_ramadan.png": {
-    "mtime": 1782538949.32218,
+    "mtime": 1782540714.5573106,
     "ast_hash": "703354878805e8d341e697c75a83b367",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/search.PNG": {
-    "mtime": 1782538949.5339966,
+    "mtime": 1782540714.857056,
     "ast_hash": "529740c6b227e97ed27fe797406d735f",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/youtube.png": {
-    "mtime": 1782538950.1402423,
+    "mtime": 1782540715.592565,
     "ast_hash": "3cb8adc33ce532807aacf1bfaffbf31b",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/code-conventions.json": {
-    "mtime": 1782538948.6796613,
+    "mtime": 1782540713.7308116,
     "ast_hash": "5c1eb980b386ba44323d9741b8c8ae28",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/powershell-shell-sensitive-args.json": {
-    "mtime": 1782538948.7066615,
+    "mtime": 1782540713.7639773,
     "ast_hash": "8dc62f50fbf74b5780312307bf6d5d19",
     "semantic_hash": ""
   },
   ".memory/memory/sources/agents.json": {
-    "mtime": 1782538948.7126625,
+    "mtime": 1782540713.768502,
     "ast_hash": "8b0ad0f82cc956b5c4a05f5413c6bd8e",
     "semantic_hash": ""
   },
   ".memory/memory/sources/project-readme.json": {
-    "mtime": 1782538948.7136621,
+    "mtime": 1782540713.769502,
     "ast_hash": "ca2b3ea34f094d5d7104225b910a6db5",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/agent-guidance.json": {
-    "mtime": 1782538948.7146614,
+    "mtime": 1782540713.7705057,
     "ast_hash": "d47a35a97e29fa13de28e5ddd1170621",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/conventions-quality.json": {
-    "mtime": 1782538948.715662,
+    "mtime": 1782540713.771504,
     "ast_hash": "e01f337f7d01373f294a3ace9cd11f7f",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/product-intent.json": {
-    "mtime": 1782538948.7166612,
+    "mtime": 1782540713.7725022,
     "ast_hash": "d4a438fd7d6896393b8026b284735904",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/create-and-report-pr-after-tasks.json": {
-    "mtime": 1782538948.717662,
+    "mtime": 1782540713.7725022,
     "ast_hash": "b1ce8ac2e98f89838415a25fa522171b",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/minimal-nonredundant-validation.json": {
-    "mtime": 1782538948.7266643,
+    "mtime": 1782540713.7868254,
     "ast_hash": "5834b369159038bc89a34e916e9ad7ee",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/run-local-e2e-jobs-in-a-dedicated-workflow.json": {
-    "mtime": 1782538948.728665,
+    "mtime": 1782540713.7888243,
     "ast_hash": "4233688d717e8e7aaaa1b424ce1ebb87",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/share-memory-and-graphify-assets.json": {
-    "mtime": 1782538948.7306628,
+    "mtime": 1782540713.7918253,
     "ast_hash": "270cbf117e0047f707f3eaaae9494195",
     "semantic_hash": ""
   },
   ".memory/relations/constraint-code-conventions-affects-project-shaft-engine.json": {
-    "mtime": 1782538948.736662,
+    "mtime": 1782540713.7983432,
     "ast_hash": "a4dd873eb9a3cb41398d92073ddd37a5",
     "semantic_hash": ""
   },
   ".memory/relations/constraint-code-conventions-derived-from-source-agents.json": {
-    "mtime": 1782538948.7376616,
+    "mtime": 1782540713.7983432,
     "ast_hash": "958da5cacc1ad227cbfc52bdcf3696cd",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-agent-guidance-derived-from-source-agents.json": {
-    "mtime": 1782538948.7386627,
+    "mtime": 1782540713.7993436,
     "ast_hash": "ceda73fdfa718f949c1c636e33d993d6",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-agent-guidance-documents-project-shaft-engine.json": {
-    "mtime": 1782538948.7386627,
+    "mtime": 1782540713.8008516,
     "ast_hash": "c17d6760da1e494ee12d62ea6cdb0e35",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-conventions-quality-derived-from-source-agents.json": {
-    "mtime": 1782538948.7396624,
+    "mtime": 1782540713.8018618,
     "ast_hash": "30f6ab1fb433f92e0f1bddb152ae89a9",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-conventions-quality-documents-project-shaft-engine.json": {
-    "mtime": 1782538948.7396624,
+    "mtime": 1782540713.8018618,
     "ast_hash": "7807b3da7440b26c5ffd411d2d58c8f4",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-product-intent-derived-from-source-project-readme.json": {
-    "mtime": 1782538948.7396624,
+    "mtime": 1782540713.8028588,
     "ast_hash": "73f46fd60b629fac27ef5b2bf7edaade",
     "semantic_hash": ""
   },
   ".memory/relations/synthesis-product-intent-summarizes-project-shaft-engine.json": {
-    "mtime": 1782538948.7406623,
+    "mtime": 1782540713.8028588,
     "ast_hash": "d75f2b943c7caec5bad6edbdd2d3ba42",
     "semantic_hash": ""
   },
   ".memory/relations/workflow-create-and-report-pr-after-tasks-documents-project-shaft-engine.json": {
-    "mtime": 1782538948.7416637,
+    "mtime": 1782540713.8038583,
     "ast_hash": "15037f0f0f4f2072b4ac7452185b7abd",
     "semantic_hash": ""
   },
   ".memory/relations/workflow-share-memory-and-graphify-assets-documents-project-shaft-engine.json": {
-    "mtime": 1782538948.7416637,
+    "mtime": 1782540713.8043628,
     "ast_hash": "15a6e2ed7ed54d18ca1a9ba283e9997f",
     "semantic_hash": ""
   },
   "tests/scripts/test_install_shaft_mcp.py": {
-    "mtime": 1782538950.3374822,
+    "mtime": 1782540715.8146243,
     "ast_hash": "60ad6539ba363c9a02ad6f85bf1660e3",
     "semantic_hash": ""
   },
   ".github/workflows/e2eLocalTests.yml": {
-    "mtime": 1782538948.6671486,
+    "mtime": 1782540713.7167888,
     "ast_hash": "1327238970e80758934fe016c4e51854",
     "semantic_hash": ""
   },
   ".github/workflows/lambdatestTests.yml": {
-    "mtime": 1782538948.6696627,
+    "mtime": 1782540713.7187877,
     "ast_hash": "89d31b06f66ca3f0545f6d5268710de3",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/code-conventions.md": {
-    "mtime": 1782538948.6796613,
+    "mtime": 1782540713.7308116,
     "ast_hash": "ebb3f6f7caa3501cab774c1d8e7598a8",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/powershell-shell-sensitive-args.md": {
-    "mtime": 1782538948.7076619,
+    "mtime": 1782540713.7644963,
     "ast_hash": "81604c5c66f8f3f2bc96d6fb9b63e0c5",
     "semantic_hash": ""
   },
   ".memory/memory/sources/agents.md": {
-    "mtime": 1782538948.7126625,
+    "mtime": 1782540713.768502,
     "ast_hash": "19d8593d2fbf9941204ff6257b7bbcce",
     "semantic_hash": ""
   },
   ".memory/memory/sources/project-readme.md": {
-    "mtime": 1782538948.7136621,
+    "mtime": 1782540713.769502,
     "ast_hash": "1644c82d3ce411b7b776e14e4a3fc832",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/agent-guidance.md": {
-    "mtime": 1782538948.7146614,
+    "mtime": 1782540713.7705057,
     "ast_hash": "d4ab69ed6a4ee277d2f623592f5aa503",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/conventions-quality.md": {
-    "mtime": 1782538948.715662,
+    "mtime": 1782540713.771504,
     "ast_hash": "41403aeb6cfbff5b7ab4193dff8bac41",
     "semantic_hash": ""
   },
   ".memory/memory/syntheses/product-intent.md": {
-    "mtime": 1782538948.7166612,
+    "mtime": 1782540713.7725022,
     "ast_hash": "072645010c12d96012e55a07eb8462a9",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/create-and-report-pr-after-tasks.md": {
-    "mtime": 1782538948.7186646,
+    "mtime": 1782540713.774007,
     "ast_hash": "1bcb51f3f1e5269b61bba6ea8533ea49",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/minimal-nonredundant-validation.md": {
-    "mtime": 1782538948.7276628,
+    "mtime": 1782540713.7868254,
     "ast_hash": "431e4f5cc6afab68b429c36739dce7c3",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/run-local-e2e-jobs-in-a-dedicated-workflow.md": {
-    "mtime": 1782538948.7296636,
+    "mtime": 1782540713.7898247,
     "ast_hash": "e21cf1d1253c1b9d9646050d8437c555",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/share-memory-and-graphify-assets.md": {
-    "mtime": 1782538948.7316608,
+    "mtime": 1782540713.792822,
     "ast_hash": "44176d6d1036c08d58f9036a56af0a8c",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/delegate-only-when-needed-for-correctness.json": {
-    "mtime": 1782538948.7186646,
+    "mtime": 1782540713.7745242,
     "ast_hash": "89452a15b27dbf71a8d319b68e201a4d",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/delegate-only-when-needed-for-correctness.md": {
-    "mtime": 1782538948.7196622,
+    "mtime": 1782540713.775531,
     "ast_hash": "b07cf652dddba20866b2ecbbe4e06136",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/heal-ai-reranking-trigger-gated.json": {
-    "mtime": 1782538948.687662,
+    "mtime": 1782540713.7414422,
     "ast_hash": "7fcb87f0b2bfa2530bca51fdb28c07cb",
     "semantic_hash": ""
   },
   ".memory/memory/facts/deterministic-ai-test-lifecycle-artifacts.json": {
-    "mtime": 1782538948.6986623,
+    "mtime": 1782540713.7574673,
     "ast_hash": "59d40c4f3bdb5eccd637c1a59cfc7abf",
     "semantic_hash": ""
   },
   ".memory/relations/decision-heal-ai-reranking-trigger-gated-affects-fact-deterministic-ai-test-lifecycle-artifacts.json": {
-    "mtime": 1782538948.7376616,
+    "mtime": 1782540713.7993436,
     "ast_hash": "a31117254d3ebfc8e782e8a3b3a3808d",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureReview.java": {
-    "mtime": 1782538948.8740609,
+    "mtime": 1782540713.9845116,
     "ast_hash": "d814a22924a6ce03afd7c440190769b5",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/resources/schema/shaft-capture-review-1.0.schema.json": {
-    "mtime": 1782538948.8900623,
+    "mtime": 1782540714.002694,
     "ast_hash": "df3ea8b3fa2bdeb83db359e221a56e29",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorTriage.java": {
-    "mtime": 1782538948.922063,
+    "mtime": 1782540714.0389862,
     "ast_hash": "9c84db99fd873d863313e37404fda544",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/java/com/shaft/doctor/model/ExecutionIntelligence.java": {
-    "mtime": 1782538948.9240623,
+    "mtime": 1782540714.042508,
     "ast_hash": "69b01ed194ab82a4e2163acfc9907648",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-doctor-triage-1.0.schema.json": {
-    "mtime": 1782538948.9360633,
+    "mtime": 1782540714.062608,
     "ast_hash": "76dc165df20999b05b4f8e442e90490f",
     "semantic_hash": ""
   },
   "shaft-doctor/src/main/resources/schema/shaft-execution-intelligence-1.0.schema.json": {
-    "mtime": 1782538948.9370623,
+    "mtime": 1782540714.062608,
     "ast_hash": "533f56c3ee115ce73ed329d13851b7cd",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/heal-ai-reranking-trigger-gated.md": {
-    "mtime": 1782538948.6886616,
+    "mtime": 1782540713.7464154,
     "ast_hash": "9e61fd0bec7fb5de29c2d5a2c6500e7c",
     "semantic_hash": ""
   },
   ".memory/memory/facts/deterministic-ai-test-lifecycle-artifacts.md": {
-    "mtime": 1782538948.6996615,
+    "mtime": 1782540713.7574673,
     "ast_hash": "db58ab1ad8c9a772b56404a0460feb8c",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/surefire-testng-bootstrap-validation-after-pr2947.json": {
-    "mtime": 1782538948.7336614,
+    "mtime": 1782540713.7953382,
     "ast_hash": "d381b7c66b8e42deb7eea0e7e7daf39e",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/use-memory-and-graphify-through-cli-in-codex.json": {
-    "mtime": 1782538948.7356634,
+    "mtime": 1782540713.797344,
     "ast_hash": "58123f0adb9df1766a0ab999904f3cfa",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/properties/internal/PropertyFileManagerInternalUnitTest.java": {
-    "mtime": 1782538949.3754728,
+    "mtime": 1782540714.622885,
     "ast_hash": "2bf9ff6704809d4685a9b285f3feff6b",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/surefire-testng-bootstrap-validation-after-pr2947.md": {
-    "mtime": 1782538948.7336614,
+    "mtime": 1782540713.7953382,
     "ast_hash": "e6782b8247772991081386a66f9a7e36",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/use-memory-and-graphify-through-cli-in-codex.md": {
-    "mtime": 1782538948.7356634,
+    "mtime": 1782540713.797344,
     "ast_hash": "e251c9a4a352674f9088647ddf3b1478",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/delegate-when-unable.json": {
-    "mtime": 1782538948.6846619,
+    "mtime": 1782540713.7369266,
     "ast_hash": "07b7ba8f381ec4cc14777d7ac55c9e78",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/delegate-when-unable.md": {
-    "mtime": 1782538948.6846619,
+    "mtime": 1782540713.7369266,
     "ast_hash": "c593eb7cd55c53cb9369998a0173f6d5",
     "semantic_hash": ""
   },
   "shaft-browserstack/src/test/java/com/shaft/integration/browserstack/BrowserStackModuleTest.java": {
-    "mtime": 1782538948.8589656,
+    "mtime": 1782540713.9646406,
     "ast_hash": "1b4f4b227bd1f4fa0f362a15c970a8d5",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/cli/CaptureCliTest.java": {
-    "mtime": 1782538948.8930612,
+    "mtime": 1782540714.0060885,
     "ast_hash": "cb0124fcb58676542f14eb61f60dc874",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/collector/CaptureCollectorUtilityTest.java": {
-    "mtime": 1782538948.8940656,
+    "mtime": 1782540714.0070896,
     "ast_hash": "aafe9ad32e00bfaa8447cc2f3f006a9d",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/control/CaptureControlFilesTest.java": {
-    "mtime": 1782538948.8950634,
+    "mtime": 1782540714.0080893,
     "ast_hash": "7531aa93c2d32105644864a1e152c070",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/control/CaptureControlServerClientTest.java": {
-    "mtime": 1782538948.8950634,
+    "mtime": 1782540714.0080893,
     "ast_hash": "c64a81e01083fbb8214913c60a910a80",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureManagerLifecycleTest.java": {
-    "mtime": 1782538948.9000628,
+    "mtime": 1782540714.0171947,
     "ast_hash": "848dbc7ec058d8787c4e36506f75dc3c",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpNoDriverServiceTest.java": {
-    "mtime": 1782538950.2322676,
+    "mtime": 1782540715.7047818,
     "ast_hash": "eb49f23fde252c361ff9cae194f9d52a",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpResultRecordsTest.java": {
-    "mtime": 1782538950.2332687,
+    "mtime": 1782540715.7054155,
     "ast_hash": "29c8c0b77c7458ee2ff5092bb54d82ba",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpServiceHelperTest.java": {
-    "mtime": 1782538950.235271,
+    "mtime": 1782540715.7057886,
     "ast_hash": "067f1647636d500429d01c8469ada10e",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/MobileServiceConfigurationTest.java": {
-    "mtime": 1782538950.2372684,
+    "mtime": 1782540715.706788,
     "ast_hash": "66e2b61a1f6b5a9bbd36168990a7e8d8",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiValueObjectsTest.java": {
-    "mtime": 1782538950.2834804,
+    "mtime": 1782540715.762586,
     "ast_hash": "a16fbefe28c40b65f9c55f41c0ba9e98",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/config/ProviderConfigurationTest.java": {
-    "mtime": 1782538950.2854807,
+    "mtime": 1782540715.7646172,
     "ast_hash": "70d00166ef741dd25140bb1036308a87",
     "semantic_hash": ""
   },
   "shaft-pilot-core/src/test/java/com/shaft/pilot/json/JsonSchemaValidatorTest.java": {
-    "mtime": 1782538950.2864807,
+    "mtime": 1782540715.765325,
     "ast_hash": "2fd93ff273c685e80b68615e7dd0a1ba",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/element-actions-normalize-allure-locator-metadata.json": {
-    "mtime": 1782538948.685663,
+    "mtime": 1782540713.7379284,
     "ast_hash": "c4534782cf2b7fccd3489053bb267f1d",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/element-actions-normalize-allure-locator-metadata.md": {
-    "mtime": 1782538948.685663,
+    "mtime": 1782540713.7379284,
     "ast_hash": "ad0b39840f727ef91570221e283b668c",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/run-local-validation-without-opening-reports.json": {
-    "mtime": 1782538948.7296636,
+    "mtime": 1782540713.790824,
     "ast_hash": "15d81102c128be197dc774dfdfc4ff37",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/JunitExtension.java": {
-    "mtime": 1782538949.0324116,
+    "mtime": 1782540714.172595,
     "ast_hash": "f874789a9d64aaf70df45f5c56ba261a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/ExecutionCountsTracker.java": {
-    "mtime": 1782538949.0364125,
+    "mtime": 1782540714.176689,
     "ast_hash": "ca195dba6330c14afb2e1f42c85be2d6",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/ExecutionFailureContext.java": {
-    "mtime": 1782538949.0374124,
+    "mtime": 1782540714.177686,
     "ast_hash": "713f781253d014b50ab39c2d5e3dff20",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/ExecutionLifecycleHelper.java": {
-    "mtime": 1782538949.0374124,
+    "mtime": 1782540714.177686,
     "ast_hash": "cab481402d02eddd743805c911080712",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/listeners/internal/TestExecutionInfo.java": {
-    "mtime": 1782538949.0394115,
+    "mtime": 1782540714.1806877,
     "ast_hash": "4dc45054b39710f3e47d2c2dd511d0be",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportContext.java": {
-    "mtime": 1782538949.0809278,
+    "mtime": 1782540714.249396,
     "ast_hash": "2ae3267e31eb1bb32289daeac90a9716",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/validation/internal/AssertionFailureFormatter.java": {
-    "mtime": 1782538949.0859282,
+    "mtime": 1782540714.2627106,
     "ast_hash": "93f73d44c5ada84c4d39cb3c8d02e6ad",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitApiSmokeTest.java": {
-    "mtime": 1782538949.392473,
+    "mtime": 1782540714.6475084,
     "ast_hash": "7f1c4d2d140d35d6dab9ffb286095937",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitCoreAssertionDependencyGuardTest.java": {
-    "mtime": 1782538949.392473,
+    "mtime": 1782540714.6475084,
     "ast_hash": "6fdc9b27e9c39b43169a4187d2540f89",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitCoreAssertionMigrationTest.java": {
-    "mtime": 1782538949.3934736,
+    "mtime": 1782540714.6485078,
     "ast_hash": "60e0a7f567ab6e030106b5cdd4e86f4c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitDatabaseSmokeTest.java": {
-    "mtime": 1782538949.3934736,
+    "mtime": 1782540714.6495075,
     "ast_hash": "6914346d28a229d411da8e85825e73d9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitProjectStructureManagerTest.java": {
-    "mtime": 1782538949.3944724,
+    "mtime": 1782540714.650508,
     "ast_hash": "42fc75d8ff6752aff87a5c0509af87d6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitReportContextTest.java": {
-    "mtime": 1782538949.3954718,
+    "mtime": 1782540714.6515086,
     "ast_hash": "31a71b30583f9afa0bf0022084a390a1",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/junitTestPackage/JunitWebGuiSmokeTest.java": {
-    "mtime": 1782538949.3964725,
+    "mtime": 1782540714.6525068,
     "ast_hash": "1d9608b8cc22fe144bb55acffca129de",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/run-local-validation-without-opening-reports.md": {
-    "mtime": 1782538948.7306628,
+    "mtime": 1782540713.7918253,
     "ast_hash": "3bc1e6a92cc0abd9587fbef7f1b389b7",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureWorkbenchHtml.java": {
-    "mtime": 1782538948.8750625,
+    "mtime": 1782540713.9855163,
     "ast_hash": "dd99ee7b3a8388fbf237e8dab5b7bdda",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CodegenFeatureCatalog.java": {
-    "mtime": 1782539890.074658,
+    "mtime": 1782540713.9855163,
     "ast_hash": "0ff87a387643b4ea8ac1060b273eb559",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureStartOptions.java": {
-    "mtime": 1782538948.8860621,
+    "mtime": 1782540713.9981792,
     "ast_hash": "08bdd33c70c75a9c693eae92d4e613af",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderControlTest.java": {
-    "mtime": 1782538948.9020643,
+    "mtime": 1782540714.0191958,
     "ast_hash": "93adf57550a29b8c7f4ed7e4f1d1c1a6",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/use-official-docs-search-index-for-shaft-mcp-guide-search.json": {
-    "mtime": 1782538948.6946633,
+    "mtime": 1782540713.7539303,
     "ast_hash": "0f6b8cc0ea6f5f8ef37b0c0c2ab043f6",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelperNewPatternCoverageUnitTest.java": {
-    "mtime": 1782538949.3884728,
+    "mtime": 1782540714.6429942,
     "ast_hash": "c98119a9f1a96e8fb4dd7f72ed70d11d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/GuideService.java": {
-    "mtime": 1782538950.188268,
+    "mtime": 1782540715.6416335,
     "ast_hash": "c2b2a7d31dd0c42a0c11b578785f4a22",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/HealerService.java": {
-    "mtime": 1782538950.1892715,
+    "mtime": 1782540715.6416335,
     "ast_hash": "b47a582f8b342bc3d3fdbf6d6c054b6c",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpGuideMatch.java": {
-    "mtime": 1782538950.1972675,
+    "mtime": 1782540715.6575236,
     "ast_hash": "e594a2f11a16113954bbf865aec5dc04",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpGuideSearchResult.java": {
-    "mtime": 1782538950.1982682,
+    "mtime": 1782540715.6585205,
     "ast_hash": "7c67b9c8caa6eb0e292f3cf578a26ec4",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpHealerAttemptResult.java": {
-    "mtime": 1782538950.1982682,
+    "mtime": 1782540715.6595151,
     "ast_hash": "ae920e7e3a41435e15a8065dfa005012",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpHealerRunResult.java": {
-    "mtime": 1782538950.1992674,
+    "mtime": 1782540715.6605167,
     "ast_hash": "053e897a9732fd3a4bd32f64ce7bc67a",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/GuideServiceTest.java": {
-    "mtime": 1782538950.2272718,
+    "mtime": 1782540715.7007606,
     "ast_hash": "18508bf8f31805be0dc13aed25dde251",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/HealerServiceTest.java": {
-    "mtime": 1782538950.2292676,
+    "mtime": 1782540715.7017684,
     "ast_hash": "99ca3e342a4e3327469eedfaeaab1ac4",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/use-official-docs-search-index-for-shaft-mcp-guide-search.md": {
-    "mtime": 1782538948.6956632,
+    "mtime": 1782540713.7544599,
     "ast_hash": "3ef2a346dc83ce9efb7c84684d1122ff",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/NetworkInterceptionRequestBuilder.java": {
-    "mtime": 1782538948.978412,
+    "mtime": 1782540714.1040244,
     "ast_hash": "b86818b00a3065ca48701567a1317112",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserNetworkInterceptionRule.java": {
-    "mtime": 1782538948.9814146,
+    "mtime": 1782540714.1051874,
     "ast_hash": "5d5037cd2ee0dddd957a7cbbad537ce8",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserNetworkInterceptor.java": {
-    "mtime": 1782538948.9814146,
+    "mtime": 1782540714.1062286,
     "ast_hash": "6e653ada7aabf17dc7859bad88323b64",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/prefer-shaft-api-builder-facade-for-rest-work.json": {
-    "mtime": 1782538948.691662,
+    "mtime": 1782540713.7504218,
     "ast_hash": "6c5f689fe277f7670d815e22bb7a6fdf",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpAndroidEmulatorProposal.java": {
-    "mtime": 1782538950.1912684,
+    "mtime": 1782540715.644174,
     "ast_hash": "c7c477a347aff6fa27cec866efffb105",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpAppiumCommandRecorder.java": {
-    "mtime": 1782538950.1912684,
+    "mtime": 1782540715.644689,
     "ast_hash": "83ee39e10ac7764d6353da3484b07ac4",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpAppiumInspectorProxy.java": {
-    "mtime": 1782538950.1922686,
+    "mtime": 1782540715.6456957,
     "ast_hash": "744bb07cd2ef7335f6b1004c193efc13",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileCode.java": {
-    "mtime": 1782538950.2002676,
+    "mtime": 1782540715.6640337,
     "ast_hash": "84fa9fe33b12aa2b45a47c4c02901b49",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileDevice.java": {
-    "mtime": 1782538950.2012672,
+    "mtime": 1782540715.6652725,
     "ast_hash": "95ab5c7a8108a17cc4b795be825ca465",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInspectorPlan.java": {
-    "mtime": 1782538950.2012672,
+    "mtime": 1782540715.6665611,
     "ast_hash": "e12fc9a2d07a08597ec6bf1400658e16",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInspectorRecordingService.java": {
-    "mtime": 1782538950.2022705,
+    "mtime": 1782540715.6665611,
     "ast_hash": "756fff2b3865bf7cd73eeacdb4edcc40",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInspectorRecordingStatus.java": {
-    "mtime": 1782538950.2022705,
+    "mtime": 1782540715.66756,
     "ast_hash": "b5e65cd7d3d46e313d788ae3bd017617",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainService.java": {
-    "mtime": 1782538950.2072685,
+    "mtime": 1782540715.6725671,
     "ast_hash": "620a83d2cfbb35eaf8cf1ddb848a3fe5",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainStatus.java": {
-    "mtime": 1782538950.2072685,
+    "mtime": 1782540715.6725671,
     "ast_hash": "14c3c586d9e84bef7eca75197de48e83",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpProcessRunner.java": {
-    "mtime": 1782538950.2092676,
+    "mtime": 1782540715.675601,
     "ast_hash": "c2fbbd25f86523263ea6ee980a280f79",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpAppiumCommandRecorderTest.java": {
-    "mtime": 1782538950.2292676,
+    "mtime": 1782540715.7017684,
     "ast_hash": "193aea409a6adf4968070c82ac9a575d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpMobileInspectorRecordingServiceTest.java": {
-    "mtime": 1782538950.2302692,
+    "mtime": 1782540715.703767,
     "ast_hash": "3eea484093358921928027a7efeabb9e",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpMobileToolchainServiceTest.java": {
-    "mtime": 1782538950.2322676,
+    "mtime": 1782540715.7042768,
     "ast_hash": "0be311e4c93392ece2f42dbc7ae5ef4a",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/prefer-shaft-api-builder-facade-for-rest-work.md": {
-    "mtime": 1782538948.691662,
+    "mtime": 1782540713.7504218,
     "ast_hash": "1e26526229bf60c93d0d4a1302628d55",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/graphify-updates-use-installed-cli-subcommands.json": {
-    "mtime": 1782538948.7036617,
+    "mtime": 1782540713.761469,
     "ast_hash": "3777cfe2bfe0c47a8179ecf78953affc",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/memory-saves-use-intent-first-json-on-stdin.json": {
-    "mtime": 1782538948.7056623,
+    "mtime": 1782540713.7624688,
     "ast_hash": "09006716c9b359bb2c0a5376fe86d6b4",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCodeGuardrailResult.java": {
-    "mtime": 1782538950.1952686,
+    "mtime": 1782540715.6486962,
     "ast_hash": "54ee97ffb919ff90d02c8897f95b2322",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCodeGuardrailViolation.java": {
-    "mtime": 1782538950.1952686,
+    "mtime": 1782540715.6496964,
     "ast_hash": "7c8ee205d8b5b7883c0975f388f0ebfb",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpScenarioCatalogResult.java": {
-    "mtime": 1782538950.211271,
+    "mtime": 1782540715.6786003,
     "ast_hash": "c32b97f036cfd501afe6d92133a405b4",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpTestAutomationScenario.java": {
-    "mtime": 1782538950.211271,
+    "mtime": 1782540715.6806026,
     "ast_hash": "b7cb78f776b05d338755f7eea2b17463",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/TestAutomationService.java": {
-    "mtime": 1782538950.2162676,
+    "mtime": 1782540715.6884327,
     "ast_hash": "b01c05194b17664b00a8b3448c28bbc8",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/TestAutomationServiceTest.java": {
-    "mtime": 1782538950.2402673,
+    "mtime": 1782540715.70879,
     "ast_hash": "bf37bb6c5c78ffc1321f11308bcc414c",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/graphify-updates-use-installed-cli-subcommands.md": {
-    "mtime": 1782538948.7046616,
+    "mtime": 1782540713.761469,
     "ast_hash": "019a7f4d72491d045dd5b85ed6c9a0bc",
     "semantic_hash": ""
   },
   ".memory/memory/gotchas/memory-saves-use-intent-first-json-on-stdin.md": {
-    "mtime": 1782538948.7066615,
+    "mtime": 1782540713.7624688,
     "ast_hash": "1af84800821947fd0ed9d3998cd81d34",
     "semantic_hash": ""
   },
   ".memory/memory/facts/mcp-test-automation-scenario-catalog.json": {
-    "mtime": 1782538948.6996615,
+    "mtime": 1782540713.758468,
     "ast_hash": "b69ee2103915fbfbf63a6b84e7ea7cb4",
     "semantic_hash": ""
   },
   ".memory/memory/facts/mcp-test-automation-scenario-catalog.md": {
-    "mtime": 1782538948.700662,
+    "mtime": 1782540713.758468,
     "ast_hash": "d5b6dadc1f57217744225be57c50dcd8",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/BrowserAssertions.java": {
-    "mtime": 1782538948.9864125,
+    "mtime": 1782540714.109228,
     "ast_hash": "b4726dd624bfff061eed882a42302cd1",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/DriverAssertions.java": {
-    "mtime": 1782538948.9874122,
+    "mtime": 1782540714.109228,
     "ast_hash": "d36427b7494516943c576a3be5a3b835",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/DriverVerifications.java": {
-    "mtime": 1782538948.9874122,
+    "mtime": 1782540714.1107345,
     "ast_hash": "3e5ab02944577b455432aa6428a6de83",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/ElementAssertions.java": {
-    "mtime": 1782538948.9884121,
+    "mtime": 1782540714.1117423,
     "ast_hash": "b7023bb7c5a5e8c4ede970cedec1f658",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/ShaftLocator.java": {
-    "mtime": 1782538948.9894118,
+    "mtime": 1782540714.1127415,
     "ast_hash": "288258c16fbeb6c7685c7c07f1864c7c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/browser/BrowserActions.java": {
-    "mtime": 1782538949.021412,
+    "mtime": 1782540714.15855,
     "ast_hash": "0d7096fded3b8cfe9063d337cd8c6f0f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/element/AlertActions.java": {
-    "mtime": 1782538949.0224118,
+    "mtime": 1782540714.1605625,
     "ast_hash": "fef3e09be9ac657711933a837b50ab7b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/element/ElementActions.java": {
-    "mtime": 1782538949.0234132,
+    "mtime": 1782540714.1615644,
     "ast_hash": "b211eeff2aa63b94465c57b783eb008d",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSession.java": {
-    "mtime": 1782538949.0244133,
+    "mtime": 1782540714.1630824,
     "ast_hash": "a834f2fb9fc40a6c472b47e2c8d67257",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSessionFactory.java": {
-    "mtime": 1782538949.0254114,
+    "mtime": 1782540714.1645873,
     "ast_hash": "3814686ba83cf9db8028599f03a98aa2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSessionManager.java": {
-    "mtime": 1782538949.0254114,
+    "mtime": 1782540714.165342,
     "ast_hash": "e6a93da7a78633257ba11063eb38de16",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightTraceManager.java": {
-    "mtime": 1782538949.0264108,
+    "mtime": 1782540714.165342,
     "ast_hash": "6475596d52a3b2ea3316f94b5f90c5c0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightBrowserValidationsBuilder.java": {
-    "mtime": 1782538949.0274203,
+    "mtime": 1782540714.1665967,
     "ast_hash": "45d289f3218bfe3c37216172b9d25551",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightDriverAssertions.java": {
-    "mtime": 1782538949.0284126,
+    "mtime": 1782540714.167595,
     "ast_hash": "aa1a8b02b65be2902eefa6a73a442468",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightDriverVerifications.java": {
-    "mtime": 1782538949.0284126,
+    "mtime": 1782540714.167595,
     "ast_hash": "10f477a754e6e569d3fc2352f603a64f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightElementValidationsBuilder.java": {
-    "mtime": 1782538949.0294116,
+    "mtime": 1782540714.1685944,
     "ast_hash": "cbed8cd855cf7132f98d80e3deccf14e",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Playwright.java": {
-    "mtime": 1782538949.0534132,
+    "mtime": 1782540714.208678,
     "ast_hash": "98c4cd280789a493e2cc63fc112d8b4d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/natural/DeterministicNaturalActionPlannerTest.java": {
-    "mtime": 1782538949.3621864,
+    "mtime": 1782540714.6073325,
     "ast_hash": "a090df735279f758b04583c539c80cd9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/GUIInterfaceCompatibilityCoverageUnitTest.java": {
-    "mtime": 1782538949.49699,
+    "mtime": 1782540714.8055499,
     "ast_hash": "a11d2c0437461819d815b6bada986ee9",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/delegate-broadly-to-spark.json": {
-    "mtime": 1782538948.6806617,
+    "mtime": 1782540713.7318106,
     "ast_hash": "064879ac7229a1eeeb1646bf93fb6140",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/use-override-annotations.json": {
-    "mtime": 1782538948.6966624,
+    "mtime": 1782540713.7544599,
     "ast_hash": "977907829a63b92ea89922f1550c2c7e",
     "semantic_hash": ""
   },
   ".memory/memory/constraints/delegate-broadly-to-spark.md": {
-    "mtime": 1782538948.6806617,
+    "mtime": 1782540713.7328103,
     "ast_hash": "cce72bac4ae644a5bcf286e117c6fb90",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/use-override-annotations.md": {
-    "mtime": 1782538948.6966624,
+    "mtime": 1782540713.7554681,
     "ast_hash": "d7a5198a2f5eb752cee7fc2fad6b545b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/AlertActionsContract.java": {
-    "mtime": 1782538948.985413,
+    "mtime": 1782540714.108229,
     "ast_hash": "0f7aa759db4842f82d61b19dfa68301a",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/BrowserActionsContract.java": {
-    "mtime": 1782538948.9864125,
+    "mtime": 1782540714.109228,
     "ast_hash": "0dff6d639b46790f8751a6f0bfa843d8",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/ElementActionsContract.java": {
-    "mtime": 1782538948.9884121,
+    "mtime": 1782540714.1117423,
     "ast_hash": "c0254142e8a4ee94e8d439d10853e0f1",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/gui-driver-facade-alias.json": {
-    "mtime": 1782538948.6866627,
+    "mtime": 1782540713.7389271,
     "ast_hash": "112ffef31b2e7dcb5a67b10e4f252bcb",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/playwright-entrypoint-casing.json": {
-    "mtime": 1782538948.6906621,
+    "mtime": 1782540713.7494204,
     "ast_hash": "faaf90924ddd4bfa4d6d5ddf68f8a956",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/driver/DriverContract.java": {
-    "mtime": 1782538948.9874122,
+    "mtime": 1782540714.1107345,
     "ast_hash": "4c8a0740e8dadf4b4ea33022614f731c",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/gui-driver-facade-alias.md": {
-    "mtime": 1782538948.687662,
+    "mtime": 1782540713.7389271,
     "ast_hash": "1d08f73622a67f46dd47f80a88936c27",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/playwright-entrypoint-casing.md": {
-    "mtime": 1782538948.6906621,
+    "mtime": 1782540713.7494204,
     "ast_hash": "c02315cea77a741aa8857863c3ae432a",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/keep-shaft-mcp-webdriver-default-with-opt-in-playwright-tools.json": {
-    "mtime": 1782538948.6886616,
+    "mtime": 1782540713.7471929,
     "ast_hash": "5fa44d4831d7aa7b8e7ef2eb5bb9faa9",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightDeviceDescriptor.java": {
-    "mtime": 1782538949.0234132,
+    "mtime": 1782540714.1620734,
     "ast_hash": "67c0996090cdbbda2d949a57a8c3db07",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/playwright/internal/PlaywrightDeviceDescriptorTest.java": {
-    "mtime": 1782538949.3691845,
+    "mtime": 1782540714.615031,
     "ast_hash": "08d00d520b346162b36ac4c36ba1bd88",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/ChromePlaywrightActionsE2ETest.java": {
-    "mtime": 1782538949.4564784,
+    "mtime": 1782540714.7439995,
     "ast_hash": "aa83f62d13d9b32c804f9669207c5e13",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/EdgePlaywrightActionsE2ETest.java": {
-    "mtime": 1782538949.4564784,
+    "mtime": 1782540714.7445164,
     "ast_hash": "ed3fad31e9488da5adfaf259443d8ede",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/FirefoxPlaywrightActionsE2ETest.java": {
-    "mtime": 1782538949.4574792,
+    "mtime": 1782540714.7451513,
     "ast_hash": "bcbdf4bb9f4467776b4d3463a8c7951c",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/GalaxyS26UltraPlaywrightActionsE2ETest.java": {
-    "mtime": 1782538949.4574792,
+    "mtime": 1782540714.7455242,
     "ast_hash": "4a474a6aa1007ba5af607d82b71831cc",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/IPhone17ProMaxPlaywrightActionsE2ETest.java": {
-    "mtime": 1782538949.4574792,
+    "mtime": 1782540714.7455242,
     "ast_hash": "8d331269ccb27a6b7e064ea85bf7990d",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/PlaywrightActionsE2ETestBase.java": {
-    "mtime": 1782538949.4584792,
+    "mtime": 1782540714.7465224,
     "ast_hash": "7f8415867f52f4e848568a3c9f935860",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/PlaywrightMobileWebE2ETestBase.java": {
-    "mtime": 1782538949.4584792,
+    "mtime": 1782540714.7465224,
     "ast_hash": "3f68d06f2c61c24f184c5b17baab7054",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/playwright/WebKitPlaywrightActionsE2ETest.java": {
-    "mtime": 1782538949.4594784,
+    "mtime": 1782540714.7475224,
     "ast_hash": "f3d37b40410e79d9e42714583965241b",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpPlaywrightRecordingService.java": {
-    "mtime": 1782538950.2092676,
+    "mtime": 1782540715.6745918,
     "ast_hash": "4a4d95b97c572ad3433ceebc3bc02d3b",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/PlaywrightService.java": {
-    "mtime": 1782538950.2142682,
+    "mtime": 1782540715.6826007,
     "ast_hash": "9f62abbb4a18edf9103d71503468d98d",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/PlaywrightServiceTest.java": {
-    "mtime": 1782538950.2382703,
+    "mtime": 1782540715.7077918,
     "ast_hash": "83323568e4bc8f319bea7e387d498f3b",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/keep-shaft-mcp-webdriver-default-with-opt-in-playwright-tools.md": {
-    "mtime": 1782538948.6896617,
+    "mtime": 1782540713.7471929,
     "ast_hash": "950eec0b85d5d4997e4760869b654fe5",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/resources/testDataFiles/mobileViewportFixture.html": {
-    "mtime": 1782538950.1232457,
+    "mtime": 1782540715.5561545,
     "ast_hash": "8077d707d3ea303dbb6c342debf4d056",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightNativeValidationsBuilder.java": {
-    "mtime": 1782538949.0294116,
+    "mtime": 1782540714.1695948,
     "ast_hash": "24fe26210c4236f7eb3ca4da2592a314",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightValidationsExecutor.java": {
-    "mtime": 1782538949.0304122,
+    "mtime": 1782540714.1705978,
     "ast_hash": "c6c0e7de7fda83abfddf1f1d0ab67901",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_documentation_boundaries.py": {
-    "mtime": 1782538950.3414812,
+    "mtime": 1782540715.8186374,
     "ast_hash": "931d4c107349f89419e24eb8a54bc12a",
     "semantic_hash": ""
   },
   "tests/scripts/test_validate_shaft_mcp_configuration.py": {
-    "mtime": 1782538950.3454878,
+    "mtime": 1782540715.8267288,
     "ast_hash": "595a0f83f71c9019bd43f91982ee7ec0",
     "semantic_hash": ""
   },
   ".agents/skills/shaft-marketing-ad-producer/SKILL.md": {
-    "mtime": 1782538948.6321423,
+    "mtime": 1782540713.6608653,
     "ast_hash": "85e6b59cd7192b33185172d1e2737e3a",
     "semantic_hash": ""
   },
   ".agents/skills/shaft-marketing-ad-producer/agents/openai.yaml": {
-    "mtime": 1782538948.6331418,
+    "mtime": 1782540713.662869,
     "ast_hash": "5e1f289ca493111b43c4b5fb5c149083",
     "semantic_hash": ""
   },
   ".codex/superpowers/plans/2026-06-23-stability-first-mcp-engine-implementation.txt": {
-    "mtime": 1782538948.6351395,
+    "mtime": 1782540713.6663878,
     "ast_hash": "767575f3fdfbc71c447912068f5506ef",
     "semantic_hash": ""
   },
   ".codex/superpowers/specs/2026-06-23-stability-first-mcp-engine-design.txt": {
-    "mtime": 1782538948.6361408,
+    "mtime": 1782540713.6673884,
     "ast_hash": "bd7f87426277e00520d3fbbbb4eda3d1",
     "semantic_hash": ""
   },
   ".github/skills/shaft-marketing-ad-producer/SKILL.md": {
-    "mtime": 1782538948.6651483,
+    "mtime": 1782540713.706515,
     "ast_hash": "35e3e4692f2e57fe41eaf6b7239d28c6",
     "semantic_hash": ""
   },
   ".github/workflows/README.md": {
-    "mtime": 1782538948.6661465,
+    "mtime": 1782540713.7147474,
     "ast_hash": "c6956e8a0cc38af6f8800ff3b36ca3b5",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft_standard.png": {
-    "mtime": 1782538949.31818,
+    "mtime": 1782540714.552445,
     "ast_hash": "5df1ce58218a4bae2d031b7faa043c03",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/do-not-wait-for-ci-unless-explicitly-requested.json": {
-    "mtime": 1782538948.7196622,
+    "mtime": 1782540713.7796183,
     "ast_hash": "e50b709e98cdd4c0a3a3af527af6d24e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/listeners/JunitExtensionLifecycleTest.java": {
-    "mtime": 1782538949.371473,
+    "mtime": 1782540714.6173604,
     "ast_hash": "0de70d5f4d6de487210dcfaad895f5f6",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/do-not-wait-for-ci-unless-explicitly-requested.md": {
-    "mtime": 1782538948.7206616,
+    "mtime": 1782540713.78053,
     "ast_hash": "080b95f36a86f347d063dbaf3df05bed",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/talk-less-outside-planning.json": {
-    "mtime": 1782538948.693666,
+    "mtime": 1782540713.7524211,
     "ast_hash": "347efbcab49046c0b2e1954ab867a9d8",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsPlaywrightVisualTest.java": {
-    "mtime": 1782538949.3561857,
+    "mtime": 1782540714.6018207,
     "ast_hash": "cf497152d7890a07d978712aee364d85",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/playwright/validation/PlaywrightElementVisualValidationTest.java": {
-    "mtime": 1782538949.3704746,
+    "mtime": 1782540714.6153593,
     "ast_hash": "bc4649c93d093c2a601e8f7f6cc26568",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainDiagnostic.java": {
-    "mtime": 1782538950.2062697,
+    "mtime": 1782540715.6715672,
     "ast_hash": "439cee60e23d196ca8026950a7c498c3",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpCaptureCodeBlockServiceTest.java": {
-    "mtime": 1782538950.2302692,
+    "mtime": 1782540715.7027676,
     "ast_hash": "8e633fbf2210bc193b6d3b8e22aa3baa",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/talk-less-outside-planning.md": {
-    "mtime": 1782538948.6946633,
+    "mtime": 1782540713.7524211,
     "ast_hash": "5415bf34405c6f4d13a76060ed778328",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/RemoteGridPreflight.java": {
-    "mtime": 1782538948.9714124,
+    "mtime": 1782540714.098515,
     "ast_hash": "76b2a413fa9d60ce891121d6ce49e1de",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/RemoteGridPreflightUnitTest.java": {
-    "mtime": 1782538949.3441799,
+    "mtime": 1782540714.5844572,
     "ast_hash": "8c86158cab9438008c9ecfa8f76fe1fa",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/internal/OpenApiCoverageReporter.java": {
-    "mtime": 1782538948.9560666,
+    "mtime": 1782540714.0778108,
     "ast_hash": "1346bcb62d2558db35ce9b880108305e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/internal/OpenApiCoverageReporterUnitTest.java": {
-    "mtime": 1782538949.3371797,
+    "mtime": 1782540714.5784295,
     "ast_hash": "568aa0017a286bb0ede8194b19217519",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/LocatorHealthReporter.java": {
-    "mtime": 1782538949.010415,
+    "mtime": 1782540714.1396523,
     "ast_hash": "c37ac816ea3749b57dd1237cd5814635",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/locator/LocatorHealthReporterUnitTest.java": {
-    "mtime": 1782538949.3611856,
+    "mtime": 1782540714.6063402,
     "ast_hash": "564b849ae9fc72c8c0e60ff66ee29cf0",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/ExecutionLifecycleHelperSourceUnitTest.java": {
-    "mtime": 1782538949.49299,
+    "mtime": 1782540714.8005762,
     "ast_hash": "64397aafb905ef4ae1defd73a4016e30",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsReportingUnitTest.java": {
-    "mtime": 1782538949.3571842,
+    "mtime": 1782540714.6028223,
     "ast_hash": "a67ef8c418bf9b0a4c50e180c95d2eec",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft_report_logo.png": {
-    "mtime": 1782538949.3171816,
+    "mtime": 1782540714.551443,
     "ast_hash": "987c93b372f4f797f601da520d349930",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureTraceReporter.java": {
-    "mtime": 1782538949.0759275,
+    "mtime": 1782540714.244389,
     "ast_hash": "2561ad0c47ea32be88544bf53fc962f1",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/FailureTraceReporterTest.java": {
-    "mtime": 1782538949.3834727,
+    "mtime": 1782540714.6364663,
     "ast_hash": "8757e6f869d616e2924133d4638d00e2",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureDiagnosticsReporter.java": {
-    "mtime": 1782538949.0749283,
+    "mtime": 1782540714.2428834,
     "ast_hash": "b42398cb7bca0a1f3068b9bb05551522",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/FailureDiagnosticsReporterTest.java": {
-    "mtime": 1782538949.3834727,
+    "mtime": 1782540714.6354647,
     "ast_hash": "0ae1c9f864ba886cbb1d9121238104c5",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/PlaywrightNetworkInterceptor.java": {
-    "mtime": 1782538948.9844117,
+    "mtime": 1782540714.108229,
     "ast_hash": "2b2528ad42b96617d91cef7b115e52fe",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/PlaywrightNaturalActionExecutor.java": {
-    "mtime": 1782538949.0194123,
+    "mtime": 1782540714.1545331,
     "ast_hash": "580e7a8e63d84599ad544362d069fe47",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/BrowserPerformanceExecutionReport.java": {
-    "mtime": 1782538949.0719283,
+    "mtime": 1782540714.2388444,
     "ast_hash": "27fd41afe4922143f302befa056e0261",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/api/RequestBuilderPerformanceTest.java": {
-    "mtime": 1782538949.3331802,
+    "mtime": 1782540714.5750387,
     "ast_hash": "2191ebf4bdd2e8e7196f0250ebdf30d9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/browser/internal/PlaywrightNetworkInterceptorTest.java": {
-    "mtime": 1782538949.346179,
+    "mtime": 1782540714.5874698,
     "ast_hash": "108dbc96ba77bae8a5522dd0fa9b8bde",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/internal/natural/PlaywrightNaturalActionExecutorTest.java": {
-    "mtime": 1782538949.364185,
+    "mtime": 1782540714.6083343,
     "ast_hash": "224a7cea785bb42c47501ecd2e056ecb",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/playwright/browser/PlaywrightBrowserActionsUnitTest.java": {
-    "mtime": 1782538949.3681843,
+    "mtime": 1782540714.613846,
     "ast_hash": "501d45447f122f7bb84022f904af07fb",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/ApiPerformanceExecutionReportUnitTest.java": {
-    "mtime": 1782538949.3814726,
+    "mtime": 1782540714.6339355,
     "ast_hash": "311fd5bb521db68d59ba8607c62182a5",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/BrowserPerformanceExecutionReportUnitTest.java": {
-    "mtime": 1782538949.3814726,
+    "mtime": 1782540714.6344583,
     "ast_hash": "0f3fbd2ea9a130612a003f801217daec",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/locator/CompositeLocator.java": {
-    "mtime": 1782538949.008413,
+    "mtime": 1782540714.1376522,
     "ast_hash": "d77b647548e25d65efcd1bbf7c6acdea",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/internal/natural/NaturalActionCompositeLocator.java": {
-    "mtime": 1782538949.015412,
+    "mtime": 1782540714.144673,
     "ast_hash": "f62837ef7588732dc6655fbadc781d43",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureBriefReporter.java": {
-    "mtime": 1782538949.073928,
+    "mtime": 1782540714.2418828,
     "ast_hash": "ce5dad3367dd60bf4087df437cebbbf9",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/FailureBriefReporterTest.java": {
-    "mtime": 1782538949.382473,
+    "mtime": 1782540714.6354647,
     "ast_hash": "a8fbe7d193de3d1c3890f762401d28f5",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/api/RetryPolicy.java": {
-    "mtime": 1782538948.9550653,
+    "mtime": 1782540714.0768108,
     "ast_hash": "9858ba53964a3a12369d1472ef8ed15b",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/FlakeProfiler.java": {
-    "mtime": 1782538949.0769296,
+    "mtime": 1782540714.244389,
     "ast_hash": "701c99c161e0c13b8b12539955fb4f51",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/FlakeProfilerUnitTest.java": {
-    "mtime": 1782538949.3844721,
+    "mtime": 1782540714.6374655,
     "ast_hash": "645d841d129c061cb7f862a8d09b56cc",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/testPackage/unitTests/PropertiesHelperEvidenceLevelUnitTest.java": {
-    "mtime": 1782538949.5079896,
+    "mtime": 1782540714.818665,
     "ast_hash": "f01472e56b66ea3645c3f2d0725d7d40",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/include-examples-or-screenshots-in-prs.json": {
-    "mtime": 1782538948.7226624,
+    "mtime": 1782540713.7825396,
     "ast_hash": "cec767873686daec7cd28b6bd61dd7f0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/TraceEventRecorder.java": {
-    "mtime": 1782538949.081929,
+    "mtime": 1782540714.2560384,
     "ast_hash": "33c59a6b5aea025ec9054ef608fc3307",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/include-examples-or-screenshots-in-prs.md": {
-    "mtime": 1782538948.7236617,
+    "mtime": 1782540713.7825396,
     "ast_hash": "f445be3526e0ecc1d8c93ecd8818e673",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionabilityDiagnostics.java": {
-    "mtime": 1782538948.9954152,
+    "mtime": 1782540714.1225743,
     "ast_hash": "7408177624edd24821b01ea3243bacdd",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/element/internal/ElementActionabilityDiagnosticsTest.java": {
-    "mtime": 1782538949.3511798,
+    "mtime": 1782540714.5904686,
     "ast_hash": "4bafb168615164fd5768bc9e05150c4c",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserNetworkProfileManager.java": {
-    "mtime": 1782538948.9824123,
+    "mtime": 1782540714.1062286,
     "ast_hash": "73d20c538670d0558de855a38fbddf83",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserStorageStateManager.java": {
-    "mtime": 1782538948.9834125,
+    "mtime": 1782540714.1072276,
     "ast_hash": "381a5f7dba5d6eecc1857e12ee344e4f",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/BrowserObservabilityRecorder.java": {
-    "mtime": 1782538949.0719283,
+    "mtime": 1782540714.2378416,
     "ast_hash": "50aa9558461b188e595e4b1d07e3fcd4",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/include-concrete-evidence-in-shaft-pr-bodies.json": {
-    "mtime": 1782538948.7206616,
+    "mtime": 1782540713.7815373,
     "ast_hash": "f016cde4de254a63c746a1f706097452",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/MobileTraceMetadata.java": {
-    "mtime": 1782538949.0789278,
+    "mtime": 1782540714.2473958,
     "ast_hash": "84c7ec31787c8850783b52d33933ac52",
     "semantic_hash": ""
   },
   ".memory/memory/workflows/include-concrete-evidence-in-shaft-pr-bodies.md": {
-    "mtime": 1782538948.7216616,
+    "mtime": 1782540713.7815373,
     "ast_hash": "be33dd34e200039f50617556815feb51",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/TraceService.java": {
-    "mtime": 1782538950.2172692,
+    "mtime": 1782540715.6906588,
     "ast_hash": "53aaa0477a571794ce4bcada4a97ca5c",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/TraceServiceTest.java": {
-    "mtime": 1782538950.2412672,
+    "mtime": 1782540715.7097898,
     "ast_hash": "ee065c790c6172158264f47cfea480a0",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/HttpContractRecorder.java": {
-    "mtime": 1782538949.0769296,
+    "mtime": 1782540714.245397,
     "ast_hash": "c070b3dd6255ca756ec87c5d440a1e66",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/gui/browser/internal/HttpContractBrowserReplayTest.java": {
-    "mtime": 1782538949.345181,
+    "mtime": 1782540714.5864677,
     "ast_hash": "5304914e164961c90a36fbce4dde0d3e",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/HttpContractRecorderTest.java": {
-    "mtime": 1782538949.3844721,
+    "mtime": 1782540714.6374655,
     "ast_hash": "0682369fddd4240b68d48daec427cb4c",
     "semantic_hash": ""
   },
   ".github/pr-evidence/ui-revamp/evidence-manifest.json": {
-    "mtime": 1782538948.6481426,
+    "mtime": 1782540713.6874516,
     "ast_hash": "298f067b440605f9d102b915602d14eb",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureReviewFinding.java": {
-    "mtime": 1782538948.8750625,
+    "mtime": 1782540713.9845116,
     "ast_hash": "6a00dd54924a42d8d1b3ec78d278fbbf",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/internal/support/ReportHtmlTheme.java": {
-    "mtime": 1782538949.0644174,
+    "mtime": 1782540714.2287953,
     "ast_hash": "2aaa548ebfd6d45fd496a5b7f9851e16",
     "semantic_hash": ""
   },
   ".github/pr-evidence/ui-revamp/shaft-ui-revamp-mobile.png": {
-    "mtime": 1782538948.6521418,
+    "mtime": 1782540713.692458,
     "ast_hash": "63de743fcf7d30ea42c334010727719a",
     "semantic_hash": ""
   },
   ".github/pr-evidence/ui-revamp/shaft-ui-revamp-side-by-side.png": {
-    "mtime": 1782538948.6601503,
+    "mtime": 1782540713.7004895,
     "ast_hash": "2fc1b0513d9f92525f078bc5334d4234",
     "semantic_hash": ""
   },
   ".agents/skills/shaft-ui-design/SKILL.md": {
-    "mtime": 1782539365.329106,
-    "ast_hash": "4575d2fccf8e955ce786d36e86b0e8b5",
+    "mtime": 1782540713.662869,
+    "ast_hash": "91ba4a711d0c6e19266c47917004d6ea",
     "semantic_hash": ""
   },
   ".agents/skills/shaft-ui-design/agents/openai.yaml": {
-    "mtime": 1782539161.2549214,
-    "ast_hash": "94522d2793425767fe84f6f5230df4c9",
+    "mtime": 1782540713.6638675,
+    "ast_hash": "0d5fac998ee4334388e44059555e5944",
     "semantic_hash": ""
   },
   ".github/skills/shaft-ui-design/SKILL.md": {
-    "mtime": 1782539365.3301053,
-    "ast_hash": "1c7c3e3ca283b3274b4a47d8a6badc86",
+    "mtime": 1782540713.707518,
+    "ast_hash": "5cf87b9e921c89a948ebd3e9e4d8f60e",
     "semantic_hash": ""
   },
   ".github/skills/shaft-ui-design/references/standards.txt": {
-    "mtime": 1782539365.3311057,
-    "ast_hash": "03c1b36ef8cd30bd6820dae4a361d2af",
+    "mtime": 1782540713.712734,
+    "ast_hash": "e0696ad726a96614da58310ecc161295",
     "semantic_hash": ""
   }
 }

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java
@@ -393,7 +393,11 @@ public class AllureManager {
         return newFileName;
     }
 
-    private static void openAllureReport(String newFileName) {
+    private static boolean openAllureReport(String newFileName) {
+        if (!SHAFT.Properties.allure.automaticallyOpen()) {
+            ReportManager.logDiscrete("Allure report automatic opening is disabled.");
+            return false;
+        }
         String reportPath = reportDirectoryPath().resolve(newFileName).toFile().getAbsolutePath();
         if (SystemUtils.IS_OS_WINDOWS) {
             reportPath = reportPath.replace("'", "''");
@@ -405,6 +409,7 @@ public class AllureManager {
         } else {
             internalTerminalSession.performTerminalCommand("xdg-open \"" + reportPath + "\"");
         }
+        return true;
     }
 
     /**

--- a/shaft-engine/src/test/java/testPackage/unitTests/AllureManagerUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/AllureManagerUnitTest.java
@@ -282,6 +282,23 @@ public class AllureManagerUnitTest {
         }
     }
 
+    @Test(description = "openAllureReport should skip the OS opener when automatic opening is disabled")
+    public void openAllureReportShouldRespectAutomaticOpenToggle() throws Exception {
+        Method openAllureReport = AllureManager.class.getDeclaredMethod("openAllureReport", String.class);
+        openAllureReport.setAccessible(true);
+
+        String originalAutomaticallyOpen = String.valueOf(SHAFT.Properties.allure.automaticallyOpen());
+        try {
+            SHAFT.Properties.allure.set().automaticallyOpen(false);
+
+            Object openRequested = openAllureReport.invoke(null, "missing-AllureReport.html");
+
+            SHAFT.Validations.assertThat().object(openRequested).isEqualTo(false).perform();
+        } finally {
+            SHAFT.Properties.allure.set().automaticallyOpen(Boolean.parseBoolean(originalAutomaticallyOpen));
+        }
+    }
+
     @Test(description = "extractSemVerFromText should parse SemVer-like versions and return null when absent")
     public void extractSemVerFromTextShouldParseExpectedPatterns() throws Exception {
         Method extractorMethod = AllureManager.class.getDeclaredMethod("extractSemVerFromText", String.class);


### PR DESCRIPTION
## Description

Fixes SHAFT's post-execution Allure report opener so `allure.automaticallyOpen=false` actually prevents launching the generated report in the OS browser. The root cause was that `AllureManager.openAllureReportAfterExecution()` documented the property, but the final `openAllureReport(...)` helper always executed the platform opener after report generation.

Also records durable workflow memory that PR branches must be rebased/merged with latest `origin/main` and conflicts resolved locally before opening a PR.

## Related Issue(s)

- None

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test coverage improvement
- [x] Documentation/agent workflow memory update

## Pre-Submission Checklist

- [x] I have read the Contributing Guide and this PR follows its guidelines.
- [x] Documentation/agent-only changes pass deterministic validators and `git diff --check`.
- [x] Behavior changes have focused automated coverage.
- [x] Affected tests pass: `mvn -pl shaft-engine -Dtest=testPackage.unitTests.AllureManagerUnitTest#openAllureReportShouldRespectAutomaticOpenToggle -Dallure.automaticallyOpen=false -Dallure.open=false -DheadlessExecution=true test`.
- [x] Code/build changes compile once with `mvn -pl shaft-engine -DskipTests -Dallure.automaticallyOpen=false -Dallure.open=false -DheadlessExecution=true package`.
- [x] New public methods/classes: not applicable.
- [x] I have not introduced any hardcoded credentials, secrets, or sensitive data.
- [x] I have not broken backward compatibility.

## How to Test

1. Run the focused AllureManager regression test with `-Dallure.automaticallyOpen=false`.
2. Confirm the reflected opener returns `false` and no OS browser open command is requested.
3. Run the `shaft-engine` package check with tests skipped for compile/package validation.

## Evidence

- `mvn -pl shaft-engine -Dtest=testPackage.unitTests.AllureManagerUnitTest#openAllureReportShouldRespectAutomaticOpenToggle -Dallure.automaticallyOpen=false -Dallure.open=false -DheadlessExecution=true test` passed: 1 test, 0 failures, 0 errors, 0 skipped.
- `mvn -pl shaft-engine -DskipTests -Dallure.automaticallyOpen=false -Dallure.open=false -DheadlessExecution=true package` passed.
- `graphify update .` refreshed root graph outputs after the core change; graph.html was skipped by Graphify because the graph exceeded the visualization node limit.
- Fetched latest `origin/main`, rebased locally, resolved generated graphify conflicts locally, reran validation, and confirmed `origin/main` is an ancestor of this branch before PR creation.

## Documentation Site

- Documentation PR: Not required.
- Documentation not required because: the public docs already say `allure.automaticallyOpen` controls whether SHAFT opens the final report after test execution and `allure.open` is passed to Allure CLI configuration. This PR makes the implementation match the existing docs.

## Additional Notes

The generated report is still written and copied when auto-open is disabled; only the final OS browser launch is skipped.