### PR TITLE
feat: add capture fallback locator replay

### DIFF
--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -849,21 +849,11 @@
   "847": "Community 847",
   "848": "Community 848",
   "849": "Community 849",
-  "850": "Community 850",
-  "851": "Community 851",
   "852": "Community 852",
   "853": "Community 853",
   "854": "Community 854",
   "855": "Community 855",
-  "856": "Community 856",
-  "857": "Community 857",
-  "858": "Community 858",
-  "859": "Community 859",
   "860": "Community 860",
   "861": "Community 861",
-  "862": "Community 862",
-  "863": "Community 863",
-  "864": "Community 864",
-  "865": "Community 865",
-  "866": "Community 866"
+  "865": "Community 865"
 }

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - SHAFT_ENGINE  (2026-06-27)
 
 ## Corpus Check
-- 1086 files · ~678,938 words
+- 1149 files · ~682,276 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 15997 nodes · 42824 edges · 867 communities (762 shown, 105 thin omitted)
-- Extraction: 81% EXTRACTED · 19% INFERRED · 0% AMBIGUOUS · INFERRED: 8249 edges (avg confidence: 0.8)
+- 16008 nodes · 42876 edges · 857 communities (760 shown, 97 thin omitted)
+- Extraction: 81% EXTRACTED · 19% INFERRED · 0% AMBIGUOUS · INFERRED: 8256 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `f6d78c2b`
+- Built from commit: `74d4def3`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -744,33 +744,23 @@
 - [[_COMMUNITY_Community 847|Community 847]]
 - [[_COMMUNITY_Community 848|Community 848]]
 - [[_COMMUNITY_Community 849|Community 849]]
-- [[_COMMUNITY_Community 850|Community 850]]
-- [[_COMMUNITY_Community 851|Community 851]]
 - [[_COMMUNITY_Community 852|Community 852]]
 - [[_COMMUNITY_Community 853|Community 853]]
 - [[_COMMUNITY_Community 854|Community 854]]
 - [[_COMMUNITY_Community 855|Community 855]]
-- [[_COMMUNITY_Community 856|Community 856]]
-- [[_COMMUNITY_Community 857|Community 857]]
-- [[_COMMUNITY_Community 858|Community 858]]
-- [[_COMMUNITY_Community 859|Community 859]]
 - [[_COMMUNITY_Community 860|Community 860]]
 - [[_COMMUNITY_Community 861|Community 861]]
-- [[_COMMUNITY_Community 862|Community 862]]
-- [[_COMMUNITY_Community 863|Community 863]]
-- [[_COMMUNITY_Community 864|Community 864]]
 - [[_COMMUNITY_Community 865|Community 865]]
-- [[_COMMUNITY_Community 866|Community 866]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `SHAFT` - 311 edges
 2. `IOException` - 123 edges
-3. `ArrayList` - 100 edges
-4. `RestActionsComprehensiveTests` - 99 edges
-5. `CaptureGenerator` - 98 edges
+3. `CaptureGenerator` - 104 edges
+4. `ArrayList` - 100 edges
+5. `RestActionsComprehensiveTests` - 99 edges
 6. `Test` - 98 edges
 7. `ReportManagerHelper` - 76 edges
-8. `String` - 73 edges
+8. `String` - 75 edges
 9. `BrowserActions` - 71 edges
 10. `Actions` - 68 edges
 
@@ -789,11 +779,11 @@
 ## Import Cycles
 - None detected.
 
-## Communities (867 total, 105 thin omitted)
+## Communities (857 total, 97 thin omitted)
 
 ### Community 0 - "Community 0"
 Cohesion: 0.04
-Nodes (7): RestActionsComprehensiveTests, API, ComparisonType, Deprecated, SuppressWarnings, BeforeMethod, Test
+Nodes (8): RestActionsComprehensiveTests, API, ComparisonType, Deprecated, InputStream, SuppressWarnings, BeforeMethod, Test
 
 ### Community 1 - "Community 1"
 Cohesion: 0.05
@@ -805,7 +795,7 @@ Nodes (6): SetProperty, Web, DefaultValue, Key, SetProperty, String
 
 ### Community 3 - "Community 3"
 Cohesion: 0.11
-Nodes (18): LocatorAssertions, PageAssertions, LinkedHashMap, List, Locator, Object, Override, Pattern (+10 more)
+Nodes (17): LocatorAssertions, PageAssertions, Parameter, LinkedHashMap, List, Locator, Object, Override (+9 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.07
@@ -816,12 +806,12 @@ Cohesion: 0.13
 Nodes (14): ConsoleEvent, BrowserObservabilityRecorder, disabled(), NetworkEvent, NetworkExchange, NetworkObservation, HttpRequest, HttpResponse (+6 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.06
-Nodes (14): CSVFileManager, CSVFileManagerTest, List, Map, String, BeforeMethod, Test, AfterMethod (+6 more)
+Cohesion: 0.09
+Nodes (7): AfterMethod, BeforeMethod, CSVFileManager, Object, String, Test, CSVFileManagerUnitTest
 
 ### Community 7 - "Community 7"
-Cohesion: 0.06
-Nodes (32): KeyboardKeys, LocatorOperation, MobileService, MobileServiceConfigurationTest, McpMobileAccessibilityTree, McpMobileContextSnapshot, McpMobileSessionResult, BrowserType (+24 more)
+Cohesion: 0.08
+Nodes (28): KeyboardKeys, LocatorOperation, MobileService, McpMobileAccessibilityTree, McpMobileContextSnapshot, McpMobileSessionResult, BrowserType, By (+20 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.07
@@ -849,23 +839,23 @@ Nodes (10): DataType, JSONFileManager, List, Map, Object, String, AfterMethod, B
 
 ### Community 14 - "Community 14"
 Cohesion: 0.14
-Nodes (19): dataString(), E, empty(), merge(), MouseButton, CaptureEventPipeline, SafePage, SafeTarget (+11 more)
+Nodes (17): E, merge(), MouseButton, CaptureEventPipeline, SafePage, SafeTarget, BrowserSignal, CaptureEvent (+9 more)
 
 ### Community 15 - "Community 15"
 Cohesion: 0.07
 Nodes (15): requestTarget(), ShaftRestAssuredFilter, ApiEvidenceLabels, FilterableResponseSpecification, FilterContext, JsonElement, FilterableRequestSpecification, Object (+7 more)
 
 ### Community 16 - "Community 16"
-Cohesion: 0.08
-Nodes (6): AfterMethod, Path, String, SuppressWarnings, Test, TerminalActionsUnitTest
+Cohesion: 0.07
+Nodes (10): JunitCoreAssertionMigrationTest, LocalShellTests, Test, Test, AfterMethod, Path, String, SuppressWarnings (+2 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.08
-Nodes (15): AsyncAppender, ReportManagerHelper, TestCaseStarted, TestCaseStarted, ByteArrayOutputStream, CheckpointStatus, InputStream, Level (+7 more)
+Cohesion: 0.09
+Nodes (14): AsyncAppender, ReportManagerHelper, TestCaseStarted, ByteArrayOutputStream, CheckpointStatus, InputStream, Level, List (+6 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.11
-Nodes (15): FileActions, Boolean, Collection, Exception, File, InputStream, String, SuppressWarnings (+7 more)
+Cohesion: 0.12
+Nodes (14): FileActions, Boolean, Collection, Exception, File, String, SuppressWarnings, TerminalActions (+6 more)
 
 ### Community 19 - "Community 19"
 Cohesion: 0.12
@@ -876,44 +866,44 @@ Cohesion: 0.13
 Nodes (6): Healing, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 21 - "Community 21"
-Cohesion: 0.12
-Nodes (16): BrowserStackModuleTest, WebDriverListener, InvocationTargetException, Navigation, Test, Alert, By, Method (+8 more)
+Cohesion: 0.14
+Nodes (13): WebDriverListener, Navigation, Alert, By, Method, Object, String, URL (+5 more)
 
 ### Community 22 - "Community 22"
-Cohesion: 0.10
-Nodes (16): NativeValidationsBuilder, TextDirectionValidationsBuilder, FileValidationsBuilder, Object, Override, RestValidationsBuilder, String, SuppressWarnings (+8 more)
+Cohesion: 0.09
+Nodes (19): NativeValidationsBuilder, AssertEqualsTests, VerifyEqualsTests, FileValidationsBuilder, Object, Override, RestValidationsBuilder, String (+11 more)
 
 ### Community 23 - "Community 23"
-Cohesion: 0.09
-Nodes (17): ClassLoader, ImageProcessingActionsCoverageUnitTest, OpenCvBlockingClassLoader, AfterMethod, BeforeMethod, BufferedImage, Class, Color (+9 more)
+Cohesion: 0.11
+Nodes (13): ImageProcessingActionsCoverageUnitTest, List, AfterMethod, BeforeMethod, BufferedImage, Color, DataProvider, Map (+5 more)
 
 ### Community 24 - "Community 24"
-Cohesion: 0.09
-Nodes (9): AllureManager, ArrayNode, Future, InputStream, List, ObjectNode, Path, Process (+1 more)
+Cohesion: 0.11
+Nodes (5): AllureManager, Future, Path, Process, String
 
 ### Community 25 - "Community 25"
-Cohesion: 0.05
-Nodes (48): AllureVerdict, DoctorRepairPublicationRequest, ExistingPullRequest, GuardedPatch, Operation, PatchManifestEntry, RecordingRunner, changedSince() (+40 more)
+Cohesion: 0.19
+Nodes (8): DoctorRepairPublicationRequest, ExistingPullRequest, DoctorRepairService, DoctorRepairRequest, Path, RepairProposal, RepairPublicationResult, String
 
 ### Community 26 - "Community 26"
-Cohesion: 0.08
-Nodes (14): DriverFactoryHelperCoverageUnitTest, TestableDriverFactoryHelper, AfterMethod, AtomicInteger, CountDownLatch, DriverFactoryHelper, DriverType, Method (+6 more)
+Cohesion: 0.07
+Nodes (15): DriverFactoryHelperCoverageUnitTest, TestableDriverFactoryHelper, OptionsManager, AfterMethod, AtomicInteger, CountDownLatch, DriverFactoryHelper, DriverType (+7 more)
 
 ### Community 27 - "Community 27"
 Cohesion: 0.08
 Nodes (4): ValidationTests, AfterMethod, BeforeMethod, Test
 
 ### Community 28 - "Community 28"
-Cohesion: 0.15
-Nodes (9): PropertyFileManager, File, HashMap, Map, MutableCapabilities, Object, Properties, String (+1 more)
+Cohesion: 0.08
+Nodes (14): PropertyFileManager, PropertyFileManagerInternalUnitTest, ThreadLocalPropertiesManager, File, HashMap, Map, MutableCapabilities, Object (+6 more)
 
 ### Community 29 - "Community 29"
 Cohesion: 0.10
 Nodes (18): AccessibilityConfig, AccessibilityHelper, AccessibilityResult, AxeBuilder, AccessibilityResult, Integer, JSONArray, JSONObject (+10 more)
 
 ### Community 30 - "Community 30"
-Cohesion: 0.14
-Nodes (12): RequestBuilderPerformanceTest, RequestBuilderTests, AfterMethod, RequestType, String, Test, AfterMethod, RequestSpecification (+4 more)
+Cohesion: 0.11
+Nodes (14): RequestBuilderPerformanceTest, RequestBuilderTests, AuthenticationType, AfterMethod, RequestType, RestActions, String, Test (+6 more)
 
 ### Community 31 - "Community 31"
 Cohesion: 0.10
@@ -924,48 +914,48 @@ Cohesion: 0.08
 Nodes (11): EngineServiceRuntimePathTest, AfterMethod, Class, Object, Path, String, Test, AfterEach (+3 more)
 
 ### Community 33 - "Community 33"
-Cohesion: 0.11
-Nodes (11): TestNGListenerHelper, Browser, ISuite, ITestContext, ITestNGMethod, ITestResult, List, Method (+3 more)
+Cohesion: 0.10
+Nodes (13): TestNGListenerHelper, Browser, ISuite, ITestContext, ITestNGMethod, ITestResult, List, Method (+5 more)
 
 ### Community 34 - "Community 34"
 Cohesion: 0.08
 Nodes (27): DeterministicNaturalActionPlanner, unsupported(), NaturalActionPlannerRegistry, PilotNaturalActionPlanner, NaturalActionKind, NaturalActionPlanner, NaturalActionStep, List (+19 more)
 
 ### Community 35 - "Community 35"
-Cohesion: 0.08
-Nodes (24): Constructor, IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, IResultListener2 (+16 more)
+Cohesion: 0.07
+Nodes (29): IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, ExecutionSummaryReport, StatusIcon() (+21 more)
 
 ### Community 36 - "Community 36"
 Cohesion: 0.07
-Nodes (26): DataTableArgument, HookTestStep, CucumberFeatureListener, Parameter, PickleStepTestStep, Result, Scenario, AllureLifecycle (+18 more)
+Nodes (27): DataTableArgument, EmbedEvent, HookTestStep, CucumberFeatureListener, PickleStepTestStep, Result, Scenario, AllureLifecycle (+19 more)
 
 ### Community 37 - "Community 37"
-Cohesion: 0.16
-Nodes (7): Paths, SetProperty, DefaultValue, Key, SetProperty, String, BeforeClass
+Cohesion: 0.17
+Nodes (6): Paths, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 38 - "Community 38"
 Cohesion: 0.09
 Nodes (18): BrowserNetworkInterceptor, ClientConfig, DriverFactoryHelper, BrowserNetworkInterceptionRule, Capabilities, Class, DriverType, List (+10 more)
 
 ### Community 39 - "Community 39"
-Cohesion: 0.08
+Cohesion: 0.09
 Nodes (11): AfterMethod, BeforeMethod, Class, List, Object, Path, String, T (+3 more)
 
 ### Community 40 - "Community 40"
-Cohesion: 0.07
-Nodes (15): NavigationAction, API, BrowserActions, Cookie, List, NetworkInterceptionRequestBuilder, Override, RuntimeException (+7 more)
+Cohesion: 0.08
+Nodes (14): NavigationAction, API, BrowserActions, Cookie, List, NetworkInterceptionRequestBuilder, Override, RuntimeException (+6 more)
 
 ### Community 41 - "Community 41"
 Cohesion: 0.16
 Nodes (16): CollectionState, EvidenceCollector, CollectionState, DoctorRedactor, DefaultPrettyPrinter, DoctorAnalysisRequest, EvidenceBundle, EvidenceCategory (+8 more)
 
 ### Community 42 - "Community 42"
-Cohesion: 0.11
-Nodes (13): ElementLookup, GetElementInformation, Actions, ClipboardAction, GetElementInformation, Beta, By, ClipboardAction (+5 more)
+Cohesion: 0.10
+Nodes (14): ElementLookup, GetElementInformation, Actions, ClipboardAction, GetElementInformation, Beta, By, ClipboardAction (+6 more)
 
 ### Community 43 - "Community 43"
-Cohesion: 0.08
-Nodes (5): E2ECoverageTests, AfterMethod, BeforeMethod, Test, TextLanguageValidationsBuilder
+Cohesion: 0.07
+Nodes (9): TextDirectionValidationsBuilder, E2ECoverageTests, NativeValidationsBuilder, ValidationsExecutor, AfterMethod, BeforeMethod, Test, TextDirection (+1 more)
 
 ### Community 44 - "Community 44"
 Cohesion: 0.08
@@ -976,8 +966,8 @@ Cohesion: 0.10
 Nodes (21): ActionsCoverageUnitTest, RecordingActions, RecordingActions, ActionType, AfterMethod, AllureLifecycle, BeforeMethod, By (+13 more)
 
 ### Community 46 - "Community 46"
-Cohesion: 0.24
-Nodes (5): AssertionSteps, PDFTests, String, Then, String
+Cohesion: 0.21
+Nodes (7): AssertionSteps, PDFTests, String, Then, ThreadLocal, WebDriver, String
 
 ### Community 47 - "Community 47"
 Cohesion: 0.08
@@ -985,7 +975,7 @@ Nodes (4): NewValidationHelperTests, AfterMethod, BeforeMethod, Test
 
 ### Community 48 - "Community 48"
 Cohesion: 0.07
-Nodes (12): NumberValidationsBuilder, ValidationsBuilderTests, Number, Object, Override, RestValidationsBuilder, SuppressWarnings, ValidationsBuilder (+4 more)
+Nodes (13): NumberValidationsBuilder, ValidationsBuilderTests, Number, Object, Override, RestValidationsBuilder, SuppressWarnings, ValidationsBuilder (+5 more)
 
 ### Community 49 - "Community 49"
 Cohesion: 0.14
@@ -996,16 +986,16 @@ Cohesion: 0.04
 Nodes (47): additionalProperties, minLength, type, maximum, minimum, type, type, minLength (+39 more)
 
 ### Community 51 - "Community 51"
-Cohesion: 0.09
-Nodes (9): AssertApiResponseEqualsTests, ApiActionsMockedTests, RequestBuilder, RequestType, Test, AfterMethod, BeforeMethod, Test (+1 more)
+Cohesion: 0.08
+Nodes (10): ApiActionsMockedTests, RequestBuilder, RequestType, AfterMethod, BeforeMethod, Test, AfterClass, BeforeClass (+2 more)
 
 ### Community 52 - "Community 52"
 Cohesion: 0.07
-Nodes (18): ApiPerformanceReportTest, SwaggerContractTest, TestUpload, Object, ParametersType, AfterMethod, AfterSuite, BeforeMethod (+10 more)
+Nodes (16): ApiPerformanceReportTest, SwaggerContractTest, testPostRequest, ContentType, AfterMethod, AfterSuite, BeforeMethod, Test (+8 more)
 
 ### Community 53 - "Community 53"
-Cohesion: 0.08
-Nodes (23): RestActions, RequestSpecBuilder, RestAssuredConfig, RequestType, RestActions, ArrayNode, Boolean, Class (+15 more)
+Cohesion: 0.10
+Nodes (19): RestActions, RequestSpecBuilder, RestAssuredConfig, ArrayNode, Boolean, Class, ContentType, Cookie (+11 more)
 
 ### Community 54 - "Community 54"
 Cohesion: 0.13
@@ -1013,7 +1003,7 @@ Nodes (28): _attachment_source_candidates(), _clean_cell(), _failure_brief_open_
 
 ### Community 55 - "Community 55"
 Cohesion: 0.14
-Nodes (15): ElementActionsHelper, TextDetectionStrategy(), AtomicInteger, Boolean, By, Class, ClipboardAction, HealingResolution (+7 more)
+Nodes (16): ElementActionsHelper, TextDetectionStrategy(), ShadowLocatorBuilder, AtomicInteger, Boolean, By, Class, ClipboardAction (+8 more)
 
 ### Community 56 - "Community 56"
 Cohesion: 0.13
@@ -1036,8 +1026,8 @@ Cohesion: 0.08
 Nodes (27): Document, GuideHttpClient, GuideIndex, GuideHttpClient, GuideService, JdkGuideHttpClient, FakeGuideHttpClient, GuideServiceTest (+19 more)
 
 ### Community 61 - "Community 61"
-Cohesion: 0.12
-Nodes (15): AllureListenerCoverageUnitTest, Throwable, Status, AfterMethod, BeforeMethod, ITestResult, List, Path (+7 more)
+Cohesion: 0.11
+Nodes (16): FulfillOptions, AllureListenerCoverageUnitTest, Throwable, Status, AfterMethod, BeforeMethod, ITestResult, List (+8 more)
 
 ### Community 62 - "Community 62"
 Cohesion: 0.14
@@ -1052,8 +1042,8 @@ Cohesion: 0.11
 Nodes (11): COSDocument, DeleteFileAfterValidationStatus, PdfFileManager, PDFParser, RandomAccessReadBufferedFile, File, String, AfterMethod (+3 more)
 
 ### Community 65 - "Community 65"
-Cohesion: 0.07
-Nodes (17): PathParamTest, BasicAPITests, GraphqlRequestTests, Map, AfterClass, BeforeClass, Test, AfterClass (+9 more)
+Cohesion: 0.06
+Nodes (23): PathParamTest, TestUpload, AssertApiResponseEqualsTests, BasicAPITests, GraphqlRequestTests, Map, Object, ParametersType (+15 more)
 
 ### Community 66 - "Community 66"
 Cohesion: 0.05
@@ -1069,35 +1059,35 @@ Nodes (42): additionalProperties, default, description, examples, $id, title, ty
 
 ### Community 69 - "Community 69"
 Cohesion: 0.10
-Nodes (12): DriverFactoryHelper, OptionsManager, AfterMethod, AtomicInteger, CountDownLatch, DriverType, Method, MutableCapabilities (+4 more)
+Nodes (11): DriverFactoryHelper, AfterMethod, AtomicInteger, CountDownLatch, DriverType, Method, MutableCapabilities, Override (+3 more)
 
 ### Community 70 - "Community 70"
 Cohesion: 0.10
 Nodes (43): expand_globs(), issue(), load_budget(), local_link_targets(), markdown_body(), normalized_paragraphs(), parse_frontmatter(), quoted_yaml_value() (+35 more)
 
 ### Community 71 - "Community 71"
-Cohesion: 0.17
-Nodes (13): ShaftHealingProviderTest, Outcome, AfterMethod, AppiumDriver, BeforeMethod, DataProvider, HealingPlatform, List (+5 more)
+Cohesion: 0.13
+Nodes (16): ShaftHeal, ShaftHealingProviderTest, Outcome, HealingReport, Optional, AfterMethod, AppiumDriver, BeforeMethod (+8 more)
 
 ### Community 72 - "Community 72"
-Cohesion: 0.20
-Nodes (12): DoctorAnalyzerTest, Arguments, CauseCategory, DoctorAnalysisRequest, DoctorAnalysisResult, List, MethodSource, ParameterizedTest (+4 more)
+Cohesion: 0.09
+Nodes (30): DoctorAnalyzerTest, empty(), reviewUiPath(), disabled(), McpResultRecordsTest, disabled(), empty(), defaults() (+22 more)
 
 ### Community 73 - "Community 73"
 Cohesion: 0.26
 Nodes (7): denyAll(), CaptureGeneratorTest, CaptureGenerationRequest, CaptureSession, Path, String, Test
 
 ### Community 74 - "Community 74"
-Cohesion: 0.10
-Nodes (16): CaptureEventPipeline, CapturePrivacyClassifier, ManagedCaptureRecorder, BrowserMetadata, BrowserSignal, CapturePrivacyPolicy, CaptureReadiness, CaptureSessionStore (+8 more)
+Cohesion: 0.11
+Nodes (11): CaptureStatusTest, ManagedCaptureRecorder, BrowserSignal, CapturePrivacyPolicy, CaptureStartRequest, CaptureStatus, CheckpointKind, Object (+3 more)
 
 ### Community 75 - "Community 75"
-Cohesion: 0.15
-Nodes (11): Actions, By, DriverFactoryHelper, ElementActions, List, Map, Override, String (+3 more)
+Cohesion: 0.19
+Nodes (8): Actions, By, ElementActions, List, Map, Override, String, SuppressWarnings
 
 ### Community 76 - "Community 76"
-Cohesion: 0.06
-Nodes (32): Session1Test, LocatorOperation, PlaywrightService, CoverageTests, AfterMethod, BeforeMethod, String, Test (+24 more)
+Cohesion: 0.08
+Nodes (26): Session1Test, LocatorOperation, PlaywrightService, AfterMethod, BeforeMethod, String, Test, By (+18 more)
 
 ### Community 77 - "Community 77"
 Cohesion: 0.11
@@ -1108,32 +1098,32 @@ Cohesion: 0.05
 Nodes (40): additionalProperties, enum, pattern, type, pattern, type, items, type (+32 more)
 
 ### Community 79 - "Community 79"
-Cohesion: 0.13
-Nodes (13): CaptureControlFiles, CaptureControlFilesTest, CaptureControlServerClientTest, ControlDescriptor, CaptureStartRequest, CaptureStatus, Class, Object (+5 more)
+Cohesion: 0.18
+Nodes (9): CaptureControlFiles, ControlDescriptor, CaptureStartRequest, CaptureStatus, Class, Object, Path, String (+1 more)
 
 ### Community 80 - "Community 80"
-Cohesion: 0.18
-Nodes (10): ElementService, LocatorOperation, By, Deprecated, LocatorOperation, locatorStrategy, String, Tool (+2 more)
+Cohesion: 0.19
+Nodes (9): ElementService, LocatorOperation, By, Deprecated, LocatorOperation, locatorStrategy, String, Tool (+1 more)
 
 ### Community 81 - "Community 81"
-Cohesion: 0.11
-Nodes (15): IOSDriver, InputStream, Path, String, SuppressWarnings, WebDriver, AfterClass, AfterMethod (+7 more)
+Cohesion: 0.18
+Nodes (8): AfterClass, AfterMethod, Boolean, SuppressWarnings, Test, ThreadLocal, WebDriver, RecordManagerTest
 
 ### Community 82 - "Community 82"
 Cohesion: 0.05
 Nodes (39): additionalProperties, type, maximum, minimum, type, additionalProperties, properties, required (+31 more)
 
 ### Community 84 - "Community 84"
-Cohesion: 0.09
-Nodes (22): option(), ProviderConfiguration(), ProviderConfigurationTest, FirestoreRestClient, Properties, CaptureStartRequest(), validateUrl(), CaptureBrowser (+14 more)
+Cohesion: 0.10
+Nodes (21): option(), ProviderConfiguration(), ProviderConfigurationTest, FirestoreRestClient, Properties, CaptureStartRequest(), validateUrl(), CaptureBrowser (+13 more)
 
 ### Community 85 - "Community 85"
-Cohesion: 0.14
-Nodes (14): ClassifiedUpload, CapturePrivacyClassifier, CapturePrivacyClassifierTest, SanitizedAttributes, SanitizedText, CapturePrivacyPolicy, ClassifiedValue, List (+6 more)
+Cohesion: 0.18
+Nodes (11): ClassifiedUpload, CapturePrivacyClassifier, SanitizedAttributes, SanitizedText, CapturePrivacyPolicy, ClassifiedValue, List, Map (+3 more)
 
 ### Community 86 - "Community 86"
-Cohesion: 0.13
-Nodes (9): AttachmentSnapshot, getType(), Screenshots, DataProvider, Object, Path, String, Test (+1 more)
+Cohesion: 0.07
+Nodes (21): AttachmentFormat, AttachmentSnapshot, AttachmentReporter, getType(), Screenshots, ByteArrayOutputStream, Path, String (+13 more)
 
 ### Community 87 - "Community 87"
 Cohesion: 0.15
@@ -1148,8 +1138,8 @@ Cohesion: 0.10
 Nodes (14): WebDriverElementValidationsBuilder, GuiVerificationTests, By, NativeValidationsBuilder, Override, String, StringBuilder, ValidationCategory (+6 more)
 
 ### Community 90 - "Community 90"
-Cohesion: 0.22
-Nodes (11): CaptureEvent, CaptureJsonCodec, CaptureSession, Checkpoint, ExternalTestDataReference, Instant, List, Path (+3 more)
+Cohesion: 0.11
+Nodes (29): append(), checkpoint(), complete(), ensureIncomplete(), interrupt(), sortedCheckpoints(), sortedEvents(), sortedReferences() (+21 more)
 
 ### Community 91 - "Community 91"
 Cohesion: 0.10
@@ -1160,20 +1150,20 @@ Cohesion: 0.09
 Nodes (51): child_text(), dependency_coordinate(), dependency_template(), direct_child(), elements_named(), ensure_android_json_exclusion(), ensure_dependency(), ensure_generator_dependency_set() (+43 more)
 
 ### Community 93 - "Community 93"
-Cohesion: 0.11
-Nodes (9): LocatorBuilder, RelativeBy, By, Locator, Page, Role, ShaftLocator, String (+1 more)
+Cohesion: 0.07
+Nodes (17): LocatorBuilder, ShadowDomTest, JDK21VirtualThreadsAndAsyncActionsTests, RelativeBy, By, Locator, Page, Role (+9 more)
 
 ### Community 94 - "Community 94"
 Cohesion: 0.05
 Nodes (37): type, additionalProperties, minLength, type, items, type, type, required (+29 more)
 
 ### Community 95 - "Community 95"
-Cohesion: 0.16
-Nodes (13): builder(), evidenceCategories(), withSanitizedContent(), withTimeout(), AiRequest, ApprovalPolicy, Duration, EvidenceCategory (+5 more)
+Cohesion: 0.11
+Nodes (15): builder(), evidenceCategories(), withSanitizedContent(), withTimeout(), AiValueObjectsTest, AiRequest, ApprovalPolicy, Duration (+7 more)
 
 ### Community 96 - "Community 96"
-Cohesion: 0.15
-Nodes (13): DriverFactory, DriverType(), DatabaseActions, DatabaseType, Deprecated, DriverFactoryHelper, DriverType, MutableCapabilities (+5 more)
+Cohesion: 0.08
+Nodes (20): DriverFactory, DriverType(), MatchJsonSchemaTests, DatabaseActions, DatabaseType, Deprecated, DriverFactoryHelper, DriverType (+12 more)
 
 ### Community 97 - "Community 97"
 Cohesion: 0.07
@@ -1196,16 +1186,16 @@ Cohesion: 0.06
 Nodes (36): additionalProperties, minLength, type, type, type, type, $id, additionalProperties (+28 more)
 
 ### Community 102 - "Community 102"
-Cohesion: 0.11
-Nodes (26): DoctorAiAnalysisServiceTest, AiBudget, defaults(), disabled(), EnumSource, from(), defaults(), ApprovalPolicy (+18 more)
+Cohesion: 0.13
+Nodes (23): DoctorAiAnalysisServiceTest, AiBudget, defaults(), disabled(), EnumSource, defaults(), ApprovalPolicy, DoctorAiAnalysisRequest (+15 more)
 
 ### Community 103 - "Community 103"
-Cohesion: 0.19
-Nodes (5): HttpContractRecorder, JsonNode, Map, String, ValidationMode
+Cohesion: 0.16
+Nodes (7): HttpContractRecorder, JsonNode, Map, Set, String, URI, ValidationMode
 
 ### Community 104 - "Community 104"
-Cohesion: 0.16
-Nodes (11): Dimension, BrowserActionsHelper, WindowType, Boolean, Exception, List, Object, SneakyThrows (+3 more)
+Cohesion: 0.11
+Nodes (15): Dimension, BrowserActionsHelper, WindowType, Boolean, Exception, List, Object, SneakyThrows (+7 more)
 
 ### Community 105 - "Community 105"
 Cohesion: 0.14
@@ -1224,24 +1214,24 @@ Cohesion: 0.13
 Nodes (5): YAMLFileManagerTests, BeforeMethod, Date, String, Test
 
 ### Community 109 - "Community 109"
-Cohesion: 0.31
-Nodes (5): AfterTest, BeforeTest, ConfigurationHelper, ITestContext, Step
+Cohesion: 0.16
+Nodes (6): AfterTest, BeforeTest, ConfigurationHelper, ReportHelper, ITestContext, Step
 
 ### Community 110 - "Community 110"
-Cohesion: 0.16
-Nodes (14): AiExecutionServiceTest, StubProvider, AiCapabilities, AiExecutionService, AiProviderAvailability, AiProviderRegistry, AiRequest, AiResponse (+6 more)
+Cohesion: 0.28
+Nodes (8): AiExecutionServiceTest, AiExecutionService, AiProviderRegistry, AiRequest, AiResponse, ApprovalPolicy, PilotConfiguration, Test
 
 ### Community 111 - "Community 111"
 Cohesion: 0.17
-Nodes (17): DeterministicRuleEngine, Confidence, Finding, Remediation, RetrySummary, RuleMatch, CauseCategory, Diagnosis (+9 more)
+Nodes (18): DeterministicRuleEngine, Confidence, Finding, distinct(), Remediation, RetrySummary, RuleMatch, CauseCategory (+10 more)
 
 ### Community 112 - "Community 112"
-Cohesion: 0.09
-Nodes (12): API, Contracts, YAML, Class, Cookie, List, Map, Object (+4 more)
+Cohesion: 0.12
+Nodes (11): API, JSON, Class, Cookie, List, Map, Object, RequestBuilder (+3 more)
 
 ### Community 113 - "Community 113"
-Cohesion: 0.30
-Nodes (4): Platform, DefaultValue, Key, SetProperty
+Cohesion: 0.15
+Nodes (6): Platform, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 114 - "Community 114"
 Cohesion: 0.12
@@ -1252,28 +1242,28 @@ Cohesion: 0.06
 Nodes (34): enum, type, items, type, items, type, $id, required (+26 more)
 
 ### Community 116 - "Community 116"
-Cohesion: 0.10
-Nodes (20): getValue(), KeyboardKeys(), TouchActions, ImmutableMap, viewport(), ScreenOrientation, By, DriverFactoryHelper (+12 more)
+Cohesion: 0.11
+Nodes (19): getValue(), KeyboardKeys(), TouchActions, ImmutableMap, viewport(), By, DriverFactoryHelper, File (+11 more)
 
 ### Community 117 - "Community 117"
-Cohesion: 0.15
-Nodes (21): AllureFile, changedSince(), HealerService, ProcessExecutor, successful(), McpHealerAttemptResult, McpHealerRunResult, ProcessExecutor (+13 more)
+Cohesion: 0.11
+Nodes (26): AllureFile, changedSince(), HealerService, ProcessExecutor, successful(), HealerServiceTest, McpHealerAttemptResult, McpHealerRunResult (+18 more)
 
 ### Community 118 - "Community 118"
-Cohesion: 0.18
-Nodes (15): CandidateExtractor, LocatorProposal, SearchContext, By, Collection, HealingConfiguration, HealingPlatform, List (+7 more)
+Cohesion: 0.17
+Nodes (16): CandidateExtractor, LocatorProposal, nativePlatform(), SearchContext, By, Collection, HealingConfiguration, HealingPlatform (+8 more)
 
 ### Community 119 - "Community 119"
 Cohesion: 0.08
 Nodes (17): Async, Driver, Playwright, WebDriver, PlaywrightDriverAssertions, PlaywrightDriverVerifications, Actions, AlertActions (+9 more)
 
 ### Community 120 - "Community 120"
-Cohesion: 0.19
+Cohesion: 0.20
 Nodes (12): YAMLFileManager, Boolean, Class, Date, Double, Integer, List, Long (+4 more)
 
 ### Community 121 - "Community 121"
 Cohesion: 0.11
-Nodes (13): AccessibilityActions, BrowserContext, BrowserNetworkInterceptionRule, Cookie, HttpRequest, HttpResponse, Locator, NetworkInterceptionRequestBuilder (+5 more)
+Nodes (12): PlaywrightBrowserValidationsBuilder, AccessibilityActions, BrowserContext, BrowserNetworkInterceptionRule, HttpRequest, HttpResponse, Locator, NetworkInterceptionRequestBuilder (+4 more)
 
 ### Community 122 - "Community 122"
 Cohesion: 0.12
@@ -1284,8 +1274,8 @@ Cohesion: 0.10
 Nodes (4): AfterMethod, BeforeClass, Test, YAMLFileManagerUnitTest
 
 ### Community 124 - "Community 124"
-Cohesion: 0.11
-Nodes (25): AiTrigger, HealingProvider, ShaftHealingProvider, safe(), stableKey(), HealingActionOutcome, HealingCandidate, HealingConfiguration (+17 more)
+Cohesion: 0.08
+Nodes (29): AiTrigger, HealingProvider, HealingReportWriter, ShaftHealingProvider, safe(), stableKey(), HealingConfiguration, HealingReport (+21 more)
 
 ### Community 125 - "Community 125"
 Cohesion: 0.15
@@ -1300,20 +1290,20 @@ Cohesion: 0.06
 Nodes (32): additionalProperties, type, items, type, minimum, type, minimum, type (+24 more)
 
 ### Community 128 - "Community 128"
-Cohesion: 0.18
-Nodes (14): AiExecutionService, CircuitState, AiAuditSink, AiProvider, AiProviderRegistry, AiRequest, AiResponse, AiResponseStatus (+6 more)
+Cohesion: 0.17
+Nodes (15): AiExecutionService, CircuitState, RedactionResult, AiAuditSink, AiProvider, AiProviderRegistry, AiRequest, AiResponse (+7 more)
 
 ### Community 129 - "Community 129"
-Cohesion: 0.16
+Cohesion: 0.17
 Nodes (13): disabled(), TraceEventRecorder, Iterable, ActionEvent, By, Event, List, Map (+5 more)
 
 ### Community 130 - "Community 130"
-Cohesion: 0.29
+Cohesion: 0.27
 Nodes (6): Config, List, String, SuppressWarnings, Test, XrayIntegrationHelper
 
 ### Community 131 - "Community 131"
-Cohesion: 0.12
-Nodes (22): DoctorRepairProposalResult, DoctorRepairService, HealingLocatorProposalRequest, DoctorService, McpWorkspacePolicy, ApprovalPolicy, Diagnosis, DoctorAnalysisResult (+14 more)
+Cohesion: 0.13
+Nodes (20): DoctorRepairProposalResult, DoctorRepairService, HealingLocatorProposalRequest, DoctorService, ApprovalPolicy, Diagnosis, DoctorAnalysisResult, DoctorAnalysisSummary (+12 more)
 
 ### Community 132 - "Community 132"
 Cohesion: 0.15
@@ -1324,19 +1314,19 @@ Cohesion: 0.15
 Nodes (10): PackageActivity, BufferedReader, File, Optional, String, Path, String, Test (+2 more)
 
 ### Community 134 - "Community 134"
-Cohesion: 0.14
-Nodes (7): Mobile, SetProperty, PropertiesManagerTests, DefaultValue, Key, SetProperty, String
+Cohesion: 0.16
+Nodes (6): Mobile, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 135 - "Community 135"
-Cohesion: 0.11
-Nodes (16): NativeValidationsBuilder, Locator, Object, Override, PlaywrightSession, PlaywrightValidationsExecutor, String, StringBuilder (+8 more)
+Cohesion: 0.10
+Nodes (18): Locator, Object, Override, PlaywrightSession, PlaywrightValidationsExecutor, String, StringBuilder, ValidationCategory (+10 more)
 
 ### Community 136 - "Community 136"
 Cohesion: 0.16
 Nodes (27): ut(), _(), a(), b(), c(), d(), f(), g() (+19 more)
 
 ### Community 137 - "Community 137"
-Cohesion: 0.16
+Cohesion: 0.17
 Nodes (16): EndpointStats, ApiPerformanceExecutionReport, appendJson(), budgetStatus(), budgetViolationMessage(), from(), percentile(), toHtmlRow() (+8 more)
 
 ### Community 138 - "Community 138"
@@ -1356,7 +1346,7 @@ Cohesion: 0.18
 Nodes (10): AccessibilityHelperCoverageUnitTest, AfterMethod, List, MockedConstruction, Path, Results, Rule, String (+2 more)
 
 ### Community 142 - "Community 142"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (3): ActionsCoverageTests, BeforeMethod, Test
 
 ### Community 143 - "Community 143"
@@ -1369,15 +1359,15 @@ Nodes (5): AfterMethod, Runnable, String, Test, ValidationHelperUnitTest
 
 ### Community 145 - "Community 145"
 Cohesion: 0.11
-Nodes (13): List, Color, Rectangle, AfterMethod, BeforeMethod, Color, Map, Method (+5 more)
+Nodes (12): Color, Rectangle, AfterMethod, BeforeMethod, Color, Map, Method, Path (+4 more)
 
 ### Community 146 - "Community 146"
 Cohesion: 0.18
 Nodes (13): CaptureCodegenStartRequest, CaptureCodegenStartRequest, CaptureService, McpCaptureReplayResult, PreDestroy, CaptureGenerationResult, CaptureStatus, CodegenBackend (+5 more)
 
 ### Community 147 - "Community 147"
-Cohesion: 0.13
-Nodes (14): BrowserEventScript, CaptureCollectorUtilityTest, close(), start(), List, String, BrowserSignal, Class (+6 more)
+Cohesion: 0.19
+Nodes (11): CaptureCollectorUtilityTest, close(), start(), BrowserSignal, Class, Consumer, Object, Override (+3 more)
 
 ### Community 148 - "Community 148"
 Cohesion: 0.14
@@ -1392,40 +1382,40 @@ Cohesion: 0.20
 Nodes (20): DoctorCli, flag(), optionalPath(), parse(), path(), pathRequired(), paths(), pathsRequired() (+12 more)
 
 ### Community 151 - "Community 151"
-Cohesion: 0.13
-Nodes (5): AfterMethod, Path, String, Test, ThreadLocalPropertiesTest
+Cohesion: 0.09
+Nodes (8): AsyncElementActionsCoverageUnitTest, Test, Test, AfterMethod, Path, String, Test, ThreadLocalPropertiesTest
 
 ### Community 152 - "Community 152"
 Cohesion: 0.19
 Nodes (11): LocatorRef, McpAppiumCommandRecorder, PointerGesture, BooleanSupplier, JsonNode, locatorStrategy, Map, McpMobileRecordedAction (+3 more)
 
 ### Community 153 - "Community 153"
-Cohesion: 0.13
-Nodes (11): APIResponse, FulfillOptions, PlaywrightNetworkInterceptor, BrowserContext, BrowserNetworkInterceptionRule, HttpMethod, HttpRequest, HttpResponse (+3 more)
+Cohesion: 0.12
+Nodes (15): APIResponse, PlaywrightNetworkInterceptor, PlaywrightNetworkInterceptorTest, Request, BrowserContext, BrowserNetworkInterceptionRule, HttpMethod, HttpRequest (+7 more)
 
 ### Community 154 - "Community 154"
-Cohesion: 0.11
-Nodes (16): CaptureGenerationReport(), notRequested(), skipped(), ExecutionSummaryReport, finalPassed(), Enrichment, List, LocatorDecision (+8 more)
+Cohesion: 0.16
+Nodes (10): CaptureGenerationReport(), notRequested(), skipped(), Enrichment, List, LocatorDecision, Status, String (+2 more)
 
 ### Community 155 - "Community 155"
 Cohesion: 0.14
 Nodes (15): CookieState, BrowserStorageStateManager, CookieState, OriginStorage, StorageState, Builder, Cookie, JavascriptExecutor (+7 more)
 
 ### Community 156 - "Community 156"
-Cohesion: 0.12
-Nodes (17): ElementActionsHelper, ScreenshotManager, ScreenshotManagerCoverageUnitTest, Boolean, By, JavascriptExecutor, List, Object (+9 more)
+Cohesion: 0.18
+Nodes (12): ScreenshotManager, Object, Boolean, By, JavascriptExecutor, List, Object, Screenshots (+4 more)
 
 ### Community 157 - "Community 157"
-Cohesion: 0.18
+Cohesion: 0.19
 Nodes (13): By, ElementActions, ElementAssertions, List, Locator, Map, Override, PlaywrightSession (+5 more)
 
 ### Community 158 - "Community 158"
-Cohesion: 0.12
-Nodes (11): Role, Override, AfterMethod, Test, Class, Object, String, SuppressWarnings (+3 more)
+Cohesion: 0.09
+Nodes (12): XpathAxis, McpAppiumCommandRecorderTest, MobileRecordingServiceTest, Role, LocatorBuilder, String, Override, AfterMethod (+4 more)
 
 ### Community 159 - "Community 159"
-Cohesion: 0.09
-Nodes (25): ActionReportContext, abbreviate(), empty(), FlakeProfileContext, from(), hasElementName(), hasLocator(), hasStepTarget() (+17 more)
+Cohesion: 0.10
+Nodes (24): ActionReportContext, abbreviate(), empty(), FlakeProfileContext, from(), hasElementName(), hasLocator(), hasStepTarget() (+16 more)
 
 ### Community 160 - "Community 160"
 Cohesion: 0.08
@@ -1436,16 +1426,16 @@ Cohesion: 0.13
 Nodes (4): AfterMethod, BeforeMethod, Test, NegativeValidationsTests
 
 ### Community 162 - "Community 162"
-Cohesion: 0.13
+Cohesion: 0.12
 Nodes (5): AfterMethod, BeforeMethod, Test, WebDriver, BrowserActionsCoverageUnitTest
 
 ### Community 164 - "Community 164"
-Cohesion: 0.24
-Nodes (7): Connection, DatabaseActions, Boolean, DatabaseType, ResultSet, String, StringBuilder
+Cohesion: 0.27
+Nodes (6): DatabaseActions, Boolean, DatabaseType, ResultSet, String, StringBuilder
 
 ### Community 165 - "Community 165"
-Cohesion: 0.18
-Nodes (8): ChromiumOptions, DesiredCapabilities, OptionsManager, LoggingPreferences, DriverType, MutableCapabilities, String, SuppressWarnings
+Cohesion: 0.12
+Nodes (13): ChromeOptions, ChromiumOptions, DesiredCapabilities, OptionsManager, OptionsManagerCoverageUnitTest, LoggingPreferences, DriverType, MutableCapabilities (+5 more)
 
 ### Community 166 - "Community 166"
 Cohesion: 0.13
@@ -1461,15 +1451,15 @@ Nodes (6): Reporting, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 169 - "Community 169"
 Cohesion: 0.17
-Nodes (6): AttachmentFormat, AttachmentReporter, ByteArrayOutputStream, Path, String, SuppressWarnings
+Nodes (16): RecordingRunner, DoctorRepairServiceTest, RecordingRunner, validationPassed(), RepairProcessRunner, RepositoryFixture, DoctorRepairRequest, Duration (+8 more)
 
 ### Community 170 - "Community 170"
-Cohesion: 0.07
-Nodes (21): FailureTraceReporterTest, BrowserService, EngineServiceTest, AndroidDriver, Attachment, List, Path, RuntimeException (+13 more)
+Cohesion: 0.12
+Nodes (10): BrowserService, EngineServiceTest, McpPageDomSnapshot, McpScreenshotResult, McpWorkspacePolicy, Path, String, Tool (+2 more)
 
 ### Community 171 - "Community 171"
-Cohesion: 0.07
-Nodes (27): ByAll, CompositeLocator, SmartLocator, SmartLocators, NaturalActionCompositeLocator, PlaywrightNaturalActionExecutor, PathStrategy, By (+19 more)
+Cohesion: 0.12
+Nodes (15): ByAll, CompositeLocator, SmartLocator, SmartLocators, NaturalActionCompositeLocator, PathStrategy, By, List (+7 more)
 
 ### Community 172 - "Community 172"
 Cohesion: 0.17
@@ -1480,8 +1470,8 @@ Cohesion: 0.16
 Nodes (12): ValidationsHelper, Boolean, ComparisonType, LinkedHashMap, List, Number, NumbersComparativeRelation, Object (+4 more)
 
 ### Community 174 - "Community 174"
-Cohesion: 0.07
-Nodes (21): AsyncElementActions, Async, CLI, GUI, JSON, Locator, Properties, Report (+13 more)
+Cohesion: 0.08
+Nodes (19): AsyncElementActions, Async, CLI, GUI, Locator, Properties, TestData, Validations (+11 more)
 
 ### Community 175 - "Community 175"
 Cohesion: 0.17
@@ -1492,8 +1482,8 @@ Cohesion: 0.18
 Nodes (5): AsyncElementActions, By, ClipboardAction, DriverFactoryHelper, String
 
 ### Community 177 - "Community 177"
-Cohesion: 0.14
-Nodes (19): empty(), TraceService, McpTraceActionSummary, McpTraceSummary, CauseCategory, CodegenBackend, EvidenceBundle, EvidenceCategory (+11 more)
+Cohesion: 0.12
+Nodes (22): empty(), TraceService, McpTraceActionSummary, McpTraceLatestResult, McpTraceReadResult, McpTraceSummary, CauseCategory, CodegenBackend (+14 more)
 
 ### Community 178 - "Community 178"
 Cohesion: 0.20
@@ -1524,12 +1514,12 @@ Cohesion: 0.22
 Nodes (6): Internal, InternalTests, DefaultValue, Key, String, Test
 
 ### Community 185 - "Community 185"
-Cohesion: 0.15
-Nodes (17): ElementActionabilityDiagnostics, ShadowDomTest, ShadowLocatorBuilder, By, List, Map, Object, Rectangle (+9 more)
+Cohesion: 0.25
+Nodes (12): ElementActionabilityDiagnostics, By, List, Map, Object, Rectangle, String, Supplier (+4 more)
 
 ### Community 186 - "Community 186"
-Cohesion: 0.20
-Nodes (8): TestNG, TestNGTests, XmlSuite, DefaultValue, Integer, Key, String, Test
+Cohesion: 0.23
+Nodes (7): TestNG, TestNGTests, DefaultValue, Integer, Key, String, Test
 
 ### Community 187 - "Community 187"
 Cohesion: 0.08
@@ -1548,7 +1538,7 @@ Cohesion: 0.12
 Nodes (19): ActiveRetryAttempt, AfterAllCallback, AfterEachCallback, AfterTestExecutionCallback, BeforeAllCallback, BeforeEachCallback, DiscoverySelector, LauncherDiscoveryRequest (+11 more)
 
 ### Community 191 - "Community 191"
-Cohesion: 0.17
+Cohesion: 0.18
 Nodes (12): PlaywrightSessionFactory, LaunchOptions, PlaywrightDeviceDescriptor, Browser, BrowserContext, BrowserType, NewContextOptions, Page (+4 more)
 
 ### Community 192 - "Community 192"
@@ -1556,36 +1546,36 @@ Cohesion: 0.16
 Nodes (3): AfterMethod, Test, ValidationsBuilderUnitTest
 
 ### Community 193 - "Community 193"
-Cohesion: 0.17
-Nodes (7): ElementActionsContract, By, ElementAssertions, List, Map, ShaftLocator, String
+Cohesion: 0.08
+Nodes (21): DriverAssertions, DriverVerifications, ElementActionsContract, BrowserAssertions, By, ElementAssertions, NativeValidationsBuilder, Object (+13 more)
 
 ### Community 194 - "Community 194"
-Cohesion: 0.14
-Nodes (8): DatabaseActionsMockedTests, AfterMethod, BeforeMethod, DatabaseActions, Object, ResultSet, String, Test
+Cohesion: 0.16
+Nodes (6): DatabaseActionsMockedTests, AfterMethod, DatabaseActions, Object, String, Test
 
 ### Community 195 - "Community 195"
 Cohesion: 0.17
 Nodes (19): build_parser(), collect_metrics(), issue(), main(), Run one external check and return a concise issue on failure., Collect stable context and memory size metrics., Run all agent setup checks., Build the command-line parser. (+11 more)
 
 ### Community 196 - "Community 196"
-Cohesion: 0.07
-Nodes (21): ActionSample, EvidenceEvent, FlakeProfileContext, ActionSample, appendJson(), FlakeProfiler, TestProfile, FlakeProfilerUnitTest (+13 more)
+Cohesion: 0.10
+Nodes (14): EvidenceEvent, appendJson(), FlakeProfiler, TestProfile, RetryEvent, ActionEvent, ArrayNode, AssertionError (+6 more)
 
 ### Community 197 - "Community 197"
-Cohesion: 0.22
-Nodes (5): ElementActions, ElementActionsMockedTests, AfterMethod, BeforeMethod, Test
+Cohesion: 0.24
+Nodes (4): ElementActionsMockedTests, AfterMethod, BeforeMethod, Test
 
 ### Community 198 - "Community 198"
-Cohesion: 0.17
-Nodes (7): ElementInformation, ElementInformationCoverageUnitTest, Element, List, Object, String, Test
+Cohesion: 0.18
+Nodes (6): ElementInformation, ElementInformationCoverageUnitTest, Element, List, String, Test
 
 ### Community 199 - "Community 199"
 Cohesion: 0.25
 Nodes (4): Jira, DefaultValue, Key, SetProperty
 
 ### Community 200 - "Community 200"
-Cohesion: 0.07
-Nodes (22): AiAuditSink, ShaftAiAuditSink, CheckpointCounter, FailureBriefReporter, String, CheckpointStatus, CheckpointType, String (+14 more)
+Cohesion: 0.06
+Nodes (32): AiAuditSink, ShaftAiAuditSink, FailureBriefReporter, FailureBriefReporterTest, ReportContext, JunitReportContextTest, AttachmentRecord, List (+24 more)
 
 ### Community 201 - "Community 201"
 Cohesion: 0.11
@@ -1596,12 +1586,12 @@ Cohesion: 0.19
 Nodes (13): GeminiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode, Map (+5 more)
 
 ### Community 204 - "Community 204"
-Cohesion: 0.19
-Nodes (12): OpenAiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode, Map (+4 more)
+Cohesion: 0.17
+Nodes (13): AiImage, OpenAiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode (+5 more)
 
 ### Community 205 - "Community 205"
-Cohesion: 0.19
-Nodes (9): CaptureManagerLifecycleTest, FailingRecorder, FakeRecorder, CaptureStartRequest, CaptureStatus, CheckpointKind, Override, String (+1 more)
+Cohesion: 0.14
+Nodes (11): FailureTraceReporterTest, AndroidDriver, Attachment, List, Path, RuntimeException, String, SuppressWarnings (+3 more)
 
 ### Community 206 - "Community 206"
 Cohesion: 0.09
@@ -1616,16 +1606,16 @@ Cohesion: 0.21
 Nodes (18): A(), ba(), c(), D(), E(), G(), i(), j() (+10 more)
 
 ### Community 209 - "Community 209"
-Cohesion: 0.06
-Nodes (39): ArtifactPaths, AssertionSuggestion, CaptureReviewFinding, CaptureGenerator, CodegenBackend(), driverClassName(), failure(), from() (+31 more)
+Cohesion: 0.05
+Nodes (50): AlertEvent, ArtifactPaths, AssertionSuggestion, CaptureReviewFinding, DataPlan, CaptureGenerator, CodegenBackend(), driverClassName() (+42 more)
 
 ### Community 210 - "Community 210"
-Cohesion: 0.13
-Nodes (7): LocatorBuilderTest, XpathAxis, LocatorBuilder, String, AfterMethod, BeforeMethod, Test
+Cohesion: 0.20
+Nodes (4): LocatorBuilderTest, AfterMethod, BeforeMethod, Test
 
 ### Community 211 - "Community 211"
-Cohesion: 0.17
-Nodes (11): HistoryDocument, HistoryRecord, HealingHistoryStore, HealingConfiguration, HealingContext, LocatorFingerprint, Optional, Path (+3 more)
+Cohesion: 0.14
+Nodes (15): HistoryDocument, HistoryRecord, HealingHistoryStore, HistoryRecord(), withChecksum(), HealingConfiguration, HealingContext, LocatorFingerprint (+7 more)
 
 ### Community 212 - "Community 212"
 Cohesion: 0.16
@@ -1648,8 +1638,8 @@ Cohesion: 0.22
 Nodes (11): expired(), InstantDeadline(), ManagedCaptureRecorderBrowserTest, BooleanSupplier, Duration, HttpExchange, HttpServer, ParameterizedTest (+3 more)
 
 ### Community 217 - "Community 217"
-Cohesion: 0.13
-Nodes (9): ReportContext, JunitReportContextTest, AttachmentRecord, Consumer, List, String, TestExecutionInfo, AfterEach (+1 more)
+Cohesion: 0.14
+Nodes (7): ActionSample, FlakeProfileContext, ActionSample, FlakeProfilerUnitTest, AfterMethod, BeforeMethod, Test
 
 ### Community 218 - "Community 218"
 Cohesion: 0.24
@@ -1668,12 +1658,12 @@ Cohesion: 0.20
 Nodes (13): AiCandidateReranker, AiExecutionService, Double, HealingConfiguration, JsonNode, List, Map, ObjectNode (+5 more)
 
 ### Community 222 - "Community 222"
-Cohesion: 0.21
-Nodes (10): HealingSupport, nativePlatform(), By, HealingContext, HealingPlatform, RemoteWebDriver, String, Supplier (+2 more)
+Cohesion: 0.24
+Nodes (9): HealingSupport, By, HealingContext, HealingPlatform, RemoteWebDriver, String, Supplier, WebDriver (+1 more)
 
 ### Community 223 - "Community 223"
 Cohesion: 0.08
-Nodes (14): RestValidationsBuilder, JSONValidationsBuilder, JsonCompareWithSpecialCharactersTests, NativeValidationsBuilder, NumberValidationsBuilder, Object, String, StringBuilder (+6 more)
+Nodes (14): RestValidationsBuilder, JSONValidationsBuilder, JsonCompareWithSpecialCharactersTests, NativeValidationsBuilder, Object, String, StringBuilder, ValidationCategory (+6 more)
 
 ### Community 224 - "Community 224"
 Cohesion: 0.19
@@ -1684,8 +1674,8 @@ Cohesion: 0.17
 Nodes (8): KeysetHandle, GoogleTink, GoogleTinkApiCoverageUnitTest, String, AfterMethod, BeforeMethod, Path, Test
 
 ### Community 226 - "Community 226"
-Cohesion: 0.18
-Nodes (11): ManagedCaptureRecorder, CaptureManager, CaptureStartRequest, CaptureStatus, CheckpointKind, Function, ManagedCaptureRecorder, Override (+3 more)
+Cohesion: 0.09
+Nodes (20): ManagedCaptureRecorder, CaptureManager, CaptureManagerLifecycleTest, FailingRecorder, FakeRecorder, CaptureStartRequest, CaptureStatus, CheckpointKind (+12 more)
 
 ### Community 227 - "Community 227"
 Cohesion: 0.20
@@ -1700,16 +1690,20 @@ Cohesion: 0.21
 Nodes (3): Method, Test, JavaScriptWaitManagerUnitTest
 
 ### Community 230 - "Community 230"
-Cohesion: 0.28
-Nodes (7): LambdaTestHelper, Boolean, DriverFactoryHelper, HashMap, MutableCapabilities, Object, String
+Cohesion: 0.14
+Nodes (10): LambdaTestHelper, Boolean, DriverFactoryHelper, HashMap, MutableCapabilities, Object, String, AfterMethod (+2 more)
 
 ### Community 231 - "Community 231"
 Cohesion: 0.18
 Nodes (3): AfterMethod, Test, RestActionsUtilsUnitTest
 
 ### Community 232 - "Community 232"
-Cohesion: 0.17
-Nodes (10): PilotTestConfiguration, RedactionPolicy, RedactionResult, Redactor, AiRequest, Set, String, PilotConfiguration (+2 more)
+Cohesion: 0.19
+Nodes (9): PilotTestConfiguration, RedactionPolicy, Redactor, AiRequest, Set, String, PilotConfiguration, ProcessingLocation (+1 more)
+
+### Community 233 - "Community 233"
+Cohesion: 0.10
+Nodes (6): PropertiesHelper, String, AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
 
 ### Community 234 - "Community 234"
 Cohesion: 0.18
@@ -1756,8 +1750,8 @@ Cohesion: 0.24
 Nodes (6): McpRuntimePaths, McpRuntimePathsTest, Map, Path, String, Test
 
 ### Community 245 - "Community 245"
-Cohesion: 0.17
-Nodes (13): AiImage, AnthropicProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode (+5 more)
+Cohesion: 0.19
+Nodes (12): AnthropicProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode, Map (+4 more)
 
 ### Community 246 - "Community 246"
 Cohesion: 0.10
@@ -1768,7 +1762,7 @@ Cohesion: 0.20
 Nodes (4): AfterMethod, BeforeMethod, Test, BrowserActionsTests
 
 ### Community 248 - "Community 248"
-Cohesion: 0.21
+Cohesion: 0.20
 Nodes (6): PlaywrightSessionManager, Browser, BrowserContext, Page, Playwright, PlaywrightSession
 
 ### Community 249 - "Community 249"
@@ -1780,16 +1774,16 @@ Cohesion: 0.50
 Nodes (3): Source-file rewrites prepared for session or full upgrades., Return source files whose contents should be replaced., SourceMigration
 
 ### Community 251 - "Community 251"
-Cohesion: 0.22
-Nodes (8): ChromeOptions, MoonTests, AfterEach, BeforeEach, String, Test, WebDriver, TestInfo
+Cohesion: 0.23
+Nodes (7): MoonTests, AfterEach, BeforeEach, String, Test, WebDriver, TestInfo
 
 ### Community 252 - "Community 252"
 Cohesion: 0.18
 Nodes (13): DoctorRepairPatchResult, DoctorRepairAiService, AiRequest, AiResponse, AiResponseStatus, Diagnosis, DoctorRepairAiRequest, EvidenceReference (+5 more)
 
 ### Community 253 - "Community 253"
-Cohesion: 0.39
-Nodes (6): ByteArrayOutputStream, Severity, Story, String, Test, AllAttachmentTypesTest
+Cohesion: 0.18
+Nodes (12): PlaywrightNaturalActionExecutor, By, CharSequence, List, Locator, NaturalActionPlan, Object, Page (+4 more)
 
 ### Community 254 - "Community 254"
 Cohesion: 0.29
@@ -1800,40 +1794,40 @@ Cohesion: 0.23
 Nodes (7): DoctorRedactor, RedactorTest, JsonNode, List, ObjectNode, String, Test
 
 ### Community 256 - "Community 256"
-Cohesion: 0.19
+Cohesion: 0.21
 Nodes (6): FailureReporter, Class, String, Throwable, Test, FailureReporterUnitTest
 
 ### Community 257 - "Community 257"
-Cohesion: 0.28
-Nodes (12): CompletableFuture, McpProcessRunner, SystemProcessRunner, Duration, InputStream, List, Map, Override (+4 more)
+Cohesion: 0.12
+Nodes (16): AllureVerdict, Operation, PatchManifestEntry, changedSince(), RepairGuard, RepairProposalStore, AllureSnapshot, Diagnosis (+8 more)
 
 ### Community 258 - "Community 258"
 Cohesion: 0.20
 Nodes (6): NaturalActions, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 259 - "Community 259"
-Cohesion: 0.19
-Nodes (7): ShaftLocator, By, Locator, Override, Page, String, Strategy
+Cohesion: 0.16
+Nodes (8): ShaftLocator, JunitCoreAssertionDependencyGuardTest, Override, String, Pattern, Path, Test, Strategy
 
 ### Community 260 - "Community 260"
 Cohesion: 0.13
-Nodes (13): $, CucumberHelper, List, Status, String, XmlSuite, AfterMethod, AtomicInteger (+5 more)
+Nodes (12): CucumberHelper, List, Status, String, XmlSuite, AfterMethod, AtomicInteger, Set (+4 more)
 
 ### Community 261 - "Community 261"
 Cohesion: 0.23
 Nodes (5): ThreadSafeGuiWizardTests, AfterMethod, BeforeMethod, SuppressWarnings, Test
 
 ### Community 262 - "Community 262"
-Cohesion: 0.09
-Nodes (32): build_parser(), CommandResult, confirm_upgrade(), coordinates_have_supported_runner(), coordinates_have_supported_stack(), default_compile_command(), extract_response_output_text(), is_stable_release() (+24 more)
+Cohesion: 0.10
+Nodes (29): CommandResult, confirm_upgrade(), coordinates_have_supported_runner(), coordinates_have_supported_stack(), default_compile_command(), extract_response_output_text(), is_stable_release(), metadata_release() (+21 more)
 
 ### Community 263 - "Community 263"
-Cohesion: 0.17
-Nodes (8): PlaywrightSession, Browser, BrowserContext, Object, Override, Page, Playwright, String
+Cohesion: 0.15
+Nodes (9): PlaywrightSession, PlaywrightTraceManager, Browser, BrowserContext, Object, Override, Page, Playwright (+1 more)
 
 ### Community 264 - "Community 264"
-Cohesion: 0.19
-Nodes (12): McpMobileInspectorRecordingServiceTest, NoopRunner, Duration, List, Map, McpMobileInspectorRecordingService, Override, Path (+4 more)
+Cohesion: 0.17
+Nodes (13): McpMobileInspectorRecordingServiceTest, NoopRunner, McpProcessRunner, Duration, List, Map, McpMobileInspectorRecordingService, Override (+5 more)
 
 ### Community 265 - "Community 265"
 Cohesion: 0.15
@@ -1852,8 +1846,8 @@ Cohesion: 0.28
 Nodes (7): LocatorRanker, ScoredLocator, ElementSnapshot, EventContext, LocatorCandidate, LocatorSelection, String
 
 ### Community 269 - "Community 269"
-Cohesion: 0.19
-Nodes (10): WebDriverAssertions, WebDriverVerifications, WizardHelpers, By, DriverFactoryHelper, NativeValidationsBuilder, Object, Override (+2 more)
+Cohesion: 0.18
+Nodes (11): $, WebDriverAssertions, WebDriverVerifications, WizardHelpers, By, DriverFactoryHelper, NativeValidationsBuilder, Object (+3 more)
 
 ### Community 270 - "Community 270"
 Cohesion: 0.25
@@ -1884,16 +1878,16 @@ Cohesion: 0.19
 Nodes (10): NaturalActionExecutor, By, CharSequence, DriverFactoryHelper, NaturalActionPlan, Object, Set, String (+2 more)
 
 ### Community 277 - "Community 277"
-Cohesion: 0.13
-Nodes (12): AlertEvent, DataPlan, CodegenBackend, ElementSnapshot, EventContext, ExternalTestDataReference, LocatorCandidate, LocatorSelection (+4 more)
+Cohesion: 0.21
+Nodes (6): CheckpointCounter, CheckpointStatus, CheckpointType, String, Test, CheckpointAndReportingTest
 
 ### Community 279 - "Community 279"
 Cohesion: 0.20
 Nodes (3): BeforeClass, Test, TestDataUnitTest
 
 ### Community 280 - "Community 280"
-Cohesion: 0.26
-Nodes (8): TraceServiceTest, McpTraceLatestResult, McpTraceReadResult, Tool, Path, String, Test, TraceService
+Cohesion: 0.40
+Nodes (5): TraceServiceTest, Path, String, Test, TraceService
 
 ### Community 281 - "Community 281"
 Cohesion: 0.18
@@ -1905,7 +1899,7 @@ Nodes (9): main(), text(), validate_maven_jvm_configuration(), validate_quality_
 
 ### Community 283 - "Community 283"
 Cohesion: 0.29
-Nodes (15): copy(), dataBoolean(), dataInt(), dataStrings(), fromJson(), generated(), longValue(), map() (+7 more)
+Nodes (16): copy(), dataBoolean(), dataInt(), dataString(), dataStrings(), fromJson(), generated(), longValue() (+8 more)
 
 ### Community 284 - "Community 284"
 Cohesion: 0.18
@@ -1920,7 +1914,7 @@ Cohesion: 0.18
 Nodes (7): HealingActionsIntegrationTest, AfterMethod, BeforeMethod, DataProvider, Object, String, Test
 
 ### Community 287 - "Community 287"
-Cohesion: 0.19
+Cohesion: 0.20
 Nodes (7): AnimatedGifManagerCoverageUnitTest, AfterMethod, BeforeMethod, Color, Method, String, Test
 
 ### Community 288 - "Community 288"
@@ -1940,8 +1934,8 @@ Cohesion: 0.17
 Nodes (6): ProgressBarLogger, ProgressBarLoggerCoverageUnitTest, Override, String, AfterMethod, Test
 
 ### Community 293 - "Community 293"
-Cohesion: 0.22
-Nodes (9): AtomicInteger, BrowserNetworkInterceptionRule, FilterableRequestSpecification, HttpRequest, HttpResponse, List, Response, Set (+1 more)
+Cohesion: 0.25
+Nodes (7): AtomicInteger, BrowserNetworkInterceptionRule, FilterableRequestSpecification, HttpRequest, HttpResponse, List, Response
 
 ### Community 294 - "Community 294"
 Cohesion: 0.32
@@ -1968,12 +1962,12 @@ Cohesion: 0.21
 Nodes (4): AfterClass, BeforeClass, Test, FileHelperUnitTest
 
 ### Community 300 - "Community 300"
-Cohesion: 0.22
-Nodes (7): ManagedCaptureRecorderControlTest, CaptureBrowser, CaptureStartOptions, CaptureStartRequest, Object, SuppressWarnings, Test
+Cohesion: 0.17
+Nodes (9): CaptureEventPipeline, ManagedCaptureRecorderControlTest, CaptureSessionStore, CaptureBrowser, CaptureStartOptions, CaptureStartRequest, Object, SuppressWarnings (+1 more)
 
 ### Community 301 - "Community 301"
-Cohesion: 0.12
-Nodes (11): FluentWebDriverAction, SelectedValueTests, Actions, AlertActions, BrowserActions, DriverFactoryHelper, TouchActions, WebDriver (+3 more)
+Cohesion: 0.19
+Nodes (7): FluentWebDriverAction, Actions, AlertActions, BrowserActions, DriverFactoryHelper, TouchActions, WebDriver
 
 ### Community 302 - "Community 302"
 Cohesion: 0.21
@@ -1992,8 +1986,8 @@ Cohesion: 0.22
 Nodes (8): AccessibilityResult, AfterMethod, BeforeMethod, List, Rule, String, Test, AccessibilityActionsCoverageUnitTest
 
 ### Community 307 - "Community 307"
-Cohesion: 0.22
-Nodes (3): AfterMethod, Test, DriverFactoryCoverageUnitTest
+Cohesion: 0.24
+Nodes (8): GuardedPatch, RepairGuard, FilePatch, List, Path, Set, String, ValidationCommand
 
 ### Community 308 - "Community 308"
 Cohesion: 0.15
@@ -2008,8 +2002,8 @@ Cohesion: 0.15
 Nodes (10): AllureCucumber7Jvm, CucumberTestRunnerListener, EventPublisher, Feature, Optional, Override, TestCaseFinished, TestSourceParsed (+2 more)
 
 ### Community 312 - "Community 312"
-Cohesion: 0.13
-Nodes (14): AiProvider, DoctorServiceTest, DoctorSnippetProvider, AfterEach, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse (+6 more)
+Cohesion: 0.26
+Nodes (6): DoctorServiceTest, DoctorService, McpAnalysisReport, Path, String, Test
 
 ### Community 313 - "Community 313"
 Cohesion: 0.27
@@ -2024,28 +2018,28 @@ Cohesion: 0.16
 Nodes (9): HealingProvider, HealingActionOutcome, HealingExplanation, HealingObservation, HealingRequest, HealingResolution, Optional, String (+1 more)
 
 ### Community 316 - "Community 316"
-Cohesion: 0.27
-Nodes (5): BrowserStackHelper, Boolean, DriverFactoryHelper, MutableCapabilities, String
+Cohesion: 0.20
+Nodes (7): BrowserStackHelper, JunitListenerHelper, Boolean, DriverFactoryHelper, MutableCapabilities, String, TestIdentifier
 
 ### Community 317 - "Community 317"
 Cohesion: 0.33
 Nodes (6): HealingLocatorProposalServiceTest, AfterEach, BeforeEach, Path, String, Test
 
 ### Community 318 - "Community 318"
-Cohesion: 0.29
-Nodes (7): DeterministicScorerTest, Double, HealingConfiguration, LocatorFingerprint, RankedCandidate, String, Test
+Cohesion: 0.14
+Nodes (14): DecisionResult, DeterministicScorerTest, HealingDecisionEngine, HealingConfiguration, List, RankedCandidate, Status, String (+6 more)
 
 ### Community 319 - "Community 319"
-Cohesion: 0.42
-Nodes (4): Cucumber, DefaultValue, Key, String
+Cohesion: 0.33
+Nodes (6): Cucumber, CucumberTests, DefaultValue, Key, String, Test
 
 ### Community 320 - "Community 320"
 Cohesion: 0.31
 Nodes (7): BrowserAssertions, NativeValidationsBuilder, Override, PlaywrightSession, String, ValidationCategory, PlaywrightBrowserValidationsBuilder
 
 ### Community 321 - "Community 321"
-Cohesion: 0.14
-Nodes (13): LocatorSignal, matches(), CaptureEvent, CapturePrivacyPolicy, CaptureSessionStore, Consumer, ExternalTestDataReference, Instant (+5 more)
+Cohesion: 0.15
+Nodes (12): LocatorSignal, matches(), CapturePrivacyPolicy, CaptureSessionStore, Consumer, Instant, JsonNode, List (+4 more)
 
 ### Community 322 - "Community 322"
 Cohesion: 0.27
@@ -2088,8 +2082,12 @@ Cohesion: 0.19
 Nodes (14): A(), Ae(), b(), ce(), ge(), le(), pe(), qe() (+6 more)
 
 ### Community 333 - "Community 333"
-Cohesion: 0.06
-Nodes (29): empty(), reviewUiPath(), disabled(), McpResultRecordsTest, PlaywrightServiceTest, disabled(), empty(), defaults() (+21 more)
+Cohesion: 0.24
+Nodes (5): List, Set, String, Test, TelemetryDeduplicationUnitTest
+
+### Community 334 - "Community 334"
+Cohesion: 0.14
+Nodes (6): CoverageTests, AfterClass, AfterMethod, BeforeClass, BeforeMethod, Test
 
 ### Community 335 - "Community 335"
 Cohesion: 0.17
@@ -2112,16 +2110,16 @@ Cohesion: 0.26
 Nodes (6): ModelSupport, JsonNode, List, Map, String, T
 
 ### Community 340 - "Community 340"
-Cohesion: 0.17
-Nodes (7): OpenApiCoverageReporter, AssertionError, HttpMethod, RequestType, String, Throwable, SpecCoverage
+Cohesion: 0.08
+Nodes (20): OpenApiCoverageReporter, OperationCoverage, SpecCoverage, OpenApiCoverageReporterUnitTest, OpenAPI, OpenApiValidationException, OpenApiValidationFilter, OperationCoverage (+12 more)
 
 ### Community 341 - "Community 341"
 Cohesion: 0.14
 Nodes (14): items, tags, items, additionalProperties, minLength, pattern, properties, required (+6 more)
 
 ### Community 342 - "Community 342"
-Cohesion: 0.21
-Nodes (7): EngineService, PostConstruct, BrowserType, Path, String, Tool, WebDriver
+Cohesion: 0.19
+Nodes (8): EngineService, PostConstruct, BrowserType, By, Path, String, Tool, WebDriver
 
 ### Community 343 - "Community 343"
 Cohesion: 0.25
@@ -2136,8 +2134,8 @@ Cohesion: 0.23
 Nodes (12): ActionMetadata, disabled(), HealingReport(), minimized(), pending(), ProviderMetadata(), PrivacyMetadata, HealingCandidate (+4 more)
 
 ### Community 346 - "Community 346"
-Cohesion: 0.39
-Nodes (5): HealerServiceTest, HealerService, Path, String, Test
+Cohesion: 0.24
+Nodes (6): ElementActionsHelper, ScreenshotManagerCoverageUnitTest, AfterMethod, BeforeMethod, Color, Test
 
 ### Community 347 - "Community 347"
 Cohesion: 0.18
@@ -2156,7 +2154,7 @@ Cohesion: 0.40
 Nodes (12): configuration_path(), expected_java(), installed_args(), installed_dependencies(), installed_jar(), installer_command(), main(), sha256() (+4 more)
 
 ### Community 351 - "Community 351"
-Cohesion: 0.22
+Cohesion: 0.20
 Nodes (7): BrowserPerformanceExecutionReportUnitTest, AfterMethod, BeforeMethod, CapturedFile, List, String, Test
 
 ### Community 352 - "Community 352"
@@ -2164,8 +2162,8 @@ Cohesion: 0.18
 Nodes (6): AfterMethod, DataProvider, Object, String, Test, DriverFactoryHelperUnitTest
 
 ### Community 353 - "Community 353"
-Cohesion: 0.15
-Nodes (8): EXCEL, ExcelFileManager, TestDataTests, String, Test, BeforeClass, Test, IoExcelFileManagerTests
+Cohesion: 0.24
+Nodes (5): EXCEL, ExcelFileManager, TestDataTests, String, Test
 
 ### Community 354 - "Community 354"
 Cohesion: 0.08
@@ -2200,8 +2198,8 @@ Cohesion: 0.27
 Nodes (4): AfterMethod, Object, Test, APIPropertiesUnitTest
 
 ### Community 363 - "Community 363"
-Cohesion: 0.12
-Nodes (13): AutoCloseable, SessionPermit, FileChannel, FileLock, CaptureSingleSessionLock, Override, Path, Override (+5 more)
+Cohesion: 0.29
+Nodes (5): HttpExchange, HttpServer, Override, String, LocalApiServer
 
 ### Community 364 - "Community 364"
 Cohesion: 0.08
@@ -2220,12 +2218,12 @@ Cohesion: 0.29
 Nodes (7): Description, AfterMethod, BeforeClass, BeforeMethod, Step, Test, FluentGuiActionsTest
 
 ### Community 368 - "Community 368"
-Cohesion: 0.32
+Cohesion: 0.31
 Nodes (6): CaptureGeneratedReplayBrowserTest, CaptureSession, ElementSnapshot, ExternalTestDataReference, String, Test
 
 ### Community 369 - "Community 369"
-Cohesion: 0.22
-Nodes (7): DriverAssertions, BrowserAssertions, By, ElementAssertions, NativeValidationsBuilder, Object, ShaftLocator
+Cohesion: 0.32
+Nodes (4): CSVFileManager, List, Map, String
 
 ### Community 370 - "Community 370"
 Cohesion: 0.28
@@ -2236,20 +2234,20 @@ Cohesion: 0.23
 Nodes (8): VisualProcessingProvider, Boolean, By, Integer, List, String, VisualValidationEngine, WebDriver
 
 ### Community 372 - "Community 372"
-Cohesion: 0.20
+Cohesion: 0.19
 Nodes (9): CaptureFixtures, PageContext, BrowserMetadata, CaptureEvent, CaptureSession, ElementSnapshot, EventContext, ExternalTestDataReference (+1 more)
 
 ### Community 373 - "Community 373"
-Cohesion: 0.11
-Nodes (7): RestActionsCoverageUnitTest, JSONValidationsBuilder, Object, RestValidationsBuilder, ValidationsExecutor, AfterMethod, Test
+Cohesion: 0.13
+Nodes (3): RestActionsCoverageUnitTest, AfterMethod, Test
 
 ### Community 374 - "Community 374"
 Cohesion: 0.10
 Nodes (14): ExhaustedLauncherRetryFixture, JunitExtensionLifecycleTest, LauncherRetryFixture, OuterSessionStateRetryFixture, Order, AfterEach, BeforeAll, BeforeEach (+6 more)
 
 ### Community 375 - "Community 375"
-Cohesion: 0.22
-Nodes (8): AccessibilityActions, BrowserNetworkInterceptionRule, DriverFactoryHelper, HttpRequest, HttpResponse, Predicate, Step, WebDriver
+Cohesion: 0.20
+Nodes (9): AccessibilityActions, BrowserNetworkInterceptionRule, DriverFactoryHelper, HttpRequest, HttpResponse, Predicate, Step, URI (+1 more)
 
 ### Community 376 - "Community 376"
 Cohesion: 0.17
@@ -2272,12 +2270,12 @@ Cohesion: 0.25
 Nodes (13): apply(), applyEnabled(), current(), NaturalActionService, textOrDefault(), withOverrides(), McpNaturalActionResult, NaturalActionSettings (+5 more)
 
 ### Community 381 - "Community 381"
-Cohesion: 0.18
-Nodes (7): AssertEqualsTests, VerifyEqualsTests, BeforeMethod, Test, AfterMethod, BeforeMethod, Test
+Cohesion: 0.20
+Nodes (3): CSVFileManagerTest, BeforeMethod, Test
 
 ### Community 382 - "Community 382"
-Cohesion: 0.22
-Nodes (7): DriverVerifications, BrowserAssertions, By, ElementAssertions, NativeValidationsBuilder, Object, ShaftLocator
+Cohesion: 0.21
+Nodes (7): IOSDriver, InputStream, Path, String, SuppressWarnings, WebDriver, RecordManager
 
 ### Community 383 - "Community 383"
 Cohesion: 0.29
@@ -2296,8 +2294,8 @@ Cohesion: 0.17
 Nodes (12): type, scope, pattern, type, branch, project, task, additionalProperties (+4 more)
 
 ### Community 387 - "Community 387"
-Cohesion: 0.19
-Nodes (7): HealingVisualProvider, OpenCvHealingVisualProvider, OpenCvHealingVisualProviderTest, Override, String, Color, Test
+Cohesion: 0.18
+Nodes (7): OpenCvVisualConsumer, HealingVisualProvider, OpenCvHealingVisualProvider, Override, String, Mat, String
 
 ### Community 388 - "Community 388"
 Cohesion: 0.17
@@ -2324,8 +2322,8 @@ Cohesion: 0.32
 Nodes (7): LocatorRankerTest, ElementSnapshot, List, LocatorCandidate, LocatorStrategy, String, Test
 
 ### Community 395 - "Community 395"
-Cohesion: 0.21
-Nodes (4): AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
+Cohesion: 0.23
+Nodes (8): AiProvider, DoctorSnippetProvider, AfterEach, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse, Override
 
 ### Community 396 - "Community 396"
 Cohesion: 0.18
@@ -2336,8 +2334,8 @@ Cohesion: 0.27
 Nodes (5): AiProviderRegistry, AiProvider, List, PilotConfiguration, String
 
 ### Community 398 - "Community 398"
-Cohesion: 0.22
-Nodes (18): append(), checkpoint(), complete(), ensureIncomplete(), interrupt(), sortedCheckpoints(), sortedEvents(), sortedReferences() (+10 more)
+Cohesion: 0.21
+Nodes (8): AutoCloseable, SessionPermit, FileChannel, FileLock, CaptureSingleSessionLock, Override, Path, Override
 
 ### Community 399 - "Community 399"
 Cohesion: 0.25
@@ -2352,7 +2350,7 @@ Cohesion: 0.25
 Nodes (6): McpServiceHelperTest, AfterEach, Class, Object, String, Test
 
 ### Community 402 - "Community 402"
-Cohesion: 0.24
+Cohesion: 0.25
 Nodes (3): ActionsExceptionDetailsUnitTest, NoSuchElementException, Test
 
 ### Community 403 - "Community 403"
@@ -2360,8 +2358,8 @@ Cohesion: 0.38
 Nodes (10): aiTrigger(), bounded(), current(), HealingConfiguration(), split(), Duration, List, Path (+2 more)
 
 ### Community 404 - "Community 404"
-Cohesion: 0.20
-Nodes (8): OperationCoverage, SpecCoverage, OpenAPI, OpenApiValidationFilter, OperationCoverage, List, ObjectNode, StringBuilder
+Cohesion: 0.35
+Nodes (3): BrowserEventScript, List, String
 
 ### Community 405 - "Community 405"
 Cohesion: 0.29
@@ -2384,12 +2382,12 @@ Cohesion: 0.29
 Nodes (4): GroupsTests, AfterMethod, BeforeMethod, Test
 
 ### Community 410 - "Community 410"
-Cohesion: 0.15
-Nodes (13): ActionCandidate, safe(), McpCaptureCodeBlockService, PomCandidates, CaptureGenerationReport, List, LocatorCandidate, LocatorDecision (+5 more)
+Cohesion: 0.16
+Nodes (11): ActionCandidate, McpCaptureCodeBlockService, PomCandidates, CaptureGenerationReport, List, LocatorCandidate, LocatorDecision, McpCodeBlock (+3 more)
 
 ### Community 411 - "Community 411"
-Cohesion: 0.14
-Nodes (7): AndroidDragAndDropTest, AndroidTouchActionsTests, MobileTest, Test, Test, AfterMethod, BeforeMethod
+Cohesion: 0.12
+Nodes (8): AndroidDragAndDropTest, AndroidTouchActionsTests, MobileTest, ScreenOrientation, Test, Test, AfterMethod, BeforeMethod
 
 ### Community 412 - "Community 412"
 Cohesion: 0.23
@@ -2440,20 +2438,20 @@ Cohesion: 0.33
 Nodes (4): HoverTests, AfterMethod, BeforeMethod, Test
 
 ### Community 425 - "Community 425"
-Cohesion: 0.13
-Nodes (15): Controller, Headers, Controller, McpAppiumInspectorProxy, McpAppiumCommandRecorder, Builder, HttpExchange, HttpResponse (+7 more)
+Cohesion: 0.06
+Nodes (38): AiProviderRegistryTest, availability(), capabilities(), execute(), CompletableFuture, Controller, Headers, Controller (+30 more)
 
 ### Community 426 - "Community 426"
-Cohesion: 0.13
-Nodes (14): AlphaProvider, VisualProcessingProviderRegistryTest, ZuluProvider, AfterMethod, Boolean, By, Integer, List (+6 more)
+Cohesion: 0.23
+Nodes (11): AlphaProvider, ZuluProvider, Boolean, By, Integer, List, Override, String (+3 more)
 
 ### Community 427 - "Community 427"
 Cohesion: 0.26
 Nodes (7): ApiPerformanceExecutionReportUnitTest, AfterMethod, CapturedFile, JsonNode, List, String, Test
 
 ### Community 428 - "Community 428"
-Cohesion: 0.24
-Nodes (4): PlaywrightTraceManager, PlaywrightTraceManager, BrowserContext, Path
+Cohesion: 0.36
+Nodes (3): PlaywrightTraceManager, BrowserContext, Path
 
 ### Community 430 - "Community 430"
 Cohesion: 0.26
@@ -2464,7 +2462,7 @@ Cohesion: 0.31
 Nodes (4): BigPageActionsTest, AfterMethod, BeforeMethod, Test
 
 ### Community 432 - "Community 432"
-Cohesion: 0.33
+Cohesion: 0.29
 Nodes (3): Class, Test, GUIInterfaceCompatibilityCoverageUnitTest
 
 ### Community 434 - "Community 434"
@@ -2472,8 +2470,8 @@ Cohesion: 0.21
 Nodes (6): AfterMethod, Class, Object, String, Test, BrowserStackHelperUnitTest
 
 ### Community 435 - "Community 435"
-Cohesion: 0.17
-Nodes (11): AiProviderRegistryTest, availability(), capabilities(), execute(), AfterEach, AiCapabilities, AiProviderAvailability, AiRequest (+3 more)
+Cohesion: 0.27
+Nodes (4): ArrayNode, InputStream, List, ObjectNode
 
 ### Community 436 - "Community 436"
 Cohesion: 0.18
@@ -2512,8 +2510,8 @@ Cohesion: 0.23
 Nodes (6): AfterMethod, DataProvider, Object, String, Test, PropertiesHelperEvidenceLevelUnitTest
 
 ### Community 445 - "Community 445"
-Cohesion: 0.19
-Nodes (7): FilesSize, DeterministicNaturalActionPlannerTest, NaturalActionRequest, String, Test, Test, RestActionsFailureLoggingUnitTest
+Cohesion: 0.10
+Nodes (14): Callable, FilesSize, from(), DeterministicNaturalActionPlannerTest, Path, Test, DoctorAnalysisResult, DoctorAnalysisSummary (+6 more)
 
 ### Community 446 - "Community 446"
 Cohesion: 0.31
@@ -2532,7 +2530,7 @@ Cohesion: 0.33
 Nodes (5): steps, Given, String, Then, When
 
 ### Community 451 - "Community 451"
-Cohesion: 0.21
+Cohesion: 0.17
 Nodes (4): AlertActions, Override, PlaywrightSession, String
 
 ### Community 452 - "Community 452"
@@ -2576,8 +2574,8 @@ Cohesion: 0.36
 Nodes (4): ChecksumTests, Path, String, Test
 
 ### Community 463 - "Community 463"
-Cohesion: 0.21
-Nodes (7): DisabledAiProvider, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse, Override, String
+Cohesion: 0.14
+Nodes (11): ready(), unavailable(), DisabledAiProvider, AiProviderAvailability, String, AiCapabilities, AiProviderAvailability, AiRequest (+3 more)
 
 ### Community 464 - "Community 464"
 Cohesion: 0.21
@@ -2592,8 +2590,8 @@ Cohesion: 0.25
 Nodes (4): NaturalActionPlanner, NaturalActionPlan, NaturalActionRequest, String
 
 ### Community 467 - "Community 467"
-Cohesion: 0.19
-Nodes (5): LightHouseGenerateReport, LightHouseGenerateReportCoverageUnitTest, WebDriver, AfterMethod, Test
+Cohesion: 0.18
+Nodes (6): LightHouseGenerateReport, LightHouseGenerateReportCoverageUnitTest, String, WebDriver, AfterMethod, Test
 
 ### Community 468 - "Community 468"
 Cohesion: 0.31
@@ -2604,7 +2602,7 @@ Cohesion: 0.17
 Nodes (6): Performance, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 471 - "Community 471"
-Cohesion: 0.31
+Cohesion: 0.26
 Nodes (4): JunitDatabaseSmokeTest, AfterAll, BeforeAll, Test
 
 ### Community 472 - "Community 472"
@@ -2648,12 +2646,12 @@ Cohesion: 0.32
 Nodes (4): ValidationsExecutorTestAccessor, Object, ValidationsExecutor, WebDriver
 
 ### Community 482 - "Community 482"
-Cohesion: 0.27
-Nodes (7): DecisionResult, HealingDecisionEngine, HealingConfiguration, List, RankedCandidate, Status, String
+Cohesion: 0.24
+Nodes (6): Class, Object, String, SuppressWarnings, Test, SmartLocatorsCoverageUnitTest
 
 ### Community 483 - "Community 483"
-Cohesion: 0.31
-Nodes (3): DbTests, BeforeClass, Test
+Cohesion: 0.21
+Nodes (5): DatabaseActions, DbTests, BeforeClass, Test, DBWizardTests
 
 ### Community 484 - "Community 484"
 Cohesion: 0.36
@@ -2692,8 +2690,8 @@ Cohesion: 0.36
 Nodes (4): IsElementClickableTest, AfterMethod, BeforeMethod, Test
 
 ### Community 493 - "Community 493"
-Cohesion: 0.21
-Nodes (6): ready(), unavailable(), AiValueObjectsTest, AiProviderAvailability, String, Test
+Cohesion: 0.24
+Nodes (6): StubProvider, AiCapabilities, AiProviderAvailability, Override, ProcessingLocation, String
 
 ### Community 494 - "Community 494"
 Cohesion: 0.38
@@ -2728,8 +2726,8 @@ Cohesion: 0.29
 Nodes (4): PlaywrightNaturalActionExecutorTest, AfterMethod, BeforeMethod, Test
 
 ### Community 502 - "Community 502"
-Cohesion: 0.16
-Nodes (14): FakeRunner, McpMobileToolchainServiceTest, McpProcessRunner, Duration, List, Map, McpMobileToolchainDiagnostic, McpMobileToolchainStatus (+6 more)
+Cohesion: 0.17
+Nodes (13): FakeRunner, McpMobileToolchainServiceTest, Duration, List, Map, McpMobileToolchainDiagnostic, McpMobileToolchainStatus, Override (+5 more)
 
 ### Community 504 - "Community 504"
 Cohesion: 0.36
@@ -2760,16 +2758,16 @@ Cohesion: 0.36
 Nodes (4): AfterMethod, BeforeMethod, Test, CustomDriverInitializationTests
 
 ### Community 511 - "Community 511"
-Cohesion: 0.22
-Nodes (9): FailureBriefReporterTest, AssertionError, Attachment, List, String, SuppressWarnings, Test, TestExecutionInfo (+1 more)
+Cohesion: 0.31
+Nodes (3): VisualProcessingProviderRegistryTest, AfterMethod, Test
 
 ### Community 512 - "Community 512"
-Cohesion: 0.31
-Nodes (4): LocalApiTestServer, HttpExchange, HttpServer, String
+Cohesion: 0.14
+Nodes (10): LocalApiTestServer, LogRedirector, Logger, InputStream, OutputStream, Level, Override, HttpExchange (+2 more)
 
 ### Community 513 - "Community 513"
-Cohesion: 0.06
-Nodes (21): testPostRequest, ArrayList, SHAFT, FileInputStream, AppiumMobileConsumer, BrowserStackSdkConsumer, LegacyCoordinateConsumer, StatusIcon() (+13 more)
+Cohesion: 0.05
+Nodes (30): ArrayList, CapturePrivacyClassifier, SHAFT, SynchronizationManager, FileInputStream, AppiumMobileConsumer, BrowserStackSdkConsumer, LegacyCoordinateConsumer (+22 more)
 
 ### Community 514 - "Community 514"
 Cohesion: 0.43
@@ -2820,15 +2818,15 @@ Cohesion: 0.39
 Nodes (3): BrowserAssertions, NativeValidationsBuilder, String
 
 ### Community 527 - "Community 527"
-Cohesion: 0.28
-Nodes (3): ThreadLocalPropertiesManager, Properties, String
+Cohesion: 0.31
+Nodes (4): SelectedValueTests, AfterMethod, BeforeMethod, Test
 
 ### Community 528 - "Community 528"
 Cohesion: 0.25
 Nodes (5): CaptureServiceTest, CaptureService, CaptureSession, Path, Test
 
 ### Community 529 - "Community 529"
-Cohesion: 0.20
+Cohesion: 0.22
 Nodes (6): RetryAnalyzer, SupportingEvidenceState, IRetryAnalyzer, ITestResult, Override, String
 
 ### Community 530 - "Community 530"
@@ -2877,7 +2875,7 @@ Nodes (5): SmartLocatorsRealisticTests, Test, AfterClass, BeforeClass, TestScena
 
 ### Community 543 - "Community 543"
 Cohesion: 0.33
-Nodes (5): SynchronizationManager, Class, Exception, List, WebDriver
+Nodes (3): BeforeClass, Test, IoExcelFileManagerTests
 
 ### Community 544 - "Community 544"
 Cohesion: 0.47
@@ -2932,16 +2930,16 @@ Cohesion: 0.33
 Nodes (3): ValidationsHelperNewPatternCoverageUnitTest, AfterMethod, Test
 
 ### Community 558 - "Community 558"
-Cohesion: 0.14
-Nodes (10): InputStream, AfterMethod, BeforeMethod, Test, Override, Path, Test, CloseTrackingInputStream (+2 more)
+Cohesion: 0.23
+Nodes (6): InputStream, Override, Path, Test, CloseTrackingInputStream, ReportManagerHelperAttachmentIoUnitTest
 
 ### Community 561 - "Community 561"
-Cohesion: 0.23
-Nodes (9): VisualEvidenceService, Double, HealingConfiguration, HealingVisualProvider, List, Optional, RankedCandidate, String (+1 more)
+Cohesion: 0.15
+Nodes (13): MultipleElementsFoundException, VisualEvidenceService, String, Throwable, Double, HealingConfiguration, HealingVisualProvider, List (+5 more)
 
 ### Community 562 - "Community 562"
-Cohesion: 0.27
-Nodes (9): DoctorReportWriter, Diagnosis, DoctorAdvisory, EvidenceBundle, List, Path, String, StringBuilder (+1 more)
+Cohesion: 0.11
+Nodes (15): MobileServiceConfigurationTest, PlaywrightServiceTest, DoctorReportWriter, Diagnosis, DoctorAdvisory, EvidenceBundle, List, Path (+7 more)
 
 ### Community 563 - "Community 563"
 Cohesion: 0.43
@@ -2952,8 +2950,8 @@ Cohesion: 0.24
 Nodes (8): BrowsingContextInfo, BidiBrowserEventCollector, BrowserSignal, Consumer, List, Override, String, WebDriver
 
 ### Community 565 - "Community 565"
-Cohesion: 0.18
-Nodes (9): CaptureWorkbenchHtml, JunitCoreAssertionDependencyGuardTest, CaptureGenerationReport, CaptureReview, Path, String, Pattern, Path (+1 more)
+Cohesion: 0.35
+Nodes (5): CaptureWorkbenchHtml, CaptureGenerationReport, CaptureReview, Path, String
 
 ### Community 566 - "Community 566"
 Cohesion: 0.36
@@ -2980,8 +2978,8 @@ Cohesion: 0.40
 Nodes (4): Allowed Work, Constraints, Refresh Agent Guidance, Validation
 
 ### Community 572 - "Community 572"
-Cohesion: 0.15
-Nodes (9): Test_LTMobIPAAppURL, Test_LTMobIPARelativePath, AfterMethod, BeforeMethod, String, Test, AfterMethod, BeforeMethod (+1 more)
+Cohesion: 0.10
+Nodes (15): IOSBasicInteractionsTest, ElementActions, Test_LTMobIPAAppURL, Test_LTMobIPARelativePath, AfterMethod, BeforeMethod, SuppressWarnings, Test (+7 more)
 
 ### Community 573 - "Community 573"
 Cohesion: 0.39
@@ -3000,8 +2998,8 @@ Cohesion: 0.23
 Nodes (5): AfterMethod, BeforeMethod, Path, Test, ExcelFileManagerCoverageUnitTest
 
 ### Community 579 - "Community 579"
-Cohesion: 0.18
-Nodes (6): AsyncElementActionsCoverageUnitTest, JDK21VirtualThreadsAndAsyncActionsTests, Test, AfterMethod, BeforeMethod, Test
+Cohesion: 0.29
+Nodes (4): AfterMethod, String, Test, PropertiesHelperInitializationUnitTest
 
 ### Community 580 - "Community 580"
 Cohesion: 0.50
@@ -3019,6 +3017,10 @@ Nodes (4): WaitActionsTest, AfterMethod, BeforeMethod, Test
 Cohesion: 0.27
 Nodes (9): agent_upgrade_plan(), ProjectAnalysis, Return whether source rewrites are eligible for this project., Validate the requested upgrade type against the detected project shape., Return a machine-readable upgrade menu for AI agents., Detected Maven project shape and requested SHAFT migration., Return optional modules supported by scan evidence., source_upgrade_supported() (+1 more)
 
+### Community 587 - "Community 587"
+Cohesion: 0.22
+Nodes (6): BrowserStackModuleTest, Constructor, InvocationTargetException, JsonSchemaValidatorTest, Test, Test
+
 ### Community 588 - "Community 588"
 Cohesion: 0.23
 Nodes (4): UnitTestsSHAFT, CSVFileManager, CSV, Test
@@ -3027,8 +3029,12 @@ Nodes (4): UnitTestsSHAFT, CSVFileManager, CSV, Test
 Cohesion: 0.50
 Nodes (3): { Client }, pgclient, values
 
+### Community 594 - "Community 594"
+Cohesion: 0.47
+Nodes (3): PathsTests, BeforeClass, Test
+
 ### Community 597 - "Community 597"
-Cohesion: 0.38
+Cohesion: 0.36
 Nodes (4): RemoteGridVideoAttachmentIT, AfterMethod, BeforeMethod, Test
 
 ### Community 599 - "Community 599"
@@ -3068,7 +3074,7 @@ Cohesion: 0.47
 Nodes (3): VisualsTests, BeforeClass, Test
 
 ### Community 626 - "Community 626"
-Cohesion: 0.31
+Cohesion: 0.25
 Nodes (6): HttpContractRecorderTest, AfterMethod, FilterableRequestSpecification, Response, String, Test
 
 ### Community 628 - "Community 628"
@@ -3084,8 +3090,8 @@ Cohesion: 0.43
 Nodes (3): AfterMethod, Test, PropertiesHelperMaximumPerformanceModeUnitTest
 
 ### Community 653 - "Community 653"
-Cohesion: 0.26
-Nodes (4): AfterMethod, BeforeMethod, Test, BrowserActionsHelperCoverageUnitTest
+Cohesion: 0.28
+Nodes (5): JSONValidationsBuilder, NativeValidationsBuilder, Object, RestValidationsBuilder, ValidationsExecutor
 
 ### Community 654 - "Community 654"
 Cohesion: 0.22
@@ -3120,12 +3126,12 @@ Cohesion: 0.47
 Nodes (3): TinkeyTests, BeforeClass, Test
 
 ### Community 662 - "Community 662"
-Cohesion: 0.29
+Cohesion: 0.36
 Nodes (3): Contract, Interaction, Path
 
 ### Community 663 - "Community 663"
-Cohesion: 0.25
-Nodes (4): DatabaseActions, DB, DatabaseType, ResultSet
+Cohesion: 0.33
+Nodes (3): DB, DatabaseType, ResultSet
 
 ### Community 664 - "Community 664"
 Cohesion: 0.42
@@ -3136,12 +3142,12 @@ Cohesion: 0.42
 Nodes (5): ClassifiedValue, Collection, Path, String, ExternalTestDataWriter
 
 ### Community 666 - "Community 666"
-Cohesion: 0.26
-Nodes (4): OptionsManagerCoverageUnitTest, AfterMethod, BeforeMethod, Test
+Cohesion: 0.43
+Nodes (5): ClassLoader, OpenCvBlockingClassLoader, Class, Override, String
 
 ### Community 667 - "Community 667"
-Cohesion: 0.33
-Nodes (3): ShaftHeal, HealingReport, Optional
+Cohesion: 0.50
+Nodes (3): CapturePrivacyClassifierTest, Path, Test
 
 ### Community 668 - "Community 668"
 Cohesion: 0.29
@@ -3160,20 +3166,20 @@ Cohesion: 0.36
 Nodes (4): RelativeLocatorsTests, AfterMethod, BeforeMethod, Test
 
 ### Community 672 - "Community 672"
-Cohesion: 0.25
-Nodes (5): OpenApiCoverageReporterUnitTest, OpenApiValidationException, AfterMethod, String, Test
+Cohesion: 0.36
+Nodes (4): AfterMethod, BeforeMethod, Test, RecordManagerCoverageUnitTest
 
 ### Community 673 - "Community 673"
-Cohesion: 0.31
-Nodes (5): IOSBasicInteractionsTest, AfterMethod, BeforeMethod, SuppressWarnings, Test
+Cohesion: 0.29
+Nodes (3): Connection, BeforeMethod, ResultSet
 
 ### Community 675 - "Community 675"
-Cohesion: 0.67
-Nodes (3): defaults(), CaptureGenerationRequest, Path
+Cohesion: 0.43
+Nodes (7): EnrichmentMode, CaptureGenerationRequest(), defaults(), ApprovalPolicy, Duration, Path, String
 
 ### Community 676 - "Community 676"
-Cohesion: 0.33
-Nodes (4): CaptureFormatException, String, Throwable, IllegalArgumentException
+Cohesion: 0.22
+Nodes (8): CaptureFormatException, McpWorkspacePolicy, String, Throwable, IllegalArgumentException, List, Path, String
 
 ### Community 677 - "Community 677"
 Cohesion: 0.36
@@ -3188,8 +3194,8 @@ Cohesion: 0.50
 Nodes (3): JiraTests, BeforeClass, Test
 
 ### Community 686 - "Community 686"
-Cohesion: 0.40
-Nodes (4): MultipleElementsFoundException, String, Throwable, WebDriverException
+Cohesion: 0.48
+Nodes (3): OpenCvHealingVisualProviderTest, Color, Test
 
 ### Community 687 - "Community 687"
 Cohesion: 0.33
@@ -3198,10 +3204,6 @@ Nodes (5): $id, required, $schema, title, type
 ### Community 708 - "Community 708"
 Cohesion: 0.50
 Nodes (4): McpMobileSessionResult(), List, McpCodeBlock, String
-
-### Community 753 - "Community 753"
-Cohesion: 0.36
-Nodes (5): LogRedirector, Logger, OutputStream, Level, Override
 
 ### Community 758 - "Community 758"
 Cohesion: 0.60
@@ -3218,10 +3220,6 @@ Nodes (7): CaptureReadinessTest, CaptureEvent, CaptureSession, ElementSnapshot, 
 ### Community 763 - "Community 763"
 Cohesion: 0.17
 Nodes (9): AccessibilityActions, AccessibilityConfig, AccessibilityResult, BrowserActions, BrowserActionsContract, List, Page, String (+1 more)
-
-### Community 766 - "Community 766"
-Cohesion: 0.27
-Nodes (3): AfterMethod, Test, LambdaTestHelperUnitTest
 
 ### Community 768 - "Community 768"
 Cohesion: 0.40
@@ -3248,8 +3246,12 @@ Cohesion: 0.53
 Nodes (3): Path, Test, ExecutionLifecycleHelperSourceUnitTest
 
 ### Community 782 - "Community 782"
-Cohesion: 0.31
+Cohesion: 0.29
 Nodes (5): AfterMethod, BeforeClass, BeforeMethod, Test, TestClass
+
+### Community 786 - "Community 786"
+Cohesion: 0.50
+Nodes (3): By, Locator, Page
 
 ### Community 787 - "Community 787"
 Cohesion: 0.16
@@ -3260,8 +3262,8 @@ Cohesion: 0.29
 Nodes (8): ensure_shaft_import(), migrate_full_source(), migrate_session_source(), Add the SHAFT import required by rewritten Java source., Wrap basic Selenium/Appium driver construction with SHAFT's driver session., Return SHAFT driver variable names from rewritten Java source., Replace simple Selenium actions with SHAFT engine action calls., shaft_driver_variables()
 
 ### Community 789 - "Community 789"
-Cohesion: 0.26
-Nodes (4): McpAppiumCommandRecorderTest, MobileRecordingServiceTest, Test, Test
+Cohesion: 0.40
+Nodes (3): DriverFactoryHelper, WebDriver, WebDriverElementValidationsBuilder
 
 ### Community 795 - "Community 795"
 Cohesion: 0.52
@@ -3300,12 +3302,8 @@ Cohesion: 0.33
 Nodes (3): PrivacySanitizer, SanitizedValue, String
 
 ### Community 817 - "Community 817"
-Cohesion: 0.08
-Nodes (19): RequestBuilder, RetryState, AuthenticationType, RetryPolicy, RetryState, API, ContentType, Deprecated (+11 more)
-
-### Community 831 - "Community 831"
-Cohesion: 0.70
-Nodes (4): HistoryRecord(), withChecksum(), LocatorFingerprint, String
+Cohesion: 0.11
+Nodes (15): RequestBuilder, RetryState, RetryPolicy, RetryState, API, Deprecated, Exception, RequestSpecification (+7 more)
 
 ### Community 833 - "Community 833"
 Cohesion: 0.27
@@ -3315,37 +3313,21 @@ Nodes (6): AfterMethod, BeforeMethod, HttpExchange, Object, String, XrayIntegrat
 Cohesion: 0.50
 Nodes (3): McpMobileToolchainService, McpMobileRecordingService, McpWorkspacePolicy
 
-### Community 840 - "Community 840"
-Cohesion: 0.39
-Nodes (5): PlaywrightNetworkInterceptorTest, Request, Route, String, Test
-
 ### Community 842 - "Community 842"
 Cohesion: 0.36
 Nodes (3): ProjectStructureManager, Path, RunType
 
-### Community 845 - "Community 845"
-Cohesion: 0.46
-Nodes (4): Callable, Path, Test, CaptureSessionStoreTest
-
-### Community 846 - "Community 846"
-Cohesion: 0.36
-Nodes (3): OpenCvVisualConsumer, Mat, String
-
 ### Community 847 - "Community 847"
-Cohesion: 0.25
-Nodes (5): DoctorFormatException, ProfileCleanupException, RuntimeException, String, Throwable
+Cohesion: 0.33
+Nodes (4): DoctorFormatException, RuntimeException, String, Throwable
 
 ### Community 848 - "Community 848"
-Cohesion: 0.36
-Nodes (4): HealingReportWriter, HealingConfiguration, HealingReport, String
+Cohesion: 0.67
+Nodes (3): build_parser(), ArgumentParser, Build the command-line parser.
 
 ### Community 849 - "Community 849"
 Cohesion: 0.39
 Nodes (3): ReportManager, Level, String
-
-### Community 850 - "Community 850"
-Cohesion: 0.39
-Nodes (4): JunitProjectStructureManagerTest, AfterEach, Path, Test
 
 ### Community 854 - "Community 854"
 Cohesion: 0.70
@@ -3358,21 +3340,21 @@ Nodes (3): McpCaptureCodeBlockService, CaptureManager, McpWorkspacePolicy
 ## Knowledge Gaps
 - **1527 isolated node(s):** `$id`, `$schema`, `additionalProperties`, `additionalProperties`, `type` (+1522 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **105 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **97 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `SHAFT` connect `Community 513` to `Community 514`, `Community 3`, `Community 517`, `Community 5`, `Community 7`, `Community 520`, `Community 9`, `Community 8`, `Community 10`, `Community 12`, `Community 13`, `Community 15`, `Community 16`, `Community 17`, `Community 18`, `Community 529`, `Community 19`, `Community 21`, `Community 23`, `Community 536`, `Community 24`, `Community 26`, `Community 538`, `Community 27`, `Community 540`, `Community 30`, `Community 31`, `Community 543`, `Community 33`, `Community 34`, `Community 547`, `Community 36`, `Community 35`, `Community 38`, `Community 544`, `Community 548`, `Community 546`, `Community 550`, `Community 43`, `Community 553`, `Community 45`, `Community 46`, `Community 557`, `Community 47`, `Community 49`, `Community 48`, `Community 563`, `Community 52`, `Community 53`, `Community 558`, `Community 55`, `Community 569`, `Community 57`, `Community 572`, `Community 65`, `Community 579`, `Community 69`, `Community 71`, `Community 584`, `Community 74`, `Community 588`, `Community 76`, `Community 77`, `Community 80`, `Community 81`, `Community 594`, `Community 597`, `Community 86`, `Community 87`, `Community 88`, `Community 89`, `Community 599`, `Community 98`, `Community 99`, `Community 615`, `Community 104`, `Community 106`, `Community 108`, `Community 621`, `Community 114`, `Community 626`, `Community 116`, `Community 628`, `Community 121`, `Community 123`, `Community 125`, `Community 129`, `Community 134`, `Community 137`, `Community 138`, `Community 650`, `Community 652`, `Community 653`, `Community 142`, `Community 654`, `Community 655`, `Community 657`, `Community 656`, `Community 145`, `Community 660`, `Community 661`, `Community 663`, `Community 539`, `Community 664`, `Community 666`, `Community 151`, `Community 156`, `Community 669`, `Community 670`, `Community 159`, `Community 672`, `Community 673`, `Community 671`, `Community 541`, `Community 32`, `Community 165`, `Community 678`, `Community 677`, `Community 167`, `Community 542`, `Community 170`, `Community 171`, `Community 172`, `Community 685`, `Community 174`, `Community 184`, `Community 185`, `Community 186`, `Community 190`, `Community 191`, `Community 196`, `Community 39`, `Community 200`, `Community 210`, `Community 214`, `Community 218`, `Community 219`, `Community 223`, `Community 225`, `Community 230`, `Community 555`, `Community 241`, `Community 243`, `Community 247`, `Community 763`, `Community 251`, `Community 253`, `Community 766`, `Community 771`, `Community 260`, `Community 261`, `Community 266`, `Community 781`, `Community 270`, `Community 271`, `Community 782`, `Community 785`, `Community 786`, `Community 275`, `Community 787`, `Community 276`, `Community 273`, `Community 279`, `Community 274`, `Community 281`, `Community 284`, `Community 286`, `Community 287`, `Community 290`, `Community 291`, `Community 293`, `Community 161`, `Community 301`, `Community 162`, `Community 817`, `Community 307`, `Community 308`, `Community 311`, `Community 312`, `Community 316`, `Community 317`, `Community 832`, `Community 833`, `Community 834`, `Community 327`, `Community 328`, `Community 329`, `Community 841`, `Community 330`, `Community 337`, `Community 850`, `Community 851`, `Community 348`, `Community 351`, `Community 352`, `Community 353`, `Community 354`, `Community 866`, `Community 358`, `Community 359`, `Community 360`, `Community 362`, `Community 364`, `Community 367`, `Community 373`, `Community 374`, `Community 375`, `Community 378`, `Community 379`, `Community 380`, `Community 381`, `Community 389`, `Community 390`, `Community 391`, `Community 392`, `Community 395`, `Community 399`, `Community 401`, `Community 403`, `Community 405`, `Community 407`, `Community 408`, `Community 409`, `Community 411`, `Community 424`, `Community 426`, `Community 427`, `Community 428`, `Community 429`, `Community 430`, `Community 431`, `Community 432`, `Community 434`, `Community 435`, `Community 444`, `Community 445`, `Community 446`, `Community 450`, `Community 454`, `Community 455`, `Community 456`, `Community 460`, `Community 461`, `Community 467`, `Community 468`, `Community 471`, `Community 473`, `Community 476`, `Community 484`, `Community 485`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 496`, `Community 498`, `Community 503`, `Community 504`, `Community 506`, `Community 509`, `Community 510`?**
+- **Why does `SHAFT` connect `Community 513` to `Community 514`, `Community 3`, `Community 517`, `Community 5`, `Community 7`, `Community 520`, `Community 9`, `Community 8`, `Community 10`, `Community 12`, `Community 13`, `Community 527`, `Community 15`, `Community 17`, `Community 18`, `Community 529`, `Community 19`, `Community 21`, `Community 22`, `Community 23`, `Community 536`, `Community 16`, `Community 26`, `Community 538`, `Community 27`, `Community 540`, `Community 30`, `Community 31`, `Community 541`, `Community 33`, `Community 34`, `Community 35`, `Community 547`, `Community 36`, `Community 38`, `Community 544`, `Community 548`, `Community 546`, `Community 550`, `Community 43`, `Community 553`, `Community 45`, `Community 46`, `Community 557`, `Community 47`, `Community 49`, `Community 48`, `Community 562`, `Community 52`, `Community 53`, `Community 563`, `Community 55`, `Community 569`, `Community 57`, `Community 572`, `Community 65`, `Community 69`, `Community 71`, `Community 584`, `Community 588`, `Community 76`, `Community 77`, `Community 80`, `Community 81`, `Community 594`, `Community 597`, `Community 86`, `Community 87`, `Community 88`, `Community 89`, `Community 599`, `Community 93`, `Community 96`, `Community 98`, `Community 99`, `Community 615`, `Community 104`, `Community 106`, `Community 108`, `Community 109`, `Community 621`, `Community 114`, `Community 626`, `Community 116`, `Community 628`, `Community 121`, `Community 123`, `Community 125`, `Community 129`, `Community 130`, `Community 137`, `Community 138`, `Community 650`, `Community 652`, `Community 142`, `Community 654`, `Community 655`, `Community 657`, `Community 656`, `Community 145`, `Community 660`, `Community 661`, `Community 151`, `Community 539`, `Community 664`, `Community 156`, `Community 669`, `Community 670`, `Community 159`, `Community 671`, `Community 161`, `Community 32`, `Community 162`, `Community 672`, `Community 165`, `Community 678`, `Community 677`, `Community 167`, `Community 542`, `Community 170`, `Community 172`, `Community 685`, `Community 174`, `Community 543`, `Community 184`, `Community 186`, `Community 190`, `Community 191`, `Community 196`, `Community 39`, `Community 200`, `Community 205`, `Community 210`, `Community 214`, `Community 217`, `Community 218`, `Community 219`, `Community 223`, `Community 225`, `Community 230`, `Community 555`, `Community 233`, `Community 241`, `Community 243`, `Community 247`, `Community 763`, `Community 251`, `Community 253`, `Community 770`, `Community 771`, `Community 260`, `Community 261`, `Community 266`, `Community 269`, `Community 270`, `Community 271`, `Community 782`, `Community 785`, `Community 273`, `Community 275`, `Community 787`, `Community 276`, `Community 781`, `Community 279`, `Community 274`, `Community 281`, `Community 284`, `Community 286`, `Community 287`, `Community 290`, `Community 291`, `Community 293`, `Community 817`, `Community 308`, `Community 311`, `Community 316`, `Community 317`, `Community 319`, `Community 833`, `Community 834`, `Community 838`, `Community 327`, `Community 328`, `Community 329`, `Community 841`, `Community 330`, `Community 844`, `Community 334`, `Community 337`, `Community 340`, `Community 342`, `Community 346`, `Community 348`, `Community 351`, `Community 352`, `Community 353`, `Community 354`, `Community 358`, `Community 359`, `Community 360`, `Community 362`, `Community 364`, `Community 367`, `Community 373`, `Community 374`, `Community 375`, `Community 378`, `Community 379`, `Community 380`, `Community 382`, `Community 389`, `Community 390`, `Community 391`, `Community 392`, `Community 395`, `Community 399`, `Community 401`, `Community 403`, `Community 405`, `Community 407`, `Community 408`, `Community 409`, `Community 411`, `Community 424`, `Community 425`, `Community 427`, `Community 428`, `Community 429`, `Community 430`, `Community 431`, `Community 432`, `Community 434`, `Community 435`, `Community 444`, `Community 445`, `Community 446`, `Community 450`, `Community 454`, `Community 455`, `Community 456`, `Community 460`, `Community 461`, `Community 467`, `Community 468`, `Community 471`, `Community 473`, `Community 476`, `Community 483`, `Community 484`, `Community 485`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 496`, `Community 498`, `Community 503`, `Community 504`, `Community 506`, `Community 509`, `Community 510`?**
   _High betweenness centrality (0.143) - this node is a cross-community bridge._
-- **Why does `ZipFile` connect `Community 500` to `Community 170`, `Community 11`, `Community 366`, `Community 400`, `Community 240`, `Community 18`, `Community 54`?**
-  _High betweenness centrality (0.037) - this node is a cross-community bridge._
-- **Why does `IOException` connect `Community 513` to `Community 512`, `Community 7`, `Community 8`, `Community 523`, `Community 13`, `Community 530`, `Community 19`, `Community 24`, `Community 25`, `Community 28`, `Community 29`, `Community 31`, `Community 41`, `Community 558`, `Community 49`, `Community 561`, `Community 562`, `Community 52`, `Community 565`, `Community 56`, `Community 57`, `Community 60`, `Community 61`, `Community 62`, `Community 64`, `Community 65`, `Community 578`, `Community 71`, `Community 72`, `Community 74`, `Community 76`, `Community 79`, `Community 81`, `Community 597`, `Community 85`, `Community 87`, `Community 88`, `Community 86`, `Community 102`, `Community 105`, `Community 116`, `Community 628`, `Community 117`, `Community 122`, `Community 131`, `Community 133`, `Community 138`, `Community 141`, `Community 658`, `Community 147`, `Community 148`, `Community 665`, `Community 155`, `Community 156`, `Community 159`, `Community 672`, `Community 170`, `Community 177`, `Community 179`, `Community 189`, `Community 200`, `Community 209`, `Community 211`, `Community 212`, `Community 214`, `Community 216`, `Community 218`, `Community 220`, `Community 241`, `Community 244`, `Community 252`, `Community 253`, `Community 257`, `Community 273`, `Community 787`, `Community 279`, `Community 287`, `Community 288`, `Community 293`, `Community 807`, `Community 299`, `Community 308`, `Community 313`, `Community 314`, `Community 833`, `Community 328`, `Community 842`, `Community 333`, `Community 847`, `Community 848`, `Community 850`, `Community 363`, `Community 392`, `Community 410`, `Community 412`, `Community 417`, `Community 418`, `Community 425`, `Community 428`, `Community 455`, `Community 456`, `Community 495`, `Community 506`?**
-  _High betweenness centrality (0.031) - this node is a cross-community bridge._
+- **Why does `ArrayList` connect `Community 513` to `Community 3`, `Community 5`, `Community 7`, `Community 9`, `Community 13`, `Community 19`, `Community 33`, `Community 34`, `Community 35`, `Community 38`, `Community 39`, `Community 41`, `Community 45`, `Community 49`, `Community 56`, `Community 59`, `Community 60`, `Community 62`, `Community 64`, `Community 72`, `Community 76`, `Community 77`, `Community 85`, `Community 87`, `Community 90`, `Community 93`, `Community 95`, `Community 98`, `Community 99`, `Community 109`, `Community 111`, `Community 117`, `Community 118`, `Community 129`, `Community 132`, `Community 141`, `Community 143`, `Community 147`, `Community 148`, `Community 150`, `Community 151`, `Community 152`, `Community 156`, `Community 157`, `Community 159`, `Community 162`, `Community 169`, `Community 176`, `Community 177`, `Community 178`, `Community 179`, `Community 180`, `Community 185`, `Community 198`, `Community 200`, `Community 205`, `Community 209`, `Community 211`, `Community 212`, `Community 220`, `Community 232`, `Community 235`, `Community 763`, `Community 252`, `Community 255`, `Community 257`, `Community 268`, `Community 273`, `Community 277`, `Community 281`, `Community 288`, `Community 293`, `Community 294`, `Community 306`, `Community 307`, `Community 321`, `Community 322`, `Community 833`, `Community 333`, `Community 340`, `Community 346`, `Community 358`, `Community 377`, `Community 394`, `Community 410`, `Community 413`, `Community 445`, `Community 502`?**
+  _High betweenness centrality (0.035) - this node is a cross-community bridge._
+- **Why does `ZipFile` connect `Community 500` to `Community 11`, `Community 205`, `Community 366`, `Community 400`, `Community 240`, `Community 18`, `Community 54`?**
+  _High betweenness centrality (0.028) - this node is a cross-community bridge._
 - **What connects `$id`, `$schema`, `additionalProperties` to the rest of the system?**
   _1638 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.041561314791403285 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.04057971014492753 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
   _Cohesion score 0.0546448087431694 - nodes in this community are weakly interconnected._
 - **Should `Community 2` be split into smaller, more focused modules?**

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -270,8 +270,8 @@
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/cli/CaptureCli.java": {
-    "mtime": 1782543164.069632,
-    "ast_hash": "f657fa4196b7eeb3707c1375698d8540",
+    "mtime": 1782550515.210448,
+    "ast_hash": "e88c3443fcc27dd70324679a0f6d7050",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/BidiBrowserEventCollector.java": {
@@ -305,8 +305,8 @@
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlClient.java": {
-    "mtime": 1782542339.464949,
-    "ast_hash": "e20830fa8bdedafef9ee138dc93671d4",
+    "mtime": 1782550171.3445148,
+    "ast_hash": "74de524fd40503eaf43b82599f5ee8f6",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlFiles.java": {
@@ -345,13 +345,13 @@
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationReport.java": {
-    "mtime": 1782542366.293584,
-    "ast_hash": "a92521e1c58dda2fd77977a5a0a94af5",
+    "mtime": 1782550171.3450203,
+    "ast_hash": "ca1bf2e0288169bcbab282bb3a751df8",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationRequest.java": {
-    "mtime": 1781239583.9596725,
-    "ast_hash": "baf507818de7dc32b660e5163a2a0a67",
+    "mtime": 1782550495.3973737,
+    "ast_hash": "3f896a7111eedf85863989b05effae7d",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationResult.java": {
@@ -360,8 +360,8 @@
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java": {
-    "mtime": 1782543159.5886772,
-    "ast_hash": "0d657e1eb02b24a284c245da5d787423",
+    "mtime": 1782550703.8403282,
+    "ast_hash": "317ee1cb009c1c47f34fc49f255e41b9",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/GeneratedTestValidator.java": {
@@ -460,8 +460,8 @@
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureManager.java": {
-    "mtime": 1782542334.610265,
-    "ast_hash": "0ee3d75d0fdca0bde2b534dc70f5afec",
+    "mtime": 1782550171.3480363,
+    "ast_hash": "e933f0ca081ad599a59fccd84b3549f2",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureSingleSessionLock.java": {
@@ -475,13 +475,13 @@
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureStatus.java": {
-    "mtime": 1782542313.9957979,
-    "ast_hash": "8b25424ae81ac5c9eaa45b3686e9663d",
+    "mtime": 1782550171.3490345,
+    "ast_hash": "db6bb625fd8d5612c5edbdca8b23aea4",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java": {
-    "mtime": 1782542330.0557475,
-    "ast_hash": "ec674c7f969d8b0bb7bf0dfd9b8ca49a",
+    "mtime": 1782550171.3490345,
+    "ast_hash": "2e79a75e19cad0250c766a61fe8d15b4",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/storage/CaptureSessionStore.java": {
@@ -495,8 +495,8 @@
     "semantic_hash": ""
   },
   "shaft-capture/src/main/resources/browser/shaft-capture-recorder.js": {
-    "mtime": 1782542481.0954642,
-    "ast_hash": "8c24115ca4dfa238397b46e03f50392a",
+    "mtime": 1782550171.3500335,
+    "ast_hash": "19a2185a860c45f7ba1a0bb78d3121fe",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/resources/schema/shaft-capture-session-1.0.schema.json": {
@@ -520,8 +520,8 @@
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java": {
-    "mtime": 1782542417.4947925,
-    "ast_hash": "b100d9b3cea0f6780ac6a691972b1b8d",
+    "mtime": 1782550652.6543934,
+    "ast_hash": "81aad25668e8fa313419ef49be66a0e1",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/generate/LocatorRankerTest.java": {
@@ -1280,8 +1280,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/Allure.java": {
-    "mtime": 1782543318.8998795,
-    "ast_hash": "6589f08fa4f7962702151456014f7d51",
+    "mtime": 1782550171.3535407,
+    "ast_hash": "b3563ae61736495969708ca06c3c4ecd",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/properties/internal/BrowserStack.java": {
@@ -1490,8 +1490,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java": {
-    "mtime": 1782544251.0376532,
-    "ast_hash": "73d640989f7553e77d953a2186081c73",
+    "mtime": 1782550171.3545463,
+    "ast_hash": "b36f35a87fe8fae751d7d38312e35678",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/ApiPerformanceExecutionReport.java": {
@@ -1920,8 +1920,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureManagerCoverageUnitTest.java": {
-    "mtime": 1782544251.0386603,
-    "ast_hash": "8a1aa7c7bc0558a04826eb143daabb7b",
+    "mtime": 1782550171.3555858,
+    "ast_hash": "384848196e390dc0b0e11637774bcd98",
     "semantic_hash": ""
   },
   "shaft-engine/src/test/java/com/shaft/tools/io/internal/ProgressBarLoggerCoverageUnitTest.java": {
@@ -4835,8 +4835,8 @@
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/cli/CaptureCliTest.java": {
-    "mtime": 1781887374.8111992,
-    "ast_hash": "cb0124fcb58676542f14eb61f60dc874",
+    "mtime": 1782550403.4854906,
+    "ast_hash": "69d91ae44ada3a29fb404576b8e8fa8f",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/collector/CaptureCollectorUtilityTest.java": {
@@ -5835,18 +5835,488 @@
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/model/CaptureReadiness.java": {
-    "mtime": 1782543159.5876768,
-    "ast_hash": "f0dca461c4906c0d1a50e573394ce585",
+    "mtime": 1782550171.3470292,
+    "ast_hash": "dc688c124803f651f641b10b53414201",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/model/CaptureReadinessTest.java": {
-    "mtime": 1782542187.562879,
-    "ast_hash": "66ccedc20fd4c37bf0ce7b876ca0ba84",
+    "mtime": 1782550171.352036,
+    "ast_hash": "366825058d3f1dc2659b67c3c8d260ba",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureStatusTest.java": {
-    "mtime": 1782542252.4053767,
-    "ast_hash": "88b1edac251e6368f4ee002f9c5458a9",
+    "mtime": 1782550171.352036,
+    "ast_hash": "690e7bdb6f145c3ad97a3e3bd8d0e1c0",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/0fdb7ac9-dfbb-4d41-ac3b-8b9375013293-container.json": {
+    "mtime": 1782550682.350907,
+    "ast_hash": "acd6386edc0c13c0964f1084caf036d9",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/144b9c59-18f1-494f-826c-5954933cf737-container.json": {
+    "mtime": 1782550682.3519106,
+    "ast_hash": "9ebf20aad4f4bec55adf87bd304ddf22",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/14e2aa47-9463-43d0-a441-501b6a49ece8-result.json": {
+    "mtime": 1782550682.353907,
+    "ast_hash": "81bcd7165d6bfc6cb49c068664890876",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/252e47e3-4a90-4f7d-914a-6c2e6e81fdc9-result.json": {
+    "mtime": 1782550682.3554204,
+    "ast_hash": "2e7a77a341f0bf2dd59da7033384b358",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/2bade429-23e7-4139-a699-73655d3213bb-result.json": {
+    "mtime": 1782550682.3554204,
+    "ast_hash": "682ece491d3ea22fe1bbd37515452d98",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/3edf1d7c-32b7-4355-a61d-6216ea0a4727-container.json": {
+    "mtime": 1782550682.3564281,
+    "ast_hash": "003428d00883ae215c505e9004c42973",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/54eb8b04-de79-46b1-9678-12b75e543690-result.json": {
+    "mtime": 1782550682.3574305,
+    "ast_hash": "a6f7180e35c683a30bedb5b5b08097a6",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/587a85f9-4299-4fac-9f72-31a685dc88d0-container.json": {
+    "mtime": 1782550682.358941,
+    "ast_hash": "aaf02df3f7f801c28d57cb8b5eba1752",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/5ec8da1f-d600-48c2-a206-c0bdd79ddade-container.json": {
+    "mtime": 1782550682.359954,
+    "ast_hash": "b593fc17657d734a0ec76aded34946be",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/5f501b4f-ce0c-43d5-9925-51dfc2be67df-container.json": {
+    "mtime": 1782550682.360953,
+    "ast_hash": "be76d82da14a6dd58eb5b190bbb585f3",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/791bbc34-e85f-4cf1-804a-5daf65ad053d-result.json": {
+    "mtime": 1782550682.3619523,
+    "ast_hash": "b63860557fb79a1d7a765e4a9743c1d6",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/80d48083-db5a-4ffb-b227-854c69cf783d-result.json": {
+    "mtime": 1782550682.3629537,
+    "ast_hash": "5247d019fd0ef5672770437de608da32",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/8863c6b7-84f9-4ece-b83d-12c768208325-container.json": {
+    "mtime": 1782550682.3639522,
+    "ast_hash": "fe97255fcb6114b9ebe0ca134be012b4",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/89051c4d-8e1c-4b54-a4ca-6c9300ee56a7-result.json": {
+    "mtime": 1782550682.3654692,
+    "ast_hash": "9ad6aa87924ea268bc0543c05b4a0978",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/89b5cdd8-bfa2-4c24-b274-c074975d293f-container.json": {
+    "mtime": 1782550682.3674686,
+    "ast_hash": "95c9cd8be7b62915dbc57f3d8d75e99d",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/9c4b5815-ea77-4189-b4e7-8f3f22128fa4-result.json": {
+    "mtime": 1782550682.3674686,
+    "ast_hash": "fd8d018de9f33dfb6b165e2e5a09b0fb",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/a1c31382-4870-45f6-8beb-05068d63b2e0-container.json": {
+    "mtime": 1782550682.3699903,
+    "ast_hash": "7f62ebea9c3ff376748acbf1eef5392d",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/a314e555-cb5a-4467-bb43-18f5517e72a2-result.json": {
+    "mtime": 1782550682.3709905,
+    "ast_hash": "5b91e972c8a4dac97ec4ffc0027ed204",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/a3f8b429-c4d0-4a21-b1ad-3614249f1a08-container.json": {
+    "mtime": 1782550682.3719873,
+    "ast_hash": "1deb85610398b59da2c23704dc8d22d8",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/a79046ee-806a-492a-a5ce-063b9cb58dd9-result.json": {
+    "mtime": 1782550682.373497,
+    "ast_hash": "3de82173a811a713767860accb1f0ae3",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/aaa91865-b4db-4f15-98fe-5f280db21b14-result.json": {
+    "mtime": 1782550682.375028,
+    "ast_hash": "bee935cf731e6a664d077e9a0a29d986",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/ae2c29f5-8781-4ef3-a309-a2b859b3376a-result.json": {
+    "mtime": 1782550682.3760276,
+    "ast_hash": "df49b006ca3a0e043e0d1cc109eb1fe9",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/b89bac3a-2015-4f58-8dee-520f7c1cecc1-result.json": {
+    "mtime": 1782550682.3780332,
+    "ast_hash": "c7ab83f2370dfff9aab86d1dd9073836",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/c5995852-371e-497c-8d9c-cc7c05156f88-result.json": {
+    "mtime": 1782550682.3790293,
+    "ast_hash": "20e098800138fef0d60848509b88ac20",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/d2963dd0-968d-479d-8b9e-20a3e94762d4-container.json": {
+    "mtime": 1782550682.381031,
+    "ast_hash": "94e0b0bf5a5b36c9edae8d8611d4674c",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/d896715e-361a-4916-b172-c6331f645e09-container.json": {
+    "mtime": 1782550682.3820324,
+    "ast_hash": "1cb11bc52f2f3536fd146ff5c27641f5",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/e241fb51-e01f-45b8-9f18-303076963633-result.json": {
+    "mtime": 1782550682.3835418,
+    "ast_hash": "716a4f128ffa62de1a78b865f944df3a",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/e281b956-d071-4765-8076-a04338b8d01d-container.json": {
+    "mtime": 1782550682.385613,
+    "ast_hash": "65ffb3c2baf7ed09bcadf2d318c89101",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/e590e0ad-7fe4-474b-b0c8-c519c774a802-container.json": {
+    "mtime": 1782550682.3866124,
+    "ast_hash": "9f7527521d13c29371a638addc6caaf6",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/f0302cb3-a50e-46d8-a68c-8875d695cae2-container.json": {
+    "mtime": 1782550682.387611,
+    "ast_hash": "5ee548fb88239b361a734c2f84934d1d",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/f4d83e9e-5238-42d5-be9a-406c8c05c491-container.json": {
+    "mtime": 1782550682.3896124,
+    "ast_hash": "f7c30d6052a35847064fa80ecb65b534",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/fec6ff04-feec-41f0-b4ec-9ba4dfbd3b6c-container.json": {
+    "mtime": 1782550682.3906112,
+    "ast_hash": "4fbceb23f65a72e29f317550d5aade5d",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/035fdd98-17c4-4bb0-a913-2e2d49c50cd3-result.json": {
+    "mtime": 1782545259.4758167,
+    "ast_hash": "588782debec1e6b129ea63e61ca8717f",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/048494cf-8977-4632-8ee6-2498d791852f-container.json": {
+    "mtime": 1782545259.476819,
+    "ast_hash": "9ea94f75b150ca12338034f3325e6d04",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/17270675-9c93-407f-8c76-8b8e4467cbfb-result.json": {
+    "mtime": 1782545261.1726604,
+    "ast_hash": "c4457bb837760a07907cf9802619d5db",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/1a11911d-667b-4dca-86d2-1ca6f5024067-result.json": {
+    "mtime": 1782545261.130579,
+    "ast_hash": "c08cc9fd80600166d6e25e8beaeb299a",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/1e0b01e9-e08b-46f9-9c8b-dc381944c337-container.json": {
+    "mtime": 1782545261.0544307,
+    "ast_hash": "364e78af21b1650683f2525d4ee3e905",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/1fa2e60d-1eb2-4266-9b27-a5454fcd22c3-container.json": {
+    "mtime": 1782545261.097945,
+    "ast_hash": "53b0845075ae547d239b9177caf4b85e",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/2158dfdf-fc8b-4074-af49-715f77c0edc3-result.json": {
+    "mtime": 1782545261.052391,
+    "ast_hash": "1149972943852b3c9272d1411584b66d",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/36d40387-287e-4bb3-b640-3fba85d79ac8-container.json": {
+    "mtime": 1782545254.108649,
+    "ast_hash": "a811c9031f25dc646b7d44da24a0673a",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/39e5a298-f74a-4987-9849-d6080bb495bc-container.json": {
+    "mtime": 1782545261.0624506,
+    "ast_hash": "14b7a06d7447a45e2d26026f13cc0fc3",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/3b3842cc-7a49-4409-b413-30c24235e8b3-container.json": {
+    "mtime": 1782545259.502373,
+    "ast_hash": "cbba6612c03e4365c4817f640393a9a5",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/449f14dc-824a-47c5-956a-86340c9dd4ec-container.json": {
+    "mtime": 1782545254.0502005,
+    "ast_hash": "86ce37ace510221862c913724f418ca2",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/47fbae7a-8e6d-4f8e-b28d-bdb120224960-container.json": {
+    "mtime": 1782545257.9595573,
+    "ast_hash": "085ec18903d128eedc1100ab305ff22e",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/5e74c063-6ad2-4610-b71e-877aa092ef6b-result.json": {
+    "mtime": 1782545259.502373,
+    "ast_hash": "654f0240274aae3fd0804a99776b154f",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/632c4c11-532a-4c01-88da-46077ac836bb-container.json": {
+    "mtime": 1782545261.1315765,
+    "ast_hash": "4ea8dfe21d9e85fc71554c768605d4dc",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/722f26a9-063b-4281-8e71-c7d7c10357ac-result.json": {
+    "mtime": 1782545254.0318518,
+    "ast_hash": "a2a05c21a7a19f437bd1e33b81a06ffc",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/7ea8940f-b227-41bf-9fa5-28a2440eabde-result.json": {
+    "mtime": 1782545261.150886,
+    "ast_hash": "62477af87c8e9dc321ecb69a10983527",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/8585528a-fc78-4279-9f74-4a6c44bd8967-container.json": {
+    "mtime": 1782545254.3860602,
+    "ast_hash": "07676c1f1dbce60692ba18ef162868c5",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/89dd6e00-9636-4e66-9b80-a3db065145d5-result.json": {
+    "mtime": 1782545254.0785832,
+    "ast_hash": "32a0a6b72e4d13c5e0a4b4262a3fd350",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/973c5fb5-2376-4cb7-adc9-6eb5668eb6a3-container.json": {
+    "mtime": 1782545261.1823492,
+    "ast_hash": "baf81c79576a73fa700018d07794ee7b",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/997ab3cc-a870-4ae1-8409-46e398518a4c-container.json": {
+    "mtime": 1782545254.4025843,
+    "ast_hash": "1d5564fc911fe5464940259ce8fdd305",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/a55b312d-f85b-4409-a3cc-7ba41cdcc827-result.json": {
+    "mtime": 1782545254.4015844,
+    "ast_hash": "df64331ff4b7ae76fd5f6e66d85fb287",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/b11c5fbe-f57e-4f87-bc0f-b6bb765c1e07-result.json": {
+    "mtime": 1782545254.3855538,
+    "ast_hash": "708716eb00f424bb23e413b7f6c7bf8e",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/bf96f1ca-a5c6-457e-b099-29208ca9867c-result.json": {
+    "mtime": 1782545261.096944,
+    "ast_hash": "447b11ae2ab17955d3d9eb77e7dcb119",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/d495911c-ba13-46b1-82c7-240f13eb5c97-result.json": {
+    "mtime": 1782545261.0247457,
+    "ast_hash": "12efa350330f967adf1b92b614e7ceda",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/da128447-d0b4-4aa0-b8dc-977dd5429fec-container.json": {
+    "mtime": 1782545261.0262027,
+    "ast_hash": "89a2b791c9bbc153f4b0c39c8c4ab8d4",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/dbfef7ae-f88b-4adf-9361-28db72f5e692-result.json": {
+    "mtime": 1782545254.1056185,
+    "ast_hash": "ba8313df7ccae6226bff6114a7aee530",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/dfd451ba-3f8d-484b-91b8-b0b4e8495b2d-container.json": {
+    "mtime": 1782545261.1518826,
+    "ast_hash": "23ec469bf9172c60e302dae0b6f2b568",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/e0b84792-e2ad-4e8f-899f-df375d3472c7-container.json": {
+    "mtime": 1782545254.080578,
+    "ast_hash": "c13402f30eaa7bdfc5304c7513da31b0",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/ee04a1fb-588e-4e3b-89e4-2bb915e2a2c0-container.json": {
+    "mtime": 1782545261.1736605,
+    "ast_hash": "7d1947b7e18ad5773f85e3b9e946457b",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/f1e41b44-38d5-40b8-96fe-e402f9e2ba09-result.json": {
+    "mtime": 1782545257.9585586,
+    "ast_hash": "e6ab3dee83ab4b4c398113026ee18b86",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/performanceReport/PerformanceReport_27-06-2026_10-27-41-2085-AM.json": {
+    "mtime": 1782545261.2166805,
+    "ast_hash": "bea963c692b3e9afc74e889098316665",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/16e4307a-a498-44a7-8bdf-d5abaa911818-attachment.txt": {
+    "mtime": 1782550671.74548,
+    "ast_hash": "cfea204bfa85b388f3ca657559b653ca",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/2138ebf8-90d9-4d68-a33e-57302bd53edc-attachment.txt": {
+    "mtime": 1782550671.5050106,
+    "ast_hash": "912397a6470041fea2174c87162e10df",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/236f9d16-fd2b-43f5-be58-f7346b9e643a-attachment.txt": {
+    "mtime": 1782550671.765587,
+    "ast_hash": "d4de1449578d0640d2125993cfdc223f",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/289af057-8143-4277-953c-84eb579749eb-attachment.txt": {
+    "mtime": 1782550679.0408938,
+    "ast_hash": "9f54b7242a7b47c3ce32ff99b3b121f1",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/29424f58-8535-46e9-bf13-72e9e24bf3b6-attachment.txt": {
+    "mtime": 1782550675.4915216,
+    "ast_hash": "267af65dbc213ae3d3b866e3cb8967ae",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/4d111943-f24f-4905-8080-a07cb28a92c9-attachment.txt": {
+    "mtime": 1782550676.6908872,
+    "ast_hash": "fa537bfd054b7a31e4c8f994a1508ed4",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/631bcb75-204d-4547-ac9d-a3cffd88d3a7-attachment.txt": {
+    "mtime": 1782550676.5577433,
+    "ast_hash": "ad279ed6fe4e2646cc1d9b719c272ea3",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/6c50cbee-2b92-4631-bd3e-9ad2fb61d110-attachment.txt": {
+    "mtime": 1782550680.2026706,
+    "ast_hash": "594528ac0067a3cd32b8a809155e1f64",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/7fdbe3e5-3c89-4689-b570-9b95bad5626c-attachment.txt": {
+    "mtime": 1782550682.1359675,
+    "ast_hash": "5a5d1e4176f0f16dbcfd777390484a06",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/aa4cae47-4185-4c28-8d34-a9079f530994-attachment.txt": {
+    "mtime": 1782550682.2297916,
+    "ast_hash": "b4521f1a885db72e487b999b01122ee6",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/b0b4f600-4e8d-48b4-9593-70e61f8d2523-attachment.txt": {
+    "mtime": 1782550672.8409295,
+    "ast_hash": "051c61f9de47383852b6a8a30e449dc5",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/da8ff39e-052c-47c4-bafc-11f4bf1ef43d-attachment.txt": {
+    "mtime": 1782550675.4197624,
+    "ast_hash": "c978b0d42cb332c2a1b186739ee51e57",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/de835ed8-d17a-4a07-aacf-09fd5659604e-attachment.txt": {
+    "mtime": 1782550680.1896324,
+    "ast_hash": "6ec475b3fda208e38e4e9e731e0a6fc5",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/ec74d35c-9208-4b26-8682-7bbfa525f6df-attachment.txt": {
+    "mtime": 1782550682.334385,
+    "ast_hash": "6be159c2b31eb77a2265cb3df2ea2396",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/f03db342-6aff-4a63-bf93-2de8ba4815ae-attachment.txt": {
+    "mtime": 1782550682.3237243,
+    "ast_hash": "1f34c6a98250785b6a842d095f3d5a74",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/189be3d0-4702-46a4-b268-a5eb7815d25a-attachment.txt": {
+    "mtime": 1782545261.1285784,
+    "ast_hash": "920206a772a475b66d23f58eb3b8851e",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/1a489e88-4de7-42c6-a07e-2c2b3b4c0a15-attachment.txt": {
+    "mtime": 1782545254.0742538,
+    "ast_hash": "c4a2d2011d87b16667bea41c7b52cb76",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/2ef608ad-9320-47aa-9226-7c4c3e519329-attachment.txt": {
+    "mtime": 1782545254.398585,
+    "ast_hash": "cdf2fd5f559b189f6ef0645e298062d0",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/4661e1ff-b87a-4d16-873a-1fa1051ebd14-attachment.txt": {
+    "mtime": 1782545253.7415187,
+    "ast_hash": "8eafedf60de85819944c5dc23c7c56f8",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/4e566465-ec35-4c5e-a6e0-796411e1355d-attachment.txt": {
+    "mtime": 1782545257.9565566,
+    "ast_hash": "3e4061cb42c7c038937bf64074c3ac28",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/7a63ab61-55b2-4540-b7c6-7cc2e370eecf-attachment.txt": {
+    "mtime": 1782545261.169665,
+    "ast_hash": "a8572b8b432150c08ad9037fe14db0ba",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/a64fe11c-1698-46a7-83d7-50768bd1d3f4-attachment.txt": {
+    "mtime": 1782545254.3830352,
+    "ast_hash": "f3b04cec6307bd5ee7cdc50f88eadd90",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/c1016f25-a5b1-4922-877d-1e0741950fdc-attachment.txt": {
+    "mtime": 1782545261.0947702,
+    "ast_hash": "00e90f38caa107ac49dea074daca3abb",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/d8da7e70-5134-426f-8935-00b13d7ce680-attachment.txt": {
+    "mtime": 1782545261.0493865,
+    "ast_hash": "9dac5340cf92df1302e099d813fdcb9b",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/ddd514ac-7a06-41c1-a548-91e43aa735ae-attachment.txt": {
+    "mtime": 1782545259.4727924,
+    "ast_hash": "525b1e661eb5f36e90de5bab557d5d06",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/e15b0965-cab9-443f-aaf4-24a960fcd7ab-attachment.txt": {
+    "mtime": 1782545259.5003731,
+    "ast_hash": "24bd097ee343dc139a0842f8e9d9a4c1",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/e51dbe0c-d033-483e-a796-10b0f67fbfb3-attachment.txt": {
+    "mtime": 1782545254.0976884,
+    "ast_hash": "980b114f03cfc502bef0ee4d6a777473",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/fdba2ddf-75a6-443e-9034-ab457eb2d82a-attachment.txt": {
+    "mtime": 1782545261.1488843,
+    "ast_hash": "a39692e3acb9735236d1ed84207ab7c5",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/ff5db7a8-ce61-4a63-abe9-607d46b92c9e-attachment.txt": {
+    "mtime": 1782545261.021709,
+    "ast_hash": "b64586ed5cbead67beb2648b52472cdd",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/execution-summary/ExecutionSummaryReport_27-06-2026_10-27-41-2180-AM.html": {
+    "mtime": 1782545261.2216768,
+    "ast_hash": "9c228bf1562ee685fbeaf660f0b9a898",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/performanceReport/PerformanceReport_27-06-2026_10-27-41-2085-AM.html": {
+    "mtime": 1782545261.2146683,
+    "ast_hash": "a2a4174535d029f822c69ced0bfcf725",
     "semantic_hash": ""
   }
 }

--- a/shaft-capture/src/main/java/com/shaft/capture/cli/CaptureCli.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/cli/CaptureCli.java
@@ -214,7 +214,8 @@ public final class CaptureCli {
                 enrichmentMode,
                 preview,
                 options.flag("approve-enrichment"),
-                approval));
+                approval,
+                options.flag("enable-fallback-locators")));
         print(result);
         return result.successful() ? 0 : 1;
     }
@@ -415,6 +416,7 @@ public final class CaptureCli {
                 + "checkpoint --description <text> [--kind USER_MARKER|ASSERTION|PAGE_TRANSITION|RECOVERY] | "
                 + "generate --session <capture.json> [--output-dir <path>] [--package <name>] "
                 + "[--class-name <name>] [--overwrite] [--skip-compile] [--replay] "
+                + "[--enable-fallback-locators] "
                 + "[--replay-timeout-seconds <seconds>] [--ai-preview --allow-local-ai|--allow-remote-ai] "
                 + "[--enrichment-preview <path>] "
                 + "[--apply-enrichment <path> --approve-enrichment] | features";
@@ -477,6 +479,7 @@ public final class CaptureCli {
                         "overwrite",
                         "skip-compile",
                         "replay",
+                        "enable-fallback-locators",
                         "ai-preview",
                         "approve-enrichment",
                         "allow-local-ai",

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationRequest.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationRequest.java
@@ -20,6 +20,7 @@ import java.time.Duration;
  * @param enrichmentPreviewPath preview path to write or apply
  * @param enrichmentApproved whether a reviewed preview may be applied
  * @param aiApprovalPolicy explicit evidence and processing-location approval for preview generation
+ * @param fallbackLocators whether generated WebDriver replay should try captured fallback locators
  */
 public record CaptureGenerationRequest(
         Path sessionPath,
@@ -33,7 +34,8 @@ public record CaptureGenerationRequest(
         EnrichmentMode enrichmentMode,
         Path enrichmentPreviewPath,
         boolean enrichmentApproved,
-        ApprovalPolicy aiApprovalPolicy) {
+        ApprovalPolicy aiApprovalPolicy,
+        boolean fallbackLocators) {
     /**
      * AI enrichment lifecycle.
      */
@@ -71,6 +73,39 @@ public record CaptureGenerationRequest(
     }
 
     /**
+     * Compatibility constructor with fallback locator replay disabled.
+     *
+     * @param sessionPath persisted Capture session
+     * @param outputDirectory generated project root
+     * @param packageName generated Java package
+     * @param className optional generated class name
+     * @param overwrite whether existing generated artifacts may be replaced
+     * @param compile whether to compile the generated source
+     * @param replay whether to execute the compiled TestNG test
+     * @param replayTimeout maximum replay duration
+     * @param enrichmentMode optional AI enrichment phase
+     * @param enrichmentPreviewPath preview path to write or apply
+     * @param enrichmentApproved whether a reviewed preview may be applied
+     * @param aiApprovalPolicy explicit evidence and processing-location approval for preview generation
+     */
+    public CaptureGenerationRequest(
+            Path sessionPath,
+            Path outputDirectory,
+            String packageName,
+            String className,
+            boolean overwrite,
+            boolean compile,
+            boolean replay,
+            Duration replayTimeout,
+            EnrichmentMode enrichmentMode,
+            Path enrichmentPreviewPath,
+            boolean enrichmentApproved,
+            ApprovalPolicy aiApprovalPolicy) {
+        this(sessionPath, outputDirectory, packageName, className, overwrite, compile, replay, replayTimeout,
+                enrichmentMode, enrichmentPreviewPath, enrichmentApproved, aiApprovalPolicy, false);
+    }
+
+    /**
      * Creates deterministic defaults for one session.
      *
      * @param sessionPath persisted session
@@ -89,6 +124,7 @@ public record CaptureGenerationRequest(
                 EnrichmentMode.NONE,
                 null,
                 false,
-                ApprovalPolicy.denyAll());
+                ApprovalPolicy.denyAll(),
+                false);
     }
 }

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -141,7 +141,8 @@ public final class CaptureGenerator {
             GenerationState state = analyze(session, sessionPath, targetBackend);
             Map<String, String> elementNames = defaultElementNames(state.targets());
             String deterministicSource = renderSource(session, request.packageName(), deterministicClassName,
-                    deterministicMethodName, state.targets(), state.data(), elementNames, List.of(), targetBackend);
+                    deterministicMethodName, state.targets(), state.data(), elementNames, List.of(), targetBackend,
+                    request.fallbackLocators());
             String fingerprint = fingerprint(codec.write(session), deterministicSource);
 
             CaptureGenerationReport.Enrichment enrichment = CaptureGenerationReport.Enrichment.notRequested();
@@ -202,7 +203,8 @@ public final class CaptureGenerator {
                 paths = artifactPaths(outputRoot, request.packageName(), className);
             }
             String source = renderSource(session, request.packageName(), className, methodName,
-                    state.targets(), state.data(), finalElementNames, appliedProposal.assertions(), targetBackend);
+                    state.targets(), state.data(), finalElementNames, appliedProposal.assertions(), targetBackend,
+                    request.fallbackLocators());
             String dataJson = writeJson(state.data().root());
 
             List<String> privacy = new ArrayList<>();
@@ -660,7 +662,9 @@ public final class CaptureGenerator {
             DataPlan data,
             Map<String, String> elementNames,
             List<CaptureEnrichmentPreview.AssertionSuggestion> extraAssertions,
-            CodegenBackend backend) {
+            CodegenBackend backend,
+            boolean fallbackLocators) {
+        boolean fallbackReplay = fallbackLocators && backend == CodegenBackend.WEBDRIVER;
         StringBuilder source = new StringBuilder();
         line(source, "package " + packageName + ";");
         line(source, "");
@@ -674,6 +678,9 @@ public final class CaptureGenerator {
         line(source, "import com.shaft.gui.internal.locator.Role;");
         line(source, "import org.openqa.selenium.By;");
         line(source, "import org.openqa.selenium.Keys;");
+        if (fallbackReplay) {
+            line(source, "import org.openqa.selenium.WebElement;");
+        }
         line(source, "import org.openqa.selenium.WindowType;");
         if (backend == CodegenBackend.WEBDRIVER) {
             line(source, "import org.openqa.selenium.support.ui.ExpectedConditions;");
@@ -684,12 +691,18 @@ public final class CaptureGenerator {
         line(source, "");
         line(source, "import java.nio.file.Path;");
         line(source, "import java.util.HashMap;");
+        if (fallbackReplay) {
+            line(source, "import java.util.List;");
+        }
         line(source, "import java.util.Map;");
         line(source, "");
         line(source, "public class " + className + " {");
         for (TargetPlan target : targets) {
             line(source, "    private static final By " + elementNames.get(target.logicalElementId()) + " = "
                     + locatorExpression(target) + ";");
+            if (fallbackReplay) {
+                renderFallbackCandidates(source, target, elementNames.get(target.logicalElementId()));
+            }
         }
         if (!targets.isEmpty()) {
             line(source, "");
@@ -724,7 +737,7 @@ public final class CaptureGenerator {
         Map<Long, CaptureEvent> eventsBySequence = new HashMap<>();
         session.events().forEach(event -> eventsBySequence.put(event.context().sequence(), event));
         for (CaptureEvent event : session.events()) {
-            renderEvent(source, event, targets, elementNames, data, backend);
+            renderEvent(source, event, targets, elementNames, data, backend, fallbackReplay);
             for (Checkpoint checkpoint : checkpoints.getOrDefault(event.context().sequence(), List.of())) {
                 String description = checkpoint.description().isBlank()
                         ? ""
@@ -735,11 +748,14 @@ public final class CaptureGenerator {
             for (CaptureEnrichmentPreview.AssertionSuggestion assertion :
                     assertions.getOrDefault(event.context().sequence(), List.of())) {
                 renderSuggestedAssertion(source, eventsBySequence.get(assertion.eventSequence()),
-                        assertion, targets, elementNames, backend);
+                        assertion, targets, elementNames, backend, fallbackReplay);
             }
         }
         line(source, "    }");
         line(source, "");
+        if (fallbackReplay) {
+            renderFallbackHelper(source);
+        }
         line(source, "    private String requiredData(String key) {");
         line(source, "        String value = testData.getTestData(\"values.\" + key);");
         line(source, "        if (value == null) {");
@@ -772,10 +788,11 @@ public final class CaptureGenerator {
             List<TargetPlan> targets,
             Map<String, String> elementNames,
             DataPlan data,
-            CodegenBackend backend) {
+            CodegenBackend backend,
+            boolean fallbackReplay) {
         String locator = target(event)
-                .map(ElementSnapshot::logicalElementId)
-                .map(elementNames::get)
+                .map(target -> locatorReference(target, elementNames, fallbackReplay,
+                        fallbackReplayApplies(event), fallbackActionable(event)))
                 .orElse("");
         if (event instanceof CaptureEvent.NavigationEvent value) {
             String statement = switch (value.action()) {
@@ -989,21 +1006,25 @@ public final class CaptureGenerator {
             CaptureEnrichmentPreview.AssertionSuggestion suggestion,
             List<TargetPlan> targets,
             Map<String, String> elementNames,
-            CodegenBackend backend) {
+            CodegenBackend backend,
+            boolean fallbackReplay) {
         Optional<ElementSnapshot> target = target(event);
         if (target.isEmpty()) {
             return;
         }
-        String locator = elementNames.get(target.get().logicalElementId());
         CaptureEvent.VerificationKind verification =
                 CaptureEvent.VerificationKind.valueOf(suggestion.verification());
+        String locator = locatorReference(target.get(), elementNames, fallbackReplay, !suggestion.negated(), false);
         renderVerification(source, verification, target.get(), null, suggestion.negated(),
                 event.context(), locator, null, backend);
     }
 
     private static String locatorExpression(TargetPlan plan) {
         LocatorCandidate candidate = plan.selection().selected().candidate();
-        ElementSnapshot target = plan.target();
+        return locatorExpression(plan.target(), candidate);
+    }
+
+    private static String locatorExpression(ElementSnapshot target, LocatorCandidate candidate) {
         String name = !target.accessibleName().isBlank() ? target.accessibleName() : target.label();
         return switch (candidate.strategy()) {
             case ROLE, ACCESSIBLE_NAME, LABEL -> semanticLocator(target, name, candidate);
@@ -1014,6 +1035,99 @@ public final class CaptureGenerator {
                     + javaString(candidate.expression()) + "\").build()";
             case XPATH -> "By.xpath(\"" + javaString(candidate.expression()) + "\")";
         };
+    }
+
+    private static void renderFallbackCandidates(StringBuilder source, TargetPlan target, String locatorName) {
+        List<LocatorCandidate> candidates = fallbackCandidates(target);
+        line(source, "    private static final By[] " + locatorName + "_FALLBACKS = {");
+        for (int index = 0; index < candidates.size(); index++) {
+            String expression = index == 0
+                    ? locatorName
+                    : locatorExpression(target.target(), candidates.get(index));
+            line(source, "            " + expression + (index + 1 == candidates.size() ? "" : ","));
+        }
+        line(source, "    };");
+    }
+
+    private static List<LocatorCandidate> fallbackCandidates(TargetPlan target) {
+        List<LocatorCandidate> candidates = new ArrayList<>();
+        candidates.add(target.selection().selected().candidate());
+        target.selection().alternatives().stream()
+                .map(LocatorRanker.ScoredLocator::candidate)
+                .filter(candidate -> candidate.uniquenessCount() == 1)
+                .filter(candidate -> !candidates.contains(candidate))
+                .forEach(candidates::add);
+        return candidates;
+    }
+
+    private static String locatorReference(
+            ElementSnapshot target,
+            Map<String, String> elementNames,
+            boolean fallbackReplay,
+            boolean useFallback,
+            boolean actionable) {
+        String locator = elementNames.get(target.logicalElementId());
+        if (!fallbackReplay || !useFallback) {
+            return locator;
+        }
+        String name = !target.accessibleName().isBlank() ? target.accessibleName() : target.label();
+        return "captureReplayLocator(\"" + javaString(target.logicalElementId()) + "\", "
+                + locator + ", " + locator + "_FALLBACKS, " + actionable + ", \""
+                + javaString(target.tagName()) + "\", \"" + javaString(name) + "\")";
+    }
+
+    private static boolean fallbackReplayApplies(CaptureEvent event) {
+        if (event instanceof CaptureEvent.WaitEvent value
+                && value.condition() == CaptureEvent.WaitCondition.ELEMENT_ABSENT) {
+            return false;
+        }
+        return !(event instanceof CaptureEvent.VerificationEvent value && value.negated());
+    }
+
+    private static boolean fallbackActionable(CaptureEvent event) {
+        if (interaction(event)) {
+            return true;
+        }
+        return event instanceof CaptureEvent.WaitEvent value
+                && value.condition() == CaptureEvent.WaitCondition.ELEMENT_CLICKABLE;
+    }
+
+    private static void renderFallbackHelper(StringBuilder source) {
+        line(source, "    private By captureReplayLocator(String logicalElementId, By selected, By[] candidates,");
+        line(source, "            boolean actionable, String expectedTagName, String expectedAccessibleName) {");
+        line(source, "        for (By candidate : candidates) {");
+        line(source, "            if (matchesCaptureTarget(candidate, expectedTagName, expectedAccessibleName, actionable)) {");
+        line(source, "                if (!candidate.equals(selected)) {");
+        line(source, "                    SHAFT.Report.log(\"Capture fallback locator used for \" + logicalElementId");
+        line(source, "                            + \": \" + selected + \" -> \" + candidate);");
+        line(source, "                }");
+        line(source, "                return candidate;");
+        line(source, "            }");
+        line(source, "        }");
+        line(source, "        return selected;");
+        line(source, "    }");
+        line(source, "");
+        line(source, "    private boolean matchesCaptureTarget(By candidate, String expectedTagName,");
+        line(source, "            String expectedAccessibleName, boolean actionable) {");
+        line(source, "        try {");
+        line(source, "            List<WebElement> matches = driver.getDriver().findElements(candidate);");
+        line(source, "            if (matches.size() != 1) {");
+        line(source, "                return false;");
+        line(source, "            }");
+        line(source, "            WebElement element = matches.getFirst();");
+        line(source, "            if (!expectedTagName.isBlank() && !expectedTagName.equalsIgnoreCase(element.getTagName())) {");
+        line(source, "                return false;");
+        line(source, "            }");
+        line(source, "            if (!expectedAccessibleName.isBlank()");
+        line(source, "                    && !expectedAccessibleName.equals(element.getAccessibleName())) {");
+        line(source, "                return false;");
+        line(source, "            }");
+        line(source, "            return !actionable || (element.isDisplayed() && element.isEnabled());");
+        line(source, "        } catch (RuntimeException exception) {");
+        line(source, "            return false;");
+        line(source, "        }");
+        line(source, "    }");
+        line(source, "");
     }
 
     private static String semanticLocator(

--- a/shaft-capture/src/test/java/com/shaft/capture/cli/CaptureCliTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/cli/CaptureCliTest.java
@@ -31,7 +31,8 @@ class CaptureCliTest {
                         "--runtime-dir", temp.toString(),
                         "--session", "capture.json",
                         "--headless",
-                        "--replay"
+                        "--replay",
+                        "--enable-fallback-locators"
                 });
 
         assertEquals(temp.toString(), invoke(
@@ -61,6 +62,11 @@ class CaptureCliTest {
                 "flag",
                 new Class<?>[] {String.class},
                 "headless"));
+        assertEquals(true, invoke(
+                options,
+                "flag",
+                new Class<?>[] {String.class},
+                "enable-fallback-locators"));
 
         InvocationTargetException missingValue = assertThrows(InvocationTargetException.class,
                 () -> invokeStatic(
@@ -127,6 +133,7 @@ class CaptureCliTest {
         assertFalse(token.contains("="));
         assertTrue(usage.contains("capture start"));
         assertTrue(usage.contains("features"));
+        assertTrue(usage.contains("--enable-fallback-locators"));
         assertEquals("operation failed.", fallbackMessage);
         assertTrue(running);
         assertEquals(12L, parsed);

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -195,6 +195,28 @@ class CaptureGeneratorTest {
     }
 
     @Test
+    void fallbackLocatorReplayOptionGeneratesSharedHelperAndRankedCandidates() throws Exception {
+        Path session = session(CaptureFixtures.representativeSession());
+        writeCaptureData("alice");
+
+        CaptureGenerationResult result = new CaptureGenerator().generate(new CaptureGenerationRequest(
+                session, temp.resolve("fallback-replay"), "generated.capture", "", false,
+                true, false, Duration.ofMinutes(1),
+                CaptureGenerationRequest.EnrichmentMode.NONE, null, false,
+                ApprovalPolicy.denyAll(), true));
+
+        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        String source = Files.readString(result.sourcePath());
+        assertTrue(source.contains("private static final By[] USERNAME_INPUT_LOCATOR_FALLBACKS"));
+        assertTrue(source.contains("USERNAME_INPUT_LOCATOR,"));
+        assertTrue(source.contains("By.cssSelector(\"form input:nth-child(1)\")"));
+        assertTrue(source.contains("captureReplayLocator(\"username-input\", USERNAME_INPUT_LOCATOR"));
+        assertTrue(source.contains("SHAFT.Report.log(\"Capture fallback locator used for \" + logicalElementId"));
+        assertTrue(source.contains(", true, \"input\", \"Username\")"));
+        assertTrue(source.contains("matchesCaptureTarget(candidate, expectedTagName, expectedAccessibleName"));
+    }
+
+    @Test
     void deterministicReviewFlagsGeneratedCodeRisks() throws Exception {
         ExternalTestDataReference card = new ExternalTestDataReference(
                 "data.card",


### PR DESCRIPTION
## Summary
- Add opt-in Capture generation support for deterministic WebDriver fallback locator replay through `--enable-fallback-locators` and `CaptureGenerationRequest.fallbackLocators()`.
- Generate a shared replay helper that tries the selected locator first, then ranked captured alternatives that resolve uniquely to the recorded tag/accessibility evidence.
- Log a SHAFT report entry whenever generated replay uses a fallback locator, and refresh Graphify metadata.

## Examples
```bash
java -cp "$MCP_CP" "$MCP_MAIN" capture generate \
  --session recordings/example.json \
  --output-dir generated-tests \
  --replay \
  --enable-fallback-locators
```

```java
private static final By[] USERNAME_INPUT_LOCATOR_FALLBACKS = {
        USERNAME_INPUT_LOCATOR,
        By.cssSelector("form input:nth-child(1)")
};

driver.element().click(captureReplayLocator("username-input", USERNAME_INPUT_LOCATOR,
        USERNAME_INPUT_LOCATOR_FALLBACKS, true, "input", "Username"));
```

```text
Capture fallback locator used for username-input: By.cssSelector: #username -> By.cssSelector: [name="username"]
```

## Validation
- Confirmed the new focused generator test failed before implementation because `CaptureGenerationRequest` had no fallback flag.
- `mvn -pl shaft-capture '-Dtest=CaptureGeneratorTest,CaptureCliTest' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test`
- `mvn -pl shaft-capture,shaft-mcp -am '-DskipTests' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' package`
- `graphify update .`

## Docs
- https://github.com/ShaftHQ/shafthq.github.io/pull/649

Closes #3109