### PR TITLE
[codex] Add Capture record-at-target snippets

### DIFF
--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -850,10 +850,5 @@
   "848": "Community 848",
   "849": "Community 849",
   "852": "Community 852",
-  "853": "Community 853",
-  "854": "Community 854",
-  "855": "Community 855",
-  "860": "Community 860",
-  "861": "Community 861",
-  "865": "Community 865"
+  "853": "Community 853"
 }

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - SHAFT_ENGINE  (2026-06-27)
 
 ## Corpus Check
-- 1149 files · ~682,276 words
+- 1137 files · ~689,175 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 16008 nodes · 42876 edges · 857 communities (760 shown, 97 thin omitted)
-- Extraction: 81% EXTRACTED · 19% INFERRED · 0% AMBIGUOUS · INFERRED: 8256 edges (avg confidence: 0.8)
+- 16029 nodes · 42958 edges · 852 communities (751 shown, 101 thin omitted)
+- Extraction: 81% EXTRACTED · 19% INFERRED · 0% AMBIGUOUS · INFERRED: 8279 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `74d4def3`
+- Built from commit: `295f02f8`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -719,7 +719,6 @@
 - [[_COMMUNITY_Community 795|Community 795]]
 - [[_COMMUNITY_Community 799|Community 799]]
 - [[_COMMUNITY_Community 800|Community 800]]
-- [[_COMMUNITY_Community 801|Community 801]]
 - [[_COMMUNITY_Community 804|Community 804]]
 - [[_COMMUNITY_Community 805|Community 805]]
 - [[_COMMUNITY_Community 807|Community 807]]
@@ -742,21 +741,15 @@
 - [[_COMMUNITY_Community 845|Community 845]]
 - [[_COMMUNITY_Community 846|Community 846]]
 - [[_COMMUNITY_Community 847|Community 847]]
-- [[_COMMUNITY_Community 848|Community 848]]
 - [[_COMMUNITY_Community 849|Community 849]]
 - [[_COMMUNITY_Community 852|Community 852]]
 - [[_COMMUNITY_Community 853|Community 853]]
-- [[_COMMUNITY_Community 854|Community 854]]
-- [[_COMMUNITY_Community 855|Community 855]]
-- [[_COMMUNITY_Community 860|Community 860]]
-- [[_COMMUNITY_Community 861|Community 861]]
-- [[_COMMUNITY_Community 865|Community 865]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `SHAFT` - 311 edges
-2. `IOException` - 123 edges
+2. `IOException` - 124 edges
 3. `CaptureGenerator` - 104 edges
-4. `ArrayList` - 100 edges
+4. `ArrayList` - 101 edges
 5. `RestActionsComprehensiveTests` - 99 edges
 6. `Test` - 98 edges
 7. `ReportManagerHelper` - 76 edges
@@ -779,11 +772,11 @@
 ## Import Cycles
 - None detected.
 
-## Communities (857 total, 97 thin omitted)
+## Communities (852 total, 101 thin omitted)
 
 ### Community 0 - "Community 0"
 Cohesion: 0.04
-Nodes (8): RestActionsComprehensiveTests, API, ComparisonType, Deprecated, InputStream, SuppressWarnings, BeforeMethod, Test
+Nodes (7): RestActionsComprehensiveTests, GraphqlRequestTests, ComparisonType, InputStream, SuppressWarnings, BeforeMethod, Test
 
 ### Community 1 - "Community 1"
 Cohesion: 0.05
@@ -794,8 +787,8 @@ Cohesion: 0.12
 Nodes (6): SetProperty, Web, DefaultValue, Key, SetProperty, String
 
 ### Community 3 - "Community 3"
-Cohesion: 0.11
-Nodes (17): LocatorAssertions, PageAssertions, Parameter, LinkedHashMap, List, Locator, Object, Override (+9 more)
+Cohesion: 0.10
+Nodes (19): LocatorAssertions, Outcome, PageAssertions, LinkedHashMap, List, Locator, Object, Override (+11 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.07
@@ -806,12 +799,12 @@ Cohesion: 0.13
 Nodes (14): ConsoleEvent, BrowserObservabilityRecorder, disabled(), NetworkEvent, NetworkExchange, NetworkObservation, HttpRequest, HttpResponse (+6 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.09
-Nodes (7): AfterMethod, BeforeMethod, CSVFileManager, Object, String, Test, CSVFileManagerUnitTest
+Cohesion: 0.06
+Nodes (14): CSVFileManager, CSVFileManagerTest, List, Map, String, BeforeMethod, Test, AfterMethod (+6 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.08
-Nodes (28): KeyboardKeys, LocatorOperation, MobileService, McpMobileAccessibilityTree, McpMobileContextSnapshot, McpMobileSessionResult, BrowserType, By (+20 more)
+Cohesion: 0.06
+Nodes (37): Autowired, KeyboardKeys, LocatorOperation, MobileService, MobileServiceConfigurationTest, McpMobileAccessibilityTree, McpMobileContextSnapshot, McpMobileSessionResult (+29 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.07
@@ -820,10 +813,6 @@ Nodes (23): BrowserStackSdkHelper, BrowserStackSdkTests, List, Map, Object, Stri
 ### Community 9 - "Community 9"
 Cohesion: 0.14
 Nodes (8): LocatorHealthReporter, LocatorStats, LocatorStats, AssertionError, By, List, ObjectNode, String
-
-### Community 10 - "Community 10"
-Cohesion: 0.07
-Nodes (7): Boolean, NumbersComparativeRelation, Object, String, Test, JavaHelper, JavaHelperUnitTest
 
 ### Community 11 - "Community 11"
 Cohesion: 0.09
@@ -839,83 +828,79 @@ Nodes (10): DataType, JSONFileManager, List, Map, Object, String, AfterMethod, B
 
 ### Community 14 - "Community 14"
 Cohesion: 0.14
-Nodes (17): E, merge(), MouseButton, CaptureEventPipeline, SafePage, SafeTarget, BrowserSignal, CaptureEvent (+9 more)
-
-### Community 15 - "Community 15"
-Cohesion: 0.07
-Nodes (15): requestTarget(), ShaftRestAssuredFilter, ApiEvidenceLabels, FilterableResponseSpecification, FilterContext, JsonElement, FilterableRequestSpecification, Object (+7 more)
+Nodes (19): dataString(), E, empty(), merge(), MouseButton, CaptureEventPipeline, SafePage, SafeTarget (+11 more)
 
 ### Community 16 - "Community 16"
 Cohesion: 0.07
-Nodes (10): JunitCoreAssertionMigrationTest, LocalShellTests, Test, Test, AfterMethod, Path, String, SuppressWarnings (+2 more)
+Nodes (6): AfterMethod, Path, String, SuppressWarnings, Test, TerminalActionsUnitTest
 
 ### Community 17 - "Community 17"
-Cohesion: 0.09
+Cohesion: 0.08
 Nodes (14): AsyncAppender, ReportManagerHelper, TestCaseStarted, ByteArrayOutputStream, CheckpointStatus, InputStream, Level, List (+6 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.12
-Nodes (14): FileActions, Boolean, Collection, Exception, File, String, SuppressWarnings, TerminalActions (+6 more)
+Cohesion: 0.08
+Nodes (22): FileActions, FileActionsCoverageUnitTest, ReportHelper, Boolean, Collection, Exception, File, InputStream (+14 more)
 
 ### Community 19 - "Community 19"
-Cohesion: 0.12
-Nodes (12): McpMobileToolchainService, McpAndroidEmulatorProposal, Duration, List, Map, McpMobileDevice, McpMobileToolchainStatus, McpProcessRunner (+4 more)
+Cohesion: 0.11
+Nodes (14): McpMobileToolchainService, McpAndroidEmulatorProposal, Duration, List, Map, McpMobileDevice, McpMobileToolchainDiagnostic, McpMobileToolchainStatus (+6 more)
 
 ### Community 20 - "Community 20"
 Cohesion: 0.13
 Nodes (6): Healing, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 21 - "Community 21"
-Cohesion: 0.14
-Nodes (13): WebDriverListener, Navigation, Alert, By, Method, Object, String, URL (+5 more)
+Cohesion: 0.07
+Nodes (27): BrowserStackModuleTest, HealingSupport, WebDriverListener, InvocationTargetException, JsonSchemaValidatorTest, Navigation, Test, Alert (+19 more)
 
 ### Community 22 - "Community 22"
-Cohesion: 0.09
-Nodes (19): NativeValidationsBuilder, AssertEqualsTests, VerifyEqualsTests, FileValidationsBuilder, Object, Override, RestValidationsBuilder, String (+11 more)
+Cohesion: 0.11
+Nodes (15): NativeValidationsBuilder, AssertEqualsTests, FileValidationsBuilder, Object, Override, RestValidationsBuilder, String, SuppressWarnings (+7 more)
 
 ### Community 23 - "Community 23"
-Cohesion: 0.11
-Nodes (13): ImageProcessingActionsCoverageUnitTest, List, AfterMethod, BeforeMethod, BufferedImage, Color, DataProvider, Map (+5 more)
+Cohesion: 0.09
+Nodes (18): ClassLoader, ImageProcessingActionsCoverageUnitTest, OpenCvBlockingClassLoader, List, AfterMethod, BeforeMethod, BufferedImage, Class (+10 more)
 
 ### Community 24 - "Community 24"
-Cohesion: 0.11
-Nodes (5): AllureManager, Future, Path, Process, String
+Cohesion: 0.08
+Nodes (11): AllureManager, BooleanSupplier, Counts, ArrayNode, Future, InputStream, List, ObjectNode (+3 more)
 
 ### Community 25 - "Community 25"
-Cohesion: 0.19
-Nodes (8): DoctorRepairPublicationRequest, ExistingPullRequest, DoctorRepairService, DoctorRepairRequest, Path, RepairProposal, RepairPublicationResult, String
+Cohesion: 0.11
+Nodes (24): AllureVerdict, DoctorRepairPublicationRequest, ExistingPullRequest, Operation, PatchManifestEntry, changedSince(), DoctorRepairService, RepairGuard (+16 more)
 
 ### Community 26 - "Community 26"
 Cohesion: 0.07
 Nodes (15): DriverFactoryHelperCoverageUnitTest, TestableDriverFactoryHelper, OptionsManager, AfterMethod, AtomicInteger, CountDownLatch, DriverFactoryHelper, DriverType (+7 more)
 
 ### Community 27 - "Community 27"
-Cohesion: 0.08
-Nodes (4): ValidationTests, AfterMethod, BeforeMethod, Test
+Cohesion: 0.06
+Nodes (8): TextDirectionValidationsBuilder, ValidationTests, NativeValidationsBuilder, ValidationsExecutor, AfterMethod, BeforeMethod, Test, TextDirection
 
 ### Community 28 - "Community 28"
-Cohesion: 0.08
-Nodes (14): PropertyFileManager, PropertyFileManagerInternalUnitTest, ThreadLocalPropertiesManager, File, HashMap, Map, MutableCapabilities, Object (+6 more)
+Cohesion: 0.21
+Nodes (3): ThreadLocalPropertiesManager, Properties, String
 
 ### Community 29 - "Community 29"
 Cohesion: 0.10
 Nodes (18): AccessibilityConfig, AccessibilityHelper, AccessibilityResult, AxeBuilder, AccessibilityResult, Integer, JSONArray, JSONObject (+10 more)
 
 ### Community 30 - "Community 30"
-Cohesion: 0.11
-Nodes (14): RequestBuilderPerformanceTest, RequestBuilderTests, AuthenticationType, AfterMethod, RequestType, RestActions, String, Test (+6 more)
+Cohesion: 0.12
+Nodes (16): RequestBuilderPerformanceTest, RequestBuilderTests, RestAssuredConfig, ContentType, ParametersType, AfterMethod, RequestType, RestActions (+8 more)
 
 ### Community 31 - "Community 31"
 Cohesion: 0.10
 Nodes (16): ChannelSftp, TerminalActions, ProcessBuilder, SftpTransferDirection, Boolean, BufferedReader, Deprecated, Exception (+8 more)
 
 ### Community 32 - "Community 32"
-Cohesion: 0.08
-Nodes (11): EngineServiceRuntimePathTest, AfterMethod, Class, Object, Path, String, Test, AfterEach (+3 more)
+Cohesion: 0.07
+Nodes (11): AfterMethod, Class, Object, Path, String, Test, AfterMethod, String (+3 more)
 
 ### Community 33 - "Community 33"
-Cohesion: 0.10
-Nodes (13): TestNGListenerHelper, Browser, ISuite, ITestContext, ITestNGMethod, ITestResult, List, Method (+5 more)
+Cohesion: 0.12
+Nodes (8): TestNGListenerHelper, ISuite, ITestContext, ITestNGMethod, ITestResult, List, String, TestExecutionInfo
 
 ### Community 34 - "Community 34"
 Cohesion: 0.08
@@ -923,11 +908,11 @@ Nodes (27): DeterministicNaturalActionPlanner, unsupported(), NaturalActionPlann
 
 ### Community 35 - "Community 35"
 Cohesion: 0.07
-Nodes (29): IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, ExecutionSummaryReport, StatusIcon() (+21 more)
+Nodes (28): Constructor, IAlterSuiteListener, IAnnotationTransformer, IExecutionListener, IInvokedMethodListener, IMethodInstance, IMethodInterceptor, IResultListener2 (+20 more)
 
 ### Community 36 - "Community 36"
 Cohesion: 0.07
-Nodes (27): DataTableArgument, EmbedEvent, HookTestStep, CucumberFeatureListener, PickleStepTestStep, Result, Scenario, AllureLifecycle (+19 more)
+Nodes (30): DataTableArgument, EmbedEvent, FulfillOptions, HookTestStep, CucumberFeatureListener, Parameter, PickleStepTestStep, Result (+22 more)
 
 ### Community 37 - "Community 37"
 Cohesion: 0.17
@@ -938,24 +923,24 @@ Cohesion: 0.09
 Nodes (18): BrowserNetworkInterceptor, ClientConfig, DriverFactoryHelper, BrowserNetworkInterceptionRule, Capabilities, Class, DriverType, List (+10 more)
 
 ### Community 39 - "Community 39"
-Cohesion: 0.09
-Nodes (11): AfterMethod, BeforeMethod, Class, List, Object, Path, String, T (+3 more)
+Cohesion: 0.08
+Nodes (12): Boolean, AfterMethod, BeforeMethod, Class, List, Object, Path, String (+4 more)
 
 ### Community 40 - "Community 40"
-Cohesion: 0.08
-Nodes (14): NavigationAction, API, BrowserActions, Cookie, List, NetworkInterceptionRequestBuilder, Override, RuntimeException (+6 more)
+Cohesion: 0.07
+Nodes (15): NavigationAction, API, BrowserActions, Cookie, List, NetworkInterceptionRequestBuilder, Override, RuntimeException (+7 more)
 
 ### Community 41 - "Community 41"
-Cohesion: 0.16
-Nodes (16): CollectionState, EvidenceCollector, CollectionState, DoctorRedactor, DefaultPrettyPrinter, DoctorAnalysisRequest, EvidenceBundle, EvidenceCategory (+8 more)
+Cohesion: 0.19
+Nodes (13): CollectionState, EvidenceCollector, CollectionState, DoctorRedactor, DoctorAnalysisRequest, EvidenceCategory, EvidenceItem, JsonNode (+5 more)
 
 ### Community 42 - "Community 42"
-Cohesion: 0.10
-Nodes (14): ElementLookup, GetElementInformation, Actions, ClipboardAction, GetElementInformation, Beta, By, ClipboardAction (+6 more)
+Cohesion: 0.11
+Nodes (13): ElementLookup, GetElementInformation, Actions, ClipboardAction, GetElementInformation, Beta, By, ClipboardAction (+5 more)
 
 ### Community 43 - "Community 43"
-Cohesion: 0.07
-Nodes (9): TextDirectionValidationsBuilder, E2ECoverageTests, NativeValidationsBuilder, ValidationsExecutor, AfterMethod, BeforeMethod, Test, TextDirection (+1 more)
+Cohesion: 0.08
+Nodes (5): E2ECoverageTests, AfterMethod, BeforeMethod, Test, TextLanguageValidationsBuilder
 
 ### Community 44 - "Community 44"
 Cohesion: 0.08
@@ -966,8 +951,8 @@ Cohesion: 0.10
 Nodes (21): ActionsCoverageUnitTest, RecordingActions, RecordingActions, ActionType, AfterMethod, AllureLifecycle, BeforeMethod, By (+13 more)
 
 ### Community 46 - "Community 46"
-Cohesion: 0.21
-Nodes (7): AssertionSteps, PDFTests, String, Then, ThreadLocal, WebDriver, String
+Cohesion: 0.24
+Nodes (5): AssertionSteps, PDFTests, String, Then, String
 
 ### Community 47 - "Community 47"
 Cohesion: 0.08
@@ -975,27 +960,27 @@ Nodes (4): NewValidationHelperTests, AfterMethod, BeforeMethod, Test
 
 ### Community 48 - "Community 48"
 Cohesion: 0.07
-Nodes (13): NumberValidationsBuilder, ValidationsBuilderTests, Number, Object, Override, RestValidationsBuilder, SuppressWarnings, ValidationsBuilder (+5 more)
+Nodes (12): NumberValidationsBuilder, ValidationsBuilderTests, Number, Object, Override, RestValidationsBuilder, SuppressWarnings, ValidationsBuilder (+4 more)
 
 ### Community 49 - "Community 49"
-Cohesion: 0.14
-Nodes (11): FailureTraceReporter, List, Path, SourceContext, StackTraceElement, String, StringBuilder, TestExecutionInfo (+3 more)
+Cohesion: 0.13
+Nodes (12): FailureTraceReporter, PlaywrightTraceManager, List, Path, SourceContext, StackTraceElement, String, StringBuilder (+4 more)
 
 ### Community 50 - "Community 50"
 Cohesion: 0.04
 Nodes (47): additionalProperties, minLength, type, maximum, minimum, type, type, minLength (+39 more)
 
 ### Community 51 - "Community 51"
-Cohesion: 0.08
-Nodes (10): ApiActionsMockedTests, RequestBuilder, RequestType, AfterMethod, BeforeMethod, Test, AfterClass, BeforeClass (+2 more)
+Cohesion: 0.07
+Nodes (12): AssertApiResponseEqualsTests, ApiActionsMockedTests, RequestBuilder, RequestType, Test, AfterMethod, BeforeMethod, Test (+4 more)
 
 ### Community 52 - "Community 52"
-Cohesion: 0.07
-Nodes (16): ApiPerformanceReportTest, SwaggerContractTest, testPostRequest, ContentType, AfterMethod, AfterSuite, BeforeMethod, Test (+8 more)
+Cohesion: 0.06
+Nodes (23): ApiPerformanceReportTest, PathParamTest, SwaggerContractTest, TestUpload, Object, ParametersType, AfterMethod, AfterSuite (+15 more)
 
 ### Community 53 - "Community 53"
 Cohesion: 0.10
-Nodes (19): RestActions, RequestSpecBuilder, RestAssuredConfig, ArrayNode, Boolean, Class, ContentType, Cookie (+11 more)
+Nodes (18): RestActions, RequestSpecBuilder, API, ArrayNode, Boolean, Class, Cookie, Deprecated (+10 more)
 
 ### Community 54 - "Community 54"
 Cohesion: 0.13
@@ -1003,11 +988,11 @@ Nodes (28): _attachment_source_candidates(), _clean_cell(), _failure_brief_open_
 
 ### Community 55 - "Community 55"
 Cohesion: 0.14
-Nodes (16): ElementActionsHelper, TextDetectionStrategy(), ShadowLocatorBuilder, AtomicInteger, Boolean, By, Class, ClipboardAction (+8 more)
+Nodes (15): ElementActionsHelper, TextDetectionStrategy(), AtomicInteger, Boolean, By, Class, HealingResolution, List (+7 more)
 
 ### Community 56 - "Community 56"
-Cohesion: 0.13
-Nodes (17): McpMobileInspectorRecordingService, Session, Duration, List, Map, McpCodeBlock, McpMobileDevice, McpMobileInspectorPlan (+9 more)
+Cohesion: 0.07
+Nodes (33): McpMobileInspectorRecordingService, Session, McpMobileInspectorRecordingServiceTest, NoopRunner, McpMobileToolchainService, McpProcessRunner, Duration, List (+25 more)
 
 ### Community 57 - "Community 57"
 Cohesion: 0.13
@@ -1026,8 +1011,8 @@ Cohesion: 0.08
 Nodes (27): Document, GuideHttpClient, GuideIndex, GuideHttpClient, GuideService, JdkGuideHttpClient, FakeGuideHttpClient, GuideServiceTest (+19 more)
 
 ### Community 61 - "Community 61"
-Cohesion: 0.11
-Nodes (16): FulfillOptions, AllureListenerCoverageUnitTest, Throwable, Status, AfterMethod, BeforeMethod, ITestResult, List (+8 more)
+Cohesion: 0.12
+Nodes (14): AllureListenerCoverageUnitTest, Throwable, AfterMethod, BeforeMethod, ITestResult, List, Path, String (+6 more)
 
 ### Community 62 - "Community 62"
 Cohesion: 0.14
@@ -1042,8 +1027,8 @@ Cohesion: 0.11
 Nodes (11): COSDocument, DeleteFileAfterValidationStatus, PdfFileManager, PDFParser, RandomAccessReadBufferedFile, File, String, AfterMethod (+3 more)
 
 ### Community 65 - "Community 65"
-Cohesion: 0.06
-Nodes (23): PathParamTest, TestUpload, AssertApiResponseEqualsTests, BasicAPITests, GraphqlRequestTests, Map, Object, ParametersType (+15 more)
+Cohesion: 0.17
+Nodes (4): AfterClass, BeforeClass, Test, APITests
 
 ### Community 66 - "Community 66"
 Cohesion: 0.05
@@ -1066,24 +1051,24 @@ Cohesion: 0.10
 Nodes (43): expand_globs(), issue(), load_budget(), local_link_targets(), markdown_body(), normalized_paragraphs(), parse_frontmatter(), quoted_yaml_value() (+35 more)
 
 ### Community 71 - "Community 71"
-Cohesion: 0.13
-Nodes (16): ShaftHeal, ShaftHealingProviderTest, Outcome, HealingReport, Optional, AfterMethod, AppiumDriver, BeforeMethod (+8 more)
+Cohesion: 0.09
+Nodes (21): ShaftHeal, ShaftHealingProviderTest, WebDomHealingAcceptanceTest, HealingReport, Optional, AfterMethod, AppiumDriver, BeforeMethod (+13 more)
 
 ### Community 72 - "Community 72"
-Cohesion: 0.09
-Nodes (30): DoctorAnalyzerTest, empty(), reviewUiPath(), disabled(), McpResultRecordsTest, disabled(), empty(), defaults() (+22 more)
+Cohesion: 0.20
+Nodes (12): DoctorAnalyzerTest, Arguments, CauseCategory, DoctorAnalysisRequest, DoctorAnalysisResult, List, MethodSource, ParameterizedTest (+4 more)
 
 ### Community 73 - "Community 73"
-Cohesion: 0.26
-Nodes (7): denyAll(), CaptureGeneratorTest, CaptureGenerationRequest, CaptureSession, Path, String, Test
+Cohesion: 0.16
+Nodes (15): allows(), ApprovalPolicy(), denyAll(), reviewPath(), reviewUiPath(), CaptureGeneratorTest, Path, CaptureGenerationRequest (+7 more)
 
 ### Community 74 - "Community 74"
 Cohesion: 0.11
-Nodes (11): CaptureStatusTest, ManagedCaptureRecorder, BrowserSignal, CapturePrivacyPolicy, CaptureStartRequest, CaptureStatus, CheckpointKind, Object (+3 more)
+Nodes (14): CapturePrivacyClassifier, ManagedCaptureRecorder, BrowserMetadata, BrowserSignal, CapturePrivacyPolicy, CaptureReadiness, CaptureStartRequest, CaptureStatus (+6 more)
 
 ### Community 75 - "Community 75"
-Cohesion: 0.19
-Nodes (8): Actions, By, ElementActions, List, Map, Override, String, SuppressWarnings
+Cohesion: 0.15
+Nodes (11): Actions, By, DriverFactoryHelper, ElementActions, List, Map, Override, String (+3 more)
 
 ### Community 76 - "Community 76"
 Cohesion: 0.08
@@ -1091,15 +1076,15 @@ Nodes (26): Session1Test, LocatorOperation, PlaywrightService, AfterMethod, Befo
 
 ### Community 77 - "Community 77"
 Cohesion: 0.11
-Nodes (9): AfterMethod, BeforeMethod, Issue, Issues, ITestResult, String, Test, TmsLinks (+1 more)
+Nodes (10): AfterMethod, BeforeMethod, Issue, Issues, ITestResult, String, Test, TmsLink (+2 more)
 
 ### Community 78 - "Community 78"
 Cohesion: 0.05
 Nodes (40): additionalProperties, enum, pattern, type, pattern, type, items, type (+32 more)
 
 ### Community 79 - "Community 79"
-Cohesion: 0.18
-Nodes (9): CaptureControlFiles, ControlDescriptor, CaptureStartRequest, CaptureStatus, Class, Object, Path, String (+1 more)
+Cohesion: 0.15
+Nodes (11): CaptureControlFiles, CaptureControlFilesTest, ControlDescriptor, CaptureStartRequest, CaptureStatus, Class, Object, Path (+3 more)
 
 ### Community 80 - "Community 80"
 Cohesion: 0.19
@@ -1114,16 +1099,16 @@ Cohesion: 0.05
 Nodes (39): additionalProperties, type, maximum, minimum, type, additionalProperties, properties, required (+31 more)
 
 ### Community 84 - "Community 84"
-Cohesion: 0.10
-Nodes (21): option(), ProviderConfiguration(), ProviderConfigurationTest, FirestoreRestClient, Properties, CaptureStartRequest(), validateUrl(), CaptureBrowser (+13 more)
+Cohesion: 0.08
+Nodes (27): option(), ProviderConfiguration(), ProviderConfigurationTest, Properties, FakeRunner, CaptureStartRequest(), validateUrl(), CaptureBrowser (+19 more)
 
 ### Community 85 - "Community 85"
-Cohesion: 0.18
-Nodes (11): ClassifiedUpload, CapturePrivacyClassifier, SanitizedAttributes, SanitizedText, CapturePrivacyPolicy, ClassifiedValue, List, Map (+3 more)
+Cohesion: 0.14
+Nodes (14): ClassifiedUpload, CapturePrivacyClassifier, CapturePrivacyClassifierTest, SanitizedAttributes, SanitizedText, CapturePrivacyPolicy, ClassifiedValue, List (+6 more)
 
 ### Community 86 - "Community 86"
-Cohesion: 0.07
-Nodes (21): AttachmentFormat, AttachmentSnapshot, AttachmentReporter, getType(), Screenshots, ByteArrayOutputStream, Path, String (+13 more)
+Cohesion: 0.13
+Nodes (9): AttachmentSnapshot, getType(), Screenshots, DataProvider, Object, Path, String, Test (+1 more)
 
 ### Community 87 - "Community 87"
 Cohesion: 0.15
@@ -1138,8 +1123,8 @@ Cohesion: 0.10
 Nodes (14): WebDriverElementValidationsBuilder, GuiVerificationTests, By, NativeValidationsBuilder, Override, String, StringBuilder, ValidationCategory (+6 more)
 
 ### Community 90 - "Community 90"
-Cohesion: 0.11
-Nodes (29): append(), checkpoint(), complete(), ensureIncomplete(), interrupt(), sortedCheckpoints(), sortedEvents(), sortedReferences() (+21 more)
+Cohesion: 0.22
+Nodes (11): CaptureEvent, CaptureJsonCodec, CaptureSession, Checkpoint, ExternalTestDataReference, Instant, List, Path (+3 more)
 
 ### Community 91 - "Community 91"
 Cohesion: 0.10
@@ -1147,11 +1132,11 @@ Nodes (3): AfterMethod, Test, NativeValidationsBuilderUnitTest
 
 ### Community 92 - "Community 92"
 Cohesion: 0.09
-Nodes (51): child_text(), dependency_coordinate(), dependency_template(), direct_child(), elements_named(), ensure_android_json_exclusion(), ensure_dependency(), ensure_generator_dependency_set() (+43 more)
+Nodes (49): child_text(), dependency_coordinate(), dependency_template(), direct_child(), elements_named(), ensure_android_json_exclusion(), ensure_dependency(), ensure_generator_dependency_set() (+41 more)
 
 ### Community 93 - "Community 93"
-Cohesion: 0.07
-Nodes (17): LocatorBuilder, ShadowDomTest, JDK21VirtualThreadsAndAsyncActionsTests, RelativeBy, By, Locator, Page, Role (+9 more)
+Cohesion: 0.11
+Nodes (9): LocatorBuilder, RelativeBy, By, Locator, Page, Role, ShaftLocator, String (+1 more)
 
 ### Community 94 - "Community 94"
 Cohesion: 0.05
@@ -1162,8 +1147,8 @@ Cohesion: 0.11
 Nodes (15): builder(), evidenceCategories(), withSanitizedContent(), withTimeout(), AiValueObjectsTest, AiRequest, ApprovalPolicy, Duration (+7 more)
 
 ### Community 96 - "Community 96"
-Cohesion: 0.08
-Nodes (20): DriverFactory, DriverType(), MatchJsonSchemaTests, DatabaseActions, DatabaseType, Deprecated, DriverFactoryHelper, DriverType (+12 more)
+Cohesion: 0.16
+Nodes (13): DriverFactory, DriverType(), DatabaseActions, DatabaseType, Deprecated, DriverFactoryHelper, DriverType, MutableCapabilities (+5 more)
 
 ### Community 97 - "Community 97"
 Cohesion: 0.07
@@ -1186,16 +1171,16 @@ Cohesion: 0.06
 Nodes (36): additionalProperties, minLength, type, type, type, type, $id, additionalProperties (+28 more)
 
 ### Community 102 - "Community 102"
-Cohesion: 0.13
-Nodes (23): DoctorAiAnalysisServiceTest, AiBudget, defaults(), disabled(), EnumSource, defaults(), ApprovalPolicy, DoctorAiAnalysisRequest (+15 more)
+Cohesion: 0.16
+Nodes (19): DoctorAiAnalysisServiceTest, AiBudget, EnumSource, from(), DoctorAnalysisResult, DoctorAnalysisSummary, AiRequest, AiResponse (+11 more)
 
 ### Community 103 - "Community 103"
-Cohesion: 0.16
-Nodes (7): HttpContractRecorder, JsonNode, Map, Set, String, URI, ValidationMode
+Cohesion: 0.17
+Nodes (5): HttpContractRecorder, JsonNode, Map, String, ValidationMode
 
 ### Community 104 - "Community 104"
-Cohesion: 0.11
-Nodes (15): Dimension, BrowserActionsHelper, WindowType, Boolean, Exception, List, Object, SneakyThrows (+7 more)
+Cohesion: 0.16
+Nodes (11): Dimension, BrowserActionsHelper, WindowType, Boolean, Exception, List, Object, SneakyThrows (+3 more)
 
 ### Community 105 - "Community 105"
 Cohesion: 0.14
@@ -1214,28 +1199,28 @@ Cohesion: 0.13
 Nodes (5): YAMLFileManagerTests, BeforeMethod, Date, String, Test
 
 ### Community 109 - "Community 109"
-Cohesion: 0.16
-Nodes (6): AfterTest, BeforeTest, ConfigurationHelper, ReportHelper, ITestContext, Step
+Cohesion: 0.31
+Nodes (5): AfterTest, BeforeTest, ConfigurationHelper, ITestContext, Step
 
 ### Community 110 - "Community 110"
-Cohesion: 0.28
-Nodes (8): AiExecutionServiceTest, AiExecutionService, AiProviderRegistry, AiRequest, AiResponse, ApprovalPolicy, PilotConfiguration, Test
+Cohesion: 0.16
+Nodes (14): AiExecutionServiceTest, StubProvider, AiCapabilities, AiExecutionService, AiProviderAvailability, AiProviderRegistry, AiRequest, AiResponse (+6 more)
 
 ### Community 111 - "Community 111"
-Cohesion: 0.17
-Nodes (18): DeterministicRuleEngine, Confidence, Finding, distinct(), Remediation, RetrySummary, RuleMatch, CauseCategory (+10 more)
+Cohesion: 0.12
+Nodes (21): DeterministicRuleEngine, Confidence, Finding, HealingProviderRegistry, Remediation, RetrySummary, RuleMatch, CauseCategory (+13 more)
 
 ### Community 112 - "Community 112"
-Cohesion: 0.12
-Nodes (11): API, JSON, Class, Cookie, List, Map, Object, RequestBuilder (+3 more)
+Cohesion: 0.09
+Nodes (12): API, Contracts, YAML, Class, Cookie, List, Map, Object (+4 more)
 
 ### Community 113 - "Community 113"
-Cohesion: 0.15
-Nodes (6): Platform, SetProperty, DefaultValue, Key, SetProperty, String
+Cohesion: 0.30
+Nodes (4): Platform, DefaultValue, Key, SetProperty
 
 ### Community 114 - "Community 114"
-Cohesion: 0.12
-Nodes (9): IIOMetadataNode, AnimatedGifManager, GifSession, ImageOutputStream, ImageWriter, RenderedImage, BufferedImage, String (+1 more)
+Cohesion: 0.08
+Nodes (16): IIOMetadataNode, AnimatedGifManager, GifSession, AnimatedGifManagerCoverageUnitTest, ImageOutputStream, ImageWriter, RenderedImage, BufferedImage (+8 more)
 
 ### Community 115 - "Community 115"
 Cohesion: 0.06
@@ -1246,8 +1231,8 @@ Cohesion: 0.11
 Nodes (19): getValue(), KeyboardKeys(), TouchActions, ImmutableMap, viewport(), By, DriverFactoryHelper, File (+11 more)
 
 ### Community 117 - "Community 117"
-Cohesion: 0.11
-Nodes (26): AllureFile, changedSince(), HealerService, ProcessExecutor, successful(), HealerServiceTest, McpHealerAttemptResult, McpHealerRunResult (+18 more)
+Cohesion: 0.15
+Nodes (21): AllureFile, changedSince(), HealerService, ProcessExecutor, successful(), McpHealerAttemptResult, McpHealerRunResult, ProcessExecutor (+13 more)
 
 ### Community 118 - "Community 118"
 Cohesion: 0.17
@@ -1262,23 +1247,23 @@ Cohesion: 0.20
 Nodes (12): YAMLFileManager, Boolean, Class, Date, Double, Integer, List, Long (+4 more)
 
 ### Community 121 - "Community 121"
-Cohesion: 0.11
-Nodes (12): PlaywrightBrowserValidationsBuilder, AccessibilityActions, BrowserContext, BrowserNetworkInterceptionRule, HttpRequest, HttpResponse, Locator, NetworkInterceptionRequestBuilder (+4 more)
+Cohesion: 0.13
+Nodes (13): AccessibilityActions, BrowserContext, BrowserNetworkInterceptionRule, Cookie, HttpRequest, HttpResponse, Locator, NetworkInterceptionRequestBuilder (+5 more)
 
 ### Community 122 - "Community 122"
-Cohesion: 0.12
-Nodes (18): AbstractHttpAiProvider, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse, AiResponseStatus, AiUsage, Function (+10 more)
+Cohesion: 0.13
+Nodes (17): AbstractHttpAiProvider, AiCapabilities, AiRequest, AiResponse, AiResponseStatus, AiUsage, Function, HttpClient (+9 more)
 
 ### Community 123 - "Community 123"
 Cohesion: 0.10
 Nodes (4): AfterMethod, BeforeClass, Test, YAMLFileManagerUnitTest
 
 ### Community 124 - "Community 124"
-Cohesion: 0.08
-Nodes (29): AiTrigger, HealingProvider, HealingReportWriter, ShaftHealingProvider, safe(), stableKey(), HealingConfiguration, HealingReport (+21 more)
+Cohesion: 0.11
+Nodes (25): AiTrigger, HealingProvider, ShaftHealingProvider, safe(), stableKey(), HealingActionOutcome, HealingCandidate, HealingConfiguration (+17 more)
 
 ### Community 125 - "Community 125"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (15): LauncherSession, Override, AfterMethod, BeforeMethod, Duration, List, Object, Optional (+7 more)
 
 ### Community 126 - "Community 126"
@@ -1290,20 +1275,20 @@ Cohesion: 0.06
 Nodes (32): additionalProperties, type, items, type, minimum, type, minimum, type (+24 more)
 
 ### Community 128 - "Community 128"
-Cohesion: 0.17
-Nodes (15): AiExecutionService, CircuitState, RedactionResult, AiAuditSink, AiProvider, AiProviderRegistry, AiRequest, AiResponse (+7 more)
+Cohesion: 0.18
+Nodes (14): AiExecutionService, CircuitState, AiAuditSink, AiProvider, AiProviderRegistry, AiRequest, AiResponse, AiResponseStatus (+6 more)
 
 ### Community 129 - "Community 129"
-Cohesion: 0.17
-Nodes (13): disabled(), TraceEventRecorder, Iterable, ActionEvent, By, Event, List, Map (+5 more)
+Cohesion: 0.09
+Nodes (20): ArtifactPaths, CaptureReviewFinding, failure(), withUnsupported(), GenerationState, distinct(), CaptureEnrichmentPreview, CaptureGenerationReport (+12 more)
 
 ### Community 130 - "Community 130"
-Cohesion: 0.27
-Nodes (6): Config, List, String, SuppressWarnings, Test, XrayIntegrationHelper
+Cohesion: 0.15
+Nodes (12): Config, List, String, SuppressWarnings, AfterMethod, BeforeMethod, HttpExchange, Object (+4 more)
 
 ### Community 131 - "Community 131"
-Cohesion: 0.13
-Nodes (20): DoctorRepairProposalResult, DoctorRepairService, HealingLocatorProposalRequest, DoctorService, ApprovalPolicy, Diagnosis, DoctorAnalysisResult, DoctorAnalysisSummary (+12 more)
+Cohesion: 0.08
+Nodes (30): DoctorRepairProposalResult, DoctorRepairService, HealingLocatorProposalRequest, DoctorService, DoctorServiceTest, McpWorkspacePolicy, ApprovalPolicy, Diagnosis (+22 more)
 
 ### Community 132 - "Community 132"
 Cohesion: 0.15
@@ -1318,8 +1303,8 @@ Cohesion: 0.16
 Nodes (6): Mobile, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 135 - "Community 135"
-Cohesion: 0.10
-Nodes (18): Locator, Object, Override, PlaywrightSession, PlaywrightValidationsExecutor, String, StringBuilder, ValidationCategory (+10 more)
+Cohesion: 0.11
+Nodes (15): Locator, Object, Override, PlaywrightSession, PlaywrightValidationsExecutor, String, StringBuilder, ValidationCategory (+7 more)
 
 ### Community 136 - "Community 136"
 Cohesion: 0.16
@@ -1362,12 +1347,12 @@ Cohesion: 0.11
 Nodes (12): Color, Rectangle, AfterMethod, BeforeMethod, Color, Map, Method, Path (+4 more)
 
 ### Community 146 - "Community 146"
-Cohesion: 0.18
-Nodes (13): CaptureCodegenStartRequest, CaptureCodegenStartRequest, CaptureService, McpCaptureReplayResult, PreDestroy, CaptureGenerationResult, CaptureStatus, CodegenBackend (+5 more)
+Cohesion: 0.14
+Nodes (17): CaptureCodegenStartRequest, CaptureCodegenStartRequest, CaptureService, McpCaptureCodeBlockService, McpCaptureReplayResult, PreDestroy, CaptureGenerationResult, CaptureManager (+9 more)
 
 ### Community 147 - "Community 147"
-Cohesion: 0.19
-Nodes (11): CaptureCollectorUtilityTest, close(), start(), BrowserSignal, Class, Consumer, Object, Override (+3 more)
+Cohesion: 0.13
+Nodes (14): BrowserEventScript, CaptureCollectorUtilityTest, close(), start(), List, String, BrowserSignal, Class (+6 more)
 
 ### Community 148 - "Community 148"
 Cohesion: 0.14
@@ -1382,8 +1367,8 @@ Cohesion: 0.20
 Nodes (20): DoctorCli, flag(), optionalPath(), parse(), path(), pathRequired(), paths(), pathsRequired() (+12 more)
 
 ### Community 151 - "Community 151"
-Cohesion: 0.09
-Nodes (8): AsyncElementActionsCoverageUnitTest, Test, Test, AfterMethod, Path, String, Test, ThreadLocalPropertiesTest
+Cohesion: 0.06
+Nodes (16): PropertyFileManager, PropertyFileManagerInternalUnitTest, File, HashMap, Map, MutableCapabilities, Object, Properties (+8 more)
 
 ### Community 152 - "Community 152"
 Cohesion: 0.19
@@ -1394,28 +1379,28 @@ Cohesion: 0.12
 Nodes (15): APIResponse, PlaywrightNetworkInterceptor, PlaywrightNetworkInterceptorTest, Request, BrowserContext, BrowserNetworkInterceptionRule, HttpMethod, HttpRequest (+7 more)
 
 ### Community 154 - "Community 154"
-Cohesion: 0.16
-Nodes (10): CaptureGenerationReport(), notRequested(), skipped(), Enrichment, List, LocatorDecision, Status, String (+2 more)
+Cohesion: 0.17
+Nodes (6): AttachmentFormat, AttachmentReporter, ByteArrayOutputStream, Path, String, SuppressWarnings
 
 ### Community 155 - "Community 155"
 Cohesion: 0.14
 Nodes (15): CookieState, BrowserStorageStateManager, CookieState, OriginStorage, StorageState, Builder, Cookie, JavascriptExecutor (+7 more)
 
 ### Community 156 - "Community 156"
-Cohesion: 0.18
-Nodes (12): ScreenshotManager, Object, Boolean, By, JavascriptExecutor, List, Object, Screenshots (+4 more)
+Cohesion: 0.11
+Nodes (18): ElementActionsHelper, ScreenshotManager, ScreenshotManagerCoverageUnitTest, Object, Boolean, By, JavascriptExecutor, List (+10 more)
 
 ### Community 157 - "Community 157"
 Cohesion: 0.19
 Nodes (13): By, ElementActions, ElementAssertions, List, Locator, Map, Override, PlaywrightSession (+5 more)
 
 ### Community 158 - "Community 158"
-Cohesion: 0.09
-Nodes (12): XpathAxis, McpAppiumCommandRecorderTest, MobileRecordingServiceTest, Role, LocatorBuilder, String, Override, AfterMethod (+4 more)
+Cohesion: 0.10
+Nodes (10): XpathAxis, McpAppiumCommandRecorderTest, Role, LocatorBuilder, String, Override, AfterMethod, Test (+2 more)
 
 ### Community 159 - "Community 159"
-Cohesion: 0.10
-Nodes (24): ActionReportContext, abbreviate(), empty(), FlakeProfileContext, from(), hasElementName(), hasLocator(), hasStepTarget() (+16 more)
+Cohesion: 0.09
+Nodes (25): ActionReportContext, abbreviate(), empty(), FlakeProfileContext, from(), hasElementName(), hasLocator(), hasStepTarget() (+17 more)
 
 ### Community 160 - "Community 160"
 Cohesion: 0.08
@@ -1426,24 +1411,24 @@ Cohesion: 0.13
 Nodes (4): AfterMethod, BeforeMethod, Test, NegativeValidationsTests
 
 ### Community 162 - "Community 162"
-Cohesion: 0.12
+Cohesion: 0.13
 Nodes (5): AfterMethod, BeforeMethod, Test, WebDriver, BrowserActionsCoverageUnitTest
 
 ### Community 164 - "Community 164"
-Cohesion: 0.27
-Nodes (6): DatabaseActions, Boolean, DatabaseType, ResultSet, String, StringBuilder
+Cohesion: 0.24
+Nodes (7): Connection, DatabaseActions, Boolean, DatabaseType, ResultSet, String, StringBuilder
 
 ### Community 165 - "Community 165"
-Cohesion: 0.12
-Nodes (13): ChromeOptions, ChromiumOptions, DesiredCapabilities, OptionsManager, OptionsManagerCoverageUnitTest, LoggingPreferences, DriverType, MutableCapabilities (+5 more)
+Cohesion: 0.21
+Nodes (8): ChromiumOptions, DesiredCapabilities, OptionsManager, LoggingPreferences, DriverType, MutableCapabilities, String, SuppressWarnings
 
 ### Community 166 - "Community 166"
-Cohesion: 0.13
-Nodes (7): BrowserActions, List, Override, Page, Runnable, String, WindowType
+Cohesion: 0.10
+Nodes (8): PlaywrightBrowserValidationsBuilder, BrowserActions, List, Override, Page, Runnable, String, UnsupportedOperationException
 
 ### Community 167 - "Community 167"
-Cohesion: 0.19
-Nodes (7): Log4j, Log4jTests, DefaultValue, Key, String, BeforeClass, Test
+Cohesion: 0.08
+Nodes (14): AsyncElementActions, AsyncElementActionsCoverageUnitTest, Log4j, Log4jTests, By, ClipboardAction, DriverFactoryHelper, String (+6 more)
 
 ### Community 168 - "Community 168"
 Cohesion: 0.07
@@ -1458,8 +1443,8 @@ Cohesion: 0.12
 Nodes (10): BrowserService, EngineServiceTest, McpPageDomSnapshot, McpScreenshotResult, McpWorkspacePolicy, Path, String, Tool (+2 more)
 
 ### Community 171 - "Community 171"
-Cohesion: 0.12
-Nodes (15): ByAll, CompositeLocator, SmartLocator, SmartLocators, NaturalActionCompositeLocator, PathStrategy, By, List (+7 more)
+Cohesion: 0.27
+Nodes (7): SmartLocator, SmartLocators, PathStrategy, By, List, Override, String
 
 ### Community 172 - "Community 172"
 Cohesion: 0.17
@@ -1470,28 +1455,28 @@ Cohesion: 0.16
 Nodes (12): ValidationsHelper, Boolean, ComparisonType, LinkedHashMap, List, Number, NumbersComparativeRelation, Object (+4 more)
 
 ### Community 174 - "Community 174"
-Cohesion: 0.08
-Nodes (19): AsyncElementActions, Async, CLI, GUI, Locator, Properties, TestData, Validations (+11 more)
+Cohesion: 0.07
+Nodes (21): AsyncElementActions, Async, CLI, GUI, JSON, Locator, Properties, Report (+13 more)
 
 ### Community 175 - "Community 175"
 Cohesion: 0.17
 Nodes (7): RetryPolicy, Duration, Integer, RequestType, Set, String, Throwable
 
 ### Community 176 - "Community 176"
-Cohesion: 0.18
-Nodes (5): AsyncElementActions, By, ClipboardAction, DriverFactoryHelper, String
+Cohesion: 0.15
+Nodes (12): requestTarget(), ShaftRestAssuredFilter, ApiEvidenceLabels, FilterableResponseSpecification, FilterContext, JsonElement, FilterableRequestSpecification, Object (+4 more)
 
 ### Community 177 - "Community 177"
-Cohesion: 0.12
-Nodes (22): empty(), TraceService, McpTraceActionSummary, McpTraceLatestResult, McpTraceReadResult, McpTraceSummary, CauseCategory, CodegenBackend (+14 more)
+Cohesion: 0.06
+Nodes (42): disabled(), TraceEventRecorder, Iterable, empty(), TraceService, TraceServiceTest, McpTraceActionSummary, McpTraceLatestResult (+34 more)
 
 ### Community 178 - "Community 178"
 Cohesion: 0.20
 Nodes (9): TestAutomationService, McpCodeGuardrailResult, McpCodeGuardrailViolation, McpScenarioCatalogResult, McpTestAutomationScenario, List, Pattern, String (+1 more)
 
 ### Community 179 - "Community 179"
-Cohesion: 0.11
-Nodes (25): DoctorAiAnalysisService, ConfigurationIdentity, Metadata, asCacheHit(), AiRequest, AiResponse, AiResponseStatus, AiUsage (+17 more)
+Cohesion: 0.12
+Nodes (23): DoctorAiAnalysisService, ConfigurationIdentity, AiRequest, AiResponse, AiResponseStatus, AiUsage, CauseCategory, Diagnosis (+15 more)
 
 ### Community 180 - "Community 180"
 Cohesion: 0.17
@@ -1506,11 +1491,11 @@ Cohesion: 0.11
 Nodes (7): Playwright, PlaywrightSetProperty, PlaywrightSetProperty, DefaultValue, Key, Override, String
 
 ### Community 183 - "Community 183"
-Cohesion: 0.27
+Cohesion: 0.28
 Nodes (8): FingerprintExtractor, HealingConfiguration, LocatorFingerprint, Map, String, Supplier, WebDriver, WebElement
 
 ### Community 184 - "Community 184"
-Cohesion: 0.22
+Cohesion: 0.23
 Nodes (6): Internal, InternalTests, DefaultValue, Key, String, Test
 
 ### Community 185 - "Community 185"
@@ -1518,8 +1503,8 @@ Cohesion: 0.25
 Nodes (12): ElementActionabilityDiagnostics, By, List, Map, Object, Rectangle, String, Supplier (+4 more)
 
 ### Community 186 - "Community 186"
-Cohesion: 0.23
-Nodes (7): TestNG, TestNGTests, DefaultValue, Integer, Key, String, Test
+Cohesion: 0.15
+Nodes (11): TestNG, TestNGTests, Browser, Method, XmlSuite, DefaultValue, Integer, Key (+3 more)
 
 ### Community 187 - "Community 187"
 Cohesion: 0.08
@@ -1531,11 +1516,11 @@ Nodes (41): analyze_project(), collect_ai_context(), collect_source_migration(),
 
 ### Community 189 - "Community 189"
 Cohesion: 0.13
-Nodes (17): Bean, BrowserService, ElementService, GuideService, ShaftMcpApplication, MobileService, NaturalActionService, PlaywrightService (+9 more)
+Nodes (16): Bean, BrowserService, ElementService, GuideService, ShaftMcpApplication, MobileService, NaturalActionService, PlaywrightService (+8 more)
 
 ### Community 190 - "Community 190"
-Cohesion: 0.12
-Nodes (19): ActiveRetryAttempt, AfterAllCallback, AfterEachCallback, AfterTestExecutionCallback, BeforeAllCallback, BeforeEachCallback, DiscoverySelector, LauncherDiscoveryRequest (+11 more)
+Cohesion: 0.17
+Nodes (15): AfterAllCallback, AfterEachCallback, AfterTestExecutionCallback, BeforeAllCallback, BeforeEachCallback, DiscoverySelector, LauncherDiscoveryRequest, LifecycleMethodExecutionExceptionHandler (+7 more)
 
 ### Community 191 - "Community 191"
 Cohesion: 0.18
@@ -1546,20 +1531,20 @@ Cohesion: 0.16
 Nodes (3): AfterMethod, Test, ValidationsBuilderUnitTest
 
 ### Community 193 - "Community 193"
-Cohesion: 0.08
-Nodes (21): DriverAssertions, DriverVerifications, ElementActionsContract, BrowserAssertions, By, ElementAssertions, NativeValidationsBuilder, Object (+13 more)
+Cohesion: 0.17
+Nodes (7): ElementActionsContract, By, ElementAssertions, List, Map, ShaftLocator, String
 
 ### Community 194 - "Community 194"
-Cohesion: 0.16
-Nodes (6): DatabaseActionsMockedTests, AfterMethod, DatabaseActions, Object, String, Test
+Cohesion: 0.14
+Nodes (8): DatabaseActionsMockedTests, AfterMethod, BeforeMethod, DatabaseActions, Object, ResultSet, String, Test
 
 ### Community 195 - "Community 195"
 Cohesion: 0.17
 Nodes (19): build_parser(), collect_metrics(), issue(), main(), Run one external check and return a concise issue on failure., Collect stable context and memory size metrics., Run all agent setup checks., Build the command-line parser. (+11 more)
 
 ### Community 196 - "Community 196"
-Cohesion: 0.10
-Nodes (14): EvidenceEvent, appendJson(), FlakeProfiler, TestProfile, RetryEvent, ActionEvent, ArrayNode, AssertionError (+6 more)
+Cohesion: 0.07
+Nodes (21): ActionSample, EvidenceEvent, FlakeProfileContext, ActionSample, appendJson(), FlakeProfiler, TestProfile, FlakeProfilerUnitTest (+13 more)
 
 ### Community 197 - "Community 197"
 Cohesion: 0.24
@@ -1570,8 +1555,8 @@ Cohesion: 0.18
 Nodes (6): ElementInformation, ElementInformationCoverageUnitTest, Element, List, String, Test
 
 ### Community 199 - "Community 199"
-Cohesion: 0.25
-Nodes (4): Jira, DefaultValue, Key, SetProperty
+Cohesion: 0.12
+Nodes (9): Jira, SetProperty, JiraTests, DefaultValue, Key, SetProperty, String, BeforeClass (+1 more)
 
 ### Community 200 - "Community 200"
 Cohesion: 0.06
@@ -1586,16 +1571,16 @@ Cohesion: 0.19
 Nodes (13): GeminiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode, Map (+5 more)
 
 ### Community 204 - "Community 204"
-Cohesion: 0.17
-Nodes (13): AiImage, OpenAiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode (+5 more)
+Cohesion: 0.19
+Nodes (12): OpenAiProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode, Map (+4 more)
 
 ### Community 205 - "Community 205"
 Cohesion: 0.14
 Nodes (11): FailureTraceReporterTest, AndroidDriver, Attachment, List, Path, RuntimeException, String, SuppressWarnings (+3 more)
 
 ### Community 206 - "Community 206"
-Cohesion: 0.09
-Nodes (8): SetProperty, Timeouts, Boolean, DefaultValue, Deprecated, Key, SetProperty, String
+Cohesion: 0.15
+Nodes (3): SetProperty, Deprecated, String
 
 ### Community 207 - "Community 207"
 Cohesion: 0.23
@@ -1606,16 +1591,16 @@ Cohesion: 0.21
 Nodes (18): A(), ba(), c(), D(), E(), G(), i(), j() (+10 more)
 
 ### Community 209 - "Community 209"
-Cohesion: 0.05
-Nodes (50): AlertEvent, ArtifactPaths, AssertionSuggestion, CaptureReviewFinding, DataPlan, CaptureGenerator, CodegenBackend(), driverClassName() (+42 more)
+Cohesion: 0.07
+Nodes (31): AlertEvent, AssertionSuggestion, DataPlan, CaptureGenerator, CodegenBackend(), driverClassName(), from(), MutableTargetPlan (+23 more)
 
 ### Community 210 - "Community 210"
-Cohesion: 0.20
-Nodes (4): LocatorBuilderTest, AfterMethod, BeforeMethod, Test
+Cohesion: 0.18
+Nodes (6): JunitCoreAssertionMigrationTest, LocatorBuilderTest, Test, AfterMethod, BeforeMethod, Test
 
 ### Community 211 - "Community 211"
-Cohesion: 0.14
-Nodes (15): HistoryDocument, HistoryRecord, HealingHistoryStore, HistoryRecord(), withChecksum(), HealingConfiguration, HealingContext, LocatorFingerprint (+7 more)
+Cohesion: 0.17
+Nodes (11): HistoryDocument, HistoryRecord, HealingHistoryStore, HealingConfiguration, HealingContext, LocatorFingerprint, Optional, Path (+3 more)
 
 ### Community 212 - "Community 212"
 Cohesion: 0.16
@@ -1626,7 +1611,7 @@ Cohesion: 0.16
 Nodes (5): ElementAssertions, NativeValidationsBuilder, String, ValidationsExecutor, VisualValidationEngine
 
 ### Community 214 - "Community 214"
-Cohesion: 0.09
+Cohesion: 0.10
 Nodes (16): ImageProcessingActions, VisualProcessingProviderRegistry, Boolean, By, File, Integer, List, String (+8 more)
 
 ### Community 215 - "Community 215"
@@ -1634,12 +1619,12 @@ Cohesion: 0.12
 Nodes (22): minLength, type, properties, $ref, $ref, $ref, body, evidence (+14 more)
 
 ### Community 216 - "Community 216"
-Cohesion: 0.22
-Nodes (11): expired(), InstantDeadline(), ManagedCaptureRecorderBrowserTest, BooleanSupplier, Duration, HttpExchange, HttpServer, ParameterizedTest (+3 more)
+Cohesion: 0.24
+Nodes (10): expired(), InstantDeadline(), ManagedCaptureRecorderBrowserTest, Duration, HttpExchange, HttpServer, ParameterizedTest, Path (+2 more)
 
 ### Community 217 - "Community 217"
-Cohesion: 0.14
-Nodes (7): ActionSample, FlakeProfileContext, ActionSample, FlakeProfilerUnitTest, AfterMethod, BeforeMethod, Test
+Cohesion: 0.19
+Nodes (9): CaptureManagerLifecycleTest, FailingRecorder, FakeRecorder, CaptureStartRequest, CaptureStatus, CheckpointKind, Override, String (+1 more)
 
 ### Community 218 - "Community 218"
 Cohesion: 0.24
@@ -1658,12 +1643,12 @@ Cohesion: 0.20
 Nodes (13): AiCandidateReranker, AiExecutionService, Double, HealingConfiguration, JsonNode, List, Map, ObjectNode (+5 more)
 
 ### Community 222 - "Community 222"
-Cohesion: 0.24
-Nodes (9): HealingSupport, By, HealingContext, HealingPlatform, RemoteWebDriver, String, Supplier, WebDriver (+1 more)
+Cohesion: 0.39
+Nodes (6): ByteArrayOutputStream, Severity, Story, String, Test, AllAttachmentTypesTest
 
 ### Community 223 - "Community 223"
-Cohesion: 0.08
-Nodes (14): RestValidationsBuilder, JSONValidationsBuilder, JsonCompareWithSpecialCharactersTests, NativeValidationsBuilder, Object, String, StringBuilder, ValidationCategory (+6 more)
+Cohesion: 0.13
+Nodes (5): NumberValidationsBuilder, AfterMethod, BeforeClass, Test, RestValidationsBuilderUnitTest
 
 ### Community 224 - "Community 224"
 Cohesion: 0.19
@@ -1674,8 +1659,8 @@ Cohesion: 0.17
 Nodes (8): KeysetHandle, GoogleTink, GoogleTinkApiCoverageUnitTest, String, AfterMethod, BeforeMethod, Path, Test
 
 ### Community 226 - "Community 226"
-Cohesion: 0.09
-Nodes (20): ManagedCaptureRecorder, CaptureManager, CaptureManagerLifecycleTest, FailingRecorder, FakeRecorder, CaptureStartRequest, CaptureStatus, CheckpointKind (+12 more)
+Cohesion: 0.18
+Nodes (11): ManagedCaptureRecorder, CaptureManager, CaptureStartRequest, CaptureStatus, CheckpointKind, Function, ManagedCaptureRecorder, Override (+3 more)
 
 ### Community 227 - "Community 227"
 Cohesion: 0.20
@@ -1690,24 +1675,20 @@ Cohesion: 0.21
 Nodes (3): Method, Test, JavaScriptWaitManagerUnitTest
 
 ### Community 230 - "Community 230"
-Cohesion: 0.14
-Nodes (10): LambdaTestHelper, Boolean, DriverFactoryHelper, HashMap, MutableCapabilities, Object, String, AfterMethod (+2 more)
+Cohesion: 0.28
+Nodes (7): LambdaTestHelper, Boolean, DriverFactoryHelper, HashMap, MutableCapabilities, Object, String
 
 ### Community 231 - "Community 231"
 Cohesion: 0.18
 Nodes (3): AfterMethod, Test, RestActionsUtilsUnitTest
 
 ### Community 232 - "Community 232"
-Cohesion: 0.19
-Nodes (9): PilotTestConfiguration, RedactionPolicy, Redactor, AiRequest, Set, String, PilotConfiguration, ProcessingLocation (+1 more)
-
-### Community 233 - "Community 233"
-Cohesion: 0.10
-Nodes (6): PropertiesHelper, String, AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
+Cohesion: 0.17
+Nodes (10): PilotTestConfiguration, RedactionPolicy, RedactionResult, Redactor, AiRequest, Set, String, PilotConfiguration (+2 more)
 
 ### Community 234 - "Community 234"
-Cohesion: 0.18
-Nodes (10): ThrowingInvocation, WebDriverElementValidationsBuilderCoverageUnitTest, AfterMethod, NativeValidationsBuilder, String, Test, ValidationType, VisualValidationEngine (+2 more)
+Cohesion: 0.13
+Nodes (13): FirestoreRestClient, ThrowingInvocation, WebDriverElementValidationsBuilderCoverageUnitTest, Deprecated, String, AfterMethod, NativeValidationsBuilder, String (+5 more)
 
 ### Community 235 - "Community 235"
 Cohesion: 0.18
@@ -1746,12 +1727,12 @@ Cohesion: 0.18
 Nodes (9): Actions, AfterMethod, BeforeMethod, ElementActions, MockedConstruction, Object, String, Test (+1 more)
 
 ### Community 244 - "Community 244"
-Cohesion: 0.24
+Cohesion: 0.22
 Nodes (6): McpRuntimePaths, McpRuntimePathsTest, Map, Path, String, Test
 
 ### Community 245 - "Community 245"
-Cohesion: 0.19
-Nodes (12): AnthropicProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode, Map (+4 more)
+Cohesion: 0.17
+Nodes (13): AiImage, AnthropicProvider, AiCapabilities, AiRequest, AiUsage, Function, HttpClient, JsonNode (+5 more)
 
 ### Community 246 - "Community 246"
 Cohesion: 0.10
@@ -1766,16 +1747,16 @@ Cohesion: 0.20
 Nodes (6): PlaywrightSessionManager, Browser, BrowserContext, Page, Playwright, PlaywrightSession
 
 ### Community 249 - "Community 249"
-Cohesion: 0.14
-Nodes (12): apply_ai_changes(), atomic_write(), FileTransaction, OriginalFile, Apply validated full-file replacements through the main transaction., Original state for one transaction-managed file., Track file writes and restore their original bytes on failure., Atomically write bytes after recording the original file state. (+4 more)
+Cohesion: 0.12
+Nodes (14): apply_ai_changes(), atomic_write(), FileTransaction, OriginalFile, Resolve and validate an AI-proposed editable path., Apply validated full-file replacements through the main transaction., Original state for one transaction-managed file., Track file writes and restore their original bytes on failure. (+6 more)
 
 ### Community 250 - "Community 250"
 Cohesion: 0.50
 Nodes (3): Source-file rewrites prepared for session or full upgrades., Return source files whose contents should be replaced., SourceMigration
 
 ### Community 251 - "Community 251"
-Cohesion: 0.23
-Nodes (7): MoonTests, AfterEach, BeforeEach, String, Test, WebDriver, TestInfo
+Cohesion: 0.22
+Nodes (8): ChromeOptions, MoonTests, AfterEach, BeforeEach, String, Test, WebDriver, TestInfo
 
 ### Community 252 - "Community 252"
 Cohesion: 0.18
@@ -1794,40 +1775,40 @@ Cohesion: 0.23
 Nodes (7): DoctorRedactor, RedactorTest, JsonNode, List, ObjectNode, String, Test
 
 ### Community 256 - "Community 256"
-Cohesion: 0.21
+Cohesion: 0.19
 Nodes (6): FailureReporter, Class, String, Throwable, Test, FailureReporterUnitTest
 
 ### Community 257 - "Community 257"
-Cohesion: 0.12
-Nodes (16): AllureVerdict, Operation, PatchManifestEntry, changedSince(), RepairGuard, RepairProposalStore, AllureSnapshot, Diagnosis (+8 more)
+Cohesion: 0.21
+Nodes (5): Timeouts, Boolean, DefaultValue, Key, SetProperty
 
 ### Community 258 - "Community 258"
 Cohesion: 0.20
 Nodes (6): NaturalActions, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 259 - "Community 259"
-Cohesion: 0.16
-Nodes (8): ShaftLocator, JunitCoreAssertionDependencyGuardTest, Override, String, Pattern, Path, Test, Strategy
+Cohesion: 0.24
+Nodes (5): ShaftLocator, Override, String, Pattern, Strategy
 
 ### Community 260 - "Community 260"
 Cohesion: 0.13
-Nodes (12): CucumberHelper, List, Status, String, XmlSuite, AfterMethod, AtomicInteger, Set (+4 more)
+Nodes (13): $, CucumberHelper, List, Status, String, XmlSuite, AfterMethod, AtomicInteger (+5 more)
 
 ### Community 261 - "Community 261"
 Cohesion: 0.23
 Nodes (5): ThreadSafeGuiWizardTests, AfterMethod, BeforeMethod, SuppressWarnings, Test
 
 ### Community 262 - "Community 262"
-Cohesion: 0.10
-Nodes (29): CommandResult, confirm_upgrade(), coordinates_have_supported_runner(), coordinates_have_supported_stack(), default_compile_command(), extract_response_output_text(), is_stable_release(), metadata_release() (+21 more)
+Cohesion: 0.09
+Nodes (25): CommandResult, confirm_upgrade(), default_compile_command(), extract_response_output_text(), is_stable_release(), metadata_release(), parse_compile_command(), Enforce the modular SHAFT dependency contract after every repair. (+17 more)
 
 ### Community 263 - "Community 263"
-Cohesion: 0.15
-Nodes (9): PlaywrightSession, PlaywrightTraceManager, Browser, BrowserContext, Object, Override, Page, Playwright (+1 more)
+Cohesion: 0.10
+Nodes (12): PlaywrightSession, AlertActions, Override, PlaywrightSession, String, Browser, BrowserContext, Object (+4 more)
 
 ### Community 264 - "Community 264"
-Cohesion: 0.17
-Nodes (13): McpMobileInspectorRecordingServiceTest, NoopRunner, McpProcessRunner, Duration, List, Map, McpMobileInspectorRecordingService, Override (+5 more)
+Cohesion: 0.11
+Nodes (5): Boolean, NumbersComparativeRelation, Object, String, JavaHelper
 
 ### Community 265 - "Community 265"
 Cohesion: 0.15
@@ -1846,8 +1827,8 @@ Cohesion: 0.28
 Nodes (7): LocatorRanker, ScoredLocator, ElementSnapshot, EventContext, LocatorCandidate, LocatorSelection, String
 
 ### Community 269 - "Community 269"
-Cohesion: 0.18
-Nodes (11): $, WebDriverAssertions, WebDriverVerifications, WizardHelpers, By, DriverFactoryHelper, NativeValidationsBuilder, Object (+3 more)
+Cohesion: 0.19
+Nodes (10): WebDriverAssertions, WebDriverVerifications, WizardHelpers, By, DriverFactoryHelper, NativeValidationsBuilder, Object, Override (+2 more)
 
 ### Community 270 - "Community 270"
 Cohesion: 0.25
@@ -1886,12 +1867,12 @@ Cohesion: 0.20
 Nodes (3): BeforeClass, Test, TestDataUnitTest
 
 ### Community 280 - "Community 280"
-Cohesion: 0.40
-Nodes (5): TraceServiceTest, Path, String, Test, TraceService
+Cohesion: 0.28
+Nodes (12): CompletableFuture, McpProcessRunner, SystemProcessRunner, Duration, InputStream, List, Map, Override (+4 more)
 
 ### Community 281 - "Community 281"
-Cohesion: 0.18
-Nodes (9): ExecutionLifecycleHelper, List, Method, RunType, Status, StatusIcon, String, TestExecutionInfo (+1 more)
+Cohesion: 0.24
+Nodes (7): ExecutionLifecycleHelper, List, Method, Status, StatusIcon, String, TestExecutionInfo
 
 ### Community 282 - "Community 282"
 Cohesion: 0.24
@@ -1899,7 +1880,7 @@ Nodes (9): main(), text(), validate_maven_jvm_configuration(), validate_quality_
 
 ### Community 283 - "Community 283"
 Cohesion: 0.29
-Nodes (16): copy(), dataBoolean(), dataInt(), dataString(), dataStrings(), fromJson(), generated(), longValue() (+8 more)
+Nodes (15): copy(), dataBoolean(), dataInt(), dataStrings(), fromJson(), generated(), longValue(), map() (+7 more)
 
 ### Community 284 - "Community 284"
 Cohesion: 0.18
@@ -1915,7 +1896,7 @@ Nodes (7): HealingActionsIntegrationTest, AfterMethod, BeforeMethod, DataProvide
 
 ### Community 287 - "Community 287"
 Cohesion: 0.20
-Nodes (7): AnimatedGifManagerCoverageUnitTest, AfterMethod, BeforeMethod, Color, Method, String, Test
+Nodes (4): AfterMethod, BeforeMethod, Test, PropertiesHelperCoverageUnitTest
 
 ### Community 288 - "Community 288"
 Cohesion: 0.16
@@ -1934,16 +1915,16 @@ Cohesion: 0.17
 Nodes (6): ProgressBarLogger, ProgressBarLoggerCoverageUnitTest, Override, String, AfterMethod, Test
 
 ### Community 293 - "Community 293"
-Cohesion: 0.25
-Nodes (7): AtomicInteger, BrowserNetworkInterceptionRule, FilterableRequestSpecification, HttpRequest, HttpResponse, List, Response
+Cohesion: 0.22
+Nodes (9): AtomicInteger, BrowserNetworkInterceptionRule, FilterableRequestSpecification, HttpRequest, HttpResponse, List, Response, Set (+1 more)
 
 ### Community 294 - "Community 294"
 Cohesion: 0.32
 Nodes (8): IssueReporter, Boolean, ITestNGMethod, ITestResult, List, Method, String, TestExecutionInfo
 
 ### Community 295 - "Community 295"
-Cohesion: 0.35
-Nodes (6): McpCaptureCodeBlockServiceTest, List, McpCodeBlock, Path, String, Test
+Cohesion: 0.14
+Nodes (8): ShadowDomTest, JDK21VirtualThreadsAndAsyncActionsTests, AfterMethod, BeforeMethod, Test, AfterMethod, BeforeMethod, Test
 
 ### Community 296 - "Community 296"
 Cohesion: 0.12
@@ -1966,20 +1947,20 @@ Cohesion: 0.17
 Nodes (9): CaptureEventPipeline, ManagedCaptureRecorderControlTest, CaptureSessionStore, CaptureBrowser, CaptureStartOptions, CaptureStartRequest, Object, SuppressWarnings (+1 more)
 
 ### Community 301 - "Community 301"
-Cohesion: 0.19
-Nodes (7): FluentWebDriverAction, Actions, AlertActions, BrowserActions, DriverFactoryHelper, TouchActions, WebDriver
+Cohesion: 0.12
+Nodes (11): FluentWebDriverAction, SelectedValueTests, Actions, AlertActions, BrowserActions, DriverFactoryHelper, TouchActions, WebDriver (+3 more)
 
 ### Community 302 - "Community 302"
 Cohesion: 0.21
 Nodes (9): fixture_commands(), main(), maven_executable(), missing_publication_paths(), publication_paths(), verify_release(), write_settings(), Path (+1 more)
 
 ### Community 303 - "Community 303"
-Cohesion: 0.18
-Nodes (9): InterceptorFactory, BrowserNetworkInterceptor, InterceptorFactory, BrowserNetworkInterceptionRule, HttpRequest, HttpResponse, Override, Response (+1 more)
+Cohesion: 0.17
+Nodes (10): InterceptorFactory, BrowserNetworkInterceptor, InterceptorFactory, BrowserNetworkInterceptionRule, Filter, HttpRequest, HttpResponse, Override (+2 more)
 
 ### Community 305 - "Community 305"
-Cohesion: 0.20
-Nodes (7): AfterMethod, InputStream, Override, String, Test, DesktopVideoRecordingProviderRegistryTest, StubDesktopVideoRecordingProvider
+Cohesion: 0.18
+Nodes (8): DesktopVideoRecordingProvider, AfterMethod, InputStream, Override, String, Test, DesktopVideoRecordingProviderRegistryTest, StubDesktopVideoRecordingProvider
 
 ### Community 306 - "Community 306"
 Cohesion: 0.22
@@ -1990,8 +1971,8 @@ Cohesion: 0.24
 Nodes (8): GuardedPatch, RepairGuard, FilePatch, List, Path, Set, String, ValidationCommand
 
 ### Community 308 - "Community 308"
-Cohesion: 0.15
-Nodes (9): FileActionsCoverageUnitTest, FileActionsReflectionInvoker, AfterMethod, BeforeMethod, Path, String, Test, FileActions (+1 more)
+Cohesion: 0.33
+Nodes (3): FileActionsReflectionInvoker, FileActions, String
 
 ### Community 309 - "Community 309"
 Cohesion: 0.23
@@ -2002,24 +1983,24 @@ Cohesion: 0.15
 Nodes (10): AllureCucumber7Jvm, CucumberTestRunnerListener, EventPublisher, Feature, Optional, Override, TestCaseFinished, TestSourceParsed (+2 more)
 
 ### Community 312 - "Community 312"
-Cohesion: 0.26
-Nodes (6): DoctorServiceTest, DoctorService, McpAnalysisReport, Path, String, Test
+Cohesion: 0.25
+Nodes (5): RestValidationsBuilder, JSONValidationsBuilder, NativeValidationsBuilder, String, ValidationsExecutor
 
 ### Community 313 - "Community 313"
 Cohesion: 0.27
 Nodes (7): CaptureControlClient, CaptureStatus, CheckpointKind, List, Object, Path, String
 
 ### Community 314 - "Community 314"
-Cohesion: 0.18
-Nodes (9): DesktopVideoRecordingProvider, DesktopVideoConsumer, IVideoRecorder, File, InputStream, Override, String, SuppressWarnings (+1 more)
+Cohesion: 0.20
+Nodes (8): DesktopVideoConsumer, IVideoRecorder, File, InputStream, Override, String, SuppressWarnings, AutomationRemarksDesktopVideoRecordingProvider
 
 ### Community 315 - "Community 315"
 Cohesion: 0.16
 Nodes (9): HealingProvider, HealingActionOutcome, HealingExplanation, HealingObservation, HealingRequest, HealingResolution, Optional, String (+1 more)
 
 ### Community 316 - "Community 316"
-Cohesion: 0.20
-Nodes (7): BrowserStackHelper, JunitListenerHelper, Boolean, DriverFactoryHelper, MutableCapabilities, String, TestIdentifier
+Cohesion: 0.27
+Nodes (5): BrowserStackHelper, Boolean, DriverFactoryHelper, MutableCapabilities, String
 
 ### Community 317 - "Community 317"
 Cohesion: 0.33
@@ -2038,8 +2019,8 @@ Cohesion: 0.31
 Nodes (7): BrowserAssertions, NativeValidationsBuilder, Override, PlaywrightSession, String, ValidationCategory, PlaywrightBrowserValidationsBuilder
 
 ### Community 321 - "Community 321"
-Cohesion: 0.15
-Nodes (12): LocatorSignal, matches(), CapturePrivacyPolicy, CaptureSessionStore, Consumer, Instant, JsonNode, List (+4 more)
+Cohesion: 0.14
+Nodes (13): LocatorSignal, matches(), CaptureEvent, CapturePrivacyPolicy, CaptureSessionStore, Consumer, ExternalTestDataReference, Instant (+5 more)
 
 ### Community 322 - "Community 322"
 Cohesion: 0.27
@@ -2050,8 +2031,8 @@ Cohesion: 0.13
 Nodes (15): type, uniqueItems, enum, additionalProperties, properties, required, type, enum (+7 more)
 
 ### Community 324 - "Community 324"
-Cohesion: 0.13
-Nodes (15): type, uniqueItems, enum, facets, additionalProperties, properties, required, type (+7 more)
+Cohesion: 0.17
+Nodes (12): enum, facets, additionalProperties, properties, required, type, enum, items (+4 more)
 
 ### Community 325 - "Community 325"
 Cohesion: 0.13
@@ -2066,8 +2047,8 @@ Cohesion: 0.21
 Nodes (7): AfterMethod, BeforeClass, BeforeMethod, Override, String, Test, TestClass
 
 ### Community 329 - "Community 329"
-Cohesion: 0.16
-Nodes (6): AndroidBasicInteractionsTests, MultipleElementsFailureTest, Test, AfterMethod, BeforeMethod, Test
+Cohesion: 0.08
+Nodes (13): AndroidBasicInteractionsTests, AndroidTouchActionsTests, MultipleElementsFailureTest, NoSuchElementFailureTest, ScreenOrientation, Test, Test, AfterMethod (+5 more)
 
 ### Community 330 - "Community 330"
 Cohesion: 0.18
@@ -2082,8 +2063,8 @@ Cohesion: 0.19
 Nodes (14): A(), Ae(), b(), ce(), ge(), le(), pe(), qe() (+6 more)
 
 ### Community 333 - "Community 333"
-Cohesion: 0.24
-Nodes (5): List, Set, String, Test, TelemetryDeduplicationUnitTest
+Cohesion: 0.05
+Nodes (37): empty(), DoctorHashing, reviewUiPath(), McpMobileToolchainServiceTest, disabled(), McpResultRecordsTest, MobileRecordingServiceTest, Metadata (+29 more)
 
 ### Community 334 - "Community 334"
 Cohesion: 0.14
@@ -2098,12 +2079,12 @@ Cohesion: 0.26
 Nodes (6): Pattern, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 337 - "Community 337"
-Cohesion: 0.21
-Nodes (4): AfterMethod, String, Test, PropertyFileManagerUnitTest
+Cohesion: 0.22
+Nodes (18): append(), checkpoint(), complete(), ensureIncomplete(), interrupt(), sortedCheckpoints(), sortedEvents(), sortedReferences() (+10 more)
 
 ### Community 338 - "Community 338"
-Cohesion: 0.53
-Nodes (5): allows(), ApprovalPolicy(), EvidenceCategory, ProcessingLocation, Set
+Cohesion: 0.22
+Nodes (4): ActiveRetryAttempt, ExtensionContext, Override, Throwable
 
 ### Community 339 - "Community 339"
 Cohesion: 0.26
@@ -2111,11 +2092,11 @@ Nodes (6): ModelSupport, JsonNode, List, Map, String, T
 
 ### Community 340 - "Community 340"
 Cohesion: 0.08
-Nodes (20): OpenApiCoverageReporter, OperationCoverage, SpecCoverage, OpenApiCoverageReporterUnitTest, OpenAPI, OpenApiValidationException, OpenApiValidationFilter, OperationCoverage (+12 more)
+Nodes (18): OpenApiCoverageReporter, OperationCoverage, SpecCoverage, OpenAPI, OpenApiValidationFilter, OperationCoverage, AssertionError, HttpMethod (+10 more)
 
 ### Community 341 - "Community 341"
-Cohesion: 0.14
-Nodes (14): items, tags, items, additionalProperties, minLength, pattern, properties, required (+6 more)
+Cohesion: 0.12
+Nodes (17): items, type, uniqueItems, tags, items, additionalProperties, minLength, pattern (+9 more)
 
 ### Community 342 - "Community 342"
 Cohesion: 0.19
@@ -2134,8 +2115,8 @@ Cohesion: 0.23
 Nodes (12): ActionMetadata, disabled(), HealingReport(), minimized(), pending(), ProviderMetadata(), PrivacyMetadata, HealingCandidate (+4 more)
 
 ### Community 346 - "Community 346"
-Cohesion: 0.24
-Nodes (6): ElementActionsHelper, ScreenshotManagerCoverageUnitTest, AfterMethod, BeforeMethod, Color, Test
+Cohesion: 0.19
+Nodes (5): RunType, RunType, AfterMethod, Test, DriverFactoryCoverageUnitTest
 
 ### Community 347 - "Community 347"
 Cohesion: 0.18
@@ -2162,12 +2143,12 @@ Cohesion: 0.18
 Nodes (6): AfterMethod, DataProvider, Object, String, Test, DriverFactoryHelperUnitTest
 
 ### Community 353 - "Community 353"
-Cohesion: 0.24
-Nodes (5): EXCEL, ExcelFileManager, TestDataTests, String, Test
+Cohesion: 0.15
+Nodes (8): EXCEL, ExcelFileManager, TestDataTests, String, Test, BeforeClass, Test, IoExcelFileManagerTests
 
 ### Community 354 - "Community 354"
-Cohesion: 0.08
-Nodes (10): Locator, LocatorMockedTests, Beta, By, LocatorBuilder, String, Test, Test (+2 more)
+Cohesion: 0.10
+Nodes (6): LocatorMockedTests, ShadowLocatorBuilder, Test, Test, LocatorBuilderUnitTest, XpathAxis
 
 ### Community 356 - "Community 356"
 Cohesion: 0.22
@@ -2202,8 +2183,8 @@ Cohesion: 0.29
 Nodes (5): HttpExchange, HttpServer, Override, String, LocalApiServer
 
 ### Community 364 - "Community 364"
-Cohesion: 0.08
-Nodes (12): BasicAuthenticationTests, NetworkInterceptionTest, TableTests, SmartLocatorsTests, Test, Test, String, Test (+4 more)
+Cohesion: 0.11
+Nodes (8): NetworkInterceptionTest, TableTests, SmartLocatorsTests, Test, String, AfterMethod, BeforeMethod, Tests
 
 ### Community 365 - "Community 365"
 Cohesion: 0.29
@@ -2218,12 +2199,12 @@ Cohesion: 0.29
 Nodes (7): Description, AfterMethod, BeforeClass, BeforeMethod, Step, Test, FluentGuiActionsTest
 
 ### Community 368 - "Community 368"
-Cohesion: 0.31
+Cohesion: 0.32
 Nodes (6): CaptureGeneratedReplayBrowserTest, CaptureSession, ElementSnapshot, ExternalTestDataReference, String, Test
 
 ### Community 369 - "Community 369"
-Cohesion: 0.32
-Nodes (4): CSVFileManager, List, Map, String
+Cohesion: 0.17
+Nodes (11): AiProviderRegistryTest, availability(), capabilities(), execute(), AfterEach, AiCapabilities, AiProviderAvailability, AiRequest (+3 more)
 
 ### Community 370 - "Community 370"
 Cohesion: 0.28
@@ -2234,11 +2215,11 @@ Cohesion: 0.23
 Nodes (8): VisualProcessingProvider, Boolean, By, Integer, List, String, VisualValidationEngine, WebDriver
 
 ### Community 372 - "Community 372"
-Cohesion: 0.19
-Nodes (9): CaptureFixtures, PageContext, BrowserMetadata, CaptureEvent, CaptureSession, ElementSnapshot, EventContext, ExternalTestDataReference (+1 more)
+Cohesion: 0.11
+Nodes (16): CaptureFixtures, CaptureReadinessTest, PageContext, BrowserMetadata, CaptureEvent, CaptureSession, ElementSnapshot, EventContext (+8 more)
 
 ### Community 373 - "Community 373"
-Cohesion: 0.13
+Cohesion: 0.16
 Nodes (3): RestActionsCoverageUnitTest, AfterMethod, Test
 
 ### Community 374 - "Community 374"
@@ -2246,8 +2227,8 @@ Cohesion: 0.10
 Nodes (14): ExhaustedLauncherRetryFixture, JunitExtensionLifecycleTest, LauncherRetryFixture, OuterSessionStateRetryFixture, Order, AfterEach, BeforeAll, BeforeEach (+6 more)
 
 ### Community 375 - "Community 375"
-Cohesion: 0.20
-Nodes (9): AccessibilityActions, BrowserNetworkInterceptionRule, DriverFactoryHelper, HttpRequest, HttpResponse, Predicate, Step, URI (+1 more)
+Cohesion: 0.22
+Nodes (8): AccessibilityActions, BrowserNetworkInterceptionRule, DriverFactoryHelper, HttpRequest, HttpResponse, Predicate, Step, WebDriver
 
 ### Community 376 - "Community 376"
 Cohesion: 0.17
@@ -2266,12 +2247,12 @@ Cohesion: 0.24
 Nodes (6): MobileTraceMetadata, Capabilities, JavascriptExecutor, Map, String, WebDriver
 
 ### Community 380 - "Community 380"
-Cohesion: 0.25
-Nodes (13): apply(), applyEnabled(), current(), NaturalActionService, textOrDefault(), withOverrides(), McpNaturalActionResult, NaturalActionSettings (+5 more)
+Cohesion: 0.15
+Nodes (17): LogRedirector, Logger, apply(), applyEnabled(), current(), NaturalActionService, textOrDefault(), withOverrides() (+9 more)
 
 ### Community 381 - "Community 381"
-Cohesion: 0.20
-Nodes (3): CSVFileManagerTest, BeforeMethod, Test
+Cohesion: 0.28
+Nodes (6): BasicAPITests, AfterClass, BeforeClass, List, Map, String
 
 ### Community 382 - "Community 382"
 Cohesion: 0.21
@@ -2282,8 +2263,8 @@ Cohesion: 0.29
 Nodes (5): DoctorModelSupport, List, Map, String, T
 
 ### Community 384 - "Community 384"
-Cohesion: 0.29
-Nodes (7): minLength, pattern, type, properties, enum, id, kind
+Cohesion: 0.17
+Nodes (12): items, type, minLength, pattern, type, additionalProperties, properties, required (+4 more)
 
 ### Community 385 - "Community 385"
 Cohesion: 0.17
@@ -2294,12 +2275,12 @@ Cohesion: 0.17
 Nodes (12): type, scope, pattern, type, branch, project, task, additionalProperties (+4 more)
 
 ### Community 387 - "Community 387"
-Cohesion: 0.18
-Nodes (7): OpenCvVisualConsumer, HealingVisualProvider, OpenCvHealingVisualProvider, Override, String, Mat, String
+Cohesion: 0.19
+Nodes (7): HealingVisualProvider, OpenCvHealingVisualProvider, OpenCvHealingVisualProviderTest, Override, String, Color, Test
 
 ### Community 388 - "Community 388"
 Cohesion: 0.17
-Nodes (12): type, items, properties, required, type, content, redacted, relativePath (+4 more)
+Nodes (12): type, properties, minLength, type, content, mediaType, redacted, relativePath (+4 more)
 
 ### Community 389 - "Community 389"
 Cohesion: 0.26
@@ -2314,11 +2295,11 @@ Cohesion: 0.26
 Nodes (4): LocatorHealthReporterUnitTest, AfterMethod, BeforeMethod, Test
 
 ### Community 392 - "Community 392"
-Cohesion: 0.35
+Cohesion: 0.36
 Nodes (4): HttpExchange, Path, String, TestPageServer
 
 ### Community 394 - "Community 394"
-Cohesion: 0.32
+Cohesion: 0.30
 Nodes (7): LocatorRankerTest, ElementSnapshot, List, LocatorCandidate, LocatorStrategy, String, Test
 
 ### Community 395 - "Community 395"
@@ -2334,7 +2315,7 @@ Cohesion: 0.27
 Nodes (5): AiProviderRegistry, AiProvider, List, PilotConfiguration, String
 
 ### Community 398 - "Community 398"
-Cohesion: 0.21
+Cohesion: 0.19
 Nodes (8): AutoCloseable, SessionPermit, FileChannel, FileLock, CaptureSingleSessionLock, Override, Path, Override
 
 ### Community 399 - "Community 399"
@@ -2350,7 +2331,7 @@ Cohesion: 0.25
 Nodes (6): McpServiceHelperTest, AfterEach, Class, Object, String, Test
 
 ### Community 402 - "Community 402"
-Cohesion: 0.25
+Cohesion: 0.24
 Nodes (3): ActionsExceptionDetailsUnitTest, NoSuchElementException, Test
 
 ### Community 403 - "Community 403"
@@ -2358,8 +2339,8 @@ Cohesion: 0.38
 Nodes (10): aiTrigger(), bounded(), current(), HealingConfiguration(), split(), Duration, List, Path (+2 more)
 
 ### Community 404 - "Community 404"
-Cohesion: 0.35
-Nodes (3): BrowserEventScript, List, String
+Cohesion: 0.29
+Nodes (5): CaptureTargetInsertionPlan, CaptureTargetInsertionPlanner, List, Path, String
 
 ### Community 405 - "Community 405"
 Cohesion: 0.29
@@ -2382,12 +2363,12 @@ Cohesion: 0.29
 Nodes (4): GroupsTests, AfterMethod, BeforeMethod, Test
 
 ### Community 410 - "Community 410"
-Cohesion: 0.16
-Nodes (11): ActionCandidate, McpCaptureCodeBlockService, PomCandidates, CaptureGenerationReport, List, LocatorCandidate, LocatorDecision, McpCodeBlock (+3 more)
+Cohesion: 0.14
+Nodes (13): ActionCandidate, safe(), McpCaptureCodeBlockService, PomCandidates, CaptureGenerationReport, List, LocatorCandidate, LocatorDecision (+5 more)
 
 ### Community 411 - "Community 411"
-Cohesion: 0.12
-Nodes (8): AndroidDragAndDropTest, AndroidTouchActionsTests, MobileTest, ScreenOrientation, Test, Test, AfterMethod, BeforeMethod
+Cohesion: 0.25
+Nodes (5): AndroidDragAndDropTest, MobileTest, Test, AfterMethod, BeforeMethod
 
 ### Community 412 - "Community 412"
 Cohesion: 0.23
@@ -2422,8 +2403,8 @@ Cohesion: 0.33
 Nodes (8): failure(), success(), AiResponse, AiResponseStatus, AiUsage, Duration, JsonNode, String
 
 ### Community 421 - "Community 421"
-Cohesion: 0.20
-Nodes (11): DriverAssertions, BrowserAssertions, By, ElementAssertions, Locator, NativeValidationsBuilder, Object, Override (+3 more)
+Cohesion: 0.15
+Nodes (13): By, Locator, Page, BrowserAssertions, By, ElementAssertions, Locator, NativeValidationsBuilder (+5 more)
 
 ### Community 422 - "Community 422"
 Cohesion: 0.20
@@ -2438,12 +2419,12 @@ Cohesion: 0.33
 Nodes (4): HoverTests, AfterMethod, BeforeMethod, Test
 
 ### Community 425 - "Community 425"
-Cohesion: 0.06
-Nodes (38): AiProviderRegistryTest, availability(), capabilities(), execute(), CompletableFuture, Controller, Headers, Controller (+30 more)
+Cohesion: 0.13
+Nodes (15): Controller, Headers, Controller, McpAppiumInspectorProxy, McpAppiumCommandRecorder, Builder, HttpExchange, HttpResponse (+7 more)
 
 ### Community 426 - "Community 426"
-Cohesion: 0.23
-Nodes (11): AlphaProvider, ZuluProvider, Boolean, By, Integer, List, Override, String (+3 more)
+Cohesion: 0.13
+Nodes (14): AlphaProvider, VisualProcessingProviderRegistryTest, ZuluProvider, AfterMethod, Boolean, By, Integer, List (+6 more)
 
 ### Community 427 - "Community 427"
 Cohesion: 0.26
@@ -2462,16 +2443,16 @@ Cohesion: 0.31
 Nodes (4): BigPageActionsTest, AfterMethod, BeforeMethod, Test
 
 ### Community 432 - "Community 432"
-Cohesion: 0.29
-Nodes (3): Class, Test, GUIInterfaceCompatibilityCoverageUnitTest
+Cohesion: 0.27
+Nodes (4): DriverAssertions, Class, Test, GUIInterfaceCompatibilityCoverageUnitTest
 
 ### Community 434 - "Community 434"
 Cohesion: 0.21
 Nodes (6): AfterMethod, Class, Object, String, Test, BrowserStackHelperUnitTest
 
 ### Community 435 - "Community 435"
-Cohesion: 0.27
-Nodes (4): ArrayNode, InputStream, List, ObjectNode
+Cohesion: 0.39
+Nodes (5): HealerServiceTest, HealerService, Path, String, Test
 
 ### Community 436 - "Community 436"
 Cohesion: 0.18
@@ -2510,8 +2491,8 @@ Cohesion: 0.23
 Nodes (6): AfterMethod, DataProvider, Object, String, Test, PropertiesHelperEvidenceLevelUnitTest
 
 ### Community 445 - "Community 445"
-Cohesion: 0.10
-Nodes (14): Callable, FilesSize, from(), DeterministicNaturalActionPlannerTest, Path, Test, DoctorAnalysisResult, DoctorAnalysisSummary (+6 more)
+Cohesion: 0.36
+Nodes (4): DeterministicNaturalActionPlannerTest, NaturalActionRequest, String, Test
 
 ### Community 446 - "Community 446"
 Cohesion: 0.31
@@ -2530,20 +2511,24 @@ Cohesion: 0.33
 Nodes (5): steps, Given, String, Then, When
 
 ### Community 451 - "Community 451"
-Cohesion: 0.17
-Nodes (4): AlertActions, Override, PlaywrightSession, String
+Cohesion: 0.21
+Nodes (8): ByAll, CompositeLocator, NaturalActionCompositeLocator, By, List, By, List, Override
 
 ### Community 452 - "Community 452"
 Cohesion: 0.40
 Nodes (3): UploadFileTests, String, Test
+
+### Community 453 - "Community 453"
+Cohesion: 0.26
+Nodes (4): OptionsManagerCoverageUnitTest, AfterMethod, BeforeMethod, Test
 
 ### Community 454 - "Community 454"
 Cohesion: 0.31
 Nodes (4): AfterMethod, BeforeMethod, Test, VisualValidationTests
 
 ### Community 455 - "Community 455"
-Cohesion: 0.20
-Nodes (6): PlaywrightActionsE2ETestBase, AfterMethod, BeforeMethod, Playwright, String, Test
+Cohesion: 0.07
+Nodes (18): ChromePlaywrightActionsE2ETest, EdgePlaywrightActionsE2ETest, FirefoxPlaywrightActionsE2ETest, PlaywrightActionsE2ETestBase, WebKitPlaywrightActionsE2ETest, Override, String, Override (+10 more)
 
 ### Community 456 - "Community 456"
 Cohesion: 0.27
@@ -2574,8 +2559,8 @@ Cohesion: 0.36
 Nodes (4): ChecksumTests, Path, String, Test
 
 ### Community 463 - "Community 463"
-Cohesion: 0.14
-Nodes (11): ready(), unavailable(), DisabledAiProvider, AiProviderAvailability, String, AiCapabilities, AiProviderAvailability, AiRequest (+3 more)
+Cohesion: 0.21
+Nodes (7): DisabledAiProvider, AiCapabilities, AiProviderAvailability, AiRequest, AiResponse, Override, String
 
 ### Community 464 - "Community 464"
 Cohesion: 0.21
@@ -2598,11 +2583,11 @@ Cohesion: 0.31
 Nodes (5): ElementMatchesSafariCompatibleTests, AfterMethod, BeforeMethod, SuppressWarnings, Test
 
 ### Community 470 - "Community 470"
-Cohesion: 0.17
+Cohesion: 0.18
 Nodes (6): Performance, SetProperty, DefaultValue, Key, SetProperty, String
 
 ### Community 471 - "Community 471"
-Cohesion: 0.26
+Cohesion: 0.31
 Nodes (4): JunitDatabaseSmokeTest, AfterAll, BeforeAll, Test
 
 ### Community 472 - "Community 472"
@@ -2622,7 +2607,7 @@ Cohesion: 0.29
 Nodes (6): Deletion Checklist, Generated PR Workflows, GitHub Actions Workflows, Relationship Map, Shared Composite Actions, Workflow Inventory
 
 ### Community 476 - "Community 476"
-Cohesion: 0.29
+Cohesion: 0.21
 Nodes (7): HttpContractBrowserReplayTest, AfterMethod, HttpMethod, HttpRequest, HttpResponse, String, Test
 
 ### Community 477 - "Community 477"
@@ -2650,8 +2635,8 @@ Cohesion: 0.24
 Nodes (6): Class, Object, String, SuppressWarnings, Test, SmartLocatorsCoverageUnitTest
 
 ### Community 483 - "Community 483"
-Cohesion: 0.21
-Nodes (5): DatabaseActions, DbTests, BeforeClass, Test, DBWizardTests
+Cohesion: 0.31
+Nodes (3): DbTests, BeforeClass, Test
 
 ### Community 484 - "Community 484"
 Cohesion: 0.36
@@ -2689,10 +2674,6 @@ Nodes (4): GetTableRowsDataTests, AfterMethod, BeforeMethod, Test
 Cohesion: 0.36
 Nodes (4): IsElementClickableTest, AfterMethod, BeforeMethod, Test
 
-### Community 493 - "Community 493"
-Cohesion: 0.24
-Nodes (6): StubProvider, AiCapabilities, AiProviderAvailability, Override, ProcessingLocation, String
-
 ### Community 494 - "Community 494"
 Cohesion: 0.38
 Nodes (4): Executable, McpNoDriverServiceTest, BeforeEach, Test
@@ -2714,8 +2695,8 @@ Cohesion: 0.36
 Nodes (4): ShadowDOMTests, AfterMethod, BeforeMethod, Test
 
 ### Community 499 - "Community 499"
-Cohesion: 0.15
-Nodes (13): items, items, type, additionalProperties, minLength, pattern, required, type (+5 more)
+Cohesion: 0.25
+Nodes (8): items, minLength, pattern, type, tags, items, type, uniqueItems
 
 ### Community 500 - "Community 500"
 Cohesion: 0.13
@@ -2726,8 +2707,8 @@ Cohesion: 0.29
 Nodes (4): PlaywrightNaturalActionExecutorTest, AfterMethod, BeforeMethod, Test
 
 ### Community 502 - "Community 502"
-Cohesion: 0.17
-Nodes (13): FakeRunner, McpMobileToolchainServiceTest, Duration, List, Map, McpMobileToolchainDiagnostic, McpMobileToolchainStatus, Override (+5 more)
+Cohesion: 0.26
+Nodes (4): AfterMethod, BeforeMethod, Test, BrowserActionsHelperCoverageUnitTest
 
 ### Community 504 - "Community 504"
 Cohesion: 0.36
@@ -2758,16 +2739,16 @@ Cohesion: 0.36
 Nodes (4): AfterMethod, BeforeMethod, Test, CustomDriverInitializationTests
 
 ### Community 511 - "Community 511"
-Cohesion: 0.31
-Nodes (3): VisualProcessingProviderRegistryTest, AfterMethod, Test
+Cohesion: 0.27
+Nodes (3): AfterMethod, Test, LambdaTestHelperUnitTest
 
 ### Community 512 - "Community 512"
-Cohesion: 0.14
-Nodes (10): LocalApiTestServer, LogRedirector, Logger, InputStream, OutputStream, Level, Override, HttpExchange (+2 more)
+Cohesion: 0.31
+Nodes (4): LocalApiTestServer, HttpExchange, HttpServer, String
 
 ### Community 513 - "Community 513"
-Cohesion: 0.05
-Nodes (30): ArrayList, CapturePrivacyClassifier, SHAFT, SynchronizationManager, FileInputStream, AppiumMobileConsumer, BrowserStackSdkConsumer, LegacyCoordinateConsumer (+22 more)
+Cohesion: 0.06
+Nodes (21): testPostRequest, ArrayList, SHAFT, FileInputStream, AppiumMobileConsumer, BrowserStackSdkConsumer, LegacyCoordinateConsumer, StatusIcon() (+13 more)
 
 ### Community 514 - "Community 514"
 Cohesion: 0.43
@@ -2818,15 +2799,15 @@ Cohesion: 0.39
 Nodes (3): BrowserAssertions, NativeValidationsBuilder, String
 
 ### Community 527 - "Community 527"
-Cohesion: 0.31
-Nodes (4): SelectedValueTests, AfterMethod, BeforeMethod, Test
+Cohesion: 0.30
+Nodes (4): OpenApiCoverageReporterUnitTest, OpenApiValidationException, String, Test
 
 ### Community 528 - "Community 528"
 Cohesion: 0.25
 Nodes (5): CaptureServiceTest, CaptureService, CaptureSession, Path, Test
 
 ### Community 529 - "Community 529"
-Cohesion: 0.22
+Cohesion: 0.20
 Nodes (6): RetryAnalyzer, SupportingEvidenceState, IRetryAnalyzer, ITestResult, Override, String
 
 ### Community 530 - "Community 530"
@@ -2846,8 +2827,8 @@ Cohesion: 0.31
 Nodes (5): EngineProperties, SetProperty, Object, SetProperty, String
 
 ### Community 535 - "Community 535"
-Cohesion: 0.18
-Nodes (9): Autowired, ShaftMcpApplicationTests, EngineService, McpMobileInspectorRecordingService, McpMobileRecordingService, McpWorkspacePolicy, Set, String (+1 more)
+Cohesion: 0.31
+Nodes (5): ShaftMcpApplicationTests, Set, String, Test, ToolCallback
 
 ### Community 536 - "Community 536"
 Cohesion: 0.24
@@ -2874,8 +2855,8 @@ Cohesion: 0.26
 Nodes (5): SmartLocatorsRealisticTests, Test, AfterClass, BeforeClass, TestScenario
 
 ### Community 543 - "Community 543"
-Cohesion: 0.33
-Nodes (3): BeforeClass, Test, IoExcelFileManagerTests
+Cohesion: 0.22
+Nodes (7): DriverAssertions, BrowserAssertions, By, ElementAssertions, NativeValidationsBuilder, Object, ShaftLocator
 
 ### Community 544 - "Community 544"
 Cohesion: 0.47
@@ -2898,16 +2879,16 @@ Cohesion: 0.47
 Nodes (3): PlatformTests, BeforeClass, Test
 
 ### Community 549 - "Community 549"
-Cohesion: 0.17
-Nodes (12): minLength, type, type, properties, bundleId, evidence, redaction, schemaVersion (+4 more)
+Cohesion: 0.13
+Nodes (14): items, type, $id, required, type, properties, evidence, redaction (+6 more)
 
 ### Community 550 - "Community 550"
 Cohesion: 0.47
 Nodes (3): WebTests, BeforeClass, Test
 
 ### Community 551 - "Community 551"
-Cohesion: 0.33
-Nodes (4): HealingProviderRegistry, HealingProvider, List, Optional
+Cohesion: 0.22
+Nodes (7): DriverVerifications, BrowserAssertions, By, ElementAssertions, NativeValidationsBuilder, Object, ShaftLocator
 
 ### Community 552 - "Community 552"
 Cohesion: 0.40
@@ -2934,12 +2915,12 @@ Cohesion: 0.23
 Nodes (6): InputStream, Override, Path, Test, CloseTrackingInputStream, ReportManagerHelperAttachmentIoUnitTest
 
 ### Community 561 - "Community 561"
-Cohesion: 0.15
-Nodes (13): MultipleElementsFoundException, VisualEvidenceService, String, Throwable, Double, HealingConfiguration, HealingVisualProvider, List (+5 more)
+Cohesion: 0.23
+Nodes (9): VisualEvidenceService, Double, HealingConfiguration, HealingVisualProvider, List, Optional, RankedCandidate, String (+1 more)
 
 ### Community 562 - "Community 562"
-Cohesion: 0.11
-Nodes (15): MobileServiceConfigurationTest, PlaywrightServiceTest, DoctorReportWriter, Diagnosis, DoctorAdvisory, EvidenceBundle, List, Path (+7 more)
+Cohesion: 0.09
+Nodes (26): CaptureGenerationReport(), notRequested(), skipped(), McpCaptureCodeBlockServiceTest, PlaywrightServiceTest, DoctorReportWriter, Enrichment, List (+18 more)
 
 ### Community 563 - "Community 563"
 Cohesion: 0.43
@@ -2978,8 +2959,8 @@ Cohesion: 0.40
 Nodes (4): Allowed Work, Constraints, Refresh Agent Guidance, Validation
 
 ### Community 572 - "Community 572"
-Cohesion: 0.10
-Nodes (15): IOSBasicInteractionsTest, ElementActions, Test_LTMobIPAAppURL, Test_LTMobIPARelativePath, AfterMethod, BeforeMethod, SuppressWarnings, Test (+7 more)
+Cohesion: 0.08
+Nodes (19): IOSBasicInteractionsTest, ElementActions, Test_LTMobIPAAppURL, Test_LTMobIPARelativePath, RelativeLocatorsTests, AfterMethod, BeforeMethod, SuppressWarnings (+11 more)
 
 ### Community 573 - "Community 573"
 Cohesion: 0.39
@@ -2998,8 +2979,8 @@ Cohesion: 0.23
 Nodes (5): AfterMethod, BeforeMethod, Path, Test, ExcelFileManagerCoverageUnitTest
 
 ### Community 579 - "Community 579"
-Cohesion: 0.29
-Nodes (4): AfterMethod, String, Test, PropertiesHelperInitializationUnitTest
+Cohesion: 0.31
+Nodes (4): VerifyEqualsTests, AfterMethod, BeforeMethod, Test
 
 ### Community 580 - "Community 580"
 Cohesion: 0.50
@@ -3018,8 +2999,8 @@ Cohesion: 0.27
 Nodes (9): agent_upgrade_plan(), ProjectAnalysis, Return whether source rewrites are eligible for this project., Validate the requested upgrade type against the detected project shape., Return a machine-readable upgrade menu for AI agents., Detected Maven project shape and requested SHAFT migration., Return optional modules supported by scan evidence., source_upgrade_supported() (+1 more)
 
 ### Community 587 - "Community 587"
-Cohesion: 0.22
-Nodes (6): BrowserStackModuleTest, Constructor, InvocationTargetException, JsonSchemaValidatorTest, Test, Test
+Cohesion: 0.38
+Nodes (5): Locator, Beta, By, LocatorBuilder, String
 
 ### Community 588 - "Community 588"
 Cohesion: 0.23
@@ -3058,7 +3039,7 @@ Cohesion: 0.67
 Nodes (3): minLength, type, id
 
 ### Community 615 - "Community 615"
-Cohesion: 0.31
+Cohesion: 0.29
 Nodes (5): AfterEach, BeforeAll, BeforeEach, Test, TestClass
 
 ### Community 616 - "Community 616"
@@ -3074,12 +3055,12 @@ Cohesion: 0.47
 Nodes (3): VisualsTests, BeforeClass, Test
 
 ### Community 626 - "Community 626"
-Cohesion: 0.25
+Cohesion: 0.31
 Nodes (6): HttpContractRecorderTest, AfterMethod, FilterableRequestSpecification, Response, String, Test
 
 ### Community 628 - "Community 628"
-Cohesion: 0.25
-Nodes (6): WebDomHealingAcceptanceTest, AfterMethod, BeforeMethod, Path, String, Test
+Cohesion: 0.33
+Nodes (5): SynchronizationManager, Class, Exception, List, WebDriver
 
 ### Community 650 - "Community 650"
 Cohesion: 0.47
@@ -3090,12 +3071,12 @@ Cohesion: 0.43
 Nodes (3): AfterMethod, Test, PropertiesHelperMaximumPerformanceModeUnitTest
 
 ### Community 653 - "Community 653"
-Cohesion: 0.28
+Cohesion: 0.27
 Nodes (5): JSONValidationsBuilder, NativeValidationsBuilder, Object, RestValidationsBuilder, ValidationsExecutor
 
 ### Community 654 - "Community 654"
-Cohesion: 0.22
-Nodes (7): ElementStepsCoverageUnitTest, BeforeMethod, By, DataProvider, Object, String, Test
+Cohesion: 0.18
+Nodes (8): ElementStepsCoverageUnitTest, ClipboardAction, BeforeMethod, By, DataProvider, Object, String, Test
 
 ### Community 655 - "Community 655"
 Cohesion: 0.32
@@ -3114,7 +3095,7 @@ Cohesion: 0.31
 Nodes (6): RepairProcessRunner, Duration, List, Path, ProcessResult, String
 
 ### Community 659 - "Community 659"
-Cohesion: 0.36
+Cohesion: 0.43
 Nodes (4): SkipDueToIssueTests, Issue, Issues, Test
 
 ### Community 660 - "Community 660"
@@ -3130,8 +3111,8 @@ Cohesion: 0.36
 Nodes (3): Contract, Interaction, Path
 
 ### Community 663 - "Community 663"
-Cohesion: 0.33
-Nodes (3): DB, DatabaseType, ResultSet
+Cohesion: 0.25
+Nodes (4): DatabaseActions, DB, DatabaseType, ResultSet
 
 ### Community 664 - "Community 664"
 Cohesion: 0.42
@@ -3142,12 +3123,12 @@ Cohesion: 0.42
 Nodes (5): ClassifiedValue, Collection, Path, String, ExternalTestDataWriter
 
 ### Community 666 - "Community 666"
-Cohesion: 0.43
-Nodes (5): ClassLoader, OpenCvBlockingClassLoader, Class, Override, String
+Cohesion: 0.33
+Nodes (4): EngineServiceRuntimePathTest, AfterEach, BeforeEach, Test
 
 ### Community 667 - "Community 667"
-Cohesion: 0.50
-Nodes (3): CapturePrivacyClassifierTest, Path, Test
+Cohesion: 0.46
+Nodes (4): Callable, Path, Test, CaptureSessionStoreTest
 
 ### Community 668 - "Community 668"
 Cohesion: 0.29
@@ -3157,29 +3138,29 @@ Nodes (7): enum, updateRelation, confidence, additionalProperties, properties, r
 Cohesion: 0.33
 Nodes (4): Actions, CheckpointType, Map, Response
 
-### Community 670 - "Community 670"
-Cohesion: 0.31
-Nodes (4): NoSuchElementFailureTest, AfterMethod, BeforeMethod, Test
-
 ### Community 671 - "Community 671"
 Cohesion: 0.36
-Nodes (4): RelativeLocatorsTests, AfterMethod, BeforeMethod, Test
+Nodes (3): OpenCvVisualConsumer, Mat, String
 
 ### Community 672 - "Community 672"
 Cohesion: 0.36
 Nodes (4): AfterMethod, BeforeMethod, Test, RecordManagerCoverageUnitTest
 
 ### Community 673 - "Community 673"
-Cohesion: 0.29
-Nodes (3): Connection, BeforeMethod, ResultSet
+Cohesion: 0.36
+Nodes (4): HealingReportWriter, HealingConfiguration, HealingReport, String
+
+### Community 674 - "Community 674"
+Cohesion: 0.39
+Nodes (4): JunitProjectStructureManagerTest, AfterEach, Path, Test
 
 ### Community 675 - "Community 675"
 Cohesion: 0.43
 Nodes (7): EnrichmentMode, CaptureGenerationRequest(), defaults(), ApprovalPolicy, Duration, Path, String
 
 ### Community 676 - "Community 676"
-Cohesion: 0.22
-Nodes (8): CaptureFormatException, McpWorkspacePolicy, String, Throwable, IllegalArgumentException, List, Path, String
+Cohesion: 0.33
+Nodes (4): CaptureFormatException, String, Throwable, IllegalArgumentException
 
 ### Community 677 - "Community 677"
 Cohesion: 0.36
@@ -3190,16 +3171,16 @@ Cohesion: 0.22
 Nodes (4): ProgressBarLoggerTestAccessor, AfterMethod, Test, ValidationAndProgressBarTests
 
 ### Community 685 - "Community 685"
-Cohesion: 0.50
-Nodes (3): JiraTests, BeforeClass, Test
+Cohesion: 0.38
+Nodes (5): ready(), unavailable(), AiProviderAvailability, AiProviderAvailability, String
 
 ### Community 686 - "Community 686"
-Cohesion: 0.48
-Nodes (3): OpenCvHealingVisualProviderTest, Color, Test
+Cohesion: 0.40
+Nodes (4): MultipleElementsFoundException, String, Throwable, WebDriverException
 
 ### Community 687 - "Community 687"
-Cohesion: 0.33
-Nodes (5): $id, required, $schema, title, type
+Cohesion: 0.47
+Nodes (3): JunitCoreAssertionDependencyGuardTest, Path, Test
 
 ### Community 708 - "Community 708"
 Cohesion: 0.50
@@ -3210,12 +3191,8 @@ Cohesion: 0.60
 Nodes (4): defaults(), DoctorAnalysisRequest, List, Path
 
 ### Community 759 - "Community 759"
-Cohesion: 0.36
-Nodes (3): PlaywrightMobileWebE2ETestBase, String, Test
-
-### Community 760 - "Community 760"
-Cohesion: 0.26
-Nodes (7): CaptureReadinessTest, CaptureEvent, CaptureSession, ElementSnapshot, List, String, Test
+Cohesion: 0.12
+Nodes (9): GalaxyS26UltraPlaywrightActionsE2ETest, IPhone17ProMaxPlaywrightActionsE2ETest, PlaywrightMobileWebE2ETestBase, Override, String, Override, String, String (+1 more)
 
 ### Community 763 - "Community 763"
 Cohesion: 0.17
@@ -3234,36 +3211,28 @@ Cohesion: 0.47
 Nodes (3): PerformanceTests, BeforeClass, Test
 
 ### Community 773 - "Community 773"
-Cohesion: 0.36
-Nodes (3): GalaxyS26UltraPlaywrightActionsE2ETest, Override, String
+Cohesion: 0.60
+Nodes (4): defaults(), disabled(), ApprovalPolicy, DoctorAiAnalysisRequest
 
 ### Community 777 - "Community 777"
-Cohesion: 0.36
-Nodes (3): IPhone17ProMaxPlaywrightActionsE2ETest, Override, String
+Cohesion: 0.70
+Nodes (4): HistoryRecord(), withChecksum(), LocatorFingerprint, String
 
 ### Community 781 - "Community 781"
 Cohesion: 0.53
 Nodes (3): Path, Test, ExecutionLifecycleHelperSourceUnitTest
 
 ### Community 782 - "Community 782"
-Cohesion: 0.29
+Cohesion: 0.31
 Nodes (5): AfterMethod, BeforeClass, BeforeMethod, Test, TestClass
-
-### Community 786 - "Community 786"
-Cohesion: 0.50
-Nodes (3): By, Locator, Page
 
 ### Community 787 - "Community 787"
 Cohesion: 0.16
 Nodes (14): limiterKey(), RemoteGridPreflight, unavailable(), PreflightReport, Semaphore, SessionPermit, Capabilities, Duration (+6 more)
 
 ### Community 788 - "Community 788"
-Cohesion: 0.29
-Nodes (8): ensure_shaft_import(), migrate_full_source(), migrate_session_source(), Add the SHAFT import required by rewritten Java source., Wrap basic Selenium/Appium driver construction with SHAFT's driver session., Return SHAFT driver variable names from rewritten Java source., Replace simple Selenium actions with SHAFT engine action calls., shaft_driver_variables()
-
-### Community 789 - "Community 789"
-Cohesion: 0.40
-Nodes (3): DriverFactoryHelper, WebDriver, WebDriverElementValidationsBuilder
+Cohesion: 0.16
+Nodes (15): build_parser(), coordinates_have_supported_runner(), coordinates_have_supported_stack(), ensure_shaft_import(), migrate_full_source(), migrate_session_source(), ArgumentParser, Add the SHAFT import required by rewritten Java source. (+7 more)
 
 ### Community 795 - "Community 795"
 Cohesion: 0.52
@@ -3273,21 +3242,9 @@ Nodes (3): CaptureRuntimePortabilityTest, Path, Test
 Cohesion: 0.16
 Nodes (13): ElementAssertions, Locator, NativeValidationsBuilder, Override, PlaywrightNativeValidationsBuilder, PlaywrightSession, PlaywrightValidationsExecutor, String (+5 more)
 
-### Community 800 - "Community 800"
-Cohesion: 0.47
-Nodes (3): ChromePlaywrightActionsE2ETest, Override, String
-
-### Community 801 - "Community 801"
-Cohesion: 0.47
-Nodes (3): EdgePlaywrightActionsE2ETest, Override, String
-
 ### Community 804 - "Community 804"
-Cohesion: 0.40
-Nodes (3): FirefoxPlaywrightActionsE2ETest, Override, String
-
-### Community 805 - "Community 805"
-Cohesion: 0.40
-Nodes (3): WebKitPlaywrightActionsE2ETest, Override, String
+Cohesion: 0.50
+Nodes (3): Object, StringBuilder, ValidationCategory
 
 ### Community 807 - "Community 807"
 Cohesion: 0.53
@@ -3295,66 +3252,58 @@ Nodes (3): RepairProposalStore, Path, RepairProposal
 
 ### Community 809 - "Community 809"
 Cohesion: 0.67
-Nodes (3): minLength, type, mediaType
+Nodes (3): defaults(), ApprovalPolicy, DoctorRepairAiRequest
 
 ### Community 812 - "Community 812"
 Cohesion: 0.33
 Nodes (3): PrivacySanitizer, SanitizedValue, String
 
 ### Community 817 - "Community 817"
-Cohesion: 0.11
-Nodes (15): RequestBuilder, RetryState, RetryPolicy, RetryState, API, Deprecated, Exception, RequestSpecification (+7 more)
-
-### Community 833 - "Community 833"
-Cohesion: 0.27
-Nodes (6): AfterMethod, BeforeMethod, HttpExchange, Object, String, XrayIntegrationHelperCoverageUnitTest
+Cohesion: 0.08
+Nodes (18): RequestBuilder, RetryState, AuthenticationType, RetryPolicy, RetryState, API, ContentType, Deprecated (+10 more)
 
 ### Community 835 - "Community 835"
-Cohesion: 0.50
-Nodes (3): McpMobileToolchainService, McpMobileRecordingService, McpWorkspacePolicy
+Cohesion: 0.67
+Nodes (3): minLength, type, bundleId
+
+### Community 840 - "Community 840"
+Cohesion: 0.67
+Nodes (3): schemaVersion, enum, type
 
 ### Community 842 - "Community 842"
 Cohesion: 0.36
 Nodes (3): ProjectStructureManager, Path, RunType
 
 ### Community 847 - "Community 847"
-Cohesion: 0.33
-Nodes (4): DoctorFormatException, RuntimeException, String, Throwable
-
-### Community 848 - "Community 848"
-Cohesion: 0.67
-Nodes (3): build_parser(), ArgumentParser, Build the command-line parser.
+Cohesion: 0.25
+Nodes (5): DoctorFormatException, ProfileCleanupException, RuntimeException, String, Throwable
 
 ### Community 849 - "Community 849"
-Cohesion: 0.39
+Cohesion: 0.40
 Nodes (3): ReportManager, Level, String
 
-### Community 854 - "Community 854"
-Cohesion: 0.70
-Nodes (3): reviewPath(), reviewUiPath(), Path
-
-### Community 860 - "Community 860"
-Cohesion: 0.50
-Nodes (3): McpCaptureCodeBlockService, CaptureManager, McpWorkspacePolicy
+### Community 852 - "Community 852"
+Cohesion: 0.22
+Nodes (3): ExecutionSummaryReport, CheckpointStatus, StringBuilder
 
 ## Knowledge Gaps
 - **1527 isolated node(s):** `$id`, `$schema`, `additionalProperties`, `additionalProperties`, `type` (+1522 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **97 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **101 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `SHAFT` connect `Community 513` to `Community 514`, `Community 3`, `Community 517`, `Community 5`, `Community 7`, `Community 520`, `Community 9`, `Community 8`, `Community 10`, `Community 12`, `Community 13`, `Community 527`, `Community 15`, `Community 17`, `Community 18`, `Community 529`, `Community 19`, `Community 21`, `Community 22`, `Community 23`, `Community 536`, `Community 16`, `Community 26`, `Community 538`, `Community 27`, `Community 540`, `Community 30`, `Community 31`, `Community 541`, `Community 33`, `Community 34`, `Community 35`, `Community 547`, `Community 36`, `Community 38`, `Community 544`, `Community 548`, `Community 546`, `Community 550`, `Community 43`, `Community 553`, `Community 45`, `Community 46`, `Community 557`, `Community 47`, `Community 49`, `Community 48`, `Community 562`, `Community 52`, `Community 53`, `Community 563`, `Community 55`, `Community 569`, `Community 57`, `Community 572`, `Community 65`, `Community 69`, `Community 71`, `Community 584`, `Community 588`, `Community 76`, `Community 77`, `Community 80`, `Community 81`, `Community 594`, `Community 597`, `Community 86`, `Community 87`, `Community 88`, `Community 89`, `Community 599`, `Community 93`, `Community 96`, `Community 98`, `Community 99`, `Community 615`, `Community 104`, `Community 106`, `Community 108`, `Community 109`, `Community 621`, `Community 114`, `Community 626`, `Community 116`, `Community 628`, `Community 121`, `Community 123`, `Community 125`, `Community 129`, `Community 130`, `Community 137`, `Community 138`, `Community 650`, `Community 652`, `Community 142`, `Community 654`, `Community 655`, `Community 657`, `Community 656`, `Community 145`, `Community 660`, `Community 661`, `Community 151`, `Community 539`, `Community 664`, `Community 156`, `Community 669`, `Community 670`, `Community 159`, `Community 671`, `Community 161`, `Community 32`, `Community 162`, `Community 672`, `Community 165`, `Community 678`, `Community 677`, `Community 167`, `Community 542`, `Community 170`, `Community 172`, `Community 685`, `Community 174`, `Community 543`, `Community 184`, `Community 186`, `Community 190`, `Community 191`, `Community 196`, `Community 39`, `Community 200`, `Community 205`, `Community 210`, `Community 214`, `Community 217`, `Community 218`, `Community 219`, `Community 223`, `Community 225`, `Community 230`, `Community 555`, `Community 233`, `Community 241`, `Community 243`, `Community 247`, `Community 763`, `Community 251`, `Community 253`, `Community 770`, `Community 771`, `Community 260`, `Community 261`, `Community 266`, `Community 269`, `Community 270`, `Community 271`, `Community 782`, `Community 785`, `Community 273`, `Community 275`, `Community 787`, `Community 276`, `Community 781`, `Community 279`, `Community 274`, `Community 281`, `Community 284`, `Community 286`, `Community 287`, `Community 290`, `Community 291`, `Community 293`, `Community 817`, `Community 308`, `Community 311`, `Community 316`, `Community 317`, `Community 319`, `Community 833`, `Community 834`, `Community 838`, `Community 327`, `Community 328`, `Community 329`, `Community 841`, `Community 330`, `Community 844`, `Community 334`, `Community 337`, `Community 340`, `Community 342`, `Community 346`, `Community 348`, `Community 351`, `Community 352`, `Community 353`, `Community 354`, `Community 358`, `Community 359`, `Community 360`, `Community 362`, `Community 364`, `Community 367`, `Community 373`, `Community 374`, `Community 375`, `Community 378`, `Community 379`, `Community 380`, `Community 382`, `Community 389`, `Community 390`, `Community 391`, `Community 392`, `Community 395`, `Community 399`, `Community 401`, `Community 403`, `Community 405`, `Community 407`, `Community 408`, `Community 409`, `Community 411`, `Community 424`, `Community 425`, `Community 427`, `Community 428`, `Community 429`, `Community 430`, `Community 431`, `Community 432`, `Community 434`, `Community 435`, `Community 444`, `Community 445`, `Community 446`, `Community 450`, `Community 454`, `Community 455`, `Community 456`, `Community 460`, `Community 461`, `Community 467`, `Community 468`, `Community 471`, `Community 473`, `Community 476`, `Community 483`, `Community 484`, `Community 485`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 496`, `Community 498`, `Community 503`, `Community 504`, `Community 506`, `Community 509`, `Community 510`?**
-  _High betweenness centrality (0.143) - this node is a cross-community bridge._
-- **Why does `ArrayList` connect `Community 513` to `Community 3`, `Community 5`, `Community 7`, `Community 9`, `Community 13`, `Community 19`, `Community 33`, `Community 34`, `Community 35`, `Community 38`, `Community 39`, `Community 41`, `Community 45`, `Community 49`, `Community 56`, `Community 59`, `Community 60`, `Community 62`, `Community 64`, `Community 72`, `Community 76`, `Community 77`, `Community 85`, `Community 87`, `Community 90`, `Community 93`, `Community 95`, `Community 98`, `Community 99`, `Community 109`, `Community 111`, `Community 117`, `Community 118`, `Community 129`, `Community 132`, `Community 141`, `Community 143`, `Community 147`, `Community 148`, `Community 150`, `Community 151`, `Community 152`, `Community 156`, `Community 157`, `Community 159`, `Community 162`, `Community 169`, `Community 176`, `Community 177`, `Community 178`, `Community 179`, `Community 180`, `Community 185`, `Community 198`, `Community 200`, `Community 205`, `Community 209`, `Community 211`, `Community 212`, `Community 220`, `Community 232`, `Community 235`, `Community 763`, `Community 252`, `Community 255`, `Community 257`, `Community 268`, `Community 273`, `Community 277`, `Community 281`, `Community 288`, `Community 293`, `Community 294`, `Community 306`, `Community 307`, `Community 321`, `Community 322`, `Community 833`, `Community 333`, `Community 340`, `Community 346`, `Community 358`, `Community 377`, `Community 394`, `Community 410`, `Community 413`, `Community 445`, `Community 502`?**
-  _High betweenness centrality (0.035) - this node is a cross-community bridge._
-- **Why does `ZipFile` connect `Community 500` to `Community 11`, `Community 205`, `Community 366`, `Community 400`, `Community 240`, `Community 18`, `Community 54`?**
-  _High betweenness centrality (0.028) - this node is a cross-community bridge._
+- **Why does `SHAFT` connect `Community 513` to `Community 514`, `Community 3`, `Community 517`, `Community 5`, `Community 7`, `Community 520`, `Community 9`, `Community 8`, `Community 10`, `Community 12`, `Community 13`, `Community 16`, `Community 17`, `Community 18`, `Community 529`, `Community 19`, `Community 21`, `Community 23`, `Community 536`, `Community 24`, `Community 26`, `Community 538`, `Community 27`, `Community 540`, `Community 30`, `Community 31`, `Community 541`, `Community 544`, `Community 34`, `Community 547`, `Community 36`, `Community 35`, `Community 38`, `Community 548`, `Community 546`, `Community 550`, `Community 553`, `Community 43`, `Community 555`, `Community 45`, `Community 46`, `Community 557`, `Community 47`, `Community 49`, `Community 48`, `Community 563`, `Community 52`, `Community 53`, `Community 55`, `Community 569`, `Community 57`, `Community 572`, `Community 65`, `Community 579`, `Community 69`, `Community 71`, `Community 584`, `Community 74`, `Community 588`, `Community 76`, `Community 77`, `Community 80`, `Community 81`, `Community 594`, `Community 597`, `Community 86`, `Community 87`, `Community 88`, `Community 89`, `Community 599`, `Community 98`, `Community 99`, `Community 615`, `Community 104`, `Community 106`, `Community 108`, `Community 621`, `Community 114`, `Community 626`, `Community 628`, `Community 116`, `Community 121`, `Community 123`, `Community 125`, `Community 130`, `Community 137`, `Community 138`, `Community 650`, `Community 652`, `Community 142`, `Community 654`, `Community 655`, `Community 657`, `Community 656`, `Community 145`, `Community 660`, `Community 661`, `Community 663`, `Community 539`, `Community 664`, `Community 151`, `Community 156`, `Community 669`, `Community 159`, `Community 672`, `Community 161`, `Community 674`, `Community 32`, `Community 162`, `Community 165`, `Community 678`, `Community 677`, `Community 167`, `Community 542`, `Community 170`, `Community 172`, `Community 174`, `Community 176`, `Community 177`, `Community 184`, `Community 186`, `Community 190`, `Community 191`, `Community 196`, `Community 39`, `Community 199`, `Community 200`, `Community 205`, `Community 210`, `Community 214`, `Community 218`, `Community 219`, `Community 222`, `Community 225`, `Community 230`, `Community 241`, `Community 243`, `Community 247`, `Community 760`, `Community 763`, `Community 251`, `Community 253`, `Community 771`, `Community 260`, `Community 261`, `Community 266`, `Community 781`, `Community 270`, `Community 271`, `Community 782`, `Community 785`, `Community 273`, `Community 275`, `Community 787`, `Community 789`, `Community 276`, `Community 279`, `Community 274`, `Community 281`, `Community 284`, `Community 286`, `Community 287`, `Community 290`, `Community 291`, `Community 293`, `Community 805`, `Community 295`, `Community 301`, `Community 817`, `Community 311`, `Community 316`, `Community 317`, `Community 319`, `Community 834`, `Community 838`, `Community 327`, `Community 328`, `Community 329`, `Community 841`, `Community 330`, `Community 844`, `Community 334`, `Community 340`, `Community 342`, `Community 346`, `Community 348`, `Community 351`, `Community 352`, `Community 353`, `Community 354`, `Community 358`, `Community 359`, `Community 360`, `Community 362`, `Community 364`, `Community 367`, `Community 369`, `Community 373`, `Community 374`, `Community 375`, `Community 378`, `Community 379`, `Community 380`, `Community 381`, `Community 382`, `Community 389`, `Community 390`, `Community 391`, `Community 395`, `Community 399`, `Community 401`, `Community 403`, `Community 405`, `Community 407`, `Community 408`, `Community 409`, `Community 411`, `Community 424`, `Community 426`, `Community 427`, `Community 428`, `Community 429`, `Community 430`, `Community 431`, `Community 432`, `Community 434`, `Community 444`, `Community 446`, `Community 450`, `Community 453`, `Community 454`, `Community 455`, `Community 456`, `Community 460`, `Community 461`, `Community 467`, `Community 468`, `Community 471`, `Community 473`, `Community 476`, `Community 484`, `Community 485`, `Community 486`, `Community 487`, `Community 488`, `Community 489`, `Community 490`, `Community 491`, `Community 492`, `Community 496`, `Community 498`, `Community 502`, `Community 503`, `Community 504`, `Community 506`, `Community 509`, `Community 510`, `Community 511`?**
+  _High betweenness centrality (0.131) - this node is a cross-community bridge._
+- **Why does `IOException` connect `Community 513` to `Community 512`, `Community 7`, `Community 8`, `Community 523`, `Community 13`, `Community 18`, `Community 530`, `Community 19`, `Community 24`, `Community 25`, `Community 29`, `Community 31`, `Community 41`, `Community 558`, `Community 49`, `Community 561`, `Community 562`, `Community 52`, `Community 565`, `Community 56`, `Community 57`, `Community 60`, `Community 61`, `Community 62`, `Community 64`, `Community 578`, `Community 71`, `Community 72`, `Community 74`, `Community 76`, `Community 79`, `Community 597`, `Community 85`, `Community 87`, `Community 88`, `Community 86`, `Community 102`, `Community 105`, `Community 114`, `Community 116`, `Community 117`, `Community 122`, `Community 131`, `Community 133`, `Community 138`, `Community 141`, `Community 658`, `Community 147`, `Community 148`, `Community 151`, `Community 665`, `Community 155`, `Community 156`, `Community 159`, `Community 673`, `Community 674`, `Community 169`, `Community 170`, `Community 687`, `Community 177`, `Community 179`, `Community 189`, `Community 200`, `Community 209`, `Community 211`, `Community 212`, `Community 214`, `Community 216`, `Community 218`, `Community 220`, `Community 222`, `Community 241`, `Community 244`, `Community 252`, `Community 273`, `Community 787`, `Community 279`, `Community 280`, `Community 288`, `Community 293`, `Community 807`, `Community 299`, `Community 307`, `Community 313`, `Community 314`, `Community 328`, `Community 842`, `Community 333`, `Community 847`, `Community 342`, `Community 363`, `Community 381`, `Community 382`, `Community 398`, `Community 404`, `Community 410`, `Community 412`, `Community 417`, `Community 418`, `Community 425`, `Community 428`, `Community 455`, `Community 456`, `Community 495`, `Community 506`?**
+  _High betweenness centrality (0.031) - this node is a cross-community bridge._
+- **Why does `ArrayList` connect `Community 513` to `Community 3`, `Community 5`, `Community 7`, `Community 9`, `Community 13`, `Community 19`, `Community 25`, `Community 34`, `Community 35`, `Community 38`, `Community 39`, `Community 41`, `Community 45`, `Community 49`, `Community 56`, `Community 59`, `Community 60`, `Community 62`, `Community 64`, `Community 74`, `Community 76`, `Community 77`, `Community 84`, `Community 85`, `Community 87`, `Community 93`, `Community 95`, `Community 98`, `Community 99`, `Community 111`, `Community 628`, `Community 117`, `Community 118`, `Community 132`, `Community 141`, `Community 143`, `Community 147`, `Community 148`, `Community 150`, `Community 152`, `Community 667`, `Community 156`, `Community 157`, `Community 159`, `Community 162`, `Community 167`, `Community 169`, `Community 177`, `Community 178`, `Community 179`, `Community 180`, `Community 185`, `Community 186`, `Community 198`, `Community 200`, `Community 205`, `Community 209`, `Community 211`, `Community 212`, `Community 220`, `Community 232`, `Community 235`, `Community 763`, `Community 252`, `Community 255`, `Community 256`, `Community 268`, `Community 273`, `Community 277`, `Community 281`, `Community 288`, `Community 293`, `Community 294`, `Community 306`, `Community 307`, `Community 321`, `Community 322`, `Community 333`, `Community 337`, `Community 340`, `Community 358`, `Community 377`, `Community 394`, `Community 404`, `Community 410`, `Community 413`?**
+  _High betweenness centrality (0.030) - this node is a cross-community bridge._
 - **What connects `$id`, `$schema`, `additionalProperties` to the rest of the system?**
   _1638 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.04057971014492753 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.040455120101137804 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
   _Cohesion score 0.0546448087431694 - nodes in this community are weakly interconnected._
 - **Should `Community 2` be split into smaller, more focused modules?**

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -270,8 +270,8 @@
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/cli/CaptureCli.java": {
-    "mtime": 1782550515.210448,
-    "ast_hash": "e88c3443fcc27dd70324679a0f6d7050",
+    "mtime": 1782551848.5937104,
+    "ast_hash": "b84d90485d615c678797ef09087652b9",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/collector/BidiBrowserEventCollector.java": {
@@ -350,8 +350,8 @@
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationRequest.java": {
-    "mtime": 1782550495.3973737,
-    "ast_hash": "3f896a7111eedf85863989b05effae7d",
+    "mtime": 1782551477.7109334,
+    "ast_hash": "001928854b63467329ee8e22039b29e2",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationResult.java": {
@@ -360,8 +360,8 @@
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java": {
-    "mtime": 1782550703.8403282,
-    "ast_hash": "317ee1cb009c1c47f34fc49f255e41b9",
+    "mtime": 1782551477.7119334,
+    "ast_hash": "b6bf26e02db2293af0a7a49aef1e7fa0",
     "semantic_hash": ""
   },
   "shaft-capture/src/main/java/com/shaft/capture/generate/GeneratedTestValidator.java": {
@@ -520,8 +520,8 @@
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java": {
-    "mtime": 1782550652.6543934,
-    "ast_hash": "81aad25668e8fa313419ef49be66a0e1",
+    "mtime": 1782551477.714441,
+    "ast_hash": "b3d7ccb944c15561e34538b544d555d5",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/generate/LocatorRankerTest.java": {
@@ -3365,8 +3365,8 @@
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java": {
-    "mtime": 1782366241.8640244,
-    "ast_hash": "d64d47ce7e08b3e0e1f0675a072da341",
+    "mtime": 1782551816.1523776,
+    "ast_hash": "d87b521364bcf8477c5f1a5747803127",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/DoctorService.java": {
@@ -3395,8 +3395,8 @@
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCaptureCodeBlockService.java": {
-    "mtime": 1782366241.8775475,
-    "ast_hash": "ba9b31e164fa47d38f4a5bf16f824aee",
+    "mtime": 1782551797.6266823,
+    "ast_hash": "b2cd7f5f571514307181ad032d4414a8",
     "semantic_hash": ""
   },
   "shaft-mcp/src/main/java/com/shaft/mcp/McpCaptureReplayResult.java": {
@@ -3510,8 +3510,8 @@
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java": {
-    "mtime": 1782537256.8080387,
-    "ast_hash": "d5b9d021533c0d88d36cb4361cb5c53a",
+    "mtime": 1782552056.284334,
+    "ast_hash": "28813d12c3a7f9ca7cebbeb708f4d4b8",
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/DoctorServiceTest.java": {
@@ -4525,8 +4525,8 @@
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft.png": {
-    "mtime": 1782366241.7654855,
-    "ast_hash": "d476641cef7c2f5c13f2da06eee7913a",
+    "mtime": 1782551477.7154474,
+    "ast_hash": "987c93b372f4f797f601da520d349930",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/resources/images/shaft_white.png": {
@@ -4835,8 +4835,8 @@
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/cli/CaptureCliTest.java": {
-    "mtime": 1782550403.4854906,
-    "ast_hash": "69d91ae44ada3a29fb404576b8e8fa8f",
+    "mtime": 1782551657.557864,
+    "ast_hash": "1e1fdb36f3f3fceeb484f74e18391a14",
     "semantic_hash": ""
   },
   "shaft-capture/src/test/java/com/shaft/capture/collector/CaptureCollectorUtilityTest.java": {
@@ -5540,8 +5540,8 @@
     "semantic_hash": ""
   },
   "shaft-mcp/src/test/java/com/shaft/mcp/McpCaptureCodeBlockServiceTest.java": {
-    "mtime": 1782366241.9045472,
-    "ast_hash": "8e633fbf2210bc193b6d3b8e22aa3baa",
+    "mtime": 1782551637.5365605,
+    "ast_hash": "fb6a6ac99b50b17f1f8da1ec701a2c6a",
     "semantic_hash": ""
   },
   ".memory/memory/decisions/talk-less-outside-planning.md": {
@@ -5587,11 +5587,6 @@
   "shaft-engine/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsReportingUnitTest.java": {
     "mtime": 1782370828.9040003,
     "ast_hash": "a67ef8c418bf9b0a4c50e180c95d2eec",
-    "semantic_hash": ""
-  },
-  "shaft-engine/src/main/resources/images/shaft_report_logo.png": {
-    "mtime": 1782378124.4408517,
-    "ast_hash": "987c93b372f4f797f601da520d349930",
     "semantic_hash": ""
   },
   "shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureTraceReporter.java": {
@@ -5849,474 +5844,419 @@
     "ast_hash": "690e7bdb6f145c3ad97a3e3bd8d0e1c0",
     "semantic_hash": ""
   },
-  "shaft-capture/allure-results/0fdb7ac9-dfbb-4d41-ac3b-8b9375013293-container.json": {
-    "mtime": 1782550682.350907,
-    "ast_hash": "acd6386edc0c13c0964f1084caf036d9",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/144b9c59-18f1-494f-826c-5954933cf737-container.json": {
-    "mtime": 1782550682.3519106,
-    "ast_hash": "9ebf20aad4f4bec55adf87bd304ddf22",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/14e2aa47-9463-43d0-a441-501b6a49ece8-result.json": {
-    "mtime": 1782550682.353907,
-    "ast_hash": "81bcd7165d6bfc6cb49c068664890876",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/252e47e3-4a90-4f7d-914a-6c2e6e81fdc9-result.json": {
-    "mtime": 1782550682.3554204,
-    "ast_hash": "2e7a77a341f0bf2dd59da7033384b358",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/2bade429-23e7-4139-a699-73655d3213bb-result.json": {
-    "mtime": 1782550682.3554204,
-    "ast_hash": "682ece491d3ea22fe1bbd37515452d98",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/3edf1d7c-32b7-4355-a61d-6216ea0a4727-container.json": {
-    "mtime": 1782550682.3564281,
-    "ast_hash": "003428d00883ae215c505e9004c42973",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/54eb8b04-de79-46b1-9678-12b75e543690-result.json": {
-    "mtime": 1782550682.3574305,
-    "ast_hash": "a6f7180e35c683a30bedb5b5b08097a6",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/587a85f9-4299-4fac-9f72-31a685dc88d0-container.json": {
-    "mtime": 1782550682.358941,
-    "ast_hash": "aaf02df3f7f801c28d57cb8b5eba1752",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/5ec8da1f-d600-48c2-a206-c0bdd79ddade-container.json": {
-    "mtime": 1782550682.359954,
-    "ast_hash": "b593fc17657d734a0ec76aded34946be",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/5f501b4f-ce0c-43d5-9925-51dfc2be67df-container.json": {
-    "mtime": 1782550682.360953,
-    "ast_hash": "be76d82da14a6dd58eb5b190bbb585f3",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/791bbc34-e85f-4cf1-804a-5daf65ad053d-result.json": {
-    "mtime": 1782550682.3619523,
-    "ast_hash": "b63860557fb79a1d7a765e4a9743c1d6",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/80d48083-db5a-4ffb-b227-854c69cf783d-result.json": {
-    "mtime": 1782550682.3629537,
-    "ast_hash": "5247d019fd0ef5672770437de608da32",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/8863c6b7-84f9-4ece-b83d-12c768208325-container.json": {
-    "mtime": 1782550682.3639522,
-    "ast_hash": "fe97255fcb6114b9ebe0ca134be012b4",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/89051c4d-8e1c-4b54-a4ca-6c9300ee56a7-result.json": {
-    "mtime": 1782550682.3654692,
-    "ast_hash": "9ad6aa87924ea268bc0543c05b4a0978",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/89b5cdd8-bfa2-4c24-b274-c074975d293f-container.json": {
-    "mtime": 1782550682.3674686,
-    "ast_hash": "95c9cd8be7b62915dbc57f3d8d75e99d",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/9c4b5815-ea77-4189-b4e7-8f3f22128fa4-result.json": {
-    "mtime": 1782550682.3674686,
-    "ast_hash": "fd8d018de9f33dfb6b165e2e5a09b0fb",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/a1c31382-4870-45f6-8beb-05068d63b2e0-container.json": {
-    "mtime": 1782550682.3699903,
-    "ast_hash": "7f62ebea9c3ff376748acbf1eef5392d",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/a314e555-cb5a-4467-bb43-18f5517e72a2-result.json": {
-    "mtime": 1782550682.3709905,
-    "ast_hash": "5b91e972c8a4dac97ec4ffc0027ed204",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/a3f8b429-c4d0-4a21-b1ad-3614249f1a08-container.json": {
-    "mtime": 1782550682.3719873,
-    "ast_hash": "1deb85610398b59da2c23704dc8d22d8",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/a79046ee-806a-492a-a5ce-063b9cb58dd9-result.json": {
-    "mtime": 1782550682.373497,
-    "ast_hash": "3de82173a811a713767860accb1f0ae3",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/aaa91865-b4db-4f15-98fe-5f280db21b14-result.json": {
-    "mtime": 1782550682.375028,
-    "ast_hash": "bee935cf731e6a664d077e9a0a29d986",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/ae2c29f5-8781-4ef3-a309-a2b859b3376a-result.json": {
-    "mtime": 1782550682.3760276,
-    "ast_hash": "df49b006ca3a0e043e0d1cc109eb1fe9",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/b89bac3a-2015-4f58-8dee-520f7c1cecc1-result.json": {
-    "mtime": 1782550682.3780332,
-    "ast_hash": "c7ab83f2370dfff9aab86d1dd9073836",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/c5995852-371e-497c-8d9c-cc7c05156f88-result.json": {
-    "mtime": 1782550682.3790293,
-    "ast_hash": "20e098800138fef0d60848509b88ac20",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/d2963dd0-968d-479d-8b9e-20a3e94762d4-container.json": {
-    "mtime": 1782550682.381031,
-    "ast_hash": "94e0b0bf5a5b36c9edae8d8611d4674c",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/d896715e-361a-4916-b172-c6331f645e09-container.json": {
-    "mtime": 1782550682.3820324,
-    "ast_hash": "1cb11bc52f2f3536fd146ff5c27641f5",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/e241fb51-e01f-45b8-9f18-303076963633-result.json": {
-    "mtime": 1782550682.3835418,
-    "ast_hash": "716a4f128ffa62de1a78b865f944df3a",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/e281b956-d071-4765-8076-a04338b8d01d-container.json": {
-    "mtime": 1782550682.385613,
-    "ast_hash": "65ffb3c2baf7ed09bcadf2d318c89101",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/e590e0ad-7fe4-474b-b0c8-c519c774a802-container.json": {
-    "mtime": 1782550682.3866124,
-    "ast_hash": "9f7527521d13c29371a638addc6caaf6",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/f0302cb3-a50e-46d8-a68c-8875d695cae2-container.json": {
-    "mtime": 1782550682.387611,
-    "ast_hash": "5ee548fb88239b361a734c2f84934d1d",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/f4d83e9e-5238-42d5-be9a-406c8c05c491-container.json": {
-    "mtime": 1782550682.3896124,
-    "ast_hash": "f7c30d6052a35847064fa80ecb65b534",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/fec6ff04-feec-41f0-b4ec-9ba4dfbd3b6c-container.json": {
-    "mtime": 1782550682.3906112,
-    "ast_hash": "4fbceb23f65a72e29f317550d5aade5d",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/035fdd98-17c4-4bb0-a913-2e2d49c50cd3-result.json": {
-    "mtime": 1782545259.4758167,
-    "ast_hash": "588782debec1e6b129ea63e61ca8717f",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/048494cf-8977-4632-8ee6-2498d791852f-container.json": {
-    "mtime": 1782545259.476819,
-    "ast_hash": "9ea94f75b150ca12338034f3325e6d04",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/17270675-9c93-407f-8c76-8b8e4467cbfb-result.json": {
-    "mtime": 1782545261.1726604,
-    "ast_hash": "c4457bb837760a07907cf9802619d5db",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/1a11911d-667b-4dca-86d2-1ca6f5024067-result.json": {
-    "mtime": 1782545261.130579,
-    "ast_hash": "c08cc9fd80600166d6e25e8beaeb299a",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/1e0b01e9-e08b-46f9-9c8b-dc381944c337-container.json": {
-    "mtime": 1782545261.0544307,
-    "ast_hash": "364e78af21b1650683f2525d4ee3e905",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/1fa2e60d-1eb2-4266-9b27-a5454fcd22c3-container.json": {
-    "mtime": 1782545261.097945,
-    "ast_hash": "53b0845075ae547d239b9177caf4b85e",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/2158dfdf-fc8b-4074-af49-715f77c0edc3-result.json": {
-    "mtime": 1782545261.052391,
-    "ast_hash": "1149972943852b3c9272d1411584b66d",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/36d40387-287e-4bb3-b640-3fba85d79ac8-container.json": {
-    "mtime": 1782545254.108649,
-    "ast_hash": "a811c9031f25dc646b7d44da24a0673a",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/39e5a298-f74a-4987-9849-d6080bb495bc-container.json": {
-    "mtime": 1782545261.0624506,
-    "ast_hash": "14b7a06d7447a45e2d26026f13cc0fc3",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/3b3842cc-7a49-4409-b413-30c24235e8b3-container.json": {
-    "mtime": 1782545259.502373,
-    "ast_hash": "cbba6612c03e4365c4817f640393a9a5",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/449f14dc-824a-47c5-956a-86340c9dd4ec-container.json": {
-    "mtime": 1782545254.0502005,
-    "ast_hash": "86ce37ace510221862c913724f418ca2",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/47fbae7a-8e6d-4f8e-b28d-bdb120224960-container.json": {
-    "mtime": 1782545257.9595573,
-    "ast_hash": "085ec18903d128eedc1100ab305ff22e",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/5e74c063-6ad2-4610-b71e-877aa092ef6b-result.json": {
-    "mtime": 1782545259.502373,
-    "ast_hash": "654f0240274aae3fd0804a99776b154f",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/632c4c11-532a-4c01-88da-46077ac836bb-container.json": {
-    "mtime": 1782545261.1315765,
-    "ast_hash": "4ea8dfe21d9e85fc71554c768605d4dc",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/722f26a9-063b-4281-8e71-c7d7c10357ac-result.json": {
-    "mtime": 1782545254.0318518,
-    "ast_hash": "a2a05c21a7a19f437bd1e33b81a06ffc",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/7ea8940f-b227-41bf-9fa5-28a2440eabde-result.json": {
-    "mtime": 1782545261.150886,
-    "ast_hash": "62477af87c8e9dc321ecb69a10983527",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/8585528a-fc78-4279-9f74-4a6c44bd8967-container.json": {
-    "mtime": 1782545254.3860602,
-    "ast_hash": "07676c1f1dbce60692ba18ef162868c5",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/89dd6e00-9636-4e66-9b80-a3db065145d5-result.json": {
-    "mtime": 1782545254.0785832,
-    "ast_hash": "32a0a6b72e4d13c5e0a4b4262a3fd350",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/973c5fb5-2376-4cb7-adc9-6eb5668eb6a3-container.json": {
-    "mtime": 1782545261.1823492,
-    "ast_hash": "baf81c79576a73fa700018d07794ee7b",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/997ab3cc-a870-4ae1-8409-46e398518a4c-container.json": {
-    "mtime": 1782545254.4025843,
-    "ast_hash": "1d5564fc911fe5464940259ce8fdd305",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/a55b312d-f85b-4409-a3cc-7ba41cdcc827-result.json": {
-    "mtime": 1782545254.4015844,
-    "ast_hash": "df64331ff4b7ae76fd5f6e66d85fb287",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/b11c5fbe-f57e-4f87-bc0f-b6bb765c1e07-result.json": {
-    "mtime": 1782545254.3855538,
-    "ast_hash": "708716eb00f424bb23e413b7f6c7bf8e",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/bf96f1ca-a5c6-457e-b099-29208ca9867c-result.json": {
-    "mtime": 1782545261.096944,
-    "ast_hash": "447b11ae2ab17955d3d9eb77e7dcb119",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/d495911c-ba13-46b1-82c7-240f13eb5c97-result.json": {
-    "mtime": 1782545261.0247457,
-    "ast_hash": "12efa350330f967adf1b92b614e7ceda",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/da128447-d0b4-4aa0-b8dc-977dd5429fec-container.json": {
-    "mtime": 1782545261.0262027,
-    "ast_hash": "89a2b791c9bbc153f4b0c39c8c4ab8d4",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/dbfef7ae-f88b-4adf-9361-28db72f5e692-result.json": {
-    "mtime": 1782545254.1056185,
-    "ast_hash": "ba8313df7ccae6226bff6114a7aee530",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/dfd451ba-3f8d-484b-91b8-b0b4e8495b2d-container.json": {
-    "mtime": 1782545261.1518826,
-    "ast_hash": "23ec469bf9172c60e302dae0b6f2b568",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/e0b84792-e2ad-4e8f-899f-df375d3472c7-container.json": {
-    "mtime": 1782545254.080578,
-    "ast_hash": "c13402f30eaa7bdfc5304c7513da31b0",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/ee04a1fb-588e-4e3b-89e4-2bb915e2a2c0-container.json": {
-    "mtime": 1782545261.1736605,
-    "ast_hash": "7d1947b7e18ad5773f85e3b9e946457b",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/f1e41b44-38d5-40b8-96fe-e402f9e2ba09-result.json": {
-    "mtime": 1782545257.9585586,
-    "ast_hash": "e6ab3dee83ab4b4c398113026ee18b86",
-    "semantic_hash": ""
-  },
   "shaft-mcp/performanceReport/PerformanceReport_27-06-2026_10-27-41-2085-AM.json": {
     "mtime": 1782545261.2166805,
     "ast_hash": "bea963c692b3e9afc74e889098316665",
     "semantic_hash": ""
   },
-  "shaft-capture/allure-results/16e4307a-a498-44a7-8bdf-d5abaa911818-attachment.txt": {
-    "mtime": 1782550671.74548,
-    "ast_hash": "cfea204bfa85b388f3ca657559b653ca",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/2138ebf8-90d9-4d68-a33e-57302bd53edc-attachment.txt": {
-    "mtime": 1782550671.5050106,
-    "ast_hash": "912397a6470041fea2174c87162e10df",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/236f9d16-fd2b-43f5-be58-f7346b9e643a-attachment.txt": {
-    "mtime": 1782550671.765587,
-    "ast_hash": "d4de1449578d0640d2125993cfdc223f",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/289af057-8143-4277-953c-84eb579749eb-attachment.txt": {
-    "mtime": 1782550679.0408938,
-    "ast_hash": "9f54b7242a7b47c3ce32ff99b3b121f1",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/29424f58-8535-46e9-bf13-72e9e24bf3b6-attachment.txt": {
-    "mtime": 1782550675.4915216,
-    "ast_hash": "267af65dbc213ae3d3b866e3cb8967ae",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/4d111943-f24f-4905-8080-a07cb28a92c9-attachment.txt": {
-    "mtime": 1782550676.6908872,
-    "ast_hash": "fa537bfd054b7a31e4c8f994a1508ed4",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/631bcb75-204d-4547-ac9d-a3cffd88d3a7-attachment.txt": {
-    "mtime": 1782550676.5577433,
-    "ast_hash": "ad279ed6fe4e2646cc1d9b719c272ea3",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/6c50cbee-2b92-4631-bd3e-9ad2fb61d110-attachment.txt": {
-    "mtime": 1782550680.2026706,
-    "ast_hash": "594528ac0067a3cd32b8a809155e1f64",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/7fdbe3e5-3c89-4689-b570-9b95bad5626c-attachment.txt": {
-    "mtime": 1782550682.1359675,
-    "ast_hash": "5a5d1e4176f0f16dbcfd777390484a06",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/aa4cae47-4185-4c28-8d34-a9079f530994-attachment.txt": {
-    "mtime": 1782550682.2297916,
-    "ast_hash": "b4521f1a885db72e487b999b01122ee6",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/b0b4f600-4e8d-48b4-9593-70e61f8d2523-attachment.txt": {
-    "mtime": 1782550672.8409295,
-    "ast_hash": "051c61f9de47383852b6a8a30e449dc5",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/da8ff39e-052c-47c4-bafc-11f4bf1ef43d-attachment.txt": {
-    "mtime": 1782550675.4197624,
-    "ast_hash": "c978b0d42cb332c2a1b186739ee51e57",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/de835ed8-d17a-4a07-aacf-09fd5659604e-attachment.txt": {
-    "mtime": 1782550680.1896324,
-    "ast_hash": "6ec475b3fda208e38e4e9e731e0a6fc5",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/ec74d35c-9208-4b26-8682-7bbfa525f6df-attachment.txt": {
-    "mtime": 1782550682.334385,
-    "ast_hash": "6be159c2b31eb77a2265cb3df2ea2396",
-    "semantic_hash": ""
-  },
-  "shaft-capture/allure-results/f03db342-6aff-4a63-bf93-2de8ba4815ae-attachment.txt": {
-    "mtime": 1782550682.3237243,
-    "ast_hash": "1f34c6a98250785b6a842d095f3d5a74",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/189be3d0-4702-46a4-b268-a5eb7815d25a-attachment.txt": {
-    "mtime": 1782545261.1285784,
-    "ast_hash": "920206a772a475b66d23f58eb3b8851e",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/1a489e88-4de7-42c6-a07e-2c2b3b4c0a15-attachment.txt": {
-    "mtime": 1782545254.0742538,
-    "ast_hash": "c4a2d2011d87b16667bea41c7b52cb76",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/2ef608ad-9320-47aa-9226-7c4c3e519329-attachment.txt": {
-    "mtime": 1782545254.398585,
-    "ast_hash": "cdf2fd5f559b189f6ef0645e298062d0",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/4661e1ff-b87a-4d16-873a-1fa1051ebd14-attachment.txt": {
-    "mtime": 1782545253.7415187,
-    "ast_hash": "8eafedf60de85819944c5dc23c7c56f8",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/4e566465-ec35-4c5e-a6e0-796411e1355d-attachment.txt": {
-    "mtime": 1782545257.9565566,
-    "ast_hash": "3e4061cb42c7c038937bf64074c3ac28",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/7a63ab61-55b2-4540-b7c6-7cc2e370eecf-attachment.txt": {
-    "mtime": 1782545261.169665,
-    "ast_hash": "a8572b8b432150c08ad9037fe14db0ba",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/a64fe11c-1698-46a7-83d7-50768bd1d3f4-attachment.txt": {
-    "mtime": 1782545254.3830352,
-    "ast_hash": "f3b04cec6307bd5ee7cdc50f88eadd90",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/c1016f25-a5b1-4922-877d-1e0741950fdc-attachment.txt": {
-    "mtime": 1782545261.0947702,
-    "ast_hash": "00e90f38caa107ac49dea074daca3abb",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/d8da7e70-5134-426f-8935-00b13d7ce680-attachment.txt": {
-    "mtime": 1782545261.0493865,
-    "ast_hash": "9dac5340cf92df1302e099d813fdcb9b",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/ddd514ac-7a06-41c1-a548-91e43aa735ae-attachment.txt": {
-    "mtime": 1782545259.4727924,
-    "ast_hash": "525b1e661eb5f36e90de5bab557d5d06",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/e15b0965-cab9-443f-aaf4-24a960fcd7ab-attachment.txt": {
-    "mtime": 1782545259.5003731,
-    "ast_hash": "24bd097ee343dc139a0842f8e9d9a4c1",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/e51dbe0c-d033-483e-a796-10b0f67fbfb3-attachment.txt": {
-    "mtime": 1782545254.0976884,
-    "ast_hash": "980b114f03cfc502bef0ee4d6a777473",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/fdba2ddf-75a6-443e-9034-ab457eb2d82a-attachment.txt": {
-    "mtime": 1782545261.1488843,
-    "ast_hash": "a39692e3acb9735236d1ed84207ab7c5",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/allure-results/ff5db7a8-ce61-4a63-abe9-607d46b92c9e-attachment.txt": {
-    "mtime": 1782545261.021709,
-    "ast_hash": "b64586ed5cbead67beb2648b52472cdd",
-    "semantic_hash": ""
-  },
-  "shaft-mcp/execution-summary/ExecutionSummaryReport_27-06-2026_10-27-41-2180-AM.html": {
-    "mtime": 1782545261.2216768,
-    "ast_hash": "9c228bf1562ee685fbeaf660f0b9a898",
-    "semantic_hash": ""
-  },
   "shaft-mcp/performanceReport/PerformanceReport_27-06-2026_10-27-41-2085-AM.html": {
     "mtime": 1782545261.2146683,
     "ast_hash": "a2a4174535d029f822c69ced0bfcf725",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/49ff6966-4da4-4625-88ee-7baa8c554a41-container.json": {
+    "mtime": 1782552124.0174305,
+    "ast_hash": "6e5a9a821c60ea4bae21fcefd80f65a8",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/a423ef15-a13a-464a-818f-18cb55e27359-container.json": {
+    "mtime": 1782552124.0229487,
+    "ast_hash": "4482cab44b50d53096d30fdfefb2b9a7",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/aa92ea15-7099-42f8-9772-1aa1023e3470-result.json": {
+    "mtime": 1782552124.0284688,
+    "ast_hash": "84359adc709e72cdf43ea490c6b5e443",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/acbced85-a305-4185-8295-9007e77a4c39-container.json": {
+    "mtime": 1782552124.030465,
+    "ast_hash": "bd0dcc992317d46c7e099b61fdb150fe",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/b5b23fa9-61cd-4038-ba91-4198d94ca5ff-result.json": {
+    "mtime": 1782552124.0370314,
+    "ast_hash": "168e948b975f825351f7c096710ce617",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/bce95353-8c8d-4d34-8645-2a1930cd8fdb-result.json": {
+    "mtime": 1782552124.0478015,
+    "ast_hash": "e076434066e5b90e906de0803cd142ef",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/ea243f7c-6fad-4d25-ba62-fa0dda1acd8c-container.json": {
+    "mtime": 1782552124.0573566,
+    "ast_hash": "a7bffda820c87899010da80be52c765c",
+    "semantic_hash": ""
+  },
+  "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureTargetInsertionPlan.java": {
+    "mtime": 1782551738.9970946,
+    "ast_hash": "eba805d7f8bd7ebe14e9c9bf8b36cfb3",
+    "semantic_hash": ""
+  },
+  "shaft-capture/src/main/java/com/shaft/capture/generate/CaptureTargetInsertionPlanner.java": {
+    "mtime": 1782552292.6060812,
+    "ast_hash": "852dcbb812bc2cc0bf4fba6d5bb8c713",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-report/summary.json": {
+    "mtime": 1782552411.5315545,
+    "ast_hash": "d58560f28c983eb4f69c50c2bb90d4ea",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/019a6ec2-e2df-4055-ae16-b0094c8cc1ab-container.json": {
+    "mtime": 1782552406.9904146,
+    "ast_hash": "3e0747f298cb3d795f5753d1c1685fa7",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/09c599b1-2dde-4b56-993d-a011fde882a6-container.json": {
+    "mtime": 1782552406.9914186,
+    "ast_hash": "ae9b1c0ad3baabdaa46169c5ee3f8120",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/0b612c76-3f6f-48c4-bf79-c17e1fa6b7b6-result.json": {
+    "mtime": 1782552406.9924204,
+    "ast_hash": "6ea7d568b1e5f51f13ab6f495a66c09b",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/12591467-9ce6-4ef2-ba49-6b4ee648a1f7-result.json": {
+    "mtime": 1782552406.9944491,
+    "ast_hash": "c8efb8099114db1d747ac347f8f007bf",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/19a3d0ef-a5b6-4e57-8e51-35b5d3310b54-result.json": {
+    "mtime": 1782552406.996457,
+    "ast_hash": "82832d719535e7a97177265b38b1a5c1",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/2ce5004d-31c1-4179-bda0-0b5350502e69-result.json": {
+    "mtime": 1782552406.997457,
+    "ast_hash": "164f4b5959a43a2544a8a3a05c26ffb5",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/38a40c2d-0267-4ce6-9a9b-806dd535519b-result.json": {
+    "mtime": 1782552406.99947,
+    "ast_hash": "c78c6ea27cc661b3af6bc738adecdbe3",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/409f13d1-cbd7-4331-93fb-5b071bb98033-container.json": {
+    "mtime": 1782552407.000464,
+    "ast_hash": "b974944e07100308d861f501848da067",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/4b601186-b883-4f6e-9d0f-f572872b7b4b-result.json": {
+    "mtime": 1782552407.005946,
+    "ast_hash": "109fd2202136ccdc988bbf2697a69227",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/4b94d668-a67c-4f93-bf70-c21c475a9705-result.json": {
+    "mtime": 1782552407.0088944,
+    "ast_hash": "7cbe8585836badde57f11f9d7084b8a0",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/4c3766e4-1f7b-4b2f-abb1-9539eeaac66b-result.json": {
+    "mtime": 1782552407.011886,
+    "ast_hash": "c78d01adbb8f2277a75eb427f0127e59",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/557ee7d3-c10b-4361-9439-00267bac2250-container.json": {
+    "mtime": 1782552407.012881,
+    "ast_hash": "c83b3d8ad98f8dd34c54db7e1aab7307",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/5ee20686-e763-423f-9cf3-983cee1b4f8e-result.json": {
+    "mtime": 1782552407.014387,
+    "ast_hash": "a10124727cf300bd23ae28bd231a6ea1",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/5f4758ab-9c4f-4512-86bb-c817300a1ed4-container.json": {
+    "mtime": 1782552407.0151415,
+    "ast_hash": "cd5ec1e4c4b221337912fffb052b5701",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/6792268c-ad00-43b0-b1ea-80ed3b1958a2-result.json": {
+    "mtime": 1782552407.016335,
+    "ast_hash": "b4cb07772878f35025971ac51ebe9002",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/6fa65b49-39a9-452e-9786-e73297970768-container.json": {
+    "mtime": 1782552407.0173337,
+    "ast_hash": "bd1a3745448126ae145ee64a40f7deac",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/7a040ec2-9ec5-4bb0-bfc1-fd6059a73f7b-container.json": {
+    "mtime": 1782552407.0198548,
+    "ast_hash": "a9d19bd2709b34752895e48fee9a4264",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/7ef66c41-62c0-4dd2-b2ee-53b6093ff3c4-container.json": {
+    "mtime": 1782552407.021852,
+    "ast_hash": "ddc83e70c4c8e57fa23c6c31e88c6d17",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/8b0d31aa-3df0-48ff-a3e8-d16bd704e88f-container.json": {
+    "mtime": 1782552407.022853,
+    "ast_hash": "83f88fcd0bee280959315866f3b6f699",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/90ea5ec7-4ee5-4e96-926e-c0924b297a23-container.json": {
+    "mtime": 1782552407.0243604,
+    "ast_hash": "443ea91ae800348368d81966e4503fe8",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/968f2d1a-fb67-49b7-9ab9-a691fcf95000-result.json": {
+    "mtime": 1782552407.0253716,
+    "ast_hash": "72821474aa47253aa71a9fbc97f8abad",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/984a1a93-73df-488e-9a4e-8a4ce61e2f52-container.json": {
+    "mtime": 1782552407.02637,
+    "ast_hash": "b0cb0abc41fc745b456a527e3cd25b41",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/9a24a193-a530-441c-9226-5613b4df58f2-result.json": {
+    "mtime": 1782552407.0273702,
+    "ast_hash": "6e5f6b6be4ae5aaa4990dd89d3bee384",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/9da253a7-a439-49db-b20d-0b5c32aa1ff1-container.json": {
+    "mtime": 1782552407.029373,
+    "ast_hash": "ce81a251f78629f9a83e6853d8da05e5",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/9ed4d227-3722-4664-865a-90799dd9e765-result.json": {
+    "mtime": 1782552407.0303693,
+    "ast_hash": "501dd6955185ea6da84d3e1827759a18",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/b287c773-a61c-426f-8c32-b172ddedf632-container.json": {
+    "mtime": 1782552407.0313673,
+    "ast_hash": "7e249a491e18650d4ad93c4082710052",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/b559417e-98e4-4ada-849c-21abb5a91b4e-container.json": {
+    "mtime": 1782552407.0323696,
+    "ast_hash": "0c80c2ed18c412353c6ba828aaf0d304",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/categories.json": {
+    "mtime": 1782552407.0498025,
+    "ast_hash": "bbc6f20af79864d58750116e43d3d312",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/cc05648c-0b3f-497f-9ed2-7112700ce542-container.json": {
+    "mtime": 1782552407.0338786,
+    "ast_hash": "0360f67bf85b6d9d6ce1a2458cdc9867",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/d85dd25c-3709-4a99-bb17-0c35e862333c-container.json": {
+    "mtime": 1782552407.0343983,
+    "ast_hash": "c2d551c75dfa42dff10a305e513889e2",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/dda5802a-d56a-426c-bd49-4c42df44f8f9-container.json": {
+    "mtime": 1782552407.0401719,
+    "ast_hash": "22f0b69542a99a3a658ddfd5ed77c216",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/e55762eb-28e8-41eb-8edb-b5a6e5a520df-result.json": {
+    "mtime": 1782552407.0421858,
+    "ast_hash": "8c4eea46845c257efc607fee5d7284b8",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/e8641dda-94cf-4f95-93e5-5d245ef96c36-result.json": {
+    "mtime": 1782552407.0447035,
+    "ast_hash": "cbf4536c7d6132133b0ed44963c2dd06",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/ea9b350e-d26d-41f4-9c56-fc7aad38dd73-result.json": {
+    "mtime": 1782552407.0467992,
+    "ast_hash": "122540b225f95ac472f8e0bd85137d68",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/f1908225-7056-4abf-80b9-d57a5e5ebe2b-container.json": {
+    "mtime": 1782552407.0487983,
+    "ast_hash": "452ffc3ef1a95dcdf5ecff772e0efefe",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/performanceReport/PerformanceReport_27-06-2026_12-18-27-3560-PM.json": {
+    "mtime": 1782551907.359018,
+    "ast_hash": "6c637303ba5c76e6f6d725e1b5fbd5e2",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/performanceReport/PerformanceReport_27-06-2026_12-19-29-0926-PM.json": {
+    "mtime": 1782551969.0948822,
+    "ast_hash": "48003880cae7ec0c1ec16381d4c3bbc1",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/performanceReport/PerformanceReport_27-06-2026_12-20-38-8801-PM.json": {
+    "mtime": 1782552038.883661,
+    "ast_hash": "249dd5fc3d6af124a2d3ea3e76370f9e",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/performanceReport/PerformanceReport_27-06-2026_12-21-38-2204-PM.json": {
+    "mtime": 1782552098.2234755,
+    "ast_hash": "8ecebc368671d59a234118763c0725ef",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/performanceReport/PerformanceReport_27-06-2026_12-26-46-9795-PM.json": {
+    "mtime": 1782552406.9815252,
+    "ast_hash": "85c5958f984455f402aa17dfd9deca80",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/0a0dadcb-cee9-48da-8817-509b44d5d031-attachment.txt": {
+    "mtime": 1782552123.579231,
+    "ast_hash": "912397a6470041fea2174c87162e10df",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/413e940d-6445-4fa0-8b48-a3e8fa96e1c6-attachment.txt": {
+    "mtime": 1782552123.850191,
+    "ast_hash": "d4de1449578d0640d2125993cfdc223f",
+    "semantic_hash": ""
+  },
+  "shaft-capture/allure-results/7caa3584-2e9d-4d43-93b8-0f376e9e564d-attachment.txt": {
+    "mtime": 1782552123.833616,
+    "ast_hash": "cfea204bfa85b388f3ca657559b653ca",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-report/2026-06-27_12-18-31-718_AllureReport.html": {
+    "mtime": 1782551911.7000134,
+    "ast_hash": "08c987ebb0b06736b4a9e3667a195d53",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-report/2026-06-27_12-19-32-962_AllureReport.html": {
+    "mtime": 1782551972.9485857,
+    "ast_hash": "d6d09c144d7b8a090de6c031397e220c",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-report/2026-06-27_12-20-43-702_AllureReport.html": {
+    "mtime": 1782552043.6919038,
+    "ast_hash": "278bb9d1408a7d0024b0ce43817ec0d5",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-report/2026-06-27_12-21-41-790_AllureReport.html": {
+    "mtime": 1782552101.7802978,
+    "ast_hash": "b13294210ba0f8c1b4ae29aa0ec7554e",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-report/2026-06-27_12-26-51-620_AllureReport.html": {
+    "mtime": 1782552411.6048844,
+    "ast_hash": "2a530922393b620b1f23e7e09f6e7333",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/0563c341-7bb1-4255-8c8c-d92c33a92e6b-attachment.txt": {
+    "mtime": 1782552403.873698,
+    "ast_hash": "24bd097ee343dc139a0842f8e9d9a4c1",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/20761072-4987-4798-9fde-058e0f91a7e2-attachment.txt": {
+    "mtime": 1782552398.913732,
+    "ast_hash": "c4a2d2011d87b16667bea41c7b52cb76",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/2f6ff8ba-30d5-4a4b-96ca-b10116213725-attachment.txt": {
+    "mtime": 1782552406.855744,
+    "ast_hash": "00e90f38caa107ac49dea074daca3abb",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/38ead4a7-d31a-4804-ad3b-bbd5bf742b89-attachment.txt": {
+    "mtime": 1782552406.943108,
+    "ast_hash": "a8572b8b432150c08ad9037fe14db0ba",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/4648ac8f-aad2-4460-939d-58433299e9af-attachment.txt": {
+    "mtime": 1782552403.850235,
+    "ast_hash": "525b1e661eb5f36e90de5bab557d5d06",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/4ffbd2bc-bc31-4047-8f95-d4c98c86231b-attachment.txt": {
+    "mtime": 1782552398.9347925,
+    "ast_hash": "980b114f03cfc502bef0ee4d6a777473",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/66c195e2-0eeb-48ce-9e00-1f5d6132e2fa-attachment.txt": {
+    "mtime": 1782552406.8127496,
+    "ast_hash": "30d4f5fb44af006de9992517d0866990",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/93237f1d-4b24-4cb0-9a3b-62480fc71303-attachment.txt": {
+    "mtime": 1782552406.8799222,
+    "ast_hash": "920206a772a475b66d23f58eb3b8851e",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/a500054d-5d29-48d0-9cc3-66ccb77d31ee-attachment.txt": {
+    "mtime": 1782552399.1294925,
+    "ast_hash": "cdf2fd5f559b189f6ef0645e298062d0",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/a56100b8-de74-426a-ae4f-52ac16e6584f-attachment.txt": {
+    "mtime": 1782552406.907527,
+    "ast_hash": "c08168faa7941ea9270e44bc4966b2c8",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/ac5b2706-3585-4bfd-b8fc-449e0323cc65-attachment.txt": {
+    "mtime": 1782552399.1154518,
+    "ast_hash": "f3b04cec6307bd5ee7cdc50f88eadd90",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/ae0ddee5-84d9-4654-a22c-97b89df017ef-attachment.txt": {
+    "mtime": 1782552405.4195411,
+    "ast_hash": "b64586ed5cbead67beb2648b52472cdd",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/b86dd191-9958-44df-945a-c86e144acdad-attachment.txt": {
+    "mtime": 1782552402.6002352,
+    "ast_hash": "3e4061cb42c7c038937bf64074c3ac28",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/c511f6ba-faa5-4552-b5cd-a9b4aba56d99-attachment.txt": {
+    "mtime": 1782552406.9225793,
+    "ast_hash": "a39692e3acb9735236d1ed84207ab7c5",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/d94525bd-93ef-4c18-8c07-281bce6de69a-attachment.txt": {
+    "mtime": 1782552398.6587255,
+    "ast_hash": "8eafedf60de85819944c5dc23c7c56f8",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allure-results/f8359e16-858f-4b18-be4e-5a97deb7007f-attachment.txt": {
+    "mtime": 1782552406.8255038,
+    "ast_hash": "9dac5340cf92df1302e099d813fdcb9b",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/allurerc.yaml": {
+    "mtime": 1782552407.0507977,
+    "ast_hash": "53f2fc33c1fadb9a8f8586345871e6c2",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/execution-summary/ExecutionSummaryReport_27-06-2026_12-26-46-9820-PM.html": {
+    "mtime": 1782552406.9853187,
+    "ast_hash": "659a31bf66721f033fde919e8975de44",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/performanceReport/PerformanceReport_27-06-2026_12-18-27-3560-PM.html": {
+    "mtime": 1782551907.3570178,
+    "ast_hash": "13f9352bb873debfc37f5e9f267943a5",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/performanceReport/PerformanceReport_27-06-2026_12-19-29-0926-PM.html": {
+    "mtime": 1782551969.0936766,
+    "ast_hash": "be3df928e100f2696ed437809fe4828b",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/performanceReport/PerformanceReport_27-06-2026_12-20-38-8801-PM.html": {
+    "mtime": 1782552038.8821485,
+    "ast_hash": "1e87bf4403cad4fd67a69c518bed0f40",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/performanceReport/PerformanceReport_27-06-2026_12-21-38-2204-PM.html": {
+    "mtime": 1782552098.222474,
+    "ast_hash": "bd253a2900e7ee72baad1cec69b5104e",
+    "semantic_hash": ""
+  },
+  "shaft-mcp/performanceReport/PerformanceReport_27-06-2026_12-26-46-9795-PM.html": {
+    "mtime": 1782552406.9805238,
+    "ast_hash": "05bca5026f5b54cccafc84b6fca53e6b",
     "semantic_hash": ""
   }
 }

--- a/shaft-capture/src/main/java/com/shaft/capture/cli/CaptureCli.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/cli/CaptureCli.java
@@ -9,6 +9,8 @@ import com.shaft.capture.control.CaptureControlServer;
 import com.shaft.capture.generate.CaptureGenerationRequest;
 import com.shaft.capture.generate.CaptureGenerationResult;
 import com.shaft.capture.generate.CaptureGenerator;
+import com.shaft.capture.generate.CaptureTargetInsertionPlan;
+import com.shaft.capture.generate.CaptureTargetInsertionPlanner;
 import com.shaft.capture.generate.CodegenFeatureCatalog;
 import com.shaft.capture.model.CaptureReadiness;
 import com.shaft.capture.model.Checkpoint;
@@ -216,7 +218,23 @@ public final class CaptureCli {
                 options.flag("approve-enrichment"),
                 approval,
                 options.flag("enable-fallback-locators")));
-        print(result);
+        if (options.values().containsKey("target-source") || options.values().containsKey("insert-after")) {
+            if (!options.values().containsKey("target-source") || !options.values().containsKey("insert-after")) {
+                throw new IllegalArgumentException(
+                        "Capture record-at-target requires both --target-source and --insert-after.");
+            }
+            CaptureTargetInsertionPlan insertion = result.successful()
+                    ? new CaptureTargetInsertionPlanner().plan(
+                            result.sourcePath(),
+                            options.pathRequired("target-source"),
+                            options.required("insert-after"),
+                            options.value("driver-variable", "driver"))
+                    : null;
+            printJson(new CaptureGenerateAtTargetResult(result, insertion),
+                    "Capture record-at-target result could not be serialized.");
+        } else {
+            print(result);
+        }
         return result.successful() ? 0 : 1;
     }
 
@@ -417,6 +435,7 @@ public final class CaptureCli {
                 + "generate --session <capture.json> [--output-dir <path>] [--package <name>] "
                 + "[--class-name <name>] [--overwrite] [--skip-compile] [--replay] "
                 + "[--enable-fallback-locators] "
+                + "[--target-source <path> --insert-after <anchor> [--driver-variable <name>]] "
                 + "[--replay-timeout-seconds <seconds>] [--ai-preview --allow-local-ai|--allow-remote-ai] "
                 + "[--enrichment-preview <path>] "
                 + "[--apply-enrichment <path> --approve-enrichment] | features";
@@ -522,5 +541,10 @@ public final class CaptureCli {
         private boolean flag(String name) {
             return flags.contains(name);
         }
+    }
+
+    private record CaptureGenerateAtTargetResult(
+            CaptureGenerationResult generation,
+            CaptureTargetInsertionPlan insertion) {
     }
 }

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureTargetInsertionPlan.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureTargetInsertionPlan.java
@@ -1,0 +1,38 @@
+package com.shaft.capture.generate;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Focused record-at-target insertion snippets derived from generated Capture source.
+ *
+ * @param targetSource existing source file selected by the user
+ * @param insertAfter insertion anchor supplied by the user
+ * @param imports imports required by locator or action snippets
+ * @param locatorFields locator fields copied from generated source
+ * @param actionSnippet generated action lines for the target method
+ * @param placement human-readable placement guidance
+ * @param anchorFound whether the target source contains the supplied anchor
+ * @param warnings safe validation warnings
+ */
+public record CaptureTargetInsertionPlan(
+        Path targetSource,
+        String insertAfter,
+        List<String> imports,
+        String locatorFields,
+        String actionSnippet,
+        String placement,
+        boolean anchorFound,
+        List<String> warnings) {
+    /**
+     * Creates an immutable insertion plan.
+     */
+    public CaptureTargetInsertionPlan {
+        insertAfter = insertAfter == null ? "" : insertAfter.trim();
+        imports = imports == null ? List.of() : List.copyOf(imports);
+        locatorFields = locatorFields == null ? "" : locatorFields.trim();
+        actionSnippet = actionSnippet == null ? "" : actionSnippet.trim();
+        placement = placement == null ? "" : placement.trim();
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureTargetInsertionPlanner.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureTargetInsertionPlanner.java
@@ -1,0 +1,183 @@
+package com.shaft.capture.generate;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Builds focused snippets for inserting Capture-generated actions into an existing source target.
+ */
+public final class CaptureTargetInsertionPlanner {
+    private static final Pattern DRIVER_TOKEN = Pattern.compile("\\bdriver\\b");
+    private static final Pattern LOCATOR_FIELD = Pattern.compile(
+            "\\s*(?:private|protected|public)?\\s*(?:static\\s+)?final\\s+By\\s+"
+                    + "([A-Za-z_$][\\w$]*)\\s*=\\s*(.+);\\s*");
+    private static final Pattern TARGET_DRIVER = Pattern.compile(
+            "\\bSHAFT\\.GUI\\.(?:Driver|WebDriver|Playwright)\\s+([A-Za-z_$][\\w$]*)\\b");
+
+    /**
+     * Creates a planner.
+     */
+    public CaptureTargetInsertionPlanner() {
+        // Public utility for CLI and MCP adapters.
+    }
+
+    /**
+     * Builds record-at-target snippets without editing the target source file.
+     *
+     * @param generatedSource generated Capture Java source
+     * @param targetSource existing Java source selected by the user
+     * @param insertAfter method name or textual anchor to insert after
+     * @param driverVariableName optional driver variable name used in the target source
+     * @return insertion snippets and validation warnings
+     */
+    public CaptureTargetInsertionPlan plan(
+            Path generatedSource,
+            Path targetSource,
+            String insertAfter,
+            String driverVariableName) {
+        if (generatedSource == null) {
+            throw new IllegalArgumentException("Generated Capture source path is required.");
+        }
+        if (targetSource == null) {
+            throw new IllegalArgumentException("Capture target source path is required.");
+        }
+        String anchor = insertAfter == null ? "" : insertAfter.trim();
+        if (anchor.isBlank()) {
+            throw new IllegalArgumentException("Capture insertion anchor is required.");
+        }
+        try {
+            String generated = Files.readString(generatedSource, StandardCharsets.UTF_8);
+            String target = Files.readString(targetSource, StandardCharsets.UTF_8);
+            String driver = javaIdentifierOrDefault(driverVariableName, targetDriver(target));
+            String method = testMethod(generated);
+            String actions = actionSnippet(method, driver);
+            String locators = locatorFields(generated);
+            boolean anchorFound = anchorFound(target, anchor);
+            List<String> warnings = new ArrayList<>();
+            if (!anchorFound) {
+                warnings.add("Target anchor " + anchor + " was not found in " + targetSource.getFileName()
+                        + "; use the snippet manually.");
+            }
+            if (actions.isBlank()) {
+                warnings.add("Generated Capture source did not contain a TestNG replay method body.");
+            }
+            if (locators.isBlank() && actions.contains("LOCATOR")) {
+                warnings.add("Generated action snippet references locators, but no locator fields were extracted.");
+            }
+            return new CaptureTargetInsertionPlan(
+                    targetSource,
+                    anchor,
+                    imports(generated),
+                    locators,
+                    actions,
+                    "Paste the action snippet in " + targetSource.getFileName() + " after " + anchor
+                            + ". Add locator fields/imports from the companion block if missing.",
+                    anchorFound,
+                    warnings);
+        } catch (IOException exception) {
+            throw new IllegalArgumentException("Capture record-at-target source could not be read.", exception);
+        }
+    }
+
+    private static List<String> imports(String source) {
+        return source.lines()
+                .filter(line -> line.startsWith("import "))
+                .map(line -> line.substring("import ".length(), line.length() - 1))
+                .toList();
+    }
+
+    private static String locatorFields(String source) {
+        StringBuilder fields = new StringBuilder();
+        source.lines().forEach(line -> {
+            if (LOCATOR_FIELD.matcher(line).matches()) {
+                fields.append(line.strip()).append('\n');
+            }
+        });
+        return fields.toString();
+    }
+
+    private static String actionSnippet(String method, String driver) {
+        if (method.isBlank()) {
+            return "";
+        }
+        List<String> lines = method.lines().toList();
+        StringBuilder code = new StringBuilder();
+        String driverReplacement = Matcher.quoteReplacement(driver);
+        for (int index = 1; index < lines.size(); index++) {
+            if (index == lines.size() - 1 && lines.get(index).trim().equals("}")) {
+                continue;
+            }
+            String trimmed = lines.get(index).trim();
+            if (!trimmed.isBlank()) {
+                code.append(DRIVER_TOKEN.matcher(trimmed).replaceAll(driverReplacement)).append('\n');
+            }
+        }
+        return code.toString();
+    }
+
+    private static String testMethod(String source) {
+        List<String> lines = source.lines().toList();
+        for (int index = 0; index < lines.size(); index++) {
+            if (!lines.get(index).trim().equals("@Test")) {
+                continue;
+            }
+            int methodStart = index + 1;
+            while (methodStart < lines.size() && !lines.get(methodStart).contains("{")) {
+                methodStart++;
+            }
+            if (methodStart >= lines.size()) {
+                return "";
+            }
+            int depth = 0;
+            List<String> method = new ArrayList<>();
+            for (int lineIndex = methodStart; lineIndex < lines.size(); lineIndex++) {
+                String line = lines.get(lineIndex);
+                method.add(line);
+                for (int charIndex = 0; charIndex < line.length(); charIndex++) {
+                    char character = line.charAt(charIndex);
+                    if (character == '{') {
+                        depth++;
+                    } else if (character == '}') {
+                        depth--;
+                    }
+                }
+                if (depth == 0) {
+                    return String.join("\n", method) + "\n";
+                }
+            }
+        }
+        return "";
+    }
+
+    private static boolean anchorFound(String source, String anchor) {
+        String quoted = Pattern.quote(anchor);
+        Pattern method = Pattern.compile("\\b" + quoted + "\\s*\\(");
+        return method.matcher(source).find()
+                || source.toLowerCase(Locale.ROOT).contains(anchor.toLowerCase(Locale.ROOT));
+    }
+
+    private static String targetDriver(String source) {
+        Matcher matcher = TARGET_DRIVER.matcher(source);
+        return matcher.find() ? matcher.group(1) : "driver";
+    }
+
+    private static String javaIdentifierOrDefault(String value, String fallback) {
+        String candidate = value == null || value.isBlank() ? fallback : value.trim();
+        if (candidate == null || candidate.isBlank() || !Character.isJavaIdentifierStart(candidate.charAt(0))) {
+            return "driver";
+        }
+        for (int index = 1; index < candidate.length(); index++) {
+            if (!Character.isJavaIdentifierPart(candidate.charAt(index))) {
+                return "driver";
+            }
+        }
+        return candidate;
+    }
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/cli/CaptureCliTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/cli/CaptureCliTest.java
@@ -134,6 +134,8 @@ class CaptureCliTest {
         assertTrue(usage.contains("capture start"));
         assertTrue(usage.contains("features"));
         assertTrue(usage.contains("--enable-fallback-locators"));
+        assertTrue(usage.contains("--target-source"));
+        assertTrue(usage.contains("--insert-after"));
         assertEquals("operation failed.", fallbackMessage);
         assertTrue(running);
         assertEquals(12L, parsed);

--- a/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
@@ -332,6 +332,50 @@ public class CaptureService {
     }
 
     /**
+     * Generates focused record-at-target code blocks for an existing Java source anchor.
+     *
+     * @param sessionPath persisted Capture JSON path inside the MCP workspace
+     * @param outputDirectory generated project root inside the MCP workspace
+     * @param packageName generated Java package
+     * @param className optional generated class name
+     * @param overwrite whether existing artifacts may be replaced
+     * @param targetSourcePath existing Java source path inside the MCP workspace
+     * @param insertAfter method name or textual anchor to insert after
+     * @param driverVariableName Java driver variable name used in extracted snippets
+     * @return generated snippets and report
+     */
+    @Tool(name = "capture_record_at_target_code_blocks",
+            description = "generates focused Capture snippets for insertion at an existing Java source anchor")
+    public McpCaptureReplayResult recordAtTargetCodeBlocks(
+            String sessionPath,
+            String outputDirectory,
+            String packageName,
+            String className,
+            boolean overwrite,
+            String targetSourcePath,
+            String insertAfter,
+            String driverVariableName) {
+        CaptureGenerationResult result = generateInternal(
+                sessionPath,
+                outputDirectory,
+                packageName,
+                className,
+                overwrite,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                CodegenBackend.WEBDRIVER);
+        return replayResult(
+                result,
+                driverVariableName,
+                workspacePolicy.existing(targetSourcePath, "Capture target source path"),
+                insertAfter);
+    }
+
+    /**
      * Generates deterministic copy-paste SHAFT Playwright code blocks from a persisted Capture session.
      *
      * @param sessionPath persisted Capture JSON path inside the MCP workspace
@@ -468,8 +512,17 @@ public class CaptureService {
     }
 
     private McpCaptureReplayResult replayResult(CaptureGenerationResult result, String driverVariableName) {
+        return replayResult(result, driverVariableName, null, "");
+    }
+
+    private McpCaptureReplayResult replayResult(
+            CaptureGenerationResult result,
+            String driverVariableName,
+            Path targetSource,
+            String insertAfter) {
         var blocks = result.successful() && result.sourcePath() != null
-                ? codeBlocks.fromGeneratedSource(result.sourcePath(), driverVariableName, result.report())
+                ? codeBlocks.fromGeneratedSource(
+                        result.sourcePath(), driverVariableName, result.report(), targetSource, insertAfter)
                 : java.util.List.<McpCodeBlock>of();
         return new McpCaptureReplayResult(
                 result.sourcePath(),

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpCaptureCodeBlockService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpCaptureCodeBlockService.java
@@ -1,6 +1,8 @@
 package com.shaft.mcp;
 
 import com.shaft.capture.generate.CaptureGenerationReport;
+import com.shaft.capture.generate.CaptureTargetInsertionPlan;
+import com.shaft.capture.generate.CaptureTargetInsertionPlanner;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -54,6 +56,25 @@ final class McpCaptureCodeBlockService {
             Path sourcePath,
             String driverVariableName,
             CaptureGenerationReport report) {
+        return fromGeneratedSource(sourcePath, driverVariableName, report, null, "");
+    }
+
+    /**
+     * Extracts generated code blocks plus focused record-at-target snippets.
+     *
+     * @param sourcePath generated Java source
+     * @param driverVariableName desired driver variable name for method snippets
+     * @param report optional structured generation report
+     * @param targetSource existing Java source selected by the user
+     * @param insertAfter method name or textual anchor to insert after
+     * @return MCP code blocks
+     */
+    List<McpCodeBlock> fromGeneratedSource(
+            Path sourcePath,
+            String driverVariableName,
+            CaptureGenerationReport report,
+            Path targetSource,
+            String insertAfter) {
         try {
             String source = Files.readString(sourcePath, StandardCharsets.UTF_8);
             List<String> imports = imports(source);
@@ -97,11 +118,70 @@ final class McpCaptureCodeBlockService {
             } else {
                 blocks.add(manualMappingWarningBlock());
             }
+            if (targetSource != null || (insertAfter != null && !insertAfter.isBlank())) {
+                blocks.addAll(targetInsertionBlocks(sourcePath, targetSource, insertAfter, driver));
+            }
             blocks.add(agentIntegrationBlock());
             return List.copyOf(blocks);
         } catch (IOException exception) {
             throw new IllegalArgumentException("Generated Capture source could not be read.", exception);
         }
+    }
+
+    private static List<McpCodeBlock> targetInsertionBlocks(
+            Path sourcePath,
+            Path targetSource,
+            String insertAfter,
+            String driver) {
+        CaptureTargetInsertionPlan plan = new CaptureTargetInsertionPlanner()
+                .plan(sourcePath, targetSource, insertAfter, driver);
+        List<McpCodeBlock> blocks = new ArrayList<>();
+        if (!plan.locatorFields().isBlank()) {
+            blocks.add(new McpCodeBlock(
+                    "capture-target-locator-fields",
+                    "Record-at-target locator fields",
+                    McpCodeBlock.Kind.LOCATOR,
+                    "java",
+                    plan.imports(),
+                    plan.locatorFields(),
+                    "Paste into " + plan.targetSource().getFileName()
+                            + " near the existing locator fields before adding the action snippet.",
+                    plan.anchorFound(),
+                    List.of(),
+                    plan.warnings()));
+        }
+        if (!plan.actionSnippet().isBlank()) {
+            blocks.add(new McpCodeBlock(
+                    "capture-target-action-snippet",
+                    "Record-at-target action snippet",
+                    McpCodeBlock.Kind.ACTION,
+                    "java",
+                    List.of(),
+                    plan.actionSnippet(),
+                    plan.placement(),
+                    plan.anchorFound(),
+                    List.of(),
+                    plan.warnings()));
+        }
+        blocks.add(new McpCodeBlock(
+                "capture-target-insertion-guide",
+                "Record-at-target insertion guide",
+                McpCodeBlock.Kind.PROVIDER_ADVISORY,
+                "text",
+                List.of(),
+                """
+                        record-at-target insertion map
+                        Target source: %s
+                        Insert after: %s
+                        Add imports and locator fields from capture-target-locator-fields when the target class does not already define them.
+                        Paste capture-target-action-snippet at the anchor, then adapt helper/data calls to local suite conventions.
+                        No source file was edited by this workflow.
+                        """.formatted(plan.targetSource(), plan.insertAfter()),
+                "Use these blocks as an approved edit plan for the selected source target.",
+                plan.anchorFound(),
+                List.of(),
+                plan.warnings()));
+        return blocks;
     }
 
     private static McpCodeBlock agentIntegrationBlock() {

--- a/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java
@@ -68,6 +68,50 @@ class CaptureServiceTest {
     }
 
     @Test
+    void recordAtTargetCodeBlocksReturnFocusedInsertionBlocksInsideWorkspace() throws Exception {
+        Path session = temp.resolve("capture.json");
+        new CaptureJsonCodec().write(session, reviewWarningSession());
+        Path target = temp.resolve("CheckoutTest.java");
+        Files.writeString(target, """
+                package tests;
+
+                import com.shaft.driver.SHAFT;
+
+                public class CheckoutTest {
+                    private SHAFT.GUI.WebDriver browser;
+
+                    public void replayCheckout() {
+                        browser.browser().navigateToURL("https://example.test");
+                    }
+                }
+                """);
+
+        CaptureService service = service();
+        McpCaptureReplayResult result;
+        try {
+            result = service.recordAtTargetCodeBlocks(
+                    session.toString(),
+                    temp.resolve("generated-target").toString(),
+                    "generated.capture",
+                    "GoldenSessionTest",
+                    false,
+                    target.toString(),
+                    "replayCheckout",
+                    "browser");
+        } finally {
+            service.close();
+        }
+
+        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertTrue(result.codeBlocks().stream()
+                .anyMatch(block -> block.id().equals("capture-target-insertion-guide")
+                        && block.code().contains("record-at-target")));
+        assertTrue(result.codeBlocks().stream()
+                .anyMatch(block -> block.id().equals("capture-target-action-snippet")
+                        && block.placement().contains("after replayCheckout")));
+    }
+
+    @Test
     void playwrightCodeBlocksToolGeneratesPlaywrightPomGuidanceInsideWorkspace() throws Exception {
         Path session = temp.resolve("capture.json");
         Files.copy(repositoryRoot().resolve(

--- a/shaft-mcp/src/test/java/com/shaft/mcp/McpCaptureCodeBlockServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/McpCaptureCodeBlockServiceTest.java
@@ -75,6 +75,62 @@ class McpCaptureCodeBlockServiceTest {
     }
 
     @Test
+    void fromGeneratedSourceAddsRecordAtTargetBlocksWhenTargetIsProvided() throws Exception {
+        Path source = writeSource("""
+                package generated.capture;
+
+                import com.shaft.driver.SHAFT;
+                import org.openqa.selenium.By;
+                import org.testng.annotations.Test;
+
+                public class LoginReplayTest {
+                    private static final By USERNAME_INPUT_LOCATOR = SHAFT.GUI.Locator.inputField("Username");
+
+                    private SHAFT.GUI.WebDriver driver;
+
+                    @Test
+                    public void replayLogin() {
+                        driver.element().click(USERNAME_INPUT_LOCATOR);
+                        driver.element().type(USERNAME_INPUT_LOCATOR, requiredData("username"));
+                    }
+                }
+                """);
+        Path target = temp.resolve("CheckoutTest.java");
+        Files.writeString(target, """
+                package tests;
+
+                import com.shaft.driver.SHAFT;
+
+                public class CheckoutTest {
+                    private SHAFT.GUI.WebDriver browser;
+
+                    public void replayCheckout() {
+                        browser.browser().navigateToURL("https://example.test");
+                    }
+                }
+                """);
+
+        List<McpCodeBlock> blocks = new McpCaptureCodeBlockService()
+                .fromGeneratedSource(source, "browser", null, target, "replayCheckout");
+
+        McpCodeBlock locators = block(blocks, "capture-target-locator-fields");
+        assertEquals(McpCodeBlock.Kind.LOCATOR, locators.kind());
+        assertTrue(locators.code().contains("private static final By USERNAME_INPUT_LOCATOR"));
+        assertTrue(locators.placement().contains("CheckoutTest.java"));
+
+        McpCodeBlock actions = block(blocks, "capture-target-action-snippet");
+        assertEquals(McpCodeBlock.Kind.ACTION, actions.kind());
+        assertTrue(actions.code().contains("browser.element().click(USERNAME_INPUT_LOCATOR);"));
+        assertTrue(actions.code().contains("browser.element().type(USERNAME_INPUT_LOCATOR, requiredData(\"username\"));"));
+        assertTrue(actions.placement().contains("after replayCheckout"));
+        assertTrue(actions.warnings().isEmpty(), actions.warnings().toString());
+
+        McpCodeBlock guide = block(blocks, "capture-target-insertion-guide");
+        assertTrue(guide.code().contains("record-at-target"));
+        assertTrue(guide.code().contains("CheckoutTest.java"));
+    }
+
+    @Test
     void fromGeneratedSourceUsesPlaywrightDriverTypeInPomGuidance() throws Exception {
         Path source = writeSource("""
                 package generated.capture;


### PR DESCRIPTION
## Summary
- Add a shared Capture record-at-target planner that extracts locator fields, imports, action snippets, placement guidance, and anchor warnings without editing the target file.
- Expose the workflow through `capture generate --target-source ... --insert-after ...` and MCP `capture_record_at_target_code_blocks`.
- Refresh graphify metadata.

## Examples
```bash
capture generate --session recordings/checkout.json \
  --output-dir generated-tests \
  --target-source src/test/java/com/acme/CheckoutTest.java \
  --insert-after replayCheckout \
  --driver-variable browser
```

```json
{
  "tool": "capture_record_at_target_code_blocks",
  "arguments": {
    "sessionPath": "recordings/checkout.json",
    "outputDirectory": "generated-tests",
    "packageName": "generated.capture",
    "className": "CheckoutReplayTest",
    "overwrite": false,
    "targetSourcePath": "src/test/java/com/acme/CheckoutTest.java",
    "insertAfter": "replayCheckout",
    "driverVariableName": "browser"
  }
}
```

## Validation
- `mvn -pl shaft-mcp -am '-Dtest=com.shaft.mcp.McpCaptureCodeBlockServiceTest,com.shaft.mcp.CaptureServiceTest' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test`
- `mvn -pl shaft-capture '-Dtest=com.shaft.capture.cli.CaptureCliTest' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test`
- `mvn -pl shaft-mcp -am '-DskipTests' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' package`
- `graphify update .`

Docs PR: https://github.com/ShaftHQ/shafthq.github.io/pull/650

Closes #3110