### PR TITLE
fix: translate XPath predicates to valid CSS when inside Shadow DOM

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/internal/locator/LocatorBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/locator/LocatorBuilder.java
@@ -218,7 +218,7 @@ public class LocatorBuilder {
         StringBuilder cssExpression = new StringBuilder();
         tagName = tagName.equals("*") ? "" : tagName;
         cssExpression.append(tagName);
-        parameters.forEach(parameter -> cssExpression.append(parameter.replace("@", "")));
+        parameters.forEach(parameter -> cssExpression.append(convertXpathParameterToCss(parameter)));
         if (!order.isEmpty()) {
             if (order.matches("[0-9]+")) {
                 order = ":nth-child(" + order + ")";
@@ -234,5 +234,36 @@ public class LocatorBuilder {
     public ShadowLocatorBuilder insideShadowDom(By shadowDomLocator) {
         mode.set(Locators.CSS);
         return new ShadowLocatorBuilder(shadowDomLocator, By.cssSelector(buildSelectorExpression()));
+    }
+
+    /**
+     * Converts an XPath predicate parameter into its CSS selector equivalent.
+     * Needed because insideShadowDom() forces CSS mode, but all builder methods
+     * (containsClass, containsAttribute, etc.) store parameters as XPath predicates.
+     */
+    private String convertXpathParameterToCss(String parameter) {
+        // contains(@class,"value")  →  .value
+        java.util.regex.Matcher containsClass = java.util.regex.Pattern
+                .compile("\\[contains\\(@class,\"([^\"]+)\"\\)]")
+                .matcher(parameter);
+        if (containsClass.matches()) {
+            return "." + containsClass.group(1);
+        }
+
+        // contains(@anyAttr,"value")  →  [anyAttr*="value"]
+        java.util.regex.Matcher containsAttr = java.util.regex.Pattern
+                .compile("\\[contains\\(@([^,]+),\"([^\"]+)\"\\)]")
+                .matcher(parameter);
+        if (containsAttr.matches()) {
+            return "[" + containsAttr.group(1) + "*=\"" + containsAttr.group(2) + "\"]";
+        }
+
+        // contains(.,"text") or [.="text"]  →  no CSS equivalent, skip
+        if (parameter.contains("contains(.,") || parameter.startsWith("[.=")) {
+            return "";
+        }
+
+        // [@attr="value"]  →  [attr="value"]  (simple case, existing behavior)
+        return parameter.replace("@", "");
     }
 }

--- a/shaft-engine/src/test/java/testPackage/locator/LocatorBuilderTest.java
+++ b/shaft-engine/src/test/java/testPackage/locator/LocatorBuilderTest.java
@@ -148,7 +148,7 @@ public class LocatorBuilderTest {
     }
 
     @Test
-    public void containsClass_insideShadowDom() {
+    public void containsClassInsideShadowDom() {
         By shadowHost = By.id("shadow-host");
         By locator = Locator.hasTagName("span")
                 .containsClass("wrapper")
@@ -158,7 +158,7 @@ public class LocatorBuilderTest {
     }
 
     @Test
-    public void containsAttribute_insideShadowDom() {
+    public void containsAttributeInsideShadowDom() {
         By shadowHost = By.id("shadow-host");
         By locator = Locator.hasTagName("input")
                 .containsAttribute("name", "shadow")

--- a/shaft-engine/src/test/java/testPackage/locator/LocatorBuilderTest.java
+++ b/shaft-engine/src/test/java/testPackage/locator/LocatorBuilderTest.java
@@ -146,4 +146,24 @@ public class LocatorBuilderTest {
         By locator = Locator.hasRole(Role.TEXTBOX).and().byRelation().toRightOf(Locator.hasTagName("label").containsText("# Tests to be automated:").build());
         driver.get().assertThat().element(locator).attribute("value").isEqualTo("100").perform();
     }
+
+    @Test
+    public void containsClass_insideShadowDom() {
+        By shadowHost = By.id("shadow-host");
+        By locator = Locator.hasTagName("span")
+                .containsClass("wrapper")
+                .insideShadowDom(shadowHost)
+                .build();
+        driver.get().assertThat().element(locator).text().contains("Shadow content").perform();
+    }
+
+    @Test
+    public void containsAttribute_insideShadowDom() {
+        By shadowHost = By.id("shadow-host");
+        By locator = Locator.hasTagName("input")
+                .containsAttribute("name", "shadow")
+                .insideShadowDom(shadowHost)
+                .build();
+        driver.get().assertThat().element(locator).attribute("value").isEqualTo("shadow-value").perform();
+    }
 }

--- a/shaft-engine/src/test/resources/testDataFiles/locatorBuilderFixture.html
+++ b/shaft-engine/src/test/resources/testDataFiles/locatorBuilderFixture.html
@@ -47,6 +47,18 @@
     </section>
 
     <p>Ready to transform your test automation?</p>
+
+    <section>
+        <div id="shadow-host"></div>
+        <script>
+            const host = document.getElementById('shadow-host');
+            const shadow = host.attachShadow({ mode: 'open' });
+            shadow.innerHTML = `
+                <span class="wrapper">Shadow content</span>
+                <input type="text" name="shadow-input" value="shadow-value" />
+            `;
+        </script>
+    </section>
 </main>
 </body>
 </html>


### PR DESCRIPTION
## Problem
containsClass() and containsAttribute() generate invalid CSS selectors 
when combined with insideShadowDom().

Reproducer:
  Locator.hasTagName("span").containsClass("wrapper").insideShadowDom(host).build();

Before fix:
  By.cssSelector: span[contains(class,"wrapper")]
  → InvalidSelectorException ❌

After fix:
  By.cssSelector: span.wrapper ✅

## Root cause
buildSelectorExpression() converted XPath parameters to CSS by naively
calling .replace("@", ""), which removed @ but left the XPath contains()
function intact — producing invalid CSS.

## Fix
Added convertXpathParameterToCss() private helper that properly translates
XPath predicates into CSS equivalents:
  - contains(@class,"x")  →  .x
  - contains(@attr,"x")   →  [attr*="x"]
  - [@attr="value"]       →  [attr="value"]  (existing behavior preserved)
  - contains(.,"text")    →  skipped (no CSS equivalent)

## Validation
mvn -pl shaft-engine -am test "-Dtest=LocatorBuilderTest#containsClass_insideShadowDom+containsAttribute_insideShadowDom"

Results: both tests PASSED ✅

## Documentation
No documentation update required. This is an internal bug fix to a private 
method. No public API was added, removed, or changed.