### PR TITLE
[codex] Improve click and type actions

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/driver/ElementActionsContract.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/driver/ElementActionsContract.java
@@ -1,5 +1,7 @@
 package com.shaft.gui.driver;
 
+import com.google.common.annotations.Beta;
+import com.shaft.gui.internal.locator.SmartLocators;
 import org.openqa.selenium.By;
 
 import java.util.List;
@@ -33,6 +35,17 @@ public interface ElementActionsContract {
     ElementActionsContract executeNativeMobileCommand(String command, Map<String, String> parameters);
 
     ElementActionsContract click(By elementLocator);
+
+    /**
+     * Clicks a clickable element resolved by visible text, label, or accessible name.
+     *
+     * @param elementName the visible text, label, or accessible name of the target element
+     * @return a self-reference to be used to chain actions
+     */
+    @Beta
+    default ElementActionsContract click(String elementName) {
+        return click(SmartLocators.clickableField(elementName));
+    }
 
     default ElementActionsContract click(ShaftLocator elementLocator) {
         return click(elementLocator.toBy());
@@ -120,6 +133,18 @@ public interface ElementActionsContract {
     String getCurrentFrame();
 
     ElementActionsContract type(By elementLocator, CharSequence... text);
+
+    /**
+     * Types into an input resolved by visible label, placeholder, or accessible name.
+     *
+     * @param elementName the visible label, placeholder, or accessible name of the target input
+     * @param text        one or more character sequences to type
+     * @return a self-reference to be used to chain actions
+     */
+    @Beta
+    default ElementActionsContract type(String elementName, CharSequence... text) {
+        return type(SmartLocators.inputField(elementName), text);
+    }
 
     default ElementActionsContract type(ShaftLocator elementLocator, CharSequence... text) {
         return type(elementLocator.toBy(), text);

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -638,7 +638,7 @@ public class Actions extends ElementActions {
                                 ((JavascriptExecutor) d).executeScript("arguments[0].click();", targetElement);
                                 ReportManager.logDiscrete("Performed Click using JavaScript; If the report is showing that the click passed but you observe that no action was taken, we recommend trying a different element locator.");
                             } else {
-                                // InvalidElementStateException is normally retryable for visibility-aware waits;
+                                // These exceptions are normally retryable for visibility-aware waits;
                                 // when JavaScript fallback is disabled, report the native click failure immediately
                                 // so the original Selenium exception is not replaced by a FluentWait timeout.
                                 throw exception;
@@ -687,14 +687,37 @@ public class Actions extends ElementActions {
                         }
                     }
                     case TYPE, TYPE_SECURELY -> {
-                        executeClearBasedOnClearMode(foundElements.get().getFirst(), SHAFT.Properties.flags.clearBeforeTypingMode());
-                        foundElements.get().getFirst().sendKeys((CharSequence[]) data);
+                        WebElement targetElement = foundElements.get().getFirst();
+                        CharSequence[] text = (CharSequence[]) data;
+                        String clearMode = SHAFT.Properties.flags.clearBeforeTypingMode();
+                        String typedText = stringifyTypedValue(text);
+                        boolean shouldValidateTypedText = shouldValidateTypedText(text);
+                        String expectedText = shouldValidateTypedText && "off".equals(clearMode)
+                                ? readElementValueForTyping(targetElement) + typedText
+                                : typedText;
+                        if (SHAFT.Properties.flags.attemptToClickBeforeTyping() && !"native".equals(clearMode)) {
+                            targetElement.click();
+                        }
+                        executeClearBasedOnClearMode(targetElement, clearMode);
+                        targetElement.sendKeys(text);
+                        validateTypedTextIfConfigured(targetElement, action, expectedText, shouldValidateTypedText);
                     }
                     case TYPE_APPEND -> {
-                        foundElements.get().getFirst().sendKeys((CharSequence[]) data);
+                        WebElement targetElement = foundElements.get().getFirst();
+                        CharSequence[] text = (CharSequence[]) data;
+                        boolean shouldValidateTypedText = shouldValidateTypedText(text);
+                        String expectedText = shouldValidateTypedText
+                                ? readElementValueForTyping(targetElement) + stringifyTypedValue(text)
+                                : "";
+                        targetElement.sendKeys(text);
+                        validateTypedTextIfConfigured(targetElement, action, expectedText, shouldValidateTypedText);
                     }
                     case JAVASCRIPT_SET_VALUE ->
-                            ((JavascriptExecutor) d).executeScript("arguments[0].value = arguments[1];", foundElements.get().getFirst(), data);
+                            ((JavascriptExecutor) d).executeScript("""
+                                    arguments[0].value = arguments[1];
+                                    arguments[0].dispatchEvent(new Event('input', {bubbles: true}));
+                                    arguments[0].dispatchEvent(new Event('change', {bubbles: true}));
+                                    """, foundElements.get().getFirst(), data);
                     case CLEAR -> {
                         executeClearBasedOnClearMode(foundElements.get().getFirst(), "native");
                         if (!"".equals(foundElements.get().getFirst().getDomProperty("value")))
@@ -1059,6 +1082,49 @@ public class Actions extends ElementActions {
             return text;
         text = element.getDomProperty("innerHTML");
         if (text != null && !text.isEmpty() && !text.contains("<"))
+            return text;
+        return "";
+    }
+
+    private void validateTypedTextIfConfigured(WebElement element, ActionType action, String expectedText, boolean shouldValidateTypedText) {
+        if (!SHAFT.Properties.flags.forceCheckTextWasTypedCorrectly() || !shouldValidateTypedText) {
+            return;
+        }
+        String actualText = readElementValueForTyping(element);
+        if (!expectedText.equals(actualText)) {
+            boolean secure = ActionType.TYPE_SECURELY.equals(action);
+            throw new IllegalStateException("Expected typed text \""
+                    + (secure ? MASKED_TYPED_VALUE : expectedText)
+                    + "\" but found \""
+                    + (secure ? MASKED_TYPED_VALUE : actualText)
+                    + "\".");
+        }
+    }
+
+    private static boolean shouldValidateTypedText(CharSequence[] text) {
+        return !stringifyTypedValue(text).chars().anyMatch(character -> character >= 0xE000 && character <= 0xF8FF);
+    }
+
+    private static String stringifyTypedValue(CharSequence[] text) {
+        if (text == null) {
+            return "";
+        }
+        StringBuilder value = new StringBuilder();
+        for (CharSequence sequence : text) {
+            value.append(sequence == null ? "" : sequence);
+        }
+        return value.toString();
+    }
+
+    private String readElementValueForTyping(WebElement element) {
+        String text = element.getDomProperty("value");
+        if (text != null && !text.isEmpty())
+            return text;
+        text = element.getDomProperty("textContent");
+        if (text != null && !text.isEmpty())
+            return text;
+        text = element.getText();
+        if (text != null && !text.isEmpty())
             return text;
         return "";
     }

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java
@@ -562,24 +562,16 @@ public class ElementActionsHelper {
      * @return {@code true} when the element is clickable; otherwise {@code false}
      */
     public boolean waitForElementToBeClickable(WebDriver driver, By elementLocator, String actionToExecute) {
-        SHAFT.Properties.flags.clickUsingJavascriptWhenWebDriverClickFails();
-
         if (!DriverFactoryHelper.isMobileNativeExecution()) {
             try {
-                new SynchronizationManager(driver).fluentWait(false)
-                        .until(f -> {
-                            WebElement targetElement = safeFindElement(driver, elementLocator);
-                            return targetElement.isDisplayed() && targetElement.isEnabled();
-                        });
-
                 return new SynchronizationManager(driver).fluentWait(true)
                         .until(f -> {
-                            if (!actionToExecute.isEmpty()) {
-                                if (actionToExecute.equalsIgnoreCase("ClickAndHold")) {
-                                    (new Actions(driver)).clickAndHold(((WebElement) this.identifyUniqueElement(driver, elementLocator).get(1))).build().perform();
-                                }
+                            WebElement targetElement = safeFindElement(driver, elementLocator);
+                            boolean clickable = targetElement.isDisplayed() && targetElement.isEnabled();
+                            if (clickable && "ClickAndHold".equalsIgnoreCase(actionToExecute)) {
+                                (new Actions(driver)).clickAndHold(targetElement).build().perform();
                             }
-                            return true;
+                            return clickable;
                         });
             } catch (org.openqa.selenium.TimeoutException e) {
                 ReportManagerHelper.logDiscrete(e);

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/element/ElementActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/element/ElementActions.java
@@ -2,8 +2,11 @@ package com.shaft.gui.playwright.element;
 
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.options.BoundingBox;
+import com.google.common.annotations.Beta;
 import com.shaft.gui.driver.ElementAssertions;
 import com.shaft.gui.driver.ShaftLocator;
+import com.shaft.gui.internal.locator.CompositeLocator;
+import com.shaft.gui.internal.locator.SmartLocators;
 import com.shaft.gui.playwright.internal.PlaywrightSession;
 import com.shaft.gui.playwright.validation.PlaywrightElementValidationsBuilder;
 import com.shaft.tools.io.ReportManager;
@@ -90,6 +93,18 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     @Override
     public ElementActions click(ShaftLocator elementLocator) {
         return click(resolve(elementLocator));
+    }
+
+    /**
+     * Clicks a clickable element resolved by visible text, label, or accessible name.
+     *
+     * @param elementName the visible text, label, or accessible name of the target element
+     * @return a self-reference to be used to chain actions
+     */
+    @Beta
+    @Override
+    public ElementActions click(String elementName) {
+        return click(SmartLocators.clickableField(elementName));
     }
 
     public ElementActions click(Locator elementLocator) {
@@ -296,6 +311,19 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
         return type(resolve(elementLocator), text);
     }
 
+    /**
+     * Types into an input resolved by visible label, placeholder, or accessible name.
+     *
+     * @param elementName the visible label, placeholder, or accessible name of the target input
+     * @param text        one or more character sequences to type
+     * @return a self-reference to be used to chain actions
+     */
+    @Beta
+    @Override
+    public ElementActions type(String elementName, CharSequence... text) {
+        return type(SmartLocators.inputField(elementName), text);
+    }
+
     public ElementActions type(Locator elementLocator, CharSequence... text) {
         return timed("playwright.element.type", () -> elementLocator.fill(join(text)));
     }
@@ -325,7 +353,8 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     public ElementActions typeAppend(Locator elementLocator, CharSequence... text) {
-        return timed("playwright.element.typeAppend", () -> elementLocator.pressSequentially(join(text)));
+        return timed("playwright.element.typeAppend",
+                () -> elementLocator.fill(readTextForAppend(elementLocator) + join(text)));
     }
 
     @Override
@@ -412,11 +441,41 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
     }
 
     private Locator resolve(By locator) {
+        if (locator instanceof CompositeLocator compositeLocator) {
+            return resolve(compositeLocator, locator);
+        }
         return ShaftLocator.from(locator).toPlaywrightLocator(session.page());
+    }
+
+    private Locator resolve(CompositeLocator compositeLocator, By originalLocator) {
+        for (By alternative : compositeLocator.alternatives()) {
+            try {
+                Locator candidate = ShaftLocator.from(alternative).toPlaywrightLocator(session.page());
+                if (candidate.count() == 1) {
+                    return candidate;
+                }
+            } catch (RuntimeException ignored) {
+                // Unsupported or non-unique alternatives do not make later portable candidates invalid.
+            }
+        }
+        throw new IllegalArgumentException("No unique Playwright element matched locator: " + originalLocator);
     }
 
     private Locator resolve(ShaftLocator locator) {
         return locator.toPlaywrightLocator(session.page());
+    }
+
+    private String readTextForAppend(Locator locator) {
+        try {
+            String value = locator.inputValue();
+            if (value != null) {
+                return value;
+            }
+        } catch (RuntimeException ignored) {
+            // Non-input elements do not expose inputValue; append to text content instead.
+        }
+        String text = locator.textContent();
+        return text == null ? "" : text;
     }
 
     private String join(CharSequence... text) {

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
@@ -24,8 +24,10 @@ import io.qameta.allure.model.Status;
 import io.qameta.allure.model.StatusDetails;
 import org.apache.logging.log4j.Level;
 import org.openqa.selenium.By;
+import org.openqa.selenium.ElementClickInterceptedException;
 import org.openqa.selenium.InvalidElementStateException;
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.Rectangle;
@@ -38,6 +40,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Sequence;
 import org.openqa.selenium.remote.RemoteWebElement;
 import org.openqa.selenium.support.ui.FluentWait;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.testng.Assert;
@@ -77,6 +80,8 @@ public class ActionsCoverageUnitTest {
         SHAFT.Properties.flags.set().forceCheckElementLocatorIsUnique(false);
         SHAFT.Properties.flags.set().scrollingMode("legacy");
         SHAFT.Properties.flags.set().clearBeforeTypingMode("off");
+        SHAFT.Properties.flags.set().forceCheckTextWasTypedCorrectly(false);
+        SHAFT.Properties.flags.set().attemptToClickBeforeTyping(false);
         SHAFT.Properties.flags.set().clickUsingJavascriptWhenWebDriverClickFails(true);
         SHAFT.Properties.visuals.set().createAnimatedGif(false);
         SHAFT.Properties.visuals.set().screenshotParamsWhenToTakeAScreenshot("ValidationPointsOnly");
@@ -332,6 +337,120 @@ public class ActionsCoverageUnitTest {
     }
 
     @Test
+    public void typingShouldClickBeforeTypingWhenConfigured() {
+        SHAFT.Properties.flags.set()
+                .attemptToClickBeforeTyping(true)
+                .clearBeforeTypingMode("off");
+        WebDriver driver = mock(WebDriver.class, org.mockito.Mockito.withSettings().extraInterfaces(JavascriptExecutor.class));
+        WebElement element = standardElement();
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+        when(((JavascriptExecutor) driver).executeScript(anyString(), any(Object[].class))).thenReturn(null);
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).type(LOCATOR, "typed");
+
+            verify(element).click();
+        }
+    }
+
+    @Test
+    public void typingShouldFailWhenConfiguredTypedTextDoesNotMatchElementValue() {
+        SHAFT.Properties.flags.set()
+                .forceCheckTextWasTypedCorrectly(true)
+                .clearBeforeTypingMode("off");
+        WebDriver driver = mock(WebDriver.class, org.mockito.Mockito.withSettings().extraInterfaces(JavascriptExecutor.class, TakesScreenshot.class));
+        WebElement element = standardElement();
+        when(element.getDomProperty("value")).thenReturn("wrong value");
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+        when(((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES)).thenReturn(PNG);
+        when(((JavascriptExecutor) driver).executeScript(anyString(), any(Object[].class))).thenReturn(null);
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            RuntimeException exception = Assert.expectThrows(RuntimeException.class,
+                    () -> new Actions(helperFor(driver)).type(LOCATOR, "expected value"));
+
+            Assert.assertTrue(exception.getMessage().contains("Expected typed text"));
+            Assert.assertTrue(exception.getMessage().contains("expected value"));
+        }
+    }
+
+    @Test
+    public void appendTypingShouldValidateFinalElementValueWhenConfigured() {
+        SHAFT.Properties.flags.set().forceCheckTextWasTypedCorrectly(true);
+        WebDriver driver = mock(WebDriver.class, org.mockito.Mockito.withSettings().extraInterfaces(JavascriptExecutor.class));
+        WebElement element = standardElement();
+        when(element.getDomProperty("value")).thenReturn("prefix", "prefix-suffix");
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+        when(((JavascriptExecutor) driver).executeScript(anyString(), any(Object[].class))).thenReturn(null);
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).typeAppend(LOCATOR, "-suffix");
+
+            verify(element).sendKeys(new CharSequence[]{"-suffix"});
+        }
+    }
+
+    @Test
+    public void secureTypingShouldMaskFailedTypedTextVerification() {
+        SHAFT.Properties.flags.set()
+                .forceCheckTextWasTypedCorrectly(true)
+                .clearBeforeTypingMode("off");
+        WebDriver driver = mock(WebDriver.class, org.mockito.Mockito.withSettings().extraInterfaces(JavascriptExecutor.class, TakesScreenshot.class));
+        WebElement element = standardElement();
+        when(element.getDomProperty("value")).thenReturn("wrong value");
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+        when(((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES)).thenReturn(PNG);
+        when(((JavascriptExecutor) driver).executeScript(anyString(), any(Object[].class))).thenReturn(null);
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            RuntimeException exception = Assert.expectThrows(RuntimeException.class,
+                    () -> new Actions(helperFor(driver)).typeSecure(LOCATOR, "secret-value"));
+
+            Assert.assertTrue(exception.getMessage().contains("********"));
+            Assert.assertFalse(exception.getMessage().contains("secret-value"));
+        }
+    }
+
+    @Test
+    public void typingValidationShouldSkipSpecialKeys() {
+        SHAFT.Properties.flags.set()
+                .forceCheckTextWasTypedCorrectly(true)
+                .clearBeforeTypingMode("off");
+        WebDriver driver = mock(WebDriver.class, org.mockito.Mockito.withSettings().extraInterfaces(JavascriptExecutor.class));
+        WebElement element = standardElement();
+        when(element.getDomProperty("value")).thenReturn("unchanged");
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+        when(((JavascriptExecutor) driver).executeScript(anyString(), any(Object[].class))).thenReturn(null);
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).type(LOCATOR, Keys.ENTER);
+
+            verify(element).sendKeys(new CharSequence[]{Keys.ENTER});
+        }
+    }
+
+    @Test
+    public void setValueUsingJavascriptShouldDispatchInputAndChangeEvents() {
+        WebDriver driver = mock(WebDriver.class, org.mockito.Mockito.withSettings().extraInterfaces(JavascriptExecutor.class));
+        WebElement element = standardElement();
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+        when(((JavascriptExecutor) driver).executeScript(anyString(), any(Object[].class))).thenReturn(null);
+        ArgumentCaptor<String> scripts = ArgumentCaptor.forClass(String.class);
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helperFor(driver)).setValueUsingJavaScript(LOCATOR, "js value");
+
+            verify((JavascriptExecutor) driver, atLeastOnce()).executeScript(scripts.capture(), any(Object[].class));
+            String setValueScript = scripts.getAllValues().stream()
+                    .filter(script -> script.contains("arguments[0].value"))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("Missing JavaScript value assignment"));
+            Assert.assertTrue(setValueScript.contains("dispatchEvent(new Event('input'"));
+            Assert.assertTrue(setValueScript.contains("dispatchEvent(new Event('change'"));
+        }
+    }
+
+    @Test
     public void smartLocatorWrappersShouldDelegateToSmartLocators() {
         WebDriver driver = mock(WebDriver.class);
         try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
@@ -573,6 +692,23 @@ public class ActionsCoverageUnitTest {
         WebDriver driver = mock(WebDriver.class, org.mockito.Mockito.withSettings().extraInterfaces(JavascriptExecutor.class, TakesScreenshot.class));
         WebElement element = standardElement();
         doThrow(new InvalidElementStateException("native click blocked")).when(element).click();
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+        when(((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES)).thenReturn(PNG);
+        DriverFactoryHelper helper = helperFor(driver);
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            new Actions(helper).click(LOCATOR);
+            verify((JavascriptExecutor) driver).executeScript(eq("arguments[0].click();"), eq(element));
+        }
+    }
+
+    @Test
+    public void performActionShouldFallbackToJavascriptClickWhenWebDriverClickIsIntercepted() {
+        SHAFT.Properties.flags.set().clickUsingJavascriptWhenWebDriverClickFails(true);
+        SHAFT.Properties.timeouts.set().defaultElementIdentificationTimeout(1);
+        WebDriver driver = mock(WebDriver.class, org.mockito.Mockito.withSettings().extraInterfaces(JavascriptExecutor.class, TakesScreenshot.class));
+        WebElement element = standardElement();
+        doThrow(new ElementClickInterceptedException("native click intercepted")).when(element).click();
         when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
         when(((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES)).thenReturn(PNG);
         DriverFactoryHelper helper = helperFor(driver);

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/ElementsHelperCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/ElementsHelperCoverageUnitTest.java
@@ -205,6 +205,18 @@ public class ElementsHelperCoverageUnitTest {
     }
 
     @Test
+    public void waitForElementToBeClickableShouldUseOneWaitCycle() {
+        try (MockedStatic<DriverFactoryHelper> driverFactoryHelper = Mockito.mockStatic(DriverFactoryHelper.class);
+             MockedConstruction<SynchronizationManager> synchronizationManagers = mockSynchronizationManagerApplyingCondition()) {
+            driverFactoryHelper.when(DriverFactoryHelper::isMobileNativeExecution).thenReturn(false);
+
+            Assert.assertTrue(helper.waitForElementToBeClickable(driver, locator, ""));
+
+            Assert.assertEquals(synchronizationManagers.constructed().size(), 1);
+        }
+    }
+
+    @Test
     public void waitForElementToBeClickableShouldReturnFalseOnTimeout() {
         try (MockedStatic<DriverFactoryHelper> driverFactoryHelper = Mockito.mockStatic(DriverFactoryHelper.class);
              MockedConstruction<SynchronizationManager> ignored = mockSynchronizationManagerThrowing(new TimeoutException("not clickable"))) {

--- a/shaft-engine/src/test/java/com/shaft/gui/playwright/element/PlaywrightElementActionsUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/playwright/element/PlaywrightElementActionsUnitTest.java
@@ -1,0 +1,96 @@
+package com.shaft.gui.playwright.element;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.shaft.gui.internal.locator.CompositeLocator;
+import com.shaft.gui.playwright.internal.PlaywrightSession;
+import org.openqa.selenium.By;
+import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Test(singleThreaded = true)
+public class PlaywrightElementActionsUnitTest {
+
+    @Test
+    public void smartClickAndTypeShouldResolveStringNames() {
+        PlaywrightSession session = mock(PlaywrightSession.class);
+        Page page = mock(Page.class);
+        Locator locator = mock(Locator.class);
+        when(session.page()).thenReturn(page);
+        when(page.locator(anyString())).thenReturn(locator);
+        when(locator.count()).thenReturn(1);
+
+        ElementActions actions = new ElementActions(session);
+
+        Assert.assertSame(actions.click("Save"), actions);
+        Assert.assertSame(actions.type("Email", "user@example.com"), actions);
+        verify(locator).click();
+        verify(locator).fill("user@example.com");
+    }
+
+    @Test
+    public void compositeLocatorShouldUseFirstUniqueConvertibleAlternative() {
+        PlaywrightSession session = mock(PlaywrightSession.class);
+        Page page = mock(Page.class);
+        Locator primary = mock(Locator.class);
+        Locator secondary = mock(Locator.class);
+        when(session.page()).thenReturn(page);
+        when(page.locator("[id=\"primary\"]")).thenReturn(primary);
+        when(page.locator("xpath=//button")).thenReturn(secondary);
+        when(primary.count()).thenReturn(2);
+        when(secondary.count()).thenReturn(1);
+
+        ElementActions actions = new ElementActions(session);
+
+        Assert.assertSame(actions.click(new TestCompositeLocator(By.id("primary"), By.xpath("//button"))), actions);
+        verify(primary, never()).click();
+        verify(secondary).click();
+    }
+
+    @Test
+    public void typeAppendShouldFillCurrentValueInOneOperation() {
+        PlaywrightSession session = mock(PlaywrightSession.class);
+        Locator locator = mock(Locator.class);
+        when(locator.inputValue()).thenReturn("frontend");
+
+        ElementActions actions = new ElementActions(session);
+
+        Assert.assertSame(actions.typeAppend(locator, " backend"), actions);
+        verify(locator).fill("frontend backend");
+        verify(locator, never()).pressSequentially(anyString());
+    }
+
+    private static final class TestCompositeLocator extends By implements CompositeLocator {
+        private final List<By> alternatives;
+
+        private TestCompositeLocator(By... alternatives) {
+            this.alternatives = List.of(alternatives);
+        }
+
+        @Override
+        public List<By> alternatives() {
+            return alternatives;
+        }
+
+        @Override
+        public List<WebElement> findElements(SearchContext context) {
+            return List.of();
+        }
+
+        @Override
+        public String toString() {
+            return "TestCompositeLocator";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Added beta `click(String)` and `type(String, CharSequence...)` convenience APIs for Smart Locator-backed WebDriver and Playwright element actions.
- Hardened WebDriver typing behavior with optional pre-type click, final typed-value verification, secure failure masking, special-key skip, JS input/change dispatch, and intercepted-click JavaScript fallback coverage.
- Improved Playwright parity with Smart Locator/composite locator resolution and optimized append typing via a single fill operation.

## User / Developer Impact
- Users can call `driver.element().click("Save")` and `driver.element().type("Email", "user@example.com")` without manually building locators.
- `forceCheckTextWasTypedCorrectly=true` now validates final WebDriver values after `type`, `typeSecure`, and `typeAppend` while avoiding false failures for Selenium special keys.
- Playwright composite locators now follow the first unique candidate pattern to avoid strict-mode ambiguity.

## Validation
- `mvn -pl shaft-engine '-Dtest=com.shaft.gui.element.internal.ActionsCoverageUnitTest,com.shaft.gui.element.internal.ElementsHelperCoverageUnitTest,com.shaft.gui.playwright.element.PlaywrightElementActionsUnitTest' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test`
- Confirmed Allure result files: 61 result JSON files, 61 passed statuses.
- `mvn -pl shaft-engine -am '-DskipTests' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test-compile`
- `graphify update .` run from a clean temporary worktree; no tracked graph output changes remained after refresh.

## Notes
- Documentation companion PR: ShaftHQ/shafthq.github.io#658