### PR TITLE
test: cover locator builder css and xpath modes

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/internal/locator/LocatorBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/locator/LocatorBuilder.java
@@ -225,7 +225,7 @@ public class LocatorBuilder {
             } else if (order.equals("last()")) {
                 order = ":last-child";
             }
-            return "(" + cssExpression + ")" + this.order;
+            return cssExpression + this.order;
         } else {
             return cssExpression.toString();
         }

--- a/shaft-engine/src/test/java/testPackage/locator/LocatorBuilderTest.java
+++ b/shaft-engine/src/test/java/testPackage/locator/LocatorBuilderTest.java
@@ -2,12 +2,17 @@ package testPackage.locator;
 
 import com.shaft.driver.SHAFT;
 import com.shaft.gui.internal.locator.Locator;
+import com.shaft.gui.internal.locator.LocatorBuilder;
 import com.shaft.gui.internal.locator.Role;
+import com.shaft.gui.internal.locator.ShadowLocatorBuilder;
 import org.openqa.selenium.By;
 import testPackage.TestPageServer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.function.Supplier;
 
 public class LocatorBuilderTest {
 
@@ -21,7 +26,75 @@ public class LocatorBuilderTest {
 
     @AfterMethod(alwaysRun = true)
     public void afterMethod() {
-        driver.get().quit();
+        if (driver.get() != null) {
+            driver.get().quit();
+            driver.remove();
+        }
+        LocatorBuilder.cleanup();
+        ShadowLocatorBuilder.cleanup();
+    }
+
+    @Test
+    public void xpathModeShouldResolveLocatorMethodsAgainstFixture() {
+        assertLocatorCases(List.of(
+                new LocatorCase("hasTagName", () -> Locator.hasTagName("article").build(), "data-locator-case", "tag-name"),
+                new LocatorCase("hasAnyTagName", () -> Locator.hasAnyTagName().hasAttribute("data-any-tag").build(), "data-locator-case", "any-tag"),
+                new LocatorCase("hasAttribute", () -> Locator.hasAnyTagName().hasAttribute("data-present").build(), "data-locator-case", "has-attribute"),
+                new LocatorCase("hasAttributeValue", () -> Locator.hasAnyTagName().hasAttribute("data-exact", "exact-value").build(), "data-locator-case", "has-attribute-value"),
+                new LocatorCase("containsAttribute", () -> Locator.hasAnyTagName().containsAttribute("data-partial", "needle").build(), "data-locator-case", "contains-attribute"),
+                new LocatorCase("hasId", () -> Locator.hasAnyTagName().hasId("exact-id-target").build(), "data-locator-case", "has-id"),
+                new LocatorCase("containsId", () -> Locator.hasAnyTagName().containsId("partial-id").build(), "data-locator-case", "contains-id"),
+                new LocatorCase("hasClass", () -> Locator.hasAnyTagName().hasClass("exact-class").build(), "data-locator-case", "has-class"),
+                new LocatorCase("containsClass", () -> Locator.hasAnyTagName().containsClass("partial-class").build(), "data-locator-case", "contains-class"),
+                new LocatorCase("hasText", () -> Locator.hasAnyTagName().hasText("Exact text target").build(), "data-locator-case", "has-text"),
+                new LocatorCase("containsText", () -> Locator.hasTagName("div").containsText("partial text target").build(), "data-locator-case", "contains-text"),
+                new LocatorCase("and", () -> Locator.hasAnyTagName().and().hasAttribute("data-and-target").build(), "data-locator-case", "and-method"),
+                new LocatorCase("hasIndex", () -> Locator.hasTagName("mark").hasIndex(2).build(), "data-locator-case", "second-index"),
+                new LocatorCase("isFirst", () -> Locator.hasTagName("mark").isFirst().build(), "data-locator-case", "first-index"),
+                new LocatorCase("isLast", () -> Locator.hasTagName("mark").isLast().build(), "data-locator-case", "last-index")
+        ));
+    }
+
+    @Test
+    public void cssModeShouldResolveLocatorMethodsInsideShadowDomAgainstFixture() {
+        By shadowHost = By.id("shadow-host");
+        assertLocatorCases(List.of(
+                new LocatorCase("hasTagName", () -> Locator.hasTagName("section").insideShadowDom(shadowHost).build(), "data-css-case", "tag-name"),
+                new LocatorCase("hasAnyTagName", () -> Locator.hasAnyTagName().hasAttribute("data-any-tag-shadow").insideShadowDom(shadowHost).build(), "data-css-case", "any-tag"),
+                new LocatorCase("hasAttribute", () -> Locator.hasAnyTagName().hasAttribute("data-present-shadow").insideShadowDom(shadowHost).build(), "data-css-case", "has-attribute"),
+                new LocatorCase("hasAttributeValue", () -> Locator.hasAnyTagName().hasAttribute("data-exact-shadow", "exact-value").insideShadowDom(shadowHost).build(), "data-css-case", "has-attribute-value"),
+                new LocatorCase("containsAttribute", () -> Locator.hasAnyTagName().containsAttribute("data-partial-shadow", "needle").insideShadowDom(shadowHost).build(), "data-css-case", "contains-attribute"),
+                new LocatorCase("hasId", () -> Locator.hasAnyTagName().hasId("shadow-exact-id-target").insideShadowDom(shadowHost).build(), "data-css-case", "has-id"),
+                new LocatorCase("containsId", () -> Locator.hasAnyTagName().containsId("partial-id").insideShadowDom(shadowHost).build(), "data-css-case", "contains-id"),
+                new LocatorCase("hasClass", () -> Locator.hasAnyTagName().hasClass("shadow-exact-class").insideShadowDom(shadowHost).build(), "data-css-case", "has-class"),
+                new LocatorCase("containsClass", () -> Locator.hasAnyTagName().containsClass("shadow-partial-class").insideShadowDom(shadowHost).build(), "data-css-case", "contains-class"),
+                new LocatorCase("hasText", () -> Locator.hasTagName("strong").hasText("Exact shadow text target").insideShadowDom(shadowHost).build(), "data-css-case", "has-text"),
+                new LocatorCase("containsText", () -> Locator.hasTagName("em").containsText("shadow partial text target").insideShadowDom(shadowHost).build(), "data-css-case", "contains-text"),
+                new LocatorCase("and", () -> Locator.hasTagName("u").and().hasAttribute("data-and-shadow").insideShadowDom(shadowHost).build(), "data-css-case", "and-method"),
+                new LocatorCase("hasIndex", () -> Locator.hasTagName("mark").hasIndex(2).insideShadowDom(shadowHost).build(), "data-css-case", "second-index"),
+                new LocatorCase("isFirst", () -> Locator.hasTagName("mark").isFirst().insideShadowDom(shadowHost).build(), "data-css-case", "first-index"),
+                new LocatorCase("isLast", () -> Locator.hasTagName("mark").isLast().insideShadowDom(shadowHost).build(), "data-css-case", "last-index")
+        ));
+    }
+
+    @Test
+    public void xpathModeShouldResolveAllRoleLocatorsAgainstFixture() {
+        assertLocatorCases(List.of(
+                new LocatorCase("roleButton", () -> Locator.hasRole(Role.BUTTON).and().hasAttribute("data-role-case", "button").build(), "data-role-case", "button"),
+                new LocatorCase("roleLink", () -> Locator.hasRole(Role.LINK).and().hasAttribute("data-role-case", "link").build(), "data-role-case", "link"),
+                new LocatorCase("roleTextbox", () -> Locator.hasRole(Role.TEXTBOX).and().hasAttribute("data-role-case", "textbox").build(), "data-role-case", "textbox"),
+                new LocatorCase("roleCheckbox", () -> Locator.hasRole(Role.CHECKBOX).and().hasAttribute("data-role-case", "checkbox").build(), "data-role-case", "checkbox"),
+                new LocatorCase("roleRadio", () -> Locator.hasRole(Role.RADIO).and().hasAttribute("data-role-case", "radio").build(), "data-role-case", "radio"),
+                new LocatorCase("roleCombobox", () -> Locator.hasRole(Role.COMBOBOX).and().hasAttribute("data-role-case", "combobox").build(), "data-role-case", "combobox"),
+                new LocatorCase("roleHeading", () -> Locator.hasRole(Role.HEADING).and().containsText("SHAFT").build(), "class", "hero__title"),
+                new LocatorCase("roleImage", () -> Locator.hasRole(Role.IMAGE).and().hasAttribute("data-role-case", "image").build(), "data-role-case", "image"),
+                new LocatorCase("roleList", () -> Locator.hasRole(Role.LIST).and().hasAttribute("data-role-case", "list").build(), "data-role-case", "list"),
+                new LocatorCase("roleListItem", () -> Locator.hasRole(Role.LISTITEM).and().hasAttribute("data-role-case", "listitem").build(), "data-role-case", "listitem"),
+                new LocatorCase("roleTable", () -> Locator.hasRole(Role.TABLE).and().hasAttribute("data-role-case", "table").build(), "data-role-case", "table"),
+                new LocatorCase("roleTableRow", () -> Locator.hasRole(Role.TABLE_ROW).and().hasAttribute("data-role-case", "table-row").build(), "data-role-case", "table-row"),
+                new LocatorCase("roleTableCell", () -> Locator.hasRole(Role.TABLE_CELL).and().hasAttribute("data-role-case", "table-cell").build(), "data-role-case", "table-cell"),
+                new LocatorCase("roleTableColumnHeader", () -> Locator.hasRole(Role.TABLE_COLUMNHEADER).and().hasAttribute("data-role-case", "table-columnheader").build(), "data-role-case", "table-columnheader")
+        ));
     }
 
     @Test
@@ -165,5 +238,21 @@ public class LocatorBuilderTest {
                 .insideShadowDom(shadowHost)
                 .build();
         driver.get().assertThat().element(locator).attribute("value").isEqualTo("shadow-value").perform();
+    }
+
+    private void assertLocatorCases(List<LocatorCase> locatorCases) {
+        for (LocatorCase locatorCase : locatorCases) {
+            try {
+                driver.get().assertThat().element(locatorCase.locator().get())
+                        .attribute(locatorCase.attribute())
+                        .isEqualTo(locatorCase.expectedValue())
+                        .perform();
+            } catch (RuntimeException | AssertionError failure) {
+                throw new AssertionError("Locator case failed: " + locatorCase.name(), failure);
+            }
+        }
+    }
+
+    private record LocatorCase(String name, Supplier<By> locator, String attribute, String expectedValue) {
     }
 }

--- a/shaft-engine/src/test/resources/testDataFiles/locatorBuilderFixture.html
+++ b/shaft-engine/src/test/resources/testDataFiles/locatorBuilderFixture.html
@@ -46,6 +46,51 @@
         <input id="test-count" type="text" value="100">
     </section>
 
+    <section id="locator-method-targets">
+        <article data-locator-case="tag-name">Tag name target</article>
+        <div data-locator-case="any-tag" data-any-tag="true">Any tag target</div>
+        <div data-locator-case="has-attribute" data-present>Has attribute target</div>
+        <div data-locator-case="has-attribute-value" data-exact="exact-value">Exact attribute target</div>
+        <div data-locator-case="contains-attribute" data-partial="prefix-needle-suffix">Partial attribute target</div>
+        <div id="exact-id-target" data-locator-case="has-id">Exact id target</div>
+        <div id="prefix-partial-id-suffix" data-locator-case="contains-id">Partial id target</div>
+        <div class="exact-class" data-locator-case="has-class">Exact class target</div>
+        <div class="alpha partial-class omega" data-locator-case="contains-class">Partial class target</div>
+        <div data-locator-case="has-text">Exact text target</div>
+        <div data-locator-case="contains-text">This contains partial text target</div>
+        <div data-locator-case="and-method" data-and-target="true">And target</div>
+        <mark data-locator-case="first-index">First indexed target</mark>
+        <mark data-locator-case="second-index">Second indexed target</mark>
+        <mark data-locator-case="last-index">Last indexed target</mark>
+    </section>
+
+    <section id="role-targets">
+        <button data-role-case="button">Role button</button>
+        <a href="#role-link" data-role-case="link">Role link</a>
+        <textarea data-role-case="textbox"></textarea>
+        <input type="checkbox" data-role-case="checkbox">
+        <input type="radio" data-role-case="radio">
+        <select data-role-case="combobox">
+            <option>One</option>
+        </select>
+        <img data-role-case="image" alt="role image" src="data:image/gif;base64,R0lGODlhAQABAAAAACw=">
+        <ul data-role-case="list">
+            <li data-role-case="listitem">Role list item</li>
+        </ul>
+        <table data-role-case="table">
+            <thead>
+            <tr data-role-case="table-row">
+                <th data-role-case="table-columnheader">Column</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td data-role-case="table-cell">Cell</td>
+            </tr>
+            </tbody>
+        </table>
+    </section>
+
     <p>Ready to transform your test automation?</p>
 
     <section>
@@ -54,8 +99,25 @@
             const host = document.getElementById('shadow-host');
             const shadow = host.attachShadow({ mode: 'open' });
             shadow.innerHTML = `
+                <mark data-css-case="first-index">CSS first indexed target</mark>
+                <mark data-css-case="second-index">CSS second indexed target</mark>
+                <div id="shadow-method-targets">
                 <span class="wrapper">Shadow content</span>
                 <input type="text" name="shadow-input" value="shadow-value" />
+                <section data-css-case="tag-name">CSS tag name target</section>
+                <div data-css-case="any-tag" data-any-tag-shadow="true">CSS any tag target</div>
+                <div data-css-case="has-attribute" data-present-shadow>CSS has attribute target</div>
+                <div data-css-case="has-attribute-value" data-exact-shadow="exact-value">CSS exact attribute target</div>
+                <div data-css-case="contains-attribute" data-partial-shadow="prefix-needle-suffix">CSS partial attribute target</div>
+                <div id="shadow-exact-id-target" data-css-case="has-id">CSS exact id target</div>
+                <div id="shadow-prefix-partial-id-suffix" data-css-case="contains-id">CSS partial id target</div>
+                <div class="shadow-exact-class" data-css-case="has-class">CSS exact class target</div>
+                <div class="alpha shadow-partial-class omega" data-css-case="contains-class">CSS partial class target</div>
+                <strong data-css-case="has-text">Exact shadow text target</strong>
+                <em data-css-case="contains-text">This contains shadow partial text target</em>
+                <u data-css-case="and-method" data-and-shadow="true">CSS and target</u>
+                </div>
+                <mark data-css-case="last-index">CSS last indexed target</mark>
             `;
         </script>
     </section>


### PR DESCRIPTION
## Summary
- add fixture-backed LocatorBuilder coverage for XPath mode, CSS/shadow mode, and all Role locators
- fix CSS positional selector generation for shadow DOM locators by removing invalid selector parentheses
- harden LocatorBuilderTest cleanup for driver and locator ThreadLocal state

## Validation
- mvn -pl shaft-engine -am -e test '-DheadlessExecution=true' '-DtargetBrowserName=chrome' '-DretryMaximumNumberOfAttempts=1' '-Dtest=LocatorBuilderTest' '-Dgpg.skip=true' (25 passed; Allure 25 passed)
- mvn -pl shaft-engine -am -e test '-DretryMaximumNumberOfAttempts=1' '-Dtest=LocatorBuilderUnitTest,LocatorBuilderExtendedUnitTest' '-Dgpg.skip=true' (41 passed; Allure 41 passed)
- mvn -pl shaft-engine -am -e package '-DskipTests=true' '-Dgpg.skip=true' '-Dcyclonedx.skip=true'
- graphify update . (refreshed successfully; generated output not committed)