### PR TITLE
docs: simplify README with theme-aware logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,20 +31,19 @@ workflows.
 - Optional modules for BrowserStack, Capture, Doctor, Heal, MCP, AI, video, and
   visual testing.
 
-## How It Compares
+## Feature Overview
 
-| Solution | Best fit | SHAFT difference |
-|---|---|---|
-| Playwright | Modern browser automation with a rich test runner | SHAFT is Java/Maven-first and covers browser, mobile, API, CLI, Database, reporting, and evidence together. |
-| Selenide | Concise Java UI tests on Selenium WebDriver | SHAFT adds broader test surfaces, configuration, artifacts, and reports around WebDriver-style automation. |
-| WebdriverIO | Node.js browser and mobile automation | SHAFT fits Java teams that want cross-surface automation without adopting a Node.js test stack. |
-| Cypress | Browser-focused E2E and component testing | SHAFT fits regression suites that extend beyond frontend browser flows. |
-| Selenium, Appium, REST Assured | Focused browser, mobile, and API building blocks | SHAFT packages these concerns into a higher-level framework with synchronized actions and evidence. |
-| Karate | Unified API, UI, performance, and mocks in one syntax | SHAFT keeps tests in Java and emphasizes framework reuse, configuration, and reporting. |
+| Area | Built in |
+|---|---|
+| UI automation | Browser and mobile driver management, synchronized actions, screenshots, and logs. |
+| Service testing | REST and GraphQL API workflows with request, response, and assertion support. |
+| System coverage | CLI and Database actions for end-to-end validation beyond the browser. |
+| Test design | Assertions, validations, test data handling, and configuration overrides. |
+| Reporting | Allure-ready evidence, attachments, execution logs, and accessibility artifacts. |
+| Extensions | Optional modules for cloud execution, capture, diagnostics, healing, MCP, AI, video, and visual checks. |
 
-Use SHAFT when the suite needs to cover multiple test surfaces with consistent
-Java APIs, repeatable configuration, and useful run artifacts. Use a narrower
-tool when the project only needs that tool's specific strength.
+SHAFT is built for Java teams that want consistent APIs, repeatable
+configuration, and useful run artifacts across the full automation suite.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,34 @@ Java 25 automation framework for Web, Mobile, API, CLI, and Database testing.
 
 </div>
 
-SHAFT is a Maven-published automation engine with synchronized actions,
-assertions, configuration, test data, reporting, evidence, and optional
-agent-assisted workflows.
+SHAFT is a Maven-published Java automation framework that keeps the common test
+automation plumbing in one place: drivers, synchronization, assertions,
+configuration, test data, reporting, evidence, and optional agent-assisted
+workflows.
+
+## Why SHAFT
+
+- Java and Maven first, with TestNG, JUnit 5, and Cucumber integration.
+- One workflow for Web, Mobile, API, CLI, Database, accessibility, reporting,
+  and evidence.
+- Configuration-first defaults for local, grid, cloud, and CI execution.
+- Optional modules for BrowserStack, Capture, Doctor, Heal, MCP, AI, video, and
+  visual testing.
+
+## How It Compares
+
+| Solution | Best fit | SHAFT difference |
+|---|---|---|
+| Playwright | Modern browser automation with a rich test runner | SHAFT is Java/Maven-first and covers browser, mobile, API, CLI, Database, reporting, and evidence together. |
+| Selenide | Concise Java UI tests on Selenium WebDriver | SHAFT adds broader test surfaces, configuration, artifacts, and reports around WebDriver-style automation. |
+| WebdriverIO | Node.js browser and mobile automation | SHAFT fits Java teams that want cross-surface automation without adopting a Node.js test stack. |
+| Cypress | Browser-focused E2E and component testing | SHAFT fits regression suites that extend beyond frontend browser flows. |
+| Selenium, Appium, REST Assured | Focused browser, mobile, and API building blocks | SHAFT packages these concerns into a higher-level framework with synchronized actions and evidence. |
+| Karate | Unified API, UI, performance, and mocks in one syntax | SHAFT keeps tests in Java and emphasizes framework reuse, configuration, and reporting. |
+
+Use SHAFT when the suite needs to cover multiple test surfaces with consistent
+Java APIs, repeatable configuration, and useful run artifacts. Use a narrower
+tool when the project only needs that tool's specific strength.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,69 +1,29 @@
 <div align="center">
 
-<img src="https://shafthq.github.io/img/shaft-automation-hero.png" alt="SHAFT connects Web, Mobile, API, CLI, Database, reporting, and agent workflows" width="900">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="shaft-engine/src/main/resources/images/shaft_white.png">
+  <img src="shaft-engine/src/main/resources/images/shaft_standard.png" alt="SHAFT logo" width="180">
+</picture>
 
 # SHAFT
 
-### Java 25 automation framework for Web, Mobile, API, CLI, and Database testing.
+Java 25 automation framework for Web, Mobile, API, CLI, and Database testing.
 
-SHAFT is a Maven-published test automation engine with one fluent API for
-synchronized actions, assertions, configuration, test data, reporting, evidence,
-and optional agent-assisted workflows.
-
-[![GitHub Stars](https://img.shields.io/github/stars/ShaftHQ/SHAFT_ENGINE?style=flat-square&logo=github)](https://github.com/ShaftHQ/SHAFT_ENGINE/stargazers)
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.shafthq/shaft-engine?style=flat-square&logo=apachemaven)](https://central.sonatype.com/artifact/io.github.shafthq/shaft-engine)
 [![Build](https://img.shields.io/github/actions/workflow/status/ShaftHQ/SHAFT_ENGINE/e2eTests.yml?branch=main&style=flat-square&label=tests)](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/workflows/e2eTests.yml)
 [![Docs](https://img.shields.io/badge/docs-live-5b4bff?style=flat-square)](https://shafthq.github.io/docs/start/overview)
 
-[User Guide](https://shafthq.github.io/docs/start/overview) ·
-[Quick Start](https://shafthq.github.io/docs/start/quick-start) ·
-[Architecture](https://shafthq.github.io/docs/features/architecture) ·
-[Contribute](CONTRIBUTING.md)
+**[Open the User Guide](https://shafthq.github.io/docs/start/overview)**
 
 </div>
 
-## What SHAFT Provides
+SHAFT is a Maven-published automation engine with synchronized actions,
+assertions, configuration, test data, reporting, evidence, and optional
+agent-assisted workflows.
 
-- Web, mobile, API, CLI, database, validation, test data, and reporting APIs.
-- Built-in synchronization, assertions, screenshots, logs, and Allure evidence.
-- TestNG, JUnit 5, and Cucumber integration.
-- Required `shaft-engine` runtime plus optional modules for MCP, Capture,
-  Doctor, Heal, AI providers, BrowserStack, local video, and visual processing.
-- Deterministic agent workflows through SHAFT MCP, Capture, Doctor, and Heal,
-  with provider-backed AI features kept optional.
+## Contributing
 
-## Go Straight To The Guide
-
-| Goal | Open |
-|---|---|
-| Evaluate SHAFT quickly | [SHAFT at a glance](https://shafthq.github.io/docs/start/overview) |
-| Create and run a project | [Quick start](https://shafthq.github.io/docs/start/quick-start) |
-| Install or generate a project | [Installation](https://shafthq.github.io/docs/start/installation) |
-| Understand artifacts and boundaries | [Architecture and modules](https://shafthq.github.io/docs/features/architecture) |
-| Test browsers | [Web testing](https://shafthq.github.io/docs/testing/web) |
-| Test mobile apps | [Mobile testing](https://shafthq.github.io/docs/testing/mobile) |
-| Test REST or GraphQL APIs | [API testing](https://shafthq.github.io/docs/testing/api) |
-| Use agent tools | [SHAFT MCP](https://shafthq.github.io/docs/agentic/mcp) |
-| Diagnose or recover failed runs | [Doctor](https://shafthq.github.io/docs/agentic/doctor) and [Heal](https://shafthq.github.io/docs/agentic/heal) |
-| Upgrade an existing project | [Upgrade guide](https://shafthq.github.io/docs/start/upgrade) |
-
-## Evidence
-
-SHAFT is published on
-[Maven Central](https://central.sonatype.com/artifact/io.github.shafthq/shaft-engine),
-listed in the
-[Selenium ecosystem](https://www.selenium.dev/ecosystem/#frameworks), and was
-recognized through the
-[Google Open Source Peer Bonus program](https://opensource.googleblog.com/2023/05/google-open-source-peer-bonus-program-announces-first-group-of-winners-2023.html).
-
-## Contribute
-
-Read [CONTRIBUTING.md](CONTRIBUTING.md) for the full local setup, validation,
-documentation, and pull request checklist.
-
-Public product documentation is maintained in
-[ShaftHQ/shafthq.github.io](https://github.com/ShaftHQ/shafthq.github.io).
-User-facing engine changes need a linked documentation pull request or a clear
-reason why documentation is not required.
+Read [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, validation, and pull
+request guidance.
 
 MIT licensed. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ workflows.
 
 ## Why SHAFT
 
-- Java and Maven first, with TestNG, JUnit 5, and Cucumber integration.
+- Java and Maven first, with TestNG, JUnit, and Cucumber integration.
 - One workflow for Web, Mobile, API, CLI, Database, accessibility, reporting,
   and evidence.
 - Configuration-first defaults for local, grid, cloud, and CI execution.


### PR DESCRIPTION
## Summary
- Replace the README hero artwork with the existing SHAFT logo.
- Use a theme-aware picture source so dark mode gets the white logo and light mode gets the standard logo.
- Keep the primary call to action as Open the User Guide.
- Add a concise feature-focused overview without competitive comparisons.

## Validation
- Passed: git diff --check -- README.md
- Passed: verified local logo asset paths exist
- Pending: GitHub PR checks are still running.
