### PR TITLE
[codex] optimize agent guidance routing

### DIFF
--- a/.github/codex/prompts/refresh-agent-instructions.md
+++ b/.github/codex/prompts/refresh-agent-instructions.md
@@ -7,8 +7,8 @@ the explicit maintainer reason.
 ## Allowed Work
 
 - Edit compact agent guidance: `AGENTS.md`, `CLAUDE.md`,
-  `.agents/skills/**`, `.github/copilot-instructions.md`, `.github/instructions/**`,
-  `.github/skills/**`, `CONTRIBUTING.md`, and
+  `.agents/skills/**`, `.claude/skills/**`, `.github/copilot-instructions.md`,
+  `.github/instructions/**`, `.github/skills/**`, `CONTRIBUTING.md`, and
   `.github/pull_request_template.md`.
 - Inspect executable configuration only when needed to verify a disputed fact.
 - Preserve unique safety and engineering rules in the narrowest canonical

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ Follow `AGENTS.md` as the canonical repository policy.
   production Java and `.github/instructions/java-tests.instructions.md` only
   to test Java.
 - Load one matching playbook from `.github/skills/` for CI failures, flaky
-  tests, release/dependency work, or SHAFT UI design.
+  tests, release/dependency work, SHAFT UI design, or marketing ads.
 - Prefer targeted reads and deterministic local checks; reuse valid evidence.
 - Preserve unrelated work and never expose secrets or claim unverified remote
   results.

--- a/.github/skills/shaft-marketing-ad-producer/SKILL.md
+++ b/.github/skills/shaft-marketing-ad-producer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shaft-marketing-ad-producer
-description: Use when planning or producing SHAFT ads needing scripts, scenes, demo capture, Allure or MCP recorder footage, captions, music, code visuals, edits, and reusable assets.
+description: Use when planning or producing SHAFT ads needing scripts, scenes, demo capture, reports, captions, music, code visuals, edits, or reusable assets.
 ---
 
 # SHAFT Marketing Ad Producer
@@ -9,12 +9,11 @@ Plan SHAFT ads without fake claims.
 
 ## Stack
 
-- Strategy/routes/scenes: `creative-production:positioning-explorer`, `creative-production:offer-explorer`, `creative-production:ads-explorer`, `creative-production:scene-explorer`, `creative-production:moodboard-explorer`.
-- Visual polish: `creative-production:generative-polish`, `imagegen`. Keep exact copy, code, logos, and UI screenshots deterministic.
-- Browser capture: `browse` or `playwright`; use `chrome:control-chrome` only for current Chrome state.
-- Desktop capture: `computer-use:computer-use`; use OBS, Windows capture, or `ffmpeg` only if installed.
-- SHAFT proof: MCP recorder/report tools such as `capture_start`, `capture_stop`, `capture_code_blocks`, `playwright_record_start`, `playwright_record_stop`, `playwright_recording_code_blocks`, mobile recording, `generate_test_report`, and Doctor/Allure tools.
-- Editing/audio: existing video tools plus approved audio-generation or licensed music. If no generator exists, write a music brief and ask for or reuse an approved track.
+- Strategy/scenes: use the relevant `creative-production:*` explorer.
+- Polish: `creative-production:generative-polish`, `imagegen`; keep exact copy, code, logos, and UI screenshots deterministic.
+- Capture: `browse` or `playwright`; use Chrome only for current profile state, and desktop/OBS/`ffmpeg` only if installed.
+- SHAFT proof: use MCP recorder, report, Doctor, Allure, and code-block tools.
+- Editing/audio: use existing video tools and approved or licensed audio; otherwise write a music brief.
 
 ## Workflow
 
@@ -30,6 +29,6 @@ Plan SHAFT ads without fake claims.
 
 Planning: campaign slate, storyboard table, asset checklist, capture plan, and theme notes.
 
-Production: scripts/storyboards, captures, code-card renders, captions, music source/brief, edit manifest, final exports, and marketing-repo paths.
+Production: scripts/storyboards, captures, code-card renders, captions, music source/brief, edit manifest, exports, and marketing-repo paths.
 
 Guardrails: no unsupported benchmarks, 3rd-party logos, security claims, generated final code text, secrets, or tokens.

--- a/.github/workflows/refresh-agent-instructions.yml
+++ b/.github/workflows/refresh-agent-instructions.yml
@@ -113,7 +113,7 @@ jobs:
                 ;;
               .github/copilot-instructions.md|.github/pull_request_template.md)
                 ;;
-              .agents/skills/*|.github/instructions/*|.github/skills/*)
+              .agents/skills/*|.claude/skills/*|.github/instructions/*|.github/skills/*)
                 ;;
               *)
                 disallowed_files+=("$file")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,57 +4,58 @@
 
 SHAFT_ENGINE is a Maven-published Java 25 automation framework; config wins.
 Core: `shaft-engine/`; optional/publication: `shaft-*`; tools: `scripts/ci/`; docs: `https://shafthq.github.io`.
-
-Start from goal/files. Prefer `rg`, excerpts, parsers, scripts. Expand only for uncertainty.
+Start from goal/files; prefer `rg`, excerpts, parsers, scripts.
 
 ## Routing
 
-Load matching `.agents/skills/`: production Java `framework-source-rules`; test
-Java `java-test-rules`; CI/Allure `ci-failure-investigator`; intermittent
-`flaky-test-stabilizer`; release/dependency `release-dependency-guard`.
-
-Bridge skills point to `.github/`; do not preload.
+Load only matching `.agents/skills/`: src/main Java
+`framework-source-rules`; src/test Java `java-test-rules`; CI/Allure
+`ci-failure-investigator`; flaky `flaky-test-stabilizer`; release/deps
+`release-dependency-guard`; broad mapping `graphify`; UI
+`shaft-ui-design`; ads `shaft-marketing-ad-producer`.
+Bridge skills point to `.github/` or tool docs; do not preload.
 
 ## New Task Flow
 
 For file edits unless told otherwise:
 
-1. Clean stale Codex worktrees/branches: delete only clean worktrees and unused merged/closed branches; preserve user work.
+1. Clean stale Codex worktrees/branches: delete only clean unused merged/closed work; preserve user work.
 2. Fetch/prune; fast-forward `main` from `origin/main`.
 3. Branch fresh `codex/*` from `origin/main`.
 4. Implement, validate, commit, push, and open a ready PR when checks pass;
    draft only when blocked, incomplete, or requested.
-5. Share the PR link.
+5. Share PR link.
 
 ## Working Rules
 
 - Read first; follow patterns; tight scope; preserve user work.
-- Delegate Codex Spark when useful; no permission needed. Own review.
-- Structured APIs for structured data.
+- Delegate Spark when useful; no permission needed; own review.
+- Use structured APIs for structured data.
 - Reproduce defects and add focused regression coverage.
 - Preserve public API; deprecate before removal/rename.
-- Public docs: `C:\Users\Mohab\IdeaProjects\shafthq.github.io`; targeted `rg`/excerpts.
-  Functionality changes need guide update plus docs PR.
+- Public docs: `C:\Users\Mohab\IdeaProjects\shafthq.github.io`; use targeted
+  `rg`/excerpts. Functionality changes need guide update + docs PR.
 - Never expose secrets or run deploy, publish, history rewrites, cleanup, or cloud suites unless explicit.
-- No generated reports, binaries, or `target/`.
-- Browser tests headless unless headed approved.
+- No generated reports, binaries, or `target/`; browser tests headless unless
+  headed approved.
 
 ## Memory
 
 Memory: `.memory/`; current files win. `AGENTS.md` is canonical; `CLAUDE.md`
-imports/adapts only. Load for history, pitfalls, durable instructions, or
-continuity: `memory load "<task>"` or `memory search`. Save only durable
-decisions, constraints, gotchas, workflows, or corrections with evidence. Reuse IDs; no duplicates, diaries, or end saves.
+adapts only. Load history, pitfalls, durable instructions, or continuity with
+`memory load "<task>"` or `memory search`. Save only durable decisions,
+constraints, gotchas, workflows, or corrections with evidence; reuse IDs; no duplicates, diaries, or end saves.
 
 ## Validation
 
-Before forked Maven/Surefire/TestNG, load gotchas. If the delete gotcha is active, avoid `mvn test`; use compile/test-compile, static checks, or a disposable copy.
+Before forked Maven/Surefire/TestNG, load gotchas. If the delete gotcha is
+active, avoid `mvn test`; use compile/test-compile, static checks, or disposable copy.
 
-Use the smallest non-redundant check. Do not rerun passing checks unless edits,
-rebases, or dependencies invalidate them.
+Use the smallest non-redundant check. Rerun passing checks only after edits,
+rebases, or dependency changes.
 
 - Guidance/memory: `python3 scripts/ci/validate_agent_setup.py`; Win: `py -3 ...`
-- Localized code: affected tests only, then one compile/package pass.
+- Localized code: affected tests, then one compile/package pass.
 - Shared API/concurrency/build/release: targeted, then full compile/package.
 - Visual: relevant test plus image/browser evidence.
 - External/cloud E2E: only with required infra.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@
 - Treat imported `AGENTS.md` as canonical; do not restate it or append logs.
 - Follow the imported new-task flow for branch cleanup, fresh `origin/main`
   branches, ready PRs, and PR links.
-- Load one matching `.agents/skills/` bridge only when its trigger applies.
+- Load one matching `.agents/skills/` bridge only when its trigger applies;
+  use `.claude/skills/graphify` for native Graphify discovery.
 - Keep plans and final responses proportional to the task and stop when the
   requested behavior is verified.
 

--- a/scripts/ci/agent_guidance_budget.json
+++ b/scripts/ci/agent_guidance_budget.json
@@ -56,6 +56,7 @@
     "AGENTS.md",
     "CLAUDE.md",
     ".agents/skills/*/SKILL.md",
+    ".claude/skills/*/SKILL.md",
     ".github/copilot-instructions.md",
     ".github/instructions/*.instructions.md",
     ".github/skills/README.md",

--- a/scripts/ci/validate_agent_guidance.py
+++ b/scripts/ci/validate_agent_guidance.py
@@ -422,6 +422,7 @@ def validate_refresh_workflow(root: Path, budget: dict) -> list[dict[str, str]]:
         "force_ai:": "force_ai input is missing",
         "python3 scripts/ci/validate_agent_setup.py": "deterministic audit step is missing",
         "if: steps.audit.outputs.needs_ai == 'true'": "paid action is not audit-gated",
+        ".claude/skills/*": "Claude skill surface is missing from the change allowlist",
     }
     errors: list[dict[str, str]] = []
     if re.search(r"(?m)^\s+schedule:\s*$", content):


### PR DESCRIPTION
## Summary
- List all checked-in repo skills in `AGENTS.md` routing and keep Claude on the single native Graphify adapter.
- Include `.claude/skills/**` in the agent-guidance refresh prompt, workflow allowlist, and total guidance budget.
- Compress the SHAFT marketing ad skill stack guidance while preserving its workflow and guardrails.

## Validation
- `py -3 scripts\ci\validate_agent_setup.py` -> Agent setup is valid: 22191 guidance bytes, 85.21% reduction, 50 memory objects.
- `py -3 C:\Users\Mohab\.codex\skills\.system\skill-creator\scripts\quick_validate.py .github\skills\shaft-marketing-ad-producer` -> Skill is valid.
- `git diff --check HEAD~1..HEAD` -> no whitespace errors.

No product code was intentionally changed.