### PR TITLE
Add MCP-backed project tools to IntelliJ plugin

### DIFF
--- a/shaft-intellij/build.gradle.kts
+++ b/shaft-intellij/build.gradle.kts
@@ -20,6 +20,8 @@ dependencies {
     }
     implementation("com.google.code.gson:gson:2.14.0")
     testImplementation("org.junit.jupiter:junit-jupiter:6.1.0")
+    testRuntimeOnly("junit:junit:4.13.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 java {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
@@ -25,6 +25,7 @@ public final class ShaftToolWindowPanel extends JPanel {
         tabs.addTab("Doctor", new ShaftFeaturePanel(project, ToolTemplates.doctor()));
         tabs.addTab("Healer", new ShaftFeaturePanel(project, ToolTemplates.healer()));
         tabs.addTab("Inspector", new ShaftFeaturePanel(project, ToolTemplates.inspector()));
+        tabs.addTab("Projects", new ShaftFeaturePanel(project, ToolTemplates.projects()));
         tabs.addTab("MCP", new ShaftFeaturePanel(project, ToolTemplates.mcp()));
         tabs.addTab("Guide", new ShaftFeaturePanel(project, ToolTemplates.guide()));
         if (ShaftSettingsState.getInstance().getState().autobotEnabled) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ToolTemplates.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ToolTemplates.java
@@ -248,6 +248,53 @@ final class ToolTemplates {
                         """));
     }
 
+    static List<ToolTemplate> projects() {
+        return List.of(
+                template("Create SHAFT Project", "shaft_project_create",
+                        """
+                        {
+                          "outputDirectory": "shaft-web-testng",
+                          "runner": "TestNG",
+                          "platform": "web",
+                          "groupId": "io.github.yourUsername",
+                          "artifactId": "shaft-web-testng",
+                          "version": "1.0.0",
+                          "optionalModules": [],
+                          "includeGithubActions": true,
+                          "includeDependabot": true,
+                          "overwrite": false
+                        }
+                        """),
+                template("Preview Current Project Upgrade", "shaft_project_upgrade",
+                        """
+                        {
+                          "projectRoot": ".",
+                          "upgradeType": "basic",
+                          "dryRun": true,
+                          "approve": false,
+                          "shaftVersion": "",
+                          "compileCommand": "",
+                          "compileTimeout": 900,
+                          "skipBaselineCompile": false,
+                          "allowAiRepair": false
+                        }
+                        """),
+                template("Apply Current Project Upgrade", "shaft_project_upgrade",
+                        """
+                        {
+                          "projectRoot": ".",
+                          "upgradeType": "basic",
+                          "dryRun": false,
+                          "approve": true,
+                          "shaftVersion": "",
+                          "compileCommand": "",
+                          "compileTimeout": 900,
+                          "skipBaselineCompile": false,
+                          "allowAiRepair": false
+                        }
+                        """));
+    }
+
     private static ToolTemplate template(String label, String toolName, String arguments) {
         return new ToolTemplate(label, toolName, arguments.stripIndent().trim());
     }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ToolTemplatesTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ToolTemplatesTest.java
@@ -1,0 +1,24 @@
+package com.shaft.intellij.ui;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ToolTemplatesTest {
+    @Test
+    void projectsExposeCreatePreviewAndApplyTemplates() {
+        Map<String, ToolTemplate> templates = ToolTemplates.projects().stream()
+                .collect(Collectors.toMap(ToolTemplate::label, template -> template));
+
+        assertEquals("shaft_project_create", templates.get("Create SHAFT Project").toolName());
+        assertTrue(templates.get("Create SHAFT Project").arguments().contains("\"runner\": \"TestNG\""));
+        assertEquals("shaft_project_upgrade", templates.get("Preview Current Project Upgrade").toolName());
+        assertTrue(templates.get("Preview Current Project Upgrade").arguments().contains("\"dryRun\": true"));
+        assertEquals("shaft_project_upgrade", templates.get("Apply Current Project Upgrade").toolName());
+        assertTrue(templates.get("Apply Current Project Upgrade").arguments().contains("\"approve\": true"));
+    }
+}

--- a/shaft-mcp/pom.xml
+++ b/shaft-mcp/pom.xml
@@ -116,6 +116,19 @@
                 <directory>src/main/resources</directory>
                 <filtering>true</filtering>
             </resource>
+            <resource>
+                <directory>${project.basedir}/../shaft-engine/src/main/resources/examples</directory>
+                <targetPath>META-INF/shaft-mcp/examples</targetPath>
+                <filtering>false</filtering>
+            </resource>
+            <resource>
+                <directory>${project.basedir}/../shaft-upgrader</directory>
+                <targetPath>META-INF/shaft-mcp</targetPath>
+                <includes>
+                    <include>upgrade_to_modular_shaft.py</include>
+                </includes>
+                <filtering>false</filtering>
+            </resource>
         </resources>
         <plugins>
             <plugin>
@@ -163,7 +176,7 @@
                     </archive>
                     <includes>
                         <include>com/**</include>
-                        <include>META-INF/shaft-mcp/*</include>
+                        <include>META-INF/shaft-mcp/**</include>
                         <include>application*.properties</include>
                         <include>logback-spring.xml</include>
                     </includes>

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpShaftProjectGenerationResult.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpShaftProjectGenerationResult.java
@@ -1,0 +1,47 @@
+package com.shaft.mcp;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Result returned after generating a SHAFT project through MCP.
+ *
+ * @param schemaVersion result schema version
+ * @param projectDirectory generated project directory
+ * @param pomPath generated Maven POM path
+ * @param runner selected test runner
+ * @param platform selected starting platform
+ * @param templateProject reused SHAFT example project
+ * @param addedModules SHAFT modules added to the generated POM
+ * @param warnings non-fatal generation warnings
+ */
+public record McpShaftProjectGenerationResult(
+        String schemaVersion,
+        Path projectDirectory,
+        Path pomPath,
+        String runner,
+        String platform,
+        String templateProject,
+        List<String> addedModules,
+        List<String> warnings) {
+    /**
+     * Current result schema version.
+     */
+    public static final String CURRENT_SCHEMA_VERSION = "1.0";
+
+    /**
+     * Creates an immutable project generation result.
+     */
+    public McpShaftProjectGenerationResult {
+        schemaVersion = text(schemaVersion).isBlank() ? CURRENT_SCHEMA_VERSION : text(schemaVersion);
+        runner = text(runner);
+        platform = text(platform);
+        templateProject = text(templateProject);
+        addedModules = addedModules == null ? List.of() : List.copyOf(addedModules);
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpShaftProjectUpgradeResult.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpShaftProjectUpgradeResult.java
@@ -1,0 +1,47 @@
+package com.shaft.mcp;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Result returned after invoking the SHAFT modular project upgrader through MCP.
+ *
+ * @param schemaVersion result schema version
+ * @param projectRoot upgraded project root
+ * @param reportPath optional upgrader report path
+ * @param dryRun whether the upgrader was run in dry-run mode
+ * @param exitCode upgrader process exit code
+ * @param stdout captured standard output
+ * @param stderr captured standard error
+ * @param timedOut whether the process exceeded the timeout
+ * @param command executed command
+ */
+public record McpShaftProjectUpgradeResult(
+        String schemaVersion,
+        Path projectRoot,
+        Path reportPath,
+        boolean dryRun,
+        int exitCode,
+        String stdout,
+        String stderr,
+        boolean timedOut,
+        List<String> command) {
+    /**
+     * Current result schema version.
+     */
+    public static final String CURRENT_SCHEMA_VERSION = "1.0";
+
+    /**
+     * Creates an immutable project upgrade result.
+     */
+    public McpShaftProjectUpgradeResult {
+        schemaVersion = text(schemaVersion).isBlank() ? CURRENT_SCHEMA_VERSION : text(schemaVersion);
+        stdout = text(stdout);
+        stderr = text(stderr);
+        command = command == null ? List.of() : List.copyOf(command);
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/ShaftMcpApplication.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/ShaftMcpApplication.java
@@ -63,6 +63,7 @@ public class ShaftMcpApplication {
             TraceService traceService,
             HealerService healerService,
             GuideService guideService,
+            ShaftProjectService shaftProjectService,
             TestAutomationService testAutomationService,
             AutobotService autobotService) {
         var engineServiceList = List.of(ToolCallbacks.from(engineService));
@@ -76,6 +77,7 @@ public class ShaftMcpApplication {
         var traceServiceList = List.of(ToolCallbacks.from(traceService));
         var healerServiceList = List.of(ToolCallbacks.from(healerService));
         var guideServiceList = List.of(ToolCallbacks.from(guideService));
+        var shaftProjectServiceList = List.of(ToolCallbacks.from(shaftProjectService));
         var testAutomationServiceList = List.of(ToolCallbacks.from(testAutomationService));
         var autobotServiceList = List.of(ToolCallbacks.from(autobotService));
 
@@ -91,6 +93,7 @@ public class ShaftMcpApplication {
         serviceList.addAll(traceServiceList);
         serviceList.addAll(healerServiceList);
         serviceList.addAll(guideServiceList);
+        serviceList.addAll(shaftProjectServiceList);
         serviceList.addAll(testAutomationServiceList);
         serviceList.addAll(autobotServiceList);
         return serviceList;

--- a/shaft-mcp/src/main/java/com/shaft/mcp/ShaftProjectService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/ShaftProjectService.java
@@ -85,6 +85,7 @@ public class ShaftProjectService {
      */
     @Tool(name = "shaft_project_create",
             description = "creates a new SHAFT Maven project from the same examples and rules used by the guide generator")
+    @SuppressWarnings("PMD.ExcessiveParameterList")
     public McpShaftProjectGenerationResult createProject(
             String outputDirectory,
             String runner,
@@ -315,10 +316,9 @@ public class ShaftProjectService {
                 return;
             }
             throw new IOException("Unsupported project generator resource protocol: " + url.getProtocol());
+        } catch (IOException exception) {
+            throw exception;
         } catch (Exception exception) {
-            if (exception instanceof IOException ioException) {
-                throw ioException;
-            }
             throw new IOException("Project generator resources could not be read.", exception);
         }
     }

--- a/shaft-mcp/src/main/java/com/shaft/mcp/ShaftProjectService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/ShaftProjectService.java
@@ -306,7 +306,7 @@ public class ShaftProjectService {
                 try (JarFile jar = connection.getJarFile()) {
                     for (JarEntry entry : jar.stream().filter(entry -> !entry.isDirectory())
                             .filter(entry -> entry.getName().startsWith(prefix)).toList()) {
-                        Path destination = target.resolve(entry.getName().substring(prefix.length()));
+                        Path destination = safeResourceDestination(target, entry.getName().substring(prefix.length()));
                         try (var input = jar.getInputStream(entry)) {
                             copyFile(input.readAllBytes(), destination, target, overwrite);
                         }
@@ -357,6 +357,15 @@ public class ShaftProjectService {
             throw new IllegalArgumentException("Generated project file escaped the output directory.");
         }
         return normalized;
+    }
+
+    static Path safeResourceDestination(Path targetRoot, String resourceName) {
+        Path normalizedRoot = targetRoot.toAbsolutePath().normalize();
+        Path normalizedDestination = normalizedRoot.resolve(resourceName).normalize();
+        if (!normalizedDestination.startsWith(normalizedRoot)) {
+            throw new IllegalArgumentException("Generated project file escaped the output directory.");
+        }
+        return normalizedDestination;
     }
 
     private static URL resource(String resourceName) throws IOException {

--- a/shaft-mcp/src/main/java/com/shaft/mcp/ShaftProjectService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/ShaftProjectService.java
@@ -1,0 +1,433 @@
+package com.shaft.mcp;
+
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.net.JarURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.regex.Matcher;
+
+/**
+ * MCP project lifecycle tools backed by existing SHAFT generator assets and upgrader scripts.
+ */
+@Service
+public class ShaftProjectService {
+    private static final String EXAMPLES_ROOT = "META-INF/shaft-mcp/examples";
+    private static final String UPGRADER_RESOURCE = "META-INF/shaft-mcp/upgrade_to_modular_shaft.py";
+    private static final int DEFAULT_COMPILE_TIMEOUT_SECONDS = 900;
+    private static final List<String> OPTIONAL_MODULES = List.of(
+            "shaft-capture",
+            "shaft-doctor",
+            "shaft-ai",
+            "shaft-heal",
+            "shaft-browserstack",
+            "shaft-video",
+            "shaft-visual",
+            "shaft-mcp");
+    private static final Map<String, Map<String, String>> PROJECTS = projects();
+
+    private final McpWorkspacePolicy workspacePolicy;
+    private final McpProcessRunner processRunner;
+    private final Path upgraderScript;
+    private final List<String> pythonCommand;
+
+    /**
+     * Creates the default project lifecycle MCP service.
+     */
+    public ShaftProjectService() {
+        this(McpWorkspacePolicy.current(), McpProcessRunner.system(), resolveUpgraderScript(), defaultPythonCommand());
+    }
+
+    ShaftProjectService(
+            McpWorkspacePolicy workspacePolicy,
+            McpProcessRunner processRunner,
+            Path upgraderScript,
+            List<String> pythonCommand) {
+        this.workspacePolicy = Objects.requireNonNull(workspacePolicy, "workspacePolicy");
+        this.processRunner = Objects.requireNonNull(processRunner, "processRunner");
+        this.upgraderScript = Objects.requireNonNull(upgraderScript, "upgraderScript");
+        this.pythonCommand = List.copyOf(Objects.requireNonNull(pythonCommand, "pythonCommand"));
+    }
+
+    /**
+     * Creates a SHAFT Maven project from the same examples and rules used by the guide generator.
+     *
+     * @param outputDirectory workspace-relative output directory
+     * @param runner TestNG, JUnit, or Cucumber
+     * @param platform web, mobile, or api where supported by the selected runner
+     * @param groupId Maven group ID
+     * @param artifactId Maven artifact ID; defaults to the guide generator artifact name when blank
+     * @param version Maven project version; defaults to 1.0.0 when blank
+     * @param optionalModules optional SHAFT module artifact IDs
+     * @param includeGithubActions whether to include the generated workflow for web/api projects
+     * @param includeDependabot whether to include Dependabot configuration
+     * @param overwrite whether existing files may be replaced
+     * @return generated project details
+     */
+    @Tool(name = "shaft_project_create",
+            description = "creates a new SHAFT Maven project from the same examples and rules used by the guide generator")
+    public McpShaftProjectGenerationResult createProject(
+            String outputDirectory,
+            String runner,
+            String platform,
+            String groupId,
+            String artifactId,
+            String version,
+            List<String> optionalModules,
+            boolean includeGithubActions,
+            boolean includeDependabot,
+            boolean overwrite) {
+        String selectedRunner = selectedRunner(runner);
+        String selectedPlatform = selectedPlatform(selectedRunner, platform);
+        String templateProject = PROJECTS.get(selectedRunner).get(selectedPlatform);
+        String projectArtifactId = text(artifactId).isBlank()
+                ? defaultArtifactId(selectedRunner, selectedPlatform)
+                : text(artifactId);
+        Path output = workspacePolicy.output(text(outputDirectory).isBlank() ? projectArtifactId : outputDirectory,
+                "Project output directory");
+        if (Files.exists(output) && !overwrite) {
+            throw new IllegalArgumentException("Project output directory already exists.");
+        }
+
+        List<String> modules = checkedModules(optionalModules, selectedPlatform);
+        List<String> warnings = List.of();
+        try {
+            copyResourceDirectory(EXAMPLES_ROOT + "/" + selectedRunner + "/" + templateProject, output, overwrite);
+            Path pomPath = output.resolve("pom.xml");
+            String pom = Files.readString(pomPath, StandardCharsets.UTF_8);
+            pom = replaceFirst(pom, "<groupId>io\\.github\\.shafthq</groupId>",
+                    "<groupId>" + escapeXml(defaultText(groupId, "io.github.yourUsername")) + "</groupId>");
+            pom = replaceFirst(pom, "<artifactId>.*?</artifactId>",
+                    "<artifactId>" + escapeXml(projectArtifactId) + "</artifactId>");
+            pom = replaceFirst(pom, "<version>1\\.0-SNAPSHOT</version>",
+                    "<version>" + escapeXml(defaultText(version, "1.0.0")) + "</version>");
+            Files.writeString(pomPath, addOptionalDependencies(pom, modules), StandardCharsets.UTF_8);
+
+            if (includeGithubActions && !"mobile".equals(selectedPlatform)) {
+                copyResourceFile(EXAMPLES_ROOT + "/.github/workflows/" + workflowName(selectedPlatform),
+                        output.resolve(".github/workflows/" + workflowName(selectedPlatform)), output, overwrite);
+            }
+            if (includeDependabot) {
+                copyResourceFile(EXAMPLES_ROOT + "/.github/dependabot.yml",
+                        output.resolve(".github/dependabot.yml"), output, overwrite);
+            }
+            return new McpShaftProjectGenerationResult(
+                    McpShaftProjectGenerationResult.CURRENT_SCHEMA_VERSION,
+                    output,
+                    pomPath,
+                    selectedRunner,
+                    selectedPlatform,
+                    templateProject,
+                    modules,
+                    warnings);
+        } catch (IOException exception) {
+            throw new IllegalStateException("SHAFT project could not be generated.", exception);
+        }
+    }
+
+    /**
+     * Runs the existing modular SHAFT project upgrader script against a Java project.
+     *
+     * @param projectRoot workspace-relative Java/Maven project root
+     * @param upgradeType basic, session, or full
+     * @param dryRun whether to preview changes without writing files
+     * @param approve explicit approval required when dryRun is false
+     * @param shaftVersion optional target SHAFT version
+     * @param compileCommand optional compile command string passed to the upgrader
+     * @param compileTimeout compile timeout in seconds; defaults to 900 when non-positive
+     * @param skipBaselineCompile whether to pass --skip-baseline-compile
+     * @param allowAiRepair whether to allow the upgrader to use its configured AI repair path
+     * @return upgrader process result
+     */
+    @Tool(name = "shaft_project_upgrade",
+            description = "runs the existing SHAFT modular project upgrader script against the current Java project")
+    public McpShaftProjectUpgradeResult upgradeProject(
+            String projectRoot,
+            String upgradeType,
+            boolean dryRun,
+            boolean approve,
+            String shaftVersion,
+            String compileCommand,
+            int compileTimeout,
+            boolean skipBaselineCompile,
+            boolean allowAiRepair) {
+        if (!dryRun && !approve) {
+            throw new IllegalArgumentException("Project upgrade mutation requires approve=true.");
+        }
+        Path root = workspacePolicy.existing(projectRoot, "Project root");
+        int timeoutSeconds = compileTimeout > 0 ? compileTimeout : DEFAULT_COMPILE_TIMEOUT_SECONDS;
+        Path report = root.resolve("target/shaft-upgrader/upgrade-report.json").normalize();
+        List<String> command = new ArrayList<>(pythonCommand);
+        command.add(upgraderScript.toString());
+        command.add("--project");
+        command.add(root.toString());
+        command.add("--upgrade-type");
+        command.add(validUpgradeType(upgradeType));
+        command.add("--compile-timeout");
+        command.add(Integer.toString(timeoutSeconds));
+        if (dryRun) {
+            command.add("--dry-run");
+        } else {
+            command.add("--yes");
+            command.add("--report");
+            command.add(report.toString());
+        }
+        if (!text(shaftVersion).isBlank()) {
+            command.add("--shaft-version");
+            command.add(text(shaftVersion));
+        }
+        if (!text(compileCommand).isBlank()) {
+            command.add("--compile-command");
+            command.add(text(compileCommand));
+        }
+        if (skipBaselineCompile) {
+            command.add("--skip-baseline-compile");
+        }
+        if (!allowAiRepair) {
+            command.add("--no-ai");
+        }
+
+        McpProcessRunner.ProcessResult result = processRunner.run(
+                command,
+                root,
+                Map.of(),
+                Duration.ofSeconds(timeoutSeconds + 60L));
+        return new McpShaftProjectUpgradeResult(
+                McpShaftProjectUpgradeResult.CURRENT_SCHEMA_VERSION,
+                root,
+                report,
+                dryRun,
+                result.exitCode(),
+                result.stdout(),
+                result.stderr(),
+                result.timedOut(),
+                command);
+    }
+
+    private static Map<String, Map<String, String>> projects() {
+        Map<String, Map<String, String>> projects = new LinkedHashMap<>();
+        projects.put("TestNG", Map.of("web", "shaft-testng-web", "mobile", "shaft-testng-mobile",
+                "api", "shaft-testng-api"));
+        projects.put("JUnit", Map.of("web", "shaft-junit-web", "mobile", "shaft-junit-mobile",
+                "api", "shaft-junit-api"));
+        projects.put("Cucumber", Map.of("web", "shaft-cucumber-web"));
+        return projects;
+    }
+
+    private static String selectedRunner(String value) {
+        String normalized = text(value);
+        return PROJECTS.keySet().stream()
+                .filter(runner -> runner.equalsIgnoreCase(normalized))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unsupported SHAFT project runner: " + value));
+    }
+
+    private static String selectedPlatform(String runner, String value) {
+        String normalized = text(value).toLowerCase(Locale.ROOT);
+        if (!PROJECTS.get(runner).containsKey(normalized)) {
+            throw new IllegalArgumentException("Unsupported SHAFT project platform for " + runner + ": " + value);
+        }
+        return normalized;
+    }
+
+    private static List<String> checkedModules(List<String> modules, String platform) {
+        Set<String> checked = new LinkedHashSet<>();
+        if (modules != null) {
+            for (String module : modules) {
+                String normalized = text(module);
+                if (!normalized.isBlank() && OPTIONAL_MODULES.contains(normalized)) {
+                    checked.add(normalized);
+                }
+            }
+        }
+        if ("web".equals(platform)) {
+            checked.add("shaft-visual");
+        }
+        return List.copyOf(checked);
+    }
+
+    private static String addOptionalDependencies(String pom, List<String> modules) {
+        List<String> missing = modules.stream()
+                .filter(module -> !pom.contains("<artifactId>" + module + "</artifactId>"))
+                .toList();
+        if (missing.isEmpty()) {
+            return pom;
+        }
+        StringBuilder block = new StringBuilder();
+        for (String module : missing) {
+            block.append("        <dependency>\n")
+                    .append("            <groupId>io.github.shafthq</groupId>\n")
+                    .append("            <artifactId>").append(module).append("</artifactId>\n")
+                    .append("        </dependency>\n");
+        }
+        String marker = "\\R    </dependencies>\\R    <build>";
+        if (!java.util.regex.Pattern.compile(marker).matcher(pom).find()) {
+            throw new IllegalArgumentException("Could not locate project dependency section in pom.xml");
+        }
+        return pom.replaceFirst(marker, Matcher.quoteReplacement("\n" + block + "    </dependencies>\n    <build>"));
+    }
+
+    private static void copyResourceDirectory(String resourceRoot, Path target, boolean overwrite) throws IOException {
+        URL url = resource(resourceRoot);
+        try {
+            if ("file".equalsIgnoreCase(url.getProtocol())) {
+                Path source = Path.of(url.toURI());
+                Files.walkFileTree(source, new SimpleFileVisitor<>() {
+                    @Override
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                        copyFile(file, target.resolve(source.relativize(file).toString()), target, overwrite);
+                        return FileVisitResult.CONTINUE;
+                    }
+                });
+                return;
+            }
+            if ("jar".equalsIgnoreCase(url.getProtocol())) {
+                JarURLConnection connection = (JarURLConnection) url.openConnection();
+                String prefix = connection.getEntryName() + "/";
+                try (JarFile jar = connection.getJarFile()) {
+                    for (JarEntry entry : jar.stream().filter(entry -> !entry.isDirectory())
+                            .filter(entry -> entry.getName().startsWith(prefix)).toList()) {
+                        Path destination = target.resolve(entry.getName().substring(prefix.length()));
+                        try (var input = jar.getInputStream(entry)) {
+                            copyFile(input.readAllBytes(), destination, target, overwrite);
+                        }
+                    }
+                }
+                return;
+            }
+            throw new IOException("Unsupported project generator resource protocol: " + url.getProtocol());
+        } catch (Exception exception) {
+            if (exception instanceof IOException ioException) {
+                throw ioException;
+            }
+            throw new IOException("Project generator resources could not be read.", exception);
+        }
+    }
+
+    private static void copyResourceFile(String resourceName, Path destination, Path targetRoot, boolean overwrite)
+            throws IOException {
+        try (var input = resource(resourceName).openStream()) {
+            copyFile(input.readAllBytes(), destination, targetRoot, overwrite);
+        }
+    }
+
+    private static void copyFile(Path source, Path destination, Path targetRoot, boolean overwrite) throws IOException {
+        Path normalized = safeDestination(destination, targetRoot);
+        Files.createDirectories(normalized.getParent());
+        if (overwrite) {
+            Files.copy(source, normalized, StandardCopyOption.REPLACE_EXISTING);
+        } else {
+            Files.copy(source, normalized);
+        }
+    }
+
+    private static void copyFile(byte[] content, Path destination, Path targetRoot, boolean overwrite)
+            throws IOException {
+        Path normalized = safeDestination(destination, targetRoot);
+        Files.createDirectories(normalized.getParent());
+        if (overwrite) {
+            Files.write(normalized, content);
+        } else {
+            Files.write(normalized, content, java.nio.file.StandardOpenOption.CREATE_NEW);
+        }
+    }
+
+    private static Path safeDestination(Path destination, Path targetRoot) {
+        Path normalized = destination.toAbsolutePath().normalize();
+        if (targetRoot != null && !normalized.startsWith(targetRoot.toAbsolutePath().normalize())) {
+            throw new IllegalArgumentException("Generated project file escaped the output directory.");
+        }
+        return normalized;
+    }
+
+    private static URL resource(String resourceName) throws IOException {
+        URL url = ShaftProjectService.class.getClassLoader().getResource(resourceName);
+        if (url == null) {
+            throw new IOException("Missing SHAFT project generator resource: " + resourceName);
+        }
+        return url;
+    }
+
+    private static Path resolveUpgraderScript() {
+        Path sourceTreeScript = McpRuntimePaths.currentRoot()
+                .resolve("shaft-upgrader")
+                .resolve("upgrade_to_modular_shaft.py");
+        if (Files.isRegularFile(sourceTreeScript)) {
+            return sourceTreeScript;
+        }
+        Path cached = McpRuntimePaths.applicationDataRoot()
+                .resolve("tools")
+                .resolve("upgrade_to_modular_shaft.py");
+        try {
+            URL resource = resource(UPGRADER_RESOURCE);
+            Files.createDirectories(cached.getParent());
+            try (var input = resource.openStream()) {
+                Files.write(cached, input.readAllBytes());
+            }
+            return cached;
+        } catch (IOException exception) {
+            throw new IllegalStateException("SHAFT upgrader script could not be resolved.", exception);
+        }
+    }
+
+    private static List<String> defaultPythonCommand() {
+        String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+        return os.contains("win") ? List.of("py", "-3") : List.of("python3");
+    }
+
+    private static String validUpgradeType(String value) {
+        String normalized = text(value).toLowerCase(Locale.ROOT);
+        if (Set.of("basic", "session", "full").contains(normalized)) {
+            return normalized;
+        }
+        throw new IllegalArgumentException("Unsupported SHAFT project upgrade type: " + value);
+    }
+
+    private static String workflowName(String platform) {
+        return "web".equals(platform) ? "web.yml" : "api.yml";
+    }
+
+    private static String defaultArtifactId(String runner, String platform) {
+        return "shaft-" + platform.toLowerCase(Locale.ROOT) + "-" + runner.toLowerCase(Locale.ROOT);
+    }
+
+    private static String escapeXml(String value) {
+        return value.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
+    }
+
+    private static String replaceFirst(String text, String regex, String replacement) {
+        return text.replaceFirst(regex, Matcher.quoteReplacement(replacement));
+    }
+
+    private static String defaultText(String value, String defaultValue) {
+        String text = text(value);
+        return text.isBlank() ? defaultValue : text;
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java
@@ -79,6 +79,8 @@ class ShaftMcpApplicationTests {
         assertTrue(toolNames.contains("mobile_replay_recording"));
         assertTrue(toolNames.contains("natural_act"));
         assertTrue(toolNames.contains("shaft_guide_search"));
+        assertTrue(toolNames.contains("shaft_project_create"));
+        assertTrue(toolNames.contains("shaft_project_upgrade"));
         assertTrue(toolNames.contains("test_automation_scenarios"));
         assertTrue(toolNames.contains("test_code_guardrails_check"));
         assertTrue(toolNames.contains("autobot_local_agent_clients"));

--- a/shaft-mcp/src/test/java/com/shaft/mcp/ShaftProjectServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/ShaftProjectServiceTest.java
@@ -1,0 +1,116 @@
+package com.shaft.mcp;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShaftProjectServiceTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void createProjectCopiesExampleAndAppliesGeneratorRules() throws Exception {
+        ShaftProjectService service = new ShaftProjectService(
+                McpWorkspacePolicy.of(temp),
+                new FakeRunner(),
+                temp.resolve("upgrade_to_modular_shaft.py"),
+                List.of("python"));
+
+        McpShaftProjectGenerationResult result = service.createProject(
+                "generated",
+                "TestNG",
+                "api",
+                "com.example",
+                "shaft-api-testng",
+                "1.2.3",
+                List.of("shaft-heal"),
+                true,
+                true,
+                false);
+
+        Path generated = temp.resolve("generated");
+        String pom = Files.readString(generated.resolve("pom.xml"));
+        assertEquals(generated, result.projectDirectory());
+        assertEquals("shaft-testng-api", result.templateProject());
+        assertTrue(pom.contains("<groupId>com.example</groupId>"));
+        assertTrue(pom.contains("<artifactId>shaft-api-testng</artifactId>"));
+        assertTrue(pom.contains("<version>1.2.3</version>"));
+        assertTrue(pom.contains("<artifactId>shaft-heal</artifactId>"));
+        assertTrue(Files.exists(generated.resolve(".github/workflows/api.yml")));
+        assertTrue(Files.exists(generated.resolve(".github/dependabot.yml")));
+    }
+
+    @Test
+    void upgradeProjectRunsExistingScriptAndRequiresApprovalForMutation() throws Exception {
+        Path project = Files.createDirectories(temp.resolve("current"));
+        Files.writeString(project.resolve("pom.xml"), "<project/>");
+        Path script = temp.resolve("upgrade_to_modular_shaft.py");
+        Files.writeString(script, "# script");
+        FakeRunner runner = new FakeRunner();
+        runner.result = new McpProcessRunner.ProcessResult(0, "ok", "", false);
+        ShaftProjectService service = new ShaftProjectService(
+                McpWorkspacePolicy.of(temp),
+                runner,
+                script,
+                List.of("python"));
+
+        McpShaftProjectUpgradeResult result = service.upgradeProject(
+                "current",
+                "basic",
+                true,
+                false,
+                "",
+                "",
+                0,
+                false,
+                false);
+
+        assertEquals(0, result.exitCode());
+        assertEquals(project, runner.workingDirectory);
+        assertTrue(runner.commands.getFirst().contains(script.toString()));
+        assertTrue(runner.commands.getFirst().contains("--dry-run"));
+        assertTrue(runner.commands.getFirst().contains("--no-ai"));
+        assertThrows(IllegalArgumentException.class, () -> service.upgradeProject(
+                "current",
+                "basic",
+                false,
+                false,
+                "",
+                "",
+                0,
+                false,
+                false));
+    }
+
+    private static final class FakeRunner implements McpProcessRunner {
+        private final List<List<String>> commands = new ArrayList<>();
+        private Path workingDirectory;
+        private ProcessResult result = new ProcessResult(0, "", "", false);
+
+        @Override
+        public ProcessResult run(
+                List<String> command,
+                Path workingDirectory,
+                Map<String, String> environment,
+                Duration timeout) {
+            commands.add(command);
+            this.workingDirectory = workingDirectory;
+            return result;
+        }
+
+        @Override
+        public Process start(List<String> command, Path workingDirectory, Map<String, String> environment) {
+            throw new UnsupportedOperationException("No process starts in unit tests.");
+        }
+    }
+}

--- a/shaft-mcp/src/test/java/com/shaft/mcp/ShaftProjectServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/ShaftProjectServiceTest.java
@@ -51,6 +51,20 @@ class ShaftProjectServiceTest {
     }
 
     @Test
+    void resourceDestinationRejectsTraversalOutsideProjectDirectory() {
+        Path project = temp.resolve("project");
+
+        assertEquals(project.resolve("src/test/java/SampleTest.java").toAbsolutePath().normalize(),
+                ShaftProjectService.safeResourceDestination(project, "src/test/java/SampleTest.java"));
+        assertThrows(IllegalArgumentException.class,
+                () -> ShaftProjectService.safeResourceDestination(project, "../pom.xml"));
+        assertThrows(IllegalArgumentException.class,
+                () -> ShaftProjectService.safeResourceDestination(project, "src/../../pom.xml"));
+        assertThrows(IllegalArgumentException.class,
+                () -> ShaftProjectService.safeResourceDestination(project, temp.resolve("pom.xml").toString()));
+    }
+
+    @Test
     void upgradeProjectRunsExistingScriptAndRequiresApprovalForMutation() throws Exception {
         Path project = Files.createDirectories(temp.resolve("current"));
         Files.writeString(project.resolve("pom.xml"), "<project/>");

--- a/shaft-mcp/src/test/resources/fixtures/mcp-tool-manifest.json
+++ b/shaft-mcp/src/test/resources/fixtures/mcp-tool-manifest.json
@@ -120,6 +120,8 @@
     {"name": "healer_run_failed_test", "mutation": true, "sensitive": true, "deprecated": false},
     {"name": "playwright_healer_run_failed_test", "mutation": true, "sensitive": true, "deprecated": false},
     {"name": "shaft_guide_search", "mutation": false, "sensitive": false, "deprecated": false},
+    {"name": "shaft_project_create", "mutation": true, "sensitive": false, "deprecated": false},
+    {"name": "shaft_project_upgrade", "mutation": true, "sensitive": true, "deprecated": false},
     {"name": "test_automation_scenarios", "mutation": false, "sensitive": false, "deprecated": false},
     {"name": "test_code_guardrails_check", "mutation": false, "sensitive": false, "deprecated": false},
     {"name": "autobot_local_agent_clients", "mutation": false, "sensitive": false, "deprecated": false},


### PR DESCRIPTION
## Summary
- add `shaft_project_create` and `shaft_project_upgrade` MCP tools backed by existing examples and `shaft-upgrader/upgrade_to_modular_shaft.py`
- package generator examples and the upgrader script into `shaft-mcp`
- add an IntelliJ Projects tab that invokes the MCP tools through existing JSON templates

## Test Plan
- [x] `mvn -pl shaft-mcp -am '-Dtest=ShaftProjectServiceTest,ShaftMcpApplicationTests' test`
- [x] `mvn -pl shaft-mcp -am package '-DskipTests'`
- [x] `jar tf shaft-mcp\target\shaft-mcp-10.2.20260627.jar` includes generator examples and upgrader script
- [ ] `gradle -p shaft-intellij check` not run locally: no `gradle` executable or wrapper is available in this checkout

## Notes
- `mvn -pl shaft-mcp -am test` exceeded the local 4-minute timeout; the timed-out Maven/Surefire PIDs were stopped.
- Graphify refreshed successfully for SHAFT_ENGINE.