### PR TITLE
Add SshConnectionOptions for strict SSH host keys and non-key auth

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/cli/SshConnectionOptions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/SshConnectionOptions.java
@@ -1,0 +1,249 @@
+package com.shaft.cli;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable SSH connection settings for reusable {@link TerminalActions} remote terminals.
+ */
+public final class SshConnectionOptions {
+    private final String host;
+    private final int port;
+    private final String username;
+    private final Path privateKey;
+    private final String privateKeyPassphrase;
+    private final String password;
+    private final Path knownHosts;
+    private final boolean strictHostKeyChecking;
+    private final KeyboardInteractive keyboardInteractive;
+    private final Map<String, String> extraJschConfig;
+    private final boolean verbose;
+    private final boolean legacyFacade;
+
+    private SshConnectionOptions(Builder builder) {
+        host = builder.host;
+        port = builder.port;
+        username = builder.username;
+        privateKey = builder.privateKey;
+        privateKeyPassphrase = builder.privateKeyPassphrase;
+        password = builder.password;
+        knownHosts = builder.knownHosts;
+        strictHostKeyChecking = builder.strictHostKeyChecking != null
+                ? builder.strictHostKeyChecking
+                : builder.knownHosts != null;
+        keyboardInteractive = builder.keyboardInteractive;
+        extraJschConfig = Collections.unmodifiableMap(new LinkedHashMap<>(builder.extraJschConfig));
+        verbose = builder.verbose;
+        legacyFacade = builder.legacyFacade;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builds permissive legacy options for existing string-based {@code remoteTerminal(...)} overloads.
+     */
+    public static SshConnectionOptions fromKeyFile(String host, int port, String username,
+                                                   String sshKeyFileFolderName, String sshKeyFileName, boolean verbose) {
+        Builder builder = builder()
+                .host(host)
+                .port(port)
+                .username(username)
+                .strictHostKeyChecking(false)
+                .verbose(verbose)
+                .legacyFacade(true);
+        if (sshKeyFileName != null && !sshKeyFileName.isBlank()) {
+            String absoluteKeyPath = FileActions.getInstance(true).getAbsolutePath(sshKeyFileFolderName, sshKeyFileName);
+            builder.privateKey(Path.of(absoluteKeyPath));
+        }
+        return builder.build();
+    }
+
+    public void validate() {
+        if (host == null || host.isBlank()) {
+            throw new IllegalArgumentException("SSH connection options require a non-blank host.");
+        }
+        if (username == null || username.isBlank()) {
+            throw new IllegalArgumentException("SSH connection options require a non-blank username.");
+        }
+        if (port <= 0) {
+            throw new IllegalArgumentException("SSH connection options require a positive port.");
+        }
+        boolean hasPrivateKey = privateKey != null;
+        boolean hasPassword = password != null && !password.isBlank();
+        boolean hasKeyboardInteractive = keyboardInteractive != null;
+        if (!legacyFacade && !hasPrivateKey && !hasPassword && !hasKeyboardInteractive) {
+            throw new IllegalArgumentException("SSH connection options require a private key, password, or keyboard-interactive handler.");
+        }
+        if (strictHostKeyChecking && knownHosts == null) {
+            throw new IllegalArgumentException("SSH strict host key checking requires a known_hosts file path.");
+        }
+    }
+
+    public String toRedactedDescription() {
+        StringBuilder description = new StringBuilder();
+        description.append(host).append(", ").append(port).append(", ").append(username);
+        if (privateKey != null) {
+            description.append(", privateKey=").append(privateKey);
+        }
+        if (knownHosts != null) {
+            description.append(", knownHosts=").append(knownHosts);
+        }
+        description.append(", strictHostKeyChecking=").append(strictHostKeyChecking);
+        if (privateKeyPassphrase != null && !privateKeyPassphrase.isBlank()) {
+            description.append(", privateKeyPassphrase=***");
+        }
+        if (password != null && !password.isBlank()) {
+            description.append(", password=***");
+        }
+        if (keyboardInteractive != null) {
+            description.append(", keyboardInteractive=enabled");
+        }
+        return description.toString();
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public Path getPrivateKey() {
+        return privateKey;
+    }
+
+    public String getPrivateKeyPassphrase() {
+        return privateKeyPassphrase;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public Path getKnownHosts() {
+        return knownHosts;
+    }
+
+    public boolean isStrictHostKeyChecking() {
+        return strictHostKeyChecking;
+    }
+
+    public KeyboardInteractive getKeyboardInteractive() {
+        return keyboardInteractive;
+    }
+
+    public Map<String, String> getExtraJschConfig() {
+        return extraJschConfig;
+    }
+
+    public boolean isVerbose() {
+        return verbose;
+    }
+
+    /**
+     * Supplies responses for JSch keyboard-interactive authentication prompts.
+     */
+    @FunctionalInterface
+    public interface KeyboardInteractive {
+        /**
+         * @param destination  remote host identifier
+         * @param name         authentication method name
+         * @param instruction  server instruction text
+         * @param prompt       prompt labels
+         * @param echo         whether each response should be echoed
+         * @return one response per prompt
+         */
+        String[] respond(String destination, String name, String instruction, String[] prompt, boolean[] echo);
+    }
+
+    public static final class Builder {
+        private String host;
+        private int port = 22;
+        private String username;
+        private Path privateKey;
+        private String privateKeyPassphrase;
+        private String password;
+        private Path knownHosts;
+        private Boolean strictHostKeyChecking;
+        private KeyboardInteractive keyboardInteractive;
+        private final Map<String, String> extraJschConfig = new LinkedHashMap<>();
+        private boolean verbose;
+        private boolean legacyFacade;
+
+        public Builder legacyFacade(boolean value) {
+            legacyFacade = value;
+            return this;
+        }
+
+        public Builder host(String value) {
+            host = value;
+            return this;
+        }
+
+        public Builder port(int value) {
+            port = value;
+            return this;
+        }
+
+        public Builder username(String value) {
+            username = value;
+            return this;
+        }
+
+        public Builder privateKey(Path value) {
+            privateKey = value;
+            return this;
+        }
+
+        public Builder privateKeyPassphrase(String value) {
+            privateKeyPassphrase = value;
+            return this;
+        }
+
+        public Builder password(String value) {
+            password = value;
+            return this;
+        }
+
+        public Builder knownHosts(Path value) {
+            knownHosts = value;
+            return this;
+        }
+
+        public Builder strictHostKeyChecking(boolean value) {
+            strictHostKeyChecking = value;
+            return this;
+        }
+
+        public Builder keyboardInteractive(KeyboardInteractive value) {
+            keyboardInteractive = value;
+            return this;
+        }
+
+        public Builder extraJschConfig(String key, String value) {
+            extraJschConfig.put(Objects.requireNonNull(key), Objects.requireNonNull(value));
+            return this;
+        }
+
+        public Builder verbose(boolean value) {
+            verbose = value;
+            return this;
+        }
+
+        public SshConnectionOptions build() {
+            SshConnectionOptions options = new SshConnectionOptions(this);
+            options.validate();
+            return options;
+        }
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/cli/SshConnectionOptions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/SshConnectionOptions.java
@@ -64,21 +64,45 @@ public final class SshConnectionOptions {
     }
 
     public void validate() {
+        validateHost();
+        validateUsername();
+        validatePort();
+        validateAuthentication();
+        validateKnownHostsForStrictChecking();
+    }
+
+    private void validateHost() {
         if (host == null || host.isBlank()) {
             throw new IllegalArgumentException("SSH connection options require a non-blank host.");
         }
+    }
+
+    private void validateUsername() {
         if (username == null || username.isBlank()) {
             throw new IllegalArgumentException("SSH connection options require a non-blank username.");
         }
+    }
+
+    private void validatePort() {
         if (port <= 0) {
             throw new IllegalArgumentException("SSH connection options require a positive port.");
         }
-        boolean hasPrivateKey = privateKey != null;
-        boolean hasPassword = password != null && !password.isBlank();
-        boolean hasKeyboardInteractive = keyboardInteractive != null;
-        if (!legacyFacade && !hasPrivateKey && !hasPassword && !hasKeyboardInteractive) {
-            throw new IllegalArgumentException("SSH connection options require a private key, password, or keyboard-interactive handler.");
+    }
+
+    private void validateAuthentication() {
+        if (legacyFacade || hasAuthenticationMethod()) {
+            return;
         }
+        throw new IllegalArgumentException("SSH connection options require a private key, password, or keyboard-interactive handler.");
+    }
+
+    private boolean hasAuthenticationMethod() {
+        return privateKey != null
+                || (password != null && !password.isBlank())
+                || keyboardInteractive != null;
+    }
+
+    private void validateKnownHostsForStrictChecking() {
         if (strictHostKeyChecking && knownHosts == null) {
             throw new IllegalArgumentException("SSH strict host key checking requires a known_hosts file path.");
         }

--- a/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
  * @see com.shaft.driver.SHAFT.CLI
  */
 @SuppressWarnings("unused")
-public class TerminalActions {
+public class TerminalActions implements AutoCloseable {
     @Getter
     private String sshHostName = "";
     @Getter
@@ -56,6 +56,7 @@ public class TerminalActions {
     private boolean verbose = false;
     private boolean isInternal = false;
     private boolean reuseRemoteSession = false;
+    private SshConnectionOptions sshConnectionOptions;
     private Session reusableRemoteSession;
     private ScheduledExecutorService reusableSessionTimeoutScheduler;
     private ScheduledFuture<?> reusableSessionTimeoutTask;
@@ -213,10 +214,38 @@ public class TerminalActions {
      */
     public static TerminalActions getRemoteInstance(String sshHostName, int sshPortNumber, String sshUsername,
                                                     String sshKeyFileFolderName, String sshKeyFileName, boolean verbose) {
-        TerminalActions terminalActions = new TerminalActions(sshHostName, sshPortNumber, sshUsername,
-                sshKeyFileFolderName, sshKeyFileName);
+        TerminalActions terminalActions = getRemoteInstance(SshConnectionOptions.fromKeyFile(sshHostName, sshPortNumber, sshUsername,
+                sshKeyFileFolderName, sshKeyFileName, verbose));
+        terminalActions.sshKeyFileFolderName = sshKeyFileFolderName;
+        terminalActions.sshKeyFileName = sshKeyFileName;
+        return terminalActions;
+    }
+
+    /**
+     * Creates a reusable remote terminal from {@link SshConnectionOptions}.
+     *
+     * @param options validated SSH connection options
+     * @return a reusable remote {@link TerminalActions} instance
+     */
+    public static TerminalActions getRemoteInstance(SshConnectionOptions options) {
+        options.validate();
+        TerminalActions terminalActions = new TerminalActions();
+        terminalActions.sshConnectionOptions = options;
+        terminalActions.sshHostName = options.getHost();
+        terminalActions.sshPortNumber = options.getPort();
+        terminalActions.sshUsername = options.getUsername();
+        if (options.getPrivateKey() != null) {
+            Path privateKey = options.getPrivateKey();
+            Path parent = privateKey.getParent();
+            terminalActions.sshKeyFileFolderName = parent == null ? "" : parent.toString();
+            if (!terminalActions.sshKeyFileFolderName.isEmpty()
+                    && !terminalActions.sshKeyFileFolderName.endsWith(File.separator)) {
+                terminalActions.sshKeyFileFolderName += File.separator;
+            }
+            terminalActions.sshKeyFileName = privateKey.getFileName().toString();
+        }
         terminalActions.reuseRemoteSession = true;
-        terminalActions.verbose = verbose;
+        terminalActions.verbose = options.isVerbose();
         return terminalActions;
     }
 
@@ -506,6 +535,14 @@ public class TerminalActions {
         }
     }
 
+    /**
+     * Closes the reusable remote SSH session by delegating to {@link #quit()}.
+     */
+    @Override
+    public synchronized void close() {
+        quit();
+    }
+
     private void passAction(String actionName, String testData, String log) {
         reportActionResult(actionName, testData, log, true);
     }
@@ -534,6 +571,13 @@ public class TerminalActions {
     }
 
     private Session createSSHsession() {
+        if (sshConnectionOptions != null) {
+            return createOptionsBackedSshSession(sshConnectionOptions);
+        }
+        return createLegacySshSession();
+    }
+
+    private Session createLegacySshSession() {
         Session session = null;
         String testData = sshHostName + ", " + sshPortNumber + ", " + sshUsername + ", " + sshKeyFileFolderName + ", "
                 + sshKeyFileName;
@@ -553,6 +597,100 @@ public class TerminalActions {
             failAction(testData, rootCauseException);
         }
         return session;
+    }
+
+    private Session createOptionsBackedSshSession(SshConnectionOptions options) {
+        Session session = null;
+        String testData = options.toRedactedDescription();
+        try {
+            JSch jsch = new JSch();
+            if (options.getKnownHosts() != null) {
+                jsch.setKnownHosts(options.getKnownHosts().toString());
+            }
+            if (options.getPrivateKey() != null) {
+                String privateKeyPath = options.getPrivateKey().toString();
+                if (options.getPrivateKeyPassphrase() != null && !options.getPrivateKeyPassphrase().isBlank()) {
+                    jsch.addIdentity(privateKeyPath, options.getPrivateKeyPassphrase());
+                } else {
+                    jsch.addIdentity(privateKeyPath);
+                }
+            }
+            session = jsch.getSession(options.getUsername(), options.getHost(), options.getPort());
+            Properties config = new Properties();
+            config.put("StrictHostKeyChecking", options.isStrictHostKeyChecking() ? "yes" : "no");
+            options.getExtraJschConfig().forEach(config::put);
+            session.setConfig(config);
+            if (options.getPassword() != null && !options.getPassword().isBlank()) {
+                session.setPassword(options.getPassword());
+            }
+            UserInfo userInfo = createUserInfo(options);
+            if (userInfo != null) {
+                session.setUserInfo(userInfo);
+            }
+            configureRemoteSshKeepAlive(session);
+            session.connect();
+            ReportManager.logDiscrete("Created SSH session for " + options.getUsername() + "@"
+                    + options.getHost() + ":" + options.getPort() + ".");
+        } catch (JSchException rootCauseException) {
+            failAction(testData, rootCauseException);
+        }
+        return session;
+    }
+
+    private UserInfo createUserInfo(SshConnectionOptions options) {
+        boolean needsUserInfo = (options.getPrivateKeyPassphrase() != null && !options.getPrivateKeyPassphrase().isBlank())
+                || options.getKeyboardInteractive() != null;
+        if (!needsUserInfo) {
+            return null;
+        }
+        return new SshUserInfo(options);
+    }
+
+    private static final class SshUserInfo implements UserInfo, UIKeyboardInteractive {
+        private final SshConnectionOptions options;
+
+        private SshUserInfo(SshConnectionOptions options) {
+            this.options = options;
+        }
+
+        @Override
+        public String getPassphrase() {
+            return options.getPrivateKeyPassphrase();
+        }
+
+        @Override
+        public String getPassword() {
+            return options.getPassword();
+        }
+
+        @Override
+        public boolean promptPassword(String message) {
+            return false;
+        }
+
+        @Override
+        public boolean promptPassphrase(String message) {
+            return false;
+        }
+
+        @Override
+        public boolean promptYesNo(String message) {
+            return false;
+        }
+
+        @Override
+        public void showMessage(String message) {
+            // no interactive console in automated tests
+        }
+
+        @Override
+        public String[] promptKeyboardInteractive(String destination, String name, String instruction,
+                                                  String[] prompt, boolean[] echo) {
+            if (options.getKeyboardInteractive() == null) {
+                return new String[prompt.length];
+            }
+            return options.getKeyboardInteractive().respond(destination, name, instruction, prompt, echo);
+        }
     }
 
     private void configureRemoteSshKeepAlive(Session session) throws JSchException {

--- a/shaft-engine/src/main/java/com/shaft/driver/SHAFT.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/SHAFT.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.shaft.api.RequestBuilder;
 import com.shaft.api.RestActions;
 import com.shaft.cli.FileActions;
+import com.shaft.cli.SshConnectionOptions;
 import com.shaft.cli.TerminalActions;
 import com.shaft.db.DatabaseActions;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
@@ -881,6 +882,16 @@ public class SHAFT {
                                                      String sshKeyFileFolderName, String sshKeyFileName, boolean verbose) {
             return TerminalActions.getRemoteInstance(sshHostName, sshPortNumber, sshUsername,
                     sshKeyFileFolderName, sshKeyFileName, verbose);
+        }
+
+        /**
+         * Creates a reusable remote terminal from {@link SshConnectionOptions}.
+         *
+         * @param options validated SSH connection options
+         * @return a reusable remote {@link TerminalActions} instance
+         */
+        public static TerminalActions remoteTerminal(SshConnectionOptions options) {
+            return TerminalActions.getRemoteInstance(options);
         }
 
         /**

--- a/shaft-engine/src/test/java/testPackage/unitTests/SshConnectionOptionsUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/SshConnectionOptionsUnitTest.java
@@ -1,0 +1,83 @@
+package testPackage.unitTests;
+
+import com.shaft.cli.SshConnectionOptions;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+
+public class SshConnectionOptionsUnitTest {
+    @Test(description = "Builder should default strict host key checking to true when known_hosts is provided")
+    public void builderShouldEnableStrictHostKeyCheckingWhenKnownHostsProvided() {
+        SshConnectionOptions options = SshConnectionOptions.builder()
+                .host("host.example.com")
+                .username("user")
+                .password("secret")
+                .knownHosts(Path.of("known_hosts"))
+                .build();
+
+        Assert.assertTrue(options.isStrictHostKeyChecking());
+    }
+
+    @Test(description = "Builder should reject blank host values")
+    public void builderShouldRejectBlankHost() {
+        IllegalArgumentException failure = Assert.expectThrows(IllegalArgumentException.class,
+                () -> SshConnectionOptions.builder()
+                        .host(" ")
+                        .username("user")
+                        .password("secret")
+                        .build());
+        Assert.assertTrue(failure.getMessage().contains("host"));
+    }
+
+    @Test(description = "Builder should reject strict host key checking without known_hosts")
+    public void builderShouldRejectStrictHostKeyCheckingWithoutKnownHosts() {
+        IllegalArgumentException failure = Assert.expectThrows(IllegalArgumentException.class,
+                () -> SshConnectionOptions.builder()
+                        .host("host.example.com")
+                        .username("user")
+                        .password("secret")
+                        .strictHostKeyChecking(true)
+                        .build());
+        Assert.assertTrue(failure.getMessage().contains("known_hosts"));
+    }
+
+    @Test(description = "Builder should require at least one authentication method")
+    public void builderShouldRequireAuthenticationMethod() {
+        IllegalArgumentException failure = Assert.expectThrows(IllegalArgumentException.class,
+                () -> SshConnectionOptions.builder()
+                        .host("host.example.com")
+                        .username("user")
+                        .build());
+        Assert.assertTrue(failure.getMessage().contains("private key"));
+    }
+
+    @Test(description = "Redacted description should not expose password or passphrase values")
+    public void redactedDescriptionShouldNotExposeSecrets() {
+        SshConnectionOptions options = SshConnectionOptions.builder()
+                .host("host.example.com")
+                .username("user")
+                .password("super-secret")
+                .privateKey(Path.of("id_rsa"))
+                .privateKeyPassphrase("phrase-secret")
+                .build();
+
+        String description = options.toRedactedDescription();
+        Assert.assertFalse(description.contains("super-secret"));
+        Assert.assertFalse(description.contains("phrase-secret"));
+        Assert.assertTrue(description.contains("password=***"));
+        Assert.assertTrue(description.contains("privateKeyPassphrase=***"));
+    }
+
+    @Test(description = "Keyboard-interactive handler should satisfy authentication requirement")
+    public void keyboardInteractiveHandlerShouldSatisfyAuthenticationRequirement() {
+        SshConnectionOptions.KeyboardInteractive handler = (destination, name, instruction, prompt, echo) -> new String[]{"response"};
+        SshConnectionOptions options = SshConnectionOptions.builder()
+                .host("host.example.com")
+                .username("user")
+                .keyboardInteractive(handler)
+                .build();
+
+        Assert.assertSame(handler, options.getKeyboardInteractive());
+    }
+}

--- a/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
@@ -3,8 +3,10 @@ package testPackage.unitTests;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
+import com.shaft.cli.SshConnectionOptions;
 import com.shaft.cli.TerminalActions;
 import com.shaft.driver.SHAFT;
+import org.apache.commons.lang3.SystemUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -357,8 +359,11 @@ public class TerminalActionsUnitTest {
     public void performTerminalCommandsShouldRunFromChangedDirectory() throws Exception {
         Path tempDir = createTempDir("cwd");
         TerminalActions terminal = TerminalActions.getInstance(false, false, true);
-        String log = terminal.performTerminalCommands(List.of("cd " + tempDir.toAbsolutePath(), "pwd"));
-        Assert.assertTrue(log.contains(tempDir.toAbsolutePath().toString()),
+        String directory = tempDir.toAbsolutePath().toString();
+        String log = SystemUtils.IS_OS_WINDOWS
+                ? terminal.performTerminalCommands(List.of("cd " + directory, "(Get-Location).Path"))
+                : terminal.performTerminalCommands(List.of("cd " + directory, "pwd"));
+        Assert.assertTrue(log.toLowerCase().contains(directory.toLowerCase()),
                 "Expected command log to include changed working directory.");
     }
 
@@ -631,6 +636,20 @@ public class TerminalActionsUnitTest {
         } finally {
             SHAFT.Properties.timeouts.set().sshServerAliveInterval(originalInterval);
         }
+    }
+
+    @Test(description = "close should delegate to quit for reusable remote terminals")
+    public void closeShouldDelegateToQuitForReusableRemoteTerminal() {
+        TerminalActions terminal = SHAFT.CLI.remoteTerminal("host.example.com", 22, "user", "", "");
+        Assert.assertTrue(terminal.isRemoteTerminal());
+        terminal.close();
+        terminal.quit();
+    }
+
+    @Test(description = "SshConnectionOptions legacy facade should disable strict host key checking by default")
+    public void sshConnectionOptionsLegacyFacadeShouldDisableStrictHostKeyChecking() {
+        SshConnectionOptions options = SshConnectionOptions.fromKeyFile("host.example.com", 22, "user", "/keys/", "id_rsa", false);
+        Assert.assertFalse(options.isStrictHostKeyChecking());
     }
 
     @Test(description = "createSSHsession should surface connection failures for invalid settings")


### PR DESCRIPTION
## Summary
- Add public `SshConnectionOptions` builder with known_hosts, strict host key checking, password, key passphrase, and keyboard-interactive auth
- Add `SHAFT.CLI.remoteTerminal(SshConnectionOptions)`; existing string overloads stay permissive for backward compatibility
- Make `TerminalActions` implement `AutoCloseable` with `close()` delegating to `quit()`

## Tests
[SshConnectionOptions-Report.html](https://github.com/user-attachments/files/29441955/SshConnectionOptions-Report.html)

Part of #3130

