### PR TITLE
Add SshCommandResult and performSshCommand

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/cli/SshCommandResult.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/SshCommandResult.java
@@ -1,0 +1,49 @@
+package com.shaft.cli;
+
+import java.util.Objects;
+
+/**
+ * Structured result of a remote SSH command executed through {@link TerminalActions}.
+ *
+ * @param command        the exact command text that was executed
+ * @param stdout         standard output captured from the remote command
+ * @param stderr         standard error captured from the remote command
+ * @param exitCode       remote process exit code
+ * @param durationMillis elapsed execution time in milliseconds
+ */
+public record SshCommandResult(
+        String command,
+        String stdout,
+        String stderr,
+        int exitCode,
+        long durationMillis) {
+
+    /**
+     * Creates an immutable SSH command result with non-null stream values.
+     */
+    public SshCommandResult {
+        command = Objects.requireNonNullElse(command, "");
+        stdout = Objects.requireNonNullElse(stdout, "");
+        stderr = Objects.requireNonNullElse(stderr, "");
+    }
+
+    /**
+     * @return {@code true} when the remote command exited with code {@code 0}
+     */
+    public boolean succeeded() {
+        return exitCode == 0;
+    }
+
+    /**
+     * @return stdout and stderr merged in execution order for callers that expect one combined log
+     */
+    public String combinedOutput() {
+        if (stdout.isEmpty()) {
+            return stderr;
+        }
+        if (stderr.isEmpty()) {
+            return stdout;
+        }
+        return stdout + System.lineSeparator() + stderr;
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
@@ -18,6 +18,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.function.BooleanSupplier;
+import java.util.function.IntSupplier;
 import java.util.regex.Pattern;
 
 /**
@@ -322,7 +324,7 @@ public class TerminalActions {
                 : internalCommands;
 
         // Perform command
-        List<String> exitLogs = isRemoteTerminal() ? executeRemoteCommand(commandsToExecute, longCommand, environmentVariables) : executeLocalCommand(commandsToExecute, longCommand, environmentVariables);
+        List<String> exitLogs = isRemoteTerminal() ? executeRemoteCommand(longCommand, environmentVariables) : executeLocalCommand(commandsToExecute, longCommand, environmentVariables);
         String log = exitLogs.get(0);
         String exitStatus = exitLogs.get(1);
 
@@ -364,6 +366,53 @@ public class TerminalActions {
      */
     public String performTerminalCommand(String command, Map<String, String> environmentVariables) {
         return performTerminalCommands(Collections.singletonList(command), environmentVariables);
+    }
+
+    /**
+     * Executes a remote SSH command and returns structured stdout, stderr, and exit code.
+     *
+     * <p>Requires a reusable remote terminal created through
+     * {@link com.shaft.driver.SHAFT.CLI#remoteTerminal(String, int, String, String, String)}.
+     * Non-zero remote exit codes are returned in the result and do not fail the action by themselves.</p>
+     *
+     * @param command the remote command to execute
+     * @return structured command result with unredacted stream content for assertions
+     */
+    public SshCommandResult performSshCommand(String command) {
+        return performSshCommand(command, Collections.emptyMap());
+    }
+
+    /**
+     * Executes a remote SSH command with environment variables and returns structured output.
+     *
+     * @param command              the remote command to execute
+     * @param environmentVariables remote environment variables sent as SSH {@code env} requests
+     * @return structured command result with unredacted stream content for assertions
+     * @see #performSshCommand(String)
+     */
+    public SshCommandResult performSshCommand(String command, Map<String, String> environmentVariables) {
+        verifyReusableRemoteSessionFeature();
+        if (command == null || command.isBlank()) {
+            failAction("SSH command", new IllegalArgumentException("SSH command must not be blank."));
+        }
+        return executeRemoteSshCommand(command, environmentVariables);
+    }
+
+    /**
+     * Executes multiple remote SSH commands sequentially on the same reusable session.
+     *
+     * @param commands             the remote commands to execute in order
+     * @param environmentVariables remote environment variables sent as SSH {@code env} requests
+     * @return one structured result per command
+     */
+    public List<SshCommandResult> performSshCommands(List<String> commands, Map<String, String> environmentVariables) {
+        verifyReusableRemoteSessionFeature();
+        List<String> internalCommands = getValidCommands(commands);
+        List<SshCommandResult> results = new ArrayList<>(internalCommands.size());
+        for (String command : internalCommands) {
+            results.add(executeRemoteSshCommand(command, environmentVariables));
+        }
+        return results;
     }
 
     private List<String> getValidCommands(List<String> commands) {
@@ -852,43 +901,149 @@ public class TerminalActions {
         return pb;
     }
 
-    private List<String> executeRemoteCommand(List<String> commands, String longCommand, Map<String, String> environmentVariables) {
-        StringBuilder logs = new StringBuilder();
-        StringBuilder exitStatuses = new StringBuilder();
+    private List<String> executeRemoteCommand(String longCommand, Map<String, String> environmentVariables) {
+        RemoteCommandCapture capture = runRemoteExecChannel(longCommand, environmentVariables);
+        return Arrays.asList(mergeRemoteCommandOutput(capture.stdout(), capture.stderr()), String.valueOf(capture.exitCode()));
+    }
+
+    private SshCommandResult executeRemoteSshCommand(String command, Map<String, String> environmentVariables) {
+        long startedAt = System.nanoTime();
+        RemoteCommandCapture capture = runRemoteExecChannel(command, environmentVariables);
+        return reportSshCommandResult(command, capture, startedAt);
+    }
+
+    private SshCommandResult reportSshCommandResult(String command, RemoteCommandCapture capture, long startedAt) {
+        long durationMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
+        SshCommandResult result = new SshCommandResult(command, capture.stdout(), capture.stderr(), capture.exitCode(), durationMillis);
+        passAction(buildSshCommandReportMessage(result), buildSshCommandReportLog(result));
+        return result;
+    }
+
+    private String buildSshCommandReportMessage(SshCommandResult result) {
+        StringBuilder reportMessage = new StringBuilder();
+        reportMessage.append("Host Name: \"").append(sshHostName).append("\"");
+        reportMessage.append(" | SSH Port Number: \"").append(sshPortNumber).append("\"");
+        reportMessage.append(" | SSH Username: \"").append(sshUsername).append("\"");
+        if (sshKeyFileName != null && !sshKeyFileName.isEmpty()) {
+            reportMessage.append(" | Key File: \"").append(sshKeyFileFolderName).append(sshKeyFileName).append("\"");
+        }
+        reportMessage.append(" | Command: \"").append(result.command()).append("\"");
+        reportMessage.append(" | Exit Status: \"").append(result.exitCode()).append("\"");
+        reportMessage.append(" | Duration (ms): \"").append(result.durationMillis()).append("\"");
+        return reportMessage.toString();
+    }
+
+    private static String buildSshCommandReportLog(SshCommandResult result) {
+        return mergeRemoteCommandOutput(result.stdout(), result.stderr());
+    }
+
+    private RemoteCommandCapture runRemoteExecChannel(String command, Map<String, String> environmentVariables) {
         int sessionTimeout = Math.toIntExact(TimeUnit.MINUTES.toMillis(SHAFT.Properties.timeouts.shellSessionTimeout()));
-        // remote execution
-        ReportManager.logDiscrete("Executing remote command: \"" + redactTerminalLogForReporting(longCommand) + "\".");
+        ReportManager.logDiscrete("Executing remote command: \"" + redactTerminalLogForReporting(command) + "\".");
         Session remoteSession = getRemoteSession();
+        if (remoteSession == null) {
+            failAction(command, new IllegalStateException("Remote SSH session is not available."));
+        }
         ChannelExec remoteChannelExecutor = null;
-        if (remoteSession != null) {
+        try {
+            remoteChannelExecutor = openRemoteExecChannel(remoteSession, command, environmentVariables, sessionTimeout);
+            return readRemoteExecChannelOutput(remoteChannelExecutor, sessionTimeout);
+        } catch (JSchException | IOException exception) {
+            failAction(command, exception);
+            return new RemoteCommandCapture("", "", -1);
+        } finally {
+            disconnectRemoteExecChannel(remoteChannelExecutor, remoteSession);
+        }
+    }
+
+    private ChannelExec openRemoteExecChannel(Session remoteSession, String command, Map<String, String> environmentVariables,
+                                              int sessionTimeout) throws JSchException {
+        remoteSession.setTimeout(sessionTimeout);
+        ChannelExec remoteChannelExecutor = (ChannelExec) remoteSession.openChannel("exec");
+        remoteChannelExecutor.setCommand(command);
+        if (environmentVariables != null) {
+            environmentVariables.forEach(remoteChannelExecutor::setEnv);
+        }
+        return remoteChannelExecutor;
+    }
+
+    private RemoteCommandCapture readRemoteExecChannelOutput(ChannelExec remoteChannelExecutor, int sessionTimeout)
+            throws IOException, JSchException {
+        return captureRemoteCommandStreams(
+                remoteChannelExecutor.getInputStream(),
+                remoteChannelExecutor.getErrStream(),
+                () -> remoteChannelExecutor.connect(sessionTimeout),
+                remoteChannelExecutor::isClosed,
+                remoteChannelExecutor::getExitStatus,
+                sessionTimeout);
+    }
+
+    private void disconnectRemoteExecChannel(ChannelExec remoteChannelExecutor, Session remoteSession) {
+        if (remoteChannelExecutor != null && remoteChannelExecutor.isConnected()) {
+            remoteChannelExecutor.disconnect();
+        }
+        disconnectRemoteSessionIfEphemeral(remoteSession);
+    }
+
+    private RemoteCommandCapture captureRemoteCommandStreams(InputStream stdoutStream, InputStream stderrStream,
+                                                             ThrowingRunnable connectAction,
+                                                             BooleanSupplier channelClosed,
+                                                             IntSupplier exitCodeSupplier,
+                                                             long timeoutMillis)
+            throws IOException, JSchException {
+        ExecutorService streamReaders = Executors.newFixedThreadPool(2);
+        try {
+            Future<String> stdoutFuture = streamReaders.submit(() -> readProcessStream(stdoutStream));
+            Future<String> stderrFuture = streamReaders.submit(() -> readProcessStream(stderrStream));
+            connectAction.run();
+            long deadline = System.currentTimeMillis() + timeoutMillis;
+            String stdout = awaitRemoteStreamOutput(stdoutFuture, timeoutMillis);
+            String stderr = awaitRemoteStreamOutput(stderrFuture, Math.max(0, deadline - System.currentTimeMillis()));
+            awaitChannelClosed(channelClosed, deadline);
+            return new RemoteCommandCapture(stdout, stderr, exitCodeSupplier.getAsInt());
+        } finally {
+            streamReaders.shutdownNow();
+        }
+    }
+
+    private String awaitRemoteStreamOutput(Future<String> future, long timeoutMillis) {
+        try {
+            return future.get(Math.max(1, timeoutMillis), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            return "";
+        } catch (ExecutionException | TimeoutException exception) {
+            return "";
+        }
+    }
+
+    private void awaitChannelClosed(BooleanSupplier channelClosed, long deadline) {
+        while (!channelClosed.getAsBoolean() && System.currentTimeMillis() < deadline) {
             try {
-                remoteSession.setTimeout(sessionTimeout);
-                remoteChannelExecutor = (ChannelExec) remoteSession.openChannel("exec");
-                remoteChannelExecutor.setCommand(longCommand);
-                if (environmentVariables != null) {
-                    environmentVariables.forEach(remoteChannelExecutor::setEnv);
-                }
-                remoteChannelExecutor.connect();
-
-                // Capture logs and close readers
-                try (BufferedReader reader = new BufferedReader(new InputStreamReader(remoteChannelExecutor.getInputStream()));
-                     BufferedReader errorReader = new BufferedReader(new InputStreamReader(remoteChannelExecutor.getErrStream()))) {
-                    logs.append(readConsoleLogs(reader));
-                    logs.append(readConsoleLogs(errorReader));
-                }
-
-                // Retrieve the exit status of the executed command and destroy open sessions
-                exitStatuses.append(remoteChannelExecutor.getExitStatus());
-            } catch (JSchException | IOException exception) {
-                failAction(longCommand, exception);
-            } finally {
-                if (remoteChannelExecutor != null && remoteChannelExecutor.isConnected()) {
-                    remoteChannelExecutor.disconnect();
-                }
-                disconnectRemoteSessionIfEphemeral(remoteSession);
+                Thread.sleep(50);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                return;
             }
         }
-        return Arrays.asList(logs.toString(), exitStatuses.toString());
+    }
+
+    private static String mergeRemoteCommandOutput(String stdout, String stderr) {
+        if (stdout == null || stdout.isEmpty()) {
+            return stderr == null ? "" : stderr;
+        }
+        if (stderr == null || stderr.isEmpty()) {
+            return stdout;
+        }
+        return stdout + System.lineSeparator() + stderr;
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws JSchException;
+    }
+
+    private record RemoteCommandCapture(String stdout, String stderr, int exitCode) {
     }
 
     private String readConsoleLogs(BufferedReader reader) throws IOException {

--- a/shaft-engine/src/test/java/testPackage/unitTests/SshCommandResultUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/SshCommandResultUnitTest.java
@@ -1,0 +1,41 @@
+package testPackage.unitTests;
+
+import com.shaft.cli.SshCommandResult;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class SshCommandResultUnitTest {
+    @Test(description = "succeeded should be true only for exit code zero")
+    public void succeededShouldReflectZeroExitCode() {
+        Assert.assertTrue(new SshCommandResult("cmd", "ok", "", 0, 1L).succeeded());
+        Assert.assertFalse(new SshCommandResult("cmd", "ok", "", 7, 1L).succeeded());
+    }
+
+    @Test(description = "combinedOutput should return stdout when stderr is empty")
+    public void combinedOutputShouldReturnStdoutOnly() {
+        SshCommandResult result = new SshCommandResult("cmd", "stdout-only", "", 0, 1L);
+        Assert.assertEquals(result.combinedOutput(), "stdout-only");
+    }
+
+    @Test(description = "combinedOutput should return stderr when stdout is empty")
+    public void combinedOutputShouldReturnStderrOnly() {
+        SshCommandResult result = new SshCommandResult("cmd", "", "stderr-only", 0, 1L);
+        Assert.assertEquals(result.combinedOutput(), "stderr-only");
+    }
+
+    @Test(description = "combinedOutput should merge stdout and stderr with a line separator")
+    public void combinedOutputShouldMergeStdoutAndStderr() {
+        SshCommandResult result = new SshCommandResult("cmd", "stdout", "stderr", 0, 1L);
+        Assert.assertEquals(result.combinedOutput(), "stdout" + System.lineSeparator() + "stderr");
+    }
+
+    @Test(description = "accessors should expose exact command and stream values")
+    public void accessorsShouldExposeCommandStreamsExitCodeAndDuration() {
+        SshCommandResult result = new SshCommandResult("systemctl status", "active", "warn", 3, 42L);
+        Assert.assertEquals(result.command(), "systemctl status");
+        Assert.assertEquals(result.stdout(), "active");
+        Assert.assertEquals(result.stderr(), "warn");
+        Assert.assertEquals(result.exitCode(), 3);
+        Assert.assertEquals(result.durationMillis(), 42L);
+    }
+}

--- a/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
@@ -5,12 +5,16 @@ import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import com.shaft.cli.TerminalActions;
 import com.shaft.driver.SHAFT;
+import org.apache.commons.lang3.SystemUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import java.io.BufferedReader;
 import java.io.StringReader;
+import java.io.InputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -18,6 +22,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+import java.util.function.IntSupplier;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -357,8 +364,11 @@ public class TerminalActionsUnitTest {
     public void performTerminalCommandsShouldRunFromChangedDirectory() throws Exception {
         Path tempDir = createTempDir("cwd");
         TerminalActions terminal = TerminalActions.getInstance(false, false, true);
-        String log = terminal.performTerminalCommands(List.of("cd " + tempDir.toAbsolutePath(), "pwd"));
-        Assert.assertTrue(log.contains(tempDir.toAbsolutePath().toString()),
+        String directory = tempDir.toAbsolutePath().toString();
+        String log = SystemUtils.IS_OS_WINDOWS
+                ? terminal.performTerminalCommands(List.of("cd " + directory, "(Get-Location).Path"))
+                : terminal.performTerminalCommands(List.of("cd " + directory, "pwd"));
+        Assert.assertTrue(log.toLowerCase().contains(directory.toLowerCase()),
                 "Expected command log to include changed working directory.");
     }
 
@@ -654,5 +664,111 @@ public class TerminalActionsUnitTest {
         InvocationTargetException failure = Assert.expectThrows(InvocationTargetException.class,
                 () -> createSshSession.invoke(terminal));
         Assert.assertTrue(failure.getCause() instanceof RuntimeException);
+    }
+
+    @Test(description = "mergeRemoteCommandOutput should preserve stdout-only remote logs")
+    public void mergeRemoteCommandOutputShouldPreserveStdoutOnly() throws Exception {
+        Method mergeRemoteCommandOutput = TerminalActions.class.getDeclaredMethod("mergeRemoteCommandOutput", String.class, String.class);
+        mergeRemoteCommandOutput.setAccessible(true);
+        String merged = (String) mergeRemoteCommandOutput.invoke(null, "stdout-only", "");
+        Assert.assertEquals(merged, "stdout-only");
+    }
+
+    @Test(description = "mergeRemoteCommandOutput should preserve stderr-only remote logs")
+    public void mergeRemoteCommandOutputShouldPreserveStderrOnly() throws Exception {
+        Method mergeRemoteCommandOutput = TerminalActions.class.getDeclaredMethod("mergeRemoteCommandOutput", String.class, String.class);
+        mergeRemoteCommandOutput.setAccessible(true);
+        String merged = (String) mergeRemoteCommandOutput.invoke(null, "", "stderr-only");
+        Assert.assertEquals(merged, "stderr-only");
+    }
+
+    @Test(description = "mergeRemoteCommandOutput should merge stdout and stderr for legacy String API")
+    public void mergeRemoteCommandOutputShouldMergeStdoutAndStderr() throws Exception {
+        Method mergeRemoteCommandOutput = TerminalActions.class.getDeclaredMethod("mergeRemoteCommandOutput", String.class, String.class);
+        mergeRemoteCommandOutput.setAccessible(true);
+        String merged = (String) mergeRemoteCommandOutput.invoke(null, "stdout", "stderr");
+        Assert.assertEquals(merged, "stdout" + System.lineSeparator() + "stderr");
+    }
+
+    @Test(description = "captureRemoteCommandStreams should drain stdout and stderr separately after the command completes")
+    public void captureRemoteCommandStreamsShouldDrainStdoutAndStderrSeparately() throws Exception {
+        Class<?> throwingRunnableType = Class.forName("com.shaft.cli.TerminalActions$ThrowingRunnable");
+        Method captureRemoteCommandStreams = TerminalActions.class.getDeclaredMethod(
+                "captureRemoteCommandStreams",
+                InputStream.class,
+                InputStream.class,
+                throwingRunnableType,
+                BooleanSupplier.class,
+                IntSupplier.class,
+                long.class);
+        captureRemoteCommandStreams.setAccessible(true);
+
+        PipedOutputStream stdoutOut = new PipedOutputStream();
+        PipedInputStream stdoutIn = new PipedInputStream(stdoutOut);
+        PipedOutputStream stderrOut = new PipedOutputStream();
+        PipedInputStream stderrIn = new PipedInputStream(stderrOut);
+        AtomicBoolean channelClosed = new AtomicBoolean(false);
+
+        Object connectAction = java.lang.reflect.Proxy.newProxyInstance(
+                throwingRunnableType.getClassLoader(),
+                new Class<?>[]{throwingRunnableType},
+                (proxy, method, args) -> {
+                    // Simulate a remote command that keeps the channel open past the old 1-second cutoff.
+                    Thread producer = new Thread(() -> {
+                        try {
+                            Thread.sleep(1500);
+                            stdoutOut.write("stdout-line\n".getBytes());
+                            stderrOut.write("stderr-line\n".getBytes());
+                            stdoutOut.close();
+                            stderrOut.close();
+                            channelClosed.set(true);
+                        } catch (Exception ignored) {
+                            Thread.currentThread().interrupt();
+                        }
+                    });
+                    producer.setDaemon(true);
+                    producer.start();
+                    return null;
+                });
+
+        Object capture = captureRemoteCommandStreams.invoke(new TerminalActions(), stdoutIn, stderrIn, connectAction,
+                (BooleanSupplier) channelClosed::get,
+                (IntSupplier) () -> 7,
+                30_000L);
+
+        Method stdoutAccessor = capture.getClass().getDeclaredMethod("stdout");
+        Method stderrAccessor = capture.getClass().getDeclaredMethod("stderr");
+        Method exitCodeAccessor = capture.getClass().getDeclaredMethod("exitCode");
+        stdoutAccessor.setAccessible(true);
+        stderrAccessor.setAccessible(true);
+        exitCodeAccessor.setAccessible(true);
+
+        Assert.assertEquals(stdoutAccessor.invoke(capture), "stdout-line");
+        Assert.assertEquals(stderrAccessor.invoke(capture), "stderr-line");
+        Assert.assertEquals(exitCodeAccessor.invoke(capture), 7);
+    }
+
+    @Test(description = "performSshCommand should reject local terminals")
+    public void performSshCommandShouldRejectLocalTerminal() {
+        TerminalActions terminal = TerminalActions.getInstance(false, false, true);
+        RuntimeException failure = Assert.expectThrows(RuntimeException.class,
+                () -> terminal.performSshCommand("echo test"));
+        Assert.assertTrue(failure.getMessage().contains("remote SSH"));
+    }
+
+    @Test(description = "performSshCommand should reject blank commands on reusable remote terminals")
+    public void performSshCommandShouldRejectBlankCommands() {
+        TerminalActions terminal = SHAFT.CLI.remoteTerminal("host.example.com", 22, "user", "", "");
+        RuntimeException failure = Assert.expectThrows(RuntimeException.class,
+                () -> terminal.performSshCommand(" "));
+        Assert.assertTrue(failure.getMessage().contains("SSH command"));
+    }
+
+    @Test(description = "performTerminalCommand should remain backward compatible for local command output")
+    public void performTerminalCommandShouldRemainBackwardCompatibleForLocalOutput() {
+        TerminalActions terminal = TerminalActions.getInstance(false, false, true);
+        String log = terminal.performTerminalCommand("echo legacy-string-api");
+        Assert.assertTrue(log.contains("legacy-string-api"),
+                "Existing String API should still return command output for assertions");
     }
 }


### PR DESCRIPTION
Part of #3131

- Add `SshCommandResult` with stdout, stderr, exit code, duration, and `succeeded()`
- Add `performSshCommand(...)` / `performSshCommands(...)` on reusable remote terminals
- Drain remote stdout/stderr concurrently; keep existing `performTerminalCommand` String API unchanged

Tests
[SshCommandResult and performSshCommand-Report.html](https://github.com/user-attachments/files/29442495/SshCommandResult.and.performSshCommand-Report.html)
