### PR TITLE
[codex] Fix IntelliJ MCP first-run project scoping

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpConnectionProbe.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpConnectionProbe.java
@@ -50,15 +50,42 @@ public final class ShaftMcpConnectionProbe {
         return test(commandLine, ShaftMcpEnvironment.forSettings(settings));
     }
 
+    /**
+     * Tests a SHAFT MCP stdio command with the current IntelliJ project as workspace.
+     *
+     * @param commandLine command line
+     * @param settings plugin settings used to build the MCP process environment
+     * @param projectRoot current IntelliJ project root
+     * @return async test result
+     */
+    public static CompletableFuture<ShaftMcpToolResult> test(
+            String commandLine,
+            ShaftSettingsState.Settings settings,
+            Path projectRoot) {
+        return test(commandLine, ShaftMcpEnvironment.forSettings(settings), projectRoot);
+    }
+
     private static CompletableFuture<ShaftMcpToolResult> test(String commandLine, Map<String, String> environment) {
+        return test(commandLine, environment, Path.of("."));
+    }
+
+    private static CompletableFuture<ShaftMcpToolResult> test(
+            String commandLine,
+            Map<String, String> environment,
+            Path projectRoot) {
         List<String> command = ShaftCommandLine.parse(commandLine == null ? "" : commandLine);
         if (command.isEmpty()) {
             return CompletableFuture.completedFuture(ShaftMcpToolResult.failure(
                     "Enter a SHAFT MCP stdio command before testing."));
         }
         return CompletableFuture.supplyAsync(() -> {
-            try (ShaftMcpStdioClient client = new ShaftMcpStdioClient(command, Path.of("."), environment)) {
-                return ShaftMcpToolResult.success(client.initializeOnly(TIMEOUT));
+            Path workspace = projectRoot == null ? Path.of(".") : projectRoot;
+            try {
+                List<String> scopedCommand = ShaftMcpProjectScope.commandForProject(command, workspace);
+                Map<String, String> scopedEnvironment = ShaftMcpProjectScope.environmentForProject(environment, workspace);
+                try (ShaftMcpStdioClient client = new ShaftMcpStdioClient(scopedCommand, workspace, scopedEnvironment)) {
+                    return ShaftMcpToolResult.success(client.initializeOnly(TIMEOUT));
+                }
             } catch (Exception exception) {
                 return ShaftMcpToolResult.failure(exception.getMessage());
             }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpInvocationService.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpInvocationService.java
@@ -126,15 +126,19 @@ public final class ShaftMcpInvocationService {
             AtomicReference<ShaftMcpStdioClient> clientReference,
             AtomicBoolean cancellationRequested) {
         Path workingDirectory = project.getBasePath() == null ? Path.of(".") : Path.of(project.getBasePath());
-        Map<String, String> environment = ShaftMcpEnvironment.forSettings(settings);
-        try (ShaftMcpStdioClient client = new ShaftMcpStdioClient(command, workingDirectory, environment)) {
-            clientReference.set(client);
-            if (cancellationRequested.get()) {
-                throw new CancellationException("Operation cancelled");
+        try {
+            Map<String, String> environment = ShaftMcpProjectScope.environmentForProject(
+                    ShaftMcpEnvironment.forSettings(settings), workingDirectory);
+            List<String> scopedCommand = ShaftMcpProjectScope.commandForProject(command, workingDirectory);
+            try (ShaftMcpStdioClient client = new ShaftMcpStdioClient(scopedCommand, workingDirectory, environment)) {
+                clientReference.set(client);
+                if (cancellationRequested.get()) {
+                    throw new CancellationException("Operation cancelled");
+                }
+                JsonElement result = client.callTool(toolName, arguments == null ? new JsonObject() : arguments,
+                        DEFAULT_TIMEOUT);
+                return ShaftMcpToolResult.success(result.toString());
             }
-            JsonElement result = client.callTool(toolName, arguments == null ? new JsonObject() : arguments,
-                    DEFAULT_TIMEOUT);
-            return ShaftMcpToolResult.success(result.toString());
         } catch (Exception exception) {
             if (cancellationRequested.get() || exception instanceof CancellationException) {
                 throw new CancellationException("Operation cancelled");
@@ -151,13 +155,17 @@ public final class ShaftMcpInvocationService {
             AtomicReference<ShaftMcpStdioClient> clientReference,
             AtomicBoolean cancellationRequested) {
         Path workingDirectory = project.getBasePath() == null ? Path.of(".") : Path.of(project.getBasePath());
-        Map<String, String> environment = ShaftMcpEnvironment.forSettings(settings);
-        try (ShaftMcpStdioClient client = new ShaftMcpStdioClient(command, workingDirectory, environment)) {
-            clientReference.set(client);
-            if (cancellationRequested.get()) {
-                throw new CancellationException("Operation cancelled");
+        try {
+            Map<String, String> environment = ShaftMcpProjectScope.environmentForProject(
+                    ShaftMcpEnvironment.forSettings(settings), workingDirectory);
+            List<String> scopedCommand = ShaftMcpProjectScope.commandForProject(command, workingDirectory);
+            try (ShaftMcpStdioClient client = new ShaftMcpStdioClient(scopedCommand, workingDirectory, environment)) {
+                clientReference.set(client);
+                if (cancellationRequested.get()) {
+                    throw new CancellationException("Operation cancelled");
+                }
+                return ShaftMcpToolResult.success(client.initializeOnly(DEFAULT_TIMEOUT));
             }
-            return ShaftMcpToolResult.success(client.initializeOnly(DEFAULT_TIMEOUT));
         } catch (Exception exception) {
             if (cancellationRequested.get() || exception instanceof CancellationException) {
                 throw new CancellationException("Operation cancelled");
@@ -174,14 +182,18 @@ public final class ShaftMcpInvocationService {
             AtomicReference<ShaftMcpStdioClient> clientReference,
             AtomicBoolean cancellationRequested) {
         Path workingDirectory = project.getBasePath() == null ? Path.of(".") : Path.of(project.getBasePath());
-        Map<String, String> environment = ShaftMcpEnvironment.forSettings(settings);
-        try (ShaftMcpStdioClient client = new ShaftMcpStdioClient(command, workingDirectory, environment)) {
-            clientReference.set(client);
-            if (cancellationRequested.get()) {
-                throw new CancellationException("Operation cancelled");
+        try {
+            Map<String, String> environment = ShaftMcpProjectScope.environmentForProject(
+                    ShaftMcpEnvironment.forSettings(settings), workingDirectory);
+            List<String> scopedCommand = ShaftMcpProjectScope.commandForProject(command, workingDirectory);
+            try (ShaftMcpStdioClient client = new ShaftMcpStdioClient(scopedCommand, workingDirectory, environment)) {
+                clientReference.set(client);
+                if (cancellationRequested.get()) {
+                    throw new CancellationException("Operation cancelled");
+                }
+                JsonElement result = client.listTools(DEFAULT_TIMEOUT);
+                return ShaftMcpToolResult.success(result.toString());
             }
-            JsonElement result = client.listTools(DEFAULT_TIMEOUT);
-            return ShaftMcpToolResult.success(result.toString());
         } catch (Exception exception) {
             if (cancellationRequested.get() || exception instanceof CancellationException) {
                 throw new CancellationException("Operation cancelled");

--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpProjectScope.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpProjectScope.java
@@ -1,0 +1,106 @@
+package com.shaft.intellij.mcp;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Applies the current IntelliJ project as the workspace for MCP launches.
+ */
+final class ShaftMcpProjectScope {
+    static final String WORKSPACE_ENVIRONMENT_VARIABLE = "SHAFT_MCP_WORKSPACE_ROOT";
+    private static final String USER_DIR_PROPERTY = "user.dir";
+    private static final String WORKSPACE_PROPERTY = "shaft.mcp.workspaceRoot";
+
+    private ShaftMcpProjectScope() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static List<String> commandForProject(List<String> command, Path projectRoot) throws IOException {
+        if (command == null || command.isEmpty()) {
+            return List.of();
+        }
+        Path root = normalize(projectRoot);
+        List<String> scoped = new ArrayList<>(command);
+        for (int index = 1; index < scoped.size(); index++) {
+            String token = scoped.get(index);
+            if (token != null && token.startsWith("@") && token.length() > 1) {
+                scoped.set(index, "@" + scopedArgFile(Path.of(token.substring(1)), root));
+                return List.copyOf(scoped);
+            }
+        }
+        return List.copyOf(scoped);
+    }
+
+    static Map<String, String> environmentForProject(Map<String, String> environment, Path projectRoot) {
+        Map<String, String> scoped = new LinkedHashMap<>(environment == null ? Map.of() : environment);
+        scoped.put(WORKSPACE_ENVIRONMENT_VARIABLE, normalize(projectRoot).toString());
+        return Map.copyOf(scoped);
+    }
+
+    private static Path scopedArgFile(Path source, Path projectRoot) throws IOException {
+        List<String> original = Files.readAllLines(source, StandardCharsets.UTF_8);
+        List<String> scoped = new ArrayList<>(original.size() + 2);
+        boolean sawUserDir = false;
+        boolean sawWorkspace = false;
+        for (String line : original) {
+            String property = propertyName(line);
+            if (USER_DIR_PROPERTY.equals(property)) {
+                scoped.add(systemProperty(USER_DIR_PROPERTY, projectRoot));
+                sawUserDir = true;
+            } else if (WORKSPACE_PROPERTY.equals(property)) {
+                scoped.add(systemProperty(WORKSPACE_PROPERTY, projectRoot));
+                sawWorkspace = true;
+            } else {
+                scoped.add(line);
+            }
+        }
+        List<String> withRequiredProperties = new ArrayList<>(scoped.size() + 2);
+        if (!sawUserDir) {
+            withRequiredProperties.add(systemProperty(USER_DIR_PROPERTY, projectRoot));
+        }
+        if (!sawWorkspace) {
+            withRequiredProperties.add(systemProperty(WORKSPACE_PROPERTY, projectRoot));
+        }
+        withRequiredProperties.addAll(scoped);
+
+        Path generated = Files.createTempFile("shaft-intellij-mcp-", ".args");
+        generated.toFile().deleteOnExit();
+        Files.write(generated, withRequiredProperties, StandardCharsets.UTF_8);
+        return generated;
+    }
+
+    private static String propertyName(String line) {
+        String value = unquote(line == null ? "" : line.trim());
+        if (!value.startsWith("-D")) {
+            return "";
+        }
+        int separator = value.indexOf('=');
+        return separator > 2 ? value.substring(2, separator) : "";
+    }
+
+    private static String systemProperty(String property, Path projectRoot) {
+        return quote("-D" + property + "=" + projectRoot.toString().replace('\\', '/'));
+    }
+
+    private static String quote(String value) {
+        return "\"" + value.replace("\"", "\\\"") + "\"";
+    }
+
+    private static String unquote(String value) {
+        if (value.length() >= 2 && ((value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"')
+                || (value.charAt(0) == '\'' && value.charAt(value.length() - 1) == '\''))) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+
+    private static Path normalize(Path projectRoot) {
+        return (projectRoot == null ? Path.of(".") : projectRoot).toAbsolutePath().normalize();
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpStdioClient.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpStdioClient.java
@@ -4,10 +4,12 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 
-import java.io.ByteArrayOutputStream;
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
@@ -19,6 +21,9 @@ import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -32,11 +37,12 @@ final class ShaftMcpStdioClient implements AutoCloseable {
     private static final String PROTOCOL_VERSION = "2024-11-05";
 
     private final Process process;
-    private final InputStream input;
+    private final BufferedReader input;
     private final OutputStream output;
     private final AtomicInteger id = new AtomicInteger(1);
     private final CompletableFuture<String> stderr;
     private final AtomicBoolean closed = new AtomicBoolean();
+    private final ExecutorService ioExecutor;
 
     ShaftMcpStdioClient(List<String> command, Path workingDirectory, Map<String, String> environment)
             throws IOException {
@@ -44,9 +50,10 @@ final class ShaftMcpStdioClient implements AutoCloseable {
         builder.directory(workingDirectory.toFile());
         builder.environment().putAll(environment);
         process = builder.start();
-        input = process.getInputStream();
+        input = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
         output = process.getOutputStream();
-        stderr = CompletableFuture.supplyAsync(() -> readAll(process.getErrorStream()));
+        ioExecutor = Executors.newFixedThreadPool(2, daemonThreadFactory());
+        stderr = CompletableFuture.supplyAsync(() -> readAll(process.getErrorStream()), ioExecutor);
     }
 
     String initializeOnly(Duration timeout) throws IOException {
@@ -113,9 +120,8 @@ final class ShaftMcpStdioClient implements AutoCloseable {
 
     private void send(JsonObject payload) throws IOException {
         byte[] body = GSON.toJson(payload).getBytes(StandardCharsets.UTF_8);
-        byte[] header = ("Content-Length: " + body.length + "\r\n\r\n").getBytes(StandardCharsets.US_ASCII);
-        output.write(header);
         output.write(body);
+        output.write('\n');
         output.flush();
     }
 
@@ -161,7 +167,7 @@ final class ShaftMcpStdioClient implements AutoCloseable {
             } catch (IOException exception) {
                 throw new UncheckedIOException(exception);
             }
-        });
+        }, ioExecutor);
         long timeoutMillis = Math.max(1, TimeUnit.NANOSECONDS.toMillis(timeoutNanos));
         try {
             return future.get(timeoutMillis, TimeUnit.MILLISECONDS);
@@ -197,37 +203,21 @@ final class ShaftMcpStdioClient implements AutoCloseable {
     }
 
     private JsonObject readMessage() throws IOException {
-        int contentLength = readContentLength();
-        if (contentLength <= 0) {
-            return null;
-        }
-        byte[] body = input.readNBytes(contentLength);
-        if (body.length != contentLength) {
-            return null;
-        }
-        return JsonParser.parseString(new String(body, StandardCharsets.UTF_8)).getAsJsonObject();
-    }
-
-    private int readContentLength() throws IOException {
-        ByteArrayOutputStream header = new ByteArrayOutputStream();
-        int previous = -1;
-        int current;
-        while ((current = input.read()) != -1) {
-            header.write(current);
-            String value = header.toString(StandardCharsets.US_ASCII);
-            if ((previous == '\n' && current == '\n') || value.endsWith("\r\n\r\n")) {
-                break;
+        String line;
+        while ((line = input.readLine()) != null) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty()) {
+                continue;
             }
-            previous = current;
-        }
-        String[] lines = header.toString(StandardCharsets.US_ASCII).split("\\r?\\n");
-        for (String line : lines) {
-            int separator = line.indexOf(':');
-            if (separator > 0 && "content-length".equalsIgnoreCase(line.substring(0, separator).trim())) {
-                return Integer.parseInt(line.substring(separator + 1).trim());
+            try {
+                JsonElement message = JsonParser.parseString(trimmed);
+                return message.isJsonObject() ? message.getAsJsonObject() : null;
+            } catch (JsonSyntaxException | IllegalStateException exception) {
+                // Spring Boot and tooling can write startup logs to stdout before MCP frames.
+                // Ignore those non-protocol lines and keep waiting for a JSON-RPC message.
             }
         }
-        return -1;
+        return null;
     }
 
     private static String readAll(InputStream stream) {
@@ -283,10 +273,20 @@ final class ShaftMcpStdioClient implements AutoCloseable {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             process.destroyForcibly();
+        } finally {
+            ioExecutor.shutdownNow();
         }
     }
 
     void cancel() {
         close();
+    }
+
+    private static ThreadFactory daemonThreadFactory() {
+        return runnable -> {
+            Thread thread = new Thread(runnable, "shaft-mcp-stdio");
+            thread.setDaemon(true);
+            return thread;
+        };
     }
 }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -1,6 +1,7 @@
 package com.shaft.intellij.ui;
 
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.components.JBTextArea;
 import com.intellij.util.ui.FormBuilder;
@@ -19,12 +20,14 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import java.awt.BorderLayout;
 import java.awt.FlowLayout;
+import java.nio.file.Path;
 import java.util.Locale;
 
 /**
  * First-run SHAFT MCP setup panel.
  */
 final class ShaftMcpSetupPanel extends JPanel {
+    private final Project project;
     private final ShaftSettingsState.Settings settings;
     private final Runnable connected;
     private final JButton install;
@@ -34,8 +37,10 @@ final class ShaftMcpSetupPanel extends JPanel {
     private final JLabel status;
     private final JBTextArea details;
 
-    ShaftMcpSetupPanel(@NotNull ShaftSettingsState.Settings settings, @NotNull Runnable connected) {
+    ShaftMcpSetupPanel(@NotNull Project project, @NotNull ShaftSettingsState.Settings settings,
+                       @NotNull Runnable connected) {
         super(new BorderLayout(8, 8));
+        this.project = project;
         this.settings = settings;
         this.connected = connected;
         setBorder(JBUI.Borders.empty(12));
@@ -119,8 +124,12 @@ final class ShaftMcpSetupPanel extends JPanel {
         settings.assistantRuntime = String.valueOf(runtime.getSelectedItem());
         settings.defaultAutobotClient = clientFromFamily(settings.assistantFamily);
         setRunning(true, "Testing...");
-        ShaftMcpConnectionProbe.test(command, settings).whenComplete((result, error) ->
+        ShaftMcpConnectionProbe.test(command, settings, projectRoot()).whenComplete((result, error) ->
                 ApplicationManager.getApplication().invokeLater(() -> showTestResult(result, error)));
+    }
+
+    private Path projectRoot() {
+        return project.getBasePath() == null ? Path.of(".") : Path.of(project.getBasePath());
     }
 
     private void showTestResult(ShaftMcpToolResult result, Throwable error) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
@@ -42,7 +42,7 @@ public final class ShaftToolWindowPanel extends JPanel {
 
     private void showSetupView() {
         removeAll();
-        ShaftMcpSetupPanel setup = new ShaftMcpSetupPanel(settings, this::showMainView);
+        ShaftMcpSetupPanel setup = new ShaftMcpSetupPanel(project, settings, this::showMainView);
         preferredFocusComponent = setup.preferredFocusComponent();
         tabs = null;
         advancedTools = null;

--- a/shaft-intellij/src/test/java/com/shaft/intellij/mcp/FakeMcpServer.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/mcp/FakeMcpServer.java
@@ -1,8 +1,8 @@
 package com.shaft.intellij.mcp;
 
-import java.io.ByteArrayOutputStream;
+import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
@@ -19,6 +19,7 @@ final class FakeMcpServer {
         String mode = args.length == 0 ? "hang" : args[0];
         switch (mode) {
             case "stderrAndExit" -> runWithStderrFailure();
+            case "stdoutNoiseThenToolsList" -> runStdoutNoiseThenToolsListServer();
             case "toolsList" -> runToolsListServer();
             case "toolResultArray" -> runToolCallResultServer("[\"first\",{\"name\":\"second\"}]");
             case "toolResultString" -> runToolCallResultServer("\"plain text result\"");
@@ -36,15 +37,21 @@ final class FakeMcpServer {
         runServer("{\"tools\":[{\"name\":\"fake_tool\"}]}");
     }
 
+    private static void runStdoutNoiseThenToolsListServer() throws Exception {
+        System.out.println("2026-06-29 INFO fake MCP startup log");
+        System.out.flush();
+        runToolsListServer();
+    }
+
     private static void runToolCallResultServer(String resultJson) throws Exception {
         runServer(resultJson);
     }
 
     private static void runServer(String toolCallResultJson) throws Exception {
-        InputStream input = System.in;
+        BufferedReader input = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
         OutputStream output = System.out;
         while (true) {
-            String message = readMessage(input);
+            String message = input.readLine();
             if (message == null) {
                 return;
             }
@@ -65,46 +72,9 @@ final class FakeMcpServer {
     private static void writeMessage(OutputStream output, int requestId, String responseTemplate) throws IOException {
         String response = responseTemplate.formatted(requestId);
         byte[] body = response.getBytes(StandardCharsets.UTF_8);
-        output.write(("Content-Length: " + body.length + "\r\n\r\n").getBytes(StandardCharsets.US_ASCII));
         output.write(body);
+        output.write('\n');
         output.flush();
-    }
-
-    private static String readMessage(InputStream input) throws IOException {
-        int contentLength = readContentLength(input);
-        if (contentLength < 0) {
-            return null;
-        }
-        byte[] body = input.readNBytes(contentLength);
-        if (body.length != contentLength) {
-            return null;
-        }
-        return new String(body, StandardCharsets.UTF_8);
-    }
-
-    private static int readContentLength(InputStream input) throws IOException {
-        ByteArrayOutputStream header = new ByteArrayOutputStream();
-        int previous = -1;
-        while (true) {
-            int current = input.read();
-            if (current == -1) {
-                return -1;
-            }
-            header.write(current);
-            String value = header.toString(StandardCharsets.US_ASCII);
-            if ((previous == '\n' && current == '\n') || value.endsWith("\r\n\r\n")) {
-                break;
-            }
-            previous = current;
-        }
-        String[] lines = header.toString(StandardCharsets.US_ASCII).split("\\r?\\n");
-        for (String line : lines) {
-            int separator = line.indexOf(':');
-            if (separator > 0 && "content-length".equalsIgnoreCase(line.substring(0, separator).trim())) {
-                return Integer.parseInt(line.substring(separator + 1).trim());
-            }
-        }
-        return -1;
     }
 
     private static int requestId(String message) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpProjectScopeTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpProjectScopeTest.java
@@ -1,0 +1,72 @@
+package com.shaft.intellij.mcp;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShaftMcpProjectScopeTest {
+    @TempDir
+    Path temporary;
+
+    @Test
+    void javaArgFileWorkspacePropertiesUseCurrentProject() throws IOException {
+        Path argsFile = temporary.resolve("shaft-mcp.args");
+        Files.writeString(argsFile, """
+                "-Duser.dir=C:/Users/me/AppData/Local/ShaftHQ/shaft-mcp/work"
+                "-Dshaft.mcp.workspaceRoot=C:/Users/me/AppData/Local/ShaftHQ/shaft-mcp/work"
+                -cp
+                "shaft-mcp.jar"
+                com.shaft.mcp.ShaftMcpApplication
+                """);
+        Path project = temporary.resolve("project").toAbsolutePath().normalize();
+
+        List<String> command = ShaftMcpProjectScope.commandForProject(List.of("java", "@" + argsFile), project);
+
+        Path scopedArgs = Path.of(command.get(1).substring(1));
+        String content = Files.readString(scopedArgs);
+        String expectedProject = project.toString().replace('\\', '/');
+        assertTrue(content.contains("\"-Duser.dir=" + expectedProject + "\""));
+        assertTrue(content.contains("\"-Dshaft.mcp.workspaceRoot=" + expectedProject + "\""));
+        assertFalse(content.contains("ShaftHQ/shaft-mcp/work"));
+        assertEquals("java", command.get(0));
+    }
+
+    @Test
+    void javaArgFileMissingWorkspacePropertiesGetsProjectScopePrefix() throws IOException {
+        Path argsFile = temporary.resolve("plain.args");
+        Files.writeString(argsFile, """
+                -cp
+                "shaft-mcp.jar"
+                com.shaft.mcp.ShaftMcpApplication
+                """);
+        Path project = temporary.resolve("project").toAbsolutePath().normalize();
+
+        List<String> command = ShaftMcpProjectScope.commandForProject(List.of("java", "@" + argsFile), project);
+
+        List<String> lines = Files.readAllLines(Path.of(command.get(1).substring(1)));
+        String expectedProject = project.toString().replace('\\', '/');
+        assertEquals("\"-Duser.dir=" + expectedProject + "\"", lines.get(0));
+        assertEquals("\"-Dshaft.mcp.workspaceRoot=" + expectedProject + "\"", lines.get(1));
+        assertEquals("-cp", lines.get(2));
+    }
+
+    @Test
+    void environmentIncludesCurrentProjectWorkspace() {
+        Path project = temporary.resolve("project").toAbsolutePath().normalize();
+
+        Map<String, String> environment = ShaftMcpProjectScope.environmentForProject(
+                Map.of("OPENAI_API_KEY", "secret"), project);
+
+        assertEquals(project.toString(), environment.get(ShaftMcpProjectScope.WORKSPACE_ENVIRONMENT_VARIABLE));
+        assertEquals("secret", environment.get("OPENAI_API_KEY"));
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpStdioClientTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpStdioClientTest.java
@@ -40,6 +40,14 @@ class ShaftMcpStdioClientTest {
     }
 
     @Test
+    void initializeIgnoresNonProtocolStdoutBeforeJsonRpcMessage() throws IOException {
+        String result = withClient("stdoutNoiseThenToolsList",
+                client -> client.initializeOnly(Duration.ofSeconds(2)));
+
+        assertEquals("SHAFT MCP connection is ready.", result);
+    }
+
+    @Test
     void listToolsReturnsRawJsonResult() throws IOException {
         JsonElement result = withClient("toolsList", client -> client.listTools(Duration.ofSeconds(2)));
 

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -128,7 +128,7 @@ class ShaftPanelSetupTest {
     void assistantAndToolsControlsExposeAccessibleMetadata() {
         assertAccessibleControls(new ShaftAssistantPanel(null, blankMcpSettings()));
         assertAccessibleControls(new ShaftFeaturePanel(null, blankMcpSettings()));
-        assertAccessibleControls(new ShaftMcpSetupPanel(blankMcpSettings(), () -> {
+        assertAccessibleControls(new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
         }));
         assertAccessibleControls(new GuidedWorkflowPanel(null, (tool, arguments) -> {
         }));


### PR DESCRIPTION
## Summary

- switch the IntelliJ MCP stdio client to newline-delimited JSON-RPC and ignore non-protocol stdout noise before JSON-RPC messages
- scope installed SHAFT MCP argfile launches to the currently open IntelliJ project instead of the installer work directory
- move MCP stdio reads to client-owned daemon IO threads so Assistant/Test MCP requests cannot starve their own response reader

## Why

The first-run install capture exposed three real plugin bugs:

- the plugin and current `shaft-mcp` server disagreed on stdio framing
- the installer argfile pinned `user.dir` / `shaft.mcp.workspaceRoot` to app-data, so open-project requests could be outside the MCP workspace
- `CompletableFuture` common-pool nesting could leave Assistant `Test MCP` disabled even after the server responded

## Validation

- `git diff --check`
- `py -3 scripts/ci/validate_shaft_mcp_configuration.py`
- `gradle -p shaft-intellij test --rerun-tasks --tests com.shaft.intellij.mcp.ShaftMcpStdioClientTest --tests com.shaft.intellij.mcp.ShaftMcpProjectScopeTest --tests com.shaft.intellij.ui.ShaftPanelSetupTest`
- `gradle -p shaft-intellij clean buildPlugin`

## Follow-up

Issue #3173 tracks two remaining first-run UX improvements found during the same capture: clearer restart guidance after disk install and cleaner Assistant rendering for `autobot_local_agent_run` output.
