### PR TITLE
Improve IntelliJ assistant response rendering and chat sessions

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpConnectionProbe.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpConnectionProbe.java
@@ -84,11 +84,19 @@ public final class ShaftMcpConnectionProbe {
                 List<String> scopedCommand = ShaftMcpProjectScope.commandForProject(command, workspace);
                 Map<String, String> scopedEnvironment = ShaftMcpProjectScope.environmentForProject(environment, workspace);
                 try (ShaftMcpStdioClient client = new ShaftMcpStdioClient(scopedCommand, workspace, scopedEnvironment)) {
-                    return ShaftMcpToolResult.success(client.initializeOnly(TIMEOUT));
+                    return ShaftMcpToolResult.success(scopedMessage(client.initializeOnly(TIMEOUT), workspace));
                 }
             } catch (Exception exception) {
                 return ShaftMcpToolResult.failure(exception.getMessage());
             }
         });
+    }
+
+    private static String scopedMessage(String message, Path workspace) {
+        String root = workspace.toAbsolutePath().normalize().toString();
+        return message + "\n\nMCP workspace: " + root
+                + "\nuser.dir: " + root
+                + "\nshaft.mcp.workspaceRoot: " + root
+                + "\nSHAFT_MCP_WORKSPACE_ROOT: " + root;
     }
 }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpInvocationService.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpInvocationService.java
@@ -164,7 +164,7 @@ public final class ShaftMcpInvocationService {
                 if (cancellationRequested.get()) {
                     throw new CancellationException("Operation cancelled");
                 }
-                return ShaftMcpToolResult.success(client.initializeOnly(DEFAULT_TIMEOUT));
+                return ShaftMcpToolResult.success(scopedMessage(client.initializeOnly(DEFAULT_TIMEOUT), workingDirectory));
             }
         } catch (Exception exception) {
             if (cancellationRequested.get() || exception instanceof CancellationException) {
@@ -223,6 +223,14 @@ public final class ShaftMcpInvocationService {
             return List.of();
         }
         return ShaftCommandLine.parse(settings.mcpCommand);
+    }
+
+    private static String scopedMessage(String message, Path workingDirectory) {
+        String root = workingDirectory.toAbsolutePath().normalize().toString();
+        return message + "\n\nMCP workspace: " + root
+                + "\nuser.dir: " + root
+                + "\nshaft.mcp.workspaceRoot: " + root
+                + "\nSHAFT_MCP_WORKSPACE_ROOT: " + root;
     }
 
     private static final String CONFIGURE_MESSAGE = "Configure the SHAFT MCP stdio command in Settings | SHAFT.";

--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpProjectScope.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpProjectScope.java
@@ -34,6 +34,9 @@ final class ShaftMcpProjectScope {
                 return List.copyOf(scoped);
             }
         }
+        if (isJavaCommand(scoped.get(0))) {
+            return javaCommandForProject(scoped, root);
+        }
         return List.copyOf(scoped);
     }
 
@@ -86,6 +89,31 @@ final class ShaftMcpProjectScope {
 
     private static String systemProperty(String property, Path projectRoot) {
         return quote("-D" + property + "=" + projectRoot.toString().replace('\\', '/'));
+    }
+
+    private static List<String> javaCommandForProject(List<String> command, Path projectRoot) {
+        List<String> scoped = new ArrayList<>(command.size() + 2);
+        scoped.add(command.get(0));
+        scoped.add(systemPropertyToken(USER_DIR_PROPERTY, projectRoot));
+        scoped.add(systemPropertyToken(WORKSPACE_PROPERTY, projectRoot));
+        for (int index = 1; index < command.size(); index++) {
+            String property = propertyName(command.get(index));
+            if (!USER_DIR_PROPERTY.equals(property) && !WORKSPACE_PROPERTY.equals(property)) {
+                scoped.add(command.get(index));
+            }
+        }
+        return List.copyOf(scoped);
+    }
+
+    private static String systemPropertyToken(String property, Path projectRoot) {
+        return "-D" + property + "=" + projectRoot.toString().replace('\\', '/');
+    }
+
+    private static boolean isJavaCommand(String token) {
+        String normalized = token == null ? "" : token.replace('\\', '/').toLowerCase();
+        int slash = normalized.lastIndexOf('/');
+        String executable = slash >= 0 ? normalized.substring(slash + 1) : normalized;
+        return "java".equals(executable) || "java.exe".equals(executable);
     }
 
     private static String quote(String value) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java
@@ -10,12 +10,17 @@ import com.google.gson.JsonParser;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 /**
  * Converts Assistant and MCP payloads into Markdown suitable for display.
  */
 final class AssistantMarkdown {
     private static final Gson PRETTY = new GsonBuilder().setPrettyPrinting().create();
+    private static final Set<String> KNOWN_TOOLS = Set.of(
+            "autobot_local_agent_clients",
+            "autobot_local_agent_run",
+            "autobot_provider_chat");
 
     private AssistantMarkdown() {
         throw new IllegalStateException("Utility class");
@@ -23,6 +28,45 @@ final class AssistantMarkdown {
 
     static String fromMcpOutput(String output) {
         return normalizeMarkdown(unwrapMcpText(output));
+    }
+
+    static String fromMcpOutput(String toolName, String output) {
+        String unwrapped = unwrapMcpText(output);
+        JsonElement parsed = parse(unwrapped);
+        if (parsed != null) {
+            String known = knownToolMarkdown(toolName, parsed);
+            if (!known.isBlank()) {
+                return known;
+            }
+            String generic = genericMarkdown(parsed);
+            if (!generic.isBlank()) {
+                return generic;
+            }
+        }
+        return normalizeMarkdown(unwrapped);
+    }
+
+    static boolean shouldFormatWithAgent(String toolName, String output) {
+        if (KNOWN_TOOLS.contains(toolName)) {
+            return false;
+        }
+        JsonElement parsed = parse(unwrapMcpText(output));
+        return parsed != null && (parsed.isJsonObject() || parsed.isJsonArray()) && genericMarkdown(parsed).isBlank();
+    }
+
+    static String formatterPrompt(String toolName, String output) {
+        return """
+                Convert this SHAFT MCP tool response into concise, user-facing Markdown.
+                Preserve facts and code exactly. Do not invent missing information.
+                Use headings, bullets, tables, or fenced code blocks only where useful.
+
+                Tool: %s
+
+                Response:
+                ```json
+                %s
+                ```
+                """.formatted(toolName == null ? "" : toolName, clip(unwrapMcpText(output), 12_000)).strip();
     }
 
     static String normalizeMarkdown(String text) {
@@ -41,6 +85,161 @@ final class AssistantMarkdown {
             return fence("java", trimmed);
         }
         return trimmed;
+    }
+
+    private static String knownToolMarkdown(String toolName, JsonElement parsed) {
+        return switch (toolName == null ? "" : toolName) {
+            case "autobot_local_agent_clients" -> clientsMarkdown(parsed);
+            case "autobot_local_agent_run" -> localAgentMarkdown(parsed);
+            case "autobot_provider_chat" -> providerChatMarkdown(parsed);
+            default -> "";
+        };
+    }
+
+    private static String clientsMarkdown(JsonElement parsed) {
+        if (!parsed.isJsonArray()) {
+            return "";
+        }
+        JsonArray clients = parsed.getAsJsonArray();
+        if (clients.isEmpty()) {
+            return "_No local assistant clients returned._";
+        }
+        StringBuilder markdown = new StringBuilder("""
+                | Client | Command | SHAFT API key |
+                | --- | --- | --- |
+                """);
+        for (JsonElement item : clients) {
+            if (!item.isJsonObject()) {
+                continue;
+            }
+            JsonObject client = item.getAsJsonObject();
+            markdown.append("| ")
+                    .append(table(string(client, "displayName", string(client, "id", "Unknown"))))
+                    .append(" | `")
+                    .append(string(client, "executableName", ""))
+                    .append("` | ")
+                    .append(booleanValue(client, "requiresCloudApiKey") ? "Required" : "Not required")
+                    .append(" |\n");
+        }
+        return markdown.toString().trim();
+    }
+
+    private static String localAgentMarkdown(JsonElement parsed) {
+        if (!parsed.isJsonObject()) {
+            return "";
+        }
+        JsonObject response = parsed.getAsJsonObject();
+        if (!response.has("stdout") && !response.has("stderr") && !response.has("status")) {
+            return "";
+        }
+        String stdout = string(response, "stdout", "");
+        String stderr = string(response, "stderr", "");
+        List<String> sections = new ArrayList<>();
+        if (!stdout.isBlank()) {
+            sections.add(normalizeMarkdown(stdout));
+        }
+        sections.add(metadataLine(
+                "Status", string(response, "status", ""),
+                "Client", string(response, "client", ""),
+                "Mode", string(response, "mode", ""),
+                "Exit", string(response, "exitCode", "")));
+        String warnings = warnings(response);
+        if (!warnings.isBlank()) {
+            sections.add(warnings);
+        }
+        if (!stderr.isBlank() && (!"SUCCESS".equals(string(response, "status", "")) || stdout.isBlank())) {
+            sections.add("**stderr**\n\n" + fence("text", stderr));
+        }
+        return joinSections(sections);
+    }
+
+    private static String providerChatMarkdown(JsonElement parsed) {
+        if (!parsed.isJsonObject()) {
+            return "";
+        }
+        JsonObject response = parsed.getAsJsonObject();
+        if (!response.has("answer") && !response.has("provider") && !response.has("fallbackReason")) {
+            return "";
+        }
+        List<String> sections = new ArrayList<>();
+        String answer = string(response, "answer", "");
+        if (!answer.isBlank()) {
+            sections.add(normalizeMarkdown(answer));
+        }
+        sections.add(metadataLine(
+                "Status", string(response, "status", ""),
+                "Provider", string(response, "provider", ""),
+                "Model", string(response, "model", ""),
+                "Mode", string(response, "mode", "")));
+        String warnings = warnings(response);
+        if (!warnings.isBlank()) {
+            sections.add(warnings);
+        }
+        String fallback = string(response, "fallbackReason", "");
+        if (!fallback.isBlank()) {
+            sections.add("**Fallback reason:** " + fallback);
+        }
+        if (answer.isBlank() && warnings.isBlank() && fallback.isBlank()) {
+            sections.add("_No answer returned._");
+        }
+        return joinSections(sections);
+    }
+
+    private static String genericMarkdown(JsonElement parsed) {
+        if (parsed.isJsonObject()) {
+            JsonObject object = parsed.getAsJsonObject();
+            if (object.has("tools") && object.get("tools").isJsonArray()) {
+                return toolsMarkdown(object.getAsJsonArray("tools"));
+            }
+            if (object.has("codeBlocks") && object.get("codeBlocks").isJsonArray()) {
+                return codeBlocksMarkdown(object.getAsJsonArray("codeBlocks"));
+            }
+            if (object.has("warnings") && object.get("warnings").isJsonArray()) {
+                String warnings = warnings(object);
+                if (!warnings.isBlank()) {
+                    return warnings + "\n\n" + fence("json", PRETTY.toJson(object));
+                }
+            }
+        }
+        return "";
+    }
+
+    private static String toolsMarkdown(JsonArray tools) {
+        if (tools.isEmpty()) {
+            return "_No tools returned._";
+        }
+        StringBuilder markdown = new StringBuilder("""
+                | Tool | Description |
+                | --- | --- |
+                """);
+        for (JsonElement item : tools) {
+            if (!item.isJsonObject()) {
+                continue;
+            }
+            JsonObject tool = item.getAsJsonObject();
+            markdown.append("| `")
+                    .append(string(tool, "name", ""))
+                    .append("` | ")
+                    .append(table(string(tool, "description", "")))
+                    .append(" |\n");
+        }
+        return markdown.toString().trim();
+    }
+
+    private static String codeBlocksMarkdown(JsonArray blocks) {
+        List<String> sections = new ArrayList<>();
+        for (JsonElement item : blocks) {
+            if (!item.isJsonObject()) {
+                continue;
+            }
+            JsonObject block = item.getAsJsonObject();
+            String language = string(block, "language", "java");
+            String code = firstTextProperty(block, "code", "content", "text");
+            if (!code.isBlank()) {
+                sections.add(fence(language.isBlank() ? "text" : language, code));
+            }
+        }
+        return joinSections(sections);
     }
 
     private static String unwrapMcpText(String output) {
@@ -124,6 +323,60 @@ final class AssistantMarkdown {
         return "";
     }
 
+    private static String warnings(JsonObject object) {
+        JsonElement warnings = object.get("warnings");
+        if (warnings == null || !warnings.isJsonArray() || warnings.getAsJsonArray().isEmpty()) {
+            return "";
+        }
+        StringBuilder markdown = new StringBuilder("**Warnings**");
+        for (JsonElement warning : warnings.getAsJsonArray()) {
+            if (warning.isJsonPrimitive()) {
+                markdown.append("\n- ").append(warning.getAsString());
+            }
+        }
+        return markdown.toString();
+    }
+
+    private static String metadataLine(String... pairs) {
+        List<String> parts = new ArrayList<>();
+        for (int index = 0; index + 1 < pairs.length; index += 2) {
+            String value = pairs[index + 1];
+            if (value != null && !value.isBlank()) {
+                parts.add("**" + pairs[index] + ":** " + value);
+            }
+        }
+        return String.join(" · ", parts);
+    }
+
+    private static String joinSections(List<String> sections) {
+        return String.join("\n\n", sections.stream()
+                .filter(section -> section != null && !section.isBlank())
+                .toList());
+    }
+
+    private static String string(JsonObject object, String key, String fallback) {
+        JsonElement value = object.get(key);
+        if (value == null || value.isJsonNull()) {
+            return fallback;
+        }
+        if (value.isJsonPrimitive()) {
+            return value.getAsString();
+        }
+        return PRETTY.toJson(value);
+    }
+
+    private static boolean booleanValue(JsonObject object, String key) {
+        JsonElement value = object.get(key);
+        return value != null
+                && value.isJsonPrimitive()
+                && value.getAsJsonPrimitive().isBoolean()
+                && value.getAsBoolean();
+    }
+
+    private static String table(String value) {
+        return value.replace("|", "\\|").replace("\n", "<br>");
+    }
+
     private static JsonElement parse(String text) {
         if (text == null || text.isBlank()) {
             return null;
@@ -157,5 +410,12 @@ final class AssistantMarkdown {
 
     private static String fence(String language, String text) {
         return "```" + language + "\n" + text.stripTrailing() + "\n```";
+    }
+
+    private static String clip(String text, int maxCharacters) {
+        if (text == null || text.length() <= maxCharacters) {
+            return text == null ? "" : text;
+        }
+        return text.substring(0, maxCharacters) + "\n... truncated ...";
     }
 }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantChatState.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantChatState.java
@@ -1,0 +1,202 @@
+package com.shaft.intellij.ui;
+
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.components.StoragePathMacros;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.xmlb.XmlSerializerUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Project-scoped persistent Assistant chat sessions.
+ */
+@State(name = "ShaftAssistantChats", storages = @Storage(StoragePathMacros.WORKSPACE_FILE))
+public final class ShaftAssistantChatState implements PersistentStateComponent<ShaftAssistantChatState.ChatState> {
+    private static final int MAX_SESSIONS = 12;
+    private static final int MAX_MESSAGES_PER_SESSION = 80;
+
+    private ChatState state = new ChatState();
+
+    /**
+     * Returns the project-level Assistant chat state service.
+     *
+     * @param project IntelliJ project
+     * @return chat state service
+     */
+    public static ShaftAssistantChatState getInstance(Project project) {
+        return project.getService(ShaftAssistantChatState.class);
+    }
+
+    @Override
+    public ChatState getState() {
+        ensureActiveSession();
+        return state;
+    }
+
+    @Override
+    public void loadState(@NotNull ChatState loadedState) {
+        XmlSerializerUtil.copyBean(loadedState, state);
+        ensureActiveSession();
+        trim();
+    }
+
+    Session activeSession() {
+        ensureActiveSession();
+        return sessionById(state.activeSessionId);
+    }
+
+    List<Session> sessions() {
+        ensureActiveSession();
+        return List.copyOf(state.sessions);
+    }
+
+    void activate(String sessionId) {
+        if (sessionById(sessionId) != null) {
+            state.activeSessionId = sessionId;
+        }
+    }
+
+    Session newSession() {
+        Session session = new Session();
+        session.id = UUID.randomUUID().toString();
+        session.title = "New chat";
+        session.createdAt = now();
+        session.updatedAt = session.createdAt;
+        state.sessions.add(0, session);
+        state.activeSessionId = session.id;
+        trim();
+        return session;
+    }
+
+    void append(String role, String markdown, String raw) {
+        if (markdown == null || markdown.isBlank()) {
+            return;
+        }
+        Session session = activeSession();
+        Message message = new Message();
+        message.role = role == null ? "" : role;
+        message.markdown = markdown;
+        message.createdAt = now();
+        session.messages.add(message);
+        session.updatedAt = message.createdAt;
+        if ("New chat".equals(session.title) && "user".equals(message.role)) {
+            session.title = titleFrom(markdown);
+        }
+        trim();
+    }
+
+    void clearActiveSession() {
+        Session session = activeSession();
+        session.messages.clear();
+        session.title = "New chat";
+        session.updatedAt = now();
+    }
+
+    String activeMarkdown() {
+        Session session = activeSession();
+        List<String> parts = new ArrayList<>();
+        for (Message message : session.messages) {
+            if (message.markdown != null && !message.markdown.isBlank()) {
+                parts.add(message.markdown);
+            }
+        }
+        return String.join("\n\n", parts);
+    }
+
+    private void ensureActiveSession() {
+        if (state.sessions == null) {
+            state.sessions = new ArrayList<>();
+        }
+        if (state.sessions.isEmpty()) {
+            newSession();
+            return;
+        }
+        if (sessionById(state.activeSessionId) == null) {
+            state.activeSessionId = state.sessions.get(0).id;
+        }
+    }
+
+    private Session sessionById(String sessionId) {
+        if (sessionId == null || state.sessions == null) {
+            return null;
+        }
+        for (Session session : state.sessions) {
+            if (sessionId.equals(session.id)) {
+                return session;
+            }
+        }
+        return null;
+    }
+
+    private void trim() {
+        ensureMessages();
+        while (state.sessions.size() > MAX_SESSIONS) {
+            state.sessions.remove(state.sessions.size() - 1);
+        }
+    }
+
+    private void ensureMessages() {
+        for (Session session : state.sessions) {
+            if (session.messages == null) {
+                session.messages = new ArrayList<>();
+            }
+            while (session.messages.size() > MAX_MESSAGES_PER_SESSION) {
+                session.messages.remove(0);
+            }
+        }
+    }
+
+    private static String titleFrom(String markdown) {
+        String text = markdown.replace("*", "")
+                .replace("`", "")
+                .replace("\n", " ")
+                .trim();
+        if (text.length() <= 40) {
+            return text.isBlank() ? "New chat" : text;
+        }
+        return text.substring(0, 37).stripTrailing() + "...";
+    }
+
+    private static String now() {
+        return Instant.now().toString();
+    }
+
+    /**
+     * XML-serializable chat state.
+     */
+    public static final class ChatState {
+        public String activeSessionId = "";
+        public List<Session> sessions = new ArrayList<>();
+    }
+
+    /**
+     * XML-serializable Assistant session.
+     */
+    public static final class Session {
+        public String id = "";
+        public String title = "New chat";
+        public String createdAt = "";
+        public String updatedAt = "";
+        public List<Message> messages = new ArrayList<>();
+
+        @Override
+        public String toString() {
+            return title == null || title.isBlank() ? "New chat" : title;
+        }
+    }
+
+    /**
+     * XML-serializable Assistant transcript message.
+     */
+    public static final class Message {
+        public String role = "";
+        public String markdown = "";
+        public String createdAt = "";
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
+import javax.swing.DefaultComboBoxModel;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
@@ -39,6 +40,10 @@ import java.util.concurrent.CancellationException;
  * SHAFT Assistant chat-style panel.
  */
 final class ShaftAssistantPanel extends JPanel {
+    private final Project project;
+    private final ShaftAssistantChatState chatState;
+    private final JComboBox<ShaftAssistantChatState.Session> chatSelector;
+    private final JButton newChat;
     private final JComboBox<String> mode;
     private final JComboBox<String> providerType;
     private final JComboBox<String> assistantFamily;
@@ -68,16 +73,29 @@ final class ShaftAssistantPanel extends JPanel {
     private String lastRawResponse = "";
     private String lastPrompt = "";
     private ShaftMcpInvocation currentInvocation;
+    private boolean refreshingChats;
 
     ShaftAssistantPanel(Project project) {
         this(project, ShaftSettingsState.getInstance().getState());
     }
 
     ShaftAssistantPanel(Project project, @NotNull ShaftSettingsState.Settings settings) {
+        this(project, settings, chatState(project));
+    }
+
+    ShaftAssistantPanel(Project project,
+                        @NotNull ShaftSettingsState.Settings settings,
+                        @NotNull ShaftAssistantChatState chatState) {
         super(new BorderLayout(6, 6));
+        this.project = project;
         this.settings = settings;
+        this.chatState = chatState;
         setBorder(JBUI.Borders.empty(8));
 
+        chatSelector = new JComboBox<>();
+        chatSelector.getAccessibleContext().setAccessibleName("Assistant chat");
+        chatSelector.addActionListener(event -> switchChat());
+        newChat = button("New chat", "Start a new Assistant chat", event -> newChat());
         mode = combo("Assistant mode", "ASK", "PLAN", "AGENT");
         mode.setSelectedItem(normalize(settings.defaultAutobotMode, "ASK"));
         providerType = combo("Assistant provider type", "LOCAL", "CLOUD");
@@ -116,6 +134,10 @@ final class ShaftAssistantPanel extends JPanel {
         prompt.setLineWrap(true);
         prompt.setWrapStyleWord(true);
         transcript = new AssistantTranscriptView();
+        String persistedTranscript = chatState.activeMarkdown();
+        if (!persistedTranscript.isBlank()) {
+            transcript.setMarkdown(persistedTranscript);
+        }
         status = new JLabel("Ready");
         progress = new JProgressBar();
         progress.setIndeterminate(true);
@@ -146,6 +168,8 @@ final class ShaftAssistantPanel extends JPanel {
         transcriptPanel.add(transcript, BorderLayout.CENTER);
 
         JPanel actionRow = wrapRow();
+        actionRow.add(chatSelector);
+        actionRow.add(newChat);
         actionRow.add(testConnection);
         actionRow.add(copyLastResponse);
         actionRow.add(copyRawResponse);
@@ -189,6 +213,7 @@ final class ShaftAssistantPanel extends JPanel {
         add(setupNotice(project, settings), BorderLayout.NORTH);
         add(transcriptPanel, BorderLayout.CENTER);
         add(south, BorderLayout.SOUTH);
+        refreshChatSelector();
     }
 
     JComponent preferredFocusComponent() {
@@ -216,8 +241,8 @@ final class ShaftAssistantPanel extends JPanel {
                 project == null || project.getBasePath() == null ? "" : project.getBasePath(),
                 customCommand.getText(),
                 allowSourceMutation.isSelected());
-        append("**You (" + ShaftUiLabels.friendly(mode.getSelectedItem()) + " via " + routeLabel(route) + ")**\n\n"
-                + AssistantMarkdown.normalizeMarkdown(text));
+        append("user", "**You (" + ShaftUiLabels.friendly(mode.getSelectedItem()) + " via " + routeLabel(route) + ")**\n\n"
+                + AssistantMarkdown.normalizeMarkdown(text), "");
         prompt.setText("");
         if (invocation.isLocal()) {
             showLocalResponse(invocation.localResponse());
@@ -262,8 +287,12 @@ final class ShaftAssistantPanel extends JPanel {
         String output = error != null ? error.getMessage()
                 : result == null ? "No result returned."
                 : result.output();
+        String markdown = AssistantMarkdown.fromMcpOutput(toolName, output);
+        if (success && formatUnknownResponse(toolName, output, markdown)) {
+            return;
+        }
         showResponse("**SHAFT Assistant (" + toolName + (success ? " OK" : " failed") + ")**\n\n"
-                + AssistantMarkdown.fromMcpOutput(output), output);
+                + markdown, output);
     }
 
     private void showLocalResponse(String response) {
@@ -276,15 +305,19 @@ final class ShaftAssistantPanel extends JPanel {
         lastRawResponse = rawResponse == null ? "" : rawResponse;
         copyLastResponse.setEnabled(true);
         copyRawResponse.setEnabled(!lastRawResponse.isBlank());
-        append(response);
+        append("assistant", response, rawResponse);
     }
 
-    private void append(String text) {
+    private void append(String role, String text, String rawResponse) {
         transcript.append(text);
+        chatState.append(role, text, rawResponse);
+        refreshChatSelector();
     }
 
     private void setRunning(boolean running, String message) {
         send.setEnabled(!running);
+        chatSelector.setEnabled(!running);
+        newChat.setEnabled(!running);
         testConnection.setEnabled(!running);
         rerunLastPrompt.setEnabled(!running && !lastPrompt.isBlank());
         mode.setEnabled(!running);
@@ -377,12 +410,42 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     private void clearTranscript() {
+        chatState.clearActiveSession();
         transcript.clear();
         lastResponse = "";
         lastRawResponse = "";
+        lastPrompt = "";
         copyLastResponse.setEnabled(false);
         copyRawResponse.setEnabled(false);
+        rerunLastPrompt.setEnabled(false);
+        refreshChatSelector();
         status.setText("Cleared");
+    }
+
+    private void newChat() {
+        chatState.newSession();
+        refreshChatSelector();
+        transcript.clear();
+        prompt.setText("");
+        lastResponse = "";
+        lastRawResponse = "";
+        lastPrompt = "";
+        copyLastResponse.setEnabled(false);
+        copyRawResponse.setEnabled(false);
+        rerunLastPrompt.setEnabled(false);
+        status.setText("New chat");
+    }
+
+    private void switchChat() {
+        if (refreshingChats) {
+            return;
+        }
+        Object selected = chatSelector.getSelectedItem();
+        if (selected instanceof ShaftAssistantChatState.Session session) {
+            chatState.activate(session.id);
+            restoreTranscript();
+            status.setText("Chat loaded");
+        }
     }
 
     private void rerun(Project project) {
@@ -409,6 +472,77 @@ final class ShaftAssistantPanel extends JPanel {
             currentInvocation.cancel();
             status.setText("Cancelling...");
         }
+    }
+
+    private boolean formatUnknownResponse(String toolName, String output, String fallbackMarkdown) {
+        if (!AssistantMarkdown.shouldFormatWithAgent(toolName, output) || project == null || !mcpConfigured()) {
+            return false;
+        }
+        if (usesCloud() && !hasSelectedCloudKey()) {
+            return false;
+        }
+        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+                AssistantMarkdown.formatterPrompt(toolName, output),
+                selectedRoute(),
+                "ASK",
+                project.getBasePath() == null ? "" : project.getBasePath(),
+                customCommand.getText(),
+                false);
+        if (invocation.isLocal()) {
+            return false;
+        }
+        setRunning(true, "Formatting response...");
+        currentInvocation = ShaftMcpInvocationService.getInstance(project).startTool(invocation.toolName(), invocation.arguments());
+        currentInvocation.future().whenComplete((result, error) -> ApplicationManager.getApplication().invokeLater(
+                () -> showFormattedUnknownResponse(toolName, output, fallbackMarkdown, invocation.toolName(), result, error)));
+        return true;
+    }
+
+    private void showFormattedUnknownResponse(String originalToolName,
+                                              String rawOutput,
+                                              String fallbackMarkdown,
+                                              String formatterToolName,
+                                              ShaftMcpToolResult result,
+                                              Throwable error) {
+        boolean success = error == null && result != null && result.success();
+        setRunning(false, success ? "Formatted" : "Finished");
+        String markdown = fallbackMarkdown;
+        if (success) {
+            String formatted = AssistantMarkdown.fromMcpOutput(formatterToolName, result.output());
+            if (!formatted.isBlank()) {
+                markdown = formatted;
+            }
+        }
+        showResponse("**SHAFT Assistant (" + originalToolName + " OK)**\n\n" + markdown, rawOutput);
+    }
+
+    private void refreshChatSelector() {
+        refreshingChats = true;
+        try {
+            DefaultComboBoxModel<ShaftAssistantChatState.Session> model = new DefaultComboBoxModel<>();
+            for (ShaftAssistantChatState.Session session : chatState.sessions()) {
+                model.addElement(session);
+            }
+            chatSelector.setModel(model);
+            chatSelector.setSelectedItem(chatState.activeSession());
+        } finally {
+            refreshingChats = false;
+        }
+    }
+
+    private void restoreTranscript() {
+        String markdown = chatState.activeMarkdown();
+        if (!markdown.isBlank()) {
+            transcript.setMarkdown(markdown);
+        } else {
+            transcript.clear();
+        }
+        lastResponse = "";
+        lastRawResponse = "";
+        lastPrompt = "";
+        copyLastResponse.setEnabled(false);
+        copyRawResponse.setEnabled(false);
+        rerunLastPrompt.setEnabled(false);
     }
 
     private void copy(String value, String message) {
@@ -457,6 +591,14 @@ final class ShaftAssistantPanel extends JPanel {
         button.getAccessibleContext().setAccessibleName(accessibleName);
         button.addActionListener(action);
         return button;
+    }
+
+    private static ShaftAssistantChatState chatState(Project project) {
+        if (project == null) {
+            return new ShaftAssistantChatState();
+        }
+        ShaftAssistantChatState state = ShaftAssistantChatState.getInstance(project);
+        return state == null ? new ShaftAssistantChatState() : state;
     }
 
     private static String resolveFamily(ShaftSettingsState.Settings settings) {

--- a/shaft-intellij/src/main/resources/META-INF/io.github.shafthq.shaft-withJava.xml
+++ b/shaft-intellij/src/main/resources/META-INF/io.github.shafthq.shaft-withJava.xml
@@ -1,0 +1,13 @@
+<idea-plugin>
+    <actions>
+        <action id="Shaft.RecordJavaTarget"
+                class="com.shaft.intellij.actions.RecordShaftFlowHereAction"
+                text="Record SHAFT Flow Here"
+                description="Prepare a SHAFT record-at-target MCP request for the current Java context"
+                icon="/icons/shaftToolWindow.png"
+                iconDark="/icons/shaftToolWindow_dark.png">
+            <add-to-group group-id="Shaft.ToolsMenu" anchor="last"/>
+            <add-to-group group-id="EditorPopupMenu" anchor="last"/>
+        </action>
+    </actions>
+</idea-plugin>

--- a/shaft-intellij/src/main/resources/META-INF/plugin.xml
+++ b/shaft-intellij/src/main/resources/META-INF/plugin.xml
@@ -4,7 +4,7 @@
     <vendor email="Mohab.MohieElDeen@outlook.com" url="https://shafthq.github.io">ShaftHQ</vendor>
 
     <depends>com.intellij.modules.platform</depends>
-    <depends>com.intellij.java</depends>
+    <depends optional="true" config-file="io.github.shafthq.shaft-withJava.xml">com.intellij.java</depends>
 
     <resource-bundle>messages.ShaftBundle</resource-bundle>
 
@@ -17,6 +17,7 @@
         <applicationService serviceImplementation="com.shaft.intellij.settings.ShaftSettingsState"/>
         <applicationService serviceImplementation="com.shaft.intellij.settings.ShaftCredentialService"/>
         <projectService serviceImplementation="com.shaft.intellij.mcp.ShaftMcpInvocationService"/>
+        <projectService serviceImplementation="com.shaft.intellij.ui.ShaftAssistantChatState"/>
         <applicationConfigurable instance="com.shaft.intellij.settings.ShaftSettingsConfigurable"
                                  id="shaft.settings"
                                  displayName="SHAFT"/>
@@ -32,14 +33,6 @@
                     description="Open the SHAFT tool window"
                     icon="/icons/shaftToolWindow.png"
                     iconDark="/icons/shaftToolWindow_dark.png"/>
-            <action id="Shaft.RecordJavaTarget"
-                    class="com.shaft.intellij.actions.RecordShaftFlowHereAction"
-                    text="Record SHAFT Flow Here"
-                    description="Prepare a SHAFT record-at-target MCP request for the current Java context"
-                    icon="/icons/shaftToolWindow.png"
-                    iconDark="/icons/shaftToolWindow_dark.png">
-                <add-to-group group-id="EditorPopupMenu" anchor="last"/>
-            </action>
         </group>
     </actions>
 </idea-plugin>

--- a/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpConnectionProbeTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpConnectionProbeTest.java
@@ -1,0 +1,52 @@
+package com.shaft.intellij.mcp;
+
+import com.shaft.intellij.settings.ShaftSettingsState;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShaftMcpConnectionProbeTest {
+    @TempDir
+    Path temporary;
+
+    @Test
+    void connectionProbeReportsEffectiveProjectWorkspace() throws Exception {
+        Path project = temporary.resolve("project").toAbsolutePath().normalize();
+        Files.createDirectories(project);
+        String command = quote(javaExecutable()) + " -cp " + quote(System.getProperty("java.class.path"))
+                + " " + FakeMcpServer.class.getName() + " stdoutNoiseThenToolsList";
+
+        ShaftMcpToolResult result = ShaftMcpConnectionProbe.test(
+                command,
+                new ShaftSettingsState.Settings(),
+                project).get(5, TimeUnit.SECONDS);
+
+        String output = result.output();
+        assertAll(
+                () -> assertTrue(result.success()),
+                () -> assertTrue(output.contains("MCP workspace: " + project)),
+                () -> assertTrue(output.contains("user.dir: " + project)),
+                () -> assertTrue(output.contains("shaft.mcp.workspaceRoot: " + project)),
+                () -> assertTrue(output.contains("SHAFT_MCP_WORKSPACE_ROOT: " + project)),
+                () -> assertFalse(output.contains("ShaftHQ/shaft-mcp/work")));
+    }
+
+    private static String javaExecutable() {
+        String javaHome = System.getProperty("java.home");
+        boolean windows = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
+        return Paths.get(javaHome, "bin", windows ? "java.exe" : "java").toString();
+    }
+
+    private static String quote(String value) {
+        return "\"" + value.replace("\"", "\\\"") + "\"";
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpProjectScopeTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpProjectScopeTest.java
@@ -60,6 +60,24 @@ class ShaftMcpProjectScopeTest {
     }
 
     @Test
+    void plainJavaCommandGetsProjectWorkspaceProperties() throws IOException {
+        Path project = temporary.resolve("project").toAbsolutePath().normalize();
+
+        List<String> command = ShaftMcpProjectScope.commandForProject(List.of(
+                "java",
+                "-Duser.dir=C:/Users/me/AppData/Local/ShaftHQ/shaft-mcp/work",
+                "-jar",
+                "shaft-mcp.jar"), project);
+
+        String expectedProject = project.toString().replace('\\', '/');
+        assertEquals("java", command.get(0));
+        assertEquals("-Duser.dir=" + expectedProject, command.get(1));
+        assertEquals("-Dshaft.mcp.workspaceRoot=" + expectedProject, command.get(2));
+        assertFalse(command.contains("-Duser.dir=C:/Users/me/AppData/Local/ShaftHQ/shaft-mcp/work"));
+        assertEquals("-jar", command.get(3));
+    }
+
+    @Test
     void environmentIncludesCurrentProjectWorkspace() {
         Path project = temporary.resolve("project").toAbsolutePath().normalize();
 

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantMarkdownTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantMarkdownTest.java
@@ -2,6 +2,7 @@ package com.shaft.intellij.ui;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -27,12 +28,111 @@ class AssistantMarkdownTest {
     }
 
     @Test
+    void unwrapsJsonRpcResultContentEnvelope() {
+        JsonObject envelope = new JsonObject();
+        envelope.addProperty("jsonrpc", "2.0");
+        envelope.addProperty("id", 1);
+        envelope.add("result", JsonParser.parseString(mcpText("Run the focused check.")));
+
+        String markdown = AssistantMarkdown.fromMcpOutput("shaft_guide_search", envelope.toString());
+
+        assertAll(
+                () -> assertTrue(markdown.contains("Run the focused check.")),
+                () -> assertFalse(markdown.contains("\"jsonrpc\"")),
+                () -> assertFalse(markdown.contains("\"content\"")));
+    }
+
+    @Test
     void formatsJsonPayloadsAsMarkdownFencedBlocks() {
         String markdown = AssistantMarkdown.fromMcpOutput(mcpText("{\"client\":\"CODEX\",\"displayName\":\"Codex CLI\"}"));
 
         assertAll(
                 () -> assertTrue(markdown.startsWith("```json")),
                 () -> assertTrue(markdown.contains("\"displayName\": \"Codex CLI\"")));
+    }
+
+    @Test
+    void formatsLocalAgentClientsAsMarkdownTable() {
+        String markdown = AssistantMarkdown.fromMcpOutput("autobot_local_agent_clients", mcpText("""
+                [
+                  {"id":"CODEX","displayName":"Codex CLI","executableName":"codex","requiresCloudApiKey":false},
+                  {"id":"CLAUDE_CODE","displayName":"Claude Code","executableName":"claude","requiresCloudApiKey":false}
+                ]
+                """));
+
+        assertAll(
+                () -> assertTrue(markdown.contains("| Client | Command | SHAFT API key |")),
+                () -> assertTrue(markdown.contains("| Codex CLI | `codex` | Not required |")),
+                () -> assertFalse(markdown.contains("\"displayName\"")));
+    }
+
+    @Test
+    void formatsLocalAgentRunAroundStdoutAndWarnings() {
+        String markdown = AssistantMarkdown.fromMcpOutput("autobot_local_agent_run", """
+                {
+                  "status": "FAILED",
+                  "client": "CODEX",
+                  "mode": "ASK",
+                  "command": ["codex", "exec"],
+                  "exitCode": 1,
+                  "stdout": "Use `mvn test` for the focused check.",
+                  "stderr": "WARN noisy diagnostic",
+                  "timedOut": false,
+                  "duration": "PT1S",
+                  "requiresCloudApiKey": false,
+                  "warnings": ["Codex returned a non-zero exit code."]
+                }
+                """);
+
+        assertAll(
+                () -> assertTrue(markdown.contains("Use `mvn test` for the focused check.")),
+                () -> assertTrue(markdown.contains("**Warnings**")),
+                () -> assertTrue(markdown.contains("Codex returned a non-zero exit code.")),
+                () -> assertTrue(markdown.contains("```text")),
+                () -> assertFalse(markdown.contains("\"stdout\"")));
+    }
+
+    @Test
+    void formatsProviderChatAnswerAndRejectedWarnings() {
+        String success = AssistantMarkdown.fromMcpOutput("autobot_provider_chat", """
+                {
+                  "status": "SUCCESS",
+                  "provider": "openai",
+                  "model": "gpt-4.1",
+                  "mode": "ASK",
+                  "answer": "Run the focused IntelliJ plugin tests.",
+                  "warnings": [],
+                  "duration": "PT2S",
+                  "fallbackReason": ""
+                }
+                """);
+        String rejected = AssistantMarkdown.fromMcpOutput("autobot_provider_chat", """
+                {
+                  "status": "REJECTED",
+                  "provider": "github",
+                  "model": "openai/gpt-4.1",
+                  "mode": "AGENT",
+                  "answer": "",
+                  "warnings": ["Cloud provider chat supports Ask and Plan only."],
+                  "duration": "PT0S",
+                  "fallbackReason": ""
+                }
+                """);
+
+        assertAll(
+                () -> assertTrue(success.contains("Run the focused IntelliJ plugin tests.")),
+                () -> assertFalse(success.contains("\"answer\"")),
+                () -> assertTrue(rejected.contains("Cloud provider chat supports Ask and Plan only.")),
+                () -> assertTrue(rejected.contains("**Status:** REJECTED")));
+    }
+
+    @Test
+    void unknownJsonCanUseAgentFormatterButKnownResponsesDoNot() {
+        assertAll(
+                () -> assertTrue(AssistantMarkdown.shouldFormatWithAgent("browser_unknown", "{\"unexpected\":true}")),
+                () -> assertTrue(AssistantMarkdown.shouldFormatWithAgent("browser_unknown", "{\"status\":\"MYSTERY\"}")),
+                () -> assertFalse(AssistantMarkdown.shouldFormatWithAgent("autobot_local_agent_clients", "[]")),
+                () -> assertFalse(AssistantMarkdown.shouldFormatWithAgent("unknown", "{\"warnings\":[\"safe\"]}")));
     }
 
     private static String mcpText(String text) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftIconAssetsTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftIconAssetsTest.java
@@ -32,10 +32,16 @@ class ShaftIconAssetsTest {
     @Test
     void pluginDescriptorRegistersDarkModeIconAndRestartRequirement() throws IOException {
         String descriptor = Files.readString(Path.of("src/main/resources/META-INF/plugin.xml"));
+        String javaDescriptor = Files.readString(Path.of(
+                "src/main/resources/META-INF/io.github.shafthq.shaft-withJava.xml"));
 
         assertAll(
                 () -> assertTrue(descriptor.contains("require-restart=\"true\"")),
-                () -> assertTrue(descriptor.contains("iconDark=\"/icons/shaftToolWindow_dark.png\"")));
+                () -> assertTrue(descriptor.contains("iconDark=\"/icons/shaftToolWindow_dark.png\"")),
+                () -> assertTrue(descriptor.contains("optional=\"true\"")),
+                () -> assertTrue(descriptor.contains("config-file=\"io.github.shafthq.shaft-withJava.xml\"")),
+                () -> assertTrue(javaDescriptor.contains("Shaft.RecordJavaTarget")),
+                () -> assertTrue(javaDescriptor.contains("EditorPopupMenu")));
     }
 
     private static boolean hasNonTransparentPixel(BufferedImage image) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ShaftPanelSetupTest {
@@ -152,6 +153,74 @@ class ShaftPanelSetupTest {
                 () -> assertTrue(markdown.contains("public class LoginTest")),
                 () -> assertFalse(markdown.contains("\\\"content\\\"")),
                 () -> assertTrue(containsText(panel, "Copy raw")));
+    }
+
+    @Test
+    void assistantDisplaysKnownClientListAsMarkdown() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+
+        showAssistantResult(panel, "autobot_local_agent_clients", ShaftMcpToolResult.success(mcpText("""
+                [
+                  {"id":"CODEX","displayName":"Codex CLI","executableName":"codex","requiresCloudApiKey":false}
+                ]
+                """)));
+
+        String markdown = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(markdown.contains("| Client | Command | SHAFT API key |")),
+                () -> assertTrue(markdown.contains("| Codex CLI | `codex` | Not required |")),
+                () -> assertFalse(markdown.contains("\\\"displayName\\\"")));
+    }
+
+    @Test
+    void assistantPersistsActiveChatAndCanStartNewContext() throws Exception {
+        ShaftAssistantChatState chatState = new ShaftAssistantChatState();
+        ShaftSettingsState.Settings settings = blankMcpSettings();
+        ShaftAssistantPanel firstPanel = new ShaftAssistantPanel(null, settings, chatState);
+
+        showAssistantResult(firstPanel, ShaftMcpToolResult.success(mcpText("First answer")));
+
+        ShaftAssistantPanel reopenedPanel = new ShaftAssistantPanel(null, settings, chatState);
+        assertTrue(transcriptMarkdown(reopenedPanel).contains("First answer"));
+
+        click(reopenedPanel, "New chat");
+        assertFalse(transcriptMarkdown(reopenedPanel).contains("First answer"));
+
+        showAssistantResult(reopenedPanel, ShaftMcpToolResult.success(mcpText("Second answer")));
+        assertAll(
+                () -> assertTrue(transcriptMarkdown(reopenedPanel).contains("Second answer")),
+                () -> assertEquals(2, chatState.sessions().size()));
+    }
+
+    @Test
+    void assistantDoesNotPersistRawResponsePayloads() throws Exception {
+        ShaftAssistantChatState chatState = new ShaftAssistantChatState();
+
+        chatState.append("assistant", "Rendered response", "{\"secret\":\"raw payload\"}");
+
+        assertAll(
+                () -> assertEquals("Rendered response",
+                        chatState.getState().sessions.get(0).messages.get(0).markdown),
+                () -> assertThrows(NoSuchFieldException.class,
+                        () -> ShaftAssistantChatState.Message.class.getDeclaredField("raw")));
+    }
+
+    @Test
+    void assistantNewChatClearsRerunAndCopyState() {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+
+        assistantPrompt(panel).setText("/help");
+        click(panel, "Send");
+        assertAll(
+                () -> assertTrue(findButton(panel, "Rerun").isEnabled()),
+                () -> assertTrue(findButton(panel, "Copy response").isEnabled()));
+
+        click(panel, "New chat");
+
+        assertAll(
+                () -> assertFalse(findButton(panel, "Rerun").isEnabled()),
+                () -> assertFalse(findButton(panel, "Copy response").isEnabled()),
+                () -> assertFalse(transcriptMarkdown(panel).contains("Slash commands:")));
     }
 
     @Test
@@ -303,10 +372,14 @@ class ShaftPanelSetupTest {
     }
 
     private static void showAssistantResult(ShaftAssistantPanel panel, ShaftMcpToolResult result) throws Exception {
+        showAssistantResult(panel, "autobot_local_agent_run", result);
+    }
+
+    private static void showAssistantResult(ShaftAssistantPanel panel, String toolName, ShaftMcpToolResult result) throws Exception {
         Method showResult = ShaftAssistantPanel.class.getDeclaredMethod(
                 "showResult", String.class, ShaftMcpToolResult.class, Throwable.class);
         showResult.setAccessible(true);
-        showResult.invoke(panel, "autobot_local_agent_run", result, null);
+        showResult.invoke(panel, toolName, result, null);
     }
 
     private static String mcpText(String text) {
@@ -432,6 +505,27 @@ class ShaftPanelSetupTest {
         if (component instanceof Container container) {
             for (Component child : container.getComponents()) {
                 JButton found = findButton(child, text);
+                if (found != null) {
+                    return found;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static JTextComponent assistantPrompt(Component component) {
+        JTextComponent prompt = textComponent(component, "Assistant prompt");
+        assertNotNull(prompt);
+        return prompt;
+    }
+
+    private static JTextComponent textComponent(Component component, String accessibleName) {
+        if (component instanceof JTextComponent textComponent && accessibleName.equals(accessibleName(textComponent))) {
+            return textComponent;
+        }
+        if (component instanceof Container container) {
+            for (Component child : container.getComponents()) {
+                JTextComponent found = textComponent(child, accessibleName);
                 if (found != null) {
                     return found;
                 }


### PR DESCRIPTION
## Summary
- Make the Java-specific recorder action an optional IntelliJ Java-plugin extension so the core SHAFT tool window can install/load without `com.intellij.java`
- Render known SHAFT/MCP responses as user-friendly Markdown and route unknown structured responses through the selected Assistant formatter when configured
- Add project-scoped persistent Assistant chat sessions with a New chat flow, without persisting raw MCP payloads
- Scope MCP Java commands and diagnostics to the open IntelliJ project for both argfile and plain Java command launches

## Validation
- `gradle -p shaft-intellij test`
- `py -3 scripts/ci/validate_agent_setup.py`
- Companion docs PR: https://github.com/ShaftHQ/shafthq.github.io/pull/671 (`yarn test:docs`)

Closes #3176