### PR TITLE
[codex] Support DPI-tolerant image actions

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java
@@ -31,6 +31,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Arrays.asList;
 
@@ -160,15 +161,8 @@ public class TouchActions extends FluentWebDriverAction {
             elementActionsHelper.failAction(driverFactoryHelper.getDriver(), "Couldn't find reference element on the current screen. If you can see it in the attached image then kindly consider cropping it and updating your reference image under this path \"" + elementReferenceScreenshot + "\".", null, attachments);
         } else {
             // Perform tap action by coordinates
-//            if (DriverFactoryHelper.isMobileNativeExecution()) {
-            PointerInput input = new PointerInput(PointerInput.Kind.TOUCH, "finger1");
-            Sequence tap = new Sequence(input, 0);
-            tap.addAction(input.createPointerMove(Duration.ZERO, PointerInput.Origin.viewport(), coordinates.get(0), coordinates.get(1)));
-            tap.addAction(input.createPointerDown(PointerInput.MouseButton.LEFT.asArg()));
-            tap.addAction(new Pause(input, Duration.ofMillis(200)));
-            tap.addAction(input.createPointerUp(PointerInput.MouseButton.LEFT.asArg()));
             try {
-                ((RemoteWebDriver) driverFactoryHelper.getDriver()).perform(ImmutableList.of(tap));
+                performCoordinateTap(coordinates);
             } catch (UnsupportedCommandException exception) {
                 elementActionsHelper.failAction(driverFactoryHelper.getDriver(),
                         "referenceImage=" + elementReferenceScreenshot + ", coordinates=" + coordinates,
@@ -177,6 +171,43 @@ public class TouchActions extends FluentWebDriverAction {
             elementActionsHelper.passAction(driverFactoryHelper.getDriver(), null,
                     Thread.currentThread().getStackTrace()[1].getMethodName(),
                     "referenceImage=" + elementReferenceScreenshot + ", coordinates=" + coordinates, attachments, null);
+        }
+        return this;
+    }
+
+    /**
+     * Taps an element found by reference image, then types into the active field.
+     *
+     * @param elementReferenceScreenshot relative path to the reference image from the local object repository
+     * @param text                       one or more {@link CharSequence} values to type into the focused element
+     * @return a self-reference to be used to chain actions
+     */
+    @SuppressWarnings("unchecked")
+    public TouchActions type(String elementReferenceScreenshot, CharSequence... text) {
+        var objects = elementActionsHelper.waitForElementPresence(driverFactoryHelper.getDriver(), elementReferenceScreenshot);
+        byte[] currentScreenImage = (byte[]) objects.get(0);
+        byte[] referenceImage = (byte[]) objects.get(1);
+        List<Integer> coordinates = (List<Integer>) objects.get(2);
+
+        var screenshotManager = new ScreenshotManager();
+        var screenshot = screenshotManager.prepareImageForReport(currentScreenImage, "type - Current Screen Image");
+        var referenceScreenshot = screenshotManager.prepareImageForReport(referenceImage, "type - Reference Screenshot");
+        List<List<Object>> attachments = new LinkedList<>();
+        attachments.add(referenceScreenshot);
+        attachments.add(screenshot);
+
+        if (Collections.emptyList().equals(coordinates)) {
+            elementActionsHelper.failAction(driverFactoryHelper.getDriver(), "Couldn't find reference element on the current screen. If you can see it in the attached image then kindly consider cropping it and updating your reference image under this path \"" + elementReferenceScreenshot + "\".", null, attachments);
+        } else {
+            String testData = "referenceImage=" + elementReferenceScreenshot + ", coordinates=" + coordinates;
+            try {
+                performCoordinateTap(coordinates);
+                new Actions(driverFactoryHelper.getDriver()).sendKeys(text).perform();
+            } catch (Exception exception) {
+                elementActionsHelper.failAction(driverFactoryHelper.getDriver(), testData, null, exception);
+            }
+            elementActionsHelper.passAction(driverFactoryHelper.getDriver(), null,
+                    Thread.currentThread().getStackTrace()[1].getMethodName(), testData, attachments, null);
         }
         return this;
     }
@@ -638,46 +669,22 @@ public class TouchActions extends FluentWebDriverAction {
         try {
             //noinspection CaughtExceptionImmediatelyRethrown
             try {
-                if (driverFactoryHelper.getDriver() instanceof AppiumDriver appiumDriver) {
-                    // appium native application
-                    var visualIdentificationObjects = attemptToSwipeElementIntoViewInNativeApp(scrollableElementLocator, elementReferenceScreenshot, swipeDirection);
-                    byte[] currentScreenImage = (byte[]) visualIdentificationObjects.get(0);
-                    byte[] referenceImage = (byte[]) visualIdentificationObjects.get(1);
-                    List<Integer> coordinates = (List<Integer>) visualIdentificationObjects.get(2);
+                var visualIdentificationObjects = attemptToSwipeElementIntoViewByImage(scrollableElementLocator, elementReferenceScreenshot, swipeDirection);
+                byte[] currentScreenImage = (byte[]) visualIdentificationObjects.get(0);
+                byte[] referenceImage = (byte[]) visualIdentificationObjects.get(1);
+                List<Integer> coordinates = (List<Integer>) visualIdentificationObjects.get(2);
 
-                    // prepare attachments
-                    var screenshotManager = new ScreenshotManager();
-                    var screenshot = screenshotManager.prepareImageForReport(currentScreenImage, "swipeElementIntoView - Current Screen Image");
-                    var referenceScreenshot = screenshotManager.prepareImageForReport(referenceImage, "swipeElementIntoView - Reference Screenshot");
-                    attachments = new LinkedList<>();
-                    attachments.add(referenceScreenshot);
-                    attachments.add(screenshot);
+                // prepare attachments
+                var screenshotManager = new ScreenshotManager();
+                var screenshot = screenshotManager.prepareImageForReport(currentScreenImage, "swipeElementIntoView - Current Screen Image");
+                var referenceScreenshot = screenshotManager.prepareImageForReport(referenceImage, "swipeElementIntoView - Reference Screenshot");
+                attachments = new LinkedList<>();
+                attachments.add(referenceScreenshot);
+                attachments.add(screenshot);
 
-                    // If coordinates are empty then OpenCV couldn't find the element on screen
-                    if (Collections.emptyList().equals(coordinates)) {
-                        elementActionsHelper.failAction(driverFactoryHelper.getDriver(), "Couldn't find reference element on the current screen. If you can see it in the attached image then kindly consider cropping it and updating your reference image.", null, attachments);
-                    }
-                } else {
-                    // Wait for element presence and get the needed data
-                    var objects = elementActionsHelper.waitForElementPresence(driverFactoryHelper.getDriver(), elementReferenceScreenshot);
-                    byte[] currentScreenImage = (byte[]) objects.get(0);
-                    byte[] referenceImage = (byte[]) objects.get(1);
-                    List<Integer> coordinates = (List<Integer>) objects.get(2);
-
-                    // prepare attachments
-                    var screenshotManager = new ScreenshotManager();
-                    var screenshot = screenshotManager.prepareImageForReport(currentScreenImage, "swipeElementIntoView - Current Screen Image");
-                    var referenceScreenshot = screenshotManager.prepareImageForReport(referenceImage, "swipeElementIntoView - Reference Screenshot");
-                    attachments = new LinkedList<>();
-                    attachments.add(referenceScreenshot);
-                    attachments.add(screenshot);
-
-                    // If coordinates are empty then OpenCV couldn't find the element on screen
-                    if (Collections.emptyList().equals(coordinates)) {
-                        elementActionsHelper.failAction(driverFactoryHelper.getDriver(), "Couldn't find reference element on the current screen. If you can see it in the attached image then kindly consider cropping it and updating your reference image.", null, attachments);
-                    } else {
-                        new Actions(driverFactoryHelper.getDriver()).scrollFromOrigin(WheelInput.ScrollOrigin.fromViewport(), coordinates.get(0), coordinates.get(1)).perform();
-                    }
+                // If coordinates are empty then OpenCV couldn't find the element on screen
+                if (Collections.emptyList().equals(coordinates)) {
+                    elementActionsHelper.failAction(driverFactoryHelper.getDriver(), "Couldn't find reference element on the current screen. If you can see it in the attached image then kindly consider cropping it and updating your reference image.", null, attachments);
                 }
                 elementActionsHelper.passAction(driverFactoryHelper.getDriver(), null, Thread.currentThread().getStackTrace()[1].getMethodName(), null, attachments, null);
             } catch (AssertionError assertionError) {
@@ -841,21 +848,80 @@ public class TouchActions extends FluentWebDriverAction {
     }
 
     @SuppressWarnings("unchecked")
-    private List<Object> attemptToSwipeElementIntoViewInNativeApp(By scrollableElementLocator, String targetElementImage, SwipeDirection swipeDirection) {
-        List<Object> visualIdentificationObjects;
-        // appium native device
-        // Wait for element presence and get the needed data
-        visualIdentificationObjects = elementActionsHelper.waitForElementPresence(driverFactoryHelper.getDriver(), targetElementImage);
-        List<Integer> coordinates = (List<Integer>) visualIdentificationObjects.get(2);
-
-        if (!Collections.emptyList().equals(coordinates)) {
-            // element is already on screen
-            ReportManager.logDiscrete("Element found on screen.");
-        } else {
-            swipeToEndOfViewInternal(scrollableElementLocator, swipeDirection);
-            visualIdentificationObjects = elementActionsHelper.waitForElementPresence(driverFactoryHelper.getDriver(), targetElementImage);
+    private List<Object> attemptToSwipeElementIntoViewByImage(By scrollableElementLocator, String targetElementImage, SwipeDirection swipeDirection) {
+        AtomicReference<List<Object>> visualIdentificationObjects = new AtomicReference<>(
+                elementActionsHelper.findElementPresence(driverFactoryHelper.getDriver(), targetElementImage));
+        AtomicBoolean canScrollMore = new AtomicBoolean(true);
+        try {
+            new SynchronizationManager(driverFactoryHelper.getDriver()).fluentWait().until(f -> {
+                List<Object> currentAttempt = elementActionsHelper.findElementPresence(driverFactoryHelper.getDriver(), targetElementImage);
+                visualIdentificationObjects.set(currentAttempt);
+                List<Integer> coordinates = (List<Integer>) currentAttempt.get(2);
+                if (!Collections.emptyList().equals(coordinates)) {
+                    ReportManager.logDiscrete("Element found on screen.");
+                    return true;
+                }
+                canScrollMore.set(performImageScrollStep(scrollableElementLocator, swipeDirection));
+                return !canScrollMore.get();
+            });
+        } catch (TimeoutException timeoutException) {
+            ReportManager.logDiscrete(timeoutException.getMessage());
         }
-        return visualIdentificationObjects;
+        return visualIdentificationObjects.get();
+    }
+
+    private void performCoordinateTap(List<Integer> coordinates) {
+        PointerInput.Kind pointerKind = driverFactoryHelper.getDriver() instanceof AppiumDriver
+                ? PointerInput.Kind.TOUCH
+                : PointerInput.Kind.MOUSE;
+        PointerInput input = new PointerInput(pointerKind, pointerKind == PointerInput.Kind.TOUCH ? "finger1" : "mouse1");
+        Sequence tap = new Sequence(input, 0);
+        tap.addAction(input.createPointerMove(Duration.ZERO, PointerInput.Origin.viewport(), coordinates.get(0), coordinates.get(1)));
+        tap.addAction(input.createPointerDown(PointerInput.MouseButton.LEFT.asArg()));
+        tap.addAction(new Pause(input, Duration.ofMillis(200)));
+        tap.addAction(input.createPointerUp(PointerInput.MouseButton.LEFT.asArg()));
+        ((RemoteWebDriver) driverFactoryHelper.getDriver()).perform(ImmutableList.of(tap));
+    }
+
+    private boolean performImageScrollStep(By scrollableElementLocator, SwipeDirection swipeDirection) {
+        if (driverFactoryHelper.getDriver() instanceof AppiumDriver) {
+            return performW3cCompliantScroll(prepareParameters(swipeDirection, scrollableElementLocator, null));
+        }
+        int deltaX = 0;
+        int deltaY = 0;
+        Dimension screenSize = driverFactoryHelper.getDriver().manage().window().getSize();
+        switch (swipeDirection) {
+            case DOWN -> deltaY = screenSize.getHeight();
+            case UP -> deltaY = -screenSize.getHeight();
+            case RIGHT -> deltaX = screenSize.getWidth();
+            case LEFT -> deltaX = -screenSize.getWidth();
+        }
+        if (driverFactoryHelper.getDriver() instanceof JavascriptExecutor javascriptExecutor) {
+            Object scrollableElement = scrollableElementLocator == null
+                    ? null
+                    : elementActionsHelper.identifyUniqueElement(driverFactoryHelper.getDriver(), scrollableElementLocator).get(1);
+            try {
+                Object moved = javascriptExecutor.executeScript("""
+                        const target = arguments[0] || document.scrollingElement || document.documentElement;
+                        const beforeLeft = target.scrollLeft;
+                        const beforeTop = target.scrollTop;
+                        target.scrollBy(arguments[1], arguments[2]);
+                        return target.scrollLeft !== beforeLeft || target.scrollTop !== beforeTop;
+                        """, scrollableElement, deltaX, deltaY);
+                return Boolean.TRUE.equals(moved);
+            } catch (WebDriverException webDriverException) {
+                ReportManager.logDiscrete(webDriverException.getMessage());
+            }
+        }
+        try {
+            WheelInput.ScrollOrigin origin = scrollableElementLocator == null
+                    ? WheelInput.ScrollOrigin.fromViewport()
+                    : WheelInput.ScrollOrigin.fromElement((WebElement) elementActionsHelper.identifyUniqueElement(driverFactoryHelper.getDriver(), scrollableElementLocator).get(1));
+            new Actions(driverFactoryHelper.getDriver()).scrollFromOrigin(origin, deltaX, deltaY).perform();
+        } catch (WebDriverException webDriverException) {
+            return false;
+        }
+        return true;
     }
 
     private HashMap<Object, Object> prepareParameters(SwipeDirection swipeDirection, By scrollableElementLocator, By targetElementLocator) {

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java
@@ -149,11 +149,9 @@ public class ElementActionsHelper {
     public List<Object> waitForElementPresence(WebDriver driver, String elementReferenceScreenshot) {
         long startTime = System.currentTimeMillis();
         long elapsedTime;
-        List<Integer> coordinates;
         boolean isFound = false;
-        byte[] currentScreenImage;
 
-        List<Object> returnedValue = new LinkedList<>();
+        List<Object> returnedValue;
         if (FileActions.getInstance(true).doesFileExist(elementReferenceScreenshot)) {
             do {
                 try {
@@ -162,25 +160,29 @@ public class ElementActionsHelper {
                 } catch (InterruptedException e) {
                     ReportManagerHelper.logDiscrete(e);
                 }
-                currentScreenImage = new ScreenshotManager().takeScreenshot(driver, null);
-                coordinates = ImageProcessingActions.findImageWithinCurrentPage(elementReferenceScreenshot, currentScreenImage);
+                returnedValue = findElementPresence(driver, elementReferenceScreenshot);
+                @SuppressWarnings("unchecked")
+                List<Integer> coordinates = (List<Integer>) returnedValue.get(2);
                 if (!Collections.emptyList().equals(coordinates)) {
                     isFound = true;
                 }
                 elapsedTime = System.currentTimeMillis() - startTime;
             } while (!isFound && elapsedTime < SHAFT.Properties.timeouts.defaultElementIdentificationTimeout() * 1000L);
-            returnedValue.add(currentScreenImage);
-            returnedValue.add(FileActions.getInstance(true).readFileAsByteArray(elementReferenceScreenshot));
-            returnedValue.add(coordinates);
         } else {
-            // reference screenshot doesn't exist
-            ReportManager.log("Reference screenshot not found. Kindly confirm the image exists under this path: \"" + elementReferenceScreenshot + "\"");
-            currentScreenImage = new ScreenshotManager().takeScreenshot(driver, null);
-            returnedValue.add(currentScreenImage);
-            returnedValue.add(new byte[0]);
-            returnedValue.add(Collections.emptyList());
+            returnedValue = findElementPresence(driver, elementReferenceScreenshot);
         }
         return returnedValue;
+    }
+
+    /**
+     * Checks once whether an on-screen image reference appears in the current viewport.
+     *
+     * @param driver the active WebDriver instance
+     * @param elementReferenceScreenshot path to the reference image file
+     * @return list containing current viewport screenshot, reference screenshot bytes, and matched coordinates
+     */
+    public List<Object> findElementPresence(WebDriver driver, String elementReferenceScreenshot) {
+        return findElementByReferenceImage(driver, elementReferenceScreenshot, Collections.emptyList());
     }
 
     /**
@@ -194,9 +196,8 @@ public class ElementActionsHelper {
         long startTime = System.currentTimeMillis();
         long elapsedTime;
         List<Integer> coordinates = Collections.emptyList();
-        byte[] currentScreenImage;
 
-        List<Object> returnedValue = new LinkedList<>();
+        List<Object> returnedValue;
         if (FileActions.getInstance(true).doesFileExist(elementReferenceScreenshot)) {
             do {
                 try {
@@ -206,20 +207,32 @@ public class ElementActionsHelper {
                     Thread.currentThread().interrupt();
                     ReportManagerHelper.logDiscrete(e);
                 }
-                currentScreenImage = new ScreenshotManager().takeScreenshot(driver, null);
-                coordinates = ImageProcessingActions.findImageWithinCurrentPage(elementReferenceScreenshot, currentScreenImage);
+                returnedValue = findElementByReferenceImage(driver, elementReferenceScreenshot, List.of(-1));
+                @SuppressWarnings("unchecked")
+                List<Integer> detectedCoordinates = (List<Integer>) returnedValue.get(2);
+                coordinates = detectedCoordinates;
                 elapsedTime = System.currentTimeMillis() - startTime;
             } while (!Collections.emptyList().equals(coordinates)
                     && elapsedTime < SHAFT.Properties.timeouts.defaultElementIdentificationTimeout() * 1000L);
+        } else {
+            returnedValue = findElementByReferenceImage(driver, elementReferenceScreenshot, List.of(-1));
+        }
+        return returnedValue;
+    }
+
+    private List<Object> findElementByReferenceImage(WebDriver driver, String elementReferenceScreenshot,
+                                                     List<Integer> missingReferenceCoordinates) {
+        List<Object> returnedValue = new LinkedList<>();
+        byte[] currentScreenImage = new ScreenshotManager().takeViewportScreenshot(driver);
+        if (FileActions.getInstance(true).doesFileExist(elementReferenceScreenshot)) {
             returnedValue.add(currentScreenImage);
             returnedValue.add(FileActions.getInstance(true).readFileAsByteArray(elementReferenceScreenshot));
-            returnedValue.add(coordinates);
+            returnedValue.add(ImageProcessingActions.findImageWithinCurrentPage(elementReferenceScreenshot, currentScreenImage));
         } else {
             ReportManager.log("Reference screenshot not found. Kindly confirm the image exists under this path: \"" + elementReferenceScreenshot + "\"");
-            currentScreenImage = new ScreenshotManager().takeScreenshot(driver, null);
             returnedValue.add(currentScreenImage);
             returnedValue.add(new byte[0]);
-            returnedValue.add(List.of(-1));
+            returnedValue.add(missingReferenceCoordinates);
         }
         return returnedValue;
     }

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotManager.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotManager.java
@@ -138,7 +138,13 @@ public class ScreenshotManager {
         return VALIDATION_ACTION_PATTERN.matcher(actionName.toLowerCase()).matches();
     }
 
-    private byte[] takeViewportScreenshot(WebDriver driver) {
+    /**
+     * Captures the current viewport screenshot.
+     *
+     * @param driver the active WebDriver instance
+     * @return encoded screenshot bytes for the current viewport
+     */
+    public byte[] takeViewportScreenshot(WebDriver driver) {
         return ScreenshotHelper.takeViewportScreenshot(driver, 6);
     }
 

--- a/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
@@ -8,12 +8,14 @@ import com.shaft.gui.element.internal.ElementActionsHelper;
 import com.shaft.properties.internal.Properties;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.ios.IOSDriver;
+import org.mockito.ArgumentCaptor;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.ScreenOrientation;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Sequence;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -26,6 +28,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -216,7 +219,8 @@ public class AndroidTouchActionsCoverageUnitTest {
         doReturn(true).doReturn(false).when(androidDriver).executeScript(eq("mobile: scrollGesture"), anyMap());
         TouchActions nativeTouchActions = new TouchActions(androidDriver);
         ElementActionsHelper nativeElementActionsHelper = mock(ElementActionsHelper.class);
-        when(nativeElementActionsHelper.waitForElementPresence(androidDriver, "native-missing.png"))
+        when(nativeElementActionsHelper.findElementPresence(androidDriver, "native-missing.png"))
+                .thenReturn(List.of(validPng, validPng, List.of()))
                 .thenReturn(List.of(validPng, validPng, List.of()))
                 .thenReturn(List.of(validPng, validPng, List.of(30, 40)));
         when(nativeElementActionsHelper.takeScreenshot(any(), any(), anyString(), any(), eq(true))).thenReturn(List.of());
@@ -228,9 +232,9 @@ public class AndroidTouchActionsCoverageUnitTest {
         RemoteWebDriver webDriver = createMockRemoteWebDriver();
         TouchActions webTouchActions = new TouchActions(webDriver);
         ElementActionsHelper webElementActionsHelper = mock(ElementActionsHelper.class);
-        when(webElementActionsHelper.waitForElementPresence(webDriver, "web-present.png"))
+        when(webElementActionsHelper.findElementPresence(webDriver, "web-present.png"))
                 .thenReturn(List.of(validPng, validPng, List.of(20, 40)));
-        when(webElementActionsHelper.waitForElementPresence(webDriver, "web-missing.png"))
+        when(webElementActionsHelper.findElementPresence(webDriver, "web-missing.png"))
                 .thenReturn(List.of(validPng, validPng, List.of()));
         injectElementActionsHelper(webTouchActions, webElementActionsHelper);
 
@@ -353,6 +357,48 @@ public class AndroidTouchActionsCoverageUnitTest {
     }
 
     @Test
+    public void visualTapShouldUseBackendSpecificPointerKind() throws Exception {
+        byte[] validPng = getValidPngBytes();
+
+        RemoteWebDriver webDriver = createMockRemoteWebDriver();
+        TouchActions webTouchActions = new TouchActions(webDriver);
+        ElementActionsHelper webElementActionsHelper = mock(ElementActionsHelper.class);
+        when(webElementActionsHelper.waitForElementPresence(webDriver, "web-present.png"))
+                .thenReturn(List.of(validPng, validPng, List.of(10, 20)));
+        injectElementActionsHelper(webTouchActions, webElementActionsHelper);
+
+        webTouchActions.tap("web-present.png");
+
+        SHAFT.Validations.assertThat().object(capturedPointerType(webDriver)).isEqualTo("mouse").perform();
+
+        AndroidDriver androidDriver = createMockAndroidDriver();
+        TouchActions androidTouchActions = new TouchActions(androidDriver);
+        ElementActionsHelper androidElementActionsHelper = mock(ElementActionsHelper.class);
+        when(androidElementActionsHelper.waitForElementPresence(androidDriver, "android-present.png"))
+                .thenReturn(List.of(validPng, validPng, List.of(10, 20)));
+        injectElementActionsHelper(androidTouchActions, androidElementActionsHelper);
+
+        androidTouchActions.tap("android-present.png");
+
+        SHAFT.Validations.assertThat().object(capturedPointerType(androidDriver)).isEqualTo("touch").perform();
+    }
+
+    @Test
+    public void visualTypeShouldTapReferenceAndSendKeysThroughActionsApi() throws Exception {
+        RemoteWebDriver driver = createMockRemoteWebDriver();
+        TouchActions touchActions = new TouchActions(driver);
+        ElementActionsHelper elementActionsHelper = mock(ElementActionsHelper.class);
+        byte[] validPng = getValidPngBytes();
+        when(elementActionsHelper.waitForElementPresence(driver, "field.png"))
+                .thenReturn(List.of(validPng, validPng, List.of(10, 20)));
+        injectElementActionsHelper(touchActions, elementActionsHelper);
+
+        touchActions.type("field.png", "hello");
+
+        verify(driver, times(2)).perform(any());
+    }
+
+    @Test
     public void swipeElementIntoViewOverloadsShouldCoverNativeAndWebPaths() throws Exception {
         AndroidDriver androidDriver = createMockAndroidDriver();
         WebElement targetElement = mock(WebElement.class);
@@ -361,7 +407,7 @@ public class AndroidTouchActionsCoverageUnitTest {
         TouchActions nativeTouchActions = new TouchActions(androidDriver);
         ElementActionsHelper nativeElementActionsHelper = mock(ElementActionsHelper.class);
         byte[] validPng = getValidPngBytes();
-        when(nativeElementActionsHelper.waitForElementPresence(any(), eq("target.png")))
+        when(nativeElementActionsHelper.findElementPresence(any(), eq("target.png")))
                 .thenReturn(List.of(validPng, validPng, List.of(100, 200)));
         when(nativeElementActionsHelper.takeScreenshot(any(), any(), anyString(), any(), eq(true))).thenReturn(List.of());
         injectElementActionsHelper(nativeTouchActions, nativeElementActionsHelper);
@@ -508,6 +554,15 @@ public class AndroidTouchActionsCoverageUnitTest {
         Field elementActionsHelperField = FluentWebDriverAction.class.getDeclaredField("elementActionsHelper");
         elementActionsHelperField.setAccessible(true);
         elementActionsHelperField.set(touchActions, elementActionsHelper);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private String capturedPointerType(RemoteWebDriver driver) {
+        ArgumentCaptor<Collection<Sequence>> actionsCaptor = ArgumentCaptor.forClass((Class) Collection.class);
+        verify(driver).perform(actionsCaptor.capture());
+        Map<String, Object> encodedSequence = actionsCaptor.getValue().iterator().next().encode();
+        Map<String, Object> parameters = (Map<String, Object>) encodedSequence.get("parameters");
+        return String.valueOf(parameters.get("pointerType"));
     }
 
     private byte[] getValidPngBytes() {

--- a/shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java
+++ b/shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -41,17 +42,30 @@ import java.util.List;
 public class OpenCvVisualProcessingProvider implements VisualProcessingProvider {
     private static final int CV_THRESH_OTSU = 8;
     private static final int CV_THRESH_BINARY = 0;
+    private static final double[] TEMPLATE_SCALE_CANDIDATES = {
+            1.0, 0.5, 0.625, 2.0 / 3.0, 0.75, 0.8, 0.9, 1.1, 1.25, 4.0 / 3.0, 1.5, 1.6, 1.75, 2.0, 2.5, 3.0
+    };
+    private static final int[] TEMPLATE_MATCH_METHODS = {
+            Imgproc.TM_CCOEFF_NORMED, Imgproc.TM_SQDIFF_NORMED, Imgproc.TM_CCORR_NORMED
+    };
+    private static final double MIN_TEMPLATE_SCREEN_AREA_RATIO = 0.02;
+    private static final double MAX_TEMPLATE_SCREEN_AREA_RATIO = 0.50;
+    private static final double SIMILAR_MATCH_ACCURACY_TOLERANCE = 0.05;
+    private static final double TINY_TEMPLATE_ACCURACY_TOLERANCE = 0.10;
+    private static final double CLEAR_MATCH_ACCURACY_MARGIN = 0.03;
 
     private static Mat preprocess(byte[] image) {
+        return preprocess(Imgcodecs.imdecode(new MatOfByte(image), Imgcodecs.IMREAD_COLOR));
+    }
+
+    private static Mat preprocess(Mat image) {
         //https://stackoverflow.com/questions/37302098/image-preprocessing-with-opencv-before-doing-character-recognition-tesseract
-        Mat img;
         Mat imgGray = new Mat();
         Mat imgGaussianBlur = new Mat();
         Mat imgSobel = new Mat();
         Mat imgThreshold = new Mat();
 
-        img = Imgcodecs.imdecode(new MatOfByte(image), Imgcodecs.IMREAD_COLOR);
-        Imgproc.cvtColor(img, imgGray, Imgproc.COLOR_BGR2GRAY);
+        Imgproc.cvtColor(image, imgGray, Imgproc.COLOR_BGR2GRAY);
         Imgproc.GaussianBlur(imgGray, imgGaussianBlur, new Size(3, 3), 0);
         Imgproc.Sobel(imgGaussianBlur, imgSobel, -1, 1, 0);
         Imgproc.threshold(imgSobel, imgThreshold, 0, 255, CV_THRESH_OTSU + CV_THRESH_BINARY);
@@ -59,7 +73,7 @@ public class OpenCvVisualProcessingProvider implements VisualProcessingProvider 
         if (SHAFT.Properties.reporting.debugMode()) {
             FileActions.getInstance(true).createFolder("target/openCV/temp/");
             String timestamp = String.valueOf(System.currentTimeMillis());
-            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_1_True_Image.png", img);
+            Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_1_True_Image.png", image);
             Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_2_imgGray.png", imgGray);
             Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_3_imgGaussianBlur.png", imgGaussianBlur);
             Imgcodecs.imwrite("target/openCV/temp/" + timestamp + "_4_imgSobel.png", imgSobel);
@@ -68,55 +82,32 @@ public class OpenCvVisualProcessingProvider implements VisualProcessingProvider 
         return imgThreshold;
     }
 
-    private static List<Integer> attemptToFindImageUsingOpenCV(String referenceImagePath, byte[] currentPageScreenshot, int attemptNumber) {
+    private static List<Integer> attemptToFindImageUsingOpenCV(String referenceImagePath, byte[] currentPageScreenshot) {
         if (currentPageScreenshot == null || Arrays.equals(currentPageScreenshot, new byte[]{})) {
             //target image is empty, force fail comparison
             ReportManager.log("Failed to identify the element using AI; target screenshot is empty.");
         } else {
             Mat img_original = Imgcodecs.imdecode(new MatOfByte(currentPageScreenshot), Imgcodecs.IMREAD_COLOR);
             Mat templ_original = Imgcodecs.imread(referenceImagePath, Imgcodecs.IMREAD_COLOR);
+            if (img_original.empty() || templ_original.empty()) {
+                ReportManager.log("Failed to identify the element using AI; target or reference image is invalid.");
+                return Collections.emptyList();
+            }
 
             Mat img = preprocess(currentPageScreenshot);
-            Mat templ = preprocess(FileActions.getInstance(true).readFileAsByteArray(referenceImagePath));
-
-            // / Create the result matrix
-            int resultCols = img.cols() - templ.cols() + 1;
-            int resultRows = img.rows() - templ.rows() + 1;
-
-            Mat result = new Mat(resultRows, resultCols, CvType.CV_32FC1);
 
             // / Do the Matching and Normalize
             try {
-                // matchMethod 1 == Imgproc.TM_SQDIFF_NORMED
-                int matchMethod = Imgproc.TM_CCOEFF_NORMED;
                 double threshold = SHAFT.Properties.visuals.visualMatchingThreshold();
 
-                switch (attemptNumber) {
-                    case 1 -> matchMethod = Imgproc.TM_SQDIFF_NORMED;
-                    case 2 -> matchMethod = Imgproc.TM_CCORR_NORMED;
+                TemplateMatch bestMatch = findBestScaledTemplateMatch(img, img_original, templ_original, threshold);
+                if (bestMatch == null) {
+                    return Collections.emptyList();
                 }
-
-                Imgproc.matchTemplate(img, templ, result, matchMethod);
-
-                // Localizing the best match with minMaxLoc
-                Core.MinMaxLocResult mmr = Core.minMaxLoc(result);
-
-                double minMaxVal;
-                double matchAccuracy;
-
-                org.opencv.core.Point matchLoc;
-                //noinspection ConstantValue
-                if (matchMethod == Imgproc.TM_SQDIFF || matchMethod == Imgproc.TM_SQDIFF_NORMED) {
-                    matchLoc = mmr.minLoc;
-                    minMaxVal = mmr.minVal;
-                    matchAccuracy = 1 - minMaxVal;
-                } else {
-                    matchLoc = mmr.maxLoc;
-                    minMaxVal = mmr.maxVal;
-                    matchAccuracy = minMaxVal;
-                }
-
-                var accuracyMessage = "Match accuracy is " + (int) Math.round(matchAccuracy * 100) + "% and threshold is " + (int) Math.round(threshold * 100) + "%. Match Method: " + matchMethod + ".";
+                var accuracyMessage = "Match accuracy is " + (int) Math.round(bestMatch.matchAccuracy() * 100)
+                        + "% and threshold is " + (int) Math.round(threshold * 100)
+                        + "%. Match Method: " + bestMatch.matchMethod()
+                        + ". Scale: " + String.format(java.util.Locale.ROOT, "%.3f", bestMatch.scale()) + ".";
                 ReportManager.logDiscrete(accuracyMessage);
 
                 if (SHAFT.Properties.reporting.debugMode()) {
@@ -126,12 +117,13 @@ public class OpenCvVisualProcessingProvider implements VisualProcessingProvider 
                         String timestamp = String.valueOf(System.currentTimeMillis());
 
                         File output = new File("target/openCV/" + timestamp + "_1_templ.png");
-                        ImageIO.write((BufferedImage) HighGui.toBufferedImage(templ_original), "png", output);
+                        ImageIO.write((BufferedImage) HighGui.toBufferedImage(bestMatch.templateOriginal()), "png", output);
 
                         output = new File("target/openCV/" + timestamp + "_3_img.png");
                         ImageIO.write((BufferedImage) HighGui.toBufferedImage(img_original), "png", output);
 
-                        Imgproc.rectangle(img_original, matchLoc, new Point(matchLoc.x + templ.cols(), matchLoc.y + templ.rows()),
+                        Imgproc.rectangle(img_original, bestMatch.matchLoc(),
+                                new Point(bestMatch.matchLoc().x + bestMatch.templateWidth(), bestMatch.matchLoc().y + bestMatch.templateHeight()),
                                 new Scalar(0, 0, 0), 2, 8, 0);
                         output = new File("target/openCV/" + timestamp + "_5_output.png");
                         ImageIO.write((BufferedImage) HighGui.toBufferedImage(img_original), "png", output);
@@ -141,17 +133,18 @@ public class OpenCvVisualProcessingProvider implements VisualProcessingProvider 
                     }
                 }
 
-                if (matchAccuracy < threshold) {
+                if (bestMatch.matchAccuracy() < threshold) {
                     return Collections.emptyList();
                 }
 
-                // returning the top left corner +1 pixel
-                int x = Integer.parseInt(String.valueOf(matchLoc.x + 1).split("\\.")[0]);
-                int y = Integer.parseInt(String.valueOf(matchLoc.y + 1).split("\\.")[0]);
+                // Return the center of the matched reference so coordinate actions land inside the target.
+                int x = (int) Math.round(bestMatch.matchLoc().x + bestMatch.templateWidth() / 2.0);
+                int y = (int) Math.round(bestMatch.matchLoc().y + bestMatch.templateHeight() / 2.0);
 
                 // creating highlighted image to be attached to the report
                 try {
-                    Imgproc.rectangle(img_original, matchLoc, new Point(matchLoc.x + templ.cols(), matchLoc.y + templ.rows()),
+                    Imgproc.rectangle(img_original, bestMatch.matchLoc(),
+                            new Point(bestMatch.matchLoc().x + bestMatch.templateWidth(), bestMatch.matchLoc().y + bestMatch.templateHeight()),
                             new Scalar(67, 176, 42), 2, 8, 0); // selenium-green
                     ByteArrayOutputStream baos = new ByteArrayOutputStream();
                     ImageIO.write((BufferedImage) HighGui.toBufferedImage(img_original), "png", baos);
@@ -171,20 +164,155 @@ public class OpenCvVisualProcessingProvider implements VisualProcessingProvider 
         return Collections.emptyList();
     }
 
+    private static TemplateMatch findBestScaledTemplateMatch(Mat image, Mat originalImage, Mat referenceOriginal,
+                                                             double threshold) {
+        TemplateMatch bestMatch = null;
+        double imageArea = (double) image.cols() * image.rows();
+        Mat grayImage = toGray(originalImage);
+        for (int matchMethod : TEMPLATE_MATCH_METHODS) {
+            for (double scale : validScales(referenceOriginal, image)) {
+                Mat scaledReference = scaleReference(referenceOriginal, scale);
+                Mat template = preprocess(scaledReference);
+                if (template.cols() > image.cols() || template.rows() > image.rows()) {
+                    continue;
+                }
+
+                TemplateMatch edgeMatch = locateBestMatch(image, template, matchMethod, scale, scaledReference);
+                Mat grayTemplate = toGray(scaledReference);
+                TemplateMatch grayMatch = locateBestMatch(grayImage, grayTemplate, matchMethod, scale, scaledReference);
+                TemplateMatch candidate = selectScaleCandidate(edgeMatch, grayMatch);
+                if (isBetterMatch(candidate, bestMatch, threshold, imageArea)) {
+                    bestMatch = candidate;
+                }
+            }
+        }
+        return bestMatch;
+    }
+
+    private static TemplateMatch locateBestMatch(Mat image, Mat template, int matchMethod, double scale, Mat templateOriginal) {
+        Mat result = new Mat(image.rows() - template.rows() + 1, image.cols() - template.cols() + 1, CvType.CV_32FC1);
+        Imgproc.matchTemplate(image, template, result, matchMethod);
+        Core.MinMaxLocResult mmr = Core.minMaxLoc(result);
+
+        Point matchLoc;
+        double matchAccuracy;
+        if (matchMethod == Imgproc.TM_SQDIFF || matchMethod == Imgproc.TM_SQDIFF_NORMED) {
+            matchLoc = mmr.minLoc;
+            matchAccuracy = 1 - mmr.minVal;
+        } else {
+            matchLoc = mmr.maxLoc;
+            matchAccuracy = mmr.maxVal;
+        }
+        return new TemplateMatch(matchLoc, matchAccuracy, matchMethod, scale, templateOriginal, template.cols(), template.rows());
+    }
+
+    private static TemplateMatch selectScaleCandidate(TemplateMatch edgeMatch, TemplateMatch grayMatch) {
+        if (isSimilarMatchLocation(edgeMatch, grayMatch) && grayMatch.matchAccuracy() > edgeMatch.matchAccuracy()) {
+            return grayMatch;
+        }
+        return edgeMatch;
+    }
+
+    private static boolean isSimilarMatchLocation(TemplateMatch first, TemplateMatch second) {
+        double maxDistance = Math.max(3, Math.min(first.templateWidth(), first.templateHeight()) * 0.25);
+        double firstCenterX = first.matchLoc().x + first.templateWidth() / 2.0;
+        double firstCenterY = first.matchLoc().y + first.templateHeight() / 2.0;
+        double secondCenterX = second.matchLoc().x + second.templateWidth() / 2.0;
+        double secondCenterY = second.matchLoc().y + second.templateHeight() / 2.0;
+        return Math.abs(firstCenterX - secondCenterX) <= maxDistance
+                && Math.abs(firstCenterY - secondCenterY) <= maxDistance;
+    }
+
+    private static boolean isBetterMatch(TemplateMatch candidate, TemplateMatch currentBest, double threshold, double imageArea) {
+        if (currentBest == null) {
+            return true;
+        }
+        boolean candidatePassed = candidate.matchAccuracy() >= threshold;
+        boolean currentBestPassed = currentBest.matchAccuracy() >= threshold;
+        if (candidatePassed && currentBestPassed) {
+            double candidateAreaRatio = areaRatio(candidate, imageArea);
+            double currentBestAreaRatio = areaRatio(currentBest, imageArea);
+            if (candidateAreaRatio > MAX_TEMPLATE_SCREEN_AREA_RATIO && currentBestAreaRatio <= MAX_TEMPLATE_SCREEN_AREA_RATIO
+                    && candidate.matchAccuracy() <= currentBest.matchAccuracy() + SIMILAR_MATCH_ACCURACY_TOLERANCE) {
+                return false;
+            }
+            if (currentBestAreaRatio > MAX_TEMPLATE_SCREEN_AREA_RATIO && candidateAreaRatio <= MAX_TEMPLATE_SCREEN_AREA_RATIO
+                    && candidate.matchAccuracy() + SIMILAR_MATCH_ACCURACY_TOLERANCE >= currentBest.matchAccuracy()) {
+                return true;
+            }
+            if (currentBestAreaRatio < MIN_TEMPLATE_SCREEN_AREA_RATIO && candidateAreaRatio >= MIN_TEMPLATE_SCREEN_AREA_RATIO
+                    && candidate.matchAccuracy() + TINY_TEMPLATE_ACCURACY_TOLERANCE >= currentBest.matchAccuracy()) {
+                return true;
+            }
+            if (candidateAreaRatio < MIN_TEMPLATE_SCREEN_AREA_RATIO && currentBestAreaRatio >= MIN_TEMPLATE_SCREEN_AREA_RATIO
+                    && currentBest.matchAccuracy() + TINY_TEMPLATE_ACCURACY_TOLERANCE >= candidate.matchAccuracy()) {
+                return false;
+            }
+            if (candidate.matchAccuracy() > currentBest.matchAccuracy() + CLEAR_MATCH_ACCURACY_MARGIN) {
+                return true;
+            }
+            if (currentBest.matchAccuracy() > candidate.matchAccuracy() + CLEAR_MATCH_ACCURACY_MARGIN) {
+                return false;
+            }
+            int candidateArea = candidate.templateWidth() * candidate.templateHeight();
+            int currentBestArea = currentBest.templateWidth() * currentBest.templateHeight();
+            return candidateArea > currentBestArea
+                    || (candidateArea == currentBestArea && candidate.matchAccuracy() > currentBest.matchAccuracy());
+        }
+        if (candidatePassed != currentBestPassed) {
+            return candidatePassed;
+        }
+        return candidate.matchAccuracy() > currentBest.matchAccuracy();
+    }
+
+    private static double areaRatio(TemplateMatch match, double imageArea) {
+        return ((double) match.templateWidth() * match.templateHeight()) / imageArea;
+    }
+
+    private static Mat toGray(Mat image) {
+        Mat gray = new Mat();
+        Imgproc.cvtColor(image, gray, Imgproc.COLOR_BGR2GRAY);
+        return gray;
+    }
+
+    private static List<Double> validScales(Mat referenceOriginal, Mat image) {
+        List<Double> scales = new ArrayList<>();
+        List<String> sizes = new ArrayList<>();
+        for (double scale : TEMPLATE_SCALE_CANDIDATES) {
+            int width = (int) Math.round(referenceOriginal.cols() * scale);
+            int height = (int) Math.round(referenceOriginal.rows() * scale);
+            String size = width + "x" + height;
+            if (width > 0 && height > 0 && width <= image.cols() && height <= image.rows() && !sizes.contains(size)) {
+                scales.add(scale);
+                sizes.add(size);
+            }
+        }
+        return scales;
+    }
+
+    private static Mat scaleReference(Mat referenceOriginal, double scale) {
+        if (Double.compare(scale, 1.0) == 0) {
+            return referenceOriginal;
+        }
+        Mat resized = new Mat();
+        Imgproc.resize(referenceOriginal, resized,
+                new Size(Math.round(referenceOriginal.cols() * scale), Math.round(referenceOriginal.rows() * scale)),
+                0, 0, scale < 1.0 ? Imgproc.INTER_AREA : Imgproc.INTER_CUBIC);
+        return resized;
+    }
+
+    private record TemplateMatch(Point matchLoc, double matchAccuracy, int matchMethod, double scale, Mat templateOriginal,
+                                 int templateWidth, int templateHeight) {
+    }
+
     @Override
     public List<Integer> findImageWithinCurrentPage(String referenceImagePath, byte[] currentPageScreenshot) {
-        int maxNumberOfAttempts = 3;
-        int attempts = 0;
-        List<Integer> foundLocation = Collections.emptyList();
-        do {
-            try {
-                foundLocation = attemptToFindImageUsingOpenCV(referenceImagePath, currentPageScreenshot, attempts);
-            } catch (Exception e) {
-                ReportManagerHelper.logDiscrete(e);
-            }
-            attempts++;
-        } while (Collections.emptyList().equals(foundLocation) && attempts < maxNumberOfAttempts);
-        return foundLocation;
+        try {
+            return attemptToFindImageUsingOpenCV(referenceImagePath, currentPageScreenshot);
+        } catch (Exception e) {
+            ReportManagerHelper.logDiscrete(e);
+            return Collections.emptyList();
+        }
     }
 
     @Override

--- a/shaft-visual/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsCoverageUnitTest.java
+++ b/shaft-visual/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsCoverageUnitTest.java
@@ -162,6 +162,16 @@ public class ImageProcessingActionsCoverageUnitTest {
     }
 
     @Test
+    public void findImageWithinCurrentPageShouldMatchReferenceCapturedAtLowerDpi() {
+        assertScaledReferenceMatch(0.5);
+    }
+
+    @Test
+    public void findImageWithinCurrentPageShouldMatchReferenceCapturedAtHigherDpi() {
+        assertScaledReferenceMatch(1.5);
+    }
+
+    @Test
     public void findImageWithinCurrentPageShouldReturnEmptyForInvalidOrEmptyInputs() {
         Path invalidReference = tempDir.resolve("invalid-reference.png");
         FILE_ACTIONS.writeToFile(invalidReference.toString(), "invalid-image");
@@ -500,6 +510,62 @@ public class ImageProcessingActionsCoverageUnitTest {
         graphics.fillRect(x, y, cropWidth, cropHeight);
         graphics.dispose();
         return encodePng(image);
+    }
+
+    private void assertScaledReferenceMatch(double referenceScale) {
+        int targetX = 26;
+        int targetY = 22;
+        int targetWidth = 36;
+        int targetHeight = 24;
+        Path referenceImage = tempDir.resolve("scaled-reference-" + referenceScale + ".png");
+        FILE_ACTIONS.writeToFile(referenceImage.toString(), encodePng(scaleImage(createReferenceTarget(targetWidth, targetHeight), referenceScale)));
+
+        List<Integer> coordinates = ImageProcessingActions.findImageWithinCurrentPage(
+                referenceImage.toString(),
+                encodePng(createScreenshotWithReferenceTarget(96, 80, targetX, targetY, targetWidth, targetHeight)));
+
+        Assert.assertFalse(coordinates.isEmpty());
+        Assert.assertEquals(coordinates.size(), 2);
+        Assert.assertTrue(Math.abs(coordinates.get(0) - (targetX + targetWidth / 2)) <= 3);
+        Assert.assertTrue(Math.abs(coordinates.get(1) - (targetY + targetHeight / 2)) <= 3);
+    }
+
+    private static BufferedImage createScreenshotWithReferenceTarget(int width, int height, int x, int y,
+                                                                    int targetWidth, int targetHeight) {
+        BufferedImage image = createImage(width, height, Color.WHITE);
+        Graphics2D graphics = image.createGraphics();
+        drawReferenceTarget(graphics, x, y, targetWidth, targetHeight);
+        graphics.dispose();
+        return image;
+    }
+
+    private static BufferedImage createReferenceTarget(int width, int height) {
+        BufferedImage image = createImage(width, height, Color.WHITE);
+        Graphics2D graphics = image.createGraphics();
+        drawReferenceTarget(graphics, 0, 0, width, height);
+        graphics.dispose();
+        return image;
+    }
+
+    private static void drawReferenceTarget(Graphics2D graphics, int x, int y, int width, int height) {
+        graphics.setColor(Color.YELLOW);
+        graphics.fillRect(x, y, width, height);
+        graphics.setColor(Color.BLACK);
+        graphics.drawRect(x, y, width - 1, height - 1);
+        graphics.drawLine(x + 3, y + 3, x + width - 4, y + height - 4);
+        graphics.drawLine(x + width - 4, y + 3, x + 3, y + height - 4);
+        graphics.setColor(Color.BLUE);
+        graphics.fillOval(x + width / 3, y + height / 4, width / 3, height / 2);
+    }
+
+    private static BufferedImage scaleImage(BufferedImage source, double scale) {
+        int width = Math.max(1, (int) Math.round(source.getWidth() * scale));
+        int height = Math.max(1, (int) Math.round(source.getHeight() * scale));
+        BufferedImage scaled = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = scaled.createGraphics();
+        graphics.drawImage(source, 0, 0, width, height, null);
+        graphics.dispose();
+        return scaled;
     }
 
     private static BufferedImage createImage(int width, int height, Color color) {


### PR DESCRIPTION
## Summary
- add scale-tolerant OpenCV matching for cropped reference screenshots captured at a different DPI or display scale
- use viewport screenshots and backend-appropriate W3C coordinate taps for Selenium/Appium image actions
- add image-based typing and headless-safe Selenium scrolling while preserving the existing shaft-visual missing-dependency error path

## Validation
- `git diff --check --cached`
- `mvn -pl shaft-visual -am test '-Dtest=ImageProcessingActionsCoverageUnitTest,ImageProcessingActionsUnitTest' '-Dallure.generateReport=false' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' '-DlightHouseExecution=false' '-DgeneratePerformanceReport=false'`
- `mvn -pl shaft-engine test '-Dtest=AndroidTouchActionsCoverageUnitTest' '-Dallure.generateReport=false' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' '-DlightHouseExecution=false' '-DgeneratePerformanceReport=false'`
