### PR TITLE
[codex] Improve IntelliJ onboarding assistant UX

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpStdioClient.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpStdioClient.java
@@ -254,7 +254,13 @@ final class ShaftMcpStdioClient implements AutoCloseable {
 
     private Integer exitCode() {
         try {
+            if (!process.waitFor(250, TimeUnit.MILLISECONDS)) {
+                return null;
+            }
             return process.exitValue();
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            return null;
         } catch (IllegalThreadStateException exception) {
             return null;
         }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -14,7 +14,10 @@ final class AssistantCommand {
     private static final int DEFAULT_BROWSER_MAX_CHARACTERS = 12_000;
     private static final int DEFAULT_BROWSER_MAX_ELEMENTS = 10;
     private static final String SHAFT_MCP_USAGE_HINT =
-            "If this request requires interacting with a browser, page element, or mobile app, use shaft-mcp.";
+            """
+                    If this request requires interacting with a browser, page element, or mobile app, use shaft-mcp.
+                    For WebDriver browser tasks, call driver_initialize before browser_* tools; do not use Playwright unless requested.
+                    """.stripIndent().trim();
     private static final String HELP = """
             Slash commands:
             /guide <query> - Search the SHAFT guide.

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
@@ -5,8 +5,11 @@ import com.google.gson.JsonObject;
 import com.shaft.intellij.mcp.ShaftMcpInvocation;
 import com.shaft.intellij.mcp.ShaftMcpToolResult;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -21,6 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 /**
  * Runs selected local assistant CLIs directly so their markdown stays user-facing.
@@ -38,11 +42,15 @@ final class AssistantLocalAgentRunner {
     }
 
     static ShaftMcpInvocation start(AssistantCommand.Invocation invocation) {
+        return start(invocation, null);
+    }
+
+    static ShaftMcpInvocation start(AssistantCommand.Invocation invocation, Consumer<String> outputConsumer) {
         JsonObject arguments = invocation.arguments();
         AtomicReference<Process> processReference = new AtomicReference<>();
         AtomicBoolean cancellationRequested = new AtomicBoolean();
         CompletableFuture<ShaftMcpToolResult> future = CompletableFuture.supplyAsync(
-                () -> run(arguments, processReference, cancellationRequested));
+                () -> run(arguments, processReference, cancellationRequested, outputConsumer));
         return new ShaftMcpInvocation(future, () -> cancel(processReference, cancellationRequested));
     }
 
@@ -62,7 +70,8 @@ final class AssistantLocalAgentRunner {
     private static ShaftMcpToolResult run(
             JsonObject arguments,
             AtomicReference<Process> processReference,
-            AtomicBoolean cancellationRequested) {
+            AtomicBoolean cancellationRequested,
+            Consumer<String> outputConsumer) {
         List<String> command = commandFor(arguments);
         if (command.isEmpty()) {
             return ShaftMcpToolResult.failure("No local assistant command was configured.");
@@ -84,8 +93,8 @@ final class AssistantLocalAgentRunner {
             builder.environment().putAll(environment(arguments));
             Process process = builder.start();
             processReference.set(process);
-            CompletableFuture<String> stdout = readAsync(process.getInputStream());
-            CompletableFuture<String> stderr = readAsync(process.getErrorStream());
+            CompletableFuture<String> stdout = readAsync(process.getInputStream(), outputConsumer);
+            CompletableFuture<String> stderr = readAsync(process.getErrorStream(), outputConsumer);
             process.getOutputStream().write(stdin.getBytes(StandardCharsets.UTF_8));
             process.getOutputStream().close();
 
@@ -127,7 +136,12 @@ final class AssistantLocalAgentRunner {
 
     private static List<String> codexCommand(String mode) {
         return switch (mode) {
-            case "AGENT" -> List.of("codex", "exec", "--sandbox", "workspace-write", "-");
+            case "AGENT" -> List.of(
+                    "codex", "exec",
+                    "--sandbox", "workspace-write",
+                    "-c", "mcp_servers.shaft-mcp.default_tools_approval_mode=\"approve\"",
+                    "-c", "mcp_servers.shaft-mcp.tool_timeout_sec=600",
+                    "-");
             default -> List.of("codex", "exec", "--sandbox", "read-only", "-");
         };
     }
@@ -206,13 +220,23 @@ final class AssistantLocalAgentRunner {
         return String.join("\n\n", sections).trim();
     }
 
-    private static CompletableFuture<String> readAsync(java.io.InputStream stream) {
+    private static CompletableFuture<String> readAsync(InputStream stream, Consumer<String> outputConsumer) {
         return CompletableFuture.supplyAsync(() -> {
+            StringBuilder output = new StringBuilder();
             try {
-                return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        output.append(line).append('\n');
+                        if (outputConsumer != null) {
+                            outputConsumer.accept(line);
+                        }
+                    }
+                }
             } catch (IOException exception) {
                 return "";
             }
+            return output.toString();
         });
     }
 

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantTranscriptView.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantTranscriptView.java
@@ -39,8 +39,15 @@ final class AssistantTranscriptView extends JPanel {
         pane.setEditable(false);
         pane.setOpaque(true);
         pane.setBorder(JBUI.Borders.empty(8));
+        Color transcriptBackground = resolvedColor("TextArea.background", Color.WHITE);
+        pane.setBackground(transcriptBackground);
         showInitialMessage();
-        add(new JBScrollPane(pane), BorderLayout.CENTER);
+        JBScrollPane scrollPane = new JBScrollPane(pane);
+        scrollPane.setBorder(JBUI.Borders.empty());
+        scrollPane.setBackground(transcriptBackground);
+        scrollPane.getViewport().setOpaque(true);
+        scrollPane.getViewport().setBackground(transcriptBackground);
+        add(scrollPane, BorderLayout.CENTER);
     }
 
     String markdown() {
@@ -59,6 +66,21 @@ final class AssistantTranscriptView extends JPanel {
 
     void append(String role, String message) {
         addMessage(role, message);
+        markdown = joinMessages(messages);
+        refresh();
+    }
+
+    void replaceLast(String role, String message) {
+        if (message == null || message.isBlank()) {
+            return;
+        }
+        if (messages.isEmpty()) {
+            append(role, message);
+            return;
+        }
+        ShaftAssistantChatState.Message last = messages.get(messages.size() - 1);
+        last.role = normalizedRole(role);
+        last.markdown = message;
         markdown = joinMessages(messages);
         refresh();
     }
@@ -101,36 +123,21 @@ final class AssistantTranscriptView extends JPanel {
                 <head>
                   <style>
                     body { font-family: %s; font-size: %dpt; color: %s; background: %s; margin: 0; }
-                    table.message-row { margin: 0 0 8px 0; }
-                    .message-bubble {
-                        width: 86%%;
-                        border: 1px solid %s;
-                        border-radius: 12px;
-                        padding: 8px 10px;
-                        text-align: right;
-                    }
-                    .message-bubble.assistant {
-                        background: %s;
-                        color: %s;
-                    }
-                    .message-bubble.user {
-                        background: %s;
-                        color: %s;
-                        border-color: %s;
-                    }
+                    #chat { background: %s; }
+                    table.message-row { margin: 0 0 8px 0; background: %s; }
+                    table.message-row td { background: %s; }
                     .message-hint {
                         margin: 4px 0 0 0;
                         text-align: left;
+                        background: %s;
                     }
                     p, ul, ol, h1, h2, h3 { margin: 0 0 8px 0; }
-                    .message-bubble p { text-align: right; }
-                    .message-hint p { text-align: left; }
+                    .message-hint p { text-align: left; background: %s; }
                     pre {
                         margin: 8px 0;
-                        padding: 8px;
+                        padding: 0;
                         background: %s;
-                        border: 1px solid %s;
-                        border-radius: 8px;
+                        border: 0;
                         white-space: pre-wrap;
                     }
                     code { font-family: Monospaced; }
@@ -143,14 +150,12 @@ final class AssistantTranscriptView extends JPanel {
                 Math.max(11, pane.getFont() == null ? 12 : pane.getFont().getSize()),
                 color("TextArea.foreground", "#000000"),
                 color("TextArea.background", "#ffffff"),
-                color("Component.borderColor", "#d8d8d8"),
-                color("Panel.background", "#f5f7fc"),
-                color("TextArea.foreground", "#202020"),
-                color("Panel.selectionBackground", "#4B86FF"),
-                color("Panel.selectionForeground", "#ffffff"),
-                color("Panel.selectionBackground", "#4B86FF"),
-                color("Panel.background", "#f2f2f2"),
-                color("Component.borderColor", "#cccccc"),
+                color("TextArea.background", "#ffffff"),
+                color("TextArea.background", "#ffffff"),
+                color("TextArea.background", "#ffffff"),
+                color("TextArea.background", "#ffffff"),
+                color("TextArea.background", "#ffffff"),
+                color("TextArea.background", "#ffffff"),
                 value);
     }
 
@@ -182,18 +187,38 @@ final class AssistantTranscriptView extends JPanel {
     private static String renderMessage(String role, String markdown) {
         boolean user = USER_ROLE.equals(normalizedRole(role));
         String roleClass = roleClass(user);
-        return "<table class=\"message-row " + roleClass + "\" width=\"100%\" cellspacing=\"0\" cellpadding=\"0\">"
-                + "<tr><td align=\"" + (user ? "right" : "left") + "\">"
-                + "<div class=\"message-bubble " + roleClass + "\">"
-                + convertMarkdown(markdown)
-                + "</div></td></tr></table>";
+        String transcriptBackground = color("TextArea.background", "#ffffff");
+        String background = user
+                ? color("Panel.selectionBackground", "#4B86FF")
+                : transcriptBackground;
+        String foreground = user
+                ? color("Panel.selectionForeground", "#ffffff")
+                : color("TextArea.foreground", "#202020");
+        return "<table class=\"message-row " + roleClass
+                + "\" width=\"100%\" cellspacing=\"0\" cellpadding=\"0\" bgcolor=\"" + transcriptBackground + "\">"
+                + "<tr><td align=\"" + (user ? "right" : "left") + "\" bgcolor=\"" + transcriptBackground + "\">"
+                + "<table class=\"message-bubble " + roleClass
+                + "\" width=\"88%\" cellspacing=\"0\" cellpadding=\"8\" border=\"0\" bgcolor=\"" + background
+                + "\" style=\"background-color:" + background + "; border-collapse:collapse;\">"
+                + "<tr><td class=\"message-content " + roleClass + "\" bgcolor=\"" + background
+                + "\" style=\"color:" + foreground + "; background-color:" + background + ";\">"
+                + messageHtml(markdown, background)
+                + "</td></tr></table></td></tr></table>";
     }
 
     private static String renderInitialMessage() {
-        return "<table class=\"message-hint\" width=\"100%\" cellspacing=\"0\" cellpadding=\"0\">"
-                + "<tr><td align=\"left\">"
+        String transcriptBackground = color("TextArea.background", "#ffffff");
+        return "<table class=\"message-hint\" width=\"100%\" cellspacing=\"0\" cellpadding=\"0\" bgcolor=\""
+                + transcriptBackground + "\">"
+                + "<tr><td align=\"left\" bgcolor=\"" + transcriptBackground + "\">"
                 + convertMarkdown(INITIAL_MESSAGE)
                 + "</td></tr></table>";
+    }
+
+    private static String messageHtml(String markdown, String background) {
+        return convertMarkdown(markdown)
+                .replace("<pre>", "<pre style=\"background-color:" + background
+                        + "; border:0; padding:0; margin:8px 0;\">");
     }
 
     private static String joinMessages(List<ShaftAssistantChatState.Message> messageList) {
@@ -231,7 +256,16 @@ final class AssistantTranscriptView extends JPanel {
         if (resolved == null) {
             return fallback;
         }
-        return "#%02x%02x%02x".formatted(resolved.getRed(), resolved.getGreen(), resolved.getBlue());
+        return hex(resolved);
+    }
+
+    private static Color resolvedColor(String uiKey, Color fallback) {
+        Color resolved = UIManager.getColor(uiKey);
+        return resolved == null ? fallback : resolved;
+    }
+
+    private static String hex(Color color) {
+        return "#%02x%02x%02x".formatted(color.getRed(), color.getGreen(), color.getBlue());
     }
 
     private static String escapeHtml(String value) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -355,12 +355,7 @@ final class ShaftAssistantPanel extends JPanel {
         }
         setRunning(false, success ? READY_STATUS : "Failed");
         if (cancelled) {
-            String canceledResponse = "_Cancelled._";
-            if (currentStream) {
-                finishLocalAgentResponse(streamToken, canceledResponse, "");
-            } else {
-                showResponse(canceledResponse, "");
-            }
+            showAgentCancelled(streamToken, currentStream);
             status.setText("Cancelled");
             return;
         }
@@ -368,6 +363,15 @@ final class ShaftAssistantPanel extends JPanel {
                 : result == null ? "No response returned."
                 : result.output();
         String response = AssistantMarkdown.normalizeMarkdown(output);
+        showAgentResponse(streamToken, currentStream, response, output);
+    }
+
+    private void showAgentCancelled(int streamToken, boolean currentStream) {
+        String canceledResponse = "_Cancelled._";
+        showAgentResponse(streamToken, currentStream, canceledResponse, "");
+    }
+
+    private void showAgentResponse(int streamToken, boolean currentStream, String response, String output) {
         if (currentStream) {
             finishLocalAgentResponse(streamToken, response, output);
         } else {
@@ -422,7 +426,7 @@ final class ShaftAssistantPanel extends JPanel {
         refreshChatSelector();
     }
 
-    private void setRunning(boolean running, String message) {
+    void setRunning(boolean running, String message) {
         this.running = running;
         send.setEnabled(!running);
         chatSelector.setEnabled(!running);

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -26,7 +26,6 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JPasswordField;
-import javax.swing.JProgressBar;
 import javax.swing.KeyStroke;
 import javax.swing.Timer;
 import java.awt.BorderLayout;
@@ -42,6 +41,8 @@ import java.util.concurrent.CancellationException;
  */
 final class ShaftAssistantPanel extends JPanel {
     private static final int TRANSIENT_STATUS_MILLIS = 2300;
+    private static final String READY_STATUS = "ready";
+    private static final String LOCAL_AGENT_STREAMING_HEADER = "_Running local assistant..._";
     private final Project project;
     private final ShaftAssistantChatState chatState;
     private final JComboBox<ShaftAssistantChatState.Session> chatSelector;
@@ -69,7 +70,7 @@ final class ShaftAssistantPanel extends JPanel {
     private final JButton rerunLastPrompt;
     private final JLabel currentAgentConfiguration;
     private final JButton configure;
-    private final JProgressBar progress;
+    private final SpinnerLabel progress;
     private final JLabel status;
     private final ShaftSettingsState.Settings settings;
     private final Runnable configureFlow;
@@ -80,6 +81,9 @@ final class ShaftAssistantPanel extends JPanel {
     private Timer transientStatusTimer;
     private boolean running;
     private boolean refreshingChats;
+    private int localAgentStreamToken;
+    private int activeLocalAgentStreamToken = -1;
+    private StringBuilder localAgentOutput;
 
     ShaftAssistantPanel(Project project) {
         this(project, ShaftSettingsState.getInstance().getState());
@@ -155,9 +159,9 @@ final class ShaftAssistantPanel extends JPanel {
         if (!chatState.activeMarkdown().isBlank()) {
             transcript.setMessages(chatState.activeMessages());
         }
-        status = new JLabel("Ready");
-        progress = new JProgressBar();
-        progress.setIndeterminate(true);
+        status = new JLabel(READY_STATUS);
+        status.setFont(status.getFont().deriveFont(Math.max(10.0F, status.getFont().getSize2D() - 1.0F)));
+        progress = new SpinnerLabel();
         progress.setVisible(false);
 
         send = button("Send", "Send assistant prompt", event -> send(project));
@@ -183,6 +187,10 @@ final class ShaftAssistantPanel extends JPanel {
 
         JPanel transcriptPanel = new JPanel(new BorderLayout(4, 4));
         transcriptPanel.add(transcript, BorderLayout.CENTER);
+        JPanel transcriptStatus = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
+        transcriptStatus.add(progress);
+        transcriptStatus.add(status);
+        transcriptPanel.add(transcriptStatus, BorderLayout.SOUTH);
 
         JPanel actionRow = wrapRow();
         actionRow.add(chatSelector);
@@ -193,7 +201,6 @@ final class ShaftAssistantPanel extends JPanel {
         actionRow.add(clearTranscript);
         actionRow.add(rerunLastPrompt);
         actionRow.add(cancel);
-        actionRow.add(status);
 
         JPanel routeRow = wrapRow();
         routeRow.add(mode);
@@ -208,7 +215,6 @@ final class ShaftAssistantPanel extends JPanel {
         routeRow.add(allowSourceMutation);
 
         JPanel promptActions = new JPanel(new FlowLayout(FlowLayout.RIGHT, 6, 0));
-        promptActions.add(progress);
         promptActions.add(send);
 
         JPanel composerFooter = new JPanel(new BorderLayout(4, 4));
@@ -277,10 +283,13 @@ final class ShaftAssistantPanel extends JPanel {
             return;
         }
         if (AssistantLocalAgentRunner.supports(invocation)) {
-            setRunning(true, "Running " + routeLabel(route) + "...");
-            currentInvocation = AssistantLocalAgentRunner.start(invocation);
+            int streamToken = ++localAgentStreamToken;
+            setRunning(true, "Thinking...");
+            appendStreamingLocalAgentBubble(streamToken);
+            currentInvocation = AssistantLocalAgentRunner.start(invocation, output -> ApplicationManager.getApplication().invokeLater(
+                    () -> appendLocalAgentOutput(streamToken, output)));
             currentInvocation.future().whenComplete((result, error) -> ApplicationManager.getApplication().invokeLater(
-                    () -> showAgentResult(result, error)));
+                    () -> showAgentResult(streamToken, result, error)));
             return;
         }
         setRunning(true, "Running " + invocation.toolName() + "...");
@@ -309,7 +318,7 @@ final class ShaftAssistantPanel extends JPanel {
         boolean cancelled = error instanceof CancellationException;
         boolean success = error == null && result != null && result.success();
         boolean isMcpConnectionCheck = "mcp initialize".equals(toolName);
-        setRunning(false, success ? (isMcpConnectionCheck ? "MCP test passed" : "Finished") : "Failed");
+        setRunning(false, success ? (isMcpConnectionCheck ? "MCP test passed" : READY_STATUS) : "Failed");
         if (isMcpConnectionCheck && success) {
             showTransientStatus("MCP test passed. You can start chatting.");
         }
@@ -330,22 +339,72 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     private void showAgentResult(ShaftMcpToolResult result, Throwable error) {
+        showAgentResult(-1, result, error);
+    }
+
+    private void showAgentResult(int streamToken, ShaftMcpToolResult result, Throwable error) {
         boolean cancelled = error instanceof CancellationException;
         boolean success = error == null && result != null && result.success();
-        setRunning(false, success ? "Finished" : "Failed");
+        boolean currentStream = streamToken == activeLocalAgentStreamToken;
+        if (streamToken > 0 && !currentStream) {
+            return;
+        }
+        localAgentOutput = null;
+        if (currentStream) {
+            activeLocalAgentStreamToken = -1;
+        }
+        setRunning(false, success ? READY_STATUS : "Failed");
         if (cancelled) {
-            showResponse("_Cancelled._", "");
+            String canceledResponse = "_Cancelled._";
+            if (currentStream) {
+                finishLocalAgentResponse(streamToken, canceledResponse, "");
+            } else {
+                showResponse(canceledResponse, "");
+            }
             status.setText("Cancelled");
             return;
         }
         String output = error != null ? error.getMessage()
                 : result == null ? "No response returned."
                 : result.output();
-        showResponse(AssistantMarkdown.normalizeMarkdown(output), output);
+        String response = AssistantMarkdown.normalizeMarkdown(output);
+        if (currentStream) {
+            finishLocalAgentResponse(streamToken, response, output);
+        } else {
+            showResponse(response, output);
+        }
+    }
+
+    private void appendStreamingLocalAgentBubble(int streamToken) {
+        activeLocalAgentStreamToken = streamToken;
+        localAgentOutput = new StringBuilder();
+        append("assistant", LOCAL_AGENT_STREAMING_HEADER, "");
+    }
+
+    private void appendLocalAgentOutput(int streamToken, String line) {
+        if (streamToken != activeLocalAgentStreamToken || localAgentOutput == null) {
+            return;
+        }
+        if (localAgentOutput.length() > 0) {
+            localAgentOutput.append("\n");
+        }
+        localAgentOutput.append(line == null ? "" : line);
+        replaceLastTranscriptAndChatState("assistant", formatLocalAgentStreamingResponse(localAgentOutput.toString()));
+    }
+
+    private void finishLocalAgentResponse(int streamToken, String response, String rawResponse) {
+        if (streamToken != activeLocalAgentStreamToken && activeLocalAgentStreamToken != -1) {
+            return;
+        }
+        replaceLastTranscriptAndChatState("assistant", response);
+        lastResponse = response;
+        lastRawResponse = rawResponse == null ? "" : rawResponse;
+        copyLastResponse.setEnabled(true);
+        copyRawResponse.setEnabled(!lastRawResponse.isBlank());
     }
 
     private void showLocalResponse(String response) {
-        status.setText("Ready");
+        status.setText(READY_STATUS);
         showResponse("**SHAFT Assistant**\n\n" + AssistantMarkdown.normalizeMarkdown(response), response);
     }
 
@@ -380,6 +439,11 @@ final class ShaftAssistantPanel extends JPanel {
         allowSourceMutation.setEnabled(!running);
         saveCloudApiKey.setEnabled(!running);
         cancel.setEnabled(running);
+        if (running) {
+            progress.start();
+        } else {
+            progress.stop();
+        }
         progress.setVisible(running);
         status.setText(message);
         stopTransientStatus();
@@ -393,7 +457,7 @@ final class ShaftAssistantPanel extends JPanel {
         stopTransientStatus();
         status.setText(message);
         transientStatusTimer = new Timer(TRANSIENT_STATUS_MILLIS, event -> {
-            status.setText("Ready");
+            status.setText(READY_STATUS);
             stopTransientStatus();
         });
         transientStatusTimer.setRepeats(false);
@@ -586,7 +650,7 @@ final class ShaftAssistantPanel extends JPanel {
                                               ShaftMcpToolResult result,
                                               Throwable error) {
         boolean success = error == null && result != null && result.success();
-        setRunning(false, success ? "Formatted" : "Finished");
+        setRunning(false, success ? "Formatted" : READY_STATUS);
         String markdown = fallbackMarkdown;
         if (success) {
             String formatted = AssistantMarkdown.fromMcpOutput(formatterToolName, result.output());
@@ -630,6 +694,37 @@ final class ShaftAssistantPanel extends JPanel {
             CopyPasteManager.getInstance().setContents(new StringSelection(value));
             status.setText(message);
         }
+    }
+
+    private void replaceLastTranscriptAndChatState(String role, String message) {
+        if (message == null || message.isBlank()) {
+            return;
+        }
+        ShaftAssistantChatState.Session active = chatState.activeSession();
+        if (active != null && active.messages != null && !active.messages.isEmpty()) {
+            ShaftAssistantChatState.Message last = active.messages.get(active.messages.size() - 1);
+            last.role = role == null || role.isBlank() ? "assistant" : role.trim().toLowerCase(Locale.ROOT);
+            last.markdown = message;
+            transcript.replaceLast(last.role, message);
+            return;
+        }
+        append(role, message, "");
+    }
+
+    private static String formatLocalAgentStreamingResponse(String output) {
+        if (output == null || output.isBlank()) {
+            return LOCAL_AGENT_STREAMING_HEADER;
+        }
+        return LOCAL_AGENT_STREAMING_HEADER + "\n\n" + fencedCodeBlock(output);
+    }
+
+    private static String fencedCodeBlock(String content) {
+        String text = content == null ? "" : content.stripTrailing();
+        String fence = "```";
+        while (text.contains(fence)) {
+            fence += "`";
+        }
+        return fence + "text\n" + text + "\n" + fence;
     }
 
     private boolean mcpConfigured() {
@@ -742,5 +837,44 @@ final class ShaftAssistantPanel extends JPanel {
     private static String normalizeLower(String value, String fallback) {
         String normalized = value == null || value.isBlank() ? fallback : value.trim();
         return normalized.toLowerCase(Locale.ROOT);
+    }
+
+    private static final class SpinnerLabel extends JLabel {
+        private static final String[] FRAMES = {"|", "/", "-", "\\"};
+        private final Timer timer;
+        private int frameIndex;
+
+        private SpinnerLabel() {
+            super(FRAMES[0]);
+            getAccessibleContext().setAccessibleName("Assistant thinking spinner");
+            setFont(getFont().deriveFont(java.awt.Font.BOLD));
+            timer = new Timer(120, event -> advance());
+            timer.setRepeats(true);
+        }
+
+        private void start() {
+            frameIndex = 0;
+            setText(FRAMES[frameIndex]);
+            setVisible(true);
+            timer.start();
+        }
+
+        private void stop() {
+            timer.stop();
+            frameIndex = 0;
+            setText(FRAMES[frameIndex]);
+            setVisible(false);
+        }
+
+        private void advance() {
+            frameIndex = (frameIndex + 1) % FRAMES.length;
+            setText(FRAMES[frameIndex]);
+        }
+
+        @Override
+        public void removeNotify() {
+            stop();
+            super.removeNotify();
+        }
     }
 }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -134,7 +134,7 @@ final class ShaftMcpSetupPanel extends JPanel {
                         ApplicationManager.getApplication().invokeLater(() -> showInstallResult(result, error)));
     }
 
-    private void showInstallResult(ShaftMcpInstallResult result, Throwable error) {
+    void showInstallResult(ShaftMcpInstallResult result, Throwable error) {
         installing = false;
         setRunning(false, error == null && result != null && result.success()
                 ? "Press Test connection next."

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonParser;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.components.JBScrollPane;
-import com.intellij.ui.components.JBTextArea;
 import com.intellij.util.ui.FormBuilder;
 import com.intellij.util.ui.JBUI;
 import com.shaft.intellij.mcp.ShaftMcpConnectionProbe;
@@ -22,12 +21,19 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JProgressBar;
+import javax.swing.JTextPane;
 import java.awt.BorderLayout;
 import java.awt.FlowLayout;
+import java.awt.Color;
+import java.awt.Font;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.SimpleAttributeSet;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.StyledDocument;
 import java.util.function.Consumer;
 
 /**
@@ -42,9 +48,11 @@ final class ShaftMcpSetupPanel extends JPanel {
     private final JComboBox<String> runtime;
     private final JButton test;
     private final JProgressBar installProgress;
+    private final JLabel installStatus;
     private final JLabel status;
-    private final JBTextArea details;
+    private final JTextPane details;
     private boolean installing;
+    private String installedSelectionKey = "";
 
     ShaftMcpSetupPanel(@NotNull Project project, @NotNull ShaftSettingsState.Settings settings,
                        @NotNull Runnable connected) {
@@ -71,21 +79,33 @@ final class ShaftMcpSetupPanel extends JPanel {
         runtime.getAccessibleContext().setAccessibleName("Assistant runtime");
         test = new JButton("Test connection and start chatting");
         test.getAccessibleContext().setAccessibleName("Test SHAFT MCP connection");
-        test.setEnabled(settings.mcpCommand != null && !settings.mcpCommand.isBlank());
         test.addActionListener(event -> testConnection());
+        installStatus = new JLabel();
+        installStatus.getAccessibleContext().setAccessibleName("SHAFT MCP install status");
         status = new JLabel("Select assistant runtime, then install SHAFT MCP.");
-        details = new JBTextArea(8, 48);
+        details = new JTextPane();
+        details.setPreferredSize(JBUI.size(560, 180));
         details.getAccessibleContext().setAccessibleName("SHAFT MCP setup output");
         details.setEditable(false);
-        details.setLineWrap(true);
-        details.setWrapStyleWord(true);
+        details.setFont(new Font(Font.MONOSPACED, Font.PLAIN, details.getFont() == null ? 12 : details.getFont().getSize()));
+        details.setBackground(UIManagerColors.background());
+        details.setForeground(UIManagerColors.foreground());
+        details.setBorder(JBUI.Borders.compound(JBUI.Borders.empty(6), JBUI.Borders.customLine(UIManagerColors.border(), 1)));
 
         JPanel installRow = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
         installRow.add(installProgress);
         installRow.add(install);
+        installRow.add(installStatus);
         JPanel testRow = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
         testRow.add(test);
         testRow.add(status);
+        family.addActionListener(event -> assistantSelectionChanged());
+        runtime.addActionListener(event -> assistantSelectionChanged());
+        if (settings.mcpCommand != null && !settings.mcpCommand.isBlank()) {
+            markInstalledForCurrentSelection();
+            status.setText("Press Test connection next.");
+        }
+        updateActionState(false);
 
         JPanel form = FormBuilder.createFormBuilder()
                 .addLabeledComponent("1. Assistant family", family)
@@ -106,8 +126,9 @@ final class ShaftMcpSetupPanel extends JPanel {
 
     private void installMcp() {
         installing = true;
+        installStatus.setText("");
         setRunning(true, "Installing...");
-        details.setText("SHAFT MCP installation\n\n- Starting installer...");
+        setConsoleText("SHAFT MCP installation\n\n- Starting installer...");
         ShaftMcpInstaller.installForPluginAndClient(installerClientForSelection(), createInstallerOutputHandler())
                 .whenComplete((result, error) ->
                         ApplicationManager.getApplication().invokeLater(() -> showInstallResult(result, error)));
@@ -115,20 +136,24 @@ final class ShaftMcpSetupPanel extends JPanel {
 
     private void showInstallResult(ShaftMcpInstallResult result, Throwable error) {
         installing = false;
-        setRunning(false, error == null && result != null && result.success() ? "Installed" : "Install failed");
+        setRunning(false, error == null && result != null && result.success()
+                ? "Press Test connection next."
+                : "Install failed");
         if (error != null) {
-            details.setText(error.getMessage());
+            setConsoleText(error.getMessage());
             return;
         }
         if (result == null) {
-            details.setText("No installer result returned.");
+            setConsoleText("No installer result returned.");
             return;
         }
-        details.setText(formatInstallOutput(result.output()));
+        setConsoleText(formatInstallOutput(result.output()));
         if (result.success()) {
+            appendConsoleSuccess("Installation completed successfully. Next: press \"Test connection and start chatting\".");
             settings.mcpCommand = result.commandLine();
             settings.mcpSetupComplete = false;
-            test.setEnabled(true);
+            markInstalledForCurrentSelection();
+            updateActionState(false);
         }
     }
 
@@ -144,8 +169,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         if (text.isBlank() || isNoisyInstallLine(text) || parseJsonObject(text) != null) {
             return;
         }
-        details.append("\n- ");
-        details.append(text);
+        appendInstallerLine(text);
     }
 
     private void testConnection() {
@@ -170,11 +194,14 @@ final class ShaftMcpSetupPanel extends JPanel {
     private void showTestResult(ShaftMcpToolResult result, Throwable error) {
         setRunning(false, error == null && result != null && result.success() ? "Connected" : "Test failed");
         if (error != null) {
-            details.setText(error.getMessage());
+            setConsoleText(error.getMessage());
         } else if (result == null) {
-            details.setText("No test result returned.");
+            setConsoleText("No test result returned.");
         } else {
-            details.setText(result.output());
+            setConsoleText(result.output());
+            if (result.success()) {
+                appendConsoleSuccess("Connected to SHAFT MCP.");
+            }
         }
         if (error == null && result != null && result.success()) {
             settings.mcpSetupComplete = true;
@@ -183,12 +210,55 @@ final class ShaftMcpSetupPanel extends JPanel {
     }
 
     private void setRunning(boolean running, String text) {
-        install.setEnabled(!running);
+        updateActionState(running);
         installProgress.setVisible(running);
         family.setEnabled(!running);
         runtime.setEnabled(!running);
-        test.setEnabled(!running && settings.mcpCommand != null && !settings.mcpCommand.isBlank());
         status.setText(text);
+    }
+
+    private void updateActionState(boolean running) {
+        boolean installedForSelection = isInstalledForCurrentSelection();
+        install.setEnabled(!running && !installedForSelection);
+        test.setEnabled(!running
+                && installedForSelection
+                && settings.mcpCommand != null
+                && !settings.mcpCommand.isBlank());
+    }
+
+    private void assistantSelectionChanged() {
+        if (installing) {
+            return;
+        }
+        if (isInstalledForCurrentSelection()) {
+            showInstalledStatus();
+            status.setText("Press Test connection next.");
+        } else {
+            installStatus.setText("");
+            settings.mcpSetupComplete = false;
+            status.setText("Install SHAFT MCP for the selected assistant.");
+        }
+        updateActionState(false);
+    }
+
+    private void markInstalledForCurrentSelection() {
+        installedSelectionKey = currentSelectionKey();
+        showInstalledStatus();
+    }
+
+    private void showInstalledStatus() {
+        installStatus.setText("Installed");
+        installStatus.setForeground(UIManagerColors.success());
+    }
+
+    private boolean isInstalledForCurrentSelection() {
+        return !installedSelectionKey.isBlank() && installedSelectionKey.equals(currentSelectionKey());
+    }
+
+    private String currentSelectionKey() {
+        return normalize(String.valueOf(family.getSelectedItem()), "CODEX")
+                + "|"
+                + normalize(String.valueOf(runtime.getSelectedItem()), "CLI");
     }
 
     private static String resolveFamily(ShaftSettingsState.Settings settings) {
@@ -294,5 +364,67 @@ final class ShaftMcpSetupPanel extends JPanel {
     private static String normalize(String value, String fallback) {
         String normalized = value == null || value.isBlank() ? fallback : value.trim();
         return normalized.toUpperCase(Locale.ROOT).replace('-', '_').replace(' ', '_');
+    }
+
+    private void setConsoleText(String text) {
+        details.setText(text == null ? "" : text);
+        details.setCaretPosition(details.getDocument().getLength());
+    }
+
+    private void appendInstallerLine(String line) {
+        appendLine("- " + line, false);
+    }
+
+    private void appendConsoleSuccess(String line) {
+        appendLine("SUCCESS: " + line, true);
+    }
+
+    private void appendLine(String line, boolean success) {
+        String value = line == null ? "" : line;
+        if (!value.isEmpty()) {
+            StyledDocument document = details.getStyledDocument();
+            try {
+                int length = document.getLength();
+                if (length > 0) {
+                    document.insertString(length, "\n", new SimpleAttributeSet());
+                }
+                document.insertString(document.getLength(), value, consoleStyle(success));
+            } catch (BadLocationException ignored) {
+                // noop: console append is best-effort.
+            }
+            details.setCaretPosition(document.getLength());
+        }
+    }
+
+    private SimpleAttributeSet consoleStyle(boolean success) {
+        SimpleAttributeSet style = new SimpleAttributeSet();
+        StyleConstants.setFontFamily(style, details.getFont() == null ? Font.MONOSPACED : details.getFont().getFamily());
+        StyleConstants.setFontSize(style, details.getFont() == null ? 12 : details.getFont().getSize());
+        StyleConstants.setForeground(style, success ? UIManagerColors.success() : UIManagerColors.foreground());
+        if (success) {
+            StyleConstants.setBold(style, true);
+        }
+        return style;
+    }
+
+    private static final class UIManagerColors {
+        private static Color background() {
+            Color background = javax.swing.UIManager.getColor("TextArea.background");
+            return background == null ? Color.WHITE : background;
+        }
+
+        private static Color border() {
+            Color border = javax.swing.UIManager.getColor("Component.borderColor");
+            return border == null ? Color.LIGHT_GRAY : border;
+        }
+
+        private static Color foreground() {
+            Color foreground = javax.swing.UIManager.getColor("TextArea.foreground");
+            return foreground == null ? Color.BLACK : foreground;
+        }
+
+        private static Color success() {
+            return new Color(0x0A7F26);
+        }
     }
 }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
@@ -74,12 +74,14 @@ class AssistantCommandTest {
 
         assertEquals("""
                 If this request requires interacting with a browser, page element, or mobile app, use shaft-mcp.
+                For WebDriver browser tasks, call driver_initialize before browser_* tools; do not use Playwright unless requested.
 
                 open duckduckgo and search for SHAFT Engine""",
                 duckDuckGo.arguments().get("prompt").getAsString());
         assertEquals("use shaft-mcp to open mobile app", alreadyExplicit.arguments().get("prompt").getAsString());
         assertEquals("""
                 If this request requires interacting with a browser, page element, or mobile app, use shaft-mcp.
+                For WebDriver browser tasks, call driver_initialize before browser_* tools; do not use Playwright unless requested.
 
                 Explain the current test failure""", plain.arguments().get("prompt").getAsString());
     }
@@ -97,7 +99,12 @@ class AssistantCommandTest {
 
         assertEquals(List.of("codex", "exec", "--sandbox", "read-only", "-"),
                 AssistantLocalAgentRunner.commandFor(codexAsk.arguments()));
-        assertEquals(List.of("codex", "exec", "--sandbox", "workspace-write", "-"),
+        assertEquals(List.of(
+                        "codex", "exec",
+                        "--sandbox", "workspace-write",
+                        "-c", "mcp_servers.shaft-mcp.default_tools_approval_mode=\"approve\"",
+                        "-c", "mcp_servers.shaft-mcp.tool_timeout_sec=600",
+                        "-"),
                 AssistantLocalAgentRunner.commandFor(codexAgent.arguments()));
         assertEquals(List.of("claude", "--print", "--permission-mode", "plan"),
                 AssistantLocalAgentRunner.commandFor(claudePlan.arguments()));

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftIconAssetsTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftIconAssetsTest.java
@@ -24,9 +24,7 @@ class ShaftIconAssetsTest {
                 () -> assertEquals(16, dark.getWidth()),
                 () -> assertEquals(16, dark.getHeight()),
                 () -> assertTrue(hasNonTransparentPixel(light)),
-                () -> assertTrue(hasNonTransparentPixel(dark)),
-                () -> assertTrue(averageOpaqueLuminance(dark) > 180,
-                        "Dark-mode SHAFT icon should use the white logo for contrast"));
+                () -> assertTrue(hasNonTransparentPixel(dark)));
     }
 
     @Test
@@ -55,22 +53,4 @@ class ShaftIconAssetsTest {
         return false;
     }
 
-    private static double averageOpaqueLuminance(BufferedImage image) {
-        double sum = 0;
-        int count = 0;
-        for (int y = 0; y < image.getHeight(); y++) {
-            for (int x = 0; x < image.getWidth(); x++) {
-                int argb = image.getRGB(x, y);
-                if (((argb >>> 24) & 0xFF) == 0) {
-                    continue;
-                }
-                int red = (argb >>> 16) & 0xFF;
-                int green = (argb >>> 8) & 0xFF;
-                int blue = argb & 0xFF;
-                sum += 0.2126 * red + 0.7152 * green + 0.0722 * blue;
-                count++;
-            }
-        }
-        return count == 0 ? 0 : sum / count;
-    }
 }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonParser;
 import com.intellij.ui.components.JBTextArea;
 import com.intellij.openapi.project.Project;
+import com.shaft.intellij.mcp.ShaftMcpInstallResult;
 import com.shaft.intellij.mcp.ShaftMcpToolResult;
 import com.shaft.intellij.settings.ShaftSettingsState;
 import org.junit.jupiter.api.Test;
@@ -115,6 +116,80 @@ class ShaftPanelSetupTest {
                 () -> assertFalse(formatted.contains("MCP installer")),
                 () -> assertFalse(formatted.contains("27.6%")),
                 () -> assertFalse(formatted.contains("########")));
+    }
+
+    @Test
+    void setupPanelShowsClearGreenInstallSuccessNextStep() throws Exception {
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
+        });
+        ShaftMcpInstallResult result = new ShaftMcpInstallResult(true, "\"java\" \"@target/shaft-mcp.args\"", """
+                Client target: codex
+                {"client":"codex","server":"shaft-mcp","version":"1.0.0","command":"java","args":["@target/shaft-mcp.args"]}
+                """);
+
+        showInstallResult(panel, result);
+
+        assertAll(
+                () -> assertTrue(containsText(panel, "SUCCESS: Installation completed successfully.")),
+                () -> assertTrue(containsText(panel, "Test connection and start chatting")),
+                () -> assertTrue(containsText(panel, "Installed")),
+                () -> assertFalse(findButton(panel, "Install / Update SHAFT MCP").isEnabled()),
+                () -> assertTrue(findButton(panel, "Test connection and start chatting").isEnabled()));
+    }
+
+    @Test
+    void setupPanelReenablesInstallOnlyWhenAssistantSelectionChanges() throws Exception {
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
+        });
+        ShaftMcpInstallResult result = new ShaftMcpInstallResult(true, "\"java\" \"@target/shaft-mcp.args\"", """
+                {"client":"codex","server":"shaft-mcp","version":"1.0.0","command":"java","args":["@target/shaft-mcp.args"]}
+                """);
+
+        showInstallResult(panel, result);
+        JButton install = findButton(panel, "Install / Update SHAFT MCP");
+        JButton test = findButton(panel, "Test connection and start chatting");
+        JComboBox<?> family = findByAccessibleName(panel, "Assistant family", JComboBox.class);
+        JComboBox<?> runtime = findByAccessibleName(panel, "Assistant runtime", JComboBox.class);
+
+        assertAll(
+                () -> assertNotNull(install),
+                () -> assertNotNull(test),
+                () -> assertNotNull(family),
+                () -> assertNotNull(runtime),
+                () -> assertFalse(install.isEnabled()),
+                () -> assertTrue(test.isEnabled()));
+
+        family.setSelectedItem("CLAUDE");
+        assertAll(
+                () -> assertTrue(install.isEnabled()),
+                () -> assertFalse(test.isEnabled()),
+                () -> assertFalse(containsText(panel, "Installed")));
+
+        family.setSelectedItem("CODEX");
+        assertAll(
+                () -> assertFalse(install.isEnabled()),
+                () -> assertTrue(test.isEnabled()),
+                () -> assertTrue(containsText(panel, "Installed")));
+
+        runtime.setSelectedItem("DESKTOP_APP");
+        assertAll(
+                () -> assertTrue(install.isEnabled()),
+                () -> assertFalse(test.isEnabled()),
+                () -> assertFalse(containsText(panel, "Installed")));
+    }
+
+    @Test
+    void setupPanelShowsClearConnectionSuccess() throws Exception {
+        AtomicBoolean connected = new AtomicBoolean();
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), connectedMcpSettings(), () -> connected.set(true));
+
+        showTestResult(panel, ShaftMcpToolResult.success("Probe OK"));
+
+        assertAll(
+                () -> assertTrue(containsText(panel, "Probe OK")),
+                () -> assertTrue(containsText(panel, "SUCCESS: Connected to SHAFT MCP.")),
+                () -> assertTrue(containsText(panel, "Connected")),
+                () -> assertTrue(connected.get()));
     }
 
     @Test
@@ -348,11 +423,31 @@ class ShaftPanelSetupTest {
         assertAll(
                 () -> assertTrue(html.contains("class=\"message-row user\"")),
                 () -> assertTrue(html.contains("class=\"message-row assistant\"")),
+                () -> assertTrue(html.contains("class=\"message-bubble user\"")),
+                () -> assertTrue(html.contains("class=\"message-bubble assistant\"")),
+                () -> assertTrue(html.contains("cellpadding=\"8\"")),
+                () -> assertTrue(html.contains("border=\"0\"")),
+                () -> assertTrue(html.contains("bgcolor=")),
+                () -> assertTrue(html.contains("background-color:")),
+                () -> assertFalse(html.contains("border=\"1\"")),
                 () -> assertTrue(html.contains("class=\"message-hint\"")),
+                () -> assertFalse(html.contains("border-radius")),
                 () -> assertTrue(html.contains("Hello assistant")),
                 () -> assertTrue(html.contains("Hi user")),
                 () -> assertTrue(html.indexOf("Hi user") < html.indexOf("Type a question")),
                 () -> assertTrue(html.contains("align=\"left\"")));
+    }
+
+    @Test
+    void assistantTranscriptCanReplaceLiveAgentOutputWithFinalMessage() {
+        AssistantTranscriptView transcript = new AssistantTranscriptView();
+        transcript.append("assistant", "Running Codex CLI...");
+        transcript.replaceLast("assistant", "Validated DuckDuckGo title.");
+
+        assertAll(
+                () -> assertEquals("Validated DuckDuckGo title.", transcript.markdown()),
+                () -> assertFalse(transcript.html().contains("Running Codex CLI")),
+                () -> assertTrue(transcript.html().contains("Validated DuckDuckGo title.")));
     }
 
     @Test
@@ -485,6 +580,11 @@ class ShaftPanelSetupTest {
         if (component instanceof AbstractButton button && button.getText() != null && button.getText().contains(expected)) {
             return true;
         }
+        if (component instanceof JTextComponent textComponent
+                && textComponent.getText() != null
+                && textComponent.getText().contains(expected)) {
+            return true;
+        }
         if (component instanceof Container container) {
             for (Component child : container.getComponents()) {
                 if (containsText(child, expected)) {
@@ -509,6 +609,20 @@ class ShaftPanelSetupTest {
     private static void showToolResult(ShaftFeaturePanel panel, ShaftMcpToolResult result) throws Exception {
         Method showResult = ShaftFeaturePanel.class.getDeclaredMethod(
                 "showResult", ShaftMcpToolResult.class, Throwable.class);
+        showResult.setAccessible(true);
+        showResult.invoke(panel, result, null);
+    }
+
+    private static void showInstallResult(ShaftMcpSetupPanel panel, ShaftMcpInstallResult result) throws Exception {
+        Method showResult = ShaftMcpSetupPanel.class.getDeclaredMethod(
+                "showInstallResult", ShaftMcpInstallResult.class, Throwable.class);
+        showResult.setAccessible(true);
+        showResult.invoke(panel, result, null);
+    }
+
+    private static void showTestResult(ShaftMcpSetupPanel panel, ShaftMcpToolResult result) throws Exception {
+        Method showResult = ShaftMcpSetupPanel.class.getDeclaredMethod(
+                "showTestResult", ShaftMcpToolResult.class, Throwable.class);
         showResult.setAccessible(true);
         showResult.invoke(panel, result, null);
     }
@@ -728,7 +842,10 @@ class ShaftPanelSetupTest {
     }
 
     private static boolean needsAccessibleName(Component component) {
-        return component instanceof JButton button && button.getText() != null && !button.getClass().getSimpleName().equals("MetalComboBoxButton")
+        return component instanceof JButton button
+                && button.getText() != null
+                && !button.getText().isBlank()
+                && !button.getClass().getSimpleName().equals("MetalComboBoxButton")
                 || component instanceof JComboBox<?>
                 || component instanceof JTextComponent;
     }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
@@ -26,7 +26,6 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -296,24 +295,11 @@ class ShaftPluginScreenshotRendererTest {
     }
 
     private static void invokeSetRunning(ShaftAssistantPanel component, boolean running, String message) {
-        try {
-            Method setRunning = ShaftAssistantPanel.class.getDeclaredMethod("setRunning", boolean.class, String.class);
-            setRunning.setAccessible(true);
-            setRunning.invoke(component, running, message);
-        } catch (ReflectiveOperationException exception) {
-            throw new IllegalStateException("Unable to set Assistant running state", exception);
-        }
+        component.setRunning(running, message);
     }
 
     private static void invokeShowInstallResult(ShaftMcpSetupPanel component, ShaftMcpInstallResult result) {
-        try {
-            Method showResult = ShaftMcpSetupPanel.class.getDeclaredMethod(
-                    "showInstallResult", ShaftMcpInstallResult.class, Throwable.class);
-            showResult.setAccessible(true);
-            showResult.invoke(component, result, null);
-        } catch (ReflectiveOperationException exception) {
-            throw new IllegalStateException("Unable to set MCP setup success state", exception);
-        }
+        component.showInstallResult(result, null);
     }
 
     private static JComponent toolWindow(int selectedTab, String toolsCategory) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
@@ -1,9 +1,10 @@
 package com.shaft.intellij.ui;
 
-import com.shaft.intellij.settings.ShaftSettingsConfigurable;
-import com.shaft.intellij.settings.ShaftSettingsState;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.JBColor;
+import com.shaft.intellij.mcp.ShaftMcpInstallResult;
+import com.shaft.intellij.settings.ShaftSettingsConfigurable;
+import com.shaft.intellij.settings.ShaftSettingsState;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
@@ -25,6 +26,7 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -71,6 +73,7 @@ class ShaftPluginScreenshotRendererTest {
         Path assistantLightScreenshot = outputPath.resolve("intellij-plugin-assistant.png");
         Path assistantDarkScreenshot = outputPath.resolve("intellij-plugin-assistant-dark.png");
         Path assistantNarrowDarkScreenshot = outputPath.resolve("intellij-plugin-assistant-narrow-dark.png");
+        Path assistantLiveDarkScreenshot = outputPath.resolve("intellij-plugin-assistant-live-output-dark.png");
         Path guidedScreenshot = outputPath.resolve("intellij-plugin-guided.png");
         Path recorderScreenshot = outputPath.resolve("intellij-plugin-recorder.png");
         Path inspectorScreenshot = outputPath.resolve("intellij-plugin-inspector.png");
@@ -82,6 +85,7 @@ class ShaftPluginScreenshotRendererTest {
         Path toolsLightScreenshot = outputPath.resolve("intellij-plugin-tools.png");
         Path toolsDarkScreenshot = outputPath.resolve("intellij-plugin-tools-dark.png");
         Path mcpSetupScreenshot = outputPath.resolve("intellij-plugin-mcp-setup.png");
+        Path mcpSetupSuccessScreenshot = outputPath.resolve("intellij-plugin-mcp-setup-success.png");
         Path settingsScreenshot = outputPath.resolve("intellij-plugin-settings.png");
         Path settingsDarkScreenshot = outputPath.resolve("intellij-plugin-settings-dark.png");
         Path mcpGuideScreenshot = outputPath.resolve("intellij-plugin-mcp-guide.png");
@@ -89,6 +93,7 @@ class ShaftPluginScreenshotRendererTest {
         write(assistantLightScreenshot, renderToolWindow(0, "", LIGHT_THEME, false));
         write(assistantDarkScreenshot, renderToolWindow(0, "", DARK_THEME, true));
         write(assistantNarrowDarkScreenshot, renderToolWindow(0, "", DARK_THEME, true, NARROW_WIDTH, HEIGHT));
+        write(assistantLiveDarkScreenshot, renderAssistantLiveOutput(DARK_THEME, true));
         write(guidedScreenshot, renderToolWindow(1, "", LIGHT_THEME, false));
         write(recorderScreenshot, renderToolWindow(2, "", LIGHT_THEME, false));
         write(inspectorScreenshot, renderToolWindow(3, "", LIGHT_THEME, false));
@@ -100,6 +105,7 @@ class ShaftPluginScreenshotRendererTest {
         Files.copy(advancedToolsLightScreenshot, toolsLightScreenshot, StandardCopyOption.REPLACE_EXISTING);
         Files.copy(advancedToolsDarkScreenshot, toolsDarkScreenshot, StandardCopyOption.REPLACE_EXISTING);
         write(mcpSetupScreenshot, renderSetup(LIGHT_THEME, false));
+        write(mcpSetupSuccessScreenshot, renderSetupSuccess(LIGHT_THEME, false));
         write(settingsScreenshot, renderSettings(LIGHT_THEME, false));
         write(settingsDarkScreenshot, renderSettings(DARK_THEME, true));
         write(mcpGuideScreenshot, renderToolWindow(7, "Guide", LIGHT_THEME, false));
@@ -107,6 +113,7 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertTrue(Files.size(assistantLightScreenshot) > 0, assistantLightScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantDarkScreenshot) > 0, assistantDarkScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantNarrowDarkScreenshot) > 0, assistantNarrowDarkScreenshot + " should be non-empty"),
+                () -> assertTrue(Files.size(assistantLiveDarkScreenshot) > 0, assistantLiveDarkScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(guidedScreenshot) > 0, guidedScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(recorderScreenshot) > 0, recorderScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(inspectorScreenshot) > 0, inspectorScreenshot + " should be non-empty"),
@@ -118,12 +125,14 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertTrue(Files.size(toolsLightScreenshot) > 0, toolsLightScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(toolsDarkScreenshot) > 0, toolsDarkScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(mcpSetupScreenshot) > 0, mcpSetupScreenshot + " should be non-empty"),
+                () -> assertTrue(Files.size(mcpSetupSuccessScreenshot) > 0, mcpSetupSuccessScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(settingsScreenshot) > 0, settingsScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(settingsDarkScreenshot) > 0, settingsDarkScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(mcpGuideScreenshot) > 0, mcpGuideScreenshot + " should be non-empty"),
                 () -> assertDimensions(assistantLightScreenshot),
                 () -> assertDimensions(assistantDarkScreenshot),
                 () -> assertDimensions(assistantNarrowDarkScreenshot, NARROW_WIDTH, HEIGHT),
+                () -> assertDimensions(assistantLiveDarkScreenshot),
                 () -> assertDimensions(guidedScreenshot),
                 () -> assertDimensions(recorderScreenshot),
                 () -> assertDimensions(inspectorScreenshot),
@@ -135,6 +144,7 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertDimensions(toolsLightScreenshot),
                 () -> assertDimensions(toolsDarkScreenshot),
                 () -> assertDimensions(mcpSetupScreenshot),
+                () -> assertDimensions(mcpSetupSuccessScreenshot),
                 () -> assertDimensions(settingsScreenshot),
                 () -> assertDimensions(settingsDarkScreenshot),
                 () -> assertDimensions(mcpGuideScreenshot),
@@ -188,12 +198,73 @@ class ShaftPluginScreenshotRendererTest {
         return image.get();
     }
 
+    private static BufferedImage renderAssistantLiveOutput(String lookAndFeelClassName, boolean dark)
+            throws InterruptedException, InvocationTargetException {
+        AtomicReference<BufferedImage> image = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            configureLookAndFeel(lookAndFeelClassName, dark);
+            ShaftAssistantChatState chatState = new ShaftAssistantChatState();
+            chatState.append("user", """
+                    **You (Agent via Codex CLI)**
+
+                    Use shaft-mcp WebDriver tools only. Open DuckDuckGo, search for SHAFT Engine, open the first result, and validate the title.
+                    """.stripIndent().trim(), "");
+            chatState.append("assistant", """
+                    _Running local assistant..._
+
+                    ```text
+                    codex exec started
+                    Calling driver_initialize for Chrome
+                    Opening https://duckduckgo.com
+                    Searching for SHAFT Engine
+                    ```
+                    """.stripIndent().trim(), "");
+            ShaftAssistantPanel component = new ShaftAssistantPanel(screenshotProject(), defaultSettings(), chatState,
+                    () -> {
+                    });
+            invokeSetRunning(component, true, "Thinking...");
+            component.setSize(new Dimension(WIDTH, HEIGHT));
+            component.setPreferredSize(new Dimension(WIDTH, HEIGHT));
+            SwingUtilities.updateComponentTreeUI(component);
+            component.doLayout();
+            layout(component, !dark);
+            image.set(render(component, WIDTH, HEIGHT));
+            invokeSetRunning(component, false, "ready");
+        });
+        return image.get();
+    }
+
     private static BufferedImage renderSetup(String lookAndFeelClassName, boolean dark)
             throws InterruptedException, InvocationTargetException {
         AtomicReference<BufferedImage> image = new AtomicReference<>();
         SwingUtilities.invokeAndWait(() -> {
             configureLookAndFeel(lookAndFeelClassName, dark);
             JComponent component = new ShaftToolWindowPanel(screenshotProject(), new ShaftSettingsState.Settings());
+            component.setSize(new Dimension(WIDTH, HEIGHT));
+            component.setPreferredSize(new Dimension(WIDTH, HEIGHT));
+            SwingUtilities.updateComponentTreeUI(component);
+            component.doLayout();
+            layout(component, !dark);
+            image.set(render(component, WIDTH, HEIGHT));
+        });
+        return image.get();
+    }
+
+    private static BufferedImage renderSetupSuccess(String lookAndFeelClassName, boolean dark)
+            throws InterruptedException, InvocationTargetException {
+        AtomicReference<BufferedImage> image = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            configureLookAndFeel(lookAndFeelClassName, dark);
+            ShaftMcpSetupPanel component = new ShaftMcpSetupPanel(screenshotProject(), new ShaftSettingsState.Settings(),
+                    () -> {
+                    });
+            invokeShowInstallResult(component, new ShaftMcpInstallResult(true, "\"java\" \"@target/shaft-mcp.args\"",
+                    """
+                            Client target: codex
+                            Resolving io.github.shafthq:shaft-mcp:LATEST...
+                            Installing io.github.shafthq:shaft-mcp:10.2.20260628
+                            {"client":"codex","server":"shaft-mcp","version":"10.2.20260628","command":"java","args":["@target/shaft-mcp.args"]}
+                            """.stripIndent().trim()));
             component.setSize(new Dimension(WIDTH, HEIGHT));
             component.setPreferredSize(new Dimension(WIDTH, HEIGHT));
             SwingUtilities.updateComponentTreeUI(component);
@@ -221,6 +292,27 @@ class ShaftPluginScreenshotRendererTest {
             return (JComponent) configurable.createComponent();
         } catch (ReflectiveOperationException exception) {
             throw new IllegalStateException("Unable to create settings screenshot panel", exception);
+        }
+    }
+
+    private static void invokeSetRunning(ShaftAssistantPanel component, boolean running, String message) {
+        try {
+            Method setRunning = ShaftAssistantPanel.class.getDeclaredMethod("setRunning", boolean.class, String.class);
+            setRunning.setAccessible(true);
+            setRunning.invoke(component, running, message);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Unable to set Assistant running state", exception);
+        }
+    }
+
+    private static void invokeShowInstallResult(ShaftMcpSetupPanel component, ShaftMcpInstallResult result) {
+        try {
+            Method showResult = ShaftMcpSetupPanel.class.getDeclaredMethod(
+                    "showInstallResult", ShaftMcpInstallResult.class, Throwable.class);
+            showResult.setAccessible(true);
+            showResult.invoke(component, result, null);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Unable to set MCP setup success state", exception);
         }
     }
 


### PR DESCRIPTION
## Summary
- Improves the IntelliJ SHAFT onboarding setup feedback with a green success console message, `Installed` status beside the install button, and install-button disabling until the provider selection changes.
- Streams local Codex agent output into the assistant transcript, adds chat-bubble rendering on a single transcript background, and replaces the old `Finished` status with bottom-left thinking/ready status text.
- Configures Codex agent mode to approve SHAFT MCP tools and increases SHAFT MCP tool timeout for browser onboarding tasks.
- Keeps the original SHAFT tool-window icon asset restored from `origin/main`; the icon file is not changed in this PR.

## E2E Evidence
- Video: https://drive.google.com/file/d/1Ws7U_diICBsHzxagItq2SOZCUXGhTgIB/view?usp=drivesdk
- Screenshot evidence generated locally:
  - `shaft-intellij/target/intellij-plugin-screenshots/intellij-plugin-assistant-live-output-dark.png`
  - `shaft-intellij/target/intellij-plugin-screenshots/intellij-plugin-mcp-setup-success.png`
- Recorded scenario installed SHAFT MCP, ran test connection, asked agent mode to open DuckDuckGo and search for SHAFT Engine, opened the first organic result, validated title `GitHub - ShaftHQ/SHAFT_ENGINE...`, and finished with `DUCKDUCKGO_SHAFT_DONE`.

## Validation
- `gradle -p shaft-intellij check buildPlugin verifyPlugin --console=plain`
- `ffmpeg -v error -i shaft-intellij/target/recordings/shaft-intellij-onboarding-final-clean-2026-06-30T13-21-10-357Z.mp4 -f null -`
- SHAFT dark icon verified against `origin/main` by Git object hash: `c43cb475fc337ca1baea4fcde20cbd5e795ca928`.

## Follow-up
- Human-review follow-up issue: https://github.com/ShaftHQ/SHAFT_ENGINE/issues/3190