### PR TITLE
Fix IntelliJ recording Gradle fallback

### DIFF
--- a/tools/intellij-plugin-recording/record-onboarding.ps1
+++ b/tools/intellij-plugin-recording/record-onboarding.ps1
@@ -1,3 +1,4 @@
 $ErrorActionPreference = 'Stop'
 Set-Location (Resolve-Path "$PSScriptRoot\..\..")
-& .\gradlew -p shaft-intellij check buildPlugin verifyPlugin
+$gradle = if (Test-Path ".\gradlew.bat") { ".\gradlew.bat" } elseif (Test-Path ".\gradlew") { ".\gradlew" } else { "gradle" }
+& $gradle -p shaft-intellij check buildPlugin verifyPlugin


### PR DESCRIPTION
## Summary
- Fix `tools/intellij-plugin-recording/record-onboarding.ps1` so it uses the repo Gradle wrapper when present and falls back to installed `gradle` in checkouts without a wrapper.

## Recording
- Video: https://drive.google.com/file/d/17sHMGab4L7o7XOOJpR_Cl9I4zFUapwHL/view?usp=drivesdk
- Note: upload succeeded to Drive root. Company-domain sharing was attempted and rejected by Drive as no applicable Workspace domain.

## Validation
- `powershell -NoProfile -ExecutionPolicy Bypass -File tools\intellij-plugin-recording\record-onboarding.ps1`
- Recorded first-run IntelliJ plugin onboarding from clean Gradle sandbox.
- MCP install and test connection completed.
- Assistant Agent mode ran with `Allow source edits` off.
- Final transcript observed title: `GitHub - ShaftHQ/SHAFT_ENGINE: Java test automation framework for web, mobile, API, CLI, database, and desktop E2E testing with a fluent API and built-in reporting. · GitHub`
- Completion marker observed: `DUCKDUCKGO_SHAFT_DONE`
- Trimmed MP4 duration: 301.6s; size: 12,854,203 bytes.