### PR TITLE
[codex] fix Dependabot vulnerable transitives

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,10 @@
         <commons.csv.version>1.14.1</commons.csv.version>
         <appium.flutterfinder.version>1.0.14</appium.flutterfinder.version>
         <sikulix.version>2.0.5</sikulix.version>
+        <jython.slim.version>2.7.4</jython.slim.version>
+        <tess4j.version>5.19.0</tess4j.version>
+        <bouncycastle.version>1.84</bouncycastle.version>
+        <ant.version>1.10.17</ant.version>
         <poi.version>5.5.1</poi.version>
         <axe.selenium.version>4.12.0</axe.selenium.version>
         <pdfbox.version>3.0.7</pdfbox.version>
@@ -365,6 +369,36 @@
                 <groupId>io.appium</groupId>
                 <artifactId>java-client</artifactId>
                 <version>${appium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.python</groupId>
+                <artifactId>jython-slim</artifactId>
+                <version>${jython.slim.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.sourceforge.tess4j</groupId>
+                <artifactId>tess4j</artifactId>
+                <version>${tess4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcutil-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.ant</groupId>
+                <artifactId>ant</artifactId>
+                <version>${ant.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.aspectj</groupId>

--- a/shaft-mcp/pom.xml
+++ b/shaft-mcp/pom.xml
@@ -40,6 +40,11 @@
                 <artifactId>jackson-core</artifactId>
                 <version>${tools.jackson.core.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Summary

- Override stale SikuliX transitives that were keeping vulnerable Bouncy Castle, Ant, BeanUtils, Collections, XMLGraphics, and iText artifacts in the runtime graph.
- Pin `shaft-mcp` Jackson databind resolution back to the root-managed Jackson line.
- Keep this as dependency management only; no Java API or behavior changes.

## Root cause

`com.sikulix:sikulixapi:2.0.5` is the latest SikuliX API release, but its POM still points at old `jython-slim` and `tess4j` versions. Maven dependency management is the smallest fix: `jython-slim:2.7.4` moves Bouncy Castle to the `jdk18on` artifact family, `tess4j:5.19.0` removes the old `ghost4j` dependency chain, and explicit Bouncy Castle/Ant pins keep those transitives on patched releases.

`shaft-mcp` imports Spring dependency management and was resolving `jackson-databind` below SHAFT's root `jackson.version`; the module now explicitly manages databind to `${jackson.version}`.

## Validation

- `py -3 scripts/ci/validate_reactor_versions.py`
- `mvn -pl shaft-sikulix -am -DskipTests '-Dallure.generateReport=false' '-Dallure.open=false' '-Dallure.automaticallyOpen=false' dependency:tree '-Dincludes=org.bouncycastle:bcprov-jdk15on,org.bouncycastle:bcpkix-jdk15on,org.bouncycastle:bcprov-jdk18on,org.bouncycastle:bcpkix-jdk18on,org.bouncycastle:bcutil-jdk18on,org.apache.ant:ant,commons-beanutils:commons-beanutils,commons-collections:commons-collections,org.apache.xmlgraphics:xmlgraphics-commons,com.lowagie:itext,org.python:jython-slim,net.sourceforge.tess4j:tess4j,org.ghost4j:ghost4j'`
- `mvn -pl report-aggregate -am -DskipTests '-Dallure.generateReport=false' '-Dallure.open=false' '-Dallure.automaticallyOpen=false' dependency:tree '-Dincludes=org.bouncycastle:bcprov-jdk15on,org.bouncycastle:bcpkix-jdk15on,org.bouncycastle:bcprov-jdk18on,org.bouncycastle:bcpkix-jdk18on,org.bouncycastle:bcutil-jdk18on,org.apache.ant:ant,commons-beanutils:commons-beanutils,commons-collections:commons-collections,org.apache.xmlgraphics:xmlgraphics-commons,com.lowagie:itext,org.python:jython-slim,net.sourceforge.tess4j:tess4j,org.ghost4j:ghost4j'`
- `mvn -pl shaft-mcp -am -DskipTests '-Dallure.generateReport=false' '-Dallure.open=false' '-Dallure.automaticallyOpen=false' dependency:tree '-Dincludes=com.fasterxml.jackson.core:jackson-databind'`
- `mvn -pl shaft-sikulix,shaft-mcp -am test-compile -DskipTests '-Dallure.generateReport=false' '-Dallure.open=false' '-Dallure.automaticallyOpen=false' '-DlighthouseExecution=false' '-DgeneratePerformanceReport=false'`
- `mvn -pl shaft-sikulix,shaft-mcp -am package -DskipTests '-Dallure.generateReport=false' '-Dallure.open=false' '-Dallure.automaticallyOpen=false' '-DlighthouseExecution=false' '-DgeneratePerformanceReport=false'`

The focused dependency trees now resolve SikuliX through `jython-slim:2.7.4`, Bouncy Castle `*-jdk18on:1.84`, `ant:1.10.17`, and `tess4j:5.19.0`; the old `*-jdk15on`, `ghost4j`, BeanUtils, Collections, XMLGraphics, and iText artifacts are absent. The MCP tree resolves `jackson-databind:2.22.0`.
