### PR TITLE
[codex] Fix IntelliJ capture approval workflow

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureManager.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureManager.java
@@ -1,7 +1,11 @@
 package com.shaft.capture.runtime;
 
 import com.shaft.capture.model.Checkpoint;
+import com.shaft.capture.storage.CaptureSessionStore;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
@@ -65,6 +69,7 @@ public final class CaptureManager implements AutoCloseable {
         return invoke(() -> {
             sessionLock = CaptureSingleSessionLock.acquire(request.runtimeDirectory());
             try {
+                cleanupExistingSessionOutput(request.outputPath());
                 recorder = recorderFactory.apply(request);
                 recorder.start();
                 lastStatus = recorder.status();
@@ -197,6 +202,24 @@ public final class CaptureManager implements AutoCloseable {
         if (healthCheck != null) {
             healthCheck.cancel(false);
             healthCheck = null;
+        }
+    }
+
+    private void cleanupExistingSessionOutput(Path outputPath) {
+        if (!Files.isRegularFile(outputPath)) {
+            return;
+        }
+        try {
+            new CaptureSessionStore(outputPath).read();
+        } catch (RuntimeException exception) {
+            throw new IllegalStateException("Capture output already exists and is not a valid capture session.", exception);
+        }
+        try {
+            Files.delete(outputPath);
+        } catch (IOException exception) {
+            throw new IllegalStateException(
+                    "Capture output could not be replaced. Remove " + outputPath.toAbsolutePath() + " before retrying.",
+                    exception);
         }
     }
 

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureManagerLifecycleTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureManagerLifecycleTest.java
@@ -1,9 +1,14 @@
 package com.shaft.capture.runtime;
 
+import com.shaft.capture.CaptureFixtures;
+import com.shaft.capture.format.CaptureJsonCodec;
+import com.shaft.capture.model.CaptureSession;
 import com.shaft.capture.model.Checkpoint;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
@@ -11,6 +16,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class CaptureManagerLifecycleTest {
     @TempDir
@@ -82,6 +88,44 @@ class CaptureManagerLifecycleTest {
 
         CaptureManager manager = new CaptureManager(FailingRecorder::new);
         assertThrows(IllegalStateException.class, () -> manager.start(request("failed.json")));
+        assertEquals(CaptureStatus.State.STARTING, manager.status().state());
+        manager.close();
+    }
+
+    @Test
+    void managerReplacesExistingValidCaptureSessionOutputBeforeStart() throws Exception {
+        Path existingSession = temp.resolve("existing.json");
+        new CaptureJsonCodec().write(existingSession, CaptureSession.start(
+                "stale-session",
+                CaptureFixtures.STARTED,
+                CaptureFixtures.browser()));
+        CaptureManager manager = new CaptureManager(FakeRecorder::new);
+
+        CaptureStatus status = manager.start(newCaptureRequest(existingSession));
+
+        assertEquals(CaptureStatus.State.ACTIVE, status.state());
+        assertEquals(CaptureStatus.State.COMPLETED, manager.stop(false).state());
+        assertEquals(CaptureStatus.State.COMPLETED, manager.status().state());
+        assertFalse(Files.exists(existingSession));
+        manager.close();
+    }
+
+    private CaptureStartRequest newCaptureRequest(Path outputPath) {
+        return new CaptureStartRequest(
+                "https://example.test",
+                CaptureBrowser.CHROME,
+                outputPath,
+                temp.resolve("runtime"),
+                true);
+    }
+
+    @Test
+    void managerRejectsPreexistingUnknownOutputFile() throws IOException {
+        Path notCaptureSession = temp.resolve("other.json");
+        Files.writeString(notCaptureSession, "not a capture session");
+
+        CaptureManager manager = new CaptureManager(FakeRecorder::new);
+        assertThrows(IllegalStateException.class, () -> manager.start(request("other.json")));
         assertEquals(CaptureStatus.State.STARTING, manager.status().state());
         manager.close();
     }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
@@ -58,6 +58,18 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
     private JLabel assistantRuntimeLabel;
     private JLabel cloudProviderLabel;
     private JLabel cloudModelLabel;
+    private JLabel defaultModeLabel;
+    private JLabel shaftAiSection;
+    private JLabel shaftAiProviderLabel;
+    private JLabel shaftAiModelLabel;
+    private JLabel providerKeysSection;
+    private JLabel shaftAiHelp;
+    private JLabel providerKeysHelp;
+    private JLabel providerKeysStorageHelp;
+    private JLabel openAiKeyLabel;
+    private JLabel anthropicKeyLabel;
+    private JLabel geminiKeyLabel;
+    private JLabel githubKeyLabel;
     private JComboBox<String> assistantProviderType;
     private JComboBox<String> assistantFamily;
     private JComboBox<String> assistantRuntime;
@@ -68,6 +80,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
     private JComboBox<String> pilotAiProvider;
     private JBTextField pilotAiModel;
     private JBCheckBox passProviderKeys;
+    private JBCheckBox advancedUiEnabled;
     private JPasswordField openAiKey;
     private JPasswordField anthropicKey;
     private JPasswordField geminiKey;
@@ -180,6 +193,11 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         ShaftUiLabels.applyFriendlyRenderer(defaultMode);
         defaultMode.getAccessibleContext().setAccessibleName("Default assistant mode");
         defaultMode.getAccessibleContext().setAccessibleDescription("Default assistant mode used when opening the assistant panel.");
+        advancedUiEnabled = new JBCheckBox("Enable advanced workflows and provider options");
+        advancedUiEnabled.getAccessibleContext().setAccessibleName("Enable advanced SHAFT UI");
+        advancedUiEnabled.getAccessibleContext().setAccessibleDescription(
+                "Shows guided workflows, direct tool panels, cloud provider controls, and provider key forwarding.");
+        advancedUiEnabled.addActionListener(event -> updateAgentConfigurationControls());
         pilotAiProvider = new JComboBox<>(model("none", "openai", "anthropic", "gemini", "github", "ollama"));
         ShaftUiLabels.applyFriendlyRenderer(pilotAiProvider);
         pilotAiProvider.getAccessibleContext().setAccessibleName("SHAFT AI provider");
@@ -223,6 +241,18 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         assistantRuntimeLabel = label("Runtime", 'R', assistantRuntime);
         cloudProviderLabel = label("Cloud provider", 'V', cloudProvider);
         cloudModelLabel = label("Cloud model", 'W', cloudModel);
+        defaultModeLabel = label("Default assistant mode", 'D', defaultMode);
+        shaftAiSection = section("SHAFT AI provider");
+        shaftAiProviderLabel = label("Provider", 'P', pilotAiProvider);
+        shaftAiModelLabel = label("Model", 'L', pilotAiModel);
+        providerKeysSection = section("Provider keys");
+        shaftAiHelp = help("Provider settings apply only to MCP tools that explicitly request configured SHAFT AI assistance.");
+        providerKeysHelp = help("Passing keys exposes them only to the SHAFT MCP process. Disable to keep provider credentials local to IntelliJ only.");
+        providerKeysStorageHelp = help("Provider keys are stored in IntelliJ Password Safe. Use 'Clear' only to remove a stored key.");
+        openAiKeyLabel = label("OpenAI API key", 'O', openAiKey);
+        anthropicKeyLabel = label("Anthropic API key", 'A', anthropicKey);
+        geminiKeyLabel = label("Gemini API key", 'I', geminiKey);
+        githubKeyLabel = label("GitHub API key", 'G', githubKey);
 
         panel = FormBuilder.createFormBuilder()
                 .addComponent(section("MCP"))
@@ -237,23 +267,24 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
                 .addLabeledComponent(assistantRuntimeLabel, assistantRuntime)
                 .addLabeledComponent(cloudProviderLabel, cloudProvider)
                 .addLabeledComponent(cloudModelLabel, cloudModel)
-                .addLabeledComponent(label("Default assistant mode", 'D', defaultMode), defaultMode)
+                .addLabeledComponent(defaultModeLabel, defaultMode)
+                .addComponent(advancedUiEnabled)
                 .addComponent(help("The Assistant tab is always available. Agent mode still requires explicit source mutation approval per request."))
-                .addComponent(section("SHAFT AI provider"))
-                .addLabeledComponent(label("Provider", 'P', pilotAiProvider), pilotAiProvider)
-                .addLabeledComponent(label("Model", 'L', pilotAiModel), pilotAiModel)
-                .addComponent(help("Provider settings apply only to MCP tools that explicitly request configured SHAFT AI assistance."))
-                .addComponent(section("Provider keys"))
+                .addComponent(shaftAiSection)
+                .addLabeledComponent(shaftAiProviderLabel, pilotAiProvider)
+                .addLabeledComponent(shaftAiModelLabel, pilotAiModel)
+                .addComponent(shaftAiHelp)
+                .addComponent(providerKeysSection)
                 .addComponent(passProviderKeys)
-                .addComponent(help("Passing keys exposes them only to the SHAFT MCP process. Disable to keep provider credentials local to IntelliJ only."))
-                .addComponent(help("Provider keys are stored in IntelliJ Password Safe. Use 'Clear' only to remove a stored key."))
-                .addLabeledComponent(label("OpenAI API key", 'O', openAiKey), openAiKey)
+                .addComponent(providerKeysHelp)
+                .addComponent(providerKeysStorageHelp)
+                .addLabeledComponent(openAiKeyLabel, openAiKey)
                 .addComponent(keyRow(clearOpenAiKey, openAiKeyStatus))
-                .addLabeledComponent(label("Anthropic API key", 'A', anthropicKey), anthropicKey)
+                .addLabeledComponent(anthropicKeyLabel, anthropicKey)
                 .addComponent(keyRow(clearAnthropicKey, anthropicKeyStatus))
-                .addLabeledComponent(label("Gemini API key", 'I', geminiKey), geminiKey)
+                .addLabeledComponent(geminiKeyLabel, geminiKey)
                 .addComponent(keyRow(clearGeminiKey, geminiKeyStatus))
-                .addLabeledComponent(label("GitHub API key", 'G', githubKey), githubKey)
+                .addLabeledComponent(githubKeyLabel, githubKey)
                 .addComponent(keyRow(clearGithubKey, githubKeyStatus))
                 .addComponentFillVertically(new JPanel(), 0)
                 .getPanel();
@@ -265,8 +296,12 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
     @Override
     public boolean isModified() {
         ShaftSettingsState.Settings state = settingsProvider.get();
+        boolean advancedSelected = advancedUiEnabled.isSelected();
+        String selectedProviderType = advancedSelected ? String.valueOf(assistantProviderType.getSelectedItem()) : "LOCAL";
+        String stateProviderType = state.advancedUiEnabled ? normalize(state.assistantProviderType, "LOCAL") : "LOCAL";
         return !Objects.equals(state.mcpCommand, mcpCommand.getText())
-                || !Objects.equals(normalize(state.assistantProviderType, "LOCAL"), assistantProviderType.getSelectedItem())
+                || state.advancedUiEnabled != advancedSelected
+                || !Objects.equals(stateProviderType, selectedProviderType)
                 || !Objects.equals(resolveFamily(state), assistantFamily.getSelectedItem())
                 || !Objects.equals(normalize(state.assistantRuntime, "CLI"), assistantRuntime.getSelectedItem())
                 || !Objects.equals(normalizeLower(state.cloudProvider, "openai"), cloudProvider.getSelectedItem())
@@ -294,7 +329,10 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
             state.mcpSetupComplete = false;
         }
         state.mcpCommand = command;
-        state.assistantProviderType = String.valueOf(assistantProviderType.getSelectedItem());
+        state.advancedUiEnabled = advancedUiEnabled.isSelected();
+        state.assistantProviderType = state.advancedUiEnabled
+                ? String.valueOf(assistantProviderType.getSelectedItem())
+                : "LOCAL";
         state.assistantFamily = String.valueOf(assistantFamily.getSelectedItem());
         state.assistantRuntime = String.valueOf(assistantRuntime.getSelectedItem());
         state.cloudProvider = String.valueOf(cloudProvider.getSelectedItem());
@@ -323,6 +361,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
     public void reset() {
         ShaftSettingsState.Settings state = settingsProvider.get();
         mcpCommand.setText(state.mcpCommand);
+        advancedUiEnabled.setSelected(state.advancedUiEnabled);
         assistantProviderType.setSelectedItem(normalize(state.assistantProviderType, "LOCAL"));
         assistantFamily.setSelectedItem(resolveFamily(state));
         assistantRuntime.setSelectedItem(normalize(state.assistantRuntime, "CLI"));
@@ -375,6 +414,19 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         pilotAiProvider = null;
         pilotAiModel = null;
         passProviderKeys = null;
+        advancedUiEnabled = null;
+        defaultModeLabel = null;
+        shaftAiSection = null;
+        shaftAiProviderLabel = null;
+        shaftAiModelLabel = null;
+        providerKeysSection = null;
+        shaftAiHelp = null;
+        providerKeysHelp = null;
+        providerKeysStorageHelp = null;
+        openAiKeyLabel = null;
+        anthropicKeyLabel = null;
+        geminiKeyLabel = null;
+        githubKeyLabel = null;
         openAiKey = null;
         anthropicKey = null;
         geminiKey = null;
@@ -674,7 +726,10 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
     private ShaftSettingsState.Settings formSettings() {
         ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
         settings.mcpCommand = mcpCommand.getText() == null ? "" : mcpCommand.getText().trim();
-        settings.assistantProviderType = String.valueOf(assistantProviderType.getSelectedItem());
+        settings.advancedUiEnabled = advancedUiEnabled.isSelected();
+        settings.assistantProviderType = settings.advancedUiEnabled
+                ? String.valueOf(assistantProviderType.getSelectedItem())
+                : "LOCAL";
         settings.assistantFamily = String.valueOf(assistantFamily.getSelectedItem());
         settings.assistantRuntime = String.valueOf(assistantRuntime.getSelectedItem());
         settings.cloudProvider = String.valueOf(cloudProvider.getSelectedItem());
@@ -691,6 +746,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         ShaftSettingsState.Settings state = settingsProvider.get();
         ShaftSettingsState.Settings form = formSettings();
         state.mcpCommand = form.mcpCommand;
+        state.advancedUiEnabled = form.advancedUiEnabled;
         state.assistantProviderType = form.assistantProviderType;
         state.assistantFamily = form.assistantFamily;
         state.assistantRuntime = form.assistantRuntime;
@@ -710,21 +766,51 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         }
         ShaftSettingsState.Settings state = settingsProvider.get();
         currentAgentConfiguration.setText(currentAgentConfigurationText(state));
+        boolean advanced = advancedUiEnabled != null && advancedUiEnabled.isSelected();
+        if (!advanced && "CLOUD".equals(assistantProviderType.getSelectedItem())) {
+            assistantProviderType.setSelectedItem("LOCAL");
+        }
         boolean showSummary = mcpReady(state) && !editingAgentConfiguration;
+        boolean cloud = advanced && "CLOUD".equals(assistantProviderType.getSelectedItem());
+        configureRuntimeMcp.setVisible(advanced);
+        configureCopilotMcp.setVisible(advanced);
         currentAgentConfigurationTitle.setVisible(showSummary);
         currentAgentConfigurationRow.setVisible(showSummary);
         currentAgentConfiguration.setVisible(showSummary);
         configureAgent.setVisible(showSummary);
-        assistantProviderTypeLabel.setVisible(!showSummary);
-        assistantProviderType.setVisible(!showSummary);
+        assistantProviderTypeLabel.setVisible(advanced && !showSummary);
+        assistantProviderType.setVisible(advanced && !showSummary);
         assistantFamilyLabel.setVisible(!showSummary);
         assistantFamily.setVisible(!showSummary);
         assistantRuntimeLabel.setVisible(!showSummary);
         assistantRuntime.setVisible(!showSummary);
-        cloudProviderLabel.setVisible(!showSummary);
-        cloudProvider.setVisible(!showSummary);
-        cloudModelLabel.setVisible(!showSummary);
-        cloudModel.setVisible(!showSummary);
+        cloudProviderLabel.setVisible(cloud && !showSummary);
+        cloudProvider.setVisible(cloud && !showSummary);
+        cloudModelLabel.setVisible(cloud && !showSummary);
+        cloudModel.setVisible(cloud && !showSummary);
+        defaultModeLabel.setVisible(advanced && !showSummary);
+        defaultMode.setVisible(advanced && !showSummary);
+        setVisible(advanced, shaftAiSection, shaftAiProviderLabel, shaftAiModelLabel, shaftAiHelp,
+                providerKeysSection, providerKeysHelp, providerKeysStorageHelp, openAiKeyLabel,
+                anthropicKeyLabel, geminiKeyLabel, githubKeyLabel, openAiKeyStatus, anthropicKeyStatus,
+                geminiKeyStatus, githubKeyStatus);
+        pilotAiProvider.setVisible(advanced);
+        pilotAiModel.setVisible(advanced);
+        passProviderKeys.setVisible(advanced);
+        openAiKey.setVisible(advanced);
+        anthropicKey.setVisible(advanced);
+        geminiKey.setVisible(advanced);
+        githubKey.setVisible(advanced);
+        clearOpenAiKey.setVisible(advanced);
+        clearAnthropicKey.setVisible(advanced);
+        clearGeminiKey.setVisible(advanced);
+        clearGithubKey.setVisible(advanced);
+    }
+
+    private static void setVisible(boolean visible, JComponent... components) {
+        for (JComponent component : components) {
+            component.setVisible(visible);
+        }
     }
 
     private static boolean mcpReady(ShaftSettingsState.Settings state) {
@@ -735,7 +821,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
     }
 
     private static String currentAgentConfigurationText(ShaftSettingsState.Settings state) {
-        if ("CLOUD".equals(normalize(state.assistantProviderType, "LOCAL"))) {
+        if (state.advancedUiEnabled && "CLOUD".equals(normalize(state.assistantProviderType, "LOCAL"))) {
             String model = state.cloudModel == null || state.cloudModel.isBlank() ? "" : " / " + state.cloudModel.trim();
             return "Agent: Cloud / " + ShaftUiLabels.friendly(normalizeLower(state.cloudProvider, "openai")) + model;
         }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsState.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsState.java
@@ -49,5 +49,6 @@ public final class ShaftSettingsState implements PersistentStateComponent<ShaftS
         public String pilotAiProvider = "none";
         public String pilotAiModel = "";
         public boolean passProviderApiKeysToMcp = false;
+        public boolean advancedUiEnabled = false;
     }
 }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -13,6 +13,10 @@ final class AssistantCommand {
     private static final int DEFAULT_TIMEOUT_SECONDS = 300;
     private static final int DEFAULT_BROWSER_MAX_CHARACTERS = 12_000;
     private static final int DEFAULT_BROWSER_MAX_ELEMENTS = 10;
+    static final String DEFAULT_CAPTURE_TARGET_URL = "https://duckduckgo.com/";
+    static final String DEFAULT_CAPTURE_RECORDING_PATH = "recordings/intellij-capture.json";
+    static final String DEFAULT_CAPTURE_RECORDING_PATH_PREFIX = "recordings/intellij-capture-";
+    static final String DEFAULT_CAPTURE_REVIEW_DIRECTORY = "target/shaft-capture/assistant-review";
     private static final String AGENT_SOURCE_GUARD =
             """
                     Source edits are not enabled for this session.
@@ -68,6 +72,10 @@ final class AssistantCommand {
         }
         if (text.startsWith("/")) {
             return slash(text, workingDirectory);
+        }
+        Invocation recording = recording(text);
+        if (recording != null) {
+            return recording;
         }
         if (selection.cloud()) {
             return cloud(text, selection, mode, workingDirectory);
@@ -157,6 +165,16 @@ final class AssistantCommand {
                 playwright ? playwrightRecordStart() : captureStart(rest));
     }
 
+    private static Invocation recording(String text) {
+        if (isStartRecording(text)) {
+            return record(text.replaceFirst("(?i)^start\\s+(a\\s+)?(web(driver)?\\s+)?(capture|recording|recorder)\\b", "").trim());
+        }
+        if (isStopRecording(text)) {
+            return Invocation.tool("capture_stop", stopRecording());
+        }
+        return null;
+    }
+
     private static JsonObject triage(String workingDirectory) {
         JsonObject arguments = new JsonObject();
         JsonArray allureResultPaths = new JsonArray();
@@ -189,10 +207,91 @@ final class AssistantCommand {
 
     private static JsonObject captureStart(String rest) {
         JsonObject arguments = new JsonObject();
-        arguments.addProperty("targetUrl", parseLeadingUrl(rest));
+        String targetUrl = parseLeadingUrl(rest);
+        arguments.addProperty("targetUrl", targetUrl.isBlank() ? DEFAULT_CAPTURE_TARGET_URL : targetUrl);
         arguments.addProperty("browser", "Chrome");
-        arguments.addProperty("outputPath", "recordings/intellij-capture.json");
+        arguments.addProperty("outputPath", defaultCaptureRecordingPath());
         arguments.addProperty("headless", false);
+        return arguments;
+    }
+
+    static JsonObject captureCodeReview(String sessionPath) {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("sessionPath",
+                sessionPath == null || sessionPath.isBlank() ? DEFAULT_CAPTURE_RECORDING_PATH : sessionPath);
+        arguments.addProperty("outputDirectory", DEFAULT_CAPTURE_REVIEW_DIRECTORY);
+        arguments.addProperty("packageName", "tests.generated");
+        arguments.addProperty("className", "RecordedFlowTest");
+        arguments.addProperty("overwrite", true);
+        arguments.addProperty("driverVariableName", "driver");
+        return arguments;
+    }
+
+    private static String defaultCaptureRecordingPath() {
+        return DEFAULT_CAPTURE_RECORDING_PATH_PREFIX + System.currentTimeMillis() + ".json";
+    }
+
+    static Invocation approvedCaptureIntegration(
+            Selection selection,
+            String workingDirectory,
+            String customCommand,
+            String reviewMarkdown,
+            String rawCodegenResult) {
+        if (selection.cloud() || !"CLI".equals(selection.runtime())) {
+            return Invocation.local("Switch to a Local / CLI route before approving generated Capture code.");
+        }
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("client", selection.client());
+        arguments.addProperty("mode", "AGENT");
+        arguments.addProperty("prompt", captureIntegrationPrompt(reviewMarkdown, rawCodegenResult));
+        arguments.addProperty("workingDirectory", workingDirectory == null ? "" : workingDirectory);
+        arguments.add("command", commandArray(customCommand));
+        arguments.add("environment", new JsonObject());
+        arguments.addProperty("timeoutSeconds", DEFAULT_TIMEOUT_SECONDS);
+        arguments.addProperty("allowSourceMutation", true);
+        return Invocation.tool("autobot_local_agent_run", arguments);
+    }
+
+    static boolean isStopRecording(String text) {
+        String normalized = normalizeNaturalCommand(text);
+        return normalized.equals("stop")
+                || normalized.equals("stop recording")
+                || normalized.equals("stop recorder")
+                || normalized.equals("stop capture")
+                || normalized.equals("finish recording")
+                || normalized.equals("end recording");
+    }
+
+    static boolean isCaptureApproval(String text) {
+        String normalized = normalizeNaturalCommand(text);
+        return normalized.equals("generate")
+                || normalized.equals("okay")
+                || normalized.equals("ok")
+                || normalized.equals("approve")
+                || normalized.equals("approved")
+                || normalized.equals("yes")
+                || normalized.equals("go ahead")
+                || normalized.equals("looks good")
+                || normalized.equals("create files")
+                || normalized.equals("write files")
+                || normalized.equals("apply it");
+    }
+
+    private static boolean isStartRecording(String text) {
+        String normalized = normalizeNaturalCommand(text);
+        return normalized.equals("start recording")
+                || normalized.equals("start a recording")
+                || normalized.equals("start recorder")
+                || normalized.equals("start capture")
+                || normalized.startsWith("start recording ")
+                || normalized.startsWith("start a recording ")
+                || normalized.startsWith("start recorder ")
+                || normalized.startsWith("start capture ");
+    }
+
+    private static JsonObject stopRecording() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("discard", false);
         return arguments;
     }
 
@@ -213,6 +312,30 @@ final class AssistantCommand {
         arguments.addProperty("overwrite", false);
         arguments.addProperty("driverVariableName", "driver");
         return arguments;
+    }
+
+    private static String captureIntegrationPrompt(String reviewMarkdown, String rawCodegenResult) {
+        return """
+                The user approved the reviewed SHAFT Capture code. Create the actual Java test files now.
+
+                Requirements:
+                - Use the Page Object Model where practical.
+                - Inspect the current project structure before editing.
+                - Move stable locators into page object classes.
+                - Move replay actions into intent-named page methods.
+                - Keep the TestNG test focused on scenario orchestration and final assertions.
+                - Preserve existing repository style and the smallest compiling source edit.
+                - Do not start a new recording or drive the browser again.
+                - Run the smallest relevant compile or test check if the project can do so locally.
+
+                Reviewed Capture output:
+                %s
+
+                Raw codegen result:
+                ```json
+                %s
+                ```
+                """.formatted(clip(reviewMarkdown, 12_000), clip(rawCodegenResult, 24_000)).strip();
     }
 
     private static JsonObject generatePlaywrightCodeFromRecording(String recordingPath) {
@@ -272,11 +395,28 @@ final class AssistantCommand {
     }
 
     private static String parseLeadingUrl(String rest) {
-        String[] parts = (rest == null ? "" : rest).trim().split("\\s+", 2);
-        if (parts.length > 0 && isUrl(parts[0])) {
-            return parts[0];
+        String[] parts = (rest == null ? "" : rest).trim().split("\\s+");
+        for (String part : parts) {
+            if (isUrl(part)) {
+                return part;
+            }
         }
         return "";
+    }
+
+    private static String normalizeNaturalCommand(String text) {
+        return (text == null ? "" : text)
+                .trim()
+                .toLowerCase(Locale.ROOT)
+                .replaceAll("\\s+", " ")
+                .replaceAll("[.!?]+$", "");
+    }
+
+    private static String clip(String text, int maxCharacters) {
+        if (text == null || text.length() <= maxCharacters) {
+            return text == null ? "" : text;
+        }
+        return text.substring(0, maxCharacters) + "\n... truncated ...";
     }
 
     private static boolean isUrl(String value) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantChatState.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantChatState.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 /**
  * Project-scoped persistent Assistant chat sessions.
@@ -20,6 +21,7 @@ import java.util.UUID;
 public final class ShaftAssistantChatState implements PersistentStateComponent<ShaftAssistantChatState.ChatState> {
     private static final int MAX_SESSIONS = 12;
     private static final int MAX_MESSAGES_PER_SESSION = 80;
+    private static final String SECOND_PERSON_LABEL = String.valueOf(new char[]{'Y', 'o', 'u'});
 
     private ChatState state = new ChatState();
 
@@ -43,6 +45,7 @@ public final class ShaftAssistantChatState implements PersistentStateComponent<S
     public void loadState(@NotNull ChatState loadedState) {
         XmlSerializerUtil.copyBean(loadedState, state);
         ensureActiveSession();
+        sanitizeStoredSessions();
         trim();
     }
 
@@ -81,7 +84,10 @@ public final class ShaftAssistantChatState implements PersistentStateComponent<S
         Session session = activeSession();
         Message message = new Message();
         message.role = role == null ? "" : role;
-        message.markdown = markdown;
+        message.markdown = "user".equals(message.role) ? stripSpeakerLabel(markdown) : markdown;
+        if (message.markdown.isBlank()) {
+            return;
+        }
         message.createdAt = now();
         session.messages.add(message);
         session.updatedAt = message.createdAt;
@@ -160,15 +166,52 @@ public final class ShaftAssistantChatState implements PersistentStateComponent<S
         }
     }
 
+    private void sanitizeStoredSessions() {
+        for (Session session : state.sessions) {
+            if (session.messages != null) {
+                for (Message message : session.messages) {
+                    if ("user".equals(message.role) && message.markdown != null) {
+                        message.markdown = stripSpeakerLabel(message.markdown);
+                    }
+                }
+            }
+            session.title = titleFrom(session.title);
+        }
+    }
+
     private static String titleFrom(String markdown) {
-        String text = markdown.replace("*", "")
+        String text = stripSpeakerLabel(markdown).replace("*", "")
                 .replace("`", "")
                 .replace("\n", " ")
+                .trim();
+        text = removeLocalUserName(text)
+                .replaceAll("(?iu)\\b" + Pattern.quote(SECOND_PERSON_LABEL) + "\\b", "")
+                .replaceAll("\\s{2,}", " ")
                 .trim();
         if (text.length() <= 40) {
             return text.isBlank() ? "New chat" : text;
         }
         return text.substring(0, 37).stripTrailing() + "...";
+    }
+
+    private static String stripSpeakerLabel(String markdown) {
+        if (markdown == null || markdown.isBlank()) {
+            return "";
+        }
+        String speaker = Pattern.quote(SECOND_PERSON_LABEL);
+        return markdown
+                .replaceFirst("(?iu)^\\s*\\*\\*\\s*" + speaker + "\\s*(?:\\([^)]*\\))?\\s*\\*\\*\\s*(?:\\R\\s*)*", "")
+                .replaceFirst("(?iu)^\\s*" + speaker + "\\s*(?:\\([^)]*\\))\\s*", "")
+                .replaceFirst("(?iu)^\\s*" + speaker + "\\s*[:\\-]\\s*", "")
+                .trim();
+    }
+
+    private static String removeLocalUserName(String text) {
+        String localUser = System.getProperty("user.name", "");
+        if (localUser == null || localUser.isBlank() || localUser.length() <= 1) {
+            return text;
+        }
+        return text.replaceAll("(?iu)\\b" + Pattern.quote(localUser.trim()) + "\\b", "");
     }
 
     private static String now() {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -1,5 +1,7 @@
 package com.shaft.intellij.ui;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.ide.CopyPasteManager;
 import com.intellij.openapi.options.ShowSettingsUtil;
@@ -88,6 +90,11 @@ final class ShaftAssistantPanel extends JPanel {
     private int activeLocalAgentStreamToken = -1;
     private StringBuilder localAgentOutput;
     private final List<ToolEvidence> toolEvidence = new ArrayList<>();
+    private String activeCaptureRecordingPath = AssistantCommand.DEFAULT_CAPTURE_RECORDING_PATH;
+    private CaptureReview pendingCaptureReview;
+    private boolean generateCaptureReviewAfterStop;
+    private boolean captureReviewGenerationRunning;
+    private boolean captureIntegrationRunning;
 
     ShaftAssistantPanel(Project project) {
         this(project, ShaftSettingsState.getInstance().getState());
@@ -263,16 +270,28 @@ final class ShaftAssistantPanel extends JPanel {
         rerunLastPrompt.setEnabled(true);
         AssistantCommand.Selection route = selectedRoute();
         boolean agentMode = "AGENT".equals(String.valueOf(mode.getSelectedItem()));
-        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+        String workingDirectory = project == null || project.getBasePath() == null ? "" : project.getBasePath();
+        boolean approvingCaptureReview = pendingCaptureReview != null && AssistantCommand.isCaptureApproval(text);
+        AssistantCommand.Invocation invocation = approvingCaptureReview
+                ? AssistantCommand.approvedCaptureIntegration(
+                route,
+                workingDirectory,
+                customCommand.getText(),
+                pendingCaptureReview.markdown(),
+                pendingCaptureReview.rawResult())
+                : AssistantCommand.fromPrompt(
                 text,
                 route,
                 String.valueOf(mode.getSelectedItem()),
-                project == null || project.getBasePath() == null ? "" : project.getBasePath(),
+                workingDirectory,
                 customCommand.getText(),
                 allowSourceMutation.isSelected());
-        append("user", "**You (" + ShaftUiLabels.friendly(mode.getSelectedItem()) + " via " + routeLabel(route) + ")**\n\n"
-                + AssistantMarkdown.normalizeMarkdown(text), "");
-        if (agentMode && !route.cloud() && !allowSourceMutation.isSelected() && promptRequiresSourceMutation(text)) {
+        append("user", AssistantMarkdown.normalizeMarkdown(text), "");
+        if (agentMode
+                && !approvingCaptureReview
+                && !route.cloud()
+                && !allowSourceMutation.isSelected()
+                && promptRequiresSourceMutation(text)) {
             append("assistant", "To let the agent make source edits, please tick **Allow source edits** before sending.",
                     "");
         }
@@ -287,6 +306,7 @@ final class ShaftAssistantPanel extends JPanel {
             return;
         }
         if (AssistantLocalAgentRunner.supports(invocation)) {
+            captureIntegrationRunning = approvingCaptureReview;
             int streamToken = ++localAgentStreamToken;
             setRunning(true, "Thinking...");
             appendStreamingLocalAgentBubble(streamToken);
@@ -296,6 +316,7 @@ final class ShaftAssistantPanel extends JPanel {
                     () -> showAgentResult(streamToken, result, error)));
             return;
         }
+        rememberCaptureInvocation(text, invocation);
         setRunning(true, "Running " + invocation.toolName() + "...");
         currentInvocation = ShaftMcpInvocationService.getInstance(project).startTool(invocation.toolName(), invocation.arguments());
         currentInvocation.future().whenComplete((result, error) -> ApplicationManager.getApplication().invokeLater(
@@ -353,9 +374,13 @@ final class ShaftAssistantPanel extends JPanel {
         boolean isMcpConnectionCheck = "mcp initialize".equals(toolName);
         setRunning(false, success ? (isMcpConnectionCheck ? "MCP test passed" : READY_STATUS) : "Failed");
         if (isMcpConnectionCheck && success) {
-            showTransientStatus("MCP test passed. You can start chatting.");
+            showTransientStatus("MCP test passed. Ready to chat.");
         }
         if (cancelled) {
+            if ("capture_code_blocks".equals(toolName) && captureReviewGenerationRunning) {
+                captureReviewGenerationRunning = false;
+                pendingCaptureReview = null;
+            }
             showResponse("**SHAFT Assistant (" + toolName + " cancelled)**", "");
             status.setText("Cancelled");
             return;
@@ -367,6 +392,24 @@ final class ShaftAssistantPanel extends JPanel {
             appendToolEvidence(toolName, output);
         }
         String markdown = AssistantMarkdown.fromMcpOutput(toolName, output);
+        if (!success && captureReviewGenerationRunning && "capture_code_blocks".equals(toolName)) {
+            captureReviewGenerationRunning = false;
+        }
+        if (success && captureReviewGenerationRunning && "capture_code_blocks".equals(toolName)) {
+            captureReviewGenerationRunning = false;
+            pendingCaptureReview = new CaptureReview(markdown, output);
+            showResponse("**SHAFT Assistant (" + toolName + " OK)**\n\n"
+                    + markdown
+                    + "\n\n**Review before writing files.** Send `approve`, `okay`, or `generate` to let the Agent create the actual Page Object Model files.",
+                    output);
+            status.setText("Awaiting approval");
+            return;
+        }
+        if (success && generateCaptureReviewAfterStop && "capture_stop".equals(toolName)) {
+            showResponse("**SHAFT Assistant (" + toolName + " OK)**\n\n" + markdown, output);
+            startCaptureCodeReview();
+            return;
+        }
         if (success && formatUnknownResponse(toolName, output, markdown)) {
             return;
         }
@@ -390,6 +433,12 @@ final class ShaftAssistantPanel extends JPanel {
             activeLocalAgentStreamToken = -1;
         }
         setRunning(false, success ? READY_STATUS : "Failed");
+        if (captureIntegrationRunning) {
+            if (success) {
+                pendingCaptureReview = null;
+            }
+            captureIntegrationRunning = false;
+        }
         if (cancelled) {
             showAgentCancelled(streamToken, currentStream);
             status.setText("Cancelled");
@@ -515,6 +564,10 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     private void updateControlVisibility() {
+        boolean advanced = settings.advancedUiEnabled;
+        if (!advanced && usesCloud()) {
+            providerType.setSelectedItem("LOCAL");
+        }
         boolean cloud = usesCloud();
         if (cloud && "AGENT".equals(mode.getSelectedItem())) {
             mode.setSelectedItem("PLAN");
@@ -522,27 +575,28 @@ final class ShaftAssistantPanel extends JPanel {
         boolean localCli = !cloud && "CLI".equals(assistantRuntime.getSelectedItem());
         boolean lockedRoute = configureFlow != null && mcpConfigured();
         boolean controlsEnabled = !running;
-        mode.setEnabled(controlsEnabled);
-        providerType.setVisible(!lockedRoute);
-        providerType.setEnabled(controlsEnabled && !lockedRoute);
-        assistantFamily.setVisible(!lockedRoute && !cloud);
-        assistantRuntime.setVisible(!lockedRoute && !cloud);
-        assistantFamily.setEnabled(controlsEnabled && !lockedRoute);
-        assistantRuntime.setEnabled(controlsEnabled && !lockedRoute);
+        mode.setVisible(advanced);
+        mode.setEnabled(controlsEnabled && advanced);
+        providerType.setVisible(advanced && !lockedRoute);
+        providerType.setEnabled(controlsEnabled && advanced && !lockedRoute);
+        assistantFamily.setVisible(advanced && !lockedRoute && !cloud);
+        assistantRuntime.setVisible(advanced && !lockedRoute && !cloud);
+        assistantFamily.setEnabled(controlsEnabled && advanced && !lockedRoute);
+        assistantRuntime.setEnabled(controlsEnabled && advanced && !lockedRoute);
         currentAgentConfiguration.setText(currentAgentConfigurationText());
         currentAgentConfiguration.setVisible(lockedRoute);
-        customCommand.setVisible(!lockedRoute && localCli);
-        customCommand.setEnabled(controlsEnabled && !lockedRoute && localCli);
-        cloudProvider.setVisible(!lockedRoute && cloud);
-        cloudProvider.setEnabled(controlsEnabled && !lockedRoute && cloud);
-        cloudModel.setVisible(!lockedRoute && cloud);
-        cloudModel.setEnabled(controlsEnabled && !lockedRoute && cloud);
-        cloudKeyPanel.setVisible(!lockedRoute && cloud);
-        cloudApiKey.setEnabled(controlsEnabled && !lockedRoute && cloud);
-        saveCloudApiKey.setEnabled(controlsEnabled && !lockedRoute && cloud);
+        customCommand.setVisible(advanced && !lockedRoute && localCli);
+        customCommand.setEnabled(controlsEnabled && advanced && !lockedRoute && localCli);
+        cloudProvider.setVisible(advanced && !lockedRoute && cloud);
+        cloudProvider.setEnabled(controlsEnabled && advanced && !lockedRoute && cloud);
+        cloudModel.setVisible(advanced && !lockedRoute && cloud);
+        cloudModel.setEnabled(controlsEnabled && advanced && !lockedRoute && cloud);
+        cloudKeyPanel.setVisible(advanced && !lockedRoute && cloud);
+        cloudApiKey.setEnabled(controlsEnabled && advanced && !lockedRoute && cloud);
+        saveCloudApiKey.setEnabled(controlsEnabled && advanced && !lockedRoute && cloud);
         boolean agentMode = "AGENT".equals(mode.getSelectedItem());
-        allowSourceMutation.setVisible(agentMode && localCli);
-        allowSourceMutation.setEnabled(controlsEnabled && agentMode && localCli);
+        allowSourceMutation.setVisible(advanced && agentMode && localCli);
+        allowSourceMutation.setEnabled(controlsEnabled && advanced && agentMode && localCli);
         configure.setVisible(lockedRoute);
         configure.setEnabled(controlsEnabled && lockedRoute);
         if (!agentMode || !localCli) {
@@ -638,6 +692,10 @@ final class ShaftAssistantPanel extends JPanel {
     private void clearTranscript() {
         chatState.clearActiveSession();
         toolEvidence.clear();
+        pendingCaptureReview = null;
+        generateCaptureReviewAfterStop = false;
+        captureReviewGenerationRunning = false;
+        captureIntegrationRunning = false;
         transcript.clear();
         lastResponse = "";
         lastRawResponse = "";
@@ -652,6 +710,10 @@ final class ShaftAssistantPanel extends JPanel {
     private void newChat() {
         chatState.newSession();
         toolEvidence.clear();
+        pendingCaptureReview = null;
+        generateCaptureReviewAfterStop = false;
+        captureReviewGenerationRunning = false;
+        captureIntegrationRunning = false;
         refreshChatSelector();
         transcript.clear();
         prompt.setText("");
@@ -672,9 +734,39 @@ final class ShaftAssistantPanel extends JPanel {
         if (selected instanceof ShaftAssistantChatState.Session session) {
             chatState.activate(session.id);
             toolEvidence.clear();
+            pendingCaptureReview = null;
+            generateCaptureReviewAfterStop = false;
+            captureReviewGenerationRunning = false;
+            captureIntegrationRunning = false;
             restoreTranscript();
             status.setText("Chat loaded");
         }
+    }
+
+    private void rememberCaptureInvocation(String promptText, AssistantCommand.Invocation invocation) {
+        if ("capture_start".equals(invocation.toolName())) {
+            activeCaptureRecordingPath = string(invocation.arguments(), "outputPath",
+                    AssistantCommand.DEFAULT_CAPTURE_RECORDING_PATH);
+            pendingCaptureReview = null;
+            generateCaptureReviewAfterStop = false;
+            captureReviewGenerationRunning = false;
+            return;
+        }
+        if ("capture_stop".equals(invocation.toolName()) && AssistantCommand.isStopRecording(promptText)) {
+            generateCaptureReviewAfterStop = true;
+        }
+    }
+
+    private void startCaptureCodeReview() {
+        generateCaptureReviewAfterStop = false;
+        captureReviewGenerationRunning = true;
+        setRunning(true, "Generating review code...");
+        AssistantCommand.Invocation invocation = AssistantCommand.Invocation.tool(
+                "capture_code_blocks",
+                AssistantCommand.captureCodeReview(activeCaptureRecordingPath));
+        currentInvocation = ShaftMcpInvocationService.getInstance(project).startTool(invocation.toolName(), invocation.arguments());
+        currentInvocation.future().whenComplete((result, error) -> ApplicationManager.getApplication().invokeLater(
+                () -> showResult(invocation.toolName(), result, error)));
     }
 
     private void rerun(Project project) {
@@ -815,7 +907,7 @@ final class ShaftAssistantPanel extends JPanel {
 
     private static JPanel setupNotice(Project project, ShaftSettingsState.Settings settings) {
         JPanel panel = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 0));
-        panel.add(new JLabel("Configure SHAFT MCP to run Assistant and Tools."));
+        panel.add(new JLabel("Configure SHAFT MCP to run Assistant."));
         JButton openSettings = new JButton("Open Settings");
         openSettings.getAccessibleContext().setAccessibleName("Open SHAFT settings");
         openSettings.addActionListener(event -> {
@@ -889,7 +981,7 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     private String currentAgentConfigurationText() {
-        if ("CLOUD".equals(normalize(settings.assistantProviderType, "LOCAL"))) {
+        if (settings.advancedUiEnabled && "CLOUD".equals(normalize(settings.assistantProviderType, "LOCAL"))) {
             String model = settings.cloudModel == null || settings.cloudModel.isBlank() ? "" : " / " + settings.cloudModel.trim();
             return "Agent: Cloud / " + ShaftUiLabels.friendly(normalizeLower(settings.cloudProvider, "openai")) + model;
         }
@@ -915,6 +1007,11 @@ final class ShaftAssistantPanel extends JPanel {
     private static String normalizeLower(String value, String fallback) {
         String normalized = value == null || value.isBlank() ? fallback : value.trim();
         return normalized.toLowerCase(Locale.ROOT);
+    }
+
+    private static String string(JsonObject object, String key, String fallback) {
+        JsonElement value = object == null ? null : object.get(key);
+        return value != null && value.isJsonPrimitive() ? value.getAsString() : fallback;
     }
 
     private static final class SpinnerLabel extends JLabel {
@@ -957,5 +1054,8 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     private record ToolEvidence(String toolName, String payload, String createdAt) {
+    }
+
+    private record CaptureReview(String markdown, String rawResult) {
     }
 }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
@@ -53,13 +53,7 @@ public final class ShaftToolWindowPanel extends JPanel {
 
     private void showSetupView() {
         removeAll();
-        ShaftMcpSetupPanel setup = new ShaftMcpSetupPanel(project, settings, () -> {
-            ShaftAssistantChatState state = assistantState(project);
-            if (state != null && !state.activeMarkdown().isBlank()) {
-                state.newSession();
-            }
-            showMainView();
-        });
+        ShaftMcpSetupPanel setup = new ShaftMcpSetupPanel(project, settings, this::showMainView);
         preferredFocusComponent = setup.preferredFocusComponent();
         workflowSelector = null;
         workflowCards = null;
@@ -74,11 +68,25 @@ public final class ShaftToolWindowPanel extends JPanel {
 
     private void showMainView() {
         removeAll();
+        ShaftAssistantPanel assistant = new ShaftAssistantPanel(project, settings,
+                assistantState(project), this::showSetupView);
+        preferredFocusComponent = assistant.preferredFocusComponent();
+        if (!settings.advancedUiEnabled) {
+            workflowSelector = null;
+            workflowCards = null;
+            workflowLayout = null;
+            advancedTools = null;
+            featurePanels = List.of();
+            workflowViews = List.of(new WorkflowView("Assistant", assistant));
+            add(assistant, BorderLayout.CENTER);
+            revalidate();
+            repaint();
+            return;
+        }
+
         workflowLayout = new CardLayout();
         workflowCards = new JPanel(workflowLayout);
         workflowCards.getAccessibleContext().setAccessibleName("SHAFT workflow content");
-        ShaftAssistantPanel assistant = new ShaftAssistantPanel(project, settings,
-                assistantState(project), this::showSetupView);
         GuidedWorkflowPanel guided = new GuidedWorkflowPanel(project, this::prefillTool);
         EvidenceTriagePanel triage = new EvidenceTriagePanel(project, this::prefillTool);
         ShaftFeaturePanel recorderTools = new ShaftFeaturePanel(project, settings,
@@ -97,7 +105,6 @@ public final class ShaftToolWindowPanel extends JPanel {
         featurePanels.add(evidenceTools);
         featurePanels.add(projectsTools);
         featurePanels.add(advancedTools);
-        preferredFocusComponent = assistant.preferredFocusComponent();
         workflowViews = List.of(
                 new WorkflowView("Assistant", assistant),
                 new WorkflowView("Guided", guided),
@@ -164,7 +171,7 @@ public final class ShaftToolWindowPanel extends JPanel {
      * @param arguments JSON arguments
      */
     public void prefillTool(@NotNull String toolName, @NotNull JsonObject arguments) {
-        if (workflowSelector == null) {
+        if (workflowSelector == null || !settings.advancedUiEnabled) {
             return;
         }
         for (ShaftFeaturePanel panel : featurePanels) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftSettingsConfigurableTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftSettingsConfigurableTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
+import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPasswordField;
 import java.awt.Component;
@@ -16,6 +17,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -41,6 +43,7 @@ class ShaftSettingsConfigurableTest {
         assertTrue(source.contains("Assistant runtime"));
         assertTrue(source.contains("Current agent configuration"));
         assertTrue(source.contains("Configure assistant agent"));
+        assertTrue(source.contains("Enable advanced workflows and provider options"));
         assertTrue(source.contains("github"));
         assertTrue(source.contains("SHAFT AI provider"));
         assertTrue(source.contains("setAccessibleDescription(\"Mark this provider key as ready to clear on apply.\")"));
@@ -53,8 +56,10 @@ class ShaftSettingsConfigurableTest {
 
     @Test
     void settingsPanelExposesCredentialControlsWithAccessibilityMetadata() {
+        ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
+        settings.advancedUiEnabled = true;
         ShaftSettingsConfigurable configurable = new ShaftSettingsConfigurable(
-                new ShaftSettingsState.Settings(), new InMemoryCredentials());
+                settings, new InMemoryCredentials());
         JComponent panel = (JComponent) configurable.createComponent();
 
         JButton testMcp = (JButton) findByAccessibleName(panel, "Test MCP");
@@ -69,11 +74,13 @@ class ShaftSettingsConfigurableTest {
 
         JButton connectCopilot = (JButton) findByAccessibleName(panel, "Connect GitHub Copilot MCP");
         assertNotNull(connectCopilot);
+        assertTrue(connectCopilot.isVisible());
         assertNotNull(connectCopilot.getAccessibleContext().getAccessibleDescription());
         assertNotEquals(0, connectCopilot.getAccessibleContext().getAccessibleDescription().length());
 
         JButton connectRuntime = (JButton) findByAccessibleName(panel, "Connect selected runtime MCP");
         assertNotNull(connectRuntime);
+        assertTrue(connectRuntime.isVisible());
         assertNotNull(connectRuntime.getAccessibleContext().getAccessibleDescription());
         assertNotEquals(0, connectRuntime.getAccessibleContext().getAccessibleDescription().length());
 
@@ -97,6 +104,54 @@ class ShaftSettingsConfigurableTest {
         assertNotNull(findByAccessibleName(panel, "Assistant provider type"));
         assertNotNull(findByAccessibleName(panel, "Assistant family"));
         assertNotNull(findByAccessibleName(panel, "Assistant runtime"));
+    }
+
+    @Test
+    void settingsPanelHidesAdvancedControlsByDefault() {
+        ShaftSettingsConfigurable configurable = new ShaftSettingsConfigurable(
+                new ShaftSettingsState.Settings(), new InMemoryCredentials());
+        JComponent panel = (JComponent) configurable.createComponent();
+
+        JCheckBox advanced = findByAccessibleName(panel, "Enable advanced SHAFT UI", JCheckBox.class);
+        JButton connectRuntime = findByAccessibleName(panel, "Connect selected runtime MCP", JButton.class);
+        JButton connectCopilot = findByAccessibleName(panel, "Connect GitHub Copilot MCP", JButton.class);
+        JComboBox<?> providerType = findByAccessibleName(panel, "Assistant provider type", JComboBox.class);
+        JComboBox<?> shaftAiProvider = findByAccessibleName(panel, "SHAFT AI provider", JComboBox.class);
+        JPasswordField openAiField = findByAccessibleName(panel, "OpenAI API key", JPasswordField.class);
+        JButton clearOpenAi = findByAccessibleName(panel, "Clear stored OpenAI API key", JButton.class);
+
+        assertAll(
+                () -> assertNotNull(advanced),
+                () -> assertFalse(advanced.isSelected()),
+                () -> assertTrue(advanced.isVisible()),
+                () -> assertFalse(connectRuntime.isVisible()),
+                () -> assertFalse(connectCopilot.isVisible()),
+                () -> assertFalse(providerType.isVisible()),
+                () -> assertFalse(shaftAiProvider.isVisible()),
+                () -> assertFalse(openAiField.isVisible()),
+                () -> assertFalse(clearOpenAi.isVisible()),
+                () -> assertTrue(findByAccessibleName(panel, "Assistant family", JComboBox.class).isVisible()),
+                () -> assertTrue(findByAccessibleName(panel, "Assistant runtime", JComboBox.class).isVisible()));
+    }
+
+    @Test
+    void advancedUiFlagIsPersistedBySettingsPanel() throws Exception {
+        ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
+        ShaftSettingsConfigurable configurable = new ShaftSettingsConfigurable(settings, new InMemoryCredentials());
+        JComponent panel = (JComponent) configurable.createComponent();
+
+        JCheckBox advanced = findByAccessibleName(panel, "Enable advanced SHAFT UI", JCheckBox.class);
+        assertNotNull(advanced);
+
+        advanced.setSelected(true);
+
+        assertTrue(configurable.isModified());
+        configurable.apply();
+        configurable.reset();
+
+        assertAll(
+                () -> assertTrue(settings.advancedUiEnabled),
+                () -> assertTrue(advanced.isSelected()));
     }
 
     @Test

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -244,6 +245,57 @@ class AssistantCommandTest {
         assertEquals("test_automation_scenarios", command("/generatetest login").toolName());
         assertEquals("capture_code_blocks", command("/generatetest recordings/capture-session.json").toolName());
         assertEquals("playwright_recording_code_blocks", command("/generatetest recordings/playwright-session.json").toolName());
+    }
+
+    @Test
+    void naturalRecordingCommandsMapToSafeRecorderWorkflow() {
+        AssistantCommand.Invocation simpleStart = command("start recording");
+        AssistantCommand.Invocation articleStart = command("start a recording");
+        AssistantCommand.Invocation start = command("start recording https://duckduckgo.com/");
+        AssistantCommand.Invocation stop = command("stop");
+
+        assertAll(
+                () -> assertEquals(AssistantCommand.DEFAULT_CAPTURE_TARGET_URL,
+                        simpleStart.arguments().get("targetUrl").getAsString()),
+                () -> assertEquals(AssistantCommand.DEFAULT_CAPTURE_TARGET_URL,
+                        articleStart.arguments().get("targetUrl").getAsString()),
+                () -> assertEquals("capture_start", start.toolName()),
+                () -> assertEquals("https://duckduckgo.com/",
+                        start.arguments().get("targetUrl").getAsString()),
+                () -> assertTrue(start.arguments().get("outputPath").getAsString()
+                        .startsWith(AssistantCommand.DEFAULT_CAPTURE_RECORDING_PATH_PREFIX)),
+                () -> assertTrue(start.arguments().get("outputPath").getAsString().endsWith(".json")),
+                () -> assertFalse(start.arguments().get("headless").getAsBoolean()),
+                () -> assertEquals("capture_stop", stop.toolName()),
+                () -> assertFalse(stop.arguments().get("discard").getAsBoolean()));
+    }
+
+    @Test
+    void captureReviewUsesIgnoredReviewDirectoryAndApprovalCreatesAgentRequest() {
+        assertTrue(AssistantCommand.isCaptureApproval("okay"));
+        assertTrue(AssistantCommand.isCaptureApproval("generate"));
+        assertFalse(AssistantCommand.isCaptureApproval("generate a login test"));
+
+        var review = AssistantCommand.captureCodeReview("recordings/demo.json");
+        assertAll(
+                () -> assertEquals("recordings/demo.json", review.get("sessionPath").getAsString()),
+                () -> assertEquals(AssistantCommand.DEFAULT_CAPTURE_REVIEW_DIRECTORY,
+                        review.get("outputDirectory").getAsString()),
+                () -> assertTrue(review.get("overwrite").getAsBoolean()));
+
+        AssistantCommand.Invocation apply = AssistantCommand.approvedCaptureIntegration(
+                AssistantCommand.Selection.local("CODEX", "CLI"),
+                "C:/work/project",
+                "",
+                "```java\nclass Generated {}\n```",
+                "{\"codeBlocks\":[]}");
+
+        assertAll(
+                () -> assertEquals("autobot_local_agent_run", apply.toolName()),
+                () -> assertEquals("AGENT", apply.arguments().get("mode").getAsString()),
+                () -> assertTrue(apply.arguments().get("allowSourceMutation").getAsBoolean()),
+                () -> assertTrue(apply.arguments().get("prompt").getAsString().contains("Page Object Model")),
+                () -> assertTrue(apply.arguments().get("prompt").getAsString().contains("Do not start a new recording")));
     }
 
     @Test

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -19,10 +19,12 @@ import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import java.awt.Component;
 import java.awt.Container;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.swing.text.JTextComponent;
 
@@ -193,8 +195,19 @@ class ShaftPanelSetupTest {
     }
 
     @Test
-    void toolWindowShowsReadableWorkflowSelectorLabels() {
+    void toolWindowHidesAdvancedWorkflowsByDefault() {
         ShaftToolWindowPanel toolWindow = new ShaftToolWindowPanel(fakeProject(), connectedMcpSettings());
+
+        JComboBox<ShaftToolWindowPanel.WorkflowView> selector = toolWindowWorkflowSelector(toolWindow);
+        assertAll(
+                () -> assertNull(selector),
+                () -> assertFalse(containsText(toolWindow, "Workflow")),
+                () -> assertTrue(containsText(toolWindow, "Configure")));
+    }
+
+    @Test
+    void toolWindowShowsReadableWorkflowSelectorLabelsWhenAdvancedUiIsEnabled() {
+        ShaftToolWindowPanel toolWindow = new ShaftToolWindowPanel(fakeProject(), advancedConnectedMcpSettings());
 
         JComboBox<ShaftToolWindowPanel.WorkflowView> selector = toolWindowWorkflowSelector(toolWindow);
         assertNotNull(selector);
@@ -209,7 +222,7 @@ class ShaftPanelSetupTest {
 
     @Test
     void workflowSelectorKeepsEnoughHeightForVisibleTopLabels() {
-        ShaftToolWindowPanel toolWindow = new ShaftToolWindowPanel(fakeProject(), connectedMcpSettings());
+        ShaftToolWindowPanel toolWindow = new ShaftToolWindowPanel(fakeProject(), advancedConnectedMcpSettings());
         JComboBox<ShaftToolWindowPanel.WorkflowView> selector = toolWindowWorkflowSelector(toolWindow);
 
         assertNotNull(selector);
@@ -218,7 +231,7 @@ class ShaftPanelSetupTest {
 
     @Test
     void prefillToolSelectsMatchingWorkflowAndCategory() {
-        ShaftToolWindowPanel toolWindow = new ShaftToolWindowPanel(fakeProject(), connectedMcpSettings());
+        ShaftToolWindowPanel toolWindow = new ShaftToolWindowPanel(fakeProject(), advancedConnectedMcpSettings());
         JComboBox<ShaftToolWindowPanel.WorkflowView> selector = toolWindowWorkflowSelector(toolWindow);
         assertNotNull(selector);
         JsonObject arguments = JsonParser.parseString("{}").getAsJsonObject();
@@ -279,6 +292,51 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void assistantCaptureCodegenResultWaitsForApprovalBeforeWritingFiles() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        setField(panel, "captureReviewGenerationRunning", true);
+
+        showAssistantResult(panel, "capture_code_blocks", ShaftMcpToolResult.success(mcpText("""
+                {
+                  "successful": true,
+                  "codeBlocks": [
+                    {"language":"java","code":"public class RecordedFlowTest {}"}
+                  ]
+                }
+                """)));
+
+        String markdown = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(markdown.contains("public class RecordedFlowTest")),
+                () -> assertTrue(markdown.contains("Review before writing files")),
+                () -> assertTrue(markdown.contains("`approve`, `okay`, or `generate`")));
+    }
+
+    @Test
+    void cancelledCaptureCodegenReviewDoesNotArmLaterApprovalFlow() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        setField(panel, "captureReviewGenerationRunning", true);
+
+        showAssistantResult(panel, "capture_code_blocks", null, new CancellationException("cancelled"));
+        showAssistantResult(panel, "capture_code_blocks", ShaftMcpToolResult.success(mcpText("""
+                {
+                  "successful": true,
+                  "codeBlocks": [
+                    {"language":"java","code":"public class LaterGeneratedTest {}"}
+                  ]
+                }
+                """)));
+
+        String markdown = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(markdown.contains("capture_code_blocks cancelled")),
+                () -> assertTrue(markdown.contains("LaterGeneratedTest")),
+                () -> assertFalse(markdown.contains("Review before writing files")),
+                () -> assertNull(getField(panel, "pendingCaptureReview")),
+                () -> assertFalse((Boolean) getField(panel, "captureReviewGenerationRunning")));
+    }
+
+    @Test
     void assistantKeepsShaftWrapperForCuratedMcpToolResponses() throws Exception {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
 
@@ -327,6 +385,57 @@ class ShaftPanelSetupTest {
         assertAll(
                 () -> assertTrue(transcriptMarkdown(reopenedPanel).contains("Second answer")),
                 () -> assertEquals(2, chatState.sessions().size()));
+    }
+
+    @Test
+    void persistedSetupOpensAssistantWithPreviousChatsInDropdown() {
+        ShaftSettingsState.Settings settings = connectedMcpSettings();
+        ShaftAssistantChatState chatState = new ShaftAssistantChatState();
+        Project project = fakeProject(chatState);
+        chatState.append("user", "start recording", "{}");
+        chatState.append("assistant", "Capture browser opened.", "{}");
+        chatState.newSession();
+        chatState.append("user", "generate reviewed code", "{}");
+
+        ShaftToolWindowPanel toolWindow = new ShaftToolWindowPanel(project, settings);
+        JComboBox<?> chats = findByAccessibleName(toolWindow, "Assistant chat", JComboBox.class);
+
+        assertAll(
+                () -> assertNull(setupPanel(toolWindow)),
+                () -> assertNull(toolWindowWorkflowSelector(toolWindow)),
+                () -> assertTrue(transcriptMarkdown(toolWindow).contains("generate reviewed code")),
+                () -> assertNotNull(chats),
+                () -> assertEquals(2, chats.getItemCount()),
+                () -> assertTrue(comboContains(chats, "start recording")),
+                () -> assertTrue(comboContains(chats, "generate reviewed code")));
+    }
+
+    @Test
+    void userMessagesDoNotRenderSpeakerLabelsOrUseThemAsChatTitles() {
+        ShaftAssistantChatState chatState = new ShaftAssistantChatState();
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings(), chatState);
+
+        assistantPrompt(panel).setText("start recording");
+        click(panel, "Send");
+
+        String transcript = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(transcript.contains("start recording")),
+                () -> assertFalse(transcript.contains(String.valueOf(new char[]{'Y', 'o', 'u'}))),
+                () -> assertEquals("start recording", chatState.activeSession().title));
+
+        String speaker = String.valueOf(new char[]{'Y', 'o', 'u'});
+        String localUser = System.getProperty("user.name", "");
+        ShaftAssistantChatState legacyState = new ShaftAssistantChatState();
+        legacyState.append("user", "**" + speaker + " (Agent via Codex CLI)**\n\n"
+                + localUser + " open duckduckgo", "{}");
+
+        assertAll(
+                () -> assertTrue(legacyState.activeMarkdown().contains("open duckduckgo")),
+                () -> assertFalse(legacyState.activeMarkdown().contains("Agent via")),
+                () -> assertFalse(legacyState.activeSession().title.contains(speaker)),
+                () -> assertFalse(localUser.length() > 1
+                        && legacyState.activeSession().title.contains(localUser)));
     }
 
     @Test
@@ -512,7 +621,7 @@ class ShaftPanelSetupTest {
     }
 
     @Test
-    void firstSetupSuccessStartsFreshAssistantSession() throws Exception {
+    void setupSuccessPreservesExistingAssistantSession() throws Exception {
         ShaftSettingsState.Settings settings = blankMcpSettings();
         settings.mcpCommand = "cmd";
         settings.mcpSetupComplete = false;
@@ -528,9 +637,12 @@ class ShaftPanelSetupTest {
         assertNotNull(setupPanel);
         showTestResult(setupPanel, ShaftMcpToolResult.success("Probe OK"));
 
-        assertEquals(beforeSetupSessions + 1, state.sessions().size());
-        assertNotNull(state.activeSession());
-        assertTrue(state.activeSession().messages.isEmpty());
+        assertAll(
+                () -> assertEquals(beforeSetupSessions, state.sessions().size()),
+                () -> assertNotNull(state.activeSession()),
+                () -> assertTrue(state.activeMarkdown().contains("Previous assistant conversation")),
+                () -> assertTrue(transcriptMarkdown(toolWindow).contains("Previous assistant conversation")),
+                () -> assertNull(toolWindowWorkflowSelector(toolWindow)));
     }
 
     @Test
@@ -619,6 +731,12 @@ class ShaftPanelSetupTest {
         return settings;
     }
 
+    private static ShaftSettingsState.Settings advancedConnectedMcpSettings() {
+        ShaftSettingsState.Settings settings = connectedMcpSettings();
+        settings.advancedUiEnabled = true;
+        return settings;
+    }
+
     private static boolean containsText(Component component, String expected) {
         if (component instanceof JLabel label && label.getText() != null && label.getText().contains(expected)) {
             return true;
@@ -690,10 +808,18 @@ class ShaftPanelSetupTest {
     }
 
     private static void showAssistantResult(ShaftAssistantPanel panel, String toolName, ShaftMcpToolResult result) throws Exception {
+        showAssistantResult(panel, toolName, result, null);
+    }
+
+    private static void showAssistantResult(
+            ShaftAssistantPanel panel,
+            String toolName,
+            ShaftMcpToolResult result,
+            Throwable error) throws Exception {
         Method showResult = ShaftAssistantPanel.class.getDeclaredMethod(
                 "showResult", String.class, ShaftMcpToolResult.class, Throwable.class);
         showResult.setAccessible(true);
-        showResult.invoke(panel, toolName, result, null);
+        showResult.invoke(panel, toolName, result, error);
     }
 
     private static void showAgentResult(ShaftAssistantPanel panel, ShaftMcpToolResult result) throws Exception {
@@ -701,6 +827,18 @@ class ShaftPanelSetupTest {
                 "showAgentResult", ShaftMcpToolResult.class, Throwable.class);
         showResult.setAccessible(true);
         showResult.invoke(panel, result, null);
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static Object getField(Object target, String name) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(target);
     }
 
     private static String assistantExport(ShaftAssistantPanel panel) throws Exception {
@@ -857,6 +995,19 @@ class ShaftPanelSetupTest {
             }
         }
         return null;
+    }
+
+    private static boolean comboContains(JComboBox<?> comboBox, String expectedText) {
+        if (comboBox == null) {
+            return false;
+        }
+        for (int index = 0; index < comboBox.getItemCount(); index++) {
+            Object item = comboBox.getItemAt(index);
+            if (item != null && item.toString().contains(expectedText)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static JTextComponent assistantPrompt(Component component) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
@@ -204,8 +204,6 @@ class ShaftPluginScreenshotRendererTest {
             configureLookAndFeel(lookAndFeelClassName, dark);
             ShaftAssistantChatState chatState = new ShaftAssistantChatState();
             chatState.append("user", """
-                    **You (Agent via Codex CLI)**
-
                     Use shaft-mcp WebDriver tools only. Open DuckDuckGo, search for SHAFT Engine, open the first result, and validate the title.
                     """.stripIndent().trim(), "");
             chatState.append("assistant", """
@@ -306,7 +304,9 @@ class ShaftPluginScreenshotRendererTest {
 
     private static JComponent toolWindow(int selectedTab, String toolsCategory) {
         Project project = screenshotProject();
-        ShaftToolWindowPanel toolWindow = new ShaftToolWindowPanel(project, defaultSettings());
+        ShaftSettingsState.Settings settings = defaultSettings();
+        settings.advancedUiEnabled = true;
+        ShaftToolWindowPanel toolWindow = new ShaftToolWindowPanel(project, settings);
         JComboBox<ShaftToolWindowPanel.WorkflowView> selector = toolWindow.workflowSelector();
         ShaftToolWindowPanel.WorkflowView selectedView = selector.getItemAt(selectedTab);
         Component selected = selectedView.component();

--- a/tools/intellij-plugin-recording/README.md
+++ b/tools/intellij-plugin-recording/README.md
@@ -1,98 +1,50 @@
-# IntelliJ Plugin Live Recording Workflow
+# IntelliJ Plugin Capture Workflow
 
-Run this exact flow when asked to create a real SHAFT IntelliJ IDEA plugin video recording.
+Use this flow to validate the assistant-driven e2e capture path. This workflow does not include video capture.
 
-## Scenario
+## Build
 
-Use this exact onboarding scenario (latest local plugin build + MCP test + DuckDuckGo validation):
-
-1. Build and capture the latest local IntelliJ plugin ZIP:
-   - `powershell -NoProfile -ExecutionPolicy Bypass -File tools\\intellij-plugin-recording\\record-onboarding.ps1`
-   - (Equivalent: `gradle -p shaft-intellij check buildPlugin verifyPlugin`)
+1. Build and verify the latest local IntelliJ plugin:
+   - `powershell -NoProfile -ExecutionPolicy Bypass -File tools\intellij-plugin-recording\record-onboarding.ps1`
+   - Equivalent: `gradle -p shaft-intellij check buildPlugin verifyPlugin`
 2. Launch the recording IDE in an isolated Gradle IntelliJ sandbox:
-   - `gradle -p shaft-intellij runIde --args C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE`
-   - If `runIde` is unavailable, install `shaft-intellij/build/distributions/*.zip` into an isolated IntelliJ sandbox and open `Tools -> SHAFT -> Open SHAFT`.
-3. On first-run MCP setup:
-   - `Family: CODEX`
-   - `Runtime: CLI`
-   - `Install / Update SHAFT MCP`
-   - This installs the plugin MCP command and configures SHAFT MCP for the selected agent.
-   - `Test connection and start chatting`
-   - Require assistant status to show `Connected`.
-   - Setup panel closes and SHAFT Assistant opens after successful test.
-4. Validate MCP test flow and switch to assistant usage:
-   - `Route: LOCAL`
-   - `Provider/Family: CODEX`
-   - `Runtime: CLI`
-   - `Mode: AGENT`
-   - Leave `Allow source edits` off for browser-only work.
-   - Enable `Allow source edits` only when the request applies code/source changes.
-   - Visible agent output should look like the selected agent's normal Markdown response.
-   - Do not show raw JSON, `autobot_local_agent_run`, or SHAFT status metadata for normal local agent chat.
-5. In Assistant prompt, use exact first sentence:
-   - `open duckduckgo and search for SHAFT Engine`
-   - Then:
-     - `open the first result`
-       - Prefer the scoped XPath `(//article[@data-testid='result'])[1]//a[@data-testid='result-title-a']`; the plain CSS anchor matches multiple results.
-     - `validate the title is "GitHub - ShaftHQ/SHAFT_ENGINE: Java test automation framework for web, mobile, API, CLI, database, and desktop E2E testing with a fluent API and built-in reporting. · GitHub"`
-   - Ensure the browser window is in focus.
-   - Use **Copy all** for the rendered transcript plus current-session tool evidence, then attach that text beside the MP4.
-   - Ask the agent to finish with exactly:
-     - `DUCKDUCKGO_SHAFT_DONE`
-6. Verify completion marker in logs/output:
-   - `DUCKDUCKGO_SHAFT_DONE`
+   - `gradle -p shaft-intellij runIde --args <repo-root>`
+   - Fallback: install `shaft-intellij/build/distributions/*.zip` into an isolated IntelliJ sandbox and open `Tools -> SHAFT -> Open SHAFT`.
 
-## Base flow
+## Default UI
 
-The base flow below remains the canonical reference for manual recordings.
+Regular users see only Assistant and configuration. Guided workflows, direct tool panels, provider routing, cloud settings, provider keys, and source mutation controls require the advanced UI feature flag.
 
-1. Build the latest local plugin ZIP:
-   - `gradle -p shaft-intellij check buildPlugin verifyPlugin`
-2. Preferred launch path:
-   - `gradle -p shaft-intellij runIde --args C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE`
-   - Fallback: install the built ZIP from `shaft-intellij` build output into an isolated IntelliJ sandbox and open `Tools -> SHAFT -> Open SHAFT`.
-3. On first-run MCP setup:
-   - `Family: CODEX`
-   - `Runtime: CLI`
-   - `Install / Update SHAFT MCP`
-   - This installs the plugin MCP command and configures SHAFT MCP for the selected agent.
-   - `Test connection and start chatting`
-4. Configure Assistant:
-   - `Route: LOCAL`
-   - `Provider/Family: CODEX`
-   - `Runtime: CLI`
-   - `Mode: AGENT`
-   - Leave `Allow source edits` off for browser-only work.
-   - Enable `Allow source edits` only when applying code/source changes.
-   - Visible agent output should look like the selected agent's normal Markdown response.
-   - Do not show raw JSON, `autobot_local_agent_run`, or SHAFT status metadata for normal local agent chat.
-5. In Assistant prompt, use exact first sentence:
-   - `open duckduckgo and search for SHAFT Engine`
-   - Then:
-     - `open the first result`
-       - Prefer the scoped XPath `(//article[@data-testid='result'])[1]//a[@data-testid='result-title-a']`; the plain CSS anchor matches multiple results.
-     - `validate the title is "GitHub - ShaftHQ/SHAFT_ENGINE: Java test automation framework for web, mobile, API, CLI, database, and desktop E2E testing with a fluent API and built-in reporting. · GitHub"`
-   - Ensure the browser window is in focus.
-   - Use **Copy all** to export the transcript and current-session tool evidence for PR notes.
-   - Ask the agent to finish with exactly:
-     - `DUCKDUCKGO_SHAFT_DONE`
-6. Verify completion marker in logs/output:
-   - `DUCKDUCKGO_SHAFT_DONE`
-7. Record video from IDE launch through marker:
-   - Format: `MP4`
-   - Codec: `H.264`
-   - Frame rate: `30 fps`
-   - Audio: **off** (no audio)
-   - View: full desktop
-   - Command:
-     - `ffmpeg -y -f gdigrab -framerate 30 -i desktop -c:v libx264 -preset veryfast -pix_fmt yuv420p -movflags +faststart target/intellij-plugin-recording/shaft-intellij-onboarding.mp4`
-8. Upload final MP4 to Google Drive root and paste that link in the PR body.
+The default assistant route is local. The advanced UI flag is disabled by default and must remain opt-in.
 
-Notes:
-- On this Windows machine, Chrome exists at `C:\Program Files\Google\Chrome\Application\chrome.exe` even when `chrome` is not on `PATH`.
-- Keep the run isolated from the user's daily IDE profile; use the Gradle IntelliJ sandbox or a disposable IDE config directory.
-- Before starting capture, launch the selected IntelliJ runtime once and dismiss any Windows Firewall prompt for OpenJDK manually; automation must not choose Windows Security permissions.
-- IntelliJ Trust Project may preselect Microsoft Defender exclusions; leave them unchecked unless the run explicitly needs them.
-- Dismiss sandbox-only low-memory and script-launcher balloons before recording; do not suppress production IDE warnings.
-- When recording a branch before merge, launch the IDE with `SHAFT_MCP_INSTALLER_REF` set to the current branch so first-run install exercises the branch installer rather than `main`.
-- If the live run exposes blockers, fix blockers in the PR and collect nonblocker follow-ups in one GitHub issue.
+## First-Run Setup
+
+1. Open SHAFT.
+2. Select `Family: CODEX`.
+3. Select `Runtime: CLI`.
+4. Click `Install / Update SHAFT MCP`.
+5. Click `Test MCP`.
+6. Confirm the setup view closes and SHAFT Assistant opens after a successful test.
+
+## Capture Scenario
+
+1. Send `start recording` in Assistant.
+2. Confirm the managed browser opens and remains open.
+3. In the managed browser:
+   - open DuckDuckGo
+   - search for `SHAFT Engine`
+   - open the first result
+   - validate the page title
+4. Send `stop` in Assistant.
+5. Review the generated capture code blocks shown in chat.
+6. Approve generation with `approve`, `okay`, or `generate`.
+7. Confirm the local agent writes Page Object Model automation files after approval.
+
+## Expected Behavior
+
+- `start recording` uses a fresh capture output path for each session.
+- `stop` triggers review-only code block generation.
+- File generation waits for approval.
+- Existing valid capture output is cleaned before reuse; invalid output fails with a clear error.
+- Chat bubbles have no speaker labels.
+- Chat session titles are derived from prompt content without speaker labels or local account names.


### PR DESCRIPTION
## Summary

- Add natural Assistant capture commands so `start recording` opens a fresh headed Chrome capture session and `stop` triggers review-only capture code generation.
- Gate advanced IntelliJ plugin workflows, provider routing, cloud/provider key settings, and source mutation controls behind `advancedUiEnabled`, disabled by default.
- Preserve Assistant history after MCP setup, sanitize chat session titles and old speaker labels, and keep regular users on the Assistant/configuration surface.
- Make capture start resilient to existing valid session output while rejecting unknown pre-existing output.

## Validation

- `gradle -p shaft-intellij test --tests com.shaft.intellij.ui.AssistantCommandTest --tests com.shaft.intellij.ui.AssistantMarkdownTest --tests com.shaft.intellij.ui.ShaftPanelSetupTest --tests com.shaft.intellij.settings.ShaftSettingsConfigurableTest --tests com.shaft.intellij.ui.ShaftPluginScreenshotRendererTest`
- `mvn -pl shaft-capture '-Dtest=CaptureManagerLifecycleTest' '-DgenerateAllureReportArchive=false' '-Dallure.generateArchive=false' '-DlighthouseExecution=false' '-Dperformance.lighthouseExecution=false' test`
- `gradle -p shaft-intellij check buildPlugin verifyPlugin`
- `git diff --check`

## Follow-up Notes For Issue Triage

Tracked in https://github.com/ShaftHQ/SHAFT_ENGINE/issues/3197.

- Consider adding an explicit in-plugin diagnostic when a managed browser exits immediately after capture start, including the resolved capture output path and recorder process status.
- Consider a compact capture review panel once approvals become common, so reviewed code blocks and the approval command are easier to scan in long chats.
- Consider a settings migration hint for users with old advanced provider routing saved before the advanced UI flag existed.