### PR TITLE
[codex] Route IntelliJ assistant setup-aware commands

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -80,9 +80,9 @@ final class AssistantCommand {
             new CommandDefinition("/triage", "Analyze failed Allure evidence",
                     List.of("/fixTestFailure"),
                     "/triage", (command, rest, workingDirectory) -> Invocation.tool("doctor_analyze_failed_allure", triage(workingDirectory))),
-            new CommandDefinition("/clients", "List local assistant clients",
-                    List.of("/client"),
-                    "/clients", (command, rest, workingDirectory) -> Invocation.tool("autobot_local_agent_clients", new JsonObject())),
+            new CommandDefinition("/assistant", "List assistant clients",
+                    List.of("/agent", "/ask", "/plan", "/clients", "/client"),
+                    "/assistant", (command, rest, workingDirectory) -> Invocation.tool("autobot_local_agent_clients", new JsonObject())),
             new CommandDefinition("/project", "Create or upgrade SHAFT projects",
                     List.of("/newshaft", "/upgrade"),
                     "/project upgrade .", AssistantCommand::project),
@@ -1086,6 +1086,9 @@ final class AssistantCommand {
     }
 
     record Invocation(List<ToolCall> toolCalls, String localResponse) {
+        private static final String LOCAL_AGENT_TOOL = "autobot_local_agent_run";
+        private static final String PROVIDER_CHAT_TOOL = "autobot_provider_chat";
+
         static Invocation tool(String toolName, JsonObject arguments) {
             return new Invocation(List.of(new ToolCall(toolName, arguments == null ? new JsonObject() : arguments)), null);
         }
@@ -1107,6 +1110,16 @@ final class AssistantCommand {
 
         boolean isSequence() {
             return toolCalls.size() > 1;
+        }
+
+        boolean requiresMcpConfiguration() {
+            return !isLocal() && toolCalls.stream().anyMatch(Invocation::isDirectMcpFeatureTool);
+        }
+
+        private static boolean isDirectMcpFeatureTool(ToolCall call) {
+            return call != null
+                    && !LOCAL_AGENT_TOOL.equals(call.toolName())
+                    && !PROVIDER_CHAT_TOOL.equals(call.toolName());
         }
 
         String toolName() {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -313,6 +313,10 @@ final class ShaftAssistantPanel extends JPanel {
         return prompt;
     }
 
+    static boolean requiresMcpSetup(AssistantCommand.Invocation invocation, boolean mcpConfigured) {
+        return invocation != null && invocation.requiresMcpConfiguration() && !mcpConfigured;
+    }
+
     private void send(Project project) {
         String text = prompt.getText().trim();
         if (text.isBlank()) {
@@ -358,8 +362,8 @@ final class ShaftAssistantPanel extends JPanel {
             showLocalResponse(invocation.localResponse());
             return;
         }
-        if (!mcpConfigured()) {
-            showLocalResponse("Configure SHAFT MCP in Settings before sending Assistant requests.");
+        if (requiresMcpSetup(invocation, mcpConfigured())) {
+            showLocalResponse("Configure SHAFT MCP in Settings before running this Assistant feature command.");
             status.setText("Configure MCP");
             return;
         }
@@ -1200,7 +1204,7 @@ final class ShaftAssistantPanel extends JPanel {
 
     private static JPanel setupNotice(Project project, ShaftSettingsState.Settings settings) {
         JPanel panel = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 0));
-        panel.add(new JLabel("Configure SHAFT MCP to run Assistant."));
+        panel.add(new JLabel("Configure SHAFT MCP to run Assistant feature commands."));
         JButton openSettings = new JButton("Open Settings");
         openSettings.setIcon(AllIcons.General.Settings);
         openSettings.getAccessibleContext().setAccessibleName("Open SHAFT settings");

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
@@ -242,6 +242,10 @@ class AssistantCommandTest {
         assertEquals("sign in", command("/inspect https://example.com sign in").arguments().get("userIntent").getAsString());
         assertEquals("test_code_guardrails_check", command("/guardrails driver.element().click(locator);").toolName());
         assertEquals("java", command("/guardrails code").arguments().get("language").getAsString());
+        assertEquals("autobot_local_agent_clients", command("/assistant").toolName());
+        assertEquals("autobot_local_agent_clients", command("/agent").toolName());
+        assertEquals("autobot_local_agent_clients", command("/ask").toolName());
+        assertEquals("autobot_local_agent_clients", command("/plan").toolName());
         assertEquals("autobot_local_agent_clients", command("/clients").toolName());
         assertEquals("test_automation_scenarios", command("/generatetest login").toolName());
         assertEquals("capture_code_blocks", command("/generatetest recordings/capture-session.json").toolName());
@@ -257,11 +261,14 @@ class AssistantCommandTest {
 
         assertAll(
                 () -> assertTrue(hints.stream().anyMatch(hint -> "/commands".equals(hint.canonical()))),
+                () -> assertTrue(hints.stream().anyMatch(hint -> "/assistant".equals(hint.canonical()))),
                 () -> assertTrue(hints.stream().anyMatch(hint -> "/browser".equals(hint.canonical()))),
                 () -> assertTrue(hints.stream().anyMatch(hint -> "/record".equals(hint.canonical()))),
                 () -> assertTrue(hints.stream().anyMatch(hint -> "/mobile".equals(hint.canonical()))),
                 () -> assertTrue(hints.stream().anyMatch(hint -> "/doctor".equals(hint.canonical()))),
                 () -> assertTrue(tooltip.contains("/commands")),
+                () -> assertTrue(tooltip.contains("/assistant")),
+                () -> assertTrue(tooltip.contains("/clients")),
                 () -> assertTrue(tooltip.contains("/shaft-help")),
                 () -> assertTrue(tooltip.contains("/browser")),
                 () -> assertTrue(tooltip.contains("/web")),
@@ -278,7 +285,38 @@ class AssistantCommandTest {
                 () -> assertTrue(help.isLocal()),
                 () -> assertTrue(help.localResponse().contains("/commands")),
                 () -> assertTrue(help.localResponse().contains("/mcp-help")),
+                () -> assertTrue(help.localResponse().contains("/assistant")),
                 () -> assertTrue(help.localResponse().contains("/browser open https://example.com sign in")));
+    }
+
+    @Test
+    void setupGateOnlyAppliesToDirectMcpFeatureInvocations() {
+        AssistantCommand.Invocation broadLocal = AssistantCommand.fromPrompt(
+                "Plan how to use mobile recording in this project",
+                AssistantCommand.Selection.local("CODEX", "CLI"),
+                "ASK",
+                ".",
+                "",
+                false);
+        AssistantCommand.Invocation broadCloud = AssistantCommand.fromPrompt(
+                "Plan how to use mobile recording in this project",
+                AssistantCommand.Selection.cloud("github", "openai/gpt-4.1"),
+                "PLAN",
+                ".",
+                "",
+                false);
+        AssistantCommand.Invocation explicitFeature = command("start mobile recording");
+        AssistantCommand.Invocation slashFeature = command("/guide locators");
+        AssistantCommand.Invocation localHelp = command("/help");
+
+        assertAll(
+                () -> assertEquals("autobot_local_agent_run", broadLocal.toolName()),
+                () -> assertFalse(broadLocal.requiresMcpConfiguration()),
+                () -> assertEquals("autobot_provider_chat", broadCloud.toolName()),
+                () -> assertFalse(broadCloud.requiresMcpConfiguration()),
+                () -> assertTrue(explicitFeature.requiresMcpConfiguration()),
+                () -> assertTrue(slashFeature.requiresMcpConfiguration()),
+                () -> assertFalse(localHelp.requiresMcpConfiguration()));
     }
 
     @Test

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -48,6 +48,37 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void assistantMcpSetupGateIgnoresBroadLocalCliPrompts() {
+        AssistantCommand.Invocation broadLocal = AssistantCommand.fromPrompt(
+                "Plan a browser recording workflow",
+                AssistantCommand.Selection.local("CODEX", "CLI"),
+                "ASK",
+                ".",
+                "",
+                false);
+        AssistantCommand.Invocation broadCloud = AssistantCommand.fromPrompt(
+                "Plan a browser recording workflow",
+                AssistantCommand.Selection.cloud("github", "openai/gpt-4.1"),
+                "PLAN",
+                ".",
+                "",
+                false);
+        AssistantCommand.Invocation mcpFeature = AssistantCommand.fromPrompt(
+                "/guide locators",
+                "CODEX",
+                "ASK",
+                ".",
+                "",
+                false);
+
+        assertAll(
+                () -> assertFalse(ShaftAssistantPanel.requiresMcpSetup(broadLocal, false)),
+                () -> assertFalse(ShaftAssistantPanel.requiresMcpSetup(broadCloud, false)),
+                () -> assertTrue(ShaftAssistantPanel.requiresMcpSetup(mcpFeature, false)),
+                () -> assertFalse(ShaftAssistantPanel.requiresMcpSetup(mcpFeature, true)));
+    }
+
+    @Test
     void toolsExplainMissingMcpConfiguration() {
         ShaftFeaturePanel panel = new ShaftFeaturePanel(null, blankMcpSettings());
 


### PR DESCRIPTION
## Summary
- Makes `/assistant` the canonical Assistant command while preserving `/agent`, `/ask`, `/plan`, `/clients`, and `/client` aliases.
- Separates selected Assistant routes from direct MCP feature invocations so broad local/cloud prompts do not hit the setup gate, while explicit feature commands still show MCP setup guidance when needed.
- Adds focused command and panel setup regressions for broad local/cloud routing versus direct MCP features.

## Root cause
The Assistant panel treated every non-local response as requiring MCP setup before dispatch, so broad selected-route prompts and direct MCP feature commands were gated the same way.

## Docs
- Companion docs PR: https://github.com/ShaftHQ/shafthq.github.io/pull/677

## Screenshots
![SHAFT IntelliJ Assistant route controls](https://raw.githubusercontent.com/ShaftHQ/shafthq.github.io/codex/issue-3203-assistant-routing-docs/static/img/agentic/intellij-plugin-assistant.png)

![SHAFT IntelliJ MCP setup flow](https://raw.githubusercontent.com/ShaftHQ/shafthq.github.io/codex/issue-3203-assistant-routing-docs/static/img/agentic/intellij-plugin-mcp-setup.png)

## Validation
- `memory load "issue 3203 intellij assistant routing tests"`
- RED: `gradle -p shaft-intellij test --tests com.shaft.intellij.ui.AssistantCommandTest`
- RED: `gradle -p shaft-intellij test --tests com.shaft.intellij.ui.ShaftPanelSetupTest`
- RED after review: `gradle -p shaft-intellij test --tests com.shaft.intellij.ui.AssistantCommandTest --tests com.shaft.intellij.ui.ShaftPanelSetupTest`
- GREEN: `gradle -p shaft-intellij test --tests com.shaft.intellij.ui.AssistantCommandTest --tests com.shaft.intellij.ui.ShaftPanelSetupTest --tests com.shaft.intellij.ui.ShaftPluginScreenshotRendererTest '-Dshaft.intellij.screenshotDir=C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/shaft-intellij/build/issue-3203-screenshots'`
- `py -3 scripts\ci\validate_documentation_boundaries.py`
- Docs PR checks: `yarn test`, `yarn typecheck`, `yarn build`, `yarn test:playwright`

Closes #3203