### PR TITLE
Add experimental SSH shell and PTY support (Part of #3132)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/cli/SshShellOptions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/SshShellOptions.java
@@ -1,0 +1,126 @@
+package com.shaft.cli;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable options for an experimental reusable SSH shell channel.
+ */
+public final class SshShellOptions {
+    private static final String DEFAULT_PTY_TYPE = "vt100";
+    private static final int DEFAULT_COLUMNS = 80;
+    private static final int DEFAULT_ROWS = 24;
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
+
+    private final boolean pty;
+    private final String ptyType;
+    private final int columns;
+    private final int rows;
+    private final Duration defaultTimeout;
+    private final Map<String, String> environment;
+
+    private SshShellOptions(Builder builder) {
+        pty = builder.pty;
+        ptyType = builder.ptyType;
+        columns = builder.columns;
+        rows = builder.rows;
+        defaultTimeout = builder.defaultTimeout;
+        environment = Collections.unmodifiableMap(new LinkedHashMap<>(builder.environment));
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public void validate() {
+        if (ptyType == null || ptyType.isBlank()) {
+            throw new IllegalArgumentException("SSH shell options require a non-blank PTY type.");
+        }
+        if (columns <= 0 || rows <= 0) {
+            throw new IllegalArgumentException("SSH shell PTY columns and rows must be positive.");
+        }
+        if (defaultTimeout == null || defaultTimeout.isZero() || defaultTimeout.isNegative()) {
+            throw new IllegalArgumentException("SSH shell options require a positive default timeout.");
+        }
+    }
+
+    public boolean isPty() {
+        return pty;
+    }
+
+    public String getPtyType() {
+        return ptyType;
+    }
+
+    public int getColumns() {
+        return columns;
+    }
+
+    public int getRows() {
+        return rows;
+    }
+
+    public Duration getDefaultTimeout() {
+        return defaultTimeout;
+    }
+
+    public Map<String, String> getEnvironment() {
+        return environment;
+    }
+
+    public static final class Builder {
+        private boolean pty;
+        private String ptyType = DEFAULT_PTY_TYPE;
+        private int columns = DEFAULT_COLUMNS;
+        private int rows = DEFAULT_ROWS;
+        private Duration defaultTimeout = DEFAULT_TIMEOUT;
+        private final Map<String, String> environment = new LinkedHashMap<>();
+
+        public Builder pty(boolean value) {
+            pty = value;
+            return this;
+        }
+
+        public Builder ptyType(String value) {
+            ptyType = value;
+            return this;
+        }
+
+        public Builder columns(int value) {
+            columns = value;
+            return this;
+        }
+
+        public Builder rows(int value) {
+            rows = value;
+            return this;
+        }
+
+        public Builder defaultTimeout(Duration value) {
+            defaultTimeout = value;
+            return this;
+        }
+
+        public Builder environment(Map<String, String> value) {
+            environment.clear();
+            if (value != null) {
+                environment.putAll(value);
+            }
+            return this;
+        }
+
+        public Builder putEnvironment(String key, String value) {
+            environment.put(Objects.requireNonNull(key), Objects.requireNonNull(value));
+            return this;
+        }
+
+        public SshShellOptions build() {
+            SshShellOptions options = new SshShellOptions(this);
+            options.validate();
+            return options;
+        }
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/cli/SshShellOptions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/SshShellOptions.java
@@ -36,12 +36,24 @@ public final class SshShellOptions {
     }
 
     public void validate() {
+        validatePtyType();
+        validateDimensions();
+        validateTimeout();
+    }
+
+    private void validatePtyType() {
         if (ptyType == null || ptyType.isBlank()) {
             throw new IllegalArgumentException("SSH shell options require a non-blank PTY type.");
         }
+    }
+
+    private void validateDimensions() {
         if (columns <= 0 || rows <= 0) {
             throw new IllegalArgumentException("SSH shell PTY columns and rows must be positive.");
         }
+    }
+
+    private void validateTimeout() {
         if (defaultTimeout == null || defaultTimeout.isZero() || defaultTimeout.isNegative()) {
             throw new IllegalArgumentException("SSH shell options require a positive default timeout.");
         }

--- a/shaft-engine/src/main/java/com/shaft/cli/SshShellSession.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/SshShellSession.java
@@ -1,6 +1,8 @@
 package com.shaft.cli;
 
 import com.jcraft.jsch.ChannelShell;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
 import com.shaft.tools.io.ReportManager;
 
 import java.io.IOException;
@@ -26,6 +28,16 @@ public final class SshShellSession implements AutoCloseable {
     private final ExecutorService outputReader;
     private volatile boolean closed;
 
+    static SshShellSession openOnSession(TerminalActions parent, Session remoteSession, SshShellOptions options,
+                                         int sessionTimeoutMillis) throws JSchException, IOException {
+        remoteSession.setTimeout(sessionTimeoutMillis);
+        ChannelShell shellChannel = (ChannelShell) remoteSession.openChannel("shell");
+        configureChannel(shellChannel, options);
+        shellChannel.connect(sessionTimeoutMillis);
+        parent.logShellOpened();
+        return new SshShellSession(parent, shellChannel, options);
+    }
+
     SshShellSession(TerminalActions parent, ChannelShell channel, SshShellOptions options) throws IOException {
         this(parent, channel, channel.getInputStream(), channel.getOutputStream(), options);
     }
@@ -41,7 +53,7 @@ public final class SshShellSession implements AutoCloseable {
         this.shellInput = shellInput;
         this.shellOutput = shellOutput;
         this.options = options;
-        this.outputReader = Executors.newSingleThreadExecutor(threadFactory());
+        this.outputReader = Executors.newSingleThreadExecutor(SshShellSession::newReaderThread);
         startOutputReader();
     }
 
@@ -85,6 +97,34 @@ public final class SshShellSession implements AutoCloseable {
      */
     public String readUntil(Pattern pattern, Duration timeout) {
         verifyOpen();
+        Duration effectiveTimeout = resolveReadTimeout(pattern, timeout);
+        return waitForPatternMatch(pattern, effectiveTimeout);
+    }
+
+    /**
+     * Closes the shell channel and removes it from the parent terminal session.
+     */
+    @Override
+    public synchronized void close() {
+        closeChannel(true);
+    }
+
+    synchronized void closeSilently() {
+        closeChannel(false);
+    }
+
+    private static void configureChannel(ChannelShell shellChannel, SshShellOptions options) {
+        shellChannel.setPty(options.isPty());
+        if (!options.isPty()) {
+            options.getEnvironment().forEach(shellChannel::setEnv);
+            return;
+        }
+        shellChannel.setPtyType(options.getPtyType());
+        shellChannel.setPtySize(options.getColumns(), options.getRows(), options.getColumns() * 8, options.getRows() * 16);
+        options.getEnvironment().forEach(shellChannel::setEnv);
+    }
+
+    private Duration resolveReadTimeout(Pattern pattern, Duration timeout) {
         if (pattern == null) {
             parent.failShellAction("SSH shell read", new IllegalArgumentException("Shell read pattern must not be null."));
         }
@@ -92,7 +132,10 @@ public final class SshShellSession implements AutoCloseable {
         if (effectiveTimeout.isZero() || effectiveTimeout.isNegative()) {
             parent.failShellAction("SSH shell read", new IllegalArgumentException("Shell read timeout must be positive."));
         }
+        return effectiveTimeout;
+    }
 
+    private String waitForPatternMatch(Pattern pattern, Duration effectiveTimeout) {
         long deadlineNanos = System.nanoTime() + effectiveTimeout.toNanos();
         while (System.nanoTime() < deadlineNanos) {
             String matchedOutput = takeMatchedOutput(pattern);
@@ -105,27 +148,16 @@ public final class SshShellSession implements AutoCloseable {
         return "";
     }
 
-    /**
-     * Closes the shell channel and removes it from the parent terminal session.
-     */
-    @Override
-    public synchronized void close() {
+    private synchronized void closeChannel(boolean unregister) {
         if (closed) {
             return;
         }
         closed = true;
         shutdownReader();
         disconnectChannel();
-        parent.unregisterShellSession(this);
-    }
-
-    synchronized void closeSilently() {
-        if (closed) {
-            return;
+        if (unregister) {
+            parent.unregisterShellSession(this);
         }
-        closed = true;
-        shutdownReader();
-        disconnectChannel();
     }
 
     private void verifyOpen() {
@@ -166,23 +198,29 @@ public final class SshShellSession implements AutoCloseable {
     }
 
     private void startOutputReader() {
-        outputReader.submit(() -> {
-            byte[] buffer = new byte[1024];
-            try {
-                int read;
-                while (!closed && (read = shellInput.read(buffer)) != -1) {
-                    String chunk = new String(buffer, 0, read, StandardCharsets.UTF_8);
-                    synchronized (outputLock) {
-                        outputBuffer.append(chunk);
-                    }
-                    parent.logShellOutput(chunk);
-                }
-            } catch (IOException exception) {
-                if (!closed) {
-                    parent.failShellAction("SSH shell read", exception);
-                }
+        outputReader.submit(this::drainShellOutput);
+    }
+
+    private void drainShellOutput() {
+        byte[] buffer = new byte[1024];
+        try {
+            int read;
+            while (!closed && (read = shellInput.read(buffer)) != -1) {
+                appendShellOutput(buffer, read);
             }
-        });
+        } catch (IOException exception) {
+            if (!closed) {
+                parent.failShellAction("SSH shell read", exception);
+            }
+        }
+    }
+
+    private void appendShellOutput(byte[] buffer, int read) {
+        String chunk = new String(buffer, 0, read, StandardCharsets.UTF_8);
+        synchronized (outputLock) {
+            outputBuffer.append(chunk);
+        }
+        parent.logShellOutput(chunk);
     }
 
     private void shutdownReader() {
@@ -195,11 +233,9 @@ public final class SshShellSession implements AutoCloseable {
         }
     }
 
-    private static java.util.concurrent.ThreadFactory threadFactory() {
-        return runnable -> {
-            Thread thread = new Thread(runnable, "SHAFT-SSH-Shell-Reader");
-            thread.setDaemon(true);
-            return thread;
-        };
+    private static Thread newReaderThread(Runnable runnable) {
+        Thread thread = new Thread(runnable, "SHAFT-SSH-Shell-Reader");
+        thread.setDaemon(true);
+        return thread;
     }
 }

--- a/shaft-engine/src/main/java/com/shaft/cli/SshShellSession.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/SshShellSession.java
@@ -1,0 +1,205 @@
+package com.shaft.cli;
+
+import com.jcraft.jsch.ChannelShell;
+import com.shaft.tools.io.ReportManager;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.regex.Pattern;
+
+/**
+ * Experimental interactive SSH shell session backed by one JSch {@link ChannelShell}.
+ */
+public final class SshShellSession implements AutoCloseable {
+    private final TerminalActions parent;
+    private final ChannelShell channel;
+    private final InputStream shellInput;
+    private final OutputStream shellOutput;
+    private final SshShellOptions options;
+    private final StringBuilder outputBuffer = new StringBuilder();
+    private final Object outputLock = new Object();
+    private final ExecutorService outputReader;
+    private volatile boolean closed;
+
+    SshShellSession(TerminalActions parent, ChannelShell channel, SshShellOptions options) throws IOException {
+        this(parent, channel, channel.getInputStream(), channel.getOutputStream(), options);
+    }
+
+    SshShellSession(TerminalActions parent, InputStream shellInput, OutputStream shellOutput, SshShellOptions options) {
+        this(parent, null, shellInput, shellOutput, options);
+    }
+
+    private SshShellSession(TerminalActions parent, ChannelShell channel, InputStream shellInput, OutputStream shellOutput,
+                            SshShellOptions options) {
+        this.parent = parent;
+        this.channel = channel;
+        this.shellInput = shellInput;
+        this.shellOutput = shellOutput;
+        this.options = options;
+        this.outputReader = Executors.newSingleThreadExecutor(threadFactory());
+        startOutputReader();
+    }
+
+    /**
+     * Writes exact text to the remote shell without appending a newline.
+     */
+    public void send(String text) {
+        verifyOpen();
+        String payload = text == null ? "" : text;
+        writeToShell(payload);
+        ReportManager.logDiscrete("Sent SSH shell input: \"" + parent.redactShellLog(payload) + "\".");
+    }
+
+    /**
+     * Writes text plus a newline to the remote shell.
+     */
+    public void sendLine(String text) {
+        send((text == null ? "" : text) + '\n');
+    }
+
+    /**
+     * Writes exact text to the remote shell without logging the raw payload.
+     */
+    public void sendSecret(String text) {
+        verifyOpen();
+        writeToShell(text == null ? "" : text);
+        ReportManager.logDiscrete("Sent secret SSH shell input (redacted).");
+    }
+
+    /**
+     * Reads shell output until the supplied pattern matches using the configured default timeout.
+     */
+    public String readUntil(Pattern pattern) {
+        return readUntil(pattern, options.getDefaultTimeout());
+    }
+
+    /**
+     * Reads shell output until the supplied pattern matches or the timeout elapses.
+     *
+     * @return all shell output read through the end of the first match
+     */
+    public String readUntil(Pattern pattern, Duration timeout) {
+        verifyOpen();
+        if (pattern == null) {
+            parent.failShellAction("SSH shell read", new IllegalArgumentException("Shell read pattern must not be null."));
+        }
+        Duration effectiveTimeout = timeout == null ? options.getDefaultTimeout() : timeout;
+        if (effectiveTimeout.isZero() || effectiveTimeout.isNegative()) {
+            parent.failShellAction("SSH shell read", new IllegalArgumentException("Shell read timeout must be positive."));
+        }
+
+        long deadlineNanos = System.nanoTime() + effectiveTimeout.toNanos();
+        while (System.nanoTime() < deadlineNanos) {
+            String matchedOutput = takeMatchedOutput(pattern);
+            if (matchedOutput != null) {
+                return matchedOutput;
+            }
+            sleepBriefly();
+        }
+        parent.failShellReadTimeout(pattern, effectiveTimeout);
+        return "";
+    }
+
+    /**
+     * Closes the shell channel and removes it from the parent terminal session.
+     */
+    @Override
+    public synchronized void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        shutdownReader();
+        disconnectChannel();
+        parent.unregisterShellSession(this);
+    }
+
+    synchronized void closeSilently() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        shutdownReader();
+        disconnectChannel();
+    }
+
+    private void verifyOpen() {
+        if (closed) {
+            parent.failShellAction("SSH shell", new IllegalStateException("SSH shell session is already closed."));
+        }
+    }
+
+    private void writeToShell(String payload) {
+        try {
+            shellOutput.write(payload.getBytes(StandardCharsets.UTF_8));
+            shellOutput.flush();
+        } catch (IOException exception) {
+            parent.failShellAction("SSH shell write", exception);
+        }
+    }
+
+    private String takeMatchedOutput(Pattern pattern) {
+        synchronized (outputLock) {
+            java.util.regex.Matcher matcher = pattern.matcher(outputBuffer);
+            if (!matcher.find()) {
+                return null;
+            }
+            int matchEnd = matcher.end();
+            String matchedOutput = outputBuffer.substring(0, matchEnd);
+            outputBuffer.delete(0, matchEnd);
+            return matchedOutput;
+        }
+    }
+
+    private void sleepBriefly() {
+        try {
+            Thread.sleep(50);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            parent.failShellAction("SSH shell read", exception);
+        }
+    }
+
+    private void startOutputReader() {
+        outputReader.submit(() -> {
+            byte[] buffer = new byte[1024];
+            try {
+                int read;
+                while (!closed && (read = shellInput.read(buffer)) != -1) {
+                    String chunk = new String(buffer, 0, read, StandardCharsets.UTF_8);
+                    synchronized (outputLock) {
+                        outputBuffer.append(chunk);
+                    }
+                    parent.logShellOutput(chunk);
+                }
+            } catch (IOException exception) {
+                if (!closed) {
+                    parent.failShellAction("SSH shell read", exception);
+                }
+            }
+        });
+    }
+
+    private void shutdownReader() {
+        outputReader.shutdownNow();
+    }
+
+    private void disconnectChannel() {
+        if (channel != null && channel.isConnected()) {
+            channel.disconnect();
+        }
+    }
+
+    private static java.util.concurrent.ThreadFactory threadFactory() {
+        return runnable -> {
+            Thread thread = new Thread(runnable, "SHAFT-SSH-Shell-Reader");
+            thread.setDaemon(true);
+            return thread;
+        };
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
@@ -16,6 +16,7 @@ import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.BooleanSupplier;
@@ -64,6 +65,7 @@ public class TerminalActions implements AutoCloseable {
     private ScheduledFuture<?> reusableSessionTimeoutTask;
     private final List<Integer> activeLocalPortForwards = new ArrayList<>();
     private final List<Integer> activeRemotePortForwards = new ArrayList<>();
+    private final List<SshShellSession> activeShellSessions = new ArrayList<>();
 
     private static final Pattern TERMINAL_LOG_SECRET_PATTERN = Pattern.compile(
             "(?i)(?<![A-Za-z0-9_])(password|passwd|token|secret|api[-_]?key|access[-_]?token|authorization)\\s*[=:]\\s*(?!\\*\\*\\*)\\S+");
@@ -564,12 +566,40 @@ public class TerminalActions implements AutoCloseable {
     }
 
     /**
+     * Opens an experimental interactive shell channel on the reusable remote SSH session.
+     *
+     * <p>Use {@link SshShellSession#readUntil(Pattern)} and {@link SshShellSession#sendLine(String)}
+     * for prompt-driven flows. Prefer {@link #performTerminalCommand(String)} or
+     * {@link #performSshCommand(String)} for one-shot remote commands.</p>
+     *
+     * @param options shell and PTY options
+     * @return a managed shell session that should be closed when finished
+     */
+    public SshShellSession openShell(SshShellOptions options) {
+        verifyReusableRemoteSessionFeature();
+        if (options == null) {
+            failAction("SSH shell", new IllegalArgumentException("SSH shell options must not be null."));
+        }
+        try {
+            SshShellSession shellSession = connectShellSession(options);
+            synchronized (this) {
+                activeShellSessions.add(shellSession);
+            }
+            return shellSession;
+        } catch (JSchException | IOException exception) {
+            failAction("SSH shell", exception);
+            return null;
+        }
+    }
+
+    /**
      * Disconnects any reusable SSH session owned by this terminal actions instance.
      *
      * <p>This method is safe to call before the first remote command is executed and is a no-op
      * for local terminals or ephemeral remote terminals.</p>
      */
     public synchronized void quit() {
+        closeOpenShellSessions();
         cancelReusableSessionTimeoutTask();
         if (reusableRemoteSession != null && reusableRemoteSession.isConnected()) {
             clearPortForwards(reusableRemoteSession);
@@ -888,6 +918,64 @@ public class TerminalActions implements AutoCloseable {
             failAction("Reusable remote SSH feature", new IllegalStateException(
                     "This feature requires a reusable remote terminal. Use SHAFT.CLI.remoteTerminal(...)."));
         }
+    }
+
+    private SshShellSession connectShellSession(SshShellOptions options) throws JSchException, IOException {
+        Session remoteSession = getRemoteSession();
+        int sessionTimeout = Math.toIntExact(TimeUnit.MINUTES.toMillis(SHAFT.Properties.timeouts.shellSessionTimeout()));
+        remoteSession.setTimeout(sessionTimeout);
+        ChannelShell shellChannel = (ChannelShell) remoteSession.openChannel("shell");
+        applyShellOptions(shellChannel, options);
+        shellChannel.connect(sessionTimeout);
+        ReportManager.logDiscrete("Opened SSH shell on " + sshUsername + "@" + sshHostName + ":" + sshPortNumber + ".");
+        return new SshShellSession(this, shellChannel, options);
+    }
+
+    private void applyShellOptions(ChannelShell shellChannel, SshShellOptions options) {
+        shellChannel.setPty(options.isPty());
+        if (options.isPty()) {
+            shellChannel.setPtyType(options.getPtyType());
+            shellChannel.setPtySize(options.getColumns(), options.getRows(), options.getColumns() * 8, options.getRows() * 16);
+        }
+        options.getEnvironment().forEach(shellChannel::setEnv);
+    }
+
+    private void closeOpenShellSessions() {
+        List<SshShellSession> sessionsToClose;
+        synchronized (this) {
+            sessionsToClose = new ArrayList<>(activeShellSessions);
+            activeShellSessions.clear();
+        }
+        for (SshShellSession shellSession : sessionsToClose) {
+            shellSession.closeSilently();
+        }
+    }
+
+    void unregisterShellSession(SshShellSession shellSession) {
+        synchronized (this) {
+            activeShellSessions.remove(shellSession);
+        }
+    }
+
+    void failShellAction(String actionName, Exception cause) {
+        failAction(actionName, cause);
+    }
+
+    void failShellReadTimeout(Pattern pattern, Duration timeout) {
+        failAction("SSH shell read", new TimeoutException(
+                "Timed out after " + timeout.toMillis() + " ms waiting for shell output matching pattern: "
+                        + pattern.pattern()));
+    }
+
+    void logShellOutput(String chunk) {
+        if (!verbose || chunk == null || chunk.isEmpty()) {
+            return;
+        }
+        ReportManager.logDiscrete(redactTerminalLogForReporting(chunk));
+    }
+
+    String redactShellLog(String value) {
+        return redactTerminalLogForReporting(value);
     }
 
     private void clearPortForwards(Session session) {

--- a/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
@@ -581,10 +581,9 @@ public class TerminalActions implements AutoCloseable {
             failAction("SSH shell", new IllegalArgumentException("SSH shell options must not be null."));
         }
         try {
-            SshShellSession shellSession = connectShellSession(options);
-            synchronized (this) {
-                activeShellSessions.add(shellSession);
-            }
+            SshShellSession shellSession = SshShellSession.openOnSession(
+                    this, getRemoteSession(), options, getRemoteSessionTimeoutMillis());
+            registerShellSession(shellSession);
             return shellSession;
         } catch (JSchException | IOException exception) {
             failAction("SSH shell", exception);
@@ -920,24 +919,24 @@ public class TerminalActions implements AutoCloseable {
         }
     }
 
-    private SshShellSession connectShellSession(SshShellOptions options) throws JSchException, IOException {
-        Session remoteSession = getRemoteSession();
-        int sessionTimeout = Math.toIntExact(TimeUnit.MINUTES.toMillis(SHAFT.Properties.timeouts.shellSessionTimeout()));
-        remoteSession.setTimeout(sessionTimeout);
-        ChannelShell shellChannel = (ChannelShell) remoteSession.openChannel("shell");
-        applyShellOptions(shellChannel, options);
-        shellChannel.connect(sessionTimeout);
-        ReportManager.logDiscrete("Opened SSH shell on " + sshUsername + "@" + sshHostName + ":" + sshPortNumber + ".");
-        return new SshShellSession(this, shellChannel, options);
+    private int getRemoteSessionTimeoutMillis() {
+        return Math.toIntExact(TimeUnit.MINUTES.toMillis(SHAFT.Properties.timeouts.shellSessionTimeout()));
     }
 
-    private void applyShellOptions(ChannelShell shellChannel, SshShellOptions options) {
-        shellChannel.setPty(options.isPty());
-        if (options.isPty()) {
-            shellChannel.setPtyType(options.getPtyType());
-            shellChannel.setPtySize(options.getColumns(), options.getRows(), options.getColumns() * 8, options.getRows() * 16);
+    void registerShellSession(SshShellSession shellSession) {
+        synchronized (this) {
+            activeShellSessions.add(shellSession);
         }
-        options.getEnvironment().forEach(shellChannel::setEnv);
+    }
+
+    int countActiveShellSessions() {
+        synchronized (this) {
+            return activeShellSessions.size();
+        }
+    }
+
+    void logShellOpened() {
+        ReportManager.logDiscrete("Opened SSH shell on " + sshUsername + "@" + sshHostName + ":" + sshPortNumber + ".");
     }
 
     private void closeOpenShellSessions() {

--- a/shaft-engine/src/test/java/com/shaft/cli/SshShellSessionUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/cli/SshShellSessionUnitTest.java
@@ -1,0 +1,145 @@
+package com.shaft.cli;
+
+import com.jcraft.jsch.ChannelShell;
+import com.shaft.driver.SHAFT;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+public class SshShellSessionUnitTest {
+    @Test(description = "readUntil should return output through the first pattern match")
+    public void readUntilShouldReturnMatchedOutput() throws Exception {
+        PipedInputStream shellInput = new PipedInputStream();
+        PipedOutputStream shellOutput = new PipedOutputStream(shellInput);
+        PipedInputStream commandInput = new PipedInputStream();
+        PipedOutputStream commandOutput = new PipedOutputStream(commandInput);
+
+        TerminalActions terminal = SHAFT.CLI.remoteTerminal("host.example.com", 22, "user", "", "");
+        SshShellSession shellSession = new SshShellSession(terminal, commandInput, shellOutput,
+                SshShellOptions.builder().defaultTimeout(Duration.ofSeconds(2)).build());
+
+        Thread producer = new Thread(() -> {
+            try {
+                TimeUnit.MILLISECONDS.sleep(100);
+                commandOutput.write("line-one\nready-prompt ".getBytes(StandardCharsets.UTF_8));
+                commandOutput.flush();
+            } catch (Exception ignored) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        producer.setDaemon(true);
+        producer.start();
+
+        String output = shellSession.readUntil(Pattern.compile("ready-prompt "));
+        Assert.assertEquals(output, "line-one\nready-prompt ");
+        shellSession.close();
+        shellInput.close();
+    }
+
+    @Test(description = "readUntil should fail with a timeout message that includes the pattern")
+    public void readUntilShouldFailWhenTimeoutExpires() throws Exception {
+        PipedInputStream commandInput = new PipedInputStream();
+        PipedOutputStream commandOutput = new PipedOutputStream(commandInput);
+        PipedInputStream shellInput = new PipedInputStream();
+        PipedOutputStream shellOutput = new PipedOutputStream(shellInput);
+
+        TerminalActions terminal = SHAFT.CLI.remoteTerminal("host.example.com", 22, "user", "", "");
+        SshShellSession shellSession = new SshShellSession(terminal, commandInput, shellOutput,
+                SshShellOptions.builder().defaultTimeout(Duration.ofMillis(200)).build());
+
+        Pattern pattern = Pattern.compile("never-appears");
+        RuntimeException failure = Assert.expectThrows(RuntimeException.class,
+                () -> shellSession.readUntil(pattern, Duration.ofMillis(200)));
+        Assert.assertTrue(failure.getMessage().contains("never-appears"));
+        Assert.assertTrue(failure.getMessage().contains("200"));
+        shellSession.close();
+        shellOutput.close();
+    }
+
+    @Test(description = "close should be idempotent")
+    public void closeShouldBeIdempotent() throws Exception {
+        PipedInputStream commandInput = new PipedInputStream();
+        PipedOutputStream commandOutput = new PipedOutputStream(commandInput);
+        PipedInputStream shellInput = new PipedInputStream();
+        PipedOutputStream shellOutput = new PipedOutputStream(shellInput);
+
+        TerminalActions terminal = SHAFT.CLI.remoteTerminal("host.example.com", 22, "user", "", "");
+        SshShellSession shellSession = new SshShellSession(terminal, commandInput, shellOutput, SshShellOptions.builder().build());
+
+        shellSession.close();
+        shellSession.close();
+        shellOutput.close();
+    }
+
+    @Test(description = "sendLine should append a newline before writing")
+    public void sendLineShouldAppendNewline() throws Exception {
+        PipedInputStream shellInput = new PipedInputStream();
+        PipedOutputStream shellOutput = new PipedOutputStream(shellInput);
+        PipedInputStream commandInput = new PipedInputStream();
+
+        TerminalActions terminal = SHAFT.CLI.remoteTerminal("host.example.com", 22, "user", "", "");
+        SshShellSession shellSession = new SshShellSession(terminal, commandInput, shellOutput, SshShellOptions.builder().build());
+
+        shellSession.sendLine("echo hello");
+        byte[] payload = shellInput.readNBytes("echo hello".length() + 1);
+        Assert.assertEquals(new String(payload, StandardCharsets.UTF_8), "echo hello\n");
+        shellSession.close();
+    }
+
+    @Test(description = "close should disconnect a connected ChannelShell opened through openShell")
+    public void closeShouldDisconnectConnectedChannelShell() throws Exception {
+        ChannelShell shellChannel = Mockito.mock(ChannelShell.class);
+        Mockito.when(shellChannel.isConnected()).thenReturn(true);
+        Mockito.when(shellChannel.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[0]));
+        Mockito.when(shellChannel.getOutputStream()).thenReturn(new ByteArrayOutputStream());
+
+        TerminalActions terminal = SHAFT.CLI.remoteTerminal("host.example.com", 22, "user", "", "");
+        SshShellSession shellSession = new SshShellSession(terminal, shellChannel, SshShellOptions.builder().build());
+
+        shellSession.close();
+        Mockito.verify(shellChannel).disconnect();
+    }
+
+    @Test(description = "sendSecret should redact shell logs used for reporting")
+    public void sendSecretShouldUseShellRedactionPath() throws Exception {
+        TerminalActions terminal = SHAFT.CLI.remoteTerminal("host.example.com", 22, "user", "", "");
+        Method redactShellLog = TerminalActions.class.getDeclaredMethod("redactShellLog", String.class);
+        redactShellLog.setAccessible(true);
+
+        String redacted = (String) redactShellLog.invoke(terminal, "password=super-secret");
+        Assert.assertFalse(redacted.contains("super-secret"));
+        Assert.assertTrue(redacted.contains("password=***"));
+    }
+
+    @Test(description = "quit should close tracked shell sessions before disconnecting the SSH session")
+    public void quitShouldCloseTrackedShellSessions() throws Exception {
+        PipedInputStream commandInput = new PipedInputStream();
+        PipedOutputStream commandOutput = new PipedOutputStream(commandInput);
+        PipedInputStream shellInput = new PipedInputStream();
+        PipedOutputStream shellOutput = new PipedOutputStream(shellInput);
+
+        TerminalActions terminal = SHAFT.CLI.remoteTerminal("host.example.com", 22, "user", "", "");
+        SshShellSession shellSession = new SshShellSession(terminal, commandInput, shellOutput, SshShellOptions.builder().build());
+
+        java.lang.reflect.Field activeShellSessionsField = TerminalActions.class.getDeclaredField("activeShellSessions");
+        activeShellSessionsField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        java.util.List<SshShellSession> activeShellSessions =
+                (java.util.List<SshShellSession>) activeShellSessionsField.get(terminal);
+        activeShellSessions.add(shellSession);
+
+        terminal.quit();
+        shellOutput.close();
+        Assert.assertTrue(activeShellSessions.isEmpty(), "quit() should clear tracked shell sessions");
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/cli/SshShellSessionUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/cli/SshShellSessionUnitTest.java
@@ -10,7 +10,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
-import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -49,9 +48,7 @@ public class SshShellSessionUnitTest {
     @Test(description = "readUntil should fail with a timeout message that includes the pattern")
     public void readUntilShouldFailWhenTimeoutExpires() throws Exception {
         PipedInputStream commandInput = new PipedInputStream();
-        PipedOutputStream commandOutput = new PipedOutputStream(commandInput);
-        PipedInputStream shellInput = new PipedInputStream();
-        PipedOutputStream shellOutput = new PipedOutputStream(shellInput);
+        PipedOutputStream shellOutput = new PipedOutputStream(new PipedInputStream());
 
         TerminalActions terminal = SHAFT.CLI.remoteTerminal("host.example.com", 22, "user", "", "");
         SshShellSession shellSession = new SshShellSession(terminal, commandInput, shellOutput,
@@ -69,9 +66,7 @@ public class SshShellSessionUnitTest {
     @Test(description = "close should be idempotent")
     public void closeShouldBeIdempotent() throws Exception {
         PipedInputStream commandInput = new PipedInputStream();
-        PipedOutputStream commandOutput = new PipedOutputStream(commandInput);
-        PipedInputStream shellInput = new PipedInputStream();
-        PipedOutputStream shellOutput = new PipedOutputStream(shellInput);
+        PipedOutputStream shellOutput = new PipedOutputStream(new PipedInputStream());
 
         TerminalActions terminal = SHAFT.CLI.remoteTerminal("host.example.com", 22, "user", "", "");
         SshShellSession shellSession = new SshShellSession(terminal, commandInput, shellOutput, SshShellOptions.builder().build());
@@ -111,12 +106,9 @@ public class SshShellSessionUnitTest {
     }
 
     @Test(description = "sendSecret should redact shell logs used for reporting")
-    public void sendSecretShouldUseShellRedactionPath() throws Exception {
+    public void sendSecretShouldUseShellRedactionPath() {
         TerminalActions terminal = SHAFT.CLI.remoteTerminal("host.example.com", 22, "user", "", "");
-        Method redactShellLog = TerminalActions.class.getDeclaredMethod("redactShellLog", String.class);
-        redactShellLog.setAccessible(true);
-
-        String redacted = (String) redactShellLog.invoke(terminal, "password=super-secret");
+        String redacted = terminal.redactShellLog("password=super-secret");
         Assert.assertFalse(redacted.contains("super-secret"));
         Assert.assertTrue(redacted.contains("password=***"));
     }
@@ -124,22 +116,15 @@ public class SshShellSessionUnitTest {
     @Test(description = "quit should close tracked shell sessions before disconnecting the SSH session")
     public void quitShouldCloseTrackedShellSessions() throws Exception {
         PipedInputStream commandInput = new PipedInputStream();
-        PipedOutputStream commandOutput = new PipedOutputStream(commandInput);
-        PipedInputStream shellInput = new PipedInputStream();
-        PipedOutputStream shellOutput = new PipedOutputStream(shellInput);
+        PipedOutputStream shellOutput = new PipedOutputStream(new PipedInputStream());
 
         TerminalActions terminal = SHAFT.CLI.remoteTerminal("host.example.com", 22, "user", "", "");
         SshShellSession shellSession = new SshShellSession(terminal, commandInput, shellOutput, SshShellOptions.builder().build());
-
-        java.lang.reflect.Field activeShellSessionsField = TerminalActions.class.getDeclaredField("activeShellSessions");
-        activeShellSessionsField.setAccessible(true);
-        @SuppressWarnings("unchecked")
-        java.util.List<SshShellSession> activeShellSessions =
-                (java.util.List<SshShellSession>) activeShellSessionsField.get(terminal);
-        activeShellSessions.add(shellSession);
+        terminal.registerShellSession(shellSession);
+        Assert.assertEquals(terminal.countActiveShellSessions(), 1);
 
         terminal.quit();
         shellOutput.close();
-        Assert.assertTrue(activeShellSessions.isEmpty(), "quit() should clear tracked shell sessions");
+        Assert.assertEquals(terminal.countActiveShellSessions(), 0);
     }
 }

--- a/shaft-engine/src/test/java/testPackage/legacy/SshShellIntegrationTest.java
+++ b/shaft-engine/src/test/java/testPackage/legacy/SshShellIntegrationTest.java
@@ -1,0 +1,54 @@
+package testPackage.legacy;
+
+import com.shaft.cli.SshShellOptions;
+import com.shaft.cli.SshShellSession;
+import com.shaft.cli.TerminalActions;
+import com.shaft.driver.SHAFT;
+import com.shaft.validation.Validations;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+import java.util.regex.Pattern;
+
+public class SshShellIntegrationTest {
+    @Test(description = "SSH shell prompt-response flow over reusable remote terminal")
+    public void sshShellPromptResponseFlow() {
+        String sshHostName = System.getenv("TEST_SSH_HOST");
+        String sshPort = System.getenv("TEST_SSH_PORT");
+        String sshUsername = System.getenv("TEST_SSH_USERNAME");
+        String sshKeyFileFolderName = System.getenv("TEST_SSH_KEY_FOLDER");
+        String sshKeyFileName = System.getenv("TEST_SSH_KEY_NAME");
+
+        if (isBlank(sshHostName) || isBlank(sshPort) || isBlank(sshUsername)
+                || isBlank(sshKeyFileFolderName) || isBlank(sshKeyFileName)) {
+            throw new SkipException("TEST_SSH_* environment variables are not configured.");
+        }
+
+        TerminalActions remote = SHAFT.CLI.remoteTerminal(
+                sshHostName,
+                Integer.parseInt(sshPort),
+                sshUsername,
+                sshKeyFileFolderName,
+                sshKeyFileName);
+
+        SshShellOptions shellOptions = SshShellOptions.builder()
+                .pty(true)
+                .defaultTimeout(Duration.ofSeconds(30))
+                .build();
+
+        try (SshShellSession shell = remote.openShell(shellOptions)) {
+            shell.sendLine("printf ready; read line; echo done-$line");
+            shell.readUntil(Pattern.compile("ready"));
+            shell.sendLine("shaft-line");
+            String finalOutput = shell.readUntil(Pattern.compile("done-shaft-line"));
+            Validations.assertThat().object(finalOutput).contains("done-shaft-line");
+        } finally {
+            remote.quit();
+        }
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/shaft-engine/src/test/java/testPackage/unitTests/SshShellOptionsUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/SshShellOptionsUnitTest.java
@@ -1,0 +1,45 @@
+package testPackage.unitTests;
+
+import com.shaft.cli.SshShellOptions;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+import java.util.Map;
+
+public class SshShellOptionsUnitTest {
+    @Test(description = "Builder should apply documented defaults")
+    public void builderShouldApplyDefaults() {
+        SshShellOptions options = SshShellOptions.builder().build();
+
+        Assert.assertFalse(options.isPty());
+        Assert.assertEquals(options.getPtyType(), "vt100");
+        Assert.assertEquals(options.getColumns(), 80);
+        Assert.assertEquals(options.getRows(), 24);
+        Assert.assertEquals(options.getDefaultTimeout(), Duration.ofSeconds(30));
+        Assert.assertTrue(options.getEnvironment().isEmpty());
+    }
+
+    @Test(description = "Builder should copy environment variables")
+    public void builderShouldCopyEnvironmentVariables() {
+        SshShellOptions options = SshShellOptions.builder()
+                .environment(Map.of("LC_ALL", "C"))
+                .build();
+
+        Assert.assertEquals(options.getEnvironment().get("LC_ALL"), "C");
+    }
+
+    @Test(description = "Builder should reject non-positive PTY dimensions")
+    public void builderShouldRejectNonPositivePtyDimensions() {
+        IllegalArgumentException failure = Assert.expectThrows(IllegalArgumentException.class,
+                () -> SshShellOptions.builder().columns(0).build());
+        Assert.assertTrue(failure.getMessage().contains("columns"));
+    }
+
+    @Test(description = "Builder should reject non-positive default timeout")
+    public void builderShouldRejectNonPositiveDefaultTimeout() {
+        IllegalArgumentException failure = Assert.expectThrows(IllegalArgumentException.class,
+                () -> SshShellOptions.builder().defaultTimeout(Duration.ZERO).build());
+        Assert.assertTrue(failure.getMessage().contains("timeout"));
+    }
+}

--- a/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
@@ -4,6 +4,7 @@ import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import com.shaft.cli.SshConnectionOptions;
+import com.shaft.cli.SshShellOptions;
 import com.shaft.cli.TerminalActions;
 import com.shaft.driver.SHAFT;
 import org.apache.commons.lang3.SystemUtils;
@@ -785,5 +786,31 @@ public class TerminalActionsUnitTest {
         String log = terminal.performTerminalCommand("echo legacy-string-api");
         Assert.assertTrue(log.contains("legacy-string-api"),
                 "Existing String API should still return command output for assertions");
+    }
+
+    @Test(description = "openShell should fail for local terminals")
+    public void openShellShouldFailForLocalTerminal() {
+        TerminalActions terminal = new TerminalActions();
+        RuntimeException failure = Assert.expectThrows(RuntimeException.class,
+                () -> terminal.openShell(SshShellOptions.builder().build()));
+        Assert.assertTrue(failure.getMessage().contains("remote SSH terminals"));
+    }
+
+    @Test(description = "openShell should fail for ephemeral remote terminals")
+    public void openShellShouldFailForEphemeralRemoteTerminal() {
+        TerminalActions terminal = new TerminalActions("host.example.com", 22, "user", "/keys/", "id_rsa");
+        RuntimeException failure = Assert.expectThrows(RuntimeException.class,
+                () -> terminal.openShell(SshShellOptions.builder().build()));
+        Assert.assertTrue(failure.getMessage().contains("SHAFT.CLI.remoteTerminal"));
+    }
+
+    @Test(description = "openShell should fail for dockerized remote terminals")
+    @SuppressWarnings("deprecation")
+    public void openShellShouldFailForDockerizedRemoteTerminal() {
+        TerminalActions terminal = new TerminalActions(
+                "host.example.com", 22, "user", "/keys/", "id_rsa", "appContainer", "appUser");
+        RuntimeException failure = Assert.expectThrows(RuntimeException.class,
+                () -> terminal.openShell(SshShellOptions.builder().build()));
+        Assert.assertTrue(failure.getMessage().contains("dockerized remote terminals"));
     }
 }


### PR DESCRIPTION
**Summary**
Adds experimental interactive SSH shell/PTY support for reusable remote terminals ([#3132](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/3132)).

- New SshShellOptions for PTY, terminal size, default timeout, and optional env vars
- New SshShellSession (AutoCloseable) with send, sendLine, sendSecret, and readUntil(Pattern[, Duration])
- TerminalActions.openShell(options) on reusable SHAFT.CLI.remoteTerminal(...) sessions 
- quit() closes tracked shell channels before disconnecting the SSH session
- Shell logs use the existing terminal redaction path; secrets are never logged raw

Tests:
[PTYShellTests-report.html](https://github.com/user-attachments/files/29592290/PTYShellTests-report.html)


Part of the #2695 SSH Feature