### PR TITLE
Finalize mobile Assistant recording workflows

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -63,7 +63,7 @@ final class AssistantCommand {
                     "/mobile native Android Pixel_6", (command, rest, workingDirectory) -> mobile(rest)),
             new CommandDefinition("/mobile-record", "Record mobile actions",
                     List.of("/app-record", "/inspector-record"),
-                    "/mobile-record inspector Android recordings/inspector.json", (command, rest, workingDirectory) -> mobileRecord(rest)),
+                    "/mobile-record inspector Android recordings/inspector.json", (command, rest, workingDirectory) -> mobileRecord("/inspector-record".equals(command) ? "inspector " + rest : rest)),
             new CommandDefinition("/mobile-codegen", "Generate mobile replay snippets",
                     List.of("/app-codegen"),
                     "/mobile-codegen recordings/mobile.json", (command, rest, workingDirectory) -> mobileCodegen(rest)),

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java
@@ -233,7 +233,107 @@ final class AssistantMarkdown {
         if (object.has("currentContext") && object.has("source") && object.has("characterCount")) {
             return mobileAccessibilityMarkdown(object);
         }
+        if (object.has("confirmationToken") && object.has("readyToStart") && object.has("confirmationRequired")) {
+            return mobileInspectorPlanMarkdown(object);
+        }
+        if (object.has("inspectorUrl") && object.has("appiumServerUrl") && object.has("actionCount")) {
+            return mobileInspectorRecordingStatusMarkdown(object);
+        }
+        if (object.has("active") && object.has("outputPath") && object.has("actionCount")) {
+            return mobileRecordingStatusMarkdown(object);
+        }
         return "";
+    }
+
+    private static String mobileRecordingStatusMarkdown(JsonObject object) {
+        List<String> sections = new ArrayList<>();
+        sections.add(metadataLine(
+                "Recording", booleanValue(object, "active") ? "active" : "stopped",
+                "Mode", string(object, "mode", ""),
+                "Actions", string(object, "actionCount", ""),
+                "Sensitive values", booleanValue(object, "includeSensitiveValues") ? "included" : "excluded"));
+        String outputPath = string(object, "outputPath", "");
+        if (!outputPath.isBlank()) {
+            sections.add("**Output:** `" + outputPath + "`");
+        }
+        String warnings = warnings(object);
+        if (!warnings.isBlank()) {
+            sections.add(warnings);
+        }
+        return joinSections(sections);
+    }
+
+    private static String mobileInspectorPlanMarkdown(JsonObject object) {
+        List<String> sections = new ArrayList<>();
+        sections.add(metadataLine(
+                "Inspector plan", booleanValue(object, "readyToStart") ? "ready" : "not ready",
+                "Platform", string(object, "platformName", ""),
+                "Confirmation", booleanValue(object, "confirmationRequired") ? "required" : "not required",
+                "Sensitive values", booleanValue(object, "includeSensitiveValues") ? "included" : "excluded"));
+        String token = string(object, "confirmationToken", "");
+        if (!token.isBlank()) {
+            sections.add("**Confirmation token:** `" + token + "`");
+        }
+        sections.add(metadataLine(
+                "Device", string(object, "selectedDeviceId", ""),
+                "AVD", string(object, "selectedAndroidAvdName", ""),
+                "Provision emulator", booleanValue(object, "willProvisionAndroidEmulator") ? "yes" : "no",
+                "Real device", booleanValue(object, "realDeviceAvailable") ? "available" : "not detected"));
+        String outputPath = string(object, "outputPath", "");
+        if (!outputPath.isBlank()) {
+            sections.add("**Recording output:** `" + outputPath + "`");
+        }
+        String nextSteps = bulletList("Next steps", object, "nextSteps");
+        if (!nextSteps.isBlank()) {
+            sections.add(nextSteps);
+        }
+        if (object.has("codeBlocks") && object.get("codeBlocks").isJsonArray()) {
+            String blocks = codeBlocksMarkdown(object.getAsJsonArray("codeBlocks"));
+            if (!blocks.isBlank()) {
+                sections.add(blocks);
+            }
+        }
+        String warnings = warnings(object);
+        if (!warnings.isBlank()) {
+            sections.add(warnings);
+        }
+        return joinSections(sections);
+    }
+
+    private static String mobileInspectorRecordingStatusMarkdown(JsonObject object) {
+        List<String> sections = new ArrayList<>();
+        sections.add(metadataLine(
+                "Inspector recording", booleanValue(object, "active") ? "active" : "stopped",
+                "Paused", booleanValue(object, "paused") ? "yes" : "no",
+                "Platform", string(object, "platformName", ""),
+                "Actions", string(object, "actionCount", "")));
+        sections.add(metadataLine(
+                "Device", string(object, "deviceId", ""),
+                "AVD", string(object, "androidAvdName", ""),
+                "Managed emulator", booleanValue(object, "managedEmulator") ? "yes" : "no"));
+        String outputPath = string(object, "outputPath", "");
+        if (!outputPath.isBlank()) {
+            sections.add("**Output:** `" + outputPath + "`");
+        }
+        String inspectorUrl = string(object, "inspectorUrl", "");
+        if (!inspectorUrl.isBlank()) {
+            sections.add("**Inspector URL:** " + inspectorUrl);
+        }
+        String appiumServerUrl = string(object, "appiumServerUrl", "");
+        if (!appiumServerUrl.isBlank()) {
+            sections.add("**Appium server:** " + appiumServerUrl);
+        }
+        if (object.has("codeBlocks") && object.get("codeBlocks").isJsonArray()) {
+            String blocks = codeBlocksMarkdown(object.getAsJsonArray("codeBlocks"));
+            if (!blocks.isBlank()) {
+                sections.add(blocks);
+            }
+        }
+        String warnings = warnings(object);
+        if (!warnings.isBlank()) {
+            sections.add(warnings);
+        }
+        return joinSections(sections);
     }
 
     private static String mobileToolchainMarkdown(JsonObject object) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
@@ -403,6 +403,7 @@ class AssistantCommandTest {
                         command("/mobile-record start recordings/mobile.json").arguments().get("outputPath").getAsString()),
                 () -> assertEquals("mobile_record_stop", command("/app-record stop").toolName()),
                 () -> assertEquals("mobile_inspector_record_prepare", inspector.toolName()),
+                () -> assertEquals("mobile_inspector_record_prepare", command("/inspector-record Android recordings/inspector.json").toolName()),
                 () -> assertEquals("Android", inspector.arguments().get("platformName").getAsString()),
                 () -> assertEquals("recordings/inspector.json", inspector.arguments().get("outputPath").getAsString()),
                 () -> assertEquals("mobile_recording_code_blocks",

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantMarkdownTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantMarkdownTest.java
@@ -232,6 +232,67 @@ class AssistantMarkdownTest {
     }
 
     @Test
+    void formatsMobileRecordingAndInspectorResponsesWithoutRawJson() {
+        String recording = AssistantMarkdown.fromMcpOutput("mobile_record_start", mcpText("""
+                {
+                  "active": true,
+                  "outputPath": "recordings/mobile.json",
+                  "mode": "default",
+                  "actionCount": 0,
+                  "includeSensitiveValues": false,
+                  "warnings": []
+                }
+                """));
+        String plan = AssistantMarkdown.fromMcpOutput("mobile_inspector_record_prepare", mcpText("""
+                {
+                  "confirmationToken": "confirm-123",
+                  "platformName": "Android",
+                  "readyToStart": true,
+                  "confirmationRequired": true,
+                  "willProvisionAndroidEmulator": false,
+                  "realDeviceAvailable": true,
+                  "selectedDeviceId": "emulator-5554",
+                  "selectedAndroidAvdName": "Pixel_6",
+                  "outputPath": "recordings/inspector.json",
+                  "includeSensitiveValues": false,
+                  "appiumCapabilities": {},
+                  "codeBlocks": [],
+                  "nextSteps": ["Review the plan, then call mobile_inspector_record_start with the confirmation token."],
+                  "warnings": ["Inspector is not opened until start is explicitly confirmed."]
+                }
+                """));
+        String status = AssistantMarkdown.fromMcpOutput("mobile_inspector_record_status", mcpText("""
+                {
+                  "active": true,
+                  "paused": false,
+                  "platformName": "Android",
+                  "deviceId": "emulator-5554",
+                  "androidAvdName": "Pixel_6",
+                  "managedEmulator": false,
+                  "outputPath": "recordings/inspector.json",
+                  "inspectorUrl": "http://127.0.0.1:4723/inspector",
+                  "appiumServerUrl": "http://127.0.0.1:4723",
+                  "actionCount": 2,
+                  "codeBlocks": [],
+                  "warnings": []
+                }
+                """));
+
+        assertAll(
+                () -> assertTrue(recording.contains("**Recording:** active")),
+                () -> assertTrue(recording.contains("**Sensitive values:** excluded")),
+                () -> assertTrue(recording.contains("`recordings/mobile.json`")),
+                () -> assertFalse(recording.contains("\"includeSensitiveValues\"")),
+                () -> assertTrue(plan.contains("**Inspector plan:** ready")),
+                () -> assertTrue(plan.contains("**Confirmation token:** `confirm-123`")),
+                () -> assertTrue(plan.contains("Inspector is not opened until start is explicitly confirmed.")),
+                () -> assertFalse(plan.contains("\"appiumCapabilities\"")),
+                () -> assertTrue(status.contains("**Inspector recording:** active")),
+                () -> assertTrue(status.contains("http://127.0.0.1:4723/inspector")),
+                () -> assertFalse(status.contains("\"managedEmulator\"")));
+    }
+
+    @Test
     void unknownJsonCanUseAgentFormatterButKnownResponsesDoNot() {
         assertAll(
                 () -> assertTrue(AssistantMarkdown.shouldFormatWithAgent("browser_unknown", "{\"unexpected\":true}")),

--- a/tools/intellij-plugin-recording/README.md
+++ b/tools/intellij-plugin-recording/README.md
@@ -53,6 +53,24 @@ Screenshot commands write workspace evidence paths and omit base64 payloads by d
 6. Approve generation with `approve`, `okay`, or `generate`.
 7. Confirm the local agent writes Page Object Model automation files after approval.
 
+## Assistant Mobile Recording
+
+The Assistant exposes the mobile recording path from chat without opening Appium Inspector or any external UI on its own. Recording commands default to workspace-contained JSON paths and keep typed values out of persisted actions unless `includeSensitiveValues` is explicitly enabled in the reviewed MCP arguments.
+
+Examples:
+
+- `/mobile-record start recordings/mobile.json` starts an MCP mobile action recording.
+- `/app-record stop` stops the active recording without discarding it; use a reviewed `discard=true` argument only when the recording should be deleted.
+- `/mobile-codegen recordings/mobile.json` and `/mobile-replay recordings/mobile.json` render reusable SHAFT mobile replay snippets from the saved recording path.
+- `/mobile-record inspector Android recordings/inspector.json` prepares a confirmation-ready wrapped Appium Inspector recording plan. The returned confirmation token must be passed to `mobile_inspector_record_start` before Inspector can run.
+- `/inspector-record Android recordings/inspector.json` is an alias for Inspector preparation, not an implicit request to open a browser or desktop Inspector window.
+
+Expected chat output:
+
+- Mobile recording status is summarized with active/stopped state, action count, output path, and whether sensitive values are excluded.
+- Inspector preparation shows readiness, confirmation requirement, device/AVD selection, output path, next steps, warnings, and code blocks without exposing raw capability JSON unless the user asks for raw MCP output.
+- Inspector status shows active/paused state, Appium/Inspector URLs, output path, action count, warnings, and generated replay snippets after stop.
+
 ## Expected Behavior
 
 - `start recording` uses a fresh capture output path for each session.


### PR DESCRIPTION
### Motivation
- Ensure Assistant mobile recording and Inspector workflows route correctly and surface user-friendly summaries instead of raw JSON.
- Provide a safe confirmation boundary for wrapped Appium Inspector sessions so Inspector UI is not opened implicitly from chat.
- Improve chat UX by rendering mobile-recording and Inspector responses as concise Markdown with output paths, confirmation tokens, next steps, warnings, and generated snippets.

### Description
- Fix alias routing in `AssistantCommand` so `/inspector-record` maps to the Inspector preparation invocation rather than falling through to an unknown mobile-record action (edit: `shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java`).
- Add mobile response formatters to `AssistantMarkdown`: `mobileRecordingStatusMarkdown`, `mobileInspectorPlanMarkdown`, and `mobileInspectorRecordingStatusMarkdown`, and wire them into `mobileMarkdown` to render recording/plan/status responses cleanly (edit: `shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java`).
- Add targeted unit tests validating command parsing and Markdown formatting for mobile recording and Inspector workflows (edit: `shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java` and `.../AssistantMarkdownTest.java`).
- Document Assistant mobile recording/Inspector behaviors and the explicit confirmation safety boundary in the IntelliJ plugin recording README, and include fresh plugin screenshots produced by the screenshot renderer test (edit: `tools/intellij-plugin-recording/README.md` and generated `target/shaft-intellij-screenshots/`).

### Testing
- Ran focused unit tests with Gradle using Java 21 and Gradle 9.6.1: `.../gradle -p shaft-intellij test --tests com.shaft.intellij.ui.AssistantCommandTest --tests com.shaft.intellij.ui.AssistantMarkdownTest`, and the tests passed.
- Rendered screenshot evidence by running `.../gradle -p shaft-intellij test --tests com.shaft.intellij.ui.ShaftPluginScreenshotRendererTest -Dshaft.intellij.screenshotDir=../target/shaft-intellij-screenshots`, which succeeded and produced screenshots under `target/shaft-intellij-screenshots/`.
- Ran CI validation scripts `python3 scripts/ci/validate_agent_setup.py`, `python3 scripts/ci/validate_shaft_mcp_configuration.py`, `python3 scripts/ci/validate_modular_documentation.py`, and `python3 scripts/ci/validate_documentation_boundaries.py`, and they all reported valid results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46612afa608320b30494398066733b)