### PR TITLE
Add natural MCP productivity commands to IntelliJ Assistant

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -91,6 +91,16 @@ final class AssistantCommand {
     private static final List<NaturalIntent> NATURAL_INTENTS = List.of(
             new NaturalIntent(AssistantCommand::isCommandHelpIntent,
                     (text, workingDirectory) -> Invocation.local(commandHelp())),
+            new NaturalIntent(AssistantCommand::isGuideSearchIntent,
+                    (text, workingDirectory) -> Invocation.tool("shaft_guide_search", guide(naturalQuery(text)))),
+            new NaturalIntent(AssistantCommand::isScenarioSearchIntent,
+                    (text, workingDirectory) -> Invocation.tool("test_automation_scenarios", scenarios(naturalQuery(text)))),
+            new NaturalIntent(AssistantCommand::isGuardrailsCheckIntent,
+                    (text, workingDirectory) -> Invocation.tool("test_code_guardrails_check", guardrails(naturalCode(text)))),
+            new NaturalIntent(AssistantCommand::isProjectCreateIntent,
+                    (text, workingDirectory) -> Invocation.tool("shaft_project_create", projectCreate(naturalProjectName(text)))),
+            new NaturalIntent(AssistantCommand::isProjectUpgradeIntent,
+                    (text, workingDirectory) -> Invocation.tool("shaft_project_upgrade", projectUpgrade(naturalProjectRoot(text, workingDirectory)))),
             new NaturalIntent(AssistantCommand::isBrowserControlIntent,
                     (text, workingDirectory) -> browser(text)),
             new NaturalIntent(AssistantCommand::isBrowserRecordingIntent,
@@ -679,6 +689,55 @@ final class AssistantCommand {
                 || normalized.contains(" can i use"));
     }
 
+    private static boolean isGuideSearchIntent(String text) {
+        String normalized = normalizeNaturalCommand(text);
+        return (normalized.startsWith("search shaft docs ")
+                || normalized.startsWith("search the shaft docs ")
+                || normalized.startsWith("search shaft guide ")
+                || normalized.startsWith("search the shaft guide ")
+                || normalized.startsWith("find shaft docs ")
+                || normalized.startsWith("find shaft guide ")
+                || normalized.startsWith("guide me on ")
+                || normalized.startsWith("docs for "))
+                && !naturalQuery(text).isBlank();
+    }
+
+    private static boolean isScenarioSearchIntent(String text) {
+        String normalized = normalizeNaturalCommand(text);
+        return (normalized.startsWith("find scenarios ")
+                || normalized.startsWith("find automation scenarios ")
+                || normalized.startsWith("show scenarios ")
+                || normalized.startsWith("automation scenarios for ")
+                || normalized.startsWith("scenario ideas for "))
+                && !naturalQuery(text).isBlank();
+    }
+
+    private static boolean isGuardrailsCheckIntent(String text) {
+        String normalized = normalizeNaturalCommand(text);
+        return (normalized.startsWith("check generated java code ")
+                || normalized.startsWith("check this java code ")
+                || normalized.startsWith("run guardrails ")
+                || normalized.startsWith("guardrails check "))
+                && !naturalCode(text).isBlank();
+    }
+
+    private static boolean isProjectCreateIntent(String text) {
+        String normalized = normalizeNaturalCommand(text);
+        return normalized.startsWith("create shaft project ")
+                || normalized.startsWith("create a shaft project ")
+                || normalized.startsWith("new shaft project ")
+                || normalized.startsWith("scaffold shaft project ");
+    }
+
+    private static boolean isProjectUpgradeIntent(String text) {
+        String normalized = normalizeNaturalCommand(text);
+        return normalized.startsWith("preview shaft upgrade")
+                || normalized.startsWith("preview upgrade")
+                || normalized.startsWith("dry run shaft upgrade")
+                || normalized.startsWith("upgrade shaft project")
+                || normalized.startsWith("upgrade this shaft project");
+    }
+
     private static boolean containsAny(String text, String... needles) {
         if (text == null || needles == null) {
             return false;
@@ -773,6 +832,67 @@ final class AssistantCommand {
                 || normalized.startsWith("analyze allure")
                 || normalized.startsWith("analyse allure")
                 || normalized.startsWith("doctor ");
+    }
+
+    private static String naturalQuery(String text) {
+        String trimmed = text(text);
+        String[] prefixes = {
+                "search the shaft docs", "search shaft docs", "search the shaft guide", "search shaft guide",
+                "find shaft docs", "find shaft guide", "guide me on", "docs for",
+                "find automation scenarios", "find scenarios", "show scenarios", "automation scenarios for",
+                "scenario ideas for", "run guardrails", "guardrails check"
+        };
+        String lower = trimmed.toLowerCase(Locale.ROOT);
+        for (String prefix : prefixes) {
+            if (lower.startsWith(prefix)) {
+                return trimmed.substring(prefix.length()).trim();
+            }
+        }
+        return trimmed;
+    }
+
+    private static String naturalCode(String text) {
+        String query = naturalQuery(text);
+        String lower = query.toLowerCase(Locale.ROOT);
+        String[] prefixes = {"check generated java code", "check this java code"};
+        for (String prefix : prefixes) {
+            if (lower.startsWith(prefix)) {
+                return query.substring(prefix.length()).trim();
+            }
+        }
+        return query;
+    }
+
+    private static String naturalProjectName(String text) {
+        String normalized = normalizeNaturalCommand(text);
+        String[] prefixes = {"create a shaft project", "create shaft project", "new shaft project", "scaffold shaft project"};
+        for (String prefix : prefixes) {
+            if (normalized.startsWith(prefix)) {
+                String name = text(text).substring(Math.min(prefix.length(), text(text).length())).trim();
+                return firstTokenOrDefault(name, "shaft-demo");
+            }
+        }
+        return "shaft-demo";
+    }
+
+    private static String naturalProjectRoot(String text, String workingDirectory) {
+        String trimmed = text(text);
+        String lower = trimmed.toLowerCase(Locale.ROOT);
+        String[] prefixes = {"preview shaft upgrade", "preview upgrade", "dry run shaft upgrade",
+                "upgrade this shaft project", "upgrade shaft project"};
+        for (String prefix : prefixes) {
+            if (lower.startsWith(prefix)) {
+                String root = firstTokenOrDefault(trimmed.substring(prefix.length()).trim(), "");
+                if (!root.isBlank()) {
+                    return root;
+                }
+            }
+        }
+        String path = firstPathLike(text);
+        if (!path.isBlank()) {
+            return path;
+        }
+        return workingDirectory == null || workingDirectory.isBlank() ? "." : workingDirectory;
     }
 
     private static JsonObject triage(String workingDirectory) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
@@ -456,7 +456,23 @@ class AssistantCommandTest {
 
     @Test
     void naturalIntentRoutesObviousMcpFeatureRequests() {
+        AssistantCommand.Invocation projectUpgrade = command("preview shaft upgrade .", "C:/work/project");
+
         assertAll(
+                () -> assertEquals("shaft_guide_search", command("search SHAFT docs locators").toolName()),
+                () -> assertEquals("locators", command("search SHAFT docs locators").arguments().get("query").getAsString()),
+                () -> assertEquals("test_automation_scenarios", command("find automation scenarios checkout").toolName()),
+                () -> assertEquals("checkout", command("find automation scenarios checkout").arguments().get("intent").getAsString()),
+                () -> assertEquals("test_code_guardrails_check",
+                        command("check generated Java code driver.element().click(locator);").toolName()),
+                () -> assertEquals("driver.element().click(locator);",
+                        command("check generated Java code driver.element().click(locator);").arguments().get("code").getAsString()),
+                () -> assertEquals("shaft_project_create", command("create SHAFT project demo-web").toolName()),
+                () -> assertEquals("demo-web", command("create SHAFT project demo-web").arguments().get("outputDirectory").getAsString()),
+                () -> assertEquals("shaft_project_upgrade", projectUpgrade.toolName()),
+                () -> assertTrue(projectUpgrade.arguments().get("dryRun").getAsBoolean()),
+                () -> assertFalse(projectUpgrade.arguments().get("approve").getAsBoolean()),
+                () -> assertEquals(".", projectUpgrade.arguments().get("projectRoot").getAsString()),
                 () -> assertEquals("mobile_record_start", command("start mobile recording").toolName()),
                 () -> assertEquals("capture_start", command("start a browser recording").toolName()),
                 () -> assertEquals("doctor_analyze_failed_allure",


### PR DESCRIPTION
### Motivation
- Improve the IntelliJ Assistant so common natural-language productivity prompts map directly to curated MCP tools for guide/docs search, scenario discovery, guardrail checks, and project operations. 
- Preserve explicit `/mcp` and existing slash commands while offering safer, higher-confidence local MCP invocations for common intents. 
- Provide deterministic behavior for upgrade previews by keeping dry-run semantics (`dryRun=true`, `approve=false`).

### Description
- Added new natural intent predicates and routing entries to `NATURAL_INTENTS` in `shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java` to handle guide/docs search, scenario search, guardrails checks, project creation, and project upgrade preview. 
- Implemented extraction helpers (`naturalQuery`, `naturalCode`, `naturalProjectName`, `naturalProjectRoot`) to derive MCP tool arguments from free-form prompts while honoring explicit roots like `.`. 
- Preserved existing slash-command handlers (`/guide`, `/scenarios`, `/guardrails`, `/project`, `/mcp`) and kept raw MCP behavior unchanged. 
- Added regression coverage in `shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java` and updated screenshot generation via `ShaftPluginScreenshotRendererTest` with artifacts placed under `artifacts/issue-3210-screenshots/`.

### Testing
- Ran `AssistantCommand` and `AssistantMarkdown` unit tests with Gradle; they passed when executed with `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2` and Gradle 9.0 via the command shown in the PR body. 
- Ran `ShaftPluginScreenshotRendererTest` to produce fresh screenshots in `artifacts/issue-3210-screenshots/` and the test succeeded. 
- Executed repository validations `python3 scripts/ci/validate_shaft_mcp_configuration.py` and `python3 scripts/ci/validate_documentation_boundaries.py`, both of which succeeded. 
- Note: an initial local run failed under the environment default JVM/Gradle (JDK 25 and Gradle 8), so the successful test run used `JAVA_HOME=.../java/21.0.2` and Gradle 9 as documented in the PR validation notes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a466ab180ec8320a1427f7da443d761)