### PR TITLE
Add deterministic release PR workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -31,6 +31,7 @@ flowchart TD
 
   MANUAL["Manual only"] --> COPILOT["Copilot Setup Steps"]
   MANUAL --> AGENTS["Refresh Agent Instructions"]
+  MANUAL --> RELEASE_PR["Prepare Release Pull Request"]
 ```
 
 `workflow_run` links use the workflow `name`, not the file name. Renaming
@@ -55,6 +56,7 @@ updating downstream workflows will break the release chain.
 | `lambdatestTests.yml` | LambdaTest E2E Tests | Nightly at 01:00 UTC, plus manual | Uploads LambdaTest mobile apps, verifies LambdaTest credentials, and runs native Android, native iOS, web app, and desktop web suites. | Serial cloud-provider workflow: later jobs depend on earlier mobile upload jobs. Delete only if LambdaTest coverage is intentionally retired. |
 | `update-selenium-grid-versions.yml` | Update Selenium Grid Docker Versions | Weekly Monday 08:00 UTC, plus manual | Reads SeleniumHQ Docker Compose references, updates SHAFT's Selenium Grid image versions, validates Docker Compose syntax, and opens an automated PR. | Maintenance bot for `shaft-engine/src/main/resources/docker-compose/selenium4.yml`, which is used by Selenium Grid E2E jobs. |
 | `sync-sample-projects-version.yml` | Sync Sample Projects SHAFT Version | Published GitHub releases, plus manual version input | Syncs sample project POM versions and plugin/dependency versions to the released SHAFT version, then opens an automated PR. | Consumes the GitHub release created by `mavenCentral_cd.yml`. |
+| `prepare-release-pr.yml` | Prepare Release Pull Request | Manual only, with release date input | Computes the dated SHAFT release version, updates release metadata, validates static release contracts, and opens an automated PR. | Creates the release PR that later feeds `Maven Central Continuous Delivery` after merge. |
 | `refresh-agent-instructions.yml` | Refresh Agent Instructions | Manual only, with reason and optional `force_ai` input | Audits agent guidance, optionally runs Codex to refresh guidance surfaces, validates the final guidance, enforces an allowlist, and opens an automated PR. | Manual maintenance bot for `AGENTS.md`, `CLAUDE.md`, `.agents`, `.github/instructions`, and related guidance files. |
 | `copilot-setup-steps.yml` | Copilot Setup Steps | Manual only | Prepares the GitHub Copilot coding-agent environment by checking out the repo, installing Java 25 and Maven, and pre-resolving Maven dependencies. | Only affects Copilot coding-agent setup. No downstream workflows depend on it. |
 
@@ -75,6 +77,7 @@ These workflows write branches and PRs instead of only reporting results:
 | --- | --- | --- |
 | `Update Selenium Grid Docker Versions` | `auto-update-selenium-grid-versions` | Update Selenium Docker image tags in the bundled Grid compose file. |
 | `Sync Sample Projects SHAFT Version` | `auto-update-sample-projects-version` | Sync sample projects to the latest or requested SHAFT version. |
+| `Prepare Release Pull Request` | `release/<version>` | Prepare dated SHAFT release metadata. |
 | `Refresh Agent Instructions` | `automation/refresh-agent-instructions` | Refresh agent guidance after a deterministic audit and optional AI review. |
 
 ## Deletion Checklist

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -1,0 +1,98 @@
+name: Prepare Release Pull Request
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_date:
+        description: "Release date in YYYY-MM-DD; version becomes {major}.{quarter}.{YYYYMMDD}"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: prepare-release-pr-${{ inputs.release_date }}
+  cancel-in-progress: false
+
+jobs:
+  prepare-release-pr:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Default Branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Update Release Metadata
+        id: prepare
+        shell: bash
+        env:
+          RELEASE_DATE: ${{ inputs.release_date }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/prepare_release_pr.py \
+            --release-date "${RELEASE_DATE}" \
+            --github-output "${GITHUB_OUTPUT}"
+
+          if git diff --quiet; then
+            echo "changes=false" >> "${GITHUB_OUTPUT}"
+            echo "Release metadata is already up to date."
+            exit 0
+          fi
+
+          echo "changes=true" >> "${GITHUB_OUTPUT}"
+          {
+            echo "files<<EOF"
+            git diff --name-only | sed 's/^/- `/;s/$/`/'
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Reject Existing Maven Central Version
+        if: steps.prepare.outputs.changes == 'true'
+        run: python3 scripts/ci/check_maven_release_version.py
+
+      - name: Validate Release Metadata
+        if: steps.prepare.outputs.changes == 'true'
+        run: |
+          python3 scripts/ci/validate_reactor_versions.py
+          python3 scripts/ci/validate_modular_documentation.py
+          python3 scripts/ci/validate_shaft_pilot_release.py
+          python3 scripts/ci/validate_maven_publication.py
+
+      - name: Create Pull Request
+        if: steps.prepare.outputs.changes == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Prepare SHAFT Engine release ${{ steps.prepare.outputs.release_version }}"
+          branch: release/${{ steps.prepare.outputs.release_version }}
+          delete-branch: true
+          title: "Prepare SHAFT Engine release ${{ steps.prepare.outputs.release_version }}"
+          body: |
+            ## Summary
+            Prepare SHAFT Engine release `${{ steps.prepare.outputs.release_version }}`.
+
+            Version formula: `{major}.{quarter}.{YYYYMMDD}` from `${{ inputs.release_date }}`.
+
+            ### Updated Files
+            ${{ steps.prepare.outputs.files }}
+
+            ## Validation
+            - `python3 scripts/ci/check_maven_release_version.py`
+            - `python3 scripts/ci/validate_reactor_versions.py`
+            - `python3 scripts/ci/validate_modular_documentation.py`
+            - `python3 scripts/ci/validate_shaft_pilot_release.py`
+            - `python3 scripts/ci/validate_maven_publication.py`
+
+            Merging this PR to `main` triggers Maven Central delivery.
+          labels: |
+            automated
+            release

--- a/scripts/ci/prepare_release_pr.py
+++ b/scripts/ci/prepare_release_pr.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Prepare deterministic SHAFT release version updates for a release PR."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+NS = {"m": "http://maven.apache.org/POM/4.0.0"}
+RELEASE_VERSION = re.compile(r"(?P<major>\d+)\.(?P<quarter>[1-4])\.(?P<date>\d{8})")
+SHAFT_VERSION_PROPERTY = re.compile(r"(<shaft\.version>)[^<]+(</shaft\.version>)")
+INTERNAL_ENGINE_VERSION = re.compile(
+    r'(@DefaultValue\(")[^"]+("\)\s+String\s+shaftEngineVersion\(\);)'
+)
+PLUGIN_VERSION = re.compile(r"^pluginVersion=.*$", re.MULTILINE)
+EXTRA_VERSION_REFERENCES = (
+    Path("modular-era-feature-catalog.md"),
+    Path("shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java"),
+)
+
+
+def _text(element: ET.Element, path: str) -> str:
+    return (element.findtext(path, default="", namespaces=NS) or "").strip()
+
+
+def root_version(root: Path = ROOT) -> str:
+    version = _text(ET.parse(root / "pom.xml").getroot(), "m:version")
+    if not RELEASE_VERSION.fullmatch(version):
+        raise ValueError(f"root version is not a dated SHAFT release: {version!r}")
+    return version
+
+
+def target_version(current_version: str, release_date: str) -> str:
+    current = RELEASE_VERSION.fullmatch(current_version)
+    if not current:
+        raise ValueError(f"current version is not a dated SHAFT release: {current_version!r}")
+    date = dt.date.fromisoformat(release_date)
+    quarter = ((date.month - 1) // 3) + 1
+    return f"{current.group('major')}.{quarter}.{date:%Y%m%d}"
+
+
+def _version_key(version: str) -> tuple[int, int, int]:
+    match = RELEASE_VERSION.fullmatch(version)
+    if not match:
+        raise ValueError(f"version is not a dated SHAFT release: {version!r}")
+    return int(match.group("major")), int(match.group("quarter")), int(match.group("date"))
+
+
+def _replace(path: Path, pattern: re.Pattern[str], replacement: str) -> bool:
+    source = path.read_text(encoding="utf-8")
+    updated, count = pattern.subn(replacement, source)
+    if count == 0:
+        raise ValueError(f"{path}: expected release version target was not found")
+    if updated == source:
+        return False
+    path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def _replace_literal(path: Path, old: str, new: str) -> bool:
+    source = path.read_text(encoding="utf-8")
+    updated = source.replace(old, new)
+    if updated == source:
+        return False
+    path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def _module_poms(root: Path) -> list[Path]:
+    parent = ET.parse(root / "pom.xml").getroot()
+    return [
+        root / _text(module, ".") / "pom.xml"
+        for module in parent.findall("m:modules/m:module", NS)
+    ]
+
+
+def _shaft_version_poms(root: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in root.rglob("pom.xml")
+        if "target" not in path.parts
+        and "<shaft.version>" in path.read_text(encoding="utf-8")
+    )
+
+
+def prepare_release(root: Path, release_date: str) -> tuple[str, str, list[Path]]:
+    current_version = root_version(root)
+    release_version = target_version(current_version, release_date)
+    if _version_key(release_version) <= _version_key(current_version):
+        raise ValueError(f"target version {release_version} must be newer than {current_version}")
+
+    changed: list[Path] = []
+    files = [
+        root / "pom.xml",
+        *_module_poms(root),
+    ]
+    for path in files:
+        if _replace_literal(path, current_version, release_version):
+            changed.append(path)
+
+    for path in _shaft_version_poms(root):
+        if _replace(path, SHAFT_VERSION_PROPERTY, rf"\g<1>{release_version}\g<2>"):
+            changed.append(path)
+
+    internal = root / "shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java"
+    if _replace(internal, INTERNAL_ENGINE_VERSION, rf"\g<1>{release_version}\g<2>"):
+        changed.append(internal)
+
+    intellij_properties = root / "shaft-intellij/gradle.properties"
+    if _replace(intellij_properties, PLUGIN_VERSION, f"pluginVersion={release_version}"):
+        changed.append(intellij_properties)
+
+    for relative in EXTRA_VERSION_REFERENCES:
+        path = root / relative
+        if path.is_file() and _replace_literal(path, current_version, release_version):
+            changed.append(path)
+
+    return current_version, release_version, sorted(set(changed))
+
+
+def _write_github_output(path: Path, old_version: str, release_version: str) -> None:
+    with path.open("a", encoding="utf-8") as output:
+        output.write(f"old_version={old_version}\n")
+        output.write(f"release_version={release_version}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--release-date", required=True, help="Release date in YYYY-MM-DD format")
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args()
+
+    try:
+        old_version, release_version, changed = prepare_release(args.root, args.release_date)
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 1
+
+    if args.github_output:
+        _write_github_output(args.github_output, old_version, release_version)
+
+    print(f"old_version={old_version}")
+    print(f"release_version={release_version}")
+    for path in changed:
+        print(f"updated={path.relative_to(args.root).as_posix()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_prepare_release_pr.py
+++ b/tests/scripts/test_prepare_release_pr.py
@@ -1,0 +1,86 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/ci/prepare_release_pr.py"
+SPEC = importlib.util.spec_from_file_location("prepare_release_pr", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+class PrepareReleasePrTest(unittest.TestCase):
+    def test_updates_release_files_from_release_date_quarter(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write(
+                root / "pom.xml",
+                """<project xmlns="http://maven.apache.org/POM/4.0.0">
+<modelVersion>4.0.0</modelVersion>
+<groupId>io.github.shafthq</groupId>
+<artifactId>shaft-parent</artifactId>
+<version>10.2.20260630</version>
+<modules><module>shaft-engine</module></modules>
+</project>
+""",
+            )
+            _write(
+                root / "shaft-engine/pom.xml",
+                """<project xmlns="http://maven.apache.org/POM/4.0.0">
+<parent><groupId>io.github.shafthq</groupId><artifactId>shaft-parent</artifactId><version>10.2.20260630</version></parent>
+<artifactId>shaft-engine</artifactId>
+</project>
+""",
+            )
+            _write(
+                root / "tools/modularization/consumer-fixtures/api/pom.xml",
+                """<project xmlns="http://maven.apache.org/POM/4.0.0">
+<properties><shaft.version>10.2.20260630</shaft.version></properties>
+</project>
+""",
+            )
+            _write(
+                root / "shaft-engine/src/main/java/com/shaft/properties/internal/Internal.java",
+                """interface Internal {
+@DefaultValue("10.2.20260630")
+String shaftEngineVersion();
+}
+""",
+            )
+            _write(root / "shaft-intellij/gradle.properties", "pluginVersion=10.2.20260630\n")
+            _write(root / "modular-era-feature-catalog.md", "Plugin 10.2.20260630\n")
+
+            old_version, release_version, changed = MODULE.prepare_release(root, "2026-07-02")
+
+            self.assertEqual("10.2.20260630", old_version)
+            self.assertEqual("10.3.20260702", release_version)
+            self.assertTrue(changed)
+            for path in changed:
+                self.assertNotIn("10.2.20260630", path.read_text(encoding="utf-8"))
+
+    def test_rejects_non_newer_release_date(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write(
+                root / "pom.xml",
+                """<project xmlns="http://maven.apache.org/POM/4.0.0">
+<modelVersion>4.0.0</modelVersion>
+<version>10.3.20260702</version>
+</project>
+""",
+            )
+
+            with self.assertRaises(ValueError):
+                MODULE.prepare_release(root, "2026-07-02")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a manual Prepare Release Pull Request workflow with a required release_date input.
- Add a deterministic Python updater for SHAFT dated versions and release metadata.
- Document the generated PR workflow in the workflow inventory.

## Validation
- py -3 tests\\scripts\\test_prepare_release_pr.py
- py -3 -m py_compile scripts\\ci\\prepare_release_pr.py
- py -3 scripts\\ci\\validate_reactor_versions.py
- py -3 scripts\\ci\\validate_modular_documentation.py
- py -3 scripts\\ci\\validate_shaft_pilot_release.py
- py -3 scripts\\ci\\validate_maven_publication.py

Note: actionlint is not installed in this local environment.