### PR TITLE
[codex] Prompt agent guidance optimization after MCP setup

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
@@ -334,6 +334,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         String command = mcpCommand.getText().trim();
         if (!Objects.equals(state.mcpCommand, command)) {
             state.mcpSetupComplete = false;
+            state.agentGuidanceOptimizationPromptPending = false;
         }
         state.mcpCommand = command;
         state.advancedUiEnabled = advancedUiEnabled.isSelected();
@@ -661,6 +662,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
             ShaftSettingsState.Settings state = settingsProvider.get();
             state.mcpCommand = result.commandLine();
             state.mcpSetupComplete = false;
+            state.agentGuidanceOptimizationPromptPending = false;
             testStatus.setText("Installed");
             updateAgentConfigurationControls();
         } else {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsState.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsState.java
@@ -39,6 +39,7 @@ public final class ShaftSettingsState implements PersistentStateComponent<ShaftS
     public static final class Settings {
         public String mcpCommand = "";
         public boolean mcpSetupComplete = true;
+        public boolean agentGuidanceOptimizationPromptPending = false;
         public String assistantProviderType = "LOCAL";
         public String assistantFamily = "";
         public String assistantRuntime = "CLI";

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
@@ -56,6 +56,21 @@ final class AssistantLocalAgentRunner {
         return new ShaftMcpInvocation(future, () -> cancel(processReference, cancellationRequested));
     }
 
+    static ShaftMcpToolResult readiness(String client, String runtime) {
+        if (!"CLI".equals(normalize(runtime))) {
+            return ShaftMcpToolResult.success("Selected agent runtime is configured by SHAFT MCP.");
+        }
+        String executable = switch (normalize(client)) {
+            case "CLAUDE_CODE" -> "claude";
+            case "COPILOT_CLI" -> "copilot";
+            default -> "codex";
+        };
+        String displayName = displayName(client);
+        return isCommandAvailable(executable)
+                ? ShaftMcpToolResult.success(displayName + " executable is available on PATH.")
+                : ShaftMcpToolResult.failure(displayName + " executable is not available on PATH.");
+    }
+
     static List<String> commandFor(JsonObject arguments) {
         List<String> custom = customCommand(arguments);
         if (!custom.isEmpty()) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -314,6 +314,7 @@ final class ShaftAssistantPanel extends JPanel {
         add(transcriptPanel, BorderLayout.CENTER);
         add(south, BorderLayout.SOUTH);
         refreshChatSelector();
+        showPendingAgentGuidanceOptimizationPrompt();
     }
 
     JComponent preferredFocusComponent() {
@@ -322,6 +323,42 @@ final class ShaftAssistantPanel extends JPanel {
 
     static boolean requiresMcpSetup(AssistantCommand.Invocation invocation, boolean mcpConfigured) {
         return invocation != null && invocation.requiresMcpConfiguration() && !mcpConfigured;
+    }
+
+    static String agentGuidanceOptimizationPrompt(ShaftSettingsState.Settings settings) {
+        String family = resolveFamily(settings);
+        String surfaces = switch (family) {
+            case "CLAUDE" -> "CLAUDE.md, AGENTS.md, .agents/skills/**, .memory/**";
+            case "COPILOT" -> ".github/copilot-instructions.md, AGENTS.md, .github/instructions/**, .github/skills/**, .memory/**";
+            default -> "AGENTS.md, .codex/config.toml, .agents/skills/**, .memory/**";
+        };
+        return """
+                Audit and optimize this SHAFT_ENGINE checkout's agent guidance for %s.
+
+                Use SHAFT MCP tools before proposing guidance edits:
+                - shaft_guide_search for official user-guide facts and URLs.
+                - test_automation_scenarios for workflow expectations.
+                - test_code_guardrails_check for code-generation guardrails.
+
+                Review only these guidance and memory surfaces: %s.
+                Keep AGENTS.md canonical, host adapters thin, and memories durable, evidence-backed, and non-duplicative.
+                Do not edit product code, tests, workflows, manifests, dependencies, generated reports, binaries, or secrets.
+
+                If source edits are not enabled, return a concise patch plan only. If edits are enabled, make the smallest guidance or memory updates and rerun `py -3 scripts/ci/validate_agent_setup.py --skip-external` on Windows or `python3 scripts/ci/validate_agent_setup.py --skip-external` elsewhere.
+                """.formatted(ShaftUiLabels.friendly(family), surfaces).strip();
+    }
+
+    private void showPendingAgentGuidanceOptimizationPrompt() {
+        if (!settings.agentGuidanceOptimizationPromptPending || !mcpReady(settings)) {
+            return;
+        }
+        settings.agentGuidanceOptimizationPromptPending = false;
+        mode.setSelectedItem("PLAN");
+        allowSourceMutation.setSelected(false);
+        prompt.setText(agentGuidanceOptimizationPrompt(settings));
+        prompt.setCaretPosition(0);
+        status.setText("Review setup optimization prompt");
+        updateControlVisibility();
     }
 
     private void send(Project project) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -333,7 +333,7 @@ final class ShaftAssistantPanel extends JPanel {
             default -> "AGENTS.md, .codex/config.toml, .agents/skills/**, .memory/**";
         };
         return """
-                Audit and optimize this SHAFT_ENGINE checkout's agent guidance for %s.
+                Audit and optimize this using shaft-engine test automation project checkout's agent guidance for %s.
 
                 Use SHAFT MCP tools before proposing guidance edits:
                 - shaft_guide_search for official user-guide facts and URLs.
@@ -342,7 +342,7 @@ final class ShaftAssistantPanel extends JPanel {
 
                 Review only these guidance and memory surfaces: %s.
                 Keep AGENTS.md canonical, host adapters thin, and memories durable, evidence-backed, and non-duplicative.
-                Do not edit product code, tests, workflows, manifests, dependencies, generated reports, binaries, or secrets.
+                Do not edit product code, tests, workflows, manifests, dependencies, generated reports, binaries, or secrets without explicit user approval.
 
                 If source edits are not enabled, return a concise patch plan only. If edits are enabled, make the smallest guidance or memory updates and rerun `py -3 scripts/ci/validate_agent_setup.py --skip-external` on Windows or `python3 scripts/ci/validate_agent_setup.py --skip-external` elsewhere.
                 """.formatted(ShaftUiLabels.friendly(family), surfaces).strip();

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -40,9 +40,15 @@ import java.util.function.Consumer;
  * First-run SHAFT MCP setup panel.
  */
 final class ShaftMcpSetupPanel extends JPanel {
+    @FunctionalInterface
+    interface AgentReadinessProbe {
+        ShaftMcpToolResult test(String client, String runtime);
+    }
+
     private final Project project;
     private final ShaftSettingsState.Settings settings;
     private final Runnable connected;
+    private final AgentReadinessProbe readinessProbe;
     private final JButton install;
     private final JComboBox<String> family;
     private final JComboBox<String> runtime;
@@ -59,10 +65,16 @@ final class ShaftMcpSetupPanel extends JPanel {
 
     ShaftMcpSetupPanel(@NotNull Project project, @NotNull ShaftSettingsState.Settings settings,
                        @NotNull Runnable connected) {
+        this(project, settings, connected, AssistantLocalAgentRunner::readiness);
+    }
+
+    ShaftMcpSetupPanel(@NotNull Project project, @NotNull ShaftSettingsState.Settings settings,
+                       @NotNull Runnable connected, @NotNull AgentReadinessProbe readinessProbe) {
         super(new BorderLayout(8, 8));
         this.project = project;
         this.settings = settings;
         this.connected = connected;
+        this.readinessProbe = readinessProbe;
         setBorder(JBUI.Borders.empty(12));
 
         install = new JButton("Install / Update SHAFT MCP");
@@ -177,6 +189,7 @@ final class ShaftMcpSetupPanel extends JPanel {
             appendConsoleSuccess("Installation completed successfully. Next: press \"Test connection and start chatting\".");
             settings.mcpCommand = result.commandLine();
             settings.mcpSetupComplete = false;
+            settings.agentGuidanceOptimizationPromptPending = false;
             markInstalledForCurrentSelection();
             showAssistNotConfigured();
             updateActionState(false);
@@ -233,15 +246,28 @@ final class ShaftMcpSetupPanel extends JPanel {
         } else {
             setConsoleText(result.output());
             if (result.success()) {
-                showAssistConfigured();
-                appendConsoleSuccess("Connected to SHAFT MCP.");
+                ShaftMcpToolResult readiness = readinessProbe.test(settings.defaultAutobotClient, settings.assistantRuntime);
+                if (readiness.success()) {
+                    showAssistConfigured();
+                    appendConsoleSuccess("Connected to SHAFT MCP.");
+                    appendConsoleSuccess(readiness.output());
+                } else {
+                    success = false;
+                    showAssistError();
+                    status.setText("Agent not ready. Retry test.");
+                    appendLine("Agent readiness failed: " + readiness.output(), false);
+                }
             } else {
                 showAssistError();
             }
         }
         if (success) {
             settings.mcpSetupComplete = true;
+            settings.agentGuidanceOptimizationPromptPending = true;
             connected.run();
+        } else {
+            settings.mcpSetupComplete = false;
+            settings.agentGuidanceOptimizationPromptPending = false;
         }
     }
 
@@ -275,6 +301,7 @@ final class ShaftMcpSetupPanel extends JPanel {
             showMcpNotConfigured();
             showAssistNotConfigured();
             settings.mcpSetupComplete = false;
+            settings.agentGuidanceOptimizationPromptPending = false;
             status.setText("Install SHAFT MCP for the selected assistant.");
         }
         updateActionState(false);

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
@@ -32,6 +32,7 @@ public final class ShaftToolWindowPanel extends JPanel {
     private JComboBox<WorkflowView> workflowSelector;
     private JPanel workflowCards;
     private CardLayout workflowLayout;
+    private final ShaftMcpSetupPanel.AgentReadinessProbe readinessProbe;
     private ShaftFeaturePanel advancedTools;
     private List<ShaftFeaturePanel> featurePanels = List.of();
     private List<WorkflowView> workflowViews = List.of();
@@ -41,9 +42,15 @@ public final class ShaftToolWindowPanel extends JPanel {
     }
 
     ShaftToolWindowPanel(Project project, @NotNull ShaftSettingsState.Settings settings) {
+        this(project, settings, AssistantLocalAgentRunner::readiness);
+    }
+
+    ShaftToolWindowPanel(Project project, @NotNull ShaftSettingsState.Settings settings,
+                         @NotNull ShaftMcpSetupPanel.AgentReadinessProbe readinessProbe) {
         super(new BorderLayout());
         this.project = project;
         this.settings = settings;
+        this.readinessProbe = readinessProbe;
         if (mcpReady(settings)) {
             showMainView();
         } else {
@@ -53,7 +60,7 @@ public final class ShaftToolWindowPanel extends JPanel {
 
     private void showSetupView() {
         removeAll();
-        ShaftMcpSetupPanel setup = new ShaftMcpSetupPanel(project, settings, this::showMainView);
+        ShaftMcpSetupPanel setup = new ShaftMcpSetupPanel(project, settings, this::showMainView, readinessProbe);
         preferredFocusComponent = setup.preferredFocusComponent();
         workflowSelector = null;
         workflowCards = null;

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -344,12 +344,12 @@ class ShaftPanelSetupTest {
         ShaftAssistantPanel second = new ShaftAssistantPanel(null, settings);
 
         assertAll(
-                () -> assertTrue(containsText(first, "Audit and optimize this SHAFT_ENGINE checkout's agent guidance")),
+                () -> assertTrue(containsText(first, "Audit and optimize")),
                 () -> assertTrue(containsText(first, "shaft_guide_search")),
                 () -> assertTrue(containsText(first, "test_automation_scenarios")),
                 () -> assertTrue(containsText(first, "test_code_guardrails_check")),
                 () -> assertFalse(settings.agentGuidanceOptimizationPromptPending),
-                () -> assertFalse(containsText(second, "Audit and optimize this SHAFT_ENGINE checkout's agent guidance")));
+                () -> assertFalse(containsText(second, "Audit and optimize")));
     }
 
     @Test

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -303,15 +303,70 @@ class ShaftPanelSetupTest {
     @Test
     void setupPanelShowsClearConnectionSuccess() throws Exception {
         AtomicBoolean connected = new AtomicBoolean();
-        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), connectedMcpSettings(), () -> connected.set(true));
+        ShaftSettingsState.Settings settings = connectedMcpSettings();
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), settings, () -> connected.set(true), readyProbe());
 
         showTestResult(panel, ShaftMcpToolResult.success("Probe OK"));
 
         assertAll(
                 () -> assertTrue(containsText(panel, "Probe OK")),
                 () -> assertTrue(containsText(panel, "SUCCESS: Connected to SHAFT MCP.")),
+                () -> assertTrue(containsText(panel, "SUCCESS: Codex CLI executable is available on PATH.")),
                 () -> assertTrue(containsText(panel, "Connected")),
-                () -> assertTrue(connected.get()));
+                () -> assertTrue(connected.get()),
+                () -> assertTrue(settings.mcpSetupComplete),
+                () -> assertTrue(settings.agentGuidanceOptimizationPromptPending));
+    }
+
+    @Test
+    void setupPanelBlocksConnectionWhenSelectedAgentIsNotReady() throws Exception {
+        AtomicBoolean connected = new AtomicBoolean();
+        ShaftSettingsState.Settings settings = connectedMcpSettings();
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), settings, () -> connected.set(true),
+                (client, runtime) -> ShaftMcpToolResult.failure("Codex CLI executable is not available on PATH."));
+
+        showTestResult(panel, ShaftMcpToolResult.success("Probe OK"));
+
+        assertAll(
+                () -> assertTrue(containsText(panel, "Assist: Error")),
+                () -> assertTrue(containsText(panel, "Agent readiness failed: Codex CLI executable is not available on PATH.")),
+                () -> assertFalse(connected.get()),
+                () -> assertFalse(settings.mcpSetupComplete),
+                () -> assertFalse(settings.agentGuidanceOptimizationPromptPending));
+    }
+
+    @Test
+    void assistantConsumesPendingGuidanceOptimizationPromptOnce() {
+        ShaftSettingsState.Settings settings = connectedMcpSettings();
+        settings.agentGuidanceOptimizationPromptPending = true;
+
+        ShaftAssistantPanel first = new ShaftAssistantPanel(null, settings);
+        ShaftAssistantPanel second = new ShaftAssistantPanel(null, settings);
+
+        assertAll(
+                () -> assertTrue(containsText(first, "Audit and optimize this SHAFT_ENGINE checkout's agent guidance")),
+                () -> assertTrue(containsText(first, "shaft_guide_search")),
+                () -> assertTrue(containsText(first, "test_automation_scenarios")),
+                () -> assertTrue(containsText(first, "test_code_guardrails_check")),
+                () -> assertFalse(settings.agentGuidanceOptimizationPromptPending),
+                () -> assertFalse(containsText(second, "Audit and optimize this SHAFT_ENGINE checkout's agent guidance")));
+    }
+
+    @Test
+    void guidanceOptimizationPromptUsesSelectedAgentSurfaces() {
+        ShaftSettingsState.Settings codex = connectedMcpSettings();
+        ShaftSettingsState.Settings claude = connectedMcpSettings();
+        claude.assistantFamily = "CLAUDE";
+        ShaftSettingsState.Settings copilot = connectedMcpSettings();
+        copilot.assistantFamily = "COPILOT";
+
+        assertAll(
+                () -> assertTrue(ShaftAssistantPanel.agentGuidanceOptimizationPrompt(codex)
+                        .contains("AGENTS.md, .codex/config.toml, .agents/skills/**, .memory/**")),
+                () -> assertTrue(ShaftAssistantPanel.agentGuidanceOptimizationPrompt(claude)
+                        .contains("CLAUDE.md, AGENTS.md, .agents/skills/**, .memory/**")),
+                () -> assertTrue(ShaftAssistantPanel.agentGuidanceOptimizationPrompt(copilot)
+                        .contains(".github/copilot-instructions.md, AGENTS.md, .github/instructions/**, .github/skills/**, .memory/**")));
     }
 
     @Test
@@ -1146,7 +1201,7 @@ class ShaftPanelSetupTest {
         state.append("user", "Previous assistant conversation", "{}");
         int beforeSetupSessions = state.sessions().size();
 
-        ShaftToolWindowPanel toolWindow = new ShaftToolWindowPanel(project, settings);
+        ShaftToolWindowPanel toolWindow = new ShaftToolWindowPanel(project, settings, readyProbe());
         ShaftMcpSetupPanel setupPanel = setupPanel(toolWindow);
         assertNotNull(setupPanel);
         showTestResult(setupPanel, ShaftMcpToolResult.success("Probe OK"));
@@ -1249,6 +1304,10 @@ class ShaftPanelSetupTest {
         ShaftSettingsState.Settings settings = connectedMcpSettings();
         settings.advancedUiEnabled = true;
         return settings;
+    }
+
+    private static ShaftMcpSetupPanel.AgentReadinessProbe readyProbe() {
+        return (client, runtime) -> ShaftMcpToolResult.success("Codex CLI executable is available on PATH.");
     }
 
     private static boolean containsText(Component component, String expected) {


### PR DESCRIPTION
## Summary
- Require first-run IntelliJ MCP setup success to include selected local agent readiness before marking setup complete.
- Pre-fill a one-time Plan-mode Assistant prompt asking the selected agent to audit guidance and memory files for SHAFT MCP best-practice tool usage.
- Cover success, readiness failure, and one-time prompt consumption in focused IntelliJ tests.

## Validation
- `gradle -p shaft-intellij test --rerun-tasks --tests com.shaft.intellij.ui.ShaftPanelSetupTest --tests com.shaft.intellij.settings.ShaftSettingsConfigurableTest`
- `gradle -p shaft-intellij test --rerun-tasks --tests com.shaft.intellij.ui.ShaftPluginScreenshotRendererTest '-Dshaft.intellij.screenshotDir=C:\Users\Mohab\IdeaProjects\SHAFT_ENGINE\shaft-intellij\build\screenshots\mcp-agent-guidance'`
- `py -3 scripts/ci/validate_shaft_mcp_configuration.py`
- `py -3 scripts/ci/validate_agent_setup.py --skip-external`
- `py -3 scripts/ci/validate_documentation_boundaries.py`
- `git diff --check`

## Screenshot Evidence
Generated locally under `shaft-intellij/build/screenshots/mcp-agent-guidance/`:
- `intellij-plugin-mcp-setup.png`
- `intellij-plugin-mcp-setup-success.png`
- `intellij-plugin-mcp-setup-error-dark.png`
- `intellij-plugin-assistant.png`
- `intellij-plugin-assistant-dark.png`