### PR TITLE
Handle malformed Doctor reports in MCP tools

### DIFF
--- a/shaft-mcp/src/main/java/com/shaft/mcp/DoctorService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/DoctorService.java
@@ -21,6 +21,7 @@ import com.shaft.doctor.repair.RepairPublicationResult;
 import com.shaft.pilot.ai.ApprovalPolicy;
 import com.shaft.pilot.ai.EvidenceCategory;
 import com.shaft.pilot.config.PilotConfiguration;
+import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 import com.shaft.capture.generate.CaptureGenerator.CodegenBackend;
 import org.springframework.ai.tool.annotation.Tool;
@@ -457,7 +458,7 @@ public class DoctorService {
         try {
             var root = JSON.readTree(Files.readString(path, StandardCharsets.UTF_8));
             return JSON.treeToValue(root.has("diagnosis") ? root.path("diagnosis") : root, Diagnosis.class);
-        } catch (IOException exception) {
+        } catch (IOException | JacksonException exception) {
             throw new IllegalArgumentException("Doctor diagnosis could not be read.", exception);
         }
     }
@@ -477,7 +478,7 @@ public class DoctorService {
                     bundlePath,
                     path.toString(),
                     parent == null ? "" : parent.resolve("doctor-report.md").toString());
-        } catch (IOException exception) {
+        } catch (IOException | JacksonException exception) {
             throw new IllegalArgumentException("Doctor report could not be read.", exception);
         }
     }


### PR DESCRIPTION
## Summary
- Wrap Jackson 3 parse/mapping failures in the existing `IllegalArgumentException` boundary for Doctor report and diagnosis reads.
- Preserves the public MCP tool error messages expected by `doctor_suggest_fix` and helper callers.

## Validation
- `py -3 scripts\ci\validate_shaft_mcp_configuration.py`
- `mvn --batch-mode -pl shaft-mcp -am '-Dtest=DoctorServiceTest,McpServiceHelperTest' test '-Dsurefire.failIfNoSpecifiedTests=false' '-Dgpg.skip' '-DheadlessExecution=true' '-DgenerateAllureReport=false' '-DgenerateExtentReport=false'`
- CI-shaped release sequence: prerequisite install without tests, then `mvn --batch-mode -pl shaft-pilot-core,shaft-capture,shaft-doctor,shaft-ai,shaft-heal,shaft-mcp test ...` (124 tests, 0 failures)
- `py -3 scripts\ci\validate_shaft_pilot_release.py --check-test-results`
- `py -3 scripts\ci\validate_maven_publication.py`