### PR TITLE
[codex] Fix shaft-sikulix Maven Central dependency convergence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
         <sikulix.version>2.0.5</sikulix.version>
         <jython.slim.version>2.7.4</jython.slim.version>
         <tess4j.version>5.19.0</tess4j.version>
+        <jnr.ffi.version>2.2.16</jnr.ffi.version>
+        <jna.version>5.18.1</jna.version>
+        <asm.version>9.7</asm.version>
+        <antlr.runtime.version>3.5.3</antlr.runtime.version>
+        <commons.compress.version>1.28.0</commons.compress.version>
         <bouncycastle.version>1.84</bouncycastle.version>
         <ant.version>1.10.17</ant.version>
         <poi.version>5.5.1</poi.version>
@@ -277,6 +282,11 @@
                 <version>${commons.codec.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${commons.compress.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
@@ -300,6 +310,36 @@
                 <groupId>io.rest-assured</groupId>
                 <artifactId>rest-assured</artifactId>
                 <version>${rest.assured.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.jnr</groupId>
+                <artifactId>jnr-ffi</artifactId>
+                <version>${jnr.ffi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna</artifactId>
+                <version>${jna.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna-platform</artifactId>
+                <version>${jna.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-util</artifactId>
+                <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-analysis</artifactId>
+                <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr-runtime</artifactId>
+                <version>${antlr.runtime.version}</version>
             </dependency>
             <!-- Override javassist: 3.18.1-GA has a default-tools profile with OS-based activation that
                  always fires on Linux and references ${java.home}/../lib/tools.jar, which does not exist

--- a/shaft-sikulix/pom.xml
+++ b/shaft-sikulix/pom.xml
@@ -33,6 +33,10 @@
                     <artifactId>opencv</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.sikulix</groupId>
+                    <artifactId>sikulix2tigervnc</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.ow2.asm</groupId>
                     <artifactId>asm-commons</artifactId>
                 </exclusion>

--- a/tools/modularization/consumer-fixtures/combined-modules/pom.xml
+++ b/tools/modularization/consumer-fixtures/combined-modules/pom.xml
@@ -117,6 +117,7 @@
                             <ignoredResourcePatterns>
                                 <ignoredResourcePattern>draftv[34]/schema</ignoredResourcePattern>
                                 <ignoredResourcePattern>changelog[.]xml</ignoredResourcePattern>
+                                <ignoredResourcePattern>versionchanges[.]txt</ignoredResourcePattern>
                             </ignoredResourcePatterns>
                         </configuration>
                     </execution>


### PR DESCRIPTION
## Summary
- Fixes Maven Central release failure from run `28640312879`, job `84934899930`.
- Adds parent dependency-management pins exported through the effective `shaft-bom` consumer graph for `shaft-sikulix` transitives.
- Excludes unused `com.sikulix:sikulix2tigervnc` from the local desktop SikuliX module to remove duplicate JSch classes.
- Keeps the combined-module duplicate-class gate intact, allowing only the non-executable `versionchanges.txt` OCR metadata duplicate.

## Validation
- `py -3 scripts/ci/validate_maven_publication.py`
- `py -3 scripts/ci/validate_reactor_versions.py`
- `py -3 scripts/ci/validate_modular_documentation.py`
- `mvn --batch-mode clean install '-DskipTests' '-Dgpg.skip' '-DautomaticallyOpen=false' '-DopenLighthouseReportWhileExecution=false'`
- `mvn --batch-mode -pl shaft-sikulix -am install '-DskipTests' '-Dgpg.skip' '-DautomaticallyOpen=false' '-DopenLighthouseReportWhileExecution=false'`
- `mvn --batch-mode -f tools/modularization/consumer-fixtures/combined-modules/pom.xml verify '-Dshaft.version=10.3.20260702'`

No local tests were run; Maven Surefire reported tests skipped/no tests for the validation commands above.