### PR TITLE
[codex] Add SHAFT agent skills installer support

### DIFF
--- a/scripts/ci/validate_documentation_boundaries.py
+++ b/scripts/ci/validate_documentation_boundaries.py
@@ -35,6 +35,8 @@ ALLOWED_GLOBS = (
     ".github/skills/**/*.md",
     ".memory/memory/*.md",
     ".memory/memory/**/*.md",
+    "shaft-skills/*.md",
+    "shaft-skills/**/*.md",
     "tools/**/*.md",
     "*/src/test/resources/fixtures/**/*.md",
 )

--- a/scripts/ci/verify_shaft_mcp_installer_release.py
+++ b/scripts/ci/verify_shaft_mcp_installer_release.py
@@ -62,6 +62,27 @@ def installer_command(client: str, *extra_args: str) -> list[str]:
     return ["sh", str(ROOT / "scripts" / "mcp" / "install-shaft-mcp.sh"), f"--{client}", *extra_args]
 
 
+def run_installer(command: list[str], *, cwd: Path, environment: dict[str, str], capture: bool = False) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(  # nosec B603 - command comes from installer_command.
+            command,
+            cwd=cwd,
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            check=True,
+            capture_output=capture,
+            text=True,
+        )
+    except subprocess.CalledProcessError as error:
+        details = []
+        if error.stdout:
+            details.append(f"stdout:\n{error.stdout}")
+        if error.stderr:
+            details.append(f"stderr:\n{error.stderr}")
+        suffix = "\n" + "\n".join(details) if details else ""
+        raise RuntimeError(f"Installer command failed: {error.cmd}{suffix}") from error
+
+
 def last_json_line(output: str) -> dict[str, object]:
     for line in reversed(output.splitlines()):
         line = line.strip()
@@ -168,6 +189,9 @@ def verify_plugin_json(result: dict[str, object], java: Path, args: Path) -> Non
         raise RuntimeError(f"Unexpected Java command in IntelliJ plugin installer output: {result}")
     if result.get("args") != [f"@{args}"]:
         raise RuntimeError(f"Unexpected SHAFT MCP arguments in IntelliJ plugin installer output: {result}")
+    shaft_skills = result.get("shaftSkills")
+    if not isinstance(shaft_skills, dict) or shaft_skills.get("installed") is not True:
+        raise RuntimeError(f"Expected IntelliJ plugin installer to install SHAFT skills by default: {result}")
 
 
 def main() -> int:
@@ -200,17 +224,21 @@ def main() -> int:
             clients.append("claude-desktop")
 
         java = expected_java(environment)
-        plugin_install = subprocess.run(  # nosec B603 - client and arguments are validated above.
+        plugin_install = run_installer(
             installer_command("intellij-plugin", "--json"),
             cwd=root,
-            env=environment,
-            check=True,
-            capture_output=True,
-            text=True,
+            environment=environment,
+            capture=True,
         )
         plugin_result = last_json_line(plugin_install.stdout)
+        shaft_skills = plugin_result.get("shaftSkills")
+        if not isinstance(shaft_skills, dict):
+            raise RuntimeError(f"Expected SHAFT skills metadata in IntelliJ plugin installer output: {plugin_result}")
+        skills_path = Path(str(shaft_skills.get("path", "")))
+        if not (skills_path / "writing-shaft-tests" / "SKILL.md").is_file():
+            raise RuntimeError(f"Expected SHAFT skills to be installed by the unattended plugin installer: {skills_path}")
         for client in clients:
-            subprocess.run(installer_command(client), cwd=root, env=environment, check=True)
+            run_installer(installer_command(client), cwd=root, environment=environment)
 
         jar = installed_jar(root, home, environment)
         args = installed_args(jar)
@@ -224,7 +252,7 @@ def main() -> int:
             verify_configuration(configuration_path(client, root, home, environment), java, args, root_property)
         verify_plugin_json(plugin_result, java, args)
 
-        subprocess.run(installer_command(clients[0]), cwd=root, env=environment, check=True)
+        run_installer(installer_command(clients[0]), cwd=root, environment=environment)
         if sha256(jar) != first_hash or jar.stat().st_mtime_ns != first_timestamp:
             raise RuntimeError("Repeated public installation did not reuse the verified JAR.")
         verify_configuration(configuration_path(clients[0], root, home, environment), java, args, "mcpServers")

--- a/scripts/mcp/install-shaft-mcp.ps1
+++ b/scripts/mcp/install-shaft-mcp.ps1
@@ -211,6 +211,16 @@ function Install-ShaftMcp {
     if (-not [string]::IsNullOrWhiteSpace($Version)) {
         $installerArguments += @("--version", $Version)
     }
+    $hasShaftSkillsDecision = $false
+    foreach ($argument in $Arguments) {
+        if ($argument -eq "--install-shaft-skills" -or $argument -eq "--skip-shaft-skills") {
+            $hasShaftSkillsDecision = $true
+            break
+        }
+    }
+    if (-not $hasShaftSkillsDecision -and [Console]::IsInputRedirected) {
+        $installerArguments += @("--install-shaft-skills")
+    }
     if ($null -ne $Arguments -and $Arguments.Count -gt 0) {
         $installerArguments += $Arguments
     }

--- a/scripts/mcp/install-shaft-mcp.sh
+++ b/scripts/mcp/install-shaft-mcp.sh
@@ -205,4 +205,15 @@ else
 fi
 
 python_script="$(resolve_python_script "$ROOT")"
+has_shaft_skills_decision=0
+for argument in "$@"; do
+  case "$argument" in
+    --install-shaft-skills|--skip-shaft-skills)
+      has_shaft_skills_decision=1
+      ;;
+  esac
+done
+if [ "$has_shaft_skills_decision" -eq 0 ] && [ ! -t 0 ]; then
+  set -- "$@" --install-shaft-skills
+fi
 exec "$python_path" "$python_script" "$@"

--- a/scripts/mcp/install_shaft_mcp.py
+++ b/scripts/mcp/install_shaft_mcp.py
@@ -17,6 +17,7 @@ import tempfile
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
 import zipfile
@@ -33,6 +34,13 @@ RUNTIME_DEPENDENCIES_ENTRY = "META-INF/shaft-mcp/runtime-dependencies.txt"
 WORKSPACE_SYSTEM_PROPERTY = "shaft.mcp.workspaceRoot"
 USER_GUIDE_URL = "https://shafthq.github.io/docs/agentic/mcp"
 BOOTSTRAP_BANNER_SHOWN = "SHAFT_MCP_BOOTSTRAP_BANNER_SHOWN"
+SHAFT_SKILLS_DIRECTORY = "shaft-skills"
+SHAFT_SKILLS_SOURCE_MARKERS = (
+    "writing-shaft-tests/SKILL.md",
+    "choosing-shaft-locators/SKILL.md",
+    "recording-shaft-tests-with-mcp/SKILL.md",
+    "analyzing-shaft-failures/SKILL.md",
+)
 TARGETS = ("codex", "claude", "claude-desktop", "copilot", "copilot-intellij", "intellij-plugin")
 TARGET_CHOICES = (
     ("codex", "Codex CLI / IDE"),
@@ -149,6 +157,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--client", choices=TARGETS)
     parser.add_argument("--version", default=os.environ.get("SHAFT_MCP_VERSION", "LATEST"))
     parser.add_argument("--json", action="store_true", help="Print machine-readable install details to stdout.")
+    parser.add_argument(
+        "--install-shaft-skills",
+        action="store_true",
+        help="Install SHAFT agent skills into the current directory without prompting.",
+    )
+    parser.add_argument(
+        "--skip-shaft-skills",
+        action="store_true",
+        help="Do not install SHAFT agent skills into the current directory.",
+    )
     for target, _ in TARGET_CHOICES:
         parser.add_argument(f"--{target}", action="store_true", dest=target.replace("-", "_"))
     parser.add_argument(
@@ -170,6 +188,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     selected = [target for target in selected if target]
     if len(set(selected)) > 1:
         fail("Specify only one MCP client target.", 2)
+    if args.install_shaft_skills and args.skip_shaft_skills:
+        fail("Specify only one of --install-shaft-skills or --skip-shaft-skills.", 2)
     args.client = selected[0] if selected else choose_client()
     if args.client not in TARGETS:
         fail("Usage: install-shaft-mcp.py [--client <codex|claude|claude-desktop|copilot|copilot-intellij|intellij-plugin>]", 2)
@@ -570,6 +590,98 @@ def install_runtime_dependencies(jar: Path, repository: str) -> list[Path]:
     resolved = [path for path in installed if path is not None]
     log(f"Installed {len(resolved)} shaft-mcp runtime dependencies.")
     return resolved
+
+
+def is_shaft_skills_source(path: Path) -> bool:
+    return path.is_dir() and all((path / marker).is_file() for marker in SHAFT_SKILLS_SOURCE_MARKERS)
+
+
+def local_shaft_skills_source() -> Path | None:
+    script = Path(__file__).resolve()
+    for parent in script.parents:
+        candidate = parent / SHAFT_SKILLS_DIRECTORY
+        if is_shaft_skills_source(candidate):
+            return candidate.resolve()
+    return None
+
+
+def copy_shaft_skills(source: Path, target: Path) -> Path:
+    source = source.resolve()
+    target = target.resolve()
+    if source == target:
+        return target
+    target.mkdir(parents=True, exist_ok=True)
+    for item in source.iterdir():
+        destination = target / item.name
+        if item.is_dir():
+            shutil.copytree(item, destination, dirs_exist_ok=True)
+        elif item.is_file():
+            shutil.copy2(item, destination)
+    return target
+
+
+def shaft_skills_archive_url() -> str:
+    explicit = os.environ.get("SHAFT_SKILLS_ARCHIVE_URL")
+    if explicit:
+        return explicit
+    ref = os.environ.get("SHAFT_MCP_INSTALLER_REF", "main").strip() or "main"
+    return f"https://github.com/ShaftHQ/SHAFT_ENGINE/archive/{urllib.parse.quote(ref, safe='/')}.zip"
+
+
+def extract_shaft_skills_from_archive(archive: Path, target: Path) -> Path:
+    target = target.resolve()
+    target.mkdir(parents=True, exist_ok=True)
+    copied = 0
+    marker = f"/{SHAFT_SKILLS_DIRECTORY}/"
+    with zipfile.ZipFile(archive) as zip_file:
+        for member in zip_file.infolist():
+            name = member.filename.replace("\\", "/")
+            if member.is_dir() or marker not in name:
+                continue
+            relative = name.split(marker, 1)[1]
+            if not relative:
+                continue
+            destination = (target / relative).resolve()
+            if target != destination and target not in destination.parents:
+                fail(f"SHAFT skills archive contains an unsafe path: {relative}", 4)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            with zip_file.open(member) as source, destination.open("wb") as output:
+                shutil.copyfileobj(source, output)
+            copied += 1
+    if copied == 0 or not is_shaft_skills_source(target):
+        fail("SHAFT skills package did not contain the expected skill files.", 4)
+    return target
+
+
+def install_shaft_skills(current_directory: Path, root: Path) -> Path:
+    target = current_directory.resolve() / SHAFT_SKILLS_DIRECTORY
+    source = local_shaft_skills_source()
+    if source is not None:
+        return copy_shaft_skills(source, target)
+    archive = root / "downloads" / "shaft-skills.zip"
+    download_file(shaft_skills_archive_url(), archive, "SHAFT skills package")
+    return extract_shaft_skills_from_archive(archive, target)
+
+
+def should_install_shaft_skills(args: argparse.Namespace, current_directory: Path) -> bool:
+    if args.install_shaft_skills:
+        return True
+    if args.skip_shaft_skills:
+        return False
+    if not sys.stdin.isatty():
+        log(f"Installing SHAFT skills into current directory by default: {current_directory}")
+        return True
+    print(
+        f"Install SHAFT skills into the current directory?\n  {current_directory}\n[Y/n]: ",
+        end="",
+        file=sys.stderr,
+        flush=True,
+    )
+    try:
+        answer = input().strip().lower()
+    except EOFError:
+        return True
+    return answer not in {"n", "no"}
 
 
 def java_argfile_quote(value: str) -> str:
@@ -1013,6 +1125,15 @@ def install(args: argparse.Namespace) -> None:
     if args.client != "intellij-plugin":
         log(f"Configuring shaft-mcp for {args.client}...")
         configure_client(args.client, java, args_file)
+    current_directory = Path.cwd().resolve()
+    skills_path = current_directory / SHAFT_SKILLS_DIRECTORY
+    skills_installed = False
+    if should_install_shaft_skills(args, current_directory):
+        log(f"Installing SHAFT skills to {skills_path}...")
+        skills_path = install_shaft_skills(current_directory, root)
+        skills_installed = True
+    else:
+        log(f"Skipped SHAFT skills installation for {skills_path}.")
     result = {
         "client": args.client,
         "server": SERVER_NAME,
@@ -1020,12 +1141,20 @@ def install(args: argparse.Namespace) -> None:
         "command": str(java),
         "args": [f"@{args_file}"],
         "userGuide": USER_GUIDE_URL,
+        "shaftSkills": {
+            "installed": skills_installed,
+            "path": str(skills_path),
+        },
     }
     if args.json:
         print(json.dumps(result, separators=(",", ":")))
     else:
         action = "installed and ready for" if args.client == "intellij-plugin" else "installed and configured for"
         print(f"shaft-mcp {version} is {action} {args.client}.")
+        if skills_installed:
+            print(f"SHAFT skills installed at {skills_path}.")
+        else:
+            print(f"SHAFT skills installation skipped for {skills_path}.")
         print(activation_hint(args.client))
         print(f"User guide: {USER_GUIDE_URL}")
 

--- a/shaft-skills/analyzing-shaft-failures/SKILL.md
+++ b/shaft-skills/analyzing-shaft-failures/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: analyzing-shaft-failures
+description: Use when analyzing SHAFT Allure results, Doctor reports, trace evidence, healer output, flaky locator/wait/assertion failures, retries, or test-fix recommendations.
+---
+
+# Analyzing SHAFT Failures
+
+## Overview
+
+Analyze populated evidence before changing tests. Separate product defects, test defects, and infrastructure problems; treat Doctor and healer patches as review-only until applied by the calling agent or user.
+
+## Evidence Workflow
+
+1. Count populated Allure `*-result.json` files before trusting status, summaries, or screenshots.
+2. Preserve the `allure-results` root; delete contents only when cleanup is explicitly needed.
+3. Use `shaft-mcp:doctor_analyze_failed_allure` for WebDriver/Selenium SHAFT failures.
+4. Use `shaft-mcp:playwright_doctor_analyze_failed_allure` for SHAFT Playwright failures.
+5. Use `shaft-mcp:doctor_suggest_fix` or `shaft-mcp:playwright_doctor_suggest_fix` only after reviewing the Doctor report.
+6. Prefer `shaft-mcp:trace_latest`, `shaft-mcp:trace_summarize`, and `shaft-mcp:doctor_analyze_trace` when structured trace evidence exists.
+7. Search the guide with `shaft-mcp:shaft_guide_search` before recommending SHAFT syntax changes.
+8. Run `shaft-mcp:test_code_guardrails_check` on any suggested Java patch.
+
+## Diagnosis Categories
+
+| Symptom | First check |
+| --- | --- |
+| Locator not found or duplicate | Current DOM/tree, smart locator, app-owned attributes |
+| Stale/hidden/covered/interactable | Page state, frame/window context, synchronized SHAFT action |
+| Assertion mismatch | Expected behavior, test data, response/body state |
+| Timeout/flaky retry | Deterministic wait condition, environment, network trace |
+| Empty report | Test did not run or result path is wrong; do not infer pass/fail |
+| Product behavior changed | Report suspected product bug, do not silently weaken assertions |
+
+## Healer Rules
+
+- `shaft-mcp:healer_run_failed_test` and `shaft-mcp:playwright_healer_run_failed_test` may rerun and propose fixes, but they do not own source edits.
+- Require a headless, bounded Maven command and workspace-local evidence paths.
+- Do not run cloud/external suites, publish PRs, or use provider advisories unless explicitly approved.
+- Validate applied fixes with the smallest affected test or compile check.
+
+## Official Guide Routes
+
+- Doctor: `https://shafthq.github.io/docs/agentic/doctor`
+- MCP: `https://shafthq.github.io/docs/agentic/mcp`
+- Flakiness: `https://shafthq.github.io/docs/testing/flakiness`
+- Web locator strategy: `https://shafthq.github.io/docs/testing/web#locator-strategy`
+- Element validations: `https://shafthq.github.io/docs/reference/actions/GUI/Element_Validations`
+
+## Common Mistakes
+
+| Mistake | Fix |
+| --- | --- |
+| Trusting empty Allure output | Count result JSON first |
+| Fixing only the named test | Check shared page/API helper callers |
+| Weakening assertion to pass | Confirm expected behavior or report product bug |
+| Applying healer patch blindly | Review evidence and guardrails first |
+| Replacing `allure-results` directory | Preserve root and clean contents only |

--- a/shaft-skills/analyzing-shaft-failures/agents/openai.yaml
+++ b/shaft-skills/analyzing-shaft-failures/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Analyzing SHAFT Failures"
+  short_description: "Analyze SHAFT failure evidence"
+  default_prompt: "Use $analyzing-shaft-failures to analyze these SHAFT Allure results and suggest the next fix."

--- a/shaft-skills/choosing-shaft-locators/SKILL.md
+++ b/shaft-skills/choosing-shaft-locators/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: choosing-shaft-locators
+description: Use when creating, reviewing, refactoring, repairing, or generating SHAFT web/mobile locators, smart locators, ARIA locators, XPath/CSS replacements, or codegen element identifiers.
+---
+
+# Choosing SHAFT Locators
+
+## Overview
+
+Choose locators that express user intent first and DOM mechanics last. A locator is not ready for generated code until it has been checked against the current page, app tree, or official guide pattern.
+
+## Locator Ladder
+
+Stop at the first rung that uniquely identifies the element:
+
+1. Smart locator: `SHAFT.GUI.Locator.inputField("Email")`, `clickableField("Sign in")`.
+2. Semantic/ARIA locator: `SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasText("Submit").build()`.
+3. Stable product-owned attribute: `data-testid`, stable `id`, `name`, or mobile `accessibilityId`.
+4. Composed `SHAFT.GUI.Locator` builder with tag, text, attributes, parent/shadow/iframe context.
+5. Stable CSS only when the app exposes no semantic signal.
+6. XPath only when required, never absolute XPath.
+
+## MCP Checks
+
+- Call `shaft-mcp:shaft_guide_search` for `Smart Locators`, `SHAFT Locator Builder`, or `web locator strategy`.
+- For live web work, use `shaft-mcp:browser_open_intent`, `shaft-mcp:browser_get_page_dom`, and screenshots when needed.
+- For Playwright projects, use the matching `shaft-mcp:playwright_*` DOM and element tools.
+- For mobile, use `shaft-mcp:mobile_get_accessibility_tree` and prefer accessibility IDs before XPath.
+- Run `shaft-mcp:test_code_guardrails_check` on final Java snippets.
+
+## Codegen Rules
+
+- Verify login, form, and navigation locators with real MCP actions before publishing them.
+- Keep generated `SHAFT.GUI.Locator.*` locators inline only for throwaway snippets; move stable locators into page objects for repo insertion.
+- Preserve user-provided locator choices from Capture when the recorder marks them as intentional.
+- Do not use coordinate-only actions while a locator candidate exists.
+- Do not paste raw DOM snapshots into source code.
+
+## Examples
+
+```java
+By email = SHAFT.GUI.Locator.inputField("Email");
+By submit = SHAFT.GUI.Locator.clickableField("Create Account");
+By alert = SHAFT.GUI.Locator.hasRole(Role.ALERT).containsText("error").build();
+By checkout = SHAFT.GUI.Locator.hasAnyTagName()
+        .hasAttribute("data-testid", "checkout")
+        .build();
+```
+
+## Official Guide Routes
+
+- Locator strategy: `https://shafthq.github.io/docs/testing/web#locator-strategy`
+- Smart Locators: `https://shafthq.github.io/docs/reference/actions/GUI/didYouKnow/Smart_Locators`
+- Locator Builder: `https://shafthq.github.io/docs/reference/actions/GUI/didYouKnow/Shaft_Locator_Builder`
+- Element identification: `https://shafthq.github.io/docs/reference/actions/GUI/Element_Identification`
+- Mobile testing: `https://shafthq.github.io/docs/testing/mobile`
+
+## Common Mistakes
+
+| Mistake | Fix |
+| --- | --- |
+| `By.xpath("/html/body/...")` | Use Smart Locator, ARIA, or builder context |
+| Generated ID chosen blindly | Prefer visible label or app-owned test attribute |
+| Multiple Smart Locator matches | Add parent/container context with `SHAFT.GUI.Locator` |
+| Locator repaired from old report only | Inspect current DOM/tree before changing source |
+| Selenium `@FindBy` | Use `By` fields and SHAFT page object methods |

--- a/shaft-skills/choosing-shaft-locators/agents/openai.yaml
+++ b/shaft-skills/choosing-shaft-locators/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Choosing SHAFT Locators"
+  short_description: "Choose robust SHAFT locators"
+  default_prompt: "Use $choosing-shaft-locators to review and improve these SHAFT locators."

--- a/shaft-skills/evaluation-prompts.md
+++ b/shaft-skills/evaluation-prompts.md
@@ -1,0 +1,27 @@
+# SHAFT Skill Evaluation Prompts
+
+Use these prompts in fresh agent sessions when subagent or model-evaluation access is approved. They are not a substitute for `quick_validate.py`; they pressure-test whether agents apply the skills under realistic drift.
+
+## `writing-shaft-tests`
+
+1. Use `$writing-shaft-tests` to write a TestNG SHAFT web login test for an existing project. The page has Email and Password fields and a Sign in button. Include one hard assertion and no sleeps.
+2. Use `$writing-shaft-tests` to review this Java snippet and list only the changes required before it can be accepted: it uses `Thread.sleep`, `driver.findElement`, `System.getProperty`, and a hard-coded token.
+3. Use `$writing-shaft-tests` to sketch a SHAFT API negative test from an OpenAPI contract where a missing required field should return 400. Keep reusable request/validation code outside the test.
+
+## `choosing-shaft-locators`
+
+1. Use `$choosing-shaft-locators` to replace `By.xpath("/html/body/div[2]/form/input[1]")` for an email field whose visible label is Email and whose placeholder is Work email.
+2. Use `$choosing-shaft-locators` to choose locators for a checkout button with accessible name Checkout, a generated id, and a stable `data-testid=checkout-submit`.
+3. Use `$choosing-shaft-locators` to diagnose a flaky mobile locator where XPath finds two Login buttons but one has accessibility id `loginButton`.
+
+## `recording-shaft-tests-with-mcp`
+
+1. Use `$recording-shaft-tests-with-mcp` to describe the MCP tool sequence for recording a WebDriver checkout flow and integrating it into existing page objects.
+2. Use `$recording-shaft-tests-with-mcp` to handle a Capture result with readiness `RISKY`, one positional CSS warning, and no post-submit assertion.
+3. Use `$recording-shaft-tests-with-mcp` to turn an Appium Inspector recording into reusable SHAFT mobile test code without leaking typed passwords.
+
+## `analyzing-shaft-failures`
+
+1. Use `$analyzing-shaft-failures` to analyze an `allure-results` directory that contains zero `*-result.json` files but a stale `summary.json` says passed.
+2. Use `$analyzing-shaft-failures` to triage a failed SHAFT web test with `NoSuchElementException` after a retry and a Doctor suggestion to use a new locator.
+3. Use `$analyzing-shaft-failures` to decide whether to apply a healer-proposed assertion change when the trace shows the product now returns a different validation message.

--- a/shaft-skills/recording-shaft-tests-with-mcp/SKILL.md
+++ b/shaft-skills/recording-shaft-tests-with-mcp/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: recording-shaft-tests-with-mcp
+description: Use when recording browser, Playwright, mobile, Appium Inspector, or user-performed flows into SHAFT tests with MCP Capture, replay, code blocks, or codegen insertion.
+---
+
+# Recording SHAFT Tests With MCP
+
+## Overview
+
+Record first, then generate reviewed SHAFT code. Treat recordings as evidence and snippets as drafts to integrate into the existing page/test structure.
+
+## WebDriver Capture Flow
+
+1. Call `shaft-mcp:shaft_guide_search` for Capture and the target test area.
+2. Start with `shaft-mcp:capture_start` or `shaft-mcp:capture_start_codegen`.
+3. Use the visible browser or MCP element tools to perform the flow.
+4. Add checkpoints with `shaft-mcp:capture_checkpoint` for assertions, page transitions, or named flow blocks.
+5. Check readiness with `shaft-mcp:capture_status`; resolve `BLOCKED` or important `RISKY` findings.
+6. Stop with `shaft-mcp:capture_stop`.
+7. Generate snippets with `shaft-mcp:capture_code_blocks`; use `shaft-mcp:capture_record_at_target_code_blocks` for insertion into an existing Java source anchor.
+8. Run `shaft-mcp:test_code_guardrails_check` before inserting or returning code.
+
+## Playwright And Mobile
+
+| Target | Tools |
+| --- | --- |
+| SHAFT Playwright direct record | `shaft-mcp:playwright_initialize`, `shaft-mcp:playwright_record_start`, `shaft-mcp:playwright_record_stop`, `shaft-mcp:playwright_recording_code_blocks` |
+| Playwright Capture generation | `shaft-mcp:playwright_capture_code_blocks` |
+| Mobile MCP recording | `shaft-mcp:mobile_record_start`, `shaft-mcp:mobile_record_stop`, `shaft-mcp:mobile_recording_code_blocks` |
+| Appium Inspector wrapper | `shaft-mcp:mobile_inspector_record_prepare`, `shaft-mcp:mobile_inspector_record_start`, `shaft-mcp:mobile_inspector_record_control`, `shaft-mcp:mobile_inspector_record_stop` |
+
+## Integration Rules
+
+- Ask for the exact target URL when the user names a site without one.
+- Keep secrets redacted. Use generated required-data placeholders instead of captured typed secrets.
+- Prefer recorded assertion mode or checkpoints so replay has meaningful verification.
+- Move stable locators/actions into page objects; do not paste a generic generated class when the repo has existing structure.
+- Keep recording artifacts as evidence, not as source.
+- Do not add sleeps, absolute XPath, raw Selenium calls, or coordinate-only actions when locator candidates exist.
+
+## Official Guide Routes
+
+- Capture: `https://shafthq.github.io/docs/agentic/capture`
+- MCP: `https://shafthq.github.io/docs/agentic/mcp`
+- Web testing: `https://shafthq.github.io/docs/testing/web`
+- Playwright backend: `https://shafthq.github.io/docs/reference/actions/GUI/Playwright_Backend`
+- Mobile testing: `https://shafthq.github.io/docs/testing/mobile`
+
+## Common Mistakes
+
+| Mistake | Fix |
+| --- | --- |
+| Starting capture after the flow | Restart and record from the first meaningful action |
+| Ignoring readiness warnings | Resolve missing assertions, risky locators, or required data first |
+| Returning raw generated class | Integrate snippets into current page/test files |
+| Publishing unverified locator | Replay or perform the action before final code |
+| Capturing secret values | Replace with safe placeholders or config-backed test data |

--- a/shaft-skills/recording-shaft-tests-with-mcp/agents/openai.yaml
+++ b/shaft-skills/recording-shaft-tests-with-mcp/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Recording SHAFT Tests with MCP"
+  short_description: "Record SHAFT tests through MCP"
+  default_prompt: "Use $recording-shaft-tests-with-mcp to record this flow and turn it into SHAFT test code."

--- a/shaft-skills/writing-shaft-tests/SKILL.md
+++ b/shaft-skills/writing-shaft-tests/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: writing-shaft-tests
+description: Use when writing, reviewing, or repairing SHAFT Java tests, page objects, API tests, mobile tests, CLI/DB tests, assertions, waits, or TestNG/JUnit/Cucumber scenarios.
+---
+
+# Writing SHAFT Tests
+
+## Overview
+
+Write SHAFT tests from official guide evidence and current repo patterns. Prefer SHAFT facades, fluent actions, SHAFT assertions, and the smallest maintainable test shape that proves the behavior.
+
+## Required Workflow
+
+1. Inspect the project first: runner, existing page/API objects, package layout, properties, and test style.
+2. Call `shaft-mcp:shaft_guide_search` before writing SHAFT code. Cite the returned guide URLs in the final answer.
+3. For broad or unclear automation requests, call `shaft-mcp:test_automation_scenarios` with the closest area (`web`, `api`, `mobile`, `cli`, `db`, `capture`, `doctor`, or `ci`).
+4. Write code using SHAFT syntax only; do not invent APIs from memory.
+5. Run `shaft-mcp:test_code_guardrails_check` on generated Java before finalizing.
+6. Validate with the smallest affected test or compile check available.
+
+## SHAFT Defaults
+
+| Need | Use |
+| --- | --- |
+| Web UI test | `SHAFT.GUI.WebDriver`, `driver.browser()`, `driver.element()`, page objects |
+| Playwright project | `SHAFT.GUI.Playwright`, not mixed WebDriver waits |
+| Mobile native/web | `SHAFT.GUI.Locator.*`, touch actions, `driver.element().assertThat(...)` |
+| API | `SHAFT.API`, reusable request builders/validators, `perform()` |
+| Assertions | `driver.assertThat(...)`, `driver.verifyThat(...)`, or `SHAFT.Validations` |
+| Guide evidence | `shaft-mcp:shaft_guide_search` |
+| Guardrails | `shaft-mcp:test_code_guardrails_check` |
+
+## Hard Rules
+
+- Do not use `Thread.sleep`; use SHAFT waits, actions, assertions, or condition-based waiting from the guide.
+- Do not use raw `driver.findElement`, Selenium `PageFactory`, `@FindBy`, implicit waits, or headed setup in generated tests.
+- Do not hard-code secrets, credentials, tokens, target URLs, or environment-specific paths.
+- Do not infer a target URL from a site/product name. Ask for the exact URL when it is missing.
+- Keep browser sessions fresh per test and always quit/clean up following the repo's test framework style.
+- Keep reusable page/API/mobile objects outside test classes only when they are actually reused.
+
+## Example Shape
+
+```java
+private final By email = SHAFT.GUI.Locator.inputField("Email");
+private final By password = SHAFT.GUI.Locator.inputField("Password");
+private final By signIn = SHAFT.GUI.Locator.clickableField("Sign in");
+
+@Test
+public void userCanSignIn() {
+    driver.browser().navigateToURL(baseUrl);
+
+    driver.element()
+            .type(email, username)
+            .and().type(password, passwordValue)
+            .and().click(signIn);
+
+    driver.assertThat().browser().url().contains("/dashboard");
+}
+```
+
+## Official Guide Routes
+
+Use `shaft-mcp:shaft_guide_search` first, then fall back to these public pages when MCP is unavailable:
+
+- Web testing: `https://shafthq.github.io/docs/testing/web`
+- API testing: `https://shafthq.github.io/docs/testing/api`
+- Mobile testing: `https://shafthq.github.io/docs/testing/mobile`
+- Element validations: `https://shafthq.github.io/docs/reference/actions/GUI/Element_Validations`
+- Validation overview: `https://shafthq.github.io/docs/reference/actions/Validations/Overview`
+- MCP: `https://shafthq.github.io/docs/agentic/mcp`
+
+## Common Mistakes
+
+| Mistake | Fix |
+| --- | --- |
+| Native Selenium snippet | Rewrite through SHAFT driver/page/API facades |
+| `Thread.sleep` after navigation | Assert URL/page state or use SHAFT synchronized action |
+| Assertions only in comments | Add real `assertThat`/`verifyThat` calls |
+| Huge generated test class | Move only reused flows into page/API objects |
+| Guardrail check skipped | Run `shaft-mcp:test_code_guardrails_check` before final answer |

--- a/shaft-skills/writing-shaft-tests/agents/openai.yaml
+++ b/shaft-skills/writing-shaft-tests/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Writing SHAFT Tests"
+  short_description: "Author SHAFT tests correctly"
+  default_prompt: "Use $writing-shaft-tests to write a SHAFT test that follows official guide patterns."

--- a/tests/scripts/test_install_shaft_mcp.py
+++ b/tests/scripts/test_install_shaft_mcp.py
@@ -30,6 +30,16 @@ def temporary_environment(**values):
                 os.environ[name] = value
 
 
+@contextlib.contextmanager
+def temporary_current_directory(path: Path):
+    original = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(original)
+
+
 class InstallShaftMcpTest(unittest.TestCase):
     def test_banner_is_not_repeated_after_bootstrap_banner(self):
         with temporary_environment(SHAFT_MCP_BOOTSTRAP_BANNER_SHOWN="1"):
@@ -63,8 +73,59 @@ class InstallShaftMcpTest(unittest.TestCase):
         self.assertEqual("intellij-plugin", args.client)
         self.assertTrue(args.json)
 
+    def test_parse_rejects_conflicting_shaft_skills_flags(self):
+        with self.assertRaises(MODULE.InstallError):
+            MODULE.parse_args(["--codex", "--install-shaft-skills", "--skip-shaft-skills"])
+
     def test_intellij_plugin_target_does_not_configure_external_client(self):
         MODULE.configure_client("intellij-plugin", Path("java"), Path("shaft-mcp.args"))
+
+    def test_unattended_install_defaults_to_shaft_skills(self):
+        args = MODULE.parse_args(["--intellij-plugin"])
+
+        stderr = io.StringIO()
+        original_stdin = MODULE.sys.stdin
+        MODULE.sys.stdin = io.StringIO("")
+        try:
+            with contextlib.redirect_stderr(stderr):
+                should_install = MODULE.should_install_shaft_skills(args, Path("project").resolve())
+        finally:
+            MODULE.sys.stdin = original_stdin
+
+        self.assertTrue(should_install)
+        self.assertIn("Installing SHAFT skills into current directory by default", stderr.getvalue())
+
+    def test_skip_shaft_skills_flag_disables_install(self):
+        args = MODULE.parse_args(["--intellij-plugin", "--skip-shaft-skills"])
+
+        self.assertFalse(MODULE.should_install_shaft_skills(args, Path("project").resolve()))
+
+    def test_install_shaft_skills_copies_package_to_current_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with temporary_current_directory(root):
+                installed = MODULE.install_shaft_skills(Path.cwd(), root / "bootstrap")
+
+            self.assertEqual(root / MODULE.SHAFT_SKILLS_DIRECTORY, installed)
+            self.assertTrue((installed / "writing-shaft-tests" / "SKILL.md").is_file())
+            self.assertTrue((installed / "recording-shaft-tests-with-mcp" / "agents" / "openai.yaml").is_file())
+
+    def test_extract_shaft_skills_from_archive(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            archive = root / "shaft-skills.zip"
+            with zipfile.ZipFile(archive, "w") as zip_file:
+                for marker in MODULE.SHAFT_SKILLS_SOURCE_MARKERS:
+                    zip_file.writestr(f"SHAFT_ENGINE-main/shaft-skills/{marker}", "skill")
+                zip_file.writestr(
+                    "SHAFT_ENGINE-main/shaft-skills/recording-shaft-tests-with-mcp/agents/openai.yaml",
+                    "openai: true",
+                )
+
+            installed = MODULE.extract_shaft_skills_from_archive(archive, root / "project" / "shaft-skills")
+
+            self.assertTrue((installed / "writing-shaft-tests" / "SKILL.md").is_file())
+            self.assertTrue((installed / "recording-shaft-tests-with-mcp" / "agents" / "openai.yaml").is_file())
 
     def test_codex_auto_approval_is_added_to_shaft_mcp_section(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/scripts/test_validate_documentation_boundaries.py
+++ b/tests/scripts/test_validate_documentation_boundaries.py
@@ -58,6 +58,12 @@ class ValidateDocumentationBoundariesTest(unittest.TestCase):
 
         self.assertEqual(validate_repository(self.root), [])
 
+    def test_allows_installable_shaft_skills(self):
+        self.write("shaft-skills/evaluation-prompts.md", "# Evaluation Prompts\n")
+        self.write("shaft-skills/writing-shaft-tests/SKILL.md", "# Writing SHAFT Tests\n")
+
+        self.assertEqual(validate_repository(self.root), [])
+
     def test_rejects_unapproved_nested_readme(self):
         self.write(".github/other/README.md", "# Other\n")
 


### PR DESCRIPTION
This PR was created by Codex, not manually by the maintainer whose token opened it.

## Summary
- Adds installable SHAFT agent skills for test writing, locator selection, MCP recording, and Allure/Doctor failure analysis.
- Updates the shaft-mcp installer to offer `shaft-skills/` after setup, with explicit install/skip flags and unattended default install.
- Extends installer release verification, focused unit tests, and documentation-boundary validation for the new skill package.

## Test Plan
- `quick_validate.py` for all 4 skills
- `py -3 -m unittest tests.scripts.test_install_shaft_mcp tests.scripts.test_validate_documentation_boundaries`
- `py -3 scripts\ci\validate_shaft_mcp_configuration.py`
- `py -3 scripts\ci\verify_shaft_mcp_installer_release.py`
- `py -3 scripts\ci\validate_documentation_boundaries.py`
- `py -3 scripts\ci\validate_agent_setup.py`
- `py -3 scripts\ci\validate_modular_documentation.py`
- `git diff --check`

## Notes
- `sh -n scripts/mcp/install-shaft-mcp.sh` was not run because `sh` is unavailable on this Windows host.