### PR TITLE
Add agentic PDCA loop skill

### DIFF
--- a/.agents/skills/agent-guidance-boundary-guard/SKILL.md
+++ b/.agents/skills/agent-guidance-boundary-guard/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: agent-guidance-boundary-guard
-description: Use when AGENTS.md, CLAUDE.md, .agents, .github skills/instructions, .codex, or .memory guidance surfaces change.
+description: Use for AGENTS.md, CLAUDE.md, .agents, .github skills/instructions, .codex, or .memory guidance changes.
 ---
 
 # Agent Guidance Boundary Guard
 
-Read and follow the [canonical agent guidance boundary playbook](../../../.github/skills/agent-guidance-boundary-guard/SKILL.md).
+Follow the [canonical guidance playbook](../../../.github/skills/agent-guidance-boundary-guard/SKILL.md).

--- a/.agents/skills/agent-guidance-boundary-guard/agents/openai.yaml
+++ b/.agents/skills/agent-guidance-boundary-guard/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Agent Guidance Boundary Guard"
   short_description: "Guard agent guidance and memory surfaces"
-  default_prompt: "Use $agent-guidance-boundary-guard to validate this guidance change."
+  default_prompt: "Use $agent-guidance-boundary-guard."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/agentic-pdca-loop/SKILL.md
+++ b/.agents/skills/agentic-pdca-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentic-pdca-loop
-description: Use for SHAFT PDCA, Kevin/Bob/Bruce roles, or quality/intuitiveness/acceptability refinement.
+description: Use for SHAFT PDCA, Kevin/Bob/Bruce roles, or refinement loops.
 ---
 
 # PDCA

--- a/.agents/skills/agentic-pdca-loop/SKILL.md
+++ b/.agents/skills/agentic-pdca-loop/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: agentic-pdca-loop
+description: Use for SHAFT PDCA, Kevin/Bob/Bruce roles, or quality/intuitiveness/acceptability refinement.
+---
+
+# PDCA
+
+Follow the [canonical PDCA playbook](../../../.github/skills/agentic-pdca-loop/SKILL.md).

--- a/.agents/skills/agentic-pdca-loop/agents/openai.yaml
+++ b/.agents/skills/agentic-pdca-loop/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Agentic PDCA Loop"
-  short_description: "Persona PDCA quality loop"
-  default_prompt: "Use $agentic-pdca-loop for this SHAFT change."
+  short_description: "Persona PDCA isolation loop"
+  default_prompt: "Use $agentic-pdca-loop."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/agentic-pdca-loop/agents/openai.yaml
+++ b/.agents/skills/agentic-pdca-loop/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Agentic PDCA Loop"
+  short_description: "Persona PDCA quality loop"
+  default_prompt: "Use $agentic-pdca-loop for this SHAFT change."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/allure-extent-report-operator/SKILL.md
+++ b/.agents/skills/allure-extent-report-operator/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: allure-extent-report-operator
-description: Use when Allure or Extent report generation, artifacts, summaries, upload actions, failure extraction, or report paths change.
+description: Use for SHAFT Allure/Extent reports, artifacts, summaries, upload actions, failure extraction, or report paths.
 ---
 
 # Allure Extent Report Operator
 
-Read and follow the [canonical report operations playbook](../../../.github/skills/allure-extent-report-operator/SKILL.md).
+Follow the [canonical report playbook](../../../.github/skills/allure-extent-report-operator/SKILL.md).

--- a/.agents/skills/allure-extent-report-operator/agents/openai.yaml
+++ b/.agents/skills/allure-extent-report-operator/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Allure Extent Report Operator"
   short_description: "Operate report artifacts and summaries"
-  default_prompt: "Use $allure-extent-report-operator to validate this report artifact change."
+  default_prompt: "Use $allure-extent-report-operator."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/ci-failure-investigator/SKILL.md
+++ b/.agents/skills/ci-failure-investigator/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: ci-failure-investigator
-description: Use when a GitHub Actions job, SHAFT Allure report, or provider E2E run fails; identify the first actionable failure and separate code defects from infrastructure, credentials, and provider faults.
+description: Use for failed GitHub Actions, SHAFT Allure reports, or provider E2E runs; find the first actionable cause.
 ---
 
 # CI Failure Investigator
 
-Read and follow the [canonical CI playbook](../../../.github/skills/ci-failure-investigator/SKILL.md).
+Follow the [canonical CI playbook](../../../.github/skills/ci-failure-investigator/SKILL.md).

--- a/.agents/skills/ci-failure-investigator/agents/openai.yaml
+++ b/.agents/skills/ci-failure-investigator/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "CI Failure Investigator"
   short_description: "Debug GitHub Actions and Allure failures"
-  default_prompt: "Use $ci-failure-investigator to identify and fix the root cause of this CI failure."
+  default_prompt: "Use $ci-failure-investigator."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/flaky-test-stabilizer/SKILL.md
+++ b/.agents/skills/flaky-test-stabilizer/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: flaky-test-stabilizer
-description: Use when a SHAFT test is intermittent, retry-only, parallel-only, or environment-sensitive; diagnose shared state, files, drivers, timing, and external dependencies without weakening assertions.
+description: Use for intermittent, retry-only, parallel-only, or environment-sensitive SHAFT tests; fix causes without weakening assertions.
 ---
 
 # Flaky Test Stabilizer
 
-Read and follow the [canonical flaky-test playbook](../../../.github/skills/flaky-test-stabilizer/SKILL.md).
+Follow the [canonical flaky-test playbook](../../../.github/skills/flaky-test-stabilizer/SKILL.md).

--- a/.agents/skills/flaky-test-stabilizer/agents/openai.yaml
+++ b/.agents/skills/flaky-test-stabilizer/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Flaky Test Stabilizer"
   short_description: "Stabilize intermittent and parallel tests"
-  default_prompt: "Use $flaky-test-stabilizer to diagnose and remove the cause of this intermittent test failure."
+  default_prompt: "Use $flaky-test-stabilizer."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/framework-source-rules/SKILL.md
+++ b/.agents/skills/framework-source-rules/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: framework-source-rules
-description: Use when editing or reviewing any src/main Java file in SHAFT; apply production compatibility, public API, properties, logging, Allure, concurrency, and WebDriver rules.
+description: Use for SHAFT src/main Java edits/reviews; apply public API, properties, logging, Allure, concurrency, and WebDriver rules.
 ---
 
 # Framework Source Rules
 
-Read and follow the [canonical production Java rules](../../../.github/instructions/framework-source.instructions.md).
+Follow the [canonical production Java rules](../../../.github/instructions/framework-source.instructions.md).

--- a/.agents/skills/framework-source-rules/agents/openai.yaml
+++ b/.agents/skills/framework-source-rules/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Framework Source Rules"
   short_description: "Apply production Java framework rules"
-  default_prompt: "Use $framework-source-rules while implementing this production Java change."
+  default_prompt: "Use $framework-source-rules."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/graphify/agents/openai.yaml
+++ b/.agents/skills/graphify/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Graphify Repository Map"
   short_description: "Query the local SHAFT repository map"
-  default_prompt: "Use $graphify to map SHAFT_ENGINE before broad file search."
+  default_prompt: "Use $graphify."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/java-test-rules/SKILL.md
+++ b/.agents/skills/java-test-rules/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: java-test-rules
-description: Use when editing or reviewing any src/test Java file in SHAFT; apply lifecycle, parallelism, isolation, Allure, browser, mocking, and focused regression rules.
+description: Use for SHAFT src/test Java edits/reviews; apply lifecycle, isolation, Allure, browser, mocking, and regression rules.
 ---
 
 # Java Test Rules
 
-Read and follow the [canonical Java test rules](../../../.github/instructions/java-tests.instructions.md).
+Follow the [canonical Java test rules](../../../.github/instructions/java-tests.instructions.md).

--- a/.agents/skills/java-test-rules/agents/openai.yaml
+++ b/.agents/skills/java-test-rules/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Java Test Rules"
   short_description: "Apply Java test isolation and lifecycle rules"
-  default_prompt: "Use $java-test-rules while implementing or reviewing this Java test change."
+  default_prompt: "Use $java-test-rules."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/mcp-transport-contract-auditor/SKILL.md
+++ b/.agents/skills/mcp-transport-contract-auditor/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: mcp-transport-contract-auditor
-description: Use when shaft-mcp manifests, fixtures, installers, Dockerfiles, tool schemas, workflows, or stdio/HTTP transport behavior changes.
+description: Use for shaft-mcp manifests, fixtures, installers, Dockerfiles, tool schemas, workflows, or transport behavior.
 ---
 
 # MCP Transport Contract Auditor
 
-Read and follow the [canonical MCP transport contract playbook](../../../.github/skills/mcp-transport-contract-auditor/SKILL.md).
+Follow the [canonical MCP transport playbook](../../../.github/skills/mcp-transport-contract-auditor/SKILL.md).

--- a/.agents/skills/mcp-transport-contract-auditor/agents/openai.yaml
+++ b/.agents/skills/mcp-transport-contract-auditor/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "MCP Transport Contract Auditor"
   short_description: "Audit MCP manifests and transports"
-  default_prompt: "Use $mcp-transport-contract-auditor to verify this shaft-mcp contract change."
+  default_prompt: "Use $mcp-transport-contract-auditor."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/modular-boundary-auditor/SKILL.md
+++ b/.agents/skills/modular-boundary-auditor/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: modular-boundary-auditor
-description: Use when SHAFT module wiring, POMs, shaft-bom, legacy-shaft-engine, examples, or consumer fixtures change.
+description: Use for SHAFT module wiring, POMs, BOM, legacy coordinates, examples, or consumer fixtures.
 ---
 
 # Modular Boundary Auditor
 
-Read and follow the [canonical modular boundary playbook](../../../.github/skills/modular-boundary-auditor/SKILL.md).
+Follow the [canonical modular boundary playbook](../../../.github/skills/modular-boundary-auditor/SKILL.md).

--- a/.agents/skills/modular-boundary-auditor/agents/openai.yaml
+++ b/.agents/skills/modular-boundary-auditor/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Modular Boundary Auditor"
   short_description: "Check module boundaries and fixtures"
-  default_prompt: "Use $modular-boundary-auditor to review this module boundary change."
+  default_prompt: "Use $modular-boundary-auditor."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/public-behavior-docs-synchronizer/SKILL.md
+++ b/.agents/skills/public-behavior-docs-synchronizer/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: public-behavior-docs-synchronizer
-description: Use when public SHAFT APIs, config, behavior, README links, release text, or docs routing may need user-guide synchronization.
+description: Use for public SHAFT API/config/behavior, README/release text, or docs routing sync.
 ---
 
 # Public Behavior Docs Synchronizer
 
-Read and follow the [canonical public docs synchronization playbook](../../../.github/skills/public-behavior-docs-synchronizer/SKILL.md).
+Follow the [canonical public docs playbook](../../../.github/skills/public-behavior-docs-synchronizer/SKILL.md).

--- a/.agents/skills/public-behavior-docs-synchronizer/agents/openai.yaml
+++ b/.agents/skills/public-behavior-docs-synchronizer/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Public Behavior Docs Synchronizer"
   short_description: "Keep public behavior and docs aligned"
-  default_prompt: "Use $public-behavior-docs-synchronizer to plan the docs sync for this public behavior change."
+  default_prompt: "Use $public-behavior-docs-synchronizer."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/release-dependency-guard/SKILL.md
+++ b/.agents/skills/release-dependency-guard/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: release-dependency-guard
-description: Use when preparing or reviewing a SHAFT release, version alignment, dependency or plugin updates, or Maven Central safeguards; validate metadata without deploying or publishing.
+description: Use for SHAFT releases, version alignment, dependency/plugin updates, or Maven Central safeguards; never deploy locally.
 ---
 
 # Release And Dependency Guard
 
-Read and follow the [canonical release playbook](../../../.github/skills/release-dependency-guard/SKILL.md).
+Follow the [canonical release playbook](../../../.github/skills/release-dependency-guard/SKILL.md).

--- a/.agents/skills/release-dependency-guard/agents/openai.yaml
+++ b/.agents/skills/release-dependency-guard/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Release And Dependency Guard"
   short_description: "Guard releases and dependency updates"
-  default_prompt: "Use $release-dependency-guard to prepare or review this release or dependency update."
+  default_prompt: "Use $release-dependency-guard."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/shaft-marketing-ad-producer/SKILL.md
+++ b/.agents/skills/shaft-marketing-ad-producer/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: shaft-marketing-ad-producer
-description: Use when planning or producing SHAFT marketing ads; scripts, scenes, demo capture, captions, music direction, code snippets, video editing, reusable assets.
+description: Use for SHAFT ad strategy, scripts, scenes, demo capture, captions, music, code visuals, edits, or reusable assets.
 ---
 
 # SHAFT Marketing Ad Producer
 
-Read and follow the [canonical SHAFT marketing ad producer playbook](../../../.github/skills/shaft-marketing-ad-producer/SKILL.md).
+Follow the [canonical SHAFT ad playbook](../../../.github/skills/shaft-marketing-ad-producer/SKILL.md).

--- a/.agents/skills/shaft-marketing-ad-producer/agents/openai.yaml
+++ b/.agents/skills/shaft-marketing-ad-producer/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "SHAFT Marketing Ad Producer"
   short_description: "Plan and produce reusable SHAFT ads"
-  default_prompt: "Use $shaft-marketing-ad-producer to plan and produce this SHAFT marketing ad."
+  default_prompt: "Use $shaft-marketing-ad-producer."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/shaft-ui-design/SKILL.md
+++ b/.agents/skills/shaft-ui-design/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: shaft-ui-design
-description: Use when creating, revamping, optimizing, reviewing, or validating SHAFT UI for core tools/reports or the public guide; apply UX, accessibility, responsive, and screenshot evidence rules.
+description: Use for SHAFT UI design/review/validation across tools, reports, plugin UI, or public guide; include UX and evidence rules.
 ---
 
 # SHAFT UI Design
 
-Read and follow the [canonical SHAFT UI design skill](../../../.github/skills/shaft-ui-design/SKILL.md).
+Follow the [canonical SHAFT UI design skill](../../../.github/skills/shaft-ui-design/SKILL.md).

--- a/.agents/skills/shaft-ui-design/agents/openai.yaml
+++ b/.agents/skills/shaft-ui-design/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "SHAFT UI Design"
   short_description: "Design SHAFT UI with proof"
-  default_prompt: "Use $shaft-ui-design for this SHAFT UI design task."
+  default_prompt: "Use $shaft-ui-design."
 policy:
   allow_implicit_invocation: true

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -12,3 +12,4 @@ Load only the matching playbook:
 - [Modular boundary auditor](modular-boundary-auditor/SKILL.md)
 - [Allure Extent report operator](allure-extent-report-operator/SKILL.md)
 - [Agent guidance boundary guard](agent-guidance-boundary-guard/SKILL.md)
+- [Agentic PDCA loop](agentic-pdca-loop/SKILL.md)

--- a/.github/skills/agentic-pdca-loop/SKILL.md
+++ b/.github/skills/agentic-pdca-loop/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: agentic-pdca-loop
-description: Use for SHAFT PDCA, Kevin/Bob/Bruce roles, or quality/intuitiveness/acceptability refinement.
+description: Use for SHAFT PDCA, Kevin/Bob/Bruce roles, or refinement loops.
 ---
 
 # PDCA
 
-Keep notes isolated. Kevin: spec, value, acceptance, risks, Mermaid/wireframe if useful. Bob: smallest cross-platform change and tests. Bruce: E2E evidence, defects, ambiguity, confidence.
+Each activity uses exactly one isolated persona: Kevin plans spec/value/acceptance/risks/Mermaid/wireframe; Bob implements the smallest cross-platform change/tests; Bruce checks E2E evidence/defects/ambiguity/confidence. Do not merge roles.
 
-Run Plan-Do-Check-Act, then two passes: quality/simplicity, then intuitiveness/reviewer acceptance. Rerun the smallest check each pass. Stop at >=90% confidence or a blocker.
+Run PDCA, then two passes: quality/simplicity, then intuitiveness/acceptability. Rerun the smallest check each pass. Stop at >=90% confidence or a blocker.

--- a/.github/skills/agentic-pdca-loop/SKILL.md
+++ b/.github/skills/agentic-pdca-loop/SKILL.md
@@ -7,4 +7,4 @@ description: Use for SHAFT PDCA, Kevin/Bob/Bruce roles, or refinement loops.
 
 Each activity uses exactly one isolated persona: Kevin plans spec/value/acceptance/risks/Mermaid/wireframe; Bob implements the smallest cross-platform change/tests; Bruce checks E2E evidence/defects/ambiguity/confidence. Do not merge roles.
 
-Run PDCA, then two passes: quality/simplicity, then intuitiveness/acceptability. Rerun the smallest check each pass. Stop at >=90% confidence or a blocker.
+Run PDCA in Kevin->Bob->Bruce order, then repeat that order for two passes: quality/simplicity, then intuitiveness/acceptability. Rerun the smallest check each pass. Stop at >=90% confidence or a blocker.

--- a/.github/skills/agentic-pdca-loop/SKILL.md
+++ b/.github/skills/agentic-pdca-loop/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: agentic-pdca-loop
+description: Use for SHAFT PDCA, Kevin/Bob/Bruce roles, or quality/intuitiveness/acceptability refinement.
+---
+
+# PDCA
+
+Keep notes isolated. Kevin: spec, value, acceptance, risks, Mermaid/wireframe if useful. Bob: smallest cross-platform change and tests. Bruce: E2E evidence, defects, ambiguity, confidence.
+
+Run Plan-Do-Check-Act, then two passes: quality/simplicity, then intuitiveness/reviewer acceptance. Rerun the smallest check each pass. Stop at >=90% confidence or a blocker.

--- a/scripts/ci/agent_guidance_budget.json
+++ b/scripts/ci/agent_guidance_budget.json
@@ -68,6 +68,7 @@
   "expected_skill_names": {
     ".agents/skills": [
       "agent-guidance-boundary-guard",
+      "agentic-pdca-loop",
       "allure-extent-report-operator",
       "ci-failure-investigator",
       "flaky-test-stabilizer",
@@ -86,6 +87,7 @@
     ],
     ".github/skills": [
       "agent-guidance-boundary-guard",
+      "agentic-pdca-loop",
       "allure-extent-report-operator",
       "ci-failure-investigator",
       "flaky-test-stabilizer",


### PR DESCRIPTION
## Summary
- add a repo-local agentic-pdca-loop skill bridge and OpenAI metadata
- add the canonical Kevin/Bob/Bruce PDCA playbook
- allowlist the skill in guidance validation and README

## Validation
- py -3 C:\Users\Mohab\.codex\skills\.system\skill-creator\scripts\quick_validate.py .agents\skills\agentic-pdca-loop
- py -3 scripts\ci\validate_agent_setup.py --skip-external
- py -3 scripts\ci\validate_agent_setup.py
- git diff --check