### PR TITLE
[codex] Improve IntelliJ onboarding and recorder UX

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventScript.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventScript.java
@@ -62,7 +62,9 @@ public final class BrowserEventScript {
      * @return queue drain JavaScript
      */
     public static String fallbackDrain() {
-        return "return globalThis.__shaftCaptureQueue ? globalThis.__shaftCaptureQueue.splice(0) : [];";
+        return "return typeof globalThis.__shaftCaptureDrain === \"function\" "
+                + "? globalThis.__shaftCaptureDrain() "
+                + ": (globalThis.__shaftCaptureQueue ? globalThis.__shaftCaptureQueue.splice(0) : []);";
     }
 
     private static String script(List<String> testIdAttributes) {

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -495,11 +495,12 @@ public final class CaptureGenerator {
             EventContext context,
             List<String> unsupported) {
         boolean targetRequired = switch (verification) {
-            case URL_EQUALS, URL_CONTAINS, TITLE_EQUALS -> false;
+            case URL_EQUALS, URL_CONTAINS, TITLE_EQUALS, TITLE_CONTAINS, PAGE_TEXT_CONTAINS -> false;
             default -> true;
         };
         boolean expectedRequired = switch (verification) {
-            case TEXT_EQUALS, TEXT_CONTAINS, ATTRIBUTE_EQUALS, URL_EQUALS, URL_CONTAINS, TITLE_EQUALS -> true;
+            case TEXT_EQUALS, TEXT_CONTAINS, ATTRIBUTE_EQUALS, URL_EQUALS, URL_CONTAINS,
+                 TITLE_EQUALS, TITLE_CONTAINS, PAGE_TEXT_CONTAINS -> true;
             default -> false;
         };
         if (targetRequired && target == null) {
@@ -1170,6 +1171,12 @@ public final class CaptureGenerator {
                     negated ? "doesNotContain" : "contains", dataExpression(expected, data));
             case TITLE_EQUALS -> nativeAssertion(source, "driver.browser().assertThat().title()",
                     negated ? "doesNotEqual" : "isEqualTo", dataExpression(expected, data));
+            case TITLE_CONTAINS -> nativeAssertion(source, "driver.browser().assertThat().title()",
+                    negated ? "doesNotContain" : "contains", dataExpression(expected, data));
+            case PAGE_TEXT_CONTAINS -> nativeAssertion(source, "driver.browser().assertThat().text()",
+                    negated ? "doesNotContain" : "contains", dataExpression(expected, data));
+            case ELEMENT_IMAGE_MATCHES -> line(source, "        driver.element().assertThat(" + locator + ")."
+                    + (negated ? "doesNotMatchReferenceImage" : "matchesReferenceImage") + "().perform();");
         }
     }
 

--- a/shaft-capture/src/main/java/com/shaft/capture/model/CaptureEvent.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/model/CaptureEvent.java
@@ -121,7 +121,10 @@ public sealed interface CaptureEvent permits CaptureEvent.NavigationEvent, Captu
         ATTRIBUTE_EQUALS,
         URL_EQUALS,
         URL_CONTAINS,
-        TITLE_EQUALS
+        TITLE_EQUALS,
+        TITLE_CONTAINS,
+        PAGE_TEXT_CONTAINS,
+        ELEMENT_IMAGE_MATCHES
     }
 
     /**

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
@@ -330,11 +330,12 @@ final class CaptureEventPipeline implements AutoCloseable {
             return;
         }
         boolean targetRequired = switch (kind) {
-            case URL_EQUALS, URL_CONTAINS, TITLE_EQUALS -> false;
+            case URL_EQUALS, URL_CONTAINS, TITLE_EQUALS, TITLE_CONTAINS, PAGE_TEXT_CONTAINS -> false;
             default -> true;
         };
         boolean expectedRequired = switch (kind) {
-            case TEXT_EQUALS, TEXT_CONTAINS, ATTRIBUTE_EQUALS, URL_EQUALS, URL_CONTAINS, TITLE_EQUALS -> true;
+            case TEXT_EQUALS, TEXT_CONTAINS, ATTRIBUTE_EQUALS, URL_EQUALS, URL_CONTAINS,
+                 TITLE_EQUALS, TITLE_CONTAINS, PAGE_TEXT_CONTAINS -> true;
             default -> false;
         };
         SafeTarget safeTarget = targetRequired ? target(signal) : null;

--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -34,11 +34,13 @@
     readinessState: "READY",
     readinessWarnings: [],
     actions: [],
+    pendingSignals: [],
     nextId: 1,
     lastUrl: String(location.href || ""),
     ...persisted()
   };
   uiState.actions = Array.isArray(uiState.actions) ? uiState.actions.slice(-80) : [];
+  uiState.pendingSignals = Array.isArray(uiState.pendingSignals) ? uiState.pendingSignals.slice(-200) : [];
   uiState.nextId = Number(uiState.nextId || uiState.actions.length + 1);
   uiState.assertionMode = Boolean(uiState.assertionMode);
   uiState.locatorMode = Boolean(uiState.locatorMode);
@@ -70,6 +72,7 @@
         readinessState: uiState.readinessState,
         readinessWarnings: uiState.readinessWarnings.slice(-20),
         actions: uiState.actions.slice(-80),
+        pendingSignals: uiState.pendingSignals.slice(-200),
         nextId: uiState.nextId,
         lastUrl: uiState.lastUrl
       }));
@@ -79,10 +82,20 @@
   };
   const send = payload => {
     payload.timestamp = Date.now();
+    uiState.pendingSignals.push(payload);
+    uiState.pendingSignals = uiState.pendingSignals.slice(-200);
+    persist();
     globalThis.__shaftCaptureQueue.push(payload);
     if (typeof channel === "function") {
       channel(JSON.stringify(payload));
     }
+  };
+  globalThis.__shaftCaptureDrain = () => {
+    const memorySignals = globalThis.__shaftCaptureQueue ? globalThis.__shaftCaptureQueue.splice(0) : [];
+    const pendingSignals = uiState.pendingSignals.slice();
+    uiState.pendingSignals = [];
+    persist();
+    return pendingSignals.length ? pendingSignals : memorySignals;
   };
   const framePath = () => {
     const path = [];
@@ -513,24 +526,49 @@
       case "title equals":
       case "title equal":
         return "TITLE_EQUALS";
+      case "title contains":
+        return "TITLE_CONTAINS";
+      case "page source contains":
+      case "page text contains":
+        return "PAGE_TEXT_CONTAINS";
+      case "image matches":
+      case "element image matches":
+      case "image does not match":
+      case "element image does not match":
+        return "ELEMENT_IMAGE_MATCHES";
       default:
         return "";
     }
   };
   const assertionLabel = kind => kind.toLowerCase().replace(/_/g, " ");
   const expectsValue = kind =>
-    ["TEXT_EQUALS", "TEXT_CONTAINS", "ATTRIBUTE_EQUALS", "URL_EQUALS", "URL_CONTAINS", "TITLE_EQUALS"]
+    ["TEXT_EQUALS", "TEXT_CONTAINS", "ATTRIBUTE_EQUALS", "URL_EQUALS", "URL_CONTAINS",
+      "TITLE_EQUALS", "TITLE_CONTAINS", "PAGE_TEXT_CONTAINS"]
       .includes(kind);
-  const pageAssertion = kind => ["URL_EQUALS", "URL_CONTAINS", "TITLE_EQUALS"].includes(kind);
+  const pageAssertion = kind =>
+    ["URL_EQUALS", "URL_CONTAINS", "TITLE_EQUALS", "TITLE_CONTAINS", "PAGE_TEXT_CONTAINS"].includes(kind);
   const defaultAttribute = element =>
     ["value", "aria-label", "title", "href", "id", "name"]
       .find(name => element && element.hasAttribute && element.hasAttribute(name)) || "value";
   const currentValue = (kind, element, attributeName) => {
     if (kind === "URL_EQUALS" || kind === "URL_CONTAINS") return valueText(location.href);
-    if (kind === "TITLE_EQUALS") return valueText(document.title);
+    if (kind === "TITLE_EQUALS" || kind === "TITLE_CONTAINS") return valueText(document.title);
+    if (kind === "PAGE_TEXT_CONTAINS") return valueText(document.body && document.body.innerText);
     if (kind === "ATTRIBUTE_EQUALS") return valueText(element && element.getAttribute(attributeName));
     if (isTextInput(element)) return valueText(element.value);
     return text(element && (element.innerText || element.textContent));
+  };
+  const browserCheckpoint = () => {
+    const selected = prompt(
+      "Browser checkpoint",
+      "url contains, url equals, title contains, title equals, page source contains");
+    const kind = assertionKind(selected);
+    if (!kind || !pageAssertion(kind)) return false;
+    const expected = prompt("Expected value", currentValue(kind, null, ""));
+    if (expected === null) return true;
+    announce("Assert " + assertionLabel(kind) + " on page");
+    sendVerification(null, {verification: kind, expected: valueText(expected)});
+    return true;
   };
   const captureAssertion = event => {
     if (!uiState.assertionMode || uiState.locatorMode || uiState.stopped || uiState.paused) return false;
@@ -542,7 +580,7 @@
     if (!target) return true;
     const selected = prompt(
       "Assertion type",
-      "visible, enabled, selected, text equals, text contains, attribute equals, url equals, url contains, title equals");
+      "visible, enabled, selected, text equals, text contains, attribute equals, image matches, image does not match");
     const kind = assertionKind(selected);
     if (!kind) {
       const unsupported = text(selected);
@@ -555,7 +593,10 @@
       }
       return true;
     }
-    const data = {verification: kind};
+    const data = {
+      verification: kind,
+      negated: text(selected).toLowerCase().includes("does not")
+    };
     let attributeName = "";
     if (kind === "ATTRIBUTE_EQUALS") {
       attributeName = text(prompt("Attribute name", defaultAttribute(element)));
@@ -993,10 +1034,24 @@
     });
     document.getElementById("shaft-capture-checkpoint").addEventListener("click", () => {
       if (uiState.stopped) return;
-      const description = text(prompt("Checkpoint description", "Review this page state"));
-      if (!description) return;
-      announce("Checkpoint: " + description);
-      sendCheckpoint(description, "USER_MARKER");
+      const scope = text(prompt("Checkpoint type", "Browser checkpoint or Element checkpoint")).toLowerCase();
+      if (scope.startsWith("browser")) {
+        browserCheckpoint();
+        return;
+      }
+      if (scope.startsWith("element")) {
+        uiState.assertionMode = true;
+        uiState.locatorMode = false;
+        persist();
+        announce("Element checkpoint: click the target element");
+        setStatus();
+        return;
+      }
+      const description = text(scope);
+      if (description) {
+        announce("Checkpoint: " + description);
+        sendCheckpoint(description, "USER_MARKER");
+      }
     });
     document.getElementById("shaft-capture-stop").addEventListener("click", () => {
       if (uiState.stopped) return;
@@ -1087,6 +1142,8 @@
     if (!named && modifiers.length === 0) return;
     emit("keyboard", event, {keys: [...modifiers, key.toUpperCase()]});
   }, true);
+  addEventListener("pagehide", persist, true);
+  addEventListener("beforeunload", persist, true);
 
   if (topLevel) {
     schedulePanel();

--- a/shaft-capture/src/test/java/com/shaft/capture/collector/CaptureCollectorUtilityTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/collector/CaptureCollectorUtilityTest.java
@@ -60,6 +60,7 @@ class CaptureCollectorUtilityTest {
         assertTrue(preload.contains("shaft"));
         assertTrue(BrowserEventScript.fallbackInstallation().contains("return ("));
         assertTrue(BrowserEventScript.fallbackDrain().contains("__shaftCaptureQueue"));
+        assertTrue(BrowserEventScript.fallbackDrain().contains("__shaftCaptureDrain"));
         assertTrue(BrowserEventScript.preloadFunction(List.of("data-pw"))
                 .contains("const testIdAttributes = [\"data-pw\"];"));
         assertTrue(BrowserEventScript.fallbackInstallation(List.of("data-\"quoted\\path"))
@@ -71,6 +72,9 @@ class CaptureCollectorUtilityTest {
         assertTrue(preload.contains("Pause recording"));
         assertTrue(preload.contains("Stop recording"));
         assertTrue(preload.contains("globalThis.top === globalThis"));
+        assertTrue(preload.contains("pendingSignals"));
+        assertTrue(preload.contains("pagehide"));
+        assertTrue(preload.contains("beforeunload"));
 
         Constructor<BrowserEventScript> constructor = BrowserEventScript.class.getDeclaredConstructor();
         constructor.setAccessible(true);

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -106,6 +106,11 @@ class CaptureGeneratorTest {
             assertTrue(recorder.contains("aria-label=\"Toggle locator picker\""));
             assertTrue(recorder.contains("kind: \"verification\""));
             assertTrue(recorder.contains("overflow-x: hidden"));
+            assertTrue(recorder.contains("pendingSignals"));
+            assertTrue(recorder.contains("pagehide"));
+            assertTrue(recorder.contains("beforeunload"));
+            assertTrue(recorder.contains("Browser checkpoint"));
+            assertTrue(recorder.contains("Element checkpoint"));
         }
     }
 
@@ -230,6 +235,47 @@ class CaptureGeneratorTest {
         assertTrue(source.contains("driver.element().click(SHAFT.GUI.Locator.inputField(\"Username\"));"));
         assertFalse(source.contains("DriverFactory"));
         assertFalse(source.contains("ExpectedConditions"));
+    }
+
+    @Test
+    void generatorRendersBrowserTextTitleAndImageVerificationCheckpoints() throws Exception {
+        ExternalTestDataReference expected = CaptureFixtures.ordinary();
+        CaptureSession verificationSession = new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "verification-session",
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(5),
+                CaptureFixtures.browser(),
+                List.of(
+                        new CaptureEvent.NavigationEvent(CaptureFixtures.context(1),
+                                CaptureEvent.NavigationAction.OPEN, "https://example.test/form"),
+                        new CaptureEvent.VerificationEvent(CaptureFixtures.context(2),
+                                CaptureEvent.VerificationKind.TITLE_CONTAINS, null, expected, false),
+                        new CaptureEvent.VerificationEvent(CaptureFixtures.context(3),
+                                CaptureEvent.VerificationKind.PAGE_TEXT_CONTAINS, null, expected, false),
+                        new CaptureEvent.VerificationEvent(CaptureFixtures.context(4),
+                                CaptureEvent.VerificationKind.ELEMENT_IMAGE_MATCHES,
+                                CaptureFixtures.target(), null, false),
+                        new CaptureEvent.VerificationEvent(CaptureFixtures.context(5),
+                                CaptureEvent.VerificationKind.ELEMENT_IMAGE_MATCHES,
+                                CaptureFixtures.target(), null, true)),
+                List.of(),
+                List.of(expected),
+                com.shaft.capture.model.RedactionSummary.empty(),
+                Map.of());
+        Path session = session(verificationSession);
+        writeCaptureData("Welcome");
+
+        CaptureGenerationResult result =
+                new CaptureGenerator().generate(request(session, temp.resolve("verification")));
+
+        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        String source = Files.readString(result.sourcePath());
+        assertTrue(source.contains("driver.browser().assertThat().title().contains(requiredData(\"username\")).perform();"));
+        assertTrue(source.contains("driver.browser().assertThat().text().contains(requiredData(\"username\")).perform();"));
+        assertTrue(source.contains("driver.element().assertThat(SHAFT.GUI.Locator.inputField(\"Username\")).matchesReferenceImage().perform();"));
+        assertTrue(source.contains("driver.element().assertThat(SHAFT.GUI.Locator.inputField(\"Username\")).doesNotMatchReferenceImage().perform();"));
     }
 
     @Test

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureManagerLifecycleTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureManagerLifecycleTest.java
@@ -38,7 +38,10 @@ class CaptureManagerLifecycleTest {
         assertEquals(CaptureStatus.State.ACTIVE,
                 manager.checkpoint("review", Checkpoint.CheckpointKind.USER_MARKER).state());
         assertEquals(1, recorderRef.get().checkpointCount);
-        assertEquals(CaptureStatus.State.COMPLETED, manager.stop(false).state());
+        CaptureStatus stopped = manager.stop(false);
+        assertEquals(CaptureStatus.State.COMPLETED, stopped.state());
+        assertEquals(request.outputPath().toString(), stopped.outputPath());
+        assertFalse(recorderRef.get().isBrowserAlive());
         assertEquals(CaptureStatus.State.COMPLETED, manager.stop(false).state());
         manager.close();
     }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -278,16 +278,22 @@ final class AssistantCommand {
         if (text.isEmpty()) {
             return Invocation.local("Enter a prompt or slash command.");
         }
-        if (text.startsWith("/")) {
+        String liveCodegen = liveCodegenSlashPrompt(text);
+        boolean liveCodegenRequest = !liveCodegen.isBlank();
+        if (!liveCodegen.isBlank()) {
+            text = liveCodegen;
+        } else if (text.startsWith("/")) {
             return slash(text, workingDirectory);
         }
-        Invocation recording = recording(text);
-        if (recording != null) {
-            return recording;
-        }
-        Invocation directIntent = directIntent(text, workingDirectory);
-        if (directIntent != null) {
-            return directIntent;
+        if (!liveCodegenRequest) {
+            Invocation recording = recording(text);
+            if (recording != null) {
+                return recording;
+            }
+            Invocation directIntent = directIntent(text, workingDirectory);
+            if (directIntent != null) {
+                return directIntent;
+            }
         }
         if (selection.cloud()) {
             return cloud(text, selection, mode, workingDirectory, openFileContext);
@@ -345,6 +351,18 @@ final class AssistantCommand {
             }
         }
         return Invocation.local("Unknown command. Use /commands for available SHAFT Assistant commands.");
+    }
+
+    private static String liveCodegenSlashPrompt(String text) {
+        String trimmed = text(text);
+        if (!"/codegen".equals(firstWord(trimmed).toLowerCase(Locale.ROOT))) {
+            return "";
+        }
+        String rest = afterFirstWord(trimmed);
+        if (rest.isBlank() || !firstJsonLikePath(rest).isBlank()) {
+            return "";
+        }
+        return "Generate SHAFT Java code for this browser flow: " + rest;
     }
 
     private static JsonObject guide(String query) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java
@@ -208,6 +208,9 @@ final class AssistantMarkdown {
             if (!doctor.isBlank()) {
                 return doctor;
             }
+            if (object.has("scenarios") && object.get("scenarios").isJsonArray()) {
+                return scenariosMarkdown(object);
+            }
             if (object.has("tools") && object.get("tools").isJsonArray()) {
                 return toolsMarkdown(object.getAsJsonArray("tools"));
             }
@@ -222,6 +225,55 @@ final class AssistantMarkdown {
             }
         }
         return "";
+    }
+
+    private static String scenariosMarkdown(JsonObject object) {
+        JsonArray scenarios = object.getAsJsonArray("scenarios");
+        if (scenarios.isEmpty()) {
+            return "_No automation scenarios matched._";
+        }
+        List<String> sections = new ArrayList<>();
+        sections.add(metadataLine(
+                "Automation scenarios", "",
+                "Intent", string(object, "intent", ""),
+                "Area", string(object, "area", "")));
+        StringBuilder list = new StringBuilder("**Automation scenarios**");
+        for (JsonElement item : scenarios) {
+            if (!item.isJsonObject()) {
+                continue;
+            }
+            JsonObject scenario = item.getAsJsonObject();
+            String title = string(scenario, "title", string(scenario, "id", "Scenario"));
+            String id = string(scenario, "id", "");
+            String summary = string(scenario, "summary", "");
+            list.append("\n- **").append(title).append("**");
+            if (!id.isBlank()) {
+                list.append(" (`").append(id).append("`)");
+            }
+            if (!summary.isBlank()) {
+                list.append(": ").append(summary);
+            }
+            String tools = scenarioToolsMarkdown(scenario);
+            if (!tools.isBlank()) {
+                list.append("\n  Tools: ").append(tools);
+            }
+        }
+        sections.add(list.toString());
+        return joinSections(sections);
+    }
+
+    private static String scenarioToolsMarkdown(JsonObject scenario) {
+        JsonElement tools = scenario.get("tools");
+        if (tools == null || !tools.isJsonArray() || tools.getAsJsonArray().isEmpty()) {
+            return "";
+        }
+        List<String> names = new ArrayList<>();
+        for (JsonElement tool : tools.getAsJsonArray()) {
+            if (tool.isJsonPrimitive()) {
+                names.add("`" + tool.getAsString() + "`");
+            }
+        }
+        return String.join(", ", names);
     }
 
     private static String doctorMarkdown(JsonObject object) {
@@ -328,6 +380,9 @@ final class AssistantMarkdown {
         String outputPath = string(object, "outputPath", "");
         if (!outputPath.isBlank()) {
             sections.add("**Output:** `" + outputPath + "`");
+            if ("COMPLETED".equalsIgnoreCase(string(object, "state", ""))) {
+                sections.add("Run `/codegen " + outputPath + "` to generate SHAFT Java from this recording.");
+            }
         }
         String warnings = warnings(object);
         if (!warnings.isBlank()) {
@@ -538,6 +593,9 @@ final class AssistantMarkdown {
         String outputPath = string(object, "outputPath", "");
         if (!outputPath.isBlank()) {
             sections.add("**Output:** `" + outputPath + "`");
+            if ("COMPLETED".equalsIgnoreCase(string(object, "state", ""))) {
+                sections.add("Run `/codegen " + outputPath + "` to generate SHAFT Java from this recording.");
+            }
         }
         String currentUrl = string(object, "currentUrl", "");
         if (!currentUrl.isBlank()) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -42,6 +42,8 @@ import javax.swing.JPopupMenu;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 import javax.swing.Timer;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import javax.swing.text.JTextComponent;
 import java.awt.BorderLayout;
 import java.awt.FlowLayout;
@@ -216,11 +218,27 @@ final class ShaftAssistantPanel extends JPanel {
         if (commandAutocomplete.getEditor().getEditorComponent() instanceof JTextComponent editor) {
             editor.getAccessibleContext().setAccessibleName("Assistant command autocomplete text");
             editor.setToolTipText("Insert a tested SHAFT command");
+            editor.getDocument().addDocumentListener(new DocumentListener() {
+                @Override
+                public void insertUpdate(DocumentEvent event) {
+                    scheduleCommandFilter(editor);
+                }
+
+                @Override
+                public void removeUpdate(DocumentEvent event) {
+                    scheduleCommandFilter(editor);
+                }
+
+                @Override
+                public void changedUpdate(DocumentEvent event) {
+                    scheduleCommandFilter(editor);
+                }
+            });
         }
         commandAutocomplete.addActionListener(event -> insertSelectedCommand());
         updatingCommandAutocomplete = true;
         try {
-            commandAutocomplete.setSelectedItem("");
+            commandAutocomplete.setSelectedItem("/");
         } finally {
             updatingCommandAutocomplete = false;
         }
@@ -288,8 +306,6 @@ final class ShaftAssistantPanel extends JPanel {
         prompt.getEmptyText().setText("Ask SHAFT, or type / for commands");
         prompt.setLineWrap(true);
         prompt.setWrapStyleWord(true);
-        prompt.setMinimumSize(JBUI.size(320, 108));
-        prompt.setPreferredSize(JBUI.size(560, 120));
         transcript = new AssistantTranscriptView(project);
         if (!chatState.activeMarkdown().isBlank()) {
             transcript.setMessages(chatState.activeMessages());
@@ -441,7 +457,10 @@ final class ShaftAssistantPanel extends JPanel {
         composer.setBorder(BorderFactory.createCompoundBorder(
                 BorderFactory.createEtchedBorder(),
                 JBUI.Borders.empty(6)));
-        composer.add(new JBScrollPane(prompt), BorderLayout.CENTER);
+        JBScrollPane promptScroll = new JBScrollPane(prompt);
+        promptScroll.setMinimumSize(JBUI.size(320, 108));
+        promptScroll.setPreferredSize(JBUI.size(560, 120));
+        composer.add(promptScroll, BorderLayout.CENTER);
         composer.add(cloudKeyPanel, BorderLayout.WEST);
         composer.add(composerFooter, BorderLayout.SOUTH);
 
@@ -1159,7 +1178,8 @@ final class ShaftAssistantPanel extends JPanel {
         if (cloud && "AGENT".equals(mode.getSelectedItem())) {
             mode.setSelectedItem("PLAN");
         }
-        boolean localCli = !cloud && "CLI".equals(assistantRuntime.getSelectedItem());
+        boolean localAgent = !cloud;
+        boolean localCli = localAgent && "CLI".equals(assistantRuntime.getSelectedItem());
         boolean lockedRoute = configureFlow != null && mcpConfigured();
         boolean controlsEnabled = !running;
         mode.setVisible(true);
@@ -1183,11 +1203,11 @@ final class ShaftAssistantPanel extends JPanel {
         cloudApiKey.setEnabled(controlsEnabled && advanced && !lockedRoute && cloud);
         saveCloudApiKey.setEnabled(controlsEnabled && advanced && !lockedRoute && cloud);
         boolean agentMode = "AGENT".equals(mode.getSelectedItem());
-        allowSourceMutation.setVisible(agentMode && localCli);
-        allowSourceMutation.setEnabled(controlsEnabled && agentMode && localCli);
+        allowSourceMutation.setVisible(agentMode && localAgent);
+        allowSourceMutation.setEnabled(controlsEnabled && agentMode && localAgent);
         configure.setVisible(lockedRoute);
         configure.setEnabled(controlsEnabled && lockedRoute);
-        if (!agentMode || !localCli) {
+        if (!agentMode || !localAgent) {
             allowSourceMutation.setSelected(false);
         }
         if (cloud) {
@@ -1226,18 +1246,50 @@ final class ShaftAssistantPanel extends JPanel {
         if (updatingCommandAutocomplete) {
             return;
         }
-        String command = canonicalCommand(String.valueOf(commandAutocomplete.getSelectedItem()));
+        String selected = String.valueOf(commandAutocomplete.getSelectedItem());
+        String command = canonicalCommand(selected);
         if (command.isBlank()) {
+            filterCommandItems(selected);
             return;
         }
         prompt.replaceSelection(command + " ");
         prompt.requestFocusInWindow();
         updatingCommandAutocomplete = true;
         try {
-            commandAutocomplete.setSelectedItem("");
+            commandAutocomplete.setModel(new DefaultComboBoxModel<>(commandItems()));
+            commandAutocomplete.setSelectedItem("/");
         } finally {
             updatingCommandAutocomplete = false;
         }
+    }
+
+    private void filterCommandItems(String prefix) {
+        String typed = prefix == null ? "" : prefix.trim();
+        String lower = typed.toLowerCase(Locale.ROOT);
+        String[] items = AssistantCommand.commandHints().stream()
+                .map(AssistantCommand.CommandHint::canonical)
+                .filter(command -> lower.isBlank()
+                        || "/".equals(lower)
+                        || command.toLowerCase(Locale.ROOT).startsWith(lower))
+                .toArray(String[]::new);
+        updatingCommandAutocomplete = true;
+        try {
+            commandAutocomplete.setModel(new DefaultComboBoxModel<>(items.length == 0 ? commandItems() : items));
+            commandAutocomplete.getEditor().setItem(typed.isBlank() ? "/" : typed);
+        } finally {
+            updatingCommandAutocomplete = false;
+        }
+    }
+
+    private void scheduleCommandFilter(JTextComponent editor) {
+        if (updatingCommandAutocomplete) {
+            return;
+        }
+        SwingUtilities.invokeLater(() -> {
+            if (!updatingCommandAutocomplete) {
+                filterCommandItems(editor.getText());
+            }
+        });
     }
 
     private void updateCloudKeyStatus() {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -82,6 +82,7 @@ final class ShaftMcpSetupPanel extends JPanel {
     private final JButton openTerminal;
     private final JButton test;
     private final JButton startChatting;
+    private final JButton resetAndReinstall;
     private final JProgressBar progress;
     private final JLabel runtimeStatus;
     private final JLabel assistStatus;
@@ -193,6 +194,12 @@ final class ShaftMcpSetupPanel extends JPanel {
         applyLabeledAction(startChatting, ShaftIcons.SEND);
         startChatting.setVisible(false);
         startChatting.addActionListener(event -> connected.run());
+        resetAndReinstall = new JButton("Reset and reinstall");
+        resetAndReinstall.getAccessibleContext().setAccessibleName("Reset and reinstall SHAFT MCP");
+        resetAndReinstall.setToolTipText("Reset setup state and copy a fresh installer command");
+        applyLabeledAction(resetAndReinstall, ShaftIcons.RESET);
+        resetAndReinstall.setVisible(false);
+        resetAndReinstall.addActionListener(event -> resetAndCopyInstaller());
         runtimeStatus = setupStatusLabel("Assistant runtime setup status");
         assistStatus = setupStatusLabel("Assistant connection setup status");
         status = new JLabel();
@@ -254,6 +261,8 @@ final class ShaftMcpSetupPanel extends JPanel {
         JPanel diagnosticRow = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
         diagnosticRow.add(copyCommand);
         diagnosticRow.add(copyOutput);
+        JPanel secondaryActions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
+        secondaryActions.add(resetAndReinstall);
         family.addActionListener(event -> assistantSelectionChanged());
         runtime.addActionListener(event -> assistantSelectionChanged());
         installerTarget.addActionListener(event -> installerTargetChanged());
@@ -276,6 +285,7 @@ final class ShaftMcpSetupPanel extends JPanel {
                 .addComponent(workflow)
                 .addComponent(installerDetailsPanel)
                 .addComponent(status)
+                .addComponent(secondaryActions)
                 .addComponentFillVertically(new JPanel(), 0)
                 .getPanel();
         detailsPanel = new JPanel(new BorderLayout(4, 4));
@@ -411,6 +421,9 @@ final class ShaftMcpSetupPanel extends JPanel {
         startChatting.setEnabled(!running && startChatting.isVisible());
         chatRow.setVisible(startChatting.isVisible());
         copyCommand.setEnabled(!running && !diagnosticCommand.isBlank());
+        boolean canReset = complete || detailsPanel.isVisible();
+        resetAndReinstall.setVisible(canReset);
+        resetAndReinstall.setEnabled(!running && canReset);
         updateProgressivePanels();
         updateSetupSteps(running);
         updateWorkflowRows(running);
@@ -533,6 +546,23 @@ final class ShaftMcpSetupPanel extends JPanel {
         openIntellijTerminal();
         setStatusText("Run command in terminal, then check.");
         updateActionState(false);
+    }
+
+    private void resetAndCopyInstaller() {
+        clearDiagnostics();
+        mcpCommand.setText("");
+        settings.mcpCommand = "";
+        settings.mcpSetupComplete = false;
+        settings.agentGuidanceOptimizationPromptPending = false;
+        installerCommand.setText(installerCommand());
+        installerCommandCopied = true;
+        terminalOpened = false;
+        startChatting.setVisible(false);
+        showRuntimeSelected();
+        showAssistNotConfigured();
+        copy(installerCommand(), "Installer command copied. Run it in terminal, then check.");
+        updateActionState(false);
+        openTerminal.requestFocusInWindow();
     }
 
     private void openIntellijTerminal() {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
@@ -144,6 +144,29 @@ class AssistantCommandTest {
     }
 
     @Test
+    void slashCodegenWithLiveInstructionsRoutesToAgentCodegenPrompt() {
+        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+                "/codegen navigate to https://duckduckgo.com, search for shaft_engine, open the first result and assert that the url is correct.",
+                AssistantCommand.Selection.local("CODEX", "CLI"),
+                "AGENT",
+                ".",
+                "",
+                true);
+
+        String prompt = invocation.arguments().has("prompt")
+                ? invocation.arguments().get("prompt").getAsString()
+                : "";
+
+        assertAll(
+                () -> assertEquals("autobot_local_agent_run", invocation.toolName()),
+                () -> assertTrue(prompt.contains("This is a code-generation request. Before returning Java:"), prompt),
+                () -> assertTrue(prompt.contains("Open a real browser session"), prompt),
+                () -> assertTrue(prompt.contains("call driver_initialize and browser_open_intent"), prompt),
+                () -> assertTrue(prompt.contains("navigate to https://duckduckgo.com"), prompt),
+                () -> assertFalse(prompt.contains("test_automation_scenarios OK")));
+    }
+
+    @Test
     void localAgentCodeRequestsStayScopedToCurrentOpenFileAndMode() {
         AssistantCommand.OpenFileContext openFile = new AssistantCommand.OpenFileContext(
                 "src/test/java/example/LoginTest.java",

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantMarkdownTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantMarkdownTest.java
@@ -151,6 +151,30 @@ class AssistantMarkdownTest {
                 () -> assertFalse(markdown.contains("\"processId\"")));
     }
 
+    @Test
+    void formatsStoppedCaptureWithCodegenHint() {
+        String markdown = AssistantMarkdown.fromMcpOutput("capture_stop", mcpText("""
+                {
+                  "state": "COMPLETED",
+                  "sessionId": "session",
+                  "browser": "chrome",
+                  "currentUrl": "https://example.test/checkout",
+                  "eventCount": 4,
+                  "readiness": "READY",
+                  "warnings": [],
+                  "outputPath": "recordings/intellij-capture.json",
+                  "aiEnabled": false,
+                  "processId": 123,
+                  "startedAt": "2026-06-30T19:00:00Z"
+                }
+                """));
+
+        assertAll(
+                () -> assertTrue(markdown.contains("**State:** COMPLETED")),
+                () -> assertTrue(markdown.contains("**Output:** `recordings/intellij-capture.json`")),
+                () -> assertTrue(markdown.contains("Run `/codegen recordings/intellij-capture.json`")));
+    }
+
 
     @Test
     void formatsMobileToolchainSessionInspectionAndScreenshotResponses() {
@@ -350,6 +374,34 @@ class AssistantMarkdownTest {
                 () -> assertTrue(markdown.contains("SHAFT-only Java")),
                 () -> assertFalse(markdown.contains("driver.get")),
                 () -> assertFalse(markdown.contains("driver.findElement")));
+    }
+
+    @Test
+    void formatsAutomationScenariosWithoutRawJson() {
+        String markdown = AssistantMarkdown.fromMcpOutput("test_automation_scenarios", mcpText("""
+                {
+                  "schemaVersion": "1.0",
+                  "area": "all",
+                  "intent": "navigate to duckduckgo, search for shaft_engine, open the first result",
+                  "scenarios": [
+                    {
+                      "id": "web-search-result",
+                      "title": "Search and open the first result",
+                      "areas": ["web"],
+                      "summary": "Initialize a browser, search, open the first result, then assert the URL.",
+                      "tools": ["driver_initialize", "browser_open_intent", "test_code_guardrails_check"]
+                    }
+                  ]
+                }
+                """));
+
+        assertAll(
+                () -> assertTrue(markdown.contains("**Automation scenarios**")),
+                () -> assertTrue(markdown.contains("Search and open the first result")),
+                () -> assertTrue(markdown.contains("Initialize a browser")),
+                () -> assertTrue(markdown.contains("`driver_initialize`")),
+                () -> assertFalse(markdown.contains("\"schemaVersion\"")),
+                () -> assertFalse(markdown.contains("\"scenarios\"")));
     }
 
     @Test

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -25,6 +25,9 @@ import javax.swing.KeyStroke;
 import javax.swing.JList;
 import javax.swing.ListCellRenderer;
 import javax.swing.JProgressBar;
+import javax.swing.JScrollPane;
+import javax.swing.JViewport;
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import java.awt.BorderLayout;
 import java.awt.Component;
@@ -1186,6 +1189,44 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void assistantCommandAutocompleteStartsWithSlashAndFiltersByTypedPrefix() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        JComboBox<?> commandAutocomplete = findByAccessibleName(panel, "Assistant command autocomplete", JComboBox.class);
+
+        assertEquals("/", String.valueOf(commandAutocomplete.getEditor().getItem()));
+
+        SwingUtilities.invokeAndWait(() -> commandAutocomplete.getEditor().setItem("/rec"));
+        SwingUtilities.invokeAndWait(() -> {
+        });
+
+        assertAll(
+                () -> assertTrue(comboContains(commandAutocomplete, "/record-web")),
+                () -> assertTrue(comboContains(commandAutocomplete, "/record-mobile")),
+                () -> assertFalse(comboContains(commandAutocomplete, "/doctor")),
+                () -> assertFalse(comboContains(commandAutocomplete, "/project")));
+    }
+
+    @Test
+    void assistantComposerKeepsLongSetupPromptScrollable() throws Exception {
+        ShaftSettingsState.Settings settings = connectedMcpSettings();
+        settings.agentGuidanceOptimizationPromptPending = true;
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, settings);
+        JTextComponent prompt = assistantPrompt(panel);
+        JScrollPane promptScroll = enclosingScrollPane(prompt);
+
+        assertNotNull(promptScroll);
+        promptScroll.setSize(new Dimension(640, 120));
+        promptScroll.doLayout();
+        int lineHeight = prompt.getFontMetrics(prompt.getFont()).getHeight();
+        int lineCount = prompt.getDocument().getDefaultRootElement().getElementCount();
+
+        assertAll(
+                () -> assertTrue(lineCount > 10),
+                () -> assertTrue(prompt.getPreferredSize().height > lineHeight * 10,
+                        "Long setup prompt should have enough view height to scroll to its final line."));
+    }
+
+    @Test
     void assistantEmptyChatOmitsStarterStripAndKeepsPromptUsable() {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
         JTextComponent prompt = assistantPrompt(panel);
@@ -1230,16 +1271,21 @@ class ShaftPanelSetupTest {
     }
 
     @Test
-    void assistantCommandAutocompleteInsertsCommandIntoPrompt() {
+    void assistantCommandAutocompleteInsertsCommandIntoPrompt() throws Exception {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
         JComboBox<?> commandAutocomplete = findByAccessibleName(panel, "Assistant command autocomplete", JComboBox.class);
         JTextComponent prompt = assistantPrompt(panel);
 
         prompt.setText("please ");
         prompt.setCaretPosition(prompt.getDocument().getLength());
-        commandAutocomplete.setSelectedItem("/record-web");
+        SwingUtilities.invokeAndWait(() -> commandAutocomplete.setSelectedItem("/record-web"));
+        SwingUtilities.invokeAndWait(() -> {
+        });
 
-        assertEquals("please /record-web ", prompt.getText());
+        assertAll(
+                () -> assertEquals("please /record-web ", prompt.getText()),
+                () -> assertEquals("/", String.valueOf(commandAutocomplete.getEditor().getItem())),
+                () -> assertTrue(comboContains(commandAutocomplete, "/doctor")));
     }
 
     @Test
@@ -1362,6 +1408,7 @@ class ShaftPanelSetupTest {
         assertAll(panels.stream()
                 .flatMap(panel -> collectButtons(panel).stream())
                 .filter(button -> !isSetupPrimaryAction(button))
+                .filter(button -> !"Reset and reinstall SHAFT MCP".equals(accessibleName(button)))
                 .map(button -> () -> assertIconOnlySymmetric(button)));
     }
 
@@ -1753,6 +1800,29 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void setupResetAndReinstallClearsStateAndCopiesInstallerCommand() throws Exception {
+        ShaftSettingsState.Settings settings = unverifiedMcpSettings();
+        settings.mcpSetupComplete = true;
+        settings.agentGuidanceOptimizationPromptPending = true;
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), settings, () -> {
+        }, readyProbe());
+        AtomicReference<String> copied = new AtomicReference<>("");
+        setField(panel, "copySink", (Consumer<String>) copied::set);
+        JTextComponent mcpCommand = (JTextComponent) getField(panel, "mcpCommand");
+
+        showTestResult(panel, ShaftMcpToolResult.success("Probe OK"));
+        clickAccessible(panel, "Reset and reinstall SHAFT MCP");
+
+        assertAll(
+                () -> assertEquals("", mcpCommand.getText()),
+                () -> assertFalse(settings.mcpSetupComplete),
+                () -> assertFalse(settings.agentGuidanceOptimizationPromptPending),
+                () -> assertTrue(copied.get().contains("install-shaft-mcp")),
+                () -> assertSingleVisiblePrimarySetupAction(panel, "Open terminal for MCP installer"),
+                () -> assertTrue(containsText(panel, "Installer command copied. Run it in terminal, then check.")));
+    }
+
+    @Test
     void assistantTranscriptUsesStandardMarkdownForHeadersRulesAndCodeBlocks() {
         AssistantTranscriptView transcript = new AssistantTranscriptView();
         transcript.append("user", """
@@ -1878,6 +1948,26 @@ class ShaftPanelSetupTest {
         JCheckBox allowEdits = findByAccessibleName(panel, "Approve source mutation for Agent mode", JCheckBox.class);
         assertAll(
                 () -> assertNotNull(allowEdits),
+                () -> assertTrue(allowEdits.isVisible()),
+                () -> assertTrue(allowEdits.isEnabled()));
+    }
+
+    @Test
+    void assistantAgentModeShowsSourceEditApprovalForLockedDesktopRuntime() {
+        ShaftSettingsState.Settings settings = connectedMcpSettings();
+        settings.assistantRuntime = "DESKTOP_APP";
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, settings, new ShaftAssistantChatState(), () -> {
+        });
+        JComboBox<?> assistantMode = findByAccessibleName(panel, "Assistant mode", JComboBox.class);
+        JCheckBox allowEdits = findByAccessibleName(panel, "Approve source mutation for Agent mode", JCheckBox.class);
+
+        assertAll(
+                () -> assertNotNull(assistantMode),
+                () -> assertNotNull(allowEdits));
+
+        assistantMode.setSelectedItem("AGENT");
+
+        assertAll(
                 () -> assertTrue(allowEdits.isVisible()),
                 () -> assertTrue(allowEdits.isEnabled()));
     }
@@ -2570,6 +2660,17 @@ class ShaftPanelSetupTest {
         JTextComponent prompt = textComponent(component, "Assistant prompt");
         assertNotNull(prompt);
         return prompt;
+    }
+
+    private static JScrollPane enclosingScrollPane(Component component) {
+        Container parent = component.getParent();
+        while (parent != null) {
+            if (parent instanceof JViewport viewport && viewport.getParent() instanceof JScrollPane scrollPane) {
+                return scrollPane;
+            }
+            parent = parent.getParent();
+        }
+        return null;
     }
 
     private static JTextComponent textComponent(Component component, String accessibleName) {

--- a/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
@@ -185,7 +185,7 @@ public class CaptureService {
      * @return final recorder status
      */
     @Tool(name = "capture_stop",
-            description = "stops SHAFT Capture; after COMPLETED, call capture_code_blocks and ask snippet or insertion")
+            description = "stops SHAFT Capture; after COMPLETED, show outputPath and tell IntelliJ users to run /codegen <outputPath>")
     public CaptureStatus stop(boolean discard) {
         return manager.stop(discard);
     }

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpAppiumInspectorProxy.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpAppiumInspectorProxy.java
@@ -307,7 +307,7 @@ final class McpAppiumInspectorProxy implements AutoCloseable {
                     <span class="brand-mark" aria-hidden="true">S</span>
                     <button id="pause" title="Pause recording" aria-label="Pause recording">||</button>
                     <button id="resume" title="Resume recording" aria-label="Resume recording">&gt;</button>
-                    <button id="checkpoint" title="Add checkpoint" aria-label="Add checkpoint">*</button>
+                    <button id="checkpoint" title="Add element checkpoint" aria-label="Add element checkpoint">*</button>
                     <button id="stop" title="Stop recording" aria-label="Stop recording">[]</button>
                     <button id="discard" title="Discard recording" aria-label="Discard recording">x</button>
                     <span class="status-chip" id="status">Recorder ready</span>
@@ -320,7 +320,7 @@ final class McpAppiumInspectorProxy implements AutoCloseable {
                   <iframe src="/inspector" title="Appium Inspector"></iframe>
                   <script>
                     async function control(action) {
-                      const checkpoint = action === 'checkpoint' ? prompt('Checkpoint name', '') || '' : '';
+                      const checkpoint = action === 'checkpoint' ? prompt('Element checkpoint description', '') || '' : '';
                       const response = await fetch('/shaft-inspector/control', {
                         method: 'POST',
                         headers: {'Content-Type': 'application/json'},


### PR DESCRIPTION
## Summary
- Improve IntelliJ setup/onboarding with reset-and-reinstall, better setup recovery state, command autocomplete, scrollable composer behavior, and human-readable capture stop guidance.
- Preserve recorder events across navigation, add guided browser/element checkpoint prompts, and generate SHAFT assertions for title/page text/image checks.
- Update MCP capture/mobile inspector guidance so agents surface `/codegen <outputPath>` and mobile checkpoints stay element-only.

## Validation
- `gradle -p shaft-intellij test --tests com.shaft.intellij.ui.ShaftPanelSetupTest --tests com.shaft.intellij.ui.AssistantCommandTest --tests com.shaft.intellij.ui.AssistantMarkdownTest --no-daemon`
- `gradle -p shaft-intellij test --tests com.shaft.intellij.ui.ShaftPluginScreenshotRendererTest --no-daemon`
- `mvn -pl shaft-capture -DskipTests=false test`
- `mvn -pl shaft-mcp -DskipTests=false test`
- `py -3 scripts/ci/validate_shaft_mcp_configuration.py`
- `git diff --check`