### PR TITLE
[codex] Improve IntelliJ onboarding guardrails

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -252,7 +252,7 @@ final class AssistantCommand {
             boolean allowSourceMutation,
             OpenFileContext openFileContext) {
         return fromPrompt(prompt, Selection.fromClient(client), mode, workingDirectory, customCommand, allowSourceMutation,
-                openFileContext);
+                openFileContext, "");
     }
 
     static Invocation fromPrompt(
@@ -274,6 +274,19 @@ final class AssistantCommand {
             String customCommand,
             boolean allowSourceMutation,
             OpenFileContext openFileContext) {
+        return fromPrompt(prompt, selection, mode, workingDirectory, customCommand, allowSourceMutation,
+                openFileContext, "");
+    }
+
+    static Invocation fromPrompt(
+            String prompt,
+            Selection selection,
+            String mode,
+            String workingDirectory,
+            String customCommand,
+            boolean allowSourceMutation,
+            OpenFileContext openFileContext,
+            String conversationContext) {
         String text = prompt == null ? "" : prompt.trim();
         if (text.isEmpty()) {
             return Invocation.local("Enter a prompt or slash command.");
@@ -296,7 +309,7 @@ final class AssistantCommand {
             }
         }
         if (selection.cloud()) {
-            return cloud(text, selection, mode, workingDirectory, openFileContext);
+            return cloud(text, selection, mode, workingDirectory, openFileContext, conversationContext);
         }
         if (!"CLI".equals(selection.runtime())) {
             return Invocation.local("SHAFT is configured for " + selection.displayName()
@@ -305,7 +318,8 @@ final class AssistantCommand {
         JsonObject arguments = new JsonObject();
         arguments.addProperty("client", selection.client());
         arguments.addProperty("mode", mode);
-        arguments.addProperty("prompt", localAgentPrompt(text, mode, allowSourceMutation, openFileContext));
+        arguments.addProperty("prompt", localAgentPrompt(text, mode, allowSourceMutation, openFileContext,
+                conversationContext));
         arguments.addProperty("workingDirectory", workingDirectory == null ? "" : workingDirectory);
         arguments.add("command", commandArray(customCommand));
         arguments.add("environment", new JsonObject());
@@ -319,26 +333,28 @@ final class AssistantCommand {
             Selection selection,
             String mode,
             String workingDirectory,
-            OpenFileContext openFileContext) {
+            OpenFileContext openFileContext,
+            String conversationContext) {
         JsonObject arguments = new JsonObject();
         arguments.addProperty("provider", selection.cloudProvider());
         arguments.addProperty("model", selection.cloudModel());
         arguments.addProperty("mode", mode);
-        arguments.addProperty("prompt", cloudPrompt(text, mode, openFileContext));
+        arguments.addProperty("prompt", cloudPrompt(text, mode, openFileContext, conversationContext));
         arguments.addProperty("workingDirectory", workingDirectory == null ? "" : workingDirectory);
         arguments.addProperty("timeoutSeconds", DEFAULT_TIMEOUT_SECONDS);
         arguments.addProperty("allowSourceMutation", false);
         return Invocation.tool("autobot_provider_chat", arguments);
     }
 
-    private static String cloudPrompt(String text, String mode, OpenFileContext openFileContext) {
+    private static String cloudPrompt(String text, String mode, OpenFileContext openFileContext,
+                                      String conversationContext) {
         if (!isCodeGenerationRequest(text)) {
-            return text;
+            return withConversationContext(text, conversationContext);
         }
-        return SHAFT_MCP_USAGE_HINT
+        return withConversationContext(SHAFT_MCP_USAGE_HINT
                 + "\n" + SHAFT_CODEGEN_TOOL_GUIDANCE
                 + "\n" + codeRequestScope(Selection.normalize(mode, "ASK"), openFileContext)
-                + "\n\n" + text;
+                + "\n\n" + text, conversationContext);
     }
 
     private static Invocation slash(String text, String workingDirectory) {
@@ -1267,7 +1283,8 @@ final class AssistantCommand {
             String text,
             String mode,
             boolean allowSourceMutation,
-            OpenFileContext openFileContext) {
+            OpenFileContext openFileContext,
+            String conversationContext) {
         String lower = text.toLowerCase(Locale.ROOT);
         String normalizedMode = Selection.normalize(mode, "ASK");
         boolean agentMode = "AGENT".equals(normalizedMode);
@@ -1282,7 +1299,55 @@ final class AssistantCommand {
                 + "\n\n" + text
                 : text)
                 : hint + "\n\n" + text;
+        withHint = withConversationContext(withHint, conversationContext);
         return agentMode && !allowSourceMutation ? withHint + "\n\n" + AGENT_SOURCE_GUARD : withHint;
+    }
+
+    static boolean requiresAgentModeForMcp(String prompt, String mode, Invocation invocation) {
+        if ("AGENT".equals(Selection.normalize(mode, "ASK")) || invocation == null || invocation.isLocal()) {
+            return false;
+        }
+        if (!Invocation.LOCAL_AGENT_TOOL.equals(invocation.toolName())) {
+            return false;
+        }
+        return promptNeedsMcpToolCalls(prompt);
+    }
+
+    private static boolean promptNeedsMcpToolCalls(String prompt) {
+        String normalized = normalizeNaturalCommand(prompt);
+        return isCodeGenerationRequest(prompt)
+                || containsAny(normalized,
+                "shaft mcp",
+                "shaft-mcp",
+                "browser",
+                "open browser",
+                "open page",
+                "open url",
+                "navigate",
+                "visit http",
+                "click",
+                "type into",
+                "search for",
+                "locator",
+                "inspect element",
+                "mobile app",
+                "record flow",
+                "take screenshot",
+                "duckduckgo");
+    }
+
+    private static String withConversationContext(String prompt, String conversationContext) {
+        String context = text(conversationContext);
+        if (context.isBlank()) {
+            return prompt;
+        }
+        return """
+                Conversation context:
+                %s
+
+                Current request:
+                %s
+                """.formatted(context, prompt).stripIndent().trim();
     }
 
     private static String codeRequestScope(String mode, OpenFileContext openFileContext) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -68,6 +68,7 @@ import java.util.concurrent.CancellationException;
  */
 final class ShaftAssistantPanel extends JPanel {
     private static final int TRANSIENT_STATUS_MILLIS = 2300;
+    private static final int MAX_AGENT_CONTEXT_CHARACTERS = 16_000;
     private static final String READY_STATUS = "Try asking me to do something...";
     private static final String SEND_TOOLTIP = "Send assistant prompt (Ctrl+Enter, Command+Enter, or Ctrl+click)";
     private static final String LOCAL_AGENT_STREAMING_HEADER = "_Running local assistant..._";
@@ -685,7 +686,9 @@ final class ShaftAssistantPanel extends JPanel {
         resetTimeline("Prompt received");
         AssistantCommand.Selection route = selectedRoute();
         boolean agentMode = "AGENT".equals(String.valueOf(mode.getSelectedItem()));
+        String selectedMode = String.valueOf(mode.getSelectedItem());
         String workingDirectory = project == null || project.getBasePath() == null ? "" : project.getBasePath();
+        String conversationContext = conversationContextForPrompt();
         boolean approvingCaptureReview = pendingCaptureReview != null && AssistantCommand.isCaptureApproval(text);
         AssistantCommand.Invocation invocation = approvingCaptureReview
                 ? AssistantCommand.approvedCaptureIntegration(
@@ -697,19 +700,27 @@ final class ShaftAssistantPanel extends JPanel {
                 : AssistantCommand.fromPrompt(
                 text,
                 route,
-                String.valueOf(mode.getSelectedItem()),
+                selectedMode,
                 workingDirectory,
                 customCommand.getText(),
                 allowSourceMutation.isSelected(),
-                openFileContext(project));
+                openFileContext(project),
+                conversationContext);
         invocation = routeNaturalStopToActiveRecorder(text, invocation);
         append("user", AssistantMarkdown.normalizeMarkdown(text), "");
+        if (!approvingCaptureReview && AssistantCommand.requiresAgentModeForMcp(text, selectedMode, invocation)) {
+            append("assistant", "This request needs MCP tool access. Switch to **Agent** mode, then send it again.",
+                    "");
+            addTimeline("Failed");
+            setRunning(false, "Switch to Agent mode");
+            return;
+        }
         if (agentMode
                 && !approvingCaptureReview
                 && !route.cloud()
                 && !allowSourceMutation.isSelected()
-                && promptRequiresSourceMutation(text)) {
-            append("assistant", "To let the agent make source edits, please tick **Allow source edits** before sending.",
+                && (promptRequiresSourceMutation(text) || continuationRequiresSourceMutation(text, conversationContext))) {
+            append("assistant", "To let the agent make source edits, please enable **Allow source edits** before sending.",
                     "");
             addTimeline("Failed");
             setRunning(false, "Approve source edits");
@@ -856,6 +867,24 @@ final class ShaftAssistantPanel extends JPanel {
                 || lower.contains("source edit")
                 || lower.contains("change source")
                 || (sourceArtifact && (mutationVerb || lower.contains("add")));
+    }
+
+    private static boolean continuationRequiresSourceMutation(String prompt, String conversationContext) {
+        return isContinuationPrompt(prompt) && promptRequiresSourceMutation(conversationContext);
+    }
+
+    private static boolean isContinuationPrompt(String prompt) {
+        String lower = prompt == null ? "" : prompt.trim().toLowerCase(Locale.ROOT);
+        return containsAny(lower,
+                "try again",
+                "retry",
+                "continue",
+                "go ahead",
+                "do it",
+                "apply",
+                "proceed",
+                "make the change",
+                "yes");
     }
 
     private static boolean containsAny(String value, String... needles) {
@@ -1740,6 +1769,40 @@ final class ShaftAssistantPanel extends JPanel {
             }
         }
         return "";
+    }
+
+    private String conversationContextForPrompt() {
+        List<ShaftAssistantChatState.Message> messages = chatState.activeMessages();
+        if (messages.isEmpty()) {
+            return "";
+        }
+        List<String> entries = new ArrayList<>();
+        int total = 0;
+        for (int index = messages.size() - 1; index >= 0; index--) {
+            ShaftAssistantChatState.Message message = messages.get(index);
+            if (message == null || message.markdown == null || message.markdown.isBlank()) {
+                continue;
+            }
+            String entry = contextRole(message.role) + ": " + message.markdown.trim();
+            int nextTotal = total + entry.length() + 2;
+            if (nextTotal > MAX_AGENT_CONTEXT_CHARACTERS && !entries.isEmpty()) {
+                break;
+            }
+            entries.add(0, clipContextEntry(entry, MAX_AGENT_CONTEXT_CHARACTERS));
+            total = nextTotal;
+        }
+        return String.join("\n\n", entries);
+    }
+
+    private static String contextRole(String role) {
+        return "user".equals(role) ? "User" : "Assistant";
+    }
+
+    private static String clipContextEntry(String entry, int maxCharacters) {
+        if (entry.length() <= maxCharacters) {
+            return entry;
+        }
+        return entry.substring(0, maxCharacters) + "\n... truncated ...";
     }
 
     private void copy(String value, String message) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -23,6 +23,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JProgressBar;
 import javax.swing.JTextPane;
+import javax.swing.Timer;
 import javax.swing.Icon;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
@@ -35,6 +36,7 @@ import java.awt.Color;
 import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.datatransfer.StringSelection;
+import java.awt.event.KeyEvent;
 import java.io.IOException;
 import java.lang.reflect.Proxy;
 import java.nio.file.Files;
@@ -50,7 +52,9 @@ import java.util.stream.Stream;
  * First-run SHAFT MCP setup panel.
  */
 final class ShaftMcpSetupPanel extends JPanel {
-    private static final String INSTALLER_REF = "a95e891cbd3d79cdaaaf4b0d608fd56d09b8c69b";
+    private static final String INSTALLER_BRANCH = "main";
+    private static final String MCP_DOCS_URL = "https://shafthq.github.io/docs/agentic/mcp";
+    private static final int TOAST_MILLIS = 2500;
     private static final String[] INSTALLER_TARGETS = {
             "CODEX",
             "CLAUDE_CODE",
@@ -72,6 +76,7 @@ final class ShaftMcpSetupPanel extends JPanel {
     private final ShaftSettingsState.Settings settings;
     private final Runnable connected;
     private final AgentReadinessProbe readinessProbe;
+    private final String recommendedFamily;
     private final JBTextArea installerCommand;
     private final JBTextArea mcpCommand;
     private final JComboBox<String> family;
@@ -87,12 +92,22 @@ final class ShaftMcpSetupPanel extends JPanel {
     private final JLabel runtimeStatus;
     private final JLabel assistStatus;
     private final JLabel chooseStep;
+    private final JLabel chooseState;
     private final JLabel installStep;
+    private final JLabel installState;
     private final JLabel detectStep;
+    private final JLabel detectState;
     private final JLabel testStep;
+    private final JLabel testState;
+    private final JLabel readyState;
     private final JLabel status;
+    private final JLabel recommendedAgent;
+    private final JLabel setupSummary;
+    private final JLabel recoveryStatus;
+    private final JLabel toast;
     private final JButton copyCommand;
     private final JButton copyOutput;
+    private final JButton copyDocs;
     private final JTextPane details;
     private final JPanel installerDetailsPanel;
     private final JPanel detailsPanel;
@@ -106,6 +121,8 @@ final class ShaftMcpSetupPanel extends JPanel {
     private boolean installerCommandCopied;
     private boolean terminalOpened;
     private Consumer<String> copySink = ShaftMcpSetupPanel::copyToClipboard;
+    private Consumer<String> toastSink = this::showToast;
+    private Timer toastTimer;
 
     ShaftMcpSetupPanel(@NotNull Project project, @NotNull ShaftSettingsState.Settings settings,
                        @NotNull Runnable connected) {
@@ -119,6 +136,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         this.settings = settings;
         this.connected = connected;
         this.readinessProbe = readinessProbe;
+        recommendedFamily = recommendedFamily(settings);
         setBorder(JBUI.Borders.empty(12));
 
         installerCommand = commandArea(3, "MCP installer command");
@@ -176,32 +194,55 @@ final class ShaftMcpSetupPanel extends JPanel {
         copyInstallerCommand = new JButton("Copy command");
         copyInstallerCommand.getAccessibleContext().setAccessibleName("Copy MCP installer command");
         copyInstallerCommand.setToolTipText("Copy the terminal installer command");
+        copyInstallerCommand.setMnemonic(KeyEvent.VK_C);
         applyLabeledAction(copyInstallerCommand, ShaftIcons.COPY);
         copyInstallerCommand.addActionListener(event -> copyInstallerCommand());
         openTerminal = new JButton("Open terminal");
         openTerminal.getAccessibleContext().setAccessibleName("Open terminal for MCP installer");
         openTerminal.setToolTipText("Open the IntelliJ terminal after copying the installer command");
+        openTerminal.setMnemonic(KeyEvent.VK_T);
         applyLabeledAction(openTerminal, ShaftIcons.CODE);
         openTerminal.addActionListener(event -> openTerminalForInstaller());
         test = new JButton("Check now");
         test.getAccessibleContext().setAccessibleName("Test SHAFT MCP connection");
         test.setToolTipText("Infer the stdio command and verify SHAFT MCP");
+        test.setMnemonic(KeyEvent.VK_K);
         applyLabeledAction(test, ShaftIcons.CHECK);
         test.addActionListener(event -> testConnection());
         startChatting = new JButton("Start chatting");
         startChatting.getAccessibleContext().setAccessibleName("Start chatting with SHAFT Assistant");
         startChatting.setToolTipText("Open the Assistant with this verified MCP command");
+        startChatting.setMnemonic(KeyEvent.VK_S);
         applyLabeledAction(startChatting, ShaftIcons.SEND);
         startChatting.setVisible(false);
         startChatting.addActionListener(event -> connected.run());
         resetAndReinstall = new JButton("Reset and reinstall");
         resetAndReinstall.getAccessibleContext().setAccessibleName("Reset and reinstall SHAFT MCP");
         resetAndReinstall.setToolTipText("Reset setup state and copy a fresh installer command");
+        resetAndReinstall.setMnemonic(KeyEvent.VK_R);
         applyLabeledAction(resetAndReinstall, ShaftIcons.RESET);
         resetAndReinstall.setVisible(false);
         resetAndReinstall.addActionListener(event -> resetAndCopyInstaller());
         runtimeStatus = setupStatusLabel("Assistant runtime setup status");
         assistStatus = setupStatusLabel("Assistant connection setup status");
+        recommendedAgent = setupStatusLabel("Recommended assistant agent");
+        recommendedAgent.setText(recommendedAgentText());
+        recommendedAgent.setVisible(true);
+        setupSummary = new JLabel();
+        setupSummary.getAccessibleContext().setAccessibleName("SHAFT MCP setup summary");
+        setupSummary.setText("Installer source: main. It configures the selected client and installs SHAFT MCP locally.");
+        recoveryStatus = new JLabel();
+        recoveryStatus.getAccessibleContext().setAccessibleName("SHAFT MCP recovery summary");
+        recoveryStatus.setVisible(false);
+        toast = new JLabel();
+        toast.getAccessibleContext().setAccessibleName("SHAFT setup clipboard toast");
+        toast.setOpaque(true);
+        toast.setBackground(UIManagerColors.activeBackground());
+        toast.setForeground(UIManagerColors.foreground());
+        toast.setBorder(JBUI.Borders.compound(
+                JBUI.Borders.customLine(UIManagerColors.progress(), 1),
+                JBUI.Borders.empty(4, 8)));
+        toast.setVisible(false);
         status = new JLabel();
         status.setPreferredSize(JBUI.size(560, 28));
         setStatusText(GUIDE_SETUP_STEP);
@@ -219,6 +260,14 @@ final class ShaftMcpSetupPanel extends JPanel {
         ShaftIconButtons.apply(copyOutput, ShaftIcons.COPY);
         copyOutput.setEnabled(false);
         copyOutput.addActionListener(event -> copyDiagnosticOutput());
+        copyDocs = new JButton("Copy docs link");
+        copyDocs.getAccessibleContext().setAccessibleName("Copy SHAFT MCP docs link");
+        copyDocs.setToolTipText("Copy the SHAFT MCP setup docs link");
+        copyDocs.setMnemonic(KeyEvent.VK_D);
+        ShaftIconButtons.apply(copyDocs, ShaftIcons.HELP);
+        copyDocs.setEnabled(false);
+        copyDocs.setVisible(false);
+        copyDocs.addActionListener(event -> copyDocsLink());
         details = new JTextPane();
         details.setPreferredSize(JBUI.size(560, 180));
         details.getAccessibleContext().setAccessibleName("SHAFT MCP setup output");
@@ -229,24 +278,30 @@ final class ShaftMcpSetupPanel extends JPanel {
         details.setBorder(JBUI.Borders.compound(JBUI.Borders.empty(6), JBUI.Borders.customLine(UIManagerColors.border(), 1)));
 
         chooseStep = setupStepLabel("Choose agent setup step");
+        chooseState = setupStateLabel("Choose agent setup state");
         installStep = setupStepLabel("Copy command setup step");
+        installState = setupStateLabel("Copy command setup state");
         detectStep = setupStepLabel("Open terminal setup step");
+        detectState = setupStateLabel("Open terminal setup state");
         testStep = setupStepLabel("Check now setup step");
+        testState = setupStateLabel("Check now setup state");
+        readyState = setupStateLabel("Start chatting setup state");
         JPanel agentControls = new JPanel();
         agentControls.setLayout(new javax.swing.BoxLayout(agentControls, javax.swing.BoxLayout.Y_AXIS));
         agentControls.add(labeledControl("Assistant family", family));
         agentControls.add(labeledControl("Runtime", runtime));
+        agentControls.add(recommendedAgent);
         JPanel checkActions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
         checkActions.add(test);
         checkActions.add(progress);
         checkActions.add(assistStatus);
-        chooseRow = stepRow(chooseStep, agentControls);
-        copyRow = stepRow(installStep, copyInstallerCommand);
-        terminalRow = stepRow(detectStep, openTerminal);
-        checkRow = stepRow(testStep, checkActions);
+        chooseRow = stepRow(chooseStep, chooseState, agentControls);
+        copyRow = stepRow(installStep, installState, copyInstallerCommand);
+        terminalRow = stepRow(detectStep, detectState, openTerminal);
+        checkRow = stepRow(testStep, testState, checkActions);
         JLabel readyStep = setupStepLabel("Start chatting setup step");
         readyStep.setText("Ready");
-        chatRow = stepRow(readyStep, startChatting);
+        chatRow = stepRow(readyStep, readyState, startChatting);
         chatRow.setVisible(false);
         JPanel workflow = new JPanel();
         workflow.setLayout(new javax.swing.BoxLayout(workflow, javax.swing.BoxLayout.Y_AXIS));
@@ -261,6 +316,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         JPanel diagnosticRow = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
         diagnosticRow.add(copyCommand);
         diagnosticRow.add(copyOutput);
+        diagnosticRow.add(copyDocs);
         JPanel secondaryActions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
         secondaryActions.add(resetAndReinstall);
         family.addActionListener(event -> assistantSelectionChanged());
@@ -281,10 +337,13 @@ final class ShaftMcpSetupPanel extends JPanel {
         installerDetailsPanel.setVisible(false);
         JPanel form = FormBuilder.createFormBuilder()
                 .addComponent(intro)
+                .addComponent(setupSummary)
                 .addComponent(runtimeStatus)
                 .addComponent(workflow)
                 .addComponent(installerDetailsPanel)
                 .addComponent(status)
+                .addComponent(toast)
+                .addComponent(recoveryStatus)
                 .addComponent(secondaryActions)
                 .addComponentFillVertically(new JPanel(), 0)
                 .getPanel();
@@ -365,7 +424,7 @@ final class ShaftMcpSetupPanel extends JPanel {
                 if (readiness.success()) {
                     showAssistConfigured();
                     showRuntimeVerified();
-                    setStatusText("Ready to chat.");
+                    setStatusText(successSummary(result.output()));
                 } else {
                     success = false;
                     showAssistError();
@@ -384,6 +443,7 @@ final class ShaftMcpSetupPanel extends JPanel {
             settings.mcpSetupComplete = true;
             settings.agentGuidanceOptimizationPromptPending = true;
             startChatting.setVisible(true);
+            startChatting.requestFocusInWindow();
         } else {
             settings.mcpSetupComplete = false;
             settings.agentGuidanceOptimizationPromptPending = false;
@@ -427,6 +487,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         updateProgressivePanels();
         updateSetupSteps(running);
         updateWorkflowRows(running);
+        updateLiveSummary();
     }
 
     private void commandChanged() {
@@ -484,6 +545,40 @@ final class ShaftMcpSetupPanel extends JPanel {
         };
     }
 
+    private String recommendedFamily(ShaftSettingsState.Settings settings) {
+        String explicit = normalize(settings.assistantFamily, "");
+        if (!explicit.isBlank()) {
+            return explicit;
+        }
+        String resolved = resolveFamily(settings);
+        if (!"CLI".equals(normalize(settings.assistantRuntime, "CLI"))) {
+            return resolved;
+        }
+        for (String familyCandidate : List.of("CODEX", "CLAUDE", "COPILOT")) {
+            ShaftMcpToolResult result = readinessProbe.test(clientFromFamily(familyCandidate), "CLI");
+            if (result != null && result.success()) {
+                return familyCandidate;
+            }
+        }
+        return resolved;
+    }
+
+    private String recommendedAgentText() {
+        return "Recommended: " + cliAgentLabel(recommendedFamily) + agentRecommendationSuffix(recommendedFamily);
+    }
+
+    private static String cliAgentLabel(String family) {
+        return switch (normalize(family, "CODEX")) {
+            case "CLAUDE" -> "Claude Code CLI";
+            case "COPILOT" -> "GitHub Copilot CLI";
+            default -> "Codex CLI";
+        };
+    }
+
+    private static String agentRecommendationSuffix(String family) {
+        return " detected";
+    }
+
     private static String clientFromFamily(String family) {
         return switch (normalize(family, "CODEX")) {
             case "CLAUDE" -> "CLAUDE_CODE";
@@ -520,16 +615,15 @@ final class ShaftMcpSetupPanel extends JPanel {
     }
 
     private static String installerCommandFor(String target) {
-        String url = "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/" + INSTALLER_REF
+        String url = "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/" + INSTALLER_BRANCH
                 + "/scripts/mcp/install-shaft-mcp";
         if (isWindows()) {
-            return "powershell -NoProfile -ExecutionPolicy Bypass -Command '$env:SHAFT_MCP_INSTALLER_REF=\""
-                    + INSTALLER_REF + "\"; $installer=Join-Path $env:TEMP \"install-shaft-mcp.ps1\"; "
+            return "powershell -NoProfile -ExecutionPolicy Bypass -Command '$installer=Join-Path $env:TEMP \"install-shaft-mcp.ps1\"; "
                     + "Invoke-WebRequest -UseBasicParsing \"" + url
                     + ".ps1\" -OutFile $installer; & $installer -Client " + target + "'";
         }
-        return "ref=" + INSTALLER_REF + "; tmp=\"${TMPDIR:-/tmp}/install-shaft-mcp.sh\"; curl -fL " + url
-                + ".sh -o \"$tmp\" && SHAFT_MCP_INSTALLER_REF=\"$ref\" sh \"$tmp\" --" + target;
+        return "tmp=\"${TMPDIR:-/tmp}/install-shaft-mcp.sh\"; curl -fL " + url
+                + ".sh -o \"$tmp\" && sh \"$tmp\" --" + target;
     }
 
     private void copyInstallerCommand() {
@@ -537,6 +631,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         installerCommandCopied = true;
         terminalOpened = false;
         updateActionState(false);
+        openTerminal.requestFocusInWindow();
     }
 
     private void openTerminalForInstaller() {
@@ -546,6 +641,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         openIntellijTerminal();
         setStatusText("Run command in terminal, then check.");
         updateActionState(false);
+        test.requestFocusInWindow();
     }
 
     private void resetAndCopyInstaller() {
@@ -844,6 +940,18 @@ final class ShaftMcpSetupPanel extends JPanel {
         return label;
     }
 
+    private static JLabel setupStateLabel(String accessibleName) {
+        JLabel label = new JLabel();
+        label.setOpaque(true);
+        label.setHorizontalAlignment(JLabel.CENTER);
+        label.setPreferredSize(JBUI.size(74, 22));
+        label.setBorder(JBUI.Borders.compound(
+                JBUI.Borders.customLine(UIManagerColors.border(), 1),
+                JBUI.Borders.empty(2, 6)));
+        label.getAccessibleContext().setAccessibleName(accessibleName);
+        return label;
+    }
+
     private static void applyLabeledAction(JButton button, Icon icon) {
         button.setIcon(icon);
         button.setMargin(JBUI.insets(4, 8));
@@ -865,12 +973,13 @@ final class ShaftMcpSetupPanel extends JPanel {
     private void updateSetupSteps(boolean running) {
         boolean hasCommand = !currentCommand().isBlank();
         boolean complete = settings.mcpSetupComplete && hasCommand;
-        setStep(chooseStep, "1 Pick agent", "done");
-        setStep(installStep, "2 Copy command", hasCommand || installerCommandCopied || complete ? "done" : "next");
-        setStep(detectStep, "3 Run in terminal", hasCommand || terminalOpened || complete
+        setStep(chooseStep, chooseState, "1 Pick agent", "done");
+        setStep(installStep, installState, "2 Copy command", hasCommand || installerCommandCopied || complete ? "done" : "next");
+        setStep(detectStep, detectState, "3 Run in terminal", hasCommand || terminalOpened || complete
                 ? "done"
                 : installerCommandCopied ? "next" : "wait");
-        setStep(testStep, "4 Check setup", running ? "checking" : complete ? "done" : hasCommand || terminalOpened ? "next" : "wait");
+        setStep(testStep, testState, "4 Check setup", running ? "checking" : complete ? "done" : hasCommand || terminalOpened ? "next" : "wait");
+        setStep(null, readyState, "Ready", complete ? "next" : "wait");
     }
 
     private void updateWorkflowRows(boolean running) {
@@ -885,29 +994,56 @@ final class ShaftMcpSetupPanel extends JPanel {
         styleStepRow(chatRow, complete ? "next" : "wait");
     }
 
-    private static void setStep(JLabel label, String name, String state) {
-        label.setText(name);
-        label.setToolTipText(name + " is " + state);
-        label.getAccessibleContext().setAccessibleName(name + " setup step: " + state);
-        label.setFont(label.getFont().deriveFont("next".equals(state) || "checking".equals(state)
-                ? Font.BOLD
-                : Font.PLAIN));
-        label.setForeground(switch (state) {
+    private static void setStep(JLabel label, JLabel stateLabel, String name, String state) {
+        if (label != null) {
+            label.setText(name);
+            label.setToolTipText(name + " is " + state);
+            label.getAccessibleContext().setAccessibleName(name + " setup step: " + state);
+            label.setFont(label.getFont().deriveFont("next".equals(state) || "checking".equals(state)
+                    ? Font.BOLD
+                    : Font.PLAIN));
+            label.setForeground(switch (state) {
+                case "done" -> UIManagerColors.success();
+                case "next", "checking" -> UIManagerColors.progress();
+                default -> UIManagerColors.foreground();
+            });
+        }
+        stateLabel.setText(switch (state) {
+            case "done" -> "Done";
+            case "next" -> "Next";
+            case "checking" -> "Checking";
+            default -> "Waiting";
+        });
+        stateLabel.setToolTipText(name + " is " + state);
+        stateLabel.getAccessibleContext().setAccessibleDescription(name + " setup state: " + state);
+        stateLabel.setBackground(switch (state) {
+            case "done" -> UIManagerColors.doneBackground();
+            case "next", "checking" -> UIManagerColors.activeBackground();
+            default -> UIManagerColors.panelBackground();
+        });
+        stateLabel.setForeground(switch (state) {
             case "done" -> UIManagerColors.success();
             case "next", "checking" -> UIManagerColors.progress();
             default -> UIManagerColors.foreground();
         });
     }
 
-    private static JPanel stepRow(JLabel label, JComponent action) {
+    private static JPanel stepRow(JLabel label, JLabel stateLabel, JComponent action) {
         JPanel row = new JPanel(new WrapLayout(FlowLayout.LEFT, 8, 4));
         row.setOpaque(true);
         row.add(label);
+        row.add(stateLabel);
         row.add(action);
         row.setBorder(JBUI.Borders.compound(
                 JBUI.Borders.customLine(UIManagerColors.border(), 1),
                 JBUI.Borders.empty(6)));
         return row;
+    }
+
+    private void updateLiveSummary() {
+        String target = String.valueOf(installerTarget.getSelectedItem()).replace('_', ' ');
+        setupSummary.setText("Installer source: main. Target: " + target + ". Runtime: " + assistantRuntimeLabel() + ".");
+        recommendedAgent.setText(recommendedAgentText());
     }
 
     private static JPanel labeledControl(String text, JComponent control) {
@@ -999,6 +1135,10 @@ final class ShaftMcpSetupPanel extends JPanel {
         copyCommand.setVisible(!diagnosticCommand.isBlank());
         copyCommand.setEnabled(!diagnosticCommand.isBlank());
         copyOutput.setEnabled(!diagnosticOutput.isBlank());
+        copyDocs.setVisible(!diagnosticOutput.isBlank());
+        copyDocs.setEnabled(!diagnosticOutput.isBlank());
+        recoveryStatus.setText("Recovery: retry Check setup, copy diagnostics, or open the SHAFT MCP docs link.");
+        recoveryStatus.setVisible(!diagnosticOutput.isBlank());
         details.setText(diagnosticOutput);
         details.setCaretPosition(details.getDocument().getLength());
         detailsPanel.setVisible(!diagnosticOutput.isBlank());
@@ -1016,6 +1156,9 @@ final class ShaftMcpSetupPanel extends JPanel {
         copyCommand.setEnabled(false);
         copyCommand.setVisible(false);
         copyOutput.setEnabled(false);
+        copyDocs.setEnabled(false);
+        copyDocs.setVisible(false);
+        recoveryStatus.setVisible(false);
         details.setText("");
         detailsPanel.setVisible(false);
         detailsPanel.revalidate();
@@ -1029,11 +1172,63 @@ final class ShaftMcpSetupPanel extends JPanel {
         copy(diagnosticOutput, "Copied diagnostic output");
     }
 
+    private void copyDocsLink() {
+        copy(MCP_DOCS_URL, "Copied SHAFT MCP docs link");
+    }
+
     private void copy(String value, String message) {
         if (value != null && !value.isBlank()) {
             copySink.accept(value);
             setStatusText(message);
+            toastSink.accept(toastMessage(message));
         }
+    }
+
+    private static String toastMessage(String message) {
+        String lower = message == null ? "" : message.toLowerCase(Locale.ROOT);
+        return lower.contains("command") ? "Command copied to clipboard" : "Copied to clipboard";
+    }
+
+    private void showToast(String message) {
+        if (toastTimer != null) {
+            toastTimer.stop();
+        }
+        toast.setText(message);
+        toast.setVisible(true);
+        if (!isShowing()) {
+            toast.setVisible(false);
+            return;
+        }
+        toastTimer = new Timer(TOAST_MILLIS, event -> {
+            toast.setVisible(false);
+            toastTimer = null;
+        });
+        toastTimer.setRepeats(false);
+        toastTimer.start();
+    }
+
+    private String successSummary(String output) {
+        String workspace = verifiedWorkspace(output);
+        return workspace.isBlank()
+                ? "Ready to chat. Verified " + assistantRuntimeLabel() + "."
+                : "Ready to chat. Verified " + assistantRuntimeLabel() + " for workspace " + workspace + ".";
+    }
+
+    private static String verifiedWorkspace(String output) {
+        if (output == null || output.isBlank()) {
+            return "";
+        }
+        for (String line : output.split("\\R")) {
+            String trimmed = line.trim();
+            String lower = trimmed.toLowerCase(Locale.ROOT);
+            if (lower.startsWith("mcp workspace:")) {
+                return trimmed.substring(trimmed.indexOf(':') + 1).trim();
+            }
+            if (lower.startsWith("workspace:")) {
+                return trimmed.substring(trimmed.indexOf(':') + 1).trim();
+            }
+        }
+        return "";
     }
 
     private static void copyToClipboard(String value) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftPluginSecurityTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftPluginSecurityTest.java
@@ -21,8 +21,8 @@ class ShaftPluginSecurityTest {
         assertFalse(source.contains("Invoke-Expression"));
         assertFalse(source.contains("| iex"));
         assertFalse(source.contains("curl -fsSL"));
-        assertFalse(setupPanel.contains("/main/"));
-        assertTrue(setupPanel.contains("SHAFT_MCP_INSTALLER_REF"));
+        assertTrue(setupPanel.contains("INSTALLER_BRANCH = \"main\""));
+        assertFalse(setupPanel.contains("SHAFT_MCP_INSTALLER_REF"));
         assertFalse(setupPanel.contains("ProcessBuilder"));
         assertFalse(setupPanel.contains("Runtime.getRuntime"));
         assertFalse(setupPanel.contains("GeneralCommandLine"));

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
@@ -99,6 +99,64 @@ class AssistantCommandTest {
     }
 
     @Test
+    void localAndCloudPromptsIncludeConversationContextWhenProvided() {
+        String context = "User: Previous target URL was https://duckduckgo.com";
+        AssistantCommand.Invocation local = AssistantCommand.fromPrompt(
+                "continue with the first result assertion",
+                AssistantCommand.Selection.local("CODEX", "CLI"),
+                "AGENT",
+                "C:/work/project",
+                "",
+                true,
+                AssistantCommand.OpenFileContext.empty(),
+                context);
+        AssistantCommand.Invocation cloud = AssistantCommand.fromPrompt(
+                "summarize next step",
+                AssistantCommand.Selection.cloud("openai", "gpt-5"),
+                "ASK",
+                "C:/work/project",
+                "",
+                false,
+                AssistantCommand.OpenFileContext.empty(),
+                context);
+
+        assertAll(
+                () -> assertTrue(local.arguments().get("prompt").getAsString().contains("Conversation context:")),
+                () -> assertTrue(local.arguments().get("prompt").getAsString().contains(context)),
+                () -> assertTrue(local.arguments().get("prompt").getAsString()
+                        .contains("Current request:\nIf this request requires interacting")),
+                () -> assertTrue(cloud.arguments().get("prompt").getAsString().contains("Conversation context:")),
+                () -> assertTrue(cloud.arguments().get("prompt").getAsString().contains(context)),
+                () -> assertTrue(cloud.arguments().get("prompt").getAsString()
+                        .contains("Current request:\nsummarize next step")));
+    }
+
+    @Test
+    void askOrPlanMcpNaturalLanguagePromptsRequireAgentModeButSlashCommandsDoNot() {
+        AssistantCommand.Invocation natural = AssistantCommand.fromPrompt(
+                "open duckduckgo and search for SHAFT Engine",
+                AssistantCommand.Selection.local("CODEX", "CLI"),
+                "PLAN",
+                ".",
+                "",
+                false);
+        AssistantCommand.Invocation slash = AssistantCommand.fromPrompt(
+                "/guide locators",
+                AssistantCommand.Selection.local("CODEX", "CLI"),
+                "PLAN",
+                ".",
+                "",
+                false);
+
+        assertAll(
+                () -> assertTrue(AssistantCommand.requiresAgentModeForMcp(
+                        "open duckduckgo and search for SHAFT Engine", "PLAN", natural)),
+                () -> assertFalse(AssistantCommand.requiresAgentModeForMcp("/guide locators", "PLAN", slash)),
+                () -> assertFalse(AssistantCommand.requiresAgentModeForMcp(
+                        "open duckduckgo and search for SHAFT Engine", "AGENT", natural)));
+    }
+
+    @Test
     void localAgentCodeGenerationPromptsNameShaftMcpPracticeToolsBeforeGeneration() {
         AssistantCommand.Invocation generatedTest = AssistantCommand.fromPrompt(
                 "generate a Java login test with a page object",

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -224,6 +224,8 @@ class ShaftPanelSetupTest {
         assertTrue(containsText(toolWindow, "3 Run in terminal"));
         assertTrue(containsText(toolWindow, "4 Check setup"));
         assertTrue(containsText(toolWindow, "Connect SHAFT Assistant"));
+        assertTrue(containsText(toolWindow, "Installer source: main"));
+        assertNotNull(findByAccessibleName(toolWindow, "Copy command setup state", JLabel.class));
         assertNull(findByAccessibleName(toolWindow, "SHAFT MCP command status", JLabel.class));
         assertFalse(findByAccessibleName(toolWindow, "Assistant runtime setup status", JLabel.class).isVisible());
         assertFalse(findByAccessibleName(toolWindow, "Assistant connection setup status", JLabel.class).isVisible());
@@ -326,7 +328,9 @@ class ShaftPanelSetupTest {
             ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
             });
             AtomicReference<String> copied = new AtomicReference<>();
+            AtomicReference<String> toast = new AtomicReference<>();
             setField(panel, "copySink", (Consumer<String>) copied::set);
+            setField(panel, "toastSink", (Consumer<String>) toast::set);
             JTextComponent command = (JTextComponent) getField(panel, "mcpCommand");
             JComponent installerDetailsPanel = (JComponent) getField(panel, "installerDetailsPanel");
 
@@ -349,18 +353,19 @@ class ShaftPanelSetupTest {
             assertAll(
                     () -> assertTrue(copied.get().contains("install-shaft-mcp")),
                     () -> assertTrue(copied.get().contains("codex")),
-                    () -> assertTrue(copied.get().contains("a95e891cbd3d79cdaaaf4b0d608fd56d09b8c69b")),
-                    () -> assertFalse(copied.get().contains("/main/")),
+                    () -> assertTrue(copied.get().contains("/main/scripts/mcp/install-shaft-mcp")),
+                    () -> assertFalse(copied.get().contains("SHAFT_MCP_INSTALLER_REF")),
+                    () -> assertEquals("Command copied to clipboard", toast.get()),
                     () -> assertFalse(findByAccessibleName(panel, "Copy MCP installer command", JButton.class).isVisible()),
                     () -> assertTrue(findByAccessibleName(panel, "Open terminal for MCP installer", JButton.class).isVisible()),
                     () -> assertFalse(installerDetailsPanel.isVisible()),
                     () -> assertFalse(findByAccessibleName(panel, "Test SHAFT MCP connection", JButton.class).isVisible()));
             if (isWindowsOs()) {
                 assertAll(
-                        () -> assertTrue(copied.get().contains("-Command '$env:SHAFT_MCP_INSTALLER_REF")),
+                        () -> assertTrue(copied.get().contains("-Command '$installer=Join-Path")),
                         () -> assertFalse(copied.get().contains("-Command \"$installer")));
             } else {
-                assertTrue(copied.get().contains("SHAFT_MCP_INSTALLER_REF=\"$ref\""));
+                assertTrue(copied.get().contains("sh \"$tmp\" --codex"));
             }
 
             clickAccessible(panel, "Open terminal for MCP installer");
@@ -414,6 +419,21 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void setupPanelShowsDetectedRecommendedCliAgentWithoutChangingDefaultSelection() {
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
+        }, (client, runtime) -> "CLAUDE_CODE".equals(client)
+                ? ShaftMcpToolResult.success("Claude Code CLI executable is available on PATH.")
+                : ShaftMcpToolResult.failure("not found"));
+        JComboBox<?> family = findByAccessibleName(panel, "Assistant family", JComboBox.class);
+        JComboBox<?> target = findByAccessibleName(panel, "MCP installer target", JComboBox.class);
+
+        assertAll(
+                () -> assertEquals("CODEX", family.getSelectedItem()),
+                () -> assertEquals("CODEX", target.getSelectedItem()),
+                () -> assertTrue(containsText(panel, "Recommended: Claude Code CLI detected")));
+    }
+
+    @Test
     void setupPanelShowsBlankManualCommandDiagnostic() throws Exception {
         Path appData = Files.createTempDirectory("shaft-mcp-empty-app-data");
         Path bootstrap = Files.createTempDirectory("shaft-mcp-empty-bootstrap");
@@ -442,6 +462,8 @@ class ShaftPanelSetupTest {
                     () -> assertTrue(detailsPanel.isVisible()),
                     () -> assertFalse(findByAccessibleName(panel, "Copy setup diagnostic command", JButton.class).isVisible()),
                     () -> assertTrue(findByAccessibleName(panel, "Copy setup diagnostic output", JButton.class).isEnabled()),
+                    () -> assertTrue(findByAccessibleName(panel, "Copy SHAFT MCP docs link", JButton.class).isEnabled()),
+                    () -> assertTrue(containsText(panel, "Recovery: retry Check setup")),
                     () -> assertNull(findButton(panel, "Install / Update SHAFT MCP")),
                     () -> assertTrue(findByAccessibleName(panel, "Test SHAFT MCP connection", JButton.class).isEnabled()));
             clickAccessible(panel, "Copy setup diagnostic output");
@@ -459,11 +481,11 @@ class ShaftPanelSetupTest {
         ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), settings, () -> connected.set(true), readyProbe());
         JComponent detailsPanel = (JComponent) getField(panel, "detailsPanel");
 
-        showTestResult(panel, ShaftMcpToolResult.success("Probe OK"));
+        showTestResult(panel, ShaftMcpToolResult.success("Probe OK\nMCP workspace: C:/work/shaft"));
 
         assertAll(
                 () -> assertTrue(containsText(panel, "Runtime: Codex CLI verified")),
-                () -> assertTrue(containsText(panel, "Ready to chat.")),
+                () -> assertTrue(containsText(panel, "Ready to chat. Verified Codex CLI for workspace C:/work/shaft.")),
                 () -> assertFalse(detailsPanel.isVisible()),
                 () -> assertNull(findByAccessibleName(panel, "MCP stdio command", JTextComponent.class)),
                 () -> assertFalse(connected.get()),
@@ -1901,7 +1923,7 @@ class ShaftPanelSetupTest {
         blockedMode.setSelectedItem("AGENT");
         assistantPrompt(blockedPanel).setText("edit this test");
         clickAccessible(blockedPanel, "Send assistant prompt");
-        assertTrue(transcriptMarkdown(blockedPanel).contains("tick **Allow source edits**"));
+        assertTrue(transcriptMarkdown(blockedPanel).contains("enable **Allow source edits**"));
 
         ShaftAssistantPanel approvedPanel = new ShaftAssistantPanel(null, blankMcpSettings());
         JComboBox<?> approvedMode = findByAccessibleName(approvedPanel, "Assistant mode", JComboBox.class);
@@ -1914,7 +1936,35 @@ class ShaftPanelSetupTest {
         allowEdits.setSelected(true);
         assistantPrompt(approvedPanel).setText("edit this test");
         clickAccessible(approvedPanel, "Send assistant prompt");
-        assertFalse(transcriptMarkdown(approvedPanel).contains("tick **Allow source edits**"));
+        assertFalse(transcriptMarkdown(approvedPanel).contains("enable **Allow source edits**"));
+    }
+
+    @Test
+    void assistantAskOrPlanMcpPromptTellsUserToSwitchToAgentMode() {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        JComboBox<?> assistantMode = findByAccessibleName(panel, "Assistant mode", JComboBox.class);
+        assertNotNull(assistantMode);
+        assistantMode.setSelectedItem("PLAN");
+
+        assistantPrompt(panel).setText("open duckduckgo and search for SHAFT Engine");
+        clickAccessible(panel, "Send assistant prompt");
+
+        assertTrue(transcriptMarkdown(panel).contains("Switch to **Agent** mode"));
+    }
+
+    @Test
+    void assistantAgentModeSourceEditWarningUsesActiveContextForContinuationPrompt() {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        JComboBox<?> assistantMode = findByAccessibleName(panel, "Assistant mode", JComboBox.class);
+        assertNotNull(assistantMode);
+        assistantMode.setSelectedItem("AGENT");
+
+        assistantPrompt(panel).setText("fix this Java test");
+        clickAccessible(panel, "Send assistant prompt");
+        assistantPrompt(panel).setText("try again");
+        clickAccessible(panel, "Send assistant prompt");
+
+        assertEquals(2, countOccurrences(transcriptMarkdown(panel), "enable **Allow source edits**"));
     }
 
     @Test
@@ -1926,7 +1976,7 @@ class ShaftPanelSetupTest {
         assistantPrompt(panel).setText("open https://example.com and update me on the login form");
         clickAccessible(panel, "Send assistant prompt");
 
-        assertFalse(transcriptMarkdown(panel).contains("tick **Allow source edits**"));
+        assertFalse(transcriptMarkdown(panel).contains("enable **Allow source edits**"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Make IntelliJ setup installer commands fetch `scripts/mcp/install-shaft-mcp` from `main` without `SHAFT_MCP_INSTALLER_REF`.
- Add setup feedback: recommended CLI display, state chips, clipboard toast, focus handoff, recovery/docs copy, and verified runtime/workspace success copy.
- Add Assistant guardrails for MCP-required Ask/Plan prompts, source-edit approval, continuation prompts, and bounded active chat context for local/cloud prompts.

## Validation
- `gradle -p shaft-intellij test --tests com.shaft.intellij.ui.ShaftPanelSetupTest --tests com.shaft.intellij.ui.AssistantCommandTest --tests com.shaft.intellij.mcp.ShaftPluginSecurityTest`
- `gradle -p shaft-intellij test --tests com.shaft.intellij.ui.ShaftPluginScreenshotRendererTest -Dshaft.intellij.screenshotDir=target/shaft-intellij-screenshots`
- `py -3 scripts/ci/validate_documentation_boundaries.py`
- `git diff --check`

No Allure reports were opened or served.
