### PR TITLE
Fix recorder persistence and assistant capture output

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventScript.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventScript.java
@@ -57,6 +57,26 @@ public final class BrowserEventScript {
     }
 
     /**
+     * Returns JavaScript that installs the fallback queue listener with a loopback event sink.
+     *
+     * @param testIdAttributes locator test-id attributes
+     * @param eventEndpoint loopback event endpoint
+     * @param eventToken loopback event token
+     * @return installation JavaScript
+     */
+    public static String fallbackInstallation(
+            List<String> testIdAttributes,
+            String eventEndpoint,
+            String eventToken) {
+        if (eventEndpoint == null || eventEndpoint.isBlank()
+                || eventToken == null || eventToken.isBlank()) {
+            return fallbackInstallation(testIdAttributes);
+        }
+        return "return (" + script(testIdAttributes) + ")(null, {url: "
+                + jsString(eventEndpoint) + ", token: " + jsString(eventToken) + "});";
+    }
+
+    /**
      * Returns JavaScript that drains fallback signals.
      *
      * @return queue drain JavaScript

--- a/shaft-capture/src/main/java/com/shaft/capture/collector/PollingBrowserEventCollector.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/collector/PollingBrowserEventCollector.java
@@ -26,6 +26,8 @@ public final class PollingBrowserEventCollector implements BrowserEventCollector
     private final WebDriver driver;
     private final boolean reportFallbackWarning;
     private final List<String> testIdAttributes;
+    private final String eventEndpoint;
+    private final String eventToken;
     private final ObjectMapper mapper = new ObjectMapper();
     private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(runnable -> {
         Thread thread = new Thread(runnable, "shaft-capture-polling");
@@ -66,12 +68,32 @@ public final class PollingBrowserEventCollector implements BrowserEventCollector
             WebDriver driver,
             boolean reportFallbackWarning,
             List<String> testIdAttributes) {
+        this(driver, reportFallbackWarning, testIdAttributes, "", "");
+    }
+
+    /**
+     * Creates a classic WebDriver collector.
+     *
+     * @param driver active driver
+     * @param reportFallbackWarning whether status should report reduced BiDi coverage
+     * @param testIdAttributes locator test-id attributes
+     * @param eventEndpoint optional loopback event endpoint
+     * @param eventToken optional loopback event token
+     */
+    public PollingBrowserEventCollector(
+            WebDriver driver,
+            boolean reportFallbackWarning,
+            List<String> testIdAttributes,
+            String eventEndpoint,
+            String eventToken) {
         if (driver == null) {
             throw new IllegalArgumentException("Capture WebDriver is required.");
         }
         this.driver = driver;
         this.reportFallbackWarning = reportFallbackWarning;
         this.testIdAttributes = testIdAttributes == null ? List.of() : List.copyOf(testIdAttributes);
+        this.eventEndpoint = eventEndpoint == null ? "" : eventEndpoint;
+        this.eventToken = eventToken == null ? "" : eventToken;
     }
 
     @Override
@@ -121,7 +143,10 @@ public final class PollingBrowserEventCollector implements BrowserEventCollector
             }
 
             JavascriptExecutor javascript = (JavascriptExecutor) driver;
-            javascript.executeScript(BrowserEventScript.fallbackInstallation(testIdAttributes));
+            javascript.executeScript(BrowserEventScript.fallbackInstallation(
+                    testIdAttributes,
+                    eventEndpoint,
+                    eventToken));
             Object drained = javascript.executeScript(BrowserEventScript.fallbackDrain());
             if (drained instanceof List<?> signals) {
                 for (Object item : signals) {

--- a/shaft-capture/src/main/java/com/shaft/capture/model/CaptureSession.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/model/CaptureSession.java
@@ -118,6 +118,22 @@ public record CaptureSession(
     }
 
     /**
+     * Returns a copy with a replaced event list.
+     *
+     * @param updatedEvents replacement events
+     * @return updated session
+     */
+    public CaptureSession withEvents(List<CaptureEvent> updatedEvents) {
+        ensureIncomplete();
+        Set<String> retainedReferenceIds = eventReferenceIds(updatedEvents);
+        List<ExternalTestDataReference> retainedReferences = dataReferences.stream()
+                .filter(reference -> retainedReferenceIds.contains(reference.id()))
+                .toList();
+        return new CaptureSession(schemaVersion, sessionId, status, startedAt, endedAt, browser,
+                updatedEvents, checkpoints, retainedReferences, redactionSummary, extensions);
+    }
+
+    /**
      * Returns a copy containing external data references and their safe summary.
      *
      * @param references references to add
@@ -200,5 +216,36 @@ public record CaptureSession(
             }
         }
         return List.copyOf(sorted);
+    }
+
+    private static Set<String> eventReferenceIds(List<CaptureEvent> values) {
+        Set<String> ids = new HashSet<>();
+        if (values == null) {
+            return ids;
+        }
+        values.forEach(event -> eventReferences(event).forEach(reference -> ids.add(reference.id())));
+        return ids;
+    }
+
+    private static List<ExternalTestDataReference> eventReferences(CaptureEvent event) {
+        if (event instanceof CaptureEvent.TypeEvent value) {
+            return List.of(value.value());
+        }
+        if (event instanceof CaptureEvent.SelectEvent value) {
+            return List.of(value.value());
+        }
+        if (event instanceof CaptureEvent.UploadEvent value) {
+            return List.of(value.file());
+        }
+        if (event instanceof CaptureEvent.AlertEvent value && value.text() != null) {
+            return List.of(value.text());
+        }
+        if (event instanceof CaptureEvent.WaitEvent value && value.expected() != null) {
+            return List.of(value.expected());
+        }
+        if (event instanceof CaptureEvent.VerificationEvent value && value.expected() != null) {
+            return List.of(value.expected());
+        }
+        return List.of();
     }
 }

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/BrowserEventSink.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/BrowserEventSink.java
@@ -1,0 +1,116 @@
+package com.shaft.capture.runtime;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import com.shaft.capture.collector.BrowserSignal;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.function.Consumer;
+
+/**
+ * Loopback sink used by the WebDriver fallback listener before navigation can clear page memory.
+ */
+final class BrowserEventSink implements AutoCloseable {
+    private static final int MAX_REQUEST_BYTES = 131_072;
+
+    private final Consumer<BrowserSignal> signalConsumer;
+    private final Consumer<String> warningConsumer;
+    private final ObjectMapper mapper = JsonMapper.builder().build();
+    private final String token = token();
+    private final HttpServer server;
+    private int port;
+
+    BrowserEventSink(
+            Consumer<BrowserSignal> signalConsumer,
+            Consumer<String> warningConsumer) {
+        if (signalConsumer == null || warningConsumer == null) {
+            throw new IllegalArgumentException("Browser event sink consumers are required.");
+        }
+        this.signalConsumer = signalConsumer;
+        this.warningConsumer = warningConsumer;
+        try {
+            server = HttpServer.create(new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0), 0);
+        } catch (IOException exception) {
+            throw new IllegalStateException("SHAFT Capture browser event sink could not start.", exception);
+        }
+        server.createContext("/event", this::handle);
+    }
+
+    String start() {
+        server.start();
+        port = server.getAddress().getPort();
+        return endpoint();
+    }
+
+    String endpoint() {
+        return port == 0 ? "" : "http://127.0.0.1:" + port + "/event";
+    }
+
+    String eventToken() {
+        return token;
+    }
+
+    @Override
+    public void close() {
+        server.stop(0);
+    }
+
+    private void handle(HttpExchange exchange) throws IOException {
+        try (exchange) {
+            exchange.getResponseHeaders().set("Access-Control-Allow-Origin", "*");
+            if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+                send(exchange, 405);
+                return;
+            }
+            byte[] body = exchange.getRequestBody().readNBytes(MAX_REQUEST_BYTES + 1);
+            if (body.length > MAX_REQUEST_BYTES) {
+                send(exchange, 413);
+                return;
+            }
+            accept(body);
+            send(exchange, 204);
+        }
+    }
+
+    private void accept(byte[] body) {
+        try {
+            JsonNode root = mapper.readTree(body);
+            if (!authorized(root.path("token").asText())) {
+                return;
+            }
+            JsonNode payload = root.path("payload");
+            if (!payload.isObject()) {
+                return;
+            }
+            signalConsumer.accept(BrowserSignal.fromJson(mapper.writeValueAsString(payload), "loopback"));
+        } catch (JacksonException exception) {
+            warningConsumer.accept("A malformed browser interaction signal was ignored.");
+        }
+    }
+
+    private boolean authorized(String candidate) {
+        return MessageDigest.isEqual(
+                token.getBytes(StandardCharsets.UTF_8),
+                candidate.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static void send(HttpExchange exchange, int status) throws IOException {
+        exchange.sendResponseHeaders(status, -1);
+    }
+
+    private static String token() {
+        byte[] bytes = new byte[32];
+        new SecureRandom().nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -36,7 +37,6 @@ import java.util.function.Consumer;
  * Converts low-level browser signals into ordered privacy-safe semantic events.
  */
 final class CaptureEventPipeline implements AutoCloseable {
-    private static final Duration INPUT_DEBOUNCE = Duration.ofMillis(350);
     private static final Duration CLICK_DEBOUNCE = Duration.ofMillis(300);
     private static final Duration NAVIGATION_DEBOUNCE = Duration.ofMillis(750);
 
@@ -123,7 +123,7 @@ final class CaptureEventPipeline implements AutoCloseable {
     }
 
     synchronized int eventCount() {
-        return Math.toIntExact(sequence);
+        return store.read().events().size();
     }
 
     @Override
@@ -142,7 +142,6 @@ final class CaptureEventPipeline implements AutoCloseable {
         }
         Instant now = Instant.now();
         List<BrowserSignal> ready = new ArrayList<>();
-        collectReady(pendingInputs, now.minus(INPUT_DEBOUNCE), ready);
         collectReady(pendingClicks, now.minus(CLICK_DEBOUNCE), ready);
         flushOrdered(ready);
     }
@@ -205,6 +204,8 @@ final class CaptureEventPipeline implements AutoCloseable {
                     target(signal).summary(), List.of());
             case "verification" -> emitVerification(signal);
             case "locator_preference" -> rememberLocatorPreference(signal);
+            case "step_update" -> updateStep(signal);
+            case "step_delete" -> deleteStep(signal);
             case "window_open" -> append(new CaptureEvent.WindowEvent(
                     context(signal), CaptureEvent.WindowAction.OPEN_TAB, logicalWindow(signal.browsingContextId())),
                     RedactionSummary.empty(), List.of());
@@ -380,7 +381,7 @@ final class CaptureEventPipeline implements AutoCloseable {
                 page.context(),
                 EventContext.ReplayStatus.NOT_REPLAYED,
                 List.of(),
-                extensions);
+                contextExtensions(signal, page, extensions));
     }
 
     private void emitContextTransitions(BrowserSignal signal, SafePage page) {
@@ -431,7 +432,8 @@ final class CaptureEventPipeline implements AutoCloseable {
     private SafePage page(BrowserSignal signal) {
         var safeUrl = privacy.sanitizeUrl(string(signal.page().get("url")));
         var safeTitle = privacy.sanitizeText(string(signal.page().get("title")));
-        RedactionSummary summary = safeUrl.summary().merge(safeTitle.summary());
+        var safeDom = privacy.sanitizeText(string(signal.page().get("domSnapshot")));
+        RedactionSummary summary = safeUrl.summary().merge(safeTitle.summary()).merge(safeDom.summary());
         List<String> frames = list(signal.page().get("framePath")).stream()
                 .map(privacy::sanitizeText)
                 .map(safe -> safe.value().isBlank() ? "frame" : safe.value())
@@ -443,7 +445,7 @@ final class CaptureEventPipeline implements AutoCloseable {
                 frames,
                 integer(signal.page().get("width"), 0),
                 integer(signal.page().get("height"), 0));
-        return new SafePage(page, summary);
+        return new SafePage(page, summary, safeDom.value());
     }
 
     private SafeTarget target(BrowserSignal signal) {
@@ -512,6 +514,42 @@ final class CaptureEventPipeline implements AutoCloseable {
         locatorPreferences.put(logicalElementId, new LocatorPreference(strategy, expression));
     }
 
+    private void updateStep(BrowserSignal signal) {
+        String clientActionId = privacy.sanitizeText(signal.dataString("clientActionId")).value();
+        String description = privacy.sanitizeText(signal.dataString("description")).value();
+        if (clientActionId.isBlank() || description.isBlank()) {
+            warningConsumer.accept("A browser step edit was ignored because it was incomplete.");
+            return;
+        }
+        store.updateEvents(events -> events.stream()
+                .map(event -> clientActionId.equals(extensionText(event.context(), "clientActionId"))
+                        ? withContext(event, withExtension(event.context(), "userDescription", description))
+                        : event)
+                .toList());
+    }
+
+    private void deleteStep(BrowserSignal signal) {
+        String clientActionId = privacy.sanitizeText(signal.dataString("clientActionId")).value();
+        if (clientActionId.isBlank()) {
+            warningConsumer.accept("A browser step deletion was ignored because it was incomplete.");
+            return;
+        }
+        Set<String> removedReferenceIds = new LinkedHashSet<>();
+        store.updateEvents(events -> events.stream()
+                .filter(event -> {
+                    boolean remove = clientActionId.equals(extensionText(event.context(), "clientActionId"));
+                    if (remove) {
+                        eventReferences(event).forEach(reference -> removedReferenceIds.add(reference.id()));
+                    }
+                    return !remove;
+                })
+                .toList());
+        if (!removedReferenceIds.isEmpty()) {
+            classifiedValues.removeIf(value -> removedReferenceIds.contains(value.reference().id()));
+            dataWriter.write(dataPath, classifiedValues);
+        }
+    }
+
     private List<LocatorCandidate> applyLocatorPreference(
             String logicalElementId,
             List<LocatorCandidate> locators) {
@@ -543,6 +581,94 @@ final class CaptureEventPipeline implements AutoCloseable {
             RedactionSummary summary,
             List<ExternalTestDataReference> references) {
         store.append(event, references, summary);
+    }
+
+    private Map<String, JsonNode> contextExtensions(
+            BrowserSignal signal,
+            SafePage page,
+            Map<String, JsonNode> extensions) {
+        Map<String, JsonNode> result = new LinkedHashMap<>();
+        String clientActionId = privacy.sanitizeText(signal.dataString("clientActionId")).value();
+        if (!clientActionId.isBlank()) {
+            result.put("clientActionId", StringNode.valueOf(clientActionId));
+        }
+        if (!page.domSnapshot().isBlank()) {
+            result.put("domSnapshot", StringNode.valueOf(page.domSnapshot()));
+        }
+        result.putAll(extensions);
+        return result;
+    }
+
+    private static EventContext withExtension(EventContext context, String name, String value) {
+        Map<String, JsonNode> extensions = new LinkedHashMap<>(context.extensions());
+        extensions.put(name, StringNode.valueOf(value));
+        return new EventContext(
+                context.sequence(),
+                context.timestamp(),
+                context.page(),
+                context.replayStatus(),
+                context.evidence(),
+                extensions);
+    }
+
+    private static String extensionText(EventContext context, String name) {
+        JsonNode value = context.extensions().get(name);
+        return value == null ? "" : value.asText("");
+    }
+
+    private static CaptureEvent withContext(CaptureEvent event, EventContext context) {
+        return switch (event) {
+            case CaptureEvent.NavigationEvent value -> new CaptureEvent.NavigationEvent(
+                    context, value.action(), value.targetUrl());
+            case CaptureEvent.ClickEvent value -> new CaptureEvent.ClickEvent(
+                    context, value.target(), value.button(), value.clickCount());
+            case CaptureEvent.TypeEvent value -> new CaptureEvent.TypeEvent(context, value.target(), value.value());
+            case CaptureEvent.ClearEvent value -> new CaptureEvent.ClearEvent(context, value.target());
+            case CaptureEvent.SelectEvent value -> new CaptureEvent.SelectEvent(
+                    context, value.target(), value.mode(), value.value());
+            case CaptureEvent.ToggleEvent value -> new CaptureEvent.ToggleEvent(
+                    context, value.target(), value.checked());
+            case CaptureEvent.UploadEvent value -> new CaptureEvent.UploadEvent(
+                    context,
+                    value.target(),
+                    value.file(),
+                    value.safeFileName(),
+                    value.mediaType(),
+                    value.sizeBytes());
+            case CaptureEvent.KeyboardEvent value -> new CaptureEvent.KeyboardEvent(
+                    context, value.target(), value.keys());
+            case CaptureEvent.WindowEvent value -> new CaptureEvent.WindowEvent(
+                    context, value.action(), value.logicalWindowId());
+            case CaptureEvent.FrameEvent value -> new CaptureEvent.FrameEvent(
+                    context, value.action(), value.logicalFrameId(), value.target());
+            case CaptureEvent.AlertEvent value -> new CaptureEvent.AlertEvent(context, value.action(), value.text());
+            case CaptureEvent.WaitEvent value -> new CaptureEvent.WaitEvent(
+                    context, value.condition(), value.timeout(), value.target(), value.expected());
+            case CaptureEvent.VerificationEvent value -> new CaptureEvent.VerificationEvent(
+                    context, value.verification(), value.target(), value.expected(), value.negated());
+        };
+    }
+
+    private static List<ExternalTestDataReference> eventReferences(CaptureEvent event) {
+        if (event instanceof CaptureEvent.TypeEvent value) {
+            return List.of(value.value());
+        }
+        if (event instanceof CaptureEvent.SelectEvent value) {
+            return List.of(value.value());
+        }
+        if (event instanceof CaptureEvent.UploadEvent value) {
+            return List.of(value.file());
+        }
+        if (event instanceof CaptureEvent.AlertEvent value && value.text() != null) {
+            return List.of(value.text());
+        }
+        if (event instanceof CaptureEvent.WaitEvent value && value.expected() != null) {
+            return List.of(value.expected());
+        }
+        if (event instanceof CaptureEvent.VerificationEvent value && value.expected() != null) {
+            return List.of(value.expected());
+        }
+        return List.of();
     }
 
     private String logicalWindow(String contextId) {
@@ -665,7 +791,7 @@ final class CaptureEventPipeline implements AutoCloseable {
         }
     }
 
-    private record SafePage(PageContext context, RedactionSummary summary) {
+    private record SafePage(PageContext context, RedactionSummary summary, String domSnapshot) {
     }
 
     private record SafeTarget(ElementSnapshot snapshot, RedactionSummary summary) {

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java
@@ -71,6 +71,7 @@ class ManagedCaptureRecorder {
     private SHAFT.GUI.WebDriver shaftDriver;
     private WebDriver driver;
     private BrowserEventCollector collector;
+    private BrowserEventSink eventSink;
     private CaptureSessionStore store;
     private CaptureEventPipeline pipeline;
     private String currentUrl;
@@ -119,12 +120,15 @@ class ManagedCaptureRecorder {
                     privacyPolicy,
                     value -> currentUrl = value,
                     this::warn);
+            startEventSink();
             startCollector(driver);
             driver.navigate().to(request.targetUrl());
             if (driver instanceof JavascriptExecutor javascript) {
                 javascript.executeScript(
                         com.shaft.capture.collector.BrowserEventScript.fallbackInstallation(
-                                request.options().testIdAttributes()));
+                                request.options().testIdAttributes(),
+                                eventSinkEndpoint(),
+                                eventSinkToken()));
             }
             pipeline.accept(BrowserSignal.generated(
                     "navigation",
@@ -545,16 +549,44 @@ class ManagedCaptureRecorder {
         try {
             collector = new CompositeBrowserEventCollector(List.of(
                     new BidiBrowserEventCollector(activeDriver, request.options().testIdAttributes()),
-                    new PollingBrowserEventCollector(activeDriver, false, request.options().testIdAttributes())));
+                    new PollingBrowserEventCollector(
+                            activeDriver,
+                            false,
+                            request.options().testIdAttributes(),
+                            eventSinkEndpoint(),
+                            eventSinkToken())));
             collector.start(this::acceptSignal, this::warn);
         } catch (RuntimeException exception) {
             if (collector != null) {
                 collector.close();
             }
             warn("WebDriver BiDi initialization failed; the compatibility listener will be used.");
-            collector = new PollingBrowserEventCollector(activeDriver, true, request.options().testIdAttributes());
+            collector = new PollingBrowserEventCollector(
+                    activeDriver,
+                    true,
+                    request.options().testIdAttributes(),
+                    eventSinkEndpoint(),
+                    eventSinkToken());
             collector.start(this::acceptSignal, this::warn);
         }
+    }
+
+    private void startEventSink() {
+        try {
+            eventSink = new BrowserEventSink(this::acceptSignal, this::warn);
+            eventSink.start();
+        } catch (RuntimeException exception) {
+            eventSink = null;
+            warn("The browser event sink could not start; fallback capture may miss fast navigations.");
+        }
+    }
+
+    private String eventSinkEndpoint() {
+        return eventSink == null ? "" : eventSink.endpoint();
+    }
+
+    private String eventSinkToken() {
+        return eventSink == null ? "" : eventSink.eventToken();
     }
 
     void acceptSignal(BrowserSignal signal) {
@@ -639,6 +671,15 @@ class ManagedCaptureRecorder {
                 warn("The browser event collector had already stopped.");
             } finally {
                 collector = null;
+            }
+        }
+        if (eventSink != null) {
+            try {
+                eventSink.close();
+            } catch (RuntimeException ignored) {
+                warn("The browser event sink had already stopped.");
+            } finally {
+                eventSink = null;
             }
         }
         if (pipeline != null) {

--- a/shaft-capture/src/main/java/com/shaft/capture/storage/CaptureSessionStore.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/storage/CaptureSessionStore.java
@@ -111,6 +111,19 @@ public final class CaptureSessionStore {
     }
 
     /**
+     * Atomically rewrites the event list.
+     *
+     * @param operation event list rewrite
+     * @return updated session
+     */
+    public CaptureSession updateEvents(java.util.function.UnaryOperator<List<CaptureEvent>> operation) {
+        if (operation == null) {
+            throw new IllegalArgumentException("Capture event update operation is required.");
+        }
+        return update(session -> session.withEvents(operation.apply(session.events())));
+    }
+
+    /**
      * Completes and atomically publishes the session.
      *
      * @param stoppedAt stop time

--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -1,4 +1,4 @@
-(channel) => {
+(channel, sink) => {
   if (globalThis.__shaftCaptureInstalled) {
     return;
   }
@@ -7,6 +7,7 @@
 
   const testIdAttributes = ["data-testid", "data-test", "data-qa"];
   const STORAGE_KEY = "shaft.capture.recorder.ui";
+  const eventSink = sink && typeof sink === "object" ? sink : {};
   const text = value => String(value || "").replace(/\s+/g, " ").trim().slice(0, 500);
   const valueText = value => String(value == null ? "" : value).slice(0, 1000);
   const dynamic = value =>
@@ -36,12 +37,16 @@
     actions: [],
     pendingSignals: [],
     nextId: 1,
+    instanceId: "",
+    currentInputActionKey: "",
     lastUrl: String(location.href || ""),
     ...persisted()
   };
   uiState.actions = Array.isArray(uiState.actions) ? uiState.actions.slice(-80) : [];
   uiState.pendingSignals = Array.isArray(uiState.pendingSignals) ? uiState.pendingSignals.slice(-200) : [];
   uiState.nextId = Number(uiState.nextId || uiState.actions.length + 1);
+  uiState.instanceId = text(uiState.instanceId) || String(Date.now()) + "-" + Math.random().toString(36).slice(2);
+  uiState.currentInputActionKey = text(uiState.currentInputActionKey);
   uiState.assertionMode = Boolean(uiState.assertionMode);
   uiState.locatorMode = Boolean(uiState.locatorMode);
   uiState.locatorPreferences = uiState.locatorPreferences && typeof uiState.locatorPreferences === "object"
@@ -74,10 +79,26 @@
         actions: uiState.actions.slice(-80),
         pendingSignals: uiState.pendingSignals.slice(-200),
         nextId: uiState.nextId,
+        instanceId: uiState.instanceId,
+        currentInputActionKey: uiState.currentInputActionKey,
         lastUrl: uiState.lastUrl
       }));
     } catch (ignored) {
       // Storage can be unavailable in sandboxed frames.
+    }
+  };
+  const postToSink = payload => {
+    if (!eventSink.url || !eventSink.token || typeof fetch !== "function") return;
+    try {
+      fetch(String(eventSink.url), {
+        method: "POST",
+        mode: "no-cors",
+        keepalive: true,
+        headers: {"Content-Type": "text/plain"},
+        body: JSON.stringify({token: String(eventSink.token), payload})
+      }).catch(() => {});
+    } catch (ignored) {
+      // Fallback polling still drains the in-page queue.
     }
   };
   const send = payload => {
@@ -86,6 +107,7 @@
     uiState.pendingSignals = uiState.pendingSignals.slice(-200);
     persist();
     globalThis.__shaftCaptureQueue.push(payload);
+    postToSink(payload);
     if (typeof channel === "function") {
       channel(JSON.stringify(payload));
     }
@@ -111,12 +133,30 @@
     }
     return path;
   };
+  const domSnapshot = () => {
+    try {
+      const root = document.documentElement;
+      if (!root) return "";
+      const clone = root.cloneNode(true);
+      clone.querySelectorAll("script, style, #shaft-capture-ui, #shaft-capture-ui-style, "
+        + "#shaft-capture-locator-highlight").forEach(element => element.remove());
+      clone.querySelectorAll("input, textarea, select").forEach(element => {
+        element.removeAttribute("value");
+        element.removeAttribute("checked");
+        element.removeAttribute("selected");
+      });
+      return String(clone.outerHTML || "").replace(/\s+/g, " ").trim().slice(0, 20000);
+    } catch (ignored) {
+      return "";
+    }
+  };
   const page = () => ({
     url: String(location.href || ""),
     title: text(document.title),
     framePath: framePath(),
     width: Number(globalThis.innerWidth || 0),
-    height: Number(globalThis.innerHeight || 0)
+    height: Number(globalThis.innerHeight || 0),
+    domSnapshot: domSnapshot()
   });
   const visibleLocation = () => text(String(location.href || "").split(/[?#]/)[0]);
   const sendControl = (action, data) =>
@@ -172,6 +212,7 @@
     checkpoint: `<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="M12 8v8"></path><path d="M8 12h8"></path></svg>`,
     stop: `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 7h10v10H7z"></path></svg>`,
     edit: `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 20h9"></path><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"></path></svg>`,
+    delete: `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18"></path><path d="M8 6V4h8v2"></path><path d="M6 6l1 14h10l1-14"></path><path d="M10 11v5"></path><path d="M14 11v5"></path></svg>`,
     pin: `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 17v5"></path><path d="M5 17h14"></path><path d="m8 4 8 8"></path><path d="M7 5l5-3 5 5-3 5Z"></path></svg>`
   })[name] || "";
   const describe = (kind, target, data) => {
@@ -193,13 +234,33 @@
         return "Capture " + kind + " on " + name;
     }
   };
-  const announce = value => {
+  const clientActionId = item => uiState.instanceId + "-" + item.id;
+  const announce = (value, mergeKey) => {
     const description = text(value);
-    if (!description) return;
-    uiState.actions.push({id: uiState.nextId++, text: description, timestamp: Date.now()});
+    if (!description) return null;
+    if (mergeKey && uiState.currentInputActionKey === mergeKey) {
+      let existing = null;
+      for (let index = uiState.actions.length - 1; index >= 0; index--) {
+        if (uiState.actions[index].mergeKey === mergeKey) {
+          existing = uiState.actions[index];
+          break;
+        }
+      }
+      if (existing) {
+        existing.text = description;
+        existing.timestamp = Date.now();
+        persist();
+        renderActions();
+        return existing;
+      }
+    }
+    const item = {id: uiState.nextId++, text: description, timestamp: Date.now(), mergeKey: mergeKey || ""};
+    uiState.actions.push(item);
     uiState.actions = uiState.actions.slice(-80);
+    uiState.currentInputActionKey = mergeKey || "";
     persist();
     renderActions();
+    return item;
   };
   const count = selector => {
     try {
@@ -485,7 +546,15 @@
       const action = data || {};
       const readiness = readinessFor(kind, target);
       if (readiness) setReadiness(readiness.state, readiness.warning);
-      announce(describe(kind, target, action));
+      const mergeKey = kind === "input" ? "input:" + target.logicalElementId : "";
+      const item = announce(describe(kind, target, action), mergeKey);
+      if (kind !== "input") {
+        uiState.currentInputActionKey = "";
+        persist();
+      }
+      if (item) {
+        action.clientActionId = clientActionId(item);
+      }
       send({kind, page: page(), target, data: action});
     }
   };
@@ -744,7 +813,7 @@
       }
       #shaft-capture-actions div {
         display: grid;
-        grid-template-columns: 1fr 32px;
+        grid-template-columns: 1fr 32px 32px;
         gap: 6px;
         align-items: start;
       }
@@ -848,7 +917,29 @@
     if (!updated || updated === item.text) return;
     item.text = updated;
     persist();
-    sendCheckpoint("Edited captured action " + item.id + ": " + updated, "USER_MARKER");
+    send({
+      kind: "step_update",
+      page: page(),
+      data: {
+        clientActionId: clientActionId(item),
+        description: updated
+      }
+    });
+    renderActions();
+  };
+  const deleteAction = item => {
+    uiState.actions = uiState.actions.filter(action => action.id !== item.id);
+    if (item.mergeKey && uiState.currentInputActionKey === item.mergeKey) {
+      uiState.currentInputActionKey = "";
+    }
+    persist();
+    send({
+      kind: "step_delete",
+      page: page(),
+      data: {
+        clientActionId: clientActionId(item)
+      }
+    });
     renderActions();
   };
   function renderActions() {
@@ -866,7 +957,13 @@
       edit.title = "Edit captured action";
       edit.setAttribute("aria-label", "Edit captured action");
       edit.addEventListener("click", () => editAction(item));
-      body.append(labelNode, edit);
+      const remove = document.createElement("button");
+      remove.type = "button";
+      remove.innerHTML = icon("delete");
+      remove.title = "Delete captured action";
+      remove.setAttribute("aria-label", "Delete captured action");
+      remove.addEventListener("click", () => deleteAction(item));
+      body.append(labelNode, edit, remove);
       row.append(body);
       list.appendChild(row);
     });

--- a/shaft-capture/src/test/java/com/shaft/capture/collector/CaptureCollectorUtilityTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/collector/CaptureCollectorUtilityTest.java
@@ -61,6 +61,9 @@ class CaptureCollectorUtilityTest {
         assertTrue(BrowserEventScript.fallbackInstallation().contains("return ("));
         assertTrue(BrowserEventScript.fallbackDrain().contains("__shaftCaptureQueue"));
         assertTrue(BrowserEventScript.fallbackDrain().contains("__shaftCaptureDrain"));
+        assertTrue(BrowserEventScript.fallbackInstallation(
+                List.of("data-pw"), "http://127.0.0.1:1234/event", "token")
+                .contains("http://127.0.0.1:1234/event"));
         assertTrue(BrowserEventScript.preloadFunction(List.of("data-pw"))
                 .contains("const testIdAttributes = [\"data-pw\"];"));
         assertTrue(BrowserEventScript.fallbackInstallation(List.of("data-\"quoted\\path"))
@@ -73,6 +76,10 @@ class CaptureCollectorUtilityTest {
         assertTrue(preload.contains("Stop recording"));
         assertTrue(preload.contains("globalThis.top === globalThis"));
         assertTrue(preload.contains("pendingSignals"));
+        assertTrue(preload.contains("domSnapshot"));
+        assertTrue(preload.contains("kind: \"step_update\""));
+        assertTrue(preload.contains("kind: \"step_delete\""));
+        assertTrue(preload.contains("Delete captured action"));
         assertTrue(preload.contains("pagehide"));
         assertTrue(preload.contains("beforeunload"));
 

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
@@ -186,6 +186,109 @@ class CaptureEventPipelineTest {
         assertTrue(preferred.signals().contains(LocatorCandidate.LocatorSignal.USER_PROVIDED));
     }
 
+    @Test
+    void keepsSlowTypingAsOneTypeEventUntilSpecialKey(@TempDir Path temp) throws Exception {
+        Path output = temp.resolve("session.json");
+        CaptureSessionStore store = startedStore(output);
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store, output, CapturePrivacyPolicy.defaults(), ignored -> {
+                }, ignored -> {
+                });
+
+        pipeline.accept(signal("input", START, usernameTarget(),
+                Map.of("value", "a", "clientActionId", "ui-1"), Map.of()));
+        Thread.sleep(500);
+        pipeline.accept(signal("input", START.plusSeconds(1), usernameTarget(),
+                Map.of("value", "alice", "clientActionId", "ui-1"), Map.of()));
+        pipeline.accept(signal("keyboard", START.plusSeconds(2), usernameTarget(),
+                Map.of("keys", List.of("ENTER")), Map.of()));
+        pipeline.close();
+
+        List<CaptureEvent> events = store.read().events();
+        assertEquals(2, events.size());
+        assertInstanceOf(CaptureEvent.TypeEvent.class, events.get(0));
+        assertEquals("ui-1", events.get(0).context().extensions().get("clientActionId").asText());
+        assertInstanceOf(CaptureEvent.KeyboardEvent.class, events.get(1));
+        String dataJson = Files.readString(output.getParent().resolve("capture-data.json"),
+                StandardCharsets.UTF_8);
+        assertFalse(dataJson.contains("\"a\""));
+        assertTrue(dataJson.contains("alice"));
+    }
+
+    @Test
+    void writesActionsBeforeStopAndStoresSanitizedDomEvidence(@TempDir Path temp) {
+        Path output = temp.resolve("session.json");
+        CaptureSessionStore store = startedStore(output);
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store, output, CapturePrivacyPolicy.defaults(), ignored -> {
+                }, ignored -> {
+                });
+
+        pipeline.accept(signal("click", START, buttonTarget(),
+                Map.of("button", 0, "clickCount", 1, "clientActionId", "ui-2"),
+                Map.of("domSnapshot", "<html><body><button id=\"submit\">Save</button>"
+                        + "<span>bearer abcdefghijklmnop</span></body></html>")));
+        pipeline.accept(signal("navigation", START.plusMillis(1), Map.of(),
+                Map.of("action", "OPEN"), Map.of("url", "https://example.test/next")));
+
+        CaptureSession session = store.read();
+        assertEquals(2, session.events().size());
+        String dom = session.events().getFirst().context().extensions().get("domSnapshot").asText();
+        assertTrue(dom.contains("button id=\"submit\""));
+        assertFalse(dom.contains("abcdefghijklmnop"));
+    }
+
+    @Test
+    void editsAndDeletesPersistedStepsByClientActionId(@TempDir Path temp) {
+        Path output = temp.resolve("session.json");
+        CaptureSessionStore store = startedStore(output);
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store, output, CapturePrivacyPolicy.defaults(), ignored -> {
+                }, ignored -> {
+                });
+
+        pipeline.accept(signal("click", START, buttonTarget(),
+                Map.of("button", 0, "clickCount", 1, "clientActionId", "ui-3"), Map.of()));
+        pipeline.accept(signal("navigation", START.plusMillis(1), Map.of(),
+                Map.of("action", "OPEN"), Map.of("url", "https://example.test/next")));
+        pipeline.accept(signal("step_update", START.plusMillis(2), Map.of(),
+                Map.of("clientActionId", "ui-3", "description", "Click primary submit"), Map.of()));
+
+        CaptureSession updated = store.read();
+        assertEquals("Click primary submit",
+                updated.events().getFirst().context().extensions().get("userDescription").asText());
+
+        pipeline.accept(signal("step_delete", START.plusMillis(3), Map.of(),
+                Map.of("clientActionId", "ui-3"), Map.of()));
+
+        CaptureSession deleted = store.read();
+        assertEquals(1, deleted.events().size());
+        assertInstanceOf(CaptureEvent.NavigationEvent.class, deleted.events().getFirst());
+    }
+
+    @Test
+    void deletingTypedStepPrunesExternalDataReference(@TempDir Path temp) throws Exception {
+        Path output = temp.resolve("session.json");
+        CaptureSessionStore store = startedStore(output);
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store, output, CapturePrivacyPolicy.defaults(), ignored -> {
+                }, ignored -> {
+                });
+
+        pipeline.accept(signal("input", START, usernameTarget(),
+                Map.of("value", "alice", "clientActionId", "ui-4"), Map.of()));
+        pipeline.accept(signal("step_delete", START.plusMillis(1), Map.of(),
+                Map.of("clientActionId", "ui-4"), Map.of()));
+
+        CaptureSession deleted = store.read();
+        assertTrue(deleted.events().isEmpty());
+        assertTrue(deleted.dataReferences().isEmpty());
+        assertEquals(0, pipeline.eventCount());
+        String dataJson = Files.readString(output.getParent().resolve("capture-data.json"),
+                StandardCharsets.UTF_8);
+        assertFalse(dataJson.contains("alice"));
+    }
+
     private static CaptureSessionStore startedStore(Path output) {
         CaptureSessionStore store = new CaptureSessionStore(output);
         store.start(CaptureSession.start(

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -208,16 +208,17 @@ final class AssistantCommand {
     static String commandHelp() {
         StringBuilder help = new StringBuilder("SHAFT Assistant commands:");
         for (CommandDefinition definition : VISIBLE_COMMANDS) {
-            help.append("\n")
+            help.append("\n\n**")
                     .append(definition.canonical())
-                    .append(" - ")
+                    .append("** - ")
                     .append(definition.summary());
             if (!definition.aliases().isEmpty()) {
                 help.append("\n  Aliases: ")
                         .append(String.join(", ", definition.aliases()));
             }
-            help.append("\n  Example: ")
-                    .append(definition.example());
+            help.append("\n  Example:\n```text\n")
+                    .append(definition.example())
+                    .append("\n```");
         }
         return help.toString();
     }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java
@@ -381,7 +381,7 @@ final class AssistantMarkdown {
         if (!outputPath.isBlank()) {
             sections.add("**Output:** `" + outputPath + "`");
             if ("COMPLETED".equalsIgnoreCase(string(object, "state", ""))) {
-                sections.add("Run `/codegen " + outputPath + "` to generate SHAFT Java from this recording.");
+                sections.add("Run codegen next:\n\n" + fence("text", "/codegen " + outputPath));
             }
         }
         String warnings = warnings(object);
@@ -594,7 +594,7 @@ final class AssistantMarkdown {
         if (!outputPath.isBlank()) {
             sections.add("**Output:** `" + outputPath + "`");
             if ("COMPLETED".equalsIgnoreCase(string(object, "state", ""))) {
-                sections.add("Run `/codegen " + outputPath + "` to generate SHAFT Java from this recording.");
+                sections.add("Run codegen next:\n\n" + fence("text", "/codegen " + outputPath));
             }
         }
         String currentUrl = string(object, "currentUrl", "");

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
@@ -506,20 +506,24 @@ class AssistantCommandTest {
     @Test
     void commandHelpShowsOnlyTestedValidCommandFamilies() {
         AssistantCommand.Invocation help = command("/commands");
+        String response = help.localResponse();
 
         assertAll(
                 () -> assertTrue(help.isLocal()),
-                () -> assertTrue(help.localResponse().contains("/codegen")),
-                () -> assertTrue(help.localResponse().contains("/record-web")),
-                () -> assertTrue(help.localResponse().contains("/record-mobile")),
-                () -> assertTrue(help.localResponse().contains("/doctor")),
-                () -> assertTrue(help.localResponse().contains("/guide")),
-                () -> assertTrue(help.localResponse().contains("/guardrails")),
-                () -> assertTrue(help.localResponse().contains("/browser")),
-                () -> assertTrue(help.localResponse().contains("/mobile")),
-                () -> assertTrue(help.localResponse().contains("/project")),
-                () -> assertFalse(help.localResponse().contains("/commands")),
-                () -> assertFalse(help.localResponse().contains("/assistant")));
+                () -> assertTrue(response.contains("**/codegen**")),
+                () -> assertTrue(response.contains("**/record-web**")),
+                () -> assertTrue(response.contains("**/record-mobile**")),
+                () -> assertTrue(response.contains("**/doctor**")),
+                () -> assertTrue(response.contains("**/guide**")),
+                () -> assertTrue(response.contains("**/guardrails**")),
+                () -> assertTrue(response.contains("**/browser**")),
+                () -> assertTrue(response.contains("**/mobile**")),
+                () -> assertTrue(response.contains("**/project**")),
+                () -> assertTrue(response.contains("```text\n/codegen recordings/intellij-capture.json\n```")),
+                () -> assertTrue(response.contains("```text\n/record-web https://example.com\n```")),
+                () -> assertFalse(response.contains("Example: /codegen")),
+                () -> assertFalse(response.contains("/commands -")),
+                () -> assertFalse(response.contains("/assistant -")));
     }
 
     @Test

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantMarkdownTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantMarkdownTest.java
@@ -172,7 +172,8 @@ class AssistantMarkdownTest {
         assertAll(
                 () -> assertTrue(markdown.contains("**State:** COMPLETED")),
                 () -> assertTrue(markdown.contains("**Output:** `recordings/intellij-capture.json`")),
-                () -> assertTrue(markdown.contains("Run `/codegen recordings/intellij-capture.json`")));
+                () -> assertTrue(markdown.contains("Run codegen next:")),
+                () -> assertTrue(markdown.contains("```text\n/codegen recordings/intellij-capture.json\n```")));
     }
 
 

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpCaptureCodeBlockService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpCaptureCodeBlockService.java
@@ -113,15 +113,9 @@ final class McpCaptureCodeBlockService {
             if (!pom.actions().isEmpty()) {
                 blocks.add(actionSequenceBlock(pom.actions()));
             }
-            if (!pom.locators().isEmpty() || !pom.actions().isEmpty()) {
-                blocks.add(pomInsertionGuideBlock(driver, driverType, pom));
-            } else {
-                blocks.add(manualMappingWarningBlock());
-            }
             if (targetSource != null || (insertAfter != null && !insertAfter.isBlank())) {
                 blocks.addAll(targetInsertionBlocks(sourcePath, targetSource, insertAfter, driver));
             }
-            blocks.add(agentIntegrationBlock());
             return List.copyOf(blocks);
         } catch (IOException exception) {
             throw new IllegalArgumentException("Generated Capture source could not be read.", exception);
@@ -163,49 +157,7 @@ final class McpCaptureCodeBlockService {
                     List.of(),
                     plan.warnings()));
         }
-        blocks.add(new McpCodeBlock(
-                "capture-target-insertion-guide",
-                "Record-at-target insertion guide",
-                McpCodeBlock.Kind.PROVIDER_ADVISORY,
-                "text",
-                List.of(),
-                """
-                        record-at-target insertion map
-                        Target source: %s
-                        Insert after: %s
-                        Add imports and locator fields from capture-target-locator-fields when the target class does not already define them.
-                        Paste capture-target-action-snippet at the anchor, then adapt helper/data calls to local suite conventions.
-                        No source file was edited by this workflow.
-                        """.formatted(plan.targetSource(), plan.insertAfter()),
-                "Use these blocks as an approved edit plan for the selected source target.",
-                plan.anchorFound(),
-                List.of(),
-                plan.warnings()));
         return blocks;
-    }
-
-    private static McpCodeBlock agentIntegrationBlock() {
-        return new McpCodeBlock(
-                "capture-agent-integration",
-                "Agent repository integration plan",
-                McpCodeBlock.Kind.PROVIDER_ADVISORY,
-                "text",
-                List.of(),
-                """
-                        The calling AI agent may use its own LLM and repository access to integrate this capture.
-                        After capture_stop, present the generated result and ask the user to choose either a Java
-                        snippet or repository insertion. Snippet mode should show the capture-full-class block as a
-                        fenced java class with imports, locator fields, setup, actions, and teardown.
-                        If the project has Page Object classes, move stable locator fields into the matching page class,
-                        place the action lines into page methods, and keep the test method as orchestration only.
-                        Preserve repository instructions, naming, setup/teardown, and existing test data conventions.
-                        Apply the smallest source edit that compiles; do not paste a generic generated class when a
-                        local Page Object pattern is already present.
-                        """,
-                "AI agent: inspect the current codebase, then insert the generated code into the most relevant classes.",
-                true,
-                List.of(),
-                List.of());
     }
 
     private static McpCodeBlock locatorInventoryBlock(List<String> imports, List<LocatorCandidate> locators) {
@@ -256,53 +208,6 @@ final class McpCaptureCodeBlockService {
                 List.of());
     }
 
-    private static McpCodeBlock pomInsertionGuideBlock(
-            String driver,
-            String driverType,
-            PomCandidates pom) {
-        String locatorSummary = pom.locators().isEmpty()
-                ? "No concrete locator candidates were extracted."
-                : "Use capture-pom-locator-inventory for " + pom.locators().size() + " locator candidate(s).";
-        String actionSummary = pom.actions().isEmpty()
-                ? "No concrete action lines were extracted."
-                : "Use capture-pom-action-sequence for " + pom.actions().size() + " action/checkpoint line(s).";
-        return new McpCodeBlock(
-                "capture-pom-insertion-guide",
-                "Capture-to-POM insertion guide",
-                McpCodeBlock.Kind.PROVIDER_ADVISORY,
-                "text",
-                List.of(),
-                """
-                        Capture-to-POM insertion map
-                        Locator fields -> page class: %s Paste stable locator candidates into the matching Page Object.
-                        Action lines -> page methods: %s Move replay actions into intent-named methods that own a %s named %s.
-                        Orchestration -> tests: keep the generated test method as scenario flow only; call page methods from tests.
-                        Preserve repository setup, teardown, data loading, assertions, and naming conventions.
-                        Do not auto-edit user repositories from MCP output; use these blocks as deterministic guidance.
-                        """.formatted(locatorSummary, actionSummary, driverType, driver),
-                "Use before editing repository files so generated replay code lands in Page Object seams.",
-                false,
-                List.of(),
-                List.of());
-    }
-
-    private static McpCodeBlock manualMappingWarningBlock() {
-        return new McpCodeBlock(
-                "capture-pom-manual-mapping-warning",
-                "Manual Page Object mapping required",
-                McpCodeBlock.Kind.PROVIDER_ADVISORY,
-                "text",
-                List.of(),
-                """
-                        Capture-to-POM extraction did not find concrete locator or action candidates.
-                        Keep the generated full-class and method snippets, then manually map replay steps into
-                        the nearest Page Object fields, page methods, and test orchestration.
-                        """,
-                "Review the generated class manually before repository insertion.",
-                false,
-                List.of(),
-                List.of("POM locator/action extraction found no concrete candidates; manual mapping is required."));
-    }
 
     private static List<String> imports(String source) {
         return source.lines()

--- a/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -58,12 +59,8 @@ class CaptureServiceTest {
         assertTrue(result.codeBlocks().stream()
                 .anyMatch(block -> block.kind() == McpCodeBlock.Kind.TEST_METHOD
                         && block.placement().contains("browser")));
-        assertTrue(result.codeBlocks().stream()
-                .anyMatch(block -> block.id().equals("capture-pom-manual-mapping-warning")
-                        && block.warnings().stream().anyMatch(message -> message.contains("manual mapping"))));
-        assertTrue(result.codeBlocks().stream()
-                .anyMatch(block -> block.id().equals("capture-agent-integration")
-                        && block.code().contains("Page Object")));
+        assertFalse(result.codeBlocks().stream()
+                .anyMatch(block -> block.kind() == McpCodeBlock.Kind.PROVIDER_ADVISORY));
         assertTrue(Files.readString(result.reviewUiPath()).contains("Playwright Codegen Feature Map"));
     }
 
@@ -103,9 +100,8 @@ class CaptureServiceTest {
         }
 
         assertTrue(result.successful(), result.report().unsupportedEvents().toString());
-        assertTrue(result.codeBlocks().stream()
-                .anyMatch(block -> block.id().equals("capture-target-insertion-guide")
-                        && block.code().contains("record-at-target")));
+        assertFalse(result.codeBlocks().stream()
+                .anyMatch(block -> block.kind() == McpCodeBlock.Kind.PROVIDER_ADVISORY));
         assertTrue(result.codeBlocks().stream()
                 .anyMatch(block -> block.id().equals("capture-target-action-snippet")
                         && block.placement().contains("after replayCheckout")));
@@ -137,9 +133,8 @@ class CaptureServiceTest {
                 .anyMatch(block -> block.id().equals("capture-test-method")
                         && block.placement().contains("SHAFT.GUI.Playwright")
                         && block.placement().contains("page")));
-        assertTrue(result.codeBlocks().stream()
-                .anyMatch(block -> block.id().equals("capture-pom-manual-mapping-warning")
-                        && block.warnings().stream().anyMatch(message -> message.contains("manual mapping"))));
+        assertFalse(result.codeBlocks().stream()
+                .anyMatch(block -> block.kind() == McpCodeBlock.Kind.PROVIDER_ADVISORY));
     }
 
     @Test

--- a/shaft-mcp/src/test/java/com/shaft/mcp/McpCaptureCodeBlockServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/McpCaptureCodeBlockServiceTest.java
@@ -17,7 +17,7 @@ class McpCaptureCodeBlockServiceTest {
     Path temp;
 
     @Test
-    void fromGeneratedSourceAddsPomLocatorActionAndInsertionGuidance() throws Exception {
+    void fromGeneratedSourceAddsPomLocatorAndActionBlocksWithoutChatGuidance() throws Exception {
         Path source = writeSource("""
                 package generated.capture;
 
@@ -44,9 +44,8 @@ class McpCaptureCodeBlockServiceTest {
                 "capture-full-class",
                 "capture-test-method",
                 "capture-pom-locator-inventory",
-                "capture-pom-action-sequence",
-                "capture-pom-insertion-guide",
-                "capture-agent-integration"), blocks.stream().map(McpCodeBlock::id).toList());
+                "capture-pom-action-sequence"
+                ), blocks.stream().map(McpCodeBlock::id).toList());
 
         McpCodeBlock locators = block(blocks, "capture-pom-locator-inventory");
         assertEquals(McpCodeBlock.Kind.LOCATOR, locators.kind());
@@ -63,12 +62,7 @@ class McpCaptureCodeBlockServiceTest {
         assertTrue(actions.code().contains("// Checkpoint: checkpoint-1 (ASSERTION). Login verified"));
         assertTrue(actions.placement().contains("page methods"));
 
-        McpCodeBlock guide = block(blocks, "capture-pom-insertion-guide");
-        assertEquals(McpCodeBlock.Kind.PROVIDER_ADVISORY, guide.kind());
-        assertTrue(guide.code().contains("Locator fields -> page class"));
-        assertTrue(guide.code().contains("Action lines -> page methods"));
-        assertTrue(guide.code().contains("Orchestration -> tests"));
-        assertTrue(guide.code().contains("SHAFT.GUI.WebDriver"));
+        assertFalse(blocks.stream().anyMatch(item -> item.kind() == McpCodeBlock.Kind.PROVIDER_ADVISORY));
     }
 
     @Test
@@ -116,9 +110,7 @@ class McpCaptureCodeBlockServiceTest {
         assertTrue(actions.placement().contains("after replayCheckout"));
         assertTrue(actions.warnings().isEmpty(), actions.warnings().toString());
 
-        McpCodeBlock guide = block(blocks, "capture-target-insertion-guide");
-        assertTrue(guide.code().contains("record-at-target"));
-        assertTrue(guide.code().contains("CheckoutTest.java"));
+        assertFalse(blocks.stream().anyMatch(item -> item.id().equals("capture-target-insertion-guide")));
     }
 
     @Test
@@ -143,7 +135,6 @@ class McpCaptureCodeBlockServiceTest {
                 .fromGeneratedSource(source, "page");
 
         assertTrue(block(blocks, "capture-test-method").placement().contains("SHAFT.GUI.Playwright"));
-        assertTrue(block(blocks, "capture-pom-insertion-guide").code().contains("SHAFT.GUI.Playwright"));
     }
 
     @Test
@@ -205,10 +196,7 @@ class McpCaptureCodeBlockServiceTest {
         List<McpCodeBlock> blocks = new McpCaptureCodeBlockService()
                 .fromGeneratedSource(source, "driver");
 
-        assertTrue(blocks.stream().anyMatch(block -> block.id().equals("capture-full-class")));
-        assertTrue(blocks.stream().anyMatch(block -> block.id().equals("capture-agent-integration")));
-        McpCodeBlock warning = block(blocks, "capture-pom-manual-mapping-warning");
-        assertTrue(warning.warnings().stream().anyMatch(message -> message.contains("manual mapping")));
+        assertEquals(List.of("capture-full-class"), blocks.stream().map(McpCodeBlock::id).toList());
     }
 
     private Path writeSource(String source) throws Exception {


### PR DESCRIPTION
## Summary
- keep SHAFT Recorder actions alive across domain changes with an authenticated loopback event sink plus polling fallback
- consolidate text entry until commit/special key, add edit/delete step persistence, and prune deleted typed data
- store sanitized DOM snapshots for codegen/locator evidence and remove capture provider advisory blocks from chat-facing codegen output
- render command examples and post-stop codegen hints as fenced copyable command blocks in IntelliJ Assistant

## Validation
- mvn -pl shaft-capture '-Dtest=CaptureEventPipelineTest,CaptureCollectorUtilityTest' '-DheadlessExecution=true' '-Dallure.generateReport=false' '-Dallure.open=false' '-DautomaticallyOpen=false' '-DopenAllureReportAfterExecution=false' '-DgenerateAllureReportArchive=false' '-DopenExecutionSummaryReportAfterExecution=false' '-DopenLighthouseReportWhileExecution=false' '-Dgpg.skip=true' test
- mvn -pl shaft-mcp '-Dtest=McpCaptureCodeBlockServiceTest,CaptureServiceTest' '-DheadlessExecution=true' '-Dallure.generateReport=false' '-Dallure.open=false' '-DautomaticallyOpen=false' '-DopenAllureReportAfterExecution=false' '-DgenerateAllureReportArchive=false' '-DopenExecutionSummaryReportAfterExecution=false' '-DopenLighthouseReportWhileExecution=false' '-Dtelemetry.enabled=false' '-Dgpg.skip=true' test
- gradle -p shaft-intellij test --tests com.shaft.intellij.ui.AssistantCommandTest --tests com.shaft.intellij.ui.AssistantMarkdownTest '-Dallure.generateReport=false' '-Dallure.open=false' '-DautomaticallyOpen=false' '-DopenAllureReportAfterExecution=false' '-DgenerateAllureReportArchive=false' '-DopenExecutionSummaryReportAfterExecution=false' '-DopenLighthouseReportWhileExecution=false' '-Dtelemetry.enabled=false'
- mvn -pl shaft-capture,shaft-mcp '-DskipTests=true' '-DheadlessExecution=true' '-Dallure.generateReport=false' '-Dallure.open=false' '-DautomaticallyOpen=false' '-DopenAllureReportAfterExecution=false' '-DgenerateAllureReportArchive=false' '-DopenExecutionSummaryReportAfterExecution=false' '-DopenLighthouseReportWhileExecution=false' '-Dtelemetry.enabled=false' '-Dgpg.skip=true' compile

No Allure report or browser-opening report command was run.