### PR TITLE
Improve IntelliJ assistant command UX

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -51,6 +51,8 @@ final class AssistantCommand {
                     - For generated code that performs a specific action: Open a real browser session; call driver_initialize and browser_open_intent with the confirmed targetUrl and userIntent to inspect the live page and locator candidates.
                     - Verify each selected locator by performing the actual action with shaft-mcp element_type, element_click, or natural_act before returning it. Do not publish unverified locators.
                     - Call test_code_guardrails_check on the final Java snippet.
+                    - Do not print full repository files or broad file dumps. Cite inspected files by path and include only the generated or changed code needed for the answer.
+                    - Put every code snippet in fenced code blocks with the correct language.
                     - Return only SHAFT-syntax Java; never return raw Selenium code.
                     """.stripIndent().trim();
     private static final CommandDefinition COMMAND_HELP = new CommandDefinition("/commands", "Show command help",
@@ -90,9 +92,13 @@ final class AssistantCommand {
             List.of("/checkcode"),
             "/guardrails driver.element().click(locator);",
             (command, rest, workingDirectory) -> Invocation.tool("test_code_guardrails_check", guardrails(rest)));
+    private static final CommandDefinition UPGRADE_COMMAND = new CommandDefinition("/upgrade",
+            "Download and run the automated upgrade script",
+            List.of(),
+            "/upgrade .", (command, rest, workingDirectory) -> upgradeScript(rest));
     private static final CommandDefinition PROJECT_COMMAND = new CommandDefinition("/project",
             "Create or upgrade SHAFT projects",
-            List.of("/newshaft", "/upgrade"),
+            List.of("/newshaft"),
             "/project upgrade .", AssistantCommand::project);
     private static final List<CommandDefinition> VISIBLE_COMMANDS = List.of(
             CODEGEN_COMMAND,
@@ -103,6 +109,7 @@ final class AssistantCommand {
             GUARDRAILS_COMMAND,
             BROWSER_COMMAND,
             MOBILE_COMMAND,
+            UPGRADE_COMMAND,
             PROJECT_COMMAND);
     private static final List<CommandDefinition> COMMANDS = List.of(
             COMMAND_HELP,
@@ -136,6 +143,7 @@ final class AssistantCommand {
             new CommandDefinition("/assistant", "List assistant clients",
                     List.of("/agent", "/ask", "/plan", "/clients", "/client"),
                     "/assistant", (command, rest, workingDirectory) -> Invocation.tool("autobot_local_agent_clients", new JsonObject())),
+            UPGRADE_COMMAND,
             PROJECT_COMMAND,
             new CommandDefinition("/mcp", "Run an explicit MCP tool",
                     List.of("/tool", "/call"),
@@ -751,6 +759,27 @@ final class AssistantCommand {
         return Invocation.local("""
                 Creating a SHAFT project writes files. Open the Projects workflow, choose Create SHAFT Project, set `outputDirectory` to `%s`, then press Run and confirm.
                 """.formatted(target).strip());
+    }
+
+    private static Invocation upgradeScript(String projectRoot) {
+        return Invocation.local("""
+                Run this from the project you want to upgrade:
+
+                ```shell
+                %s
+                ```
+                """.formatted(upgradeScriptCommand(firstTokenOrDefault(projectRoot, "."))).strip());
+    }
+
+    private static String upgradeScriptCommand(String projectRoot) {
+        String target = pythonSingleQuoted(projectRoot == null || projectRoot.isBlank() ? "." : projectRoot.trim());
+        return "python -c \"import runpy,sys,urllib.request as u;p='upgrade_to_modular_shaft.py';"
+                + "u.urlretrieve('https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/shaft-upgrader/upgrade_to_modular_shaft.py',p);"
+                + "sys.argv=[p,'--project','" + target + "'];runpy.run_path(p,run_name='__main__')\"";
+    }
+
+    private static String pythonSingleQuoted(String value) {
+        return value.replace("\\", "\\\\").replace("'", "\\'");
     }
 
     private static JsonObject projectUpgrade(String projectRoot) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -91,6 +91,7 @@ final class ShaftAssistantPanel extends JPanel {
     private final JButton saveCloudApiKey;
     private final JLabel cloudKeyStatus;
     private final JBCheckBox allowSourceMutation;
+    private final JBCheckBox verboseAgentOutput;
     private final JBTextArea prompt;
     private final AssistantTranscriptView transcript;
     private final JButton send;
@@ -127,6 +128,7 @@ final class ShaftAssistantPanel extends JPanel {
     private boolean updatingCommandAutocomplete;
     private int localAgentStreamToken;
     private int activeLocalAgentStreamToken = -1;
+    private int killedLocalAgentStreamToken = -1;
     private StringBuilder localAgentOutput;
     private final List<ToolEvidence> toolEvidence = new ArrayList<>();
     private String activeCaptureRecordingPath = AssistantCommand.DEFAULT_CAPTURE_RECORDING_PATH;
@@ -300,6 +302,9 @@ final class ShaftAssistantPanel extends JPanel {
         allowSourceMutation = new JBCheckBox("Allow source edits");
         allowSourceMutation.getAccessibleContext().setAccessibleName("Approve source mutation for Agent mode");
         allowSourceMutation.setToolTipText("Enable only when Agent mode should edit local source files");
+        verboseAgentOutput = new JBCheckBox("Verbose");
+        verboseAgentOutput.getAccessibleContext().setAccessibleName("Show verbose agent output");
+        verboseAgentOutput.setToolTipText("Show live local agent output instead of only the final result");
         prompt = new JBTextArea(6, 40);
         prompt.getAccessibleContext().setAccessibleName("Assistant prompt");
         prompt.getAccessibleContext().setAccessibleDescription(
@@ -439,6 +444,7 @@ final class ShaftAssistantPanel extends JPanel {
         routeRow.add(cloudProvider);
         routeRow.add(cloudModel);
         routeRow.add(allowSourceMutation);
+        routeRow.add(verboseAgentOutput);
 
         JPanel commandActions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
         commandActions.add(commandAutocomplete);
@@ -555,16 +561,26 @@ final class ShaftAssistantPanel extends JPanel {
         if (trigger == '@') {
             return workflowContextSuggestions();
         }
+        if (trigger == '/') {
+            return commandContextSuggestions();
+        }
         if (trigger == '#') {
             return projectContextSuggestions(project, openFileContext);
         }
         return List.of();
     }
 
+    private static List<ContextSuggestion> commandContextSuggestions() {
+        return AssistantCommand.commandHints().stream()
+                .map(hint -> new ContextSuggestion(hint.canonical(), hint.example()))
+                .toList();
+    }
+
     private static List<ContextSuggestion> workflowContextSuggestions() {
         return List.of(
-                new ContextSuggestion("@workflow:record-web", "/record-web "),
-                new ContextSuggestion("@workflow:record-mobile", "/record-mobile "),
+                new ContextSuggestion("@workflow:record-web", "/record-web https://example.com"),
+                new ContextSuggestion("@workflow:record-mobile",
+                        "/record-mobile inspector Android recordings/inspector.json"),
                 new ContextSuggestion("@workflow:codegen", "/codegen "),
                 new ContextSuggestion("@workflow:doctor", "/doctor "),
                 new ContextSuggestion("@tool:guide-search", "/guide "),
@@ -594,7 +610,7 @@ final class ShaftAssistantPanel extends JPanel {
             @Override
             public void keyTyped(KeyEvent event) {
                 char trigger = event.getKeyChar();
-                if (trigger == '@' || trigger == '#') {
+                if (trigger == '@' || trigger == '#' || trigger == '/') {
                     SwingUtilities.invokeLater(() -> showContextSuggestions(trigger));
                 }
             }
@@ -605,8 +621,8 @@ final class ShaftAssistantPanel extends JPanel {
         hideContextPopup();
         List<ContextSuggestion> suggestions = contextSuggestionsForTest(trigger);
         if (suggestions.isEmpty()) {
-            setStatus(trigger == '#'
-                    ? "No project context available"
+            setStatus(trigger == '#' ? "No project context available"
+                    : trigger == '/' ? "No SHAFT commands available"
                     : "No Assistant context available");
             return;
         }
@@ -989,6 +1005,11 @@ final class ShaftAssistantPanel extends JPanel {
         boolean cancelled = error instanceof CancellationException;
         boolean success = error == null && result != null && result.success();
         boolean currentStream = streamToken == activeLocalAgentStreamToken;
+        if (streamToken > 0 && streamToken == killedLocalAgentStreamToken) {
+            killedLocalAgentStreamToken = -1;
+            setRunning(false, "Killed");
+            return;
+        }
         if (streamToken > 0 && !currentStream && activeLocalAgentStreamToken != -1) {
             return;
         }
@@ -1045,7 +1066,9 @@ final class ShaftAssistantPanel extends JPanel {
     private void appendStreamingLocalAgentBubble(int streamToken) {
         activeLocalAgentStreamToken = streamToken;
         localAgentOutput = new StringBuilder();
-        append("assistant", LOCAL_AGENT_STREAMING_HEADER, "");
+        if (verboseLocalAgentOutput()) {
+            append("assistant", LOCAL_AGENT_STREAMING_HEADER, "");
+        }
     }
 
     private void appendLocalAgentOutput(int streamToken, String line) {
@@ -1056,7 +1079,9 @@ final class ShaftAssistantPanel extends JPanel {
             localAgentOutput.append("\n");
         }
         localAgentOutput.append(line == null ? "" : line);
-        replaceLastTranscriptAndChatState("assistant", formatLocalAgentStreamingResponse(localAgentOutput.toString()));
+        if (verboseLocalAgentOutput()) {
+            replaceLastTranscriptAndChatState("assistant", formatLocalAgentStreamingResponse(localAgentOutput.toString()));
+        }
     }
 
     private void finishLocalAgentResponse(int streamToken, String response, String rawResponse) {
@@ -1064,12 +1089,28 @@ final class ShaftAssistantPanel extends JPanel {
             return;
         }
         String displayResponse = withTokenUsage(response, rawResponse);
-        replaceLastTranscriptAndChatState("assistant", displayResponse);
+        if (verboseLocalAgentOutput()) {
+            replaceLastTranscriptAndChatState("assistant", displayResponse);
+        } else {
+            append("assistant", displayResponse, rawResponse);
+        }
         lastResponse = displayResponse;
         lastRawResponse = rawResponse == null ? "" : rawResponse;
         copyLastResponse.setEnabled(true);
         copyRawResponse.setEnabled(!lastRawResponse.isBlank());
         updateActionChrome();
+    }
+
+    private boolean verboseLocalAgentOutput() {
+        return verboseAgentOutput != null && verboseAgentOutput.isSelected();
+    }
+
+    private void stopLocalAgentStreaming() {
+        if (activeLocalAgentStreamToken > 0) {
+            killedLocalAgentStreamToken = activeLocalAgentStreamToken;
+        }
+        activeLocalAgentStreamToken = -1;
+        localAgentOutput = null;
     }
 
     private void showLocalResponse(String response) {
@@ -1136,6 +1177,7 @@ final class ShaftAssistantPanel extends JPanel {
         customCommand.setEnabled(!running);
         commandAutocomplete.setEnabled(!running);
         allowSourceMutation.setEnabled(!running);
+        verboseAgentOutput.setEnabled(!running);
         saveCloudApiKey.setEnabled(!running);
         approveCaptureReview.setEnabled(!running && pendingCaptureReview != null);
         copyCaptureReview.setEnabled(!running && pendingCaptureReview != null);
@@ -1259,10 +1301,15 @@ final class ShaftAssistantPanel extends JPanel {
         boolean agentMode = "AGENT".equals(mode.getSelectedItem());
         allowSourceMutation.setVisible(agentMode && localAgent);
         allowSourceMutation.setEnabled(controlsEnabled && agentMode && localAgent);
+        verboseAgentOutput.setVisible(localAgent && localCli);
+        verboseAgentOutput.setEnabled(controlsEnabled && localAgent && localCli);
         configure.setVisible(lockedRoute);
         configure.setEnabled(controlsEnabled && lockedRoute);
         if (!agentMode || !localAgent) {
             allowSourceMutation.setSelected(false);
+        }
+        if (!localAgent || !localCli) {
+            verboseAgentOutput.setSelected(false);
         }
         if (cloud) {
             updateCloudKeyStatus();
@@ -1301,7 +1348,7 @@ final class ShaftAssistantPanel extends JPanel {
             return;
         }
         String selected = String.valueOf(commandAutocomplete.getSelectedItem());
-        String command = canonicalCommand(selected);
+        String command = commandInsertion(selected);
         if (command.isBlank()) {
             filterCommandItems(selected);
             return;
@@ -1679,6 +1726,7 @@ final class ShaftAssistantPanel extends JPanel {
     private void cancelOrKillCurrent() {
         if (currentInvocation != null) {
             if (cancelRequested) {
+                stopLocalAgentStreaming();
                 currentInvocation.kill();
                 setStatus("Killing...");
                 addTimeline("Killed");
@@ -1972,8 +2020,14 @@ final class ShaftAssistantPanel extends JPanel {
         }
         for (AssistantCommand.CommandHint hint : AssistantCommand.commandHints()) {
             if (hint.canonical().equals(command)) {
+                String aliases = hint.synonyms().isEmpty()
+                        ? ""
+                        : "<br><span style='color:#6A737D'>Aliases: "
+                        + escapeHtml(String.join(", ", hint.synonyms()))
+                        + "</span>";
                 return "<html><b>" + escapeHtml(command) + "</b> - "
                         + escapeHtml(hint.summary())
+                        + aliases
                         + "<br><span style='color:#6A737D'>"
                         + escapeHtml(hint.example())
                         + "</span></html>";
@@ -1989,7 +2043,7 @@ final class ShaftAssistantPanel extends JPanel {
         return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
     }
 
-    private static String canonicalCommand(String value) {
+    private static String commandInsertion(String value) {
         String normalized = value == null ? "" : value.trim();
         if (normalized.isBlank()) {
             return "";
@@ -1997,10 +2051,10 @@ final class ShaftAssistantPanel extends JPanel {
         String firstToken = normalized.split("\\s+", 2)[0];
         for (AssistantCommand.CommandHint hint : AssistantCommand.commandHints()) {
             if (hint.canonical().equalsIgnoreCase(firstToken)) {
-                return hint.canonical();
+                return hint.example();
             }
             if (hint.synonyms().stream().anyMatch(alias -> alias.equalsIgnoreCase(firstToken))) {
-                return hint.canonical();
+                return hint.example();
             }
         }
         return "";

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
@@ -193,12 +193,18 @@ class AssistantCommandTest {
                         generatedPrompt),
                 () -> assertTrue(generatedPrompt.contains("Do not publish unverified locators"), generatedPrompt),
                 () -> assertTrue(generatedPrompt.contains("Call test_code_guardrails_check"), generatedPrompt),
+                () -> assertTrue(generatedPrompt.contains("Do not print full repository files"), generatedPrompt),
+                () -> assertTrue(generatedPrompt.contains("Put every code snippet in fenced code blocks"),
+                        generatedPrompt),
                 () -> assertTrue(generatedPrompt.contains("Return only SHAFT-syntax Java"), generatedPrompt),
                 () -> assertTrue(explicitPrompt.contains("Call shaft_guide_search"), explicitPrompt),
                 () -> assertTrue(explicitPrompt.contains("ask the user to confirm the exact target URL"),
                         explicitPrompt),
                 () -> assertTrue(explicitPrompt.contains("browser_open_intent"), explicitPrompt),
-                () -> assertTrue(explicitPrompt.contains("Call test_code_guardrails_check"), explicitPrompt));
+                () -> assertTrue(explicitPrompt.contains("Call test_code_guardrails_check"), explicitPrompt),
+                () -> assertTrue(explicitPrompt.contains("Do not print full repository files"), explicitPrompt),
+                () -> assertTrue(explicitPrompt.contains("Put every code snippet in fenced code blocks"),
+                        explicitPrompt));
     }
 
     @Test
@@ -472,6 +478,19 @@ class AssistantCommandTest {
     }
 
     @Test
+    void slashUpgradeShowsCopyableAutomatedUpgradeScript() {
+        AssistantCommand.Invocation upgrade = command("/upgrade .");
+        String response = upgrade.localResponse();
+
+        assertAll(
+                () -> assertTrue(upgrade.isLocal()),
+                () -> assertTrue(response.contains("```shell\npython -c \"import runpy,sys,urllib.request as u;")),
+                () -> assertTrue(response.contains("u.urlretrieve('https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/shaft-upgrader/upgrade_to_modular_shaft.py',p)")),
+                () -> assertTrue(response.contains("sys.argv=[p,'--project','.'];runpy.run_path(p,run_name='__main__')")),
+                () -> assertTrue(response.contains("\n```")));
+    }
+
+    @Test
     void commandRegistryShowsOnlyTestedValidCommandFamilies() {
         List<AssistantCommand.CommandHint> hints = AssistantCommand.commandHints();
         String tooltip = AssistantCommand.commandTooltip();
@@ -486,6 +505,7 @@ class AssistantCommandTest {
                                 "/guardrails",
                                 "/browser",
                                 "/mobile",
+                                "/upgrade",
                                 "/project"),
                         hints.stream().map(AssistantCommand.CommandHint::canonical).toList()),
                 () -> assertTrue(tooltip.contains("/codegen")),
@@ -496,6 +516,7 @@ class AssistantCommandTest {
                 () -> assertTrue(tooltip.contains("/guardrails")),
                 () -> assertTrue(tooltip.contains("/browser")),
                 () -> assertTrue(tooltip.contains("/mobile")),
+                () -> assertTrue(tooltip.contains("/upgrade")),
                 () -> assertTrue(tooltip.contains("/project")),
                 () -> assertFalse(tooltip.contains("/commands")),
                 () -> assertFalse(tooltip.contains("/assistant")),
@@ -518,9 +539,11 @@ class AssistantCommandTest {
                 () -> assertTrue(response.contains("**/guardrails**")),
                 () -> assertTrue(response.contains("**/browser**")),
                 () -> assertTrue(response.contains("**/mobile**")),
+                () -> assertTrue(response.contains("**/upgrade**")),
                 () -> assertTrue(response.contains("**/project**")),
                 () -> assertTrue(response.contains("```text\n/codegen recordings/intellij-capture.json\n```")),
                 () -> assertTrue(response.contains("```text\n/record-web https://example.com\n```")),
+                () -> assertTrue(response.contains("```text\n/upgrade .\n```")),
                 () -> assertFalse(response.contains("Example: /codegen")),
                 () -> assertFalse(response.contains("/commands -")),
                 () -> assertFalse(response.contains("/assistant -")));

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -1069,19 +1069,62 @@ class ShaftPanelSetupTest {
     }
 
     @Test
-    void assistantTranscriptShowsSentPromptAndLiveAgentOutputInVisibleChat() throws Exception {
+    void assistantTranscriptHidesLiveAgentOutputUntilFinalResultByDefault() throws Exception {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
 
         assistantPrompt(panel).setText("visible realtime user prompt");
         clickAccessible(panel, "Send assistant prompt");
         appendStreamingLocalAgentBubble(panel, 77);
         appendLocalAgentOutput(panel, 77, "visible realtime agent response");
+        showAgentResult(panel, 77, ShaftMcpToolResult.success("public class GeneratedTest { void test() {} }"));
 
         assertAll(
                 () -> assertTrue(transcriptMarkdown(panel).contains("visible realtime user prompt")),
-                () -> assertTrue(transcriptMarkdown(panel).contains("visible realtime agent response")),
+                () -> assertFalse(transcriptMarkdown(panel).contains("visible realtime agent response")),
+                () -> assertTrue(transcriptMarkdown(panel).contains("```java")),
+                () -> assertTrue(transcriptMarkdown(panel).contains("GeneratedTest")),
                 () -> assertTrue(containsText(panel, "visible realtime user prompt")),
-                () -> assertTrue(containsText(panel, "visible realtime agent response")));
+                () -> assertFalse(containsText(panel, "visible realtime agent response")));
+    }
+
+    @Test
+    void assistantVerboseModeShowsLiveAgentOutput() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        JCheckBox verbose = findByAccessibleName(panel, "Show verbose agent output", JCheckBox.class);
+        verbose.setSelected(true);
+
+        appendStreamingLocalAgentBubble(panel, 88);
+        appendLocalAgentOutput(panel, 88, "visible verbose agent response");
+
+        assertAll(
+                () -> assertTrue(transcriptMarkdown(panel).contains("visible verbose agent response")),
+                () -> assertTrue(containsText(panel, "visible verbose agent response")));
+    }
+
+    @Test
+    void assistantKillStopsLocalAgentStreamingImmediately() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        JCheckBox verbose = findByAccessibleName(panel, "Show verbose agent output", JCheckBox.class);
+        AtomicBoolean killed = new AtomicBoolean();
+        ShaftMcpInvocation invocation = new ShaftMcpInvocation(
+                new CompletableFuture<>(),
+                () -> {
+                },
+                () -> killed.set(true));
+        verbose.setSelected(true);
+        setField(panel, "currentInvocation", invocation);
+        panel.setRunning(true, "Thinking...");
+        appendStreamingLocalAgentBubble(panel, 99);
+        appendLocalAgentOutput(panel, 99, "visible before kill");
+
+        cancelOrKillCurrent(panel);
+        cancelOrKillCurrent(panel);
+        appendLocalAgentOutput(panel, 99, "late output after kill");
+
+        assertAll(
+                () -> assertTrue(killed.get()),
+                () -> assertTrue(transcriptMarkdown(panel).contains("visible before kill")),
+                () -> assertFalse(transcriptMarkdown(panel).contains("late output after kill")));
     }
 
     @Test
@@ -1174,6 +1217,7 @@ class ShaftPanelSetupTest {
         JComboBox<?> commandAutocomplete = findByAccessibleName(panel, "Assistant command autocomplete", JComboBox.class);
         JButton commandInfo = findByAccessibleName(panel, "SHAFT command hints", JButton.class);
         JButton contextInfo = findByAccessibleName(panel, "Assistant context suggestions", JButton.class);
+        JCheckBox verbose = findByAccessibleName(panel, "Show verbose agent output", JCheckBox.class);
         JProgressBar spinner = findByAccessibleName(panel, "Assistant thinking spinner", JProgressBar.class);
         JButton sendButton = findByAccessibleName(panel, "Send assistant prompt", JButton.class);
         JLabel status = findByAccessibleName(panel, "Assistant status", JLabel.class);
@@ -1183,56 +1227,70 @@ class ShaftPanelSetupTest {
         String renderedText = renderedGuide instanceof JLabel label ? label.getText() : "";
 
         assertAll(
-                () -> assertNotNull(commandAutocomplete),
-                () -> assertTrue(commandAutocomplete.isEditable()),
-                () -> assertTrue(commandAutocomplete.getToolTipText().contains("tested commands")),
-                () -> assertFalse(comboContains(commandAutocomplete, "/commands")),
-                () -> assertTrue(comboContains(commandAutocomplete, "/codegen")),
-                () -> assertTrue(comboContains(commandAutocomplete, "/record-web")),
-                () -> assertTrue(comboContains(commandAutocomplete, "/record-mobile")),
-                () -> assertTrue(comboContains(commandAutocomplete, "/doctor")),
-                () -> assertTrue(comboContains(commandAutocomplete, "/guide")),
-                () -> assertTrue(comboContains(commandAutocomplete, "/guardrails")),
-                () -> assertTrue(comboContains(commandAutocomplete, "/browser")),
-                () -> assertTrue(comboContains(commandAutocomplete, "/mobile")),
-                () -> assertTrue(comboContains(commandAutocomplete, "/project")),
-                () -> assertTrue(renderedText.contains("Search the SHAFT guide")),
-                () -> assertTrue(prompt.getAccessibleContext().getAccessibleDescription().contains("guarded local Agent")),
-                () -> assertTrue(prompt instanceof JBTextArea),
-                () -> assertTrue(((JBTextArea) prompt).getRows() >= 6),
-                () -> assertFalse(containsText(panel, "Add context (#), extensions (@), commands (/commands)")),
-                () -> assertNotNull(commandInfo),
-                () -> assertNotNull(contextInfo),
-                () -> assertTrue(contextInfo.getToolTipText().contains("@workflow")),
-                () -> assertTrue(commandInfo.getToolTipText().contains("/codegen")),
-                () -> assertTrue(commandInfo.getToolTipText().contains("/record-web")),
-                () -> assertTrue(commandInfo.getToolTipText().contains("/record-mobile")),
-                () -> assertTrue(commandInfo.getToolTipText().contains("/doctor")),
-                () -> assertTrue(commandInfo.getToolTipText().contains("/guide")),
-                () -> assertTrue(commandInfo.getToolTipText().contains("/guardrails")),
-                () -> assertTrue(commandInfo.getToolTipText().contains("/browser")),
-                () -> assertTrue(commandInfo.getToolTipText().contains("/mobile")),
-                () -> assertTrue(commandInfo.getToolTipText().contains("/project")),
-                () -> assertEquals(commandAutocomplete.getParent(), commandInfo.getParent()),
+                () -> assertNotNull(commandAutocomplete, "command autocomplete should exist"),
+                () -> assertTrue(commandAutocomplete.isEditable(), "command autocomplete should be editable"),
+                () -> assertTrue(commandAutocomplete.getToolTipText().contains("tested commands"),
+                        "command autocomplete tooltip should mention tested commands"),
+                () -> assertFalse(comboContains(commandAutocomplete, "/commands"), "command picker should hide /commands"),
+                () -> assertTrue(comboContains(commandAutocomplete, "/codegen"), "command picker should list /codegen"),
+                () -> assertTrue(comboContains(commandAutocomplete, "/record-web"), "command picker should list /record-web"),
+                () -> assertTrue(comboContains(commandAutocomplete, "/record-mobile"),
+                        "command picker should list /record-mobile"),
+                () -> assertTrue(comboContains(commandAutocomplete, "/doctor"), "command picker should list /doctor"),
+                () -> assertTrue(comboContains(commandAutocomplete, "/guide"), "command picker should list /guide"),
+                () -> assertTrue(comboContains(commandAutocomplete, "/guardrails"), "command picker should list /guardrails"),
+                () -> assertTrue(comboContains(commandAutocomplete, "/browser"), "command picker should list /browser"),
+                () -> assertTrue(comboContains(commandAutocomplete, "/mobile"), "command picker should list /mobile"),
+                () -> assertTrue(comboContains(commandAutocomplete, "/upgrade"), "command picker should list /upgrade"),
+                () -> assertTrue(comboContains(commandAutocomplete, "/project"), "command picker should list /project"),
+                () -> assertTrue(renderedText.contains("Search the SHAFT guide"), renderedText),
+                () -> assertTrue(prompt.getAccessibleContext().getAccessibleDescription().contains("guarded local Agent"),
+                        "prompt description should mention guarded local Agent"),
+                () -> assertTrue(prompt instanceof JBTextArea, "prompt should be a JBTextArea"),
+                () -> assertTrue(((JBTextArea) prompt).getRows() >= 6, "prompt should have at least six rows"),
+                () -> assertFalse(containsText(panel, "Add context (#), extensions (@), commands (/commands)"),
+                        "old starter strip copy should stay removed"),
+                () -> assertNotNull(commandInfo, "command help button should exist"),
+                () -> assertNotNull(contextInfo, "context suggestions button should exist"),
+                () -> assertNotNull(verbose),
+                () -> assertFalse(verbose.isSelected()),
+                () -> assertTrue(verbose.getToolTipText().contains("live local agent output")),
+                () -> assertTrue(contextInfo.getToolTipText().contains("@workflow"), "context tooltip should mention @workflow"),
+                () -> assertTrue(commandInfo.getToolTipText().contains("/codegen"), "command tooltip should list /codegen"),
+                () -> assertTrue(commandInfo.getToolTipText().contains("/record-web"), "command tooltip should list /record-web"),
+                () -> assertTrue(commandInfo.getToolTipText().contains("/record-mobile"), "command tooltip should list /record-mobile"),
+                () -> assertTrue(commandInfo.getToolTipText().contains("/doctor"), "command tooltip should list /doctor"),
+                () -> assertTrue(commandInfo.getToolTipText().contains("/guide"), "command tooltip should list /guide"),
+                () -> assertTrue(commandInfo.getToolTipText().contains("/guardrails"), "command tooltip should list /guardrails"),
+                () -> assertTrue(commandInfo.getToolTipText().contains("/browser"), "command tooltip should list /browser"),
+                () -> assertTrue(commandInfo.getToolTipText().contains("/mobile"), "command tooltip should list /mobile"),
+                () -> assertTrue(commandInfo.getToolTipText().contains("/upgrade"), "command tooltip should list /upgrade"),
+                () -> assertTrue(commandInfo.getToolTipText().contains("/project"), "command tooltip should list /project"),
+                () -> assertEquals(commandAutocomplete.getParent(), commandInfo.getParent(),
+                        "command autocomplete and help should share a row"),
                 () -> assertTrue(componentIndex(commandAutocomplete.getParent(), commandInfo)
-                        > componentIndex(commandAutocomplete.getParent(), commandAutocomplete)),
+                        > componentIndex(commandAutocomplete.getParent(), commandAutocomplete),
+                        "command help should follow autocomplete"),
                 () -> assertTrue(componentIndex(commandAutocomplete.getParent(), contextInfo)
-                        > componentIndex(commandAutocomplete.getParent(), commandInfo)),
-                () -> assertNotNull(spinner),
-                () -> assertTrue(spinner.isIndeterminate()),
-                () -> assertFalse(spinner.isVisible()),
-                () -> assertNotNull(status),
-                () -> assertTrue(status.getToolTipText().contains("Try asking")),
-                () -> assertTrue(status.getAccessibleContext().getAccessibleDescription().contains("Try asking")),
-                () -> assertNotNull(sendButton),
-                () -> assertTrue(sendButton.getToolTipText().contains("Command+Enter")),
-                () -> assertTrue(sendButton.getToolTipText().contains("Ctrl+click")),
-                () -> assertTrue(sendButton.getParent().getLayout() instanceof FlowLayout),
-                () -> assertEquals(FlowLayout.RIGHT, ((FlowLayout) sendButton.getParent().getLayout()).getAlignment()),
-                () -> assertEquals("", sendButton.getText()),
-                () -> assertNotNull(sendButton.getIcon()),
-                () -> assertTrue(sendButton.getIcon().getIconWidth() > 0),
-                () -> assertTrue(sendButton.getIcon().getIconHeight() > 0));
+                        > componentIndex(commandAutocomplete.getParent(), commandInfo),
+                        "context help should follow command help"),
+                () -> assertNotNull(spinner, "spinner should exist"),
+                () -> assertTrue(spinner.isIndeterminate(), "spinner should be indeterminate"),
+                () -> assertFalse(spinner.isVisible(), "spinner should be hidden while idle"),
+                () -> assertNotNull(status, "status should exist"),
+                () -> assertTrue(status.getToolTipText().contains("Try asking"), "status tooltip should be idle copy"),
+                () -> assertTrue(status.getAccessibleContext().getAccessibleDescription().contains("Try asking"),
+                        "status accessible description should be idle copy"),
+                () -> assertNotNull(sendButton, "send button should exist"),
+                () -> assertTrue(sendButton.getToolTipText().contains("Command+Enter"), "send tooltip should mention Command+Enter"),
+                () -> assertTrue(sendButton.getToolTipText().contains("Ctrl+click"), "send tooltip should mention Ctrl+click"),
+                () -> assertTrue(sendButton.getParent().getLayout() instanceof FlowLayout, "send row should use FlowLayout"),
+                () -> assertEquals(FlowLayout.RIGHT, ((FlowLayout) sendButton.getParent().getLayout()).getAlignment(),
+                        "send row should align right"),
+                () -> assertEquals("", sendButton.getText(), "send button should stay icon-only"),
+                () -> assertNotNull(sendButton.getIcon(), "send button should have an icon"),
+                () -> assertTrue(sendButton.getIcon().getIconWidth() > 0, "send icon should have width"),
+                () -> assertTrue(sendButton.getIcon().getIconHeight() > 0, "send icon should have height"));
     }
 
     @Test
@@ -1251,6 +1309,14 @@ class ShaftPanelSetupTest {
                 () -> assertTrue(comboContains(commandAutocomplete, "/record-mobile")),
                 () -> assertFalse(comboContains(commandAutocomplete, "/doctor")),
                 () -> assertFalse(comboContains(commandAutocomplete, "/project")));
+
+        SwingUtilities.invokeAndWait(() -> commandAutocomplete.getEditor().setItem("/up"));
+        SwingUtilities.invokeAndWait(() -> {
+        });
+
+        assertAll(
+                () -> assertTrue(comboContains(commandAutocomplete, "/upgrade")),
+                () -> assertFalse(comboContains(commandAutocomplete, "/record-web")));
     }
 
     @Test
@@ -1303,34 +1369,45 @@ class ShaftPanelSetupTest {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
 
         List<ShaftAssistantPanel.ContextSuggestion> workflowSuggestions = panel.contextSuggestionsForTest('@');
+        List<ShaftAssistantPanel.ContextSuggestion> slashSuggestions = panel.contextSuggestionsForTest('/');
         List<ShaftAssistantPanel.ContextSuggestion> fileSuggestions = panel.contextSuggestionsForTest('#');
         List<ShaftAssistantPanel.ContextSuggestion> unsupportedSuggestions = panel.contextSuggestionsForTest('$');
 
         assertAll(
                 () -> assertTrue(workflowSuggestions.stream().anyMatch(
                         suggestion -> "@workflow:record-web".equals(suggestion.label())
-                                && "/record-web ".equals(suggestion.insertion()))),
+                                && "/record-web https://example.com".equals(suggestion.insertion()))),
+                () -> assertTrue(workflowSuggestions.stream().anyMatch(
+                        suggestion -> "@workflow:record-mobile".equals(suggestion.label())
+                                && "/record-mobile inspector Android recordings/inspector.json"
+                                .equals(suggestion.insertion()))),
                 () -> assertTrue(workflowSuggestions.stream().anyMatch(
                         suggestion -> "@tool:guardrails".equals(suggestion.label())
                                 && "/guardrails ".equals(suggestion.insertion()))),
+                () -> assertTrue(slashSuggestions.stream().anyMatch(
+                        suggestion -> "/upgrade".equals(suggestion.label())
+                                && "/upgrade .".equals(suggestion.insertion()))),
+                () -> assertTrue(slashSuggestions.stream().anyMatch(
+                        suggestion -> "/record-web".equals(suggestion.label())
+                                && "/record-web https://example.com".equals(suggestion.insertion()))),
                 () -> assertTrue(fileSuggestions.isEmpty()),
                 () -> assertTrue(unsupportedSuggestions.isEmpty()));
     }
 
     @Test
-    void assistantCommandAutocompleteInsertsCommandIntoPrompt() throws Exception {
+    void assistantCommandAutocompleteInsertsCommandExampleIntoPrompt() throws Exception {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
         JComboBox<?> commandAutocomplete = findByAccessibleName(panel, "Assistant command autocomplete", JComboBox.class);
         JTextComponent prompt = assistantPrompt(panel);
 
         prompt.setText("please ");
         prompt.setCaretPosition(prompt.getDocument().getLength());
-        SwingUtilities.invokeAndWait(() -> commandAutocomplete.setSelectedItem("/record-web"));
+        SwingUtilities.invokeAndWait(() -> commandAutocomplete.setSelectedItem("/upgrade"));
         SwingUtilities.invokeAndWait(() -> {
         });
 
         assertAll(
-                () -> assertEquals("please /record-web ", prompt.getText()),
+                () -> assertEquals("please /upgrade . ", prompt.getText()),
                 () -> assertEquals("/", String.valueOf(commandAutocomplete.getEditor().getItem())),
                 () -> assertTrue(comboContains(commandAutocomplete, "/doctor")));
     }
@@ -2400,6 +2477,12 @@ class ShaftPanelSetupTest {
         Method method = ShaftAssistantPanel.class.getDeclaredMethod("appendLocalAgentOutput", int.class, String.class);
         method.setAccessible(true);
         method.invoke(panel, streamToken, line);
+    }
+
+    private static void cancelOrKillCurrent(ShaftAssistantPanel panel) throws Exception {
+        Method method = ShaftAssistantPanel.class.getDeclaredMethod("cancelOrKillCurrent");
+        method.setAccessible(true);
+        method.invoke(panel);
     }
 
     private static void setField(Object target, String name, Object value) throws Exception {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
@@ -287,6 +287,7 @@ class ShaftPluginScreenshotRendererTest {
             ShaftAssistantPanel component = new ShaftAssistantPanel(screenshotProject(), settings, chatState,
                     () -> {
                     });
+            selectButton(component, "Verbose");
             invokeSetRunning(component, true, "Thinking...");
             component.setSize(new Dimension(WIDTH, HEIGHT));
             component.setPreferredSize(new Dimension(WIDTH, HEIGHT));
@@ -502,6 +503,18 @@ class ShaftPluginScreenshotRendererTest {
             container.doLayout();
             for (Component child : container.getComponents()) {
                 layout(child, light);
+            }
+        }
+    }
+
+    private static void selectButton(Component component, String text) {
+        if (component instanceof AbstractButton button && text.equals(button.getText())) {
+            button.setSelected(true);
+            return;
+        }
+        if (component instanceof Container container) {
+            for (Component child : container.getComponents()) {
+                selectButton(child, text);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add visible `/upgrade` Assistant command that returns a copyable shell code block for the automated SHAFT upgrader.
- Add slash-trigger command suggestions and example-based autocomplete insertion, including fuller web/mobile recording examples.
- Add default-off `Verbose` local-agent output mode, stop late stream output after Kill, and guide codegen agents away from full repo dumps while requiring fenced code snippets.

## Validation
- `gradle -p shaft-intellij test`
- `gradle -p shaft-intellij test --tests "com.shaft.intellij.ui.ShaftPluginScreenshotRendererTest" '-Dshaft.intellij.screenshotDir=target/shaft-intellij-screenshots'`

## Screenshot Evidence
- `shaft-intellij/target/shaft-intellij-screenshots/intellij-plugin-assistant.png`
- `shaft-intellij/target/shaft-intellij-screenshots/intellij-plugin-assistant-live-output-dark.png`

## Docs Note
- Targeted docs search found `shafthq.github.io/docs/agentic/intellij.md` should be updated in a separate docs PR; the docs checkout is already on `codex/recorder-flow-docs-20260704`, so this code PR does not mix docs changes into that active docs branch.