### PR TITLE
Fix IntelliJ Assistant onboarding blockers

### DIFF
--- a/.memory/events.jsonl
+++ b/.memory/events.jsonl
@@ -140,3 +140,5 @@
 {"actor":"agent","event":"memory.created","id":"decision.assistant-markdown-copy-controls-are-icon-only","timestamp":"2026-07-02T23:32:22+03:00"}
 {"actor":"agent","event":"memory.created","id":"decision.assistant-transcript-fallback-paints-real-rounded-bubbles","timestamp":"2026-07-02T23:32:22+03:00"}
 {"actor":"agent","event":"memory.created","id":"fact.intellij-mcp-setup-troubleshooting","timestamp":"2026-07-03T17:15:57+03:00"}
+{"actor":"agent","event":"memory.created","id":"fact.intellij-assistant-codegen-avoids-live-browser-unless-explicit","timestamp":"2026-07-05T10:18:19+03:00"}
+{"actor":"agent","event":"memory.created","id":"fact.intellij-mcp-setup-copies-skills-install-flag","timestamp":"2026-07-05T10:18:19+03:00"}

--- a/.memory/memory/facts/intellij-assistant-codegen-avoids-live-browser-unless-explicit.json
+++ b/.memory/memory/facts/intellij-assistant-codegen-avoids-live-browser-unless-explicit.json
@@ -1,0 +1,27 @@
+{
+  "body_path": "memory/facts/intellij-assistant-codegen-avoids-live-browser-unless-explicit.md",
+  "content_hash": "sha256:4267b716a1454b13a1a21da759bdc9a6057631f9b1889a25dd70ceaff5905c3f",
+  "created_at": "2026-07-05T10:18:19+03:00",
+  "evidence": [],
+  "id": "fact.intellij-assistant-codegen-avoids-live-browser-unless-explicit",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Fix IntelliJ Assistant onboarding blockers from issue 3285"
+  },
+  "status": "active",
+  "tags": [
+    "intellij",
+    "assistant",
+    "codegen",
+    "issue-3285"
+  ],
+  "title": "IntelliJ Assistant codegen avoids live browser unless explicit",
+  "type": "fact",
+  "updated_at": "2026-07-05T10:18:19+03:00"
+}

--- a/.memory/memory/facts/intellij-assistant-codegen-avoids-live-browser-unless-explicit.md
+++ b/.memory/memory/facts/intellij-assistant-codegen-avoids-live-browser-unless-explicit.md
@@ -1,0 +1,1 @@
+Natural Page Object/codegen prompts route to the guarded local-agent codegen path before live browser sequences. Code-only or no-browser prompts avoid live driver tools; explicit live locator verification can still opt into driver_initialize/browser_open_intent guidance.

--- a/.memory/memory/facts/intellij-mcp-setup-copies-skills-install-flag.json
+++ b/.memory/memory/facts/intellij-mcp-setup-copies-skills-install-flag.json
@@ -1,0 +1,27 @@
+{
+  "body_path": "memory/facts/intellij-mcp-setup-copies-skills-install-flag.md",
+  "content_hash": "sha256:d2e0d746128bed0ae66fea8bc93a4548e399f31099f5fdfb4a80ef3e20e43d65",
+  "created_at": "2026-07-05T10:18:19+03:00",
+  "evidence": [],
+  "id": "fact.intellij-mcp-setup-copies-skills-install-flag",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Fix IntelliJ Assistant onboarding blockers from issue 3285"
+  },
+  "status": "active",
+  "tags": [
+    "intellij",
+    "mcp",
+    "installer",
+    "issue-3285"
+  ],
+  "title": "IntelliJ MCP setup copies skills install flag",
+  "type": "fact",
+  "updated_at": "2026-07-05T10:18:19+03:00"
+}

--- a/.memory/memory/facts/intellij-mcp-setup-copies-skills-install-flag.md
+++ b/.memory/memory/facts/intellij-mcp-setup-copies-skills-install-flag.md
@@ -1,0 +1,1 @@
+The IntelliJ setup panel appends --install-shaft-skills to copied SHAFT MCP installer commands so onboarding does not depend on the interactive skills prompt.

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -49,17 +49,23 @@ final class AssistantCommand {
                     - Call test_automation_scenarios for broad test/page-object design to learn the matching SHAFT coding pattern.
                     - Inspect existing project code and call shaft_coding_partner_plan before creating tests, page objects, locators, or actions.
                     - Reuse existing tests, page objects, locator fields, and action methods first.
-                    - If required actions or locators are missing, record the complete flow, then insert only the missing locators/actions into the planned source anchors.
+                    - If required actions or locators are missing, ask before starting live browser work; otherwise return review-only Java and mark locator assumptions as unverified.
                     - If the user names a site, product, or environment without an explicit URL, ask the user to confirm the exact target URL before navigating or writing code. Do not infer canonical URLs.
                     - For any requested site/action, preserve the user's requested target. Never substitute a different URL, domain, or example page in code or screenshot evidence.
-                    - For generated code that performs a specific action: Open a real browser session; call driver_initialize and browser_open_intent with the confirmed targetUrl and userIntent to inspect the live page and locator candidates.
-                    - Verify each selected locator by performing the actual action with shaft-mcp element_type, element_click, or natural_act before returning it. Do not publish unverified locators.
+                    - If the user asks for code only, a draft, or says not to run/open a browser, do not call live browser tools.
+                    - Do not publish locators as verified unless a live browser session actually checked them.
                     - Never generate SHAFT.GUI.Locator.xpath(...); prefer smart locators and the locator builder, then By.xpath only as a last fallback.
                     - Use native Playwright locators only as a last fallback in SHAFT Playwright-specific code.
                     - Call test_code_guardrails_check on the final Java snippet.
                     - Do not print full repository files or broad file dumps. Cite inspected files by path and include only the generated or changed code needed for the answer.
                     - Put every code snippet in fenced code blocks with the correct language.
                     - Return only SHAFT-syntax Java; never return raw Selenium code.
+                    """.stripIndent().trim();
+    private static final String SHAFT_LIVE_CODEGEN_TOOL_GUIDANCE =
+            """
+                    Live browser verification was explicitly requested:
+                    - Open a real browser session; call driver_initialize and browser_open_intent with the confirmed targetUrl and userIntent to inspect the live page and locator candidates.
+                    - Verify each selected locator by performing the actual action with shaft-mcp element_type, element_click, or natural_act before returning it.
                     """.stripIndent().trim();
     private static final CommandDefinition COMMAND_HELP = new CommandDefinition("/commands", "Show command help",
             List.of("/help", "/mcp-help", "/shaft-help"),
@@ -334,12 +340,18 @@ final class AssistantCommand {
         } else if (text.startsWith("/")) {
             return slash(text, workingDirectory, openFileContext);
         }
+        boolean codeGenerationRequest = isCodeGenerationRequest(text);
         if (!liveCodegenRequest) {
             if (isCodingPartnerIntent(text)) {
                 return Invocation.tool(
                         "shaft_coding_partner_plan",
                         codingPartnerPlan(naturalCodingPartnerIntent(text), workingDirectory, openFileContext));
             }
+            if (isGuardrailsCheckIntent(text)) {
+                return Invocation.tool("test_code_guardrails_check", guardrails(naturalCode(text)));
+            }
+        }
+        if (!liveCodegenRequest && !codeGenerationRequest) {
             Invocation recording = recording(text);
             if (recording != null) {
                 return recording;
@@ -393,7 +405,7 @@ final class AssistantCommand {
             return withConversationContext(text, conversationContext);
         }
         return withConversationContext(SHAFT_MCP_USAGE_HINT
-                + "\n" + SHAFT_CODEGEN_TOOL_GUIDANCE
+                + "\n" + codeGenerationGuidance(text)
                 + "\n" + codeRequestScope(Selection.normalize(mode, "ASK"), openFileContext)
                 + "\n\n" + text, conversationContext);
     }
@@ -1037,7 +1049,7 @@ final class AssistantCommand {
 
     private static boolean isBrowserControlIntent(String text) {
         String lower = text == null ? "" : text.toLowerCase(Locale.ROOT);
-        if (isBrowserRecordingIntent(lower) || isCommandHelpIntent(lower)) {
+        if (isBrowserRecordingIntent(lower) || isCommandHelpIntent(lower) || isCodeOnlyRequest(lower)) {
             return false;
         }
         boolean mentionsBrowserAction = containsAny(lower,
@@ -1441,11 +1453,11 @@ final class AssistantCommand {
         boolean codeGenerationRequest = isCodeGenerationRequest(text);
         String hint = SHAFT_MCP_USAGE_HINT
                 + (codeGenerationRequest
-                ? "\n" + SHAFT_CODEGEN_TOOL_GUIDANCE + "\n" + codeRequestScope(normalizedMode, openFileContext)
+                ? "\n" + codeGenerationGuidance(text) + "\n" + codeRequestScope(normalizedMode, openFileContext)
                 : "");
         String withHint = lower.contains("shaft-mcp")
                 ? (codeGenerationRequest
-                ? SHAFT_CODEGEN_TOOL_GUIDANCE + "\n" + codeRequestScope(normalizedMode, openFileContext)
+                ? codeGenerationGuidance(text) + "\n" + codeRequestScope(normalizedMode, openFileContext)
                 + "\n\n" + text
                 : text)
                 : hint + "\n\n" + text;
@@ -1530,6 +1542,8 @@ final class AssistantCommand {
                 "generate java",
                 "generate test",
                 "generate tests",
+                "write code",
+                "write java",
                 "create test",
                 "create tests",
                 "write test",
@@ -1552,7 +1566,51 @@ final class AssistantCommand {
                 "fix code",
                 "fix this code",
                 "java code",
+                "code only",
+                "code-only",
+                "draft code",
                 "generated code");
+    }
+
+    private static String codeGenerationGuidance(String text) {
+        return shouldUseLiveCodegenTools(text)
+                ? SHAFT_CODEGEN_TOOL_GUIDANCE + "\n" + SHAFT_LIVE_CODEGEN_TOOL_GUIDANCE
+                : SHAFT_CODEGEN_TOOL_GUIDANCE;
+    }
+
+    private static boolean shouldUseLiveCodegenTools(String text) {
+        String normalized = normalizeNaturalCommand(text);
+        return !isCodeOnlyRequest(normalized)
+                && containsAny(normalized,
+                "live browser",
+                "live locator",
+                "verify locator",
+                "verify locators",
+                "inspect live",
+                "run browser",
+                "open browser",
+                "record flow",
+                "record the flow",
+                "capture flow",
+                "capture the flow");
+    }
+
+    private static boolean isCodeOnlyRequest(String text) {
+        String normalized = normalizeNaturalCommand(text);
+        return containsAny(normalized,
+                "code only",
+                "code-only",
+                "draft only",
+                "draft code",
+                "write code only",
+                "do not run browser",
+                "dont run browser",
+                "don't run browser",
+                "without running browser",
+                "do not open browser",
+                "dont open browser",
+                "don't open browser",
+                "no browser");
     }
 
     private static String[] splitTargetUrlAndIntent(String rest) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -734,9 +734,13 @@ final class ShaftAssistantPanel extends JPanel {
         }
         if (agentMode
                 && !approvingCaptureReview
-                && !route.cloud()
-                && !allowSourceMutation.isSelected()
-                && (promptRequiresSourceMutation(text) || continuationRequiresSourceMutation(text, conversationContext))) {
+                && requiresSourceEditApprovalBeforeSend(
+                        agentMode,
+                        route.cloud(),
+                        allowSourceMutation.isSelected(),
+                        customCommand.getText(),
+                        text,
+                        conversationContext)) {
             showResponse("To let the agent make source edits, please enable **Allow source edits** before sending.",
                     "");
             addTimeline("Failed");
@@ -864,6 +868,21 @@ final class ShaftAssistantPanel extends JPanel {
         currentToolSequence = List.of();
         sequenceMarkdown = null;
         sequenceRawOutput = null;
+    }
+
+    static boolean requiresSourceEditApprovalBeforeSend(
+            boolean agentMode,
+            boolean cloudRoute,
+            boolean allowSourceMutation,
+            String customCommand,
+            String prompt,
+            String conversationContext) {
+        return agentMode
+                && !cloudRoute
+                && !allowSourceMutation
+                && customCommand != null
+                && !customCommand.isBlank()
+                && (promptRequiresSourceMutation(prompt) || continuationRequiresSourceMutation(prompt, conversationContext));
     }
 
     private static boolean promptRequiresSourceMutation(String text) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -620,10 +620,10 @@ final class ShaftMcpSetupPanel extends JPanel {
         if (isWindows()) {
             return "powershell -NoProfile -ExecutionPolicy Bypass -Command '$installer=Join-Path $env:TEMP \"install-shaft-mcp.ps1\"; "
                     + "Invoke-WebRequest -UseBasicParsing \"" + url
-                    + ".ps1\" -OutFile $installer; & $installer -Client " + target + "'";
+                    + ".ps1\" -OutFile $installer; & $installer -Client " + target + " --install-shaft-skills'";
         }
         return "tmp=\"${TMPDIR:-/tmp}/install-shaft-mcp.sh\"; curl -fL " + url
-                + ".sh -o \"$tmp\" && sh \"$tmp\" --" + target;
+                + ".sh -o \"$tmp\" && sh \"$tmp\" --" + target + " --install-shaft-skills";
     }
 
     private void copyInstallerCommand() {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
@@ -185,18 +185,16 @@ class AssistantCommandTest {
                 () -> assertTrue(generatedPrompt.contains("Call test_automation_scenarios"), generatedPrompt),
                 () -> assertTrue(generatedPrompt.contains("call shaft_coding_partner_plan"), generatedPrompt),
                 () -> assertTrue(generatedPrompt.contains("Reuse existing tests, page objects"), generatedPrompt),
-                () -> assertTrue(generatedPrompt.contains("record the complete flow"), generatedPrompt),
+                () -> assertTrue(generatedPrompt.contains("ask before starting live browser work"), generatedPrompt),
                 () -> assertTrue(generatedPrompt.contains("ask the user to confirm the exact target URL"),
                         generatedPrompt),
                 () -> assertTrue(generatedPrompt.contains("Do not infer canonical URLs"), generatedPrompt),
                 () -> assertTrue(generatedPrompt.contains("Never substitute a different URL, domain, or example page"),
                         generatedPrompt),
-                () -> assertTrue(generatedPrompt.contains("Open a real browser session"), generatedPrompt),
-                () -> assertTrue(generatedPrompt.contains("call driver_initialize and browser_open_intent"),
+                () -> assertTrue(generatedPrompt.contains("do not call live browser tools"), generatedPrompt),
+                () -> assertTrue(generatedPrompt.contains("Do not publish locators as verified"), generatedPrompt),
+                () -> assertFalse(generatedPrompt.contains("Live browser verification was explicitly requested"),
                         generatedPrompt),
-                () -> assertTrue(generatedPrompt.contains("element_type, element_click, or natural_act"),
-                        generatedPrompt),
-                () -> assertTrue(generatedPrompt.contains("Do not publish unverified locators"), generatedPrompt),
                 () -> assertTrue(generatedPrompt.contains("Never generate SHAFT.GUI.Locator.xpath"), generatedPrompt),
                 () -> assertTrue(generatedPrompt.contains("Call test_code_guardrails_check"), generatedPrompt),
                 () -> assertTrue(generatedPrompt.contains("Do not print full repository files"), generatedPrompt),
@@ -206,7 +204,8 @@ class AssistantCommandTest {
                 () -> assertTrue(explicitPrompt.contains("Call shaft_guide_search"), explicitPrompt),
                 () -> assertTrue(explicitPrompt.contains("ask the user to confirm the exact target URL"),
                         explicitPrompt),
-                () -> assertTrue(explicitPrompt.contains("browser_open_intent"), explicitPrompt),
+                () -> assertTrue(explicitPrompt.contains("do not call live browser tools"), explicitPrompt),
+                () -> assertFalse(explicitPrompt.contains("browser_open_intent"), explicitPrompt),
                 () -> assertTrue(explicitPrompt.contains("Call test_code_guardrails_check"), explicitPrompt),
                 () -> assertTrue(explicitPrompt.contains("Do not print full repository files"), explicitPrompt),
                 () -> assertTrue(explicitPrompt.contains("Put every code snippet in fenced code blocks"),
@@ -214,7 +213,7 @@ class AssistantCommandTest {
     }
 
     @Test
-    void slashCodegenWithLiveInstructionsRoutesToAgentCodegenPrompt() {
+    void slashCodegenWithLiveInstructionsRoutesToReviewOnlyAgentCodegenPrompt() {
         AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
                 "/codegen navigate to https://duckduckgo.com, search for shaft_engine, open the first result and assert that the url is correct.",
                 AssistantCommand.Selection.local("CODEX", "CLI"),
@@ -230,10 +229,29 @@ class AssistantCommandTest {
         assertAll(
                 () -> assertEquals("autobot_local_agent_run", invocation.toolName()),
                 () -> assertTrue(prompt.contains("This is a code-generation request. Before returning Java:"), prompt),
-                () -> assertTrue(prompt.contains("Open a real browser session"), prompt),
-                () -> assertTrue(prompt.contains("call driver_initialize and browser_open_intent"), prompt),
+                () -> assertTrue(prompt.contains("ask before starting live browser work"), prompt),
+                () -> assertFalse(prompt.contains("Live browser verification was explicitly requested"), prompt),
                 () -> assertTrue(prompt.contains("navigate to https://duckduckgo.com"), prompt),
                 () -> assertFalse(prompt.contains("test_automation_scenarios OK")));
+    }
+
+    @Test
+    void codeOnlyBrowserCodegenPromptDoesNotRouteToLiveBrowserSequence() {
+        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+                "write code only for https://duckduckgo.com search Page Object; do not run browser",
+                AssistantCommand.Selection.local("CODEX", "CLI"),
+                "AGENT",
+                ".",
+                "",
+                true);
+
+        String prompt = invocation.arguments().get("prompt").getAsString();
+
+        assertAll(
+                () -> assertEquals("autobot_local_agent_run", invocation.toolName()),
+                () -> assertFalse(invocation.isSequence()),
+                () -> assertTrue(prompt.contains("do not call live browser tools"), prompt),
+                () -> assertFalse(prompt.contains("Live browser verification was explicitly requested"), prompt));
     }
 
     @Test
@@ -284,12 +302,12 @@ class AssistantCommandTest {
                 () -> assertTrue(agentPrompt.contains("current open class only"), agentPrompt),
                 () -> assertEquals("autobot_provider_chat", cloud.toolName()),
                 () -> assertTrue(cloudPrompt.contains("Use only the currently open file"), cloudPrompt),
-                () -> assertTrue(cloudPrompt.contains("Open a real browser session"), cloudPrompt),
-                () -> assertTrue(cloudPrompt.contains("Do not publish unverified locators"), cloudPrompt));
+                () -> assertTrue(cloudPrompt.contains("ask before starting live browser work"), cloudPrompt),
+                () -> assertTrue(cloudPrompt.contains("Do not publish locators as verified"), cloudPrompt));
     }
 
     @Test
-    void localAgentLoginCodeGenerationRequiresUrlConfirmationAndLiveLocatorProof() {
+    void localAgentLoginCodeGenerationRequiresUrlConfirmationBeforeLiveLocatorProof() {
         AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
                 "generate code to login to saucedemo",
                 "CODEX",
@@ -305,10 +323,29 @@ class AssistantCommandTest {
                 () -> assertTrue(prompt.contains("ask the user to confirm the exact target URL"), prompt),
                 () -> assertTrue(prompt.contains("Do not infer canonical URLs"), prompt),
                 () -> assertTrue(prompt.contains("Never substitute a different URL, domain, or example page"), prompt),
+                () -> assertTrue(prompt.contains("ask before starting live browser work"), prompt),
+                () -> assertFalse(prompt.contains("Live browser verification was explicitly requested"), prompt),
+                () -> assertTrue(prompt.contains("Do not publish locators as verified"), prompt),
+                () -> assertTrue(prompt.contains("Return only SHAFT-syntax Java"), prompt));
+    }
+
+    @Test
+    void localAgentCodeGenerationCanRequestExplicitLiveBrowserVerification() {
+        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+                "generate code to login to https://example.com and verify locators live",
+                "CODEX",
+                "AGENT",
+                ".",
+                "",
+                true);
+
+        String prompt = invocation.arguments().get("prompt").getAsString();
+
+        assertAll(
+                () -> assertTrue(prompt.contains("Live browser verification was explicitly requested"), prompt),
                 () -> assertTrue(prompt.contains("Open a real browser session"), prompt),
                 () -> assertTrue(prompt.contains("browser_open_intent"), prompt),
                 () -> assertTrue(prompt.contains("element_type, element_click, or natural_act"), prompt),
-                () -> assertTrue(prompt.contains("Do not publish unverified locators"), prompt),
                 () -> assertTrue(prompt.contains("Return only SHAFT-syntax Java"), prompt));
     }
 

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -353,6 +353,7 @@ class ShaftPanelSetupTest {
             assertAll(
                     () -> assertTrue(copied.get().contains("install-shaft-mcp")),
                     () -> assertTrue(copied.get().contains("codex")),
+                    () -> assertTrue(copied.get().contains("--install-shaft-skills")),
                     () -> assertTrue(copied.get().contains("/main/scripts/mcp/install-shaft-mcp")),
                     () -> assertFalse(copied.get().contains("SHAFT_MCP_INSTALLER_REF")),
                     () -> assertEquals("Command copied to clipboard", toast.get()),
@@ -399,7 +400,8 @@ class ShaftPanelSetupTest {
                 () -> assertNotNull(manualTarget),
                 () -> assertFalse(target.isVisible()),
                 () -> assertEquals("CODEX", target.getSelectedItem()),
-                () -> assertTrue(installer.getText().contains("codex")));
+                () -> assertTrue(installer.getText().contains("codex")),
+                () -> assertTrue(installer.getText().contains("--install-shaft-skills")));
 
         family.setSelectedItem("CLAUDE");
         runtime.setSelectedItem("DESKTOP_APP");
@@ -1978,6 +1980,7 @@ class ShaftPanelSetupTest {
                 () -> assertFalse(settings.mcpSetupComplete),
                 () -> assertFalse(settings.agentGuidanceOptimizationPromptPending),
                 () -> assertTrue(copied.get().contains("install-shaft-mcp")),
+                () -> assertTrue(copied.get().contains("--install-shaft-skills")),
                 () -> assertSingleVisiblePrimarySetupAction(panel, "Open terminal for MCP installer"),
                 () -> assertTrue(containsText(panel, "Installer command copied. Run it in terminal, then check.")));
     }
@@ -2069,27 +2072,18 @@ class ShaftPanelSetupTest {
     }
 
     @Test
-    void assistantAgentModeWarnsOnlyWhenSourceMutationIsNotApproved() {
-        ShaftAssistantPanel blockedPanel = new ShaftAssistantPanel(null, blankMcpSettings());
-        JComboBox<?> blockedMode = findByAccessibleName(blockedPanel, "Assistant mode", JComboBox.class);
-        assertNotNull(blockedMode);
-        blockedMode.setSelectedItem("AGENT");
-        assistantPrompt(blockedPanel).setText("edit this test");
-        clickAccessible(blockedPanel, "Send assistant prompt");
-        assertTrue(transcriptMarkdown(blockedPanel).contains("enable **Allow source edits**"));
-
-        ShaftAssistantPanel approvedPanel = new ShaftAssistantPanel(null, blankMcpSettings());
-        JComboBox<?> approvedMode = findByAccessibleName(approvedPanel, "Assistant mode", JComboBox.class);
-        JCheckBox allowEdits = findByAccessibleName(approvedPanel,
-                "Approve source mutation for Agent mode", JCheckBox.class);
+    void assistantAgentModeSourceEditApprovalOnlyBlocksUnsandboxedCustomCommands() {
         assertAll(
-                () -> assertNotNull(approvedMode),
-                () -> assertNotNull(allowEdits));
-        approvedMode.setSelectedItem("AGENT");
-        allowEdits.setSelected(true);
-        assistantPrompt(approvedPanel).setText("edit this test");
-        clickAccessible(approvedPanel, "Send assistant prompt");
-        assertFalse(transcriptMarkdown(approvedPanel).contains("enable **Allow source edits**"));
+                () -> assertFalse(ShaftAssistantPanel.requiresSourceEditApprovalBeforeSend(
+                        true, false, false, "", "edit this test", "")),
+                () -> assertTrue(ShaftAssistantPanel.requiresSourceEditApprovalBeforeSend(
+                        true, false, false, "custom-agent --unsafe", "edit this test", "")),
+                () -> assertFalse(ShaftAssistantPanel.requiresSourceEditApprovalBeforeSend(
+                        true, false, true, "custom-agent --unsafe", "edit this test", "")),
+                () -> assertFalse(ShaftAssistantPanel.requiresSourceEditApprovalBeforeSend(
+                        false, false, false, "custom-agent --unsafe", "edit this test", "")),
+                () -> assertFalse(ShaftAssistantPanel.requiresSourceEditApprovalBeforeSend(
+                        true, true, false, "custom-agent --unsafe", "edit this test", "")));
     }
 
     @Test
@@ -2107,17 +2101,11 @@ class ShaftPanelSetupTest {
 
     @Test
     void assistantAgentModeSourceEditWarningUsesActiveContextForContinuationPrompt() {
-        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
-        JComboBox<?> assistantMode = findByAccessibleName(panel, "Assistant mode", JComboBox.class);
-        assertNotNull(assistantMode);
-        assistantMode.setSelectedItem("AGENT");
-
-        assistantPrompt(panel).setText("fix this Java test");
-        clickAccessible(panel, "Send assistant prompt");
-        assistantPrompt(panel).setText("try again");
-        clickAccessible(panel, "Send assistant prompt");
-
-        assertEquals(2, countOccurrences(transcriptMarkdown(panel), "enable **Allow source edits**"));
+        assertAll(
+                () -> assertTrue(ShaftAssistantPanel.requiresSourceEditApprovalBeforeSend(
+                        true, false, false, "custom-agent --unsafe", "try again", "fix this Java test")),
+                () -> assertFalse(ShaftAssistantPanel.requiresSourceEditApprovalBeforeSend(
+                        true, false, false, "", "try again", "fix this Java test")));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Allow default local CLI Agent mode to run without source-edit approval by relying on the existing read-only sandbox; custom local commands still require approval.
- Route Page Object/codegen prompts through the guarded local-agent codegen path before natural browser sequences, with code-only/no-browser prompts kept away from live driver execution unless live verification is explicit.
- Add `--install-shaft-skills` to the IntelliJ setup panel's copied installer command.
- Record durable Memory facts for the shipped routing/setup behavior.
- Paired docs sync: ShaftHQ/shafthq.github.io#708.

## Validation
- `gradle test --tests "com.shaft.intellij.ui.AssistantCommandTest" --tests "com.shaft.intellij.ui.ShaftPanelSetupTest"` with JDK 21
- `gradle check` with JDK 21
- `py -3 scripts/ci/validate_shaft_mcp_configuration.py`
- `py -3 scripts/ci/validate_documentation_boundaries.py`
- `py -3 scripts/ci/validate_agent_setup.py --skip-external`
- Docs PR: `npm run test:docs`

Closes #3285.