### PR TITLE
Switch IntelliJ AI defaults and Gemini payloads to JSON schema format

### DIFF
--- a/.memory/events.jsonl
+++ b/.memory/events.jsonl
@@ -140,3 +140,4 @@
 {"actor":"agent","event":"memory.created","id":"decision.assistant-markdown-copy-controls-are-icon-only","timestamp":"2026-07-02T23:32:22+03:00"}
 {"actor":"agent","event":"memory.created","id":"decision.assistant-transcript-fallback-paints-real-rounded-bubbles","timestamp":"2026-07-02T23:32:22+03:00"}
 {"actor":"agent","event":"memory.created","id":"fact.intellij-mcp-setup-troubleshooting","timestamp":"2026-07-03T17:15:57+03:00"}
+{"actor":"agent","event":"memory.created","id":"workflow.reset-core-and-user-guide-before-tasks","timestamp":"2026-07-05T08:31:01+03:00"}

--- a/.memory/memory/workflows/reset-core-and-user-guide-before-tasks.json
+++ b/.memory/memory/workflows/reset-core-and-user-guide-before-tasks.json
@@ -1,0 +1,30 @@
+{
+  "body_path": "memory/workflows/reset-core-and-user-guide-before-tasks.md",
+  "content_hash": "sha256:8a57c1abf50feaec24b94e41c975438dc87e905a416de4ef0110847f84986c65",
+  "created_at": "2026-07-05T08:31:01+03:00",
+  "evidence": [],
+  "facets": {
+    "category": "workflow"
+  },
+  "id": "workflow.reset-core-and-user-guide-before-tasks",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Remember user repo reset workflow preference from 2026-07-05"
+  },
+  "status": "active",
+  "tags": [
+    "git",
+    "workflow",
+    "repo-reset",
+    "user-preference"
+  ],
+  "title": "Reset core and user guide repos before tasks",
+  "type": "workflow",
+  "updated_at": "2026-07-05T08:31:01+03:00"
+}

--- a/.memory/memory/workflows/reset-core-and-user-guide-before-tasks.md
+++ b/.memory/memory/workflows/reset-core-and-user-guide-before-tasks.md
@@ -1,0 +1,1 @@
+Before any task, clean/delete local stale branches and worktrees from both SHAFT_ENGINE and shafthq.github.io, then check out the remote main/master branch and override local uncommitted changes except local Graphify files. Evidence: direct user message in this thread on 2026-07-05. This is a user workflow preference and applies unless a later explicit instruction supersedes it.

--- a/shaft-ai/src/main/java/com/shaft/ai/provider/GeminiProvider.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/provider/GeminiProvider.java
@@ -65,9 +65,8 @@ public final class GeminiProvider extends AbstractHttpAiProvider {
         }
         ObjectNode generationConfig = root.putObject("generationConfig");
         generationConfig.put("maxOutputTokens", outputTokenLimit(request, PilotConfiguration.current()));
-        ObjectNode text = generationConfig.putObject("responseFormat").putObject("text");
-        text.put("mimeType", "application/json");
-        text.set("schema", request.desiredResponseSchema());
+        generationConfig.put("responseMimeType", "application/json");
+        generationConfig.set("responseSchema", request.desiredResponseSchema());
         return root;
     }
 

--- a/shaft-ai/src/test/java/com/shaft/ai/provider/ProviderConformanceTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/provider/ProviderConformanceTest.java
@@ -29,6 +29,7 @@ import com.shaft.pilot.ai.EvidenceCategory;
 import com.shaft.pilot.ai.ProcessingLocation;
 import com.shaft.pilot.config.PilotConfiguration;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -92,6 +93,13 @@ class ProviderConformanceTest {
         assertTrue(capturedBody.get().contains("answer"));
         if (!"ollama".equals(providerId)) {
             assertTrue(capturedCredential.get().contains("test-credential"));
+        }
+        if ("gemini".equals(providerId)) {
+            JsonNode body = JSON.readTree(capturedBody.get());
+            JsonNode generationConfig = body.path("generationConfig");
+            assertEquals("application/json", generationConfig.path("responseMimeType").asText());
+            assertTrue(generationConfig.has("responseSchema"));
+            assertFalse(generationConfig.has("responseFormat"));
         }
     }
 
@@ -172,6 +180,38 @@ class ProviderConformanceTest {
         var ids = new AiProviderRegistry().serviceProviders().stream().map(AiProvider::id).toList();
 
         assertEquals(List.of("anthropic", "gemini", "github", "ollama", "openai"), ids);
+    }
+
+    @Test
+    void liveGeminiDuckDuckGoPromptReturnsValidTestCase() {
+        Assumptions.assumeTrue(Boolean.getBoolean("shaft.ai.liveGemini"),
+                "Set -Dshaft.ai.liveGemini=true to run the live Gemini conformance test.");
+        Assumptions.assumeTrue(hasEnvironment("GEMINI_API_KEY"),
+                "Set GEMINI_API_KEY to run the live Gemini conformance test.");
+        SHAFT.Properties.pilot.set()
+                .enabled(true)
+                .provider("gemini")
+                .localConsent(false)
+                .remoteConsent(true)
+                .allowedEvidenceCategories("TEXT")
+                .retryMaxAttempts(1)
+                .timeoutSeconds(60)
+                .maxOutputTokens(2_000);
+
+        AiResponse response = new AiExecutionService().execute(duckDuckGoTestCaseRequest());
+
+        assertEquals(AiResponseStatus.SUCCESS, response.status());
+        assertEquals("gemini", response.provider());
+        assertFalse(response.model().isBlank());
+        JsonNode payload = response.structuredPayload();
+        String className = payload.path("className").asText("");
+        String source = payload.path("source").asText("");
+        String lowerSource = source.toLowerCase(java.util.Locale.ROOT);
+        assertTrue(className.contains("DuckDuckGo"));
+        assertTrue(source.contains("SHAFT"));
+        assertTrue(source.contains("@Test"));
+        assertTrue(lowerSource.contains("duckduckgo"));
+        assertTrue(lowerSource.contains("search"));
     }
 
     @Test
@@ -274,6 +314,42 @@ class ProviderConformanceTest {
                 .timeout(Duration.ofSeconds(1))
                 .deterministicFallback(JSON.createObjectNode().put("answer", "deterministic"))
                 .build();
+    }
+
+    private static AiRequest duckDuckGoTestCaseRequest() {
+        tools.jackson.databind.node.ObjectNode properties = JSON.createObjectNode();
+        properties.set("className", JSON.createObjectNode().put("type", "string"));
+        properties.set("summary", JSON.createObjectNode().put("type", "string"));
+        properties.set("source", JSON.createObjectNode().put("type", "string"));
+        tools.jackson.databind.node.ObjectNode schema = JSON.createObjectNode().put("type", "object");
+        schema.set("properties", properties);
+        schema.putArray("required").add("className").add("summary").add("source");
+        tools.jackson.databind.node.ObjectNode fallback = JSON.createObjectNode()
+                .put("className", "")
+                .put("summary", "")
+                .put("source", "");
+        ApprovalPolicy approval = new ApprovalPolicy(false, true, EnumSet.of(EvidenceCategory.TEXT));
+        return AiRequest.builder("live-gemini-duckduckgo", schema)
+                .text("""
+                        Generate one complete Java TestNG SHAFT Engine web test case.
+                        Requirements:
+                        - Class name must be DuckDuckGoSearchTest.
+                        - Use com.shaft.driver.SHAFT.
+                        - Open https://duckduckgo.com/.
+                        - Search for SHAFT Engine.
+                        - Validate that search results are shown.
+                        - Return Java source in the source field only.
+                        """)
+                .budget(new AiBudget(8_000, 2_000, java.math.BigDecimal.ZERO))
+                .approvalPolicy(approval)
+                .timeout(Duration.ofSeconds(60))
+                .deterministicFallback(fallback)
+                .build();
+    }
+
+    private static boolean hasEnvironment(String name) {
+        String value = System.getenv(name);
+        return value != null && !value.isBlank();
     }
 
     private static void configure(String providerId, int port) {

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Pilot.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Pilot.java
@@ -169,7 +169,7 @@ public interface Pilot extends EngineProperties<Pilot> {
 
     /** @return configured Gemini model */
     @Key("pilot.ai.gemini.model")
-    @DefaultValue("")
+    @DefaultValue("gemini-3.5-flash")
     String geminiModel();
 
     /** @return environment variable containing the Gemini credential */

--- a/shaft-intellij/.idea/workspace.xml
+++ b/shaft-intellij/.idea/workspace.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PropertiesComponent">{}</component>
+</project>

--- a/shaft-intellij/build.gradle.kts
+++ b/shaft-intellij/build.gradle.kts
@@ -95,5 +95,7 @@ tasks {
     test {
         useJUnitPlatform()
         systemProperty("shaft.intellij.screenshotDir", System.getProperty("shaft.intellij.screenshotDir", ""))
+        systemProperty("shaft.intellij.liveGemini", System.getProperty("shaft.intellij.liveGemini", "false"))
+        systemProperty("shaft.intellij.liveMcpCommand", System.getProperty("shaft.intellij.liveMcpCommand", ""))
     }
 }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
@@ -161,12 +161,12 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         ShaftUiLabels.applyFriendlyRenderer(assistantRuntime);
         assistantRuntime.getAccessibleContext().setAccessibleName("Assistant runtime");
         assistantRuntime.getAccessibleContext().setAccessibleDescription("Local runtime: command line, IDE plugin, or desktop app.");
-        cloudProvider = new JComboBox<>(model("openai", "anthropic", "gemini", "github"));
+        cloudProvider = new JComboBox<>(model("gemini", "openai", "anthropic", "github"));
         ShaftUiLabels.applyFriendlyRenderer(cloudProvider);
         cloudProvider.getAccessibleContext().setAccessibleName("Assistant cloud provider");
         cloudProvider.getAccessibleContext().setAccessibleDescription("Cloud provider used by Assistant Ask and Plan prompts.");
         cloudModel = new JBTextField();
-        cloudModel.getEmptyText().setText("Cloud model, for example openai/gpt-4.1");
+        cloudModel.getEmptyText().setText("Cloud model, for example gemini-3.5-flash");
         cloudModel.getAccessibleContext().setAccessibleName("Assistant cloud model");
         cloudModel.getAccessibleContext().setAccessibleDescription("Model name passed to the selected cloud provider.");
         defaultClient = new JComboBox<>(model("CODEX", "CLAUDE_CODE", "COPILOT_CLI"));
@@ -188,7 +188,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         pilotAiProvider.getAccessibleContext().setAccessibleDescription(
                 "Optional SHAFT AI provider used by MCP tools that request configured provider assistance.");
         pilotAiModel = new JBTextField();
-        pilotAiModel.getEmptyText().setText("Provider model, for example gpt-4.1");
+        pilotAiModel.getEmptyText().setText("Provider model, for example gemini-3.5-flash");
         pilotAiModel.getAccessibleContext().setAccessibleName("SHAFT AI provider model");
         pilotAiModel.getAccessibleContext().setAccessibleDescription("Model name passed to SHAFT MCP provider tools.");
         passProviderKeys = new JBCheckBox("Pass stored provider keys to SHAFT MCP environment");
@@ -287,7 +287,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
                 || !Objects.equals(stateProviderType, selectedProviderType)
                 || !Objects.equals(resolveFamily(state), assistantFamily.getSelectedItem())
                 || !Objects.equals(normalize(state.assistantRuntime, "CLI"), assistantRuntime.getSelectedItem())
-                || !Objects.equals(normalizeLower(state.cloudProvider, "openai"), cloudProvider.getSelectedItem())
+                || !Objects.equals(normalizeLower(state.cloudProvider, "gemini"), cloudProvider.getSelectedItem())
                 || !Objects.equals(state.cloudModel == null ? "" : state.cloudModel, cloudModel.getText())
                 || !Objects.equals(state.defaultAutobotClient, clientFromFamily(String.valueOf(assistantFamily.getSelectedItem())))
                 || !Objects.equals(state.defaultAutobotMode, defaultMode.getSelectedItem())
@@ -349,7 +349,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         assistantProviderType.setSelectedItem(normalize(state.assistantProviderType, "LOCAL"));
         assistantFamily.setSelectedItem(resolveFamily(state));
         assistantRuntime.setSelectedItem(normalize(state.assistantRuntime, "CLI"));
-        cloudProvider.setSelectedItem(normalizeLower(state.cloudProvider, "openai"));
+        cloudProvider.setSelectedItem(normalizeLower(state.cloudProvider, "gemini"));
         cloudModel.setText(state.cloudModel == null ? "" : state.cloudModel);
         defaultClient.setSelectedItem(clientFromFamily(resolveFamily(state)));
         defaultMode.setSelectedItem(state.defaultAutobotMode);
@@ -697,7 +697,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
     private static String currentAgentConfigurationText(ShaftSettingsState.Settings state) {
         if (state.advancedUiEnabled && "CLOUD".equals(normalize(state.assistantProviderType, "LOCAL"))) {
             String model = state.cloudModel == null || state.cloudModel.isBlank() ? "" : " / " + state.cloudModel.trim();
-            return "Agent: Cloud / " + ShaftUiLabels.friendly(normalizeLower(state.cloudProvider, "openai")) + model;
+            return "Agent: Cloud / " + ShaftUiLabels.friendly(normalizeLower(state.cloudProvider, "gemini")) + model;
         }
         return "Agent: Local / " + ShaftUiLabels.friendly(resolveFamily(state))
                 + " / " + ShaftUiLabels.friendly(normalize(state.assistantRuntime, "CLI"));

--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsState.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsState.java
@@ -43,8 +43,8 @@ public final class ShaftSettingsState implements PersistentStateComponent<ShaftS
         public String assistantProviderType = "LOCAL";
         public String assistantFamily = "";
         public String assistantRuntime = "CLI";
-        public String cloudProvider = "openai";
-        public String cloudModel = "";
+        public String cloudProvider = "gemini";
+        public String cloudModel = "gemini-3.5-flash";
         public String defaultAutobotClient = "CODEX";
         public String defaultAutobotMode = "ASK";
         public String pilotAiProvider = "none";

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -1836,7 +1836,7 @@ final class AssistantCommand {
         }
 
         static Selection cloud(String provider, String model) {
-            return new Selection(true, "", "", normalize(provider, "openai").toLowerCase(Locale.ROOT),
+            return new Selection(true, "", "", normalize(provider, "gemini").toLowerCase(Locale.ROOT),
                     model == null ? "" : model.trim());
         }
 

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -273,8 +273,8 @@ final class ShaftAssistantPanel extends JPanel {
         currentAgentConfiguration.getAccessibleContext().setAccessibleName("Current agent configuration");
         currentAgentConfiguration.getAccessibleContext().setAccessibleDescription(
                 "Read-only assistant agent configuration from the completed MCP setup flow.");
-        cloudProvider = combo("Assistant cloud provider", "openai", "anthropic", "gemini", "github");
-        cloudProvider.setSelectedItem(normalizeLower(settings.cloudProvider, "openai"));
+        cloudProvider = combo("Assistant cloud provider", "gemini", "openai", "anthropic", "github");
+        cloudProvider.setSelectedItem(normalizeLower(settings.cloudProvider, "gemini"));
         cloudModel = new JBTextField();
         cloudModel.setColumns(16);
         cloudModel.getEmptyText().setText("model");
@@ -2134,7 +2134,7 @@ final class ShaftAssistantPanel extends JPanel {
     private String currentAgentConfigurationText() {
         if (settings.advancedUiEnabled && "CLOUD".equals(normalize(settings.assistantProviderType, "LOCAL"))) {
             String model = settings.cloudModel == null || settings.cloudModel.isBlank() ? "" : " " + settings.cloudModel.trim();
-            return ShaftUiLabels.friendly(normalizeLower(settings.cloudProvider, "openai")) + model;
+            return ShaftUiLabels.friendly(normalizeLower(settings.cloudProvider, "gemini")) + model;
         }
         return ShaftUiLabels.friendly(resolveFamily(settings)) + " "
                 + ShaftUiLabels.friendly(normalize(settings.assistantRuntime, "CLI"));
@@ -2143,7 +2143,7 @@ final class ShaftAssistantPanel extends JPanel {
     private String currentAgentConfigurationTooltip() {
         if (settings.advancedUiEnabled && "CLOUD".equals(normalize(settings.assistantProviderType, "LOCAL"))) {
             String model = settings.cloudModel == null || settings.cloudModel.isBlank() ? "" : " / " + settings.cloudModel.trim();
-            return "Agent: Cloud / " + ShaftUiLabels.friendly(normalizeLower(settings.cloudProvider, "openai")) + model;
+            return "Agent: Cloud / " + ShaftUiLabels.friendly(normalizeLower(settings.cloudProvider, "gemini")) + model;
         }
         return "Agent: Local / " + ShaftUiLabels.friendly(resolveFamily(settings))
                 + " / " + ShaftUiLabels.friendly(normalize(settings.assistantRuntime, "CLI"));

--- a/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpEnvironmentTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpEnvironmentTest.java
@@ -29,7 +29,24 @@ class ShaftMcpEnvironmentTest {
     }
 
     @Test
+    void javaToolOptionsUseGeminiCloudDefaults() {
+        ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
+        settings.assistantProviderType = "CLOUD";
+        settings.passProviderApiKeysToMcp = false;
+
+        Map<String, String> environment = ShaftMcpEnvironment.forSettings(settings);
+
+        String options = environment.get("JAVA_TOOL_OPTIONS");
+        assertTrue(options.contains("-Dpilot.ai.enabled=true"));
+        assertTrue(options.contains("-Dpilot.ai.provider=gemini"));
+        assertTrue(options.contains("-Dpilot.ai.consent.remote=true"));
+        assertTrue(options.contains("-Dpilot.ai.gemini.model=gemini-3.5-flash"));
+        assertFalse(environment.containsKey("GEMINI_API_KEY"));
+    }
+
+    @Test
     void selectedProviderKeyNameIsStable() {
+        assertEquals("GEMINI_API_KEY", ShaftMcpEnvironment.providerKeyName("gemini"));
         assertEquals("GITHUB_TOKEN", ShaftMcpEnvironment.providerKeyName("github"));
         assertEquals("ANTHROPIC_API_KEY", ShaftMcpEnvironment.providerKeyName("anthropic"));
         assertEquals("", ShaftMcpEnvironment.providerKeyName("none"));

--- a/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftSettingsConfigurableTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftSettingsConfigurableTest.java
@@ -108,6 +108,14 @@ class ShaftSettingsConfigurableTest {
         assertNotNull(findByAccessibleName(panel, "Assistant family"));
         assertNotNull(findByAccessibleName(panel, "Assistant runtime"));
 
+        JComboBox<?> assistantCloudProvider = findByAccessibleName(panel, "Assistant cloud provider", JComboBox.class);
+        JBTextField assistantCloudModel = findByAccessibleName(panel, "Assistant cloud model", JBTextField.class);
+        JBTextField shaftAiModel = findByAccessibleName(panel, "SHAFT AI provider model", JBTextField.class);
+        assertEquals("gemini", assistantCloudProvider.getSelectedItem());
+        assertEquals("gemini-3.5-flash", assistantCloudModel.getText());
+        assertEquals("Cloud model, for example gemini-3.5-flash", assistantCloudModel.getEmptyText().getText());
+        assertEquals("Provider model, for example gemini-3.5-flash", shaftAiModel.getEmptyText().getText());
+
         collectAllButtons(panel).forEach(ShaftSettingsConfigurableTest::assertIconOnlySymmetric);
     }
 

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
@@ -134,6 +134,23 @@ class AssistantCommandTest {
     }
 
     @Test
+    void cloudSelectionDefaultsBlankProviderToGemini() {
+        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+                "Summarize this test",
+                AssistantCommand.Selection.cloud("", ""),
+                "ASK",
+                ".",
+                "",
+                true);
+
+        assertEquals("autobot_provider_chat", invocation.toolName());
+        assertEquals("gemini", invocation.arguments().get("provider").getAsString());
+        assertEquals("", invocation.arguments().get("model").getAsString());
+        assertEquals("ASK", invocation.arguments().get("mode").getAsString());
+        assertFalse(invocation.arguments().get("allowSourceMutation").getAsBoolean());
+    }
+
+    @Test
     void askOrPlanMcpNaturalLanguagePromptsRequireAgentModeButSlashCommandsDoNot() {
         AssistantCommand.Invocation natural = AssistantCommand.fromPrompt(
                 "open duckduckgo and search for SHAFT Engine",

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantGeminiLiveE2ETest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantGeminiLiveE2ETest.java
@@ -1,0 +1,176 @@
+package com.shaft.intellij.ui;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.shaft.intellij.mcp.ShaftCommandLine;
+import com.shaft.intellij.settings.ShaftSettingsState;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class AssistantGeminiLiveE2ETest {
+    @Test
+    void livePluginMcpGeminiPromptGeneratesValidDuckDuckGoTestCase() throws Exception {
+        Assumptions.assumeTrue(Boolean.getBoolean("shaft.intellij.liveGemini"),
+                "Set -Dshaft.intellij.liveGemini=true to run the live Gemini IntelliJ MCP test.");
+        String apiKey = System.getenv("GEMINI_API_KEY");
+        Assumptions.assumeTrue(apiKey != null && !apiKey.isBlank(),
+                "Set GEMINI_API_KEY to run the live Gemini IntelliJ MCP test.");
+        String commandLine = System.getProperty("shaft.intellij.liveMcpCommand", "").trim();
+        Assumptions.assumeTrue(!commandLine.isBlank(),
+                "Set -Dshaft.intellij.liveMcpCommand to a SHAFT MCP stdio command.");
+
+        Path workspace = Path.of(System.getProperty("shaft.intellij.workspaceRoot", ".."))
+                .toAbsolutePath()
+                .normalize();
+        ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
+        settings.assistantProviderType = "CLOUD";
+        settings.cloudProvider = "gemini";
+        settings.cloudModel = "gemini-3.5-flash";
+        settings.passProviderApiKeysToMcp = false;
+        Map<String, String> environment = new HashMap<>(mcpEnvironment(settings));
+        environment.put("GEMINI_API_KEY", apiKey);
+        environment.put("SHAFT_MCP_WORKSPACE_ROOT", workspace.toString());
+
+        String options = environment.getOrDefault("JAVA_TOOL_OPTIONS", "");
+        assertTrue(options.contains("-Dpilot.ai.provider=gemini"));
+        assertTrue(options.contains("-Dpilot.ai.gemini.model=gemini-3.5-flash"));
+
+        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+                """
+                        /codegen create one complete Java TestNG SHAFT Engine web test case.
+                        Requirements:
+                        - Class name must be DuckDuckGoSearchTest.
+                        - Use com.shaft.driver.SHAFT.
+                        - Open https://duckduckgo.com/.
+                        - Search for SHAFT Engine.
+                        - Validate that search results are shown.
+                        - Return the Java source for the test case.
+                        """,
+                AssistantCommand.Selection.cloud("", ""),
+                "ASK",
+                workspace.toString(),
+                "",
+                false);
+
+        assertEquals("autobot_provider_chat", invocation.toolName());
+        assertEquals("gemini", invocation.arguments().get("provider").getAsString());
+        assertEquals("ASK", invocation.arguments().get("mode").getAsString());
+
+        JsonElement result = callTool(
+                ShaftCommandLine.parse(commandLine),
+                workspace,
+                environment,
+                invocation.toolName(),
+                invocation.arguments(),
+                Duration.ofSeconds(150));
+        String responseText = mcpText(result);
+        JsonObject response;
+        try {
+            response = JsonParser.parseString(responseText).getAsJsonObject();
+        } catch (com.google.gson.JsonSyntaxException exception) {
+            fail("MCP text response was not JSON. Preview: " + preview(responseText), exception);
+            return;
+        }
+        String answer = response.get("answer").getAsString();
+        String lowerAnswer = answer.toLowerCase(Locale.ROOT);
+        String markdown = AssistantMarkdown.fromMcpOutput(invocation.toolName(), result.toString());
+
+        assertEquals("SUCCESS", response.get("status").getAsString(), response.toString());
+        assertEquals("gemini", response.get("provider").getAsString());
+        assertEquals("gemini-3.5-flash", response.get("model").getAsString());
+        assertEquals("ASK", response.get("mode").getAsString());
+        assertTrue(answer.contains("DuckDuckGoSearchTest"), answer);
+        assertTrue(answer.contains("SHAFT"), answer);
+        assertTrue(answer.contains("@Test"), answer);
+        assertTrue(lowerAnswer.contains("duckduckgo.com"), answer);
+        assertTrue(lowerAnswer.contains("search"), answer);
+        assertFalse(AssistantMarkdown.containsRejectedGeneratedJava(markdown), markdown);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, String> mcpEnvironment(ShaftSettingsState.Settings settings) throws Exception {
+        Class<?> environmentClass = Class.forName("com.shaft.intellij.mcp.ShaftMcpEnvironment");
+        Method forSettings = environmentClass.getDeclaredMethod("forSettings", ShaftSettingsState.Settings.class);
+        forSettings.setAccessible(true);
+        return (Map<String, String>) forSettings.invoke(null, settings);
+    }
+
+    private static JsonElement callTool(
+            List<String> command,
+            Path workspace,
+            Map<String, String> environment,
+            String toolName,
+            JsonObject arguments,
+            Duration timeout) throws Exception {
+        Class<?> clientClass = Class.forName("com.shaft.intellij.mcp.ShaftMcpStdioClient");
+        Constructor<?> constructor = clientClass.getDeclaredConstructor(List.class, Path.class, Map.class);
+        constructor.setAccessible(true);
+        Object client = constructor.newInstance(command, workspace, environment);
+        try {
+            Method callTool = clientClass.getDeclaredMethod("callTool", String.class, JsonObject.class, Duration.class);
+            callTool.setAccessible(true);
+            return (JsonElement) callTool.invoke(client, toolName, arguments, timeout);
+        } catch (InvocationTargetException exception) {
+            Throwable cause = exception.getCause();
+            if (cause instanceof IOException ioException) {
+                throw ioException;
+            }
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            throw exception;
+        } finally {
+            Method close = clientClass.getDeclaredMethod("close");
+            close.setAccessible(true);
+            close.invoke(client);
+        }
+    }
+
+    private static String mcpText(JsonElement result) {
+        JsonElement current = result;
+        for (int depth = 0; depth < 3; depth++) {
+            if (current == null || !current.isJsonObject()) {
+                break;
+            }
+            JsonObject object = current.getAsJsonObject();
+            if (!object.has("content")) {
+                break;
+            }
+            JsonObject item = object.getAsJsonArray("content").get(0).getAsJsonObject();
+            String text = item.get("text").getAsString();
+            JsonElement nested;
+            try {
+                nested = JsonParser.parseString(text);
+            } catch (com.google.gson.JsonSyntaxException exception) {
+                return text;
+            }
+            if (!nested.isJsonObject()) {
+                return text;
+            }
+            current = nested;
+        }
+        return current.toString();
+    }
+
+    private static String preview(String text) {
+        String normalized = text == null ? "" : text.replaceAll("\\s+", " ").trim();
+        return normalized.length() <= 500 ? normalized : normalized.substring(0, 500);
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/AutobotService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/AutobotService.java
@@ -149,7 +149,7 @@ public class AutobotService {
             AiRequest request = AiRequest.builder("autobot-provider-chat", answerSchema())
                     .text(prompt == null ? "" : prompt)
                     .approvalPolicy(new ApprovalPolicy(false, true, EnumSet.of(EvidenceCategory.TEXT)))
-                    .budget(new AiBudget(8_000, 1_000, BigDecimal.ZERO))
+                    .budget(new AiBudget(8_000, 2_000, BigDecimal.ZERO))
                     .timeout(Duration.ofSeconds(timeoutSeconds > 0 ? timeoutSeconds : DEFAULT_TIMEOUT_SECONDS))
                     .deterministicFallback(JSON.createObjectNode().put("answer", ""))
                     .build();
@@ -202,6 +202,6 @@ public class AutobotService {
     }
 
     private static String normalizeProvider(String provider) {
-        return provider == null || provider.isBlank() ? "openai" : provider.trim().toLowerCase(Locale.ROOT);
+        return provider == null || provider.isBlank() ? "gemini" : provider.trim().toLowerCase(Locale.ROOT);
     }
 }

--- a/shaft-mcp/src/test/java/com/shaft/mcp/AutobotServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/AutobotServiceTest.java
@@ -8,6 +8,7 @@ import com.shaft.pilot.agent.LocalAgentService;
 import com.shaft.pilot.agent.LocalAgentStatus;
 import com.shaft.pilot.ai.AiResponse;
 import com.shaft.pilot.ai.AiResponseStatus;
+import com.shaft.pilot.config.PilotConfiguration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -105,6 +106,30 @@ class AutobotServiceTest {
         assertEquals(AiResponseStatus.SUCCESS.name(), response.status());
         assertEquals("ok", response.answer());
         assertEquals("Explain this failure", capturedText.get());
+    }
+
+    @Test
+    void providerChatDefaultsBlankProviderToGeminiDefaultModel() {
+        AtomicReference<String> capturedProvider = new AtomicReference<>("");
+        AtomicReference<String> capturedModel = new AtomicReference<>("");
+        AutobotService service = new AutobotService(McpWorkspacePolicy.of(workspace),
+                new LocalAgentService(client -> true, new CapturingRunner()), request -> {
+                    PilotConfiguration configuration = PilotConfiguration.current();
+                    capturedProvider.set(configuration.provider());
+                    capturedModel.set(configuration.provider("gemini").model());
+                    return AiResponse.success("gemini", capturedModel.get(),
+                            tools.jackson.databind.node.JsonNodeFactory.instance.objectNode().put("answer", "ok"),
+                            Duration.ofMillis(10), com.shaft.pilot.ai.AiUsage.empty(), request.deterministicFallback());
+                });
+
+        AutobotProviderChatResponse response = service.runProviderChat(
+                "", "", "ASK", "Explain this failure", "", 10, false);
+
+        assertEquals(AiResponseStatus.SUCCESS.name(), response.status());
+        assertEquals("gemini", response.provider());
+        assertEquals("gemini-3.5-flash", response.model());
+        assertEquals("gemini", capturedProvider.get());
+        assertEquals("gemini-3.5-flash", capturedModel.get());
     }
 
     private static final class CapturingRunner implements LocalAgentProcessRunner {

--- a/shaft-mcp/src/test/resources/fixtures/shaft-pilot/providers/gemini.properties
+++ b/shaft-mcp/src/test/resources/fixtures/shaft-pilot/providers/gemini.properties
@@ -3,6 +3,6 @@ pilot.ai.provider=gemini
 pilot.ai.consent.local=false
 pilot.ai.consent.remote=true
 pilot.ai.allowedEvidenceCategories=TEXT,LOG,CONFIGURATION
-pilot.ai.gemini.model=<model>
+pilot.ai.gemini.model=gemini-3.5-flash
 pilot.ai.gemini.apiKeyEnvironmentVariable=GEMINI_API_KEY
 pilot.ai.telemetry.enabled=false

--- a/shaft-pilot-core/src/test/java/com/shaft/pilot/config/ProviderConfigurationTest.java
+++ b/shaft-pilot-core/src/test/java/com/shaft/pilot/config/ProviderConfigurationTest.java
@@ -66,4 +66,17 @@ class ProviderConfigurationTest {
         assertEquals(ProcessingLocation.REMOTE, configuration.processingLocation());
         SHAFT.Properties.clearForCurrentThread();
     }
+
+    @Test
+    void currentConfigurationUsesGeminiFlashAsDefaultModel() {
+        SHAFT.Properties.clearForCurrentThread();
+
+        ProviderConfiguration configuration = PilotConfiguration.current().provider("gemini");
+
+        assertEquals(URI.create("https://generativelanguage.googleapis.com/v1beta/models"), configuration.endpoint());
+        assertEquals("gemini-3.5-flash", configuration.model());
+        assertEquals("GEMINI_API_KEY", configuration.apiKeyEnvironmentVariable());
+        assertEquals(ProcessingLocation.REMOTE, configuration.processingLocation());
+        SHAFT.Properties.clearForCurrentThread();
+    }
 }


### PR DESCRIPTION
## Summary
- Updated Gemini request payloads to use `responseMimeType` and `responseSchema` instead of the nested response format object.
- Switched SHAFT IntelliJ cloud defaults and UI labels to Gemini, including provider/model defaults and selection order.
- Added conformance and live E2E coverage for Gemini-backed DuckDuckGo test case generation.
- Set the engine-side default Gemini model to `gemini-3.5-flash`.

## Testing
- Added/updated unit tests for Gemini payload shape, IntelliJ settings defaults, assistant command selection, and MCP environment wiring.
- Added live Gemini conformance and IntelliJ MCP E2E tests guarded by opt-in system properties and `GEMINI_API_KEY`.
- Not run (not requested).