### PR TITLE
Adopt agentic skills/MCP tooling (partial implementation of #3292)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "extraKnownMarketplaces": {
+    "anthropics/knowledge-work-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/knowledge-work-plugins"
+      }
+    },
+    "anthropics/skills": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/skills"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "jdtls-lsp@claude-plugins-official": true,
+    "design@anthropics/knowledge-work-plugins": true,
+    "frontend-design@claude-plugins-official": true,
+    "mcp-server-dev@claude-plugins-official": true,
+    "chrome-devtools-mcp@claude-plugins-official": true,
+    "example-skills@anthropics/skills": true
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,9 +6,7 @@
     },
     "maven-tools-mcp": {
       "command": "docker",
-      "args": ["run", "-i", "--rm", "arvindand/maven-tools-mcp:latest"],
-      "alwaysAllow": false,
-      "autoApprove": false
+      "args": ["run", "-i", "--rm", "arvindand/maven-tools-mcp:latest"]
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    },
+    "maven-tools-mcp": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "arvindand/maven-tools-mcp:latest"],
+      "alwaysAllow": false,
+      "autoApprove": false
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,23 @@ Before forked Maven/Surefire/TestNG, load gotchas. If delete gotcha is active, a
 
 PowerShell: quote `'-Dname=value'`, `'stash@{0}'`, args with `{}`, `@`, `;`, `&`, `|`. Confirm Allure before SHAFT verdicts.
 
+## Agentic Skills & MCP Tools
+
+Issue #3292: 8 of 10 skills/MCP servers adopted (configured in `.claude/settings.json`, `.mcp.json`).
+
+- `jdtls-lsp`: Java language server; precise symbol navigation across Maven reactor and shaft-intellij.
+- `design` plugin: WCAG audits, design-critique, UX copywriting for Swing UI and docs DESIGN_LANGUAGE.md.
+- `frontend-design`: Distinctive visual design guidance for docs React components.
+- `mcp-server-dev`: Best practices for MCP server design (shaft-mcp has 80+ tools, published to registry).
+- `chrome-devtools-mcp`: Performance traces, network analysis, console debugging for docs UI and AutoBot.
+- `context7` (MCP): Version-pinned library docs on demand (Spring Boot 4.1, Spring AI 2.0, JUnit 6, Selenium 4.45, etc.).
+- `maven-tools-mcp` (MCP): Maven Central tools (version lookups, upgrade recommendations, license/CVE) for release automation.
+- `webapp-testing`: Playwright verification workflow for screenshot/browser-log evidence on UI/report PRs.
+
+**Not configurable here (separate follow-up):**
+- JetBrains IntelliJ IDEA MCP server (#5): Manual enable in IDEA 2025.2+ via Settings | Tools | MCP Server.
+- `a11ymcp` (#7): For shafthq.github.io docs repo; requires separate PR with axe-core accessibility testing.
+
 ## Completion
 
 Report changes/checks/outcomes.


### PR DESCRIPTION
## Summary

Implements 8 of 10 recommended agentic skills/MCP servers from issue #3292 to improve developer efficiency, reduce token usage, and enhance UX for both shaft-intellij and the SHAFT user guide.

**Configured items:**
- `.claude/settings.json`: Declares two new marketplaces (anthropics/knowledge-work-plugins, anthropics/skills) and enables 6 plugins/skills
- `.mcp.json`: Declares two project-scoped MCP servers (context7 for version-pinned library docs, maven-tools-mcp for Maven Central intelligence)
- `AGENTS.md`: Added "Agentic Skills & MCP Tools" section documenting what each tool is for and when to use it

**Implementation details:**
- `jdtls-lsp`: Java language server plugin from claude-plugins-official
- `design`: Bundle of design-practice skills from anthropics/knowledge-work-plugins marketplace
- `frontend-design`: Distinctive visual design guidance plugin
- `mcp-server-dev`: Best practices for MCP server design
- `chrome-devtools-mcp`: Chrome DevTools for performance/network debugging
- `context7`: MCP server for version-pinned library docs (npx @upstash/context7-mcp)
- `maven-tools-mcp`: MCP server for Maven Central data (docker run)
- `webapp-testing`: Playwright verification workflow skill

**Not implemented (separate follow-up):**
- JetBrains IntelliJ IDEA built-in MCP server (#5): Requires manual developer setup in IDEA 2025.2+; not configurable via repo files
- `a11ymcp` (#7): Intended for shafthq.github.io docs repo; requires separate PR to that repository

Addresses #3292

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>