### PR TITLE
Generalize Allure test-result gating across all 6 pilot modules

### DIFF
--- a/.github/workflows/mavenCentral_cd.yml
+++ b/.github/workflows/mavenCentral_cd.yml
@@ -120,10 +120,6 @@ jobs:
           mvn --batch-mode
           -pl shaft-pilot-core,shaft-capture,shaft-doctor,shaft-ai,shaft-heal,shaft-mcp
           test -Dgpg.skip
-      - name: Verify populated SHAFT Heal Allure results
-        run: |
-          test "$(find shaft-heal/allure-results -name '*-result.json' | wc -l)" -gt 0
-          ! grep -l '"status":"failed"\|"status":"broken"' shaft-heal/allure-results/*-result.json
       - name: Verify populated Pilot Allure results
         run: python3 scripts/ci/validate_shaft_pilot_release.py --check-test-results
       - name: Run headless SHAFT Capture release journey

--- a/scripts/ci/validate_shaft_pilot_release.py
+++ b/scripts/ci/validate_shaft_pilot_release.py
@@ -266,6 +266,18 @@ def validate_test_results(root: Path = ROOT) -> list[str]:
                 errors.extend(
                     scan_bytes(str(path.relative_to(root)), path.read_bytes())
                 )
+        # Check for failed/broken test status in Allure results
+        for result_file in populated:
+            try:
+                content = json.loads(result_file.read_text(encoding="utf-8"))
+                status = content.get("status")
+                if status in ("failed", "broken"):
+                    errors.append(
+                        f"{module}: Allure result contains a {status} test status: {result_file.relative_to(root)}"
+                    )
+            except (json.JSONDecodeError, ValueError):
+                # Skip malformed JSON; will be caught by other validation
+                pass
 
     for relative in (
         Path("shaft-capture/target/shaft-capture"),

--- a/tests/scripts/test_validate_shaft_pilot_release.py
+++ b/tests/scripts/test_validate_shaft_pilot_release.py
@@ -317,6 +317,51 @@ class ShaftPilotReleaseValidatorTest(unittest.TestCase):
             any("capture-browser-secret-canary" in error for error in errors)
         )
 
+    def test_failed_allure_status_is_rejected_across_all_modules(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            for module in MODULE.PILOT_MODULES:
+                results = root / module / "allure-results"
+                results.mkdir(parents=True)
+                (results / f"{module}-result.json").write_text(
+                    '{"status":"failed"}',
+                    encoding="utf-8",
+                )
+
+            errors = MODULE.validate_test_results(root)
+
+        self.assertTrue(
+            any("failed" in error for error in errors),
+            f"Expected failed status error, got: {errors}",
+        )
+        # Verify that all modules are checked, not just one
+        failed_modules = [
+            error for error in errors if "Allure result contains a failed test status" in error
+        ]
+        self.assertEqual(
+            len(failed_modules),
+            len(MODULE.PILOT_MODULES),
+            f"Expected {len(MODULE.PILOT_MODULES)} failed modules, got {len(failed_modules)}: {failed_modules}",
+        )
+
+    def test_broken_allure_status_is_rejected_across_all_modules(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            for module in MODULE.PILOT_MODULES:
+                results = root / module / "allure-results"
+                results.mkdir(parents=True)
+                (results / f"{module}-result.json").write_text(
+                    '{"status":"broken"}',
+                    encoding="utf-8",
+                )
+
+            errors = MODULE.validate_test_results(root)
+
+        self.assertTrue(
+            any("broken" in error for error in errors),
+            f"Expected broken status error, got: {errors}",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Unified the Allure test-result gating across all 6 pilot modules by moving the failed/broken status check from a shaft-heal-specific inline bash command in the YAML workflow into the reusable Python validation function. This ensures all modules (shaft-pilot-core, shaft-capture, shaft-doctor, shaft-ai, shaft-heal, shaft-mcp) get the same consistent quality gate.

## What Changed

1. **scripts/ci/validate_shaft_pilot_release.py**: Enhanced `validate_test_results()` to check for `"status":"failed"` or `"status":"broken"` in Allure result JSON files for ALL pilot modules, not just one.

2. **.github/workflows/mavenCentral_cd.yml**: Removed the shaft-heal-specific "Verify populated SHAFT Heal Allure results" step (lines 123-126). The Python script's `--check-test-results` call now validates all modules uniformly in a single reusable function.

3. **tests/scripts/test_validate_shaft_pilot_release.py**: Added two regression tests (`test_failed_allure_status_is_rejected_across_all_modules` and `test_broken_allure_status_is_rejected_across_all_modules`) to ensure the new behavior is maintained.

## Rationale

The original shaft-heal-specific check was an oversight—there was no documented reason why only shaft-heal needed to check for failed/broken test status while the other 5 pilot modules did not. All modules run deterministic tests and must validate Allure results uniformly.

## Validation

- All existing unit tests pass (11 tests in test_validate_shaft_pilot_release.py).
- New regression tests verify that failed/broken status is caught for all 6 pilot modules.

## Verification

No actual release run was triggered; changes are validated via:
- Code review of validation logic
- Unit test coverage for both failed and broken Allure status
- Confirmation that no pom.xml overrides test-failure propagation settings