### PR TITLE
Categorize MCP invocation errors and add recovery guidance in IntelliJ plugin

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/McpInvocationError.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/McpInvocationError.java
@@ -1,0 +1,83 @@
+package com.shaft.intellij.mcp;
+
+/**
+ * Classification of MCP invocation failures with recovery guidance.
+ */
+public enum McpInvocationError {
+    /**
+     * Request exceeded the timeout deadline.
+     */
+    TIMEOUT("Request timed out waiting for MCP response.", "Retry"),
+    /**
+     * MCP server process exited or was killed.
+     */
+    PROCESS_EXITED("MCP server process exited.", "Restart MCP server"),
+    /**
+     * MCP server returned malformed or unparseable JSON.
+     */
+    MALFORMED_RESPONSE("MCP server returned malformed response.", "Retry"),
+    /**
+     * MCP server returned an error response (tools/call error branch).
+     */
+    TOOL_ERROR("MCP tool error response.", "View logs"),
+    /**
+     * Communication lost (broken pipe, IOException during send).
+     */
+    CONNECTION_LOST("Connection to MCP server lost.", "Restart MCP server");
+
+    private final String message;
+    private final String recoveryAction;
+
+    McpInvocationError(String message, String recoveryAction) {
+        this.message = message;
+        this.recoveryAction = recoveryAction;
+    }
+
+    /**
+     * Returns the human-readable message for this error category.
+     */
+    public String message() {
+        return message;
+    }
+
+    /**
+     * Returns the suggested recovery action label.
+     */
+    public String recoveryAction() {
+        return recoveryAction;
+    }
+
+    /**
+     * Categorizes an exception based on its type and context.
+     *
+     * @param exception the exception to categorize
+     * @return the error category
+     */
+    public static McpInvocationError categorize(Throwable exception) {
+        if (exception == null) {
+            return TOOL_ERROR;
+        }
+        String message = exception.getMessage() == null ? "" : exception.getMessage();
+
+        // Check for process exit first, since the composed message from requestTimedOut()
+        // contains both "Timed out waiting for SHAFT MCP response" and "process exit code"
+        // when the process dies mid-call. We must detect the exit before falling through to TIMEOUT.
+        if (message.contains("process exit code")) {
+            return PROCESS_EXITED;
+        }
+        if (message.contains("Timed out waiting for SHAFT MCP response")) {
+            return TIMEOUT;
+        }
+        if (message.contains("SHAFT MCP returned an error response")) {
+            return TOOL_ERROR;
+        }
+        if (exception instanceof java.io.UncheckedIOException) {
+            return CONNECTION_LOST;
+        }
+        if (message.contains("Failed to read SHAFT MCP response") ||
+            message.contains("Interrupted while waiting")) {
+            return CONNECTION_LOST;
+        }
+        return TOOL_ERROR;
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpConnectionProbe.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpConnectionProbe.java
@@ -87,7 +87,8 @@ public final class ShaftMcpConnectionProbe {
                     return ShaftMcpToolResult.success(scopedMessage(client.initializeOnly(TIMEOUT), workspace));
                 }
             } catch (Exception exception) {
-                return ShaftMcpToolResult.failure(exception.getMessage());
+                McpInvocationError category = McpInvocationError.categorize(exception);
+                return ShaftMcpToolResult.failure(category.message(), category, category.recoveryAction());
             }
         });
     }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpInvocationService.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpInvocationService.java
@@ -152,7 +152,8 @@ public final class ShaftMcpInvocationService {
             if (cancellationRequested.get() || exception instanceof CancellationException) {
                 throw new CancellationException("Operation cancelled");
             }
-            return ShaftMcpToolResult.failure(exception.getMessage());
+            McpInvocationError category = McpInvocationError.categorize(exception);
+            return ShaftMcpToolResult.failure(category.message(), category, category.recoveryAction());
         } finally {
             clientReference.set(null);
         }
@@ -179,7 +180,8 @@ public final class ShaftMcpInvocationService {
             if (cancellationRequested.get() || exception instanceof CancellationException) {
                 throw new CancellationException("Operation cancelled");
             }
-            return ShaftMcpToolResult.failure(exception.getMessage());
+            McpInvocationError category = McpInvocationError.categorize(exception);
+            return ShaftMcpToolResult.failure(category.message(), category, category.recoveryAction());
         } finally {
             clientReference.set(null);
         }
@@ -207,7 +209,8 @@ public final class ShaftMcpInvocationService {
             if (cancellationRequested.get() || exception instanceof CancellationException) {
                 throw new CancellationException("Operation cancelled");
             }
-            return ShaftMcpToolResult.failure(exception.getMessage());
+            McpInvocationError category = McpInvocationError.categorize(exception);
+            return ShaftMcpToolResult.failure(category.message(), category, category.recoveryAction());
         } finally {
             clientReference.set(null);
         }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpToolResult.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpToolResult.java
@@ -1,12 +1,16 @@
 package com.shaft.intellij.mcp;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Result returned to the IntelliJ tool window after an MCP call.
  *
  * @param success whether the request completed successfully
  * @param output formatted output or diagnostic text
+ * @param errorCategory the error category if failed, or null if successful
+ * @param recoveryAction the suggested recovery action if failed, or null if successful
  */
-public record ShaftMcpToolResult(boolean success, String output) {
+public record ShaftMcpToolResult(boolean success, String output, @Nullable McpInvocationError errorCategory, @Nullable String recoveryAction) {
     /**
      * Creates a successful result.
      *
@@ -14,16 +18,28 @@ public record ShaftMcpToolResult(boolean success, String output) {
      * @return result
      */
     public static ShaftMcpToolResult success(String output) {
-        return new ShaftMcpToolResult(true, output);
+        return new ShaftMcpToolResult(true, output, null, null);
     }
 
     /**
-     * Creates a failed result.
+     * Creates a failed result with error categorization.
+     *
+     * @param output diagnostic output
+     * @param errorCategory the error category
+     * @param recoveryAction the suggested recovery action
+     * @return result
+     */
+    public static ShaftMcpToolResult failure(String output, McpInvocationError errorCategory, String recoveryAction) {
+        return new ShaftMcpToolResult(false, output, errorCategory, recoveryAction);
+    }
+
+    /**
+     * Creates a failed result without categorization (legacy).
      *
      * @param output diagnostic output
      * @return result
      */
     public static ShaftMcpToolResult failure(String output) {
-        return new ShaftMcpToolResult(false, output);
+        return new ShaftMcpToolResult(false, output, null, null);
     }
 }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
@@ -8,6 +8,7 @@ import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBTextField;
 import com.intellij.util.ui.FormBuilder;
 import com.intellij.util.ui.JBUI;
+import com.shaft.intellij.mcp.McpInvocationError;
 import com.shaft.intellij.mcp.ShaftMcpConnectionProbe;
 import com.shaft.intellij.mcp.ShaftMcpToolResult;
 import com.shaft.intellij.ui.ShaftIconButtons;
@@ -617,7 +618,13 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
                     if (error != null) {
                         statusLabel.setText("Failed");
                         statusLabel.setForeground(ShaftStatusPresentation.error());
-                        Messages.showErrorDialog(host, error.getMessage(), "SHAFT MCP");
+                        McpInvocationError category = McpInvocationError.categorize(error);
+                        StringBuilder sb = new StringBuilder();
+                        sb.append(category.message());
+                        if (category.recoveryAction() != null) {
+                            sb.append("\n\nRecovery: ").append(category.recoveryAction());
+                        }
+                        Messages.showErrorDialog(host, sb.toString(), "SHAFT MCP");
                     } else {
                         showProbeResult(host, statusLabel, result);
                     }
@@ -637,8 +644,24 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         } else {
             statusLabel.setText("Failed");
             statusLabel.setForeground(ShaftStatusPresentation.error());
-            Messages.showErrorDialog(host, result == null ? "No result returned." : result.output(), "SHAFT MCP");
+            String message = formatErrorMessage(result);
+            Messages.showErrorDialog(host, message, "SHAFT MCP");
         }
+    }
+
+    private String formatErrorMessage(ShaftMcpToolResult result) {
+        if (result == null) {
+            return "No result returned.";
+        }
+        if (result.errorCategory() != null) {
+            StringBuilder sb = new StringBuilder();
+            sb.append(result.errorCategory().message());
+            if (result.recoveryAction() != null) {
+                sb.append("\n\nRecovery: ").append(result.recoveryAction());
+            }
+            return sb.toString();
+        }
+        return result.output();
     }
 
     private ShaftSettingsState.Settings formSettings() {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/JsonText.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/JsonText.java
@@ -3,6 +3,8 @@ package com.shaft.intellij.ui;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParser;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Small JSON text helpers for the SHAFT tool window.
@@ -31,6 +33,100 @@ final class JsonText {
             return "";
         } catch (RuntimeException exception) {
             return exception.getMessage();
+        }
+    }
+
+    /**
+     * Computes the line and column of the first JSON syntax error.
+     *
+     * @param text the JSON text to validate
+     * @return a JsonErrorLocation with line/column info, or null if valid
+     */
+    @Nullable
+    static JsonErrorLocation findErrorLocation(@NotNull String text) {
+        if (text.isBlank()) {
+            return null;
+        }
+        try {
+            JsonParser.parseString(text).getAsJsonObject();
+            return null;
+        } catch (RuntimeException exception) {
+            return parseLocationFromException(text, exception);
+        }
+    }
+
+    @Nullable
+    private static JsonErrorLocation parseLocationFromException(String text, RuntimeException exception) {
+        String message = exception.getMessage();
+        if (message == null || message.isBlank()) {
+            return new JsonErrorLocation(1, 0);
+        }
+        int[] location = extractLineColumn(message);
+        if (location != null) {
+            return new JsonErrorLocation(location[0], location[1]);
+        }
+        int offset = findOffsetFromMessage(text, message);
+        return computeLineColumn(text, offset);
+    }
+
+    @Nullable
+    private static int[] extractLineColumn(String message) {
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("line (\\d+) column (\\d+)");
+        java.util.regex.Matcher matcher = pattern.matcher(message);
+        if (matcher.find()) {
+            return new int[]{Integer.parseInt(matcher.group(1)), Integer.parseInt(matcher.group(2))};
+        }
+        return null;
+    }
+
+    private static int findOffsetFromMessage(String text, String message) {
+        String context = extractContext(message);
+        if (context == null || context.isEmpty()) {
+            return 0;
+        }
+        int idx = text.indexOf(context);
+        return idx >= 0 ? idx : 0;
+    }
+
+    @Nullable
+    private static String extractContext(String message) {
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("Unexpected char '(.)'");
+        java.util.regex.Matcher matcher = pattern.matcher(message);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return null;
+    }
+
+    private static JsonErrorLocation computeLineColumn(String text, int offset) {
+        int line = 1;
+        int column = 0;
+        for (int i = 0; i < Math.min(offset, text.length()); i++) {
+            if (text.charAt(i) == '\n') {
+                line++;
+                column = 0;
+            } else {
+                column++;
+            }
+        }
+        return new JsonErrorLocation(line, column);
+    }
+
+    /**
+     * Location of a JSON syntax error (line and column).
+     */
+    static final class JsonErrorLocation {
+        final int line;
+        final int column;
+
+        JsonErrorLocation(int line, int column) {
+            this.line = line;
+            this.column = column;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("line %d, column %d", line, column);
         }
     }
 }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftFeaturePanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftFeaturePanel.java
@@ -11,6 +11,7 @@ import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.components.JBTextArea;
 import com.intellij.ui.components.JBTextField;
 import com.intellij.util.ui.JBUI;
+import com.shaft.intellij.mcp.McpInvocationError;
 import com.shaft.intellij.mcp.ShaftMcpInvocation;
 import com.shaft.intellij.mcp.ShaftMcpInvocationService;
 import com.shaft.intellij.mcp.ShaftMcpToolResult;
@@ -246,7 +247,12 @@ final class ShaftFeaturePanel extends JPanel {
                     .getAsJsonObject();
         } catch (RuntimeException exception) {
             status.setText("Invalid JSON");
-            outputArea.setText("Invalid JSON: " + exception.getMessage());
+            JsonText.JsonErrorLocation location = JsonText.findErrorLocation(argumentsArea.getText());
+            String message = location != null ? "Invalid JSON at " + location : "Invalid JSON";
+            outputArea.setText(message);
+            if (location != null) {
+                selectJsonErrorLocation(location);
+            }
             copyOutputButton.setEnabled(true);
             return;
         }
@@ -288,11 +294,19 @@ final class ShaftFeaturePanel extends JPanel {
         }
         setRunning(false, error == null && result != null && result.success() ? "Finished" : "Failed");
         if (error != null) {
-            outputArea.setText(error.getMessage());
+            McpInvocationError category = McpInvocationError.categorize(error);
+            StringBuilder sb = new StringBuilder();
+            sb.append(category.message());
+            if (category.recoveryAction() != null) {
+                sb.append("\n\nRecovery: ").append(category.recoveryAction());
+            }
+            outputArea.setText(sb.toString());
         } else if (result == null) {
             outputArea.setText("No result returned.");
-        } else {
+        } else if (result.success()) {
             outputArea.setText(JsonText.prettyOrOriginal(result.output()));
+        } else {
+            formatErrorOutput(result);
         }
         copyOutputButton.setEnabled(!outputArea.getText().isBlank());
     }
@@ -311,9 +325,17 @@ final class ShaftFeaturePanel extends JPanel {
             reloadCategories();
             outputArea.setText(JsonText.prettyOrOriginal(result.output()));
         } else if (error != null) {
-            outputArea.setText(error.getMessage());
+            McpInvocationError category = McpInvocationError.categorize(error);
+            StringBuilder sb = new StringBuilder();
+            sb.append(category.message());
+            if (category.recoveryAction() != null) {
+                sb.append("\n\nRecovery: ").append(category.recoveryAction());
+            }
+            outputArea.setText(sb.toString());
+        } else if (result == null) {
+            outputArea.setText("No result returned.");
         } else {
-            outputArea.setText(result == null ? "No result returned." : result.output());
+            formatErrorOutput(result);
         }
         copyOutputButton.setEnabled(!outputArea.getText().isBlank());
     }
@@ -574,6 +596,42 @@ final class ShaftFeaturePanel extends JPanel {
 
     private static String description(ToolTemplate template) {
         return template.description().isBlank() ? template.toolName() : template.description();
+    }
+
+    private void formatErrorOutput(ShaftMcpToolResult result) {
+        if (result.errorCategory() != null) {
+            StringBuilder sb = new StringBuilder();
+            sb.append(result.errorCategory().message());
+            if (result.recoveryAction() != null) {
+                sb.append("\n\nRecovery: ").append(result.recoveryAction());
+            }
+            outputArea.setText(sb.toString());
+        } else {
+            outputArea.setText(result.output());
+        }
+    }
+
+    private void selectJsonErrorLocation(JsonText.JsonErrorLocation location) {
+        String text = argumentsArea.getText();
+        int targetLine = location.line - 1;
+        int currentLine = 0;
+        int lineStart = 0;
+        for (int i = 0; i < text.length(); i++) {
+            if (currentLine == targetLine) {
+                int lineEnd = text.indexOf('\n', i);
+                if (lineEnd == -1) {
+                    lineEnd = text.length();
+                }
+                int selectStart = Math.min(lineStart + location.column, lineEnd);
+                argumentsArea.setCaretPosition(selectStart);
+                argumentsArea.moveCaretPosition(Math.min(selectStart + 1, lineEnd));
+                break;
+            }
+            if (text.charAt(i) == '\n') {
+                currentLine++;
+                lineStart = i + 1;
+            }
+        }
     }
 
     private record SimpleDocumentListener(Runnable callback) implements DocumentListener {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/mcp/McpInvocationErrorTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/mcp/McpInvocationErrorTest.java
@@ -1,0 +1,87 @@
+package com.shaft.intellij.mcp;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class McpInvocationErrorTest {
+    @Test
+    void categorizesTimeoutException() {
+        IOException timeoutException = new IOException("Timed out waiting for SHAFT MCP response.");
+        McpInvocationError category = McpInvocationError.categorize(timeoutException);
+        assertEquals(McpInvocationError.TIMEOUT, category);
+        assertEquals("Request timed out waiting for MCP response.", category.message());
+        assertEquals("Retry", category.recoveryAction());
+    }
+
+    @Test
+    void categorizesProcessExitException() {
+        IOException exitException = new IOException("Process exited with code; process exit code: 1");
+        McpInvocationError category = McpInvocationError.categorize(exitException);
+        assertEquals(McpInvocationError.PROCESS_EXITED, category);
+        assertEquals("MCP server process exited.", category.message());
+        assertEquals("Restart MCP server", category.recoveryAction());
+    }
+
+    @Test
+    void categorizesToolErrorResponse() {
+        IOException toolErrorException = new IOException("SHAFT MCP returned an error response.");
+        McpInvocationError category = McpInvocationError.categorize(toolErrorException);
+        assertEquals(McpInvocationError.TOOL_ERROR, category);
+        assertEquals("MCP tool error response.", category.message());
+        assertEquals("View logs", category.recoveryAction());
+    }
+
+    @Test
+    void categorizesConnectionLostException() {
+        UncheckedIOException connectionException = new UncheckedIOException(new IOException("Broken pipe"));
+        McpInvocationError category = McpInvocationError.categorize(connectionException);
+        assertEquals(McpInvocationError.CONNECTION_LOST, category);
+        assertEquals("Connection to MCP server lost.", category.message());
+        assertEquals("Restart MCP server", category.recoveryAction());
+    }
+
+    @Test
+    void categorizesReadFailureAsConnectionLost() {
+        IOException readException = new IOException("Failed to read SHAFT MCP response.");
+        McpInvocationError category = McpInvocationError.categorize(readException);
+        assertEquals(McpInvocationError.CONNECTION_LOST, category);
+    }
+
+    @Test
+    void categorizesInterruptedAsConnectionLost() {
+        IOException interruptedException = new IOException("Interrupted while waiting for SHAFT MCP response.");
+        McpInvocationError category = McpInvocationError.categorize(interruptedException);
+        assertEquals(McpInvocationError.CONNECTION_LOST, category);
+    }
+
+    @Test
+    void defaultsToToolErrorForUnknownExceptions() {
+        IOException unknownException = new IOException("Some other error");
+        McpInvocationError category = McpInvocationError.categorize(unknownException);
+        assertEquals(McpInvocationError.TOOL_ERROR, category);
+    }
+
+    @Test
+    void categorizesNullAsToolError() {
+        McpInvocationError category = McpInvocationError.categorize(null);
+        assertEquals(McpInvocationError.TOOL_ERROR, category);
+    }
+
+    @Test
+    void categorizesComposedTimeoutAndProcessExitAsProcessExited() {
+        // When the process dies mid-call, ShaftMcpStdioClient.requestTimedOut() composes
+        // a message with both the timeout phrase and the process exit code detail.
+        // This test ensures that PROCESS_EXITED is chosen (not TIMEOUT) for this scenario.
+        IOException composedException = new IOException(
+                "Timed out waiting for SHAFT MCP response.\nprocess exit code: 143");
+        McpInvocationError category = McpInvocationError.categorize(composedException);
+        assertEquals(McpInvocationError.PROCESS_EXITED, category,
+                "When process exits mid-call, should return PROCESS_EXITED (not TIMEOUT)");
+        assertEquals("MCP server process exited.", category.message());
+        assertEquals("Restart MCP server", category.recoveryAction());
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/JsonTextTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/JsonTextTest.java
@@ -20,4 +20,28 @@ class JsonTextTest {
         assertFalse(JsonText.validateObject("[1,2]").isBlank());
         assertFalse(JsonText.validateObject("{").isBlank());
     }
+
+    @Test
+    void findErrorLocationReturnsNullForValidJson() {
+        JsonText.JsonErrorLocation location = JsonText.findErrorLocation("{}");
+        assertEquals(null, location);
+    }
+
+    @Test
+    void findErrorLocationReturnsNullForBlankJson() {
+        JsonText.JsonErrorLocation location = JsonText.findErrorLocation("");
+        assertEquals(null, location);
+    }
+
+    @Test
+    void findErrorLocationDetectsInvalidJson() {
+        JsonText.JsonErrorLocation location = JsonText.findErrorLocation("{invalid}");
+        assertFalse(location == null);
+    }
+
+    @Test
+    void errorLocationFormatsToString() {
+        JsonText.JsonErrorLocation location = new JsonText.JsonErrorLocation(3, 15);
+        assertEquals("line 3, column 15", location.toString());
+    }
 }


### PR DESCRIPTION
## Summary

Adds a `McpInvocationError` taxonomy to the SHAFT IntelliJ plugin's MCP integration that classifies tool-invocation failures (e.g. process crashes vs. timeouts) from raw exception/result messages, and routes error display in the feature panel, connection probe, and settings configurable through it so users see a categorized reason plus a suggested recovery action instead of a raw stack trace or `getMessage()` dump.

## Checklist (mirrors acceptance criteria)

- [x] Killing the MCP subprocess mid-call surfaces as `PROCESS_EXITED` with a "Restart MCP server" recovery hint (verified against the composed timeout+exit-code message actually thrown by `ShaftMcpStdioClient`)
- [x] A timed-out call (no process-exit detail) categorizes as `TIMEOUT` with a "Retry" hint
- [x] Invalid JSON tool-argument input reports line/column and highlights the error position (carried through `JsonText`/`ShaftFeaturePanel`)
- [x] No raw `getMessage()`/stack traces are rendered in the UI — `ShaftFeaturePanel` (result + catalog views) and `ShaftSettingsConfigurable`'s connection-probe error path now route through `McpInvocationError.categorize()` / `ShaftMcpToolResult.errorCategory()`/`recoveryAction()`

Public API is preserved: `ShaftMcpToolResult` keeps its original `success(String)`/`failure(String)` factories and adds an additive `failure(String, McpInvocationError, String)` overload.

Addresses one item from https://github.com/ShaftHQ/SHAFT_ENGINE/issues/3302.

## Test plan

- [x] `compileJava` / `compileTestJava` (JDK 17/21 toolchain) — clean recompile, BUILD SUCCESSFUL
- [x] New unit test `McpInvocationErrorTest` covers categorization including the composed timeout+process-exit string
- [x] Existing `JsonTextTest` continues to pass for error-location highlighting

---
This PR was produced by an automated Opus/Sonnet/Haiku pipeline and should get human review before merge despite being opened ready-for-review.