### PR TITLE
Add experimental SSH shell session API

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/cli/SshShellOptions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/SshShellOptions.java
@@ -1,0 +1,128 @@
+package com.shaft.cli;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Options for an experimental reusable SSH shell session.
+ */
+public final class SshShellOptions {
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
+    private static final String DEFAULT_PTY_TYPE = "vt100";
+    private static final int DEFAULT_COLUMNS = 80;
+    private static final int DEFAULT_ROWS = 24;
+
+    private final boolean pty;
+    private final String ptyType;
+    private final int columns;
+    private final int rows;
+    private final Duration defaultTimeout;
+    private final Map<String, String> environmentVariables;
+
+    private SshShellOptions(Builder builder) {
+        pty = builder.pty;
+        ptyType = builder.ptyType == null || builder.ptyType.isBlank() ? DEFAULT_PTY_TYPE : builder.ptyType;
+        columns = builder.columns;
+        rows = builder.rows;
+        defaultTimeout = builder.defaultTimeout == null ? DEFAULT_TIMEOUT : builder.defaultTimeout;
+        environmentVariables = Collections.unmodifiableMap(new LinkedHashMap<>(builder.environmentVariables));
+        validate();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static SshShellOptions defaults() {
+        return builder().build();
+    }
+
+    private void validate() {
+        if (columns <= 0) {
+            throw new IllegalArgumentException("SSH shell columns must be positive.");
+        }
+        if (rows <= 0) {
+            throw new IllegalArgumentException("SSH shell rows must be positive.");
+        }
+        if (defaultTimeout.isZero() || defaultTimeout.isNegative()) {
+            throw new IllegalArgumentException("SSH shell default timeout must be positive.");
+        }
+    }
+
+    public boolean isPty() {
+        return pty;
+    }
+
+    public String getPtyType() {
+        return ptyType;
+    }
+
+    public int getColumns() {
+        return columns;
+    }
+
+    public int getRows() {
+        return rows;
+    }
+
+    public Duration getDefaultTimeout() {
+        return defaultTimeout;
+    }
+
+    public Map<String, String> getEnvironmentVariables() {
+        return environmentVariables;
+    }
+
+    public static final class Builder {
+        private boolean pty;
+        private String ptyType = DEFAULT_PTY_TYPE;
+        private int columns = DEFAULT_COLUMNS;
+        private int rows = DEFAULT_ROWS;
+        private Duration defaultTimeout = DEFAULT_TIMEOUT;
+        private final Map<String, String> environmentVariables = new LinkedHashMap<>();
+
+        public Builder pty(boolean value) {
+            pty = value;
+            return this;
+        }
+
+        public Builder ptyType(String value) {
+            ptyType = value;
+            return this;
+        }
+
+        public Builder columns(int value) {
+            columns = value;
+            return this;
+        }
+
+        public Builder rows(int value) {
+            rows = value;
+            return this;
+        }
+
+        public Builder defaultTimeout(Duration value) {
+            defaultTimeout = value;
+            return this;
+        }
+
+        public Builder environmentVariable(String key, String value) {
+            environmentVariables.put(Objects.requireNonNull(key), Objects.requireNonNull(value));
+            return this;
+        }
+
+        public Builder environmentVariables(Map<String, String> values) {
+            if (values != null) {
+                values.forEach(this::environmentVariable);
+            }
+            return this;
+        }
+
+        public SshShellOptions build() {
+            return new SshShellOptions(this);
+        }
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/cli/SshShellSession.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/SshShellSession.java
@@ -1,0 +1,141 @@
+package com.shaft.cli;
+
+import com.jcraft.jsch.ChannelShell;
+import com.jcraft.jsch.JSchException;
+import com.shaft.tools.io.ReportManager;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
+
+/**
+ * Experimental prompt-response SSH shell session backed by one JSch {@link ChannelShell}.
+ */
+public final class SshShellSession implements AutoCloseable {
+    private final ChannelShell channel;
+    private final InputStream inputStream;
+    private final OutputStream outputStream;
+    private final Duration defaultTimeout;
+    private final Runnable closeCallback;
+    private volatile boolean closed;
+
+    SshShellSession(ChannelShell channel, SshShellOptions options, Runnable closeCallback) throws IOException, JSchException {
+        this(channel, channel.getInputStream(), channel.getOutputStream(), options.getDefaultTimeout(), closeCallback);
+        configureChannel(channel, options);
+        channel.connect(Math.toIntExact(options.getDefaultTimeout().toMillis()));
+    }
+
+    SshShellSession(InputStream inputStream, OutputStream outputStream, Duration defaultTimeout) {
+        this(null, inputStream, outputStream, defaultTimeout, null);
+    }
+
+    private SshShellSession(ChannelShell channel, InputStream inputStream, OutputStream outputStream,
+                            Duration defaultTimeout, Runnable closeCallback) {
+        this.channel = channel;
+        this.inputStream = Objects.requireNonNull(inputStream);
+        this.outputStream = Objects.requireNonNull(outputStream);
+        this.defaultTimeout = Objects.requireNonNull(defaultTimeout);
+        this.closeCallback = closeCallback;
+    }
+
+    private static void configureChannel(ChannelShell channel, SshShellOptions options) {
+        channel.setPty(options.isPty());
+        if (options.isPty()) {
+            channel.setPtyType(options.getPtyType(), options.getColumns(), options.getRows(), 0, 0);
+        }
+        options.getEnvironmentVariables().forEach(channel::setEnv);
+    }
+
+    public void send(String text) {
+        write(text);
+        ReportManager.logDiscrete("Sent SSH shell input.");
+    }
+
+    public void sendLine(String text) {
+        send(Objects.requireNonNullElse(text, "") + "\n");
+    }
+
+    public void sendSecret(String text) {
+        write(text);
+        ReportManager.logDiscrete("Sent SSH shell secret input.");
+    }
+
+    public String readUntil(Pattern pattern) {
+        return readUntil(pattern, defaultTimeout);
+    }
+
+    public String readUntil(Pattern pattern, Duration timeout) {
+        Objects.requireNonNull(pattern, "pattern");
+        validateTimeout(timeout);
+        long deadline = System.nanoTime() + timeout.toNanos();
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try {
+            while (System.nanoTime() < deadline) {
+                drainAvailableBytes(output);
+                String currentOutput = output.toString(StandardCharsets.UTF_8);
+                if (pattern.matcher(currentOutput).find()) {
+                    ReportManager.logDiscrete("Read SSH shell output until pattern: \"" + pattern + "\".");
+                    return currentOutput;
+                }
+                sleepBriefly();
+            }
+        } catch (IOException exception) {
+            throw new RuntimeException("Failed to read SSH shell output.", exception);
+        }
+        TimeoutException timeoutException = new TimeoutException("Timed out after " + timeout
+                + " waiting for SSH shell output matching pattern: " + pattern);
+        throw new RuntimeException(timeoutException.getMessage(), timeoutException);
+    }
+
+    private void drainAvailableBytes(ByteArrayOutputStream output) throws IOException {
+        while (inputStream.available() > 0) {
+            output.write(inputStream.read());
+        }
+    }
+
+    private void write(String text) {
+        if (closed) {
+            throw new IllegalStateException("SSH shell session is closed.");
+        }
+        try {
+            outputStream.write(Objects.requireNonNullElse(text, "").getBytes(StandardCharsets.UTF_8));
+            outputStream.flush();
+        } catch (IOException exception) {
+            throw new RuntimeException("Failed to write SSH shell input.", exception);
+        }
+    }
+
+    private void validateTimeout(Duration timeout) {
+        if (timeout == null || timeout.isZero() || timeout.isNegative()) {
+            throw new IllegalArgumentException("SSH shell read timeout must be positive.");
+        }
+    }
+
+    private void sleepBriefly() {
+        try {
+            Thread.sleep(25);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        if (channel != null && channel.isConnected()) {
+            channel.disconnect();
+        }
+        if (closeCallback != null) {
+            closeCallback.run();
+        }
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
@@ -64,6 +64,7 @@ public class TerminalActions implements AutoCloseable {
     private ScheduledFuture<?> reusableSessionTimeoutTask;
     private final List<Integer> activeLocalPortForwards = new ArrayList<>();
     private final List<Integer> activeRemotePortForwards = new ArrayList<>();
+    private final List<SshShellSession> activeShellSessions = new ArrayList<>();
 
     private static final Pattern TERMINAL_LOG_SECRET_PATTERN = Pattern.compile(
             "(?i)(?<![A-Za-z0-9_])(password|passwd|token|secret|api[-_]?key|access[-_]?token|authorization)\\s*[=:]\\s*(?!\\*\\*\\*)\\S+");
@@ -444,6 +445,37 @@ public class TerminalActions implements AutoCloseable {
         return results;
     }
 
+    /**
+     * Opens an experimental prompt-response shell over the reusable SSH session.
+     *
+     * <p>Prefer {@link #performTerminalCommand(String)} or {@link #performSshCommand(String)}
+     * for non-interactive commands. Shell sessions are intended for CLIs that require prompts
+     * or a pseudo-terminal.</p>
+     *
+     * @param options shell channel options; use {@link SshShellOptions#defaults()} for defaults
+     * @return an open shell session that should be closed by the caller
+     */
+    public synchronized SshShellSession openShell(SshShellOptions options) {
+        verifyReusableRemoteSessionFeature();
+        SshShellOptions shellOptions = options == null ? SshShellOptions.defaults() : options;
+        Session remoteSession = getRemoteSession();
+        try {
+            ChannelShell shellChannel = (ChannelShell) remoteSession.openChannel("shell");
+            SshShellSession[] shellSessionHolder = new SshShellSession[1];
+            SshShellSession shellSession = new SshShellSession(shellChannel, shellOptions,
+                    () -> removeActiveShellSession(shellSessionHolder[0]));
+            shellSessionHolder[0] = shellSession;
+            activeShellSessions.add(shellSession);
+            passAction("openShell", "Host Name: \"" + sshHostName + "\" | SSH Port Number: \"" + sshPortNumber + "\"",
+                    "Opened SSH shell session.");
+            return shellSession;
+        } catch (JSchException | IOException exception) {
+            failAction("openShell", "Host Name: \"" + sshHostName + "\" | SSH Port Number: \"" + sshPortNumber + "\"",
+                    exception);
+            return null;
+        }
+    }
+
     private List<String> getValidCommands(List<String> commands) {
         if (commands == null || commands.isEmpty()) {
             failAction("Terminal command", new IllegalArgumentException("At least one terminal command must be provided."));
@@ -571,11 +603,13 @@ public class TerminalActions implements AutoCloseable {
      */
     public synchronized void quit() {
         cancelReusableSessionTimeoutTask();
+        closeActiveShellSessions();
         if (reusableRemoteSession != null && reusableRemoteSession.isConnected()) {
             clearPortForwards(reusableRemoteSession);
             reusableRemoteSession.disconnect();
         }
         reusableRemoteSession = null;
+        activeShellSessions.clear();
         activeLocalPortForwards.clear();
         activeRemotePortForwards.clear();
         if (reusableSessionTimeoutScheduler != null) {
@@ -785,6 +819,20 @@ public class TerminalActions implements AutoCloseable {
         if (reusableSessionTimeoutTask != null) {
             reusableSessionTimeoutTask.cancel(false);
             reusableSessionTimeoutTask = null;
+        }
+    }
+
+    private synchronized void removeActiveShellSession(SshShellSession shellSession) {
+        activeShellSessions.remove(shellSession);
+    }
+
+    private synchronized void closeActiveShellSessions() {
+        for (SshShellSession shellSession : new ArrayList<>(activeShellSessions)) {
+            try {
+                shellSession.close();
+            } catch (Exception exception) {
+                ReportManager.logDiscrete("Could not close SSH shell session: " + exception.getMessage());
+            }
         }
     }
 

--- a/shaft-engine/src/test/java/com/shaft/cli/SshShellOptionsUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/cli/SshShellOptionsUnitTest.java
@@ -1,0 +1,58 @@
+package com.shaft.cli;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+import java.util.Map;
+
+public class SshShellOptionsUnitTest {
+    @Test(description = "Default shell options should be usable without a PTY")
+    public void defaultsShouldUseNonPtyShellWithTimeout() {
+        SshShellOptions options = SshShellOptions.defaults();
+
+        Assert.assertFalse(options.isPty());
+        Assert.assertEquals(options.getPtyType(), "vt100");
+        Assert.assertEquals(options.getColumns(), 80);
+        Assert.assertEquals(options.getRows(), 24);
+        Assert.assertEquals(options.getDefaultTimeout(), Duration.ofSeconds(30));
+        Assert.assertTrue(options.getEnvironmentVariables().isEmpty());
+    }
+
+    @Test(description = "Builder should preserve PTY and environment options")
+    public void builderShouldPreservePtyAndEnvironmentOptions() {
+        SshShellOptions options = SshShellOptions.builder()
+                .pty(true)
+                .ptyType("xterm")
+                .columns(120)
+                .rows(40)
+                .defaultTimeout(Duration.ofSeconds(5))
+                .environmentVariables(Map.of("LC_ALL", "C"))
+                .build();
+
+        Assert.assertTrue(options.isPty());
+        Assert.assertEquals(options.getPtyType(), "xterm");
+        Assert.assertEquals(options.getColumns(), 120);
+        Assert.assertEquals(options.getRows(), 40);
+        Assert.assertEquals(options.getDefaultTimeout(), Duration.ofSeconds(5));
+        Assert.assertEquals(options.getEnvironmentVariables().get("LC_ALL"), "C");
+    }
+
+    @Test(description = "Builder should reject invalid terminal dimensions")
+    public void builderShouldRejectInvalidDimensions() {
+        IllegalArgumentException columnsFailure = Assert.expectThrows(IllegalArgumentException.class,
+                () -> SshShellOptions.builder().columns(0).build());
+        Assert.assertTrue(columnsFailure.getMessage().contains("columns"));
+
+        IllegalArgumentException rowsFailure = Assert.expectThrows(IllegalArgumentException.class,
+                () -> SshShellOptions.builder().rows(0).build());
+        Assert.assertTrue(rowsFailure.getMessage().contains("rows"));
+    }
+
+    @Test(description = "Builder should reject invalid default timeouts")
+    public void builderShouldRejectInvalidDefaultTimeouts() {
+        IllegalArgumentException failure = Assert.expectThrows(IllegalArgumentException.class,
+                () -> SshShellOptions.builder().defaultTimeout(Duration.ZERO).build());
+        Assert.assertTrue(failure.getMessage().contains("timeout"));
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/cli/SshShellSessionUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/cli/SshShellSessionUnitTest.java
@@ -1,0 +1,76 @@
+package com.shaft.cli;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.regex.Pattern;
+
+public class SshShellSessionUnitTest {
+    @Test(description = "send should write exact shell input")
+    public void sendShouldWriteExactInput() {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        SshShellSession session = new SshShellSession(new ByteArrayInputStream(new byte[0]), output, Duration.ofSeconds(1));
+
+        session.send("printf ready");
+
+        Assert.assertEquals(output.toString(StandardCharsets.UTF_8), "printf ready");
+    }
+
+    @Test(description = "sendLine should append a shell newline")
+    public void sendLineShouldAppendShellNewline() {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        SshShellSession session = new SshShellSession(new ByteArrayInputStream(new byte[0]), output, Duration.ofSeconds(1));
+
+        session.sendLine("yes");
+
+        Assert.assertEquals(output.toString(StandardCharsets.UTF_8), "yes\n");
+    }
+
+    @Test(description = "sendSecret should write exact input without exposing it through the API")
+    public void sendSecretShouldWriteExactInput() {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        SshShellSession session = new SshShellSession(new ByteArrayInputStream(new byte[0]), output, Duration.ofSeconds(1));
+
+        session.sendSecret("sensitive-password\n");
+
+        Assert.assertEquals(output.toString(StandardCharsets.UTF_8), "sensitive-password\n");
+    }
+
+    @Test(description = "readUntil should return output through the matching text")
+    public void readUntilShouldReturnMatchingOutput() {
+        ByteArrayInputStream input = new ByteArrayInputStream("ready\nPassword:".getBytes(StandardCharsets.UTF_8));
+        SshShellSession session = new SshShellSession(input, new ByteArrayOutputStream(), Duration.ofSeconds(1));
+
+        String output = session.readUntil(Pattern.compile("Password:"));
+
+        Assert.assertEquals(output, "ready\nPassword:");
+    }
+
+    @Test(description = "readUntil should fail when the pattern is not seen before timeout")
+    public void readUntilShouldFailOnTimeout() {
+        SshShellSession session = new SshShellSession(new ByteArrayInputStream(new byte[0]),
+                new ByteArrayOutputStream(), Duration.ofMillis(50));
+
+        RuntimeException failure = Assert.expectThrows(RuntimeException.class,
+                () -> session.readUntil(Pattern.compile("never"), Duration.ofMillis(50)));
+
+        Assert.assertTrue(failure.getMessage().contains("Timed out"));
+        Assert.assertTrue(failure.getMessage().contains("never"));
+    }
+
+    @Test(description = "send should reject writes after close")
+    public void sendShouldRejectWritesAfterClose() {
+        SshShellSession session = new SshShellSession(new ByteArrayInputStream(new byte[0]),
+                new ByteArrayOutputStream(), Duration.ofSeconds(1));
+
+        session.close();
+
+        IllegalStateException failure = Assert.expectThrows(IllegalStateException.class,
+                () -> session.send("late"));
+        Assert.assertTrue(failure.getMessage().contains("closed"));
+    }
+}

--- a/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
@@ -4,6 +4,7 @@ import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import com.shaft.cli.SshConnectionOptions;
+import com.shaft.cli.SshShellOptions;
 import com.shaft.cli.TerminalActions;
 import com.shaft.driver.SHAFT;
 import org.apache.commons.lang3.SystemUtils;
@@ -777,6 +778,32 @@ public class TerminalActionsUnitTest {
         RuntimeException failure = Assert.expectThrows(RuntimeException.class,
                 () -> terminal.performSshCommand(" "));
         Assert.assertTrue(failure.getMessage().contains("SSH command"));
+    }
+
+    @Test(description = "openShell should reject local terminals")
+    public void openShellShouldRejectLocalTerminals() {
+        TerminalActions terminal = TerminalActions.getInstance(false, false, true);
+        RuntimeException failure = Assert.expectThrows(RuntimeException.class,
+                () -> terminal.openShell(SshShellOptions.defaults()));
+        Assert.assertTrue(failure.getMessage().contains("remote SSH"));
+    }
+
+    @Test(description = "openShell should reject dockerized remote terminals")
+    @SuppressWarnings("deprecation")
+    public void openShellShouldRejectDockerizedRemoteTerminals() {
+        TerminalActions terminal = new TerminalActions("host.example.com", 22, "user", "", "",
+                "container", "root");
+        RuntimeException failure = Assert.expectThrows(RuntimeException.class,
+                () -> terminal.openShell(SshShellOptions.defaults()));
+        Assert.assertTrue(failure.getMessage().contains("dockerized remote terminals"));
+    }
+
+    @Test(description = "openShell should reject non-reusable remote terminals")
+    public void openShellShouldRejectNonReusableRemoteTerminals() {
+        TerminalActions terminal = new TerminalActions("host.example.com", 22, "user", "", "");
+        RuntimeException failure = Assert.expectThrows(RuntimeException.class,
+                () -> terminal.openShell(SshShellOptions.defaults()));
+        Assert.assertTrue(failure.getMessage().contains("reusable remote terminal"));
     }
 
     @Test(description = "performTerminalCommand should remain backward compatible for local command output")


### PR DESCRIPTION
## Summary
- add `SshShellOptions` and `SshShellSession` for prompt-response SSH shell flows
- add `TerminalActions.openShell(...)` with reusable-remote guards and cleanup through `quit()`
- cover shell option defaults, send/read timeout behavior, and unsupported terminal guards

Fixes #3132

## Tests
- `docker run --rm -v "$PWD":/workspace -v shaft-agent-m2:/root/.m2 -w /workspace maven:3.9.11-eclipse-temurin-25 mvn -q -pl shaft-engine -Dtest=com.shaft.cli.SshShellOptionsUnitTest,com.shaft.cli.SshShellSessionUnitTest,testPackage.unitTests.TerminalActionsUnitTest test -Dgpg.skip -DskipITs`
- `git diff --check`
- `python3 scripts/ci/validate_agent_setup.py`