### PR TITLE
Fix: Redact sensitive regions in screenshot evidence before AI analysis

### DIFF
--- a/shaft-doctor/src/main/java/com/shaft/doctor/DoctorAnalysisRequest.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/DoctorAnalysisRequest.java
@@ -15,6 +15,7 @@ import java.util.List;
  * @param minimumAllureResults minimum valid Allure result count expected from the run
  * @param maxItemBytes maximum retained bytes per evidence item
  * @param maxBundleBytes maximum retained bytes across the bundle
+ * @param redactScreenshots whether screenshots containing sensitive fields should be masked
  */
 public record DoctorAnalysisRequest(
         List<Path> inputPaths,
@@ -25,7 +26,8 @@ public record DoctorAnalysisRequest(
         boolean includePageSnapshots,
         int minimumAllureResults,
         long maxItemBytes,
-        long maxBundleBytes) {
+        long maxBundleBytes,
+        boolean redactScreenshots) {
     /**
      * Default maximum retained size for one evidence item.
      */
@@ -80,6 +82,6 @@ public record DoctorAnalysisRequest(
             List<Path> allowedRoots,
             Path outputDirectory) {
         return new DoctorAnalysisRequest(inputPaths, List.of(), allowedRoots, outputDirectory,
-                false, false, 1, DEFAULT_MAX_ITEM_BYTES, DEFAULT_MAX_BUNDLE_BYTES);
+                false, false, 1, DEFAULT_MAX_ITEM_BYTES, DEFAULT_MAX_BUNDLE_BYTES, true);
     }
 }

--- a/shaft-doctor/src/main/java/com/shaft/doctor/DoctorAnalyzer.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/DoctorAnalyzer.java
@@ -186,7 +186,8 @@ public final class DoctorAnalyzer {
                 request.includePageSnapshots(),
                 request.minimumAllureResults(),
                 request.maxItemBytes(),
-                request.maxBundleBytes());
+                request.maxBundleBytes(),
+                request.redactScreenshots());
     }
 
     private static Path realPath(Path path) {

--- a/shaft-doctor/src/main/java/com/shaft/doctor/cli/DoctorCli.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/cli/DoctorCli.java
@@ -116,7 +116,8 @@ public final class DoctorCli {
                     options.flag("include-page-snapshots"),
                     Math.toIntExact(options.positiveLong("minimum-results", 1)),
                     options.positiveLong("max-item-bytes", DoctorAnalysisRequest.DEFAULT_MAX_ITEM_BYTES),
-                    options.positiveLong("max-bundle-bytes", DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES));
+                    options.positiveLong("max-bundle-bytes", DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES),
+                    true);
             DoctorAnalyzer analyzer = new DoctorAnalyzer();
             DoctorAnalysisResult result;
             DoctorAdvisory advisory = null;

--- a/shaft-doctor/src/main/java/com/shaft/doctor/collect/EvidenceCollector.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/collect/EvidenceCollector.java
@@ -39,6 +39,16 @@ import java.util.zip.ZipInputStream;
  * Collects bounded local evidence through explicit allowlisted adapter boundaries.
  */
 public final class EvidenceCollector {
+    private record AttachmentInfo(
+            Path artifact,
+            String reference,
+            String name,
+            String type,
+            String extension,
+            String diagnosticName,
+            boolean isScreenshot,
+            boolean isPageSnapshot) {
+    }
     private static final int MAX_FILES = 10_000;
     private static final int MAX_ATTRIBUTE_LENGTH = 2_048;
     private static final Set<String> TEXT_EXTENSIONS = Set.of(
@@ -284,55 +294,140 @@ public final class EvidenceCollector {
             CollectionState state) {
         JsonNode attachments = node.path("attachments");
         if (attachments.isArray()) {
-            for (JsonNode attachment : attachments) {
-                String source = attachment.path("source").asText("");
-                if (source.isBlank()) {
-                    continue;
-                }
-                Path candidate = resultFile.getParent().resolve(source);
-                if (!Files.exists(candidate)) {
-                    continue;
-                }
-                Path artifact = allowedRealPath(candidate, roots);
-                if (!Files.isRegularFile(artifact)) {
-                    continue;
-                }
-                String name = attachment.path("name").asText("").toLowerCase(Locale.ROOT);
-                String type = attachment.path("type").asText("").toLowerCase(Locale.ROOT);
-                String extension = extension(artifact.getFileName().toString().toLowerCase(Locale.ROOT));
-                String reference = portableReference(artifact, roots);
-                String diagnosticName = name + " " + source.toLowerCase(Locale.ROOT);
-                if (type.startsWith("image/") || SCREENSHOT_EXTENSIONS.contains(extension)) {
-                    if (request.includeScreenshots()) {
-                        collectBinary(artifact, reference, EvidenceCategory.SCREENSHOT,
-                                type.isBlank() ? mediaType(extension) : type, request, items, state);
-                    } else {
-                        state.omittedItems++;
-                    }
-                } else if (type.contains("html") || type.contains("multipart/related")
-                        || name.contains("page source") || name.contains("snapshot")) {
-                    if (request.includePageSnapshots()) {
-                        collectText(artifact, reference, EvidenceCategory.PAGE_SNAPSHOT,
-                                type.isBlank() ? mediaType(extension) : type,
-                                request, redactor, items, state);
-                    } else {
-                        state.omittedItems++;
-                    }
-                } else if (isDiagnosticsZip(diagnosticName, type, extension)) {
-                    collectDiagnosticsZip(artifact, reference, request, redactor, items, state);
-                } else if (name.contains("log") || name.contains("action history")
-                        || name.contains("shaft")) {
-                    collectText(artifact, reference, EvidenceCategory.SHAFT_LOG,
-                            type.isBlank() ? mediaType(extension) : type,
-                            request, redactor, items, state);
-                }
-            }
+            collectAllureAttachmentsInArray(attachments, resultFile, roots, request, redactor, items, state);
         }
         for (JsonNode child : node) {
             if (child.isObject() || child.isArray()) {
-                collectAllureAttachments(child, resultFile, roots, request, redactor, items, state);
+                if (!child.equals(attachments)) {
+                    collectAllureAttachments(child, resultFile, roots, request, redactor, items, state);
+                }
             }
         }
+    }
+
+    private void collectAllureAttachmentsInArray(
+            JsonNode attachments,
+            Path resultFile,
+            List<Path> roots,
+            DoctorAnalysisRequest request,
+            DoctorRedactor redactor,
+            Map<String, EvidenceItem> items,
+            CollectionState state) {
+        List<AttachmentInfo> infos = new ArrayList<>();
+        for (JsonNode attachment : attachments) {
+            String source = attachment.path("source").asText("");
+            if (source.isBlank()) {
+                continue;
+            }
+            Path candidate = resultFile.getParent().resolve(source);
+            if (!Files.exists(candidate)) {
+                continue;
+            }
+            Path artifact = allowedRealPath(candidate, roots);
+            if (!Files.isRegularFile(artifact)) {
+                continue;
+            }
+            String name = attachment.path("name").asText("").toLowerCase(Locale.ROOT);
+            String type = attachment.path("type").asText("").toLowerCase(Locale.ROOT);
+            String extension = extension(artifact.getFileName().toString().toLowerCase(Locale.ROOT));
+            String reference = portableReference(artifact, roots);
+            String diagnosticName = name + " " + source.toLowerCase(Locale.ROOT);
+            boolean isScreenshot = type.startsWith("image/") || SCREENSHOT_EXTENSIONS.contains(extension);
+            boolean isPageSnapshot = type.contains("html") || type.contains("multipart/related")
+                    || name.contains("page source") || name.contains("snapshot");
+            infos.add(new AttachmentInfo(artifact, reference, name, type, extension, diagnosticName,
+                    isScreenshot, isPageSnapshot));
+        }
+        for (int i = 0; i < infos.size(); i++) {
+            AttachmentInfo info = infos.get(i);
+            if (info.isScreenshot() && request.includeScreenshots()) {
+                AttachmentInfo matchingSnapshot = findMatchingPageSnapshot(infos, i);
+                collectBinaryWithOptionalRedaction(info, request, redactor, items, state, matchingSnapshot);
+            } else if (info.isScreenshot()) {
+                state.omittedItems++;
+            } else if (info.isPageSnapshot() && request.includePageSnapshots()) {
+                collectText(info.artifact(), info.reference(), EvidenceCategory.PAGE_SNAPSHOT,
+                        info.type().isBlank() ? mediaType(info.extension()) : info.type(),
+                        request, redactor, items, state);
+            } else if (info.isPageSnapshot()) {
+                state.omittedItems++;
+            } else if (isDiagnosticsZip(info.diagnosticName(), info.type(), info.extension())) {
+                collectDiagnosticsZip(info.artifact(), info.reference(), request, redactor, items, state);
+            } else if (info.name().contains("log") || info.name().contains("action history")
+                    || info.name().contains("shaft")) {
+                collectText(info.artifact(), info.reference(), EvidenceCategory.SHAFT_LOG,
+                        info.type().isBlank() ? mediaType(info.extension()) : info.type(),
+                        request, redactor, items, state);
+            }
+        }
+    }
+
+    private AttachmentInfo findMatchingPageSnapshot(List<AttachmentInfo> infos, int screenshotIndex) {
+        AttachmentInfo screenshot = infos.get(screenshotIndex);
+        AttachmentInfo precedingSnapshot = null;
+        for (int i = screenshotIndex - 1; i >= 0; i--) {
+            if (infos.get(i).isPageSnapshot()) {
+                precedingSnapshot = infos.get(i);
+                break;
+            }
+        }
+        if (precedingSnapshot != null) {
+            return precedingSnapshot;
+        }
+        for (int i = screenshotIndex + 1; i < infos.size(); i++) {
+            if (infos.get(i).isPageSnapshot()) {
+                return infos.get(i);
+            }
+        }
+        return null;
+    }
+
+    private void collectBinaryWithOptionalRedaction(
+            AttachmentInfo screenshot,
+            DoctorAnalysisRequest request,
+            DoctorRedactor redactor,
+            Map<String, EvidenceItem> items,
+            CollectionState state,
+            AttachmentInfo matchingSnapshot) {
+        byte[] retained = readBounded(screenshot.artifact(), request.maxItemBytes());
+        boolean shouldRedact = request.redactScreenshots() && matchingSnapshot != null;
+        if (shouldRedact) {
+            try {
+                byte[] snapshotBytes = readBounded(matchingSnapshot.artifact(), request.maxItemBytes());
+                String snapshotContent = new String(snapshotBytes, StandardCharsets.UTF_8);
+                List<String> sensitiveRegions = redactor.extractSensitiveRegions(snapshotContent);
+                if (!sensitiveRegions.isEmpty()) {
+                    retained = redactor.redactScreenshot(retained, sensitiveRegions);
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        boolean truncated = FilesSize.size(screenshot.artifact()) > retained.length;
+        if (state.retainedBytes + retained.length > request.maxBundleBytes()) {
+            state.omittedItems++;
+            return;
+        }
+        String digest = DoctorHashing.sha256(retained);
+        String id = evidenceId(EvidenceCategory.SCREENSHOT, screenshot.reference(), digest);
+        String extension = extension(screenshot.artifact().getFileName().toString().toLowerCase(Locale.ROOT));
+        String relativePath = "artifacts/" + id + extension;
+        Path destination = request.outputDirectory().resolve(relativePath).normalize();
+        if (!destination.startsWith(request.outputDirectory())) {
+            throw new IllegalArgumentException("Doctor artifact destination escaped the output directory.");
+        }
+        try {
+            Files.createDirectories(destination.getParent());
+            Files.write(destination, retained);
+        } catch (IOException exception) {
+            throw new IllegalStateException("Doctor binary evidence could not be retained.", exception);
+        }
+        EvidenceItem item = new EvidenceItem(
+                id, EvidenceCategory.SCREENSHOT, screenshot.type().isBlank() ? mediaType(extension) : screenshot.type(),
+                relativePath, digest, retained.length, null,
+                false, truncated, Map.of(),
+                new EvidenceProvenance(adapter(EvidenceCategory.SCREENSHOT), screenshot.reference(), digest));
+        items.putIfAbsent(id, item);
+        state.retainedBytes += retained.length;
     }
 
     private void collectDiagnosticsText(

--- a/shaft-doctor/src/main/java/com/shaft/doctor/collect/EvidenceCollector.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/collect/EvidenceCollector.java
@@ -313,66 +313,97 @@ public final class EvidenceCollector {
             DoctorRedactor redactor,
             Map<String, EvidenceItem> items,
             CollectionState state) {
-        List<AttachmentInfo> infos = new ArrayList<>();
-        for (JsonNode attachment : attachments) {
-            String source = attachment.path("source").asText("");
-            if (source.isBlank()) {
-                continue;
-            }
-            Path candidate = resultFile.getParent().resolve(source);
-            if (!Files.exists(candidate)) {
-                continue;
-            }
-            Path artifact = allowedRealPath(candidate, roots);
-            if (!Files.isRegularFile(artifact)) {
-                continue;
-            }
-            String name = attachment.path("name").asText("").toLowerCase(Locale.ROOT);
-            String type = attachment.path("type").asText("").toLowerCase(Locale.ROOT);
-            String extension = extension(artifact.getFileName().toString().toLowerCase(Locale.ROOT));
-            String reference = portableReference(artifact, roots);
-            String diagnosticName = name + " " + source.toLowerCase(Locale.ROOT);
-            boolean isScreenshot = type.startsWith("image/") || SCREENSHOT_EXTENSIONS.contains(extension);
-            boolean isPageSnapshot = type.contains("html") || type.contains("multipart/related")
-                    || name.contains("page source") || name.contains("snapshot");
-            infos.add(new AttachmentInfo(artifact, reference, name, type, extension, diagnosticName,
-                    isScreenshot, isPageSnapshot));
-        }
+        List<AttachmentInfo> infos = describeAttachments(attachments, resultFile, roots);
         for (int i = 0; i < infos.size(); i++) {
-            AttachmentInfo info = infos.get(i);
-            if (info.isScreenshot() && request.includeScreenshots()) {
-                AttachmentInfo matchingSnapshot = findMatchingPageSnapshot(infos, i);
-                collectBinaryWithOptionalRedaction(info, request, redactor, items, state, matchingSnapshot);
-            } else if (info.isScreenshot()) {
-                state.omittedItems++;
-            } else if (info.isPageSnapshot() && request.includePageSnapshots()) {
-                collectText(info.artifact(), info.reference(), EvidenceCategory.PAGE_SNAPSHOT,
-                        info.type().isBlank() ? mediaType(info.extension()) : info.type(),
-                        request, redactor, items, state);
-            } else if (info.isPageSnapshot()) {
-                state.omittedItems++;
-            } else if (isDiagnosticsZip(info.diagnosticName(), info.type(), info.extension())) {
-                collectDiagnosticsZip(info.artifact(), info.reference(), request, redactor, items, state);
-            } else if (info.name().contains("log") || info.name().contains("action history")
-                    || info.name().contains("shaft")) {
-                collectText(info.artifact(), info.reference(), EvidenceCategory.SHAFT_LOG,
-                        info.type().isBlank() ? mediaType(info.extension()) : info.type(),
-                        request, redactor, items, state);
-            }
+            dispatchAttachment(infos, i, request, redactor, items, state);
         }
     }
 
-    private AttachmentInfo findMatchingPageSnapshot(List<AttachmentInfo> infos, int screenshotIndex) {
-        AttachmentInfo screenshot = infos.get(screenshotIndex);
-        AttachmentInfo precedingSnapshot = null;
-        for (int i = screenshotIndex - 1; i >= 0; i--) {
-            if (infos.get(i).isPageSnapshot()) {
-                precedingSnapshot = infos.get(i);
-                break;
+    private List<AttachmentInfo> describeAttachments(JsonNode attachments, Path resultFile, List<Path> roots) {
+        List<AttachmentInfo> infos = new ArrayList<>();
+        for (JsonNode attachment : attachments) {
+            AttachmentInfo info = describeAttachment(attachment, resultFile, roots);
+            if (info != null) {
+                infos.add(info);
             }
         }
-        if (precedingSnapshot != null) {
-            return precedingSnapshot;
+        return infos;
+    }
+
+    private AttachmentInfo describeAttachment(JsonNode attachment, Path resultFile, List<Path> roots) {
+        String source = attachment.path("source").asText("");
+        if (source.isBlank()) {
+            return null;
+        }
+        Path candidate = resultFile.getParent().resolve(source);
+        if (!Files.exists(candidate)) {
+            return null;
+        }
+        Path artifact = allowedRealPath(candidate, roots);
+        if (!Files.isRegularFile(artifact)) {
+            return null;
+        }
+        String name = attachment.path("name").asText("").toLowerCase(Locale.ROOT);
+        String type = attachment.path("type").asText("").toLowerCase(Locale.ROOT);
+        String extension = extension(artifact.getFileName().toString().toLowerCase(Locale.ROOT));
+        String reference = portableReference(artifact, roots);
+        String diagnosticName = name + " " + source.toLowerCase(Locale.ROOT);
+        boolean isScreenshot = type.startsWith("image/") || SCREENSHOT_EXTENSIONS.contains(extension);
+        boolean isPageSnapshot = type.contains("html") || type.contains("multipart/related")
+                || name.contains("page source") || name.contains("snapshot");
+        return new AttachmentInfo(artifact, reference, name, type, extension, diagnosticName,
+                isScreenshot, isPageSnapshot);
+    }
+
+    private void dispatchAttachment(
+            List<AttachmentInfo> infos,
+            int index,
+            DoctorAnalysisRequest request,
+            DoctorRedactor redactor,
+            Map<String, EvidenceItem> items,
+            CollectionState state) {
+        AttachmentInfo info = infos.get(index);
+        if (info.isScreenshot()) {
+            if (request.includeScreenshots()) {
+                AttachmentInfo matchingSnapshot = findMatchingPageSnapshot(infos, index);
+                collectBinaryWithOptionalRedaction(info, request, redactor, items, state, matchingSnapshot);
+            } else {
+                state.omittedItems++;
+            }
+        } else if (info.isPageSnapshot()) {
+            if (request.includePageSnapshots()) {
+                collectText(info.artifact(), info.reference(), EvidenceCategory.PAGE_SNAPSHOT,
+                        info.type().isBlank() ? mediaType(info.extension()) : info.type(),
+                        request, redactor, items, state);
+            } else {
+                state.omittedItems++;
+            }
+        } else if (isDiagnosticsZip(info.diagnosticName(), info.type(), info.extension())) {
+            collectDiagnosticsZip(info.artifact(), info.reference(), request, redactor, items, state);
+        } else if (info.name().contains("log") || info.name().contains("action history")
+                || info.name().contains("shaft")) {
+            collectText(info.artifact(), info.reference(), EvidenceCategory.SHAFT_LOG,
+                    info.type().isBlank() ? mediaType(info.extension()) : info.type(),
+                    request, redactor, items, state);
+        }
+    }
+
+    /**
+     * Finds the page snapshot that best corresponds to the screenshot at {@code screenshotIndex},
+     * using a deterministic rule: the nearest preceding page snapshot in attachment order, else the
+     * nearest following one, else {@code null} when no snapshot exists in the same attachment list.
+     * This replaces the previous first-match-wins pairing that could correlate a screenshot with an
+     * unrelated snapshot's sensitive fields.
+     *
+     * @param infos ordered attachment descriptors for the enclosing Allure result
+     * @param screenshotIndex index of the screenshot within {@code infos}
+     * @return the paired page snapshot, or {@code null} if none is found
+     */
+    private AttachmentInfo findMatchingPageSnapshot(List<AttachmentInfo> infos, int screenshotIndex) {
+        for (int i = screenshotIndex - 1; i >= 0; i--) {
+            if (infos.get(i).isPageSnapshot()) {
+                return infos.get(i);
+            }
         }
         for (int i = screenshotIndex + 1; i < infos.size(); i++) {
             if (infos.get(i).isPageSnapshot()) {
@@ -390,17 +421,8 @@ public final class EvidenceCollector {
             CollectionState state,
             AttachmentInfo matchingSnapshot) {
         byte[] retained = readBounded(screenshot.artifact(), request.maxItemBytes());
-        boolean shouldRedact = request.redactScreenshots() && matchingSnapshot != null;
-        if (shouldRedact) {
-            try {
-                byte[] snapshotBytes = readBounded(matchingSnapshot.artifact(), request.maxItemBytes());
-                String snapshotContent = new String(snapshotBytes, StandardCharsets.UTF_8);
-                List<String> sensitiveRegions = redactor.extractSensitiveRegions(snapshotContent);
-                if (!sensitiveRegions.isEmpty()) {
-                    retained = redactor.redactScreenshot(retained, sensitiveRegions);
-                }
-            } catch (Exception ignored) {
-            }
+        if (request.redactScreenshots() && matchingSnapshot != null) {
+            retained = redactScreenshotIfSensitive(retained, matchingSnapshot, request, redactor);
         }
         boolean truncated = FilesSize.size(screenshot.artifact()) > retained.length;
         if (state.retainedBytes + retained.length > request.maxBundleBytes()) {
@@ -428,6 +450,38 @@ public final class EvidenceCollector {
                 new EvidenceProvenance(adapter(EvidenceCategory.SCREENSHOT), screenshot.reference(), digest));
         items.putIfAbsent(id, item);
         state.retainedBytes += retained.length;
+    }
+
+    /**
+     * Masks the given screenshot bytes when its paired page snapshot indicates sensitive fields.
+     *
+     * <p>This fails closed: if the paired snapshot cannot be read/decoded, or masking a screenshot
+     * that was determined to be sensitive fails, the evidence collection itself fails rather than
+     * silently retaining the unredacted screenshot bytes.
+     *
+     * @param screenshotBytes original screenshot bytes
+     * @param matchingSnapshot the paired page snapshot used to decide whether masking is required
+     * @param request active collection request (bounds the snapshot read size)
+     * @param redactor shared redactor used to detect sensitive fields and perform masking
+     * @return masked bytes if the paired snapshot has sensitive fields, otherwise the original bytes
+     */
+    private byte[] redactScreenshotIfSensitive(
+            byte[] screenshotBytes,
+            AttachmentInfo matchingSnapshot,
+            DoctorAnalysisRequest request,
+            DoctorRedactor redactor) {
+        byte[] snapshotBytes = readBounded(matchingSnapshot.artifact(), request.maxItemBytes());
+        String snapshotContent = new String(snapshotBytes, StandardCharsets.UTF_8);
+        List<String> sensitiveRegions = redactor.extractSensitiveRegions(snapshotContent);
+        if (sensitiveRegions.isEmpty()) {
+            return screenshotBytes;
+        }
+        try {
+            return redactor.redactScreenshot(screenshotBytes, sensitiveRegions);
+        } catch (IOException exception) {
+            throw new IllegalStateException(
+                    "Doctor screenshot evidence was marked sensitive but could not be redacted.", exception);
+        }
     }
 
     private void collectDiagnosticsText(

--- a/shaft-doctor/src/main/java/com/shaft/doctor/collect/EvidenceCollector.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/collect/EvidenceCollector.java
@@ -297,10 +297,8 @@ public final class EvidenceCollector {
             collectAllureAttachmentsInArray(attachments, resultFile, roots, request, redactor, items, state);
         }
         for (JsonNode child : node) {
-            if (child.isObject() || child.isArray()) {
-                if (!child.equals(attachments)) {
-                    collectAllureAttachments(child, resultFile, roots, request, redactor, items, state);
-                }
+            if ((child.isObject() || child.isArray()) && !child.equals(attachments)) {
+                collectAllureAttachments(child, resultFile, roots, request, redactor, items, state);
             }
         }
     }

--- a/shaft-doctor/src/main/java/com/shaft/doctor/internal/DoctorRedactor.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/internal/DoctorRedactor.java
@@ -25,6 +25,15 @@ import javax.imageio.ImageIO;
  * Structured and textual deterministic redaction for Doctor evidence.
  */
 public final class DoctorRedactor {
+    /**
+     * Marker returned by {@link #extractSensitiveRegions(String)} indicating that the whole
+     * screenshot must be masked because real per-field pixel coordinates cannot be derived
+     * from a static HTML snapshot.
+     */
+    private static final String WHOLE_IMAGE_MARKER = "WHOLE_IMAGE";
+    private static final List<String> WHOLE_IMAGE_REGIONS = List.of(WHOLE_IMAGE_MARKER);
+    private static final String SENSITIVE_FIELD_SELECTOR =
+            "input[type=password],[autocomplete=current-password],[autocomplete=new-password]";
     private static final Set<String> SENSITIVE_FIELDS = Set.of(
             "authorization", "proxy-authorization", "cookie", "set-cookie",
             "password", "passwd", "secret", "token", "access_token", "refresh_token",
@@ -207,68 +216,71 @@ public final class DoctorRedactor {
             return List.of();
         }
         Document document = Jsoup.parseBodyFragment(htmlContent);
-        boolean hasSensitiveFields = false;
-        for (Element element : document.select(
-                "input[type=password],[autocomplete=current-password],[autocomplete=new-password]")) {
-            hasSensitiveFields = true;
-            break;
-        }
-        if (!hasSensitiveFields) {
-            for (Element element : document.getAllElements()) {
-                for (org.jsoup.nodes.Attribute attribute : element.attributes().asList()) {
-                    if (isSensitive(attribute.getKey())) {
-                        hasSensitiveFields = true;
-                        break;
-                    }
-                }
-                if (hasSensitiveFields) {
-                    break;
+        boolean hasSensitiveFields = hasSensitiveInputElements(document) || hasSensitiveAttributes(document);
+        return hasSensitiveFields ? WHOLE_IMAGE_REGIONS : List.of();
+    }
+
+    private static boolean hasSensitiveInputElements(Document document) {
+        return !document.select(SENSITIVE_FIELD_SELECTOR).isEmpty();
+    }
+
+    private static boolean hasSensitiveAttributes(Document document) {
+        for (Element element : document.getAllElements()) {
+            for (org.jsoup.nodes.Attribute attribute : element.attributes().asList()) {
+                if (isSensitive(attribute.getKey())) {
+                    return true;
                 }
             }
         }
-        return hasSensitiveFields ? List.of("WHOLE_IMAGE") : List.of();
+        return false;
     }
 
     /**
      * Applies full-image opaque masking to screenshot bytes when sensitive regions are detected.
      * Only masks if regions list contains the whole-image marker.
      *
+     * <p>Redaction fails closed: if the sensitive regions marker is present but the image cannot
+     * be re-encoded after masking, this method throws rather than returning the original,
+     * still-sensitive bytes, since silently falling back would leak unredacted evidence.
+     *
      * @param screenshotBytes original screenshot image bytes
-     * @param regions masking decision (empty = no masking, contains "WHOLE_IMAGE" = mask entire image)
-     * @return masked image bytes, or original bytes if no masking needed
-     * @throws IOException if image reading/writing fails
+     * @param regions masking decision (empty = no masking, contains the whole-image marker = mask entire image)
+     * @return masked image bytes, or original bytes if no masking needed or the bytes are not a decodable image
+     * @throws IOException if a decodable image was masked but could not be re-encoded
      */
     public byte[] redactScreenshot(byte[] screenshotBytes, List<String> regions) throws IOException {
         if (screenshotBytes == null || screenshotBytes.length == 0) {
             return screenshotBytes;
         }
-        if (regions == null || regions.isEmpty() || !regions.contains("WHOLE_IMAGE")) {
+        if (regions == null || !regions.contains(WHOLE_IMAGE_MARKER)) {
             return screenshotBytes;
         }
-        try {
-            BufferedImage image = ImageIO.read(new ByteArrayInputStream(screenshotBytes));
-            if (image == null) {
-                return screenshotBytes;
-            }
-            int width = image.getWidth();
-            int height = image.getHeight();
-            BufferedImage masked = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
-            int opaqueBlack = 0xFF000000;
-            for (int y = 0; y < height; y++) {
-                for (int x = 0; x < width; x++) {
-                    masked.setRGB(x, y, opaqueBlack);
-                }
-            }
-            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-            String extension = guessImageFormat(screenshotBytes);
-            if (extension == null || extension.isEmpty()) {
-                extension = "png";
-            }
-            ImageIO.write(masked, extension, outputStream);
-            return outputStream.toByteArray();
-        } catch (IOException exception) {
+        BufferedImage image = ImageIO.read(new ByteArrayInputStream(screenshotBytes));
+        if (image == null) {
             return screenshotBytes;
         }
+        BufferedImage masked = paintOpaqueBlack(image);
+        return encodeImage(masked, guessImageFormat(screenshotBytes));
+    }
+
+    private static BufferedImage paintOpaqueBlack(BufferedImage source) {
+        int width = source.getWidth();
+        int height = source.getHeight();
+        BufferedImage masked = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        int opaqueBlack = 0xFF000000;
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                masked.setRGB(x, y, opaqueBlack);
+            }
+        }
+        return masked;
+    }
+
+    private static byte[] encodeImage(BufferedImage image, String format) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        String extension = format == null || format.isEmpty() ? "png" : format;
+        ImageIO.write(image, extension, outputStream);
+        return outputStream.toByteArray();
     }
 
     private static String guessImageFormat(byte[] bytes) {

--- a/shaft-doctor/src/main/java/com/shaft/doctor/internal/DoctorRedactor.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/internal/DoctorRedactor.java
@@ -8,6 +8,10 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -15,6 +19,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
+import javax.imageio.ImageIO;
 
 /**
  * Structured and textual deterministic redaction for Doctor evidence.
@@ -184,6 +189,105 @@ public final class DoctorRedactor {
 
     private static boolean looksLikeHtml(String value) {
         return value.indexOf('<') >= 0 && value.indexOf('>') > value.indexOf('<');
+    }
+
+    /**
+     * Determines if HTML page snapshot indicates sensitive fields requiring screenshot masking.
+     * Returns empty list if no sensitive fields found, or a special marker indicating whole-image masking.
+     *
+     * Since jsoup parses static HTML (not rendered layout), real pixel coordinates are not derivable.
+     * This method adopts a conservative approach: when sensitive input fields are detected,
+     * it returns a marker indicating full-image masking rather than fake precise regions.
+     *
+     * @param htmlContent HTML page snapshot content
+     * @return empty list if no sensitive fields, or list with single marker element for whole-image masking
+     */
+    public List<String> extractSensitiveRegions(String htmlContent) {
+        if (htmlContent == null || htmlContent.isBlank()) {
+            return List.of();
+        }
+        Document document = Jsoup.parseBodyFragment(htmlContent);
+        boolean hasSensitiveFields = false;
+        for (Element element : document.select(
+                "input[type=password],[autocomplete=current-password],[autocomplete=new-password]")) {
+            hasSensitiveFields = true;
+            break;
+        }
+        if (!hasSensitiveFields) {
+            for (Element element : document.getAllElements()) {
+                for (org.jsoup.nodes.Attribute attribute : element.attributes().asList()) {
+                    if (isSensitive(attribute.getKey())) {
+                        hasSensitiveFields = true;
+                        break;
+                    }
+                }
+                if (hasSensitiveFields) {
+                    break;
+                }
+            }
+        }
+        return hasSensitiveFields ? List.of("WHOLE_IMAGE") : List.of();
+    }
+
+    /**
+     * Applies full-image opaque masking to screenshot bytes when sensitive regions are detected.
+     * Only masks if regions list contains the whole-image marker.
+     *
+     * @param screenshotBytes original screenshot image bytes
+     * @param regions masking decision (empty = no masking, contains "WHOLE_IMAGE" = mask entire image)
+     * @return masked image bytes, or original bytes if no masking needed
+     * @throws IOException if image reading/writing fails
+     */
+    public byte[] redactScreenshot(byte[] screenshotBytes, List<String> regions) throws IOException {
+        if (screenshotBytes == null || screenshotBytes.length == 0) {
+            return screenshotBytes;
+        }
+        if (regions == null || regions.isEmpty() || !regions.contains("WHOLE_IMAGE")) {
+            return screenshotBytes;
+        }
+        try {
+            BufferedImage image = ImageIO.read(new ByteArrayInputStream(screenshotBytes));
+            if (image == null) {
+                return screenshotBytes;
+            }
+            int width = image.getWidth();
+            int height = image.getHeight();
+            BufferedImage masked = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+            int opaqueBlack = 0xFF000000;
+            for (int y = 0; y < height; y++) {
+                for (int x = 0; x < width; x++) {
+                    masked.setRGB(x, y, opaqueBlack);
+                }
+            }
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            String extension = guessImageFormat(screenshotBytes);
+            if (extension == null || extension.isEmpty()) {
+                extension = "png";
+            }
+            ImageIO.write(masked, extension, outputStream);
+            return outputStream.toByteArray();
+        } catch (IOException exception) {
+            return screenshotBytes;
+        }
+    }
+
+    private static String guessImageFormat(byte[] bytes) {
+        if (bytes == null || bytes.length < 4) {
+            return "png";
+        }
+        if (bytes[0] == (byte) 0xFF && bytes[1] == (byte) 0xD8 && bytes[2] == (byte) 0xFF) {
+            return "jpg";
+        }
+        if (bytes[0] == (byte) 0x89 && bytes[1] == 0x50 && bytes[2] == 0x4E && bytes[3] == 0x47) {
+            return "png";
+        }
+        if (bytes[0] == 0x47 && bytes[1] == 0x49 && bytes[2] == 0x46) {
+            return "gif";
+        }
+        if (bytes[0] == 0x52 && bytes[1] == 0x49 && bytes[2] == 0x46 && bytes[3] == 0x46) {
+            return "webp";
+        }
+        return "png";
     }
 
     private record NamedPattern(String name, Pattern pattern) {

--- a/shaft-doctor/src/main/java/com/shaft/doctor/internal/DoctorRedactor.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/internal/DoctorRedactor.java
@@ -287,19 +287,35 @@ public final class DoctorRedactor {
         if (bytes == null || bytes.length < 4) {
             return "png";
         }
-        if (bytes[0] == (byte) 0xFF && bytes[1] == (byte) 0xD8 && bytes[2] == (byte) 0xFF) {
+        if (isJpegSignature(bytes)) {
             return "jpg";
         }
-        if (bytes[0] == (byte) 0x89 && bytes[1] == 0x50 && bytes[2] == 0x4E && bytes[3] == 0x47) {
+        if (isPngSignature(bytes)) {
             return "png";
         }
-        if (bytes[0] == 0x47 && bytes[1] == 0x49 && bytes[2] == 0x46) {
+        if (isGifSignature(bytes)) {
             return "gif";
         }
-        if (bytes[0] == 0x52 && bytes[1] == 0x49 && bytes[2] == 0x46 && bytes[3] == 0x46) {
+        if (isWebpSignature(bytes)) {
             return "webp";
         }
         return "png";
+    }
+
+    private static boolean isJpegSignature(byte[] bytes) {
+        return bytes[0] == (byte) 0xFF && bytes[1] == (byte) 0xD8 && bytes[2] == (byte) 0xFF;
+    }
+
+    private static boolean isPngSignature(byte[] bytes) {
+        return bytes[0] == (byte) 0x89 && bytes[1] == 0x50 && bytes[2] == 0x4E && bytes[3] == 0x47;
+    }
+
+    private static boolean isGifSignature(byte[] bytes) {
+        return bytes[0] == 0x47 && bytes[1] == 0x49 && bytes[2] == 0x46;
+    }
+
+    private static boolean isWebpSignature(byte[] bytes) {
+        return bytes[0] == 0x52 && bytes[1] == 0x49 && bytes[2] == 0x46 && bytes[3] == 0x46;
     }
 
     private record NamedPattern(String name, Pattern pattern) {

--- a/shaft-doctor/src/test/java/com/shaft/doctor/DoctorAnalyzerTest.java
+++ b/shaft-doctor/src/test/java/com/shaft/doctor/DoctorAnalyzerTest.java
@@ -201,7 +201,8 @@ class DoctorAnalyzerTest {
                 false,
                 1,
                 128,
-                4_096));
+                4_096,
+                true));
 
         String bundleText = Files.readString(Path.of(result.bundlePath()), StandardCharsets.UTF_8);
         assertFalse(bundleText.contains("truncated-json-canary"));
@@ -405,7 +406,8 @@ class DoctorAnalyzerTest {
                 false,
                 1,
                 256,
-                512);
+                512,
+                true);
         assertThrows(IllegalArgumentException.class, () -> new DoctorAnalyzer().analyze(escaped));
 
         Path bounded = Files.createDirectories(allowed.resolve("bounded"));
@@ -420,7 +422,8 @@ class DoctorAnalyzerTest {
                 false,
                 1,
                 512,
-                1_024));
+                1_024,
+                true));
         assertTrue(result.bundle().evidence().stream().anyMatch(item -> item.truncated()));
         assertTrue(Long.parseLong(result.bundle().metadata().get("retainedBytes")) <= 1_024);
     }
@@ -447,7 +450,8 @@ class DoctorAnalyzerTest {
                 false,
                 1,
                 256,
-                512);
+                512,
+                true);
 
         assertThrows(IllegalArgumentException.class, () -> new DoctorAnalyzer().analyze(redirected));
     }
@@ -489,7 +493,8 @@ class DoctorAnalyzerTest {
                 false,
                 1,
                 DoctorAnalysisRequest.DEFAULT_MAX_ITEM_BYTES,
-                DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES));
+                DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES,
+                true));
 
         assertEquals(resource("golden/doctor-report.json"),
                 Files.readString(Path.of(result.jsonReportPath())).replace("\r\n", "\n"));
@@ -528,7 +533,8 @@ class DoctorAnalyzerTest {
                 pages,
                 minimumResults,
                 DoctorAnalysisRequest.DEFAULT_MAX_ITEM_BYTES,
-                DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES));
+                DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES,
+                true));
     }
 
     private static DoctorAnalysisRequest request(Path root, Path input, String outputName) {
@@ -541,7 +547,8 @@ class DoctorAnalyzerTest {
                 false,
                 1,
                 DoctorAnalysisRequest.DEFAULT_MAX_ITEM_BYTES,
-                DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES);
+                DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES,
+                true);
     }
 
     private static void writeResult(

--- a/shaft-doctor/src/test/java/com/shaft/doctor/collect/EvidenceCollectorPairingTest.java
+++ b/shaft-doctor/src/test/java/com/shaft/doctor/collect/EvidenceCollectorPairingTest.java
@@ -1,0 +1,319 @@
+package com.shaft.doctor.collect;
+
+import com.shaft.doctor.DoctorAnalysisRequest;
+import com.shaft.doctor.model.EvidenceBundle;
+import com.shaft.doctor.model.EvidenceCategory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EvidenceCollectorPairingTest {
+
+    @Test
+    void eachScreenshotIsMatchedWithItsOwnPageSnapshot(@TempDir Path temp) throws IOException {
+        Path inputDir = Files.createDirectories(temp.resolve("input"));
+        Path outputDir = Files.createDirectories(temp.resolve("output"));
+        EvidenceCollector collector = new EvidenceCollector();
+        writeMultipleScreenshotPairsInResult(inputDir);
+        DoctorAnalysisRequest request = new DoctorAnalysisRequest(
+                List.of(inputDir),
+                List.of(),
+                List.of(temp),
+                outputDir,
+                true,
+                true,
+                1,
+                DoctorAnalysisRequest.DEFAULT_MAX_ITEM_BYTES,
+                DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES,
+                true);
+        EvidenceBundle bundle = collector.collect(request);
+        Map<String, Long> categoryCount = bundle.evidence().stream()
+                .collect(java.util.stream.Collectors.groupingBy(
+                        item -> item.category().name(),
+                        java.util.stream.Collectors.counting()));
+        assertEquals(2L, categoryCount.getOrDefault("SCREENSHOT", 0L),
+                "Should have exactly 2 screenshots");
+        assertEquals(2L, categoryCount.getOrDefault("PAGE_SNAPSHOT", 0L),
+                "Should have exactly 2 page snapshots");
+    }
+
+    @Test
+    void screenshotWithoutMatchingSnapshotIsNotMasked(@TempDir Path temp) throws IOException {
+        Path inputDir = Files.createDirectories(temp.resolve("input"));
+        Path outputDir = Files.createDirectories(temp.resolve("output"));
+        EvidenceCollector collector = new EvidenceCollector();
+        writeOrphanedScreenshot(inputDir);
+        DoctorAnalysisRequest request = new DoctorAnalysisRequest(
+                List.of(inputDir),
+                List.of(),
+                List.of(temp),
+                outputDir,
+                true,
+                true,
+                1,
+                DoctorAnalysisRequest.DEFAULT_MAX_ITEM_BYTES,
+                DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES,
+                true);
+        EvidenceBundle bundle = collector.collect(request);
+        long screenshotCount = bundle.evidence().stream()
+                .filter(item -> item.category() == EvidenceCategory.SCREENSHOT)
+                .count();
+        assertEquals(1L, screenshotCount, "Orphaned screenshot should still be collected");
+    }
+
+    @Test
+    void pairingOrderingIsStableDeterministic(@TempDir Path temp) throws IOException {
+        Path inputDir = Files.createDirectories(temp.resolve("input"));
+        Path outputDir = Files.createDirectories(temp.resolve("output"));
+        EvidenceCollector collector = new EvidenceCollector();
+        writeOrphanedScreenshot(inputDir);
+        DoctorAnalysisRequest request = new DoctorAnalysisRequest(
+                List.of(inputDir),
+                List.of(),
+                List.of(temp),
+                outputDir,
+                true,
+                true,
+                1,
+                DoctorAnalysisRequest.DEFAULT_MAX_ITEM_BYTES,
+                DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES,
+                true);
+        EvidenceBundle bundle1 = collector.collect(request);
+        EvidenceBundle bundle2 = collector.collect(request);
+        assertEquals(bundle1.evidence().size(), bundle2.evidence().size(),
+                "Evidence count should be stable across runs");
+        for (int i = 0; i < bundle1.evidence().size(); i++) {
+            assertEquals(bundle1.evidence().get(i).id(), bundle2.evidence().get(i).id(),
+                    "Evidence IDs should be in stable deterministic order");
+        }
+    }
+
+    @Test
+    void screenReductionWithSensitiveFieldsWhenRedactFlagEnabled(@TempDir Path temp) throws IOException {
+        Path inputDir = Files.createDirectories(temp.resolve("input"));
+        Path outputDir = Files.createDirectories(temp.resolve("output"));
+        EvidenceCollector collector = new EvidenceCollector();
+        writeMixedPairsWithSensitivityVerification(inputDir);
+        DoctorAnalysisRequest request = new DoctorAnalysisRequest(
+                List.of(inputDir),
+                List.of(),
+                List.of(temp),
+                outputDir,
+                true,
+                true,
+                1,
+                DoctorAnalysisRequest.DEFAULT_MAX_ITEM_BYTES,
+                DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES,
+                true);
+        EvidenceBundle bundle = collector.collect(request);
+
+        var screenshotItems = bundle.evidence().stream()
+                .filter(item -> item.category() == EvidenceCategory.SCREENSHOT)
+                .toList();
+
+        assertTrue(screenshotItems.size() >= 2, "Should have at least 2 screenshots");
+
+        int maskedCount = 0;
+        int unmaskedCount = 0;
+        int expectedBlack = 0xFF000000;
+
+        for (var item : screenshotItems) {
+            byte[] screenshotBytes = Files.readAllBytes(outputDir.resolve(item.relativePath()));
+            java.awt.image.BufferedImage image = javax.imageio.ImageIO.read(
+                    new java.io.ByteArrayInputStream(screenshotBytes));
+
+            if (image == null) {
+                continue;
+            }
+
+            boolean isAllBlack = true;
+            for (int y = 0; y < image.getHeight() && isAllBlack; y++) {
+                for (int x = 0; x < image.getWidth() && isAllBlack; x++) {
+                    if (image.getRGB(x, y) != expectedBlack) {
+                        isAllBlack = false;
+                    }
+                }
+            }
+
+            if (isAllBlack) {
+                maskedCount++;
+            } else {
+                unmaskedCount++;
+            }
+        }
+
+        assertTrue(maskedCount >= 1, "At least one screenshot should be masked (sensitive). Found " +
+                maskedCount + " masked and " + unmaskedCount + " unmasked out of " + screenshotItems.size());
+        assertTrue(unmaskedCount >= 1, "At least one screenshot should NOT be masked (benign). Found " +
+                maskedCount + " masked and " + unmaskedCount + " unmasked out of " + screenshotItems.size());
+    }
+
+    private void writeMixedPairsWithSensitivityVerification(Path inputDir) throws IOException {
+        String resultJson = """
+                {
+                  "uuid": "mixed-sensitivity-test",
+                  "name": "testMixedSensitivity",
+                  "status": "passed",
+                  "start": 1000,
+                  "stop": 2000,
+                  "attachments": [
+                    {
+                      "name": "Screenshot benign",
+                      "source": "screenshot_benign.png",
+                      "type": "image/png"
+                    },
+                    {
+                      "name": "Page snapshot benign",
+                      "source": "snapshot_benign.html",
+                      "type": "text/html"
+                    },
+                    {
+                      "name": "Page snapshot sensitive",
+                      "source": "snapshot_sensitive.html",
+                      "type": "text/html"
+                    },
+                    {
+                      "name": "Screenshot sensitive",
+                      "source": "screenshot_sensitive.png",
+                      "type": "image/png"
+                    }
+                  ]
+                }
+                """;
+        Files.writeString(inputDir.resolve("test-result.json"), resultJson, StandardCharsets.UTF_8);
+        Files.write(inputDir.resolve("screenshot_benign.png"), createMinimalPng());
+        Files.write(inputDir.resolve("screenshot_sensitive.png"), createMinimalPng());
+        Files.writeString(inputDir.resolve("snapshot_benign.html"),
+                "<html><body><h1>Normal content</h1></body></html>",
+                StandardCharsets.UTF_8);
+        Files.writeString(inputDir.resolve("snapshot_sensitive.html"),
+                "<html><body><input type=\"password\" value=\"secret\"></body></html>",
+                StandardCharsets.UTF_8);
+    }
+
+    private void writeMultipleScreenshotPairsInResult(Path inputDir) throws IOException {
+        String resultJson = """
+                {
+                  "uuid": "test-123",
+                  "name": "testMultiplePairs",
+                  "status": "passed",
+                  "start": 1000,
+                  "stop": 2000,
+                  "attachments": [
+                    {
+                      "name": "Screenshot 1",
+                      "source": "screenshot1.png",
+                      "type": "image/png"
+                    },
+                    {
+                      "name": "Page snapshot 1",
+                      "source": "snapshot1.html",
+                      "type": "text/html"
+                    },
+                    {
+                      "name": "Screenshot 2",
+                      "source": "screenshot2.png",
+                      "type": "image/png"
+                    },
+                    {
+                      "name": "Page snapshot 2",
+                      "source": "snapshot2.html",
+                      "type": "text/html"
+                    }
+                  ]
+                }
+                """;
+        Files.writeString(inputDir.resolve("test-result.json"), resultJson, StandardCharsets.UTF_8);
+        Files.write(inputDir.resolve("screenshot1.png"), createMinimalPng());
+        Files.write(inputDir.resolve("screenshot2.png"), createMinimalPng());
+        Files.writeString(inputDir.resolve("snapshot1.html"), "<html><body>Snapshot 1</body></html>", StandardCharsets.UTF_8);
+        Files.writeString(inputDir.resolve("snapshot2.html"), "<html><body>Snapshot 2</body></html>", StandardCharsets.UTF_8);
+    }
+
+    private void writeOrphanedScreenshot(Path inputDir) throws IOException {
+        String resultJson = """
+                {
+                  "uuid": "orphan-test",
+                  "name": "testOrphanedScreenshot",
+                  "status": "passed",
+                  "start": 1000,
+                  "stop": 2000,
+                  "attachments": [
+                    {
+                      "name": "Screenshot",
+                      "source": "screenshot.png",
+                      "type": "image/png"
+                    }
+                  ]
+                }
+                """;
+        Files.writeString(inputDir.resolve("test-result.json"), resultJson, StandardCharsets.UTF_8);
+        Files.write(inputDir.resolve("screenshot.png"), createMinimalPng());
+    }
+
+    private void writeSensitivePageSnapshot(Path inputDir) throws IOException {
+        String resultJson = """
+                {
+                  "uuid": "sensitive-test",
+                  "name": "testSensitiveSnapshot",
+                  "status": "passed",
+                  "start": 1000,
+                  "stop": 2000,
+                  "attachments": [
+                    {
+                      "name": "Screenshot",
+                      "source": "screenshot.png",
+                      "type": "image/png"
+                    },
+                    {
+                      "name": "Page snapshot",
+                      "source": "snapshot.html",
+                      "type": "text/html"
+                    }
+                  ]
+                }
+                """;
+        Files.writeString(inputDir.resolve("test-result.json"), resultJson, StandardCharsets.UTF_8);
+        Files.write(inputDir.resolve("screenshot.png"), createMinimalPng());
+        Files.writeString(inputDir.resolve("snapshot.html"),
+                "<html><body><input type=\"password\" value=\"secret\"></body></html>",
+                StandardCharsets.UTF_8);
+    }
+
+    private byte[] createMinimalPng() throws IOException {
+        java.awt.image.BufferedImage image = new java.awt.image.BufferedImage(
+                10, 10, java.awt.image.BufferedImage.TYPE_INT_RGB);
+        for (int y = 0; y < 10; y++) {
+            for (int x = 0; x < 10; x++) {
+                image.setRGB(x, y, 0xFFFFFFFF);
+            }
+        }
+        java.io.ByteArrayOutputStream output = new java.io.ByteArrayOutputStream();
+        javax.imageio.ImageIO.write(image, "png", output);
+        return output.toByteArray();
+    }
+
+    private byte[] createAllBlackPng() throws IOException {
+        java.awt.image.BufferedImage image = new java.awt.image.BufferedImage(
+                10, 10, java.awt.image.BufferedImage.TYPE_INT_RGB);
+        for (int y = 0; y < 10; y++) {
+            for (int x = 0; x < 10; x++) {
+                image.setRGB(x, y, 0xFF000000);
+            }
+        }
+        java.io.ByteArrayOutputStream output = new java.io.ByteArrayOutputStream();
+        javax.imageio.ImageIO.write(image, "png", output);
+        return output.toByteArray();
+    }
+}

--- a/shaft-doctor/src/test/java/com/shaft/doctor/collect/EvidenceCollectorPairingTest.java
+++ b/shaft-doctor/src/test/java/com/shaft/doctor/collect/EvidenceCollectorPairingTest.java
@@ -14,8 +14,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EvidenceCollectorPairingTest {
@@ -262,54 +260,12 @@ class EvidenceCollectorPairingTest {
         Files.write(inputDir.resolve("screenshot.png"), createMinimalPng());
     }
 
-    private void writeSensitivePageSnapshot(Path inputDir) throws IOException {
-        String resultJson = """
-                {
-                  "uuid": "sensitive-test",
-                  "name": "testSensitiveSnapshot",
-                  "status": "passed",
-                  "start": 1000,
-                  "stop": 2000,
-                  "attachments": [
-                    {
-                      "name": "Screenshot",
-                      "source": "screenshot.png",
-                      "type": "image/png"
-                    },
-                    {
-                      "name": "Page snapshot",
-                      "source": "snapshot.html",
-                      "type": "text/html"
-                    }
-                  ]
-                }
-                """;
-        Files.writeString(inputDir.resolve("test-result.json"), resultJson, StandardCharsets.UTF_8);
-        Files.write(inputDir.resolve("screenshot.png"), createMinimalPng());
-        Files.writeString(inputDir.resolve("snapshot.html"),
-                "<html><body><input type=\"password\" value=\"secret\"></body></html>",
-                StandardCharsets.UTF_8);
-    }
-
     private byte[] createMinimalPng() throws IOException {
         java.awt.image.BufferedImage image = new java.awt.image.BufferedImage(
                 10, 10, java.awt.image.BufferedImage.TYPE_INT_RGB);
         for (int y = 0; y < 10; y++) {
             for (int x = 0; x < 10; x++) {
                 image.setRGB(x, y, 0xFFFFFFFF);
-            }
-        }
-        java.io.ByteArrayOutputStream output = new java.io.ByteArrayOutputStream();
-        javax.imageio.ImageIO.write(image, "png", output);
-        return output.toByteArray();
-    }
-
-    private byte[] createAllBlackPng() throws IOException {
-        java.awt.image.BufferedImage image = new java.awt.image.BufferedImage(
-                10, 10, java.awt.image.BufferedImage.TYPE_INT_RGB);
-        for (int y = 0; y < 10; y++) {
-            for (int x = 0; x < 10; x++) {
-                image.setRGB(x, y, 0xFF000000);
             }
         }
         java.io.ByteArrayOutputStream output = new java.io.ByteArrayOutputStream();

--- a/shaft-doctor/src/test/java/com/shaft/doctor/internal/DoctorRedactorTest.java
+++ b/shaft-doctor/src/test/java/com/shaft/doctor/internal/DoctorRedactorTest.java
@@ -75,7 +75,8 @@ class DoctorRedactorTest {
         byte[] originalImage = createMinimalPngImage();
         List<String> regions = List.of();
         byte[] result = redactor.redactScreenshot(originalImage, regions);
-        java.util.Arrays.equals(originalImage, result);
+        assertTrue(java.util.Arrays.equals(originalImage, result),
+                "Image should be returned unchanged when no regions are marked for masking");
     }
 
     @Test

--- a/shaft-doctor/src/test/java/com/shaft/doctor/internal/DoctorRedactorTest.java
+++ b/shaft-doctor/src/test/java/com/shaft/doctor/internal/DoctorRedactorTest.java
@@ -1,0 +1,138 @@
+package com.shaft.doctor.internal;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DoctorRedactorTest {
+
+    @Test
+    void extractSensitiveRegionsDetectsPasswordFields() {
+        DoctorRedactor redactor = new DoctorRedactor();
+        String htmlWithPassword = "<html><body><input type=\"password\" value=\"secret\"></body></html>";
+        List<String> regions = redactor.extractSensitiveRegions(htmlWithPassword);
+        assertEquals(List.of("WHOLE_IMAGE"), regions, "Password field should trigger whole-image mask marker");
+    }
+
+    @Test
+    void extractSensitiveRegionsDetectsAutocompletePasswordFields() {
+        DoctorRedactor redactor = new DoctorRedactor();
+        String htmlWithAutocomplete = "<html><body><input autocomplete=\"current-password\"></body></html>";
+        List<String> regions = redactor.extractSensitiveRegions(htmlWithAutocomplete);
+        assertEquals(List.of("WHOLE_IMAGE"), regions, "Autocomplete password field should trigger whole-image mask");
+    }
+
+    @Test
+    void extractSensitiveRegionsDetectsSensitiveAttributes() {
+        DoctorRedactor redactor = new DoctorRedactor();
+        String htmlWithSensitiveAttribute = "<html><body><div api-key=\"secret123\"></div></body></html>";
+        List<String> regions = redactor.extractSensitiveRegions(htmlWithSensitiveAttribute);
+        assertEquals(List.of("WHOLE_IMAGE"), regions, "Sensitive attribute should trigger whole-image mask");
+    }
+
+    @Test
+    void extractSensitiveRegionsReturnsEmptyListForBenignHtml() {
+        DoctorRedactor redactor = new DoctorRedactor();
+        String benignHtml = "<html><body><h1>Hello World</h1><p>Normal content</p></body></html>";
+        List<String> regions = redactor.extractSensitiveRegions(benignHtml);
+        assertEquals(List.of(), regions, "Benign HTML should return empty list (no masking needed)");
+    }
+
+    @Test
+    void extractSensitiveRegionsHandlesNullInput() {
+        DoctorRedactor redactor = new DoctorRedactor();
+        List<String> regions = redactor.extractSensitiveRegions(null);
+        assertEquals(List.of(), regions, "Null input should return empty list");
+    }
+
+    @Test
+    void extractSensitiveRegionsHandlesBlankInput() {
+        DoctorRedactor redactor = new DoctorRedactor();
+        List<String> regions = redactor.extractSensitiveRegions("   ");
+        assertEquals(List.of(), regions, "Blank input should return empty list");
+    }
+
+    @Test
+    void redactScreenshotAppliesFullImageMaskWhenWholeImageMarkerPresent() throws IOException {
+        DoctorRedactor redactor = new DoctorRedactor();
+        byte[] originalImage = createMinimalPngImage();
+        List<String> regions = List.of("WHOLE_IMAGE");
+        byte[] maskedImage = redactor.redactScreenshot(originalImage, regions);
+        assertNotEquals(originalImage, maskedImage, "Masked image should differ from original");
+        assertFalse(java.util.Arrays.equals(originalImage, maskedImage), "Image bytes should be different after masking");
+        assertTrue(maskedImage.length > 0, "Masked image should not be empty");
+    }
+
+    @Test
+    void redactScreenshotDoesNotMaskWhenRegionsEmpty() throws IOException {
+        DoctorRedactor redactor = new DoctorRedactor();
+        byte[] originalImage = createMinimalPngImage();
+        List<String> regions = List.of();
+        byte[] result = redactor.redactScreenshot(originalImage, regions);
+        java.util.Arrays.equals(originalImage, result);
+    }
+
+    @Test
+    void redactScreenshotHandlesNullInput() throws IOException {
+        DoctorRedactor redactor = new DoctorRedactor();
+        List<String> regions = List.of("WHOLE_IMAGE");
+        byte[] result = redactor.redactScreenshot(null, regions);
+        assertEquals(null, result, "Null screenshot should return null");
+    }
+
+    @Test
+    void redactScreenshotHandlesEmptyInput() throws IOException {
+        DoctorRedactor redactor = new DoctorRedactor();
+        byte[] emptyImage = new byte[0];
+        List<String> regions = List.of("WHOLE_IMAGE");
+        byte[] result = redactor.redactScreenshot(emptyImage, regions);
+        assertEquals(emptyImage, result, "Empty screenshot should be returned unchanged");
+    }
+
+    @Test
+    void redactScreenshotHandlesInvalidImageData() throws IOException {
+        DoctorRedactor redactor = new DoctorRedactor();
+        byte[] invalidImage = "not an image".getBytes();
+        List<String> regions = List.of("WHOLE_IMAGE");
+        byte[] result = redactor.redactScreenshot(invalidImage, regions);
+        assertEquals(invalidImage, result, "Invalid image data should be returned unchanged (graceful fallback)");
+    }
+
+    @Test
+    void redactScreenshotMasksPixelsAsOpaque() throws IOException {
+        DoctorRedactor redactor = new DoctorRedactor();
+        byte[] originalImage = createMinimalPngImage();
+        List<String> regions = List.of("WHOLE_IMAGE");
+        byte[] maskedImage = redactor.redactScreenshot(originalImage, regions);
+        java.awt.image.BufferedImage image = javax.imageio.ImageIO.read(
+                new java.io.ByteArrayInputStream(maskedImage));
+        if (image != null) {
+            int expectedBlack = 0xFF000000;
+            for (int y = 0; y < image.getHeight(); y++) {
+                for (int x = 0; x < image.getWidth(); x++) {
+                    int pixel = image.getRGB(x, y);
+                    assertEquals(expectedBlack, pixel, "All pixels should be opaque black");
+                }
+            }
+        }
+    }
+
+    private byte[] createMinimalPngImage() throws IOException {
+        java.awt.image.BufferedImage image = new java.awt.image.BufferedImage(
+                10, 10, java.awt.image.BufferedImage.TYPE_INT_RGB);
+        for (int y = 0; y < 10; y++) {
+            for (int x = 0; x < 10; x++) {
+                image.setRGB(x, y, 0xFFFFFFFF);
+            }
+        }
+        java.io.ByteArrayOutputStream output = new java.io.ByteArrayOutputStream();
+        javax.imageio.ImageIO.write(image, "png", output);
+        return output.toByteArray();
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/DoctorService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/DoctorService.java
@@ -104,7 +104,8 @@ public class DoctorService {
                 includePageSnapshots,
                 minimumAllureResults <= 0 ? 1 : minimumAllureResults,
                 DoctorAnalysisRequest.DEFAULT_MAX_ITEM_BYTES,
-                DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES);
+                DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES,
+                true);
         DoctorAnalysisResult result = new DoctorAnalyzer().analyze(request);
         return remediationService.build(
                 result,
@@ -165,7 +166,8 @@ public class DoctorService {
                 includePageSnapshots,
                 minimumAllureResults <= 0 ? 1 : minimumAllureResults,
                 DoctorAnalysisRequest.DEFAULT_MAX_ITEM_BYTES,
-                DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES);
+                DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES,
+                true);
         DoctorAnalysisResult result = new DoctorAnalyzer().analyze(request);
         return remediationService.build(
                 result,
@@ -291,7 +293,8 @@ public class DoctorService {
                 includePageSnapshots,
                 minimumAllureResults <= 0 ? 1 : minimumAllureResults,
                 DoctorAnalysisRequest.DEFAULT_MAX_ITEM_BYTES,
-                DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES);
+                DoctorAnalysisRequest.DEFAULT_MAX_BUNDLE_BYTES,
+                true);
         DoctorAnalyzer analyzer = new DoctorAnalyzer();
         DoctorAnalysisResult result;
         PilotConfiguration configuration = currentConfiguration();


### PR DESCRIPTION
## Summary

Follow-up fix for an item from #3302 that was **rejected by QA in a first implementation pass**. This PR is a fresh implementation on a new branch from `origin/main` (the earlier PR never merged).

The Doctor evidence-collection pipeline had three related problems:

1. **Fake sensitive regions** — `DoctorRedactor.extractSensitiveRegions` fabricated pixel-coordinate regions with no basis in the actual screenshot content, giving the false impression of precise region-level redaction.
2. **Wrong screenshot/snapshot pairing** — `EvidenceCollector` paired screenshots with page snapshots using a "first match wins" heuristic, so a screenshot could be evaluated against the wrong snapshot's sensitive-field data and be redacted (or not redacted) incorrectly.
3. **Dead config knob** — a `redactScreenshots`-style flag existed but wasn't sourced from any real caller-provided value, giving a false sense of configurability.

## What changed

- **`DoctorRedactor`**: `extractSensitiveRegions` no longer invents coordinates — it returns `List.of()` or `List.of("WHOLE_IMAGE")` only. `redactScreenshot` now masks the **entire real `BufferedImage`** (every pixel painted opaque black) rather than pretending to target specific regions it cannot actually locate. Javadoc explicitly documents this whole-image limitation.
- **`EvidenceCollector`**: builds an ordered `AttachmentInfo` list and pairs each screenshot with its own page snapshot via a documented, deterministic rule — nearest preceding snapshot, else nearest following, else no match — replacing the old first-match-wins pairing. Also guards `collectAllureAttachments` against re-descending into the same already-special-cased `attachments` array node, avoiding double-counting.
- **`DoctorAnalysisRequest` / `DoctorAnalyzer` / `DoctorCli` / `DoctorService`**: `redactScreenshots` is now a real field on the request record, genuinely consulted at the masking decision point (`request.redactScreenshots() && matchingSnapshot != null`) instead of a properties-file entry that configured nothing.
- Added `DoctorRedactorTest` (12 tests) and `EvidenceCollectorPairingTest` (4 tests) covering pixel-level masking and per-screenshot snapshot correlation, including a mixed benign/sensitive pairing case in the same step proving correct per-screenshot correlation (not "first wins").

## Checklist proving the root cause is resolved

- [x] No fabricated region coordinates anywhere in `DoctorRedactor` — verified no coordinate math remains in `extractSensitiveRegions`.
- [x] `redactScreenshot` masks every pixel of a real image (asserted via all-black-pixel and byte-diff tests), not a fake region.
- [x] Screenshot-to-snapshot pairing is deterministic and documented, and a test proves two screenshots in the same step can resolve to different (correct) snapshots rather than both taking the first one.
- [x] No misleading properties-file entry reintroduced (zero hits for `redactScreenshots` / `doctor.ai.redactScreenshots` under `shaft-engine` properties).
- [x] `redactScreenshots` is a real field consulted at the masking decision point.
- [x] `collectAllureAttachments` recursion guard prevents double-counting the same attachments array node.
- [x] All new and pre-existing Doctor tests compile and pass (`DoctorRedactorTest`, `EvidenceCollectorPairingTest`, `DoctorAnalyzerTest`).

## Known follow-up (non-blocking, called out by QA)

Every call site of `redactScreenshots` (`DoctorCli`, `DoctorService` x3) currently hardcodes `true` literally — there is no `--redact-screenshots/--no-redact-screenshots` CLI flag or MCP tool parameter yet, unlike sibling flags `includeScreenshots`/`includePageSnapshots` which are wired to real `options.flag(...)` calls. This defaults safely to masking-on and is a real, consulted field (unlike the original dead knob), but does not yet let a caller override it. Recommended as a fast follow-up, not a blocker for this PR.

## Note

This PR was produced by an automated pipeline. It is ready for review but should get human review before merge.