### PR TITLE
Show progress for Test MCP and Refresh Tools background actions

### DIFF
--- a/shaft-intellij/build.gradle.kts
+++ b/shaft-intellij/build.gradle.kts
@@ -94,6 +94,7 @@ tasks {
 
     test {
         useJUnitPlatform()
+        systemProperty("java.awt.headless", "true")
         systemProperty("shaft.intellij.screenshotDir", System.getProperty("shaft.intellij.screenshotDir", ""))
         systemProperty("shaft.intellij.liveGemini", System.getProperty("shaft.intellij.liveGemini", "false"))
         systemProperty("shaft.intellij.liveMcpCommand", System.getProperty("shaft.intellij.liveMcpCommand", ""))

--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
@@ -41,6 +41,8 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
     private static final String ANTHROPIC_PROVIDER_KEY = "ANTHROPIC_API_KEY";
     private static final String GEMINI_PROVIDER_KEY = "GEMINI_API_KEY";
     private static final String GITHUB_PROVIDER_KEY = "GITHUB_TOKEN";
+    private static final String TEST_MCP_TOOLTIP = "Test MCP";
+    private static final String TESTING_MCP_TOOLTIP = "Testing...";
 
     private final Supplier<ShaftSettingsState.Settings> settingsProvider;
     private final Supplier<CredentialAccess> credentialsProvider;
@@ -97,6 +99,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
     private boolean geminiClearRequested;
     private boolean githubClearRequested;
     private boolean editingAgentConfiguration;
+    private boolean testMcpInFlight;
 
     /**
      * Creates a settings page backed by IntelliJ persistent services.
@@ -604,7 +607,12 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         if (button == null || statusLabel == null || host == null || mcpCommand == null || passProviderKeys == null) {
             return;
         }
+        if (testMcpInFlight) {
+            return;
+        }
+        testMcpInFlight = true;
         button.setEnabled(false);
+        button.setToolTipText(TESTING_MCP_TOOLTIP);
         statusLabel.setEnabled(true);
         statusLabel.setText("Testing...");
         statusLabel.setForeground(ShaftStatusPresentation.progress());
@@ -614,9 +622,11 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
                     if (button == null || statusLabel == null || host == null) {
                         return;
                     }
+                    testMcpInFlight = false;
                     button.setEnabled(true);
+                    button.setToolTipText(TEST_MCP_TOOLTIP);
                     if (error != null) {
-                        statusLabel.setText("Failed");
+                        statusLabel.setText(ShaftStatusPresentation.ERROR_ICON + " Failed");
                         statusLabel.setForeground(ShaftStatusPresentation.error());
                         McpInvocationError category = McpInvocationError.categorize(error);
                         StringBuilder sb = new StringBuilder();
@@ -636,13 +646,13 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
             return;
         }
         if (result != null && result.success()) {
-            statusLabel.setText("Connected");
+            statusLabel.setText(ShaftStatusPresentation.SUCCESS_ICON + " Connected");
             statusLabel.setForeground(ShaftStatusPresentation.success());
             saveConnectedSettings();
             editingAgentConfiguration = false;
             updateAgentConfigurationControls();
         } else {
-            statusLabel.setText("Failed");
+            statusLabel.setText(ShaftStatusPresentation.ERROR_ICON + " Failed");
             statusLabel.setForeground(ShaftStatusPresentation.error());
             String message = formatErrorMessage(result);
             Messages.showErrorDialog(host, message, "SHAFT MCP");

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftFeaturePanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftFeaturePanel.java
@@ -46,6 +46,9 @@ import java.util.stream.Collectors;
  * MCP tools panel with editable JSON arguments.
  */
 final class ShaftFeaturePanel extends JPanel {
+    private static final String REFRESH_TOOLS_TOOLTIP = "Refresh tools";
+    private static final String REFRESHING_TOOLTIP = "Refreshing...";
+
     private List<ToolCategory> categories;
     private final boolean catalogRefreshEnabled;
     private final JBTextField search;
@@ -268,6 +271,9 @@ final class ShaftFeaturePanel extends JPanel {
         if (!catalogRefreshEnabled) {
             return;
         }
+        if (currentInvocation != null) {
+            return;
+        }
         if (!mcpConfigured()) {
             status.setText("Configure MCP");
             outputArea.setText("Configure SHAFT MCP in Settings before refreshing the tool catalog.");
@@ -278,6 +284,7 @@ final class ShaftFeaturePanel extends JPanel {
             return;
         }
         setRunning(true, "Refreshing tools...");
+        refreshCatalogButton.setToolTipText(REFRESHING_TOOLTIP);
         outputArea.setText("");
         copyOutputButton.setEnabled(false);
         currentInvocation = ShaftMcpInvocationService.getInstance(project).startListTools();
@@ -312,6 +319,7 @@ final class ShaftFeaturePanel extends JPanel {
     }
 
     private void showCatalogResult(ShaftMcpToolResult result, Throwable error) {
+        refreshCatalogButton.setToolTipText(REFRESH_TOOLS_TOOLTIP);
         if (error instanceof CancellationException) {
             setRunning(false, "Cancelled");
             outputArea.setText("Cancelled.");
@@ -319,7 +327,11 @@ final class ShaftFeaturePanel extends JPanel {
             return;
         }
         boolean success = error == null && result != null && result.success();
-        setRunning(false, success ? "Tools refreshed" : "Failed");
+        // setRunning(false, ...) clears currentInvocation, which reloadCategories() -> refreshTools()
+        // -> loadSelectedTemplate() -> validateArguments() reads to decide whether to reset the status
+        // label back to "Ready". Run that reload first so the SUCCESS_ICON/ERROR_ICON completion
+        // message set below is the last write to the status label, not clobbered by it.
+        setRunning(false, null);
         if (success) {
             categories = ToolTemplates.categories(result.output());
             reloadCategories();
@@ -337,6 +349,9 @@ final class ShaftFeaturePanel extends JPanel {
         } else {
             formatErrorOutput(result);
         }
+        status.setText(success
+                ? ShaftStatusPresentation.SUCCESS_ICON + " Tools refreshed"
+                : ShaftStatusPresentation.ERROR_ICON + " Failed");
         copyOutputButton.setEnabled(!outputArea.getText().isBlank());
     }
 
@@ -436,7 +451,9 @@ final class ShaftFeaturePanel extends JPanel {
         toolSelector.setEnabled(!running);
         argumentsArea.setEnabled(!running);
         progress.setVisible(running);
-        status.setText(message);
+        if (message != null) {
+            status.setText(message);
+        }
         if (!running) {
             currentInvocation = null;
         }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftSettingsConfigurableTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftSettingsConfigurableTest.java
@@ -363,19 +363,19 @@ class ShaftSettingsConfigurableTest {
             ShaftMcpToolResult result) throws Exception {
         Method showProbeResult = ShaftSettingsConfigurable.class.getDeclaredMethod(
                 "showProbeResult", JPanel.class, JLabel.class, ShaftMcpToolResult.class);
-        showProbeResult.setAccessible(true);
+        showProbeResult.setAccessible(true); // NOPMD - reflective test invocation of a private completion handler, matching the established pattern in ShaftPanelSetupTest
         showProbeResult.invoke(configurable, host, statusLabel, result);
     }
 
     private static void invokeTestMcpConnection(ShaftSettingsConfigurable configurable) throws Exception {
         Method testMcpConnection = ShaftSettingsConfigurable.class.getDeclaredMethod("testMcpConnection");
-        testMcpConnection.setAccessible(true);
+        testMcpConnection.setAccessible(true); // NOPMD - reflective test invocation of a private completion handler, matching the established pattern in ShaftPanelSetupTest
         testMcpConnection.invoke(configurable);
     }
 
     private static Object getField(Object target, String name) throws Exception {
         Field field = target.getClass().getDeclaredField(name);
-        field.setAccessible(true);
+        field.setAccessible(true); // NOPMD - test-only field inspection, matching the established getField/setField helpers in ShaftPanelSetupTest
         return field.get(target);
     }
 

--- a/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftSettingsConfigurableTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftSettingsConfigurableTest.java
@@ -1,6 +1,8 @@
 package com.shaft.intellij.settings;
 
 import com.intellij.ui.components.JBTextField;
+import com.shaft.intellij.mcp.ShaftMcpToolResult;
+import com.shaft.intellij.ui.ShaftStatusPresentation;
 import org.junit.jupiter.api.Test;
 
 import javax.swing.JButton;
@@ -8,10 +10,14 @@ import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
+import javax.swing.JPanel;
 import javax.swing.JPasswordField;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -25,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ShaftSettingsConfigurableTest {
@@ -258,6 +265,118 @@ class ShaftSettingsConfigurableTest {
 
         assertEquals(0, openAiField.getPassword().length);
         assertTrue(configurable.isModified());
+    }
+
+    @Test
+    void testMcpButtonEntersBusyStateAndBlocksReentryWhileInFlight() throws Exception {
+        ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
+        // A non-blank command routes ShaftMcpConnectionProbe.test through its
+        // CompletableFuture.supplyAsync branch (a blank command resolves inline on the calling
+        // thread instead, which would race this assertion). The executable does not exist, so the
+        // background ProcessBuilder.start() call fails almost immediately with an IOException
+        // instead of running/waiting on a real MCP handshake - we only need the synchronous busy
+        // state that testMcpConnection() sets up before handing off to that background thread.
+        settings.mcpCommand = "\"" + Path.of("does", "not", "exist", "shaft-mcp-missing.exe") + "\"";
+        ShaftSettingsConfigurable configurable = new ShaftSettingsConfigurable(settings, new InMemoryCredentials());
+        JComponent panel = (JComponent) configurable.createComponent();
+
+        JButton testMcp = findByAccessibleName(panel, "Test MCP", JButton.class);
+        assertNotNull(testMcp);
+
+        testMcp.doClick();
+
+        assertAll(
+                () -> assertFalse(testMcp.isEnabled(), "button should be disabled while the probe is in flight"),
+                () -> assertEquals("Testing...", testMcp.getToolTipText()),
+                () -> assertEquals(Boolean.TRUE, getField(configurable, "testMcpInFlight")));
+
+        // Re-entry guard: invoking the real completion-guarded method again while
+        // testMcpInFlight is still true must be a no-op, not start a second probe.
+        invokeTestMcpConnection(configurable);
+
+        assertAll(
+                () -> assertFalse(testMcp.isEnabled(), "second click while in flight must not re-enable or restart"),
+                () -> assertEquals("Testing...", testMcp.getToolTipText(),
+                        "tooltip must still read the busy label after a blocked re-entrant call"),
+                () -> assertEquals(Boolean.TRUE, getField(configurable, "testMcpInFlight")));
+    }
+
+    @Test
+    void showProbeResultAppliesSuccessGlyphThroughRealCompletionPath() throws Exception {
+        ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
+        settings.mcpSetupComplete = false;
+        ShaftSettingsConfigurable configurable = new ShaftSettingsConfigurable(settings, new InMemoryCredentials());
+        JComponent panel = (JComponent) configurable.createComponent();
+        JLabel statusLabel = findByAccessibleName(panel, "SHAFT MCP test status", JLabel.class);
+        assertNotNull(statusLabel);
+        statusLabel.setText("Testing...");
+
+        invokeShowProbeResult(configurable, (JPanel) panel, statusLabel,
+                ShaftMcpToolResult.success("Handshake acknowledged."));
+
+        assertAll(
+                () -> assertEquals(ShaftStatusPresentation.SUCCESS_ICON + " Connected", statusLabel.getText()),
+                () -> assertTrue(settings.mcpSetupComplete, "a successful probe should mark MCP setup complete"));
+    }
+
+    @Test
+    void showProbeResultAppliesErrorGlyphThroughRealCompletionPathBeforeReportingTheFailure() throws Exception {
+        ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
+        settings.mcpSetupComplete = false;
+        ShaftSettingsConfigurable configurable = new ShaftSettingsConfigurable(settings, new InMemoryCredentials());
+        JComponent panel = (JComponent) configurable.createComponent();
+        JLabel statusLabel = findByAccessibleName(panel, "SHAFT MCP test status", JLabel.class);
+        assertNotNull(statusLabel);
+        statusLabel.setText("Testing...");
+
+        // showProbeResult's failure branch reports the outcome via Messages.showErrorDialog(host, ...).
+        // This module has no test-only seam (e.g. TestDialogManager.setTestDialog) wired up for that
+        // call - there is no existing precedent for stubbing Messages in this suite. The JUnit5 IntelliJ
+        // test framework attached to this module's test JVM enforces its own EDT-thread assertion
+        // before DialogWrapper ever reaches real AWT/Swing dialog code, so invoking this off the EDT (as
+        // any plain JUnit test body runs) surfaces as a real, deterministic IntelliJ threading exception
+        // instead of popping a blocking modal. We still invoke the real, private
+        // showProbeResult(JPanel, JLabel, ShaftMcpToolResult) method via reflection - not a hand-written
+        // stand-in - and the assertions below confirm the ERROR_ICON glyph the method sets on the label
+        // (which happens before the dialog call in production code) really came from that invocation.
+        InvocationTargetException wrapped = assertThrows(InvocationTargetException.class,
+                () -> invokeShowProbeResult(configurable, (JPanel) panel, statusLabel,
+                        ShaftMcpToolResult.failure("MCP server process exited.")));
+
+        assertAll(
+                () -> assertNotNull(wrapped.getCause()),
+                () -> assertTrue(wrapped.getCause() instanceof RuntimeException,
+                        "expected the real Messages.showErrorDialog call to fail with a runtime exception, got: "
+                                + wrapped.getCause()),
+                () -> assertTrue(wrapped.getCause().getMessage() != null
+                                && wrapped.getCause().getMessage().contains("Event Dispatch Thread"),
+                        "expected IntelliJ's EDT-only threading assertion inside Messages.showErrorDialog, got: "
+                                + wrapped.getCause()),
+                () -> assertEquals(ShaftStatusPresentation.ERROR_ICON + " Failed", statusLabel.getText()),
+                () -> assertFalse(settings.mcpSetupComplete));
+    }
+
+    private static void invokeShowProbeResult(
+            ShaftSettingsConfigurable configurable,
+            JPanel host,
+            JLabel statusLabel,
+            ShaftMcpToolResult result) throws Exception {
+        Method showProbeResult = ShaftSettingsConfigurable.class.getDeclaredMethod(
+                "showProbeResult", JPanel.class, JLabel.class, ShaftMcpToolResult.class);
+        showProbeResult.setAccessible(true);
+        showProbeResult.invoke(configurable, host, statusLabel, result);
+    }
+
+    private static void invokeTestMcpConnection(ShaftSettingsConfigurable configurable) throws Exception {
+        Method testMcpConnection = ShaftSettingsConfigurable.class.getDeclaredMethod("testMcpConnection");
+        testMcpConnection.setAccessible(true);
+        testMcpConnection.invoke(configurable);
+    }
+
+    private static Object getField(Object target, String name) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(target);
     }
 
     private static List<JButton> collectButtons(Component root) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -65,6 +65,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -272,6 +273,80 @@ class ShaftPanelSetupTest {
                 () -> assertTrue(containsText(toolWindow, "Connect SHAFT Assistant")),
                 () -> assertTrue(containsText(tools, "Configure SHAFT MCP")),
                 () -> assertTrue(outputText(tools).contains("Configure SHAFT MCP in Settings before running Tools requests.")));
+    }
+
+    @Test
+    void refreshCatalogEntersBusyStateThenBlocksReentryViaRealGuard() throws Exception {
+        ShaftFeaturePanel tools = new ShaftFeaturePanel(fakeProject(), connectedMcpSettings());
+        JButton refreshButton = findButton(tools, "Refresh tools");
+        assertNotNull(refreshButton);
+        assertEquals("Refresh tools", refreshButton.getToolTipText());
+
+        // The fake test Project has no real ShaftMcpInvocationService/Application wired up (this
+        // suite never registers one - see fakeProject()), so refreshCatalog()'s call into
+        // ShaftMcpInvocationService.getInstance(project).startListTools() is expected to throw once
+        // it gets that far. What we're proving here is that setRunning(true, ...) and the busy
+        // tooltip swap already happened - via the real refreshCatalog(Project) method - before that
+        // unrelated plumbing gap is hit.
+        assertThrows(NullPointerException.class, () -> invokeRefreshCatalog(tools, fakeProject()));
+
+        assertAll(
+                () -> assertFalse(refreshButton.isEnabled(), "button should be disabled once refreshCatalog() starts running"),
+                () -> assertEquals("Refreshing...", refreshButton.getToolTipText()));
+
+        // Re-entry guard: seed currentInvocation as if a request were genuinely in flight, then
+        // invoke the real refreshCatalog(Project) method again. The guard at the top of the method
+        // must return immediately without touching the button/tooltip/currentInvocation again.
+        ShaftMcpInvocation inFlight = new ShaftMcpInvocation(new CompletableFuture<>(), () -> {
+        });
+        setField(tools, "currentInvocation", inFlight);
+        refreshButton.setEnabled(true);
+        refreshButton.setToolTipText("Refresh tools");
+
+        invokeRefreshCatalog(tools, fakeProject());
+
+        assertAll(
+                () -> assertSame(inFlight, getField(tools, "currentInvocation"),
+                        "a blocked re-entrant call must not replace the in-flight invocation"),
+                () -> assertTrue(refreshButton.isEnabled(),
+                        "the re-entry guard must return before touching button state"),
+                () -> assertEquals("Refresh tools", refreshButton.getToolTipText(),
+                        "the re-entry guard must return before touching the tooltip"));
+    }
+
+    @Test
+    void showCatalogResultAppliesSuccessAndErrorGlyphsThroughRealCompletionPath() throws Exception {
+        ShaftFeaturePanel tools = new ShaftFeaturePanel(fakeProject(), connectedMcpSettings());
+        JButton refreshButton = findButton(tools, "Refresh tools");
+        assertNotNull(refreshButton);
+
+        setField(tools, "currentInvocation", new ShaftMcpInvocation(new CompletableFuture<>(), () -> {
+        }));
+        refreshButton.setToolTipText("Refreshing...");
+
+        showCatalogResult(tools, ShaftMcpToolResult.success(mcpToolsList()));
+
+        assertAll(
+                () -> assertTrue(statusText(tools).contains(ShaftStatusPresentation.SUCCESS_ICON),
+                        "success completion should surface the shared SUCCESS_ICON glyph: " + statusText(tools)),
+                () -> assertTrue(statusText(tools).contains("Tools refreshed")),
+                () -> assertEquals("Refresh tools", refreshButton.getToolTipText(),
+                        "tooltip should be restored once the refresh completes"),
+                () -> assertNull(getField(tools, "currentInvocation"), "completion must clear the in-flight guard"),
+                () -> assertTrue(refreshButton.isEnabled()));
+
+        setField(tools, "currentInvocation", new ShaftMcpInvocation(new CompletableFuture<>(), () -> {
+        }));
+        refreshButton.setToolTipText("Refreshing...");
+
+        showCatalogResult(tools, ShaftMcpToolResult.failure("MCP server process exited."));
+
+        assertAll(
+                () -> assertTrue(statusText(tools).contains(ShaftStatusPresentation.ERROR_ICON),
+                        "error completion should surface the shared ERROR_ICON glyph: " + statusText(tools)),
+                () -> assertTrue(statusText(tools).contains("Failed")),
+                () -> assertEquals("Refresh tools", refreshButton.getToolTipText()),
+                () -> assertNull(getField(tools, "currentInvocation")));
     }
 
     @Test
@@ -2468,6 +2543,45 @@ class ShaftPanelSetupTest {
                 "showResult", ShaftMcpToolResult.class, Throwable.class);
         showResult.setAccessible(true);
         showResult.invoke(panel, result, null);
+    }
+
+    private static void showCatalogResult(ShaftFeaturePanel panel, ShaftMcpToolResult result) throws Exception {
+        Method showCatalogResult = ShaftFeaturePanel.class.getDeclaredMethod(
+                "showCatalogResult", ShaftMcpToolResult.class, Throwable.class);
+        showCatalogResult.setAccessible(true);
+        showCatalogResult.invoke(panel, result, null);
+    }
+
+    private static void invokeRefreshCatalog(ShaftFeaturePanel panel, Project project) throws Exception {
+        Method refreshCatalog = ShaftFeaturePanel.class.getDeclaredMethod("refreshCatalog", Project.class);
+        refreshCatalog.setAccessible(true);
+        try {
+            refreshCatalog.invoke(panel, project);
+        } catch (java.lang.reflect.InvocationTargetException wrapped) {
+            Throwable cause = wrapped.getCause();
+            if (cause instanceof Exception exception) {
+                throw exception;
+            }
+            if (cause instanceof Error error) {
+                throw error;
+            }
+            throw wrapped;
+        }
+    }
+
+    private static String statusText(ShaftFeaturePanel panel) throws Exception {
+        return (String) ((JLabel) getField(panel, "status")).getText();
+    }
+
+    private static String mcpToolsList() {
+        JsonObject tool = new JsonObject();
+        tool.addProperty("name", "browser_navigate");
+        tool.addProperty("description", "Navigate the browser");
+        JsonArray tools = new JsonArray();
+        tools.add(tool);
+        JsonObject result = new JsonObject();
+        result.add("tools", tools);
+        return result.toString();
     }
 
     private static void showTestResult(ShaftMcpSetupPanel panel, ShaftMcpToolResult result) throws Exception {


### PR DESCRIPTION
## Summary

- `ShaftFeaturePanel.refreshCatalog()` (Advanced tab "Refresh tools") and `ShaftSettingsConfigurable.testMcpConnection()` (Settings "Test MCP") now guard re-entry while a request is in flight, swap the button's tooltip to a busy label ("Refreshing.../Testing...") without changing its accessible name, and report the outcome on completion through the existing `showCatalogResult()`/`showProbeResult()` paths using the shared `ShaftStatusPresentation.SUCCESS_ICON`/`ERROR_ICON` glyphs.
- Fixed a latent bug this change surfaced: on a successful catalog refresh, reloading tool categories re-validates the arguments editor, which reset the status label back to "Ready" immediately after the SUCCESS_ICON message was set. The completion glyph is now written after that reload so it isn't clobbered.
- `shaft-intellij/build.gradle.kts`: the `test` task now runs with `-Djava.awt.headless=true` so an accidental real dialog attempt fails deterministically in CI instead of hanging.

This addresses one item from #3302. It was rejected by QA three times across two prior implementation passes, always because the new regression test for the MCP error-glyph path wrote the expected string directly into the label and asserted against its own string (a tautology) instead of invoking the real completion method. This pass fixes that specifically:

- `ShaftSettingsConfigurableTest` reflectively invokes the real, private `showProbeResult(JPanel, JLabel, ShaftMcpToolResult)` for both the success and error paths (mirroring the existing reflective-invocation pattern already used for `showResult`/`showTestResult` in `ShaftPanelSetupTest`), and asserts on the label text the method itself wrote.
- The error path also drives the real `Messages.showErrorDialog(...)` call. This test suite has no `TestDialogManager`/stub seam for IntelliJ `Messages` dialogs (confirmed no existing precedent anywhere in this module), so the test asserts on the resulting IntelliJ EDT-threading exception (`Messages`/`DialogWrapper` enforce EDT-only construction) and confirms the `ERROR_ICON` glyph was already applied to the label *before* that call - proving the real method executed, not a hand-written stand-in.
- `ShaftPanelSetupTest` adds equivalent coverage for `ShaftFeaturePanel`: reflectively invoking the real `refreshCatalog(Project)` (re-entry guard) and `showCatalogResult(ShaftMcpToolResult, Throwable)` (completion glyphs), asserting on real button/tooltip/field state rather than self-written strings.

## Test plan

- [x] `gradle compileJava compileTestJava` - compiles cleanly.
- [x] `gradle test --tests "com.shaft.intellij.ui.ShaftPanelSetupTest" --tests "com.shaft.intellij.settings.ShaftSettingsConfigurableTest"` - all pass, run repeatedly (including `--rerun`) for stability.
- [x] `gradle test` (full `shaft-intellij` module) - all pass.

**Note: this PR was produced by an automated pipeline and needs human review before merge.**