### PR TITLE
Fix cross-origin recorder panel state loss

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/collector/BidiBrowserEventCollector.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/collector/BidiBrowserEventCollector.java
@@ -19,6 +19,8 @@ public final class BidiBrowserEventCollector implements BrowserEventCollector {
 
     private final WebDriver driver;
     private final List<String> testIdAttributes;
+    private final String eventEndpoint;
+    private final String eventToken;
     private final Map<String, String> promptTypes = new ConcurrentHashMap<>();
     private Script script;
     private BrowsingContextInspector contexts;
@@ -40,11 +42,31 @@ public final class BidiBrowserEventCollector implements BrowserEventCollector {
      * @param testIdAttributes locator test-id attributes
      */
     public BidiBrowserEventCollector(WebDriver driver, List<String> testIdAttributes) {
+        this(driver, testIdAttributes, "", "");
+    }
+
+    /**
+     * Creates a BiDi collector whose preload script also carries the loopback event sink,
+     * so the in-page recorder can rehydrate its panel state after a cross-origin navigation
+     * re-installs it on a fresh, storage-isolated document.
+     *
+     * @param driver BiDi-capable driver
+     * @param testIdAttributes locator test-id attributes
+     * @param eventEndpoint loopback event endpoint
+     * @param eventToken loopback event token
+     */
+    public BidiBrowserEventCollector(
+            WebDriver driver,
+            List<String> testIdAttributes,
+            String eventEndpoint,
+            String eventToken) {
         if (driver == null) {
             throw new IllegalArgumentException("Capture WebDriver is required.");
         }
         this.driver = driver;
         this.testIdAttributes = testIdAttributes == null ? List.of() : List.copyOf(testIdAttributes);
+        this.eventEndpoint = eventEndpoint == null ? "" : eventEndpoint;
+        this.eventToken = eventToken == null ? "" : eventToken;
     }
 
     @Override
@@ -66,7 +88,7 @@ public final class BidiBrowserEventCollector implements BrowserEventCollector {
             }
         });
         preloadId = script.addPreloadScript(
-                BrowserEventScript.preloadFunction(testIdAttributes),
+                BrowserEventScript.preloadFunction(testIdAttributes, eventEndpoint, eventToken),
                 List.of(new ChannelValue(CHANNEL)));
 
         contexts = new BrowsingContextInspector(driver);

--- a/shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventScript.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventScript.java
@@ -38,6 +38,28 @@ public final class BrowserEventScript {
     }
 
     /**
+     * Returns the BiDi preload function declaration with a loopback event sink so the
+     * in-page recorder can rehydrate its panel state after a cross-origin navigation,
+     * where BiDi re-installs this script on a fresh, storage-isolated document.
+     *
+     * @param testIdAttributes locator test-id attributes
+     * @param eventEndpoint loopback event endpoint
+     * @param eventToken loopback event token
+     * @return JavaScript function
+     */
+    public static String preloadFunction(
+            List<String> testIdAttributes,
+            String eventEndpoint,
+            String eventToken) {
+        if (eventEndpoint == null || eventEndpoint.isBlank()
+                || eventToken == null || eventToken.isBlank()) {
+            return preloadFunction(testIdAttributes);
+        }
+        return "(channel) => (" + script(testIdAttributes) + ")(channel, {url: "
+                + jsString(eventEndpoint) + ", token: " + jsString(eventToken) + "})";
+    }
+
+    /**
      * Returns JavaScript that installs the fallback queue listener.
      *
      * @return installation JavaScript

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/BrowserEventSink.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/BrowserEventSink.java
@@ -11,20 +11,27 @@ import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Base64;
+import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Loopback sink used by the WebDriver fallback listener before navigation can clear page memory.
+ * Also answers a token-authenticated GET with the current session snapshot, so the in-page
+ * recorder can rehydrate its panel state after a cross-origin navigation resets page-scoped
+ * storage.
  */
 final class BrowserEventSink implements AutoCloseable {
     private static final int MAX_REQUEST_BYTES = 131_072;
 
     private final Consumer<BrowserSignal> signalConsumer;
     private final Consumer<String> warningConsumer;
+    private final Supplier<Map<String, Object>> stateSupplier;
     private final ObjectMapper mapper = JsonMapper.builder().build();
     private final String token = token();
     private final HttpServer server;
@@ -32,12 +39,14 @@ final class BrowserEventSink implements AutoCloseable {
 
     BrowserEventSink(
             Consumer<BrowserSignal> signalConsumer,
-            Consumer<String> warningConsumer) {
-        if (signalConsumer == null || warningConsumer == null) {
+            Consumer<String> warningConsumer,
+            Supplier<Map<String, Object>> stateSupplier) {
+        if (signalConsumer == null || warningConsumer == null || stateSupplier == null) {
             throw new IllegalArgumentException("Browser event sink consumers are required.");
         }
         this.signalConsumer = signalConsumer;
         this.warningConsumer = warningConsumer;
+        this.stateSupplier = stateSupplier;
         try {
             server = HttpServer.create(new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0), 0);
         } catch (IOException exception) {
@@ -68,6 +77,10 @@ final class BrowserEventSink implements AutoCloseable {
     private void handle(HttpExchange exchange) throws IOException {
         try (exchange) {
             exchange.getResponseHeaders().set("Access-Control-Allow-Origin", "*");
+            if ("GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+                handleState(exchange);
+                return;
+            }
             if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
                 send(exchange, 405);
                 return;
@@ -80,6 +93,31 @@ final class BrowserEventSink implements AutoCloseable {
             accept(body);
             send(exchange, 204);
         }
+    }
+
+    private void handleState(HttpExchange exchange) throws IOException {
+        if (!authorized(queryParameter(exchange.getRequestURI().getRawQuery(), "token"))) {
+            send(exchange, 403);
+            return;
+        }
+        byte[] body = mapper.writeValueAsBytes(stateSupplier.get());
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, body.length);
+        exchange.getResponseBody().write(body);
+    }
+
+    private static String queryParameter(String rawQuery, String name) {
+        if (rawQuery == null || rawQuery.isBlank()) {
+            return "";
+        }
+        for (String pair : rawQuery.split("&")) {
+            int separator = pair.indexOf('=');
+            String key = separator < 0 ? pair : pair.substring(0, separator);
+            if (name.equals(URLDecoder.decode(key, StandardCharsets.UTF_8))) {
+                return separator < 0 ? "" : URLDecoder.decode(pair.substring(separator + 1), StandardCharsets.UTF_8);
+            }
+        }
+        return "";
     }
 
     private void accept(byte[] body) {

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java
@@ -567,7 +567,11 @@ class ManagedCaptureRecorder {
     private void startCollector(WebDriver activeDriver) {
         try {
             collector = new CompositeBrowserEventCollector(List.of(
-                    new BidiBrowserEventCollector(activeDriver, request.options().testIdAttributes()),
+                    new BidiBrowserEventCollector(
+                            activeDriver,
+                            request.options().testIdAttributes(),
+                            eventSinkEndpoint(),
+                            eventSinkToken()),
                     new PollingBrowserEventCollector(
                             activeDriver,
                             false,
@@ -592,7 +596,7 @@ class ManagedCaptureRecorder {
 
     private void startEventSink() {
         try {
-            eventSink = new BrowserEventSink(this::acceptSignal, this::warn);
+            eventSink = new BrowserEventSink(this::acceptSignal, this::warn, this::sessionSnapshot);
             eventSink.start();
         } catch (RuntimeException exception) {
             eventSink = null;
@@ -606,6 +610,19 @@ class ManagedCaptureRecorder {
 
     private String eventSinkToken() {
         return eventSink == null ? "" : eventSink.eventToken();
+    }
+
+    /**
+     * Server-authoritative continuation state for the in-page recorder panel, so it can
+     * rehydrate after a cross-origin navigation clears its page-scoped storage instead of
+     * appearing to have silently restarted.
+     */
+    synchronized Map<String, Object> sessionSnapshot() {
+        Map<String, Object> snapshot = new LinkedHashMap<>();
+        snapshot.put("instanceId", sessionId);
+        snapshot.put("eventCount", pipeline == null ? 0 : pipeline.eventCount());
+        snapshot.put("readinessState", readiness().state().name());
+        return snapshot;
     }
 
     void acceptSignal(BrowserSignal signal) {

--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -1705,10 +1705,39 @@
   addEventListener("pagehide", persist, true);
   addEventListener("beforeunload", persist, true);
 
+  // A fresh top-level document (e.g. after a cross-origin navigation) always starts with
+  // empty page-scoped sessionStorage, even mid-recording. Before announcing a brand-new
+  // session, ask the loopback sink -- which is not origin-scoped -- whether this browser
+  // is already mid-recording, so the panel continues instead of appearing to have reset.
+  const announceStart = () => {
+    if (!eventSink.url || !eventSink.token || typeof fetch !== "function") {
+      announce("Open " + visibleLocation());
+      return;
+    }
+    fetch(String(eventSink.url) + "?token=" + encodeURIComponent(String(eventSink.token)))
+      .then(response => response.ok ? response.json() : null)
+      .then(state => {
+        const eventCount = state ? Number(state.eventCount) : 0;
+        if (!eventCount) {
+          announce("Open " + visibleLocation());
+          return;
+        }
+        uiState.instanceId = text(state.instanceId) || uiState.instanceId;
+        uiState.nextId = Math.max(uiState.nextId, eventCount + 1);
+        if (["READY", "RISKY", "BLOCKED"].includes(state.readinessState)) {
+          uiState.readinessState = state.readinessState;
+        }
+        persist();
+        announce("Continuing recording after navigating to a new domain ("
+          + eventCount + " action" + (eventCount === 1 ? "" : "s") + " already captured)");
+      })
+      .catch(() => announce("Open " + visibleLocation()));
+  };
+
   if (topLevel) {
     schedulePanel();
     if (uiState.actions.length === 0) {
-      announce("Open " + visibleLocation());
+      announceStart();
     }
     setInterval(() => {
       const current = String(location.href || "");

--- a/shaft-capture/src/test/java/com/shaft/capture/collector/CaptureCollectorUtilityTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/collector/CaptureCollectorUtilityTest.java
@@ -68,6 +68,15 @@ class CaptureCollectorUtilityTest {
                 .contains("const testIdAttributes = [\"data-pw\"];"));
         assertTrue(BrowserEventScript.fallbackInstallation(List.of("data-\"quoted\\path"))
                 .contains("\"data-\\\"quoted\\\\path\""));
+        String bidiPreloadWithSink = BrowserEventScript.preloadFunction(
+                List.of("data-pw"), "http://127.0.0.1:1234/event", "token");
+        assertTrue(bidiPreloadWithSink.startsWith("(channel) => ("));
+        assertTrue(bidiPreloadWithSink.contains("http://127.0.0.1:1234/event"));
+        assertTrue(bidiPreloadWithSink.contains("{url: \"http://127.0.0.1:1234/event\", token: \"token\"}"));
+        assertEquals(BrowserEventScript.preloadFunction(List.of("data-pw")),
+                BrowserEventScript.preloadFunction(List.of("data-pw"), "", ""));
+        assertEquals(BrowserEventScript.preloadFunction(List.of("data-pw")),
+                BrowserEventScript.preloadFunction(List.of("data-pw"), null, null));
         assertTrue(preload.contains("SHAFT Capture"));
         assertTrue(preload.contains("kind: \"control\""));
         assertTrue(preload.contains("kind: \"verification\""));
@@ -120,6 +129,8 @@ class CaptureCollectorUtilityTest {
                 () -> new PollingBrowserEventCollector(null, true, List.of("data-pw")));
         assertInstanceOf(BidiBrowserEventCollector.class,
                 new BidiBrowserEventCollector(driver, List.of("data-pw")));
+        assertInstanceOf(BidiBrowserEventCollector.class,
+                new BidiBrowserEventCollector(driver, List.of("data-pw"), "http://127.0.0.1:1234/event", "token"));
         assertInstanceOf(PollingBrowserEventCollector.class,
                 new PollingBrowserEventCollector(driver, false, List.of("data-pw")));
     }

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/BrowserEventSinkTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/BrowserEventSinkTest.java
@@ -1,0 +1,77 @@
+package com.shaft.capture.runtime;
+
+import com.shaft.capture.collector.BrowserSignal;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BrowserEventSinkTest {
+    @Test
+    void authorizedGetReturnsSuppliedStateWhileUnauthorizedGetIsRejectedAndPostStillWorks() throws Exception {
+        List<BrowserSignal> received = new CopyOnWriteArrayList<>();
+        List<String> warnings = new CopyOnWriteArrayList<>();
+        BrowserEventSink sink = new BrowserEventSink(
+                received::add,
+                warnings::add,
+                () -> Map.of("instanceId", "session-42", "eventCount", 7, "readinessState", "RISKY"));
+        String endpoint = sink.start();
+        String token = sink.eventToken();
+
+        try {
+            HttpClient http = HttpClient.newHttpClient();
+
+            HttpResponse<String> missingToken = http.send(HttpRequest.newBuilder()
+                    .uri(URI.create(endpoint))
+                    .GET()
+                    .build(), HttpResponse.BodyHandlers.ofString());
+            HttpResponse<String> wrongToken = http.send(HttpRequest.newBuilder()
+                    .uri(URI.create(endpoint + "?token=wrong"))
+                    .GET()
+                    .build(), HttpResponse.BodyHandlers.ofString());
+            HttpResponse<String> authorized = http.send(HttpRequest.newBuilder()
+                    .uri(URI.create(endpoint + "?token=" + token))
+                    .GET()
+                    .build(), HttpResponse.BodyHandlers.ofString());
+
+            assertEquals(403, missingToken.statusCode());
+            assertEquals(403, wrongToken.statusCode());
+            assertEquals(200, authorized.statusCode());
+            assertEquals("*", authorized.headers().firstValue("Access-Control-Allow-Origin").orElse(""));
+            assertTrue(authorized.body().contains("\"instanceId\":\"session-42\""));
+            assertTrue(authorized.body().contains("\"eventCount\":7"));
+            assertTrue(authorized.body().contains("\"readinessState\":\"RISKY\""));
+
+            HttpResponse<String> posted = http.send(HttpRequest.newBuilder()
+                    .uri(URI.create(endpoint))
+                    .POST(HttpRequest.BodyPublishers.ofString(
+                            "{\"token\":\"" + token + "\",\"payload\":{\"kind\":\"click\"}}"))
+                    .build(), HttpResponse.BodyHandlers.ofString());
+
+            assertEquals(204, posted.statusCode());
+            assertEquals(1, received.size());
+            assertEquals("click", received.getFirst().kind());
+        } finally {
+            sink.close();
+        }
+    }
+
+    @Test
+    void constructorRejectsMissingCollaborators() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new BrowserEventSink(null, ignored -> { }, Map::of));
+        assertThrows(IllegalArgumentException.class,
+                () -> new BrowserEventSink(ignored -> { }, null, Map::of));
+        assertThrows(IllegalArgumentException.class,
+                () -> new BrowserEventSink(ignored -> { }, ignored -> { }, null));
+    }
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/BrowserEventSinkTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/BrowserEventSinkTest.java
@@ -60,6 +60,7 @@ class BrowserEventSinkTest {
             assertEquals(204, posted.statusCode());
             assertEquals(1, received.size());
             assertEquals("click", received.getFirst().kind());
+            assertTrue(warnings.isEmpty());
         } finally {
             sink.close();
         }

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderControlTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderControlTest.java
@@ -74,6 +74,40 @@ class ManagedCaptureRecorderControlTest {
     }
 
     @Test
+    void sessionSnapshotReflectsEventCountAndReadinessWithAStableInstanceIdForRehydration() throws Exception {
+        CaptureStartRequest request = request(CaptureBrowser.CHROME, CaptureStartOptions.defaults());
+        ManagedCaptureRecorder recorder = new ManagedCaptureRecorder(request);
+        CaptureSessionStore store = new CaptureSessionStore(request.outputPath());
+        store.start(CaptureSession.start(
+                "snapshot-session",
+                Instant.parse("2026-01-02T03:04:05Z"),
+                new BrowserMetadata("chrome", "149", "test", "browser", Map.of())));
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store,
+                request.outputPath(),
+                CapturePrivacyPolicy.defaults(),
+                ignored -> { },
+                ignored -> { });
+        recorder.activeSessionForTesting(store, pipeline);
+
+        Map<String, Object> beforeAnyEvents = recorder.sessionSnapshot();
+        assertEquals(0, beforeAnyEvents.get("eventCount"));
+        assertEquals("READY", beforeAnyEvents.get("readinessState"));
+        Object instanceId = beforeAnyEvents.get("instanceId");
+        assertNotNull(instanceId);
+
+        recorder.acceptSignal(BrowserSignal.generated(
+                "navigation",
+                "window-1",
+                Map.of("url", "https://example.test/checkout", "title", "Checkout"),
+                Map.of("action", "OPEN")));
+
+        Map<String, Object> afterCrossOriginNavigation = recorder.sessionSnapshot();
+        assertEquals(1, afterCrossOriginNavigation.get("eventCount"));
+        assertEquals(instanceId, afterCrossOriginNavigation.get("instanceId"));
+    }
+
+    @Test
     void browserOptionsCarryCodegenSessionMetadataWithoutLaunchingBrowser() throws Exception {
         CaptureStartOptions options = new CaptureStartOptions(
                 "java",

--- a/shaft-mcp/src/test/java/com/shaft/mcp/McpMobileToolchainServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/McpMobileToolchainServiceTest.java
@@ -148,7 +148,7 @@ class McpMobileToolchainServiceTest {
     }
 
     @Test
-    void toolchainStatusReturnsNormalResultWhenPropertiesInitialized() {
+    void toolchainStatusReturnsNormalResultWhenPropertiesInitialized() throws Exception {
         Path toolRoot = Files.createDirectories(temp.resolve("tools"));
         Path sdk = Files.createDirectories(temp.resolve("android-sdk"));
         Path avdHome = Files.createDirectories(temp.resolve("avd-home"));


### PR DESCRIPTION
## Summary

Closes #3319. That issue's own body was corrupted by a bug in the batch issue-creation tooling used earlier today — its body is a verbatim duplicate of unrelated issue #3322's content, also duplicated onto #3320/#3321. I worked from the title alone plus direct investigation of the actual "SHAFT Capture" recorder session-lifecycle code.

Investigation findings against the three concerns named in the title:
- **Real-time JSON persistence** — already correct. `CaptureSessionStore.update()` does an atomic read-modify-write on every event; no buffering risk.
- **Browser shutdown** — already correct. `ManagedCaptureRecorder`'s 1-second health check detects browser death and marks the session `INCOMPLETE` with a timestamp; nothing is lost.
- **Cross-domain continuity** — real, reproducible bug, fixed here: the in-page recorder overlay persisted its panel state (action list, next id, readiness, instanceId) to `sessionStorage`, which browsers clear on cross-origin navigation. A multi-domain recording (e.g. login -> payment gateway) made the panel look like it had silently restarted, even though the server-side session JSON never lost anything.

## Fix

- `BrowserEventSink` now answers a token-authenticated `GET` on its existing loopback `/event` endpoint with the live session snapshot (`instanceId`, `eventCount`, `readinessState`), sourced from `ManagedCaptureRecorder.sessionSnapshot()`.
- `BidiBrowserEventCollector`'s preload script — which normally wins the reinstall race over the polling fallback collector on a fresh document, and previously never received the event sink at all — now carries the same `{url, token}` sink object (embedded as a literal in the preload source, no new Selenium BiDi API surface used), so the in-page script can always reach the sink regardless of which collector installs first.
- `shaft-capture-recorder.js`: on a fresh top-level document with no locally-persisted state, the recorder asks the sink whether a session is already in progress. If so, it keeps the stable `instanceId`, continues action numbering from the server's event count, adopts the current readiness state, and announces "Continuing recording after navigating to a new domain (N action(s) already captured)" instead of silently looking like a new recording.

## Test plan

- [x] `BrowserEventScriptTest`-style additions in `CaptureCollectorUtilityTest`: new `preloadFunction(attrs, endpoint, token)` overload embeds the sink correctly and falls back to the plain preload when blank/null.
- [x] New `BrowserEventSinkTest`: authorized GET returns the supplied snapshot JSON with CORS header; missing/wrong token gets 403; existing POST behavior unchanged.
- [x] `ManagedCaptureRecorderControlTest`: new test asserts `sessionSnapshot()` reflects event count/readiness and keeps a stable `instanceId` across signals, without launching a browser.
- [x] `mvn -pl shaft-capture test-compile` and targeted `mvn -pl shaft-capture test -Dtest=BrowserEventSinkTest,CaptureCollectorUtilityTest,ManagedCaptureRecorderControlTest` — 10/10 passing.

No live-browser cross-origin E2E was run (requires the `external-e2e`-tagged infra per repo convention); the fix is covered at the unit level on both the Java state/auth logic and the JS embedding logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)