### PR TITLE
Fix release-candidate build blocker and shaft-mcp static-cache init gap

### DIFF
--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -463,7 +463,7 @@ class CaptureGeneratorTest {
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains(
                 "driver.element().assertThat(SHAFT.GUI.Locator.inputField(\"Username\")).attribute(\"autocomplete\")"
-                        + ".isEqualTo(requiredData(\"username\")).perform();"));
+                        + ".isEqualTo(requiredData(\"username\"));"));
     }
 
     @Test

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileToolchainService.java
@@ -61,7 +61,6 @@ final class McpMobileToolchainService {
     McpMobileToolchainService() {
         this(McpProcessRunner.system(), System.getenv(), McpRuntimePaths.applicationDataRoot().resolve("tools"),
                 System.getProperty("os.name", ""), System.getProperty("os.arch", ""));
-        ensurePropertiesInitialized();
     }
 
     McpMobileToolchainService(
@@ -70,6 +69,7 @@ final class McpMobileToolchainService {
             Path toolRoot,
             String osName,
             String osArch) {
+        ensurePropertiesInitialized();
         this.runner = runner;
         this.environment = environment == null ? Map.of() : Map.copyOf(environment);
         this.toolRoot = toolRoot.toAbsolutePath().normalize();


### PR DESCRIPTION
## Summary
- Fix `CaptureGeneratorTest.recordedElementAssertionWithChosenLocatorAndTestDataGeneratesMatchingValidationsCall`, which was blocking the `release-candidate` CI check on #3344. #3329 removed `.perform()` from `CaptureGenerator.nativeAssertion()`'s output for this assertion family, but the test (added by #3331 the same day) still expected the stale `.perform()` suffix — a rebase oversight, not a production bug. Adjacent tests in the same file already confirm the no-`.perform()` convention.
- Fixes #3343: `McpMobileToolchainService`'s static property cache was only populated by the no-arg constructor; the 5-arg constructor used by every test (and by DI) never called `ensurePropertiesInitialized()`, so `nodeLtsVersion()`/`androidEmulatorDeviceProfile()`/etc. returned `null`/`0`. Moved the init call into the 5-arg constructor so every construction path populates the cache.

## Note for release
This fix lands on `main`. PR #3344's `release-candidate` check runs on branch `release/10.3.20260706`, so that branch will need a rebase/merge from `main` after this PR merges before its RC job goes green.

## Testing
- `mvn -pl shaft-capture -am test -Dtest=CaptureGeneratorTest` → 20/20 passed
- `mvn -pl shaft-mcp -am test -Dtest=McpMobileToolchainServiceTest` → 7/7 passed (previously 2 failing)
- `mvn -pl shaft-capture,shaft-mcp -am test-compile` → clean

Closes #3343