### PR TITLE
Fix saved Workflow scripts to use top-level args instead of exported run()

### DIFF
--- a/.claude/workflows/shaft-bug-fix.js
+++ b/.claude/workflows/shaft-bug-fix.js
@@ -211,23 +211,26 @@ async function ownTask(task) {
   return { task: task.id, escalated: true, escalation, runLog };
 }
 
-export default async function run({ issue }) {
-  const plan = await withFallback("plan", PLAN_CHAIN, planPrompt(issue), {
-    effort: "high",
-    schema: PLAN_SCHEMA,
-  });
+// Workflow scripts run as top-level async code against the `args`
+// global, not as an exported function -- an `export default` here is a
+// syntax error under the runtime's non-module script evaluation.
+const { issue } = args;
 
-  // Single-task plans skip the orchestrator: routing one task is pure
-  // overhead.
-  const tasks =
-    plan.tasks.length > 1
-      ? (
-          await withFallback("orchestrate", ORCH_CHAIN, orchestratePrompt(plan), {
-            schema: TASKS_SCHEMA,
-          })
-        ).tasks
-      : plan.tasks;
+const plan = await withFallback("plan", PLAN_CHAIN, planPrompt(issue), {
+  effort: "high",
+  schema: PLAN_SCHEMA,
+});
 
-  const results = await pipeline(tasks, ownTask);
-  return { plan: plan.summary, results, runLog };
-}
+// Single-task plans skip the orchestrator: routing one task is pure
+// overhead.
+const tasks =
+  plan.tasks.length > 1
+    ? (
+        await withFallback("orchestrate", ORCH_CHAIN, orchestratePrompt(plan), {
+          schema: TASKS_SCHEMA,
+        })
+      ).tasks
+    : plan.tasks;
+
+const results = await pipeline(tasks, ownTask);
+return { plan: plan.summary, results, runLog };

--- a/.claude/workflows/shaft-bug-fix.js
+++ b/.claude/workflows/shaft-bug-fix.js
@@ -214,7 +214,13 @@ async function ownTask(task) {
 // Workflow scripts run as top-level async code against the `args`
 // global, not as an exported function -- an `export default` here is a
 // syntax error under the runtime's non-module script evaluation.
-const { issue } = args;
+//
+// The runtime hands `args` through as a JSON-encoded string even when
+// the caller passes a real object/array -- parse it back or every field
+// silently reads as undefined (array/object property lookups on a
+// string return undefined instead of throwing, so this fails silently).
+const parsedArgs = typeof args === "string" ? JSON.parse(args) : args;
+const { issue } = parsedArgs;
 
 const plan = await withFallback("plan", PLAN_CHAIN, planPrompt(issue), {
   effort: "high",

--- a/.claude/workflows/shaft-release-ci-fix.js
+++ b/.claude/workflows/shaft-release-ci-fix.js
@@ -212,9 +212,15 @@ async function ownFix(fix) {
 // global, not as an exported function -- an `export default` here is a
 // syntax error under the runtime's non-module script evaluation.
 //
+// The runtime hands `args` through as a JSON-encoded string even when
+// the caller passes a real object/array -- parse it back or every field
+// silently reads as undefined (array/object property lookups on a
+// string return undefined instead of throwing, so this fails silently).
+//
 // args.failingJobs: [{ name, runUrl }] -- e.g. from
 // `gh run view <id> --json jobs`.
-const { failingJobs } = args;
+const parsedArgs = typeof args === "string" ? JSON.parse(args) : args;
+const { failingJobs } = parsedArgs;
 
 const verdicts = await parallel(
   failingJobs.map((job) => () =>

--- a/.claude/workflows/shaft-release-ci-fix.js
+++ b/.claude/workflows/shaft-release-ci-fix.js
@@ -208,23 +208,27 @@ async function ownFix(fix) {
   return { fix: fix.id, escalated: true, escalation, runLog };
 }
 
-// failingJobs: [{ name, runUrl }] -- e.g. from
+// Workflow scripts run as top-level async code against the `args`
+// global, not as an exported function -- an `export default` here is a
+// syntax error under the runtime's non-module script evaluation.
+//
+// args.failingJobs: [{ name, runUrl }] -- e.g. from
 // `gh run view <id> --json jobs`.
-export default async function run({ failingJobs }) {
-  const verdicts = await parallel(
-    failingJobs.map((job) => () =>
-      agent(triagePrompt(job), { model: "haiku", schema: TRIAGE_VERDICT })
-    )
-  );
-  runLog.push({ phase: "triage", model: "haiku", jobs: failingJobs.length });
+const { failingJobs } = args;
 
-  const plan = await withFallback("synthesize", SYNTH_CHAIN, synthesisPrompt(verdicts), {
-    effort: "high",
-    schema: FIX_PLAN_SCHEMA,
-  });
+const verdicts = await parallel(
+  failingJobs.map((job) => () =>
+    agent(triagePrompt(job), { model: "haiku", schema: TRIAGE_VERDICT })
+  )
+);
+runLog.push({ phase: "triage", model: "haiku", jobs: failingJobs.length });
 
-  const results = await pipeline(plan.fixes, ownFix);
+const plan = await withFallback("synthesize", SYNTH_CHAIN, synthesisPrompt(verdicts), {
+  effort: "high",
+  schema: FIX_PLAN_SCHEMA,
+});
 
-  // Terminate here. Rerun-watching is /loop / Monitor territory.
-  return { rootCauses: plan.rootCauses, results, runLog };
-}
+const results = await pipeline(plan.fixes, ownFix);
+
+// Terminate here. Rerun-watching is /loop / Monitor territory.
+return { rootCauses: plan.rootCauses, results, runLog };

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 scripts/mcp/*.sh text eol=lf
+.claude/workflows/*.js text eol=lf


### PR DESCRIPTION
## Summary
- Both `.claude/workflows/shaft-bug-fix.js` and `.claude/workflows/shaft-release-ci-fix.js` ended with `export default async function run(...)`. The Workflow tool actually executes scripts as top-level async code against an `args` global (per its own documented pattern), so the trailing `export default` is a syntax error (`Unexpected keyword 'export'`) that made both saved workflows unusable.
- Rewrote both to destructure `args` at the top level and removed the function wrapper, matching the documented top-level-`return` pattern.
- Added `.claude/workflows/*.js text eol=lf` to `.gitattributes` and renormalized both files, since CRLF line endings on these files also tripped the Workflow tool's permission-dialog control-character check when invoked via `scriptPath`.
- **Second, worse bug found after the first fix**: even with the syntax error gone, both workflows silently no-op'd on every real invocation. Confirmed via a throwaway diagnostic script that the Workflow tool hands `args` through as a `JSON.stringify`'d **string**, even when the caller passes a real object or array. `const { issue } = args` on a string doesn't throw — property lookups on a string just return `undefined` — so `issue` silently became `undefined`, and the prompt-builder's `Array.join` turned that into an empty string with zero visible error. Both scripts now guard with `typeof args === "string" ? JSON.parse(args) : args` before destructuring.

Found while starting the shaft-bug-fix pipeline for issue #3346 P1 — this was a hard blocker (the workflow looked like it ran successfully and produced a plausible "no defect found" plan, when in fact it never saw the real issue text at all), not scope creep, so fixing it stood on its own as prerequisite infrastructure before any of the 6 Playwright-parity tickets could run.

## Test plan
- [x] `node --check` on both files passes (no dangling syntax).
- [x] Diagnostic script confirmed `args` arrives as a JSON string for both object and raw-string payloads, and that `JSON.parse(args)` recovers the intended value.
- [x] Re-ran the shaft-bug-fix Workflow with the `JSON.parse` guard in place against issue #3346 P1; the plan phase correctly received the full issue text (verified in the run's plan output) instead of the earlier blank-issue no-op.