### PR TITLE
Fix custom.properties mis-copy from bundled jar in external installs

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
@@ -339,15 +339,19 @@ public class PropertiesHelper {
                 .forEach(file -> {
                     if (!fileActions.doesFileExist(targetPropertiesFolderPath + file)) {
                         if (isExternalRun) {
-                            var tempPath = propertiesFolderPath.replace("/default", "");
                             try {
-                                if (tempPath.contains("file:")) {
-                                    fileActions.copyFileFromJar(tempPath, targetPropertiesFolderPath, file.replace("/", ""));
+                                if (propertiesFolderPath.contains("file:")) {
+                                    // propertiesFolderPath already points inside the bundled "default"
+                                    // jar entry, which is where the template file actually lives --
+                                    // stripping "/default" here breaks the entry-name match in
+                                    // copyFileFromJar and silently mis-copies to a nested
+                                    // "default/<file>" destination instead of the intended target path.
+                                    fileActions.copyFileFromJar(propertiesFolderPath, targetPropertiesFolderPath, file.replace("/", ""));
                                 } else {
                                     throw new IOException("Properties folder path does not contain 'file:' protocol, indicating it is not running from a jar file.");
                                 }
                             } catch (Throwable ignored) {
-                                fileActions.copyFile(tempPath + file, targetPropertiesFolderPath + file);
+                                downloadPropertiesFile(targetPropertiesFolderPath, file.replace("/", ""));
                             }
                         } else {
                             fileActions.copyFile(PropertyFileManager.resolveCustomPropertiesTemplatePath(),
@@ -359,9 +363,13 @@ public class PropertiesHelper {
     }
 
     private static void downloadPropertiesFile(String fileName) {
+        downloadPropertiesFile(Properties.paths.properties(), fileName);
+    }
+
+    private static void downloadPropertiesFile(String targetFolderPath, String fileName) {
         var baseURI = "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/refs/heads/main/shaft-engine/src/main/resources/properties/default/";
         FileActions.getInstance(true).downloadFile(baseURI + fileName,
-                Properties.paths.properties() + File.separator + fileName);
+                targetFolderPath + File.separator + fileName);
     }
 
     private static void attachPropertyFiles() {


### PR DESCRIPTION
## Summary
- `PropertiesHelper.overrideTargetProperties()` stripped `/default` from the resolved jar-resource source path before calling `copyFileFromJar`, but that path already points at the bundled `default` jar entry where `custom.properties` actually lives.
- Stripping it breaks `copyFileFromJar`'s entry-name matching, silently mis-copying the file to a nested `default/<file>` destination instead of the intended target path.
- On a second run of the same process (e.g. the public shaft-mcp installer's "run twice" verification), the file still appears missing at the expected location, the retry fires, and the broken catch-block fallback throws trying to treat a `jar:` URL as a plain filesystem path.
- This is what's currently failing the "Verify public shaft-mcp installer" jobs (all 3 platforms) in the Maven Central Continuous Delivery workflow for the already-published `10.3.20260706` artifact: `FileNotFoundException: Source 'jar:file:...!/resources/properties/custom.properties' does not exist`.

Also fixed the broken fallback: instead of attempting a filesystem copy from a `jar:` URL (which can never work), it now downloads the bundled template from GitHub raw content, matching the pattern already used elsewhere in this file (`downloadDefaultProperties`).

Per discussion, this PR only fixes the source -- it does not cut a new release. The already-published `10.3.20260706` artifact remains broken until a future version bump picks this fix up.

## Test plan
- [x] Verified end-to-end with a reflection-based repro invoking `overrideTargetProperties` against a locally built `shaft-engine` jar from a fresh external working directory: `custom.properties` now lands at the correct top-level path with no exception (previously landed nested under `default/`).
- [x] `PropertiesHelperCoverageUnitTest`, `PropertiesHelperEvidenceLevelUnitTest`, `PropertiesHelperInitializationUnitTest`, `PropertiesHelperMaximumPerformanceModeUnitTest` all pass (20/20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)