### PR TITLE
Make workflow implementer/fixer/escalator prompts commit their work

### DIFF
--- a/.claude/workflows/shaft-bug-fix.js
+++ b/.claude/workflows/shaft-bug-fix.js
@@ -74,6 +74,30 @@ const VALIDATION_RULES = [
   "static checks, or a disposable copy.",
 ].join(" ");
 
+// Each isolation:"worktree" agent call gets a FRESH, randomly-picked
+// worktree -- not the same one across implement/fix/escalate rounds for
+// the same task. Two consequences every implementer-role prompt must
+// carry: (1) your own worktree may already hold a *different* task's
+// leftover state (or be clean) -- if the files this task should have
+// touched aren't here, search sibling worktrees under
+// `.claude/worktrees/` for your own prior round's commits/diff before
+// concluding nothing was done; (2) the orchestrator can only discover
+// your work via `git log`/`git diff` on YOUR worktree, so uncommitted
+// changes are invisible and effectively lost once this call returns --
+// general "don't commit unless asked" guidance does not apply here,
+// commit is mandatory.
+const COMMIT_INSTRUCTION = [
+  "IMPORTANT: this worktree is disposable and only discoverable via git.",
+  "Before you finish, `git add` every file you touched and `git commit`",
+  "with a descriptive message -- uncommitted changes are invisible to the",
+  "orchestrator and will be lost. This overrides any general instinct to",
+  "leave changes staged/uncommitted \"unless explicitly asked\"; committing",
+  "IS how you hand off a task in this workflow. If the files this task",
+  "expects aren't in your worktree, check sibling worktrees under",
+  "`.claude/worktrees/wf_*` for a prior round's commit before assuming no",
+  "work was done.",
+].join(" ");
+
 function planPrompt(issue) {
   return [
     "You are Kevin, the PDCA planner (see .github/skills/agentic-pdca-loop/SKILL.md).",
@@ -112,6 +136,8 @@ function implementPrompt(task) {
     JSON.stringify(task, null, 2),
     "",
     "Compile-check what you changed. Report the files you touched.",
+    "",
+    COMMIT_INSTRUCTION,
   ].join("\n");
 }
 
@@ -144,6 +170,8 @@ function fixPrompt(task, gaps) {
     "",
     "Task for reference:",
     JSON.stringify(task, null, 2),
+    "",
+    COMMIT_INSTRUCTION,
   ].join("\n");
 }
 
@@ -159,6 +187,8 @@ function escalatePrompt(task, gaps) {
     "",
     "Open gaps:",
     JSON.stringify(gaps, null, 2),
+    "",
+    COMMIT_INSTRUCTION,
   ].join("\n");
 }
 

--- a/.claude/workflows/shaft-release-ci-fix.js
+++ b/.claude/workflows/shaft-release-ci-fix.js
@@ -76,6 +76,30 @@ const VALIDATION_RULES = [
   "static checks, or a disposable copy.",
 ].join(" ");
 
+// Each isolation:"worktree" agent call gets a FRESH, randomly-picked
+// worktree -- not the same one across implement/fix/escalate rounds for
+// the same fix. Two consequences every implementer-role prompt must
+// carry: (1) your own worktree may already hold different leftover
+// state (or be clean) -- if the files this fix should have touched
+// aren't here, search sibling worktrees under `.claude/worktrees/` for
+// your own prior round's commits/diff before concluding nothing was
+// done; (2) the orchestrator can only discover your work via
+// `git log`/`git diff` on YOUR worktree, so uncommitted changes are
+// invisible and effectively lost once this call returns -- general
+// "don't commit unless asked" guidance does not apply here, commit is
+// mandatory.
+const COMMIT_INSTRUCTION = [
+  "IMPORTANT: this worktree is disposable and only discoverable via git.",
+  "Before you finish, `git add` every file you touched and `git commit`",
+  "with a descriptive message -- uncommitted changes are invisible to the",
+  "orchestrator and will be lost. This overrides any general instinct to",
+  "leave changes staged/uncommitted \"unless explicitly asked\"; committing",
+  "IS how you hand off a fix in this workflow. If the files this fix",
+  "expects aren't in your worktree, check sibling worktrees under",
+  "`.claude/worktrees/wf_*` for a prior round's commit before assuming no",
+  "work was done.",
+].join(" ");
+
 function triagePrompt(job) {
   return [
     "You are a READ-ONLY CI triage agent. Do not edit files or rerun",
@@ -114,6 +138,8 @@ function implementPrompt(fix) {
     "an explicit instruction in the fix goal.",
     "",
     JSON.stringify(fix, null, 2),
+    "",
+    COMMIT_INSTRUCTION,
   ].join("\n");
 }
 
@@ -145,6 +171,8 @@ function fixGapsPrompt(fix, gaps) {
     "",
     "Fix for reference:",
     JSON.stringify(fix, null, 2),
+    "",
+    COMMIT_INSTRUCTION,
   ].join("\n");
 }
 
@@ -159,6 +187,8 @@ function escalatePrompt(fix, gaps) {
     "",
     "Open gaps:",
     JSON.stringify(gaps, null, 2),
+    "",
+    COMMIT_INSTRUCTION,
   ].join("\n");
 }
 


### PR DESCRIPTION
## Summary
- Follow-up to #3352. While integrating a real `shaft-bug-fix` run for issue #3346 P1, found that `isolation:"worktree"` agent calls land in a fresh, randomly-picked worktree each time — not the same one across a task's implement → QA → fix → escalate rounds.
- Several sub-agents, following the general "don't commit unless explicitly asked" instinct baked into their base instructions, left their final work **uncommitted** — invisible to the orchestrator (which can only discover work via `git log`/`git diff`) and at real risk of being lost once the ephemeral worktree is cleaned up. One escalation agent explicitly reasoned "I did not commit these final fixes... per repo instructions, only commit when the user explicitly asks" and left verified, working code sitting uncommitted.
- Added a shared `COMMIT_INSTRUCTION` block appended to every implement/fix/escalate prompt in both saved workflows (`shaft-bug-fix.js`, `shaft-release-ci-fix.js`), explicitly overriding that instinct for this context, and telling agents to check sibling worktrees under `.claude/worktrees/wf_*` for their own prior round's commits before concluding nothing was done (since a task's own worktree may look clean/empty purely because a previous round happened to land somewhere else).

This doesn't fix the underlying "new worktree per call" allocator behavior (that's in the harness, not these scripts), but it does make sure whichever worktree each round lands in ends up with a clean, committed, git-discoverable state — which is what let me actually reconcile the #3346 P1 run at all.

## Test plan
- [x] `node --check` on both files passes.
- [x] `python3 scripts/ci/validate_agent_setup.py` passes.