### PR TITLE
Fix IntelliJ plugin onboarding flow (#3363)

### DIFF
--- a/.github/workflows/intellij-plugin.yml
+++ b/.github/workflows/intellij-plugin.yml
@@ -6,18 +6,55 @@ on:
       - 'shaft-intellij/**'
       - '.github/workflows/intellij-plugin.yml'
       - '.github/workflows/publish-intellij-plugin.yml'
+      - 'scripts/mcp/**'
+      - 'tests/scripts/test_install_shaft_mcp.py'
+      - 'scripts/ci/verify_shaft_mcp_installer_release.py'
+      - 'scripts/ci/validate_installer_contract.py'
+      - 'tests/scripts/test_validate_installer_contract.py'
   push:
     branches: [ main ]
     paths:
       - 'shaft-intellij/**'
       - '.github/workflows/intellij-plugin.yml'
       - '.github/workflows/publish-intellij-plugin.yml'
+      - 'scripts/mcp/**'
+      - 'tests/scripts/test_install_shaft_mcp.py'
+      - 'scripts/ci/verify_shaft_mcp_installer_release.py'
+      - 'scripts/ci/validate_installer_contract.py'
+      - 'tests/scripts/test_validate_installer_contract.py'
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  installer-verification:
+    name: Installer verification (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-15, windows-2025]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'zulu'
+          check-latest: true
+      - name: Run unittest for installer script
+        run: python -m unittest tests.scripts.test_install_shaft_mcp -v
+      - name: Validate installer contract
+        run: python scripts/ci/validate_installer_contract.py
+      - name: Verify installer release
+        run: python scripts/ci/verify_shaft_mcp_installer_release.py
+
   build-and-verify:
     runs-on: ubuntu-22.04
     steps:

--- a/scripts/ci/validate_installer_contract.py
+++ b/scripts/ci/validate_installer_contract.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Validate installer contract between Python, Java, and shell scripts."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def parse_targets_from_python(py_file: Path) -> set[str]:
+    """Parse TARGETS tuple from install_shaft_mcp.py using regex."""
+    content = py_file.read_text(encoding="utf-8")
+    # Match: TARGETS = ("codex", "claude", ...)
+    match = re.search(r'TARGETS\s*=\s*\((.*?)\)', content, re.DOTALL)
+    if not match:
+        return set()
+    targets_str = match.group(1)
+    # Extract quoted strings
+    targets = re.findall(r'"([^"]+)"', targets_str)
+    return set(targets)
+
+
+def parse_installer_targets_from_java(java_file: Path) -> dict[str, str]:
+    """Parse INSTALLER_TARGETS array and installerArgumentFor mapping from Java file.
+
+    Returns dict: {INSTALLER_TARGET_NAME -> mapped_argument}
+    """
+    content = java_file.read_text(encoding="utf-8")
+
+    # Parse INSTALLER_TARGETS array
+    targets_match = re.search(
+        r'static\s+final\s+String\[\]\s+INSTALLER_TARGETS\s*=\s*\{(.*?)\};',
+        content,
+        re.DOTALL
+    )
+    if not targets_match:
+        return {}
+
+    targets_str = targets_match.group(1)
+    installer_targets = re.findall(r'"([^"]+)"', targets_str)
+
+    # Parse installerArgumentFor switch statement
+    # Match: private static String installerArgumentFor(String target) { return switch (normalize(target, "CODEX")) { ... }; }
+    arg_for_match = re.search(
+        r'private\s+static\s+String\s+installerArgumentFor\s*\(\s*String\s+target\s*\)\s*\{.*?return\s+switch\s*\(\s*normalize\s*\([^)]*\)\s*\)\s*\{(.*?)\s*\}\s*;',
+        content,
+        re.DOTALL
+    )
+
+    mapping = {}
+    if arg_for_match:
+        switch_body = arg_for_match.group(1)
+        # Parse each case: case "CLAUDE_CODE" -> "claude";
+        cases = re.findall(
+            r'case\s+"([^"]+)"\s*->\s*"([^"]+)"',
+            switch_body
+        )
+        for case_name, case_value in cases:
+            mapping[case_name] = case_value
+
+        # Parse default case: default -> "codex";
+        default_match = re.search(r'default\s*->\s*"([^"]+)"', switch_body)
+        if default_match:
+            # The default case covers entries without explicit cases
+            default_value = default_match.group(1)
+            # CODEX doesn't have an explicit case, so it maps through default
+            for target in installer_targets:
+                if target not in mapping:
+                    mapping[target] = default_value
+
+    return mapping
+
+
+def validate(root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+
+    # Parse TARGETS from Python installer
+    py_installer = root / "scripts/mcp/install_shaft_mcp.py"
+    if not py_installer.is_file():
+        errors.append(f"missing Python installer: {py_installer}")
+        return errors
+
+    targets = parse_targets_from_python(py_installer)
+    if not targets:
+        errors.append(f"unable to parse TARGETS from {py_installer}")
+        return errors
+
+    # Parse installer argument mapping from Java
+    java_setup = root / "shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java"
+    if not java_setup.is_file():
+        errors.append(f"missing Java setup panel: {java_setup}")
+        return errors
+
+    installer_targets_mapping = parse_installer_targets_from_java(java_setup)
+    if not installer_targets_mapping:
+        errors.append(f"unable to parse INSTALLER_TARGETS or installerArgumentFor from {java_setup}")
+        return errors
+
+    # Extract the set of mapped values from Java mapping
+    java_targets = set(installer_targets_mapping.values())
+
+    # Verify set equality
+    if targets != java_targets:
+        missing_in_java = targets - java_targets
+        extra_in_java = java_targets - targets
+
+        if missing_in_java:
+            for target in sorted(missing_in_java):
+                errors.append(
+                    f"target '{target}' is in TARGETS ({py_installer}) "
+                    f"but missing from installerArgumentFor mapping ({java_setup})"
+                )
+
+        if extra_in_java:
+            for target in sorted(extra_in_java):
+                errors.append(
+                    f"target '{target}' is in installerArgumentFor mapping ({java_setup}) "
+                    f"but missing from TARGETS ({py_installer})"
+                )
+
+    # Verify every installer target resolves through the mapping
+    for installer_target, mapped_value in installer_targets_mapping.items():
+        if mapped_value not in targets:
+            errors.append(
+                f"installerArgumentFor('{installer_target}') maps to '{mapped_value}' "
+                f"which is not in TARGETS; check {java_setup} and {py_installer}"
+            )
+
+    # Parse and verify installer command references in Java
+    java_content = java_setup.read_text(encoding="utf-8")
+    # installerCommandFor builds: /scripts/mcp/install-shaft-mcp + .ps1 or .sh
+    if "/scripts/mcp/install-shaft-mcp" not in java_content:
+        errors.append(
+            f"installerCommandFor must reference '/scripts/mcp/install-shaft-mcp' in {java_setup}"
+        )
+
+    # Verify shell scripts exist
+    ps1_installer = root / "scripts/mcp/install-shaft-mcp.ps1"
+    sh_installer = root / "scripts/mcp/install-shaft-mcp.sh"
+
+    if not ps1_installer.is_file():
+        errors.append(
+            f"missing Windows installer script referenced by installerCommandFor: {ps1_installer}"
+        )
+
+    if not sh_installer.is_file():
+        errors.append(
+            f"missing Unix installer script referenced by installerCommandFor: {sh_installer}"
+        )
+
+    return errors
+
+
+def main() -> int:
+    errors = validate()
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    print("Installer contract between Python TARGETS, Java installerArgumentFor, and shell scripts is valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mcp/install_shaft_mcp.py
+++ b/scripts/mcp/install_shaft_mcp.py
@@ -59,7 +59,9 @@ AGENT_VALIDATION_SCRIPT_FILES = (
     "scripts/ci/validate_agent_setup.py",
     "scripts/ci/validate_agent_guidance.py",
     "scripts/ci/validate_documentation_boundaries.py",
+    "scripts/ci/agent_guidance_budget.json",
 )
+AGENT_GUIDANCE_SCAFFOLD_MARKER = "AGENTS.md"
 TARGETS = ("codex", "claude", "claude-desktop", "copilot", "copilot-intellij", "intellij-plugin")
 TARGET_CHOICES = (
     ("codex", "Codex CLI / IDE"),
@@ -699,6 +701,17 @@ def download_shaft_skills_files(target: Path) -> Path:
     return target
 
 
+def has_agent_guidance_scaffold(target: Path) -> bool:
+    """Whether the target project already carries the AGENTS.md guidance
+    scaffold this validator suite is designed to check. The suite validates
+    project-specific conventions (README.md content, host-context files,
+    guidance file budgets, etc.) that only exist in a project that has
+    deliberately adopted this scaffold -- installing it into an unrelated
+    project makes the onboarding-referenced validator crash on missing files
+    it has no reason to expect."""
+    return (target / AGENT_GUIDANCE_SCAFFOLD_MARKER).is_file()
+
+
 def download_agent_validation_script_files(target: Path) -> Path:
     target = target.resolve()
     target.mkdir(parents=True, exist_ok=True)
@@ -1197,8 +1210,12 @@ def install(args: argparse.Namespace) -> None:
         log(f"Installing SHAFT skills to {skills_path}...")
         skills_path = install_shaft_skills(current_directory, root)
         skills_installed = True
-        log("Fetching agent validation script files...")
-        validation_script_dir = download_agent_validation_script_files(current_directory)
+        if has_agent_guidance_scaffold(current_directory):
+            log("Fetching agent validation script files...")
+            validation_script_dir = download_agent_validation_script_files(current_directory)
+        else:
+            log(f"Skipped agent validation scripts: no {AGENT_GUIDANCE_SCAFFOLD_MARKER} guidance "
+                f"scaffold found in {current_directory}.")
     else:
         log(f"Skipped SHAFT skills installation for {skills_path}.")
     result = {

--- a/scripts/mcp/install_shaft_mcp.py
+++ b/scripts/mcp/install_shaft_mcp.py
@@ -150,12 +150,33 @@ def normalize_client(value: str | None) -> str | None:
     return normalized or None
 
 
+def render_client_menu() -> list[str]:
+    """Render the interactive client-menu lines, grouped into labeled sections.
+
+    Entries are numbered contiguously in TARGET_CHOICES order; only section
+    headers and a one-line clarifier are inserted around them, so
+    choose_client()'s numeric-or-name input loop stays unaffected by the
+    grouping.
+    """
+    lines = ["Choose the MCP client to configure:", "AI agents:"]
+    for index, (target, label) in enumerate(TARGET_CHOICES, start=1):
+        if target == "intellij-plugin":
+            lines.append("Advanced / IDE integration:")
+            lines.append(f"  {index}. {label}")
+            lines.append(
+                "     (Configures the plugin's own MCP command; unnecessary "
+                "inside the plugin's guided setup.)"
+            )
+        else:
+            lines.append(f"  {index}. {label}")
+    return lines
+
+
 def choose_client() -> str:
     if not sys.stdin.isatty():
         fail("Pass a client target when running non-interactively.", 2)
-    print("Choose the MCP client to configure:")
-    for index, (_, label) in enumerate(TARGET_CHOICES, start=1):
-        print(f"  {index}. {label}")
+    for line in render_client_menu():
+        print(line)
     while True:
         answer = input("Enter a number: ").strip()
         if answer.isdigit():

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -34,6 +34,11 @@ final class AssistantCommand {
                     Do not apply patches, write files, or run filesystem commands that would mutate source.
                     The user should decide whether and how to apply any suggested edits.
                     """.stripIndent().trim();
+    private static final String AGENT_SOURCE_APPROVAL =
+            """
+                    Source edits are approved for this session.
+                    You may apply patches, write files, and run filesystem commands needed to make the requested source changes.
+                    """.stripIndent().trim();
     private static final String SHAFT_MCP_USAGE_HINT =
             """
                     If this request requires interacting with a browser, page element, or mobile app, use shaft-mcp.
@@ -1537,7 +1542,12 @@ final class AssistantCommand {
                 : text)
                 : hint + "\n\n" + text;
         withHint = withConversationContext(withHint, conversationContext);
-        return agentMode && !allowSourceMutation ? withHint + "\n\n" + AGENT_SOURCE_GUARD : withHint;
+        if (!agentMode) {
+            return withHint;
+        }
+        return allowSourceMutation
+                ? withHint + "\n\n" + AGENT_SOURCE_APPROVAL
+                : withHint + "\n\n" + AGENT_SOURCE_GUARD;
     }
 
     static boolean requiresAgentModeForMcp(String prompt, String mode, Invocation invocation) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
@@ -42,6 +42,8 @@ final class AssistantLocalAgentRunner {
     private static final int COMPACT_TIMEOUT_SECONDS = 30;
     private static final String CUSTOM_AGENT_APPROVAL_WARNING =
             "Custom Agent commands require Allow source edits because SHAFT cannot enforce read-only execution.";
+    private static final String BUFFERED_MODE_NOTICE =
+            "Live output is unavailable for this CLI; the full response will appear once it completes.";
     private static final Pattern MODEL_LINE_PATTERN = Pattern.compile("(claude-[a-z0-9.-]+|gpt-[a-z0-9.-]+|o[0-9][a-z0-9.-]*)",
             Pattern.CASE_INSENSITIVE);
 
@@ -69,11 +71,28 @@ final class AssistantLocalAgentRunner {
             AssistantCommand.Invocation invocation,
             Consumer<String> outputConsumer,
             ProcessLauncher processLauncher) {
+        return start(invocation, outputConsumer, processLauncher, true);
+    }
+
+    /**
+     * Package-private overload used by tests to drive a stub process for a default-command
+     * invocation (Claude/Codex/Copilot) whose real executable is not guaranteed to be installed on
+     * the test machine's PATH, bypassing the {@code isCommandAvailable} gate that protects the real
+     * CLI path in {@link #start(AssistantCommand.Invocation, Consumer, ProcessLauncher)}. Mirrors the
+     * existing bypass overloads for {@link #runCompactPreamble} and {@link #listModels(JsonObject,
+     * ProcessLauncher)}.
+     */
+    static ShaftMcpInvocation start(
+            AssistantCommand.Invocation invocation,
+            Consumer<String> outputConsumer,
+            ProcessLauncher processLauncher,
+            boolean requireCommandAvailable) {
         JsonObject arguments = invocation.arguments();
         AtomicReference<Process> processReference = new AtomicReference<>();
         AtomicBoolean cancellationRequested = new AtomicBoolean();
-        CompletableFuture<ShaftMcpToolResult> future = CompletableFuture.supplyAsync(
-                () -> run(arguments, processReference, cancellationRequested, outputConsumer, processLauncher));
+        CompletableFuture<ShaftMcpToolResult> future = CompletableFuture.supplyAsync(() -> run(
+                arguments, processReference, cancellationRequested, outputConsumer, processLauncher,
+                requireCommandAvailable));
         return new ShaftMcpInvocation(
                 future,
                 () -> cancel(processReference, cancellationRequested, false),
@@ -171,6 +190,16 @@ final class AssistantLocalAgentRunner {
             AtomicBoolean cancellationRequested,
             Consumer<String> outputConsumer,
             ProcessLauncher processLauncher) {
+        return run(arguments, processReference, cancellationRequested, outputConsumer, processLauncher, true);
+    }
+
+    private static ShaftMcpToolResult run(
+            JsonObject arguments,
+            AtomicReference<Process> processReference,
+            AtomicBoolean cancellationRequested,
+            Consumer<String> outputConsumer,
+            ProcessLauncher processLauncher,
+            boolean requireCommandAvailable) {
         List<String> command = commandFor(arguments);
         if (command.isEmpty()) {
             return ShaftMcpToolResult.failure("No local assistant command was configured.");
@@ -180,20 +209,24 @@ final class AssistantLocalAgentRunner {
                 && !allowSourceMutation(arguments)) {
             return ShaftMcpToolResult.failure(CUSTOM_AGENT_APPROVAL_WARNING);
         }
-        if (defaultCommand(arguments) && !isCommandAvailable(command.get(0))) {
+        if (requireCommandAvailable && defaultCommand(arguments) && !isCommandAvailable(command.get(0))) {
             return ShaftMcpToolResult.failure(displayName(string(arguments, "client", "CODEX"))
                     + " executable is not available on PATH.");
         }
         Duration timeout = Duration.ofSeconds(intValue(arguments, "timeoutSeconds", DEFAULT_TIMEOUT_SECONDS));
         String stdin = string(arguments, "prompt", "");
         Path workingDirectory = workingDirectory(arguments);
+        boolean isDefaultCommand = defaultCommand(arguments);
+        StructuredStreamParser streamParser = isDefaultCommand ? structuredStreamParser(command) : null;
+        Consumer<String> effectiveConsumer =
+                effectiveConsumer(outputConsumer, streamParser, isDefaultCommand);
         try {
             Process process = processLauncher.launch(command, workingDirectory, environment(arguments));
             processReference.set(process);
             InputStream stdoutStream = process.getInputStream();
             InputStream stderrStream = process.getErrorStream();
-            CompletableFuture<String> stdout = readAsync(stdoutStream, outputConsumer);
-            CompletableFuture<String> stderr = readAsync(stderrStream, outputConsumer);
+            CompletableFuture<String> stdout = readAsync(stdoutStream, effectiveConsumer);
+            CompletableFuture<String> stderr = readAsync(stderrStream, effectiveConsumer);
             process.getOutputStream().write(stdin.getBytes(StandardCharsets.UTF_8));
             process.getOutputStream().close();
 
@@ -212,8 +245,13 @@ final class AssistantLocalAgentRunner {
                 stderrNow(stderr);
                 throw new CancellationException("Operation cancelled");
             }
-            String output = agentOutput(process.exitValue() == 0, stdoutNow(stdout), stderrNow(stderr), "");
-            return process.exitValue() == 0
+            boolean success = process.exitValue() == 0;
+            String rawStdout = stdoutNow(stdout);
+            String rawStderr = stderrNow(stderr);
+            String output = success && streamParser != null && streamParser.hasTerminalEvent()
+                    ? streamParser.finalOutput()
+                    : agentOutput(success, rawStdout, rawStderr, "");
+            return success
                     ? ShaftMcpToolResult.success(output)
                     : ShaftMcpToolResult.failure(output);
         } catch (InterruptedException exception) {
@@ -232,6 +270,216 @@ final class AssistantLocalAgentRunner {
         }
     }
 
+    /**
+     * Returns a stream-event parser when {@code command} is a structured-stream default command
+     * (Claude's {@code stream-json} output or Codex's experimental {@code --json} output), or
+     * {@code null} for buffered-output commands (Copilot, custom commands) so callers know to fall
+     * back to today's buffered {@link #agentOutput} handling untouched.
+     */
+    private static StructuredStreamParser structuredStreamParser(List<String> command) {
+        if (command.isEmpty()) {
+            return null;
+        }
+        String executable = command.get(0);
+        if ("claude".equals(executable) && command.contains("stream-json")) {
+            return new StructuredStreamParser(StructuredStreamParser.Format.CLAUDE);
+        }
+        if ("codex".equals(executable) && command.contains("--json")) {
+            return new StructuredStreamParser(StructuredStreamParser.Format.CODEX);
+        }
+        return null;
+    }
+
+    /**
+     * Wraps the caller's {@code outputConsumer} so that structured-stream default commands receive
+     * human-readable progress lines translated from NDJSON, while buffered-output <em>default</em>
+     * commands (Copilot, whose CLI has no known streaming flag) receive a single honest notice that
+     * live output is unavailable, followed by silence until the buffered response returns. Custom
+     * commands are never wrapped — SHAFT cannot know a hand-typed command's output shape, so its raw
+     * lines are forwarded unchanged exactly as before, the same pass-through behavior a slow custom
+     * CLI already relied on. A {@code null} caller consumer is left as {@code null} in every case
+     * since there is nothing to forward lines to.
+     */
+    private static Consumer<String> effectiveConsumer(
+            Consumer<String> outputConsumer, StructuredStreamParser streamParser, boolean isDefaultCommand) {
+        if (outputConsumer == null) {
+            return null;
+        }
+        if (streamParser != null) {
+            return line -> streamParser.accept(line, outputConsumer);
+        }
+        if (!isDefaultCommand) {
+            return outputConsumer;
+        }
+        AtomicBoolean notified = new AtomicBoolean();
+        return line -> {
+            if (notified.compareAndSet(false, true)) {
+                outputConsumer.accept(BUFFERED_MODE_NOTICE);
+            }
+        };
+    }
+
+    /**
+     * Translates a structured NDJSON stream (Claude {@code stream-json} or Codex experimental
+     * {@code --json} events) into human-readable progress lines delivered through the caller's
+     * {@code outputConsumer}, while separately capturing the terminal event's final answer text and
+     * usage object. Both CLIs' event schemas are experimental/subject to drift, so unrecognized event
+     * types, missing fields, and non-JSON lines are all skipped or passed through harmlessly rather
+     * than treated as parse failures — only a well-formed terminal event upgrades the result away
+     * from today's buffered {@link #agentOutput} fallback.
+     *
+     * <p>Not thread-safe: each invocation of {@link #run} creates its own instance, but stdout and
+     * stderr are each read on their own thread via {@link #readAsync}, so access to the mutable
+     * terminal-event fields is synchronized.
+     */
+    private static final class StructuredStreamParser {
+        enum Format { CLAUDE, CODEX }
+
+        private final Format format;
+        private String answer;
+        private Integer inputTokens;
+        private Integer outputTokens;
+
+        StructuredStreamParser(Format format) {
+            this.format = format;
+        }
+
+        synchronized void accept(String line, Consumer<String> outputConsumer) {
+            String trimmed = line == null ? "" : line.strip();
+            if (trimmed.isEmpty()) {
+                return;
+            }
+            JsonObject event = parseObject(trimmed);
+            if (event == null) {
+                // Non-JSON output (banners, warnings) is not part of the structured contract but is
+                // still useful progress information, so it passes through unchanged.
+                outputConsumer.accept(line);
+                return;
+            }
+            String humanReadableLine = format == Format.CLAUDE ? describeClaudeEvent(event) : describeCodexEvent(event);
+            if (humanReadableLine != null) {
+                outputConsumer.accept(humanReadableLine);
+            }
+        }
+
+        synchronized boolean hasTerminalEvent() {
+            return answer != null;
+        }
+
+        synchronized String finalOutput() {
+            JsonObject usage = new JsonObject();
+            usage.addProperty("input_tokens", orZero(inputTokens));
+            usage.addProperty("output_tokens", orZero(outputTokens));
+            JsonObject usageHolder = new JsonObject();
+            usageHolder.add("usage", usage);
+            return answer.strip() + "\n\n" + usageHolder;
+        }
+
+        private String describeClaudeEvent(JsonObject event) {
+            String type = stringField(event, "type");
+            if ("assistant".equals(type)) {
+                JsonObject message = objectField(event, "message");
+                JsonElement content = message == null ? null : message.get("content");
+                if (content != null && content.isJsonArray()) {
+                    for (JsonElement blockElement : content.getAsJsonArray()) {
+                        if (!blockElement.isJsonObject()) {
+                            continue;
+                        }
+                        JsonObject block = blockElement.getAsJsonObject();
+                        String blockType = stringField(block, "type");
+                        if ("tool_use".equals(blockType)) {
+                            String toolName = stringField(block, "name");
+                            return "Calling tool " + (toolName == null ? "(unknown)" : toolName) + "...";
+                        }
+                        if ("text".equals(blockType)) {
+                            String text = stringField(block, "text");
+                            if (text != null && !text.isBlank()) {
+                                return text;
+                            }
+                        }
+                    }
+                }
+                return null;
+            }
+            if ("result".equals(type)) {
+                String resultText = stringField(event, "result");
+                answer = resultText == null ? "" : resultText;
+                JsonObject usage = objectField(event, "usage");
+                inputTokens = intField(usage, "input_tokens");
+                outputTokens = intField(usage, "output_tokens");
+                return null;
+            }
+            return null;
+        }
+
+        private String describeCodexEvent(JsonObject event) {
+            String type = stringField(event, "type");
+            if ("item.completed".equals(type) || "item.updated".equals(type)) {
+                JsonObject item = objectField(event, "item");
+                String itemType = stringField(item, "type");
+                if ("tool_call".equals(itemType) || "command_execution".equals(itemType) || "mcp_tool_call".equals(itemType)) {
+                    String toolName = firstNonBlank(stringField(item, "name"), stringField(item, "tool"), stringField(item, "command"));
+                    return "Calling tool " + (toolName == null ? "(unknown)" : toolName) + "...";
+                }
+                if ("agent_message".equals(itemType)) {
+                    String text = stringField(item, "text");
+                    if (text != null && !text.isBlank()) {
+                        return text;
+                    }
+                }
+                return null;
+            }
+            if ("turn.completed".equals(type) || "turn.failed".equals(type)) {
+                JsonObject usage = objectField(event, "usage");
+                inputTokens = firstNonNull(intField(usage, "input_tokens"), inputTokens);
+                outputTokens = firstNonNull(intField(usage, "output_tokens"), outputTokens);
+                if ("turn.completed".equals(type)) {
+                    String lastAgentMessage = stringField(event, "last_agent_message");
+                    answer = lastAgentMessage != null ? lastAgentMessage : (answer == null ? "" : answer);
+                }
+                return null;
+            }
+            return null;
+        }
+
+        private static String firstNonBlank(String... candidates) {
+            for (String candidate : candidates) {
+                if (candidate != null && !candidate.isBlank()) {
+                    return candidate;
+                }
+            }
+            return null;
+        }
+
+        private static Integer firstNonNull(Integer preferred, Integer fallback) {
+            return preferred != null ? preferred : fallback;
+        }
+
+        private static JsonObject parseObject(String candidate) {
+            if (!candidate.startsWith("{")) {
+                return null;
+            }
+            try {
+                JsonElement parsed = JsonParser.parseString(candidate);
+                return parsed.isJsonObject() ? parsed.getAsJsonObject() : null;
+            } catch (JsonParseException exception) {
+                return null;
+            }
+        }
+
+        private static String stringField(JsonObject object, String key) {
+            JsonElement value = object == null ? null : object.get(key);
+            return value != null && value.isJsonPrimitive() && value.getAsJsonPrimitive().isString()
+                    ? value.getAsString()
+                    : null;
+        }
+
+        private static JsonObject objectField(JsonObject object, String key) {
+            JsonElement value = object == null ? null : object.get(key);
+            return value != null && value.isJsonObject() ? value.getAsJsonObject() : null;
+        }
+    }
+
     private static void cancel(
             AtomicReference<Process> processReference,
             AtomicBoolean cancellationRequested,
@@ -247,6 +495,14 @@ final class AssistantLocalAgentRunner {
         }
     }
 
+    /**
+     * {@code --json} is an experimental Codex CLI flag (documented alongside its
+     * {@code --experimental-json} alias) that switches {@code codex exec} to emit newline-delimited
+     * JSON events (thread/turn/item lifecycle plus a final {@code turn.completed} usage summary)
+     * instead of a single buffered blob. Because it is experimental, its event schema is subject to
+     * drift between Codex CLI releases, so the NDJSON parser in {@link #run} is deliberately
+     * tolerant: unrecognized event types or fields are skipped rather than treated as errors.
+     */
     private static List<String> codexCommand(String mode, boolean allowSourceMutation) {
         return switch (mode) {
             case "AGENT" -> List.of(
@@ -254,16 +510,24 @@ final class AssistantLocalAgentRunner {
                     "--sandbox", allowSourceMutation ? "workspace-write" : "read-only",
                     "-c", "mcp_servers.shaft-mcp.default_tools_approval_mode=\"approve\"",
                     "-c", "mcp_servers.shaft-mcp.tool_timeout_sec=600",
+                    "--json",
                     "-");
-            default -> List.of("codex", "exec", "--sandbox", "read-only", "-");
+            default -> List.of("codex", "exec", "--sandbox", "read-only", "--json", "-");
         };
     }
 
+    /**
+     * {@code --output-format stream-json} requires {@code --verbose} whenever it is paired with
+     * {@code --print} (the CLI rejects the combination otherwise), so every mode below carries both
+     * flags together to receive incremental NDJSON events instead of a single buffered blob.
+     */
     private static List<String> claudeCommand(String mode, boolean allowSourceMutation) {
         return switch (mode) {
-            case "PLAN" -> List.of("claude", "--print", "--permission-mode", "plan");
-            case "AGENT" -> List.of("claude", "--print", "--permission-mode", allowSourceMutation ? "acceptEdits" : "plan");
-            default -> List.of("claude", "--print");
+            case "PLAN" -> List.of("claude", "--print", "--permission-mode", "plan",
+                    "--output-format", "stream-json", "--verbose");
+            case "AGENT" -> List.of("claude", "--print", "--permission-mode", allowSourceMutation ? "acceptEdits" : "plan",
+                    "--output-format", "stream-json", "--verbose");
+            default -> List.of("claude", "--print", "--output-format", "stream-json", "--verbose");
         };
     }
 
@@ -483,21 +747,63 @@ final class AssistantLocalAgentRunner {
     }
 
     /**
-     * Parses token usage from an agent's raw output. Looks for a JSON object anywhere in the text
-     * containing a {@code usage} field with {@code input_tokens}/{@code output_tokens} (the Claude
-     * CLI {@code --output-format json} shape), falling back to top-level
-     * {@code input_tokens}/{@code output_tokens} fields. Returns {@code null} when no structured
-     * usage metadata is present, so callers can fall back to an estimate and label it accordingly.
+     * Parses token usage from an agent's raw output. First tries the output as NDJSON: each line is
+     * parsed independently as a JSON object carrying (or holding a nested {@code usage} object with)
+     * {@code input_tokens}/{@code output_tokens}, and the <em>last</em> line that yields usage fields
+     * wins — matching a structured-stream terminal event that may be followed by later
+     * housekeeping/log lines. When no line parses to usage, falls back to the original
+     * first-brace/last-brace whole-text extraction (the Claude CLI {@code --output-format json}
+     * shape). Returns {@code null} when no structured usage metadata is present in either form, so
+     * callers can fall back to an estimate and label it accordingly.
      */
     static TokenUsage parseTokenUsage(String output) {
         String trimmed = output == null ? "" : output.strip();
         if (trimmed.isBlank()) {
             return null;
         }
+        TokenUsage fromLines = parseTokenUsageFromLines(trimmed);
+        if (fromLines != null) {
+            return fromLines;
+        }
         JsonObject usageHolder = extractJsonObject(trimmed);
         if (usageHolder == null) {
             return null;
         }
+        return usageFromHolder(usageHolder);
+    }
+
+    /**
+     * Scans {@code text} line by line, parsing each non-blank line as a standalone JSON object and
+     * keeping the usage parsed from the last line that has one. Lines that are not valid JSON (plain
+     * prose, partial output) are skipped rather than treated as errors, since NDJSON output is
+     * expected to interleave structured events with the occasional non-JSON banner line.
+     */
+    private static TokenUsage parseTokenUsageFromLines(String text) {
+        TokenUsage lastMatch = null;
+        for (String line : text.split("\\r?\\n")) {
+            String candidate = line.strip();
+            if (candidate.length() < 2 || !candidate.startsWith("{") || !candidate.endsWith("}")) {
+                continue;
+            }
+            JsonObject parsed;
+            try {
+                JsonElement element = JsonParser.parseString(candidate);
+                if (!element.isJsonObject()) {
+                    continue;
+                }
+                parsed = element.getAsJsonObject();
+            } catch (JsonParseException exception) {
+                continue;
+            }
+            TokenUsage usage = usageFromHolder(parsed);
+            if (usage != null) {
+                lastMatch = usage;
+            }
+        }
+        return lastMatch;
+    }
+
+    private static TokenUsage usageFromHolder(JsonObject usageHolder) {
         JsonObject usage = resolveUsageObject(usageHolder);
         Integer inputTokens = intField(usage, "input_tokens");
         Integer outputTokens = intField(usage, "output_tokens");
@@ -505,6 +811,45 @@ final class AssistantLocalAgentRunner {
             return null;
         }
         return TokenUsage.reported(orZero(inputTokens), orZero(outputTokens));
+    }
+
+    /**
+     * Returns {@code output} with its trailing usage-metadata JSON line removed, leaving only the
+     * human-facing answer text. This is the display-side counterpart to {@link #parseTokenUsage}:
+     * both inspect the same trailing line, so a change to one's line-detection rules must be mirrored
+     * in the other. When the last non-blank line is not a parseable usage object, {@code output} is
+     * returned unchanged (stripped of surrounding whitespace) so plain prose responses are never
+     * altered.
+     */
+    static String stripTrailingUsageMetadata(String output) {
+        String trimmed = output == null ? "" : output.strip();
+        if (trimmed.isBlank()) {
+            return trimmed;
+        }
+        String[] lines = trimmed.split("\\r?\\n");
+        int lastLineIndex = lines.length - 1;
+        String lastLine = lines[lastLineIndex].strip();
+        if (lastLine.length() < 2 || !lastLine.startsWith("{") || !lastLine.endsWith("}")) {
+            return trimmed;
+        }
+        JsonObject parsed;
+        try {
+            JsonElement element = JsonParser.parseString(lastLine);
+            if (!element.isJsonObject()) {
+                return trimmed;
+            }
+            parsed = element.getAsJsonObject();
+        } catch (JsonParseException exception) {
+            return trimmed;
+        }
+        if (usageFromHolder(parsed) == null) {
+            return trimmed;
+        }
+        StringBuilder remainder = new StringBuilder();
+        for (int index = 0; index < lastLineIndex; index++) {
+            remainder.append(lines[index]).append('\n');
+        }
+        return remainder.toString().strip();
     }
 
     private static JsonObject resolveUsageObject(JsonObject usageHolder) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantTranscriptView.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantTranscriptView.java
@@ -20,16 +20,20 @@ import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.util.ui.JBUI;
 
+import javax.swing.Action;
 import javax.swing.JComponent;
 import javax.swing.JEditorPane;
 import javax.swing.JLabel;
+import javax.swing.JMenuItem;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
 import javax.swing.JScrollBar;
 import javax.swing.UIManager;
 import javax.swing.BoxLayout;
 import javax.swing.SwingUtilities;
 import javax.swing.BorderFactory;
 import javax.swing.event.HyperlinkEvent;
+import javax.swing.text.DefaultEditorKit;
 import javax.swing.text.html.HTMLEditorKit;
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -41,6 +45,9 @@ import java.awt.RenderingHints;
 import java.awt.Dimension;
 import java.awt.LayoutManager;
 import java.awt.datatransfer.StringSelection;
+import java.awt.event.ActionEvent;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -82,6 +89,8 @@ final class AssistantTranscriptView extends JPanel {
     private final LafManagerListener lafListener;
     private Disposable lafConnectionDisposable;
     private int truncationBoundaryIndex = -1;
+    private Runnable copyFullTranscriptAction = () -> { };
+    private JPopupMenu lastMessageContextMenu;
 
     AssistantTranscriptView() {
         this(null);
@@ -185,6 +194,21 @@ final class AssistantTranscriptView extends JPanel {
 
     void setTruncationBoundaryIndex(int index) {
         this.truncationBoundaryIndex = index;
+    }
+
+    /**
+     * Injects the action driven by the "Copy full transcript" context menu item.
+     * Callers (namely {@code ShaftAssistantPanel}) should reuse the exact same
+     * export-and-copy path used by their own "Copy assistant transcript" action.
+     *
+     * @param action callback invoked when a message pane's "Copy full transcript" item is clicked
+     */
+    void setCopyFullTranscriptAction(Runnable action) {
+        this.copyFullTranscriptAction = action == null ? () -> { } : action;
+    }
+
+    JPopupMenu lastMessageContextMenuForTest() {
+        return lastMessageContextMenu;
     }
 
     private JBScrollPane createFallbackScrollPane(Color transcriptBackground) {
@@ -309,6 +333,7 @@ final class AssistantTranscriptView extends JPanel {
         htmlPane.setBorder(JBUI.Borders.empty());
         htmlPane.setForeground(foreground);
         htmlPane.addHyperlinkListener(AssistantTranscriptView::copyCodeFromFallbackLink);
+        htmlPane.addMouseListener(new TranscriptContextMenuListener(htmlPane));
         String rendered = toFallbackHtml(html, foreground, background);
         htmlPane.putClientProperty(TRANSCRIPT_RENDERED_HTML_PROPERTY, rendered);
         htmlPane.setText(rendered);
@@ -328,6 +353,82 @@ final class AssistantTranscriptView extends JPanel {
         int bubblePadding = JBUI.scale(22);
         int bubbleWidth = (int) Math.floor(Math.max(JBUI.scale(180), viewportWidth - rowPadding) * 0.88D);
         return Math.max(JBUI.scale(140), bubbleWidth - bubblePadding);
+    }
+
+    private JPopupMenu buildMessageContextMenu(JEditorPane pane) {
+        JPopupMenu menu = new JPopupMenu("Assistant transcript message actions");
+        String selectedText = pane.getSelectedText();
+        boolean hasSelection = selectedText != null && !selectedText.isEmpty();
+
+        JMenuItem copyItem = new JMenuItem("Copy");
+        copyItem.getAccessibleContext().setAccessibleName("Copy");
+        copyItem.setEnabled(hasSelection);
+        copyItem.addActionListener(event -> copySelection(pane));
+
+        JMenuItem selectAllItem = new JMenuItem("Select All");
+        selectAllItem.getAccessibleContext().setAccessibleName("Select All");
+        selectAllItem.addActionListener(event -> pane.selectAll());
+
+        JMenuItem copyFullTranscriptItem = new JMenuItem("Copy full transcript");
+        copyFullTranscriptItem.getAccessibleContext().setAccessibleName("Copy full transcript");
+        copyFullTranscriptItem.addActionListener(event -> copyFullTranscriptAction.run());
+
+        menu.add(copyItem);
+        menu.add(selectAllItem);
+        menu.add(copyFullTranscriptItem);
+        return menu;
+    }
+
+    private static void copySelection(JEditorPane pane) {
+        Action copyAction = pane.getActionMap().get(DefaultEditorKit.copyAction);
+        if (copyAction != null) {
+            copyAction.actionPerformed(new ActionEvent(pane, ActionEvent.ACTION_PERFORMED, DefaultEditorKit.copyAction));
+        }
+    }
+
+    /**
+     * Right-click handler for a per-message HTML pane. Installed fresh on every
+     * pane created by {@link #fallbackHtmlPane}, so it survives transcript re-renders.
+     */
+    final class TranscriptContextMenuListener implements MouseListener {
+        private final JEditorPane pane;
+
+        private TranscriptContextMenuListener(JEditorPane pane) {
+            this.pane = pane;
+        }
+
+        @Override
+        public void mouseClicked(MouseEvent event) {
+        }
+
+        @Override
+        public void mousePressed(MouseEvent event) {
+            maybeShowPopup(event);
+        }
+
+        @Override
+        public void mouseReleased(MouseEvent event) {
+            maybeShowPopup(event);
+        }
+
+        @Override
+        public void mouseEntered(MouseEvent event) {
+        }
+
+        @Override
+        public void mouseExited(MouseEvent event) {
+        }
+
+        private void maybeShowPopup(MouseEvent event) {
+            if (!event.isPopupTrigger()) {
+                return;
+            }
+            JPopupMenu menu = buildMessageContextMenu(pane);
+            lastMessageContextMenu = menu;
+            if (pane.isShowing()) {
+                menu.show(pane, event.getX(), event.getY());
+            }
+        }
     }
 
     private String toFallbackHtml(String value, Color foreground, Color background) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantChatState.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantChatState.java
@@ -84,6 +84,17 @@ public final class ShaftAssistantChatState implements PersistentStateComponent<S
     }
 
     Session newSession() {
+        // Dedup guard: if sessions is non-empty and the current active session
+        // (resolved directly via sessionById, not activeSession() to avoid recursion)
+        // has zero messages, return/activate that existing empty session instead of creating a new one.
+        if (!sessions.isEmpty()) {
+            Session activeSession = sessionById(activeSessionId);
+            if (activeSession != null && activeSession.messages != null && activeSession.messages.isEmpty()) {
+                // Current session is already empty; return it without creating a new one
+                return activeSession;
+            }
+        }
+
         Session session = new Session();
         session.id = UUID.randomUUID().toString();
         session.title = "New chat";

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -343,6 +343,7 @@ final class ShaftAssistantPanel extends JPanel {
         prompt.setLineWrap(true);
         prompt.setWrapStyleWord(true);
         transcript = new AssistantTranscriptView(project);
+        transcript.setCopyFullTranscriptAction(this::copyFullTranscript);
         if (!chatState.activeMarkdown().isBlank()) {
             transcript.setMessages(chatState.activeMessages());
             lastPrompt = latestUserPrompt();
@@ -395,7 +396,7 @@ final class ShaftAssistantPanel extends JPanel {
         ShaftIconButtons.apply(copyRawResponse, ShaftIcons.CODE);
         copyRawResponse.setEnabled(false);
         copyTranscript = button("Copy all", "Copy assistant transcript",
-                event -> copy(exportTranscriptWithEvidence(), "Copied transcript"));
+                event -> copyFullTranscript());
         ShaftIconButtons.apply(copyTranscript, ShaftIcons.COPY);
         captureReviewStatus = new JLabel("Capture review ready");
         captureReviewStatus.getAccessibleContext().setAccessibleName("Capture review status");
@@ -1708,6 +1709,10 @@ final class ShaftAssistantPanel extends JPanel {
         if (!lastRawResponse.isBlank()) {
             copy(lastRawResponse, "Copied raw response");
         }
+    }
+
+    private void copyFullTranscript() {
+        copy(exportTranscriptWithEvidence(), "Copied transcript");
     }
 
     private String exportTranscriptWithEvidence() {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -49,6 +49,7 @@ import javax.swing.event.DocumentListener;
 import javax.swing.text.JTextComponent;
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Container;
 import java.awt.FlowLayout;
 import java.awt.Component;
 import java.awt.FontMetrics;
@@ -113,6 +114,7 @@ final class ShaftAssistantPanel extends JPanel {
     private final DefaultListModel<String> timelineModel;
     private final JList<String> timeline;
     private final JPanel timelinePanel;
+    private final JPanel actionRow;
     private final JButton clearTranscript;
     private final JButton rerunLastPrompt;
     private final JLabel currentAgentConfiguration;
@@ -430,8 +432,8 @@ final class ShaftAssistantPanel extends JPanel {
         this.configure = button("Configure", "Open SHAFT MCP setup", event -> openSetup());
         ShaftIconButtons.apply(this.configure, ShaftIcons.SETTINGS);
 
-        mode.addActionListener(event -> updateControlVisibility());
-        providerType.addActionListener(event -> updateControlVisibility());
+        mode.addActionListener(event -> onModeOrRouteSelectionChanged());
+        providerType.addActionListener(event -> onModeOrRouteSelectionChanged());
         assistantFamily.addActionListener(event -> updateControlVisibility());
         assistantRuntime.addActionListener(event -> updateControlVisibility());
         cloudProvider.addActionListener(event -> updateControlVisibility());
@@ -466,7 +468,7 @@ final class ShaftAssistantPanel extends JPanel {
         header.add(new JLabel("SHAFT"), BorderLayout.NORTH);
         header.add(chatRow, BorderLayout.CENTER);
 
-        JPanel actionRow = wrapRow();
+        actionRow = wrapRow();
         actionRow.add(copyLastResponse);
         actionRow.add(copyRawResponse);
         actionRow.add(copyTranscript);
@@ -575,7 +577,7 @@ final class ShaftAssistantPanel extends JPanel {
                 Keep AGENTS.md canonical, host adapters thin, and memories durable, evidence-backed, and non-duplicative.
                 Do not edit product code, tests, workflows, manifests, dependencies, generated reports, binaries, or secrets without explicit user approval.
 
-                If source edits are not enabled, return a concise patch plan only. If edits are enabled, make the smallest guidance or memory updates and rerun `py -3 scripts/ci/validate_agent_setup.py --skip-external` on Windows or `python3 scripts/ci/validate_agent_setup.py --skip-external` elsewhere.
+                After making any guidance or memory updates, rerun `py -3 scripts/ci/validate_agent_setup.py --skip-external` on Windows or `python3 scripts/ci/validate_agent_setup.py --skip-external` elsewhere.
                 """.formatted(ShaftUiLabels.friendly(family), surfaces).strip();
     }
 
@@ -1435,6 +1437,15 @@ final class ShaftAssistantPanel extends JPanel {
         status.setVisible(!READY_STATUS.equals(value));
     }
 
+    private void onModeOrRouteSelectionChanged() {
+        boolean agentMode = "AGENT".equals(mode.getSelectedItem());
+        boolean cloud = usesCloud();
+        if (!agentMode || cloud) {
+            allowSourceMutation.setSelected(false);
+        }
+        updateControlVisibility();
+    }
+
     private void updateControlVisibility() {
         boolean advanced = settings.advancedUiEnabled;
         if (!advanced && usesCloud()) {
@@ -1479,9 +1490,6 @@ final class ShaftAssistantPanel extends JPanel {
         autoCompact.setEnabled(controlsEnabled && localAgent && localCli);
         configure.setVisible(lockedRoute);
         configure.setEnabled(controlsEnabled && lockedRoute);
-        if (!agentMode || !localAgent) {
-            allowSourceMutation.setSelected(false);
-        }
         if (!localAgent || !localCli) {
             verboseAgentOutput.setSelected(false);
         }
@@ -1556,6 +1564,18 @@ final class ShaftAssistantPanel extends JPanel {
         cancel.setEnabled(running);
         timelinePanel.setVisible(running || timelineModel.size() > 1);
         timelinePanel.revalidate();
+        refreshActionRowLayout();
+    }
+
+    private void refreshActionRowLayout() {
+        Container container = actionRow == null ? null : actionRow.getParent();
+        if (container == null) {
+            actionRow.revalidate();
+            actionRow.repaint();
+            return;
+        }
+        container.revalidate();
+        container.repaint();
     }
 
     private void insertSelectedCommand() {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -327,7 +327,9 @@ final class ShaftAssistantPanel extends JPanel {
         allowSourceMutation.setToolTipText("Enable only when Agent mode should edit local source files");
         verboseAgentOutput = new JBCheckBox("Verbose");
         verboseAgentOutput.getAccessibleContext().setAccessibleName("Show verbose agent output");
-        verboseAgentOutput.setToolTipText("Show live local agent output instead of only the final result");
+        verboseAgentOutput.setToolTipText("Show live local agent output instead of only the final result. "
+                + "GitHub Copilot CLI and custom agent commands cannot stream live output; "
+                + "their response is buffered until the command completes.");
         autoCompact = new JBCheckBox("Auto-compact");
         autoCompact.getAccessibleContext().setAccessibleName("Compact agent context before each request");
         autoCompact.setToolTipText("Send the agent CLI's compact/compress command before each new prompt, when supported");
@@ -1197,9 +1199,13 @@ final class ShaftAssistantPanel extends JPanel {
         if (!output.isBlank() && !rejectedGeneratedJava) {
             appendToolEvidence("autobot_local_agent_run", output);
         }
+        // The raw output may carry a trailing usage-metadata JSON line (the structured-stream
+        // contract from AssistantLocalAgentRunner). That line is never meant for the transcript, so
+        // it is stripped before markdown normalization; withTokenUsage still receives the untouched
+        // raw `output` below so AssistantLocalAgentRunner.parseTokenUsage can read the usage from it.
         String response = rejectedGeneratedJava
                 ? AssistantMarkdown.nativeSeleniumRejectionMarkdown()
-                : AssistantMarkdown.normalizeMarkdown(output);
+                : AssistantMarkdown.normalizeMarkdown(AssistantLocalAgentRunner.stripTrailingUsageMetadata(output));
         if (rejectedGeneratedJava) {
             setStatus("Rejected generated code");
             addTimeline("Failed");

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -1574,7 +1574,10 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     private void refreshActionRowLayout() {
-        Container container = actionRow == null ? null : actionRow.getParent();
+        if (actionRow == null) {
+            return;
+        }
+        Container container = actionRow.getParent();
         if (container == null) {
             actionRow.revalidate();
             actionRow.repaint();

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -409,6 +409,18 @@ final class ShaftMcpSetupPanel extends JPanel {
         return project.getBasePath() == null ? Path.of(".") : Path.of(project.getBasePath());
     }
 
+    /**
+     * Whether this project already carries the AGENTS.md guidance scaffold the
+     * agent-guidance-optimization prompt and its referenced validator script
+     * are designed for. Installing/prompting that validator into an unrelated
+     * project makes it crash on files (README.md, host-context files, guidance
+     * budgets) it has no reason to expect -- so the prompt must not be shown
+     * unless the project has actually adopted this scaffold.
+     */
+    private boolean hasAgentGuidanceScaffold() {
+        return Files.isRegularFile(projectRoot().resolve("AGENTS.md"));
+    }
+
     private void showTestResult(ShaftMcpToolResult result, Throwable error) {
         boolean success = error == null && result != null && result.success();
         setRunning(false, success ? "Connected" : "Test failed. Retry test.");
@@ -443,7 +455,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         }
         if (success) {
             settings.mcpSetupComplete = true;
-            settings.agentGuidanceOptimizationPromptPending = true;
+            settings.agentGuidanceOptimizationPromptPending = hasAgentGuidanceScaffold();
             startChatting.setVisible(true);
             startChatting.requestFocusInWindow();
         } else {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
@@ -75,7 +75,7 @@ public final class ShaftToolWindowPanel extends JPanel {
     private void showSetupView() {
         disposeApiRecordingPanel();
         removeAll();
-        ShaftMcpSetupPanel setup = new ShaftMcpSetupPanel(project, settings, this::showMainView, readinessProbe);
+        ShaftMcpSetupPanel setup = new ShaftMcpSetupPanel(project, settings, this::onSetupComplete, readinessProbe);
         preferredFocusComponent = setup.preferredFocusComponent();
         workflowSelector = null;
         workflowCards = null;
@@ -86,6 +86,11 @@ public final class ShaftToolWindowPanel extends JPanel {
         add(setup, BorderLayout.CENTER);
         revalidate();
         repaint();
+    }
+
+    private void onSetupComplete() {
+        assistantChatState.newSession();
+        showMainView();
     }
 
     private void showMainView() {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftUiLabels.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftUiLabels.java
@@ -60,7 +60,7 @@ public final class ShaftUiLabels {
             case "CLAUDE_DESKTOP" -> "Claude Desktop";
             case "COPILOT_CLI" -> "GitHub Copilot CLI";
             case "COPILOT_INTELLIJ" -> "GitHub Copilot in IntelliJ";
-            case "INTELLIJ_PLUGIN" -> "SHAFT IntelliJ plugin";
+            case "INTELLIJ_PLUGIN" -> "SHAFT IntelliJ plugin (this plugin only - no external agent)";
             case "CLI" -> "CLI";
             case "IDE_PLUGIN" -> "IDE plugin";
             case "DESKTOP_APP" -> "Desktop app";

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
@@ -446,13 +446,17 @@ class AssistantCommandTest {
         AssistantCommand.Invocation custom = AssistantCommand.fromPrompt(
                 "Explain this failure", "CODEX", "ASK", ".", "custom-agent --safe", false);
 
-        assertEquals(List.of("codex", "exec", "--sandbox", "read-only", "-"),
+        // Deliberate flag change (R3-T1): codex exec now always adds the experimental --json flag,
+        // and claude always adds --output-format stream-json --verbose, so the runner receives
+        // incremental NDJSON events instead of a single buffered blob. Custom commands are untouched.
+        assertEquals(List.of("codex", "exec", "--sandbox", "read-only", "--json", "-"),
                 AssistantLocalAgentRunner.commandFor(codexAsk.arguments()));
         assertEquals(List.of(
                 "codex", "exec",
                 "--sandbox", "workspace-write",
                 "-c", "mcp_servers.shaft-mcp.default_tools_approval_mode=\"approve\"",
                 "-c", "mcp_servers.shaft-mcp.tool_timeout_sec=600",
+                "--json",
                 "-"),
                 AssistantLocalAgentRunner.commandFor(codexAgent.arguments()));
         assertEquals(List.of(
@@ -460,9 +464,11 @@ class AssistantCommandTest {
                 "--sandbox", "read-only",
                 "-c", "mcp_servers.shaft-mcp.default_tools_approval_mode=\"approve\"",
                 "-c", "mcp_servers.shaft-mcp.tool_timeout_sec=600",
+                "--json",
                 "-"),
                 AssistantLocalAgentRunner.commandFor(codexAgentNoSource.arguments()));
-        assertEquals(List.of("claude", "--print", "--permission-mode", "plan"),
+        assertEquals(List.of("claude", "--print", "--permission-mode", "plan",
+                        "--output-format", "stream-json", "--verbose"),
                 AssistantLocalAgentRunner.commandFor(claudePlan.arguments()));
         assertEquals(List.of("custom-agent", "--safe"), AssistantLocalAgentRunner.commandFor(custom.arguments()));
     }
@@ -1078,6 +1084,92 @@ class AssistantCommandTest {
                 () -> assertEquals("line one", delivered.get(0)),
                 () -> assertEquals("line two", delivered.get(1)),
                 () -> assertEquals("line three", delivered.get(2)));
+    }
+
+    @Test
+    void structuredClaudeStreamProducesHumanReadableProgressAndParsesTerminalUsage() throws Exception {
+        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+                "Explain this failure", "CLAUDE_CODE", "ASK", ".", "", false);
+        String toolUseEvent = """
+                {"type":"assistant","message":{"content":[{"type":"tool_use","id":"tool_1","name":"shaft_guide_search","input":{}}]}}""";
+        String assistantTextEvent = """
+                {"type":"assistant","message":{"content":[{"type":"text","text":"Looking into the failure now."}]}}""";
+        String terminalEvent = """
+                {"type":"result","subtype":"success","result":"The failure was a stale locator.","usage":{"input_tokens":123,"output_tokens":45}}""";
+        FakeProcess process = FakeProcess.withStdout(
+                String.join("\n", toolUseEvent, assistantTextEvent, terminalEvent) + "\n", 0);
+        List<String> delivered = new CopyOnWriteArrayList<>();
+
+        // requireCommandAvailable=false: this exercises the real claude default command shape without
+        // depending on the claude CLI actually being installed on the test machine's PATH.
+        ShaftMcpInvocation running = AssistantLocalAgentRunner.start(
+                invocation, delivered::add, (command, workingDirectory, environment) -> process, false);
+        ShaftMcpToolResult result = running.future().get(5, TimeUnit.SECONDS);
+
+        AssistantLocalAgentRunner.TokenUsage usage = AssistantLocalAgentRunner.parseTokenUsage(result.output());
+
+        assertAll(
+                () -> assertTrue(result.success()),
+                () -> assertTrue(result.output().contains("The failure was a stale locator.")),
+                () -> assertFalse(delivered.isEmpty()),
+                () -> assertTrue(delivered.stream().anyMatch(line -> line.contains("shaft_guide_search")),
+                        "Expected a human-readable tool_use line: " + delivered),
+                () -> assertTrue(delivered.stream().anyMatch(line -> line.contains("Looking into the failure now.")),
+                        "Expected the assistant text to be delivered: " + delivered),
+                () -> assertTrue(delivered.stream().noneMatch(line -> line.startsWith("{")),
+                        "Consumer lines should be human-readable, not raw JSON: " + delivered),
+                () -> assertEquals(123, usage.inputTokens()),
+                () -> assertEquals(45, usage.outputTokens()),
+                () -> assertFalse(usage.estimated()));
+    }
+
+    @Test
+    void plainProseThroughCustomCommandNeverInventsUsageMetadata() throws Exception {
+        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+                "Explain this failure", "CODEX", "ASK", ".", "stub-agent --print", false);
+        String prose = "Here is the explanation.\nIt spans several lines.\nNo structured data anywhere.";
+        FakeProcess process = FakeProcess.withStdout(prose + "\n", 0);
+
+        ShaftMcpInvocation running = AssistantLocalAgentRunner.start(
+                invocation, line -> { }, (command, workingDirectory, environment) -> process);
+        ShaftMcpToolResult result = running.future().get(5, TimeUnit.SECONDS);
+
+        assertAll(
+                () -> assertTrue(result.success()),
+                () -> assertEquals(prose, result.output()),
+                () -> assertNull(AssistantLocalAgentRunner.parseTokenUsage(result.output())));
+    }
+
+    @Test
+    void bufferedCopilotInvocationSendsExactlyOneHonestLiveOutputNotice() throws Exception {
+        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+                "Explain this failure", "COPILOT_CLI", "ASK", ".", "", false);
+        String bufferedResponse = "The full Copilot answer, delivered only once the process exits.";
+        FakeProcess process = FakeProcess.withStdout(bufferedResponse + "\n", 0);
+        List<String> delivered = new CopyOnWriteArrayList<>();
+
+        // requireCommandAvailable=false: this exercises the real "copilot ask" default command shape
+        // without depending on the copilot CLI actually being installed on the test machine's PATH.
+        ShaftMcpInvocation running = AssistantLocalAgentRunner.start(
+                invocation, delivered::add, (command, workingDirectory, environment) -> process, false);
+        ShaftMcpToolResult result = running.future().get(5, TimeUnit.SECONDS);
+
+        assertAll(
+                () -> assertTrue(result.success()),
+                () -> assertEquals(1, delivered.size(), "Expected exactly one notice line: " + delivered),
+                () -> assertTrue(delivered.get(0).toLowerCase(Locale.ROOT).contains("live output"),
+                        "Notice should explain live output is unavailable: " + delivered.get(0)),
+                () -> assertTrue(result.output().contains(bufferedResponse)));
+    }
+
+    @Test
+    void stripTrailingUsageMetadataRemovesUsageLineButKeepsProseAndAnswerText() {
+        String withUsage = "The answer text.\n\n{\"usage\":{\"input_tokens\":123,\"output_tokens\":45}}";
+        String plainProse = "Just a plain multi-line\nanswer with no usage metadata.";
+
+        assertAll(
+                () -> assertEquals("The answer text.", AssistantLocalAgentRunner.stripTrailingUsageMetadata(withUsage)),
+                () -> assertEquals(plainProse, AssistantLocalAgentRunner.stripTrailingUsageMetadata(plainProse)));
     }
 
     @Test

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
@@ -97,9 +97,17 @@ class AssistantCommandTest {
                 Never generate raw Selenium code such as WebDriver, ChromeDriver, driver.get(...), driver.findElement(...), or direct WebElement actions.
                 For repeated search-result anchors, scope the locator to the first result container; for DuckDuckGo use `(//article[@data-testid='result'])[1]//a[@data-testid='result-title-a']`.
 
-                open duckduckgo and search for SHAFT Engine""",
+                open duckduckgo and search for SHAFT Engine
+
+                Source edits are approved for this session.
+                You may apply patches, write files, and run filesystem commands needed to make the requested source changes.""",
                 duckDuckGo.arguments().get("prompt").getAsString());
-        assertEquals("use shaft-mcp to open mobile app", alreadyExplicit.arguments().get("prompt").getAsString());
+        assertEquals("""
+                use shaft-mcp to open mobile app
+
+                Source edits are approved for this session.
+                You may apply patches, write files, and run filesystem commands needed to make the requested source changes.""",
+                alreadyExplicit.arguments().get("prompt").getAsString());
         assertEquals("""
                 If this request requires interacting with a browser, page element, or mobile app, use shaft-mcp.
                 For WebDriver browser tasks, call driver_initialize before browser_* tools; do not use Playwright unless requested.
@@ -389,6 +397,40 @@ class AssistantCommandTest {
 
         assertTrue(invocation.arguments().get("prompt").getAsString().contains("Source edits are not enabled for this session"));
         assertTrue(invocation.arguments().get("prompt").getAsString().contains("Do not apply patches"));
+    }
+
+    @Test
+    void agentModeWithSourceEditsAddsAffirmativeSourceApprovalInPrompt() {
+        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+                "Implement this login flow in Java",
+                "CODEX",
+                "AGENT",
+                ".",
+                "",
+                true);
+
+        String prompt = invocation.arguments().get("prompt").getAsString();
+        assertAll(
+                () -> assertTrue(prompt.contains("Source edits are approved for this session"), prompt),
+                () -> assertFalse(prompt.contains("Source edits are not enabled"), prompt));
+    }
+
+    @Test
+    void nonAgentModesOmitSourceMutationConstantsFromPrompt() {
+        AssistantCommand.Invocation askInvocation = AssistantCommand.fromPrompt(
+                "Explain this login flow", "CODEX", "ASK", ".", "", true);
+        AssistantCommand.Invocation planInvocation = AssistantCommand.fromPrompt(
+                "Plan this login flow", "CODEX", "PLAN", ".", "", true);
+
+        assertAll(
+                () -> assertFalse(askInvocation.arguments().get("prompt").getAsString()
+                        .contains("Source edits are not enabled")),
+                () -> assertFalse(askInvocation.arguments().get("prompt").getAsString()
+                        .contains("Source edits are approved")),
+                () -> assertFalse(planInvocation.arguments().get("prompt").getAsString()
+                        .contains("Source edits are not enabled")),
+                () -> assertFalse(planInvocation.arguments().get("prompt").getAsString()
+                        .contains("Source edits are approved")));
     }
 
     @Test

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantChatStateTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantChatStateTest.java
@@ -1,0 +1,74 @@
+package com.shaft.intellij.ui;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShaftAssistantChatStateTest {
+    @Test
+    void newSessionReturnsExistingEmptySessionWithoutCreating() {
+        ShaftAssistantChatState state = new ShaftAssistantChatState();
+        state.newSession();
+        int initialCount = state.sessions().size();
+        String initialActiveId = state.activeSession().id;
+
+        ShaftAssistantChatState.Session result = state.newSession();
+
+        assertAll(
+                () -> assertEquals(initialCount, state.sessions().size(),
+                        "Should not create a new session when active session is empty"),
+                () -> assertEquals(initialActiveId, result.id,
+                        "Should return the existing empty session"),
+                () -> assertTrue(result.messages.isEmpty(),
+                        "Returned session should have no messages"));
+    }
+
+    @Test
+    void newSessionCreatesNewWhenActiveSessionHasMessages() {
+        ShaftAssistantChatState state = new ShaftAssistantChatState();
+        state.append("user", "first message", "{}");
+        int initialCount = state.sessions().size();
+        String initialActiveId = state.activeSession().id;
+
+        ShaftAssistantChatState.Session result = state.newSession();
+
+        assertAll(
+                () -> assertEquals(initialCount + 1, state.sessions().size(),
+                        "Should create a new session when active session has messages"),
+                () -> assertNotEquals(initialActiveId, result.id,
+                        "New session should have a different ID"),
+                () -> assertTrue(result.messages.isEmpty(),
+                        "New session should start with no messages"),
+                () -> assertEquals(result.id, state.activeSession().id,
+                        "New session should become the active session"));
+    }
+
+    @Test
+    void newSessionInMultiSessionStatePreservesPreviousSessions() {
+        ShaftAssistantChatState state = new ShaftAssistantChatState();
+        state.append("user", "session 1 message", "{}");
+        String session1Id = state.activeSession().id;
+
+        state.newSession();
+        state.append("user", "session 2 message", "{}");
+        String session2Id = state.activeSession().id;
+
+        int beforeCount = state.sessions().size();
+        ShaftAssistantChatState.Session result = state.newSession();
+
+        assertAll(
+                () -> assertEquals(beforeCount + 1, state.sessions().size(),
+                        "Should create new session when activating on non-empty session"),
+                () -> assertTrue(state.sessions().stream()
+                        .anyMatch(s -> s.id.equals(session1Id)),
+                        "Previous session 1 should still exist"),
+                () -> assertTrue(state.sessions().stream()
+                        .anyMatch(s -> s.id.equals(session2Id)),
+                        "Previous session 2 should still exist"),
+                () -> assertEquals(result.id, state.activeSession().id,
+                        "Newly created session should be active"));
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -1128,6 +1128,106 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void setupCompleteCallbackCreatesNewSessionBeforeShowingMainView() throws Exception {
+        ShaftAssistantChatState chatState = new ShaftAssistantChatState();
+        chatState.append("user", "previous message", "{}");
+        chatState.append("assistant", "previous answer", "{}");
+        int initialSessionCount = chatState.sessions().size();
+        String previousSessionId = chatState.activeSession().id;
+
+        // Create tool window with unverified MCP settings (shows setup panel)
+        ShaftToolWindowPanel toolWindow = new ShaftToolWindowPanel(fakeProject(chatState), unverifiedMcpSettings());
+
+        // Simulate successful setup and trigger callback by clicking "Start chatting"
+        ShaftMcpSetupPanel setupPanel = setupPanel(toolWindow);
+        assertNotNull(setupPanel);
+        showTestResult(setupPanel, ShaftMcpToolResult.success("Probe OK\nMCP workspace: C:/work/shaft"));
+        JButton startChatting = findByAccessibleName(setupPanel, "Start chatting with SHAFT Assistant", JButton.class);
+        assertNotNull(startChatting);
+        startChatting.doClick();
+
+        assertAll(
+                () -> assertEquals(initialSessionCount + 1, chatState.sessions().size(),
+                        "Setup complete callback should create a new session"),
+                () -> assertTrue(chatState.activeMessages().isEmpty(),
+                        "New active session should have no messages"),
+                () -> assertNotEquals(previousSessionId, chatState.activeSession().id,
+                        "Active session should be the new one"),
+                () -> assertNotNull(findByAccessibleName(toolWindow, "Assistant prompt", JTextComponent.class),
+                        "Main view should be displayed with empty chat"));
+    }
+
+    @Test
+    void setupCompleteDedupGuardPreventsDoubleSessionCreation() throws Exception {
+        ShaftAssistantChatState chatState = new ShaftAssistantChatState();
+        chatState.append("user", "first chat", "{}");
+        chatState.newSession(); // Create empty session
+        int sessionCount = chatState.sessions().size();
+        String activeSessionId = chatState.activeSession().id;
+
+        // Invoke newSession() again while active session is empty
+        ShaftAssistantChatState.Session returned = chatState.newSession();
+
+        assertAll(
+                () -> assertEquals(sessionCount, chatState.sessions().size(),
+                        "Second newSession() on empty active session should not create new session"),
+                () -> assertEquals(activeSessionId, returned.id,
+                        "Should return the existing empty session"),
+                () -> assertEquals(activeSessionId, chatState.activeSession().id,
+                        "Active session ID should remain unchanged"));
+    }
+
+    @Test
+    void newSessionCreatesNewWhenActiveSesionHasMessages() {
+        ShaftAssistantChatState chatState = new ShaftAssistantChatState();
+        chatState.append("user", "existing message", "{}");
+        int initialSessionCount = chatState.sessions().size();
+        String initialActiveId = chatState.activeSession().id;
+
+        ShaftAssistantChatState.Session newSession = chatState.newSession();
+
+        assertAll(
+                () -> assertEquals(initialSessionCount + 1, chatState.sessions().size(),
+                        "Should create new session when active has messages"),
+                () -> assertNotEquals(initialActiveId, newSession.id,
+                        "New session should have different ID"),
+                () -> assertTrue(newSession.messages.isEmpty(),
+                        "New session should be empty"),
+                () -> assertEquals(newSession.id, chatState.activeSession().id,
+                        "New session should become active"));
+    }
+
+    @Test
+    void assistantPanelUiResetWorksWithDedupedSession() throws Exception {
+        ShaftAssistantChatState chatState = new ShaftAssistantChatState();
+        chatState.append("user", "initial prompt", "{}");
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(fakeProject(chatState), blankMcpSettings(), chatState);
+
+        // Simulate clearing the active session and creating a new one (like "New chat" does internally)
+        chatState.clearActiveSession();
+        ShaftAssistantChatState.Session firstClear = chatState.activeSession();
+
+        // Call newSession() twice - second time should reuse the empty session instead of creating a new one
+        chatState.newSession();
+        ShaftAssistantChatState.Session afterFirstNew = chatState.activeSession();
+        int sessionCountAfterFirst = chatState.sessions().size();
+
+        chatState.newSession();
+        ShaftAssistantChatState.Session afterSecondNew = chatState.activeSession();
+        int sessionCountAfterSecond = chatState.sessions().size();
+
+        assertAll(
+                () -> assertTrue(chatState.activeMessages().isEmpty(),
+                        "Chat should be empty after newSession"),
+                () -> assertEquals(sessionCountAfterFirst, sessionCountAfterSecond,
+                        "Second newSession() on empty session should not create new session (dedup guard)"),
+                () -> assertEquals(afterFirstNew.id, afterSecondNew.id,
+                        "After second newSession(), should still be on the same empty session"),
+                () -> assertNotNull(findByAccessibleName(panel, "Assistant prompt", JTextComponent.class),
+                        "UI should still be functional"));
+    }
+
+    @Test
     void assistantKeepsCurrentSessionHistoryInDropdown() {
         ShaftAssistantChatState chatState = new ShaftAssistantChatState();
         chatState.append("user", "first in-memory chat", "{}");
@@ -2311,13 +2411,16 @@ class ShaftPanelSetupTest {
     }
 
     @Test
-    void setupSuccessPreservesExistingAssistantSession() throws Exception {
+    void setupSuccessOpensNewFreshSessionWithoutLosingSessions() throws Exception {
         ShaftSettingsState.Settings settings = blankMcpSettings();
         settings.mcpCommand = "cmd";
         settings.mcpSetupComplete = false;
         Project project = fakeProject();
         ShaftAssistantChatState chatState = new ShaftAssistantChatState();
         chatState.append("user", "Previous assistant conversation", "{}");
+        String previousSessionId = chatState.activeSession().id;
+        int initialSessionCount = chatState.sessions().size();
+
         ShaftToolWindowPanel toolWindow = new ShaftToolWindowPanel(project, settings, readyProbe(), chatState);
 
         ShaftMcpSetupPanel setupPanel = setupPanel(toolWindow);
@@ -2326,7 +2429,16 @@ class ShaftPanelSetupTest {
         clickAccessible(setupPanel, "Start chatting with SHAFT Assistant");
 
         assertAll(
-                () -> assertTrue(transcriptMarkdown(toolWindow).contains("Previous assistant conversation")),
+                () -> assertTrue(chatState.activeMessages().isEmpty(),
+                        "Setup complete should open a fresh (empty) session"),
+                () -> assertNotEquals(previousSessionId, chatState.activeSession().id,
+                        "Should have created a new session"),
+                () -> assertEquals(initialSessionCount + 1, chatState.sessions().size(),
+                        "Previous session should still exist in sessions list"),
+                () -> assertTrue(chatState.sessions().stream().anyMatch(s -> s.id.equals(previousSessionId)),
+                        "Previous session with conversation should still be selectable"),
+                () -> assertFalse(transcriptMarkdown(toolWindow).contains("Previous assistant conversation"),
+                        "Current transcript should show the new empty session, not previous conversation"),
                 () -> assertNull(toolWindowWorkflowSelector(toolWindow)));
     }
 

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -604,13 +604,20 @@ class ShaftPanelSetupTest {
         ShaftAssistantPanel first = new ShaftAssistantPanel(null, settings);
         ShaftAssistantPanel second = new ShaftAssistantPanel(null, settings);
 
+        JComboBox<?> assistantMode = findByAccessibleName(first, "Assistant mode", JComboBox.class);
+        JCheckBox allowEdits = findByAccessibleName(first, "Approve source mutation for Agent mode", JCheckBox.class);
+
         assertAll(
                 () -> assertTrue(containsText(first, "Audit and optimize")),
                 () -> assertTrue(containsText(first, "shaft_guide_search")),
                 () -> assertTrue(containsText(first, "test_automation_scenarios")),
                 () -> assertTrue(containsText(first, "test_code_guardrails_check")),
                 () -> assertFalse(settings.agentGuidanceOptimizationPromptPending),
-                () -> assertFalse(containsText(second, "Audit and optimize")));
+                () -> assertFalse(containsText(second, "Audit and optimize")),
+                () -> assertEquals("PLAN", assistantMode.getSelectedItem(),
+                        "Onboarding optimization prompt should force Plan mode"),
+                () -> assertFalse(allowEdits.isSelected(),
+                        "Onboarding optimization prompt should leave source edits unchecked"));
     }
 
     @Test
@@ -628,6 +635,17 @@ class ShaftPanelSetupTest {
                         .contains("CLAUDE.md, AGENTS.md, .agents/skills/**, .memory/**")),
                 () -> assertTrue(ShaftAssistantPanel.agentGuidanceOptimizationPrompt(copilot)
                         .contains(".github/copilot-instructions.md, AGENTS.md, .github/instructions/**, .github/skills/**, .memory/**")));
+    }
+
+    @Test
+    void guidanceOptimizationPromptRerunInstructionIsUnconditional() {
+        ShaftSettingsState.Settings codex = connectedMcpSettings();
+
+        String prompt = ShaftAssistantPanel.agentGuidanceOptimizationPrompt(codex);
+
+        assertAll(
+                () -> assertFalse(prompt.contains("If source edits are not enabled"), prompt),
+                () -> assertTrue(prompt.contains("validate_agent_setup.py --skip-external"), prompt));
     }
 
     @Test
@@ -2379,6 +2397,84 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void allowSourceMutationSurvivesRunningCycleInAgentModeLocalRoute() {
+        ShaftSettingsState.Settings settings = connectedMcpSettings();
+        settings.advancedUiEnabled = true;
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, settings);
+        JComboBox<?> assistantMode = findByAccessibleName(panel, "Assistant mode", JComboBox.class);
+        JComboBox<?> assistantProviderType = findByAccessibleName(panel, "Assistant provider type", JComboBox.class);
+        JCheckBox allowEdits = findByAccessibleName(panel, "Approve source mutation for Agent mode", JCheckBox.class);
+
+        assistantProviderType.setSelectedItem("LOCAL");
+        assistantMode.setSelectedItem("AGENT");
+        allowEdits.setSelected(true);
+
+        panel.setRunning(true, "Thinking...");
+        panel.setRunning(false, "Ready");
+
+        assertTrue(allowEdits.isSelected(),
+                "Allow source edits should remain selected after a running cycle in Agent mode");
+    }
+
+    @Test
+    void allowSourceMutationUnchecksExactlyOnceWhenModeLeavesAgent() {
+        ShaftSettingsState.Settings settings = connectedMcpSettings();
+        settings.advancedUiEnabled = true;
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, settings);
+        JComboBox<?> assistantMode = findByAccessibleName(panel, "Assistant mode", JComboBox.class);
+        JComboBox<?> assistantProviderType = findByAccessibleName(panel, "Assistant provider type", JComboBox.class);
+        JCheckBox allowEdits = findByAccessibleName(panel, "Approve source mutation for Agent mode", JCheckBox.class);
+
+        assistantProviderType.setSelectedItem("LOCAL");
+        assistantMode.setSelectedItem("AGENT");
+        allowEdits.setSelected(true);
+        assertTrue(allowEdits.isSelected());
+
+        assistantMode.setSelectedItem("ASK");
+        assertFalse(allowEdits.isSelected(), "Switching away from Agent mode should uncheck source edits");
+
+        assistantMode.setSelectedItem("AGENT");
+        allowEdits.setSelected(true);
+        assistantMode.setSelectedItem("PLAN");
+        assertFalse(allowEdits.isSelected(), "Switching to Plan mode should uncheck source edits");
+    }
+
+    @Test
+    void allowSourceMutationUnchecksExactlyOnceWhenCloudForcesModeSwitch() {
+        // The live cloud route is not reachable in this headless test harness: usesCloud()==true
+        // makes updateControlVisibility() call updateCloudKeyStatus(), which needs
+        // ApplicationManager.getApplication() (unavailable without IntelliJ Platform Test Framework
+        // fixtures, which this task's tests must not require/pull in). onModeOrRouteSelectionChanged()
+        // unchecks allowSourceMutation for the newly selected route *before* delegating to
+        // updateControlVisibility(), so the unchecking behavior under test is fully exercised
+        // regardless of whether updateControlVisibility() can complete afterward in this harness.
+        ShaftSettingsState.Settings settings = connectedMcpSettings();
+        settings.advancedUiEnabled = true;
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, settings);
+        JComboBox<?> assistantMode = findByAccessibleName(panel, "Assistant mode", JComboBox.class);
+        JComboBox<?> assistantProviderType = findByAccessibleName(panel, "Assistant provider type", JComboBox.class);
+        JCheckBox allowEdits = findByAccessibleName(panel, "Approve source mutation for Agent mode", JCheckBox.class);
+
+        assistantProviderType.setSelectedItem("LOCAL");
+        assistantMode.setSelectedItem("AGENT");
+        allowEdits.setSelected(true);
+        assertTrue(allowEdits.isSelected());
+
+        // Selecting CLOUD while in Agent mode makes onModeOrRouteSelectionChanged() uncheck the
+        // checkbox immediately, then forces mode back to PLAN inside updateControlVisibility().
+        // updateControlVisibility() itself throws further downstream in this bare harness (missing
+        // ApplicationManager); that is an unrelated, pre-existing environment limitation, not a
+        // re-entrancy bug, so it is tolerated here.
+        try {
+            assistantProviderType.setSelectedItem("CLOUD");
+        } catch (NullPointerException ignoredMissingApplicationManager) {
+            // Expected in this headless harness; see comment above.
+        }
+
+        assertFalse(allowEdits.isSelected(), "Cloud route should uncheck source edits exactly once");
+    }
+
+    @Test
     void assistantAgentModeShowsSourceEditApprovalForLockedDesktopRuntime() {
         ShaftSettingsState.Settings settings = connectedMcpSettings();
         settings.assistantRuntime = "DESKTOP_APP";
@@ -2396,6 +2492,95 @@ class ShaftPanelSetupTest {
         assertAll(
                 () -> assertTrue(allowEdits.isVisible()),
                 () -> assertTrue(allowEdits.isEnabled()));
+    }
+
+    @Test
+    void actionRowButtonsAreLaidOutAfterClearingTranscript() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
+        panel.simulateAppendForTest("user", "Plan a resilient login test", "");
+        panel.simulateAppendForTest("assistant", "Here is a plan.", "raw output");
+
+        layoutPanel(panel);
+        assertActionRowButtonsSaneAfterLayout(panel, true);
+
+        clickAccessible(panel, "Clear assistant transcript");
+        SwingUtilities.invokeAndWait(() -> {
+        });
+        layoutPanel(panel);
+
+        JButton clear = findByAccessibleName(panel, "Clear assistant transcript", JButton.class);
+        JButton copyTranscript = findByAccessibleName(panel, "Copy assistant transcript", JButton.class);
+        JButton rerun = findByAccessibleName(panel, "Rerun last assistant prompt", JButton.class);
+        JButton copyResponse = findByAccessibleName(panel, "Copy last assistant response", JButton.class);
+        assertAll(
+                () -> assertFalse(clear.isVisible(), "Clear should hide once transcript is empty"),
+                () -> assertFalse(copyTranscript.isVisible(), "Copy all should hide once transcript is empty"),
+                () -> assertFalse(rerun.isVisible(), "Rerun should hide once last prompt is cleared"),
+                () -> assertFalse(copyResponse.isVisible(), "Copy response should hide once last response is cleared"));
+        assertActionRowButtonsSaneAfterLayout(panel, false);
+    }
+
+    @Test
+    void actionRowButtonsAreLaidOutAfterAppendingMessages() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
+
+        panel.simulateAppendForTest("user", "Plan a resilient login test", "");
+        SwingUtilities.invokeAndWait(() -> {
+        });
+        panel.simulateAppendForTest("assistant", "Here is a plan.", "raw output");
+        SwingUtilities.invokeAndWait(() -> {
+        });
+        layoutPanel(panel);
+
+        assertActionRowButtonsSaneAfterLayout(panel, true);
+    }
+
+    private static void layoutPanel(ShaftAssistantPanel panel) throws Exception {
+        panel.setBounds(0, 0, 900, 700);
+        SwingUtilities.invokeAndWait(() -> {
+            panel.doLayout();
+            walkComponents(panel, comp -> {
+                if (comp instanceof JComponent jc && comp != panel) {
+                    jc.doLayout();
+                }
+            });
+            panel.validate();
+        });
+    }
+
+    private static void assertActionRowButtonsSaneAfterLayout(ShaftAssistantPanel panel, boolean expectResponseButtonsVisible)
+            throws Exception {
+        JLabel statusLabel = (JLabel) getField(panel, "status");
+        List<JButton> actionRowButtons = List.of(
+                findByAccessibleName(panel, "Copy last assistant response", JButton.class),
+                findByAccessibleName(panel, "Copy last raw assistant response", JButton.class),
+                findByAccessibleName(panel, "Copy assistant transcript", JButton.class),
+                findByAccessibleName(panel, "Clear assistant transcript", JButton.class),
+                findByAccessibleName(panel, "Rerun last assistant prompt", JButton.class),
+                findByAccessibleName(panel, "Reconnect to MCP server", JButton.class),
+                findByAccessibleName(panel, "Cancel assistant request", JButton.class));
+        boolean anyVisible = false;
+        for (JButton button : actionRowButtons) {
+            assertNotNull(button);
+            if (!button.isVisible()) {
+                continue;
+            }
+            anyVisible = true;
+            assertTrue(button.getWidth() > 0,
+                    accessibleName(button) + " should have a positive width after layout");
+            assertTrue(button.getHeight() > 0,
+                    accessibleName(button) + " should have a positive height after layout");
+            java.awt.Rectangle buttonBounds = new java.awt.Rectangle(
+                    SwingUtilities.convertPoint(button.getParent(), button.getLocation(), panel), button.getSize());
+            java.awt.Rectangle statusBounds = new java.awt.Rectangle(
+                    SwingUtilities.convertPoint(statusLabel.getParent(), statusLabel.getLocation(), panel),
+                    statusLabel.getSize());
+            assertFalse(buttonBounds.intersects(statusBounds),
+                    accessibleName(button) + " bounds " + buttonBounds + " should not intersect status bounds " + statusBounds);
+        }
+        if (expectResponseButtonsVisible) {
+            assertTrue(anyVisible, "Expected at least one action-row button to be visible after layout");
+        }
     }
 
     @Test

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -613,9 +613,55 @@ class ShaftPanelSetupTest {
                 () -> assertTrue(findByAccessibleName(panel, "Start chatting with SHAFT Assistant", JButton.class).isVisible()),
                 () -> assertFalse(findByAccessibleName(panel, "Test SHAFT MCP connection", JButton.class).isVisible()),
                 () -> assertTrue(settings.mcpSetupComplete),
-                () -> assertTrue(settings.agentGuidanceOptimizationPromptPending));
+                // fakeProject()'s base path has no AGENTS.md, so the guidance-optimization
+                // prompt (which references a validator only meaningful for a project that
+                // adopted that scaffold) must not be scheduled -- see
+                // setupSuccessSchedulesGuidanceOptimizationPromptOnlyWithAgentsMdScaffold
+                // for the case where the scaffold is present.
+                () -> assertFalse(settings.agentGuidanceOptimizationPromptPending));
         clickAccessible(panel, "Start chatting with SHAFT Assistant");
         assertTrue(connected.get());
+    }
+
+    @Test
+    void setupSuccessSchedulesGuidanceOptimizationPromptOnlyWithAgentsMdScaffold() throws Exception {
+        // Regression test for issue #3363 bug 9: the agent-guidance-optimization
+        // prompt tells the agent to rerun scripts/ci/validate_agent_setup.py, a
+        // validator that only works in a project that has actually adopted the
+        // AGENTS.md scaffold. Scheduling that prompt for any successfully
+        // configured project -- regardless of whether it has that scaffold --
+        // made the agent report back that required config/scaffold files were
+        // missing, because they never existed in the target project at all.
+        Path projectWithoutScaffold = Files.createTempDirectory("shaft-no-scaffold");
+        Path projectWithScaffold = Files.createTempDirectory("shaft-with-scaffold");
+        try {
+            Files.writeString(projectWithScaffold.resolve("AGENTS.md"), "# Guidance\n");
+
+            ShaftSettingsState.Settings withoutScaffoldSettings = unverifiedMcpSettings();
+            ShaftMcpSetupPanel withoutScaffoldPanel = new ShaftMcpSetupPanel(
+                    fakeProject(new ShaftAssistantChatState(), projectWithoutScaffold.toString()),
+                    withoutScaffoldSettings, () -> {
+                    }, readyProbe());
+            showTestResult(withoutScaffoldPanel, ShaftMcpToolResult.success("Probe OK"));
+
+            ShaftSettingsState.Settings withScaffoldSettings = unverifiedMcpSettings();
+            ShaftMcpSetupPanel withScaffoldPanel = new ShaftMcpSetupPanel(
+                    fakeProject(new ShaftAssistantChatState(), projectWithScaffold.toString()),
+                    withScaffoldSettings, () -> {
+                    }, readyProbe());
+            showTestResult(withScaffoldPanel, ShaftMcpToolResult.success("Probe OK"));
+
+            assertAll(
+                    () -> assertFalse(withoutScaffoldSettings.agentGuidanceOptimizationPromptPending,
+                            "No AGENTS.md scaffold: the guidance-optimization prompt must not be scheduled"),
+                    () -> assertTrue(withScaffoldSettings.agentGuidanceOptimizationPromptPending,
+                            "AGENTS.md scaffold present: the guidance-optimization prompt should be scheduled"));
+        } finally {
+            Files.deleteIfExists(projectWithoutScaffold.resolve("AGENTS.md"));
+            Files.deleteIfExists(projectWithoutScaffold);
+            Files.deleteIfExists(projectWithScaffold.resolve("AGENTS.md"));
+            Files.deleteIfExists(projectWithScaffold);
+        }
     }
 
     @Test
@@ -3827,6 +3873,10 @@ class ShaftPanelSetupTest {
     }
 
     private static Project fakeProject(ShaftAssistantChatState assistantChatState) {
+        return fakeProject(assistantChatState, "");
+    }
+
+    private static Project fakeProject(ShaftAssistantChatState assistantChatState, String basePath) {
         return (Project) Proxy.newProxyInstance(Project.class.getClassLoader(), new Class<?>[]{Project.class},
                 (proxy, method, arguments) -> {
                     switch (method.getName()) {
@@ -3836,7 +3886,7 @@ class ShaftPanelSetupTest {
                         case "hashCode":
                             return System.identityHashCode(proxy);
                         case "getBasePath":
-                            return "";
+                            return basePath;
                         case "getName":
                             return "SHAFT test project";
                         case "getService":

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -1363,6 +1363,43 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void assistantStructuredLocalAgentResponseShowsExactReportedTokenCountAndHidesRawUsageJson() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        // Shaped per the R3-T1 contract: an answer followed by a trailing single-line usage JSON,
+        // as produced by AssistantLocalAgentRunner's structured-stream terminal event / finalOutput.
+        String rawResponse = "The failure was a stale locator."
+                + "\n\n{\"usage\":{\"input_tokens\":123,\"output_tokens\":45}}";
+
+        appendStreamingLocalAgentBubble(panel, 101);
+        showAgentResult(panel, 101, ShaftMcpToolResult.success(rawResponse));
+
+        String markdown = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(markdown.contains("The failure was a stale locator."), markdown),
+                () -> assertTrue(markdown.contains("Tokens consumed:"), markdown),
+                () -> assertTrue(markdown.contains("`168`"), markdown),
+                () -> assertTrue(markdown.contains("input: 123"), markdown),
+                () -> assertTrue(markdown.contains("output: 45"), markdown),
+                () -> assertFalse(markdown.contains("(estimated)"), markdown),
+                () -> assertFalse(markdown.contains("input_tokens"), markdown));
+    }
+
+    @Test
+    void assistantFallbackLocalAgentResponseKeepsEstimatedTokenCount() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        String rawResponse = "Here is the explanation.\nIt spans several lines.\nNo structured data anywhere.";
+
+        appendStreamingLocalAgentBubble(panel, 102);
+        showAgentResult(panel, 102, ShaftMcpToolResult.success(rawResponse));
+
+        String markdown = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(markdown.contains("Here is the explanation."), markdown),
+                () -> assertTrue(markdown.matches("(?s).*\\*\\*Tokens consumed:\\*\\* `\\d+` \\(estimated\\).*"),
+                        markdown));
+    }
+
+    @Test
     void assistantKillStopsLocalAgentStreamingImmediately() throws Exception {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
         JCheckBox verbose = findByAccessibleName(panel, "Show verbose agent output", JCheckBox.class);

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -24,7 +24,9 @@ import javax.swing.JLabel;
 import javax.swing.KeyStroke;
 import javax.swing.JList;
 import javax.swing.ListCellRenderer;
+import javax.swing.JMenuItem;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
 import javax.swing.JProgressBar;
 import javax.swing.JScrollPane;
 import javax.swing.JViewport;
@@ -417,6 +419,10 @@ class ShaftPanelSetupTest {
                     () -> assertTrue(command instanceof JBTextArea),
                     () -> assertTrue(((JBTextArea) command).getRows() >= 4),
                     () -> assertFalse(findByAccessibleName(panel, "MCP installer target", JComboBox.class).isVisible()),
+                    () -> assertEquals(6, findByAccessibleName(panel, "MCP installer target", JComboBox.class)
+                            .getItemCount()),
+                    () -> assertEquals("INTELLIJ_PLUGIN", lastComboItem(
+                            findByAccessibleName(panel, "MCP installer target", JComboBox.class))),
                     () -> assertNotNull(findByAccessibleName(panel, "Show manual MCP install target", JCheckBox.class)),
                     () -> assertNotNull(findByAccessibleName(panel, "Copy MCP installer command", JButton.class)),
                     () -> assertNotNull(findByAccessibleName(panel, "Open terminal for MCP installer", JButton.class)),
@@ -464,7 +470,7 @@ class ShaftPanelSetupTest {
     }
 
     @Test
-    void setupPanelUpdatesInstallerCommandForSelectedAssistantClient() {
+    void setupPanelUpdatesInstallerCommandForSelectedAssistantClient() throws Exception {
         ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
         });
         JTextComponent installer = findByAccessibleName(panel, "MCP installer command", JTextComponent.class);
@@ -495,6 +501,41 @@ class ShaftPanelSetupTest {
         manualTarget.doClick();
         target.setSelectedItem("INTELLIJ_PLUGIN");
         assertTrue(installer.getText().contains("intellij-plugin"));
+
+        // Regression lock: INTELLIJ_PLUGIN stays last among exactly the 6 known installer targets.
+        List<String> installerTargetTokens = new ArrayList<>();
+        for (int index = 0; index < target.getItemCount(); index++) {
+            installerTargetTokens.add(String.valueOf(target.getItemAt(index)));
+        }
+        assertAll(
+                () -> assertEquals(6, target.getItemCount()),
+                () -> assertEquals("INTELLIJ_PLUGIN", lastComboItem(target)),
+                () -> assertEquals(List.of("CODEX", "CLAUDE_CODE", "CLAUDE_DESKTOP", "COPILOT_CLI",
+                        "COPILOT_INTELLIJ", "INTELLIJ_PLUGIN"), installerTargetTokens));
+
+        // The disambiguated label must not collapse back to a bare peer-agent name, and the
+        // distinct IDE_PLUGIN runtime token (used by the runtime combo, not this target combo)
+        // must stay unaffected.
+        assertAll(
+                () -> assertEquals("SHAFT IntelliJ plugin (this plugin only - no external agent)",
+                        ShaftUiLabels.friendly("INTELLIJ_PLUGIN")),
+                () -> assertNotEquals("SHAFT IntelliJ plugin", ShaftUiLabels.friendly("INTELLIJ_PLUGIN")),
+                () -> assertEquals("IDE plugin", ShaftUiLabels.friendly("IDE_PLUGIN")));
+
+        // installerArgumentFor()/installerCommandFor() must keep producing the exact same
+        // --client argument strings as before for every known installer target token.
+        assertAll(
+                () -> assertEquals("codex", installerArgumentFor("CODEX")),
+                () -> assertEquals("claude", installerArgumentFor("CLAUDE_CODE")),
+                () -> assertEquals("claude-desktop", installerArgumentFor("CLAUDE_DESKTOP")),
+                () -> assertEquals("copilot", installerArgumentFor("COPILOT_CLI")),
+                () -> assertEquals("copilot-intellij", installerArgumentFor("COPILOT_INTELLIJ")),
+                () -> assertEquals("intellij-plugin", installerArgumentFor("INTELLIJ_PLUGIN")));
+        for (String token : installerTargetTokens) {
+            String argument = installerArgumentFor(token);
+            String command = installerCommandFor(argument);
+            assertTrue(command.contains(argument), command);
+        }
     }
 
     @Test
@@ -509,6 +550,7 @@ class ShaftPanelSetupTest {
         assertAll(
                 () -> assertEquals("CODEX", family.getSelectedItem()),
                 () -> assertEquals("CODEX", target.getSelectedItem()),
+                () -> assertEquals("INTELLIJ_PLUGIN", lastComboItem(target)),
                 () -> assertTrue(containsText(panel, "Recommended: Claude Code CLI detected")));
     }
 
@@ -2166,6 +2208,90 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void assistantTranscriptMessagePaneShowsContextMenuWithCopyActionsAndSurvivesRerender() {
+        AssistantTranscriptView transcript = new AssistantTranscriptView();
+        transcript.append("assistant", "First response");
+
+        JEditorPane firstPane = transcriptHtmlPanes(transcript).get(0);
+        MouseListener listener = transcriptContextMenuListener(firstPane);
+        assertNotNull(listener, "Context menu listener should be installed in fallbackHtmlPane");
+
+        listener.mouseReleased(popupTriggerEvent(firstPane));
+        JPopupMenu menu = transcript.lastMessageContextMenuForTest();
+        assertNotNull(menu);
+        JMenuItem copyItem = findByAccessibleName(menu, "Copy", JMenuItem.class);
+        JMenuItem selectAllItem = findByAccessibleName(menu, "Select All", JMenuItem.class);
+        JMenuItem copyFullTranscriptItem = findByAccessibleName(menu, "Copy full transcript", JMenuItem.class);
+
+        assertAll(
+                () -> assertEquals(3, menu.getComponentCount()),
+                () -> assertNotNull(copyItem),
+                () -> assertFalse(copyItem.isEnabled(), "Copy should be disabled without a selection"),
+                () -> assertNotNull(selectAllItem),
+                () -> assertTrue(selectAllItem.isEnabled()),
+                () -> assertNotNull(copyFullTranscriptItem),
+                () -> assertTrue(copyFullTranscriptItem.isEnabled()));
+
+        firstPane.select(0, firstPane.getDocument().getLength());
+        listener.mouseReleased(popupTriggerEvent(firstPane));
+        JMenuItem copyItemAfterSelection = findByAccessibleName(
+                transcript.lastMessageContextMenuForTest(), "Copy", JMenuItem.class);
+        assertTrue(copyItemAfterSelection.isEnabled(), "Copy should be enabled once the pane has a selection");
+
+        transcript.append("assistant", "Second response");
+        List<JEditorPane> panesAfterRerender = transcriptHtmlPanes(transcript);
+        JEditorPane newestPane = panesAfterRerender.get(panesAfterRerender.size() - 1);
+        MouseListener listenerAfterRerender = transcriptContextMenuListener(newestPane);
+        assertNotNull(listenerAfterRerender, "Context menu should survive a transcript re-render");
+
+        listenerAfterRerender.mouseReleased(popupTriggerEvent(newestPane));
+        assertEquals(3, transcript.lastMessageContextMenuForTest().getComponentCount());
+    }
+
+    @Test
+    void assistantTranscriptContextMenuIgnoresNonPopupTriggerEvents() {
+        AssistantTranscriptView transcript = new AssistantTranscriptView();
+        transcript.append("assistant", "Response");
+        JEditorPane pane = transcriptHtmlPanes(transcript).get(0);
+        MouseListener listener = transcriptContextMenuListener(pane);
+        assertNotNull(listener);
+
+        MouseEvent plainClick = new MouseEvent(pane, MouseEvent.MOUSE_RELEASED, System.currentTimeMillis(),
+                InputEvent.BUTTON1_DOWN_MASK, 4, 4, 1, false, MouseEvent.BUTTON1);
+        listener.mousePressed(plainClick);
+        listener.mouseReleased(plainClick);
+
+        assertNull(transcript.lastMessageContextMenuForTest());
+    }
+
+    @Test
+    void assistantTranscriptCopyFullTranscriptContextMenuItemReusesCopyButtonExportPath() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
+        showAssistantResult(panel, ShaftMcpToolResult.success("Rendered assistant output"));
+        AssistantTranscriptView view = getTranscriptView(panel);
+        assertNotNull(view);
+
+        String expectedExport = assistantExport(panel);
+        assertTrue(expectedExport.contains("Rendered assistant output"));
+
+        AtomicInteger invocations = new AtomicInteger();
+        view.setCopyFullTranscriptAction(invocations::incrementAndGet);
+
+        List<JEditorPane> panes = transcriptHtmlPanes(view);
+        JEditorPane pane = panes.get(panes.size() - 1);
+        MouseListener listener = transcriptContextMenuListener(pane);
+        assertNotNull(listener);
+        listener.mouseReleased(popupTriggerEvent(pane));
+
+        JMenuItem copyFullTranscriptItem = findByAccessibleName(
+                view.lastMessageContextMenuForTest(), "Copy full transcript", JMenuItem.class);
+        assertNotNull(copyFullTranscriptItem);
+        copyFullTranscriptItem.doClick();
+
+        assertEquals(1, invocations.get());
+    }
+
+    @Test
     void assistantTranscriptCodeCopyControlDoesNotPaintRectangularOutline() {
         AssistantTranscriptView transcript = new AssistantTranscriptView();
         transcript.append("assistant", """
@@ -3014,6 +3140,20 @@ class ShaftPanelSetupTest {
         return panes;
     }
 
+    private static MouseListener transcriptContextMenuListener(JEditorPane pane) {
+        for (MouseListener listener : pane.getMouseListeners()) {
+            if (listener instanceof AssistantTranscriptView.TranscriptContextMenuListener) {
+                return listener;
+            }
+        }
+        return null;
+    }
+
+    private static MouseEvent popupTriggerEvent(JEditorPane pane) {
+        return new MouseEvent(pane, MouseEvent.MOUSE_RELEASED, System.currentTimeMillis(),
+                InputEvent.BUTTON3_DOWN_MASK, 6, 6, 1, true, MouseEvent.BUTTON3);
+    }
+
     private static void collectTranscriptHtmlPanes(Component component, List<JEditorPane> panes) {
         if (component instanceof JEditorPane pane
                 && pane.getClientProperty(AssistantTranscriptView.TRANSCRIPT_RENDERED_HTML_PROPERTY) != null) {
@@ -3580,6 +3720,22 @@ class ShaftPanelSetupTest {
             }
         }
         return false;
+    }
+
+    private static Object lastComboItem(JComboBox<?> comboBox) {
+        return comboBox.getItemAt(comboBox.getItemCount() - 1);
+    }
+
+    private static String installerArgumentFor(String target) throws Exception {
+        Method method = ShaftMcpSetupPanel.class.getDeclaredMethod("installerArgumentFor", String.class);
+        method.setAccessible(true);
+        return (String) method.invoke(null, target);
+    }
+
+    private static String installerCommandFor(String argument) throws Exception {
+        Method method = ShaftMcpSetupPanel.class.getDeclaredMethod("installerCommandFor", String.class);
+        method.setAccessible(true);
+        return (String) method.invoke(null, argument);
     }
 
     private static boolean listContains(JList<?> list, String expectedText) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -3933,4 +3933,162 @@ class ShaftPanelSetupTest {
             }
         }
     }
+
+    // ------------------------------------------------------------------
+    // Round 5 (issue #3363) capstone: walks the entire onboarding journey
+    // -- setup -> install command -> Start chatting -> agent-mode consent
+    // -> verbose streaming/token count -> Clear -> right-click context menu
+    // -> New chat -- in one ordered flow, so a future regression in any of
+    // Rounds 1-4's fixes fails here even if a narrower unit test is ever
+    // weakened or deleted.
+    // ------------------------------------------------------------------
+    @Test
+    void onboardingJourneyCoversSetupThroughNewChatWithoutRegressingAnyRoundFix() throws Exception {
+        // Step 1: setup view shown. Pre-seed a prior session so step 3's
+        // fresh-session assertion isn't vacuously true.
+        ShaftAssistantChatState chatState = new ShaftAssistantChatState();
+        chatState.append("user", "previous onboarding message", "{}");
+        chatState.append("assistant", "previous onboarding answer", "{}");
+        int sessionsBeforeStartChatting = chatState.sessions().size();
+
+        // readyProbe() stub, never the real AssistantLocalAgentRunner::readiness probe --
+        // that real probe checks for an actual agent CLI on PATH and made a Round 2 test
+        // pass locally but fail on clean CI runners; every construction here must stay
+        // deterministic regardless of what's installed on the machine running it.
+        ShaftToolWindowPanel toolWindow = new ShaftToolWindowPanel(
+                fakeProject(chatState), unverifiedMcpSettings(), readyProbe(), chatState);
+        ShaftMcpSetupPanel setupPanel = setupPanel(toolWindow);
+        assertNotNull(setupPanel, "Unverified MCP settings must show the setup panel first");
+
+        // Step 2: install command contract -- must never auto-suggest intellij-plugin
+        // by default (Round 4 fix) and must reference a real installer script.
+        JTextComponent installerCommandField =
+                findByAccessibleName(setupPanel, "MCP installer command", JTextComponent.class);
+        assertNotNull(installerCommandField);
+        String installerCommandText = installerCommandField.getText();
+        assertAll(
+                () -> assertFalse(installerCommandText.contains("-Client intellij-plugin"),
+                        "Round 4 fix: the setup panel must never auto-suggest the intellij-plugin target: "
+                                + installerCommandText),
+                () -> assertTrue(installerCommandText.contains("install-shaft-mcp"),
+                        "Installer command must reference a real installer script: " + installerCommandText));
+
+        // Step 3: Check -> Start chatting must open a fresh session (Round 2 fix).
+        showTestResult(setupPanel, ShaftMcpToolResult.success("Probe OK\nMCP workspace: C:/work/shaft"));
+        JButton startChatting =
+                findByAccessibleName(setupPanel, "Start chatting with SHAFT Assistant", JButton.class);
+        assertNotNull(startChatting);
+        startChatting.doClick();
+
+        assertAll(
+                () -> assertEquals(sessionsBeforeStartChatting + 1, chatState.sessions().size(),
+                        "Round 2 fix: Start chatting must create exactly one new session"),
+                () -> assertTrue(chatState.activeMessages().isEmpty(),
+                        "Round 2 fix: the new active session must start empty"),
+                () -> assertNotNull(findByAccessibleName(toolWindow, "Assistant prompt", JTextComponent.class),
+                        "Round 2 fix: the main view must be shown with an empty prompt after Start chatting"));
+
+        ShaftAssistantPanel assistantPanel = findAssistantPanel(toolWindow);
+        assertNotNull(assistantPanel, "Main view should now host the Assistant panel");
+
+        // Step 4: agent-mode consent integrity (Round 2 fix, both defects).
+        JComboBox<?> assistantMode = findByAccessibleName(assistantPanel, "Assistant mode", JComboBox.class);
+        JCheckBox allowEdits =
+                findByAccessibleName(assistantPanel, "Approve source mutation for Agent mode", JCheckBox.class);
+        assistantMode.setSelectedItem("AGENT");
+        allowEdits.setSelected(true);
+
+        // A run-state cycle that is NOT itself a user-driven mode change must not
+        // silently reset the checkbox (Round 2 defect A).
+        assistantPanel.setRunning(true, "Thinking...");
+        assistantPanel.setRunning(false, "Ready");
+        assertTrue(allowEdits.isSelected(),
+                "Round 2 fix: Allow source edits must survive a running cycle that isn't a mode change");
+
+        // The constructed prompt must carry an affirmative, unconditional instruction
+        // once edits are truly enabled (Round 2 defect B).
+        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+                "Implement this login flow in Java", "CODEX", "AGENT", ".", "", true);
+        String agentPromptText = invocation.arguments().get("prompt").getAsString();
+        assertAll(
+                () -> assertTrue(agentPromptText.contains("Source edits are approved for this session"),
+                        "Round 2 fix: prompt must carry an affirmative source-edit instruction: " + agentPromptText),
+                () -> assertFalse(agentPromptText.contains("Source edits are not enabled"),
+                        "Round 2 fix: prompt must not carry the unresolved negative conditional: " + agentPromptText));
+
+        // Step 5: verbose streaming shows real progress, and a structured response
+        // reports an exact token count with no "(estimated)" fallback (Round 3 fix).
+        JCheckBox verboseOutput =
+                findByAccessibleName(assistantPanel, "Show verbose agent output", JCheckBox.class);
+        verboseOutput.setSelected(true);
+        appendStreamingLocalAgentBubble(assistantPanel, 555);
+        appendLocalAgentOutput(assistantPanel, 555, "intermediate progress line");
+
+        // While streaming is in progress the interim line must be visible (Round 3 fix)
+        // -- it is later superseded by the final answer once the result finalizes the
+        // bubble, so this must be checked before showAgentResult(), not after.
+        assertTrue(transcriptMarkdown(assistantPanel).contains("intermediate progress line"),
+                "Round 3 fix: verbose streaming must show real progress, not just the static placeholder");
+
+        String rawResponse = "The login flow now handles expired sessions."
+                + "\n\n{\"usage\":{\"input_tokens\":210,\"output_tokens\":64}}";
+        showAgentResult(assistantPanel, 555, ShaftMcpToolResult.success(rawResponse));
+
+        String markdownAfterAgentRun = transcriptMarkdown(assistantPanel);
+        assertAll(
+                () -> assertTrue(markdownAfterAgentRun.contains("The login flow now handles expired sessions."),
+                        markdownAfterAgentRun),
+                () -> assertTrue(markdownAfterAgentRun.contains("`274`"),
+                        "Round 3 fix: exact token count (210 + 64) must be shown: " + markdownAfterAgentRun),
+                () -> assertFalse(markdownAfterAgentRun.contains("(estimated)"),
+                        "Round 3 fix: a structured response must not fall back to the estimate"));
+
+        // Step 6: Clear must not leave the action row visually broken (Round 2 fix).
+        clickAccessible(assistantPanel, "Clear assistant transcript");
+        layoutPanel(assistantPanel);
+        assertActionRowButtonsSaneAfterLayout(assistantPanel, false);
+
+        // Step 7: right-click context menu on the transcript (Round 4 fix). Re-populate
+        // the transcript first -- Clear left it empty, and there must be a rendered
+        // message pane to right-click on.
+        assistantPanel.simulateAppendForTest("assistant", "Rendered assistant output for the journey test", "");
+        AssistantTranscriptView transcriptView = getTranscriptView(assistantPanel);
+        assertNotNull(transcriptView);
+        List<JEditorPane> panes = transcriptHtmlPanes(transcriptView);
+        assertFalse(panes.isEmpty(), "Expected at least one rendered transcript pane after re-populating");
+        JEditorPane lastPane = panes.get(panes.size() - 1);
+        MouseListener contextMenuListener = transcriptContextMenuListener(lastPane);
+        assertNotNull(contextMenuListener, "Round 4 fix: transcript panes must install a context-menu listener");
+        contextMenuListener.mouseReleased(popupTriggerEvent(lastPane));
+        JPopupMenu contextMenu = transcriptView.lastMessageContextMenuForTest();
+        assertAll(
+                () -> assertNotNull(findByAccessibleName(contextMenu, "Copy", JMenuItem.class),
+                        "Round 4 fix: transcript context menu must offer Copy"),
+                () -> assertNotNull(findByAccessibleName(contextMenu, "Select All", JMenuItem.class),
+                        "Round 4 fix: transcript context menu must offer Select All"),
+                () -> assertNotNull(findByAccessibleName(contextMenu, "Copy full transcript", JMenuItem.class),
+                        "Round 4 fix: transcript context menu must offer Copy full transcript"));
+
+        // Step 8: New chat -- fresh transcript, cleared prompt, no session data lost
+        // across the whole journey.
+        assistantPrompt(assistantPanel).setText("stray text that must be cleared by New chat");
+        click(assistantPanel, "New chat");
+
+        assertAll(
+                () -> assertTrue(transcriptMarkdown(assistantPanel).isBlank(),
+                        "New chat must clear the visible transcript"),
+                () -> assertTrue(assistantPrompt(assistantPanel).getText().isBlank(),
+                        "New chat must clear the prompt field"),
+                () -> assertEquals(sessionsBeforeStartChatting + 2, chatState.sessions().size(),
+                        "New chat must not lose any prior session across the whole journey"));
+    }
+
+    private static ShaftAssistantPanel findAssistantPanel(ShaftToolWindowPanel toolWindow) {
+        for (Component component : toolWindow.getComponents()) {
+            if (component instanceof ShaftAssistantPanel assistant) {
+                return assistant;
+            }
+        }
+        return null;
+    }
 }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -1154,8 +1154,13 @@ class ShaftPanelSetupTest {
         int initialSessionCount = chatState.sessions().size();
         String previousSessionId = chatState.activeSession().id;
 
-        // Create tool window with unverified MCP settings (shows setup panel)
-        ShaftToolWindowPanel toolWindow = new ShaftToolWindowPanel(fakeProject(chatState), unverifiedMcpSettings());
+        // Create tool window with unverified MCP settings (shows setup panel). Use the stubbed
+        // readyProbe() rather than the real AssistantLocalAgentRunner::readiness default -- that
+        // real probe checks whether an actual agent CLI is installed on PATH, which made this test
+        // pass or fail depending on the machine running it (installed locally, absent on clean CI
+        // runners) instead of testing the session-reset behavior it's meant to cover.
+        ShaftToolWindowPanel toolWindow = new ShaftToolWindowPanel(
+                fakeProject(chatState), unverifiedMcpSettings(), readyProbe(), chatState);
 
         // Simulate successful setup and trigger callback by clicking "Start chatting"
         ShaftMcpSetupPanel setupPanel = setupPanel(toolWindow);
@@ -1224,7 +1229,6 @@ class ShaftPanelSetupTest {
 
         // Simulate clearing the active session and creating a new one (like "New chat" does internally)
         chatState.clearActiveSession();
-        ShaftAssistantChatState.Session firstClear = chatState.activeSession();
 
         // Call newSession() twice - second time should reuse the empty session instead of creating a new one
         chatState.newSession();

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -28,6 +28,7 @@ import javax.swing.JPanel;
 import javax.swing.JProgressBar;
 import javax.swing.JScrollPane;
 import javax.swing.JViewport;
+import javax.swing.RepaintManager;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import java.awt.BorderLayout;
@@ -2430,13 +2431,25 @@ class ShaftPanelSetupTest {
         allowEdits.setSelected(true);
         assertTrue(allowEdits.isSelected());
 
+        AtomicInteger uncheckCount = new AtomicInteger();
+        allowEdits.addItemListener(event -> {
+            if (!allowEdits.isSelected()) {
+                uncheckCount.incrementAndGet();
+            }
+        });
+
         assistantMode.setSelectedItem("ASK");
-        assertFalse(allowEdits.isSelected(), "Switching away from Agent mode should uncheck source edits");
+        assertAll(
+                () -> assertFalse(allowEdits.isSelected(), "Switching away from Agent mode should uncheck source edits"),
+                () -> assertEquals(1, uncheckCount.get(), "Uncheck should fire exactly once, no listener re-entrancy loop"));
 
         assistantMode.setSelectedItem("AGENT");
         allowEdits.setSelected(true);
+        uncheckCount.set(0);
         assistantMode.setSelectedItem("PLAN");
-        assertFalse(allowEdits.isSelected(), "Switching to Plan mode should uncheck source edits");
+        assertAll(
+                () -> assertFalse(allowEdits.isSelected(), "Switching to Plan mode should uncheck source edits"),
+                () -> assertEquals(1, uncheckCount.get(), "Uncheck should fire exactly once, no listener re-entrancy loop"));
     }
 
     @Test
@@ -2444,10 +2457,12 @@ class ShaftPanelSetupTest {
         // The live cloud route is not reachable in this headless test harness: usesCloud()==true
         // makes updateControlVisibility() call updateCloudKeyStatus(), which needs
         // ApplicationManager.getApplication() (unavailable without IntelliJ Platform Test Framework
-        // fixtures, which this task's tests must not require/pull in). onModeOrRouteSelectionChanged()
-        // unchecks allowSourceMutation for the newly selected route *before* delegating to
-        // updateControlVisibility(), so the unchecking behavior under test is fully exercised
-        // regardless of whether updateControlVisibility() can complete afterward in this harness.
+        // fixtures, which this task's tests must not require/pull in). updateControlVisibility()
+        // forces mode back to PLAN (the behavior this test proves) *before* it reaches
+        // updateCloudKeyStatus(), so the NPE from the missing ApplicationManager happens strictly
+        // after both effects under test (uncheck + forced PLAN switch) have already taken place.
+        // The try/catch below only swallows that trailing, unrelated environment limitation; every
+        // assertion about the behavior under test runs after the mutation that can throw.
         ShaftSettingsState.Settings settings = connectedMcpSettings();
         settings.advancedUiEnabled = true;
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, settings);
@@ -2459,19 +2474,33 @@ class ShaftPanelSetupTest {
         assistantMode.setSelectedItem("AGENT");
         allowEdits.setSelected(true);
         assertTrue(allowEdits.isSelected());
+        assertEquals("AGENT", assistantMode.getSelectedItem());
+
+        AtomicInteger uncheckCount = new AtomicInteger();
+        allowEdits.addItemListener(event -> {
+            if (!allowEdits.isSelected()) {
+                uncheckCount.incrementAndGet();
+            }
+        });
 
         // Selecting CLOUD while in Agent mode makes onModeOrRouteSelectionChanged() uncheck the
-        // checkbox immediately, then forces mode back to PLAN inside updateControlVisibility().
-        // updateControlVisibility() itself throws further downstream in this bare harness (missing
-        // ApplicationManager); that is an unrelated, pre-existing environment limitation, not a
-        // re-entrancy bug, so it is tolerated here.
+        // checkbox immediately, then delegates to updateControlVisibility(), which forces mode back
+        // to PLAN before it reaches the cloud-key-status lookup that NPEs in this bare harness
+        // (missing ApplicationManager). That NPE is an unrelated, pre-existing environment
+        // limitation, not a re-entrancy bug, so it is tolerated here -- but only after the mode
+        // switch to PLAN has already happened, which the assertions below verify end-to-end.
         try {
             assistantProviderType.setSelectedItem("CLOUD");
         } catch (NullPointerException ignoredMissingApplicationManager) {
             // Expected in this headless harness; see comment above.
         }
 
-        assertFalse(allowEdits.isSelected(), "Cloud route should uncheck source edits exactly once");
+        assertAll(
+                () -> assertFalse(allowEdits.isSelected(), "Cloud route should uncheck source edits exactly once"),
+                () -> assertEquals(1, uncheckCount.get(),
+                        "Source edits checkbox should uncheck exactly once with no listener re-entrancy loop"),
+                () -> assertEquals("PLAN", assistantMode.getSelectedItem(),
+                        "Forcing cloud route while in Agent mode should switch mode to PLAN end-to-end"));
     }
 
     @Test
@@ -2503,10 +2532,23 @@ class ShaftPanelSetupTest {
         layoutPanel(panel);
         assertActionRowButtonsSaneAfterLayout(panel, true);
 
-        clickAccessible(panel, "Clear assistant transcript");
-        SwingUtilities.invokeAndWait(() -> {
-        });
-        layoutPanel(panel);
+        RevalidateSpy spy = RevalidateSpy.install();
+        try {
+            clickAccessible(panel, "Clear assistant transcript");
+            SwingUtilities.invokeAndWait(() -> {
+            });
+        } finally {
+            spy.uninstall();
+        }
+        assertTrue(spy.sawRevalidateFor(actionRowContainer(panel)),
+                "updateActionChrome() should revalidate the action row's container after Clear,"
+                        + " without relying on the test's manual layout walk");
+
+        // Do NOT call the manual layoutPanel() walker before asserting bounds here: that helper
+        // forces doLayout()/validate() on every component regardless of production behavior, which
+        // would make this assertion pass even if updateActionChrome()'s revalidate()/repaint() call
+        // were deleted. Instead, flush the revalidate/repaint that production code already scheduled.
+        flushPendingLayoutAndRepaint(panel);
 
         JButton clear = findByAccessibleName(panel, "Clear assistant transcript", JButton.class);
         JButton copyTranscript = findByAccessibleName(panel, "Copy assistant transcript", JButton.class);
@@ -2523,16 +2565,92 @@ class ShaftPanelSetupTest {
     @Test
     void actionRowButtonsAreLaidOutAfterAppendingMessages() throws Exception {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
-
-        panel.simulateAppendForTest("user", "Plan a resilient login test", "");
-        SwingUtilities.invokeAndWait(() -> {
-        });
-        panel.simulateAppendForTest("assistant", "Here is a plan.", "raw output");
-        SwingUtilities.invokeAndWait(() -> {
-        });
         layoutPanel(panel);
 
+        RevalidateSpy spy = RevalidateSpy.install();
+        try {
+            panel.simulateAppendForTest("user", "Plan a resilient login test", "");
+            SwingUtilities.invokeAndWait(() -> {
+            });
+            panel.simulateAppendForTest("assistant", "Here is a plan.", "raw output");
+            SwingUtilities.invokeAndWait(() -> {
+            });
+        } finally {
+            spy.uninstall();
+        }
+        assertTrue(spy.sawRevalidateFor(actionRowContainer(panel)),
+                "updateActionChrome() should revalidate the action row's container after appending"
+                        + " messages (a non-Clear caller), proving the fix lives in updateActionChrome()"
+                        + " rather than being Clear-specific");
+
+        // Same rationale as above: flush the production-scheduled revalidate/repaint instead of
+        // forcing layout manually, so a deleted refreshActionRowLayout() call would fail this test.
+        flushPendingLayoutAndRepaint(panel);
+
         assertActionRowButtonsSaneAfterLayout(panel, true);
+    }
+
+    /**
+     * Resolves the same container that {@code ShaftAssistantPanel.refreshActionRowLayout()}
+     * revalidates/repaints: the action row's parent, falling back to the action row itself.
+     */
+    private static Container actionRowContainer(ShaftAssistantPanel panel) throws Exception {
+        JPanel actionRow = (JPanel) getField(panel, "actionRow");
+        Container parent = actionRow.getParent();
+        return parent != null ? parent : actionRow;
+    }
+
+    /**
+     * Flushes a revalidate()/repaint() that production code already scheduled (via
+     * {@code RepaintManager}) into an actual layout pass. The spy assertion (run before this method)
+     * is what keeps the test sensitive to a deleted {@code refreshActionRowLayout()} call; this
+     * method's job is only to produce realized bounds afterward, so it mirrors {@link
+     * #layoutPanel(ShaftAssistantPanel)}'s recursive doLayout()/validate() walk rather than relying
+     * on {@code Container.validate()} to recurse into every nested panel on its own.
+     */
+    private static void flushPendingLayoutAndRepaint(ShaftAssistantPanel panel) throws Exception {
+        layoutPanel(panel);
+    }
+
+    /**
+     * A {@link RepaintManager} that records exactly which components had {@code revalidate()}
+     * invoked on them (via {@code addInvalidComponent}), so tests can assert that production code
+     * itself requested a layout refresh instead of relying on a test helper that forces layout
+     * unconditionally. Deliberately does NOT track {@code addDirtyRegion} (repaint): a plain
+     * {@link javax.swing.AbstractButton#doClick()} already marks the unrealized top-level panel
+     * dirty as a side effect of the button's own pressed/armed paint state (Swing's default
+     * RepaintManager walks up to the nearest showing-or-root ancestor), which would make a
+     * repaint-based check pass trivially even with no production revalidate/repaint call at all.
+     * revalidate() does not have that false-positive: only an explicit
+     * {@code JComponent.revalidate()} call adds the exact component to the invalid-component list.
+     */
+    private static final class RevalidateSpy extends RepaintManager {
+        private final RepaintManager delegate;
+        private final List<Component> invalidated = new ArrayList<>();
+
+        private RevalidateSpy(RepaintManager delegate) {
+            this.delegate = delegate;
+        }
+
+        static RevalidateSpy install() {
+            RevalidateSpy spy = new RevalidateSpy(RepaintManager.currentManager(null));
+            RepaintManager.setCurrentManager(spy);
+            return spy;
+        }
+
+        void uninstall() {
+            RepaintManager.setCurrentManager(delegate);
+        }
+
+        boolean sawRevalidateFor(Component target) {
+            return invalidated.contains(target);
+        }
+
+        @Override
+        public synchronized void addInvalidComponent(JComponent invalidComponent) {
+            invalidated.add(invalidComponent);
+            delegate.addInvalidComponent(invalidComponent);
+        }
     }
 
     private static void layoutPanel(ShaftAssistantPanel panel) throws Exception {

--- a/tests/scripts/test_install_shaft_mcp.py
+++ b/tests/scripts/test_install_shaft_mcp.py
@@ -98,6 +98,22 @@ class InstallShaftMcpTest(unittest.TestCase):
     def test_intellij_plugin_target_does_not_configure_external_client(self):
         MODULE.configure_client("intellij-plugin", Path("java"), Path("shaft-mcp.args"))
 
+    def test_has_agent_guidance_scaffold_requires_agents_md(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+
+            self.assertFalse(MODULE.has_agent_guidance_scaffold(root))
+
+            (root / "AGENTS.md").write_text("# Guidance\n", encoding="utf-8")
+            self.assertTrue(MODULE.has_agent_guidance_scaffold(root))
+
+    def test_agent_validation_script_files_includes_guidance_budget(self):
+        # Regression test for issue #3363 bug 9: a fresh onboarding install used to
+        # copy the validator scripts without the budget config they require,
+        # making the onboarding-referenced `validate_agent_setup.py` crash with
+        # FileNotFoundError on any project that installed them.
+        self.assertIn("scripts/ci/agent_guidance_budget.json", MODULE.AGENT_VALIDATION_SCRIPT_FILES)
+
     def test_render_client_menu_groups_ai_agents_and_advanced_sections(self):
         lines = MODULE.render_client_menu()
 

--- a/tests/scripts/test_install_shaft_mcp.py
+++ b/tests/scripts/test_install_shaft_mcp.py
@@ -40,6 +40,24 @@ def temporary_current_directory(path: Path):
         os.chdir(original)
 
 
+class _InteractiveStdin(io.StringIO):
+    """A StringIO that reports isatty() == True, so choose_client() reads
+    scripted answers via input() instead of failing the non-interactive check."""
+
+    def isatty(self) -> bool:
+        return True
+
+
+@contextlib.contextmanager
+def scripted_stdin(answer: str):
+    original_stdin = MODULE.sys.stdin
+    MODULE.sys.stdin = _InteractiveStdin(f"{answer}\n")
+    try:
+        yield
+    finally:
+        MODULE.sys.stdin = original_stdin
+
+
 class InstallShaftMcpTest(unittest.TestCase):
     def test_banner_is_not_repeated_after_bootstrap_banner(self):
         with temporary_environment(SHAFT_MCP_BOOTSTRAP_BANNER_SHOWN="1"):
@@ -79,6 +97,59 @@ class InstallShaftMcpTest(unittest.TestCase):
 
     def test_intellij_plugin_target_does_not_configure_external_client(self):
         MODULE.configure_client("intellij-plugin", Path("java"), Path("shaft-mcp.args"))
+
+    def test_render_client_menu_groups_ai_agents_and_advanced_sections(self):
+        lines = MODULE.render_client_menu()
+
+        self.assertIn("AI agents:", lines)
+        self.assertIn("Advanced / IDE integration:", lines)
+        ai_agents_index = lines.index("AI agents:")
+        advanced_index = lines.index("Advanced / IDE integration:")
+        self.assertLess(ai_agents_index, advanced_index)
+
+        # The intellij-plugin entry's label must appear only after the
+        # second (advanced) header, never mixed into the AI agents group.
+        plugin_label = dict(MODULE.TARGET_CHOICES)["intellij-plugin"]
+        label_line_indexes = [index for index, line in enumerate(lines) if plugin_label in line]
+        self.assertEqual(1, len(label_line_indexes))
+        self.assertGreater(label_line_indexes[0], advanced_index)
+
+        # Numbered entries stay contiguous 1..6, in TARGET_CHOICES order,
+        # regardless of which section they were printed under.
+        numbered_lines = [line.strip() for line in lines if line.strip()[:1].isdigit()]
+        expected_numbered_lines = [
+            f"{index}. {label}" for index, (_, label) in enumerate(MODULE.TARGET_CHOICES, start=1)
+        ]
+        self.assertEqual(expected_numbered_lines, numbered_lines)
+
+        # A one-line clarifier explains the plugin entry is unnecessary from
+        # inside the plugin's own guided setup.
+        self.assertTrue(
+            any(
+                "plugin's own MCP command" in line and "guided setup" in line
+                for line in lines
+            ),
+            f"Expected a clarifier line in: {lines}",
+        )
+
+    def test_choose_client_numeric_and_name_input_resolve_to_same_target(self):
+        results = []
+        for answer in ("6", "intellij-plugin"):
+            with scripted_stdin(answer):
+                with contextlib.redirect_stdout(io.StringIO()):
+                    results.append(MODULE.choose_client())
+
+        self.assertEqual(["intellij-plugin", "intellij-plugin"], results)
+
+    def test_choose_client_prints_the_grouped_menu(self):
+        stdout = io.StringIO()
+        with scripted_stdin("6"):
+            with contextlib.redirect_stdout(stdout):
+                MODULE.choose_client()
+
+        printed_lines = stdout.getvalue().splitlines()
+        for line in MODULE.render_client_menu():
+            self.assertIn(line, printed_lines)
 
     def test_unattended_install_defaults_to_shaft_skills(self):
         args = MODULE.parse_args(["--intellij-plugin"])

--- a/tests/scripts/test_install_shaft_mcp.py
+++ b/tests/scripts/test_install_shaft_mcp.py
@@ -106,7 +106,11 @@ class InstallShaftMcpTest(unittest.TestCase):
             with temporary_current_directory(root):
                 installed = MODULE.install_shaft_skills(Path.cwd(), root / "bootstrap")
 
-            self.assertEqual(root / MODULE.SHAFT_SKILLS_DIRECTORY, installed)
+            # Compare resolved paths: os.chdir(root) followed by Path.cwd() inside
+            # install_shaft_skills returns the OS's canonicalized cwd (symlinks resolved on
+            # macOS, short 8.3 names expanded on Windows), which textually differs from the
+            # unresolved `root` built from tempfile.TemporaryDirectory() on those platforms.
+            self.assertEqual((root / MODULE.SHAFT_SKILLS_DIRECTORY).resolve(), installed.resolve())
             self.assertTrue((installed / "writing-shaft-tests" / "SKILL.md").is_file())
             self.assertTrue((installed / "recording-shaft-tests-with-mcp" / "agents" / "openai.yaml").is_file())
 

--- a/tests/scripts/test_validate_installer_contract.py
+++ b/tests/scripts/test_validate_installer_contract.py
@@ -1,0 +1,280 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "validate_installer_contract.py"
+SPEC = importlib.util.spec_from_file_location("validate_installer_contract", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+if SPEC.loader is None:
+    raise ImportError(f"Unable to load {MODULE_PATH}")
+SPEC.loader.exec_module(MODULE)
+
+
+class ValidateInstallerContractTest(unittest.TestCase):
+    def test_valid_contract_passes(self):
+        """In-sync targets, Java mapping, and scripts should pass."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "scripts" / "mcp").mkdir(parents=True, exist_ok=True)
+            (root / "shaft-intellij" / "src" / "main" / "java" / "com" / "shaft" / "intellij" / "ui").mkdir(
+                parents=True, exist_ok=True)
+
+            # Write matching Python TARGETS
+            py_installer = root / "scripts/mcp/install_shaft_mcp.py"
+            py_installer.write_text(
+                'TARGETS = ("codex", "claude", "claude-desktop", "copilot", "copilot-intellij", "intellij-plugin")\n',
+                encoding="utf-8"
+            )
+
+            # Write matching Java installerArgumentFor
+            java_setup = root / "shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java"
+            java_setup.write_text(
+                '''
+                private static final String[] INSTALLER_TARGETS = {
+                    "CODEX",
+                    "CLAUDE_CODE",
+                    "CLAUDE_DESKTOP",
+                    "COPILOT_CLI",
+                    "COPILOT_INTELLIJ",
+                    "INTELLIJ_PLUGIN"
+                };
+
+                private static String installerArgumentFor(String target) {
+                    return switch (normalize(target, "CODEX")) {
+                        case "CLAUDE_CODE" -> "claude";
+                        case "CLAUDE_DESKTOP" -> "claude-desktop";
+                        case "COPILOT_CLI" -> "copilot";
+                        case "COPILOT_INTELLIJ" -> "copilot-intellij";
+                        case "INTELLIJ_PLUGIN" -> "intellij-plugin";
+                        default -> "codex";
+                    };
+                }
+                ''',
+                encoding="utf-8"
+            )
+
+            # Write installer scripts
+            (root / "scripts/mcp/install-shaft-mcp.ps1").write_text("# PowerShell installer", encoding="utf-8")
+            (root / "scripts/mcp/install-shaft-mcp.sh").write_text("#!/bin/bash\n# Shell installer", encoding="utf-8")
+
+            # Write a minimal Java file referencing the installer command
+            java_setup.write_text(
+                '''
+                private static final String[] INSTALLER_TARGETS = {
+                    "CODEX",
+                    "CLAUDE_CODE",
+                    "CLAUDE_DESKTOP",
+                    "COPILOT_CLI",
+                    "COPILOT_INTELLIJ",
+                    "INTELLIJ_PLUGIN"
+                };
+
+                private static String installerArgumentFor(String target) {
+                    return switch (normalize(target, "CODEX")) {
+                        case "CLAUDE_CODE" -> "claude";
+                        case "CLAUDE_DESKTOP" -> "claude-desktop";
+                        case "COPILOT_CLI" -> "copilot";
+                        case "COPILOT_INTELLIJ" -> "copilot-intellij";
+                        case "INTELLIJ_PLUGIN" -> "intellij-plugin";
+                        default -> "codex";
+                    };
+                }
+
+                private static String installerCommandFor(String target) {
+                    String url = "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main"
+                            + "/scripts/mcp/install-shaft-mcp";
+                    if (isWindows()) {
+                        return "powershell ...";
+                    }
+                    return "curl ... " + url + ".sh";
+                }
+                ''',
+                encoding="utf-8"
+            )
+
+            errors = MODULE.validate(root)
+            self.assertEqual([], errors, f"Unexpected errors: {errors}")
+
+    def test_target_missing_from_targets_fails(self):
+        """A target in Java mapping but missing from TARGETS should fail."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "scripts" / "mcp").mkdir(parents=True, exist_ok=True)
+            (root / "shaft-intellij" / "src" / "main" / "java" / "com" / "shaft" / "intellij" / "ui").mkdir(
+                parents=True, exist_ok=True)
+
+            # Write Python TARGETS missing "extra-target"
+            py_installer = root / "scripts/mcp/install_shaft_mcp.py"
+            py_installer.write_text(
+                'TARGETS = ("codex", "claude", "claude-desktop")\n',
+                encoding="utf-8"
+            )
+
+            # Write Java with extra target that maps to something
+            java_setup = root / "shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java"
+            java_setup.write_text(
+                '''
+                private static final String[] INSTALLER_TARGETS = {
+                    "CODEX",
+                    "CLAUDE_CODE",
+                    "CLAUDE_DESKTOP",
+                    "COPILOT_CLI"
+                };
+
+                private static String installerArgumentFor(String target) {
+                    return switch (normalize(target, "CODEX")) {
+                        case "CLAUDE_CODE" -> "claude";
+                        case "CLAUDE_DESKTOP" -> "claude-desktop";
+                        case "COPILOT_CLI" -> "copilot";
+                        default -> "codex";
+                    };
+                }
+
+                private static String installerCommandFor(String target) {
+                    return "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/scripts/mcp/install-shaft-mcp";
+                }
+                ''',
+                encoding="utf-8"
+            )
+
+            # Write installer scripts
+            (root / "scripts/mcp/install-shaft-mcp.ps1").write_text("# PowerShell", encoding="utf-8")
+            (root / "scripts/mcp/install-shaft-mcp.sh").write_text("#!/bin/bash", encoding="utf-8")
+
+            errors = MODULE.validate(root)
+            self.assertTrue(any("copilot" in e.lower() and "missing from TARGETS" in e for e in errors),
+                            f"Expected error about missing copilot target in TARGETS, got: {errors}")
+
+    def test_target_missing_from_java_mapping_fails(self):
+        """A target in TARGETS but missing from Java mapping should fail."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "scripts" / "mcp").mkdir(parents=True, exist_ok=True)
+            (root / "shaft-intellij" / "src" / "main" / "java" / "com" / "shaft" / "intellij" / "ui").mkdir(
+                parents=True, exist_ok=True)
+
+            # Write Python TARGETS with extra target
+            py_installer = root / "scripts/mcp/install_shaft_mcp.py"
+            py_installer.write_text(
+                'TARGETS = ("codex", "claude", "missing-target")\n',
+                encoding="utf-8"
+            )
+
+            # Write Java missing the mapping
+            java_setup = root / "shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java"
+            java_setup.write_text(
+                '''
+                private static final String[] INSTALLER_TARGETS = {
+                    "CODEX",
+                    "CLAUDE_CODE"
+                };
+
+                private static String installerArgumentFor(String target) {
+                    return switch (normalize(target, "CODEX")) {
+                        case "CLAUDE_CODE" -> "claude";
+                        default -> "codex";
+                    };
+                }
+
+                private static String installerCommandFor(String target) {
+                    return "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/scripts/mcp/install-shaft-mcp";
+                }
+                ''',
+                encoding="utf-8"
+            )
+
+            # Write installer scripts
+            (root / "scripts/mcp/install-shaft-mcp.ps1").write_text("# PowerShell", encoding="utf-8")
+            (root / "scripts/mcp/install-shaft-mcp.sh").write_text("#!/bin/bash", encoding="utf-8")
+
+            errors = MODULE.validate(root)
+            self.assertTrue(any("missing-target" in e.lower() and "missing from installerArgumentFor" in e for e in errors),
+                            f"Expected error about missing-target missing from Java mapping, got: {errors}")
+
+    def test_missing_installer_script_fails(self):
+        """Missing .ps1 or .sh installer script should fail."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "scripts" / "mcp").mkdir(parents=True, exist_ok=True)
+            (root / "shaft-intellij" / "src" / "main" / "java" / "com" / "shaft" / "intellij" / "ui").mkdir(
+                parents=True, exist_ok=True)
+
+            # Write valid matching Python and Java
+            py_installer = root / "scripts/mcp/install_shaft_mcp.py"
+            py_installer.write_text(
+                'TARGETS = ("codex", "claude")\n',
+                encoding="utf-8"
+            )
+
+            java_setup = root / "shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java"
+            java_setup.write_text(
+                '''
+                private static final String[] INSTALLER_TARGETS = {
+                    "CODEX",
+                    "CLAUDE_CODE"
+                };
+
+                private static String installerArgumentFor(String target) {
+                    return switch (normalize(target, "CODEX")) {
+                        case "CLAUDE_CODE" -> "claude";
+                        default -> "codex";
+                    };
+                }
+
+                private static String installerCommandFor(String target) {
+                    return "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/scripts/mcp/install-shaft-mcp";
+                }
+                ''',
+                encoding="utf-8"
+            )
+
+            # Only write .ps1, not .sh
+            (root / "scripts/mcp/install-shaft-mcp.ps1").write_text("# PowerShell", encoding="utf-8")
+
+            errors = MODULE.validate(root)
+            self.assertTrue(any("install-shaft-mcp.sh" in e and "missing" in e.lower() for e in errors),
+                            f"Expected error about missing .sh script, got: {errors}")
+
+    def test_parse_targets_extracts_all_targets(self):
+        """Parsing TARGETS should extract all quoted strings from tuple."""
+        with tempfile.TemporaryDirectory() as tmp:
+            py_file = Path(tmp) / "install.py"
+            py_file.write_text(
+                'TARGETS = ("target1", "target2", "target3")\n',
+                encoding="utf-8"
+            )
+
+            targets = MODULE.parse_targets_from_python(py_file)
+            self.assertEqual({"target1", "target2", "target3"}, targets)
+
+    def test_parse_installer_targets_handles_default_arm(self):
+        """Parsing Java should handle default -> "codex" arm without literal CODEX case."""
+        with tempfile.TemporaryDirectory() as tmp:
+            java_file = Path(tmp) / "Setup.java"
+            java_file.write_text(
+                '''
+                private static final String[] INSTALLER_TARGETS = {
+                    "CODEX",
+                    "CLAUDE_CODE"
+                };
+
+                private static String installerArgumentFor(String target) {
+                    return switch (normalize(target, "CODEX")) {
+                        case "CLAUDE_CODE" -> "claude";
+                        default -> "codex";
+                    };
+                }
+                ''',
+                encoding="utf-8"
+            )
+
+            mapping = MODULE.parse_installer_targets_from_java(java_file)
+            # CODEX should be mapped to "codex" via the default arm
+            self.assertEqual("codex", mapping.get("CODEX"))
+            self.assertEqual("claude", mapping.get("CLAUDE_CODE"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes the IntelliJ plugin onboarding flow reported in #3363, landing in sequential rounds on this one branch/PR per repo convention. Now covers all 10 originally-reported bugs plus a systemic CI gap and a capstone regression test.

## Fixes
- [x] **Round 1 — CI gate**: `scripts/mcp/**` had zero PR-blocking CI. Added a PR-blocking installer-verification job (21 existing unit tests + a new `validate_installer_contract.py` + the existing end-to-end `verify_shaft_mcp_installer_release.py`).
- [x] **Round 2 — chat/session bugs**: "Start chatting" now always opens a fresh session; the Clear-button action row is revalidated/repainted after visibility toggles; the "Allow source edits" prompt now carries an affirmative, checkbox-accurate instruction instead of an unresolved static conditional.
- [x] **Round 3 — streaming/token-count**: Claude/Codex local-agent invocations use structured incremental output, so verbose mode shows real progress and token counts are exact whenever the CLI reports real usage. Honest fallback estimate preserved for Copilot/custom commands.
- [x] **Round 4 — UX polish**: installer client menu grouped into "AI agents" vs "Advanced / IDE integration"; setup panel's plugin entry disambiguated and kept last; chat transcript has a right-click context menu (Copy / Select All / Copy full transcript).
- [x] **Bug 9 (installer pushes SHAFT-internal validators onto arbitrary projects)**: the onboarding agent reported required guidance-validator config/scaffold as "missing" -- reproduced empirically (the validator suite crashes even with the missing budget file added, since it also expects README.md/host-context files/etc. that only exist in a project that already adopted this scaffold). Fixed by only installing/prompting for this validator suite when the target project already has an `AGENTS.md` scaffold, and by including the previously-missing `agent_guidance_budget.json` for projects that do.
- [x] **CI-failure fixes + review findings**: fixed a test that depended on a real (uninstalled-in-CI) agent-readiness probe instead of the existing stub, a cross-platform path-comparison bug in a pre-existing installer test (macOS symlink resolution / Windows 8.3 short names), and 2 inline code-review findings (null-guard, unused variable).
- [x] **Capstone regression test**: `onboardingJourneyCoversSetupThroughNewChatWithoutRegressingAnyRoundFix` walks the entire onboarding flow in one ordered test, so a future regression in any of these fixes fails here even if a narrower unit test is ever weakened or deleted. Runs under the existing `gradle -p shaft-intellij check` -- already both the PR gate and the release gate.

## Independent review
This PR underwent an independent Opus-model review pass that reproduced bug 9 empirically before it was fixed, and re-verified all other fixes against the original issue and real test runs (not just static review).

## Test plan
- [x] `gradle -p shaft-intellij check buildPlugin verifyPlugin` (the actual CI command) — BUILD SUCCESSFUL, plugin verified compatible against both IU-243 and IU-262
- [x] Full Python installer suite (26/26) + contract validator (6/6)
- [x] Full `gradle test` for shaft-intellij (120 tests in ShaftPanelSetupTest alone) — all green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>