### PR TITLE
IntelliJ plugin: Gemini cloud provider setup + model/effort selection (#3369)

### DIFF
--- a/shaft-intellij/build.gradle.kts
+++ b/shaft-intellij/build.gradle.kts
@@ -103,5 +103,8 @@ tasks {
         systemProperty("shaft.intellij.screenshotDir", System.getProperty("shaft.intellij.screenshotDir", ""))
         systemProperty("shaft.intellij.liveGemini", System.getProperty("shaft.intellij.liveGemini", "false"))
         systemProperty("shaft.intellij.liveMcpCommand", System.getProperty("shaft.intellij.liveMcpCommand", ""))
+        systemProperty("shaft.intellij.workspaceRoot", System.getProperty("shaft.intellij.workspaceRoot", ".."))
+        systemProperty("shaft.intellij.liveGeminiModel",
+                System.getProperty("shaft.intellij.liveGeminiModel", "gemini-3.5-flash"))
     }
 }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsState.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsState.java
@@ -45,6 +45,8 @@ public final class ShaftSettingsState implements PersistentStateComponent<ShaftS
         public String assistantRuntime = "CLI";
         public String cloudProvider = "gemini";
         public String cloudModel = "gemini-3.5-flash";
+        public String localModel = "";
+        public String assistantEffort = "DEFAULT";
         public String defaultAutobotClient = "CODEX";
         public String defaultAutobotMode = "ASK";
         public String pilotAiProvider = "none";

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -451,8 +451,15 @@ final class AssistantCommand {
         JsonObject arguments = new JsonObject();
         arguments.addProperty("client", selection.client());
         arguments.addProperty("mode", mode);
-        arguments.addProperty("prompt", localAgentPrompt(text, mode, allowSourceMutation, openFileContext,
-                conversationContext));
+        arguments.addProperty("model", selection.localModel());
+        arguments.addProperty("effort", selection.effort());
+        // Codex receives the effort as a real CLI config flag in AssistantLocalAgentRunner; the
+        // other CLIs have no effort flag, so their prompt carries the preference instead.
+        String localPrompt = localAgentPrompt(text, mode, allowSourceMutation, openFileContext,
+                conversationContext);
+        arguments.addProperty("prompt", "CODEX".equals(selection.family())
+                ? localPrompt
+                : withEffortHint(localPrompt, selection.effort()));
         arguments.addProperty("workingDirectory", workingDirectory == null ? "" : workingDirectory);
         arguments.add("command", commandArray(customCommand));
         arguments.add("environment", new JsonObject());
@@ -472,7 +479,8 @@ final class AssistantCommand {
         arguments.addProperty("provider", selection.cloudProvider());
         arguments.addProperty("model", selection.cloudModel());
         arguments.addProperty("mode", mode);
-        arguments.addProperty("prompt", cloudPrompt(text, mode, openFileContext, conversationContext));
+        arguments.addProperty("prompt",
+                withEffortHint(cloudPrompt(text, mode, openFileContext, conversationContext), selection.effort()));
         arguments.addProperty("workingDirectory", workingDirectory == null ? "" : workingDirectory);
         arguments.addProperty("timeoutSeconds", DEFAULT_TIMEOUT_SECONDS);
         arguments.addProperty("allowSourceMutation", false);
@@ -1583,6 +1591,13 @@ final class AssistantCommand {
                 "duckduckgo");
     }
 
+    private static String withEffortHint(String prompt, String effort) {
+        if (!AssistantModelCatalog.isExplicitEffort(effort)) {
+            return prompt;
+        }
+        return "Use " + effort.toLowerCase(Locale.ROOT) + " reasoning effort for this request.\n\n" + prompt;
+    }
+
     private static String withConversationContext(String prompt, String conversationContext) {
         String context = text(conversationContext);
         if (context.isBlank()) {
@@ -1973,14 +1988,31 @@ final class AssistantCommand {
         }
     }
 
-    record Selection(boolean cloud, String family, String runtime, String cloudProvider, String cloudModel) {
+    record Selection(boolean cloud, String family, String runtime, String cloudProvider, String cloudModel,
+                     String localModel, String effort) {
         static Selection local(String family, String runtime) {
-            return new Selection(false, normalize(family, "CODEX"), normalize(runtime, "CLI"), "", "");
+            return local(family, runtime, "", "");
+        }
+
+        static Selection local(String family, String runtime, String model, String effort) {
+            return new Selection(false, normalize(family, "CODEX"), normalize(runtime, "CLI"), "", "",
+                    model == null ? "" : model.trim(), normalizeEffort(effort));
         }
 
         static Selection cloud(String provider, String model) {
+            return cloud(provider, model, "");
+        }
+
+        static Selection cloud(String provider, String model, String effort) {
             return new Selection(true, "", "", normalize(provider, "gemini").toLowerCase(Locale.ROOT),
-                    model == null ? "" : model.trim());
+                    model == null ? "" : model.trim(), "", normalizeEffort(effort));
+        }
+
+        private static String normalizeEffort(String effort) {
+            String normalized = normalize(effort, AssistantModelCatalog.DEFAULT_EFFORT);
+            return AssistantModelCatalog.isExplicitEffort(normalized)
+                    ? normalized
+                    : AssistantModelCatalog.DEFAULT_EFFORT;
         }
 
         static Selection fromClient(String client) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
@@ -177,10 +177,12 @@ final class AssistantLocalAgentRunner {
         }
         boolean allowSourceMutation = allowSourceMutation(arguments);
         String mode = normalize(string(arguments, "mode", "ASK"));
+        String model = string(arguments, "model", "").trim();
+        String effort = normalize(string(arguments, "effort", ""));
         return switch (normalize(string(arguments, "client", "CODEX"))) {
-            case "CLAUDE_CODE" -> claudeCommand(mode, allowSourceMutation);
-            case "COPILOT_CLI" -> copilotCommand(mode, allowSourceMutation);
-            default -> codexCommand(mode, allowSourceMutation);
+            case "CLAUDE_CODE" -> claudeCommand(mode, allowSourceMutation, model);
+            case "COPILOT_CLI" -> copilotCommand(mode, allowSourceMutation, model);
+            default -> codexCommand(mode, allowSourceMutation, model, effort);
         };
     }
 
@@ -503,17 +505,27 @@ final class AssistantLocalAgentRunner {
      * drift between Codex CLI releases, so the NDJSON parser in {@link #run} is deliberately
      * tolerant: unrecognized event types or fields are skipped rather than treated as errors.
      */
-    private static List<String> codexCommand(String mode, boolean allowSourceMutation) {
-        return switch (mode) {
-            case "AGENT" -> List.of(
-                    "codex", "exec",
-                    "--sandbox", allowSourceMutation ? "workspace-write" : "read-only",
-                    "-c", "mcp_servers.shaft-mcp.default_tools_approval_mode=\"approve\"",
-                    "-c", "mcp_servers.shaft-mcp.tool_timeout_sec=600",
-                    "--json",
-                    "-");
-            default -> List.of("codex", "exec", "--sandbox", "read-only", "--json", "-");
-        };
+    private static List<String> codexCommand(String mode, boolean allowSourceMutation, String model, String effort) {
+        List<String> command = new ArrayList<>(List.of("codex", "exec"));
+        if (!model.isBlank()) {
+            command.add("--model");
+            command.add(model);
+        }
+        if (AssistantModelCatalog.isExplicitEffort(effort)) {
+            command.add("-c");
+            command.add("model_reasoning_effort=\"" + effort.toLowerCase(Locale.ROOT) + "\"");
+        }
+        command.add("--sandbox");
+        command.add("AGENT".equals(mode) && allowSourceMutation ? "workspace-write" : "read-only");
+        if ("AGENT".equals(mode)) {
+            command.add("-c");
+            command.add("mcp_servers.shaft-mcp.default_tools_approval_mode=\"approve\"");
+            command.add("-c");
+            command.add("mcp_servers.shaft-mcp.tool_timeout_sec=600");
+        }
+        command.add("--json");
+        command.add("-");
+        return List.copyOf(command);
     }
 
     /**
@@ -521,22 +533,35 @@ final class AssistantLocalAgentRunner {
      * {@code --print} (the CLI rejects the combination otherwise), so every mode below carries both
      * flags together to receive incremental NDJSON events instead of a single buffered blob.
      */
-    private static List<String> claudeCommand(String mode, boolean allowSourceMutation) {
-        return switch (mode) {
-            case "PLAN" -> List.of("claude", "--print", "--permission-mode", "plan",
-                    "--output-format", "stream-json", "--verbose");
-            case "AGENT" -> List.of("claude", "--print", "--permission-mode", allowSourceMutation ? "acceptEdits" : "plan",
-                    "--output-format", "stream-json", "--verbose");
-            default -> List.of("claude", "--print", "--output-format", "stream-json", "--verbose");
-        };
+    private static List<String> claudeCommand(String mode, boolean allowSourceMutation, String model) {
+        List<String> command = new ArrayList<>(List.of("claude", "--print"));
+        if (!model.isBlank()) {
+            command.add("--model");
+            command.add(model);
+        }
+        if ("PLAN".equals(mode) || "AGENT".equals(mode)) {
+            command.add("--permission-mode");
+            command.add("AGENT".equals(mode) && allowSourceMutation ? "acceptEdits" : "plan");
+        }
+        command.add("--output-format");
+        command.add("stream-json");
+        command.add("--verbose");
+        return List.copyOf(command);
     }
 
-    private static List<String> copilotCommand(String mode, boolean allowSourceMutation) {
-        return switch (mode) {
-            case "PLAN" -> List.of("copilot", "plan");
-            case "AGENT" -> List.of("copilot", allowSourceMutation ? "agent" : "ask");
-            default -> List.of("copilot", "ask");
-        };
+    private static List<String> copilotCommand(String mode, boolean allowSourceMutation, String model) {
+        List<String> command = new ArrayList<>();
+        command.add("copilot");
+        command.add(switch (mode) {
+            case "PLAN" -> "plan";
+            case "AGENT" -> allowSourceMutation ? "agent" : "ask";
+            default -> "ask";
+        });
+        if (!model.isBlank()) {
+            command.add("--model");
+            command.add(model);
+        }
+        return List.copyOf(command);
     }
 
     /**

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantModelCatalog.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantModelCatalog.java
@@ -1,0 +1,91 @@
+package com.shaft.intellij.ui;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Curated model and effort-level choices for the Assistant chat view.
+ *
+ * <p>Live CLI listings win when a local agent can report its own models; these lists keep the
+ * model selector useful when a cloud provider or CLI cannot list models. Model combos stay
+ * editable so newer model names can always be typed in.</p>
+ */
+final class AssistantModelCatalog {
+    static final String DEFAULT_EFFORT = "DEFAULT";
+    private static final List<String> EFFORT_LEVELS = List.of(DEFAULT_EFFORT, "LOW", "MEDIUM", "HIGH");
+    private static final List<String> CLAUDE_MODELS =
+            List.of("claude-fable-5", "claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5");
+
+    private AssistantModelCatalog() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Returns the suggested models for a cloud provider selected in the Assistant chat view.
+     *
+     * @param provider cloud provider identifier: gemini, openai, anthropic, or github
+     * @return non-empty model list, most capable defaults first
+     */
+    static List<String> cloudModels(String provider) {
+        return switch (normalizeLower(provider)) {
+            case "openai" -> List.of("gpt-5.2", "gpt-5.2-codex", "gpt-5.1", "gpt-5.1-mini");
+            case "anthropic" -> CLAUDE_MODELS;
+            case "github" -> List.of("openai/gpt-4.1", "openai/gpt-4.1-mini", "openai/gpt-4o");
+            default -> List.of("gemini-3.5-flash", "gemini-3.5-pro", "gemini-3-flash", "gemini-3-pro");
+        };
+    }
+
+    /**
+     * Returns the fallback models for a local agent family when its CLI cannot report a model
+     * list of its own.
+     *
+     * @param family local assistant family: CODEX, CLAUDE, or COPILOT
+     * @return non-empty model list, most capable defaults first
+     */
+    static List<String> localModels(String family) {
+        return switch (normalizeUpper(family)) {
+            case "CLAUDE" -> CLAUDE_MODELS;
+            case "COPILOT" -> List.of("gpt-5.2", "claude-sonnet-5", "gemini-3.5-pro");
+            default -> List.of("gpt-5.2-codex", "gpt-5.2", "gpt-5.1-codex-mini");
+        };
+    }
+
+    /**
+     * Returns the default model preselected for a cloud provider.
+     *
+     * @param provider cloud provider identifier
+     * @return first catalog model for the provider
+     */
+    static String defaultCloudModel(String provider) {
+        return cloudModels(provider).get(0);
+    }
+
+    /**
+     * Returns the selectable reasoning-effort levels, with {@link #DEFAULT_EFFORT} first.
+     *
+     * @return effort-level tokens
+     */
+    static List<String> effortLevels() {
+        return EFFORT_LEVELS;
+    }
+
+    /**
+     * Indicates whether an effort token is an explicit (non-default) level that should be
+     * forwarded to the selected model.
+     *
+     * @param effort effort token
+     * @return true for LOW, MEDIUM, or HIGH
+     */
+    static boolean isExplicitEffort(String effort) {
+        String normalized = normalizeUpper(effort);
+        return !normalized.isBlank() && !DEFAULT_EFFORT.equals(normalized) && EFFORT_LEVELS.contains(normalized);
+    }
+
+    private static String normalizeLower(String value) {
+        return value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private static String normalizeUpper(String value) {
+        return value == null ? "" : value.trim().toUpperCase(Locale.ROOT).replace('-', '_').replace(' ', '_');
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantModelCatalog.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantModelCatalog.java
@@ -31,7 +31,7 @@ final class AssistantModelCatalog {
             case "openai" -> List.of("gpt-5.2", "gpt-5.2-codex", "gpt-5.1", "gpt-5.1-mini");
             case "anthropic" -> CLAUDE_MODELS;
             case "github" -> List.of("openai/gpt-4.1", "openai/gpt-4.1-mini", "openai/gpt-4o");
-            default -> List.of("gemini-3.5-flash", "gemini-3.5-pro", "gemini-3-flash", "gemini-3-pro");
+            default -> List.of("gemini-3.5-flash", "gemini-2.5-flash", "gemini-2.5-pro", "gemini-flash-latest");
         };
     }
 

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -89,8 +89,9 @@ final class ShaftAssistantPanel extends JPanel {
     private final JComboBox<String> assistantFamily;
     private final JComboBox<String> assistantRuntime;
     private final JComboBox<String> cloudProvider;
-    private final JBTextField cloudModel;
+    private final JComboBox<String> cloudModel;
     private final JComboBox<String> localModel;
+    private final JComboBox<String> effort;
     private final JBTextField customCommand;
     private final JPanel cloudKeyPanel;
     private final JPasswordField cloudApiKey;
@@ -290,12 +291,15 @@ final class ShaftAssistantPanel extends JPanel {
                 "Read-only assistant agent configuration from the completed MCP setup flow.");
         cloudProvider = combo("Assistant cloud provider", "gemini", "openai", "anthropic", "github");
         cloudProvider.setSelectedItem(normalizeLower(settings.cloudProvider, "gemini"));
-        cloudModel = new JBTextField();
-        cloudModel.setColumns(16);
-        cloudModel.getEmptyText().setText("model");
+        cloudModel = new JComboBox<>();
+        cloudModel.setEditable(true);
         cloudModel.getAccessibleContext().setAccessibleName("Assistant cloud model");
-        cloudModel.setToolTipText("Optional provider model override");
-        cloudModel.setText(settings.cloudModel == null ? "" : settings.cloudModel);
+        cloudModel.setToolTipText("Models available for the selected cloud provider; type any other model name");
+        if (cloudModel.getEditor().getEditorComponent() instanceof JTextComponent cloudModelEditor) {
+            cloudModelEditor.getAccessibleContext().setAccessibleName("Assistant cloud model text");
+            cloudModelEditor.setToolTipText("Models available for the selected cloud provider; type any other model name");
+        }
+        applyCloudModelChoices(settings.cloudModel);
         localModel = new JComboBox<>();
         localModel.setEditable(true);
         localModel.getAccessibleContext().setAccessibleName("Assistant local agent model");
@@ -304,6 +308,13 @@ final class ShaftAssistantPanel extends JPanel {
             localModelEditor.getAccessibleContext().setAccessibleName("Assistant local agent model text");
             localModelEditor.setToolTipText("Model reported by the connected agent CLI");
         }
+        // Seed the selector from the curated catalog so it is never empty; the async CLI listing
+        // replaces these entries when the connected agent can report its own models.
+        applyLocalModels(resolveFamily(settings), List.of());
+        modelListFamily = "";
+        effort = combo("Assistant effort", AssistantModelCatalog.effortLevels().toArray(new String[0]));
+        effort.setSelectedItem(normalize(settings.assistantEffort, AssistantModelCatalog.DEFAULT_EFFORT));
+        effort.setToolTipText("Reasoning effort requested from the selected model");
         customCommand = new JBTextField();
         customCommand.setColumns(18);
         customCommand.getEmptyText().setText("Optional local agent command");
@@ -439,7 +450,10 @@ final class ShaftAssistantPanel extends JPanel {
         providerType.addActionListener(event -> onModeOrRouteSelectionChanged());
         assistantFamily.addActionListener(event -> updateControlVisibility());
         assistantRuntime.addActionListener(event -> updateControlVisibility());
-        cloudProvider.addActionListener(event -> updateControlVisibility());
+        cloudProvider.addActionListener(event -> {
+            applyCloudModelChoices("");
+            updateControlVisibility();
+        });
         bindKeyboard(project);
         bindContextInsertion();
 
@@ -491,6 +505,7 @@ final class ShaftAssistantPanel extends JPanel {
         routeRow.add(cloudProvider);
         routeRow.add(cloudModel);
         routeRow.add(localModel);
+        routeRow.add(effort);
         routeRow.add(allowSourceMutation);
         routeRow.add(verboseAgentOutput);
         routeRow.add(autoCompact);
@@ -1030,14 +1045,18 @@ final class ShaftAssistantPanel extends JPanel {
         settings.assistantFamily = String.valueOf(assistantFamily.getSelectedItem());
         settings.assistantRuntime = String.valueOf(assistantRuntime.getSelectedItem());
         settings.cloudProvider = String.valueOf(cloudProvider.getSelectedItem());
-        settings.cloudModel = cloudModel.getText().trim();
+        settings.cloudModel = editableComboText(cloudModel);
+        settings.localModel = editableComboText(localModel);
+        settings.assistantEffort = String.valueOf(effort.getSelectedItem());
         settings.defaultAutobotClient = clientFromFamily(settings.assistantFamily);
         if (usesCloud()) {
             settings.pilotAiProvider = settings.cloudProvider;
             settings.pilotAiModel = settings.cloudModel;
-            return AssistantCommand.Selection.cloud(settings.cloudProvider, settings.cloudModel);
+            return AssistantCommand.Selection.cloud(settings.cloudProvider, settings.cloudModel,
+                    settings.assistantEffort);
         }
-        return AssistantCommand.Selection.local(settings.assistantFamily, settings.assistantRuntime);
+        return AssistantCommand.Selection.local(settings.assistantFamily, settings.assistantRuntime,
+                settings.localModel, settings.assistantEffort);
     }
 
     private void showResult(String toolName, ShaftMcpToolResult result, Throwable error) {
@@ -1348,6 +1367,7 @@ final class ShaftAssistantPanel extends JPanel {
         cloudProvider.setEnabled(!running);
         cloudModel.setEnabled(!running);
         localModel.setEnabled(!running);
+        effort.setEnabled(!running);
         customCommand.setEnabled(!running);
         commandAutocomplete.setEnabled(!running);
         allowSourceMutation.setEnabled(!running);
@@ -1455,7 +1475,10 @@ final class ShaftAssistantPanel extends JPanel {
 
     private void updateControlVisibility() {
         boolean advanced = settings.advancedUiEnabled;
-        if (!advanced && usesCloud()) {
+        // A cloud provider chosen during first-run setup stays usable in the basic UI; only
+        // ad-hoc cloud switches remain an advanced-mode capability.
+        boolean cloudConfigured = "CLOUD".equals(normalize(settings.assistantProviderType, "LOCAL"));
+        if (!advanced && usesCloud() && !cloudConfigured) {
             providerType.setSelectedItem("LOCAL");
         }
         boolean cloud = usesCloud();
@@ -1481,18 +1504,22 @@ final class ShaftAssistantPanel extends JPanel {
         customCommand.setEnabled(controlsEnabled && advanced && !lockedRoute && localCli);
         cloudProvider.setVisible(advanced && !lockedRoute && cloud);
         cloudProvider.setEnabled(controlsEnabled && advanced && !lockedRoute && cloud);
-        cloudModel.setVisible(advanced && !lockedRoute && cloud);
-        cloudModel.setEnabled(controlsEnabled && advanced && !lockedRoute && cloud);
-        cloudKeyPanel.setVisible(advanced && !lockedRoute && cloud);
-        cloudApiKey.setEnabled(controlsEnabled && advanced && !lockedRoute && cloud);
-        saveCloudApiKey.setEnabled(controlsEnabled && advanced && !lockedRoute && cloud);
+        // Model and effort selectors stay visible for the active route in every UI mode so the
+        // user can always pick the right model after provider setup (issue #3369).
+        cloudModel.setVisible(cloud);
+        cloudModel.setEnabled(controlsEnabled && cloud);
+        cloudKeyPanel.setVisible(cloud);
+        cloudApiKey.setEnabled(controlsEnabled && cloud);
+        saveCloudApiKey.setEnabled(controlsEnabled && cloud);
         boolean agentMode = "AGENT".equals(mode.getSelectedItem());
         allowSourceMutation.setVisible(agentMode && localAgent);
         allowSourceMutation.setEnabled(controlsEnabled && agentMode && localAgent);
         verboseAgentOutput.setVisible(localAgent && localCli);
         verboseAgentOutput.setEnabled(controlsEnabled && localAgent && localCli);
-        localModel.setVisible(advanced && !lockedRoute && localCli);
-        localModel.setEnabled(controlsEnabled && advanced && !lockedRoute && localCli);
+        localModel.setVisible(localCli);
+        localModel.setEnabled(controlsEnabled && localCli);
+        effort.setVisible(cloud || localCli);
+        effort.setEnabled(controlsEnabled && (cloud || localCli));
         autoCompact.setVisible(localAgent && localCli);
         autoCompact.setEnabled(controlsEnabled && localAgent && localCli);
         configure.setVisible(lockedRoute);
@@ -1528,13 +1555,33 @@ final class ShaftAssistantPanel extends JPanel {
         String previousSelection = localModel.getEditor() == null
                 ? null
                 : String.valueOf(localModel.getEditor().getItem());
-        DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>(models.toArray(new String[0]));
+        // The CLI-reported list wins; the curated catalog keeps the selector useful when the CLI
+        // cannot list its models (issue #3369).
+        List<String> effectiveModels = models.isEmpty() ? AssistantModelCatalog.localModels(family) : models;
+        DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>(effectiveModels.toArray(new String[0]));
         localModel.setModel(model);
         if (previousSelection != null && !previousSelection.isBlank()) {
             localModel.setSelectedItem(previousSelection);
-        } else if (!models.isEmpty()) {
-            localModel.setSelectedItem(models.get(0));
+        } else if (settings.localModel != null && !settings.localModel.isBlank()) {
+            localModel.setSelectedItem(settings.localModel.trim());
+        } else if (!effectiveModels.isEmpty()) {
+            localModel.setSelectedItem(effectiveModels.get(0));
         }
+    }
+
+    private void applyCloudModelChoices(String preferredModel) {
+        String provider = normalizeLower(String.valueOf(cloudProvider.getSelectedItem()), "gemini");
+        List<String> models = AssistantModelCatalog.cloudModels(provider);
+        cloudModel.setModel(new DefaultComboBoxModel<>(models.toArray(new String[0])));
+        String preferred = preferredModel == null ? "" : preferredModel.trim();
+        cloudModel.setSelectedItem(preferred.isBlank() ? models.get(0) : preferred);
+    }
+
+    private static String editableComboText(JComboBox<String> combo) {
+        Object item = combo.isEditable() && combo.getEditor() != null
+                ? combo.getEditor().getItem()
+                : combo.getSelectedItem();
+        return item == null ? "" : item.toString().trim();
     }
 
     private static void runOnEdt(Runnable action) {
@@ -1641,7 +1688,7 @@ final class ShaftAssistantPanel extends JPanel {
     private void updateCloudKeyStatus() {
         String provider = String.valueOf(cloudProvider.getSelectedItem());
         String keyName = providerKeyName(provider);
-        boolean stored = !keyName.isBlank() && ShaftCredentialService.getInstance().hasApiKey(keyName);
+        boolean stored = !keyName.isBlank() && storedCloudKey(keyName);
         String providerLabel = ShaftUiLabels.friendly(provider);
         cloudKeyStatus.setText(stored ? providerLabel + " key stored" : "Enter " + providerLabel + " key");
         cloudApiKey.setVisible(!stored);
@@ -1663,7 +1710,13 @@ final class ShaftAssistantPanel extends JPanel {
 
     private boolean hasSelectedCloudKey() {
         String keyName = providerKeyName(String.valueOf(cloudProvider.getSelectedItem()));
-        return !keyName.isBlank() && ShaftCredentialService.getInstance().hasApiKey(keyName);
+        return !keyName.isBlank() && storedCloudKey(keyName);
+    }
+
+    private static boolean storedCloudKey(String keyName) {
+        // Password Safe needs a running IntelliJ application; headless panel tests have none.
+        return ApplicationManager.getApplication() != null
+                && ShaftCredentialService.getInstance().hasApiKey(keyName);
     }
 
     private void bindKeyboard(Project project) {
@@ -2397,7 +2450,7 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     private String currentAgentConfigurationText() {
-        if (settings.advancedUiEnabled && "CLOUD".equals(normalize(settings.assistantProviderType, "LOCAL"))) {
+        if ("CLOUD".equals(normalize(settings.assistantProviderType, "LOCAL"))) {
             String model = settings.cloudModel == null || settings.cloudModel.isBlank() ? "" : " " + settings.cloudModel.trim();
             return ShaftUiLabels.friendly(normalizeLower(settings.cloudProvider, "gemini")) + model;
         }
@@ -2406,7 +2459,7 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     private String currentAgentConfigurationTooltip() {
-        if (settings.advancedUiEnabled && "CLOUD".equals(normalize(settings.assistantProviderType, "LOCAL"))) {
+        if ("CLOUD".equals(normalize(settings.assistantProviderType, "LOCAL"))) {
             String model = settings.cloudModel == null || settings.cloudModel.isBlank() ? "" : " / " + settings.cloudModel.trim();
             return "Agent: Cloud / " + ShaftUiLabels.friendly(normalizeLower(settings.cloudProvider, "gemini")) + model;
         }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -66,21 +66,38 @@ final class ShaftMcpSetupPanel extends JPanel {
     private static final String GUIDE_SETUP_STEP =
             "Next: choose agent, copy command, open terminal, then check.";
     private static final String CHECK_NEXT_STEP = "Press Check now.";
+    private static final String GEMINI_FAMILY = "GEMINI";
+    private static final String GEMINI_KEY_NAME = "GEMINI_API_KEY";
 
     @FunctionalInterface
     interface AgentReadinessProbe {
         ShaftMcpToolResult test(String client, String runtime);
     }
 
+    /**
+     * Cloud provider API-key storage used by the setup check. Backed by IntelliJ Password Safe in
+     * production and injectable so tests never touch the real credential store.
+     */
+    interface CloudKeyStore {
+        boolean hasKey(String keyName);
+
+        void saveKey(String keyName, char[] secret);
+    }
+
     private final Project project;
     private final ShaftSettingsState.Settings settings;
     private final Runnable connected;
     private final AgentReadinessProbe readinessProbe;
+    private final CloudKeyStore cloudKeyStore;
     private final String recommendedFamily;
     private final JBTextArea installerCommand;
     private final JBTextArea mcpCommand;
     private final JComboBox<String> family;
     private final JComboBox<String> runtime;
+    private final javax.swing.JPasswordField geminiApiKey;
+    private final JLabel geminiKeyStatus;
+    private final JPanel runtimeRow;
+    private final JPanel apiKeyRow;
     private final JComboBox<String> installerTarget;
     private final JCheckBox manualInstallerTarget;
     private final JButton copyInstallerCommand;
@@ -131,11 +148,18 @@ final class ShaftMcpSetupPanel extends JPanel {
 
     ShaftMcpSetupPanel(@NotNull Project project, @NotNull ShaftSettingsState.Settings settings,
                        @NotNull Runnable connected, @NotNull AgentReadinessProbe readinessProbe) {
+        this(project, settings, connected, readinessProbe, passwordSafeKeyStore());
+    }
+
+    ShaftMcpSetupPanel(@NotNull Project project, @NotNull ShaftSettingsState.Settings settings,
+                       @NotNull Runnable connected, @NotNull AgentReadinessProbe readinessProbe,
+                       @NotNull CloudKeyStore cloudKeyStore) {
         super(new BorderLayout(8, 8));
         this.project = project;
         this.settings = settings;
         this.connected = connected;
         this.readinessProbe = readinessProbe;
+        this.cloudKeyStore = cloudKeyStore;
         recommendedFamily = recommendedFamily(settings);
         setBorder(JBUI.Borders.empty(12));
 
@@ -168,14 +192,19 @@ final class ShaftMcpSetupPanel extends JPanel {
         progress.setIndeterminate(true);
         progress.setVisible(false);
         progress.setPreferredSize(JBUI.size(96, 14));
-        family = new JComboBox<>(new String[]{"CODEX", "CLAUDE", "COPILOT"});
+        family = new JComboBox<>(new String[]{"CODEX", "CLAUDE", "COPILOT", GEMINI_FAMILY});
         ShaftUiLabels.applyFriendlyRenderer(family);
-        family.setSelectedItem(resolveFamily(settings));
+        family.setSelectedItem(initialFamily(settings));
         family.getAccessibleContext().setAccessibleName("Assistant family");
         runtime = new JComboBox<>(new String[]{"CLI", "IDE_PLUGIN", "DESKTOP_APP"});
         ShaftUiLabels.applyFriendlyRenderer(runtime);
         runtime.setSelectedItem(normalize(settings.assistantRuntime, "CLI"));
         runtime.getAccessibleContext().setAccessibleName("Assistant runtime");
+        geminiApiKey = new javax.swing.JPasswordField(24);
+        geminiApiKey.getAccessibleContext().setAccessibleName("Gemini API key");
+        geminiApiKey.getAccessibleContext().setAccessibleDescription(
+                "Google AI Studio API key stored in IntelliJ Password Safe when the setup check passes.");
+        geminiKeyStatus = setupStatusLabel("Gemini API key status");
         installerTarget = new JComboBox<>(INSTALLER_TARGETS);
         ShaftUiLabels.applyFriendlyRenderer(installerTarget);
         installerTarget.setSelectedItem(suggestedInstallerTarget());
@@ -290,7 +319,12 @@ final class ShaftMcpSetupPanel extends JPanel {
         agentControls.setLayout(new javax.swing.BoxLayout(agentControls, javax.swing.BoxLayout.Y_AXIS));
         agentControls.setOpaque(false);
         agentControls.add(labeledControl("Assistant family", family));
-        agentControls.add(labeledControl("Runtime", runtime));
+        runtimeRow = labeledControl("Runtime", runtime);
+        agentControls.add(runtimeRow);
+        apiKeyRow = labeledControl("Gemini API key", geminiApiKey);
+        apiKeyRow.add(geminiKeyStatus);
+        apiKeyRow.setVisible(false);
+        agentControls.add(apiKeyRow);
         agentControls.add(recommendedAgent);
         JPanel checkActions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
         checkActions.setOpaque(false);
@@ -326,6 +360,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         installerTarget.addActionListener(event -> installerTargetChanged());
         showRuntimeSelected();
         showAssistNotConfigured();
+        updateCloudControls();
         JPanel intro = new JPanel(new BorderLayout(4, 2));
         JLabel title = new JLabel("Connect SHAFT Assistant");
         title.setFont(title.getFont().deriveFont(Font.BOLD));
@@ -375,10 +410,7 @@ final class ShaftMcpSetupPanel extends JPanel {
             }
         }
         settings.mcpCommand = command;
-        settings.assistantProviderType = "LOCAL";
-        settings.assistantFamily = String.valueOf(family.getSelectedItem());
-        settings.assistantRuntime = String.valueOf(runtime.getSelectedItem());
-        settings.defaultAutobotClient = clientFromFamily(settings.assistantFamily);
+        applySelectionToSettings();
         if (command.isBlank()) {
             showAssistError();
             settings.mcpSetupComplete = false;
@@ -434,7 +466,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         } else {
             if (result.success()) {
                 clearDiagnostics();
-                ShaftMcpToolResult readiness = readinessProbe.test(settings.defaultAutobotClient, settings.assistantRuntime);
+                ShaftMcpToolResult readiness = verifySelectedAgentReadiness();
                 if (readiness.success()) {
                     showAssistConfigured();
                     showRuntimeVerified();
@@ -476,6 +508,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         mcpCommand.setEnabled(!running);
         family.setEnabled(!running);
         runtime.setEnabled(!running);
+        geminiApiKey.setEnabled(!running);
         setStatusText(text);
     }
 
@@ -521,6 +554,7 @@ final class ShaftMcpSetupPanel extends JPanel {
     }
 
     private void assistantSelectionChanged() {
+        updateCloudControls();
         showRuntimeSelected();
         if (!manualInstallerTarget.isSelected()) {
             String suggestedTarget = suggestedInstallerTarget();
@@ -556,6 +590,99 @@ final class ShaftMcpSetupPanel extends JPanel {
             case "CLAUDE_CODE" -> "CLAUDE";
             case "COPILOT_CLI" -> "COPILOT";
             default -> "CODEX";
+        };
+    }
+
+    private static String initialFamily(ShaftSettingsState.Settings settings) {
+        boolean geminiCloudConfigured = "CLOUD".equals(normalize(settings.assistantProviderType, "LOCAL"))
+                && "gemini".equalsIgnoreCase(settings.cloudProvider == null ? "" : settings.cloudProvider.trim());
+        return geminiCloudConfigured ? GEMINI_FAMILY : resolveFamily(settings);
+    }
+
+    private boolean cloudFamilySelected() {
+        return GEMINI_FAMILY.equals(normalize(String.valueOf(family.getSelectedItem()), "CODEX"));
+    }
+
+    /**
+     * Writes the current agent selection into settings. A Gemini selection configures the cloud
+     * provider route (issue #3369) and never overwrites the last local family, so switching back
+     * to a local agent later restores the previous local configuration.
+     */
+    private void applySelectionToSettings() {
+        if (cloudFamilySelected()) {
+            settings.assistantProviderType = "CLOUD";
+            settings.cloudProvider = "gemini";
+            if (settings.cloudModel == null || settings.cloudModel.isBlank()) {
+                settings.cloudModel = AssistantModelCatalog.defaultCloudModel("gemini");
+            }
+            settings.passProviderApiKeysToMcp = true;
+            return;
+        }
+        settings.assistantProviderType = "LOCAL";
+        settings.assistantFamily = String.valueOf(family.getSelectedItem());
+        settings.assistantRuntime = String.valueOf(runtime.getSelectedItem());
+        settings.defaultAutobotClient = clientFromFamily(settings.assistantFamily);
+    }
+
+    /**
+     * Verifies the selected agent after a successful MCP probe: local families check their CLI
+     * runtime, while the Gemini cloud route stores the entered API key and checks that one is
+     * present in Password Safe.
+     */
+    private ShaftMcpToolResult verifySelectedAgentReadiness() {
+        if (!cloudFamilySelected()) {
+            return readinessProbe.test(settings.defaultAutobotClient, settings.assistantRuntime);
+        }
+        applySelectionToSettings();
+        storeEnteredGeminiKey();
+        updateCloudControls();
+        return cloudKeyStore.hasKey(GEMINI_KEY_NAME)
+                ? ShaftMcpToolResult.success("Gemini API key is stored in IntelliJ Password Safe.")
+                : ShaftMcpToolResult.failure(
+                "No Gemini API key stored. Paste your Google AI Studio API key, then check again.");
+    }
+
+    private void storeEnteredGeminiKey() {
+        char[] entered = geminiApiKey.getPassword();
+        boolean meaningful = false;
+        for (char character : entered) {
+            if (!Character.isWhitespace(character)) {
+                meaningful = true;
+                break;
+            }
+        }
+        if (meaningful) {
+            cloudKeyStore.saveKey(GEMINI_KEY_NAME, entered);
+            geminiApiKey.setText("");
+        } else {
+            java.util.Arrays.fill(entered, '\0');
+        }
+    }
+
+    private void updateCloudControls() {
+        boolean cloud = cloudFamilySelected();
+        runtimeRow.setVisible(!cloud);
+        apiKeyRow.setVisible(cloud);
+        // The CLI recommendation only applies to local agent families.
+        recommendedAgent.setVisible(!cloud);
+        if (cloud) {
+            geminiKeyStatus.setText(cloudKeyStore.hasKey(GEMINI_KEY_NAME)
+                    ? "Key stored in Password Safe."
+                    : "Paste your Google AI Studio API key.");
+        }
+    }
+
+    private static CloudKeyStore passwordSafeKeyStore() {
+        return new CloudKeyStore() {
+            @Override
+            public boolean hasKey(String keyName) {
+                return com.shaft.intellij.settings.ShaftCredentialService.getInstance().hasApiKey(keyName);
+            }
+
+            @Override
+            public void saveKey(String keyName, char[] secret) {
+                com.shaft.intellij.settings.ShaftCredentialService.getInstance().setApiKey(keyName, secret);
+            }
         };
     }
 
@@ -613,6 +740,9 @@ final class ShaftMcpSetupPanel extends JPanel {
             case "COPILOT" -> "IDE_PLUGIN".equals(normalize(String.valueOf(runtime.getSelectedItem()), "CLI"))
                     ? "COPILOT_INTELLIJ"
                     : "COPILOT_CLI";
+            // Gemini prompts run through SHAFT MCP's provider chat, so only this plugin's own
+            // MCP integration needs installing.
+            case GEMINI_FAMILY -> "INTELLIJ_PLUGIN";
             default -> "CODEX";
         };
     }
@@ -820,6 +950,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         return switch (normalize(String.valueOf(family.getSelectedItem()), "CODEX")) {
             case "CLAUDE" -> "claude --version";
             case "COPILOT" -> "copilot --version";
+            case GEMINI_FAMILY -> "";
             default -> "codex --version";
         };
     }
@@ -907,6 +1038,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         return switch (normalize(String.valueOf(family.getSelectedItem()), "CODEX")) {
             case "CLAUDE" -> "For Claude, run `claude mcp list` for Claude Code or restart Claude Desktop after desktop config changes.";
             case "COPILOT" -> "For GitHub Copilot, check the Copilot MCP client configuration and any organization MCP policy.";
+            case GEMINI_FAMILY -> "For Gemini, paste a valid Google AI Studio API key in the setup form, then check again.";
             default -> "For Codex, run `codex mcp list` and verify the SHAFT MCP server in the Codex config.";
         };
     }
@@ -926,6 +1058,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         return switch (normalize(String.valueOf(family.getSelectedItem()), "CODEX")) {
             case "CLAUDE" -> "Claude";
             case "COPILOT" -> "GitHub Copilot";
+            case GEMINI_FAMILY -> "Gemini";
             default -> "Codex";
         };
     }
@@ -1111,6 +1244,7 @@ final class ShaftMcpSetupPanel extends JPanel {
             case "COPILOT" -> "IDE_PLUGIN".equals(selectedRuntime)
                     ? "GitHub Copilot in IntelliJ"
                     : "GitHub Copilot CLI";
+            case GEMINI_FAMILY -> "Gemini cloud API";
             default -> "Codex " + ShaftUiLabels.friendly(selectedRuntime);
         };
     }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftUiLabels.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftUiLabels.java
@@ -70,6 +70,10 @@ public final class ShaftUiLabels {
             case "GITHUB" -> "GitHub";
             case "OLLAMA" -> "Ollama";
             case "NONE" -> "None";
+            case "DEFAULT" -> "Default effort";
+            case "LOW" -> "Low effort";
+            case "MEDIUM" -> "Medium effort";
+            case "HIGH" -> "High effort";
             default -> text;
         };
     }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
@@ -474,6 +474,66 @@ class AssistantCommandTest {
     }
 
     @Test
+    void directLocalAgentRunnerAppliesSelectedModelAndEffort() {
+        AssistantCommand.Invocation codex = AssistantCommand.fromPrompt(
+                "Explain this failure",
+                AssistantCommand.Selection.local("CODEX", "CLI", "gpt-5.2-codex", "HIGH"),
+                "ASK", ".", "", false);
+        AssistantCommand.Invocation claude = AssistantCommand.fromPrompt(
+                "Explain this failure",
+                AssistantCommand.Selection.local("CLAUDE", "CLI", "claude-sonnet-5", "LOW"),
+                "ASK", ".", "", false);
+        AssistantCommand.Invocation copilot = AssistantCommand.fromPrompt(
+                "Explain this failure",
+                AssistantCommand.Selection.local("COPILOT", "CLI", "gpt-5.2", "DEFAULT"),
+                "ASK", ".", "", false);
+
+        assertAll(
+                () -> assertEquals(List.of(
+                                "codex", "exec",
+                                "--model", "gpt-5.2-codex",
+                                "-c", "model_reasoning_effort=\"high\"",
+                                "--sandbox", "read-only", "--json", "-"),
+                        AssistantLocalAgentRunner.commandFor(codex.arguments())),
+                // Codex receives the effort as a CLI config flag, so its prompt stays clean.
+                () -> assertFalse(codex.arguments().get("prompt").getAsString()
+                        .contains("reasoning effort")),
+                () -> assertEquals(List.of(
+                                "claude", "--print",
+                                "--model", "claude-sonnet-5",
+                                "--output-format", "stream-json", "--verbose"),
+                        AssistantLocalAgentRunner.commandFor(claude.arguments())),
+                // Claude Code has no effort flag, so the prompt carries the preference instead.
+                () -> assertTrue(claude.arguments().get("prompt").getAsString()
+                        .startsWith("Use low reasoning effort for this request.")),
+                () -> assertEquals(List.of("copilot", "ask", "--model", "gpt-5.2"),
+                        AssistantLocalAgentRunner.commandFor(copilot.arguments())),
+                // Default effort adds neither a flag nor a prompt hint.
+                () -> assertFalse(copilot.arguments().get("prompt").getAsString()
+                        .contains("reasoning effort")));
+    }
+
+    @Test
+    void cloudInvocationCarriesSelectedModelAndEffortHint() {
+        AssistantCommand.Invocation withEffort = AssistantCommand.fromPrompt(
+                "Explain this failure",
+                AssistantCommand.Selection.cloud("gemini", "gemini-3.5-pro", "MEDIUM"),
+                "ASK", ".", "", false);
+        AssistantCommand.Invocation defaultEffort = AssistantCommand.fromPrompt(
+                "Explain this failure",
+                AssistantCommand.Selection.cloud("gemini", "", ""),
+                "ASK", ".", "", false);
+
+        assertAll(
+                () -> assertEquals("autobot_provider_chat", withEffort.toolName()),
+                () -> assertEquals("gemini-3.5-pro", withEffort.arguments().get("model").getAsString()),
+                () -> assertTrue(withEffort.arguments().get("prompt").getAsString()
+                        .startsWith("Use medium reasoning effort for this request.")),
+                () -> assertFalse(defaultEffort.arguments().get("prompt").getAsString()
+                        .contains("reasoning effort")));
+    }
+
+    @Test
     void directCustomAgentCommandRequiresSourceEditApprovalBecauseItCannotBeSandboxed() throws Exception {
         AssistantCommand.Invocation custom = AssistantCommand.fromPrompt(
                 "Inspect the browser",

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantGeminiLiveE2ETest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantGeminiLiveE2ETest.java
@@ -35,6 +35,9 @@ class AssistantGeminiLiveE2ETest {
         String commandLine = System.getProperty("shaft.intellij.liveMcpCommand", "").trim();
         Assumptions.assumeTrue(!commandLine.isBlank(),
                 "Set -Dshaft.intellij.liveMcpCommand to a SHAFT MCP stdio command.");
+        // The default flash model is periodically load-shed by Google with 503 "high demand"
+        // responses; override the model when live verification needs a less contended one.
+        String model = System.getProperty("shaft.intellij.liveGeminiModel", "gemini-3.5-flash").trim();
 
         Path workspace = Path.of(System.getProperty("shaft.intellij.workspaceRoot", ".."))
                 .toAbsolutePath()
@@ -42,7 +45,7 @@ class AssistantGeminiLiveE2ETest {
         ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
         settings.assistantProviderType = "CLOUD";
         settings.cloudProvider = "gemini";
-        settings.cloudModel = "gemini-3.5-flash";
+        settings.cloudModel = model;
         settings.passProviderApiKeysToMcp = false;
         Map<String, String> environment = new HashMap<>(mcpEnvironment(settings));
         environment.put("GEMINI_API_KEY", apiKey);
@@ -50,7 +53,7 @@ class AssistantGeminiLiveE2ETest {
 
         String options = environment.getOrDefault("JAVA_TOOL_OPTIONS", "");
         assertTrue(options.contains("-Dpilot.ai.provider=gemini"));
-        assertTrue(options.contains("-Dpilot.ai.gemini.model=gemini-3.5-flash"));
+        assertTrue(options.contains("-Dpilot.ai.gemini.model=" + model));
 
         AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
                 """
@@ -89,18 +92,29 @@ class AssistantGeminiLiveE2ETest {
             return;
         }
         String answer = response.get("answer").getAsString();
-        String lowerAnswer = answer.toLowerCase(Locale.ROOT);
+        // The provider may legitimately return the Java source inline in the answer or as
+        // structured codeBlocks with only a summary answer; verify the combined generation.
+        StringBuilder generatedBuilder = new StringBuilder(answer);
+        if (response.get("codeBlocks") != null && response.get("codeBlocks").isJsonArray()) {
+            for (JsonElement block : response.getAsJsonArray("codeBlocks")) {
+                if (block.isJsonObject() && block.getAsJsonObject().has("code")) {
+                    generatedBuilder.append('\n').append(block.getAsJsonObject().get("code").getAsString());
+                }
+            }
+        }
+        String generated = generatedBuilder.toString();
+        String lowerGenerated = generated.toLowerCase(Locale.ROOT);
         String markdown = AssistantMarkdown.fromMcpOutput(invocation.toolName(), result.toString());
 
         assertEquals("SUCCESS", response.get("status").getAsString(), response.toString());
         assertEquals("gemini", response.get("provider").getAsString());
-        assertEquals("gemini-3.5-flash", response.get("model").getAsString());
+        assertTrue(response.get("model").getAsString().startsWith(model), response.get("model").getAsString());
         assertEquals("ASK", response.get("mode").getAsString());
-        assertTrue(answer.contains("DuckDuckGoSearchTest"), answer);
-        assertTrue(answer.contains("SHAFT"), answer);
-        assertTrue(answer.contains("@Test"), answer);
-        assertTrue(lowerAnswer.contains("duckduckgo.com"), answer);
-        assertTrue(lowerAnswer.contains("search"), answer);
+        assertTrue(generated.contains("DuckDuckGoSearchTest"), generated);
+        assertTrue(generated.contains("SHAFT"), generated);
+        assertTrue(generated.contains("@Test"), generated);
+        assertTrue(lowerGenerated.contains("duckduckgo.com"), generated);
+        assertTrue(lowerGenerated.contains("search"), generated);
         assertFalse(AssistantMarkdown.containsRejectedGeneratedJava(markdown), markdown);
     }
 

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantModelCatalogTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantModelCatalogTest.java
@@ -1,0 +1,49 @@
+package com.shaft.intellij.ui;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AssistantModelCatalogTest {
+    @Test
+    void cloudCatalogListsModelsForEveryProviderWithGeminiFallback() {
+        assertAll(
+                () -> assertEquals("gemini-3.5-flash", AssistantModelCatalog.defaultCloudModel("gemini")),
+                () -> assertTrue(AssistantModelCatalog.cloudModels("anthropic")
+                        .containsAll(List.of("claude-fable-5", "claude-opus-4-8", "claude-sonnet-5"))),
+                () -> assertFalse(AssistantModelCatalog.cloudModels("openai").isEmpty()),
+                () -> assertFalse(AssistantModelCatalog.cloudModels("github").isEmpty()),
+                () -> assertEquals(AssistantModelCatalog.cloudModels("gemini"),
+                        AssistantModelCatalog.cloudModels("unknown-provider")));
+    }
+
+    @Test
+    void localCatalogCoversEveryAssistantFamily() {
+        assertAll(
+                () -> assertTrue(AssistantModelCatalog.localModels("CLAUDE").contains("claude-sonnet-5")),
+                () -> assertFalse(AssistantModelCatalog.localModels("CODEX").isEmpty()),
+                () -> assertFalse(AssistantModelCatalog.localModels("COPILOT").isEmpty()),
+                () -> assertEquals(AssistantModelCatalog.localModels("CODEX"),
+                        AssistantModelCatalog.localModels("unknown-family")));
+    }
+
+    @Test
+    void effortLevelsStartWithDefaultAndOnlyExplicitLevelsAreForwarded() {
+        assertAll(
+                () -> assertEquals(AssistantModelCatalog.DEFAULT_EFFORT,
+                        AssistantModelCatalog.effortLevels().get(0)),
+                () -> assertTrue(AssistantModelCatalog.effortLevels()
+                        .containsAll(List.of("LOW", "MEDIUM", "HIGH"))),
+                () -> assertTrue(AssistantModelCatalog.isExplicitEffort("high")),
+                () -> assertTrue(AssistantModelCatalog.isExplicitEffort("Medium")),
+                () -> assertFalse(AssistantModelCatalog.isExplicitEffort(AssistantModelCatalog.DEFAULT_EFFORT)),
+                () -> assertFalse(AssistantModelCatalog.isExplicitEffort("")),
+                () -> assertFalse(AssistantModelCatalog.isExplicitEffort(null)),
+                () -> assertFalse(AssistantModelCatalog.isExplicitEffort("EXTREME")));
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -686,6 +686,110 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void setupPanelConfiguresGeminiCloudProviderWithStoredApiKey() throws Exception {
+        java.util.Map<String, String> storedKeys = new java.util.HashMap<>();
+        ShaftMcpSetupPanel.CloudKeyStore keyStore = fakeKeyStore(storedKeys);
+        ShaftSettingsState.Settings settings = unverifiedMcpSettings();
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), settings, () -> {
+        }, (client, runtime) -> ShaftMcpToolResult.failure("local CLI readiness must not gate the cloud route"),
+                keyStore);
+        JComboBox<?> family = findByAccessibleName(panel, "Assistant family", JComboBox.class);
+        javax.swing.JPasswordField apiKey =
+                findByAccessibleName(panel, "Gemini API key", javax.swing.JPasswordField.class);
+        JComponent runtimeRow = (JComponent) getField(panel, "runtimeRow");
+        JComponent apiKeyRow = (JComponent) getField(panel, "apiKeyRow");
+
+        assertAll(
+                () -> assertFalse(apiKeyRow.isVisible()),
+                () -> assertTrue(runtimeRow.isVisible()));
+
+        family.setSelectedItem("GEMINI");
+        assertAll(
+                () -> assertTrue(apiKeyRow.isVisible()),
+                () -> assertFalse(runtimeRow.isVisible()),
+                () -> assertTrue(containsText(panel, "Paste your Google AI Studio API key.")));
+
+        apiKey.setText("test-gemini-key");
+        showTestResult(panel, ShaftMcpToolResult.success("Probe OK"));
+
+        assertAll(
+                () -> assertEquals("test-gemini-key", storedKeys.get("GEMINI_API_KEY")),
+                () -> assertEquals(0, apiKey.getPassword().length),
+                () -> assertEquals("CLOUD", settings.assistantProviderType),
+                () -> assertEquals("gemini", settings.cloudProvider),
+                () -> assertEquals("gemini-3.5-flash", settings.cloudModel),
+                () -> assertTrue(settings.passProviderApiKeysToMcp),
+                () -> assertTrue(settings.mcpSetupComplete),
+                () -> assertTrue(containsText(panel, "Ready to chat. Verified Gemini cloud API.")),
+                () -> assertTrue(findByAccessibleName(panel, "Start chatting with SHAFT Assistant", JButton.class)
+                        .isVisible()));
+    }
+
+    @Test
+    void setupPanelBlocksGeminiConnectionWithoutStoredApiKey() throws Exception {
+        ShaftSettingsState.Settings settings = unverifiedMcpSettings();
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), settings, () -> {
+        }, readyProbe(), fakeKeyStore(new java.util.HashMap<>()));
+        JComboBox<?> family = findByAccessibleName(panel, "Assistant family", JComboBox.class);
+
+        family.setSelectedItem("GEMINI");
+        showTestResult(panel, ShaftMcpToolResult.success("Probe OK"));
+
+        assertAll(
+                () -> assertTrue(containsText(panel, "Assist: Error")),
+                () -> assertTrue(containsText(panel, "No Gemini API key stored")),
+                () -> assertFalse(settings.mcpSetupComplete),
+                () -> assertFalse(settings.agentGuidanceOptimizationPromptPending));
+    }
+
+    @Test
+    void assistantShowsModelAndEffortSelectorsWithoutAdvancedMode() {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
+        JComboBox<?> localModel = findByAccessibleName(panel, "Assistant local agent model", JComboBox.class);
+        JComboBox<?> effort = findByAccessibleName(panel, "Assistant effort", JComboBox.class);
+
+        assertAll(
+                () -> assertTrue(localModel.isVisible()),
+                () -> assertTrue(effort.isVisible()),
+                () -> assertEquals("DEFAULT", effort.getSelectedItem()),
+                () -> assertTrue(effort.getItemCount() >= 4));
+    }
+
+    @Test
+    void assistantKeepsCloudRouteAndModelListFromSetupWithoutAdvancedMode() {
+        ShaftSettingsState.Settings settings = connectedMcpSettings();
+        settings.assistantProviderType = "CLOUD";
+        settings.cloudProvider = "gemini";
+        settings.cloudModel = "gemini-3.5-flash";
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, settings);
+        JComboBox<?> providerType = findByAccessibleName(panel, "Assistant provider type", JComboBox.class);
+        JComboBox<?> cloudModel = findByAccessibleName(panel, "Assistant cloud model", JComboBox.class);
+        JComboBox<?> effort = findByAccessibleName(panel, "Assistant effort", JComboBox.class);
+
+        assertAll(
+                // Basic mode must not force the setup-selected cloud route back to LOCAL.
+                () -> assertEquals("CLOUD", providerType.getSelectedItem()),
+                () -> assertTrue(cloudModel.isVisible()),
+                () -> assertTrue(effort.isVisible()),
+                () -> assertEquals("gemini-3.5-flash", String.valueOf(cloudModel.getSelectedItem())),
+                () -> assertTrue(cloudModel.getItemCount() >= 2));
+    }
+
+    private static ShaftMcpSetupPanel.CloudKeyStore fakeKeyStore(java.util.Map<String, String> storedKeys) {
+        return new ShaftMcpSetupPanel.CloudKeyStore() {
+            @Override
+            public boolean hasKey(String keyName) {
+                return storedKeys.containsKey(keyName);
+            }
+
+            @Override
+            public void saveKey(String keyName, char[] secret) {
+                storedKeys.put(keyName, new String(secret));
+            }
+        };
+    }
+
+    @Test
     void assistantConsumesPendingGuidanceOptimizationPromptOnce() {
         ShaftSettingsState.Settings settings = connectedMcpSettings();
         settings.agentGuidanceOptimizationPromptPending = true;

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
@@ -123,6 +123,7 @@ class ShaftPluginScreenshotRendererTest {
         Path toolsLightScreenshot = outputPath.resolve("intellij-plugin-tools.png");
         Path toolsDarkScreenshot = outputPath.resolve("intellij-plugin-tools-dark.png");
         Path mcpSetupScreenshot = outputPath.resolve("intellij-plugin-mcp-setup.png");
+        Path mcpSetupGeminiScreenshot = outputPath.resolve("intellij-plugin-mcp-setup-gemini.png");
         Path mcpSetupNarrowDarkScreenshot = outputPath.resolve("intellij-plugin-mcp-setup-narrow-dark.png");
         Path mcpSetupSuccessScreenshot = outputPath.resolve("intellij-plugin-mcp-setup-success.png");
         Path mcpSetupErrorScreenshot = outputPath.resolve("intellij-plugin-mcp-setup-error-dark.png");
@@ -146,6 +147,7 @@ class ShaftPluginScreenshotRendererTest {
         Files.copy(advancedToolsLightScreenshot, toolsLightScreenshot, StandardCopyOption.REPLACE_EXISTING);
         Files.copy(advancedToolsDarkScreenshot, toolsDarkScreenshot, StandardCopyOption.REPLACE_EXISTING);
         write(mcpSetupScreenshot, renderSetup(LIGHT_THEME, false));
+        write(mcpSetupGeminiScreenshot, renderSetupGemini(LIGHT_THEME, false));
         write(mcpSetupNarrowDarkScreenshot, renderSetup(DARK_THEME, true, NARROW_WIDTH, HEIGHT));
         write(mcpSetupSuccessScreenshot, renderSetupSuccess(LIGHT_THEME, false));
         write(mcpSetupErrorScreenshot, renderSetupError(DARK_THEME, true));
@@ -169,6 +171,7 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertTrue(Files.size(toolsLightScreenshot) > 0, toolsLightScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(toolsDarkScreenshot) > 0, toolsDarkScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(mcpSetupScreenshot) > 0, mcpSetupScreenshot + " should be non-empty"),
+                () -> assertTrue(Files.size(mcpSetupGeminiScreenshot) > 0, mcpSetupGeminiScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(mcpSetupNarrowDarkScreenshot) > 0, mcpSetupNarrowDarkScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(mcpSetupSuccessScreenshot) > 0, mcpSetupSuccessScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(mcpSetupErrorScreenshot) > 0, mcpSetupErrorScreenshot + " should be non-empty"),
@@ -191,6 +194,7 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertDimensions(toolsLightScreenshot),
                 () -> assertDimensions(toolsDarkScreenshot),
                 () -> assertDimensions(mcpSetupScreenshot),
+                () -> assertDimensions(mcpSetupGeminiScreenshot),
                 () -> assertDimensions(mcpSetupNarrowDarkScreenshot, NARROW_WIDTH, HEIGHT),
                 () -> assertDimensions(mcpSetupSuccessScreenshot),
                 () -> assertDimensions(mcpSetupErrorScreenshot),
@@ -329,6 +333,60 @@ class ShaftPluginScreenshotRendererTest {
             image.set(render(toolWindow, width, height));
         });
         return image.get();
+    }
+
+    private static BufferedImage renderSetupGemini(String lookAndFeelClassName, boolean dark)
+            throws InterruptedException, InvocationTargetException {
+        AtomicReference<BufferedImage> image = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            configureLookAndFeel(lookAndFeelClassName, dark);
+            ShaftMcpSetupPanel component = new ShaftMcpSetupPanel(screenshotProject(),
+                    new ShaftSettingsState.Settings(),
+                    () -> {
+                    }, (client, runtime) -> ShaftMcpToolResult.success("Codex CLI executable is available on PATH."),
+                    new ShaftMcpSetupPanel.CloudKeyStore() {
+                        @Override
+                        public boolean hasKey(String keyName) {
+                            return false;
+                        }
+
+                        @Override
+                        public void saveKey(String keyName, char[] secret) {
+                            // Screenshot rendering never stores real keys.
+                        }
+                    });
+            JComboBox<?> family = findComboByAccessibleName(component, "Assistant family");
+            if (family != null) {
+                family.setSelectedItem("GEMINI");
+            }
+            component.setSize(new Dimension(WIDTH, HEIGHT));
+            component.setPreferredSize(new Dimension(WIDTH, HEIGHT));
+            SwingUtilities.updateComponentTreeUI(component);
+            component.doLayout();
+            layout(component, !dark);
+
+            // Verify setup panel labels are not cropped and backgrounds are continuous
+            verifySetupPanelRendering(component);
+
+            image.set(render(component, WIDTH, HEIGHT));
+        });
+        return image.get();
+    }
+
+    private static JComboBox<?> findComboByAccessibleName(java.awt.Component component, String accessibleName) {
+        if (component instanceof JComboBox<?> combo
+                && accessibleName.equals(combo.getAccessibleContext().getAccessibleName())) {
+            return combo;
+        }
+        if (component instanceof java.awt.Container container) {
+            for (java.awt.Component child : container.getComponents()) {
+                JComboBox<?> found = findComboByAccessibleName(child, accessibleName);
+                if (found != null) {
+                    return found;
+                }
+            }
+        }
+        return null;
     }
 
     private static BufferedImage renderSetupSuccess(String lookAndFeelClassName, boolean dark)

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
@@ -44,6 +44,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ShaftPluginScreenshotRendererTest {
+    static {
+        // Without an activated IconLoader this headless JVM paints placeholder glyphs instead of
+        // the plugin's SVG action icons, which makes screenshot evidence unrepresentative.
+        com.intellij.openapi.util.IconLoader.activate();
+    }
+
     private static final int WIDTH = 860;
     private static final int NARROW_WIDTH = 360;
     private static final int HEIGHT = 780;

--- a/shaft-mcp/src/main/java/com/shaft/mcp/AutobotService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/AutobotService.java
@@ -161,7 +161,10 @@ public class AutobotService {
             AiRequest request = AiRequest.builder("autobot-provider-chat", codegenSchema())
                     .text(prompt == null ? "" : prompt)
                     .approvalPolicy(new ApprovalPolicy(false, true, EnumSet.of(EvidenceCategory.TEXT)))
-                    .budget(new AiBudget(8_000, 2_000, BigDecimal.ZERO))
+                    // Reasoning models spend thinking tokens from the same output budget; 2k
+                    // routinely truncated a full generated test class into malformed JSON
+                    // (live Gemini evidence in ShaftHQ/SHAFT_ENGINE#3369).
+                    .budget(new AiBudget(8_000, 8_000, BigDecimal.ZERO))
                     .timeout(Duration.ofSeconds(timeoutSeconds > 0 ? timeoutSeconds : DEFAULT_TIMEOUT_SECONDS))
                     .deterministicFallback(JSON.createObjectNode().put("answer", ""))
                     .build();


### PR DESCRIPTION
Closes #3369.

## What changed

### Gemini API key as a cloud provider in the agent selection setup
- The first-run **Pick agent** step now offers **Gemini** next to Codex, Claude, and GitHub Copilot.
- Selecting Gemini swaps the runtime selector for a **Gemini API key** field; **Check setup** stores the key in IntelliJ Password Safe, saves the Cloud/Gemini route with a default model, enables passing the stored key to the SHAFT MCP process, and switches the installer target to `intellij-plugin` (cloud prompts run through `autobot_provider_chat`).
- A missing key fails the check inline with a paste-and-retry hint. Key storage is injectable (`CloudKeyStore`) so tests never touch the real credential store.

### Model list + effort levels in the assistant chat view
- The composer now shows a **model** selector and a reasoning-**effort** selector (Default/Low/Medium/High) for the active route in both basic and advanced UI, including after setup locks the route.
- Local routes list CLI-reported models and fall back to a curated per-family catalog (`AssistantModelCatalog`); cloud routes list a curated per-provider catalog (e.g. `claude-fable-5`, `claude-opus-4-8`, `claude-sonnet-5` for Anthropic). Both selectors stay editable.
- The selected model reaches the CLIs as `--model` and `autobot_provider_chat` as the `model` argument (the previously dead `localModel` dropdown is now wired). Effort maps to Codex's `model_reasoning_effort` config flag; Claude/Copilot/cloud providers receive a one-line reasoning-effort preamble.
- A cloud route configured during setup is no longer forced back to LOCAL in the basic UI.

### Live verification fixes (real Gemini API key)
- `AssistantGeminiLiveE2ETest` passed green end-to-end (plugin invocation -> shaft-mcp -> Gemini `generateContent` -> valid `DuckDuckGoSearchTest`). That run surfaced and fixed:
  - Gradle never forwarded `shaft.intellij.workspaceRoot` to the test JVM (MCP rejected the Autobot working directory); also added a `shaft.intellij.liveGeminiModel` override because Google load-sheds `gemini-3.5-flash` structured-output calls with 503 during demand spikes.
  - The live test asserted generated Java inline in `answer`; providers legitimately return it in `codeBlocks`.
  - `autobot_provider_chat`'s 2k output-token budget truncated full test classes into malformed JSON on reasoning models (thinking tokens share the budget); raised to 8k.
- The screenshot renderer now activates `IconLoader` so evidence shows the real SVG action icons instead of placeholder glyphs.

## Checks
- `gradle test` (shaft-intellij): 277 tests, 0 failures.
- `mvn -pl shaft-mcp -am compile`: clean.
- Live E2E: `-Dshaft.intellij.liveGemini=true -Dshaft.intellij.liveGeminiModel=gemini-2.5-flash` green against the real Gemini API.

## Screenshots
Rendered via `ShaftPluginScreenshotRendererTest` (now with real icons): new Gemini setup step and the composer's model/effort selectors; also refreshed in the docs PR.

Docs PR: ShaftHQ/shafthq.github.io (branch `codex/intellij-gemini-model-selection-3369`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)