### PR TITLE
Fix /record-web session loss, stop, and guided assertion flow

### DIFF
--- a/scripts/mcp/install-shaft-mcp.ps1
+++ b/scripts/mcp/install-shaft-mcp.ps1
@@ -176,8 +176,29 @@ function Install-ShaftMcp {
         return [pscustomobject] @{ Command = $python; Prefix = @() }
     }
 
+    function Test-ShaftEngineRepoCheckout([string] $ScriptDirectory) {
+        # Only a real SHAFT_ENGINE checkout has its own repo root pom.xml two directories up from
+        # scripts/mcp (matching where this very script lives in-tree). A remote "copy command" run
+        # always downloads install-shaft-mcp.ps1 into a scratch/temp directory instead, so this
+        # check reliably tells a genuine in-repo invocation apart from that scratch directory --
+        # otherwise a stale install_shaft_mcp.py left behind by an earlier remote run in the same
+        # temp directory would be reused forever instead of always fetching the latest installer.
+        if ([string]::IsNullOrWhiteSpace($ScriptDirectory)) {
+            return $false
+        }
+        $repoPom = Join-Path $ScriptDirectory "..\..\pom.xml"
+        if (-not (Test-Path -LiteralPath $repoPom)) {
+            return $false
+        }
+        try {
+            return (Get-Content -LiteralPath $repoPom -Raw) -match "<artifactId>\s*shaft-parent\s*</artifactId>"
+        } catch {
+            return $false
+        }
+    }
+
     function Resolve-PythonInstallerScript([string] $Root) {
-        if (-not [string]::IsNullOrWhiteSpace($PSScriptRoot)) {
+        if ((-not [string]::IsNullOrWhiteSpace($PSScriptRoot)) -and (Test-ShaftEngineRepoCheckout $PSScriptRoot)) {
             $local = Join-Path $PSScriptRoot "install_shaft_mcp.py"
             if (Test-Path -LiteralPath $local) {
                 return (Resolve-Path -LiteralPath $local).Path

--- a/scripts/mcp/install-shaft-mcp.sh
+++ b/scripts/mcp/install-shaft-mcp.sh
@@ -174,6 +174,20 @@ install_portable_python() {
   printf '%s\n' "$python_path"
 }
 
+# Only a real SHAFT_ENGINE checkout has its own repo root pom.xml two directories up from
+# scripts/mcp (matching where this very script lives in-tree). A remote "copy command" run always
+# downloads install-shaft-mcp.sh into a scratch/temp directory instead, so this check reliably
+# tells a genuine in-repo invocation apart from that scratch directory -- otherwise a stale
+# install_shaft_mcp.py left behind by an earlier remote run in the same temp directory would be
+# reused forever instead of always fetching the latest installer.
+is_shaft_engine_repo_checkout() {
+  script_dir="$1"
+  [ -n "$script_dir" ] || return 1
+  repo_pom="$script_dir/../../pom.xml"
+  [ -f "$repo_pom" ] || return 1
+  grep -Eq '<artifactId>[[:space:]]*shaft-parent[[:space:]]*</artifactId>' "$repo_pom" 2>/dev/null
+}
+
 resolve_python_script() {
   root="$1"
   script_dir=""
@@ -182,7 +196,8 @@ resolve_python_script() {
       script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd -P || true)"
       ;;
   esac
-  if [ -n "$script_dir" ] && [ -f "$script_dir/install_shaft_mcp.py" ]; then
+  if [ -n "$script_dir" ] && is_shaft_engine_repo_checkout "$script_dir" \
+      && [ -f "$script_dir/install_shaft_mcp.py" ]; then
     printf '%s\n' "$script_dir/install_shaft_mcp.py"
     return 0
   fi

--- a/shaft-capture/src/main/java/com/shaft/capture/collector/PollingBrowserEventCollector.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/collector/PollingBrowserEventCollector.java
@@ -185,6 +185,12 @@ public final class PollingBrowserEventCollector implements BrowserEventCollector
             if (warned.compareAndSet(false, true)) {
                 warningConsumer.accept("The compatibility listener temporarily lost browser access.");
             }
+        } catch (RuntimeException exception) {
+            // Any other failure must not escape: an uncaught exception would silently cancel
+            // this scheduled poll forever and every later browser interaction would be lost.
+            if (warned.compareAndSet(false, true)) {
+                warningConsumer.accept("The compatibility listener skipped one polling cycle.");
+            }
         }
     }
 

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
@@ -189,8 +189,15 @@ final class CaptureEventPipeline implements AutoCloseable {
     }
 
     private void flushSignal(BrowserSignal signal) {
-        if (signal != null) {
+        if (signal == null) {
+            return;
+        }
+        try {
             emit(signal);
+        } catch (RuntimeException exception) {
+            // Debounced signals flush on the scheduled debounce thread, where an uncaught
+            // exception would cancel the flush loop forever; one bad signal must only skip itself.
+            warningConsumer.accept("A browser interaction could not be normalized and was skipped.");
         }
     }
 

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureManager.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureManager.java
@@ -19,6 +19,10 @@ import java.util.function.Function;
  */
 public final class CaptureManager implements AutoCloseable {
     private static final Duration HEALTH_INTERVAL = Duration.ofSeconds(1);
+    // Transient WebDriver hiccups (a busy page, a slow DevTools round trip) can make one
+    // liveness probe fail while the browser is perfectly healthy. Only consecutive failures
+    // may tear the session down, or a single flaky check silently discards the recording.
+    private static final int HEALTH_FAILURES_BEFORE_INTERRUPT = 3;
 
     private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(runnable -> {
         Thread thread = new Thread(runnable, "shaft-capture-manager");
@@ -33,6 +37,7 @@ public final class CaptureManager implements AutoCloseable {
     private volatile String mode = "record";
     private CaptureSingleSessionLock sessionLock;
     private ScheduledFuture<?> healthCheck;
+    private int consecutiveHealthFailures;
 
     /**
      * Creates the default managed recorder lifecycle.
@@ -76,6 +81,7 @@ public final class CaptureManager implements AutoCloseable {
                 recorder = recorderFactory.apply(request);
                 recorder.start();
                 lastStatus = recorder.status();
+                consecutiveHealthFailures = 0;
                 healthCheck = executor.scheduleWithFixedDelay(
                         this::verifyBrowserHealth,
                         HEALTH_INTERVAL.toMillis(),
@@ -307,12 +313,18 @@ public final class CaptureManager implements AutoCloseable {
             releaseLock();
             return;
         }
-        if (!current.isBrowserAlive()) {
-            cancelHealthCheck();
-            lastStatus = current.interrupt();
-            recorder = null;
-            releaseLock();
+        if (current.isBrowserAlive()) {
+            consecutiveHealthFailures = 0;
+            return;
         }
+        consecutiveHealthFailures++;
+        if (consecutiveHealthFailures < HEALTH_FAILURES_BEFORE_INTERRUPT) {
+            return;
+        }
+        cancelHealthCheck();
+        lastStatus = current.interrupt();
+        recorder = null;
+        releaseLock();
     }
 
     private ManagedCaptureRecorder requireRecorder() {

--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -644,9 +644,10 @@
   // 1:1 so every choice maps directly to a SHAFT Validations API call in CaptureGenerator;
   // nothing here is generated or inferred at runtime.
   const ELEMENT_ASSERTIONS = [
-    {kind: "ELEMENT_VISIBLE", label: "Element is visible", needsValue: false, needsAttribute: false},
-    {kind: "ELEMENT_ENABLED", label: "Element is enabled", needsValue: false, needsAttribute: false},
-    {kind: "ELEMENT_SELECTED", label: "Element is selected", needsValue: false, needsAttribute: false},
+    {kind: "ELEMENT_PRESENT", label: "Element exists", needsValue: false, needsAttribute: false, booleanCheck: true},
+    {kind: "ELEMENT_VISIBLE", label: "Element is visible", needsValue: false, needsAttribute: false, booleanCheck: true},
+    {kind: "ELEMENT_ENABLED", label: "Element is enabled", needsValue: false, needsAttribute: false, booleanCheck: true},
+    {kind: "ELEMENT_SELECTED", label: "Element is selected", needsValue: false, needsAttribute: false, booleanCheck: true},
     {kind: "TEXT_EQUALS", label: "Text equals", needsValue: true, needsAttribute: false},
     {kind: "TEXT_CONTAINS", label: "Text contains", needsValue: true, needsAttribute: false},
     {kind: "ATTRIBUTE_EQUALS", label: "Attribute equals", needsValue: true, needsAttribute: true},
@@ -825,13 +826,20 @@
     return row;
   };
   const finishAssertion = (target, payload, summaryText) => {
-    announce(summaryText, "", target ? {
+    const item = announce(summaryText, "", target ? {
       kind: "verification",
       target,
       locator: bestLocatorSummary(target),
       readiness: "READY",
       warning: ""
     } : {kind: "verification", readiness: "READY", warning: ""});
+    if (item) {
+      // Carrying the client action id and description lets the persisted verification event
+      // surface in the server-side step list, so saved assertions rehydrate across navigations
+      // exactly like recorded interactions.
+      payload.clientActionId = clientActionId(item);
+      payload.stepDescription = text(summaryText);
+    }
     sendVerification(target, payload);
     closeAssertionPanel();
     uiState.assertionMode = false;
@@ -843,6 +851,22 @@
     const list = document.createElement("div");
     list.className = "assertion-data-step";
     const fields = [];
+    let expectedBooleanInput = null;
+    if (catalogEntry.booleanCheck) {
+      const label = document.createElement("label");
+      const caption = document.createElement("span");
+      caption.textContent = "Expected";
+      expectedBooleanInput = document.createElement("select");
+      expectedBooleanInput.name = "expectedBoolean";
+      [{value: "true", label: "true"}, {value: "false", label: "false"}].forEach(option => {
+        const item = document.createElement("option");
+        item.value = option.value;
+        item.textContent = option.label;
+        expectedBooleanInput.appendChild(item);
+      });
+      label.append(caption, expectedBooleanInput);
+      list.appendChild(label);
+    }
     if (catalogEntry.needsAttribute) {
       const label = document.createElement("label");
       const caption = document.createElement("span");
@@ -872,7 +896,8 @@
     confirm.type = "button";
     confirm.textContent = "Save assertion";
     confirm.addEventListener("click", () => {
-      const payload = {verification: catalogEntry.kind, negated: false};
+      const negated = Boolean(expectedBooleanInput && expectedBooleanInput.value === "false");
+      const payload = {verification: catalogEntry.kind, negated};
       if (catalogEntry.needsAttribute) {
         payload.attributeName = text(fields[0].value);
         if (!payload.attributeName) return;
@@ -881,12 +906,15 @@
         payload.expected = valueText(valueInput.value);
       }
       const name = target ? targetName(target) : "page";
-      finishAssertion(target, payload, "Assert " + catalogEntry.label.toLowerCase() + " on " + name);
+      const summary = negated
+        ? "Assert not " + catalogEntry.label.toLowerCase() + " on " + name
+        : "Assert " + catalogEntry.label.toLowerCase() + " on " + name;
+      finishAssertion(target, payload, summary);
     });
     const actions = cancelAssertionRow(closeAssertionPanel);
     actions.appendChild(confirm);
     renderAssertionPanel(catalogEntry.label, [list, actions]);
-    const first = list.querySelector("input");
+    const first = list.querySelector("select,input");
     if (first) first.focus();
   };
   const showAssertionCatalogStep = (catalog, target, element) => {
@@ -1231,7 +1259,8 @@
         color: var(--shaft-text-muted);
         font-size: 12px;
       }
-      #shaft-capture-assertion-panel input {
+      #shaft-capture-assertion-panel input,
+      #shaft-capture-assertion-panel select {
         min-width: 0;
         height: 30px;
         border: 1px solid var(--shaft-border);
@@ -1394,14 +1423,20 @@
   const quickAssertion = item => {
     const target = item.details && item.details.target;
     if (!target) return;
-    announce("Assert element visible on " + targetName(target), "", {
+    const summaryText = "Assert element visible on " + targetName(target);
+    const created = announce(summaryText, "", {
       kind: "verification",
       target,
       locator: bestLocatorSummary(target),
       readiness: "READY",
       warning: ""
     });
-    sendVerification(target, {verification: "ELEMENT_VISIBLE"});
+    const payload = {verification: "ELEMENT_VISIBLE"};
+    if (created) {
+      payload.clientActionId = clientActionId(created);
+      payload.stepDescription = text(summaryText);
+    }
+    sendVerification(target, payload);
   };
   const deleteAction = item => {
     uiState.actions = uiState.actions.filter(action => action.id !== item.id);

--- a/shaft-capture/src/test/java/com/shaft/capture/collector/PollingBrowserEventCollectorResilienceTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/collector/PollingBrowserEventCollectorResilienceTest.java
@@ -1,0 +1,138 @@
+package com.shaft.capture.collector;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The polling collector runs on a scheduled executor, where an uncaught exception silently
+ * cancels all future polls: one unexpected runtime failure used to stop event collection for the
+ * rest of the session while the browser stayed interactive (issue #3365).
+ */
+class PollingBrowserEventCollectorResilienceTest {
+    @Test
+    void pollingSurvivesUnexpectedRuntimeFailures() throws Exception {
+        AtomicInteger polls = new AtomicInteger();
+        List<String> warnings = new CopyOnWriteArrayList<>();
+        WebDriver driver = new ThrowingDriver(polls);
+        PollingBrowserEventCollector collector =
+                new PollingBrowserEventCollector(driver, false, List.of());
+        try {
+            collector.start(signal -> {
+            }, warnings::add);
+            waitFor(() -> polls.get() >= 3, Duration.ofSeconds(5));
+        } finally {
+            collector.close();
+        }
+
+        assertTrue(polls.get() >= 3,
+                "Polling must keep running after an unexpected runtime failure in one cycle.");
+        assertEquals(List.of("The compatibility listener skipped one polling cycle."), warnings,
+                "The unexpected failure must be reported exactly once.");
+    }
+
+    private static void waitFor(java.util.function.BooleanSupplier condition, Duration timeout)
+            throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (!condition.getAsBoolean() && System.nanoTime() < deadline) {
+            Thread.sleep(50);
+        }
+        assertTrue(condition.getAsBoolean());
+    }
+
+    /**
+     * Minimal driver stub whose every command fails with a plain RuntimeException — the class of
+     * failure the collector's WebDriverException handling never covered.
+     */
+    private static final class ThrowingDriver implements WebDriver, JavascriptExecutor {
+        private final AtomicInteger polls;
+
+        private ThrowingDriver(AtomicInteger polls) {
+            this.polls = polls;
+        }
+
+        @Override
+        public Set<String> getWindowHandles() {
+            polls.incrementAndGet();
+            throw new IllegalStateException("unexpected driver failure");
+        }
+
+        @Override
+        public Object executeScript(String script, Object... args) {
+            throw new IllegalStateException("unexpected driver failure");
+        }
+
+        @Override
+        public Object executeAsyncScript(String script, Object... args) {
+            throw new IllegalStateException("unexpected driver failure");
+        }
+
+        @Override
+        public void get(String url) {
+        }
+
+        @Override
+        public String getCurrentUrl() {
+            throw new IllegalStateException("unexpected driver failure");
+        }
+
+        @Override
+        public String getTitle() {
+            throw new IllegalStateException("unexpected driver failure");
+        }
+
+        @Override
+        public List<WebElement> findElements(By by) {
+            return List.of();
+        }
+
+        @Override
+        public WebElement findElement(By by) {
+            throw new IllegalStateException("unexpected driver failure");
+        }
+
+        @Override
+        public String getPageSource() {
+            return "";
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public void quit() {
+        }
+
+        @Override
+        public String getWindowHandle() {
+            throw new IllegalStateException("unexpected driver failure");
+        }
+
+        @Override
+        public TargetLocator switchTo() {
+            throw new IllegalStateException("unexpected driver failure");
+        }
+
+        @Override
+        public Navigation navigate() {
+            throw new IllegalStateException("unexpected driver failure");
+        }
+
+        @Override
+        public Options manage() {
+            throw new IllegalStateException("unexpected driver failure");
+        }
+    }
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureManagerHealthCheckTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureManagerHealthCheckTest.java
@@ -99,7 +99,7 @@ class CaptureManagerHealthCheckTest {
         }
 
         @Override
-        CaptureStatus status() {
+        synchronized CaptureStatus status() {
             return new CaptureStatus(
                     state,
                     "flaky-session",
@@ -114,25 +114,25 @@ class CaptureManagerHealthCheckTest {
         }
 
         @Override
-        void checkpoint(String description, Checkpoint.CheckpointKind kind) {
+        synchronized void checkpoint(String description, Checkpoint.CheckpointKind kind) {
             // Unused in health-check tests.
         }
 
         @Override
-        CaptureStatus stop(boolean discard) {
+        synchronized CaptureStatus stop(boolean discard) {
             state = discard ? CaptureStatus.State.DISCARDED : CaptureStatus.State.COMPLETED;
             return status();
         }
 
         @Override
-        CaptureStatus interrupt() {
+        synchronized CaptureStatus interrupt() {
             interruptCount.incrementAndGet();
             state = CaptureStatus.State.INCOMPLETE;
             return status();
         }
 
         @Override
-        boolean isBrowserAlive() {
+        synchronized boolean isBrowserAlive() {
             if (state != CaptureStatus.State.ACTIVE) {
                 return false;
             }

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureManagerHealthCheckTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureManagerHealthCheckTest.java
@@ -1,0 +1,142 @@
+package com.shaft.capture.runtime;
+
+import com.shaft.capture.model.Checkpoint;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The periodic browser health check must only tear a session down after consecutive liveness
+ * failures: one transient WebDriver hiccup (a busy page, a slow DevTools round trip) used to
+ * interrupt the recorder immediately, silently discarding every later interaction (issue #3365).
+ */
+class CaptureManagerHealthCheckTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void transientLivenessFailuresDoNotInterruptTheSession() throws Exception {
+        // Browser reports dead for two consecutive checks, then recovers.
+        AtomicReference<FlakyRecorder> recorderRef = new AtomicReference<>();
+        CaptureManager manager = new CaptureManager(request -> {
+            FlakyRecorder recorder = new FlakyRecorder(request, 2);
+            recorderRef.set(recorder);
+            return recorder;
+        });
+
+        assertEquals(CaptureStatus.State.ACTIVE, manager.start(request("transient.json")).state());
+        waitFor(() -> recorderRef.get().livenessChecks.get() >= 4, Duration.ofSeconds(15));
+
+        assertEquals(0, recorderRef.get().interruptCount.get(),
+                "Transient liveness failures must not interrupt the recording session.");
+        assertEquals(CaptureStatus.State.ACTIVE, manager.status().state());
+        assertEquals(CaptureStatus.State.COMPLETED, manager.stop(false).state());
+        manager.close();
+    }
+
+    @Test
+    void persistentLivenessFailuresInterruptTheSession() throws Exception {
+        AtomicReference<FlakyRecorder> recorderRef = new AtomicReference<>();
+        CaptureManager manager = new CaptureManager(request -> {
+            FlakyRecorder recorder = new FlakyRecorder(request, Integer.MAX_VALUE);
+            recorderRef.set(recorder);
+            return recorder;
+        });
+
+        assertEquals(CaptureStatus.State.ACTIVE, manager.start(request("persistent.json")).state());
+        waitFor(() -> recorderRef.get().interruptCount.get() > 0, Duration.ofSeconds(15));
+
+        assertEquals(1, recorderRef.get().interruptCount.get());
+        assertTrue(recorderRef.get().livenessChecks.get() >= 3,
+                "The session must only be interrupted after consecutive failed liveness checks.");
+        assertEquals(CaptureStatus.State.INCOMPLETE, manager.status().state());
+        manager.close();
+    }
+
+    private CaptureStartRequest request(String outputName) {
+        return new CaptureStartRequest(
+                "https://example.test",
+                CaptureBrowser.CHROME,
+                temp.resolve(outputName),
+                temp.resolve("runtime"),
+                true);
+    }
+
+    private static void waitFor(java.util.function.BooleanSupplier condition, Duration timeout)
+            throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (!condition.getAsBoolean() && System.nanoTime() < deadline) {
+            Thread.sleep(100);
+        }
+        assertTrue(condition.getAsBoolean());
+    }
+
+    private static final class FlakyRecorder extends ManagedCaptureRecorder {
+        private final CaptureStartRequest request;
+        private final int deadChecks;
+        private final AtomicInteger livenessChecks = new AtomicInteger();
+        private final AtomicInteger interruptCount = new AtomicInteger();
+        private CaptureStatus.State state = CaptureStatus.State.STARTING;
+
+        FlakyRecorder(CaptureStartRequest request, int deadChecks) {
+            super(request);
+            this.request = request;
+            this.deadChecks = deadChecks;
+        }
+
+        @Override
+        void start() {
+            state = CaptureStatus.State.ACTIVE;
+        }
+
+        @Override
+        CaptureStatus status() {
+            return new CaptureStatus(
+                    state,
+                    "flaky-session",
+                    request.browser().name().toLowerCase(),
+                    request.targetUrl(),
+                    0,
+                    List.of(),
+                    request.outputPath().toString(),
+                    false,
+                    ProcessHandle.current().pid(),
+                    Instant.parse("2026-01-02T03:04:05Z"));
+        }
+
+        @Override
+        void checkpoint(String description, Checkpoint.CheckpointKind kind) {
+            // Unused in health-check tests.
+        }
+
+        @Override
+        CaptureStatus stop(boolean discard) {
+            state = discard ? CaptureStatus.State.DISCARDED : CaptureStatus.State.COMPLETED;
+            return status();
+        }
+
+        @Override
+        CaptureStatus interrupt() {
+            interruptCount.incrementAndGet();
+            state = CaptureStatus.State.INCOMPLETE;
+            return status();
+        }
+
+        @Override
+        boolean isBrowserAlive() {
+            if (state != CaptureStatus.State.ACTIVE) {
+                return false;
+            }
+            return livenessChecks.incrementAndGet() > deadChecks;
+        }
+    }
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
@@ -258,6 +258,120 @@ class ManagedCaptureRecorderBrowserTest {
                 "The final COMPLETE file must include the domain-B action.");
     }
 
+    /**
+     * Drives the in-page recorder overlay's guided assertion flow end to end, exactly as a user
+     * would (issue #3365): the single Assertion entry point offers Element and Browser branches;
+     * the Element branch captures the clicked target, offers scored locator candidates plus a
+     * manual locator, then a fixed assertion catalog including existence with a true/false
+     * expected choice; the Browser branch offers the fixed page-level catalog with an editable
+     * expected value. Both saved assertions must persist as {@code VerificationEvent}s in the
+     * session file and surface in the server-side step list.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"chrome", "edge"})
+    void overlayGuidedAssertionFlowPersistsVerificationEvents(
+            String browserName,
+            @TempDir Path temp) throws Exception {
+        HttpServer server = localFixture();
+        Path output = temp.resolve(browserName + "-assertions.json");
+        ManagedCaptureRecorder recorder = new ManagedCaptureRecorder(new CaptureStartRequest(
+                "http://127.0.0.1:" + server.getAddress().getPort() + "/",
+                CaptureBrowser.parse(browserName),
+                output,
+                temp.resolve(browserName + "-assertions-runtime"),
+                true));
+        try {
+            recorder.start();
+            WebDriver driver = recorder.driverForTesting();
+            waitFor(() -> elementPresent(driver, By.id("shaft-capture-assert")));
+
+            // Element branch: entry point -> Element -> click target -> pick locator ->
+            // "Element exists" with expected=false (negated existence).
+            driver.findElement(By.id("shaft-capture-assert")).click();
+            waitFor(() -> elementPresent(driver, assertionChoice("Element")));
+            driver.findElement(assertionChoice("Element")).click();
+            driver.findElement(By.id("username")).click();
+            waitFor(() -> elementPresent(driver, By.xpath(
+                    "//*[@id='shaft-capture-assertion-panel']//button[normalize-space()='Use this locator']")));
+            driver.findElement(By.xpath(
+                    "//*[@id='shaft-capture-assertion-panel']//button[normalize-space()='Use this locator']")).click();
+            waitFor(() -> elementPresent(driver, By.cssSelector(
+                    "#shaft-capture-assertion-panel button[data-assertion-kind='ELEMENT_PRESENT']")));
+            driver.findElement(By.cssSelector(
+                    "#shaft-capture-assertion-panel button[data-assertion-kind='ELEMENT_PRESENT']")).click();
+            waitFor(() -> elementPresent(driver, By.cssSelector(
+                    "#shaft-capture-assertion-panel select[name='expectedBoolean']")));
+            new Select(driver.findElement(By.cssSelector(
+                    "#shaft-capture-assertion-panel select[name='expectedBoolean']"))).selectByValue("false");
+            driver.findElement(By.xpath(
+                    "//*[@id='shaft-capture-assertion-panel']//button[normalize-space()='Save assertion']")).click();
+            waitFor(() -> stepDescriptions(recorder).stream()
+                    .anyMatch(description -> description.startsWith("Assert not element exists")));
+
+            // Browser branch: entry point -> Browser -> "Title contains" with an edited value.
+            driver.findElement(By.id("shaft-capture-assert")).click();
+            waitFor(() -> elementPresent(driver, assertionChoice("Browser")));
+            driver.findElement(assertionChoice("Browser")).click();
+            waitFor(() -> elementPresent(driver, By.cssSelector(
+                    "#shaft-capture-assertion-panel button[data-assertion-kind='TITLE_CONTAINS']")));
+            driver.findElement(By.cssSelector(
+                    "#shaft-capture-assertion-panel button[data-assertion-kind='TITLE_CONTAINS']")).click();
+            waitFor(() -> elementPresent(driver, By.cssSelector(
+                    "#shaft-capture-assertion-panel input[name='expected']")));
+            WebElement expected = driver.findElement(By.cssSelector(
+                    "#shaft-capture-assertion-panel input[name='expected']"));
+            expected.clear();
+            expected.sendKeys("Capture Fixture");
+            driver.findElement(By.xpath(
+                    "//*[@id='shaft-capture-assertion-panel']//button[normalize-space()='Save assertion']")).click();
+            waitFor(() -> stepDescriptions(recorder).stream()
+                    .anyMatch(description -> description.startsWith("Assert title contains")));
+
+            recorder.stop(false);
+        } finally {
+            if (recorder.status().state() == CaptureStatus.State.ACTIVE) {
+                recorder.interrupt();
+            }
+            server.stop(0);
+        }
+
+        CaptureSession session = new CaptureJsonCodec().read(output);
+        assertEquals(CaptureSession.SessionStatus.COMPLETED, session.status());
+        List<CaptureEvent.VerificationEvent> verifications = session.events().stream()
+                .filter(CaptureEvent.VerificationEvent.class::isInstance)
+                .map(CaptureEvent.VerificationEvent.class::cast)
+                .toList();
+        CaptureEvent.VerificationEvent existence = verifications.stream()
+                .filter(event -> event.verification() == CaptureEvent.VerificationKind.ELEMENT_PRESENT)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "The Element branch must persist an ELEMENT_PRESENT verification event."));
+        assertTrue(existence.negated(),
+                "Choosing expected=false must persist the existence assertion as negated.");
+        assertTrue(existence.target() != null && !existence.target().locatorCandidates().isEmpty(),
+                "The element assertion must carry the picked target's locator candidates.");
+        CaptureEvent.VerificationEvent title = verifications.stream()
+                .filter(event -> event.verification() == CaptureEvent.VerificationKind.TITLE_CONTAINS)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "The Browser branch must persist a TITLE_CONTAINS verification event."));
+        assertFalse(title.negated(), "The browser assertion was not negated.");
+        assertTrue(title.expected() != null,
+                "The browser assertion must persist its expected value reference.");
+    }
+
+    private static By assertionChoice(String label) {
+        return By.xpath("//*[@id='shaft-capture-assertion-panel']//button[normalize-space()='" + label + "']");
+    }
+
+    private static boolean elementPresent(WebDriver driver, By locator) {
+        try {
+            return !driver.findElements(locator).isEmpty();
+        } catch (WebDriverException ignored) {
+            return false;
+        }
+    }
+
     private static List<String> persistedDescriptions(CaptureSession session) {
         List<String> descriptions = new java.util.ArrayList<>();
         for (String field : List.of("userDescription", "stepDescription")) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpInvocationService.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpInvocationService.java
@@ -2,10 +2,12 @@ package com.shaft.intellij.mcp;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.project.Project;
 import com.shaft.intellij.settings.ShaftSettingsState;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
@@ -17,13 +19,25 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Project service that invokes SHAFT MCP tools through the configured stdio command.
+ *
+ * <p>Tool calls share one long-lived MCP server process per project. Session-starting tools
+ * (SHAFT Capture recordings, live browser/mobile drivers) keep their state inside that process,
+ * so it must survive across tool calls: a recording started by {@code capture_start} stays
+ * collecting until {@code capture_stop} arrives on the same process. The shared process is
+ * respawned transparently when it dies or when the configured command changes, and is shut down
+ * gracefully (stdin end-of-stream first) so live sessions can release their browsers.</p>
  */
-public final class ShaftMcpInvocationService {
+public final class ShaftMcpInvocationService implements Disposable {
     private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(90);
     private static final String DISCONNECTED_MESSAGE = "MCP connection is disconnected. Click 'Reconnect' to restore service.";
 
     private final Project project;
     private final ShaftMcpConnectionState connectionState;
+    private final Object clientLock = new Object();
+    private ShaftMcpStdioClient sharedClient;
+    private List<String> sharedCommand = List.of();
+    private Map<String, String> sharedEnvironment = Map.of();
+    private Path sharedWorkingDirectory;
 
     /**
      * Creates the project-scoped invocation service.
@@ -79,7 +93,8 @@ public final class ShaftMcpInvocationService {
         AtomicReference<ShaftMcpStdioClient> clientReference = new AtomicReference<>();
         AtomicBoolean cancellationRequested = new AtomicBoolean();
         CompletableFuture<ShaftMcpToolResult> future = CompletableFuture.supplyAsync(
-                () -> listTools(command, settings, clientReference, cancellationRequested));
+                () -> call(command, settings, clientReference, cancellationRequested,
+                        client -> client.listTools(DEFAULT_TIMEOUT)));
         return new ShaftMcpInvocation(
                 future,
                 () -> cancel(clientReference, cancellationRequested, false),
@@ -105,7 +120,9 @@ public final class ShaftMcpInvocationService {
         AtomicReference<ShaftMcpStdioClient> clientReference = new AtomicReference<>();
         AtomicBoolean cancellationRequested = new AtomicBoolean();
         CompletableFuture<ShaftMcpToolResult> future = CompletableFuture.supplyAsync(
-                () -> invoke(command, toolName, arguments, settings, clientReference, cancellationRequested));
+                () -> call(command, settings, clientReference, cancellationRequested,
+                        client -> client.callTool(toolName,
+                                arguments == null ? new JsonObject() : arguments, DEFAULT_TIMEOUT)));
         return new ShaftMcpInvocation(
                 future,
                 () -> cancel(clientReference, cancellationRequested, false),
@@ -133,35 +150,91 @@ public final class ShaftMcpInvocationService {
                 () -> cancel(clientReference, cancellationRequested, true));
     }
 
-    private ShaftMcpToolResult invoke(
+    @Override
+    public void dispose() {
+        synchronized (clientLock) {
+            closeSharedClientLocked();
+        }
+    }
+
+    private interface McpRequest {
+        JsonElement send(ShaftMcpStdioClient client) throws IOException;
+    }
+
+    private ShaftMcpToolResult call(
             List<String> command,
-            String toolName,
-            JsonObject arguments,
             ShaftSettingsState.Settings settings,
             AtomicReference<ShaftMcpStdioClient> clientReference,
-            AtomicBoolean cancellationRequested) {
+            AtomicBoolean cancellationRequested,
+            McpRequest request) {
         Path workingDirectory = project.getBasePath() == null ? Path.of(".") : Path.of(project.getBasePath());
+        ShaftMcpStdioClient client = null;
         try {
             Map<String, String> environment = ShaftMcpProjectScope.environmentForProject(
                     ShaftMcpEnvironment.forSettings(settings), workingDirectory);
             List<String> scopedCommand = ShaftMcpProjectScope.commandForProject(command, workingDirectory);
-            try (ShaftMcpStdioClient client = new ShaftMcpStdioClient(scopedCommand, workingDirectory, environment)) {
-                clientReference.set(client);
-                if (cancellationRequested.get()) {
-                    throw new CancellationException("Operation cancelled");
-                }
-                JsonElement result = client.callTool(toolName, arguments == null ? new JsonObject() : arguments,
-                        DEFAULT_TIMEOUT);
-                return ShaftMcpToolResult.success(result.toString());
+            client = acquireClient(scopedCommand, workingDirectory, environment);
+            clientReference.set(client);
+            if (cancellationRequested.get()) {
+                throw new CancellationException("Operation cancelled");
             }
+            JsonElement result = request.send(client);
+            return ShaftMcpToolResult.success(result.toString());
         } catch (Exception exception) {
             if (cancellationRequested.get() || exception instanceof CancellationException) {
                 throw new CancellationException("Operation cancelled");
             }
+            dropClientIfDead(client);
             McpInvocationError category = McpInvocationError.categorize(exception);
             return ShaftMcpToolResult.failure(category.message(), category, category.recoveryAction());
         } finally {
             clientReference.set(null);
+        }
+    }
+
+    /**
+     * Returns the shared MCP server client, spawning a fresh process when none is alive or the
+     * effective command, environment, or working directory changed since the last call.
+     */
+    private ShaftMcpStdioClient acquireClient(
+            List<String> scopedCommand,
+            Path workingDirectory,
+            Map<String, String> environment) throws IOException {
+        synchronized (clientLock) {
+            if (sharedClient != null
+                    && sharedClient.isAlive()
+                    && sharedCommand.equals(scopedCommand)
+                    && sharedEnvironment.equals(environment)
+                    && workingDirectory.equals(sharedWorkingDirectory)) {
+                return sharedClient;
+            }
+            closeSharedClientLocked();
+            sharedClient = new ShaftMcpStdioClient(scopedCommand, workingDirectory, environment);
+            sharedCommand = List.copyOf(scopedCommand);
+            sharedEnvironment = Map.copyOf(environment);
+            sharedWorkingDirectory = workingDirectory;
+            return sharedClient;
+        }
+    }
+
+    private void dropClientIfDead(ShaftMcpStdioClient client) {
+        if (client == null || client.isAlive()) {
+            return;
+        }
+        synchronized (clientLock) {
+            if (sharedClient == client) {
+                closeSharedClientLocked();
+            }
+        }
+    }
+
+    private void closeSharedClientLocked() {
+        if (sharedClient != null) {
+            sharedClient.close();
+            sharedClient = null;
+            sharedCommand = List.of();
+            sharedEnvironment = Map.of();
+            sharedWorkingDirectory = null;
         }
     }
 
@@ -193,51 +266,35 @@ public final class ShaftMcpInvocationService {
         }
     }
 
-    private ShaftMcpToolResult listTools(
-            List<String> command,
-            ShaftSettingsState.Settings settings,
-            AtomicReference<ShaftMcpStdioClient> clientReference,
-            AtomicBoolean cancellationRequested) {
-        Path workingDirectory = project.getBasePath() == null ? Path.of(".") : Path.of(project.getBasePath());
-        try {
-            Map<String, String> environment = ShaftMcpProjectScope.environmentForProject(
-                    ShaftMcpEnvironment.forSettings(settings), workingDirectory);
-            List<String> scopedCommand = ShaftMcpProjectScope.commandForProject(command, workingDirectory);
-            try (ShaftMcpStdioClient client = new ShaftMcpStdioClient(scopedCommand, workingDirectory, environment)) {
-                clientReference.set(client);
-                if (cancellationRequested.get()) {
-                    throw new CancellationException("Operation cancelled");
-                }
-                JsonElement result = client.listTools(DEFAULT_TIMEOUT);
-                return ShaftMcpToolResult.success(result.toString());
-            }
-        } catch (Exception exception) {
-            if (cancellationRequested.get() || exception instanceof CancellationException) {
-                throw new CancellationException("Operation cancelled");
-            }
-            McpInvocationError category = McpInvocationError.categorize(exception);
-            return ShaftMcpToolResult.failure(category.message(), category, category.recoveryAction());
-        } finally {
-            clientReference.set(null);
-        }
-    }
-
     private static ShaftMcpInvocation completed(String message) {
         return new ShaftMcpInvocation(CompletableFuture.completedFuture(ShaftMcpToolResult.failure(message)), () -> {
         });
     }
 
-    private static void cancel(AtomicReference<ShaftMcpStdioClient> clientReference,
-                               AtomicBoolean cancellationRequested,
-                               boolean force) {
+    private void cancel(AtomicReference<ShaftMcpStdioClient> clientReference,
+                        AtomicBoolean cancellationRequested,
+                        boolean force) {
         cancellationRequested.set(true);
         ShaftMcpStdioClient client = force ? clientReference.getAndSet(null) : clientReference.get();
-        if (client != null) {
-            if (force) {
-                client.kill();
-            } else {
-                client.cancel();
+        if (client == null) {
+            return;
+        }
+        if (force) {
+            // Force-kill terminates the shared server process; live sessions in it are lost and
+            // the next tool call spawns a fresh process.
+            synchronized (clientLock) {
+                if (sharedClient == client) {
+                    sharedClient = null;
+                    sharedCommand = List.of();
+                    sharedEnvironment = Map.of();
+                    sharedWorkingDirectory = null;
+                }
             }
+            client.kill();
+        } else {
+            // Graceful cancel abandons in-flight requests but keeps the shared server process
+            // (and any live capture or driver session inside it) running.
+            client.cancel();
         }
     }
 

--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpStdioClient.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpStdioClient.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -19,7 +18,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -31,10 +32,17 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Minimal JSON-RPC MCP stdio client used by the IntelliJ shell.
+ *
+ * <p>The client is safe to keep open across many tool calls: a dedicated reader thread routes
+ * responses to their callers by JSON-RPC id, so concurrent requests never consume each other's
+ * responses. Long-lived server-side sessions (an active SHAFT Capture recording, an initialized
+ * WebDriver) only survive while their server process is alive, so callers that start such
+ * sessions must reuse one client instead of closing it after every call.</p>
  */
 final class ShaftMcpStdioClient implements AutoCloseable {
     private static final Gson GSON = new Gson();
     private static final String PROTOCOL_VERSION = "2024-11-05";
+    private static final Duration GRACEFUL_EXIT_WAIT = Duration.ofSeconds(5);
 
     private final Process process;
     private final BufferedReader input;
@@ -43,6 +51,10 @@ final class ShaftMcpStdioClient implements AutoCloseable {
     private final CompletableFuture<String> stderr;
     private final AtomicBoolean closed = new AtomicBoolean();
     private final ExecutorService ioExecutor;
+    private final Map<Integer, CompletableFuture<JsonObject>> pendingRequests = new ConcurrentHashMap<>();
+    private final Object initializationLock = new Object();
+    private final Object sendLock = new Object();
+    private volatile boolean initialized;
 
     ShaftMcpStdioClient(List<String> command, Path workingDirectory, Map<String, String> environment)
             throws IOException {
@@ -54,6 +66,16 @@ final class ShaftMcpStdioClient implements AutoCloseable {
         output = process.getOutputStream();
         ioExecutor = Executors.newFixedThreadPool(2, daemonThreadFactory());
         stderr = CompletableFuture.supplyAsync(() -> readAll(process.getErrorStream()), ioExecutor);
+        ioExecutor.execute(this::readResponses);
+    }
+
+    /**
+     * Reports whether the server process is still running.
+     *
+     * @return true while the process is alive and the client has not been closed
+     */
+    boolean isAlive() {
+        return !closed.get() && process.isAlive();
     }
 
     String initializeOnly(Duration timeout) throws IOException {
@@ -65,8 +87,7 @@ final class ShaftMcpStdioClient implements AutoCloseable {
         initialize(timeout);
         int requestId = id.getAndIncrement();
         JsonObject request = request(requestId, "tools/list");
-        send(request);
-        return awaitResult(requestId, timeout);
+        return awaitResult(sendRequest(requestId, request), timeout);
     }
 
     JsonElement callTool(String toolName, JsonObject arguments, Duration timeout) throws IOException {
@@ -77,28 +98,32 @@ final class ShaftMcpStdioClient implements AutoCloseable {
         params.addProperty("name", toolName);
         params.add("arguments", arguments);
         request.add("params", params);
-        send(request);
-        return awaitResult(requestId, timeout);
+        return awaitResult(sendRequest(requestId, request), timeout);
     }
 
     private void initialize(Duration timeout) throws IOException {
-        int requestId = id.getAndIncrement();
-        JsonObject request = request(requestId, "initialize");
-        JsonObject params = new JsonObject();
-        params.addProperty("protocolVersion", PROTOCOL_VERSION);
-        params.add("capabilities", new JsonObject());
-        JsonObject clientInfo = new JsonObject();
-        clientInfo.addProperty("name", "shaft-intellij");
-        clientInfo.addProperty("version", pluginVersion());
-        params.add("clientInfo", clientInfo);
-        request.add("params", params);
-        send(request);
-        awaitResult(requestId, timeout);
+        synchronized (initializationLock) {
+            if (initialized) {
+                return;
+            }
+            int requestId = id.getAndIncrement();
+            JsonObject request = request(requestId, "initialize");
+            JsonObject params = new JsonObject();
+            params.addProperty("protocolVersion", PROTOCOL_VERSION);
+            params.add("capabilities", new JsonObject());
+            JsonObject clientInfo = new JsonObject();
+            clientInfo.addProperty("name", "shaft-intellij");
+            clientInfo.addProperty("version", pluginVersion());
+            params.add("clientInfo", clientInfo);
+            request.add("params", params);
+            awaitResult(sendRequest(requestId, request), timeout);
 
-        JsonObject initialized = new JsonObject();
-        initialized.addProperty("jsonrpc", "2.0");
-        initialized.addProperty("method", "notifications/initialized");
-        send(initialized);
+            JsonObject initializedNotification = new JsonObject();
+            initializedNotification.addProperty("jsonrpc", "2.0");
+            initializedNotification.addProperty("method", "notifications/initialized");
+            send(initializedNotification);
+            initialized = true;
+        }
     }
 
     private static String pluginVersion() {
@@ -120,69 +145,111 @@ final class ShaftMcpStdioClient implements AutoCloseable {
 
     private void send(JsonObject payload) throws IOException {
         byte[] body = GSON.toJson(payload).getBytes(StandardCharsets.UTF_8);
-        output.write(body);
-        output.write('\n');
-        output.flush();
+        synchronized (sendLock) {
+            output.write(body);
+            output.write('\n');
+            output.flush();
+        }
     }
 
-    private JsonElement awaitResult(int requestId, Duration timeout) throws IOException {
-        long deadline = System.nanoTime() + timeout.toNanos();
-        JsonElement response = null;
-        boolean waiting = true;
-        while (waiting && response == null && System.nanoTime() < deadline) {
-            long timeoutNanos = deadline - System.nanoTime();
-            JsonObject message = readMessage(timeoutNanos);
-            if (message == null) {
-                waiting = process.isAlive();
-            } else if (message.has("id") && matchesId(message, requestId)) {
-                if (message.has("error")) {
-                    throw withDiagnostics("SHAFT MCP returned an error response.",
-                            new IOException(message.get("error").toString()));
-                }
-                JsonElement result = message.get("result");
-                response = result == null || result.isJsonNull() ? new JsonObject() : result;
-            }
-        }
-        if (response != null) {
-            return response;
-        }
-        throw requestTimedOut();
-    }
-
-    private boolean matchesId(JsonObject message, int requestId) {
+    private PendingRequest sendRequest(int requestId, JsonObject request) throws IOException {
+        CompletableFuture<JsonObject> response = new CompletableFuture<>();
+        pendingRequests.put(requestId, response);
         try {
-            return message.get("id").getAsInt() == requestId;
-        } catch (IllegalStateException | ClassCastException exception) {
-            return false;
+            send(request);
+        } catch (IOException exception) {
+            pendingRequests.remove(requestId);
+            throw withDiagnostics("Failed to send SHAFT MCP request.", exception);
+        } catch (RuntimeException exception) {
+            pendingRequests.remove(requestId);
+            throw exception;
         }
+        return new PendingRequest(requestId, response);
     }
 
-    private JsonObject readMessage(long timeoutNanos) throws IOException {
-        if (timeoutNanos <= 0) {
-            return null;
-        }
-        CompletableFuture<JsonObject> future = CompletableFuture.supplyAsync(() -> {
-            try {
-                return readMessage();
-            } catch (IOException exception) {
-                throw new UncheckedIOException(exception);
-            }
-        }, ioExecutor);
-        long timeoutMillis = Math.max(1, TimeUnit.NANOSECONDS.toMillis(timeoutNanos));
+    private JsonElement awaitResult(PendingRequest pending, Duration timeout) throws IOException {
         try {
-            return future.get(timeoutMillis, TimeUnit.MILLISECONDS);
+            JsonObject message = pending.response().get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+            if (message.has("error")) {
+                throw withDiagnostics("SHAFT MCP returned an error response.",
+                        new IOException(message.get("error").toString()));
+            }
+            JsonElement result = message.get("result");
+            return result == null || result.isJsonNull() ? new JsonObject() : result;
         } catch (TimeoutException exception) {
-            future.cancel(true);
-            close();
             throw requestTimedOut();
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
             throw withDiagnostics("Interrupted while waiting for SHAFT MCP response.", exception);
+        } catch (CancellationException exception) {
+            throw exception;
         } catch (ExecutionException exception) {
-            if (exception.getCause() instanceof UncheckedIOException ioException) {
-                throw withDiagnostics("Failed to read SHAFT MCP response.", ioException.getCause());
+            Throwable cause = exception.getCause();
+            if (cause instanceof CancellationException cancellation) {
+                throw cancellation;
             }
-            throw withDiagnostics("Failed to read SHAFT MCP response.", exception);
+            throw withDiagnostics("Failed to read SHAFT MCP response.", cause == null ? exception : cause);
+        } finally {
+            pendingRequests.remove(pending.requestId());
+        }
+    }
+
+    /**
+     * Continuously reads JSON-RPC frames from the server and completes the matching pending
+     * request. Runs on a dedicated daemon thread for the lifetime of the process.
+     */
+    private void readResponses() {
+        try {
+            String line;
+            while ((line = input.readLine()) != null) {
+                String trimmed = line.trim();
+                if (trimmed.isEmpty()) {
+                    continue;
+                }
+                dispatch(trimmed);
+            }
+        } catch (IOException ignored) {
+            // Stream closed with the process; pending requests fail below.
+        } finally {
+            IOException processExited = withDiagnostics("SHAFT MCP process exited.", (Throwable) null,
+                    failureDetails());
+            pendingRequests.values().forEach(pending -> pending.completeExceptionally(processExited));
+            pendingRequests.clear();
+        }
+    }
+
+    private void dispatch(String line) {
+        JsonObject message;
+        try {
+            JsonElement parsed = JsonParser.parseString(line);
+            if (!parsed.isJsonObject()) {
+                return;
+            }
+            message = parsed.getAsJsonObject();
+        } catch (JsonSyntaxException | IllegalStateException exception) {
+            // Spring Boot and tooling can write startup logs to stdout before MCP frames.
+            // Ignore those non-protocol lines and keep waiting for JSON-RPC messages.
+            return;
+        }
+        Integer requestId = messageId(message);
+        if (requestId == null) {
+            return;
+        }
+        CompletableFuture<JsonObject> pending = pendingRequests.remove(requestId);
+        if (pending != null) {
+            pending.complete(message);
+        }
+    }
+
+    private static Integer messageId(JsonObject message) {
+        if (!message.has("id")) {
+            return null;
+        }
+        try {
+            return message.get("id").getAsInt();
+        } catch (IllegalStateException | ClassCastException | NumberFormatException
+                 | UnsupportedOperationException exception) {
+            return null;
         }
     }
 
@@ -200,24 +267,6 @@ final class ShaftMcpStdioClient implements AutoCloseable {
             composed = message + "\n" + details;
         }
         return cause == null ? new IOException(composed) : new IOException(composed, cause);
-    }
-
-    private JsonObject readMessage() throws IOException {
-        String line;
-        while ((line = input.readLine()) != null) {
-            String trimmed = line.trim();
-            if (trimmed.isEmpty()) {
-                continue;
-            }
-            try {
-                JsonElement message = JsonParser.parseString(trimmed);
-                return message.isJsonObject() ? message.getAsJsonObject() : null;
-            } catch (JsonSyntaxException | IllegalStateException exception) {
-                // Spring Boot and tooling can write startup logs to stdout before MCP frames.
-                // Ignore those non-protocol lines and keep waiting for a JSON-RPC message.
-            }
-        }
-        return null;
     }
 
     private static String readAll(InputStream stream) {
@@ -271,8 +320,14 @@ final class ShaftMcpStdioClient implements AutoCloseable {
         close(false, true);
     }
 
+    /**
+     * Abandons every in-flight request without terminating the server process, so an active
+     * server-side session (for example a live SHAFT Capture recording) keeps running.
+     */
     void cancel() {
-        close(false, false);
+        pendingRequests.values().forEach(pending ->
+                pending.completeExceptionally(new CancellationException("Operation cancelled")));
+        pendingRequests.clear();
     }
 
     void kill() {
@@ -287,14 +342,24 @@ final class ShaftMcpStdioClient implements AutoCloseable {
             }
             return;
         }
+        cancel();
         if (force) {
             process.destroyForcibly();
         } else {
-            process.destroy();
+            // Closing stdin signals end-of-session to the stdio transport, letting the server
+            // shut down gracefully and release live sessions (an active SHAFT Capture recording
+            // quits its managed browser). Process.destroy() on Windows terminates immediately
+            // and would orphan those sessions, so it is only the fallback.
+            closeQuietly(output);
         }
         try {
-            if (awaitExit && !process.waitFor(2, TimeUnit.SECONDS)) {
+            // A server that never completed the handshake has no live sessions to release, so a
+            // long graceful wait would only delay probes of hung or misconfigured commands.
+            long exitWaitMillis = initialized ? GRACEFUL_EXIT_WAIT.toMillis() : 500;
+            if (awaitExit && !process.waitFor(exitWaitMillis, TimeUnit.MILLISECONDS)) {
                 process.destroyForcibly();
+            } else if (!awaitExit && !force) {
+                process.destroy();
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -304,11 +369,22 @@ final class ShaftMcpStdioClient implements AutoCloseable {
         }
     }
 
+    private static void closeQuietly(OutputStream stream) {
+        try {
+            stream.close();
+        } catch (IOException ignored) {
+            // The process may already have exited.
+        }
+    }
+
     private static ThreadFactory daemonThreadFactory() {
         return runnable -> {
             Thread thread = new Thread(runnable, "shaft-mcp-stdio");
             thread.setDaemon(true);
             return thread;
         };
+    }
+
+    private record PendingRequest(int requestId, CompletableFuture<JsonObject> response) {
     }
 }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/mcp/FakeMcpServer.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/mcp/FakeMcpServer.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 final class FakeMcpServer {
     private static final Pattern CONTENT_ID = Pattern.compile("\"id\"\\s*:\\s*(\\d+)");
     private static final Pattern METHOD = Pattern.compile("\"method\"\\s*:\\s*\"([^\"]+)\"");
+    private static final Pattern TOOL_NAME = Pattern.compile("\"name\"\\s*:\\s*\"([^\"]+)\"");
 
     private FakeMcpServer() {
     }
@@ -23,6 +24,8 @@ final class FakeMcpServer {
             case "toolsList" -> runToolsListServer();
             case "toolResultArray" -> runToolCallResultServer("[\"first\",{\"name\":\"second\"}]");
             case "toolResultString" -> runToolCallResultServer("\"plain text result\"");
+            case "echoTool" -> runEchoToolServer();
+            case "silentToolCalls" -> runSilentToolCallServer();
             case "hang" -> Thread.sleep(Long.MAX_VALUE);
             default -> Thread.sleep(Long.MAX_VALUE);
         }
@@ -45,6 +48,50 @@ final class FakeMcpServer {
 
     private static void runToolCallResultServer(String resultJson) throws Exception {
         runServer(resultJson);
+    }
+
+    /**
+     * Responds to every tools/call with the requested tool name, so tests can prove concurrent
+     * callers each receive the response matching their own request id.
+     */
+    private static void runEchoToolServer() throws Exception {
+        BufferedReader input = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
+        OutputStream output = System.out;
+        while (true) {
+            String message = input.readLine();
+            if (message == null) {
+                return;
+            }
+            int requestId = requestId(message);
+            switch (requestMethod(message)) {
+                case "initialize" -> writeMessage(output, requestId,
+                        "{\"jsonrpc\":\"2.0\",\"id\":%d,\"result\":{\"protocolVersion\":\"2024-11-05\"}}");
+                case "tools/call" -> writeMessage(output, requestId,
+                        "{\"jsonrpc\":\"2.0\",\"id\":%d,\"result\":{\"echoedTool\":\""
+                                + toolName(message) + "\"}}");
+                default -> {
+                }
+            }
+        }
+    }
+
+    /**
+     * Answers the initialize handshake but never responds to tools/call, so tests can cancel an
+     * in-flight request and prove the server process stays alive.
+     */
+    private static void runSilentToolCallServer() throws Exception {
+        BufferedReader input = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
+        OutputStream output = System.out;
+        while (true) {
+            String message = input.readLine();
+            if (message == null) {
+                return;
+            }
+            if ("initialize".equals(requestMethod(message))) {
+                writeMessage(output, requestId(message),
+                        "{\"jsonrpc\":\"2.0\",\"id\":%d,\"result\":{\"protocolVersion\":\"2024-11-05\"}}");
+            }
+        }
     }
 
     private static void runServer(String toolCallResultJson) throws Exception {
@@ -85,5 +132,10 @@ final class FakeMcpServer {
     private static String requestMethod(String message) {
         Matcher matcher = METHOD.matcher(message);
         return matcher.find() ? matcher.group(1) : "";
+    }
+
+    private static String toolName(String message) {
+        Matcher matcher = TOOL_NAME.matcher(message);
+        return matcher.find() ? matcher.group(1) : "unknown";
     }
 }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpStdioClientTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpStdioClientTest.java
@@ -11,6 +11,8 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,7 +42,7 @@ class ShaftMcpStdioClientTest {
     }
 
     @Test
-    void initializeIgnoresNonProtocolStdoutBeforeJsonRpcMessage() throws IOException {
+    void initializeIgnoresNonProtocolStdoutBeforeJsonRpcMessage() throws Exception {
         String result = withClient("stdoutNoiseThenToolsList",
                 client -> client.initializeOnly(Duration.ofSeconds(2)));
 
@@ -48,7 +50,7 @@ class ShaftMcpStdioClientTest {
     }
 
     @Test
-    void listToolsReturnsRawJsonResult() throws IOException {
+    void listToolsReturnsRawJsonResult() throws Exception {
         JsonElement result = withClient("toolsList", client -> client.listTools(Duration.ofSeconds(2)));
 
         assertEquals("fake_tool", result.getAsJsonObject()
@@ -56,7 +58,76 @@ class ShaftMcpStdioClientTest {
     }
 
     @Test
-    void callToolPreservesNonObjectJsonResults() throws IOException {
+    void clientSurvivesAcrossSequentialToolCalls() throws Exception {
+        withClient("echoTool", client -> {
+            JsonElement first = client.callTool("capture_start", new JsonObject(), Duration.ofSeconds(5));
+            assertTrue(client.isAlive(),
+                    "The server process must stay alive between tool calls: session-starting tools "
+                            + "(capture_start) keep their live session inside it.");
+            JsonElement second = client.callTool("capture_status", new JsonObject(), Duration.ofSeconds(5));
+
+            assertEquals("capture_start", first.getAsJsonObject().get("echoedTool").getAsString());
+            assertEquals("capture_status", second.getAsJsonObject().get("echoedTool").getAsString());
+            assertTrue(client.isAlive());
+            return null;
+        });
+    }
+
+    @Test
+    void concurrentToolCallsReceiveTheirOwnResponses() throws Exception {
+        withClient("echoTool", client -> {
+            client.initializeOnly(Duration.ofSeconds(5));
+            CompletableFuture<JsonElement> first = CompletableFuture.supplyAsync(() -> callQuietly(
+                    client, "capture_status"));
+            CompletableFuture<JsonElement> second = CompletableFuture.supplyAsync(() -> callQuietly(
+                    client, "shaft_guide_search"));
+
+            assertEquals("capture_status", first.join()
+                    .getAsJsonObject().get("echoedTool").getAsString());
+            assertEquals("shaft_guide_search", second.join()
+                    .getAsJsonObject().get("echoedTool").getAsString());
+            return null;
+        });
+    }
+
+    @Test
+    void cancelAbandonsInFlightRequestWithoutKillingTheServerProcess() throws Exception {
+        withClient("silentToolCalls", client -> {
+            client.initializeOnly(Duration.ofSeconds(5));
+            CompletableFuture<Throwable> failure = CompletableFuture.supplyAsync(() -> {
+                try {
+                    client.callTool("never_answered", new JsonObject(), Duration.ofSeconds(30));
+                    return null;
+                } catch (IOException | RuntimeException exception) {
+                    return exception;
+                }
+            });
+            // The tool call registers asynchronously; keep cancelling until it has been abandoned.
+            for (int attempt = 0; attempt < 100 && !failure.isDone(); attempt++) {
+                client.cancel();
+                Thread.sleep(50);
+            }
+
+            Throwable outcome = failure.join();
+            assertTrue(outcome instanceof CancellationException,
+                    "Cancel must abandon the pending request, got: " + outcome);
+            assertTrue(client.isAlive(),
+                    "Cancel must not terminate the shared server process; live sessions "
+                            + "(an active recording) must keep running.");
+            return null;
+        });
+    }
+
+    private static JsonElement callQuietly(ShaftMcpStdioClient client, String toolName) {
+        try {
+            return client.callTool(toolName, new JsonObject(), Duration.ofSeconds(5));
+        } catch (IOException exception) {
+            throw new java.io.UncheckedIOException(exception);
+        }
+    }
+
+    @Test
+    void callToolPreservesNonObjectJsonResults() throws Exception {
         JsonElement array = withClient("toolResultArray",
                 client -> client.callTool("fake_tool", new JsonObject(), Duration.ofSeconds(2)));
         JsonElement string = withClient("toolResultString",
@@ -67,10 +138,10 @@ class ShaftMcpStdioClientTest {
     }
 
     private interface ClientAction<T> {
-        T call(ShaftMcpStdioClient client) throws IOException;
+        T call(ShaftMcpStdioClient client) throws Exception;
     }
 
-    private static <T> T withClient(String mode, ClientAction<T> action) throws IOException {
+    private static <T> T withClient(String mode, ClientAction<T> action) throws Exception {
         List<String> command = List.of(javaExecutable(), "-cp", System.getProperty("java.class.path"),
                 FakeMcpServer.class.getName(), mode);
         try (ShaftMcpStdioClient client = new ShaftMcpStdioClient(command, Path.of("."), Map.of())) {

--- a/tests/scripts/test_installer_repo_checkout_detection.py
+++ b/tests/scripts/test_installer_repo_checkout_detection.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Regression coverage for the installer wrappers' repo-checkout detection.
+
+install-shaft-mcp.sh/.ps1 can reuse a co-located install_shaft_mcp.py instead of downloading a
+fresh copy, but that shortcut must only fire for a genuine SHAFT_ENGINE checkout (verified via the
+repo root pom.xml two directories up). Otherwise a stale install_shaft_mcp.py left behind in a
+scratch/temp directory by an earlier "copy command" run would be reused forever instead of always
+fetching the latest installer -- reintroducing whatever bug that stale copy carried (see #3374).
+"""
+
+from __future__ import annotations
+
+import platform
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SHAFT_PARENT_POM = "<project><artifactId>shaft-parent</artifactId></project>"
+
+
+def _write_scenarios(root: Path) -> tuple[Path, Path]:
+    """Creates a genuine-repo-checkout directory and an unrelated scratch directory.
+
+    Both get a co-located install_shaft_mcp.py sibling; only the repo-checkout one should be
+    considered eligible for local reuse.
+    """
+    repo_checkout = root / "repoA" / "scripts" / "mcp"
+    repo_checkout.mkdir(parents=True)
+    (root / "repoA" / "pom.xml").write_text(SHAFT_PARENT_POM, encoding="utf-8")
+    (repo_checkout / "install_shaft_mcp.py").write_text("print('local sibling used')", encoding="utf-8")
+
+    scratch = root / "scratchB" / "deep" / "enough"
+    scratch.mkdir(parents=True)
+    (scratch / "install_shaft_mcp.py").write_text("print('stale file used')", encoding="utf-8")
+
+    return repo_checkout, scratch
+
+
+@unittest.skipUnless(shutil.which("sh"), "sh is required to test install-shaft-mcp.sh")
+class ShellInstallerRepoCheckoutDetectionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        script = (ROOT / "scripts" / "mcp" / "install-shaft-mcp.sh").read_text(encoding="utf-8")
+        marker = "\nbanner\n"
+        boundary = script.index(marker)
+        # Only the function/helper definitions above the top-level execution are needed; sourcing
+        # the whole file would immediately run the real installer.
+        self.functions_only = script[:boundary]
+
+    def _detect(self, directory: Path) -> bool:
+        script = (
+            self.functions_only
+            + f'\nif is_shaft_engine_repo_checkout "{directory.as_posix()}"; '
+            + 'then echo REPO_CHECKOUT; else echo NOT_REPO_CHECKOUT; fi\n'
+        )
+        result = subprocess.run(
+            ["sh", "-c", script],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return "REPO_CHECKOUT" == result.stdout.strip()
+
+    def test_genuine_repo_checkout_is_detected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_checkout, _ = _write_scenarios(Path(tmp))
+            self.assertTrue(self._detect(repo_checkout))
+
+    def test_scratch_directory_with_stale_sibling_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _, scratch = _write_scenarios(Path(tmp))
+            self.assertFalse(self._detect(scratch))
+
+
+@unittest.skipUnless(platform.system() == "Windows", "PowerShell installer only ships for Windows")
+class PowerShellInstallerRepoCheckoutDetectionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        script = (ROOT / "scripts" / "mcp" / "install-shaft-mcp.ps1").read_text(encoding="utf-8")
+        start = script.index("function Test-ShaftEngineRepoCheckout")
+        end = script.index("\n    function Resolve-PythonInstallerScript")
+        self.function_only = script[start:end]
+
+    def _detect(self, directory: Path) -> bool:
+        command = (
+            self.function_only
+            + f'\nif (Test-ShaftEngineRepoCheckout "{directory}") '
+            + '{ Write-Output "REPO_CHECKOUT" } else { Write-Output "NOT_REPO_CHECKOUT" }'
+        )
+        result = subprocess.run(
+            ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", command],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return "REPO_CHECKOUT" == result.stdout.strip()
+
+    def test_genuine_repo_checkout_is_detected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_checkout, _ = _write_scenarios(Path(tmp))
+            self.assertTrue(self._detect(repo_checkout))
+
+    def test_scratch_directory_with_stale_sibling_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _, scratch = _write_scenarios(Path(tmp))
+            self.assertFalse(self._detect(scratch))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_installer_repo_checkout_detection.py
+++ b/tests/scripts/test_installer_repo_checkout_detection.py
@@ -50,17 +50,20 @@ class ShellInstallerRepoCheckoutDetectionTest(unittest.TestCase):
         self.functions_only = script[:boundary]
 
     def _detect(self, directory: Path) -> bool:
-        script = (
-            self.functions_only
-            + f'\nif is_shaft_engine_repo_checkout "{directory.as_posix()}"; '
-            + 'then echo REPO_CHECKOUT; else echo NOT_REPO_CHECKOUT; fi\n'
+        # The candidate directory is passed as a real argv entry ($1), never interpolated into
+        # the script text, so this cannot be mistaken for a shell-injection-shaped invocation.
+        script = self.functions_only + (
+            '\nis_shaft_engine_repo_checkout "$1" && echo REPO_CHECKOUT || echo NOT_REPO_CHECKOUT\n'
         )
-        result = subprocess.run(
-            ["sh", "-c", script],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
+        with tempfile.TemporaryDirectory() as script_dir:
+            script_path = Path(script_dir) / "detect.sh"
+            script_path.write_text(script, encoding="utf-8")
+            result = subprocess.run(
+                ["sh", str(script_path), str(directory)],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
         return "REPO_CHECKOUT" == result.stdout.strip()
 
     def test_genuine_repo_checkout_is_detected(self) -> None:
@@ -83,17 +86,25 @@ class PowerShellInstallerRepoCheckoutDetectionTest(unittest.TestCase):
         self.function_only = script[start:end]
 
     def _detect(self, directory: Path) -> bool:
-        command = (
-            self.function_only
-            + f'\nif (Test-ShaftEngineRepoCheckout "{directory}") '
-            + '{ Write-Output "REPO_CHECKOUT" } else { Write-Output "NOT_REPO_CHECKOUT" }'
+        # The candidate directory is bound through a real -Directory CLI parameter, never
+        # interpolated into the script text, so this cannot be mistaken for a command-injection-
+        # shaped invocation.
+        script = (
+            "param([string] $Directory)\n"
+            + self.function_only
+            + '\nif (Test-ShaftEngineRepoCheckout $Directory) '
+            + '{ Write-Output "REPO_CHECKOUT" } else { Write-Output "NOT_REPO_CHECKOUT" }\n'
         )
-        result = subprocess.run(
-            ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", command],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
+        with tempfile.TemporaryDirectory() as script_dir:
+            script_path = Path(script_dir) / "detect.ps1"
+            script_path.write_text(script, encoding="utf-8")
+            result = subprocess.run(
+                ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass",
+                 "-File", str(script_path), "-Directory", str(directory)],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
         return "REPO_CHECKOUT" == result.stdout.strip()
 
     def test_genuine_repo_checkout_is_detected(self) -> None:


### PR DESCRIPTION
Closes #3365

## Root cause

The IntelliJ plugin's `ShaftMcpInvocationService` spawned a **one-shot MCP stdio process per tool call** and destroyed it (`Process.destroy()` — a hard `TerminateProcess` on Windows, no `@PreDestroy`) as soon as the call returned. `capture_start` starts a *live session* — a managed browser, BiDi/polling collectors, and the loopback event sink — inside that process, so the session died seconds after it began:

- the orphaned Chrome window kept running with its in-page overlay (which is why the UI kept listing actions), but **every interaction after startup was lost** — the recording file kept only the startup `OPEN_TAB` + initial navigation with status `INCOMPLETE`;
- the overlay **Stop** control posted into a dead channel, so the browser never closed and the session was never finalized;
- saved assertions were likewise never persisted.

The direct-recorder browser E2E always passed (and still does) because it never crossed the plugin's process boundary.

## Fix

**IntelliJ plugin — persistent MCP session (the actual bug):**
- `ShaftMcpStdioClient` is now a persistent, concurrency-safe client: a dedicated reader thread routes JSON-RPC responses to callers by request id; `cancel()` abandons in-flight requests **without** terminating the server; `close()` signals stdin end-of-stream first so the server shuts down gracefully and releases live sessions (quitting an active recording's browser), with forcible termination only as fallback.
- `ShaftMcpInvocationService` keeps **one shared MCP server process per project** across tool calls, respawns it transparently when it dies or the configured command/environment changes, and disposes it with the project.

**Capture runtime hardening (same failure class):**
- `CaptureManager`'s 1s browser health check now requires **3 consecutive** failed liveness probes before `interrupt()` — one transient `WebDriverException` no longer silently discards a recording.
- `PollingBrowserEventCollector.poll()` and `CaptureEventPipeline`'s debounced flush survive unexpected `RuntimeException`s instead of letting their scheduled executors die silently.

**Recorder overlay — guided assertion flow (bug 3):**
- Element catalog adds **"Element exists"** (`ELEMENT_PRESENT`) and an **Expected true/false** choice for the boolean checks (exists/visible/enabled/selected); `false` persists as a negated verification, rendered by the generator as `doesNotExist()` / `isHidden()` / `isDisabled()` / `isNotSelected()`.
- Saved assertions now carry `clientActionId`/`stepDescription`, so they show in the server-side step list and rehydrate across navigations like recorded actions.

## Verification

- `shaft-capture` full unit suite: **208/208 passed** (includes new `CaptureManagerHealthCheckTest` and `PollingBrowserEventCollectorResilienceTest`).
- `shaft-capture` browser E2E (`-DincludeCaptureBrowserE2E`, headless, Windows, Chrome 150 + Edge): **6/6 passed**, including the new `overlayGuidedAssertionFlowPersistsVerificationEvents` which drives the overlay's Element branch (click target → scored locator pick → existence with expected=false) and Browser branch (title contains with edited expected value) end to end and asserts the persisted `VerificationEvent`s.
- `shaft-intellij` full Gradle test suite: passed, including new persistent-client tests (reuse across sequential calls, concurrent response dispatch by id, cancel-without-kill).

Docs PR follows in shafthq.github.io (persistent MCP session lifecycle + guided assertion flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)