### PR TITLE
Fix CaptureManager.isAssetResource() no-op against real capture data

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/format/CaptureJsonCodec.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/format/CaptureJsonCodec.java
@@ -26,7 +26,7 @@ import java.util.List;
  * Stable human-readable JSON codec with schema validation and migration.
  */
 public final class CaptureJsonCodec {
-    private static final String SCHEMA_RESOURCE = "/schema/shaft-capture-session-1.1.schema.json";
+    private static final String SCHEMA_RESOURCE = "/schema/shaft-capture-session-1.2.schema.json";
     private final ObjectMapper mapper;
     private final JsonNode schema;
     private final DefaultPrettyPrinter printer;

--- a/shaft-capture/src/main/java/com/shaft/capture/format/CaptureSchemaMigrator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/format/CaptureSchemaMigrator.java
@@ -17,7 +17,7 @@ public final class CaptureSchemaMigrator {
 
     /**
      * Migrates a supported capture tree to the current schema.
-     * Supports 0.9 → 1.0 and 1.0 → 1.1 deterministic migration chains.
+     * Supports 0.9 → 1.0 → 1.1 → 1.2 deterministic migration chains.
      *
      * @param input parsed capture tree
      * @return migrated deep copy at CURRENT_SCHEMA_VERSION
@@ -33,16 +33,20 @@ public final class CaptureSchemaMigrator {
         }
         if (LEGACY_SCHEMA_VERSION.equals(version)) {
             migrated = migrateFrom0_9To1_0(migrated);
-        } else if ("1.0".equals(version)) {
-            // Already at 1.0, proceed to 1.1 migration below
+        } else if ("1.0".equals(version) || "1.1".equals(version)) {
+            // Already at 1.0 or 1.1, proceed to the migration steps below
         } else {
             throw new CaptureFormatException("Unsupported capture schema version '" + version
-                    + "'. Supported versions are " + LEGACY_SCHEMA_VERSION + ", 1.0, and "
+                    + "'. Supported versions are " + LEGACY_SCHEMA_VERSION + ", 1.0, 1.1, and "
                     + CaptureSession.CURRENT_SCHEMA_VERSION + ".");
         }
         // Migrate from 1.0 to 1.1
         if ("1.0".equals(migrated.path("schemaVersion").asText(""))) {
             migrated = migrateFrom1_0To1_1(migrated);
+        }
+        // Migrate from 1.1 to 1.2
+        if ("1.1".equals(migrated.path("schemaVersion").asText(""))) {
+            migrated = migrateFrom1_1To1_2(migrated);
         }
         return migrated;
     }
@@ -103,6 +107,16 @@ public final class CaptureSchemaMigrator {
                 }
             }
         }
+        return tree;
+    }
+
+    /**
+     * Migrates a 1.1 session tree to 1.2 by stamping schemaVersion. Purely a version stamp: 1.2
+     * only widens the {@code resourceKind} property's allowed values (adding STYLESHEET, SCRIPT,
+     * IMAGE, FONT, MEDIA), which does not change the shape of any existing 1.1 document.
+     */
+    private static ObjectNode migrateFrom1_1To1_2(ObjectNode tree) {
+        tree.put("schemaVersion", "1.2");
         return tree;
     }
 }

--- a/shaft-capture/src/main/java/com/shaft/capture/model/CaptureSession.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/model/CaptureSession.java
@@ -40,7 +40,7 @@ public record CaptureSession(
     /**
      * Current persisted schema version.
      */
-    public static final String CURRENT_SCHEMA_VERSION = "1.1";
+    public static final String CURRENT_SCHEMA_VERSION = "1.2";
 
     /**
      * Session lifecycle states.

--- a/shaft-capture/src/main/java/com/shaft/capture/model/network/ResourceKind.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/model/network/ResourceKind.java
@@ -8,5 +8,23 @@ public enum ResourceKind {
     FETCH,
     DOCUMENT,
     WEBSOCKET_HANDSHAKE,
-    OTHER
+    OTHER,
+    STYLESHEET,
+    SCRIPT,
+    IMAGE,
+    FONT,
+    MEDIA;
+
+    /**
+     * Reports whether this kind is asset-like noise (stylesheet, script, image, font, or media)
+     * rather than API/document/websocket traffic.
+     *
+     * @return {@code true} for asset-type resource kinds
+     */
+    public boolean isAsset() {
+        return switch (this) {
+            case STYLESHEET, SCRIPT, IMAGE, FONT, MEDIA -> true;
+            default -> false;
+        };
+    }
 }

--- a/shaft-capture/src/main/java/com/shaft/capture/network/CaptureNetworkRecorder.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/network/CaptureNetworkRecorder.java
@@ -235,8 +235,8 @@ public final class CaptureNetworkRecorder implements AutoCloseable {
             byte[] responseBody,
             long startNanos,
             String failureReason) {
-        InternalResourceKind internalKind = classify(request, response);
-        if (!accepted(request, pageOrigin, internalKind)) {
+        ResourceKind resourceKind = classify(request, response);
+        if (!accepted(request, pageOrigin, resourceKind)) {
             return;
         }
         if (recordedCount.get() >= options.maxTransactions()) {
@@ -274,7 +274,7 @@ public final class CaptureNetworkRecorder implements AutoCloseable {
 
         RecordedTransaction transaction = new RecordedTransaction(
                 String.valueOf(transactionId),
-                internalKind.canonicalKind(),
+                resourceKind,
                 requestRecord,
                 responseRecord,
                 timing,
@@ -293,7 +293,7 @@ public final class CaptureNetworkRecorder implements AutoCloseable {
         }
     }
 
-    private boolean accepted(HttpRequest request, String pageOrigin, InternalResourceKind resourceKind) {
+    private boolean accepted(HttpRequest request, String pageOrigin, ResourceKind resourceKind) {
         if (!options.includeAssetTypes() && resourceKind.isAsset()) {
             return false;
         }
@@ -311,51 +311,16 @@ public final class CaptureNetworkRecorder implements AutoCloseable {
     }
 
     /**
-     * Finer-grained internal resource classification used only for asset-type filtering.
-     * {@link com.shaft.capture.model.network.ResourceKind} (T1's canonical, persisted vocabulary)
-     * does not distinguish stylesheet/script/image/font/media from other non-API traffic, so this
-     * richer classification is translated down to {@link #canonicalKind()} at the point a
-     * transaction is recorded.
-     */
-    private enum InternalResourceKind {
-        DOCUMENT(ResourceKind.DOCUMENT, false),
-        XHR_FETCH(ResourceKind.XHR, false),
-        STYLESHEET(ResourceKind.OTHER, true),
-        SCRIPT(ResourceKind.OTHER, true),
-        IMAGE(ResourceKind.OTHER, true),
-        FONT(ResourceKind.OTHER, true),
-        MEDIA(ResourceKind.OTHER, true),
-        WEBSOCKET(ResourceKind.WEBSOCKET_HANDSHAKE, false),
-        OTHER(ResourceKind.OTHER, false);
-
-        private final ResourceKind canonicalKind;
-        private final boolean asset;
-
-        InternalResourceKind(ResourceKind canonicalKind, boolean asset) {
-            this.canonicalKind = canonicalKind;
-            this.asset = asset;
-        }
-
-        ResourceKind canonicalKind() {
-            return canonicalKind;
-        }
-
-        boolean isAsset() {
-            return asset;
-        }
-    }
-
-    /**
      * Ordered classification rules, evaluated first-match-wins in exactly this order.
      * A loop over a rule table (rather than a sequential if-return chain) keeps this
      * method's own NPath complexity low regardless of rule count -- PMD's NPath metric
      * is multiplicative across sequential branches in one method body, so a long guard
      * chain explodes combinatorially even when each guard is a single trivial call.
      */
-    private record ClassificationRule(BooleanSupplier matches, InternalResourceKind kind) {
+    private record ClassificationRule(BooleanSupplier matches, ResourceKind kind) {
     }
 
-    private static InternalResourceKind classify(HttpRequest request, HttpResponse response) {
+    private static ResourceKind classify(HttpRequest request, HttpResponse response) {
         String accept = header(request, "Accept");
         String contentType = response == null ? "" : value(response.getContentType());
         if (contentType.isBlank()) {
@@ -365,21 +330,21 @@ public final class CaptureNetworkRecorder implements AutoCloseable {
         String finalContentType = contentType;
 
         List<ClassificationRule> rules = List.of(
-                new ClassificationRule(() -> isDocument(finalContentType, accept, path), InternalResourceKind.DOCUMENT),
-                new ClassificationRule(() -> isStylesheet(finalContentType, path), InternalResourceKind.STYLESHEET),
-                new ClassificationRule(() -> isScript(finalContentType, path), InternalResourceKind.SCRIPT),
-                new ClassificationRule(() -> isImage(finalContentType, path), InternalResourceKind.IMAGE),
-                new ClassificationRule(() -> isFont(finalContentType, path), InternalResourceKind.FONT),
-                new ClassificationRule(() -> isMedia(finalContentType, path), InternalResourceKind.MEDIA),
-                new ClassificationRule(() -> isWebSocket(request), InternalResourceKind.WEBSOCKET),
-                new ClassificationRule(() -> isXhrOrFetch(finalContentType, accept, request), InternalResourceKind.XHR_FETCH));
+                new ClassificationRule(() -> isDocument(finalContentType, accept, path), ResourceKind.DOCUMENT),
+                new ClassificationRule(() -> isStylesheet(finalContentType, path), ResourceKind.STYLESHEET),
+                new ClassificationRule(() -> isScript(finalContentType, path), ResourceKind.SCRIPT),
+                new ClassificationRule(() -> isImage(finalContentType, path), ResourceKind.IMAGE),
+                new ClassificationRule(() -> isFont(finalContentType, path), ResourceKind.FONT),
+                new ClassificationRule(() -> isMedia(finalContentType, path), ResourceKind.MEDIA),
+                new ClassificationRule(() -> isWebSocket(request), ResourceKind.WEBSOCKET_HANDSHAKE),
+                new ClassificationRule(() -> isXhrOrFetch(finalContentType, accept, request), ResourceKind.XHR));
 
         for (ClassificationRule rule : rules) {
             if (rule.matches().getAsBoolean()) {
                 return rule.kind();
             }
         }
-        return isBlankOrHtmlPath(path) ? InternalResourceKind.DOCUMENT : InternalResourceKind.XHR_FETCH;
+        return isBlankOrHtmlPath(path) ? ResourceKind.DOCUMENT : ResourceKind.XHR;
     }
 
     private static boolean isDocument(String contentType, String accept, String path) {
@@ -568,7 +533,7 @@ public final class CaptureNetworkRecorder implements AutoCloseable {
      * {@code EventContext} (sequence, page, timestamp).
      *
      * @param transactionId stable identifier correlating request and response evidence
-     * @param resourceKind canonical (T1) resource classification
+     * @param resourceKind fine-grained resource classification
      * @param request sanitized outbound request evidence
      * @param response sanitized inbound response evidence, or {@code null} when the exchange failed
      *                 before a response was observed

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureManager.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureManager.java
@@ -1,6 +1,7 @@
 package com.shaft.capture.runtime;
 
 import com.shaft.capture.model.Checkpoint;
+import com.shaft.capture.model.network.ResourceKind;
 import com.shaft.capture.storage.CaptureSessionStore;
 
 import java.io.IOException;
@@ -198,23 +199,18 @@ public final class CaptureManager implements AutoCloseable {
     /**
      * Reports whether a transaction's resource kind is asset-like noise rather than an API call.
      *
-     * <p>Known gap: {@link NetworkTransaction#resourceKind()} built from a real captured session
-     * is populated from {@code com.shaft.capture.model.network.ResourceKind} (T1's canonical
-     * model), whose P1 vocabulary (XHR, FETCH, DOCUMENT, WEBSOCKET_HANDSHAKE, OTHER) does not
-     * distinguish images, fonts, stylesheets, or media from other non-API traffic -- they all
-     * collapse into {@code OTHER} at capture time. This lowercase "image"/"font"/"stylesheet"/
-     * "media" matching therefore only fires for callers (or fixtures) that populate
-     * {@code resourceKind} with those finer-grained labels directly; it will not currently
-     * exclude asset noise recorded by the real {@code CaptureNetworkRecorder} pipeline, since
-     * that pipeline emits T1's coarser enum. Growing a dedicated asset-type vocabulary in the
-     * capture model is tracked as a P2 follow-up.
+     * @param resourceKind {@link com.shaft.capture.model.network.ResourceKind#name()} value, case-insensitive
+     * @return {@code true} when the resource kind is asset-type noise
      */
     private static boolean isAssetResource(String resourceKind) {
-        String kind = resourceKind == null ? "" : resourceKind.toLowerCase(java.util.Locale.ROOT);
-        return switch (kind) {
-            case "image", "font", "stylesheet", "media" -> true;
-            default -> false;
-        };
+        if (resourceKind == null || resourceKind.isBlank()) {
+            return false;
+        }
+        try {
+            return ResourceKind.valueOf(resourceKind.trim().toUpperCase(java.util.Locale.ROOT)).isAsset();
+        } catch (IllegalArgumentException unknownResourceKind) {
+            return false;
+        }
     }
 
     private static boolean matchesGlob(String value, String globPattern) {

--- a/shaft-capture/src/main/resources/schema/shaft-capture-session-1.2.schema.json
+++ b/shaft-capture/src/main/resources/schema/shaft-capture-session-1.2.schema.json
@@ -1,0 +1,250 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://shafthq.github.io/schemas/capture/session-1.2.schema.json",
+  "title": "SHAFT Capture Session",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "sessionId",
+    "status",
+    "startedAt",
+    "browser",
+    "events",
+    "checkpoints",
+    "dataReferences",
+    "redactionSummary",
+    "extensions"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "enum": [
+        "1.2"
+      ]
+    },
+    "sessionId": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "INCOMPLETE",
+        "COMPLETED"
+      ]
+    },
+    "startedAt": {
+      "type": "string"
+    },
+    "endedAt": {
+      "type": "string"
+    },
+    "browser": {
+      "type": "object",
+      "required": [
+        "browserName",
+        "logicalSessionId",
+        "capabilities"
+      ]
+    },
+    "events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "type",
+          "context"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "navigation",
+              "click",
+              "type",
+              "clear",
+              "select",
+              "toggle",
+              "upload",
+              "keyboard",
+              "window",
+              "frame",
+              "alert",
+              "wait",
+              "verification",
+              "network"
+            ]
+          },
+          "context": {
+            "type": "object",
+            "required": [
+              "sequence",
+              "timestamp",
+              "page",
+              "replayStatus",
+              "evidence",
+              "extensions"
+            ]
+          },
+          "transactionId": {
+            "type": "string"
+          },
+          "resourceKind": {
+            "type": "string",
+            "enum": [
+              "XHR",
+              "FETCH",
+              "DOCUMENT",
+              "WEBSOCKET_HANDSHAKE",
+              "OTHER",
+              "STYLESHEET",
+              "SCRIPT",
+              "IMAGE",
+              "FONT",
+              "MEDIA"
+            ]
+          },
+          "request": {
+            "type": "object",
+            "required": [
+              "method",
+              "url",
+              "headers"
+            ],
+            "properties": {
+              "method": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              },
+              "headers": {
+                "type": "object"
+              },
+              "body": {
+                "$comment": "BodyRef: safe reference to a captured request body, never the raw content.",
+                "type": "object",
+                "required": [
+                  "ref",
+                  "sizeBytes",
+                  "truncated"
+                ],
+                "properties": {
+                  "ref": {
+                    "type": "string"
+                  },
+                  "sha256": {
+                    "type": "string"
+                  },
+                  "sizeBytes": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "encoding": {
+                    "type": "string"
+                  },
+                  "truncated": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          },
+          "response": {
+            "type": "object",
+            "required": [
+              "statusCode",
+              "headers"
+            ],
+            "properties": {
+              "statusCode": {
+                "type": "integer",
+                "minimum": 100,
+                "maximum": 599
+              },
+              "headers": {
+                "type": "object"
+              },
+              "body": {
+                "$comment": "BodyRef: safe reference to a captured response body, never the raw content.",
+                "type": "object",
+                "required": [
+                  "ref",
+                  "sizeBytes",
+                  "truncated"
+                ],
+                "properties": {
+                  "ref": {
+                    "type": "string"
+                  },
+                  "sha256": {
+                    "type": "string"
+                  },
+                  "sizeBytes": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "encoding": {
+                    "type": "string"
+                  },
+                  "truncated": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          },
+          "timing": {
+            "type": "object",
+            "properties": {
+              "blocked": {
+                "type": "string"
+              },
+              "dns": {
+                "type": "string"
+              },
+              "connect": {
+                "type": "string"
+              },
+              "send": {
+                "type": "string"
+              },
+              "ttfb": {
+                "type": "string"
+              },
+              "receive": {
+                "type": "string"
+              }
+            }
+          },
+          "failureReason": {
+            "type": "string"
+          },
+          "initiatorPageUrl": {
+            "type": "string"
+          },
+          "correlatedUiSequence": {
+            "type": "integer"
+          }
+        }
+      }
+    },
+    "checkpoints": {
+      "type": "array"
+    },
+    "dataReferences": {
+      "type": "array"
+    },
+    "redactionSummary": {
+      "type": "object",
+      "required": [
+        "redactedValueCount",
+        "removedAttributeCount",
+        "redactedUrlParameterCount",
+        "appliedRules"
+      ]
+    },
+    "extensions": {
+      "type": "object"
+    }
+  }
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/format/CaptureJsonCodecTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/format/CaptureJsonCodecTest.java
@@ -41,11 +41,11 @@ class CaptureJsonCodecTest {
     @Test
     void canonicalGoldenFileUpgradesAndRemainsStable() throws IOException {
         String golden = resource("golden-session-1.0.json");
-        String expectedUpgraded = resource("golden-session-1.1.json");
+        String expectedUpgraded = resource("golden-session-1.2.json");
 
         CaptureSession session = codec.read(golden);
 
-        // Reading 1.0 migrates to 1.1; the canonical serialized form is byte-stable.
+        // Reading 1.0 migrates to the current schema version; the canonical serialized form is byte-stable.
         String serialized = codec.write(session);
         assertEquals(normalizeLineEndings(expectedUpgraded), normalizeLineEndings(serialized));
 

--- a/shaft-capture/src/test/java/com/shaft/capture/format/CaptureSchemaMigratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/format/CaptureSchemaMigratorTest.java
@@ -76,18 +76,18 @@ class CaptureSchemaMigratorTest {
 
         ObjectNode migrated = CaptureSchemaMigrator.migrate(original.deepCopy());
 
-        assertEquals("1.1", migrated.path("schemaVersion").asText());
+        assertEquals(CaptureSession.CURRENT_SCHEMA_VERSION, migrated.path("schemaVersion").asText());
         assertEquals(14, migrated.path("events").size());
         assertEquals(1, migrated.path("checkpoints").size());
         assertEquals(3, migrated.path("dataReferences").size());
 
         // Deep-equal on every pre-existing node except schemaVersion.
         ObjectNode originalWithUpgradedVersion = original.deepCopy();
-        originalWithUpgradedVersion.put("schemaVersion", "1.1");
+        originalWithUpgradedVersion.put("schemaVersion", CaptureSession.CURRENT_SCHEMA_VERSION);
         assertEquals(originalWithUpgradedVersion, migrated);
 
         // The migrated tree must itself be schema-valid and re-readable by the codec.
-        JsonNode schema = loadSchema("shaft-capture-session-1.1.schema.json");
+        JsonNode schema = loadSchema("shaft-capture-session-1.2.schema.json");
         List<String> errors = JsonSchemaValidator.validate(schema, migrated);
         assertTrue(errors.isEmpty(), "Migrated representative session should validate. Errors: " + errors);
 
@@ -97,13 +97,13 @@ class CaptureSchemaMigratorTest {
     }
 
     @Test
-    void version1_0SessionMigratesToVersion1_1() throws IOException {
+    void version1_0SessionMigratesToCurrentSchema() throws IOException {
         String golden = resource("golden-session-1.0.json");
         JsonNode parsed = mapper.readTree(golden);
 
         JsonNode migrated = CaptureSchemaMigrator.migrate(parsed);
 
-        assertEquals("1.1", migrated.path("schemaVersion").asText());
+        assertEquals(CaptureSession.CURRENT_SCHEMA_VERSION, migrated.path("schemaVersion").asText());
         assertEquals(0, migrated.path("events").size());
         assertNotNull(migrated.path("checkpoints"));
         assertNotNull(migrated.path("dataReferences"));
@@ -123,6 +123,7 @@ class CaptureSchemaMigratorTest {
         assertTrue(exception.getMessage().contains("0.9"));
         assertTrue(exception.getMessage().contains("1.0"));
         assertTrue(exception.getMessage().contains("1.1"));
+        assertTrue(exception.getMessage().contains("1.2"));
     }
 
     @Test
@@ -149,11 +150,11 @@ class CaptureSchemaMigratorTest {
         JsonNode parsed = mapper.readTree(golden);
         JsonNode migrated = CaptureSchemaMigrator.migrate(parsed);
 
-        // Ensure the migrated JSON validates against the 1.1 schema
-        JsonNode schema = loadSchema("shaft-capture-session-1.1.schema.json");
+        // Ensure the migrated JSON validates against the current schema
+        JsonNode schema = loadSchema("shaft-capture-session-1.2.schema.json");
         List<String> errors = JsonSchemaValidator.validate(schema, migrated);
 
-        assertTrue(errors.isEmpty(), "Migrated UI-only session should validate against 1.1 schema. Errors: " + errors);
+        assertTrue(errors.isEmpty(), "Migrated UI-only session should validate against current schema. Errors: " + errors);
     }
 
     @Test
@@ -238,6 +239,64 @@ class CaptureSchemaMigratorTest {
     }
 
     @Test
+    void assetResourceKindsAreValidInCurrentSchema() throws IOException {
+        // A 1.2 session with a minimal network event for each newly widened asset resourceKind
+        // must pass schema validation -- this is the exact write-time gap issue #3358's fix closes:
+        // without the widened enum, recording a real image/font/stylesheet/script/media transaction
+        // (e.g. with includeAssetTypes=true) would fail CaptureJsonCodec.write()'s schema validation.
+        for (String assetKind : List.of("STYLESHEET", "SCRIPT", "IMAGE", "FONT", "MEDIA")) {
+            ObjectNode session = mapper.createObjectNode();
+            session.put("schemaVersion", "1.2");
+            session.put("sessionId", "asset-session-" + assetKind);
+            session.put("status", "INCOMPLETE");
+            session.put("startedAt", "2026-01-02T03:04:05Z");
+
+            ObjectNode browser = session.putObject("browser");
+            browser.put("browserName", "chrome");
+            browser.put("logicalSessionId", "browser-1");
+            browser.set("capabilities", mapper.createObjectNode());
+
+            ObjectNode networkEvent = session.putArray("events").addObject();
+            networkEvent.put("type", "network");
+            networkEvent.put("transactionId", "txn-1");
+            networkEvent.put("resourceKind", assetKind);
+            ObjectNode context = networkEvent.putObject("context");
+            context.put("sequence", 1);
+            context.put("timestamp", "2026-01-02T03:04:06Z");
+            ObjectNode page = context.putObject("page");
+            page.put("url", "https://example.test");
+            page.put("title", "Example");
+            page.put("logicalWindowId", "window-1");
+            page.set("framePath", mapper.createArrayNode());
+            page.put("viewportWidth", 1280);
+            page.put("viewportHeight", 720);
+            context.put("replayStatus", "NOT_REPLAYED");
+            context.set("evidence", mapper.createArrayNode());
+            context.set("extensions", mapper.createObjectNode());
+
+            ObjectNode request = networkEvent.putObject("request");
+            request.put("method", "GET");
+            request.put("url", "https://example.test/static/asset");
+            request.set("headers", mapper.createObjectNode());
+
+            session.set("checkpoints", mapper.createArrayNode());
+            session.set("dataReferences", mapper.createArrayNode());
+            ObjectNode summary = session.putObject("redactionSummary");
+            summary.put("redactedValueCount", 0);
+            summary.put("removedAttributeCount", 0);
+            summary.put("redactedUrlParameterCount", 0);
+            summary.set("appliedRules", mapper.createArrayNode());
+            session.set("extensions", mapper.createObjectNode());
+
+            JsonNode schema = loadSchema("shaft-capture-session-1.2.schema.json");
+            List<String> errors = JsonSchemaValidator.validate(schema, session);
+
+            assertTrue(errors.isEmpty(),
+                    "Session with resourceKind=" + assetKind + " should validate. Errors: " + errors);
+        }
+    }
+
+    @Test
     void networkEventMissingBodyRefRequiredFieldsFailsSchemaValidation() throws IOException {
         ObjectNode session = mapper.createObjectNode();
         session.put("schemaVersion", "1.1");
@@ -290,12 +349,12 @@ class CaptureSchemaMigratorTest {
     }
 
     @Test
-    void migration0_9To1_0To1_1ChainPreservesData() throws IOException {
+    void migration0_9To1_0To1_1To1_2ChainPreservesData() throws IOException {
         String legacy = resource("legacy-session-0.9.json");
         JsonNode parsed = mapper.readTree(legacy);
         ObjectNode step1 = CaptureSchemaMigrator.migrate(parsed);
 
-        assertEquals("1.1", step1.path("schemaVersion").asText());
+        assertEquals(CaptureSession.CURRENT_SCHEMA_VERSION, step1.path("schemaVersion").asText());
         assertEquals("INCOMPLETE", step1.path("status").asText());
         assertEquals(3, step1.path("events").size());
 

--- a/shaft-capture/src/test/java/com/shaft/capture/network/CaptureNetworkRecorderTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/network/CaptureNetworkRecorderTest.java
@@ -6,6 +6,7 @@ import com.shaft.capture.model.CaptureEvent;
 import com.shaft.capture.model.CaptureSession;
 import com.shaft.capture.model.EventContext;
 import com.shaft.capture.model.PageContext;
+import com.shaft.capture.model.network.ResourceKind;
 import com.shaft.capture.storage.CaptureSessionStore;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.gui.browser.internal.BrowserNetworkInterceptionRule;
@@ -116,6 +117,35 @@ class CaptureNetworkRecorderTest {
             filterRef.get().apply(next).execute(assetRequest);
 
             assertTrue(events.isEmpty(), "Asset requests must be dropped when includeAssetTypes is false.");
+            recorder.close();
+        }
+    }
+
+    @Test
+    void recordsFineGrainedResourceKindForAssetRequestsWhenIncludeAssetTypesIsTrue() throws Exception {
+        // Regression for issue #3358: CaptureNetworkRecorder.classify() must surface its
+        // fine-grained classification all the way into RecordedTransaction.resourceKind() instead
+        // of collapsing every asset request down to the coarse OTHER bucket, since that collapse is
+        // what made CaptureManager.isAssetResource() a silent no-op against real capture data.
+        List<CaptureNetworkRecorder.RecordedTransaction> events = new ArrayList<>();
+        NetworkCaptureOptions options = new NetworkCaptureOptions(
+                true, List.of(), List.of(), false, 500, 0);
+        WebDriver driver = devToolsDriver("https://example.test/app");
+
+        AtomicReference<Filter> filterRef = new AtomicReference<>();
+        try (MockedConstruction<NetworkInterceptor> ignored = mockInterceptor(filterRef)) {
+            CaptureNetworkRecorder recorder = new CaptureNetworkRecorder(
+                    driver, temp.resolve("bodies"), options, "session-1", events::add, warnings::add);
+            assertTrue(recorder.start());
+
+            filterRef.get().apply(req -> new HttpResponse().setStatus(200).addHeader("Content-Type", "text/css"))
+                    .execute(new HttpRequest(HttpMethod.GET, "https://example.test/static/app.css"));
+            filterRef.get().apply(req -> new HttpResponse().setStatus(200).addHeader("Content-Type", "image/png"))
+                    .execute(new HttpRequest(HttpMethod.GET, "https://example.test/static/logo.png"));
+
+            assertEquals(2, events.size());
+            assertEquals(ResourceKind.STYLESHEET, events.get(0).resourceKind());
+            assertEquals(ResourceKind.IMAGE, events.get(1).resourceKind());
             recorder.close();
         }
     }

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureManagerNetworkTransactionsTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureManagerNetworkTransactionsTest.java
@@ -72,8 +72,8 @@ class CaptureManagerNetworkTransactionsTest {
         List<NetworkTransaction> withoutAssets = manager.networkTransactions(excludeAssets, 100);
 
         assertEquals(2, withoutAssets.size());
-        assertTrue(withoutAssets.stream().noneMatch(tx -> "image".equals(tx.resourceKind())
-                || "stylesheet".equals(tx.resourceKind())));
+        assertTrue(withoutAssets.stream().noneMatch(tx -> "IMAGE".equals(tx.resourceKind())
+                || "STYLESHEET".equals(tx.resourceKind())));
 
         NetworkCaptureOptions includeAssets = new NetworkCaptureOptions();
         includeAssets.excludeAssets = false;
@@ -157,10 +157,10 @@ class CaptureManagerNetworkTransactionsTest {
                             Map.of("authorization", "[REDACTED]"),
                             List.of(2)),
                     new NetworkTransaction(
-                            "tx-3", "GET", "https://cdn.example.test/logo.png", 200, "image", 12L,
+                            "tx-3", "GET", "https://cdn.example.test/logo.png", 200, "IMAGE", 12L,
                             Map.of(), List.of()),
                     new NetworkTransaction(
-                            "tx-4", "GET", "https://cdn.example.test/app.css", 200, "stylesheet", 9L,
+                            "tx-4", "GET", "https://cdn.example.test/app.css", 200, "STYLESHEET", 9L,
                             Map.of(), List.of()));
         }
 

--- a/shaft-capture/src/test/resources/fixtures/golden-session-1.2.json
+++ b/shaft-capture/src/test/resources/fixtures/golden-session-1.2.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion" : "1.2",
+  "sessionId" : "golden-session",
+  "status" : "INCOMPLETE",
+  "startedAt" : "2026-01-02T03:04:05Z",
+  "browser" : {
+    "browserName" : "chrome",
+    "browserVersion" : "137",
+    "platform" : "Windows 11",
+    "logicalSessionId" : "browser-1",
+    "capabilities" : {
+      "browsername" : "chrome"
+    }
+  },
+  "events" : [ ],
+  "checkpoints" : [ ],
+  "dataReferences" : [ ],
+  "redactionSummary" : {
+    "redactedValueCount" : 0,
+    "removedAttributeCount" : 0,
+    "redactedUrlParameterCount" : 0,
+    "appliedRules" : [ ]
+  },
+  "extensions" : { }
+}


### PR DESCRIPTION
## Summary

- `CaptureNetworkRecorder.classify()` already computed a fine-grained resource classification internally (stylesheet/script/image/font/media) but collapsed it to the coarse public `ResourceKind` enum (XHR/FETCH/DOCUMENT/WEBSOCKET_HANDSHAKE/OTHER) before it reached `NetworkEvent` — so `CaptureManager.isAssetResource()`'s "image"/"font"/"stylesheet"/"media" string matching could never fire against real captured transactions, only against test fixtures that bypassed the pipeline.
- Widened `ResourceKind` with `STYLESHEET`/`SCRIPT`/`IMAGE`/`FONT`/`MEDIA` plus an `isAsset()` predicate, threaded that classification straight through `CaptureNetworkRecorder` (deleting the now-redundant private `InternalResourceKind` enum), and rewrote `isAssetResource()` to key off `ResourceKind.valueOf(...).isAsset()` instead of a hand-rolled lowercase switch that could drift out of sync with the enum.
- Bumped the capture session schema to `1.2` since the persisted `resourceKind` enum is now wider (the JSON schema validates it at write time); prior versions in this repo (0.9→1.0→1.1) followed the same convention for additive schema changes, and it lets an older reader fail with a clear "unsupported schema version" error instead of an opaque validation failure.
- Note: unifying on `ResourceKind.isAsset()` means `CaptureManager` now also treats `SCRIPT` as asset noise, matching `CaptureNetworkRecorder`'s long-standing early-drop classification (which the old lowercase switch had missed).

## Test plan

- [x] `mvn -pl shaft-capture -am test-compile` — clean compile
- [x] `mvn -pl shaft-capture -am test -Dtest=CaptureNetworkRecorderTest,CaptureManagerNetworkTransactionsTest,CaptureJsonCodecTest,CaptureSchemaMigratorTest,NetworkEventTest,ApiCaptureGeneratorTest,CaptureManagerLifecycleTest` — 56/56 passing
- [x] New `CaptureNetworkRecorderTest.recordsFineGrainedResourceKindForAssetRequestsWhenIncludeAssetTypesIsTrue` proves fine-grained classification survives the real recorder pipeline
- [x] New `CaptureSchemaMigratorTest.assetResourceKindsAreValidInCurrentSchema` proves the widened schema accepts all five new resource kinds at write time
- [x] `CaptureManagerNetworkTransactionsTest` fixture updated to the real `.name()`-shaped uppercase strings, which the old code silently failed to match

Fixes #3358

🤖 Generated with [Claude Code](https://claude.com/claude-code)