### PR TITLE
Close remaining #3347 gaps: trace screenshots, IntelliJ trace viewer, sharded merge

### DIFF
--- a/.github/workflows/sharded-merged-report.yml
+++ b/.github/workflows/sharded-merged-report.yml
@@ -1,0 +1,93 @@
+name: Sharded Execution + Merged Report Demo
+
+# Dispatch-only demo of the D8 -Dshaft.shard=N/M sharding + merged-report
+# pipeline (issue #3347). Does NOT replace or touch the existing manual
+# class-filter partitioning in e2eTests.yml -- it is a separate, opt-in
+# recipe showing the shard -> assemble -> merge flow end to end using
+# scripts/ci/assemble_shard_blob.py and ShardMergeCli.
+#
+# The default test filter targets ShardPartitionerUnitTest itself (a fast,
+# browser-free TestNG unit test), so a dispatch run stays quick; point
+# test_filter at a broader suite to shard real end-to-end tests.
+
+concurrency:
+  group: sharded-merged-report-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_filter:
+        description: '-Dtest= filter passed to every shard'
+        required: false
+        default: '%regex[.*ShardPartitionerUnitTest.*]'
+
+env:
+  TOTAL_SHARDS: 3
+
+jobs:
+  shard:
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test-env
+        with:
+          node-version: ''
+      - name: Run shard ${{ matrix.shard }}/${{ env.TOTAL_SHARDS }}
+        run: mvn -pl shaft-engine -am -e test "-Dshaft.shard=${{ matrix.shard }}/${{ env.TOTAL_SHARDS }}" "-DheadlessExecution=true" "-Dtest=${{ github.event.inputs.test_filter }}"
+      - name: Assemble shard blob
+        run: python3 scripts/ci/assemble_shard_blob.py --shard ${{ matrix.shard }} --output "target/shard-blobs/shard-${{ matrix.shard }}" --zip
+      - name: Upload shard blob
+        uses: actions/upload-artifact@v7
+        with:
+          name: shard-blob-${{ matrix.shard }}
+          path: target/shard-blobs/shard-${{ matrix.shard }}.zip
+          if-no-files-found: error
+
+  merge:
+    needs: shard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test-env
+        with:
+          node-version: ''
+      - name: Download all shard blobs
+        uses: actions/download-artifact@v7
+        with:
+          pattern: shard-blob-*
+          path: downloaded-blobs
+      - name: Unzip shard blobs into ShardBlob layout
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/shard-blobs
+          for zip in downloaded-blobs/*/*.zip; do
+            name="$(basename "$zip" .zip)"
+            mkdir -p "target/shard-blobs/$name"
+            unzip -oq "$zip" -d "target/shard-blobs/$name"
+          done
+      - name: Build report-aggregate + shaft-doctor
+        run: mvn -q -pl report-aggregate -am -DskipTests -Dgpg.skip=true install
+      - name: Merge shards
+        shell: bash
+        run: |
+          set -euo pipefail
+          blobs=(target/shard-blobs/*/)
+          mvn -q -pl report-aggregate exec:java \
+            "-Dexec.mainClass=com.shaft.reportaggregate.ShardMergeCli" \
+            "-Dexec.args=--output target/merged-report ${blobs[*]}"
+      - name: Upload merged report
+        uses: actions/upload-artifact@v7
+        with:
+          name: merged-report
+          path: target/merged-report
+          if-no-files-found: error

--- a/report-aggregate/src/test/java/com/shaft/reportaggregate/ShardMergeCliTest.java
+++ b/report-aggregate/src/test/java/com/shaft/reportaggregate/ShardMergeCliTest.java
@@ -35,11 +35,56 @@ class ShardMergeCliTest {
     }
 
     @Test
+    void mainMergesShardsWithExecutionIntelligenceAndTraces() throws Exception {
+        Path shard1 = writeShardWithIntelligence("shard-1", "com.example.Test.a", "failed", "LOCATOR", "HIGH");
+        Path shard2 = writeShardWithIntelligence("shard-2", "com.example.Test.b", "passed", "TIMING_SYNCHRONIZATION", "MEDIUM");
+        Path output = tempDir.resolve("merged");
+
+        String stdout = captureStdout(() -> ShardMergeCli.main(new String[]{
+                "--output", output.toString(), shard1.toString(), shard2.toString()}));
+
+        assertTrue(stdout.contains("Merged 2 shard(s), 2 Allure result(s)"), stdout);
+        assertTrue(Files.isDirectory(output.resolve("allure-results")));
+        assertTrue(Files.isRegularFile(output.resolve("speedboard.html")));
+        assertTrue(Files.isDirectory(output.resolve("shaft-traces").resolve("shard-1")));
+        assertTrue(Files.isDirectory(output.resolve("shaft-traces").resolve("shard-2")));
+        String speedboard = Files.readString(output.resolve("speedboard.html"), StandardCharsets.UTF_8);
+        assertTrue(speedboard.contains("Doctor triage across shards"), speedboard);
+        assertTrue(speedboard.contains("LOCATOR"), speedboard);
+        assertTrue(speedboard.contains("TIMING_SYNCHRONIZATION"), speedboard);
+    }
+
+    @Test
     void mainRequiresAtLeastOneShardDirectory() {
         IllegalArgumentException failure = assertThrows(IllegalArgumentException.class,
                 () -> ShardMergeCli.main(new String[]{"--output", tempDir.resolve("merged").toString()}));
 
         assertTrue(failure.getMessage().contains("At least one shard blob directory is required"));
+    }
+
+    private Path writeShardWithIntelligence(String shardName, String fullName, String status,
+            String primaryCause, String confidence) throws Exception {
+        Path shard = Files.createDirectories(tempDir.resolve(shardName).resolve("allure-results"));
+        Files.writeString(shard.resolve("t-result.json"),
+                "{\"fullName\":\"" + fullName + "\",\"status\":\"" + status + "\",\"start\":0,\"stop\":10}",
+                StandardCharsets.UTF_8);
+        Path traceDirectory = Files.createDirectories(
+                tempDir.resolve(shardName).resolve("shaft-traces").resolve(fullName));
+        Files.writeString(traceDirectory.resolve("index.json"), "{}", StandardCharsets.UTF_8);
+        Files.writeString(tempDir.resolve(shardName).resolve("execution-intelligence.json"), """
+                {
+                  "schemaVersion": "1.0",
+                  "bundleId": "bundle-1",
+                  "totalAllureResults": 1,
+                  "failingAttempts": 1,
+                  "hiddenRetryFailures": 0,
+                  "recurringFailures": 0,
+                  "primaryCause": "%s",
+                  "confidence": "%s",
+                  "summary": "Deterministic summary for %s."
+                }
+                """.formatted(primaryCause, confidence, shardName), StandardCharsets.UTF_8);
+        return shard.getParent();
     }
 
     private static String captureStdout(Runnable action) {

--- a/scripts/ci/assemble_shard_blob.py
+++ b/scripts/ci/assemble_shard_blob.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Assemble one shard's self-contained blob for SHAFT's D8 sharded-merge pipeline.
+
+Stages a shard's ``allure-results`` directory, ``target/shaft-traces`` directory,
+and (optionally) a doctor ``execution-intelligence.json`` digest into the
+``ShardBlob`` layout that ``ShardMerger``/``ShardMergeCli``/the shaft-mcp
+``report_merge_shards`` tool already read:
+
+    <output>/
+      allure-results/*.json
+      shaft-traces/...             (optional)
+      execution-intelligence.json  (optional)
+
+shaft-engine has no dependency on shaft-doctor -- the two are deliberately
+kept apart by the reactor's ``enforce-engine-dependency-boundary`` Enforcer
+rule -- so the engine cannot run ``shaft-doctor analyze`` itself once a test
+run finishes. This script is the post-test orchestration step that closes
+that gap. The doctor step is best-effort: pass ``--doctor-command`` with a
+full command line to run it, or omit it entirely to stage a blob without
+``execution-intelligence.json``; ``ShardBlob``/``ShardMerger`` already treat
+that file as optional, so a missing or failing doctor step never blocks
+assembling (and later merging) the blob.
+
+Usage:
+    scripts/ci/assemble_shard_blob.py --shard 1
+
+    scripts/ci/assemble_shard_blob.py --shard 1 --zip \\
+        --doctor-command "java -cp shaft-doctor.jar com.shaft.doctor.cli.DoctorCli analyze --input allure-results --allowed-root . --output-dir target/shaft-doctor"
+
+Exit codes:
+    0   blob assembled (with or without execution-intelligence.json)
+    2   usage / environment error (e.g. allure-results directory missing)
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import shutil
+import subprocess  # nosec B404
+import sys
+import zipfile
+from pathlib import Path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--shard", required=True, help="Shard label, e.g. '1' for -Dshaft.shard=1/3")
+    parser.add_argument(
+        "--allure-results", type=Path, default=Path("allure-results"),
+        help="Allure results directory for this shard's run (default: allure-results)",
+    )
+    parser.add_argument(
+        "--traces-dir", type=Path, default=Path("target/shaft-traces"),
+        help="SHAFT trace directory for this shard's run (default: target/shaft-traces)",
+    )
+    parser.add_argument(
+        "--doctor-command", type=str, default=None,
+        help="Full 'shaft-doctor analyze' command line (shell-split) to run before staging; "
+        "omit to stage the blob without execution-intelligence.json",
+    )
+    parser.add_argument(
+        "--doctor-output", type=Path, default=Path("target/shaft-doctor"),
+        help="Directory the doctor command writes execution-intelligence.json into "
+        "(default: target/shaft-doctor)",
+    )
+    parser.add_argument(
+        "--output", type=Path, default=None,
+        help="Shard blob output directory (default: target/shard-blobs/shard-<shard>)",
+    )
+    parser.add_argument("--zip", action="store_true", help="Also produce <output>.zip alongside the directory")
+    return parser
+
+
+def run_doctor(command_line: str) -> bool:
+    """Runs the configured shaft-doctor command; returns True on success."""
+    parts = shlex.split(command_line)
+    if not parts:
+        return False
+    executable = shutil.which(parts[0]) or parts[0]
+    # List-args with no shell=True; the command line is an operator-supplied
+    # CI configuration value, not attacker-controlled input.
+    completed = subprocess.run(  # nosec B603
+        [executable, *parts[1:]], capture_output=True, text=True, check=False
+    )
+    if completed.returncode != 0:
+        print(
+            f"WARNING: shaft-doctor analyze failed (exit {completed.returncode}), "
+            f"staging blob without execution-intelligence.json:\n{completed.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def stage_directory(source: Path, destination: Path) -> None:
+    """Copies source into destination, replacing any existing directory."""
+    if destination.exists():
+        shutil.rmtree(destination)
+    shutil.copytree(source, destination)
+
+
+def zip_blob(output: Path) -> Path:
+    """Zips the assembled blob directory into <output>.zip and returns its path."""
+    zip_path = output.with_suffix(".zip")
+    if zip_path.exists():
+        zip_path.unlink()
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as archive:
+        for file in sorted(output.rglob("*")):
+            if file.is_file():
+                archive.write(file, file.relative_to(output))
+    return zip_path
+
+
+def assemble(args: argparse.Namespace) -> Path:
+    """Stages the ShardBlob layout under args.output and returns its path."""
+    output = (args.output or Path("target") / "shard-blobs" / f"shard-{args.shard}").resolve()
+    if output.exists():
+        shutil.rmtree(output)
+    output.mkdir(parents=True)
+
+    if not args.allure_results.is_dir():
+        raise SystemExit(f"Allure results directory not found: {args.allure_results}")
+    stage_directory(args.allure_results, output / "allure-results")
+
+    if args.traces_dir.is_dir():
+        stage_directory(args.traces_dir, output / "shaft-traces")
+    else:
+        print(f"No shaft-traces directory at {args.traces_dir}; blob will have no shaft-traces/.", file=sys.stderr)
+
+    if args.doctor_command:
+        if run_doctor(args.doctor_command):
+            intelligence = args.doctor_output / "execution-intelligence.json"
+            if intelligence.is_file():
+                shutil.copy2(intelligence, output / "execution-intelligence.json")
+            else:
+                print(
+                    f"shaft-doctor analyze ran but did not produce {intelligence}; "
+                    "blob will have no execution-intelligence.json.",
+                    file=sys.stderr,
+                )
+    else:
+        print("No --doctor-command supplied; blob will have no execution-intelligence.json.", file=sys.stderr)
+
+    if args.zip:
+        print(f"Zipped blob: {zip_blob(output)}")
+
+    return output
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Runs the CLI."""
+    args = build_parser().parse_args(argv)
+    output = assemble(args)
+    print(f"Shard {args.shard} blob assembled at {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run_sharded_and_merge.py
+++ b/scripts/ci/run_sharded_and_merge.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Run SHAFT's sharded-execution + merged-report pipeline (D8) end-to-end, locally.
+
+Orchestrates, for a total of N shards:
+
+  1. one Maven test invocation per shard using ``-Dshaft.shard=<i>/<N>``
+     (partitioning itself is deterministic and handled entirely by
+     ``ShardPartitioner``/``TestNGListener`` inside the test run -- this
+     script only drives N separate invocations);
+  2. ``scripts/ci/assemble_shard_blob.py`` after each shard run, staging that
+     shard's ``allure-results``/``target/shaft-traces``/optional doctor
+     ``execution-intelligence.json`` into the ``ShardBlob`` layout; and
+  3. one merge step (``ShardMergeCli``) combining every shard blob into one
+     Allure result set plus a "speedboard" HTML with cross-shard doctor
+     triage.
+
+This intentionally does not replace or touch the existing manual class-filter
+CI partitioning in ``.github/workflows/e2eTests.yml`` -- it is a separate,
+opt-in recipe for the ``-Dshaft.shard`` mechanism, runnable locally or wired
+into a CI matrix job (see ``.github/workflows/sharded-merged-report.yml``,
+which runs shards 1..N as parallel jobs and calls this same assemble/merge
+machinery across job boundaries via artifact upload/download instead of
+in one local process).
+
+Usage:
+    scripts/ci/run_sharded_and_merge.py --shards 3 --test "%regex[.*SmokeTest.*]"
+
+    scripts/ci/run_sharded_and_merge.py --shards 3 \\
+        --doctor-command "java -cp shaft-doctor.jar com.shaft.doctor.cli.DoctorCli analyze --input allure-results --allowed-root . --output-dir target/shaft-doctor" \\
+        --merge-command "java -cp report-aggregate.jar com.shaft.reportaggregate.ShardMergeCli --output {output} {blobs}"
+
+Exit codes:
+    0   sharded runs + assembly + merge all completed
+    1   a shard's Maven test invocation, blob assembly, or the merge step failed
+    2   usage / environment error (e.g. --shards < 1)
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import shutil
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+
+# report-aggregate has no runnable-jar packaging (no exec-maven-plugin
+# binding, no Main-Class manifest) -- this default drives ShardMergeCli via
+# an ad-hoc `exec:java` goal invocation, which Maven can resolve without any
+# pom changes. Override with --merge-command once a packaged CLI exists.
+DEFAULT_MERGE_COMMAND = (
+    'mvn -q -pl report-aggregate exec:java '
+    '-Dexec.mainClass=com.shaft.reportaggregate.ShardMergeCli '
+    '-Dexec.args="--output {output} {blobs}"'
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--shards", type=int, required=True, help="Total shard count (the M in -Dshaft.shard=N/M)")
+    parser.add_argument("--test", type=str, default=None, help="Optional -Dtest= filter forwarded to every shard's Maven run")
+    parser.add_argument(
+        "--no-headless", dest="headless", action="store_false", default=True,
+        help="Do not force -DheadlessExecution=true (default: headless is forced on)",
+    )
+    parser.add_argument("--extra-mvn-arg", action="append", default=[], help="Additional -D... argument, may be repeated")
+    parser.add_argument("--doctor-command", type=str, default=None, help="Forwarded to assemble_shard_blob.py --doctor-command")
+    parser.add_argument("--output", type=Path, default=Path("target/merged-report"), help="Merged report output directory")
+    parser.add_argument(
+        "--merge-command", type=str, default=None,
+        help="Full merge command line (shell-split); {output} and {blobs} placeholders are substituted. "
+        "Defaults to a report-aggregate exec:java invocation of ShardMergeCli.",
+    )
+    parser.add_argument(
+        "--skip-tests", action="store_true",
+        help="Skip running mvn test per shard (assumes allure-results/target/shaft-traces already exist "
+        "from a prior run) -- useful for re-running just assembly+merge",
+    )
+    return parser
+
+
+def run(command: list[str], step: str) -> None:
+    """Runs one subprocess step to completion, raising with a labeled message on failure."""
+    executable = shutil.which(command[0]) or command[0]
+    # List-args with no shell=True; every argument is either a fixed literal
+    # or an internally-built -D/flag value, never unsanitized external input.
+    completed = subprocess.run([executable, *command[1:]])  # nosec B603
+    if completed.returncode != 0:
+        raise SystemExit(f"{step} failed with exit code {completed.returncode}")
+
+
+def run_shard_tests(shard: int, args: argparse.Namespace) -> None:
+    """Runs one shard's Maven test invocation, matching the -am shape CI already uses."""
+    command = ["mvn", "-pl", "shaft-engine", "-am", "test", f"-Dshaft.shard={shard}/{args.shards}"]
+    if args.headless:
+        command.append("-DheadlessExecution=true")
+    if args.test:
+        command.append(f"-Dtest={args.test}")
+    command.extend(args.extra_mvn_arg)
+    run(command, f"Shard {shard} Maven test")
+
+
+def assemble_shard(shard: int, args: argparse.Namespace) -> Path:
+    """Stages one shard's blob via assemble_shard_blob.py and returns its directory."""
+    blob_dir = Path("target") / "shard-blobs" / f"shard-{shard}"
+    command = [sys.executable, "scripts/ci/assemble_shard_blob.py", "--shard", str(shard), "--output", str(blob_dir)]
+    if args.doctor_command:
+        command += ["--doctor-command", args.doctor_command]
+    run(command, f"Shard {shard} blob assembly")
+    return blob_dir
+
+
+def merge_shards(blob_dirs: list[Path], args: argparse.Namespace) -> None:
+    """Runs the configured (or default) merge command over every shard blob."""
+    # shlex.split() below applies POSIX escaping rules, where a bare backslash
+    # is an escape character -- it silently eats Windows-style path
+    # separators (target\shard-blobs\shard-1 -> targetshard-blobsshard-1).
+    # Rendering paths as forward slashes sidesteps that entirely; both
+    # Windows and POSIX toolchains accept forward-slash paths.
+    blobs = " ".join(blob.as_posix() for blob in blob_dirs)
+    template = args.merge_command or DEFAULT_MERGE_COMMAND
+    rendered = template.format(output=args.output.as_posix(), blobs=blobs)
+    run(shlex.split(rendered), "Shard merge")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Runs the CLI."""
+    args = build_parser().parse_args(argv)
+    if args.shards < 1:
+        raise SystemExit("--shards must be >= 1")
+
+    blob_dirs = []
+    for shard in range(1, args.shards + 1):
+        if not args.skip_tests:
+            run_shard_tests(shard, args)
+        blob_dirs.append(assemble_shard(shard, args))
+
+    merge_shards(blob_dirs, args)
+    print(f"Merged {args.shards} shard(s) into {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/shaft-doctor/src/main/java/com/shaft/doctor/shard/MergedReport.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/shard/MergedReport.java
@@ -12,6 +12,7 @@ import java.util.List;
  * @param shardCount number of shard blobs merged
  * @param totalResults total Allure result files merged (containers/attachments not counted)
  * @param flakyClusters tests observed with inconsistent pass/fail outcomes across shards
+ * @param shardIntelligence per-shard doctor {@code ExecutionIntelligence} digests, for shards that had one
  * @param warnings safe warnings (e.g. an unreadable shard blob was skipped)
  */
 public record MergedReport(
@@ -20,9 +21,11 @@ public record MergedReport(
         int shardCount,
         int totalResults,
         List<FlakyCluster> flakyClusters,
+        List<ShardIntelligence> shardIntelligence,
         List<String> warnings) {
     public MergedReport {
         flakyClusters = flakyClusters == null ? List.of() : List.copyOf(flakyClusters);
+        shardIntelligence = shardIntelligence == null ? List.of() : List.copyOf(shardIntelligence);
         warnings = warnings == null ? List.of() : List.copyOf(warnings);
     }
 }

--- a/shaft-doctor/src/main/java/com/shaft/doctor/shard/ShardIntelligence.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/shard/ShardIntelligence.java
@@ -1,0 +1,33 @@
+package com.shaft.doctor.shard;
+
+/**
+ * One shard's doctor {@code ExecutionIntelligence} digest, reduced to the fields useful for
+ * cross-shard doctor-triage aggregation in the merged speedboard -- SHAFT's differentiator over
+ * Playwright's plain {@code merge-reports}, which carries no failure intelligence.
+ *
+ * @param shardId shard identifier (blob directory name)
+ * @param primaryCause deterministic primary cause name
+ * @param confidence deterministic confidence name
+ * @param failingAttempts failed or broken attempt count reported by the shard's doctor run
+ * @param hiddenRetryFailures retry-hidden failure count reported by the shard's doctor run
+ * @param recurringFailures recurring failure count reported by the shard's doctor run
+ * @param summary concise per-shard doctor summary
+ */
+public record ShardIntelligence(
+        String shardId,
+        String primaryCause,
+        String confidence,
+        int failingAttempts,
+        int hiddenRetryFailures,
+        int recurringFailures,
+        String summary) {
+    public ShardIntelligence {
+        shardId = shardId == null ? "" : shardId;
+        primaryCause = primaryCause == null ? "UNKNOWN" : primaryCause;
+        confidence = confidence == null ? "UNKNOWN" : confidence;
+        failingAttempts = Math.max(0, failingAttempts);
+        hiddenRetryFailures = Math.max(0, hiddenRetryFailures);
+        recurringFailures = Math.max(0, recurringFailures);
+        summary = summary == null ? "" : summary;
+    }
+}

--- a/shaft-doctor/src/main/java/com/shaft/doctor/shard/ShardMerger.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/shard/ShardMerger.java
@@ -1,5 +1,6 @@
 package com.shaft.doctor.shard;
 
+import com.shaft.doctor.model.ExecutionIntelligence;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
@@ -45,8 +46,10 @@ public final class ShardMerger {
     public static MergedReport merge(List<Path> shardRoots, Path outputDirectory) {
         Path output = outputDirectory.toAbsolutePath().normalize();
         Path mergedAllureResults = output.resolve("allure-results");
+        Path mergedTraces = output.resolve("shaft-traces");
         List<String> warnings = new ArrayList<>();
         List<AllureResultSummary> allResults = new ArrayList<>();
+        List<ShardIntelligence> shardIntelligence = new ArrayList<>();
 
         try {
             Files.createDirectories(mergedAllureResults);
@@ -64,6 +67,8 @@ public final class ShardMerger {
             shardCount++;
             String shardId = blob.root().getFileName() == null ? blob.root().toString() : blob.root().getFileName().toString();
             allResults.addAll(copyAllureResults(blob, shardId, mergedAllureResults, warnings));
+            copyTraces(blob, shardId, mergedTraces, warnings);
+            readShardIntelligence(blob, shardId, warnings).ifPresent(shardIntelligence::add);
         }
 
         Map<String, List<AllureResultSummary>> byFullName = new LinkedHashMap<>();
@@ -72,10 +77,63 @@ public final class ShardMerger {
         }
         List<FlakyCluster> flakyClusters = flakyClusters(byFullName);
         Path speedboard = output.resolve("speedboard.html");
-        writeSpeedboard(speedboard, allResults, flakyClusters, shardCount);
+        writeSpeedboard(speedboard, allResults, flakyClusters, shardCount, shardIntelligence);
 
         return new MergedReport(mergedAllureResults, speedboard, shardCount, allResults.size(),
-                flakyClusters, List.copyOf(warnings));
+                flakyClusters, List.copyOf(shardIntelligence), List.copyOf(warnings));
+    }
+
+    /**
+     * Copies a shard's {@code shaft-traces} directory (if present) through untouched into
+     * {@code <output>/shaft-traces/<shardId>/}, namespaced by shard id since two shards may
+     * otherwise persist traces for differently-numbered attempts of the same test id.
+     */
+    private static void copyTraces(ShardBlob blob, String shardId, Path mergedTraces, List<String> warnings) {
+        if (!Files.isDirectory(blob.traces())) {
+            return;
+        }
+        Path destination = mergedTraces.resolve(shardId);
+        try (Stream<Path> paths = Files.walk(blob.traces())) {
+            for (Path source : paths.toList()) {
+                Path target = destination.resolve(blob.traces().relativize(source).toString());
+                if (Files.isDirectory(source)) {
+                    Files.createDirectories(target);
+                } else {
+                    Files.createDirectories(target.getParent());
+                    Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
+                }
+            }
+        } catch (IOException exception) {
+            warnings.add("Could not copy shaft-traces for shard " + shardId + ": " + exception.getMessage());
+        }
+    }
+
+    /**
+     * Reads and reduces a shard's optional {@code execution-intelligence.json} (produced by an
+     * out-of-band {@code shaft-doctor analyze} run against that shard's Allure results) into a
+     * {@link ShardIntelligence} digest for cross-shard doctor-triage aggregation. A shard without
+     * one, or with an unreadable one, is skipped with a warning rather than failing the merge.
+     */
+    private static java.util.Optional<ShardIntelligence> readShardIntelligence(
+            ShardBlob blob, String shardId, List<String> warnings) {
+        if (!Files.isRegularFile(blob.executionIntelligence())) {
+            return java.util.Optional.empty();
+        }
+        try {
+            ExecutionIntelligence intelligence = JSON.readValue(
+                    Files.readString(blob.executionIntelligence(), StandardCharsets.UTF_8), ExecutionIntelligence.class);
+            return java.util.Optional.of(new ShardIntelligence(
+                    shardId,
+                    intelligence.primaryCause() == null ? "UNKNOWN" : intelligence.primaryCause().name(),
+                    intelligence.confidence() == null ? "UNKNOWN" : intelligence.confidence().name(),
+                    intelligence.failingAttempts(),
+                    intelligence.hiddenRetryFailures(),
+                    intelligence.recurringFailures(),
+                    intelligence.summary()));
+        } catch (IOException | RuntimeException malformed) {
+            warnings.add("Could not read execution-intelligence.json for shard " + shardId + ": " + malformed.getMessage());
+            return java.util.Optional.empty();
+        }
     }
 
     private static List<AllureResultSummary> copyAllureResults(
@@ -141,7 +199,8 @@ public final class ShardMerger {
     }
 
     private static void writeSpeedboard(
-            Path destination, List<AllureResultSummary> results, List<FlakyCluster> flakyClusters, int shardCount) {
+            Path destination, List<AllureResultSummary> results, List<FlakyCluster> flakyClusters, int shardCount,
+            List<ShardIntelligence> shardIntelligence) {
         List<AllureResultSummary> slowestFirst = new ArrayList<>(results);
         slowestFirst.sort((a, b) -> Long.compare(b.durationMs(), a.durationMs()));
 
@@ -155,6 +214,25 @@ public final class ShardMerger {
                 .append("<p>Shards merged: ").append(shardCount)
                 .append(" &middot; Total results: ").append(results.size())
                 .append(" &middot; Flaky clusters: ").append(flakyClusters.size()).append("</p>");
+
+        html.append("<h2>Doctor triage across shards</h2>");
+        if (shardIntelligence.isEmpty()) {
+            html.append("<p>No per-shard execution-intelligence.json was available.</p>");
+        } else {
+            html.append("<table><tr><th>Shard</th><th>Primary Cause</th><th>Confidence</th>")
+                    .append("<th>Failing Attempts</th><th>Hidden Retry Failures</th><th>Recurring Failures</th>")
+                    .append("<th>Summary</th></tr>");
+            for (ShardIntelligence intelligence : shardIntelligence) {
+                html.append("<tr><td>").append(escape(intelligence.shardId())).append("</td><td>")
+                        .append(escape(intelligence.primaryCause())).append("</td><td>")
+                        .append(escape(intelligence.confidence())).append("</td><td>")
+                        .append(intelligence.failingAttempts()).append("</td><td>")
+                        .append(intelligence.hiddenRetryFailures()).append("</td><td>")
+                        .append(intelligence.recurringFailures()).append("</td><td>")
+                        .append(escape(intelligence.summary())).append("</td></tr>");
+            }
+            html.append("</table>");
+        }
 
         html.append("<h2>Flaky clusters (inconsistent pass/fail across shards)</h2>");
         if (flakyClusters.isEmpty()) {

--- a/shaft-doctor/src/test/java/com/shaft/doctor/shard/ShardMergerTest.java
+++ b/shaft-doctor/src/test/java/com/shaft/doctor/shard/ShardMergerTest.java
@@ -85,6 +85,85 @@ class ShardMergerTest {
         assertFalse(report.warnings().isEmpty());
     }
 
+    @Test
+    void copiesShaftTracesFromEveryShardIntoMergedOutputNamespacedByShard() throws Exception {
+        Path shard1 = writeShard("shard-1", result("test-a", "com.example.Test.a", "passed", 0, 100));
+        writeTrace(shard1, "com.example.Test.a", "{\"testId\": \"com.example.Test.a\"}");
+        Path shard2 = writeShard("shard-2", result("test-b", "com.example.Test.b", "passed", 0, 100));
+        writeTrace(shard2, "com.example.Test.b", "{\"testId\": \"com.example.Test.b\"}");
+
+        MergedReport report = ShardMerger.merge(List.of(shard1, shard2), tempDir.resolve("merged"));
+
+        Path mergedTraces = report.mergedAllureResultsDirectory().getParent().resolve("shaft-traces");
+        assertTrue(Files.exists(mergedTraces.resolve("shard-1").resolve("com.example.Test.a").resolve("index.json")));
+        assertTrue(Files.exists(mergedTraces.resolve("shard-2").resolve("com.example.Test.b").resolve("index.json")));
+        assertTrue(report.warnings().isEmpty(), report.warnings().toString());
+    }
+
+    @Test
+    void shardWithNoTracesDirectoryMergesWithoutWarning() throws Exception {
+        Path shard = writeShard("shard-1", result("test-a", "com.example.Test.a", "passed", 0, 100));
+
+        MergedReport report = ShardMerger.merge(List.of(shard), tempDir.resolve("merged"));
+
+        assertTrue(report.warnings().isEmpty(), report.warnings().toString());
+    }
+
+    @Test
+    void aggregatesExecutionIntelligenceAcrossShardsIntoSpeedboard() throws Exception {
+        Path shard1 = writeShard("shard-1", result("test-a", "com.example.Test.a", "failed", 0, 100));
+        writeExecutionIntelligence(shard1, "LOCATOR", "HIGH", 3, 1, 2, "Locator drift on shard 1.");
+        Path shard2 = writeShard("shard-2", result("test-b", "com.example.Test.b", "passed", 0, 100));
+        writeExecutionIntelligence(shard2, "TIMING_SYNCHRONIZATION", "MEDIUM", 1, 0, 0, "Timing flake on shard 2.");
+
+        MergedReport report = ShardMerger.merge(List.of(shard1, shard2), tempDir.resolve("merged"));
+
+        assertEquals(2, report.shardIntelligence().size());
+        ShardIntelligence first = report.shardIntelligence().get(0);
+        assertEquals("shard-1", first.shardId());
+        assertEquals("LOCATOR", first.primaryCause());
+        assertEquals("HIGH", first.confidence());
+        assertEquals(3, first.failingAttempts());
+        String speedboard = Files.readString(report.speedboardHtmlPath(), StandardCharsets.UTF_8);
+        assertTrue(speedboard.contains("Doctor triage across shards"), speedboard);
+        assertTrue(speedboard.contains("Locator drift on shard 1."), speedboard);
+        assertTrue(speedboard.contains("Timing flake on shard 2."), speedboard);
+    }
+
+    @Test
+    void malformedExecutionIntelligenceIsSkippedWithAWarningRatherThanThrowing() throws Exception {
+        Path shard = writeShard("shard-1", result("test-a", "com.example.Test.a", "passed", 0, 100));
+        Files.writeString(shard.resolve("execution-intelligence.json"), "{not valid json", StandardCharsets.UTF_8);
+
+        MergedReport report = ShardMerger.merge(List.of(shard), tempDir.resolve("merged"));
+
+        assertTrue(report.shardIntelligence().isEmpty());
+        assertFalse(report.warnings().isEmpty());
+    }
+
+    private void writeTrace(Path shard, String testId, String indexJson) throws Exception {
+        Path traceDirectory = Files.createDirectories(shard.resolve("shaft-traces").resolve(testId));
+        Files.writeString(traceDirectory.resolve("index.json"), indexJson, StandardCharsets.UTF_8);
+    }
+
+    private void writeExecutionIntelligence(Path shard, String primaryCause, String confidence,
+            int failingAttempts, int hiddenRetryFailures, int recurringFailures, String summary) throws Exception {
+        Files.writeString(shard.resolve("execution-intelligence.json"), """
+                {
+                  "schemaVersion": "1.0",
+                  "bundleId": "bundle-1",
+                  "totalAllureResults": 1,
+                  "failingAttempts": %d,
+                  "hiddenRetryFailures": %d,
+                  "recurringFailures": %d,
+                  "primaryCause": "%s",
+                  "confidence": "%s",
+                  "summary": "%s"
+                }
+                """.formatted(failingAttempts, hiddenRetryFailures, recurringFailures, primaryCause, confidence, summary),
+                StandardCharsets.UTF_8);
+    }
+
     private Path writeShard(String name, String... resultJsonFiles) throws Exception {
         Path shard = Files.createDirectories(tempDir.resolve(name));
         Path allureResults = Files.createDirectories(shard.resolve("allure-results"));

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -1500,6 +1500,7 @@ public class Actions extends ElementActions {
         if (screenshot != null) {
             long profilerStart = FlakeProfiler.isEnabled() ? System.nanoTime() : 0L;
             Allure.addAttachment(SCREENSHOT_ATTACHMENT_FORMATTER.format(ZonedDateTime.now()) + "_" + JavaHelper.convertToSentenceCase(action) + "_" + JavaHelper.removeSpecialCharacters(elementName), "image/png", new ByteArrayInputStream(screenshot), ".png");
+            TraceEventRecorder.recordScreenshot(event, screenshot);
             if (profilerStart != 0L) {
                 FlakeProfiler.recordEvidenceCapture("report attachment", action,
                         TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - profilerStart));

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Reporting.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Reporting.java
@@ -118,6 +118,10 @@ public interface Reporting extends EngineProperties<Reporting> {
     @DefaultValue("true")
     boolean traceIncludeDomSnapshots();
 
+    @Key("shaft.trace.includeScreenshots")
+    @DefaultValue("true")
+    boolean traceIncludeScreenshots();
+
     @Key("shaft.trace.includeNativePageSource")
     @DefaultValue("true")
     boolean traceIncludeNativePageSource();
@@ -274,6 +278,11 @@ public interface Reporting extends EngineProperties<Reporting> {
 
         public SetProperty traceIncludeDomSnapshots(boolean value) {
             setProperty("shaft.trace.includeDomSnapshots", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty traceIncludeScreenshots(boolean value) {
+            setProperty("shaft.trace.includeScreenshots", String.valueOf(value));
             return this;
         }
 

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureTraceReporter.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureTraceReporter.java
@@ -18,8 +18,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -39,6 +42,7 @@ public final class FailureTraceReporter {
             "(?i)(\"(?:password|passwd|pwd|secret|token|access[_-]?key|api[_-]?key)\"\\s*:\\s*\")[^\"]*(\")");
     private static final int SNIPPET_RADIUS = 2;
     private static final ThreadLocal<String> CURRENT_NETWORK_JSON = ThreadLocal.withInitial(() -> "[]");
+    private static final ThreadLocal<Map<String, byte[]>> CURRENT_SCREENSHOTS = ThreadLocal.withInitial(Map::of);
 
     private FailureTraceReporter() {
         throw new IllegalStateException("Utility class");
@@ -59,13 +63,16 @@ public final class FailureTraceReporter {
             stopPlaywrightTraceIfRunning();
             String json = renderTraceJson(info, logText, attachments);
             String html = renderTraceHtml(json);
-            byte[] zip = renderTraceZip(json, html, CURRENT_NETWORK_JSON.get());
-            persistTraceArtifacts(info, zip);
+            Map<String, byte[]> screenshots = CURRENT_SCREENSHOTS.get();
+            byte[] zip = renderTraceZip(json, html, CURRENT_NETWORK_JSON.get(), screenshots);
+            persistTraceArtifacts(info, zip, screenshots);
             attach("zip", "shaft-trace.zip", zip, "shaft-trace.zip");
+            attach("html", "SHAFT Trace Report.html", html.getBytes(StandardCharsets.UTF_8), "SHAFT Trace Report.html");
         } catch (RuntimeException e) {
             ReportManagerHelper.logDiscrete("Could not attach SHAFT trace report: " + e.getMessage(), Level.WARN);
         } finally {
             CURRENT_NETWORK_JSON.remove();
+            CURRENT_SCREENSHOTS.remove();
         }
     }
 
@@ -85,6 +92,7 @@ public final class FailureTraceReporter {
         SourceContext source = sourceContext(info);
         Snapshot snapshot = snapshot();
         List<TraceEventRecorder.ActionEvent> actions = TraceEventRecorder.drain();
+        CURRENT_SCREENSHOTS.set(decodeScreenshots(actions));
         BrowserObservabilityRecorder.collectConsole(DriverFactoryHelper.getActiveDriver());
         String observabilityJson = BrowserObservabilityRecorder.drainMetadataJson();
         String networkJson = BrowserObservabilityRecorder.drainNetworkJson();
@@ -126,6 +134,27 @@ public final class FailureTraceReporter {
         array(json, 1, "attachments", attachmentEntries(attachments), false);
         json.append("}\n");
         return json.toString();
+    }
+
+    /**
+     * Decodes the base64 {@code screenshot} field each drained {@link TraceEventRecorder.ActionEvent}
+     * may carry back into raw PNG bytes, keyed by action id, so they can be persisted as standalone
+     * files alongside the trace zip/directory. Invalid entries are skipped rather than failing trace
+     * generation.
+     */
+    private static Map<String, byte[]> decodeScreenshots(List<TraceEventRecorder.ActionEvent> actions) {
+        Map<String, byte[]> screenshots = new LinkedHashMap<>();
+        for (TraceEventRecorder.ActionEvent action : actions) {
+            if (action.screenshot().isEmpty()) {
+                continue;
+            }
+            try {
+                screenshots.put(action.id(), Base64.getDecoder().decode(action.screenshot()));
+            } catch (IllegalArgumentException ignored) {
+                // Corrupt base64 must never fail trace generation; just skip persisting that file.
+            }
+        }
+        return screenshots;
     }
 
     static boolean shouldAttachTrace(TestExecutionInfo info) {
@@ -193,6 +222,7 @@ public final class FailureTraceReporter {
                       <button data-tab="source">Source</button>
                       <button data-tab="snapshot">Snapshot</button>
                       <button data-tab="domSnapshot">DOM Snapshot</button>
+                      <button data-tab="screenshot">Screenshot</button>
                       <button data-tab="locatorHealth">Locator Health</button>
                       <button data-tab="network">Network</button>
                       <button data-tab="console">Console</button>
@@ -209,6 +239,11 @@ public final class FailureTraceReporter {
                       </div>
                       <iframe id="dom-snapshot-frame" title="DOM snapshot" sandbox=""
                               style="width:100%;height:420px;border:1px solid var(--shaft-border,#ccc);background:#fff"></iframe>
+                    </div>
+                    <div id="screenshot-panel" hidden>
+                      <img id="screenshot-image" alt="Action screenshot"
+                           style="max-width:100%;border:1px solid var(--shaft-border,#ccc)">
+                      <p id="screenshot-empty" class="muted" hidden>No screenshot captured for this action.</p>
                     </div>
                   </section>
                 </div>
@@ -254,7 +289,7 @@ public final class FailureTraceReporter {
                   actions.filter(action => !query || JSON.stringify(action).toLowerCase().includes(query)).forEach(action => {
                     const button = document.createElement('button');
                     button.className = `action ${action.status}${selected && selected.id === action.id ? ' selected' : ''}`;
-                    button.innerHTML = `<strong>${esc(action.name || 'Action')}</strong><div class="muted">${esc(action.category)} - ${esc(action.status)} - ${esc(action.durationMs || 0)}ms</div>`;
+                    button.innerHTML = `<strong>${esc(action.name || 'Action')}</strong><div class="muted">${esc(action.category)} - ${esc(action.status)} - ${esc(action.durationMs || 0)}ms${action.screenshot ? ' 📷' : ''}</div>`;
                     button.addEventListener('click', () => { selected = action; renderActions(); renderDetails(); });
                     actionList.appendChild(button);
                   });
@@ -278,13 +313,29 @@ public final class FailureTraceReporter {
                   document.querySelectorAll('#dom-snapshot-tabs button').forEach(button =>
                       button.classList.toggle('selected', button.dataset.dom === selectedDomSide));
                 }
+                const screenshotPanel = document.getElementById('screenshot-panel');
+                const screenshotImage = document.getElementById('screenshot-image');
+                const screenshotEmpty = document.getElementById('screenshot-empty');
+                function renderScreenshot(){
+                  const action = selected || {};
+                  const hasScreenshot = Boolean(action.screenshot);
+                  screenshotImage.hidden = !hasScreenshot;
+                  screenshotEmpty.hidden = hasScreenshot;
+                  if (hasScreenshot) {
+                    screenshotImage.src = 'data:image/png;base64,' + action.screenshot;
+                  }
+                }
                 function renderTab(tab){
                   const action = selected || {};
                   const isDomSnapshot = tab === 'domSnapshot';
-                  tabContent.hidden = isDomSnapshot;
+                  const isScreenshot = tab === 'screenshot';
+                  tabContent.hidden = isDomSnapshot || isScreenshot;
                   domSnapshotPanel.hidden = !isDomSnapshot;
+                  screenshotPanel.hidden = !isScreenshot;
                   if (isDomSnapshot) {
                     renderDomSnapshot();
+                  } else if (isScreenshot) {
+                    renderScreenshot();
                   } else {
                     const data = tab === 'json' ? trace : tab === 'exception' && action.exception && (action.exception.type || action.exception.message) ? action.exception : trace[tab];
                     tabContent.textContent = typeof data === 'string' ? data : JSON.stringify(data || {}, null, 2);
@@ -306,7 +357,7 @@ public final class FailureTraceReporter {
                 """;
     }
 
-    private static byte[] renderTraceZip(String json, String html, String networkJson) {
+    private static byte[] renderTraceZip(String json, String html, String networkJson, Map<String, byte[]> screenshots) {
         int maxBytes = Math.max(1, SHAFT.Properties.reporting.traceMaxArtifactMb()) * 1024 * 1024;
         try (ByteArrayOutputStream output = new ByteArrayOutputStream();
              ZipOutputStream zip = new ZipOutputStream(output)) {
@@ -314,6 +365,9 @@ public final class FailureTraceReporter {
             addZipEntry(zip, "shaft-network.har", BrowserObservabilityRecorder.networkHarJson(networkJson)
                     .getBytes(StandardCharsets.UTF_8), maxBytes);
             addZipEntry(zip, "SHAFT Trace Report.html", html.getBytes(StandardCharsets.UTF_8), maxBytes);
+            for (Map.Entry<String, byte[]> entry : screenshots.entrySet()) {
+                addZipEntry(zip, "screenshots/" + entry.getKey() + ".png", entry.getValue(), maxBytes);
+            }
             Path playwrightTrace = PlaywrightTraceManager.getLastTracePath();
             if (playwrightTrace != null && Files.isRegularFile(playwrightTrace)) {
                 addZipEntry(zip, playwrightTrace.getFileName().toString(), Files.readAllBytes(playwrightTrace), maxBytes);
@@ -346,7 +400,7 @@ public final class FailureTraceReporter {
         AttachmentReporter.attachBasedOnFileType(type, name, output, description);
     }
 
-    private static void persistTraceArtifacts(TestExecutionInfo info, byte[] zip) {
+    private static void persistTraceArtifacts(TestExecutionInfo info, byte[] zip, Map<String, byte[]> screenshots) {
         try {
             Path directory = traceDirectory(info);
             Files.createDirectories(directory);
@@ -354,8 +408,15 @@ public final class FailureTraceReporter {
             Files.deleteIfExists(directory.resolve("SHAFT Trace Report.html"));
             Files.deleteIfExists(directory.resolve("shaft-trace.json"));
             Files.write(zipPath, zip);
-            Files.writeString(directory.resolve("index.json"), renderTraceIndexJson(info, zipPath),
-                    StandardCharsets.UTF_8);
+            if (!screenshots.isEmpty()) {
+                Path screenshotsDirectory = directory.resolve("screenshots");
+                Files.createDirectories(screenshotsDirectory);
+                for (Map.Entry<String, byte[]> entry : screenshots.entrySet()) {
+                    Files.write(screenshotsDirectory.resolve(entry.getKey() + ".png"), entry.getValue());
+                }
+            }
+            Files.writeString(directory.resolve("index.json"),
+                    renderTraceIndexJson(info, zipPath, !screenshots.isEmpty()), StandardCharsets.UTF_8);
         } catch (IOException e) {
             ReportManagerHelper.logDiscrete("Could not persist SHAFT trace artifacts: " + e.getMessage(), Level.WARN);
         }
@@ -383,7 +444,7 @@ public final class FailureTraceReporter {
         return safeId.length() <= 120 ? safeId : safeId.substring(0, 120);
     }
 
-    private static String renderTraceIndexJson(TestExecutionInfo info, Path zipPath) {
+    private static String renderTraceIndexJson(TestExecutionInfo info, Path zipPath, boolean hasScreenshots) {
         StringBuilder json = new StringBuilder();
         json.append("{\n");
         field(json, 1, "testId", safeTestId(info), true);
@@ -392,7 +453,10 @@ public final class FailureTraceReporter {
         objectStart(json, 1, "entries");
         field(json, 2, "html", "SHAFT Trace Report.html", true);
         field(json, 2, "json", "shaft-trace.json", true);
-        field(json, 2, "network", "shaft-network.har", false);
+        field(json, 2, "network", "shaft-network.har", hasScreenshots);
+        if (hasScreenshots) {
+            field(json, 2, "screenshots", "screenshots", false);
+        }
         objectEnd(json, 1, false);
         json.append("}\n");
         return json.toString();

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/TraceEventRecorder.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/TraceEventRecorder.java
@@ -6,6 +6,7 @@ import org.openqa.selenium.WebDriver;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -18,6 +19,8 @@ import java.util.concurrent.TimeUnit;
 public final class TraceEventRecorder {
     private static final ThreadLocal<List<ActionEvent>> EVENTS = ThreadLocal.withInitial(ArrayList::new);
     private static final ThreadLocal<Integer> NEXT_ID = ThreadLocal.withInitial(() -> 0);
+    private static final ThreadLocal<Map<String, byte[]>> SCREENSHOTS = ThreadLocal.withInitial(LinkedHashMap::new);
+    private static final ThreadLocal<Long> SCREENSHOT_BYTES = ThreadLocal.withInitial(() -> 0L);
     private static final int MAX_DOM_SNAPSHOT_CHARACTERS = 200_000;
 
     private TraceEventRecorder() {
@@ -63,6 +66,27 @@ public final class TraceEventRecorder {
                 currentUrl(driver),
                 domSnapshot(driver),
                 driver);
+    }
+
+    /**
+     * Buffers a screenshot for the given action, keyed by {@link Event#id()}, so {@link #finish}
+     * can embed it in the action's trace JSON. Gated by {@code shaft.trace.includeScreenshots} and
+     * bounded by {@code shaft.trace.maxArtifactMb} so buffered PNGs can never grow unbounded within
+     * a single thread's trace. Never throws.
+     *
+     * @param event started event handle from {@link #start}
+     * @param png   screenshot bytes, or {@code null}
+     */
+    public static void recordScreenshot(Event event, byte[] png) {
+        if (event == null || !event.enabled() || png == null || png.length == 0 || !isScreenshotEnabled()) {
+            return;
+        }
+        long used = SCREENSHOT_BYTES.get();
+        if (used + png.length > screenshotBudgetBytes()) {
+            return;
+        }
+        SCREENSHOTS.get().put(event.id(), png);
+        SCREENSHOT_BYTES.set(used + png.length);
     }
 
     /**
@@ -153,7 +177,8 @@ public final class TraceEventRecorder {
                 metadata == null ? Map.of() : new LinkedHashMap<>(metadata),
                 actionability == null ? Map.of() : new LinkedHashMap<>(actionability),
                 event.domSnapshotBefore(),
-                domSnapshot(event.driver())));
+                domSnapshot(event.driver()),
+                screenshotBase64(event.id())));
     }
 
     /**
@@ -193,6 +218,18 @@ public final class TraceEventRecorder {
     public static void clear() {
         EVENTS.remove();
         NEXT_ID.remove();
+        SCREENSHOTS.remove();
+        SCREENSHOT_BYTES.remove();
+    }
+
+    /**
+     * Consumes the buffered screenshot for the given action id, base64-encoded for JSON
+     * embedding. Removes the entry from the buffer once consumed so screenshots never outlive
+     * the action they belong to.
+     */
+    private static String screenshotBase64(String id) {
+        byte[] png = SCREENSHOTS.get().remove(id);
+        return png == null ? "" : Base64.getEncoder().encodeToString(png);
     }
 
     static String toJson(List<ActionEvent> events) {
@@ -219,13 +256,17 @@ public final class TraceEventRecorder {
             stringArray(json, 3, "attachments", event.attachments(), true);
             boolean hasActionability = !event.actionability().isEmpty();
             boolean hasDomSnapshots = !event.domSnapshotBefore().isEmpty() || !event.domSnapshotAfter().isEmpty();
-            map(json, 3, "metadata", event.metadata(), hasActionability || hasDomSnapshots);
+            boolean hasScreenshot = !event.screenshot().isEmpty();
+            map(json, 3, "metadata", event.metadata(), hasActionability || hasDomSnapshots || hasScreenshot);
             if (hasActionability) {
-                objectMap(json, 3, "actionability", event.actionability(), hasDomSnapshots);
+                objectMap(json, 3, "actionability", event.actionability(), hasDomSnapshots || hasScreenshot);
             }
             if (hasDomSnapshots) {
                 field(json, 3, "domSnapshotBefore", event.domSnapshotBefore(), true);
-                field(json, 3, "domSnapshotAfter", event.domSnapshotAfter(), false);
+                field(json, 3, "domSnapshotAfter", event.domSnapshotAfter(), hasScreenshot);
+            }
+            if (hasScreenshot) {
+                field(json, 3, "screenshot", event.screenshot(), false);
             }
             indent(json, 2).append("}");
         }
@@ -286,6 +327,24 @@ public final class TraceEventRecorder {
             return SHAFT.Properties.reporting != null && SHAFT.Properties.reporting.traceIncludeDomSnapshots();
         } catch (RuntimeException e) {
             return false;
+        }
+    }
+
+    private static boolean isScreenshotEnabled() {
+        try {
+            return SHAFT.Properties.reporting != null && SHAFT.Properties.reporting.traceIncludeScreenshots();
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+
+    private static long screenshotBudgetBytes() {
+        try {
+            return SHAFT.Properties.reporting == null
+                    ? Long.MAX_VALUE
+                    : (long) SHAFT.Properties.reporting.traceMaxArtifactMb() * 1024L * 1024L;
+        } catch (RuntimeException e) {
+            return Long.MAX_VALUE;
         }
     }
 
@@ -467,6 +526,6 @@ public final class TraceEventRecorder {
     record ActionEvent(String id, String category, String name, String status, String startTime, long durationMs,
                        String locator, String url, String message, String exceptionType, String exceptionMessage,
                        List<String> attachments, Map<String, String> metadata, Map<String, Object> actionability,
-                       String domSnapshotBefore, String domSnapshotAfter) {
+                       String domSnapshotBefore, String domSnapshotAfter, String screenshot) {
     }
 }

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/FailureTraceReporterTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/FailureTraceReporterTest.java
@@ -36,6 +36,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -62,13 +63,15 @@ public class FailureTraceReporterTest {
             FailureTraceReporter.attachOnFailure(failingInfo, "token=raw-secret", List.of());
 
             List<Attachment> added = attachments().subList(beforePassing, attachments().size());
-            Assert.assertEquals(added.size(), 1, "Only the trace archive should be attached.");
+            Assert.assertEquals(added.size(), 2, "The trace archive and the viewer HTML should both be attached.");
             Assert.assertEquals(added.getFirst().getName(), "shaft-trace.zip");
             Assert.assertEquals(added.getFirst().getType(), "application/zip");
-            Assert.assertFalse(added.stream().anyMatch(attachment -> "text/html".equals(attachment.getType())));
+            Assert.assertTrue(added.stream().anyMatch(attachment -> "text/html".equals(attachment.getType())
+                    && "SHAFT Trace Report.html".equals(attachment.getName())));
             Assert.assertFalse(added.stream().anyMatch(attachment -> "application/json".equals(attachment.getType())));
             Assert.assertFalse(Files.exists(traceDirectory.resolve("SHAFT Trace Report.html")));
             Assert.assertFalse(Files.exists(traceDirectory.resolve("shaft-trace.json")));
+            Assert.assertFalse(Files.isDirectory(traceDirectory.resolve("screenshots")));
             Assert.assertTrue(Files.exists(traceDirectory.resolve("shaft-trace.zip")));
             try (ZipFile zip = new ZipFile(traceDirectory.resolve("shaft-trace.zip").toFile())) {
                 Assert.assertNotNull(zip.getEntry("SHAFT Trace Report.html"));
@@ -80,12 +83,15 @@ public class FailureTraceReporterTest {
                 Assert.assertTrue(html.contains("copyJson()"), html);
                 Assert.assertTrue(html.contains("data-tab=\"domSnapshot\""), html);
                 Assert.assertTrue(html.contains("dom-snapshot-frame"), html);
+                Assert.assertTrue(html.contains("data-tab=\"screenshot\""), html);
+                Assert.assertTrue(html.contains("screenshot-image"), html);
             }
             String index = Files.readString(traceDirectory.resolve("index.json"), StandardCharsets.UTF_8);
             Assert.assertTrue(index.contains("\"archive\": \"target/shaft-traces/id-failingScenario/shaft-trace.zip\""), index);
             Assert.assertTrue(index.contains("\"html\": \"SHAFT Trace Report.html\""), index);
             Assert.assertTrue(index.contains("\"json\": \"shaft-trace.json\""), index);
             Assert.assertTrue(index.contains("\"network\": \"shaft-network.har\""), index);
+            Assert.assertFalse(index.contains("\"screenshots\""), "No screenshots entry when nothing was buffered: " + index);
         } finally {
             TraceEventRecorder.clear();
             deleteDirectory(traceDirectory);
@@ -205,6 +211,81 @@ public class FailureTraceReporterTest {
             Assert.assertFalse(json.contains("domSnapshotAfter"), json);
         } finally {
             TraceEventRecorder.clear();
+            Properties.clearForCurrentThread();
+        }
+    }
+
+    @Test(description = "Trace JSON should embed a screenshot keyed by the action's traceActionId when enabled")
+    public void traceJsonShouldEmbedScreenshotKeyedByActionIdWhenEnabled() throws Exception {
+        try {
+            SHAFT.Properties.reporting.set().traceEnabled(true).traceMode("failure").traceIncludeScreenshots(true);
+            byte[] png = "fake-png-bytes".getBytes(StandardCharsets.UTF_8);
+
+            TraceEventRecorder.Event event = TraceEventRecorder.start("element", "CLICK", By.id("pay"), null);
+            TraceEventRecorder.recordScreenshot(event, png);
+            TraceEventRecorder.finish(event, "failed", "Click failed",
+                    new RuntimeException("boom"), Map.of(), List.of());
+
+            String json = FailureTraceReporter.renderTraceJson(info("failingScenario", failure()), "failed", List.of());
+
+            Assert.assertTrue(json.contains("\"id\": \"action-1\""), json);
+            Assert.assertTrue(json.contains("\"screenshot\": \""
+                    + Base64.getEncoder().encodeToString(png) + "\""), json);
+        } finally {
+            TraceEventRecorder.clear();
+            Properties.clearForCurrentThread();
+        }
+    }
+
+    @Test(description = "Trace JSON should omit the screenshot field when the property is disabled")
+    public void traceJsonShouldOmitScreenshotWhenDisabled() throws Exception {
+        try {
+            SHAFT.Properties.reporting.set().traceEnabled(true).traceMode("failure").traceIncludeScreenshots(false);
+            byte[] png = "fake-png-bytes".getBytes(StandardCharsets.UTF_8);
+
+            TraceEventRecorder.Event event = TraceEventRecorder.start("element", "CLICK", By.id("pay"), null);
+            TraceEventRecorder.recordScreenshot(event, png);
+            TraceEventRecorder.finish(event, "failed", "Click failed",
+                    new RuntimeException("boom"), Map.of(), List.of());
+
+            String json = FailureTraceReporter.renderTraceJson(info("failingScenario", failure()), "failed", List.of());
+
+            Assert.assertFalse(json.contains("\"screenshot\":"), json);
+        } finally {
+            TraceEventRecorder.clear();
+            Properties.clearForCurrentThread();
+        }
+    }
+
+    @Test(description = "Buffered screenshots should persist as PNG files in the trace zip and directory, keyed by action id")
+    public void failureModeShouldPersistScreenshotsWhenBuffered() throws Exception {
+        TestExecutionInfo failingInfo = info("screenshotScenario", failure());
+        Path traceDirectory = FailureTraceReporter.traceDirectory(failingInfo);
+        try {
+            deleteDirectory(traceDirectory);
+            SHAFT.Properties.reporting.set().traceEnabled(true).traceMode("failure").traceIncludeScreenshots(true);
+            byte[] png = "fake-png-bytes".getBytes(StandardCharsets.UTF_8);
+
+            TraceEventRecorder.Event event = TraceEventRecorder.start("element", "CLICK", By.id("pay"), null);
+            TraceEventRecorder.recordScreenshot(event, png);
+            TraceEventRecorder.finish(event, "failed", "Click failed",
+                    new RuntimeException("boom"), Map.of(), List.of());
+
+            FailureTraceReporter.attachOnFailure(failingInfo, "failed", List.of());
+
+            Path screenshotFile = traceDirectory.resolve("screenshots").resolve("action-1.png");
+            Assert.assertTrue(Files.exists(screenshotFile));
+            Assert.assertEquals(Files.readAllBytes(screenshotFile), png);
+
+            try (ZipFile zip = new ZipFile(traceDirectory.resolve("shaft-trace.zip").toFile())) {
+                Assert.assertNotNull(zip.getEntry("screenshots/action-1.png"));
+            }
+
+            String index = Files.readString(traceDirectory.resolve("index.json"), StandardCharsets.UTF_8);
+            Assert.assertTrue(index.contains("\"screenshots\": \"screenshots\""), index);
+        } finally {
+            TraceEventRecorder.clear();
+            deleteDirectory(traceDirectory);
             Properties.clearForCurrentThread();
         }
     }
@@ -564,6 +645,7 @@ public class FailureTraceReporterTest {
             Assert.assertEquals(SHAFT.Properties.reporting.traceMode(), "failure");
             Assert.assertTrue(SHAFT.Properties.reporting.traceIncludeCodeContext());
             Assert.assertTrue(SHAFT.Properties.reporting.traceIncludeFullPageSnapshots());
+            Assert.assertTrue(SHAFT.Properties.reporting.traceIncludeScreenshots());
             Assert.assertTrue(SHAFT.Properties.reporting.traceIncludeNativePageSource());
             Assert.assertTrue(SHAFT.Properties.reporting.traceIncludeNetwork());
             Assert.assertTrue(SHAFT.Properties.reporting.traceIncludeConsole());
@@ -574,6 +656,7 @@ public class FailureTraceReporterTest {
                     .traceMode("always")
                     .traceIncludeCodeContext(false)
                     .traceIncludeFullPageSnapshots(false)
+                    .traceIncludeScreenshots(false)
                     .traceIncludeNativePageSource(false)
                     .traceIncludeNetwork(false)
                     .traceIncludeConsole(false)
@@ -583,6 +666,7 @@ public class FailureTraceReporterTest {
             Assert.assertEquals(SHAFT.Properties.reporting.traceMode(), "always");
             Assert.assertFalse(SHAFT.Properties.reporting.traceIncludeCodeContext());
             Assert.assertFalse(SHAFT.Properties.reporting.traceIncludeFullPageSnapshots());
+            Assert.assertFalse(SHAFT.Properties.reporting.traceIncludeScreenshots());
             Assert.assertFalse(SHAFT.Properties.reporting.traceIncludeNativePageSource());
             Assert.assertFalse(SHAFT.Properties.reporting.traceIncludeNetwork());
             Assert.assertFalse(SHAFT.Properties.reporting.traceIncludeConsole());

--- a/shaft-intellij/src/main/java/com/shaft/intellij/actions/ShowTraceViewerAction.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/actions/ShowTraceViewerAction.java
@@ -1,0 +1,131 @@
+package com.shaft.intellij.actions;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.intellij.ide.BrowserUtil;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.shaft.intellij.notifications.ShaftNotifier;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * Opens the offline SHAFT trace viewer HTML for the most recently generated {@code
+ * target/shaft-traces} trace in the user's default browser.
+ * <p>
+ * Uses an external-browser fallback ({@link BrowserUtil#browse}) rather than an embedded JCEF
+ * panel: the plugin has no existing JCEF dependency, and plugin tests run headless, so an
+ * embedded panel would be unverifiable by automated tests.
+ */
+public final class ShowTraceViewerAction extends AnAction implements DumbAware {
+    private static final String VIEWER_HTML_NAME = "SHAFT Trace Report.html";
+    private static final String TRACE_ZIP_NAME = "shaft-trace.zip";
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent event) {
+        Project project = event.getProject();
+        if (project == null) {
+            return;
+        }
+        String basePath = project.getBasePath();
+        Path viewer;
+        try {
+            viewer = basePath == null ? null : resolveLatestTraceViewer(Path.of(basePath));
+        } catch (IOException e) {
+            ShaftNotifier.warn(project, "SHAFT", "Could not resolve a SHAFT trace viewer: " + e.getMessage());
+            return;
+        }
+        if (viewer == null) {
+            ShaftNotifier.warn(project, "SHAFT", "No SHAFT trace was found under target/shaft-traces.");
+            return;
+        }
+        BrowserUtil.browse(viewer.toUri());
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent event) {
+        event.getPresentation().setEnabledAndVisible(event.getProject() != null);
+    }
+
+    /**
+     * Resolves the offline viewer HTML for the most recently generated trace under
+     * {@code <projectRoot>/target/shaft-traces}, extracting it from {@code shaft-trace.zip} when
+     * no loose copy exists on disk. Returns {@code null} when no trace can be found. Pure
+     * filesystem logic with no IDE dependency, so it is unit-testable headless.
+     *
+     * @param projectRoot project base directory
+     * @return resolved viewer HTML path, or {@code null} when no trace exists
+     */
+    static Path resolveLatestTraceViewer(Path projectRoot) throws IOException {
+        Path traceRoot = projectRoot.resolve("target").resolve("shaft-traces");
+        if (!Files.isDirectory(traceRoot)) {
+            return null;
+        }
+        Path newestDirectory = null;
+        Instant newestGeneratedAt = null;
+        try (Stream<Path> paths = Files.walk(traceRoot, 2)) {
+            List<Path> indexFiles = paths
+                    .filter(path -> "index.json".equals(path.getFileName().toString()))
+                    .toList();
+            for (Path indexPath : indexFiles) {
+                Instant generatedAt = generatedAt(indexPath);
+                if (newestGeneratedAt == null || generatedAt.isAfter(newestGeneratedAt)) {
+                    newestGeneratedAt = generatedAt;
+                    newestDirectory = indexPath.getParent();
+                }
+            }
+        }
+        return newestDirectory == null ? null : resolveViewerHtml(newestDirectory);
+    }
+
+    private static Instant generatedAt(Path indexPath) {
+        try {
+            String content = Files.readString(indexPath);
+            JsonObject index = JsonParser.parseString(content).getAsJsonObject();
+            if (index.has("generatedAt")) {
+                return Instant.parse(index.get("generatedAt").getAsString());
+            }
+        } catch (RuntimeException | IOException ignored) {
+            // Fall through to the file's modified time; a malformed index must never break discovery.
+        }
+        try {
+            FileTime modified = Files.getLastModifiedTime(indexPath);
+            return modified.toInstant();
+        } catch (IOException e) {
+            return Instant.EPOCH;
+        }
+    }
+
+    private static Path resolveViewerHtml(Path traceDirectory) throws IOException {
+        Path loose = traceDirectory.resolve(VIEWER_HTML_NAME);
+        if (Files.isRegularFile(loose)) {
+            return loose;
+        }
+        Path archive = traceDirectory.resolve(TRACE_ZIP_NAME);
+        if (!Files.isRegularFile(archive)) {
+            return null;
+        }
+        try (InputStream input = Files.newInputStream(archive); ZipInputStream zip = new ZipInputStream(input)) {
+            ZipEntry entry;
+            while ((entry = zip.getNextEntry()) != null) {
+                if (VIEWER_HTML_NAME.equals(entry.getName())) {
+                    Files.write(loose, zip.readAllBytes());
+                    return loose;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/shaft-intellij/src/main/resources/META-INF/io.github.shafthq.shaft-withJava.xml
+++ b/shaft-intellij/src/main/resources/META-INF/io.github.shafthq.shaft-withJava.xml
@@ -17,5 +17,13 @@
                 iconDark="/icons/shaftToolWindow_dark.svg">
             <add-to-group group-id="Shaft.ToolsMenu" anchor="last"/>
         </action>
+        <action id="Shaft.ShowTraceViewer"
+                class="com.shaft.intellij.actions.ShowTraceViewerAction"
+                text="Show SHAFT Trace Viewer"
+                description="Open the latest SHAFT failure trace viewer in your browser"
+                icon="/icons/shaftToolWindow.svg"
+                iconDark="/icons/shaftToolWindow_dark.svg">
+            <add-to-group group-id="Shaft.ToolsMenu" anchor="last"/>
+        </action>
     </actions>
 </idea-plugin>

--- a/shaft-intellij/src/test/java/com/shaft/intellij/actions/ShowTraceViewerActionTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/actions/ShowTraceViewerActionTest.java
@@ -1,0 +1,101 @@
+package com.shaft.intellij.actions;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercises only {@link ShowTraceViewerAction#resolveLatestTraceViewer(Path)} -- the pure
+ * filesystem resolution logic, with no IDE/JCEF dependency -- so it runs headless like the rest
+ * of this plugin's test suite.
+ */
+class ShowTraceViewerActionTest {
+    @TempDir
+    Path project;
+
+    @Test
+    void returnsNullWhenNoTracesExist() throws IOException {
+        assertNull(ShowTraceViewerAction.resolveLatestTraceViewer(project));
+    }
+
+    @Test
+    void resolvesLooseHtmlWhenAlreadyPresent() throws IOException {
+        Path traceDirectory = writeTraceIndex("only-trace", Instant.parse("2026-07-08T10:00:00Z"));
+        Path html = traceDirectory.resolve("SHAFT Trace Report.html");
+        Files.writeString(html, "<html>loose</html>");
+
+        Path resolved = ShowTraceViewerAction.resolveLatestTraceViewer(project);
+
+        assertEquals(html, resolved);
+        assertEquals("<html>loose</html>", Files.readString(resolved));
+    }
+
+    @Test
+    void extractsHtmlFromTraceZipWhenNoLooseCopyExists() throws IOException {
+        Path traceDirectory = writeTraceIndex("zipped-trace", Instant.parse("2026-07-08T10:00:00Z"));
+        writeTraceZip(traceDirectory.resolve("shaft-trace.zip"), "<html>from-zip</html>");
+
+        Path resolved = ShowTraceViewerAction.resolveLatestTraceViewer(project);
+
+        assertEquals(traceDirectory.resolve("SHAFT Trace Report.html"), resolved);
+        assertEquals("<html>from-zip</html>", Files.readString(resolved));
+    }
+
+    @Test
+    void selectsTheNewestTraceByGeneratedAt() throws IOException {
+        Path older = writeTraceIndex("older", Instant.parse("2026-07-08T09:00:00Z"));
+        writeTraceZip(older.resolve("shaft-trace.zip"), "<html>older</html>");
+        Path newer = writeTraceIndex("newer", Instant.parse("2026-07-08T11:00:00Z"));
+        writeTraceZip(newer.resolve("shaft-trace.zip"), "<html>newer</html>");
+
+        Path resolved = ShowTraceViewerAction.resolveLatestTraceViewer(project);
+
+        assertTrue(resolved.startsWith(newer), resolved.toString());
+    }
+
+    @Test
+    void fallsBackToFileModifiedTimeWhenGeneratedAtIsMissing() throws IOException {
+        Path traceDirectory = project.resolve("target").resolve("shaft-traces").resolve("no-timestamp");
+        Files.createDirectories(traceDirectory);
+        Files.writeString(traceDirectory.resolve("index.json"), "{\"testId\": \"no-timestamp\"}");
+        Files.writeString(traceDirectory.resolve("SHAFT Trace Report.html"), "<html>fallback</html>");
+        Files.setLastModifiedTime(traceDirectory.resolve("index.json"), FileTime.from(Instant.now()));
+
+        Path resolved = ShowTraceViewerAction.resolveLatestTraceViewer(project);
+
+        assertEquals(traceDirectory.resolve("SHAFT Trace Report.html"), resolved);
+    }
+
+    private Path writeTraceIndex(String testId, Instant generatedAt) throws IOException {
+        Path traceDirectory = project.resolve("target").resolve("shaft-traces").resolve(testId);
+        Files.createDirectories(traceDirectory);
+        Files.writeString(traceDirectory.resolve("index.json"), """
+                {
+                  "testId": "%s",
+                  "generatedAt": "%s",
+                  "archive": "target/shaft-traces/%s/shaft-trace.zip",
+                  "entries": {"html": "SHAFT Trace Report.html", "json": "shaft-trace.json", "network": "shaft-network.har"}
+                }
+                """.formatted(testId, generatedAt, testId));
+        return traceDirectory;
+    }
+
+    private void writeTraceZip(Path zipPath, String html) throws IOException {
+        try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(zipPath))) {
+            zip.putNextEntry(new ZipEntry("SHAFT Trace Report.html"));
+            zip.write(html.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            zip.closeEntry();
+        }
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/TraceService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/TraceService.java
@@ -6,6 +6,7 @@ import tools.jackson.databind.node.ObjectNode;
 import com.shaft.capture.generate.CaptureGenerator.CodegenBackend;
 import com.shaft.doctor.shard.FlakyCluster;
 import com.shaft.doctor.shard.MergedReport;
+import com.shaft.doctor.shard.ShardIntelligence;
 import com.shaft.doctor.shard.ShardMerger;
 import com.shaft.doctor.model.CauseCategory;
 import com.shaft.doctor.model.Confidence;
@@ -211,6 +212,7 @@ public class TraceService {
                 report.shardCount(),
                 report.totalResults(),
                 report.flakyClusters(),
+                report.shardIntelligence(),
                 report.warnings());
     }
 
@@ -800,6 +802,7 @@ public class TraceService {
      * @param shardCount number of shard blobs merged
      * @param totalResults total Allure result files merged
      * @param flakyClusters tests observed with inconsistent pass/fail outcomes across shards
+     * @param shardIntelligence per-shard doctor {@code ExecutionIntelligence} digests, for shards that had one
      * @param warnings safe warnings (e.g. an unreadable shard blob was skipped)
      */
     public record McpMergeShardsResult(
@@ -809,6 +812,7 @@ public class TraceService {
             int shardCount,
             int totalResults,
             List<FlakyCluster> flakyClusters,
+            List<ShardIntelligence> shardIntelligence,
             List<String> warnings) {
         /**
          * Creates an immutable merge-shards result.
@@ -818,6 +822,7 @@ public class TraceService {
             mergedAllureResultsDirectory = mergedAllureResultsDirectory == null ? "" : mergedAllureResultsDirectory.trim();
             speedboardHtmlPath = speedboardHtmlPath == null ? "" : speedboardHtmlPath.trim();
             flakyClusters = flakyClusters == null ? List.of() : List.copyOf(flakyClusters);
+            shardIntelligence = shardIntelligence == null ? List.of() : List.copyOf(shardIntelligence);
             warnings = warnings == null ? List.of() : List.copyOf(warnings);
         }
     }

--- a/tests/scripts/test_assemble_shard_blob.py
+++ b/tests/scripts/test_assemble_shard_blob.py
@@ -1,0 +1,123 @@
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest import mock
+
+from scripts.ci.assemble_shard_blob import main
+
+
+class AssembleShardBlobTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.allure_results = self.root / "allure-results"
+        self.allure_results.mkdir()
+        (self.allure_results / "abc-result.json").write_text('{"status": "passed"}', encoding="utf-8")
+        self.traces_dir = self.root / "target" / "shaft-traces"
+        (self.traces_dir / "com.example.Test.a").mkdir(parents=True)
+        (self.traces_dir / "com.example.Test.a" / "index.json").write_text("{}", encoding="utf-8")
+        self.output = self.root / "shard-1"
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_stages_allure_results_and_traces_without_a_doctor_command(self):
+        exit_code = main([
+            "--shard", "1",
+            "--allure-results", str(self.allure_results),
+            "--traces-dir", str(self.traces_dir),
+            "--output", str(self.output),
+        ])
+
+        self.assertEqual(exit_code, 0)
+        self.assertTrue((self.output / "allure-results" / "abc-result.json").is_file())
+        self.assertTrue((self.output / "shaft-traces" / "com.example.Test.a" / "index.json").is_file())
+        self.assertFalse((self.output / "execution-intelligence.json").exists())
+
+    def test_missing_allure_results_directory_fails_with_a_clear_error(self):
+        with self.assertRaises(SystemExit):
+            main([
+                "--shard", "1",
+                "--allure-results", str(self.root / "does-not-exist"),
+                "--output", str(self.output),
+            ])
+
+    def test_missing_traces_directory_still_assembles_a_valid_blob(self):
+        exit_code = main([
+            "--shard", "1",
+            "--allure-results", str(self.allure_results),
+            "--traces-dir", str(self.root / "no-traces-here"),
+            "--output", str(self.output),
+        ])
+
+        self.assertEqual(exit_code, 0)
+        self.assertTrue((self.output / "allure-results" / "abc-result.json").is_file())
+        self.assertFalse((self.output / "shaft-traces").exists())
+
+    @mock.patch("scripts.ci.assemble_shard_blob.subprocess.run")
+    def test_successful_doctor_command_copies_execution_intelligence(self, run):
+        run.return_value = mock.Mock(returncode=0, stdout="", stderr="")
+        doctor_output = self.root / "target" / "shaft-doctor"
+        doctor_output.mkdir(parents=True)
+        (doctor_output / "execution-intelligence.json").write_text('{"schemaVersion": "1.0"}', encoding="utf-8")
+
+        exit_code = main([
+            "--shard", "1",
+            "--allure-results", str(self.allure_results),
+            "--traces-dir", str(self.traces_dir),
+            "--doctor-command", "shaft-doctor analyze --input allure-results",
+            "--doctor-output", str(doctor_output),
+            "--output", str(self.output),
+        ])
+
+        self.assertEqual(exit_code, 0)
+        self.assertTrue((self.output / "execution-intelligence.json").is_file())
+        run.assert_called_once()
+
+    @mock.patch("scripts.ci.assemble_shard_blob.subprocess.run")
+    def test_failing_doctor_command_still_assembles_a_blob_without_execution_intelligence(self, run):
+        run.return_value = mock.Mock(returncode=1, stdout="", stderr="boom")
+
+        exit_code = main([
+            "--shard", "1",
+            "--allure-results", str(self.allure_results),
+            "--traces-dir", str(self.traces_dir),
+            "--doctor-command", "shaft-doctor analyze --input allure-results",
+            "--output", str(self.output),
+        ])
+
+        self.assertEqual(exit_code, 0)
+        self.assertFalse((self.output / "execution-intelligence.json").exists())
+
+    def test_no_doctor_command_assembles_a_blob_without_execution_intelligence(self):
+        exit_code = main([
+            "--shard", "1",
+            "--allure-results", str(self.allure_results),
+            "--traces-dir", str(self.traces_dir),
+            "--output", str(self.output),
+        ])
+
+        self.assertEqual(exit_code, 0)
+        self.assertFalse((self.output / "execution-intelligence.json").exists())
+
+    def test_zip_flag_produces_a_zip_archive_matching_the_blob_layout(self):
+        exit_code = main([
+            "--shard", "1",
+            "--allure-results", str(self.allure_results),
+            "--traces-dir", str(self.traces_dir),
+            "--output", str(self.output),
+            "--zip",
+        ])
+
+        self.assertEqual(exit_code, 0)
+        zip_path = self.output.with_suffix(".zip")
+        self.assertTrue(zip_path.is_file())
+        with zipfile.ZipFile(zip_path) as archive:
+            names = set(archive.namelist())
+        self.assertIn("allure-results/abc-result.json", names)
+        self.assertIn("shaft-traces/com.example.Test.a/index.json", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_run_sharded_and_merge.py
+++ b/tests/scripts/test_run_sharded_and_merge.py
@@ -1,0 +1,73 @@
+import unittest
+from unittest import mock
+
+from scripts.ci.run_sharded_and_merge import main
+
+
+class RunShardedAndMergeTest(unittest.TestCase):
+    def test_runs_tests_assembly_and_merge_for_every_shard(self):
+        with mock.patch("scripts.ci.run_sharded_and_merge.subprocess.run") as run:
+            run.return_value = mock.Mock(returncode=0)
+
+            exit_code = main(["--shards", "2"])
+
+        self.assertEqual(exit_code, 0)
+        # 2 shards x (mvn test + assemble) + 1 merge == 5 subprocess calls.
+        self.assertEqual(run.call_count, 5)
+        commands = [call.args[0] for call in run.call_args_list]
+
+        self.assertIn("-Dshaft.shard=1/2", commands[0])
+        self.assertIn("-DheadlessExecution=true", commands[0])
+        self.assertTrue(any("assemble_shard_blob.py" in part for part in commands[1]))
+        self.assertIn("--shard", commands[1])
+        self.assertIn("1", commands[1])
+
+        self.assertIn("-Dshaft.shard=2/2", commands[2])
+        self.assertIn("2", commands[3])
+
+        merge_command = commands[4]
+        joined = " ".join(merge_command)
+        self.assertIn("ShardMergeCli", joined)
+        self.assertIn("target/shard-blobs/shard-1", joined)
+        self.assertIn("target/shard-blobs/shard-2", joined)
+
+    def test_skip_tests_only_runs_assembly_and_merge(self):
+        with mock.patch("scripts.ci.run_sharded_and_merge.subprocess.run") as run:
+            run.return_value = mock.Mock(returncode=0)
+
+            exit_code = main(["--shards", "2", "--skip-tests"])
+
+        self.assertEqual(exit_code, 0)
+        # 2 shards x assemble only + 1 merge == 3 subprocess calls.
+        self.assertEqual(run.call_count, 3)
+
+    def test_failing_step_raises_with_a_labeled_message(self):
+        with mock.patch("scripts.ci.run_sharded_and_merge.subprocess.run") as run:
+            run.return_value = mock.Mock(returncode=1)
+
+            with self.assertRaisesRegex(SystemExit, "Shard 1 Maven test failed"):
+                main(["--shards", "1"])
+
+    def test_zero_shards_is_rejected(self):
+        with self.assertRaises(SystemExit):
+            main(["--shards", "0"])
+
+    def test_custom_merge_command_template_is_rendered(self):
+        with mock.patch("scripts.ci.run_sharded_and_merge.subprocess.run") as run:
+            run.return_value = mock.Mock(returncode=0)
+
+            exit_code = main([
+                "--shards", "1", "--skip-tests",
+                "--merge-command", "java -cp report-aggregate.jar com.shaft.reportaggregate.ShardMergeCli --output {output} {blobs}",
+                "--output", "custom-merged",
+            ])
+
+        self.assertEqual(exit_code, 0)
+        merge_command = run.call_args_list[-1].args[0]
+        self.assertIn("--output", merge_command)
+        self.assertIn("custom-merged", merge_command)
+        self.assertIn("target/shard-blobs/shard-1", merge_command)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Issue #3347 (Trace Viewer + sharded execution/merged report) turned out to be ~70-75% already implemented by a prior merge (`2de1056166`, PR #3361). This PR closes the remaining, concrete gaps rather than rebuilding from scratch.

**Trace Viewer (D2):**
- Screenshots keyed by `traceActionId`: `TraceEventRecorder` buffers a screenshot per action (bounded by `shaft.trace.maxArtifactMb`), embeds it as base64 in the trace JSON, and `FailureTraceReporter` additionally persists `screenshots/<actionId>.png` into the trace zip/directory plus an additive `index.json` `entries.screenshots` field. The offline viewer HTML gains a Screenshot tab and a filmstrip marker in the action list.
- The viewer HTML is now attached directly to Allure (`text/html`), not just zip-wrapped.
- New IntelliJ **"Show SHAFT Trace Viewer"** action — external-browser fallback (`BrowserUtil.browse`) rather than an embedded JCEF panel, since the plugin has no JCEF precedent and its tests run headless (an embedded panel would be unverifiable by automated tests). Trace-resolution logic is pure filesystem code, unit-tested headless.
- CSSOM capture via Selenium BiDi remains **explicitly deferred**: BiDi support exists only in shaft-capture, shaft-engine has no dependency on shaft-capture, and an engine-wide BiDi lifecycle isn't guaranteed across every driver backend (grid/BrowserStack/Playwright/Appium). The existing outerHTML-only DOM snapshot already satisfies the additive acceptance language.

**Sharded execution + merged report (D8):**
- New `scripts/ci/assemble_shard_blob.py` stages a shard's `allure-results` + `shaft-traces` + optional doctor `execution-intelligence.json` into the `ShardBlob` layout `ShardMerger` already reads (shaft-engine has no dependency on shaft-doctor, so this has to be a post-test orchestration step, not an engine-side hook).
- `ShardMerger` now copies each shard's `shaft-traces` through into the merged output (namespaced by shard id), and reads/aggregates per-shard `ExecutionIntelligence` into a new "Doctor triage across shards" speedboard section — the differentiator over Playwright's plain `merge-reports`. `MergedReport` and the `report_merge_shards` MCP result gain an additive `shardIntelligence` field.
- New `scripts/ci/run_sharded_and_merge.py` orchestrates N sharded Maven runs + blob assembly + merge as a local recipe, and a new dispatch-only `.github/workflows/sharded-merged-report.yml` demonstrates the same flow as a 3-shard matrix + merge job, without touching the existing class-filter partitioning in `e2eTests.yml`.

## Test plan

- [x] `shaft-engine`: `FailureTraceReporterTest` (18/18) — screenshot embed/omit, zip/index entries, direct-HTML-attach assertion updated for the new second attachment.
- [x] `shaft-doctor`: `ShardMergerTest` (9/9) — trace copy-through, EI aggregation, malformed-EI tolerance.
- [x] `report-aggregate`: `ShardMergeCliTest` (3/3) — two-blob merge with traces + execution-intelligence.
- [x] `shaft-mcp`: `TraceServiceTest` (10/10) — `report_merge_shards` still passes with the additive `shardIntelligence` field.
- [x] `shaft-intellij`: full Gradle test suite (329/330 — the one failure, `ShaftPanelSetupTest.assistantCommandAutocompleteStartsWithSlashAndFiltersByTypedPrefix`, is unrelated to this change, passes in isolation, and is a pre-existing `ThreadLeakTracker` flake). New `ShowTraceViewerActionTest` (5/5) covers the trace-resolution logic headless.
- [x] New Python scripts: `tests/scripts/test_assemble_shard_blob.py` (7/7), `tests/scripts/test_run_sharded_and_merge.py` (5/5).
- [x] `scripts/ci/local_gate.py --modules shaft-engine,shaft-doctor,report-aggregate,shaft-mcp` — compile + Enforcer convergence/banned-deps clean.
- [ ] `.github/workflows/sharded-merged-report.yml` is `workflow_dispatch`-only and needs a manual dispatch run on GitHub to fully exercise (can't run inline from this session).
- No `ShaftPluginScreenshotRendererTest` update needed — a Tools-menu action adds no rendered panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)