### PR TITLE
Fix mobile capture CA directory permissions breaking Linux CI

### DIFF
--- a/shaft-capture-proxy/src/main/java/com/shaft/capture/proxy/CaptureCertificateAuthority.java
+++ b/shaft-capture-proxy/src/main/java/com/shaft/capture/proxy/CaptureCertificateAuthority.java
@@ -83,7 +83,7 @@ public final class CaptureCertificateAuthority {
         this.directory = directory;
         try {
             Files.createDirectories(directory);
-            OwnerOnlyFilePermissions.restrictToOwner(directory);
+            OwnerOnlyFilePermissions.restrictDirectoryToOwner(directory);
             Path keyPath = directory.resolve(KEY_FILE);
             Path certPath = directory.resolve(CERT_FILE);
             if (Files.exists(keyPath) && Files.exists(certPath)) {

--- a/shaft-capture/src/main/java/com/shaft/capture/storage/OwnerOnlyFilePermissions.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/storage/OwnerOnlyFilePermissions.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Restricts a file to owner-only access on any filesystem. Extracted from
+ * Restricts a file or directory to owner-only access on any filesystem. Extracted from
  * {@code com.shaft.capture.network.SecretHeaderReplacer} so every locally-stored secret --
  * captured header secrets, and the mobile capture proxy's CA private key -- goes through the same
  * single, tested implementation of this security-sensitive operation rather than duplicating it.
@@ -33,20 +33,40 @@ public final class OwnerOnlyFilePermissions {
      * @param path file path
      */
     public static void restrictToOwner(Path path) {
+        restrict(path, false);
+    }
+
+    /**
+     * Sets owner-only permissions on a directory, keeping it traversable by its owner.
+     * Unlike {@link #restrictToOwner(Path)}, this also grants the owner execute (search)
+     * permission -- on POSIX systems, a directory without its own execute bit cannot be
+     * traversed into by anyone, including its owner, so a plain owner-read/write-only directory
+     * would block every subsequent read or write of files inside it.
+     *
+     * @param directory directory path
+     */
+    public static void restrictDirectoryToOwner(Path directory) {
+        restrict(directory, true);
+    }
+
+    private static void restrict(Path path, boolean directory) {
         try {
             Set<PosixFilePermission> perms = new HashSet<>();
             perms.add(PosixFilePermission.OWNER_READ);
             perms.add(PosixFilePermission.OWNER_WRITE);
+            if (directory) {
+                perms.add(PosixFilePermission.OWNER_EXECUTE);
+            }
             Files.setPosixFilePermissions(path, perms);
         } catch (UnsupportedOperationException posixUnsupported) {
             // Not a POSIX filesystem (e.g. Windows/NTFS); fall back to an owner-only ACL.
-            applyOwnerOnlyAcl(path);
+            applyOwnerOnlyAcl(path, directory);
         } catch (IOException ignored) {
             // Best-effort; the file remains at its filesystem-default permissions.
         }
     }
 
-    private static void applyOwnerOnlyAcl(Path path) {
+    private static void applyOwnerOnlyAcl(Path path, boolean directory) {
         try {
             AclFileAttributeView aclView = Files.getFileAttributeView(path, AclFileAttributeView.class);
             if (aclView == null) {
@@ -54,21 +74,26 @@ public final class OwnerOnlyFilePermissions {
                 return;
             }
             UserPrincipal owner = aclView.getOwner();
+            Set<AclEntryPermission> permissions = new HashSet<>(Set.of(
+                    AclEntryPermission.READ_DATA,
+                    AclEntryPermission.WRITE_DATA,
+                    AclEntryPermission.APPEND_DATA,
+                    AclEntryPermission.READ_ATTRIBUTES,
+                    AclEntryPermission.WRITE_ATTRIBUTES,
+                    AclEntryPermission.READ_NAMED_ATTRS,
+                    AclEntryPermission.WRITE_NAMED_ATTRS,
+                    AclEntryPermission.READ_ACL,
+                    AclEntryPermission.WRITE_ACL,
+                    AclEntryPermission.DELETE,
+                    AclEntryPermission.SYNCHRONIZE));
+            if (directory) {
+                // Mirrors the POSIX execute bit above: lets the owner traverse into the directory.
+                permissions.add(AclEntryPermission.EXECUTE);
+            }
             AclEntry ownerEntry = AclEntry.newBuilder()
                     .setType(AclEntryType.ALLOW)
                     .setPrincipal(owner)
-                    .setPermissions(
-                            AclEntryPermission.READ_DATA,
-                            AclEntryPermission.WRITE_DATA,
-                            AclEntryPermission.APPEND_DATA,
-                            AclEntryPermission.READ_ATTRIBUTES,
-                            AclEntryPermission.WRITE_ATTRIBUTES,
-                            AclEntryPermission.READ_NAMED_ATTRS,
-                            AclEntryPermission.WRITE_NAMED_ATTRS,
-                            AclEntryPermission.READ_ACL,
-                            AclEntryPermission.WRITE_ACL,
-                            AclEntryPermission.DELETE,
-                            AclEntryPermission.SYNCHRONIZE)
+                    .setPermissions(permissions)
                     .build();
             aclView.setAcl(List.of(ownerEntry));
         } catch (IOException | UnsupportedOperationException ignored) {

--- a/shaft-capture/src/test/java/com/shaft/capture/storage/OwnerOnlyFilePermissionsTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/storage/OwnerOnlyFilePermissionsTest.java
@@ -72,6 +72,8 @@ class OwnerOnlyFilePermissionsTest {
 
     @Test
     void doesNotThrowForAMissingDirectory() {
-        OwnerOnlyFilePermissions.restrictDirectoryToOwner(tempDir.resolve("does-not-exist"));
+        // Best-effort by design: a missing path must not throw, since callers treat this as a
+        // hardening step applied after the directory was already created.
+        assertDoesNotThrow(() -> OwnerOnlyFilePermissions.restrictDirectoryToOwner(tempDir.resolve("does-not-exist")));
     }
 }

--- a/shaft-capture/src/test/java/com/shaft/capture/storage/OwnerOnlyFilePermissionsTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/storage/OwnerOnlyFilePermissionsTest.java
@@ -12,6 +12,7 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.util.List;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -42,5 +43,35 @@ class OwnerOnlyFilePermissionsTest {
         // Best-effort by design: a missing path must not throw, since callers treat this as a
         // hardening step applied after a real write already succeeded.
         OwnerOnlyFilePermissions.restrictToOwner(tempDir.resolve("does-not-exist.txt"));
+    }
+
+    @Test
+    void restrictedDirectoryRemainsTraversableAndWritableByItsOwner() throws IOException {
+        Path directory = Files.createDirectories(tempDir.resolve("owner-only-dir"));
+
+        OwnerOnlyFilePermissions.restrictDirectoryToOwner(directory);
+
+        // On POSIX, a directory needs its own execute (search) bit for its owner to traverse into
+        // it -- restrictToOwner's plain read+write-only permissions would lock the owner out of a
+        // directory (unlike a file, where read+write alone is sufficient), so this must use the
+        // directory-specific overload and keep the directory usable afterward.
+        assertDoesNotThrow(() -> Files.writeString(directory.resolve("inside.txt"), "content"),
+                "Restricting a directory to its owner must not also block the owner's own access to it");
+
+        try {
+            Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(directory);
+            assertEquals(Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE,
+                    PosixFilePermission.OWNER_EXECUTE), permissions);
+        } catch (UnsupportedOperationException posixUnsupported) {
+            AclFileAttributeView aclView = Files.getFileAttributeView(directory, AclFileAttributeView.class);
+            assertTrue(aclView != null, "Filesystem supports neither POSIX permissions nor ACLs");
+            List<AclEntry> acl = aclView.getAcl();
+            assertEquals(1, acl.size(), "Expected exactly one owner-only ACL entry, got: " + acl);
+        }
+    }
+
+    @Test
+    void doesNotThrowForAMissingDirectory() {
+        OwnerOnlyFilePermissions.restrictDirectoryToOwner(tempDir.resolve("does-not-exist"));
     }
 }


### PR DESCRIPTION
## Summary
- Fixes PR #3378's `release-candidate` CI failure (ubuntu-22.04): `MobileApiCaptureControllerTest` and `MobileServiceConfigurationTest` failed with `Capture CA could not be loaded or generated.`, even after #3379 wired in `@TempDir`-backed CA isolation for those tests.
- Root cause: `CaptureCertificateAuthority`'s constructor restricts its own storage directory to owner **read+write only** via `OwnerOnlyFilePermissions.restrictToOwner(directory)`. On POSIX systems, a directory needs its own **execute (search)** bit for anyone — including its owner — to traverse into it and access files by name. Every subsequent write of the key/cert files into that now-locked-down directory fails with a permission error, which the constructor wraps as `CaptureProxyException("Capture CA could not be loaded or generated.")`.
- This only reproduces on POSIX (the Linux CI runner): Windows' ACL fallback path is masked by the OS's default "bypass traverse checking" privilege, so the same code silently "worked" locally.
- Fix: add `OwnerOnlyFilePermissions.restrictDirectoryToOwner(Path)`, a directory-aware variant that keeps the owner's execute/traverse permission (POSIX `rwx------`; ACL fallback adds `EXECUTE`), and use it for the CA directory instead of the file-oriented `restrictToOwner(Path)`. `restrictToOwner` itself is unchanged for its existing file call sites (the CA key/cert files, and `SecretHeaderReplacer`'s secrets file).

## Test plan
- [x] `mvn -pl shaft-capture test -Dtest=OwnerOnlyFilePermissionsTest` — includes a new regression test (`restrictedDirectoryRemainsTraversableAndWritableByItsOwner`) that reproduces the exact failure mode: writing a file into a directory immediately after restricting it.
- [x] `mvn -pl shaft-capture-proxy test -Dtest=CaptureCertificateAuthorityTest`
- [x] `mvn -pl shaft-mcp test -Dtest=MobileApiCaptureControllerTest,MobileServiceConfigurationTest` — the originally failing tests, now passing.

Note: all verification above ran on Windows, where this bug doesn't reproduce (see root cause above) — the fix targets POSIX (Linux CI) semantics specifically. The regression test asserts the actual POSIX permission bits and directory-writability, so it will exercise the real behavior on the Linux CI runner for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)