### PR TITLE
Add aria-snapshot assertions and visual regression baselines (#3349)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ For edits: preserve work; at session start fetch/prune, branch/worktree fresh `c
 - Docs repo `C:\Users\Mohab\IdeaProjects\shafthq.github.io`; targeted `rg`/excerpts. Function changes need guide + docs PR.
 - Never expose secrets or run deploy/publish/rewrites/cleanup/cloud suites unless asked.
 - No generated reports, binaries, or `target/`; browser tests headless unless headed approved.
+- Blockers/small issues hit while working: fix inline. Medium/large issues or enhancement ideas noticed: consolidate into one followup GitHub issue. Never go out of your way to hunt for either.
 
 ## Windows/Codex Safety
 

--- a/shaft-engine/pom.xml
+++ b/shaft-engine/pom.xml
@@ -633,6 +633,8 @@
                 <directory>${project.basedir}/src/main/resources</directory>
                 <includes>
                     <include>junit-platform.properties</include>
+                    <include>axe.min.js</include>
+                    <include>ariaSnapshot.js</include>
                 </includes>
             </resource>
         </resources>

--- a/shaft-engine/src/main/java/com/shaft/gui/driver/BrowserAssertions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/driver/BrowserAssertions.java
@@ -1,6 +1,7 @@
 package com.shaft.gui.driver;
 
 import com.shaft.validation.internal.NativeValidationsBuilder;
+import com.shaft.validation.internal.VisualValidationsBuilder;
 
 /**
  * Public contract for browser-level hard/soft validation starters.
@@ -22,4 +23,13 @@ public interface BrowserAssertions {
     }
 
     NativeValidationsBuilder text();
+
+    /**
+     * Starts a visual-regression assertion against the current page's baseline full-page screenshot.
+     *
+     * @return a VisualValidationsBuilder to optionally set diff-budget/mask options and then perform() your validation
+     */
+    default VisualValidationsBuilder matchesScreenshot() {
+        throw new UnsupportedOperationException("matchesScreenshot is not supported by this browser assertions implementation.");
+    }
 }

--- a/shaft-engine/src/main/java/com/shaft/gui/driver/ElementActionsContract.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/driver/ElementActionsContract.java
@@ -185,4 +185,16 @@ public interface ElementActionsContract {
     default ElementActionsContract captureScreenshot(ShaftLocator elementLocator) {
         return captureScreenshot(elementLocator.toBy());
     }
+
+    /**
+     * Captures an accessible-name-tree ("aria") snapshot of the target element, serialized as YAML.
+     *
+     * @param elementLocator the locator of the element to snapshot
+     * @return the captured snapshot serialized as YAML
+     */
+    String ariaSnapshot(By elementLocator);
+
+    default String ariaSnapshot(ShaftLocator elementLocator) {
+        return ariaSnapshot(elementLocator.toBy());
+    }
 }

--- a/shaft-engine/src/main/java/com/shaft/gui/driver/ElementAssertions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/driver/ElementAssertions.java
@@ -3,6 +3,7 @@ package com.shaft.gui.driver;
 import com.shaft.validation.ValidationEnums;
 import com.shaft.validation.internal.NativeValidationsBuilder;
 import com.shaft.validation.internal.ValidationsExecutor;
+import com.shaft.validation.internal.VisualValidationsBuilder;
 
 /**
  * Public contract for element-level hard/soft validation starters.
@@ -49,4 +50,23 @@ public interface ElementAssertions {
     NativeValidationsBuilder textTrimmed();
 
     NativeValidationsBuilder cssProperty(String elementCssProperty);
+
+    /**
+     * Starts a visual-regression assertion against the element's baseline screenshot.
+     *
+     * @return a VisualValidationsBuilder to optionally set diff-budget/mask options and then perform() your validation
+     */
+    default VisualValidationsBuilder matchesScreenshot() {
+        throw new UnsupportedOperationException("matchesScreenshot is not supported by this element assertions implementation.");
+    }
+
+    /**
+     * Starts an accessible-name-tree regression assertion against the element's baseline aria snapshot.
+     *
+     * @param snapshotFileName the baseline file name (under the configured aria snapshot folder) to compare against or create
+     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     */
+    default ValidationsExecutor matchesAriaSnapshot(String snapshotFileName) {
+        throw new UnsupportedOperationException("matchesAriaSnapshot is not supported by this element assertions implementation.");
+    }
 }

--- a/shaft-engine/src/main/java/com/shaft/gui/element/ElementActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/ElementActions.java
@@ -4,6 +4,7 @@ import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.driver.internal.FluentWebDriverAction;
 import com.shaft.driver.internal.WizardHelpers;
 import com.shaft.gui.element.internal.Actions;
+import com.shaft.gui.internal.aria.AriaSnapshotHelper;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.validation.internal.WebDriverElementValidationsBuilder;
 import org.openqa.selenium.*;
@@ -473,6 +474,19 @@ public class ElementActions extends FluentWebDriverAction implements com.shaft.g
     @Override
     public Actions captureScreenshot(By elementLocator) {
         return new Actions(driverFactoryHelper).captureScreenshot(elementLocator);
+    }
+
+    /**
+     * Captures an accessible-name-tree ("aria") snapshot of the target element, serialized as YAML.
+     * Use with {@code assertThat(elementLocator).matchesAriaSnapshot(fileName)} for regression baselining.
+     *
+     * @param elementLocator the locator of the element to snapshot
+     * @return the captured snapshot serialized as YAML
+     * @see <a href="https://shafthq.github.io/">SHAFT User Guide &ndash; Element Actions</a>
+     */
+    @Override
+    public String ariaSnapshot(By elementLocator) {
+        return AriaSnapshotHelper.captureAriaSnapshot(driverFactoryHelper.getDriver(), elementLocator);
     }
 
 }

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/aria/AriaNode.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/aria/AriaNode.java
@@ -1,0 +1,17 @@
+package com.shaft.gui.internal.aria;
+
+import java.util.List;
+
+/**
+ * A single accessible-name-tree node: an ARIA role, its accessible name, and its children.
+ *
+ * @param role the ARIA role (explicit {@code role} attribute or implicit-by-tag-name)
+ * @param name the accessible name, resolved via aria-label/aria-labelledby/alt/title/value/text, or empty
+ * @param children the node's own accessible descendants (never {@code null})
+ */
+public record AriaNode(String role, String name, List<AriaNode> children) {
+    public AriaNode {
+        name = name == null ? "" : name;
+        children = children == null ? List.of() : List.copyOf(children);
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/aria/AriaSnapshotHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/aria/AriaSnapshotHelper.java
@@ -1,0 +1,229 @@
+package com.shaft.gui.internal.aria;
+
+import com.microsoft.playwright.Locator;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Captures and compares accessible-name-tree ("aria") snapshots: a pragmatic, DOM-walk-based subset of
+ * ARIA role/name resolution (not full ARIA AAM spec compliance), serialized as a strict subset of
+ * Playwright's aria snapshot YAML DSL (no {@code [level=n]} attributes, no regex names).
+ *
+ * <p>Both backends run the same {@code ariaSnapshot.js} DOM walk so web output is directly comparable.</p>
+ */
+public final class AriaSnapshotHelper {
+    private static final Pattern LABEL_PATTERN = Pattern.compile("^(\\S+)(?:\\s+\"((?:[^\"\\\\]|\\\\.)*)\")?$");
+
+    private AriaSnapshotHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Captures an aria snapshot of the element matched by {@code locator}, using Selenium JavaScript execution.
+     *
+     * @param driver active WebDriver instance (must support {@link JavascriptExecutor})
+     * @param locator locator of the element to snapshot
+     * @return the captured snapshot serialized as YAML
+     */
+    public static String captureAriaSnapshot(WebDriver driver, By locator) {
+        if (!(driver instanceof JavascriptExecutor executor)) {
+            throw new IllegalArgumentException("WebDriver must support JavaScript execution.");
+        }
+        WebElement element = driver.findElement(locator);
+        Object raw = executor.executeScript(readAriaSnapshotScript() + ";return __shaftAriaSnapshot(arguments[0]);", element);
+        return serialize(toNodes(raw));
+    }
+
+    /**
+     * Captures an aria snapshot of the element matched by {@code locator}, using Playwright JavaScript evaluation.
+     *
+     * @param locator Playwright locator of the element to snapshot
+     * @return the captured snapshot serialized as YAML
+     */
+    public static String captureAriaSnapshot(Locator locator) {
+        Object raw = locator.evaluate("(element) => { " + readAriaSnapshotScript() + "; return __shaftAriaSnapshot(element); }");
+        return serialize(toNodes(raw));
+    }
+
+    /**
+     * Serializes an accessible-name-tree forest to SHAFT's aria snapshot YAML format.
+     *
+     * @param forest the top-level nodes to serialize
+     * @return the YAML representation
+     */
+    public static String serialize(List<AriaNode> forest) {
+        StringBuilder builder = new StringBuilder();
+        appendNodes(builder, forest, 0);
+        return builder.toString();
+    }
+
+    /**
+     * Parses SHAFT's aria snapshot YAML format back into an accessible-name-tree forest.
+     *
+     * @param yaml the YAML representation
+     * @return the parsed top-level nodes, or an empty list for blank input
+     */
+    public static List<AriaNode> parse(String yaml) {
+        if (yaml == null || yaml.isBlank()) {
+            return List.of();
+        }
+        return fromYamlList(new Yaml().load(yaml));
+    }
+
+    /**
+     * Performs a partial-subset structural match: every baseline node must match an actual node at the
+     * same depth, in order (role equal; name equal after trim, or the baseline name may be blank to match
+     * any actual name); extra actual siblings/children are allowed. This is a pragmatic (greedy, not fully
+     * backtracking) subsequence match, sufficient for visual/structural regression baselining.
+     *
+     * @param baselineYaml the stored baseline snapshot
+     * @param actualYaml the freshly captured snapshot
+     * @return the match result, with a readable diff message on mismatch
+     */
+    public static AriaMatchResult match(String baselineYaml, String actualYaml) {
+        List<AriaNode> baseline = parse(baselineYaml);
+        List<AriaNode> actual = parse(actualYaml);
+        String diff = matchForest(baseline, actual, "");
+        return new AriaMatchResult(diff == null, diff == null ? "" : diff);
+    }
+
+    private static String matchForest(List<AriaNode> baseline, List<AriaNode> actual, String path) {
+        int actualIndex = 0;
+        for (AriaNode expected : baseline) {
+            boolean found = false;
+            while (actualIndex < actual.size()) {
+                AriaNode candidate = actual.get(actualIndex++);
+                if (roleAndNameMatch(expected, candidate)) {
+                    String childPath = path + "/" + describe(expected);
+                    String childDiff = matchForest(expected.children(), candidate.children(), childPath);
+                    if (childDiff == null) {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            if (!found) {
+                return "Expected node " + describe(expected) + " at " + (path.isEmpty() ? "/" : path)
+                        + " was not found in the actual aria snapshot.";
+            }
+        }
+        return null;
+    }
+
+    private static boolean roleAndNameMatch(AriaNode expected, AriaNode actual) {
+        if (!expected.role().equals(actual.role())) {
+            return false;
+        }
+        return expected.name().isBlank() || expected.name().equals(actual.name());
+    }
+
+    private static String describe(AriaNode node) {
+        return node.name().isBlank() ? node.role() : node.role() + " \"" + node.name() + "\"";
+    }
+
+    private static void appendNodes(StringBuilder builder, List<AriaNode> nodes, int indentLevel) {
+        String indent = "  ".repeat(indentLevel);
+        for (AriaNode node : nodes) {
+            String label = formatLabel(node.role(), node.name());
+            if (node.children().isEmpty()) {
+                builder.append(indent).append("- ").append(label).append('\n');
+            } else {
+                builder.append(indent).append("- ").append(label).append(":\n");
+                appendNodes(builder, node.children(), indentLevel + 1);
+            }
+        }
+    }
+
+    private static String formatLabel(String role, String name) {
+        if (name == null || name.isBlank()) {
+            return role;
+        }
+        return role + " \"" + name.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<AriaNode> toNodes(Object raw) {
+        if (!(raw instanceof List<?> rawList)) {
+            return List.of();
+        }
+        List<AriaNode> nodes = new ArrayList<>();
+        for (Object item : rawList) {
+            if (item instanceof Map<?, ?> map) {
+                String role = String.valueOf(map.get("role"));
+                Object nameObj = map.get("name");
+                nodes.add(new AriaNode(role, nameObj == null ? "" : String.valueOf(nameObj), toNodes(map.get("children"))));
+            }
+        }
+        return nodes;
+    }
+
+    private static List<AriaNode> fromYamlList(Object loaded) {
+        if (!(loaded instanceof List<?> list)) {
+            return List.of();
+        }
+        List<AriaNode> nodes = new ArrayList<>();
+        for (Object item : list) {
+            nodes.add(fromYamlItem(item));
+        }
+        return nodes;
+    }
+
+    private static AriaNode fromYamlItem(Object item) {
+        if (item instanceof String scalar) {
+            String[] roleAndName = parseLabel(scalar);
+            return new AriaNode(roleAndName[0], roleAndName[1], List.of());
+        }
+        if (item instanceof Map<?, ?> map && map.size() == 1) {
+            Map.Entry<?, ?> entry = map.entrySet().iterator().next();
+            String[] roleAndName = parseLabel(String.valueOf(entry.getKey()));
+            return new AriaNode(roleAndName[0], roleAndName[1], fromYamlList(entry.getValue()));
+        }
+        throw new IllegalArgumentException("Malformed aria snapshot node: " + item);
+    }
+
+    private static String[] parseLabel(String label) {
+        Matcher matcher = LABEL_PATTERN.matcher(label.trim());
+        if (!matcher.matches()) {
+            return new String[]{label.trim(), ""};
+        }
+        String role = matcher.group(1);
+        String name = matcher.group(2);
+        if (name == null) {
+            return new String[]{role, ""};
+        }
+        return new String[]{role, name.replace("\\\"", "\"").replace("\\\\", "\\")};
+    }
+
+    private static String readAriaSnapshotScript() {
+        try (InputStream stream = AriaSnapshotHelper.class.getClassLoader().getResourceAsStream("ariaSnapshot.js")) {
+            if (stream == null) {
+                throw new IllegalStateException("ariaSnapshot.js was not found on the classpath.");
+            }
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Result of a partial-subset aria snapshot comparison.
+     *
+     * @param matched {@code true} when every baseline node was found in the actual snapshot
+     * @param diffMessage a readable description of the first mismatch, or empty when matched
+     */
+    public record AriaMatchResult(boolean matched, String diffMessage) {
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
@@ -280,6 +280,60 @@ public class ImageProcessingActions {
                 visualBaselinePath + ".png", visualBaselinePath + "_shutterbug");
     }
 
+    /**
+     * Compares an element's actual screenshot against its visual-regression baseline using a pixel-level diff.
+     * Saves the actual screenshot as the new baseline when none exists yet, or when {@code -Dshaft.updateSnapshots=true}.
+     *
+     * @param elementLocator locator of the element being compared
+     * @param actualScreenshot encoded screenshot bytes of the current state
+     * @param maskRects pixel-space {@code [x, y, width, height]} regions to exclude from comparison, or {@code null}
+     * @param maxDiffPixels maximum allowed differing pixel count, or {@code null} to ignore this budget
+     * @param maxDiffPixelRatio maximum allowed differing pixel ratio (0.0-1.0), or {@code null} to ignore this budget
+     * @return the comparison result
+     */
+    public static VisualProcessingProvider.ScreenshotComparisonResult compareScreenshotAgainstBaseline(
+            By elementLocator, byte[] actualScreenshot, List<int[]> maskRects, Integer maxDiffPixels, Double maxDiffPixelRatio) {
+        return compareScreenshotAgainstBaselineByHash(formatElementLocatorToImagePath(elementLocator), actualScreenshot, maskRects, maxDiffPixels, maxDiffPixelRatio);
+    }
+
+    /**
+     * Compares a backend-neutral actual screenshot (e.g. a full-page capture) against its visual-regression
+     * baseline using a pixel-level diff. Saves the actual screenshot as the new baseline when none exists yet,
+     * or when {@code -Dshaft.updateSnapshots=true}.
+     *
+     * @param baselineKey stable backend-neutral baseline description
+     * @param actualScreenshot encoded screenshot bytes of the current state
+     * @param maskRects pixel-space {@code [x, y, width, height]} regions to exclude from comparison, or {@code null}
+     * @param maxDiffPixels maximum allowed differing pixel count, or {@code null} to ignore this budget
+     * @param maxDiffPixelRatio maximum allowed differing pixel ratio (0.0-1.0), or {@code null} to ignore this budget
+     * @return the comparison result
+     */
+    public static VisualProcessingProvider.ScreenshotComparisonResult compareScreenshotAgainstBaseline(
+            String baselineKey, byte[] actualScreenshot, List<int[]> maskRects, Integer maxDiffPixels, Double maxDiffPixelRatio) {
+        return compareScreenshotAgainstBaselineByHash(formatElementLocatorToImagePath(baselineKey), actualScreenshot, maskRects, maxDiffPixels, maxDiffPixelRatio);
+    }
+
+    private static VisualProcessingProvider.ScreenshotComparisonResult compareScreenshotAgainstBaselineByHash(
+            String hashedName, byte[] actualScreenshot, List<int[]> maskRects, Integer maxDiffPixels, Double maxDiffPixelRatio) {
+        String baselineImagePath = getAiFolderPath() + hashedName + ".png";
+        boolean updateSnapshots = SHAFT.Properties.visuals.updateSnapshots();
+
+        if (!FileActions.getInstance(true).doesFileExist(baselineImagePath) || updateSnapshots) {
+            ReportManager.logDiscrete("Passing the test and saving a reference screenshot baseline.");
+            FileActions.getInstance(true).writeToFile(baselineImagePath, actualScreenshot);
+            return new VisualProcessingProvider.ScreenshotComparisonResult(true, new byte[0], 0, 0.0);
+        }
+
+        byte[] baselineImage = FileActions.getInstance(true).readFileAsByteArray(baselineImagePath);
+        VisualProcessingProvider.ScreenshotComparisonResult result = VisualProcessingProviderRegistry.requireProvider()
+                .compareScreenshotAgainstBaseline(baselineImage, actualScreenshot, maskRects, maxDiffPixels, maxDiffPixelRatio);
+
+        if (!result.matched() && result.diffImage() != null && result.diffImage().length > 0) {
+            FileActions.getInstance(true).writeToFile(getAiFolderPath() + hashedName + "_diff.png", result.diffImage());
+        }
+        return result;
+    }
+
     private static void compareImageFolders(File[] referenceFiles, File[] testFiles, File testFolder, double threshold) throws IOException {
         int passedImagesCount = 0;
         int failedImagesCount = 0;

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/VisualProcessingProvider.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/VisualProcessingProvider.java
@@ -60,4 +60,35 @@ public interface VisualProcessingProvider {
      * Loads any native libraries required by this provider.
      */
     void load();
+
+    /**
+     * Result of a pixel-level screenshot comparison against a baseline image.
+     *
+     * @param matched   {@code true} when the observed pixel difference is within the configured budget
+     * @param diffImage encoded PNG highlighting the differing pixels, or an empty array when {@code matched} is {@code true}
+     * @param diffPixels number of pixels that differ after masking
+     * @param diffRatio  {@code diffPixels} divided by the total pixel count of the compared images
+     */
+    record ScreenshotComparisonResult(boolean matched, byte[] diffImage, long diffPixels, double diffRatio) {
+    }
+
+    /**
+     * Compares raw screenshot bytes against a baseline image using a pixel-level diff, honoring optional
+     * mask rectangles and diff budgets. Used by the {@code matchesScreenshot()} visual-regression assertion.
+     *
+     * <p>Providers that cannot perform a pixel diff may keep the default implementation.</p>
+     *
+     * @param baselineImage      encoded baseline (reference) image bytes
+     * @param actualImage        encoded actual (current) screenshot bytes
+     * @param maskRects          pixel-space {@code [x, y, width, height]} regions to exclude from comparison, or {@code null}
+     * @param maxDiffPixels      maximum allowed differing pixel count, or {@code null} to ignore this budget
+     * @param maxDiffPixelRatio  maximum allowed differing pixel ratio (0.0-1.0), or {@code null} to ignore this budget
+     * @return the comparison result
+     * @throws UnsupportedOperationException when the provider does not support pixel-diff screenshot comparison
+     */
+    default ScreenshotComparisonResult compareScreenshotAgainstBaseline(byte[] baselineImage, byte[] actualImage,
+                                                                         List<int[]> maskRects, Integer maxDiffPixels,
+                                                                         Double maxDiffPixelRatio) {
+        throw new UnsupportedOperationException("The configured visual processing provider does not support pixel-diff screenshot comparison.");
+    }
 }

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/element/ElementActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/element/ElementActions.java
@@ -5,6 +5,7 @@ import com.microsoft.playwright.options.BoundingBox;
 import com.google.common.annotations.Beta;
 import com.shaft.gui.driver.ElementAssertions;
 import com.shaft.gui.driver.ShaftLocator;
+import com.shaft.gui.internal.aria.AriaSnapshotHelper;
 import com.shaft.gui.internal.locator.CompositeLocator;
 import com.shaft.gui.internal.locator.SmartLocators;
 import com.shaft.gui.playwright.internal.PlaywrightSession;
@@ -438,6 +439,20 @@ public class ElementActions implements com.shaft.gui.driver.ElementActionsContra
             ReportManagerHelper.attach("Playwright Screenshot", "element.png", new ByteArrayInputStream(screenshot));
             ReportManager.log("Captured Playwright element screenshot.");
         });
+    }
+
+    @Override
+    public String ariaSnapshot(By elementLocator) {
+        return ariaSnapshot(resolve(elementLocator));
+    }
+
+    @Override
+    public String ariaSnapshot(ShaftLocator elementLocator) {
+        return ariaSnapshot(resolve(elementLocator));
+    }
+
+    public String ariaSnapshot(Locator elementLocator) {
+        return AriaSnapshotHelper.captureAriaSnapshot(elementLocator);
     }
 
     private Locator resolve(By locator) {

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightBrowserValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightBrowserValidationsBuilder.java
@@ -4,6 +4,7 @@ import com.shaft.gui.driver.BrowserAssertions;
 import com.shaft.gui.playwright.internal.PlaywrightSession;
 import com.shaft.validation.ValidationEnums;
 import com.shaft.validation.internal.NativeValidationsBuilder;
+import com.shaft.validation.internal.VisualValidationsBuilder;
 
 public class PlaywrightBrowserValidationsBuilder implements BrowserAssertions {
     private final ValidationEnums.ValidationCategory validationCategory;
@@ -48,6 +49,12 @@ public class PlaywrightBrowserValidationsBuilder implements BrowserAssertions {
     public NativeValidationsBuilder text() {
         reportMessageBuilder.append("text ");
         return builder("text");
+    }
+
+    @Override
+    public VisualValidationsBuilder matchesScreenshot() {
+        reportMessageBuilder.append("page matches the visual regression baseline screenshot.");
+        return new PlaywrightVisualValidationsBuilder(validationCategory, session, null, null, true, reportMessageBuilder);
     }
 
     private NativeValidationsBuilder builder(String browserAttribute) {

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightElementValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightElementValidationsBuilder.java
@@ -6,6 +6,7 @@ import com.shaft.gui.playwright.internal.PlaywrightSession;
 import com.shaft.validation.ValidationEnums;
 import com.shaft.validation.internal.NativeValidationsBuilder;
 import com.shaft.validation.internal.ValidationsExecutor;
+import com.shaft.validation.internal.VisualValidationsBuilder;
 
 public class PlaywrightElementValidationsBuilder implements ElementAssertions {
     private final ValidationEnums.ValidationCategory validationCategory;
@@ -154,6 +155,22 @@ public class PlaywrightElementValidationsBuilder implements ElementAssertions {
     public NativeValidationsBuilder cssProperty(String elementCssProperty) {
         reportMessageBuilder.append("CSS property \"").append(elementCssProperty).append("\" ");
         return builder("elementCssPropertyEquals", null, elementCssProperty);
+    }
+
+    @Override
+    public ValidationsExecutor matchesAriaSnapshot(String snapshotFileName) {
+        appendShaftElementNameIfAvailable();
+        reportMessageBuilder.append("matches the aria snapshot \"").append(snapshotFileName).append("\".");
+        var executor = builder("elementAriaSnapshotMatches", null, null).createAriaSnapshotExecutor(snapshotFileName);
+        executor.internalPerform();
+        return executor;
+    }
+
+    @Override
+    public VisualValidationsBuilder matchesScreenshot() {
+        appendShaftElementNameIfAvailable();
+        reportMessageBuilder.append("matches the visual regression baseline screenshot.");
+        return new PlaywrightVisualValidationsBuilder(validationCategory, session, locator, locatorDescription, false, reportMessageBuilder);
     }
 
     private PlaywrightNativeValidationsBuilder builder(String validationMethod, String elementAttribute, String elementCssProperty) {

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightNativeValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightNativeValidationsBuilder.java
@@ -15,6 +15,7 @@ final class PlaywrightNativeValidationsBuilder extends NativeValidationsBuilder 
     private final String playwrightElementCssProperty;
     private final String playwrightBrowserAttribute;
     private ValidationEnums.VisualValidationEngine visualValidationEngine;
+    private String ariaSnapshotFileName;
 
     PlaywrightNativeValidationsBuilder(ValidationEnums.ValidationCategory validationCategory,
                                        PlaywrightSession session,
@@ -48,6 +49,14 @@ final class PlaywrightNativeValidationsBuilder extends NativeValidationsBuilder 
         this.validationComparisonType = ValidationEnums.ValidationComparisonType.EQUALS;
         this.expectedValue = validationType.getValue();
         this.visualValidationEngine = visualValidationEngine;
+        return new PlaywrightValidationsExecutor(this);
+    }
+
+    PlaywrightValidationsExecutor createAriaSnapshotExecutor(String snapshotFileName) {
+        this.validationType = ValidationEnums.ValidationType.POSITIVE;
+        this.validationComparisonType = ValidationEnums.ValidationComparisonType.EQUALS;
+        this.expectedValue = true;
+        this.ariaSnapshotFileName = snapshotFileName;
         return new PlaywrightValidationsExecutor(this);
     }
 
@@ -106,6 +115,10 @@ final class PlaywrightNativeValidationsBuilder extends NativeValidationsBuilder 
 
     ValidationEnums.VisualValidationEngine visualValidationEngine() {
         return visualValidationEngine;
+    }
+
+    String ariaSnapshotFileName() {
+        return ariaSnapshotFileName;
     }
 
     StringBuilder reportMessageBuilder() {

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightValidationsExecutor.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightValidationsExecutor.java
@@ -5,9 +5,12 @@ import com.microsoft.playwright.Page;
 import com.microsoft.playwright.assertions.LocatorAssertions;
 import com.microsoft.playwright.assertions.PageAssertions;
 import com.microsoft.playwright.assertions.PlaywrightAssertions;
+import com.shaft.cli.FileActions;
 import com.shaft.driver.SHAFT;
+import com.shaft.gui.internal.aria.AriaSnapshotHelper;
 import com.shaft.gui.internal.image.ImageProcessingActions;
 import com.shaft.gui.internal.image.ScreenshotManager;
+import com.shaft.gui.internal.image.VisualProcessingProvider;
 import com.shaft.gui.playwright.internal.PlaywrightSession;
 import com.shaft.tools.io.internal.BrowserPerformanceExecutionReport;
 import com.shaft.tools.internal.support.JavaHelper;
@@ -48,6 +51,10 @@ final class PlaywrightValidationsExecutor extends ValidationsExecutor {
     private final ValidationEnums.ValidationComparisonType validationComparisonType;
     private final Object expectedValue;
     private final StringBuilder reportMessageBuilder;
+    private final Integer maxDiffPixels;
+    private final Double maxDiffPixelRatio;
+    private final List<Locator> maskLocators;
+    private final String ariaSnapshotFileName;
     private String validationCategoryString;
     private String customReportMessage = "";
 
@@ -66,6 +73,31 @@ final class PlaywrightValidationsExecutor extends ValidationsExecutor {
         this.elementCssProperty = builder.playwrightElementCssProperty();
         this.browserAttribute = builder.playwrightBrowserAttribute();
         this.reportMessageBuilder = builder.reportMessageBuilder();
+        this.maxDiffPixels = null;
+        this.maxDiffPixelRatio = null;
+        this.maskLocators = List.of();
+        this.ariaSnapshotFileName = builder.ariaSnapshotFileName();
+    }
+
+    PlaywrightValidationsExecutor(PlaywrightVisualValidationsBuilder builder) {
+        super(new SeedBuilder(builder.validationCategory()));
+        this.validationCategory = builder.validationCategory();
+        this.session = builder.session();
+        this.locator = builder.playwrightLocator();
+        this.locatorDescription = builder.playwrightLocatorDescription();
+        this.validationMethod = builder.pageLevel() ? "pageMatchesScreenshot" : "elementMatchesScreenshot";
+        this.validationType = ValidationEnums.ValidationType.POSITIVE;
+        this.visualValidationEngine = null;
+        this.validationComparisonType = null;
+        this.expectedValue = null;
+        this.elementAttribute = null;
+        this.elementCssProperty = null;
+        this.browserAttribute = null;
+        this.reportMessageBuilder = builder.reportMessageBuilder();
+        this.maxDiffPixels = builder.maxDiffPixelsValue();
+        this.maxDiffPixelRatio = builder.maxDiffPixelRatioValue();
+        this.maskLocators = builder.playwrightMaskLocators();
+        this.ariaSnapshotFileName = null;
     }
 
     @Override
@@ -114,6 +146,12 @@ final class PlaywrightValidationsExecutor extends ValidationsExecutor {
     private Outcome evaluate() {
         if ("elementMatches".equals(validationMethod)) {
             return evaluateElementMatches();
+        }
+        if ("elementMatchesScreenshot".equals(validationMethod) || "pageMatchesScreenshot".equals(validationMethod)) {
+            return evaluateMatchesScreenshot();
+        }
+        if ("elementAriaSnapshotMatches".equals(validationMethod)) {
+            return evaluateAriaSnapshot();
         }
         Object reportedExpected = expectedValue;
         Supplier<Object> actualSupplier = this::readActual;
@@ -271,6 +309,81 @@ final class PlaywrightValidationsExecutor extends ValidationsExecutor {
                 visualAttachments, visualComparisonAttached);
     }
 
+    private Outcome evaluateMatchesScreenshot() {
+        boolean pageLevel = "pageMatchesScreenshot".equals(validationMethod);
+        byte[] actualScreenshot = pageLevel
+                ? session.page().screenshot(new Page.ScreenshotOptions().setFullPage(true))
+                : locator.screenshot();
+
+        String baselineKey = pageLevel ? "page_" + ReportManagerHelper.getCallingMethodFullName() : locatorDescription;
+        byte[] baselineImage = ImageProcessingActions.getReferenceImage(baselineKey);
+        List<int[]> maskRects = resolveMaskRects();
+
+        VisualProcessingProvider.ScreenshotComparisonResult comparisonResult = ImageProcessingActions
+                .compareScreenshotAgainstBaseline(baselineKey, actualScreenshot, maskRects, maxDiffPixels, maxDiffPixelRatio);
+
+        boolean visualComparisonAttached = baselineImage != null
+                && attachVisualComparison(baselineImage, actualScreenshot, comparisonResult.diffImage());
+
+        boolean expected = true;
+        boolean actual = comparisonResult.matched();
+        return new Outcome(expected == actual, expected, actual, commonParameters(expected, actual), List.of(), visualComparisonAttached);
+    }
+
+    private Outcome evaluateAriaSnapshot() {
+        String actualYaml = AriaSnapshotHelper.captureAriaSnapshot(locator);
+        String baselinePath = resolveAriaSnapshotPath(ariaSnapshotFileName);
+        boolean updateSnapshots = SHAFT.Properties.visuals.updateSnapshots();
+        boolean baselineExists = FileActions.getInstance(true).doesFileExist(baselinePath);
+        boolean matched;
+        String baselineYaml;
+        List<List<Object>> attachments = new ArrayList<>();
+
+        if (!baselineExists || updateSnapshots) {
+            FileActions.getInstance(true).writeToFile(baselinePath, actualYaml);
+            matched = true;
+            baselineYaml = actualYaml;
+        } else {
+            baselineYaml = FileActions.getInstance(true).readFile(baselinePath);
+            var matchResult = AriaSnapshotHelper.match(baselineYaml, actualYaml);
+            matched = matchResult.matched();
+            if (!matched) {
+                attachments.add(List.of("Aria Snapshot Diff", "aria-snapshot-diff.txt", matchResult.diffMessage()));
+            }
+        }
+        attachments.add(List.of("Expected Aria Snapshot", ariaSnapshotFileName + ".yaml", baselineYaml));
+        attachments.add(List.of("Actual Aria Snapshot", ariaSnapshotFileName + "_actual.yaml", actualYaml));
+
+        boolean expected = true;
+        return new Outcome(expected == matched, expected, matched, commonParameters(expected, matched), attachments, false);
+    }
+
+    private static String resolveAriaSnapshotPath(String snapshotFileName) {
+        String fileName = snapshotFileName.endsWith(".yaml") || snapshotFileName.endsWith(".yml")
+                ? snapshotFileName : snapshotFileName + ".yaml";
+        return SHAFT.Properties.paths.ariaSnapshot() + fileName;
+    }
+
+    private List<int[]> resolveMaskRects() {
+        if (maskLocators == null || maskLocators.isEmpty()) {
+            return List.of();
+        }
+        List<int[]> rects = new ArrayList<>();
+        for (Locator mask : maskLocators) {
+            var box = mask.boundingBox();
+            if (box == null) {
+                continue;
+            }
+            rects.add(new int[]{
+                    (int) Math.round(box.x),
+                    (int) Math.round(box.y),
+                    (int) Math.round(box.width),
+                    (int) Math.round(box.height)
+            });
+        }
+        return rects;
+    }
+
     private static boolean attachVisualComparison(byte[] expectedImage, byte[] actualImage, byte[] differenceImage) {
         try {
             var content = new JSONObject()
@@ -404,6 +517,17 @@ final class PlaywrightValidationsExecutor extends ValidationsExecutor {
             case "elementMatches" -> {
                 parameters.put("Should match", String.valueOf(expected));
                 parameters.put("Visual engine", visualValidationEngine.name());
+                parameters.put("Actual value", String.valueOf(actual));
+                return parameters;
+            }
+            case "elementMatchesScreenshot", "pageMatchesScreenshot" -> {
+                parameters.put("Should match", String.valueOf(expected));
+                parameters.put("Actual value", String.valueOf(actual));
+                return parameters;
+            }
+            case "elementAriaSnapshotMatches" -> {
+                parameters.put("Snapshot file", ariaSnapshotFileName);
+                parameters.put("Should match", String.valueOf(expected));
                 parameters.put("Actual value", String.valueOf(actual));
                 return parameters;
             }

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightVisualValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightVisualValidationsBuilder.java
@@ -1,0 +1,98 @@
+package com.shaft.gui.playwright.validation;
+
+import com.microsoft.playwright.Locator;
+import com.shaft.gui.playwright.internal.PlaywrightSession;
+import com.shaft.validation.ValidationEnums;
+import com.shaft.validation.internal.ValidationsExecutor;
+import com.shaft.validation.internal.VisualValidationsBuilder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Playwright variant of {@link VisualValidationsBuilder}: adds a Playwright {@link Locator}-based
+ * {@code mask(...)} overload and routes {@link #perform()} through {@link PlaywrightValidationsExecutor}
+ * instead of the Selenium-oriented base executor.
+ */
+public final class PlaywrightVisualValidationsBuilder extends VisualValidationsBuilder {
+    private final PlaywrightSession session;
+    private final Locator playwrightLocator;
+    private final String playwrightLocatorDescription;
+    private final List<Locator> playwrightMaskLocators = new ArrayList<>();
+
+    PlaywrightVisualValidationsBuilder(ValidationEnums.ValidationCategory validationCategory, PlaywrightSession session,
+                                       Locator playwrightLocator, String playwrightLocatorDescription, boolean pageLevel,
+                                       StringBuilder reportMessageBuilder) {
+        super(validationCategory, null, null, pageLevel, reportMessageBuilder);
+        this.session = session;
+        this.playwrightLocator = playwrightLocator;
+        this.playwrightLocatorDescription = playwrightLocatorDescription;
+    }
+
+    @Override
+    public PlaywrightVisualValidationsBuilder maxDiffPixels(int maxDiffPixels) {
+        super.maxDiffPixels(maxDiffPixels);
+        return this;
+    }
+
+    @Override
+    public PlaywrightVisualValidationsBuilder maxDiffPixelRatio(double maxDiffPixelRatio) {
+        super.maxDiffPixelRatio(maxDiffPixelRatio);
+        return this;
+    }
+
+    /**
+     * Excludes the region(s) covered by the given Playwright locators from the pixel comparison.
+     *
+     * @param masks Playwright locators of elements whose bounding boxes should be excluded from the diff
+     * @return this builder, to continue chaining options
+     */
+    public PlaywrightVisualValidationsBuilder mask(Locator... masks) {
+        playwrightMaskLocators.addAll(Arrays.asList(masks));
+        return this;
+    }
+
+    @Override
+    public ValidationsExecutor perform() {
+        var executor = new PlaywrightValidationsExecutor(this);
+        executor.internalPerform();
+        return executor;
+    }
+
+    PlaywrightSession session() {
+        return session;
+    }
+
+    Locator playwrightLocator() {
+        return playwrightLocator;
+    }
+
+    String playwrightLocatorDescription() {
+        return playwrightLocatorDescription;
+    }
+
+    List<Locator> playwrightMaskLocators() {
+        return playwrightMaskLocators;
+    }
+
+    boolean pageLevel() {
+        return pageLevel;
+    }
+
+    Integer maxDiffPixelsValue() {
+        return maxDiffPixels;
+    }
+
+    Double maxDiffPixelRatioValue() {
+        return maxDiffPixelRatio;
+    }
+
+    ValidationEnums.ValidationCategory validationCategory() {
+        return validationCategory;
+    }
+
+    StringBuilder reportMessageBuilder() {
+        return reportMessageBuilder;
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Paths.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Paths.java
@@ -41,6 +41,10 @@ public interface Paths extends EngineProperties<Paths> {
     @DefaultValue("src/main/resources/dynamicObjectRepository/")
     String dynamicObjectRepository();
 
+    @Key("ariaSnapshotFolderPath")
+    @DefaultValue("src/test/resources/aria/")
+    String ariaSnapshot();
+
     @Key("testDataFolderPath")
     @DefaultValue("src/test/resources/testDataFiles/")
     String testData();
@@ -95,6 +99,11 @@ public interface Paths extends EngineProperties<Paths> {
 
         public SetProperty dynamicObjectRepository(String value) {
             setProperty("dynamicObjectRepositoryPath", value);
+            return this;
+        }
+
+        public SetProperty ariaSnapshot(String value) {
+            setProperty("ariaSnapshotFolderPath", value);
             return this;
         }
 

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Visuals.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Visuals.java
@@ -11,6 +11,9 @@ import org.aeonbits.owner.ConfigFactory;
  * <pre>{@code
  * SHAFT.Properties.visuals.set().screenshotParamsWhenToTakeAScreenshot("Always");
  * }</pre>
+ *
+ * <p>Set {@code -Dshaft.updateSnapshots=true} to regenerate visual and aria-snapshot baselines instead of
+ * comparing against the existing ones.</p>
  */
 @SuppressWarnings("unused")
 @Sources({"system:properties", "file:src/main/resources/properties/VisualValidations.properties", "file:src/main/resources/properties/default/VisualValidations.properties", "classpath:VisualValidations.properties"})
@@ -76,6 +79,10 @@ public interface Visuals extends EngineProperties<Visuals> {
     @Key("whenToTakePageSourceSnapshot")
     @DefaultValue("failuresOnly")
     String whenToTakePageSourceSnapshot();
+
+    @Key("shaft.updateSnapshots")
+    @DefaultValue("false")
+    boolean updateSnapshots();
 
     default SetProperty set() {
         return new SetProperty();
@@ -150,6 +157,11 @@ public interface Visuals extends EngineProperties<Visuals> {
 
         public SetProperty whenToTakePageSourceSnapshot(String value) {
             setProperty("whenToTakePageSourceSnapshot", value);
+            return this;
+        }
+
+        public SetProperty updateSnapshots(boolean value) {
+            setProperty("shaft.updateSnapshots", String.valueOf(value));
             return this;
         }
 

--- a/shaft-engine/src/main/java/com/shaft/validation/accessibility/AccessibilityActions.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/accessibility/AccessibilityActions.java
@@ -373,6 +373,42 @@ public class AccessibilityActions {
     }
 
     /**
+     * Asserts (hard assertion) that the current page has no accessibility violations matching any
+     * of the supplied WCAG tags (e.g. {@code "wcag2a"}, {@code "wcag21aa"}, {@code "best-practice"}).
+     *
+     * <p>Example:
+     * <pre>{@code
+     * driver.accessibility().assertIsAccessible("wcag2a", "wcag2aa");
+     * }</pre>
+     *
+     * @param wcagTags one or more axe-core WCAG tags to scope the audit to
+     * @return this {@code AccessibilityActions} instance for method chaining
+     */
+    public AccessibilityActions assertIsAccessible(String... wcagTags) {
+        boolean accessible = isAccessibleForTags(wcagTags);
+        assertCondition(accessible, "Assert the page is accessible for WCAG tags: " + String.join(", ", wcagTags));
+        return this;
+    }
+
+    /**
+     * Verifies (soft assertion) that the current page has no accessibility violations matching any
+     * of the supplied WCAG tags (e.g. {@code "wcag2a"}, {@code "wcag21aa"}, {@code "best-practice"}).
+     *
+     * <p>Example:
+     * <pre>{@code
+     * driver.accessibility().verifyIsAccessible("wcag2a", "wcag2aa");
+     * }</pre>
+     *
+     * @param wcagTags one or more axe-core WCAG tags to scope the audit to
+     * @return this {@code AccessibilityActions} instance for method chaining
+     */
+    public AccessibilityActions verifyIsAccessible(String... wcagTags) {
+        boolean accessible = isAccessibleForTags(wcagTags);
+        verifyCondition(accessible, "Verify the page is accessible for WCAG tags: " + String.join(", ", wcagTags));
+        return this;
+    }
+
+    /**
      * Asserts (hard assertion) that the current page has no accessibility violations matching
      * any of the supplied impact levels.
      *
@@ -619,6 +655,12 @@ public class AccessibilityActions {
             return !analyzeAndReturn("CurrentPage", false).hasViolations();
         }
         return AccessibilityHelper.isAccessible(driver.getDriver());
+    }
+
+    private boolean isAccessibleForTags(String... wcagTags) {
+        AccessibilityHelper.AccessibilityConfig config = new AccessibilityHelper.AccessibilityConfig()
+                .setTags(Arrays.asList(wcagTags));
+        return !analyzeAndReturn("CurrentPage", config, false).hasViolations();
     }
 
     private WebDriver rawDriver() {

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsExecutor.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsExecutor.java
@@ -14,6 +14,7 @@ import io.restassured.response.Response;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -43,6 +44,10 @@ public class ValidationsExecutor {
     private String folderRelativePath;
     private String fileName;
     private boolean jsonIgnoringOrderComparison;
+    private Integer maxDiffPixels;
+    private Double maxDiffPixelRatio;
+    private List<By> maskLocators;
+    private String ariaSnapshotFileName;
 
     public ValidationsExecutor(WebDriverElementValidationsBuilder webDriverElementValidationsBuilder) {
         this.validationCategory = webDriverElementValidationsBuilder.validationCategory;
@@ -51,7 +56,20 @@ public class ValidationsExecutor {
         this.validationType = webDriverElementValidationsBuilder.validationType;
         this.validationMethod = webDriverElementValidationsBuilder.validationMethod;
         this.visualValidationEngine = webDriverElementValidationsBuilder.visualValidationEngine;
+        this.ariaSnapshotFileName = webDriverElementValidationsBuilder.ariaSnapshotFileName;
         this.reportMessageBuilder = webDriverElementValidationsBuilder.reportMessageBuilder;
+    }
+
+    public ValidationsExecutor(VisualValidationsBuilder visualValidationsBuilder) {
+        this.validationCategory = visualValidationsBuilder.validationCategory;
+        this.driver.set(visualValidationsBuilder.driver);
+        this.locator = visualValidationsBuilder.locator;
+        this.validationType = visualValidationsBuilder.validationType;
+        this.validationMethod = visualValidationsBuilder.pageLevel ? "pageMatchesScreenshot" : "elementMatchesScreenshot";
+        this.maxDiffPixels = visualValidationsBuilder.maxDiffPixels;
+        this.maxDiffPixelRatio = visualValidationsBuilder.maxDiffPixelRatio;
+        this.maskLocators = visualValidationsBuilder.maskLocators;
+        this.reportMessageBuilder = visualValidationsBuilder.reportMessageBuilder;
     }
 
     public ValidationsExecutor(NativeValidationsBuilder nativeValidationsBuilder) {
@@ -184,6 +202,12 @@ public class ValidationsExecutor {
                     validationsHelper.validateElementExists(driver.get(), locator, validationType);
             case "elementMatches" ->
                     validationsHelper.validateElementMatches(driver.get(), locator, visualValidationEngine, validationType);
+            case "elementMatchesScreenshot" ->
+                    validationsHelper.validateMatchesScreenshot(driver.get(), locator, false, maskLocators, maxDiffPixels, maxDiffPixelRatio, validationType);
+            case "pageMatchesScreenshot" ->
+                    validationsHelper.validateMatchesScreenshot(driver.get(), locator, true, maskLocators, maxDiffPixels, maxDiffPixelRatio, validationType);
+            case "elementAriaSnapshotMatches" ->
+                    validationsHelper.validateElementAriaSnapshot(driver.get(), locator, ariaSnapshotFileName, validationType);
             case "elementAttributeEquals" ->
                     validationsHelper.validateElementAttribute(driver.get(), locator, elementAttribute, String.valueOf(expectedValue), validationComparisonType, validationType);
             case "elementDomAttributeEquals" ->

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java
@@ -8,8 +8,11 @@ import com.shaft.gui.browser.BrowserActions;
 import com.shaft.gui.browser.internal.BrowserActionsHelper;
 import com.shaft.gui.element.ElementActions;
 import com.shaft.gui.element.internal.Actions;
+import com.shaft.gui.internal.aria.AriaSnapshotHelper;
 import com.shaft.gui.internal.image.ImageProcessingActions;
+import com.shaft.gui.internal.image.ScreenshotHelper;
 import com.shaft.gui.internal.image.ScreenshotManager;
+import com.shaft.gui.internal.image.VisualProcessingProvider;
 import com.shaft.properties.internal.Properties;
 import com.shaft.tools.internal.support.JavaHelper;
 import com.shaft.tools.io.ReportManager;
@@ -35,6 +38,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -593,6 +597,154 @@ public class ValidationsHelper {
         updateAllureParameters(parameters);
         // force take page screenshot, (rather than element highlighted screenshot)
         reportValidationState(validationState.get(), expected, actual, driver, elementCount.get() == 0 ? null : locator, attachments, visualComparisonAttached.get());
+    }
+
+    protected void validateMatchesScreenshot(WebDriver driver, By locator, boolean pageLevel, List<By> maskLocators,
+                                             Integer maxDiffPixels, Double maxDiffPixelRatio, ValidationEnums.ValidationType validationType) {
+        // read actual value based on desired existing state
+        // Note: do not try/catch this block as the upstream failure will already be reported along with any needed attachments
+        AtomicBoolean expected = new AtomicBoolean(false);
+        AtomicBoolean actual = new AtomicBoolean(false);
+        AtomicBoolean validationState = new AtomicBoolean(false);
+        List<List<Object>> attachments = new ArrayList<>();
+        AtomicBoolean visualComparisonAttached = new AtomicBoolean(false);
+        String pageBaselineKey = pageLevel ? "page_" + ReportManagerHelper.getCallingMethodFullName() : null;
+
+        try {
+            new SynchronizationManager(driver).fluentWait(true).until(f -> {
+                byte[] actualScreenshot;
+                if (pageLevel) {
+                    try {
+                        actualScreenshot = ScreenshotHelper.makeFullScreenshot(driver);
+                    } catch (IOException ioException) {
+                        ReportManagerHelper.logDiscrete(ioException);
+                        return false; // force the wait block to try again
+                    }
+                } else {
+                    try {
+                        actualScreenshot = driver.findElement(locator).getScreenshotAs(OutputType.BYTES);
+                    } catch (WebDriverException webDriverException) {
+                        if (Objects.requireNonNull(webDriverException.getMessage()).contains("Cannot take screenshot with 0 width.")) {
+                            throw new NoSuchElementException("Cannot take screenshot with 0 width.");
+                        } else if (Objects.requireNonNull(webDriverException.getMessage()).contains("NS_ERROR_FAILURE")) {
+                            return false; // force the wait block to try again in case of unknown error with firefox
+                        } else {
+                            throw webDriverException;
+                        }
+                    }
+                }
+
+                List<int[]> maskRects = resolveMaskRects(driver, maskLocators);
+
+                byte[] baselineImage = pageLevel
+                        ? ImageProcessingActions.getReferenceImage(pageBaselineKey)
+                        : ImageProcessingActions.getReferenceImage(locator);
+
+                VisualProcessingProvider.ScreenshotComparisonResult comparisonResult = pageLevel
+                        ? ImageProcessingActions.compareScreenshotAgainstBaseline(pageBaselineKey, actualScreenshot, maskRects, maxDiffPixels, maxDiffPixelRatio)
+                        : ImageProcessingActions.compareScreenshotAgainstBaseline(locator, actualScreenshot, maskRects, maxDiffPixels, maxDiffPixelRatio);
+
+                if (baselineImage != null) {
+                    visualComparisonAttached.set(attachVisualComparison(baselineImage, actualScreenshot, comparisonResult.diffImage()));
+                }
+
+                expected.set(validationType.getValue());
+                actual.set(comparisonResult.matched());
+                // force validation type to be positive since the expected and actual values have been adjusted already
+                validationState.set(performValidation(expected.get(), actual.get(), ValidationEnums.ValidationComparisonType.EQUALS, ValidationEnums.ValidationType.POSITIVE));
+                return validationState.get();
+            });
+        } catch (TimeoutException timeoutException) {
+            //timeout was exhausted and the validation failed
+        }
+        //reporting block
+        var parameters = new LinkedHashMap<String, String>();
+        parameters.put(pageLevel ? "Page" : "Locator", pageLevel ? "current page" : String.valueOf(locator));
+        parameters.put("Should match", String.valueOf(expected.get()));
+        parameters.put("Actual value", String.valueOf(actual.get()));
+        updateAllureParameters(parameters);
+        // force take page screenshot, (rather than element highlighted screenshot)
+        reportValidationState(validationState.get(), expected, actual, driver, pageLevel ? null : locator, attachments, visualComparisonAttached.get());
+    }
+
+    private static List<int[]> resolveMaskRects(WebDriver driver, List<By> maskLocators) {
+        if (maskLocators == null || maskLocators.isEmpty()) {
+            return List.of();
+        }
+        double scalingFactor = SHAFT.Properties.visuals.screenshotParamsScalingFactor();
+        List<int[]> rects = new ArrayList<>();
+        for (By mask : maskLocators) {
+            try {
+                var rect = driver.findElement(mask).getRect();
+                rects.add(new int[]{
+                        (int) Math.round(rect.getX() * scalingFactor),
+                        (int) Math.round(rect.getY() * scalingFactor),
+                        (int) Math.round(rect.getWidth() * scalingFactor),
+                        (int) Math.round(rect.getHeight() * scalingFactor)
+                });
+            } catch (NoSuchElementException noSuchElementException) {
+                ReportManagerHelper.logDiscrete("Mask locator \"" + mask + "\" did not match any element; skipping mask.", Level.DEBUG);
+            }
+        }
+        return rects;
+    }
+
+    protected void validateElementAriaSnapshot(WebDriver driver, By locator, String snapshotFileName, ValidationEnums.ValidationType validationType) {
+        AtomicBoolean expected = new AtomicBoolean(false);
+        AtomicBoolean actual = new AtomicBoolean(false);
+        AtomicBoolean validationState = new AtomicBoolean(false);
+        AtomicReference<List<List<Object>>> attachmentsRef = new AtomicReference<>(new ArrayList<>());
+        String baselinePath = resolveAriaSnapshotPath(snapshotFileName);
+
+        try {
+            new SynchronizationManager(driver).fluentWait(true).until(f -> {
+                List<List<Object>> attachments = new ArrayList<>();
+                String actualYaml = AriaSnapshotHelper.captureAriaSnapshot(driver, locator);
+                boolean updateSnapshots = SHAFT.Properties.visuals.updateSnapshots();
+                boolean baselineExists = FileActions.getInstance(true).doesFileExist(baselinePath);
+                boolean matched;
+                String baselineYaml;
+
+                if (!baselineExists || updateSnapshots) {
+                    ReportManager.logDiscrete("Passing the test and saving a reference aria snapshot baseline.");
+                    FileActions.getInstance(true).writeToFile(baselinePath, actualYaml);
+                    matched = true;
+                    baselineYaml = actualYaml;
+                } else {
+                    baselineYaml = FileActions.getInstance(true).readFile(baselinePath);
+                    var matchResult = AriaSnapshotHelper.match(baselineYaml, actualYaml);
+                    matched = matchResult.matched();
+                    if (!matched) {
+                        attachments.add(List.of("Aria Snapshot Diff", "aria-snapshot-diff.txt", matchResult.diffMessage()));
+                    }
+                }
+                attachments.add(List.of("Expected Aria Snapshot", snapshotFileName + ".yaml", baselineYaml));
+                attachments.add(List.of("Actual Aria Snapshot", snapshotFileName + "_actual.yaml", actualYaml));
+                attachmentsRef.set(attachments);
+
+                expected.set(validationType.getValue());
+                actual.set(matched);
+                // force validation type to be positive since the expected and actual values have been adjusted already
+                validationState.set(performValidation(expected.get(), actual.get(), ValidationEnums.ValidationComparisonType.EQUALS, ValidationEnums.ValidationType.POSITIVE));
+                return validationState.get();
+            });
+        } catch (TimeoutException timeoutException) {
+            //timeout was exhausted and the validation failed
+        }
+        //reporting block
+        var parameters = new LinkedHashMap<String, String>();
+        parameters.put("Locator", String.valueOf(locator));
+        parameters.put("Snapshot file", snapshotFileName);
+        parameters.put("Should match", String.valueOf(expected.get()));
+        parameters.put("Actual value", String.valueOf(actual.get()));
+        updateAllureParameters(parameters);
+        reportValidationState(validationState.get(), expected, actual, driver, locator, attachmentsRef.get());
+    }
+
+    private static String resolveAriaSnapshotPath(String snapshotFileName) {
+        String fileName = snapshotFileName.endsWith(".yaml") || snapshotFileName.endsWith(".yml")
+                ? snapshotFileName : snapshotFileName + ".yaml";
+        return SHAFT.Properties.paths.ariaSnapshot() + fileName;
     }
 
     private static boolean attachVisualComparison(byte[] expectedImage, byte[] actualImage, byte[] differenceImage) {

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/VisualValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/VisualValidationsBuilder.java
@@ -1,0 +1,83 @@
+package com.shaft.validation.internal;
+
+import com.shaft.validation.ValidationEnums;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Fluent options builder for the {@code matchesScreenshot()} visual-regression assertion.
+ *
+ * <p>Unlike most SHAFT validation builders (which execute immediately on their terminal call),
+ * this builder gathers optional diff-budget/mask options before {@link #perform()} triggers the
+ * comparison, mirroring Playwright's {@code toHaveScreenshot()} options.</p>
+ */
+@SuppressWarnings("unused")
+public class VisualValidationsBuilder {
+    protected final ValidationEnums.ValidationCategory validationCategory;
+    protected final WebDriver driver;
+    protected final By locator;
+    protected final boolean pageLevel;
+    protected final StringBuilder reportMessageBuilder;
+    protected final ValidationEnums.ValidationType validationType = ValidationEnums.ValidationType.POSITIVE;
+    protected final List<By> maskLocators = new ArrayList<>();
+    protected Integer maxDiffPixels;
+    protected Double maxDiffPixelRatio;
+
+    public VisualValidationsBuilder(ValidationEnums.ValidationCategory validationCategory, WebDriver driver, By locator,
+                                    boolean pageLevel, StringBuilder reportMessageBuilder) {
+        this.validationCategory = validationCategory;
+        this.driver = driver;
+        this.locator = locator;
+        this.pageLevel = pageLevel;
+        this.reportMessageBuilder = reportMessageBuilder;
+    }
+
+    /**
+     * Caps the number of differing pixels allowed for the comparison to still pass.
+     *
+     * @param maxDiffPixels maximum allowed differing pixel count
+     * @return this builder, to continue chaining options
+     */
+    public VisualValidationsBuilder maxDiffPixels(int maxDiffPixels) {
+        this.maxDiffPixels = maxDiffPixels;
+        return this;
+    }
+
+    /**
+     * Caps the ratio of differing pixels (0.0-1.0) allowed for the comparison to still pass.
+     *
+     * @param maxDiffPixelRatio maximum allowed differing pixel ratio
+     * @return this builder, to continue chaining options
+     */
+    public VisualValidationsBuilder maxDiffPixelRatio(double maxDiffPixelRatio) {
+        this.maxDiffPixelRatio = maxDiffPixelRatio;
+        return this;
+    }
+
+    /**
+     * Excludes the region(s) covered by the given locators from the pixel comparison.
+     *
+     * @param masks locators of elements whose bounding boxes should be excluded from the diff
+     * @return this builder, to continue chaining options
+     */
+    public VisualValidationsBuilder mask(By... masks) {
+        this.maskLocators.addAll(Arrays.asList(masks));
+        return this;
+    }
+
+    /**
+     * Executes the visual-regression comparison (or saves a new baseline on first run / when
+     * {@code -Dshaft.updateSnapshots=true} is set).
+     *
+     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     */
+    public ValidationsExecutor perform() {
+        var executor = new ValidationsExecutor(this);
+        executor.internalPerform();
+        return executor;
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverBrowserValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverBrowserValidationsBuilder.java
@@ -84,4 +84,18 @@ public class WebDriverBrowserValidationsBuilder implements com.shaft.gui.driver.
         return new NativeValidationsBuilder(this);
     }
 
+    /**
+     * Use this to check that the current page matches its visual-regression baseline screenshot
+     * (full-page pixel diff via OpenCV; see {@link VisualValidationsBuilder} for diff-budget/mask options).
+     * On the first test run this method takes a full-page screenshot and the test passes, saving it as
+     * the baseline for subsequent runs.
+     *
+     * @return a VisualValidationsBuilder to optionally set diff-budget/mask options and then perform() your validation
+     */
+    @Override
+    public VisualValidationsBuilder matchesScreenshot() {
+        reportMessageBuilder.append("page matches the visual regression baseline screenshot.");
+        return new VisualValidationsBuilder(validationCategory, driver, null, true, reportMessageBuilder);
+    }
+
 }

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverElementValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverElementValidationsBuilder.java
@@ -16,6 +16,7 @@ public class WebDriverElementValidationsBuilder implements com.shaft.gui.driver.
     protected ValidationEnums.VisualValidationEngine visualValidationEngine;
     protected String elementAttribute;
     protected String elementCssProperty;
+    protected String ariaSnapshotFileName;
 
     public WebDriverElementValidationsBuilder(ValidationEnums.ValidationCategory validationCategory, WebDriver driver, By locator, StringBuilder reportMessageBuilder) {
         this.validationCategory = validationCategory;
@@ -120,6 +121,43 @@ public class WebDriverElementValidationsBuilder implements com.shaft.gui.driver.
         this.validationMethod = "elementMatches";
         this.visualValidationEngine = visualValidationEngine;
         appendVisualValidationMessage(false);
+        var executor = new ValidationsExecutor(this);
+        executor.internalPerform();
+        return executor;
+    }
+
+    /**
+     * Use this to check that the target element matches its visual-regression baseline screenshot
+     * (pixel diff via OpenCV; see {@link VisualValidationsBuilder} for diff-budget/mask options).
+     * On the first test run this method takes a screenshot of the target element and the test passes,
+     * saving it as the baseline for subsequent runs. Baselines are stored alongside the other visual
+     * baselines under the configured {@code dynamicObjectRepositoryPath}.
+     *
+     * @return a VisualValidationsBuilder to optionally set diff-budget/mask options and then perform() your validation
+     */
+    @Override
+    public VisualValidationsBuilder matchesScreenshot() {
+        appendShaftElementNameIfAvailable();
+        reportMessageBuilder.append("matches the visual regression baseline screenshot.");
+        return new VisualValidationsBuilder(validationCategory, driver, locator, false, reportMessageBuilder);
+    }
+
+    /**
+     * Use this to check that the target element matches its accessible-name-tree ("aria") baseline snapshot,
+     * using partial-subset semantics (see {@link com.shaft.gui.internal.aria.AriaSnapshotHelper}).
+     * On the first test run this method saves the current snapshot as the baseline and the test passes,
+     * under the configured {@code ariaSnapshotFolderPath}.
+     *
+     * @param snapshotFileName the baseline file name (without extension) to compare against or create
+     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     */
+    @Override
+    public ValidationsExecutor matchesAriaSnapshot(String snapshotFileName) {
+        this.validationType = ValidationEnums.ValidationType.POSITIVE;
+        this.validationMethod = "elementAriaSnapshotMatches";
+        this.ariaSnapshotFileName = snapshotFileName;
+        appendShaftElementNameIfAvailable();
+        reportMessageBuilder.append("matches the aria snapshot \"").append(snapshotFileName).append("\".");
         var executor = new ValidationsExecutor(this);
         executor.internalPerform();
         return executor;

--- a/shaft-engine/src/main/resources/ariaSnapshot.js
+++ b/shaft-engine/src/main/resources/ariaSnapshot.js
@@ -1,0 +1,121 @@
+function __shaftAriaSnapshot(root) {
+    var IMPLICIT_ROLES_BY_TAG = {
+        a: 'link',
+        button: 'button',
+        h1: 'heading', h2: 'heading', h3: 'heading', h4: 'heading', h5: 'heading', h6: 'heading',
+        nav: 'navigation',
+        ul: 'list', ol: 'list',
+        li: 'listitem',
+        img: 'img',
+        main: 'main',
+        header: 'banner',
+        footer: 'contentinfo',
+        table: 'table',
+        form: 'form',
+        textarea: 'textbox',
+        option: 'option',
+        dialog: 'dialog',
+        article: 'article',
+        section: 'region'
+    };
+
+    var IMPLICIT_INPUT_ROLES_BY_TYPE = {
+        text: 'textbox', email: 'textbox', search: 'searchbox', tel: 'textbox', url: 'textbox', password: 'textbox',
+        checkbox: 'checkbox', radio: 'radio', range: 'slider',
+        button: 'button', submit: 'button', reset: 'button',
+        number: 'spinbutton'
+    };
+
+    function computeRole(el) {
+        var explicit = el.getAttribute('role');
+        if (explicit) {
+            return explicit.split(/\s+/)[0];
+        }
+        var tag = el.tagName.toLowerCase();
+        if (tag === 'a') {
+            return el.hasAttribute('href') ? 'link' : null;
+        }
+        if (tag === 'input') {
+            var type = (el.getAttribute('type') || 'text').toLowerCase();
+            return IMPLICIT_INPUT_ROLES_BY_TYPE[type] || 'textbox';
+        }
+        if (tag === 'select') {
+            return el.multiple ? 'listbox' : 'combobox';
+        }
+        return IMPLICIT_ROLES_BY_TAG[tag] || null;
+    }
+
+    function resolveLabelledBy(ids) {
+        return ids.split(/\s+/).map(function (id) {
+            var referenced = document.getElementById(id);
+            return referenced ? referenced.textContent : '';
+        }).join(' ').trim();
+    }
+
+    function directText(el) {
+        var text = '';
+        for (var i = 0; i < el.childNodes.length; i++) {
+            var node = el.childNodes[i];
+            if (node.nodeType === 3) {
+                text += node.textContent;
+            }
+        }
+        return text.replace(/\s+/g, ' ').trim();
+    }
+
+    function computeName(el) {
+        var ariaLabel = el.getAttribute('aria-label');
+        if (ariaLabel && ariaLabel.trim()) {
+            return ariaLabel.trim();
+        }
+        var labelledBy = el.getAttribute('aria-labelledby');
+        if (labelledBy) {
+            var resolved = resolveLabelledBy(labelledBy);
+            if (resolved) {
+                return resolved;
+            }
+        }
+        if (el.tagName.toLowerCase() === 'img') {
+            var alt = el.getAttribute('alt');
+            if (alt) {
+                return alt.trim();
+            }
+        }
+        var title = el.getAttribute('title');
+        if (title && title.trim()) {
+            return title.trim();
+        }
+        if ('value' in el && typeof el.value === 'string' && el.value.trim()) {
+            return el.value.trim();
+        }
+        return directText(el);
+    }
+
+    function isHidden(el) {
+        if (el.getAttribute('aria-hidden') === 'true') {
+            return true;
+        }
+        if (el.hidden) {
+            return true;
+        }
+        var style = window.getComputedStyle(el);
+        return style.display === 'none' || style.visibility === 'hidden';
+    }
+
+    function walk(el) {
+        if (!el || el.nodeType !== 1 || isHidden(el)) {
+            return [];
+        }
+        var children = [];
+        for (var i = 0; i < el.children.length; i++) {
+            children = children.concat(walk(el.children[i]));
+        }
+        var role = computeRole(el);
+        if (role) {
+            return [{role: role, name: computeName(el), children: children}];
+        }
+        return children;
+    }
+
+    return walk(root);
+}

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/aria/AriaSnapshotHelperUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/aria/AriaSnapshotHelperUnitTest.java
@@ -1,0 +1,116 @@
+package com.shaft.gui.internal.aria;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+public class AriaSnapshotHelperUnitTest {
+
+    @Test(description = "serialize/parse should round-trip a nested forest with names and leaf-only nodes")
+    public void serializeAndParseShouldRoundTrip() {
+        List<AriaNode> forest = List.of(
+                new AriaNode("navigation", "", List.of(
+                        new AriaNode("link", "Home", List.of()),
+                        new AriaNode("link", "Docs", List.of())
+                )),
+                new AriaNode("heading", "Welcome", List.of()),
+                new AriaNode("button", "Sign in", List.of())
+        );
+
+        String yaml = AriaSnapshotHelper.serialize(forest);
+        List<AriaNode> roundTripped = AriaSnapshotHelper.parse(yaml);
+
+        Assert.assertEquals(roundTripped, forest);
+    }
+
+    @Test(description = "serialize should quote-escape names containing quotes and backslashes")
+    public void serializeShouldEscapeSpecialCharactersInNames() {
+        List<AriaNode> forest = List.of(new AriaNode("button", "Say \"hi\" \\ bye", List.of()));
+
+        String yaml = AriaSnapshotHelper.serialize(forest);
+        List<AriaNode> roundTripped = AriaSnapshotHelper.parse(yaml);
+
+        Assert.assertEquals(roundTripped, forest);
+    }
+
+    @Test(description = "parse should return an empty forest for blank input")
+    public void parseShouldReturnEmptyForestForBlankInput() {
+        Assert.assertTrue(AriaSnapshotHelper.parse("").isEmpty());
+        Assert.assertTrue(AriaSnapshotHelper.parse(null).isEmpty());
+    }
+
+    @Test(description = "match should pass when the baseline is an exact match of the actual snapshot")
+    public void matchShouldPassForExactMatch() {
+        String yaml = AriaSnapshotHelper.serialize(List.of(
+                new AriaNode("navigation", "", List.of(new AriaNode("link", "Home", List.of())))
+        ));
+
+        var result = AriaSnapshotHelper.match(yaml, yaml);
+
+        Assert.assertTrue(result.matched());
+    }
+
+    @Test(description = "match should pass when the actual snapshot has extra sibling and child nodes at the same depth as the baseline")
+    public void matchShouldPassWhenActualHasExtraNodes() {
+        String baseline = AriaSnapshotHelper.serialize(List.of(
+                new AriaNode("navigation", "", List.of(new AriaNode("link", "Home", List.of())))
+        ));
+        String actual = AriaSnapshotHelper.serialize(List.of(
+                new AriaNode("navigation", "", List.of(
+                        new AriaNode("link", "Home", List.of()),
+                        new AriaNode("link", "Docs", List.of())
+                )),
+                new AriaNode("button", "Sign in", List.of())
+        ));
+
+        var result = AriaSnapshotHelper.match(baseline, actual);
+
+        Assert.assertTrue(result.matched());
+    }
+
+    @Test(description = "match should pass when the baseline name is blank, matching any actual name")
+    public void matchShouldTreatBlankBaselineNameAsWildcard() {
+        String baseline = AriaSnapshotHelper.serialize(List.of(new AriaNode("heading", "", List.of())));
+        String actual = AriaSnapshotHelper.serialize(List.of(new AriaNode("heading", "Anything", List.of())));
+
+        var result = AriaSnapshotHelper.match(baseline, actual);
+
+        Assert.assertTrue(result.matched());
+    }
+
+    @Test(description = "match should fail with a readable diff when a baseline node is missing from the actual snapshot")
+    public void matchShouldFailWhenBaselineNodeIsMissing() {
+        String baseline = AriaSnapshotHelper.serialize(List.of(new AriaNode("button", "Sign in", List.of())));
+        String actual = AriaSnapshotHelper.serialize(List.of(new AriaNode("link", "Home", List.of())));
+
+        var result = AriaSnapshotHelper.match(baseline, actual);
+
+        Assert.assertFalse(result.matched());
+        Assert.assertTrue(result.diffMessage().contains("button \"Sign in\""));
+    }
+
+    @Test(description = "match should fail on a role mismatch even when the name matches")
+    public void matchShouldFailOnRoleMismatch() {
+        String baseline = AriaSnapshotHelper.serialize(List.of(new AriaNode("button", "Home", List.of())));
+        String actual = AriaSnapshotHelper.serialize(List.of(new AriaNode("link", "Home", List.of())));
+
+        var result = AriaSnapshotHelper.match(baseline, actual);
+
+        Assert.assertFalse(result.matched());
+    }
+
+    @Test(description = "match should fail when a required child node is absent from the matched actual node's children")
+    public void matchShouldFailWhenChildNodeIsMissing() {
+        String baseline = AriaSnapshotHelper.serialize(List.of(
+                new AriaNode("navigation", "", List.of(new AriaNode("link", "Docs", List.of())))
+        ));
+        String actual = AriaSnapshotHelper.serialize(List.of(
+                new AriaNode("navigation", "", List.of(new AriaNode("link", "Home", List.of())))
+        ));
+
+        var result = AriaSnapshotHelper.match(baseline, actual);
+
+        Assert.assertFalse(result.matched());
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsScreenshotBaselineUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsScreenshotBaselineUnitTest.java
@@ -1,0 +1,159 @@
+package com.shaft.gui.internal.image;
+
+import com.shaft.cli.FileActions;
+import com.shaft.driver.SHAFT;
+import com.shaft.properties.internal.Properties;
+import org.openqa.selenium.By;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Coverage-focused unit tests for {@link ImageProcessingActions#compareScreenshotAgainstBaseline}, covering
+ * the {@code matchesScreenshot()} baseline auto-create-on-first-run and {@code -Dshaft.updateSnapshots} lifecycle.
+ */
+public class ImageProcessingActionsScreenshotBaselineUnitTest {
+    private static final FileActions FILE_ACTIONS = FileActions.getInstance(true);
+    private static final Path TEMP_ROOT = Path.of("target", "temp", "imageProcessingActionsScreenshotBaselineUnitTest");
+
+    private Path tempDir;
+
+    @BeforeMethod(alwaysRun = true)
+    public void beforeMethod(Method method) throws Exception {
+        tempDir = TEMP_ROOT.resolve(method.getName());
+        FILE_ACTIONS.deleteFolder(tempDir.toString());
+        FILE_ACTIONS.createFolder(tempDir.toString());
+        setAiFolderPath(tempDir.toAbsolutePath() + File.separator);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void afterMethod() throws Exception {
+        setAiFolderPath(null);
+        VisualProcessingProviderRegistry.resetProviderForTesting();
+        if (tempDir != null) {
+            FILE_ACTIONS.deleteFolder(tempDir.toString());
+        }
+        Properties.clearForCurrentThread();
+    }
+
+    @Test
+    public void compareScreenshotAgainstBaselineByLocatorShouldCreateMissingBaselineAndPass() {
+        By locator = By.id("new-screenshot-baseline");
+        byte[] actual = png(Color.PINK);
+
+        var result = ImageProcessingActions.compareScreenshotAgainstBaseline(locator, actual, null, null, null);
+
+        String hashed = ImageProcessingActions.formatElementLocatorToImagePath(locator);
+        Assert.assertTrue(result.matched());
+        Assert.assertTrue(FILE_ACTIONS.doesFileExist(tempDir.resolve(hashed + ".png").toString()));
+        Assert.assertEquals(FILE_ACTIONS.readFileAsByteArray(tempDir.resolve(hashed + ".png").toString()), actual);
+    }
+
+    @Test
+    public void compareScreenshotAgainstBaselineByKeyShouldCreateMissingBaselineAndPass() {
+        String baselineKey = "page_new-baseline";
+        byte[] actual = png(Color.CYAN);
+
+        var result = ImageProcessingActions.compareScreenshotAgainstBaseline(baselineKey, actual, null, null, null);
+
+        String hashed = ImageProcessingActions.formatElementLocatorToImagePath(baselineKey);
+        Assert.assertTrue(result.matched());
+        Assert.assertTrue(FILE_ACTIONS.doesFileExist(tempDir.resolve(hashed + ".png").toString()));
+    }
+
+    @Test
+    public void updateSnapshotsShouldOverwriteExistingBaselineAndPass() {
+        By locator = By.id("existing-baseline-to-update");
+        String hashed = ImageProcessingActions.formatElementLocatorToImagePath(locator);
+        byte[] oldBaseline = png(Color.GRAY);
+        byte[] newScreenshot = png(Color.ORANGE);
+        FILE_ACTIONS.writeToFile(tempDir.resolve(hashed + ".png").toString(), oldBaseline);
+        SHAFT.Properties.visuals.set().updateSnapshots(true);
+
+        var result = ImageProcessingActions.compareScreenshotAgainstBaseline(locator, newScreenshot, null, null, null);
+
+        Assert.assertTrue(result.matched());
+        Assert.assertEquals(FILE_ACTIONS.readFileAsByteArray(tempDir.resolve(hashed + ".png").toString()), newScreenshot);
+    }
+
+    @Test
+    public void existingBaselineShouldDelegateToProviderAndPersistDiffImageOnMismatch() {
+        By locator = By.id("existing-baseline-mismatch");
+        String hashed = ImageProcessingActions.formatElementLocatorToImagePath(locator);
+        byte[] baseline = png(Color.GREEN);
+        byte[] actual = png(Color.RED);
+        byte[] diffImage = png(Color.MAGENTA);
+        FILE_ACTIONS.writeToFile(tempDir.resolve(hashed + ".png").toString(), baseline);
+
+        VisualProcessingProvider provider = mock(VisualProcessingProvider.class);
+        when(provider.compareScreenshotAgainstBaseline(any(), any(), any(), any(), any()))
+                .thenReturn(new VisualProcessingProvider.ScreenshotComparisonResult(false, diffImage, 42, 0.5));
+        VisualProcessingProviderRegistry.setProviderForTesting(provider);
+
+        var result = ImageProcessingActions.compareScreenshotAgainstBaseline(locator, actual, null, 10, null);
+
+        Assert.assertFalse(result.matched());
+        Assert.assertEquals(result.diffPixels(), 42);
+        Assert.assertEquals(FILE_ACTIONS.readFileAsByteArray(tempDir.resolve(hashed + "_diff.png").toString()), diffImage);
+    }
+
+    @Test
+    public void existingBaselineMatchShouldNotWriteDiffImage() {
+        By locator = By.id("existing-baseline-match");
+        String hashed = ImageProcessingActions.formatElementLocatorToImagePath(locator);
+        byte[] baseline = png(Color.GREEN);
+        byte[] actual = png(Color.GREEN);
+        FILE_ACTIONS.writeToFile(tempDir.resolve(hashed + ".png").toString(), baseline);
+
+        VisualProcessingProvider provider = mock(VisualProcessingProvider.class);
+        when(provider.compareScreenshotAgainstBaseline(any(), any(), any(), any(), any()))
+                .thenReturn(new VisualProcessingProvider.ScreenshotComparisonResult(true, new byte[0], 0, 0.0));
+        VisualProcessingProviderRegistry.setProviderForTesting(provider);
+
+        var result = ImageProcessingActions.compareScreenshotAgainstBaseline(locator, actual, null, null, null);
+
+        Assert.assertTrue(result.matched());
+        Assert.assertFalse(FILE_ACTIONS.doesFileExist(tempDir.resolve(hashed + "_diff.png").toString()));
+    }
+
+    private static byte[] png(Color color) {
+        BufferedImage image = new BufferedImage(6, 6, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        graphics.setColor(color);
+        graphics.fillRect(0, 0, 6, 6);
+        graphics.dispose();
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try {
+            javax.imageio.ImageIO.write(image, "png", output);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+        return output.toByteArray();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void setAiFolderPath(String value) throws Exception {
+        Field aiFolderPathField = ImageProcessingActions.class.getDeclaredField("aiFolderPath");
+        aiFolderPathField.setAccessible(true);
+        ThreadLocal<String> aiFolderPath = (ThreadLocal<String>) aiFolderPathField.get(null);
+        if (value == null) {
+            aiFolderPath.remove();
+        } else {
+            aiFolderPath.set(value);
+        }
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/validation/internal/VisualValidationsBuilderUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/validation/internal/VisualValidationsBuilderUnitTest.java
@@ -1,0 +1,79 @@
+package com.shaft.validation.internal;
+
+import com.shaft.validation.ValidationEnums;
+import org.openqa.selenium.By;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+/**
+ * Coverage-focused unit tests for {@link VisualValidationsBuilder} wiring from both the element-level
+ * and page-level {@code matchesScreenshot()} entry points. These tests exercise builder configuration
+ * paths without requiring a live browser session; end-to-end baseline lifecycle behavior is covered by
+ * {@code ImageProcessingActionsScreenshotBaselineUnitTest}.
+ */
+public class VisualValidationsBuilderUnitTest {
+    private static final By SAMPLE_LOCATOR = By.id("sample");
+
+    @AfterMethod(alwaysRun = true)
+    public void resetState() {
+        ValidationsHelper.resetVerificationStateAfterFailing();
+    }
+
+    @Test(description = "element-level matchesScreenshot() should return an unexecuted builder seeded with the element target")
+    public void elementMatchesScreenshotShouldSeedBuilderWithoutExecuting() {
+        WebDriverElementValidationsBuilder elementBuilder = new WebDriverElementValidationsBuilder(
+                ValidationEnums.ValidationCategory.HARD_ASSERT, null, SAMPLE_LOCATOR, new StringBuilder("the element "));
+
+        VisualValidationsBuilder visualBuilder = elementBuilder.matchesScreenshot();
+
+        Assert.assertFalse(visualBuilder.pageLevel);
+        Assert.assertEquals(visualBuilder.locator, SAMPLE_LOCATOR);
+        Assert.assertEquals(visualBuilder.validationCategory, ValidationEnums.ValidationCategory.HARD_ASSERT);
+        Assert.assertTrue(elementBuilder.reportMessageBuilder.toString().contains("matches the visual regression baseline screenshot."));
+    }
+
+    @Test(description = "page-level matchesScreenshot() should seed a page-level builder with a null locator")
+    public void browserMatchesScreenshotShouldSeedPageLevelBuilder() {
+        WebDriverBrowserValidationsBuilder browserBuilder = new WebDriverBrowserValidationsBuilder(
+                ValidationEnums.ValidationCategory.HARD_ASSERT, null, new StringBuilder("the browser "));
+
+        VisualValidationsBuilder visualBuilder = browserBuilder.matchesScreenshot();
+
+        Assert.assertTrue(visualBuilder.pageLevel);
+        Assert.assertNull(visualBuilder.locator);
+        Assert.assertTrue(browserBuilder.reportMessageBuilder.toString().contains("page matches the visual regression baseline screenshot."));
+    }
+
+    @Test(description = "maxDiffPixels/maxDiffPixelRatio/mask options should populate builder fields without executing")
+    public void optionsShouldPopulateFieldsWithoutExecuting() {
+        WebDriverElementValidationsBuilder elementBuilder = new WebDriverElementValidationsBuilder(
+                ValidationEnums.ValidationCategory.HARD_ASSERT, null, SAMPLE_LOCATOR, new StringBuilder());
+        By mask = By.id("mask");
+
+        VisualValidationsBuilder visualBuilder = elementBuilder.matchesScreenshot()
+                .maxDiffPixels(100)
+                .maxDiffPixelRatio(0.05)
+                .mask(mask);
+
+        Assert.assertEquals(visualBuilder.maxDiffPixels, Integer.valueOf(100));
+        Assert.assertEquals(visualBuilder.maxDiffPixelRatio, Double.valueOf(0.05));
+        Assert.assertEquals(visualBuilder.maskLocators, List.of(mask));
+    }
+
+    @Test(description = "mask() should accumulate locators across multiple chained calls")
+    public void maskShouldAccumulateLocatorsAcrossChainedCalls() {
+        WebDriverElementValidationsBuilder elementBuilder = new WebDriverElementValidationsBuilder(
+                ValidationEnums.ValidationCategory.HARD_ASSERT, null, SAMPLE_LOCATOR, new StringBuilder());
+        By firstMask = By.id("mask-1");
+        By secondMask = By.id("mask-2");
+
+        VisualValidationsBuilder visualBuilder = elementBuilder.matchesScreenshot()
+                .mask(firstMask)
+                .mask(secondMask);
+
+        Assert.assertEquals(visualBuilder.maskLocators, List.of(firstMask, secondMask));
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/validation/internal/WebDriverElementValidationsBuilderAriaSnapshotUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/validation/internal/WebDriverElementValidationsBuilderAriaSnapshotUnitTest.java
@@ -1,0 +1,80 @@
+package com.shaft.validation.internal;
+
+import com.shaft.cli.FileActions;
+import com.shaft.driver.SHAFT;
+import com.shaft.properties.internal.Properties;
+import com.shaft.validation.ValidationEnums;
+import org.mockito.Mockito;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Coverage-focused unit tests for {@code matchesAriaSnapshot()} wiring from
+ * {@link WebDriverElementValidationsBuilder} through to the baseline lifecycle.
+ */
+public class WebDriverElementValidationsBuilderAriaSnapshotUnitTest {
+    private static final By SAMPLE_LOCATOR = By.id("sample");
+
+    @AfterMethod(alwaysRun = true)
+    public void resetState() {
+        ValidationsHelper.resetVerificationStateAfterFailing();
+        Properties.clearForCurrentThread();
+    }
+
+    @Test(description = "matchesAriaSnapshot() should configure validation state before execution")
+    public void matchesAriaSnapshotShouldConfigureStateBeforeExecution() {
+        WebDriverElementValidationsBuilder builder = new WebDriverElementValidationsBuilder(
+                ValidationEnums.ValidationCategory.HARD_ASSERT, null, SAMPLE_LOCATOR, new StringBuilder("the element "));
+
+        try {
+            builder.matchesAriaSnapshot("login-form");
+            Assert.fail("Expected invocation to fail without a live WebDriver session.");
+        } catch (Throwable ignored) {
+            // expected in unit context without a browser session
+        }
+
+        Assert.assertEquals(builder.validationMethod, "elementAriaSnapshotMatches");
+        Assert.assertEquals(builder.ariaSnapshotFileName, "login-form");
+        Assert.assertEquals(builder.validationType, ValidationEnums.ValidationType.POSITIVE);
+        Assert.assertTrue(builder.reportMessageBuilder.toString().contains("matches the aria snapshot \"login-form\"."));
+    }
+
+    @Test(description = "first run should save the captured aria snapshot as the new baseline and pass")
+    public void matchesAriaSnapshotShouldCreateMissingBaselineAndPass() {
+        WebDriver driver = mock(WebDriver.class, Mockito.withSettings().extraInterfaces(JavascriptExecutor.class));
+        WebElement element = mock(WebElement.class);
+        when(driver.findElement(SAMPLE_LOCATOR)).thenReturn(element);
+        when(((JavascriptExecutor) driver).executeScript(anyString(), any())).thenReturn(List.of(
+                Map.of("role", "button", "name", "Sign in", "children", List.of())
+        ));
+
+        String baselineFile = "matchesAriaSnapshotShouldCreateMissingBaselineAndPass_" + System.identityHashCode(this);
+        String baselinePath = SHAFT.Properties.paths.ariaSnapshot() + baselineFile + ".yaml";
+        FileActions.getInstance(true).deleteFile(baselinePath);
+
+        try {
+            WebDriverElementValidationsBuilder builder = new WebDriverElementValidationsBuilder(
+                    ValidationEnums.ValidationCategory.HARD_ASSERT, driver, SAMPLE_LOCATOR, new StringBuilder("the element "));
+
+            builder.matchesAriaSnapshot(baselineFile);
+
+            Assert.assertTrue(FileActions.getInstance(true).doesFileExist(baselinePath));
+            Assert.assertTrue(FileActions.getInstance(true).readFile(baselinePath).contains("button \"Sign in\""));
+        } finally {
+            FileActions.getInstance(true).deleteFile(baselinePath);
+        }
+    }
+}

--- a/shaft-engine/src/test/java/testPackage/unitTests/AccessibilityActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/AccessibilityActionsCoverageUnitTest.java
@@ -7,6 +7,7 @@ import com.shaft.gui.driver.BrowserActionsContract;
 import com.shaft.properties.internal.Properties;
 import com.shaft.validation.accessibility.AccessibilityActions;
 import com.shaft.validation.accessibility.AccessibilityHelper;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.openqa.selenium.WebDriver;
@@ -123,6 +124,40 @@ public class AccessibilityActionsCoverageUnitTest {
             Assert.assertSame(accessibilityActions.verifyNoCriticalViolations("Safe"), accessibilityActions);
             Assert.assertSame(accessibilityActions.assertIsAccessible(), accessibilityActions);
             Assert.assertSame(accessibilityActions.verifyIsAccessible(), accessibilityActions);
+        }
+    }
+
+    @Test
+    public void shouldScopeTagFilteredAccessibilityAssertionsToRequestedWcagTags() {
+        AccessibilityHelper.AccessibilityResult accessibleResult = resultWithViolations(List.of(), 100.0);
+
+        try (MockedStatic<AccessibilityHelper> helper = Mockito.mockStatic(AccessibilityHelper.class)) {
+            helper.when(() -> AccessibilityHelper.analyzePageAccessibilityAndSave(any(WebDriver.class), Mockito.eq("CurrentPage"),
+                            any(AccessibilityHelper.AccessibilityConfig.class), Mockito.eq(false)))
+                    .thenReturn(accessibleResult);
+
+            Assert.assertSame(accessibilityActions.assertIsAccessible("wcag2a", "wcag2aa"), accessibilityActions);
+            Assert.assertSame(accessibilityActions.verifyIsAccessible("wcag2a", "wcag2aa"), accessibilityActions);
+
+            ArgumentCaptor<AccessibilityHelper.AccessibilityConfig> configCaptor =
+                    ArgumentCaptor.forClass(AccessibilityHelper.AccessibilityConfig.class);
+            helper.verify(() -> AccessibilityHelper.analyzePageAccessibilityAndSave(any(WebDriver.class), Mockito.eq("CurrentPage"),
+                    configCaptor.capture(), Mockito.eq(false)), times(2));
+            configCaptor.getAllValues().forEach(config ->
+                    Assert.assertEquals(config.getTags(), List.of("wcag2a", "wcag2aa")));
+        }
+    }
+
+    @Test
+    public void shouldFailTagFilteredAssertionWhenViolationsExistForRequestedTags() {
+        AccessibilityHelper.AccessibilityResult violatingResult = resultWithViolations(List.of(mockedRule("color-contrast", "critical")), 40.0);
+
+        try (MockedStatic<AccessibilityHelper> helper = Mockito.mockStatic(AccessibilityHelper.class)) {
+            helper.when(() -> AccessibilityHelper.analyzePageAccessibilityAndSave(any(WebDriver.class), Mockito.eq("CurrentPage"),
+                            any(AccessibilityHelper.AccessibilityConfig.class), Mockito.eq(false)))
+                    .thenReturn(violatingResult);
+
+            Assert.assertThrows(AssertionError.class, () -> accessibilityActions.assertIsAccessible("wcag2a"));
         }
     }
 

--- a/shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java
+++ b/shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java
@@ -427,6 +427,79 @@ public class OpenCvVisualProcessingProvider implements VisualProcessingProvider 
     }
 
     @Override
+    public ScreenshotComparisonResult compareScreenshotAgainstBaseline(byte[] baselineImage, byte[] actualImage,
+                                                                        List<int[]> maskRects, Integer maxDiffPixels,
+                                                                        Double maxDiffPixelRatio) {
+        Mat baseline = Imgcodecs.imdecode(new MatOfByte(baselineImage), Imgcodecs.IMREAD_COLOR);
+        Mat actual = Imgcodecs.imdecode(new MatOfByte(actualImage), Imgcodecs.IMREAD_COLOR);
+        if (baseline.empty() || actual.empty()) {
+            return new ScreenshotComparisonResult(false, new byte[0], Long.MAX_VALUE, 1.0);
+        }
+        if (baseline.rows() != actual.rows() || baseline.cols() != actual.cols()) {
+            long totalPixels = (long) baseline.rows() * baseline.cols();
+            return new ScreenshotComparisonResult(false, encodePng(actual), totalPixels, 1.0);
+        }
+
+        applyMask(baseline, maskRects);
+        applyMask(actual, maskRects);
+
+        Mat diff = new Mat();
+        Core.absdiff(baseline, actual, diff);
+        Mat grayDiff = new Mat();
+        Imgproc.cvtColor(diff, grayDiff, Imgproc.COLOR_BGR2GRAY);
+        Mat thresholded = new Mat();
+        Imgproc.threshold(grayDiff, thresholded, 30, 255, Imgproc.THRESH_BINARY);
+
+        long diffPixels = Core.countNonZero(thresholded);
+        long totalPixels = (long) baseline.rows() * baseline.cols();
+        double diffRatio = totalPixels == 0 ? 0.0 : (double) diffPixels / totalPixels;
+
+        long allowedDiffPixels;
+        if (maxDiffPixels != null) {
+            allowedDiffPixels = maxDiffPixels;
+        } else if (maxDiffPixelRatio != null) {
+            allowedDiffPixels = Math.round(maxDiffPixelRatio * totalPixels);
+        } else {
+            allowedDiffPixels = 0;
+        }
+        boolean matched = diffPixels <= allowedDiffPixels;
+
+        byte[] diffImageBytes = new byte[0];
+        if (!matched) {
+            Mat highlighted = actual.clone();
+            highlighted.setTo(new Scalar(67, 176, 42), thresholded); // selenium-green highlight on differing pixels
+            diffImageBytes = encodePng(highlighted);
+        }
+
+        return new ScreenshotComparisonResult(matched, diffImageBytes, diffPixels, diffRatio);
+    }
+
+    private static void applyMask(Mat image, List<int[]> maskRects) {
+        if (maskRects == null) {
+            return;
+        }
+        for (int[] rect : maskRects) {
+            if (rect == null || rect.length < 4) {
+                continue;
+            }
+            int x = Math.max(0, rect[0]);
+            int y = Math.max(0, rect[1]);
+            int width = Math.min(rect[2], image.cols() - x);
+            int height = Math.min(rect[3], image.rows() - y);
+            if (width <= 0 || height <= 0) {
+                continue;
+            }
+            Imgproc.rectangle(image, new Point(x, y), new Point(x + width, y + height), new Scalar(0, 0, 0), -1);
+        }
+    }
+
+    private static byte[] encodePng(Mat mat) {
+        MatOfByte buffer = new MatOfByte();
+        Imgcodecs.imencode(".png", mat, buffer);
+        return buffer.toArray();
+    }
+
+    @Override
     public void load() {
         var libName = "";
         try {

--- a/shaft-visual/src/test/java/com/shaft/gui/internal/image/OpenCvScreenshotDiffTest.java
+++ b/shaft-visual/src/test/java/com/shaft/gui/internal/image/OpenCvScreenshotDiffTest.java
@@ -1,0 +1,120 @@
+package com.shaft.gui.internal.image;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+public class OpenCvScreenshotDiffTest {
+    private final OpenCvVisualProcessingProvider provider = new OpenCvVisualProcessingProvider();
+
+    @BeforeClass(alwaysRun = true)
+    public void loadOpenCvNativeLibrary() {
+        // Engine startup loads the native lib asynchronously (see PropertiesHelper); force a
+        // synchronous load here so this class is deterministic when run in isolation.
+        provider.load();
+    }
+
+    @Test
+    public void identicalImagesShouldMatchWithZeroDiffPixels() {
+        byte[] baseline = png(20, 20, Color.BLUE, null);
+        byte[] actual = png(20, 20, Color.BLUE, null);
+
+        var result = provider.compareScreenshotAgainstBaseline(baseline, actual, null, null, null);
+
+        Assert.assertTrue(result.matched());
+        Assert.assertEquals(result.diffPixels(), 0);
+        Assert.assertEquals(result.diffRatio(), 0.0, 0.0001);
+        Assert.assertEquals(result.diffImage().length, 0);
+    }
+
+    @Test
+    public void changedPixelsWithinMaxDiffPixelsBudgetShouldMatch() {
+        byte[] baseline = png(10, 10, Color.WHITE, null);
+        byte[] actual = png(10, 10, Color.WHITE, new int[]{0, 0, 2, 2}); // 4 changed pixels
+
+        var withinBudget = provider.compareScreenshotAgainstBaseline(baseline, actual, null, 4, null);
+        var overBudget = provider.compareScreenshotAgainstBaseline(baseline, actual, null, 3, null);
+
+        Assert.assertTrue(withinBudget.matched());
+        Assert.assertEquals(withinBudget.diffPixels(), 4);
+
+        Assert.assertFalse(overBudget.matched());
+        Assert.assertEquals(overBudget.diffPixels(), 4);
+        Assert.assertTrue(overBudget.diffImage().length > 0);
+    }
+
+    @Test
+    public void changedPixelsWithinMaxDiffPixelRatioBudgetShouldMatch() {
+        byte[] baseline = png(10, 10, Color.WHITE, null); // 100 total pixels
+        byte[] actual = png(10, 10, Color.WHITE, new int[]{0, 0, 2, 2}); // 4 changed pixels -> ratio 0.04
+
+        var withinBudget = provider.compareScreenshotAgainstBaseline(baseline, actual, null, null, 0.04);
+        var overBudget = provider.compareScreenshotAgainstBaseline(baseline, actual, null, null, 0.03);
+
+        Assert.assertTrue(withinBudget.matched());
+        Assert.assertEquals(withinBudget.diffRatio(), 0.04, 0.0001);
+
+        Assert.assertFalse(overBudget.matched());
+    }
+
+    @Test
+    public void maskedRegionShouldBeIgnoredDuringComparison() {
+        byte[] baseline = png(10, 10, Color.WHITE, null);
+        byte[] actual = png(10, 10, Color.WHITE, new int[]{0, 0, 4, 4}); // 16 changed pixels, all within the mask
+
+        var result = provider.compareScreenshotAgainstBaseline(baseline, actual, List.of(new int[]{0, 0, 4, 4}), null, null);
+
+        Assert.assertTrue(result.matched());
+        Assert.assertEquals(result.diffPixels(), 0);
+    }
+
+    @Test
+    public void sizeMismatchShouldFailWithFullFrameDiff() {
+        byte[] baseline = png(10, 10, Color.WHITE, null);
+        byte[] actual = png(12, 12, Color.WHITE, null);
+
+        var result = provider.compareScreenshotAgainstBaseline(baseline, actual, null, null, null);
+
+        Assert.assertFalse(result.matched());
+        Assert.assertEquals(result.diffPixels(), 100);
+        Assert.assertEquals(result.diffRatio(), 1.0, 0.0001);
+        Assert.assertTrue(result.diffImage().length > 0);
+    }
+
+    @Test
+    public void defaultZeroBudgetShouldFailOnAnyDifference() {
+        byte[] baseline = png(10, 10, Color.WHITE, null);
+        byte[] actual = png(10, 10, Color.WHITE, new int[]{5, 5, 1, 1}); // 1 changed pixel
+
+        var result = provider.compareScreenshotAgainstBaseline(baseline, actual, null, null, null);
+
+        Assert.assertFalse(result.matched());
+        Assert.assertEquals(result.diffPixels(), 1);
+    }
+
+    private static byte[] png(int width, int height, Color background, int[] redRect) {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        graphics.setColor(background);
+        graphics.fillRect(0, 0, width, height);
+        if (redRect != null) {
+            graphics.setColor(Color.RED);
+            graphics.fillRect(redRect[0], redRect[1], redRect[2], redRect[3]);
+        }
+        graphics.dispose();
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try {
+            ImageIO.write(image, "png", output);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+        return output.toByteArray();
+    }
+}


### PR DESCRIPTION
## Summary

Implements the core `shaft-engine`/`shaft-visual` capability from #3349, scoped to **web (Selenium + Playwright)** per the #3347→#3380 gap-closing precedent: ship the engine capability now, defer recorder/MCP/doctor/IntelliJ surfacing to a follow-up issue.

Research found this was not greenfield: axe-core a11y checking and image-diff/baseline machinery (including an existing Allure `application/vnd.allure.image.diff` expected/actual/diff renderer) already existed in the repo. This PR is mostly *wiring existing machinery into new fluent APIs* rather than building from scratch.

### D6 — aria snapshots + tag-filtered accessibility audit
- `driver.element().ariaSnapshot(locator)` — captures an accessible-name-tree YAML snapshot via JS eval (`AriaSnapshotHelper`), reusing the same `executeScript`/`evaluate` pattern axe-core already uses in this repo. A pragmatic subset of ARIA role/name resolution, not full ARIA AAM spec compliance.
- `assertThat(locator).matchesAriaSnapshot(fileName)` — partial-subset baseline comparison (every baseline node must appear in the actual snapshot at the same depth, in order; extra actual siblings/children are allowed), auto-creating baselines under `src/test/resources/aria/` (configurable via `SHAFT.Properties.paths.ariaSnapshot()`).
- `AccessibilityActions.assertIsAccessible/verifyIsAccessible(String... wcagTags)` — exposes the already-working axe-core pipeline as a tag-filtered assertion (e.g. `driver.accessibility().assertIsAccessible("wcag2a", "wcag2aa")`).

### D7 — visual regression baselines
- `assertThat(locator).matchesScreenshot()` and `assertThat().browser().matchesScreenshot()` via a new `VisualValidationsBuilder` (Selenium + Playwright), with fluent `.maxDiffPixels(int)`, `.maxDiffPixelRatio(double)`, `.mask(By...)` / `.mask(Locator...)` options.
- `-Dshaft.updateSnapshots=true` regenerates baselines instead of comparing.
- `OpenCvVisualProcessingProvider` gains a real pixel-diff comparison (`compareScreenshotAgainstBaseline`) — the existing OpenCV path was template-matching only; only the Shutterbug engine produced a diff image before this change. No new image-diff library.
- Reuses the existing Allure `application/vnd.allure.image.diff` expected/actual/diff attachment for both new assertion types.

### Incidental fix
While wiring `ariaSnapshot.js` as a classpath resource, found that `axe.min.js` (and now `ariaSnapshot.js`) were **never actually copied into `target/classes` or the packaged jar** — `shaft-engine`'s resources `<includes>` filter only listed `junit-platform.properties`, silently breaking `AccessibilityHelper.readAxeScript()` for any real consumer of the published artifact (reproduced identically on `main` via `git stash` before touching anything). Fixed with a 2-line `pom.xml` include-list addition; this also fixed 6 previously-broken `AccessibilityHelperCoverageUnitTest` tests when run in isolation.

### Also found, filed separately (not fixed here — unrelated pre-existing flakiness)
3 `ImageProcessingActionsCoverageUnitTest` OpenCV template-match tests fail in isolation on `main` itself (confirmed via `git stash`), unrelated to this PR's scope: [#3382](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/3382).

## Deferred to a follow-up issue

- Mobile aria-tree assertion from Appium page-source XML (native path, needs emulator infra to verify).
- `VerificationKind.ARIA_SNAPSHOT_MATCHES` + `shaft-capture` recorder-toolbar wiring.
- MCP tools `browser_aria_snapshot` / `browser_accessibility_audit`.
- Accessibility findings surfaced in `shaft-doctor` (no SPI/extension point exists today).
- `driver.assertThat().page().isAccessible(wcagTags)` as a new fluent `page()` chain surface (the tag-filtered assert on the existing `accessibility()` facade satisfies the acceptance criterion without new API surface).
- IntelliJ "Visual Baselines" Accept/Reject Swing panel.
- Aria format richness (`[level=n]` attributes, `/regex/` name matching).

## Test plan

All new tests are pure-JVM (no live browser), matching this repo's existing Mockito-based coverage-test conventions:

- [x] `AriaSnapshotHelperUnitTest` (9 tests) — serialize/parse round-trip, partial-subset match semantics
- [x] `OpenCvScreenshotDiffTest` (6 tests) — pixel-diff, masks, maxDiffPixels/Ratio budgets
- [x] `VisualValidationsBuilderUnitTest` (4 tests) — builder field wiring
- [x] `ImageProcessingActionsScreenshotBaselineUnitTest` (5 tests) — baseline auto-create, `updateSnapshots`, provider delegation
- [x] `WebDriverElementValidationsBuilderAriaSnapshotUnitTest` (2 tests) — builder wiring + first-run baseline creation
- [x] `AccessibilityActionsCoverageUnitTest` (+2 tests) — tag-filtered assert/verify wiring
- [x] `mvn -pl shaft-engine,shaft-visual -am compile` / `-am test-compile` — clean
- [x] All 40 new/touched tests pass in scoped runs (`mvn -pl shaft-engine,shaft-visual -am test -Dtest=...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)