### PR TITLE
Fix recorder overlay toolbar misclicks from bottom-anchored panel growth

### DIFF
--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -1034,7 +1034,10 @@
         right: 16px;
         bottom: 16px;
         width: min(380px, calc(100vw - 32px));
-        max-height: min(520px, calc(100vh - 32px));
+        /* Fixed height (not max-height): the panel is bottom-anchored, so a shrink-to-fit
+           height lets every appended action row push the header/toolbar buttons upward on
+           screen, which can make a click land on stale coordinates right as a row appears. */
+        height: min(520px, calc(100vh - 32px));
         z-index: 2147483647;
         display: flex;
         flex-direction: column;
@@ -1124,6 +1127,8 @@
         background: rgba(197, 48, 48, .12);
       }
       #shaft-capture-actions {
+        flex: 1 1 auto;
+        min-height: 0;
         overflow-y: auto;
         overflow-x: hidden;
         padding: 8px 10px 10px;

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.StaleElementReferenceException;
@@ -358,6 +359,73 @@ class ManagedCaptureRecorderBrowserTest {
         assertFalse(title.negated(), "The browser assertion was not negated.");
         assertTrue(title.expected() != null,
                 "The browser assertion must persist its expected value reference.");
+    }
+
+    /**
+     * Regression for issue #3378: the recorder overlay toolbar ({@code #shaft-capture-ui header})
+     * used to be bottom-anchored with a content-sized height, so every appended action row pushed
+     * the toolbar -- and the {@code #shaft-capture-assert} button inside it -- upward on screen. A
+     * click dispatched right as a row was appended could then land on stale coordinates and
+     * silently miss. Asserts the assert button's viewport position is unchanged as the recorded
+     * action list grows, which only holds when the panel has a fixed height and the action list is
+     * the flexible/scrolling region that absorbs growth.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"chrome", "edge"})
+    void overlayToolbarStaysAnchoredWhileActionListGrows(
+            String browserName,
+            @TempDir Path temp) throws Exception {
+        HttpServer server = localFixture();
+        Path output = temp.resolve(browserName + "-anchor.json");
+        ManagedCaptureRecorder recorder = new ManagedCaptureRecorder(new CaptureStartRequest(
+                "http://127.0.0.1:" + server.getAddress().getPort() + "/",
+                CaptureBrowser.parse(browserName),
+                output,
+                temp.resolve(browserName + "-anchor-runtime"),
+                true));
+        try {
+            recorder.start();
+            WebDriver driver = recorder.driverForTesting();
+            JavascriptExecutor js = (JavascriptExecutor) driver;
+            waitFor(() -> elementPresent(driver, By.id("shaft-capture-assert")));
+
+            // Let the initial "Open ..." breadcrumb settle so the row count is deterministic.
+            waitFor(() -> actionRowCount(js) >= 1);
+            double baselineTop = assertButtonTop(js);
+            long baselineRows = actionRowCount(js);
+
+            // Append two more rows via real user actions, then wait for both to land before
+            // re-measuring; this proves the toolbar's position, not a timing coincidence.
+            driver.findElement(By.id("terms")).click();
+            new Select(driver.findElement(By.id("country"))).selectByVisibleText("Egypt");
+            waitFor(() -> actionRowCount(js) >= baselineRows + 2);
+
+            double grownTop = assertButtonTop(js);
+            recorder.stop(false);
+
+            assertEquals(baselineTop, grownTop, 1.5d,
+                    "The #shaft-capture-assert toolbar button must not move on screen as the "
+                            + "recorded-action list grows; a shifting toolbar lets a click that "
+                            + "started before a row appended land on stale coordinates (#3378).");
+        } finally {
+            if (recorder.status().state() == CaptureStatus.State.ACTIVE) {
+                recorder.interrupt();
+            }
+            server.stop(0);
+        }
+    }
+
+    private static double assertButtonTop(JavascriptExecutor js) {
+        Object value = js.executeScript(
+                "return document.getElementById('shaft-capture-assert').getBoundingClientRect().top;");
+        return ((Number) value).doubleValue();
+    }
+
+    private static long actionRowCount(JavascriptExecutor js) {
+        Object value = js.executeScript(
+                "const l = document.getElementById('shaft-capture-action-list');"
+                        + "return l ? l.childElementCount : 0;");
+        return ((Number) value).longValue();
     }
 
     private static By assertionChoice(String label) {


### PR DESCRIPTION
## Summary

- Fixes the flaky `ManagedCaptureRecorderBrowserTest.overlayGuidedAssertionFlowPersistsVerificationEvents` failure blocking [PR #3378](https://github.com/ShaftHQ/SHAFT_ENGINE/pull/3378)'s `release-candidate` CI job ([run](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/28936539342/job/85848277913)).
- Root cause: `#shaft-capture-ui` (the recorder's in-page overlay toolbar) is `position: fixed; bottom: 16px` with a shrink-to-fit (`max-height`) column, so every appended recorded-action row grew the panel and pushed its bottom-anchored header — and `#shaft-capture-assert` inside it — upward on screen. A click dispatched right as a row appeared could land on stale coordinates with no exception, which is a real production misclick risk for users of the overlay, not just test flakiness.
- Fix: give the panel a fixed `height` instead of `max-height`, and make `#shaft-capture-actions` the flexible/scrolling region (`flex: 1 1 auto; min-height: 0;`) that absorbs list growth, so the toolbar's screen position is now structurally invariant.
- Added `overlayToolbarStaysAnchoredWhileActionListGrows` (chrome + edge), which drives two real user actions to grow the action list and asserts `#shaft-capture-assert`'s `getBoundingClientRect().top` is unchanged. Verified this test fails deterministically (~137px shift) against the pre-fix CSS and passes cleanly against the fix, in both browsers.

## Test plan
- [x] `mvn -pl shaft-capture test-compile` — compiles cleanly
- [x] `node --check shaft-capture-recorder.js` — template-literal CSS edit is syntactically valid
- [x] `mvn -pl shaft-capture test -DincludeCaptureBrowserE2E -Dtest=ManagedCaptureRecorderBrowserTest#overlayGuidedAssertionFlowPersistsVerificationEvents+overlayToolbarStaysAnchoredWhileActionListGrows` — 4/4 green (chrome + edge, both methods), headless, run locally
- [x] Confirmed the new regression test fails against the unfixed JS (stashed just the CSS change) before restoring the fix
- [ ] This PR alone won't retrigger PR #3378's `release-candidate` job (that workflow only triggers on `pom.xml`/workflow-path changes). Once merged to `main`, it needs syncing into `release/10.3.20260708` via the existing "Merge branch 'main' into release/10.3.20260708" pattern (already used for #3379 and #3381) to turn PR #3378 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)