### PR TITLE
Back off SHAFT Capture polling collector once BiDi is proven healthy

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/collector/BidiActivityGate.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/collector/BidiActivityGate.java
@@ -1,0 +1,53 @@
+package com.shaft.capture.collector;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BooleanSupplier;
+
+/**
+ * Tracks whether a {@link BidiBrowserEventCollector} running alongside a
+ * {@link PollingBrowserEventCollector} has delivered a signal recently, so the polling collector
+ * can skip its own redundant script round-trips while BiDi is proven healthy, and resume full-rate
+ * polling the moment BiDi goes quiet.
+ */
+public final class BidiActivityGate implements BooleanSupplier {
+    private static final Duration DEFAULT_GRACE_PERIOD = Duration.ofSeconds(2);
+    private static final long NEVER = Long.MIN_VALUE;
+
+    private final long gracePeriodNanos;
+    private final AtomicLong lastActivityNanos = new AtomicLong(NEVER);
+
+    /**
+     * Creates a gate using the default two-second grace period.
+     */
+    public BidiActivityGate() {
+        this(DEFAULT_GRACE_PERIOD);
+    }
+
+    /**
+     * Creates a gate with a custom grace period.
+     *
+     * @param gracePeriod how long BiDi activity keeps reporting healthy after the last signal
+     */
+    public BidiActivityGate(Duration gracePeriod) {
+        this.gracePeriodNanos = (gracePeriod == null ? DEFAULT_GRACE_PERIOD : gracePeriod).toNanos();
+    }
+
+    /**
+     * Records that a BiDi collector just delivered a signal.
+     */
+    public void recordActivity() {
+        lastActivityNanos.set(System.nanoTime());
+    }
+
+    /**
+     * Reports whether BiDi has delivered a signal within the grace period.
+     *
+     * @return true while BiDi is proven healthy
+     */
+    @Override
+    public boolean getAsBoolean() {
+        long last = lastActivityNanos.get();
+        return last != NEVER && System.nanoTime() - last <= gracePeriodNanos;
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/collector/PollingBrowserEventCollector.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/collector/PollingBrowserEventCollector.java
@@ -15,6 +15,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
 /**
@@ -29,6 +30,7 @@ public final class PollingBrowserEventCollector implements BrowserEventCollector
     private final String eventEndpoint;
     private final String eventToken;
     private final String stepsEndpoint;
+    private final BooleanSupplier recentBidiActivity;
     private final ObjectMapper mapper = new ObjectMapper();
     private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(runnable -> {
         Thread thread = new Thread(runnable, "shaft-capture-polling");
@@ -109,6 +111,31 @@ public final class PollingBrowserEventCollector implements BrowserEventCollector
             String eventEndpoint,
             String eventToken,
             String stepsEndpoint) {
+        this(driver, reportFallbackWarning, testIdAttributes, eventEndpoint, eventToken, stepsEndpoint,
+                () -> false);
+    }
+
+    /**
+     * Creates a classic WebDriver collector that skips its own redundant script round-trips while
+     * {@code recentBidiActivity} reports that a BiDi collector running alongside it is already
+     * delivering the same signals, and resumes full-rate polling the moment BiDi goes quiet.
+     *
+     * @param driver active driver
+     * @param reportFallbackWarning whether status should report reduced BiDi coverage
+     * @param testIdAttributes locator test-id attributes
+     * @param eventEndpoint optional loopback event endpoint
+     * @param eventToken optional loopback event token
+     * @param stepsEndpoint optional loopback steps query endpoint
+     * @param recentBidiActivity reports true while BiDi is proven healthy
+     */
+    public PollingBrowserEventCollector(
+            WebDriver driver,
+            boolean reportFallbackWarning,
+            List<String> testIdAttributes,
+            String eventEndpoint,
+            String eventToken,
+            String stepsEndpoint,
+            BooleanSupplier recentBidiActivity) {
         if (driver == null) {
             throw new IllegalArgumentException("Capture WebDriver is required.");
         }
@@ -118,6 +145,7 @@ public final class PollingBrowserEventCollector implements BrowserEventCollector
         this.eventEndpoint = eventEndpoint == null ? "" : eventEndpoint;
         this.eventToken = eventToken == null ? "" : eventToken;
         this.stepsEndpoint = stepsEndpoint == null ? "" : stepsEndpoint;
+        this.recentBidiActivity = recentBidiActivity == null ? () -> false : recentBidiActivity;
     }
 
     @Override
@@ -144,26 +172,43 @@ public final class PollingBrowserEventCollector implements BrowserEventCollector
 
     private void poll(Consumer<BrowserSignal> signalConsumer, Consumer<String> warningConsumer) {
         try {
+            // While BiDi is proven healthy, this cycle still walks the same WebDriver-only cursors
+            // (window handles, current URL) so lastWindows/lastUrl never go stale -- otherwise the
+            // moment BiDi goes quiet, resuming full polling would misread the whole gap since the
+            // last real check as new and replay a burst of already-reported window/navigation
+            // signals. It just skips emitting duplicates of what BiDi already delivered, and skips
+            // the executeScript round-trips entirely, since those are this collector's only actual
+            // overhead on the page's renderer.
+            boolean bidiHealthy = recentBidiActivity.getAsBoolean();
+
             Set<String> windows = new LinkedHashSet<>(driver.getWindowHandles());
-            for (String opened : difference(windows, lastWindows)) {
-                signalConsumer.accept(BrowserSignal.generated(
-                        "window_open", opened, Map.of(), Map.of()));
-            }
-            for (String closed : difference(lastWindows, windows)) {
-                signalConsumer.accept(BrowserSignal.generated(
-                        "window_close", closed, Map.of(), Map.of()));
+            if (!bidiHealthy) {
+                for (String opened : difference(windows, lastWindows)) {
+                    signalConsumer.accept(BrowserSignal.generated(
+                            "window_open", opened, Map.of(), Map.of()));
+                }
+                for (String closed : difference(lastWindows, windows)) {
+                    signalConsumer.accept(BrowserSignal.generated(
+                            "window_close", closed, Map.of(), Map.of()));
+                }
             }
             lastWindows = Set.copyOf(windows);
 
             String contextId = driver.getWindowHandle();
             String currentUrl = driver.getCurrentUrl();
             if (!currentUrl.equals(lastUrl)) {
+                if (!bidiHealthy) {
+                    signalConsumer.accept(BrowserSignal.generated(
+                            "navigation",
+                            contextId,
+                            Map.of("url", currentUrl, "title", driver.getTitle()),
+                            Map.of("action", "OPEN")));
+                }
                 lastUrl = currentUrl;
-                signalConsumer.accept(BrowserSignal.generated(
-                        "navigation",
-                        contextId,
-                        Map.of("url", currentUrl, "title", driver.getTitle()),
-                        Map.of("action", "OPEN")));
+            }
+
+            if (bidiHealthy) {
+                return;
             }
 
             JavascriptExecutor javascript = (JavascriptExecutor) driver;

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java
@@ -1,6 +1,7 @@
 package com.shaft.capture.runtime;
 
 import tools.jackson.databind.node.StringNode;
+import com.shaft.capture.collector.BidiActivityGate;
 import com.shaft.capture.collector.BidiBrowserEventCollector;
 import com.shaft.capture.collector.BrowserEventCollector;
 import com.shaft.capture.collector.BrowserSignal;
@@ -49,6 +50,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
 
 /**
  * Owns one SHAFT-managed browser and its deterministic capture pipeline.
@@ -615,19 +617,39 @@ class ManagedCaptureRecorder {
 
     private void startCollector(WebDriver activeDriver) {
         try {
+            BidiActivityGate bidiActivityGate = new BidiActivityGate();
+            BidiBrowserEventCollector bidiCollector = new BidiBrowserEventCollector(
+                    activeDriver,
+                    request.options().testIdAttributes(),
+                    eventSinkStepsEndpoint(),
+                    eventSinkToken());
+            // The polling collector reads bidiActivityGate to back off its own redundant script
+            // round-trips once BiDi is proven healthy; this wrapper is what feeds that gate,
+            // without BidiBrowserEventCollector itself needing to know the polling collector exists.
+            BrowserEventCollector trackedBidiCollector = new BrowserEventCollector() {
+                @Override
+                public void start(Consumer<BrowserSignal> signalConsumer, Consumer<String> warningConsumer) {
+                    bidiCollector.start(signal -> {
+                        bidiActivityGate.recordActivity();
+                        signalConsumer.accept(signal);
+                    }, warningConsumer);
+                }
+
+                @Override
+                public void close() {
+                    bidiCollector.close();
+                }
+            };
             collector = new CompositeBrowserEventCollector(List.of(
-                    new BidiBrowserEventCollector(
-                            activeDriver,
-                            request.options().testIdAttributes(),
-                            eventSinkStepsEndpoint(),
-                            eventSinkToken()),
+                    trackedBidiCollector,
                     new PollingBrowserEventCollector(
                             activeDriver,
                             false,
                             request.options().testIdAttributes(),
                             eventSinkEndpoint(),
                             eventSinkToken(),
-                            eventSinkStepsEndpoint())));
+                            eventSinkStepsEndpoint(),
+                            bidiActivityGate)));
             collector.start(this::acceptSignal, this::warn);
         } catch (RuntimeException exception) {
             if (collector != null) {

--- a/shaft-capture/src/test/java/com/shaft/capture/collector/PollingBrowserEventCollectorBidiBackoffTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/collector/PollingBrowserEventCollectorBidiBackoffTest.java
@@ -105,6 +105,7 @@ class PollingBrowserEventCollectorBidiBackoffTest {
 
         @Override
         public void get(String url) {
+            // Navigation is driven by getCurrentUrl()/getWindowHandles() in this stub, not get().
         }
 
         @Override
@@ -134,10 +135,12 @@ class PollingBrowserEventCollectorBidiBackoffTest {
 
         @Override
         public void close() {
+            // The test closes the collector directly; the driver itself has no session to end.
         }
 
         @Override
         public void quit() {
+            // Same as close(): nothing for this stub to release.
         }
 
         @Override

--- a/shaft-capture/src/test/java/com/shaft/capture/collector/PollingBrowserEventCollectorBidiBackoffTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/collector/PollingBrowserEventCollectorBidiBackoffTest.java
@@ -1,0 +1,163 @@
+package com.shaft.capture.collector;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression for issue #3385: the polling collector used to re-run its executeScript
+ * install/drain round-trips, and re-emit window/navigation signals, on every 100ms tick
+ * regardless of whether a BiDi collector running alongside it was already delivering the same
+ * signals. Asserts it backs off both once the shared {@link BidiActivityGate} reports healthy,
+ * while still tracking window/URL cursors so a later BiDi outage resumes full polling without
+ * replaying a stale catch-up burst for windows BiDi already reported.
+ */
+class PollingBrowserEventCollectorBidiBackoffTest {
+    @Test
+    void backsOffScriptRoundTripsWhileBidiIsHealthyAndResumesCleanlyWhenItGoesQuiet() throws Exception {
+        RecordingDriver driver = new RecordingDriver();
+        BidiActivityGate gate = new BidiActivityGate(Duration.ofMillis(300));
+        List<BrowserSignal> signals = new CopyOnWriteArrayList<>();
+        PollingBrowserEventCollector collector =
+                new PollingBrowserEventCollector(driver, false, List.of(), "", "", "", gate);
+        try {
+            collector.start(signals::add, warning -> { });
+            waitFor(() -> driver.executeScriptCalls.get() >= 2, Duration.ofSeconds(2));
+            int executeScriptCallsBeforeHealthy = driver.executeScriptCalls.get();
+
+            // Simulate a BiDi collector delivering a signal, then a new window opening -- BiDi
+            // would already report this window, so polling must not duplicate it.
+            gate.recordActivity();
+            driver.openWindow("popup-1");
+            Thread.sleep(250);
+
+            assertEquals(executeScriptCallsBeforeHealthy, driver.executeScriptCalls.get(),
+                    "executeScript must not run again while BiDi is proven healthy.");
+            assertTrue(signals.stream().noneMatch(PollingBrowserEventCollectorBidiBackoffTest::isPopupWindowOpen),
+                    "A window_open signal for popup-1 must not be emitted while BiDi is healthy "
+                            + "and already covering it.");
+
+            // Let the gate's grace period lapse so the collector treats BiDi as quiet again.
+            waitFor(() -> driver.executeScriptCalls.get() > executeScriptCallsBeforeHealthy,
+                    Duration.ofSeconds(2));
+
+            assertTrue(signals.stream().noneMatch(PollingBrowserEventCollectorBidiBackoffTest::isPopupWindowOpen),
+                    "Resuming full polling after a BiDi outage must not replay popup-1 as a new "
+                            + "window; its cursor was already tracked while BiDi was healthy.");
+        } finally {
+            collector.close();
+        }
+    }
+
+    private static boolean isPopupWindowOpen(BrowserSignal signal) {
+        return "window_open".equals(signal.kind()) && "popup-1".equals(signal.browsingContextId());
+    }
+
+    private static void waitFor(BooleanSupplier condition, Duration timeout) throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (!condition.getAsBoolean() && System.nanoTime() < deadline) {
+            Thread.sleep(20);
+        }
+        assertTrue(condition.getAsBoolean());
+    }
+
+    /**
+     * Minimal driver stub that counts executeScript/getWindowHandles calls and lets the test
+     * simulate a new window opening mid-poll.
+     */
+    private static final class RecordingDriver implements WebDriver, JavascriptExecutor {
+        private final AtomicInteger executeScriptCalls = new AtomicInteger();
+        private final Set<String> windows = Collections.synchronizedSet(new LinkedHashSet<>(List.of("main")));
+
+        void openWindow(String handle) {
+            windows.add(handle);
+        }
+
+        @Override
+        public Set<String> getWindowHandles() {
+            return new LinkedHashSet<>(windows);
+        }
+
+        @Override
+        public Object executeScript(String script, Object... args) {
+            executeScriptCalls.incrementAndGet();
+            return null;
+        }
+
+        @Override
+        public Object executeAsyncScript(String script, Object... args) {
+            return null;
+        }
+
+        @Override
+        public void get(String url) {
+        }
+
+        @Override
+        public String getCurrentUrl() {
+            return "http://example.test/";
+        }
+
+        @Override
+        public String getTitle() {
+            return "";
+        }
+
+        @Override
+        public List<WebElement> findElements(By by) {
+            return List.of();
+        }
+
+        @Override
+        public WebElement findElement(By by) {
+            throw new org.openqa.selenium.NoSuchElementException("not used");
+        }
+
+        @Override
+        public String getPageSource() {
+            return "";
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public void quit() {
+        }
+
+        @Override
+        public String getWindowHandle() {
+            return "main";
+        }
+
+        @Override
+        public TargetLocator switchTo() {
+            throw new UnsupportedOperationException("not used");
+        }
+
+        @Override
+        public Navigation navigate() {
+            throw new UnsupportedOperationException("not used");
+        }
+
+        @Override
+        public Options manage() {
+            throw new UnsupportedOperationException("not used");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `ManagedCaptureRecorder.startCollector()` always ran a `BidiBrowserEventCollector` and a `PollingBrowserEventCollector` concurrently. The polling collector re-ran its `executeScript` install/drain round-trips, plus WebDriver-based window/navigation polling, on a fixed 100ms tick **regardless of whether BiDi was already delivering the same signals** — redundant renderer main-thread churn on every capture session.
- Worse: BiDi and polling identify windows via different ID schemes (BiDi browsing-context IDs vs. WebDriver window handles), so `CaptureEventPipeline.logicalWindow(...)` would map the *same* real tab open/close to two different logical windows if both collectors fired for it — a plausible duplicate-event bug, not just overhead.
- Adds `BidiActivityGate`: a small shared health tracker. A thin wrapper around the BiDi collector's signal consumer (in `ManagedCaptureRecorder`, `BidiBrowserEventCollector` itself is untouched) calls `recordActivity()` on every BiDi-delivered signal. `PollingBrowserEventCollector` checks the gate each tick:
  - **BiDi healthy**: skips emitting window/navigation signals (BiDi already covers them) and skips the `executeScript` round-trips entirely — but still walks the cheap WebDriver-only window/URL cursors so they never go stale.
  - **BiDi quiet** (no signal within the grace period, default 2s): resumes full-rate polling exactly as before, with cursors already current, so there's no catch-up burst of stale duplicate signals on resume.
- All existing `PollingBrowserEventCollector` constructors keep working unchanged (they delegate to the new gate-aware constructor with a default `() -> false` gate, i.e. today's always-poll behavior).

Closes the second half of #3385 (the CI coverage-gap half was #3386).

## Test plan
- [x] New unit test `PollingBrowserEventCollectorBidiBackoffTest` (no browser needed — a hand-rolled `WebDriver`/`JavascriptExecutor` stub): proves `executeScript` stops firing while the gate reports healthy, proves no `window_open` signal is emitted for a window that opens during that window, and proves resuming after the grace period lapses does **not** replay that window as new (cursor was kept current throughout).
- [x] Verified the test actually catches the regression: temporarily hard-coded `bidiHealthy = false` in `poll()`, watched the test fail deterministically (`executeScript` count `2` → `6`), then restored the real gate check.
- [x] `mvn -pl shaft-capture test` (full non-E2E suite): 213/213 passed.
- [x] `mvn -pl shaft-capture test -DincludeCaptureBrowserE2E -Dtest=ManagedCaptureRecorderBrowserTest,CaptureGeneratedReplayBrowserTest` (real headless Chrome + Edge, including the popup/window-open journey): 9/9 passed — confirms the real BiDi wiring in `ManagedCaptureRecorder` still works end-to-end after the rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)