### PR TITLE
Fix release-publish event chain broken by GITHUB_TOKEN anti-recursion

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -44,6 +44,15 @@ of `mavenCentral_cd.yml`'s `workflow_run` conclusion: that workflow's own run no
 `check_release_needed` in `mavenCentral_cd.yml`), so only the actual GitHub Release event
 is a reliable "a new version was really delivered" signal for these two.
 
+**The release must be created with a PAT (`BOT_TOKEN`), not the default `GITHUB_TOKEN`.**
+GitHub does not fan a `release` event out to other workflows when the release was created
+using the run's own `GITHUB_TOKEN` (anti-recursion protection); only `workflow_dispatch` and
+`repository_dispatch` are exempt from that rule. `mavenCentral_cd.yml`'s `announce_release`
+job therefore passes `token: ${{ secrets.BOT_TOKEN }}` to `ncipollo/release-action`. If that
+step is ever reverted to `GITHUB_TOKEN`, `publish-intellij-plugin.yml`, `publish-shaft-mcp.yml`,
+`sync-sample-projects-version.yml`, and (transitively) `deploy-shaft-mcp.yml` will silently
+never run again — there is no failure, the event simply never fires.
+
 ## Workflow Inventory
 
 | File | Workflow name | Trigger | What it does | Relationships and delete impact |

--- a/.github/workflows/deploy-shaft-mcp.yml
+++ b/.github/workflows/deploy-shaft-mcp.yml
@@ -2,9 +2,10 @@ name: Deploy shaft-mcp
 
 on:
   workflow_run:
+    # No branches filter: the upstream workflow now runs from `release: published`
+    # events (a release tag, not main), so head_branch here is the tag name.
     workflows: ["Publish shaft-mcp Distributions"]
     types: [completed]
-    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/mavenCentral_cd.yml
+++ b/.github/workflows/mavenCentral_cd.yml
@@ -267,9 +267,13 @@ jobs:
       - name: Create GitHub Release
         id: create_release
         uses: ncipollo/release-action@v1.21.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          # A release created with the default GITHUB_TOKEN does not emit a `release`
+          # event (GitHub's anti-recursion rule), so publish-intellij-plugin.yml,
+          # publish-shaft-mcp.yml, and sync-sample-projects-version.yml — which all
+          # listen for `release: published` — would never fire. BOT_TOKEN is a PAT,
+          # so its release does trigger those workflows.
+          token: ${{ secrets.BOT_TOKEN }}
           allowUpdates: false
           generateReleaseNotes: true
           bodyFile: /tmp/release_body.md


### PR DESCRIPTION
## Summary
- `mavenCentral_cd.yml`'s `announce_release` job creates the GitHub Release with the default `GITHUB_TOKEN`. GitHub's anti-recursion rule means a release created that way never fans out a `release` event to other workflows. `publish-intellij-plugin.yml`, `publish-shaft-mcp.yml`, and `sync-sample-projects-version.yml` were all switched to `release: published` by #3376 (merged earlier today) and have never actually fired since — confirmed via `gh api actions/runs?event=release` returning zero runs ever in this repo's history. Fix: create the release with `secrets.BOT_TOKEN` (a PAT) instead.
- `deploy-shaft-mcp.yml`: drop the now-stale `branches: [main]` filter on its `workflow_run` trigger — the upstream now runs from release tags, not `main`, so the filter silently suppressed every deploy.
- README updated with a warning explaining why this token choice matters (no visible failure if reverted, the event just silently never fires).

## Why this is urgent
`mavenCentral_cd.yml` run [28945152200](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/28945152200) is in flight right now for the just-merged 10.3.20260708 release. Once it reaches `announce_release`, it creates the GitHub Release — this needs to merge before that step runs, or this release's downstream publish chain (JetBrains Marketplace, GHCR/MCP registry, sample-project sync) goes dark with no visible error.

This PR is deliberately minimal (3 files, release-chain fix only) so it can be reviewed and merged fast. The broader workflow trigger/scope/de-duplication cleanup is in a separate PR: #3388.

## Test plan
- [x] Both edited workflow YAML files parse
- [x] Verified via `gh api` that zero `release`-event workflow runs have ever occurred in this repo, confirming the bug is real
- [ ] CI on this PR (security.yml CodeQL/dependency-review — this PR doesn't touch shaft-pilot-release.yml or its infra, so that heavy release-candidate gate does not fire)

🤖 Generated with [Claude Code](https://claude.com/claude-code)