### PR TITLE
Fix agentic config enhancements from issue #3390

### DIFF
--- a/.agents/skills/ci-failure-investigator/SKILL.md
+++ b/.agents/skills/ci-failure-investigator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci-failure-investigator
-description: Use for failed GitHub Actions, SHAFT Allure reports, or provider E2E runs; find the first actionable cause.
+description: Use for failed GitHub Actions, failed-run Allure reports, or provider E2E failures; find the first actionable cause.
 ---
 
 # CI Failure Investigator

--- a/.agents/skills/mcp-transport-contract-auditor/SKILL.md
+++ b/.agents/skills/mcp-transport-contract-auditor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-transport-contract-auditor
-description: Use for shaft-mcp manifests, fixtures, installers, Dockerfiles, tool schemas, workflows, or transport behavior.
+description: Use for shaft-mcp manifests, fixtures, installers, Dockerfiles, tool schemas, startup, or transport behavior.
 ---
 
 # MCP Transport Contract Auditor

--- a/.github/skills/mcp-transport-contract-auditor/SKILL.md
+++ b/.github/skills/mcp-transport-contract-auditor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-transport-contract-auditor
-description: Use when auditing shaft-mcp tool manifests, client fixtures, installers, containers, workflows, or local transport contracts.
+description: Use when auditing shaft-mcp tool manifests, client fixtures, installers, containers, startup, or local transport contracts.
 ---
 
 # MCP Transport Contract Auditor

--- a/.github/skills/shaft-marketing-ad-producer/SKILL.md
+++ b/.github/skills/shaft-marketing-ad-producer/SKILL.md
@@ -9,9 +9,9 @@ Plan SHAFT ads without fake claims.
 
 ## Stack
 
-- Strategy/scenes: use the relevant `creative-production:*` explorer.
-- Polish: `creative-production:generative-polish`, `imagegen`; keep exact copy, code, logos, and UI screenshots deterministic.
-- Capture: `browse` or `playwright`; use Chrome only for current profile state, and desktop/OBS/`ffmpeg` only if installed.
+- Strategy/scenes: plan in the brief/storyboard; no dedicated tool.
+- Visuals: keep exact copy, code, logos, and UI screenshots deterministic; no image-generation tool, so write a visual brief.
+- Capture: `webapp-testing`/Playwright for web; `chrome-devtools-mcp` for perf/network; desktop/OBS/`ffmpeg` if installed.
 - SHAFT proof: use MCP recorder, report, Doctor, Allure, and code-block tools.
 - Editing/audio: use existing video tools and approved or licensed audio; otherwise write a music brief.
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,7 @@
     },
     "maven-tools-mcp": {
       "command": "docker",
-      "args": ["run", "-i", "--rm", "arvindand/maven-tools-mcp:latest"]
+      "args": ["run", "-i", "--rm", "arvindand/maven-tools-mcp:3.1.1"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes #3390. Resolves the five deferred agentic-config audit items from the 2026-07-08 review:

1. **Skill trigger overlap** — narrowed `ci-failure-investigator`'s `.agents` shim description from advertising general "SHAFT Allure reports" to "failed-run Allure reports / provider E2E failures," so it no longer overlaps `allure-extent-report-operator`'s report-operation scope. The canonical `.github` description and openai.yaml sidecar were already failure-scoped, so left as-is.
2. **Ambiguous "workflows" wording** — replaced the bare "workflows" trigger in both `mcp-transport-contract-auditor` descriptions (`.agents` and `.github`) with body-aligned "startup," which reads as server/process startup rather than CI/GitHub Actions workflows.
3. **Stale/unreachable tool references** — removed dead `creative-production:*` / `imagegen` / `browse` references from `shaft-marketing-ad-producer`'s Stack section (none of those plugins/tools have ever been configured in this repo) and repointed capture at the real `webapp-testing`/Playwright and `chrome-devtools-mcp` tooling, with a "write a visual brief" fallback for the absent image-generation tooling.
4. **Unpinned MCP server image** — pinned `maven-tools-mcp` from `:latest` to `:3.1.1` (current stable, verified against Docker Hub and GitHub releases). Notably, `:latest` currently resolves to the `3.1.2-SNAPSHOT` digest, not a stable release, which is exactly the silent-drift risk the issue flagged. `context7` stays unpinned deliberately since `npx` resolves it per-invocation rather than floating on a cached image tag.
5. **"Dead" `active_guidance_globs` key** — investigated and found the issue's premise is **false**: the key is read at `scripts/ci/validate_agent_guidance.py:440` and consumed by the forbidden-pattern and duplicate-paragraph checks; `scripts/ci/validate_agent_setup.py:230` invokes that module. The original audit only grepped `validate_agent_setup.py` directly and missed the import. No code change made — documenting the correction here instead of adding a comment to the strict-JSON budget file.

Guidance byte total nets +1 byte (34771 vs 34770 baseline), well within the ~1230-byte headroom before the `minimum_reduction_percent` floor.

## Test plan

- [x] `py -3 scripts/ci/validate_agent_setup.py --skip-external --format json` → `valid: true`, `guidance_bytes: 34771` (max 36000), all host token estimates within budget
- [x] `.mcp.json` and `scripts/ci/agent_guidance_budget.json` parse as valid JSON
- [x] Verified `arvindand/maven-tools-mcp:3.1.1` is the current stable tag via Docker Hub API and GitHub releases before pinning

🤖 Generated with [Claude Code](https://claude.com/claude-code)