### PR TITLE
Fix SHAFT Capture recorder: process churn, duplicate actions, orphaned placeholder

### DIFF
--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -607,11 +607,27 @@
       selected: Boolean(element.checked || element.selected)
     };
   };
+  let lastClickEmission = null;
   const emit = (kind, event, data) => {
     if (uiState.paused || uiState.stopped || uiState.locatorMode) return;
     const target = snapshot(event);
     if (target) {
       const action = data || {};
+      // Root cause: one native double-click fires click(detail 1), click(detail 2), then
+      // dblclick. event.detail>=2 authoritatively marks the second click as a continuation of
+      // the first, so revoke the single-click row + its server step and replace it with one
+      // click carrying clickCount=2, instead of recording three separate actions.
+      if (kind === "click") {
+        if (Number(action.clickCount || 1) >= 2
+            && lastClickEmission
+            && lastClickEmission.logicalElementId === target.logicalElementId
+            && uiState.actions.some(existing => existing.id === lastClickEmission.item.id)) {
+          deleteAction(lastClickEmission.item);
+        }
+        lastClickEmission = null;
+      } else {
+        lastClickEmission = null;
+      }
       const readiness = readinessFor(kind, target);
       if (readiness) setReadiness(readiness.state, readiness.warning);
       const mergeKey = kind === "input" ? "input:" + target.logicalElementId : "";
@@ -630,6 +646,9 @@
       if (item) {
         action.clientActionId = clientActionId(item);
         action.stepDescription = description;
+      }
+      if (kind === "click" && item) {
+        lastClickEmission = {item, logicalElementId: target.logicalElementId};
       }
       send({kind, page: page(), target, data: action});
     }
@@ -976,7 +995,9 @@
     clearLocatorHighlight();
     renderLocatorPanel(null);
     persist();
-    announce("Element assertion: click the target element");
+    // The "click the target element" guidance is mode UI, not a recorded action, so it is
+    // surfaced through the status chip (see setStatus) rather than the action list. Announcing
+    // it as an action left a permanent placeholder row that nothing ever removed.
     setStatus();
   };
   const beginBrowserAssertion = () => {
@@ -1640,6 +1661,7 @@
     document.getElementById("shaft-capture-pause").addEventListener("click", () => {
       if (uiState.stopped) return;
       uiState.paused = !uiState.paused;
+      lastClickEmission = null;
       if (uiState.paused) {
         uiState.locatorMode = false;
         clearLocatorHighlight();
@@ -1681,6 +1703,7 @@
     document.getElementById("shaft-capture-stop").addEventListener("click", () => {
       if (uiState.stopped) return;
       uiState.stopped = true;
+      lastClickEmission = null;
       persist();
       announce("Stop recording");
       sendControl("STOP");
@@ -1696,10 +1719,16 @@
   };
   setInterval(() => {
     const current = String(location.href || "");
-    if (uiState.stopped || uiState.paused || current === uiState.lastUrl) return;
-    setReadiness("RISKY", "Step " + uiState.nextId + " needs a follow-up assertion after navigation.");
+    if (current === uiState.lastUrl) return;
     uiState.lastUrl = current;
-    announce("Navigate to " + visibleLocation());
+    if (!uiState.stopped && !uiState.paused) {
+      setReadiness("RISKY", "Step " + uiState.nextId + " needs a follow-up assertion after navigation.");
+      announce("Navigate to " + visibleLocation());
+      lastClickEmission = null;
+    }
+    if (topLevel) {
+      syncStepsFromServer();
+    }
     persist();
   }, 500);
 
@@ -1720,11 +1749,11 @@
     });
   }, true);
   addEventListener("dblclick", event => {
-    if (captureLocatorPick(event)) return;
-    emit("click", event, {
-    button: Number(event.button || 0),
-    clickCount: 2
-    });
+    // A native dblclick is always preceded by a click with detail=2, which the click listener
+    // above already emits with clickCount=2 (and coalesces with the preceding single click via
+    // lastClickEmission), so emitting again here would duplicate the action. Only the locator-pick
+    // guard still applies.
+    captureLocatorPick(event);
   }, true);
   const editingKeys = new Set(["Backspace", "Delete", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"]);
   const isEditingKey = key => editingKeys.has(key);
@@ -1816,14 +1845,5 @@
         announce("Open " + visibleLocation());
       }
     }
-    setInterval(() => {
-      const current = String(location.href || "");
-      if (current !== uiState.lastUrl) {
-        uiState.lastUrl = current;
-        persist();
-        announce("Navigate to " + visibleLocation());
-        syncStepsFromServer();
-      }
-    }, 500);
   }
 }

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
@@ -106,6 +106,7 @@ class ManagedCaptureRecorderBrowserTest {
                 .map(Object::getClass)
                 .collect(java.util.stream.Collectors.toSet());
         assertTrue(eventTypes.contains(CaptureEvent.NavigationEvent.class));
+        assertTrue(eventTypes.contains(CaptureEvent.ClickEvent.class));
         assertTrue(eventTypes.contains(CaptureEvent.TypeEvent.class));
         assertTrue(eventTypes.contains(CaptureEvent.SelectEvent.class));
         assertTrue(eventTypes.contains(CaptureEvent.ToggleEvent.class));
@@ -113,6 +114,28 @@ class ManagedCaptureRecorderBrowserTest {
         assertTrue(eventTypes.contains(CaptureEvent.FrameEvent.class));
         assertTrue(eventTypes.contains(CaptureEvent.WindowEvent.class));
         assertTrue(eventTypes.contains(CaptureEvent.AlertEvent.class));
+
+        // Regression for issue #3393: a native double-click used to fire click(detail 1),
+        // click(detail 2), and dblclick, each emitting its own ClickEvent -- one user gesture
+        // produced up to three recorded actions. Exactly one ClickEvent with clickCount=2 must be
+        // persisted for the double-clicked element, and single clicks must stay single events.
+        List<CaptureEvent.ClickEvent> clicks = session.events().stream()
+                .filter(CaptureEvent.ClickEvent.class::isInstance)
+                .map(CaptureEvent.ClickEvent.class::cast)
+                .toList();
+        List<CaptureEvent.ClickEvent> doubleClicks = clicks.stream()
+                .filter(click -> "double".equals(click.target().logicalElementId()))
+                .toList();
+        assertEquals(1, doubleClicks.size(),
+                "One double-click gesture must persist exactly one ClickEvent, not one per native "
+                        + "click/dblclick DOM event.");
+        assertEquals(2, doubleClicks.get(0).clickCount());
+        List<CaptureEvent.ClickEvent> singleClicks = clicks.stream()
+                .filter(click -> "replace".equals(click.target().logicalElementId()))
+                .toList();
+        assertEquals(1, singleClicks.size(), "A single click must not be suppressed by the double-click fix.");
+        assertEquals(1, singleClicks.get(0).clickCount());
+
         assertFalse(Files.readString(output, StandardCharsets.UTF_8).contains(SECRET_CANARY));
         assertFalse(Files.readString(output.getParent().resolve("capture-data.json"),
                 StandardCharsets.UTF_8).contains(SECRET_CANARY));
@@ -309,6 +332,32 @@ class ManagedCaptureRecorderBrowserTest {
             waitFor(() -> stepDescriptions(recorder).stream()
                     .anyMatch(description -> description.startsWith("Assert not element exists")));
 
+            // Regression for issue #3393: the "Element assertion: click the target element"
+            // placeholder row used to persist in the overlay action list even after the real
+            // assertion was built; it must never appear, and exactly one row for the completed
+            // assertion must be present.
+            String actionListTextAfterElementAssertion =
+                    driver.findElement(By.id("shaft-capture-action-list")).getText();
+            assertFalse(actionListTextAfterElementAssertion.contains("click the target element"),
+                    "The assertion-mode placeholder row must never appear in the recorded action list.");
+            assertEquals(1, java.util.Arrays.stream(actionListTextAfterElementAssertion.split("\n"))
+                            .filter(line -> line.startsWith("Assert not element exists"))
+                            .count(),
+                    "Exactly one row for the completed element assertion must be present.");
+
+            // Begin-then-cancel must also leave no placeholder residue.
+            driver.findElement(By.id("shaft-capture-assert")).click();
+            waitFor(() -> elementPresent(driver, assertionChoice("Element")));
+            driver.findElement(assertionChoice("Element")).click();
+            waitFor(() -> driver.findElement(By.id("shaft-capture-status")).getText()
+                    .contains("Assertion mode"));
+            driver.findElement(By.id("shaft-capture-assert")).click();
+            waitFor(() -> !driver.findElement(By.id("shaft-capture-status")).getText()
+                    .contains("Assertion mode"));
+            assertFalse(driver.findElement(By.id("shaft-capture-action-list")).getText()
+                            .contains("click the target element"),
+                    "Cancelling an in-progress element assertion must not leave a placeholder row.");
+
             // Browser branch: entry point -> Browser -> "Title contains" with an edited value.
             driver.findElement(By.id("shaft-capture-assert")).click();
             waitFor(() -> elementPresent(driver, assertionChoice("Browser")));
@@ -415,6 +464,52 @@ class ManagedCaptureRecorderBrowserTest {
         }
     }
 
+    /**
+     * Regression for issue #3393: the recorder overlay used to run two independent, redundant
+     * navigation-polling {@code setInterval} loops in the top-level frame, both announcing the
+     * same navigation with no de-duplication, so one navigation appended two "Navigate to" rows.
+     * Drives a real navigation and asserts exactly one such row lands in the overlay action list.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"chrome", "edge"})
+    void singleNavigationAppendsExactlyOneNavigateRow(
+            String browserName,
+            @TempDir Path temp) throws Exception {
+        HttpServer server = localFixture();
+        String baseUrl = "http://127.0.0.1:" + server.getAddress().getPort() + "/";
+        Path output = temp.resolve(browserName + "-nav-dedup.json");
+        ManagedCaptureRecorder recorder = new ManagedCaptureRecorder(new CaptureStartRequest(
+                baseUrl,
+                CaptureBrowser.parse(browserName),
+                output,
+                temp.resolve(browserName + "-nav-dedup-runtime"),
+                true));
+        try {
+            recorder.start();
+            WebDriver driver = recorder.driverForTesting();
+            JavascriptExecutor js = (JavascriptExecutor) driver;
+            waitFor(() -> elementPresent(driver, By.id("shaft-capture-action-list")));
+
+            driver.navigate().to(baseUrl + "popup");
+            waitFor(() -> navigateRowCount(js) >= 1);
+            // The (pre-fix, duplicate) navigation pollers both ran on a 500ms interval; sleeping
+            // across several ticks gives a reintroduced duplicate loop every chance to fire again
+            // before asserting the count stayed at exactly one.
+            Thread.sleep(1500);
+
+            assertEquals(1, navigateRowCount(js),
+                    "One navigation must append exactly one \"Navigate to\" row, not one per "
+                            + "redundant polling loop.");
+
+            recorder.stop(false);
+        } finally {
+            if (recorder.status().state() == CaptureStatus.State.ACTIVE) {
+                recorder.interrupt();
+            }
+            server.stop(0);
+        }
+    }
+
     private static double assertButtonTop(JavascriptExecutor js) {
         Object value = js.executeScript(
                 "return document.getElementById('shaft-capture-assert').getBoundingClientRect().top;");
@@ -425,6 +520,15 @@ class ManagedCaptureRecorderBrowserTest {
         Object value = js.executeScript(
                 "const l = document.getElementById('shaft-capture-action-list');"
                         + "return l ? l.childElementCount : 0;");
+        return ((Number) value).longValue();
+    }
+
+    private static long navigateRowCount(JavascriptExecutor js) {
+        Object value = js.executeScript(
+                "const l = document.getElementById('shaft-capture-action-list');"
+                        + "if (!l) return 0;"
+                        + "return Array.from(l.querySelectorAll('li')).filter(li => "
+                        + "(li.textContent || '').includes('Navigate to')).length;");
         return ((Number) value).longValue();
     }
 

--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpInvocationService.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpInvocationService.java
@@ -33,6 +33,7 @@ public final class ShaftMcpInvocationService implements Disposable {
 
     private final Project project;
     private final ShaftMcpConnectionState connectionState;
+    private final ShaftMcpClientFactory clientFactory;
     private final Object clientLock = new Object();
     private ShaftMcpStdioClient sharedClient;
     private List<String> sharedCommand = List.of();
@@ -45,8 +46,29 @@ public final class ShaftMcpInvocationService implements Disposable {
      * @param project IntelliJ project
      */
     public ShaftMcpInvocationService(@NotNull Project project) {
+        this(project, ShaftMcpStdioClient::new);
+    }
+
+    /**
+     * Test seam: tolerates a {@code null} project so unit tests can exercise the shared-client pool
+     * without the IntelliJ platform. Not public API.
+     *
+     * @param project       IntelliJ project, or {@code null} in tests
+     * @param clientFactory factory used to spawn the shared MCP server process
+     */
+    ShaftMcpInvocationService(Project project, ShaftMcpClientFactory clientFactory) {
         this.project = project;
-        this.connectionState = project.getService(ShaftMcpConnectionState.class);
+        this.connectionState = project == null ? null : project.getService(ShaftMcpConnectionState.class);
+        this.clientFactory = clientFactory;
+    }
+
+    /**
+     * Spawns the shared MCP server process; overridable in tests to avoid real process creation.
+     */
+    @FunctionalInterface
+    interface ShaftMcpClientFactory {
+        ShaftMcpStdioClient create(List<String> command, Path workingDirectory, Map<String, String> environment)
+                throws IOException;
     }
 
     /**
@@ -196,7 +218,7 @@ public final class ShaftMcpInvocationService implements Disposable {
      * Returns the shared MCP server client, spawning a fresh process when none is alive or the
      * effective command, environment, or working directory changed since the last call.
      */
-    private ShaftMcpStdioClient acquireClient(
+    ShaftMcpStdioClient acquireClient(
             List<String> scopedCommand,
             Path workingDirectory,
             Map<String, String> environment) throws IOException {
@@ -209,7 +231,7 @@ public final class ShaftMcpInvocationService implements Disposable {
                 return sharedClient;
             }
             closeSharedClientLocked();
-            sharedClient = new ShaftMcpStdioClient(scopedCommand, workingDirectory, environment);
+            sharedClient = clientFactory.create(scopedCommand, workingDirectory, environment);
             sharedCommand = List.copyOf(scopedCommand);
             sharedEnvironment = Map.copyOf(environment);
             sharedWorkingDirectory = workingDirectory;

--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpProjectScope.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpProjectScope.java
@@ -1,6 +1,7 @@
 package com.shaft.intellij.mcp;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -8,6 +9,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Applies the current IntelliJ project as the workspace for MCP launches.
@@ -16,6 +18,21 @@ final class ShaftMcpProjectScope {
     static final String WORKSPACE_ENVIRONMENT_VARIABLE = "SHAFT_MCP_WORKSPACE_ROOT";
     private static final String USER_DIR_PROPERTY = "user.dir";
     private static final String WORKSPACE_PROPERTY = "shaft.mcp.workspaceRoot";
+
+    /**
+     * Caches the generated scoped argfile per (source argfile, project root) so repeated calls with
+     * unchanged inputs return the same path. {@link ShaftMcpInvocationService#acquireClient} reuses
+     * its shared MCP process only when the scoped command is unchanged; without this cache, every
+     * call minted a brand-new temp file and the shared process was torn down and respawned on every
+     * tool invocation, killing live sessions such as SHAFT Capture recordings within seconds.
+     */
+    private static final Map<ArgFileKey, ScopedArgFile> SCOPED_ARG_FILES = new ConcurrentHashMap<>();
+
+    private record ArgFileKey(Path source, Path projectRoot) {
+    }
+
+    private record ScopedArgFile(List<String> content, Path generated) {
+    }
 
     private ShaftMcpProjectScope() {
         throw new IllegalStateException("Utility class");
@@ -47,6 +64,33 @@ final class ShaftMcpProjectScope {
     }
 
     private static Path scopedArgFile(Path source, Path projectRoot) throws IOException {
+        List<String> content = materializeScopedArgFile(source, projectRoot);
+        ArgFileKey key = new ArgFileKey(source.toAbsolutePath().normalize(), projectRoot);
+        try {
+            ScopedArgFile entry = SCOPED_ARG_FILES.compute(key, (ignoredKey, existing) -> {
+                if (existing != null && existing.content().equals(content) && Files.exists(existing.generated())) {
+                    return existing;
+                }
+                Path generated;
+                try {
+                    generated = Files.createTempFile("shaft-intellij-mcp-", ".args");
+                    generated.toFile().deleteOnExit();
+                    Files.write(generated, content, StandardCharsets.UTF_8);
+                } catch (IOException exception) {
+                    throw new UncheckedIOException(exception);
+                }
+                if (existing != null) {
+                    deleteQuietly(existing.generated());
+                }
+                return new ScopedArgFile(List.copyOf(content), generated);
+            });
+            return entry.generated();
+        } catch (UncheckedIOException exception) {
+            throw exception.getCause();
+        }
+    }
+
+    private static List<String> materializeScopedArgFile(Path source, Path projectRoot) throws IOException {
         List<String> original = Files.readAllLines(source, StandardCharsets.UTF_8);
         List<String> scoped = new ArrayList<>(original.size() + 2);
         boolean sawUserDir = false;
@@ -71,11 +115,16 @@ final class ShaftMcpProjectScope {
             withRequiredProperties.add(systemProperty(WORKSPACE_PROPERTY, projectRoot));
         }
         withRequiredProperties.addAll(scoped);
+        return withRequiredProperties;
+    }
 
-        Path generated = Files.createTempFile("shaft-intellij-mcp-", ".args");
-        generated.toFile().deleteOnExit();
-        Files.write(generated, withRequiredProperties, StandardCharsets.UTF_8);
-        return generated;
+    private static void deleteQuietly(Path path) {
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException ignored) {
+            // Windows can fail to delete a file while another process still holds a handle open;
+            // deleteOnExit() registered at creation time remains the backstop for cleanup.
+        }
     }
 
     private static String propertyName(String line) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpInvocationServiceTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpInvocationServiceTest.java
@@ -1,0 +1,105 @@
+package com.shaft.intellij.mcp;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercises {@link ShaftMcpInvocationService#acquireClient} directly, bypassing the IntelliJ
+ * platform via the package-private client-factory seam, to pin the "one shared MCP process across
+ * tool calls" contract documented on the class. Without it, a scoped command that is not
+ * value-stable across calls (see {@link ShaftMcpProjectScopeTest}) silently defeats process reuse.
+ */
+class ShaftMcpInvocationServiceTest {
+    private final List<ShaftMcpStdioClient> spawned = new ArrayList<>();
+
+    @AfterEach
+    void closeSpawnedClients() {
+        spawned.forEach(ShaftMcpStdioClient::close);
+        spawned.clear();
+    }
+
+    @Test
+    void identicalCommandReusesTheSameClientInstance() throws IOException {
+        RecordingFactory factory = new RecordingFactory();
+        ShaftMcpInvocationService service = new ShaftMcpInvocationService(null, factory);
+        List<String> command = echoToolCommand();
+
+        ShaftMcpStdioClient first = service.acquireClient(command, Path.of("."), Map.of());
+        ShaftMcpStdioClient second = service.acquireClient(command, Path.of("."), Map.of());
+
+        assertSame(first, second,
+                "Two calls with an unchanged scoped command must reuse the shared MCP process so a live "
+                        + "session (e.g. a SHAFT Capture recording) is not torn down between tool calls.");
+        assertEquals(1, factory.created.size());
+    }
+
+    @Test
+    void changedCommandClosesOldClientAndCreatesNew() throws IOException {
+        RecordingFactory factory = new RecordingFactory();
+        ShaftMcpInvocationService service = new ShaftMcpInvocationService(null, factory);
+        List<String> commandA = echoToolCommand();
+        List<String> commandB = new ArrayList<>(commandA);
+        commandB.add("--unused-marker");
+
+        ShaftMcpStdioClient first = service.acquireClient(commandA, Path.of("."), Map.of());
+        ShaftMcpStdioClient second = service.acquireClient(commandB, Path.of("."), Map.of());
+
+        assertNotSame(first, second,
+                "A changed scoped command (e.g. from a genuinely changed source argfile) must respawn.");
+        assertEquals(2, factory.created.size());
+        assertFalse(first.isAlive(), "The superseded process must be closed once the new one is acquired.");
+    }
+
+    @Test
+    void deadClientIsRecreated() throws IOException {
+        RecordingFactory factory = new RecordingFactory();
+        ShaftMcpInvocationService service = new ShaftMcpInvocationService(null, factory);
+        List<String> command = echoToolCommand();
+
+        ShaftMcpStdioClient first = service.acquireClient(command, Path.of("."), Map.of());
+        first.kill();
+        ShaftMcpStdioClient second = service.acquireClient(command, Path.of("."), Map.of());
+
+        assertNotSame(first, second, "A dead shared client must be replaced even when the command is unchanged.");
+        assertEquals(2, factory.created.size());
+        assertTrue(second.isAlive());
+    }
+
+    private static List<String> echoToolCommand() {
+        return List.of(javaExecutable(), "-cp", System.getProperty("java.class.path"),
+                FakeMcpServer.class.getName(), "echoTool");
+    }
+
+    private static String javaExecutable() {
+        String javaHome = System.getProperty("java.home");
+        boolean windows = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
+        return Paths.get(javaHome, "bin", windows ? "java.exe" : "java").toString();
+    }
+
+    private final class RecordingFactory implements ShaftMcpInvocationService.ShaftMcpClientFactory {
+        private final List<ShaftMcpStdioClient> created = new ArrayList<>();
+
+        @Override
+        public ShaftMcpStdioClient create(List<String> command, Path workingDirectory, Map<String, String> environment)
+                throws IOException {
+            ShaftMcpStdioClient client = new ShaftMcpStdioClient(command, workingDirectory, environment);
+            created.add(client);
+            spawned.add(client);
+            return client;
+        }
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpProjectScopeTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpProjectScopeTest.java
@@ -87,4 +87,89 @@ class ShaftMcpProjectScopeTest {
         assertEquals(project.toString(), environment.get(ShaftMcpProjectScope.WORKSPACE_ENVIRONMENT_VARIABLE));
         assertEquals("secret", environment.get("OPENAI_API_KEY"));
     }
+
+    @Test
+    void argFileCommandIsStableAcrossRepeatedCallsForUnchangedSource() throws IOException {
+        Path argsFile = temporary.resolve("shaft-mcp.args");
+        Files.writeString(argsFile, """
+                -cp
+                "shaft-mcp.jar"
+                com.shaft.mcp.ShaftMcpApplication
+                """);
+        Path project = temporary.resolve("project").toAbsolutePath().normalize();
+
+        List<String> first = ShaftMcpProjectScope.commandForProject(List.of("java", "@" + argsFile), project);
+        List<String> second = ShaftMcpProjectScope.commandForProject(List.of("java", "@" + argsFile), project);
+
+        assertEquals(first, second,
+                "Repeated calls with an unchanged source argfile must return the same scoped command so "
+                        + "ShaftMcpInvocationService.acquireClient can reuse its shared MCP process.");
+    }
+
+    @Test
+    void changedArgFileContentProducesNewScopedFileWithUpdatedContent() throws IOException {
+        Path argsFile = temporary.resolve("shaft-mcp.args");
+        Files.writeString(argsFile, """
+                -cp
+                "shaft-mcp.jar"
+                com.shaft.mcp.ShaftMcpApplication
+                """);
+        Path project = temporary.resolve("project").toAbsolutePath().normalize();
+
+        List<String> first = ShaftMcpProjectScope.commandForProject(List.of("java", "@" + argsFile), project);
+        Path firstScopedFile = Path.of(first.get(1).substring(1));
+
+        Files.writeString(argsFile, """
+                -cp
+                "shaft-mcp-updated.jar"
+                com.shaft.mcp.ShaftMcpApplication
+                """);
+        List<String> second = ShaftMcpProjectScope.commandForProject(List.of("java", "@" + argsFile), project);
+        Path secondScopedFile = Path.of(second.get(1).substring(1));
+
+        assertFalse(first.equals(second), "Changed source content must yield a different scoped command.");
+        assertTrue(Files.readString(secondScopedFile).contains("shaft-mcp-updated.jar"));
+        assertFalse(Files.exists(firstScopedFile), "The superseded scoped argfile should be cleaned up.");
+    }
+
+    @Test
+    void deletedScopedFileIsRegenerated() throws IOException {
+        Path argsFile = temporary.resolve("shaft-mcp.args");
+        Files.writeString(argsFile, """
+                -cp
+                "shaft-mcp.jar"
+                com.shaft.mcp.ShaftMcpApplication
+                """);
+        Path project = temporary.resolve("project").toAbsolutePath().normalize();
+
+        List<String> first = ShaftMcpProjectScope.commandForProject(List.of("java", "@" + argsFile), project);
+        Path firstScopedFile = Path.of(first.get(1).substring(1));
+        Files.delete(firstScopedFile);
+
+        List<String> second = ShaftMcpProjectScope.commandForProject(List.of("java", "@" + argsFile), project);
+        Path secondScopedFile = Path.of(second.get(1).substring(1));
+
+        assertTrue(Files.exists(secondScopedFile), "A missing scoped argfile must be regenerated, not left dangling.");
+        assertTrue(Files.readString(secondScopedFile).contains("shaft-mcp.jar"));
+    }
+
+    @Test
+    void differentProjectRootsProduceDistinctStableArgFiles() throws IOException {
+        Path argsFile = temporary.resolve("shaft-mcp.args");
+        Files.writeString(argsFile, """
+                -cp
+                "shaft-mcp.jar"
+                com.shaft.mcp.ShaftMcpApplication
+                """);
+        Path projectA = temporary.resolve("projectA").toAbsolutePath().normalize();
+        Path projectB = temporary.resolve("projectB").toAbsolutePath().normalize();
+
+        List<String> forA = ShaftMcpProjectScope.commandForProject(List.of("java", "@" + argsFile), projectA);
+        List<String> forB = ShaftMcpProjectScope.commandForProject(List.of("java", "@" + argsFile), projectB);
+        List<String> forARepeated = ShaftMcpProjectScope.commandForProject(List.of("java", "@" + argsFile), projectA);
+
+        assertFalse(forA.equals(forB), "Distinct project roots must not share a scoped argfile.");
+        assertEquals(forA, forARepeated,
+                "Serving project B must not evict or perturb project A's cached scoped argfile.");
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #3393. All four reported symptoms trace to three independent root causes; none are specific to "non-SHAFT" projects, they reproduce on any project the recorder is used against.

- **MCP process churn (symptoms 3 & 4 — browser doesn't close, recording stops after the first navigation):** `ShaftMcpProjectScope` minted a brand-new randomized temp argfile on *every* MCP tool call, so the scoped command was never equal to itself and `ShaftMcpInvocationService.acquireClient` tore down and respawned the shared MCP server process on every call — including the automatic `capture_status` diagnostic fired 1.5s after every `capture_start`. That killed the recording's in-process session and orphaned the browser. Fixed by memoizing the generated scoped argfile per `(source, project root)`, validated by content so a genuine config change still respawns the process.
- **Duplicated actions (symptom 1):** a native double-click fires `click(detail=1)`, `click(detail=2)`, then `dblclick`; the recorder emitted a separate action for each. Fixed with a revoke-and-replace: the first click is deleted and replaced by a single `clickCount=2` action once `detail>=2` confirms the gesture continues. Also merged two redundant `setInterval` navigation-polling loops that both announced the same navigation with no dedup.
- **Assertion placeholder never removed (symptom 2):** "click the target element" was announced as a permanent action-list row with no removal path. Fixed by surfacing that guidance through the existing status chip instead of the action list.

## Test plan
- New/extended `ShaftMcpProjectScopeTest` cases proving the scoped argfile is stable across repeated calls, regenerates on content change or deletion, and stays isolated per project root.
- New `ShaftMcpInvocationServiceTest` proving the shared MCP client is reused for an unchanged command, replaced on a changed command, and recreated when dead.
- Extended `ManagedCaptureRecorderBrowserTest` (real headless Chrome/Edge): exactly one `ClickEvent` with `clickCount=2` per double-click gesture, exactly one "Navigate to" row per navigation, and no assertion-placeholder row ever appears (including a begin-then-cancel flow).
- `shaft-intellij` full Gradle test suite: 337 tests, 0 failures.
- `ManagedCaptureRecorderBrowserTest` run headless against real Chrome/Edge: 10/10 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)