### PR TITLE
Fix RestActions JSON request bodies to honor Jackson annotations (Part of #3412)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/api/RestActions.java
+++ b/shaft-engine/src/main/java/com/shaft/api/RestActions.java
@@ -1474,8 +1474,8 @@ public class RestActions {
             try {
                 switch (contentType) {
                     case JSON ->
-                        // "application/json", "application/javascript", "text/javascript", "text/json" ->
-                            builder.setBody(body, ObjectMapperType.GSON);
+                        // Serialize POJOs with SHAFT's Jackson mapper (as on the response side) so Jackson annotations are honored.
+                            builder.setBody(serializeJsonRequestBody(body));
                     case XML ->
                         //   "application/xml", "text/xml", "application/xhtml+xml" ->
                             builder.setBody(body, ObjectMapperType.JAXB);
@@ -1485,6 +1485,13 @@ public class RestActions {
                 failAction("Issue with parsing body content", rootCauseException);
             }
         }
+    }
+
+    private static String serializeJsonRequestBody(Object body) throws JacksonException {
+        if (body instanceof String stringBody) {
+            return stringBody;
+        }
+        return JACKSON_MAPPER.writeValueAsString(body);
     }
 
     private void prepareRequestBody(RequestSpecBuilder builder, List<List<Object>> parameters,

--- a/shaft-engine/src/test/java/com/shaft/api/RestActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/api/RestActionsCoverageUnitTest.java
@@ -1,7 +1,10 @@
 package com.shaft.api;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.annotation.JsonNaming;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.ObjectNode;
 import com.shaft.driver.SHAFT;
@@ -43,6 +46,39 @@ public class RestActionsCoverageUnitTest {
     private static final String COVERAGE_TEST_DATA = "src/test/resources/testDataFiles/restActionsCoverage/";
 
     private record ApiUser(int id, String name) {
+    }
+
+    // tools.jackson (Jackson 3) annotations: SHAFT serializes with a tools.jackson mapper, which ignores legacy com.fasterxml.jackson databind annotations.
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    private static class CustomerPayload {
+        private String name;
+        private Integer dialCode;
+        private String phone;
+        private String optionalField;
+
+        CustomerPayload(String name, Integer dialCode, String phone, String optionalField) {
+            this.name = name;
+            this.dialCode = dialCode;
+            this.phone = phone;
+            this.optionalField = optionalField;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Integer getDialCode() {
+            return dialCode;
+        }
+
+        public String getPhone() {
+            return phone;
+        }
+
+        public String getOptionalField() {
+            return optionalField;
+        }
     }
 
     @AfterMethod(alwaysRun = true)
@@ -119,6 +155,21 @@ public class RestActionsCoverageUnitTest {
                 () -> actions.buildNewRequest("users", RestActions.RequestType.GET).setPathParameters("10"));
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> actions.buildNewRequest("users/{id}", RestActions.RequestType.GET).setPathParameters(Map.of("missing", 10)));
+    }
+
+    @Test
+    public void prepareRequestSpecsShouldHonorJacksonNamingOnJsonRequestBodies() {
+        RestActions actions = new RestActions("http://localhost/");
+        Map<String, String> headers = Map.of("Content-Type", "application/json");
+        CustomerPayload payload = new CustomerPayload("Test", 966, "512345678", null);
+
+        RequestSpecification spec = actions.prepareRequestSpecs(
+                null, null, payload, ContentType.JSON, Map.of(), headers, RestAssuredConfig.config(), true, true);
+
+        String wireBody = ((FilterableRequestSpecification) spec).getBody();
+        Validations.assertThat().object(wireBody).contains("\"dial_code\":966").perform();
+        Validations.assertThat().object(wireBody).doesNotContain("dialCode").perform();
+        Validations.assertThat().object(wireBody).doesNotContain("optional_field").perform();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Serialize JSON POJO request bodies with SHAFT's Jackson mapper instead of RestAssured Gson so `@JsonNaming`, `@JsonInclude`, and `@JsonProperty` are honored on the wire.
- Aligns request serialization with the existing Jackson-based response parsing path in `RestActions`.
- Adds a focused regression test in `RestActionsCoverageUnitTest` for snake_case wire output and `NON_NULL` omission.

##Tests
[RestActionsJSONRequestBodies-report.html](https://github.com/user-attachments/files/29900787/RestActionsJSONRequestBodies-report.html)
Closes #3412