### PR TITLE
Stream-patch the generated Allure single-file index to fix teardown OOM (#3407)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java
@@ -12,16 +12,22 @@ import com.shaft.properties.internal.ThreadLocalPropertiesManager;
 import com.shaft.tools.io.ReportManager;
 import org.apache.commons.lang3.SystemUtils;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -81,6 +87,7 @@ public class AllureManager {
     private static final String ALLURE_ATTACHMENT_PREVIEW_FIX_ID = "shaft-allure-attachment-preview-fix";
     private static final String ALLURE_ATTACHMENT_PREVIEW_SCRIPT_ID = "shaft-allure-attachment-preview-script";
     private static final String ALLURE_THEME_COLORS_ID = "shaft-allure-theme-colors";
+    private static final int INDEX_PATCH_BUFFER_SIZE = 64 * 1024;
     private static final String ALLURE_ATTACHMENT_PREVIEW_FIX_STYLE = """
             <style id="shaft-allure-attachment-preview-fix">
             .shaft-allure-image-modal {
@@ -730,44 +737,223 @@ public class AllureManager {
         };
     }
 
+    /**
+     * Result of a single streaming pass over {@code index.html} looking for the SHAFT patch markers
+     * and the insertion points ({@code </head>} / {@code </body>}).
+     *
+     * @param previewFixPresent    {@code true} when the attachment-preview-fix {@code <style>} id is present
+     * @param previewScriptPresent {@code true} when the attachment-preview-fix {@code <script>} id is present
+     * @param themeColorsPresent   {@code true} when the theme-colors {@code <style>} id is present
+     * @param headEndOffset        absolute byte offset of the first {@code </head>}, or {@code -1} if absent
+     * @param bodyEndOffset        absolute byte offset of the last {@code </body>}, or {@code -1} if absent
+     */
+    private record IndexMarkerScan(boolean previewFixPresent, boolean previewScriptPresent,
+                                    boolean themeColorsPresent, long headEndOffset, long bodyEndOffset) {
+    }
+
+    /** A byte-range insertion to apply while streaming {@code index.html} to its patched copy. */
+    private record IndexInsertion(long offset, byte[] bytes) {
+    }
+
+    /**
+     * Patches the generated Allure single-file report's {@code index.html} to inject SHAFT's
+     * attachment-preview-fix styling/script and theme-color overrides, without ever holding the
+     * whole file in memory.
+     *
+     * <p>Single-file Allure reports inline every attachment as base64, so {@code index.html} can
+     * grow far beyond the forked JVM's heap; the previous implementation read the whole file into a
+     * {@code String} and built additional full copies via {@code String.substring} concatenation,
+     * which could throw {@link OutOfMemoryError} during teardown (issue #3407). This implementation
+     * instead scans the file once for markers/insertion-points (bounded 64KB buffer) and then streams
+     * a second, single sequential pass to write the patched copy.
+     */
     private static void patchGeneratedAllureReportIndex(Path reportDirectory) {
         Path indexPath = reportDirectory.resolve("index.html");
         if (!Files.isRegularFile(indexPath)) {
             return;
         }
         try {
-            String html = Files.readString(indexPath, StandardCharsets.UTF_8);
+            IndexMarkerScan scan;
+            try (InputStream in = new BufferedInputStream(Files.newInputStream(indexPath), INDEX_PATCH_BUFFER_SIZE)) {
+                scan = scanIndexMarkers(in);
+            }
             String headPatch = "";
-            if (!html.contains("id=\"" + ALLURE_ATTACHMENT_PREVIEW_FIX_ID + "\"")) {
+            if (!scan.previewFixPresent()) {
                 headPatch += ALLURE_ATTACHMENT_PREVIEW_FIX_STYLE;
             }
-            if (!html.contains("id=\"" + ALLURE_ATTACHMENT_PREVIEW_SCRIPT_ID + "\"")) {
+            if (!scan.previewScriptPresent()) {
                 headPatch += ALLURE_ATTACHMENT_PREVIEW_FIX_SCRIPT;
             }
-            String bodyPatch = "";
-            if (!html.contains("id=\"" + ALLURE_THEME_COLORS_ID + "\"")) {
-                bodyPatch += ALLURE_THEME_COLORS_STYLE;
-            }
+            String bodyPatch = scan.themeColorsPresent() ? "" : ALLURE_THEME_COLORS_STYLE;
             if (headPatch.isEmpty() && bodyPatch.isEmpty()) {
                 return;
             }
-            String patchedHtml = html;
-            if (!headPatch.isEmpty()) {
-                int headEnd = patchedHtml.indexOf("</head>");
-                patchedHtml = headEnd >= 0
-                        ? patchedHtml.substring(0, headEnd) + headPatch + patchedHtml.substring(headEnd)
-                        : headPatch + patchedHtml;
-            }
-            if (!bodyPatch.isEmpty()) {
-                int bodyEnd = patchedHtml.lastIndexOf("</body>");
-                patchedHtml = bodyEnd >= 0
-                        ? patchedHtml.substring(0, bodyEnd) + bodyPatch + patchedHtml.substring(bodyEnd)
-                        : patchedHtml + bodyPatch;
-            }
-            Files.writeString(indexPath, patchedHtml, StandardCharsets.UTF_8);
+            writePatchedIndex(indexPath, scan, headPatch, bodyPatch);
         } catch (IOException e) {
             ReportManager.logDiscrete("Could not patch Allure report styling: " + e.getMessage());
         }
+    }
+
+    /**
+     * Streams {@code in} once, locating the SHAFT patch id markers and the first {@code </head>} /
+     * last {@code </body>} byte offsets. Uses a sliding window with a carried-over tail so that a
+     * marker split across two reads (regardless of chunk size) is still found.
+     */
+    private static IndexMarkerScan scanIndexMarkers(InputStream in) throws IOException {
+        byte[] previewFixMarker = ("id=\"" + ALLURE_ATTACHMENT_PREVIEW_FIX_ID + "\"").getBytes(StandardCharsets.UTF_8);
+        byte[] previewScriptMarker = ("id=\"" + ALLURE_ATTACHMENT_PREVIEW_SCRIPT_ID + "\"").getBytes(StandardCharsets.UTF_8);
+        byte[] themeColorsMarker = ("id=\"" + ALLURE_THEME_COLORS_ID + "\"").getBytes(StandardCharsets.UTF_8);
+        byte[] headEndMarker = "</head>".getBytes(StandardCharsets.UTF_8);
+        byte[] bodyEndMarker = "</body>".getBytes(StandardCharsets.UTF_8);
+
+        boolean previewFixPresent = false;
+        boolean previewScriptPresent = false;
+        boolean themeColorsPresent = false;
+        boolean headFound = false;
+        long headEndOffset = -1;
+        long bodyEndOffset = -1;
+
+        int maxMarkerLength = Math.max(previewFixMarker.length,
+                Math.max(previewScriptMarker.length,
+                        Math.max(themeColorsMarker.length,
+                                Math.max(headEndMarker.length, bodyEndMarker.length))));
+        int carryLength = maxMarkerLength - 1;
+        byte[] window = new byte[carryLength + INDEX_PATCH_BUFFER_SIZE];
+        int carried = 0;
+        long windowStartOffset = 0;
+
+        while (true) {
+            int read = in.read(window, carried, window.length - carried);
+            if (read < 0) {
+                break;
+            }
+            if (read == 0) {
+                continue;
+            }
+            int windowLength = carried + read;
+
+            if (!previewFixPresent) {
+                int minStart = Math.max(0, carried - previewFixMarker.length + 1);
+                previewFixPresent = indexOfMarker(window, windowLength, minStart, previewFixMarker, false) >= 0;
+            }
+            if (!previewScriptPresent) {
+                int minStart = Math.max(0, carried - previewScriptMarker.length + 1);
+                previewScriptPresent = indexOfMarker(window, windowLength, minStart, previewScriptMarker, false) >= 0;
+            }
+            if (!themeColorsPresent) {
+                int minStart = Math.max(0, carried - themeColorsMarker.length + 1);
+                themeColorsPresent = indexOfMarker(window, windowLength, minStart, themeColorsMarker, false) >= 0;
+            }
+            if (!headFound) {
+                int minStart = Math.max(0, carried - headEndMarker.length + 1);
+                int matchIndex = indexOfMarker(window, windowLength, minStart, headEndMarker, false);
+                if (matchIndex >= 0) {
+                    headEndOffset = windowStartOffset + matchIndex;
+                    headFound = true;
+                }
+            }
+            int bodyMinStart = Math.max(0, carried - bodyEndMarker.length + 1);
+            int bodyMatchIndex = indexOfMarker(window, windowLength, bodyMinStart, bodyEndMarker, true);
+            if (bodyMatchIndex >= 0) {
+                bodyEndOffset = windowStartOffset + bodyMatchIndex;
+            }
+
+            int newCarry = Math.min(carryLength, windowLength);
+            System.arraycopy(window, windowLength - newCarry, window, 0, newCarry);
+            windowStartOffset += windowLength - newCarry;
+            carried = newCarry;
+        }
+
+        return new IndexMarkerScan(previewFixPresent, previewScriptPresent, themeColorsPresent, headEndOffset, bodyEndOffset);
+    }
+
+    /**
+     * Naive byte-array search for {@code marker} within {@code window[0, windowLength)}, restricted
+     * to start indices {@code >= minStart}. Returns the first match when {@code findLast} is
+     * {@code false}, otherwise the last match; {@code -1} when none is found.
+     */
+    private static int indexOfMarker(byte[] window, int windowLength, int minStart, byte[] marker, boolean findLast) {
+        int maxStart = windowLength - marker.length;
+        int result = -1;
+        for (int i = minStart; i <= maxStart; i++) {
+            boolean matches = true;
+            for (int j = 0; j < marker.length; j++) {
+                if (window[i + j] != marker[j]) {
+                    matches = false;
+                    break;
+                }
+            }
+            if (matches) {
+                result = i;
+                if (!findLast) {
+                    return result;
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Streams {@code indexPath} to a sibling temp file, inserting {@code headPatch} immediately
+     * before {@code scan.headEndOffset()} (or at offset 0 if absent) and {@code bodyPatch}
+     * immediately before {@code scan.bodyEndOffset()} (or at EOF if absent), then atomically
+     * replaces {@code indexPath}. Offsets are computed on the original (unpatched) file; since
+     * neither patch constant contains the literals {@code </head>} or {@code </body>}, this is
+     * equivalent to the old post-insertion string arithmetic.
+     */
+    private static void writePatchedIndex(Path indexPath, IndexMarkerScan scan, String headPatch, String bodyPatch) throws IOException {
+        List<IndexInsertion> insertions = new ArrayList<>(2);
+        if (!headPatch.isEmpty()) {
+            long offset = scan.headEndOffset() >= 0 ? scan.headEndOffset() : 0L;
+            insertions.add(new IndexInsertion(offset, headPatch.getBytes(StandardCharsets.UTF_8)));
+        }
+        if (!bodyPatch.isEmpty()) {
+            long offset = scan.bodyEndOffset() >= 0 ? scan.bodyEndOffset() : Long.MAX_VALUE;
+            insertions.add(new IndexInsertion(offset, bodyPatch.getBytes(StandardCharsets.UTF_8)));
+        }
+        insertions.sort(Comparator.comparingLong(IndexInsertion::offset));
+
+        Path tempPath = indexPath.resolveSibling(indexPath.getFileName() + ".shaft-patch.tmp");
+        try {
+            try (InputStream in = new BufferedInputStream(Files.newInputStream(indexPath), INDEX_PATCH_BUFFER_SIZE);
+                 OutputStream out = new BufferedOutputStream(Files.newOutputStream(tempPath), INDEX_PATCH_BUFFER_SIZE)) {
+                long position = 0;
+                for (IndexInsertion insertion : insertions) {
+                    position = copyIndexBytes(in, out, position, insertion.offset());
+                    out.write(insertion.bytes());
+                }
+                copyIndexBytes(in, out, position, Long.MAX_VALUE);
+            }
+        } catch (IOException e) {
+            Files.deleteIfExists(tempPath);
+            throw e;
+        }
+        try {
+            Files.move(tempPath, indexPath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException e) {
+            Files.move(tempPath, indexPath, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    /**
+     * Copies bytes from {@code in} to {@code out}, starting at absolute {@code position}, until
+     * absolute {@code targetOffset} is reached ({@code Long.MAX_VALUE} means "copy to EOF"). Reads
+     * at most {@code min(bufferLength, targetOffset - position)} per iteration. Returns the new
+     * position (which may be short of {@code targetOffset} if EOF was reached first).
+     */
+    private static long copyIndexBytes(InputStream in, OutputStream out, long position, long targetOffset) throws IOException {
+        byte[] buffer = new byte[INDEX_PATCH_BUFFER_SIZE];
+        while (targetOffset == Long.MAX_VALUE || position < targetOffset) {
+            long remaining = targetOffset == Long.MAX_VALUE ? buffer.length : targetOffset - position;
+            int toRead = (int) Math.min(buffer.length, remaining);
+            int read = in.read(buffer, 0, toRead);
+            if (read < 0) {
+                break;
+            }
+            out.write(buffer, 0, read);
+            position += read;
+        }
+        return position;
     }
 
     private static void writeAllureCategoriesIfSupported() {

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java
@@ -77,6 +77,8 @@ import java.util.regex.Pattern;
  * state and should not be accessed concurrently.
  */
 public class AllureManager {
+    private static final int INDEX_PATCH_BUFFER_SIZE = 64 * 1024;
+
     private AllureManager() {
         throw new IllegalStateException("Utility class");
     }
@@ -87,7 +89,6 @@ public class AllureManager {
     private static final String ALLURE_ATTACHMENT_PREVIEW_FIX_ID = "shaft-allure-attachment-preview-fix";
     private static final String ALLURE_ATTACHMENT_PREVIEW_SCRIPT_ID = "shaft-allure-attachment-preview-script";
     private static final String ALLURE_THEME_COLORS_ID = "shaft-allure-theme-colors";
-    private static final int INDEX_PATCH_BUFFER_SIZE = 64 * 1024;
     private static final String ALLURE_ATTACHMENT_PREVIEW_FIX_STYLE = """
             <style id="shaft-allure-attachment-preview-fix">
             .shaft-allure-image-modal {
@@ -747,8 +748,9 @@ public class AllureManager {
      * @param headEndOffset        absolute byte offset of the first {@code </head>}, or {@code -1} if absent
      * @param bodyEndOffset        absolute byte offset of the last {@code </body>}, or {@code -1} if absent
      */
-    private record IndexMarkerScan(boolean previewFixPresent, boolean previewScriptPresent,
-                                    boolean themeColorsPresent, long headEndOffset, long bodyEndOffset) {
+    // package-private so unit tests can assert scan results without reflection
+    record IndexMarkerScan(boolean previewFixPresent, boolean previewScriptPresent,
+                           boolean themeColorsPresent, long headEndOffset, long bodyEndOffset) {
     }
 
     /** A byte-range insertion to apply while streaming {@code index.html} to its patched copy. */
@@ -943,17 +945,18 @@ public class AllureManager {
      */
     private static long copyIndexBytes(InputStream in, OutputStream out, long position, long targetOffset) throws IOException {
         byte[] buffer = new byte[INDEX_PATCH_BUFFER_SIZE];
-        while (targetOffset == Long.MAX_VALUE || position < targetOffset) {
-            long remaining = targetOffset == Long.MAX_VALUE ? buffer.length : targetOffset - position;
+        long currentPosition = position;
+        while (targetOffset == Long.MAX_VALUE || currentPosition < targetOffset) {
+            long remaining = targetOffset == Long.MAX_VALUE ? buffer.length : targetOffset - currentPosition;
             int toRead = (int) Math.min(buffer.length, remaining);
             int read = in.read(buffer, 0, toRead);
             if (read < 0) {
                 break;
             }
             out.write(buffer, 0, read);
-            position += read;
+            currentPosition += read;
         }
-        return position;
+        return currentPosition;
     }
 
     private static void writeAllureCategoriesIfSupported() {

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureManagerCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureManagerCoverageUnitTest.java
@@ -3,18 +3,24 @@ package com.shaft.tools.io.internal;
 import com.shaft.driver.SHAFT;
 import com.shaft.properties.internal.Properties;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.util.Comparator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -244,6 +250,140 @@ public class AllureManagerCoverageUnitTest {
     }
 
     @Test
+    public void patchGeneratedAllureReportIndexShouldNotRewriteAlreadyPatchedReport() throws Exception {
+        Path reportDirectory = testDirectory.resolve("generated-report");
+        Files.createDirectories(reportDirectory);
+        Path index = reportDirectory.resolve("index.html");
+        Files.writeString(index, "<html><head></head><body></body></html>", StandardCharsets.UTF_8);
+
+        invoke("patchGeneratedAllureReportIndex", new Class[]{Path.class}, reportDirectory);
+        Files.setLastModifiedTime(index, FileTime.fromMillis(0));
+        byte[] contentBeforeSecondPatch = Files.readAllBytes(index);
+
+        invoke("patchGeneratedAllureReportIndex", new Class[]{Path.class}, reportDirectory);
+
+        Assert.assertEquals(Files.getLastModifiedTime(index), FileTime.fromMillis(0));
+        Assert.assertEquals(Files.readAllBytes(index), contentBeforeSecondPatch);
+    }
+
+    @Test
+    public void scanIndexMarkersShouldFindMarkersSpanningAnyReadBoundary() throws Exception {
+        String filler = "x".repeat(50);
+        String html = filler
+                + "id=\"shaft-allure-attachment-preview-fix\""
+                + filler
+                + "</head>"
+                + filler
+                + "</body>"
+                + filler
+                + "</body>"
+                + filler;
+        byte[] bytes = html.getBytes(StandardCharsets.UTF_8);
+        int headEndOffset = html.indexOf("</head>");
+        int lastBodyEndOffset = html.lastIndexOf("</body>");
+        Assert.assertTrue(headEndOffset >= 0 && lastBodyEndOffset >= 0);
+
+        InputStream trickleStream = new InputStream() {
+            private int position = 0;
+
+            @Override
+            public int read() {
+                if (position >= bytes.length) {
+                    return -1;
+                }
+                return bytes[position++] & 0xFF;
+            }
+
+            @Override
+            public int read(byte[] buffer, int offset, int length) {
+                if (position >= bytes.length) {
+                    return -1;
+                }
+                int toCopy = Math.min(Math.min(length, 3), bytes.length - position);
+                System.arraycopy(bytes, position, buffer, offset, toCopy);
+                position += toCopy;
+                return toCopy;
+            }
+        };
+
+        Object scan = invoke("scanIndexMarkers", new Class[]{InputStream.class}, trickleStream);
+
+        Assert.assertEquals(recordAccessor(scan, "previewFixPresent"), true);
+        Assert.assertEquals(recordAccessor(scan, "previewScriptPresent"), false);
+        Assert.assertEquals(recordAccessor(scan, "themeColorsPresent"), false);
+        Assert.assertEquals(recordAccessor(scan, "headEndOffset"), (long) headEndOffset);
+        Assert.assertEquals(recordAccessor(scan, "bodyEndOffset"), (long) lastBodyEndOffset);
+    }
+
+    @Test
+    public void patchGeneratedAllureReportIndexShouldHandleMissingHeadAndBodyTags() throws Exception {
+        Path reportDirectory = testDirectory.resolve("generated-report");
+        Files.createDirectories(reportDirectory);
+        Path index = reportDirectory.resolve("index.html");
+        Files.writeString(index, "<main>x</main>", StandardCharsets.UTF_8);
+
+        invoke("patchGeneratedAllureReportIndex", new Class[]{Path.class}, reportDirectory);
+
+        String html = Files.readString(index, StandardCharsets.UTF_8);
+        Assert.assertTrue(html.startsWith("<style id=\"shaft-allure-attachment-preview-fix\">"), html);
+        Assert.assertTrue(html.endsWith("</style>\n"), html);
+        Assert.assertTrue(html.contains("<main>x</main>"), html);
+    }
+
+    @Test
+    public void patchGeneratedAllureReportIndexShouldStreamLargeReportsWithBoundedAllocation() throws Exception {
+        Path reportDirectory = testDirectory.resolve("generated-report");
+        Files.createDirectories(reportDirectory);
+        Path index = reportDirectory.resolve("index.html");
+
+        String chunk = "AbCdEfGhIj0123456789".repeat(51); // ~1KB
+        ByteArrayOutputStream largeContentBuilder = new ByteArrayOutputStream();
+        largeContentBuilder.writeBytes("<html><head></head><body><img src=\"data:image/png;base64,".getBytes(StandardCharsets.UTF_8));
+        for (int i = 0; i < 24 * 1024; i++) {
+            largeContentBuilder.writeBytes(chunk.getBytes(StandardCharsets.UTF_8));
+        }
+        largeContentBuilder.writeBytes("\"></body></html>".getBytes(StandardCharsets.UTF_8));
+        byte[] largeContent = largeContentBuilder.toByteArray();
+        Files.write(index, largeContent);
+        long originalLength = Files.size(index);
+
+        Object originalScan;
+        try (InputStream in = new ByteArrayInputStream(largeContent)) {
+            originalScan = invoke("scanIndexMarkers", new Class[]{InputStream.class}, in);
+        }
+        long originalBodyEndOffset = (long) recordAccessor(originalScan, "bodyEndOffset");
+
+        var threadMxBean = ManagementFactory.getThreadMXBean();
+        if (!(threadMxBean instanceof com.sun.management.ThreadMXBean sunThreadMxBean)
+                || !sunThreadMxBean.isThreadAllocatedMemorySupported()) {
+            throw new SkipException("Per-thread allocation measurement is not supported on this JVM.");
+        }
+
+        Method method = AllureManager.class.getDeclaredMethod("patchGeneratedAllureReportIndex", Path.class);
+        method.setAccessible(true);
+        long before = sunThreadMxBean.getCurrentThreadAllocatedBytes();
+        method.invoke(null, reportDirectory);
+        long allocated = sunThreadMxBean.getCurrentThreadAllocatedBytes() - before;
+
+        Assert.assertTrue(allocated < 8L * 1024 * 1024, "allocated=" + allocated);
+        Assert.assertTrue(Files.size(index) > originalLength);
+
+        // The last </body> shifts by both patches: the head patch lands before </head>,
+        // and the theme style is inserted immediately before </body> itself.
+        long insertedByteLength = staticStringFieldByteLength("ALLURE_ATTACHMENT_PREVIEW_FIX_STYLE")
+                + staticStringFieldByteLength("ALLURE_ATTACHMENT_PREVIEW_FIX_SCRIPT")
+                + staticStringFieldByteLength("ALLURE_THEME_COLORS_STYLE");
+        try (InputStream in = Files.newInputStream(index)) {
+            Object scan = invoke("scanIndexMarkers", new Class[]{InputStream.class}, in);
+            Assert.assertEquals(recordAccessor(scan, "previewFixPresent"), true);
+            Assert.assertEquals(recordAccessor(scan, "previewScriptPresent"), true);
+            Assert.assertEquals(recordAccessor(scan, "themeColorsPresent"), true);
+            long patchedBodyEndOffset = (long) recordAccessor(scan, "bodyEndOffset");
+            Assert.assertEquals(patchedBodyEndOffset - originalBodyEndOffset, insertedByteLength);
+        }
+    }
+
+    @Test
     public void patchMissingStatusDetailsInResultsShouldPatchResultAndContainerFilesButPreserveAttachments() throws Exception {
         Path resultFile = allureResultsDirectory.resolve("sample-result.json");
         Files.writeString(resultFile, """
@@ -366,6 +506,18 @@ public class AllureManagerCoverageUnitTest {
         Field field = AllureManager.class.getDeclaredField(fieldName);
         field.setAccessible(true);
         field.set(null, value);
+    }
+
+    private static Object recordAccessor(Object record, String componentName) throws Exception {
+        Method accessor = record.getClass().getMethod(componentName);
+        accessor.setAccessible(true);
+        return accessor.invoke(record);
+    }
+
+    private static long staticStringFieldByteLength(String fieldName) throws Exception {
+        Field field = AllureManager.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return ((String) field.get(null)).getBytes(StandardCharsets.UTF_8).length;
     }
 
     private static void resetAllureManagerState() throws Exception {

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureManagerCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureManagerCoverageUnitTest.java
@@ -306,13 +306,13 @@ public class AllureManagerCoverageUnitTest {
             }
         };
 
-        Object scan = invoke("scanIndexMarkers", new Class[]{InputStream.class}, trickleStream);
+        var scan = (AllureManager.IndexMarkerScan) invoke("scanIndexMarkers", new Class[]{InputStream.class}, trickleStream);
 
-        Assert.assertEquals(recordAccessor(scan, "previewFixPresent"), true);
-        Assert.assertEquals(recordAccessor(scan, "previewScriptPresent"), false);
-        Assert.assertEquals(recordAccessor(scan, "themeColorsPresent"), false);
-        Assert.assertEquals(recordAccessor(scan, "headEndOffset"), (long) headEndOffset);
-        Assert.assertEquals(recordAccessor(scan, "bodyEndOffset"), (long) lastBodyEndOffset);
+        Assert.assertTrue(scan.previewFixPresent());
+        Assert.assertFalse(scan.previewScriptPresent());
+        Assert.assertFalse(scan.themeColorsPresent());
+        Assert.assertEquals(scan.headEndOffset(), headEndOffset);
+        Assert.assertEquals(scan.bodyEndOffset(), lastBodyEndOffset);
     }
 
     @Test
@@ -347,11 +347,11 @@ public class AllureManagerCoverageUnitTest {
         Files.write(index, largeContent);
         long originalLength = Files.size(index);
 
-        Object originalScan;
+        AllureManager.IndexMarkerScan originalScan;
         try (InputStream in = new ByteArrayInputStream(largeContent)) {
-            originalScan = invoke("scanIndexMarkers", new Class[]{InputStream.class}, in);
+            originalScan = (AllureManager.IndexMarkerScan) invoke("scanIndexMarkers", new Class[]{InputStream.class}, in);
         }
-        long originalBodyEndOffset = (long) recordAccessor(originalScan, "bodyEndOffset");
+        long originalBodyEndOffset = originalScan.bodyEndOffset();
 
         var threadMxBean = ManagementFactory.getThreadMXBean();
         if (!(threadMxBean instanceof com.sun.management.ThreadMXBean sunThreadMxBean)
@@ -359,27 +359,22 @@ public class AllureManagerCoverageUnitTest {
             throw new SkipException("Per-thread allocation measurement is not supported on this JVM.");
         }
 
-        Method method = AllureManager.class.getDeclaredMethod("patchGeneratedAllureReportIndex", Path.class);
-        method.setAccessible(true);
         long before = sunThreadMxBean.getCurrentThreadAllocatedBytes();
-        method.invoke(null, reportDirectory);
+        invoke("patchGeneratedAllureReportIndex", new Class[]{Path.class}, reportDirectory);
         long allocated = sunThreadMxBean.getCurrentThreadAllocatedBytes() - before;
 
+        long patchedLength = Files.size(index);
         Assert.assertTrue(allocated < 8L * 1024 * 1024, "allocated=" + allocated);
-        Assert.assertTrue(Files.size(index) > originalLength);
+        Assert.assertTrue(patchedLength > originalLength);
 
-        // The last </body> shifts by both patches: the head patch lands before </head>,
+        // The last </body> shifts by every inserted byte: the head patches land before </head>,
         // and the theme style is inserted immediately before </body> itself.
-        long insertedByteLength = staticStringFieldByteLength("ALLURE_ATTACHMENT_PREVIEW_FIX_STYLE")
-                + staticStringFieldByteLength("ALLURE_ATTACHMENT_PREVIEW_FIX_SCRIPT")
-                + staticStringFieldByteLength("ALLURE_THEME_COLORS_STYLE");
         try (InputStream in = Files.newInputStream(index)) {
-            Object scan = invoke("scanIndexMarkers", new Class[]{InputStream.class}, in);
-            Assert.assertEquals(recordAccessor(scan, "previewFixPresent"), true);
-            Assert.assertEquals(recordAccessor(scan, "previewScriptPresent"), true);
-            Assert.assertEquals(recordAccessor(scan, "themeColorsPresent"), true);
-            long patchedBodyEndOffset = (long) recordAccessor(scan, "bodyEndOffset");
-            Assert.assertEquals(patchedBodyEndOffset - originalBodyEndOffset, insertedByteLength);
+            var scan = (AllureManager.IndexMarkerScan) invoke("scanIndexMarkers", new Class[]{InputStream.class}, in);
+            Assert.assertTrue(scan.previewFixPresent());
+            Assert.assertTrue(scan.previewScriptPresent());
+            Assert.assertTrue(scan.themeColorsPresent());
+            Assert.assertEquals(scan.bodyEndOffset() - originalBodyEndOffset, patchedLength - originalLength);
         }
     }
 
@@ -506,18 +501,6 @@ public class AllureManagerCoverageUnitTest {
         Field field = AllureManager.class.getDeclaredField(fieldName);
         field.setAccessible(true);
         field.set(null, value);
-    }
-
-    private static Object recordAccessor(Object record, String componentName) throws Exception {
-        Method accessor = record.getClass().getMethod(componentName);
-        accessor.setAccessible(true);
-        return accessor.invoke(record);
-    }
-
-    private static long staticStringFieldByteLength(String fieldName) throws Exception {
-        Field field = AllureManager.class.getDeclaredField(fieldName);
-        field.setAccessible(true);
-        return ((String) field.get(null)).getBytes(StandardCharsets.UTF_8).length;
     }
 
     private static void resetAllureManagerState() throws Exception {


### PR DESCRIPTION
Closes #3407.

## Problem

`AllureManager.patchGeneratedAllureReportIndex` read the entire generated single-file `index.html` into a `String` (`Files.readString`) and then built additional full copies via `String.substring` concatenation to inject the theme/preview-fix markup. Allure's single-file report inlines every attachment as base64, so on suites with many screenshots the report exceeds the forked surefire JVM heap — `java.lang.OutOfMemoryError: Java heap space` during `engineTearDown`, after all tests had already passed (confirmed in scheduled runs 28916954272 / 28917051358).

## Fix

The method now runs in two bounded-memory passes (64 KB buffers), never holding the report in memory:

1. **Scan** (`scanIndexMarkers(InputStream)`): a single sliding-window byte pass locates the three SHAFT patch-id markers plus the first `</head>` and last `</body>` byte offsets. A carried-over window tail guarantees markers split across read boundaries are found regardless of chunk size. All markers are ASCII, so byte-level search is UTF-8-safe and avoids decoding the file.
2. **Write** (`writePatchedIndex`): a sequential copy through a sibling temp file inserts the head/body patches at the recorded offsets, then atomically replaces `index.html` (with a non-atomic fallback).

Semantics are unchanged: head patches go immediately before the first `</head>` (prepended when absent), the theme style immediately before the last `</body>` (appended when absent), and an already-patched report is detected during the scan and **never rewritten** (the patch constants contain no `</head>`/`</body>` literals, so offsets computed on the original file are equivalent to the old post-insertion string arithmetic).

## Regression tests (per the review suggestions on the issue)

- `patchGeneratedAllureReportIndexShouldStreamLargeReportsWithBoundedAllocation` — patches a ~25 MB synthetic single-file report while measuring per-thread allocation via `com.sun.management.ThreadMXBean`; asserts < 8 MB allocated (the old implementation allocated ≥ 3× the file size) and verifies the patched offsets/markers without loading the file as one `String`. Skips gracefully on JVMs without allocation measurement.
- `scanIndexMarkersShouldFindMarkersSpanningAnyReadBoundary` — drives the scanner with an adversarial 3-bytes-per-read stream so every marker straddles input-buffer boundaries; asserts exact first-`</head>`/last-`</body>` offsets.
- `patchGeneratedAllureReportIndexShouldNotRewriteAlreadyPatchedReport` — pins the mtime and asserts an already-patched file is byte-identical and untouched.
- `patchGeneratedAllureReportIndexShouldHandleMissingHeadAndBodyTags` — prepend/append fallback behavior.

## Verification

`mvn -pl shaft-engine test -Dtest=AllureManagerCoverageUnitTest,AllureManagerUnitTest -DheadlessExecution=true` → 61 run, 60 passed, 0 failed, 1 pre-existing environment-dependent skip (`resolveAllureCommandPrefixShouldPreferSystemAllureWhenVersionIsNot2x`, no system allure binary on PATH). Both existing patch-index tests (idempotency, insertion positions, content) pass unchanged.

Internal performance fix with no public-behavior change, so no docs update is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)