### PR TITLE
Add a portable installer for shaft-cli (--install-shaft-cli)

### DIFF
--- a/.github/workflows/mavenCentral_cd.yml
+++ b/.github/workflows/mavenCentral_cd.yml
@@ -18,6 +18,7 @@ on:
       - 'shaft-ai/**'
       - 'shaft-heal/**'
       - 'shaft-mcp/**'
+      - 'shaft-cli/**'
       - 'shaft-browserstack/**'
       - 'shaft-video/**'
       - 'shaft-visual/**'

--- a/scripts/ci/validate_maven_publication.py
+++ b/scripts/ci/validate_maven_publication.py
@@ -27,6 +27,7 @@ PUBLIC_ARTIFACTS = {
     "shaft-visual": (Path("shaft-visual/pom.xml"), "jar"),
     "shaft-sikulix": (Path("shaft-sikulix/pom.xml"), "jar"),
     "shaft-mcp": (Path("shaft-mcp/pom.xml"), "jar"),
+    "shaft-cli": (Path("shaft-cli/pom.xml"), "jar"),
     "shaft-bom": (Path("shaft-bom/pom.xml"), "pom"),
     "SHAFT_ENGINE": (Path("legacy-shaft-engine/pom.xml"), "pom"),
 }

--- a/scripts/ci/verify_shaft_mcp_installer_release.py
+++ b/scripts/ci/verify_shaft_mcp_installer_release.py
@@ -214,6 +214,45 @@ def verify_configuration(configuration: Path, java: Path, args: Path, root_prope
         raise RuntimeError(f"Unexpected shaft-mcp arguments in {configuration}: {entry['args']}")
 
 
+def installed_shaft_cli_jar(root: Path, home: Path, environment: dict[str, str]) -> Path:
+    system = platform.system()
+    if system == "Windows":
+        versions = root / "local-app-data" / "ShaftHQ" / "shaft-cli" / "versions"
+    elif system == "Darwin":
+        versions = home / "Library" / "Application Support" / "ShaftHQ" / "shaft-cli" / "versions"
+    elif system == "Linux":
+        versions = Path(environment["XDG_DATA_HOME"]) / "shafthq" / "shaft-cli" / "versions"
+    else:
+        raise RuntimeError(f"Unsupported release-verification operating system: {system}")
+    jars = list(versions.glob("*/shaft-cli.jar"))
+    if len(jars) != 1:
+        raise RuntimeError(f"Expected one installed shaft-cli JAR, found: {jars}")
+    return jars[0].resolve()
+
+
+def verify_shaft_cli_launcher(jar: Path) -> Path:
+    args = jar.with_name("shaft-cli.args")
+    if not args.is_file():
+        raise RuntimeError(f"Expected installed shaft-cli argfile: {args}")
+    content = args.read_text(encoding="utf-8")
+    if "-jar" not in content or jar.name not in content:
+        raise RuntimeError(f"Installed shaft-cli argfile does not reference the jar: {args}")
+    wrapper = jar.with_name("shaft-cli.cmd" if platform.system() == "Windows" else "shaft-cli")
+    if not wrapper.is_file():
+        raise RuntimeError(f"Expected installed shaft-cli launcher: {wrapper}")
+    if platform.system() != "Windows" and not os.access(wrapper, os.X_OK):
+        raise RuntimeError(f"Installed shaft-cli launcher is not executable: {wrapper}")
+    return wrapper.resolve()
+
+
+def verify_shaft_cli_result(result: dict[str, object], launcher: Path) -> None:
+    shaft_cli = result.get("shaftCli")
+    if not isinstance(shaft_cli, dict) or shaft_cli.get("installed") is not True:
+        raise RuntimeError(f"Expected IntelliJ plugin installer to install shaft-cli when requested: {result}")
+    if Path(str(shaft_cli.get("launcher", ""))).resolve() != launcher:
+        raise RuntimeError(f"Unexpected shaft-cli launcher in installer output: {result}")
+
+
 def verify_plugin_json(result: dict[str, object], java: Path, args: Path) -> None:
     if result.get("client") != "intellij-plugin":
         raise RuntimeError(f"Unexpected IntelliJ plugin installer target: {result}")
@@ -259,7 +298,7 @@ def main() -> int:
 
         java = expected_java(environment)
         plugin_install = run_installer(
-            installer_command("intellij-plugin", "--json"),
+            installer_command("intellij-plugin", "--install-shaft-cli", "--json"),
             cwd=root,
             environment=environment,
             capture=True,
@@ -271,6 +310,9 @@ def main() -> int:
         skills_path = Path(str(shaft_skills.get("path", "")))
         if not (skills_path / "writing-shaft-tests" / "SKILL.md").is_file():
             raise RuntimeError(f"Expected SHAFT skills to be installed by the unattended plugin installer: {skills_path}")
+        shaft_cli_jar = installed_shaft_cli_jar(root, home, environment)
+        shaft_cli_launcher = verify_shaft_cli_launcher(shaft_cli_jar)
+        verify_shaft_cli_result(plugin_result, shaft_cli_launcher)
         for client in clients:
             run_installer(installer_command(client), cwd=root, environment=environment)
 

--- a/scripts/mcp/install_shaft_mcp.py
+++ b/scripts/mcp/install_shaft_mcp.py
@@ -31,6 +31,8 @@ ARTIFACT_PATH = "io/github/shafthq/shaft-mcp"
 DEFAULT_REPOSITORY = "https://repo.maven.apache.org/maven2"
 MAIN_CLASS = "com.shaft.mcp.ShaftMcpApplication"
 RUNTIME_DEPENDENCIES_ENTRY = "META-INF/shaft-mcp/runtime-dependencies.txt"
+SHAFT_CLI_ARTIFACT_PATH = "io/github/shafthq/shaft-cli"
+SHAFT_CLI_MAIN_CLASS = "com.shaft.commandline.ShaftCli"
 # Explicit per-project override honored by shaft-mcp; the installer must never pin it
 # globally ("shaft.mcp.workspaceRoot") or every non-IntelliJ client would be locked out
 # of its own project. Only the fallback below is written to the launcher argfile.
@@ -214,6 +216,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_true",
         help="Do not install SHAFT agent skills into the current directory.",
     )
+    parser.add_argument(
+        "--install-shaft-cli",
+        action="store_true",
+        help="Also install shaft-cli, a command-line client over the shaft-mcp tool set.",
+    )
     for target, _ in TARGET_CHOICES:
         parser.add_argument(f"--{target}", action="store_true", dest=target.replace("-", "_"))
     parser.add_argument(
@@ -290,6 +297,17 @@ def application_data_root() -> Path:
         return home() / "Library" / "Application Support" / "ShaftHQ" / "shaft-mcp"
     base = Path(os.environ.get("XDG_DATA_HOME") or home() / ".local" / "share")
     return base / "shafthq" / "shaft-mcp"
+
+
+def shaft_cli_application_data_root() -> Path:
+    name = system_name()
+    if name == "Windows":
+        base = Path(os.environ.get("LOCALAPPDATA") or home() / "AppData" / "Local")
+        return base / "ShaftHQ" / "shaft-cli"
+    if name == "Darwin":
+        return home() / "Library" / "Application Support" / "ShaftHQ" / "shaft-cli"
+    base = Path(os.environ.get("XDG_DATA_HOME") or home() / ".local" / "share")
+    return base / "shafthq" / "shaft-cli"
 
 
 def maven_local_repository() -> Path:
@@ -603,6 +621,31 @@ def install_shaft_mcp_jar(version: str, repository: str, root: Path) -> Path:
     return target.resolve()
 
 
+def install_shaft_cli_jar(version: str, repository: str, root: Path) -> Path:
+    """
+    Downloads and verifies shaft-cli's self-contained shaded jar. Unlike shaft-mcp's thin
+    jar, shaft-cli has no runtime-dependency manifest to resolve and is not a build-time
+    Maven dependency, so there is no local Maven repository mirror to maintain here.
+    """
+    version_path = f"{SHAFT_CLI_ARTIFACT_PATH}/{version}"
+    filename = f"shaft-cli-{version}.jar"
+    url = f"{repository}/{version_path}/{filename}"
+    expected = expected_sha256(url)
+    target_dir = shaft_cli_application_data_root() / "versions" / version
+    target = target_dir / "shaft-cli.jar"
+    if target.is_file() and file_sha256(target) == expected:
+        log(f"shaft-cli {version} is already installed and up to date (download skipped).")
+        return target.resolve()
+
+    source = root / "downloads" / filename
+    download_file(url, source, f"io.github.shafthq:shaft-cli:{version}")
+    if file_sha256(source) != expected:
+        fail(f"Checksum verification failed for {source}.", 4)
+
+    copy_verified(source, target, expected, "Installed shaft-cli JAR")
+    return target.resolve()
+
+
 def copy_verified(source: Path, target: Path, expected_sha256_digest: str, label: str) -> None:
     target.parent.mkdir(parents=True, exist_ok=True)
     temporary = target.with_name(f".{target.name}.{os.getpid()}.tmp")
@@ -886,6 +929,36 @@ def write_launcher_args(jar: Path, dependencies: list[Path]) -> Path:
     temporary.write_text(content, encoding="utf-8", newline="\n")
     os.replace(temporary, args_file)
     return args_file.resolve()
+
+
+def write_text_with_replace(path: Path, content: str) -> None:
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(content, encoding="utf-8", newline="\n")
+    os.replace(temporary, path)
+
+
+def write_shaft_cli_launcher(java: Path, jar: Path) -> Path:
+    """
+    Writes shaft-cli.args (a Java @argfile, resolved the same way agent clients resolve
+    shaft-mcp.args) plus a directly runnable wrapper script next to the jar, so both a
+    future programmatic launcher and a human at a terminal have a stable entry point.
+    """
+    args_file = jar.parent / "shaft-cli.args"
+    args_content = "\n".join(("-jar", java_argfile_quote(str(jar.resolve())))) + "\n"
+    write_text_with_replace(args_file, args_content)
+
+    java_path = str(java.resolve())
+    args_path = str(args_file.resolve())
+    if system_name() == "Windows":
+        wrapper = jar.parent / "shaft-cli.cmd"
+        wrapper_content = f'@echo off\r\n"{java_path}" @"{args_path}" %*\r\n'
+    else:
+        wrapper = jar.parent / "shaft-cli"
+        wrapper_content = f'#!/usr/bin/env sh\nexec "{java_path}" @"{args_path}" "$@"\n'
+    write_text_with_replace(wrapper, wrapper_content)
+    if system_name() != "Windows":
+        wrapper.chmod(wrapper.stat().st_mode | 0o111)
+    return wrapper.resolve()
 
 
 def read_lines(stream: Any, target: queue.Queue[str], sink: list[str] | None = None) -> None:
@@ -1304,6 +1377,12 @@ def install(args: argparse.Namespace) -> None:
     log(f"Verifying shaft-mcp {version} over stdio...")
     probe_stdio(java, args_file)
 
+    shaft_cli_launcher = None
+    if args.install_shaft_cli:
+        log(f"Installing io.github.shafthq:shaft-cli:{version}")
+        shaft_cli_jar = install_shaft_cli_jar(version, repository, root)
+        shaft_cli_launcher = write_shaft_cli_launcher(java, shaft_cli_jar)
+
     if args.client != "intellij-plugin":
         log(f"Configuring shaft-mcp for {args.client}...")
         configure_client(args.client, java, args_file)
@@ -1341,6 +1420,11 @@ def install(args: argparse.Namespace) -> None:
             "installed": True,
             "path": str(validation_script_dir),
         }
+    if shaft_cli_launcher:
+        result["shaftCli"] = {
+            "installed": True,
+            "launcher": str(shaft_cli_launcher),
+        }
     if args.json:
         print(json.dumps(result, separators=(",", ":")))
     else:
@@ -1352,6 +1436,8 @@ def install(args: argparse.Namespace) -> None:
                 print(f"Agent validation script files installed at {validation_script_dir}.")
         else:
             print(f"SHAFT skills installation skipped for {skills_path}.")
+        if shaft_cli_launcher:
+            print(f"shaft-cli {version} installed; run it at {shaft_cli_launcher}")
         print(activation_hint(args.client))
         print(f"User guide: {USER_GUIDE_URL}")
 

--- a/shaft-cli/README.md
+++ b/shaft-cli/README.md
@@ -2,6 +2,12 @@
 
 shaft-cli is an MCP client and command-line interface to shaft-mcp. It brings all 147 shaft-mcp tools to the command line with zero tool-logic duplication, operating in two modes: stateless one-shot commands and persistent session mode for stateful tools.
 
+## Install
+
+Pass `--install-shaft-cli` to the shaft-mcp installer (`scripts/mcp/install-shaft-mcp.sh` / `.ps1`, or the public copy-paste command documented at https://shafthq.github.io/docs/agentic/mcp) to also install shaft-cli — no local Java or Python required; the installer bootstraps whatever is missing. The flag is independent of `--client`, so it can be combined with any MCP client target, or run on its own.
+
+The installer downloads and SHA-256-verifies `shaft-cli-<version>.jar` from Maven Central, then writes a runnable launcher (`shaft-cli` on macOS/Linux, `shaft-cli.cmd` on Windows) plus a `shaft-cli.args` Java argfile next to it, under the platform's application-data root — e.g. `%LOCALAPPDATA%\ShaftHQ\shaft-cli\versions\<version>\` on Windows, `~/Library/Application Support/ShaftHQ/shaft-cli/versions/<version>/` on macOS, `${XDG_DATA_HOME:-~/.local/share}/shafthq/shaft-cli/versions/<version>/` on Linux.
+
 ## Modes
 
 **One-shot mode** (default): Each command spawns an ephemeral shaft-mcp child process over stdio, runs a single tool call, and exits. Suitable for stateless tools like guide search and doctor analysis.
@@ -91,4 +97,4 @@ Only picocli and Jackson. No compile-time dependency on shaft-mcp or any shaft m
 
 ## Scope
 
-Installer `--cli` flag, docs-site page, shell completion, and native binaries are out of scope for the MVP.
+Docs-site page, shell completion, and native binaries are out of scope for the MVP. (Installer support shipped — see Install above.)

--- a/tests/scripts/test_install_shaft_mcp.py
+++ b/tests/scripts/test_install_shaft_mcp.py
@@ -495,6 +495,68 @@ class InstallShaftMcpTest(unittest.TestCase):
             args = MODULE.parse_args(["--codex"])
         self.assertEqual("0.5.0", args.version)
 
+    def test_parse_install_shaft_cli_flag_independent_of_client(self):
+        args = MODULE.parse_args(["--codex", "--install-shaft-cli"])
+
+        self.assertEqual("codex", args.client)
+        self.assertTrue(args.install_shaft_cli)
+
+    def test_install_shaft_cli_jar_from_file_repository(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            repository = root / "repo"
+            version = "1.0.0"
+            artifact = (repository / "io" / "github" / "shafthq" / "shaft-cli" / version
+                        / f"shaft-cli-{version}.jar")
+            artifact.parent.mkdir(parents=True)
+            artifact.write_bytes(b"shaft-cli-jar-bytes")
+            artifact.with_name(artifact.name + ".sha256").write_text(
+                hashlib.sha256(b"shaft-cli-jar-bytes").hexdigest() + "\n",
+                encoding="utf-8",
+            )
+
+            with temporary_environment(
+                    HOME=str(root / "home"),
+                    USERPROFILE=str(root / "home"),
+                    LOCALAPPDATA=str(root / "local-app-data"),
+                    XDG_DATA_HOME=str(root / "xdg-data")), \
+                    contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                jar = MODULE.install_shaft_cli_jar(version, repository.as_uri(), root)
+                # A second run must skip the download: a verified copy already exists locally.
+                reinstalled = MODULE.install_shaft_cli_jar(version, repository.as_uri(), root)
+                expected = (MODULE.shaft_cli_application_data_root() / "versions" / version
+                            / "shaft-cli.jar").resolve()
+
+            self.assertEqual(b"shaft-cli-jar-bytes", jar.read_bytes())
+            self.assertEqual(expected, jar)
+            self.assertEqual(jar, reinstalled)
+
+    def test_write_shaft_cli_launcher(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            java = root / "java"
+            jar = root / "versions" / "1.0.0" / "shaft-cli.jar"
+            jar.parent.mkdir(parents=True)
+            jar.write_bytes(b"")
+
+            launcher = MODULE.write_shaft_cli_launcher(java, jar)
+
+            args_file = jar.parent / "shaft-cli.args"
+            self.assertTrue(args_file.is_file())
+            args_content = args_file.read_text(encoding="utf-8")
+            self.assertIn("-jar", args_content)
+            self.assertIn(MODULE.java_argfile_quote(str(jar.resolve())), args_content)
+
+            self.assertTrue(launcher.is_file())
+            launcher_content = launcher.read_text(encoding="utf-8")
+            self.assertIn(str(java.resolve()), launcher_content)
+            self.assertIn(str(args_file.resolve()), launcher_content)
+            if MODULE.system_name() == "Windows":
+                self.assertEqual("shaft-cli.cmd", launcher.name)
+            else:
+                self.assertEqual("shaft-cli", launcher.name)
+                self.assertTrue(os.access(launcher, os.X_OK))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Adds an opt-in `--install-shaft-cli` flag to the existing shaft-mcp installer (`scripts/mcp/install_shaft_mcp.py`), mirroring shaft-mcp's own portable, dependency-free install path: downloads and SHA-256-verifies shaft-cli's shaded jar from Maven Central, then writes a runnable launcher (`shaft-cli`/`shaft-cli.cmd`) plus a Java argfile next to it under a per-OS app-data root. shaft-cli's own README already named this exact extension point ("Installer `--cli` flag ... out of scope for the MVP").
- Fixes a release-pipeline gap discovered while building this: shaft-cli (merged in #3439) was missing from `mavenCentral_cd.yml`'s trigger paths and from `validate_maven_publication.py`'s `PUBLIC_ARTIFACTS`, so it had never actually been published to Maven Central. Confirmed empirically via a `search.maven.org` query (`numFound: 0`) before starting. Both are fixed so the installer has something to download once this releases.
- Extends the post-deploy release verification (`verify_shaft_mcp_installer_release.py` + the `verify_public_shaft_mcp_installer` job) to also exercise `--install-shaft-cli` and assert the jar/launcher land correctly.

First slice of a larger epic tracked in #3443: IntelliJ plugin setup-step integration, making shaft-cli the assistant panel's primary transport (shaft-mcp as fallback), routing shaft-skills through cached shaft-cli commands, and giving shaft-upgrader an AI-powered mode — all follow-ups that depend on this installer existing.

## Test plan

- [x] `py -3 -m py_compile scripts/mcp/install_shaft_mcp.py` and `scripts/ci/verify_shaft_mcp_installer_release.py`
- [x] `py -3 -m unittest tests.scripts.test_install_shaft_mcp -v` — 33/33 pass, including new offline tests using the existing `file://` repository fixture pattern (no network needed)
- [x] `py -3 scripts/ci/validate_maven_publication.py` — passes with shaft-cli added
- [x] `py -3 scripts/ci/validate_installer_contract.py` — passes unchanged (this change doesn't touch MCP client `TARGETS`)
- [ ] Live end-to-end run of the public installer against a real published shaft-cli version — not possible yet since nothing is on Maven Central until this PR's release ships; the extended `verify_public_shaft_mcp_installer` CI job will exercise it for real on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)