### PR TITLE
ci: add PR-blocking path-filtered documentation-boundary gate

### DIFF
--- a/.github/workflows/docs-boundary-gate.yml
+++ b/.github/workflows/docs-boundary-gate.yml
@@ -1,0 +1,27 @@
+name: Documentation Boundary Gate
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+      - "**/*.mdx"
+      - "scripts/ci/validate_documentation_boundaries.py"
+      - ".github/workflows/docs-boundary-gate.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-boundary-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  documentation-boundary-gate:
+    name: Documentation Boundary Gate
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Validate documentation boundaries
+        run: python3 scripts/ci/validate_documentation_boundaries.py


### PR DESCRIPTION
## Summary
Implements #3447: adds `.github/workflows/docs-boundary-gate.yml`, a `pull_request`-triggered gate that runs `scripts/ci/validate_documentation_boundaries.py`, path-filtered to `**/*.md` / `**/*.mdx`, the validator script itself, and the gate workflow file.

## Notes
- Ran the validator against current `origin/main` first as the issue requires: **clean** (`Documentation boundary is valid (237 tracked Markdown files)`), so no latent violations will block unrelated Markdown PRs.
- Conventions copied from `shaft-pilot-release.yml` / `mavenCentral_cd.yml`: `ubuntu-22.04`, `actions/checkout@v7`, bare `python3` invocation (no setup-python), `permissions: contents: read`, per-PR concurrency group.
- No external allowlist file exists — `ALLOWED_EXACT`/`ALLOWED_GLOBS` are hardcoded in the script, so the path filter needs nothing beyond the script itself.
- The workflow self-includes its own path, so this PR itself exercises the gate.
- Flipping the check to *required* is a repo-settings action (Settings → Branches) that has to be done by an admin after this merges.

Closes #3447

🤖 Generated with [Claude Code](https://claude.com/claude-code)