### PR TITLE
fix: OpenCV template-match false negatives (MAX_PATH imread + tiny-screenshot watermark crash)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotHelper.java
@@ -93,8 +93,14 @@ public class ScreenshotHelper {
             return (BufferedImage) img;
         }
 
+        // Image#getScaledInstance() can round a dimension down to 0 for extreme downscale ratios
+        // (e.g. watermarking a very small screenshot); clamp to 1px so this never throws
+        // "Width/height cannot be <= 0" instead of just producing a barely-visible watermark.
+        int width = Math.max(1, img.getWidth(null));
+        int height = Math.max(1, img.getHeight(null));
+
         // Create a buffered image with transparency
-        BufferedImage bufferedImage = new BufferedImage(img.getWidth(null), img.getHeight(null), BufferedImage.TYPE_INT_ARGB);
+        BufferedImage bufferedImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
 
         // Draw the image on to the buffered image
         Graphics2D bGr = bufferedImage.createGraphics();

--- a/shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java
+++ b/shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java
@@ -82,13 +82,29 @@ public class OpenCvVisualProcessingProvider implements VisualProcessingProvider 
         return imgThreshold;
     }
 
+    /**
+     * Decodes an image file from disk via an in-memory byte buffer instead of {@link Imgcodecs#imread(String)}.
+     * {@code imread} opens the path through the native OS file APIs, which silently fail (returning an empty
+     * {@link Mat}, not an exception) for absolute paths beyond the Windows {@code MAX_PATH} (260 character) limit —
+     * a realistic scenario for the AI-aided element identification folder nested under a long project/build path.
+     * Reading the bytes with Java NIO and decoding them with {@link Imgcodecs#imdecode} sidesteps that native path
+     * handling entirely, mirroring how the current-page screenshot bytes are already decoded above.
+     */
+    private static Mat readImage(String imagePath) {
+        try {
+            return Imgcodecs.imdecode(new MatOfByte(Files.readAllBytes(Paths.get(imagePath))), Imgcodecs.IMREAD_COLOR);
+        } catch (IOException e) {
+            return new Mat();
+        }
+    }
+
     private static List<Integer> attemptToFindImageUsingOpenCV(String referenceImagePath, byte[] currentPageScreenshot) {
         if (currentPageScreenshot == null || Arrays.equals(currentPageScreenshot, new byte[]{})) {
             //target image is empty, force fail comparison
             ReportManager.log("Failed to identify the element using AI; target screenshot is empty.");
         } else {
             Mat img_original = Imgcodecs.imdecode(new MatOfByte(currentPageScreenshot), Imgcodecs.IMREAD_COLOR);
-            Mat templ_original = Imgcodecs.imread(referenceImagePath, Imgcodecs.IMREAD_COLOR);
+            Mat templ_original = readImage(referenceImagePath);
             if (img_original.empty() || templ_original.empty()) {
                 ReportManager.log("Failed to identify the element using AI; target or reference image is invalid.");
                 return Collections.emptyList();


### PR DESCRIPTION
## Summary
Fixes #3382. The three `ImageProcessingActionsCoverageUnitTest` isolation failures were caused by **two production bugs**, not matcher warm-up sensitivity:

1. **`Imgcodecs.imread` silently fails past Windows MAX_PATH.** The baseline image was loaded with `imread(path)`, which returns an empty `Mat` (no exception) for absolute paths >260 chars — proven by an A/B probe on identical bytes (imdecode OK, imread at short path OK, imread at the real 293-char path empty). Now decoded from bytes via `Files.readAllBytes` + `imdecode`, mirroring how the live screenshot is already decoded.
2. **Static watermark-logo cache breaks on a tiny first screenshot.** `ScreenshotHelper` scales the logo to `width/8` of the first screenshot processed in the JVM; a 12×12 synthetic PNG yielded a 0-height scaled image, `toBufferedImage` threw, and a broad `catch` in `findImageWithinCurrentPage` silently converted an accuracy-1.0 match into a false negative. Dimensions are now clamped to 1px. This is exactly the order dependency observed: in the full suite a real screenshot warms the cache first.

## Verification
- `mvn -pl shaft-visual test -Dtest=ImageProcessingActionsCoverageUnitTest -DheadlessExecution=true`: all tests pass in isolation (was 3 failures); re-verified independently after review.
- Each of the 3 originally-failing methods run individually: pass.
- `OpenCvScreenshotDiffTest` in isolation: 6/6 pass, no regression.

## Follow-up (out of scope, will file separately)
In `attemptToFindImageUsingOpenCV`, report-attachment failures other than `IOException` still fail the whole match; attachment errors should be non-fatal to the match verdict.

Closes #3382

🤖 Generated with [Claude Code](https://claude.com/claude-code)