### PR TITLE
feat: land the remaining composable scope of #3349 (baseline naming, recorder assertions, MCP a11y tools)

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/AssertionCatalog.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/AssertionCatalog.java
@@ -19,7 +19,9 @@ public final class AssertionCatalog {
             entry(CaptureEvent.VerificationKind.TEXT_EQUALS, "Text equals", true, false),
             entry(CaptureEvent.VerificationKind.TEXT_CONTAINS, "Text contains", true, false),
             entry(CaptureEvent.VerificationKind.ATTRIBUTE_EQUALS, "Attribute equals", true, true),
-            entry(CaptureEvent.VerificationKind.ELEMENT_IMAGE_MATCHES, "Image matches reference", false, false));
+            entry(CaptureEvent.VerificationKind.ELEMENT_IMAGE_MATCHES, "Image matches reference", false, false),
+            entry(CaptureEvent.VerificationKind.ARIA_SNAPSHOT_MATCHES, "Aria snapshot matches", true, false),
+            entry(CaptureEvent.VerificationKind.SCREENSHOT_MATCHES, "Screenshot matches baseline", false, false));
 
     private static final List<Entry> BROWSER_ASSERTIONS = List.of(
             entry(CaptureEvent.VerificationKind.URL_EQUALS, "URL equals", true, false),

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -478,7 +478,7 @@ public final class CaptureGenerator {
             }
         } else if (event instanceof CaptureEvent.VerificationEvent value) {
             validateVerification(id, value.verification(), value.target(), value.expected(),
-                    value.context(), unsupported);
+                    value.negated(), value.context(), unsupported);
         } else if (event instanceof CaptureEvent.FrameEvent value
                 && backend == CodegenBackend.PLAYWRIGHT
                 && value.action() != CaptureEvent.FrameAction.TOP) {
@@ -501,6 +501,7 @@ public final class CaptureGenerator {
             CaptureEvent.VerificationKind verification,
             ElementSnapshot target,
             ExternalTestDataReference expected,
+            boolean negated,
             EventContext context,
             List<String> unsupported) {
         boolean targetRequired = switch (verification) {
@@ -509,7 +510,7 @@ public final class CaptureGenerator {
         };
         boolean expectedRequired = switch (verification) {
             case TEXT_EQUALS, TEXT_CONTAINS, ATTRIBUTE_EQUALS, URL_EQUALS, URL_CONTAINS,
-                 TITLE_EQUALS, TITLE_CONTAINS, PAGE_TEXT_CONTAINS -> true;
+                 TITLE_EQUALS, TITLE_CONTAINS, PAGE_TEXT_CONTAINS, ARIA_SNAPSHOT_MATCHES -> true;
             default -> false;
         };
         if (targetRequired && target == null) {
@@ -524,6 +525,10 @@ public final class CaptureGenerator {
         if (verification == CaptureEvent.VerificationKind.ATTRIBUTE_EQUALS
                 && extensionText(context, "attributeName").isBlank()) {
             unsupported.add(eventId + ": ATTRIBUTE_EQUALS requires context.extensions.attributeName.");
+        }
+        if ((verification == CaptureEvent.VerificationKind.ARIA_SNAPSHOT_MATCHES
+                || verification == CaptureEvent.VerificationKind.SCREENSHOT_MATCHES) && negated) {
+            unsupported.add(eventId + ": " + verification + " does not support negated verification.");
         }
     }
 
@@ -1229,6 +1234,10 @@ public final class CaptureGenerator {
                     negated ? "doesNotContain" : "contains", dataExpression(expected, data));
             case ELEMENT_IMAGE_MATCHES -> line(source, "        driver.element().assertThat(" + locator + ")."
                     + (negated ? "doesNotMatchReferenceImage" : "matchesReferenceImage") + "();");
+            case ARIA_SNAPSHOT_MATCHES -> line(source, "        driver.element().assertThat(" + locator
+                    + ").matchesAriaSnapshot(" + dataExpression(expected, data) + ");");
+            case SCREENSHOT_MATCHES -> line(source, "        driver.element().assertThat(" + locator
+                    + ").matchesScreenshot().perform();");
         }
     }
 

--- a/shaft-capture/src/main/java/com/shaft/capture/model/CaptureEvent.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/model/CaptureEvent.java
@@ -129,7 +129,9 @@ public sealed interface CaptureEvent permits CaptureEvent.NavigationEvent, Captu
         TITLE_EQUALS,
         TITLE_CONTAINS,
         PAGE_TEXT_CONTAINS,
-        ELEMENT_IMAGE_MATCHES
+        ELEMENT_IMAGE_MATCHES,
+        ARIA_SNAPSHOT_MATCHES,
+        SCREENSHOT_MATCHES
     }
 
     /**

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
@@ -427,7 +427,7 @@ final class CaptureEventPipeline implements AutoCloseable {
         };
         boolean expectedRequired = switch (kind) {
             case TEXT_EQUALS, TEXT_CONTAINS, ATTRIBUTE_EQUALS, URL_EQUALS, URL_CONTAINS,
-                 TITLE_EQUALS, TITLE_CONTAINS, PAGE_TEXT_CONTAINS -> true;
+                 TITLE_EQUALS, TITLE_CONTAINS, PAGE_TEXT_CONTAINS, ARIA_SNAPSHOT_MATCHES -> true;
             default -> false;
         };
         SafeTarget safeTarget = targetRequired ? target(signal) : null;

--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -703,7 +703,9 @@
     {kind: "TEXT_EQUALS", label: "Text equals", needsValue: true, needsAttribute: false},
     {kind: "TEXT_CONTAINS", label: "Text contains", needsValue: true, needsAttribute: false},
     {kind: "ATTRIBUTE_EQUALS", label: "Attribute equals", needsValue: true, needsAttribute: true},
-    {kind: "ELEMENT_IMAGE_MATCHES", label: "Image matches reference", needsValue: false, needsAttribute: false}
+    {kind: "ELEMENT_IMAGE_MATCHES", label: "Image matches reference", needsValue: false, needsAttribute: false},
+    {kind: "ARIA_SNAPSHOT_MATCHES", label: "Aria snapshot matches", needsValue: true, needsAttribute: false},
+    {kind: "SCREENSHOT_MATCHES", label: "Screenshot matches baseline", needsValue: false, needsAttribute: false}
   ];
   const BROWSER_ASSERTIONS = [
     {kind: "URL_EQUALS", label: "URL equals", needsValue: true, needsAttribute: false},
@@ -717,6 +719,9 @@
     if (kind === "TITLE_EQUALS" || kind === "TITLE_CONTAINS") return valueText(document.title);
     if (kind === "PAGE_TEXT_CONTAINS") return valueText(document.body && document.body.innerText);
     if (kind === "ATTRIBUTE_EQUALS") return valueText(element && element.getAttribute(attributeName));
+    // The aria-snapshot baseline file name is unrelated to the element's current text/attribute
+    // content, so leave the field blank instead of prefilling it with a misleading default.
+    if (kind === "ARIA_SNAPSHOT_MATCHES") return "";
     if (isTextInput(element)) return valueText(element.value);
     return text(element && (element.innerText || element.textContent));
   };

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/AssertionCatalogTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/AssertionCatalogTest.java
@@ -20,7 +20,9 @@ class AssertionCatalogTest {
                 CaptureEvent.VerificationKind.TEXT_EQUALS,
                 CaptureEvent.VerificationKind.TEXT_CONTAINS,
                 CaptureEvent.VerificationKind.ATTRIBUTE_EQUALS,
-                CaptureEvent.VerificationKind.ELEMENT_IMAGE_MATCHES),
+                CaptureEvent.VerificationKind.ELEMENT_IMAGE_MATCHES,
+                CaptureEvent.VerificationKind.ARIA_SNAPSHOT_MATCHES,
+                CaptureEvent.VerificationKind.SCREENSHOT_MATCHES),
                 kinds);
     }
 
@@ -56,5 +58,22 @@ class AssertionCatalogTest {
         for (AssertionCatalog.Entry entry : AssertionCatalog.browserAssertions()) {
             assertEquals(true, entry.needsValue(), entry.kind() + " expected-value prompt flag");
         }
+    }
+
+    @Test
+    void ariaSnapshotMatchesPromptsForTheBaselineNameButScreenshotMatchesDoesNot() {
+        AssertionCatalog.Entry ariaSnapshot = AssertionCatalog.elementAssertions().stream()
+                .filter(entry -> entry.kind() == CaptureEvent.VerificationKind.ARIA_SNAPSHOT_MATCHES)
+                .findFirst()
+                .orElseThrow();
+        assertEquals(true, ariaSnapshot.needsValue());
+        assertEquals(false, ariaSnapshot.needsAttribute());
+
+        AssertionCatalog.Entry screenshot = AssertionCatalog.elementAssertions().stream()
+                .filter(entry -> entry.kind() == CaptureEvent.VerificationKind.SCREENSHOT_MATCHES)
+                .findFirst()
+                .orElseThrow();
+        assertEquals(false, screenshot.needsValue());
+        assertEquals(false, screenshot.needsAttribute());
     }
 }

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -535,6 +535,82 @@ class CaptureGeneratorTest {
     }
 
     @Test
+    void generatorRendersAriaSnapshotAndScreenshotVerificationCheckpoints() throws Exception {
+        ExternalTestDataReference expected = CaptureFixtures.ordinary();
+        CaptureSession verificationSession = new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "aria-screenshot-verification-session",
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(5),
+                CaptureFixtures.browser(),
+                List.of(
+                        new CaptureEvent.NavigationEvent(CaptureFixtures.context(1),
+                                CaptureEvent.NavigationAction.OPEN, "https://example.test/form"),
+                        new CaptureEvent.VerificationEvent(CaptureFixtures.context(2),
+                                CaptureEvent.VerificationKind.ARIA_SNAPSHOT_MATCHES,
+                                CaptureFixtures.target(), expected, false),
+                        new CaptureEvent.VerificationEvent(CaptureFixtures.context(3),
+                                CaptureEvent.VerificationKind.SCREENSHOT_MATCHES,
+                                CaptureFixtures.target(), null, false)),
+                List.of(),
+                List.of(expected),
+                com.shaft.capture.model.RedactionSummary.empty(),
+                Map.of());
+        Path session = session(verificationSession);
+        writeCaptureData("alice");
+
+        CaptureGenerationResult result =
+                new CaptureGenerator().generate(request(session, temp.resolve("aria-screenshot-verification")));
+
+        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        String source = Files.readString(result.sourcePath());
+        assertTrue(source.contains(
+                "driver.element().assertThat(SHAFT.GUI.Locator.inputField(\"Username\"))"
+                        + ".matchesAriaSnapshot(requiredData(\"username\"));"));
+        assertTrue(source.contains(
+                "driver.element().assertThat(SHAFT.GUI.Locator.inputField(\"Username\")).matchesScreenshot().perform();"));
+    }
+
+    @Test
+    void negatedAriaSnapshotAndScreenshotVerificationsAreUnsupported() throws Exception {
+        ExternalTestDataReference expected = CaptureFixtures.ordinary();
+        CaptureSession verificationSession = new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "negated-aria-screenshot-verification-session",
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(5),
+                CaptureFixtures.browser(),
+                List.of(
+                        new CaptureEvent.NavigationEvent(CaptureFixtures.context(1),
+                                CaptureEvent.NavigationAction.OPEN, "https://example.test/form"),
+                        new CaptureEvent.VerificationEvent(CaptureFixtures.context(2),
+                                CaptureEvent.VerificationKind.ARIA_SNAPSHOT_MATCHES,
+                                CaptureFixtures.target(), expected, true),
+                        new CaptureEvent.VerificationEvent(CaptureFixtures.context(3),
+                                CaptureEvent.VerificationKind.SCREENSHOT_MATCHES,
+                                CaptureFixtures.target(), null, true)),
+                List.of(),
+                List.of(expected),
+                com.shaft.capture.model.RedactionSummary.empty(),
+                Map.of());
+        Path session = session(verificationSession);
+        writeCaptureData("alice");
+
+        CaptureGenerationResult result =
+                new CaptureGenerator().generate(request(session, temp.resolve("negated-aria-screenshot")));
+
+        assertFalse(result.successful());
+        assertTrue(result.report().unsupportedEvents().stream()
+                .anyMatch(unsupported -> unsupported.contains("ARIA_SNAPSHOT_MATCHES")
+                        && unsupported.contains("does not support negated verification")));
+        assertTrue(result.report().unsupportedEvents().stream()
+                .anyMatch(unsupported -> unsupported.contains("SCREENSHOT_MATCHES")
+                        && unsupported.contains("does not support negated verification")));
+    }
+
+    @Test
     void recordedElementAssertionWithChosenLocatorAndTestDataGeneratesMatchingValidationsCall() throws Exception {
         ExternalTestDataReference expected = CaptureFixtures.ordinary();
         ElementSnapshot target = CaptureFixtures.target();

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
@@ -223,7 +223,7 @@ public class ImageProcessingActions {
     }
 
     private static byte[] getReferenceImageByHashedLocatorName(String hashedLocatorName) {
-        String referenceImagePath = getAiFolderPath() + hashedLocatorName + ".png";
+        String referenceImagePath = resolveExistingBaselinePath(hashedLocatorName, false);
         if (FileActions.getInstance(true).doesFileExist(referenceImagePath)) {
             return FileActions.getInstance(true).readFileAsByteArray(referenceImagePath);
         } else {
@@ -315,12 +315,13 @@ public class ImageProcessingActions {
 
     private static VisualProcessingProvider.ScreenshotComparisonResult compareScreenshotAgainstBaselineByHash(
             String hashedName, byte[] actualScreenshot, List<int[]> maskRects, Integer maxDiffPixels, Double maxDiffPixelRatio) {
-        String baselineImagePath = getAiFolderPath() + hashedName + ".png";
+        String newBaselineImagePath = getAiFolderPath() + hashedName + browserPlatformSuffix() + ".png";
         boolean updateSnapshots = SHAFT.Properties.visuals.updateSnapshots();
+        String baselineImagePath = resolveExistingBaselinePath(hashedName, true);
 
         if (!FileActions.getInstance(true).doesFileExist(baselineImagePath) || updateSnapshots) {
             ReportManager.logDiscrete("Passing the test and saving a reference screenshot baseline.");
-            FileActions.getInstance(true).writeToFile(baselineImagePath, actualScreenshot);
+            FileActions.getInstance(true).writeToFile(newBaselineImagePath, actualScreenshot);
             return new VisualProcessingProvider.ScreenshotComparisonResult(true, new byte[0], 0, 0.0);
         }
 
@@ -329,9 +330,59 @@ public class ImageProcessingActions {
                 .compareScreenshotAgainstBaseline(baselineImage, actualScreenshot, maskRects, maxDiffPixels, maxDiffPixelRatio);
 
         if (!result.matched() && result.diffImage() != null && result.diffImage().length > 0) {
-            FileActions.getInstance(true).writeToFile(getAiFolderPath() + hashedName + "_diff.png", result.diffImage());
+            FileActions.getInstance(true).writeToFile(getAiFolderPath() + hashedName + browserPlatformSuffix() + "_diff.png", result.diffImage());
         }
         return result;
+    }
+
+    /**
+     * Resolves the on-disk path of an existing {@code matchesScreenshot} baseline for the given hashed name,
+     * preferring the per-browser/OS naming scheme and falling back to the legacy (pre-per-browser/OS) baseline
+     * when only that one exists. When neither exists, returns the new-scheme path so callers create baselines there.
+     *
+     * @param hashedName    stable hashed baseline file name without extension or browser/OS suffix
+     * @param logFallback   whether to emit a one-line notice when falling back to a legacy baseline
+     * @return the resolved baseline path to read from (or to treat as "missing" when creating a new baseline)
+     */
+    private static String resolveExistingBaselinePath(String hashedName, boolean logFallback) {
+        String newBaselineImagePath = getAiFolderPath() + hashedName + browserPlatformSuffix() + ".png";
+        if (FileActions.getInstance(true).doesFileExist(newBaselineImagePath)) {
+            return newBaselineImagePath;
+        }
+        String legacyBaselineImagePath = getAiFolderPath() + hashedName + ".png";
+        if (FileActions.getInstance(true).doesFileExist(legacyBaselineImagePath)) {
+            if (logFallback) {
+                ReportManager.logDiscrete("No per-browser/OS baseline found at \"" + newBaselineImagePath
+                        + "\"; falling back to legacy baseline \"" + legacyBaselineImagePath + "\".");
+            }
+            return legacyBaselineImagePath;
+        }
+        return newBaselineImagePath;
+    }
+
+    /**
+     * Builds the sanitized {@code _<browser>_<platform>} suffix appended to {@code matchesScreenshot} baseline
+     * file names so that cross-browser/OS runs no longer share (and fight over) a single baseline image.
+     *
+     * @return the sanitized browser/platform suffix, e.g. {@code "_chrome_windows"}
+     */
+    private static String browserPlatformSuffix() {
+        String browser = sanitizeForBaselineFileName(SHAFT.Properties.web.targetBrowserName());
+        String platform = sanitizeForBaselineFileName(SHAFT.Properties.platform.targetPlatform());
+        return "_" + browser + "_" + platform;
+    }
+
+    /**
+     * Lowercases and strips non-alphanumeric characters so browser/platform names are safe to embed in file names.
+     *
+     * @param value raw browser or platform name
+     * @return sanitized, file-system-safe value (possibly empty)
+     */
+    private static String sanitizeForBaselineFileName(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]", "");
     }
 
     private static void compareImageFolders(File[] referenceFiles, File[] testFiles, File testFolder, double threshold) throws IOException {

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsScreenshotBaselineUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsScreenshotBaselineUnitTest.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
+import java.util.Arrays;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -24,7 +25,8 @@ import static org.mockito.Mockito.when;
 
 /**
  * Coverage-focused unit tests for {@link ImageProcessingActions#compareScreenshotAgainstBaseline}, covering
- * the {@code matchesScreenshot()} baseline auto-create-on-first-run and {@code -Dshaft.updateSnapshots} lifecycle.
+ * the {@code matchesScreenshot()} baseline auto-create-on-first-run, {@code -Dshaft.updateSnapshots} lifecycle,
+ * and the per-browser/OS baseline naming scheme with legacy fallback.
  */
 public class ImageProcessingActionsScreenshotBaselineUnitTest {
     private static final FileActions FILE_ACTIONS = FileActions.getInstance(true);
@@ -50,6 +52,15 @@ public class ImageProcessingActionsScreenshotBaselineUnitTest {
         Properties.clearForCurrentThread();
     }
 
+    /**
+     * Mirrors {@code ImageProcessingActions#browserPlatformSuffix()}: lowercase, non-alphanumerics stripped.
+     */
+    private static String browserPlatformSuffix() {
+        String browser = SHAFT.Properties.web.targetBrowserName().toLowerCase().replaceAll("[^a-z0-9]", "");
+        String platform = SHAFT.Properties.platform.targetPlatform().toLowerCase().replaceAll("[^a-z0-9]", "");
+        return "_" + browser + "_" + platform;
+    }
+
     @Test
     public void compareScreenshotAgainstBaselineByLocatorShouldCreateMissingBaselineAndPass() {
         By locator = By.id("new-screenshot-baseline");
@@ -58,9 +69,11 @@ public class ImageProcessingActionsScreenshotBaselineUnitTest {
         var result = ImageProcessingActions.compareScreenshotAgainstBaseline(locator, actual, null, null, null);
 
         String hashed = ImageProcessingActions.formatElementLocatorToImagePath(locator);
+        String newSchemePath = tempDir.resolve(hashed + browserPlatformSuffix() + ".png").toString();
         Assert.assertTrue(result.matched());
-        Assert.assertTrue(FILE_ACTIONS.doesFileExist(tempDir.resolve(hashed + ".png").toString()));
-        Assert.assertEquals(FILE_ACTIONS.readFileAsByteArray(tempDir.resolve(hashed + ".png").toString()), actual);
+        Assert.assertTrue(FILE_ACTIONS.doesFileExist(newSchemePath), "new baseline should be written under the new per-browser/OS naming scheme");
+        Assert.assertEquals(FILE_ACTIONS.readFileAsByteArray(newSchemePath), actual);
+        Assert.assertFalse(FILE_ACTIONS.doesFileExist(tempDir.resolve(hashed + ".png").toString()), "a fresh baseline must not be written under the legacy scheme");
     }
 
     @Test
@@ -72,32 +85,52 @@ public class ImageProcessingActionsScreenshotBaselineUnitTest {
 
         String hashed = ImageProcessingActions.formatElementLocatorToImagePath(baselineKey);
         Assert.assertTrue(result.matched());
-        Assert.assertTrue(FILE_ACTIONS.doesFileExist(tempDir.resolve(hashed + ".png").toString()));
+        Assert.assertTrue(FILE_ACTIONS.doesFileExist(tempDir.resolve(hashed + browserPlatformSuffix() + ".png").toString()));
     }
 
     @Test
     public void updateSnapshotsShouldOverwriteExistingBaselineAndPass() {
         By locator = By.id("existing-baseline-to-update");
         String hashed = ImageProcessingActions.formatElementLocatorToImagePath(locator);
+        String newSchemePath = tempDir.resolve(hashed + browserPlatformSuffix() + ".png").toString();
         byte[] oldBaseline = png(Color.GRAY);
         byte[] newScreenshot = png(Color.ORANGE);
-        FILE_ACTIONS.writeToFile(tempDir.resolve(hashed + ".png").toString(), oldBaseline);
+        FILE_ACTIONS.writeToFile(newSchemePath, oldBaseline);
         SHAFT.Properties.visuals.set().updateSnapshots(true);
 
         var result = ImageProcessingActions.compareScreenshotAgainstBaseline(locator, newScreenshot, null, null, null);
 
         Assert.assertTrue(result.matched());
-        Assert.assertEquals(FILE_ACTIONS.readFileAsByteArray(tempDir.resolve(hashed + ".png").toString()), newScreenshot);
+        Assert.assertEquals(FILE_ACTIONS.readFileAsByteArray(newSchemePath), newScreenshot);
+    }
+
+    @Test
+    public void updateSnapshotsWithOnlyLegacyBaselineShouldWriteNewSchemeBaseline() {
+        By locator = By.id("legacy-baseline-to-update");
+        String hashed = ImageProcessingActions.formatElementLocatorToImagePath(locator);
+        String legacyPath = tempDir.resolve(hashed + ".png").toString();
+        String newSchemePath = tempDir.resolve(hashed + browserPlatformSuffix() + ".png").toString();
+        byte[] legacyBaseline = png(Color.GRAY);
+        byte[] newScreenshot = png(Color.ORANGE);
+        FILE_ACTIONS.writeToFile(legacyPath, legacyBaseline);
+        SHAFT.Properties.visuals.set().updateSnapshots(true);
+
+        var result = ImageProcessingActions.compareScreenshotAgainstBaseline(locator, newScreenshot, null, null, null);
+
+        Assert.assertTrue(result.matched());
+        Assert.assertEquals(FILE_ACTIONS.readFileAsByteArray(newSchemePath), newScreenshot,
+                "-Dshaft.updateSnapshots must always write the new per-browser/OS scheme, even when only a legacy baseline existed");
     }
 
     @Test
     public void existingBaselineShouldDelegateToProviderAndPersistDiffImageOnMismatch() {
         By locator = By.id("existing-baseline-mismatch");
         String hashed = ImageProcessingActions.formatElementLocatorToImagePath(locator);
+        String newSchemePath = tempDir.resolve(hashed + browserPlatformSuffix() + ".png").toString();
         byte[] baseline = png(Color.GREEN);
         byte[] actual = png(Color.RED);
         byte[] diffImage = png(Color.MAGENTA);
-        FILE_ACTIONS.writeToFile(tempDir.resolve(hashed + ".png").toString(), baseline);
+        FILE_ACTIONS.writeToFile(newSchemePath, baseline);
 
         VisualProcessingProvider provider = mock(VisualProcessingProvider.class);
         when(provider.compareScreenshotAgainstBaseline(any(), any(), any(), any(), any()))
@@ -108,16 +141,17 @@ public class ImageProcessingActionsScreenshotBaselineUnitTest {
 
         Assert.assertFalse(result.matched());
         Assert.assertEquals(result.diffPixels(), 42);
-        Assert.assertEquals(FILE_ACTIONS.readFileAsByteArray(tempDir.resolve(hashed + "_diff.png").toString()), diffImage);
+        Assert.assertEquals(FILE_ACTIONS.readFileAsByteArray(tempDir.resolve(hashed + browserPlatformSuffix() + "_diff.png").toString()), diffImage);
     }
 
     @Test
     public void existingBaselineMatchShouldNotWriteDiffImage() {
         By locator = By.id("existing-baseline-match");
         String hashed = ImageProcessingActions.formatElementLocatorToImagePath(locator);
+        String newSchemePath = tempDir.resolve(hashed + browserPlatformSuffix() + ".png").toString();
         byte[] baseline = png(Color.GREEN);
         byte[] actual = png(Color.GREEN);
-        FILE_ACTIONS.writeToFile(tempDir.resolve(hashed + ".png").toString(), baseline);
+        FILE_ACTIONS.writeToFile(newSchemePath, baseline);
 
         VisualProcessingProvider provider = mock(VisualProcessingProvider.class);
         when(provider.compareScreenshotAgainstBaseline(any(), any(), any(), any(), any()))
@@ -127,7 +161,53 @@ public class ImageProcessingActionsScreenshotBaselineUnitTest {
         var result = ImageProcessingActions.compareScreenshotAgainstBaseline(locator, actual, null, null, null);
 
         Assert.assertTrue(result.matched());
-        Assert.assertFalse(FILE_ACTIONS.doesFileExist(tempDir.resolve(hashed + "_diff.png").toString()));
+        Assert.assertFalse(FILE_ACTIONS.doesFileExist(tempDir.resolve(hashed + browserPlatformSuffix() + "_diff.png").toString()));
+    }
+
+    @Test
+    public void legacyBaselineOnlyShouldBeUsedAsFallbackAndNotBeUpgraded() {
+        By locator = By.id("legacy-only-baseline");
+        String hashed = ImageProcessingActions.formatElementLocatorToImagePath(locator);
+        String legacyPath = tempDir.resolve(hashed + ".png").toString();
+        String newSchemePath = tempDir.resolve(hashed + browserPlatformSuffix() + ".png").toString();
+        byte[] legacyBaseline = png(Color.GREEN);
+        byte[] actual = png(Color.GREEN);
+        FILE_ACTIONS.writeToFile(legacyPath, legacyBaseline);
+
+        VisualProcessingProvider provider = mock(VisualProcessingProvider.class);
+        when(provider.compareScreenshotAgainstBaseline(any(), any(), any(), any(), any()))
+                .thenReturn(new VisualProcessingProvider.ScreenshotComparisonResult(true, new byte[0], 0, 0.0));
+        VisualProcessingProviderRegistry.setProviderForTesting(provider);
+
+        var result = ImageProcessingActions.compareScreenshotAgainstBaseline(locator, actual, null, null, null);
+
+        Assert.assertTrue(result.matched(), "an existing legacy baseline should be used instead of treating it as missing");
+        Assert.assertFalse(FILE_ACTIONS.doesFileExist(newSchemePath), "a passing comparison against the legacy fallback must not silently create a new-scheme baseline");
+    }
+
+    @Test
+    public void bothSchemesPresentShouldPreferNewSchemeBaseline() {
+        By locator = By.id("both-schemes-present");
+        String hashed = ImageProcessingActions.formatElementLocatorToImagePath(locator);
+        String legacyPath = tempDir.resolve(hashed + ".png").toString();
+        String newSchemePath = tempDir.resolve(hashed + browserPlatformSuffix() + ".png").toString();
+        byte[] legacyBaseline = png(Color.RED);
+        byte[] newSchemeBaseline = png(Color.GREEN);
+        FILE_ACTIONS.writeToFile(legacyPath, legacyBaseline);
+        FILE_ACTIONS.writeToFile(newSchemePath, newSchemeBaseline);
+
+        VisualProcessingProvider provider = mock(VisualProcessingProvider.class);
+        when(provider.compareScreenshotAgainstBaseline(any(byte[].class), any(), any(), any(), any()))
+                .thenAnswer(invocation -> {
+                    byte[] baselineArg = invocation.getArgument(0);
+                    boolean matchesNewScheme = Arrays.equals(baselineArg, newSchemeBaseline);
+                    return new VisualProcessingProvider.ScreenshotComparisonResult(matchesNewScheme, new byte[0], matchesNewScheme ? 0 : 99, matchesNewScheme ? 0.0 : 1.0);
+                });
+        VisualProcessingProviderRegistry.setProviderForTesting(provider);
+
+        var result = ImageProcessingActions.compareScreenshotAgainstBaseline(locator, png(Color.GREEN), null, null, null);
+
+        Assert.assertTrue(result.matched(), "when both schemes exist, the new per-browser/OS scheme must win");
     }
 
     private static byte[] png(Color color) {

--- a/shaft-mcp/src/main/java/com/shaft/mcp/BrowserService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/BrowserService.java
@@ -1,14 +1,18 @@
 package com.shaft.mcp;
 
+import com.deque.html.axecore.results.CheckedNode;
+import com.deque.html.axecore.results.Rule;
 import com.shaft.capture.generate.LocatorRanker;
 import com.shaft.capture.model.ElementSnapshot;
 import com.shaft.capture.model.EventContext;
 import com.shaft.capture.model.LocatorCandidate;
 import com.shaft.capture.model.PageContext;
 import com.shaft.driver.SHAFT;
+import com.shaft.validation.accessibility.AccessibilityHelper;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.openqa.selenium.By;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
@@ -22,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Comparator;
 import java.util.EnumSet;
@@ -33,12 +38,15 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.shaft.mcp.EngineService.getDriver;
+import static com.shaft.mcp.EngineService.getLocator;
 
 @Service
 public class BrowserService {
     private static final int DEFAULT_DOM_CHARACTER_LIMIT = 200_000;
     private static final int DEFAULT_ELEMENT_LIMIT = 10;
     private static final int MAX_ELEMENT_LIMIT = 25;
+    private static final int MAX_VIOLATION_NODES = 5;
+    private static final int MAX_VIOLATION_NODE_HTML_LENGTH = 200;
     private static final Logger logger = LoggerFactory.getLogger(BrowserService.class);
 
     private final McpWorkspacePolicy workspacePolicy;
@@ -389,6 +397,97 @@ public class BrowserService {
             logger.error("Failed to take browser screenshot.", e);
             throw e;
         }
+    }
+
+    /**
+     * Captures an accessible-name-tree aria snapshot (SHAFT's YAML subset of Playwright's aria snapshot
+     * DSL) of the whole page or a single element for MCP browser automation inspection.
+     *
+     * @param locatorStrategy locator strategy; leave unset together with locatorValue to snapshot the
+     *                        whole page
+     * @param locatorValue    locator value; leave blank to snapshot the whole page
+     * @return the aria snapshot serialized as YAML
+     */
+    @Tool(name = "browser_aria_snapshot",
+            description = "captures an accessible-name-tree aria snapshot (YAML) of the whole page, or of one "
+                    + "element when a locator is supplied")
+    public String ariaSnapshot(locatorStrategy locatorStrategy, String locatorValue) {
+        try {
+            SHAFT.GUI.WebDriver driver = getDriver();
+            boolean wholePage = locatorStrategy == null || locatorValue == null || locatorValue.isBlank();
+            By locator = wholePage ? By.tagName("html") : getLocator(locatorStrategy, locatorValue);
+            String snapshot = driver.element().ariaSnapshot(locator);
+            logger.info("Aria snapshot captured (wholePage: {}, characters: {}).",
+                    wholePage, snapshot == null ? 0 : snapshot.length());
+            return snapshot;
+        } catch (Exception e) {
+            logger.error("Failed to capture aria snapshot.", e);
+            throw e;
+        }
+    }
+
+    /**
+     * Runs a non-asserting axe-core WCAG accessibility audit on the current page and returns the
+     * violations found. Unlike {@code AccessibilityActions.assertIsAccessible}, this tool never fails
+     * the call when violations exist; it reports them so the caller can decide what to do.
+     *
+     * @param wcagTags optional axe-core WCAG tags (e.g. {@code wcag2a}, {@code wcag21aa}) to scope the
+     *                 audit to; when empty, SHAFT's default tag set is used
+     * @return the audit result, including a violation count and a per-violation summary
+     */
+    @Tool(name = "browser_accessibility_audit",
+            description = "runs a non-asserting axe-core WCAG accessibility audit on the current page and "
+                    + "returns the violations found; never fails the call when violations exist")
+    public McpAccessibilityAuditResult accessibilityAudit(String... wcagTags) {
+        try {
+            SHAFT.GUI.WebDriver driver = getDriver();
+            AccessibilityHelper.AccessibilityConfig config = new AccessibilityHelper.AccessibilityConfig();
+            List<String> tags = wcagTags == null || wcagTags.length == 0
+                    ? List.copyOf(config.getTags())
+                    : List.of(wcagTags);
+            if (wcagTags != null && wcagTags.length > 0) {
+                config.setTags(Arrays.asList(wcagTags));
+            }
+            AccessibilityHelper.AccessibilityResult result =
+                    driver.browser().accessibility().analyzeAndReturn("mcp-accessibility-audit", config, false);
+            List<McpAccessibilityViolation> violations = result.getViolations().stream()
+                    .map(BrowserService::toAccessibilityViolation)
+                    .toList();
+            logger.info("Accessibility audit completed (violations: {}, score: {}).",
+                    result.getViolationsCount(), result.getAccessibilityScore());
+            return new McpAccessibilityAuditResult(
+                    result.getAccessibilityScore(),
+                    result.getViolationsCount(),
+                    result.getPassCount(),
+                    tags,
+                    violations,
+                    violations.isEmpty()
+                            ? List.of()
+                            : List.of("Accessibility violations were found; this tool reports them without "
+                                    + "failing the call."));
+        } catch (Exception e) {
+            logger.error("Failed to run accessibility audit.", e);
+            throw e;
+        }
+    }
+
+    private static McpAccessibilityViolation toAccessibilityViolation(Rule rule) {
+        List<CheckedNode> nodes = rule.getNodes() == null ? List.of() : rule.getNodes();
+        List<McpAccessibilityViolationNode> nodeSummaries = nodes.stream()
+                .limit(MAX_VIOLATION_NODES)
+                .map(node -> new McpAccessibilityViolationNode(
+                        String.valueOf(node.getTarget()),
+                        trimTo(node.getHtml(), MAX_VIOLATION_NODE_HTML_LENGTH)))
+                .toList();
+        return new McpAccessibilityViolation(
+                rule.getId(),
+                rule.getImpact(),
+                rule.getDescription(),
+                rule.getHelp(),
+                rule.getHelpUrl(),
+                rule.getTags() == null ? List.of() : List.copyOf(rule.getTags()),
+                nodes.size(),
+                nodeSummaries);
     }
 
     private Path writeScreenshot(String outputPath, byte[] png) {

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpAccessibilityAuditResult.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpAccessibilityAuditResult.java
@@ -1,0 +1,16 @@
+package com.shaft.mcp;
+
+import java.util.List;
+
+/**
+ * Non-asserting axe-core accessibility audit result returned by {@code browser_accessibility_audit}.
+ * The audit is reported as data; callers decide whether the violations found are acceptable.
+ */
+public record McpAccessibilityAuditResult(
+        double accessibilityScore,
+        int violationsCount,
+        int passesCount,
+        List<String> wcagTags,
+        List<McpAccessibilityViolation> violations,
+        List<String> warnings) {
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpAccessibilityViolation.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpAccessibilityViolation.java
@@ -1,0 +1,17 @@
+package com.shaft.mcp;
+
+import java.util.List;
+
+/**
+ * A single axe-core rule violation, returned by {@code browser_accessibility_audit}.
+ */
+public record McpAccessibilityViolation(
+        String id,
+        String impact,
+        String description,
+        String help,
+        String helpUrl,
+        List<String> tags,
+        int nodeCount,
+        List<McpAccessibilityViolationNode> nodes) {
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpAccessibilityViolationNode.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpAccessibilityViolationNode.java
@@ -1,0 +1,9 @@
+package com.shaft.mcp;
+
+/**
+ * A single DOM node implicated in an accessibility violation, returned by {@code browser_accessibility_audit}.
+ */
+public record McpAccessibilityViolationNode(
+        String target,
+        String html) {
+}

--- a/shaft-mcp/src/test/java/com/shaft/mcp/McpNoDriverServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/McpNoDriverServiceTest.java
@@ -43,6 +43,10 @@ class McpNoDriverServiceTest {
         assertNoDriver(service::getTitle);
         assertNoDriver(() -> service.getPageDom(10));
         assertNoDriver(() -> service.takeScreenshot("shot.png", false));
+        assertNoDriver(() -> service.ariaSnapshot(null, null));
+        assertNoDriver(() -> service.ariaSnapshot(locatorStrategy.ID, "content"));
+        assertNoDriver(() -> service.accessibilityAudit());
+        assertNoDriver(() -> service.accessibilityAudit("wcag2a", "wcag2aa"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
PR #3383 shipped the core of #3349 (web aria snapshots, axe-core audits, the full `matchesScreenshot()` baseline lifecycle) and deferred the rest. This PR lands everything deferred that is pure composition of those primitives:

1. **Per-browser/OS baseline naming** — `matchesScreenshot()` baselines now carry a `_<browser>_<platform>` suffix (from `web.targetBrowserName()` / `platform.targetPlatform()`, sanitized). Backward compatible: lookup prefers the new scheme, falls back to legacy baselines with a one-line notice; new baselines and `-Dshaft.updateSnapshots` always write the new scheme, so committed baselines don't break.
2. **Recorder toolbar assertions** — `ARIA_SNAPSHOT_MATCHES` and `SCREENSHOT_MATCHES` wired end-to-end (enum → catalog → generator → runtime pipeline → JS mirror). Negated variants are rejected as unsupported since neither engine API has a does-not-match form. Includes a fix to a second exhaustive switch in `CaptureEventPipeline` that would otherwise drop the expected snapshot value.
3. **MCP tools** — `browser_aria_snapshot` (page or element, YAML) and `browser_accessibility_audit` (non-asserting axe audit returning score + capped violation summaries; never fails on violations). No engine changes needed — reuses `AriaSnapshotHelper` and the existing `AccessibilityActions.analyzeAndReturn`.

## API-surface note
The issue's literal `driver.assertThat().page().isAccessible(wcagTags)` is satisfied by the existing `driver.accessibility().assertIsAccessible(wcagTags)` / `.verifyIsAccessible(...)` chain that shipped with #3383 — no redundant second chain added (per that PR's rationale).

## Remaining scope → focused follow-ups
- #3451 mobile aria snapshot from Appium accessibility XML (emulator-infra-gated)
- #3452 shaft-doctor a11y evidence category (new SPI design)
- #3453 IntelliJ Visual Baselines Accept/Reject panel (new UI surface)

## Verification
- `ImageProcessingActionsScreenshotBaselineUnitTest`: 8/8 (3 new: new-scheme create, legacy fallback, updateSnapshots migration) — re-verified independently after review
- `VisualValidationsBuilderUnitTest`: 4/4
- `AssertionCatalogTest`: 5/5, `CaptureGeneratorTest`: 30/30 (2 new)
- `McpNoDriverServiceTest`: 5/5 (4 new no-driver-guard assertions)
- `mvn -pl shaft-engine,shaft-capture,shaft-mcp test-compile` clean

Closes #3349

🤖 Generated with [Claude Code](https://claude.com/claude-code)