### PR TITLE
fix: report-attachment failures no longer fail OpenCV template matches

### DIFF
--- a/shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java
+++ b/shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java
@@ -168,8 +168,12 @@ public class OpenCvVisualProcessingProvider implements VisualProcessingProvider 
                     List<List<Object>> attachments = new LinkedList<>();
                     attachments.add(screenshot);
                     ReportManagerHelper.log("Successfully identified the element using AI; OpenCV. " + accuracyMessage, attachments);
-                } catch (IOException e) {
-                    ReportManager.log("Successfully identified the element using AI; OpenCV. " + accuracyMessage);
+                } catch (Exception e) {
+                    // Report-attachment failures (encoding/highlighting issues, etc.) must never downgrade
+                    // an already-successful template match into a "not found" verdict; log and continue.
+                    ReportManagerHelper.logDiscrete(e);
+                    ReportManager.log("Successfully identified the element using AI; OpenCV. " + accuracyMessage
+                            + " Failed to attach the highlighted match image to the report.");
                 }
                 return Arrays.asList(x, y);
             } catch (org.opencv.core.CvException e) {

--- a/shaft-visual/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsCoverageUnitTest.java
+++ b/shaft-visual/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsCoverageUnitTest.java
@@ -162,6 +162,27 @@ public class ImageProcessingActionsCoverageUnitTest {
     }
 
     @Test
+    public void findImageWithinCurrentPageShouldReturnMatchWhenReportAttachmentFails() {
+        // Regression for #3450: a failure while preparing/attaching the highlighted match image to the
+        // report must not downgrade an already-successful template match into a "not found" verdict.
+        byte[] screenshot = createPatternPng(64, 64, 16, 18, 18, 14, Color.ORANGE);
+        byte[] croppedReference = createPng(18, 14, Color.ORANGE);
+        Path referenceImage = tempDir.resolve("attachment-failure-reference.png");
+        FILE_ACTIONS.writeToFile(referenceImage.toString(), croppedReference);
+
+        try (MockedConstruction<com.shaft.gui.internal.image.ScreenshotManager> ignored = Mockito.mockConstruction(
+                com.shaft.gui.internal.image.ScreenshotManager.class,
+                (mock, context) -> when(mock.prepareImageForReport(any(), anyString()))
+                        .thenThrow(new RuntimeException("forced report-attachment failure")))) {
+
+            List<Integer> coordinates = ImageProcessingActions.findImageWithinCurrentPage(referenceImage.toString(), screenshot);
+
+            Assert.assertFalse(coordinates.isEmpty());
+            Assert.assertEquals(coordinates.size(), 2);
+        }
+    }
+
+    @Test
     public void findImageWithinCurrentPageShouldMatchReferenceCapturedAtLowerDpi() {
         assertScaledReferenceMatch(0.5);
     }


### PR DESCRIPTION
## Summary
Fixes #3450 (follow-up to #3382 / PR #3449). The report-attachment block in `attemptToFindImageUsingOpenCV` caught only `IOException`; any other exception thrown while producing/attaching the highlighted match image propagated to the broad `catch (Exception)` in `findImageWithinCurrentPage` and silently converted a successful template match into a "not found" verdict. The catch is widened to `Exception`, logs the failure discretely, and returns the already-computed match coordinates.

## Regression test
`findImageWithinCurrentPageShouldReturnMatchWhenReportAttachmentFails` forces `ScreenshotManager.prepareImageForReport` to throw a `RuntimeException` (deliberately not an `IOException`) via `Mockito.mockConstruction` and asserts the match coordinates are still returned. Fails against the pre-fix code.

## Verification
- `ImageProcessingActionsCoverageUnitTest`: 34/34 (incl. new test), scoped headless run
- `OpenCvScreenshotDiffTest`: 6/6

Closes #3450

🤖 Generated with [Claude Code](https://claude.com/claude-code)