### PR TITLE
feat: #3350 part 2 — storageStatePath init option, routeFromHar, MCP storage-state tools

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -6,6 +6,7 @@ import com.shaft.driver.SHAFT;
 import com.shaft.gui.browser.BrowserActions;
 import com.shaft.gui.browser.internal.BrowserNetworkInterceptionRule;
 import com.shaft.gui.browser.internal.BrowserNetworkInterceptor;
+import com.shaft.gui.browser.internal.BrowserStorageStateManager;
 import com.shaft.gui.internal.healing.HealingManager;
 import com.shaft.gui.internal.healing.HealingStrategy;
 import com.shaft.gui.internal.video.RecordManager;
@@ -44,12 +45,14 @@ import org.openqa.selenium.remote.http.ClientConfig;
 import org.openqa.selenium.remote.http.ConnectionFailedException;
 import org.openqa.selenium.safari.SafariDriver;
 import org.testng.Reporter;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.io.ByteArrayInputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1330,6 +1333,7 @@ public class DriverFactoryHelper {
                 if (SHAFT.Properties.flags.autoMaximizeBrowserWindow() && (targetBrowserName.contains(Browser.SAFARI.browserName().toLowerCase()) || targetBrowserName.contains(Browser.FIREFOX.browserName().toLowerCase()))) {
                     new BrowserActions(this).maximizeWindow();
                 }
+                loadInitialStorageState();
             }
             // start session recording
             RecordManager.startVideoRecording(driver);
@@ -1355,5 +1359,44 @@ public class DriverFactoryHelper {
         ReportManager.log("Attached to existing WebDriver session '" + driver + "'.");
         setDriver(driver);
         startBrowserObservability();
+    }
+
+    /**
+     * Loads {@code SHAFT.Properties.web.storageStatePath()} into the freshly-initialized driver, when configured.
+     *
+     * <p>Navigates to the origin recorded inside the storage-state file (falling back to
+     * {@code SHAFT.Properties.web.baseURL()}) before loading, since cookies can only be added for the
+     * driver's current origin. Failures are logged as warnings and never fail driver initialization.
+     */
+    private void loadInitialStorageState() {
+        String storageStatePath = SHAFT.Properties.web.storageStatePath();
+        if (storageStatePath.isBlank()) {
+            return;
+        }
+        try {
+            String origin = peekStorageStateOrigin(storageStatePath);
+            if (origin.isBlank()) {
+                origin = SHAFT.Properties.web.baseURL();
+            }
+            if (!origin.isBlank()) {
+                driver.navigate().to(origin);
+            }
+            BrowserStorageStateManager.load(driver, storageStatePath);
+            ReportManager.logDiscrete("Loaded browser storage state from \"" + storageStatePath + "\".");
+        } catch (Exception exception) {
+            ReportManager.logDiscrete("Could not load browser storage state from \"" + storageStatePath
+                    + "\". Cause: " + exception.getClass().getSimpleName(), Level.WARN);
+        }
+    }
+
+    private static String peekStorageStateOrigin(String filePath) {
+        try {
+            var mapper = JsonMapper.builder().build();
+            BrowserStorageStateManager.StorageState state = mapper.readValue(
+                    Path.of(filePath).toFile(), BrowserStorageStateManager.StorageState.class);
+            return state.origin == null ? "" : state.origin;
+        } catch (RuntimeException exception) {
+            return "";
+        }
     }
 }

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -10,6 +10,7 @@ import com.shaft.gui.browser.internal.BrowserActionsHelper;
 import com.shaft.gui.browser.internal.BrowserNetworkProfileManager;
 import com.shaft.gui.browser.internal.BrowserNetworkInterceptionRule;
 import com.shaft.gui.browser.internal.BrowserStorageStateManager;
+import com.shaft.gui.browser.internal.HarReplayRules;
 import com.shaft.gui.browser.internal.JavaScriptWaitManager;
 import com.shaft.gui.internal.image.ScreenshotManager;
 import com.shaft.gui.internal.locator.LocatorBuilder;
@@ -784,6 +785,26 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
         HttpContractRecorder.browserReplayRules(contractFilePath)
                 .forEach(rule -> driverFactoryHelper.registerBrowserNetworkInterceptionRule(rule));
         browserActionsHelper.passAction(driverFactoryHelper.getDriver(), "Loaded HTTP contract replay rules.");
+        return this;
+    }
+
+    /**
+     * Replays recorded HAR (HTTP Archive) responses through the browser network interceptor.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * driver.browser().routeFromHar("src/test/resources/har/checkout.har");
+     * driver.browser().navigateToURL("https://shop.example/checkout");
+     * }</pre>
+     *
+     * @param harFilePath path to a HAR 1.2 JSON file
+     * @return a self-reference to be used to chain actions
+     */
+    @Override
+    public BrowserActions routeFromHar(String harFilePath) {
+        HarReplayRules.buildRules(harFilePath)
+                .forEach(rule -> driverFactoryHelper.registerBrowserNetworkInterceptionRule(rule));
+        browserActionsHelper.passAction(driverFactoryHelper.getDriver(), "Loaded HAR replay rules.");
         return this;
     }
 

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/internal/HarReplayRules.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/internal/HarReplayRules.java
@@ -1,0 +1,221 @@
+package com.shaft.gui.browser.internal;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.openqa.selenium.remote.http.Contents;
+import org.openqa.selenium.remote.http.HttpRequest;
+import org.openqa.selenium.remote.http.HttpResponse;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Builds browser network interception replay rules from a HAR (HTTP Archive) 1.2 file.
+ *
+ * <p>Matching is exact: a HAR entry replays only for requests whose HTTP method
+ * (case-insensitive) and full request URL (including query string, case-sensitive) are identical
+ * to the entry's recorded {@code request.method}/{@code request.url}. There is no path/query
+ * normalization, body matching, or wildcarding, unlike
+ * {@link com.shaft.tools.io.internal.HttpContractRecorder} contract replay. Duplicate entries for
+ * the same method/URL are replayed in recorded order, one per matching request, mirroring the
+ * contract replay cursor behavior.</p>
+ *
+ * <p>Entries without a {@code response} object, or with a non-positive {@code response.status},
+ * are skipped. A {@code response.content.encoding} of {@code "base64"} is base64-decoded; any
+ * other (or missing) encoding is treated as UTF-8 text. The {@code Content-Length} and
+ * {@code Content-Encoding} response headers are dropped when replaying, because HAR
+ * {@code response.content.text} is always already-decoded per the HAR spec, so passing along the
+ * original transfer headers would misrepresent the reconstructed body.</p>
+ */
+public final class HarReplayRules {
+    private static final ObjectMapper MAPPER = JsonMapper.builder().build();
+    private static final Set<String> SKIPPED_RESPONSE_HEADERS = Set.of("content-length", "content-encoding");
+
+    private HarReplayRules() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Builds one mock replay rule from every response-bearing entry in a HAR file.
+     *
+     * @param harFilePath path to a HAR 1.2 JSON file
+     * @return replay rules that return recorded HAR responses
+     */
+    public static List<BrowserNetworkInterceptionRule> buildRules(String harFilePath) {
+        List<HarEntry> replayable = readEntries(requireNonBlank(harFilePath, "harFilePath"));
+        AtomicInteger cursor = new AtomicInteger();
+        return List.of(BrowserNetworkInterceptionRule.mock(
+                request -> replayable.stream()
+                        .anyMatch(entry -> matches(entry, requestMethod(request), requestUrl(request))),
+                request -> toBrowserResponse(nextReplayEntry(replayable, cursor, request))));
+    }
+
+    private static HarEntry nextReplayEntry(List<HarEntry> replayable, AtomicInteger cursor, HttpRequest request) {
+        String method = requestMethod(request);
+        String url = requestUrl(request);
+        for (int index = cursor.get(); index < replayable.size(); index++) {
+            HarEntry entry = replayable.get(index);
+            if (matches(entry, method, url)) {
+                cursor.set(index + 1);
+                return entry;
+            }
+        }
+        return replayable.stream()
+                .filter(entry -> matches(entry, method, url))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("No HAR entry matched " + method + " " + url));
+    }
+
+    private static boolean matches(HarEntry entry, String method, String url) {
+        return entry.method().equalsIgnoreCase(method) && entry.url().equals(url);
+    }
+
+    private static HttpResponse toBrowserResponse(HarEntry entry) {
+        HttpResponse response = new HttpResponse().setStatus(entry.status());
+        entry.headers().forEach(header -> {
+            if (header.name != null && !SKIPPED_RESPONSE_HEADERS.contains(header.name.toLowerCase(Locale.ROOT))) {
+                response.addHeader(header.name, value(header.value));
+            }
+        });
+        if (entry.body().length > 0) {
+            response.setContent(Contents.bytes(entry.body()));
+        }
+        return response;
+    }
+
+    private static List<HarEntry> readEntries(String harFilePath) {
+        Har har = readHar(Path.of(harFilePath));
+        List<HarEntry> entries = new ArrayList<>();
+        for (HarEntryDto entryDto : entriesOf(har)) {
+            HarEntry entry = toEntry(entryDto);
+            if (entry != null) {
+                entries.add(entry);
+            }
+        }
+        return entries;
+    }
+
+    private static Har readHar(Path path) {
+        try {
+            return MAPPER.readValue(path.toFile(), Har.class);
+        } catch (RuntimeException e) {
+            throw new IllegalStateException("Could not read HAR file from " + path, e);
+        }
+    }
+
+    private static List<HarEntryDto> entriesOf(Har har) {
+        if (har == null || har.log == null || har.log.entries == null) {
+            return List.of();
+        }
+        return har.log.entries;
+    }
+
+    private static HarEntry toEntry(HarEntryDto dto) {
+        if (dto == null || dto.request == null || dto.response == null) {
+            return null;
+        }
+        String method = value(dto.request.method);
+        String url = value(dto.request.url);
+        if (method.isBlank() || url.isBlank() || dto.response.status <= 0) {
+            return null;
+        }
+        return new HarEntry(method.toUpperCase(Locale.ROOT), url, dto.response.status,
+                headersOf(dto.response.headers), bodyOf(dto.response.content));
+    }
+
+    private static List<HarHeaderDto> headersOf(List<HarHeaderDto> headers) {
+        return headers == null ? List.of() : headers;
+    }
+
+    private static byte[] bodyOf(HarContentDto content) {
+        if (content == null || content.text == null) {
+            return new byte[0];
+        }
+        if ("base64".equalsIgnoreCase(content.encoding)) {
+            try {
+                return Base64.getDecoder().decode(content.text);
+            } catch (IllegalArgumentException e) {
+                return content.text.getBytes(StandardCharsets.UTF_8);
+            }
+        }
+        return content.text.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static String requestMethod(HttpRequest request) {
+        return request == null || request.getMethod() == null ? "" : request.getMethod().name();
+    }
+
+    private static String requestUrl(HttpRequest request) {
+        return request == null ? "" : value(request.getUri());
+    }
+
+    private static String requireNonBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be blank.");
+        }
+        return value;
+    }
+
+    private static String value(String value) {
+        return value == null ? "" : value;
+    }
+
+    private record HarEntry(String method, String url, int status, List<HarHeaderDto> headers, byte[] body) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("java:S1104")
+    static class Har {
+        public HarLog log;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("java:S1104")
+    static class HarLog {
+        public List<HarEntryDto> entries;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("java:S1104")
+    static class HarEntryDto {
+        public HarRequestDto request;
+        public HarResponseDto response;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("java:S1104")
+    static class HarRequestDto {
+        public String method;
+        public String url;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("java:S1104")
+    static class HarResponseDto {
+        public int status;
+        public List<HarHeaderDto> headers;
+        public HarContentDto content;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("java:S1104")
+    static class HarHeaderDto {
+        public String name;
+        public String value;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @SuppressWarnings("java:S1104")
+    static class HarContentDto {
+        public String text;
+        public String encoding;
+        public String mimeType;
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/driver/BrowserActionsContract.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/driver/BrowserActionsContract.java
@@ -98,6 +98,14 @@ public interface BrowserActionsContract {
 
     BrowserActionsContract replayContract(String contractFilePath);
 
+    /**
+     * Replays recorded HAR (HTTP Archive) responses through the browser network interceptor.
+     *
+     * @param harFilePath path to a HAR 1.2 JSON file
+     * @return a self-reference to be used to chain actions
+     */
+    BrowserActionsContract routeFromHar(String harFilePath);
+
     BrowserActionsContract fullScreenWindow();
 
     BrowserActionsContract switchToWindow(String nameOrHandle);

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/browser/BrowserActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/browser/BrowserActions.java
@@ -9,6 +9,7 @@ import com.shaft.driver.SHAFT;
 import com.shaft.enums.internal.Screenshots;
 import com.shaft.gui.browser.NetworkInterceptionRequestBuilder;
 import com.shaft.gui.browser.internal.BrowserNetworkInterceptionRule;
+import com.shaft.gui.browser.internal.HarReplayRules;
 import com.shaft.gui.browser.internal.PlaywrightStorageStateManager;
 import com.shaft.gui.playwright.internal.PlaywrightSession;
 import com.shaft.gui.playwright.validation.PlaywrightBrowserValidationsBuilder;
@@ -270,6 +271,26 @@ public class BrowserActions implements com.shaft.gui.driver.BrowserActionsContra
         HttpContractRecorder.browserReplayRules(contractFilePath)
                 .forEach(rule -> session.networkInterceptor().addRule(rule));
         ReportManager.log("Loaded HTTP contract replay rules.");
+        return this;
+    }
+
+    /**
+     * Replays recorded HAR (HTTP Archive) responses through the Playwright network interceptor.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * driver.browser().routeFromHar("src/test/resources/har/checkout.har");
+     * driver.browser().navigateToURL("https://shop.example/checkout");
+     * }</pre>
+     *
+     * @param harFilePath path to a HAR 1.2 JSON file
+     * @return a self-reference to be used to chain actions
+     */
+    @Override
+    public BrowserActions routeFromHar(String harFilePath) {
+        HarReplayRules.buildRules(harFilePath)
+                .forEach(rule -> session.networkInterceptor().addRule(rule));
+        ReportManager.log("Loaded HAR replay rules.");
         return this;
     }
 

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSessionFactory.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSessionFactory.java
@@ -6,8 +6,11 @@ import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
 import com.shaft.driver.SHAFT;
+import com.shaft.gui.browser.internal.BrowserStorageStateManager;
+import com.shaft.gui.browser.internal.PlaywrightStorageStateManager;
 import com.shaft.tools.io.ReportManager;
 import org.apache.logging.log4j.Level;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.nio.file.Path;
 import java.util.Locale;
@@ -37,7 +40,48 @@ public final class PlaywrightSessionFactory {
         PlaywrightSessionManager.setSession(session);
         String device = deviceDescriptor == null ? "" : " and device '" + deviceDescriptor.name() + "'";
         ReportManager.logDiscrete("Created Playwright GUI session using browser '" + resolvedBrowserName + "'" + device + ".", Level.INFO);
+        loadInitialStorageState(browserContext, page);
         return session;
+    }
+
+    /**
+     * Loads {@code SHAFT.Properties.web.storageStatePath()} into the freshly-created session, when configured.
+     *
+     * <p>Navigates to the origin recorded inside the storage-state file (falling back to
+     * {@code SHAFT.Properties.web.baseURL()}) before loading, so origin-scoped {@code localStorage} and
+     * {@code sessionStorage} are restored correctly. Failures are logged as warnings and never fail
+     * session creation.
+     */
+    private static void loadInitialStorageState(BrowserContext browserContext, Page page) {
+        String storageStatePath = SHAFT.Properties.web.storageStatePath();
+        if (storageStatePath.isBlank()) {
+            return;
+        }
+        try {
+            String origin = peekStorageStateOrigin(storageStatePath);
+            if (origin.isBlank()) {
+                origin = SHAFT.Properties.web.baseURL();
+            }
+            if (!origin.isBlank()) {
+                page.navigate(origin);
+            }
+            PlaywrightStorageStateManager.load(browserContext, page, storageStatePath);
+            ReportManager.logDiscrete("Loaded Playwright browser storage state from \"" + storageStatePath + "\".");
+        } catch (RuntimeException exception) {
+            ReportManager.logDiscrete("Could not load Playwright browser storage state from \"" + storageStatePath
+                    + "\". Cause: " + exception.getClass().getSimpleName(), Level.WARN);
+        }
+    }
+
+    private static String peekStorageStateOrigin(String filePath) {
+        try {
+            var mapper = JsonMapper.builder().build();
+            BrowserStorageStateManager.StorageState state = mapper.readValue(
+                    Path.of(filePath).toFile(), BrowserStorageStateManager.StorageState.class);
+            return state.origin == null ? "" : state.origin;
+        } catch (RuntimeException exception) {
+            return "";
+        }
     }
 
     public static PlaywrightSession attach(Playwright playwright, Browser browser, BrowserContext browserContext, Page page) {

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Web.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Web.java
@@ -87,6 +87,26 @@ public interface Web extends EngineProperties<Web> {
     @DefaultValue("none")
     String readinessState();
 
+    /**
+     * Path to a storage-state JSON file (the schema produced by {@code BrowserActions.saveStorageState})
+     * that a freshly-initialized driver should automatically load, restoring cookies and, when possible,
+     * {@code localStorage}/{@code sessionStorage}.
+     *
+     * <p>At driver-init time there is no page loaded yet, so cookies cannot simply be added for an
+     * arbitrary domain. SHAFT reads the {@code origin} recorded inside the storage-state file (falling
+     * back to {@link #baseURL()} when the file has none) and navigates the fresh driver there first,
+     * mirroring how {@code loadStorageState} recommends navigating before loading. Origin-scoped
+     * {@code localStorage}/{@code sessionStorage} is therefore restored correctly only when an origin
+     * could be resolved; if neither is available, only cookies that the driver accepts without a page
+     * navigation are restored. A failure to load (missing file, unreachable origin, etc.) is logged as a
+     * warning and does not fail driver initialization.
+     *
+     * <p>Default is blank, meaning the feature is disabled.
+     */
+    @Key("storageStatePath")
+    @DefaultValue("")
+    String storageStatePath();
+
     default SetProperty set() {
         return new SetProperty();
     }
@@ -172,6 +192,11 @@ public interface Web extends EngineProperties<Web> {
 
         public SetProperty readinessState(String value) {
             setProperty("readinessState", value);
+            return this;
+        }
+
+        public SetProperty storageStatePath(String value) {
+            setProperty("storageStatePath", value);
             return this;
         }
     }

--- a/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelperStorageStateUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelperStorageStateUnitTest.java
@@ -1,0 +1,116 @@
+package com.shaft.driver.internal.DriverFactory;
+
+import com.shaft.driver.SHAFT;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ * Covers {@code DriverFactoryHelper#loadInitialStorageState()}, the WebDriver-side wiring for the
+ * {@code SHAFT.Properties.web.storageStatePath()} driver-init option.
+ */
+@Test(singleThreaded = true)
+public class DriverFactoryHelperStorageStateUnitTest {
+    private final String savedStorageStatePath = SHAFT.Properties.web.storageStatePath();
+    private final String savedBaseURL = SHAFT.Properties.web.baseURL();
+    private Path storageStateFile;
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() throws Exception {
+        SHAFT.Properties.web.set().storageStatePath(savedStorageStatePath).baseURL(savedBaseURL);
+        if (storageStateFile != null) {
+            Files.deleteIfExists(storageStateFile);
+        }
+    }
+
+    private static void invokeLoadInitialStorageState(DriverFactoryHelper helper) throws Exception {
+        Method method = DriverFactoryHelper.class.getDeclaredMethod("loadInitialStorageState");
+        method.setAccessible(true);
+        method.invoke(helper);
+    }
+
+    @Test
+    public void blankPropertyShouldSkipLoadingEntirely() throws Exception {
+        SHAFT.Properties.web.set().storageStatePath("");
+        DriverFactoryHelper helper = new DriverFactoryHelper();
+        WebDriver driver = mock(WebDriver.class);
+        helper.setDriver(driver);
+
+        invokeLoadInitialStorageState(helper);
+
+        verifyNoInteractions(driver);
+    }
+
+    @Test
+    public void configuredPropertyShouldNavigateToRecordedOriginThenLoadStorageState() throws Exception {
+        storageStateFile = Files.createTempFile("shaft-driver-init-storage-state", ".json");
+        Files.writeString(storageStateFile, "{\"schemaVersion\":\"1.0\",\"origin\":\"https://example.com\","
+                + "\"cookies\":[],\"origins\":[{\"origin\":\"https://example.com\",\"localStorage\":{},\"sessionStorage\":{}}]}");
+        SHAFT.Properties.web.set().storageStatePath(storageStateFile.toString());
+
+        DriverFactoryHelper helper = new DriverFactoryHelper();
+        WebDriver driver = mock(WebDriver.class, withSettings().extraInterfaces(JavascriptExecutor.class));
+        WebDriver.Navigation navigation = mock(WebDriver.Navigation.class);
+        WebDriver.Options options = mock(WebDriver.Options.class);
+        when(driver.navigate()).thenReturn(navigation);
+        when(driver.manage()).thenReturn(options);
+        when(((JavascriptExecutor) driver).executeScript(anyString(), any(), any())).thenReturn(null);
+        helper.setDriver(driver);
+
+        invokeLoadInitialStorageState(helper);
+
+        verify(navigation).to("https://example.com");
+        verify(options).deleteAllCookies();
+        verify((JavascriptExecutor) driver).executeScript(anyString(), any(), any());
+    }
+
+    @Test
+    public void missingOriginInFileShouldFallBackToConfiguredBaseURL() throws Exception {
+        storageStateFile = Files.createTempFile("shaft-driver-init-storage-state-no-origin", ".json");
+        Files.writeString(storageStateFile, "{\"schemaVersion\":\"1.0\",\"cookies\":[],\"origins\":[]}");
+        SHAFT.Properties.web.set().storageStatePath(storageStateFile.toString()).baseURL("https://fallback.example.com");
+
+        DriverFactoryHelper helper = new DriverFactoryHelper();
+        WebDriver driver = mock(WebDriver.class, withSettings().extraInterfaces(JavascriptExecutor.class));
+        WebDriver.Navigation navigation = mock(WebDriver.Navigation.class);
+        WebDriver.Options options = mock(WebDriver.Options.class);
+        when(driver.navigate()).thenReturn(navigation);
+        when(driver.manage()).thenReturn(options);
+        when(((JavascriptExecutor) driver).executeScript(anyString(), any(), any())).thenReturn(null);
+        helper.setDriver(driver);
+
+        invokeLoadInitialStorageState(helper);
+
+        verify(navigation).to("https://fallback.example.com");
+    }
+
+    @Test
+    public void missingFileShouldLogWarningAndNotPropagateException() throws Exception {
+        SHAFT.Properties.web.set().storageStatePath("target/does-not-exist-" + System.nanoTime() + ".json").baseURL("");
+
+        DriverFactoryHelper helper = new DriverFactoryHelper();
+        WebDriver driver = mock(WebDriver.class);
+        helper.setDriver(driver);
+
+        // Should not throw despite the file not existing.
+        invokeLoadInitialStorageState(helper);
+
+        verify(driver, never()).navigate();
+        Assert.assertTrue(true, "loadInitialStorageState swallowed the failure as expected.");
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/gui/browser/internal/HarReplayRulesTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/browser/internal/HarReplayRulesTest.java
@@ -1,0 +1,103 @@
+package com.shaft.gui.browser.internal;
+
+import org.openqa.selenium.remote.http.Contents;
+import org.openqa.selenium.remote.http.HttpMethod;
+import org.openqa.selenium.remote.http.HttpRequest;
+import org.openqa.selenium.remote.http.HttpResponse;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+public class HarReplayRulesTest {
+    private static final String HAR_JSON = """
+            {
+              "log": {
+                "version": "1.2",
+                "creator": {"name": "test", "version": "1.0"},
+                "entries": [
+                  {
+                    "startedDateTime": "2026-01-01T00:00:00.000Z",
+                    "request": {"method": "GET", "url": "https://shop.test/api/items?id=123", "headers": []},
+                    "response": {
+                      "status": 200,
+                      "statusText": "OK",
+                      "headers": [
+                        {"name": "Content-Type", "value": "application/json"},
+                        {"name": "Content-Length", "value": "999"}
+                      ],
+                      "content": {"size": 11, "mimeType": "application/json", "text": "{\\"ok\\":true}"}
+                    }
+                  },
+                  {
+                    "request": {"method": "GET", "url": "https://shop.test/api/items?id=123"},
+                    "response": {
+                      "status": 200,
+                      "headers": [{"name": "Content-Type", "value": "application/octet-stream"}],
+                      "content": {"mimeType": "application/octet-stream", "text": "aGVsbG8=", "encoding": "base64"}
+                    }
+                  },
+                  {
+                    "request": {"method": "POST", "url": "https://shop.test/api/pending"}
+                  }
+                ]
+              }
+            }
+            """;
+
+    private Path harFile;
+
+    @AfterMethod(alwaysRun = true)
+    public void cleanup() throws Exception {
+        if (harFile != null) {
+            Files.deleteIfExists(harFile);
+        }
+    }
+
+    @Test
+    public void buildRulesShouldReplayInOrderAndSkipEntriesWithoutAResponse() throws Exception {
+        harFile = Files.createTempFile("shaft-har-replay", ".har");
+        Files.writeString(harFile, HAR_JSON);
+
+        List<BrowserNetworkInterceptionRule> rules = HarReplayRules.buildRules(harFile.toString());
+        Assert.assertEquals(rules.size(), 1);
+        BrowserNetworkInterceptionRule rule = rules.getFirst();
+
+        HttpRequest matchingRequest = request(HttpMethod.GET, "https://shop.test/api/items?id=123");
+        Assert.assertTrue(rule.matches(matchingRequest));
+
+        HttpResponse firstReplay = rule.createResponse(matchingRequest);
+        Assert.assertEquals(firstReplay.getStatus(), 200);
+        Assert.assertEquals(firstReplay.getHeader("Content-Type"), "application/json");
+        Assert.assertNull(firstReplay.getHeader("Content-Length"));
+        Assert.assertEquals(bodyOf(firstReplay), "{\"ok\":true}");
+
+        HttpResponse secondReplay = rule.createResponse(matchingRequest);
+        Assert.assertEquals(secondReplay.getHeader("Content-Type"), "application/octet-stream");
+        Assert.assertEquals(bodyOf(secondReplay), "hello");
+    }
+
+    @Test
+    public void buildRulesShouldMatchExactUrlOnlyAndIgnoreSkippedEntries() throws Exception {
+        harFile = Files.createTempFile("shaft-har-replay", ".har");
+        Files.writeString(harFile, HAR_JSON);
+
+        BrowserNetworkInterceptionRule rule = HarReplayRules.buildRules(harFile.toString()).getFirst();
+
+        Assert.assertFalse(rule.matches(request(HttpMethod.GET, "https://shop.test/api/items?id=999")));
+        Assert.assertFalse(rule.matches(request(HttpMethod.POST, "https://shop.test/api/items?id=123")));
+        Assert.assertFalse(rule.matches(request(HttpMethod.POST, "https://shop.test/api/pending")));
+    }
+
+    private HttpRequest request(HttpMethod method, String url) {
+        return new HttpRequest(method, url);
+    }
+
+    private String bodyOf(HttpResponse response) {
+        return new String(Contents.bytes(response.getContent()), StandardCharsets.UTF_8);
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/gui/playwright/browser/PlaywrightBrowserActionsUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/playwright/browser/PlaywrightBrowserActionsUnitTest.java
@@ -27,11 +27,15 @@ import static org.mockito.Mockito.when;
 
 public class PlaywrightBrowserActionsUnitTest {
     private Path storageStateFile;
+    private Path harFile;
 
     @AfterMethod(alwaysRun = true)
     public void tearDown() throws Exception {
         if (storageStateFile != null) {
             Files.deleteIfExists(storageStateFile);
+        }
+        if (harFile != null) {
+            Files.deleteIfExists(harFile);
         }
     }
 
@@ -82,5 +86,39 @@ public class PlaywrightBrowserActionsUnitTest {
         AccessibilityActions accessibility = actions.accessibility();
 
         Assert.assertNotNull(accessibility);
+    }
+
+    @Test
+    public void shouldRegisterRouteFromHarThroughPlaywrightNetworkInterceptor() throws Exception {
+        PlaywrightSession session = mock(PlaywrightSession.class);
+        BrowserContext context = mock(BrowserContext.class);
+        Page page = mock(Page.class);
+        AtomicReference<Consumer<Route>> handler = new AtomicReference<>();
+        when(session.browserContext()).thenReturn(context);
+        when(session.page()).thenReturn(page);
+        when(session.networkInterceptor()).thenReturn(new PlaywrightNetworkInterceptor(context));
+        when(context.route(eq("**/*"), any())).thenAnswer(invocation -> {
+            handler.set(invocation.getArgument(1));
+            return (AutoCloseable) () -> { };
+        });
+        BrowserActions actions = new BrowserActions(session);
+
+        harFile = Files.createTempFile("shaft-pw-wiring-har", ".har");
+        Files.writeString(harFile, """
+                {
+                  "log": {
+                    "version": "1.2",
+                    "entries": [
+                      {
+                        "request": {"method": "GET", "url": "https://shop.test/api/items"},
+                        "response": {"status": 200, "headers": [], "content": {"text": "{\\"ok\\":true}"}}
+                      }
+                    ]
+                  }
+                }
+                """);
+
+        Assert.assertSame(actions.routeFromHar(harFile.toString()), actions);
+        Assert.assertNotNull(handler.get());
     }
 }

--- a/shaft-engine/src/test/java/com/shaft/gui/playwright/internal/PlaywrightSessionFactoryStorageStateUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/playwright/internal/PlaywrightSessionFactoryStorageStateUnitTest.java
@@ -1,0 +1,102 @@
+package com.shaft.gui.playwright.internal;
+
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.Page;
+import com.shaft.driver.SHAFT;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers {@code PlaywrightSessionFactory#loadInitialStorageState(BrowserContext, Page)}, the
+ * Playwright-side wiring for the {@code SHAFT.Properties.web.storageStatePath()} driver-init option.
+ */
+@Test(singleThreaded = true)
+public class PlaywrightSessionFactoryStorageStateUnitTest {
+    private final String savedStorageStatePath = SHAFT.Properties.web.storageStatePath();
+    private final String savedBaseURL = SHAFT.Properties.web.baseURL();
+    private Path storageStateFile;
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() throws Exception {
+        SHAFT.Properties.web.set().storageStatePath(savedStorageStatePath).baseURL(savedBaseURL);
+        if (storageStateFile != null) {
+            Files.deleteIfExists(storageStateFile);
+        }
+    }
+
+    private static void invokeLoadInitialStorageState(BrowserContext context, Page page) throws Exception {
+        Method method = PlaywrightSessionFactory.class.getDeclaredMethod("loadInitialStorageState", BrowserContext.class, Page.class);
+        method.setAccessible(true);
+        method.invoke(null, context, page);
+    }
+
+    @Test
+    public void blankPropertyShouldSkipLoadingEntirely() throws Exception {
+        SHAFT.Properties.web.set().storageStatePath("");
+        BrowserContext context = mock(BrowserContext.class);
+        Page page = mock(Page.class);
+
+        invokeLoadInitialStorageState(context, page);
+
+        verifyNoInteractions(context);
+        verifyNoInteractions(page);
+    }
+
+    @Test
+    public void configuredPropertyShouldNavigateToRecordedOriginThenLoadStorageState() throws Exception {
+        storageStateFile = Files.createTempFile("shaft-playwright-init-storage-state", ".json");
+        Files.writeString(storageStateFile, "{\"schemaVersion\":\"1.0\",\"origin\":\"https://example.com\","
+                + "\"cookies\":[],\"origins\":[{\"origin\":\"https://example.com\",\"localStorage\":{\"k\":\"v\"},\"sessionStorage\":{}}]}");
+        SHAFT.Properties.web.set().storageStatePath(storageStateFile.toString());
+
+        BrowserContext context = mock(BrowserContext.class);
+        Page page = mock(Page.class);
+        when(page.url()).thenReturn("https://example.com");
+
+        invokeLoadInitialStorageState(context, page);
+
+        verify(page).navigate("https://example.com");
+        verify(context).clearCookies();
+        verify(page).evaluate(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    public void missingOriginInFileShouldFallBackToConfiguredBaseURL() throws Exception {
+        storageStateFile = Files.createTempFile("shaft-playwright-init-storage-state-no-origin", ".json");
+        Files.writeString(storageStateFile, "{\"schemaVersion\":\"1.0\",\"cookies\":[],\"origins\":[]}");
+        SHAFT.Properties.web.set().storageStatePath(storageStateFile.toString()).baseURL("https://fallback.example.com");
+
+        BrowserContext context = mock(BrowserContext.class);
+        Page page = mock(Page.class);
+        when(page.url()).thenReturn("https://fallback.example.com");
+
+        invokeLoadInitialStorageState(context, page);
+
+        verify(page).navigate("https://fallback.example.com");
+    }
+
+    @Test
+    public void missingFileShouldLogWarningAndNotPropagateException() throws Exception {
+        SHAFT.Properties.web.set().storageStatePath("target/does-not-exist-" + System.nanoTime() + ".json").baseURL("");
+
+        BrowserContext context = mock(BrowserContext.class);
+        Page page = mock(Page.class);
+
+        // Should not throw despite the file not existing.
+        invokeLoadInitialStorageState(context, page);
+
+        verify(page, never()).navigate(org.mockito.ArgumentMatchers.anyString());
+        Assert.assertTrue(true, "loadInitialStorageState swallowed the failure as expected.");
+    }
+}

--- a/shaft-engine/src/test/java/testPackage/properties/WebTests.java
+++ b/shaft-engine/src/test/java/testPackage/properties/WebTests.java
@@ -18,6 +18,7 @@ public class WebTests {
     int browserWindowWidth;
     int browserWindowHeight;
     boolean incognitoMode;
+    String storageStatePath;
 
     @BeforeClass
     public void beforeClass() {
@@ -34,6 +35,7 @@ public class WebTests {
         browserWindowWidth = 1920;
         browserWindowHeight = 1080;
         incognitoMode = SHAFT.Properties.web.incognitoMode();
+        storageStatePath = SHAFT.Properties.web.storageStatePath();
     }
 
     @Test
@@ -50,6 +52,7 @@ public class WebTests {
                 .baseURL(baseURL)
                 .browserWindowWidth(browserWindowWidth)
                 .browserWindowHeight(browserWindowHeight)
-                .incognitoMode(incognitoMode);
+                .incognitoMode(incognitoMode)
+                .storageStatePath(storageStatePath);
     }
 }

--- a/shaft-engine/src/test/java/testPackage/unitTests/WebStorageStatePathSetPropertyUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/WebStorageStatePathSetPropertyUnitTest.java
@@ -1,0 +1,33 @@
+package testPackage.unitTests;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.properties.internal.Web;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Coverage: {@code SHAFT.Properties.web.storageStatePath()} default value and fluent override.
+ */
+@Test(singleThreaded = true)
+public class WebStorageStatePathSetPropertyUnitTest {
+    private final String originalStorageStatePath = SHAFT.Properties.web.storageStatePath();
+
+    @AfterMethod(alwaysRun = true)
+    public void afterMethod() {
+        SHAFT.Properties.web.set().storageStatePath(originalStorageStatePath);
+    }
+
+    @Test(description = "Coverage: storageStatePath defaults to blank (feature disabled) unless explicitly configured")
+    public void storageStatePathShouldDefaultToBlank() {
+        SHAFT.Properties.web.set().storageStatePath("");
+        Assert.assertEquals(SHAFT.Properties.web.storageStatePath(), "");
+    }
+
+    @Test(description = "Coverage: storageStatePath fluent setter updates the effective value and returns the same builder")
+    public void storageStatePathFluentSetterShouldUpdateEffectiveValue() {
+        Web.SetProperty setProperty = SHAFT.Properties.web.set();
+        Assert.assertSame(setProperty.storageStatePath("target/auth-state.json"), setProperty);
+        Assert.assertEquals(SHAFT.Properties.web.storageStatePath(), "target/auth-state.json");
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/BrowserService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/BrowserService.java
@@ -400,6 +400,56 @@ public class BrowserService {
     }
 
     /**
+     * Saves the active browser session's cookies, {@code localStorage}, and {@code sessionStorage} to a
+     * JSON file.
+     *
+     * @param filePath workspace-relative or workspace-contained output file path
+     * @return the absolute path the storage state was written to
+     */
+    @Tool(name = "browser_storage_state_save",
+            description = "saves the active browser session's cookies, localStorage, and sessionStorage to a JSON file")
+    public String saveStorageState(String filePath) {
+        try {
+            SHAFT.GUI.WebDriver driver = getDriver();
+            Path resolved = workspacePolicy.output(filePath, "Storage state output path");
+            driver.browser().saveStorageState(resolved.toString());
+            logger.info("Browser storage state saved (path length: {}).", resolved.toString().length());
+            return resolved.toString();
+        } catch (Exception e) {
+            logger.error("Failed to save browser storage state.", e);
+            throw e;
+        }
+    }
+
+    /**
+     * Loads cookies, {@code localStorage}, and {@code sessionStorage} from a JSON file into the active
+     * browser session.
+     *
+     * <p>Navigate to the target origin before loading storage state so browser cookie domain rules can
+     * apply.
+     *
+     * @param filePath workspace-contained source JSON file path
+     * @return a short confirmation including the resolved path and restored cookie count
+     */
+    @Tool(name = "browser_storage_state_load",
+            description = "loads cookies, localStorage, and sessionStorage from a JSON file into the active "
+                    + "browser session; navigate to the target origin first")
+    public String loadStorageState(String filePath) {
+        try {
+            SHAFT.GUI.WebDriver driver = getDriver();
+            Path resolved = workspacePolicy.existing(filePath, "Storage state input path");
+            driver.browser().loadStorageState(resolved.toString());
+            int cookieCount = driver.browser().getAllCookies().size();
+            logger.info("Browser storage state loaded (path length: {}, cookies: {}).",
+                    resolved.toString().length(), cookieCount);
+            return "Loaded browser storage state from " + resolved + " (cookies restored: " + cookieCount + ")";
+        } catch (Exception e) {
+            logger.error("Failed to load browser storage state.", e);
+            throw e;
+        }
+    }
+
+    /**
      * Captures an accessible-name-tree aria snapshot (SHAFT's YAML subset of Playwright's aria snapshot
      * DSL) of the whole page or a single element for MCP browser automation inspection.
      *

--- a/shaft-mcp/src/main/java/com/shaft/mcp/PlaywrightService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/PlaywrightService.java
@@ -307,6 +307,50 @@ public class PlaywrightService {
     }
 
     /**
+     * Saves the active Playwright session's cookies, {@code localStorage}, and {@code sessionStorage} to
+     * a JSON file.
+     *
+     * <p>Produces the same JSON schema as {@code browser_storage_state_save}, so files are interchangeable
+     * between the WebDriver and Playwright backends.
+     *
+     * @param filePath workspace-relative or workspace-contained output file path
+     * @return the absolute path the storage state was written to
+     */
+    @Tool(name = "playwright_browser_storage_state_save",
+            description = "saves the active SHAFT Playwright session's cookies, localStorage, and sessionStorage "
+                    + "to a JSON file")
+    public String saveStorageState(String filePath) {
+        SHAFT.GUI.Playwright driver = getDriver();
+        Path resolved = workspacePolicy.output(filePath, "Storage state output path");
+        driver.browser().saveStorageState(resolved.toString());
+        logger.info("Playwright storage state saved (path length: {}).", resolved.toString().length());
+        return resolved.toString();
+    }
+
+    /**
+     * Loads cookies, {@code localStorage}, and {@code sessionStorage} from a JSON file into the active
+     * Playwright session.
+     *
+     * <p>Navigate to the target origin before loading storage state so browser cookie domain rules can
+     * apply.
+     *
+     * @param filePath workspace-contained source JSON file path
+     * @return a short confirmation including the resolved path and restored cookie count
+     */
+    @Tool(name = "playwright_browser_storage_state_load",
+            description = "loads cookies, localStorage, and sessionStorage from a JSON file into the active "
+                    + "SHAFT Playwright session; navigate to the target origin first")
+    public String loadStorageState(String filePath) {
+        SHAFT.GUI.Playwright driver = getDriver();
+        Path resolved = workspacePolicy.existing(filePath, "Storage state input path");
+        driver.browser().loadStorageState(resolved.toString());
+        int cookieCount = driver.browser().getAllCookies().size();
+        logger.info("Playwright storage state loaded (path length: {}, cookies: {}).",
+                resolved.toString().length(), cookieCount);
+        return "Loaded browser storage state from " + resolved + " (cookies restored: " + cookieCount + ")";
+    }
+
+    /**
      * Clicks a Playwright element.
      */
     @Tool(name = "playwright_element_click", description = "clicks an element using SHAFT Playwright")

--- a/shaft-mcp/src/test/java/com/shaft/mcp/McpNoDriverServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/McpNoDriverServiceTest.java
@@ -47,6 +47,8 @@ class McpNoDriverServiceTest {
         assertNoDriver(() -> service.ariaSnapshot(locatorStrategy.ID, "content"));
         assertNoDriver(() -> service.accessibilityAudit());
         assertNoDriver(() -> service.accessibilityAudit("wcag2a", "wcag2aa"));
+        assertNoDriver(() -> service.saveStorageState("state.json"));
+        assertNoDriver(() -> service.loadStorageState("state.json"));
     }
 
     @Test
@@ -86,6 +88,8 @@ class McpNoDriverServiceTest {
         assertNoDriver(() -> service.clickSemantic("Submit"));
         assertNoDriver(() -> service.type(locatorStrategy.ID, "name", "value"));
         assertNoDriver(() -> service.typeSemantic("Name", "value"));
+        assertNoDriver(() -> service.saveStorageState("state.json"));
+        assertNoDriver(() -> service.loadStorageState("state.json"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
Second composable batch of #3350, building on part 1 (#3458):

1. **`storageStatePath` driver-init option** — `SHAFT.Properties.web.storageStatePath()` (+ `SetProperty`): when set, a freshly-initialized driver auto-loads the storage-state file on both backends. Since cookies are origin-scoped and no page is loaded at init, the hook navigates to the origin recorded in the file (fallback: `baseURL`) before loading — the same sequencing `ManagedCaptureRecorder` already uses. Fail-soft: any load failure logs a warning and never fails driver init.
2. **`routeFromHar(harFilePath)`** — on `BrowserActionsContract` and both backend `BrowserActions` (only the two known implementers exist; both implemented). Reads HAR 1.2, builds mock rules on the existing `BrowserNetworkInterceptionRule` machinery (same shape as `replayContract`). Exact method+URL matching; duplicate entries replay sequentially in recorded order; base64 bodies decoded; `Content-Length`/`Content-Encoding` stripped since HAR bodies are pre-decoded.
3. **MCP storage-state tools** — `browser_storage_state_save/load` and `playwright_browser_storage_state_save/load`, gated through `McpWorkspacePolicy` (output vs existing path resolution), driver-guard-first ordering so no-driver calls fail with the contract's `IllegalStateException`. (Named save/load rather than the issue's sketched get/set to match the file-based engine API.)

## Remaining #3350 scope (next PR(s))
Full-body `NetworkTransactionStore` + HAR emit wiring, MCP network tool pack (`browser_network_requests`/`browser_route`/…), `SHAFT.Auth.setup`. HAR "update mode" deliberately deferred (separate recording concern). Mobile persistence tracked in #3457.

## Verification
- shaft-engine combined: `DriverFactoryHelperStorageStateUnitTest`, `PlaywrightSessionFactoryStorageStateUnitTest`, `WebStorageStatePathSetPropertyUnitTest`, `HarReplayRulesTest`, `PlaywrightBrowserActionsUnitTest`, `HttpContractBrowserReplayTest`: **16/16**
- shaft-mcp: `McpNoDriverServiceTest`: **5/5** (against the refreshed engine snapshot)
- Pre-existing `DriverFactoryHelperCoverageUnitTest` (35 tests) and `WebTests` regression-checked by the implementing agent; `test-compile` clean.

Refs #3350

🤖 Generated with [Claude Code](https://claude.com/claude-code)