### PR TITLE
feat: reporting accuracy, checkpoint evidence completeness, and logging UX

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/internal/locator/LocatorHealthReporter.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/locator/LocatorHealthReporter.java
@@ -35,7 +35,7 @@ public final class LocatorHealthReporter {
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final ConcurrentMap<String, LocatorStats> LOCATORS = new ConcurrentHashMap<>();
     private static final DateTimeFormatter FILENAME_FORMATTER =
-            DateTimeFormatter.ofPattern("dd-MM-yyyy_HH-mm-ss-SSSS-a").withZone(ZoneId.systemDefault());
+            DateTimeFormatter.ofPattern("dd-MM-yyyy_HH-mm-ss-SSS").withZone(ZoneId.systemDefault());
     private static final Pattern SECRET_ASSIGNMENT = Pattern.compile(
             "(?i)(password|passwd|secret|token|api[-_]?key|authorization|cookie)\\s*[:=]\\s*[^\\s,;]+");
     private static final Pattern LONG_TOKEN = Pattern.compile("\\b[a-zA-Z0-9_-]{32,}\\b");

--- a/shaft-engine/src/main/java/com/shaft/listeners/AllureListener.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/AllureListener.java
@@ -290,7 +290,7 @@ public class AllureListener implements StepLifecycleListener, FixtureLifecycleLi
                 result.setStatusDetails(details);
                 // Attach the stacktrace as a readable text file so it appears in the Allure report
                 getLifecycle().addAttachment(
-                        "Exception Stacktrace",
+                        "Exception Stack Trace",
                         "text/plain",
                         ".txt",
                         new ByteArrayInputStream(trace.getBytes(StandardCharsets.UTF_8)));

--- a/shaft-engine/src/main/java/com/shaft/listeners/JunitListener.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/JunitListener.java
@@ -153,7 +153,7 @@ public class JunitListener implements LauncherSessionListener {
         failedTests.add(testIdentifier);
         countsTracker.recordFailed(info);
         isLastFinishedTestOK = false;
-        ExecutionLifecycleHelper.logFinishedTestInformation(info, "Failed");
+        ExecutionLifecycleHelper.logFinishedTestInformation(info, "Failed", throwable);
         appendToExecutionSummaryReport(info, throwable == null ? "" : throwable.getMessage(), ExecutionSummaryReport.StatusIcon.FAILED, ExecutionSummaryReport.Status.FAILED);
         IssueReporter.updateIssuesLog(info, false);
     }

--- a/shaft-engine/src/main/java/com/shaft/listeners/internal/ExecutionLifecycleHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/internal/ExecutionLifecycleHelper.java
@@ -73,12 +73,24 @@ public final class ExecutionLifecycleHelper {
      * @param status execution status text
      */
     public static void logFinishedTestInformation(TestExecutionInfo info, String status) {
+        logFinishedTestInformation(info, status, null);
+    }
+
+    /**
+     * Logs the end of a test method including the failure root cause when available.
+     *
+     * @param info current test metadata
+     * @param status execution status text
+     * @param failureReason throwable that ended the test, or {@code null}
+     */
+    public static void logFinishedTestInformation(TestExecutionInfo info, String status, Throwable failureReason) {
         if (info != null) {
             ReportManagerHelper.logFinishedTestInformation(
                     valueOrBlank(info.className()),
                     valueOrBlank(info.methodName()),
                     valueOrBlank(info.description()),
-                    valueOrBlank(status));
+                    valueOrBlank(status),
+                    failureReason);
         }
     }
 

--- a/shaft-engine/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java
@@ -498,7 +498,7 @@ public class TestNGListenerHelper {
                 } else if (iTestResult.getStatus() == ITestResult.SKIP) {
                     methodStatus = "Skipped";
                 }
-                ReportManagerHelper.logFinishedTestInformation(className, methodName, methodDescription, methodStatus);
+                ReportManagerHelper.logFinishedTestInformation(className, methodName, methodDescription, methodStatus, iTestResult.getThrowable());
             }
         }
     }

--- a/shaft-engine/src/main/java/com/shaft/performance/internal/LightHouseGenerateReport.java
+++ b/shaft-engine/src/main/java/com/shaft/performance/internal/LightHouseGenerateReport.java
@@ -22,7 +22,7 @@ import java.util.List;
  * can be attached to Allure reports for CI/CD integration.
  */
 public class LightHouseGenerateReport {
-    private static final DateTimeFormatter FILENAME_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy_HH-mm-ss-SSSS-a");
+    private static final DateTimeFormatter FILENAME_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy_HH-mm-ss-SSS");
     final WebDriver driver;
     int PortNum;
     String PageName;

--- a/shaft-engine/src/main/java/com/shaft/tools/internal/support/HTMLHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/internal/support/HTMLHelper.java
@@ -18,7 +18,7 @@ public enum HTMLHelper {
                   width: 180px;
                   height: 180px;
                   border-radius: 50%;
-                  background: conic-gradient(var(--shaft-pass) ${CHECKPOINTS_PASSED_PERCENTAGE}deg, var(--shaft-fail) 0);
+                  background: conic-gradient(var(--shaft-pass) ${CHECKPOINTS_PASSED_DEGREES}deg, var(--shaft-fail) 0);
                   box-shadow: inset 0 0 0 28px var(--shaft-surface);
                 }
               </style>
@@ -124,9 +124,9 @@ public enum HTMLHelper {
                     <h2>Issue Signals</h2>
                     <div class="metric-grid">
                       <div class="metric-card"><div class="metric-label">Total Issues</div><div class="metric-value">${TOTAL_ISSUES}</div></div>
-                      <div class="metric-card"><div class="metric-label">Should Pass</div><div class="metric-value">${NO_OPEN_ISSUES_FAILED}</div></div>
-                      <div class="metric-card"><div class="metric-label">Resolved</div><div class="metric-value">${OPEN_ISSUES_PASSED}</div></div>
-                      <div class="metric-card"><div class="metric-label">Expected Failures</div><div class="metric-value">${OPEN_ISSUES_FAILED}</div></div>
+                      <div class="metric-card"><div class="metric-label">Failed · No Known Issue</div><div class="metric-value">${NO_OPEN_ISSUES_FAILED}</div></div>
+                      <div class="metric-card"><div class="metric-label">Passed · Issue Still Open</div><div class="metric-value">${OPEN_ISSUES_PASSED}</div></div>
+                      <div class="metric-card"><div class="metric-label">Failed · Known Issue</div><div class="metric-value">${OPEN_ISSUES_FAILED}</div></div>
                     </div>
                   </section>
                   <section class="panel">

--- a/shaft-engine/src/main/java/com/shaft/tools/internal/support/ReportHtmlTheme.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/internal/support/ReportHtmlTheme.java
@@ -247,6 +247,20 @@ public final class ReportHtmlTheme {
     }
 
     /**
+     * Escapes user-supplied text for safe embedding in generated report HTML.
+     *
+     * @param value raw text, or {@code null}
+     * @return HTML-escaped text, never {@code null}
+     */
+    public static String escapeHtml(String value) {
+        return value == null ? "" : value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;");
+    }
+
+    /**
      * Maps a report status to a CSS class suffix.
      *
      * @param status report status text

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/ApiPerformanceExecutionReport.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/ApiPerformanceExecutionReport.java
@@ -36,7 +36,7 @@ public class ApiPerformanceExecutionReport {
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
     private static final String BUDGET_METRIC = "p95";
     private static final DateTimeFormatter READABLE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault());
-    private static final DateTimeFormatter FILENAME_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy_HH-mm-ss-SSSS-a").withZone(ZoneId.systemDefault());
+    private static final DateTimeFormatter FILENAME_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy_HH-mm-ss-SSS").withZone(ZoneId.systemDefault());
 
     /**
      * Creates a new API performance execution report helper instance.

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/BrowserPerformanceExecutionReport.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/BrowserPerformanceExecutionReport.java
@@ -31,7 +31,7 @@ public final class BrowserPerformanceExecutionReport {
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
     private static final String BUDGET_METRIC = "p95";
     private static final DateTimeFormatter READABLE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault());
-    private static final DateTimeFormatter FILENAME_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy_HH-mm-ss-SSSS-a").withZone(ZoneId.systemDefault());
+    private static final DateTimeFormatter FILENAME_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy_HH-mm-ss-SSS").withZone(ZoneId.systemDefault());
     private static final Map<String, List<Double>> BROWSER_ACTION_DATA = new ConcurrentHashMap<>();
     private static final Map<String, List<Double>> PAGE_LOAD_DATA = new ConcurrentHashMap<>();
 

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointCounter.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointCounter.java
@@ -4,7 +4,8 @@ import com.shaft.tools.internal.support.HTMLHelper;
 import com.shaft.tools.internal.support.ReportHtmlTheme;
 
 import java.util.ArrayList;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -15,8 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * publish the generated report attachment.
  */
 public class CheckpointCounter {
-    private static final ConcurrentHashMap<Integer, ArrayList<?>> checkpoints = new ConcurrentHashMap<>();
-    private static final AtomicInteger checkpointSequence = new AtomicInteger(0);
+    private static final List<ArrayList<String>> checkpoints = new CopyOnWriteArrayList<>();
     private static final AtomicInteger passedCheckpoints = new AtomicInteger(0);
     private static final AtomicInteger failedCheckpoints = new AtomicInteger(0);
 
@@ -39,7 +39,7 @@ public class CheckpointCounter {
         entry.add(type.toString());
         entry.add(message);
         entry.add(status.toString());
-        checkpoints.put(checkpointSequence.incrementAndGet(), entry);
+        checkpoints.add(entry);
 
         if (status == CheckpointStatus.PASS) {
             passedCheckpoints.incrementAndGet();
@@ -58,18 +58,21 @@ public class CheckpointCounter {
             return;
         }
         StringBuilder detailsBuilder = new StringBuilder();
-        checkpoints.forEach((key, value) -> detailsBuilder.append(String.format(
-                HTMLHelper.CHECKPOINT_DETAILS_FORMAT.getValue(),
-                key,
-                value.get(0),
-                value.get(1),
-                ReportHtmlTheme.statusClass(String.valueOf(value.get(2))),
-                value.get(2))));
+        int checkpointId = 0;
+        for (ArrayList<String> value : checkpoints) {
+            detailsBuilder.append(String.format(
+                    HTMLHelper.CHECKPOINT_DETAILS_FORMAT.getValue(),
+                    ++checkpointId,
+                    ReportHtmlTheme.escapeHtml(value.get(0)),
+                    ReportHtmlTheme.escapeHtml(value.get(1)),
+                    ReportHtmlTheme.statusClass(value.get(2)),
+                    value.get(2)));
+        }
 
         ReportManagerHelper.attach("HTML",
                 "Checkpoints Report",
                 HTMLHelper.CHECKPOINT_COUNTER.getValue()
-                        .replace("${CHECKPOINTS_PASSED_PERCENTAGE}", String.valueOf(passedCheckpoints.get() * 360d / checkpoints.size()))
+                        .replace("${CHECKPOINTS_PASSED_DEGREES}", String.valueOf(passedCheckpoints.get() * 360d / checkpoints.size()))
                         .replace("${CHECKPOINTS_TOTAL}", String.valueOf(checkpoints.size()))
                         .replace("${CHECKPOINTS_PASSED}", String.valueOf(passedCheckpoints.get()))
                         .replace("${CHECKPOINTS_FAILED}", String.valueOf(failedCheckpoints.get()))

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/ExecutionSummaryReport.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/ExecutionSummaryReport.java
@@ -11,15 +11,15 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class ExecutionSummaryReport {
-    private static final ConcurrentHashMap<Integer, ArrayList<?>> casesDetails = new ConcurrentHashMap<>();
-    private static final ConcurrentHashMap<Integer, ArrayList<?>> validations = new ConcurrentHashMap<>();
+    private static final List<ArrayList<String>> casesDetails = new CopyOnWriteArrayList<>();
     private static final AtomicInteger passedValidations = new AtomicInteger(0);
     private static final AtomicInteger failedValidations = new AtomicInteger(0);
-    private static final DateTimeFormatter FILENAME_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy_HH-mm-ss-SSSS-a").withZone(ZoneId.systemDefault());
+    private static final DateTimeFormatter FILENAME_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy_HH-mm-ss-SSS").withZone(ZoneId.systemDefault());
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy").withZone(ZoneId.systemDefault());
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss").withZone(ZoneId.systemDefault());
 
@@ -35,13 +35,10 @@ public class ExecutionSummaryReport {
         entry.add(errorMessage);
         entry.add(status);
         entry.add(issue);
-        casesDetails.put(casesDetails.size() + 1, entry);
+        casesDetails.add(entry);
     }
 
     public static void validationsIncrement(CheckpointStatus status) {
-        ArrayList<String> entry = new ArrayList<>();
-        validations.put(validations.size() + 1, entry);
-
         if (status == CheckpointStatus.PASS) {
             passedValidations.incrementAndGet();
         } else {
@@ -53,16 +50,19 @@ public class ExecutionSummaryReport {
         int total = passed + failed + skipped;
 
         StringBuilder detailsBuilder = new StringBuilder();
-        casesDetails.forEach((key, value) -> detailsBuilder.append(String.format(
-                HTMLHelper.EXECUTION_SUMMARY_DETAILS_FORMAT.getValue(),
-                key,
-                value.getFirst(),
-                value.get(1),
-                value.get(2),
-                value.get(3),
-                ReportHtmlTheme.statusClass(String.valueOf(value.get(4))),
-                value.get(4),
-                value.get(5))));
+        int caseId = 0;
+        for (ArrayList<String> value : casesDetails) {
+            detailsBuilder.append(String.format(
+                    HTMLHelper.EXECUTION_SUMMARY_DETAILS_FORMAT.getValue(),
+                    ++caseId,
+                    ReportHtmlTheme.escapeHtml(value.getFirst()),
+                    ReportHtmlTheme.escapeHtml(value.get(1)),
+                    ReportHtmlTheme.escapeHtml(value.get(2)),
+                    ReportHtmlTheme.escapeHtml(value.get(3)),
+                    ReportHtmlTheme.statusClass(value.get(4)),
+                    value.get(4),
+                    ReportHtmlTheme.escapeHtml(value.get(5))));
+        }
 
         var fileActionsSession = FileActions.getInstance(true);
 
@@ -102,20 +102,21 @@ public class ExecutionSummaryReport {
                     .replace("${CASES_PASSED_PERCENTAGE_PIE}", String.valueOf(passed * 100 / total))
                     .replace("${CASES_FAILED_PERCENTAGE_PIE}", String.valueOf((failed * 100 / total) + (passed * 100 / total)));
         } else {
-            report = report.replace("${CASES_PASSED_PERCENTAGE}", String.valueOf(total))
-                    .replace("${CASES_PASSED_PERCENTAGE_PIE}", String.valueOf(total))
-                    .replace("${CASES_FAILED_PERCENTAGE_PIE}", String.valueOf(total));
+            report = report.replace("${CASES_PASSED_PERCENTAGE}", "0.00")
+                    .replace("${CASES_PASSED_PERCENTAGE_PIE}", "0")
+                    .replace("${CASES_FAILED_PERCENTAGE_PIE}", "0");
         }
-        if (!validations.isEmpty()) {
+        int totalValidations = passedValidations.get() + failedValidations.get();
+        if (totalValidations > 0) {
             report = report
-                    .replace("${VALIDATION_PASSED_PERCENTAGE_PIE}", String.valueOf(passedValidations.get() * 360d / validations.size()))
-                    .replace("${VALIDATION_PASSED_PERCENTAGE}", String.valueOf(new DecimalFormat("0.00").format((float) passedValidations.get() * 100 / validations.size())))
-                    .replace("${VALIDATION_TOTAL}", String.valueOf(validations.size()));
+                    .replace("${VALIDATION_PASSED_PERCENTAGE_PIE}", String.valueOf(passedValidations.get() * 360d / totalValidations))
+                    .replace("${VALIDATION_PASSED_PERCENTAGE}", String.valueOf(new DecimalFormat("0.00").format((float) passedValidations.get() * 100 / totalValidations)))
+                    .replace("${VALIDATION_TOTAL}", String.valueOf(totalValidations));
         } else {
             report = report
-                    .replace("${VALIDATION_PASSED_PERCENTAGE_PIE}", String.valueOf(0))
-                    .replace("${VALIDATION_PASSED_PERCENTAGE}", String.valueOf(0))
-                    .replace("${VALIDATION_TOTAL}", String.valueOf(0));
+                    .replace("${VALIDATION_PASSED_PERCENTAGE_PIE}", "0")
+                    .replace("${VALIDATION_PASSED_PERCENTAGE}", "0.00")
+                    .replace("${VALIDATION_TOTAL}", "0");
         }
         return report;
     }

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureReporter.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureReporter.java
@@ -25,7 +25,7 @@ public class FailureReporter {
             List<List<Object>> attachments = new ArrayList<>();
             List<Object> actualValueAttachment = Arrays.asList(JavaHelper.convertToSentenceCase(failedFileManager.getSimpleName()) + " - " +
                             JavaHelper.convertToSentenceCase(actionName),
-                    "Exception Stacktrace", ReportManagerHelper.formatStackTraceToLogEntry(throwable));
+                    "Exception Stack Trace", ReportManagerHelper.formatStackTraceToLogEntry(throwable));
             attachments.add(actualValueAttachment);
             ReportManagerHelper.log(message + rootCause, attachments);
         }
@@ -42,9 +42,10 @@ public class FailureReporter {
     }
 
     public static String getRootCause(Throwable throwable) {
-        var rootCauseMessage = Throwables.getRootCause(throwable).getLocalizedMessage();
+        var rootCause = Throwables.getRootCause(throwable);
+        var rootCauseMessage = rootCause.getLocalizedMessage();
         if (rootCauseMessage != null)
-            return " Root cause: \"" + Throwables.getRootCause(throwable).getClass().getName() + ": " + rootCauseMessage.split("\n")[0] + "\"";
-        return " Root cause: \"" + Throwables.getRootCause(throwable).getClass().getName() + ": " + "\"";
+            return " Root cause: \"" + rootCause.getClass().getName() + ": " + rootCauseMessage.split("\n")[0] + "\"";
+        return " Root cause: \"" + rootCause.getClass().getName() + "\"";
     }
 }

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/LogRedirector.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/LogRedirector.java
@@ -27,9 +27,20 @@ public class LogRedirector extends OutputStream {
     @Override
     public void write(byte[] b, int off, int len) {
         Objects.checkFromIndexSize(off, len, b.length);
-        // len == 0 condition implicitly handled by loop bounds
-        for (int i = 0; i < len; i++) {
-            write(b[off + i]);
+        int end = off + len;
+        int segmentStart = off;
+        for (int i = off; i < end; i++) {
+            byte current = b[i];
+            if (current == '\r' || current == '\n') {
+                if (i > segmentStart) {
+                    lineBuffers.get().write(b, segmentStart, i - segmentStart);
+                }
+                flush();
+                segmentStart = i + 1;
+            }
+        }
+        if (segmentStart < end) {
+            lineBuffers.get().write(b, segmentStart, end - segmentStart);
         }
     }
 

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/ProgressBarLogger.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/ProgressBarLogger.java
@@ -65,7 +65,7 @@ public class ProgressBarLogger implements AutoCloseable {
                 );
         task = () -> {
             pb = pbb.build();
-            pb.setExtraMessage("seconds.");
+            pb.setExtraMessage("seconds");
             boolean interrupted = false;
             while (Duration.ofSeconds(timeoutVal - 1).minus(pb.getElapsedAfterStart()).isPositive()) {
                 try {

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 //@Getter
 @SuppressWarnings("unused")
 public class ReportManagerHelper {
-    private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm:ss.SSSS a");
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm:ss.SSS");
     private static final String REPORT_MANAGER_PREFIX = "[ReportManager] ";
     private static final String SHAFT_ENGINE_LOGS_ATTACHMENT_TYPE = "SHAFT Engine Logs";
     private static final String LOG4J_LOG_FILE_SYSTEM_PROPERTY = "shaft.log.file";
@@ -431,7 +431,7 @@ public class ReportManagerHelper {
     public static void logConfigurationMethodInformation(String className, String testMethodName, String configurationMethodType) {
         // In TestNG Reporter, this log entry is logged at the end of the previous test
         // (or null for the first test)
-        createImportantReportEntry("⚙ Starting execution of " + JavaHelper.convertToSentenceCase(configurationMethodType).toLowerCase() + " configuration method\n'"
+        createImportantReportEntry("⚙ Starting " + JavaHelper.convertToSentenceCase(configurationMethodType).toLowerCase() + " configuration\n'"
                 + className + "." + testMethodName + "'");
     }
 
@@ -460,6 +460,10 @@ public class ReportManagerHelper {
     }
 
     public static void logFinishedTestInformation(String className, String testMethodName, String testDescription, String testStatus) {
+        logFinishedTestInformation(className, testMethodName, testDescription, testStatus, null);
+    }
+
+    public static void logFinishedTestInformation(String className, String testMethodName, String testDescription, String testStatus, Throwable failureReason) {
         StringBuilder reportMessage = new StringBuilder();
 
         String statusIndicator = switch (testStatus.toUpperCase()) {
@@ -480,6 +484,9 @@ public class ReportManagerHelper {
             reportMessage.append("\nDescription: '").append(testDescription).append("'");
         }
         reportMessage.append("\nStatus: ").append(testStatus);
+        if (failureReason != null) {
+            reportMessage.append("\n").append(FailureReporter.getRootCause(failureReason).trim());
+        }
 
         createImportantReportEntry(reportMessage.toString(), logLevel);
     }
@@ -512,6 +519,8 @@ public class ReportManagerHelper {
     public static void attach(String attachmentType, String attachmentName, String attachmentContent) {
         if (!attachmentContent.trim().isEmpty()) {
             createAttachment(attachmentType, attachmentName, new ByteArrayInputStream(attachmentContent.getBytes(StandardCharsets.UTF_8)));
+        } else {
+            createLogEntry("Skipped report attachment '" + attachmentType + " - " + attachmentName + "' because its content was empty.", Level.DEBUG);
         }
     }
 
@@ -655,19 +664,13 @@ public class ReportManagerHelper {
     }
 
     public static String getCallingMethodFullName() {
-        StackTraceElement[] callingStack = Thread.currentThread().getStackTrace();
-        var callingMethodFullName = new StringBuilder();
-        for (var i = 1; i < callingStack.length; i++) {
-            if (!callingStack[i].getClassName().contains("shaft")) {
-                callingMethodFullName.append(callingStack[i].getClassName());
-                if (!callingStack[i].getMethodName().isEmpty()) {
-                    callingMethodFullName.append(".");
-                    callingMethodFullName.append(callingStack[i].getMethodName());
-                }
-                break;
-            }
-        }
-        return callingMethodFullName.toString();
+        return STACK_WALKER.walk(frames -> frames
+                .filter(frame -> !frame.getClassName().contains("shaft"))
+                .findFirst()
+                .map(frame -> frame.getMethodName().isEmpty()
+                        ? frame.getClassName()
+                        : frame.getClassName() + "." + frame.getMethodName())
+                .orElse(""));
     }
 
     public static String getCallingClassFullName() {
@@ -1175,10 +1178,10 @@ public class ReportManagerHelper {
     }
 
     public static String getExecutionDuration(long startTime, long endTime) {
-        long durationWithMillis = TimeUnit.MILLISECONDS.toMillis(endTime - startTime);
+        long durationWithMillis = Math.max(0, endTime - startTime);
 
         String duration = "";
-        if (durationWithMillis > 0 && durationWithMillis < 1000) {
+        if (durationWithMillis < 1000) {
             duration = durationWithMillis + " millis";
         } else if (durationWithMillis >= 1000 && durationWithMillis < 60000) {
             duration = String.format("%02d sec, %02d millis",

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java
@@ -921,11 +921,6 @@ public class ValidationsHelper {
         }
     }
 
-    static boolean isExpectedOrActualValueLong(String expectedValue, String actualValue) {
-        return (expectedValue != null && expectedValue.length() >= 500)
-                || (actualValue != null && actualValue.length() >= 500);
-    }
-
     private void reportValidationState(boolean validationState, Object expected, Object actual, WebDriver driver, By locator, List<List<Object>> attachments) {
         reportValidationState(validationState, expected, actual, driver, locator, attachments, false);
     }
@@ -965,16 +960,14 @@ public class ValidationsHelper {
                 attachments.add(pageSourceAttachment);
             }
         } else {
-            // prepare testData attachments
-            boolean isExpectedOrActualValueLong = ValidationsHelper.isExpectedOrActualValueLong(String.valueOf(expected), String.valueOf(actual));
-            if (isExpectedOrActualValueLong) {
-                List<Object> expectedValueAttachment = Arrays.asList("Validation Test Data", "Expected Value",
-                        expected);
-                List<Object> actualValueAttachment = Arrays.asList("Validation Test Data", "Actual Value", actual);
-                attachments.add(expectedValueAttachment);
-                attachments.add(actualValueAttachment);
-                ReportManager.logDiscrete("Expected and Actual values are attached.");
-            }
+            // prepare testData attachments; always attach expected/actual so every checkpoint carries its evidence
+            List<Object> expectedValueAttachment = Arrays.asList("Validation Test Data", "Expected Value",
+                    String.valueOf(expected));
+            List<Object> actualValueAttachment = Arrays.asList("Validation Test Data", "Actual Value",
+                    String.valueOf(actual));
+            attachments.add(expectedValueAttachment);
+            attachments.add(actualValueAttachment);
+            ReportManager.logDiscrete("Expected and Actual values are attached.");
         }
         // add attachments
         long profilerAttachmentStart = !attachments.isEmpty() && FlakeProfiler.isEnabled() ? System.nanoTime() : 0L;

--- a/shaft-engine/src/test/java/com/shaft/listeners/AllureListenerCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/listeners/AllureListenerCoverageUnitTest.java
@@ -220,7 +220,7 @@ public class AllureListenerCoverageUnitTest {
         assertEquals(result.getStatusDetails().getMessage(), "configuration exploded");
         assertTrue(result.getStatusDetails().getTrace().contains("configuration exploded"));
         assertEquals(result.getAttachments().size(), 1);
-        assertEquals(result.getAttachments().getFirst().getName(), "Exception Stacktrace");
+        assertEquals(result.getAttachments().getFirst().getName(), "Exception Stack Trace");
         assertNull(TestNGListenerHelper.getAndClearPendingConfigFailure());
         assertAttachmentFileContains("configuration exploded");
     }

--- a/shaft-engine/src/test/java/testPackage/unitTests/CheckpointAndReportingTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/CheckpointAndReportingTest.java
@@ -7,7 +7,7 @@ import com.shaft.validation.Validations;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Field;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.testng.Assert.*;
@@ -21,7 +21,6 @@ import static org.testng.Assert.*;
 public class CheckpointAndReportingTest {
 
     private static final Field CHECKPOINTS_FIELD;
-    private static final Field SEQUENCE_FIELD;
     private static final Field PASSED_FIELD;
     private static final Field FAILED_FIELD;
 
@@ -29,8 +28,6 @@ public class CheckpointAndReportingTest {
         try {
             CHECKPOINTS_FIELD = CheckpointCounter.class.getDeclaredField("checkpoints");
             CHECKPOINTS_FIELD.setAccessible(true);
-            SEQUENCE_FIELD = CheckpointCounter.class.getDeclaredField("checkpointSequence");
-            SEQUENCE_FIELD.setAccessible(true);
             PASSED_FIELD = CheckpointCounter.class.getDeclaredField("passedCheckpoints");
             PASSED_FIELD.setAccessible(true);
             FAILED_FIELD = CheckpointCounter.class.getDeclaredField("failedCheckpoints");
@@ -41,14 +38,13 @@ public class CheckpointAndReportingTest {
     }
 
     private void resetCheckpointCounter() throws Exception {
-        ((ConcurrentHashMap<?, ?>) CHECKPOINTS_FIELD.get(null)).clear();
-        ((AtomicInteger) SEQUENCE_FIELD.get(null)).set(0);
+        ((List<?>) CHECKPOINTS_FIELD.get(null)).clear();
         ((AtomicInteger) PASSED_FIELD.get(null)).set(0);
         ((AtomicInteger) FAILED_FIELD.get(null)).set(0);
     }
 
     private int getCheckpointsSize() throws Exception {
-        return ((ConcurrentHashMap<?, ?>) CHECKPOINTS_FIELD.get(null)).size();
+        return ((List<?>) CHECKPOINTS_FIELD.get(null)).size();
     }
 
     private int getPassedCount() throws Exception {

--- a/shaft-engine/src/test/java/testPackage/unitTests/TestNGListenerHelperCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/TestNGListenerHelperCoverageUnitTest.java
@@ -301,9 +301,9 @@ public class TestNGListenerHelperCoverageUnitTest {
             TestNGListenerHelper.logFinishedTestInformation(cucumber);
 
             reportManagerHelper.verify(() -> com.shaft.tools.io.internal.ReportManagerHelper.logTestInformation("sampleClass", "sampleMethod", "sample description"));
-            reportManagerHelper.verify(() -> com.shaft.tools.io.internal.ReportManagerHelper.logFinishedTestInformation("sampleClass", "sampleMethod", "sample description", "Passed"));
-            reportManagerHelper.verify(() -> com.shaft.tools.io.internal.ReportManagerHelper.logFinishedTestInformation("sampleClass", "sampleMethod", "sample description", "Failed"));
-            reportManagerHelper.verify(() -> com.shaft.tools.io.internal.ReportManagerHelper.logFinishedTestInformation("sampleClass", "sampleMethod", "sample description", "Skipped"));
+            reportManagerHelper.verify(() -> com.shaft.tools.io.internal.ReportManagerHelper.logFinishedTestInformation(Mockito.eq("sampleClass"), Mockito.eq("sampleMethod"), Mockito.eq("sample description"), Mockito.eq("Passed"), Mockito.any()));
+            reportManagerHelper.verify(() -> com.shaft.tools.io.internal.ReportManagerHelper.logFinishedTestInformation(Mockito.eq("sampleClass"), Mockito.eq("sampleMethod"), Mockito.eq("sample description"), Mockito.eq("Failed"), Mockito.any()));
+            reportManagerHelper.verify(() -> com.shaft.tools.io.internal.ReportManagerHelper.logFinishedTestInformation(Mockito.eq("sampleClass"), Mockito.eq("sampleMethod"), Mockito.eq("sample description"), Mockito.eq("Skipped"), Mockito.any()));
         }
     }
 


### PR DESCRIPTION
## Summary

Focused pass over the logging/evidence/reporting subsystem prioritizing the Allure report and console logs: failure-reason clarity, checkpoint evidence by default, accuracy fixes, and report UI polish.

### Evidence & failure clarity (Allure + console)
- **Every checkpoint now carries evidence by default**: non-UI validations always attach `Expected Value` / `Actual Value` (previously only when a value exceeded 500 chars). UI validations already attach screenshots by default (`ValidationPointsOnly`). Failed data validations now also populate the Allure step trace via the existing attachment wiring. Also fixes a latent `ClassCastException` when expected/actual were non-String objects.
- **Console finished-test banner now shows the failure root cause** (`Root cause: "class: message"`) for TestNG and JUnit failures — previously only `Status: Failed`.
- Empty attachments log a discrete debug note instead of vanishing silently.
- Unified `Exception Stack Trace` attachment naming (was `Exception Stacktrace` in two of four sites).

### Accuracy
- Timestamps: `dd-MM-yyyy HH:mm:ss.SSSS a` mixed a 24-hour clock with an AM/PM marker (log lines rendered like `18:22:33.1234 PM`); same broken pattern in five report-filename formatters. Now standard `HH:mm:ss.SSS`.
- `ExecutionSummaryReport` used `map.put(size + 1, …)` for case rows and validation counts — racy under parallel execution (lost rows, pass rates above 100%) and `ConcurrentHashMap` iteration order is not insertion order. Rows now use an ordered concurrent list; validation totals derive from the pass/fail counters. Same ordering fix in `CheckpointCounter`.
- `getRootCause` no longer emits a dangling `: ` when the root cause has no message; `getExecutionDuration` reports `0 millis` instead of an empty string.
- Config-method banner wording: "Starting execution of before method configuration method" → "Starting before method configuration".

### Report UI/UX
- Test names, suites, error messages, and checkpoint messages are HTML-escaped in the Execution Summary and Checkpoints reports — assertion messages like `expected <true> but found <false>` no longer break the tables (shared `ReportHtmlTheme.escapeHtml`, consistent with the failure reporters).
- Issue Signals cards renamed to say what they count: `Failed · No Known Issue`, `Passed · Issue Still Open`, `Failed · Known Issue`.
- Empty runs show `0.00%` consistently; checkpoint donut token renamed to `CHECKPOINTS_PASSED_DEGREES` to match its actual unit.

### Performance
- `LogRedirector` (wraps `System.out`/`System.err`) wrote redirected output one byte at a time; now scans for line breaks and writes bulk segments.
- `getCallingMethodFullName` uses the shared `StackWalker` instead of materializing the full stack trace on every debug companion log line.

## Verification
- `mvn -pl shaft-engine test-compile` clean on JDK 25.
- Targeted headless suites, all green (111 tests, 0 failures): ReportManagerHelperUnitTests, CheckpointAndReportingTest, TestNGListenerHelperCoverageUnitTest, AllureListenerCoverageUnitTest, ReportManagerHelperAttachmentIoUnitTest, JunitListenerApiCoverageUnitTest, LightHouseGenerateReportCoverageUnitTest, FailureReporterUnitTest, RestActionsFailureLoggingUnitTest, ExecutionLifecycleHelperSourceUnitTest, CucumberTestsHelperCoverageUnitTest, LocatorHealthReporterUnitTest, FailureTraceReporterTest.
- `CheckpointAndReportingTest` exercises the new always-attach path end-to-end via real `Validations.assertThat()` calls.

## Out of scope (follow-up)
Step pass/fail status is still inferred from the log text containing "failed" (`getStepStatus`) — fixing it properly requires threading explicit status through the public logging API; tracked as a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)