### PR TITLE
ci: pause guaranteed-red LambdaTest nightly schedule (#2927 containment)

### DIFF
--- a/.github/workflows/lambdatestTests.yml
+++ b/.github/workflows/lambdatestTests.yml
@@ -5,8 +5,11 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  schedule:
-    - cron: '00 1 * * *'
+  # Nightly schedule paused while the LambdaTest account is plan-blocked /
+  # minutes-exhausted (see issue #2927) — every scheduled run is guaranteed red.
+  # Re-enable once the account can start sessions again:
+  # schedule:
+  #   - cron: '00 1 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
Pauses the `schedule:` trigger of `.github/workflows/lambdatestTests.yml` (keeping `workflow_dispatch`) while the LambdaTest account is plan-blocked / minutes-exhausted, per the empirical probe documented in #2927:

- NativeAndroid / NativeIOS / WebApp: 403 `LT_FEATURE_NOT_AVAILABLE_IN_CURRENT_PLAN`
- DesktopWeb: 400 `Lifetime Minutes Exhausted`

Every nightly run is a guaranteed failure burning ~25 runner-minutes/day. The commented-out cron plus an explanatory comment makes re-enabling a one-line revert once the account question (OSS grant or plan upgrade) is settled.

The issue itself remains open pending the account-side decision documented in the issue comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)