### PR TITLE
feat: mobile aria-snapshot assertion from Appium accessibility XML (closes #3451)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/internal/aria/MobileAccessibilityTreeConverter.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/aria/MobileAccessibilityTreeConverter.java
@@ -1,0 +1,171 @@
+package com.shaft.gui.internal.aria;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Converts Appium accessibility XML (UiAutomator2 {@code hierarchy}/{@code node} trees, or XCUITest
+ * {@code XCUIElementType*} trees) into the {@link AriaNode} forest consumed by {@link AriaSnapshotHelper},
+ * so {@code matchesAriaSnapshot()} baselines work the same way for native mobile as for web.
+ */
+public final class MobileAccessibilityTreeConverter {
+    private static final String ANDROID_ROOT_TAG = "hierarchy";
+    private static final String XCUI_ELEMENT_TYPE_PREFIX = "XCUIElementType";
+
+    /**
+     * Names, in priority order, that {@link #deriveName(Element)} checks to resolve an accessible name.
+     * Mirrors {@code McpAppiumLocatorSuggester.ACCESSIBLE_NAME_ATTRIBUTES}.
+     */
+    private static final List<String> ACCESSIBLE_NAME_ATTRIBUTES = List.of(
+            "content-desc", "name", "label", "text", "value");
+
+    /**
+     * Generic layout-only roles that are filtered out (with their children hoisted up) when the node
+     * has no accessible name of its own.
+     */
+    private static final Set<String> GENERIC_CONTAINER_ROLES = Set.of(
+            "framelayout", "linearlayout", "relativelayout", "viewgroup", "other", "window");
+
+    private MobileAccessibilityTreeConverter() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Converts Appium accessibility XML (either a full page source or a single element's
+     * {@code outerXML} subtree) into an {@link AriaNode} forest.
+     *
+     * <p>The synthetic Android root wrapper tag {@code hierarchy} is skipped; its children become the
+     * top-level forest. Nameless generic-container nodes (e.g. {@code FrameLayout}, {@code LinearLayout},
+     * {@code XCUIElementTypeOther}, {@code XCUIElementTypeWindow}) are dropped and their children hoisted
+     * up in their place; a nameless generic container with no children is dropped entirely. Every other
+     * node is kept, whether or not it has a name.</p>
+     *
+     * @param pageSourceXml the Appium accessibility XML to convert
+     * @return the converted top-level nodes
+     * @throws IllegalArgumentException if {@code pageSourceXml} is blank or is not well-formed XML
+     */
+    public static List<AriaNode> convert(String pageSourceXml) {
+        if (pageSourceXml == null || pageSourceXml.isBlank()) {
+            throw new IllegalArgumentException("Appium accessibility XML must not be blank.");
+        }
+        Element root = parseDocument(pageSourceXml).getDocumentElement();
+        if (root == null) {
+            return List.of();
+        }
+        List<AriaNode> forest = new ArrayList<>();
+        if (ANDROID_ROOT_TAG.equals(root.getTagName())) {
+            for (Element child : childElements(root)) {
+                forest.addAll(convertElement(child));
+            }
+        } else {
+            forest.addAll(convertElement(root));
+        }
+        return forest;
+    }
+
+    /**
+     * Captures an aria snapshot of the element matched by {@code locator} on a mobile-native session:
+     * reads the element's {@code outerXML} attribute (Appium UiAutomator2/XCUITest subtree XML), falling
+     * back to the full {@link WebDriver#getPageSource()} when {@code outerXML} is unavailable, then
+     * converts and serializes it.
+     *
+     * @param driver active mobile-native WebDriver instance
+     * @param locator locator of the element to snapshot
+     * @return the captured snapshot serialized as YAML
+     */
+    public static String captureAriaSnapshot(WebDriver driver, By locator) {
+        WebElement element = driver.findElement(locator);
+        String xml = element.getAttribute("outerXML");
+        if (xml == null || xml.isBlank()) {
+            xml = driver.getPageSource();
+        }
+        return AriaSnapshotHelper.serialize(convert(xml));
+    }
+
+    /**
+     * Converts a single element, and recursively its children, returning the list of nodes it
+     * contributes to its parent's child list: normally a single-element list, an empty list when the
+     * element is a nameless generic container with no surviving children, or the element's own
+     * (already-converted) children when it is a nameless generic container that does have children.
+     */
+    private static List<AriaNode> convertElement(Element element) {
+        List<AriaNode> children = new ArrayList<>();
+        for (Element childElement : childElements(element)) {
+            children.addAll(convertElement(childElement));
+        }
+        String role = deriveRole(element);
+        String name = deriveName(element);
+        if (name.isBlank() && GENERIC_CONTAINER_ROLES.contains(role)) {
+            return children;
+        }
+        return List.of(new AriaNode(role, name, children));
+    }
+
+    private static String deriveRole(Element element) {
+        String tagName = element.getTagName();
+        if (tagName.startsWith(XCUI_ELEMENT_TYPE_PREFIX)) {
+            String stripped = tagName.substring(XCUI_ELEMENT_TYPE_PREFIX.length());
+            return stripped.isBlank() ? tagName.toLowerCase(Locale.ROOT) : stripped.toLowerCase(Locale.ROOT);
+        }
+        String classAttribute = attribute(element, "class");
+        String source = classAttribute.isBlank() ? tagName : classAttribute;
+        int lastDot = source.lastIndexOf('.');
+        String role = lastDot >= 0 ? source.substring(lastDot + 1) : source;
+        return role.toLowerCase(Locale.ROOT);
+    }
+
+    private static String deriveName(Element element) {
+        for (String attributeName : ACCESSIBLE_NAME_ATTRIBUTES) {
+            String value = attribute(element, attributeName);
+            if (!value.isBlank()) {
+                return value;
+            }
+        }
+        return "";
+    }
+
+    private static String attribute(Element element, String name) {
+        return element.hasAttribute(name) ? element.getAttribute(name).trim() : "";
+    }
+
+    private static List<Element> childElements(Element element) {
+        NodeList childNodes = element.getChildNodes();
+        List<Element> elements = new ArrayList<>();
+        for (int index = 0; index < childNodes.getLength(); index++) {
+            Node child = childNodes.item(index);
+            if (child instanceof Element childElement) {
+                elements.add(childElement);
+            }
+        }
+        return elements;
+    }
+
+    private static Document parseDocument(String xml) {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
+            return factory.newDocumentBuilder().parse(new InputSource(new StringReader(xml)));
+        } catch (Exception exception) {
+            throw new IllegalArgumentException("Failed to parse Appium accessibility XML: " + exception.getMessage(), exception);
+        }
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java
@@ -3,12 +3,14 @@ package com.shaft.validation.internal;
 import com.shaft.api.RestActions;
 import com.shaft.cli.FileActions;
 import com.shaft.driver.SHAFT;
+import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.driver.internal.DriverFactory.SynchronizationManager;
 import com.shaft.gui.browser.BrowserActions;
 import com.shaft.gui.browser.internal.BrowserActionsHelper;
 import com.shaft.gui.element.ElementActions;
 import com.shaft.gui.element.internal.Actions;
 import com.shaft.gui.internal.aria.AriaSnapshotHelper;
+import com.shaft.gui.internal.aria.MobileAccessibilityTreeConverter;
 import com.shaft.gui.internal.image.ImageProcessingActions;
 import com.shaft.gui.internal.image.ScreenshotHelper;
 import com.shaft.gui.internal.image.ScreenshotManager;
@@ -724,7 +726,9 @@ public class ValidationsHelper {
         try {
             new SynchronizationManager(driver).fluentWait(true).until(f -> {
                 List<List<Object>> attachments = new ArrayList<>();
-                String actualYaml = AriaSnapshotHelper.captureAriaSnapshot(driver, locator);
+                String actualYaml = DriverFactoryHelper.isMobileNativeExecution()
+                        ? MobileAccessibilityTreeConverter.captureAriaSnapshot(driver, locator)
+                        : AriaSnapshotHelper.captureAriaSnapshot(driver, locator);
                 boolean updateSnapshots = SHAFT.Properties.visuals.updateSnapshots();
                 boolean baselineExists = FileActions.getInstance(true).doesFileExist(baselinePath);
                 boolean matched;

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/aria/MobileAccessibilityTreeConverterUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/aria/MobileAccessibilityTreeConverterUnitTest.java
@@ -1,0 +1,147 @@
+package com.shaft.gui.internal.aria;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+public class MobileAccessibilityTreeConverterUnitTest {
+
+    private static final String ANDROID_XML = """
+            <hierarchy>
+              <android.widget.FrameLayout class="android.widget.FrameLayout" bounds="[0,0][1080,2160]">
+                <android.widget.LinearLayout class="android.widget.LinearLayout" bounds="[0,0][1080,200]">
+                  <android.widget.TextView class="android.widget.TextView" text="Welcome" bounds="[20,20][500,80]"/>
+                  <android.widget.Button class="android.widget.Button" content-desc="Sign in" resource-id="com.example:id/signin" bounds="[600,20][1000,80]"/>
+                </android.widget.LinearLayout>
+                <android.widget.ViewGroup class="android.widget.ViewGroup" bounds="[0,200][1080,2160]">
+                  <android.widget.EditText class="android.widget.EditText" text="" resource-id="com.example:id/username" bounds="[20,220][1000,280]"/>
+                </android.widget.ViewGroup>
+              </android.widget.FrameLayout>
+            </hierarchy>
+            """;
+
+    private static final String IOS_XML = """
+            <XCUIElementTypeOther type="XCUIElementTypeOther">
+              <XCUIElementTypeStaticText type="XCUIElementTypeStaticText" name="Welcome" label="Welcome" value="Welcome"/>
+              <XCUIElementTypeButton type="XCUIElementTypeButton" name="Sign in" label="Sign in"/>
+              <XCUIElementTypeOther type="XCUIElementTypeOther">
+                <XCUIElementTypeTextField type="XCUIElementTypeTextField" name="username" value=""/>
+              </XCUIElementTypeOther>
+            </XCUIElementTypeOther>
+            """;
+
+    @Test(description = "convert should skip the synthetic Android hierarchy wrapper and hoist nameless generic containers, keeping named/leaf nodes")
+    public void convertShouldSkipHierarchyWrapperAndHoistNamelessContainers() {
+        List<AriaNode> forest = MobileAccessibilityTreeConverter.convert(ANDROID_XML);
+
+        // FrameLayout, LinearLayout, and ViewGroup are all nameless generic containers: hoisted away,
+        // leaving their named/leaf descendants at the top level.
+        Assert.assertEquals(forest, List.of(
+                new AriaNode("textview", "Welcome", List.of()),
+                new AriaNode("button", "Sign in", List.of()),
+                new AriaNode("edittext", "", List.of())
+        ));
+    }
+
+    @Test(description = "convert should derive iOS roles by stripping the XCUIElementType prefix and hoist nameless XCUIElementTypeOther containers")
+    public void convertShouldDeriveIosRolesAndHoistNamelessOtherContainers() {
+        List<AriaNode> forest = MobileAccessibilityTreeConverter.convert(IOS_XML);
+
+        Assert.assertEquals(forest, List.of(
+                new AriaNode("statictext", "Welcome", List.of()),
+                new AriaNode("button", "Sign in", List.of()),
+                new AriaNode("textfield", "username", List.of())
+        ));
+    }
+
+    @Test(description = "convert should preserve real nesting for named containers instead of hoisting them")
+    public void convertShouldPreserveNestingForNamedContainers() {
+        String xml = """
+                <hierarchy>
+                  <android.widget.LinearLayout class="android.widget.LinearLayout" content-desc="Toolbar" bounds="[0,0][1080,200]">
+                    <android.widget.Button class="android.widget.Button" content-desc="Back" bounds="[0,0][100,200]"/>
+                  </android.widget.LinearLayout>
+                </hierarchy>
+                """;
+
+        List<AriaNode> forest = MobileAccessibilityTreeConverter.convert(xml);
+
+        Assert.assertEquals(forest, List.of(
+                new AriaNode("linearlayout", "Toolbar", List.of(
+                        new AriaNode("button", "Back", List.of())
+                ))
+        ));
+    }
+
+    @Test(description = "convert should drop a nameless generic container that has no surviving children")
+    public void convertShouldDropEmptyNamelessGenericContainer() {
+        String xml = """
+                <hierarchy>
+                  <android.widget.FrameLayout class="android.widget.FrameLayout" bounds="[0,0][1080,2160]"/>
+                </hierarchy>
+                """;
+
+        List<AriaNode> forest = MobileAccessibilityTreeConverter.convert(xml);
+
+        Assert.assertTrue(forest.isEmpty());
+    }
+
+    @Test(description = "convert should fall back to the tag name when the class attribute is absent")
+    public void convertShouldFallBackToTagNameForRole() {
+        String xml = """
+                <hierarchy>
+                  <node text="Save" bounds="[0,0][100,50]"/>
+                </hierarchy>
+                """;
+
+        List<AriaNode> forest = MobileAccessibilityTreeConverter.convert(xml);
+
+        Assert.assertEquals(forest, List.of(new AriaNode("node", "Save", List.of())));
+    }
+
+    @Test(description = "serialized converted forest should match SHAFT's aria snapshot YAML shape")
+    public void convertedForestShouldSerializeToExpectedYamlShape() {
+        String yaml = AriaSnapshotHelper.serialize(MobileAccessibilityTreeConverter.convert(ANDROID_XML));
+
+        Assert.assertEquals(yaml, """
+                - textview "Welcome"
+                - button "Sign in"
+                - edittext
+                """);
+    }
+
+    @Test(description = "a baseline captured from the Android tree should match-subset an actual snapshot from the same tree")
+    public void convertedAndroidForestShouldRoundTripThroughMatch() {
+        String baseline = AriaSnapshotHelper.serialize(MobileAccessibilityTreeConverter.convert(ANDROID_XML));
+        String actual = AriaSnapshotHelper.serialize(MobileAccessibilityTreeConverter.convert(ANDROID_XML));
+
+        var result = AriaSnapshotHelper.match(baseline, actual);
+
+        Assert.assertTrue(result.matched());
+    }
+
+    @Test(description = "a baseline captured from the iOS tree should match-subset an actual snapshot from the same tree")
+    public void convertedIosForestShouldRoundTripThroughMatch() {
+        String baseline = AriaSnapshotHelper.serialize(MobileAccessibilityTreeConverter.convert(IOS_XML));
+        String actual = AriaSnapshotHelper.serialize(MobileAccessibilityTreeConverter.convert(IOS_XML));
+
+        var result = AriaSnapshotHelper.match(baseline, actual);
+
+        Assert.assertTrue(result.matched());
+    }
+
+    @Test(description = "convert should reject blank input")
+    public void convertShouldRejectBlankInput() {
+        Assert.assertThrows(IllegalArgumentException.class, () -> MobileAccessibilityTreeConverter.convert(""));
+        Assert.assertThrows(IllegalArgumentException.class, () -> MobileAccessibilityTreeConverter.convert(null));
+    }
+
+    @Test(description = "convert should throw a clear IllegalArgumentException for malformed XML")
+    public void convertShouldThrowForMalformedXml() {
+        IllegalArgumentException exception = Assert.expectThrows(IllegalArgumentException.class,
+                () -> MobileAccessibilityTreeConverter.convert("<hierarchy><node bounds=\"[0,0][10,10]\"></hierarchy>"));
+
+        Assert.assertTrue(exception.getMessage().contains("Failed to parse Appium accessibility XML"));
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/validation/internal/WebDriverElementValidationsBuilderAriaSnapshotUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/validation/internal/WebDriverElementValidationsBuilderAriaSnapshotUnitTest.java
@@ -77,4 +77,36 @@ public class WebDriverElementValidationsBuilderAriaSnapshotUnitTest {
             FileActions.getInstance(true).deleteFile(baselinePath);
         }
     }
+
+    @Test(description = "on a mobile-native session, first run should capture via the Appium accessibility XML converter instead of JavaScript execution")
+    public void matchesAriaSnapshotShouldUseMobileConverterOnMobileNativeExecution() {
+        String previousTargetPlatform = SHAFT.Properties.platform.targetPlatform();
+        SHAFT.Properties.platform.set().targetPlatform("Android");
+
+        WebDriver driver = mock(WebDriver.class);
+        WebElement element = mock(WebElement.class);
+        when(driver.findElement(SAMPLE_LOCATOR)).thenReturn(element);
+        when(element.getAttribute("outerXML")).thenReturn("""
+                <hierarchy>
+                  <android.widget.Button class="android.widget.Button" content-desc="Sign in" bounds="[0,0][100,50]"/>
+                </hierarchy>
+                """);
+
+        String baselineFile = "matchesAriaSnapshotShouldUseMobileConverterOnMobileNativeExecution_" + System.identityHashCode(this);
+        String baselinePath = SHAFT.Properties.paths.ariaSnapshot() + baselineFile + ".yaml";
+        FileActions.getInstance(true).deleteFile(baselinePath);
+
+        try {
+            WebDriverElementValidationsBuilder builder = new WebDriverElementValidationsBuilder(
+                    ValidationEnums.ValidationCategory.HARD_ASSERT, driver, SAMPLE_LOCATOR, new StringBuilder("the element "));
+
+            builder.matchesAriaSnapshot(baselineFile);
+
+            Assert.assertTrue(FileActions.getInstance(true).doesFileExist(baselinePath));
+            Assert.assertTrue(FileActions.getInstance(true).readFile(baselinePath).contains("button \"Sign in\""));
+        } finally {
+            FileActions.getInstance(true).deleteFile(baselinePath);
+            SHAFT.Properties.platform.set().targetPlatform(previousTargetPlatform);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Makes `matchesAriaSnapshot(...)` work for native mobile sessions (closes #3451):

- New pure-JVM `MobileAccessibilityTreeConverter` (same package as `AriaSnapshotHelper`): XXE-safe parsing of Appium accessibility XML (Android UiAutomator2 `hierarchy`/`node` trees and iOS `XCUIElementType*` trees) into the existing `AriaNode` forest. Role from `class` last-segment / `XCUIElementType` suffix; name from `content-desc`/`name`/`label`/`text`/`value` priority. Nameless generic containers (FrameLayout/LinearLayout/Other/Window/…) are dropped with children hoisted, recursively, to keep auto-captured baselines readable.
- `captureAriaSnapshot(driver, locator)`: element `outerXML` subtree with `getPageSource()` fallback, serialized through `AriaSnapshotHelper.serialize`.
- `ValidationsHelper.validateElementAriaSnapshot` branches on `DriverFactoryHelper.isMobileNativeExecution()` — the entire assertion surface (`SHAFT.GUI.WebDriver.assertThat().element(locator).matchesAriaSnapshot(name)`), baseline lifecycle, `updateSnapshots` flow, partial matching via `AriaSnapshotHelper.match`, and Allure attachments are reused unchanged; zero new public API.
- Live-device E2E remains gated on emulator CI capacity per the issue.

## Verification
- 22/22 tests green (testng-results.xml): 10 new converter tests (Android + iOS fixtures, nesting, hoisting policy, wrapper skipping, round-trip through `AriaSnapshotHelper.match`, malformed-XML rejection), 3 aria-snapshot builder tests incl. a new Mockito mobile-branch test (mocked `outerXML`, `targetPlatform=Android`), 9 pre-existing helper tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)