### PR TITLE
feat: persist Appium session capabilities and app-state snapshots for session reuse (closes #3457)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java
@@ -8,6 +8,7 @@ import com.shaft.driver.internal.DriverFactory.SynchronizationManager;
 import com.shaft.driver.internal.FluentWebDriverAction;
 import com.shaft.driver.internal.WizardHelpers;
 import com.shaft.gui.element.internal.ElementActionsHelper;
+import com.shaft.gui.element.internal.MobileSessionStateManager;
 import com.shaft.gui.internal.healing.HealingManager;
 import com.shaft.gui.internal.healing.HealingResolution;
 import com.shaft.gui.internal.image.ScreenshotManager;
@@ -834,6 +835,93 @@ public class TouchActions extends FluentWebDriverAction {
      */
     public TouchActions rotate(String orientation) {
         return rotate(enumValue(ScreenOrientation.class, orientation, "orientation"));
+    }
+
+    /**
+     * Saves the active Appium session capabilities to a JSON file, so a later test run can reuse
+     * the same device/app configuration without re-resolving it.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * driver.touch().saveSessionCapabilities("target/mobile-session-cache/device.json");
+     * }</pre>
+     *
+     * @param filePath target JSON file path
+     * @return a self-reference to be used to chain actions
+     */
+    public TouchActions saveSessionCapabilities(String filePath) {
+        WebDriver driver = driverFactoryHelper.getDriver();
+        try {
+            MobileSessionStateManager.saveCapabilities(driver, filePath);
+            elementActionsHelper.passAction(driver, null, Thread.currentThread().getStackTrace()[1].getMethodName(), filePath, null, null);
+        } catch (Exception rootCauseException) {
+            elementActionsHelper.failAction(driver, filePath, null, rootCauseException);
+        }
+        return this;
+    }
+
+    /**
+     * Loads previously saved Appium session capabilities from a JSON file.
+     *
+     * <p>This is a static method because capabilities must be known before a driver session exists.
+     * Example:
+     * <pre>{@code
+     * MutableCapabilities capabilities = TouchActions.loadSessionCapabilities("target/mobile-session-cache/device.json");
+     * SHAFT.GUI.WebDriver driver = new SHAFT.GUI.WebDriver(DriverFactory.DriverType.APPIUM_MOBILE_NATIVE, capabilities);
+     * }</pre>
+     *
+     * @param filePath source JSON file path
+     * @return capabilities restored from the file
+     */
+    public static MutableCapabilities loadSessionCapabilities(String filePath) {
+        return MobileSessionStateManager.loadCapabilities(filePath);
+    }
+
+    /**
+     * Saves a snapshot of the current mobile app state (active app, context, orientation, window size)
+     * to a JSON file.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * driver.touch().saveAppState("target/mobile-session-cache/app-state.json");
+     * }</pre>
+     *
+     * @param filePath target JSON file path
+     * @return a self-reference to be used to chain actions
+     */
+    public TouchActions saveAppState(String filePath) {
+        WebDriver driver = driverFactoryHelper.getDriver();
+        try {
+            MobileSessionStateManager.saveAppState(driver, filePath);
+            elementActionsHelper.passAction(driver, null, Thread.currentThread().getStackTrace()[1].getMethodName(), filePath, null, null);
+        } catch (Exception rootCauseException) {
+            elementActionsHelper.failAction(driver, filePath, null, rootCauseException);
+        }
+        return this;
+    }
+
+    /**
+     * Restores what is restorable of a previously saved mobile app-state snapshot on the current
+     * live session: re-activates the app, switches context, and rotates the device when supported.
+     * Unsupported restore steps are skipped silently.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * driver.touch().loadAppState("target/mobile-session-cache/app-state.json");
+     * }</pre>
+     *
+     * @param filePath source JSON file path
+     * @return a self-reference to be used to chain actions
+     */
+    public TouchActions loadAppState(String filePath) {
+        WebDriver driver = driverFactoryHelper.getDriver();
+        try {
+            MobileSessionStateManager.loadAppState(driver, filePath);
+            elementActionsHelper.passAction(driver, null, Thread.currentThread().getStackTrace()[1].getMethodName(), filePath, null, null);
+        } catch (Exception rootCauseException) {
+            elementActionsHelper.failAction(driver, filePath, null, rootCauseException);
+        }
+        return this;
     }
 
     private static <T extends Enum<T>> T enumValue(Class<T> enumType, String value, String parameterName) {

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/MobileSessionStateManager.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/MobileSessionStateManager.java
@@ -1,0 +1,310 @@
+package com.shaft.gui.element.internal;
+
+import com.shaft.driver.SHAFT;
+import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.ios.IOSDriver;
+import io.appium.java_client.remote.SupportsContextSwitching;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.Platform;
+import org.openqa.selenium.ScreenOrientation;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Saves and restores Appium session capabilities and mobile app-state snapshots for one WebDriver session.
+ */
+public final class MobileSessionStateManager {
+    private static final ObjectMapper JSON = JsonMapper.builder()
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .build();
+
+    private MobileSessionStateManager() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Saves the active Appium session capabilities to a JSON file.
+     *
+     * @param driver   active WebDriver (must be a RemoteWebDriver/Appium session)
+     * @param filePath target JSON file
+     */
+    public static void saveCapabilities(WebDriver driver, String filePath) {
+        requireDriver(driver);
+        Path path = path(filePath);
+        RemoteWebDriver remoteWebDriver = requireRemoteWebDriver(driver);
+        Capabilities capabilities = remoteWebDriver.getCapabilities();
+        SessionCapabilitiesState state = new SessionCapabilitiesState();
+        state.schemaVersion = "1.0";
+        state.platformName = firstNonBlank(capability(capabilities, "platformName"), platformName(capabilities));
+        state.capabilities = capabilities == null ? Map.of() : new LinkedHashMap<>(capabilities.asMap());
+        write(path, state);
+    }
+
+    /**
+     * Loads previously saved Appium session capabilities from a JSON file.
+     *
+     * <p>This is a static method because capabilities must be known before a driver session exists.
+     * Example:
+     * <pre>{@code
+     * MutableCapabilities capabilities = MobileSessionStateManager.loadCapabilities("target/mobile-session-cache/device.json");
+     * DriverFactory.getHelper(DriverFactory.DriverType.APPIUM_MOBILE_NATIVE, capabilities);
+     * }</pre>
+     *
+     * @param filePath source JSON file
+     * @return capabilities restored from the file
+     */
+    public static MutableCapabilities loadCapabilities(String filePath) {
+        Path path = path(filePath);
+        try {
+            SessionCapabilitiesState state = JSON.readValue(path.toFile(), SessionCapabilitiesState.class);
+            Map<String, Object> capabilities = new LinkedHashMap<>();
+            if (state.capabilities != null) {
+                state.capabilities.forEach((key, value) -> {
+                    if (value != null) {
+                        capabilities.put(key, value);
+                    }
+                });
+            }
+            return new MutableCapabilities(capabilities);
+        } catch (RuntimeException e) {
+            throw new IllegalStateException("Could not load mobile session capabilities from `" + path + "`.", e);
+        }
+    }
+
+    /**
+     * Saves a snapshot of the current mobile app state (active app, context, orientation, window size)
+     * to a JSON file.
+     *
+     * @param driver   active WebDriver
+     * @param filePath target JSON file
+     */
+    public static void saveAppState(WebDriver driver, String filePath) {
+        requireDriver(driver);
+        Path path = path(filePath);
+        Capabilities capabilities = capabilities(driver);
+        AppStateSnapshot state = new AppStateSnapshot();
+        state.schemaVersion = "1.0";
+        state.appPackage = firstNonBlank(capability(capabilities, "appium:appPackage"),
+                capability(capabilities, "appPackage"), SHAFT.Properties.mobile.appPackage());
+        state.appActivity = firstNonBlank(capability(capabilities, "appium:appActivity"),
+                capability(capabilities, "appActivity"), SHAFT.Properties.mobile.appActivity());
+        state.bundleId = firstNonBlank(capability(capabilities, "appium:bundleId"),
+                capability(capabilities, "bundleId"), SHAFT.Properties.mobile.bundleId());
+        state.context = context(driver);
+        state.orientation = orientation(driver);
+        state.windowSize = windowSize(driver);
+        write(path, state);
+    }
+
+    /**
+     * Restores what is restorable of a previously saved mobile app-state snapshot on a live session:
+     * re-activates the app, switches context, and rotates the device when the corresponding
+     * capability is supported by the active driver. Unsupported restore steps are skipped silently.
+     *
+     * @param driver   active WebDriver
+     * @param filePath source JSON file
+     */
+    public static void loadAppState(WebDriver driver, String filePath) {
+        requireDriver(driver);
+        Path path = path(filePath);
+        AppStateSnapshot state;
+        try {
+            state = JSON.readValue(path.toFile(), AppStateSnapshot.class);
+        } catch (RuntimeException e) {
+            throw new IllegalStateException("Could not load mobile app state from `" + path + "`.", e);
+        }
+        restoreActiveApp(driver, state);
+        restoreContext(driver, state);
+        restoreOrientation(driver, state);
+    }
+
+    private static void restoreActiveApp(WebDriver driver, AppStateSnapshot state) {
+        try {
+            if (driver instanceof AndroidDriver androidDriver) {
+                String appId = firstNonBlank(state.appPackage, state.bundleId);
+                if (appId != null) {
+                    androidDriver.activateApp(appId);
+                }
+            } else if (driver instanceof IOSDriver iosDriver) {
+                String appId = firstNonBlank(state.bundleId, state.appPackage);
+                if (appId != null) {
+                    iosDriver.activateApp(appId);
+                }
+            }
+        } catch (RuntimeException ignored) {
+            // restoring the active app is best-effort; skip silently when unsupported
+        }
+    }
+
+    private static void restoreContext(WebDriver driver, AppStateSnapshot state) {
+        if (state.context == null || state.context.isBlank()) {
+            return;
+        }
+        if (driver instanceof SupportsContextSwitching contextDriver) {
+            try {
+                String current = contextDriver.getContext();
+                if (!state.context.equals(current)) {
+                    contextDriver.context(state.context);
+                }
+            } catch (RuntimeException ignored) {
+                // context switching unsupported by the active provider; skip silently
+            }
+        }
+    }
+
+    private static void restoreOrientation(WebDriver driver, AppStateSnapshot state) {
+        if (state.orientation == null || state.orientation.isBlank()) {
+            return;
+        }
+        ScreenOrientation orientation;
+        try {
+            orientation = ScreenOrientation.valueOf(state.orientation.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ignored) {
+            return;
+        }
+        try {
+            if (driver instanceof AndroidDriver androidDriver) {
+                androidDriver.rotate(orientation);
+            } else if (driver instanceof IOSDriver iosDriver) {
+                iosDriver.rotate(orientation);
+            }
+        } catch (RuntimeException ignored) {
+            // rotation unsupported by the active provider; skip silently
+        }
+    }
+
+    private static void requireDriver(WebDriver driver) {
+        if (driver == null) {
+            throw new IllegalArgumentException("A WebDriver session is required for mobile session state.");
+        }
+    }
+
+    private static RemoteWebDriver requireRemoteWebDriver(WebDriver driver) {
+        if (driver instanceof RemoteWebDriver remoteWebDriver) {
+            return remoteWebDriver;
+        }
+        throw new IllegalArgumentException("Mobile session capabilities require a RemoteWebDriver (Appium) session.");
+    }
+
+    private static Path path(String filePath) {
+        if (filePath == null || filePath.isBlank()) {
+            throw new IllegalArgumentException("Mobile session state path must not be blank.");
+        }
+        return Path.of(filePath).toAbsolutePath().normalize();
+    }
+
+    private static void write(Path path, Object state) {
+        try {
+            if (path.getParent() != null) {
+                Files.createDirectories(path.getParent());
+            }
+            JSON.writeValue(path.toFile(), state);
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not save mobile session state to `" + path + "`.", e);
+        }
+    }
+
+    private static Capabilities capabilities(WebDriver driver) {
+        if (driver instanceof RemoteWebDriver remoteWebDriver) {
+            try {
+                return remoteWebDriver.getCapabilities();
+            } catch (RuntimeException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static String capability(Capabilities capabilities, String key) {
+        if (capabilities == null || key == null || key.isBlank()) {
+            return null;
+        }
+        Object value = capabilities.getCapability(key);
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private static String platformName(Capabilities capabilities) {
+        if (capabilities == null) {
+            return null;
+        }
+        Platform platform = capabilities.getPlatformName();
+        return platform == null ? null : platform.name();
+    }
+
+    private static String context(WebDriver driver) {
+        if (driver instanceof SupportsContextSwitching contextDriver) {
+            try {
+                String context = contextDriver.getContext();
+                return (context == null || context.isBlank()) ? null : context;
+            } catch (RuntimeException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static String orientation(WebDriver driver) {
+        try {
+            if (driver instanceof AndroidDriver androidDriver) {
+                return String.valueOf(androidDriver.getOrientation());
+            }
+            if (driver instanceof IOSDriver iosDriver) {
+                return String.valueOf(iosDriver.getOrientation());
+            }
+        } catch (RuntimeException ignored) {
+            return null;
+        }
+        return null;
+    }
+
+    private static String windowSize(WebDriver driver) {
+        try {
+            Dimension size = driver.manage().window().getSize();
+            return size.getWidth() + "x" + size.getHeight();
+        } catch (RuntimeException ignored) {
+            return null;
+        }
+    }
+
+    private static String firstNonBlank(String... candidates) {
+        if (candidates == null) {
+            return null;
+        }
+        for (String candidate : candidates) {
+            if (candidate != null && !candidate.isBlank()) {
+                return candidate.trim();
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("java:S1104")
+    public static class SessionCapabilitiesState {
+        public String schemaVersion;
+        public String platformName;
+        public Map<String, Object> capabilities = new LinkedHashMap<>();
+    }
+
+    @SuppressWarnings("java:S1104")
+    public static class AppStateSnapshot {
+        public String schemaVersion;
+        public String appPackage;
+        public String appActivity;
+        public String bundleId;
+        public String context;
+        public String orientation;
+        public String windowSize;
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Paths.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Paths.java
@@ -90,6 +90,14 @@ public interface Paths extends EngineProperties<Paths> {
     @DefaultValue("target/auth-cache/")
     String authCache();
 
+    /**
+     * Folder that holds {@code TouchActions.saveSessionCapabilities}/{@code saveAppState} JSON
+     * snapshots used to reuse Appium session capabilities and mobile app state across test runs.
+     */
+    @Key("mobileSessionCacheFolderPath")
+    @DefaultValue("target/mobile-session-cache/")
+    String mobileSessionCache();
+
     default SetProperty set() {
         return new SetProperty();
     }
@@ -157,6 +165,11 @@ public interface Paths extends EngineProperties<Paths> {
 
         public SetProperty authCache(String value) {
             setProperty("authCacheFolderPath", value);
+            return this;
+        }
+
+        public SetProperty mobileSessionCache(String value) {
+            setProperty("mobileSessionCacheFolderPath", value);
             return this;
         }
 

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/MobileSessionStateManagerTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/MobileSessionStateManagerTest.java
@@ -1,0 +1,279 @@
+package com.shaft.gui.element.internal;
+
+import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.ios.IOSDriver;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.ScreenOrientation;
+import org.openqa.selenium.WebDriver;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MobileSessionStateManagerTest {
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    private Path stateFile;
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() throws Exception {
+        if (stateFile != null) {
+            Files.deleteIfExists(stateFile);
+        }
+    }
+
+    @Test
+    public void shouldRejectNullDriverForSaveMethods() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> MobileSessionStateManager.saveCapabilities(null, "target/state.json"));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> MobileSessionStateManager.saveAppState(null, "target/state.json"));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> MobileSessionStateManager.loadAppState(null, "target/state.json"));
+    }
+
+    @Test
+    public void shouldRejectBlankPathForSaveMethods() {
+        AndroidDriver driver = mock(AndroidDriver.class);
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> MobileSessionStateManager.saveCapabilities(driver, " "));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> MobileSessionStateManager.saveAppState(driver, null));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> MobileSessionStateManager.loadAppState(driver, ""));
+    }
+
+    @Test
+    public void shouldRejectBlankPathForLoadCapabilities() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> MobileSessionStateManager.loadCapabilities(" "));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> MobileSessionStateManager.loadCapabilities(null));
+    }
+
+    @Test
+    public void shouldRejectNonRemoteWebDriverForSaveCapabilities() {
+        WebDriver driver = mock(WebDriver.class);
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> MobileSessionStateManager.saveCapabilities(driver, "target/state.json"));
+    }
+
+    @Test
+    public void shouldSaveCapabilitiesToJsonFile() throws Exception {
+        AndroidDriver driver = mock(AndroidDriver.class);
+        MutableCapabilities capabilities = new MutableCapabilities();
+        capabilities.setCapability("platformName", "Android");
+        capabilities.setCapability("appium:automationName", "UiAutomator2");
+        capabilities.setCapability("appium:appPackage", "com.example.app");
+        when(driver.getCapabilities()).thenReturn(capabilities);
+
+        stateFile = Files.createTempFile("shaft-mobile-capabilities", ".json");
+        MobileSessionStateManager.saveCapabilities(driver, stateFile.toString());
+
+        MobileSessionStateManager.SessionCapabilitiesState state =
+                JSON.readValue(stateFile.toFile(), MobileSessionStateManager.SessionCapabilitiesState.class);
+
+        Assert.assertEquals(state.schemaVersion, "1.0");
+        // Selenium's MutableCapabilities canonicalizes "platformName" into the Platform enum's name.
+        Assert.assertEquals(state.platformName, "ANDROID");
+        Assert.assertEquals(state.capabilities.get("appium:automationName"), "UiAutomator2");
+        Assert.assertEquals(state.capabilities.get("appium:appPackage"), "com.example.app");
+    }
+
+    @Test
+    public void shouldLoadCapabilitiesRoundTrip() throws Exception {
+        stateFile = Files.createTempFile("shaft-mobile-capabilities-load", ".json");
+        Files.writeString(stateFile, """
+                {
+                  "schemaVersion" : "1.0",
+                  "platformName" : "Android",
+                  "capabilities" : {
+                    "platformName" : "Android",
+                    "appium:appPackage" : "com.example.app",
+                    "appium:noReset" : true,
+                    "appium:unused" : null
+                  }
+                }
+                """);
+
+        MutableCapabilities capabilities = MobileSessionStateManager.loadCapabilities(stateFile.toString());
+
+        // Selenium's MutableCapabilities canonicalizes "platformName" into a Platform enum value.
+        Assert.assertEquals(String.valueOf(capabilities.getCapability("platformName")), "ANDROID");
+        Assert.assertEquals(capabilities.getCapability("appium:appPackage"), "com.example.app");
+        Assert.assertEquals(capabilities.getCapability("appium:noReset"), true);
+        Assert.assertFalse(capabilities.getCapabilityNames().contains("appium:unused"));
+    }
+
+    @Test
+    public void shouldRaiseIllegalStateWhenLoadCapabilitiesFileMissing() {
+        Assert.assertThrows(IllegalStateException.class,
+                () -> MobileSessionStateManager.loadCapabilities("target/does-not-exist-" + System.nanoTime() + ".json"));
+    }
+
+    @Test
+    public void shouldSaveAppStateToJsonFile() throws Exception {
+        AndroidDriver driver = mock(AndroidDriver.class);
+        MutableCapabilities capabilities = new MutableCapabilities();
+        capabilities.setCapability("appium:appPackage", "com.example.app");
+        capabilities.setCapability("appium:appActivity", ".MainActivity");
+        when(driver.getCapabilities()).thenReturn(capabilities);
+        when(driver.getContext()).thenReturn("NATIVE_APP");
+        when(driver.getOrientation()).thenReturn(ScreenOrientation.PORTRAIT);
+        WebDriver.Options options = mock(WebDriver.Options.class);
+        WebDriver.Window window = mock(WebDriver.Window.class);
+        when(driver.manage()).thenReturn(options);
+        when(options.window()).thenReturn(window);
+        when(window.getSize()).thenReturn(new Dimension(1080, 1920));
+
+        stateFile = Files.createTempFile("shaft-mobile-app-state", ".json");
+        MobileSessionStateManager.saveAppState(driver, stateFile.toString());
+
+        MobileSessionStateManager.AppStateSnapshot state =
+                JSON.readValue(stateFile.toFile(), MobileSessionStateManager.AppStateSnapshot.class);
+
+        Assert.assertEquals(state.schemaVersion, "1.0");
+        Assert.assertEquals(state.appPackage, "com.example.app");
+        Assert.assertEquals(state.appActivity, ".MainActivity");
+        Assert.assertEquals(state.context, "NATIVE_APP");
+        Assert.assertEquals(state.orientation, "PORTRAIT");
+        Assert.assertEquals(state.windowSize, "1080x1920");
+    }
+
+    @Test
+    public void shouldRaiseIllegalStateWhenLoadAppStateFileMissing() {
+        AndroidDriver driver = mock(AndroidDriver.class);
+        Assert.assertThrows(IllegalStateException.class,
+                () -> MobileSessionStateManager.loadAppState(driver, "target/does-not-exist-" + System.nanoTime() + ".json"));
+    }
+
+    @Test
+    public void shouldRestoreAndroidAppStateFromJsonFile() throws Exception {
+        AndroidDriver driver = mock(AndroidDriver.class);
+        when(driver.getContext()).thenReturn("NATIVE_APP");
+
+        stateFile = Files.createTempFile("shaft-mobile-app-state-load", ".json");
+        Files.writeString(stateFile, """
+                {
+                  "schemaVersion" : "1.0",
+                  "appPackage" : "com.example.app",
+                  "appActivity" : ".MainActivity",
+                  "bundleId" : null,
+                  "context" : "WEBVIEW_1",
+                  "orientation" : "LANDSCAPE",
+                  "windowSize" : "1080x1920"
+                }
+                """);
+
+        MobileSessionStateManager.loadAppState(driver, stateFile.toString());
+
+        verify(driver).activateApp("com.example.app");
+        verify(driver).context("WEBVIEW_1");
+        verify(driver).rotate(ScreenOrientation.LANDSCAPE);
+    }
+
+    @Test
+    public void shouldSkipContextSwitchWhenSnapshotContextMatchesCurrentContext() throws Exception {
+        AndroidDriver driver = mock(AndroidDriver.class);
+        when(driver.getContext()).thenReturn("NATIVE_APP");
+
+        stateFile = Files.createTempFile("shaft-mobile-app-state-same-context", ".json");
+        Files.writeString(stateFile, """
+                {
+                  "schemaVersion" : "1.0",
+                  "appPackage" : null,
+                  "appActivity" : null,
+                  "bundleId" : null,
+                  "context" : "NATIVE_APP",
+                  "orientation" : null,
+                  "windowSize" : null
+                }
+                """);
+
+        MobileSessionStateManager.loadAppState(driver, stateFile.toString());
+
+        verify(driver, never()).context(org.mockito.ArgumentMatchers.anyString());
+        verify(driver, never()).activateApp(org.mockito.ArgumentMatchers.anyString());
+        verify(driver, never()).rotate(org.mockito.ArgumentMatchers.any(ScreenOrientation.class));
+    }
+
+    @Test
+    public void shouldSkipMissingFieldsWithoutThrowing() throws Exception {
+        AndroidDriver driver = mock(AndroidDriver.class);
+        when(driver.getContext()).thenReturn("NATIVE_APP");
+
+        stateFile = Files.createTempFile("shaft-mobile-app-state-empty", ".json");
+        Files.writeString(stateFile, """
+                {
+                  "schemaVersion" : "1.0",
+                  "appPackage" : null,
+                  "appActivity" : null,
+                  "bundleId" : null,
+                  "context" : null,
+                  "orientation" : null,
+                  "windowSize" : null
+                }
+                """);
+
+        MobileSessionStateManager.loadAppState(driver, stateFile.toString());
+
+        verify(driver, never()).activateApp(org.mockito.ArgumentMatchers.anyString());
+        verify(driver, never()).context(org.mockito.ArgumentMatchers.anyString());
+        verify(driver, never()).rotate(org.mockito.ArgumentMatchers.any(ScreenOrientation.class));
+    }
+
+    @Test
+    public void shouldRestoreIosAppStateUsingBundleId() throws Exception {
+        IOSDriver driver = mock(IOSDriver.class);
+        when(driver.getContext()).thenReturn("NATIVE_APP");
+
+        stateFile = Files.createTempFile("shaft-mobile-app-state-ios", ".json");
+        Files.writeString(stateFile, """
+                {
+                  "schemaVersion" : "1.0",
+                  "appPackage" : null,
+                  "appActivity" : null,
+                  "bundleId" : "com.example.iosApp",
+                  "context" : "NATIVE_APP",
+                  "orientation" : "PORTRAIT",
+                  "windowSize" : "750x1334"
+                }
+                """);
+
+        MobileSessionStateManager.loadAppState(driver, stateFile.toString());
+
+        verify(driver).activateApp("com.example.iosApp");
+        verify(driver).rotate(ScreenOrientation.PORTRAIT);
+        verify(driver, never()).context(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    public void shouldSkipRestoreStepsWhenUnsupportedByDriver() throws Exception {
+        WebDriver driver = mock(WebDriver.class);
+
+        stateFile = Files.createTempFile("shaft-mobile-app-state-unsupported", ".json");
+        Files.writeString(stateFile, """
+                {
+                  "schemaVersion" : "1.0",
+                  "appPackage" : "com.example.app",
+                  "appActivity" : null,
+                  "bundleId" : null,
+                  "context" : "WEBVIEW_1",
+                  "orientation" : "PORTRAIT",
+                  "windowSize" : null
+                }
+                """);
+
+        MobileSessionStateManager.loadAppState(driver, stateFile.toString());
+        // No interfaces implemented by the plain WebDriver mock, so every restore step must be skipped silently.
+    }
+}

--- a/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
@@ -11,6 +11,7 @@ import io.appium.java_client.ios.IOSDriver;
 import org.mockito.ArgumentCaptor;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
+import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.ScreenOrientation;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
@@ -514,6 +515,35 @@ public class AndroidTouchActionsCoverageUnitTest {
 
         verify(driver, times(3)).executeScript(eq("mobile: scrollGesture"), anyMap());
         verify(driver, never()).findElements(isNull());
+    }
+
+    @Test
+    public void sessionStateApisShouldDelegateToMobileSessionStateManager() throws Exception {
+        AndroidDriver driver = createMockAndroidDriver();
+        MutableCapabilities capabilities = new MutableCapabilities();
+        capabilities.setCapability("platformName", "Android");
+        capabilities.setCapability("appium:appPackage", "com.example.app");
+        when(driver.getCapabilities()).thenReturn(capabilities);
+        when(driver.getContext()).thenReturn("NATIVE_APP");
+
+        Path capabilitiesFile = TEMP_DIR.resolve("touchActions-session-capabilities.json");
+        Path appStateFile = TEMP_DIR.resolve("touchActions-app-state.json");
+
+        TouchActions touchActions = new TouchActions(driver);
+        touchActions.saveSessionCapabilities(capabilitiesFile.toString())
+                .saveAppState(appStateFile.toString());
+
+        SHAFT.Validations.assertThat().object(Files.exists(capabilitiesFile)).isTrue().perform();
+        SHAFT.Validations.assertThat().object(Files.exists(appStateFile)).isTrue().perform();
+
+        MutableCapabilities loadedCapabilities = TouchActions.loadSessionCapabilities(capabilitiesFile.toString());
+        SHAFT.Validations.assertThat().object(loadedCapabilities.getCapability("appium:appPackage")).isEqualTo("com.example.app").perform();
+
+        touchActions.loadAppState(appStateFile.toString());
+        verify(driver).activateApp("com.example.app");
+
+        Files.deleteIfExists(capabilitiesFile);
+        Files.deleteIfExists(appStateFile);
     }
 
     private AndroidDriver createMockAndroidDriver() {

--- a/shaft-engine/src/test/java/testPackage/unitTests/MobileSessionCacheFolderPathSetPropertyUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/MobileSessionCacheFolderPathSetPropertyUnitTest.java
@@ -1,0 +1,33 @@
+package testPackage.unitTests;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.properties.internal.Paths;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Coverage: {@code SHAFT.Properties.paths.mobileSessionCache()} default value and fluent override.
+ */
+@Test(singleThreaded = true)
+public class MobileSessionCacheFolderPathSetPropertyUnitTest {
+    private final String originalMobileSessionCache = SHAFT.Properties.paths.mobileSessionCache();
+
+    @AfterMethod(alwaysRun = true)
+    public void afterMethod() {
+        SHAFT.Properties.paths.set().mobileSessionCache(originalMobileSessionCache);
+    }
+
+    @Test(description = "Coverage: mobileSessionCache defaults to target/mobile-session-cache/ unless explicitly configured")
+    public void mobileSessionCacheShouldDefaultToTargetFolder() {
+        SHAFT.Properties.paths.set().mobileSessionCache("target/mobile-session-cache/");
+        Assert.assertEquals(SHAFT.Properties.paths.mobileSessionCache(), "target/mobile-session-cache/");
+    }
+
+    @Test(description = "Coverage: mobileSessionCache fluent setter updates the effective value and returns the same builder")
+    public void mobileSessionCacheFluentSetterShouldUpdateEffectiveValue() {
+        Paths.SetProperty setProperty = SHAFT.Properties.paths.set();
+        Assert.assertSame(setProperty.mobileSessionCache("target/custom-mobile-cache/"), setProperty);
+        Assert.assertEquals(SHAFT.Properties.paths.mobileSessionCache(), "target/custom-mobile-cache/");
+    }
+}


### PR DESCRIPTION
## Summary
Adds mobile session-state persistence mirroring the #3350 browser storage-state precedent 1:1 (closes #3457):

- New `MobileSessionStateManager` (internal, sibling of the mobile action helpers): Jackson 3 JSON persistence with `schemaVersion`, two DTOs — `SessionCapabilitiesState` (full `Capabilities.asMap()`) and `AppStateSnapshot` (active app package/activity/bundleId, Appium context, orientation, window size — captured with the proven `MobileTraceMetadata` patterns).
- API surface on `driver.touch()` (the de-facto mobile facade; no mobile facade class exists by design): `saveSessionCapabilities(path)`, `saveAppState(path)`, `loadAppState(path)` (fluent, pass/fail-reported like `sendAppToBackground`), plus static `TouchActions.loadSessionCapabilities(path)` returning `MutableCapabilities` for the existing `DriverFactory.getHelper(driverType, caps)` seam — static because capabilities are needed before a session exists.
- `loadAppState` restore is deliberately best-effort: re-activate app / switch context / rotate only when the provider supports it, skip silently otherwise.
- New `SHAFT.Properties.paths.mobileSessionCache()` (`target/mobile-session-cache/` default) mirroring `authCache`.
- Driver-init auto-load and emulator-gated E2E deliberately deferred per the issue's phasing.

## Verification
40/40 tests green (surefire XML): 14 new `MobileSessionStateManagerTest` (arg validation, round-trips, missing-file, Android + iOS branches, skip-when-unsupported), 2 new property setter tests, extended `AndroidTouchActionsCoverageUnitTest` (17), and `BrowserStorageStateManagerTest` (7) as an unaffected regression check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)