### PR TITLE
feat: IntelliJ SHAFT Tests tree, gutter run/debug, and bounded watch mode (#3467)

### DIFF
--- a/shaft-intellij/build.gradle.kts
+++ b/shaft-intellij/build.gradle.kts
@@ -19,6 +19,10 @@ dependencies {
     intellijPlatform {
         intellijIdea(providers.gradleProperty("platformVersion").get())
         bundledPlugin("com.intellij.java")
+        // JUnitConfiguration/TestNGConfiguration classes live in these separate bundled plugins
+        // (see io.github.shafthq.shaft-withJUnit.xml / shaft-withTestNG.xml), not in com.intellij.java.
+        bundledPlugin("JUnit")
+        bundledPlugin("TestNG-J")
     }
     implementation("com.google.code.gson:gson:2.14.0")
     testImplementation("org.junit.jupiter:junit-jupiter:6.1.0")

--- a/shaft-intellij/src/main/java/com/shaft/intellij/notifications/FailedRunDoctorNotifier.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/notifications/FailedRunDoctorNotifier.java
@@ -11,11 +11,6 @@ import com.intellij.notification.NotificationGroupManager;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.wm.ToolWindow;
-import com.intellij.openapi.wm.ToolWindowManager;
-import com.intellij.ui.content.Content;
-import com.shaft.intellij.settings.ShaftSettingsState;
-import com.shaft.intellij.ui.ShaftToolWindowPanel;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -114,35 +109,21 @@ public final class FailedRunDoctorNotifier implements ExecutionListener {
     }
 
     private static void openDoctorWorkflow(Project project) {
-        openToolWorkflow(project, "doctor_analyze_failed_allure", doctorArguments());
+        ShaftToolWorkflowLauncher.open(project, "doctor_analyze_failed_allure", doctorArguments());
     }
 
     private static void openHealerWorkflow(Project project) {
-        openToolWorkflow(project, "healer_run_failed_test", healerArguments());
+        ShaftToolWorkflowLauncher.open(project, "healer_run_failed_test", healerArguments());
     }
 
-    private static void openToolWorkflow(Project project, String toolName, JsonObject arguments) {
-        if (!ShaftSettingsState.getInstance().getState().advancedUiEnabled) {
-            ShaftNotifier.warn(project, "SHAFT",
-                    "Ask the SHAFT Assistant to \"diagnose my last failed test run\" to analyze the "
-                            + "failure from chat.");
-            return;
-        }
-        ToolWindowManager.getInstance(project).invokeLater(() -> {
-            ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("SHAFT");
-            if (toolWindow == null) {
-                return;
-            }
-            toolWindow.show(() -> {
-                Content content = toolWindow.getContentManager().getContent(0);
-                if (content != null && content.getComponent() instanceof ShaftToolWindowPanel panel) {
-                    panel.prefillTool(toolName, arguments);
-                }
-            });
-        });
-    }
-
-    static JsonObject doctorArguments() {
+    /**
+     * Builds the {@code doctor_analyze_failed_allure} MCP arguments for the last failed run. Public
+     * so {@code ShaftTestsPanel} (issue #3467 "SHAFT Tests" tab) can reuse the same one-click
+     * Doctor prefill this notifier offers.
+     *
+     * @return MCP tool arguments
+     */
+    public static JsonObject doctorArguments() {
         JsonObject arguments = new JsonObject();
         JsonArray allurePaths = new JsonArray();
         allurePaths.add("allure-results");
@@ -161,7 +142,13 @@ public final class FailedRunDoctorNotifier implements ExecutionListener {
         return arguments;
     }
 
-    static JsonObject healerArguments() {
+    /**
+     * Builds the {@code healer_run_failed_test} MCP arguments for the last failed run. Public for
+     * the same reason as {@link #doctorArguments()}.
+     *
+     * @return MCP tool arguments
+     */
+    public static JsonObject healerArguments() {
         JsonObject arguments = new JsonObject();
         JsonArray testCommand = new JsonArray();
         testCommand.add("mvn");

--- a/shaft-intellij/src/main/java/com/shaft/intellij/notifications/ShaftToolWorkflowLauncher.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/notifications/ShaftToolWorkflowLauncher.java
@@ -1,0 +1,51 @@
+package com.shaft.intellij.notifications;
+
+import com.google.gson.JsonObject;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.ui.content.Content;
+import com.shaft.intellij.settings.ShaftSettingsState;
+import com.shaft.intellij.ui.ShaftToolWindowPanel;
+
+/**
+ * Opens the SHAFT tool window and pre-fills an MCP tool request, or -- while advanced workflows
+ * are off (the default) -- points the user at the Assistant instead of silently claiming a panel
+ * opened. Shared by {@link FailedRunDoctorNotifier} and the "SHAFT Tests" tool-window tab
+ * (issue #3467), both of which trigger the same Doctor/Healer prefill flow from different UI
+ * surfaces.
+ */
+public final class ShaftToolWorkflowLauncher {
+    private ShaftToolWorkflowLauncher() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Opens the SHAFT tool window and pre-fills {@code toolName} with {@code arguments}, or warns
+     * and no-ops when advanced workflows are disabled.
+     *
+     * @param project current project
+     * @param toolName MCP tool name to pre-fill
+     * @param arguments MCP tool arguments
+     */
+    public static void open(Project project, String toolName, JsonObject arguments) {
+        if (!ShaftSettingsState.getInstance().getState().advancedUiEnabled) {
+            ShaftNotifier.warn(project, "SHAFT",
+                    "Ask the SHAFT Assistant to \"diagnose my last failed test run\" to analyze the "
+                            + "failure from chat.");
+            return;
+        }
+        ToolWindowManager.getInstance(project).invokeLater(() -> {
+            ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("SHAFT");
+            if (toolWindow == null) {
+                return;
+            }
+            toolWindow.show(() -> {
+                Content content = toolWindow.getContentManager().getContent(0);
+                if (content != null && content.getComponent() instanceof ShaftToolWindowPanel panel) {
+                    panel.prefillTool(toolName, arguments);
+                }
+            });
+        });
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
@@ -86,6 +86,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
     private JBTextField pilotAiModel;
     private JBCheckBox passProviderKeys;
     private JBCheckBox advancedUiEnabled;
+    private JBCheckBox watchModeEnabled;
     private JPasswordField openAiKey;
     private JPasswordField anthropicKey;
     private JPasswordField geminiKey;
@@ -208,6 +209,11 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         advancedUiEnabled.getAccessibleContext().setAccessibleDescription(
                 "Shows guided workflows, direct tool panels, cloud provider controls, and provider key forwarding.");
         advancedUiEnabled.addActionListener(event -> updateAgentConfigurationControls());
+        watchModeEnabled = new JBCheckBox("Enable watch mode (rerun the last test on source save)");
+        watchModeEnabled.getAccessibleContext().setAccessibleName("Enable SHAFT watch mode");
+        watchModeEnabled.getAccessibleContext().setAccessibleDescription(
+                "Reruns the last SHAFT test run configuration when a src/test/ file changes, "
+                        + "throttled to at most 6 reruns per rolling 5-minute window.");
         pilotAiProvider = new JComboBox<>(model("none", "openai", "anthropic", "gemini", "github", "ollama"));
         ShaftUiLabels.applyFriendlyRenderer(pilotAiProvider);
         pilotAiProvider.getAccessibleContext().setAccessibleName("SHAFT AI provider");
@@ -279,6 +285,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
                 .addLabeledComponent(defaultModeLabel, defaultMode)
                 .addComponent(advancedUiEnabled)
                 .addComponent(help("The Assistant tab is always available. Agent mode still requires explicit source mutation approval per request."))
+                .addComponent(watchModeEnabled)
                 .addComponent(shaftAiSection)
                 .addLabeledComponent(shaftAiProviderLabel, pilotAiProvider)
                 .addLabeledComponent(shaftAiModelLabel, pilotAiModel)
@@ -310,6 +317,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         String stateProviderType = state.advancedUiEnabled ? normalize(state.assistantProviderType, "LOCAL") : "LOCAL";
         return !Objects.equals(state.mcpCommand, mcpCommand.getText())
                 || state.advancedUiEnabled != advancedSelected
+                || state.watchModeEnabled != watchModeEnabled.isSelected()
                 || !Objects.equals(stateProviderType, selectedProviderType)
                 || !Objects.equals(resolveFamily(state), assistantFamily.getSelectedItem())
                 || !Objects.equals(normalize(state.assistantRuntime, "CLI"), assistantRuntime.getSelectedItem())
@@ -340,6 +348,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         }
         state.mcpCommand = command;
         state.advancedUiEnabled = advancedUiEnabled.isSelected();
+        state.watchModeEnabled = watchModeEnabled.isSelected();
         state.assistantProviderType = state.advancedUiEnabled
                 ? String.valueOf(assistantProviderType.getSelectedItem())
                 : "LOCAL";
@@ -372,6 +381,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         ShaftSettingsState.Settings state = settingsProvider.get();
         mcpCommand.setText(state.mcpCommand);
         advancedUiEnabled.setSelected(state.advancedUiEnabled);
+        watchModeEnabled.setSelected(state.watchModeEnabled);
         assistantProviderType.setSelectedItem(normalize(state.assistantProviderType, "LOCAL"));
         assistantFamily.setSelectedItem(resolveFamily(state));
         assistantRuntime.setSelectedItem(normalize(state.assistantRuntime, "CLI"));
@@ -422,6 +432,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         pilotAiModel = null;
         passProviderKeys = null;
         advancedUiEnabled = null;
+        watchModeEnabled = null;
         defaultModeLabel = null;
         shaftAiSection = null;
         shaftAiProviderLabel = null;

--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsState.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsState.java
@@ -74,6 +74,12 @@ public final class ShaftSettingsState implements PersistentStateComponent<ShaftS
         public boolean advancedUiEnabled = false;
         public boolean autoCompactEnabled = false;
         /**
+         * Opt-in, default-off "watch mode": reruns the last SHAFT test run configuration when a
+         * {@code src/test/} file changes, bounded by {@code WatchRerunThrottle} (see
+         * {@code ShaftTestWatchService}).
+         */
+        public boolean watchModeEnabled = false;
+        /**
          * Recorder browser visibility preference shared by the Guided workflow panel and the
          * assistant web/mobile recording flows.
          */

--- a/shaft-intellij/src/main/java/com/shaft/intellij/testindex/ShaftTestIndex.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/testindex/ShaftTestIndex.java
@@ -1,0 +1,86 @@
+package com.shaft.intellij.testindex;
+
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Project-level index of recent SHAFT test run results, backing the "SHAFT Tests" tool-window
+ * tab ({@code ShaftTestsPanel}).
+ * <p>
+ * <b>Granularity (v1):</b> one row per run-configuration name, not per {@code @Test} method.
+ * Populated from {@link ShaftTestIndexListener#processTerminated}, which only sees the run
+ * profile's name and exit code -- parsing the per-test SM Test Runner protocol tree
+ * ({@code SMTestProxy}) to get per-method rows would pull in platform test-framework UI
+ * dependencies this lightweight plugin module intentionally avoids. A future iteration could add
+ * per-method rows without changing this class's public shape.
+ */
+public final class ShaftTestIndex {
+    /** Pass-fail status of the most recent run recorded for a test id. */
+    public enum Status { PASS, FAIL }
+
+    /**
+     * One recorded run-configuration result.
+     *
+     * @param testId run-configuration display name (v1 granularity; see class javadoc)
+     * @param status {@link Status#PASS} when {@code lastExitCode == 0}, otherwise {@link Status#FAIL}
+     * @param lastRunAtMillis epoch millis the run terminated
+     * @param lastExitCode raw process exit code
+     */
+    public record TestRowState(String testId, Status status, long lastRunAtMillis, int lastExitCode) {
+    }
+
+    private final Map<String, TestRowState> rowsByTestId = new ConcurrentHashMap<>();
+
+    /**
+     * Returns the project-level test index.
+     *
+     * @param project the project to scope the index to, or {@code null} for a fresh, unpersisted
+     *                instance
+     * @return test index service
+     */
+    public static ShaftTestIndex getInstance(@Nullable Project project) {
+        if (project == null) {
+            return new ShaftTestIndex();
+        }
+        ShaftTestIndex index = project.getService(ShaftTestIndex.class);
+        return index == null ? new ShaftTestIndex() : index;
+    }
+
+    /**
+     * Records (or overwrites) the most recent result for a test id.
+     *
+     * @param testId run-configuration display name; blank/{@code null} ids are ignored
+     * @param exitCode raw process exit code ({@code 0} is treated as pass)
+     * @param timestampMillis epoch millis the run terminated
+     */
+    public void recordRun(@Nullable String testId, int exitCode, long timestampMillis) {
+        if (testId == null || testId.isBlank()) {
+            return;
+        }
+        Status status = exitCode == 0 ? Status.PASS : Status.FAIL;
+        rowsByTestId.put(testId, new TestRowState(testId, status, timestampMillis, exitCode));
+    }
+
+    /**
+     * Returns all recorded rows, most recently run first.
+     *
+     * @return an immutable, time-ordered snapshot
+     */
+    public List<TestRowState> snapshot() {
+        return rowsByTestId.values().stream()
+                .sorted(Comparator.comparingLong(TestRowState::lastRunAtMillis).reversed())
+                .toList();
+    }
+
+    /**
+     * Clears every recorded row.
+     */
+    public void clear() {
+        rowsByTestId.clear();
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/testindex/ShaftTestIndexListener.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/testindex/ShaftTestIndexListener.java
@@ -1,0 +1,55 @@
+package com.shaft.intellij.testindex;
+
+import com.intellij.execution.ExecutionListener;
+import com.intellij.execution.RunnerAndConfigurationSettings;
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Locale;
+
+/**
+ * Feeds {@link ShaftTestIndex} (pass/fail rows for the "SHAFT Tests" tool-window tab) and
+ * {@link ShaftTestWatchService} (the "last run configuration" watch-mode replays) from the same
+ * IDE execution events, mirroring {@code FailedRunDoctorNotifier}'s run-profile heuristic.
+ */
+public final class ShaftTestIndexListener implements ExecutionListener {
+    @Override
+    public void processStarted(@NotNull String executorId,
+                               @NotNull ExecutionEnvironment environment,
+                               @NotNull ProcessHandler handler) {
+        Project project = environment.getProject();
+        if (project.isDisposed() || !looksLikeTestRun(environment)) {
+            return;
+        }
+        RunnerAndConfigurationSettings settings = environment.getRunnerAndConfigurationSettings();
+        if (settings != null) {
+            // Also forces ShaftTestWatchService's lazy project-service instantiation (and with it,
+            // its VFS_CHANGES subscription) the first time any test runs in this project session --
+            // watch-mode reruns are meaningless before a "last run" exists anyway, so there is
+            // nothing to eagerly wire up any earlier than this.
+            ShaftTestWatchService.getInstance(project).recordLastRunSettings(settings);
+        }
+    }
+
+    @Override
+    public void processTerminated(@NotNull String executorId,
+                                  @NotNull ExecutionEnvironment environment,
+                                  @NotNull ProcessHandler handler,
+                                  int exitCode) {
+        Project project = environment.getProject();
+        if (project.isDisposed() || !looksLikeTestRun(environment)) {
+            return;
+        }
+        String profileName = environment.getRunProfile().getName();
+        ShaftTestIndex.getInstance(project).recordRun(profileName, exitCode, System.currentTimeMillis());
+    }
+
+    private static boolean looksLikeTestRun(ExecutionEnvironment environment) {
+        String profileName = environment.getRunProfile().getName();
+        String profileClass = environment.getRunProfile().getClass().getName().toLowerCase(Locale.ROOT);
+        String name = profileName == null ? "" : profileName.toLowerCase(Locale.ROOT);
+        return profileClass.contains("test") || name.contains("test") || name.contains("suite");
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/testindex/ShaftTestWatchService.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/testindex/ShaftTestWatchService.java
@@ -1,0 +1,159 @@
+package com.shaft.intellij.testindex;
+
+import com.intellij.execution.RunnerAndConfigurationSettings;
+import com.intellij.execution.executors.DefaultRunExecutor;
+import com.intellij.execution.runners.ExecutionUtil;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationGroupManager;
+import com.intellij.notification.NotificationType;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFileManager;
+import com.intellij.openapi.vfs.newvfs.BulkFileListener;
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
+import com.intellij.util.Alarm;
+import com.intellij.util.messages.MessageBusConnection;
+import com.shaft.intellij.settings.ShaftSettingsState;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Bounded, opt-in "watch mode": when {@link ShaftSettingsState.Settings#watchModeEnabled} is on,
+ * saving a file under {@code src/test/} debounces then reruns the last SHAFT test run
+ * configuration (captured by {@link ShaftTestIndexListener}).
+ * <p>
+ * Bounded scheduling (a 750ms debounce plus {@link WatchRerunThrottle}'s rolling-window cap)
+ * exists because unbounded Maven-fork reruns on rapid saves are a known repo risk on Windows: each
+ * rerun forks a fresh Surefire JVM, and an unthrottled save-triggered loop can pile up forked-JVM
+ * starts faster than they finish. Default OFF; the setting lives in {@code ShaftSettingsState}.
+ */
+public final class ShaftTestWatchService implements Disposable {
+    private static final long DEBOUNCE_MILLIS = 750L;
+    private static final String NOTIFICATION_GROUP_ID = "SHAFT Notifications";
+
+    private final Project project;
+    private final WatchRerunThrottle throttle;
+    private final Alarm debounceAlarm;
+    private volatile RunnerAndConfigurationSettings lastRunSettings;
+
+    public ShaftTestWatchService(@NotNull Project project) {
+        this(project, new WatchRerunThrottle());
+    }
+
+    ShaftTestWatchService(@NotNull Project project, @NotNull WatchRerunThrottle throttle) {
+        this.project = project;
+        this.throttle = throttle;
+        this.debounceAlarm = new Alarm(Alarm.ThreadToUse.POOLED_THREAD, this);
+        MessageBusConnection connection = project.getMessageBus().connect(this);
+        connection.subscribe(VirtualFileManager.VFS_CHANGES, new BulkFileListener() {
+            @Override
+            public void after(@NotNull List<? extends VFileEvent> events) {
+                onEvents(events);
+            }
+        });
+    }
+
+    /**
+     * Returns the project-level watch service.
+     *
+     * @param project the project to scope watch mode to
+     * @return watch service
+     */
+    public static ShaftTestWatchService getInstance(@NotNull Project project) {
+        return project.getService(ShaftTestWatchService.class);
+    }
+
+    /**
+     * Records the settings of the most recently started test run, so a later watch-mode trigger has
+     * something to replay. Called by {@link ShaftTestIndexListener}.
+     *
+     * @param settings the run configuration settings that were just started
+     */
+    void recordLastRunSettings(@NotNull RunnerAndConfigurationSettings settings) {
+        this.lastRunSettings = settings;
+    }
+
+    private void onEvents(List<? extends VFileEvent> events) {
+        if (project.isDisposed() || !isWatchModeEnabled()) {
+            return;
+        }
+        String basePath = project.getBasePath();
+        if (basePath == null) {
+            return;
+        }
+        boolean relevant = events.stream().anyMatch(event -> isTestSourceChange(event.getPath(), basePath));
+        if (!relevant) {
+            return;
+        }
+        debounceAlarm.cancelAllRequests();
+        debounceAlarm.addRequest(this::onDebounceFired, (int) DEBOUNCE_MILLIS);
+    }
+
+    private void onDebounceFired() {
+        if (project.isDisposed() || !isWatchModeEnabled()) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        if (throttle.tryAcquire(now)) {
+            rerunLastTest();
+        } else if (throttle.shouldNotifyThrottled(now)) {
+            notifyThrottled();
+        }
+    }
+
+    private void rerunLastTest() {
+        RunnerAndConfigurationSettings settings = lastRunSettings;
+        if (settings == null) {
+            // Nothing has run in this project session yet: no-op, per design (there is nothing
+            // meaningful to replay).
+            return;
+        }
+        ApplicationManager.getApplication().invokeLater(() -> {
+            if (!project.isDisposed()) {
+                ExecutionUtil.runConfiguration(settings, DefaultRunExecutor.getRunExecutorInstance());
+            }
+        });
+    }
+
+    private void notifyThrottled() {
+        Notification notification = NotificationGroupManager.getInstance()
+                .getNotificationGroup(NOTIFICATION_GROUP_ID)
+                .createNotification("SHAFT watch mode paused",
+                        "SHAFT watch mode paused — rerun limit reached", NotificationType.WARNING);
+        notification.notify(project);
+    }
+
+    private boolean isWatchModeEnabled() {
+        return ShaftSettingsState.getInstance().getState().watchModeEnabled;
+    }
+
+    /**
+     * Returns whether a changed file path is under a {@code src/test/} directory within the given
+     * project base path. Pure string logic (normalizes {@code \} to {@code /} for Windows paths),
+     * kept separate from the VFS glue above so it is directly unit testable.
+     *
+     * @param eventPath changed file's absolute path, or {@code null}
+     * @param projectBasePath project base path, or {@code null}
+     * @return {@code true} when the path is a test-source change within the project
+     */
+    static boolean isTestSourceChange(@Nullable String eventPath, @Nullable String projectBasePath) {
+        if (eventPath == null || projectBasePath == null) {
+            return false;
+        }
+        String normalizedEvent = eventPath.replace('\\', '/');
+        String normalizedBase = projectBasePath.replace('\\', '/');
+        if (!normalizedEvent.startsWith(normalizedBase)) {
+            return false;
+        }
+        return normalizedEvent.contains("/src/test/");
+    }
+
+    @Override
+    public void dispose() {
+        // debounceAlarm and the message bus connection are children of this Disposable and are
+        // cancelled/disconnected automatically.
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/testindex/WatchRerunThrottle.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/testindex/WatchRerunThrottle.java
@@ -1,0 +1,64 @@
+package com.shaft.intellij.testindex;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Pure, clock-free rerun throttle for SHAFT watch mode.
+ * <p>
+ * Bounded scheduling exists because unbounded reruns on rapid file saves are a known repo risk on
+ * Windows: each rerun forks a fresh Maven/Surefire JVM, and a save-triggered loop that isn't
+ * capped can pile up forked-JVM starts faster than they finish. This throttle caps watch-mode
+ * reruns to {@value #MAX_RERUNS_PER_WINDOW} within any rolling {@value #WINDOW_MILLIS}ms window.
+ */
+public final class WatchRerunThrottle {
+    static final int MAX_RERUNS_PER_WINDOW = 6;
+    static final long WINDOW_MILLIS = 5 * 60_000L;
+
+    private final Deque<Long> rerunTimestamps = new ArrayDeque<>();
+    private boolean throttledNotificationPending = false;
+
+    /**
+     * Attempts to acquire permission for a rerun at {@code nowMillis}. Records the timestamp and
+     * returns {@code true} when under the limit; returns {@code false} without recording anything
+     * when the rolling window already holds {@value #MAX_RERUNS_PER_WINDOW} reruns.
+     *
+     * @param nowMillis current time in epoch millis (caller-supplied so this stays clock-free)
+     * @return {@code true} when the rerun is allowed
+     */
+    public synchronized boolean tryAcquire(long nowMillis) {
+        evictExpired(nowMillis);
+        if (rerunTimestamps.size() >= MAX_RERUNS_PER_WINDOW) {
+            return false;
+        }
+        rerunTimestamps.addLast(nowMillis);
+        // Back under the limit: the next time we get throttled deserves a fresh notification.
+        throttledNotificationPending = true;
+        return true;
+    }
+
+    /**
+     * Returns whether the "rerun limit reached" notification should be shown right now. Only the
+     * first call after entering a throttled state returns {@code true}; subsequent calls while
+     * still throttled return {@code false} so watch mode does not spam a notification per keystroke.
+     * The next successful {@link #tryAcquire} call re-arms this. Callers should only consult this
+     * after a {@link #tryAcquire} call has just returned {@code false}.
+     *
+     * @param nowMillis current time in epoch millis
+     * @return {@code true} at most once per throttled window
+     */
+    public synchronized boolean shouldNotifyThrottled(long nowMillis) {
+        evictExpired(nowMillis);
+        if (rerunTimestamps.size() < MAX_RERUNS_PER_WINDOW || !throttledNotificationPending) {
+            return false;
+        }
+        throttledNotificationPending = false;
+        return true;
+    }
+
+    private void evictExpired(long nowMillis) {
+        while (!rerunTimestamps.isEmpty() && nowMillis - rerunTimestamps.peekFirst() >= WINDOW_MILLIS) {
+            rerunTimestamps.pollFirst();
+        }
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/testrunner/ShaftJUnitRunConfigurationProducer.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/testrunner/ShaftJUnitRunConfigurationProducer.java
@@ -1,0 +1,87 @@
+package com.shaft.intellij.testrunner;
+
+import com.intellij.execution.PsiLocation;
+import com.intellij.execution.actions.ConfigurationContext;
+import com.intellij.execution.actions.RunConfigurationProducer;
+import com.intellij.execution.junit.JUnitConfiguration;
+import com.intellij.execution.junit.JUnitConfigurationType;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.util.Ref;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.shaft.intellij.project.ShaftProjectDetector;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Creates IntelliJ's own {@link JUnitConfiguration} from a SHAFT test method/class context, so
+ * the gutter run/debug icons ({@link ShaftTestLineMarkerContributor}) and "Run Context
+ * Configuration" actions work for SHAFT tests without a bespoke SHAFT run-configuration type.
+ * <p>
+ * Registered only when the bundled JUnit plugin is enabled (see
+ * {@code io.github.shafthq.shaft-withJUnit.xml}), since {@link JUnitConfiguration} classes live
+ * in that plugin, not in {@code com.intellij.java} itself.
+ */
+public final class ShaftJUnitRunConfigurationProducer extends RunConfigurationProducer<JUnitConfiguration> {
+    public ShaftJUnitRunConfigurationProducer() {
+        super(JUnitConfigurationType.getInstance().getFactory());
+    }
+
+    @Override
+    protected boolean setupConfigurationFromContext(@NotNull JUnitConfiguration configuration,
+                                                     @NotNull ConfigurationContext context,
+                                                     @NotNull Ref<PsiElement> sourceElement) {
+        if (!ShaftProjectDetector.isShaftProject(context.getProject())) {
+            return false;
+        }
+        PsiElement element = context.getPsiLocation();
+        PsiMethod method = PsiTreeUtil.getParentOfType(element, PsiMethod.class, false);
+        if (method != null && ShaftTestMethodAnnotations.isShaftRunnableTestMethod(annotationQualifiedNames(method))) {
+            Module module = configuration.getPersistentData().setTestMethod(PsiLocation.fromPsiElement(method));
+            if (module != null) {
+                configuration.setModule(module);
+            }
+            configuration.setName(configuration.suggestedName());
+            sourceElement.set(method);
+            return true;
+        }
+        PsiClass psiClass = PsiTreeUtil.getParentOfType(element, PsiClass.class, false);
+        if (psiClass != null && psiClass.getName() != null && hasRunnableMethod(psiClass)) {
+            configuration.beClassConfiguration(psiClass);
+            sourceElement.set(psiClass);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isConfigurationFromContext(@NotNull JUnitConfiguration configuration,
+                                              @NotNull ConfigurationContext context) {
+        PsiElement element = context.getPsiLocation();
+        return element != null && configuration.isConfiguredByElement(element);
+    }
+
+    private static boolean hasRunnableMethod(PsiClass psiClass) {
+        for (PsiMethod method : psiClass.getMethods()) {
+            if (ShaftTestMethodAnnotations.isShaftRunnableTestMethod(annotationQualifiedNames(method))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static List<String> annotationQualifiedNames(PsiMethod method) {
+        List<String> qualifiedNames = new ArrayList<>();
+        for (com.intellij.psi.PsiAnnotation annotation : method.getModifierList().getAnnotations()) {
+            String qualifiedName = annotation.getQualifiedName();
+            if (qualifiedName != null) {
+                qualifiedNames.add(qualifiedName);
+            }
+        }
+        return qualifiedNames;
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/testrunner/ShaftTestLineMarkerContributor.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/testrunner/ShaftTestLineMarkerContributor.java
@@ -1,0 +1,53 @@
+package com.shaft.intellij.testrunner;
+
+import com.intellij.execution.lineMarker.RunLineMarkerContributor;
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiAnnotation;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiIdentifier;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiModifierList;
+import com.shaft.intellij.project.ShaftProjectDetector;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Adds gutter run/debug icons on SHAFT test methods (TestNG or JUnit {@code @Test}) inside a
+ * SHAFT project. Decision logic lives in {@link ShaftTestMethodAnnotations} (plain strings, unit
+ * tested); this class is thin PSI glue: it resolves the method identifier under the caret,
+ * extracts annotation fully-qualified names, and gates on {@link ShaftProjectDetector} the same
+ * way {@code RecordShaftFlowHereAction} does.
+ */
+public final class ShaftTestLineMarkerContributor extends RunLineMarkerContributor {
+    @Override
+    public Info getInfo(PsiElement element) {
+        if (!(element instanceof PsiIdentifier) || !(element.getParent() instanceof PsiMethod method)) {
+            return null;
+        }
+        if (!element.equals(method.getNameIdentifier())) {
+            return null;
+        }
+        Project project = element.getProject();
+        if (!ShaftProjectDetector.isShaftProject(project)) {
+            return null;
+        }
+        if (!ShaftTestMethodAnnotations.isShaftRunnableTestMethod(annotationQualifiedNames(method))) {
+            return null;
+        }
+        return RunLineMarkerContributor.withExecutorActions(AllIcons.RunConfigurations.TestState.Run);
+    }
+
+    private static List<String> annotationQualifiedNames(PsiMethod method) {
+        PsiModifierList modifiers = method.getModifierList();
+        List<String> qualifiedNames = new ArrayList<>();
+        for (PsiAnnotation annotation : modifiers.getAnnotations()) {
+            String qualifiedName = annotation.getQualifiedName();
+            if (qualifiedName != null) {
+                qualifiedNames.add(qualifiedName);
+            }
+        }
+        return qualifiedNames;
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/testrunner/ShaftTestMethodAnnotations.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/testrunner/ShaftTestMethodAnnotations.java
@@ -1,0 +1,37 @@
+package com.shaft.intellij.testrunner;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * Pure predicate over annotation fully-qualified names deciding whether a Java method is a
+ * runnable SHAFT test entry point. Kept free of PSI/platform types so it is directly unit
+ * testable; {@link ShaftTestLineMarkerContributor} and the run-configuration producers extract
+ * plain annotation FQNs from PSI and hand them here.
+ */
+public final class ShaftTestMethodAnnotations {
+    public static final String TESTNG_TEST = "org.testng.annotations.Test";
+    public static final String JUNIT4_TEST = "org.junit.Test";
+    public static final String JUNIT5_TEST = "org.junit.jupiter.api.Test";
+
+    private static final Set<String> RUNNABLE_TEST_ANNOTATION_FQNS = Set.of(TESTNG_TEST, JUNIT4_TEST, JUNIT5_TEST);
+
+    private ShaftTestMethodAnnotations() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Returns whether a method carrying the given annotation fully-qualified names is a SHAFT
+     * runnable test method (TestNG {@code @Test}, JUnit 4 {@code @Test}, or JUnit 5 {@code @Test}).
+     *
+     * @param annotationQualifiedNames qualified names of the annotations present on the method, or
+     *                                 {@code null}
+     * @return {@code true} when at least one recognized test annotation is present
+     */
+    public static boolean isShaftRunnableTestMethod(Collection<String> annotationQualifiedNames) {
+        if (annotationQualifiedNames == null || annotationQualifiedNames.isEmpty()) {
+            return false;
+        }
+        return annotationQualifiedNames.stream().anyMatch(RUNNABLE_TEST_ANNOTATION_FQNS::contains);
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/testrunner/ShaftTestNgRunConfigurationProducer.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/testrunner/ShaftTestNgRunConfigurationProducer.java
@@ -1,0 +1,81 @@
+package com.shaft.intellij.testrunner;
+
+import com.intellij.execution.PsiLocation;
+import com.intellij.execution.actions.ConfigurationContext;
+import com.intellij.execution.actions.RunConfigurationProducer;
+import com.intellij.execution.configurations.ConfigurationFactory;
+import com.intellij.openapi.util.Ref;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.shaft.intellij.project.ShaftProjectDetector;
+import com.theoryinpractice.testng.configuration.TestNGConfiguration;
+import com.theoryinpractice.testng.configuration.TestNGConfigurationType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Creates IntelliJ's own {@link TestNGConfiguration} from a SHAFT test method/class context,
+ * mirroring {@link ShaftJUnitRunConfigurationProducer} for TestNG {@code @Test} methods.
+ * <p>
+ * Registered only when the bundled TestNG-J plugin is enabled (see
+ * {@code io.github.shafthq.shaft-withTestNG.xml}).
+ */
+public final class ShaftTestNgRunConfigurationProducer extends RunConfigurationProducer<TestNGConfiguration> {
+    public ShaftTestNgRunConfigurationProducer() {
+        super((ConfigurationFactory) TestNGConfigurationType.getInstance());
+    }
+
+    @Override
+    protected boolean setupConfigurationFromContext(@NotNull TestNGConfiguration configuration,
+                                                     @NotNull ConfigurationContext context,
+                                                     @NotNull Ref<PsiElement> sourceElement) {
+        if (!ShaftProjectDetector.isShaftProject(context.getProject())) {
+            return false;
+        }
+        PsiElement element = context.getPsiLocation();
+        PsiMethod method = PsiTreeUtil.getParentOfType(element, PsiMethod.class, false);
+        if (method != null && ShaftTestMethodAnnotations.isShaftRunnableTestMethod(annotationQualifiedNames(method))) {
+            configuration.setMethodConfiguration(PsiLocation.fromPsiElement(method));
+            sourceElement.set(method);
+            return true;
+        }
+        PsiClass psiClass = PsiTreeUtil.getParentOfType(element, PsiClass.class, false);
+        if (psiClass != null && psiClass.getName() != null && hasRunnableMethod(psiClass)) {
+            configuration.setClassConfiguration(psiClass);
+            sourceElement.set(psiClass);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isConfigurationFromContext(@NotNull TestNGConfiguration configuration,
+                                              @NotNull ConfigurationContext context) {
+        PsiElement element = context.getPsiLocation();
+        return element != null && configuration.isConfiguredByElement(element);
+    }
+
+    private static boolean hasRunnableMethod(PsiClass psiClass) {
+        for (PsiMethod method : psiClass.getMethods()) {
+            if (ShaftTestMethodAnnotations.isShaftRunnableTestMethod(annotationQualifiedNames(method))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static List<String> annotationQualifiedNames(PsiMethod method) {
+        List<String> qualifiedNames = new ArrayList<>();
+        for (com.intellij.psi.PsiAnnotation annotation : method.getModifierList().getAnnotations()) {
+            String qualifiedName = annotation.getQualifiedName();
+            if (qualifiedName != null) {
+                qualifiedNames.add(qualifiedName);
+            }
+        }
+        return qualifiedNames;
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftTestsPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftTestsPanel.java
@@ -1,0 +1,219 @@
+package com.shaft.intellij.ui;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.components.JBList;
+import com.intellij.ui.components.JBScrollPane;
+import com.intellij.util.ui.JBUI;
+import com.shaft.intellij.notifications.FailedRunDoctorNotifier;
+import com.shaft.intellij.notifications.ShaftToolWorkflowLauncher;
+import com.shaft.intellij.testindex.ShaftTestIndex;
+
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.DefaultListModel;
+import javax.swing.Icon;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.FlowLayout;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * "SHAFT Tests" tool-window tab: lists recent SHAFT test-run results from {@link ShaftTestIndex}
+ * (run-configuration granularity -- see that class's javadoc) with Refresh/Clear actions and, for
+ * a selected failed run, one-click "Diagnose with SHAFT Doctor" / "Heal failed test" buttons that
+ * reuse the same MCP prefill flow as {@code FailedRunDoctorNotifier}'s failed-run balloon.
+ */
+final class ShaftTestsPanel extends JPanel {
+    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss")
+            .withZone(ZoneId.systemDefault());
+
+    private final Project project;
+    private final ShaftTestIndex testIndex;
+    private final DefaultListModel<ShaftTestIndex.TestRowState> listModel = new DefaultListModel<>();
+    private final JBList<ShaftTestIndex.TestRowState> rowList = new JBList<>(listModel);
+    private final JButton refreshButton;
+    private final JButton clearButton;
+    private final JButton diagnoseButton;
+    private final JButton healButton;
+    private final JLabel statusLabel = new JLabel(" ");
+
+    ShaftTestsPanel(Project project) {
+        this(project, ShaftTestIndex.getInstance(project));
+    }
+
+    ShaftTestsPanel(Project project, ShaftTestIndex testIndex) {
+        super(new BorderLayout(8, 8));
+        this.project = project;
+        this.testIndex = testIndex;
+        setBorder(JBUI.Borders.empty(8));
+
+        refreshButton = button("Refresh", "Reload rows from the SHAFT test run index",
+                ShaftIcons.RERUN, this::refresh);
+        clearButton = button("Clear", "Clear all recorded SHAFT test-run rows",
+                ShaftIcons.CLEAR, this::clearRows);
+        JPanel toolbar = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
+        toolbar.add(refreshButton);
+        toolbar.add(clearButton);
+
+        rowList.getAccessibleContext().setAccessibleName("SHAFT test runs");
+        rowList.setCellRenderer(new DefaultListCellRenderer() {
+            @Override
+            public Component getListCellRendererComponent(JList<?> list, Object value, int index,
+                                                           boolean isSelected, boolean cellHasFocus) {
+                JLabel label = (JLabel) super.getListCellRendererComponent(
+                        list, value, index, isSelected, cellHasFocus);
+                if (value instanceof ShaftTestIndex.TestRowState row) {
+                    label.setText(formatRowLabel(row));
+                }
+                return label;
+            }
+        });
+        rowList.addListSelectionListener(event -> {
+            if (!event.getValueIsAdjusting()) {
+                onSelectionChanged();
+            }
+        });
+        JBScrollPane listScroll = new JBScrollPane(rowList);
+        listScroll.setPreferredSize(JBUI.size(400, 260));
+
+        diagnoseButton = button("Diagnose with SHAFT Doctor",
+                "Prefill a doctor_analyze_failed_allure request for the selected failed run.",
+                ShaftIcons.SEARCH, this::diagnoseSelected);
+        healButton = button("Heal failed test",
+                "Prefill a healer_run_failed_test request for the selected failed run.",
+                ShaftIcons.CHECK, this::healSelected);
+        diagnoseButton.setEnabled(false);
+        healButton.setEnabled(false);
+        JPanel actions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
+        actions.add(diagnoseButton);
+        actions.add(healButton);
+
+        statusLabel.getAccessibleContext().setAccessibleName("SHAFT test runs status");
+        statusLabel.setBorder(JBUI.Borders.emptyTop(4));
+        JPanel south = new JPanel(new BorderLayout(4, 4));
+        south.add(actions, BorderLayout.NORTH);
+        south.add(statusLabel, BorderLayout.SOUTH);
+
+        add(toolbar, BorderLayout.NORTH);
+        add(listScroll, BorderLayout.CENTER);
+        add(south, BorderLayout.SOUTH);
+
+        refresh();
+    }
+
+    private void refresh() {
+        listModel.clear();
+        List<ShaftTestIndex.TestRowState> rows = testIndex.snapshot();
+        rows.forEach(listModel::addElement);
+        statusLabel.setText(rows.isEmpty()
+                ? "No test runs recorded yet. Run a SHAFT test to populate this tab."
+                : rows.size() + " test run(s) recorded.");
+        onSelectionChanged();
+    }
+
+    private void clearRows() {
+        testIndex.clear();
+        refresh();
+    }
+
+    private void onSelectionChanged() {
+        boolean failed = isFailRow(rowList.getSelectedValue());
+        diagnoseButton.setEnabled(failed);
+        healButton.setEnabled(failed);
+    }
+
+    private void diagnoseSelected() {
+        if (!isFailRow(rowList.getSelectedValue())) {
+            return;
+        }
+        ShaftToolWorkflowLauncher.open(project, "doctor_analyze_failed_allure",
+                FailedRunDoctorNotifier.doctorArguments());
+    }
+
+    private void healSelected() {
+        if (!isFailRow(rowList.getSelectedValue())) {
+            return;
+        }
+        ShaftToolWorkflowLauncher.open(project, "healer_run_failed_test",
+                FailedRunDoctorNotifier.healerArguments());
+    }
+
+    // ------------------------------------------------------------------
+    // Pure row logic (unit tested)
+    // ------------------------------------------------------------------
+
+    /**
+     * Returns whether a row is a failed run whose Doctor/Heal actions should be enabled.
+     *
+     * @param row selected row, or {@code null} when nothing is selected
+     * @return {@code true} only for a non-null {@link ShaftTestIndex.Status#FAIL} row
+     */
+    static boolean isFailRow(ShaftTestIndex.TestRowState row) {
+        return row != null && row.status() == ShaftTestIndex.Status.FAIL;
+    }
+
+    /**
+     * Formats a row for display: status, test id, and last-run time.
+     *
+     * @param row row to format
+     * @return display label, for example {@code "FAIL  CheckoutTest  14:32:10"}
+     */
+    static String formatRowLabel(ShaftTestIndex.TestRowState row) {
+        String statusText = row.status() == ShaftTestIndex.Status.PASS ? "PASS" : "FAIL";
+        return statusText + "  " + row.testId() + "  " + formatTimestamp(row.lastRunAtMillis());
+    }
+
+    private static String formatTimestamp(long millis) {
+        if (millis <= 0) {
+            return "";
+        }
+        return TIME_FORMAT.format(Instant.ofEpochMilli(millis));
+    }
+
+    // ------------------------------------------------------------------
+    // Layout helpers (mirrors VisualBaselinesPanel's conventions)
+    // ------------------------------------------------------------------
+
+    private static JButton button(String text, String description, Icon icon, Runnable action) {
+        JButton buttonComponent = new JButton();
+        ShaftIconButtons.apply(buttonComponent, description, text, icon);
+        buttonComponent.getAccessibleContext().setAccessibleDescription(description);
+        buttonComponent.addActionListener(event -> action.run());
+        return buttonComponent;
+    }
+
+    // ------------------------------------------------------------------
+    // Test-only accessors
+    // ------------------------------------------------------------------
+
+    JComponent refreshButtonForTest() {
+        return refreshButton;
+    }
+
+    JComponent clearButtonForTest() {
+        return clearButton;
+    }
+
+    JBList<ShaftTestIndex.TestRowState> rowListForTest() {
+        return rowList;
+    }
+
+    JComponent diagnoseButtonForTest() {
+        return diagnoseButton;
+    }
+
+    JComponent healButtonForTest() {
+        return healButton;
+    }
+
+    JLabel statusLabelForTest() {
+        return statusLabel;
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
@@ -129,6 +129,7 @@ public final class ShaftToolWindowPanel extends JPanel {
             guidedWorkflowPanel = guided;
             views.add(new WorkflowView("Guided", guided, ShaftIcons.CODE));
             EvidenceTriagePanel triage = new EvidenceTriagePanel(project, this::prefillTool);
+            ShaftTestsPanel shaftTests = new ShaftTestsPanel(project);
             VisualBaselinesPanel visualBaselines = new VisualBaselinesPanel(project);
             ShaftFeaturePanel recorderTools = new ShaftFeaturePanel(project, settings,
                     List.of(new ToolCategory("Recorder", ToolTemplates.recorder())));
@@ -148,6 +149,7 @@ public final class ShaftToolWindowPanel extends JPanel {
             views.add(new WorkflowView("Recorder", recorderTools, ShaftIcons.VIEW));
             views.add(new WorkflowView("Inspector", inspectorTools, ShaftIcons.SEARCH));
             views.add(new WorkflowView("Triage", triage, ShaftIcons.CHECK));
+            views.add(new WorkflowView("SHAFT Tests", shaftTests, ShaftIcons.RERUN));
             views.add(new WorkflowView("Visual Baselines", visualBaselines, ShaftIcons.VIEW));
             views.add(new WorkflowView("Evidence", evidenceTools, ShaftIcons.EDIT));
             views.add(new WorkflowView("Projects", projectsTools, ShaftIcons.SETTINGS));

--- a/shaft-intellij/src/main/resources/META-INF/io.github.shafthq.shaft-withJUnit.xml
+++ b/shaft-intellij/src/main/resources/META-INF/io.github.shafthq.shaft-withJUnit.xml
@@ -1,0 +1,8 @@
+<!-- Optional JUnit-plugin integration: JUnitConfiguration and friends live in the separate bundled
+     "JUnit" plugin (not com.intellij.java), so this only loads when JUnit is enabled -- which
+     guarantees com.intellij.java is present too, since JUnit itself hard-depends on it. -->
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <runConfigurationProducer implementation="com.shaft.intellij.testrunner.ShaftJUnitRunConfigurationProducer"/>
+    </extensions>
+</idea-plugin>

--- a/shaft-intellij/src/main/resources/META-INF/io.github.shafthq.shaft-withJava.xml
+++ b/shaft-intellij/src/main/resources/META-INF/io.github.shafthq.shaft-withJava.xml
@@ -4,6 +4,12 @@
              generated test class (issue #3425 B3). -->
         <annotator language="JAVA"
                    implementationClass="com.shaft.intellij.java.CaptureReportAnnotator"/>
+        <!-- Only needs Java PSI (method annotations); the JUnit/TestNG run-configuration producers
+             that actually create run configurations live in their own optional-dependency files
+             below because JUnitConfiguration/TestNGConfiguration classes belong to the separate
+             bundled "JUnit" and "TestNG-J" plugins, not to com.intellij.java itself. -->
+        <runLineMarkerContributor language="JAVA"
+                   implementationClass="com.shaft.intellij.testrunner.ShaftTestLineMarkerContributor"/>
     </extensions>
     <actions>
         <action id="Shaft.RecordJavaTarget"

--- a/shaft-intellij/src/main/resources/META-INF/io.github.shafthq.shaft-withTestNG.xml
+++ b/shaft-intellij/src/main/resources/META-INF/io.github.shafthq.shaft-withTestNG.xml
@@ -1,0 +1,7 @@
+<!-- Optional TestNG-plugin integration: TestNGConfiguration lives in the bundled "TestNG-J"
+     plugin, so this only loads when it is enabled. -->
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <runConfigurationProducer implementation="com.shaft.intellij.testrunner.ShaftTestNgRunConfigurationProducer"/>
+    </extensions>
+</idea-plugin>

--- a/shaft-intellij/src/main/resources/META-INF/plugin.xml
+++ b/shaft-intellij/src/main/resources/META-INF/plugin.xml
@@ -6,6 +6,8 @@
     <depends>com.intellij.modules.platform</depends>
     <depends optional="true" config-file="io.github.shafthq.shaft-withJava.xml">com.intellij.java</depends>
     <depends optional="true" config-file="io.github.shafthq.shaft-withTerminal.xml">org.jetbrains.plugins.terminal</depends>
+    <depends optional="true" config-file="io.github.shafthq.shaft-withJUnit.xml">JUnit</depends>
+    <depends optional="true" config-file="io.github.shafthq.shaft-withTestNG.xml">TestNG-J</depends>
 
     <resource-bundle>messages.ShaftBundle</resource-bundle>
 
@@ -22,6 +24,8 @@
         <projectService serviceImplementation="com.shaft.intellij.mcp.ShaftMcpInvocationService"/>
         <projectService serviceImplementation="com.shaft.intellij.ui.ShaftAssistantChatState"/>
         <projectService serviceImplementation="com.shaft.intellij.approval.ToolApprovalService"/>
+        <projectService serviceImplementation="com.shaft.intellij.testindex.ShaftTestIndex"/>
+        <projectService serviceImplementation="com.shaft.intellij.testindex.ShaftTestWatchService"/>
         <applicationConfigurable instance="com.shaft.intellij.settings.ShaftSettingsConfigurable"
                                  id="shaft.settings"
                                  displayName="SHAFT"/>
@@ -30,6 +34,8 @@
 
     <projectListeners>
         <listener class="com.shaft.intellij.notifications.FailedRunDoctorNotifier"
+                  topic="com.intellij.execution.ExecutionListener"/>
+        <listener class="com.shaft.intellij.testindex.ShaftTestIndexListener"
                   topic="com.intellij.execution.ExecutionListener"/>
     </projectListeners>
 

--- a/shaft-intellij/src/test/java/com/shaft/intellij/testindex/ShaftTestIndexTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/testindex/ShaftTestIndexTest.java
@@ -1,0 +1,82 @@
+package com.shaft.intellij.testindex;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShaftTestIndexTest {
+    @Test
+    void recordRunMarksZeroExitCodeAsPass() {
+        ShaftTestIndex index = new ShaftTestIndex();
+        index.recordRun("SignInTest", 0, 1_000L);
+
+        List<ShaftTestIndex.TestRowState> rows = index.snapshot();
+        assertEquals(1, rows.size());
+        assertEquals(ShaftTestIndex.Status.PASS, rows.get(0).status());
+        assertEquals(0, rows.get(0).lastExitCode());
+    }
+
+    @Test
+    void recordRunMarksNonZeroExitCodeAsFail() {
+        ShaftTestIndex index = new ShaftTestIndex();
+        index.recordRun("CheckoutTest", 1, 1_000L);
+
+        List<ShaftTestIndex.TestRowState> rows = index.snapshot();
+        assertEquals(1, rows.size());
+        assertEquals(ShaftTestIndex.Status.FAIL, rows.get(0).status());
+    }
+
+    @Test
+    void recordRunOverwritesThePreviousResultForTheSameTestId() {
+        ShaftTestIndex index = new ShaftTestIndex();
+        index.recordRun("SearchTest", 1, 1_000L);
+        index.recordRun("SearchTest", 0, 2_000L);
+
+        List<ShaftTestIndex.TestRowState> rows = index.snapshot();
+        assertEquals(1, rows.size());
+        assertEquals(ShaftTestIndex.Status.PASS, rows.get(0).status());
+        assertEquals(2_000L, rows.get(0).lastRunAtMillis());
+    }
+
+    @Test
+    void snapshotOrdersMostRecentRunFirst() {
+        ShaftTestIndex index = new ShaftTestIndex();
+        index.recordRun("OldestTest", 0, 1_000L);
+        index.recordRun("NewestTest", 0, 3_000L);
+        index.recordRun("MiddleTest", 0, 2_000L);
+
+        List<ShaftTestIndex.TestRowState> rows = index.snapshot();
+        assertEquals(List.of("NewestTest", "MiddleTest", "OldestTest"),
+                rows.stream().map(ShaftTestIndex.TestRowState::testId).toList());
+    }
+
+    @Test
+    void clearRemovesAllRows() {
+        ShaftTestIndex index = new ShaftTestIndex();
+        index.recordRun("SignInTest", 0, 1_000L);
+        index.clear();
+
+        assertTrue(index.snapshot().isEmpty());
+    }
+
+    @Test
+    void recordRunIgnoresBlankOrNullTestId() {
+        ShaftTestIndex index = new ShaftTestIndex();
+        index.recordRun(null, 0, 1_000L);
+        index.recordRun("  ", 0, 1_000L);
+
+        assertTrue(index.snapshot().isEmpty());
+    }
+
+    @Test
+    void getInstanceReturnsAFreshInstanceForNullProject() {
+        ShaftTestIndex first = ShaftTestIndex.getInstance(null);
+        ShaftTestIndex second = ShaftTestIndex.getInstance(null);
+
+        first.recordRun("SignInTest", 0, 1_000L);
+        assertTrue(second.snapshot().isEmpty(), "null-project instances should not share state");
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/testindex/ShaftTestWatchServiceTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/testindex/ShaftTestWatchServiceTest.java
@@ -1,0 +1,47 @@
+package com.shaft.intellij.testindex;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShaftTestWatchServiceTest {
+    private static final String PROJECT_ROOT = "C:/dev/shop-tests";
+
+    @Test
+    void recognizesTestSourceFileUnderProject() {
+        assertTrue(ShaftTestWatchService.isTestSourceChange(
+                "C:/dev/shop-tests/src/test/java/SignInTest.java", PROJECT_ROOT));
+    }
+
+    @Test
+    void normalizesWindowsBackslashesBeforeMatching() {
+        assertTrue(ShaftTestWatchService.isTestSourceChange(
+                "C:\\dev\\shop-tests\\src\\test\\java\\SignInTest.java", "C:\\dev\\shop-tests"));
+    }
+
+    @Test
+    void ignoresMainSourceFiles() {
+        assertFalse(ShaftTestWatchService.isTestSourceChange(
+                "C:/dev/shop-tests/src/main/java/App.java", PROJECT_ROOT));
+    }
+
+    @Test
+    void ignoresFilesOutsideTheProject() {
+        assertFalse(ShaftTestWatchService.isTestSourceChange(
+                "C:/other/src/test/java/SignInTest.java", PROJECT_ROOT));
+    }
+
+    @Test
+    void returnsFalseForNullInputs() {
+        assertFalse(ShaftTestWatchService.isTestSourceChange(null, PROJECT_ROOT));
+        assertFalse(ShaftTestWatchService.isTestSourceChange(
+                "C:/dev/shop-tests/src/test/java/SignInTest.java", null));
+    }
+
+    @Test
+    void ignoresTargetOrBuildOutputEvenIfPathContainsTestSubstring() {
+        assertFalse(ShaftTestWatchService.isTestSourceChange(
+                "C:/dev/shop-tests/target/test-classes/SignInTest.class", PROJECT_ROOT));
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/testindex/WatchRerunThrottleTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/testindex/WatchRerunThrottleTest.java
@@ -1,0 +1,103 @@
+package com.shaft.intellij.testindex;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WatchRerunThrottleTest {
+    private static final long WINDOW_MILLIS = 5 * 60_000L;
+
+    @Test
+    void allowsRerunsUnderTheLimit() {
+        WatchRerunThrottle throttle = new WatchRerunThrottle();
+        long now = 0L;
+        for (int i = 0; i < 6; i++) {
+            assertTrue(throttle.tryAcquire(now + i), "rerun " + i + " should be allowed");
+        }
+    }
+
+    @Test
+    void deniesTheSeventhRerunWithinTheWindow() {
+        WatchRerunThrottle throttle = new WatchRerunThrottle();
+        long now = 0L;
+        for (int i = 0; i < 6; i++) {
+            assertTrue(throttle.tryAcquire(now + i));
+        }
+        assertFalse(throttle.tryAcquire(now + 6), "the 7th rerun within the window should be denied");
+    }
+
+    @Test
+    void allowsRerunsAgainAfterTheWindowExpires() {
+        WatchRerunThrottle throttle = new WatchRerunThrottle();
+        for (int i = 0; i < 6; i++) {
+            assertTrue(throttle.tryAcquire(i));
+        }
+        assertFalse(throttle.tryAcquire(6));
+
+        long afterWindow = WINDOW_MILLIS + 1;
+        assertTrue(throttle.tryAcquire(afterWindow), "a rerun after the window expires should be allowed");
+    }
+
+    @Test
+    void evictsOnlyExpiredTimestampsNotTheWholeWindow() {
+        WatchRerunThrottle throttle = new WatchRerunThrottle();
+        // An old batch of 3, then (after a large gap) a fresh batch of 3 -- 6 total, window full.
+        assertTrue(throttle.tryAcquire(0));
+        assertTrue(throttle.tryAcquire(1));
+        assertTrue(throttle.tryAcquire(2));
+        long freshBatchStart = WINDOW_MILLIS / 2;
+        assertTrue(throttle.tryAcquire(freshBatchStart));
+        assertTrue(throttle.tryAcquire(freshBatchStart + 1));
+        assertTrue(throttle.tryAcquire(freshBatchStart + 2));
+        assertFalse(throttle.tryAcquire(freshBatchStart + 3), "the window is already full");
+
+        // Once the old batch (0, 1, 2) has aged out but the fresh batch (with a huge remaining
+        // shelf life) has not, exactly 3 slots should free up, not the whole window.
+        long now = WINDOW_MILLIS + 3;
+        assertTrue(throttle.tryAcquire(now));
+        assertTrue(throttle.tryAcquire(now + 1));
+        assertTrue(throttle.tryAcquire(now + 2));
+        assertFalse(throttle.tryAcquire(now + 3), "only 3 slots should have freed up, not the whole window");
+    }
+
+    @Test
+    void notifiesOnceWhenThrottledThenStaysSilentUntilRearmed() {
+        WatchRerunThrottle throttle = new WatchRerunThrottle();
+        for (int i = 0; i < 6; i++) {
+            assertTrue(throttle.tryAcquire(i));
+        }
+        long throttledAt = 6L;
+        assertFalse(throttle.tryAcquire(throttledAt));
+        assertTrue(throttle.shouldNotifyThrottled(throttledAt), "first throttle hit should notify");
+        assertFalse(throttle.tryAcquire(throttledAt + 1));
+        assertFalse(throttle.shouldNotifyThrottled(throttledAt + 1), "repeated throttle hits should stay silent");
+    }
+
+    @Test
+    void rearmsNotificationAfterTheWindowOpensBackUp() {
+        WatchRerunThrottle throttle = new WatchRerunThrottle();
+        for (int i = 0; i < 6; i++) {
+            assertTrue(throttle.tryAcquire(i));
+        }
+        assertFalse(throttle.tryAcquire(6));
+        assertTrue(throttle.shouldNotifyThrottled(6));
+
+        long afterWindow = WINDOW_MILLIS + 10;
+        assertTrue(throttle.tryAcquire(afterWindow), "window has expired, so this rerun is allowed");
+
+        for (int i = 0; i < 5; i++) {
+            assertTrue(throttle.tryAcquire(afterWindow + 1 + i));
+        }
+        assertFalse(throttle.tryAcquire(afterWindow + 6));
+        assertTrue(throttle.shouldNotifyThrottled(afterWindow + 6),
+                "a fresh throttled window should notify again");
+    }
+
+    @Test
+    void doesNotNotifyWhileStillUnderTheLimit() {
+        WatchRerunThrottle throttle = new WatchRerunThrottle();
+        assertTrue(throttle.tryAcquire(0));
+        assertFalse(throttle.shouldNotifyThrottled(0));
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/testrunner/ShaftTestMethodAnnotationsTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/testrunner/ShaftTestMethodAnnotationsTest.java
@@ -1,0 +1,47 @@
+package com.shaft.intellij.testrunner;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShaftTestMethodAnnotationsTest {
+    @Test
+    void recognizesTestNgAnnotation() {
+        assertTrue(ShaftTestMethodAnnotations.isShaftRunnableTestMethod(
+                List.of("org.testng.annotations.Test")));
+    }
+
+    @Test
+    void recognizesJUnit4Annotation() {
+        assertTrue(ShaftTestMethodAnnotations.isShaftRunnableTestMethod(
+                List.of("org.junit.Test")));
+    }
+
+    @Test
+    void recognizesJUnit5Annotation() {
+        assertTrue(ShaftTestMethodAnnotations.isShaftRunnableTestMethod(
+                List.of("org.junit.jupiter.api.Test")));
+    }
+
+    @Test
+    void ignoresUnrelatedAnnotations() {
+        assertFalse(ShaftTestMethodAnnotations.isShaftRunnableTestMethod(
+                List.of("java.lang.Override", "javax.annotation.Nullable")));
+    }
+
+    @Test
+    void returnsFalseForEmptyOrNullCollections() {
+        assertFalse(ShaftTestMethodAnnotations.isShaftRunnableTestMethod(List.of()));
+        assertFalse(ShaftTestMethodAnnotations.isShaftRunnableTestMethod(null));
+    }
+
+    @Test
+    void recognizesTestAnnotationMixedWithOthers() {
+        assertTrue(ShaftTestMethodAnnotations.isShaftRunnableTestMethod(
+                Set.of("java.lang.Override", "org.junit.jupiter.api.Test")));
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -1247,8 +1247,8 @@ class ShaftPanelSetupTest {
             labels.add(selector.getItemAt(index).label());
         }
 
-        assertEquals(List.of("Assistant", "Guided", "Recorder", "Inspector", "Triage", "Visual Baselines",
-                "Evidence", "Projects", "Advanced"), labels);
+        assertEquals(List.of("Assistant", "Guided", "Recorder", "Inspector", "Triage", "SHAFT Tests",
+                "Visual Baselines", "Evidence", "Projects", "Advanced"), labels);
     }
 
     @Test

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
@@ -6,11 +6,13 @@ import com.intellij.ui.JBColor;
 import com.shaft.intellij.mcp.ShaftMcpToolResult;
 import com.shaft.intellij.settings.ShaftSettingsConfigurable;
 import com.shaft.intellij.settings.ShaftSettingsState;
+import com.shaft.intellij.testindex.ShaftTestIndex;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import javax.imageio.ImageIO;
 import javax.swing.AbstractButton;
+import javax.swing.DefaultListModel;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
@@ -125,6 +127,8 @@ class ShaftPluginScreenshotRendererTest {
         Path recorderScreenshot = outputPath.resolve("intellij-plugin-recorder.png");
         Path inspectorScreenshot = outputPath.resolve("intellij-plugin-inspector.png");
         Path triageScreenshot = outputPath.resolve("intellij-plugin-triage.png");
+        Path shaftTestsScreenshot = outputPath.resolve("intellij-plugin-shaft-tests.png");
+        Path shaftTestsDarkScreenshot = outputPath.resolve("intellij-plugin-shaft-tests-dark.png");
         Path visualBaselinesScreenshot = outputPath.resolve("intellij-plugin-visual-baselines.png");
         Path evidenceScreenshot = outputPath.resolve("intellij-plugin-evidence.png");
         Path projectsScreenshot = outputPath.resolve("intellij-plugin-projects.png");
@@ -152,11 +156,13 @@ class ShaftPluginScreenshotRendererTest {
         write(recorderScreenshot, renderToolWindow(2, "", LIGHT_THEME, false));
         write(inspectorScreenshot, renderToolWindow(3, "", LIGHT_THEME, false));
         write(triageScreenshot, renderToolWindow(4, "", LIGHT_THEME, false));
+        write(shaftTestsScreenshot, renderShaftTests(LIGHT_THEME, false));
+        write(shaftTestsDarkScreenshot, renderShaftTests(DARK_THEME, true));
         write(visualBaselinesScreenshot, renderVisualBaselines(LIGHT_THEME, false));
-        write(evidenceScreenshot, renderToolWindow(6, "", LIGHT_THEME, false));
-        write(projectsScreenshot, renderToolWindow(7, "", LIGHT_THEME, false));
-        write(advancedToolsLightScreenshot, renderToolWindow(8, "", LIGHT_THEME, false));
-        write(advancedToolsDarkScreenshot, renderToolWindow(8, "", DARK_THEME, true));
+        write(evidenceScreenshot, renderToolWindow(7, "", LIGHT_THEME, false));
+        write(projectsScreenshot, renderToolWindow(8, "", LIGHT_THEME, false));
+        write(advancedToolsLightScreenshot, renderToolWindow(9, "", LIGHT_THEME, false));
+        write(advancedToolsDarkScreenshot, renderToolWindow(9, "", DARK_THEME, true));
         Files.copy(advancedToolsLightScreenshot, toolsLightScreenshot, StandardCopyOption.REPLACE_EXISTING);
         Files.copy(advancedToolsDarkScreenshot, toolsDarkScreenshot, StandardCopyOption.REPLACE_EXISTING);
         write(mcpSetupScreenshot, renderSetup(LIGHT_THEME, false));
@@ -166,7 +172,7 @@ class ShaftPluginScreenshotRendererTest {
         write(mcpSetupErrorScreenshot, renderSetupError(DARK_THEME, true));
         write(settingsScreenshot, renderSettings(LIGHT_THEME, false));
         write(settingsDarkScreenshot, renderSettings(DARK_THEME, true));
-        write(mcpGuideScreenshot, renderToolWindow(8, "Guide", LIGHT_THEME, false));
+        write(mcpGuideScreenshot, renderToolWindow(9, "Guide", LIGHT_THEME, false));
         assertAll(
                 () -> assertTrue(Files.size(assistantLightScreenshot) > 0, assistantLightScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantEmptyScreenshot) > 0, assistantEmptyScreenshot + " should be non-empty"),
@@ -179,6 +185,8 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertTrue(Files.size(recorderScreenshot) > 0, recorderScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(inspectorScreenshot) > 0, inspectorScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(triageScreenshot) > 0, triageScreenshot + " should be non-empty"),
+                () -> assertTrue(Files.size(shaftTestsScreenshot) > 0, shaftTestsScreenshot + " should be non-empty"),
+                () -> assertTrue(Files.size(shaftTestsDarkScreenshot) > 0, shaftTestsDarkScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(visualBaselinesScreenshot) > 0, visualBaselinesScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(evidenceScreenshot) > 0, evidenceScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(projectsScreenshot) > 0, projectsScreenshot + " should be non-empty"),
@@ -205,6 +213,8 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertDimensions(recorderScreenshot),
                 () -> assertDimensions(inspectorScreenshot),
                 () -> assertDimensions(triageScreenshot),
+                () -> assertDimensions(shaftTestsScreenshot),
+                () -> assertDimensions(shaftTestsDarkScreenshot),
                 () -> assertDimensions(visualBaselinesScreenshot),
                 () -> assertDimensions(evidenceScreenshot),
                 () -> assertDimensions(projectsScreenshot),
@@ -222,6 +232,8 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertDimensions(mcpGuideScreenshot),
                 () -> assertTrue(Files.mismatch(assistantLightScreenshot, assistantDarkScreenshot) >= 0,
                         "Assistant light and dark screenshots should differ"),
+                () -> assertTrue(Files.mismatch(shaftTestsScreenshot, shaftTestsDarkScreenshot) >= 0,
+                        "SHAFT Tests light and dark screenshots should differ"),
                 () -> assertTrue(Files.mismatch(settingsScreenshot, settingsDarkScreenshot) >= 0,
                         "Settings light and dark screenshots should differ"),
                 () -> assertTrue(Files.mismatch(advancedToolsLightScreenshot, advancedToolsDarkScreenshot) >= 0,
@@ -260,6 +272,44 @@ class ShaftPluginScreenshotRendererTest {
             image.set(render(component, width, height));
         });
         return image.get();
+    }
+
+    private static BufferedImage renderShaftTests(String lookAndFeelClassName, boolean dark)
+            throws InterruptedException, InvocationTargetException {
+        AtomicReference<BufferedImage> image = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            configureLookAndFeel(lookAndFeelClassName, dark);
+            ShaftTestIndex testIndex = new ShaftTestIndex();
+            long now = System.currentTimeMillis();
+            testIndex.recordRun("com.example.SignInTest", 0, now - 120_000);
+            testIndex.recordRun("com.example.CheckoutTest", 1, now - 60_000);
+            testIndex.recordRun("com.example.SearchTest", 0, now);
+            ShaftTestsPanel component = new ShaftTestsPanel(screenshotProject(), testIndex);
+            selectFailRowIfPresent(component);
+            component.setSize(new Dimension(WIDTH, HEIGHT));
+            component.setPreferredSize(new Dimension(WIDTH, HEIGHT));
+            SwingUtilities.updateComponentTreeUI(component);
+            component.doLayout();
+            layout(component, !dark);
+            image.set(render(component, WIDTH, HEIGHT));
+        });
+        return image.get();
+    }
+
+    /** Selects the first FAIL row so the screenshot shows Doctor/Heal enabled, falling back to
+     * row 0 when nothing failed. */
+    private static void selectFailRowIfPresent(ShaftTestsPanel component) {
+        DefaultListModel<ShaftTestIndex.TestRowState> model =
+                (DefaultListModel<ShaftTestIndex.TestRowState>) component.rowListForTest().getModel();
+        for (int i = 0; i < model.getSize(); i++) {
+            if (ShaftTestsPanel.isFailRow(model.getElementAt(i))) {
+                component.rowListForTest().setSelectedIndex(i);
+                return;
+            }
+        }
+        if (model.getSize() > 0) {
+            component.rowListForTest().setSelectedIndex(0);
+        }
     }
 
     private static BufferedImage renderVisualBaselines(String lookAndFeelClassName, boolean dark)

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftTestsPanelTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftTestsPanelTest.java
@@ -1,0 +1,53 @@
+package com.shaft.intellij.ui;
+
+import com.shaft.intellij.testindex.ShaftTestIndex;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ShaftTestsPanelTest {
+    @Test
+    void isFailRowIsTrueOnlyForFailStatus() {
+        ShaftTestIndex.TestRowState passRow = new ShaftTestIndex.TestRowState(
+                "SignInTest", ShaftTestIndex.Status.PASS, 1_000L, 0);
+        ShaftTestIndex.TestRowState failRow = new ShaftTestIndex.TestRowState(
+                "CheckoutTest", ShaftTestIndex.Status.FAIL, 1_000L, 1);
+
+        assertFalse(ShaftTestsPanel.isFailRow(passRow));
+        assertTrue(ShaftTestsPanel.isFailRow(failRow));
+    }
+
+    @Test
+    void isFailRowIsFalseForNull() {
+        assertFalse(ShaftTestsPanel.isFailRow(null));
+    }
+
+    @Test
+    void formatRowLabelIncludesStatusAndTestId() {
+        ShaftTestIndex.TestRowState row = new ShaftTestIndex.TestRowState(
+                "com.example.CheckoutTest", ShaftTestIndex.Status.FAIL, 1_000L, 1);
+
+        String label = ShaftTestsPanel.formatRowLabel(row);
+
+        assertTrue(label.startsWith("FAIL"));
+        assertTrue(label.contains("com.example.CheckoutTest"));
+    }
+
+    @Test
+    void formatRowLabelUsesPassForZeroExitCode() {
+        ShaftTestIndex.TestRowState row = new ShaftTestIndex.TestRowState(
+                "com.example.SignInTest", ShaftTestIndex.Status.PASS, 1_000L, 0);
+
+        assertTrue(ShaftTestsPanel.formatRowLabel(row).startsWith("PASS"));
+    }
+
+    @Test
+    void formatRowLabelOmitsTimeForNonPositiveTimestamp() {
+        ShaftTestIndex.TestRowState row = new ShaftTestIndex.TestRowState(
+                "com.example.SignInTest", ShaftTestIndex.Status.PASS, 0L, 0);
+
+        assertEquals("PASS  com.example.SignInTest  ", ShaftTestsPanel.formatRowLabel(row));
+    }
+}


### PR DESCRIPTION
## Summary
Ships items 1-3 of #3467 (item 4 — recorder pick-state plumbing — split to #3483 per the scoping research; no shaft-capture/shaft-mcp changes):

**1. Gutter run/debug + run-configuration producers** (`com.shaft.intellij.testrunner`)
- `ShaftTestLineMarkerContributor` on Java method identifiers, gated by `ShaftProjectDetector` + a pure `ShaftTestMethodAnnotations` predicate (TestNG/JUnit4/JUnit5 `@Test`).
- `ShaftJUnitRunConfigurationProducer` / `ShaftTestNgRunConfigurationProducer` produce IntelliJ's own JUnit/TestNG run configurations — no custom SHAFT run-config type.
- Correct classloading isolation: producers live in new optional-dependency descriptors gated on the bundled **JUnit** and **TestNG-J** plugins respectively (`JUnitConfiguration`/`TestNGConfiguration` do not live in `com.intellij.java`); the PSI-only line marker stays in `shaft-withJava.xml`. Plugin degrades gracefully when either bundled plugin is disabled.

**2. "SHAFT Tests" tree** — new `ShaftTestIndex` project service fed by an `ExecutionListener` (run-configuration-level granularity for v1, documented), rendered as a new workflow card `ShaftTestsPanel` with per-row Doctor/Heal actions for FAIL rows, reusing the exact `doctorArguments()`/`healerArguments()` payloads via a shared `ShaftToolWorkflowLauncher` extracted from `FailedRunDoctorNotifier` (balloon behavior unchanged).

**3. Watch mode** — opt-in (`watchModeEnabled`, default **off**), `BulkFileListener` on `src/test` paths, 750ms debounce via `Alarm`, and a pure clock-free `WatchRerunThrottle` (max 6 reruns per rolling 5-min window, throttle balloon shown once per window). Reruns re-execute the last test run configuration through IntelliJ's own execution machinery — no raw processes; bounded by construction against the Windows Maven-fork runaway risk.

## Verification
- `gradle -p shaft-intellij check`: **502 tests, 0 failures, 0 errors** (5 pre-existing gated skips). New unit tests: `WatchRerunThrottleTest`, `ShaftTestIndexTest`, `ShaftTestWatchServiceTest`, `ShaftTestMethodAnnotationsTest`, `ShaftTestsPanelTest`; `ShaftPanelSetupTest` updated for the new card.
- `gradle -p shaft-intellij buildPlugin`: BUILD SUCCESSFUL — assembled jar verified to contain both new optional-dep descriptors.
- Screenshot renderer: 27 PNGs including new `intellij-plugin-shaft-tests(.png|-dark.png)` (3 seeded rows, FAIL row selected, Doctor/Heal enabled); all workflow-card tab indices in the renderer audited/updated for the inserted card. Renders verified locally (renderer is evidence-only, skipped in CI by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)