### PR TITLE
fix: eliminate live Selenium version ranges blocking the 10.3.20260712 Maven Central delivery

### DIFF
--- a/shaft-engine/pom.xml
+++ b/shaft-engine/pom.xml
@@ -128,6 +128,17 @@
             <groupId>io.github.ashwithpoojary98</groupId>
             <artifactId>appium_flutterfinder_java</artifactId>
             <version>${appium.flutterfinder.version}</version>
+            <exclusions>
+                <!-- java-client declares open selenium ranges ([4.42.0, 5.0)); through this
+                     unexcluded path they resolve against live Central metadata, so a new
+                     Selenium release silently mixes versions on the classpath (10.3.20260712
+                     delivery failed on 4.46-compiled bytecode vs pinned 4.45 runtime).
+                     The direct java-client dependency above already prunes its selenium edges. -->
+                <exclusion>
+                    <groupId>io.appium</groupId>
+                    <artifactId>java-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- WEBDRIVER MANAGER -->

--- a/shaft-mcp/pom.xml
+++ b/shaft-mcp/pom.xml
@@ -21,6 +21,17 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Import the reactor's selenium-bom before spring-boot-dependencies: Spring Boot
+                 also manages org.seleniumhq.selenium artifacts (at an older version), and the
+                 first import wins, so without this shaft-mcp runs Selenium 4.43 test classpaths
+                 against shaft-engine/shaft-capture bytecode compiled with the reactor pin. -->
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-bom</artifactId>
+                <version>${selenium.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
## Summary
The merged release PR #3472 passed its release-candidate gate, but Maven Central delivery failed twice (run 29210409659) with:

```
CaptureServiceApiToolsTest.apiStartRejectsSecondConcurrentSessionViaTheSharedSingleSessionLock:124
Caused by: java.lang.NoSuchMethodError: 'java.lang.String org.openqa.selenium.bidi.module.Script.onMessage(java.util.function.Consumer)'
```

## Root cause
- Appium `java-client` declares hard Selenium ranges `[4.42.0, 5.0)` on selenium-api/remote-driver/support. Hard ranges resolve against **live Central metadata** and beat BOM pins (MNG-4463).
- shaft-engine excludes selenium from its direct java-client dependency, but `appium_flutterfinder_java → java-client` re-introduces the ranges **unexcluded**.
- Selenium **4.46.0** (published to Central shortly before the release) changed `Script.onMessage`'s return type from `long` to `String`. Cold-metadata runs (delivery, which restored a 46 MB shaft-cli cache containing no selenium artifacts) resolved the range to 4.46 at compile time; warm-cache runs (the gate, dev machines) kept resolving 4.45 — hence gate-green/delivery-red on the identical commit.
- Compounding skew: shaft-mcp's `spring-boot-dependencies` BOM import downgraded its Selenium test runtime to **4.43.0** against the reactor's 4.45.0 pin (first BOM import wins over the parent's selenium-bom import).

## Changes
- **shaft-engine/pom.xml**: exclude `io.appium:java-client` from `appium_flutterfinder_java`. The direct java-client dependency already prunes its selenium edges, so no live range remains anywhere in the graph; Selenium resolution is now fully pinned and metadata-independent.
- **shaft-mcp/pom.xml**: import the reactor's `selenium-bom` ahead of `spring-boot-dependencies` so shaft-mcp's test runtime (was 4.43) matches the bytecode shaft-engine/shaft-capture compile against (4.45).

## Validation
- `mvn -pl shaft-mcp dependency:tree`: selenium now resolves 4.45.0 end to end (was 4.43.0).
- `mvn -pl shaft-engine dependency:tree -Dincludes=io.appium:java-client -Dverbose`: single java-client node, flutterfinder subtree pruned.
- `javap` cross-check: 4.43/4.45 `Script.onMessage` returns `long`, 4.46 returns `String` — matching the failure descriptor exactly.
- Scoped tests (surefire XML verdicts): `CaptureServiceApiToolsTest` 15/15, `ShaftMcpApplicationTests` 5/5.

Merging this restores the blocked **10.3.20260712** delivery: mavenCentral_cd re-triggers on the main push and `check_maven_release_version` still sees the version as unpublished.

Closes #3485 (the "flaky" failure was this deterministic resolution bug — the gate's pass was the metadata-freshness artifact, not the delivery's failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)