### PR TITLE
feat: persist recorder pick state so the IDE Pick-Locator action receives real picks (closes #3483)

### DIFF
--- a/.github/workflows/intellij-plugin.yml
+++ b/.github/workflows/intellij-plugin.yml
@@ -12,6 +12,7 @@ on:
       - 'scripts/ci/validate_installer_contract.py'
       - 'tests/scripts/test_validate_installer_contract.py'
       - 'shaft-mcp/src/main/java/com/shaft/mcp/**'
+      - 'shaft-capture/**'
       - 'shaft-skills/**'
       - 'tests/scripts/test_generate_shaft_skills_tool_catalog.py'
   push:
@@ -26,6 +27,7 @@ on:
       - 'scripts/ci/validate_installer_contract.py'
       - 'tests/scripts/test_validate_installer_contract.py'
       - 'shaft-mcp/src/main/java/com/shaft/mcp/**'
+      - 'shaft-capture/**'
       - 'shaft-skills/**'
       - 'tests/scripts/test_generate_shaft_skills_tool_catalog.py'
   workflow_dispatch:

--- a/shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlFiles.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlFiles.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFilePermission;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -63,6 +64,29 @@ public final class CaptureControlFiles {
             return CaptureStatus.notRunning();
         }
         return readJson(statusPath(), CaptureStatus.class);
+    }
+
+    /**
+     * Persists the most recent {@code /locator/pick} result so a caller with no candidates of its
+     * own (for example, the SHAFT MCP {@code capture_pick_locator} tool serving an IntelliJ
+     * Pick-Locator action) can still recover the user's most recent recorder pick.
+     *
+     * @param pick last locator pick
+     */
+    public void writeLastPick(LastPick pick) {
+        writeJson(lastPickPath(), pick, false);
+    }
+
+    /**
+     * Reads the most recent persisted {@code /locator/pick} result.
+     *
+     * @return the last persisted pick, or {@code null} when none has been persisted yet
+     */
+    public LastPick readLastPick() {
+        if (!Files.isRegularFile(lastPickPath())) {
+            return null;
+        }
+        return readJson(lastPickPath(), LastPick.class);
     }
 
     /**
@@ -175,6 +199,10 @@ public final class CaptureControlFiles {
         return runtimeDirectory.resolve("status.json");
     }
 
+    private Path lastPickPath() {
+        return runtimeDirectory.resolve("lastPick.json");
+    }
+
     private Path descriptorPath() {
         return runtimeDirectory.resolve("control.json");
     }
@@ -254,6 +282,26 @@ public final class CaptureControlFiles {
             if (port < 1 || port > 65535 || processId < 1) {
                 throw new IllegalArgumentException("Capture control endpoint metadata is invalid.");
             }
+        }
+    }
+
+    /**
+     * The most recent {@code /locator/pick} result, persisted so a later caller with no candidates
+     * of its own can recover the user's last recorder pick. {@code capturedAtMillis} is carried for
+     * future staleness checks; no consumer currently enforces freshness (v1 non-goal).
+     *
+     * @param snippet winning candidate's copy-paste Java locator expression
+     * @param candidates every supplied candidate, ranked best-first
+     * @param capturedAtMillis epoch millis when the pick was captured
+     */
+    public record LastPick(
+            String snippet, List<CaptureControlServer.RankedCandidate> candidates, long capturedAtMillis) {
+        /**
+         * Creates an immutable last-pick record.
+         */
+        public LastPick {
+            snippet = snippet == null ? "" : snippet;
+            candidates = candidates == null ? List.of() : List.copyOf(candidates);
         }
     }
 

--- a/shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlServer.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/control/CaptureControlServer.java
@@ -156,6 +156,10 @@ public final class CaptureControlServer implements AutoCloseable {
      * The recorder JS computes candidates client-side (it already has the live DOM) and posts them
      * here rather than this server re-deriving them, since deriving locator evidence requires the
      * live page the browser has and this control server does not.
+     *
+     * <p>The ranked result is also persisted via {@link CaptureControlFiles#writeLastPick} so a
+     * later caller with no candidates of its own (the SHAFT MCP {@code capture_pick_locator} tool,
+     * serving an IntelliJ Pick-Locator action) can still recover the user's most recent pick.
      */
     private PickLocatorResponse pickLocator(HttpExchange exchange) {
         requireMethod(exchange, "POST");
@@ -171,7 +175,10 @@ public final class CaptureControlServer implements AutoCloseable {
                         candidate.strategy().name(), candidate.expression(), candidate.score(),
                         PickedLocatorSnippetBuilder.snippet(candidate)))
                 .toList();
-        return new PickLocatorResponse(PickedLocatorSnippetBuilder.snippet(winner), rankedResponse);
+        String winnerSnippet = PickedLocatorSnippetBuilder.snippet(winner);
+        files.writeLastPick(new CaptureControlFiles.LastPick(
+                winnerSnippet, rankedResponse, System.currentTimeMillis()));
+        return new PickLocatorResponse(winnerSnippet, rankedResponse);
     }
 
     private static List<LocatorCandidate> toCandidates(List<CandidateRequest> requested) {

--- a/shaft-capture/src/test/java/com/shaft/capture/control/CaptureControlFilesTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/control/CaptureControlFilesTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -59,6 +60,26 @@ class CaptureControlFilesTest {
         files.clearActiveControl();
         assertFalse(files.hasActiveControl());
         assertEquals(CaptureStatus.State.STARTING, files.readStatus().state());
+    }
+
+    @Test
+    void lastPickRoundTripsAndIsAbsentUntilWritten() {
+        CaptureControlFiles files = new CaptureControlFiles(temp);
+
+        assertNull(files.readLastPick(), "No pick has been persisted yet.");
+
+        CaptureControlFiles.LastPick pick = new CaptureControlFiles.LastPick(
+                "SHAFT.GUI.Locator.id(\"username\")",
+                List.of(
+                        new CaptureControlServer.RankedCandidate(
+                                "ID", "username", 100, "SHAFT.GUI.Locator.id(\"username\")"),
+                        new CaptureControlServer.RankedCandidate(
+                                "CSS", "div.form > input", 10, "SHAFT.GUI.Locator.cssSelector(\"div.form > input\")")),
+                1_700_000_000_000L);
+
+        files.writeLastPick(pick);
+
+        assertEquals(pick, files.readLastPick());
     }
 
     @Test

--- a/shaft-capture/src/test/java/com/shaft/capture/control/CaptureControlServerClientTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/control/CaptureControlServerClientTest.java
@@ -167,6 +167,14 @@ class CaptureControlServerClientTest {
             assertTrue(response.body().contains("SHAFT.GUI.Locator.id(\\\"username\\\")"),
                     "The ID strategy should outrank CSS here, got: " + response.body());
             assertTrue(response.body().contains("\"ranked\""));
+
+            CaptureControlFiles.LastPick lastPick = files.readLastPick();
+            assertEquals("SHAFT.GUI.Locator.id(\"username\")", lastPick.snippet(),
+                    "/locator/pick must persist the winning snippet so a later empty-candidates "
+                            + "caller (e.g. the MCP capture_pick_locator tool) can recover it.");
+            assertEquals(2, lastPick.candidates().size());
+            assertEquals("ID", lastPick.candidates().getFirst().strategy());
+            assertTrue(lastPick.capturedAtMillis() > 0);
         } finally {
             server.close();
             manager.close();

--- a/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
@@ -506,6 +506,13 @@ public class CaptureService {
      * {@code CaptureControlServer}'s {@code /locator/pick} endpoint (used by a detached recorder
      * UI); this MCP tool serves the same in-process, without a loopback HTTP round trip.
      *
+     * <p>When no valid candidates are supplied (for example, an IntelliJ Pick-Locator caret action
+     * probing readiness with an empty payload), this falls back to the last pick persisted under
+     * this service's session runtime directory by {@code CaptureControlServer}'s
+     * {@code /locator/pick} endpoint -- see {@link com.shaft.capture.control.CaptureControlFiles#readLastPick()}.
+     * Freshness of that persisted pick (how long ago it was captured) is a documented non-goal for
+     * v1; see {@link com.shaft.capture.control.CaptureControlFiles.LastPick#capturedAtMillis()}.
+     *
      * @param candidates locator candidates observed for the picked element, e.g. from the recorder
      *                   overlay's inspect-mode click handler
      * @return the winning candidate's snippet plus every candidate ranked best-first
@@ -515,7 +522,7 @@ public class CaptureService {
     public McpPickLocatorResult pickLocator(List<McpLocatorCandidate> candidates) {
         List<com.shaft.capture.model.LocatorCandidate> parsed = parseCandidates(candidates);
         if (parsed.isEmpty()) {
-            return new McpPickLocatorResult("", List.of());
+            return persistedPick();
         }
         List<com.shaft.capture.model.LocatorCandidate> ranked =
                 parsed.stream().sorted(com.shaft.capture.model.LocatorCandidate.BEST_FIRST).toList();
@@ -525,6 +532,26 @@ public class CaptureService {
                         com.shaft.capture.control.PickedLocatorSnippetBuilder.snippet(candidate)))
                 .toList();
         return new McpPickLocatorResult(rankedResult.getFirst().snippet(), rankedResult);
+    }
+
+    /**
+     * Reads the last locator pick persisted under {@link #RUNTIME_DIRECTORY} -- the same session
+     * runtime directory this service always uses to start managed capture sessions -- so a caller
+     * with no candidates of its own can still recover the user's most recent recorder pick.
+     *
+     * @return the persisted pick, or a blank result when none has been persisted yet
+     */
+    private McpPickLocatorResult persistedPick() {
+        com.shaft.capture.control.CaptureControlFiles.LastPick lastPick =
+                new com.shaft.capture.control.CaptureControlFiles(RUNTIME_DIRECTORY).readLastPick();
+        if (lastPick == null) {
+            return new McpPickLocatorResult("", List.of());
+        }
+        List<McpRankedLocatorCandidate> ranked = lastPick.candidates().stream()
+                .map(candidate -> new McpRankedLocatorCandidate(
+                        candidate.strategy(), candidate.expression(), candidate.score(), candidate.snippet()))
+                .toList();
+        return new McpPickLocatorResult(lastPick.snippet(), ranked);
     }
 
     private static List<com.shaft.capture.model.LocatorCandidate> parseCandidates(List<McpLocatorCandidate> candidates) {

--- a/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceApiToolsTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceApiToolsTest.java
@@ -1,5 +1,7 @@
 package com.shaft.mcp;
 
+import com.shaft.capture.control.CaptureControlFiles;
+import com.shaft.capture.control.CaptureControlServer;
 import com.shaft.capture.format.CaptureJsonCodec;
 import com.shaft.capture.model.BrowserMetadata;
 import com.shaft.capture.model.CaptureEvent;
@@ -31,6 +33,7 @@ import java.util.TreeMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -343,6 +346,56 @@ class CaptureServiceApiToolsTest {
         try {
             CaptureService.McpPickLocatorResult result = service.pickLocator(
                     List.of(new CaptureService.McpLocatorCandidate("NOT_A_STRATEGY", "x", 1, true, true)));
+
+            assertTrue(result.snippet().isEmpty());
+            assertTrue(result.ranked().isEmpty());
+        } finally {
+            service.close();
+        }
+    }
+
+    @Test
+    void pickLocatorWithNoCandidatesReturnsThePersistedPickWhenOneExists() throws Exception {
+        // Mirrors CaptureService's private RUNTIME_DIRECTORY constant: capture_pick_locator falls
+        // back to the pick persisted there by CaptureControlServer's /locator/pick endpoint.
+        Path runtimeDirectory = Path.of("target", "shaft-capture-mcp");
+        CaptureControlFiles files = new CaptureControlFiles(runtimeDirectory);
+        files.writeLastPick(new CaptureControlFiles.LastPick(
+                "SHAFT.GUI.Locator.id(\"username\")",
+                List.of(new CaptureControlServer.RankedCandidate(
+                        "ID", "username", 100, "SHAFT.GUI.Locator.id(\"username\")")),
+                System.currentTimeMillis()));
+        CaptureService service = new CaptureService(
+                new CaptureManager(),
+                McpWorkspacePolicy.of(temp),
+                new McpCaptureCodeBlockService());
+        try {
+            CaptureService.McpPickLocatorResult result = service.pickLocator(List.of());
+
+            assertEquals("SHAFT.GUI.Locator.id(\"username\")", result.snippet());
+            assertEquals(1, result.ranked().size());
+            assertEquals("ID", result.ranked().getFirst().strategy());
+        } finally {
+            service.close();
+            Files.deleteIfExists(files.runtimeDirectory().resolve("lastPick.json"));
+        }
+    }
+
+    @Test
+    void pickLocatorWithNoCandidatesReturnsBlankWhenNoPickIsPersisted() throws Exception {
+        Path runtimeDirectory = Path.of("target", "shaft-capture-mcp");
+        CaptureControlFiles files = new CaptureControlFiles(runtimeDirectory);
+        // Self-contained regardless of test execution order: ensure no stray lastPick.json from a
+        // sibling test remains before asserting the blank fallback.
+        Files.deleteIfExists(files.runtimeDirectory().resolve("lastPick.json"));
+        CaptureService service = new CaptureService(
+                new CaptureManager(),
+                McpWorkspacePolicy.of(temp),
+                new McpCaptureCodeBlockService());
+        try {
+            assertNull(files.readLastPick(), "Precondition: no pick persisted for this test.");
+
+            CaptureService.McpPickLocatorResult result = service.pickLocator(List.of());
 
             assertTrue(result.snippet().isEmpty());
             assertTrue(result.ranked().isEmpty());


### PR DESCRIPTION
## Summary
Closes the pick-state loop split out of #3467 (closes #3483):

- **shaft-capture**: `CaptureControlServer` `/locator/pick` now persists the ranked result (winning snippet, ranked candidates, `capturedAtMillis`) as `lastPick.json` via a new `CaptureControlFiles.writeLastPick`/`readLastPick` pair — same atomic temp-file + `ATOMIC_MOVE`, owner-only-permissions mechanism as `status.json`.
- **shaft-mcp**: `capture_pick_locator` with an empty candidate list (the IntelliJ Pick-Locator caret action's call shape) now falls back to the persisted last pick from the session runtime directory instead of short-circuiting to a blank result. Non-empty-candidates path unchanged; `McpPickLocatorResult` shape unchanged (staleness enforcement is a documented v1 non-goal, timestamp is persisted for future use).
- **shaft-intellij**: zero changes needed — the existing action's empty-input call now receives the user's real last pick.
- **CI path gap fixed**: `shaft-capture/**` added to `intellij-plugin.yml` triggers (was documented in #3483 — pick-state changes previously wouldn't exercise the plugin workflow).

## Verification (surefire XML)
- `CaptureControlFilesTest`: 3/3 (last-pick round-trip, missing-file semantics)
- `CaptureControlServerClientTest`: 5/5 (`/locator/pick` persists `lastPick.json`)
- `CaptureServiceApiToolsTest`: 17/17 (empty-candidates fallback returns persisted pick when present, blank when absent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)