### PR TITLE
fix: sync refresh-workflow allowlist fixture and CodeQL module coverage with validators (closes #3481)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -62,7 +62,7 @@ jobs:
           maven-version: 3.9.5
 
       - name: Build all Java-bearing SHAFT modules
-        run: mvn -B -pl shaft-engine,shaft-pilot-core,shaft-capture,shaft-doctor,shaft-ai,shaft-heal,shaft-browserstack,shaft-video,shaft-visual,shaft-sikulix,shaft-mcp,report-aggregate -am clean package --file pom.xml -DskipTests -Dgpg.skip
+        run: mvn -B -pl shaft-engine,shaft-pilot-core,shaft-capture,shaft-capture-proxy,shaft-doctor,shaft-ai,shaft-heal,shaft-browserstack,shaft-video,shaft-visual,shaft-sikulix,shaft-mcp,report-aggregate -am clean package --file pom.xml -DskipTests -Dgpg.skip
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/scripts/ci/validate_quality_configuration.py
+++ b/scripts/ci/validate_quality_configuration.py
@@ -155,7 +155,11 @@ def validate_quality_configuration(root: Path = ROOT) -> list[str]:
     codecov_count = (workflow_text + action_text).count("codecov/codecov-action@")
 
     codeql = (root / ".github" / "workflows" / "security.yml").read_text(encoding="utf-8")
-    selector = "-pl shaft-engine,shaft-pilot-core,shaft-capture,shaft-doctor,shaft-ai,shaft-heal,shaft-browserstack,shaft-video,shaft-visual,shaft-sikulix,shaft-mcp -am"
+    selector = (
+        "-pl shaft-engine,shaft-pilot-core,shaft-capture,shaft-capture-proxy,shaft-doctor,"
+        "shaft-ai,shaft-heal,shaft-browserstack,shaft-video,shaft-visual,shaft-sikulix,"
+        "shaft-mcp,report-aggregate -am"
+    )
     if selector not in codeql:
         errors.append("CodeQL build must compile every Java-bearing module")
 

--- a/tests/scripts/test_validate_agent_guidance.py
+++ b/tests/scripts/test_validate_agent_guidance.py
@@ -47,6 +47,12 @@ steps:
     run: python3 scripts/ci/validate_agent_setup.py
   - if: steps.audit.outputs.needs_ai == 'true'
     uses: openai/codex-action@v1
+  - id: changes
+    run: |
+      case "$file" in
+        .agents/skills/*|.claude/skills/*|.github/instructions/*|.github/skills/*)
+          ;;
+      esac
 """,
         )
         self.budget = {


### PR DESCRIPTION
## Summary
Fixes the two pre-existing red validators on main (closes #3481), both confirmed as drift via git blame:

1. **CodeQL module coverage**: `shaft-capture-proxy` (added to `JAVA_MODULES` 2026-07-07) was missing from `security.yml`'s CodeQL `-pl` build list, and the validator's exact-substring `selector` had also drifted (it predated both `shaft-capture-proxy` and the intentional `report-aggregate` addition from 2026-07-08). Both sides now agree on the full module list.
2. **Refresh-workflow allowlist**: production `.github/workflows/refresh-agent-instructions.yml` was already correct — the failure was in the test's own synthetic "valid repository" fixture, which predated the validator's `.claude/skills/*` allowlist requirement (introduced in #3148). The fixture now includes the expected allowlist pattern.

## Verification
- Before: `py -3 -m unittest discover -s tests/scripts` → 232 tests, 2 failures (exactly the issue's two).
- After: **232/232 passing, 0 failures.**
- `py -3 scripts/ci/validate_agent_setup.py` → valid (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)