### PR TITLE
fix: resolve IntelliJ Plugin Verifier findings (deprecated APIs + invalid withJUnit descriptor)

### DIFF
--- a/shaft-intellij/build.gradle.kts
+++ b/shaft-intellij/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
+import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
 
 plugins {
     java
@@ -46,15 +47,41 @@ intellijPlatform {
         name = "SHAFT"
         version = project.version.toString()
         description = """
-            SHAFT integration for IntelliJ IDEA with an Assistant-first SHAFT MCP chat surface plus curated recorder,
-            playback, Doctor, Healer, Inspector, project, MCP, and guide tools.
+            <p>SHAFT's official IntelliJ IDEA companion: record, generate, run, and heal automated tests powered by
+            <a href="https://shafthq.github.io">SHAFT Engine</a> — through an Assistant-first, chat-driven workflow
+            backed by the SHAFT MCP server.</p>
+
+            <h3>Highlights</h3>
+            <ul>
+              <li><b>Assistant chat</b> — describe a scenario in plain language and get runnable SHAFT test code;
+              slash commands cover recording, inspection, test generation, and failed-test triage.</li>
+              <li><b>Web recorder</b> — capture real browser sessions and turn them into SHAFT tests, with
+              Pick-Locator results flowing straight into the editor.</li>
+              <li><b>Run from the gutter</b> — SHAFT-aware JUnit and TestNG run configurations for test classes
+              and methods.</li>
+              <li><b>SHAFT Tests panel</b> — recent runs at a glance, with one-click Doctor diagnosis and Healer
+              locator repair for failures.</li>
+              <li><b>Inspector &amp; locator tools</b> — inspect live pages, propose resilient locators, and
+              validate them before committing.</li>
+              <li><b>Visual baselines &amp; evidence</b> — triage visual-regression diffs and browse execution
+              evidence without leaving the IDE.</li>
+              <li><b>Guided setup</b> — a wizard installs and verifies the SHAFT MCP server and the assistant
+              runtime (Codex or Gemini) in a couple of clicks.</li>
+              <li><b>Advanced tools</b> — the full SHAFT MCP tool catalog, refreshed live, with curated safe
+              defaults and explicit approval prompts before anything runs.</li>
+            </ul>
+
+            <p>The plugin activates only in projects that use SHAFT and stays out of the way everywhere else.</p>
         """.trimIndent()
         changeNotes = """
             <ul>
-              <li>Adds guided Recorder, Locator, Doctor, Trace, Healer, and locator-proposal workflows.</li>
-              <li>Expands Assistant slash commands for recording, inspection, test generation, and failed-test triage.</li>
-              <li>Refreshes Advanced Tools from the live SHAFT MCP catalog while preserving curated safe defaults.</li>
-              <li>Improves MCP stdio result handling, accessibility metadata, and narrow tool-window tab behavior.</li>
+              <li>Fixes plugin installation failing with "Failed to load the plugin descriptor" caused by a
+              malformed optional JUnit integration descriptor.</li>
+              <li>Migrates run-configuration producers off deprecated IntelliJ Platform APIs flagged by the
+              JetBrains Plugin Verifier.</li>
+              <li>Hardens the release pipeline: builds now fail on deprecated API usage, plugin-structure
+              defects, and invalid descriptors before anything reaches the Marketplace.</li>
+              <li>Refreshes the Marketplace description and screenshots.</li>
             </ul>
         """.trimIndent()
         ideaVersion {
@@ -80,6 +107,21 @@ intellijPlatform {
     }
 
     pluginVerification {
+        // The default failure level (COMPATIBILITY_PROBLEMS only) let the 10.3.20260712 release
+        // ship with deprecated API usages and a malformed optional descriptor that made the
+        // Marketplace archive uninstallable ("Failed to load the plugin descriptor"). Fail CI on
+        // anything that would degrade or break the plugin at Marketplace review or install time.
+        failureLevel = listOf(
+            VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS,
+            VerifyPluginTask.FailureLevel.DEPRECATED_API_USAGES,
+            VerifyPluginTask.FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES,
+            VerifyPluginTask.FailureLevel.INTERNAL_API_USAGES,
+            VerifyPluginTask.FailureLevel.OVERRIDE_ONLY_API_USAGES,
+            VerifyPluginTask.FailureLevel.NON_EXTENDABLE_API_USAGES,
+            VerifyPluginTask.FailureLevel.PLUGIN_STRUCTURE_WARNINGS,
+            VerifyPluginTask.FailureLevel.MISSING_DEPENDENCIES,
+            VerifyPluginTask.FailureLevel.INVALID_PLUGIN,
+        )
         ides {
             current()
             // Pin the build that rejected 10.3.20260707 (LafManager.removeLafManagerListener removal)
@@ -92,6 +134,9 @@ intellijPlatform {
 tasks {
     withType<JavaCompile>().configureEach {
         options.release.set(17)
+        // Deprecated platform APIs must fail the build at compile time, before the plugin
+        // verifier (and long before Marketplace review) sees them.
+        options.compilerArgs.addAll(listOf("-Xlint:deprecation", "-Werror"))
     }
 
     processResources {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/testrunner/ShaftJUnitRunConfigurationProducer.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/testrunner/ShaftJUnitRunConfigurationProducer.java
@@ -2,7 +2,8 @@ package com.shaft.intellij.testrunner;
 
 import com.intellij.execution.PsiLocation;
 import com.intellij.execution.actions.ConfigurationContext;
-import com.intellij.execution.actions.RunConfigurationProducer;
+import com.intellij.execution.actions.LazyRunConfigurationProducer;
+import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.junit.JUnitConfiguration;
 import com.intellij.execution.junit.JUnitConfigurationType;
 import com.intellij.openapi.module.Module;
@@ -26,9 +27,10 @@ import java.util.List;
  * {@code io.github.shafthq.shaft-withJUnit.xml}), since {@link JUnitConfiguration} classes live
  * in that plugin, not in {@code com.intellij.java} itself.
  */
-public final class ShaftJUnitRunConfigurationProducer extends RunConfigurationProducer<JUnitConfiguration> {
-    public ShaftJUnitRunConfigurationProducer() {
-        super(JUnitConfigurationType.getInstance().getFactory());
+public final class ShaftJUnitRunConfigurationProducer extends LazyRunConfigurationProducer<JUnitConfiguration> {
+    @Override
+    public @NotNull ConfigurationFactory getConfigurationFactory() {
+        return JUnitConfigurationType.getInstance().getFactory();
     }
 
     @Override

--- a/shaft-intellij/src/main/java/com/shaft/intellij/testrunner/ShaftTestNgRunConfigurationProducer.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/testrunner/ShaftTestNgRunConfigurationProducer.java
@@ -2,7 +2,7 @@ package com.shaft.intellij.testrunner;
 
 import com.intellij.execution.PsiLocation;
 import com.intellij.execution.actions.ConfigurationContext;
-import com.intellij.execution.actions.RunConfigurationProducer;
+import com.intellij.execution.actions.LazyRunConfigurationProducer;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.openapi.util.Ref;
 import com.intellij.psi.PsiClass;
@@ -24,9 +24,10 @@ import java.util.List;
  * Registered only when the bundled TestNG-J plugin is enabled (see
  * {@code io.github.shafthq.shaft-withTestNG.xml}).
  */
-public final class ShaftTestNgRunConfigurationProducer extends RunConfigurationProducer<TestNGConfiguration> {
-    public ShaftTestNgRunConfigurationProducer() {
-        super((ConfigurationFactory) TestNGConfigurationType.getInstance());
+public final class ShaftTestNgRunConfigurationProducer extends LazyRunConfigurationProducer<TestNGConfiguration> {
+    @Override
+    public @NotNull ConfigurationFactory getConfigurationFactory() {
+        return (ConfigurationFactory) TestNGConfigurationType.getInstance();
     }
 
     @Override
@@ -39,13 +40,13 @@ public final class ShaftTestNgRunConfigurationProducer extends RunConfigurationP
         PsiElement element = context.getPsiLocation();
         PsiMethod method = PsiTreeUtil.getParentOfType(element, PsiMethod.class, false);
         if (method != null && ShaftTestMethodAnnotations.isShaftRunnableTestMethod(annotationQualifiedNames(method))) {
-            configuration.setMethodConfiguration(PsiLocation.fromPsiElement(method));
+            configuration.beMethodConfiguration(PsiLocation.fromPsiElement(method));
             sourceElement.set(method);
             return true;
         }
         PsiClass psiClass = PsiTreeUtil.getParentOfType(element, PsiClass.class, false);
         if (psiClass != null && psiClass.getName() != null && hasRunnableMethod(psiClass)) {
-            configuration.setClassConfiguration(psiClass);
+            configuration.beClassConfiguration(psiClass);
             sourceElement.set(psiClass);
             return true;
         }

--- a/shaft-intellij/src/main/resources/META-INF/io.github.shafthq.shaft-withJUnit.xml
+++ b/shaft-intellij/src/main/resources/META-INF/io.github.shafthq.shaft-withJUnit.xml
@@ -1,5 +1,5 @@
 <!-- Optional JUnit-plugin integration: JUnitConfiguration and friends live in the separate bundled
-     "JUnit" plugin (not com.intellij.java), so this only loads when JUnit is enabled -- which
+     "JUnit" plugin (not com.intellij.java), so this only loads when JUnit is enabled, which
      guarantees com.intellij.java is present too, since JUnit itself hard-depends on it. -->
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ShaftPluginDescriptorXmlTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ShaftPluginDescriptorXmlTest.java
@@ -1,0 +1,38 @@
+package com.shaft.intellij;
+
+import org.junit.jupiter.api.Test;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Every descriptor under META-INF must be well-formed XML: IntelliJ silently fails to load an
+ * optional-dependency config file whose XML is invalid (the Plugin Verifier flagged
+ * {@code io.github.shafthq.shaft-withJUnit.xml} for a "--" inside a comment, which the XML spec
+ * forbids). The string-based descriptor tests never parse these files, so this is the only guard.
+ */
+class ShaftPluginDescriptorXmlTest {
+
+    @Test
+    void allPluginDescriptorsAreWellFormedXml() throws IOException {
+        List<Path> descriptors;
+        try (Stream<Path> files = Files.list(Path.of("src/main/resources/META-INF"))) {
+            descriptors = files.filter(path -> path.getFileName().toString().endsWith(".xml")).toList();
+        }
+        assertFalse(descriptors.isEmpty(), "expected plugin descriptors under META-INF");
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setAttribute("http://javax.xml.XMLConstants/property/accessExternalDTD", "");
+        assertAll(descriptors.stream().map(descriptor ->
+                () -> assertDoesNotThrow(
+                        () -> factory.newDocumentBuilder().parse(descriptor.toFile()),
+                        descriptor + " is not well-formed XML")));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the JetBrains Plugin Verifier findings for SHAFT 10.3.20260712, the resulting **Marketplace installation failure** ("Plugin SHAFT was not installed: Failed to load the plugin descriptor from the downloaded archive"), and hardens CI so neither class of defect can ship again. Also refreshes the Marketplace description/change notes.

### Root cause of the installation failure
`io.github.shafthq.shaft-withJUnit.xml` contained `--` inside an XML comment, which the XML spec forbids. IntelliJ parses every descriptor when loading a plugin, so the whole downloaded archive was rejected as "probably not an IntelliJ plugin". Fixed by rewording the comment; guarded by a new `ShaftPluginDescriptorXmlTest` that strict-parses every `META-INF/*.xml` (verified red on the old text, green now).

### Deprecated API usages (4)
- `RunConfigurationProducer.<init>(ConfigurationFactory)` ×2 → both producers now extend `LazyRunConfigurationProducer` with `getConfigurationFactory()`.
- `TestNGConfiguration.setMethodConfiguration/setClassConfiguration` → `beMethodConfiguration`/`beClassConfiguration`.

### CI hardening (why this got through before)
`verifyPlugin` ran in all four workflows but the default `failureLevel` only fails on `COMPATIBILITY_PROBLEMS` — deprecated APIs and structure defects were warnings. Now:
- **Strict verifier failure levels** in `build.gradle.kts`: deprecated/scheduled-for-removal/internal/override-only/non-extendable API usage, plugin-structure warnings, missing dependencies, and invalid plugins all fail the build. Inherited by `intellij-plugin.yml`, `publish-intellij-plugin.yml`, `mavenCentral_cd.yml`, and `shaft-pilot-release.yml` with no workflow changes.
- **`-Xlint:deprecation -Werror`** on javac: deprecated platform APIs fail at compile time, against the 2024.3 baseline; the pinned 2026.2 verifier IDE catches newer deprecations/removals.

### Marketplace copy
`pluginConfiguration` description rewritten around the real feature surface (Assistant chat, recorder, gutter run configs, Doctor/Healer, Inspector, visual baselines, evidence, guided setup, approval prompts, SHAFT-project gating); change notes now describe the installability fix.

## Verification
- `gradle check buildPlugin verifyPlugin` with strict levels: **BUILD SUCCESSFUL**, plugin **Compatible** against IU-243.21565.193 and IU-262.8665.81, zero findings.
- Clean `compileJava` under `-Werror`: zero deprecation warnings.
- Full `shaft-intellij` test suite green (unrelated flake tracked in #3491).
- Screenshot renderer regenerated the full catalog; three Marketplace gallery images delivered separately (no plugin UI changed in this PR).

## Release note
Version `10.3.20260712` is already taken on Marketplace — this fix must ship under the next release version (release flow owns the bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)