### PR TITLE
fix: recorder no longer invents navigation actions on redirects; back/forward recorded reliably; overlay UX polish

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/collector/BidiBrowserEventCollector.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/collector/BidiBrowserEventCollector.java
@@ -22,6 +22,8 @@ public final class BidiBrowserEventCollector implements BrowserEventCollector {
     private final List<String> testIdAttributes;
     private final String stepsEndpoint;
     private final String stepsToken;
+    private final String eventEndpoint;
+    private final String eventToken;
     private final Map<String, String> promptTypes = new ConcurrentHashMap<>();
     // A subframe URL change is never a user navigation step (ads and embeds navigate on their
     // own); only top-level contexts may produce navigation signals. Child contexts are tracked
@@ -65,6 +67,29 @@ public final class BidiBrowserEventCollector implements BrowserEventCollector {
             List<String> testIdAttributes,
             String stepsEndpoint,
             String stepsToken) {
+        this(driver, testIdAttributes, stepsEndpoint, stepsToken, "", "");
+    }
+
+    /**
+     * Creates a BiDi collector whose preload script also posts every signal to the loopback
+     * event sink, so preload-installed recorder instances have two delivery channels (the BiDi
+     * script channel and the HTTP sink). Single-channel preload delivery lost signals from
+     * back/forward-cache restored pages.
+     *
+     * @param driver BiDi-capable driver
+     * @param testIdAttributes locator test-id attributes
+     * @param stepsEndpoint optional loopback steps query endpoint
+     * @param stepsToken optional loopback steps query token
+     * @param eventEndpoint optional loopback event endpoint
+     * @param eventToken optional loopback event token
+     */
+    public BidiBrowserEventCollector(
+            WebDriver driver,
+            List<String> testIdAttributes,
+            String stepsEndpoint,
+            String stepsToken,
+            String eventEndpoint,
+            String eventToken) {
         if (driver == null) {
             throw new IllegalArgumentException("Capture WebDriver is required.");
         }
@@ -72,6 +97,8 @@ public final class BidiBrowserEventCollector implements BrowserEventCollector {
         this.testIdAttributes = testIdAttributes == null ? List.of() : List.copyOf(testIdAttributes);
         this.stepsEndpoint = stepsEndpoint == null ? "" : stepsEndpoint;
         this.stepsToken = stepsToken == null ? "" : stepsToken;
+        this.eventEndpoint = eventEndpoint == null ? "" : eventEndpoint;
+        this.eventToken = eventToken == null ? "" : eventToken;
     }
 
     @Override
@@ -93,7 +120,8 @@ public final class BidiBrowserEventCollector implements BrowserEventCollector {
             }
         });
         preloadId = script.addPreloadScript(
-                BrowserEventScript.preloadFunction(testIdAttributes, stepsEndpoint, stepsToken),
+                BrowserEventScript.preloadFunction(
+                        testIdAttributes, stepsEndpoint, stepsToken, eventEndpoint, eventToken),
                 List.of(new ChannelValue(CHANNEL)));
 
         contexts = new BrowsingContextInspector(driver);

--- a/shaft-capture/src/main/java/com/shaft/capture/collector/BidiBrowserEventCollector.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/collector/BidiBrowserEventCollector.java
@@ -8,6 +8,7 @@ import org.openqa.selenium.bidi.script.ChannelValue;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
@@ -22,6 +23,10 @@ public final class BidiBrowserEventCollector implements BrowserEventCollector {
     private final String stepsEndpoint;
     private final String stepsToken;
     private final Map<String, String> promptTypes = new ConcurrentHashMap<>();
+    // A subframe URL change is never a user navigation step (ads and embeds navigate on their
+    // own); only top-level contexts may produce navigation signals. Child contexts are tracked
+    // from their creation events, which BiDi delivers before any navigation within them.
+    private final Set<String> childContexts = ConcurrentHashMap.newKeySet();
     private Script script;
     private BrowsingContextInspector contexts;
     private String preloadId;
@@ -92,16 +97,28 @@ public final class BidiBrowserEventCollector implements BrowserEventCollector {
                 List.of(new ChannelValue(CHANNEL)));
 
         contexts = new BrowsingContextInspector(driver);
-        contexts.onNavigationCommitted(info -> signalConsumer.accept(BrowserSignal.generated(
-                "navigation",
-                info.getBrowsingContextId(),
-                Map.of("url", info.getUrl()),
-                Map.of("action", "OPEN"))));
-        contexts.onHistoryUpdated(info -> signalConsumer.accept(BrowserSignal.generated(
-                "navigation",
-                info.getBrowsingContextId(),
-                Map.of("url", info.getUrl()),
-                Map.of("action", "OPEN"))));
+        contexts.onNavigationCommitted(info -> {
+            if (childContexts.contains(info.getBrowsingContextId())) {
+                return;
+            }
+            signalConsumer.accept(BrowserSignal.generated(
+                    "navigation",
+                    info.getBrowsingContextId(),
+                    Map.of("url", info.getUrl()),
+                    Map.of("action", "OPEN")));
+        });
+        contexts.onHistoryUpdated(info -> {
+            if (childContexts.contains(info.getBrowsingContextId())) {
+                return;
+            }
+            // pushState/replaceState rewrites are tagged so the pipeline can keep the current
+            // URL fresh without ever recording them as user navigation steps.
+            signalConsumer.accept(BrowserSignal.generated(
+                    "navigation",
+                    info.getBrowsingContextId(),
+                    Map.of("url", info.getUrl()),
+                    Map.of("action", "OPEN", "navigationSource", "history")));
+        });
         contexts.onBrowsingContextCreated(info -> {
             if (isTopLevel(info)) {
                 signalConsumer.accept(BrowserSignal.generated(
@@ -109,6 +126,8 @@ public final class BidiBrowserEventCollector implements BrowserEventCollector {
                         info.getId(),
                         Map.of("url", info.getUrl()),
                         Map.of()));
+            } else {
+                childContexts.add(info.getId());
             }
         });
         contexts.onBrowsingContextDestroyed(info -> {
@@ -118,6 +137,8 @@ public final class BidiBrowserEventCollector implements BrowserEventCollector {
                         info.getId(),
                         Map.of("url", info.getUrl()),
                         Map.of()));
+            } else {
+                childContexts.remove(info.getId());
             }
         });
         contexts.onUserPromptOpened(prompt ->

--- a/shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventScript.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/collector/BrowserEventScript.java
@@ -14,6 +14,8 @@ public final class BrowserEventScript {
             "const testIdAttributes = [\"data-testid\", \"data-test\", \"data-qa\"];";
     private static final String DEFAULT_STEPS_ENDPOINT =
             "const stepsEndpoint = {url: \"\", token: \"\"};";
+    private static final String DEFAULT_INJECTED_SINK =
+            "const injectedSink = {url: \"\", token: \"\"};";
     private static final String SCRIPT = load();
 
     private BrowserEventScript() {
@@ -51,7 +53,29 @@ public final class BrowserEventScript {
      * @return JavaScript function
      */
     public static String preloadFunction(List<String> testIdAttributes, String stepsEndpoint, String stepsToken) {
-        return script(testIdAttributes, stepsEndpoint, stepsToken);
+        return script(testIdAttributes, stepsEndpoint, stepsToken, "", "");
+    }
+
+    /**
+     * Returns the BiDi preload function declaration with the loopback event sink baked in, so
+     * preload-installed recorder instances deliver every signal through both the BiDi script
+     * channel and the HTTP sink. Single-channel preload delivery lost signals from
+     * back/forward-cache restored pages.
+     *
+     * @param testIdAttributes locator test-id attributes
+     * @param stepsEndpoint loopback steps query endpoint
+     * @param stepsToken loopback steps query token
+     * @param eventEndpoint loopback event endpoint
+     * @param eventToken loopback event token
+     * @return JavaScript function
+     */
+    public static String preloadFunction(
+            List<String> testIdAttributes,
+            String stepsEndpoint,
+            String stepsToken,
+            String eventEndpoint,
+            String eventToken) {
+        return script(testIdAttributes, stepsEndpoint, stepsToken, eventEndpoint, eventToken);
     }
 
     /**
@@ -127,6 +151,15 @@ public final class BrowserEventScript {
     }
 
     private static String script(List<String> testIdAttributes, String stepsEndpoint, String stepsToken) {
+        return script(testIdAttributes, stepsEndpoint, stepsToken, "", "");
+    }
+
+    private static String script(
+            List<String> testIdAttributes,
+            String stepsEndpoint,
+            String stepsToken,
+            String eventEndpoint,
+            String eventToken) {
         String result = SCRIPT;
         if (testIdAttributes != null && !testIdAttributes.isEmpty()) {
             result = result.replace(DEFAULT_TEST_ID_ATTRIBUTES,
@@ -137,6 +170,12 @@ public final class BrowserEventScript {
             result = result.replace(DEFAULT_STEPS_ENDPOINT,
                     "const stepsEndpoint = {url: " + jsString(stepsEndpoint)
                             + ", token: " + jsString(stepsToken) + "};");
+        }
+        if (eventEndpoint != null && !eventEndpoint.isBlank()
+                && eventToken != null && !eventToken.isBlank()) {
+            result = result.replace(DEFAULT_INJECTED_SINK,
+                    "const injectedSink = {url: " + jsString(eventEndpoint)
+                            + ", token: " + jsString(eventToken) + "};");
         }
         return result;
     }

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
@@ -38,7 +38,14 @@ import java.util.function.Consumer;
  */
 final class CaptureEventPipeline implements AutoCloseable {
     private static final Duration CLICK_DEBOUNCE = Duration.ofMillis(300);
-    private static final Duration NAVIGATION_DEBOUNCE = Duration.ofMillis(750);
+    // Same-URL navigations within this window are one navigation delivered twice (racing
+    // channels, or BiDi's commit racing the recorder's own explicit OPEN across a slow load).
+    private static final Duration NAVIGATION_DEBOUNCE = Duration.ofSeconds(10);
+    // A navigation observed this soon after a recorded user interaction is a consequence of that
+    // interaction (link click, form submit, server redirect chain), not a navigation the user
+    // performed: recording it adds a phantom navigateToURL step to the generated test. Only
+    // spontaneous navigations (address bar, the initial open) become steps.
+    private static final Duration INTERACTION_NAVIGATION_WINDOW = Duration.ofSeconds(10);
 
     private final CaptureSessionStore store;
     private final CapturePrivacyClassifier privacy;
@@ -67,6 +74,7 @@ final class CaptureEventPipeline implements AutoCloseable {
     private long sequence;
     private String lastNavigationUrl = "";
     private Instant lastNavigationAt = Instant.EPOCH;
+    private Instant lastInteractionAt = Instant.EPOCH;
     private String lastWindow = "";
     private List<String> lastFramePath = List.of();
     private boolean closed;
@@ -100,6 +108,9 @@ final class CaptureEventPipeline implements AutoCloseable {
         }
         if (isDuplicate(signal)) {
             return;
+        }
+        if (isUserInteraction(signal.kind()) && signal.timestamp().isAfter(lastInteractionAt)) {
+            lastInteractionAt = signal.timestamp();
         }
         try {
             switch (signal.kind()) {
@@ -256,20 +267,33 @@ final class CaptureEventPipeline implements AutoCloseable {
 
     private void emitNavigation(BrowserSignal signal) {
         SafePage page = page(signal);
-        if (page.context().url().equals(lastNavigationUrl)
+        boolean duplicateDelivery = page.context().url().equals(lastNavigationUrl)
                 && Duration.between(lastNavigationAt, signal.timestamp()).abs()
-                .compareTo(NAVIGATION_DEBOUNCE) < 0) {
-            return;
-        }
+                .compareTo(NAVIGATION_DEBOUNCE) < 0;
+        // pushState/replaceState URL rewrites (SPA route changes, results-page canonicalization
+        // like DuckDuckGo appending query flags after a search) are never a user navigation.
+        boolean historyRewrite = "history".equals(signal.dataString("navigationSource"));
+        boolean interactionConsequence = Duration.between(lastInteractionAt, signal.timestamp()).abs()
+                .compareTo(INTERACTION_NAVIGATION_WINDOW) < 0;
         lastNavigationUrl = page.context().url();
         lastNavigationAt = signal.timestamp();
         currentUrlConsumer.accept(page.context().url());
+        if (duplicateDelivery || historyRewrite || interactionConsequence) {
+            return;
+        }
         CaptureEvent.NavigationAction action = enumValue(
                 CaptureEvent.NavigationAction.class,
                 signal.dataString("action"),
                 CaptureEvent.NavigationAction.OPEN);
         append(new CaptureEvent.NavigationEvent(context(signal, page), action, page.context().url()),
                 page.summary(), List.of());
+    }
+
+    private static boolean isUserInteraction(String kind) {
+        return switch (kind) {
+            case "click", "input", "select", "toggle", "upload", "keyboard" -> true;
+            default -> false;
+        };
     }
 
     /**

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
@@ -46,6 +46,11 @@ final class CaptureEventPipeline implements AutoCloseable {
     // performed: recording it adds a phantom navigateToURL step to the generated test. Only
     // spontaneous navigations (address bar, the initial open) become steps.
     private static final Duration INTERACTION_NAVIGATION_WINDOW = Duration.ofSeconds(10);
+    // An overlay-reported user navigation whose URL was appended this recently describes the
+    // navigation a collector already recorded (channels race within milliseconds), so it only
+    // contributes its row identity. Anything older is a distinct user navigation — e.g. pressing
+    // Back to a page whose original open was recorded seconds earlier.
+    private static final Duration OVERLAY_NAVIGATION_ATTACH_WINDOW = Duration.ofSeconds(2);
 
     private final CaptureSessionStore store;
     private final CapturePrivacyClassifier privacy;
@@ -75,6 +80,8 @@ final class CaptureEventPipeline implements AutoCloseable {
     private String lastNavigationUrl = "";
     private Instant lastNavigationAt = Instant.EPOCH;
     private Instant lastInteractionAt = Instant.EPOCH;
+    private String lastAppendedNavigationUrl = "";
+    private Instant lastAppendedNavigationAt = Instant.EPOCH;
     private String lastWindow = "";
     private List<String> lastFramePath = List.of();
     private boolean closed;
@@ -267,26 +274,87 @@ final class CaptureEventPipeline implements AutoCloseable {
 
     private void emitNavigation(BrowserSignal signal) {
         SafePage page = page(signal);
-        boolean duplicateDelivery = page.context().url().equals(lastNavigationUrl)
+        String url = page.context().url();
+        String source = signal.dataString("navigationSource");
+        boolean duplicateDelivery = url.equals(lastNavigationUrl)
                 && Duration.between(lastNavigationAt, signal.timestamp()).abs()
                 .compareTo(NAVIGATION_DEBOUNCE) < 0;
-        // pushState/replaceState URL rewrites (SPA route changes, results-page canonicalization
-        // like DuckDuckGo appending query flags after a search) are never a user navigation.
-        boolean historyRewrite = "history".equals(signal.dataString("navigationSource"));
         boolean interactionConsequence = Duration.between(lastInteractionAt, signal.timestamp()).abs()
                 .compareTo(INTERACTION_NAVIGATION_WINDOW) < 0;
-        lastNavigationUrl = page.context().url();
+        lastNavigationUrl = url;
         lastNavigationAt = signal.timestamp();
-        currentUrlConsumer.accept(page.context().url());
-        if (duplicateDelivery || historyRewrite || interactionConsequence) {
-            return;
+        currentUrlConsumer.accept(url);
+        switch (source) {
+            // pushState/replaceState URL rewrites (SPA route changes, results-page
+            // canonicalization like DuckDuckGo appending query flags after a search) are never
+            // a user navigation.
+            case "history" -> {
+            }
+            // The overlay's "Open" breadcrumb only contributes its row identity to the
+            // already-recorded initial OPEN so the breadcrumb survives server step syncs; it
+            // must never append a second open event.
+            case "user_annotation" -> attachOverlayIdentity(signal, url);
+            // Overlay-observed user navigations (URL poll, back/forward traversal) are
+            // authoritative: back/forward in particular happens right after interactions and
+            // must not be swallowed by the interaction window. If a collector already appended
+            // this navigation, the signal only contributes its row identity.
+            case "user_traversal", "user_reported" -> {
+                boolean recentlyAppended = url.equals(lastAppendedNavigationUrl)
+                        && Duration.between(lastAppendedNavigationAt, signal.timestamp()).abs()
+                        .compareTo(OVERLAY_NAVIGATION_ATTACH_WINDOW) < 0;
+                if (recentlyAppended) {
+                    attachOverlayIdentity(signal, url);
+                } else {
+                    appendNavigation(signal, page, url);
+                }
+            }
+            default -> {
+                if (!duplicateDelivery && !interactionConsequence) {
+                    appendNavigation(signal, page, url);
+                }
+            }
         }
+    }
+
+    private void appendNavigation(BrowserSignal signal, SafePage page, String url) {
         CaptureEvent.NavigationAction action = enumValue(
                 CaptureEvent.NavigationAction.class,
                 signal.dataString("action"),
                 CaptureEvent.NavigationAction.OPEN);
-        append(new CaptureEvent.NavigationEvent(context(signal, page), action, page.context().url()),
+        append(new CaptureEvent.NavigationEvent(context(signal, page), action, url),
                 page.summary(), List.of());
+        lastAppendedNavigationUrl = url;
+        lastAppendedNavigationAt = signal.timestamp();
+    }
+
+    /**
+     * Gives the most recent identity-less recorded navigation to {@code url} the overlay row's
+     * client action id and description, so the row becomes a server-backed step: it survives
+     * step syncs across navigations and can be edited or deleted like any other step.
+     */
+    private void attachOverlayIdentity(BrowserSignal signal, String url) {
+        String clientActionId = privacy.sanitizeText(signal.dataString("clientActionId")).value();
+        if (clientActionId.isBlank()) {
+            return;
+        }
+        String stepDescription = privacy.sanitizeText(signal.dataString("stepDescription")).value();
+        store.updateEvents(events -> {
+            for (int index = events.size() - 1; index >= 0; index--) {
+                if (!(events.get(index) instanceof CaptureEvent.NavigationEvent navigation)
+                        || !navigation.targetUrl().equals(url)
+                        || !extensionText(navigation.context(), "clientActionId").isBlank()) {
+                    continue;
+                }
+                EventContext context = withExtension(navigation.context(), "clientActionId", clientActionId);
+                if (!stepDescription.isBlank()) {
+                    context = withExtension(context, "stepDescription", stepDescription);
+                }
+                List<CaptureEvent> updated = new ArrayList<>(events);
+                updated.set(index, withContext(navigation, context));
+                return updated;
+            }
+            return events;
+        });
     }
 
     private static boolean isUserInteraction(String kind) {
@@ -305,7 +373,10 @@ final class CaptureEventPipeline implements AutoCloseable {
      */
     private boolean suppressDuplicateOrDeletedStep(BrowserSignal signal) {
         boolean oneShotStep = switch (signal.kind()) {
-            case "click", "select", "toggle", "upload", "keyboard", "verification" -> true;
+            // Navigations qualify only when overlay-identified (a blank id falls through
+            // below): collector navigations have no client action id and keep their own
+            // URL-based debounce.
+            case "click", "select", "toggle", "upload", "keyboard", "verification", "navigation" -> true;
             default -> false;
         };
         if (!oneShotStep) {

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java
@@ -421,6 +421,11 @@ class ManagedCaptureRecorder {
         List<String> arguments = new ArrayList<>();
         arguments.add(profileArgument);
         arguments.add("--profile-directory=Default");
+        // A back/forward-cache restore resumes a page whose recorder instance has a dead BiDi
+        // script channel and a loopback sink whose fetches reject, silently losing every signal
+        // the restored page emits (most importantly the user's back/forward navigation itself).
+        // Recording fidelity needs fresh documents; bfcache is only a load-time optimization.
+        arguments.add("--disable-features=BackForwardCache");
         if (!request.options().userAgent().isBlank()) {
             arguments.add("--user-agent=" + request.options().userAgent());
         }
@@ -896,6 +901,8 @@ class ManagedCaptureRecorder {
                     activeDriver,
                     request.options().testIdAttributes(),
                     eventSinkStepsEndpoint(),
+                    eventSinkToken(),
+                    eventSinkEndpoint(),
                     eventSinkToken());
             // The polling collector reads bidiActivityGate to back off its own redundant script
             // round-trips once BiDi is proven healthy; this wrapper is what feeds that gate,

--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -7,8 +7,11 @@
 
   const testIdAttributes = ["data-testid", "data-test", "data-qa"];
   const stepsEndpoint = {url: "", token: ""};
+  // Loopback sink injected at build time so BiDi preload instances also get dual delivery
+  // (script channel + HTTP sink); the fallback installer passes it as the sink argument.
+  const injectedSink = {url: "", token: ""};
   const STORAGE_KEY = "shaft.capture.recorder.ui";
-  const eventSink = sink && typeof sink === "object" ? sink : {};
+  const eventSink = sink && typeof sink === "object" ? sink : injectedSink;
   const text = value => String(value || "").replace(/\s+/g, " ").trim().slice(0, 500);
   const valueText = value => String(value == null ? "" : value).slice(0, 1000);
   const dynamic = value =>
@@ -1866,6 +1869,33 @@
   // them created "Navigate to" rows for navigations the user never performed, e.g. a search
   // redirect landing on the results page counted as two extra navigation actions.
   const INTERACTION_NAVIGATION_WINDOW_MS = 10000;
+  // Announces a user-performed navigation and reports it to the server with this row's client
+  // action id, so the persisted NavigationEvent carries the row's identity: the row then
+  // survives server step syncs and stays editable/deletable like every other step. Sources:
+  // "user_reported" (URL poll), "user_traversal" (back/forward, which the interaction window
+  // must never swallow), and "user_annotation" (the initial "Open" breadcrumb, which only tags
+  // the already-recorded initial OPEN event and must never append a second one).
+  const reportNavigation = (source, breadcrumb) => {
+    if (uiState.stopped || uiState.paused) return;
+    uiState.lastUrl = String(location.href || "");
+    const description = (breadcrumb ? "Open " : "Navigate to ") + visibleLocation();
+    const lastAction = uiState.actions[uiState.actions.length - 1];
+    const data = {action: "OPEN", navigationSource: source};
+    // Redirect hops with the query stripped read identically; one row is the truth.
+    if (!(lastAction && lastAction.text === description)) {
+      if (!breadcrumb) {
+        setReadiness("RISKY", "Step " + uiState.nextId + " needs a follow-up assertion after navigation.");
+      }
+      const item = announce(description);
+      if (item) {
+        data.clientActionId = clientActionId(item);
+        data.stepDescription = item.text;
+      }
+      lastClickEmission = null;
+    }
+    send({kind: "navigation", page: page(), data});
+    persist();
+  };
   if (topLevel) {
     setInterval(() => {
       const current = String(location.href || "");
@@ -1873,19 +1903,46 @@
       uiState.lastUrl = current;
       if (!uiState.stopped && !uiState.paused) {
         const sinceInteraction = Date.now() - uiState.lastInteractionAt;
-        const description = "Navigate to " + visibleLocation();
-        const lastAction = uiState.actions[uiState.actions.length - 1];
-        // Redirect hops with the query stripped read identically; one row is the truth.
-        const repeatsLastRow = Boolean(lastAction && lastAction.text === description);
-        if (sinceInteraction > INTERACTION_NAVIGATION_WINDOW_MS && !repeatsLastRow) {
-          setReadiness("RISKY", "Step " + uiState.nextId + " needs a follow-up assertion after navigation.");
-          announce(description);
+        if (sinceInteraction > INTERACTION_NAVIGATION_WINDOW_MS) {
+          reportNavigation("user_reported", false);
         }
         lastClickEmission = null;
       }
       syncStepsFromServer();
       persist();
     }, 500);
+    // Back/forward is a navigation the user performed, even right after an interaction, so it
+    // bypasses the interaction window. Same-document traversals fire popstate. Cross-document
+    // traversals are detected on pageshow — the one event that fires for both a back/forward
+    // cache restore (persisted=true) and a fresh document, and late enough that the navigation
+    // timing entry (absent at preload time) reliably reports "back_forward".
+    addEventListener("popstate", () => reportNavigation("user_traversal", false), true);
+    addEventListener("pageshow", event => {
+      const freshTraversal = (() => {
+        try {
+          const entry = performance.getEntriesByType
+            && performance.getEntriesByType("navigation")[0];
+          return Boolean(entry && entry.type === "back_forward");
+        } catch (ignored) {
+          return false;
+        }
+      })();
+      if (!event.persisted && !freshTraversal) return;
+      if (event.persisted) {
+        // A bfcache restore resumes this page with its pre-navigation in-memory state; newer
+        // rows recorded on the page the user came back from live in shared storage.
+        const stored = persisted();
+        if (stored && typeof stored === "object" && Array.isArray(stored.actions)) {
+          Object.assign(uiState, stored);
+          uiState.actions = stored.actions.slice(-80);
+          renderActions();
+        }
+      }
+      if (uiState.actions.length > 0) {
+        // A first-ever page skips this — its "Open" breadcrumb already covers the arrival.
+        reportNavigation("user_traversal", false);
+      }
+    }, true);
   }
 
   addEventListener("mousemove", event => {
@@ -2011,13 +2068,13 @@
       syncStepsFromServer();
       setTimeout(() => {
         if (uiState.actions.length === 0) {
-          announce("Open " + visibleLocation());
+          reportNavigation("user_annotation", true);
         }
       }, 400);
     } else {
       syncStepsFromServer();
       if (uiState.actions.length === 0) {
-        announce("Open " + visibleLocation());
+        reportNavigation("user_annotation", true);
       }
     }
   }

--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -42,6 +42,7 @@
   const uiState = {
     paused: false,
     stopped: false,
+    minimized: false,
     assertionMode: false,
     locatorMode: false,
     locatorPreferences: {},
@@ -53,6 +54,7 @@
     instanceId: "",
     currentInputActionKey: "",
     lastUrl: String(location.href || ""),
+    lastInteractionAt: 0,
     ...persisted()
   };
   uiState.actions = Array.isArray(uiState.actions) ? uiState.actions.slice(-80) : [];
@@ -62,6 +64,8 @@
   uiState.currentInputActionKey = text(uiState.currentInputActionKey);
   uiState.assertionMode = Boolean(uiState.assertionMode);
   uiState.locatorMode = Boolean(uiState.locatorMode);
+  uiState.minimized = Boolean(uiState.minimized);
+  uiState.lastInteractionAt = Number(uiState.lastInteractionAt) || 0;
   uiState.locatorPreferences = uiState.locatorPreferences && typeof uiState.locatorPreferences === "object"
     ? uiState.locatorPreferences
     : {};
@@ -78,6 +82,7 @@
       sessionStorage.setItem(STORAGE_KEY, JSON.stringify({
         paused: uiState.paused,
         stopped: uiState.stopped,
+        minimized: uiState.minimized,
         assertionMode: uiState.assertionMode,
         locatorMode: uiState.locatorMode,
         locatorPreferences: uiState.locatorPreferences,
@@ -88,7 +93,8 @@
         nextId: uiState.nextId,
         instanceId: uiState.instanceId,
         currentInputActionKey: uiState.currentInputActionKey,
-        lastUrl: uiState.lastUrl
+        lastUrl: uiState.lastUrl,
+        lastInteractionAt: uiState.lastInteractionAt
       }));
     } catch (ignored) {
       // Storage can be unavailable in sandboxed frames.
@@ -150,8 +156,12 @@
       });
   };
   const applyServerSteps = steps => {
+    // Keyed by the same client action id the server persisted (locally announced rows carry it
+    // as instanceId-id, rehydrated rows as remoteId), so a sync preserves the local row object
+    // and its details (locator summary, quick-assert target, warnings) instead of replacing
+    // every recorded row with a details-less skeleton after each navigation.
     const localByRemoteId = new Map(
-      uiState.actions.filter(item => item.remoteId).map(item => [item.remoteId, item]));
+      uiState.actions.map(item => [clientActionId(item), item]));
     const merged = steps
       .filter(step => step && step.clientActionId)
       .sort((left, right) => Number(left.sequence || 0) - Number(right.sequence || 0))
@@ -624,6 +634,9 @@
     if (document.getElementById("shaft-capture-assertion-panel")) return;
     const target = snapshot(event);
     if (target) {
+      // Navigations observed shortly after this moment are consequences of this interaction
+      // (link click, form submit, redirect chain), not navigations the user performed.
+      uiState.lastInteractionAt = Date.now();
       const action = data || {};
       if (kind === "input") {
         const currentValue = String(action.value || "");
@@ -1132,6 +1145,19 @@
         font: 13px/1.35 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       }
       #shaft-capture-ui * { box-sizing: border-box; font: inherit; letter-spacing: 0; }
+      /* Minimized: only the header toolbar stays, so the page underneath is usable while
+         recording continues; the title carries the live step count. */
+      #shaft-capture-ui[data-minimized="true"] { height: auto; }
+      #shaft-capture-ui[data-minimized="true"] .status-chip,
+      #shaft-capture-ui[data-minimized="true"] #shaft-capture-locator-panel,
+      #shaft-capture-ui[data-minimized="true"] #shaft-capture-actions,
+      #shaft-capture-ui[data-minimized="true"] #shaft-capture-dialog,
+      #shaft-capture-ui[data-minimized="true"] #shaft-capture-assertion-panel { display: none; }
+      #shaft-capture-empty-hint {
+        margin: 2px 0 0;
+        color: var(--shaft-text-muted);
+        font-size: 12px;
+      }
       #shaft-capture-assertion-banner {
         position: fixed;
         top: 16px;
@@ -1451,6 +1477,14 @@
     const pick = document.getElementById("shaft-capture-pick");
     const stop = document.getElementById("shaft-capture-stop");
     if (!status || !pause || !assert || !pick || !stop) return;
+    // Assertion and locator flows render inside the panel body; a minimized panel would hide
+    // the very UI those modes are waiting on, so entering either mode expands the panel.
+    if (uiState.minimized
+        && (uiState.assertionMode || uiState.locatorMode
+          || document.getElementById("shaft-capture-assertion-panel"))) {
+      uiState.minimized = false;
+      persist();
+    }
     if ((uiState.stopped || uiState.paused) && uiState.locatorMode) {
       uiState.locatorMode = false;
       clearLocatorHighlight();
@@ -1490,6 +1524,25 @@
     pick.setAttribute("aria-pressed", String(uiState.locatorMode));
     pick.disabled = uiState.stopped || uiState.paused;
     stop.disabled = uiState.stopped;
+    const panel = document.getElementById("shaft-capture-ui");
+    if (panel) panel.dataset.minimized = String(uiState.minimized);
+    const minimize = document.getElementById("shaft-capture-minimize");
+    if (minimize) {
+      minimize.innerHTML = icon(uiState.minimized ? "up" : "down");
+      minimize.title = uiState.minimized ? "Expand the recorder panel" : "Minimize the recorder panel";
+      minimize.setAttribute("aria-label", minimize.title);
+      minimize.setAttribute("aria-expanded", String(!uiState.minimized));
+    }
+    const title = document.getElementById("shaft-capture-title");
+    if (title) {
+      // The step count stays visible while minimized so recording progress is never hidden.
+      title.textContent = uiState.minimized
+        ? "SHAFT Capture · " + uiState.actions.length
+          + (uiState.actions.length === 1 ? " step" : " steps")
+        : "SHAFT Capture";
+    }
+    const emptyHint = document.getElementById("shaft-capture-empty-hint");
+    if (emptyHint) emptyHint.hidden = uiState.actions.length > 0;
   };
   const editAction = item => {
     showDialog("Edit captured action", [
@@ -1730,15 +1783,16 @@
     panel.innerHTML = `
       <header>
         <span class="brand-mark" aria-hidden="true">S</span>
-        <strong>SHAFT Capture</strong>
+        <strong id="shaft-capture-title">SHAFT Capture</strong>
         <button id="shaft-capture-pause" type="button"></button>
         <button id="shaft-capture-assert" type="button" title="Add assertion" aria-label="Add assertion" aria-pressed="false">${icon("assert")}</button>
         <button id="shaft-capture-pick" type="button" title="Toggle locator picker" aria-label="Toggle locator picker" aria-pressed="false">${icon("locator")}</button>
         <button id="shaft-capture-stop" type="button" title="Stop recording" aria-label="Stop recording">${icon("stop")}</button>
+        <button id="shaft-capture-minimize" type="button" aria-expanded="true"></button>
       </header>
       <div id="shaft-capture-status" class="status-chip shaft-capture-readiness"></div>
       <div id="shaft-capture-locator-panel" hidden></div>
-      <div id="shaft-capture-actions"><ol id="shaft-capture-action-list"></ol></div>
+      <div id="shaft-capture-actions"><p id="shaft-capture-empty-hint" hidden>No steps yet. Click, type, and navigate in this page &mdash; every action is recorded here as an editable step.</p><ol id="shaft-capture-action-list"></ol></div>
     `;
     document.body.appendChild(panel);
     document.getElementById("shaft-capture-pause").addEventListener("click", () => {
@@ -1792,6 +1846,11 @@
       sendControl("STOP");
       setStatus();
     });
+    document.getElementById("shaft-capture-minimize").addEventListener("click", () => {
+      uiState.minimized = !uiState.minimized;
+      persist();
+      setStatus();
+    });
     renderActions();
   };
   const schedulePanel = () => {
@@ -1802,14 +1861,26 @@
   };
   // Only the top-level frame polls for navigations: a subframe URL change is never a user
   // navigation step, and announcing it produced phantom "Navigate to" rows (#3432).
+  // Navigations observed within this window after a recorded interaction are consequences of
+  // that interaction (link click, form submit, server redirect, history rewrite) — announcing
+  // them created "Navigate to" rows for navigations the user never performed, e.g. a search
+  // redirect landing on the results page counted as two extra navigation actions.
+  const INTERACTION_NAVIGATION_WINDOW_MS = 10000;
   if (topLevel) {
     setInterval(() => {
       const current = String(location.href || "");
       if (current === uiState.lastUrl) return;
       uiState.lastUrl = current;
       if (!uiState.stopped && !uiState.paused) {
-        setReadiness("RISKY", "Step " + uiState.nextId + " needs a follow-up assertion after navigation.");
-        announce("Navigate to " + visibleLocation());
+        const sinceInteraction = Date.now() - uiState.lastInteractionAt;
+        const description = "Navigate to " + visibleLocation();
+        const lastAction = uiState.actions[uiState.actions.length - 1];
+        // Redirect hops with the query stripped read identically; one row is the truth.
+        const repeatsLastRow = Boolean(lastAction && lastAction.text === description);
+        if (sinceInteraction > INTERACTION_NAVIGATION_WINDOW_MS && !repeatsLastRow) {
+          setReadiness("RISKY", "Step " + uiState.nextId + " needs a follow-up assertion after navigation.");
+          announce(description);
+        }
         lastClickEmission = null;
       }
       syncStepsFromServer();

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
@@ -486,6 +486,98 @@ class CaptureEventPipelineTest {
     }
 
     @Test
+    void recordsBackForwardTraversalDespiteRecentInteraction(@TempDir Path temp) {
+        // Back/forward is a navigation the user performed even right after an interaction, so
+        // the overlay reports it as user_traversal and the interaction window must not swallow
+        // it. The overlay row's client action id rides along, making the row a server-backed
+        // step that survives step syncs.
+        Path output = temp.resolve("session.json");
+        CaptureSessionStore store = startedStore(output);
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store, output, CapturePrivacyPolicy.defaults(), ignored -> {
+                }, ignored -> {
+                });
+
+        pipeline.accept(signal("navigation", START, Map.of(),
+                Map.of("action", "OPEN"), Map.of("url", "https://example.test/a")));
+        pipeline.accept(signal("click", START.plusSeconds(3), buttonTarget(),
+                Map.of("button", 0, "clickCount", 1), Map.of()));
+        pipeline.accept(signal("navigation", START.plusSeconds(4), Map.of(),
+                Map.of("action", "OPEN"), Map.of("url", "https://example.test/b")));
+        pipeline.accept(signal("navigation", START.plusSeconds(6), Map.of(),
+                Map.of("action", "OPEN", "navigationSource", "user_traversal",
+                        "clientActionId", "traversal-9", "stepDescription", "Navigate to https://example.test/a"),
+                Map.of("url", "https://example.test/a")));
+        pipeline.close();
+
+        List<CaptureEvent.NavigationEvent> navigations = store.read().events().stream()
+                .filter(CaptureEvent.NavigationEvent.class::isInstance)
+                .map(CaptureEvent.NavigationEvent.class::cast)
+                .toList();
+        assertEquals(2, navigations.size(),
+                "The click-consequence navigation is suppressed but the user's back traversal "
+                        + "must be recorded.");
+        assertEquals("https://example.test/a", navigations.get(1).targetUrl());
+        assertEquals("traversal-9",
+                navigations.get(1).context().extensions().get("clientActionId").asText());
+        assertTrue(store.steps().stream()
+                        .anyMatch(step -> "traversal-9".equals(step.clientActionId())),
+                "The traversal must surface in the server-backed step list.");
+    }
+
+    @Test
+    void overlayReportAttachesIdentityToFreshlyRecordedNavigation(@TempDir Path temp) {
+        // The overlay's "Open" breadcrumb (and any overlay-reported navigation a collector beat
+        // it to) only contributes its row identity to the already-recorded event, so the row
+        // survives step syncs without ever appending a duplicate navigation.
+        Path output = temp.resolve("session.json");
+        CaptureSessionStore store = startedStore(output);
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store, output, CapturePrivacyPolicy.defaults(), ignored -> {
+                }, ignored -> {
+                });
+
+        pipeline.accept(signal("navigation", START, Map.of(),
+                Map.of("action", "OPEN"), Map.of("url", "https://example.test/home")));
+        pipeline.accept(signal("navigation", START.plusMillis(600), Map.of(),
+                Map.of("action", "OPEN", "navigationSource", "user_annotation",
+                        "clientActionId", "open-1", "stepDescription", "Open https://example.test/home"),
+                Map.of("url", "https://example.test/home")));
+        pipeline.close();
+
+        List<CaptureEvent> events = store.read().events();
+        assertEquals(1, events.size(), "The annotation must never append a second open event.");
+        CaptureEvent.NavigationEvent navigation =
+                assertInstanceOf(CaptureEvent.NavigationEvent.class, events.getFirst());
+        assertEquals("open-1", navigation.context().extensions().get("clientActionId").asText());
+        assertEquals("Open https://example.test/home",
+                navigation.context().extensions().get("stepDescription").asText());
+        assertEquals(1, store.steps().size());
+    }
+
+    @Test
+    void deletedOverlayNavigationStaysDeletedWhenRevocationOvertakesTheSignal(@TempDir Path temp) {
+        Path output = temp.resolve("session.json");
+        CaptureSessionStore store = startedStore(output);
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store, output, CapturePrivacyPolicy.defaults(), ignored -> {
+                }, ignored -> {
+                });
+
+        pipeline.accept(signal("step_delete", START, Map.of(),
+                Map.of("clientActionId", "traversal-4"), Map.of()));
+        pipeline.accept(signal("navigation", START.plusSeconds(1), Map.of(),
+                Map.of("action", "OPEN", "navigationSource", "user_traversal",
+                        "clientActionId", "traversal-4"),
+                Map.of("url", "https://example.test/back")));
+        pipeline.close();
+
+        assertEquals(0, store.read().events().size(),
+                "A deleted overlay navigation must stay deleted even when the revocation "
+                        + "overtakes the navigation signal across channels.");
+    }
+
+    @Test
     void debouncesSameUrlNavigationRedeliveredAcrossChannels(@TempDir Path temp) {
         // BiDi's navigationCommitted and the recorder's own explicit OPEN signal describe the
         // same navigation; across a slow page load they can arrive several seconds apart.

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
@@ -405,14 +405,104 @@ class CaptureEventPipelineTest {
                 Map.of("button", 0, "clickCount", 1, "clientActionId", "ui-2"),
                 Map.of("domSnapshot", "<html><body><button id=\"submit\">Save</button>"
                         + "<span>bearer abcdefghijklmnop</span></body></html>")));
+        // The navigation flushes the debounced click immediately; it is itself a consequence of
+        // that click (within the interaction window) so it never becomes a recorded step.
         pipeline.accept(signal("navigation", START.plusMillis(1), Map.of(),
                 Map.of("action", "OPEN"), Map.of("url", "https://example.test/next")));
 
         CaptureSession session = store.read();
-        assertEquals(2, session.events().size());
+        assertEquals(1, session.events().size());
         String dom = session.events().getFirst().context().extensions().get("domSnapshot").asText();
         assertTrue(dom.contains("button id=\"submit\""));
         assertFalse(dom.contains("abcdefghijklmnop"));
+    }
+
+    @Test
+    void suppressesNavigationsCausedByRecentInteractions(@TempDir Path temp) {
+        // A navigation shortly after a user interaction (link click, form submit, server redirect
+        // chain) is a consequence of that interaction, not a navigation the user performed;
+        // recording it generated a phantom navigateToURL step. Spontaneous navigations (address
+        // bar, initial open) must still be recorded.
+        Path output = temp.resolve("session.json");
+        CaptureSessionStore store = startedStore(output);
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store, output, CapturePrivacyPolicy.defaults(), ignored -> {
+                }, ignored -> {
+                });
+
+        pipeline.accept(signal("navigation", START, Map.of(),
+                Map.of("action", "OPEN"), Map.of("url", "https://example.test/home")));
+        pipeline.accept(signal("click", START.plusSeconds(2), buttonTarget(),
+                Map.of("button", 0, "clickCount", 1), Map.of()));
+        // Submit response page plus its redirect hop: both within the interaction window.
+        pipeline.accept(signal("navigation", START.plusSeconds(3), Map.of(),
+                Map.of("action", "OPEN"), Map.of("url", "https://example.test/search?q=x")));
+        pipeline.accept(signal("navigation", START.plusSeconds(4), Map.of(),
+                Map.of("action", "OPEN"), Map.of("url", "https://example.test/results?q=x")));
+        // Long after the last interaction: a genuine user navigation, recorded.
+        pipeline.accept(signal("navigation", START.plusSeconds(60), Map.of(),
+                Map.of("action", "OPEN"), Map.of("url", "https://example.test/pricing")));
+        pipeline.close();
+
+        List<CaptureEvent> events = store.read().events();
+        List<CaptureEvent.NavigationEvent> navigations = events.stream()
+                .filter(CaptureEvent.NavigationEvent.class::isInstance)
+                .map(CaptureEvent.NavigationEvent.class::cast)
+                .toList();
+        assertEquals(2, navigations.size(),
+                "Only the initial open and the spontaneous navigation are user steps; "
+                        + "interaction-consequence navigations must be suppressed.");
+        assertEquals("https://example.test/home", navigations.get(0).targetUrl());
+        assertEquals("https://example.test/pricing", navigations.get(1).targetUrl());
+        assertEquals(1, events.stream().filter(CaptureEvent.ClickEvent.class::isInstance).count());
+    }
+
+    @Test
+    void neverRecordsHistoryRewriteNavigationsAsSteps(@TempDir Path temp) {
+        // pushState/replaceState URL rewrites (SPA routes, results-page canonicalization such as
+        // DuckDuckGo appending query flags after a search) are tagged navigationSource=history by
+        // the BiDi collector and must never become navigation steps, even with no recent
+        // interaction.
+        Path output = temp.resolve("session.json");
+        CaptureSessionStore store = startedStore(output);
+        java.util.concurrent.atomic.AtomicReference<String> currentUrl = new java.util.concurrent.atomic.AtomicReference<>("");
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store, output, CapturePrivacyPolicy.defaults(), currentUrl::set, ignored -> {
+                });
+
+        pipeline.accept(signal("navigation", START, Map.of(),
+                Map.of("action", "OPEN"), Map.of("url", "https://example.test/results")));
+        pipeline.accept(signal("navigation", START.plusSeconds(30), Map.of(),
+                Map.of("action", "OPEN", "navigationSource", "history"),
+                Map.of("url", "https://example.test/results?ia=web")));
+        pipeline.close();
+
+        List<CaptureEvent> events = store.read().events();
+        assertEquals(1, events.size());
+        assertEquals("https://example.test/results",
+                assertInstanceOf(CaptureEvent.NavigationEvent.class, events.getFirst()).targetUrl());
+        assertEquals("https://example.test/results?ia=web", currentUrl.get(),
+                "History rewrites must still refresh the reported current URL.");
+    }
+
+    @Test
+    void debouncesSameUrlNavigationRedeliveredAcrossChannels(@TempDir Path temp) {
+        // BiDi's navigationCommitted and the recorder's own explicit OPEN signal describe the
+        // same navigation; across a slow page load they can arrive several seconds apart.
+        Path output = temp.resolve("session.json");
+        CaptureSessionStore store = startedStore(output);
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store, output, CapturePrivacyPolicy.defaults(), ignored -> {
+                }, ignored -> {
+                });
+
+        pipeline.accept(signal("navigation", START, Map.of(),
+                Map.of("action", "OPEN"), Map.of("url", "https://example.test/home")));
+        pipeline.accept(signal("navigation", START.plusSeconds(4), Map.of(),
+                Map.of("action", "OPEN"), Map.of("url", "https://example.test/home")));
+        pipeline.close();
+
+        assertEquals(1, store.read().events().size());
     }
 
     @Test
@@ -426,8 +516,8 @@ class CaptureEventPipelineTest {
 
         pipeline.accept(signal("click", START, buttonTarget(),
                 Map.of("button", 0, "clickCount", 1, "clientActionId", "ui-3"), Map.of()));
-        pipeline.accept(signal("navigation", START.plusMillis(1), Map.of(),
-                Map.of("action", "OPEN"), Map.of("url", "https://example.test/next")));
+        pipeline.accept(signal("keyboard", START.plusMillis(1), buttonTarget(),
+                Map.of("keys", List.of("CONTROL", "S")), Map.of()));
         pipeline.accept(signal("step_update", START.plusMillis(2), Map.of(),
                 Map.of("clientActionId", "ui-3", "description", "Click primary submit"), Map.of()));
 
@@ -440,7 +530,7 @@ class CaptureEventPipelineTest {
 
         CaptureSession deleted = store.read();
         assertEquals(1, deleted.events().size());
-        assertInstanceOf(CaptureEvent.NavigationEvent.class, deleted.events().getFirst());
+        assertInstanceOf(CaptureEvent.KeyboardEvent.class, deleted.events().getFirst());
     }
 
     @Test

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
@@ -530,6 +530,145 @@ class ManagedCaptureRecorderBrowserTest {
         }
     }
 
+    /**
+     * Realistic search journey against a search-engine-style fixture: type a query, press Enter
+     * (GET form submit), get 302-redirected to the results page, which then canonicalizes its own
+     * URL via {@code history.replaceState}, then click a result link. None of those page changes
+     * were performed by the user as navigations — the reported bug was the recorder announcing
+     * two "Navigate to" actions for the search redirect alone — so:
+     * <ul>
+     *   <li>the overlay must show zero "Navigate to" rows,</li>
+     *   <li>the persisted session must contain exactly one NavigationEvent (the initial open),</li>
+     *   <li>generated code must contain exactly one {@code navigateToURL} call.</li>
+     * </ul>
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"chrome", "edge"})
+    void searchRedirectJourneyRecordsOnlyUserPerformedSteps(
+            String browserName,
+            @TempDir Path temp) throws Exception {
+        HttpServer server = localFixture();
+        String baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+        Path output = temp.resolve(browserName + "-search-redirect.json");
+        ManagedCaptureRecorder recorder = new ManagedCaptureRecorder(new CaptureStartRequest(
+                baseUrl + "/search-home",
+                CaptureBrowser.parse(browserName),
+                output,
+                temp.resolve(browserName + "-search-redirect-runtime"),
+                true));
+        try {
+            recorder.start();
+            WebDriver driver = recorder.driverForTesting();
+            JavascriptExecutor js = (JavascriptExecutor) driver;
+            waitFor(() -> elementPresent(driver, By.id("q")));
+
+            driver.findElement(By.id("q")).sendKeys("shaft engine");
+            driver.findElement(By.id("q")).sendKeys(org.openqa.selenium.Keys.ENTER);
+            waitFor(() -> elementPresent(driver, By.id("result-link")));
+            waitFor(() -> String.valueOf(driver.getCurrentUrl()).contains("ia=web"));
+            driver.findElement(By.id("result-link")).click();
+            waitFor(() -> elementPresent(driver, By.id("detail-page")));
+
+            // Several 500ms poll ticks so a reintroduced consequence-navigation announcement has
+            // every chance to fire before the count is asserted.
+            Thread.sleep(2000);
+            assertEquals(0, navigateRowCount(js),
+                    "Form-submit redirects, history rewrites, and link-click navigations are "
+                            + "consequences of recorded interactions, never their own \"Navigate "
+                            + "to\" actions. Rows: " + actionRowTexts(js));
+
+            recorder.stop(false);
+        } finally {
+            if (recorder.status().state() == CaptureStatus.State.ACTIVE) {
+                recorder.interrupt();
+            }
+            server.stop(0);
+        }
+
+        CaptureSession session = new CaptureJsonCodec().read(output);
+        List<CaptureEvent.NavigationEvent> navigations = session.events().stream()
+                .filter(CaptureEvent.NavigationEvent.class::isInstance)
+                .map(CaptureEvent.NavigationEvent.class::cast)
+                .toList();
+        assertEquals(1, navigations.size(),
+                "Exactly one NavigationEvent (the initial open) must be persisted for the whole "
+                        + "search journey; got: "
+                        + navigations.stream().map(CaptureEvent.NavigationEvent::targetUrl).toList());
+        assertTrue(navigations.getFirst().targetUrl().contains("/search-home"));
+        assertTrue(session.events().stream().anyMatch(CaptureEvent.TypeEvent.class::isInstance),
+                "The typed search query must be recorded.");
+        assertTrue(session.events().stream().anyMatch(event ->
+                        event instanceof CaptureEvent.ClickEvent click
+                                && "result-link".equals(click.target().logicalElementId())),
+                "The result-link click must be recorded.");
+
+        com.shaft.capture.generate.CaptureGenerationResult generated =
+                new com.shaft.capture.generate.CaptureGenerator().generate(
+                        new com.shaft.capture.generate.CaptureGenerationRequest(
+                                output, temp.resolve(browserName + "-generated"),
+                                "generated.capture", "", false,
+                                false, false, Duration.ofMinutes(1),
+                                com.shaft.capture.generate.CaptureGenerationRequest.EnrichmentMode.NONE,
+                                null, false,
+                                com.shaft.pilot.ai.ApprovalPolicy.denyAll()));
+        assertTrue(generated.successful(),
+                "Codegen must succeed for the recorded search journey: "
+                        + generated.report().unsupportedEvents());
+        String source = Files.readString(generated.sourcePath(), StandardCharsets.UTF_8);
+        long navigateCalls = source.split(java.util.regex.Pattern.quote("navigateToURL("), -1).length - 1L;
+        assertEquals(1, navigateCalls,
+                "Generated code must open the start URL exactly once and drive everything else "
+                        + "through the recorded interactions.");
+    }
+
+    /**
+     * The minimize control collapses the panel to its header toolbar so the page underneath
+     * stays usable, while recording continues and the header keeps a live step count; expanding
+     * restores the full step list.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"chrome", "edge"})
+    void overlayMinimizeKeepsRecordingWhilePanelBodyIsCollapsed(
+            String browserName,
+            @TempDir Path temp) throws Exception {
+        HttpServer server = localFixture();
+        Path output = temp.resolve(browserName + "-minimize.json");
+        ManagedCaptureRecorder recorder = new ManagedCaptureRecorder(new CaptureStartRequest(
+                "http://127.0.0.1:" + server.getAddress().getPort() + "/",
+                CaptureBrowser.parse(browserName),
+                output,
+                temp.resolve(browserName + "-minimize-runtime"),
+                true));
+        try {
+            recorder.start();
+            WebDriver driver = recorder.driverForTesting();
+            waitFor(() -> elementPresent(driver, By.id("shaft-capture-minimize")));
+
+            driver.findElement(By.id("shaft-capture-minimize")).click();
+            waitFor(() -> !driver.findElement(By.id("shaft-capture-actions")).isDisplayed());
+            assertTrue(driver.findElement(By.id("shaft-capture-title")).getText().contains("step"),
+                    "The minimized header must keep a live step count visible.");
+
+            driver.findElement(By.id("terms")).click();
+            waitFor(() -> stepDescriptions(recorder).stream()
+                    .anyMatch(description -> description.contains("Terms")));
+            assertFalse(driver.findElement(By.id("shaft-capture-actions")).isDisplayed(),
+                    "Recording an action must not expand the minimized panel.");
+
+            driver.findElement(By.id("shaft-capture-minimize")).click();
+            waitFor(() -> driver.findElement(By.id("shaft-capture-actions")).isDisplayed());
+            assertTrue(driver.findElement(By.id("shaft-capture-action-list")).getText().contains("Terms"),
+                    "Expanding must restore the full recorded step list.");
+
+            recorder.stop(false);
+        } finally {
+            if (recorder.status().state() == CaptureStatus.State.ACTIVE) {
+                recorder.interrupt();
+            }
+            server.stop(0);
+        }
+    }
+
     private static double assertButtonTop(JavascriptExecutor js) {
         Object value = js.executeScript(
                 "return document.getElementById('shaft-capture-assert').getBoundingClientRect().top;");
@@ -675,6 +814,41 @@ class ManagedCaptureRecorderBrowserTest {
         });
         server.createContext("/popup", exchange -> respond(exchange,
                 "<!doctype html><title>Popup</title><p>Popup</p>"));
+        // Search-engine-style redirect chain (issue: DuckDuckGo search recorded two navigation
+        // actions the user never performed): a GET form submit that 302-redirects to a results
+        // page which then canonicalizes its own URL with history.replaceState.
+        server.createContext("/search-home", exchange -> respond(exchange, """
+                <!doctype html>
+                <html>
+                <head><title>Search Fixture</title></head>
+                <body>
+                  <form action="/search" method="get">
+                    <input id="q" name="q" placeholder="Search">
+                  </form>
+                </body>
+                </html>
+                """));
+        server.createContext("/search", exchange -> {
+            String query = exchange.getRequestURI().getRawQuery();
+            exchange.getResponseHeaders().set("Location",
+                    "/results" + (query == null || query.isBlank() ? "" : "?" + query));
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+        });
+        server.createContext("/results", exchange -> respond(exchange, """
+                <!doctype html>
+                <html>
+                <head><title>Results</title></head>
+                <body>
+                  <a id="result-link" href="/detail">Result detail</a>
+                  <script>
+                    history.replaceState(null, "", location.pathname + location.search + "&ia=web");
+                  </script>
+                </body>
+                </html>
+                """));
+        server.createContext("/detail", exchange -> respond(exchange,
+                "<!doctype html><title>Detail</title><p id=\"detail-page\">Detail</p>"));
         server.start();
         return server;
     }

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
@@ -622,6 +622,78 @@ class ManagedCaptureRecorderBrowserTest {
     }
 
     /**
+     * Back/forward traversals are navigations the user performed, and they typically happen
+     * within seconds of a recorded interaction — the interaction-consequence window must not
+     * swallow them (they were silently dropped when the consequence suppression first landed).
+     * The journey clicks a link, presses Back, then Forward, and expects:
+     * <ul>
+     *   <li>the click-consequence navigation to B stays suppressed,</li>
+     *   <li>both traversals are recorded as navigation events carrying the overlay row's
+     *       identity (so the rows survive step syncs),</li>
+     *   <li>generated code replays open + back-target + forward-target navigations.</li>
+     * </ul>
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"chrome", "edge"})
+    void backForwardJourneyRecordsUserTraversals(
+            String browserName,
+            @TempDir Path temp) throws Exception {
+        HttpServer server = localFixture();
+        String baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+        Path output = temp.resolve(browserName + "-traversal.json");
+        ManagedCaptureRecorder recorder = new ManagedCaptureRecorder(new CaptureStartRequest(
+                baseUrl + "/nav-a",
+                CaptureBrowser.parse(browserName),
+                output,
+                temp.resolve(browserName + "-traversal-runtime"),
+                true));
+        try {
+            recorder.start();
+            WebDriver driver = recorder.driverForTesting();
+            JavascriptExecutor js = (JavascriptExecutor) driver;
+            waitFor(() -> elementPresent(driver, By.id("to-b")));
+
+            driver.findElement(By.id("to-b")).click();
+            waitFor(() -> elementPresent(driver, By.id("nav-b-page")));
+            // Dwell past the overlay-identity attach window so the Back traversal to /nav-a is
+            // a distinct user navigation rather than a redelivery of the initial open.
+            Thread.sleep(2500);
+            driver.navigate().back();
+            waitFor(() -> elementPresent(driver, By.id("to-b")));
+            Thread.sleep(1000);
+            driver.navigate().forward();
+            waitFor(() -> elementPresent(driver, By.id("nav-b-page")));
+            Thread.sleep(2000);
+
+            assertEquals(2, navigateRowCount(js),
+                    "Back and Forward must each append exactly one \"Navigate to\" row. Rows: "
+                            + actionRowTexts(js));
+
+            recorder.stop(false);
+        } finally {
+            if (recorder.status().state() == CaptureStatus.State.ACTIVE) {
+                recorder.interrupt();
+            }
+            server.stop(0);
+        }
+
+        CaptureSession session = new CaptureJsonCodec().read(output);
+        List<String> navigationUrls = session.events().stream()
+                .filter(CaptureEvent.NavigationEvent.class::isInstance)
+                .map(CaptureEvent.NavigationEvent.class::cast)
+                .map(CaptureEvent.NavigationEvent::targetUrl)
+                .toList();
+        assertEquals(3, navigationUrls.size(),
+                "Initial open plus the two traversals must be recorded (and the click "
+                        + "consequence suppressed); got: " + navigationUrls);
+        assertTrue(navigationUrls.get(0).contains("/nav-a"));
+        assertTrue(navigationUrls.get(1).contains("/nav-a"),
+                "The Back traversal to /nav-a must be recorded.");
+        assertTrue(navigationUrls.get(2).contains("/nav-b"),
+                "The Forward traversal to /nav-b must be recorded.");
+    }
+
+    /**
      * The minimize control collapses the panel to its header toolbar so the page underneath
      * stays usable, while recording continues and the header keeps a live step count; expanding
      * restores the full step list.
@@ -849,6 +921,10 @@ class ManagedCaptureRecorderBrowserTest {
                 """));
         server.createContext("/detail", exchange -> respond(exchange,
                 "<!doctype html><title>Detail</title><p id=\"detail-page\">Detail</p>"));
+        server.createContext("/nav-a", exchange -> respond(exchange,
+                "<!doctype html><title>Nav A</title><a id=\"to-b\" href=\"/nav-b\">Go to B</a>"));
+        server.createContext("/nav-b", exchange -> respond(exchange,
+                "<!doctype html><title>Nav B</title><p id=\"nav-b-page\">B</p>"));
         server.start();
         return server;
     }


### PR DESCRIPTION
## Problem

Searching on DuckDuckGo (or any redirect-based flow) made the recorder show **two "Navigate to" actions the user never performed**, and generated tests gained matching phantom `navigateToURL(...)` calls. Root causes ran through all three layers:

- `BidiBrowserEventCollector` recorded a NavigationEvent for every `navigationCommitted` **and** `historyUpdated` (DuckDuckGo canonicalizes its results URL via `history.replaceState`), on any frame.
- Every NavigationEvent becomes `driver.browser().navigateToURL(...)` in generated code — click/Enter-caused navigations were recorded as if the user typed a URL.
- The overlay separately announced every same-origin URL change from its 500ms poll.

## Fix (Playwright-codegen semantics: navigations caused by interactions are consequences, not steps)

- **Pipeline**: navigations within 10s of a recorded interaction are suppressed; `historyUpdated` rewrites and subframe navigations are never steps; same-URL redeliveries debounce across a 10s window (BiDi commit vs the recorder's explicit OPEN across slow loads).
- **Back/forward is still a user action**: the overlay reports traversals (`popstate` + `pageshow`, where the navigation timing entry is reliably populated) as authoritative signals that bypass the interaction window.
- **Navigation rows are now server-backed steps**: overlay-announced navigations carry a `clientActionId` that the pipeline appends or attaches to the recorded event — rows survive step syncs and are editable/deletable like any step.
- **Delivery hardening** (found by the new journeys): the BiDi preload recorder instance now gets the loopback sink injected (dual-channel delivery), and the managed browser disables the back/forward cache — a bfcache-restored page loses both its BiDi script channel and its sink fetches, stranding every signal it emits.

## Overlay UX

- **Minimize** control collapses the panel to its toolbar with a live step count, so the page underneath stays usable while recording continues.
- **Empty-state hint** explains what will be recorded.
- Step syncs preserve local row details (locator summary, quick-assert target) instead of replacing rows with skeletons.

## Verification

- New real-browser e2e journeys (Chrome + Edge): search-engine-style redirect chain (302 + `replaceState`) records exactly **one** NavigationEvent and one generated `navigateToURL`; back/forward journey records both traversals (3 consecutive stable runs); minimize keeps recording while collapsed.
- Live probe against **real duckduckgo.com**: overlay shows `Open → Type → Press ENTER` with zero phantom navigation rows; session has exactly 1 NavigationEvent.
- Full recorder e2e suite 16/16; full shaft-capture unit suite 257/257 (incl. 6 new pipeline tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)