### PR TITLE
feat(validation): matchesScreenshot() executes immediately — no perform() required

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -1237,7 +1237,7 @@ public final class CaptureGenerator {
             case ARIA_SNAPSHOT_MATCHES -> line(source, "        driver.element().assertThat(" + locator
                     + ").matchesAriaSnapshot(" + dataExpression(expected, data) + ");");
             case SCREENSHOT_MATCHES -> line(source, "        driver.element().assertThat(" + locator
-                    + ").matchesScreenshot().perform();");
+                    + ").matchesScreenshot();");
         }
     }
 

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -569,7 +569,7 @@ class CaptureGeneratorTest {
                 "driver.element().assertThat(SHAFT.GUI.Locator.inputField(\"Username\"))"
                         + ".matchesAriaSnapshot(requiredData(\"username\"));"));
         assertTrue(source.contains(
-                "driver.element().assertThat(SHAFT.GUI.Locator.inputField(\"Username\")).matchesScreenshot().perform();"));
+                "driver.element().assertThat(SHAFT.GUI.Locator.inputField(\"Username\")).matchesScreenshot();"));
     }
 
     @Test

--- a/shaft-engine/src/main/java/com/shaft/gui/driver/BrowserAssertions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/driver/BrowserAssertions.java
@@ -1,7 +1,8 @@
 package com.shaft.gui.driver;
 
+import com.shaft.validation.VisualComparisonOptions;
 import com.shaft.validation.internal.NativeValidationsBuilder;
-import com.shaft.validation.internal.VisualValidationsBuilder;
+import com.shaft.validation.internal.ValidationsExecutor;
 
 /**
  * Public contract for browser-level hard/soft validation starters.
@@ -25,11 +26,23 @@ public interface BrowserAssertions {
     NativeValidationsBuilder text();
 
     /**
-     * Starts a visual-regression assertion against the current page's baseline full-page screenshot.
+     * Asserts that the current page matches its baseline full-page screenshot. Executes immediately,
+     * like every other assertion &mdash; no {@code perform()} is required.
      *
-     * @return a VisualValidationsBuilder to optionally set diff-budget/mask options and then perform() your validation
+     * @return a ValidationsExecutor object to optionally set a custom validation message
      */
-    default VisualValidationsBuilder matchesScreenshot() {
+    default ValidationsExecutor matchesScreenshot() {
+        throw new UnsupportedOperationException("matchesScreenshot is not supported by this browser assertions implementation.");
+    }
+
+    /**
+     * Asserts that the current page matches its baseline full-page screenshot, using the given
+     * diff-budget/mask options (see {@link VisualComparisonOptions}). Executes immediately.
+     *
+     * @param options the visual comparison options (diff budgets, masks), or {@code null} for defaults
+     * @return a ValidationsExecutor object to optionally set a custom validation message
+     */
+    default ValidationsExecutor matchesScreenshot(VisualComparisonOptions options) {
         throw new UnsupportedOperationException("matchesScreenshot is not supported by this browser assertions implementation.");
     }
 }

--- a/shaft-engine/src/main/java/com/shaft/gui/driver/ElementAssertions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/driver/ElementAssertions.java
@@ -1,9 +1,9 @@
 package com.shaft.gui.driver;
 
 import com.shaft.validation.ValidationEnums;
+import com.shaft.validation.VisualComparisonOptions;
 import com.shaft.validation.internal.NativeValidationsBuilder;
 import com.shaft.validation.internal.ValidationsExecutor;
-import com.shaft.validation.internal.VisualValidationsBuilder;
 
 /**
  * Public contract for element-level hard/soft validation starters.
@@ -52,11 +52,23 @@ public interface ElementAssertions {
     NativeValidationsBuilder cssProperty(String elementCssProperty);
 
     /**
-     * Starts a visual-regression assertion against the element's baseline screenshot.
+     * Asserts that the element matches its baseline screenshot. Executes immediately, like every other
+     * assertion &mdash; no {@code perform()} is required.
      *
-     * @return a VisualValidationsBuilder to optionally set diff-budget/mask options and then perform() your validation
+     * @return a ValidationsExecutor object to optionally set a custom validation message
      */
-    default VisualValidationsBuilder matchesScreenshot() {
+    default ValidationsExecutor matchesScreenshot() {
+        throw new UnsupportedOperationException("matchesScreenshot is not supported by this element assertions implementation.");
+    }
+
+    /**
+     * Asserts that the element matches its baseline screenshot, using the given diff-budget/mask
+     * options (see {@link VisualComparisonOptions}). Executes immediately.
+     *
+     * @param options the visual comparison options (diff budgets, masks), or {@code null} for defaults
+     * @return a ValidationsExecutor object to optionally set a custom validation message
+     */
+    default ValidationsExecutor matchesScreenshot(VisualComparisonOptions options) {
         throw new UnsupportedOperationException("matchesScreenshot is not supported by this element assertions implementation.");
     }
 

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightBrowserValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightBrowserValidationsBuilder.java
@@ -1,10 +1,12 @@
 package com.shaft.gui.playwright.validation;
 
+import com.microsoft.playwright.Locator;
 import com.shaft.gui.driver.BrowserAssertions;
 import com.shaft.gui.playwright.internal.PlaywrightSession;
 import com.shaft.validation.ValidationEnums;
+import com.shaft.validation.VisualComparisonOptions;
 import com.shaft.validation.internal.NativeValidationsBuilder;
-import com.shaft.validation.internal.VisualValidationsBuilder;
+import com.shaft.validation.internal.ValidationsExecutor;
 
 public class PlaywrightBrowserValidationsBuilder implements BrowserAssertions {
     private final ValidationEnums.ValidationCategory validationCategory;
@@ -52,9 +54,19 @@ public class PlaywrightBrowserValidationsBuilder implements BrowserAssertions {
     }
 
     @Override
-    public VisualValidationsBuilder matchesScreenshot() {
+    public ValidationsExecutor matchesScreenshot() {
+        return matchesScreenshot(null);
+    }
+
+    @Override
+    public ValidationsExecutor matchesScreenshot(VisualComparisonOptions options) {
         reportMessageBuilder.append("page matches the visual regression baseline screenshot.");
-        return new PlaywrightVisualValidationsBuilder(validationCategory, session, null, null, true, reportMessageBuilder);
+        var builder = new PlaywrightVisualValidationsBuilder(validationCategory, session, null, null, true, reportMessageBuilder);
+        builder.applyOptions(options);
+        if (options instanceof PlaywrightVisualComparisonOptions playwrightOptions) {
+            builder.mask(playwrightOptions.getPlaywrightMaskLocators().toArray(new Locator[0]));
+        }
+        return builder.perform();
     }
 
     private NativeValidationsBuilder builder(String browserAttribute) {

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightElementValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightElementValidationsBuilder.java
@@ -4,9 +4,9 @@ import com.microsoft.playwright.Locator;
 import com.shaft.gui.driver.ElementAssertions;
 import com.shaft.gui.playwright.internal.PlaywrightSession;
 import com.shaft.validation.ValidationEnums;
+import com.shaft.validation.VisualComparisonOptions;
 import com.shaft.validation.internal.NativeValidationsBuilder;
 import com.shaft.validation.internal.ValidationsExecutor;
-import com.shaft.validation.internal.VisualValidationsBuilder;
 
 public class PlaywrightElementValidationsBuilder implements ElementAssertions {
     private final ValidationEnums.ValidationCategory validationCategory;
@@ -167,10 +167,20 @@ public class PlaywrightElementValidationsBuilder implements ElementAssertions {
     }
 
     @Override
-    public VisualValidationsBuilder matchesScreenshot() {
+    public ValidationsExecutor matchesScreenshot() {
+        return matchesScreenshot(null);
+    }
+
+    @Override
+    public ValidationsExecutor matchesScreenshot(VisualComparisonOptions options) {
         appendShaftElementNameIfAvailable();
         reportMessageBuilder.append("matches the visual regression baseline screenshot.");
-        return new PlaywrightVisualValidationsBuilder(validationCategory, session, locator, locatorDescription, false, reportMessageBuilder);
+        var builder = new PlaywrightVisualValidationsBuilder(validationCategory, session, locator, locatorDescription, false, reportMessageBuilder);
+        builder.applyOptions(options);
+        if (options instanceof PlaywrightVisualComparisonOptions playwrightOptions) {
+            builder.mask(playwrightOptions.getPlaywrightMaskLocators().toArray(new Locator[0]));
+        }
+        return builder.perform();
     }
 
     private PlaywrightNativeValidationsBuilder builder(String validationMethod, String elementAttribute, String elementCssProperty) {

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightVisualComparisonOptions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightVisualComparisonOptions.java
@@ -1,0 +1,69 @@
+package com.shaft.gui.playwright.validation;
+
+import com.microsoft.playwright.Locator;
+import com.shaft.validation.VisualComparisonOptions;
+import org.openqa.selenium.By;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Playwright variant of {@link VisualComparisonOptions} that adds a Playwright {@link Locator}-based
+ * {@code mask(...)} overload, for use with the Playwright engine's
+ * {@code assertThat(...).matchesScreenshot(options)} assertion.
+ *
+ * <pre>{@code
+ * driver.element().assertThat(locator)
+ *       .matchesScreenshot(PlaywrightVisualComparisonOptions.create()
+ *               .maxDiffPixelRatio(0.01)
+ *               .mask(page.locator("#timestamp")));
+ * }</pre>
+ */
+public class PlaywrightVisualComparisonOptions extends VisualComparisonOptions {
+    private final List<Locator> playwrightMaskLocators = new ArrayList<>();
+
+    /**
+     * @return a new, empty Playwright options object to configure and pass to {@code matchesScreenshot(...)}
+     */
+    public static PlaywrightVisualComparisonOptions create() {
+        return new PlaywrightVisualComparisonOptions();
+    }
+
+    @Override
+    public PlaywrightVisualComparisonOptions maxDiffPixels(int maxDiffPixels) {
+        super.maxDiffPixels(maxDiffPixels);
+        return this;
+    }
+
+    @Override
+    public PlaywrightVisualComparisonOptions maxDiffPixelRatio(double maxDiffPixelRatio) {
+        super.maxDiffPixelRatio(maxDiffPixelRatio);
+        return this;
+    }
+
+    @Override
+    public PlaywrightVisualComparisonOptions mask(By... masks) {
+        super.mask(masks);
+        return this;
+    }
+
+    /**
+     * Excludes the region(s) covered by the given Playwright locators from the pixel comparison.
+     *
+     * @param masks Playwright locators of elements whose bounding boxes should be excluded from the diff
+     * @return this options object, to continue chaining
+     */
+    public PlaywrightVisualComparisonOptions mask(Locator... masks) {
+        this.playwrightMaskLocators.addAll(Arrays.asList(masks));
+        return this;
+    }
+
+    /**
+     * @return the (possibly empty) list of Playwright locators whose regions are excluded from the diff
+     */
+    public List<Locator> getPlaywrightMaskLocators() {
+        return Collections.unmodifiableList(playwrightMaskLocators);
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/validation/VisualComparisonOptions.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/VisualComparisonOptions.java
@@ -1,0 +1,91 @@
+package com.shaft.validation;
+
+import org.openqa.selenium.By;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Options for the {@code matchesScreenshot(...)} visual-regression assertion, mirroring Playwright's
+ * {@code toHaveScreenshot()} options.
+ *
+ * <p>Build with {@link #create()} and the fluent setters, then pass the result to
+ * {@code assertThat(...).matchesScreenshot(options)}. Like every other SHAFT assertion,
+ * {@code matchesScreenshot(...)} executes immediately &mdash; no trailing {@code perform()} is
+ * required.</p>
+ *
+ * <pre>{@code
+ * driver.element().assertThat(By.id("logo"))
+ *       .matchesScreenshot(VisualComparisonOptions.create()
+ *               .maxDiffPixelRatio(0.01)
+ *               .mask(By.id("timestamp")));
+ * }</pre>
+ */
+public class VisualComparisonOptions {
+    private final List<By> maskLocators = new ArrayList<>();
+    private Integer maxDiffPixels;
+    private Double maxDiffPixelRatio;
+
+    /**
+     * @return a new, empty options object to configure and pass to {@code matchesScreenshot(...)}
+     */
+    public static VisualComparisonOptions create() {
+        return new VisualComparisonOptions();
+    }
+
+    /**
+     * Caps the number of differing pixels allowed for the comparison to still pass.
+     *
+     * @param maxDiffPixels maximum allowed differing pixel count
+     * @return this options object, to continue chaining
+     */
+    public VisualComparisonOptions maxDiffPixels(int maxDiffPixels) {
+        this.maxDiffPixels = maxDiffPixels;
+        return this;
+    }
+
+    /**
+     * Caps the ratio of differing pixels (0.0-1.0) allowed for the comparison to still pass.
+     *
+     * @param maxDiffPixelRatio maximum allowed differing pixel ratio
+     * @return this options object, to continue chaining
+     */
+    public VisualComparisonOptions maxDiffPixelRatio(double maxDiffPixelRatio) {
+        this.maxDiffPixelRatio = maxDiffPixelRatio;
+        return this;
+    }
+
+    /**
+     * Excludes the region(s) covered by the given locators from the pixel comparison.
+     *
+     * @param masks locators of elements whose bounding boxes should be excluded from the diff
+     * @return this options object, to continue chaining
+     */
+    public VisualComparisonOptions mask(By... masks) {
+        this.maskLocators.addAll(Arrays.asList(masks));
+        return this;
+    }
+
+    /**
+     * @return the configured maximum differing pixel count, or {@code null} if unset
+     */
+    public Integer getMaxDiffPixels() {
+        return maxDiffPixels;
+    }
+
+    /**
+     * @return the configured maximum differing pixel ratio, or {@code null} if unset
+     */
+    public Double getMaxDiffPixelRatio() {
+        return maxDiffPixelRatio;
+    }
+
+    /**
+     * @return the (possibly empty) list of locators whose regions are excluded from the diff
+     */
+    public List<By> getMaskLocators() {
+        return Collections.unmodifiableList(maskLocators);
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/VisualValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/VisualValidationsBuilder.java
@@ -1,6 +1,7 @@
 package com.shaft.validation.internal;
 
 import com.shaft.validation.ValidationEnums;
+import com.shaft.validation.VisualComparisonOptions;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 
@@ -66,6 +67,27 @@ public class VisualValidationsBuilder {
      */
     public VisualValidationsBuilder mask(By... masks) {
         this.maskLocators.addAll(Arrays.asList(masks));
+        return this;
+    }
+
+    /**
+     * Copies the diff-budget and mask settings from a public {@link VisualComparisonOptions} object
+     * onto this internal builder. Playwright {@code Locator}-based masks are handled separately by
+     * the Playwright entry points.
+     *
+     * @param options the caller-supplied options, or {@code null} for defaults
+     * @return this builder, to continue chaining
+     */
+    public VisualValidationsBuilder applyOptions(VisualComparisonOptions options) {
+        if (options != null) {
+            if (options.getMaxDiffPixels() != null) {
+                this.maxDiffPixels = options.getMaxDiffPixels();
+            }
+            if (options.getMaxDiffPixelRatio() != null) {
+                this.maxDiffPixelRatio = options.getMaxDiffPixelRatio();
+            }
+            this.maskLocators.addAll(options.getMaskLocators());
+        }
         return this;
     }
 

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverBrowserValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverBrowserValidationsBuilder.java
@@ -1,6 +1,7 @@
 package com.shaft.validation.internal;
 
 import com.shaft.validation.ValidationEnums;
+import com.shaft.validation.VisualComparisonOptions;
 import org.openqa.selenium.WebDriver;
 
 public class WebDriverBrowserValidationsBuilder implements com.shaft.gui.driver.BrowserAssertions {
@@ -86,16 +87,30 @@ public class WebDriverBrowserValidationsBuilder implements com.shaft.gui.driver.
 
     /**
      * Use this to check that the current page matches its visual-regression baseline screenshot
-     * (full-page pixel diff via OpenCV; see {@link VisualValidationsBuilder} for diff-budget/mask options).
-     * On the first test run this method takes a full-page screenshot and the test passes, saving it as
-     * the baseline for subsequent runs.
+     * (full-page pixel diff via OpenCV). On the first test run this method takes a full-page screenshot
+     * and the test passes, saving it as the baseline for subsequent runs. The comparison executes
+     * immediately &mdash; no {@code perform()} is required.
      *
-     * @return a VisualValidationsBuilder to optionally set diff-budget/mask options and then perform() your validation
+     * @return a ValidationsExecutor object to optionally set a custom validation message
      */
     @Override
-    public VisualValidationsBuilder matchesScreenshot() {
+    public ValidationsExecutor matchesScreenshot() {
+        return matchesScreenshot(null);
+    }
+
+    /**
+     * Same as {@link #matchesScreenshot()}, but with diff-budget/mask options (see
+     * {@link VisualComparisonOptions}). The comparison executes immediately.
+     *
+     * @param options the visual comparison options (diff budgets, masks), or {@code null} for defaults
+     * @return a ValidationsExecutor object to optionally set a custom validation message
+     */
+    @Override
+    public ValidationsExecutor matchesScreenshot(VisualComparisonOptions options) {
         reportMessageBuilder.append("page matches the visual regression baseline screenshot.");
-        return new VisualValidationsBuilder(validationCategory, driver, null, true, reportMessageBuilder);
+        return new VisualValidationsBuilder(validationCategory, driver, null, true, reportMessageBuilder)
+                .applyOptions(options)
+                .perform();
     }
 
 }

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverElementValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverElementValidationsBuilder.java
@@ -2,6 +2,7 @@ package com.shaft.validation.internal;
 
 import com.shaft.tools.internal.support.JavaHelper;
 import com.shaft.validation.ValidationEnums;
+import com.shaft.validation.VisualComparisonOptions;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 
@@ -128,18 +129,32 @@ public class WebDriverElementValidationsBuilder implements com.shaft.gui.driver.
 
     /**
      * Use this to check that the target element matches its visual-regression baseline screenshot
-     * (pixel diff via OpenCV; see {@link VisualValidationsBuilder} for diff-budget/mask options).
-     * On the first test run this method takes a screenshot of the target element and the test passes,
-     * saving it as the baseline for subsequent runs. Baselines are stored alongside the other visual
-     * baselines under the configured {@code dynamicObjectRepositoryPath}.
+     * (pixel diff via OpenCV). On the first test run this method takes a screenshot of the target
+     * element and the test passes, saving it as the baseline for subsequent runs. Baselines are stored
+     * alongside the other visual baselines under the configured {@code dynamicObjectRepositoryPath}.
+     * The comparison executes immediately &mdash; no {@code perform()} is required.
      *
-     * @return a VisualValidationsBuilder to optionally set diff-budget/mask options and then perform() your validation
+     * @return a ValidationsExecutor object to optionally set a custom validation message
      */
     @Override
-    public VisualValidationsBuilder matchesScreenshot() {
+    public ValidationsExecutor matchesScreenshot() {
+        return matchesScreenshot(null);
+    }
+
+    /**
+     * Same as {@link #matchesScreenshot()}, but with diff-budget/mask options (see
+     * {@link VisualComparisonOptions}). The comparison executes immediately.
+     *
+     * @param options the visual comparison options (diff budgets, masks), or {@code null} for defaults
+     * @return a ValidationsExecutor object to optionally set a custom validation message
+     */
+    @Override
+    public ValidationsExecutor matchesScreenshot(VisualComparisonOptions options) {
         appendShaftElementNameIfAvailable();
         reportMessageBuilder.append("matches the visual regression baseline screenshot.");
-        return new VisualValidationsBuilder(validationCategory, driver, locator, false, reportMessageBuilder);
+        return new VisualValidationsBuilder(validationCategory, driver, locator, false, reportMessageBuilder)
+                .applyOptions(options)
+                .perform();
     }
 
     /**

--- a/shaft-engine/src/test/java/com/shaft/validation/internal/VisualValidationsBuilderUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/validation/internal/VisualValidationsBuilderUnitTest.java
@@ -1,79 +1,89 @@
 package com.shaft.validation.internal;
 
+import com.shaft.gui.playwright.validation.PlaywrightVisualComparisonOptions;
 import com.shaft.validation.ValidationEnums;
+import com.shaft.validation.VisualComparisonOptions;
 import org.openqa.selenium.By;
 import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import java.util.List;
 
 /**
- * Coverage-focused unit tests for {@link VisualValidationsBuilder} wiring from both the element-level
- * and page-level {@code matchesScreenshot()} entry points. These tests exercise builder configuration
- * paths without requiring a live browser session; end-to-end baseline lifecycle behavior is covered by
+ * Coverage-focused unit tests for the {@code matchesScreenshot(...)} option plumbing. Since
+ * {@code matchesScreenshot(...)} now executes immediately (like every other assertion, needing no
+ * {@code perform()}), these tests exercise the public {@link VisualComparisonOptions} builder and the
+ * internal {@link VisualValidationsBuilder#applyOptions(VisualComparisonOptions)} seeding without a live
+ * browser session; end-to-end baseline lifecycle behavior is covered by
  * {@code ImageProcessingActionsScreenshotBaselineUnitTest}.
  */
 public class VisualValidationsBuilderUnitTest {
     private static final By SAMPLE_LOCATOR = By.id("sample");
 
-    @AfterMethod(alwaysRun = true)
-    public void resetState() {
-        ValidationsHelper.resetVerificationStateAfterFailing();
-    }
-
-    @Test(description = "element-level matchesScreenshot() should return an unexecuted builder seeded with the element target")
-    public void elementMatchesScreenshotShouldSeedBuilderWithoutExecuting() {
-        WebDriverElementValidationsBuilder elementBuilder = new WebDriverElementValidationsBuilder(
-                ValidationEnums.ValidationCategory.HARD_ASSERT, null, SAMPLE_LOCATOR, new StringBuilder("the element "));
-
-        VisualValidationsBuilder visualBuilder = elementBuilder.matchesScreenshot();
-
-        Assert.assertFalse(visualBuilder.pageLevel);
-        Assert.assertEquals(visualBuilder.locator, SAMPLE_LOCATOR);
-        Assert.assertEquals(visualBuilder.validationCategory, ValidationEnums.ValidationCategory.HARD_ASSERT);
-        Assert.assertTrue(elementBuilder.reportMessageBuilder.toString().contains("matches the visual regression baseline screenshot."));
-    }
-
-    @Test(description = "page-level matchesScreenshot() should seed a page-level builder with a null locator")
-    public void browserMatchesScreenshotShouldSeedPageLevelBuilder() {
-        WebDriverBrowserValidationsBuilder browserBuilder = new WebDriverBrowserValidationsBuilder(
-                ValidationEnums.ValidationCategory.HARD_ASSERT, null, new StringBuilder("the browser "));
-
-        VisualValidationsBuilder visualBuilder = browserBuilder.matchesScreenshot();
-
-        Assert.assertTrue(visualBuilder.pageLevel);
-        Assert.assertNull(visualBuilder.locator);
-        Assert.assertTrue(browserBuilder.reportMessageBuilder.toString().contains("page matches the visual regression baseline screenshot."));
-    }
-
-    @Test(description = "maxDiffPixels/maxDiffPixelRatio/mask options should populate builder fields without executing")
-    public void optionsShouldPopulateFieldsWithoutExecuting() {
-        WebDriverElementValidationsBuilder elementBuilder = new WebDriverElementValidationsBuilder(
-                ValidationEnums.ValidationCategory.HARD_ASSERT, null, SAMPLE_LOCATOR, new StringBuilder());
-        By mask = By.id("mask");
-
-        VisualValidationsBuilder visualBuilder = elementBuilder.matchesScreenshot()
-                .maxDiffPixels(100)
-                .maxDiffPixelRatio(0.05)
-                .mask(mask);
-
-        Assert.assertEquals(visualBuilder.maxDiffPixels, Integer.valueOf(100));
-        Assert.assertEquals(visualBuilder.maxDiffPixelRatio, Double.valueOf(0.05));
-        Assert.assertEquals(visualBuilder.maskLocators, List.of(mask));
-    }
-
-    @Test(description = "mask() should accumulate locators across multiple chained calls")
-    public void maskShouldAccumulateLocatorsAcrossChainedCalls() {
-        WebDriverElementValidationsBuilder elementBuilder = new WebDriverElementValidationsBuilder(
-                ValidationEnums.ValidationCategory.HARD_ASSERT, null, SAMPLE_LOCATOR, new StringBuilder());
+    @Test(description = "VisualComparisonOptions should accumulate diff budgets and masks fluently")
+    public void optionsShouldAccumulateFields() {
         By firstMask = By.id("mask-1");
         By secondMask = By.id("mask-2");
 
-        VisualValidationsBuilder visualBuilder = elementBuilder.matchesScreenshot()
-                .mask(firstMask)
-                .mask(secondMask);
+        VisualComparisonOptions options = VisualComparisonOptions.create()
+                .maxDiffPixels(100)
+                .maxDiffPixelRatio(0.05)
+                .mask(firstMask, secondMask);
 
-        Assert.assertEquals(visualBuilder.maskLocators, List.of(firstMask, secondMask));
+        Assert.assertEquals(options.getMaxDiffPixels(), Integer.valueOf(100));
+        Assert.assertEquals(options.getMaxDiffPixelRatio(), Double.valueOf(0.05));
+        Assert.assertEquals(options.getMaskLocators(), List.of(firstMask, secondMask));
+    }
+
+    @Test(description = "unset VisualComparisonOptions fields should stay null so builder defaults apply")
+    public void unsetOptionsShouldStayNull() {
+        VisualComparisonOptions options = VisualComparisonOptions.create();
+
+        Assert.assertNull(options.getMaxDiffPixels());
+        Assert.assertNull(options.getMaxDiffPixelRatio());
+        Assert.assertTrue(options.getMaskLocators().isEmpty());
+    }
+
+    @Test(description = "applyOptions should copy diff budgets and masks onto the internal builder")
+    public void applyOptionsShouldSeedBuilderFields() {
+        By mask = By.id("mask");
+        VisualValidationsBuilder builder = new VisualValidationsBuilder(
+                ValidationEnums.ValidationCategory.HARD_ASSERT, null, SAMPLE_LOCATOR, false, new StringBuilder());
+
+        builder.applyOptions(VisualComparisonOptions.create()
+                .maxDiffPixels(42)
+                .maxDiffPixelRatio(0.02)
+                .mask(mask));
+
+        Assert.assertEquals(builder.maxDiffPixels, Integer.valueOf(42));
+        Assert.assertEquals(builder.maxDiffPixelRatio, Double.valueOf(0.02));
+        Assert.assertEquals(builder.maskLocators, List.of(mask));
+    }
+
+    @Test(description = "applyOptions(null) should leave the builder at its defaults")
+    public void applyOptionsNullShouldLeaveDefaults() {
+        VisualValidationsBuilder builder = new VisualValidationsBuilder(
+                ValidationEnums.ValidationCategory.HARD_ASSERT, null, SAMPLE_LOCATOR, false, new StringBuilder());
+
+        builder.applyOptions(null);
+
+        Assert.assertNull(builder.maxDiffPixels);
+        Assert.assertNull(builder.maxDiffPixelRatio);
+        Assert.assertTrue(builder.maskLocators.isEmpty());
+    }
+
+    @Test(description = "PlaywrightVisualComparisonOptions should keep fluent chaining typed and inherit By masks")
+    public void playwrightOptionsShouldStayTypedAndInheritByMasks() {
+        By byMask = By.id("by-mask");
+
+        PlaywrightVisualComparisonOptions options = PlaywrightVisualComparisonOptions.create()
+                .maxDiffPixels(7)
+                .maxDiffPixelRatio(0.03)
+                .mask(byMask);
+
+        Assert.assertEquals(options.getMaxDiffPixels(), Integer.valueOf(7));
+        Assert.assertEquals(options.getMaxDiffPixelRatio(), Double.valueOf(0.03));
+        Assert.assertEquals(options.getMaskLocators(), List.of(byMask));
+        Assert.assertTrue(options.getPlaywrightMaskLocators().isEmpty());
     }
 }


### PR DESCRIPTION
## Problem

Every SHAFT assertion executes on its terminal call (e.g. `assertThat(x).text().isEqualTo(\"y\")` runs immediately; a trailing `.perform()` is a redundant no-op). `matchesScreenshot()` was the **only** exception: it returned a lazy `VisualValidationsBuilder` and required `.perform()` to actually run the comparison. It deferred solely because of its trailing options (`maxDiffPixelRatio`/`mask`/`maxDiffPixels`).

This surfaced as a docs-quality test flagging the visual example for `.perform()` on an assertion — the right fix is to make the API consistent, not to special-case the check.

## Change

`matchesScreenshot()` now executes immediately like every other assertion — **no `perform()` required**. Options move from trailing builder methods to a new options object, mirroring Playwright's `toHaveScreenshot(options)`:

```java
// before
driver.element().assertThat(By.id("logo"))
      .matchesScreenshot().maxDiffPixelRatio(0.01).mask(By.id("ts")).perform();

// after
driver.element().assertThat(By.id("logo"))
      .matchesScreenshot(VisualComparisonOptions.create()
              .maxDiffPixelRatio(0.01)
              .mask(By.id("ts")));
```

- New public `com.shaft.validation.VisualComparisonOptions` (+ `PlaywrightVisualComparisonOptions` for `Locator` masks).
- `matchesScreenshot()` / `matchesScreenshot(VisualComparisonOptions)` execute immediately and return `ValidationsExecutor`, across all four entry points (WebDriver + Playwright, element + browser) and the `ElementAssertions`/`BrowserAssertions` contracts.
- `shaft-capture` code generator emits `matchesScreenshot()` without `.perform()` (consistent with the `matchesReferenceImage()` / `matchesAriaSnapshot()` it already generates).

## Compatibility

Existing **bare** `matchesScreenshot().perform()` calls still compile and behave identically (`ValidationsExecutor.perform()` is a no-op log). Only **trailing-option chains** (`.matchesScreenshot().maxDiffPixelRatio(...)...`) need migrating to the options object — a source change for that specific pattern.

## Verification

- `shaft-engine` `test-compile` → BUILD SUCCESS.
- `VisualValidationsBuilderUnitTest` (rewritten for the options API) → 5/5 pass, headless.
- Full multi-module reactor (incl. `shaft-capture`) validated by CI.

Docs updated separately in ShaftHQ/shafthq.github.io (example → options object).

🤖 Generated with [Claude Code](https://claude.com/claude-code)