### PR TITLE
feat: web recorder overlay — labeled toolbar, step overflow menu, suppressed-events log (#3536)

### DIFF
--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -2196,6 +2196,8 @@
       confirmPanel.hidden = true;
       confirmPanel.innerHTML = "";
     }
+    // Restore the first-run coach once the dialog closes (#3536).
+    maybeShowCoach();
   };
   const confirmStop = () => {
     commitPendingDelete();
@@ -2226,6 +2228,10 @@
       </div>`;
     document.getElementById("shaft-capture-stop-confirm-yes").addEventListener("click", confirmStop);
     document.getElementById("shaft-capture-stop-confirm-no").addEventListener("click", closeStopConfirm);
+    // Free vertical space for the dialog's buttons on a first session (#3536): the coach is
+    // orientation noise while a stop decision is on screen, and the fixed-height panel cannot
+    // stack the labeled header, the coach, and the dialog at once without clipping.
+    maybeShowCoach();
     const sessionUrl = sessionEndpointUrl();
     if (sessionUrl && stepsEndpoint.token && typeof fetch === "function") {
       fetch(sessionUrl + "?token=" + encodeURIComponent(stepsEndpoint.token), {method: "GET"})
@@ -2405,6 +2411,14 @@
     renderSuppressedLog();
     renderActions();
   };
+  // #3536: the panel is a fixed-height flex column (overflow:hidden), so first-run orientation
+  // chrome and a modal sub-panel compete for the same vertical space. When the stop confirmation
+  // is open, suppress the coach so its buttons are never pushed out of the interactable area — the
+  // labeled toolbar's extra header line would otherwise clip the dialog on a first session.
+  const modalSubPanelOpen = () => {
+    const stop = document.getElementById("shaft-capture-stop-confirm");
+    return Boolean(stop && !stop.hidden);
+  };
   // A1 (#3536): first-session labeled toolbar, gated the same way as maybeShowCoach — top-frame
   // only, and hidden once dismissed or once the session stops (mirroring stop hiding the coach).
   function maybeShowToolbarLabels() {
@@ -2423,7 +2437,7 @@
   function maybeShowCoach() {
     const coach = document.getElementById("shaft-capture-coach");
     if (!coach) return;
-    coach.hidden = !(topLevel && !uiState.coachDismissed && !uiState.stopped);
+    coach.hidden = !(topLevel && !uiState.coachDismissed && !uiState.stopped && !modalSubPanelOpen());
   }
   // Draggable panel (#3496 B1): the header is the drag handle; the remembered position is
   // page-session-scoped via the same top-frame-only persisted UI state as everything else.

--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -47,12 +47,17 @@
     stopped: false,
     minimized: false,
     coachDismissed: false,
+    // #3536 A1/C1: first-session control labels and the opt-in suppressed-events log follow the
+    // exact coachDismissed precedent (default here, sanitize below, write out in persist()).
+    toolbarLabelsDismissed: false,
+    suppressedLogVisible: false,
     assertionMode: false,
     locatorMode: false,
     locatorPreferences: {},
     panelPosition: null,
     readinessState: "READY",
     readinessWarnings: [],
+    suppressedEvents: [],
     actions: [],
     pendingSignals: [],
     nextId: 1,
@@ -71,6 +76,8 @@
   uiState.locatorMode = Boolean(uiState.locatorMode);
   uiState.minimized = Boolean(uiState.minimized);
   uiState.coachDismissed = Boolean(uiState.coachDismissed);
+  uiState.toolbarLabelsDismissed = Boolean(uiState.toolbarLabelsDismissed);
+  uiState.suppressedLogVisible = Boolean(uiState.suppressedLogVisible);
   uiState.lastInteractionAt = Number(uiState.lastInteractionAt) || 0;
   uiState.locatorPreferences = uiState.locatorPreferences && typeof uiState.locatorPreferences === "object"
     ? uiState.locatorPreferences
@@ -85,6 +92,9 @@
   uiState.readinessWarnings = Array.isArray(uiState.readinessWarnings)
     ? uiState.readinessWarnings.slice(-20)
     : [];
+  uiState.suppressedEvents = Array.isArray(uiState.suppressedEvents)
+    ? uiState.suppressedEvents.slice(-50)
+    : [];
   globalThis.__shaftCaptureUiState = uiState;
   const persist = () => {
     if (!topLevel) return;
@@ -94,12 +104,15 @@
         stopped: uiState.stopped,
         minimized: uiState.minimized,
         coachDismissed: uiState.coachDismissed,
+        toolbarLabelsDismissed: uiState.toolbarLabelsDismissed,
+        suppressedLogVisible: uiState.suppressedLogVisible,
         assertionMode: uiState.assertionMode,
         locatorMode: uiState.locatorMode,
         locatorPreferences: uiState.locatorPreferences,
         panelPosition: uiState.panelPosition,
         readinessState: uiState.readinessState,
         readinessWarnings: uiState.readinessWarnings.slice(-20),
+        suppressedEvents: uiState.suppressedEvents.slice(-50),
         actions: uiState.actions.slice(-80),
         pendingSignals: uiState.pendingSignals.slice(-200),
         nextId: uiState.nextId,
@@ -1459,9 +1472,38 @@
       }
       #shaft-capture-actions .action-row {
         display: grid;
-        grid-template-columns: 1fr repeat(5, 28px);
+        /* B5 (#3536): assert/edit/delete moved into the row overflow menu, so only up/down and
+           the overflow toggle stay inline; each gets a larger 32px touch target. */
+        grid-template-columns: 1fr repeat(3, 32px);
         gap: 6px;
         align-items: start;
+      }
+      #shaft-capture-actions .action-row button,
+      #shaft-capture-actions .row-overflow-menu button {
+        min-width: 32px;
+        min-height: 32px;
+      }
+      #shaft-capture-actions li { position: relative; }
+      #shaft-capture-actions .row-overflow-menu {
+        position: absolute;
+        right: 0;
+        top: 100%;
+        z-index: 5;
+        display: grid;
+        gap: 4px;
+        margin-top: 4px;
+        padding: 6px;
+        border: 1px solid var(--shaft-border);
+        border-radius: 8px;
+        background: var(--shaft-surface);
+        box-shadow: var(--shaft-shadow);
+      }
+      #shaft-capture-actions .row-overflow-menu[hidden] { display: none; }
+      #shaft-capture-actions .row-overflow-menu button {
+        width: 100%;
+        justify-content: flex-start;
+        gap: 6px;
+        padding: 0 8px;
       }
       #shaft-capture-actions span,
       #shaft-capture-actions small {
@@ -1657,6 +1699,53 @@
         border-radius: 6px;
         box-shadow: 0 0 0 3px rgba(0, 110, 192, .2);
       }
+      /* A1 (#3536): first-session labeled toolbar. Labels stay hidden until
+         .show-ctrl-labels is toggled on the panel root by maybeShowToolbarLabels(). */
+      .ctrl-label { display: none; }
+      #shaft-capture-ui.show-ctrl-labels header button {
+        display: inline-flex;
+        align-items: center;
+        width: auto;
+        padding: 0 8px;
+      }
+      #shaft-capture-ui.show-ctrl-labels .ctrl-label {
+        display: inline;
+        margin-inline-start: 4px;
+      }
+      #shaft-capture-labels-dismiss {
+        width: auto;
+        height: auto;
+        padding: 2px 8px;
+        font-size: 11px;
+        font-weight: 700;
+      }
+      /* C1 (#3536): opt-in persistent log of suppressed (transparently-ignored) navigations. */
+      #shaft-capture-suppressed-toggle {
+        display: block;
+        width: auto;
+        height: auto;
+        margin: 6px 0 0;
+        padding: 2px 0;
+        border: none;
+        background: none;
+        color: var(--shaft-primary);
+        font-size: 11px;
+        font-weight: 700;
+        text-align: left;
+      }
+      #shaft-capture-suppressed-toggle[hidden] { display: none; }
+      #shaft-capture-suppressed-log {
+        margin: 4px 0 0;
+        padding: 6px 8px;
+        max-height: 120px;
+        overflow-y: auto;
+        border: 1px dashed var(--shaft-border);
+        border-radius: 6px;
+        color: var(--shaft-text-muted);
+        font-size: 11px;
+      }
+      #shaft-capture-suppressed-log[hidden] { display: none; }
+      #shaft-capture-suppressed-log div { padding: 2px 0; overflow-wrap: anywhere; }
     `;
     (document.head || document.documentElement).appendChild(style);
   };
@@ -1727,7 +1816,10 @@
       warningLine.textContent = latestWarning;
       warningLine.hidden = !latestWarning;
     }
-    pause.innerHTML = icon(uiState.paused ? "play" : "pause");
+    // A1 (#3536): pause's label is dynamic (Pause/Resume), so it is rebuilt here alongside the icon
+    // rather than baked into the static header markup like the assert/pick/stop labels.
+    pause.innerHTML = icon(uiState.paused ? "play" : "pause")
+      + '<span class="ctrl-label">' + (uiState.paused ? "Resume" : "Pause") + "</span>";
     pause.title = uiState.paused ? "Resume recording" : "Pause recording";
     pause.setAttribute("aria-label", pause.title);
     assert.setAttribute("aria-pressed", String(uiState.assertionMode || assertionPanelOpen));
@@ -1873,6 +1965,29 @@
     if (/^Stop recording/.test(value)) return "Stop";
     return "Step";
   };
+  // B5 (#3536): only one row's overflow menu is open at a time; a single document-level listener
+  // (installed once here, not per row) closes it on outside click or Esc so listeners never leak
+  // across re-renders.
+  let openRowOverflowMenu = null;
+  const closeRowOverflowMenu = () => {
+    if (!openRowOverflowMenu) return;
+    openRowOverflowMenu.menu.hidden = true;
+    openRowOverflowMenu.button.setAttribute("aria-expanded", "false");
+    openRowOverflowMenu = null;
+  };
+  const toggleRowOverflowMenu = (button, menu) => {
+    const opening = menu.hidden;
+    closeRowOverflowMenu();
+    if (opening) {
+      menu.hidden = false;
+      button.setAttribute("aria-expanded", "true");
+      openRowOverflowMenu = {button, menu};
+    }
+  };
+  document.addEventListener("click", () => closeRowOverflowMenu());
+  document.addEventListener("keydown", event => {
+    if (String(event.key || "") === "Escape") closeRowOverflowMenu();
+  });
   function renderActions() {
     const list = document.getElementById("shaft-capture-action-list");
     if (!list) return;
@@ -1898,8 +2013,12 @@
       assert.innerHTML = icon("assert");
       assert.title = "Add visible assertion for this target";
       assert.setAttribute("aria-label", "Add visible assertion for this target");
+      assert.setAttribute("role", "menuitem");
       assert.disabled = !details.target;
-      assert.addEventListener("click", () => quickAssertion(item));
+      assert.addEventListener("click", () => {
+        closeRowOverflowMenu();
+        quickAssertion(item);
+      });
       const up = document.createElement("button");
       up.type = "button";
       up.innerHTML = icon("up");
@@ -1919,19 +2038,48 @@
       edit.innerHTML = icon("edit");
       edit.title = "Edit captured action";
       edit.setAttribute("aria-label", "Edit captured action");
-      edit.addEventListener("click", () => editAction(item));
+      edit.setAttribute("role", "menuitem");
+      edit.addEventListener("click", () => {
+        closeRowOverflowMenu();
+        editAction(item);
+      });
       const remove = document.createElement("button");
       remove.type = "button";
       remove.innerHTML = icon("delete");
       remove.title = "Delete captured action";
       remove.setAttribute("aria-label", "Delete captured action");
-      remove.addEventListener("click", () => deleteAction(item));
-      body.append(textWrap, assert, up, down, edit, remove);
-      row.append(body);
+      remove.setAttribute("role", "menuitem");
+      remove.addEventListener("click", () => {
+        closeRowOverflowMenu();
+        deleteAction(item);
+      });
+      // B5 (#3536): secondary actions (assert/edit/delete) live in the overflow menu; up/down
+      // stay inline so reordering never needs an extra click.
+      const overflow = document.createElement("button");
+      overflow.type = "button";
+      overflow.className = "row-overflow-toggle";
+      overflow.textContent = "⋯";
+      overflow.title = "More actions";
+      overflow.setAttribute("aria-label", "More actions");
+      overflow.setAttribute("aria-haspopup", "menu");
+      overflow.setAttribute("aria-expanded", "false");
+      const menu = document.createElement("div");
+      menu.className = "row-overflow-menu";
+      menu.setAttribute("role", "menu");
+      menu.hidden = true;
+      menu.append(assert, edit, remove);
+      overflow.addEventListener("click", event => {
+        event.stopPropagation();
+        toggleRowOverflowMenu(overflow, menu);
+      });
+      body.append(textWrap, up, down, overflow);
+      row.append(body, menu);
       list.appendChild(row);
     });
     setStatus();
     maybeShowCoach();
+    maybeShowToolbarLabels();
+    renderSuppressedLog();
   }
   const renderLocatorPanel = target => {
     const panel = document.getElementById("shaft-capture-locator-panel");
@@ -2112,11 +2260,12 @@
         <span class="brand-mark" aria-hidden="true">S</span>
         <strong id="shaft-capture-title">SHAFT Capture</strong>
         <button id="shaft-capture-pause" type="button"></button>
-        <button id="shaft-capture-assert" type="button" title="Add assertion" aria-label="Add assertion" aria-pressed="false">${icon("assert")}</button>
-        <button id="shaft-capture-pick" type="button" title="Toggle locator picker" aria-label="Toggle locator picker" aria-pressed="false">${icon("locator")}</button>
-        <button id="shaft-capture-stop" type="button" title="Stop recording" aria-label="Stop recording">${icon("stop")}</button>
+        <button id="shaft-capture-assert" type="button" title="Add assertion" aria-label="Add assertion" aria-pressed="false">${icon("assert")}<span class="ctrl-label">Assert</span></button>
+        <button id="shaft-capture-pick" type="button" title="Toggle locator picker" aria-label="Toggle locator picker" aria-pressed="false">${icon("locator")}<span class="ctrl-label">Pick</span></button>
+        <button id="shaft-capture-stop" type="button" title="Stop recording" aria-label="Stop recording">${icon("stop")}<span class="ctrl-label">Stop</span></button>
         <button id="shaft-capture-help-toggle" type="button" title="Show recorder help" aria-label="Show recorder help" aria-expanded="false">?</button>
         <button id="shaft-capture-minimize" type="button" aria-expanded="true"></button>
+        <button id="shaft-capture-labels-dismiss" type="button" hidden>Hide labels</button>
       </header>
       <div id="shaft-capture-status" class="status-chip shaft-capture-readiness">
         <span id="shaft-capture-readiness-pill" class="status-pill"></span>
@@ -2146,7 +2295,7 @@
       </div>
       <div id="shaft-capture-stop-confirm" hidden></div>
       <div id="shaft-capture-locator-panel" hidden></div>
-      <div id="shaft-capture-actions"><p id="shaft-capture-empty-hint" hidden>No steps yet. Click, type, and navigate in this page &mdash; every action is recorded here as an editable step.</p><div id="shaft-capture-ignored-note" hidden></div><div id="shaft-capture-sync-note" hidden></div><div id="shaft-capture-undo-note" hidden><span>Step deleted.</span><button id="shaft-capture-undo" type="button">Undo</button></div><ol id="shaft-capture-action-list"></ol></div>
+      <div id="shaft-capture-actions"><p id="shaft-capture-empty-hint" hidden>No steps yet. Click, type, and navigate in this page &mdash; every action is recorded here as an editable step.</p><div id="shaft-capture-ignored-note" hidden></div><div id="shaft-capture-sync-note" hidden></div><div id="shaft-capture-undo-note" hidden><span>Step deleted.</span><button id="shaft-capture-undo" type="button">Undo</button></div><ol id="shaft-capture-action-list"></ol><button id="shaft-capture-suppressed-toggle" type="button" hidden aria-expanded="false"></button><div id="shaft-capture-suppressed-log" role="log" hidden></div></div>
     `;
     document.body.appendChild(panel);
     document.getElementById("shaft-capture-pause").addEventListener("click", () => {
@@ -2221,6 +2370,25 @@
         if (coach) coach.hidden = true;
       });
     }
+    // A1 (#3536): dismissing the first-session labels is one-way for the rest of the session,
+    // mirroring coachDismissed.
+    const labelsDismiss = document.getElementById("shaft-capture-labels-dismiss");
+    if (labelsDismiss) {
+      labelsDismiss.addEventListener("click", () => {
+        uiState.toolbarLabelsDismissed = true;
+        persist();
+        maybeShowToolbarLabels();
+      });
+    }
+    // C1 (#3536): toggling the suppressed-events log is opt-in and stays persisted for the session.
+    const suppressedToggle = document.getElementById("shaft-capture-suppressed-toggle");
+    if (suppressedToggle) {
+      suppressedToggle.addEventListener("click", () => {
+        uiState.suppressedLogVisible = !uiState.suppressedLogVisible;
+        persist();
+        renderSuppressedLog();
+      });
+    }
     installPanelDrag(panel);
     if (uiState.panelPosition) {
       applyPanelPosition(panel, uiState.panelPosition.left, uiState.panelPosition.top);
@@ -2233,8 +2401,20 @@
       persist();
     });
     maybeShowCoach();
+    maybeShowToolbarLabels();
+    renderSuppressedLog();
     renderActions();
   };
+  // A1 (#3536): first-session labeled toolbar, gated the same way as maybeShowCoach — top-frame
+  // only, and hidden once dismissed or once the session stops (mirroring stop hiding the coach).
+  function maybeShowToolbarLabels() {
+    const panel = document.getElementById("shaft-capture-ui");
+    if (!panel) return;
+    const show = topLevel && !uiState.toolbarLabelsDismissed && !uiState.stopped;
+    panel.classList.toggle("show-ctrl-labels", show);
+    const dismiss = document.getElementById("shaft-capture-labels-dismiss");
+    if (dismiss) dismiss.hidden = !show;
+  }
   // First-run coach marks (#3510 A3): a dismissible, session-scoped set of at-most-three tips shown
   // until the user dismisses them, so a first-time user is oriented without nagging returning users
   // (the "seen" flag rides the same top-frame sessionStorage as the rest of the UI state). The count
@@ -2311,6 +2491,29 @@
   // recorded step (and therefore NOT recorded as its own step), say so briefly instead of
   // silently dropping it, so users trust that "missing" rows are deliberate.
   let ignoredNoteTimer = null;
+  // C1 (#3536): renders the toggle button (always, so its "(N)" count stays live even while the
+  // log itself is collapsed) and the log body (only while uiState.suppressedLogVisible).
+  function renderSuppressedLog() {
+    const toggle = document.getElementById("shaft-capture-suppressed-toggle");
+    const log = document.getElementById("shaft-capture-suppressed-log");
+    if (!toggle || !log) return;
+    const count = uiState.suppressedEvents.length;
+    toggle.hidden = !(topLevel && count > 0);
+    toggle.textContent = (uiState.suppressedLogVisible ? "Hide" : "Show") + " suppressed events (" + count + ")";
+    toggle.setAttribute("aria-expanded", String(uiState.suppressedLogVisible));
+    log.hidden = !uiState.suppressedLogVisible;
+    if (!uiState.suppressedLogVisible) return;
+    log.textContent = "";
+    uiState.suppressedEvents.slice().reverse().forEach(event => {
+      const line = document.createElement("div");
+      // textContent, never innerHTML: reason strings come from page-observed navigation state.
+      line.textContent = new Date(Number(event.timestamp) || 0).toLocaleTimeString([], {
+        hour: "2-digit",
+        minute: "2-digit"
+      }) + " — " + String(event.reason || "");
+      log.appendChild(line);
+    });
+  }
   const noteIgnored = reason => {
     const note = document.getElementById("shaft-capture-ignored-note");
     if (!note) return;
@@ -2320,6 +2523,13 @@
     ignoredNoteTimer = setTimeout(() => {
       note.hidden = true;
     }, 6000);
+    // Persistent opt-in log (#3536 C1): the transient note above still auto-hides, but the toggle
+    // count is refreshed unconditionally (not only "if visible") so it never goes stale between
+    // renderActions()/renderPanel() calls.
+    uiState.suppressedEvents.push({reason: String(reason), timestamp: Date.now()});
+    uiState.suppressedEvents = uiState.suppressedEvents.slice(-50);
+    persist();
+    renderSuppressedLog();
   };
   // Server-sync transparency (#3510 C3): when a background re-sync from the durable session changes
   // the visible step list (a cross-origin navigation rehydrated rows this page had not seen), say

--- a/shaft-capture/src/test/java/com/shaft/capture/collector/CaptureCollectorUtilityTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/collector/CaptureCollectorUtilityTest.java
@@ -82,6 +82,16 @@ class CaptureCollectorUtilityTest {
         assertTrue(preload.contains("Delete captured action"));
         assertTrue(preload.contains("pagehide"));
         assertTrue(preload.contains("beforeunload"));
+        // #3536 A1: first-session labeled toolbar.
+        assertTrue(preload.contains("toolbarLabelsDismissed"));
+        assertTrue(preload.contains("show-ctrl-labels"));
+        assertTrue(preload.contains("shaft-capture-labels-dismiss"));
+        // #3536 B5: step-row overflow menu.
+        assertTrue(preload.contains("row-overflow-menu"));
+        assertTrue(preload.contains("More actions"));
+        // #3536 C1: persistent suppressed-events log.
+        assertTrue(preload.contains("shaft-capture-suppressed-toggle"));
+        assertTrue(preload.contains("suppressedEvents"));
 
         Constructor<BrowserEventScript> constructor = BrowserEventScript.class.getDeclaredConstructor();
         constructor.setAccessible(true);

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
@@ -903,6 +903,11 @@ class ManagedCaptureRecorderBrowserTest {
                     .get(rowsBefore - 1)
                     .findElement(By.cssSelector(".action-row > span > span:not(.step-badge)"))
                     .getText().trim();
+            // #3536 B5: delete now lives behind the row's overflow menu, so open it first.
+            driver.findElements(By.cssSelector("#shaft-capture-action-list li .row-overflow-toggle"))
+                    .get(rowsBefore - 1).click();
+            waitFor(() -> driver.findElements(By.cssSelector("#shaft-capture-action-list li .row-overflow-menu"))
+                    .get(rowsBefore - 1).isDisplayed());
             driver.findElements(By.cssSelector(
                     "#shaft-capture-action-list li button[aria-label='Delete captured action']"))
                     .get(rowsBefore - 1).click();
@@ -941,6 +946,149 @@ class ManagedCaptureRecorderBrowserTest {
             assertTrue(after.getX() < before.getX() && after.getY() < before.getY(),
                     "Dragging the header must move the panel, before=" + before.getPoint()
                             + " after=" + after.getPoint());
+        } finally {
+            if (recorder.status().state() == CaptureStatus.State.ACTIVE) {
+                recorder.interrupt();
+            }
+            server.stop(0);
+        }
+    }
+
+    /**
+     * Issue #3536 A1: icon-only header buttons show text labels for the first session until
+     * dismissed. The panel carries a {@code show-ctrl-labels} class while labels are visible, and
+     * dismissing persists {@code toolbarLabelsDismissed} so labels never come back for the rest of
+     * the session.
+     */
+    @Test
+    void overlayToolbarShowsFirstSessionLabelsUntilDismissed(@TempDir Path temp) throws Exception {
+        HttpServer server = localFixture();
+        Path output = temp.resolve("toolbar-labels.json");
+        ManagedCaptureRecorder recorder = new ManagedCaptureRecorder(new CaptureStartRequest(
+                "http://127.0.0.1:" + server.getAddress().getPort() + "/",
+                CaptureBrowser.parse("chrome"),
+                output,
+                temp.resolve("toolbar-labels-runtime"),
+                true));
+        try {
+            recorder.start();
+            WebDriver driver = recorder.driverForTesting();
+            JavascriptExecutor js = (JavascriptExecutor) driver;
+            waitFor(() -> elementPresent(driver, By.id("shaft-capture-labels-dismiss")));
+
+            assertTrue(driver.findElement(By.id("shaft-capture-ui")).getAttribute("class")
+                            .contains("show-ctrl-labels"),
+                    "Labels must be visible on the first session.");
+            assertTrue(driver.findElement(By.id("shaft-capture-assert"))
+                            .findElement(By.cssSelector(".ctrl-label")).isDisplayed(),
+                    "A visible control label must render inside the Assert button.");
+            assertTrue(driver.findElement(By.id("shaft-capture-labels-dismiss")).isDisplayed(),
+                    "The dismiss affordance must be visible while labels show.");
+
+            driver.findElement(By.id("shaft-capture-labels-dismiss")).click();
+            waitFor(() -> !driver.findElement(By.id("shaft-capture-ui")).getAttribute("class")
+                    .contains("show-ctrl-labels"));
+            assertFalse(driver.findElement(By.id("shaft-capture-ui")).getAttribute("class")
+                            .contains("show-ctrl-labels"),
+                    "Dismissing must hide the labels.");
+            assertEquals(Boolean.TRUE, js.executeScript(
+                            "return globalThis.__shaftCaptureUiState.toolbarLabelsDismissed;"),
+                    "Dismissing must persist toolbarLabelsDismissed.");
+
+            recorder.stop(false);
+        } finally {
+            if (recorder.status().state() == CaptureStatus.State.ACTIVE) {
+                recorder.interrupt();
+            }
+            server.stop(0);
+        }
+    }
+
+    /**
+     * Issue #3536 B5: each step row carries a "More actions" overflow menu holding assert/edit/
+     * delete, while up/down remain always-visible inline buttons. Opening the menu reveals the
+     * menu items; Esc closes it again.
+     */
+    @Test
+    void overlayStepRowOverflowMenuHoldsSecondaryActions(@TempDir Path temp) throws Exception {
+        HttpServer server = localFixture();
+        Path output = temp.resolve("overflow-menu.json");
+        ManagedCaptureRecorder recorder = new ManagedCaptureRecorder(new CaptureStartRequest(
+                "http://127.0.0.1:" + server.getAddress().getPort() + "/",
+                CaptureBrowser.parse("chrome"),
+                output,
+                temp.resolve("overflow-menu-runtime"),
+                true));
+        try {
+            recorder.start();
+            WebDriver driver = recorder.driverForTesting();
+            waitFor(() -> elementPresent(driver, By.id("shaft-capture-action-list")));
+            driver.findElement(By.id("username")).click();
+            waitFor(() -> !driver.findElements(By.cssSelector("#shaft-capture-action-list li")).isEmpty());
+
+            WebElement row = driver.findElements(By.cssSelector("#shaft-capture-action-list li")).get(0);
+            assertTrue(elementPresent(driver, By.cssSelector(
+                            "#shaft-capture-action-list li .row-overflow-toggle")),
+                    "Every row must carry a 'More actions' overflow toggle.");
+            assertTrue(row.findElement(By.cssSelector(
+                            ".action-row button[aria-label='Move captured action up']")).isDisplayed(),
+                    "Up must remain a direct, always-visible row button.");
+            assertTrue(row.findElement(By.cssSelector(
+                            ".action-row button[aria-label='Move captured action down']")).isDisplayed(),
+                    "Down must remain a direct, always-visible row button.");
+
+            WebElement toggle = row.findElement(By.cssSelector(".row-overflow-toggle"));
+            WebElement menu = row.findElement(By.cssSelector(".row-overflow-menu"));
+            assertFalse(menu.isDisplayed(), "The overflow menu must start closed.");
+            toggle.click();
+            waitFor(menu::isDisplayed);
+            assertEquals("true", toggle.getAttribute("aria-expanded"));
+            assertTrue(menu.findElement(By.cssSelector("button[aria-label='Edit captured action']"))
+                    .isDisplayed());
+            assertTrue(menu.findElement(By.cssSelector("button[aria-label='Delete captured action']"))
+                    .isDisplayed());
+
+            new Actions(driver).sendKeys(org.openqa.selenium.Keys.ESCAPE).perform();
+            waitFor(() -> !menu.isDisplayed());
+            assertEquals("false", toggle.getAttribute("aria-expanded"));
+
+            recorder.stop(false);
+        } finally {
+            if (recorder.status().state() == CaptureStatus.State.ACTIVE) {
+                recorder.interrupt();
+            }
+            server.stop(0);
+        }
+    }
+
+    /**
+     * Issue #3536 C1: the suppressed-events toggle/log DOM wiring exists from render time even
+     * before any suppression happens, and both stay hidden while {@code uiState.suppressedEvents}
+     * is empty. A real suppression only fires from the 10-second interaction-navigation window
+     * (issue #3496), which is not reproducible deterministically here, so this asserts the
+     * always-verifiable existence+visibility contract instead of a flaky live trigger.
+     */
+    @Test
+    void overlaySuppressedEventsLogStaysHiddenWithoutSuppressions(@TempDir Path temp) throws Exception {
+        HttpServer server = localFixture();
+        Path output = temp.resolve("suppressed-log.json");
+        ManagedCaptureRecorder recorder = new ManagedCaptureRecorder(new CaptureStartRequest(
+                "http://127.0.0.1:" + server.getAddress().getPort() + "/",
+                CaptureBrowser.parse("chrome"),
+                output,
+                temp.resolve("suppressed-log-runtime"),
+                true));
+        try {
+            recorder.start();
+            WebDriver driver = recorder.driverForTesting();
+            waitFor(() -> elementPresent(driver, By.id("shaft-capture-suppressed-toggle")));
+
+            assertFalse(driver.findElement(By.id("shaft-capture-suppressed-toggle")).isDisplayed(),
+                    "The suppressed-events toggle must stay hidden with no suppressed events yet.");
+            assertFalse(driver.findElement(By.id("shaft-capture-suppressed-log")).isDisplayed(),
+                    "The suppressed-events log must stay hidden with no suppressed events yet.");
+
+            recorder.stop(false);
         } finally {
             if (recorder.status().state() == CaptureStatus.State.ACTIVE) {
                 recorder.interrupt();


### PR DESCRIPTION
Addresses #3536 (follow-up to #3510). Delivers the bounded, top-frame-only overlay slices; defers the pieces that need protocol/transport/linkage changes (documented below).

## What changed
All in `shaft-capture/src/main/resources/browser/shaft-capture-recorder.js` (UI only — no wire-protocol change), reusing the existing `coachDismissed` session-persistence precedent (declare default → sanitize → `persist()`), top-frame gated.

- **A1 — first-session labeled toolbar.** Header buttons (assert/pick/stop, and the dynamic pause/resume) show text labels (`.ctrl-label`) on the first session until dismissed, via a new persisted `toolbarLabelsDismissed` flag, a `maybeShowToolbarLabels()` gate (mirroring `maybeShowCoach()`), and a "Hide labels" affordance.
- **B5 — step-row overflow menu + larger touch targets.** Secondary actions (assert/edit/delete) move into a per-row "More actions" (`⋯`) menu (`role="menu"`, items `role="menuitem"`); **up/down stay inline** for a11y. One document-level listener (installed once, not per row) closes the open menu on outside-click or `Esc`. Action buttons bumped to 32px min touch targets.
- **C1 — expert suppressed-events log.** An opt-in, persistent log of `Ignored:<reason>` navigations (new `suppressedEvents` array + `suppressedLogVisible` flag). The transient `Ignored:` note is unchanged; a `Show/Hide suppressed events (N)` toggle appears only when there is something to show, and the log renders via `textContent` only (never `innerHTML`).

## Tests (verified locally, headless)
- `CaptureCollectorUtilityTest` — script-marker assertions for the new IDs/state. **5/5 pass.**
- `ManagedCaptureRecorderBrowserTest` (real Chrome via the `capture-browser-e2e` profile, `-DheadlessExecution=true`) — three new `@Test` methods (`overlayToolbarShowsFirstSessionLabelsUntilDismissed`, `overlayStepRowOverflowMenuHoldsSecondaryActions`, `overlaySuppressedEventsLogStaysHiddenWithoutSuppressions`); the existing `overlayErgonomicsBadgesUndoHelpAndDrag` now opens the overflow menu before deleting (delete moved behind it). **4/4 pass, 0 failures/errors.**

## Deferred (with reasons — not in this PR)
- **B2 drag-and-drop reorder** — the server `step_reorder` protocol only understands single adjacent swaps by `direction`; translating a multi-position drag into repeated swaps risks the pipeline's byte-identical dedup collapsing same-millisecond signals. Deserves its own protocol decision (a target-index/`afterClientActionId` payload). ▲▼ reorder already works.
- **C5 cross-origin iframe warning** — no subframe→top-frame channel exists today (no `postMessage`/shared reachable state); surfacing it needs a new transport (most naturally via the server sink), which is a larger change.
- **C6 "used for codegen" badge** — needs new cross-step linkage state the overlay doesn't model.
- **B6 Guided-form progressive disclosure** — lives in the IntelliJ plugin / MCP start flow, not the overlay JS (cf. #3513/#3538).

🤖 Generated with [Claude Code](https://claude.com/claude-code)