### PR TITLE
feat: IntelliJ setup screen — shaft-mcp version check + copy-run install command (#3538)

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/SetupPrerequisites.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/SetupPrerequisites.java
@@ -91,10 +91,14 @@ final class SetupPrerequisites {
 
     private static final String ENGINE_METADATA_URL =
             "https://repo1.maven.org/maven2/io/github/shafthq/SHAFT_ENGINE/maven-metadata.xml";
+    private static final String MCP_METADATA_URL =
+            "https://repo1.maven.org/maven2/io/github/shafthq/shaft-mcp/maven-metadata.xml";
     private static final Pattern METADATA_RELEASE = Pattern.compile("<release>\\s*([^<\\s]+)\\s*</release>");
     private static final Pattern VERSION_LIKE = Pattern.compile("\\d+(\\.\\d+)+");
     private static final AtomicReference<String> RESOLVED_ENGINE_VERSION = new AtomicReference<>();
     private static final AtomicReference<CompletableFuture<Void>> ENGINE_VERSION_PREFETCH = new AtomicReference<>();
+    private static final AtomicReference<String> RESOLVED_MCP_VERSION = new AtomicReference<>();
+    private static final AtomicReference<CompletableFuture<Void>> MCP_VERSION_PREFETCH = new AtomicReference<>();
 
     /**
      * Pre-downloads SHAFT Engine and its transitive dependencies into the local Maven repository so
@@ -175,7 +179,40 @@ final class SetupPrerequisites {
         }
     }
 
+    /**
+     * Starts (at most once) a background resolution of the latest released shaft-mcp version from
+     * Maven Central, mirroring {@link #prefetchLatestEngineVersion()}, so a later EDT call to
+     * {@link #knownLatestMcpVersion()} never blocks on the network (issue #3538).
+     */
+    static void prefetchLatestMcpVersion() {
+        if (MCP_VERSION_PREFETCH.compareAndSet(null, new CompletableFuture<>())) {
+            CompletableFuture
+                    .runAsync(() -> {
+                        String release = releaseVersionFromMavenCentral(MCP_METADATA_URL);
+                        if (!release.isBlank()) {
+                            RESOLVED_MCP_VERSION.set(release);
+                        }
+                    })
+                    .whenComplete((ignored, error) -> MCP_VERSION_PREFETCH.get().complete(null));
+        }
+    }
+
+    /**
+     * Best-known latest shaft-mcp release as a concrete version number, or blank when the background
+     * resolution has not completed (yet) or the machine is offline. The setup flow's "SHAFT MCP
+     * version" step treats blank as a neutral, non-blocking "unknown" state — it never fails setup
+     * (issue #3538).
+     */
+    static String knownLatestMcpVersion() {
+        String resolved = RESOLVED_MCP_VERSION.get();
+        return isVersionLike(resolved) ? resolved : "";
+    }
+
     private static String releaseVersionFromMavenCentral() {
+        return releaseVersionFromMavenCentral(ENGINE_METADATA_URL);
+    }
+
+    private static String releaseVersionFromMavenCentral(String metadataUrl) {
         // No try-with-resources: HttpClient is only AutoCloseable on JDK 21+, and this module
         // still compiles with --release 17.
         try {
@@ -184,7 +221,7 @@ final class SetupPrerequisites {
                     .followRedirects(HttpClient.Redirect.NORMAL)
                     .build();
             HttpResponse<String> response = client.send(
-                    HttpRequest.newBuilder(URI.create(ENGINE_METADATA_URL))
+                    HttpRequest.newBuilder(URI.create(metadataUrl))
                             .timeout(Duration.ofSeconds(10))
                             .GET()
                             .build(),

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -112,6 +112,9 @@ final class ShaftMcpSetupPanel extends JPanel {
     private final JButton copyUpgradeCommand;
     private final JButton checkUpgrade;
     private final JLabel upgradeDetail;
+    private final JButton checkMcpVersion;
+    private final JButton copyMcpInstallCommand;
+    private final JLabel mcpVersionDetail;
     private final JButton copyInstallerCommand;
     private final JButton test;
     private final JButton startChatting;
@@ -130,6 +133,8 @@ final class ShaftMcpSetupPanel extends JPanel {
     private final JLabel installState;
     private final JLabel testStep;
     private final JLabel testState;
+    private final JLabel mcpVersionStep;
+    private final JLabel mcpVersionState;
     private final JLabel readyState;
     private final JLabel status;
     private final JLabel recommendedAgent;
@@ -151,6 +156,7 @@ final class ShaftMcpSetupPanel extends JPanel {
     private final JPanel chooseRow;
     private final JPanel installRow;
     private final JPanel checkRow;
+    private final JPanel mcpVersionRow;
     private final JPanel chatRow;
     private java.util.function.Function<String, List<SetupPrerequisites.Prerequisite>> prerequisitesDetector =
             SetupPrerequisites::detect;
@@ -166,6 +172,10 @@ final class ShaftMcpSetupPanel extends JPanel {
     /** Runs the real project-vs-latest SHAFT version comparison; injectable for tests. */
     private java.util.function.Supplier<ShaftProjectVersionCheck.Result> upgradeChecker = () ->
             ShaftProjectVersionCheck.check(projectRoot(), SetupPrerequisites.knownLatestEngineVersion());
+    private ShaftMcpVersionCheck.Result mcpVersionCheckResult;
+    /** Runs the real installed-vs-latest shaft-mcp version comparison; injectable for tests. */
+    private java.util.function.Supplier<ShaftMcpVersionCheck.Result> mcpVersionChecker = () ->
+            ShaftMcpVersionCheck.check(installedShaftMcpVersion(), SetupPrerequisites.knownLatestMcpVersion());
     /**
      * Opens a terminal tab (name, command) with the command pre-typed; injectable for tests.
      * Returns whether the terminal actually opened so status text can say what really happened.
@@ -293,6 +303,18 @@ final class ShaftMcpSetupPanel extends JPanel {
         applyLabeledAction(checkUpgrade, ShaftIcons.CHECK);
         checkUpgrade.addActionListener(event -> runUpgradeCheck(true));
         upgradeDetail = setupStatusLabel("SHAFT project version status");
+        checkMcpVersion = new JButton("Check");
+        checkMcpVersion.getAccessibleContext().setAccessibleName("Check SHAFT MCP version");
+        checkMcpVersion.setToolTipText("Compare the installed SHAFT MCP version against the latest release");
+        applyLabeledAction(checkMcpVersion, ShaftIcons.CHECK);
+        checkMcpVersion.addActionListener(event -> runMcpVersionCheck(true));
+        copyMcpInstallCommand = new JButton("Copy command");
+        copyMcpInstallCommand.getAccessibleContext().setAccessibleName("Copy SHAFT MCP install command");
+        copyMcpInstallCommand.setToolTipText("Copy the SHAFT MCP install/update command and open a terminal with "
+                + "it pre-typed — just press Enter there to run it");
+        applyLabeledAction(copyMcpInstallCommand, ShaftIcons.COPY);
+        copyMcpInstallCommand.addActionListener(event -> copyMcpInstallCommand());
+        mcpVersionDetail = setupStatusLabel("SHAFT MCP version status");
         copyInstallerCommand = new JButton("Copy command");
         copyInstallerCommand.getAccessibleContext().setAccessibleName("Copy MCP installer command");
         copyInstallerCommand.setToolTipText("Copy the installer command and open a terminal with it pre-typed "
@@ -418,6 +440,8 @@ final class ShaftMcpSetupPanel extends JPanel {
         installState = setupStateLabel("Install SHAFT MCP setup state");
         testStep = setupStepLabel("Check now setup step");
         testState = setupStateLabel("Check now setup state");
+        mcpVersionStep = setupStepLabel("SHAFT MCP version setup step");
+        mcpVersionState = setupStateLabel("SHAFT MCP version setup state");
         readyState = setupStateLabel("Start chatting setup state");
         JPanel agentControls = new JPanel();
         agentControls.setLayout(new javax.swing.BoxLayout(agentControls, javax.swing.BoxLayout.Y_AXIS));
@@ -444,10 +468,16 @@ final class ShaftMcpSetupPanel extends JPanel {
         installActions.setOpaque(false);
         installActions.add(copyInstallerCommand);
         installActions.add(installShaftCli);
+        JPanel mcpVersionActions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
+        mcpVersionActions.setOpaque(false);
+        mcpVersionActions.add(checkMcpVersion);
+        mcpVersionActions.add(copyMcpInstallCommand);
+        mcpVersionActions.add(mcpVersionDetail);
         upgradeRow = stepRow(upgradeStep, upgradeState, upgradeActions);
         chooseRow = stepRow(chooseStep, chooseState, agentControls);
         installRow = stepRow(installStep, installState, installActions);
         checkRow = stepRow(testStep, testState, checkActions);
+        mcpVersionRow = stepRow(mcpVersionStep, mcpVersionState, mcpVersionActions);
         prerequisitesList = new JPanel();
         prerequisitesList.setLayout(new javax.swing.BoxLayout(prerequisitesList, javax.swing.BoxLayout.Y_AXIS));
         prerequisitesList.setOpaque(false);
@@ -460,6 +490,8 @@ final class ShaftMcpSetupPanel extends JPanel {
         JButton copyEngineWarmup = new JButton("Copy SHAFT Engine warm-up command");
         // Resolve the latest engine release off-EDT now so the click below can pin a real version.
         SetupPrerequisites.prefetchLatestEngineVersion();
+        // Same fire-once, off-EDT pattern for the latest shaft-mcp release (issue #3538).
+        SetupPrerequisites.prefetchLatestMcpVersion();
         copyEngineWarmup.getAccessibleContext().setAccessibleName("Copy SHAFT Engine warm-up command");
         copyEngineWarmup.setToolTipText("Copy a Maven command that downloads SHAFT Engine and its dependencies "
                 + "into the local Maven repository so future projects reuse them without re-downloading; "
@@ -509,6 +541,8 @@ final class ShaftMcpSetupPanel extends JPanel {
         workflow.add(installRow);
         workflow.add(javax.swing.Box.createVerticalStrut(6));
         workflow.add(checkRow);
+        workflow.add(javax.swing.Box.createVerticalStrut(6));
+        workflow.add(mcpVersionRow);
         workflow.add(javax.swing.Box.createVerticalStrut(6));
         workflow.add(chatRow);
         JPanel targetRow = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
@@ -605,6 +639,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         refreshPrerequisites();
         refreshRealChecks();
         runUpgradeCheck(false);
+        runMcpVersionCheck(false);
         if (!currentCommand().isBlank()) {
             setStatusText(CHECK_NEXT_STEP);
         }
@@ -668,6 +703,41 @@ final class ShaftMcpSetupPanel extends JPanel {
                     + "workflow) to scaffold one, then press Check.";
             case LATEST_UNKNOWN -> "SHAFT " + upgradeCheckResult.projectVersion() + " detected, but the latest "
                     + "release could not be determined (offline?). Press Check to retry.";
+        };
+    }
+
+    /**
+     * Runs the real "SHAFT MCP version" check: compares the installed shaft-mcp version (detected
+     * from disk) against the latest released version, and reflects the truth in the step badge and
+     * detail label. This row never gates the rest of the setup flow — an unknown latest version
+     * (offline) is a neutral state, never a failure (issue #3538).
+     */
+    private void runMcpVersionCheck(boolean announce) {
+        mcpVersionCheckResult = mcpVersionChecker.get();
+        mcpVersionDetail.setText(mcpVersionDetailText());
+        mcpVersionDetail.setForeground(switch (mcpVersionCheckResult.state()) {
+            case UP_TO_DATE -> ShaftStatusPresentation.success();
+            case UPGRADE_AVAILABLE -> ShaftStatusPresentation.progress();
+            default -> ShaftStatusPresentation.pending();
+        });
+        if (announce) {
+            setStatusText(mcpVersionDetailText());
+        }
+        updateActionState(false);
+    }
+
+    private String mcpVersionDetailText() {
+        if (mcpVersionCheckResult == null) {
+            return "";
+        }
+        return switch (mcpVersionCheckResult.state()) {
+            case UP_TO_DATE -> "SHAFT MCP " + mcpVersionCheckResult.installedVersion() + " is up to date.";
+            case UPGRADE_AVAILABLE -> "Update available — installed " + mcpVersionCheckResult.installedVersion()
+                    + ", latest " + mcpVersionCheckResult.latestVersion() + ".";
+            case NOT_INSTALLED -> "SHAFT MCP is not installed yet.";
+            case LATEST_UNKNOWN -> "Couldn't check the latest SHAFT MCP version (offline); installed: "
+                    + (mcpVersionCheckResult.installedVersion().isBlank()
+                    ? "none" : mcpVersionCheckResult.installedVersion()) + ".";
         };
     }
 
@@ -924,6 +994,13 @@ final class ShaftMcpSetupPanel extends JPanel {
         copyUpgradeCommand.setVisible(!upgradeDone);
         copyUpgradeCommand.setEnabled(!running && !upgradeDone);
         checkUpgrade.setEnabled(!running);
+        // Never gates the rest of setup (issue #3538): the copy button stays available for every
+        // state except an already-up-to-date install, including the offline LATEST_UNKNOWN state.
+        boolean mcpVersionUpToDate = mcpVersionCheckResult != null
+                && mcpVersionCheckResult.state() == ShaftMcpVersionCheck.State.UP_TO_DATE;
+        copyMcpInstallCommand.setVisible(!mcpVersionUpToDate);
+        copyMcpInstallCommand.setEnabled(!running && !mcpVersionUpToDate);
+        checkMcpVersion.setEnabled(!running);
         startChatting.setVisible((complete && !startWithoutAgent.isVisible()) || startChatting.isVisible());
         startChatting.setEnabled(!running && startChatting.isVisible());
         startWithoutAgent.setEnabled(!running && startWithoutAgent.isVisible());
@@ -1240,6 +1317,25 @@ final class ShaftMcpSetupPanel extends JPanel {
         test.requestFocusInWindow();
     }
 
+    /**
+     * Copies the SHAFT MCP install/update command for the selected client. Install and upgrade are
+     * the same command — re-running the installer script always fetches the latest release — so
+     * there is no separate "install" vs "upgrade" flavor of this command (issue #3538).
+     */
+    private void copyMcpInstallCommand() {
+        String command = installerCommandFor(installerArgumentFor(String.valueOf(installerTarget.getSelectedItem())));
+        copy(command, "Copied SHAFT MCP install command");
+        boolean opened = terminalOpener.test("SHAFT MCP install", command);
+        if (opened) {
+            openIntellijTerminal();
+        }
+        setStatusText(opened
+                ? "Terminal opened with the SHAFT MCP install command pre-typed. Press Enter there to run it; "
+                + "when it finishes, press Check."
+                : "SHAFT MCP install command copied. Paste it into a terminal, run it; when it finishes, press Check.");
+        updateActionState(false);
+    }
+
     private void resetAndCopyInstaller() {
         clearDiagnostics();
         mcpCommand.setText("");
@@ -1321,6 +1417,24 @@ final class ShaftMcpSetupPanel extends JPanel {
         }
         Path java = installerJava(bootstrapRoot);
         return quote(java == null ? "java" : java.toString()) + " " + quote("@" + argsFile);
+    }
+
+    /**
+     * Installed shaft-mcp version, read from the parent directory name of the newest
+     * {@code versions/<version>/shaft-mcp.args} on disk — the same file
+     * {@link #inferInstalledStdioCommand(Path, Path)} already reads to build the stdio command
+     * (issue #3538). Blank when nothing is installed.
+     */
+    static String installedShaftMcpVersion(Path applicationDataRoot) {
+        Path argsFile = latestArgsFile(applicationDataRoot);
+        if (argsFile == null || argsFile.getParent() == null) {
+            return "";
+        }
+        return String.valueOf(argsFile.getParent().getFileName());
+    }
+
+    private static String installedShaftMcpVersion() {
+        return installedShaftMcpVersion(applicationDataRoot());
     }
 
     private static Path latestArgsFile(Path applicationDataRoot) {
@@ -1693,6 +1807,22 @@ final class ShaftMcpSetupPanel extends JPanel {
         return installedCommandDetected || hasCommand ? "next" : "wait";
     }
 
+    /**
+     * Never "failed" (issue #3538): an offline latest-version lookup is surfaced as "optional" —
+     * the same neutral badge the upgrade step's LATEST_UNKNOWN uses — so this row can never block
+     * the rest of setup.
+     */
+    private String mcpVersionStepState() {
+        if (mcpVersionCheckResult == null) {
+            return "optional";
+        }
+        return switch (mcpVersionCheckResult.state()) {
+            case UP_TO_DATE -> "done";
+            case UPGRADE_AVAILABLE, NOT_INSTALLED -> "next";
+            case LATEST_UNKNOWN -> "optional";
+        };
+    }
+
     private void updateSetupSteps(boolean running) {
         boolean hasCommand = !currentCommand().isBlank();
         boolean complete = settings.mcpSetupComplete && hasCommand;
@@ -1700,6 +1830,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         setStep(chooseStep, chooseState, "2 Pick agent", chooseStepState());
         setStep(installStep, installState, "3 Install SHAFT MCP", installStepState(hasCommand));
         setStep(testStep, testState, "4 Check setup", checkStepState(running, complete, hasCommand));
+        setStep(mcpVersionStep, mcpVersionState, "SHAFT MCP version", mcpVersionStepState());
         setStep(null, readyState, "Ready", complete ? "next" : "wait");
     }
 
@@ -1710,6 +1841,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         styleStepRow(chooseRow, chooseStepState());
         styleStepRow(installRow, installStepState(hasCommand));
         styleStepRow(checkRow, checkStepState(running, complete, hasCommand));
+        styleStepRow(mcpVersionRow, mcpVersionStepState());
         styleStepRow(chatRow, complete ? "next" : "wait");
     }
 

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpVersionCheck.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpVersionCheck.java
@@ -1,0 +1,59 @@
+package com.shaft.intellij.ui;
+
+/**
+ * Real check for the setup flow's "SHAFT MCP version" step (issue #3538): compares the installed
+ * shaft-mcp version — detected from the newest {@code versions/<version>/shaft-mcp.args} on disk —
+ * against the latest released version. Mirrors {@link ShaftProjectVersionCheck}'s shape but is
+ * scoped to shaft-mcp itself rather than the project's SHAFT Engine dependency, and never reports a
+ * blocking outcome: an unknown latest version is a neutral state, not a failure.
+ */
+final class ShaftMcpVersionCheck {
+
+    /**
+     * Outcome of one check.
+     */
+    enum State {
+        /** No installed shaft-mcp was found on disk. */
+        NOT_INSTALLED,
+        /** Installed shaft-mcp is at or above the latest known release. */
+        UP_TO_DATE,
+        /** Installed shaft-mcp is below the latest known release. */
+        UPGRADE_AVAILABLE,
+        /** The latest release (or the installed version) could not be determined (offline). */
+        LATEST_UNKNOWN
+    }
+
+    /**
+     * One check result.
+     *
+     * @param state            comparison outcome
+     * @param installedVersion version detected on disk, or blank when not installed
+     * @param latestVersion    latest released version used for comparison, or blank when unknown
+     */
+    record Result(State state, String installedVersion, String latestVersion) {
+    }
+
+    private ShaftMcpVersionCheck() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static Result check(String installed, String latest) {
+        String installedTrimmed = installed == null ? "" : installed.trim();
+        String latestTrimmed = latest == null ? "" : latest.trim();
+        if (installedTrimmed.isBlank()) {
+            return new Result(State.NOT_INSTALLED, "", latestTrimmed);
+        }
+        if (latestTrimmed.isBlank() || !ShaftProjectVersionCheck.isVersionLike(latestTrimmed)
+                || !ShaftProjectVersionCheck.isVersionLike(installedTrimmed)) {
+            // Can't compare either way — still surface the install/update command rather than
+            // blocking, since offline is expected and must never fail the setup flow.
+            return new Result(State.LATEST_UNKNOWN, installedTrimmed, latestTrimmed);
+        }
+        return new Result(
+                ShaftProjectVersionCheck.compareVersions(installedTrimmed, latestTrimmed) >= 0
+                        ? State.UP_TO_DATE
+                        : State.UPGRADE_AVAILABLE,
+                installedTrimmed,
+                latestTrimmed);
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
@@ -181,6 +181,12 @@ public final class ShaftToolWindowPanel extends JPanel {
                 if (value instanceof WorkflowView workflow) {
                     label.setIcon(workflow.icon());
                     label.setIconTextGap(6);
+                    // Screen readers announce what each workflow does, not just its short name
+                    // (issue #3538 G4).
+                    String description = workflowDescription(workflow.label());
+                    if (!description.isBlank()) {
+                        label.getAccessibleContext().setAccessibleDescription(description);
+                    }
                 }
                 return label;
             }
@@ -431,6 +437,27 @@ public final class ShaftToolWindowPanel extends JPanel {
 
     private static boolean mcpReady(ShaftSettingsState.Settings settings) {
         return settings != null && settings.mcpReady();
+    }
+
+    /**
+     * One-line description of what each workflow selector entry does, announced by screen readers
+     * alongside the short label (issue #3538 G4). Blank for any future label added here without a
+     * matching case, so a missing entry degrades to "no description" rather than a crash.
+     */
+    private static String workflowDescription(String label) {
+        return switch (label) {
+            case "Assistant" -> "Chat with the SHAFT Assistant to record, generate, and diagnose tests";
+            case "Guided" -> "Step-by-step guided workflow across recording, code generation, and diagnosis";
+            case "Recorder" -> "Record browser or mobile actions into SHAFT test code";
+            case "Inspector" -> "Inspect page or app elements and pick resilient locators";
+            case "Triage" -> "Review failed test evidence and get suggested fixes";
+            case "SHAFT Tests" -> "Run and review SHAFT Engine test suites";
+            case "Visual Baselines" -> "Manage and compare visual regression baselines";
+            case "Evidence" -> "Doctor and healer tools for failure evidence";
+            case "Projects" -> "Create or upgrade SHAFT projects";
+            case "Advanced" -> "Raw SHAFT MCP tool catalog for advanced users";
+            default -> "";
+        };
     }
 
     record WorkflowView(String label, JComponent component, Icon icon) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftMcpVersionCheckTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftMcpVersionCheckTest.java
@@ -1,0 +1,56 @@
+package com.shaft.intellij.ui;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Pure, no-IO coverage of {@link ShaftMcpVersionCheck}'s state branches (issue #3538).
+ */
+class ShaftMcpVersionCheckTest {
+    @Test
+    void blankInstalledIsNotInstalledRegardlessOfLatest() {
+        assertAll(
+                () -> assertEquals(ShaftMcpVersionCheck.State.NOT_INSTALLED,
+                        ShaftMcpVersionCheck.check("", "10.3.20260710").state()),
+                () -> assertEquals(ShaftMcpVersionCheck.State.NOT_INSTALLED,
+                        ShaftMcpVersionCheck.check(null, "").state()),
+                () -> assertEquals(ShaftMcpVersionCheck.State.NOT_INSTALLED,
+                        ShaftMcpVersionCheck.check("   ", "10.3.20260710").state()));
+    }
+
+    @Test
+    void blankOrNonVersionLikeLatestIsUnknownButNeverBlocking() {
+        ShaftMcpVersionCheck.Result blankLatest = ShaftMcpVersionCheck.check("10.3.20260703", "");
+        ShaftMcpVersionCheck.Result garbageLatest = ShaftMcpVersionCheck.check("10.3.20260703", "RELEASE");
+        assertAll(
+                () -> assertEquals(ShaftMcpVersionCheck.State.LATEST_UNKNOWN, blankLatest.state()),
+                () -> assertEquals("10.3.20260703", blankLatest.installedVersion()),
+                () -> assertEquals(ShaftMcpVersionCheck.State.LATEST_UNKNOWN, garbageLatest.state()));
+    }
+
+    @Test
+    void nonVersionLikeInstalledIsAlsoUnknownEvenWithGoodLatest() {
+        assertEquals(ShaftMcpVersionCheck.State.LATEST_UNKNOWN,
+                ShaftMcpVersionCheck.check("dev-build", "10.3.20260710").state());
+    }
+
+    @Test
+    void installedAtOrAboveLatestIsUpToDate() {
+        assertAll(
+                () -> assertEquals(ShaftMcpVersionCheck.State.UP_TO_DATE,
+                        ShaftMcpVersionCheck.check("10.3.20260710", "10.3.20260710").state()),
+                () -> assertEquals(ShaftMcpVersionCheck.State.UP_TO_DATE,
+                        ShaftMcpVersionCheck.check("10.3.20260801", "10.3.20260710").state()));
+    }
+
+    @Test
+    void installedBelowLatestIsUpgradeAvailableWithBothVersionsPreserved() {
+        ShaftMcpVersionCheck.Result result = ShaftMcpVersionCheck.check("10.2.20260101", "10.3.20260710");
+        assertAll(
+                () -> assertEquals(ShaftMcpVersionCheck.State.UPGRADE_AVAILABLE, result.state()),
+                () -> assertEquals("10.2.20260101", result.installedVersion()),
+                () -> assertEquals("10.3.20260710", result.latestVersion()));
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -709,6 +709,84 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void setupPanelMcpVersionStepReflectsRealVersionCheck() throws Exception {
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
+        });
+        JLabel mcpVersionState = findByAccessibleName(panel, "SHAFT MCP version setup state", JLabel.class);
+        JLabel mcpVersionDetail = findByAccessibleName(panel, "SHAFT MCP version status", JLabel.class);
+
+        // Installed at or above the latest release is green without any clicks, matching the
+        // "Upgrade project" row's real-check pattern (issue #3538).
+        setField(panel, "mcpVersionChecker", (java.util.function.Supplier<ShaftMcpVersionCheck.Result>) () ->
+                new ShaftMcpVersionCheck.Result(
+                        ShaftMcpVersionCheck.State.UP_TO_DATE, "10.3.20260710", "10.3.20260710"));
+        clickAccessible(panel, "Check SHAFT MCP version");
+        assertAll(
+                () -> assertEquals("Done", mcpVersionState.getText()),
+                () -> assertTrue(mcpVersionDetail.getText().contains("is up to date")),
+                () -> assertFalse(
+                        findByAccessibleName(panel, "Copy SHAFT MCP install command", JButton.class).isVisible()));
+
+        // Installed but behind the latest release keeps the row actionable.
+        setField(panel, "mcpVersionChecker", (java.util.function.Supplier<ShaftMcpVersionCheck.Result>) () ->
+                new ShaftMcpVersionCheck.Result(
+                        ShaftMcpVersionCheck.State.UPGRADE_AVAILABLE, "10.2.20260101", "10.3.20260710"));
+        clickAccessible(panel, "Check SHAFT MCP version");
+        assertAll(
+                () -> assertEquals("Next", mcpVersionState.getText()),
+                () -> assertTrue(mcpVersionDetail.getText().contains("latest 10.3.20260710")),
+                () -> assertTrue(
+                        findByAccessibleName(panel, "Copy SHAFT MCP install command", JButton.class).isVisible()));
+
+        // Nothing installed offers the install command.
+        setField(panel, "mcpVersionChecker", (java.util.function.Supplier<ShaftMcpVersionCheck.Result>) () ->
+                new ShaftMcpVersionCheck.Result(ShaftMcpVersionCheck.State.NOT_INSTALLED, "", ""));
+        clickAccessible(panel, "Check SHAFT MCP version");
+        assertAll(
+                () -> assertEquals("Next", mcpVersionState.getText()),
+                () -> assertTrue(mcpVersionDetail.getText().contains("not installed yet")),
+                () -> assertTrue(
+                        findByAccessibleName(panel, "Copy SHAFT MCP install command", JButton.class).isVisible()));
+
+        // Offline (latest unknown) is a neutral, non-blocking "Optional" badge — never "Failed"
+        // and never disables the rest of setup (issue #3538).
+        setField(panel, "mcpVersionChecker", (java.util.function.Supplier<ShaftMcpVersionCheck.Result>) () ->
+                new ShaftMcpVersionCheck.Result(ShaftMcpVersionCheck.State.LATEST_UNKNOWN, "10.3.20260703", ""));
+        clickAccessible(panel, "Check SHAFT MCP version");
+        assertAll(
+                () -> assertEquals("Optional", mcpVersionState.getText()),
+                () -> assertTrue(mcpVersionDetail.getText().contains("offline")),
+                () -> assertTrue(mcpVersionDetail.getText().contains("10.3.20260703")),
+                () -> assertTrue(
+                        findByAccessibleName(panel, "Copy SHAFT MCP install command", JButton.class).isVisible()),
+                () -> assertTrue(findByAccessibleName(panel, "Test SHAFT MCP connection", JButton.class).isVisible(),
+                        "the MCP version row must never gate the rest of setup"));
+    }
+
+    @Test
+    void setupPanelDetectsRealInstalledMcpVersionFromDisk() throws Exception {
+        Path appData = tempDirectory("shaft-mcp-app-data");
+        Path argsFile = appData.resolve("versions").resolve("10.3.20260703").resolve("shaft-mcp.args");
+        Files.createDirectories(argsFile.getParent());
+        Files.writeString(argsFile, "-cp\nshaft-mcp.jar\ncom.shaft.mcp.ShaftMcpApplication\n");
+        String oldAppData = System.getProperty("shaft.intellij.mcp.applicationDataRoot");
+        System.setProperty("shaft.intellij.mcp.applicationDataRoot", appData.toString());
+        try {
+            assertEquals("10.3.20260703", ShaftMcpSetupPanel.installedShaftMcpVersion(appData));
+
+            // Real on-disk detection runs once in the constructor (issue #3538); regardless of
+            // network availability for the "latest" half of the comparison, the installed version
+            // this test just wrote to disk must flow through into the row's detail text.
+            ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
+            });
+            JLabel mcpVersionDetail = findByAccessibleName(panel, "SHAFT MCP version status", JLabel.class);
+            assertTrue(mcpVersionDetail.getText().contains("10.3.20260703"), mcpVersionDetail.getText());
+        } finally {
+            restoreProperty("shaft.intellij.mcp.applicationDataRoot", oldAppData);
+        }
+    }
+
+    @Test
     void setupPanelScrollsVerticallyAndNeverHorizontally() {
         ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
         });
@@ -2525,6 +2603,9 @@ class ShaftPanelSetupTest {
                 .filter(button -> !"Reset everything".equals(accessibleName(button)))
                 .filter(button -> !"Copy SHAFT upgrade command".equals(accessibleName(button)))
                 .filter(button -> !"Check SHAFT project version".equals(accessibleName(button)))
+                // The shaft-mcp version step's check button is labeled like its upgrade-step peer
+                // above: it names the exact check being run on a first-run setup screen (issue #3538).
+                .filter(button -> !"Check SHAFT MCP version".equals(accessibleName(button)))
                 // Lane/teaching controls keep visible labels by design: the no-agent start names
                 // its lane (issue #3425 A2/B7/A6), and the health-chip recheck is a compact
                 // header action.


### PR DESCRIPTION
Addresses #3538. Centerpiece is a **scope addition requested during the issue sweep**: the initial setup screen now checks the installed shaft-mcp version against the latest and offers a copy-and-run install command when stale/missing. Also lands **G4** (a11y). Other #3538 items are deferred (below).

## What changed
- **Latest version** (`SetupPrerequisites`): resolved off-EDT from Maven Central (`io.github.shafthq:shaft-mcp` `maven-metadata.xml`), fire-once into an `AtomicReference`, mirroring the existing engine-version prefetch and reusing the shared metadata parser.
- **Installed version** (`ShaftMcpSetupPanel`): read from the newest `versions/<version>/shaft-mcp.args` directory name (the same file the stdio-command inference already uses).
- **Comparison** (`ShaftMcpVersionCheck`, new): pure `NOT_INSTALLED / UP_TO_DATE / UPGRADE_AVAILABLE / LATEST_UNKNOWN`, reusing `ShaftProjectVersionCheck.compareVersions`/`isVersionLike`.
- **Setup row**: a new "SHAFT MCP version" row (Check + Copy command + detail label) mirroring the existing "Upgrade project" row. The **install command is the update command** — re-running the installer fetches the latest, so there is no separate flavor. Copy button shows for every state except already-up-to-date. **Non-blocking**: offline → a neutral "Optional" state, never an error, never gates the Assistant.
- **G4 (a11y)**: workflow-selector items get `AccessibleDescription` so screen readers announce what each workflow does.

## Row states
| State | Badge | Detail | Copy button |
|---|---|---|---|
| Up to date | Done | `SHAFT MCP <v> is up to date.` | hidden |
| Update available | Next | `Update available — installed <a>, latest <b>.` | shown |
| Not installed | Next | `SHAFT MCP is not installed yet.` | shown |
| Offline | Optional | `Couldn't check the latest SHAFT MCP version (offline); installed: <v or none>.` | shown |

## Verification (JDK21 Gradle)
- `ShaftMcpVersionCheckTest` (5 state branches) + `ShaftPanelSetupTest` (incl. real on-disk detection via `-Dshaft.intellij.mcp.applicationDataRoot`, and all-4-states via injected checker) — **green**.
- `ShaftPluginScreenshotRendererTest` — **green**; the new row renders within bounds (`verifySetupPanelLabelsAndBackground` asserts no cropped label). Setup screen renders the row as "SHAFT MCP <version> is up to date" in the up-to-date fixture.

## Deferred from #3538 (not in this PR — larger/higher-churn, tracked for follow-up)
- **S2** setup-density collapse (highest screenshot re-baseline churn), **S4** safe re-enter setup, **A3** first-session tooltip coach, **G3** progressive-nav soft prompts, **O3** fresh/consumer-project hints, **A5** raw-JSON-behind-Details disclosure widget, and the broad **a11y keyboard/screen-reader pass**. G4 (selector descriptions) is done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)