### PR TITLE
fix: Assistant first-run welcome-in-chat + fix clipped Got it/chip overlap

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantTranscriptView.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantTranscriptView.java
@@ -397,6 +397,43 @@ final class AssistantTranscriptView extends JPanel {
         return row;
     }
 
+    /**
+     * Renders an assistant-styled bubble containing {@code markdown} plus a trailing
+     * {@code actions} row (for example a "Got it" dismiss button), sharing the exact bubble chrome
+     * and word-wrap-safe {@link WidthAwareHtmlPane} rendering that persisted transcript messages
+     * use via {@link #fallbackMessage}. Intended for {@link #showWidget(String, JComponent)}
+     * callers (namely the first-run welcome) that need an assistant bubble look without adding
+     * anything to the persisted {@link #messages}/{@link #markdown} model. The returned component
+     * is plain content, not a pre-aligned row: {@link #showWidget(String, JComponent)} applies the
+     * same West/East alignment {@link #fallbackMessage} applies directly.
+     */
+    JComponent assistantBubbleWithActions(String markdown, JComponent actions) {
+        Color background = resolvedColor("Panel.background", new Color(0xF6F8FA));
+        Color foreground = resolvedColor("TextArea.foreground", new Color(0x202020));
+        Color stroke = resolvedColor("Component.borderColor", new Color(0xD0D7DE));
+        RoundedBubblePanel bubble = new RoundedBubblePanel(background, stroke, 18);
+        bubble.setLayout(new BorderLayout(0, 8));
+        bubble.setBorder(JBUI.Borders.empty(9, 11));
+        bubble.setBackground(background);
+        bubble.setForeground(foreground);
+        bubble.putClientProperty(TRANSCRIPT_BUBBLE_PROPERTY, UNKNOWN_ROLE);
+        bubble.getAccessibleContext().setAccessibleName("Assistant welcome message bubble");
+        JEditorPane htmlPane = fallbackHtmlPane(convertMarkdown(markdown), foreground, background);
+        htmlPane.putClientProperty(TRANSCRIPT_ROLE_PROPERTY, UNKNOWN_ROLE);
+        // Unlike a persisted fallbackMessage() pane, this one can exist in the tree of a freshly
+        // constructed, otherwise message-less panel (the welcome shows before any real message
+        // exists), so it needs its own accessible name rather than relying on siblings for context.
+        htmlPane.getAccessibleContext().setAccessibleName("Assistant welcome message content");
+        bubble.add(htmlPane, BorderLayout.CENTER);
+        if (actions != null) {
+            JPanel actionsRow = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+            actionsRow.setOpaque(false);
+            actionsRow.add(actions);
+            bubble.add(actionsRow, BorderLayout.SOUTH);
+        }
+        return bubble;
+    }
+
     private JEditorPane fallbackHtmlPane(String html, Color foreground, Color background) {
         JEditorPane htmlPane = new WidthAwareHtmlPane(this::fallbackBubbleContentWidth);
         htmlPane.setContentType("text/html");

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantTranscriptView.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantTranscriptView.java
@@ -419,6 +419,10 @@ final class AssistantTranscriptView extends JPanel {
         bubble.putClientProperty(TRANSCRIPT_BUBBLE_PROPERTY, UNKNOWN_ROLE);
         bubble.getAccessibleContext().setAccessibleName("Assistant welcome message bubble");
         JEditorPane htmlPane = fallbackHtmlPane(convertMarkdown(markdown), foreground, background);
+        // JEditorPane under-reports the preferred height of a trailing HTML list by roughly its last
+        // item's bottom margin, which cropped the final "Review code into a test" step against the
+        // actions row below. Reserve extra bottom room so BorderLayout gives the pane enough height.
+        htmlPane.setBorder(JBUI.Borders.emptyBottom(JBUI.scale(10)));
         htmlPane.putClientProperty(TRANSCRIPT_ROLE_PROPERTY, UNKNOWN_ROLE);
         // Unlike a persisted fallbackMessage() pane, this one can exist in the tree of a freshly
         // constructed, otherwise message-less panel (the welcome shows before any real message

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -114,11 +114,12 @@ final class ShaftAssistantPanel extends JPanel {
      * shown once via {@link #showFirstRunWelcomeIfNeeded()} until dismissed.
      */
     private static final String FIRST_RUN_WELCOME_MARKDOWN =
-            "👋 I'm the SHAFT Assistant. I can record flows, generate tests, and diagnose failures.\n\n"
-                    + "**First run**\n\n"
-                    + "1. Check setup (header strip)\n"
-                    + "2. Record a sample flow\n"
-                    + "3. Review code into a test";
+            "👋 Hi! I'm the SHAFT Assistant — I turn what you do in your app into real tests.\n\n"
+                    + "**Let's get started 🚀**\n\n"
+                    + "1. ⚙️ Check your setup in the status strip up top.\n"
+                    + "2. 🎬 Record a sample flow — just click around your app.\n"
+                    + "3. 🧪 Review code to turn it into a real test.\n"
+                    + "4. 💬 Or just tell me what you need below.";
     private final Project project;
     private final ShaftAssistantChatState chatState;
     private final JComboBox<ShaftAssistantChatState.Session> chatSelector;

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -109,6 +109,16 @@ final class ShaftAssistantPanel extends JPanel {
                     + "before any actions were captured) or code generation may have failed silently. "
                     + "Record the journey again, confirm the recording actually captured actions, then "
                     + "ask for a test generated from that recording._";
+    /**
+     * First-run welcome (issue #3500 O1, follow-up #3540): the Assistant's own first message,
+     * shown once via {@link #showFirstRunWelcomeIfNeeded()} until dismissed.
+     */
+    private static final String FIRST_RUN_WELCOME_MARKDOWN =
+            "👋 I'm the SHAFT Assistant. I can record flows, generate tests, and diagnose failures.\n\n"
+                    + "**First run**\n\n"
+                    + "1. Check setup (header strip)\n"
+                    + "2. Record a sample flow\n"
+                    + "3. Review code into a test";
     private final Project project;
     private final ShaftAssistantChatState chatState;
     private final JComboBox<ShaftAssistantChatState.Session> chatSelector;
@@ -356,6 +366,8 @@ final class ShaftAssistantPanel extends JPanel {
             transcript.setMessages(chatState.activeMessages());
             lastPrompt = latestUserPrompt();
             updateContextTruncationBoundary();
+        } else {
+            showFirstRunWelcomeIfNeeded();
         }
         status = new JLabel(READY_STATUS);
         status.getAccessibleContext().setAccessibleName("Assistant status");
@@ -756,6 +768,20 @@ final class ShaftAssistantPanel extends JPanel {
         append(role, message, rawResponse);
     }
 
+    /**
+     * TODO(#3540 slash-command autocomplete, deferred): a "/" trigger case was NOT added here.
+     * Issue #3428 deliberately retired the slash-command UX (no picker, no "/" popup, no slash
+     * mentions anywhere) in favor of plain-language intents routed by the agent, and
+     * {@code assistantContextSuggestionsAppearOnlyForImplementedTriggers} /
+     * {@code assistantComposerUsesPlainLanguageInputAndModernThinkingIndicator} in
+     * {@code ShaftPanelSetupTest} assert that retirement. Reintroducing a "/" popup would directly
+     * reverse that decision and break both tests, so it needs an explicit product call, not a
+     * silent revival inside an unrelated first-run-welcome change. If reinstated, mirror this exact
+     * {@code @}/{@code #} mechanism ({@link #bindContextInsertion()}, {@link
+     * #showContextSuggestions(char)}, {@link #populateContextPopup(List)}, {@link
+     * #insertContextSuggestion(char, ContextSuggestion)}) with a new {@code case '/'} here backed by
+     * a small static command list, exactly as originally planned.
+     */
     private List<ContextSuggestion> contextSuggestions(
             char trigger,
             Project project,
@@ -1920,6 +1946,13 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     private void append(String role, String text, String rawResponse) {
+        // Any real message (user or assistant) ends the first-run welcome (issue #3540): the
+        // welcome is only ever valid on a genuinely empty transcript, and this always follows
+        // showFirstRunWelcomeIfNeeded() showing it (or a no-op if never shown/already dismissed),
+        // so clearWidget() here is safe even when nothing is currently showing. append() is never
+        // called while an approval widget occupies the same slot (see showFirstRunWelcomeIfNeeded's
+        // javadoc), so this never fights that widget for the slot.
+        transcript.clearWidget();
         transcript.append(role, text);
         chatState.append(role, text, rawResponse);
         updateContextTruncationBoundary();
@@ -2175,11 +2208,42 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     /**
+     * Shows the first-run welcome as the Assistant's own first message in the transcript (issue
+     * #3500 O1, follow-up #3540), via the same ephemeral {@link AssistantTranscriptView#showWidget}
+     * slot used for {@link ToolApprovalPromptPanel} -- never persisted into
+     * chatState/markdown/Copy-transcript. A no-op unless the transcript is genuinely empty and the
+     * flag isn't set, so it's safe to call after every transition to an empty transcript
+     * (construction, New chat, chat switch, Clear); {@link #transcript}'s single widget slot is
+     * never contested because those same call sites always {@code transcript.clear()} first, and an
+     * approval widget only ever appears after some message has already hidden this welcome (every
+     * {@link #append(String, String, String)} call clears it unconditionally).
+     */
+    private void showFirstRunWelcomeIfNeeded() {
+        if (settings.firstRunCoachDismissed || !transcript.markdown().isBlank()) {
+            return;
+        }
+        javax.swing.JButton gotIt = new javax.swing.JButton("Got it");
+        gotIt.getAccessibleContext().setAccessibleName("Dismiss first run coach");
+        gotIt.setToolTipText("Hide this first-run guide permanently.");
+        gotIt.setMargin(JBUI.insets(1, 8));
+        gotIt.addActionListener(event -> {
+            settings.firstRunCoachDismissed = true;
+            transcript.clearWidget();
+        });
+        transcript.showWidget("assistant", transcript.assistantBubbleWithActions(FIRST_RUN_WELCOME_MARKDOWN, gotIt));
+    }
+
+    /**
      * First-run empty-state chips (issue #3500 A6): three concrete next actions that pre-fill the
      * composer instead of executing anything, so the user stays in control of the first send.
+     * {@code WrapLayout} (not plain {@code FlowLayout}) reports correct wrapped preferred height in
+     * a narrow tool window; a plain {@code FlowLayout} row under-reports it, letting whatever
+     * follows collide with a wrapped second line of chips (root cause of the first-run coach clip,
+     * issue #3540 -- the coach strip that used to sit above this row is now the transcript welcome
+     * bubble; see {@link #showFirstRunWelcomeIfNeeded()}).
      */
     private javax.swing.JPanel buildEmptyStateChips() {
-        javax.swing.JPanel chipRow = new javax.swing.JPanel(new java.awt.FlowLayout(java.awt.FlowLayout.LEFT, 6, 0));
+        javax.swing.JPanel chipRow = new javax.swing.JPanel(new WrapLayout(java.awt.FlowLayout.LEFT, 6, 0));
         chipRow.setOpaque(false);
         chipRow.add(emptyStateChip("Record a sample flow",
                 "Record a sample web flow on a practice page, add one assertion, and generate a reviewed test."));
@@ -2187,44 +2251,8 @@ final class ShaftAssistantPanel extends JPanel {
                 "How do I add assertions while recording a web flow?"));
         chipRow.add(emptyStateChip("Diagnose my last failure",
                 "Diagnose my most recent failed test run and propose a fix."));
-        emptyStateChips = new javax.swing.JPanel();
-        emptyStateChips.setLayout(new javax.swing.BoxLayout(emptyStateChips, javax.swing.BoxLayout.Y_AXIS));
-        emptyStateChips.setOpaque(false);
-        javax.swing.JPanel coach = buildFirstRunCoach();
-        if (coach != null) {
-            emptyStateChips.add(coach);
-        }
-        emptyStateChips.add(chipRow);
+        emptyStateChips = chipRow;
         return emptyStateChips;
-    }
-
-    /**
-     * First-run happy-path coach (issue #3500 O1): one dismissible line telling the whole story in
-     * three steps; never reappears once acknowledged.
-     */
-    private javax.swing.JPanel buildFirstRunCoach() {
-        if (settings.firstRunCoachDismissed) {
-            return null;
-        }
-        javax.swing.JPanel coach = new javax.swing.JPanel(new java.awt.FlowLayout(java.awt.FlowLayout.LEFT, 6, 0));
-        coach.setOpaque(false);
-        javax.swing.JLabel story = new javax.swing.JLabel(
-                "First run: 1. Check setup (header strip)  2. Record a sample flow  3. Review code into a test.");
-        story.getAccessibleContext().setAccessibleName("First run happy path coach");
-        story.setForeground(ShaftStatusPresentation.pending());
-        javax.swing.JButton gotIt = new javax.swing.JButton("Got it");
-        gotIt.getAccessibleContext().setAccessibleName("Dismiss first run coach");
-        gotIt.setToolTipText("Hide this first-run guide permanently.");
-        gotIt.setMargin(JBUI.insets(1, 8));
-        gotIt.addActionListener(event -> {
-            settings.firstRunCoachDismissed = true;
-            coach.setVisible(false);
-            emptyStateChips.revalidate();
-            emptyStateChips.repaint();
-        });
-        coach.add(story);
-        coach.add(gotIt);
-        return coach;
     }
 
     private javax.swing.JButton emptyStateChip(String label, String cannedPrompt) {
@@ -2410,6 +2438,7 @@ final class ShaftAssistantPanel extends JPanel {
         captureIntegrationRunning = false;
         transcript.clear();
         contextTruncationBoundaryIndex = -1;
+        showFirstRunWelcomeIfNeeded();
         lastResponse = "";
         lastRawResponse = "";
         lastPrompt = "";
@@ -2431,6 +2460,7 @@ final class ShaftAssistantPanel extends JPanel {
         captureIntegrationRunning = false;
         refreshChatSelector();
         transcript.clear();
+        showFirstRunWelcomeIfNeeded();
         prompt.setText("");
         lastResponse = "";
         lastRawResponse = "";
@@ -2929,6 +2959,7 @@ final class ShaftAssistantPanel extends JPanel {
         } else {
             transcript.clear();
             contextTruncationBoundaryIndex = -1;
+            showFirstRunWelcomeIfNeeded();
         }
         lastResponse = "";
         lastRawResponse = "";

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonParser;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.ui.components.JBTextArea;
 import com.intellij.openapi.project.Project;
+import com.intellij.util.ui.WrapLayout;
 import com.shaft.intellij.approval.LocalAgentApprovalBridge;
 import com.shaft.intellij.approval.ToolApprovalDecision;
 import com.shaft.intellij.approval.ToolApprovalService;
@@ -1341,16 +1342,52 @@ class ShaftPanelSetupTest {
         ShaftSettingsState.Settings settings = connectedMcpSettings();
         ShaftToolWindowPanel toolWindow = new ShaftToolWindowPanel(fakeProject(), settings);
 
-        assertNotNull(findByAccessibleName(toolWindow, "First run happy path coach", JLabel.class),
-                "The first-run coach must show on an empty transcript before dismissal.");
+        // Issue #3540: the first-run coach moved from a bottom strip under the chips into the
+        // transcript itself, as the Assistant's own first (non-persisted) message.
+        assertNotNull(findByAccessibleName(toolWindow, "Assistant welcome message bubble", JComponent.class),
+                "The first-run welcome must show as the Assistant's first transcript message before dismissal.");
         JButton dismiss = findByAccessibleName(toolWindow, "Dismiss first run coach", JButton.class);
         assertNotNull(dismiss);
         dismiss.doClick();
-        assertTrue(settings.firstRunCoachDismissed, "Dismissing the coach must persist the acknowledgment.");
+        assertAll(
+                () -> assertTrue(settings.firstRunCoachDismissed,
+                        "Dismissing the coach must persist the acknowledgment."),
+                () -> assertNull(findByAccessibleName(toolWindow, "Assistant welcome message bubble", JComponent.class),
+                        "Dismissing must remove the welcome bubble from the transcript immediately."));
 
         ShaftToolWindowPanel reopened = new ShaftToolWindowPanel(fakeProject(), settings);
-        assertNull(findByAccessibleName(reopened, "First run happy path coach", JLabel.class),
-                "The coach must never reappear once acknowledged.");
+        assertNull(findByAccessibleName(reopened, "Assistant welcome message bubble", JComponent.class),
+                "The welcome must never reappear once acknowledged.");
+    }
+
+    /**
+     * Root cause of the original clip (issue #3540): a plain {@code FlowLayout} row's
+     * {@code getPreferredSize()} does not depend on the row's own width, so it under-reports height
+     * once its content wraps to more than one line in a narrow tool window -- whatever the parent
+     * lays out below the row then collides with the wrapped second line. {@code WrapLayout}
+     * computes preferred size from the row's actual current width, so a narrower row correctly
+     * reports a taller preferred size once its chips no longer fit on one line.
+     */
+    @Test
+    void emptyStateChipRowReportsWrappedHeightInNarrowToolWindowWithoutClipping() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        JPanel chipRow = (JPanel) getField(panel, "emptyStateChips");
+        assertNotNull(chipRow);
+
+        chipRow.setSize(new Dimension(1200, chipRow.getPreferredSize().height));
+        int wideHeight = chipRow.getPreferredSize().height;
+        chipRow.setSize(new Dimension(140, wideHeight));
+        int narrowHeight = chipRow.getPreferredSize().height;
+
+        assertAll(
+                () -> assertTrue(chipRow.getLayout() instanceof WrapLayout,
+                        "The empty-state chip row must use WrapLayout, not a plain FlowLayout that "
+                                + "under-reports wrapped preferred height (issue #3540 root cause)."),
+                () -> assertTrue(narrowHeight > wideHeight,
+                        "A narrow chip row wrapping the three chips onto more than one line must "
+                                + "report a taller preferred height than the same row laid out on one "
+                                + "wide line (wide=" + wideHeight + ", narrow=" + narrowHeight + "), "
+                                + "otherwise whatever follows it clips the wrapped second line."));
     }
 
     @Test
@@ -3866,6 +3903,7 @@ class ShaftPanelSetupTest {
     @Test
     void gateToolDispatchesImmediatelyWhenApproveAllToolsFlagIsSet() throws Exception {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        clearFirstRunWelcome(panel);
         approvalServiceOf(panel).record(ToolApprovalDecision.APPROVE_ALL_TOOLS, "unused");
         AssistantCommand.Invocation invocation = AssistantCommand.Invocation.tool("capture_start", new JsonObject());
 
@@ -3936,6 +3974,7 @@ class ShaftPanelSetupTest {
     @Test
     void sequenceSkipsARepeatPromptForAToolAlreadyApprovedThisRun() throws Exception {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        clearFirstRunWelcome(panel);
         setField(panel, "currentToolSequence", List.of(
                 new AssistantCommand.ToolCall("capture_start", new JsonObject()),
                 new AssistantCommand.ToolCall("capture_start", new JsonObject())));
@@ -4053,6 +4092,7 @@ class ShaftPanelSetupTest {
     @Test
     void localAgentApprovalIsAutoDeniedWhenTheRunHasEnded() throws Exception {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        clearFirstRunWelcome(panel);
         setField(panel, "activeLocalAgentStreamToken", -1);
 
         LocalAgentApprovalBridge.ApprovalRequestHandler handler = localAgentApprovalHandler(panel, 11);
@@ -4174,6 +4214,16 @@ class ShaftPanelSetupTest {
     private static JComponent transcriptWidget(ShaftAssistantPanel panel) throws Exception {
         AssistantTranscriptView transcript = (AssistantTranscriptView) getField(panel, "transcript");
         return transcript.pendingWidgetForTest();
+    }
+
+    /**
+     * Clears the first-run welcome bubble a fresh panel shows in the transcript widget slot (#3540),
+     * so approval-flow tests that assert an empty widget slot exercise the returning-user /
+     * post-first-message state — real tool dispatch only happens after the user's first message,
+     * which already clears the welcome.
+     */
+    private static void clearFirstRunWelcome(ShaftAssistantPanel panel) throws Exception {
+        ((AssistantTranscriptView) getField(panel, "transcript")).clearWidget();
     }
 
     private static JButton approvalDecisionButton(ToolApprovalPromptPanel panel, String label) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
@@ -118,6 +118,7 @@ class ShaftPluginScreenshotRendererTest {
 
         Path assistantLightScreenshot = outputPath.resolve("intellij-plugin-assistant.png");
         Path assistantEmptyScreenshot = outputPath.resolve("intellij-plugin-assistant-empty.png");
+        Path assistantEmptyNarrowScreenshot = outputPath.resolve("intellij-plugin-assistant-empty-narrow.png");
         Path assistantDarkScreenshot = outputPath.resolve("intellij-plugin-assistant-dark.png");
         Path assistantNarrowDarkScreenshot = outputPath.resolve("intellij-plugin-assistant-narrow-dark.png");
         Path assistantLiveDarkScreenshot = outputPath.resolve("intellij-plugin-assistant-live-output-dark.png");
@@ -147,6 +148,7 @@ class ShaftPluginScreenshotRendererTest {
 
         write(assistantLightScreenshot, renderToolWindow(0, "", LIGHT_THEME, false));
         write(assistantEmptyScreenshot, renderAssistantEmpty(LIGHT_THEME, false));
+        write(assistantEmptyNarrowScreenshot, renderAssistantEmpty(DARK_THEME, true, NARROW_WIDTH, HEIGHT));
         write(assistantDarkScreenshot, renderToolWindow(0, "", DARK_THEME, true));
         write(assistantNarrowDarkScreenshot, renderToolWindow(0, "", DARK_THEME, true, NARROW_WIDTH, HEIGHT));
         write(assistantLiveDarkScreenshot, renderAssistantLiveOutput(DARK_THEME, true));
@@ -176,6 +178,7 @@ class ShaftPluginScreenshotRendererTest {
         assertAll(
                 () -> assertTrue(Files.size(assistantLightScreenshot) > 0, assistantLightScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantEmptyScreenshot) > 0, assistantEmptyScreenshot + " should be non-empty"),
+                () -> assertTrue(Files.size(assistantEmptyNarrowScreenshot) > 0, assistantEmptyNarrowScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantDarkScreenshot) > 0, assistantDarkScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantNarrowDarkScreenshot) > 0, assistantNarrowDarkScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantLiveDarkScreenshot) > 0, assistantLiveDarkScreenshot + " should be non-empty"),
@@ -204,6 +207,7 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertTrue(Files.size(mcpGuideScreenshot) > 0, mcpGuideScreenshot + " should be non-empty"),
                 () -> assertDimensions(assistantLightScreenshot),
                 () -> assertDimensions(assistantEmptyScreenshot),
+                () -> assertDimensions(assistantEmptyNarrowScreenshot, NARROW_WIDTH, HEIGHT),
                 () -> assertDimensions(assistantDarkScreenshot),
                 () -> assertDimensions(assistantNarrowDarkScreenshot, NARROW_WIDTH, HEIGHT),
                 () -> assertDimensions(assistantLiveDarkScreenshot),
@@ -374,6 +378,13 @@ class ShaftPluginScreenshotRendererTest {
 
     private static BufferedImage renderAssistantEmpty(String lookAndFeelClassName, boolean dark)
             throws InterruptedException, InvocationTargetException {
+        return renderAssistantEmpty(lookAndFeelClassName, dark, WIDTH, HEIGHT);
+    }
+
+    // A narrow width proves the first-run welcome bubble and empty-state chip row (issue #3540:
+    // WrapLayout, not FlowLayout) report correct wrapped height and never clip against each other.
+    private static BufferedImage renderAssistantEmpty(String lookAndFeelClassName, boolean dark, int width, int height)
+            throws InterruptedException, InvocationTargetException {
         AtomicReference<BufferedImage> image = new AtomicReference<>();
         SwingUtilities.invokeAndWait(() -> {
             configureLookAndFeel(lookAndFeelClassName, dark);
@@ -382,12 +393,12 @@ class ShaftPluginScreenshotRendererTest {
             ShaftSettingsState.Settings settings = defaultSettings();
             JComponent component = new ShaftToolWindowPanel(
                     screenshotProject(), settings, AssistantLocalAgentRunner::readiness, new ShaftAssistantChatState());
-            component.setSize(new Dimension(WIDTH, HEIGHT));
-            component.setPreferredSize(new Dimension(WIDTH, HEIGHT));
+            component.setSize(new Dimension(width, height));
+            component.setPreferredSize(new Dimension(width, height));
             SwingUtilities.updateComponentTreeUI(component);
             component.doLayout();
             layout(component, !dark);
-            image.set(render(component, WIDTH, HEIGHT));
+            image.set(render(component, width, height));
         });
         return image.get();
     }


### PR DESCRIPTION
Addresses two user reports about the IntelliJ SHAFT Assistant panel. **(A) shipped**; **(B) surfaced for a product decision** (see below).

## (A) First-run welcome moves into the chat; clipped "Got it" / chip overlap fixed
The first-run hint + a new welcome message now render as the Assistant's **first (non-persisted) message inside the transcript**, instead of a cramped bottom coach strip whose "Got it" button was clipped by the empty-state suggestion chips in a narrow tool window.

**Root cause of the clip:** `buildFirstRunCoach()` and the empty-state `chipRow` used plain `java.awt.FlowLayout` under a `BoxLayout.Y_AXIS`, which under-reports wrapped height — so the wrapped "Got it" line collided with the chip row.

**Fix:**
- `AssistantTranscriptView.assistantBubbleWithActions(...)` builds a word-wrap-safe assistant bubble, shown via the existing **non-persisted `showWidget` slot** so it never pollutes chat history or empty-state detection. "Got it" persists `firstRunCoachDismissed` and clears the widget; the first real user turn clears it too.
- `buildFirstRunCoach()` retired; the empty-state chip row now uses `com.intellij.util.ui.WrapLayout` (width-aware height) with no `BoxLayout` wrapper — the stacked-FlowLayout clip cannot recur.

**Verified:** full `:shaft-intellij:test` green (559 tests) incl. the updated `firstRunCoachShowsOnceAndDismissPersists`, a new `WrapLayout` no-clip test, and the 3 approval-flow tests arranged for the returning-user (welcome-cleared) state. Screenshot renderer green with a new **narrow-width empty-state PNG** proving the welcome renders and the chips no longer overlap (attached in the conversation).

## (B) "/" slash-command autocomplete — NOT added (needs a product decision)
The requested `/` command autocomplete was **deliberately retired** in #3428 (first-time-user trust pass): *"no command picker, no '/' popup … plain-language requests routed by intent."* Two tests actively enforce that retirement (`assistantContextSuggestionsAppearOnlyForImplementedTriggers`, `assistantComposerUsesPlainLanguageInputAndModernThinkingIndicator`). Reintroducing it would reverse a considered, tested decision — so it's flagged for the maintainer rather than silently done. A precise TODO (naming the retirement commit/tests and the `@`/`#` mirror-mechanism to reuse) is left on `contextSuggestions()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)