### PR TITLE
fix(intellij): stop raw stream-json leaking into Assistant transcript on local-agent failure

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
@@ -495,9 +495,21 @@ final class AssistantLocalAgentRunner {
                 boolean success = process.exitValue() == 0;
                 String rawStdout = stdoutNow(stdout);
                 String rawStderr = stderrNow(stderr);
-                String output = success && streamParser != null && streamParser.hasTerminalEvent()
-                        ? streamParser.finalOutput()
-                        : agentOutput(success, rawStdout, rawStderr, "");
+                String output;
+                if (success) {
+                    output = streamParser != null && streamParser.hasTerminalEvent()
+                            ? streamParser.finalOutput()
+                            : agentOutput(true, rawStdout, rawStderr, "");
+                } else if (streamParser != null) {
+                    // A structured (stream-json / --json) CLI writes machine NDJSON to stdout, so on a
+                    // failed run the raw stream must never reach the transcript verbatim -- rerun/codegen
+                    // failures used to dump lines like {"type":"system","subtype":"thinking_tokens",...}.
+                    // Render the parser's cleaned answer, or a plain-language reason plus stderr when the
+                    // CLI died before emitting a terminal event.
+                    output = streamParser.failureOutput(process.exitValue(), rawStderr);
+                } else {
+                    output = agentOutput(false, rawStdout, rawStderr, "");
+                }
                 return success
                         ? ShaftMcpToolResult.success(output)
                         : ShaftMcpToolResult.failure(output);
@@ -608,6 +620,9 @@ final class AssistantLocalAgentRunner {
         private String answer;
         private Integer inputTokens;
         private Integer outputTokens;
+        // A short, human-readable reason captured from a non-success terminal event (Claude's error
+        // subtype, Codex's turn.failed detail), used to explain a failure whose answer text is empty.
+        private String terminalDetail;
 
         StructuredStreamParser(Format format) {
             this.format = format;
@@ -641,17 +656,46 @@ final class AssistantLocalAgentRunner {
         }
 
         synchronized String finalOutput() {
+            return composeOutput(answer.strip());
+        }
+
+        /**
+         * Cleaned output for a failed structured run. Prefers the terminal answer text; when the CLI
+         * died before returning one, synthesizes a plain-language reason (from {@link #terminalDetail}
+         * or the exit code) and appends stderr. Never returns the raw NDJSON stdout, so native stream
+         * events such as {@code {"type":"system","subtype":"thinking_tokens",...}} can no longer leak
+         * verbatim into the transcript.
+         */
+        synchronized String failureOutput(int exitCode, String stderr) {
+            String core = answer == null ? "" : answer.strip();
+            if (core.isBlank()) {
+                core = terminalDetail != null && !terminalDetail.isBlank()
+                        ? "The local assistant stopped before finishing: " + terminalDetail + "."
+                        : "The local assistant exited with code " + exitCode + " before returning an answer.";
+            }
+            String stderrText = stderr == null ? "" : stderr.strip();
+            if (!stderrText.isBlank()) {
+                core = core + "\n\n```\n" + stderrText + "\n```";
+            }
+            return composeOutput(core);
+        }
+
+        private String composeOutput(String core) {
+            StringBuilder output = new StringBuilder(core);
+            String activity = activitySummary();
+            if (!activity.isBlank()) {
+                output.append("\n\n").append(activity);
+            }
+            return output + "\n\n" + usageHolder();
+        }
+
+        private JsonObject usageHolder() {
             JsonObject usage = new JsonObject();
             usage.addProperty("input_tokens", orZero(inputTokens));
             usage.addProperty("output_tokens", orZero(outputTokens));
             JsonObject usageHolder = new JsonObject();
             usageHolder.add("usage", usage);
-            StringBuilder output = new StringBuilder(answer.strip());
-            String activity = activitySummary();
-            if (!activity.isBlank()) {
-                output.append("\n\n").append(activity);
-            }
-            return output + "\n\n" + usageHolder;
+            return usageHolder;
         }
 
         /**
@@ -747,6 +791,10 @@ final class AssistantLocalAgentRunner {
                 inputTokens = intField(usage, "input_tokens");
                 outputTokens = intField(usage, "output_tokens");
                 recordPermissionDenials(event.get("permission_denials"));
+                String subtype = stringField(event, "subtype");
+                if (booleanField(event, "is_error") || (subtype != null && subtype.startsWith("error"))) {
+                    terminalDetail = humanizeSubtype(subtype);
+                }
                 // Fully consumed: this event becomes the final answer, so it is mapped, not hidden.
                 return CONSUMED;
             }
@@ -867,6 +915,10 @@ final class AssistantLocalAgentRunner {
                 if ("turn.completed".equals(type)) {
                     String lastAgentMessage = stringField(event, "last_agent_message");
                     answer = lastAgentMessage != null ? lastAgentMessage : (answer == null ? "" : answer);
+                } else {
+                    JsonObject error = objectField(event, "error");
+                    terminalDetail = firstNonBlank(stringField(event, "error"),
+                            stringField(error, "message"), stringField(error, "type"));
                 }
                 // Fully consumed: this event becomes the final answer/usage, so it is mapped, not hidden.
                 return CONSUMED;
@@ -881,6 +933,18 @@ final class AssistantLocalAgentRunner {
                 }
             }
             return null;
+        }
+
+        /**
+         * Turns a machine error subtype (e.g. {@code error_max_turns}) into a short prose reason
+         * (e.g. {@code max turns}) for the failure headline.
+         */
+        private static String humanizeSubtype(String subtype) {
+            if (subtype == null || subtype.isBlank()) {
+                return "the run failed";
+            }
+            String cleaned = subtype.replace("error_", "").replace('_', ' ').trim();
+            return cleaned.isBlank() ? "the run failed" : cleaned;
         }
 
         private static Integer firstNonNull(Integer preferred, Integer fallback) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerVerboseStreamTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerVerboseStreamTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -269,6 +270,59 @@ class AssistantLocalAgentRunnerVerboseStreamTest {
                 "A plain Q&A run must not grow an activity footer: " + output);
     }
 
+    /**
+     * Regression for the "rerun failure dumps raw JSON" report: a structured (stream-json) CLI that
+     * exits non-zero after emitting only native NDJSON events (system/thinking lines, no terminal
+     * result) must render a clean, plain-language failure message -- never the raw stream.
+     */
+    @Test
+    void failedStructuredRunWithoutTerminalEventNeverLeaksRawNdjson() throws Exception {
+        String nativeNoise = "{\"type\":\"system\",\"subtype\":\"thinking_tokens\",\"tokens\":42}\n"
+                + "{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"abc\"}\n";
+
+        ShaftMcpToolResult result = failingRun(claudeInvocation(), nativeNoise,
+                "chrome exited: session not created", 1);
+
+        assertFalse(result.success(), "A non-zero exit must fail the run: " + result.output());
+        String output = result.output();
+        assertFalse(output.contains("thinking_tokens"),
+                "Raw native NDJSON must never leak into the failure output: " + output);
+        assertFalse(output.contains("\"type\":\"system\""),
+                "Raw native NDJSON must never leak into the failure output: " + output);
+        assertTrue(output.contains("exited with code 1"),
+                "A run with no terminal event must explain the exit: " + output);
+        assertTrue(output.contains("chrome exited: session not created"),
+                "stderr carries the real cause and must be surfaced: " + output);
+    }
+
+    /**
+     * When the structured CLI DOES emit a terminal error result, its human answer text (and error
+     * subtype) drive the failure message instead of the raw stream.
+     */
+    @Test
+    void failedStructuredRunWithTerminalErrorResultShowsHumanReadableReason() throws Exception {
+        String errorResult = "{\"type\":\"result\",\"subtype\":\"error_during_execution\",\"is_error\":true,"
+                + "\"result\":\"Could not reach the target URL.\",\"usage\":{\"input_tokens\":3,\"output_tokens\":1}}";
+
+        ShaftMcpToolResult result = failingRun(claudeInvocation(),
+                "{\"type\":\"system\",\"subtype\":\"thinking_tokens\",\"tokens\":9}\n" + errorResult + "\n", "", 1);
+
+        assertFalse(result.success(), result.output());
+        String output = result.output();
+        assertTrue(output.contains("Could not reach the target URL."),
+                "The terminal error answer text must be shown: " + output);
+        assertFalse(output.contains("thinking_tokens"),
+                "Raw native NDJSON must never leak into the failure output: " + output);
+    }
+
+    private static ShaftMcpToolResult failingRun(
+            AssistantCommand.Invocation invocation, String stdout, String stderr, int exitCode) throws Exception {
+        StubProcess process = new StubProcess(stdout, stderr, exitCode);
+        ShaftMcpInvocation running = AssistantLocalAgentRunner.start(
+                invocation, line -> { }, (command, workingDirectory, environment) -> process, false);
+        return running.future().get(5, TimeUnit.SECONDS);
+    }
+
     private static String finalOutput(AssistantCommand.Invocation invocation, String stdout) throws Exception {
         StubProcess process = new StubProcess(stdout);
         ShaftMcpInvocation running = AssistantLocalAgentRunner.start(
@@ -320,9 +374,17 @@ class AssistantLocalAgentRunnerVerboseStreamTest {
      */
     private static final class StubProcess extends Process {
         private final InputStream stdout;
+        private final InputStream stderr;
+        private final int exitCode;
 
         StubProcess(String stdoutContent) {
+            this(stdoutContent, "", 0);
+        }
+
+        StubProcess(String stdoutContent, String stderrContent, int exitCode) {
             this.stdout = new ByteArrayInputStream(stdoutContent.getBytes(StandardCharsets.UTF_8));
+            this.stderr = new ByteArrayInputStream(stderrContent.getBytes(StandardCharsets.UTF_8));
+            this.exitCode = exitCode;
         }
 
         @Override
@@ -337,12 +399,12 @@ class AssistantLocalAgentRunnerVerboseStreamTest {
 
         @Override
         public InputStream getErrorStream() {
-            return new ByteArrayInputStream(new byte[0]);
+            return stderr;
         }
 
         @Override
         public int waitFor() {
-            return 0;
+            return exitCode;
         }
 
         @Override
@@ -352,7 +414,7 @@ class AssistantLocalAgentRunnerVerboseStreamTest {
 
         @Override
         public int exitValue() {
-            return 0;
+            return exitCode;
         }
 
         @Override


### PR DESCRIPTION
## Problem

Running a scenario codegen/rerun through a **local-agent CLI** in the IntelliJ SHAFT Assistant and having it **fail** dumped raw native NDJSON into the transcript — e.g. `{"type":"system","subtype":"thinking_tokens",...}` and SVG path noise — behind a cryptic "Failed". (Reported with a screenshot during the workflow audit.)

## Root cause

`AssistantLocalAgentRunner.run()` used the structured stream parser's cleaned output **only on success**; on failure it fell back to `agentOutput(false, rawStdout, ...)` = the raw stdout. For a structured command (Claude `stream-json`, Codex `--json`) stdout *is* machine NDJSON, and multi-object NDJSON also defeats `AssistantMarkdown.normalizeMarkdown`'s single-value JSON parse, so it rendered verbatim/unformatted in the transcript.

## Fix

On a failed **structured** run, render a cleaned message instead of raw stdout:
- the terminal error **answer text** when the CLI emitted one, else
- a plain-language reason — from the CLI's error subtype (`error_max_turns` → "max turns") / Codex `turn.failed` detail, or the exit code — plus **stderr** (the real cause) and the usual activity footer.

Raw NDJSON stdout is never surfaced for a structured command. Non-structured/custom commands (e.g. Copilot) keep their existing raw-stdout passthrough — their stdout is plain prose, not NDJSON.

Scope note: this is the "human-readable root cause instead of raw JSON + Failed" half of the rerun-failure report. The separate asks to *auto-close the browser* and *auto-run doctor* on failure are a larger follow-up (they touch the MCP execution path, not just output formatting).

## Verification

`./gradlew :shaft-intellij:test` (JDK 21) — all green:
- New regression tests in `AssistantLocalAgentRunnerVerboseStreamTest`:
  - `failedStructuredRunWithoutTerminalEventNeverLeaksRawNdjson` — a non-zero exit with only native NDJSON (no terminal event) yields "exited with code 1" + stderr and **never** contains `thinking_tokens` / `"type":"system"`.
  - `failedStructuredRunWithTerminalErrorResultShowsHumanReadableReason` — a terminal error result surfaces its human answer text, not the raw stream.
- Adjacent suites unaffected: `AssistantLocalAgentRunner*` (42), `AssistantCommandTest` (62), `AssistantMarkdownTest` (31) — 0 failures.

This is a transcript-content fix in the runner (asserted directly by unit tests on the produced string), not a layout/style change, so the Swing screenshot renderer — which only displays supplied text — wouldn't exercise the fixed path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)