### PR TITLE
feat: IntelliJ live-execution transparency — MCP progress streaming (#3546)

### DIFF
--- a/scripts/mcp/generate_shaft_skills_tool_catalog.py
+++ b/scripts/mcp/generate_shaft_skills_tool_catalog.py
@@ -24,7 +24,19 @@ SOURCE_DIR = REPO_ROOT / "shaft-mcp" / "src" / "main" / "java" / "com" / "shaft"
 OUTPUT_PATH = REPO_ROOT / "shaft-skills" / "references" / "shaft-mcp-tools.md"
 GENERATOR_RELATIVE_PATH = "scripts/mcp/generate_shaft_skills_tool_catalog.py"
 TOOL_MARKER = "@Tool("
+# Spring AI exposes MCP tools via two annotations: the plain @Tool (registered through
+# ToolCallbacks.from) and @McpTool (annotation-scanned; the only form that can receive an
+# McpSyncServerExchange / @McpProgressToken and emit notifications/progress — see #3546). Both
+# carry the same name/description attributes, so the catalog scans them identically. "@McpTool("
+# never contains "@Tool(" as a substring, so the two markers count disjointly.
+MCP_TOOL_MARKER = "@McpTool("
+TOOL_MARKERS = (TOOL_MARKER, MCP_TOOL_MARKER)
 SERVICE_CLASS_SUFFIX = "Service"
+
+
+def count_tool_markers(text: str) -> int:
+    """Total @Tool( plus @McpTool( literal occurrences in one file."""
+    return sum(text.count(marker) for marker in TOOL_MARKERS)
 
 # Basic Java escape sequences that can legally appear inside a string literal in these
 # annotations. Anything not listed here is passed through unescaped (the backslash is dropped
@@ -82,22 +94,23 @@ def find_source_files(source_dir: Path) -> list[Path]:
     for path in sorted(source_dir.rglob("*.java")):
         if path in flat_set:
             continue
-        if TOOL_MARKER in path.read_text(encoding="utf-8"):
+        if count_tool_markers(path.read_text(encoding="utf-8")) > 0:
             nested_files.append(path)
     return flat_files + nested_files
 
 
 def find_tool_annotations(text: str) -> list[int]:
-    """Returns the index right after each literal "@Tool(" occurrence, in source order."""
+    """Returns the index right after each literal "@Tool(" / "@McpTool(" occurrence, in source order."""
     positions = []
-    index = 0
-    while True:
-        index = text.find(TOOL_MARKER, index)
-        if index == -1:
-            break
-        positions.append(index + len(TOOL_MARKER))
-        index += len(TOOL_MARKER)
-    return positions
+    for marker in TOOL_MARKERS:
+        index = 0
+        while True:
+            index = text.find(marker, index)
+            if index == -1:
+                break
+            positions.append(index + len(marker))
+            index += len(marker)
+    return sorted(positions)
 
 
 def extract_annotation_body(text: str, start: int) -> str | None:
@@ -285,13 +298,13 @@ def build_catalog(source_dir: Path) -> tuple[list[ServiceSection], int]:
 
     for path in files:
         text = path.read_text(encoding="utf-8")
-        raw_count = text.count(TOOL_MARKER)
+        raw_count = count_tool_markers(text)
         if raw_count == 0:
             continue
         entries, errors = parse_file(path, text)
         if errors or len(entries) != raw_count:
             mismatched_files.append(
-                f"{display_path(path)}: found {raw_count} @Tool( occurrence(s), parsed {len(entries)}"
+                f"{display_path(path)}: found {raw_count} @Tool(/@McpTool( occurrence(s), parsed {len(entries)}"
             )
             all_errors.extend(errors)
             continue

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -43,6 +43,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -72,6 +73,7 @@ public final class CaptureGenerator {
             .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
             .build();
     private static final DefaultPrettyPrinter PRINTER = printer();
+    private static final BiConsumer<Double, String> NO_OP_PROGRESS = (fraction, message) -> { };
 
     private final CaptureJsonCodec codec;
     private final LocatorRanker locatorRanker;
@@ -122,9 +124,25 @@ public final class CaptureGenerator {
      * @param backend generated SHAFT GUI backend
      * @return generated artifacts and report
      */
-    @SuppressWarnings("PMD.NPathComplexity")
     public CaptureGenerationResult generate(CaptureGenerationRequest request, CodegenBackend backend) {
+        return generate(request, backend, NO_OP_PROGRESS);
+    }
+
+    /**
+     * Generates, validates, and reports one SHAFT TestNG test for a selected GUI backend, reporting
+     * best-effort milestone progress as generation advances.
+     *
+     * @param request generation options
+     * @param backend generated SHAFT GUI backend
+     * @param progress receives (fraction 0.0-1.0, milestone message) callbacks; never invoked with
+     *                 a null argument, safe to pass a no-op consumer
+     * @return generated artifacts and report
+     */
+    @SuppressWarnings("PMD.NPathComplexity")
+    public CaptureGenerationResult generate(
+            CaptureGenerationRequest request, CodegenBackend backend, BiConsumer<Double, String> progress) {
         Objects.requireNonNull(request, "request");
+        BiConsumer<Double, String> reporter = progress == null ? NO_OP_PROGRESS : progress;
         CodegenBackend targetBackend = backend == null ? CodegenBackend.WEBDRIVER : backend;
         Path sessionPath = request.sessionPath().toAbsolutePath().normalize();
         Path outputRoot = request.outputDirectory().toAbsolutePath().normalize();
@@ -134,6 +152,7 @@ public final class CaptureGenerator {
         ArtifactPaths paths = null;
         try {
             session = codec.read(sessionPath);
+            reporter.accept(0.1, "Read capture session " + sessionPath.getFileName());
             validatePackage(request.packageName());
             String deterministicClassName = request.className().isBlank()
                     ? defaultClassName(session)
@@ -143,10 +162,12 @@ public final class CaptureGenerator {
             paths = artifactPaths(outputRoot, request.packageName(), deterministicClassName);
 
             GenerationState state = analyze(session, sessionPath, targetBackend);
+            reporter.accept(0.3, "Analyzed " + session.events().size() + " captured event(s)");
             Map<String, String> elementNames = defaultElementNames(state.targets());
             String deterministicSource = renderSource(session, request.packageName(), deterministicClassName,
                     deterministicMethodName, state.targets(), state.data(), elementNames, List.of(), targetBackend,
                     request.fallbackLocators(), Set.of());
+            reporter.accept(0.5, "Generated deterministic test source for " + deterministicClassName);
             String fingerprint = fingerprint(codec.write(session), deterministicSource);
             Set<Long> appliedControlFlowGuards = Set.of();
             if (request.controlFlowMode() == CaptureGenerationRequest.ControlFlowMode.PREVIEW) {
@@ -249,6 +270,7 @@ public final class CaptureGenerator {
                         CaptureGenerationReport.Validation.skipped("Generation failed before replay."),
                         enrichment);
                 writeReportIfPossible(reportPath, report);
+                reporter.accept(1.0, "Generation complete: FAILED");
                 return result(paths.source(), paths.data(), reportPath,
                         request.enrichmentPreviewPath(), report);
             }
@@ -258,6 +280,7 @@ public final class CaptureGenerator {
             CaptureGenerationReport.Validation compilation = request.compile()
                     ? validator.compile(paths.source(), paths.classes())
                     : CaptureGenerationReport.Validation.skipped("Compilation was not requested.");
+            reporter.accept(request.replay() ? 0.75 : 0.9, "Compiled generated test: " + compilation.status());
             CaptureGenerationReport.Validation replay = CaptureGenerationReport.Validation.skipped(
                     "Replay was not requested.");
             if (request.replay()
@@ -268,9 +291,11 @@ public final class CaptureGenerator {
                         outputRoot.resolve("src/test/resources"),
                         outputRoot,
                         request.replayTimeout());
+                reporter.accept(0.9, "Replayed generated test: " + replay.status());
             } else if (request.replay()) {
                 replay = CaptureGenerationReport.Validation.skipped(
                         "Replay was skipped because compilation failed.");
+                reporter.accept(0.9, "Replay skipped: compilation failed");
             }
             boolean successful = compilation.status()
                     != CaptureGenerationReport.Validation.ValidationStatus.FAILED
@@ -295,10 +320,12 @@ public final class CaptureGenerator {
                         replay,
                         enrichment);
                 atomicWrite(reportPath, writeJson(privacyFailure));
+                reporter.accept(1.0, "Generation complete: FAILED");
                 return result(paths.source(), paths.data(), reportPath,
                         request.enrichmentPreviewPath(), privacyFailure);
             }
             atomicWrite(reportPath, reportJson);
+            reporter.accept(1.0, "Generation complete: " + (successful ? "SUCCESS" : "FAILED"));
             return result(paths.source(), paths.data(), reportPath,
                     request.enrichmentPreviewPath(), report);
         } catch (RuntimeException exception) {
@@ -316,6 +343,7 @@ public final class CaptureGenerator {
                     CaptureGenerationReport.Validation.skipped("Generation failed before replay."),
                     CaptureGenerationReport.Enrichment.notRequested());
             writeReportIfPossible(reportPath, report);
+            reporter.accept(1.0, "Generation complete: FAILED");
             return result(safePaths.source(), safePaths.data(), reportPath,
                     request.enrichmentPreviewPath(), report);
         }

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -90,6 +91,33 @@ class CaptureGeneratorTest {
         assertTrue(workbench.contains("--shaft-primary"));
         assertTrue(workbench.contains("status-chip"));
 
+    }
+
+    @Test
+    void generateReportsMilestoneProgressWithoutChangingTheResult() throws Exception {
+        Path session = session(CaptureFixtures.representativeSession());
+        writeCaptureData("alice");
+
+        List<double[]> fractions = new ArrayList<>();
+        List<String> messages = new ArrayList<>();
+        CaptureGenerationResult result = new CaptureGenerator().generate(
+                request(session, temp.resolve("progress")),
+                CaptureGenerator.CodegenBackend.WEBDRIVER,
+                (fraction, message) -> {
+                    fractions.add(new double[] {fraction});
+                    messages.add(message);
+                });
+
+        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertTrue(fractions.size() >= 2,
+                "expected at least two progress milestones, got: " + messages);
+        assertTrue(messages.stream().anyMatch(message -> !message.isBlank()));
+        for (int index = 1; index < fractions.size(); index++) {
+            assertTrue(fractions.get(index)[0] >= fractions.get(index - 1)[0],
+                    "progress fractions should be non-decreasing: " + messages);
+        }
+        assertEquals(1.0, fractions.get(fractions.size() - 1)[0], 0.0001,
+                "the final milestone should report full completion");
     }
 
     @Test

--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpInvocationService.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpInvocationService.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 /**
  * Project service that invokes SHAFT MCP tools through the configured stdio command.
@@ -264,7 +265,23 @@ public final class ShaftMcpInvocationService implements Disposable {
      * @return cancellable invocation
      */
     public ShaftMcpInvocation startTool(String toolName, JsonObject arguments) {
-        return startTool(toolName, arguments, ShaftSettingsState.getInstance().getState());
+        return startTool(toolName, arguments, ShaftSettingsState.getInstance().getState(), null);
+    }
+
+    /**
+     * Starts a cancellable SHAFT MCP tool invocation, streaming {@code notifications/progress}
+     * milestones to {@code onProgress} while the call is in flight (issue #3546). The server only
+     * emits progress for tools that opted in (currently {@code capture_generate_replay}); calling
+     * this for any other tool is harmless and simply never invokes {@code onProgress}.
+     *
+     * @param toolName   MCP tool name
+     * @param arguments  JSON object arguments
+     * @param onProgress callback for streamed progress updates, invoked on the caller's background
+     *                   thread — callers touching UI state must marshal to the UI thread themselves
+     * @return cancellable invocation
+     */
+    public ShaftMcpInvocation startTool(String toolName, JsonObject arguments, Consumer<ShaftMcpProgress> onProgress) {
+        return startTool(toolName, arguments, ShaftSettingsState.getInstance().getState(), onProgress);
     }
 
     /**
@@ -278,6 +295,21 @@ public final class ShaftMcpInvocationService implements Disposable {
      * @return cancellable invocation
      */
     ShaftMcpInvocation startTool(String toolName, JsonObject arguments, ShaftSettingsState.Settings settings) {
+        return startTool(toolName, arguments, settings, null);
+    }
+
+    /**
+     * Test seam: same logic as {@link #startTool(String, JsonObject, Consumer)} with explicit
+     * settings. Not public API.
+     *
+     * @param toolName   MCP tool name
+     * @param arguments  JSON object arguments
+     * @param settings   explicit settings, bypassing {@code ShaftSettingsState.getInstance()}
+     * @param onProgress callback for streamed progress updates, or {@code null} to opt out
+     * @return cancellable invocation
+     */
+    ShaftMcpInvocation startTool(String toolName, JsonObject arguments, ShaftSettingsState.Settings settings,
+            Consumer<ShaftMcpProgress> onProgress) {
         List<String> command = verifiedCommand(settings);
         if (command.isEmpty()) {
             return completed(CONFIGURE_MESSAGE);
@@ -294,7 +326,7 @@ public final class ShaftMcpInvocationService implements Disposable {
         CompletableFuture<ShaftMcpToolResult> future = CompletableFuture.supplyAsync(
                 () -> call(command, settings, clientReference, cancellationRequested,
                         client -> client.callTool(toolName,
-                                arguments == null ? new JsonObject() : arguments, DEFAULT_TIMEOUT)));
+                                arguments == null ? new JsonObject() : arguments, DEFAULT_TIMEOUT, onProgress)));
         return new ShaftMcpInvocation(
                 future,
                 () -> cancel(clientReference, cancellationRequested, false),

--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpProgress.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpProgress.java
@@ -1,0 +1,16 @@
+package com.shaft.intellij.mcp;
+
+/**
+ * A single MCP {@code notifications/progress} update relayed to a caller-registered progress
+ * callback (issue #3546). The server sends these best-effort, only for tools that opted in
+ * (currently {@code capture_generate_replay}) and only when the caller requested progress by
+ * supplying a callback; callers that pass no callback never see this type.
+ *
+ * @param progress current progress value; the MCP spec favors a 0.0-1.0 fraction but does not
+ *                 constrain it server-side, so this is passed through verbatim
+ * @param total    optional total {@code progress} is measured against, or {@code null} when the
+ *                 server did not report one
+ * @param message  optional human-readable milestone text, or {@code null} when absent
+ */
+public record ShaftMcpProgress(double progress, Double total, String message) {
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpStdioClient.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpStdioClient.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 /**
  * Minimal JSON-RPC MCP stdio client used by the IntelliJ shell.
@@ -61,6 +62,14 @@ final class ShaftMcpStdioClient implements AutoCloseable {
     private final AtomicBoolean closed = new AtomicBoolean();
     private final ExecutorService ioExecutor;
     private final Map<Integer, CompletableFuture<JsonObject>> pendingRequests = new ConcurrentHashMap<>();
+    /**
+     * Callbacks for in-flight tool calls that requested progress streaming, keyed by the
+     * {@code progressToken} sent in the request's {@code _meta}. Registered right before the
+     * request is sent and always removed once that call finishes (success, failure, or
+     * cancellation) — an unknown or late token in an inbound {@code notifications/progress} frame
+     * is simply a no-op (see {@link #handleProgressNotification(JsonObject)}).
+     */
+    private final Map<String, Consumer<ShaftMcpProgress>> progressCallbacks = new ConcurrentHashMap<>();
     private final Object initializationLock = new Object();
     private final Object sendLock = new Object();
     private volatile boolean initialized;
@@ -100,14 +109,45 @@ final class ShaftMcpStdioClient implements AutoCloseable {
     }
 
     JsonElement callTool(String toolName, JsonObject arguments, Duration timeout) throws IOException {
+        return callTool(toolName, arguments, timeout, null);
+    }
+
+    /**
+     * Invokes an MCP tool, optionally streaming {@code notifications/progress} milestones back to
+     * {@code onProgress} while the call is in flight (issue #3546). Purely additive: when
+     * {@code onProgress} is {@code null} no progress token is sent, matching the server's opt-in
+     * design, and a server that never emits progress (every tool but {@code capture_generate_replay}
+     * today) behaves exactly as before.
+     *
+     * @param toolName   MCP tool name
+     * @param arguments  JSON object arguments
+     * @param timeout    request timeout
+     * @param onProgress callback for streamed progress updates, or {@code null} to opt out
+     * @return the tool call result
+     */
+    JsonElement callTool(String toolName, JsonObject arguments, Duration timeout, Consumer<ShaftMcpProgress> onProgress)
+            throws IOException {
         initialize(timeout);
         int requestId = id.getAndIncrement();
         JsonObject request = request(requestId, "tools/call");
         JsonObject params = new JsonObject();
         params.addProperty("name", toolName);
         params.add("arguments", arguments);
+        String progressToken = onProgress == null ? null : String.valueOf(requestId);
+        if (progressToken != null) {
+            JsonObject meta = new JsonObject();
+            meta.addProperty("progressToken", progressToken);
+            params.add("_meta", meta);
+            progressCallbacks.put(progressToken, onProgress);
+        }
         request.add("params", params);
-        return awaitResult(sendRequest(requestId, request), timeout);
+        try {
+            return awaitResult(sendRequest(requestId, request), timeout);
+        } finally {
+            if (progressToken != null) {
+                progressCallbacks.remove(progressToken);
+            }
+        }
     }
 
     private void initialize(Duration timeout) throws IOException {
@@ -119,6 +159,10 @@ final class ShaftMcpStdioClient implements AutoCloseable {
             JsonObject request = request(requestId, "initialize");
             JsonObject params = new JsonObject();
             params.addProperty("protocolVersion", PROTOCOL_VERSION);
+            // No "progress" capability to declare here: the server (CaptureService#generateReplay,
+            // shaft-mcp) emits notifications/progress purely from the per-request _meta.progressToken
+            // it receives via @McpProgressToken, not from any client-declared capability (issue
+            // #3546). Progress is opted into per tool call in callTool(...), not at handshake time.
             params.add("capabilities", new JsonObject());
             JsonObject clientInfo = new JsonObject();
             clientInfo.addProperty("name", "shaft-intellij");
@@ -258,12 +302,66 @@ final class ShaftMcpStdioClient implements AutoCloseable {
         }
         Integer requestId = messageId(message);
         if (requestId == null) {
+            // JSON-RPC notifications carry no id. The only one this client understands today is
+            // notifications/progress; anything else (for example a future notifications/* the
+            // server starts sending) is silently ignored, matching this method's behavior before
+            // progress streaming existed (issue #3546).
+            if (isProgressNotification(message)) {
+                handleProgressNotification(message);
+            }
             return;
         }
         CompletableFuture<JsonObject> pending = pendingRequests.remove(requestId);
         if (pending != null) {
             pending.complete(message);
         }
+    }
+
+    private static boolean isProgressNotification(JsonObject message) {
+        JsonElement method = message.get("method");
+        return method != null && method.isJsonPrimitive() && method.getAsJsonPrimitive().isString()
+                && "notifications/progress".equals(method.getAsString());
+    }
+
+    /**
+     * Routes an inbound {@code notifications/progress} frame to the callback registered for its
+     * {@code progressToken}, if any. A missing token, an unrecognized/late token (the tool call it
+     * belonged to already finished and unregistered it), or a missing/non-numeric {@code progress}
+     * field are all treated as a no-op — progress is best-effort and must never fail the call it
+     * describes.
+     */
+    private void handleProgressNotification(JsonObject message) {
+        JsonElement paramsElement = message.get("params");
+        if (paramsElement == null || !paramsElement.isJsonObject()) {
+            return;
+        }
+        JsonObject params = paramsElement.getAsJsonObject();
+        String token = asString(params.get("progressToken"));
+        if (token == null) {
+            return;
+        }
+        Consumer<ShaftMcpProgress> callback = progressCallbacks.get(token);
+        if (callback == null) {
+            return;
+        }
+        Double progress = asDouble(params.get("progress"));
+        if (progress == null) {
+            return;
+        }
+        callback.accept(new ShaftMcpProgress(progress, asDouble(params.get("total")), asString(params.get("message"))));
+    }
+
+    private static Double asDouble(JsonElement element) {
+        if (element == null || !element.isJsonPrimitive() || !element.getAsJsonPrimitive().isNumber()) {
+            return null;
+        }
+        return element.getAsDouble();
+    }
+
+    private static String asString(JsonElement element) {
+        // A progressToken may legally be a JSON-RPC string or number; JsonPrimitive#getAsString()
+        // renders either, so both forms resolve to the same map key.
+        return element == null || !element.isJsonPrimitive() ? null : element.getAsString();
     }
 
     private static Integer messageId(JsonObject message) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -25,6 +25,7 @@ import com.shaft.intellij.mcp.ShaftMcpConnectionState;
 import com.shaft.intellij.mcp.ShaftMcpHeartbeat;
 import com.shaft.intellij.mcp.ShaftMcpInvocation;
 import com.shaft.intellij.mcp.ShaftMcpInvocationService;
+import com.shaft.intellij.mcp.ShaftMcpProgress;
 import com.shaft.intellij.mcp.ShaftMcpToolResult;
 import com.shaft.intellij.settings.ShaftCredentialService;
 import com.shaft.intellij.settings.ShaftSettingsState;
@@ -1157,9 +1158,25 @@ final class ShaftAssistantPanel extends JPanel {
         }
         // #3513 A8: name the routed tool in a plain-language "Running: <tool> …" confirmation.
         setRunning(true, "Running: " + invocation.toolName() + " …");
-        currentInvocation = ShaftMcpInvocationService.getInstance(project).startTool(invocation.toolName(), invocation.arguments());
+        currentInvocation = ShaftMcpInvocationService.getInstance(project).startTool(
+                invocation.toolName(), invocation.arguments(), this::onToolProgress);
         currentInvocation.future().whenComplete((result, error) -> ApplicationManager.getApplication().invokeLater(
                 () -> showResult(invocation.toolName(), result, error)));
+    }
+
+    /**
+     * Renders a streamed {@code notifications/progress} milestone in the run timeline as it
+     * arrives, so a long tool call (for example {@code capture_generate_replay}) shows what it is
+     * doing instead of sitting on a bare "Running" line the whole time (issue #3546). The server
+     * streams progress best-effort for opted-in tools only; every other tool call never invokes
+     * this. Called from the MCP client's background thread, so UI updates are marshaled to the EDT.
+     */
+    private void onToolProgress(ShaftMcpProgress progress) {
+        String message = progress.message();
+        if (message == null || message.isBlank()) {
+            return;
+        }
+        ApplicationManager.getApplication().invokeLater(() -> addTimeline(message));
     }
 
     /**
@@ -1212,7 +1229,8 @@ final class ShaftAssistantPanel extends JPanel {
 
     private void dispatchApprovedSequenceTool(int index, AssistantCommand.ToolCall toolCall) {
         setRunning(true, "Running: " + toolCall.toolName() + " (" + (index + 1) + "/" + currentToolSequence.size() + ") …");
-        currentInvocation = ShaftMcpInvocationService.getInstance(project).startTool(toolCall.toolName(), toolCall.arguments());
+        currentInvocation = ShaftMcpInvocationService.getInstance(project).startTool(
+                toolCall.toolName(), toolCall.arguments(), this::onToolProgress);
         currentInvocation.future().whenComplete((result, error) -> ApplicationManager.getApplication().invokeLater(
                 () -> showSequenceResult(index, toolCall, result, error)));
     }
@@ -1749,7 +1767,33 @@ final class ShaftAssistantPanel extends JPanel {
         if (verboseLocalAgentOutput()) {
             localAgentBubbleRendersContent = true;
             replaceLastTranscriptAndChatState("assistant", formatLocalAgentStreamingResponse(localAgentOutput.toString()));
+        } else {
+            // Verbose gates the full streaming bubble, but a non-verbose run must not look frozen
+            // either (issue #3546): surface a compact milestone in the run timeline instead.
+            addCompactLocalAgentMilestone(line);
         }
+    }
+
+    /**
+     * Reflects one local-agent output line as a compact run-timeline entry for non-verbose runs.
+     * Raw NDJSON lines (an unmapped Claude/Codex structured-stream event with no human-readable
+     * translation, see {@code AssistantLocalAgentRunner}'s {@code StructuredStreamParser#accept})
+     * always start with {@code {}; skipping those keeps this method's visibility contract identical
+     * to Verbose mode's pre-#3546 raw-content boundary (#3545: raw stdout stays invisible unless the
+     * user opts into Verbose) while still giving a signal of progress for everything else — translated
+     * milestones ("Calling tool X...", "Thinking: ...") and plain-prose/banner lines.
+     */
+    private void addCompactLocalAgentMilestone(String line) {
+        if (line == null) {
+            return;
+        }
+        String trimmed = line.strip();
+        if (trimmed.isEmpty() || trimmed.startsWith("{") || trimmed.startsWith("[")) {
+            return;
+        }
+        // The timeline is a single-line-per-entry heartbeat, not a transcript, so long milestone
+        // text (a full answer paragraph, a tool call with long arguments) is kept skimmable.
+        addTimeline(trimmed.length() > 80 ? trimmed.substring(0, 77) + "..." : trimmed);
     }
 
     /**

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftFeaturePanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftFeaturePanel.java
@@ -14,6 +14,7 @@ import com.intellij.util.ui.JBUI;
 import com.shaft.intellij.mcp.McpInvocationError;
 import com.shaft.intellij.mcp.ShaftMcpInvocation;
 import com.shaft.intellij.mcp.ShaftMcpInvocationService;
+import com.shaft.intellij.mcp.ShaftMcpProgress;
 import com.shaft.intellij.mcp.ShaftMcpToolResult;
 import com.shaft.intellij.settings.ShaftSettingsState;
 import org.jetbrains.annotations.NotNull;
@@ -298,9 +299,25 @@ final class ShaftFeaturePanel extends JPanel {
         setRunning(true, "Running: " + template.toolName() + " …");
         outputArea.setText("");
         copyOutputButton.setEnabled(false);
-        currentInvocation = ShaftMcpInvocationService.getInstance(project).startTool(template.toolName(), arguments);
+        currentInvocation = ShaftMcpInvocationService.getInstance(project).startTool(
+                template.toolName(), arguments, this::onToolProgress);
         currentInvocation.future().whenComplete((result, error) -> ApplicationManager.getApplication().invokeLater(
                 () -> showResult(result, error)));
+    }
+
+    /**
+     * Reflects a streamed {@code notifications/progress} milestone in the status line while a tool
+     * runs, so a long call (for example {@code capture_generate_replay}) shows what it is doing
+     * instead of a static "Running: <tool> …" the whole time (issue #3546). The server streams
+     * progress best-effort for opted-in tools only; every other tool call never invokes this.
+     * Called from the MCP client's background thread, so the UI update is marshaled to the EDT.
+     */
+    private void onToolProgress(ShaftMcpProgress progress) {
+        String message = progress.message();
+        if (message == null || message.isBlank()) {
+            return;
+        }
+        ApplicationManager.getApplication().invokeLater(() -> status.setText(message));
     }
 
     private void refreshCatalog(Project project) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/mcp/FakeMcpServer.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/mcp/FakeMcpServer.java
@@ -12,6 +12,7 @@ final class FakeMcpServer {
     private static final Pattern CONTENT_ID = Pattern.compile("\"id\"\\s*:\\s*(\\d+)");
     private static final Pattern METHOD = Pattern.compile("\"method\"\\s*:\\s*\"([^\"]+)\"");
     private static final Pattern TOOL_NAME = Pattern.compile("\"name\"\\s*:\\s*\"([^\"]+)\"");
+    private static final Pattern PROGRESS_TOKEN = Pattern.compile("\"progressToken\"\\s*:\\s*\"([^\"]+)\"");
 
     private FakeMcpServer() {
     }
@@ -28,6 +29,7 @@ final class FakeMcpServer {
                     "{\"content\":[{\"type\":\"text\",\"text\":\"boom\"}],\"isError\":true}");
             case "echoTool" -> runEchoToolServer();
             case "silentToolCalls" -> runSilentToolCallServer();
+            case "progressStream" -> runProgressStreamServer();
             case "hang" -> Thread.sleep(Long.MAX_VALUE);
             default -> Thread.sleep(Long.MAX_VALUE);
         }
@@ -116,6 +118,66 @@ final class FakeMcpServer {
                 }
             }
         }
+    }
+
+    /**
+     * Answers {@code tools/call} with an {@code ok} result, but first emits three
+     * {@code notifications/progress}-shaped frames the client's {@link ShaftMcpStdioClient#dispatch}
+     * must route safely: one for an unregistered token (proves an unknown/late token is a silent
+     * no-op regardless of whether this call requested progress), one id-less notification using an
+     * unrelated method (proves non-progress notifications stay ignored exactly as before progress
+     * streaming existed), and — only when the request itself carried a {@code _meta.progressToken} —
+     * one for that real token (proves a registered callback receives it).
+     */
+    private static void runProgressStreamServer() throws Exception {
+        BufferedReader input = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
+        OutputStream output = System.out;
+        while (true) {
+            String message = input.readLine();
+            if (message == null) {
+                return;
+            }
+            int requestId = requestId(message);
+            switch (requestMethod(message)) {
+                case "initialize" -> writeMessage(output, requestId,
+                        "{\"jsonrpc\":\"2.0\",\"id\":%d,\"result\":{\"protocolVersion\":\"2024-11-05\"}}");
+                case "tools/call" -> {
+                    String token = progressToken(message);
+                    writeRaw(output, progressFrame("unregistered-token", 0.9, null, "should be ignored"));
+                    writeRaw(output, "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/message\","
+                            + "\"params\":{\"level\":\"info\",\"data\":\"noise\"}}");
+                    if (token != null) {
+                        writeRaw(output, progressFrame(token, 0.5, 1.0, "halfway there"));
+                    }
+                    writeMessage(output, requestId, "{\"jsonrpc\":\"2.0\",\"id\":%d,\"result\":{\"ok\":true}}");
+                }
+                default -> {
+                }
+            }
+        }
+    }
+
+    private static String progressToken(String message) {
+        Matcher matcher = PROGRESS_TOKEN.matcher(message);
+        return matcher.find() ? matcher.group(1) : null;
+    }
+
+    private static String progressFrame(String token, double progressValue, Double total, String messageText) {
+        StringBuilder json = new StringBuilder("{\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\",\"params\":{");
+        json.append("\"progressToken\":\"").append(token).append("\",\"progress\":").append(progressValue);
+        if (total != null) {
+            json.append(",\"total\":").append(total);
+        }
+        if (messageText != null) {
+            json.append(",\"message\":\"").append(messageText).append('"');
+        }
+        return json.append("}}").toString();
+    }
+
+    private static void writeRaw(OutputStream output, String json) throws IOException {
+        output.write(json.getBytes(StandardCharsets.UTF_8));
+        output.write('\n');
+        output.flush();
     }
 
     private static void writeMessage(OutputStream output, int requestId, String responseTemplate) throws IOException {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpStdioClientTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpStdioClientTest.java
@@ -144,38 +144,34 @@ class ShaftMcpStdioClientTest {
 
     @Test
     void callToolStreamsProgressNotificationsToRegisteredCallback() throws Exception {
-        withClient("progressStream", client -> {
+        List<ShaftMcpProgress> updates = Collections.synchronizedList(new ArrayList<>());
+        JsonElement result = withClient("progressStream", client -> {
             client.initializeOnly(Duration.ofSeconds(5));
-            List<ShaftMcpProgress> updates = Collections.synchronizedList(new ArrayList<>());
-
-            JsonElement result = client.callTool("fake_tool", new JsonObject(), Duration.ofSeconds(5), updates::add);
-
-            assertTrue(result.getAsJsonObject().get("ok").getAsBoolean());
-            // Only the frame carrying this call's own progressToken reaches the callback: the
-            // unregistered-token frame and the unrelated notifications/message frame the fake
-            // server also sends must both be silent no-ops.
-            assertEquals(1, updates.size());
-            assertEquals(0.5, updates.get(0).progress());
-            assertEquals(1.0, updates.get(0).total());
-            assertEquals("halfway there", updates.get(0).message());
-            return null;
+            return client.callTool("fake_tool", new JsonObject(), Duration.ofSeconds(5), updates::add);
         });
+
+        assertTrue(result.getAsJsonObject().get("ok").getAsBoolean());
+        // Only the frame carrying this call's own progressToken reaches the callback: the
+        // unregistered-token frame and the unrelated notifications/message frame the fake
+        // server also sends must both be silent no-ops.
+        assertEquals(1, updates.size());
+        assertEquals(0.5, updates.get(0).progress());
+        assertEquals(1.0, updates.get(0).total());
+        assertEquals("halfway there", updates.get(0).message());
     }
 
     @Test
     void callToolWithoutProgressCallbackIgnoresProgressNotifications() throws Exception {
-        withClient("progressStream", client -> {
+        // No callback: no progressToken is sent, so this exercises an id-less
+        // notifications/progress frame for a token nobody registered, plus an unrelated id-less
+        // notification, arriving on a call that never opted into progress at all. Neither may
+        // throw or otherwise disrupt the normal tools/call response.
+        JsonElement result = withClient("progressStream", client -> {
             client.initializeOnly(Duration.ofSeconds(5));
-
-            // No callback: no progressToken is sent, so this exercises an id-less
-            // notifications/progress frame for a token nobody registered, plus an unrelated id-less
-            // notification, arriving on a call that never opted into progress at all. Neither may
-            // throw or otherwise disrupt the normal tools/call response.
-            JsonElement result = client.callTool("fake_tool", new JsonObject(), Duration.ofSeconds(5));
-
-            assertTrue(result.getAsJsonObject().get("ok").getAsBoolean());
-            return null;
+            return client.callTool("fake_tool", new JsonObject(), Duration.ofSeconds(5));
         });
+
+        assertTrue(result.getAsJsonObject().get("ok").getAsBoolean());
     }
 
     private interface ClientAction<T> {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpStdioClientTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpStdioClientTest.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.time.Duration;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -138,6 +140,42 @@ class ShaftMcpStdioClientTest {
 
         assertEquals("first", array.getAsJsonArray().get(0).getAsString());
         assertEquals("plain text result", string.getAsString());
+    }
+
+    @Test
+    void callToolStreamsProgressNotificationsToRegisteredCallback() throws Exception {
+        withClient("progressStream", client -> {
+            client.initializeOnly(Duration.ofSeconds(5));
+            List<ShaftMcpProgress> updates = Collections.synchronizedList(new ArrayList<>());
+
+            JsonElement result = client.callTool("fake_tool", new JsonObject(), Duration.ofSeconds(5), updates::add);
+
+            assertTrue(result.getAsJsonObject().get("ok").getAsBoolean());
+            // Only the frame carrying this call's own progressToken reaches the callback: the
+            // unregistered-token frame and the unrelated notifications/message frame the fake
+            // server also sends must both be silent no-ops.
+            assertEquals(1, updates.size());
+            assertEquals(0.5, updates.get(0).progress());
+            assertEquals(1.0, updates.get(0).total());
+            assertEquals("halfway there", updates.get(0).message());
+            return null;
+        });
+    }
+
+    @Test
+    void callToolWithoutProgressCallbackIgnoresProgressNotifications() throws Exception {
+        withClient("progressStream", client -> {
+            client.initializeOnly(Duration.ofSeconds(5));
+
+            // No callback: no progressToken is sent, so this exercises an id-less
+            // notifications/progress frame for a token nobody registered, plus an unrelated id-less
+            // notification, arriving on a call that never opted into progress at all. Neither may
+            // throw or otherwise disrupt the normal tools/call response.
+            JsonElement result = client.callTool("fake_tool", new JsonObject(), Duration.ofSeconds(5));
+
+            assertTrue(result.getAsJsonObject().get("ok").getAsBoolean());
+            return null;
+        });
     }
 
     private interface ClientAction<T> {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
@@ -122,6 +122,7 @@ class ShaftPluginScreenshotRendererTest {
         Path assistantDarkScreenshot = outputPath.resolve("intellij-plugin-assistant-dark.png");
         Path assistantNarrowDarkScreenshot = outputPath.resolve("intellij-plugin-assistant-narrow-dark.png");
         Path assistantLiveDarkScreenshot = outputPath.resolve("intellij-plugin-assistant-live-output-dark.png");
+        Path assistantProgressMilestonesScreenshot = outputPath.resolve("intellij-plugin-assistant-progress-milestones.png");
         Path assistantApprovalPromptScreenshot = outputPath.resolve("intellij-plugin-assistant-approval-prompt.png");
         Path mcpSetupPostSetupScreenshot = outputPath.resolve("intellij-plugin-mcp-setup-post-setup.png");
         Path guidedScreenshot = outputPath.resolve("intellij-plugin-guided.png");
@@ -152,6 +153,7 @@ class ShaftPluginScreenshotRendererTest {
         write(assistantDarkScreenshot, renderToolWindow(0, "", DARK_THEME, true));
         write(assistantNarrowDarkScreenshot, renderToolWindow(0, "", DARK_THEME, true, NARROW_WIDTH, HEIGHT));
         write(assistantLiveDarkScreenshot, renderAssistantLiveOutput(DARK_THEME, true));
+        write(assistantProgressMilestonesScreenshot, renderAssistantProgressMilestones(LIGHT_THEME, false));
         write(assistantApprovalPromptScreenshot, renderApprovalPrompt(LIGHT_THEME, false));
         write(mcpSetupPostSetupScreenshot, renderPostSetupSettings(LIGHT_THEME, false));
         write(guidedScreenshot, renderToolWindow(1, "", LIGHT_THEME, false));
@@ -182,6 +184,8 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertTrue(Files.size(assistantDarkScreenshot) > 0, assistantDarkScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantNarrowDarkScreenshot) > 0, assistantNarrowDarkScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantLiveDarkScreenshot) > 0, assistantLiveDarkScreenshot + " should be non-empty"),
+                () -> assertTrue(Files.size(assistantProgressMilestonesScreenshot) > 0,
+                        assistantProgressMilestonesScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantApprovalPromptScreenshot) > 0, assistantApprovalPromptScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(mcpSetupPostSetupScreenshot) > 0, mcpSetupPostSetupScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(guidedScreenshot) > 0, guidedScreenshot + " should be non-empty"),
@@ -211,6 +215,7 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertDimensions(assistantDarkScreenshot),
                 () -> assertDimensions(assistantNarrowDarkScreenshot, NARROW_WIDTH, HEIGHT),
                 () -> assertDimensions(assistantLiveDarkScreenshot),
+                () -> assertDimensions(assistantProgressMilestonesScreenshot),
                 () -> assertDimensions(assistantApprovalPromptScreenshot),
                 () -> assertDimensions(mcpSetupPostSetupScreenshot),
                 () -> assertDimensions(guidedScreenshot),
@@ -433,6 +438,58 @@ class ShaftPluginScreenshotRendererTest {
             invokeSetRunning(component, false, "Try asking me to do something...");
         });
         return image.get();
+    }
+
+    /**
+     * Renders the Assistant run timeline mid-{@code capture_generate_replay}, with several
+     * streamed {@code notifications/progress} milestones already appended (issue #3546), so the
+     * screenshot documents live-execution transparency instead of a static "Running" placeholder
+     * that never changes. The milestone text mirrors what {@code CaptureGenerator#generate}
+     * actually reports server-side (shaft-capture), for a realistic shot.
+     *
+     * <p>Driven through {@code addTimeline} directly — the same rendering path {@code
+     * onToolProgress} feeds in production — rather than a real {@code dispatchApprovedTool} call,
+     * because this harness's fake {@link #screenshotProject()} has no live
+     * {@code ShaftMcpInvocationService} to dispatch through.
+     */
+    private static BufferedImage renderAssistantProgressMilestones(String lookAndFeelClassName, boolean dark)
+            throws InterruptedException, InvocationTargetException {
+        AtomicReference<BufferedImage> image = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            configureLookAndFeel(lookAndFeelClassName, dark);
+            ShaftAssistantChatState chatState = new ShaftAssistantChatState();
+            chatState.append("user", "/codegen recordings/demo-recording.json", "");
+            ShaftSettingsState.Settings settings = defaultSettings();
+            settings.defaultAutobotMode = "AGENT";
+            ShaftAssistantPanel component = new ShaftAssistantPanel(screenshotProject(), settings, chatState,
+                    () -> {
+                    });
+            invokeAddTimeline(component, "Tool selected: capture_generate_replay");
+            invokeAddTimeline(component, "Running");
+            invokeSetRunning(component, true, "Running: capture_generate_replay …");
+            invokeAddTimeline(component, "Read capture session demo-recording.json");
+            invokeAddTimeline(component, "Analyzed 12 captured event(s)");
+            invokeAddTimeline(component, "Generated deterministic test source for DemoRecordingTest");
+            invokeAddTimeline(component, "Compiled generated test: PASSED");
+            component.setSize(new Dimension(WIDTH, HEIGHT));
+            component.setPreferredSize(new Dimension(WIDTH, HEIGHT));
+            SwingUtilities.updateComponentTreeUI(component);
+            component.doLayout();
+            layout(component, !dark);
+            image.set(render(component, WIDTH, HEIGHT));
+            invokeSetRunning(component, false, "Try asking me to do something...");
+        });
+        return image.get();
+    }
+
+    private static void invokeAddTimeline(ShaftAssistantPanel component, String step) {
+        try {
+            Method method = ShaftAssistantPanel.class.getDeclaredMethod("addTimeline", String.class);
+            method.setAccessible(true);
+            method.invoke(component, step);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Unable to render the progress-milestones timeline", exception);
+        }
     }
 
     private static BufferedImage renderApprovalPrompt(String lookAndFeelClassName, boolean dark)

--- a/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
@@ -21,7 +21,11 @@ import com.shaft.capture.runtime.NetworkCaptureOptions;
 import com.shaft.capture.runtime.NetworkTransaction;
 import com.shaft.pilot.ai.ApprovalPolicy;
 import com.shaft.pilot.ai.EvidenceCategory;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpSchema;
 import jakarta.annotation.PreDestroy;
+import org.springframework.ai.mcp.annotation.McpProgressToken;
+import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.stereotype.Service;
 
@@ -38,6 +42,7 @@ import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
 /**
@@ -621,6 +626,10 @@ public class CaptureService {
     /**
      * Generates, compiles, and optionally replays a deterministic SHAFT TestNG test from a Capture session.
      *
+     * <p>Plain Java overload with no progress reporting, preserved for direct callers (for example,
+     * white-box tests); the MCP-exposed tool is {@link #generateReplay(String, String, String, String,
+     * boolean, boolean, boolean, boolean, boolean, String, String, McpSyncServerExchange)}.
+     *
      * @param sessionPath persisted Capture JSON path inside the MCP workspace
      * @param outputDirectory generated project root inside the MCP workspace
      * @param packageName generated Java package
@@ -633,7 +642,42 @@ public class CaptureService {
      * @param driverVariableName Java driver variable name used in extracted snippets
      * @return generation report plus copy-paste code blocks
      */
-    @Tool(name = "capture_generate_replay",
+    public McpCaptureReplayResult generateReplay(
+            String sessionPath,
+            String outputDirectory,
+            String packageName,
+            String className,
+            boolean overwrite,
+            boolean replay,
+            boolean useAi,
+            boolean allowLocalAi,
+            boolean allowRemoteAi,
+            String driverVariableName) {
+        return generateReplay(sessionPath, outputDirectory, packageName, className, overwrite, replay, useAi,
+                allowLocalAi, allowRemoteAi, driverVariableName, null, null);
+    }
+
+    /**
+     * Generates, compiles, and optionally replays a deterministic SHAFT TestNG test from a Capture session,
+     * streaming best-effort milestone progress over the MCP exchange when the caller requested it.
+     *
+     * @param sessionPath persisted Capture JSON path inside the MCP workspace
+     * @param outputDirectory generated project root inside the MCP workspace
+     * @param packageName generated Java package
+     * @param className optional generated class name
+     * @param overwrite whether existing generated source and test-data files may be replaced; status reports are always refreshed
+     * @param replay whether to execute the generated test
+     * @param useAi whether to request optional AI enrichment preview
+     * @param allowLocalAi explicit approval for local inference
+     * @param allowRemoteAi explicit approval for remote inference
+     * @param driverVariableName Java driver variable name used in extracted snippets
+     * @param progressToken MCP progress token supplied by the requester; null when the client did
+     *                      not request progress notifications
+     * @param exchange live MCP server exchange used to emit progress notifications; injected by the
+     *                 annotation-scanning MCP tool provider, never exposed in the tool's input schema
+     * @return generation report plus copy-paste code blocks
+     */
+    @McpTool(name = "capture_generate_replay",
             description = "generates, compiles, optionally replays, and returns copy-paste SHAFT code blocks from a "
                     + "persisted recording JSON (sessionPath); works on any recording file, no active capture session required")
     public McpCaptureReplayResult generateReplay(
@@ -646,7 +690,9 @@ public class CaptureService {
             boolean useAi,
             boolean allowLocalAi,
             boolean allowRemoteAi,
-            String driverVariableName) {
+            String driverVariableName,
+            @McpProgressToken String progressToken,
+            McpSyncServerExchange exchange) {
         CaptureGenerationResult result = generateInternal(
                 sessionPath,
                 outputDirectory,
@@ -659,8 +705,29 @@ public class CaptureService {
                 false,
                 allowLocalAi,
                 allowRemoteAi,
-                CodegenBackend.WEBDRIVER);
+                CodegenBackend.WEBDRIVER,
+                progressReporter(progressToken, exchange));
         return replayResult(result, driverVariableName);
+    }
+
+    /**
+     * Builds a best-effort progress-notification sink for a Capture generation call: a no-op when
+     * the client did not request progress (no token) or the tool is invoked outside a live MCP
+     * exchange (for example, direct unit tests).
+     *
+     * @param progressToken MCP progress token supplied by the requester, or null/blank
+     * @param exchange live MCP server exchange, or null outside a real MCP call
+     * @return a progress sink safe to pass to {@link CaptureGenerator#generate}
+     */
+    private static BiConsumer<Double, String> progressReporter(String progressToken, McpSyncServerExchange exchange) {
+        if (exchange == null || progressToken == null || progressToken.isBlank()) {
+            return (fraction, message) -> { };
+        }
+        return (fraction, message) -> exchange.progressNotification(
+                McpSchema.ProgressNotification.builder(progressToken, fraction)
+                        .total(1.0)
+                        .message(message)
+                        .build());
     }
 
     /**
@@ -989,6 +1056,36 @@ public class CaptureService {
             boolean allowLocalAi,
             boolean allowRemoteAi,
             CodegenBackend backend) {
+        return generateInternal(
+                sessionPath,
+                outputDirectory,
+                packageName,
+                className,
+                overwrite,
+                replay,
+                aiPreview,
+                applyEnrichment,
+                approveEnrichment,
+                allowLocalAi,
+                allowRemoteAi,
+                backend,
+                (fraction, message) -> { });
+    }
+
+    private CaptureGenerationResult generateInternal(
+            String sessionPath,
+            String outputDirectory,
+            String packageName,
+            String className,
+            boolean overwrite,
+            boolean replay,
+            boolean aiPreview,
+            boolean applyEnrichment,
+            boolean approveEnrichment,
+            boolean allowLocalAi,
+            boolean allowRemoteAi,
+            CodegenBackend backend,
+            BiConsumer<Double, String> progress) {
         Path output = outputDirectory == null || outputDirectory.isBlank()
                 ? workspacePolicy.output("generated-tests", "Capture generation output directory")
                 : workspacePolicy.output(outputDirectory, "Capture generation output directory");
@@ -1014,7 +1111,8 @@ public class CaptureService {
                         allowLocalAi || aiPreview || applyEnrichment,
                         allowRemoteAi || aiPreview || applyEnrichment,
                         EnumSet.of(EvidenceCategory.TEXT))),
-                backend);
+                backend,
+                progress);
     }
 
     private String workspacePath(String value, String label) {

--- a/shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java
@@ -1,5 +1,7 @@
 package com.shaft.mcp;
 
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.spec.McpSchema;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.JsonNode;
 import org.junit.jupiter.api.Test;
@@ -12,7 +14,9 @@ import java.io.File;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -42,9 +46,7 @@ class ShaftMcpApplicationTests {
         Set<String> toolNames = callbacks.stream()
                 .map(ToolCallback.class::cast)
                 .map(callback -> callback.getToolDefinition().name())
-                .collect(Collectors.toSet());
-        Set<String> expected = expectedTools();
-        assertEquals(expected, toolNames);
+                .collect(Collectors.toCollection(HashSet::new));
         callbacks.stream()
                 .map(ToolCallback.class::cast)
                 .forEach(callback -> {
@@ -52,6 +54,21 @@ class ShaftMcpApplicationTests {
                     assertFalse(GENERIC_PARAMETER_NAME.matcher(schema).find(),
                             callback.getToolDefinition().name() + " exposes generic parameter names: " + schema);
                 });
+
+        // Tools that need a live MCP exchange (for example, to stream progress notifications) are
+        // exposed via @McpTool annotation scanning instead of the plain @Tool/ToolCallback path
+        // above; they register on a separate "toolSpecs" bean that the real McpSyncServer also
+        // consumes (McpServerAutoConfiguration merges both lists), so the full external tool
+        // catalog is the union of the two.
+        for (McpServerFeatures.SyncToolSpecification toolSpecification : annotationScannedToolSpecs()) {
+            McpSchema.Tool tool = toolSpecification.tool();
+            assertTrue(toolNames.add(tool.name()),
+                    tool.name() + " is registered both as a ToolCallback and an annotation-scanned MCP tool");
+            assertNoGenericParameterNames(tool);
+        }
+
+        Set<String> expected = expectedTools();
+        assertEquals(expected, toolNames);
         assertTrue(toolNames.contains("doctor_analyze_failed_allure"));
         assertTrue(toolNames.contains("trace_latest"));
         assertTrue(toolNames.contains("trace_read"));
@@ -199,5 +216,30 @@ class ShaftMcpApplicationTests {
         }
         assertTrue(duplicates.isEmpty(), "MCP tool manifest contains duplicate tools: " + duplicates);
         return tools;
+    }
+
+    /**
+     * Tools annotated {@code @McpTool} (for example, {@code capture_generate_replay}, which needs
+     * a live {@code McpSyncServerExchange} to stream progress notifications) register on the
+     * "toolSpecs" bean built by Spring AI's annotation-scanning MCP auto-configuration, not on the
+     * "shaftTools" {@code List<ToolCallback>} bean. That auto-configuration only requires
+     * {@code spring.ai.mcp.server.annotation-scanner.enabled} (defaults true) and is unaffected by
+     * this test class's {@code spring.ai.mcp.server.enabled=false}, so the bean is present here too.
+     */
+    @SuppressWarnings("unchecked")
+    private List<McpServerFeatures.SyncToolSpecification> annotationScannedToolSpecs() {
+        return (List<McpServerFeatures.SyncToolSpecification>) context.getBean("toolSpecs", List.class);
+    }
+
+    private static void assertNoGenericParameterNames(McpSchema.Tool tool) {
+        Object properties = tool.inputSchema().get("properties");
+        if (!(properties instanceof Map<?, ?> propertiesMap)) {
+            return;
+        }
+        Set<String> generic = propertiesMap.keySet().stream()
+                .map(Object::toString)
+                .filter(name -> name.matches("arg\\d+"))
+                .collect(Collectors.toSet());
+        assertTrue(generic.isEmpty(), tool.name() + " exposes generic parameter names: " + generic);
     }
 }


### PR DESCRIPTION
Closes #3546. Foundational child of the IntelliJ UX program #3553.

## What & why
Long MCP tool calls (canonically `capture_generate_replay`) previously showed a static "Running" placeholder with no signal until they finished — they looked frozen. This wires end-to-end **MCP `notifications/progress`** streaming so the plugin renders live milestones.

## Server side (shaft-mcp + shaft-capture) — `b2f89b5`
- Migrated `capture_generate_replay` off plain `@Tool` onto Spring AI 2.0's **`@McpTool`** so it can receive `@McpProgressToken` + `McpSyncServerExchange` and emit progress. Plain `@Tool`/`ToolCallbacks.from` methods never get the exchange — this was the gating design finding, confirmed statically (auto-config imports the annotation scanner, default-enabled) and empirically.
- Threaded a best-effort `BiConsumer<Double,String>` progress sink into `CaptureGenerator.generate()` via a new overload; existing callers delegate through a no-op sink → **no public signature changes**, tool name/JSON schema unchanged, **164-tool manifest intact**.
- Milestones fire on every return path (read → analyze → generate → compile → replay → complete, including failure paths).

## Client + UI (shaft-intellij) — `8e21fbe`
- `ShaftMcpStdioClient.callTool(...)` gains an optional `Consumer<ShaftMcpProgress>` overload that sends a per-request `_meta.progressToken` and registers a callback (removed in `finally`); `dispatch()` now routes inbound `notifications/progress` (previously dropped as id-less). Unknown/late tokens and other id-less notifications stay no-ops.
- `ShaftMcpInvocationService` threads the optional callback through `startTool` overloads — existing 5 call sites + tests untouched.
- `ShaftAssistantPanel` / `ShaftFeaturePanel` stream milestones into the Run timeline / status pill via `invokeLater` (EDT-safe).
- Non-verbose local-agent runs now post compact milestone lines (raw NDJSON still hidden unless Verbose, preserving #3545) so they no longer look frozen.

**Backward-compatible:** no callback → no token → prior behavior; a server that never emits progress behaves exactly as before.

## Verification
- `ShaftMcpApplicationTests` **5/5** (independently re-run, JDK25) — proves `@McpTool` registers alongside the `ToolCallback` list and the manifest is unchanged.
- `ShaftMcpStdioClientTest` **10/10** (independently re-run, JDK21) — incl. 2 new routing tests (real-token routed, unknown-token no-op, non-progress id-less notification ignored) via a new `FakeMcpServer` progressStream mode.
- `CaptureGeneratorTest` progress test — ≥2 monotonic milestones ending at 1.0, generation result unchanged.
- Full shaft-intellij module: **563/563**, 0 failures.
- Screenshot fixture `renderAssistantProgressMilestones` added; Assistant timeline renders streamed milestones with an active progress pill.

## Scope
No new MCP tools (no manifest/catalog sync needed). No engine features. Per the #3553 tracker, this is the progress spine that #3547 (failure-render) and the codegen milestone narrative build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)