### PR TITLE
feat: humanize IntelliJ tool output + fix advancedUiEnabled no-ops (#3552)

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/actions/RecordApiWebAction.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/actions/RecordApiWebAction.java
@@ -60,10 +60,12 @@ public final class RecordApiWebAction extends AnAction implements DumbAware {
         arguments.add("networkOptions", networkOptions);
 
         if (!ShaftSettingsState.getInstance().getState().advancedUiEnabled) {
-            // showApiRecordingTab silently no-ops while advanced workflows are off (the default), so
-            // notifying "prepared" here would claim a recording started when nothing actually did.
-            ShaftNotifier.warn(project, "SHAFT",
-                    "Enable advanced workflows in Settings | SHAFT to open the API Recording tab.");
+            // Default mode: route to the Assistant with the URL the user just typed, carried into an
+            // equivalent plain-language request, instead of discarding it behind a dead-end warning
+            // (issue #3552) -- the raw API Recording tab stays hidden here.
+            openAssistantPrompt(project, recordApiPrompt(targetUrl.trim()));
+            ShaftNotifier.info(project, "SHAFT",
+                    "API recording request ready in the Assistant for " + targetUrl.trim() + ".");
             return;
         }
         openApiRecordingTab(project, targetUrl.trim(), arguments);
@@ -74,6 +76,29 @@ public final class RecordApiWebAction extends AnAction implements DumbAware {
     public void update(@NotNull AnActionEvent event) {
         Project project = event.getProject();
         event.getPresentation().setEnabledAndVisible(project != null && ShaftProjectDetector.isShaftProject(project));
+    }
+
+    /**
+     * Plain-language Assistant equivalent of the {@code capture_api_start} MCP request. Package-
+     * private for {@code RecordApiWebActionTest}.
+     */
+    static String recordApiPrompt(String targetUrl) {
+        return "Record API traffic on " + targetUrl;
+    }
+
+    private static void openAssistantPrompt(Project project, String text) {
+        ToolWindowManager.getInstance(project).invokeLater(() -> {
+            ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("SHAFT");
+            if (toolWindow == null) {
+                return;
+            }
+            toolWindow.show(() -> {
+                Content content = toolWindow.getContentManager().getContent(0);
+                if (content != null && content.getComponent() instanceof ShaftToolWindowPanel panel) {
+                    panel.prefillAssistantPrompt(text);
+                }
+            });
+        });
     }
 
     private static void openApiRecordingTab(Project project, String targetUrl, JsonObject arguments) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/actions/RecordShaftFlowHereAction.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/actions/RecordShaftFlowHereAction.java
@@ -53,17 +53,19 @@ public final class RecordShaftFlowHereAction extends AnAction implements DumbAwa
         arguments.addProperty("insertAfter", context.methodName());
         arguments.addProperty("driverVariableName", "driver");
 
+        if (!ShaftSettingsState.getInstance().getState().advancedUiEnabled) {
+            // Default mode: route to the Assistant with an equivalent plain-language request instead
+            // of copying raw MCP JSON to the clipboard and leaving the user to paste it somewhere
+            // (issue #3552) -- prefillTool() only exists on the raw Tools panel that stays hidden here.
+            openAssistantPrompt(project, recordFlowPrompt(context));
+            ShaftNotifier.info(project, "SHAFT",
+                    "Record-at-target request ready in the Assistant for " + context.displayName() + ".");
+            return;
+        }
         JsonObject request = new JsonObject();
         request.addProperty("tool", "capture_record_at_target_code_blocks");
         request.add("arguments", arguments);
         CopyPasteManager.getInstance().setContents(new StringSelection(request.toString()));
-        if (!ShaftSettingsState.getInstance().getState().advancedUiEnabled) {
-            // prefillTool silently no-ops while advanced workflows are off (the default), so notifying
-            // "prepared" here would claim the tool window opened when nothing actually did.
-            ShaftNotifier.warn(project, "SHAFT", "Record-at-target request copied to the clipboard for "
-                    + context.displayName() + ". Enable advanced workflows in Settings | SHAFT to open it there.");
-            return;
-        }
         openToolWindow(project, arguments);
         ShaftNotifier.info(project, "SHAFT", "Record-at-target tool prepared for " + context.displayName() + ".");
     }
@@ -78,6 +80,29 @@ public final class RecordShaftFlowHereAction extends AnAction implements DumbAwa
             available = JavaTargetContextResolver.resolve(file, editor.getCaretModel().getOffset()) != null;
         }
         event.getPresentation().setEnabledAndVisible(available);
+    }
+
+    /**
+     * Plain-language Assistant equivalent of the {@code capture_record_at_target_code_blocks} MCP
+     * request. Package-private for {@code RecordShaftFlowHereActionTest}.
+     */
+    static String recordFlowPrompt(JavaTargetContext context) {
+        return "Record a SHAFT flow at " + context.methodName() + " in " + context.className();
+    }
+
+    private static void openAssistantPrompt(Project project, String text) {
+        ToolWindowManager.getInstance(project).invokeLater(() -> {
+            ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("SHAFT");
+            if (toolWindow == null) {
+                return;
+            }
+            toolWindow.show(() -> {
+                Content content = toolWindow.getContentManager().getContent(0);
+                if (content != null && content.getComponent() instanceof ShaftToolWindowPanel panel) {
+                    panel.prefillAssistantPrompt(text);
+                }
+            });
+        });
     }
 
     private static void openToolWindow(Project project, JsonObject arguments) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/notifications/ShaftToolWorkflowLauncher.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/notifications/ShaftToolWorkflowLauncher.java
@@ -9,11 +9,11 @@ import com.shaft.intellij.settings.ShaftSettingsState;
 import com.shaft.intellij.ui.ShaftToolWindowPanel;
 
 /**
- * Opens the SHAFT tool window and pre-fills an MCP tool request, or -- while advanced workflows
- * are off (the default) -- points the user at the Assistant instead of silently claiming a panel
- * opened. Shared by {@link FailedRunDoctorNotifier} and the "SHAFT Tests" tool-window tab
- * (issue #3467), both of which trigger the same Doctor/Healer prefill flow from different UI
- * surfaces.
+ * Opens the SHAFT tool window and pre-fills either an MCP tool request (advanced workflows on) or
+ * the Assistant composer with an equivalent plain-language request (advanced workflows off, the
+ * default) -- always acting, never a silent no-op or a dead-end warning. Shared by
+ * {@link FailedRunDoctorNotifier} and the "SHAFT Tests" tool-window tab (issue #3467), both of
+ * which trigger the same Doctor/Healer prefill flow from different UI surfaces.
  */
 public final class ShaftToolWorkflowLauncher {
     private ShaftToolWorkflowLauncher() {
@@ -21,20 +21,17 @@ public final class ShaftToolWorkflowLauncher {
     }
 
     /**
-     * Opens the SHAFT tool window and pre-fills {@code toolName} with {@code arguments}, or warns
-     * and no-ops when advanced workflows are disabled.
+     * Opens the SHAFT tool window and pre-fills {@code toolName} with {@code arguments} directly in
+     * the raw Tools panel when advanced workflows are on; otherwise opens the Assistant tab and
+     * pre-fills its composer with an equivalent plain-language request for the user to review and
+     * send themselves (issue #3552).
      *
      * @param project current project
      * @param toolName MCP tool name to pre-fill
      * @param arguments MCP tool arguments
      */
     public static void open(Project project, String toolName, JsonObject arguments) {
-        if (!ShaftSettingsState.getInstance().getState().advancedUiEnabled) {
-            ShaftNotifier.warn(project, "SHAFT",
-                    "Ask the SHAFT Assistant to \"diagnose my last failed test run\" to analyze the "
-                            + "failure from chat.");
-            return;
-        }
+        boolean advancedUiEnabled = ShaftSettingsState.getInstance().getState().advancedUiEnabled;
         ToolWindowManager.getInstance(project).invokeLater(() -> {
             ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("SHAFT");
             if (toolWindow == null) {
@@ -42,10 +39,26 @@ public final class ShaftToolWorkflowLauncher {
             }
             toolWindow.show(() -> {
                 Content content = toolWindow.getContentManager().getContent(0);
-                if (content != null && content.getComponent() instanceof ShaftToolWindowPanel panel) {
+                if (!(content != null && content.getComponent() instanceof ShaftToolWindowPanel panel)) {
+                    return;
+                }
+                if (advancedUiEnabled) {
                     panel.prefillTool(toolName, arguments);
+                } else {
+                    panel.prefillAssistantPrompt(assistantPromptFor(toolName));
                 }
             });
         });
+    }
+
+    /**
+     * Plain-language Assistant equivalent of a Doctor/Healer MCP tool request, so default-mode users
+     * (advanced workflows off) get a ready-to-send request instead of the raw tool call.
+     * Package-private for {@code ShaftToolWorkflowLauncherTest}.
+     */
+    static String assistantPromptFor(String toolName) {
+        return "healer_run_failed_test".equals(toolName)
+                ? "Heal my last failed test run"
+                : "Diagnose my last failed test run";
     }
 }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java
@@ -173,6 +173,7 @@ final class AssistantMarkdown {
             case "autobot_provider_status" -> providerStatusMarkdown(parsed);
             case "shaft_coding_partner_diff" -> codingPartnerDiffMarkdown(parsed);
             case "verify_run_focused" -> verifyMarkdown(parsed);
+            case "healer_run_failed_test", "playwright_healer_run_failed_test" -> healerMarkdown(parsed);
             default -> "";
         };
     }
@@ -886,19 +887,23 @@ final class AssistantMarkdown {
     }
 
     private static String doctorActionsMarkdown(JsonArray actions) {
+        return titledActionsMarkdown("Recommended actions", actions);
+    }
+
+    private static String titledActionsMarkdown(String title, JsonArray actions) {
         if (actions.isEmpty()) {
             return "";
         }
-        StringBuilder markdown = new StringBuilder("**Recommended actions**");
+        StringBuilder markdown = new StringBuilder("**").append(title).append("**");
         for (JsonElement item : actions) {
             if (!item.isJsonObject()) {
                 continue;
             }
             JsonObject action = item.getAsJsonObject();
-            String title = string(action, "title", "Action");
+            String actionTitle = string(action, "title", "Action");
             String text = string(action, "action", "");
             String status = string(action, "status", "");
-            markdown.append("\n- **").append(title).append("**");
+            markdown.append("\n- **").append(actionTitle).append("**");
             if (!status.isBlank()) {
                 markdown.append(" (`").append(status).append("`)");
             }
@@ -907,6 +912,91 @@ final class AssistantMarkdown {
             }
         }
         return markdown.toString();
+    }
+
+    /**
+     * Renders an {@code McpHealerRunResult} ({@code healer_run_failed_test},
+     * {@code playwright_healer_run_failed_test}) as a readable card: the overall status, each
+     * guarded rerun attempt, the nested Doctor {@code analysis} (delegated to {@link
+     * #doctorMarkdown(JsonObject)} so a manual doctor run and a healer's embedded diagnosis read
+     * identically — issue #3552), and the top-level review-only actions/code blocks. The top-level
+     * {@code actions}/{@code codeBlocks} are a superset of {@code analysis}'s own (the healer merges
+     * the doctor's remediation into its own list plus an agent-handoff action/snippet — see
+     * {@code HealerService}), so they are labelled "Healer actions"/"Handoff snippets" rather than
+     * reusing the Doctor card's "Recommended actions"/"Fix snippets" headers, to avoid two
+     * identically-labelled sections that would read as a plain duplicate.
+     */
+    private static String healerMarkdown(JsonElement parsed) {
+        if (!parsed.isJsonObject()) {
+            return "";
+        }
+        JsonObject object = parsed.getAsJsonObject();
+        if (!object.has("schemaVersion") || !object.has("attempts") || !object.has("analysis")) {
+            return "";
+        }
+        List<String> sections = new ArrayList<>();
+        String status = string(object, "status", "");
+        sections.add("**" + healerStatusIcon(status) + " Healer:** " + status);
+        if (object.get("attempts").isJsonArray()) {
+            appendNonBlank(sections, healerAttemptsMarkdown(object.getAsJsonArray("attempts")));
+        }
+        JsonElement analysis = object.get("analysis");
+        if (analysis != null && analysis.isJsonObject()) {
+            appendNonBlank(sections, doctorMarkdown(analysis.getAsJsonObject()));
+        }
+        if (object.has("actions") && object.get("actions").isJsonArray()) {
+            appendNonBlank(sections, titledActionsMarkdown("Healer actions", object.getAsJsonArray("actions")));
+        }
+        if (object.has("codeBlocks") && object.get("codeBlocks").isJsonArray()) {
+            String blocks = codeBlocksMarkdown(object.getAsJsonArray("codeBlocks"));
+            if (!blocks.isBlank()) {
+                sections.add("**Handoff snippets**\n\n" + blocks);
+            }
+        }
+        appendNonBlank(sections, warnings(object));
+        return joinSections(sections);
+    }
+
+    private static String healerAttemptsMarkdown(JsonArray attempts) {
+        if (attempts.isEmpty()) {
+            return "";
+        }
+        StringBuilder markdown = new StringBuilder("**Attempts**");
+        for (JsonElement item : attempts) {
+            if (!item.isJsonObject()) {
+                continue;
+            }
+            JsonObject attempt = item.getAsJsonObject();
+            markdown.append("\n- Attempt ").append(string(attempt, "attemptNumber", "?")).append(": ")
+                    .append(healerAttemptOutcome(attempt));
+            String exitCode = string(attempt, "exitCode", "");
+            if (!exitCode.isBlank()) {
+                markdown.append(" (exit ").append(exitCode).append(")");
+            }
+            String diagnostics = string(attempt, "diagnostics", "");
+            if (!diagnostics.isBlank()) {
+                markdown.append(" — ").append(diagnostics);
+            }
+        }
+        return markdown.toString();
+    }
+
+    private static String healerAttemptOutcome(JsonObject attempt) {
+        if (booleanValue(attempt, "passed")) {
+            return ShaftStatusPresentation.SUCCESS_ICON + " passed";
+        }
+        if (booleanValue(attempt, "timedOut")) {
+            return ShaftStatusPresentation.WARNING_ICON + " timed out";
+        }
+        return ShaftStatusPresentation.ERROR_ICON + " failed";
+    }
+
+    private static String healerStatusIcon(String status) {
+        return switch (status) {
+            case "PASSED" -> ShaftStatusPresentation.SUCCESS_ICON;
+            case "FAILED_WITH_SUGGESTIONS", "PRODUCT_BUG_SUSPECTED" -> ShaftStatusPresentation.WARNING_ICON;
+            default -> ShaftStatusPresentation.ERROR_ICON;
+        };
     }
 
     private static String mobileMarkdown(JsonObject object) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java
@@ -931,30 +931,55 @@ final class AssistantMarkdown {
             return "";
         }
         JsonObject object = parsed.getAsJsonObject();
-        if (!object.has("schemaVersion") || !object.has("attempts") || !object.has("analysis")) {
+        if (!isHealerResult(object)) {
             return "";
         }
+        // Each section helper returns "" when its data is absent, so appendNonBlank does the
+        // filtering and this method stays flat (keeps NPath complexity low).
         List<String> sections = new ArrayList<>();
-        String status = string(object, "status", "");
-        sections.add("**" + healerStatusIcon(status) + " Healer:** " + status);
-        if (object.get("attempts").isJsonArray()) {
-            appendNonBlank(sections, healerAttemptsMarkdown(object.getAsJsonArray("attempts")));
-        }
-        JsonElement analysis = object.get("analysis");
-        if (analysis != null && analysis.isJsonObject()) {
-            appendNonBlank(sections, doctorMarkdown(analysis.getAsJsonObject()));
-        }
-        if (object.has("actions") && object.get("actions").isJsonArray()) {
-            appendNonBlank(sections, titledActionsMarkdown("Healer actions", object.getAsJsonArray("actions")));
-        }
-        if (object.has("codeBlocks") && object.get("codeBlocks").isJsonArray()) {
-            String blocks = codeBlocksMarkdown(object.getAsJsonArray("codeBlocks"));
-            if (!blocks.isBlank()) {
-                sections.add("**Handoff snippets**\n\n" + blocks);
-            }
-        }
+        sections.add(healerStatusLine(object));
+        appendNonBlank(sections, healerAttemptsSection(object));
+        appendNonBlank(sections, healerAnalysisSection(object));
+        appendNonBlank(sections, healerActionsSection(object));
+        appendNonBlank(sections, healerSnippetsSection(object));
         appendNonBlank(sections, warnings(object));
         return joinSections(sections);
+    }
+
+    private static boolean isHealerResult(JsonObject object) {
+        return object.has("schemaVersion") && object.has("attempts") && object.has("analysis");
+    }
+
+    private static String healerStatusLine(JsonObject object) {
+        String status = string(object, "status", "");
+        return "**" + healerStatusIcon(status) + " Healer:** " + status;
+    }
+
+    private static String healerAttemptsSection(JsonObject object) {
+        return object.get("attempts").isJsonArray()
+                ? healerAttemptsMarkdown(object.getAsJsonArray("attempts"))
+                : "";
+    }
+
+    private static String healerAnalysisSection(JsonObject object) {
+        JsonElement analysis = object.get("analysis");
+        return analysis != null && analysis.isJsonObject()
+                ? doctorMarkdown(analysis.getAsJsonObject())
+                : "";
+    }
+
+    private static String healerActionsSection(JsonObject object) {
+        return object.has("actions") && object.get("actions").isJsonArray()
+                ? titledActionsMarkdown("Healer actions", object.getAsJsonArray("actions"))
+                : "";
+    }
+
+    private static String healerSnippetsSection(JsonObject object) {
+        if (!object.has("codeBlocks") || !object.get("codeBlocks").isJsonArray()) {
+            return "";
+        }
+        String blocks = codeBlocksMarkdown(object.getAsJsonArray("codeBlocks"));
+        return blocks.isBlank() ? "" : "**Handoff snippets**\n\n" + blocks;
     }
 
     private static String healerAttemptsMarkdown(JsonArray attempts) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -593,6 +593,25 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     /**
+     * Fills the composer with {@code text} for the user to review and send themselves — never
+     * auto-sends (issue #3552, mirrors {@link #emptyStateChip(String, String)}). Used by
+     * {@link ShaftToolWindowPanel#prefillAssistantPrompt(String)} so action/notification entry
+     * points that used to silently no-op while advanced workflows are off can instead route the
+     * user straight to the Assistant with a ready-to-send plain-language request.
+     *
+     * @param text plain-language prompt to prefill
+     */
+    void prefillPrompt(String text) {
+        if (text == null || text.isBlank()) {
+            return;
+        }
+        prompt.setText(text);
+        prompt.setCaretPosition(text.length());
+        prompt.requestFocusInWindow();
+        setStatus("Review the prefilled request, then send it");
+    }
+
+    /**
      * Text area with a placeholder that wraps to the component's real width. IntelliJ's
      * {@code StatusText} empty text never wraps and clips long lines even when the tool window is
      * wide, cutting off the invite mid-sentence.

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -611,6 +611,16 @@ final class ShaftAssistantPanel extends JPanel {
         setStatus("Review the prefilled request, then send it");
     }
 
+    /** Package-private test accessor: current composer text. */
+    String promptText() {
+        return prompt.getText();
+    }
+
+    /** Package-private test accessor: rendered transcript markdown (blank until a turn is sent). */
+    String transcriptMarkdown() {
+        return transcript.markdown();
+    }
+
     /**
      * Text area with a placeholder that wraps to the component's real width. IntelliJ's
      * {@code StatusText} empty text never wraps and clips long lines even when the tool window is

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftFeaturePanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftFeaturePanel.java
@@ -59,6 +59,10 @@ final class ShaftFeaturePanel extends JPanel {
     private final JLabel templateDescription;
     private final JBTextArea argumentsArea;
     private final JBTextArea outputArea;
+    private final AssistantTranscriptView outputCard;
+    private final JPanel outputCards;
+    private final JButton toggleRawOutputButton;
+    private boolean showingRawOutput;
     private final JButton runButton;
     private final JButton cancelButton;
     private final JButton restoreDefaultsButton;
@@ -112,10 +116,22 @@ final class ShaftFeaturePanel extends JPanel {
         argumentsArea.setLineWrap(true);
         argumentsArea.setWrapStyleWord(true);
         outputArea = new JBTextArea(10, 32);
-        outputArea.getAccessibleContext().setAccessibleName("SHAFT tool output");
+        outputArea.getAccessibleContext().setAccessibleName("SHAFT tool output (raw JSON)");
         outputArea.setEditable(false);
         outputArea.setLineWrap(true);
         outputArea.setWrapStyleWord(true);
+        // Humanized card is the default view (issue #3552); outputArea keeps holding the untouched
+        // raw text so copyOutputButton and the "View raw JSON" toggle always show the exact bytes.
+        outputCard = new AssistantTranscriptView(project);
+        outputCard.getAccessibleContext().setAccessibleName("SHAFT tool output");
+        outputCards = new JPanel(new java.awt.CardLayout());
+        outputCards.add(outputCard, "card");
+        outputCards.add(new JBScrollPane(outputArea), "raw");
+        toggleRawOutputButton = new JButton();
+        ShaftIconButtons.apply(toggleRawOutputButton, "View raw JSON", "Toggle raw SHAFT tool output",
+                ShaftIcons.CODE);
+        toggleRawOutputButton.setEnabled(false);
+        toggleRawOutputButton.addActionListener(event -> toggleRawOutput());
         status = new JLabel("Ready");
         progress = new JProgressBar();
         progress.setIndeterminate(true);
@@ -203,8 +219,11 @@ final class ShaftFeaturePanel extends JPanel {
 
         JPanel output = new JPanel(new BorderLayout(4, 4));
         JLabel outputLabel = label("Output", 'O', outputArea);
-        output.add(outputLabel, BorderLayout.NORTH);
-        output.add(new JBScrollPane(outputArea), BorderLayout.CENTER);
+        JPanel outputHeader = new JPanel(new BorderLayout());
+        outputHeader.add(outputLabel, BorderLayout.WEST);
+        outputHeader.add(toggleRawOutputButton, BorderLayout.EAST);
+        output.add(outputHeader, BorderLayout.NORTH);
+        output.add(outputCards, BorderLayout.CENTER);
 
         JSplitPane splitPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT, center, output);
         splitPane.setResizeWeight(0.66);
@@ -263,11 +282,10 @@ final class ShaftFeaturePanel extends JPanel {
         }
         if (!mcpConfigured()) {
             status.setText("Configure MCP");
-            outputArea.setText("Configure SHAFT MCP in Settings before running Tools requests.");
-            copyOutputButton.setEnabled(true);
+            setOutput(template.toolName(), "Configure SHAFT MCP in Settings before running Tools requests.");
             return;
         }
-        if (!projectAvailable(project)) {
+        if (!projectAvailable(project, template.toolName())) {
             return;
         }
         if (template.confirmationRequired()
@@ -289,20 +307,18 @@ final class ShaftFeaturePanel extends JPanel {
             status.setText("Invalid JSON");
             JsonText.JsonErrorLocation location = JsonText.findErrorLocation(argumentsArea.getText());
             String message = location != null ? "Invalid JSON at " + location : "Invalid JSON";
-            outputArea.setText(message);
+            setOutput(template.toolName(), message);
             if (location != null) {
                 selectJsonErrorLocation(location);
             }
-            copyOutputButton.setEnabled(true);
             return;
         }
         setRunning(true, "Running: " + template.toolName() + " …");
-        outputArea.setText("");
-        copyOutputButton.setEnabled(false);
+        clearOutput();
         currentInvocation = ShaftMcpInvocationService.getInstance(project).startTool(
                 template.toolName(), arguments, this::onToolProgress);
         currentInvocation.future().whenComplete((result, error) -> ApplicationManager.getApplication().invokeLater(
-                () -> showResult(result, error)));
+                () -> showResult(template.toolName(), result, error)));
     }
 
     /**
@@ -329,17 +345,15 @@ final class ShaftFeaturePanel extends JPanel {
         }
         if (!mcpConfigured()) {
             status.setText("Configure MCP");
-            outputArea.setText("Configure SHAFT MCP in Settings before refreshing the tool catalog.");
-            copyOutputButton.setEnabled(true);
+            setOutput("", "Configure SHAFT MCP in Settings before refreshing the tool catalog.");
             return;
         }
-        if (!projectAvailable(project)) {
+        if (!projectAvailable(project, "")) {
             return;
         }
         setRunning(true, "Refreshing tools...");
         refreshCatalogButton.setToolTipText(REFRESHING_TOOLTIP);
-        outputArea.setText("");
-        copyOutputButton.setEnabled(false);
+        clearOutput();
         // The button is an explicit user request for fresh data, so it must bypass the cache
         // unlike the silent auto-populate warm-up (which serves the cache when present).
         currentInvocation = ShaftMcpInvocationService.getInstance(project).startListTools(true);
@@ -347,11 +361,10 @@ final class ShaftFeaturePanel extends JPanel {
                 () -> showCatalogResult(result, error)));
     }
 
-    private void showResult(ShaftMcpToolResult result, Throwable error) {
+    private void showResult(String toolName, ShaftMcpToolResult result, Throwable error) {
         if (error instanceof CancellationException) {
             setRunning(false, "Cancelled");
-            outputArea.setText("Cancelled.");
-            copyOutputButton.setEnabled(true);
+            setOutput(toolName, "Cancelled.");
             return;
         }
         setRunning(false, error == null && result != null && result.success() ? "Finished" : "Failed");
@@ -362,23 +375,21 @@ final class ShaftFeaturePanel extends JPanel {
             if (category.recoveryAction() != null) {
                 sb.append("\n\nRecovery: ").append(category.recoveryAction());
             }
-            outputArea.setText(sb.toString());
+            setOutput(toolName, sb.toString());
         } else if (result == null) {
-            outputArea.setText("No result returned.");
+            setOutput(toolName, "No result returned.");
         } else if (result.success()) {
-            outputArea.setText(JsonText.prettyOrOriginal(result.output()));
+            setOutput(toolName, JsonText.prettyOrOriginal(result.output()));
         } else {
-            formatErrorOutput(result);
+            setOutput(toolName, formatErrorOutput(result));
         }
-        copyOutputButton.setEnabled(!outputArea.getText().isBlank());
     }
 
     private void showCatalogResult(ShaftMcpToolResult result, Throwable error) {
         refreshCatalogButton.setToolTipText(REFRESH_TOOLS_TOOLTIP);
         if (error instanceof CancellationException) {
             setRunning(false, "Cancelled");
-            outputArea.setText("Cancelled.");
-            copyOutputButton.setEnabled(true);
+            setOutput("", "Cancelled.");
             return;
         }
         boolean success = error == null && result != null && result.success();
@@ -390,7 +401,7 @@ final class ShaftFeaturePanel extends JPanel {
         if (success) {
             categories = ToolTemplates.categories(result.output());
             reloadCategories();
-            outputArea.setText(JsonText.prettyOrOriginal(result.output()));
+            setOutput("", JsonText.prettyOrOriginal(result.output()));
         } else if (error != null) {
             McpInvocationError category = McpInvocationError.categorize(error);
             StringBuilder sb = new StringBuilder();
@@ -398,16 +409,15 @@ final class ShaftFeaturePanel extends JPanel {
             if (category.recoveryAction() != null) {
                 sb.append("\n\nRecovery: ").append(category.recoveryAction());
             }
-            outputArea.setText(sb.toString());
+            setOutput("", sb.toString());
         } else if (result == null) {
-            outputArea.setText("No result returned.");
+            setOutput("", "No result returned.");
         } else {
-            formatErrorOutput(result);
+            setOutput("", formatErrorOutput(result));
         }
         status.setText(success
                 ? ShaftStatusPresentation.SUCCESS_ICON + " Tools refreshed"
                 : ShaftStatusPresentation.ERROR_ICON + " Failed");
-        copyOutputButton.setEnabled(!outputArea.getText().isBlank());
     }
 
     private void reloadCategories() {
@@ -544,14 +554,45 @@ final class ShaftFeaturePanel extends JPanel {
         return settings.mcpReady();
     }
 
-    private boolean projectAvailable(Project project) {
+    private boolean projectAvailable(Project project, String toolName) {
         if (project != null) {
             return true;
         }
         status.setText("Open project");
-        outputArea.setText("Open an IntelliJ project before running SHAFT MCP tools.");
-        copyOutputButton.setEnabled(true);
+        setOutput(toolName, "Open an IntelliJ project before running SHAFT MCP tools.");
         return false;
+    }
+
+    /**
+     * Renders a tool result as a humanized card (issue #3552), reusing the same
+     * {@link AssistantMarkdown} the Assistant chat renders with so a Tools-panel run and an
+     * Assistant-routed run of the same tool read identically. {@code outputArea} keeps holding the
+     * exact, untouched {@code rawText} so {@link #copyOutputButton} and the raw-JSON toggle always
+     * expose the real bytes, one click away from the card.
+     */
+    private void setOutput(String toolName, String rawText) {
+        outputArea.setText(rawText);
+        outputCard.setMarkdown(AssistantMarkdown.fromMcpOutput(toolName, rawText));
+        showRawOutput(false);
+        boolean hasOutput = !rawText.isBlank();
+        copyOutputButton.setEnabled(hasOutput);
+        toggleRawOutputButton.setEnabled(hasOutput);
+    }
+
+    private void clearOutput() {
+        setOutput("", "");
+    }
+
+    private void toggleRawOutput() {
+        showRawOutput(!showingRawOutput);
+    }
+
+    private void showRawOutput(boolean raw) {
+        showingRawOutput = raw;
+        ((java.awt.CardLayout) outputCards.getLayout()).show(outputCards, raw ? "raw" : "card");
+        // Icon-only button (issue #3538 icon-only-and-symmetric convention): the state flips in the
+        // tooltip, never in visible text.
+        toggleRawOutputButton.setToolTipText(raw ? "View summarized output" : "View raw JSON");
     }
 
     private static JPanel setupNotice(Project project, ShaftSettingsState.Settings settings) {
@@ -670,17 +711,16 @@ final class ShaftFeaturePanel extends JPanel {
         return template.description().isBlank() ? template.toolName() : template.description();
     }
 
-    private void formatErrorOutput(ShaftMcpToolResult result) {
+    private static String formatErrorOutput(ShaftMcpToolResult result) {
         if (result.errorCategory() != null) {
             StringBuilder sb = new StringBuilder();
             sb.append(result.output());
             if (result.recoveryAction() != null) {
                 sb.append("\n\nRecovery: ").append(result.recoveryAction());
             }
-            outputArea.setText(sb.toString());
-        } else {
-            outputArea.setText(result.output());
+            return sb.toString();
         }
+        return result.output();
     }
 
     private void selectJsonErrorLocation(JsonText.JsonErrorLocation location) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
@@ -313,6 +313,11 @@ public final class ShaftToolWindowPanel extends JPanel {
         return workflowSelector;
     }
 
+    /** Package-private test accessor: the retained Assistant panel, or {@code null} before setup. */
+    ShaftAssistantPanel assistantPanel() {
+        return assistantPanel;
+    }
+
     /**
      * Selects the workflow tab that owns the MCP tool template and pre-fills the request.
      *

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
@@ -40,6 +40,7 @@ public final class ShaftToolWindowPanel extends JPanel {
     private final ShaftMcpSetupPanel.AgentReadinessProbe readinessProbe;
     private final ShaftMcpSetupPanel.AgentReadinessProbe deepReadinessProbe;
     private ShaftFeaturePanel advancedTools;
+    private ShaftAssistantPanel assistantPanel;
     private List<ShaftFeaturePanel> featurePanels = List.of();
     private List<WorkflowView> workflowViews = List.of();
     private ApiRecordingSessionPanel apiRecordingPanel;
@@ -99,6 +100,7 @@ public final class ShaftToolWindowPanel extends JPanel {
         workflowCards = null;
         workflowLayout = null;
         advancedTools = null;
+        assistantPanel = null;
         featurePanels = List.of();
         workflowViews = List.of();
         add(setup, BorderLayout.CENTER);
@@ -117,6 +119,7 @@ public final class ShaftToolWindowPanel extends JPanel {
         removeAll();
         ShaftAssistantPanel assistant = new ShaftAssistantPanel(project, settings,
                 assistantChatState, this::showSetupView);
+        assistantPanel = assistant;
         preferredFocusComponent = assistant.preferredFocusComponent();
         workflowLayout = new CardLayout();
         workflowCards = new JPanel(workflowLayout);
@@ -342,6 +345,27 @@ public final class ShaftToolWindowPanel extends JPanel {
         }
         advancedTools.prefillTool(toolName, arguments);
         selectWorkflow(advancedTools);
+    }
+
+    /**
+     * Selects the Assistant tab and fills its composer with {@code text} for the user to review and
+     * send themselves (issue #3552). The Assistant is the product for regular users, so this is the
+     * "act" half of the advancedUiEnabled gate audit: entry points that used to silently no-op or
+     * dead-end in a warning while advanced workflows are off now route here instead, landing a
+     * ready-to-send plain-language request rather than leaving the user to retype it. A no-op here
+     * (main view not yet built, e.g. the setup view is showing) is not a silent dead end: the tool
+     * window itself already surfaces the setup panel explaining what to do next.
+     *
+     * @param text plain-language prompt to prefill
+     */
+    public void prefillAssistantPrompt(@NotNull String text) {
+        if (assistantPanel == null) {
+            return;
+        }
+        assistantPanel.prefillPrompt(text);
+        if (workflowSelector != null) {
+            selectWorkflow(assistantPanel);
+        }
     }
 
     /**

--- a/shaft-intellij/src/test/java/com/shaft/intellij/actions/RecordApiWebActionTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/actions/RecordApiWebActionTest.java
@@ -1,0 +1,18 @@
+package com.shaft.intellij.actions;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Covers the default-mode (advancedUiEnabled=false) Assistant prompt {@code RecordApiWebAction}
+ * builds instead of the old dead-end warning that discarded the typed URL (issue #3552).
+ */
+class RecordApiWebActionTest {
+    @Test
+    void recordApiPromptCarriesTheTypedUrl() {
+        String prompt = RecordApiWebAction.recordApiPrompt("https://example.com/checkout");
+
+        assertEquals("Record API traffic on https://example.com/checkout", prompt);
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/actions/RecordShaftFlowHereActionTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/actions/RecordShaftFlowHereActionTest.java
@@ -1,0 +1,23 @@
+package com.shaft.intellij.actions;
+
+import com.shaft.intellij.java.JavaTargetContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Covers the default-mode (advancedUiEnabled=false) Assistant prompt {@code
+ * RecordShaftFlowHereAction} builds instead of the old copy-to-clipboard-and-warn no-op
+ * (issue #3552).
+ */
+class RecordShaftFlowHereActionTest {
+    @Test
+    void recordFlowPromptNamesTheMethodAndClassInPlainLanguage() {
+        JavaTargetContext context = new JavaTargetContext(
+                "src/test/java/LoginTest.java", "tests", "LoginTest", "logsIn");
+
+        String prompt = RecordShaftFlowHereAction.recordFlowPrompt(context);
+
+        assertEquals("Record a SHAFT flow at logsIn in LoginTest", prompt);
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/notifications/ShaftToolWorkflowLauncherTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/notifications/ShaftToolWorkflowLauncherTest.java
@@ -1,0 +1,27 @@
+package com.shaft.intellij.notifications;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Covers the plain-language Assistant prompt {@code ShaftToolWorkflowLauncher} routes to in
+ * default mode (advancedUiEnabled=false) instead of the old dead-end warning that told the user
+ * to retype the request themselves (issue #3552). The rest of {@link ShaftToolWorkflowLauncher}
+ * drives {@code ToolWindowManager}/{@code Content}, which need a live IntelliJ platform and are
+ * not exercised by this lightweight Gradle unit test JVM (same gap {@code
+ * FailedRunDoctorNotifierTest} documents for the sibling notifier).
+ */
+class ShaftToolWorkflowLauncherTest {
+    @Test
+    void doctorToolNameMapsToADiagnoseRequest() {
+        assertEquals("Diagnose my last failed test run",
+                ShaftToolWorkflowLauncher.assistantPromptFor("doctor_analyze_failed_allure"));
+    }
+
+    @Test
+    void healerToolNameMapsToAHealRequest() {
+        assertEquals("Heal my last failed test run",
+                ShaftToolWorkflowLauncher.assistantPromptFor("healer_run_failed_test"));
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantMarkdownTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantMarkdownTest.java
@@ -556,6 +556,86 @@ class AssistantMarkdownTest {
     }
 
     @Test
+    void formatsHealerRunResultAsACardDelegatingItsNestedAnalysisToTheDoctorRenderer() {
+        // Issue #3552: a healer run must read as a readable card (status, delegated Doctor
+        // diagnosis, attempts, review actions), not raw JSON -- the whole point of the shared
+        // renderer this ticket adds so a healer's embedded diagnosis reads like a manual Doctor run.
+        String markdown = AssistantMarkdown.fromMcpOutput("healer_run_failed_test", mcpText("""
+                {
+                  "schemaVersion": "1.0",
+                  "status": "FAILED_WITH_SUGGESTIONS",
+                  "attempts": [
+                    {"attemptNumber": 1, "exitCode": 1, "timedOut": false, "passed": false,
+                     "allureResultCount": 1, "failedAllureResultCount": 1,
+                     "diagnostics": "Locator not found: login_button"}
+                  ],
+                  "analysis": {
+                    "schemaVersion": "1.0",
+                    "status": "DETERMINISTIC",
+                    "bundleId": "bundle-456",
+                    "primaryCause": "LOCATOR",
+                    "confidence": "HIGH",
+                    "summary": "Button locator no longer matches the page.",
+                    "actions": [],
+                    "codeBlocks": [],
+                    "bundlePath": "target/shaft-healer/evidence-bundle.json",
+                    "jsonReportPath": "target/shaft-healer/doctor-report.json",
+                    "markdownReportPath": "target/shaft-healer/doctor-report.md",
+                    "warnings": []
+                  },
+                  "actions": [
+                    {"title":"Replay flow","action":"Use the agent to replay the failing flow.",
+                     "status":"PROVIDER_ADVISORY"}
+                  ],
+                  "codeBlocks": [
+                    {"title":"Agent handoff","language":"text","code":"Replay recording X and inspect the DOM."}
+                  ],
+                  "warnings": []
+                }
+                """));
+
+        assertAll(
+                () -> assertTrue(markdown.contains("Healer:"), markdown),
+                () -> assertTrue(markdown.contains("FAILED_WITH_SUGGESTIONS"), markdown),
+                () -> assertTrue(markdown.contains("Attempt 1"), markdown),
+                () -> assertTrue(markdown.contains("Locator not found: login_button"), markdown),
+                () -> assertTrue(markdown.contains("**Primary cause:** LOCATOR"), markdown),
+                () -> assertTrue(markdown.contains("Button locator no longer matches the page."), markdown),
+                () -> assertTrue(markdown.contains("target/shaft-healer/doctor-report.json"), markdown),
+                () -> assertTrue(markdown.contains("Healer actions"), markdown),
+                () -> assertTrue(markdown.contains("Use the agent to replay the failing flow."), markdown),
+                () -> assertTrue(markdown.contains("Handoff snippets"), markdown),
+                () -> assertTrue(markdown.contains("Replay recording X and inspect the DOM."), markdown),
+                () -> assertFalse(markdown.contains("\"schemaVersion\"")));
+    }
+
+    @Test
+    void healerMarkdownAlsoDispatchesForThePlaywrightHealerToolName() {
+        String markdown = AssistantMarkdown.fromMcpOutput("playwright_healer_run_failed_test", mcpText("""
+                {
+                  "schemaVersion": "1.0",
+                  "status": "PASSED",
+                  "attempts": [
+                    {"attemptNumber": 1, "exitCode": 0, "timedOut": false, "passed": true,
+                     "allureResultCount": 1, "failedAllureResultCount": 0, "diagnostics": ""}
+                  ],
+                  "analysis": {
+                    "schemaVersion": "1.0", "status": "DETERMINISTIC", "bundleId": "",
+                    "primaryCause": "UNKNOWN", "confidence": "UNKNOWN", "summary": "",
+                    "actions": [], "codeBlocks": [], "bundlePath": "", "jsonReportPath": "",
+                    "markdownReportPath": "", "warnings": []
+                  },
+                  "actions": [], "codeBlocks": [], "warnings": []
+                }
+                """));
+
+        assertAll(
+                () -> assertTrue(markdown.contains("Healer:"), markdown),
+                () -> assertTrue(markdown.contains("PASSED"), markdown),
+                () -> assertTrue(markdown.contains("Attempt 1"), markdown));
+    }
+
+    @Test
     void rejectsNativeSeleniumGeneratedJavaSnippetsWithRegenerationTools() {
         String markdown = AssistantMarkdown.fromMcpOutput("capture_code_blocks", mcpText("""
                 {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPromptRoutingTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPromptRoutingTest.java
@@ -1,0 +1,121 @@
+package com.shaft.intellij.ui;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.components.JBTextArea;
+import com.shaft.intellij.settings.ShaftSettingsState;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the "act, don't silently no-op" half of issue #3552: in default mode
+ * (advancedUiEnabled=false) the SHAFT tool window still has exactly one workflow view
+ * (Assistant), and {@link ShaftToolWindowPanel#prefillAssistantPrompt(String)} must fill its
+ * composer and select that tab -- never auto-send, mirroring the existing empty-state chip norm
+ * ({@code ShaftAssistantPanel#emptyStateChip}).
+ */
+class ShaftAssistantPromptRoutingTest {
+    @Test
+    void prefillPromptFillsTheComposerAndFocusesItWithoutSending() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
+
+        panel.prefillPrompt("Diagnose my last failed test run");
+
+        JBTextArea prompt = (JBTextArea) getField(panel, "prompt");
+        assertEquals("Diagnose my last failed test run", prompt.getText());
+        AssistantTranscriptView transcript = (AssistantTranscriptView) getField(panel, "transcript");
+        assertTrue(transcript.markdown().isBlank(),
+                "prefillPrompt must never auto-send: the transcript stays empty until the user "
+                        + "reviews and sends it themselves.");
+    }
+
+    @Test
+    void prefillPromptOnBlankTextIsANoOp() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
+        JBTextArea prompt = (JBTextArea) getField(panel, "prompt");
+        prompt.setText("existing draft");
+
+        panel.prefillPrompt("");
+        panel.prefillPrompt(null);
+
+        assertEquals("existing draft", prompt.getText());
+    }
+
+    @Test
+    void toolWindowPrefillAssistantPromptRoutesThroughTheAssistantPanelInDefaultMode() throws Exception {
+        // connectedMcpSettings() leaves advancedUiEnabled at its default (false), matching the
+        // majority of users this gate-audit targets.
+        ShaftToolWindowPanel toolWindow = new ShaftToolWindowPanel(fakeProject(), connectedMcpSettings());
+
+        toolWindow.prefillAssistantPrompt("Heal my last failed test run");
+
+        ShaftAssistantPanel assistantPanel = (ShaftAssistantPanel) getField(toolWindow, "assistantPanel");
+        assertNotNull(assistantPanel, "showMainView() must always build and retain the Assistant panel");
+        JBTextArea prompt = (JBTextArea) getField(assistantPanel, "prompt");
+        assertEquals("Heal my last failed test run", prompt.getText());
+        assertEquals("Assistant", selectedWorkflowLabel(toolWindow));
+    }
+
+    @Test
+    void toolWindowPrefillAssistantPromptIsANoOpBeforeMcpIsConfigured() throws Exception {
+        // Before setup completes, showSetupView() is active and no ShaftAssistantPanel exists yet;
+        // this must not throw -- the setup panel itself already explains what to do next.
+        ShaftSettingsState.Settings unconfigured = new ShaftSettingsState.Settings();
+        unconfigured.mcpCommand = "";
+        ShaftToolWindowPanel toolWindow = new ShaftToolWindowPanel(fakeProject(), unconfigured);
+
+        toolWindow.prefillAssistantPrompt("Diagnose my last failed test run");
+
+        assertEquals(null, getField(toolWindow, "assistantPanel"));
+    }
+
+    private static String selectedWorkflowLabel(ShaftToolWindowPanel toolWindow) {
+        Object selected = toolWindow.workflowSelector().getSelectedItem();
+        return selected instanceof ShaftToolWindowPanel.WorkflowView view ? view.label() : "";
+    }
+
+    private static ShaftSettingsState.Settings connectedMcpSettings() {
+        ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
+        settings.mcpCommand = "\"java\" \"@target/shaft-mcp.args\"";
+        settings.mcpSetupComplete = true;
+        return settings;
+    }
+
+    private static Project fakeProject() {
+        return (Project) Proxy.newProxyInstance(Project.class.getClassLoader(), new Class<?>[]{Project.class},
+                (proxy, method, arguments) -> {
+                    switch (method.getName()) {
+                        case "equals":
+                            return proxy == (arguments == null || arguments.length == 0 ? null : arguments[0]);
+                        case "hashCode":
+                            return System.identityHashCode(proxy);
+                        case "getBasePath":
+                            return "";
+                        case "getName":
+                            return "shaft-assistant-prompt-routing-test-project";
+                        case "getService":
+                            return null;
+                        default:
+                            return defaultValue(method.getReturnType());
+                    }
+                });
+    }
+
+    private static Object defaultValue(Class<?> returnType) {
+        if (!returnType.isPrimitive()) {
+            return null;
+        }
+        return returnType == boolean.class ? false : 0;
+    }
+
+    private static Object getField(Object target, String name) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPromptRoutingTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPromptRoutingTest.java
@@ -1,15 +1,14 @@
 package com.shaft.intellij.ui;
 
 import com.intellij.openapi.project.Project;
-import com.intellij.ui.components.JBTextArea;
 import com.shaft.intellij.settings.ShaftSettingsState;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.Proxy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -21,48 +20,44 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class ShaftAssistantPromptRoutingTest {
     @Test
-    void prefillPromptFillsTheComposerAndFocusesItWithoutSending() throws Exception {
+    void prefillPromptFillsTheComposerAndFocusesItWithoutSending() {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
 
         panel.prefillPrompt("Diagnose my last failed test run");
 
-        JBTextArea prompt = (JBTextArea) getField(panel, "prompt");
-        assertEquals("Diagnose my last failed test run", prompt.getText());
-        AssistantTranscriptView transcript = (AssistantTranscriptView) getField(panel, "transcript");
-        assertTrue(transcript.markdown().isBlank(),
+        assertEquals("Diagnose my last failed test run", panel.promptText());
+        assertTrue(panel.transcriptMarkdown().isBlank(),
                 "prefillPrompt must never auto-send: the transcript stays empty until the user "
                         + "reviews and sends it themselves.");
     }
 
     @Test
-    void prefillPromptOnBlankTextIsANoOp() throws Exception {
+    void prefillPromptOnBlankTextIsANoOp() {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
-        JBTextArea prompt = (JBTextArea) getField(panel, "prompt");
-        prompt.setText("existing draft");
+        panel.prefillPrompt("existing draft");
 
         panel.prefillPrompt("");
         panel.prefillPrompt(null);
 
-        assertEquals("existing draft", prompt.getText());
+        assertEquals("existing draft", panel.promptText());
     }
 
     @Test
-    void toolWindowPrefillAssistantPromptRoutesThroughTheAssistantPanelInDefaultMode() throws Exception {
+    void toolWindowPrefillAssistantPromptRoutesThroughTheAssistantPanelInDefaultMode() {
         // connectedMcpSettings() leaves advancedUiEnabled at its default (false), matching the
         // majority of users this gate-audit targets.
         ShaftToolWindowPanel toolWindow = new ShaftToolWindowPanel(fakeProject(), connectedMcpSettings());
 
         toolWindow.prefillAssistantPrompt("Heal my last failed test run");
 
-        ShaftAssistantPanel assistantPanel = (ShaftAssistantPanel) getField(toolWindow, "assistantPanel");
+        ShaftAssistantPanel assistantPanel = toolWindow.assistantPanel();
         assertNotNull(assistantPanel, "showMainView() must always build and retain the Assistant panel");
-        JBTextArea prompt = (JBTextArea) getField(assistantPanel, "prompt");
-        assertEquals("Heal my last failed test run", prompt.getText());
+        assertEquals("Heal my last failed test run", assistantPanel.promptText());
         assertEquals("Assistant", selectedWorkflowLabel(toolWindow));
     }
 
     @Test
-    void toolWindowPrefillAssistantPromptIsANoOpBeforeMcpIsConfigured() throws Exception {
+    void toolWindowPrefillAssistantPromptIsANoOpBeforeMcpIsConfigured() {
         // Before setup completes, showSetupView() is active and no ShaftAssistantPanel exists yet;
         // this must not throw -- the setup panel itself already explains what to do next.
         ShaftSettingsState.Settings unconfigured = new ShaftSettingsState.Settings();
@@ -71,7 +66,7 @@ class ShaftAssistantPromptRoutingTest {
 
         toolWindow.prefillAssistantPrompt("Diagnose my last failed test run");
 
-        assertEquals(null, getField(toolWindow, "assistantPanel"));
+        assertNull(toolWindow.assistantPanel());
     }
 
     private static String selectedWorkflowLabel(ShaftToolWindowPanel toolWindow) {
@@ -111,11 +106,5 @@ class ShaftAssistantPromptRoutingTest {
             return null;
         }
         return returnType == boolean.class ? false : 0;
-    }
-
-    private static Object getField(Object target, String name) throws Exception {
-        Field field = target.getClass().getDeclaredField(name);
-        field.setAccessible(true);
-        return field.get(target);
     }
 }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -4355,9 +4355,9 @@ class ShaftPanelSetupTest {
 
     private static void showToolResult(ShaftFeaturePanel panel, ShaftMcpToolResult result) throws Exception {
         Method showResult = ShaftFeaturePanel.class.getDeclaredMethod(
-                "showResult", ShaftMcpToolResult.class, Throwable.class);
+                "showResult", String.class, ShaftMcpToolResult.class, Throwable.class);
         showResult.setAccessible(true);
-        showResult.invoke(panel, result, null);
+        showResult.invoke(panel, "", result, null);
     }
 
     private static void showCatalogResult(ShaftFeaturePanel panel, ShaftMcpToolResult result) throws Exception {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
@@ -124,6 +124,8 @@ class ShaftPluginScreenshotRendererTest {
         Path assistantLiveDarkScreenshot = outputPath.resolve("intellij-plugin-assistant-live-output-dark.png");
         Path assistantProgressMilestonesScreenshot = outputPath.resolve("intellij-plugin-assistant-progress-milestones.png");
         Path assistantApprovalPromptScreenshot = outputPath.resolve("intellij-plugin-assistant-approval-prompt.png");
+        Path toolsHumanizedDoctorCardScreenshot = outputPath.resolve("intellij-plugin-tools-humanized-doctor-card.png");
+        Path assistantDefaultModePrefillScreenshot = outputPath.resolve("intellij-plugin-assistant-default-mode-prefill.png");
         Path mcpSetupPostSetupScreenshot = outputPath.resolve("intellij-plugin-mcp-setup-post-setup.png");
         Path guidedScreenshot = outputPath.resolve("intellij-plugin-guided.png");
         Path recorderScreenshot = outputPath.resolve("intellij-plugin-recorder.png");
@@ -155,6 +157,8 @@ class ShaftPluginScreenshotRendererTest {
         write(assistantLiveDarkScreenshot, renderAssistantLiveOutput(DARK_THEME, true));
         write(assistantProgressMilestonesScreenshot, renderAssistantProgressMilestones(LIGHT_THEME, false));
         write(assistantApprovalPromptScreenshot, renderApprovalPrompt(LIGHT_THEME, false));
+        write(toolsHumanizedDoctorCardScreenshot, renderToolsHumanizedDoctorCard(LIGHT_THEME, false));
+        write(assistantDefaultModePrefillScreenshot, renderAssistantDefaultModePrefill(LIGHT_THEME, false));
         write(mcpSetupPostSetupScreenshot, renderPostSetupSettings(LIGHT_THEME, false));
         write(guidedScreenshot, renderToolWindow(1, "", LIGHT_THEME, false));
         write(recorderScreenshot, renderToolWindow(2, "", LIGHT_THEME, false));
@@ -187,6 +191,8 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertTrue(Files.size(assistantProgressMilestonesScreenshot) > 0,
                         assistantProgressMilestonesScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantApprovalPromptScreenshot) > 0, assistantApprovalPromptScreenshot + " should be non-empty"),
+                () -> assertTrue(Files.size(toolsHumanizedDoctorCardScreenshot) > 0, toolsHumanizedDoctorCardScreenshot + " should be non-empty"),
+                () -> assertTrue(Files.size(assistantDefaultModePrefillScreenshot) > 0, assistantDefaultModePrefillScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(mcpSetupPostSetupScreenshot) > 0, mcpSetupPostSetupScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(guidedScreenshot) > 0, guidedScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(recorderScreenshot) > 0, recorderScreenshot + " should be non-empty"),
@@ -217,6 +223,8 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertDimensions(assistantLiveDarkScreenshot),
                 () -> assertDimensions(assistantProgressMilestonesScreenshot),
                 () -> assertDimensions(assistantApprovalPromptScreenshot),
+                () -> assertDimensions(toolsHumanizedDoctorCardScreenshot),
+                () -> assertDimensions(assistantDefaultModePrefillScreenshot),
                 () -> assertDimensions(mcpSetupPostSetupScreenshot),
                 () -> assertDimensions(guidedScreenshot),
                 () -> assertDimensions(recorderScreenshot),
@@ -507,6 +515,89 @@ class ShaftPluginScreenshotRendererTest {
             selectButton(component, "Allow source edits");
             invokeStartMcpInvocation(component, AssistantCommand.Invocation.tool(
                     "capture_start", captureStartArguments()));
+            component.setSize(new Dimension(WIDTH, HEIGHT));
+            component.setPreferredSize(new Dimension(WIDTH, HEIGHT));
+            SwingUtilities.updateComponentTreeUI(component);
+            component.doLayout();
+            layout(component, !dark);
+            image.set(render(component, WIDTH, HEIGHT));
+        });
+        return image.get();
+    }
+
+    /**
+     * Renders the Tools panel's humanized doctor card (issue #3552): a {@code
+     * doctor_analyze_failed_allour} result routed through {@link AssistantMarkdown} instead of raw
+     * pretty-printed JSON, with the "View raw JSON" toggle button visible (still one click away).
+     */
+    private static BufferedImage renderToolsHumanizedDoctorCard(String lookAndFeelClassName, boolean dark)
+            throws InterruptedException, InvocationTargetException {
+        AtomicReference<BufferedImage> image = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            configureLookAndFeel(lookAndFeelClassName, dark);
+            ShaftFeaturePanel component = new ShaftFeaturePanel(screenshotProject(), defaultSettings());
+            invokeShowResult(component, "doctor_analyze_failed_allure", ShaftMcpToolResult.success("""
+                    {
+                      "schemaVersion": "1.0",
+                      "status": "DETERMINISTIC",
+                      "bundleId": "bundle-123",
+                      "primaryCause": "LOCATOR",
+                      "confidence": "HIGH",
+                      "summary": "The sign-in button locator no longer matches the page after a redesign.",
+                      "actions": [
+                        {"title":"Update locator","action":"Replace the stale CSS selector with the new data-testid.",
+                         "status":"SUGGESTED"}
+                      ],
+                      "codeBlocks": [
+                        {"title":"Locator fix","language":"java",
+                         "code":"driver.element().click(SHAFT.GUI.Locator.hasTestId(\\"sign-in-button\\"));",
+                         "copyPasteReady":true}
+                      ],
+                      "providerFallback": {"used":false,"reason":"AI advisory disabled by default."},
+                      "bundlePath": "target/shaft-doctor/evidence-bundle.json",
+                      "jsonReportPath": "target/shaft-doctor/doctor-report.json",
+                      "markdownReportPath": "target/shaft-doctor/doctor-report.md",
+                      "warnings": []
+                    }
+                    """), null);
+            component.setSize(new Dimension(WIDTH, HEIGHT));
+            component.setPreferredSize(new Dimension(WIDTH, HEIGHT));
+            SwingUtilities.updateComponentTreeUI(component);
+            component.doLayout();
+            layout(component, !dark);
+            image.set(render(component, WIDTH, HEIGHT));
+        });
+        return image.get();
+    }
+
+    private static void invokeShowResult(
+            ShaftFeaturePanel component, String toolName, ShaftMcpToolResult result, Throwable error) {
+        try {
+            Method method = ShaftFeaturePanel.class.getDeclaredMethod(
+                    "showResult", String.class, ShaftMcpToolResult.class, Throwable.class);
+            method.setAccessible(true);
+            method.invoke(component, toolName, result, error);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Unable to render the Tools panel result", exception);
+        }
+    }
+
+    /**
+     * Renders the SHAFT tool window in DEFAULT mode (advancedUiEnabled=false -- how most users run
+     * it) right after a gate-audited entry point (issue #3552, e.g. {@code
+     * ShaftToolWorkflowLauncher}, {@code RecordShaftFlowHereAction}, {@code RecordApiWebAction})
+     * routed a plain-language request into the Assistant composer instead of silently no-opping or
+     * dead-ending in a warning. The composer is filled but nothing has been sent -- the transcript
+     * stays on the first-run welcome, proving this is a prefill, not an auto-send.
+     */
+    private static BufferedImage renderAssistantDefaultModePrefill(String lookAndFeelClassName, boolean dark)
+            throws InterruptedException, InvocationTargetException {
+        AtomicReference<BufferedImage> image = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            configureLookAndFeel(lookAndFeelClassName, dark);
+            ShaftSettingsState.Settings settings = defaultSettings();
+            ShaftToolWindowPanel component = new ShaftToolWindowPanel(screenshotProject(), settings);
+            component.prefillAssistantPrompt("Diagnose my last failed test run");
             component.setSize(new Dimension(WIDTH, HEIGHT));
             component.setPreferredSize(new Dimension(WIDTH, HEIGHT));
             SwingUtilities.updateComponentTreeUI(component);


### PR DESCRIPTION
Closes #3552. Child of the IntelliJ UX program #3553. shaft-intellij only.

## Item 1 — Humanize tool output
The plugin already had a mature JSON→Markdown humanizer (`AssistantMarkdown`) wired into the Assistant, but the Tools/Evidence panel dumped raw JSON. This reuses that humanizer everywhere and fills the gaps:
- **`healerMarkdown`** (new): renders `healer_run_failed_test` (+ playwright variant) as a card — status + guarded-rerun attempts, delegating the nested Doctor `analysis` to the existing `doctorMarkdown` so a manual doctor run and a healer's embedded diagnosis read identically. The superset top-level actions/snippets are labelled "Healer actions"/"Handoff snippets" to avoid reading as literal duplicates of the analysis card.
- **Tools panel** (`ShaftFeaturePanel`): `showResult`/`showCatalogResult` now render `AssistantMarkdown.fromMcpOutput(toolName, raw)` as a card (CardLayout) instead of raw JSON, with a **"View raw JSON" toggle**; `copyOutputButton` still copies the exact raw bytes. No second markdown engine — reuses the Assistant's view.

## Item 2 — advancedUiEnabled gate audit
Three entry points silently no-op'd in default mode (the majority who never enable advanced UI). Each now **acts** by routing to the Assistant (prefill, never auto-send — following the established `emptyStateChip` norm):
- New `ShaftAssistantPanel.prefillPrompt(String)` + `ShaftToolWindowPanel.prefillAssistantPrompt(...)` (assistant panel now held as a field).
- `ShaftToolWorkflowLauncher` → opens the window and prefills "Diagnose/Heal my last failed test run" (was a dead-end warn); `RecordShaftFlowHereAction` → "Record a SHAFT flow at `<method>` in `<class>`" (was clipboard+warn); `RecordApiWebAction` → "Record API traffic on `<url>`" carrying the URL the user typed (was warn+discard).
- Legitimate progressive-disclosure `advancedUiEnabled` reads (default-view choice, guided panel, settings checkbox, control visibility) left unchanged.

**Product decision:** default-mode actions **prefill and focus** the composer for the user to review and send — not auto-send — matching the existing "plain-language prefills, review and send it yourself" norm. Called out explicitly rather than guessed.

## Why it matters for the program
The shared humanization renderer (esp. `healerMarkdown`/`doctorMarkdown` reading identically) is the prerequisite the #3547 failure-recovery ticket's auto-doctor summary builds on.

## Verification
- Full shaft-intellij module: **573/573**, 0 failures.
- `AssistantMarkdownTest` 33/33 (+2 healer: card delegates to doctor renderer; playwright name dispatches), `ShaftAssistantPromptRoutingTest` 4/4 (prefill fills+focuses without sending; blank no-op; routes to Assistant tab; no-op before MCP setup), `ShaftToolWorkflowLauncherTest` 2/2, `Record*ActionTest` 2/2. `FailedRunDoctorNotifierTest` 6/6 unaffected — all independently re-run (JDK21).
- Screenshots (rendered + visually confirmed): humanized Doctor card in the Tools panel with the raw-JSON toggle, and a default-mode action prefilling the Assistant composer with nothing auto-sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)