### PR TITLE
feat: IntelliJ failure recovery — browser-close + auto-doctor + real test target (#3547)

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/GeneratedTestValidator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/GeneratedTestValidator.java
@@ -18,6 +18,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -28,6 +29,7 @@ import java.util.stream.Stream;
  */
 public class GeneratedTestValidator {
     private static final ObjectMapper JSON = new ObjectMapper();
+    private static final Duration PROCESS_TREE_KILL_GRACE = Duration.ofSeconds(5);
 
     /**
      * Compiles one generated test class against the current SHAFT runtime.
@@ -92,6 +94,7 @@ public class GeneratedTestValidator {
         Path testngOutput = replayDirectory.resolve("testng-output");
         Path outputLog = replayDirectory.resolve("replay.log");
         Path chromeDriverLog = replayDirectory.resolve("chromedriver.log");
+        Process process = null;
         try {
             Files.createDirectories(allureResults);
             Files.createDirectories(testngOutput);
@@ -128,14 +131,16 @@ public class GeneratedTestValidator {
             command.add(testngOutput.toAbsolutePath().normalize().toString());
             command.add("-testclass");
             command.add(fullyQualifiedClassName);
-            Process process = new ProcessBuilder(command)
+            process = new ProcessBuilder(command)
                     .directory(workDirectory.toAbsolutePath().normalize().toFile())
                     .redirectErrorStream(true)
                     .redirectOutput(outputLog.toFile())
                     .start();
             boolean finished = process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
             if (!finished) {
-                process.destroyForcibly();
+                // destroyForcibly() only kills the forked TestNG JVM itself -- it leaves
+                // ChromeDriver/Chrome (its descendants) running as orphans, especially on Windows.
+                destroyProcessTree(process);
                 return failed("Generated test replay timed out.");
             }
             AllureSummary allure = allure(allureResults);
@@ -158,10 +163,53 @@ public class GeneratedTestValidator {
                     List.copyOf(diagnostics),
                     allure.count());
         } catch (IOException exception) {
+            if (process != null) {
+                destroyProcessTree(process);
+            }
             return failed("Generated test replay could not be launched: " + exception.getMessage());
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
+            if (process != null) {
+                destroyProcessTree(process);
+            }
             return failed("Generated test replay was interrupted.");
+        }
+    }
+
+    /**
+     * Forcibly kills a process and every descendant it spawned (e.g. ChromeDriver and the Chrome
+     * it launches beneath the forked TestNG JVM). {@link Process#destroyForcibly()} alone only
+     * terminates the top-level process -- descendants are reparented and survive as orphans,
+     * which on Windows leaves a visible browser window behind after a failed/timed-out replay.
+     *
+     * <p>Descendants must be snapshotted before the process is destroyed: {@link
+     * Process#descendants()} reports nothing once the parent has already exited.
+     *
+     * @param process the process (and its process tree) to terminate
+     */
+    static void destroyProcessTree(Process process) {
+        List<ProcessHandle> descendants = process.descendants().toList();
+        process.destroyForcibly();
+        descendants.forEach(ProcessHandle::destroyForcibly);
+        // The top-level process already has a live OS handle from ProcessBuilder#start(), so
+        // Process#waitFor() is the authoritative wait for it. Descendants are only known as
+        // ProcessHandle snapshots (there is no Process object for them), so ProcessHandle#onExit()
+        // is the only option there -- re-deriving a ProcessHandle for the top-level process via
+        // Process#toHandle() after it has already been destroyed is avoided on purpose, since a
+        // freshly looked-up handle can race a reused PID immediately after exit.
+        try {
+            process.waitFor(PROCESS_TREE_KILL_GRACE.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+        }
+        List<CompletableFuture<ProcessHandle>> descendantExits =
+                descendants.stream().map(ProcessHandle::onExit).toList();
+        try {
+            CompletableFuture.allOf(descendantExits.toArray(new CompletableFuture[0]))
+                    .get(PROCESS_TREE_KILL_GRACE.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (Exception exception) {
+            // Best-effort grace period; destroyForcibly() was already issued to every handle above,
+            // so a slow or already-gone process here does not change the outcome.
         }
     }
 

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/GeneratedTestValidatorProcessTreeTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/GeneratedTestValidatorProcessTreeTest.java
@@ -1,0 +1,116 @@
+package com.shaft.capture.generate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression coverage for the orphaned-browser defect: a timed-out replay used to call only
+ * {@code Process.destroyForcibly()} on the forked TestNG JVM, which does not kill descendants
+ * (ChromeDriver/Chrome). {@code Process.destroyForcibly()} makes no cross-platform promise about
+ * descendants -- on POSIX it never touches them, and even where the OS incidentally cleans up
+ * simple child chains, real-world browser processes are documented to escape that cleanup. The
+ * only portable fix is to enumerate and kill the process tree explicitly, which is what
+ * {@link GeneratedTestValidator#destroyProcessTree(Process)} does.
+ */
+class GeneratedTestValidatorProcessTreeTest {
+
+    @TempDir
+    Path temp;
+
+    @Test
+    void destroyProcessTreeTerminatesEveryDescendantAcrossMultipleGenerations() throws Exception {
+        Path classesDir = temp.resolve("classes");
+        Files.createDirectories(classesDir);
+        compile(classesDir, "Grandchild", GRANDCHILD_SOURCE);
+        compile(classesDir, "Child", CHILD_SOURCE);
+        compile(classesDir, "Top", TOP_SOURCE);
+        String javaExe = ProcessHandle.current().info().command().orElse("java");
+
+        Process top = new ProcessBuilder(javaExe, "-cp", classesDir.toString(), "Top", classesDir.toString())
+                .redirectErrorStream(true)
+                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                .start();
+        List<ProcessHandle> descendants = awaitDescendants(top, 2);
+        assertTrue(top.isAlive(), "the top-level process should still be alive before teardown");
+        assertTrue(descendants.stream().allMatch(ProcessHandle::isAlive),
+                "both spawned descendants should be alive before teardown");
+
+        GeneratedTestValidator.destroyProcessTree(top);
+
+        assertFalse(top.isAlive(), "destroyProcessTree() must kill the top-level process");
+        assertFalse(descendants.stream().anyMatch(ProcessHandle::isAlive),
+                "destroyProcessTree() must kill every descendant, not just the top-level process");
+    }
+
+    /**
+     * Waits until the process reports at least {@code minimumCount} descendants (a child and its
+     * own child both register once spawned), which can take a moment on a loaded machine.
+     */
+    private static List<ProcessHandle> awaitDescendants(Process process, int minimumCount) throws InterruptedException {
+        for (int attempt = 0; attempt < 100; attempt++) {
+            List<ProcessHandle> descendants = process.descendants().toList();
+            if (descendants.size() >= minimumCount) {
+                return descendants;
+            }
+            Thread.sleep(100);
+        }
+        throw new IllegalStateException("The process tree never grew to " + minimumCount + " descendants.");
+    }
+
+    private static void compile(Path classesDir, String className, String source) throws Exception {
+        Path sourceFile = classesDir.resolve(className + ".java");
+        Files.writeString(sourceFile, source, StandardCharsets.UTF_8);
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        int result = compiler.run(null, null, null,
+                "-d", classesDir.toString(), sourceFile.toString());
+        if (result != 0) {
+            throw new IllegalStateException("Failed to compile " + className + " for the process-tree test.");
+        }
+    }
+
+    private static final String GRANDCHILD_SOURCE = """
+            public class Grandchild {
+                public static void main(String[] args) throws Exception {
+                    Thread.sleep(60_000);
+                }
+            }
+            """;
+
+    // Child spawns Grandchild, so the top-level process has two generations of descendants beneath
+    // it -- mirroring the forked TestNG JVM -> ChromeDriver -> Chrome shape in production.
+    private static final String CHILD_SOURCE = """
+            public class Child {
+                public static void main(String[] args) throws Exception {
+                    String javaHome = System.getProperty("java.home");
+                    String javaExe = javaHome + java.io.File.separator + "bin" + java.io.File.separator + "java";
+                    ProcessBuilder builder = new ProcessBuilder(javaExe, "-cp", args[0], "Grandchild");
+                    builder.inheritIO();
+                    builder.start();
+                    Thread.sleep(60_000);
+                }
+            }
+            """;
+
+    private static final String TOP_SOURCE = """
+            public class Top {
+                public static void main(String[] args) throws Exception {
+                    String javaHome = System.getProperty("java.home");
+                    String javaExe = javaHome + java.io.File.separator + "bin" + java.io.File.separator + "java";
+                    ProcessBuilder builder = new ProcessBuilder(javaExe, "-cp", args[0], "Child", args[0]);
+                    builder.inheritIO();
+                    builder.start();
+                    Thread.sleep(60_000);
+                }
+            }
+            """;
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/notifications/FailedRunDoctorNotifier.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/notifications/FailedRunDoctorNotifier.java
@@ -12,21 +12,25 @@ import com.intellij.notification.NotificationType;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
 /**
- * Offers one-click SHAFT Doctor triage when a test run fails and Allure evidence exists.
+ * Offers automatic and one-click SHAFT Doctor triage when a test run fails and evidence exists.
  *
- * <p>The deterministic Doctor analysis turns failed Allure results into a root-cause report in
- * seconds, but it used to hide behind a workflow template the user had to know about. This
- * listener raises a notification right at the failed run, one click away from the prefilled
- * {@code doctor_analyze_failed_allure} request.</p>
+ * <p>On a failed run with Allure (or, failing that, SHAFT trace) evidence, this listener both
+ * (a) automatically runs the read-only {@code doctor_analyze_failed_allure}/{@code
+ * doctor_analyze_trace} diagnosis and renders a human-readable root-cause card into the Assistant
+ * transcript within one round trip, and (b) raises a notification offering to re-run Doctor or run
+ * Healer, so the user has a persistent way back to the same diagnosis even if they were not
+ * watching the Assistant tab when it appeared (issue #3547).</p>
  */
 public final class FailedRunDoctorNotifier implements ExecutionListener {
     private static final String GROUP_ID = "SHAFT Notifications";
@@ -46,13 +50,24 @@ public final class FailedRunDoctorNotifier implements ExecutionListener {
             return;
         }
         String basePath = project.getBasePath();
-        if (basePath == null || !hasAllureResults(Path.of(basePath))) {
+        if (basePath == null) {
+            return;
+        }
+        Path projectRoot = Path.of(basePath);
+        String allureResultsPath = resolveAllureResultsPath(projectRoot);
+        String tracePath = allureResultsPath == null ? resolveNewestTraceDirectory(projectRoot) : null;
+        if (allureResultsPath == null && tracePath == null) {
+            // No evidence at all yet (for example a timeout-killed replay that never flushed
+            // Allure results): nothing to diagnose, and a notification with a Diagnose button that
+            // would immediately fail is worse than no notification.
             return;
         }
         if (throttled(basePath)) {
             return;
         }
-        notifyDoctorAvailable(project);
+        String testIdentity = environment.getRunProfile().getName();
+        notifyDoctorAvailable(project, testIdentity, allureResultsPath, tracePath);
+        openDoctorWorkflow(project, allureResultsPath, tracePath);
     }
 
     private static boolean looksLikeTestRun(ExecutionEnvironment environment) {
@@ -62,20 +77,77 @@ public final class FailedRunDoctorNotifier implements ExecutionListener {
         return profileClass.contains("test") || name.contains("test") || name.contains("suite");
     }
 
-    private static boolean hasAllureResults(Path projectRoot) {
-        Path allureResults = projectRoot.resolve("allure-results");
-        if (!Files.isDirectory(allureResults)) {
-            allureResults = projectRoot.resolve("target").resolve("allure-results");
+    /**
+     * Resolves the Allure results directory actually present on disk, relative to the project root
+     * ({@code allure-results} or the more common Maven default {@code target/allure-results}), or
+     * {@code null} when neither has any result files yet. Threading the real resolved path into
+     * {@link #doctorArguments(String)} (rather than always hardcoding {@code allure-results}) fixes
+     * a real bug: the previous hardcoded value silently failed on any project using the Maven
+     * default layout, because the MCP workspace policy rejects a path that does not exist on disk
+     * rather than falling through to auto-discovery.
+     *
+     * @param projectRoot project base directory
+     * @return project-relative path to the Allure results directory, or {@code null}
+     */
+    @Nullable
+    static String resolveAllureResultsPath(Path projectRoot) {
+        Path candidate = projectRoot.resolve("allure-results");
+        if (!hasResultFiles(candidate)) {
+            candidate = projectRoot.resolve("target").resolve("allure-results");
         }
+        return hasResultFiles(candidate) ? relative(projectRoot, candidate) : null;
+    }
+
+    private static boolean hasResultFiles(Path allureResults) {
         if (!Files.isDirectory(allureResults)) {
             return false;
         }
         try (Stream<Path> entries = Files.list(allureResults)) {
-            return entries.anyMatch(entry -> entry.getFileName().toString().endsWith("-result.json")
-                    || entry.getFileName().toString().endsWith("result.json"));
+            return entries.anyMatch(entry -> entry.getFileName().toString().endsWith("result.json"));
         } catch (IOException unreadable) {
             return false;
         }
+    }
+
+    /**
+     * Resolves the most recently generated SHAFT trace directory under {@code
+     * target/shaft-traces} (an {@code index.json} up to two levels deep), used as the
+     * {@code doctor_analyze_trace} fallback when no Allure evidence exists at all -- for example a
+     * replay killed by timeout before Allure results were flushed, which may still have left a
+     * trace. Best-effort: any unreadable entry is skipped rather than failing the whole scan.
+     *
+     * @param projectRoot project base directory
+     * @return project-relative path to the newest trace directory, or {@code null} when none exists
+     */
+    @Nullable
+    static String resolveNewestTraceDirectory(Path projectRoot) {
+        Path traceRoot = projectRoot.resolve("target").resolve("shaft-traces");
+        if (!Files.isDirectory(traceRoot)) {
+            return null;
+        }
+        Path newestDirectory = null;
+        Instant newestModified = null;
+        try (Stream<Path> entries = Files.walk(traceRoot, 2)) {
+            for (Path indexPath : entries.filter(path -> "index.json".equals(path.getFileName().toString())).toList()) {
+                Instant modified;
+                try {
+                    modified = Files.getLastModifiedTime(indexPath).toInstant();
+                } catch (IOException unreadable) {
+                    continue;
+                }
+                if (newestModified == null || modified.isAfter(newestModified)) {
+                    newestModified = modified;
+                    newestDirectory = indexPath.getParent();
+                }
+            }
+        } catch (IOException unreadable) {
+            return null;
+        }
+        return newestDirectory == null ? null : relative(projectRoot, newestDirectory);
+    }
+
+    private static String relative(Path projectRoot, Path candidate) {
+        return projectRoot.relativize(candidate).toString().replace('\\', '/');
     }
 
     private static boolean throttled(String basePath) {
@@ -84,49 +156,73 @@ public final class FailedRunDoctorNotifier implements ExecutionListener {
         return previous != null && now - previous < THROTTLE_MILLIS;
     }
 
-    private static void notifyDoctorAvailable(Project project) {
+    private static void notifyDoctorAvailable(
+            Project project, String testIdentity, @Nullable String allureResultsPath, @Nullable String tracePath) {
         Notification notification = NotificationGroupManager.getInstance()
                 .getNotificationGroup(GROUP_ID)
                 .createNotification(
                         "Test run failed",
-                        "Allure evidence found. SHAFT Doctor can triage the failure deterministically.",
+                        "SHAFT Doctor is diagnosing the failure now -- open the SHAFT Assistant tab for the "
+                                + "root cause, or re-run it below.",
                         NotificationType.WARNING);
         notification.addAction(new NotificationAction("Diagnose with SHAFT Doctor") {
             @Override
             public void actionPerformed(@NotNull AnActionEvent event, @NotNull Notification current) {
                 current.expire();
-                openDoctorWorkflow(project);
+                openDoctorWorkflow(project, allureResultsPath, tracePath);
             }
         });
         notification.addAction(new NotificationAction("Heal failed test") {
             @Override
             public void actionPerformed(@NotNull AnActionEvent event, @NotNull Notification current) {
                 current.expire();
-                openHealerWorkflow(project);
+                openHealerWorkflow(project, testIdentity);
             }
         });
         notification.notify(project);
     }
 
-    private static void openDoctorWorkflow(Project project) {
-        ShaftToolWorkflowLauncher.open(project, "doctor_analyze_failed_allure", doctorArguments());
-    }
-
-    private static void openHealerWorkflow(Project project) {
-        ShaftToolWorkflowLauncher.open(project, "healer_run_failed_test", healerArguments());
+    /**
+     * Runs the Doctor analysis (Allure evidence when available, otherwise the newest trace) and
+     * renders it into the Assistant transcript -- used both automatically on failure and by the
+     * notification's "Diagnose" button, so both paths always produce an actual diagnosis in default
+     * mode rather than only prefilling the composer (issue #3547).
+     */
+    private static void openDoctorWorkflow(
+            Project project, @Nullable String allureResultsPath, @Nullable String tracePath) {
+        if (allureResultsPath != null) {
+            ShaftToolWorkflowLauncher.runAndRender(
+                    project, "doctor_analyze_failed_allure", doctorArguments(allureResultsPath));
+        } else if (tracePath != null) {
+            ShaftToolWorkflowLauncher.runAndRender(project, "doctor_analyze_trace", traceArguments(tracePath));
+        }
     }
 
     /**
-     * Builds the {@code doctor_analyze_failed_allure} MCP arguments for the last failed run. Public
-     * so {@code ShaftTestsPanel} (issue #3467 "SHAFT Tests" tab) can reuse the same one-click
-     * Doctor prefill this notifier offers.
+     * Runs the Healer analysis for {@code testIdentity} and renders it into the Assistant transcript
+     * -- used by the notification's "Heal" button, which must actually run in default mode rather
+     * than only prefilling the composer (issue #3547).
+     */
+    private static void openHealerWorkflow(Project project, String testIdentity) {
+        ShaftToolWorkflowLauncher.runAndRender(project, "healer_run_failed_test", healerArguments(testIdentity));
+    }
+
+    /**
+     * Builds the {@code doctor_analyze_failed_allure} MCP arguments. Public so {@code
+     * ShaftTestsPanel} (issue #3467 "SHAFT Tests" tab) can reuse the same one-click Doctor prefill
+     * this notifier offers.
      *
+     * @param allureResultsPath project-relative Allure results directory to analyze, or
+     *                          {@code null}/blank to let the server auto-discover the newest
+     *                          evidence in the workspace
      * @return MCP tool arguments
      */
-    public static JsonObject doctorArguments() {
+    public static JsonObject doctorArguments(@Nullable String allureResultsPath) {
         JsonObject arguments = new JsonObject();
         JsonArray allurePaths = new JsonArray();
-        allurePaths.add("allure-results");
+        if (allureResultsPath != null && !allureResultsPath.isBlank()) {
+            allurePaths.add(allureResultsPath);
+        }
         arguments.add("allureResultPaths", allurePaths);
         arguments.add("historicalBundlePaths", new JsonArray());
         arguments.addProperty("outputDirectory", "target/shaft-doctor");
@@ -143,17 +239,36 @@ public final class FailedRunDoctorNotifier implements ExecutionListener {
     }
 
     /**
-     * Builds the {@code healer_run_failed_test} MCP arguments for the last failed run. Public for
-     * the same reason as {@link #doctorArguments()}.
+     * Builds the {@code doctor_analyze_trace} MCP arguments for the trace-only fallback (no Allure
+     * evidence found).
      *
+     * @param tracePath project-relative SHAFT trace directory
      * @return MCP tool arguments
      */
-    public static JsonObject healerArguments() {
+    private static JsonObject traceArguments(String tracePath) {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("tracePath", tracePath);
+        arguments.addProperty("backend", "webdriver");
+        return arguments;
+    }
+
+    /**
+     * Builds the {@code healer_run_failed_test} MCP arguments for {@code testIdentity} (the real
+     * failing run-configuration name -- see {@link #resolveTestSelector}), replacing the previous
+     * hardcoded {@code -Dtest=ExampleTest} placeholder (issue #3547). Public for the same reason as
+     * {@link #doctorArguments(String)}.
+     *
+     * @param testIdentity the failing run's identity, typically {@code
+     *                     ExecutionEnvironment.getRunProfile().getName()} or a {@code
+     *                     ShaftTestIndex} row's {@code testId}
+     * @return MCP tool arguments
+     */
+    public static JsonObject healerArguments(@Nullable String testIdentity) {
         JsonObject arguments = new JsonObject();
         JsonArray testCommand = new JsonArray();
         testCommand.add("mvn");
         testCommand.add("-q");
-        testCommand.add("-Dtest=ExampleTest");
+        testCommand.add("-Dtest=" + resolveTestSelector(testIdentity));
         testCommand.add("test");
         arguments.add("testCommand", testCommand);
         arguments.addProperty("repositoryRoot", ".");
@@ -168,5 +283,62 @@ public final class FailedRunDoctorNotifier implements ExecutionListener {
         arguments.addProperty("allowRemoteAi", false);
         arguments.addProperty("driverVariableName", "driver");
         return arguments;
+    }
+
+    /**
+     * Best-effort Maven {@code -Dtest} selector for {@code runConfigurationName}. Falls back to a
+     * generic {@code *Test} wildcard only when the identity is entirely blank/unknown -- never
+     * crashes, and never silently reintroduces a nonexistent hardcoded class name.
+     *
+     * @param runConfigurationName the run profile display name, or {@code null}
+     * @return a Maven {@code -Dtest} selector value (without the {@code -Dtest=} prefix)
+     */
+    static String resolveTestSelector(@Nullable String runConfigurationName) {
+        String normalized = normalizeTestIdentity(runConfigurationName);
+        return normalized.isBlank() ? "*Test" : normalized;
+    }
+
+    /**
+     * Best-effort normalization from an IntelliJ run-configuration display name to a Maven Surefire
+     * test selector. Handles the common IDE shapes:
+     * <ul>
+     *     <li>{@code "CheckoutTest"} -&gt; {@code "CheckoutTest"} (unchanged)</li>
+     *     <li>{@code "CheckoutTest.testLogin"} -&gt; {@code "CheckoutTest#testLogin"} (Maven's
+     *     class-and-method syntax)</li>
+     *     <li>{@code "CheckoutTest (1)"} -&gt; {@code "CheckoutTest"} (IDE run-counter suffix
+     *     stripped)</li>
+     * </ul>
+     * Anything that does not match a known shape (a fully custom run-configuration name, a suite
+     * name with spaces, etc.) is returned unchanged as the best available identity -- the profile
+     * display name may not equal the Maven class name, and this is a best effort, not a guarantee.
+     *
+     * @param runConfigurationName the run profile display name, or {@code null}
+     * @return normalized selector, or {@code ""} when {@code runConfigurationName} is blank
+     */
+    static String normalizeTestIdentity(@Nullable String runConfigurationName) {
+        if (runConfigurationName == null) {
+            return "";
+        }
+        String trimmed = runConfigurationName.trim();
+        if (trimmed.isEmpty()) {
+            return "";
+        }
+        String withoutRunCounter = trimmed.replaceAll("\\s*\\([^()]*\\)\\s*$", "").trim();
+        String candidate = withoutRunCounter.isEmpty() ? trimmed : withoutRunCounter;
+        int dot = candidate.indexOf('.');
+        if (dot > 0 && dot == candidate.lastIndexOf('.') && dot + 1 < candidate.length()) {
+            String classPart = candidate.substring(0, dot);
+            String methodPart = candidate.substring(dot + 1);
+            if (isJavaIdentifier(classPart) && isJavaIdentifier(methodPart)) {
+                return classPart + "#" + methodPart;
+            }
+        }
+        return candidate;
+    }
+
+    private static boolean isJavaIdentifier(String value) {
+        return !value.isBlank()
+                && Character.isJavaIdentifierStart(value.charAt(0))
+                && value.chars().allMatch(Character::isJavaIdentifierPart);
     }
 }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/notifications/ShaftToolWorkflowLauncher.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/notifications/ShaftToolWorkflowLauncher.java
@@ -32,6 +32,33 @@ public final class ShaftToolWorkflowLauncher {
      */
     public static void open(Project project, String toolName, JsonObject arguments) {
         boolean advancedUiEnabled = ShaftSettingsState.getInstance().getState().advancedUiEnabled;
+        withToolWindowPanel(project, panel -> {
+            if (advancedUiEnabled) {
+                panel.prefillTool(toolName, arguments);
+            } else {
+                panel.prefillAssistantPrompt(assistantPromptFor(toolName));
+            }
+        });
+    }
+
+    /**
+     * Opens the SHAFT tool window, runs {@code toolName} against the live MCP connection, and
+     * renders its result into the Assistant transcript as a read-only diagnosis card -- regardless
+     * of the {@code advancedUiEnabled} setting (issue #3547). Unlike {@link #open}, this always
+     * executes the call: a Doctor/Healer analysis is read-only-or-guarded and the caller (an
+     * automatic failure-recovery trigger, or a user who explicitly clicked "Diagnose"/"Heal") has
+     * already decided it should run, so a prefill-only no-op in default mode would silently fail to
+     * deliver what the action promised.
+     *
+     * @param project current project
+     * @param toolName MCP tool name to run
+     * @param arguments MCP tool arguments
+     */
+    public static void runAndRender(Project project, String toolName, JsonObject arguments) {
+        withToolWindowPanel(project, panel -> panel.runAssistantTool(toolName, arguments));
+    }
+
+    private static void withToolWindowPanel(Project project, java.util.function.Consumer<ShaftToolWindowPanel> action) {
         ToolWindowManager.getInstance(project).invokeLater(() -> {
             ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("SHAFT");
             if (toolWindow == null) {
@@ -39,13 +66,8 @@ public final class ShaftToolWorkflowLauncher {
             }
             toolWindow.show(() -> {
                 Content content = toolWindow.getContentManager().getContent(0);
-                if (!(content != null && content.getComponent() instanceof ShaftToolWindowPanel panel)) {
-                    return;
-                }
-                if (advancedUiEnabled) {
-                    panel.prefillTool(toolName, arguments);
-                } else {
-                    panel.prefillAssistantPrompt(assistantPromptFor(toolName));
+                if (content != null && content.getComponent() instanceof ShaftToolWindowPanel panel) {
+                    action.accept(panel);
                 }
             });
         });

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -611,6 +611,50 @@ final class ShaftAssistantPanel extends JPanel {
         setStatus("Review the prefilled request, then send it");
     }
 
+    /**
+     * Runs {@code toolName} against the live MCP connection and renders its result into the
+     * transcript as an assistant message, without touching the composer, run/timeline, or capture-
+     * review state -- unlike {@link #dispatchApprovedTool}, this is not a user "send": it backs
+     * failure-recovery entry points (issue #3547) that trigger a read-only Doctor/Healer diagnosis
+     * from outside the composer, either automatically on a failed test run or from a notification's
+     * "Diagnose"/"Heal" action. The MCP callback runs on a background thread, so rendering is
+     * marshaled onto the EDT.
+     *
+     * @param toolName MCP tool name to run
+     * @param arguments MCP tool arguments
+     */
+    void runToolAndRenderCard(String toolName, JsonObject arguments) {
+        ShaftMcpInvocationService.getInstance(project).startTool(toolName, arguments).future()
+                .whenComplete((result, error) -> ApplicationManager.getApplication().invokeLater(
+                        () -> append("assistant", toolCardMarkdown(toolName, result, error),
+                                result == null ? "" : result.output())));
+    }
+
+    /**
+     * Pure formatting for {@link #runToolAndRenderCard}: renders a tool result (or failure) as
+     * plain-language Markdown, reusing {@link AssistantMarkdown#fromMcpOutput} for the known Doctor
+     * card shape so a manual doctor run and an auto-triggered one read identically. Never returns
+     * raw JSON or an exception's fully-qualified class name -- a thrown error (for example
+     * {@code doctor_analyze_failed_allure} finding no Allure evidence at all) degrades to a plain
+     * "couldn't finish" card instead. Package-private and static so it is directly unit-testable
+     * without the EDT or a live MCP connection.
+     *
+     * @param toolName MCP tool name that was run
+     * @param result the tool result, or {@code null} if none was returned
+     * @param error the failure, or {@code null} on success
+     * @return transcript-ready Markdown
+     */
+    static String toolCardMarkdown(String toolName, ShaftMcpToolResult result, Throwable error) {
+        if (error != null) {
+            return AssistantMarkdown.toolFailureMarkdown(toolName, AssistantMarkdown.humanizeError(error));
+        }
+        if (result == null) {
+            return AssistantMarkdown.toolFailureMarkdown(toolName, "No result returned.");
+        }
+        String markdown = AssistantMarkdown.fromMcpOutput(toolName, result.output());
+        return result.success() ? markdown : AssistantMarkdown.toolFailureMarkdown(toolName, markdown);
+    }
+
     /** Package-private test accessor: current composer text. */
     String promptText() {
         return prompt.getText();

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftTestsPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftTestsPanel.java
@@ -130,19 +130,24 @@ final class ShaftTestsPanel extends JPanel {
     }
 
     private void diagnoseSelected() {
-        if (!isFailRow(rowList.getSelectedValue())) {
+        ShaftTestIndex.TestRowState selected = rowList.getSelectedValue();
+        if (!isFailRow(selected)) {
             return;
         }
+        // No resolved Allure directory is known from this tab's row-level data (unlike
+        // FailedRunDoctorNotifier, which resolves it from the just-failed run's project root): pass
+        // null so the server auto-discovers the newest evidence instead of guessing a path.
         ShaftToolWorkflowLauncher.open(project, "doctor_analyze_failed_allure",
-                FailedRunDoctorNotifier.doctorArguments());
+                FailedRunDoctorNotifier.doctorArguments(null));
     }
 
     private void healSelected() {
-        if (!isFailRow(rowList.getSelectedValue())) {
+        ShaftTestIndex.TestRowState selected = rowList.getSelectedValue();
+        if (!isFailRow(selected)) {
             return;
         }
         ShaftToolWorkflowLauncher.open(project, "healer_run_failed_test",
-                FailedRunDoctorNotifier.healerArguments());
+                FailedRunDoctorNotifier.healerArguments(selected.testId()));
     }
 
     // ------------------------------------------------------------------

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
@@ -374,6 +374,28 @@ public final class ShaftToolWindowPanel extends JPanel {
     }
 
     /**
+     * Selects the Assistant tab, runs {@code toolName} against the live MCP connection, and renders
+     * the result into the transcript as a read-only diagnosis card -- unlike {@link
+     * #prefillAssistantPrompt}, this always executes rather than waiting for the user to review and
+     * send (issue #3547 failure-recovery: an automatic post-failure diagnosis, or an explicit
+     * "Diagnose"/"Heal" click, must actually produce a diagnosis in default mode, not a prefilled
+     * request). A no-op when the main view has not been built yet (setup view still showing), same
+     * rationale as {@link #prefillAssistantPrompt}.
+     *
+     * @param toolName MCP tool name to run
+     * @param arguments MCP tool arguments
+     */
+    public void runAssistantTool(@NotNull String toolName, @NotNull JsonObject arguments) {
+        if (assistantPanel == null) {
+            return;
+        }
+        assistantPanel.runToolAndRenderCard(toolName, arguments);
+        if (workflowSelector != null) {
+            selectWorkflow(assistantPanel);
+        }
+    }
+
+    /**
      * Opens (or reuses) the API Recording tab for the given target URL and MCP
      * {@code capture_api_start} arguments, starting a new polling session.
      *

--- a/shaft-intellij/src/test/java/com/shaft/intellij/notifications/FailedRunDoctorNotifierTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/notifications/FailedRunDoctorNotifierTest.java
@@ -3,14 +3,26 @@ package com.shaft.intellij.notifications;
 import com.google.gson.JsonObject;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * {@code processTerminated} itself drives {@code ExecutionEnvironment}/{@code ToolWindowManager},
+ * which need a live IntelliJ platform and are not exercised by this lightweight Gradle unit test
+ * JVM (same documented gap as {@link ShaftToolWorkflowLauncherTest}). This class instead covers
+ * every pure piece {@code processTerminated} delegates to: argument building, evidence-path
+ * resolution, and real-test-identity normalization (issue #3547).
+ */
 class FailedRunDoctorNotifierTest {
     @Test
     void doctorArgumentsBuildsCorrectJsonStructure() {
-        JsonObject arguments = FailedRunDoctorNotifier.doctorArguments();
+        JsonObject arguments = FailedRunDoctorNotifier.doctorArguments("allure-results");
 
         assertEquals(".", arguments.get("repositoryRoot").getAsString());
         assertEquals("target/shaft-doctor", arguments.get("outputDirectory").getAsString());
@@ -24,18 +36,30 @@ class FailedRunDoctorNotifierTest {
     }
 
     @Test
-    void doctorArgumentsIncludesAllureResultPaths() {
-        JsonObject arguments = FailedRunDoctorNotifier.doctorArguments();
+    void doctorArgumentsIncludesTheResolvedAllureResultsPath() {
+        JsonObject arguments = FailedRunDoctorNotifier.doctorArguments("target/allure-results");
 
         assertTrue(arguments.has("allureResultPaths"));
         assertTrue(arguments.get("allureResultPaths").isJsonArray());
         assertEquals(1, arguments.getAsJsonArray("allureResultPaths").size());
-        assertEquals("allure-results", arguments.getAsJsonArray("allureResultPaths").get(0).getAsString());
+        assertEquals("target/allure-results", arguments.getAsJsonArray("allureResultPaths").get(0).getAsString());
+    }
+
+    @Test
+    void doctorArgumentsLeavesAllureResultPathsEmptyWhenPathIsUnknown() {
+        // A null/blank path must produce an empty array, not a guessed literal: DoctorService
+        // treats an empty allureResultPaths as "auto-discover the newest evidence in the
+        // workspace," which is the whole point of not hardcoding a directory that might not exist
+        // (the bug this replaces -- see resolveAllureResultsPath's javadoc).
+        assertTrue(FailedRunDoctorNotifier.doctorArguments(null)
+                .getAsJsonArray("allureResultPaths").isEmpty());
+        assertTrue(FailedRunDoctorNotifier.doctorArguments("  ")
+                .getAsJsonArray("allureResultPaths").isEmpty());
     }
 
     @Test
     void doctorArgumentsIncludesEmptyHistoricalBundlesAndSourcePaths() {
-        JsonObject arguments = FailedRunDoctorNotifier.doctorArguments();
+        JsonObject arguments = FailedRunDoctorNotifier.doctorArguments("allure-results");
 
         assertTrue(arguments.has("historicalBundlePaths"));
         assertTrue(arguments.get("historicalBundlePaths").isJsonArray());
@@ -48,7 +72,7 @@ class FailedRunDoctorNotifierTest {
 
     @Test
     void healerArgumentsBuildsCorrectJsonStructure() {
-        JsonObject arguments = FailedRunDoctorNotifier.healerArguments();
+        JsonObject arguments = FailedRunDoctorNotifier.healerArguments("CheckoutTest");
 
         assertEquals(".", arguments.get("repositoryRoot").getAsString());
         assertEquals("target/shaft-healer", arguments.get("outputDirectory").getAsString());
@@ -63,24 +87,152 @@ class FailedRunDoctorNotifierTest {
     }
 
     @Test
-    void healerArgumentsIncludesTestCommand() {
-        JsonObject arguments = FailedRunDoctorNotifier.healerArguments();
+    void healerArgumentsThreadsTheRealFailingTestIntoTheCommand() {
+        JsonObject arguments = FailedRunDoctorNotifier.healerArguments("CheckoutTest");
 
         assertTrue(arguments.has("testCommand"));
         assertTrue(arguments.get("testCommand").isJsonArray());
         assertEquals(4, arguments.getAsJsonArray("testCommand").size());
         assertEquals("mvn", arguments.getAsJsonArray("testCommand").get(0).getAsString());
         assertEquals("-q", arguments.getAsJsonArray("testCommand").get(1).getAsString());
-        assertEquals("-Dtest=ExampleTest", arguments.getAsJsonArray("testCommand").get(2).getAsString());
+        assertEquals("-Dtest=CheckoutTest", arguments.getAsJsonArray("testCommand").get(2).getAsString());
         assertEquals("test", arguments.getAsJsonArray("testCommand").get(3).getAsString());
     }
 
     @Test
+    void healerArgumentsNeverReintroducesTheHardcodedExampleTestPlaceholder() {
+        JsonObject arguments = FailedRunDoctorNotifier.healerArguments("LoginFlowTest");
+
+        String testCommandEntry = arguments.getAsJsonArray("testCommand").get(2).getAsString();
+        assertFalse(testCommandEntry.contains("ExampleTest"));
+        assertEquals("-Dtest=LoginFlowTest", testCommandEntry);
+    }
+
+    @Test
+    void healerArgumentsFallsBackToAWildcardWhenIdentityIsUnknown() {
+        JsonObject arguments = FailedRunDoctorNotifier.healerArguments(null);
+
+        // Never crashes and never fabricates a specific nonexistent class name; the wildcard at
+        // least matches the common *Test naming convention instead of a class that does not exist.
+        assertEquals("-Dtest=*Test", arguments.getAsJsonArray("testCommand").get(2).getAsString());
+    }
+
+    @Test
     void healerArgumentsIncludesEmptyAllowedSourcePaths() {
-        JsonObject arguments = FailedRunDoctorNotifier.healerArguments();
+        JsonObject arguments = FailedRunDoctorNotifier.healerArguments("CheckoutTest");
 
         assertTrue(arguments.has("allowedSourcePaths"));
         assertTrue(arguments.get("allowedSourcePaths").isJsonArray());
         assertEquals(0, arguments.getAsJsonArray("allowedSourcePaths").size());
+    }
+
+    @Test
+    void normalizeTestIdentityLeavesASimpleClassNameUnchanged() {
+        assertEquals("CheckoutTest", FailedRunDoctorNotifier.normalizeTestIdentity("CheckoutTest"));
+    }
+
+    @Test
+    void normalizeTestIdentityConvertsClassDotMethodToMavenSyntax() {
+        assertEquals("CheckoutTest#testLogin",
+                FailedRunDoctorNotifier.normalizeTestIdentity("CheckoutTest.testLogin"));
+    }
+
+    @Test
+    void normalizeTestIdentityStripsAnIdeRunCounterSuffix() {
+        assertEquals("CheckoutTest", FailedRunDoctorNotifier.normalizeTestIdentity("CheckoutTest (1)"));
+    }
+
+    @Test
+    void normalizeTestIdentityFallsBackToTheRawProfileNameWhenUnresolvable() {
+        // Not a recognizable class/method shape (a custom suite name with spaces): the profile
+        // name itself is still the best available identity, per the issue's "fall back to the
+        // profile name (don't crash)" instruction.
+        assertEquals("All Smoke Tests", FailedRunDoctorNotifier.normalizeTestIdentity("All Smoke Tests"));
+    }
+
+    @Test
+    void normalizeTestIdentityHandlesNullAndBlank() {
+        assertEquals("", FailedRunDoctorNotifier.normalizeTestIdentity(null));
+        assertEquals("", FailedRunDoctorNotifier.normalizeTestIdentity("   "));
+    }
+
+    @Test
+    void resolveAllureResultsPathPrefersTheProjectRootDirectoryWhenPresent() throws IOException {
+        Path projectRoot = Files.createTempDirectory("shaft-doctor-notifier-test");
+        try {
+            Path allureResults = projectRoot.resolve("allure-results");
+            Files.createDirectories(allureResults);
+            Files.writeString(allureResults.resolve("abc-result.json"), "{}");
+
+            assertEquals("allure-results", FailedRunDoctorNotifier.resolveAllureResultsPath(projectRoot));
+        } finally {
+            deleteRecursively(projectRoot);
+        }
+    }
+
+    @Test
+    void resolveAllureResultsPathFallsBackToTheMavenDefaultLayout() throws IOException {
+        Path projectRoot = Files.createTempDirectory("shaft-doctor-notifier-test");
+        try {
+            Path allureResults = projectRoot.resolve("target").resolve("allure-results");
+            Files.createDirectories(allureResults);
+            Files.writeString(allureResults.resolve("abc-result.json"), "{}");
+
+            assertEquals("target/allure-results",
+                    FailedRunDoctorNotifier.resolveAllureResultsPath(projectRoot).replace('\\', '/'));
+        } finally {
+            deleteRecursively(projectRoot);
+        }
+    }
+
+    @Test
+    void resolveAllureResultsPathReturnsNullWhenNoEvidenceExists() throws IOException {
+        Path projectRoot = Files.createTempDirectory("shaft-doctor-notifier-test");
+        try {
+            assertNull(FailedRunDoctorNotifier.resolveAllureResultsPath(projectRoot));
+        } finally {
+            deleteRecursively(projectRoot);
+        }
+    }
+
+    @Test
+    void resolveNewestTraceDirectoryReturnsNullWhenNoTraceExists() throws IOException {
+        Path projectRoot = Files.createTempDirectory("shaft-doctor-notifier-test");
+        try {
+            assertNull(FailedRunDoctorNotifier.resolveNewestTraceDirectory(projectRoot));
+        } finally {
+            deleteRecursively(projectRoot);
+        }
+    }
+
+    @Test
+    void resolveNewestTraceDirectoryFindsATraceUnderTargetShaftTraces() throws IOException {
+        Path projectRoot = Files.createTempDirectory("shaft-doctor-notifier-test");
+        try {
+            Path traceDirectory = projectRoot.resolve("target").resolve("shaft-traces").resolve("run-1");
+            Files.createDirectories(traceDirectory);
+            Files.writeString(traceDirectory.resolve("index.json"), "{}");
+
+            String resolved = FailedRunDoctorNotifier.resolveNewestTraceDirectory(projectRoot);
+
+            assertEquals("target/shaft-traces/run-1", resolved.replace('\\', '/'));
+        } finally {
+            deleteRecursively(projectRoot);
+        }
+    }
+
+    private static void deleteRecursively(Path root) throws IOException {
+        if (!Files.exists(root)) {
+            return;
+        }
+        try (var paths = Files.walk(root)) {
+            paths.sorted(java.util.Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException ignored) {
+                    // Best-effort cleanup; the OS temp folder is the backstop.
+                }
+            });
+        }
     }
 }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPanelToolCardTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPanelToolCardTest.java
@@ -1,0 +1,85 @@
+package com.shaft.intellij.ui;
+
+import com.shaft.intellij.mcp.ShaftMcpToolResult;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers {@link ShaftAssistantPanel#toolCardMarkdown}, the pure rendering step behind {@link
+ * ShaftAssistantPanel#runToolAndRenderCard} -- the auto-doctor-on-failure and "Diagnose"/"Heal"
+ * button entry points added for issue #3547. The EDT-marshaling wrapper around it needs a live MCP
+ * connection and {@code ApplicationManager}, neither available in this lightweight Gradle unit
+ * test JVM, so this class exercises the actual card-formatting logic directly instead.
+ */
+class ShaftAssistantPanelToolCardTest {
+    @Test
+    void rendersARepresentativeDoctorAnalysisReportAsAHumanReadableCard() {
+        String output = """
+                {
+                  "schemaVersion": "1.0",
+                  "status": "DETERMINISTIC",
+                  "bundleId": "bundle-123",
+                  "primaryCause": "LOCATOR",
+                  "confidence": "HIGH",
+                  "summary": "Button locator no longer matches the page.",
+                  "actions": [
+                    {"title":"Update locator","action":"Replace the stale CSS selector.","status":"SUGGESTED"}
+                  ],
+                  "codeBlocks": [
+                    {"title":"Locator fix","language":"java","code":"driver.element().click(SHAFT.GUI.Locator.id(\\"login\\"));","copyPasteReady":true}
+                  ],
+                  "bundlePath": "target/shaft-doctor/evidence-bundle.json",
+                  "jsonReportPath": "target/shaft-doctor/doctor-report.json",
+                  "markdownReportPath": "target/shaft-doctor/doctor-report.md",
+                  "warnings": []
+                }
+                """;
+
+        String markdown = ShaftAssistantPanel.toolCardMarkdown(
+                "doctor_analyze_failed_allure", ShaftMcpToolResult.success(output), null);
+
+        assertAll(
+                () -> assertTrue(markdown.contains("**Primary cause:** LOCATOR"), markdown),
+                () -> assertTrue(markdown.contains("Button locator no longer matches the page."), markdown),
+                () -> assertTrue(markdown.contains("Replace the stale CSS selector."), markdown),
+                () -> assertFalse(markdown.contains("\"schemaVersion\""), markdown));
+    }
+
+    @Test
+    void degradesGracefullyWhenTheMcpCallThrowsInsteadOfLeakingTheRawException() {
+        Throwable thrown = new IllegalArgumentException(
+                "No Allure results were found in this workspace (/repo). Run the failing test with "
+                        + "SHAFT reporting enabled first, or pass allureResultPaths explicitly.");
+
+        String markdown = ShaftAssistantPanel.toolCardMarkdown("doctor_analyze_failed_allure", null, thrown);
+
+        assertAll(
+                () -> assertTrue(markdown.contains("couldn't finish"), markdown),
+                () -> assertTrue(markdown.contains("No Allure results were found"), markdown),
+                () -> assertFalse(markdown.contains("IllegalArgumentException"), markdown),
+                () -> assertFalse(markdown.contains("java.lang."), markdown),
+                () -> assertFalse(markdown.contains("{"), markdown));
+    }
+
+    @Test
+    void degradesGracefullyWhenNoResultAndNoErrorAreAvailable() {
+        String markdown = ShaftAssistantPanel.toolCardMarkdown("doctor_analyze_failed_allure", null, null);
+
+        assertAll(
+                () -> assertTrue(markdown.contains("couldn't finish"), markdown),
+                () -> assertTrue(markdown.contains("No result returned."), markdown));
+    }
+
+    @Test
+    void degradesGracefullyOnAToolLevelFailureResultWithoutAThrownException() {
+        String markdown = ShaftAssistantPanel.toolCardMarkdown(
+                "doctor_analyze_failed_allure", ShaftMcpToolResult.failure("Trace path could not be read."), null);
+
+        assertAll(
+                () -> assertTrue(markdown.contains("couldn't finish"), markdown),
+                () -> assertTrue(markdown.contains("Trace path could not be read."), markdown));
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
@@ -123,6 +123,7 @@ class ShaftPluginScreenshotRendererTest {
         Path assistantNarrowDarkScreenshot = outputPath.resolve("intellij-plugin-assistant-narrow-dark.png");
         Path assistantLiveDarkScreenshot = outputPath.resolve("intellij-plugin-assistant-live-output-dark.png");
         Path assistantProgressMilestonesScreenshot = outputPath.resolve("intellij-plugin-assistant-progress-milestones.png");
+        Path assistantFailureRecoveryCardScreenshot = outputPath.resolve("intellij-plugin-assistant-failure-recovery-card.png");
         Path assistantApprovalPromptScreenshot = outputPath.resolve("intellij-plugin-assistant-approval-prompt.png");
         Path toolsHumanizedDoctorCardScreenshot = outputPath.resolve("intellij-plugin-tools-humanized-doctor-card.png");
         Path assistantDefaultModePrefillScreenshot = outputPath.resolve("intellij-plugin-assistant-default-mode-prefill.png");
@@ -156,6 +157,7 @@ class ShaftPluginScreenshotRendererTest {
         write(assistantNarrowDarkScreenshot, renderToolWindow(0, "", DARK_THEME, true, NARROW_WIDTH, HEIGHT));
         write(assistantLiveDarkScreenshot, renderAssistantLiveOutput(DARK_THEME, true));
         write(assistantProgressMilestonesScreenshot, renderAssistantProgressMilestones(LIGHT_THEME, false));
+        write(assistantFailureRecoveryCardScreenshot, renderAssistantFailureRecoveryCard(LIGHT_THEME, false));
         write(assistantApprovalPromptScreenshot, renderApprovalPrompt(LIGHT_THEME, false));
         write(toolsHumanizedDoctorCardScreenshot, renderToolsHumanizedDoctorCard(LIGHT_THEME, false));
         write(assistantDefaultModePrefillScreenshot, renderAssistantDefaultModePrefill(LIGHT_THEME, false));
@@ -190,6 +192,8 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertTrue(Files.size(assistantLiveDarkScreenshot) > 0, assistantLiveDarkScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantProgressMilestonesScreenshot) > 0,
                         assistantProgressMilestonesScreenshot + " should be non-empty"),
+                () -> assertTrue(Files.size(assistantFailureRecoveryCardScreenshot) > 0,
+                        assistantFailureRecoveryCardScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantApprovalPromptScreenshot) > 0, assistantApprovalPromptScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(toolsHumanizedDoctorCardScreenshot) > 0, toolsHumanizedDoctorCardScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantDefaultModePrefillScreenshot) > 0, assistantDefaultModePrefillScreenshot + " should be non-empty"),
@@ -222,6 +226,7 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertDimensions(assistantNarrowDarkScreenshot, NARROW_WIDTH, HEIGHT),
                 () -> assertDimensions(assistantLiveDarkScreenshot),
                 () -> assertDimensions(assistantProgressMilestonesScreenshot),
+                () -> assertDimensions(assistantFailureRecoveryCardScreenshot),
                 () -> assertDimensions(assistantApprovalPromptScreenshot),
                 () -> assertDimensions(toolsHumanizedDoctorCardScreenshot),
                 () -> assertDimensions(assistantDefaultModePrefillScreenshot),
@@ -498,6 +503,63 @@ class ShaftPluginScreenshotRendererTest {
         } catch (ReflectiveOperationException exception) {
             throw new IllegalStateException("Unable to render the progress-milestones timeline", exception);
         }
+    }
+
+    /**
+     * Renders the Assistant transcript's failure-recovery card (issue #3547): the plain-language
+     * root-cause card that {@code FailedRunDoctorNotifier} now renders automatically after a failed
+     * test run (and that the notification's "Diagnose"/"Heal" buttons also produce directly, even
+     * in default mode), instead of a bare "Failed" timeline entry or raw JSON. Seeded through the
+     * same pure {@link ShaftAssistantPanel#toolCardMarkdown} formatting step {@code
+     * runToolAndRenderCard} uses in production, then appended via {@link
+     * ShaftAssistantPanel#simulateAppendForTest} -- this harness's fake {@link #screenshotProject()}
+     * has no live {@code ShaftMcpInvocationService} to dispatch a real MCP round trip through, the
+     * same reason {@link #renderAssistantProgressMilestones} drives {@code addTimeline} directly.
+     */
+    private static BufferedImage renderAssistantFailureRecoveryCard(String lookAndFeelClassName, boolean dark)
+            throws InterruptedException, InvocationTargetException {
+        AtomicReference<BufferedImage> image = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            configureLookAndFeel(lookAndFeelClassName, dark);
+            ShaftAssistantChatState chatState = new ShaftAssistantChatState();
+            ShaftSettingsState.Settings settings = defaultSettings();
+            ShaftAssistantPanel component = new ShaftAssistantPanel(screenshotProject(), settings, chatState,
+                    () -> {
+                    });
+            String cardMarkdown = ShaftAssistantPanel.toolCardMarkdown(
+                    "doctor_analyze_failed_allure", ShaftMcpToolResult.success("""
+                            {
+                              "schemaVersion": "1.0",
+                              "status": "DETERMINISTIC",
+                              "bundleId": "bundle-456",
+                              "primaryCause": "LOCATOR",
+                              "confidence": "HIGH",
+                              "summary": "The checkout submit button locator no longer matches the page after a redesign.",
+                              "actions": [
+                                {"title":"Update locator","action":"Replace the stale CSS selector with the new data-testid.",
+                                 "status":"SUGGESTED"}
+                              ],
+                              "codeBlocks": [
+                                {"title":"Locator fix","language":"java",
+                                 "code":"driver.element().click(SHAFT.GUI.Locator.hasTestId(\\"checkout-submit\\"));",
+                                 "copyPasteReady":true}
+                              ],
+                              "providerFallback": {"used":false,"reason":"AI advisory disabled by default."},
+                              "bundlePath": "target/shaft-doctor/evidence-bundle.json",
+                              "jsonReportPath": "target/shaft-doctor/doctor-report.json",
+                              "markdownReportPath": "target/shaft-doctor/doctor-report.md",
+                              "warnings": []
+                            }
+                            """), null);
+            component.simulateAppendForTest("assistant", cardMarkdown, "");
+            component.setSize(new Dimension(WIDTH, HEIGHT));
+            component.setPreferredSize(new Dimension(WIDTH, HEIGHT));
+            SwingUtilities.updateComponentTreeUI(component);
+            component.doLayout();
+            layout(component, !dark);
+            image.set(render(component, WIDTH, HEIGHT));
+        });
+        return image.get();
     }
 
     private static BufferedImage renderApprovalPrompt(String lookAndFeelClassName, boolean dark)


### PR DESCRIPTION
Closes #3547. Child of the IntelliJ UX program #3553. Depends on the #3546 progress spine + #3552 humanizer (both merged).

## Item 1 — no orphaned browser on a failed replay (shaft-capture)
`GeneratedTestValidator.replay()` spawns a **forked TestNG JVM**; on timeout it called only `process.destroyForcibly()`, which kills the top process but not its descendant ChromeDriver/Chrome — so a failed/timed-out replay left an **orphaned browser** (esp. on Windows). (The issue's `driver_quit` premise was a red herring — that's a different, interactive-session browser.)
- New `destroyProcessTree(Process)`: snapshots `descendants()` **before** destroy (it's empty once the parent exits), force-destroys the whole tree, then waits a grace period on the authoritative parent handle + descendant `onExit()` futures. Also applied in the launch `catch` blocks.
- Regression test builds a real 3-generation process tree (Top→Child→Grandchild, mirroring JVM→ChromeDriver→Chrome) and asserts the whole tree dies. Live-probed to confirm `destroyForcibly()`-alone orphans a descendant while the tree-kill does not.

## Items 2–4 — diagnose + explain on failure (shaft-intellij)
- **Auto-doctor:** on a failed rerun/replay, `FailedRunDoctorNotifier` runs `doctor_analyze_failed_allure` (trace fallback) and renders a plain-language root-cause card in the Assistant transcript via `AssistantMarkdown.fromMcpOutput` (the #3552 renderer) — within one doctor round-trip. **Degrades gracefully:** missing/incomplete artifacts (e.g. a timeout-killed run) or a thrown error render a plain "couldn't diagnose" line — never raw JSON or a stack trace (4 dedicated degrade tests).
- **Real test target:** threads the actual failing run identity (`ShaftTestIndex`/`ExecutionEnvironment`) into the doctor/healer args, replacing the hardcoded `-Dtest=ExampleTest` + fixed allure path. **Fixes a latent bug:** the hardcoded `["allure-results"]` path throws in `McpWorkspacePolicy.existingList` on the common `target/allure-results` layout — now resolves the real path or lets the server auto-discover.
- **Balloon "Diagnose"/"Heal" buttons** now execute-and-render the analysis in default mode (satisfying the acceptance criterion), a deliberate scoped refinement of #3552's fill-don't-send norm for these two explicit, read-only buttons only. The general gate-audit prefills are untouched. (Item 4's launcher dead-end warn was already fixed by #3552.)

## Verification
- `GeneratedTestValidatorProcessTreeTest` **1/1** (Maven/JDK25, re-run) — real 3-gen tree-kill.
- `FailedRunDoctorNotifierTest` **19/19**, `ShaftAssistantPanelToolCardTest` **4/4** (all degrade paths assert no raw JSON/exception), `ShaftToolWorkflowLauncherTest` **2/2**, `ShaftTestsPanelTest` **5/5**, `AssistantMarkdownTest` 33/33, `ShaftPanelSetupTest` 164/164 (Gradle/JDK21, re-run).
- Screenshot fixture: Assistant transcript showing the plain-language failure/root-cause card (zero raw JSON).

## Scope
No new MCP tools (reuses `doctor_*`), so no manifest/catalog change. shaft-capture browser-close + shaft-intellij recovery UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)