### PR TITLE
feat: close the recorder->editor loop — insert/create-class + network-options + include filter (#3548)

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiCaptureGenerationRequest.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiCaptureGenerationRequest.java
@@ -4,6 +4,7 @@ import com.shaft.capture.generate.CaptureGenerationRequest;
 import com.shaft.pilot.ai.ApprovalPolicy;
 
 import java.nio.file.Path;
+import java.util.List;
 
 /**
  * Options for generating a {@code SHAFT.API} test class from a recorded session.
@@ -30,6 +31,10 @@ import java.nio.file.Path;
  * @param aiApprovalPolicy explicit evidence and processing-location approval for preview generation;
  *                        {@link ApprovalPolicy#denyAll()} by default, so AI naming never runs
  *                        unless the caller explicitly approves it
+ * @param excludedTransactionIds recorded transaction IDs (see {@code CaptureEvent.NetworkEvent#transactionId()})
+ *                               to omit from the generated test entirely, driven by a caller-side
+ *                               transaction include/exclude selection; empty includes every renderable
+ *                               transaction (the default)
  */
 public record ApiCaptureGenerationRequest(
         Path sessionPath,
@@ -45,7 +50,8 @@ public record ApiCaptureGenerationRequest(
         CaptureGenerationRequest.EnrichmentMode enrichmentMode,
         Path enrichmentPreviewPath,
         boolean enrichmentApproved,
-        ApprovalPolicy aiApprovalPolicy) {
+        ApprovalPolicy aiApprovalPolicy,
+        List<String> excludedTransactionIds) {
     public ApiCaptureGenerationRequest {
         packageName = packageName == null || packageName.isBlank() ? "tests.generated" : packageName;
         className = className == null ? "" : className.trim();
@@ -56,9 +62,49 @@ public record ApiCaptureGenerationRequest(
                 ? outputDirectory.resolve("target/shaft-capture/api-enrichment-preview.json")
                 : enrichmentPreviewPath;
         aiApprovalPolicy = aiApprovalPolicy == null ? ApprovalPolicy.denyAll() : aiApprovalPolicy;
+        excludedTransactionIds = excludedTransactionIds == null ? List.of() : List.copyOf(excludedTransactionIds);
         if (enrichmentMode == CaptureGenerationRequest.EnrichmentMode.APPLY && !enrichmentApproved) {
             throw new IllegalArgumentException("Applying AI enrichment requires explicit approval.");
         }
+    }
+
+    /**
+     * Compatibility constructor for callers compiled before the transaction include/exclude filter
+     * was added.
+     *
+     * @param sessionPath path to the recorded {@code CaptureSession} JSON file
+     * @param outputDirectory project root the generated source/test-data/report are written under
+     * @param packageName generated class package
+     * @param className generated class name; blank derives one deterministically from the session ID
+     * @param style how transactions are grouped into test methods
+     * @param validationDepth how thoroughly each response is validated
+     * @param compile whether to compile the generated source
+     * @param replay whether to replay the compiled class
+     * @param overwrite whether existing output files may be overwritten
+     * @param openApiSpecPath optional path to an OpenAPI spec to cross-report recorded endpoints against
+     * @param enrichmentMode optional AI naming-enrichment phase
+     * @param enrichmentPreviewPath preview path to write or read
+     * @param enrichmentApproved whether a reviewed preview may be applied
+     * @param aiApprovalPolicy explicit evidence and processing-location approval for preview generation
+     */
+    public ApiCaptureGenerationRequest(
+            Path sessionPath,
+            Path outputDirectory,
+            String packageName,
+            String className,
+            ApiCodegenStyle style,
+            ApiValidationDepth validationDepth,
+            boolean compile,
+            boolean replay,
+            boolean overwrite,
+            Path openApiSpecPath,
+            CaptureGenerationRequest.EnrichmentMode enrichmentMode,
+            Path enrichmentPreviewPath,
+            boolean enrichmentApproved,
+            ApprovalPolicy aiApprovalPolicy) {
+        this(sessionPath, outputDirectory, packageName, className, style, validationDepth, compile, replay,
+                overwrite, openApiSpecPath, enrichmentMode, enrichmentPreviewPath, enrichmentApproved,
+                aiApprovalPolicy, List.of());
     }
 
     /**

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiCaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiCaptureGenerator.java
@@ -119,7 +119,7 @@ public final class ApiCaptureGenerator {
         }
 
         Path bodiesDirectory = sessionPath.getParent().resolve(session.sessionId() + "-network-bodies");
-        List<ApiTransaction> transactions = extractTransactions(session, bodiesDirectory);
+        List<ApiTransaction> transactions = extractTransactions(session, bodiesDirectory, request.excludedTransactionIds());
         if (transactions.isEmpty()) {
             unsupported.add("No renderable API transactions (XHR/FETCH with a recorded response) "
                     + "were found in this session.");
@@ -353,7 +353,8 @@ public final class ApiCaptureGenerator {
 
     // ---- transaction extraction ----
 
-    private List<ApiTransaction> extractTransactions(CaptureSession session, Path bodiesDirectory) {
+    private List<ApiTransaction> extractTransactions(
+            CaptureSession session, Path bodiesDirectory, List<String> excludedTransactionIds) {
         List<ApiTransaction> transactions = new ArrayList<>();
         String lastDedupeKey = null;
         for (CaptureEvent event : session.events()) {
@@ -361,6 +362,12 @@ public final class ApiCaptureGenerator {
                 continue;
             }
             if (!isRenderableResourceKind(networkEvent.resourceKind()) || networkEvent.response() == null) {
+                continue;
+            }
+            if (excludedTransactionIds.contains(networkEvent.transactionId())) {
+                // Deselected in the recorder's transaction table (issue #3548 item 3): honor the
+                // caller's include/exclude choice by omitting it before dedupe/rendering, not just
+                // decorating the table client-side.
                 continue;
             }
             String dedupeKey = networkEvent.request().method() + " " + networkEvent.request().url();

--- a/shaft-intellij/src/main/java/com/shaft/intellij/actions/RecordApiWebAction.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/actions/RecordApiWebAction.java
@@ -15,6 +15,10 @@ import com.shaft.intellij.settings.ShaftSettingsState;
 import com.shaft.intellij.ui.ShaftToolWindowPanel;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
 /**
  * Prepares an MCP {@code capture_api_start} request for a target URL and opens the
  * API Recording tab so the user can review captured network transactions live.
@@ -22,6 +26,17 @@ import org.jetbrains.annotations.NotNull;
 public final class RecordApiWebAction extends AnAction implements DumbAware {
     private static final String DEFAULT_TARGET_URL = "https://example.com";
     private static final String START_TOOL_NAME = "capture_api_start";
+
+    /**
+     * Exact field names of {@code com.shaft.capture.runtime.NetworkCaptureOptions}, the class the
+     * MCP layer binds {@code networkOptions} JSON keys to. A key outside this set is silently
+     * ignored by the binder rather than rejected -- most dangerously, a typo'd
+     * {@code captureRequestBodies}/{@code captureResponseBodies} leaves body capture off with no
+     * error, which is the exact silent failure issue #3548 item 2 hardens against.
+     */
+    static final Set<String> NETWORK_CAPTURE_OPTIONS_FIELDS = Set.of(
+            "enabled", "excludeAssets", "excludePattern", "includePattern",
+            "captureResponseBodies", "captureRequestBodies");
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent event) {
@@ -51,6 +66,15 @@ public final class RecordApiWebAction extends AnAction implements DumbAware {
         networkOptions.addProperty("excludeAssets", true);
         networkOptions.addProperty("captureRequestBodies", true);
         networkOptions.addProperty("captureResponseBodies", true);
+
+        List<String> unknownKeys = unknownNetworkCaptureOptionKeys(networkOptions);
+        if (!unknownKeys.isEmpty()) {
+            // Warn instead of failing the request: an unrecognized key is dropped by the MCP binder,
+            // not rejected, so the recording still starts -- just without the intended option applied.
+            ShaftNotifier.warn(project, "SHAFT", "networkOptions has unrecognized key(s) " + unknownKeys
+                    + " -- they will be silently ignored and any body capture they were meant to control "
+                    + "may default off. Valid keys: " + NETWORK_CAPTURE_OPTIONS_FIELDS);
+        }
 
         JsonObject arguments = new JsonObject();
         arguments.addProperty("targetUrl", targetUrl.trim());
@@ -84,6 +108,25 @@ public final class RecordApiWebAction extends AnAction implements DumbAware {
      */
     static String recordApiPrompt(String targetUrl) {
         return "Record API traffic on " + targetUrl;
+    }
+
+    /**
+     * Returns any {@code networkOptions} keys that do not match a
+     * {@code com.shaft.capture.runtime.NetworkCaptureOptions} field, so a mistyped key can be
+     * surfaced as a visible warning instead of silently doing nothing. Package-private for
+     * {@code RecordApiWebActionTest}.
+     *
+     * @param networkOptions the {@code networkOptions} JSON object about to be sent
+     * @return unknown key names, in encounter order; empty when every key is valid
+     */
+    static List<String> unknownNetworkCaptureOptionKeys(JsonObject networkOptions) {
+        List<String> unknown = new ArrayList<>();
+        for (String key : networkOptions.keySet()) {
+            if (!NETWORK_CAPTURE_OPTIONS_FIELDS.contains(key)) {
+                unknown.add(key);
+            }
+        }
+        return unknown;
     }
 
     private static void openAssistantPrompt(Project project, String text) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ApiRecordingSessionPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ApiRecordingSessionPanel.java
@@ -40,6 +40,7 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
     private static final int POLL_INTERVAL_MILLIS = 2_000;
     private static final String TRANSACTIONS_TOOL_NAME = "capture_api_transactions";
     private static final String STOP_TOOL_NAME = "capture_api_stop";
+    private static final String GENERATE_TOOL_NAME = "capture_api_generate";
 
     private final Project project;
     private final TransactionTableModel tableModel = new TransactionTableModel();
@@ -47,11 +48,13 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
     private final TableRowSorter<TransactionTableModel> rowSorter = new TableRowSorter<>(tableModel);
     private final JBTextField filterField = new JBTextField();
     private final JButton stopButton = new JButton("Stop");
+    private final JButton generateButton = new JButton("Generate");
     private final JLabel statusLabel = new JLabel("Recording...");
     private final Alarm pollAlarm;
 
     private volatile boolean stopped;
     private String sessionId;
+    private String sessionOutputPath = "";
     private ShaftMcpInvocation currentInvocation;
 
     /**
@@ -92,15 +95,23 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
         });
 
         stopButton.addActionListener(event -> stopRecording());
+        generateButton.setEnabled(false);
+        generateButton.getAccessibleContext().setAccessibleDescription(
+                "Generate a SHAFT.API test from the included transactions");
+        generateButton.addActionListener(event -> generateCode());
 
         JPanel header = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 2));
         JLabel titleLabel = new JLabel("Recording: " + targetUrl);
         titleLabel.setFont(titleLabel.getFont().deriveFont(Font.BOLD));
         header.add(titleLabel);
 
+        JPanel actions = new JPanel(new FlowLayout(FlowLayout.RIGHT, 6, 0));
+        actions.add(stopButton);
+        actions.add(generateButton);
+
         JPanel toolbar = new JPanel(new BorderLayout(6, 0));
         toolbar.add(filterField, BorderLayout.CENTER);
-        toolbar.add(stopButton, BorderLayout.EAST);
+        toolbar.add(actions, BorderLayout.EAST);
 
         JPanel north = new JPanel(new BorderLayout(4, 4));
         north.add(header, BorderLayout.NORTH);
@@ -137,6 +148,10 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
 
     JButton stopButton() {
         return stopButton;
+    }
+
+    JButton generateButton() {
+        return generateButton;
     }
 
     JLabel statusLabel() {
@@ -198,28 +213,29 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
         statusLabel.setText("Recording... " + rows.size() + " transaction(s)");
     }
 
-    private static List<TransactionRow> parseTransactions(String output) {
+    // Package-private (not private) for ApiRecordingSessionPanelTest: this parsing logic is pure
+    // and worth covering directly without standing up the full panel (which needs a live Project).
+    static List<TransactionRow> parseTransactions(String output) {
         List<TransactionRow> rows = new ArrayList<>();
-        JsonObject payload = AssistantMarkdown.jsonObjectFromMcpOutput(output);
-        if (payload == null) {
+        // capture_api_transactions returns a bare List<NetworkTransaction> -- a JSON array, not an
+        // object -- so this must unwrap to an array, not look for an object with a "transactions"
+        // key (that key never exists on the wire and previously left this table permanently empty).
+        JsonArray transactions = AssistantMarkdown.jsonArrayFromMcpOutput(output);
+        if (transactions == null) {
             return rows;
         }
-        JsonElement transactionsElement = payload.get("transactions");
-        if (transactionsElement == null || !transactionsElement.isJsonArray()) {
-            return rows;
-        }
-        JsonArray transactions = transactionsElement.getAsJsonArray();
         for (JsonElement element : transactions) {
             if (!element.isJsonObject()) {
                 continue;
             }
             JsonObject transaction = element.getAsJsonObject();
             rows.add(new TransactionRow(
+                    stringOf(transaction, "transactionId"),
                     stringOf(transaction, "method"),
                     stringOf(transaction, "url"),
-                    stringOf(transaction, "status"),
+                    intOf(transaction, "statusCode") == 0 ? "" : String.valueOf(intOf(transaction, "statusCode")),
                     stringOf(transaction, "resourceKind"),
-                    stringOf(transaction, "size"),
+                    responseSize(transaction),
                     true));
         }
         return rows;
@@ -228,6 +244,26 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
     private static String stringOf(JsonObject object, String key) {
         JsonElement element = object.get(key);
         return element == null || element.isJsonNull() ? "" : element.getAsString();
+    }
+
+    private static int intOf(JsonObject object, String key) {
+        JsonElement element = object.get(key);
+        return element == null || element.isJsonNull() || !element.isJsonPrimitive() ? 0 : element.getAsInt();
+    }
+
+    // NetworkTransaction#bodyRefMetadata nests a "response" entry with a "sizeBytes" field (see
+    // CaptureSessionStore#putBodyRefMetadata); absent when the transaction has no response body.
+    private static String responseSize(JsonObject transaction) {
+        JsonElement metadata = transaction.get("bodyRefMetadata");
+        if (metadata == null || !metadata.isJsonObject()) {
+            return "";
+        }
+        JsonElement response = metadata.getAsJsonObject().get("response");
+        if (response == null || !response.isJsonObject()) {
+            return "";
+        }
+        JsonElement sizeBytes = response.getAsJsonObject().get("sizeBytes");
+        return sizeBytes == null || sizeBytes.isJsonNull() ? "" : sizeBytes.getAsString();
     }
 
     /**
@@ -257,9 +293,64 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
                 .whenComplete((result, error) -> ApplicationManager.getApplication().invokeLater(() -> {
                     if (error != null || result == null || !result.success()) {
                         statusLabel.setText("Stopped (with errors). " + tableModel.getRowCount() + " transaction(s).");
-                    } else {
-                        statusLabel.setText("Stopped. " + tableModel.getRowCount() + " transaction(s).");
+                        return;
                     }
+                    // capture_api_stop returns CaptureStatus, whose outputPath is the persisted session
+                    // JSON capture_api_generate needs -- captured here so Generate has a sessionPath.
+                    JsonObject status = AssistantMarkdown.jsonObjectFromMcpOutput(result.output());
+                    sessionOutputPath = status != null && status.has("outputPath")
+                            ? status.get("outputPath").getAsString()
+                            : "";
+                    generateButton.setEnabled(!sessionOutputPath.isBlank());
+                    statusLabel.setText("Stopped. " + tableModel.getRowCount() + " transaction(s).");
+                }));
+    }
+
+    /**
+     * Generates a {@code SHAFT.API} test from the stopped session via {@code capture_api_generate},
+     * excluding any transaction whose Include checkbox is unchecked (issue #3548 item 3).
+     */
+    private void generateCode() {
+        if (sessionOutputPath.isBlank()) {
+            statusLabel.setText("Stop the recording before generating code.");
+            return;
+        }
+        generateButton.setEnabled(false);
+        statusLabel.setText("Generating SHAFT.API test...");
+
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("sessionPath", sessionOutputPath);
+        arguments.addProperty("outputDirectory", "generated-tests");
+        arguments.addProperty("packageName", "tests.generated");
+        arguments.addProperty("className", "");
+        arguments.addProperty("style", "SCENARIO");
+        arguments.addProperty("validationDepth", "SCHEMA");
+        arguments.addProperty("overwrite", false);
+        arguments.addProperty("replay", false);
+        arguments.addProperty("openApiSpecPath", "");
+        JsonArray excludedTransactionIds = new JsonArray();
+        tableModel.excludedTransactionIds().forEach(excludedTransactionIds::add);
+        arguments.add("excludedTransactionIds", excludedTransactionIds);
+
+        ShaftMcpInvocationService.getInstance(project)
+                .startTool(GENERATE_TOOL_NAME, arguments)
+                .future()
+                .whenComplete((result, error) -> ApplicationManager.getApplication().invokeLater(() -> {
+                    generateButton.setEnabled(true);
+                    if (error != null || result == null || !result.success()) {
+                        statusLabel.setText("Generation failed: "
+                                + (result != null ? result.output() : String.valueOf(error)));
+                        return;
+                    }
+                    JsonObject payload = AssistantMarkdown.jsonObjectFromMcpOutput(result.output());
+                    boolean successful = payload != null && payload.has("successful")
+                            && payload.get("successful").getAsBoolean();
+                    String sourcePath = payload != null && payload.has("sourcePath")
+                            ? payload.get("sourcePath").getAsString()
+                            : "";
+                    statusLabel.setText(successful
+                            ? "Generated " + sourcePath
+                            : "Generation completed with errors -- see the SHAFT tool output.");
                 }));
     }
 
@@ -280,6 +371,9 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
     /**
      * One row of the API recording transactions table.
      *
+     * @param id recorded transaction ID ({@code NetworkTransaction#transactionId}); used to drive
+     *           {@code capture_api_generate}'s {@code excludedTransactionIds} filter, not just to
+     *           display the row
      * @param method HTTP method
      * @param url request URL
      * @param status HTTP status
@@ -287,7 +381,7 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
      * @param size response size
      * @param included whether the row is included in generated code (session-local state)
      */
-    record TransactionRow(String method, String url, String status, String resourceKind, String size,
+    record TransactionRow(String id, String method, String url, String status, String resourceKind, String size,
                            boolean included) {
     }
 
@@ -300,15 +394,15 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
         private List<TransactionRow> rows = new ArrayList<>();
 
         void setRows(List<TransactionRow> newRows) {
-            // Preserve session-local include checkbox state by matching on URL+method.
+            // Preserve session-local include checkbox state by matching on the stable transaction ID.
             List<TransactionRow> merged = new ArrayList<>(newRows.size());
             for (TransactionRow row : newRows) {
                 boolean included = rows.stream()
-                        .filter(existing -> existing.method().equals(row.method()) && existing.url().equals(row.url()))
+                        .filter(existing -> existing.id().equals(row.id()))
                         .findFirst()
                         .map(TransactionRow::included)
                         .orElse(true);
-                merged.add(new TransactionRow(row.method(), row.url(), row.status(), row.resourceKind(),
+                merged.add(new TransactionRow(row.id(), row.method(), row.url(), row.status(), row.resourceKind(),
                         row.size(), included));
             }
             rows = merged;
@@ -317,6 +411,20 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
 
         List<TransactionRow> rows() {
             return rows;
+        }
+
+        /**
+         * Returns the transaction IDs whose Include checkbox is unchecked, in table order, for
+         * {@code capture_api_generate}'s {@code excludedTransactionIds} filter.
+         *
+         * @return excluded transaction IDs
+         */
+        List<String> excludedTransactionIds() {
+            return rows.stream()
+                    .filter(row -> !row.included())
+                    .map(TransactionRow::id)
+                    .filter(id -> !id.isBlank())
+                    .toList();
         }
 
         @Override
@@ -364,8 +472,8 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
                 return;
             }
             TransactionRow row = rows.get(rowIndex);
-            rows.set(rowIndex, new TransactionRow(row.method(), row.url(), row.status(), row.resourceKind(),
-                    row.size(), included));
+            rows.set(rowIndex, new TransactionRow(row.id(), row.method(), row.url(), row.status(),
+                    row.resourceKind(), row.size(), included));
             fireTableCellUpdated(rowIndex, columnIndex);
         }
     }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java
@@ -124,6 +124,20 @@ final class AssistantMarkdown {
         return parsed != null && parsed.isJsonObject() ? parsed.getAsJsonObject() : null;
     }
 
+    /**
+     * Unwraps an MCP {@code content[].text} envelope down to the tool's own JSON result and returns
+     * it as a JSON array, for tools whose return type serializes as a bare array (for example a
+     * {@code List<...>}) rather than an object -- {@link #jsonObjectFromMcpOutput} always returns
+     * null for those since the unwrapped payload is never a JSON object.
+     *
+     * @param output raw tool output text
+     * @return the parsed array, or null when the unwrapped payload is not a JSON array
+     */
+    static JsonArray jsonArrayFromMcpOutput(String output) {
+        JsonElement parsed = parse(unwrapMcpText(output));
+        return parsed != null && parsed.isJsonArray() ? parsed.getAsJsonArray() : null;
+    }
+
     static boolean shouldFormatWithAgent(String toolName, String output) {
         if (KNOWN_TOOLS.contains(toolName)) {
             return false;

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/GuidedWorkflowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/GuidedWorkflowPanel.java
@@ -4,14 +4,20 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiFile;
 import com.intellij.ui.components.JBTextArea;
 import com.intellij.ui.components.JBTextField;
 import com.intellij.util.Alarm;
 import com.intellij.util.ui.JBUI;
+import com.shaft.intellij.java.JavaTargetContextResolver;
 import com.shaft.intellij.mcp.ShaftMcpInvocationService;
 import com.shaft.intellij.mcp.ShaftMcpToolResult;
 import com.shaft.intellij.settings.ShaftSettingsState;
@@ -27,6 +33,11 @@ import java.awt.BorderLayout;
 import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.GridLayout;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Guided recorder, locator, and code-generation entry points backed by existing MCP tools.
@@ -136,7 +147,15 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
                         this::trySampleRecording),
                 button("Start recording", "Start a SHAFT recording", ShaftIcons.SEND, this::startRecording),
                 button("Stop recording", "Stop the active SHAFT recording", ShaftIcons.CANCEL, this::stopRecording),
-                button("Review code", "Generate reviewed SHAFT code blocks from a recording", ShaftIcons.CODE, this::generateCode));
+                button("Review code", "Generate reviewed SHAFT code blocks from a recording", ShaftIcons.CODE, this::generateCode),
+                // Closes the recorder -> editor loop (issue #3548 item 1): "Review code" only
+                // prefills the Tools panel for manual copy; these execute the same *_code_blocks
+                // tool and write the result into the editor, mirroring the Assistant Capture-review
+                // strip's "Insert into open class"/"Create test class" seams.
+                button("Insert at caret", "Insert generated SHAFT code at the editor caret", ShaftIcons.EDIT,
+                        this::insertCodeAtCaret),
+                button("Create test class", "Create a test class from the generated recording", ShaftIcons.CODE,
+                        this::createTestClassFromRecording));
         JPanel locator = section("Locator",
                 button("Inspect locator", "Inspect the page and propose locator candidates", ShaftIcons.SEARCH, this::inspectLocator),
                 button("Guardrail check", "Check generated SHAFT code for automation anti-patterns", ShaftIcons.CHECK, this::guardrailCheck));
@@ -627,15 +646,29 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
     }
 
     private void generateCode() {
-        JsonObject arguments = new JsonObject();
+        prefill.prefill(codeBlocksToolName(), codeBlocksArguments());
+    }
+
+    /**
+     * Returns the {@code *_code_blocks} MCP tool matching the selected backend, shared by
+     * "Review code", "Insert at caret", and "Create test class" so the three actions always
+     * generate from the same recording.
+     */
+    private String codeBlocksToolName() {
         if (mobile()) {
+            return "mobile_recording_code_blocks";
+        }
+        if (playwright()) {
+            return "playwright_recording_code_blocks";
+        }
+        return "capture_code_blocks";
+    }
+
+    private JsonObject codeBlocksArguments() {
+        JsonObject arguments = new JsonObject();
+        if (mobile() || playwright()) {
             arguments.addProperty("recordingPath", sessionPath.getText().trim());
             arguments.addProperty("driverVariableName", "driver");
-            prefill.prefill("mobile_recording_code_blocks", arguments);
-        } else if (playwright()) {
-            arguments.addProperty("recordingPath", sessionPath.getText().trim());
-            arguments.addProperty("driverVariableName", "driver");
-            prefill.prefill("playwright_recording_code_blocks", arguments);
         } else {
             arguments.addProperty("sessionPath", sessionPath.getText().trim());
             arguments.addProperty("outputDirectory", ".");
@@ -643,8 +676,213 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
             arguments.addProperty("className", "GeneratedShaftTest");
             arguments.addProperty("overwrite", false);
             arguments.addProperty("driverVariableName", "driver");
-            prefill.prefill("capture_code_blocks", arguments);
         }
+        return arguments;
+    }
+
+    /**
+     * "Insert at caret" (issue #3548 item 1): executes the same {@code *_code_blocks} tool "Review
+     * code" only prefills, then writes the generated {@code TEST_METHOD} snippet (falling back to
+     * the full class) into the editor at the caret -- the same {@code FileDocumentManager
+     * .requestWriting} + {@code WriteCommandAction} seam {@code PickLocatorAtCaretAction} already
+     * proved, not a new insertion mechanism.
+     */
+    private void insertCodeAtCaret() {
+        ShaftMcpInvocationService invocationService = invocationService();
+        if (invocationService == null) {
+            prefill.prefill(codeBlocksToolName(), codeBlocksArguments());
+            return;
+        }
+        if (selectedJavaEditor() == null) {
+            setRecorderStatus("Open a Java file in the editor first.");
+            return;
+        }
+        setRecorderStatus("Generating code to insert at caret...");
+        invocationService.startTool(codeBlocksToolName(), codeBlocksArguments())
+                .future()
+                .whenComplete((result, error) -> onEdt(() -> applyInsertAtCaret(result, error)));
+    }
+
+    private void applyInsertAtCaret(ShaftMcpToolResult result, Throwable error) {
+        if (failed(result, error)) {
+            setRecorderStatus("Could not generate code to insert: " + failureText(result, error));
+            return;
+        }
+        JsonObject raw = AssistantMarkdown.jsonObjectFromMcpOutput(result.output());
+        String snippet = firstBlockByKind(raw, "TEST_METHOD");
+        if (snippet.isBlank()) {
+            snippet = firstFullClassBlock(raw);
+        }
+        if (snippet.isBlank()) {
+            setRecorderStatus("The generated result has no insertable code block.");
+            return;
+        }
+        Editor editor = selectedJavaEditor();
+        if (editor == null) {
+            setRecorderStatus("Open a Java file in the editor first.");
+            return;
+        }
+        Document document = editor.getDocument();
+        if (!FileDocumentManager.getInstance().requestWriting(document, project)) {
+            setRecorderStatus("The current file could not be made writable.");
+            return;
+        }
+        int offset = Math.max(0, Math.min(editor.getCaretModel().getOffset(), document.getTextLength()));
+        String toInsert = snippet;
+        WriteCommandAction.writeCommandAction(project)
+                .withName("Insert SHAFT Recorded Code")
+                .run(() -> document.insertString(offset, toInsert));
+        setRecorderStatus("Inserted generated code at the caret.");
+    }
+
+    /**
+     * "Create test class" (issue #3548 item 1): executes the same {@code *_code_blocks} tool, then
+     * writes the {@code FULL_CLASS} block into {@code src/test/java} (never overwriting) and opens
+     * it, mirroring {@code ShaftAssistantPanel#createTestClassFromReview}.
+     */
+    private void createTestClassFromRecording() {
+        ShaftMcpInvocationService invocationService = invocationService();
+        if (invocationService == null) {
+            prefill.prefill(codeBlocksToolName(), codeBlocksArguments());
+            return;
+        }
+        if (project == null || project.getBasePath() == null) {
+            setRecorderStatus("No open project.");
+            return;
+        }
+        setRecorderStatus("Generating test class...");
+        invocationService.startTool(codeBlocksToolName(), codeBlocksArguments())
+                .future()
+                .whenComplete((result, error) -> onEdt(() -> applyCreateTestClass(result, error)));
+    }
+
+    private void applyCreateTestClass(ShaftMcpToolResult result, Throwable error) {
+        if (failed(result, error)) {
+            setRecorderStatus("Could not generate test class: " + failureText(result, error));
+            return;
+        }
+        JsonObject raw = AssistantMarkdown.jsonObjectFromMcpOutput(result.output());
+        String code = firstFullClassBlock(raw);
+        if (code.isBlank()) {
+            setRecorderStatus("The generated result has no full-class code block.");
+            return;
+        }
+        Matcher classMatcher = Pattern.compile("class\\s+(\\w+)").matcher(code);
+        Matcher packageMatcher = Pattern.compile("package\\s+([\\w.]+)\\s*;").matcher(code);
+        if (!classMatcher.find()) {
+            setRecorderStatus("Could not determine the generated class name.");
+            return;
+        }
+        String body = packageMatcher.find() ? code : "package tests.generated;\n\n" + code;
+        String packagePath = (packageMatcher.reset().find() ? packageMatcher.group(1) : "tests.generated")
+                .replace('.', '/');
+        Path target = Path.of(project.getBasePath(), "src", "test", "java")
+                .resolve(packagePath).resolve(classMatcher.group(1) + ".java");
+        try {
+            if (Files.exists(target)) {
+                setRecorderStatus("Already exists - opened " + target.getFileName() + " (not overwritten).");
+            } else {
+                Files.createDirectories(target.getParent());
+                Files.writeString(target, body);
+                setRecorderStatus("Created " + target.getFileName() + " in src/test/java.");
+            }
+            openFileInEditor(target);
+        } catch (IOException writeFailure) {
+            setRecorderStatus("Could not write test class: " + writeFailure.getMessage());
+        }
+    }
+
+    /**
+     * Returns the editor selected in the editor tab strip, gated on it holding a resolvable Java
+     * target (same gate {@code PickLocatorAtCaretAction#isAvailable} uses), or null when there is
+     * none -- callers treat null as "open a Java file first".
+     */
+    private Editor selectedJavaEditor() {
+        if (project == null) {
+            return null;
+        }
+        Editor editor = FileEditorManager.getInstance(project).getSelectedTextEditor();
+        if (editor == null) {
+            return null;
+        }
+        PsiFile file = PsiDocumentManager.getInstance(project).getPsiFile(editor.getDocument());
+        return JavaTargetContextResolver.resolve(file, editor.getCaretModel().getOffset()) != null ? editor : null;
+    }
+
+    private void openFileInEditor(Path path) {
+        try {
+            var virtualFile = com.intellij.openapi.vfs.LocalFileSystem.getInstance()
+                    .refreshAndFindFileByNioFile(path);
+            if (virtualFile != null && project != null) {
+                FileEditorManager.getInstance(project).openFile(virtualFile, true);
+            }
+        } catch (RuntimeException | Error headlessTestEnvironment) {
+            // Best effort: the path was already reported in the status label.
+        }
+    }
+
+    /**
+     * Returns the {@code code} of the first {@code codeBlocks[]} entry whose {@code kind} matches,
+     * or {@code ""} when none match. Kind (not id) is used because the id differs per backend
+     * (e.g. {@code capture-test-method} vs {@code playwright-replay-method}).
+     */
+    private static String firstBlockByKind(JsonObject raw, String kind) {
+        if (raw == null || !raw.has("codeBlocks") || !raw.get("codeBlocks").isJsonArray()) {
+            return "";
+        }
+        for (var element : raw.getAsJsonArray("codeBlocks")) {
+            if (!element.isJsonObject()) {
+                continue;
+            }
+            JsonObject block = element.getAsJsonObject();
+            if (kind.equals(jsonString(block, "kind"))) {
+                String code = blockCode(block);
+                if (!code.isBlank()) {
+                    return code;
+                }
+            }
+        }
+        return "";
+    }
+
+    /**
+     * Returns the {@code capture-full-class} block's code, falling back to the first block whose
+     * code contains {@code "class "} when the id is missing (mirrors {@code
+     * ShaftAssistantPanel#firstJavaClassBlock}).
+     */
+    private static String firstFullClassBlock(JsonObject raw) {
+        if (raw == null || !raw.has("codeBlocks") || !raw.get("codeBlocks").isJsonArray()) {
+            return "";
+        }
+        String fallback = "";
+        for (var element : raw.getAsJsonArray("codeBlocks")) {
+            if (!element.isJsonObject()) {
+                continue;
+            }
+            JsonObject block = element.getAsJsonObject();
+            String code = blockCode(block);
+            if (code.isBlank() || !code.contains("class ")) {
+                continue;
+            }
+            if ("capture-full-class".equals(jsonString(block, "id"))) {
+                return code;
+            }
+            if (fallback.isBlank()) {
+                fallback = code;
+            }
+        }
+        return fallback;
+    }
+
+    // McpCodeBlock's source is in "code"; a few callers key on "content" instead, so both are
+    // checked (mirrors ShaftAssistantPanel#firstJavaClassBlock).
+    private static String blockCode(JsonObject block) {
+        String code = jsonString(block, "code");
+        return code.isBlank() ? jsonString(block, "content") : code;
+    }
+
+    private static String jsonString(JsonObject object, String key) {
+        return object.has(key) && object.get(key).isJsonPrimitive() ? object.get(key).getAsString() : "";
     }
 
     private void inspectLocator() {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -2715,7 +2715,7 @@ final class ShaftAssistantPanel extends JPanel {
             if (code.isBlank() || !code.contains("class ")) {
                 continue;
             }
-            if ("full-class".equals(string(block, "id", ""))) {
+            if ("capture-full-class".equals(string(block, "id", ""))) {
                 return code;
             }
             if (fallback.isBlank()) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/actions/RecordApiWebActionTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/actions/RecordApiWebActionTest.java
@@ -1,12 +1,17 @@
 package com.shaft.intellij.actions;
 
+import com.google.gson.JsonObject;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Covers the default-mode (advancedUiEnabled=false) Assistant prompt {@code RecordApiWebAction}
- * builds instead of the old dead-end warning that discarded the typed URL (issue #3552).
+ * builds instead of the old dead-end warning that discarded the typed URL (issue #3552), and the
+ * {@code networkOptions} key-validation contract hardening (issue #3548 item 2).
  */
 class RecordApiWebActionTest {
     @Test
@@ -14,5 +19,39 @@ class RecordApiWebActionTest {
         String prompt = RecordApiWebAction.recordApiPrompt("https://example.com/checkout");
 
         assertEquals("Record API traffic on https://example.com/checkout", prompt);
+    }
+
+    @Test
+    void validNetworkCaptureOptionsKeysReportNoUnknowns() {
+        JsonObject networkOptions = new JsonObject();
+        networkOptions.addProperty("enabled", true);
+        networkOptions.addProperty("excludeAssets", true);
+        networkOptions.addProperty("excludePattern", "");
+        networkOptions.addProperty("includePattern", "");
+        networkOptions.addProperty("captureRequestBodies", true);
+        networkOptions.addProperty("captureResponseBodies", true);
+
+        assertEquals(List.of(), RecordApiWebAction.unknownNetworkCaptureOptionKeys(networkOptions));
+    }
+
+    @Test
+    void mistypedNetworkCaptureOptionsKeyIsReportedAsUnknown() {
+        JsonObject networkOptions = new JsonObject();
+        networkOptions.addProperty("enabled", true);
+        // Typo: the real field is captureResponseBodies -- this silently defaults response body
+        // capture off instead of failing without item 2's validation.
+        networkOptions.addProperty("captureResponsBodies", true);
+
+        List<String> unknown = RecordApiWebAction.unknownNetworkCaptureOptionKeys(networkOptions);
+
+        assertEquals(List.of("captureResponsBodies"), unknown);
+    }
+
+    @Test
+    void networkCaptureOptionsFieldSetMatchesTheSixBoundFields() {
+        assertTrue(RecordApiWebAction.NETWORK_CAPTURE_OPTIONS_FIELDS.containsAll(List.of(
+                "enabled", "excludeAssets", "excludePattern", "includePattern",
+                "captureResponseBodies", "captureRequestBodies")));
+        assertEquals(6, RecordApiWebAction.NETWORK_CAPTURE_OPTIONS_FIELDS.size());
     }
 }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ApiRecordingSessionPanelTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ApiRecordingSessionPanelTest.java
@@ -1,0 +1,98 @@
+package com.shaft.intellij.ui;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the pure parsing/filtering logic behind {@link ApiRecordingSessionPanel} directly,
+ * mirroring {@code PickLocatorAtCaretActionTest}'s style: the panel itself needs a live
+ * {@code Project} (an {@code Alarm} and MCP polling start in its constructor), so it is not
+ * unit-testable, but {@code parseTransactions} and {@code TransactionTableModel} are pure/local
+ * state and testable in isolation.
+ */
+class ApiRecordingSessionPanelTest {
+    @Test
+    void parseTransactionsReadsTheBareArrayCapture_api_transactionsReturns() {
+        // Regression for issue #3548 item 3's front-loaded finding: capture_api_transactions
+        // returns a bare JSON array (List<NetworkTransaction>), not an object with a "transactions"
+        // key. The old code looked for that key and always got an empty table.
+        String output = mcpArrayText("""
+                [
+                  {"transactionId": "tx-1", "method": "GET", "url": "https://api.example.test/orders",
+                   "statusCode": 200, "resourceKind": "XHR",
+                   "bodyRefMetadata": {"response": {"sizeBytes": 128}}},
+                  {"transactionId": "tx-2", "method": "DELETE", "url": "https://api.example.test/admin",
+                   "statusCode": 204, "resourceKind": "FETCH"}
+                ]
+                """.strip());
+
+        List<ApiRecordingSessionPanel.TransactionRow> rows = ApiRecordingSessionPanel.parseTransactions(output);
+
+        assertEquals(2, rows.size());
+        ApiRecordingSessionPanel.TransactionRow first = rows.get(0);
+        assertEquals("tx-1", first.id());
+        assertEquals("GET", first.method());
+        assertEquals("https://api.example.test/orders", first.url());
+        assertEquals("200", first.status());
+        assertEquals("XHR", first.resourceKind());
+        assertEquals("128", first.size());
+        assertTrue(first.included());
+
+        ApiRecordingSessionPanel.TransactionRow second = rows.get(1);
+        assertEquals("tx-2", second.id());
+        assertEquals("204", second.status());
+        assertEquals("", second.size());
+    }
+
+    @Test
+    void parseTransactionsReturnsEmptyForNonArrayOutput() {
+        assertEquals(List.of(), ApiRecordingSessionPanel.parseTransactions(mcpArrayText("{\"state\": \"ACTIVE\"}")));
+    }
+
+    @Test
+    void tableModelExcludedTransactionIdsReturnsOnlyUncheckedRows() {
+        ApiRecordingSessionPanel.TransactionTableModel model = new ApiRecordingSessionPanel.TransactionTableModel();
+        model.setRows(List.of(
+                new ApiRecordingSessionPanel.TransactionRow("tx-1", "GET", "https://a", "200", "XHR", "10", true),
+                new ApiRecordingSessionPanel.TransactionRow("tx-2", "POST", "https://b", "201", "FETCH", "20", true)));
+
+        model.setValueAt(false, 1, ApiRecordingSessionPanel.TransactionTableModel.INCLUDE_COLUMN);
+
+        assertEquals(List.of("tx-2"), model.excludedTransactionIds());
+    }
+
+    @Test
+    void tableModelSetRowsPreservesIncludedStateAcrossPollsByMatchingOnId() {
+        // Regression: matching on id (not method+url) is what makes the include checkbox survive a
+        // poll cycle now that the URL/status/size can legitimately repeat across transactions.
+        ApiRecordingSessionPanel.TransactionTableModel model = new ApiRecordingSessionPanel.TransactionTableModel();
+        model.setRows(List.of(
+                new ApiRecordingSessionPanel.TransactionRow("tx-1", "GET", "https://a", "200", "XHR", "10", true)));
+        model.setValueAt(false, 0, ApiRecordingSessionPanel.TransactionTableModel.INCLUDE_COLUMN);
+
+        // Next poll returns the same transaction again (still recording) plus a new one.
+        model.setRows(List.of(
+                new ApiRecordingSessionPanel.TransactionRow("tx-1", "GET", "https://a", "200", "XHR", "10", true),
+                new ApiRecordingSessionPanel.TransactionRow("tx-2", "GET", "https://a", "200", "XHR", "10", true)));
+
+        assertEquals(List.of("tx-1"), model.excludedTransactionIds());
+    }
+
+    private static String mcpArrayText(String text) {
+        JsonObject item = new JsonObject();
+        item.addProperty("type", "text");
+        item.addProperty("text", text);
+        JsonArray content = new JsonArray();
+        content.add(item);
+        JsonObject result = new JsonObject();
+        result.add("content", content);
+        result.addProperty("isError", false);
+        return result.toString();
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantMarkdownTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantMarkdownTest.java
@@ -11,6 +11,8 @@ import java.util.concurrent.CompletionException;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AssistantMarkdownTest {
@@ -91,6 +93,30 @@ class AssistantMarkdownTest {
                 () -> assertTrue(markdown.startsWith("```java")),
                 () -> assertTrue(markdown.contains("public class LoginTest")),
                 () -> assertFalse(markdown.contains("\"content\"")));
+    }
+
+    @Test
+    void jsonArrayFromMcpOutputUnwrapsAListReturningToolsBareArrayResult() {
+        // Regression for the bug behind issue #3548 item 3: a tool whose return type serializes as
+        // a bare JSON array (e.g. List<NetworkTransaction>) previously left jsonObjectFromMcpOutput
+        // returning null forever, since the unwrapped payload is never a JSON object.
+        String output = mcpText("""
+                [{"transactionId": "tx-1", "method": "GET", "url": "https://api.example.test/orders"}]
+                """.strip());
+
+        JsonArray transactions = AssistantMarkdown.jsonArrayFromMcpOutput(output);
+
+        assertAll(
+                () -> assertNotNull(transactions),
+                () -> assertEquals(1, transactions.size()),
+                () -> assertEquals("tx-1", transactions.get(0).getAsJsonObject().get("transactionId").getAsString()));
+    }
+
+    @Test
+    void jsonArrayFromMcpOutputReturnsNullForAnObjectResult() {
+        String output = mcpText("{\"state\": \"ACTIVE\"}");
+
+        assertNull(AssistantMarkdown.jsonArrayFromMcpOutput(output));
     }
 
     @Test

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowPanelTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowPanelTest.java
@@ -152,6 +152,41 @@ class GuidedWorkflowPanelTest {
     }
 
     @Test
+    void insertAtCaretAndCreateTestClassGenerateFromTheSameToolAsReviewCode() {
+        // Issue #3548 item 1: without a live project (no MCP connection, no open editor -- the
+        // state every headless unit test runs in), invocationService() is null and these buttons
+        // fall back to the same review-only prefill "Review code" already uses, so the recorder
+        // stays testable with PickLocatorAtCaretActionTest's pure-logic style even though the
+        // WriteCommandAction/PSI insertion path itself is not unit-testable here.
+        List<CapturedInvocation> invocations = new ArrayList<>();
+        GuidedWorkflowPanel panel = new GuidedWorkflowPanel(null,
+                (toolName, arguments) -> invocations.add(new CapturedInvocation(toolName, arguments)));
+        expandAdvanced(panel);
+        JButton insertAtCaret = findButton(panel, "Insert at caret");
+        JButton createTestClass = findButton(panel, "Create test class");
+        assertNotNull(insertAtCaret);
+        assertNotNull(createTestClass);
+
+        insertAtCaret.doClick();
+        CapturedInvocation insert = last(invocations);
+        assertAll(
+                () -> assertEquals("capture_code_blocks", insert.toolName()),
+                () -> assertEquals("driver", insert.arguments().get("driverVariableName").getAsString()));
+
+        createTestClass.doClick();
+        CapturedInvocation create = last(invocations);
+        assertEquals("capture_code_blocks", create.toolName());
+
+        select(findByAccessibleName(panel, "Guided workflow backend", JComboBox.class), "Mobile (web emulation)");
+        insertAtCaret.doClick();
+        assertEquals("mobile_recording_code_blocks", last(invocations).toolName());
+
+        select(findByAccessibleName(panel, "Guided workflow backend", JComboBox.class), "Playwright");
+        createTestClass.doClick();
+        assertEquals("playwright_recording_code_blocks", last(invocations).toolName());
+    }
+
+    @Test
     void webRecordingStartCarriesIntentAsSessionGoal() {
         List<CapturedInvocation> invocations = new ArrayList<>();
         GuidedWorkflowPanel panel = new GuidedWorkflowPanel(null,
@@ -345,6 +380,8 @@ class GuidedWorkflowPanelTest {
                 () -> assertNotNull(findButton(panel, "Start recording")),
                 () -> assertNotNull(findButton(panel, "Stop recording")),
                 () -> assertNotNull(findButton(panel, "Review code")),
+                () -> assertNotNull(findButton(panel, "Insert at caret")),
+                () -> assertNotNull(findButton(panel, "Create test class")),
                 () -> assertNotNull(findButton(panel, "Plan coding partner")),
                 () -> assertNotNull(findButton(panel, "Find reuse")),
                 () -> assertNotNull(findButton(panel, "Inspect locator")),

--- a/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
@@ -410,6 +410,9 @@ public class CaptureService {
      *               to enable automatically for non-idempotent methods)
      * @param openApiSpecPath optional path (inside the MCP workspace) to an OpenAPI JSON/YAML spec
      *                        to cross-report recorded endpoints against; blank skips coverage
+     * @param excludedTransactionIds recorded transaction IDs to omit from generation entirely
+     *                               (drives a recorder transaction-table include/exclude selection);
+     *                               empty includes every renderable transaction
      * @return generated artifacts, compile/replay result, and copy-paste code blocks
      */
     @Tool(name = "capture_api_generate",
@@ -423,7 +426,8 @@ public class CaptureService {
             String validationDepth,
             boolean overwrite,
             boolean replay,
-            String openApiSpecPath) {
+            String openApiSpecPath,
+            List<String> excludedTransactionIds) {
         Path output = outputDirectory == null || outputDirectory.isBlank()
                 ? workspacePolicy.output("generated-tests", "Capture generation output directory")
                 : workspacePolicy.output(outputDirectory, "Capture generation output directory");
@@ -440,7 +444,12 @@ public class CaptureService {
                 true,
                 replay,
                 overwrite,
-                openApiSpec));
+                openApiSpec,
+                CaptureGenerationRequest.EnrichmentMode.NONE,
+                null,
+                false,
+                null,
+                excludedTransactionIds));
         boolean successful = result.report().status() == CaptureGenerationReport.Status.SUCCESS;
         List<McpCodeBlock> blocks = successful && result.sourcePath() != null
                 ? codeBlocks.fromGeneratedSource(result.sourcePath(), "api", result.report())

--- a/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceApiToolsTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceApiToolsTest.java
@@ -204,7 +204,7 @@ class CaptureServiceApiToolsTest {
 
             McpCaptureReplayResult result = service.generateApi(
                     "recordings/session-mcp.json", "generated", "tests.generated", "",
-                    "SCENARIO", "STATUS", true, false, "openapi.json");
+                    "SCENARIO", "STATUS", true, false, "openapi.json", List.of());
 
             assertTrue(result.successful(), "Generation report: " + result.report());
             assertNotNull(result.report().openApiCoverage());
@@ -227,13 +227,87 @@ class CaptureServiceApiToolsTest {
 
             McpCaptureReplayResult result = service.generateApi(
                     "recordings/session-mcp.json", "generated", "tests.generated", "",
-                    "SCENARIO", "STATUS", true, false, "");
+                    "SCENARIO", "STATUS", true, false, "", List.of());
 
             assertTrue(result.successful(), "Generation report: " + result.report());
             assertFalse(result.report().openApiCoverage().loadable());
         } finally {
             service.close();
         }
+    }
+
+    @Test
+    void generateApiOmitsExcludedTransactionsFromTheGeneratedTest() throws Exception {
+        // Issue #3548 item 3: deselecting a transaction in the recorder table must remove it from
+        // generated output, not just decorate the table client-side.
+        CaptureService service = new CaptureService(
+                new CaptureManager(),
+                McpWorkspacePolicy.of(temp),
+                new McpCaptureCodeBlockService());
+        try {
+            writeRecordedSessionWithTwoTransactions();
+
+            McpCaptureReplayResult result = service.generateApi(
+                    "recordings/session-mcp-two.json", "generated-excluded", "tests.generated", "",
+                    "SCENARIO", "STATUS", true, false, "", List.of("tx-2"));
+
+            assertTrue(result.successful(), "Generation report: " + result.report());
+            String source = Files.readString(result.sourcePath());
+            assertTrue(source.contains("/orders"), "Included transaction missing from generated source: " + source);
+            assertFalse(source.contains("/admin"), "Excluded transaction leaked into generated source: " + source);
+        } finally {
+            service.close();
+        }
+    }
+
+    private Path writeRecordedSessionWithTwoTransactions() throws Exception {
+        Path sessionPath = temp.resolve("recordings/session-mcp-two.json");
+        Files.createDirectories(sessionPath.getParent());
+        Path bodiesDirectory = sessionPath.getParent().resolve("session-mcp-two-network-bodies");
+        Files.createDirectories(bodiesDirectory);
+        NetworkBodyStore bodyStore = new NetworkBodyStore();
+        BodyRef ordersResponse = bodyStore.store(
+                "{\"id\":\"1\"}".getBytes(StandardCharsets.UTF_8), "application/json", bodiesDirectory);
+        BodyRef adminResponse = bodyStore.store(
+                "{\"id\":\"2\"}".getBytes(StandardCharsets.UTF_8), "application/json", bodiesDirectory);
+
+        Instant started = Instant.parse("2026-01-02T03:04:05Z");
+        BrowserMetadata browser = new BrowserMetadata("chrome", "137", "Windows 11", "browser-1", Map.of());
+        CaptureEvent.NetworkEvent createOrder = new CaptureEvent.NetworkEvent(
+                context(1, started),
+                "tx-1",
+                ResourceKind.FETCH,
+                new HttpRequestRecord("POST", "https://api.example.test/orders", headers(), null),
+                new HttpResponseRecord(201, headers(), ordersResponse),
+                new NetworkTiming(null, null, null, null, null, null),
+                "",
+                "https://app.example.test/",
+                null);
+        CaptureEvent.NetworkEvent deleteAdmin = new CaptureEvent.NetworkEvent(
+                context(2, started),
+                "tx-2",
+                ResourceKind.FETCH,
+                new HttpRequestRecord("DELETE", "https://api.example.test/admin", headers(), null),
+                new HttpResponseRecord(204, headers(), adminResponse),
+                new NetworkTiming(null, null, null, null, null, null),
+                "",
+                "https://app.example.test/",
+                null);
+
+        CaptureSession session = new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "session-mcp-two",
+                CaptureSession.SessionStatus.COMPLETED,
+                started,
+                started.plusSeconds(5),
+                browser,
+                List.of(createOrder, deleteAdmin),
+                List.of(),
+                List.of(),
+                RedactionSummary.empty(),
+                Map.of());
+        new CaptureJsonCodec().write(sessionPath, session);
+        return sessionPath;
     }
 
     private Path writeRecordedSession() throws Exception {


### PR DESCRIPTION
Closes #3548. Child of the IntelliJ UX program #3553. Independent of the other children.

## Item 1 — generated code reaches the editor from the specialist recorder
Previously the recorder → code loop dead-ended as JSON in the Tools panel; only `PickLocatorAtCaretAction` wrote to the editor. `GuidedWorkflowPanel` now has **"Insert at caret"** and **"Create test class"** buttons that *execute* the `*_code_blocks` tool (not just prefill it) and route the result through the two proven seams:
- insert → `FileDocumentManager.requestWriting` + `WriteCommandAction` (mirrors `PickLocatorAtCaretAction`),
- create → `Files.writeString` new-file under `src/test/java` (mirrors `ShaftAssistantPanel.createTestClassFromReview`).
Also fixes a real bug found in passing: `firstJavaClassBlock` matched `id=="full-class"` but the actual FULL_CLASS id is `"capture-full-class"` — corrected in the existing method and the mirrored code (it had been silently relying on the `class `-substring fallback).

## Item 2 — NetworkCaptureOptions contract honesty
`RecordApiWebAction` now validates `networkOptions` keys against the six real `runtime/NetworkCaptureOptions` fields (`enabled, excludeAssets, excludePattern, includePattern, captureResponseBodies, captureRequestBodies`) and surfaces a visible `ShaftNotifier.warn` on any unknown key — instead of silently defaulting body capture off.

## Item 3 — the "Include" checkboxes actually drive generation
The include/exclude selections were session-local decoration; generation regenerates from the on-disk session with no filter. Added end-to-end:
- `capture_api_generate` gains a named `excludedTransactionIds` param → threaded into `ApiCaptureGenerationRequest`/`ApiCaptureGenerator.extractTransactions`, which omits excluded ids **before** dedupe/render. **Manifest-safe** — adding a named param to an existing tool leaves the name-based gates untouched (verified: `ShaftMcpApplicationTests` + both Python catalog suites green).
- `ApiRecordingSessionPanel` threads the table's deselected ids into a new **"Generate"** button (there was no generation entry point at all before).
- **Fixes a latent prerequisite bug:** `parseTransactions` looked for a `transactions` object key, but `capture_api_transactions` returns a bare JSON array — so the table had *never* populated real transactions. New `AssistantMarkdown.jsonArrayFromMcpOutput` unwraps the array; rows now carry `transactionId` and merge-on-poll by id.

## Verification
- Maven (JDK25): `ShaftMcpApplicationTests` **5/5** (manifest intact, no generic-arg violation), `CaptureServiceApiToolsTest` **18/18** (new `generateApiOmitsExcludedTransactionsFromTheGeneratedTest`). Python catalog-sync **18/18**.
- Gradle (JDK21): `GuidedWorkflowPanelTest` 13/13, `ApiRecordingSessionPanelTest` 4/4 (new), `AssistantMarkdownTest` 35/35, `RecordApiWebActionTest` 4/4, `PickLocatorAtCaretActionTest` 13/13.
- Screenshot: recorder row grew from 4 → 6 buttons (Try/Start/Stop/Review/Insert-at-caret/Create-test-class).

## Scope
Adds one named param to an existing MCP tool (no new tool → no manifest/catalog name churn). Distinct from #3530 (pure-API/RestAssured fidelity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)