### PR TITLE
feat: IntelliJ composer UX + onboarding trust (#3550, #3551)

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
@@ -631,6 +631,9 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         statusLabel.setEnabled(true);
         statusLabel.setText("Testing...");
         statusLabel.setForeground(ShaftStatusPresentation.progress());
+        // Race fix (issue #3551): a check is starting, so the persisted state must not read ready
+        // for the whole in-flight window (mirrors ShaftMcpSetupPanel#testConnection()).
+        settingsProvider.get().mcpSetupComplete = false;
         String command = mcpCommand.getText() == null ? "" : mcpCommand.getText().trim();
         ShaftMcpConnectionProbe.test(command, formSettings(), resolveProjectRoot()).whenComplete((result, error) ->
                 ApplicationManager.getApplication().invokeLater(() -> {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsState.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsState.java
@@ -35,9 +35,10 @@ public final class ShaftSettingsState implements PersistentStateComponent<ShaftS
 
     /**
      * Returns the documented factory-default settings bean used to reset the plugin to a
-     * fresh-install state. Every field matches {@link Settings}' own field defaults except
-     * {@link Settings#mcpSetupComplete}, which is explicitly forced to {@code false} here so the
-     * setup view renders after a reset even though the bean's own default is {@code true}.
+     * fresh-install state. Every field matches {@link Settings}' own field defaults, including
+     * {@link Settings#mcpSetupComplete} (now {@code false} by default, issue #3551); the explicit
+     * assignment here is kept as defense-in-depth so a reset is provably fresh even if the bean
+     * default ever changes again.
      *
      * @return a new Settings instance holding the factory defaults
      */
@@ -53,7 +54,14 @@ public final class ShaftSettingsState implements PersistentStateComponent<ShaftS
      */
     public static final class Settings {
         public String mcpCommand = "";
-        public boolean mcpSetupComplete = true;
+        /**
+         * Defaults to {@code false} (issue #3551): a fresh install (or a check that is still in
+         * flight) must never read as ready. Because IntelliJ's XML serializer omits properties
+         * that equal the bean default, a pre-existing user whose {@code shaft.xml} predates this
+         * change and never wrote {@code mcpSetupComplete} will load {@code false} here once and
+         * see one self-healing re-check after upgrading — acceptable and honest, not a bug.
+         */
+        public boolean mcpSetupComplete = false;
         /**
          * Last verified agent-lane readiness (two-lane setup, issue #3425): true only when the
          * optional agent check actually passed during setup. Read by the readiness strip

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -92,6 +92,9 @@ final class ShaftAssistantPanel extends JPanel {
     private static final String READY_STATUS = "Try asking me to do something...";
     private static final String SEND_TOOLTIP = "Send assistant prompt (Ctrl+Enter, Command+Enter, or Ctrl+click)";
     private static final String LOCAL_AGENT_STREAMING_HEADER = "_Running local assistant..._";
+    private static final String LOCAL_MODEL_TOOLTIP_LIVE = "Model reported by the connected agent CLI";
+    private static final String LOCAL_MODEL_TOOLTIP_FALLBACK =
+            "Fallback model list (CLI did not report models) — click refresh to try again";
     /**
      * Prefix applied to a local-agent CLI's own tool names (e.g. {@code "Bash"}, {@code "Write"})
      * before recording/checking approval decisions, so they can never collide with SHAFT MCP tool
@@ -132,6 +135,7 @@ final class ShaftAssistantPanel extends JPanel {
     private final JComboBox<String> cloudProvider;
     private final JComboBox<String> cloudModel;
     private final JComboBox<String> localModel;
+    private final JButton refreshLocalModels;
     private final JComboBox<String> effort;
     private final JBTextField customCommand;
     private final JPanel cloudKeyPanel;
@@ -188,6 +192,8 @@ final class ShaftAssistantPanel extends JPanel {
     /** True once the user's second cancel click escalates to a kill for the current invocation. */
     private boolean killRequested;
     private boolean refreshingChats;
+    /** True when {@link #localModel} shows the curated catalog because the CLI reported no models. */
+    private boolean localModelListIsFallback;
     private int localAgentStreamToken;
     private int activeLocalAgentStreamToken = -1;
     private int killedLocalAgentStreamToken = -1;
@@ -304,15 +310,22 @@ final class ShaftAssistantPanel extends JPanel {
         localModel = new JComboBox<>();
         localModel.setEditable(true);
         localModel.getAccessibleContext().setAccessibleName("Assistant local agent model");
-        localModel.setToolTipText("Model reported by the connected agent CLI");
+        localModel.setToolTipText(LOCAL_MODEL_TOOLTIP_LIVE);
         if (localModel.getEditor().getEditorComponent() instanceof JTextComponent localModelEditor) {
             localModelEditor.getAccessibleContext().setAccessibleName("Assistant local agent model text");
-            localModelEditor.setToolTipText("Model reported by the connected agent CLI");
+            localModelEditor.setToolTipText(LOCAL_MODEL_TOOLTIP_LIVE);
         }
         // Seed the selector from the curated catalog so it is never empty; the async CLI listing
         // replaces these entries when the connected agent can report its own models.
         applyLocalModels(resolveFamily(settings), List.of());
         modelListFamily = "";
+        refreshLocalModels = button("Refresh", "Refresh local agent models", event -> {
+            // Bypass refreshLocalModelsIfNeeded's already-fetched guard so a manual click always
+            // asks the CLI again, even when it already reported (or failed to report) for this family.
+            modelListFamily = "";
+            refreshLocalModelsIfNeeded();
+        });
+        ShaftIconButtons.apply(refreshLocalModels, ShaftIcons.RERUN);
         effort = combo("Assistant effort", AssistantModelCatalog.effortLevels().toArray(new String[0]));
         effort.setSelectedItem(normalize(settings.assistantEffort, AssistantModelCatalog.DEFAULT_EFFORT));
         effort.setToolTipText("Reasoning effort requested from the selected model");
@@ -540,6 +553,7 @@ final class ShaftAssistantPanel extends JPanel {
         routeRow.add(cloudProvider);
         routeRow.add(cloudModel);
         routeRow.add(localModel);
+        routeRow.add(refreshLocalModels);
         routeRow.add(effort);
         routeRow.add(allowSourceMutation);
         routeRow.add(verboseAgentOutput);
@@ -844,18 +858,11 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     /**
-     * TODO(#3540 slash-command autocomplete, deferred): a "/" trigger case was NOT added here.
-     * Issue #3428 deliberately retired the slash-command UX (no picker, no "/" popup, no slash
-     * mentions anywhere) in favor of plain-language intents routed by the agent, and
-     * {@code assistantContextSuggestionsAppearOnlyForImplementedTriggers} /
-     * {@code assistantComposerUsesPlainLanguageInputAndModernThinkingIndicator} in
-     * {@code ShaftPanelSetupTest} assert that retirement. Reintroducing a "/" popup would directly
-     * reverse that decision and break both tests, so it needs an explicit product call, not a
-     * silent revival inside an unrelated first-run-welcome change. If reinstated, mirror this exact
+     * Slash-command autocomplete (issue #3540, reversing the #3428 retirement): mirrors the
      * {@code @}/{@code #} mechanism ({@link #bindContextInsertion()}, {@link
      * #showContextSuggestions(char)}, {@link #populateContextPopup(List)}, {@link
-     * #insertContextSuggestion(char, ContextSuggestion)}) with a new {@code case '/'} here backed by
-     * a small static command list, exactly as originally planned.
+     * #insertContextSuggestion(char, ContextSuggestion)}) with the {@code case '/'} below, backed by
+     * {@link AssistantCommand#commandHints(boolean)}.
      */
     private List<ContextSuggestion> contextSuggestions(
             char trigger,
@@ -866,6 +873,9 @@ final class ShaftAssistantPanel extends JPanel {
         }
         if (trigger == '#') {
             return projectContextSuggestions(project, openFileContext);
+        }
+        if (trigger == '/') {
+            return slashCommandSuggestions(expertEnabled());
         }
         return List.of();
     }
@@ -885,6 +895,22 @@ final class ShaftAssistantPanel extends JPanel {
                         "Generate a SHAFT test from "),
                 new ContextSuggestion("@workflow:doctor", "Diagnose my last failed test run"),
                 new ContextSuggestion("@workflow:upgrade", "Upgrade this project to the latest SHAFT"));
+    }
+
+    /**
+     * Command entries for the {@code /} popup: canonical name, summary, and example from each
+     * {@link AssistantCommand.CommandHint}, core-only unless Expert mode is on. Synonyms are folded
+     * into {@code matchText} (never shown) so filtering by an alias, e.g. typing {@code /docs},
+     * still surfaces the {@code /guide} entry.
+     */
+    private static List<ContextSuggestion> slashCommandSuggestions(boolean expertEnabled) {
+        return AssistantCommand.commandHints(expertEnabled).stream()
+                .map(hint -> new ContextSuggestion(
+                        "<html><b>" + hint.canonical() + "</b> — " + hint.summary()
+                                + "<br><small>" + hint.example() + "</small></html>",
+                        hint.canonical() + " ",
+                        hint.canonical() + " " + String.join(" ", hint.synonyms())))
+                .toList();
     }
 
     private static List<ContextSuggestion> projectContextSuggestions(
@@ -909,7 +935,7 @@ final class ShaftAssistantPanel extends JPanel {
             @Override
             public void keyTyped(KeyEvent event) {
                 char trigger = event.getKeyChar();
-                if (trigger == '@' || trigger == '#') {
+                if (trigger == '@' || trigger == '#' || trigger == '/') {
                     SwingUtilities.invokeLater(() -> showContextSuggestions(trigger));
                 }
             }
@@ -936,11 +962,26 @@ final class ShaftAssistantPanel extends JPanel {
         });
     }
 
+    /**
+     * Slash commands are only offered when "/" opens the composer line, matching the Slack / Discord /
+     * CLI convention (issue #3550); a "/" inside a URL or path (e.g. {@code https://}) must not pop the
+     * command menu. "@" and "#" keep firing anywhere, matching their existing in-text mention behaviour.
+     */
+    static boolean slashTriggerAllowed(String textBeforeTrigger) {
+        return textBeforeTrigger == null || textBeforeTrigger.isBlank();
+    }
+
     private void showContextSuggestions(char trigger) {
         hideContextPopup();
+        if (trigger == '/'
+                && !slashTriggerAllowed(prompt.getText().substring(0, Math.max(0, prompt.getCaretPosition() - 1)))) {
+            return;
+        }
         List<ContextSuggestion> suggestions = contextSuggestionsForTest(trigger);
         if (suggestions.isEmpty()) {
-            setStatus(trigger == '#' ? "No project context available" : "No Assistant context available");
+            setStatus(trigger == '#' ? "No project context available"
+                    : trigger == '/' ? "No matching command"
+                    : "No Assistant context available");
             return;
         }
         if (!prompt.isShowing()) {
@@ -1712,6 +1753,12 @@ final class ShaftAssistantPanel extends JPanel {
         boolean success = error == null && result != null && result.success();
         boolean currentStream = streamToken == activeLocalAgentStreamToken;
         boolean captureIntegrationRun = captureIntegrationRunning;
+        // Capture whatever the streaming bubble already rendered before it is cleared below: a plain
+        // Cancel (as opposed to Kill, which finalizes synchronously in stopLocalAgentStreaming) reaches
+        // this method asynchronously once the future completes, and the partial output the user already
+        // saw would otherwise be silently discarded by showAgentCancelled's hardcoded "_Cancelled._".
+        boolean hadPartialOutput = localAgentBubbleRendersContent && localAgentOutput != null && !localAgentOutput.isEmpty();
+        String partialOutput = hadPartialOutput ? localAgentOutput.toString() : "";
         localAgentOutput = null;
         if (currentStream) {
             activeLocalAgentStreamToken = -1;
@@ -1726,7 +1773,7 @@ final class ShaftAssistantPanel extends JPanel {
         if (cancelled) {
             String terminalStep = killed ? "Killed" : "Cancelled";
             addTerminalTimeline(terminalStep);
-            showAgentCancelled(streamToken, currentStream);
+            showAgentCancelled(streamToken, currentStream, killed, partialOutput);
             setStatus(terminalStep);
             return;
         }
@@ -1801,8 +1848,11 @@ final class ShaftAssistantPanel extends JPanel {
         }
     }
 
-    private void showAgentCancelled(int streamToken, boolean currentStream) {
-        String canceledResponse = "_Cancelled._";
+    private void showAgentCancelled(int streamToken, boolean currentStream, boolean killed, String partialOutput) {
+        String label = killed ? "Killed" : "Cancelled";
+        String canceledResponse = partialOutput == null || partialOutput.isBlank()
+                ? "_" + label + "._"
+                : formatLocalAgentStreamingResponse(partialOutput) + "\n\n_" + label + "._ (partial output above)";
         showAgentResponse(streamToken, currentStream, canceledResponse, "");
     }
 
@@ -1896,13 +1946,17 @@ final class ShaftAssistantPanel extends JPanel {
     private void stopLocalAgentStreaming() {
         if (activeLocalAgentStreamToken > 0) {
             killedLocalAgentStreamToken = activeLocalAgentStreamToken;
-            // A killed run never reaches finishLocalAgentResponse, so if the bubble never rendered any
-            // live content (Verbose was off, or no output arrived before the kill), it would otherwise
-            // be left showing the bare "Running local assistant..." header forever. Content that WAS
-            // rendered is left frozen as-is -- it's real output the user already saw.
-            if (!localAgentBubbleRendersContent) {
-                replaceLastTranscriptAndChatState("assistant", "_Cancelled._");
-            }
+            // A killed run never reaches finishLocalAgentResponse (handleKilledOrStaleAgentStream
+            // short-circuits the eventual async completion for this stream token), so this synchronous
+            // path must append the terminal marker itself -- otherwise a bubble that already rendered
+            // live content would be left frozen with no indication the run was killed, and a bubble
+            // that never rendered anything would be left showing the bare "Running local assistant..."
+            // header forever.
+            String finalized = localAgentBubbleRendersContent
+                    ? formatLocalAgentStreamingResponse(localAgentOutput.toString())
+                            + "\n\n_Killed._ (partial output above)"
+                    : "_Killed._";
+            replaceLastTranscriptAndChatState("assistant", finalized);
         }
         activeLocalAgentStreamToken = -1;
         localAgentOutput = null;
@@ -2252,6 +2306,8 @@ final class ShaftAssistantPanel extends JPanel {
         verboseAgentOutput.setEnabled(controlsEnabled);
         localModel.setVisible(localCli);
         localModel.setEnabled(controlsEnabled && localCli);
+        refreshLocalModels.setVisible(localCli);
+        refreshLocalModels.setEnabled(controlsEnabled && localCli);
         effort.setVisible(cloud || localCli);
         effort.setEnabled(controlsEnabled && (cloud || localCli));
         autoCompact.setVisible(localAgent && localCli);
@@ -2288,9 +2344,15 @@ final class ShaftAssistantPanel extends JPanel {
                 : String.valueOf(localModel.getEditor().getItem());
         // The CLI-reported list wins; the curated catalog keeps the selector useful when the CLI
         // cannot list its models (issue #3369).
-        List<String> effectiveModels = models.isEmpty() ? AssistantModelCatalog.localModels(family) : models;
+        localModelListIsFallback = models.isEmpty();
+        List<String> effectiveModels = localModelListIsFallback ? AssistantModelCatalog.localModels(family) : models;
         DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>(effectiveModels.toArray(new String[0]));
         localModel.setModel(model);
+        String tooltip = localModelListIsFallback ? LOCAL_MODEL_TOOLTIP_FALLBACK : LOCAL_MODEL_TOOLTIP_LIVE;
+        localModel.setToolTipText(tooltip);
+        if (localModel.getEditor().getEditorComponent() instanceof JTextComponent localModelEditor) {
+            localModelEditor.setToolTipText(tooltip);
+        }
         if (previousSelection != null && !previousSelection.isBlank()) {
             localModel.setSelectedItem(previousSelection);
         } else if (settings.localModel != null && !settings.localModel.isBlank()) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -89,6 +89,19 @@ final class ShaftMcpSetupPanel extends JPanel {
         void saveKey(String keyName, char[] secret);
     }
 
+    /**
+     * Opens a terminal tab (name, command) with the command pre-typed; injectable for tests.
+     * Returns whether the terminal actually opened (the pre-type was scheduled) — that alone does
+     * not mean the command was actually typed, since the pre-type is async and can still fail after
+     * the widget opens (issue #3551). {@code onOutcome} fires exactly once, off the EDT boundary of
+     * the caller's choosing, with the real outcome once it is known; callers that don't need it may
+     * pass a no-op consumer.
+     */
+    @FunctionalInterface
+    interface TerminalOpener {
+        boolean open(String tabName, String command, Consumer<Boolean> onOutcome);
+    }
+
     private final Project project;
     private final ShaftSettingsState.Settings settings;
     private final Runnable connected;
@@ -176,11 +189,7 @@ final class ShaftMcpSetupPanel extends JPanel {
     /** Runs the real installed-vs-latest shaft-mcp version comparison; injectable for tests. */
     private java.util.function.Supplier<ShaftMcpVersionCheck.Result> mcpVersionChecker = () ->
             ShaftMcpVersionCheck.check(installedShaftMcpVersion(), SetupPrerequisites.knownLatestMcpVersion());
-    /**
-     * Opens a terminal tab (name, command) with the command pre-typed; injectable for tests.
-     * Returns whether the terminal actually opened so status text can say what really happened.
-     */
-    private java.util.function.BiPredicate<String, String> terminalOpener = this::openTerminalWithPreparedCommand;
+    private TerminalOpener terminalOpener = this::openTerminalWithPreparedCommand;
     private Consumer<String> copySink = ShaftMcpSetupPanel::copyToClipboard;
     private Consumer<String> toastSink = this::showToast;
     private Timer toastTimer;
@@ -737,7 +746,7 @@ final class ShaftMcpSetupPanel extends JPanel {
             case NOT_INSTALLED -> "SHAFT MCP is not installed yet.";
             case LATEST_UNKNOWN -> "Couldn't check the latest SHAFT MCP version (offline); installed: "
                     + (mcpVersionCheckResult.installedVersion().isBlank()
-                    ? "none" : mcpVersionCheckResult.installedVersion()) + ".";
+                    ? "none" : mcpVersionCheckResult.installedVersion()) + ". Press Check to retry.";
         };
     }
 
@@ -834,10 +843,14 @@ final class ShaftMcpSetupPanel extends JPanel {
             }
         }
         settings.mcpCommand = command;
+        // Race fix (issue #3551): a check is starting, so readiness must go false for the whole
+        // in-flight window — mcpReady() would otherwise still read true from a previous successful
+        // check while this one is running (mcpCommand is already set above, above the failure and
+        // commandChanged() branches that are the only other places this used to be reset).
+        settings.mcpSetupComplete = false;
         applySelectionToSettings();
         if (command.isBlank()) {
             showAssistError();
-            settings.mcpSetupComplete = false;
             settings.agentGuidanceOptimizationPromptPending = false;
             setStatusText("Run installer, then check again.");
             setDiagnosticText(troubleshootingDetails("Probe failed",
@@ -853,11 +866,20 @@ final class ShaftMcpSetupPanel extends JPanel {
         boolean cloudSelected = cloudFamilySelected();
         String selectedClient = settings.defaultAutobotClient;
         String selectedRuntime = settings.assistantRuntime;
+        String selectedClientLabel = assistantRuntimeLabel();
         ShaftMcpConnectionProbe.test(command, settings, projectRoot()).whenComplete((result, error) -> {
+            boolean phaseOnePassed = error == null && result != null && result.success() && !cloudSelected;
+            if (phaseOnePassed) {
+                // Incremental feedback only (issue #3551): the deep readiness probe below spawns
+                // the client CLI and blocks on Process.waitFor() for up to ~10s with no streaming
+                // hook to attach to, so this is a plain "still working" message posted before that
+                // wait starts — never a claim of real protocol visibility into the CLI's progress.
+                ApplicationManager.getApplication().invokeLater(() -> setStatusText(
+                        "SHAFT MCP connected — asking " + selectedClientLabel
+                                + " to verify access (~10s)..."));
+            }
             ShaftMcpToolResult precomputedReadiness =
-                    error == null && result != null && result.success() && !cloudSelected
-                            ? deepReadinessProbe.test(selectedClient, selectedRuntime)
-                            : null;
+                    phaseOnePassed ? deepReadinessProbe.test(selectedClient, selectedRuntime) : null;
             ApplicationManager.getApplication().invokeLater(
                     () -> showTestResult(result, error, precomputedReadiness));
         });
@@ -1293,7 +1315,7 @@ final class ShaftMcpSetupPanel extends JPanel {
     private void copyUpgradeCommand() {
         String command = upgradeCommand();
         copy(command, "Copied SHAFT upgrade command");
-        boolean opened = terminalOpener.test("SHAFT upgrade", command);
+        boolean opened = terminalOpener.open("SHAFT upgrade", command, typed -> { });
         if (opened) {
             openIntellijTerminal();
         }
@@ -1306,7 +1328,7 @@ final class ShaftMcpSetupPanel extends JPanel {
     private void copyInstallerCommand() {
         String command = installerCommand();
         copy(command, "Copied MCP installer command");
-        boolean opened = terminalOpener.test("SHAFT MCP install", command);
+        boolean opened = terminalOpener.open("SHAFT MCP install", command, typed -> { });
         if (opened) {
             openIntellijTerminal();
         }
@@ -1325,7 +1347,7 @@ final class ShaftMcpSetupPanel extends JPanel {
     private void copyMcpInstallCommand() {
         String command = installerCommandFor(installerArgumentFor(String.valueOf(installerTarget.getSelectedItem())));
         copy(command, "Copied SHAFT MCP install command");
-        boolean opened = terminalOpener.test("SHAFT MCP install", command);
+        boolean opened = terminalOpener.open("SHAFT MCP install", command, typed -> { });
         if (opened) {
             openIntellijTerminal();
         }
@@ -1386,8 +1408,9 @@ final class ShaftMcpSetupPanel extends JPanel {
                 Messages.getWarningIcon()) == Messages.YES;
     }
 
-    private boolean openTerminalWithPreparedCommand(String tabName, String command) {
-        return ShaftTerminalCommands.openWithPreparedCommand(project, projectRoot().toString(), tabName, command);
+    private boolean openTerminalWithPreparedCommand(String tabName, String command, Consumer<Boolean> onOutcome) {
+        return ShaftTerminalCommands.openWithPreparedCommand(
+                project, projectRoot().toString(), tabName, command, onOutcome);
     }
 
     private void openIntellijTerminal() {
@@ -1845,10 +1868,21 @@ final class ShaftMcpSetupPanel extends JPanel {
         styleStepRow(chatRow, complete ? "next" : "wait");
     }
 
+    /**
+     * Human-readable step-state word for tooltips/badges. Kept separate from the internal
+     * {@code state} string keys used by every {@code switch} in this class: {@code "optional"}
+     * used to display as the literal word "Optional", which reads as "not needed" even though it
+     * only ever means "the latest-version lookup was offline" (issue #3551). Only this display
+     * copy changes; the state key itself, and every color/badge switch keyed on it, is untouched.
+     */
+    private static String displayState(String state) {
+        return "optional".equals(state) ? "Offline" : state;
+    }
+
     private static void setStep(JLabel label, JLabel stateLabel, String name, String state) {
         if (label != null) {
             label.setText(name);
-            label.setToolTipText(name + " is " + state);
+            label.setToolTipText(name + " is " + displayState(state));
             label.getAccessibleContext().setAccessibleName(name + " setup step: " + state);
             label.setFont(label.getFont().deriveFont("next".equals(state) || "checking".equals(state)
                     || "optional".equals(state)
@@ -1866,10 +1900,10 @@ final class ShaftMcpSetupPanel extends JPanel {
             case "failed" -> "Failed";
             case "next" -> "Next";
             case "checking" -> "Checking";
-            case "optional" -> "Optional";
+            case "optional" -> "Offline";
             default -> "Waiting";
         });
-        stateLabel.setToolTipText(name + " is " + state);
+        stateLabel.setToolTipText(name + " is " + displayState(state));
         stateLabel.getAccessibleContext().setAccessibleDescription(name + " setup state: " + state);
         stateLabel.setBackground(switch (state) {
             case "done" -> UIManagerColors.doneBackground();
@@ -2036,16 +2070,23 @@ final class ShaftMcpSetupPanel extends JPanel {
      * Every runnable command copied from this setup screen behaves the same way: it lands on the
      * clipboard AND a terminal tab opens with the command pre-typed, so the user only presses
      * Enter. Falls back to clipboard-only messaging when the Terminal plugin is unavailable.
+     * Opening the tab is synchronous, but the pre-type itself is async and can still silently fail
+     * afterward (issue #3551), so the "opened" branch first shows a neutral interim status and only
+     * claims the command was actually pre-typed once {@code onOutcome} confirms it. No
+     * {@code invokeLater} here: the real {@code onOutcome} caller is a {@code javax.swing.Timer}
+     * listener, which the Swing contract already guarantees runs on the EDT.
      */
     private void copyCommandIntoTerminal(String command, String tabName, String copiedMessage) {
         if (command == null || command.isBlank()) {
             return;
         }
         copy(command, copiedMessage);
-        boolean opened = terminalOpener.test(tabName, command);
+        boolean opened = terminalOpener.open(tabName, command, typed -> setStatusText(typed
+                ? copiedMessage + ". Terminal opened with it pre-typed — press Enter there to run it."
+                : "Copied — paste into a terminal (couldn't auto-type it there)."));
         if (opened) {
             openIntellijTerminal();
-            setStatusText(copiedMessage + ". Terminal opened with it pre-typed — press Enter there to run it.");
+            setStatusText(copiedMessage + ". Terminal opened — typing the command...");
         } else {
             setStatusText(copiedMessage + ". Paste it into a terminal to run it.");
         }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftTerminalCommands.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftTerminalCommands.java
@@ -4,6 +4,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 
 import java.lang.reflect.Method;
+import java.util.function.Consumer;
 
 /**
  * Opens an IntelliJ terminal tab and pre-types a command into its shell so the user only has to
@@ -27,9 +28,22 @@ final class ShaftTerminalCommands {
      * Opens a new terminal tab named {@code tabName} in the project root and types {@code command}
      * into it without executing it. Returns {@code true} when the terminal tab was opened and the
      * pre-type was scheduled; {@code false} means the caller should tell the user to paste the
-     * already-copied command manually.
+     * already-copied command manually. This overload never learns whether the async pre-type
+     * actually succeeded; prefer the {@link Consumer} overload when the caller can react to that.
      */
     static boolean openWithPreparedCommand(Project project, String workingDirectory, String tabName, String command) {
+        return openWithPreparedCommand(project, workingDirectory, tabName, command, typed -> { });
+    }
+
+    /**
+     * Same as {@link #openWithPreparedCommand(Project, String, String, String)}, but {@code
+     * onOutcome} is invoked exactly once, off the EDT, once the async pre-type has genuinely
+     * finished: {@code true} only on a real {@code TtyConnector.write()} success, {@code false} when
+     * retries were exhausted or the write threw (issue #3551 — the boolean return here only means
+     * "typing was scheduled", not "the command was typed").
+     */
+    static boolean openWithPreparedCommand(Project project, String workingDirectory, String tabName, String command,
+                                            Consumer<Boolean> onOutcome) {
         if (project == null || command == null || command.isBlank()
                 || ApplicationManager.getApplication() == null) {
             return false;
@@ -41,7 +55,7 @@ final class ShaftTerminalCommands {
             if (widget == null) {
                 return false;
             }
-            scheduleCommandTyping(widget, command);
+            scheduleCommandTyping(widget, command, onOutcome);
             return true;
         } catch (Throwable terminalUnavailable) {
             // Terminal plugin disabled/missing, or its API drifted: the clipboard fallback covers it.
@@ -69,26 +83,32 @@ final class ShaftTerminalCommands {
      * plain jediterm {@code TtyConnector.write(String)} (types WITHOUT pressing Enter — running a
      * just-downloaded script stays the user's explicit decision). A slow shell start no longer
      * silently loses the command: while the TTY connector is missing, typing retries on a short
-     * cadence before giving up to the clipboard fallback.
+     * cadence before giving up to the clipboard fallback. {@code onOutcome} fires exactly once, on
+     * genuine success or genuine failure (retry-exhaustion or a thrown {@code write()}) — never on
+     * a still-retrying attempt (issue #3551).
      */
-    private static void scheduleCommandTyping(Object widget, String command) {
+    private static void scheduleCommandTyping(Object widget, String command, Consumer<Boolean> onOutcome) {
         java.util.concurrent.atomic.AtomicInteger attempts = new java.util.concurrent.atomic.AtomicInteger();
         javax.swing.Timer typeSoon = new javax.swing.Timer(TYPE_RETRY_DELAY_MILLIS, null);
         typeSoon.setInitialDelay(SHELL_READY_DELAY_MILLIS);
         typeSoon.addActionListener(event -> {
             boolean typed = false;
+            boolean writeThrew = false;
             try {
                 Object connector = ttyConnector(widget);
                 if (connector != null) {
                     connector.getClass().getMethod("write", String.class).invoke(connector, command);
                     typed = true;
                 }
-            } catch (Throwable ignored) {
-                // Best effort: the command is already on the clipboard.
-                typed = true;
+            } catch (Throwable failedToWrite) {
+                // The write genuinely failed; report failure below instead of claiming success -
+                // the command is still safely on the clipboard as a fallback.
+                writeThrew = true;
             }
-            if (typed || attempts.incrementAndGet() >= MAX_TYPE_ATTEMPTS) {
+            boolean retriesExhausted = attempts.incrementAndGet() >= MAX_TYPE_ATTEMPTS;
+            if (typed || writeThrew || retriesExhausted) {
                 typeSoon.stop();
+                onOutcome.accept(typed);
             }
         });
         typeSoon.setRepeats(true);

--- a/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftPluginResetServiceTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftPluginResetServiceTest.java
@@ -21,13 +21,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ShaftPluginResetServiceTest {
 
     @Test
-    void factoryDefaultsForceNotSetUpStateEvenThoughBeanDefaultsToComplete() {
+    void factoryDefaultsForceNotSetUpStateMatchingTheBeansOwnDefault() {
         ShaftSettingsState.Settings bareBeanDefaults = new ShaftSettingsState.Settings();
         ShaftSettingsState.Settings factoryDefaults = ShaftSettingsState.factoryDefaults();
 
         assertAll(
-                () -> assertTrue(bareBeanDefaults.mcpSetupComplete,
-                        "Sanity check: the bean's own default is mcpSetupComplete = true"),
+                () -> assertFalse(bareBeanDefaults.mcpSetupComplete,
+                        "Sanity check: the bean's own default is mcpSetupComplete = false (issue #3551)"),
                 () -> assertFalse(factoryDefaults.mcpReady(), "Factory defaults must not be MCP-ready"),
                 () -> assertEquals("", factoryDefaults.mcpCommand),
                 () -> assertFalse(factoryDefaults.mcpSetupComplete,

--- a/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftSettingsConfigurableTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftSettingsConfigurableTest.java
@@ -288,7 +288,8 @@ class ShaftSettingsConfigurableTest {
         assertAll(
                 () -> assertFalse(testMcp.isEnabled(), "button should be disabled while the probe is in flight"),
                 () -> assertEquals("Testing...", testMcp.getToolTipText()),
-                () -> assertEquals(Boolean.TRUE, getField(configurable, "testMcpInFlight")));
+                () -> assertEquals(Boolean.TRUE, getField(configurable, "testMcpInFlight")),
+                () -> assertFalse(settings.mcpSetupComplete, "must not read ready while a check is in flight"));
 
         // Re-entry guard: invoking the real completion-guarded method again while
         // testMcpInFlight is still true must be a no-op, not start a second probe.

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -624,7 +624,7 @@ class ShaftPanelSetupTest {
         AtomicReference<String> terminalTab = new AtomicReference<>();
         AtomicReference<String> terminalCommand = new AtomicReference<>();
         setField(panel, "copySink", (Consumer<String>) copied::set);
-        setField(panel, "terminalOpener", (java.util.function.BiPredicate<String, String>) (tab, command) -> {
+        setField(panel, "terminalOpener", (ShaftMcpSetupPanel.TerminalOpener) (tab, command, onOutcome) -> {
             terminalTab.set(tab);
             terminalCommand.set(command);
             return true;
@@ -658,7 +658,7 @@ class ShaftPanelSetupTest {
         List<String> copied = new ArrayList<>();
         List<String> terminalCommands = new ArrayList<>();
         setField(panel, "copySink", (Consumer<String>) copied::add);
-        setField(panel, "terminalOpener", (java.util.function.BiPredicate<String, String>) (tab, command) -> {
+        setField(panel, "terminalOpener", (ShaftMcpSetupPanel.TerminalOpener) (tab, command, onOutcome) -> {
             terminalCommands.add(command);
             return true;
         });
@@ -679,6 +679,59 @@ class ShaftPanelSetupTest {
                 () -> assertEquals(2, terminalCommands.size()),
                 () -> assertTrue(terminalCommands.get(0).contains("mvn"), terminalCommands.get(0)),
                 () -> assertEquals("java -version", terminalCommands.get(1)));
+    }
+
+    @Test
+    void copyCommandIntoTerminalShowsInterimStatusThenReconcilesOnAFailedPreType() throws Exception {
+        // The pre-type is async (issue #3551): opening the tab alone must not yet claim success.
+        // No ApplicationManager/EDT plumbing is needed here since copyCommandIntoTerminal calls
+        // onOutcome directly (the real javax.swing.Timer caller already runs on the EDT).
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
+        });
+        AtomicReference<Consumer<Boolean>> capturedOutcome = new AtomicReference<>();
+        setField(panel, "copySink", (Consumer<String>) text -> {
+        });
+        setField(panel, "terminalOpener", (ShaftMcpSetupPanel.TerminalOpener) (tab, command, onOutcome) -> {
+            capturedOutcome.set(onOutcome);
+            return true;
+        });
+        setField(panel, "diagnosticCommand", "java -version");
+        JButton diagnostic = findByAccessibleName(panel, "Copy setup diagnostic command", JButton.class);
+        diagnostic.setEnabled(true);
+
+        diagnostic.doClick();
+
+        assertAll(
+                () -> assertTrue(containsText(panel, "Terminal opened — typing the command..."),
+                        "opening the tab must not yet claim the command was typed"),
+                () -> assertNotNull(capturedOutcome.get(), "the outcome callback must be captured"));
+
+        capturedOutcome.get().accept(Boolean.FALSE);
+
+        assertTrue(containsText(panel, "Copied — paste into a terminal (couldn't auto-type it there)."),
+                "a failed async pre-type must retract the earlier 'pre-typed' framing");
+    }
+
+    @Test
+    void copyCommandIntoTerminalConfirmsPreTypeSuccessOnceTheOutcomeArrives() throws Exception {
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
+        });
+        AtomicReference<Consumer<Boolean>> capturedOutcome = new AtomicReference<>();
+        setField(panel, "copySink", (Consumer<String>) text -> {
+        });
+        setField(panel, "terminalOpener", (ShaftMcpSetupPanel.TerminalOpener) (tab, command, onOutcome) -> {
+            capturedOutcome.set(onOutcome);
+            return true;
+        });
+        setField(panel, "diagnosticCommand", "java -version");
+        JButton diagnostic = findByAccessibleName(panel, "Copy setup diagnostic command", JButton.class);
+        diagnostic.setEnabled(true);
+
+        diagnostic.doClick();
+        capturedOutcome.get().accept(Boolean.TRUE);
+
+        assertTrue(containsText(panel, "Terminal opened with it pre-typed — press Enter there to run it."),
+                "a genuine write() success must confirm the command really was pre-typed");
     }
 
     @Test
@@ -749,14 +802,17 @@ class ShaftPanelSetupTest {
                 () -> assertTrue(
                         findByAccessibleName(panel, "Copy SHAFT MCP install command", JButton.class).isVisible()));
 
-        // Offline (latest unknown) is a neutral, non-blocking "Optional" badge — never "Failed"
-        // and never disables the rest of setup (issue #3538).
+        // Offline (latest unknown) is a neutral, non-blocking badge — never "Failed" and never
+        // disables the rest of setup (issue #3538); it reads as "Offline" with a retry callout,
+        // not "Optional"/"not needed" (issue #3551).
         setField(panel, "mcpVersionChecker", (java.util.function.Supplier<ShaftMcpVersionCheck.Result>) () ->
                 new ShaftMcpVersionCheck.Result(ShaftMcpVersionCheck.State.LATEST_UNKNOWN, "10.3.20260703", ""));
         clickAccessible(panel, "Check SHAFT MCP version");
         assertAll(
-                () -> assertEquals("Optional", mcpVersionState.getText()),
+                () -> assertEquals("Offline", mcpVersionState.getText()),
                 () -> assertTrue(mcpVersionDetail.getText().contains("offline")),
+                () -> assertTrue(mcpVersionDetail.getText().contains("Press Check to retry."),
+                        mcpVersionDetail.getText()),
                 () -> assertTrue(mcpVersionDetail.getText().contains("10.3.20260703")),
                 () -> assertTrue(
                         findByAccessibleName(panel, "Copy SHAFT MCP install command", JButton.class).isVisible()),
@@ -1132,6 +1188,33 @@ class ShaftPanelSetupTest {
                 () -> assertTrue(effort.isVisible()),
                 () -> assertEquals("DEFAULT", effort.getSelectedItem()),
                 () -> assertTrue(effort.getItemCount() >= 4));
+    }
+
+    @Test
+    void assistantLocalModelTooltipReflectsFallbackWhenCliReportsNoModels() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        JComboBox<?> localModel = findByAccessibleName(panel, "Assistant local agent model", JComboBox.class);
+
+        applyLocalModels(panel, "CODEX", List.of());
+        assertTrue(localModel.getToolTipText().contains("Fallback model list"), localModel.getToolTipText());
+
+        applyLocalModels(panel, "CODEX", List.of("o1", "o1-mini"));
+        assertFalse(localModel.getToolTipText().contains("Fallback model list"), localModel.getToolTipText());
+    }
+
+    @Test
+    void assistantRefreshLocalModelsButtonIsVisibleForLocalCliAndResetsModelListFamily() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        JButton refresh = findByAccessibleName(panel, "Refresh local agent models", JButton.class);
+
+        assertNotNull(refresh);
+        assertTrue(refresh.isVisible(), "refresh should be visible for the default local CLI route");
+
+        applyLocalModels(panel, "CODEX", List.of("o1"));
+        assertEquals("CODEX", getField(panel, "modelListFamily"));
+
+        clickAccessible(panel, "Refresh local agent models");
+        assertEquals("", getField(panel, "modelListFamily"));
     }
 
     @Test
@@ -2110,6 +2193,9 @@ class ShaftPanelSetupTest {
         assertAll(
                 () -> assertTrue(killed.get()),
                 () -> assertTrue(transcriptMarkdown(panel).contains("visible before kill")),
+                () -> assertTrue(transcriptMarkdown(panel).contains("Killed"),
+                        "a killed run with rendered content must still show a terminal marker: "
+                                + transcriptMarkdown(panel)),
                 () -> assertFalse(transcriptMarkdown(panel).contains("late output after kill")));
     }
 
@@ -2166,7 +2252,7 @@ class ShaftPanelSetupTest {
     }
 
     @Test
-    void assistantKilledNonVerboseRunReplacesBarePlaceholderWithCancelled() throws Exception {
+    void assistantKilledNonVerboseRunReplacesBarePlaceholderWithKilled() throws Exception {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
         AtomicBoolean killed = new AtomicBoolean();
         ShaftMcpInvocation invocation = new ShaftMcpInvocation(
@@ -2184,7 +2270,7 @@ class ShaftPanelSetupTest {
         String markdown = transcriptMarkdown(panel);
         assertAll(
                 () -> assertTrue(killed.get()),
-                () -> assertTrue(markdown.contains("Cancelled"),
+                () -> assertTrue(markdown.contains("Killed"),
                         "A killed non-verbose run must not leave the bare placeholder stuck forever: " + markdown),
                 () -> assertFalse(markdown.contains("Running local assistant"), markdown));
     }
@@ -2430,6 +2516,33 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void assistantCancelAfterPartialStreamedOutputPreservesPartialAndShowsCancelled() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        JCheckBox verbose = findByAccessibleName(panel, "Show verbose agent output", JCheckBox.class);
+        verbose.setSelected(true);
+        ShaftMcpInvocation invocation = new ShaftMcpInvocation(
+                new CompletableFuture<>(), () -> {
+        }, () -> {
+        });
+        setField(panel, "currentInvocation", invocation);
+        panel.setRunning(true, "Thinking...");
+        appendStreamingLocalAgentBubble(panel, 301);
+        appendLocalAgentOutput(panel, 301, "partial answer streamed before cancel");
+
+        // A single cancel click only requests cancellation -- it must not escalate to a kill.
+        cancelOrKillCurrent(panel);
+        assertEquals(false, getField(panel, "killRequested"));
+
+        showAgentResult(panel, 301, null, new CancellationException("cancelled"));
+
+        String markdown = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(markdown.contains("partial answer streamed before cancel"), markdown),
+                () -> assertTrue(markdown.contains("Cancelled"), markdown),
+                () -> assertFalse(markdown.contains("Killed"), markdown));
+    }
+
+    @Test
     void assistantKillRequestTerminalEntryIsKilledNotCancelled() throws Exception {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
         JList<?> timeline = findByAccessibleName(panel, "Assistant execution timeline", JList.class);
@@ -2480,10 +2593,35 @@ class ShaftPanelSetupTest {
                 () -> assertTrue(workflowSuggestions.stream()
                         .noneMatch(suggestion -> suggestion.insertion().startsWith("/")),
                         "workflow insertions must be plain language"),
-                // The '/' trigger is retired along with the slash-command UX.
-                () -> assertTrue(slashSuggestions.isEmpty()),
+                // The '/' trigger reinstates slash-command autocomplete (issue #3540): core commands
+                // only by default (Expert mode off), backed by AssistantCommand's command registry.
+                () -> assertFalse(slashSuggestions.isEmpty(), "slash commands should be suggested"),
+                () -> assertTrue(slashSuggestions.stream().anyMatch(
+                        suggestion -> suggestion.insertion().equals("/record ")
+                                && suggestion.label().contains("/record")
+                                && suggestion.label().contains("Record web actions")),
+                        slashSuggestions.toString()),
+                () -> assertTrue(slashSuggestions.stream()
+                        .noneMatch(suggestion -> suggestion.label().contains("/guardrails")),
+                        "expert-only commands must stay hidden when Expert mode is off: " + slashSuggestions),
                 () -> assertTrue(fileSuggestions.isEmpty()),
                 () -> assertTrue(unsupportedSuggestions.isEmpty()));
+    }
+
+    @Test
+    void slashCommandPopupOnlyTriggersAtTheStartOfTheComposerLine() {
+        // A leading "/" is a command; a "/" inside a URL/path (https://, a/b) must not pop the menu
+        // (issue #3550). "@"/"#" keep firing anywhere, so this guard is slash-only.
+        assertAll(
+                () -> assertTrue(ShaftAssistantPanel.slashTriggerAllowed(""),
+                        "an empty composer must offer commands"),
+                () -> assertTrue(ShaftAssistantPanel.slashTriggerAllowed("   "),
+                        "leading whitespace still counts as line start"),
+                () -> assertTrue(ShaftAssistantPanel.slashTriggerAllowed(null)),
+                () -> assertFalse(ShaftAssistantPanel.slashTriggerAllowed("https:/"),
+                        "a slash inside a URL is not a command"),
+                () -> assertFalse(ShaftAssistantPanel.slashTriggerAllowed("open the "),
+                        "a slash mid-sentence is not a command"));
     }
 
     @Test
@@ -4475,10 +4613,16 @@ class ShaftPanelSetupTest {
 
     private static void showAgentResult(ShaftAssistantPanel panel, int streamToken, ShaftMcpToolResult result)
             throws Exception {
+        showAgentResult(panel, streamToken, result, null);
+    }
+
+    private static void showAgentResult(
+            ShaftAssistantPanel panel, int streamToken, ShaftMcpToolResult result, Throwable error)
+            throws Exception {
         Method showResult = ShaftAssistantPanel.class.getDeclaredMethod(
                 "showAgentResult", int.class, ShaftMcpToolResult.class, Throwable.class);
         showResult.setAccessible(true);
-        showResult.invoke(panel, streamToken, result, null);
+        showResult.invoke(panel, streamToken, result, error);
     }
 
     private static void appendStreamingLocalAgentBubble(ShaftAssistantPanel panel, int streamToken) throws Exception {
@@ -4497,6 +4641,13 @@ class ShaftPanelSetupTest {
         Method method = ShaftAssistantPanel.class.getDeclaredMethod("cancelOrKillCurrent");
         method.setAccessible(true);
         method.invoke(panel);
+    }
+
+    private static void applyLocalModels(ShaftAssistantPanel panel, String family, List<String> models)
+            throws Exception {
+        Method method = ShaftAssistantPanel.class.getDeclaredMethod("applyLocalModels", String.class, List.class);
+        method.setAccessible(true);
+        method.invoke(panel, family, models);
     }
 
     private static void setField(Object target, String name, Object value) throws Exception {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
@@ -13,10 +13,13 @@ import org.junit.jupiter.api.Test;
 import javax.imageio.ImageIO;
 import javax.swing.AbstractButton;
 import javax.swing.DefaultListModel;
+import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
+import javax.swing.JMenuItem;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.plaf.ColorUIResource;
@@ -30,6 +33,7 @@ import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -125,6 +129,8 @@ class ShaftPluginScreenshotRendererTest {
         Path assistantProgressMilestonesScreenshot = outputPath.resolve("intellij-plugin-assistant-progress-milestones.png");
         Path assistantFailureRecoveryCardScreenshot = outputPath.resolve("intellij-plugin-assistant-failure-recovery-card.png");
         Path assistantApprovalPromptScreenshot = outputPath.resolve("intellij-plugin-assistant-approval-prompt.png");
+        Path assistantModelFallbackScreenshot = outputPath.resolve("intellij-plugin-assistant-model-fallback.png");
+        Path assistantSlashCommandsScreenshot = outputPath.resolve("intellij-plugin-assistant-slash-commands.png");
         Path toolsHumanizedDoctorCardScreenshot = outputPath.resolve("intellij-plugin-tools-humanized-doctor-card.png");
         Path assistantDefaultModePrefillScreenshot = outputPath.resolve("intellij-plugin-assistant-default-mode-prefill.png");
         Path mcpSetupPostSetupScreenshot = outputPath.resolve("intellij-plugin-mcp-setup-post-setup.png");
@@ -146,6 +152,7 @@ class ShaftPluginScreenshotRendererTest {
         Path mcpSetupNarrowDarkScreenshot = outputPath.resolve("intellij-plugin-mcp-setup-narrow-dark.png");
         Path mcpSetupSuccessScreenshot = outputPath.resolve("intellij-plugin-mcp-setup-success.png");
         Path mcpSetupErrorScreenshot = outputPath.resolve("intellij-plugin-mcp-setup-error-dark.png");
+        Path mcpSetupOfflineScreenshot = outputPath.resolve("intellij-plugin-mcp-setup-offline.png");
         Path settingsScreenshot = outputPath.resolve("intellij-plugin-settings.png");
         Path settingsDarkScreenshot = outputPath.resolve("intellij-plugin-settings-dark.png");
         Path mcpGuideScreenshot = outputPath.resolve("intellij-plugin-mcp-guide.png");
@@ -159,6 +166,8 @@ class ShaftPluginScreenshotRendererTest {
         write(assistantProgressMilestonesScreenshot, renderAssistantProgressMilestones(LIGHT_THEME, false));
         write(assistantFailureRecoveryCardScreenshot, renderAssistantFailureRecoveryCard(LIGHT_THEME, false));
         write(assistantApprovalPromptScreenshot, renderApprovalPrompt(LIGHT_THEME, false));
+        write(assistantModelFallbackScreenshot, renderAssistantModelFallback(LIGHT_THEME, false));
+        write(assistantSlashCommandsScreenshot, renderAssistantSlashCommands(LIGHT_THEME, false));
         write(toolsHumanizedDoctorCardScreenshot, renderToolsHumanizedDoctorCard(LIGHT_THEME, false));
         write(assistantDefaultModePrefillScreenshot, renderAssistantDefaultModePrefill(LIGHT_THEME, false));
         write(mcpSetupPostSetupScreenshot, renderPostSetupSettings(LIGHT_THEME, false));
@@ -180,6 +189,7 @@ class ShaftPluginScreenshotRendererTest {
         write(mcpSetupNarrowDarkScreenshot, renderSetup(DARK_THEME, true, NARROW_WIDTH, HEIGHT));
         write(mcpSetupSuccessScreenshot, renderSetupSuccess(LIGHT_THEME, false));
         write(mcpSetupErrorScreenshot, renderSetupError(DARK_THEME, true));
+        write(mcpSetupOfflineScreenshot, renderSetupMcpOffline(LIGHT_THEME, false));
         write(settingsScreenshot, renderSettings(LIGHT_THEME, false));
         write(settingsDarkScreenshot, renderSettings(DARK_THEME, true));
         write(mcpGuideScreenshot, renderToolWindow(9, "Guide", LIGHT_THEME, false));
@@ -195,6 +205,8 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertTrue(Files.size(assistantFailureRecoveryCardScreenshot) > 0,
                         assistantFailureRecoveryCardScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantApprovalPromptScreenshot) > 0, assistantApprovalPromptScreenshot + " should be non-empty"),
+                () -> assertTrue(Files.size(assistantModelFallbackScreenshot) > 0, assistantModelFallbackScreenshot + " should be non-empty"),
+                () -> assertTrue(Files.size(assistantSlashCommandsScreenshot) > 0, assistantSlashCommandsScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(toolsHumanizedDoctorCardScreenshot) > 0, toolsHumanizedDoctorCardScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantDefaultModePrefillScreenshot) > 0, assistantDefaultModePrefillScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(mcpSetupPostSetupScreenshot) > 0, mcpSetupPostSetupScreenshot + " should be non-empty"),
@@ -216,6 +228,7 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertTrue(Files.size(mcpSetupNarrowDarkScreenshot) > 0, mcpSetupNarrowDarkScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(mcpSetupSuccessScreenshot) > 0, mcpSetupSuccessScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(mcpSetupErrorScreenshot) > 0, mcpSetupErrorScreenshot + " should be non-empty"),
+                () -> assertTrue(Files.size(mcpSetupOfflineScreenshot) > 0, mcpSetupOfflineScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(settingsScreenshot) > 0, settingsScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(settingsDarkScreenshot) > 0, settingsDarkScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(mcpGuideScreenshot) > 0, mcpGuideScreenshot + " should be non-empty"),
@@ -228,6 +241,7 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertDimensions(assistantProgressMilestonesScreenshot),
                 () -> assertDimensions(assistantFailureRecoveryCardScreenshot),
                 () -> assertDimensions(assistantApprovalPromptScreenshot),
+                () -> assertDimensions(assistantModelFallbackScreenshot),
                 () -> assertDimensions(toolsHumanizedDoctorCardScreenshot),
                 () -> assertDimensions(assistantDefaultModePrefillScreenshot),
                 () -> assertDimensions(mcpSetupPostSetupScreenshot),
@@ -249,6 +263,7 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertDimensions(mcpSetupNarrowDarkScreenshot, NARROW_WIDTH, HEIGHT),
                 () -> assertDimensions(mcpSetupSuccessScreenshot),
                 () -> assertDimensions(mcpSetupErrorScreenshot),
+                () -> assertDimensions(mcpSetupOfflineScreenshot),
                 () -> assertDimensions(settingsScreenshot),
                 () -> assertDimensions(settingsDarkScreenshot),
                 () -> assertDimensions(mcpGuideScreenshot),
@@ -588,6 +603,81 @@ class ShaftPluginScreenshotRendererTest {
     }
 
     /**
+     * Renders the Assistant local-model refresh control in its fallback state (issue #3551): when
+     * the connected local CLI reports no models, {@code applyLocalModels} falls back to the curated
+     * {@link AssistantModelCatalog} list and sets {@code localModelListIsFallback}, and the "Refresh
+     * local agent models" button stays visible so the user can retry the live CLI listing. {@code
+     * defaultSettings()} already normalizes to provider=LOCAL/runtime=CLI, so the panel starts in
+     * the local-CLI configuration this control only appears in; the empty live list is then forced
+     * through the same {@code applyLocalModels} seam production uses after a real CLI listing call
+     * (via reflection, since it is private), rather than racing the panel's own async CLI probe
+     * that already runs once at construction time.
+     */
+    private static BufferedImage renderAssistantModelFallback(String lookAndFeelClassName, boolean dark)
+            throws InterruptedException, InvocationTargetException {
+        AtomicReference<BufferedImage> image = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            configureLookAndFeel(lookAndFeelClassName, dark);
+            ShaftAssistantChatState chatState = new ShaftAssistantChatState();
+            ShaftAssistantPanel component = new ShaftAssistantPanel(screenshotProject(), defaultSettings(), chatState,
+                    () -> {
+                    });
+            invokeApplyLocalModels(component, "CODEX", List.of());
+            component.setSize(new Dimension(WIDTH, HEIGHT));
+            component.setPreferredSize(new Dimension(WIDTH, HEIGHT));
+            SwingUtilities.updateComponentTreeUI(component);
+            component.doLayout();
+            layout(component, !dark);
+            image.set(render(component, WIDTH, HEIGHT));
+        });
+        return image.get();
+    }
+
+    private static void invokeApplyLocalModels(ShaftAssistantPanel component, String family, List<String> models) {
+        try {
+            Method method = ShaftAssistantPanel.class.getDeclaredMethod("applyLocalModels", String.class, List.class);
+            method.setAccessible(true);
+            method.invoke(component, family, models);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Unable to apply the local-model fallback state", exception);
+        }
+    }
+
+    /**
+     * BEST-EFFORT representative shot of the "/" command popup (issue #3550). A live {@link
+     * JPopupMenu} never paints when captured off-screen through {@link #render}: {@code
+     * JPopupMenu#show} backs it with a heavyweight popup window this headless harness never
+     * realizes, so the menu is built and populated exactly as {@code populateContextPopup} does --
+     * one {@link JMenuItem} per {@link AssistantCommand.CommandHint} from {@code
+     * AssistantCommand.commandHints(false)} (core-only, matching default non-Expert mode) -- and
+     * rendered standalone, without ever calling {@code show}. The interactive filter/select
+     * behaviour behind this popup is already covered by {@code ShaftPanelSetupTest}; this shot is
+     * evidence of the command list's contents only.
+     */
+    private static BufferedImage renderAssistantSlashCommands(String lookAndFeelClassName, boolean dark)
+            throws InterruptedException, InvocationTargetException {
+        AtomicReference<BufferedImage> image = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            configureLookAndFeel(lookAndFeelClassName, dark);
+            JPopupMenu popup = new JPopupMenu("Assistant context suggestions");
+            popup.getAccessibleContext().setAccessibleName("Assistant context suggestions");
+            for (AssistantCommand.CommandHint hint : AssistantCommand.commandHints(false)) {
+                JMenuItem item = new JMenuItem("<html><b>" + hint.canonical() + "</b> — " + hint.summary()
+                        + "<br><small>" + hint.example() + "</small></html>");
+                item.getAccessibleContext().setAccessibleName("Insert " + hint.canonical());
+                popup.add(item);
+            }
+            SwingUtilities.updateComponentTreeUI(popup);
+            Dimension size = popup.getPreferredSize();
+            popup.setSize(size);
+            popup.doLayout();
+            layout(popup, !dark);
+            image.set(render(popup, Math.max(1, size.width), Math.max(1, size.height)));
+        });
+        return image.get();
+    }
+
+    /**
      * Renders the Tools panel's humanized doctor card (issue #3552): a {@code
      * doctor_analyze_failed_allour} result routed through {@link AssistantMarkdown} instead of raw
      * pretty-printed JSON, with the "View raw JSON" toggle button visible (still one click away).
@@ -842,6 +932,77 @@ class ShaftPluginScreenshotRendererTest {
             image.set(render(component, WIDTH, HEIGHT));
         });
         return image.get();
+    }
+
+    /**
+     * Renders the SHAFT MCP version wizard-step row in its Offline state (issue #3551): when the
+     * "latest" half of a {@link ShaftMcpVersionCheck} can't be resolved (no network), the row shows
+     * a neutral "Offline" badge with the currently-installed version and a "Press Check to retry."
+     * callout -- never a red "Failed", and never blocking the rest of setup -- matching {@code
+     * ShaftPanelSetupTest#setupPanelMcpVersionStepReflectsRealVersionCheck}. Reproduced the same way
+     * that test does: swap in a fake {@code mcpVersionChecker} and click "Check SHAFT MCP version".
+     */
+    private static BufferedImage renderSetupMcpOffline(String lookAndFeelClassName, boolean dark)
+            throws InterruptedException, InvocationTargetException {
+        AtomicReference<BufferedImage> image = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            configureLookAndFeel(lookAndFeelClassName, dark);
+            ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
+            settings.mcpCommand = "\"java\" \"@target/shaft-mcp.args\"";
+            ShaftMcpSetupPanel component = new ShaftMcpSetupPanel(screenshotProject(), settings,
+                    () -> {
+                    });
+            setField(component, "mcpVersionChecker",
+                    (java.util.function.Supplier<ShaftMcpVersionCheck.Result>) () -> new ShaftMcpVersionCheck.Result(
+                            ShaftMcpVersionCheck.State.LATEST_UNKNOWN, "10.3.20260703", ""));
+            clickAccessible(component, "Check SHAFT MCP version");
+            component.setSize(new Dimension(WIDTH, HEIGHT));
+            component.setPreferredSize(new Dimension(WIDTH, HEIGHT));
+            SwingUtilities.updateComponentTreeUI(component);
+            component.doLayout();
+            layout(component, !dark);
+
+            // Verify setup panel labels are not cropped and backgrounds are continuous
+            verifySetupPanelRendering(component);
+
+            image.set(render(component, WIDTH, HEIGHT));
+        });
+        return image.get();
+    }
+
+    private static void setField(Object target, String name, Object value) {
+        try {
+            Field field = target.getClass().getDeclaredField(name);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Unable to set field " + name, exception);
+        }
+    }
+
+    private static void clickAccessible(Component component, String accessibleName) {
+        JButton button = findByAccessibleName(component, accessibleName, JButton.class);
+        if (button == null) {
+            throw new IllegalStateException("No button found with accessible name: " + accessibleName);
+        }
+        button.doClick();
+    }
+
+    private static <T extends JComponent> T findByAccessibleName(
+            Component component, String accessibleName, Class<T> type) {
+        if (type.isInstance(component)
+                && accessibleName.equals(((JComponent) component).getAccessibleContext().getAccessibleName())) {
+            return type.cast(component);
+        }
+        if (component instanceof Container container) {
+            for (Component child : container.getComponents()) {
+                T found = findByAccessibleName(child, accessibleName, type);
+                if (found != null) {
+                    return found;
+                }
+            }
+        }
+        return null;
     }
 
     private static JComponent settingsPanel() {


### PR DESCRIPTION
Closes the final two children of the **#3553** IntelliJ UX program (`shaft-intellij`). Both harden *existing* functionality; no new engine surface. Verified on JDK21: `compileTestJava` + **260** targeted tests green.

## #3550 — Assistant composer UX
- **`/` slash-command autocomplete** backed by the existing `AssistantCommand` command registry (reuses the `@`/`#` popup + in-place filter mechanism; synonyms fold into match text). Gated to **line-start** so a `/` inside a URL/path (`https://`) never pops the command menu — the standard Slack/Discord/CLI convention. Flips the two tests that asserted the deliberate #3428 retirement (this is the tracked #3540 reversal).
- **Kill/Cancel finalization** — a killed stream now always ends the bubble in a terminal `_Killed._` state (no more frozen bubble), and a graceful cancel after partial streaming **preserves** the partial output instead of replacing it with a bare `_Cancelled._`.
- **Model-catalog freshness** — the local-model combo labels a static fallback list via tooltip and exposes a **refresh** button that bypasses the already-fetched guard.

## #3551 — Onboarding trust
- **Readiness race fix** (the ticket's stated static-default cause was wrong): `mcpReady()` already gates on a non-blank command, so the real defect was that `testConnection()` set `mcpCommand` synchronously *before* the ~10s async probe, leaving `mcpReady()==true` during the in-flight window. Now `mcpSetupComplete` is set `false` at check-start (zero-migration-risk); the bean default is also flipped `true`→`false` with a documented one-time self-healing re-check for pre-existing users.
- **Incremental "Check now" feedback** between the two probe phases so the ~10s deep check never looks hung.
- **Offline latest-version rows** read as **"Offline"** with a *"Press Check to retry."* callout instead of the misleading "Optional" badge.
- **Terminal fallback signal** — the async pre-type now reports its real outcome: a failed auto-type shows *"Copied — paste into a terminal (couldn't auto-type it there)."* instead of silently claiming success (threaded a `Consumer<Boolean>` outcome through `ShaftTerminalCommands`).

## Evidence
Screenshot-renderer cases added to `ShaftPluginScreenshotRendererTest` (rendered + visually verified locally, clean-state via `-Dshaft.intellij.mcp.applicationDataRoot=`/`bootstrapRoot=`):
- `intellij-plugin-mcp-setup-offline` — the **Offline** MCP-version badge + retry copy.
- `intellij-plugin-assistant-slash-commands` — the `/` command popup listing the core commands with samples.
- `intellij-plugin-assistant-model-fallback` — the local-model combo on the fallback list with the refresh button visible.

No MCP-tool-manifest/catalog sync needed (no `@Tool` surface changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)