### PR TITLE
feat: domain-consistent accessibility evidence card (#3532 E)

### DIFF
--- a/hs_err_pid3316.log
+++ b/hs_err_pid3316.log
@@ -1,0 +1,945 @@
+#
+# A fatal error has been detected by the Java Runtime Environment:
+#
+#  EXCEPTION_ACCESS_VIOLATION (0xc0000005) at pc=0x00007ffb9c82dd07, pid=3316, tid=25720
+#
+# JRE version: OpenJDK Runtime Environment (25.0.1+8) (build 25.0.1+8-27)
+# Java VM: OpenJDK 64-Bit Server VM (25.0.1+8-27, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, windows-amd64)
+# Problematic frame:
+# V  [jvm.dll+0x26dd07]
+#
+# No core dump will be written. Minidumps are not enabled by default on client versions of Windows
+#
+# If you would like to submit a bug report, please visit:
+#   https://bugreport.java.com/bugreport/crash.jsp
+#
+
+---------------  S U M M A R Y ------------
+
+Command Line: --add-opens=java.base/java.lang=ALL-UNNAMED --enable-native-access=ALL-UNNAMED -XX:+IgnoreUnrecognizedVMOptions --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8 -Dclassworlds.conf=C:/apache-maven-3.9.10/bin/m2.conf -Dmaven.home=C:/apache-maven-3.9.10 -Dlibrary.jansi.path=C:/apache-maven-3.9.10/lib/jansi-native -Dmaven.multiModuleProjectDirectory=C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE org.codehaus.plexus.classworlds.launcher.Launcher -q -pl shaft-engine test -Dtest=WebDriverElementValidationsBuilderAriaSnapshotUnitTest,AriaSnapshotHelperUnitTest -DheadlessExecution=true -Dgpg.skip=true -Dallure.skip=true
+
+Host: AMD Ryzen 9 5900HS with Radeon Graphics        , 16 cores, 23G,  Windows 11 , 64 bit Build 26100 (10.0.26100.8737)
+Time: Tue Jul 14 21:22:00 2026 Egypt Summer Time elapsed time: 8.911645 seconds (0d 0h 0m 8s)
+
+---------------  T H R E A D  ---------------
+
+Current thread (0x0000015224e04e20):  JavaThread "C2 CompilerThread4" daemon [_thread_in_vm, id=25720, stack(0x00000036b9900000,0x00000036b9a00000) (1024K)]
+
+
+Current CompileTask:
+C2:8911 11022       4       jdk.internal.classfile.impl.StackMapGenerator::processBlock (2767 bytes)
+
+Stack: [0x00000036b9900000,0x00000036b9a00000],  sp=0x00000036b99fd420,  free space=1013k
+Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
+V  [jvm.dll+0x26dd07]  (no source info available)
+V  [jvm.dll+0x26cad3]  (no source info available)
+V  [jvm.dll+0x2670a8]  (no source info available)
+V  [jvm.dll+0x2bf2e7]  (no source info available)
+V  [jvm.dll+0x237b60]  (no source info available)
+V  [jvm.dll+0x2cfb56]  (no source info available)
+V  [jvm.dll+0x2cddd5]  (no source info available)
+V  [jvm.dll+0x48e6d1]  (no source info available)
+V  [jvm.dll+0x906a0d]  (no source info available)
+V  [jvm.dll+0x7a5135]  (no source info available)
+C  [ucrtbase.dll+0x2cd30]  (no source info available)
+C  [KERNEL32.DLL+0x2e957]  (no source info available)
+C  [ntdll.dll+0xaad6c]  (no source info available)
+
+
+siginfo: EXCEPTION_ACCESS_VIOLATION (0xc0000005), reading address 0x00000000000000a0
+
+
+Registers:
+RAX=0x0000000000000000, RBX=0x0000000000000008, RCX=0x00000152253face8, RDX=0x00000152253face8
+RSP=0x00000036b99fd420, RBP=0x0000000000000000, RSI=0x00000152253facd8, RDI=0x0000000000000000
+R8 =0x0000000000000004, R9 =0x00000152246d4030, R10=0x0000000000000001, R11=0x00000036b99fd3f8
+R12=0x0000015224ce2530, R13=0x0000000000000000, R14=0x00000152253facd8, R15=0x00000152253face8
+RIP=0x00007ffb9c82dd07, EFLAGS=0x0000000000010202
+
+XMM[0]=0x0000000000000000 0x00000000054efefa
+XMM[1]=0x000001521f57f630 0x000001521f57f630
+XMM[2]=0x000001521f5a4c20 0x000001521f5a4c20
+XMM[3]=0x0000000000000000 0x0000000000000000
+XMM[4]=0x0000000000000000 0x0000000000000000
+XMM[5]=0x000001521f580998 0x000001521f580998
+XMM[6]=0x0000000000000000 0x0000000000000000
+XMM[7]=0x0000000000000000 0x0000000000000000
+XMM[8]=0x0000000000000000 0x0000000000000000
+XMM[9]=0x0000000000000000 0x0000000000000000
+XMM[10]=0x0000000000000000 0x0000000000000000
+XMM[11]=0x0000000000000000 0x0000000000000000
+XMM[12]=0x0000000000000000 0x0000000000000000
+XMM[13]=0x0000000000000000 0x0000000000000000
+XMM[14]=0x0000000000000000 0x0000000000000000
+XMM[15]=0x0000000000000000 0x0000000000000000
+  MXCSR=0x00001fa0
+
+
+Register to memory mapping:
+
+RAX=0x0 is null
+RBX=0x0000000000000008 is an unknown value
+RCX=0x00000152253face8 points into unknown readable memory: 0x00007ffb9d07a5a8 | a8 a5 07 9d fb 7f 00 00
+RDX=0x00000152253face8 points into unknown readable memory: 0x00007ffb9d07a5a8 | a8 a5 07 9d fb 7f 00 00
+RSP=0x00000036b99fd420 is pointing into the stack for thread: 0x0000015224e04e20
+RBP=0x0 is null
+RSI=0x00000152253facd8 points into unknown readable memory: 0x00007ffb9d07aee8 | e8 ae 07 9d fb 7f 00 00
+RDI=0x0 is null
+R8 =0x0000000000000004 is an unknown value
+R9 =0x00000152246d4030 points into unknown readable memory: 0x0000000000000007 | 07 00 00 00 00 00 00 00
+R10=0x0000000000000001 is an unknown value
+R11=0x00000036b99fd3f8 is pointing into the stack for thread: 0x0000015224e04e20
+R12=0x0000015224ce2530 points into unknown readable memory: 0x000001522928d6d0 | d0 d6 28 29 52 01 00 00
+R13=0x0 is null
+R14=0x00000152253facd8 points into unknown readable memory: 0x00007ffb9d07aee8 | e8 ae 07 9d fb 7f 00 00
+R15=0x00000152253face8 points into unknown readable memory: 0x00007ffb9d07a5a8 | a8 a5 07 9d fb 7f 00 00
+
+Top of Stack: (sp=0x00000036b99fd420)
+0x00000036b99fd420:   000000008c36c990 00000152253f9f98   ..6.......?%R...
+0x00000036b99fd430:   000001522a53f290 00007ffb9cd13b8a   ..S*R....;......
+0x00000036b99fd440:   00000152253facd8 00000036b99fe2c0   ..?%R.......6...
+0x00000036b99fd450:   00000152246d4030 00000152200bfd20   0@m$R... .. R...
+0x00000036b99fd460:   00000152253face8 00007ffb9c82cad3   ..?%R...........
+0x00000036b99fd470:   0000000000003138 000001522a53f290   81........S*R...
+0x00000036b99fd480:   000001522928d718 00007ffb9c83034d   ..()R...M.......
+0x00000036b99fd490:   00000000000000a5 000000008c36d3d8   ..........6.....
+0x00000036b99fd4a0:   0000015226291800 0000000000000002   ..)&R...........
+0x00000036b99fd4b0:   00000036b99fe2c0 00000036b99fe2c0   ....6.......6...
+0x00000036b99fd4c0:   0000000000000002 000001527a5efa20   ........ .^zR...
+0x00000036b99fd4d0:   00000036b99fee20 00000036b99fd640    ...6...@...6...
+0x00000036b99fd4e0:   0000015224e04e20 000001522a53f070    N.$R...p.S*R...
+0x00000036b99fd4f0:   000001522928d718 00007ffb9c8270a8   ..()R....p......
+0x00000036b99fd500:   000001522928d6f0 0000015226291410   ..()R.....)&R...
+0x00000036b99fd510:   00000000000003d8 0000015226291450   ........P.)&R...
+0x00000036b99fd520:   000000008c36d3d8 0000015224e04e20   ..6..... N.$R...
+0x00000036b99fd530:   0000000000000000 00007ffb9c87f2e7   ................
+0x00000036b99fd540:   000000008c36d3d8 00000036b99fe428   ..6.....(...6...
+0x00000036b99fd550:   00000036b99fe190 0000000000000002   ....6...........
+0x00000036b99fd560:   0000000000000000 0000000000000000   ................
+0x00000036b99fd570:   00000036b99fe190 00000152246d4030   ....6...0@m$R...
+0x00000036b99fd580:   00000152360d3640 00000152360d78b0   @6.6R....x.6R...
+0x00000036b99fd590:   00000152360db630 00000000000083b0   0..6R...........
+0x00000036b99fd5a0:   000001521f57f108 0000000000000000   ..W.R...........
+0x00000036b99fd5b0:   0000000000000000 0000000000000000   ................
+0x00000036b99fd5c0:   0000000000000000 0000000000000000   ................
+0x00000036b99fd5d0:   0000000000000000 00007ffb9d068d8c   ................
+0x00000036b99fd5e0:   0000000000000000 00000036b99fe190   ............6...
+0x00000036b99fd5f0:   0000000000000000 0000000000000000   ................
+0x00000036b99fd600:   0000000000000000 0000000000000000   ................
+0x00000036b99fd610:   0000000000000000 0000000000000000   ................
+
+Instructions: (pc=0x00007ffb9c82dd07)
+  0x00007ffb9c82dc07:   b6 c3 d0 e8 a8 01 75 63 48 8b f9 48 83 e7 fc 74
+  0x00007ffb9c82dc17:   5a 65 48 8b 04 25 58 00 00 00 8b 0d d5 9b b3 00
+  0x00007ffb9c82dc27:   48 89 74 24 30 48 8b 34 c8 b8 48 00 00 00 80 3c
+  0x00007ffb9c82dc37:   30 00 75 05 e8 e8 a0 77 00 b8 20 00 00 00 48 8b
+  0x00007ffb9c82dc47:   d7 48 8b 04 30 48 8b 88 b8 07 00 00 48 8b 49 38
+  0x00007ffb9c82dc57:   e8 a4 25 00 00 48 8b 74 24 30 83 e3 03 48 0b c3
+  0x00007ffb9c82dc67:   48 8b 5c 24 38 48 83 c4 20 5f c3 83 e3 03 8b c3
+  0x00007ffb9c82dc77:   48 8b 5c 24 38 48 83 c4 20 5f c3 cc cc cc cc cc
+  0x00007ffb9c82dc87:   cc cc cc cc cc cc cc cc cc 40 55 56 41 55 41 57
+  0x00007ffb9c82dc97:   48 83 ec 28 45 33 ed 4c 8b fa 44 39 2d 58 81 a7
+  0x00007ffb9c82dca7:   00 48 8b f1 41 8b ed 0f 86 2d 01 00 00 44 8b 05
+  0x00007ffb9c82dcb7:   41 9b b3 00 65 48 8b 04 25 58 00 00 00 48 89 5c
+  0x00007ffb9c82dcc7:   24 50 48 89 7c 24 58 41 8b fd 4c 89 64 24 60 4e
+  0x00007ffb9c82dcd7:   8d 24 c0 4c 89 74 24 20 90 49 8b 07 49 8b cf ff
+  0x00007ffb9c82dce7:   50 20 84 c0 49 8b dd 48 63 c7 49 0f 45 df 48 8b
+  0x00007ffb9c82dcf7:   5b 08 48 8b 5c c3 10 48 85 db 0f 84 a9 00 00 00
+=>0x00007ffb9c82dd07:   4c 39 ab 98 00 00 00 0f 84 9c 00 00 00 44 38 2d
+  0x00007ffb9c82dd17:   ed e1 ad 00 48 8b c3 74 20 66 83 7b 0c 06 75 07
+  0x00007ffb9c82dd27:   48 8b 83 e8 00 00 00 66 83 78 0c 04 77 0b 0f b6
+  0x00007ffb9c82dd37:   80 30 01 00 00 3c 01 72 70 48 8b 8b 98 00 00 00
+  0x00007ffb9c82dd47:   e8 74 93 02 00 84 c0 74 3e 4d 8b 34 24 b8 48 00
+  0x00007ffb9c82dd57:   00 00 46 38 2c 30 75 05 e8 c4 9f 77 00 b8 20 00
+  0x00007ffb9c82dd67:   00 00 48 8b d3 4a 8b 0c 30 48 8b 89 b8 07 00 00
+  0x00007ffb9c82dd77:   48 8b 49 38 e8 80 24 00 00 48 8b 4e 08 48 63 d7
+  0x00007ffb9c82dd87:   48 89 44 d1 10 eb 2e 48 8b 46 08 48 63 cf 4c 89
+  0x00007ffb9c82dd97:   68 08 48 8b 46 08 4c 89 6c c8 10 48 8b 46 08 48
+  0x00007ffb9c82dda7:   63 cf 4c 89 6c c8 18 eb 0c 48 8b 46 08 48 63 cf
+  0x00007ffb9c82ddb7:   4c 89 6c c8 10 ff c5 83 c7 02 3b 2d 39 80 a7 00
+  0x00007ffb9c82ddc7:   0f 82 13 ff ff ff 4c 8b 74 24 20 4c 8b 64 24 60
+  0x00007ffb9c82ddd7:   48 8b 7c 24 58 48 8b 5c 24 50 48 83 c4 28 41 5f
+  0x00007ffb9c82dde7:   41 5d 5e 5d c3 cc cc cc cc 48 89 5c 24 08 48 89
+  0x00007ffb9c82ddf7:   74 24 10 57 48 83 ec 20 4c 63 42 10 48 8b f1 48
+
+
+Stack slot to memory mapping:
+
+stack at sp + 0 slots: 0x000000008c36c990 is a pointer to class: 
+jdk.internal.classfile.impl.StackMapGenerator$Frame {0x000000008c36c998}
+ - instance size:     7
+ - klass size:        67
+ - access:            final synchronized 
+ - flags:             rewritten has_nonstatic_fields defined_by_boot_loader has_localvariable_table 
+ - state:             fully_initialized
+ - name:              'jdk/internal/classfile/impl/StackMapGenerator$Frame'
+ - super:             'java/lang/Object'
+ - sub:               
+ - arrays:            'jdk/internal/classfile/impl/StackMapGenerator$Frame'[]
+ - methods:           Array<T>(0x000000008caa98b0)
+ - method ordering:   Array<T>(0x000000008c6f6b40)
+ - local interfaces:  Array<T>(0x000000008c69fb48)
+ - trans. interfaces: Array<T>(0x000000008c69fb48)
+ - secondary supers: Array<T>(0x000000008c69fb30)
+ - hash_slot:         11
+ - secondary bitmap: 0x0000000000000000
+ - constants:         constant pool [353] {0x000000008caa8d68} for 'jdk/internal/classfile/impl/StackMapGenerator$Frame' cache=0x000000008c45bc38
+ - class loader data:  loader data: 0x000001527efeb3d0 of 'bootstrap'
+ - source file:       'StackMapGenerator.java'
+ - inner classes:     Array<T>(0x000000008c6f6b20)
+ - nest members:     Array<T>(0x000000008c69fb40)
+ - permitted subclasses:     Array<T>(0x000000008c69fb40)
+ - java mirror:       a 'java/lang/Class'{0x000000068b2aea80} = 'jdk/internal/classfile/impl/StackMapGenerator$Frame'
+ - vtable length      5  (start addr: 0x000000008c36cb68)
+ - itable length      2 (start addr: 0x000000008c36cb90)
+ - ---- static fields (0 words):
+ - ---- non-static fields (11 words):
+ - 'offset' 'I' @12 
+ - 'localsSize' 'I' @16 
+ - 'stackSize' 'I' @20 
+ - 'flags' 'I' @24 
+ - 'frameMaxStack' 'I' @28 
+ - 'frameMaxLocals' 'I' @32 
+ - 'dirty' 'Z' @36 
+ - 'localsChanged' 'Z' @37 
+ - private final 'classHierarchy' 'Ljdk/internal/classfile/impl/ClassHierarchyImpl;' @40 
+ - private 'locals' '[Ljdk/internal/classfile/impl/StackMapGenerator$Type;' @44 
+ - private 'stack' '[Ljdk/internal/classfile/impl/StackMapGenerator$Type;' @48 
+ - final synthetic 'this$0' 'Ljdk/internal/classfile/impl/StackMapGenerator;' @52 
+ - non-static oop maps (1 entries): 40-52 
+stack at sp + 1 slots: 0x00000152253f9f98 points into unknown readable memory: 0x00007ffb9d07aee8 | e8 ae 07 9d fb 7f 00 00
+stack at sp + 2 slots: 0x000001522a53f290 points into unknown readable memory: 0x00007ffb9d07b428 | 28 b4 07 9d fb 7f 00 00
+stack at sp + 3 slots: 0x00007ffb9cd13b8a jvm.dll
+stack at sp + 4 slots: 0x00000152253facd8 points into unknown readable memory: 0x00007ffb9d07aee8 | e8 ae 07 9d fb 7f 00 00
+stack at sp + 5 slots: 0x00000036b99fe2c0 is pointing into the stack for thread: 0x0000015224e04e20
+stack at sp + 6 slots: 0x00000152246d4030 points into unknown readable memory: 0x0000000000000007 | 07 00 00 00 00 00 00 00
+stack at sp + 7 slots: 0x00000152200bfd20 is pointing into metadata
+
+Lock stack of current Java thread (top to bottom):
+
+
+---------------  P R O C E S S  ---------------
+
+Threads class SMR info:
+_java_thread_list=0x0000015227d1a6b0, length=21, elements={
+0x000001527a5d3ea0, 0x000001527f144dc0, 0x000001527f1476e0, 0x000001527f14a770,
+0x000001527f14b700, 0x000001527f151330, 0x000001527f14e400, 0x000001527f14f020,
+0x000001527f168940, 0x000001521f5c3100, 0x000001521f682dd0, 0x000001521f6961a0,
+0x000001521f5c5950, 0x000001521f5c6160, 0x000001521f5c6970, 0x000001521f5c99d0,
+0x000001521f5c91c0, 0x0000015224e04e20, 0x0000015224e015b0, 0x0000015224dfdd40,
+0x0000015224dff570
+}
+
+Java Threads: ( => current thread )
+  0x000001527a5d3ea0 JavaThread "main"                              [_thread_in_Java, id=23816, stack(0x00000036b8100000,0x00000036b8200000) (1024K)]
+  0x000001527f144dc0 JavaThread "Reference Handler"          daemon [_thread_blocked, id=2508, stack(0x00000036b8900000,0x00000036b8a00000) (1024K)]
+  0x000001527f1476e0 JavaThread "Finalizer"                  daemon [_thread_blocked, id=29028, stack(0x00000036b8a00000,0x00000036b8b00000) (1024K)]
+  0x000001527f14a770 JavaThread "Signal Dispatcher"          daemon [_thread_blocked, id=22420, stack(0x00000036b8b00000,0x00000036b8c00000) (1024K)]
+  0x000001527f14b700 JavaThread "Attach Listener"            daemon [_thread_blocked, id=23868, stack(0x00000036b8c00000,0x00000036b8d00000) (1024K)]
+  0x000001527f151330 JavaThread "Service Thread"             daemon [_thread_blocked, id=5432, stack(0x00000036b8d00000,0x00000036b8e00000) (1024K)]
+  0x000001527f14e400 JavaThread "Monitor Deflation Thread"   daemon [_thread_blocked, id=15908, stack(0x00000036b8e00000,0x00000036b8f00000) (1024K)]
+  0x000001527f14f020 JavaThread "C2 CompilerThread0"         daemon [_thread_blocked, id=27288, stack(0x00000036b8f00000,0x00000036b9000000) (1024K)]
+  0x000001527f168940 JavaThread "C1 CompilerThread0"         daemon [_thread_blocked, id=8628, stack(0x00000036b9000000,0x00000036b9100000) (1024K)]
+  0x000001521f5c3100 JavaThread "C1 CompilerThread1"         daemon [_thread_blocked, id=2976, stack(0x00000036b9100000,0x00000036b9200000) (1024K)]
+  0x000001521f682dd0 JavaThread "Notification Thread"        daemon [_thread_blocked, id=13632, stack(0x00000036b9200000,0x00000036b9300000) (1024K)]
+  0x000001521f6961a0 JavaThread "Common-Cleaner"             daemon [_thread_blocked, id=11100, stack(0x00000036b9300000,0x00000036b9400000) (1024K)]
+  0x000001521f5c5950 JavaThread "C2 CompilerThread1"         daemon [_thread_blocked, id=6668, stack(0x00000036b9400000,0x00000036b9500000) (1024K)]
+  0x000001521f5c6160 JavaThread "C1 CompilerThread2"         daemon [_thread_blocked, id=30012, stack(0x00000036b9500000,0x00000036b9600000) (1024K)]
+  0x000001521f5c6970 JavaThread "C1 CompilerThread3"         daemon [_thread_blocked, id=22728, stack(0x00000036b9600000,0x00000036b9700000) (1024K)]
+  0x000001521f5c99d0 JavaThread "C2 CompilerThread2"         daemon [_thread_blocked, id=26780, stack(0x00000036b9700000,0x00000036b9800000) (1024K)]
+  0x000001521f5c91c0 JavaThread "C2 CompilerThread3"         daemon [_thread_in_native, id=14720, stack(0x00000036b9800000,0x00000036b9900000) (1024K)]
+=>0x0000015224e04e20 JavaThread "C2 CompilerThread4"         daemon [_thread_in_vm, id=25720, stack(0x00000036b9900000,0x00000036b9a00000) (1024K)]
+  0x0000015224e015b0 JavaThread "C2 CompilerThread5"         daemon [_thread_in_native, id=13416, stack(0x00000036b9a00000,0x00000036b9b00000) (1024K)]
+  0x0000015224dfdd40 JavaThread "C2 CompilerThread6"         daemon [_thread_in_native, id=16296, stack(0x00000036ba900000,0x00000036baa00000) (1024K)]
+  0x0000015224dff570 JavaThread "C2 CompilerThread7"         daemon [_thread_in_native, id=4332, stack(0x00000036baa00000,0x00000036bab00000) (1024K)]
+Total: 21
+
+Other Threads:
+  0x000001527f137040 VMThread "VM Thread"                           [id=3204, stack(0x00000036b8800000,0x00000036b8900000) (1024K)] _threads_hazard_ptr=0x0000015227d1a6b0
+  0x000001527f1261c0 WatcherThread "VM Periodic Task Thread"        [id=28020, stack(0x00000036b8700000,0x00000036b8800000) (1024K)]
+  0x000001527cb1b7f0 WorkerThread "GC Thread#0"                     [id=28620, stack(0x00000036b8200000,0x00000036b8300000) (1024K)]
+  0x0000015224c76ee0 WorkerThread "GC Thread#1"                     [id=1996, stack(0x00000036b9d00000,0x00000036b9e00000) (1024K)]
+  0x0000015224c77720 WorkerThread "GC Thread#2"                     [id=25160, stack(0x00000036b9e00000,0x00000036b9f00000) (1024K)]
+  0x000001522494dc20 WorkerThread "GC Thread#3"                     [id=15516, stack(0x00000036b9f00000,0x00000036ba000000) (1024K)]
+  0x000001522494e050 WorkerThread "GC Thread#4"                     [id=29652, stack(0x00000036ba000000,0x00000036ba100000) (1024K)]
+  0x000001522494e480 WorkerThread "GC Thread#5"                     [id=27364, stack(0x00000036ba100000,0x00000036ba200000) (1024K)]
+  0x00000152260c7d30 WorkerThread "GC Thread#6"                     [id=4680, stack(0x00000036ba200000,0x00000036ba300000) (1024K)]
+  0x000001522499c0f0 WorkerThread "GC Thread#7"                     [id=1412, stack(0x00000036ba300000,0x00000036ba400000) (1024K)]
+  0x000001522499b850 WorkerThread "GC Thread#8"                     [id=25896, stack(0x00000036ba400000,0x00000036ba500000) (1024K)]
+  0x00000152262187e0 WorkerThread "GC Thread#9"                     [id=11912, stack(0x00000036b9b00000,0x00000036b9c00000) (1024K)]
+  0x0000015226219080 WorkerThread "GC Thread#10"                    [id=23848, stack(0x00000036b9c00000,0x00000036b9d00000) (1024K)]
+  0x000001522a0d0d10 WorkerThread "GC Thread#11"                    [id=3444, stack(0x00000036ba500000,0x00000036ba600000) (1024K)]
+  0x000001522a0cea90 WorkerThread "GC Thread#12"                    [id=8616, stack(0x00000036ba600000,0x00000036ba700000) (1024K)]
+  0x000001527cb2f090 ConcurrentGCThread "G1 Main Marker"            [id=30748, stack(0x00000036b8300000,0x00000036b8400000) (1024K)]
+  0x000001527cb322e0 WorkerThread "G1 Conc#0"                       [id=31128, stack(0x00000036b8400000,0x00000036b8500000) (1024K)]
+  0x000001522a0ceee0 WorkerThread "G1 Conc#1"                       [id=24760, stack(0x00000036ba700000,0x00000036ba800000) (1024K)]
+  0x000001522a0d26f0 WorkerThread "G1 Conc#2"                       [id=25412, stack(0x00000036ba800000,0x00000036ba900000) (1024K)]
+  0x000001527cb4ea70 ConcurrentGCThread "G1 Refine#0"               [id=29668, stack(0x00000036b8500000,0x00000036b8600000) (1024K)]
+  0x000001527efebd60 ConcurrentGCThread "G1 Service"                [id=26172, stack(0x00000036b8600000,0x00000036b8700000) (1024K)]
+Total: 21
+
+Threads with active compile tasks:
+C2 CompilerThread3  8984 10946       4       lombok.javac.JavacAST::buildStatementOrExpression (120 bytes)
+C2 CompilerThread4  8984 11022       4       jdk.internal.classfile.impl.StackMapGenerator::processBlock (2767 bytes)
+C2 CompilerThread5  8984 11129   !   4       lombok.javac.JavacAST::drill (146 bytes)
+C2 CompilerThread6  8984 11067   !   4       com.sun.tools.javac.comp.Resolve::loadClass (83 bytes)
+C2 CompilerThread7  8984 11126   !   4       com.sun.tools.javac.code.ClassFinder::loadClass (127 bytes)
+Total: 5
+
+VM state: synchronizing (normal execution)
+
+VM Mutex/Monitor currently owned by a thread:  ([mutex/lock_event])
+[0x00007ffb9d3394e8] Threads_lock - owner thread: 0x000001527f137040
+[0x00007ffb9d339668] Heap_lock - owner thread: 0x000001527a5d3ea0
+
+Heap address: 0x0000000689800000, size: 5992 MB, Compressed Oops mode: Zero based, Oop shift amount: 3
+
+CDS archive(s) mapped at: [0x000000008c000000-0x000000008cdd0000-0x000000008cdd0000), size 14483456, SharedBaseAddress: 0x000000008c000000, ArchiveRelocationMode: 1.
+Compressed class space mapped at: 0x000000008d000000-0x00000000cd000000, reserved size: 1073741824
+UseCompressedClassPointers 1, UseCompactObjectHeaders 0
+Narrow klass pointer bits 32, Max shift 3
+Narrow klass base: 0x000000008c000000, Narrow klass shift: 0
+Encoding Range: [0x000000008c000000 - 0x000000018c000000), (4294967296 bytes)
+Klass Range:    [0x000000008c010000 - 0x00000000cd000000), (1090453504 bytes)
+Klass ID Range:  [65536 - 1090519033) (1090453497)
+Protection zone: [0x000000008c000000 - 0x000000008c010000), (65536 bytes)
+
+GC Precious Log:
+ CardTable entry size: 512
+ Card Set container configuration: InlinePtr #cards 4 size 8 Array Of Cards #cards 32 size 80 Howl #buckets 8 coarsen threshold 7372 Howl Bitmap #cards 1024 size 144 coarsen threshold 921 Card regions per heap region 1 cards per card region 8192
+ CPUs: 16 total, 16 available
+ Memory: 23967M
+ Large Page Support: Disabled
+ NUMA Support: Disabled
+ Compressed Oops: Enabled (Zero based)
+ Heap Region Size: 4M
+ Heap Min Capacity: 8M
+ Heap Initial Capacity: 376M
+ Heap Max Capacity: 5992M
+ Pre-touch: Disabled
+ Parallel Workers: 13
+ Concurrent Workers: 3
+ Concurrent Refinement Workers: 13
+ Periodic GC: Disabled
+
+Heap:
+ garbage-first heap   total reserved 6135808K, committed 233472K, used 204662K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 24 young (98304K), 1 survivors (4096K)
+
+Heap Regions: E=young(eden), S=young(survivor), O=old, HS=humongous(starts), HC=humongous(continues), CS=collection set, F=free, TAMS=top-at-mark-start, PB=parsable bottom
+|   0|0x0000000689800000, 0x0000000689c00000, 0x0000000689c00000|100%| O|  |TAMS 0x0000000689800000| PB 0x0000000689800000| Untracked |  0
+|   1|0x0000000689c00000, 0x000000068a000000, 0x000000068a000000|100%| O|  |TAMS 0x0000000689c00000| PB 0x0000000689c00000| Untracked |  0
+|   2|0x000000068a000000, 0x000000068a400000, 0x000000068a400000|100%| O|  |TAMS 0x000000068a000000| PB 0x000000068a000000| Untracked |  0
+|   3|0x000000068a400000, 0x000000068a800000, 0x000000068a800000|100%| O|  |TAMS 0x000000068a400000| PB 0x000000068a400000| Untracked |  0
+|   4|0x000000068a800000, 0x000000068a800000, 0x000000068ac00000|  0%| F|  |TAMS 0x000000068a800000| PB 0x000000068a800000| Untracked |  0
+|   5|0x000000068ac00000, 0x000000068b000000, 0x000000068b000000|100%| O|  |TAMS 0x000000068ac00000| PB 0x000000068ac00000| Untracked |  0
+|   6|0x000000068b000000, 0x000000068b400000, 0x000000068b400000|100%| O|  |TAMS 0x000000068b000000| PB 0x000000068b000000| Untracked |  0
+|   7|0x000000068b400000, 0x000000068b800000, 0x000000068b800000|100%| O|  |TAMS 0x000000068b400000| PB 0x000000068b400000| Untracked |  0
+|   8|0x000000068b800000, 0x000000068bc00000, 0x000000068bc00000|100%| O|  |TAMS 0x000000068b800000| PB 0x000000068b800000| Untracked |  0
+|   9|0x000000068bc00000, 0x000000068c000000, 0x000000068c000000|100%| O|  |TAMS 0x000000068bc00000| PB 0x000000068bc00000| Untracked |  0
+|  10|0x000000068c000000, 0x000000068c400000, 0x000000068c400000|100%| O|  |TAMS 0x000000068c000000| PB 0x000000068c000000| Untracked |  0
+|  11|0x000000068c400000, 0x000000068c800000, 0x000000068c800000|100%| O|  |TAMS 0x000000068c400000| PB 0x000000068c400000| Untracked |  0
+|  12|0x000000068c800000, 0x000000068cc00000, 0x000000068cc00000|100%| O|  |TAMS 0x000000068c800000| PB 0x000000068c800000| Untracked |  0
+|  13|0x000000068cc00000, 0x000000068d000000, 0x000000068d000000|100%| O|  |TAMS 0x000000068cc00000| PB 0x000000068cc00000| Untracked |  0
+|  14|0x000000068d000000, 0x000000068d400000, 0x000000068d400000|100%| O|  |TAMS 0x000000068d000000| PB 0x000000068d000000| Untracked |  0
+|  15|0x000000068d400000, 0x000000068d800000, 0x000000068d800000|100%| O|  |TAMS 0x000000068d400000| PB 0x000000068d400000| Untracked |  0
+|  16|0x000000068d800000, 0x000000068dc00000, 0x000000068dc00000|100%| O|  |TAMS 0x000000068d800000| PB 0x000000068d800000| Untracked |  0
+|  17|0x000000068dc00000, 0x000000068e000000, 0x000000068e000000|100%| O|  |TAMS 0x000000068dc00000| PB 0x000000068dc00000| Untracked |  0
+|  18|0x000000068e000000, 0x000000068e400000, 0x000000068e400000|100%| O|Cm|TAMS 0x000000068e000000| PB 0x000000068e000000| Complete |  0
+|  19|0x000000068e400000, 0x000000068e800000, 0x000000068e800000|100%| O|  |TAMS 0x000000068e400000| PB 0x000000068e400000| Untracked |  0
+|  20|0x000000068e800000, 0x000000068ec00000, 0x000000068ec00000|100%| O|  |TAMS 0x000000068e800000| PB 0x000000068e800000| Untracked |  0
+|  21|0x000000068ec00000, 0x000000068f000000, 0x000000068f000000|100%| O|  |TAMS 0x000000068ec00000| PB 0x000000068ec00000| Untracked |  0
+|  22|0x000000068f000000, 0x000000068f400000, 0x000000068f400000|100%| O|  |TAMS 0x000000068f000000| PB 0x000000068f000000| Untracked |  0
+|  23|0x000000068f400000, 0x000000068f800000, 0x000000068f800000|100%| O|  |TAMS 0x000000068f400000| PB 0x000000068f400000| Untracked |  0
+|  24|0x000000068f800000, 0x000000068fc00000, 0x000000068fc00000|100%| O|  |TAMS 0x000000068f800000| PB 0x000000068f800000| Untracked |  0
+|  25|0x000000068fc00000, 0x0000000690000000, 0x0000000690000000|100%| O|  |TAMS 0x000000068fc00000| PB 0x000000068fc00000| Untracked |  0
+|  26|0x0000000690000000, 0x000000069020a280, 0x0000000690400000| 50%| O|  |TAMS 0x0000000690000000| PB 0x0000000690000000| Untracked |  0
+|  27|0x0000000690400000, 0x0000000690400000, 0x0000000690800000|  0%| F|  |TAMS 0x0000000690400000| PB 0x0000000690400000| Untracked |  0
+|  28|0x0000000690800000, 0x0000000690800000, 0x0000000690c00000|  0%| F|  |TAMS 0x0000000690800000| PB 0x0000000690800000| Untracked |  0
+|  29|0x0000000690c00000, 0x0000000690c00000, 0x0000000691000000|  0%| F|  |TAMS 0x0000000690c00000| PB 0x0000000690c00000| Untracked |  0
+|  30|0x0000000691000000, 0x0000000691000000, 0x0000000691400000|  0%| F|  |TAMS 0x0000000691000000| PB 0x0000000691000000| Untracked |  0
+|  31|0x0000000691400000, 0x0000000691400000, 0x0000000691800000|  0%| F|  |TAMS 0x0000000691400000| PB 0x0000000691400000| Untracked |  0
+|  32|0x0000000691800000, 0x0000000691c00000, 0x0000000691c00000|100%| E|CS|TAMS 0x0000000691800000| PB 0x0000000691800000| Complete |  0
+|  33|0x0000000691c00000, 0x0000000691dd35f8, 0x0000000692000000| 45%| S|CS|TAMS 0x0000000691c00000| PB 0x0000000691c00000| Complete |  0
+|  34|0x0000000692000000, 0x0000000692400000, 0x0000000692400000|100%| E|CS|TAMS 0x0000000692000000| PB 0x0000000692000000| Complete |  0
+|  35|0x0000000692400000, 0x0000000692800000, 0x0000000692800000|100%| E|CS|TAMS 0x0000000692400000| PB 0x0000000692400000| Complete |  0
+|  36|0x0000000692800000, 0x0000000692c00000, 0x0000000692c00000|100%| E|CS|TAMS 0x0000000692800000| PB 0x0000000692800000| Complete |  0
+|  37|0x0000000692c00000, 0x0000000693000000, 0x0000000693000000|100%| E|CS|TAMS 0x0000000692c00000| PB 0x0000000692c00000| Complete |  0
+|  38|0x0000000693000000, 0x0000000693400000, 0x0000000693400000|100%| E|CS|TAMS 0x0000000693000000| PB 0x0000000693000000| Complete |  0
+|  39|0x0000000693400000, 0x0000000693800000, 0x0000000693800000|100%| E|CS|TAMS 0x0000000693400000| PB 0x0000000693400000| Complete |  0
+|  40|0x0000000693800000, 0x0000000693c00000, 0x0000000693c00000|100%| E|CS|TAMS 0x0000000693800000| PB 0x0000000693800000| Complete |  0
+|  41|0x0000000693c00000, 0x0000000694000000, 0x0000000694000000|100%| E|CS|TAMS 0x0000000693c00000| PB 0x0000000693c00000| Complete |  0
+|  42|0x0000000694000000, 0x0000000694400000, 0x0000000694400000|100%| E|CS|TAMS 0x0000000694000000| PB 0x0000000694000000| Complete |  0
+|  43|0x0000000694400000, 0x0000000694800000, 0x0000000694800000|100%| E|CS|TAMS 0x0000000694400000| PB 0x0000000694400000| Complete |  0
+|  44|0x0000000694800000, 0x0000000694c00000, 0x0000000694c00000|100%| E|CS|TAMS 0x0000000694800000| PB 0x0000000694800000| Complete |  0
+|  45|0x0000000694c00000, 0x0000000695000000, 0x0000000695000000|100%| E|CS|TAMS 0x0000000694c00000| PB 0x0000000694c00000| Complete |  0
+|  46|0x0000000695000000, 0x0000000695400000, 0x0000000695400000|100%| E|CS|TAMS 0x0000000695000000| PB 0x0000000695000000| Complete |  0
+|  47|0x0000000695400000, 0x0000000695800000, 0x0000000695800000|100%| E|CS|TAMS 0x0000000695400000| PB 0x0000000695400000| Complete |  0
+|  48|0x0000000695800000, 0x0000000695c00000, 0x0000000695c00000|100%| E|CS|TAMS 0x0000000695800000| PB 0x0000000695800000| Complete |  0
+|  49|0x0000000695c00000, 0x0000000696000000, 0x0000000696000000|100%| E|CS|TAMS 0x0000000695c00000| PB 0x0000000695c00000| Complete |  0
+|  50|0x0000000696000000, 0x0000000696400000, 0x0000000696400000|100%| E|CS|TAMS 0x0000000696000000| PB 0x0000000696000000| Complete |  0
+|  90|0x00000006a0000000, 0x00000006a0400000, 0x00000006a0400000|100%| E|CS|TAMS 0x00000006a0000000| PB 0x00000006a0000000| Complete |  0
+|  91|0x00000006a0400000, 0x00000006a0800000, 0x00000006a0800000|100%| E|CS|TAMS 0x00000006a0400000| PB 0x00000006a0400000| Complete |  0
+|  92|0x00000006a0800000, 0x00000006a0c00000, 0x00000006a0c00000|100%| E|CS|TAMS 0x00000006a0800000| PB 0x00000006a0800000| Complete |  0
+|  93|0x00000006a0c00000, 0x00000006a1000000, 0x00000006a1000000|100%| E|CS|TAMS 0x00000006a0c00000| PB 0x00000006a0c00000| Complete |  0
+|1496|0x00000007ff800000, 0x00000007ffc00000, 0x00000007ffc00000|100%| O|  |TAMS 0x00000007ff800000| PB 0x00000007ff800000| Untracked |  0
+|1497|0x00000007ffc00000, 0x0000000800000000, 0x0000000800000000|100%| E|CS|TAMS 0x00000007ffc00000| PB 0x00000007ffc00000| Complete |  0
+
+Card table byte_map: [0x000001527df90000,0x000001527eb50000] _byte_map_base: 0x000001527ab44000
+
+Marking Bits: (CMBitMap*) 0x000001527cb1bf80
+ Bits: [0x00000152177c0000, 0x000001521d560000)
+
+Polling page: 0x000001527a8c0000
+
+Metaspace:
+Metaspace        used 32671K, committed 33216K, reserved 1114112K
+ class space     used 3030K, committed 3264K, reserved 1048576K
+
+Usage:
+  Non-class:     28.95 MB used.
+      Class:      2.96 MB used.
+       Both:     31.91 MB used.
+
+Virtual space:
+  Non-class space:       64.00 MB reserved,      29.25 MB ( 46%) committed,  1 nodes.
+      Class space:        1.00 GB reserved,       3.19 MB ( <1%) committed,  1 nodes.
+             Both:        1.06 GB reserved,      32.44 MB (  3%) committed. 
+
+Chunk freelists:
+   Non-Class:  1.92 MB
+       Class:  12.73 MB
+        Both:  14.66 MB
+
+MaxMetaspaceSize: unlimited
+CompressedClassSpaceSize: 1.00 GB
+Initial GC threshold: 21.00 MB
+Current GC threshold: 53.12 MB
+CDS: on
+ - commit_granule_bytes: 65536.
+ - commit_granule_words: 8192.
+ - virtual_space_node_default_size: 8388608.
+ - enlarge_chunks_in_place: 1.
+UseCompressedClassPointers 1, UseCompactObjectHeaders 0
+Narrow klass pointer bits 32, Max shift 3
+Narrow klass base: 0x000000008c000000, Narrow klass shift: 0
+Encoding Range: [0x000000008c000000 - 0x000000018c000000), (4294967296 bytes)
+Klass Range:    [0x000000008c010000 - 0x00000000cd000000), (1090453504 bytes)
+Klass ID Range:  [65536 - 1090519033) (1090453497)
+Protection zone: [0x000000008c000000 - 0x000000008c010000), (65536 bytes)
+
+
+Internal statistics:
+
+num_allocs_failed_limit: 3.
+num_arena_births: 504.
+num_arena_deaths: 0.
+num_vsnodes_births: 2.
+num_vsnodes_deaths: 0.
+num_space_committed: 519.
+num_space_uncommitted: 0.
+num_chunks_returned_to_freelist: 3.
+num_chunks_taken_from_freelist: 1786.
+num_chunk_merges: 3.
+num_chunk_splits: 1233.
+num_chunks_enlarged: 912.
+num_inconsistent_stats: 0.
+
+CodeHeap 'non-profiled nmethods': size=119232Kb used=6023Kb max_used=6023Kb free=113209Kb
+ bounds [0x0000015210350000, 0x0000015210990000, 0x00000152177c0000]
+CodeHeap 'profiled nmethods': size=119104Kb used=15768Kb max_used=17931Kb free=103335Kb
+ bounds [0x00000152087c0000, 0x0000015209950000, 0x000001520fc10000]
+CodeHeap 'non-nmethods': size=7424Kb used=3144Kb max_used=3489Kb free=4280Kb
+ bounds [0x000001520fc10000, 0x000001520ffb0000, 0x0000015210350000]
+CodeCache: size=245760Kb, used=24935Kb, max_used=27443Kb, free=220824Kb
+ total_blobs=9866, nmethods=9281, adapters=484, full_count=0
+Compilation: enabled, stopped_count=0, restarted_count=0
+
+Compilation events (20 events):
+Event: 8.902 Thread 0x000001521f5c5950 nmethod 10962 0x0000015210714608 code [0x0000015210714700, 0x0000015210719b08]
+Event: 8.902 Thread 0x000001521f5c3100 nmethod 11014 0x00000152094a0388 code [0x00000152094a0480, 0x00000152094a0a40]
+Event: 8.903 Thread 0x000001521f5c6970 nmethod 11013 0x000001520953c608 code [0x000001520953c700, 0x000001520953d038]
+Event: 8.903 Thread 0x0000015224dff570 nmethod 11008 0x000001521072e088 code [0x000001521072e180, 0x000001521072e898]
+Event: 8.903 Thread 0x0000015224e04e20 nmethod 11012 0x000001521070c888 code [0x000001521070c980, 0x000001521070cfe8]
+Event: 8.904 Thread 0x000001527f168940 11015       3       sun.net.util.IPAddressUtil::checkUserInfo (44 bytes)
+Event: 8.904 Thread 0x000001527f168940 nmethod 11015 0x0000015208d9e788 code [0x0000015208d9e880, 0x0000015208d9f5f8]
+Event: 8.905 Thread 0x000001527f168940 11016       1       java.lang.reflect.Method::getMethodAccessor (5 bytes)
+Event: 8.905 Thread 0x000001527f168940 nmethod 11016 0x000001521070c588 code [0x000001521070c680, 0x000001521070c748]
+Event: 8.906 Thread 0x000001521f5c3100 11018       3       java.lang.invoke.MethodType::methodType (69 bytes)
+Event: 8.906 Thread 0x000001521f5c3100 nmethod 11018 0x0000015208967b88 code [0x0000015208967c80, 0x0000015208968110]
+Event: 8.906 Thread 0x000001521f5c6970 11019       3       java.lang.invoke.InvokerBytecodeGenerator$ClassData::<init> (15 bytes)
+Event: 8.906 Thread 0x0000015224e04e20 11022       4       jdk.internal.classfile.impl.StackMapGenerator::processBlock (2767 bytes)
+Event: 8.906 Thread 0x000001521f5c3100 11020       3       java.lang.classfile.constantpool.MemberRefEntry::name (12 bytes)
+Event: 8.906 Thread 0x000001521f5c6970 nmethod 11019 0x0000015208937508 code [0x0000015208937600, 0x0000015208937888]
+Event: 8.906 Thread 0x000001521f5c6970 11021       3       java.lang.classfile.constantpool.FieldRefEntry::typeSymbol (10 bytes)
+Event: 8.906 Thread 0x000001521f5c6160 11023       3       java.lang.reflect.Method::setMethodAccessor (20 bytes)
+Event: 8.907 Thread 0x000001521f5c3100 nmethod 11020 0x00000152087ea088 code [0x00000152087ea180, 0x00000152087ea6a0]
+Event: 8.907 Thread 0x000001521f5c6970 nmethod 11021 0x000001520957de88 code [0x000001520957df80, 0x000001520957e770]
+Event: 8.907 Thread 0x000001521f5c6160 nmethod 11023 0x0000015208b81588 code [0x0000015208b81680, 0x0000015208b81a48]
+
+GC Heap Usage History (20 events):
+Event: 4.829 {heap Before GC invocations=3 (full 0):
+ garbage-first heap   total reserved 6135808K, committed 389120K, used 27992K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 7 young (28672K), 6 survivors (24576K)
+}
+Event: 4.837 {heap After GC invocations=4 (full 0):
+ garbage-first heap   total reserved 6135808K, committed 389120K, used 28726K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 3 young (12288K), 3 survivors (12288K)
+}
+Event: 5.686 {heap Before GC invocations=5 (full 0):
+ garbage-first heap   total reserved 6135808K, committed 122880K, used 110646K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 24 young (98304K), 3 survivors (12288K)
+}
+Event: 5.698 {heap After GC invocations=6 (full 0):
+ garbage-first heap   total reserved 6135808K, committed 151552K, used 47449K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 7 young (28672K), 7 survivors (28672K)
+}
+Event: 5.973 {heap Before GC invocations=6 (full 0):
+ garbage-first heap   total reserved 6135808K, committed 151552K, used 108889K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 22 young (90112K), 7 survivors (28672K)
+}
+Event: 6.012 {heap After GC invocations=7 (full 0):
+ garbage-first heap   total reserved 6135808K, committed 155648K, used 59650K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 3 young (12288K), 3 survivors (12288K)
+}
+Event: 6.512 {heap Before GC invocations=7 (full 0):
+ garbage-first heap   total reserved 6135808K, committed 155648K, used 116994K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 17 young (69632K), 3 survivors (12288K)
+}
+Event: 6.525 {heap After GC invocations=8 (full 0):
+ garbage-first heap   total reserved 6135808K, committed 155648K, used 80384K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 3 young (12288K), 3 survivors (12288K)
+}
+Event: 6.934 {heap Before GC invocations=8 (full 0):
+ garbage-first heap   total reserved 6135808K, committed 155648K, used 125440K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 14 young (57344K), 3 survivors (12288K)
+}
+Event: 6.944 {heap After GC invocations=9 (full 0):
+ garbage-first heap   total reserved 6135808K, committed 155648K, used 92672K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 2 young (8192K), 2 survivors (8192K)
+}
+Event: 7.164 {heap Before GC invocations=9 (full 0):
+ garbage-first heap   total reserved 6135808K, committed 155648K, used 129536K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 11 young (45056K), 2 survivors (8192K)
+}
+Event: 7.177 {heap After GC invocations=10 (full 0):
+ garbage-first heap   total reserved 6135808K, committed 233472K, used 100041K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 2 young (8192K), 2 survivors (8192K)
+}
+Event: 7.532 {heap Before GC invocations=11 (full 0):
+ garbage-first heap   total reserved 6135808K, committed 233472K, used 177865K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 21 young (86016K), 2 survivors (8192K)
+}
+Event: 7.542 {heap After GC invocations=12 (full 0):
+ garbage-first heap   total reserved 6135808K, committed 233472K, used 108719K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 3 young (12288K), 3 survivors (12288K)
+}
+Event: 8.125 {heap Before GC invocations=12 (full 0):
+ garbage-first heap   total reserved 6135808K, committed 233472K, used 190639K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 23 young (94208K), 3 survivors (12288K)
+}
+Event: 8.137 {heap After GC invocations=13 (full 0):
+ garbage-first heap   total reserved 6135808K, committed 233472K, used 111561K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 1 young (4096K), 1 survivors (4096K)
+}
+Event: 8.425 {heap Before GC invocations=13 (full 0):
+ garbage-first heap   total reserved 6135808K, committed 233472K, used 193481K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 21 young (86016K), 1 survivors (4096K)
+}
+Event: 8.427 {heap After GC invocations=14 (full 0):
+ garbage-first heap   total reserved 6135808K, committed 233472K, used 110550K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 1 young (4096K), 1 survivors (4096K)
+}
+Event: 8.696 {heap Before GC invocations=15 (full 0):
+ garbage-first heap   total reserved 6135808K, committed 233472K, used 196566K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 22 young (90112K), 1 survivors (4096K)
+}
+Event: 8.697 {heap After GC invocations=16 (full 0):
+ garbage-first heap   total reserved 6135808K, committed 233472K, used 110454K [0x0000000689800000, 0x0000000800000000)
+  region size 4096K, 1 young (4096K), 1 survivors (4096K)
+}
+
+Metaspace Usage History (20 events):
+Event: 4.829 {metaspace Before GC invocations=3 (full 0):
+ Metaspace       used 21243K, committed 21504K, reserved 1114112K
+  class space    used 1945K, committed 2048K, reserved 1048576K
+}
+Event: 4.837 {metaspace After GC invocations=4 (full 0):
+ Metaspace       used 21243K, committed 21504K, reserved 1114112K
+  class space    used 1945K, committed 2048K, reserved 1048576K
+}
+Event: 5.686 {metaspace Before GC invocations=5 (full 0):
+ Metaspace       used 28303K, committed 28736K, reserved 1114112K
+  class space    used 2625K, committed 2816K, reserved 1048576K
+}
+Event: 5.698 {metaspace After GC invocations=6 (full 0):
+ Metaspace       used 28303K, committed 28736K, reserved 1114112K
+  class space    used 2625K, committed 2816K, reserved 1048576K
+}
+Event: 5.973 {metaspace Before GC invocations=6 (full 0):
+ Metaspace       used 28677K, committed 29056K, reserved 1114112K
+  class space    used 2661K, committed 2816K, reserved 1048576K
+}
+Event: 6.012 {metaspace After GC invocations=7 (full 0):
+ Metaspace       used 28677K, committed 29056K, reserved 1114112K
+  class space    used 2661K, committed 2816K, reserved 1048576K
+}
+Event: 6.512 {metaspace Before GC invocations=7 (full 0):
+ Metaspace       used 28720K, committed 29120K, reserved 1114112K
+  class space    used 2661K, committed 2816K, reserved 1048576K
+}
+Event: 6.525 {metaspace After GC invocations=8 (full 0):
+ Metaspace       used 28720K, committed 29120K, reserved 1114112K
+  class space    used 2661K, committed 2816K, reserved 1048576K
+}
+Event: 6.934 {metaspace Before GC invocations=8 (full 0):
+ Metaspace       used 29427K, committed 29824K, reserved 1114112K
+  class space    used 2727K, committed 2880K, reserved 1048576K
+}
+Event: 6.944 {metaspace After GC invocations=9 (full 0):
+ Metaspace       used 29427K, committed 29824K, reserved 1114112K
+  class space    used 2727K, committed 2880K, reserved 1048576K
+}
+Event: 7.164 {metaspace Before GC invocations=9 (full 0):
+ Metaspace       used 29604K, committed 30016K, reserved 1114112K
+  class space    used 2732K, committed 2880K, reserved 1048576K
+}
+Event: 7.177 {metaspace After GC invocations=10 (full 0):
+ Metaspace       used 29604K, committed 30016K, reserved 1114112K
+  class space    used 2732K, committed 2880K, reserved 1048576K
+}
+Event: 7.532 {metaspace Before GC invocations=11 (full 0):
+ Metaspace       used 30187K, committed 30592K, reserved 1114112K
+  class space    used 2759K, committed 2944K, reserved 1048576K
+}
+Event: 7.542 {metaspace After GC invocations=12 (full 0):
+ Metaspace       used 30187K, committed 30592K, reserved 1114112K
+  class space    used 2759K, committed 2944K, reserved 1048576K
+}
+Event: 8.125 {metaspace Before GC invocations=12 (full 0):
+ Metaspace       used 32065K, committed 32512K, reserved 1114112K
+  class space    used 2942K, committed 3136K, reserved 1048576K
+}
+Event: 8.137 {metaspace After GC invocations=13 (full 0):
+ Metaspace       used 32065K, committed 32512K, reserved 1114112K
+  class space    used 2942K, committed 3136K, reserved 1048576K
+}
+Event: 8.425 {metaspace Before GC invocations=13 (full 0):
+ Metaspace       used 32166K, committed 32640K, reserved 1114112K
+  class space    used 2950K, committed 3136K, reserved 1048576K
+}
+Event: 8.427 {metaspace After GC invocations=14 (full 0):
+ Metaspace       used 32166K, committed 32640K, reserved 1114112K
+  class space    used 2950K, committed 3136K, reserved 1048576K
+}
+Event: 8.696 {metaspace Before GC invocations=15 (full 0):
+ Metaspace       used 32175K, committed 32640K, reserved 1114112K
+  class space    used 2950K, committed 3136K, reserved 1048576K
+}
+Event: 8.697 {metaspace After GC invocations=16 (full 0):
+ Metaspace       used 32175K, committed 32640K, reserved 1114112K
+  class space    used 2950K, committed 3136K, reserved 1048576K
+}
+
+Dll operation events (7 events):
+Event: 0.011 Loaded shared library C:\Users\Mohab\.jdks\openjdk-25.0.1\bin\java.dll
+Event: 0.054 Loaded shared library C:\Users\Mohab\.jdks\openjdk-25.0.1\bin\net.dll
+Event: 0.056 Loaded shared library C:\Users\Mohab\.jdks\openjdk-25.0.1\bin\nio.dll
+Event: 0.060 Loaded shared library C:\Users\Mohab\.jdks\openjdk-25.0.1\bin\zip.dll
+Event: 0.182 Loaded shared library C:\apache-maven-3.9.10\lib\jansi-native\Windows\x86_64\jansi.dll
+Event: 0.183 Loaded shared library C:\Users\Mohab\.jdks\openjdk-25.0.1\bin\jimage.dll
+Event: 0.191 Loaded shared library C:\Users\Mohab\.jdks\openjdk-25.0.1\bin\verify.dll
+
+Deoptimization events (20 events):
+Event: 8.892 Thread 0x000001527a5d3ea0 Uncommon trap: trap_request=0xffffff45 fr.pc=0x0000015210659840 relative=0x00000000000064c0
+Event: 8.892 Thread 0x000001527a5d3ea0 Uncommon trap: reason=unstable_if action=reinterpret pc=0x0000015210659840 method=java.lang.invoke.MethodType.genericMethodType(IZ)Ljava/lang/invoke/MethodType; @ 27 c2
+Event: 8.892 Thread 0x000001527a5d3ea0 DEOPT PACKING pc=0x0000015210659840 sp=0x00000036b81fc210
+Event: 8.892 Thread 0x000001527a5d3ea0 DEOPT UNPACKING pc=0x000001520fd2f882 sp=0x00000036b81fc1c0 mode 2
+Event: 8.900 Thread 0x000001527a5d3ea0 Uncommon trap: trap_request=0xffffffde fr.pc=0x000001521039ecd0 relative=0x0000000000000050
+Event: 8.900 Thread 0x000001527a5d3ea0 Uncommon trap: reason=class_check action=maybe_recompile pc=0x000001521039ecd0 method=java.lang.invoke.DirectMethodHandle.internalMemberName(Ljava/lang/Object;)Ljava/lang/Object; @ 1 c2
+Event: 8.900 Thread 0x000001527a5d3ea0 DEOPT PACKING pc=0x000001521039ecd0 sp=0x00000036b81fc7c0
+Event: 8.900 Thread 0x000001527a5d3ea0 DEOPT UNPACKING pc=0x000001520fd2f882 sp=0x00000036b81fc750 mode 2
+Event: 8.902 Thread 0x000001527a5d3ea0 Uncommon trap: trap_request=0xffffffde fr.pc=0x000001521039ecd0 relative=0x0000000000000050
+Event: 8.902 Thread 0x000001527a5d3ea0 Uncommon trap: reason=class_check action=maybe_recompile pc=0x000001521039ecd0 method=java.lang.invoke.DirectMethodHandle.internalMemberName(Ljava/lang/Object;)Ljava/lang/Object; @ 1 c2
+Event: 8.902 Thread 0x000001527a5d3ea0 DEOPT PACKING pc=0x000001521039ecd0 sp=0x00000036b81fc890
+Event: 8.902 Thread 0x000001527a5d3ea0 DEOPT UNPACKING pc=0x000001520fd2f882 sp=0x00000036b81fc820 mode 2
+Event: 8.902 Thread 0x000001527a5d3ea0 Uncommon trap: trap_request=0xffffffde fr.pc=0x000001521039ecd0 relative=0x0000000000000050
+Event: 8.902 Thread 0x000001527a5d3ea0 Uncommon trap: reason=class_check action=maybe_recompile pc=0x000001521039ecd0 method=java.lang.invoke.DirectMethodHandle.internalMemberName(Ljava/lang/Object;)Ljava/lang/Object; @ 1 c2
+Event: 8.902 Thread 0x000001527a5d3ea0 DEOPT PACKING pc=0x000001521039ecd0 sp=0x00000036b81fc6b0
+Event: 8.902 Thread 0x000001527a5d3ea0 DEOPT UNPACKING pc=0x000001520fd2f882 sp=0x00000036b81fc640 mode 2
+Event: 8.902 Thread 0x000001527a5d3ea0 Uncommon trap: trap_request=0xffffffde fr.pc=0x000001521039ecd0 relative=0x0000000000000050
+Event: 8.902 Thread 0x000001527a5d3ea0 Uncommon trap: reason=class_check action=maybe_recompile pc=0x000001521039ecd0 method=java.lang.invoke.DirectMethodHandle.internalMemberName(Ljava/lang/Object;)Ljava/lang/Object; @ 1 c2
+Event: 8.902 Thread 0x000001527a5d3ea0 DEOPT PACKING pc=0x000001521039ecd0 sp=0x00000036b81fc780
+Event: 8.902 Thread 0x000001527a5d3ea0 DEOPT UNPACKING pc=0x000001520fd2f882 sp=0x00000036b81fc710 mode 2
+
+Classes loaded (20 events):
+Event: 7.936 Loading class java/util/IdentityHashMap$EntrySet
+Event: 7.937 Loading class java/util/IdentityHashMap$EntrySet done
+Event: 7.937 Loading class java/util/IdentityHashMap$EntryIterator
+Event: 7.937 Loading class java/util/IdentityHashMap$EntryIterator done
+Event: 7.938 Loading class java/util/IdentityHashMap$EntryIterator$Entry
+Event: 7.938 Loading class java/util/IdentityHashMap$EntryIterator$Entry done
+Event: 7.944 Loading class java/util/function/UnaryOperator
+Event: 7.944 Loading class java/util/function/UnaryOperator done
+Event: 7.951 Loading class java/util/regex/Pattern$Caret
+Event: 7.952 Loading class java/util/regex/Pattern$Caret done
+Event: 8.867 Loading class java/util/regex/Pattern$SliceI
+Event: 8.867 Loading class java/util/regex/Pattern$SliceI done
+Event: 8.894 Loading class java/lang/invoke/BoundMethodHandle$Species_LLLLLL
+Event: 8.894 Loading class java/lang/invoke/BoundMethodHandle$Species_LLLLLL done
+Event: 8.895 Loading class java/lang/invoke/MethodHandleImpl$ArrayAccessor
+Event: 8.896 Loading class java/lang/invoke/MethodHandleImpl$ArrayAccessor done
+Event: 8.896 Loading class java/lang/invoke/MethodHandleImpl$ArrayAccessor$1
+Event: 8.896 Loading class java/lang/invoke/MethodHandleImpl$ArrayAccessor$1 done
+Event: 8.897 Loading class java/lang/invoke/BoundMethodHandle$Species_LLLLLLL
+Event: 8.897 Loading class java/lang/invoke/BoundMethodHandle$Species_LLLLLLL done
+
+Classes unloaded (0 events):
+No events
+
+Classes redefined (0 events):
+No events
+
+Internal exceptions (20 events):
+Event: 7.469 Thread 0x000001527a5d3ea0 Exception <a 'sun/nio/fs/WindowsException'{0x0000000693950400}> (0x0000000693950400) 
+thrown [s\open\src\hotspot\share\prims\jni.cpp, line 516]
+Event: 7.469 Thread 0x000001527a5d3ea0 Exception <a 'sun/nio/fs/WindowsException'{0x00000006939be9e8}> (0x00000006939be9e8) 
+thrown [s\open\src\hotspot\share\prims\jni.cpp, line 516]
+Event: 7.484 Thread 0x000001527a5d3ea0 Exception <a 'sun/nio/fs/WindowsException'{0x0000000693463248}> (0x0000000693463248) 
+thrown [s\open\src\hotspot\share\prims\jni.cpp, line 516]
+Event: 7.484 Thread 0x000001527a5d3ea0 Exception <a 'sun/nio/fs/WindowsException'{0x0000000693463bb8}> (0x0000000693463bb8) 
+thrown [s\open\src\hotspot\share\prims\jni.cpp, line 516]
+Event: 7.484 Thread 0x000001527a5d3ea0 Exception <a 'sun/nio/fs/WindowsException'{0x00000006934719f8}> (0x00000006934719f8) 
+thrown [s\open\src\hotspot\share\prims\jni.cpp, line 516]
+Event: 7.484 Thread 0x000001527a5d3ea0 Exception <a 'sun/nio/fs/WindowsException'{0x0000000693496960}> (0x0000000693496960) 
+thrown [s\open\src\hotspot\share\prims\jni.cpp, line 516]
+Event: 7.605 Thread 0x000001527a5d3ea0 Implicit null exception at 0x0000015210472eef to 0x0000015210473394
+Event: 7.621 Thread 0x000001527a5d3ea0 Implicit null exception at 0x000001521057dfcb to 0x000001521057e1ec
+Event: 7.980 Thread 0x000001527a5d3ea0 Implicit null exception at 0x00000152105c0739 to 0x00000152105c0b48
+Event: 8.844 Thread 0x000001527a5d3ea0 Implicit null exception at 0x00000152103dc95c to 0x00000152103dd0f8
+Event: 8.891 Thread 0x000001527a5d3ea0 Exception <a 'java/lang/NoSuchMethodError'{0x00000006924d2778}: 'java.lang.Object java.lang.invoke.DelegatingMethodHandle$Holder.reinvoke_L(java.lang.Object, java.lang.Object, long, java.lang.Object)'> (0x00000006924d2778) 
+thrown [s\open\src\hotspot\share\interpreter\linkResolver.cpp, line 804]
+Event: 8.893 Thread 0x000001527a5d3ea0 Exception <a 'java/lang/NoSuchMethodError'{0x00000006924fb320}: 'java.lang.Object java.lang.invoke.DirectMethodHandle$Holder.invokeVirtual(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object)'> (0x00000006924fb320) 
+thrown [s\open\src\hotspot\share\interpreter\linkResolver.cpp, line 804]
+Event: 8.895 Thread 0x000001527a5d3ea0 Exception <a 'java/lang/NoSuchMethodError'{0x000000069253d9f0}: 'java.lang.Object java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object)'> (0x000000069253d9f0) 
+thrown [s\open\src\hotspot\share\interpreter\linkResolver.cpp, line 804]
+Event: 8.896 Thread 0x000001527a5d3ea0 Exception <a 'java/lang/NoSuchMethodError'{0x0000000692556678}: 'java.lang.Object java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(java.lang.Object, java.lang.Object, int)'> (0x0000000692556678) 
+thrown [s\open\src\hotspot\share\interpreter\linkResolver.cpp, line 804]
+Event: 8.896 Thread 0x000001527a5d3ea0 Exception <a 'java/lang/NoSuchMethodError'{0x000000069255f028}: 'void java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(java.lang.Object, java.lang.Object, int, java.lang.Object)'> (0x000000069255f028) 
+thrown [s\open\src\hotspot\share\interpreter\linkResolver.cpp, line 804]
+Event: 8.896 Thread 0x000001527a5d3ea0 Exception <a 'java/lang/NoSuchMethodError'{0x000000069256f5b8}: 'void java.lang.invoke.DelegatingMethodHandle$Holder.delegate(java.lang.Object, java.lang.Object, int, java.lang.Object)'> (0x000000069256f5b8) 
+thrown [s\open\src\hotspot\share\interpreter\linkResolver.cpp, line 804]
+Event: 8.898 Thread 0x000001527a5d3ea0 Exception <a 'java/lang/NoSuchMethodError'{0x0000000692594fc0}: 'java.lang.Object java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object)'> (0x0000000692594fc0) 
+thrown [s\open\src\hotspot\share\interpreter\linkResolver.cpp, line 804]
+Event: 8.901 Thread 0x000001527a5d3ea0 Exception <a 'java/lang/NoSuchMethodError'{0x00000006925c6a00}: 'void java.lang.invoke.DirectMethodHandle$Holder.invokeInterface(java.lang.Object, java.lang.Object, java.lang.Object, int)'> (0x00000006925c6a00) 
+thrown [s\open\src\hotspot\share\interpreter\linkResolver.cpp, line 804]
+Event: 8.901 Thread 0x000001527a5d3ea0 Exception <a 'java/lang/NoSuchMethodError'{0x00000006925d7480}: 'void java.lang.invoke.DelegatingMethodHandle$Holder.reinvoke_L(java.lang.Object, java.lang.Object, java.lang.Object, int)'> (0x00000006925d7480) 
+thrown [s\open\src\hotspot\share\interpreter\linkResolver.cpp, line 804]
+Event: 8.905 Thread 0x000001527a5d3ea0 Exception <a 'java/lang/NoSuchMethodError'{0x0000000692623648}: 'java.lang.Object java.lang.invoke.DirectMethodHandle$Holder.invokeVirtual(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object)'> (0x0000000692623648) 
+thrown [s\open\src\hotspot\share\interpreter\linkResolver.cpp, line 804]
+
+VM Operations (20 events):
+Event: 7.532 Executing safepoint VM operation: G1CollectForAllocation (G1 Evacuation Pause)
+Event: 7.542 Executing safepoint VM operation: G1CollectForAllocation (G1 Evacuation Pause) done
+Event: 7.633 Executing non-safepoint VM operation: HandshakeAllThreads (Deoptimize)
+Event: 7.633 Executing non-safepoint VM operation: HandshakeAllThreads (Deoptimize) done
+Event: 7.793 Executing non-safepoint VM operation: HandshakeAllThreads (Deoptimize)
+Event: 7.793 Executing non-safepoint VM operation: HandshakeAllThreads (Deoptimize) done
+Event: 7.938 Executing non-safepoint VM operation: HandshakeAllThreads (Deoptimize)
+Event: 7.938 Executing non-safepoint VM operation: HandshakeAllThreads (Deoptimize) done
+Event: 8.125 Executing safepoint VM operation: G1CollectForAllocation (G1 Evacuation Pause)
+Event: 8.137 Executing safepoint VM operation: G1CollectForAllocation (G1 Evacuation Pause) done
+Event: 8.425 Executing safepoint VM operation: G1CollectForAllocation (G1 Evacuation Pause)
+Event: 8.428 Executing safepoint VM operation: G1CollectForAllocation (G1 Evacuation Pause) done
+Event: 8.503 Executing safepoint VM operation: G1PauseRemark
+Event: 8.511 Executing safepoint VM operation: G1PauseRemark done
+Event: 8.534 Executing safepoint VM operation: G1PauseCleanup
+Event: 8.535 Executing safepoint VM operation: G1PauseCleanup done
+Event: 8.696 Executing safepoint VM operation: G1CollectForAllocation (G1 Evacuation Pause)
+Event: 8.697 Executing safepoint VM operation: G1CollectForAllocation (G1 Evacuation Pause) done
+Event: 8.872 Executing non-safepoint VM operation: HandshakeAllThreads (Deoptimize)
+Event: 8.873 Executing non-safepoint VM operation: HandshakeAllThreads (Deoptimize) done
+
+Memory protections (0 events):
+No events
+
+Nmethod flushes (20 events):
+Event: 8.509 Thread 0x000001527f137040 flushing  nmethod 0x000001520976c188
+Event: 8.509 Thread 0x000001527f137040 flushing  nmethod 0x000001520976d608
+Event: 8.509 Thread 0x000001527f137040 flushing  nmethod 0x000001520976ec88
+Event: 8.509 Thread 0x000001527f137040 flushing  nmethod 0x00000152097c6088
+Event: 8.509 Thread 0x000001527f137040 flushing  nmethod 0x00000152097cab08
+Event: 8.509 Thread 0x000001527f137040 flushing  nmethod 0x0000015209809588
+Event: 8.509 Thread 0x000001527f137040 flushing  nmethod 0x0000015209831e88
+Event: 8.509 Thread 0x000001527f137040 flushing  nmethod 0x0000015209832188
+Event: 8.509 Thread 0x000001527f137040 flushing  nmethod 0x0000015209832b88
+Event: 8.509 Thread 0x000001527f137040 flushing  nmethod 0x0000015209834288
+Event: 8.509 Thread 0x000001527f137040 flushing  nmethod 0x000001520983c588
+Event: 8.509 Thread 0x000001527f137040 flushing  nmethod 0x000001520983da08
+Event: 8.509 Thread 0x000001527f137040 flushing  nmethod 0x0000015209840188
+Event: 8.509 Thread 0x000001527f137040 flushing  nmethod 0x0000015209840488
+Event: 8.509 Thread 0x000001527f137040 flushing  nmethod 0x0000015209843d08
+Event: 8.509 Thread 0x000001527f137040 flushing  nmethod 0x000001520984bb08
+Event: 8.509 Thread 0x000001527f137040 flushing  nmethod 0x000001520984d288
+Event: 8.509 Thread 0x000001527f137040 flushing  nmethod 0x000001520984d588
+Event: 8.509 Thread 0x000001527f137040 flushing  nmethod 0x0000015209868888
+Event: 8.509 Thread 0x000001527f137040 flushing  nmethod 0x0000015209869088
+
+Events (20 events):
+Event: 0.471 Thread 0x000001527f168940 Thread added: 0x000001521f5c99d0
+Event: 0.471 Thread 0x000001527f168940 Thread added: 0x000001521f5c91c0
+Event: 0.471 Thread 0x000001527f168940 Thread added: 0x000001521f5c81a0
+Event: 0.479 Thread 0x000001521f5c6970 Thread added: 0x000001521f5c89b0
+Event: 0.479 Thread 0x000001521f5c6970 Thread added: 0x0000015224dfbd00
+Event: 0.480 Thread 0x000001521f5c6970 Thread added: 0x0000015224df94b0
+Event: 0.904 Thread 0x0000015224df94b0 Thread exited: 0x0000015224df94b0
+Event: 1.126 Thread 0x0000015224dfbd00 Thread exited: 0x0000015224dfbd00
+Event: 3.840 Thread 0x000001521f5c89b0 Thread added: 0x0000015224e01dc0
+Event: 3.840 Thread 0x000001521f5c89b0 Thread added: 0x0000015224e04610
+Event: 4.316 Thread 0x0000015224e04610 Thread exited: 0x0000015224e04610
+Event: 4.556 Thread 0x0000015224e01dc0 Thread exited: 0x0000015224e01dc0
+Event: 4.840 Thread 0x000001521f5c89b0 Thread exited: 0x000001521f5c89b0
+Event: 5.037 Thread 0x000001521f5c81a0 Thread exited: 0x000001521f5c81a0
+Event: 5.510 Thread 0x000001521f5c6160 Thread added: 0x0000015224e04e20
+Event: 5.549 Thread 0x000001521f5c6970 Thread added: 0x0000015224e015b0
+Event: 6.111 Thread 0x000001527f168940 Thread added: 0x0000015224e05e40
+Event: 7.737 Thread 0x0000015224e05e40 Thread exited: 0x0000015224e05e40
+Event: 8.055 Thread 0x000001521f5c6970 Thread added: 0x0000015224dfdd40
+Event: 8.199 Thread 0x000001521f5c3100 Thread added: 0x0000015224dff570
+
+
+Dynamic libraries:
+0x00007ff701a50000 - 0x00007ff701a5e000 	C:\Users\Mohab\.jdks\openjdk-25.0.1\bin\java.exe
+0x00007ffc6db80000 - 0x00007ffc6dde6000 	C:\Windows\SYSTEM32\ntdll.dll
+0x00007ffc6bd00000 - 0x00007ffc6bdc9000 	C:\Windows\System32\KERNEL32.DLL
+0x00007ffc6b280000 - 0x00007ffc6b680000 	C:\Windows\System32\KERNELBASE.dll
+0x00007ffc6b690000 - 0x00007ffc6b7dc000 	C:\Windows\System32\ucrtbase.dll
+0x00007ffc46d20000 - 0x00007ffc46d3e000 	C:\Users\Mohab\.jdks\openjdk-25.0.1\bin\VCRUNTIME140.dll
+0x00007ffc47420000 - 0x00007ffc47437000 	C:\Users\Mohab\.jdks\openjdk-25.0.1\bin\jli.dll
+0x00007ffc6c8f0000 - 0x00007ffc6cab7000 	C:\Windows\System32\USER32.dll
+0x00007ffc55cf0000 - 0x00007ffc55f82000 	C:\Windows\WinSxS\amd64_microsoft.windows.common-controls_6595b64144ccf1df_6.0.26100.8737_none_3e092eaee333b772\COMCTL32.dll
+0x00007ffc6b250000 - 0x00007ffc6b277000 	C:\Windows\System32\win32u.dll
+0x00007ffc6d220000 - 0x00007ffc6d2c9000 	C:\Windows\System32\msvcrt.dll
+0x00007ffc6bfb0000 - 0x00007ffc6bfdb000 	C:\Windows\System32\GDI32.dll
+0x00007ffc6af20000 - 0x00007ffc6b049000 	C:\Windows\System32\gdi32full.dll
+0x00007ffc6b0e0000 - 0x00007ffc6b183000 	C:\Windows\System32\msvcp_win.dll
+0x00007ffc6c090000 - 0x00007ffc6c0c2000 	C:\Windows\System32\IMM32.DLL
+0x00007ffc65440000 - 0x00007ffc6544c000 	C:\Users\Mohab\.jdks\openjdk-25.0.1\bin\vcruntime140_1.dll
+0x00007ffc24000000 - 0x00007ffc2408d000 	C:\Users\Mohab\.jdks\openjdk-25.0.1\bin\msvcp140.dll
+0x00007ffb9c5c0000 - 0x00007ffb9d41f000 	C:\Users\Mohab\.jdks\openjdk-25.0.1\bin\server\jvm.dll
+0x00007ffc6bb70000 - 0x00007ffc6bc27000 	C:\Windows\System32\ADVAPI32.dll
+0x00007ffc6ba00000 - 0x00007ffc6baaa000 	C:\Windows\System32\sechost.dll
+0x00007ffc6b8b0000 - 0x00007ffc6b9c8000 	C:\Windows\System32\RPCRT4.dll
+0x00007ffc6cb20000 - 0x00007ffc6cba0000 	C:\Windows\System32\WS2_32.dll
+0x00007ffc6ac00000 - 0x00007ffc6ac5e000 	C:\Windows\SYSTEM32\POWRPROF.dll
+0x00007ffc63e10000 - 0x00007ffc63e1b000 	C:\Windows\SYSTEM32\VERSION.dll
+0x00007ffc681e0000 - 0x00007ffc68216000 	C:\Windows\SYSTEM32\WINMM.dll
+0x00007ffc6abe0000 - 0x00007ffc6abf4000 	C:\Windows\SYSTEM32\UMPDC.dll
+0x00007ffc69a80000 - 0x00007ffc69a9b000 	C:\Windows\SYSTEM32\kernel.appcore.dll
+0x00007ffc628d0000 - 0x00007ffc628da000 	C:\Users\Mohab\.jdks\openjdk-25.0.1\bin\jimage.dll
+0x00007ffc67e60000 - 0x00007ffc680a2000 	C:\Windows\SYSTEM32\DBGHELP.DLL
+0x00007ffc6d7b0000 - 0x00007ffc6db33000 	C:\Windows\System32\combase.dll
+0x00007ffc6d040000 - 0x00007ffc6d119000 	C:\Windows\System32\OLEAUT32.dll
+0x00007ffc680b0000 - 0x00007ffc680eb000 	C:\Windows\SYSTEM32\dbgcore.DLL
+0x00007ffc6b190000 - 0x00007ffc6b23c000 	C:\Windows\System32\bcryptPrimitives.dll
+0x00007ffc2afb0000 - 0x00007ffc2afcf000 	C:\Users\Mohab\.jdks\openjdk-25.0.1\bin\java.dll
+0x00007ffc6d4b0000 - 0x00007ffc6d649000 	C:\Windows\System32\ole32.dll
+0x00007ffc6c0d0000 - 0x00007ffc6c862000 	C:\Windows\System32\SHELL32.dll
+0x00007ffc68820000 - 0x00007ffc690b2000 	C:\Windows\SYSTEM32\windows.storage.dll
+0x00007ffc6d6b0000 - 0x00007ffc6d7a7000 	C:\Windows\System32\SHCORE.dll
+0x00007ffc6bf40000 - 0x00007ffc6bfa7000 	C:\Windows\System32\shlwapi.dll
+0x00007ffc6acc0000 - 0x00007ffc6ace9000 	C:\Windows\SYSTEM32\profapi.dll
+0x00007ffc36880000 - 0x00007ffc36892000 	C:\Users\Mohab\.jdks\openjdk-25.0.1\bin\net.dll
+0x00007ffc6a030000 - 0x00007ffc6a09c000 	C:\Windows\system32\mswsock.dll
+0x00007ffc2af90000 - 0x00007ffc2afa6000 	C:\Users\Mohab\.jdks\openjdk-25.0.1\bin\nio.dll
+0x00007ffc24230000 - 0x00007ffc24247000 	C:\Users\Mohab\.jdks\openjdk-25.0.1\bin\zip.dll
+0x00007ffc53600000 - 0x00007ffc53624000 	C:\apache-maven-3.9.10\lib\jansi-native\Windows\x86_64\jansi.dll
+0x00007ffc65560000 - 0x00007ffc65570000 	C:\Users\Mohab\.jdks\openjdk-25.0.1\bin\verify.dll
+
+JVMTI agents: none
+
+dbghelp: loaded successfully - version: 4.0.5 - missing functions: none
+symbol engine: initialized successfully - sym options: 0x614 - pdb path: .;C:\Users\Mohab\.jdks\openjdk-25.0.1\bin;C:\Windows\SYSTEM32;C:\Windows\WinSxS\amd64_microsoft.windows.common-controls_6595b64144ccf1df_6.0.26100.8737_none_3e092eaee333b772;C:\Users\Mohab\.jdks\openjdk-25.0.1\bin\server;C:\apache-maven-3.9.10\lib\jansi-native\Windows\x86_64
+
+VM Arguments:
+jvm_args: --add-opens=java.base/java.lang=ALL-UNNAMED --enable-native-access=ALL-UNNAMED -XX:+IgnoreUnrecognizedVMOptions --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8 -Dclassworlds.conf=C:/apache-maven-3.9.10/bin/m2.conf -Dmaven.home=C:/apache-maven-3.9.10 -Dlibrary.jansi.path=C:/apache-maven-3.9.10/lib/jansi-native -Dmaven.multiModuleProjectDirectory=C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE 
+java_command: org.codehaus.plexus.classworlds.launcher.Launcher -q -pl shaft-engine test -Dtest=WebDriverElementValidationsBuilderAriaSnapshotUnitTest,AriaSnapshotHelperUnitTest -DheadlessExecution=true -Dgpg.skip=true -Dallure.skip=true
+java_class_path (initial): C:/apache-maven-3.9.10/boot/plexus-classworlds-2.9.0.jar
+Launcher Type: SUN_STANDARD
+
+[Global flags]
+     intx CICompilerCount                          = 12                                        {product} {ergonomic}
+     uint ConcGCThreads                            = 3                                         {product} {ergonomic}
+     uint G1ConcRefinementThreads                  = 13                                        {product} {ergonomic}
+   size_t G1HeapRegionSize                         = 4194304                                   {product} {ergonomic}
+     bool IgnoreUnrecognizedVMOptions              = true                                      {product} {command line}
+   size_t InitialHeapSize                          = 394264576                                 {product} {ergonomic}
+   size_t MarkStackSize                            = 4194304                                   {product} {ergonomic}
+   size_t MarkStackSizeMax                         = 536870912                                 {product} {ergonomic}
+   size_t MaxHeapSize                              = 6283067392                                {product} {ergonomic}
+   size_t MaxNewSize                               = 3766484992                                {product} {ergonomic}
+   size_t MinHeapDeltaBytes                        = 4194304                                   {product} {ergonomic}
+   size_t MinHeapSize                              = 8388608                                   {product} {ergonomic}
+    uintx NonNMethodCodeHeapSize                   = 7602176                                {pd product} {ergonomic}
+    uintx NonProfiledCodeHeapSize                  = 122093568                              {pd product} {ergonomic}
+    uintx ProfiledCodeHeapSize                     = 121962496                              {pd product} {ergonomic}
+    uintx ReservedCodeCacheSize                    = 251658240                              {pd product} {ergonomic}
+     bool SegmentedCodeCache                       = true                                      {product} {ergonomic}
+   size_t SoftMaxHeapSize                          = 6283067392                             {manageable} {ergonomic}
+     bool UseCompressedOops                        = true                           {product lp64_product} {ergonomic}
+     bool UseG1GC                                  = true                                      {product} {ergonomic}
+     bool UseLargePagesIndividualAllocation        = false                                  {pd product} {ergonomic}
+
+Logging:
+Log output configuration:
+ #0: stdout all=warning uptime,level,tags foldmultilines=false
+ #1: stderr all=off uptime,level,tags foldmultilines=false
+
+Release file:
+IMPLEMENTOR="Oracle Corporation" 
+JAVA_RUNTIME_VERSION="25.0.1+8-27" 
+JAVA_VERSION="25.0.1" 
+JAVA_VERSION_DATE="2025-10-21" 
+LIBC="default" 
+MODULES="java.base java.compiler java.datatransfer java.xml java.prefs java.desktop java.instrument java.logging java.management java.security.sasl java.naming java.rmi java.management.rmi java.net.http java.scripting java.security.jgss java.transaction.xa java.sql java.sql.rowset java.xml.crypto java.se java.smartcardio jdk.accessibility jdk.internal.jvmstat jdk.attach jdk.charsets jdk.internal.opt jdk.zipfs jdk.compiler jdk.crypto.cryptoki jdk.crypto.ec jdk.crypto.mscapi jdk.dynalink jdk.internal.ed jdk.editpad jdk.internal.vm.ci jdk.graal.compiler jdk.graal.compiler.management jdk.hotspot.agent jdk.httpserver jdk.incubator.vector jdk.internal.le jdk.internal.md jdk.jartool jdk.javadoc jdk.jcmd jdk.management jdk.management.agent jdk.jconsole jdk.jdeps jdk.jdwp.agent jdk.jdi jdk.jfr jdk.jlink jdk.jpackage jdk.jshell jdk.jsobject jdk.jstatd jdk.localedata jdk.management.jfr jdk.naming.dns jdk.naming.rmi jdk.net jdk.nio.mapmode jdk.sctp jdk.security.auth jdk.security.jgss jdk.unsupported jdk.unsupported.desktop jdk.xml.dom" 
+OS_ARCH="x86_64" 
+OS_NAME="Windows" 
+SOURCE=".:git:78770bfaefd2" 
+
+Environment Variables:
+JAVA_HOME=C:/Users/Mohab/.jdks/openjdk-25.0.1
+PATH=C:\Users\Mohab\bin;C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\local\bin;C:\Program Files\Git\usr\bin;C:\Program Files\Git\usr\bin;C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin;C:\Users\Mohab\bin;C:\Program Files\PowerShell\7;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3\bin\x64;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3\bin;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.3\libnvvp;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0;C:\Windows\System32\OpenSSH;C:\Program Files (x86)\NVIDIA Corporation\PhysX\Common;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0;C:\Windows\System32\OpenSSH;C:\Program Files\NVIDIA Corporation\NVIDIA App\NvDLISR;C:\Program Files (x86)\Yarn\bin;C:\Program Files\dotnet;C:\Program Files\NVIDIA Corporation\Nsight Compute 2026.2.0;C:\Program Files\Microsoft SQL Server\170\Tools\Binn;C:\Program Files\Microsoft SQL Server\Client SDK\ODBC\170\Tools\Binn;C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit;C:\Program Files\PowerShell\7;C:\Program Files\nodejs;C:\Program Files\Docker\Docker\resources\bin;C:\Program Files\GitHub CLI;C:\Program Files\Git\cmd;C:\Program Files\Go\bin;C:\Program Files\CMake\bin;C:\Users\Mohab\.grok\bin;C:\Users\Mohab\scoop\shims;C:\Users\Mohab\AppData\Local\Programs\Python\Python314\Scripts;C:\Users\Mohab\AppData\Local\Programs\Python\Python314;C:\Users\Mohab\AppData\Local\Programs\Python\Python313\Scripts;C:\Users\Mohab\AppData\Local\Programs\Python\Python313;C:\Users\Mohab\AppData\Local\Microsoft\WindowsApps;C:\Users\Mohab\AppData\Local\JetBrains\Toolbox\scripts;C:\apache-maven-3.9.10\bin;C:\Users\Mohab\AppData\Local\Programs\Microsoft VS Code\bin;C:\Users\Mohab\android-tools\cmdline-tools\platform-tools;C:\Users\Mohab\android-tools\cmdline-tools\latest\bin;C:\Users\Mohab\.jdks\openjdk-25.0.1\bin;C:\Users\Mohab\android-tools\emulator;C:\Users\Mohab\AppData\Local\Yarn\bin;C:\Users\Mohab\AppData\Local\Microsoft\WinGet\Links;C:\Users\Mohab\.local\bin;C:\Users\Mohab\AppData\Local\Programs\Ollama;C:\Users\Mohab\go\bin;C:\Users\Mohab\.dotnet\tools;C:\Users\Mohab\.lmstudio\bin;C:\Users\Mohab\.bun\bin;C:\Users\Mohab\AppData\Roaming\npm;C:\Users\Mohab\AppData\Local\PowerToys\DSCModules;C:\Users\Mohab\AppData\Roaming\Python\Python313\Scripts;C:\Users\Mohab\AppData\Local\Programs\Gradle\gradle-9.0.0\bin;C:\Users\Mohab\go\bin;C:\Program Files\Git\usr\bin\vendor_perl;C:\Program Files\Git\usr\bin\core_perl;C:\Users\Mohab\.claude\plugins\cache\claude-plugins-official\frontend-design\1633f19268ce\bin;C:\Users\Mohab\.claude\plugins\cache\claude-plugins-official\mcp-server-dev\1633f19268ce\bin;C:\Users\Mohab\.claude\plugins\cache\claude-plugins-official\skill-creator\1633f19268ce\bin;C:\Users\Mohab\.claude\plugins\cache\claude-plugins-official\jdtls-lsp\1.0.0\bin;C:\Users\Mohab\.claude\plugins\cache\fable-method\fable\1.2.1\bin;C:\Users\Mohab\.claude\plugins\cache\claude-plugins-official\superpowers\6.1.1\bin
+USERNAME=Mohab
+SHELL=C:\Program Files\Git\usr\bin\bash.exe
+TERM=xterm-256color
+OS=Windows_NT
+PROCESSOR_IDENTIFIER=AMD64 Family 25 Model 80 Stepping 0, AuthenticAMD
+TMP=C:\Users\Mohab\AppData\Local\Temp
+TEMP=C:\Users\Mohab\AppData\Local\Temp
+
+
+
+
+Compilation memory statistics disabled.
+
+Periodic native trim disabled
+
+---------------  S Y S T E M  ---------------
+
+OS:
+ Windows 11 , 64 bit Build 26100 (10.0.26100.8737)
+OS uptime: 0 days 5:06 hours
+Hyper-V role detected
+
+CPU: total 16 (initial active 16) (16 cores per cpu, 2 threads per core) family 25 model 80 stepping 0 microcode 0xa50000c, cx8, cmov, fxsr, ht, mmx, 3dnowpref, sse, sse2, sse3, ssse3, sse4a, sse4.1, sse4.2, popcnt, lzcnt, tsc, tscinvbit, avx, avx2, aes, erms, clmul, bmi1, bmi2, adx, sha, fma, vzeroupper, clflush, clflushopt, clwb, hv, rdtscp, rdpid, fsrm, f16c, cet_ss
+Processor Information for the first 16 processors :
+  Max Mhz: 3301, Current Mhz: 3301, Mhz Limit: 3301
+
+Memory: 4k page, system-wide physical 23967M (6839M free)
+TotalPageFile size 60831M (AvailPageFile size 39303M)
+current process WorkingSet (physical memory assigned to process): 579M, peak: 629M
+current process commit charge ("private bytes"): 626M, peak: 691M
+
+vm_info: OpenJDK 64-Bit Server VM (25.0.1+8-27) for windows-amd64 JRE (25.0.1+8-27), built on 2025-09-25T16:41:16Z with unknown MS VC++:1943
+
+END.

--- a/replay_pid3316.log
+++ b/replay_pid3316.log
@@ -1,0 +1,5417 @@
+version 2
+JvmtiExport can_access_local_variables 0
+JvmtiExport can_hotswap_or_post_breakpoint 1
+JvmtiExport can_post_on_exceptions 0
+# 168 ciObject found
+instanceKlass jdk/internal/classfile/impl/StackMapGenerator
+ciInstanceKlass java/lang/Cloneable 1 0 7 100 1 100 1 1 1
+instanceKlass lombok/core/handlers/InclusionExclusionUtils$1
+instanceKlass lombok/ToString$Exclude
+instanceKlass lombok/ToString$Include
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d343c00
+instanceKlass lombok/javac/handlers/JavacHandlerUtil$JCAnnotatedTypeReflect
+instanceKlass lombok/javac/handlers/JavacHandlerUtil$GetterMethod
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d343800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d343400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d343000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d342c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d342800
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d342400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d342000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d341c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d341800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d341400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d341000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d340c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d340800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d340400
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d340000
+instanceKlass lombok/EqualsAndHashCode$AnyAnnotation
+instanceKlass lombok/core/handlers/InclusionExclusionUtils$2
+instanceKlass lombok/core/handlers/InclusionExclusionUtils$Included
+instanceKlass lombok/EqualsAndHashCode$Exclude
+instanceKlass lombok/EqualsAndHashCode$Include
+instanceKlass lombok/core/handlers/InclusionExclusionUtils
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d33bc00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d33b800
+instanceKlass lombok/javac/handlers/JavacHandlerUtil$CopyJavadoc$6
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d33b400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d33b000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d33ac00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d33a800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d33a400
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d33a000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d339c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d339800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d339400
+instanceKlass com/sun/tools/javac/tree/Pretty$1
+instanceKlass lombok/core/CleanupRegistry$CleanupKey
+instanceKlass lombok/javac/handlers/JavacHandlerUtil$CopyJavadoc$2$1
+instanceKlass lombok/javac/Javac$JavadocOps_8
+instanceKlass lombok/core/CleanupTask
+instanceKlass com/sun/tools/javac/code/DeferredCompletionFailureHandler$DeferredCompleter
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d339000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d338c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d338800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d338400
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d338000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d336c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d336800
+instanceKlass com/sun/tools/javac/comp/Annotate$Queues
+instanceKlass com/sun/tools/javac/comp/Annotate$AnnotationContext
+instanceKlass lombok/javac/handlers/JavacHandlerUtil$EnterReflect
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d336400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d336000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d335c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d335800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d335400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d335000
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d334c00
+instanceKlass lombok/javac/handlers/JavacHandlerUtil$ClassSymbolMembersField
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d334800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d334400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d334000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d333c00
+# instanceKlass java/lang/invoke/LambdaForm$BMH+0x000000008d333800
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d333400
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d333000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d332c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d332800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d332400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d332000
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d331c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d331800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d331400
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d331000
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d330c00
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d330800
+instanceKlass java/lang/invoke/MethodHandleImpl$ArrayAccessor
+instanceKlass java/lang/invoke/MethodHandleImpl$CasesHolder
+instanceKlass java/lang/invoke/MethodHandleImpl$LoopClauses
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d330400
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d330000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d32bc00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d32b800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d32b400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d32b000
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d32ac00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d32a800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d32a400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d32a000
+# instanceKlass java/lang/invoke/LambdaForm$BMH+0x000000008d329c00
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d329800
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d329400
+instanceKlass lombok/core/AnnotationValues$1
+instanceKlass lombok/delombok/FormatPreferences
+instanceKlass lombok/delombok/LombokOptionsFactory
+instanceKlass lombok/core/configuration/AllowHelper
+instanceKlass  @bci java/util/regex/Pattern SingleI (II)Ljava/util/regex/Pattern$BmpCharPredicate; 2 <appendix> member <vmtarget> ; # java/util/regex/Pattern$$Lambda+0x000000008d1dbca0
+instanceKlass lombok/experimental/FieldDefaults
+instanceKlass lombok/core/handlers/HandlerUtil
+instanceKlass lombok/core/AnnotationValues
+instanceKlass lombok/core/AnnotationValues$AnnotationValue
+instanceKlass lombok/core/FieldAugment
+instanceKlass lombok/javac/JavacAugments
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d329000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d328c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d328800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d328400
+instanceKlass lombok/core/configuration/ConfigurationSource
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d328000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d327c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d327800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d327400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d327000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d326c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d326800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d326400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d326000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d325c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d325800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d325400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d325000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d324c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d324800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d324400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d324000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d323c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d323800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d323400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d323000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d322c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d322800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d322400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d322000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d321c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d321800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d321400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d321000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d320c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d320800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d320400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d320000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d31dc00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d31d800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d31d400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d31d000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d31cc00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d31c800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d31c400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d31c000
+instanceKlass lombok/core/TypeResolver
+instanceKlass lombok/core/LombokImmutableList$1
+instanceKlass lombok/core/AST$FieldAccess
+instanceKlass lombok/javac/JavacImportList
+instanceKlass lombok/javac/PackageName
+instanceKlass lombok/core/configuration/FileSystemSourceCache$Content
+instanceKlass lombok/core/configuration/ConfigurationFile
+instanceKlass lombok/core/configuration/BubblingConfigurationResolver
+instanceKlass lombok/core/LombokConfiguration$3
+instanceKlass lombok/core/configuration/FileSystemSourceCache$1
+instanceKlass lombok/core/configuration/ConfigurationProblemReporter$1
+instanceKlass lombok/core/configuration/ConfigurationProblemReporter
+instanceKlass lombok/core/configuration/ConfigurationParser
+instanceKlass lombok/core/configuration/ConfigurationFileToSource
+instanceKlass lombok/core/configuration/FileSystemSourceCache
+instanceKlass lombok/core/LombokConfiguration$1
+instanceKlass lombok/core/configuration/ConfigurationResolverFactory
+instanceKlass lombok/core/configuration/ConfigurationResolver
+instanceKlass lombok/core/LombokConfiguration
+instanceKlass lombok/core/ImportList
+instanceKlass java/util/function/UnaryOperator
+instanceKlass lombok/javac/JavacAST$ErrorLog
+instanceKlass java/util/IdentityHashMap$EntryIterator$Entry
+instanceKlass com/sun/tools/javac/model/JavacElements$1
+instanceKlass javax/annotation/processing/SupportedOptions
+instanceKlass com/sun/tools/javac/util/MatchingUtils
+instanceKlass javax/annotation/processing/SupportedAnnotationTypes
+instanceKlass lombok/javac/HandlerLibrary$VisitorContainer
+instanceKlass lombok/experimental/WithBy
+instanceKlass lombok/With
+instanceKlass lombok/Value
+instanceKlass lombok/javac/JavacASTAdapter
+instanceKlass lombok/experimental/UtilityClass
+instanceKlass lombok/ToString
+instanceKlass lombok/Synchronized
+instanceKlass lombok/experimental/SuperBuilder
+instanceKlass lombok/javac/handlers/JavacSingularsRecipes$StatementMaker
+instanceKlass lombok/javac/handlers/JavacSingularsRecipes$ExpressionMaker
+instanceKlass lombok/javac/handlers/HandleBuilder$BuilderJob
+instanceKlass lombok/experimental/StandardException
+instanceKlass lombok/SneakyThrows
+instanceKlass lombok/Singular
+instanceKlass lombok/Setter
+instanceKlass lombok/core/PrintAST
+instanceKlass lombok/NonNull
+instanceKlass lombok/extern/slf4j/XSlf4j
+instanceKlass lombok/extern/slf4j/Slf4j
+instanceKlass lombok/extern/log4j/Log4j
+instanceKlass lombok/extern/log4j/Log4j2
+instanceKlass lombok/extern/java/Log
+instanceKlass lombok/extern/jbosslog/JBossLog
+instanceKlass lombok/extern/flogger/Flogger
+instanceKlass lombok/CustomLog
+instanceKlass lombok/extern/apachecommons/CommonsLog
+instanceKlass lombok/Locked$Write
+instanceKlass lombok/Locked$Read
+instanceKlass lombok/Locked
+instanceKlass lombok/extern/jackson/Jacksonized
+instanceKlass lombok/experimental/Helper
+instanceKlass lombok/Getter
+instanceKlass lombok/experimental/FieldNameConstants
+instanceKlass lombok/core/LombokImmutableList
+instanceKlass lombok/core/JavaIdentifiers
+instanceKlass lombok/experimental/ExtensionMethod
+instanceKlass lombok/EqualsAndHashCode
+instanceKlass lombok/experimental/Delegate
+instanceKlass lombok/Data
+instanceKlass lombok/RequiredArgsConstructor
+instanceKlass lombok/NoArgsConstructor
+instanceKlass lombok/AllArgsConstructor
+instanceKlass lombok/Cleanup
+instanceKlass lombok/Builder$Default
+instanceKlass lombok/Builder
+instanceKlass lombok/javac/handlers/HandleConstructor
+instanceKlass lombok/core/LombokInternalAliasing
+instanceKlass lombok/core/AlreadyHandledAnnotations
+instanceKlass lombok/javac/ResolutionResetNeeded
+instanceKlass lombok/core/HandlerPriority
+instanceKlass lombok/javac/HandlerLibrary$AnnotationHandlerContainer
+instanceKlass lombok/experimental/Accessors
+instanceKlass lombok/javac/JavacAnnotationHandler
+instanceKlass lombok/core/SpiLoadUtil$1$1
+instanceKlass lombok/core/SpiLoadUtil$1
+instanceKlass lombok/core/SpiLoadUtil
+instanceKlass lombok/core/configuration/ConfigurationKeysLoader
+instanceKlass lombok/core/configuration/CheckerFrameworkVersion
+instanceKlass lombok/core/configuration/MappedConfigEnum
+instanceKlass lombok/core/configuration/TypeName
+instanceKlass lombok/core/configuration/LogDeclaration
+instanceKlass lombok/core/configuration/IdentifierName
+instanceKlass lombok/core/configuration/ConfigurationDataType$6
+instanceKlass lombok/core/configuration/ConfigurationDataType$7
+instanceKlass lombok/core/configuration/NullAnnotationLibrary
+instanceKlass lombok/core/configuration/ConfigurationValueType
+instanceKlass lombok/core/configuration/ConfigurationDataType$5
+instanceKlass lombok/core/configuration/ConfigurationDataType$4
+instanceKlass lombok/core/configuration/ConfigurationDataType$3
+instanceKlass lombok/core/configuration/ConfigurationDataType$2
+instanceKlass lombok/core/configuration/ConfigurationDataType$1
+instanceKlass lombok/core/configuration/ConfigurationValueParser
+instanceKlass lombok/core/configuration/ConfigurationDataType
+instanceKlass lombok/core/configuration/ConfigurationKey
+instanceKlass lombok/ConfigurationKeys
+instanceKlass lombok/core/configuration/ConfigurationKeysLoader$LoaderLoader
+instanceKlass lombok/core/TypeLibrary
+instanceKlass lombok/javac/HandlerLibrary
+instanceKlass lombok/javac/JavacASTVisitor
+instanceKlass lombok/javac/JavacTransformer
+instanceKlass java/text/BreakIterator
+instanceKlass com/sun/tools/javac/api/JavacScope
+instanceKlass com/sun/source/util/DocTreePath
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d304000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d2f9c00
+instanceKlass com/sun/source/util/TaskEvent
+instanceKlass lombok/core/LombokNode
+instanceKlass lombok/core/AST
+instanceKlass lombok/javac/handlers/JavacHandlerUtil
+instanceKlass lombok/javac/JavacTreeMaker$FieldId
+instanceKlass lombok/javac/JavacTreeMaker$MethodId
+instanceKlass lombok/javac/JavacTreeMaker
+instanceKlass javax/lang/model/type/TypeVisitor
+instanceKlass lombok/javac/JavacTreeMaker$SchroedingerType
+instanceKlass lombok/javac/Javac
+instanceKlass lombok/javac/apt/Java9Compiler
+instanceKlass lombok/javac/apt/LombokFileObjects$Compiler
+instanceKlass lombok/javac/apt/LombokFileObject
+instanceKlass lombok/javac/apt/LombokFileObjects
+instanceKlass lombok/javac/apt/MessagerDiagnosticsReceiver
+instanceKlass javax/tools/ForwardingJavaFileManager
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d2f9800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d2f9400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d2f9000
+instanceKlass java/lang/invoke/LambdaFormEditor$1
+instanceKlass lombok/permit/dummy/Parent
+instanceKlass java/lang/Class$EnclosingMethodInfo
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d2f3c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d2f3800
+instanceKlass lombok/core/CleanupRegistry
+instanceKlass lombok/permit/Permit$Fake
+instanceKlass lombok/permit/Permit
+instanceKlass lombok/core/DiagnosticsReceiver
+instanceKlass lombok/launch/AnnotationProcessorHider$AstModificationNotifierData
+instanceKlass lombok/core/AnnotationProcessor$ProcessorDescriptor
+instanceKlass lombok/launch/ClassFileMetaData
+instanceKlass java/util/zip/ZipFile$ZipEntryIterator
+instanceKlass java/util/WeakHashMap$HashIterator
+instanceKlass java/net/URLDecoder
+instanceKlass lombok/launch/PackageShader
+instanceKlass lombok/launch/Main
+instanceKlass com/sun/tools/javac/processing/JavacProcessingEnvironment$ProcessorState
+instanceKlass com/sun/tools/javac/processing/JavacRoundEnvironment
+instanceKlass javax/lang/model/util/AbstractElementVisitor6
+instanceKlass javax/lang/model/element/ElementVisitor
+instanceKlass  @bci com/sun/tools/javac/processing/JavacProcessingEnvironment$Round <init> (Lcom/sun/tools/javac/processing/JavacProcessingEnvironment;ILjava/util/Set;Lcom/sun/tools/javac/util/Log$DeferredDiagnosticHandler;)V 24 <appendix> argL0 ; # com/sun/tools/javac/processing/JavacProcessingEnvironment$Round$$Lambda+0x000000008d2f5438
+instanceKlass  @bci com/sun/tools/javac/processing/JavacProcessingEnvironment$Round <init> (Lcom/sun/tools/javac/processing/JavacProcessingEnvironment;ILjava/util/Set;Lcom/sun/tools/javac/util/Log$DeferredDiagnosticHandler;)V 15 <appendix> argL0 ; # com/sun/tools/javac/processing/JavacProcessingEnvironment$Round$$Lambda+0x000000008d2f51e0
+instanceKlass com/sun/tools/javac/processing/JavacProcessingEnvironment$Round
+instanceKlass  @bci com/sun/tools/javac/code/TypeAnnotations$TypeAnnotationPositions visitClassDef (Lcom/sun/tools/javac/tree/JCTree$JCClassDecl;)V 78 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/TypeAnnotations$TypeAnnotationPositions$$Lambda+0x000000008d2f48f8
+instanceKlass  @bci com/sun/tools/javac/code/TypeAnnotations annotationTargetType (Lcom/sun/tools/javac/tree/JCTree;Lcom/sun/tools/javac/code/Attribute$Compound;Lcom/sun/tools/javac/code/Symbol;)Lcom/sun/tools/javac/code/TypeAnnotations$AnnotationType; 64 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/TypeAnnotations$$Lambda+0x000000008d2f46a0
+instanceKlass  @bci com/sun/tools/javac/code/TypeAnnotations annotationTargetType (Lcom/sun/tools/javac/tree/JCTree;Lcom/sun/tools/javac/code/Attribute$Compound;Lcom/sun/tools/javac/code/Symbol;)Lcom/sun/tools/javac/code/TypeAnnotations$AnnotationType; 50 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/TypeAnnotations$$Lambda+0x000000008d2f4250
+instanceKlass  @bci com/sun/tools/javac/code/TypeAnnotations annotationTargets (Lcom/sun/tools/javac/code/Symbol$TypeSymbol;)Lcom/sun/tools/javac/util/List; 56 <appendix> argL0 ; # com/sun/tools/javac/code/TypeAnnotations$$Lambda+0x000000008d2efc90
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$TypeAnnotationSymbolVisitor classExtends (I)Ljava/util/function/Predicate; 1 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$TypeAnnotationSymbolVisitor$$Lambda+0x000000008d2ef5c8
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$TypeAnnotationSymbolVisitor thrownType (I)Ljava/util/function/Predicate; 1 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$TypeAnnotationSymbolVisitor$$Lambda+0x000000008d2ef370
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$TypeAnnotationStructuralTypeMapping rewriteTypeParams (Lcom/sun/tools/javac/util/List;Lcom/sun/tools/javac/util/List;)Lcom/sun/tools/javac/util/List; 19 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$TypeAnnotationStructuralTypeMapping$$Lambda+0x000000008d2ef120
+instanceKlass java/util/Spliterators$2Adapter
+instanceKlass java/util/PrimitiveIterator$OfInt
+instanceKlass java/util/PrimitiveIterator
+instanceKlass java/util/Spliterators$AbstractIntSpliterator
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$TypeAnnotationStructuralTypeMapping rewriteTypeParams (Lcom/sun/tools/javac/util/List;Lcom/sun/tools/javac/util/List;)Lcom/sun/tools/javac/util/List; 1 <appendix> argL0 ; # com/sun/tools/javac/jvm/ClassReader$TypeAnnotationStructuralTypeMapping$$Lambda+0x000000008d2eeed8
+instanceKlass java/util/function/IntUnaryOperator
+instanceKlass com/sun/tools/javac/code/Types$TypePair
+instanceKlass  @bci com/sun/tools/javac/code/Symtab getClassField (Lcom/sun/tools/javac/code/Type;Lcom/sun/tools/javac/code/Types;)Lcom/sun/tools/javac/code/Symbol$VarSymbol; 16 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Symtab$$Lambda+0x000000008d2eea70
+instanceKlass com/sun/tools/javac/code/Types$UniqueType
+instanceKlass com/sun/tools/javac/code/Flags
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$TypeAnnotationSymbolVisitor addTypeAnnotations (Lcom/sun/tools/javac/code/Type;Lcom/sun/tools/javac/code/TargetType;)Lcom/sun/tools/javac/code/Type; 3 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$TypeAnnotationSymbolVisitor$$Lambda+0x000000008d2ee3e8
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$TypeAnnotationSymbolVisitor addTypeAnnotations (Lcom/sun/tools/javac/code/Type;Ljava/util/function/Predicate;)Lcom/sun/tools/javac/code/Type; 127 <appendix> argL0 ; # com/sun/tools/javac/jvm/ClassReader$TypeAnnotationSymbolVisitor$$Lambda+0x000000008d2edc40
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$TypeAnnotationSymbolVisitor methodFormalParameter (I)Ljava/util/function/Predicate; 1 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$TypeAnnotationSymbolVisitor$$Lambda+0x000000008d2ed9e8
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$TypeAnnotationSymbolVisitor typeParameterBound (Lcom/sun/tools/javac/code/TargetType;II)Ljava/util/function/Predicate; 3 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x000000008d2f0800
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$TypeAnnotationSymbolVisitor typeParameterBound (Lcom/sun/tools/javac/code/TargetType;II)Ljava/util/function/Predicate; 3 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d2f0400
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$TypeAnnotationSymbolVisitor typeParameterBound (Lcom/sun/tools/javac/code/TargetType;II)Ljava/util/function/Predicate; 3 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$TypeAnnotationSymbolVisitor$$Lambda+0x000000008d2ed788
+instanceKlass  @cpi com/sun/tools/javac/jvm/ClassReader$TypeAnnotationSymbolVisitor 358 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d2f0000
+instanceKlass  @bci com/sun/tools/javac/code/Type constValue ()Ljava/lang/Object; 3 <appendix> argL0 ; # com/sun/tools/javac/code/Type$$Lambda+0x000000008d2ed288
+instanceKlass com/sun/tools/javac/comp/Resolve$MethodResolutionContext$Candidate
+instanceKlass com/sun/tools/javac/code/Types$ImplementationCache$Entry
+instanceKlass  @bci com/sun/tools/javac/code/Types membersClosure (Lcom/sun/tools/javac/code/Type;Z)Lcom/sun/tools/javac/code/Scope$CompoundScope; 15 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Types$$Lambda+0x000000008d2ec788
+instanceKlass com/sun/tools/javac/comp/Resolve$LookupFilter
+instanceKlass com/sun/tools/javac/comp/Resolve$MethodResolutionContext
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$ProxyType resolve ()Lcom/sun/tools/javac/code/Type; 13 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$ProxyType$$Lambda+0x000000008d2eb600
+instanceKlass  @bci com/sun/tools/javac/comp/TypeEnter ensureImportsChecked (Lcom/sun/tools/javac/util/List;)V 50 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/TypeEnter$$Lambda+0x000000008d2eb3d0
+instanceKlass com/sun/tools/javac/code/Types$25
+instanceKlass  @bci com/sun/tools/javac/code/Scope$FilterImportScope lambda$getSymbols$0 (Lcom/sun/tools/javac/util/List;)Ljava/util/Iterator; 10 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$FilterImportScope$$Lambda+0x000000008d2eaf60
+instanceKlass  @bci com/sun/tools/javac/code/Scope$FilterImportScope lambda$getSymbols$0 (Lcom/sun/tools/javac/util/List;)Ljava/util/Iterator; 1 <appendix> argL0 ; # com/sun/tools/javac/code/Scope$FilterImportScope$$Lambda+0x000000008d2ead18
+instanceKlass  @bci com/sun/tools/javac/code/Scope$FilterImportScope getSymbols (Ljava/util/function/Predicate;Lcom/sun/tools/javac/code/Scope$LookupKind;)Ljava/lang/Iterable; 58 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$FilterImportScope$$Lambda+0x000000008d2eaac8
+instanceKlass  @bci com/sun/tools/javac/code/Types$TypeMapping visit (Lcom/sun/tools/javac/util/List;Ljava/lang/Object;)Lcom/sun/tools/javac/util/List; 3 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Types$TypeMapping$$Lambda+0x000000008d2ea878
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader lookupMethod (Lcom/sun/tools/javac/code/Symbol$TypeSymbol;Lcom/sun/tools/javac/util/Name;Lcom/sun/tools/javac/util/List;)Lcom/sun/tools/javac/code/Symbol$MethodSymbol; 5 <appendix> argL0 ; # com/sun/tools/javac/jvm/ClassReader$$Lambda+0x000000008d2ea620
+instanceKlass com/sun/tools/javac/comp/TypeEnter$1
+instanceKlass com/sun/tools/javac/code/TypeAnnotationPosition$TypePathEntry
+instanceKlass com/sun/tools/javac/jvm/ClassReader$ParameterAnnotations
+instanceKlass com/sun/tools/javac/code/Scope$ImportScope$1
+instanceKlass  @bci com/sun/tools/javac/comp/TypeEnter$MembersPhase addAccessor (Lcom/sun/tools/javac/tree/JCTree$JCVariableDecl;Lcom/sun/tools/javac/comp/Env;)V 129 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/TypeEnter$MembersPhase$$Lambda+0x000000008d2e94e8
+instanceKlass  @bci com/sun/tools/javac/comp/TypeEnter$MembersPhase addRecordMembersIfNeeded (Lcom/sun/tools/javac/tree/JCTree$JCClassDecl;Lcom/sun/tools/javac/comp/Env;)V 464 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/TypeEnter$MembersPhase$$Lambda+0x000000008d2e92a8
+instanceKlass  @bci com/sun/tools/javac/comp/TypeEnter$MembersPhase addRecordMembersIfNeeded (Lcom/sun/tools/javac/tree/JCTree$JCClassDecl;Lcom/sun/tools/javac/comp/Env;)V 452 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/TypeEnter$MembersPhase$$Lambda+0x000000008d2e9048
+instanceKlass  @bci com/sun/tools/javac/comp/TypeEnter lookupMethod (Lcom/sun/tools/javac/code/Symbol$TypeSymbol;Lcom/sun/tools/javac/util/Name;Lcom/sun/tools/javac/util/List;)Lcom/sun/tools/javac/code/Symbol$MethodSymbol; 5 <appendix> argL0 ; # com/sun/tools/javac/comp/TypeEnter$$Lambda+0x000000008d2e8df0
+instanceKlass  @bci com/sun/tools/javac/comp/TypeEnter$MembersPhase finishClass (Lcom/sun/tools/javac/tree/JCTree$JCClassDecl;Lcom/sun/tools/javac/tree/JCTree;Lcom/sun/tools/javac/comp/Env;)V 123 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/TypeEnter$MembersPhase$$Lambda+0x000000008d2e8b90
+instanceKlass com/sun/tools/javac/tree/TreeMaker$2
+instanceKlass  @bci com/sun/tools/javac/comp/TypeEnter$RecordConstructorHelper <init> (Lcom/sun/tools/javac/comp/TypeEnter;Lcom/sun/tools/javac/code/Symbol$ClassSymbol;Lcom/sun/tools/javac/util/List;)V 29 <appendix> argL0 ; # com/sun/tools/javac/comp/TypeEnter$RecordConstructorHelper$$Lambda+0x000000008d2e8728
+instanceKlass  @bci com/sun/tools/javac/tree/TreeInfo recordFields (Lcom/sun/tools/javac/tree/JCTree$JCClassDecl;)Lcom/sun/tools/javac/util/List; 27 <appendix> argL0 ; # com/sun/tools/javac/tree/TreeInfo$$Lambda+0x000000008d2e8248
+instanceKlass  @bci com/sun/tools/javac/tree/TreeInfo recordFields (Lcom/sun/tools/javac/tree/JCTree$JCClassDecl;)Lcom/sun/tools/javac/util/List; 17 <appendix> argL0 ; # com/sun/tools/javac/tree/TreeInfo$$Lambda+0x000000008d2e8000
+instanceKlass  @bci com/sun/tools/javac/tree/TreeInfo recordFields (Lcom/sun/tools/javac/tree/JCTree$JCClassDecl;)Lcom/sun/tools/javac/util/List; 7 <appendix> argL0 ; # com/sun/tools/javac/tree/TreeInfo$$Lambda+0x000000008d2e4400
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader parameter (IILcom/sun/tools/javac/code/Type;Lcom/sun/tools/javac/code/Symbol$MethodSymbol;Ljava/util/Set;)Lcom/sun/tools/javac/code/Symbol$VarSymbol; 83 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$$Lambda+0x000000008d2e4d40
+instanceKlass com/sun/tools/javac/jvm/ClassReader$TypeAnnotationProxy
+instanceKlass com/sun/tools/javac/code/TypeAnnotationPosition
+instanceKlass com/sun/tools/javac/jvm/ClassReader$28
+instanceKlass  @bci com/sun/tools/javac/comp/Check checkUniqueImport (Lcom/sun/tools/javac/util/JCDiagnostic$DiagnosticPosition;Lcom/sun/tools/javac/code/Scope;Lcom/sun/tools/javac/code/Scope;Lcom/sun/tools/javac/code/Scope;Lcom/sun/tools/javac/code/Symbol;Z)Z 2 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Check$$Lambda+0x000000008d2e5480
+instanceKlass  @bci com/sun/tools/javac/comp/Check checkImportsUnique (Lcom/sun/tools/javac/tree/JCTree$JCCompilationUnit;)V 90 <appendix> argL0 ; # com/sun/tools/javac/comp/Check$$Lambda+0x000000008d2e5228
+instanceKlass  @bci com/sun/tools/javac/comp/TypeEnter complete (Lcom/sun/tools/javac/code/Symbol;)V 191 <appendix> argL0 ; # com/sun/tools/javac/comp/TypeEnter$$Lambda+0x000000008d2e5000
+instanceKlass  @bci com/sun/tools/javac/code/TypeAnnotations validateTypeAnnotationsSignatures (Lcom/sun/tools/javac/comp/Env;Lcom/sun/tools/javac/tree/JCTree$JCClassDecl;)V 7 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/TypeAnnotations$$Lambda+0x000000008d2e7bc0
+instanceKlass  @bci com/sun/tools/javac/code/TypeAnnotations organizeTypeAnnotationsSignatures (Lcom/sun/tools/javac/comp/Env;Lcom/sun/tools/javac/tree/JCTree$JCClassDecl;)V 7 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/TypeAnnotations$$Lambda+0x000000008d2e7990
+instanceKlass  @bci com/sun/tools/javac/comp/Annotate annotateLater (Lcom/sun/tools/javac/util/List;Lcom/sun/tools/javac/comp/Env;Lcom/sun/tools/javac/code/Symbol;Lcom/sun/tools/javac/tree/JCTree;)V 32 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Annotate$$Lambda+0x000000008d2e7760
+instanceKlass  @bci com/sun/tools/javac/comp/Annotate annotateLater (Lcom/sun/tools/javac/util/List;Lcom/sun/tools/javac/comp/Env;Lcom/sun/tools/javac/code/Symbol;Lcom/sun/tools/javac/tree/JCTree;)V 19 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Annotate$$Lambda+0x000000008d2e7530
+instanceKlass com/sun/tools/javac/code/SymbolMetadata
+instanceKlass  @bci com/sun/tools/javac/code/Scope$NamedImportScope lambda$getSymbolsByName$0 ([Lcom/sun/tools/javac/code/Scope;Lcom/sun/tools/javac/util/Name;Ljava/util/function/Predicate;Lcom/sun/tools/javac/code/Scope$LookupKind;)Ljava/util/Iterator; 7 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$NamedImportScope$$Lambda+0x000000008d2e7030
+instanceKlass  @bci com/sun/tools/javac/code/Scope$NamedImportScope getSymbolsByName (Lcom/sun/tools/javac/util/Name;Ljava/util/function/Predicate;Lcom/sun/tools/javac/code/Scope$LookupKind;)Ljava/lang/Iterable; 29 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$NamedImportScope$$Lambda+0x000000008d2e6de0
+instanceKlass  @bci com/sun/tools/javac/code/Symbol$VarSymbol setLazyConstValue (Lcom/sun/tools/javac/comp/Env;Lcom/sun/tools/javac/comp/Env;Lcom/sun/tools/javac/comp/Attr;Lcom/sun/tools/javac/tree/JCTree$JCVariableDecl;)V 7 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Symbol$VarSymbol$$Lambda+0x000000008d2e6bb0
+instanceKlass com/sun/tools/javac/util/Iterators$1
+instanceKlass  @bci com/sun/tools/javac/code/Scope$FilterImportScope lambda$getSymbolsByName$0 (Lcom/sun/tools/javac/util/List;)Ljava/util/Iterator; 10 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$FilterImportScope$$Lambda+0x000000008d2e66e8
+instanceKlass  @bci com/sun/tools/javac/code/Scope$FilterImportScope lambda$getSymbolsByName$0 (Lcom/sun/tools/javac/util/List;)Ljava/util/Iterator; 1 <appendix> argL0 ; # com/sun/tools/javac/code/Scope$FilterImportScope$$Lambda+0x000000008d2e64a0
+instanceKlass  @bci com/sun/tools/javac/code/Scope$FilterImportScope getSymbolsByName (Lcom/sun/tools/javac/util/Name;Ljava/util/function/Predicate;Lcom/sun/tools/javac/code/Scope$LookupKind;)Ljava/lang/Iterable; 62 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$FilterImportScope$$Lambda+0x000000008d2e6250
+instanceKlass  @bci com/sun/tools/javac/code/Scope$CompoundScope lambda$getSymbolsByName$0 (Lcom/sun/tools/javac/util/Name;Ljava/util/function/Predicate;Lcom/sun/tools/javac/code/Scope$LookupKind;)Ljava/util/Iterator; 7 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$CompoundScope$$Lambda+0x000000008d2e6000
+instanceKlass  @bci com/sun/tools/javac/code/Scope$CompoundScope getSymbolsByName (Lcom/sun/tools/javac/util/Name;Ljava/util/function/Predicate;Lcom/sun/tools/javac/code/Scope$LookupKind;)Ljava/lang/Iterable; 4 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$CompoundScope$$Lambda+0x000000008d2e3c60
+instanceKlass  @bci com/sun/tools/javac/comp/Annotate queueScanTreeAndTypeAnnotate (Lcom/sun/tools/javac/tree/JCTree;Lcom/sun/tools/javac/comp/Env;Lcom/sun/tools/javac/code/Symbol;Lcom/sun/tools/javac/tree/JCTree;)V 12 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Annotate$$Lambda+0x000000008d2e3a30
+instanceKlass  @bci com/sun/tools/javac/comp/TypeEnter defaultConstructor (Lcom/sun/tools/javac/tree/TreeMaker;Lcom/sun/tools/javac/comp/TypeEnter$DefaultConstructorHelper;)Lcom/sun/tools/javac/tree/JCTree; 144 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/TypeEnter$$Lambda+0x000000008d2e37e0
+instanceKlass com/sun/tools/javac/comp/TypeEnter$BasicConstructorHelper
+instanceKlass com/sun/tools/javac/jvm/ClassReader$CompleterDeproxy
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$11 read (Lcom/sun/tools/javac/code/Symbol;I)V 79 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$11$$Lambda+0x000000008d2e1948
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader parameter (IILcom/sun/tools/javac/code/Type;Lcom/sun/tools/javac/code/Symbol$MethodSymbol;Ljava/util/Set;)Lcom/sun/tools/javac/code/Symbol$VarSymbol; 155 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$$Lambda+0x000000008d2e11a8
+instanceKlass com/sun/tools/javac/jvm/Code$1
+instanceKlass  @bci com/sun/tools/javac/code/Symtab lookupPackage (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;Lcom/sun/tools/javac/util/Name;Z)Lcom/sun/tools/javac/code/Symbol$PackageSymbol; 112 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Symtab$$Lambda+0x000000008d2e0d38
+instanceKlass  @bci com/sun/tools/javac/code/Symtab lookupPackage (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;Lcom/sun/tools/javac/util/Name;Z)Lcom/sun/tools/javac/code/Symbol$PackageSymbol; 101 <appendix> argL0 ; # com/sun/tools/javac/code/Symtab$$Lambda+0x000000008d2e0af0
+instanceKlass  @bci com/sun/tools/javac/jvm/PoolReader getType (I)Lcom/sun/tools/javac/code/Type; 14 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/PoolReader$$Lambda+0x000000008d2e06c0
+instanceKlass  @cpi com/sun/tools/javac/jvm/PoolReader 361 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d2e4000
+instanceKlass com/sun/tools/javac/util/Name$NameMapper
+instanceKlass  @bci com/sun/tools/javac/code/Scope$ScopeImpl remove (Lcom/sun/tools/javac/code/Symbol;)V 21 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$ScopeImpl$$Lambda+0x000000008d2e0460
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader readInnerClasses (Lcom/sun/tools/javac/code/Symbol$ClassSymbol;)V 67 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$$Lambda+0x000000008d2e0230
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader readInnerClasses (Lcom/sun/tools/javac/code/Symbol$ClassSymbol;)V 41 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$$Lambda+0x000000008d2e0000
+instanceKlass com/sun/tools/javac/jvm/ClassReader$SourceFileObject
+instanceKlass  @bci com/sun/tools/javac/code/ClassFinder classFileNotFound (Lcom/sun/tools/javac/code/Symbol$ClassSymbol;)Lcom/sun/tools/javac/code/Symbol$CompletionFailure; 4 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/ClassFinder$$Lambda+0x000000008d2dca30
+instanceKlass  @bci com/sun/tools/javac/code/ClassFinder loadClass (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;Lcom/sun/tools/javac/util/Name;)Lcom/sun/tools/javac/code/Symbol$ClassSymbol; 28 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/ClassFinder$$Lambda+0x000000008d2dc800
+instanceKlass com/sun/tools/javac/comp/MatchBindingsComputer$1
+instanceKlass  @bci com/sun/tools/javac/comp/Check checkDeprecated (Lcom/sun/tools/javac/util/JCDiagnostic$DiagnosticPosition;Lcom/sun/tools/javac/code/Symbol;Lcom/sun/tools/javac/code/Symbol;)V 2 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Check$$Lambda+0x000000008d2ddb30
+instanceKlass com/sun/tools/javac/comp/Attr$13
+instanceKlass com/sun/tools/javac/code/Scope$FilterImportScope$SymbolImporter
+instanceKlass com/sun/tools/javac/platform/JDKPlatformProvider$PlatformDescriptionImpl$1$1
+instanceKlass  @bci com/sun/tools/javac/platform/JDKPlatformProvider$PlatformDescriptionImpl$1 list (Ljavax/tools/JavaFileManager$Location;Ljava/lang/String;Ljava/util/Set;Z)Ljava/lang/Iterable; 33 <appendix> member <vmtarget> ; # com/sun/tools/javac/platform/JDKPlatformProvider$PlatformDescriptionImpl$1$$Lambda+0x000000008d2dd000
+instanceKlass  @bci com/sun/tools/javac/comp/TypeEnter$ImportsPhase resolveImports (Lcom/sun/tools/javac/tree/JCTree$JCCompilationUnit;Lcom/sun/tools/javac/comp/Env;)V 94 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/TypeEnter$ImportsPhase$$Lambda+0x000000008d2dbd98
+instanceKlass  @bci com/sun/tools/javac/comp/TypeEnter$ImportsPhase resolveImports (Lcom/sun/tools/javac/tree/JCTree$JCCompilationUnit;Lcom/sun/tools/javac/comp/Env;)V 82 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/TypeEnter$ImportsPhase$$Lambda+0x000000008d2dbb68
+instanceKlass com/sun/tools/javac/code/Scope$ImportFilter
+instanceKlass  @bci com/sun/tools/javac/code/DeferredLintHandler push (Lcom/sun/tools/javac/tree/JCTree;)V 64 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/DeferredLintHandler$$Lambda+0x000000008d2db928
+instanceKlass java/nio/file/FileTreeWalker$1
+instanceKlass com/sun/tools/javac/code/Scope$ScopeImpl$2
+instanceKlass  @bci com/sun/tools/javac/code/Scope$ScopeImpl getSymbolsByName (Lcom/sun/tools/javac/util/Name;Ljava/util/function/Predicate;Lcom/sun/tools/javac/code/Scope$LookupKind;)Ljava/lang/Iterable; 4 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$ScopeImpl$$Lambda+0x000000008d2db1f0
+instanceKlass com/sun/tools/javac/comp/Check$6
+instanceKlass com/sun/tools/javac/comp/AttrContext
+instanceKlass  @bci com/sun/tools/javac/comp/Enter visitTopLevel (Lcom/sun/tools/javac/tree/JCTree$JCCompilationUnit;)V 287 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Enter$$Lambda+0x000000008d2d9de0
+instanceKlass  @cpi com/sun/tools/javac/comp/TypeEnter$ImportsPhase 730 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d2dc000
+instanceKlass  @bci com/sun/tools/javac/comp/Enter visitTopLevel (Lcom/sun/tools/javac/tree/JCTree$JCCompilationUnit;)V 273 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Enter$$Lambda+0x000000008d2d9b80
+instanceKlass com/sun/tools/javac/code/Scope$ScopeImpl$1
+instanceKlass  @bci com/sun/tools/javac/code/Scope$ScopeImpl getSymbols (Ljava/util/function/Predicate;Lcom/sun/tools/javac/code/Scope$LookupKind;)Ljava/lang/Iterable; 3 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Scope$ScopeImpl$$Lambda+0x000000008d2d96b8
+instanceKlass com/sun/tools/javac/code/ClassFinder$2
+instanceKlass com/sun/tools/javac/code/ClassFinder$1
+instanceKlass  @bci com/sun/tools/javac/code/ClassFinder list (Ljavax/tools/JavaFileManager$Location;Lcom/sun/tools/javac/code/Symbol$PackageSymbol;Ljava/lang/String;Ljava/util/Set;)Ljava/lang/Iterable; 26 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/ClassFinder$$Lambda+0x000000008d2d8b98
+instanceKlass  @bci java/nio/file/Files asUncheckedRunnable (Ljava/io/Closeable;)Ljava/lang/Runnable; 1 <appendix> member <vmtarget> ; # java/nio/file/Files$$Lambda+0x000000008d1d7eb0
+instanceKlass java/nio/file/Files$2
+instanceKlass  @bci com/sun/tools/javac/file/JavacFileManager pathsAndContainers (Ljavax/tools/JavaFileManager$Location;Lcom/sun/tools/javac/file/RelativePath$RelativeDirectory;)Ljava/util/List; 22 <appendix> member <vmtarget> ; # com/sun/tools/javac/file/JavacFileManager$$Lambda+0x000000008d2d8948
+instanceKlass java/util/ComparableTimSort
+instanceKlass  @bci com/sun/tools/javac/file/JavacFileManager indexPathsAndContainersByRelativeDirectory (Ljavax/tools/JavaFileManager$Location;)Ljava/util/Map; 213 <appendix> argL0 ; # com/sun/tools/javac/file/JavacFileManager$$Lambda+0x000000008d2d8710
+instanceKlass  @bci com/sun/tools/javac/file/JavacFileManager indexPathsAndContainersByRelativeDirectory (Ljavax/tools/JavaFileManager$Location;)Ljava/util/Map; 167 <appendix> member <vmtarget> ; # com/sun/tools/javac/file/JavacFileManager$$Lambda+0x000000008d2d84c0
+instanceKlass java/util/concurrent/locks/AbstractQueuedLongSynchronizer$Node
+instanceKlass  @bci jdk/nio/zipfs/ZipFileSystem createVersionedLinks (I)Ljava/util/function/Function; 50 <appendix> member <vmtarget> ; # jdk/nio/zipfs/ZipFileSystem$$Lambda+0x000000008d24bce8
+instanceKlass  @bci jdk/nio/zipfs/ZipFileSystem lambda$createVersionedLinks$0 (Ljava/util/HashMap;Ljdk/nio/zipfs/ZipFileSystem$IndexNode;)V 8 <appendix> member <vmtarget> ; # jdk/nio/zipfs/ZipFileSystem$$Lambda+0x000000008d24baa8
+instanceKlass  @bci jdk/nio/zipfs/ZipFileSystem createVersionedLinks (I)Ljava/util/function/Function; 39 <appendix> member <vmtarget> ; # jdk/nio/zipfs/ZipFileSystem$$Lambda+0x000000008d24b868
+instanceKlass  @bci jdk/nio/zipfs/ZipFileSystem determineReleaseVersion (Ljava/util/Map;)Ljava/util/Optional; 64 <appendix> member <vmtarget> ; # jdk/nio/zipfs/ZipFileSystem$$TypeSwitch+0x000000008d24b658
+instanceKlass java/lang/classfile/instruction/SwitchCase
+instanceKlass  @bci java/lang/runtime/SwitchBootstraps generateTypeSwitchSkeleton (Ljava/lang/Class;[Ljava/lang/Object;Ljava/util/List;Ljava/util/List;)Ljava/util/function/Consumer; 45 <appendix> member <vmtarget> ; # java/lang/runtime/SwitchBootstraps$$Lambda+0x800000019
+instanceKlass  @bci java/lang/runtime/SwitchBootstraps generateTypeSwitch (Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/Class;[Ljava/lang/Object;)Ljava/lang/invoke/MethodHandle; 70 <appendix> member <vmtarget> ; # java/lang/runtime/SwitchBootstraps$$Lambda+0x800000018
+instanceKlass jdk/internal/misc/PreviewFeatures
+instanceKlass java/lang/runtime/SwitchBootstraps
+instanceKlass java/nio/file/Files$3
+instanceKlass java/nio/file/SimpleFileVisitor
+instanceKlass java/nio/file/FileVisitor
+instanceKlass com/sun/tools/javac/file/JavacFileManager$ArchiveContainer
+instanceKlass com/sun/tools/javac/file/JavacFileManager$PathAndContainer
+instanceKlass  @bci com/sun/tools/javac/file/JavacFileManager pathsAndContainers (Ljavax/tools/JavaFileManager$Location;Lcom/sun/tools/javac/file/RelativePath$RelativeDirectory;)Ljava/util/List; 6 <appendix> member <vmtarget> ; # com/sun/tools/javac/file/JavacFileManager$$Lambda+0x000000008d2d4c60
+instanceKlass java/util/RegularEnumSet$EnumSetIterator
+instanceKlass  @bci com/sun/tools/javac/code/ClassFinder fillIn (Lcom/sun/tools/javac/code/Symbol$PackageSymbol;)V 27 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/ClassFinder$$Lambda+0x000000008d2d4a30
+instanceKlass  @bci com/sun/tools/javac/comp/Modules completeModule (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;)V 327 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000008d2d4800
+instanceKlass  @bci com/sun/tools/javac/comp/Modules initVisiblePackages (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;Ljava/util/Collection;)V 103 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000008d2d5d18
+instanceKlass  @bci com/sun/tools/javac/comp/Modules setupAllModules ()V 974 <appendix> argL0 ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000008d2d5ad0
+instanceKlass  @bci com/sun/tools/javac/comp/Modules setupAllModules ()V 964 <appendix> argL0 ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000008d2d5878
+instanceKlass com/sun/tools/javac/jvm/ClassReader$AnnotationDeproxy
+instanceKlass com/sun/tools/javac/jvm/ClassReader$ProxyVisitor
+instanceKlass  @bci com/sun/tools/javac/comp/Modules lambda$setupAllModules$2 (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;)Z 11 <appendix> argL0 ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000008d2d5000
+instanceKlass  @bci com/sun/tools/javac/comp/Modules setupAllModules ()V 400 <appendix> argL0 ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000008d2d7d30
+instanceKlass  @bci com/sun/tools/javac/comp/Modules setupAllModules ()V 329 <appendix> argL0 ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000008d2d7ad8
+instanceKlass  @bci com/sun/tools/javac/comp/Modules setupAllModules ()V 285 <appendix> argL0 ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000008d2d7880
+instanceKlass  @bci com/sun/tools/javac/comp/Modules setupAllModules ()V 279 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000008d2d7620
+instanceKlass  @bci com/sun/tools/javac/comp/Modules completeModule (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;)V 10 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000008d2d73e0
+instanceKlass com/sun/tools/javac/jvm/ClassReader$UsesProvidesCompleter
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader readClass (Lcom/sun/tools/javac/code/Symbol$ClassSymbol;)V 419 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$$Lambda+0x000000008d2d6f70
+instanceKlass  @bci com/sun/tools/javac/util/List collector ()Ljava/util/stream/Collector; 15 <appendix> argL0 ; # com/sun/tools/javac/util/List$$Lambda+0x000000008d2d6d28
+instanceKlass  @bci com/sun/tools/javac/util/List collector ()Ljava/util/stream/Collector; 10 <appendix> argL0 ; # com/sun/tools/javac/util/List$$Lambda+0x000000008d2d6ad8
+instanceKlass  @bci com/sun/tools/javac/util/List collector ()Ljava/util/stream/Collector; 5 <appendix> argL0 ; # com/sun/tools/javac/util/List$$Lambda+0x000000008d2d68a0
+instanceKlass  @bci com/sun/tools/javac/util/List collector ()Ljava/util/stream/Collector; 0 <appendix> argL0 ; # com/sun/tools/javac/util/List$$Lambda+0x000000008d2d6678
+instanceKlass  @bci com/sun/tools/javac/code/Symbol$ClassSymbol getPermittedSubclasses ()Lcom/sun/tools/javac/util/List; 9 <appendix> argL0 ; # com/sun/tools/javac/code/Symbol$ClassSymbol$$Lambda+0x000000008d2d6430
+instanceKlass com/sun/tools/javac/jvm/ClassReader$InterimProvidesDirective
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$24 read (Lcom/sun/tools/javac/code/Symbol;I)V 977 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$24$$Lambda+0x000000008d2d3cc8
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$24 read (Lcom/sun/tools/javac/code/Symbol;I)V 919 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$24$$Lambda+0x000000008d2d3a98
+instanceKlass com/sun/tools/javac/jvm/ClassReader$InterimUsesDirective
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$24 read (Lcom/sun/tools/javac/code/Symbol;I)V 830 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$24$$Lambda+0x000000008d2d3650
+instanceKlass javax/lang/model/element/ModuleElement$ExportsDirective
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$24 read (Lcom/sun/tools/javac/code/Symbol;I)V 175 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$24$$Lambda+0x000000008d2d2d50
+instanceKlass  @cpi com/sun/tools/javac/jvm/ClassReader$24 373 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d2d4000
+instanceKlass  @bci com/sun/tools/javac/jvm/ClassReader$24 read (Lcom/sun/tools/javac/code/Symbol;I)V 63 <appendix> member <vmtarget> ; # com/sun/tools/javac/jvm/ClassReader$24$$Lambda+0x000000008d2d2b20
+instanceKlass com/sun/tools/javac/jvm/PoolReader$Utf8Mapper
+instanceKlass com/sun/tools/javac/jvm/PoolReader$ImmutablePoolHelper
+instanceKlass com/sun/tools/javac/jvm/PoolReader
+instanceKlass com/sun/tools/javac/comp/Modules$3
+instanceKlass com/sun/tools/javac/code/ModuleFinder$1
+instanceKlass javax/tools/ForwardingFileObject
+instanceKlass javax/tools/StandardLocation$LazyPatternHolder
+instanceKlass com/sun/tools/javac/file/JavacFileManager$DirectoryContainer
+instanceKlass  @bci com/sun/tools/javac/comp/Modules initModules (Lcom/sun/tools/javac/util/List;)V 30 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000008d2d17d0
+instanceKlass  @bci com/sun/tools/javac/parser/JavacParser methodDeclaratorRest (ILcom/sun/tools/javac/tree/JCTree$JCModifiers;Lcom/sun/tools/javac/tree/JCTree$JCExpression;Lcom/sun/tools/javac/util/Name;Lcom/sun/tools/javac/util/List;ZZZLcom/sun/tools/javac/parser/Tokens$Comment;)Lcom/sun/tools/javac/tree/JCTree; 224 <appendix> argL0 ; # com/sun/tools/javac/parser/JavacParser$$Lambda+0x000000008d2d1138
+instanceKlass com/sun/tools/javac/parser/JavacParser$LambdaClassifier
+instanceKlass com/sun/tools/javac/parser/LazyDocCommentTable$Entry
+instanceKlass com/sun/tools/javac/util/Position$LineMapImpl
+instanceKlass com/sun/tools/javac/util/Position$LineMap
+instanceKlass com/sun/tools/javac/util/Position
+instanceKlass  @bci com/sun/tools/javac/tree/TreeMaker TopLevel (Lcom/sun/tools/javac/util/List;)Lcom/sun/tools/javac/tree/JCTree$JCCompilationUnit; 117 <appendix> member <vmtarget> ; # com/sun/tools/javac/tree/TreeMaker$$Lambda+0x000000008d2c9210
+instanceKlass com/sun/tools/javac/parser/Scanner$1
+instanceKlass com/sun/tools/javac/parser/JavadocTokenizer$OffsetMap
+instanceKlass com/sun/tools/javac/util/JCDiagnostic$SimpleDiagnosticPosition
+instanceKlass com/sun/tools/javac/tree/JCTree$1
+instanceKlass  @bci java/util/stream/Collectors joining ()Ljava/util/stream/Collector; 19 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x000000008d1d6688
+instanceKlass  @bci java/util/stream/Collectors joining ()Ljava/util/stream/Collector; 14 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x000000008d1d6438
+instanceKlass  @bci java/util/stream/Collectors joining ()Ljava/util/stream/Collector; 9 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x000000008d1d6200
+instanceKlass  @bci java/util/stream/Collectors joining ()Ljava/util/stream/Collector; 4 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x000000008d1d5fd8
+instanceKlass  @bci com/sun/tools/javac/parser/JavacParser merge (Lcom/sun/tools/javac/util/ListBuffer;Lcom/sun/tools/javac/util/ListBuffer;)Z 55 <appendix> argL0 ; # com/sun/tools/javac/parser/JavacParser$$Lambda+0x000000008d2ca000
+instanceKlass  @bci com/sun/tools/javac/parser/JavacParser annotationValue ()Lcom/sun/tools/javac/tree/JCTree$JCExpression; 175 <appendix> argL0 ; # com/sun/tools/javac/parser/JavacParser$$Lambda+0x000000008d2cec48
+instanceKlass  @bci com/sun/tools/javac/parser/JavacParser arguments ()Lcom/sun/tools/javac/util/List; 80 <appendix> argL0 ; # com/sun/tools/javac/parser/JavacParser$$Lambda+0x000000008d2cea00
+instanceKlass com/sun/tools/javac/tree/TreeInfo$2
+instanceKlass com/sun/tools/javac/tree/TreeInfo
+instanceKlass  @bci java/lang/String stripIndent ()Ljava/lang/String; 73 <appendix> member <vmtarget> ; # java/lang/String$$Lambda+0x000000008d1d5d90
+instanceKlass java/util/AbstractList$RandomAccessSpliterator
+instanceKlass java/lang/StringLatin1$LinesSpliterator
+instanceKlass com/sun/tools/javac/parser/JavacParser$2
+instanceKlass  @bci com/sun/tools/javac/parser/JavacParser accept (Lcom/sun/tools/javac/parser/Tokens$TokenKind;)V 2 <appendix> argL0 ; # com/sun/tools/javac/parser/JavacParser$$Lambda+0x000000008d2cd8b8
+instanceKlass com/sun/tools/javac/resources/CompilerProperties$Errors
+instanceKlass com/sun/tools/javac/util/IntHashTable
+instanceKlass com/sun/tools/javac/parser/LazyDocCommentTable
+instanceKlass  @bci com/sun/tools/javac/parser/JavacParser <init> (Lcom/sun/tools/javac/parser/ParserFactory;Lcom/sun/tools/javac/parser/Lexer;ZZZZ)V 70 <appendix> argL0 ; # com/sun/tools/javac/parser/JavacParser$$Lambda+0x000000008d2ccf78
+instanceKlass com/sun/tools/javac/parser/JavacParser$ErrorRecoveryAction
+instanceKlass com/sun/tools/javac/parser/JavacParser$AbstractEndPosTable
+instanceKlass com/sun/tools/javac/tree/EndPosTable
+instanceKlass com/sun/tools/javac/parser/JavacParser
+instanceKlass com/sun/tools/javac/parser/Scanner
+instanceKlass com/sun/source/tree/LineMap
+instanceKlass com/sun/tools/javac/file/BaseFileManager$ContentCacheEntry
+instanceKlass com/sun/tools/javac/util/ArrayUtils
+instanceKlass com/sun/tools/javac/util/DiagnosticSource
+instanceKlass com/sun/tools/javac/main/JavaCompiler$InitialFileParser
+instanceKlass com/sun/tools/javac/main/JavaCompiler$InitialFileParserIntf
+instanceKlass  @bci com/sun/tools/javac/util/Log$DeferredDiagnosticHandler <init> (Lcom/sun/tools/javac/util/Log;Ljava/util/function/Predicate;Z)V 28 <appendix> argL0 ; # com/sun/tools/javac/util/Log$DeferredDiagnosticHandler$$Lambda+0x000000008d2c5678
+instanceKlass javax/annotation/processing/AbstractProcessor
+instanceKlass com/sun/tools/javac/processing/JavacProcessingEnvironment$DiscoveredProcessors$ProcessorStateIterator
+instanceKlass com/sun/tools/javac/processing/JavacProcessingEnvironment$DiscoveredProcessors
+instanceKlass com/sun/tools/javac/util/Iterators$CompoundIterator
+instanceKlass  @bci com/sun/tools/javac/processing/JavacProcessingEnvironment initProcessorIterator (Ljava/lang/Iterable;)V 234 <appendix> argL0 ; # com/sun/tools/javac/processing/JavacProcessingEnvironment$$Lambda+0x000000008d2c4ce8
+instanceKlass  @bci java/util/stream/ReferencePipeline toArray ()[Ljava/lang/Object; 1 <appendix> argL0 ; # java/util/stream/ReferencePipeline$$Lambda+0x000000008d1d58e8
+instanceKlass  @bci com/sun/tools/javac/processing/JavacProcessingEnvironment initProcessorIterator (Ljava/lang/Iterable;)V 202 <appendix> argL0 ; # com/sun/tools/javac/processing/JavacProcessingEnvironment$$Lambda+0x000000008d2c4aa0
+instanceKlass com/sun/tools/javac/platform/PlatformDescription$PluginInfo
+instanceKlass javax/annotation/processing/Processor
+instanceKlass com/sun/tools/javac/file/JavacFileManager$3
+instanceKlass  @bci com/sun/tools/javac/file/JavacFileManager asFiles (Ljava/lang/Iterable;)Ljava/lang/Iterable; 7 <appendix> member <vmtarget> ; # com/sun/tools/javac/file/JavacFileManager$$Lambda+0x000000008d2c45e0
+instanceKlass com/sun/tools/javac/model/JavacTypes
+instanceKlass com/sun/tools/javac/processing/JavacMessager
+instanceKlass com/sun/tools/javac/processing/JavacFiler
+instanceKlass com/sun/tools/javac/util/ForwardingDiagnosticFormatter$ForwardingConfiguration
+instanceKlass com/sun/tools/javac/code/Types$DefaultSymbolVisitor
+instanceKlass com/sun/tools/javac/util/ForwardingDiagnosticFormatter
+instanceKlass  @bci com/sun/tools/javac/main/JavaCompiler <init> (Lcom/sun/tools/javac/util/Context;)V 408 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/JavaCompiler$$Lambda+0x000000008d2c18b0
+instanceKlass com/sun/tools/javac/code/ModuleFinder$ModuleNameFromSourceReader
+instanceKlass  @bci com/sun/tools/javac/main/JavaCompiler <init> (Lcom/sun/tools/javac/util/Context;)V 395 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/JavaCompiler$$Lambda+0x000000008d2c1680
+instanceKlass com/sun/tools/javac/comp/Modules$PackageNameFinder
+instanceKlass com/sun/tools/javac/api/MultiTaskListener
+instanceKlass com/sun/tools/javac/comp/ThisEscapeAnalyzer$Ref
+instanceKlass com/sun/tools/javac/comp/WarningAnalyzer
+instanceKlass com/sun/tools/javac/parser/UnicodeReader
+instanceKlass com/sun/tools/javac/parser/ScannerFactory
+instanceKlass com/sun/tools/javac/parser/Tokens$Token
+instanceKlass com/sun/tools/javac/parser/Tokens
+instanceKlass com/sun/tools/javac/tree/DCTree
+instanceKlass com/sun/tools/javac/tree/DocTreeMaker$SentenceBreaker
+instanceKlass com/sun/tools/javac/parser/ReferenceParser
+instanceKlass com/sun/tools/javac/model/JavacElements
+instanceKlass com/sun/tools/javac/tree/DocCommentTable
+instanceKlass com/sun/tools/javac/api/JavacTrees$DocCommentTreeTransformer
+instanceKlass com/sun/source/util/DocSourcePositions
+instanceKlass com/sun/source/tree/Scope
+instanceKlass com/sun/source/util/SourcePositions
+instanceKlass com/sun/source/doctree/DocTypeTree
+instanceKlass com/sun/source/doctree/AuthorTree
+instanceKlass com/sun/source/doctree/EntityTree
+instanceKlass com/sun/source/doctree/CommentTree
+instanceKlass com/sun/source/doctree/EndElementTree
+instanceKlass com/sun/source/doctree/DeprecatedTree
+instanceKlass com/sun/source/doctree/DocRootTree
+instanceKlass com/sun/source/doctree/AttributeTree
+instanceKlass com/sun/source/doctree/ValueTree
+instanceKlass com/sun/source/doctree/ParamTree
+instanceKlass com/sun/source/doctree/LiteralTree
+instanceKlass com/sun/source/doctree/ProvidesTree
+instanceKlass com/sun/source/doctree/SnippetTree
+instanceKlass com/sun/source/doctree/SystemPropertyTree
+instanceKlass com/sun/source/doctree/UnknownBlockTagTree
+instanceKlass com/sun/source/doctree/VersionTree
+instanceKlass com/sun/source/doctree/RawTextTree
+instanceKlass com/sun/source/doctree/SerialTree
+instanceKlass com/sun/source/doctree/SerialDataTree
+instanceKlass com/sun/source/doctree/SpecTree
+instanceKlass com/sun/source/doctree/StartElementTree
+instanceKlass com/sun/source/doctree/UsesTree
+instanceKlass com/sun/source/doctree/SerialFieldTree
+instanceKlass com/sun/source/doctree/LinkTree
+instanceKlass com/sun/source/doctree/ReferenceTree
+instanceKlass com/sun/source/doctree/ErroneousTree
+instanceKlass com/sun/source/doctree/UnknownInlineTagTree
+instanceKlass com/sun/source/doctree/EscapeTree
+instanceKlass com/sun/source/doctree/TextTree
+instanceKlass com/sun/source/doctree/ThrowsTree
+instanceKlass com/sun/source/doctree/HiddenTree
+instanceKlass com/sun/source/doctree/IdentifierTree
+instanceKlass com/sun/source/doctree/InheritDocTree
+instanceKlass com/sun/tools/javac/parser/Tokens$Comment
+instanceKlass com/sun/source/doctree/DocCommentTree
+instanceKlass com/sun/source/doctree/IndexTree
+instanceKlass com/sun/source/doctree/ReturnTree
+instanceKlass com/sun/source/doctree/SinceTree
+instanceKlass com/sun/source/doctree/SummaryTree
+instanceKlass com/sun/source/doctree/InlineTagTree
+instanceKlass com/sun/source/doctree/SeeTree
+instanceKlass com/sun/source/doctree/BlockTagTree
+instanceKlass com/sun/source/doctree/DocTree
+instanceKlass com/sun/tools/javac/tree/DocTreeMaker
+instanceKlass com/sun/source/util/DocTreeFactory
+instanceKlass com/sun/tools/javac/parser/Lexer
+instanceKlass com/sun/tools/javac/parser/ParserFactory
+instanceKlass  @bci com/sun/tools/javac/code/ClassFinder <init> (Lcom/sun/tools/javac/util/Context;)V 330 <appendix> argL0 ; # com/sun/tools/javac/code/ClassFinder$$Lambda+0x000000008d2bb1a0
+instanceKlass jdk/internal/jimage/ImageReader$Node
+instanceKlass jdk/internal/jrtfs/SystemImage$2
+instanceKlass java/lang/Class$Holder
+instanceKlass  @bci jdk/internal/jrtfs/SystemImage <clinit> ()V 0 <appendix> argL0 ; # jdk/internal/jrtfs/SystemImage$$Lambda+0x000000008d1d46c0
+instanceKlass jdk/internal/jrtfs/SystemImage
+instanceKlass jdk/internal/jrtfs/JrtPath
+instanceKlass com/sun/tools/javac/file/JRTIndex
+instanceKlass com/sun/tools/javac/jvm/ClassReader$AttributeReader
+instanceKlass com/sun/tools/javac/comp/Analyzer$2
+instanceKlass com/sun/tools/javac/comp/Analyzer$1
+instanceKlass com/sun/tools/javac/comp/Analyzer$StatementAnalyzer
+instanceKlass com/sun/tools/javac/comp/Analyzer$DeferredAnalysisHelper
+instanceKlass com/sun/tools/javac/comp/Analyzer
+instanceKlass  @bci com/sun/tools/javac/code/Symtab <init> (Lcom/sun/tools/javac/util/Context;)V 2310 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Symtab$$Lambda+0x000000008d2b5e98
+instanceKlass com/sun/tools/javac/code/Symtab$2
+instanceKlass com/sun/tools/javac/code/Symtab$1
+instanceKlass  @bci com/sun/tools/javac/code/Symtab doEnterClass (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;Lcom/sun/tools/javac/code/Symbol$ClassSymbol;)V 8 <appendix> argL0 ; # com/sun/tools/javac/code/Symtab$$Lambda+0x000000008d2b5170
+instanceKlass  @bci com/sun/tools/javac/code/Symtab getClass (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;Lcom/sun/tools/javac/util/Name;)Lcom/sun/tools/javac/code/Symbol$ClassSymbol; 7 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Symtab$$Lambda+0x000000008d2b4f40
+instanceKlass  @bci com/sun/tools/javac/code/Symtab enterPackage (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;Lcom/sun/tools/javac/util/Name;)Lcom/sun/tools/javac/code/Symbol$PackageSymbol; 29 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Symtab$$Lambda+0x000000008d2b4d10
+instanceKlass com/sun/tools/javac/jvm/JNIWriter
+instanceKlass com/sun/tools/javac/jvm/Code
+instanceKlass com/sun/tools/javac/jvm/PoolWriter$WriteablePoolHelper
+instanceKlass com/sun/tools/javac/code/Types$SignatureGenerator
+instanceKlass com/sun/tools/javac/jvm/PoolWriter
+instanceKlass  @bci com/sun/tools/javac/comp/Lower$TypePairs hashCode ()I 1 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x000000008d2b1400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d2b1000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d2b0c00
+instanceKlass  @bci com/sun/tools/javac/comp/Lower$TypePairs hashCode ()I 1 <appendix> argL2 argL2 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x000000008d2b0800
+instanceKlass  @bci java/lang/runtime/ObjectMethods bootstrap (Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object; 37 <appendix> argL0 ; # java/lang/runtime/ObjectMethods$$Lambda+0x800000015
+instanceKlass java/lang/invoke/DirectMethodHandle$1
+instanceKlass java/lang/invoke/MethodHandleImpl$2
+instanceKlass java/lang/runtime/ObjectMethods
+instanceKlass com/sun/tools/javac/code/Preview$1
+instanceKlass  @bci com/sun/tools/javac/util/Options lambda$getBoolean$0 (Ljava/lang/String;Z)Ljava/lang/Boolean; 21 <appendix> argL0 ; # com/sun/tools/javac/util/Options$$Lambda+0x000000008d2ae588
+instanceKlass  @bci com/sun/tools/javac/util/Options lambda$getBoolean$0 (Ljava/lang/String;Z)Ljava/lang/Boolean; 13 <appendix> member <vmtarget> ; # com/sun/tools/javac/util/Options$$Lambda+0x000000008d2ae338
+instanceKlass  @bci com/sun/tools/javac/util/Options getBoolean (Ljava/lang/String;Z)Z 4 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x000000008d2b0400
+instanceKlass  @bci com/sun/tools/javac/util/Options getBoolean (Ljava/lang/String;Z)Z 4 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d2b0000
+instanceKlass  @bci com/sun/tools/javac/util/Options getBoolean (Ljava/lang/String;Z)Z 4 <appendix> member <vmtarget> ; # com/sun/tools/javac/util/Options$$Lambda+0x000000008d2ae108
+instanceKlass com/sun/tools/javac/comp/ConstFold
+instanceKlass  @bci com/sun/tools/javac/comp/Operators initBinaryOperators ()V 1049 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$$Lambda+0x000000008d2ace40
+instanceKlass  @bci com/sun/tools/javac/comp/Operators initBinaryOperators ()V 951 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$$Lambda+0x000000008d2acbe8
+instanceKlass  @bci com/sun/tools/javac/comp/Operators initBinaryOperators ()V 855 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$$Lambda+0x000000008d2ac990
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$BinaryNumericOperator <init> (Lcom/sun/tools/javac/comp/Operators;Lcom/sun/tools/javac/tree/JCTree$Tag;)V 3 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$BinaryNumericOperator$$Lambda+0x000000008d2ac4b8
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$BinaryOperatorHelper addBinaryOperator (Lcom/sun/tools/javac/comp/Operators$OperatorType;Lcom/sun/tools/javac/comp/Operators$OperatorType;Lcom/sun/tools/javac/comp/Operators$OperatorType;[I)Lcom/sun/tools/javac/comp/Operators$BinaryOperatorHelper; 11 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Operators$BinaryOperatorHelper$$Lambda+0x000000008d2ac008
+instanceKlass  @bci com/sun/tools/javac/comp/Operators initUnaryOperators ()V 180 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$$Lambda+0x000000008d2ab1b0
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$UnaryOperatorHelper addUnaryOperator (Lcom/sun/tools/javac/comp/Operators$OperatorType;Lcom/sun/tools/javac/comp/Operators$OperatorType;[I)Lcom/sun/tools/javac/comp/Operators$UnaryOperatorHelper; 9 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Operators$UnaryOperatorHelper$$Lambda+0x000000008d2aaf80
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 192 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x000000008d2aab38
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 173 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x000000008d2aa8f0
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 154 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x000000008d2aa6a8
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 135 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x000000008d2aa460
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 116 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x000000008d2aa218
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 97 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x000000008d2a9fd0
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 79 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x000000008d2a9d88
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 61 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x000000008d2a9b40
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 43 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x000000008d2a98f8
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 25 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x000000008d2a96b0
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$OperatorType <clinit> ()V 7 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$OperatorType$$Lambda+0x000000008d2a9468
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$UnaryNumericOperator <init> (Lcom/sun/tools/javac/comp/Operators;Lcom/sun/tools/javac/tree/JCTree$Tag;)V 3 <appendix> argL0 ; # com/sun/tools/javac/comp/Operators$UnaryNumericOperator$$Lambda+0x000000008d2a8fc0
+instanceKlass  @bci com/sun/tools/javac/code/Symbol$MethodSymbol <clinit> ()V 0 <appendix> argL0 ; # com/sun/tools/javac/code/Symbol$MethodSymbol$$Lambda+0x000000008d2a86e8
+instanceKlass com/sun/tools/javac/comp/Operators$OperatorHelper
+instanceKlass com/sun/tools/javac/comp/Operators
+instanceKlass com/sun/tools/javac/comp/Lower$EnumMapping
+instanceKlass com/sun/tools/javac/jvm/PoolConstant$Dynamic
+instanceKlass com/sun/tools/javac/jvm/StringConcat
+instanceKlass com/sun/tools/javac/jvm/Gen$GenFinalizer
+instanceKlass com/sun/tools/javac/jvm/Items$Item
+instanceKlass com/sun/tools/javac/jvm/ClassWriter$AttributeWriter
+instanceKlass com/sun/tools/javac/jvm/ClassFile
+instanceKlass com/sun/tools/javac/util/MandatoryWarningHandler
+instanceKlass com/sun/tools/javac/code/Preview
+instanceKlass com/sun/tools/javac/code/ModuleFinder$ModuleLocationIterator
+instanceKlass com/sun/tools/javac/code/ModuleFinder
+instanceKlass com/sun/tools/javac/comp/Flow$PatternDescription
+instanceKlass com/sun/tools/javac/comp/Flow
+instanceKlass com/sun/tools/javac/comp/Infer$GraphStrategy
+instanceKlass com/sun/tools/javac/comp/InferenceContext
+instanceKlass com/sun/tools/javac/comp/Infer$IncorporationEngine
+instanceKlass com/sun/tools/javac/code/Type$UndetVar$UndetVarListener
+instanceKlass javax/lang/model/element/TypeParameterElement
+instanceKlass com/sun/tools/javac/comp/Infer
+instanceKlass com/sun/tools/javac/util/Dependencies
+instanceKlass com/sun/tools/javac/comp/TypeEnvs
+instanceKlass com/sun/tools/javac/code/TypeAnnotations
+instanceKlass  @bci com/sun/tools/javac/code/DeferredLintHandler pushImmediate (Lcom/sun/tools/javac/code/Lint;)V 5 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/DeferredLintHandler$$Lambda+0x000000008d29dcc8
+instanceKlass com/sun/tools/javac/code/DeferredLintHandler$LintLogger
+instanceKlass com/sun/tools/javac/code/DeferredLintHandler
+instanceKlass  @bci com/sun/tools/javac/comp/TypeEnter$ImportsPhase <init> (Lcom/sun/tools/javac/comp/TypeEnter;)V 28 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/TypeEnter$ImportsPhase$$Lambda+0x000000008d29d130
+instanceKlass com/sun/tools/javac/comp/TypeEnter$DefaultConstructorHelper
+instanceKlass com/sun/tools/javac/util/GraphUtils$DependencyKind
+instanceKlass com/sun/tools/javac/comp/TypeEnter$Phase
+instanceKlass com/sun/tools/javac/comp/TypeEnter
+instanceKlass  @bci com/sun/tools/javac/code/Types <init> (Lcom/sun/tools/javac/util/Context;)V 360 <appendix> argL0 ; # com/sun/tools/javac/code/Types$$Lambda+0x000000008d29b500
+instanceKlass com/sun/tools/javac/code/Types$CandidatesCache
+instanceKlass com/sun/tools/javac/code/Types$ImplementationCache
+instanceKlass com/sun/tools/javac/code/Types$3
+instanceKlass com/sun/tools/javac/code/Types$DescriptorCache
+instanceKlass com/sun/tools/javac/code/Types
+instanceKlass com/sun/tools/javac/tree/TreeMaker$AnnotationBuilder
+instanceKlass com/sun/tools/javac/code/Attribute$Visitor
+instanceKlass com/sun/tools/javac/tree/TreeMaker
+instanceKlass com/sun/tools/javac/tree/JCTree$Factory
+instanceKlass com/sun/tools/javac/comp/DeferredAttr$4
+instanceKlass com/sun/tools/javac/tree/TreeCopier
+instanceKlass com/sun/tools/javac/comp/DeferredAttr$DeferredAttrContext
+instanceKlass com/sun/tools/javac/comp/DeferredAttr$DeferredStuckPolicy
+instanceKlass com/sun/tools/javac/comp/AttrRecover
+instanceKlass com/sun/tools/javac/comp/Resolve$ReferenceLookupResult
+instanceKlass com/sun/tools/javac/api/Formattable$LocalizedString
+instanceKlass com/sun/tools/javac/comp/Resolve$10
+instanceKlass com/sun/tools/javac/comp/Resolve$9
+instanceKlass com/sun/tools/javac/comp/Resolve$8
+instanceKlass  @bci com/sun/tools/javac/comp/Resolve onDemandImportScopeRecovery (Z)Lcom/sun/tools/javac/comp/Resolve$RecoveryLoadClass; 2 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d28c000
+instanceKlass  @bci com/sun/tools/javac/comp/Resolve onDemandImportScopeRecovery (Z)Lcom/sun/tools/javac/comp/Resolve$RecoveryLoadClass; 2 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Resolve$$Lambda+0x000000008d28b418
+instanceKlass  @bci com/sun/tools/javac/comp/Resolve <init> (Lcom/sun/tools/javac/util/Context;)V 86 <appendix> member <vmtarget> ; # com/sun/tools/javac/comp/Resolve$$Lambda+0x000000008d28b1e8
+instanceKlass com/sun/tools/javac/comp/Resolve$7
+instanceKlass  @bci com/sun/tools/javac/comp/Resolve <init> (Lcom/sun/tools/javac/util/Context;)V 64 <appendix> argL0 ; # com/sun/tools/javac/comp/Resolve$$Lambda+0x000000008d28ad88
+instanceKlass com/sun/tools/javac/comp/Env
+instanceKlass com/sun/tools/javac/comp/Resolve$AbstractMethodCheck
+instanceKlass com/sun/tools/javac/comp/Resolve$2
+instanceKlass com/sun/tools/javac/code/Scope$ScopeListener
+instanceKlass com/sun/tools/javac/comp/Resolve$LookupHelper
+instanceKlass com/sun/tools/javac/comp/Resolve$ReferenceChooser
+instanceKlass com/sun/tools/javac/comp/Resolve$LogResolveHelper
+instanceKlass com/sun/tools/javac/comp/Resolve$RecoveryLoadClass
+instanceKlass com/sun/tools/javac/comp/Resolve
+instanceKlass  @bci com/sun/tools/javac/comp/Check <init> (Lcom/sun/tools/javac/util/Context;)V 62 <appendix> argL0 ; # com/sun/tools/javac/comp/Check$$Lambda+0x000000008d2825a8
+instanceKlass com/sun/tools/javac/comp/Check$1
+instanceKlass com/sun/tools/javac/util/Warner
+instanceKlass com/sun/tools/javac/comp/Check
+instanceKlass com/sun/tools/javac/comp/Modules$1
+instanceKlass  @bci com/sun/tools/javac/comp/Modules <clinit> ()V 0 <appendix> argL0 ; # com/sun/tools/javac/comp/Modules$$Lambda+0x000000008d280460
+instanceKlass com/sun/tools/javac/util/Iterators
+instanceKlass com/sun/tools/javac/code/Directive
+instanceKlass javax/lang/model/element/ModuleElement$RequiresDirective
+instanceKlass javax/lang/model/element/ModuleElement$Directive
+instanceKlass  @bci com/sun/tools/javac/code/Symtab enterModule (Lcom/sun/tools/javac/util/Name;)Lcom/sun/tools/javac/code/Symbol$ModuleSymbol; 37 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Symtab$$Lambda+0x000000008d27e628
+instanceKlass com/sun/tools/javac/code/Scope$ScopeListenerList
+instanceKlass com/sun/tools/javac/code/Scope$Entry
+instanceKlass com/sun/tools/javac/comp/Annotate$AnnotationTypeMetadata
+instanceKlass  @bci com/sun/tools/javac/code/Symtab addRootPackageFor (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;)V 36 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Symtab$$Lambda+0x000000008d27cef8
+instanceKlass  @bci com/sun/tools/javac/code/Symtab doEnterPackage (Lcom/sun/tools/javac/code/Symbol$ModuleSymbol;Lcom/sun/tools/javac/code/Symbol$PackageSymbol;)V 8 <appendix> argL0 ; # com/sun/tools/javac/code/Symtab$$Lambda+0x000000008d27ccb0
+instanceKlass com/sun/tools/javac/api/Formattable
+instanceKlass com/sun/tools/javac/code/Kinds$KindSelector
+instanceKlass com/sun/tools/javac/code/MissingInfoHandler
+instanceKlass com/sun/tools/javac/code/TypeMetadata
+instanceKlass javax/lang/model/type/NullType
+instanceKlass com/sun/tools/javac/code/Symtab
+instanceKlass com/sun/tools/javac/comp/MatchBindingsComputer$MatchBindings
+instanceKlass com/sun/source/util/SimpleTreeVisitor
+instanceKlass javax/lang/model/type/UnionType
+instanceKlass com/sun/tools/javac/comp/Resolve$MethodCheck
+instanceKlass javax/lang/model/element/RecordComponentElement
+instanceKlass javax/lang/model/type/IntersectionType
+instanceKlass com/sun/tools/javac/comp/Check$NestedCheckContext
+instanceKlass com/sun/tools/javac/comp/Attr$ResultInfo
+instanceKlass com/sun/tools/javac/code/Types$DefaultTypeVisitor
+instanceKlass com/sun/tools/javac/comp/Annotate$2
+instanceKlass com/sun/tools/javac/comp/Check$CheckContext
+instanceKlass javax/lang/model/element/AnnotationMirror
+instanceKlass com/sun/tools/javac/comp/Annotate
+instanceKlass com/sun/tools/javac/util/ByteBuffer
+instanceKlass com/sun/tools/javac/code/Attribute
+instanceKlass javax/lang/model/element/AnnotationValue
+instanceKlass javax/lang/model/type/PrimitiveType
+instanceKlass com/sun/tools/javac/comp/Annotate$AnnotationTypeCompleter
+instanceKlass com/sun/tools/javac/jvm/ClassReader
+instanceKlass  @bci com/sun/tools/javac/code/ClassFinder <init> (Lcom/sun/tools/javac/util/Context;)V 23 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/ClassFinder$$Lambda+0x000000008d266428
+instanceKlass com/sun/tools/javac/code/Scope
+instanceKlass com/sun/tools/javac/code/ClassFinder
+instanceKlass com/sun/tools/javac/util/Convert
+instanceKlass com/sun/tools/javac/util/Name
+instanceKlass javax/lang/model/element/Name
+instanceKlass com/sun/tools/javac/util/Name$Table
+instanceKlass com/sun/tools/javac/util/Names
+instanceKlass com/sun/tools/javac/code/Symbol$Completer$1
+instanceKlass  @bci com/sun/tools/javac/main/JavaCompiler <init> (Lcom/sun/tools/javac/util/Context;)V 6 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/JavaCompiler$$Lambda+0x000000008d264240
+instanceKlass javax/lang/model/element/ModuleElement
+instanceKlass javax/lang/model/element/PackageElement
+instanceKlass com/sun/tools/javac/main/JavaCompiler
+instanceKlass javax/lang/model/element/TypeElement
+instanceKlass javax/lang/model/element/QualifiedNameable
+instanceKlass com/sun/source/tree/WildcardTree
+instanceKlass com/sun/source/tree/OpensTree
+instanceKlass com/sun/source/tree/CaseTree
+instanceKlass com/sun/source/tree/UsesTree
+instanceKlass com/sun/source/tree/BlockTree
+instanceKlass com/sun/source/tree/ThrowTree
+instanceKlass com/sun/source/tree/BreakTree
+instanceKlass com/sun/source/tree/IfTree
+instanceKlass com/sun/source/tree/CatchTree
+instanceKlass com/sun/source/tree/TryTree
+instanceKlass com/sun/source/tree/YieldTree
+instanceKlass com/sun/source/tree/UnaryTree
+instanceKlass com/sun/source/tree/MethodInvocationTree
+instanceKlass com/sun/source/tree/IdentifierTree
+instanceKlass com/sun/source/tree/EmptyStatementTree
+instanceKlass com/sun/source/tree/ExpressionStatementTree
+instanceKlass com/sun/source/tree/UnionTypeTree
+instanceKlass com/sun/source/tree/ConditionalExpressionTree
+instanceKlass com/sun/source/tree/ArrayAccessTree
+instanceKlass com/sun/source/tree/AssignmentTree
+instanceKlass com/sun/source/tree/ParameterizedTypeTree
+instanceKlass com/sun/source/tree/ModuleTree
+instanceKlass com/sun/source/tree/DoWhileLoopTree
+instanceKlass com/sun/source/tree/DeconstructionPatternTree
+instanceKlass com/sun/source/tree/LabeledStatementTree
+instanceKlass com/sun/source/tree/VariableTree
+instanceKlass com/sun/source/tree/IntersectionTypeTree
+instanceKlass com/sun/source/tree/LambdaExpressionTree
+instanceKlass com/sun/source/tree/EnhancedForLoopTree
+instanceKlass com/sun/source/tree/ClassTree
+instanceKlass com/sun/source/tree/MethodTree
+instanceKlass com/sun/source/tree/PrimitiveTypeTree
+instanceKlass com/sun/source/tree/ParenthesizedTree
+instanceKlass com/sun/source/tree/CompoundAssignmentTree
+instanceKlass com/sun/source/tree/ArrayTypeTree
+instanceKlass com/sun/source/tree/InstanceOfTree
+instanceKlass com/sun/source/tree/PackageTree
+instanceKlass com/sun/source/tree/MemberSelectTree
+instanceKlass com/sun/source/tree/MemberReferenceTree
+instanceKlass com/sun/source/tree/ExportsTree
+instanceKlass com/sun/source/tree/AnnotatedTypeTree
+instanceKlass com/sun/source/tree/ErroneousTree
+instanceKlass com/sun/source/tree/BindingPatternTree
+instanceKlass com/sun/source/tree/BinaryTree
+instanceKlass com/sun/source/tree/AnyPatternTree
+instanceKlass com/sun/source/tree/PatternTree
+instanceKlass com/sun/source/tree/LiteralTree
+instanceKlass com/sun/source/tree/RequiresTree
+instanceKlass com/sun/source/tree/ProvidesTree
+instanceKlass com/sun/source/tree/DirectiveTree
+instanceKlass com/sun/source/tree/ConstantCaseLabelTree
+instanceKlass com/sun/source/tree/ModifiersTree
+instanceKlass com/sun/source/tree/PatternCaseLabelTree
+instanceKlass com/sun/source/tree/TypeCastTree
+instanceKlass com/sun/source/tree/TypeParameterTree
+instanceKlass com/sun/source/tree/DefaultCaseLabelTree
+instanceKlass com/sun/source/tree/CaseLabelTree
+instanceKlass com/sun/source/tree/SynchronizedTree
+instanceKlass com/sun/source/tree/SwitchExpressionTree
+instanceKlass com/sun/source/tree/ImportTree
+instanceKlass com/sun/source/tree/ForLoopTree
+instanceKlass com/sun/source/tree/NewClassTree
+instanceKlass com/sun/source/tree/NewArrayTree
+instanceKlass com/sun/source/tree/WhileLoopTree
+instanceKlass com/sun/source/tree/SwitchTree
+instanceKlass com/sun/source/tree/AssertTree
+instanceKlass com/sun/source/tree/ReturnTree
+instanceKlass com/sun/source/tree/ContinueTree
+instanceKlass com/sun/source/tree/StatementTree
+instanceKlass com/sun/source/tree/AnnotationTree
+instanceKlass  @bci java/util/regex/Pattern ALL ()Ljava/util/regex/Pattern$CharPredicate; 0 <appendix> argL0 ; # java/util/regex/Pattern$$Lambda+0x000000008d1d3ba8
+instanceKlass javax/annotation/processing/Filer
+instanceKlass javax/annotation/processing/Messager
+instanceKlass javax/annotation/processing/RoundEnvironment
+instanceKlass com/sun/tools/javac/processing/JavacProcessingEnvironment$ServiceIterator
+instanceKlass com/sun/tools/javac/tree/JCTree$Visitor
+instanceKlass com/sun/tools/javac/processing/JavacProcessingEnvironment
+instanceKlass javax/annotation/processing/ProcessingEnvironment
+instanceKlass  @bci javax/lang/model/SourceVersion getLatestSupported ()Ljavax/lang/model/SourceVersion; 19 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x000000008d250400
+instanceKlass java/lang/StringConcatHelper$StringConcatBase
+instanceKlass java/lang/invoke/StringConcatFactory$InlineHiddenClassStrategy$2
+instanceKlass java/lang/invoke/StringConcatFactory$InlineHiddenClassStrategy$1
+instanceKlass java/lang/invoke/StringConcatFactory$InlineHiddenClassStrategy
+instanceKlass  @bci com/sun/tools/javac/main/Arguments validate ()Z 1326 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/Arguments$$Lambda+0x000000008d254b00
+instanceKlass  @bci com/sun/tools/javac/main/Arguments validate ()Z 1236 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/Arguments$$Lambda+0x000000008d2548d0
+instanceKlass com/sun/tools/javac/util/Pair
+instanceKlass  @bci com/sun/tools/javac/code/DeferredCompletionFailureHandler$1 uninstall ()V 9 <appendix> argL0 ; # com/sun/tools/javac/code/DeferredCompletionFailureHandler$1$$Lambda+0x000000008d254480
+instanceKlass  @bci com/sun/tools/javac/api/JavacTaskImpl doCall ()Lcom/sun/tools/javac/main/Main$Result; 2 <appendix> member <vmtarget> ; # com/sun/tools/javac/api/JavacTaskImpl$$Lambda+0x000000008d254250
+instanceKlass  @bci com/sun/tools/javac/code/DeferredCompletionFailureHandler$1 install ()V 9 <appendix> argL0 ; # com/sun/tools/javac/code/DeferredCompletionFailureHandler$1$$Lambda+0x000000008d24fd80
+instanceKlass com/sun/tools/javac/code/DeferredCompletionFailureHandler$FlipSymbolDescription
+instanceKlass com/sun/tools/javac/code/DeferredCompletionFailureHandler$3
+instanceKlass com/sun/tools/javac/code/DeferredCompletionFailureHandler$2
+instanceKlass com/sun/tools/javac/code/Symbol$Completer
+instanceKlass com/sun/tools/javac/code/DeferredCompletionFailureHandler$1
+instanceKlass com/sun/tools/javac/code/DeferredCompletionFailureHandler$Handler
+instanceKlass com/sun/tools/javac/code/DeferredCompletionFailureHandler
+instanceKlass com/sun/tools/javac/parser/Parser
+instanceKlass com/sun/tools/javac/api/JavacTaskImpl$Filter
+instanceKlass  @bci com/sun/tools/javac/util/Options get (Ljava/lang/String;)Ljava/lang/String; 3 <appendix> member <vmtarget> ; # com/sun/tools/javac/util/Options$$Lambda+0x000000008d24df98
+instanceKlass  @bci com/sun/tools/javac/util/Options isSet (Ljava/lang/String;)Z 3 <appendix> member <vmtarget> ; # com/sun/tools/javac/util/Options$$Lambda+0x000000008d24dd68
+instanceKlass com/sun/tools/javac/main/DelegatingJavaFileManager
+instanceKlass java/time/LocalDate$1
+instanceKlass  @bci java/time/temporal/TemporalAdjusters nextOrSame (Ljava/time/DayOfWeek;)Ljava/time/temporal/TemporalAdjuster; 6 <appendix> member <vmtarget> ; # java/time/temporal/TemporalAdjusters$$Lambda+0x000000008d1d3980
+instanceKlass  @cpi java/time/temporal/TemporalAdjusters 209 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d250000
+instanceKlass java/time/temporal/TemporalAdjusters
+instanceKlass jdk/nio/zipfs/ZipUtils
+instanceKlass  @bci com/sun/tools/javac/platform/JDKPlatformProvider$PlatformDescriptionImpl getFileManager ()Ljavax/tools/JavaFileManager; 542 <appendix> argL0 ; # com/sun/tools/javac/platform/JDKPlatformProvider$PlatformDescriptionImpl$$Lambda+0x000000008d24cf90
+instanceKlass com/sun/tools/javac/platform/JDKPlatformProvider$PlatformDescriptionImpl
+instanceKlass  @bci com/sun/tools/javac/platform/PlatformUtils lookupPlatformDescription (Ljava/lang/String;)Lcom/sun/tools/javac/platform/PlatformDescription; 82 <appendix> member <vmtarget> ; # com/sun/tools/javac/platform/PlatformUtils$$Lambda+0x000000008d24c460
+instanceKlass  @bci com/sun/tools/javac/platform/PlatformUtils lambda$lookupPlatformDescription$0 (Ljava/lang/String;Lcom/sun/tools/javac/platform/PlatformProvider;)Z 21 <appendix> member <vmtarget> ; # com/sun/tools/javac/platform/PlatformUtils$$Lambda+0x000000008d24c200
+instanceKlass java/util/TreeMap$TreeMapSpliterator
+instanceKlass jdk/nio/zipfs/ZipDirectoryStream$1
+instanceKlass jdk/nio/zipfs/ZipDirectoryStream
+instanceKlass sun/nio/fs/WindowsSecurity
+instanceKlass sun/nio/fs/AbstractAclFileAttributeView
+instanceKlass  @bci jdk/nio/zipfs/ZipFileSystem <init> (Ljdk/nio/zipfs/ZipFileSystemProvider;Ljava/nio/file/Path;Ljava/util/Map;)V 595 <appendix> member <vmtarget> ; # jdk/nio/zipfs/ZipFileSystem$$Lambda+0x000000008d249650
+instanceKlass jdk/nio/zipfs/ZipFileAttributeView
+instanceKlass jdk/nio/zipfs/ZipPath
+instanceKlass jdk/nio/zipfs/ZipFileSystem$END
+instanceKlass jdk/nio/zipfs/ZipConstants
+instanceKlass jdk/nio/zipfs/ZipCoder
+instanceKlass jdk/nio/zipfs/ZipFileAttributes
+instanceKlass jdk/nio/zipfs/ZipFileSystem$IndexNode
+instanceKlass  @bci com/sun/tools/javac/platform/JDKPlatformProvider <clinit> ()V 17 <appendix> argL0 ; # com/sun/tools/javac/platform/JDKPlatformProvider$$Lambda+0x000000008d243d38
+instanceKlass com/sun/tools/javac/platform/PlatformDescription
+instanceKlass com/sun/tools/javac/platform/JDKPlatformProvider
+instanceKlass  @bci com/sun/tools/javac/platform/PlatformUtils lookupPlatformDescription (Ljava/lang/String;)Lcom/sun/tools/javac/platform/PlatformDescription; 65 <appendix> member <vmtarget> ; # com/sun/tools/javac/platform/PlatformUtils$$Lambda+0x000000008d243890
+instanceKlass com/sun/tools/javac/platform/PlatformProvider
+instanceKlass com/sun/tools/javac/platform/PlatformUtils
+instanceKlass  @bci com/sun/tools/javac/main/Arguments checkOptionAllowed (ZLcom/sun/tools/javac/main/Arguments$ErrorReporter;[Lcom/sun/tools/javac/main/Option;)V 33 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/Arguments$$Lambda+0x000000008d2431d8
+instanceKlass  @bci com/sun/tools/javac/main/Arguments checkOptionAllowed (ZLcom/sun/tools/javac/main/Arguments$ErrorReporter;[Lcom/sun/tools/javac/main/Option;)V 17 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/Arguments$$Lambda+0x000000008d242f78
+instanceKlass  @bci com/sun/tools/javac/main/Arguments handleReleaseOptions (Ljava/util/function/Predicate;)Z 22 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/Arguments$$Lambda+0x000000008d242d48
+instanceKlass com/sun/tools/javac/main/Arguments$ErrorReporter
+instanceKlass  @bci com/sun/tools/javac/main/Arguments processArgs (Ljava/lang/Iterable;Ljava/util/Set;Lcom/sun/tools/javac/main/OptionHelper;ZZ)Z 24 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x000000008d245000
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d244c00
+instanceKlass  @bci com/sun/tools/javac/main/Arguments processArgs (Ljava/lang/Iterable;Ljava/util/Set;Lcom/sun/tools/javac/main/OptionHelper;ZZ)Z 24 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d244800
+instanceKlass  @bci com/sun/tools/javac/main/Arguments processArgs (Ljava/lang/Iterable;Ljava/util/Set;Lcom/sun/tools/javac/main/OptionHelper;ZZ)Z 24 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/Arguments$$Lambda+0x000000008d242ae8
+instanceKlass  @cpi com/sun/tools/javac/main/Arguments 1141 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d244400
+instanceKlass  @bci com/sun/tools/javac/util/Options isLintExplicitlyDisabled (Lcom/sun/tools/javac/code/Lint$LintCategory;)Z 10 <appendix> member <vmtarget> ; # com/sun/tools/javac/util/Options$$Lambda+0x000000008d242888
+instanceKlass  @bci com/sun/tools/javac/util/Options isLintExplicitlyEnabled (Lcom/sun/tools/javac/code/Lint$LintCategory;)Z 10 <appendix> member <vmtarget> ; # com/sun/tools/javac/util/Options$$Lambda+0x000000008d242628
+instanceKlass com/sun/tools/javac/resources/CompilerProperties$Fragments
+instanceKlass  @bci com/sun/tools/javac/util/Options get (Lcom/sun/tools/javac/main/Option;)Ljava/lang/String; 3 <appendix> member <vmtarget> ; # com/sun/tools/javac/util/Options$$Lambda+0x000000008d241948
+instanceKlass  @bci com/sun/tools/javac/util/Options isSet (Lcom/sun/tools/javac/main/Option;Ljava/lang/String;)Z 4 <appendix> member <vmtarget> ; # com/sun/tools/javac/util/Options$$Lambda+0x000000008d241518
+instanceKlass  @bci com/sun/tools/javac/util/Options isSet (Lcom/sun/tools/javac/main/Option;)Z 3 <appendix> member <vmtarget> ; # com/sun/tools/javac/util/Options$$Lambda+0x000000008d2412e8
+instanceKlass com/sun/tools/javac/resources/CompilerProperties$LintWarnings
+instanceKlass sun/nio/fs/WindowsUriSupport
+instanceKlass java/util/AbstractMap$SimpleEntry
+instanceKlass jdk/internal/jimage/ImageBufferCache$2
+instanceKlass jdk/internal/jimage/ImageBufferCache
+instanceKlass java/nio/channels/AsynchronousFileChannel
+instanceKlass java/nio/channels/AsynchronousChannel
+instanceKlass java/nio/file/FileStore
+instanceKlass com/sun/tools/javac/util/StringUtils
+instanceKlass  @bci com/sun/tools/javac/file/CacheFSInfo isFile (Ljava/nio/file/Path;)Z 5 <appendix> argL0 ; # com/sun/tools/javac/file/CacheFSInfo$$Lambda+0x000000008d240830
+instanceKlass  @cpi com/sun/tools/javac/file/CacheFSInfo 178 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d244000
+instanceKlass  @bci com/sun/tools/javac/file/CacheFSInfo getAttributes (Ljava/nio/file/Path;)Ljava/util/Optional; 6 <appendix> member <vmtarget> ; # com/sun/tools/javac/file/CacheFSInfo$$Lambda+0x000000008d2405e0
+instanceKlass com/sun/tools/javac/file/BaseFileManager$3
+instanceKlass com/sun/tools/doclint/DocLint$1
+instanceKlass com/sun/source/tree/CompilationUnitTree
+instanceKlass com/sun/source/util/TreePath
+instanceKlass javax/lang/model/util/Types
+instanceKlass javax/lang/model/util/Elements
+instanceKlass com/sun/source/util/Trees
+instanceKlass com/sun/source/util/TreeScanner
+instanceKlass com/sun/source/tree/TreeVisitor
+instanceKlass  @bci com/sun/tools/doclint/DocLint newDocLint ()Lcom/sun/tools/doclint/DocLint; 17 <appendix> argL0 ; # com/sun/tools/doclint/DocLint$$Lambda+0x000000008d23cf48
+instanceKlass java/util/ServiceLoader$ProviderSpliterator
+instanceKlass com/sun/tools/doclint/DocLint
+instanceKlass com/sun/source/util/Plugin
+instanceKlass com/sun/tools/javac/util/ListBuffer$1
+instanceKlass com/sun/tools/javac/main/Arguments
+instanceKlass com/sun/tools/javac/api/ClientCodeWrapper$WrappedDiagnosticListener
+instanceKlass com/sun/tools/javac/api/ClientCodeWrapper$Trusted
+instanceKlass com/sun/tools/javac/api/ClientCodeWrapper$WrappedJavaFileManager
+instanceKlass com/sun/source/util/TaskListener
+instanceKlass com/sun/tools/javac/api/ClientCodeWrapper
+instanceKlass com/sun/tools/javac/file/PathFileObject
+instanceKlass  @bci com/sun/tools/javac/file/CacheFSInfo getCanonicalFile (Ljava/nio/file/Path;)Ljava/nio/file/Path; 6 <appendix> member <vmtarget> ; # com/sun/tools/javac/file/CacheFSInfo$$Lambda+0x000000008d23a1b0
+instanceKlass  @bci com/sun/tools/javac/file/BaseFileManager setContext (Lcom/sun/tools/javac/util/Context;)V 48 <appendix> member <vmtarget> ; # com/sun/tools/javac/file/BaseFileManager$$Lambda+0x000000008d239ac8
+instanceKlass  @bci com/sun/tools/javac/util/Log <init> (Lcom/sun/tools/javac/util/Context;Ljava/util/Map;)V 152 <appendix> member <vmtarget> ; # com/sun/tools/javac/util/Log$$Lambda+0x000000008d239888
+instanceKlass  @bci com/sun/tools/javac/util/JCDiagnostic$Factory <init> (Lcom/sun/tools/javac/util/Context;)V 23 <appendix> member <vmtarget> ; # com/sun/tools/javac/util/JCDiagnostic$Factory$$Lambda+0x000000008d239648
+instanceKlass com/sun/tools/javac/util/JCDiagnostic
+instanceKlass  @bci com/sun/tools/javac/util/Options whenReady (Ljava/util/function/Consumer;)V 20 <appendix> member <vmtarget> ; # com/sun/tools/javac/util/Options$$Lambda+0x000000008d238ec8
+instanceKlass  @bci com/sun/tools/javac/util/JavacMessages <init> (Lcom/sun/tools/javac/util/Context;)V 45 <appendix> member <vmtarget> ; # com/sun/tools/javac/util/JavacMessages$$Lambda+0x000000008d238c88
+instanceKlass com/sun/tools/javac/util/Options
+instanceKlass javax/lang/model/type/ArrayType
+instanceKlass javax/lang/model/type/NoType
+instanceKlass javax/lang/model/type/ExecutableType
+instanceKlass javax/lang/model/element/ExecutableElement
+instanceKlass javax/lang/model/element/Parameterizable
+instanceKlass javax/lang/model/element/VariableElement
+instanceKlass javax/lang/model/type/WildcardType
+instanceKlass javax/lang/model/type/TypeVariable
+instanceKlass com/sun/tools/javac/jvm/PoolConstant$LoadableConstant
+instanceKlass javax/lang/model/type/ErrorType
+instanceKlass javax/lang/model/type/DeclaredType
+instanceKlass javax/lang/model/type/ReferenceType
+instanceKlass javax/lang/model/type/TypeMirror
+instanceKlass com/sun/tools/javac/code/AnnoConstruct
+instanceKlass javax/lang/model/element/Element
+instanceKlass javax/lang/model/AnnotatedConstruct
+instanceKlass com/sun/tools/javac/jvm/PoolConstant
+instanceKlass com/sun/tools/javac/util/AbstractDiagnosticFormatter$SimpleConfiguration
+instanceKlass com/sun/source/tree/ExpressionTree
+instanceKlass com/sun/tools/javac/tree/JCTree
+instanceKlass com/sun/source/tree/Tree
+instanceKlass com/sun/tools/javac/api/DiagnosticFormatter$Configuration
+instanceKlass com/sun/tools/javac/code/Printer
+instanceKlass com/sun/tools/javac/code/Symbol$Visitor
+instanceKlass com/sun/tools/javac/code/Type$Visitor
+instanceKlass  @bci jdk/internal/module/SystemModuleFinders$SystemModuleReader open (Ljava/lang/String;)Ljava/util/Optional; 6 <appendix> member <vmtarget> ; # jdk/internal/module/SystemModuleFinders$SystemModuleReader$$Lambda+0x000000008d1cf480
+instanceKlass jdk/internal/module/SystemModuleFinders
+instanceKlass java/util/ResourceBundle$CacheKeyReference
+instanceKlass java/util/ResourceBundle$CacheKey
+instanceKlass com/sun/tools/javac/util/List$2
+instanceKlass  @bci com/sun/tools/javac/util/JavacMessages add (Ljava/lang/String;)V 2 <appendix> member <vmtarget> ; # com/sun/tools/javac/util/JavacMessages$$Lambda+0x000000008d234d00
+instanceKlass com/sun/tools/javac/util/JavacMessages$ResourceBundleHelper
+instanceKlass com/sun/tools/javac/util/JavacMessages
+instanceKlass com/sun/tools/javac/api/Messages
+instanceKlass com/sun/tools/javac/util/JCDiagnostic$Factory
+instanceKlass  @bci com/sun/tools/javac/file/JavacFileManager <init> (Lcom/sun/tools/javac/util/Context;ZLjava/nio/charset/Charset;)V 11 <appendix> argL0 ; # com/sun/tools/javac/file/JavacFileManager$$Lambda+0x000000008d22e908
+instanceKlass java/util/JumboEnumSet$EnumSetIterator
+instanceKlass com/sun/tools/javac/file/Locations$ModuleTable
+instanceKlass  @bci com/sun/tools/javac/file/Locations$ModuleSourcePathLocationHandler <init> (Lcom/sun/tools/javac/file/Locations;)V 28 <appendix> argL0 ; # com/sun/tools/javac/file/Locations$ModuleSourcePathLocationHandler$$Lambda+0x000000008d22dea8
+instanceKlass  @bci com/sun/tools/javac/file/Locations <init> ()V 5 <appendix> argL0 ; # com/sun/tools/javac/file/Locations$$Lambda+0x000000008d22cff8
+instanceKlass javax/tools/StandardJavaFileManager$PathFactory
+instanceKlass com/sun/tools/javac/file/Locations$LocationHandler
+instanceKlass com/sun/tools/javac/file/Locations
+instanceKlass com/sun/tools/javac/file/JavacFileManager$1
+instanceKlass  @bci com/sun/tools/javac/main/Option getOptions (Lcom/sun/tools/javac/main/Option$OptionGroup;)Ljava/util/Set; 17 <appendix> argL0 ; # com/sun/tools/javac/main/Option$$Lambda+0x000000008d22c030
+instanceKlass  @bci com/sun/tools/javac/main/Option getOptions (Lcom/sun/tools/javac/main/Option$OptionGroup;)Ljava/util/Set; 7 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/Option$$Lambda+0x000000008d22bdd0
+instanceKlass  @bci com/sun/tools/javac/main/Option getXLintChoices ()Ljava/util/Set; 42 <appendix> member <vmtarget> ; # com/sun/tools/javac/main/Option$$Lambda+0x000000008d22b990
+instanceKlass  @bci com/sun/tools/javac/main/Option getXLintChoices ()Ljava/util/Set; 26 <appendix> argL0 ; # com/sun/tools/javac/main/Option$$Lambda+0x000000008d22b748
+instanceKlass  @bci com/sun/tools/javac/code/Lint$LintCategory <init> (Ljava/lang/String;ILjava/lang/String;Z[Ljava/lang/String;)V 60 <appendix> member <vmtarget> ; # com/sun/tools/javac/code/Lint$LintCategory$$Lambda+0x000000008d22b0b8
+instanceKlass com/sun/tools/javac/code/Lint
+instanceKlass com/sun/tools/javac/util/Assert
+instanceKlass com/sun/tools/javac/file/RelativePath
+instanceKlass javax/tools/JavaFileObject
+instanceKlass javax/tools/JavaFileManager$Location
+instanceKlass javax/tools/FileObject
+instanceKlass com/sun/tools/javac/file/JavacFileManager$Container
+instanceKlass com/sun/tools/javac/util/JCDiagnostic$DiagnosticInfo
+instanceKlass com/sun/tools/javac/main/OptionHelper
+instanceKlass  @bci com/sun/tools/javac/file/CacheFSInfo preRegister (Lcom/sun/tools/javac/util/Context;)V 3 <appendix> argL0 ; # com/sun/tools/javac/file/CacheFSInfo$$Lambda+0x000000008d224b38
+instanceKlass com/sun/tools/javac/file/FSInfo
+instanceKlass com/sun/tools/javac/util/AbstractDiagnosticFormatter
+instanceKlass com/sun/tools/javac/api/DiagnosticFormatter
+instanceKlass com/sun/tools/javac/util/Log$DiagnosticHandler
+instanceKlass com/sun/tools/javac/util/JCDiagnostic$DiagnosticPosition
+instanceKlass com/sun/tools/javac/util/AbstractLog
+instanceKlass com/sun/tools/javac/util/Context$Factory
+instanceKlass com/sun/tools/javac/util/Context$Key
+instanceKlass javax/tools/DiagnosticCollector
+instanceKlass org/codehaus/plexus/compiler/javac/JavaxToolsCompiler$1
+instanceKlass org/codehaus/plexus/util/StringUtils
+instanceKlass  @bci org/codehaus/plexus/compiler/javac/JavacCompiler$JavaVersion isOlderOrEqualTo (Ljava/lang/String;)Z 33 <appendix> member <vmtarget> ; # org/codehaus/plexus/compiler/javac/JavacCompiler$JavaVersion$$Lambda+0x000000008d21b118
+instanceKlass org/apache/maven/shared/utils/io/SelectorUtils
+instanceKlass org/apache/maven/shared/utils/io/MatchPattern
+instanceKlass org/apache/maven/shared/utils/io/MatchPatterns
+instanceKlass org/apache/maven/shared/utils/io/DirectoryScanner
+instanceKlass org/apache/maven/shared/utils/io/FileUtils
+instanceKlass  @bci java/util/stream/SortedOps$RefSortingSink end ()V 48 <appendix> member <vmtarget> ; # java/util/stream/SortedOps$RefSortingSink$$Lambda+0x000000008d1cccf0
+instanceKlass  @bci org/apache/maven/plugin/compiler/AbstractCompilerMojo executeReal ()V 3312 <appendix> argL0 ; # org/apache/maven/plugin/compiler/AbstractCompilerMojo$$Lambda+0x000000008d21f8c8
+instanceKlass  @bci org/apache/maven/plugin/compiler/AbstractCompilerMojo executeReal ()V 3302 <appendix> argL0 ; # org/apache/maven/plugin/compiler/AbstractCompilerMojo$$Lambda+0x000000008d21f680
+instanceKlass java/util/Collections$ReverseComparator
+instanceKlass org/apache/maven/shared/utils/logging/AnsiMessageBuilder
+instanceKlass org/apache/maven/shared/utils/logging/LoggerLevelRenderer
+instanceKlass org/apache/maven/shared/utils/logging/MessageUtils
+instanceKlass sun/nio/fs/BasicFileAttributesHolder
+instanceKlass  @bci org/apache/maven/plugin/compiler/AbstractCompilerMojo isDependencyChanged ()Z 191 <appendix> member <vmtarget> ; # org/apache/maven/plugin/compiler/AbstractCompilerMojo$$Lambda+0x000000008d21e6a0
+instanceKlass  @bci java/nio/file/Files walk (Ljava/nio/file/Path;I[Ljava/nio/file/FileVisitOption;)Ljava/util/stream/Stream; 43 <appendix> argL0 ; # java/nio/file/Files$$Lambda+0x000000008d1cbff8
+instanceKlass  @bci java/nio/file/Files walk (Ljava/nio/file/Path;I[Ljava/nio/file/FileVisitOption;)Ljava/util/stream/Stream; 30 <appendix> member <vmtarget> ; # java/nio/file/Files$$Lambda+0x000000008d1cbdc8
+instanceKlass java/nio/file/FileTreeWalker$Event
+instanceKlass sun/nio/fs/WindowsDirectoryStream$WindowsDirectoryIterator
+instanceKlass java/nio/file/FileTreeWalker$DirectoryNode
+instanceKlass sun/nio/fs/WindowsDirectoryStream
+instanceKlass java/nio/file/DirectoryStream
+instanceKlass java/nio/file/Files$AcceptAllFilter
+instanceKlass java/nio/file/DirectoryStream$Filter
+instanceKlass java/nio/file/FileTreeWalker
+instanceKlass java/nio/file/FileTreeIterator
+instanceKlass org/apache/maven/plugin/compiler/TestCompilerMojo$$FastClassByGuice$$268024214
+instanceKlass org/apache/maven/plugins/resources/TestResourcesMojo$$FastClassByGuice$$266519772
+instanceKlass org/apache/maven/shared/utils/StringUtils
+instanceKlass  @bci org/apache/maven/plugin/compiler/AbstractCompilerMojo executeReal ()V 1279 <appendix> argL0 ; # org/apache/maven/plugin/compiler/AbstractCompilerMojo$$Lambda+0x000000008d21e000
+instanceKlass org/apache/maven/plugin/compiler/DeltaList
+instanceKlass  @bci java/util/stream/Collectors toCollection (Ljava/util/function/Supplier;)Ljava/util/stream/Collector; 10 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x000000008d1ca1e0
+instanceKlass  @bci java/util/stream/Collectors toCollection (Ljava/util/function/Supplier;)Ljava/util/stream/Collector; 5 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x000000008d1c9fa8
+instanceKlass  @bci org/apache/maven/plugin/compiler/AbstractCompilerMojo hasInputFileTreeChanged (Lorg/apache/maven/shared/incremental/IncrementalBuildHelper;Ljava/util/Set;)Z 127 <appendix> argL0 ; # org/apache/maven/plugin/compiler/AbstractCompilerMojo$$Lambda+0x000000008d21dbc0
+instanceKlass  @bci org/apache/maven/plugin/compiler/AbstractCompilerMojo hasInputFileTreeChanged (Lorg/apache/maven/shared/incremental/IncrementalBuildHelper;Ljava/util/Set;)Z 117 <appendix> argL0 ; # org/apache/maven/plugin/compiler/AbstractCompilerMojo$$Lambda+0x000000008d21d978
+instanceKlass java/nio/file/attribute/FileTime$1
+instanceKlass org/codehaus/plexus/util/io/InputStreamFacade
+instanceKlass org/codehaus/plexus/util/BaseFileUtils
+instanceKlass  @bci org/apache/maven/plugin/compiler/AbstractCompilerMojo getBuildStartTimeInstant ()Ljava/util/Optional; 26 <appendix> argL0 ; # org/apache/maven/plugin/compiler/AbstractCompilerMojo$$Lambda+0x000000008d21d2d8
+instanceKlass  @bci org/apache/maven/plugin/compiler/AbstractCompilerMojo getBuildStartTimeInstant ()Ljava/util/Optional; 18 <appendix> argL0 ; # org/apache/maven/plugin/compiler/AbstractCompilerMojo$$Lambda+0x000000008d21d090
+instanceKlass  @bci org/apache/maven/plugin/compiler/AbstractCompilerMojo getBuildStartTimeInstant ()Ljava/util/Optional; 10 <appendix> argL0 ; # org/apache/maven/plugin/compiler/AbstractCompilerMojo$$Lambda+0x000000008d21ce48
+instanceKlass org/apache/maven/shared/incremental/IncrementalBuildHelperRequest
+instanceKlass org/codehaus/plexus/util/SelectorUtils
+instanceKlass org/codehaus/plexus/util/MatchPatterns
+instanceKlass org/codehaus/plexus/util/MatchPattern
+instanceKlass org/codehaus/plexus/util/AbstractScanner
+instanceKlass org/codehaus/plexus/util/Scanner
+instanceKlass org/codehaus/plexus/compiler/util/scan/mapping/SuffixMapping
+instanceKlass org/codehaus/plexus/compiler/util/scan/AbstractSourceInclusionScanner
+instanceKlass  @bci org/apache/maven/plugin/compiler/AbstractCompilerMojo resolveProcessorPathEntries ()Ljava/util/List; 98 <appendix> argL0 ; # org/apache/maven/plugin/compiler/AbstractCompilerMojo$$Lambda+0x000000008d215768
+instanceKlass org/apache/maven/project/MavenProject$LoggingList$1
+instanceKlass com/sun/tools/javac/util/Context
+instanceKlass com/sun/tools/javac/file/BaseFileManager
+instanceKlass com/sun/source/util/JavacTask
+instanceKlass javax/tools/JavaCompiler$CompilationTask
+instanceKlass javax/tools/StandardJavaFileManager
+instanceKlass com/sun/tools/javac/api/JavacTool
+instanceKlass javax/tools/ToolProvider
+instanceKlass org/codehaus/plexus/compiler/PlexusLoggerWrapper
+instanceKlass org/eclipse/sisu/wire/ProviderIterableAdapter$ProviderEntry
+instanceKlass org/eclipse/sisu/wire/ProviderIterableAdapter$ProviderIterator
+instanceKlass org/eclipse/sisu/wire/ProviderIterableAdapter
+instanceKlass org/apache/maven/toolchain/DefaultToolchainManager$$FastClassByGuice$$265964039
+instanceKlass org/apache/maven/plugin/compiler/CompilerMojo$$FastClassByGuice$$265056299
+instanceKlass org/codehaus/plexus/compiler/javac/JavaxToolsCompiler$$FastClassByGuice$$264233060
+instanceKlass org/codehaus/plexus/compiler/javac/JavacCompiler$$FastClassByGuice$$262378213
+instanceKlass org/codehaus/plexus/compiler/manager/DefaultCompilerManager$$FastClassByGuice$$262110231
+instanceKlass org/codehaus/plexus/languages/java/jpms/LocationManager$$FastClassByGuice$$260967306
+instanceKlass org/eclipse/sisu/wire/BeanProviders$2
+instanceKlass javax/tools/Diagnostic
+instanceKlass javax/tools/JavaCompiler
+instanceKlass javax/tools/Tool
+instanceKlass javax/tools/JavaFileManager
+instanceKlass javax/tools/OptionChecker
+instanceKlass javax/tools/DiagnosticListener
+instanceKlass org/codehaus/plexus/compiler/CompilerMessage
+instanceKlass org/codehaus/plexus/util/cli/StreamConsumer
+instanceKlass org/codehaus/plexus/compiler/CompilerOutputStyle
+instanceKlass org/codehaus/plexus/languages/java/jpms/ResolvePathsRequest
+instanceKlass org/codehaus/plexus/languages/java/jpms/ResolvePathRequest
+instanceKlass org/codehaus/plexus/languages/java/jpms/ResolvePathResult
+instanceKlass org/codehaus/plexus/languages/java/jpms/ManifestModuleNameExtractor
+instanceKlass org/codehaus/plexus/languages/java/jpms/SourceModuleInfoParser
+instanceKlass org/codehaus/plexus/languages/java/jpms/ModuleInfoParser
+instanceKlass org/codehaus/plexus/languages/java/jpms/ModuleNameExtractor
+instanceKlass org/codehaus/plexus/languages/java/jpms/JavaModuleDescriptor
+instanceKlass org/codehaus/plexus/languages/java/jpms/ResolvePathsResult
+instanceKlass org/codehaus/plexus/compiler/CompilerResult
+instanceKlass org/apache/maven/shared/incremental/IncrementalBuildHelper
+instanceKlass org/codehaus/plexus/compiler/util/scan/SourceInclusionScanner
+instanceKlass org/apache/maven/plugin/compiler/DependencyCoordinate
+instanceKlass org/apache/maven/shared/utils/logging/MessageBuilder
+instanceKlass org/codehaus/plexus/compiler/CompilerConfiguration
+instanceKlass org/codehaus/plexus/compiler/util/scan/mapping/SourceMapping
+instanceKlass org/codehaus/plexus/compiler/javac/JavaxToolsCompiler
+instanceKlass org/codehaus/plexus/compiler/javac/InProcessCompiler
+instanceKlass org/codehaus/plexus/compiler/AbstractCompiler
+instanceKlass org/codehaus/plexus/compiler/Compiler
+instanceKlass org/codehaus/plexus/compiler/manager/DefaultCompilerManager
+instanceKlass org/codehaus/plexus/compiler/manager/CompilerManager
+instanceKlass org/codehaus/plexus/languages/java/jpms/LocationManager
+instanceKlass org/sonatype/plexus/build/incremental/EmptyScanner
+instanceKlass java/nio/file/attribute/PosixFileAttributes
+instanceKlass java/nio/BufferMismatch
+instanceKlass sun/nio/fs/WindowsChannelFactory$2
+instanceKlass java/nio/file/attribute/UserDefinedFileAttributeView
+instanceKlass java/nio/file/attribute/AclFileAttributeView
+instanceKlass java/nio/file/attribute/DosFileAttributeView
+instanceKlass java/nio/file/attribute/PosixFileAttributeView
+instanceKlass java/nio/file/attribute/FileOwnerAttributeView
+instanceKlass org/apache/maven/shared/filtering/FilteringUtils$1
+instanceKlass org/apache/maven/shared/filtering/FilteringUtils
+instanceKlass org/codehaus/plexus/util/io/InputStreamFacade
+instanceKlass org/codehaus/plexus/util/BaseFileUtils
+instanceKlass org/codehaus/plexus/util/SelectorUtils
+instanceKlass org/codehaus/plexus/util/MatchPatterns
+instanceKlass org/codehaus/plexus/util/MatchPattern
+instanceKlass org/codehaus/plexus/interpolation/RecursionInterceptor
+instanceKlass org/codehaus/plexus/interpolation/AbstractValueSource
+instanceKlass org/apache/maven/plugins/resources/MavenBuildTimestamp
+instanceKlass org/apache/maven/shared/filtering/FilterWrapper
+instanceKlass org/codehaus/plexus/util/StringUtils
+instanceKlass org/sonatype/plexus/build/incremental/DefaultBuildContext$$FastClassByGuice$$259186084
+instanceKlass org/apache/maven/plugins/resources/ResourcesMojo$$FastClassByGuice$$258225641
+instanceKlass org/codehaus/plexus/build/DefaultBuildContext$$FastClassByGuice$$257614623
+instanceKlass org/apache/maven/shared/filtering/DefaultMavenResourcesFiltering$$FastClassByGuice$$256748179
+instanceKlass org/apache/maven/shared/filtering/DefaultMavenReaderFilter$$FastClassByGuice$$254994095
+instanceKlass org/apache/maven/shared/filtering/DefaultMavenFileFilter$$FastClassByGuice$$254428271
+instanceKlass org/codehaus/plexus/util/AbstractScanner
+instanceKlass org/codehaus/plexus/interpolation/Interpolator
+instanceKlass org/codehaus/plexus/interpolation/BasicInterpolator
+instanceKlass org/codehaus/plexus/interpolation/ValueSource
+instanceKlass org/codehaus/plexus/util/Scanner
+instanceKlass org/apache/maven/shared/filtering/AbstractMavenFilteringRequest
+instanceKlass org/codehaus/plexus/build/DefaultBuildContext
+instanceKlass org/codehaus/plexus/build/BuildContext
+instanceKlass org/apache/maven/shared/filtering/DefaultMavenResourcesFiltering
+instanceKlass org/apache/maven/shared/filtering/MavenResourcesFiltering
+instanceKlass org/apache/maven/shared/filtering/MavenReaderFilter
+instanceKlass org/apache/maven/shared/filtering/BaseFilter
+instanceKlass org/apache/maven/shared/filtering/MavenFileFilter
+instanceKlass org/apache/maven/shared/filtering/DefaultFilterInfo
+instanceKlass org/sonatype/plexus/build/incremental/BuildContext
+instanceKlass org/jacoco/core/runtime/CommandLineSupport
+instanceKlass org/codehaus/plexus/util/StringUtils
+instanceKlass org/apache/maven/plugin/lifecycle/Lifecycle
+instanceKlass org/codehaus/plexus/util/introspection/MethodMap
+instanceKlass org/codehaus/plexus/util/introspection/ClassMap$CacheMiss
+instanceKlass org/codehaus/plexus/util/introspection/ClassMap
+instanceKlass org/codehaus/plexus/util/introspection/ReflectionValueExtractor$Tokenizer
+instanceKlass org/codehaus/plexus/util/introspection/ReflectionValueExtractor
+instanceKlass org/jacoco/maven/AgentMojo$$FastClassByGuice$$252781802
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d204000
+instanceKlass org/jacoco/core/tools/ExecFileLoader
+instanceKlass org/jacoco/maven/FileFilter
+instanceKlass org/jacoco/maven/ReportSupport
+instanceKlass org/apache/maven/doxia/sink/SinkFactory
+instanceKlass org/codehaus/doxia/sink/Sink
+instanceKlass org/apache/maven/doxia/sink/Sink
+instanceKlass org/jacoco/core/runtime/AgentOptions
+instanceKlass org/jacoco/core/runtime/IExecutionDataAccessorGenerator
+instanceKlass org/jacoco/core/tools/ExecDumpClient
+instanceKlass org/jacoco/report/check/Limit
+instanceKlass org/jacoco/report/check/Rule
+instanceKlass org/jacoco/core/analysis/ICoverageNode
+instanceKlass org/jacoco/report/IReportGroupVisitor
+instanceKlass org/apache/maven/reporting/MavenMultiPageReport
+instanceKlass org/apache/maven/reporting/MavenReport
+instanceKlass org/jacoco/report/check/IViolationsOutput
+instanceKlass  @bci org/apache/maven/enforcer/rules/utils/ArtifactMatcher$Pattern matches (ILjava/lang/String;)Z 108 <appendix> member <vmtarget> ; # org/apache/maven/enforcer/rules/utils/ArtifactMatcher$Pattern$$Lambda+0x000000008d1bda60
+instanceKlass  @bci java/util/function/Predicate or (Ljava/util/function/Predicate;)Ljava/util/function/Predicate; 7 <appendix> member <vmtarget> ; # java/util/function/Predicate$$Lambda+0x000000008d1c7b10
+instanceKlass  @bci org/apache/maven/enforcer/rules/utils/ArtifactUtils lambda$prepareDependencyArtifactMatcher$5 (Lorg/apache/maven/enforcer/rules/utils/ArtifactMatcher$Pattern;)Ljava/util/function/Predicate; 6 <appendix> member <vmtarget> ; # org/apache/maven/enforcer/rules/utils/ArtifactUtils$$Lambda+0x000000008d1bd800
+instanceKlass  @bci org/apache/commons/lang3/StringUtils stripAll ([Ljava/lang/String;Ljava/lang/String;)[Ljava/lang/String; 17 <appendix> member <vmtarget> ; # org/apache/commons/lang3/StringUtils$$Lambda+0x000000008d1bfb88
+instanceKlass org/apache/commons/lang3/ArrayUtils
+instanceKlass  @bci org/apache/maven/enforcer/rules/utils/ArtifactUtils lambda$cleansePatterns$9 (Ljava/util/Collection;)Ljava/util/stream/Stream; 26 <appendix> argL0 ; # org/apache/maven/enforcer/rules/utils/ArtifactUtils$$Lambda+0x000000008d1bf730
+instanceKlass  @bci org/apache/maven/enforcer/rules/utils/ArtifactUtils lambda$cleansePatterns$9 (Ljava/util/Collection;)Ljava/util/stream/Stream; 16 <appendix> argL0 ; # org/apache/maven/enforcer/rules/utils/ArtifactUtils$$Lambda+0x000000008d1bf4e8
+instanceKlass  @bci org/apache/maven/enforcer/rules/utils/ArtifactUtils lambda$cleansePatterns$9 (Ljava/util/Collection;)Ljava/util/stream/Stream; 6 <appendix> argL0 ; # org/apache/maven/enforcer/rules/utils/ArtifactUtils$$Lambda+0x000000008d1bf2a0
+instanceKlass org/eclipse/aether/util/graph/manager/DependencyManagerUtils
+instanceKlass  @bci org/apache/maven/enforcer/rules/dependency/RequireUpperBoundDeps$RequireUpperBoundDepsVisitor visitEnter (Lorg/eclipse/aether/graph/DependencyNode;)Z 97 <appendix> argL0 ; # org/apache/maven/enforcer/rules/dependency/RequireUpperBoundDeps$RequireUpperBoundDepsVisitor$$Lambda+0x000000008d1bf000
+instanceKlass  @cpi com/sun/tools/javac/main/Arguments 1152 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d1bd400
+instanceKlass  @bci org/apache/maven/enforcer/rules/dependency/RequireUpperBoundDeps$RequireUpperBoundDepsVisitor visitEnter (Lorg/eclipse/aether/graph/DependencyNode;)Z 64 <appendix> argL0 ; # org/apache/maven/enforcer/rules/dependency/RequireUpperBoundDeps$RequireUpperBoundDepsVisitor$$Lambda+0x000000008d1bedb8
+instanceKlass org/apache/maven/enforcer/rules/dependency/RequireUpperBoundDeps$DependencyNodeHopCountPair
+instanceKlass  @bci org/apache/maven/enforcer/rules/dependency/RequireUpperBoundDeps execute ()V 44 <appendix> member <vmtarget> ; # org/apache/maven/enforcer/rules/dependency/RequireUpperBoundDeps$$Lambda+0x000000008d1be938
+instanceKlass  @bci org/apache/maven/enforcer/rules/dependency/DependencyVersionMap addDependency (Lorg/eclipse/aether/graph/DependencyNode;)V 11 <appendix> argL0 ; # org/apache/maven/enforcer/rules/dependency/DependencyVersionMap$$Lambda+0x000000008d1be6f0
+instanceKlass java/util/concurrent/ConcurrentLinkedDeque$Node
+instanceKlass org/apache/maven/enforcer/rules/utils/ParentsVisitor
+instanceKlass org/eclipse/aether/util/graph/visitor/PathRecordingDependencyVisitor
+instanceKlass org/apache/maven/enforcer/rules/dependency/BanDynamicVersions$BannedDynamicVersionCollector
+instanceKlass  @bci org/apache/maven/enforcer/rules/dependency/BanDynamicVersions collectDependenciesWithBannedDynamicVersions (Lorg/eclipse/aether/graph/DependencyNode;)Ljava/util/List; 34 <appendix> argL0 ; # org/apache/maven/enforcer/rules/dependency/BanDynamicVersions$$Lambda+0x000000008d1be000
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions getProfilePluginManagementPlugins (Ljava/util/List;Lorg/apache/maven/model/Profile;)V 28 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1bbcb8
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions getProfilePluginManagementPlugins (Ljava/util/List;Lorg/apache/maven/model/Profile;)V 20 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1bba70
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions getProfilePluginManagementPlugins (Ljava/util/List;Lorg/apache/maven/model/Profile;)V 12 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1bb828
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions getProfilePluginManagementPlugins (Ljava/util/List;Lorg/apache/maven/model/Profile;)V 4 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1bb5e0
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions getProfileReportingPlugins (Ljava/util/List;Lorg/apache/maven/model/Profile;)V 20 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1bb3b8
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions getProfileReportingPlugins (Ljava/util/List;Lorg/apache/maven/model/Profile;)V 12 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1bb170
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions getProfileReportingPlugins (Ljava/util/List;Lorg/apache/maven/model/Profile;)V 4 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1baf28
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions getProfilePlugins (Ljava/util/List;Lorg/apache/maven/model/Profile;)V 20 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1bad00
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions getProfilePlugins (Ljava/util/List;Lorg/apache/maven/model/Profile;)V 12 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1baab8
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions getProfilePlugins (Ljava/util/List;Lorg/apache/maven/model/Profile;)V 4 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1ba870
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions addPluginsInProfiles (Ljava/util/List;Lorg/apache/maven/model/Model;)V 12 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1ba648
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions addPluginsInProfiles (Ljava/util/List;Lorg/apache/maven/model/Model;)V 4 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1ba400
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions getPluginManagementPlugins (Ljava/util/List;Lorg/apache/maven/model/Model;)V 28 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1ba1d8
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions getPluginManagementPlugins (Ljava/util/List;Lorg/apache/maven/model/Model;)V 20 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1b9f90
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions getPluginManagementPlugins (Ljava/util/List;Lorg/apache/maven/model/Model;)V 12 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1b9d48
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions getPluginManagementPlugins (Ljava/util/List;Lorg/apache/maven/model/Model;)V 4 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1b9b00
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions getReportingPlugins (Ljava/util/List;Lorg/apache/maven/model/Model;)V 20 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1b98d8
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions getReportingPlugins (Ljava/util/List;Lorg/apache/maven/model/Model;)V 12 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1b9690
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions getReportingPlugins (Ljava/util/List;Lorg/apache/maven/model/Model;)V 4 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1b9448
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions getPlugins (Ljava/util/List;Lorg/apache/maven/model/Model;)V 20 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1b9220
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions getPlugins (Ljava/util/List;Lorg/apache/maven/model/Model;)V 12 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1b8fd8
+instanceKlass  @bci org/apache/maven/enforcer/rules/RequirePluginVersions getPlugins (Ljava/util/List;Lorg/apache/maven/model/Model;)V 4 <appendix> argL0 ; # org/apache/maven/enforcer/rules/RequirePluginVersions$$Lambda+0x000000008d1b8d90
+instanceKlass  @bci org/apache/maven/plugin/internal/DefaultPluginValidationManager$PluginValidationIssues reportPluginIssue (Lorg/apache/maven/plugin/PluginValidationManager$IssueLocality;Ljava/lang/String;Ljava/lang/String;)V 18 <appendix> argL0 ; # org/apache/maven/plugin/internal/DefaultPluginValidationManager$PluginValidationIssues$$Lambda+0x000000008d1b3300
+instanceKlass  @bci org/apache/maven/plugin/internal/DefaultPluginValidationManager reportPluginValidationIssue (Lorg/apache/maven/plugin/PluginValidationManager$IssueLocality;Lorg/eclipse/aether/RepositorySystemSession;Lorg/eclipse/aether/artifact/Artifact;Ljava/lang/String;)V 30 <appendix> argL0 ; # org/apache/maven/plugin/internal/DefaultPluginValidationManager$$Lambda+0x000000008d1b30b8
+instanceKlass  @bci org/apache/maven/plugin/internal/DefaultPluginValidationManager pluginIssues (Lorg/eclipse/aether/RepositorySystemSession;)Ljava/util/concurrent/ConcurrentHashMap; 9 <appendix> argL0 ; # org/apache/maven/plugin/internal/DefaultPluginValidationManager$$Lambda+0x000000008d1b2e90
+instanceKlass  @bci org/apache/maven/enforcer/rules/dependency/RequireReleaseDeps execute ()V 116 <appendix> argL0 ; # org/apache/maven/enforcer/rules/dependency/RequireReleaseDeps$$Lambda+0x000000008d1b8b48
+instanceKlass org/apache/maven/enforcer/rules/utils/ArtifactMatcher$MatchingArtifact
+instanceKlass  @bci org/apache/maven/enforcer/rules/utils/ArtifactUtils toArtifact (Lorg/eclipse/aether/graph/Dependency;)Lorg/apache/maven/artifact/Artifact; 21 <appendix> member <vmtarget> ; # org/apache/maven/enforcer/rules/utils/ArtifactUtils$$Lambda+0x000000008d1b86f0
+instanceKlass  @cpi com/sun/tools/javac/code/Symtab 1381 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d1bd000
+instanceKlass  @bci org/apache/maven/enforcer/rules/dependency/BannedDependenciesBase validate (Lorg/eclipse/aether/graph/DependencyNode;ILjava/lang/StringBuilder;Ljava/util/Set;)Z 88 <appendix> argL0 ; # org/apache/maven/enforcer/rules/dependency/BannedDependenciesBase$$Lambda+0x000000008d1b84a0
+instanceKlass java/lang/invoke/TypeConvertingMethodAdapter$BoxHolder
+instanceKlass  @bci org/apache/maven/enforcer/rules/dependency/BannedDependenciesBase validate (Lorg/eclipse/aether/graph/DependencyNode;ILjava/lang/StringBuilder;Ljava/util/Set;)Z 74 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x000000008d1bcc00
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d1bc800
+instanceKlass  @bci org/apache/maven/enforcer/rules/dependency/BannedDependenciesBase validate (Lorg/eclipse/aether/graph/DependencyNode;ILjava/lang/StringBuilder;Ljava/util/Set;)Z 74 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d1bc400
+instanceKlass  @bci org/apache/maven/enforcer/rules/dependency/BannedDependenciesBase validate (Lorg/eclipse/aether/graph/DependencyNode;ILjava/lang/StringBuilder;Ljava/util/Set;)Z 74 <appendix> member <vmtarget> ; # org/apache/maven/enforcer/rules/dependency/BannedDependenciesBase$$Lambda+0x000000008d1b8250
+instanceKlass  @cpi org/apache/maven/enforcer/rules/dependency/BannedDependenciesBase 279 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d1bc000
+instanceKlass  @bci org/apache/maven/enforcer/rules/dependency/ResolverUtil lambda$resolveTransitiveDependencies$4 (Lorg/eclipse/aether/artifact/ArtifactTypeRegistry;Ljava/util/List;)Ljava/util/List; 7 <appendix> member <vmtarget> ; # org/apache/maven/enforcer/rules/dependency/ResolverUtil$$Lambda+0x000000008d1b8000
+instanceKlass  @bci org/apache/maven/enforcer/rules/dependency/ResolverUtil resolveTransitiveDependencies (ZZZLjava/util/List;)Lorg/eclipse/aether/graph/DependencyNode; 151 <appendix> member <vmtarget> ; # org/apache/maven/enforcer/rules/dependency/ResolverUtil$$Lambda+0x000000008d1b5c00
+instanceKlass  @bci org/apache/maven/enforcer/rules/dependency/ResolverUtil resolveTransitiveDependencies (ZZZLjava/util/List;)Lorg/eclipse/aether/graph/DependencyNode; 141 <appendix> argL0 ; # org/apache/maven/enforcer/rules/dependency/ResolverUtil$$Lambda+0x000000008d1b7ba0
+instanceKlass  @bci org/apache/maven/enforcer/rules/dependency/ResolverUtil resolveTransitiveDependencies (ZZZLjava/util/List;)Lorg/eclipse/aether/graph/DependencyNode; 110 <appendix> member <vmtarget> ; # org/apache/maven/enforcer/rules/dependency/ResolverUtil$$Lambda+0x000000008d1b7950
+instanceKlass  @bci org/apache/maven/enforcer/rules/dependency/ResolverUtil resolveTransitiveDependencies (ZZZLjava/util/List;)Lorg/eclipse/aether/graph/DependencyNode; 98 <appendix> member <vmtarget> ; # org/apache/maven/enforcer/rules/dependency/ResolverUtil$$Lambda+0x000000008d1b76f0
+instanceKlass  @bci org/apache/maven/enforcer/rules/dependency/ResolverUtil resolveTransitiveDependencies (ZZZLjava/util/List;)Lorg/eclipse/aether/graph/DependencyNode; 86 <appendix> member <vmtarget> ; # org/apache/maven/enforcer/rules/dependency/ResolverUtil$$Lambda+0x000000008d1b7498
+instanceKlass  @cpi com/sun/tools/javac/jvm/ClassReader$TypeAnnotationSymbolVisitor 361 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d1b5800
+instanceKlass  @bci org/apache/maven/enforcer/rules/utils/ArtifactUtils prepareDependencyArtifactMatcher (Ljava/util/Collection;)Ljava/util/function/Predicate; 34 <appendix> argL0 ; # org/apache/maven/enforcer/rules/utils/ArtifactUtils$$Lambda+0x000000008d1b7240
+instanceKlass java/util/stream/ReduceOps$2ReducingSink
+instanceKlass  @bci org/apache/maven/enforcer/rules/utils/ArtifactUtils prepareDependencyArtifactMatcher (Ljava/util/Collection;)Ljava/util/function/Predicate; 24 <appendix> argL0 ; # org/apache/maven/enforcer/rules/utils/ArtifactUtils$$Lambda+0x000000008d1b6ff0
+instanceKlass  @cpi org/apache/maven/enforcer/rules/utils/ArtifactUtils 258 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d1b5400
+instanceKlass  @bci org/apache/maven/enforcer/rules/utils/ArtifactUtils prepareDependencyArtifactMatcher (Ljava/util/Collection;)Ljava/util/function/Predicate; 14 <appendix> argL0 ; # org/apache/maven/enforcer/rules/utils/ArtifactUtils$$Lambda+0x000000008d1b6da8
+instanceKlass  @bci org/apache/maven/enforcer/rules/utils/ArtifactUtils prepareDependencyArtifactMatcher (Ljava/util/Collection;)Ljava/util/function/Predicate; 4 <appendix> argL0 ; # org/apache/maven/enforcer/rules/utils/ArtifactUtils$$Lambda+0x000000008d1b6b60
+instanceKlass org/apache/maven/enforcer/rules/utils/ArtifactMatcher$Pattern
+instanceKlass  @bci org/apache/maven/enforcer/rules/utils/ArtifactUtils cleansePatterns (Ljava/util/Collection;)Ljava/util/stream/Stream; 4 <appendix> argL0 ; # org/apache/maven/enforcer/rules/utils/ArtifactUtils$$Lambda+0x000000008d1b66f0
+instanceKlass org/apache/maven/enforcer/rules/utils/ArtifactUtils
+instanceKlass org/apache/commons/lang3/CharSequenceUtils
+instanceKlass org/apache/commons/lang3/Strings
+instanceKlass  @bci org/apache/commons/lang3/SystemUtils <clinit> ()V 222 <appendix> argL0 ; # org/apache/commons/lang3/SystemUtils$$Lambda+0x000000008d1ab968
+instanceKlass org/apache/commons/lang3/math/NumberUtils
+instanceKlass  @bci org/apache/commons/lang3/SystemProperties getProperty (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String; 2 <appendix> member <vmtarget> ; # org/apache/commons/lang3/SystemProperties$$Lambda+0x000000008d1ab328
+instanceKlass  @bci java/util/regex/CharPredicates forUnicodeBlock (Ljava/lang/String;)Ljava/util/regex/Pattern$CharPredicate; 6 <appendix> member <vmtarget> ; # java/util/regex/CharPredicates$$Lambda+0x000000008d1c5610
+instanceKlass java/lang/Character$Subset
+instanceKlass org/apache/commons/lang3/StringUtils
+instanceKlass  @bci org/apache/commons/lang3/function/Suppliers <clinit> ()V 0 <appendix> argL0 ; # org/apache/commons/lang3/function/Suppliers$$Lambda+0x000000008d1aaca0
+instanceKlass org/apache/commons/lang3/function/Suppliers
+instanceKlass org/apache/commons/lang3/SystemProperties
+instanceKlass org/apache/commons/lang3/SystemUtils
+instanceKlass  @bci org/apache/maven/plugins/enforcer/internal/EnforcerRuleCache isCached (Lorg/apache/maven/enforcer/rule/api/AbstractEnforcerRule;)Z 98 <appendix> argL0 ; # org/apache/maven/plugins/enforcer/internal/EnforcerRuleCache$$Lambda+0x000000008d1aa428
+instanceKlass org/apache/maven/plugins/enforcer/internal/DefaultEnforcementRuleHelper
+instanceKlass  @bci org/apache/maven/plugins/enforcer/EnforceMojo filterOutRuleConfigProviders (Ljava/util/List;)Ljava/util/List; 16 <appendix> argL0 ; # org/apache/maven/plugins/enforcer/EnforceMojo$$Lambda+0x000000008d1a9ee8
+instanceKlass  @bci org/apache/maven/plugins/enforcer/EnforceMojo filterOutRuleConfigProviders (Ljava/util/List;)Ljava/util/List; 6 <appendix> argL0 ; # org/apache/maven/plugins/enforcer/EnforceMojo$$Lambda+0x000000008d1a9c90
+instanceKlass  @bci org/apache/maven/plugins/enforcer/EnforceMojo processRuleConfigProviders (Ljava/util/List;)Ljava/util/List; 38 <appendix> member <vmtarget> ; # org/apache/maven/plugins/enforcer/EnforceMojo$$Lambda+0x000000008d1a9a40
+instanceKlass  @bci org/apache/maven/plugins/enforcer/EnforceMojo processRuleConfigProviders (Ljava/util/List;)Ljava/util/List; 27 <appendix> member <vmtarget> ; # org/apache/maven/plugins/enforcer/EnforceMojo$$Lambda+0x000000008d1a97f0
+instanceKlass  @bci org/apache/maven/plugins/enforcer/EnforceMojo processRuleConfigProviders (Ljava/util/List;)Ljava/util/List; 16 <appendix> argL0 ; # org/apache/maven/plugins/enforcer/EnforceMojo$$Lambda+0x000000008d1a9598
+instanceKlass  @bci org/apache/maven/plugins/enforcer/EnforceMojo processRuleConfigProviders (Ljava/util/List;)Ljava/util/List; 6 <appendix> argL0 ; # org/apache/maven/plugins/enforcer/EnforceMojo$$Lambda+0x000000008d1a9340
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d1b5000
+instanceKlass org/apache/maven/plugin/internal/DefaultPluginManager$$FastClassByGuice$$251934300
+instanceKlass  @bci org/apache/maven/plugins/enforcer/internal/EnforcerRuleManager getRuleLevelFromConfig (Lorg/codehaus/plexus/configuration/PlexusConfiguration;)Lorg/apache/maven/enforcer/rule/api/EnforcerLevel; 14 <appendix> argL0 ; # org/apache/maven/plugins/enforcer/internal/EnforcerRuleManager$$Lambda+0x000000008d1a8ef8
+instanceKlass org/apache/maven/plugins/enforcer/internal/AbstractEnforcerLogger
+instanceKlass  @bci org/apache/maven/plugins/enforcer/EnforceMojo setRulesToSkip (Ljava/util/List;)V 22 <appendix> argL0 ; # org/apache/maven/plugins/enforcer/EnforceMojo$$Lambda+0x000000008d1a86a0
+instanceKlass org/codehaus/plexus/util/StringUtils
+instanceKlass  @bci org/apache/maven/plugins/enforcer/EnforceMojo setRulesToSkip (Ljava/util/List;)V 12 <appendix> argL0 ; # org/apache/maven/plugins/enforcer/EnforceMojo$$Lambda+0x000000008d1a8238
+instanceKlass  @bci jdk/internal/reflect/MethodHandleIntegerFieldAccessorImpl setInt (Ljava/lang/Object;I)V 41 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x000000008d1b4c00
+instanceKlass  @bci com/sun/tools/javac/comp/Lower$TypePairs hashCode ()I 1 <appendix> argL1 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x000000008d1b4800
+instanceKlass org/eclipse/sisu/plexus/CompositeBeanHelper$1
+instanceKlass org/eclipse/sisu/plexus/TypeArguments
+instanceKlass org/eclipse/sisu/plexus/CompositeBeanHelper
+instanceKlass org/apache/maven/plugin/internal/ValidatingConfigurationListener
+instanceKlass org/apache/maven/plugin/DebugConfigurationListener
+instanceKlass  @bci org/apache/maven/plugin/internal/ReadOnlyPluginParametersValidator doValidate (Lorg/apache/maven/execution/MavenSession;Lorg/apache/maven/plugin/descriptor/MojoDescriptor;Ljava/lang/Class;Lorg/codehaus/plexus/configuration/PlexusConfiguration;Lorg/codehaus/plexus/component/configurator/expression/ExpressionEvaluator;)V 35 <appendix> member <vmtarget> ; # org/apache/maven/plugin/internal/ReadOnlyPluginParametersValidator$$Lambda+0x000000008d1b1d18
+instanceKlass  @bci org/apache/maven/plugin/internal/ReadOnlyPluginParametersValidator doValidate (Lorg/apache/maven/execution/MavenSession;Lorg/apache/maven/plugin/descriptor/MojoDescriptor;Ljava/lang/Class;Lorg/codehaus/plexus/configuration/PlexusConfiguration;Lorg/codehaus/plexus/component/configurator/expression/ExpressionEvaluator;)V 17 <appendix> argL0 ; # org/apache/maven/plugin/internal/ReadOnlyPluginParametersValidator$$Lambda+0x000000008d1b1ac0
+instanceKlass  @bci org/apache/maven/plugin/internal/AbstractMavenPluginDescriptorSourcedParametersValidator isIgnoredProperty (Ljava/lang/String;)Z 55 <appendix> member <vmtarget> ; # org/apache/maven/plugin/internal/AbstractMavenPluginDescriptorSourcedParametersValidator$$Lambda+0x000000008d1b1860
+instanceKlass  @bci org/apache/maven/plugin/internal/DeprecatedPluginValidator doValidate (Lorg/apache/maven/execution/MavenSession;Lorg/apache/maven/plugin/descriptor/MojoDescriptor;Ljava/lang/Class;Lorg/codehaus/plexus/configuration/PlexusConfiguration;Lorg/codehaus/plexus/component/configurator/expression/ExpressionEvaluator;)V 71 <appendix> member <vmtarget> ; # org/apache/maven/plugin/internal/DeprecatedPluginValidator$$Lambda+0x000000008d1b1620
+instanceKlass  @cpi org/apache/maven/plugin/internal/ReadOnlyPluginParametersValidator 131 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d1b4400
+instanceKlass  @bci org/apache/maven/plugin/internal/DeprecatedPluginValidator doValidate (Lorg/apache/maven/execution/MavenSession;Lorg/apache/maven/plugin/descriptor/MojoDescriptor;Ljava/lang/Class;Lorg/codehaus/plexus/configuration/PlexusConfiguration;Lorg/codehaus/plexus/component/configurator/expression/ExpressionEvaluator;)V 53 <appendix> argL0 ; # org/apache/maven/plugin/internal/DeprecatedPluginValidator$$Lambda+0x000000008d1b13c8
+instanceKlass  @cpi com/sun/tools/javac/comp/Operators$UnaryNumericOperator 71 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d1b4000
+instanceKlass  @bci org/apache/maven/plugin/internal/DeprecatedPluginValidator doValidate (Lorg/apache/maven/execution/MavenSession;Lorg/apache/maven/plugin/descriptor/MojoDescriptor;Ljava/lang/Class;Lorg/codehaus/plexus/configuration/PlexusConfiguration;Lorg/codehaus/plexus/component/configurator/expression/ExpressionEvaluator;)V 43 <appendix> argL0 ; # org/apache/maven/plugin/internal/DeprecatedPluginValidator$$Lambda+0x000000008d1b1170
+instanceKlass  @bci org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator doValidate (Lorg/apache/maven/execution/MavenSession;Lorg/apache/maven/plugin/descriptor/MojoDescriptor;Ljava/lang/Class;Lorg/codehaus/plexus/configuration/PlexusConfiguration;Lorg/codehaus/plexus/component/configurator/expression/ExpressionEvaluator;)V 43 <appendix> member <vmtarget> ; # org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator$$Lambda+0x000000008d1b0f30
+instanceKlass  @bci org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator doValidate (Lorg/apache/maven/execution/MavenSession;Lorg/apache/maven/plugin/descriptor/MojoDescriptor;Ljava/lang/Class;Lorg/codehaus/plexus/configuration/PlexusConfiguration;Lorg/codehaus/plexus/component/configurator/expression/ExpressionEvaluator;)V 29 <appendix> member <vmtarget> ; # org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator$$Lambda+0x000000008d1b0ce0
+instanceKlass  @bci org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator doValidate (Lorg/apache/maven/execution/MavenSession;Lorg/apache/maven/plugin/descriptor/MojoDescriptor;Ljava/lang/Class;Lorg/codehaus/plexus/configuration/PlexusConfiguration;Lorg/codehaus/plexus/component/configurator/expression/ExpressionEvaluator;)V 18 <appendix> member <vmtarget> ; # org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator$$Lambda+0x000000008d1b0a80
+instanceKlass org/apache/maven/monitor/logging/DefaultLog
+instanceKlass org/eclipse/sisu/inject/MildKeys
+instanceKlass java/time/Year
+instanceKlass java/time/LocalDate
+instanceKlass java/time/chrono/ChronoLocalDate
+instanceKlass java/time/zone/ZoneOffsetTransition
+instanceKlass java/time/LocalTime
+instanceKlass java/time/LocalDateTime
+instanceKlass java/time/chrono/ChronoLocalDateTime
+instanceKlass java/time/zone/ZoneOffsetTransitionRule
+instanceKlass java/time/zone/ZoneRules
+instanceKlass java/time/zone/Ser
+instanceKlass java/io/Externalizable
+instanceKlass java/time/zone/ZoneRulesProvider
+instanceKlass  @bci java/time/format/DateTimeFormatter <clinit> ()V 1075 <appendix> argL0 ; # java/time/format/DateTimeFormatter$$Lambda+0x80000001b
+instanceKlass  @bci java/time/format/DateTimeFormatter <clinit> ()V 1067 <appendix> argL0 ; # java/time/format/DateTimeFormatter$$Lambda+0x80000001a
+instanceKlass java/time/Period
+instanceKlass java/time/chrono/ChronoPeriod
+instanceKlass java/time/format/DateTimeFormatterBuilder$TextPrinterParser
+instanceKlass java/time/format/DateTimeTextProvider$1
+instanceKlass java/time/format/DateTimeTextProvider
+instanceKlass java/time/format/DateTimeTextProvider$LocaleStore
+instanceKlass java/time/format/DateTimeFormatterBuilder$InstantPrinterParser
+instanceKlass java/time/format/DateTimeFormatterBuilder$StringLiteralPrinterParser
+instanceKlass java/time/format/DateTimeFormatterBuilder$ZoneIdPrinterParser
+instanceKlass java/time/format/DateTimeFormatterBuilder$OffsetIdPrinterParser
+instanceKlass java/time/format/DecimalStyle
+instanceKlass java/time/format/DateTimeFormatterBuilder$CompositePrinterParser
+instanceKlass java/time/chrono/AbstractChronology
+instanceKlass java/time/chrono/Chronology
+instanceKlass java/time/format/DateTimeFormatterBuilder$CharLiteralPrinterParser
+instanceKlass java/time/format/DateTimeFormatterBuilder$NumberPrinterParser
+instanceKlass java/time/format/DateTimeFormatterBuilder$DateTimePrinterParser
+instanceKlass java/time/temporal/JulianFields
+instanceKlass java/time/temporal/IsoFields
+instanceKlass java/time/Instant
+instanceKlass java/time/temporal/TemporalAdjuster
+instanceKlass java/time/temporal/ValueRange
+instanceKlass java/time/temporal/TemporalField
+instanceKlass  @bci java/time/format/DateTimeFormatterBuilder <clinit> ()V 0 <appendix> argL0 ; # java/time/format/DateTimeFormatterBuilder$$Lambda+0x80000001c
+instanceKlass java/time/temporal/TemporalQuery
+instanceKlass java/time/format/DateTimeFormatterBuilder
+instanceKlass java/time/format/DateTimeFormatter
+instanceKlass org/codehaus/plexus/component/configurator/converters/ParameterizedConfigurationConverter
+instanceKlass org/codehaus/plexus/component/configurator/converters/AbstractConfigurationConverter
+instanceKlass org/codehaus/plexus/component/configurator/converters/ConfigurationConverter
+instanceKlass org/codehaus/plexus/component/configurator/converters/lookup/DefaultConverterLookup
+instanceKlass org/codehaus/plexus/component/configurator/expression/DefaultExpressionEvaluator
+instanceKlass org/apache/maven/plugins/enforcer/EnforceMojo$$FastClassByGuice$$251024514
+instanceKlass org/apache/maven/enforcer/rules/version/RequireMavenVersion$$FastClassByGuice$$249999874
+instanceKlass org/apache/maven/enforcer/rules/version/RequireJavaVersion$$FastClassByGuice$$248516282
+instanceKlass org/apache/maven/enforcer/rules/utils/ExpressionEvaluator$$FastClassByGuice$$247595775
+instanceKlass org/apache/maven/enforcer/rules/utils/EnforcerRuleUtils$$FastClassByGuice$$246751612
+instanceKlass org/apache/maven/enforcer/rules/property/RequireProperty$$FastClassByGuice$$245728212
+instanceKlass org/apache/maven/enforcer/rules/property/RequireEnvironmentVariable$$FastClassByGuice$$245157872
+instanceKlass org/apache/maven/enforcer/rules/files/RequireFilesSize$$FastClassByGuice$$243407134
+instanceKlass org/apache/maven/enforcer/rules/files/RequireFilesExist$$FastClassByGuice$$243240694
+instanceKlass org/apache/maven/enforcer/rules/files/RequireFilesDontExist$$FastClassByGuice$$241382944
+instanceKlass org/apache/maven/enforcer/rules/dependency/ResolverUtil$$FastClassByGuice$$241168824
+instanceKlass org/apache/maven/enforcer/rules/dependency/RequireUpperBoundDeps$$FastClassByGuice$$239170460
+instanceKlass org/apache/maven/enforcer/rules/dependency/RequireReleaseDeps$$FastClassByGuice$$238112764
+instanceKlass org/apache/maven/enforcer/rules/dependency/EnforceBytecodeVersion$$FastClassByGuice$$237306027
+instanceKlass org/apache/maven/enforcer/rules/dependency/DependencyConvergence$$FastClassByGuice$$236484238
+instanceKlass org/apache/maven/enforcer/rules/dependency/BannedDependencies$$FastClassByGuice$$234973916
+instanceKlass org/apache/maven/enforcer/rules/dependency/BanTransitiveDependencies$$FastClassByGuice$$234597973
+instanceKlass org/apache/maven/enforcer/rules/dependency/BanDynamicVersions$$FastClassByGuice$$233698624
+instanceKlass org/apache/maven/enforcer/rules/checksum/RequireTextFileChecksum$$FastClassByGuice$$231892751
+instanceKlass org/apache/maven/enforcer/rules/checksum/RequireFileChecksum$$FastClassByGuice$$231313461
+instanceKlass org/apache/maven/enforcer/rules/RequireSnapshotVersion$$FastClassByGuice$$230057351
+instanceKlass org/apache/maven/enforcer/rules/RequireSameVersions$$FastClassByGuice$$229580133
+instanceKlass org/apache/maven/enforcer/rules/RequireReleaseVersion$$FastClassByGuice$$227728394
+instanceKlass org/apache/maven/enforcer/rules/RequireProfileIdsExist$$FastClassByGuice$$226646048
+instanceKlass org/apache/maven/enforcer/rules/RequirePrerequisite$$FastClassByGuice$$225536225
+instanceKlass org/apache/maven/enforcer/rules/RequirePluginVersions$$FastClassByGuice$$225378818
+instanceKlass org/apache/maven/enforcer/rules/RequireOS$$FastClassByGuice$$223517997
+instanceKlass org/apache/maven/enforcer/rules/RequireNoRepositories$$FastClassByGuice$$223343155
+instanceKlass org/apache/maven/enforcer/rules/RequireMatchingCoordinates$$FastClassByGuice$$221561847
+instanceKlass org/apache/maven/enforcer/rules/RequireJavaVendor$$FastClassByGuice$$220938118
+instanceKlass org/apache/maven/enforcer/rules/RequireExplicitDependencyScope$$FastClassByGuice$$219241290
+instanceKlass org/apache/maven/enforcer/rules/RequireActiveProfile$$FastClassByGuice$$218283180
+instanceKlass org/apache/maven/enforcer/rules/ReactorModuleConvergence$$FastClassByGuice$$217225926
+instanceKlass org/apache/maven/enforcer/rules/ExternalRules$$FastClassByGuice$$216650798
+instanceKlass org/apache/maven/enforcer/rules/EvaluateBeanshell$$FastClassByGuice$$214979013
+instanceKlass org/apache/maven/enforcer/rules/BannedRepositories$$FastClassByGuice$$214846532
+instanceKlass org/apache/maven/enforcer/rules/BannedPlugins$$FastClassByGuice$$213032528
+instanceKlass org/apache/maven/enforcer/rules/BanDuplicatePomDependencyVersions$$FastClassByGuice$$212214792
+instanceKlass org/apache/maven/enforcer/rules/BanDistributionManagement$$FastClassByGuice$$211405534
+instanceKlass org/apache/maven/enforcer/rules/BanDependencyManagementScope$$FastClassByGuice$$210088454
+instanceKlass org/apache/maven/enforcer/rules/AlwaysPass$$FastClassByGuice$$209160222
+instanceKlass org/apache/maven/enforcer/rules/AlwaysFail$$FastClassByGuice$$208345551
+instanceKlass org/apache/maven/plugins/enforcer/internal/EnforcerRuleManager$$FastClassByGuice$$206668301
+instanceKlass org/apache/maven/plugins/enforcer/internal/EnforcerRuleCache$$FastClassByGuice$$206130005
+instanceKlass org/apache/maven/enforcer/rules/dependency/RequireUpperBoundDeps$RequireUpperBoundDepsVisitor
+instanceKlass org/apache/maven/enforcer/rules/dependency/EnforceBytecodeVersion$ChecksOptions
+instanceKlass org/apache/maven/enforcer/rules/dependency/DependencyVersionMap
+instanceKlass org/apache/maven/enforcer/rules/utils/ParentNodeProvider
+instanceKlass org/apache/maven/enforcer/rules/utils/ArtifactMatcher
+instanceKlass org/apache/maven/enforcer/rules/utils/PluginWrapper
+instanceKlass org/apache/maven/model/building/ModelProblemCollectorRequest
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d1a4000
+instanceKlass javax/xml/transform/Result
+instanceKlass javax/xml/transform/Source
+instanceKlass bsh/Interpreter
+instanceKlass bsh/ConsoleInterface
+instanceKlass org/apache/maven/enforcer/rule/api/EnforcerLogger
+instanceKlass org/apache/maven/enforcer/rule/api/EnforcerRule
+instanceKlass org/apache/maven/plugins/enforcer/internal/EnforcerRuleDesc
+instanceKlass org/apache/maven/enforcer/rule/api/EnforcerRuleHelper
+instanceKlass org/apache/maven/plugin/PluginParameterExpressionEvaluator
+instanceKlass org/codehaus/plexus/component/configurator/expression/TypeAwareExpressionEvaluator
+instanceKlass org/apache/maven/enforcer/rules/utils/EnforcerRuleUtils
+instanceKlass org/apache/maven/enforcer/rules/dependency/ResolverUtil
+instanceKlass org/apache/maven/enforcer/rule/api/AbstractEnforcerRuleBase
+instanceKlass org/apache/maven/enforcer/rule/api/EnforcerRuleBase
+instanceKlass org/apache/maven/plugins/enforcer/internal/EnforcerRuleManager
+instanceKlass org/apache/maven/plugins/enforcer/internal/EnforcerRuleCache
+instanceKlass  @bci org/apache/maven/plugin/DefaultPluginRealmCache get (Lorg/apache/maven/plugin/PluginRealmCache$Key;Lorg/apache/maven/plugin/PluginRealmCache$PluginRealmSupplier;)Lorg/apache/maven/plugin/PluginRealmCache$CacheRecord; 6 <appendix> member <vmtarget> ; # org/apache/maven/plugin/DefaultPluginRealmCache$$Lambda+0x000000008d196f38
+instanceKlass  @bci org/apache/maven/plugin/internal/DefaultMavenPluginManager setupPluginRealm (Lorg/apache/maven/plugin/descriptor/PluginDescriptor;Lorg/apache/maven/execution/MavenSession;Ljava/lang/ClassLoader;Ljava/util/List;Lorg/eclipse/aether/graph/DependencyFilter;)V 177 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d195400
+instanceKlass  @bci org/apache/maven/plugin/internal/DefaultMavenPluginManager setupPluginRealm (Lorg/apache/maven/plugin/descriptor/PluginDescriptor;Lorg/apache/maven/execution/MavenSession;Ljava/lang/ClassLoader;Ljava/util/List;Lorg/eclipse/aether/graph/DependencyFilter;)V 177 <appendix> member <vmtarget> ; # org/apache/maven/plugin/internal/DefaultMavenPluginManager$$Lambda+0x000000008d196d08
+instanceKlass org/apache/maven/plugin/DefaultPluginRealmCache$CacheKey
+instanceKlass org/apache/maven/lifecycle/internal/MojoExecutor$ProjectLock
+instanceKlass org/apache/maven/artifact/resolver/filter/AbstractScopeArtifactFilter
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d195000
+instanceKlass java/util/Collections$UnmodifiableList$1
+instanceKlass org/apache/maven/model/merge/ModelMerger$1
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d194c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d194800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d194400
+instanceKlass org/eclipse/aether/collection/DependencyManagement
+instanceKlass  @bci org/apache/maven/RepositoryUtils toDependency (Lorg/apache/maven/model/Dependency;Lorg/eclipse/aether/artifact/ArtifactTypeRegistry;)Lorg/eclipse/aether/graph/Dependency; 106 <appendix> argL0 ; # org/apache/maven/RepositoryUtils$$Lambda+0x000000008d196000
+instanceKlass  @bci org/apache/maven/RepositoryUtils toDependency (Lorg/apache/maven/artifact/Artifact;Ljava/util/Collection;)Lorg/eclipse/aether/graph/Dependency; 29 <appendix> argL0 ; # org/apache/maven/RepositoryUtils$$Lambda+0x000000008d193d70
+instanceKlass org/apache/maven/project/DefaultDependencyResolutionRequest
+instanceKlass org/apache/maven/lifecycle/internal/LifecycleDependencyResolver$ReactorDependencyFilter
+instanceKlass  @bci org/apache/maven/project/artifact/DefaultProjectArtifactsCache createKey (Lorg/apache/maven/project/MavenProject;Ljava/util/Collection;Ljava/util/Collection;ZLorg/eclipse/aether/RepositorySystemSession;)Lorg/apache/maven/project/artifact/ProjectArtifactsCache$Key; 26 <appendix> argL0 ; # org/apache/maven/project/artifact/DefaultProjectArtifactsCache$$Lambda+0x000000008d193468
+instanceKlass org/apache/maven/project/artifact/DefaultProjectArtifactsCache$CacheKey
+instanceKlass  @bci java/util/function/Predicate and (Ljava/util/function/Predicate;)Ljava/util/function/Predicate; 7 <appendix> member <vmtarget> ; # java/util/function/Predicate$$Lambda+0x000000008d03e300
+instanceKlass  @cpi java/util/function/Predicate 72 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d194000
+instanceKlass  @bci org/apache/maven/artifact/resolver/filter/ExclusionArtifactFilter <init> (Ljava/util/List;)V 14 <appendix> argL0 ; # org/apache/maven/artifact/resolver/filter/ExclusionArtifactFilter$$Lambda+0x000000008d192ff8
+instanceKlass  @bci org/apache/maven/artifact/resolver/filter/ExclusionArtifactFilter <init> (Ljava/util/List;)V 5 <appendix> argL0 ; # org/apache/maven/artifact/resolver/filter/ExclusionArtifactFilter$$Lambda+0x000000008d192da0
+instanceKlass org/apache/maven/artifact/resolver/filter/ExclusionArtifactFilter
+instanceKlass org/apache/maven/lifecycle/internal/MojoExecutor$1
+instanceKlass org/apache/maven/lifecycle/internal/ExecutionPlanItem
+instanceKlass  @bci org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator checkUnknownMojoConfigurationParameters (Lorg/apache/maven/plugin/MojoExecution;)V 200 <appendix> member <vmtarget> ; # org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator$$Lambda+0x000000008d1924c0
+instanceKlass  @bci org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator checkUnknownMojoConfigurationParameters (Lorg/apache/maven/plugin/MojoExecution;)V 188 <appendix> member <vmtarget> ; # org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator$$Lambda+0x000000008d192260
+instanceKlass  @bci org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator checkUnknownMojoConfigurationParameters (Lorg/apache/maven/plugin/MojoExecution;)V 147 <appendix> member <vmtarget> ; # org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator$$Lambda+0x000000008d192010
+instanceKlass  @bci org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator checkUnknownMojoConfigurationParameters (Lorg/apache/maven/plugin/MojoExecution;)V 136 <appendix> argL0 ; # org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator$$Lambda+0x000000008d191dc8
+instanceKlass  @bci org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator checkUnknownMojoConfigurationParameters (Lorg/apache/maven/plugin/MojoExecution;)V 126 <appendix> argL0 ; # org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator$$Lambda+0x000000008d191b70
+instanceKlass  @bci org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator checkUnknownMojoConfigurationParameters (Lorg/apache/maven/plugin/MojoExecution;)V 110 <appendix> argL0 ; # org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator$$Lambda+0x000000008d191948
+instanceKlass  @bci org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator checkUnknownMojoConfigurationParameters (Lorg/apache/maven/plugin/MojoExecution;)V 102 <appendix> argL0 ; # org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator$$Lambda+0x000000008d191700
+instanceKlass  @bci org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator getUnknownParameters (Lorg/apache/maven/plugin/MojoExecution;Ljava/util/Set;)Ljava/util/Set; 21 <appendix> member <vmtarget> ; # org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator$$Lambda+0x000000008d1914a0
+instanceKlass  @bci org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator getUnknownParameters (Lorg/apache/maven/plugin/MojoExecution;Ljava/util/Set;)Ljava/util/Set; 10 <appendix> argL0 ; # org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator$$Lambda+0x000000008d191258
+instanceKlass  @bci org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator checkUnknownMojoConfigurationParameters (Lorg/apache/maven/plugin/MojoExecution;)V 54 <appendix> member <vmtarget> ; # org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator$$Lambda+0x000000008d191008
+instanceKlass  @bci org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator checkUnknownMojoConfigurationParameters (Lorg/apache/maven/plugin/MojoExecution;)V 37 <appendix> argL0 ; # org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator$$Lambda+0x000000008d190de0
+instanceKlass org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator$$FastClassByGuice$$205359586
+instanceKlass  @bci org/apache/maven/plugin/internal/PlexusContainerDefaultDependenciesValidator doValidate (Lorg/eclipse/aether/RepositorySystemSession;Lorg/eclipse/aether/artifact/Artifact;Lorg/eclipse/aether/resolution/ArtifactDescriptorResult;)V 19 <appendix> argL0 ; # org/apache/maven/plugin/internal/PlexusContainerDefaultDependenciesValidator$$Lambda+0x000000008d190950
+instanceKlass  @bci org/apache/maven/plugin/internal/PlexusContainerDefaultDependenciesValidator doValidate (Lorg/eclipse/aether/RepositorySystemSession;Lorg/eclipse/aether/artifact/Artifact;Lorg/eclipse/aether/resolution/ArtifactDescriptorResult;)V 9 <appendix> argL0 ; # org/apache/maven/plugin/internal/PlexusContainerDefaultDependenciesValidator$$Lambda+0x000000008d1906f8
+instanceKlass  @bci org/apache/maven/plugin/internal/MavenScopeDependenciesValidator doValidate (Lorg/eclipse/aether/RepositorySystemSession;Lorg/eclipse/aether/artifact/Artifact;Lorg/eclipse/aether/resolution/ArtifactDescriptorResult;)V 59 <appendix> argL0 ; # org/apache/maven/plugin/internal/MavenScopeDependenciesValidator$$Lambda+0x000000008d1904b0
+instanceKlass  @bci org/apache/maven/plugin/internal/MavenScopeDependenciesValidator doValidate (Lorg/eclipse/aether/RepositorySystemSession;Lorg/eclipse/aether/artifact/Artifact;Lorg/eclipse/aether/resolution/ArtifactDescriptorResult;)V 49 <appendix> argL0 ; # org/apache/maven/plugin/internal/MavenScopeDependenciesValidator$$Lambda+0x000000008d190258
+instanceKlass  @bci org/apache/maven/plugin/internal/MavenScopeDependenciesValidator doValidate (Lorg/eclipse/aether/RepositorySystemSession;Lorg/eclipse/aether/artifact/Artifact;Lorg/eclipse/aether/resolution/ArtifactDescriptorResult;)V 39 <appendix> argL0 ; # org/apache/maven/plugin/internal/MavenScopeDependenciesValidator$$Lambda+0x000000008d190000
+instanceKlass  @bci org/apache/maven/plugin/internal/MavenScopeDependenciesValidator doValidate (Lorg/eclipse/aether/RepositorySystemSession;Lorg/eclipse/aether/artifact/Artifact;Lorg/eclipse/aether/resolution/ArtifactDescriptorResult;)V 29 <appendix> argL0 ; # org/apache/maven/plugin/internal/MavenScopeDependenciesValidator$$Lambda+0x000000008d18c400
+instanceKlass  @bci org/apache/maven/plugin/internal/MavenScopeDependenciesValidator doValidate (Lorg/eclipse/aether/RepositorySystemSession;Lorg/eclipse/aether/artifact/Artifact;Lorg/eclipse/aether/resolution/ArtifactDescriptorResult;)V 19 <appendix> argL0 ; # org/apache/maven/plugin/internal/MavenScopeDependenciesValidator$$Lambda+0x000000008d18cca0
+instanceKlass  @bci org/apache/maven/plugin/internal/MavenScopeDependenciesValidator doValidate (Lorg/eclipse/aether/RepositorySystemSession;Lorg/eclipse/aether/artifact/Artifact;Lorg/eclipse/aether/resolution/ArtifactDescriptorResult;)V 9 <appendix> argL0 ; # org/apache/maven/plugin/internal/MavenScopeDependenciesValidator$$Lambda+0x000000008d18ca48
+instanceKlass  @bci org/apache/maven/plugin/internal/MavenMixedDependenciesValidator doValidate (Lorg/eclipse/aether/RepositorySystemSession;Lorg/eclipse/aether/artifact/Artifact;Lorg/eclipse/aether/resolution/ArtifactDescriptorResult;)V 39 <appendix> argL0 ; # org/apache/maven/plugin/internal/MavenMixedDependenciesValidator$$Lambda+0x000000008d18c800
+instanceKlass  @bci org/apache/maven/plugin/internal/MavenMixedDependenciesValidator doValidate (Lorg/eclipse/aether/RepositorySystemSession;Lorg/eclipse/aether/artifact/Artifact;Lorg/eclipse/aether/resolution/ArtifactDescriptorResult;)V 29 <appendix> argL0 ; # org/apache/maven/plugin/internal/MavenMixedDependenciesValidator$$Lambda+0x000000008d18db98
+instanceKlass  @bci org/apache/maven/plugin/internal/MavenMixedDependenciesValidator doValidate (Lorg/eclipse/aether/RepositorySystemSession;Lorg/eclipse/aether/artifact/Artifact;Lorg/eclipse/aether/resolution/ArtifactDescriptorResult;)V 19 <appendix> argL0 ; # org/apache/maven/plugin/internal/MavenMixedDependenciesValidator$$Lambda+0x000000008d18d940
+instanceKlass  @bci org/apache/maven/plugin/internal/MavenMixedDependenciesValidator doValidate (Lorg/eclipse/aether/RepositorySystemSession;Lorg/eclipse/aether/artifact/Artifact;Lorg/eclipse/aether/resolution/ArtifactDescriptorResult;)V 9 <appendix> argL0 ; # org/apache/maven/plugin/internal/MavenMixedDependenciesValidator$$Lambda+0x000000008d18d6f8
+instanceKlass  @bci java/util/stream/Collectors toSet ()Ljava/util/stream/Collector; 14 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x800000040
+instanceKlass  @bci java/util/stream/Collectors toSet ()Ljava/util/stream/Collector; 9 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x800000038
+instanceKlass  @bci java/util/stream/Collectors toSet ()Ljava/util/stream/Collector; 4 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x800000045
+instanceKlass  @bci org/apache/maven/plugin/internal/Maven2DependenciesValidator doValidate (Lorg/eclipse/aether/RepositorySystemSession;Lorg/eclipse/aether/artifact/Artifact;Lorg/eclipse/aether/resolution/ArtifactDescriptorResult;)V 49 <appendix> argL0 ; # org/apache/maven/plugin/internal/Maven2DependenciesValidator$$Lambda+0x000000008d18d4a0
+instanceKlass  @bci org/apache/maven/plugin/internal/Maven2DependenciesValidator doValidate (Lorg/eclipse/aether/RepositorySystemSession;Lorg/eclipse/aether/artifact/Artifact;Lorg/eclipse/aether/resolution/ArtifactDescriptorResult;)V 39 <appendix> argL0 ; # org/apache/maven/plugin/internal/Maven2DependenciesValidator$$Lambda+0x000000008d18d258
+instanceKlass  @bci org/apache/maven/plugin/internal/Maven2DependenciesValidator doValidate (Lorg/eclipse/aether/RepositorySystemSession;Lorg/eclipse/aether/artifact/Artifact;Lorg/eclipse/aether/resolution/ArtifactDescriptorResult;)V 29 <appendix> argL0 ; # org/apache/maven/plugin/internal/Maven2DependenciesValidator$$Lambda+0x000000008d18d000
+instanceKlass  @bci org/apache/maven/plugin/internal/Maven2DependenciesValidator doValidate (Lorg/eclipse/aether/RepositorySystemSession;Lorg/eclipse/aether/artifact/Artifact;Lorg/eclipse/aether/resolution/ArtifactDescriptorResult;)V 19 <appendix> argL0 ; # org/apache/maven/plugin/internal/Maven2DependenciesValidator$$Lambda+0x000000008d18fd58
+instanceKlass  @bci org/apache/maven/plugin/internal/Maven2DependenciesValidator doValidate (Lorg/eclipse/aether/RepositorySystemSession;Lorg/eclipse/aether/artifact/Artifact;Lorg/eclipse/aether/resolution/ArtifactDescriptorResult;)V 9 <appendix> argL0 ; # org/apache/maven/plugin/internal/Maven2DependenciesValidator$$Lambda+0x000000008d18fb10
+instanceKlass org/apache/maven/artifact/handler/DefaultArtifactHandler$__sisu12$$FastClassByGuice$$203732212
+instanceKlass org/apache/maven/model/Notifier
+instanceKlass  @bci org/apache/maven/plugin/internal/DefaultMavenPluginManager getPluginDescriptor (Lorg/apache/maven/model/Plugin;Ljava/util/List;Lorg/eclipse/aether/RepositorySystemSession;)Lorg/apache/maven/plugin/descriptor/PluginDescriptor; 24 <appendix> member <vmtarget> ; # org/apache/maven/plugin/internal/DefaultMavenPluginManager$$Lambda+0x000000008d18f610
+instanceKlass  @bci org/apache/maven/plugin/DefaultPluginDescriptorCache createKey (Lorg/apache/maven/model/Plugin;Ljava/util/List;Lorg/eclipse/aether/RepositorySystemSession;)Lorg/apache/maven/plugin/PluginDescriptorCache$Key; 14 <appendix> argL0 ; # org/apache/maven/plugin/DefaultPluginDescriptorCache$$Lambda+0x000000008d18f3c8
+instanceKlass org/apache/maven/plugin/DefaultPluginDescriptorCache$CacheKey
+instanceKlass org/apache/maven/lifecycle/internal/GoalTask
+instanceKlass org/apache/maven/execution/ProjectExecutionEvent
+instanceKlass org/apache/maven/lifecycle/internal/CompoundProjectExecutionListener
+instanceKlass org/apache/maven/lifecycle/internal/DefaultLifecycleMappingDelegate$$FastClassByGuice$$202553546
+instanceKlass org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculator$$FastClassByGuice$$202093038
+instanceKlass org/apache/maven/project/artifact/DefaultProjectArtifactsCache$$FastClassByGuice$$200945728
+instanceKlass org/apache/maven/lifecycle/internal/builder/singlethreaded/SingleThreadedBuilder$$FastClassByGuice$$199417160
+instanceKlass org/apache/maven/graph/DefaultProjectDependencyGraph$MavenProjectComparator
+instanceKlass org/apache/maven/graph/FilteredProjectDependencyGraph$Key
+instanceKlass org/apache/maven/lifecycle/internal/LifecycleTask
+instanceKlass  @bci org/apache/maven/plugin/internal/DefaultPluginValidationManager validationPluginExcludes (Lorg/eclipse/aether/RepositorySystemSession;)Ljava/util/List; 11 <appendix> member <vmtarget> ; # org/apache/maven/plugin/internal/DefaultPluginValidationManager$$Lambda+0x000000008d1873e8
+instanceKlass  @bci org/apache/maven/plugin/internal/DefaultPluginValidationManager validationReportLevel (Lorg/eclipse/aether/RepositorySystemSession;)Lorg/apache/maven/plugin/internal/DefaultPluginValidationManager$ValidationReportLevel; 10 <appendix> member <vmtarget> ; # org/apache/maven/plugin/internal/DefaultPluginValidationManager$$Lambda+0x000000008d1871b8
+instanceKlass  @bci org/sonatype/central/publisher/plugin/DeployLifecycleParticipant setUpCentralPublishingExecution (Lorg/apache/maven/model/Plugin;)V 50 <appendix> member <vmtarget> ; # org/sonatype/central/publisher/plugin/DeployLifecycleParticipant$$Lambda+0x000000008d183658
+instanceKlass  @bci org/sonatype/central/publisher/plugin/DeployLifecycleParticipant getCentralPublishingPluginExecutions (Ljava/util/List;)J 58 <appendix> argL0 ; # org/sonatype/central/publisher/plugin/DeployLifecycleParticipant$$Lambda+0x000000008d183400
+instanceKlass  @bci org/sonatype/central/publisher/plugin/DeployLifecycleParticipant getCentralPublishingPluginExecutions (Ljava/util/List;)J 48 <appendix> argL0 ; # org/sonatype/central/publisher/plugin/DeployLifecycleParticipant$$Lambda+0x000000008d1831b8
+instanceKlass  @bci org/sonatype/central/publisher/plugin/DeployLifecycleParticipant getCentralPublishingPluginExecutions (Ljava/util/List;)J 38 <appendix> argL0 ; # org/sonatype/central/publisher/plugin/DeployLifecycleParticipant$$Lambda+0x000000008d182f70
+instanceKlass  @bci org/sonatype/central/publisher/plugin/DeployLifecycleParticipant getCentralPublishingPluginExecutions (Ljava/util/List;)J 28 <appendix> argL0 ; # org/sonatype/central/publisher/plugin/DeployLifecycleParticipant$$Lambda+0x000000008d182d28
+instanceKlass  @bci org/sonatype/central/publisher/plugin/DeployLifecycleParticipant getCentralPublishingPluginExecutions (Ljava/util/List;)J 18 <appendix> member <vmtarget> ; # org/sonatype/central/publisher/plugin/DeployLifecycleParticipant$$Lambda+0x000000008d182ac8
+instanceKlass  @bci org/sonatype/central/publisher/plugin/DeployLifecycleParticipant getCentralPublishingPluginExecutions (Ljava/util/List;)J 7 <appendix> member <vmtarget> ; # org/sonatype/central/publisher/plugin/DeployLifecycleParticipant$$Lambda+0x000000008d182878
+instanceKlass org/sonatype/central/publisher/plugin/DeployLifecycleParticipant$$FastClassByGuice$$198741012
+instanceKlass org/apache/maven/internal/aether/MavenChainedWorkspaceReader
+instanceKlass  @bci java/util/stream/Collectors lambda$groupingBy$0 (Ljava/util/function/Function;Ljava/util/function/Supplier;Ljava/util/function/BiConsumer;Ljava/util/Map;Ljava/lang/Object;)V 20 <appendix> member <vmtarget> ; # java/util/stream/Collectors$$Lambda+0x000000008d03dae8
+instanceKlass  @bci java/util/stream/Collectors groupingBy (Ljava/util/function/Function;Ljava/util/function/Supplier;Ljava/util/stream/Collector;)Ljava/util/stream/Collector; 19 <appendix> member <vmtarget> ; # java/util/stream/Collectors$$Lambda+0x000000008d03d8a8
+instanceKlass  @bci java/util/stream/Collectors groupingBy (Ljava/util/function/Function;Ljava/util/stream/Collector;)Ljava/util/stream/Collector; 1 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x000000008d03d680
+instanceKlass  @bci org/apache/maven/ReactorReader <init> (Lorg/apache/maven/execution/MavenSession;)V 14 <appendix> argL0 ; # org/apache/maven/ReactorReader$$Lambda+0x000000008d186b18
+instanceKlass  @bci org/apache/maven/ReactorReader <init> (Lorg/apache/maven/execution/MavenSession;)V 5 <appendix> argL0 ; # org/apache/maven/ReactorReader$$Lambda+0x000000008d1868d0
+instanceKlass  @bci org/apache/maven/session/scope/internal/SessionScope$ScopeState scope (Lcom/google/inject/Key;Lcom/google/inject/Provider;)Lcom/google/inject/Provider; 6 <appendix> member <vmtarget> ; # org/apache/maven/session/scope/internal/SessionScope$ScopeState$$Lambda+0x000000008d186680
+instanceKlass  @bci org/apache/maven/execution/MavenSession setProjects (Ljava/util/List;)V 40 <appendix> argL0 ; # org/apache/maven/execution/MavenSession$$Lambda+0x000000008d186428
+instanceKlass  @bci org/apache/maven/execution/MavenSession setProjects (Ljava/util/List;)V 22 <appendix> member <vmtarget> ; # org/apache/maven/execution/MavenSession$$Lambda+0x000000008d1861f8
+instanceKlass  @bci org/apache/maven/graph/FilteredProjectDependencyGraph <init> (Lorg/apache/maven/execution/ProjectDependencyGraph;Ljava/util/Collection;)V 103 <appendix> member <vmtarget> ; # org/apache/maven/graph/FilteredProjectDependencyGraph$$Lambda+0x000000008d185f98
+instanceKlass org/apache/maven/graph/FilteredProjectDependencyGraph
+instanceKlass org/codehaus/plexus/util/dag/TopologicalSorter
+instanceKlass org/codehaus/plexus/util/dag/CycleDetector
+instanceKlass org/codehaus/plexus/util/dag/Vertex
+instanceKlass org/codehaus/plexus/util/dag/DAG
+instanceKlass org/apache/maven/project/ProjectSorter
+instanceKlass org/apache/maven/graph/DefaultProjectDependencyGraph
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d18c000
+instanceKlass org/apache/maven/project/DefaultProjectBuildingResult
+instanceKlass org/apache/maven/lifecycle/mapping/DefaultLifecycleMapping$__sisu1$$FastClassByGuice$$197319770
+instanceKlass org/apache/maven/lifecycle/Lifecycle$__sisu7$$FastClassByGuice$$197019863
+instanceKlass org/apache/maven/lifecycle/Lifecycle$__sisu8$$FastClassByGuice$$195887370
+instanceKlass org/apache/maven/lifecycle/mapping/LifecycleMojo
+instanceKlass org/apache/maven/lifecycle/mapping/DefaultLifecycleMapping$$FastClassByGuice$$194079889
+instanceKlass org/apache/maven/lifecycle/mapping/Lifecycle
+instanceKlass org/apache/maven/project/DefaultProjectRealmCache$CacheKey
+instanceKlass com/google/inject/internal/Messages$Converter
+instanceKlass com/google/inject/internal/Messages
+instanceKlass org/apache/maven/artifact/repository/metadata/AbstractRepositoryMetadata
+instanceKlass org/sonatype/central/publisher/plugin/model/DeferArtifactRequest
+instanceKlass org/sonatype/central/publisher/plugin/utils/HashAlgorithm
+instanceKlass org/sonatype/central/publisher/plugin/model/StageArtifactRequest
+instanceKlass org/sonatype/central/publisher/plugin/model/BundleArtifactRequest
+instanceKlass org/sonatype/central/publisher/client/model/DeploymentApiResponse
+instanceKlass org/sonatype/central/publisher/plugin/model/WaitForDeploymentStateRequest
+instanceKlass java/time/temporal/Temporal
+instanceKlass java/time/temporal/TemporalAccessor
+instanceKlass org/sonatype/central/publisher/plugin/model/UploadArtifactRequest
+instanceKlass org/sonatype/central/publisher/plugin/config/PlexusContextConfigImpl
+instanceKlass org/sonatype/central/publisher/plugin/utils/AuthData
+instanceKlass org/sonatype/central/publisher/plugin/model/ArtifactWithFile
+instanceKlass org/sonatype/central/publisher/client/PublisherClient
+instanceKlass org/w3c/dom/Element
+instanceKlass org/w3c/dom/Document
+instanceKlass org/w3c/dom/Node
+instanceKlass sun/security/util/SecurityProperties
+instanceKlass jdk/internal/util/Exceptions
+instanceKlass jdk/internal/util/Exceptions$SensitiveInfo
+instanceKlass org/sonatype/central/publisher/plugin/watcher/DeploymentPublishedWatcher
+instanceKlass org/sonatype/central/publisher/plugin/utils/PurlUtils
+instanceKlass org/sonatype/central/publisher/plugin/utils/ProjectUtils
+instanceKlass org/sonatype/central/publisher/plugin/utils/MojoUtils
+instanceKlass org/sonatype/central/publisher/plugin/utils/HashUtils
+instanceKlass org/sonatype/central/publisher/plugin/uploader/ArtifactUploader
+instanceKlass org/sonatype/central/publisher/plugin/stager/ArtifactStager
+instanceKlass org/sonatype/central/publisher/plugin/published/ComponentPublishedChecker
+instanceKlass org/sonatype/central/publisher/plugin/deffer/ArtifactDeferrer
+instanceKlass org/sonatype/central/publisher/plugin/config/PlexusContextConfig
+instanceKlass org/sonatype/central/publisher/plugin/bundler/ArtifactBundler
+instanceKlass java/util/jar/JarVerifier
+instanceKlass org/eclipse/sisu/space/FileEntryIterator
+instanceKlass org/eclipse/sisu/space/ResourceEnumeration
+instanceKlass org/eclipse/sisu/plexus/ComponentDescriptorBeanModule$PlexusDescriptorBeanSource
+instanceKlass org/eclipse/sisu/plexus/ComponentDescriptorBeanModule$ComponentMetadata
+instanceKlass org/apache/maven/plugin/AbstractMojo
+instanceKlass org/apache/maven/plugin/ContextEnabled
+instanceKlass org/apache/maven/plugin/Mojo
+instanceKlass org/eclipse/sisu/plexus/ComponentDescriptorBeanModule
+instanceKlass org/apache/maven/plugin/MavenPluginValidator
+instanceKlass java/io/RandomAccessFile$1
+instanceKlass org/codehaus/plexus/component/repository/ComponentDependency
+instanceKlass org/codehaus/plexus/component/repository/ComponentRequirement
+instanceKlass org/codehaus/plexus/configuration/DefaultPlexusConfiguration
+instanceKlass org/apache/maven/classrealm/ArtifactClassRealmConstituent
+instanceKlass  @bci org/apache/maven/RepositoryUtils toArtifacts (Ljava/util/Collection;)Ljava/util/Collection; 6 <appendix> argL0 ; # org/apache/maven/RepositoryUtils$$Lambda+0x000000008d179328
+instanceKlass org/apache/maven/plugin/DefaultExtensionRealmCache$CacheKey
+instanceKlass org/eclipse/aether/util/graph/visitor/TreeDependencyVisitor
+instanceKlass org/eclipse/aether/util/graph/visitor/FilteringDependencyVisitor
+instanceKlass org/eclipse/aether/internal/impl/ArtifactRequestBuilder
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictResolver$NodeInfo
+instanceKlass org/eclipse/aether/util/artifact/ArtifactIdUtils
+instanceKlass org/eclipse/aether/util/graph/transformer/NearestVersionSelector$ConflictGroup
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictResolver$ConflictItem
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictResolver$ScopeContext
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictResolver$ConflictContext
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictResolver$State
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictIdSorter$RootQueue
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictIdSorter$ConflictId
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictMarker$ConflictGroup
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictMarker$Key
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictMarker
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictIdSorter
+instanceKlass org/eclipse/aether/util/graph/transformer/TransformationContextKeys
+instanceKlass org/eclipse/aether/internal/impl/collect/DefaultDependencyGraphTransformationContext
+instanceKlass org/eclipse/aether/util/graph/selector/ExclusionDependencySelector$ExclusionComparator
+instanceKlass org/eclipse/aether/internal/impl/collect/DataPool$GraphKey
+instanceKlass org/eclipse/aether/internal/impl/collect/DefaultDependencyCycle
+instanceKlass org/eclipse/aether/internal/impl/collect/DataPool$Descriptor
+instanceKlass  @bci org/eclipse/aether/internal/impl/collect/DataPool$HardInternPool intern (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object; 6 <appendix> member <vmtarget> ; # org/eclipse/aether/internal/impl/collect/DataPool$HardInternPool$$Lambda+0x000000008d175230
+instanceKlass org/apache/maven/model/Site
+instanceKlass org/eclipse/aether/internal/impl/collect/DataPool$DescriptorKey
+instanceKlass org/eclipse/aether/internal/impl/collect/DataPool$Constraint$VersionRepo
+instanceKlass org/eclipse/aether/internal/impl/collect/DataPool$Constraint
+instanceKlass org/eclipse/aether/internal/impl/collect/DataPool$ConstraintKey
+instanceKlass org/eclipse/aether/internal/impl/collect/CollectStepDataImpl
+instanceKlass org/eclipse/aether/collection/CollectStepData
+instanceKlass org/eclipse/aether/graph/Dependency$Exclusions$1
+instanceKlass  @bci org/eclipse/aether/util/graph/manager/ClassicDependencyManager deriveChildManager (Lorg/eclipse/aether/collection/DependencyCollectionContext;)Lorg/eclipse/aether/collection/DependencyManager; 420 <appendix> argL0 ; # org/eclipse/aether/util/graph/manager/ClassicDependencyManager$$Lambda+0x000000008d173e30
+instanceKlass org/eclipse/aether/util/graph/manager/ClassicDependencyManager$Key
+instanceKlass org/eclipse/aether/internal/impl/collect/df/NodeStack
+instanceKlass org/eclipse/aether/graph/DependencyCycle
+instanceKlass org/eclipse/aether/internal/impl/collect/DataPool$HardInternPool
+instanceKlass org/eclipse/aether/internal/impl/collect/DataPool$WeakInternPool
+instanceKlass org/eclipse/aether/internal/impl/collect/DataPool$InternPool
+instanceKlass org/apache/maven/model/merge/ModelMerger$NotifierKeyComputer
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder lambda$getInterpolatedProfiles$4 (Lorg/apache/maven/model/Activation;Lorg/codehaus/plexus/interpolation/RegexBasedInterpolator;Lorg/apache/maven/model/building/DefaultModelProblemCollector;Ljava/lang/String;)V 32 <appendix> member <vmtarget> ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d1730f0
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder lambda$getInterpolatedProfiles$4 (Lorg/apache/maven/model/Activation;Lorg/codehaus/plexus/interpolation/RegexBasedInterpolator;Lorg/apache/maven/model/building/DefaultModelProblemCollector;Ljava/lang/String;)V 12 <appendix> member <vmtarget> ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d172ec0
+instanceKlass java/util/Formatter$Flags
+instanceKlass java/util/Formattable
+instanceKlass java/util/Formatter$FormatSpecifier
+instanceKlass java/util/Formatter$Conversion
+instanceKlass java/util/Formatter$FormatString
+instanceKlass java/util/Formatter
+instanceKlass org/apache/maven/model/io/xpp3/MavenXpp3Reader$1
+instanceKlass org/apache/maven/model/io/xpp3/MavenXpp3Reader$ContentTransformer
+instanceKlass org/apache/maven/model/io/xpp3/MavenXpp3Reader
+instanceKlass org/apache/maven/repository/internal/DefaultModelResolver
+instanceKlass  @bci org/eclipse/aether/named/support/NamedLockFactorySupport closeLock (Ljava/lang/String;)V 6 <appendix> member <vmtarget> ; # org/eclipse/aether/named/support/NamedLockFactorySupport$$Lambda+0x000000008d172578
+instanceKlass java/util/AbstractMap$ValueIterator
+instanceKlass sun/nio/ch/FileKey
+instanceKlass sun/nio/ch/FileLockTable
+instanceKlass sun/nio/fs/WindowsFileSystemProvider$1
+instanceKlass org/eclipse/aether/repository/LocalArtifactRequest
+instanceKlass org/eclipse/aether/internal/impl/DefaultRepositoryEventDispatcher$1
+instanceKlass org/eclipse/aether/RepositoryEvent$Builder
+instanceKlass org/eclipse/aether/internal/impl/filter/RemoteRepositoryFilterSourceSupport$SimpleResult
+instanceKlass  @bci org/eclipse/aether/internal/impl/filter/DefaultRemoteRepositoryFilterManager getRemoteRepositoryFilter (Lorg/eclipse/aether/RepositorySystemSession;)Lorg/eclipse/aether/spi/connector/filter/RemoteRepositoryFilter; 11 <appendix> member <vmtarget> ; # org/eclipse/aether/internal/impl/filter/DefaultRemoteRepositoryFilterManager$$Lambda+0x000000008d171670
+instanceKlass  @bci org/eclipse/aether/named/support/ReadWriteLockNamedLock <init> (Ljava/lang/String;Lorg/eclipse/aether/named/support/NamedLockFactorySupport;Ljava/util/concurrent/locks/ReadWriteLock;)V 7 <appendix> argL0 ; # org/eclipse/aether/named/support/ReadWriteLockNamedLock$$Lambda+0x000000008d170ff8
+instanceKlass org/eclipse/aether/named/support/Retry$DoNotRetry
+instanceKlass  @bci org/eclipse/aether/named/support/NamedLockFactorySupport getLock (Ljava/lang/String;)Lorg/eclipse/aether/named/support/NamedLockSupport; 6 <appendix> member <vmtarget> ; # org/eclipse/aether/named/support/NamedLockFactorySupport$$Lambda+0x000000008d170b50
+instanceKlass java/time/temporal/TemporalUnit
+instanceKlass java/time/Duration
+instanceKlass java/time/temporal/TemporalAmount
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapter$AdaptedLockSyncContext
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/GAVNameMapper
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/NameMappers
+instanceKlass  @bci org/eclipse/aether/DefaultSessionData computeIfAbsent (Ljava/lang/Object;Ljava/util/function/Supplier;)Ljava/lang/Object; 6 <appendix> member <vmtarget> ; # org/eclipse/aether/DefaultSessionData$$Lambda+0x000000008d170230
+instanceKlass  @bci org/eclipse/aether/internal/impl/synccontext/DefaultSyncContextFactory newInstance (Lorg/eclipse/aether/RepositorySystemSession;Z)Lorg/eclipse/aether/SyncContext; 18 <appendix> member <vmtarget> ; # org/eclipse/aether/internal/impl/synccontext/DefaultSyncContextFactory$$Lambda+0x000000008d170000
+instanceKlass org/apache/maven/repository/internal/DefaultVersionResolver$Key
+instanceKlass org/eclipse/aether/util/version/GenericVersion$Item
+instanceKlass org/eclipse/aether/util/version/GenericVersion$Tokenizer
+instanceKlass org/eclipse/aether/util/version/GenericVersion
+instanceKlass org/eclipse/aether/util/version/GenericVersionConstraint
+instanceKlass org/eclipse/aether/version/VersionRange
+instanceKlass org/eclipse/aether/version/VersionConstraint
+instanceKlass org/eclipse/aether/util/version/GenericVersionScheme
+instanceKlass org/eclipse/aether/internal/impl/collect/CachingArtifactTypeRegistry
+instanceKlass org/eclipse/sisu/wire/NamedIterableAdapter$NamedEntry
+instanceKlass org/eclipse/sisu/wire/NamedIterableAdapter$NamedIterator
+instanceKlass org/apache/maven/plugin/internal/WagonExcluder
+instanceKlass org/eclipse/aether/util/filter/AndDependencyFilter
+instanceKlass org/eclipse/aether/util/filter/ScopeDependencyFilter
+instanceKlass org/eclipse/aether/artifact/AbstractArtifact
+instanceKlass org/apache/maven/plugin/CacheUtils
+instanceKlass org/apache/maven/plugin/DefaultPluginArtifactsCache$CacheKey
+instanceKlass org/apache/maven/model/building/DefaultModelBuildingEvent
+instanceKlass org/apache/maven/model/building/ModelBuildingEventCatapult$1
+instanceKlass org/apache/maven/project/ReactorModelPool$CacheKey
+instanceKlass  @bci org/apache/maven/utils/Os getOsFamily ()Ljava/lang/String; 74 <appendix> argL0 ; # org/apache/maven/utils/Os$$Lambda+0x000000008d16f620
+instanceKlass org/apache/maven/utils/Os
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder lambda$getInterpolatedProfiles$2 (Lorg/codehaus/plexus/interpolation/RegexBasedInterpolator;Lorg/apache/maven/model/building/DefaultModelProblemCollector;Lorg/apache/maven/model/ActivationOS;)V 107 <appendix> member <vmtarget> ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d16f1d0
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder lambda$getInterpolatedProfiles$2 (Lorg/codehaus/plexus/interpolation/RegexBasedInterpolator;Lorg/apache/maven/model/building/DefaultModelProblemCollector;Lorg/apache/maven/model/ActivationOS;)V 84 <appendix> member <vmtarget> ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d16ef90
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder lambda$getInterpolatedProfiles$2 (Lorg/codehaus/plexus/interpolation/RegexBasedInterpolator;Lorg/apache/maven/model/building/DefaultModelProblemCollector;Lorg/apache/maven/model/ActivationOS;)V 61 <appendix> member <vmtarget> ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d16ed50
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder lambda$getInterpolatedProfiles$2 (Lorg/codehaus/plexus/interpolation/RegexBasedInterpolator;Lorg/apache/maven/model/building/DefaultModelProblemCollector;Lorg/apache/maven/model/ActivationOS;)V 38 <appendix> member <vmtarget> ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d16eb10
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder lambda$getInterpolatedProfiles$2 (Lorg/codehaus/plexus/interpolation/RegexBasedInterpolator;Lorg/apache/maven/model/building/DefaultModelProblemCollector;Lorg/apache/maven/model/ActivationOS;)V 12 <appendix> member <vmtarget> ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d16e8e0
+instanceKlass org/apache/maven/artifact/handler/DefaultArtifactHandler$__sisu9$$FastClassByGuice$$193665277
+instanceKlass java/util/stream/Streams$RangeIntSpliterator
+instanceKlass org/apache/maven/repository/internal/DefaultModelCache$Key
+instanceKlass org/apache/maven/model/building/ModelCacheTag$2
+instanceKlass org/apache/maven/model/building/ModelCacheTag$1
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder lambda$getInterpolatedProfiles$1 (Lorg/apache/maven/model/profile/DefaultProfileActivationContext;Lorg/apache/maven/model/building/DefaultModelProblemCollector;Lorg/apache/maven/model/ActivationFile;)V 57 <appendix> member <vmtarget> ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d16dfa8
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder lambda$getInterpolatedProfiles$1 (Lorg/apache/maven/model/profile/DefaultProfileActivationContext;Lorg/apache/maven/model/building/DefaultModelProblemCollector;Lorg/apache/maven/model/ActivationFile;)V 34 <appendix> member <vmtarget> ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d16daf0
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder lambda$getInterpolatedProfiles$1 (Lorg/apache/maven/model/profile/DefaultProfileActivationContext;Lorg/apache/maven/model/building/DefaultModelProblemCollector;Lorg/apache/maven/model/ActivationFile;)V 8 <appendix> member <vmtarget> ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d16d8c0
+instanceKlass  @bci org/apache/maven/model/validation/DefaultModelValidator validate30RawProfileActivation (Lorg/apache/maven/model/building/ModelProblemCollector;Lorg/apache/maven/model/Activation;Ljava/lang/String;)V 156 <appendix> member <vmtarget> ; # org/apache/maven/model/validation/DefaultModelValidator$$Lambda+0x000000008d16d680
+instanceKlass  @bci org/apache/maven/model/validation/DefaultModelValidator validate30RawProfileActivation (Lorg/apache/maven/model/building/ModelProblemCollector;Lorg/apache/maven/model/Activation;Ljava/lang/String;)V 143 <appendix> argL0 ; # org/apache/maven/model/validation/DefaultModelValidator$$Lambda+0x000000008d16d438
+instanceKlass  @bci org/apache/maven/model/validation/DefaultModelValidator validate30RawProfileActivation (Lorg/apache/maven/model/building/ModelProblemCollector;Lorg/apache/maven/model/Activation;Ljava/lang/String;)V 133 <appendix> member <vmtarget> ; # org/apache/maven/model/validation/DefaultModelValidator$$Lambda+0x000000008d16d1f8
+instanceKlass  @bci org/apache/maven/model/validation/DefaultModelValidator validate30RawProfileActivation (Lorg/apache/maven/model/building/ModelProblemCollector;Lorg/apache/maven/model/Activation;Ljava/lang/String;)V 120 <appendix> argL0 ; # org/apache/maven/model/validation/DefaultModelValidator$$Lambda+0x000000008d16cfb0
+instanceKlass  @bci org/apache/maven/model/validation/DefaultModelValidator validate30RawProfileActivation (Lorg/apache/maven/model/building/ModelProblemCollector;Lorg/apache/maven/model/Activation;Ljava/lang/String;)V 110 <appendix> member <vmtarget> ; # org/apache/maven/model/validation/DefaultModelValidator$$Lambda+0x000000008d16cd70
+instanceKlass  @bci org/apache/maven/model/validation/DefaultModelValidator validate30RawProfileActivation (Lorg/apache/maven/model/building/ModelProblemCollector;Lorg/apache/maven/model/Activation;Ljava/lang/String;)V 97 <appendix> argL0 ; # org/apache/maven/model/validation/DefaultModelValidator$$Lambda+0x000000008d16cb28
+instanceKlass  @bci org/apache/maven/model/validation/DefaultModelValidator validate30RawProfileActivation (Lorg/apache/maven/model/building/ModelProblemCollector;Lorg/apache/maven/model/Activation;Ljava/lang/String;)V 87 <appendix> member <vmtarget> ; # org/apache/maven/model/validation/DefaultModelValidator$$Lambda+0x000000008d16c8e8
+instanceKlass  @bci org/apache/maven/model/validation/DefaultModelValidator validate30RawProfileActivation (Lorg/apache/maven/model/building/ModelProblemCollector;Lorg/apache/maven/model/Activation;Ljava/lang/String;)V 74 <appendix> argL0 ; # org/apache/maven/model/validation/DefaultModelValidator$$Lambda+0x000000008d16c6a0
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$BinaryOperatorHelper addBinaryOperator (Lcom/sun/tools/javac/comp/Operators$OperatorType;Lcom/sun/tools/javac/comp/Operators$OperatorType;Lcom/sun/tools/javac/comp/Operators$OperatorType;[I)Lcom/sun/tools/javac/comp/Operators$BinaryOperatorHelper; 11 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d169400
+instanceKlass  @bci org/apache/maven/model/validation/DefaultModelValidator validate30RawProfileActivation (Lorg/apache/maven/model/building/ModelProblemCollector;Lorg/apache/maven/model/Activation;Ljava/lang/String;)V 39 <appendix> member <vmtarget> ; # org/apache/maven/model/validation/DefaultModelValidator$$Lambda+0x000000008d16c460
+instanceKlass  @cpi org/apache/maven/model/validation/DefaultModelValidator 1292 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d169000
+instanceKlass  @bci org/apache/maven/model/validation/DefaultModelValidator validate30RawProfileActivation (Lorg/apache/maven/model/building/ModelProblemCollector;Lorg/apache/maven/model/Activation;Ljava/lang/String;)V 25 <appendix> member <vmtarget> ; # org/apache/maven/model/validation/DefaultModelValidator$$Lambda+0x000000008d16c230
+instanceKlass  @bci org/apache/maven/model/validation/DefaultModelValidator validate30RawProfileActivation (Lorg/apache/maven/model/building/ModelProblemCollector;Lorg/apache/maven/model/Activation;Ljava/lang/String;)V 16 <appendix> member <vmtarget> ; # org/apache/maven/model/validation/DefaultModelValidator$$Lambda+0x000000008d16c000
+instanceKlass org/apache/maven/model/Exclusion
+instanceKlass org/apache/maven/project/DefaultProjectBuilder$InterimResult
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d168c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d168800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d168400
+# instanceKlass java/lang/invoke/LambdaForm$BMH+0x000000008d168000
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d161c00
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d161800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d161400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d161000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d160c00
+instanceKlass org/apache/maven/artifact/handler/DefaultArtifactHandler$__sisu13$$FastClassByGuice$$192459224
+instanceKlass org/apache/maven/artifact/versioning/Restriction
+instanceKlass org/apache/maven/artifact/versioning/ComparableVersion$StringItem
+instanceKlass org/apache/maven/artifact/ArtifactUtils
+instanceKlass org/apache/maven/artifact/DefaultArtifact
+instanceKlass org/apache/maven/artifact/handler/DefaultArtifactHandler$$FastClassByGuice$$191649018
+instanceKlass org/apache/maven/artifact/versioning/ComparableVersion$IntItem
+instanceKlass org/apache/maven/artifact/versioning/ComparableVersion$Item
+instanceKlass org/apache/maven/artifact/versioning/ComparableVersion
+instanceKlass org/apache/maven/artifact/versioning/DefaultArtifactVersion
+instanceKlass org/apache/maven/repository/internal/ArtifactDescriptorUtils
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder interpolateModel (Lorg/apache/maven/model/Model;Lorg/apache/maven/model/building/ModelBuildingRequest;Lorg/apache/maven/model/building/ModelProblemCollector;)Lorg/apache/maven/model/Model; 219 <appendix> member <vmtarget> ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d167110
+instanceKlass  @cpi org/apache/maven/model/building/DefaultModelBuilder 1548 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d160800
+instanceKlass java/util/function/IntConsumer
+instanceKlass java/util/Spliterator$OfInt
+instanceKlass java/util/Spliterator$OfPrimitive
+instanceKlass java/util/stream/IntStream
+instanceKlass org/apache/maven/model/Extension
+instanceKlass org/codehaus/plexus/interpolation/util/StringUtils
+instanceKlass org/apache/maven/model/DistributionManagement
+instanceKlass org/apache/maven/model/Organization
+instanceKlass org/apache/maven/model/CiManagement
+instanceKlass org/apache/maven/model/IssueManagement
+instanceKlass org/apache/maven/model/Prerequisites
+instanceKlass org/apache/maven/model/MailingList
+instanceKlass org/apache/maven/model/Parent
+instanceKlass org/codehaus/plexus/interpolation/reflection/MethodMap
+instanceKlass org/codehaus/plexus/interpolation/reflection/ClassMap$CacheMiss
+instanceKlass org/codehaus/plexus/interpolation/reflection/ClassMap
+instanceKlass org/codehaus/plexus/interpolation/reflection/ReflectionValueExtractor$Tokenizer
+instanceKlass org/codehaus/plexus/interpolation/reflection/ReflectionValueExtractor
+instanceKlass org/codehaus/plexus/interpolation/util/ValueSourceUtils
+instanceKlass org/apache/maven/model/interpolation/StringVisitorModelInterpolator$ModelVisitor
+instanceKlass org/apache/maven/model/interpolation/StringVisitorModelInterpolator$1
+instanceKlass org/codehaus/plexus/interpolation/PrefixAwareRecursionInterceptor
+instanceKlass org/apache/maven/model/interpolation/UrlNormalizingPostProcessor
+instanceKlass org/apache/maven/model/interpolation/PathTranslatingPostProcessor
+instanceKlass java/text/DontCareFieldPosition$1
+instanceKlass java/text/Format$FieldDelegate
+instanceKlass java/text/StringBufFactory$StringBuilderImpl
+instanceKlass java/text/Format$StringBuf
+instanceKlass java/text/StringBufFactory
+instanceKlass org/apache/maven/model/interpolation/MavenBuildTimestamp
+instanceKlass org/apache/maven/model/interpolation/ProblemDetectingValueSource
+instanceKlass org/codehaus/plexus/interpolation/PrefixedValueSourceWrapper
+instanceKlass org/codehaus/plexus/interpolation/FeedbackEnabledValueSource
+instanceKlass org/codehaus/plexus/interpolation/AbstractDelegatingValueSource
+instanceKlass org/codehaus/plexus/interpolation/QueryEnabledValueSource
+instanceKlass org/apache/maven/model/merge/ModelMerger$ExtensionKeyComputer
+instanceKlass org/apache/maven/model/merge/ModelMerger$ResourceKeyComputer
+instanceKlass org/apache/maven/model/merge/ModelMerger$SourceDominant
+instanceKlass org/apache/maven/model/merge/ModelMerger$DependencyKeyComputer
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder getInterpolatedProfiles (Lorg/apache/maven/model/Model;Lorg/apache/maven/model/profile/DefaultProfileActivationContext;Lorg/apache/maven/model/building/DefaultModelProblemCollector;)Ljava/util/List; 205 <appendix> member <vmtarget> ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d15d7b0
+instanceKlass  @cpi com/sun/tools/javac/comp/Annotate 1389 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d160400
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder getInterpolatedProfiles (Lorg/apache/maven/model/Model;Lorg/apache/maven/model/profile/DefaultProfileActivationContext;Lorg/apache/maven/model/building/DefaultModelProblemCollector;)Ljava/util/List; 191 <appendix> argL0 ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d15d568
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder lambda$getInterpolatedProfiles$3 (Lorg/codehaus/plexus/interpolation/RegexBasedInterpolator;Lorg/apache/maven/model/building/DefaultModelProblemCollector;Lorg/apache/maven/model/ActivationProperty;)V 61 <appendix> member <vmtarget> ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d15d328
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder lambda$getInterpolatedProfiles$3 (Lorg/codehaus/plexus/interpolation/RegexBasedInterpolator;Lorg/apache/maven/model/building/DefaultModelProblemCollector;Lorg/apache/maven/model/ActivationProperty;)V 38 <appendix> member <vmtarget> ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d15d0e8
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder lambda$getInterpolatedProfiles$3 (Lorg/codehaus/plexus/interpolation/RegexBasedInterpolator;Lorg/apache/maven/model/building/DefaultModelProblemCollector;Lorg/apache/maven/model/ActivationProperty;)V 12 <appendix> member <vmtarget> ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d15ceb8
+instanceKlass  @cpi com/sun/tools/javac/comp/TypeEnter 823 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d160000
+instanceKlass org/apache/maven/model/building/DefaultModelBuilder$InterpolateString
+instanceKlass org/apache/maven/model/building/DefaultModelBuilder$1Interpolation
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder getInterpolatedProfiles (Lorg/apache/maven/model/Model;Lorg/apache/maven/model/profile/DefaultProfileActivationContext;Lorg/apache/maven/model/building/DefaultModelProblemCollector;)Ljava/util/List; 181 <appendix> member <vmtarget> ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d15ca58
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder getInterpolatedProfiles (Lorg/apache/maven/model/Model;Lorg/apache/maven/model/profile/DefaultProfileActivationContext;Lorg/apache/maven/model/building/DefaultModelProblemCollector;)Ljava/util/List; 169 <appendix> argL0 ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d15c810
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder getInterpolatedProfiles (Lorg/apache/maven/model/Model;Lorg/apache/maven/model/profile/DefaultProfileActivationContext;Lorg/apache/maven/model/building/DefaultModelProblemCollector;)Ljava/util/List; 159 <appendix> member <vmtarget> ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d15c5d0
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder getInterpolatedProfiles (Lorg/apache/maven/model/Model;Lorg/apache/maven/model/profile/DefaultProfileActivationContext;Lorg/apache/maven/model/building/DefaultModelProblemCollector;)Ljava/util/List; 147 <appendix> argL0 ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d15c388
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder getInterpolatedProfiles (Lorg/apache/maven/model/Model;Lorg/apache/maven/model/profile/DefaultProfileActivationContext;Lorg/apache/maven/model/building/DefaultModelProblemCollector;)Ljava/util/List; 137 <appendix> member <vmtarget> ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d15c148
+instanceKlass  @cpi com/sun/tools/javac/comp/Annotate 1392 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d154400
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder getInterpolatedProfiles (Lorg/apache/maven/model/Model;Lorg/apache/maven/model/profile/DefaultProfileActivationContext;Lorg/apache/maven/model/building/DefaultModelProblemCollector;)Ljava/util/List; 126 <appendix> argL0 ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d15bf00
+instanceKlass  @bci org/apache/maven/model/profile/DefaultProfileActivationContext setProjectProperties (Ljava/util/Properties;)Lorg/apache/maven/model/profile/DefaultProfileActivationContext; 27 <appendix> argL0 ; # org/apache/maven/model/profile/DefaultProfileActivationContext$$Lambda+0x000000008d15ba40
+instanceKlass  @bci org/apache/maven/model/profile/DefaultProfileActivationContext setProjectProperties (Ljava/util/Properties;)Lorg/apache/maven/model/profile/DefaultProfileActivationContext; 19 <appendix> argL0 ; # org/apache/maven/model/profile/DefaultProfileActivationContext$$Lambda+0x000000008d15b7f8
+instanceKlass  @bci org/apache/maven/model/profile/DefaultProfileActivationContext setProjectProperties (Ljava/util/Properties;)Lorg/apache/maven/model/profile/DefaultProfileActivationContext; 14 <appendix> argL0 ; # org/apache/maven/model/profile/DefaultProfileActivationContext$$Lambda+0x000000008d15b5b0
+instanceKlass  @bci org/apache/maven/model/building/DefaultModelBuilder getProfileActivationContext (Lorg/apache/maven/model/building/ModelBuildingRequest;Lorg/apache/maven/model/Model;)Lorg/apache/maven/model/profile/DefaultProfileActivationContext; 55 <appendix> member <vmtarget> ; # org/apache/maven/model/building/DefaultModelBuilder$$Lambda+0x000000008d15b360
+instanceKlass org/apache/maven/model/building/ModelProblemUtils
+instanceKlass org/apache/maven/model/io/xpp3/MavenXpp3ReaderEx$Xpp3DomBuilderInputLocationBuilder
+instanceKlass org/apache/maven/model/DependencyManagement
+instanceKlass org/apache/maven/model/Scm
+instanceKlass org/apache/maven/model/License
+instanceKlass org/apache/maven/model/io/xpp3/MavenXpp3ReaderEx$1
+instanceKlass org/codehaus/plexus/util/xml/Xpp3DomBuilder$InputLocationBuilder
+instanceKlass org/apache/maven/model/io/xpp3/MavenXpp3ReaderEx$ContentTransformer
+instanceKlass org/apache/maven/model/io/xpp3/MavenXpp3ReaderEx
+instanceKlass org/apache/maven/model/building/ModelSource2
+instanceKlass org/apache/maven/model/building/DefaultModelBuildingResult
+instanceKlass org/apache/maven/model/building/AbstractModelBuildingListener
+instanceKlass org/apache/maven/project/ProjectModelResolver
+instanceKlass org/apache/maven/model/building/DefaultModelBuildingRequest
+instanceKlass org/apache/maven/artifact/repository/LegacyLocalRepositoryManager
+instanceKlass org/apache/maven/repository/internal/DefaultModelCache
+instanceKlass org/apache/maven/project/DefaultProjectBuildingRequest
+instanceKlass org/apache/maven/lifecycle/internal/DefaultExecutionEventCatapult$1
+instanceKlass org/apache/maven/lifecycle/internal/DefaultExecutionEvent
+instanceKlass org/apache/maven/AbstractMavenLifecycleParticipant
+instanceKlass java/util/concurrent/atomic/AtomicReference
+instanceKlass org/apache/maven/session/scope/internal/SessionScope$CachingProvider
+instanceKlass  @bci org/apache/maven/session/scope/internal/SessionScope seed (Ljava/lang/Class;Ljava/lang/Object;)V 3 <appendix> member <vmtarget> ; # org/apache/maven/session/scope/internal/SessionScope$$Lambda+0x000000008d155ad0
+instanceKlass org/apache/maven/settings/RuntimeInfo
+instanceKlass org/eclipse/aether/internal/impl/LocalPathPrefixComposerFactorySupport$LocalPathPrefixComposerSupport
+instanceKlass org/eclipse/aether/internal/impl/SimpleLocalRepositoryManager
+instanceKlass java/util/ArrayList$SubList$1
+instanceKlass org/eclipse/aether/internal/impl/PrioritizedComponent
+instanceKlass org/eclipse/sisu/wire/EntrySetAdapter$ValueIterator
+instanceKlass org/eclipse/aether/internal/impl/PrioritizedComponents
+instanceKlass  @bci org/apache/maven/RepositoryUtils toRepos (Ljava/util/List;)Ljava/util/List; 18 <appendix> argL0 ; # org/apache/maven/RepositoryUtils$$Lambda+0x000000008d157380
+instanceKlass java/util/Spliterators$EmptySpliterator
+instanceKlass org/eclipse/aether/repository/RemoteRepository$Builder
+instanceKlass java/net/spi/URLStreamHandlerProvider
+instanceKlass jdk/internal/misc/ThreadTracker
+instanceKlass java/net/URL$ThreadTrackHolder
+instanceKlass org/eclipse/aether/util/ConfigUtils
+instanceKlass org/eclipse/aether/AbstractRepositoryListener
+instanceKlass org/eclipse/aether/util/repository/DefaultAuthenticationSelector
+instanceKlass org/eclipse/aether/util/repository/DefaultProxySelector
+instanceKlass org/eclipse/aether/util/repository/DefaultMirrorSelector$MirrorDef
+instanceKlass org/eclipse/aether/util/repository/DefaultMirrorSelector
+instanceKlass org/apache/maven/settings/crypto/DefaultSettingsDecryptionResult
+instanceKlass org/apache/maven/settings/crypto/DefaultSettingsDecryptionRequest
+instanceKlass org/apache/maven/RepositoryUtils$MavenArtifactTypeRegistry
+instanceKlass org/apache/maven/RepositoryUtils
+instanceKlass org/eclipse/aether/util/repository/SimpleResolutionErrorPolicy
+instanceKlass  @bci java/util/stream/Collectors mapMerger (Ljava/util/function/BinaryOperator;)Ljava/util/function/BinaryOperator; 1 <appendix> member <vmtarget> ; # java/util/stream/Collectors$$Lambda+0x000000008d039568
+instanceKlass  @bci java/util/stream/Collectors toMap (Ljava/util/function/Function;Ljava/util/function/Function;Ljava/util/function/BinaryOperator;Ljava/util/function/Supplier;)Ljava/util/stream/Collector; 3 <appendix> member <vmtarget> ; # java/util/stream/Collectors$$Lambda+0x000000008d039328
+instanceKlass  @cpi java/util/stream/Collectors 1304 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d154000
+instanceKlass  @bci java/util/stream/Collectors toMap (Ljava/util/function/Function;Ljava/util/function/Function;Ljava/util/function/BinaryOperator;)Ljava/util/stream/Collector; 3 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x000000008d039100
+instanceKlass  @bci org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory getPropertiesFromRequestedProfiles (Lorg/apache/maven/execution/MavenExecutionRequest;)Ljava/util/Map; 59 <appendix> argL0 ; # org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory$$Lambda+0x000000008d153098
+instanceKlass  @bci org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory getPropertiesFromRequestedProfiles (Lorg/apache/maven/execution/MavenExecutionRequest;)Ljava/util/Map; 54 <appendix> argL0 ; # org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory$$Lambda+0x000000008d152e50
+instanceKlass  @bci org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory getPropertiesFromRequestedProfiles (Lorg/apache/maven/execution/MavenExecutionRequest;)Ljava/util/Map; 49 <appendix> argL0 ; # org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory$$Lambda+0x000000008d152c08
+instanceKlass  @bci org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory getPropertiesFromRequestedProfiles (Lorg/apache/maven/execution/MavenExecutionRequest;)Ljava/util/Map; 39 <appendix> argL0 ; # org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory$$Lambda+0x000000008d1529c0
+instanceKlass  @bci org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory getPropertiesFromRequestedProfiles (Lorg/apache/maven/execution/MavenExecutionRequest;)Ljava/util/Map; 29 <appendix> argL0 ; # org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory$$Lambda+0x000000008d152778
+instanceKlass  @bci org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory getPropertiesFromRequestedProfiles (Lorg/apache/maven/execution/MavenExecutionRequest;)Ljava/util/Map; 19 <appendix> member <vmtarget> ; # org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory$$Lambda+0x000000008d152518
+instanceKlass org/eclipse/aether/util/repository/SimpleArtifactDescriptorPolicy
+instanceKlass org/eclipse/aether/artifact/DefaultArtifactType
+instanceKlass org/eclipse/aether/util/artifact/SimpleArtifactTypeRegistry
+instanceKlass org/eclipse/aether/util/graph/transformer/JavaDependencyContextRefiner
+instanceKlass org/eclipse/aether/util/graph/transformer/ChainedDependencyGraphTransformer
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictResolver
+instanceKlass org/eclipse/aether/graph/Exclusion
+instanceKlass org/eclipse/aether/util/graph/selector/ExclusionDependencySelector
+instanceKlass org/eclipse/aether/util/graph/selector/OptionalDependencySelector
+instanceKlass org/eclipse/aether/util/graph/selector/ScopeDependencySelector
+instanceKlass org/eclipse/aether/util/graph/selector/AndDependencySelector
+instanceKlass org/eclipse/aether/util/graph/manager/ClassicDependencyManager
+instanceKlass org/eclipse/aether/util/graph/traverser/FatArtifactTraverser
+instanceKlass org/eclipse/aether/DefaultSessionData
+instanceKlass org/eclipse/aether/DefaultRepositorySystemSession$NullFileTransformerManager
+instanceKlass org/eclipse/aether/transform/FileTransformerManager
+instanceKlass org/eclipse/aether/DefaultRepositorySystemSession$NullArtifactTypeRegistry
+instanceKlass org/eclipse/aether/DefaultRepositorySystemSession$NullAuthenticationSelector
+instanceKlass org/eclipse/aether/DefaultRepositorySystemSession$NullProxySelector
+instanceKlass org/eclipse/aether/DefaultRepositorySystemSession$NullMirrorSelector
+instanceKlass org/eclipse/aether/SessionData
+instanceKlass org/eclipse/aether/artifact/ArtifactTypeRegistry
+instanceKlass org/eclipse/aether/collection/DependencyGraphTransformer
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictResolver$VersionSelector
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictResolver$ScopeSelector
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictResolver$OptionalitySelector
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictResolver$ScopeDeriver
+instanceKlass org/apache/maven/repository/internal/MavenRepositorySystemUtils
+instanceKlass org/apache/maven/execution/DefaultMavenExecutionResult
+instanceKlass org/apache/maven/artifact/repository/MavenArtifactRepository
+instanceKlass org/apache/maven/artifact/repository/layout/ArtifactRepositoryLayout2
+instanceKlass org/apache/maven/artifact/repository/layout/DefaultRepositoryLayout$$FastClassByGuice$$190468663
+instanceKlass java/util/StringTokenizer
+instanceKlass org/apache/maven/execution/AbstractExecutionListener
+instanceKlass org/eclipse/aether/transfer/AbstractTransferListener
+instanceKlass org/apache/maven/toolchain/building/DefaultToolchainsBuildingResult
+instanceKlass org/apache/maven/toolchain/building/DefaultToolchainsBuilder$1
+instanceKlass org/apache/maven/toolchain/model/io/xpp3/MavenToolchainsXpp3Writer
+instanceKlass org/apache/maven/toolchain/model/io/xpp3/MavenToolchainsXpp3Reader$1
+instanceKlass org/apache/maven/toolchain/model/io/xpp3/MavenToolchainsXpp3Reader$ContentTransformer
+instanceKlass org/apache/maven/toolchain/model/io/xpp3/MavenToolchainsXpp3Reader
+instanceKlass org/apache/maven/building/DefaultProblemCollector
+instanceKlass org/apache/maven/building/ProblemCollectorFactory
+instanceKlass org/apache/maven/toolchain/building/DefaultToolchainsBuildingRequest
+instanceKlass org/apache/maven/settings/building/DefaultSettingsBuildingResult
+instanceKlass org/apache/maven/settings/building/DefaultSettingsBuilder$1
+instanceKlass org/codehaus/plexus/interpolation/os/OperatingSystemUtils$DefaultEnvVarSource
+instanceKlass org/codehaus/plexus/interpolation/os/OperatingSystemUtils$EnvVarSource
+instanceKlass org/codehaus/plexus/interpolation/os/OperatingSystemUtils
+instanceKlass org/codehaus/plexus/util/xml/pull/MXSerializer
+instanceKlass org/codehaus/plexus/util/xml/pull/XmlSerializer
+instanceKlass org/apache/maven/settings/io/xpp3/SettingsXpp3Writer
+instanceKlass org/codehaus/plexus/util/xml/pull/EntityReplacementMap
+instanceKlass org/apache/maven/settings/io/xpp3/SettingsXpp3Reader$1
+instanceKlass org/apache/maven/settings/io/xpp3/SettingsXpp3Reader$ContentTransformer
+instanceKlass org/apache/maven/settings/io/xpp3/SettingsXpp3Reader
+instanceKlass org/apache/maven/building/FileSource
+instanceKlass org/apache/maven/settings/building/DefaultSettingsBuildingRequest
+instanceKlass  @bci java/util/regex/CharPredicates ASCII_WORD ()Ljava/util/regex/Pattern$BmpCharPredicate; 0 <appendix> argL0 ; # java/util/regex/CharPredicates$$Lambda+0x000000008d0387d8
+instanceKlass org/apache/maven/graph/DefaultGraphBuilder$$FastClassByGuice$$189096662
+instanceKlass jdk/internal/math/ToDecimal
+instanceKlass org/apache/maven/plugin/prefix/internal/DefaultPluginPrefixResolver$$FastClassByGuice$$188003918
+instanceKlass org/apache/maven/plugin/CompoundMojoExecutionListener
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d14c000
+instanceKlass org/apache/maven/plugin/DefaultBuildPluginManager$$FastClassByGuice$$187622584
+instanceKlass org/apache/maven/lifecycle/internal/DefaultLifecycleTaskSegmentCalculator$$FastClassByGuice$$186533775
+instanceKlass org/apache/maven/lifecycle/internal/DefaultExecutionEventCatapult$$FastClassByGuice$$185249356
+instanceKlass org/apache/maven/project/DefaultProjectDependenciesResolver$$FastClassByGuice$$183935675
+instanceKlass org/apache/maven/project/RepositorySessionDecorator
+instanceKlass org/apache/maven/plugin/DefaultPluginArtifactsCache$$FastClassByGuice$$182587458
+instanceKlass com/google/inject/internal/DelegatingInvocationHandler
+instanceKlass org/apache/maven/artifact/repository/metadata/io/DefaultMetadataReader$$FastClassByGuice$$181988696
+instanceKlass org/apache/maven/plugin/version/internal/DefaultPluginVersionResolver$$FastClassByGuice$$180750746
+instanceKlass org/apache/maven/plugin/DefaultExtensionRealmCache$$FastClassByGuice$$179895541
+instanceKlass org/apache/maven/rtinfo/internal/DefaultRuntimeInformation$$FastClassByGuice$$178259064
+instanceKlass org/apache/maven/plugin/DefaultPluginRealmCache$$FastClassByGuice$$177386529
+instanceKlass org/apache/maven/plugin/DefaultPluginDescriptorCache$$FastClassByGuice$$176851829
+instanceKlass org/apache/maven/plugin/internal/DefaultMavenPluginManager$$FastClassByGuice$$175285904
+instanceKlass  @bci sun/security/provider/AbstractDrbg <clinit> ()V 12 <appendix> argL0 ; # sun/security/provider/AbstractDrbg$$Lambda+0x000000008d0385b0
+instanceKlass  @cpi sun/security/provider/AbstractDrbg 383 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d141000
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d140c00
+instanceKlass sun/security/provider/EntropySource
+instanceKlass sun/security/provider/AbstractDrbg
+instanceKlass java/security/DrbgParameters$Instantiation
+instanceKlass java/security/DrbgParameters
+instanceKlass sun/security/provider/MoreDrbgParameters
+instanceKlass java/security/SecureRandomSpi
+instanceKlass jdk/internal/event/Event
+instanceKlass sun/security/util/SecurityProviderConstants
+instanceKlass java/security/Provider$UString
+instanceKlass java/security/Provider$Service
+instanceKlass sun/security/provider/NativePRNG$NonBlocking
+instanceKlass sun/security/provider/NativePRNG$Blocking
+instanceKlass sun/security/provider/NativePRNG
+instanceKlass sun/security/provider/SunEntries
+instanceKlass java/security/Permission
+instanceKlass java/security/Guard
+instanceKlass sun/security/util/SecurityConstants
+instanceKlass java/security/Security$2
+instanceKlass jdk/internal/access/JavaSecurityPropertiesAccess
+instanceKlass java/security/Security$SecPropLoader
+instanceKlass java/security/Security
+instanceKlass jdk/internal/math/FloatingDecimal$ASCIIToBinaryBuffer
+instanceKlass jdk/internal/math/MathUtils
+instanceKlass jdk/internal/math/FloatingDecimal$PreparedASCIIToBinaryBuffer
+instanceKlass jdk/internal/math/FloatingDecimal$ASCIIToBinaryConverter
+instanceKlass jdk/internal/math/FloatingDecimal$BinaryToASCIIBuffer
+instanceKlass jdk/internal/math/FloatingDecimal$ExceptionalBinaryToASCIIBuffer
+instanceKlass jdk/internal/math/FloatingDecimal$BinaryToASCIIConverter
+instanceKlass jdk/internal/math/FloatingDecimal
+instanceKlass javax/security/auth/login/Configuration$Parameters
+instanceKlass java/security/Policy$Parameters
+instanceKlass javax/crypto/KDFParameters
+instanceKlass java/security/cert/CertStoreParameters
+instanceKlass java/security/SecureRandomParameters
+instanceKlass java/security/Provider$EngineDescription
+instanceKlass  @bci java/security/Provider <clinit> ()V 28 <appendix> argL0 ; # java/security/Provider$$Lambda+0x000000008d033ed8
+instanceKlass java/security/Provider$ServiceKey
+instanceKlass sun/security/jca/ProviderConfig
+instanceKlass sun/security/jca/ProviderList
+instanceKlass sun/security/jca/Providers
+instanceKlass java/security/Key
+instanceKlass java/security/spec/AlgorithmParameterSpec
+instanceKlass org/apache/maven/repository/DefaultMirrorSelector$$FastClassByGuice$$174797551
+instanceKlass org/apache/maven/repository/legacy/repository/DefaultArtifactRepositoryFactory$$FastClassByGuice$$173160096
+instanceKlass org/eclipse/aether/artifact/ArtifactType
+instanceKlass  @bci org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapterFactoryImpl <init> (Ljava/util/Map;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lorg/eclipse/aether/impl/RepositorySystemLifecycle;)V 63 <appendix> member <vmtarget> ; # org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapterFactoryImpl$$Lambda+0x000000008d142ce8
+instanceKlass  @cpi org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapterFactoryImpl 335 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d140800
+instanceKlass org/eclipse/sisu/wire/NamedIterableAdapter
+instanceKlass org/eclipse/aether/internal/impl/DefaultUpdateCheckManager$1
+instanceKlass org/apache/maven/project/artifact/DefaultMavenMetadataCache$$FastClassByGuice$$172861385
+instanceKlass org/apache/maven/repository/legacy/DefaultUpdateCheckManager$$FastClassByGuice$$171356301
+instanceKlass org/apache/maven/repository/legacy/DefaultWagonManager$$FastClassByGuice$$170687451
+instanceKlass org/apache/maven/artifact/repository/metadata/DefaultRepositoryMetadataManager$$FastClassByGuice$$169327200
+instanceKlass org/apache/maven/project/artifact/DefaultMetadataSource$$FastClassByGuice$$168016751
+instanceKlass org/apache/maven/artifact/resolver/DefaultResolutionErrorHandler$$FastClassByGuice$$167245846
+instanceKlass org/apache/maven/plugin/internal/DefaultLegacySupport$$FastClassByGuice$$166167681
+instanceKlass org/apache/maven/repository/legacy/resolver/conflict/NearestConflictResolver$$FastClassByGuice$$164956732
+instanceKlass org/apache/maven/artifact/resolver/DefaultArtifactCollector$$FastClassByGuice$$164298779
+instanceKlass jdk/internal/vm/ThreadContainers
+instanceKlass jdk/internal/invoke/MhUtil
+instanceKlass jdk/internal/vm/StackableScope
+instanceKlass org/apache/maven/artifact/resolver/DefaultArtifactResolver$DaemonThreadCreator
+instanceKlass java/util/concurrent/ThreadPoolExecutor$AbortPolicy
+instanceKlass java/util/concurrent/RejectedExecutionHandler
+instanceKlass java/util/concurrent/AbstractExecutorService
+instanceKlass java/util/concurrent/ExecutorService
+instanceKlass org/apache/maven/artifact/resolver/DefaultArtifactResolver$$FastClassByGuice$$162990048
+instanceKlass org/apache/maven/artifact/handler/manager/DefaultArtifactHandlerManager$$FastClassByGuice$$162103094
+instanceKlass org/apache/maven/artifact/factory/DefaultArtifactFactory$$FastClassByGuice$$160839649
+instanceKlass org/apache/maven/repository/legacy/LegacyRepositorySystem$$FastClassByGuice$$159458461
+instanceKlass org/apache/maven/project/DefaultProjectRealmCache$$FastClassByGuice$$159155365
+instanceKlass org/codehaus/plexus/classworlds/realm/Entry
+instanceKlass java/util/Random
+instanceKlass java/util/random/RandomGenerator
+instanceKlass org/eclipse/sisu/inject/Guice4$2
+instanceKlass org/apache/maven/project/DefaultProjectBuildingHelper$$FastClassByGuice$$157689936
+instanceKlass org/apache/maven/lifecycle/internal/DefaultLifecyclePluginAnalyzer$$FastClassByGuice$$157243939
+instanceKlass org/apache/maven/model/plugin/DefaultLifecycleBindingsInjector$$FastClassByGuice$$155951434
+instanceKlass org/apache/maven/model/Contributor
+instanceKlass org/apache/maven/model/PatternSet
+instanceKlass org/apache/maven/model/merge/ModelMerger$KeyComputer
+instanceKlass org/apache/maven/model/merge/ModelMerger$Remapping
+instanceKlass org/apache/maven/project/DefaultProjectBuilder$$FastClassByGuice$$154239890
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d140400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d140000
+instanceKlass org/apache/maven/DefaultMaven$$FastClassByGuice$$153821479
+instanceKlass org/apache/maven/cli/event/DefaultEventSpyContext
+instanceKlass org/eclipse/sisu/wire/EntryListAdapter$ValueIterator
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d13cc00
+instanceKlass org/apache/maven/cli/logging/Slf4jLogger
+instanceKlass org/eclipse/sisu/inject/LazyBeanEntry$JsrNamed
+instanceKlass org/eclipse/sisu/inject/LazyBeanEntry
+instanceKlass javax/annotation/Priority
+instanceKlass org/eclipse/sisu/inject/Implementations
+instanceKlass org/eclipse/sisu/plexus/LazyPlexusBean
+instanceKlass org/eclipse/sisu/inject/RankedSequence$Itr
+instanceKlass org/eclipse/sisu/inject/RankedBindings$Itr
+instanceKlass org/eclipse/sisu/inject/LocatedBeans$Itr
+instanceKlass org/eclipse/sisu/plexus/RealmFilteredBeans$FilteredItr
+instanceKlass org/eclipse/sisu/plexus/DefaultPlexusBeans$Itr
+instanceKlass org/eclipse/sisu/plexus/DefaultPlexusBeans
+instanceKlass org/eclipse/sisu/plexus/RealmFilteredBeans
+instanceKlass org/eclipse/sisu/inject/BeanCache
+instanceKlass org/eclipse/sisu/inject/LocatedBeans
+instanceKlass org/eclipse/sisu/inject/MildElements$Indexable
+instanceKlass com/google/inject/internal/ProviderInternalFactory$1
+instanceKlass com/google/inject/internal/ConstructorInjector$1
+instanceKlass  @bci jdk/internal/reflect/MethodHandleObjectFieldAccessorImpl set (Ljava/lang/Object;Ljava/lang/Object;)V 41 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x000000008d13c800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d13c400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d13c000
+instanceKlass org/eclipse/sisu/inject/WatchedBeans
+instanceKlass org/eclipse/sisu/inject/MildValues$ValueItr
+instanceKlass org/eclipse/sisu/inject/InjectorBindings
+instanceKlass com/google/inject/spi/ProvisionListener$ProvisionInvocation
+instanceKlass com/google/inject/internal/MembersInjectorImpl$1
+instanceKlass com/google/inject/internal/InternalContext
+instanceKlass com/google/inject/internal/Initializer$1
+instanceKlass com/google/common/collect/AbstractMapBasedMultimap$AsMap$AsMapIterator
+instanceKlass org/codehaus/plexus/DefaultPlexusContainer$$FastClassByGuice$$152517583
+instanceKlass org/eclipse/sisu/wire/TypeConverterCache$$FastClassByGuice$$151774376
+instanceKlass com/google/inject/internal/SingleMethodInjector$1
+instanceKlass org/eclipse/sisu/inject/DefaultBeanLocator$$FastClassByGuice$$150260489
+instanceKlass com/google/inject/internal/InjectorImpl$MethodInvoker
+instanceKlass com/google/inject/internal/SingleMethodInjector
+instanceKlass org/eclipse/sisu/plexus/PlexusXmlBeanConverter$$FastClassByGuice$$149803542
+instanceKlass org/sonatype/plexus/components/sec/dispatcher/DefaultSecDispatcher$$FastClassByGuice$$147882929
+instanceKlass org/sonatype/plexus/components/cipher/DefaultPlexusCipher$$FastClassByGuice$$147832210
+instanceKlass org/codehaus/plexus/component/configurator/MapOrientedComponentConfigurator$$FastClassByGuice$$146503868
+instanceKlass org/codehaus/plexus/component/configurator/BasicComponentConfigurator$$FastClassByGuice$$145182364
+instanceKlass org/apache/maven/settings/validation/DefaultSettingsValidator$$FastClassByGuice$$144520746
+instanceKlass org/apache/maven/settings/io/DefaultSettingsWriter$$FastClassByGuice$$142613168
+instanceKlass org/apache/maven/settings/io/DefaultSettingsReader$$FastClassByGuice$$142075033
+instanceKlass org/apache/maven/settings/crypto/DefaultSettingsDecrypter$$FastClassByGuice$$140610173
+instanceKlass org/apache/maven/settings/building/DefaultSettingsBuilder$$FastClassByGuice$$139913218
+instanceKlass org/eclipse/aether/transport/wagon/WagonTransporterFactory$$FastClassByGuice$$138680406
+instanceKlass org/eclipse/aether/internal/transport/wagon/PlexusWagonProvider$$FastClassByGuice$$138237673
+instanceKlass org/eclipse/aether/internal/transport/wagon/PlexusWagonConfigurator$$FastClassByGuice$$137306979
+instanceKlass org/eclipse/aether/transport/http/XChecksumChecksumExtractor$$FastClassByGuice$$135596731
+instanceKlass org/eclipse/aether/transport/http/Nexus2ChecksumExtractor$$FastClassByGuice$$134343887
+instanceKlass org/eclipse/aether/transport/http/HttpTransporterFactory$$FastClassByGuice$$134187103
+instanceKlass org/eclipse/aether/transport/file/FileTransporterFactory$$FastClassByGuice$$132744040
+instanceKlass org/apache/maven/repository/internal/VersionsMetadataGeneratorFactory$$FastClassByGuice$$131641811
+instanceKlass org/apache/maven/repository/internal/SnapshotMetadataGeneratorFactory$$FastClassByGuice$$130801380
+instanceKlass org/apache/maven/repository/internal/PluginsMetadataGeneratorFactory$$FastClassByGuice$$129654172
+instanceKlass org/apache/maven/repository/internal/DefaultVersionResolver$$FastClassByGuice$$128285504
+instanceKlass org/apache/maven/repository/internal/DefaultVersionRangeResolver$$FastClassByGuice$$127611544
+instanceKlass org/apache/maven/repository/internal/DefaultModelCacheFactory$$FastClassByGuice$$126528976
+instanceKlass org/apache/maven/repository/internal/DefaultArtifactDescriptorReader$$FastClassByGuice$$125368934
+instanceKlass org/eclipse/aether/named/providers/NoopNamedLockFactory$$FastClassByGuice$$124678341
+instanceKlass org/eclipse/aether/named/providers/LocalSemaphoreNamedLockFactory$$FastClassByGuice$$123264798
+instanceKlass org/eclipse/aether/named/providers/LocalReadWriteLockNamedLockFactory$$FastClassByGuice$$122266028
+instanceKlass org/eclipse/aether/named/providers/FileLockNamedLockFactory$$FastClassByGuice$$121316134
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/providers/StaticNameMapperProvider$$FastClassByGuice$$119936723
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/providers/GAVNameMapperProvider$$FastClassByGuice$$118664823
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/providers/FileStaticNameMapperProvider$$FastClassByGuice$$117941084
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/providers/FileHashingGAVNameMapperProvider$$FastClassByGuice$$117351395
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/providers/FileGAVNameMapperProvider$$FastClassByGuice$$115515155
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/providers/DiscriminatingNameMapperProvider$$FastClassByGuice$$115222837
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapterFactoryImpl$$FastClassByGuice$$113892847
+instanceKlass org/eclipse/aether/internal/impl/synccontext/legacy/DefaultSyncContextFactory$$FastClassByGuice$$112293106
+instanceKlass org/eclipse/aether/internal/impl/synccontext/DefaultSyncContextFactory$$FastClassByGuice$$112076496
+instanceKlass org/eclipse/aether/internal/impl/slf4j/Slf4jLoggerFactory$$FastClassByGuice$$110952732
+instanceKlass org/eclipse/aether/internal/impl/resolution/TrustedChecksumsArtifactResolverPostProcessor$$FastClassByGuice$$110065178
+instanceKlass org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSource$$FastClassByGuice$$108727901
+instanceKlass org/eclipse/aether/internal/impl/filter/GroupIdRemoteRepositoryFilterSource$$FastClassByGuice$$107932820
+instanceKlass org/eclipse/aether/internal/impl/filter/DefaultRemoteRepositoryFilterManager$$FastClassByGuice$$106697339
+instanceKlass org/eclipse/aether/internal/impl/collect/df/DfDependencyCollector$$FastClassByGuice$$105369409
+instanceKlass org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector$$FastClassByGuice$$104471974
+instanceKlass org/eclipse/aether/internal/impl/collect/DefaultDependencyCollector$$FastClassByGuice$$102761576
+instanceKlass org/eclipse/aether/internal/impl/checksum/TrustedToProvidedChecksumsSourceAdapter$$FastClassByGuice$$101955108
+instanceKlass org/eclipse/aether/internal/impl/checksum/SummaryFileTrustedChecksumsSource$$FastClassByGuice$$100982975
+instanceKlass org/eclipse/aether/internal/impl/checksum/SparseDirectoryTrustedChecksumsSource$$FastClassByGuice$$99619850
+instanceKlass org/eclipse/aether/internal/impl/checksum/Sha512ChecksumAlgorithmFactory$$FastClassByGuice$$99544536
+instanceKlass org/eclipse/aether/internal/impl/checksum/Sha256ChecksumAlgorithmFactory$$FastClassByGuice$$97936946
+instanceKlass org/eclipse/aether/internal/impl/checksum/Sha1ChecksumAlgorithmFactory$$FastClassByGuice$$96507211
+instanceKlass  @bci com/google/inject/internal/aop/ImmutableStringTrie buildTrie (Ljava/util/Collection;)Ljava/util/function/ToIntFunction; 38 <appendix> argL0 ; # com/google/inject/internal/aop/ImmutableStringTrie$$Lambda+0x000000008d12a380
+instanceKlass org/eclipse/aether/internal/impl/checksum/Md5ChecksumAlgorithmFactory$$FastClassByGuice$$95490166
+instanceKlass org/eclipse/aether/internal/impl/checksum/DefaultChecksumAlgorithmFactorySelector$$FastClassByGuice$$94486911
+instanceKlass org/eclipse/aether/internal/impl/SimpleLocalRepositoryManagerFactory$$FastClassByGuice$$93520104
+instanceKlass org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactory$$FastClassByGuice$$92664098
+instanceKlass org/eclipse/aether/internal/impl/LoggerFactoryProvider$$FastClassByGuice$$91631799
+instanceKlass org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerFactory$$FastClassByGuice$$90340201
+instanceKlass org/eclipse/aether/internal/impl/DefaultUpdatePolicyAnalyzer$$FastClassByGuice$$89882851
+instanceKlass org/eclipse/aether/internal/impl/DefaultUpdateCheckManager$$FastClassByGuice$$88717906
+instanceKlass org/eclipse/aether/internal/impl/DefaultTransporterProvider$$FastClassByGuice$$88060758
+instanceKlass org/eclipse/aether/internal/impl/DefaultTrackingFileManager$$FastClassByGuice$$86180891
+instanceKlass org/eclipse/aether/internal/impl/DefaultRepositorySystemLifecycle$$FastClassByGuice$$85870384
+instanceKlass org/eclipse/aether/internal/impl/DefaultRepositorySystem$$FastClassByGuice$$84320090
+instanceKlass org/eclipse/aether/internal/impl/DefaultRepositoryLayoutProvider$$FastClassByGuice$$83437553
+instanceKlass org/eclipse/aether/internal/impl/DefaultRepositoryEventDispatcher$$FastClassByGuice$$82736881
+instanceKlass org/eclipse/aether/internal/impl/DefaultRepositoryConnectorProvider$$FastClassByGuice$$81059280
+instanceKlass org/eclipse/aether/internal/impl/DefaultRemoteRepositoryManager$$FastClassByGuice$$80651645
+instanceKlass org/eclipse/aether/internal/impl/DefaultOfflineController$$FastClassByGuice$$79248062
+instanceKlass org/eclipse/aether/internal/impl/DefaultMetadataResolver$$FastClassByGuice$$77875874
+instanceKlass org/eclipse/aether/internal/impl/DefaultLocalRepositoryProvider$$FastClassByGuice$$76865944
+instanceKlass org/eclipse/aether/internal/impl/DefaultLocalPathPrefixComposerFactory$$FastClassByGuice$$76359167
+instanceKlass org/eclipse/aether/internal/impl/DefaultLocalPathComposer$$FastClassByGuice$$75403520
+instanceKlass org/eclipse/aether/internal/impl/DefaultInstaller$$FastClassByGuice$$74391194
+instanceKlass org/eclipse/aether/internal/impl/DefaultFileProcessor$$FastClassByGuice$$73255043
+instanceKlass org/eclipse/aether/internal/impl/DefaultDeployer$$FastClassByGuice$$72139322
+instanceKlass org/eclipse/aether/internal/impl/DefaultChecksumPolicyProvider$$FastClassByGuice$$70320284
+instanceKlass org/eclipse/aether/internal/impl/DefaultArtifactResolver$$FastClassByGuice$$69581088
+instanceKlass org/eclipse/aether/connector/basic/BasicRepositoryConnectorFactory$$FastClassByGuice$$68273351
+instanceKlass org/apache/maven/model/validation/DefaultModelValidator$$FastClassByGuice$$67286342
+instanceKlass org/apache/maven/model/superpom/DefaultSuperPomProvider$$FastClassByGuice$$66724054
+instanceKlass org/apache/maven/model/profile/activation/PropertyProfileActivator$$FastClassByGuice$$65847066
+instanceKlass org/apache/maven/model/profile/activation/OperatingSystemProfileActivator$$FastClassByGuice$$64717950
+instanceKlass org/apache/maven/model/profile/activation/JdkVersionProfileActivator$$FastClassByGuice$$63433054
+instanceKlass org/apache/maven/model/profile/activation/FileProfileActivator$$FastClassByGuice$$62844969
+instanceKlass org/apache/maven/model/profile/DefaultProfileSelector$$FastClassByGuice$$61323471
+instanceKlass org/apache/maven/model/profile/DefaultProfileInjector$$FastClassByGuice$$60059028
+instanceKlass org/apache/maven/model/plugin/DefaultReportingConverter$$FastClassByGuice$$58792345
+instanceKlass org/apache/maven/model/plugin/DefaultReportConfigurationExpander$$FastClassByGuice$$58232915
+instanceKlass org/apache/maven/model/plugin/DefaultPluginConfigurationExpander$$FastClassByGuice$$57021363
+instanceKlass org/apache/maven/model/path/ProfileActivationFilePathInterpolator$$FastClassByGuice$$55951776
+instanceKlass org/apache/maven/model/path/DefaultUrlNormalizer$$FastClassByGuice$$55050231
+instanceKlass org/apache/maven/model/path/DefaultPathTranslator$$FastClassByGuice$$54023645
+instanceKlass org/apache/maven/model/path/DefaultModelUrlNormalizer$$FastClassByGuice$$53476290
+instanceKlass org/apache/maven/model/path/DefaultModelPathTranslator$$FastClassByGuice$$51727168
+instanceKlass org/apache/maven/model/normalization/DefaultModelNormalizer$$FastClassByGuice$$50380089
+instanceKlass org/apache/maven/model/management/DefaultPluginManagementInjector$$FastClassByGuice$$49829078
+instanceKlass org/apache/maven/model/management/DefaultDependencyManagementInjector$$FastClassByGuice$$48674826
+instanceKlass org/apache/maven/model/locator/DefaultModelLocator$$FastClassByGuice$$47362427
+instanceKlass org/apache/maven/model/io/DefaultModelWriter$$FastClassByGuice$$46499496
+instanceKlass org/apache/maven/model/io/DefaultModelReader$$FastClassByGuice$$46070811
+instanceKlass org/apache/maven/model/interpolation/StringVisitorModelInterpolator$$FastClassByGuice$$44986287
+instanceKlass org/apache/maven/model/interpolation/DefaultModelVersionProcessor$$FastClassByGuice$$43693179
+instanceKlass org/apache/maven/model/inheritance/DefaultInheritanceAssembler$$FastClassByGuice$$42979210
+instanceKlass org/apache/maven/model/composition/DefaultDependencyManagementImporter$$FastClassByGuice$$40927388
+instanceKlass org/apache/maven/model/building/DefaultModelProcessor$$FastClassByGuice$$40331012
+instanceKlass org/apache/maven/model/building/DefaultModelBuilder$$FastClassByGuice$$38997138
+instanceKlass org/apache/maven/cli/internal/BootstrapCoreExtensionManager$$FastClassByGuice$$38790892
+instanceKlass org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor$$FastClassByGuice$$36799564
+instanceKlass org/apache/maven/toolchain/io/DefaultToolchainsWriter$$FastClassByGuice$$36315315
+instanceKlass org/apache/maven/toolchain/io/DefaultToolchainsReader$$FastClassByGuice$$34937027
+instanceKlass org/apache/maven/toolchain/building/DefaultToolchainsBuilder$$FastClassByGuice$$34364807
+instanceKlass org/apache/maven/plugin/internal/ReadOnlyPluginParametersValidator$$FastClassByGuice$$33288418
+instanceKlass org/apache/maven/plugin/internal/PlexusContainerDefaultDependenciesValidator$$FastClassByGuice$$32141420
+instanceKlass org/apache/maven/plugin/internal/MavenScopeDependenciesValidator$$FastClassByGuice$$30535475
+instanceKlass org/apache/maven/plugin/internal/MavenMixedDependenciesValidator$$FastClassByGuice$$29623813
+instanceKlass org/apache/maven/plugin/internal/Maven3CompatDependenciesValidator$$FastClassByGuice$$29355047
+instanceKlass org/apache/maven/plugin/internal/Maven2DependenciesValidator$$FastClassByGuice$$27484338
+instanceKlass org/apache/maven/plugin/internal/DeprecatedPluginValidator$$FastClassByGuice$$26253321
+instanceKlass org/apache/maven/plugin/internal/DeprecatedCoreExpressionValidator$$FastClassByGuice$$25422958
+instanceKlass org/apache/maven/plugin/internal/DefaultPluginValidationManager$$FastClassByGuice$$24601856
+instanceKlass org/apache/maven/plugin/DefaultMojosExecutionStrategy$$FastClassByGuice$$24019425
+instanceKlass org/apache/maven/lifecycle/internal/LifecycleDependencyResolver$$FastClassByGuice$$22442150
+instanceKlass org/apache/maven/lifecycle/internal/DefaultProjectArtifactFactory$$FastClassByGuice$$21863532
+instanceKlass org/apache/maven/internal/aether/ResolverLifecycle$$FastClassByGuice$$20386494
+instanceKlass com/google/inject/internal/InjectorImpl$SyntheticProviderBindingImpl$1
+instanceKlass com/google/inject/internal/InjectorImpl$1
+instanceKlass org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory$$FastClassByGuice$$19040567
+instanceKlass com/google/inject/internal/SingleFieldInjector
+instanceKlass org/apache/maven/extension/internal/CoreExportsProvider$$FastClassByGuice$$18783498
+instanceKlass org/apache/maven/execution/DefaultMavenExecutionRequestPopulator$$FastClassByGuice$$17765262
+instanceKlass org/apache/maven/classrealm/DefaultClassRealmManager$$FastClassByGuice$$15817365
+instanceKlass org/apache/maven/ReactorReader$$FastClassByGuice$$15569232
+instanceKlass org/apache/maven/DefaultArtifactFilterManager$$FastClassByGuice$$13691046
+instanceKlass com/google/inject/internal/SingleParameterInjector
+instanceKlass org/apache/maven/lifecycle/internal/MojoExecutor$$FastClassByGuice$$13049707
+instanceKlass org/apache/maven/lifecycle/internal/LifecycleModuleBuilder$$FastClassByGuice$$11614347
+instanceKlass org/apache/maven/lifecycle/internal/LifecycleStarter$$FastClassByGuice$$10645356
+instanceKlass org/apache/maven/lifecycle/internal/builder/BuilderCommon$$FastClassByGuice$$10271584
+instanceKlass org/apache/maven/lifecycle/internal/MojoDescriptorCreator$$FastClassByGuice$$9190062
+instanceKlass org/apache/maven/lifecycle/internal/LifecyclePluginResolver$$FastClassByGuice$$7390894
+instanceKlass org/apache/maven/lifecycle/internal/BuildListCalculator$$FastClassByGuice$$6327371
+instanceKlass org/apache/maven/lifecycle/DefaultLifecycles$$FastClassByGuice$$6202044
+instanceKlass org/apache/maven/bridge/MavenRepositorySystem$$FastClassByGuice$$4683725
+instanceKlass org/apache/maven/eventspy/internal/EventSpyDispatcher$$FastClassByGuice$$3417269
+instanceKlass org/eclipse/sisu/bean/BeanPropertySetter
+instanceKlass org/eclipse/sisu/PreDestroy
+instanceKlass org/eclipse/sisu/PostConstruct
+instanceKlass org/apache/maven/lifecycle/internal/LifecycleDebugLogger$$FastClassByGuice$$2244326
+instanceKlass org/apache/maven/lifecycle/Lifecycle$$FastClassByGuice$$2024580
+instanceKlass org/eclipse/sisu/plexus/PlexusConfigurations$ConfigurationProvider
+instanceKlass com/google/inject/internal/ProxyFactory
+instanceKlass com/google/common/collect/TransformedIterator
+instanceKlass  @bci com/google/inject/internal/ConstructorInjectorStore createConstructor (Lcom/google/inject/spi/InjectionPoint;Lcom/google/inject/internal/Errors;)Lcom/google/inject/internal/ConstructorInjector; 62 <appendix> argL0 ; # com/google/inject/internal/ConstructorInjectorStore$$Lambda+0x000000008d11ae98
+instanceKlass com/google/inject/spi/InterceptorBinding
+instanceKlass com/google/inject/internal/MethodAspect
+instanceKlass com/google/inject/internal/MembersInjectorImpl
+instanceKlass org/eclipse/sisu/bean/BeanInjector
+instanceKlass org/eclipse/sisu/plexus/PlexusLifecycleManager$2
+instanceKlass org/eclipse/sisu/bean/PropertyBinder$1
+instanceKlass org/eclipse/sisu/plexus/ProvidedPropertyBinding
+instanceKlass org/eclipse/sisu/plexus/PlexusRequirements$AbstractRequirementProvider
+instanceKlass org/eclipse/sisu/bean/BeanPropertyField
+instanceKlass org/eclipse/sisu/bean/DeclaredMembers$MemberIterator
+instanceKlass org/eclipse/sisu/bean/BeanPropertyIterator
+instanceKlass org/eclipse/sisu/bean/DeclaredMembers
+instanceKlass org/eclipse/sisu/bean/IgnoreSetters
+instanceKlass org/eclipse/sisu/bean/BeanProperties
+instanceKlass org/eclipse/sisu/plexus/PlexusRequirements
+instanceKlass org/eclipse/sisu/plexus/PlexusConfigurations
+instanceKlass org/eclipse/sisu/plexus/PlexusPropertyBinder
+instanceKlass org/eclipse/sisu/bean/BeanLifecycle
+instanceKlass com/google/inject/internal/EncounterImpl
+instanceKlass  @bci com/google/inject/internal/AbstractBindingProcessor$Processor scheduleInitialization (Lcom/google/inject/internal/BindingImpl;)V 9 <appendix> member <vmtarget> ; # com/google/inject/internal/AbstractBindingProcessor$Processor$$Lambda+0x000000008d116998
+instanceKlass  @bci org/apache/maven/session/scope/internal/SessionScope scope (Lcom/google/inject/Key;Lcom/google/inject/Provider;)Lcom/google/inject/Provider; 3 <appendix> member <vmtarget> ; # org/apache/maven/session/scope/internal/SessionScope$$Lambda+0x000000008d116750
+instanceKlass org/apache/maven/execution/scope/internal/MojoExecutionScope$2
+instanceKlass com/google/inject/internal/ProviderInternalFactory
+instanceKlass com/google/inject/internal/InternalProviderInstanceBindingImpl$Factory
+instanceKlass com/google/inject/internal/FactoryProxy
+instanceKlass com/google/inject/internal/InternalFactoryToProviderAdapter
+instanceKlass com/google/inject/internal/ConstructionContext
+instanceKlass com/google/inject/internal/SingletonScope$1
+instanceKlass com/google/inject/internal/ProviderToInternalFactoryAdapter
+instanceKlass com/google/inject/internal/CycleDetectingLock$CycleDetectingLockFactory$ReentrantCycleDetectingLock
+instanceKlass com/google/inject/internal/Initializer$InjectableReference
+instanceKlass com/google/inject/internal/ProvisionListenerStackCallback
+instanceKlass com/google/common/cache/LocalCache$AbstractReferenceEntry
+instanceKlass com/google/inject/internal/ProvisionListenerCallbackStore$KeyBinding
+instanceKlass com/google/inject/internal/util/Classes
+instanceKlass com/google/inject/spi/ExposedBinding
+instanceKlass com/google/inject/internal/CreationListener
+instanceKlass com/google/inject/internal/InjectorShell$LoggerFactory
+instanceKlass com/google/inject/internal/InjectorShell$InjectorFactory
+instanceKlass com/google/inject/internal/Initializables$1
+instanceKlass com/google/inject/internal/Initializables
+instanceKlass com/google/inject/internal/ConstantFactory
+instanceKlass com/google/inject/internal/InjectorShell
+instanceKlass com/google/inject/internal/ProvisionListenerCallbackStore
+instanceKlass com/google/inject/spi/TypeEncounter
+instanceKlass com/google/inject/internal/SingleMemberInjector
+instanceKlass com/google/inject/internal/MembersInjectorStore
+instanceKlass com/google/inject/internal/TypeConverterBindingProcessor$4
+instanceKlass com/google/inject/internal/TypeConverterBindingProcessor$2
+instanceKlass com/google/inject/internal/TypeConverterBindingProcessor$1
+instanceKlass com/google/inject/internal/TypeConverterBindingProcessor$5
+instanceKlass com/google/inject/internal/FailableCache
+instanceKlass com/google/inject/internal/ConstructorInjectorStore
+instanceKlass com/google/inject/internal/DeferredLookups
+instanceKlass com/google/inject/spi/ProviderBinding
+instanceKlass com/google/inject/spi/ConvertedConstantBinding
+instanceKlass com/google/inject/internal/InjectorImpl
+instanceKlass com/google/inject/internal/Lookups
+instanceKlass com/google/inject/internal/InjectorImpl$InjectorOptions
+instanceKlass  @bci com/google/inject/internal/AbstractProcessor process (Lcom/google/inject/internal/InjectorImpl;Ljava/util/List;)V 13 <appendix> member <vmtarget> ; # com/google/inject/internal/AbstractProcessor$$Lambda+0x000000008d10e140
+instanceKlass  @bci com/google/inject/spi/BindingSourceRestriction check (Lcom/google/inject/internal/GuiceInternal;Ljava/util/List;)Lcom/google/common/collect/ImmutableList; 11 <appendix> argL0 ; # com/google/inject/spi/BindingSourceRestriction$$Lambda+0x000000008d10d840
+instanceKlass org/eclipse/sisu/wire/BeanProviders$3
+instanceKlass org/sonatype/inject/BeanEntry
+instanceKlass org/eclipse/sisu/BeanEntry
+instanceKlass org/eclipse/sisu/wire/BeanProviders$6
+instanceKlass com/google/inject/internal/ProvisionListenerStackCallback$ProvisionCallback
+instanceKlass com/google/inject/internal/ConstructorInjector
+instanceKlass com/google/inject/internal/DefaultConstructionProxyFactory$FastClassProxy
+instanceKlass  @bci com/google/inject/internal/aop/AbstractGlueGenerator lambda$bindSignaturesToInvokers$0 (Ljava/lang/invoke/MethodHandle;Ljava/util/function/ToIntFunction;Ljava/lang/String;)Ljava/util/function/BiFunction; 8 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x000000008d10bc00
+instanceKlass java/lang/ClassValue$RemovalToken
+instanceKlass  @bci com/google/inject/internal/aop/AbstractGlueGenerator bindSignaturesToInvokers (Ljava/util/function/ToIntFunction;Ljava/lang/invoke/MethodHandle;)Ljava/util/function/Function; 13 <appendix> member <vmtarget> ; # com/google/inject/internal/aop/AbstractGlueGenerator$$Lambda+0x000000008d10c230
+instanceKlass com/google/inject/internal/aop/ImmutableStringTrie
+instanceKlass java/util/function/ToIntFunction
+instanceKlass org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver$$FastClassByGuice$$961148
+instanceKlass com/google/inject/internal/aop/GeneratedClassDefiner
+# instanceKlass java/lang/ClassLoader$$DefineAccessByGuice$$+0x000000008d10b800
+instanceKlass java/lang/classfile/AccessFlags
+instanceKlass java/lang/classfile/MethodModel
+instanceKlass java/lang/classfile/FieldModel
+instanceKlass  @bci jdk/internal/classfile/impl/ClassFileImpl attributeMapper ()Ljava/util/function/Function; 7 <appendix> argL0 ; # jdk/internal/classfile/impl/ClassFileImpl$$Lambda+0x80000004b
+instanceKlass java/lang/classfile/ClassModel
+instanceKlass java/lang/classfile/AttributedElement
+instanceKlass java/lang/classfile/CompoundElement
+instanceKlass  @bci jdk/internal/reflect/DirectMethodHandleAccessor invokeImpl (Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object; 92 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x000000008d10b400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d10b000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d10ac00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d10a800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d10a400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d10a000
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d109c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d109800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d109400
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d109000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d108c00
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d108800
+instanceKlass java/lang/invoke/ClassSpecializer$Factory$1$5$1
+instanceKlass java/lang/invoke/ClassSpecializer$Factory$1$5
+instanceKlass java/lang/invoke/ClassSpecializer$Factory$1$4
+instanceKlass java/lang/invoke/ClassSpecializer$Factory$1$3
+instanceKlass java/lang/invoke/ClassSpecializer$Factory$1$2
+instanceKlass java/lang/invoke/ClassSpecializer$Factory$1$1Var
+instanceKlass java/lang/invoke/ClassSpecializer$Factory$1$1
+instanceKlass java/lang/invoke/ClassSpecializer$Factory$1
+instanceKlass java/lang/invoke/MethodHandles$1
+# instanceKlass java/lang/invoke/LambdaForm$BMH+0x000000008d108400
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d108000
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d106400
+instanceKlass sun/invoke/util/ValueConversions$1
+instanceKlass  @bci com/google/inject/internal/aop/UnsafeClassDefiner$ClassLoaderDefineClassHolder <clinit> ()V 0 <appendix> argL0 ; # com/google/inject/internal/aop/UnsafeClassDefiner$ClassLoaderDefineClassHolder$$Lambda+0x000000008d106800
+instanceKlass com/google/inject/internal/aop/UnsafeClassDefiner$ClassLoaderDefineClassHolder
+instanceKlass com/google/inject/internal/aop/BytecodeTasks
+instanceKlass  @bci com/google/inject/internal/aop/AbstractGlueGenerator generateTrampoline (Lorg/objectweb/asm/ClassWriter;Ljava/util/Collection;)V 30 <appendix> argL0 ; # com/google/inject/internal/aop/AbstractGlueGenerator$$Lambda+0x000000008d1078a0
+instanceKlass org/objectweb/asm/Handle
+instanceKlass org/objectweb/asm/Label
+instanceKlass com/google/inject/internal/aop/AbstractGlueGenerator
+instanceKlass  @bci com/google/inject/internal/aop/ClassBuilding buildFastClass (Ljava/lang/Class;)Ljava/util/function/Function; 20 <appendix> member <vmtarget> ; # com/google/inject/internal/aop/ClassBuilding$$Lambda+0x000000008d103a58
+instanceKlass  @bci com/google/inject/internal/aop/ClassBuilding buildFastClass (Ljava/lang/Class;)Ljava/util/function/Function; 10 <appendix> member <vmtarget> ; # com/google/inject/internal/aop/ClassBuilding$$Lambda+0x000000008d103818
+instanceKlass org/objectweb/asm/Type
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d106000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d105c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d105800
+# instanceKlass java/lang/invoke/LambdaForm$BMH+0x000000008d105400
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d105000
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x000000008d104c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d104800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d104400
+instanceKlass jdk/internal/vm/annotation/ForceInline
+instanceKlass  @bci com/google/inject/internal/aop/UnsafeClassDefiner <clinit> ()V 29 <appendix> argL0 ; # com/google/inject/internal/aop/UnsafeClassDefiner$$Lambda+0x000000008d1033d8
+instanceKlass com/google/inject/internal/aop/HiddenClassDefiner
+instanceKlass  @bci java/util/stream/Collectors joining (Ljava/lang/CharSequence;Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/util/stream/Collector; 22 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x800000043
+instanceKlass  @bci java/util/stream/Collectors joining (Ljava/lang/CharSequence;Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/util/stream/Collector; 17 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x800000041
+instanceKlass  @bci java/util/stream/Collectors joining (Ljava/lang/CharSequence;Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/util/stream/Collector; 12 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x80000003e
+instanceKlass  @bci java/util/stream/Collectors joining (Ljava/lang/CharSequence;Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/util/stream/Collector; 7 <appendix> member <vmtarget> ; # java/util/stream/Collectors$$Lambda+0x800000046
+instanceKlass  @bci java/lang/Class methodToString (Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/String; 42 <appendix> argL0 ; # java/lang/Class$$Lambda+0x000000008d02d148
+instanceKlass jdk/internal/reflect/FieldAccessorImpl
+instanceKlass jdk/internal/reflect/FieldAccessor
+instanceKlass sun/misc/Unsafe
+instanceKlass  @bci com/google/inject/internal/aop/UnsafeClassDefiner <clinit> ()V 11 <appendix> argL0 ; # com/google/inject/internal/aop/UnsafeClassDefiner$$Lambda+0x000000008d102f88
+instanceKlass com/google/inject/internal/aop/AnonymousClassDefiner
+instanceKlass java/security/PrivilegedExceptionAction
+instanceKlass com/google/inject/internal/aop/UnsafeClassDefiner
+instanceKlass com/google/inject/internal/aop/ClassDefining$ClassDefinerHolder
+instanceKlass com/google/inject/internal/aop/ClassDefiner
+instanceKlass com/google/inject/internal/aop/ClassDefining
+instanceKlass  @bci com/google/inject/internal/aop/ClassBuilding getOverridableObjectMethods ()[Ljava/lang/reflect/Method; 15 <appendix> member <vmtarget> ; # com/google/inject/internal/aop/ClassBuilding$$Lambda+0x000000008d1024d8
+instanceKlass  @cpi com/google/inject/internal/aop/ClassBuilding 315 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d104000
+instanceKlass  @bci com/google/inject/internal/BytecodeGen <clinit> ()V 25 <appendix> argL0 ; # com/google/inject/internal/BytecodeGen$$Lambda+0x000000008d102270
+instanceKlass com/google/inject/internal/BytecodeGen$EnhancerBuilder
+instanceKlass com/google/inject/internal/aop/ClassBuilding
+instanceKlass com/google/common/collect/MapMakerInternalMap$StrongValueEntry
+instanceKlass com/google/common/collect/MapMakerInternalMap$WeakKeyStrongValueEntry$Helper
+instanceKlass com/google/common/collect/MapMakerInternalMap$InternalEntry
+instanceKlass com/google/common/collect/MapMakerInternalMap$1
+instanceKlass com/google/common/collect/MapMakerInternalMap$InternalEntryHelper
+instanceKlass com/google/common/collect/MapMakerInternalMap$WeakValueReference
+instanceKlass com/google/common/collect/MapMaker
+instanceKlass com/google/inject/internal/BytecodeGen
+instanceKlass com/google/inject/internal/ConstructionProxy
+instanceKlass com/google/inject/internal/DefaultConstructionProxyFactory
+instanceKlass com/google/inject/internal/ConstructionProxyFactory
+instanceKlass com/google/inject/internal/ConstructorBindingImpl$Factory
+instanceKlass org/eclipse/sisu/inject/TypeArguments$Implicit
+instanceKlass org/eclipse/sisu/wire/BeanProviders$7
+instanceKlass org/eclipse/sisu/wire/BeanProviders$4
+instanceKlass org/eclipse/sisu/wire/BeanProviders$1
+instanceKlass org/eclipse/sisu/wire/PlaceholderBeanProvider
+instanceKlass com/google/inject/spi/ProviderLookup$1
+instanceKlass com/google/inject/spi/ProviderWithDependencies
+instanceKlass com/google/inject/spi/ProviderLookup
+instanceKlass org/eclipse/sisu/wire/BeanProviders
+instanceKlass org/eclipse/sisu/inject/HiddenSource
+instanceKlass org/eclipse/sisu/wire/LocatorWiring
+instanceKlass com/google/inject/ProvidedBy
+instanceKlass com/google/inject/ImplementedBy
+instanceKlass org/sonatype/plexus/components/cipher/PBECipher
+instanceKlass org/codehaus/classworlds/ClassRealm
+instanceKlass org/apache/maven/settings/crypto/SettingsDecryptionResult
+instanceKlass org/apache/maven/settings/building/DefaultSettingsProblemCollector
+instanceKlass org/apache/maven/settings/merge/MavenSettingsMerger
+instanceKlass org/apache/maven/settings/building/SettingsBuildingResult
+instanceKlass org/apache/maven/settings/building/SettingsProblemCollector
+instanceKlass org/eclipse/aether/impl/MetadataGenerator
+instanceKlass org/apache/maven/model/Relocation
+instanceKlass org/apache/maven/repository/internal/ArtifactDescriptorReaderDelegate
+instanceKlass org/eclipse/aether/named/support/AdaptedSemaphoreNamedLock$AdaptedSemaphore
+instanceKlass org/eclipse/aether/named/support/NamedLockSupport
+instanceKlass org/eclipse/aether/named/support/NamedLockFactorySupport$NamedLockHolder
+instanceKlass org/eclipse/aether/named/NamedLock
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapter
+instanceKlass org/eclipse/aether/spi/log/Logger
+instanceKlass org/eclipse/aether/internal/impl/filter/PrefixesRemoteRepositoryFilterSource$Node
+instanceKlass org/eclipse/aether/spi/connector/filter/RemoteRepositoryFilter$Result
+instanceKlass org/eclipse/aether/spi/connector/filter/RemoteRepositoryFilter
+instanceKlass org/eclipse/aether/collection/DependencyTraverser
+instanceKlass org/eclipse/aether/collection/DependencyManager
+instanceKlass org/eclipse/aether/internal/impl/collect/df/DfDependencyCollector$Args
+instanceKlass org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector$DescriptorResolutionResult
+instanceKlass org/eclipse/aether/internal/impl/collect/bf/BfDependencyCollector$Args
+instanceKlass org/eclipse/aether/internal/impl/collect/bf/DependencyProcessingContext
+instanceKlass org/eclipse/aether/internal/impl/collect/bf/DependencyResolutionSkipper
+instanceKlass org/eclipse/aether/graph/DefaultDependencyNode
+instanceKlass org/eclipse/aether/version/Version
+instanceKlass org/eclipse/aether/internal/impl/collect/PremanagedDependency
+instanceKlass org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate$Results
+instanceKlass org/eclipse/aether/internal/impl/collect/DefaultDependencyCollectionContext
+instanceKlass org/eclipse/aether/collection/DependencyCollectionContext
+instanceKlass org/eclipse/aether/internal/impl/collect/DataPool
+instanceKlass org/eclipse/aether/internal/impl/collect/DefaultVersionFilterContext
+instanceKlass org/eclipse/aether/collection/VersionFilter
+instanceKlass org/eclipse/aether/collection/DependencyGraphTransformationContext
+instanceKlass org/eclipse/aether/collection/VersionFilter$VersionFilterContext
+instanceKlass org/eclipse/aether/spi/connector/Transfer
+instanceKlass org/eclipse/aether/internal/impl/checksum/SummaryFileTrustedChecksumsSource$SummaryFileWriter
+instanceKlass org/eclipse/aether/internal/impl/checksum/SparseDirectoryTrustedChecksumsSource$SparseDirectoryWriter
+instanceKlass org/eclipse/aether/spi/checksums/TrustedChecksumsSource$Writer
+instanceKlass org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithm
+instanceKlass org/eclipse/aether/impl/UpdateCheck
+instanceKlass org/eclipse/aether/spi/connector/transport/Transporter
+instanceKlass java/nio/channels/FileLock
+instanceKlass org/eclipse/aether/resolution/ArtifactDescriptorRequest
+instanceKlass org/eclipse/aether/resolution/VersionRangeResult
+instanceKlass org/eclipse/aether/resolution/VersionRangeRequest
+instanceKlass org/eclipse/aether/resolution/DependencyResult
+instanceKlass org/eclipse/aether/resolution/DependencyRequest
+instanceKlass org/eclipse/aether/collection/CollectResult
+instanceKlass org/eclipse/aether/collection/CollectRequest
+instanceKlass org/eclipse/aether/resolution/VersionRequest
+instanceKlass java/util/concurrent/atomic/AtomicBoolean
+instanceKlass org/eclipse/aether/spi/connector/layout/RepositoryLayout
+instanceKlass org/eclipse/aether/RepositoryEvent
+instanceKlass org/eclipse/aether/repository/LocalRepository
+instanceKlass org/eclipse/aether/internal/impl/LocalPathPrefixComposer
+instanceKlass org/eclipse/aether/transform/FileTransformer
+instanceKlass org/eclipse/aether/installation/InstallResult
+instanceKlass org/eclipse/aether/installation/InstallRequest
+instanceKlass org/eclipse/aether/spi/io/FileProcessor$ProgressListener
+instanceKlass org/eclipse/aether/internal/impl/DefaultDeployer$EventCatapult
+instanceKlass org/eclipse/aether/deployment/DeployResult
+instanceKlass org/eclipse/aether/deployment/DeployRequest
+instanceKlass org/eclipse/aether/repository/RepositoryPolicy
+instanceKlass org/eclipse/aether/transfer/TransferResource
+instanceKlass org/eclipse/aether/spi/connector/checksum/ChecksumPolicy
+instanceKlass org/eclipse/aether/resolution/ArtifactRequest
+instanceKlass org/eclipse/aether/internal/impl/DefaultArtifactResolver$ResolutionGroup
+instanceKlass org/eclipse/aether/resolution/VersionResult
+instanceKlass org/eclipse/aether/repository/LocalArtifactResult
+instanceKlass org/eclipse/aether/SyncContext
+instanceKlass org/eclipse/aether/spi/locator/ServiceLocator
+instanceKlass org/eclipse/aether/repository/RemoteRepository
+instanceKlass org/eclipse/aether/spi/connector/RepositoryConnector
+instanceKlass org/apache/maven/model/validation/DefaultModelValidator$1ActivationFrame
+instanceKlass org/apache/maven/model/profile/activation/JdkVersionProfileActivator$RangeValue
+instanceKlass org/apache/maven/model/InputLocation
+instanceKlass org/apache/maven/model/InputSource
+instanceKlass org/apache/maven/model/interpolation/StringVisitorModelInterpolator$InnerInterpolator
+instanceKlass org/apache/maven/model/building/ModelData
+instanceKlass org/apache/maven/model/building/ModelBuildingEventCatapult
+instanceKlass org/apache/maven/model/ActivationFile
+instanceKlass org/apache/maven/model/profile/DefaultProfileActivationContext
+instanceKlass org/apache/maven/model/ActivationOS
+instanceKlass org/apache/maven/model/Activation
+instanceKlass org/apache/maven/model/ActivationProperty
+instanceKlass org/apache/maven/model/building/DefaultModelProblemCollector
+instanceKlass org/codehaus/plexus/interpolation/RegexBasedInterpolator
+instanceKlass org/apache/maven/model/building/ModelCacheTag
+instanceKlass org/apache/maven/model/building/ModelBuildingEvent
+instanceKlass org/apache/maven/model/profile/ProfileActivationContext
+instanceKlass org/apache/maven/model/building/ModelProblemCollectorExt
+instanceKlass org/apache/maven/cli/internal/extension/model/CoreExtension
+instanceKlass org/apache/maven/building/ProblemCollector
+instanceKlass org/apache/maven/toolchain/merge/MavenToolchainMerger
+instanceKlass org/codehaus/plexus/interpolation/InterpolationPostProcessor
+instanceKlass org/apache/maven/toolchain/building/ToolchainsBuildingResult
+instanceKlass org/eclipse/aether/graph/Dependency
+instanceKlass org/eclipse/aether/resolution/ArtifactDescriptorResult
+instanceKlass org/apache/maven/plugin/internal/DefaultPluginValidationManager$PluginValidationIssues
+instanceKlass com/google/inject/util/Types
+instanceKlass org/eclipse/sisu/Nullable
+instanceKlass org/eclipse/aether/repository/AuthenticationSelector
+instanceKlass org/eclipse/aether/repository/ProxySelector
+instanceKlass org/eclipse/aether/repository/MirrorSelector
+instanceKlass org/eclipse/aether/resolution/ResolutionErrorPolicy
+instanceKlass org/eclipse/aether/repository/LocalRepositoryManager
+instanceKlass org/apache/maven/classrealm/ClassRealmManagerDelegate
+instanceKlass org/apache/maven/classrealm/ClassRealmConstituent
+instanceKlass org/apache/maven/classrealm/ClassRealmRequest
+instanceKlass org/eclipse/aether/repository/WorkspaceRepository
+instanceKlass org/apache/maven/ArtifactFilterManagerDelegate
+instanceKlass org/apache/maven/lifecycle/internal/PhaseRecorder
+instanceKlass org/apache/maven/lifecycle/internal/DependencyContext
+instanceKlass org/apache/maven/lifecycle/internal/ProjectIndex
+instanceKlass org/apache/maven/plugin/MojoExecutionRunner
+instanceKlass org/apache/maven/repository/legacy/resolver/conflict/DefaultConflictResolverFactory
+instanceKlass org/apache/maven/repository/legacy/repository/DefaultArtifactRepositoryFactory
+instanceKlass org/eclipse/aether/DefaultRepositorySystemSession
+instanceKlass org/apache/maven/execution/MavenExecutionResult
+instanceKlass org/apache/maven/DefaultMaven
+instanceKlass org/eclipse/aether/resolution/ArtifactResult
+instanceKlass org/eclipse/aether/collection/DependencySelector
+instanceKlass org/eclipse/aether/resolution/ArtifactDescriptorPolicy
+instanceKlass org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver
+instanceKlass org/apache/maven/execution/DefaultRuntimeInformation
+instanceKlass org/apache/maven/configuration/BeanConfigurationRequest
+instanceKlass org/codehaus/plexus/component/configurator/converters/lookup/ConverterLookup
+instanceKlass org/apache/maven/configuration/internal/DefaultBeanConfigurator
+instanceKlass org/apache/maven/project/artifact/DefaultMavenMetadataCache$CacheKey
+instanceKlass org/apache/maven/project/artifact/DefaultMavenMetadataCache
+instanceKlass org/apache/maven/artifact/versioning/ArtifactVersion
+instanceKlass org/apache/maven/repository/metadata/DefaultGraphConflictResolutionPolicy
+instanceKlass org/apache/maven/rtinfo/internal/DefaultRuntimeInformation
+instanceKlass org/apache/maven/execution/ProjectExecutionListener
+instanceKlass org/apache/maven/repository/legacy/resolver/conflict/NewestConflictResolver
+instanceKlass org/apache/maven/plugin/DefaultBuildPluginManager
+instanceKlass org/apache/maven/artifact/repository/layout/FlatRepositoryLayout
+instanceKlass org/apache/maven/lifecycle/internal/DefaultLifecycleExecutionPlanCalculator
+instanceKlass org/apache/maven/plugin/descriptor/Parameter
+instanceKlass org/apache/maven/lifecycle/internal/DefaultMojoExecutionConfigurator
+instanceKlass org/apache/maven/plugin/internal/DefaultPluginManager
+instanceKlass org/sonatype/plexus/components/sec/dispatcher/PasswordDecryptor
+instanceKlass sun/reflect/generics/tree/MethodTypeSignature
+instanceKlass sun/reflect/generics/tree/VoidDescriptor
+instanceKlass org/sonatype/plexus/components/sec/dispatcher/model/SettingsSecurity
+instanceKlass org/apache/maven/project/path/DefaultPathTranslator
+instanceKlass org/apache/maven/lifecycle/DefaultLifecycleExecutor
+instanceKlass org/apache/maven/artifact/repository/DefaultArtifactRepositoryFactory
+instanceKlass org/apache/maven/plugin/PluginRealmCache$PluginRealmSupplier
+instanceKlass org/apache/maven/plugin/PluginRealmCache$Key
+instanceKlass org/apache/maven/plugin/DefaultPluginRealmCache
+instanceKlass org/apache/maven/execution/ExecutionEvent
+instanceKlass org/apache/maven/lifecycle/internal/DefaultExecutionEventCatapult
+instanceKlass org/apache/maven/project/ReactorModelPool
+instanceKlass org/apache/maven/model/building/ModelBuildingResult
+instanceKlass org/apache/maven/project/DefaultProjectBuilder$InternalConfig
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d0e6000
+instanceKlass org/apache/maven/model/resolution/ModelResolver
+instanceKlass org/apache/maven/model/building/ModelBuildingListener
+instanceKlass org/apache/maven/model/building/ModelCache
+instanceKlass org/apache/maven/project/DefaultProjectBuilder
+instanceKlass org/apache/maven/plugin/internal/DefaultLegacySupport
+instanceKlass org/apache/maven/plugin/PluginArtifactsCache$CacheRecord
+instanceKlass org/apache/maven/plugin/PluginArtifactsCache$Key
+instanceKlass org/apache/maven/plugin/DefaultPluginArtifactsCache
+instanceKlass org/apache/maven/project/ProjectBuildingResult
+instanceKlass org/apache/maven/exception/ExceptionSummary
+instanceKlass org/apache/maven/exception/DefaultExceptionHandler
+instanceKlass org/apache/maven/artifact/resolver/DefaultArtifactResolver
+instanceKlass org/apache/maven/execution/BuildSummary
+instanceKlass org/apache/maven/repository/legacy/resolver/DefaultLegacyArtifactCollector
+instanceKlass org/apache/maven/project/DefaultDependencyResolutionResult
+instanceKlass org/apache/maven/project/DependencyResolutionRequest
+instanceKlass org/apache/maven/project/DependencyResolutionResult
+instanceKlass org/apache/maven/project/DefaultProjectDependenciesResolver
+instanceKlass org/apache/maven/toolchain/DefaultToolchainsBuilder
+instanceKlass org/apache/maven/repository/ArtifactTransferListener
+instanceKlass org/apache/maven/repository/legacy/LegacyRepositorySystem
+instanceKlass org/apache/maven/settings/crypto/SettingsDecryptionRequest
+instanceKlass org/apache/maven/lifecycle/mapping/LifecyclePhase
+instanceKlass org/apache/maven/lifecycle/internal/DefaultLifecyclePluginAnalyzer$GoalSpec
+instanceKlass org/apache/maven/lifecycle/internal/DefaultLifecyclePluginAnalyzer
+instanceKlass org/apache/maven/repository/legacy/resolver/conflict/OldestConflictResolver
+instanceKlass org/apache/maven/plugin/version/internal/DefaultPluginVersionResolver$Versions
+instanceKlass org/apache/maven/plugin/version/internal/DefaultPluginVersionResult
+instanceKlass org/apache/maven/plugin/version/internal/DefaultPluginVersionResolver$Key
+instanceKlass org/apache/maven/plugin/version/PluginVersionResult
+instanceKlass org/eclipse/aether/version/VersionScheme
+instanceKlass org/apache/maven/plugin/version/internal/DefaultPluginVersionResolver
+instanceKlass org/apache/maven/lifecycle/internal/builder/multithreaded/ConcurrencyDependencyGraph
+instanceKlass org/apache/maven/lifecycle/internal/builder/multithreaded/ThreadOutputMuxer
+instanceKlass org/apache/maven/lifecycle/internal/TaskSegment
+instanceKlass org/apache/maven/lifecycle/internal/ProjectSegment
+instanceKlass java/util/concurrent/CompletionService
+instanceKlass org/apache/maven/lifecycle/internal/builder/multithreaded/MultiThreadedBuilder
+instanceKlass org/apache/maven/project/DefaultProjectBuildingHelper
+instanceKlass org/apache/maven/model/building/Result
+instanceKlass org/apache/maven/execution/ProjectDependencyGraph
+instanceKlass org/apache/maven/graph/DefaultGraphBuilder
+instanceKlass org/apache/maven/lifecycle/mapping/DefaultLifecycleMapping
+instanceKlass org/apache/maven/wagon/observers/ChecksumObserver
+instanceKlass org/apache/maven/repository/legacy/DefaultWagonManager
+instanceKlass org/apache/maven/toolchain/DefaultToolchainManager
+instanceKlass org/apache/maven/lifecycle/internal/DefaultLifecycleTaskSegmentCalculator
+instanceKlass org/apache/http/config/Registry
+instanceKlass org/apache/http/impl/conn/PoolingHttpClientConnectionManager
+instanceKlass org/apache/http/pool/ConnPoolControl
+instanceKlass org/apache/http/client/methods/CloseableHttpResponse
+instanceKlass org/apache/http/HttpResponse
+instanceKlass org/apache/maven/wagon/shared/http/BasicAuthScope
+instanceKlass org/apache/maven/wagon/shared/http/HttpConfiguration
+instanceKlass org/apache/http/impl/client/CloseableHttpClient
+instanceKlass org/apache/http/client/HttpClient
+instanceKlass org/apache/http/Header
+instanceKlass org/apache/http/NameValuePair
+instanceKlass org/apache/http/client/RedirectStrategy
+instanceKlass org/apache/http/config/Lookup
+instanceKlass org/apache/http/conn/ssl/TrustStrategy
+instanceKlass org/apache/http/ssl/TrustStrategy
+instanceKlass org/apache/http/client/HttpRequestRetryHandler
+instanceKlass org/apache/http/auth/Credentials
+instanceKlass org/apache/http/client/AuthCache
+instanceKlass org/apache/http/client/CredentialsProvider
+instanceKlass org/apache/http/client/ServiceUnavailableRetryStrategy
+instanceKlass org/apache/http/protocol/HttpContext
+instanceKlass org/apache/http/HttpEntity
+instanceKlass org/apache/http/client/methods/HttpUriRequest
+instanceKlass org/apache/http/HttpRequest
+instanceKlass org/apache/http/HttpMessage
+instanceKlass org/apache/http/auth/AuthScheme
+instanceKlass org/apache/http/conn/HttpClientConnectionManager
+instanceKlass org/apache/maven/wagon/InputData
+instanceKlass org/apache/maven/wagon/OutputData
+instanceKlass org/apache/maven/wagon/events/SessionListener
+instanceKlass java/util/EventObject
+instanceKlass org/apache/maven/wagon/resource/Resource
+instanceKlass org/apache/maven/wagon/repository/RepositoryPermissions
+instanceKlass org/apache/maven/wagon/proxy/ProxyInfo
+instanceKlass org/apache/maven/wagon/authentication/AuthenticationInfo
+instanceKlass org/apache/maven/wagon/events/TransferEventSupport
+instanceKlass org/apache/maven/wagon/events/SessionEventSupport
+instanceKlass org/apache/maven/wagon/repository/Repository
+instanceKlass org/apache/maven/wagon/proxy/ProxyInfoProvider
+instanceKlass org/apache/maven/wagon/AbstractWagon
+instanceKlass org/apache/maven/wagon/StreamingWagon
+instanceKlass org/apache/maven/DefaultProjectDependenciesResolver
+instanceKlass org/apache/maven/artifact/repository/metadata/Versioning
+instanceKlass org/apache/maven/repository/legacy/resolver/conflict/NearestConflictResolver
+instanceKlass org/apache/maven/model/merge/ModelMerger
+instanceKlass org/apache/maven/model/plugin/DefaultLifecycleBindingsInjector
+instanceKlass org/apache/maven/project/artifact/MavenMetadataSource$ProjectRelocation
+instanceKlass org/apache/maven/model/building/ModelProblem
+instanceKlass org/apache/maven/repository/legacy/metadata/MetadataResolutionRequest
+instanceKlass org/apache/maven/repository/legacy/metadata/ResolutionGroup
+instanceKlass org/apache/maven/project/artifact/MavenMetadataSource
+instanceKlass org/apache/maven/toolchain/model/TrackableBase
+instanceKlass org/apache/maven/toolchain/DefaultToolchain
+instanceKlass org/apache/maven/toolchain/ToolchainPrivate
+instanceKlass org/apache/maven/toolchain/java/JavaToolchain
+instanceKlass org/apache/maven/toolchain/Toolchain
+instanceKlass org/apache/maven/toolchain/java/JavaToolchainFactory
+instanceKlass org/apache/maven/artifact/factory/DefaultArtifactFactory
+instanceKlass org/apache/maven/artifact/repository/metadata/RepositoryMetadata
+instanceKlass org/apache/maven/model/Reporting
+instanceKlass org/apache/maven/model/PluginContainer
+instanceKlass org/apache/maven/project/inheritance/DefaultModelInheritanceAssembler
+instanceKlass org/apache/maven/project/ProjectRealmCache$CacheRecord
+instanceKlass org/apache/maven/project/ProjectRealmCache$Key
+instanceKlass org/apache/maven/project/DefaultProjectRealmCache
+instanceKlass org/apache/maven/settings/building/SettingsBuildingRequest
+instanceKlass org/apache/maven/plugin/PluginRealmCache$CacheRecord
+instanceKlass org/eclipse/aether/graph/DependencyFilter
+instanceKlass org/eclipse/aether/util/graph/visitor/AbstractDepthFirstNodeListGenerator
+instanceKlass org/eclipse/aether/graph/DependencyNode
+instanceKlass org/apache/maven/plugin/descriptor/PluginDescriptorBuilder
+instanceKlass org/codehaus/plexus/component/configurator/expression/ExpressionEvaluator
+instanceKlass org/codehaus/plexus/configuration/PlexusConfiguration
+instanceKlass org/apache/maven/plugin/logging/Log
+instanceKlass org/apache/maven/plugin/version/PluginVersionRequest
+instanceKlass org/codehaus/plexus/component/configurator/ConfigurationListener
+instanceKlass org/eclipse/aether/graph/DependencyVisitor
+instanceKlass org/apache/maven/plugin/internal/DefaultMavenPluginManager
+instanceKlass org/apache/maven/artifact/metadata/ArtifactMetadata
+instanceKlass org/apache/maven/repository/legacy/metadata/ArtifactMetadata
+instanceKlass org/apache/maven/artifact/repository/layout/DefaultRepositoryLayout
+instanceKlass org/apache/maven/repository/metadata/ClasspathContainer
+instanceKlass org/apache/maven/repository/metadata/DefaultClasspathTransformation
+instanceKlass org/apache/maven/plugin/ExtensionRealmCache$CacheRecord
+instanceKlass org/apache/maven/plugin/ExtensionRealmCache$Key
+instanceKlass org/apache/maven/plugin/DefaultExtensionRealmCache
+instanceKlass org/apache/maven/repository/legacy/resolver/transform/DefaultArtifactTransformationManager
+instanceKlass org/apache/maven/artifact/repository/metadata/Metadata
+instanceKlass org/apache/maven/artifact/repository/metadata/io/DefaultMetadataReader
+instanceKlass org/apache/maven/lifecycle/internal/DefaultLifecycleMappingDelegate
+instanceKlass org/apache/maven/wagon/events/TransferListener
+instanceKlass org/apache/maven/profiles/ProfileManager
+instanceKlass org/apache/maven/model/building/ModelSource
+instanceKlass org/apache/maven/project/ProjectBuilderConfiguration
+instanceKlass org/apache/maven/project/DefaultMavenProjectBuilder
+instanceKlass org/apache/maven/project/validation/ModelValidationResult
+instanceKlass org/apache/maven/model/ModelBase
+instanceKlass org/apache/maven/model/building/ModelBuildingRequest
+instanceKlass org/apache/maven/model/building/ModelProblemCollector
+instanceKlass org/apache/maven/project/validation/DefaultModelValidator
+instanceKlass org/eclipse/aether/artifact/Artifact
+instanceKlass org/apache/maven/project/artifact/ProjectArtifactsCache$CacheRecord
+instanceKlass org/apache/maven/project/artifact/ProjectArtifactsCache$Key
+instanceKlass org/apache/maven/project/artifact/DefaultProjectArtifactsCache
+instanceKlass org/apache/maven/artifact/repository/Authentication
+instanceKlass org/apache/maven/artifact/versioning/VersionRange
+instanceKlass org/apache/maven/model/Dependency
+instanceKlass org/apache/maven/settings/RepositoryBase
+instanceKlass org/apache/maven/model/RepositoryBase
+instanceKlass org/apache/maven/settings/RepositoryPolicy
+instanceKlass org/apache/maven/model/RepositoryPolicy
+instanceKlass org/apache/maven/repository/Proxy
+instanceKlass org/apache/maven/artifact/repository/ArtifactRepositoryPolicy
+instanceKlass org/apache/maven/artifact/Artifact
+instanceKlass org/apache/maven/artifact/resolver/filter/ArtifactFilter
+instanceKlass org/apache/maven/settings/TrackableBase
+instanceKlass org/apache/maven/artifact/repository/ArtifactRepository
+instanceKlass org/apache/maven/repository/DefaultMirrorSelector
+instanceKlass org/apache/maven/artifact/handler/manager/DefaultArtifactHandlerManager
+instanceKlass org/eclipse/aether/RequestTrace
+instanceKlass org/apache/maven/plugin/prefix/PluginPrefixRequest
+instanceKlass org/eclipse/aether/repository/ArtifactRepository
+instanceKlass org/eclipse/aether/metadata/Metadata
+instanceKlass org/apache/maven/plugin/prefix/PluginPrefixResult
+instanceKlass org/apache/maven/plugin/prefix/internal/DefaultPluginPrefixResolver
+instanceKlass org/eclipse/aether/RepositoryListener
+instanceKlass org/apache/maven/profiles/ProfilesRoot
+instanceKlass org/codehaus/plexus/logging/AbstractLogEnabled
+instanceKlass org/apache/maven/artifact/resolver/ArtifactResolutionResult
+instanceKlass org/apache/maven/artifact/resolver/ArtifactResolutionRequest
+instanceKlass org/apache/maven/artifact/repository/RepositoryRequest
+instanceKlass org/apache/maven/artifact/resolver/DefaultResolutionErrorHandler
+instanceKlass org/eclipse/aether/RepositorySystemSession
+instanceKlass org/apache/maven/model/ConfigurationContainer
+instanceKlass org/apache/maven/model/InputLocationTracker
+instanceKlass org/codehaus/plexus/component/repository/ComponentSetDescriptor
+instanceKlass org/apache/maven/plugin/PluginDescriptorCache$PluginDescriptorSupplier
+instanceKlass org/apache/maven/plugin/PluginDescriptorCache$Key
+instanceKlass org/apache/maven/plugin/DefaultPluginDescriptorCache
+instanceKlass org/apache/maven/artifact/resolver/ResolutionNode
+instanceKlass org/apache/maven/repository/legacy/resolver/conflict/FarthestConflictResolver
+instanceKlass org/apache/maven/lifecycle/MavenExecutionPlan
+instanceKlass org/apache/maven/lifecycle/internal/ReactorBuildStatus
+instanceKlass org/apache/maven/lifecycle/internal/ProjectBuildList
+instanceKlass org/apache/maven/lifecycle/internal/ReactorContext
+instanceKlass org/apache/maven/lifecycle/internal/builder/singlethreaded/SingleThreadedBuilder
+instanceKlass org/apache/maven/artifact/handler/DefaultArtifactHandler
+instanceKlass org/objectweb/asm/Handler
+instanceKlass org/objectweb/asm/Frame
+instanceKlass org/objectweb/asm/ByteVector
+instanceKlass org/objectweb/asm/Symbol
+instanceKlass org/objectweb/asm/SymbolTable
+instanceKlass org/objectweb/asm/RecordComponentVisitor
+instanceKlass org/objectweb/asm/ModuleVisitor
+instanceKlass org/objectweb/asm/MethodVisitor
+instanceKlass org/objectweb/asm/FieldVisitor
+instanceKlass org/apache/maven/repository/metadata/MetadataGraphEdge
+instanceKlass org/apache/maven/repository/metadata/MetadataGraph
+instanceKlass org/apache/maven/repository/metadata/MetadataGraphVertex
+instanceKlass org/apache/maven/repository/metadata/DefaultGraphConflictResolver
+instanceKlass com/google/inject/spi/ProviderWithExtensionVisitor
+instanceKlass com/google/common/collect/Iterables
+instanceKlass java/util/stream/ForEachOps$ForEachOp
+instanceKlass java/util/stream/ForEachOps
+instanceKlass  @bci com/google/inject/spi/InjectionPoint forConstructorOf (Lcom/google/inject/TypeLiteral;Z)Lcom/google/inject/spi/InjectionPoint; 83 <appendix> member <vmtarget> ; # com/google/inject/spi/InjectionPoint$$Lambda+0x000000008d0b3aa0
+instanceKlass  @bci com/google/inject/spi/InjectionPoint forConstructorOf (Lcom/google/inject/TypeLiteral;Z)Lcom/google/inject/spi/InjectionPoint; 67 <appendix> argL0 ; # com/google/inject/spi/InjectionPoint$$Lambda+0x000000008d0b3848
+instanceKlass  @bci com/google/inject/spi/InjectionPoint forConstructorOf (Lcom/google/inject/TypeLiteral;Z)Lcom/google/inject/spi/InjectionPoint; 57 <appendix> argL0 ; # com/google/inject/spi/InjectionPoint$$Lambda+0x000000008d0b35f0
+instanceKlass  @bci com/google/inject/spi/InjectionPoint forConstructorOf (Lcom/google/inject/TypeLiteral;Z)Lcom/google/inject/spi/InjectionPoint; 24 <appendix> argL0 ; # com/google/inject/spi/InjectionPoint$$Lambda+0x000000008d0b3398
+instanceKlass org/eclipse/sisu/plexus/PlexusBean
+instanceKlass org/codehaus/plexus/component/repository/ComponentDescriptor
+instanceKlass com/google/inject/spi/ProvidesMethodBinding
+instanceKlass org/eclipse/sisu/inject/Guice4
+instanceKlass com/google/inject/internal/GuiceInternal
+instanceKlass org/sonatype/inject/Parameters
+instanceKlass org/eclipse/sisu/plexus/PlexusXmlBeanConverter
+instanceKlass org/eclipse/sisu/plexus/PlexusBeanConverter
+instanceKlass com/google/inject/spi/TypeConverterBinding
+instanceKlass java/lang/reflect/AnnotatedParameterizedType
+instanceKlass sun/reflect/generics/tree/Wildcard
+instanceKlass sun/reflect/generics/tree/BottomSignature
+instanceKlass org/eclipse/sisu/inject/DefaultRankingFunction
+instanceKlass com/google/inject/spi/ProvisionListenerBinding
+instanceKlass com/google/inject/spi/TypeListenerBinding
+instanceKlass org/eclipse/sisu/bean/BeanListener
+instanceKlass com/google/inject/matcher/Matchers
+instanceKlass org/eclipse/sisu/bean/PropertyBinder
+instanceKlass org/eclipse/sisu/plexus/PlexusBeanBinder
+instanceKlass com/google/inject/spi/InjectionListener
+instanceKlass org/sonatype/plexus/components/sec/dispatcher/DefaultSecDispatcher
+instanceKlass org/sonatype/plexus/components/cipher/DefaultPlexusCipher
+instanceKlass org/sonatype/plexus/components/cipher/PlexusCipher
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d0b4000
+instanceKlass java/lang/invoke/MethodHandle$1
+instanceKlass org/codehaus/plexus/component/configurator/AbstractComponentConfigurator
+instanceKlass org/codehaus/plexus/component/configurator/ComponentConfigurator
+instanceKlass org/apache/maven/settings/validation/DefaultSettingsValidator
+instanceKlass org/apache/maven/settings/validation/SettingsValidator
+instanceKlass org/apache/maven/settings/io/DefaultSettingsWriter
+instanceKlass org/apache/maven/settings/io/SettingsWriter
+instanceKlass org/apache/maven/settings/io/DefaultSettingsReader
+instanceKlass org/apache/maven/settings/io/SettingsReader
+instanceKlass org/apache/maven/settings/crypto/DefaultSettingsDecrypter
+instanceKlass org/apache/maven/settings/crypto/SettingsDecrypter
+instanceKlass org/apache/maven/settings/building/DefaultSettingsBuilder
+instanceKlass org/apache/maven/settings/building/SettingsBuilder
+instanceKlass org/eclipse/aether/transport/wagon/WagonTransporterFactory
+instanceKlass org/eclipse/aether/internal/transport/wagon/PlexusWagonProvider
+instanceKlass org/eclipse/aether/transport/wagon/WagonProvider
+instanceKlass org/eclipse/aether/internal/transport/wagon/PlexusWagonConfigurator
+instanceKlass org/eclipse/aether/transport/wagon/WagonConfigurator
+instanceKlass org/eclipse/aether/transport/http/ChecksumExtractor
+instanceKlass org/eclipse/aether/transport/http/HttpTransporterFactory
+instanceKlass org/eclipse/aether/transport/file/FileTransporterFactory
+instanceKlass org/eclipse/aether/spi/connector/transport/TransporterFactory
+instanceKlass org/apache/maven/repository/internal/VersionsMetadataGeneratorFactory
+instanceKlass org/apache/maven/repository/internal/SnapshotMetadataGeneratorFactory
+instanceKlass org/apache/maven/repository/internal/PluginsMetadataGeneratorFactory
+instanceKlass org/eclipse/aether/impl/MetadataGeneratorFactory
+instanceKlass org/apache/maven/repository/internal/DefaultVersionResolver
+instanceKlass org/eclipse/aether/impl/VersionResolver
+instanceKlass org/apache/maven/repository/internal/DefaultVersionRangeResolver
+instanceKlass org/eclipse/aether/impl/VersionRangeResolver
+instanceKlass org/apache/maven/repository/internal/DefaultModelCacheFactory
+instanceKlass org/apache/maven/repository/internal/ModelCacheFactory
+instanceKlass org/apache/maven/repository/internal/DefaultArtifactDescriptorReader
+instanceKlass org/eclipse/aether/impl/ArtifactDescriptorReader
+instanceKlass org/eclipse/aether/named/support/NamedLockFactorySupport
+instanceKlass org/eclipse/aether/named/NamedLockFactory
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/providers/StaticNameMapperProvider
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/providers/GAVNameMapperProvider
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/providers/FileStaticNameMapperProvider
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/providers/FileHashingGAVNameMapperProvider
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/providers/FileGAVNameMapperProvider
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/NameMapper
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/providers/DiscriminatingNameMapperProvider
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapterFactoryImpl
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapterFactory
+instanceKlass org/eclipse/aether/internal/impl/synccontext/legacy/DefaultSyncContextFactory
+instanceKlass org/eclipse/aether/impl/SyncContextFactory
+instanceKlass org/eclipse/aether/internal/impl/synccontext/DefaultSyncContextFactory
+instanceKlass org/eclipse/aether/spi/synccontext/SyncContextFactory
+instanceKlass java/lang/Deprecated
+instanceKlass org/eclipse/aether/internal/impl/slf4j/Slf4jLoggerFactory
+instanceKlass org/eclipse/aether/internal/impl/resolution/ArtifactResolverPostProcessorSupport
+instanceKlass org/eclipse/aether/internal/impl/filter/RemoteRepositoryFilterSourceSupport
+instanceKlass org/eclipse/aether/spi/connector/filter/RemoteRepositoryFilterSource
+instanceKlass org/eclipse/aether/spi/resolution/ArtifactResolverPostProcessor
+instanceKlass org/eclipse/aether/internal/impl/filter/DefaultRemoteRepositoryFilterManager
+instanceKlass org/eclipse/aether/impl/RemoteRepositoryFilterManager
+instanceKlass org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate
+instanceKlass org/eclipse/aether/internal/impl/collect/DefaultDependencyCollector
+instanceKlass org/eclipse/aether/impl/DependencyCollector
+instanceKlass org/eclipse/aether/internal/impl/checksum/TrustedToProvidedChecksumsSourceAdapter
+instanceKlass org/eclipse/aether/spi/checksums/ProvidedChecksumsSource
+instanceKlass org/eclipse/aether/internal/impl/checksum/FileTrustedChecksumsSourceSupport
+instanceKlass org/eclipse/aether/spi/checksums/TrustedChecksumsSource
+instanceKlass org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithmFactorySupport
+instanceKlass org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithmFactory
+instanceKlass org/eclipse/aether/internal/impl/checksum/DefaultChecksumAlgorithmFactorySelector
+instanceKlass org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithmFactorySelector
+instanceKlass org/eclipse/aether/internal/impl/SimpleLocalRepositoryManagerFactory
+instanceKlass org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactory
+instanceKlass org/eclipse/aether/spi/connector/layout/RepositoryLayoutFactory
+instanceKlass org/eclipse/aether/spi/log/LoggerFactory
+instanceKlass org/eclipse/aether/internal/impl/LoggerFactoryProvider
+instanceKlass org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerFactory
+instanceKlass org/eclipse/aether/spi/localrepo/LocalRepositoryManagerFactory
+instanceKlass org/eclipse/aether/internal/impl/DefaultUpdatePolicyAnalyzer
+instanceKlass org/eclipse/aether/impl/UpdatePolicyAnalyzer
+instanceKlass org/eclipse/aether/internal/impl/DefaultUpdateCheckManager
+instanceKlass org/eclipse/aether/impl/UpdateCheckManager
+instanceKlass org/eclipse/aether/internal/impl/DefaultTransporterProvider
+instanceKlass org/eclipse/aether/spi/connector/transport/TransporterProvider
+instanceKlass org/eclipse/aether/internal/impl/DefaultTrackingFileManager
+instanceKlass org/eclipse/aether/internal/impl/TrackingFileManager
+instanceKlass org/eclipse/aether/internal/impl/DefaultRepositorySystemLifecycle
+instanceKlass org/eclipse/aether/impl/RepositorySystemLifecycle
+instanceKlass org/eclipse/aether/internal/impl/DefaultRepositorySystem
+instanceKlass org/eclipse/aether/RepositorySystem
+instanceKlass org/eclipse/aether/internal/impl/DefaultRepositoryLayoutProvider
+instanceKlass org/eclipse/aether/spi/connector/layout/RepositoryLayoutProvider
+instanceKlass org/eclipse/aether/internal/impl/DefaultRepositoryEventDispatcher
+instanceKlass org/eclipse/aether/impl/RepositoryEventDispatcher
+instanceKlass org/eclipse/aether/internal/impl/DefaultRepositoryConnectorProvider
+instanceKlass org/eclipse/aether/impl/RepositoryConnectorProvider
+instanceKlass org/eclipse/aether/internal/impl/DefaultRemoteRepositoryManager
+instanceKlass org/eclipse/aether/impl/RemoteRepositoryManager
+instanceKlass org/eclipse/aether/internal/impl/DefaultOfflineController
+instanceKlass org/eclipse/aether/impl/OfflineController
+instanceKlass org/eclipse/aether/internal/impl/DefaultMetadataResolver
+instanceKlass org/eclipse/aether/impl/MetadataResolver
+instanceKlass org/eclipse/aether/internal/impl/DefaultLocalRepositoryProvider
+instanceKlass org/eclipse/aether/impl/LocalRepositoryProvider
+instanceKlass org/eclipse/aether/internal/impl/LocalPathPrefixComposerFactorySupport
+instanceKlass org/eclipse/aether/internal/impl/LocalPathPrefixComposerFactory
+instanceKlass org/eclipse/aether/internal/impl/DefaultLocalPathComposer
+instanceKlass org/eclipse/aether/internal/impl/LocalPathComposer
+instanceKlass org/eclipse/aether/internal/impl/DefaultInstaller
+instanceKlass org/eclipse/aether/impl/Installer
+instanceKlass org/eclipse/aether/internal/impl/DefaultFileProcessor
+instanceKlass org/eclipse/aether/spi/io/FileProcessor
+instanceKlass org/eclipse/aether/internal/impl/DefaultDeployer
+instanceKlass org/eclipse/aether/impl/Deployer
+instanceKlass org/eclipse/aether/internal/impl/DefaultChecksumPolicyProvider
+instanceKlass org/eclipse/aether/spi/connector/checksum/ChecksumPolicyProvider
+instanceKlass org/eclipse/aether/internal/impl/DefaultArtifactResolver
+instanceKlass org/eclipse/aether/impl/ArtifactResolver
+instanceKlass org/eclipse/aether/connector/basic/BasicRepositoryConnectorFactory
+instanceKlass org/eclipse/aether/spi/locator/Service
+instanceKlass org/eclipse/aether/spi/connector/RepositoryConnectorFactory
+instanceKlass org/apache/maven/model/validation/DefaultModelValidator
+instanceKlass org/apache/maven/model/validation/ModelValidator
+instanceKlass org/apache/maven/model/superpom/DefaultSuperPomProvider
+instanceKlass org/apache/maven/model/superpom/SuperPomProvider
+instanceKlass org/apache/maven/model/profile/activation/PropertyProfileActivator
+instanceKlass org/apache/maven/model/profile/activation/OperatingSystemProfileActivator
+instanceKlass org/apache/maven/model/profile/activation/JdkVersionProfileActivator
+instanceKlass org/apache/maven/model/profile/activation/FileProfileActivator
+instanceKlass org/apache/maven/model/profile/activation/ProfileActivator
+instanceKlass org/apache/maven/model/profile/DefaultProfileSelector
+instanceKlass org/apache/maven/model/profile/ProfileSelector
+instanceKlass org/apache/maven/model/profile/DefaultProfileInjector
+instanceKlass org/apache/maven/model/profile/ProfileInjector
+instanceKlass org/apache/maven/model/plugin/DefaultReportingConverter
+instanceKlass org/apache/maven/model/plugin/ReportingConverter
+instanceKlass org/apache/maven/model/plugin/DefaultReportConfigurationExpander
+instanceKlass org/apache/maven/model/plugin/ReportConfigurationExpander
+instanceKlass org/apache/maven/model/plugin/DefaultPluginConfigurationExpander
+instanceKlass org/apache/maven/model/plugin/PluginConfigurationExpander
+instanceKlass org/apache/maven/model/path/ProfileActivationFilePathInterpolator
+instanceKlass org/apache/maven/model/path/DefaultUrlNormalizer
+instanceKlass org/apache/maven/model/path/UrlNormalizer
+instanceKlass org/apache/maven/model/path/DefaultPathTranslator
+instanceKlass org/apache/maven/model/path/PathTranslator
+instanceKlass org/apache/maven/model/path/DefaultModelUrlNormalizer
+instanceKlass org/apache/maven/model/path/ModelUrlNormalizer
+instanceKlass org/apache/maven/model/path/DefaultModelPathTranslator
+instanceKlass org/apache/maven/model/path/ModelPathTranslator
+instanceKlass org/apache/maven/model/normalization/DefaultModelNormalizer
+instanceKlass org/apache/maven/model/normalization/ModelNormalizer
+instanceKlass org/apache/maven/model/management/DefaultPluginManagementInjector
+instanceKlass org/apache/maven/model/management/PluginManagementInjector
+instanceKlass org/apache/maven/model/management/DefaultDependencyManagementInjector
+instanceKlass org/apache/maven/model/management/DependencyManagementInjector
+instanceKlass org/apache/maven/model/locator/DefaultModelLocator
+instanceKlass org/apache/maven/model/io/DefaultModelWriter
+instanceKlass org/apache/maven/model/io/ModelWriter
+instanceKlass org/apache/maven/model/io/DefaultModelReader
+instanceKlass org/apache/maven/model/interpolation/AbstractStringBasedModelInterpolator
+instanceKlass org/apache/maven/model/interpolation/ModelInterpolator
+instanceKlass org/apache/maven/model/interpolation/DefaultModelVersionProcessor
+instanceKlass org/apache/maven/model/interpolation/ModelVersionProcessor
+instanceKlass org/apache/maven/model/inheritance/DefaultInheritanceAssembler
+instanceKlass org/apache/maven/model/inheritance/InheritanceAssembler
+instanceKlass org/apache/maven/model/composition/DefaultDependencyManagementImporter
+instanceKlass org/apache/maven/model/composition/DependencyManagementImporter
+instanceKlass  @bci sun/reflect/annotation/AnnotationParser parseClassArray (ILjava/nio/ByteBuffer;Ljdk/internal/reflect/ConstantPool;Ljava/lang/Class;)Ljava/lang/Object; 10 <appendix> member <vmtarget> ; # sun/reflect/annotation/AnnotationParser$$Lambda+0x000000008d029138
+instanceKlass org/apache/maven/model/building/DefaultModelProcessor
+instanceKlass org/apache/maven/model/building/ModelProcessor
+instanceKlass org/apache/maven/model/io/ModelReader
+instanceKlass org/apache/maven/model/locator/ModelLocator
+instanceKlass org/apache/maven/model/building/DefaultModelBuilder
+instanceKlass org/apache/maven/model/building/ModelBuilder
+instanceKlass org/apache/maven/cli/internal/BootstrapCoreExtensionManager
+instanceKlass org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor
+instanceKlass org/apache/maven/cli/configuration/ConfigurationProcessor
+instanceKlass org/apache/maven/toolchain/io/DefaultToolchainsWriter
+instanceKlass org/apache/maven/toolchain/io/ToolchainsWriter
+instanceKlass org/apache/maven/toolchain/io/DefaultToolchainsReader
+instanceKlass org/apache/maven/toolchain/io/ToolchainsReader
+instanceKlass org/apache/maven/toolchain/building/DefaultToolchainsBuilder
+instanceKlass org/apache/maven/toolchain/building/ToolchainsBuilder
+instanceKlass org/apache/maven/execution/MavenSession
+instanceKlass org/apache/maven/session/scope/internal/SessionScope$ScopeState
+instanceKlass  @bci org/apache/maven/session/scope/internal/SessionScope <clinit> ()V 0 <appendix> argL0 ; # org/apache/maven/session/scope/internal/SessionScope$$Lambda+0x000000008d0a07c0
+instanceKlass org/apache/maven/session/scope/internal/SessionScope
+instanceKlass org/apache/maven/plugin/internal/AbstractMavenPluginDependenciesValidator
+instanceKlass org/apache/maven/plugin/internal/MavenPluginDependenciesValidator
+instanceKlass org/apache/maven/plugin/internal/AbstractMavenPluginParametersValidator
+instanceKlass org/apache/maven/plugin/internal/MavenPluginConfigurationValidator
+instanceKlass org/apache/maven/eventspy/AbstractEventSpy
+instanceKlass org/apache/maven/eventspy/EventSpy
+instanceKlass org/apache/maven/plugin/PluginValidationManager
+instanceKlass org/apache/maven/plugin/DefaultMojosExecutionStrategy
+instanceKlass org/apache/maven/plugin/MojosExecutionStrategy
+instanceKlass org/apache/maven/lifecycle/internal/LifecycleDependencyResolver
+instanceKlass org/apache/maven/lifecycle/internal/DefaultProjectArtifactFactory
+instanceKlass org/apache/maven/lifecycle/internal/ProjectArtifactFactory
+instanceKlass org/apache/maven/internal/aether/ResolverLifecycle
+instanceKlass org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory
+instanceKlass org/apache/maven/extension/internal/CoreExportsProvider
+instanceKlass org/apache/maven/plugin/MojoExecution
+instanceKlass org/apache/maven/project/MavenProject
+instanceKlass org/apache/maven/execution/MojoExecutionEvent
+instanceKlass org/apache/maven/execution/scope/internal/MojoExecutionScope$ScopeState
+instanceKlass org/apache/maven/execution/scope/MojoExecutionScoped
+instanceKlass com/google/inject/RestrictedBindingSource$Permit
+instanceKlass org/apache/maven/execution/scope/internal/MojoExecutionScope$1
+instanceKlass org/apache/maven/execution/scope/internal/MojoExecutionScope
+instanceKlass org/apache/maven/execution/MojoExecutionListener
+instanceKlass org/eclipse/sisu/space/QualifiedTypeBinder$1
+instanceKlass org/apache/maven/execution/DefaultMavenExecutionRequestPopulator
+instanceKlass org/apache/maven/execution/MavenExecutionRequestPopulator
+instanceKlass org/apache/maven/classrealm/DefaultClassRealmManager
+instanceKlass org/apache/maven/classrealm/ClassRealmManager
+instanceKlass org/apache/maven/SessionScoped
+instanceKlass org/apache/maven/ReactorReader
+instanceKlass org/apache/maven/repository/internal/MavenWorkspaceReader
+instanceKlass org/eclipse/aether/repository/WorkspaceReader
+instanceKlass org/eclipse/sisu/space/WildcardKey$QualifiedImpl
+instanceKlass org/eclipse/sisu/space/WildcardKey$Qualified
+instanceKlass org/eclipse/sisu/space/WildcardKey
+instanceKlass org/eclipse/sisu/Typed
+instanceKlass org/sonatype/inject/EagerSingleton
+instanceKlass org/eclipse/sisu/EagerSingleton
+instanceKlass org/sonatype/inject/Mediator
+instanceKlass org/eclipse/sisu/inject/TypeArguments
+instanceKlass org/apache/maven/DefaultArtifactFilterManager
+instanceKlass org/apache/maven/ArtifactFilterManager
+instanceKlass org/objectweb/asm/Context
+instanceKlass org/objectweb/asm/Attribute
+instanceKlass org/objectweb/asm/AnnotationVisitor
+instanceKlass org/objectweb/asm/ClassReader
+instanceKlass org/eclipse/sisu/space/IndexedClassFinder$1
+instanceKlass org/eclipse/sisu/inject/Logs$SLF4JSink
+instanceKlass org/eclipse/sisu/inject/Logs$Sink
+instanceKlass org/eclipse/sisu/inject/Logs
+instanceKlass org/eclipse/sisu/space/QualifierCache
+instanceKlass org/eclipse/sisu/space/QualifiedTypeVisitor
+instanceKlass org/eclipse/sisu/plexus/PlexusTypeVisitor$ComponentAnnotationVisitor
+instanceKlass org/eclipse/sisu/space/AnnotationVisitor
+instanceKlass org/eclipse/sisu/plexus/PlexusTypeVisitor
+instanceKlass org/eclipse/sisu/space/ClassVisitor
+instanceKlass org/eclipse/sisu/plexus/PlexusXmlBeanModule$PlexusXmlBeanSource
+instanceKlass org/eclipse/sisu/inject/DescriptionSource
+instanceKlass org/eclipse/sisu/inject/AnnotatedSource
+instanceKlass org/eclipse/sisu/Hidden
+instanceKlass org/eclipse/sisu/Priority
+instanceKlass org/eclipse/sisu/Description
+instanceKlass org/eclipse/sisu/inject/Sources
+instanceKlass com/google/inject/Key$AnnotationInstanceStrategy
+instanceKlass com/google/inject/name/NamedImpl
+instanceKlass com/google/inject/name/Named
+instanceKlass com/google/inject/name/Names
+instanceKlass com/google/inject/internal/MoreTypes$ParameterizedTypeImpl
+instanceKlass sun/reflect/generics/reflectiveObjects/ParameterizedTypeImpl
+instanceKlass sun/reflect/generics/reflectiveObjects/LazyReflectiveObjectGenerator
+instanceKlass org/apache/maven/wagon/Wagon
+instanceKlass org/apache/maven/toolchain/ToolchainsBuilder
+instanceKlass org/apache/maven/toolchain/ToolchainManagerPrivate
+instanceKlass org/apache/maven/toolchain/ToolchainManager
+instanceKlass org/apache/maven/toolchain/ToolchainFactory
+instanceKlass org/apache/maven/settings/MavenSettingsBuilder
+instanceKlass org/apache/maven/rtinfo/RuntimeInformation
+instanceKlass org/apache/maven/project/artifact/ProjectArtifactsCache
+instanceKlass org/apache/maven/project/artifact/MavenMetadataCache
+instanceKlass org/apache/maven/project/ProjectRealmCache
+instanceKlass org/apache/maven/project/ProjectDependenciesResolver
+instanceKlass org/apache/maven/project/ProjectBuildingHelper
+instanceKlass org/apache/maven/project/ProjectBuilder
+instanceKlass org/apache/maven/project/MavenProjectHelper
+instanceKlass org/apache/maven/plugin/version/PluginVersionResolver
+instanceKlass org/apache/maven/plugin/prefix/PluginPrefixResolver
+instanceKlass org/apache/maven/plugin/internal/PluginDependenciesResolver
+instanceKlass org/apache/maven/plugin/PluginRealmCache
+instanceKlass org/apache/maven/plugin/PluginManager
+instanceKlass org/apache/maven/plugin/PluginDescriptorCache
+instanceKlass org/apache/maven/plugin/PluginArtifactsCache
+instanceKlass org/apache/maven/plugin/MavenPluginManager
+instanceKlass org/apache/maven/plugin/LegacySupport
+instanceKlass org/apache/maven/plugin/ExtensionRealmCache
+instanceKlass org/apache/maven/plugin/BuildPluginManager
+instanceKlass org/apache/maven/model/plugin/LifecycleBindingsInjector
+instanceKlass org/apache/maven/lifecycle/internal/builder/BuilderCommon
+instanceKlass org/apache/maven/lifecycle/internal/builder/Builder
+instanceKlass org/apache/maven/lifecycle/internal/MojoExecutor
+instanceKlass org/apache/maven/lifecycle/internal/MojoDescriptorCreator
+instanceKlass org/apache/maven/lifecycle/internal/LifecycleTaskSegmentCalculator
+instanceKlass org/apache/maven/lifecycle/internal/LifecycleStarter
+instanceKlass org/apache/maven/lifecycle/internal/LifecyclePluginResolver
+instanceKlass org/apache/maven/lifecycle/internal/LifecycleModuleBuilder
+instanceKlass org/apache/maven/lifecycle/internal/LifecycleExecutionPlanCalculator
+instanceKlass org/apache/maven/lifecycle/internal/LifecycleDebugLogger
+instanceKlass org/apache/maven/lifecycle/internal/ExecutionEventCatapult
+instanceKlass org/apache/maven/lifecycle/internal/BuildListCalculator
+instanceKlass org/apache/maven/lifecycle/MojoExecutionConfigurator
+instanceKlass org/apache/maven/lifecycle/LifecycleMappingDelegate
+instanceKlass org/apache/maven/lifecycle/LifecycleExecutor
+instanceKlass org/apache/maven/lifecycle/LifeCyclePluginAnalyzer
+instanceKlass org/apache/maven/lifecycle/DefaultLifecycles
+instanceKlass org/apache/maven/graph/GraphBuilder
+instanceKlass org/apache/maven/eventspy/internal/EventSpyDispatcher
+instanceKlass org/apache/maven/configuration/BeanConfigurator
+instanceKlass org/apache/maven/bridge/MavenRepositorySystem
+instanceKlass org/apache/maven/artifact/resolver/ResolutionErrorHandler
+instanceKlass org/apache/maven/artifact/repository/metadata/io/MetadataReader
+instanceKlass org/apache/maven/artifact/metadata/ArtifactMetadataSource
+instanceKlass org/apache/maven/repository/legacy/metadata/ArtifactMetadataSource
+instanceKlass org/apache/maven/artifact/handler/manager/ArtifactHandlerManager
+instanceKlass org/apache/maven/artifact/factory/ArtifactFactory
+instanceKlass org/apache/maven/ProjectDependenciesResolver
+instanceKlass org/apache/maven/Maven
+instanceKlass org/apache/maven/artifact/handler/ArtifactHandler
+instanceKlass org/sonatype/plexus/components/sec/dispatcher/SecDispatcher
+instanceKlass org/apache/maven/lifecycle/Lifecycle
+instanceKlass org/eclipse/sisu/space/CloningClassSpace$1
+instanceKlass org/apache/maven/lifecycle/mapping/LifecycleMapping
+instanceKlass org/apache/maven/repository/metadata/GraphConflictResolver
+instanceKlass org/apache/maven/repository/metadata/GraphConflictResolutionPolicy
+instanceKlass org/eclipse/sisu/plexus/ConfigurationImpl
+instanceKlass org/apache/maven/repository/metadata/ClasspathTransformation
+instanceKlass org/apache/maven/repository/legacy/resolver/transform/ArtifactTransformationManager
+instanceKlass org/apache/maven/repository/legacy/resolver/transform/ArtifactTransformation
+instanceKlass org/apache/maven/repository/legacy/resolver/conflict/ConflictResolverFactory
+instanceKlass org/apache/maven/repository/legacy/resolver/conflict/ConflictResolver
+instanceKlass org/apache/maven/repository/legacy/repository/ArtifactRepositoryFactory
+instanceKlass org/apache/maven/repository/legacy/UpdateCheckManager
+instanceKlass org/apache/maven/repository/RepositorySystem
+instanceKlass org/apache/maven/repository/MirrorSelector
+instanceKlass org/apache/maven/project/validation/ModelValidator
+instanceKlass org/apache/maven/project/path/PathTranslator
+instanceKlass org/apache/maven/project/interpolation/ModelInterpolator
+instanceKlass org/apache/maven/project/inheritance/ModelInheritanceAssembler
+instanceKlass org/apache/maven/project/MavenProjectBuilder
+instanceKlass org/apache/maven/profiles/MavenProfilesBuilder
+instanceKlass org/apache/maven/execution/RuntimeInformation
+instanceKlass java/lang/foreign/MemorySegment
+instanceKlass org/apache/maven/artifact/resolver/ArtifactResolver
+instanceKlass org/apache/maven/artifact/resolver/ArtifactCollector
+instanceKlass org/apache/maven/repository/legacy/resolver/LegacyArtifactCollector
+instanceKlass org/apache/maven/artifact/repository/metadata/RepositoryMetadataManager
+instanceKlass org/apache/maven/artifact/repository/layout/ArtifactRepositoryLayout
+instanceKlass org/apache/maven/artifact/repository/ArtifactRepositoryFactory
+instanceKlass org/apache/maven/artifact/manager/WagonManager
+instanceKlass org/apache/maven/repository/legacy/WagonManager
+instanceKlass org/apache/maven/artifact/installer/ArtifactInstaller
+instanceKlass org/eclipse/sisu/plexus/PlexusXmlMetadata
+instanceKlass org/eclipse/sisu/plexus/Roles
+instanceKlass org/apache/maven/artifact/deployer/ArtifactDeployer
+instanceKlass org/eclipse/sisu/plexus/Hints
+instanceKlass org/eclipse/sisu/space/AbstractDeferredClass
+instanceKlass org/eclipse/sisu/plexus/RequirementImpl
+instanceKlass org/codehaus/plexus/component/annotations/Requirement
+instanceKlass org/eclipse/sisu/space/Streams
+instanceKlass org/eclipse/sisu/plexus/ComponentImpl
+instanceKlass org/codehaus/plexus/component/annotations/Component
+instanceKlass org/eclipse/sisu/plexus/PlexusTypeRegistry
+instanceKlass org/eclipse/sisu/plexus/PlexusXmlScanner
+instanceKlass org/eclipse/sisu/space/QualifiedTypeBinder
+instanceKlass org/eclipse/sisu/plexus/PlexusTypeBinder
+instanceKlass com/google/inject/spi/InjectionRequest
+instanceKlass org/eclipse/sisu/bean/BeanProperty
+instanceKlass com/google/common/collect/ObjectArrays
+instanceKlass com/google/inject/internal/Nullability
+instanceKlass  @bci com/google/inject/internal/KotlinSupport$KotlinUnsupported <clinit> ()V 7 <appendix> argL0 ; # com/google/inject/internal/KotlinSupport$KotlinUnsupported$$Lambda+0x000000008d095d20
+instanceKlass  @cpi com/sun/tools/javac/comp/Modules 1632 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d090800
+instanceKlass com/google/inject/internal/KotlinSupport$KotlinUnsupported
+instanceKlass com/google/inject/internal/KotlinSupport$KotlinSupportHolder
+instanceKlass com/google/inject/internal/KotlinSupportInterface
+instanceKlass com/google/inject/internal/KotlinSupport
+instanceKlass com/google/inject/spi/InjectionPoint$OverrideIndex
+instanceKlass org/eclipse/sisu/Mediator
+instanceKlass org/eclipse/sisu/inject/RankedBindings
+instanceKlass sun/reflect/generics/tree/TypeVariableSignature
+instanceKlass com/google/inject/Inject
+instanceKlass javax/inject/Inject
+instanceKlass  @bci com/google/inject/internal/DeclaredMembers getDeclaredFields (Ljava/lang/Class;)[Ljava/lang/reflect/Field; 38 <appendix> argL0 ; # com/google/inject/internal/DeclaredMembers$$Lambda+0x000000008d094908
+instanceKlass  @bci com/google/inject/internal/DeclaredMembers getDeclaredFields (Ljava/lang/Class;)[Ljava/lang/reflect/Field; 20 <appendix> argL0 ; # com/google/inject/internal/DeclaredMembers$$Lambda+0x000000008d0946c0
+instanceKlass  @bci com/google/inject/internal/DeclaredMembers getDeclaredFields (Ljava/lang/Class;)[Ljava/lang/reflect/Field; 15 <appendix> argL0 ; # com/google/inject/internal/DeclaredMembers$$Lambda+0x000000008d094478
+instanceKlass  @bci com/google/inject/internal/DeclaredMembers getDeclaredFields (Ljava/lang/Class;)[Ljava/lang/reflect/Field; 7 <appendix> argL0 ; # com/google/inject/internal/DeclaredMembers$$Lambda+0x000000008d094230
+instanceKlass java/lang/reflect/WildcardType
+instanceKlass com/google/inject/spi/InjectionPoint$InjectableMembers
+instanceKlass com/google/inject/spi/InjectionPoint$InjectableMember
+instanceKlass com/google/inject/spi/InjectionPoint
+instanceKlass java/lang/reflect/ParameterizedType
+instanceKlass com/google/inject/internal/MoreTypes$GenericArrayTypeImpl
+instanceKlass com/google/inject/internal/MoreTypes$CompositeType
+instanceKlass com/google/inject/Key$AnnotationTypeStrategy
+instanceKlass com/google/common/cache/LocalCache$StrongValueReference
+instanceKlass com/google/common/util/concurrent/AbstractFuture$Failure
+instanceKlass com/google/common/util/concurrent/AbstractFuture$Cancellation
+instanceKlass com/google/common/util/concurrent/AbstractFuture$DelegatingToFuture
+instanceKlass com/google/common/util/concurrent/Platform
+instanceKlass com/google/common/util/concurrent/Uninterruptibles
+instanceKlass com/google/common/util/concurrent/AbstractFuture$Listener
+instanceKlass com/google/common/util/concurrent/AbstractFutureState$Waiter
+instanceKlass com/google/common/util/concurrent/LazyLogger
+instanceKlass java/util/concurrent/Executor
+instanceKlass com/google/common/util/concurrent/AbstractFutureState$AtomicHelper
+instanceKlass com/google/common/util/concurrent/internal/InternalFutureFailureAccess
+instanceKlass com/google/common/util/concurrent/AbstractFuture$Trusted
+instanceKlass com/google/common/util/concurrent/ListenableFuture
+instanceKlass  @bci com/sun/tools/javac/comp/Operators$UnaryOperatorHelper addUnaryOperator (Lcom/sun/tools/javac/comp/Operators$OperatorType;Lcom/sun/tools/javac/comp/Operators$OperatorType;[I)Lcom/sun/tools/javac/comp/Operators$UnaryOperatorHelper; 9 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d090400
+instanceKlass  @bci sun/reflect/annotation/AnnotationParser parseEnumArray (ILjava/lang/Class;Ljava/nio/ByteBuffer;Ljdk/internal/reflect/ConstantPool;Ljava/lang/Class;)Ljava/lang/Object; 16 <appendix> member <vmtarget> ; # sun/reflect/annotation/AnnotationParser$$Lambda+0x000000008d026cc8
+instanceKlass java/lang/annotation/Documented
+instanceKlass java/lang/annotation/Target
+instanceKlass javax/inject/Named
+instanceKlass javax/inject/Qualifier
+instanceKlass com/google/inject/BindingAnnotation
+instanceKlass javax/inject/Scope
+instanceKlass com/google/inject/ScopeAnnotation
+instanceKlass com/google/inject/internal/Annotations$AnnotationChecker
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d090000
+instanceKlass jdk/internal/classfile/impl/StackMapDecoder$1
+instanceKlass jdk/internal/classfile/impl/StackMapDecoder
+instanceKlass jdk/internal/classfile/impl/StackCounter
+instanceKlass  @bci java/lang/reflect/ProxyGenerator lambda$generateLookupAccessor$0 (Ljava/lang/classfile/MethodBuilder;)V 30 <appendix> member <vmtarget> ; # java/lang/reflect/ProxyGenerator$$Lambda+0x000000008d025740
+instanceKlass  @bci java/lang/reflect/ProxyGenerator generateLookupAccessor (Ljava/lang/classfile/ClassBuilder;)V 10 <appendix> member <vmtarget> ; # java/lang/reflect/ProxyGenerator$$Lambda+0x000000008d025500
+instanceKlass  @bci java/lang/reflect/ProxyGenerator generateStaticInitializer (Ljava/lang/classfile/ClassBuilder;)V 10 <appendix> member <vmtarget> ; # java/lang/reflect/ProxyGenerator$$Lambda+0x000000008d0252c0
+instanceKlass java/lang/classfile/attribute/StackMapTableAttribute
+instanceKlass java/lang/classfile/attribute/StackMapFrameInfo
+instanceKlass java/lang/classfile/instruction/ExceptionCatch
+instanceKlass  @bci java/lang/reflect/ProxyGenerator$ProxyMethod lambda$generateMethod$0 (Ljava/lang/classfile/MethodBuilder;)V 30 <appendix> member <vmtarget> ; # java/lang/reflect/ProxyGenerator$ProxyMethod$$Lambda+0x000000008d0249a8
+instanceKlass java/lang/classfile/attribute/ExceptionsAttribute
+instanceKlass  @bci java/lang/reflect/ProxyGenerator$ProxyMethod generateMethod (Ljava/lang/classfile/ClassBuilder;)V 42 <appendix> member <vmtarget> ; # java/lang/reflect/ProxyGenerator$ProxyMethod$$Lambda+0x000000008d024248
+instanceKlass  @bci java/lang/reflect/ProxyGenerator generateConstructor (Ljava/lang/classfile/ClassBuilder;)V 8 <appendix> member <vmtarget> ; # java/lang/reflect/ProxyGenerator$$Lambda+0x000000008d024008
+instanceKlass  @bci java/lang/reflect/ProxyGenerator generateClassFile ()[B 197 <appendix> member <vmtarget> ; # java/lang/reflect/ProxyGenerator$$Lambda+0x000000008d023dc8
+instanceKlass  @bci java/lang/reflect/ProxyGenerator proxyMethodsFor (Ljava/lang/String;)Ljava/util/List; 5 <appendix> argL0 ; # java/lang/reflect/ProxyGenerator$$Lambda+0x000000008d023b80
+instanceKlass java/lang/reflect/ProxyGenerator$ProxyMethod
+instanceKlass java/lang/classfile/attribute/StackMapFrameInfo$ObjectVerificationTypeInfo
+instanceKlass java/lang/classfile/attribute/StackMapFrameInfo$VerificationTypeInfo
+instanceKlass java/util/StringJoiner
+instanceKlass java/lang/classfile/ClassFile$Option
+instanceKlass java/lang/reflect/ProxyGenerator
+instanceKlass  @bci java/lang/WeakPairMap computeIfAbsent (Ljava/lang/Object;Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object; 18 <appendix> member <vmtarget> ; # java/lang/WeakPairMap$$Lambda+0x000000008d022ee8
+instanceKlass  @bci java/lang/Module implAddExportsOrOpens (Ljava/lang/String;Ljava/lang/Module;ZZ)V 151 <appendix> argL0 ; # java/lang/Module$$Lambda+0x000000008d022cb0
+instanceKlass  @bci java/lang/module/ModuleDescriptor$Builder packages (Ljava/util/Set;)Ljava/lang/module/ModuleDescriptor$Builder; 17 <appendix> argL0 ; # java/lang/module/ModuleDescriptor$Builder$$Lambda+0x80000000e
+instanceKlass jdk/internal/module/Checks
+instanceKlass java/lang/module/ModuleDescriptor$Builder
+instanceKlass  @bci java/lang/reflect/Proxy$ProxyBuilder getDynamicModule (Ljava/lang/ClassLoader;)Ljava/lang/Module; 4 <appendix> argL0 ; # java/lang/reflect/Proxy$ProxyBuilder$$Lambda+0x000000008d022580
+instanceKlass java/lang/PublicMethods
+instanceKlass java/util/Collections$1
+instanceKlass java/lang/reflect/Proxy$ProxyBuilder
+instanceKlass  @bci java/lang/reflect/Proxy getProxyConstructor (Ljava/lang/ClassLoader;[Ljava/lang/Class;)Ljava/lang/reflect/Constructor; 18 <appendix> argL0 ; # java/lang/reflect/Proxy$$Lambda+0x000000008d021908
+instanceKlass java/lang/ClassValue$Identity
+instanceKlass java/lang/ClassValue$Entry
+instanceKlass java/lang/ClassValue
+instanceKlass java/lang/reflect/Proxy
+instanceKlass sun/reflect/annotation/AnnotationInvocationHandler
+instanceKlass sun/reflect/annotation/ExceptionProxy
+instanceKlass java/lang/annotation/Inherited
+instanceKlass java/lang/annotation/Retention
+instanceKlass sun/reflect/annotation/AnnotationType
+instanceKlass java/lang/reflect/GenericArrayType
+instanceKlass sun/reflect/generics/visitor/Reifier
+instanceKlass sun/reflect/generics/visitor/TypeTreeVisitor
+instanceKlass sun/reflect/generics/factory/CoreReflectionFactory
+instanceKlass sun/reflect/generics/factory/GenericsFactory
+instanceKlass sun/reflect/generics/scope/AbstractScope
+instanceKlass sun/reflect/generics/scope/Scope
+instanceKlass com/google/inject/internal/Annotations$TestAnnotation
+instanceKlass com/google/inject/internal/Annotations$AnnotationToStringConfig
+instanceKlass com/google/common/base/Joiner$MapJoiner
+instanceKlass com/google/common/base/Joiner
+instanceKlass java/lang/reflect/InvocationHandler
+instanceKlass com/google/inject/internal/Annotations
+instanceKlass org/eclipse/sisu/Parameters
+instanceKlass org/eclipse/sisu/wire/ParameterKeys
+instanceKlass com/google/inject/internal/util/StackTraceElements$InMemoryStackTraceElement
+instanceKlass com/google/inject/internal/util/StackTraceElements
+instanceKlass org/eclipse/sisu/wire/TypeConverterCache
+instanceKlass com/google/inject/internal/Scoping
+instanceKlass com/google/inject/internal/InternalFactory
+instanceKlass java/lang/StackTraceElement$HashedModules
+instanceKlass com/google/inject/internal/InternalFlags$1
+instanceKlass com/google/inject/internal/InternalFlags
+instanceKlass com/google/inject/spi/ConstructorBinding
+instanceKlass com/google/inject/spi/ProviderInstanceBinding
+instanceKlass com/google/inject/internal/DelayedInitialize
+instanceKlass com/google/inject/spi/ProviderKeyBinding
+instanceKlass com/google/inject/spi/InstanceBinding
+instanceKlass com/google/inject/spi/HasDependencies
+instanceKlass com/google/inject/spi/LinkedKeyBinding
+instanceKlass com/google/inject/spi/UntargettedBinding
+instanceKlass com/google/inject/internal/BindingImpl
+instanceKlass com/google/inject/Key$AnnotationStrategy
+instanceKlass org/eclipse/sisu/wire/ElementAnalyzer$1
+instanceKlass com/google/inject/util/Modules$EmptyModule
+instanceKlass com/google/inject/util/Modules$OverriddenModuleBuilder
+instanceKlass com/google/inject/util/Modules
+instanceKlass java/util/stream/Nodes$ArrayNode
+instanceKlass  @bci com/google/inject/internal/DeclaredMembers getDeclaredMethods (Ljava/lang/Class;)[Ljava/lang/reflect/Method; 62 <appendix> argL0 ; # com/google/inject/internal/DeclaredMembers$$Lambda+0x000000008d085b70
+instanceKlass java/util/stream/SortedOps
+instanceKlass com/google/common/collect/Ordering
+instanceKlass  @bci com/google/inject/internal/DeclaredMembers getDeclaredMethods (Ljava/lang/Class;)[Ljava/lang/reflect/Method; 38 <appendix> argL0 ; # com/google/inject/internal/DeclaredMembers$$Lambda+0x000000008d07f028
+instanceKlass  @bci com/google/inject/internal/DeclaredMembers getDeclaredMethods (Ljava/lang/Class;)[Ljava/lang/reflect/Method; 33 <appendix> argL0 ; # com/google/inject/internal/DeclaredMembers$$Lambda+0x000000008d07ede0
+instanceKlass  @bci java/util/Comparator thenComparing (Ljava/util/Comparator;)Ljava/util/Comparator; 7 <appendix> member <vmtarget> ; # java/util/Comparator$$Lambda+0x000000008d01e7c8
+instanceKlass  @cpi java/util/Comparator 251 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d080400
+instanceKlass  @bci java/util/Comparator comparing (Ljava/util/function/Function;Ljava/util/Comparator;)Ljava/util/Comparator; 12 <appendix> member <vmtarget> ; # java/util/Comparator$$Lambda+0x000000008d01e520
+instanceKlass  @bci com/google/inject/internal/DeclaredMembers getDeclaredMethods (Ljava/lang/Class;)[Ljava/lang/reflect/Method; 20 <appendix> argL0 ; # com/google/inject/internal/DeclaredMembers$$Lambda+0x000000008d07eb98
+instanceKlass  @bci com/google/inject/internal/DeclaredMembers getDeclaredMethods (Ljava/lang/Class;)[Ljava/lang/reflect/Method; 15 <appendix> argL0 ; # com/google/inject/internal/DeclaredMembers$$Lambda+0x000000008d07e950
+instanceKlass  @bci java/util/Comparator comparing (Ljava/util/function/Function;)Ljava/util/Comparator; 6 <appendix> member <vmtarget> ; # java/util/Comparator$$Lambda+0x000000008d01e278
+instanceKlass jdk/internal/classfile/impl/BytecodeHelpers$1
+instanceKlass java/lang/invoke/TypeConvertingMethodAdapter$1
+instanceKlass java/lang/classfile/constantpool/IntegerEntry
+instanceKlass sun/invoke/util/BytecodeDescriptor
+instanceKlass java/lang/classfile/constantpool/StringEntry
+instanceKlass java/lang/classfile/constantpool/ConstantValueEntry
+instanceKlass java/lang/invoke/InnerClassLambdaMetafactory$4
+instanceKlass java/lang/invoke/InnerClassLambdaMetafactory$SerializationSupport
+instanceKlass  @cpi java/util/Comparator 259 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d080000
+instanceKlass  @bci com/google/inject/internal/DeclaredMembers getDeclaredMethods (Ljava/lang/Class;)[Ljava/lang/reflect/Method; 7 <appendix> argL0 ; # com/google/inject/internal/DeclaredMembers$$Lambda+0x000000008d07e708
+instanceKlass com/google/inject/internal/DeclaredMembers
+instanceKlass com/google/common/base/ExtraObjectsMethodsForWeb
+instanceKlass com/google/common/collect/ImmutableMap$Builder
+instanceKlass com/google/inject/internal/MoreTypes
+instanceKlass com/google/inject/multibindings/ProvidesIntoOptional
+instanceKlass com/google/inject/multibindings/ProvidesIntoMap
+instanceKlass com/google/inject/multibindings/ProvidesIntoSet
+instanceKlass com/google/inject/Provides
+instanceKlass javax/inject/Singleton
+instanceKlass com/google/inject/spi/ElementSource
+instanceKlass com/google/inject/spi/ScopeBinding
+instanceKlass com/google/inject/Scopes$2
+instanceKlass com/google/inject/Scopes$1
+instanceKlass com/google/inject/internal/SingletonScope
+instanceKlass com/google/inject/Scopes
+instanceKlass com/google/inject/Singleton
+instanceKlass com/google/inject/spi/Elements$ModuleInfo
+instanceKlass com/google/inject/PrivateModule
+instanceKlass  @bci java/util/stream/Collectors toList ()Ljava/util/stream/Collector; 14 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x000000008d01d0f8
+instanceKlass  @bci java/util/stream/Collectors toList ()Ljava/util/stream/Collector; 9 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x000000008d01cec0
+instanceKlass  @bci java/util/stream/Collectors toList ()Ljava/util/stream/Collector; 4 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x000000008d01cc98
+instanceKlass  @bci com/google/inject/spi/BindingSourceRestriction$PermitMapConstruction pushModule (Ljava/lang/Class;Lcom/google/inject/spi/ModuleSource;)V 5 <appendix> member <vmtarget> ; # com/google/inject/spi/BindingSourceRestriction$PermitMapConstruction$$Lambda+0x000000008d07a3d8
+instanceKlass  @bci com/google/inject/spi/BindingSourceRestriction getPermits (Ljava/lang/Class;)Ljava/util/stream/Stream; 43 <appendix> argL0 ; # com/google/inject/spi/BindingSourceRestriction$$Lambda+0x000000008d07a180
+instanceKlass  @bci com/google/inject/spi/BindingSourceRestriction getPermits (Ljava/lang/Class;)Ljava/util/stream/Stream; 33 <appendix> argL0 ; # com/google/inject/spi/BindingSourceRestriction$$Lambda+0x000000008d079f38
+instanceKlass  @cpi com/sun/tools/javac/code/Scope$FilterImportScope 171 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d074400
+instanceKlass java/util/stream/Streams$2
+instanceKlass java/util/stream/Streams$ConcatSpliterator
+instanceKlass sun/reflect/annotation/AnnotatedTypeFactory$AnnotatedTypeBaseImpl
+instanceKlass java/lang/reflect/AnnotatedType
+instanceKlass sun/reflect/annotation/AnnotatedTypeFactory
+instanceKlass sun/reflect/annotation/TypeAnnotation$LocationInfo$Location
+instanceKlass sun/reflect/annotation/TypeAnnotation$LocationInfo
+instanceKlass sun/reflect/generics/tree/ClassSignature
+instanceKlass sun/reflect/generics/tree/Signature
+instanceKlass sun/reflect/generics/tree/ClassTypeSignature
+instanceKlass sun/reflect/generics/tree/SimpleClassTypeSignature
+instanceKlass sun/reflect/generics/tree/FieldTypeSignature
+instanceKlass sun/reflect/generics/tree/BaseType
+instanceKlass sun/reflect/generics/tree/TypeSignature
+instanceKlass sun/reflect/generics/tree/ReturnType
+instanceKlass sun/reflect/generics/tree/TypeArgument
+instanceKlass sun/reflect/generics/tree/FormalTypeParameter
+instanceKlass sun/reflect/generics/tree/TypeTree
+instanceKlass sun/reflect/generics/tree/Tree
+instanceKlass sun/reflect/generics/parser/SignatureParser
+instanceKlass java/lang/reflect/TypeVariable
+instanceKlass sun/reflect/generics/repository/AbstractRepository
+instanceKlass sun/reflect/annotation/TypeAnnotation
+instanceKlass sun/reflect/annotation/TypeAnnotationParser
+instanceKlass java/lang/Class$AnnotationData
+instanceKlass com/google/inject/RestrictedBindingSource
+instanceKlass com/google/inject/spi/BindingSourceRestriction
+instanceKlass com/google/inject/spi/ModuleSource
+instanceKlass com/google/inject/internal/ProviderMethodsModule
+instanceKlass com/google/inject/spi/BindingSourceRestriction$PermitMapConstruction$PermitMapImpl
+instanceKlass com/google/inject/spi/BindingSourceRestriction$PermitMap
+instanceKlass com/google/inject/spi/BindingSourceRestriction$PermitMapConstruction
+instanceKlass com/google/common/collect/Hashing
+instanceKlass com/google/common/math/IntMath$1
+instanceKlass com/google/common/math/MathPreconditions
+instanceKlass com/google/common/math/IntMath
+instanceKlass com/google/inject/internal/AbstractBindingBuilder
+instanceKlass com/google/inject/binder/ConstantBindingBuilder
+instanceKlass com/google/inject/binder/AnnotatedElementBuilder
+instanceKlass com/google/inject/spi/Elements$RecordingBinder
+instanceKlass com/google/inject/Binding
+instanceKlass com/google/inject/spi/DefaultBindingTargetVisitor
+instanceKlass com/google/inject/spi/BindingTargetVisitor
+instanceKlass com/google/inject/spi/Elements
+instanceKlass com/google/inject/internal/InjectorShell$RootModule
+instanceKlass com/google/common/collect/ListMultimap
+instanceKlass com/google/inject/internal/InjectorBindingData
+instanceKlass java/util/concurrent/atomic/AtomicReferenceArray
+instanceKlass java/util/concurrent/Future
+instanceKlass com/google/common/cache/LocalCache$LoadingValueReference
+instanceKlass java/util/concurrent/ConcurrentLinkedQueue$Node
+instanceKlass com/google/common/cache/Weigher
+instanceKlass com/google/common/base/Predicate
+instanceKlass com/google/common/base/Equivalence
+instanceKlass java/util/function/BiPredicate
+instanceKlass com/google/common/base/MoreObjects
+instanceKlass com/google/common/cache/LocalCache$1
+instanceKlass com/google/common/cache/ReferenceEntry
+instanceKlass com/google/common/cache/CacheLoader
+instanceKlass com/google/common/cache/LocalCache$LocalManualCache
+instanceKlass  @bci com/google/inject/internal/WeakKeySet <init> (Ljava/lang/Object;)V 12 <appendix> member <vmtarget> ; # com/google/inject/internal/WeakKeySet$$Lambda+0x000000008d070dd8
+instanceKlass  @cpi com/sun/tools/javac/code/Symtab 1410 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d074000
+instanceKlass java/util/AbstractMap$SimpleImmutableEntry
+instanceKlass com/google/common/cache/RemovalListener
+instanceKlass com/google/common/cache/LocalCache$ValueReference
+instanceKlass com/google/common/cache/CacheBuilder$2
+instanceKlass com/google/common/cache/CacheStats
+instanceKlass com/google/common/base/Suppliers$SupplierOfInstance
+instanceKlass com/google/common/base/Suppliers
+instanceKlass com/google/common/cache/CacheBuilder$1
+instanceKlass com/google/common/cache/AbstractCache$StatsCounter
+instanceKlass com/google/common/cache/LoadingCache
+instanceKlass com/google/common/cache/Cache
+instanceKlass com/google/common/base/Supplier
+instanceKlass com/google/common/cache/CacheBuilder
+instanceKlass com/google/inject/internal/WeakKeySet
+instanceKlass com/google/common/collect/Sets
+instanceKlass com/google/inject/internal/InjectorJitBindingData
+instanceKlass java/util/Arrays$ArrayItr
+instanceKlass com/google/inject/internal/ProcessedBindingData
+instanceKlass com/google/inject/spi/DefaultElementVisitor
+instanceKlass com/google/inject/internal/InjectorShell$Builder
+instanceKlass com/google/common/collect/Lists
+instanceKlass com/google/common/collect/AbstractMapEntry
+instanceKlass com/google/common/collect/LinkedHashMultimap$ValueSetLink
+instanceKlass com/google/common/collect/CollectPreconditions
+instanceKlass com/google/common/collect/Platform
+instanceKlass com/google/common/collect/Multiset
+instanceKlass com/google/common/collect/AbstractMultimap
+instanceKlass com/google/common/collect/SetMultimap
+instanceKlass com/google/common/collect/ImmutableMap
+instanceKlass com/google/common/collect/BiMap
+instanceKlass com/google/common/base/Converter
+instanceKlass com/google/common/base/Function
+instanceKlass com/google/common/collect/SortedMapDifference
+instanceKlass com/google/common/collect/MapDifference
+instanceKlass com/google/common/collect/Maps
+instanceKlass com/google/inject/internal/CycleDetectingLock
+instanceKlass com/google/common/collect/Multimap
+instanceKlass com/google/inject/internal/CycleDetectingLock$CycleDetectingLockFactory
+instanceKlass com/google/inject/internal/Initializable
+instanceKlass com/google/inject/internal/Initializer
+instanceKlass com/google/common/collect/PeekingIterator
+instanceKlass com/google/common/collect/UnmodifiableIterator
+instanceKlass com/google/common/collect/Iterators
+instanceKlass com/google/common/collect/ImmutableCollection$Builder
+instanceKlass com/google/common/collect/ImmutableSet$SetBuilderImpl
+instanceKlass com/google/inject/internal/util/SourceProvider
+instanceKlass com/google/inject/spi/ErrorDetail
+instanceKlass com/google/inject/internal/Errors
+instanceKlass com/google/common/base/Preconditions
+instanceKlass java/util/logging/Logger$SystemLoggerHelper
+instanceKlass jdk/internal/logger/BootstrapLogger$BootstrapExecutors
+instanceKlass jdk/internal/logger/BootstrapLogger$RedirectedLoggers
+instanceKlass java/util/Spliterators$1Adapter
+instanceKlass java/util/Spliterators$ArraySpliterator
+instanceKlass jdk/internal/logger/BootstrapLogger$DetectBackend
+instanceKlass jdk/internal/logger/BootstrapLogger
+instanceKlass sun/util/logging/PlatformLogger$ConfigurableBridge
+instanceKlass sun/util/logging/PlatformLogger$Bridge
+instanceKlass java/lang/System$Logger
+instanceKlass  @bci java/util/stream/MatchOps makeRef (Ljava/util/function/Predicate;Ljava/util/stream/MatchOps$MatchKind;)Ljava/util/stream/TerminalOp; 20 <appendix> member <vmtarget> ; # java/util/stream/MatchOps$$Lambda+0x800000004
+instanceKlass java/util/stream/MatchOps$BooleanTerminalSink
+instanceKlass java/util/stream/MatchOps$MatchOp
+instanceKlass java/util/stream/MatchOps
+instanceKlass java/util/stream/Streams
+instanceKlass java/util/stream/Stream$Builder
+instanceKlass java/util/stream/Streams$AbstractStreamBuilderImpl
+instanceKlass java/util/stream/ReferencePipeline$7$1FlatMap
+instanceKlass java/util/stream/FindOps$FindOp
+instanceKlass  @bci java/util/stream/FindOps$FindSink$OfRef <clinit> ()V 6 <appendix> argL0 ; # java/util/stream/FindOps$FindSink$OfRef$$Lambda+0x800000048
+instanceKlass  @bci java/util/stream/FindOps$FindSink$OfRef <clinit> ()V 0 <appendix> argL0 ; # java/util/stream/FindOps$FindSink$OfRef$$Lambda+0x800000049
+instanceKlass java/util/stream/FindOps$FindSink
+instanceKlass java/util/stream/FindOps
+instanceKlass  @bci java/util/logging/Level$KnownLevel findByName (Ljava/lang/String;Ljava/util/function/Function;)Ljava/util/Optional; 29 <appendix> argL0 ; # java/util/logging/Level$KnownLevel$$Lambda+0x800000022
+instanceKlass java/util/ArrayList$ArrayListSpliterator
+instanceKlass  @bci java/util/logging/Level findLevel (Ljava/lang/String;)Ljava/util/logging/Level; 13 <appendix> argL0 ; # java/util/logging/Level$$Lambda+0x80000001f
+instanceKlass java/util/Hashtable$Enumerator
+instanceKlass java/util/logging/LogManager$VisitedLoggers
+instanceKlass java/util/function/Predicate
+instanceKlass  @bci java/util/logging/LogManager$LoggerContext addLocalLogger (Ljava/util/logging/Logger;Z)Z 95 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x000000008d068000
+instanceKlass java/lang/invoke/StringConcatFactory
+instanceKlass java/lang/System$LoggerFinder
+instanceKlass java/util/logging/LogManager$LoggingProviderAccess
+instanceKlass sun/util/logging/internal/LoggingProviderImpl$LogManagerAccess
+instanceKlass java/util/Collections$SynchronizedMap
+instanceKlass java/util/logging/LogManager$LogNode
+instanceKlass java/util/logging/LogManager$LoggerContext
+instanceKlass java/util/logging/LogManager
+instanceKlass java/util/logging/Logger$ConfigurationData
+instanceKlass java/util/logging/Logger$LoggerBundle
+instanceKlass  @bci java/util/logging/Level$KnownLevel add (Ljava/util/logging/Level;)V 49 <appendix> argL0 ; # java/util/logging/Level$KnownLevel$$Lambda+0x800000021
+instanceKlass  @bci java/util/logging/Level$KnownLevel add (Ljava/util/logging/Level;)V 19 <appendix> argL0 ; # java/util/logging/Level$KnownLevel$$Lambda+0x800000020
+instanceKlass java/util/logging/Level
+instanceKlass java/util/logging/Handler
+instanceKlass java/util/logging/Logger
+instanceKlass com/google/common/base/Ticker
+instanceKlass com/google/common/base/Stopwatch
+instanceKlass com/google/inject/internal/util/ContinuousStopwatch
+instanceKlass com/google/inject/Injector
+instanceKlass com/google/inject/internal/InternalInjectorCreator
+instanceKlass com/google/inject/Guice
+instanceKlass org/eclipse/sisu/wire/Wiring
+instanceKlass org/eclipse/sisu/wire/WireModule$Strategy$1
+instanceKlass org/eclipse/sisu/wire/WireModule$Strategy
+instanceKlass org/eclipse/sisu/wire/AbstractTypeConverter
+instanceKlass com/google/inject/spi/ElementVisitor
+instanceKlass org/eclipse/sisu/wire/WireModule
+instanceKlass org/eclipse/sisu/bean/BeanBinder
+instanceKlass org/eclipse/sisu/plexus/PlexusBindingModule
+instanceKlass org/codehaus/plexus/DefaultPlexusContainer$BootModule
+instanceKlass org/codehaus/plexus/component/annotations/Configuration
+instanceKlass org/eclipse/sisu/plexus/PlexusAnnotatedMetadata
+instanceKlass org/eclipse/sisu/plexus/PlexusBeanMetadata
+instanceKlass org/eclipse/sisu/plexus/PlexusAnnotatedBeanModule$PlexusAnnotatedBeanSource
+instanceKlass org/eclipse/sisu/space/SpaceModule$2
+instanceKlass org/eclipse/sisu/space/SpaceModule$Strategy$2
+instanceKlass org/eclipse/sisu/space/SpaceModule$Strategy$1
+instanceKlass org/eclipse/sisu/space/DefaultClassFinder
+instanceKlass org/objectweb/asm/ClassVisitor
+instanceKlass org/eclipse/sisu/space/SpaceScanner
+instanceKlass org/eclipse/sisu/space/IndexedClassFinder
+instanceKlass org/eclipse/sisu/space/ClassFinder
+instanceKlass org/eclipse/sisu/space/SpaceModule
+instanceKlass org/eclipse/sisu/space/SpaceVisitor
+instanceKlass org/eclipse/sisu/plexus/PlexusTypeListener
+instanceKlass org/eclipse/sisu/space/QualifiedTypeListener
+instanceKlass org/eclipse/sisu/plexus/PlexusAnnotatedBeanModule$1
+instanceKlass org/eclipse/sisu/space/SpaceModule$Strategy
+instanceKlass org/eclipse/sisu/plexus/PlexusAnnotatedBeanModule
+instanceKlass org/eclipse/sisu/plexus/PlexusBeanSource
+instanceKlass org/eclipse/sisu/plexus/PlexusXmlBeanModule
+instanceKlass org/eclipse/sisu/plexus/PlexusBeanModule
+instanceKlass org/eclipse/sisu/space/URLClassSpace
+instanceKlass org/codehaus/plexus/DefaultPlexusContainer$SLF4JLoggerFactoryProvider
+instanceKlass com/google/inject/util/Providers$ConstantProvider
+instanceKlass com/google/inject/util/Providers
+instanceKlass org/codehaus/plexus/personality/plexus/lifecycle/phase/Disposable
+instanceKlass org/codehaus/plexus/personality/plexus/lifecycle/phase/Startable
+instanceKlass org/codehaus/plexus/personality/plexus/lifecycle/phase/Initializable
+instanceKlass org/codehaus/plexus/personality/plexus/lifecycle/phase/Contextualizable
+instanceKlass org/codehaus/plexus/logging/LogEnabled
+instanceKlass org/eclipse/sisu/bean/PropertyBinding
+instanceKlass javax/annotation/PreDestroy
+instanceKlass javax/annotation/PostConstruct
+instanceKlass org/eclipse/sisu/bean/LifecycleBuilder
+instanceKlass org/eclipse/sisu/bean/BeanScheduler$1
+instanceKlass com/google/inject/spi/DefaultBindingScopingVisitor
+instanceKlass com/google/inject/spi/BindingScopingVisitor
+instanceKlass org/eclipse/sisu/bean/BeanScheduler$CycleActivator
+instanceKlass com/google/inject/PrivateBinder
+instanceKlass com/google/inject/spi/ModuleAnnotatedMethodScanner
+instanceKlass com/google/inject/spi/Message
+instanceKlass com/google/inject/spi/Element
+instanceKlass com/google/inject/Scope
+instanceKlass com/google/inject/MembersInjector
+instanceKlass com/google/inject/binder/AnnotatedConstantBindingBuilder
+instanceKlass com/google/inject/spi/TypeListener
+instanceKlass org/aopalliance/intercept/MethodInterceptor
+instanceKlass org/aopalliance/intercept/Interceptor
+instanceKlass org/aopalliance/aop/Advice
+instanceKlass com/google/inject/spi/Dependency
+instanceKlass com/google/inject/Key
+instanceKlass com/google/inject/binder/AnnotatedBindingBuilder
+instanceKlass com/google/inject/binder/LinkedBindingBuilder
+instanceKlass com/google/inject/binder/ScopedBindingBuilder
+instanceKlass com/google/inject/TypeLiteral
+instanceKlass com/google/inject/spi/ProvisionListener
+instanceKlass com/google/inject/Binder
+instanceKlass org/eclipse/sisu/bean/BeanScheduler
+instanceKlass org/eclipse/sisu/plexus/DefaultPlexusBeanLocator
+instanceKlass org/eclipse/sisu/plexus/RealmManager
+instanceKlass org/codehaus/plexus/context/ContextMapAdapter
+instanceKlass org/codehaus/plexus/context/DefaultContext
+instanceKlass org/codehaus/plexus/logging/AbstractLogger
+instanceKlass org/codehaus/plexus/logging/AbstractLoggerManager
+instanceKlass java/util/Date
+instanceKlass java/text/DigitList
+instanceKlass java/text/FieldPosition
+instanceKlass java/text/DecimalFormatSymbols
+instanceKlass java/text/DateFormatSymbols
+instanceKlass sun/util/calendar/CalendarDate
+instanceKlass sun/util/resources/Bundles$CacheKeyReference
+instanceKlass java/util/ResourceBundle$ResourceBundleProviderHelper
+instanceKlass  @bci sun/util/cldr/CLDRLocaleProviderAdapter applyAliases (Ljava/util/Locale;)Ljava/util/Locale; 4 <appendix> argL0 ; # sun/util/cldr/CLDRLocaleProviderAdapter$$Lambda+0x80000005a
+instanceKlass sun/util/resources/Bundles$CacheKey
+instanceKlass java/util/ResourceBundle$1
+instanceKlass jdk/internal/access/JavaUtilResourceBundleAccess
+instanceKlass sun/util/resources/Bundles
+instanceKlass sun/util/resources/LocaleData$LocaleDataStrategy
+instanceKlass sun/util/resources/Bundles$Strategy
+instanceKlass sun/util/resources/LocaleData
+instanceKlass sun/util/locale/provider/LocaleResources
+instanceKlass java/util/stream/Sink$ChainedReference
+instanceKlass java/util/stream/Node$Builder
+instanceKlass java/util/stream/AbstractSpinedBuffer
+instanceKlass java/util/stream/Node$OfDouble
+instanceKlass java/util/stream/Node$OfLong
+instanceKlass java/util/stream/Node$OfInt
+instanceKlass java/util/stream/Node$OfPrimitive
+instanceKlass java/util/stream/Nodes$EmptyNode
+instanceKlass java/util/stream/Node
+instanceKlass java/util/stream/Nodes
+instanceKlass  @bci sun/util/locale/provider/LocaleProviderAdapter toLocaleArray (Ljava/util/Set;)[Ljava/util/Locale; 21 <appendix> argL0 ; # sun/util/locale/provider/LocaleProviderAdapter$$Lambda+0x80000005d
+instanceKlass java/util/function/IntFunction
+instanceKlass java/util/stream/DistinctOps
+instanceKlass  @bci sun/util/locale/provider/LocaleProviderAdapter toLocaleArray (Ljava/util/Set;)[Ljava/util/Locale; 6 <appendix> argL0 ; # sun/util/locale/provider/LocaleProviderAdapter$$Lambda+0x80000005b
+instanceKlass java/util/Spliterators$IteratorSpliterator
+instanceKlass java/util/Spliterators
+instanceKlass  @bci java/util/ResourceBundle$Control getCandidateLocales (Ljava/lang/String;Ljava/util/Locale;)Ljava/util/List; 23 <appendix> argL0 ; # java/util/ResourceBundle$Control$$Lambda+0x80000001d
+instanceKlass  @bci java/util/ResourceBundle$Control <clinit> ()V 39 <appendix> argL0 ; # java/util/ResourceBundle$Control$$Lambda+0x80000001e
+instanceKlass java/util/ResourceBundle
+instanceKlass java/util/ResourceBundle$Control
+instanceKlass sun/util/locale/provider/CalendarDataUtility$CalendarWeekParameterGetter
+instanceKlass sun/util/locale/provider/LocaleServiceProviderPool$LocalizedObjectGetter
+instanceKlass sun/util/locale/provider/LocaleServiceProviderPool
+instanceKlass java/util/Locale$Builder
+instanceKlass sun/util/locale/provider/CalendarDataUtility
+instanceKlass sun/util/calendar/CalendarSystem$GregorianHolder
+instanceKlass sun/util/calendar/CalendarSystem
+instanceKlass java/util/Calendar$Builder
+instanceKlass sun/util/locale/provider/AvailableLanguageTags
+instanceKlass java/util/ServiceLoader$ProviderImpl
+instanceKlass java/util/ServiceLoader$Provider
+instanceKlass sun/util/resources/cldr/provider/CLDRLocaleDataMetaInfo
+instanceKlass jdk/internal/module/ModulePatcher$PatchedModuleReader
+instanceKlass java/util/ServiceLoader$2
+instanceKlass java/util/ServiceLoader$1
+instanceKlass java/util/ServiceLoader$LazyClassPathLookupIterator
+instanceKlass java/util/concurrent/CopyOnWriteArrayList$COWIterator
+instanceKlass java/util/ServiceLoader$ModuleServicesLookupIterator
+instanceKlass java/util/ServiceLoader
+instanceKlass java/util/Locale$LocaleCache
+instanceKlass jdk/internal/util/ReferencedKeyMap$1
+instanceKlass sun/util/locale/BaseLocale$1InterningCache
+instanceKlass sun/util/locale/InternalLocaleBuilder$CaseInsensitiveChar
+instanceKlass sun/util/locale/InternalLocaleBuilder
+instanceKlass sun/util/locale/StringTokenIterator
+instanceKlass java/text/ParsePosition
+instanceKlass sun/util/cldr/CLDRBaseLocaleDataMetaInfo
+instanceKlass sun/util/locale/provider/LocaleDataMetaInfo
+instanceKlass sun/util/locale/provider/ResourceBundleBasedAdapter
+instanceKlass sun/util/locale/provider/LocaleProviderAdapter
+instanceKlass java/util/spi/LocaleServiceProvider
+instanceKlass sun/util/calendar/CalendarUtils
+instanceKlass sun/util/calendar/ZoneInfoFile$ZoneOffsetTransitionRule
+instanceKlass java/lang/invoke/VarHandle$AccessDescriptor
+instanceKlass java/lang/invoke/VarForm
+instanceKlass java/lang/invoke/VarHandleGuards
+instanceKlass java/lang/invoke/VarHandles
+instanceKlass jdk/internal/util/ByteArray
+instanceKlass sun/util/calendar/ZoneInfoFile
+instanceKlass java/time/ZoneId
+instanceKlass java/util/TimeZone
+instanceKlass java/util/Calendar
+instanceKlass java/text/AttributedCharacterIterator$Attribute
+instanceKlass com/google/inject/matcher/AbstractMatcher
+instanceKlass com/google/inject/matcher/Matcher
+instanceKlass com/google/inject/spi/TypeConverter
+instanceKlass org/codehaus/plexus/DefaultPlexusContainer$LoggerProvider
+instanceKlass org/codehaus/plexus/DefaultPlexusContainer$DefaultsModule
+instanceKlass org/codehaus/plexus/DefaultPlexusContainer$ContainerModule
+instanceKlass java/util/concurrent/locks/ReentrantReadWriteLock$WriteLock
+instanceKlass java/util/concurrent/locks/ReentrantReadWriteLock$ReadLock
+instanceKlass java/util/concurrent/locks/ReentrantReadWriteLock
+instanceKlass java/util/concurrent/locks/ReadWriteLock
+instanceKlass org/eclipse/sisu/inject/ImplicitBindings
+instanceKlass org/eclipse/sisu/inject/MildValues$InverseMapping
+instanceKlass org/eclipse/sisu/inject/MildValues
+instanceKlass org/eclipse/sisu/inject/Weak
+instanceKlass sun/reflect/misc/ReflectUtil
+instanceKlass java/util/concurrent/atomic/AtomicReferenceFieldUpdater
+instanceKlass org/eclipse/sisu/inject/RankedSequence$Content
+instanceKlass org/eclipse/sisu/inject/RankedSequence
+instanceKlass org/eclipse/sisu/inject/BindingSubscriber
+instanceKlass org/eclipse/sisu/inject/DefaultBeanLocator
+instanceKlass org/eclipse/sisu/inject/DeferredClass
+instanceKlass org/codehaus/plexus/DefaultPlexusContainer$LoggerManagerProvider
+instanceKlass org/eclipse/sisu/inject/DeferredProvider
+instanceKlass com/google/inject/Provider
+instanceKlass com/google/inject/AbstractModule
+instanceKlass org/codehaus/plexus/context/Context
+instanceKlass org/eclipse/sisu/inject/BindingPublisher
+instanceKlass org/eclipse/sisu/inject/RankingFunction
+instanceKlass org/eclipse/sisu/space/ClassSpace
+instanceKlass javax/inject/Provider
+instanceKlass org/eclipse/sisu/bean/BeanManager
+instanceKlass org/eclipse/sisu/plexus/PlexusBeanLocator
+instanceKlass org/codehaus/plexus/classworlds/ClassWorldListener
+instanceKlass com/google/inject/Module
+instanceKlass org/eclipse/sisu/inject/MutableBeanLocator
+instanceKlass org/eclipse/sisu/inject/BeanLocator
+instanceKlass org/codehaus/plexus/DefaultPlexusContainer
+instanceKlass org/codehaus/plexus/MutablePlexusContainer
+instanceKlass jdk/internal/foreign/MemorySessionImpl
+instanceKlass java/lang/foreign/MemorySegment$Scope
+instanceKlass java/util/stream/ReduceOps$AccumulatingSink
+instanceKlass java/util/stream/TerminalSink
+instanceKlass java/util/stream/Sink
+instanceKlass java/util/stream/ReduceOps$Box
+instanceKlass java/util/stream/ReduceOps$ReduceOp
+instanceKlass java/util/stream/TerminalOp
+instanceKlass java/util/stream/ReduceOps
+instanceKlass  @bci java/util/function/Function andThen (Ljava/util/function/Function;)Ljava/util/function/Function; 7 <appendix> member <vmtarget> ; # java/util/function/Function$$Lambda+0x000000008d0127e0
+instanceKlass  @cpi java/util/function/Function 58 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d05c000
+instanceKlass  @bci org/apache/maven/extension/internal/CoreExports <init> (Lorg/codehaus/plexus/classworlds/realm/ClassRealm;Ljava/util/Set;Ljava/util/Set;)V 38 <appendix> argL0 ; # org/apache/maven/extension/internal/CoreExports$$Lambda+0x000000008d058478
+instanceKlass  @bci java/util/stream/Collectors castingIdentity ()Ljava/util/function/Function; 0 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x800000042
+instanceKlass  @bci java/util/stream/Collectors uniqKeysMapMerger ()Ljava/util/function/BinaryOperator; 0 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x000000008d012590
+instanceKlass java/util/function/BinaryOperator
+instanceKlass  @bci java/util/stream/Collectors uniqKeysMapAccumulator (Ljava/util/function/Function;Ljava/util/function/Function;)Ljava/util/function/BiConsumer; 2 <appendix> member <vmtarget> ; # java/util/stream/Collectors$$Lambda+0x000000008d012350
+instanceKlass  @bci java/util/stream/Collectors toMap (Ljava/util/function/Function;Ljava/util/function/Function;)Ljava/util/stream/Collector; 4 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x000000008d012128
+instanceKlass java/util/stream/Collector
+instanceKlass java/util/stream/Collectors
+instanceKlass  @bci org/apache/maven/extension/internal/CoreExports <init> (Lorg/codehaus/plexus/classworlds/realm/ClassRealm;Ljava/util/Set;Ljava/util/Set;)V 30 <appendix> member <vmtarget> ; # org/apache/maven/extension/internal/CoreExports$$Lambda+0x000000008d058228
+instanceKlass  @bci java/util/function/Function identity ()Ljava/util/function/Function; 0 <appendix> argL0 ; # java/util/function/Function$$Lambda+0x000000008d011ce0
+instanceKlass java/lang/classfile/constantpool/InterfaceMethodRefEntry
+instanceKlass java/util/EnumMap$1
+instanceKlass java/util/stream/StreamOpFlag$MaskBuilder
+instanceKlass java/util/stream/Stream
+instanceKlass java/util/stream/BaseStream
+instanceKlass java/util/stream/PipelineHelper
+instanceKlass java/util/stream/StreamSupport
+instanceKlass java/util/Spliterator
+instanceKlass java/util/HashMap$HashMapSpliterator
+instanceKlass org/apache/maven/extension/internal/CoreExports
+instanceKlass java/util/Collections$UnmodifiableCollection$1
+instanceKlass org/codehaus/plexus/DefaultContainerConfiguration
+instanceKlass org/codehaus/plexus/ContainerConfiguration
+instanceKlass org/codehaus/plexus/util/BaseIOUtil
+instanceKlass org/codehaus/plexus/util/xml/XMLWriter
+instanceKlass org/codehaus/plexus/util/xml/Xpp3Dom
+instanceKlass org/codehaus/plexus/util/xml/pull/MXParser
+instanceKlass org/codehaus/plexus/util/xml/pull/XmlPullParser
+instanceKlass org/codehaus/plexus/util/xml/Xpp3DomBuilder
+instanceKlass java/util/regex/ASCII
+instanceKlass  @bci java/util/regex/CharPredicates ASCII_SPACE ()Ljava/util/regex/Pattern$BmpCharPredicate; 0 <appendix> argL0 ; # java/util/regex/CharPredicates$$Lambda+0x800000025
+instanceKlass  @bci java/util/regex/Pattern DOT ()Ljava/util/regex/Pattern$CharPredicate; 0 <appendix> argL0 ; # java/util/regex/Pattern$$Lambda+0x000000008d010378
+instanceKlass  @bci java/util/regex/Pattern union (Ljava/util/regex/Pattern$CharPredicate;Ljava/util/regex/Pattern$CharPredicate;Z)Ljava/util/regex/Pattern$CharPredicate; 14 <appendix> member <vmtarget> ; # java/util/regex/Pattern$$Lambda+0x000000008d00fc98
+instanceKlass org/codehaus/plexus/util/ReaderFactory
+instanceKlass org/apache/maven/project/ExtensionDescriptor
+instanceKlass org/apache/maven/project/ExtensionDescriptorBuilder
+instanceKlass org/apache/maven/extension/internal/CoreExtensionEntry
+instanceKlass org/codehaus/plexus/logging/Logger
+instanceKlass org/apache/maven/cli/logging/Slf4jLoggerManager
+instanceKlass org/slf4j/impl/MavenSlf4jSimpleFriend
+instanceKlass org/slf4j/MavenSlf4jFriend
+instanceKlass  @bci org/apache/commons/cli/CommandLine getOptionValue (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String; 7 <appendix> member <vmtarget> ; # org/apache/commons/cli/CommandLine$$Lambda+0x000000008d056660
+instanceKlass org/apache/maven/cli/logging/impl/Slf4jSimpleConfiguration$1
+instanceKlass org/apache/maven/cli/logging/BaseSlf4jConfiguration
+instanceKlass org/codehaus/plexus/util/PropertyUtils
+instanceKlass org/apache/maven/cli/logging/Slf4jConfiguration
+instanceKlass org/apache/maven/cli/logging/Slf4jConfigurationFactory
+instanceKlass org/slf4j/impl/OutputChoice
+instanceKlass java/io/FileInputStream$1
+instanceKlass org/slf4j/impl/SimpleLoggerConfiguration$1
+instanceKlass java/text/Format
+instanceKlass org/slf4j/impl/SimpleLoggerConfiguration
+instanceKlass org/slf4j/helpers/NamedLoggerBase
+instanceKlass org/slf4j/impl/SimpleLoggerFactory
+instanceKlass org/slf4j/impl/StaticLoggerBinder
+instanceKlass org/slf4j/spi/LoggerFactoryBinder
+instanceKlass java/util/Collections$3
+instanceKlass java/net/URLClassLoader$1
+instanceKlass jdk/internal/loader/URLClassPath$1
+instanceKlass java/lang/CompoundEnumeration
+instanceKlass jdk/internal/loader/BuiltinClassLoader$1
+instanceKlass java/util/Collections$EmptyEnumeration
+instanceKlass org/slf4j/helpers/Util
+instanceKlass org/slf4j/helpers/NOPLoggerFactory
+instanceKlass java/util/concurrent/LinkedBlockingQueue$Node
+instanceKlass java/util/concurrent/locks/AbstractQueuedSynchronizer$ConditionObject
+instanceKlass java/util/concurrent/locks/Condition
+instanceKlass java/util/concurrent/BlockingQueue
+instanceKlass org/slf4j/helpers/SubstituteLoggerFactory
+instanceKlass org/slf4j/ILoggerFactory
+instanceKlass org/slf4j/event/LoggingEvent
+instanceKlass org/slf4j/LoggerFactory
+instanceKlass java/util/LinkedList$ListItr
+instanceKlass org/codehaus/plexus/util/StringUtils
+instanceKlass org/apache/maven/cli/CLIReportingUtils
+instanceKlass  @bci org/apache/maven/cli/MavenCli populateProperties (Lorg/apache/maven/cli/CliRequest;Ljava/util/Properties;Ljava/util/Properties;)V 236 <appendix> argL0 ; # org/apache/maven/cli/MavenCli$$Lambda+0x000000008d0509d8
+instanceKlass  @cpi com/sun/tools/javac/code/DeferredLintHandler 210 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d054000
+instanceKlass java/util/function/BiConsumer
+instanceKlass org/codehaus/plexus/interpolation/SimpleRecursionInterceptor
+instanceKlass org/codehaus/plexus/interpolation/AbstractValueSource
+instanceKlass org/codehaus/plexus/interpolation/RecursionInterceptor
+instanceKlass org/codehaus/plexus/interpolation/StringSearchInterpolator
+instanceKlass org/codehaus/plexus/interpolation/Interpolator
+instanceKlass org/codehaus/plexus/interpolation/BasicInterpolator
+instanceKlass org/apache/maven/properties/internal/SystemProperties
+instanceKlass java/util/concurrent/ConcurrentHashMap$MapEntry
+instanceKlass java/util/Collections$SynchronizedCollection
+instanceKlass java/util/Properties$EntrySet
+instanceKlass java/util/Collections$UnmodifiableMap$UnmodifiableEntrySet$UnmodifiableEntry
+instanceKlass java/util/Collections$UnmodifiableMap$UnmodifiableEntrySet$1
+instanceKlass org/codehaus/plexus/util/Os
+instanceKlass org/apache/maven/properties/internal/EnvironmentUtils
+instanceKlass java/util/LinkedList$Node
+instanceKlass java/util/AbstractList$Itr
+instanceKlass org/apache/commons/cli/DefaultParser
+instanceKlass org/apache/commons/cli/Util
+instanceKlass  @bci org/apache/commons/cli/CommandLine$Builder <clinit> ()V 0 <appendix> argL0 ; # org/apache/commons/cli/CommandLine$Builder$$Lambda+0x000000008d04fd58
+instanceKlass  @cpi org/apache/commons/cli/CommandLine$Builder 102 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d04c800
+instanceKlass  @cpi com/sun/tools/javac/code/DeferredCompletionFailureHandler$1 101 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d04c400
+instanceKlass org/apache/commons/cli/CommandLine$Builder
+instanceKlass org/apache/commons/cli/CommandLine
+instanceKlass java/util/Collections$UnmodifiableCollection
+instanceKlass java/util/LinkedHashMap$LinkedHashIterator
+instanceKlass org/apache/commons/cli/Parser
+instanceKlass org/apache/maven/cli/CleanArgument
+instanceKlass org/apache/commons/cli/OptionValidator
+instanceKlass org/apache/commons/cli/Option$Builder
+instanceKlass org/apache/commons/cli/Option
+instanceKlass org/apache/commons/cli/Options
+instanceKlass org/apache/commons/cli/CommandLineParser
+instanceKlass org/apache/maven/cli/CLIManager
+instanceKlass org/apache/maven/cli/logging/Slf4jStdoutLogger
+instanceKlass sun/nio/fs/WindowsPath$1
+instanceKlass sun/nio/fs/WindowsLinkSupport
+instanceKlass java/util/IdentityHashMap$IdentityHashMapIterator
+instanceKlass org/eclipse/aether/DefaultRepositoryCache
+instanceKlass org/apache/maven/project/ProjectBuildingRequest
+instanceKlass org/eclipse/aether/RepositoryCache
+instanceKlass java/util/regex/IntHashSet
+instanceKlass java/util/regex/Matcher
+instanceKlass java/util/regex/MatchResult
+instanceKlass java/util/Properties$LineReader
+instanceKlass org/apache/maven/execution/DefaultMavenExecutionRequest
+instanceKlass org/apache/maven/execution/MavenExecutionRequest
+instanceKlass sun/net/www/MessageHeader
+instanceKlass java/lang/Shutdown$Lock
+instanceKlass java/lang/Shutdown
+instanceKlass java/lang/ApplicationShutdownHooks$1
+instanceKlass java/lang/ApplicationShutdownHooks
+instanceKlass java/lang/Thread$ThreadNumbering
+instanceKlass sun/net/www/protocol/jar/JarFileFactory
+instanceKlass sun/net/www/protocol/jar/URLJarFile$URLJarFileCloseController
+instanceKlass java/net/URLConnection
+instanceKlass jdk/internal/jimage/ImageLocation
+instanceKlass jdk/internal/jimage/decompressor/Decompressor
+instanceKlass jdk/internal/jimage/ImageStringsReader
+instanceKlass jdk/internal/jimage/ImageStrings
+instanceKlass org/fusesource/jansi/io/AnsiOutputStream$ZeroWidthSupplier
+instanceKlass jdk/internal/jimage/ImageHeader
+instanceKlass jdk/internal/loader/NativeLibraries$Unloader
+instanceKlass jdk/internal/jimage/NativeImageBuffer$1
+instanceKlass jdk/internal/jimage/NativeImageBuffer
+instanceKlass java/security/AccessControlContext
+instanceKlass java/security/AccessController
+instanceKlass jdk/internal/jimage/BasicImageReader$1
+instanceKlass java/security/PrivilegedAction
+instanceKlass jdk/internal/jimage/BasicImageReader
+instanceKlass jdk/internal/jimage/ImageReader
+instanceKlass jdk/internal/jimage/ImageReaderFactory$1
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d04c000
+instanceKlass jdk/internal/reflect/Reflection$1Holder
+instanceKlass sun/reflect/annotation/AnnotationParser
+instanceKlass org/fusesource/jansi/internal/OSInfo
+instanceKlass jdk/internal/jimage/ImageReaderFactory
+instanceKlass jdk/internal/module/SystemModuleFinders$SystemImage
+instanceKlass jdk/internal/module/SystemModuleFinders$SystemModuleReader
+instanceKlass java/lang/module/ModuleReader
+instanceKlass jdk/internal/loader/BuiltinClassLoader$2
+instanceKlass jdk/internal/module/Resources
+instanceKlass org/fusesource/jansi/internal/JansiLoader$1
+instanceKlass  @bci org/fusesource/jansi/internal/JansiLoader initialize ()Z 10 <appendix> argL0 ; # org/fusesource/jansi/internal/JansiLoader$$Lambda+0x000000008d049148
+instanceKlass org/fusesource/jansi/internal/JansiLoader
+instanceKlass org/fusesource/jansi/internal/CLibrary
+instanceKlass java/util/TreeMap$Entry
+instanceKlass java/lang/ProcessEnvironment$CheckedEntry
+instanceKlass java/lang/ProcessEnvironment$CheckedEntrySet$1
+instanceKlass java/lang/ProcessEnvironment$EntryComparator
+instanceKlass java/lang/ProcessEnvironment$NameComparator
+instanceKlass org/fusesource/jansi/io/AnsiProcessor
+instanceKlass org/fusesource/jansi/io/AnsiOutputStream$WidthSupplier
+instanceKlass org/fusesource/jansi/AnsiConsole
+instanceKlass  @bci org/fusesource/jansi/Ansi <clinit> ()V 26 <appendix> argL0 ; # org/fusesource/jansi/Ansi$$Lambda+0x000000008d047c98
+instanceKlass  @cpi jdk/internal/jrtfs/SystemImage 218 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d046800
+instanceKlass java/util/concurrent/Callable
+instanceKlass org/fusesource/jansi/Ansi
+instanceKlass org/apache/maven/shared/utils/logging/LoggerLevelRenderer
+instanceKlass org/apache/maven/shared/utils/logging/MessageBuilder
+instanceKlass org/apache/maven/shared/utils/logging/MessageUtils
+instanceKlass  @bci jdk/internal/reflect/DirectMethodHandleAccessor invokeImpl (Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object; 72 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x000000008d046400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d046000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d045c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d045800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d045400
+instanceKlass sun/invoke/util/ValueConversions$WrapperCache
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x000000008d045000
+instanceKlass java/lang/invoke/LambdaFormBuffer
+instanceKlass java/lang/invoke/LambdaFormEditor$TransformKey
+instanceKlass java/lang/invoke/LambdaFormEditor
+instanceKlass java/lang/invoke/DelegatingMethodHandle$Holder
+instanceKlass jdk/internal/reflect/MethodHandleAccessorFactory$LazyStaticHolder
+instanceKlass  @bci java/util/regex/Pattern negate (Ljava/util/regex/Pattern$CharPredicate;)Ljava/util/regex/Pattern$CharPredicate; 1 <appendix> member <vmtarget> ; # java/util/regex/Pattern$$Lambda+0x80000002f
+instanceKlass  @bci java/util/regex/Pattern Range (II)Ljava/util/regex/Pattern$CharPredicate; 23 <appendix> member <vmtarget> ; # java/util/regex/Pattern$$Lambda+0x800000028
+instanceKlass  @bci java/util/regex/Pattern union (Ljava/util/regex/Pattern$CharPredicate;Ljava/util/regex/Pattern$CharPredicate;Z)Ljava/util/regex/Pattern$CharPredicate; 6 <appendix> member <vmtarget> ; # java/util/regex/Pattern$$Lambda+0x800000030
+instanceKlass  @bci java/util/regex/CharPredicates ASCII_DIGIT ()Ljava/util/regex/Pattern$BmpCharPredicate; 0 <appendix> argL0 ; # java/util/regex/CharPredicates$$Lambda+0x800000024
+instanceKlass java/util/regex/CharPredicates
+instanceKlass java/util/regex/Pattern$BitClass
+instanceKlass java/util/regex/Pattern$TreeInfo
+instanceKlass  @bci java/util/regex/Pattern Single (I)Ljava/util/regex/Pattern$BmpCharPredicate; 1 <appendix> member <vmtarget> ; # java/util/regex/Pattern$$Lambda+0x800000027
+instanceKlass java/util/regex/Pattern$BmpCharPredicate
+instanceKlass java/util/regex/Pattern$CharPredicate
+instanceKlass java/util/regex/Pattern$Node
+instanceKlass java/util/regex/Pattern
+instanceKlass org/apache/maven/cli/CliRequest
+instanceKlass org/codehaus/plexus/interpolation/ValueSource
+instanceKlass org/apache/maven/execution/ExecutionListener
+instanceKlass org/eclipse/aether/transfer/TransferListener
+instanceKlass org/slf4j/Logger
+instanceKlass org/codehaus/plexus/logging/LoggerManager
+instanceKlass org/apache/maven/toolchain/building/ToolchainsBuildingRequest
+instanceKlass org/apache/maven/building/Source
+instanceKlass org/apache/maven/exception/ExceptionHandler
+instanceKlass org/apache/maven/eventspy/EventSpy$Context
+instanceKlass org/codehaus/plexus/PlexusContainer
+instanceKlass org/apache/maven/cli/MavenCli
+instanceKlass  @bci java/util/zip/ZipFile$Source initCEN (ILjava/util/zip/ZipCoder;)V 507 <appendix> argL0 ; # java/util/zip/ZipFile$Source$$Lambda+0x000000008d004348
+instanceKlass java/util/TreeMap$PrivateEntryIterator
+instanceKlass java/util/TimSort
+instanceKlass java/util/Arrays$LegacyMergeSort
+instanceKlass  @bci org/codehaus/plexus/classworlds/launcher/Configurator associateRealms ()V 18 <appendix> argL0 ; # org/codehaus/plexus/classworlds/launcher/Configurator$$Lambda+0x000000008d0424a8
+instanceKlass  @bci org/codehaus/plexus/classworlds/launcher/ConfigurationParser loadGlob (Ljava/lang/String;Z)V 83 <appendix> member <vmtarget> ; # org/codehaus/plexus/classworlds/launcher/ConfigurationParser$$Lambda+0x000000008d042278
+instanceKlass  @cpi org/codehaus/plexus/classworlds/launcher/ConfigurationParser 340 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x000000008d043000
+instanceKlass jdk/internal/classfile/impl/AnnotationReader
+instanceKlass jdk/internal/classfile/impl/TerminalFieldBuilder
+instanceKlass java/lang/classfile/FieldBuilder
+instanceKlass java/lang/invoke/InvokerBytecodeGenerator$2
+instanceKlass sun/invoke/empty/Empty
+instanceKlass sun/invoke/util/VerifyType
+instanceKlass java/lang/invoke/InvokerBytecodeGenerator$4$1
+instanceKlass java/lang/classfile/constantpool/FieldRefEntry
+instanceKlass java/lang/invoke/InvokerBytecodeGenerator$4
+instanceKlass java/lang/classfile/attribute/SourceFileAttribute
+instanceKlass java/lang/classfile/Superclass
+instanceKlass java/lang/invoke/InvokerBytecodeGenerator$1
+instanceKlass java/lang/invoke/InvokerBytecodeGenerator$3
+instanceKlass java/io/FilenameFilter
+instanceKlass org/codehaus/plexus/classworlds/strategy/AbstractStrategy
+instanceKlass org/codehaus/plexus/classworlds/strategy/Strategy
+instanceKlass org/codehaus/plexus/classworlds/strategy/StrategyFactory
+instanceKlass java/util/NavigableMap
+instanceKlass java/util/SortedMap
+instanceKlass java/util/NavigableSet
+instanceKlass java/util/SortedSet
+instanceKlass java/util/SequencedSet
+instanceKlass sun/nio/ch/IOStatus
+instanceKlass sun/nio/ch/Util$BufferCache
+instanceKlass sun/nio/ch/Util
+instanceKlass jdk/internal/misc/Blocker
+instanceKlass sun/nio/ch/NativeThread
+instanceKlass java/nio/charset/CoderResult
+instanceKlass java/io/Reader
+instanceKlass java/lang/Readable
+instanceKlass org/codehaus/plexus/classworlds/launcher/ConfigurationParser
+instanceKlass org/codehaus/plexus/classworlds/launcher/Configurator
+instanceKlass org/codehaus/plexus/classworlds/launcher/ConfigurationHandler
+instanceKlass sun/nio/ch/SelChImpl
+instanceKlass java/nio/channels/NetworkChannel
+instanceKlass sun/nio/ch/Streams
+instanceKlass java/nio/channels/Channels
+instanceKlass sun/nio/ch/FileChannelImpl$Closer
+instanceKlass sun/nio/ch/NativeThreadSet
+instanceKlass java/nio/channels/spi/AbstractInterruptibleChannel$1
+instanceKlass sun/nio/ch/Interruptible
+instanceKlass sun/nio/ch/IOUtil
+instanceKlass sun/nio/ch/NativeDispatcher
+instanceKlass java/nio/channels/ScatteringByteChannel
+instanceKlass java/nio/channels/GatheringByteChannel
+instanceKlass java/nio/channels/SeekableByteChannel
+instanceKlass java/nio/channels/ByteChannel
+instanceKlass java/nio/channels/WritableByteChannel
+instanceKlass java/nio/channels/ReadableByteChannel
+instanceKlass java/nio/channels/spi/AbstractInterruptibleChannel
+instanceKlass java/nio/channels/InterruptibleChannel
+instanceKlass java/nio/channels/Channel
+instanceKlass java/util/Collections$EmptyIterator
+instanceKlass sun/nio/fs/WindowsChannelFactory$Flags
+instanceKlass sun/nio/fs/WindowsChannelFactory$1
+instanceKlass sun/nio/fs/WindowsChannelFactory
+instanceKlass sun/nio/fs/WindowsSecurityDescriptor
+instanceKlass java/nio/file/attribute/FileAttribute
+instanceKlass java/net/URI$Parser
+instanceKlass java/nio/file/FileSystems$DefaultFileSystemHolder
+instanceKlass java/nio/file/FileSystems
+instanceKlass java/nio/file/Paths
+instanceKlass java/lang/PublicMethods$Key
+instanceKlass java/lang/PublicMethods$MethodList
+instanceKlass org/codehaus/plexus/classworlds/ClassWorld
+instanceKlass jdk/internal/misc/MethodFinder
+instanceKlass org/codehaus/plexus/classworlds/launcher/Launcher
+instanceKlass java/security/PermissionCollection
+instanceKlass java/security/SecureClassLoader$1
+instanceKlass java/util/zip/Checksum$1
+instanceKlass java/util/zip/CRC32
+instanceKlass java/util/zip/Checksum
+instanceKlass sun/nio/ByteBuffered
+instanceKlass java/lang/Package$VersionInfo
+instanceKlass java/lang/NamedPackage
+instanceKlass java/util/SequencedMap
+instanceKlass java/util/jar/Attributes
+instanceKlass jdk/internal/loader/Resource
+instanceKlass sun/security/util/Debug
+instanceKlass sun/security/util/SignatureFileVerifier
+instanceKlass java/util/zip/ZipFile$InflaterCleanupAction
+instanceKlass java/util/zip/Inflater$InflaterZStreamRef
+instanceKlass java/util/zip/Inflater
+instanceKlass java/util/zip/ZipEntry
+instanceKlass java/nio/Bits$1
+instanceKlass jdk/internal/misc/VM$BufferPool
+instanceKlass java/nio/Bits
+instanceKlass sun/nio/ch/DirectBuffer
+instanceKlass jdk/internal/perf/PerfCounter$CoreCounters
+instanceKlass jdk/internal/perf/Perf
+instanceKlass jdk/internal/perf/PerfCounter
+instanceKlass sun/util/locale/LocaleUtils
+instanceKlass java/util/Locale
+instanceKlass java/nio/file/attribute/FileTime
+instanceKlass java/util/zip/ZipUtils
+instanceKlass java/util/zip/ZipFile$Source$End
+instanceKlass java/io/RandomAccessFile$2
+instanceKlass jdk/internal/access/JavaIORandomAccessFileAccess
+instanceKlass java/io/RandomAccessFile
+instanceKlass java/io/DataInput
+instanceKlass java/io/DataOutput
+instanceKlass sun/nio/fs/WindowsNativeDispatcher$CompletionStatus
+instanceKlass sun/nio/fs/WindowsNativeDispatcher$AclInformation
+instanceKlass sun/nio/fs/WindowsNativeDispatcher$Account
+instanceKlass sun/nio/fs/WindowsNativeDispatcher$DiskFreeSpace
+instanceKlass sun/nio/fs/WindowsNativeDispatcher$VolumeInformation
+instanceKlass sun/nio/fs/WindowsNativeDispatcher$FirstStream
+instanceKlass sun/nio/fs/WindowsNativeDispatcher$FirstFile
+instanceKlass java/util/Enumeration
+instanceKlass java/util/concurrent/ConcurrentHashMap$Traverser
+instanceKlass jdk/internal/loader/NativeLibraries$2
+instanceKlass jdk/internal/loader/NativeLibrary
+instanceKlass java/util/ArrayDeque$DeqIterator
+instanceKlass jdk/internal/loader/NativeLibraries$NativeLibraryContext$1
+instanceKlass jdk/internal/loader/NativeLibraries$NativeLibraryContext
+instanceKlass jdk/internal/loader/NativeLibraries$1
+instanceKlass jdk/internal/loader/NativeLibraries$LibraryPaths
+instanceKlass sun/nio/fs/WindowsNativeDispatcher
+instanceKlass sun/nio/fs/NativeBuffer$Deallocator
+instanceKlass sun/nio/fs/NativeBuffer
+instanceKlass java/lang/ThreadLocal$ThreadLocalMap
+instanceKlass java/lang/ThreadLocal
+instanceKlass sun/nio/fs/NativeBuffers
+instanceKlass sun/nio/fs/WindowsFileAttributes
+instanceKlass java/nio/file/attribute/DosFileAttributes
+instanceKlass sun/nio/fs/AbstractBasicFileAttributeView
+instanceKlass sun/nio/fs/DynamicFileAttributeView
+instanceKlass sun/nio/fs/WindowsFileAttributeViews
+instanceKlass sun/nio/fs/Util
+instanceKlass java/nio/file/attribute/BasicFileAttributeView
+instanceKlass java/nio/file/attribute/FileAttributeView
+instanceKlass java/nio/file/attribute/AttributeView
+instanceKlass java/nio/file/Files
+instanceKlass java/nio/file/CopyOption
+instanceKlass java/nio/file/attribute/BasicFileAttributes
+instanceKlass sun/nio/fs/WindowsPath
+instanceKlass java/nio/file/Path
+instanceKlass java/nio/file/Watchable
+instanceKlass java/util/zip/ZipFile$Source$Key
+instanceKlass sun/nio/fs/WindowsPathParser
+instanceKlass java/nio/file/FileSystem
+instanceKlass java/nio/file/OpenOption
+instanceKlass java/nio/file/spi/FileSystemProvider
+instanceKlass sun/nio/fs/DefaultFileSystemProvider
+instanceKlass java/util/zip/ZipFile$Source
+instanceKlass java/lang/ref/Cleaner$Cleanable
+instanceKlass jdk/internal/ref/CleanerImpl$CleanableList$Node
+instanceKlass jdk/internal/ref/CleanerImpl$CleanableList
+instanceKlass jdk/internal/ref/CleanerImpl
+instanceKlass java/lang/ref/Cleaner$1
+instanceKlass java/lang/ref/Cleaner
+instanceKlass jdk/internal/ref/CleanerFactory$1
+instanceKlass java/util/concurrent/ThreadFactory
+instanceKlass jdk/internal/ref/CleanerFactory
+instanceKlass java/util/zip/ZipFile$CleanableResource
+instanceKlass java/util/zip/ZipCoder
+instanceKlass java/lang/Runtime$Version
+instanceKlass java/util/jar/JavaUtilJarAccessImpl
+instanceKlass jdk/internal/access/JavaUtilJarAccess
+instanceKlass jdk/internal/loader/FileURLMapper
+instanceKlass java/util/zip/ZipFile$1
+instanceKlass jdk/internal/access/JavaUtilZipFileAccess
+instanceKlass java/util/BitSet
+instanceKlass java/util/zip/ZipFile
+instanceKlass java/util/zip/ZipConstants
+instanceKlass jdk/internal/loader/URLClassPath$Loader
+instanceKlass sun/net/util/URLUtil
+instanceKlass sun/nio/cs/SingleByte
+instanceKlass sun/nio/cs/MS1252$Holder
+instanceKlass sun/nio/cs/ArrayDecoder
+instanceKlass java/nio/charset/CharsetDecoder
+instanceKlass sun/launcher/LauncherHelper
+instanceKlass jdk/internal/vm/ContinuationSupport
+instanceKlass java/lang/WeakPairMap$Pair$Lookup
+instanceKlass java/lang/WeakPairMap$Pair
+instanceKlass java/lang/WeakPairMap
+instanceKlass java/lang/Module$ReflectionData
+instanceKlass java/util/ArrayList$Itr
+instanceKlass java/lang/invoke/Invokers$Holder
+instanceKlass java/lang/invoke/DirectMethodHandle$2
+instanceKlass java/lang/invoke/ClassSpecializer$Factory
+instanceKlass java/lang/invoke/ClassSpecializer$SpeciesData
+instanceKlass java/lang/invoke/ClassSpecializer$1
+instanceKlass jdk/internal/vm/annotation/Stable
+instanceKlass java/lang/invoke/ClassSpecializer
+instanceKlass java/lang/invoke/MethodHandleImpl$1
+instanceKlass jdk/internal/access/JavaLangInvokeAccess
+instanceKlass  @bci jdk/internal/module/ModuleBootstrap decode (Ljava/lang/String;Ljava/lang/String;Z)Ljava/util/Map; 193 <appendix> argL0 ; # jdk/internal/module/ModuleBootstrap$$Lambda+0x000000008d000800
+instanceKlass jdk/internal/util/ModifiedUtf
+instanceKlass java/lang/StringCoding
+instanceKlass jdk/internal/classfile/impl/ClassReaderImpl
+instanceKlass java/lang/classfile/ClassReader
+instanceKlass jdk/internal/classfile/impl/ClassHierarchyImpl$CachedClassHierarchyResolver$1
+instanceKlass java/lang/classfile/ClassHierarchyResolver$ClassHierarchyInfo
+instanceKlass jdk/internal/classfile/impl/ClassHierarchyImpl$CachedClassHierarchyResolver
+instanceKlass jdk/internal/classfile/impl/ClassHierarchyImpl$ClassLoadingClassHierarchyResolver$1
+instanceKlass jdk/internal/classfile/impl/ClassHierarchyImpl$ClassLoadingClassHierarchyResolver
+instanceKlass java/lang/classfile/ClassHierarchyResolver
+instanceKlass jdk/internal/classfile/impl/ClassHierarchyImpl
+instanceKlass jdk/internal/classfile/impl/RawBytecodeHelper$1
+instanceKlass jdk/internal/classfile/impl/RawBytecodeHelper
+instanceKlass jdk/internal/classfile/impl/StackMapGenerator$Frame
+instanceKlass jdk/internal/classfile/impl/StackMapGenerator
+instanceKlass java/lang/classfile/CustomAttribute
+instanceKlass jdk/internal/classfile/impl/BytecodeHelpers
+instanceKlass java/lang/invoke/TypeConvertingMethodAdapter
+instanceKlass jdk/internal/classfile/impl/DirectCodeBuilder$8
+instanceKlass java/lang/invoke/InnerClassLambdaMetafactory$6
+instanceKlass java/lang/classfile/constantpool/MethodRefEntry
+instanceKlass java/lang/classfile/constantpool/MemberRefEntry
+instanceKlass java/lang/classfile/constantpool/NameAndTypeEntry
+instanceKlass java/lang/classfile/instruction/LabelTarget
+instanceKlass java/lang/classfile/Label
+instanceKlass jdk/internal/classfile/impl/BufWriterImpl
+instanceKlass java/lang/classfile/BufWriter
+instanceKlass java/lang/classfile/instruction/LocalVariableType
+instanceKlass java/lang/classfile/instruction/LocalVariable
+instanceKlass java/lang/classfile/instruction/CharacterRange
+instanceKlass java/lang/classfile/PseudoInstruction
+instanceKlass java/lang/classfile/CodeElement
+instanceKlass jdk/internal/classfile/impl/TerminalCodeBuilder
+instanceKlass jdk/internal/classfile/impl/LabelContext
+instanceKlass java/lang/classfile/CodeBuilder
+instanceKlass jdk/internal/classfile/impl/TerminalMethodBuilder
+instanceKlass jdk/internal/classfile/impl/MethodInfo
+instanceKlass java/lang/classfile/MethodBuilder
+instanceKlass java/lang/invoke/InnerClassLambdaMetafactory$3
+instanceKlass java/lang/classfile/Interfaces
+instanceKlass java/util/ImmutableCollections$Access$1
+instanceKlass jdk/internal/access/JavaUtilCollectionAccess
+instanceKlass java/util/ImmutableCollections$Access
+instanceKlass jdk/internal/classfile/impl/AttributeHolder
+instanceKlass java/lang/classfile/ClassBuilder
+instanceKlass java/lang/classfile/ClassFileBuilder
+instanceKlass jdk/internal/classfile/impl/AbstractDirectBuilder
+instanceKlass java/lang/invoke/InnerClassLambdaMetafactory$1
+instanceKlass java/util/function/Consumer
+instanceKlass jdk/internal/classfile/impl/ClassFileImpl
+instanceKlass java/lang/classfile/ClassFile
+instanceKlass java/lang/invoke/LambdaProxyClassArchive
+instanceKlass java/lang/classfile/constantpool/ClassEntry
+instanceKlass java/lang/classfile/constantpool/LoadableConstantEntry
+instanceKlass jdk/internal/classfile/impl/Util
+instanceKlass jdk/internal/classfile/impl/EntryMap
+instanceKlass jdk/internal/classfile/impl/BootstrapMethodEntryImpl
+instanceKlass java/lang/classfile/BootstrapMethodEntry
+instanceKlass jdk/internal/classfile/impl/SplitConstantPool
+instanceKlass java/lang/invoke/InfoFromMemberName
+instanceKlass java/lang/invoke/MethodHandleInfo
+instanceKlass java/lang/invoke/AbstractValidatingLambdaMetafactory
+instanceKlass java/lang/invoke/BootstrapMethodInvoker
+instanceKlass java/lang/invoke/InvokerBytecodeGenerator$8
+instanceKlass jdk/internal/classfile/impl/AbstractAttributeMapper
+instanceKlass java/lang/classfile/AttributeMapper
+instanceKlass java/lang/classfile/Attributes
+instanceKlass jdk/internal/classfile/impl/Util$Writable
+instanceKlass jdk/internal/classfile/impl/AbstractElement
+instanceKlass java/lang/classfile/attribute/RuntimeVisibleAnnotationsAttribute
+instanceKlass java/lang/classfile/FieldElement
+instanceKlass java/lang/classfile/MethodElement
+instanceKlass java/lang/classfile/ClassElement
+instanceKlass java/lang/classfile/Attribute
+instanceKlass java/lang/classfile/ClassFileElement
+instanceKlass java/lang/classfile/constantpool/Utf8Entry
+instanceKlass java/lang/classfile/constantpool/AnnotationConstantValueEntry
+instanceKlass java/lang/classfile/constantpool/PoolEntry
+instanceKlass jdk/internal/classfile/impl/AbstractPoolEntry
+instanceKlass jdk/internal/classfile/impl/TemporaryConstantPool
+instanceKlass java/lang/classfile/constantpool/ConstantPoolBuilder
+instanceKlass java/lang/classfile/constantpool/ConstantPool
+instanceKlass java/lang/classfile/Annotation
+instanceKlass java/lang/classfile/AnnotationElement
+instanceKlass java/lang/invoke/InvokerBytecodeGenerator
+instanceKlass java/lang/invoke/LambdaForm$Holder
+instanceKlass java/lang/invoke/LambdaForm$Name
+instanceKlass java/lang/reflect/Array
+instanceKlass java/lang/invoke/Invokers
+instanceKlass sun/invoke/util/ValueConversions
+instanceKlass java/lang/invoke/DirectMethodHandle$Holder
+instanceKlass java/lang/invoke/LambdaForm$NamedFunction
+instanceKlass java/lang/constant/DynamicConstantDesc
+instanceKlass jdk/internal/constant/DirectMethodHandleDescImpl$1
+instanceKlass jdk/internal/constant/DirectMethodHandleDescImpl
+instanceKlass java/lang/constant/DirectMethodHandleDesc
+instanceKlass java/lang/constant/MethodHandleDesc$1
+instanceKlass java/lang/constant/MethodHandleDesc
+instanceKlass jdk/internal/constant/MethodTypeDescImpl
+instanceKlass java/lang/constant/MethodTypeDesc
+instanceKlass jdk/internal/constant/ConstantUtils
+instanceKlass jdk/internal/constant/ArrayClassDescImpl
+instanceKlass jdk/internal/constant/ClassOrInterfaceDescImpl
+instanceKlass java/lang/constant/ClassDesc
+instanceKlass java/lang/constant/ConstantDescs
+instanceKlass sun/invoke/util/Wrapper$Format
+instanceKlass java/lang/invoke/MethodTypeForm
+instanceKlass jdk/internal/util/StrongReferenceKey
+instanceKlass jdk/internal/util/ReferenceKey
+instanceKlass jdk/internal/util/ReferencedKeyMap
+instanceKlass java/lang/invoke/MethodType$1
+instanceKlass java/lang/invoke/LambdaMetafactory
+instanceKlass java/lang/ModuleLayer$Controller
+instanceKlass java/util/concurrent/CopyOnWriteArrayList
+instanceKlass jdk/internal/module/ServicesCatalog$ServiceProvider
+instanceKlass jdk/internal/loader/AbstractClassLoaderValue$Memoizer
+instanceKlass java/util/ImmutableCollections$ListItr
+instanceKlass java/util/ListIterator
+instanceKlass java/util/ImmutableCollections$Set12$1
+instanceKlass jdk/internal/loader/BuiltinClassLoader$LoadedModule
+instanceKlass java/lang/Module$EnableNativeAccess
+instanceKlass jdk/internal/loader/BootLoader
+instanceKlass java/util/Optional
+instanceKlass java/util/ImmutableCollections$SetN$SetNIterator
+instanceKlass jdk/internal/loader/AbstractClassLoaderValue
+instanceKlass jdk/internal/module/ServicesCatalog
+instanceKlass java/util/Deque
+instanceKlass java/util/Queue
+instanceKlass sun/net/util/IPAddressUtil$MASKS
+instanceKlass sun/net/util/IPAddressUtil
+instanceKlass java/net/URLStreamHandler
+instanceKlass java/lang/StringUTF16
+instanceKlass sun/net/www/ParseUtil
+instanceKlass java/net/URL$1
+instanceKlass jdk/internal/access/JavaNetURLAccess
+instanceKlass java/net/URL$DefaultFactory
+instanceKlass java/net/URLStreamHandlerFactory
+instanceKlass jdk/internal/loader/URLClassPath
+instanceKlass java/util/concurrent/ConcurrentHashMap$CollectionView
+instanceKlass jdk/internal/loader/ClassLoaderHelper
+instanceKlass jdk/internal/loader/NativeLibraries
+instanceKlass java/security/Principal
+instanceKlass java/lang/ClassLoader$ParallelLoaders
+instanceKlass java/security/cert/Certificate
+instanceKlass jdk/internal/loader/ArchivedClassLoaders
+instanceKlass java/net/URI$1
+instanceKlass jdk/internal/access/JavaNetUriAccess
+instanceKlass jdk/internal/module/ArchivedBootLayer
+instanceKlass jdk/internal/module/ModuleBootstrap$Counters
+instanceKlass jdk/internal/module/ModuleLoaderMap$Modules
+instanceKlass jdk/internal/module/ModuleLoaderMap
+instanceKlass jdk/internal/module/ModulePatcher
+instanceKlass jdk/internal/util/DecimalDigits
+instanceKlass java/io/FileSystem
+instanceKlass java/io/DefaultFileSystem
+instanceKlass java/io/File
+instanceKlass java/lang/module/ModuleDescriptor$1
+instanceKlass jdk/internal/access/JavaLangModuleAccess
+instanceKlass sun/invoke/util/VerifyAccess
+instanceKlass java/util/KeyValueHolder
+instanceKlass java/util/ImmutableCollections$MapN$MapNIterator
+instanceKlass java/lang/invoke/MethodHandles$Lookup
+instanceKlass java/lang/invoke/MemberName$Factory
+instanceKlass java/lang/invoke/MethodHandles
+instanceKlass jdk/internal/module/ModuleBootstrap
+instanceKlass java/util/HexFormat
+instanceKlass jdk/internal/util/ClassFileDumper
+instanceKlass java/lang/CharacterData
+instanceKlass java/lang/invoke/MethodHandleStatics
+instanceKlass java/util/Collections
+instanceKlass java/lang/Thread$ThreadIdentifiers
+instanceKlass sun/io/Win32ErrorMode
+instanceKlass jdk/internal/misc/OSEnvironment
+instanceKlass jdk/internal/misc/Signal$NativeHandler
+instanceKlass java/util/Hashtable$Entry
+instanceKlass jdk/internal/misc/Signal
+instanceKlass java/lang/Terminator$1
+instanceKlass jdk/internal/misc/Signal$Handler
+instanceKlass java/lang/Terminator
+instanceKlass java/nio/ByteOrder
+instanceKlass java/nio/Buffer$2
+instanceKlass jdk/internal/access/JavaNioAccess
+instanceKlass java/nio/Buffer$1
+instanceKlass jdk/internal/misc/ScopedMemoryAccess
+instanceKlass java/nio/charset/CodingErrorAction
+instanceKlass java/nio/charset/CharsetEncoder
+instanceKlass java/io/Writer
+instanceKlass java/io/OutputStream
+instanceKlass java/io/Flushable
+instanceKlass java/io/FileDescriptor$1
+instanceKlass jdk/internal/access/JavaIOFileDescriptorAccess
+instanceKlass java/io/FileDescriptor
+instanceKlass jdk/internal/util/StaticProperty
+instanceKlass jdk/internal/reflect/MethodHandleAccessorFactory
+instanceKlass jdk/internal/reflect/Reflection
+instanceKlass java/lang/reflect/Modifier
+instanceKlass java/lang/Class$Atomic
+instanceKlass java/lang/Class$ReflectionData
+instanceKlass java/nio/charset/StandardCharsets
+instanceKlass sun/nio/cs/HistoricallyNamedCharset
+instanceKlass java/util/Arrays
+instanceKlass jdk/internal/util/Preconditions$3
+instanceKlass jdk/internal/util/Preconditions$2
+instanceKlass jdk/internal/util/Preconditions$4
+instanceKlass java/util/function/BiFunction
+instanceKlass jdk/internal/util/Preconditions$1
+instanceKlass jdk/internal/util/Preconditions
+instanceKlass java/nio/charset/spi/CharsetProvider
+instanceKlass java/nio/charset/Charset
+instanceKlass java/util/HashMap$HashIterator
+instanceKlass java/util/concurrent/locks/LockSupport
+instanceKlass java/util/concurrent/ConcurrentHashMap$Node
+instanceKlass java/util/concurrent/ConcurrentHashMap$CounterCell
+instanceKlass java/util/concurrent/locks/ReentrantLock
+instanceKlass java/util/concurrent/locks/Lock
+instanceKlass java/lang/Runtime
+instanceKlass java/lang/VersionProps
+instanceKlass java/lang/StringConcatHelper
+instanceKlass jdk/internal/util/ArraysSupport
+instanceKlass java/lang/StringLatin1
+instanceKlass java/lang/StrictMath
+instanceKlass jdk/internal/util/SystemProps$Raw
+instanceKlass jdk/internal/util/SystemProps
+instanceKlass java/lang/System$1
+instanceKlass jdk/internal/access/JavaLangAccess
+instanceKlass java/lang/ref/ReferenceQueue$Lock
+instanceKlass java/lang/ref/ReferenceQueue
+instanceKlass java/lang/ref/Reference$1
+instanceKlass jdk/internal/access/JavaLangRefAccess
+instanceKlass java/lang/Math
+instanceKlass java/io/ObjectStreamClass
+instanceKlass jdk/internal/reflect/ReflectionFactory
+instanceKlass jdk/internal/access/SharedSecrets
+instanceKlass java/lang/reflect/ReflectAccess
+instanceKlass jdk/internal/access/JavaLangReflectAccess
+instanceKlass java/util/Objects
+instanceKlass jdk/internal/misc/CDS
+instanceKlass java/lang/Module$ArchivedData
+instanceKlass jdk/internal/misc/VM
+instanceKlass java/lang/String$CaseInsensitiveComparator
+instanceKlass java/util/Comparator
+instanceKlass java/io/ObjectStreamField
+instanceKlass jdk/internal/math/FDBigInteger
+instanceKlass java/lang/ModuleLayer
+instanceKlass java/util/ImmutableCollections
+instanceKlass jdk/internal/module/ModuleLoaderMap$Mapper
+instanceKlass java/util/function/Function
+instanceKlass java/lang/module/ResolvedModule
+instanceKlass java/lang/module/Configuration
+instanceKlass java/util/HashMap$Node
+instanceKlass java/util/Map$Entry
+instanceKlass java/util/Collections$UnmodifiableMap
+instanceKlass jdk/internal/module/ModuleHashes
+instanceKlass jdk/internal/module/ModuleTarget
+instanceKlass java/lang/module/ModuleDescriptor$Opens
+instanceKlass java/lang/module/ModuleDescriptor$Provides
+instanceKlass jdk/internal/module/SystemModuleFinders$2
+instanceKlass jdk/internal/module/ModuleHashes$HashSupplier
+instanceKlass jdk/internal/module/SystemModuleFinders$1
+instanceKlass java/util/function/Supplier
+instanceKlass java/net/URI
+instanceKlass java/lang/module/ModuleDescriptor$Exports
+instanceKlass java/lang/module/ModuleDescriptor$Requires
+instanceKlass java/lang/module/ModuleDescriptor$Version
+instanceKlass java/lang/module/ModuleDescriptor
+instanceKlass java/lang/module/ModuleReference
+instanceKlass java/util/Set
+instanceKlass jdk/internal/module/SystemModuleFinders$SystemModuleFinder
+instanceKlass java/lang/module/ModuleFinder
+instanceKlass jdk/internal/module/ArchivedModuleGraph
+instanceKlass sun/util/locale/BaseLocale
+instanceKlass java/util/jar/Attributes$Name
+instanceKlass java/lang/Character$CharacterCache
+instanceKlass java/lang/Short$ShortCache
+instanceKlass java/lang/Byte$ByteCache
+instanceKlass java/lang/Long$LongCache
+instanceKlass java/lang/Integer$IntegerCache
+instanceKlass jdk/internal/vm/FillerObject
+instanceKlass jdk/internal/vm/vector/VectorSupport$VectorPayload
+instanceKlass jdk/internal/vm/vector/VectorSupport
+instanceKlass java/lang/reflect/RecordComponent
+instanceKlass java/util/Iterator
+instanceKlass java/lang/Void
+instanceKlass java/lang/Number
+instanceKlass java/lang/Character
+instanceKlass java/lang/Boolean
+instanceKlass java/util/concurrent/locks/AbstractOwnableSynchronizer
+instanceKlass java/lang/LiveStackFrame
+instanceKlass java/lang/ClassFrameInfo
+instanceKlass java/lang/StackWalker$StackFrame
+instanceKlass java/lang/StackStreamFactory$AbstractStackWalker
+instanceKlass java/lang/StackWalker
+instanceKlass java/nio/Buffer
+instanceKlass java/lang/StackTraceElement
+instanceKlass java/util/RandomAccess
+instanceKlass java/util/List
+instanceKlass java/util/SequencedCollection
+instanceKlass java/util/AbstractCollection
+instanceKlass java/util/Collection
+instanceKlass java/lang/Iterable
+instanceKlass java/util/concurrent/ConcurrentMap
+instanceKlass java/util/AbstractMap
+instanceKlass java/security/CodeSource
+instanceKlass jdk/internal/loader/ClassLoaders
+instanceKlass java/util/jar/Manifest
+instanceKlass java/lang/Enum
+instanceKlass java/net/URL
+instanceKlass java/io/InputStream
+instanceKlass java/io/Closeable
+instanceKlass java/lang/AutoCloseable
+instanceKlass jdk/internal/module/Modules
+instanceKlass jdk/internal/misc/Unsafe
+instanceKlass jdk/internal/misc/UnsafeConstants
+instanceKlass java/lang/AbstractStringBuilder
+instanceKlass java/lang/Appendable
+instanceKlass java/lang/AssertionStatusDirectives
+instanceKlass jdk/internal/foreign/abi/ABIDescriptor
+instanceKlass jdk/internal/foreign/abi/NativeEntryPoint
+instanceKlass java/lang/invoke/CallSite
+instanceKlass java/lang/invoke/MethodType
+instanceKlass java/lang/invoke/TypeDescriptor$OfMethod
+instanceKlass java/lang/invoke/LambdaForm
+instanceKlass java/lang/invoke/MethodHandleNatives
+instanceKlass java/lang/invoke/MethodHandleImpl
+instanceKlass java/lang/invoke/ResolvedMethodName
+instanceKlass java/lang/invoke/MemberName
+instanceKlass java/lang/invoke/VarHandle
+instanceKlass java/lang/invoke/MethodHandle
+instanceKlass jdk/internal/reflect/ConstructorAccessorImpl
+instanceKlass jdk/internal/reflect/ConstructorAccessor
+instanceKlass jdk/internal/reflect/CallerSensitive
+instanceKlass java/lang/annotation/Annotation
+instanceKlass jdk/internal/reflect/ConstantPool
+instanceKlass jdk/internal/reflect/MethodAccessorImpl
+instanceKlass jdk/internal/reflect/MethodAccessor
+instanceKlass jdk/internal/vm/StackChunk
+instanceKlass jdk/internal/vm/Continuation
+instanceKlass jdk/internal/vm/ContinuationScope
+instanceKlass java/lang/reflect/Parameter
+instanceKlass java/lang/reflect/Member
+instanceKlass java/lang/reflect/AccessibleObject
+instanceKlass java/lang/Module
+instanceKlass java/util/Map
+instanceKlass java/util/Dictionary
+instanceKlass java/lang/ThreadGroup
+instanceKlass java/lang/Thread$UncaughtExceptionHandler
+instanceKlass java/lang/Thread$Constants
+instanceKlass java/lang/Thread$FieldHolder
+instanceKlass java/lang/Thread
+instanceKlass java/lang/Runnable
+instanceKlass java/lang/ref/Reference
+instanceKlass java/lang/Record
+instanceKlass java/security/ProtectionDomain
+instanceKlass java/lang/Throwable
+instanceKlass java/lang/System
+instanceKlass java/lang/ClassLoader
+instanceKlass java/lang/Cloneable
+instanceKlass java/lang/Class
+instanceKlass java/lang/invoke/TypeDescriptor$OfField
+instanceKlass java/lang/invoke/TypeDescriptor
+instanceKlass java/lang/reflect/Type
+instanceKlass java/lang/reflect/GenericDeclaration
+instanceKlass java/lang/reflect/AnnotatedElement
+instanceKlass java/lang/String
+instanceKlass java/lang/constant/ConstantDesc
+instanceKlass java/lang/constant/Constable
+instanceKlass java/lang/CharSequence
+instanceKlass java/lang/Comparable
+instanceKlass java/io/Serializable
+ciInstanceKlass java/lang/Object 1 1 115 7 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 8 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 1 100 1 8 1 10 12 1 10 7 12 1 1 1 7 1 10 12 1 7 1 10 12 1 1 8 1 3 8 1 100 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 3 1 1
+ciInstanceKlass java/io/Serializable 1 0 7 100 1 100 1 1 1
+ciInstanceKlass java/lang/System 1 1 591 10 100 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 9 12 1 1 10 7 12 1 1 1 11 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 100 1 8 1 10 12 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 10 12 1 1 7 1 10 12 1 1 100 1 8 1 10 10 12 1 1 100 1 8 1 10 10 7 12 1 1 10 12 10 100 12 1 1 10 7 12 1 1 1 100 1 8 1 10 10 100 12 1 1 1 10 100 12 1 1 1 100 1 10 100 12 1 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 8 1 10 12 1 1 10 12 1 1 8 1 10 12 1 7 1 7 1 10 12 1 9 7 12 1 1 1 10 7 12 1 1 1 10 12 1 10 12 1 10 7 12 1 1 1 100 1 8 1 10 9 12 1 1 9 12 1 10 12 1 10 100 12 1 1 10 12 1 10 12 1 1 100 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 8 1 11 7 12 1 1 10 12 11 12 1 1 11 7 12 1 1 1 11 7 12 1 1 11 12 1 1 7 1 11 12 1 10 12 1 8 1 10 12 1 1 8 1 8 1 8 1 8 1 11 12 1 10 12 1 1 10 12 1 10 12 1 8 1 10 12 1 1 8 1 9 12 1 8 1 10 7 12 1 1 8 1 7 1 9 7 12 1 1 1 10 12 1 7 1 9 12 10 9 12 7 1 10 12 9 12 1 1 8 1 10 12 1 1 8 1 9 12 1 10 7 12 1 1 10 12 1 10 12 1 1 11 7 12 1 1 10 12 10 7 12 1 1 1 9 12 1 1 100 1 100 1 8 1 10 12 1 1 10 12 1 8 1 8 1 10 8 1 8 1 8 1 8 1 8 1 10 8 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 7 1 10 10 12 1 10 12 1 9 12 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 100 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1 1
+staticfield java/lang/System in Ljava/io/InputStream; java/io/BufferedInputStream
+staticfield java/lang/System out Ljava/io/PrintStream; org/fusesource/jansi/AnsiPrintStream
+staticfield java/lang/System err Ljava/io/PrintStream; org/fusesource/jansi/AnsiPrintStream
+instanceKlass java/security/Security$1
+instanceKlass java/security/Provider
+ciInstanceKlass java/util/Properties 1 1 690 10 7 12 1 1 1 100 1 10 7 12 1 1 7 1 10 12 1 9 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 8 1 10 7 12 1 1 1 7 1 10 12 1 10 12 1 1 8 1 10 12 1 7 1 10 12 10 12 1 1 9 12 1 1 10 12 1 1 7 1 10 12 1 10 12 1 10 12 1 1 100 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 100 1 3 10 10 100 12 1 1 1 10 12 1 10 12 1 1 8 1 10 12 1 10 12 1 1 8 1 10 100 12 1 1 10 12 1 1 10 12 1 10 12 1 1 100 1 10 12 1 10 12 1 1 100 1 9 100 12 1 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 100 1 9 12 1 1 7 1 100 1 10 12 1 100 1 11 7 12 1 1 1 11 12 1 1 11 100 12 1 1 1 11 7 12 1 1 1 11 12 1 1 11 12 1 11 12 1 10 12 1 1 8 1 10 12 1 10 100 12 1 1 10 12 1 100 1 10 10 12 1 10 12 1 100 1 10 10 12 1 1 10 100 12 1 1 9 100 12 1 1 10 12 1 1 10 100 12 1 1 1 100 1 100 1 100 1 10 8 1 8 1 10 12 1 10 12 1 10 12 1 1 10 10 12 1 1 10 12 1 1 100 1 10 10 12 1 11 7 12 1 1 10 7 12 1 1 1 8 1 10 100 12 1 1 11 11 7 1 8 1 10 100 1 11 10 12 1 10 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 10 12 1 10 12 1 10 12 1 10 10 12 1 1 10 12 1 1 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 10 11 12 1 4 11 10 12 1 1 10 100 12 1 1 11 12 1 10 12 1 1 10 100 12 1 1 10 12 1 100 1 8 1 10 12 1 10 10 100 12 1 1 1 100 1 6 0 10 12 1 1 11 100 12 1 1 1 10 12 1 10 12 1 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 100 1 1
+staticfield java/util/Properties UNSAFE Ljdk/internal/misc/Unsafe; jdk/internal/misc/Unsafe
+instanceKlass java/util/Hashtable
+ciInstanceKlass java/util/Dictionary 1 1 36 10 7 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/util/Properties
+ciInstanceKlass java/util/Hashtable 1 1 516 100 1 10 7 12 1 1 1 9 7 12 1 1 1 100 1 100 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 7 12 1 1 1 8 1 10 12 1 9 12 1 1 7 1 9 12 1 1 4 10 7 12 1 1 1 9 12 1 4 10 12 1 11 100 12 1 1 1 10 12 1 1 10 12 1 1 9 12 1 10 12 1 1 100 1 10 9 12 1 1 10 7 12 1 1 1 9 12 1 1 10 12 1 10 12 1 3 9 12 1 9 12 1 3 10 12 1 10 12 1 10 12 1 1 11 12 1 1 11 100 12 1 1 1 11 100 12 1 1 1 11 12 1 100 1 11 12 1 11 12 1 10 12 1 1 10 12 1 1 10 12 1 9 12 1 1 9 12 9 12 1 1 10 100 1 100 1 10 12 1 10 8 1 10 10 12 1 8 1 10 8 1 10 100 12 1 1 1 7 1 10 12 1 10 12 1 100 1 10 12 1 10 12 1 1 100 1 10 100 1 10 10 12 1 1 11 12 1 1 11 12 1 100 1 10 10 10 100 12 1 1 11 100 12 1 1 1 100 1 10 11 100 12 1 1 11 100 12 1 10 12 1 10 12 1 1 10 100 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 8 10 100 12 1 1 100 1 8 1 10 4 4 10 12 1 1 10 12 1 8 1 4 10 12 10 100 12 1 1 1 100 1 11 100 12 1 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 10 100 1 100 1 1 1 1 1 1 5 0 1 1 1 1 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 100 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/util/Map 1 1 263 11 7 12 1 1 1 11 12 1 1 10 7 12 1 1 11 12 1 1 11 100 12 1 1 1 11 100 12 1 1 1 11 12 1 1 7 1 11 12 1 11 12 1 100 1 100 1 10 12 1 1 11 100 12 1 1 1 11 100 12 1 1 1 11 12 1 11 12 1 10 12 1 1 11 12 1 11 7 12 1 9 7 12 1 1 1 7 1 10 12 7 1 7 1 10 12 1 7 1 10 100 1 11 12 1 11 12 1 1 11 12 1 1 100 1 11 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/String 1 1 1471 10 7 12 1 1 1 8 1 9 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 1 9 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 7 12 1 1 1 7 1 9 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 9 7 12 1 1 10 12 9 7 12 1 1 10 12 1 1 3 10 12 1 1 7 1 11 12 1 1 11 12 1 11 12 1 1 10 100 12 1 1 1 10 12 1 1 9 100 12 1 1 1 10 12 1 1 10 12 1 11 12 1 1 10 12 1 10 12 10 12 1 1 100 1 100 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 1 100 1 10 12 1 1 100 1 10 12 1 1 10 12 1 1 10 12 1 10 10 12 1 100 1 100 1 7 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 100 12 1 1 100 1 11 10 7 12 1 1 11 12 1 11 12 1 10 12 1 10 12 1 10 12 10 12 1 1 10 10 100 12 1 1 1 10 100 12 1 1 10 12 1 1 10 100 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 100 1 10 12 1 1 10 12 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 3 3 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 100 1 10 8 1 10 12 1 1 10 12 1 8 1 10 12 1 1 10 12 10 12 1 8 1 10 10 12 1 1 10 12 1 1 7 1 5 0 100 1 8 1 10 10 12 1 1 5 0 5 0 5 0 10 12 1 1 10 100 1 10 10 12 1 10 12 1 10 12 1 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 10 12 1 1 10 10 12 1 100 1 10 9 100 12 1 1 1 11 100 12 1 1 1 10 12 1 1 10 12 1 1 10 7 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 11 7 1 11 12 10 12 1 10 12 1 1 10 12 1 1 10 10 12 1 10 12 1 9 12 1 1 11 7 12 1 1 1 10 12 10 10 12 1 10 12 1 1 10 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 10 12 1 1 10 10 7 12 1 1 1 10 12 1 10 12 1 10 12 10 10 12 10 10 12 1 10 12 1 10 10 12 10 12 1 1 10 12 10 10 12 10 12 1 10 12 10 12 10 10 12 1 10 12 1 1 10 12 1 1 10 10 12 1 10 7 12 1 1 1 10 12 1 1 10 10 7 12 1 1 1 11 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 100 1 10 10 12 1 10 12 1 1 8 1 10 12 1 3 3 10 12 1 10 12 1 1 10 12 7 1 10 10 12 1 1 10 12 10 12 1 10 12 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 7 1 10 12 1 10 12 1 1 8 1 10 12 1 1 10 12 1 11 100 12 1 1 1 11 7 12 1 1 11 12 1 10 12 1 10 12 1 1 10 10 7 12 1 1 1 10 12 1 10 12 1 10 10 12 10 12 1 1 10 10 12 1 10 10 12 1 10 10 12 1 10 10 12 1 10 12 1 1 10 10 12 1 8 1 10 12 1 1 18 12 1 1 11 7 12 1 1 1 3 18 12 1 18 12 1 8 1 10 7 12 1 1 1 11 12 1 1 10 12 10 10 12 1 10 11 12 1 1 10 12 1 1 11 12 1 18 3 11 10 11 11 10 12 1 10 12 1 1 8 1 10 12 1 10 12 1 10 12 1 1 10 10 12 1 11 100 12 1 100 1 100 1 10 12 100 1 10 10 100 12 1 1 1 100 1 10 7 1 10 10 12 1 10 10 12 1 8 1 10 10 12 1 8 1 8 1 10 12 1 10 12 1 10 10 12 10 100 12 1 1 10 7 12 1 1 10 100 12 1 1 8 1 10 12 1 10 12 1 10 9 12 1 10 12 9 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 10 12 1 10 12 1 8 1 10 100 12 1 1 1 10 12 10 12 1 1 10 12 10 12 10 12 7 1 9 12 1 1 7 1 10 100 1 100 1 100 1 100 1 1 1 1 1 1 5 0 1 1 1 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 10 12 16 15 10 12 15 10 12 15 10 12 15 10 7 12 1 1 1 1 100 1 1 1 1 1 100 1 100 1 1 1
+staticfield java/lang/String COMPACT_STRINGS Z 1
+staticfield java/lang/String serialPersistentFields [Ljava/io/ObjectStreamField; 0 [Ljava/io/ObjectStreamField;
+staticfield java/lang/String CASE_INSENSITIVE_ORDER Ljava/util/Comparator; java/lang/String$CaseInsensitiveComparator
+ciInstanceKlass java/lang/Comparable 1 0 12 100 1 100 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/CharSequence 1 1 145 11 7 12 1 1 1 18 12 1 1 100 1 10 100 12 1 1 1 18 10 100 12 1 1 1 11 12 1 1 11 100 1 11 12 1 1 10 100 12 1 1 1 11 12 1 1 10 12 1 1 10 12 1 100 1 10 12 1 1 10 100 12 1 1 1 100 1 10 10 12 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 1 15 11 12 16 15 11 12 15 10 100 12 1 1 1 1 1 100 1 100 1 1 100 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/constant/Constable 1 0 11 100 1 100 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/constant/ConstantDesc 1 0 37 100 1 100 1 1 1 1 7 1 1 1 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/AutoCloseable 1 0 12 100 1 100 1 1 1 1 100 1 1 1
+ciInstanceKlass java/io/Closeable 1 0 14 100 1 100 1 100 1 1 1 1 100 1 1 1
+ciInstanceKlass java/lang/Appendable 1 0 14 100 1 100 1 1 1 1 100 1 1 1 1 1
+ciInstanceKlass java/util/Iterator 1 1 53 100 1 8 1 10 12 1 1 10 7 12 1 1 1 11 7 12 1 1 1 11 12 1 1 11 7 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass jdk/nio/zipfs/ZipFileSystem$EntryInputStream
+instanceKlass org/apache/commons/io/input/AbstractInputStream
+instanceKlass sun/nio/ch/ChannelInputStream
+instanceKlass java/util/zip/ZipFile$ZipFileInputStream
+instanceKlass java/io/FilterInputStream
+instanceKlass java/io/FileInputStream
+instanceKlass java/io/ByteArrayInputStream
+ciInstanceKlass java/io/InputStream 1 1 197 100 1 10 7 12 1 1 1 100 1 10 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 100 1 100 1 3 10 12 1 1 100 1 8 1 10 12 1 10 7 12 1 1 1 3 100 1 8 1 10 10 100 12 1 1 1 100 1 10 11 100 12 1 1 1 10 12 1 1 11 12 1 1 11 100 12 1 1 1 11 12 1 1 100 1 10 100 12 1 1 1 5 0 10 12 1 10 12 1 1 100 1 10 8 1 10 8 1 8 1 10 12 1 1 10 7 12 1 1 1 100 1 5 0 10 12 1 100 1 100 1 1 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass lombok/javac/apt/LombokProcessor$1
+instanceKlass lombok/launch/ShadowClassLoader
+instanceKlass org/eclipse/sisu/space/CloningClassSpace$CloningClassLoader
+instanceKlass java/security/SecureClassLoader
+ciInstanceKlass java/lang/ClassLoader 1 1 1076 9 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 7 1 10 12 1 1 10 12 1 1 9 12 1 1 10 12 1 1 100 1 10 12 1 10 12 1 1 10 7 12 1 1 1 100 1 8 1 10 12 1 10 7 1 10 7 1 7 1 7 1 10 12 1 10 12 1 9 12 1 1 10 10 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 1 7 1 10 12 1 9 12 1 1 10 12 1 1 10 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 10 12 1 1 9 12 10 12 1 1 7 1 10 8 1 10 12 1 1 10 12 1 10 7 1 7 1 10 7 12 1 1 1 10 7 12 1 1 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 7 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 10 12 1 10 12 1 10 10 12 1 1 10 12 1 1 100 1 8 1 10 8 1 10 12 1 10 12 1 100 1 8 1 10 12 1 1 10 12 1 1 10 10 12 1 1 10 12 1 1 10 12 1 1 10 7 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 8 1 9 12 1 10 12 1 1 8 1 8 1 10 7 12 1 1 100 1 10 10 12 10 12 1 10 12 1 10 12 1 10 12 1 1 10 7 12 1 1 10 12 1 10 7 1 7 1 10 12 1 1 10 12 1 10 7 1 10 12 1 100 1 18 12 1 10 100 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 10 12 1 10 12 1 100 1 10 12 1 8 1 10 10 12 1 1 10 12 1 10 12 1 1 100 1 10 12 1 1 10 100 12 1 1 10 12 1 10 7 12 1 1 10 12 1 8 1 100 1 10 10 12 1 9 12 1 10 7 12 1 1 10 12 1 100 1 8 1 10 12 1 10 8 1 8 1 10 12 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 100 1 100 1 10 12 1 1 100 1 100 1 10 100 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 8 1 7 1 18 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 10 12 1 18 12 1 11 100 12 1 1 1 100 1 10 12 1 1 10 12 1 10 11 12 1 1 10 18 10 12 1 1 11 100 12 1 18 12 1 11 12 1 1 10 12 1 10 12 1 1 10 12 1 1 100 1 8 1 10 10 12 1 8 1 8 1 10 100 12 1 1 10 12 1 100 1 10 10 12 1 8 1 8 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 100 12 1 1 1 11 100 12 1 1 100 1 10 11 10 12 1 10 12 1 10 12 1 1 9 100 12 1 1 9 12 1 1 9 12 9 12 1 9 12 1 9 12 1 8 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 8 1 10 12 1 1 8 10 12 1 1 8 8 10 12 1 10 12 1 10 12 1 11 12 1 1 10 100 12 1 1 1 100 1 10 12 1 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 1 15 10 12 16 1 16 15 10 12 16 1 16 1 15 10 12 16 15 10 12 16 15 10 12 16 15 10 100 12 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/ClassLoader nocerts [Ljava/security/cert/Certificate; 0 [Ljava/security/cert/Certificate;
+staticfield java/lang/ClassLoader $assertionsDisabled Z 1
+instanceKlass com/sun/tools/javac/file/BaseFileManager$1
+instanceKlass org/apache/maven/shared/utils/logging/MessageUtils$1
+instanceKlass java/util/logging/LogManager$Cleaner
+instanceKlass org/apache/maven/shared/utils/logging/MessageUtils$1
+instanceKlass jdk/internal/misc/InnocuousThread
+instanceKlass java/lang/ref/Finalizer$FinalizerThread
+instanceKlass java/lang/ref/Reference$ReferenceHandler
+instanceKlass java/lang/BaseVirtualThread
+ciInstanceKlass java/lang/Thread 1 1 761 9 7 12 1 1 1 9 7 12 1 1 1 9 12 1 9 12 1 10 12 1 1 9 12 1 1 10 100 12 1 1 10 12 1 10 100 12 1 1 100 1 8 1 10 12 1 1 9 12 1 1 9 12 1 9 12 1 1 100 1 10 12 1 1 10 12 1 100 1 10 12 10 12 1 1 9 12 1 1 10 12 1 100 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 100 1 8 1 10 9 100 12 1 1 1 10 12 1 1 10 3 8 1 100 1 5 0 10 7 12 1 1 1 9 12 1 10 12 1 1 10 7 1 100 1 8 1 10 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 10 12 1 10 12 1 10 7 12 1 1 5 0 9 12 1 10 7 12 1 1 1 10 12 1 1 9 12 1 1 10 100 12 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 9 12 1 1 10 7 12 1 1 9 12 1 8 1 9 100 12 1 1 1 5 0 100 1 10 100 1 10 100 1 10 7 1 10 8 1 10 12 1 1 10 7 12 1 10 12 1 10 12 1 100 1 8 1 10 10 12 1 10 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 10 12 1 7 1 9 12 1 1 100 1 10 10 12 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 9 12 1 1 10 10 12 1 1 10 12 1 1 11 7 12 1 1 10 7 12 1 1 9 12 1 1 9 12 1 1 10 100 12 1 1 10 12 1 1 10 12 1 10 7 12 1 1 10 12 1 100 1 10 9 12 1 1 10 12 1 11 100 12 1 1 11 12 1 10 12 1 10 12 1 10 12 1 9 12 1 10 10 12 1 10 12 1 1 9 12 1 9 12 10 12 1 8 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 100 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 9 7 12 1 1 1 8 1 10 9 12 1 10 12 1 100 1 8 1 10 10 12 1 8 1 10 12 1 1 9 12 8 1 10 10 12 1 10 12 1 8 1 10 12 1 10 8 1 9 12 1 1 10 12 1 1 10 10 12 1 10 12 1 100 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 11 100 12 1 1 1 10 12 1 1 9 12 1 10 12 1 10 12 1 1 11 100 12 1 1 1 10 12 1 1 1 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/Thread NEW_THREAD_BINDINGS Ljava/lang/Object; java/lang/Class
+staticfield java/lang/Thread EMPTY_STACK_TRACE [Ljava/lang/StackTraceElement; 0 [Ljava/lang/StackTraceElement;
+ciInstanceKlass java/lang/Runnable 1 0 11 100 1 100 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/Class 1 1 1652 10 7 12 1 1 1 10 7 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 10 12 1 1 8 1 10 12 1 8 1 8 1 10 12 1 1 10 7 12 1 1 1 10 12 1 7 1 10 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 8 1 10 12 1 8 1 10 12 1 8 1 8 1 10 12 1 1 10 7 12 1 1 1 18 12 1 1 11 7 12 1 1 1 8 1 8 1 8 1 10 7 12 1 1 1 11 12 1 1 8 1 10 12 1 10 10 12 1 1 10 12 1 8 1 10 12 1 1 8 1 10 12 1 10 12 1 1 11 100 12 1 1 1 11 100 12 1 1 1 11 8 1 18 8 1 10 12 1 10 7 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 10 12 1 1 10 7 1 10 12 1 8 1 10 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 9 100 12 1 1 9 100 1 9 100 1 9 100 1 9 100 1 9 100 1 9 100 1 9 100 1 9 7 1 9 12 1 1 7 1 8 1 10 12 1 10 12 1 1 100 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 7 1 7 1 10 10 12 1 1 10 12 1 1 100 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 12 9 12 1 1 10 12 1 9 12 1 1 9 12 1 1 10 12 1 1 10 7 1 10 12 1 10 12 1 1 10 9 12 1 10 12 1 8 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 9 7 12 1 1 1 10 12 1 10 7 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 9 100 12 1 1 1 9 12 1 10 12 1 10 12 1 1 9 12 1 1 10 7 10 12 1 1 10 100 12 1 1 10 12 1 10 12 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 7 1 10 10 12 1 1 10 12 1 1 10 12 10 10 12 1 1 100 1 8 1 10 10 12 1 1 10 12 1 100 1 11 12 1 10 12 1 10 12 1 10 100 12 1 1 10 10 12 1 1 8 1 10 12 1 8 1 9 12 1 10 12 1 10 12 1 10 12 1 10 12 100 1 9 12 1 10 12 1 9 12 1 10 12 1 10 12 1 10 12 1 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 7 1 10 10 12 1 10 12 1 11 100 12 1 1 11 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 7 1 10 10 12 1 1 10 12 1 1 10 12 1 1 10 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 10 12 1 1 100 1 10 10 12 1 1 10 100 12 1 1 1 100 1 100 1 10 12 1 1 10 12 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 10 100 12 1 1 1 11 7 12 1 1 10 12 1 10 12 1 9 7 12 1 1 8 1 10 12 1 10 12 1 10 12 1 10 12 1 1 9 12 1 9 12 1 1 10 7 12 1 1 9 12 1 10 12 1 1 10 10 12 1 10 7 12 1 1 1 10 7 12 1 1 10 7 12 1 1 9 12 1 1 10 12 1 9 12 1 10 12 1 10 12 1 1 9 12 1 1 9 12 1 10 12 1 10 12 1 1 9 12 1 7 1 10 10 12 1 1 7 1 10 7 11 7 1 9 12 1 1 9 12 1 10 12 1 9 12 1 1 9 12 1 10 12 1 10 12 1 1 9 12 1 7 1 10 10 12 1 1 10 10 12 1 10 12 10 10 12 1 9 12 1 10 12 1 1 10 12 1 8 10 7 8 1 18 8 1 8 1 10 12 1 9 12 1 9 12 1 1 10 12 1 7 1 7 1 10 12 1 9 12 1 1 10 10 12 1 9 12 1 8 1 10 12 1 10 10 12 1 1 100 1 100 1 9 12 1 100 1 8 1 10 10 7 12 1 1 1 10 12 11 7 12 1 1 1 10 12 1 10 12 1 1 10 8 1 10 12 1 8 1 10 12 1 1 9 7 12 1 1 11 12 7 1 11 7 12 1 1 9 12 1 10 100 12 1 1 1 10 7 12 1 1 10 12 1 1 9 12 1 9 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 11 12 1 11 12 1 1 11 7 12 1 1 11 12 1 7 1 11 12 1 10 7 12 1 1 1 10 12 1 11 12 1 10 100 12 1 1 1 10 12 1 10 7 12 1 1 1 11 12 1 11 12 1 1 10 12 1 10 12 1 1 9 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 8 1 10 12 1 10 12 1 10 12 1 8 1 8 1 10 7 12 1 1 10 100 12 1 1 100 1 10 12 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 18 12 1 1 11 12 1 1 18 11 12 1 18 12 1 11 12 1 10 12 1 10 12 1 10 12 1 10 12 10 12 1 8 1 10 12 1 7 1 9 12 1 1 100 1 100 1 100 1 100 1 1 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 10 12 16 15 11 12 16 1 15 10 12 16 16 15 10 12 16 15 16 1 15 10 12 16 15 10 7 12 1 1 1 1 1 100 1 1 1 1 1 1 1 1 100 1 1 100 1 100 1 1 100 1 100 1 1
+staticfield java/lang/Class EMPTY_CLASS_ARRAY [Ljava/lang/Class; 0 [Ljava/lang/Class;
+staticfield java/lang/Class serialPersistentFields [Ljava/io/ObjectStreamField; 0 [Ljava/io/ObjectStreamField;
+ciInstanceKlass java/lang/reflect/AnnotatedElement 1 1 165 11 7 12 1 1 1 11 12 1 1 100 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 100 12 1 1 1 11 12 1 1 11 100 12 1 1 10 100 12 1 1 1 10 12 1 10 100 12 1 1 1 18 12 1 1 11 100 12 1 1 18 12 1 18 12 1 1 10 100 12 1 1 1 11 100 12 1 1 1 100 1 10 100 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 16 15 16 1 16 1 15 11 12 16 16 1 15 10 100 12 1 1 1 16 1 15 10 100 12 1 1 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/reflect/Type 1 1 17 11 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/invoke/TypeDescriptor 1 0 17 100 1 100 1 1 1 1 1 1 100 1 100 1 1 1 1
+ciInstanceKlass java/lang/invoke/TypeDescriptor$OfField 1 0 21 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/reflect/GenericDeclaration 1 0 30 100 1 100 1 100 1 1 1 1 1 1 1 1 100 1 8 1 1 12 10 1 1 1 8 1 1 1 8 1
+ciInstanceKlass java/lang/Module 1 1 1076 10 7 12 1 1 1 9 7 12 1 1 1 10 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 7 1 10 7 12 1 1 1 10 12 1 1 11 7 12 1 1 1 10 12 1 1 10 12 1 8 1 10 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 9 12 1 1 10 7 12 1 1 1 9 7 12 1 1 1 100 1 10 8 1 10 12 1 1 10 12 1 10 12 8 1 10 7 12 1 1 1 10 100 12 1 1 1 10 100 12 1 1 1 8 1 10 12 1 8 1 9 12 1 100 1 8 1 10 12 1 10 8 1 8 1 8 1 10 7 12 1 1 1 8 1 10 100 12 1 1 1 8 1 10 12 1 9 12 1 1 11 12 1 9 7 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 8 1 10 12 1 1 10 12 1 10 12 1 1 9 7 12 1 1 1 10 12 1 1 10 12 1 1 9 12 1 10 12 1 10 12 1 9 12 1 1 11 7 12 1 1 10 12 1 1 9 12 1 9 12 1 10 12 1 10 12 1 100 1 8 1 10 10 12 1 1 10 12 1 8 1 10 12 1 1 8 1 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 18 12 1 1 10 12 1 1 11 12 1 9 12 1 11 12 7 1 10 12 1 18 12 1 11 12 1 1 11 12 1 1 11 12 1 10 12 1 1 10 12 1 1 9 12 1 10 12 10 7 12 1 1 10 7 1 18 12 1 1 11 100 12 1 1 1 18 12 1 11 12 1 1 10 100 12 1 1 1 11 12 1 1 10 7 12 1 1 11 12 1 1 10 12 1 1 7 1 11 12 1 7 1 7 1 10 12 1 10 7 12 1 1 1 10 7 12 1 1 1 10 11 7 12 1 8 1 10 12 1 10 12 1 1 10 7 12 1 1 10 12 1 10 12 1 7 1 10 12 1 10 11 12 1 10 12 11 12 1 1 11 7 12 1 1 11 12 1 1 10 12 1 1 9 12 1 1 100 1 10 10 12 1 1 11 100 1 10 12 1 1 11 12 1 10 11 10 12 1 11 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 10 12 1 10 12 1 1 10 10 12 1 1 10 12 1 18 12 1 11 12 1 18 12 1 10 12 1 10 12 1 10 12 7 1 10 12 1 10 12 1 10 12 1 9 12 1 7 1 10 10 10 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 9 12 1 10 12 1 100 1 8 1 10 12 1 1 10 12 1 10 100 12 1 1 100 1 10 12 1 1 100 1 8 1 100 1 9 100 12 1 1 1 11 100 12 1 1 10 12 1 1 11 12 1 1 18 12 1 1 11 12 1 1 100 1 10 12 1 10 12 1 1 100 1 100 1 10 12 8 1 10 12 1 1 10 12 1 1 10 7 12 1 1 10 12 1 1 10 12 1 10 12 10 12 1 1 7 1 10 10 12 1 1 10 100 12 1 1 1 100 1 10 100 12 1 1 1 10 100 12 1 1 8 1 18 12 1 1 100 1 100 1 9 12 1 1 9 12 1 9 12 1 11 100 12 1 1 1 100 1 11 12 1 1 100 1 10 12 1 8 1 10 12 1 10 12 10 12 1 8 1 10 10 100 12 1 1 10 12 1 1 7 1 10 10 12 1 10 7 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 10 12 10 12 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 10 12 16 15 10 12 16 1 16 15 10 12 16 16 15 10 16 1 15 10 12 16 1 15 10 12 16 1 16 1 15 10 12 16 15 10 7 12 1 1 1 15 10 100 12 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/Module ALL_UNNAMED_MODULE Ljava/lang/Module; java/lang/Module
+staticfield java/lang/Module ALL_UNNAMED_MODULE_SET Ljava/util/Set; java/util/ImmutableCollections$Set12
+staticfield java/lang/Module EVERYONE_MODULE Ljava/lang/Module; java/lang/Module
+staticfield java/lang/Module EVERYONE_SET Ljava/util/Set; java/util/ImmutableCollections$Set12
+staticfield java/lang/Module $assertionsDisabled Z 1
+ciInstanceKlass jdk/internal/misc/Unsafe 1 1 1248 10 7 12 1 1 1 10 7 12 1 1 9 12 1 1 9 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 100 1 10 10 12 1 1 10 12 1 1 5 0 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 100 1 100 1 10 8 1 10 12 1 1 10 12 1 8 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 5 0 5 0 5 0 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 100 1 8 1 10 100 1 10 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 9 7 12 1 1 9 12 1 100 1 10 10 12 1 1 8 1 10 8 1 8 1 10 12 1 1 9 7 12 1 1 1 9 100 1 9 7 1 9 7 1 9 9 100 1 9 7 1 9 100 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 5 0 5 0 9 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 8 1 3 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 100 1 10 100 1 10 9 12 1 5 0 10 12 1 1 5 0 10 12 1 5 0 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 5 0 5 0 5 0 10 12 1 1 10 12 1 10 12 1 10 12 10 100 12 1 1 8 1 100 1 11 12 1 1 8 1 11 12 1 1 10 100 12 1 1 10 12 1 10 7 1 10 12 1 1 9 12 1 1 7 1 9 12 1 7 1 9 12 1 7 1 9 12 1 7 1 9 12 1 7 1 9 12 1 7 1 9 12 1 7 1 9 12 1 7 1 9 12 1 10 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield jdk/internal/misc/Unsafe theUnsafe Ljdk/internal/misc/Unsafe; jdk/internal/misc/Unsafe
+staticfield jdk/internal/misc/Unsafe ARRAY_BOOLEAN_BASE_OFFSET J 16
+staticfield jdk/internal/misc/Unsafe ARRAY_BYTE_BASE_OFFSET J 16
+staticfield jdk/internal/misc/Unsafe ARRAY_SHORT_BASE_OFFSET J 16
+staticfield jdk/internal/misc/Unsafe ARRAY_CHAR_BASE_OFFSET J 16
+staticfield jdk/internal/misc/Unsafe ARRAY_INT_BASE_OFFSET J 16
+staticfield jdk/internal/misc/Unsafe ARRAY_LONG_BASE_OFFSET J 16
+staticfield jdk/internal/misc/Unsafe ARRAY_FLOAT_BASE_OFFSET J 16
+staticfield jdk/internal/misc/Unsafe ARRAY_DOUBLE_BASE_OFFSET J 16
+staticfield jdk/internal/misc/Unsafe ARRAY_OBJECT_BASE_OFFSET J 16
+staticfield jdk/internal/misc/Unsafe ARRAY_BOOLEAN_INDEX_SCALE I 1
+staticfield jdk/internal/misc/Unsafe ARRAY_BYTE_INDEX_SCALE I 1
+staticfield jdk/internal/misc/Unsafe ARRAY_SHORT_INDEX_SCALE I 2
+staticfield jdk/internal/misc/Unsafe ARRAY_CHAR_INDEX_SCALE I 2
+staticfield jdk/internal/misc/Unsafe ARRAY_INT_INDEX_SCALE I 4
+staticfield jdk/internal/misc/Unsafe ARRAY_LONG_INDEX_SCALE I 8
+staticfield jdk/internal/misc/Unsafe ARRAY_FLOAT_INDEX_SCALE I 4
+staticfield jdk/internal/misc/Unsafe ARRAY_DOUBLE_INDEX_SCALE I 8
+staticfield jdk/internal/misc/Unsafe ARRAY_OBJECT_INDEX_SCALE I 4
+staticfield jdk/internal/misc/Unsafe ADDRESS_SIZE I 8
+ciInstanceKlass java/lang/Thread$FieldHolder 1 1 55 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 100 1 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/Thread$Constants 0 0 47 100 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 8 1 10 12 1 9 100 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/ThreadGroup 1 1 380 10 7 12 1 1 1 9 7 12 1 1 1 8 1 9 12 1 1 7 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 1 18 12 1 1 11 100 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 11 12 1 1 11 100 12 1 1 11 12 1 1 10 12 1 1 10 12 1 10 12 1 11 12 1 11 12 1 1 10 12 1 100 1 10 18 12 1 1 11 100 12 1 1 1 11 12 1 1 9 100 12 1 1 1 10 12 1 1 8 1 10 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 11 12 10 12 1 1 10 12 1 1 11 100 1 9 12 1 100 1 10 8 1 10 12 1 1 10 12 1 1 8 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 7 1 8 1 10 8 1 10 12 1 10 12 1 8 1 9 12 1 1 9 12 1 10 100 12 1 1 1 100 9 12 1 1 7 1 9 12 1 10 12 10 12 1 1 100 10 12 9 12 1 10 12 1 100 1 10 100 1 10 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 10 12 16 16 15 10 12 16 15 10 100 12 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/ThreadGroup $assertionsDisabled Z 1
+ciInstanceKlass java/lang/Thread$UncaughtExceptionHandler 1 0 16 100 1 100 1 1 1 1 1 1 1 1 100 1 1 1
+instanceKlass java/lang/ThreadBuilders$BoundVirtualThread
+instanceKlass java/lang/VirtualThread
+ciInstanceKlass java/lang/BaseVirtualThread 0 0 36 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 100 1 1
+ciInstanceKlass java/lang/VirtualThread 0 0 928 9 100 12 1 1 1 9 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 10 100 12 1 1 1 9 12 1 1 100 1 10 12 1 9 12 1 1 18 12 1 1 9 12 1 1 10 12 1 1 100 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 9 12 1 1 10 12 1 10 100 12 1 10 12 1 10 12 1 10 12 1 10 12 1 9 12 1 1 11 100 12 1 1 1 10 10 12 1 11 100 12 1 1 1 10 12 1 100 1 10 12 1 1 100 1 9 12 1 1 5 0 10 100 12 1 1 1 9 12 1 100 1 100 1 10 10 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 10 12 1 100 1 10 10 12 1 10 12 1 1 9 12 1 1 10 12 1 1 9 12 1 1 10 12 1 9 12 1 10 100 12 1 1 10 9 10 10 12 1 1 10 12 1 1 10 100 12 1 1 10 100 1 10 9 10 100 1 10 12 1 1 10 12 1 10 10 12 1 1 9 12 1 10 12 1 10 12 1 9 12 1 1 10 12 1 10 12 1 10 12 1 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 9 12 1 18 9 100 12 1 1 1 10 12 1 1 9 12 1 10 12 1 10 12 1 1 10 12 1 9 12 1 1 18 12 1 9 12 1 9 12 1 10 12 9 12 1 1 10 100 12 1 1 10 12 1 10 12 1 1 10 100 12 1 1 10 12 1 100 1 8 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 100 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 100 12 1 1 8 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 10 12 1 100 1 10 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 11 100 12 1 1 11 12 1 10 12 9 100 12 1 1 1 9 12 1 10 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 100 1 10 10 12 1 1 10 12 1 100 1 100 1 10 8 1 10 12 1 1 10 12 1 10 12 1 10 10 12 1 8 1 10 10 12 1 10 12 1 10 100 12 1 1 8 1 8 1 10 12 1 1 10 10 9 100 12 1 1 1 10 12 1 1 10 12 1 10 10 12 9 12 1 10 12 1 1 10 12 1 9 12 1 10 12 1 1 9 12 1 10 12 1 1 9 12 1 10 12 1 1 18 12 1 1 8 1 10 12 1 1 8 1 8 1 10 100 12 1 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 10 12 1 18 12 1 1 18 12 1 1 5 0 9 12 1 10 12 1 10 12 1 10 100 1 10 12 1 1 9 12 1 9 12 1 1 10 12 1 1 10 12 1 10 12 10 12 1 1 10 100 12 1 1 10 12 1 1 100 1 8 1 10 10 12 1 8 10 12 1 1 8 8 9 12 1 8 8 10 12 1 10 12 1 1 8 1 18 12 1 10 100 12 1 1 10 12 1 10 12 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 3 1 3 3 1 3 3 1 3 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 16 15 10 12 15 10 12 15 10 12 16 15 10 12 16 15 10 12 16 15 10 12 16 15 10 12 15 10 100 12 1 1 1 1 1 1 1 100 1 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/ThreadBuilders$BoundVirtualThread 0 0 132 10 100 12 1 1 1 9 100 12 1 1 1 10 100 12 1 1 1 9 12 1 1 10 12 1 1 10 12 1 1 9 12 1 1 10 100 12 1 1 1 10 12 1 1 100 1 8 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 8 1 10 12 1 8 1 10 12 1 1 10 100 12 1 1 9 100 12 1 1 1 10 12 1 1 10 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1
+instanceKlass lombok/javac/handlers/HandleDelegate$DelegateRecursion
+instanceKlass org/apache/maven/artifact/repository/metadata/RepositoryMetadataDeploymentException
+instanceKlass org/apache/maven/artifact/repository/metadata/RepositoryMetadataInstallationException
+instanceKlass java/lang/Exception
+instanceKlass java/lang/Error
+ciInstanceKlass java/lang/Throwable 1 1 403 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 10 12 1 1 9 12 1 1 10 12 1 1 10 100 12 1 1 1 9 12 1 1 10 12 1 1 10 12 1 100 1 100 1 10 8 1 10 12 1 1 8 1 10 100 12 1 1 10 10 12 1 100 1 8 1 10 10 7 12 1 1 10 12 1 8 1 9 100 12 1 1 1 10 12 1 1 100 1 10 12 10 12 1 100 1 10 10 7 12 1 1 1 11 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 8 1 10 12 1 10 12 1 1 8 1 8 1 10 12 1 1 10 12 1 8 1 8 1 9 12 1 10 100 12 1 1 100 1 10 11 12 1 8 1 8 1 10 7 12 1 1 8 1 10 12 1 8 1 100 1 10 12 1 9 12 1 1 10 12 1 10 7 12 1 9 12 1 1 10 12 1 1 100 1 8 1 10 12 1 10 100 12 1 1 10 12 1 1 100 1 10 100 12 1 1 1 10 12 1 11 100 12 1 1 1 11 100 12 1 1 1 11 12 1 8 1 10 12 1 1 8 1 10 10 9 100 12 1 1 1 8 1 10 12 1 1 11 10 100 1 8 1 10 11 12 1 1 8 1 9 12 1 10 100 12 1 1 11 9 12 1 1 11 12 1 1 100 10 12 1 10 12 1 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/Throwable UNASSIGNED_STACK [Ljava/lang/StackTraceElement; 0 [Ljava/lang/StackTraceElement;
+staticfield java/lang/Throwable SUPPRESSED_SENTINEL Ljava/util/List; java/util/Collections$EmptyList
+staticfield java/lang/Throwable EMPTY_THROWABLE_ARRAY [Ljava/lang/Throwable; 0 [Ljava/lang/Throwable;
+staticfield java/lang/Throwable $assertionsDisabled Z 1
+ciInstanceKlass jdk/internal/vm/ContinuationScope 0 0 50 10 100 12 1 1 1 10 100 12 1 1 1 100 1 9 100 12 1 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/vm/StackChunk 1 1 32 10 100 12 1 1 1 9 100 12 1 1 1 9 12 1 1 9 12 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/Boolean 1 1 146 10 7 12 1 1 1 9 7 12 1 1 1 10 12 1 1 10 12 1 8 1 10 7 12 1 1 9 12 1 1 9 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 9 100 12 1 1 9 12 10 100 12 1 1 1 10 12 1 1 8 1 10 7 12 1 1 1 9 12 1 1 100 1 100 1 100 1 1 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1
+staticfield java/lang/Boolean TRUE Ljava/lang/Boolean; java/lang/Boolean
+staticfield java/lang/Boolean FALSE Ljava/lang/Boolean; java/lang/Boolean
+staticfield java/lang/Boolean TYPE Ljava/lang/Class; java/lang/Class
+ciInstanceKlass java/lang/Character 1 1 603 7 1 100 1 100 1 9 12 1 1 8 1 9 12 1 1 100 1 9 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 10 100 12 1 1 1 10 7 12 1 1 1 9 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 10 12 1 1 3 3 3 3 3 10 12 1 1 10 12 1 3 11 7 12 1 1 1 11 12 1 1 10 12 1 1 10 12 1 1 100 1 10 10 12 1 3 10 12 1 1 10 12 1 10 12 1 1 100 1 8 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 7 12 1 1 10 10 12 1 10 10 12 1 10 12 1 1 10 12 1 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 10 12 10 10 12 1 10 10 12 1 10 10 12 1 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 10 12 1 10 10 12 1 10 10 12 1 1 10 10 12 1 10 5 0 10 12 1 10 12 1 10 10 12 1 10 10 12 1 1 10 10 12 1 10 10 12 1 9 12 1 1 100 1 10 10 12 1 10 12 1 1 3 10 100 12 1 1 1 10 12 1 10 100 12 1 1 100 1 10 10 12 1 1 10 12 1 1 10 12 1 1 8 1 10 12 1 9 100 12 1 1 1 10 12 1 10 10 12 1 10 12 1 1 10 12 1 10 10 12 1 1 10 10 12 1 1 100 1 8 1 10 12 1 1 10 7 12 1 1 1 8 1 10 12 1 1 9 12 1 1 100 1 100 1 100 1 1 1 1 3 1 3 1 3 1 3 1 1 1 1 1 3 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 3 1 1 3 1 1 1 1 1 3 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1
+staticfield java/lang/Character TYPE Ljava/lang/Class; java/lang/Class
+staticfield java/lang/Character $assertionsDisabled Z 1
+ciInstanceKlass java/lang/Float 1 1 277 7 1 100 1 10 7 12 1 1 1 10 100 12 1 1 1 4 100 1 10 12 1 1 10 12 1 1 8 1 8 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 7 1 4 10 7 12 1 1 9 12 1 1 10 12 1 1 10 12 1 10 10 12 1 1 10 12 1 10 12 1 3 3 100 1 4 4 4 3 10 12 1 1 9 12 1 1 100 1 10 3 3 4 4 10 12 1 3 3 3 10 12 1 1 10 12 1 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 8 1 10 12 1 1 9 12 1 1 100 1 100 1 100 1 1 1 1 4 1 4 1 1 1 4 1 1 3 1 3 1 3 1 3 1 3 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/Float TYPE Ljava/lang/Class; java/lang/Class
+staticfield java/lang/Float $assertionsDisabled Z 1
+instanceKlass java/math/BigDecimal
+instanceKlass java/math/BigInteger
+instanceKlass java/util/concurrent/atomic/AtomicLong
+instanceKlass java/util/concurrent/atomic/AtomicInteger
+instanceKlass java/lang/Long
+instanceKlass java/lang/Integer
+instanceKlass java/lang/Short
+instanceKlass java/lang/Byte
+instanceKlass java/lang/Double
+instanceKlass java/lang/Float
+ciInstanceKlass java/lang/Number 1 1 37 10 7 12 1 1 1 10 100 12 1 1 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/Double 1 1 288 7 1 100 1 10 100 12 1 1 1 10 12 1 1 10 100 1 10 12 1 1 10 100 12 1 1 1 6 0 8 1 10 12 1 1 8 1 10 12 1 1 8 1 6 0 10 12 1 1 100 1 5 0 5 0 8 1 8 1 10 100 12 1 1 1 10 100 12 1 1 1 8 1 10 12 1 1 8 1 8 1 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 7 1 6 0 10 7 12 1 1 9 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 5 0 10 12 1 1 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 8 1 10 7 12 1 1 1 9 12 1 1 100 1 100 1 100 1 1 1 6 0 1 6 0 1 6 0 1 1 1 6 0 1 1 3 1 3 1 3 1 3 1 3 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/Double TYPE Ljava/lang/Class; java/lang/Class
+ciInstanceKlass java/lang/Byte 1 1 212 7 1 100 1 10 100 12 1 1 1 9 12 1 1 8 1 9 12 1 1 100 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 9 7 12 1 1 1 10 12 1 1 7 1 100 1 10 12 1 1 8 1 10 12 1 1 8 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 8 1 8 1 10 7 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 5 0 10 12 1 1 8 1 10 7 12 1 1 1 9 12 1 1 100 1 100 1 1 1 3 1 3 1 1 1 1 3 1 3 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/Byte TYPE Ljava/lang/Class; java/lang/Class
+ciInstanceKlass java/lang/Short 1 1 220 7 1 100 1 100 1 10 100 12 1 1 1 10 12 1 1 7 1 100 1 10 12 1 1 8 1 10 12 1 1 8 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 9 12 1 1 8 1 9 12 1 1 100 1 10 12 1 1 10 12 1 10 100 12 1 1 1 10 100 12 1 1 1 9 7 12 1 1 1 10 12 1 10 12 1 1 10 8 1 8 1 10 7 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 3 3 5 0 10 12 1 1 8 1 10 7 12 1 1 1 9 12 1 1 100 1 100 1 1 1 3 1 3 1 1 1 1 3 1 3 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/Short TYPE Ljava/lang/Class; java/lang/Class
+ciInstanceKlass java/lang/Integer 1 1 436 7 1 100 1 7 1 7 1 10 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 10 100 12 1 1 1 10 10 12 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 7 12 1 1 10 12 1 1 10 12 1 10 12 1 7 1 8 1 10 12 1 8 1 100 1 10 12 1 1 10 12 1 1 8 1 10 12 1 1 8 1 10 12 1 1 10 12 1 1 10 12 1 1 3 3 10 7 12 1 1 1 11 7 1 10 12 1 1 11 10 12 1 1 10 12 1 1 8 1 10 12 1 10 12 1 8 1 100 1 10 12 1 8 1 10 12 1 1 10 12 1 8 1 10 12 1 10 12 1 7 1 9 12 1 1 9 12 1 1 10 12 1 10 7 1 9 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 8 1 8 1 10 12 1 1 8 1 8 1 8 1 8 1 8 1 8 1 10 12 1 10 12 1 10 12 1 5 0 3 3 3 3 10 12 1 10 12 1 3 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 8 1 10 7 12 1 1 1 9 12 1 1 100 1 100 1 100 1 1 1 1 3 1 1 1 1 1 3 1 3 1 1 5 0 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/Integer TYPE Ljava/lang/Class; java/lang/Class
+staticfield java/lang/Integer digits [B 36
+ciInstanceKlass java/lang/Long 1 1 498 7 1 100 1 7 1 7 1 10 12 1 1 9 12 1 1 9 7 12 1 1 1 10 100 12 1 1 1 10 12 1 1 10 100 12 1 1 1 10 10 12 10 12 1 10 12 1 10 12 1 5 0 5 0 100 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 100 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 7 12 1 1 10 12 1 1 10 12 1 10 12 1 7 1 8 1 10 12 1 8 1 100 1 10 12 1 10 12 1 1 8 1 10 12 1 1 8 1 10 12 1 1 10 12 1 1 10 12 1 1 5 0 5 0 10 100 12 1 1 1 11 100 1 10 12 1 1 11 10 12 1 1 10 12 1 1 8 1 5 0 10 12 1 1 10 12 1 1 8 1 8 1 10 12 1 8 1 10 12 1 10 12 1 5 0 5 0 9 7 12 1 1 1 10 12 1 10 12 1 1 8 1 8 1 10 12 1 1 8 1 8 1 8 1 8 1 8 1 8 1 10 12 1 10 12 1 10 7 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 5 0 5 0 5 0 10 12 1 1 10 12 1 5 0 5 0 10 12 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 8 1 10 7 12 1 1 1 9 12 1 1 100 1 100 1 100 1 1 1 1 5 0 1 1 1 1 3 1 3 1 5 0 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/Long TYPE Ljava/lang/Class; java/lang/Class
+ciInstanceKlass java/lang/Void 1 1 31 10 100 12 1 1 1 8 1 10 7 12 1 1 1 9 7 12 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/Void TYPE Ljava/lang/Class; java/lang/Class
+ciInstanceKlass jdk/internal/vm/vector/VectorSupport 0 0 597 100 1 10 100 12 1 1 1 9 12 1 1 10 100 12 1 1 1 100 1 10 12 1 11 100 12 1 1 1 11 100 12 1 1 1 11 100 12 1 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 1 11 100 12 1 1 11 100 12 1 1 1 11 100 12 1 1 1 11 100 12 1 1 11 100 12 1 1 1 11 100 12 1 1 100 1 10 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 9 12 1 1 10 100 12 1 1 11 100 12 1 1 10 100 12 1 1 1 10 100 12 1 1 10 12 1 1 10 12 1 1 1 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass jdk/internal/vm/vector/VectorSupport$VectorShuffle
+instanceKlass jdk/internal/vm/vector/VectorSupport$VectorMask
+instanceKlass jdk/internal/vm/vector/VectorSupport$Vector
+ciInstanceKlass jdk/internal/vm/vector/VectorSupport$VectorPayload 0 0 32 10 100 12 1 1 1 9 100 12 1 1 1 10 100 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/vm/vector/VectorSupport$Vector 0 0 28 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1
+ciInstanceKlass jdk/internal/vm/vector/VectorSupport$VectorMask 0 0 28 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1
+ciInstanceKlass jdk/internal/vm/vector/VectorSupport$VectorShuffle 0 0 28 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1
+ciInstanceKlass jdk/internal/vm/FillerObject 0 0 16 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1
+instanceKlass java/lang/ref/PhantomReference
+instanceKlass java/lang/ref/FinalReference
+instanceKlass java/lang/ref/WeakReference
+instanceKlass java/lang/ref/SoftReference
+ciInstanceKlass java/lang/ref/Reference 1 1 198 9 7 12 1 1 1 9 7 12 1 1 10 12 1 1 10 12 1 1 9 12 1 1 10 12 1 1 9 12 1 1 9 12 1 1 7 1 10 12 1 10 7 12 1 1 10 12 1 10 12 1 1 10 12 1 7 1 8 1 10 12 1 1 7 1 10 12 1 1 10 12 1 1 10 12 1 7 1 10 12 10 7 12 1 1 1 9 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 9 12 1 100 1 100 1 10 9 12 1 9 12 1 100 1 10 10 12 1 10 10 7 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 1 1
+staticfield java/lang/ref/Reference processPendingLock Ljava/lang/Object; java/lang/Object
+staticfield java/lang/ref/Reference $assertionsDisabled Z 1
+instanceKlass java/util/ResourceBundle$BundleReference
+instanceKlass org/eclipse/sisu/inject/MildElements$Soft
+instanceKlass sun/util/locale/provider/LocaleResources$ResourceReference
+instanceKlass sun/util/resources/Bundles$BundleReference
+instanceKlass jdk/internal/util/SoftReferenceKey
+instanceKlass org/eclipse/sisu/inject/MildKeys$Soft
+instanceKlass java/lang/invoke/LambdaFormEditor$Transform
+ciInstanceKlass java/lang/ref/SoftReference 1 1 50 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1
+instanceKlass com/sun/tools/javac/util/UnsharedNameTable$HashEntry
+instanceKlass java/util/ResourceBundle$KeyElementReference
+instanceKlass sun/nio/ch/FileLockTable$FileLockReference
+instanceKlass org/eclipse/sisu/inject/MildElements$Weak
+instanceKlass com/google/common/collect/MapMakerInternalMap$AbstractWeakKeyEntry
+instanceKlass com/google/common/cache/LocalCache$WeakEntry
+instanceKlass java/lang/WeakPairMap$WeakRefPeer
+instanceKlass java/util/logging/LogManager$LoggerWeakRef
+instanceKlass java/util/logging/Level$KnownLevel
+instanceKlass org/eclipse/sisu/inject/MildKeys$Weak
+instanceKlass java/lang/ThreadLocal$ThreadLocalMap$Entry
+instanceKlass jdk/internal/util/WeakReferenceKey
+instanceKlass java/util/WeakHashMap$Entry
+ciInstanceKlass java/lang/ref/WeakReference 1 1 34 10 7 12 1 1 1 10 12 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/lang/ref/Finalizer
+ciInstanceKlass java/lang/ref/FinalReference 1 1 50 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 100 1 8 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1
+instanceKlass jdk/internal/ref/PhantomCleanable
+instanceKlass jdk/internal/ref/Cleaner
+ciInstanceKlass java/lang/ref/PhantomReference 1 1 47 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/ref/Finalizer 1 1 177 9 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 9 12 1 9 12 1 1 10 12 1 100 1 8 1 10 12 1 10 12 1 1 9 12 1 100 1 10 12 1 7 1 11 7 12 1 1 10 12 1 100 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 100 12 1 1 8 1 10 12 1 10 12 1 10 12 1 100 1 10 12 1 10 100 12 1 1 1 100 1 10 10 12 1 1 7 1 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 7 1 10 7 1 10 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/ref/Finalizer lock Ljava/lang/Object; java/lang/Object
+staticfield java/lang/ref/Finalizer ENABLED Z 1
+staticfield java/lang/ref/Finalizer $assertionsDisabled Z 1
+instanceKlass java/lang/reflect/Executable
+instanceKlass java/lang/reflect/Field
+ciInstanceKlass java/lang/reflect/AccessibleObject 1 1 374 10 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 9 12 1 1 7 1 10 7 12 1 1 1 11 12 1 100 1 10 12 1 7 1 100 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 7 1 10 7 12 1 1 1 10 12 1 1 11 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 8 1 100 1 100 1 10 10 12 1 1 8 1 10 12 1 10 12 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 100 1 10 12 1 10 12 1 9 100 12 1 1 1 10 12 1 1 10 12 1 10 100 1 100 1 8 1 10 8 1 10 12 1 8 1 10 12 1 10 12 1 1 10 100 1 8 1 10 11 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 9 12 1 1 100 1 10 12 1 7 1 10 12 1 10 12 1 1 10 100 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 1 10 12 1 9 12 1 10 100 12 1 1 8 1 10 12 1 1 8 1 10 100 12 1 1 1 9 12 1 100 1 10 7 1 10 10 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/reflect/AccessibleObject reflectionFactory Ljdk/internal/reflect/ReflectionFactory; jdk/internal/reflect/ReflectionFactory
+ciInstanceKlass java/lang/reflect/Method 1 1 468 9 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 9 12 1 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 100 1 8 1 10 12 1 10 12 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 9 7 12 1 1 1 10 12 1 1 10 12 10 7 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 1 9 12 1 10 7 1 10 100 12 1 1 1 10 7 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 10 8 1 10 12 1 10 12 1 7 1 8 1 8 1 8 1 10 12 1 10 12 1 1 10 12 1 1 10 10 12 1 1 10 12 1 11 100 1 10 12 1 9 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 11 12 1 9 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 9 12 1 1 10 7 12 1 1 1 10 7 12 1 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 11 7 12 1 1 1 10 7 12 1 1 1 7 1 100 1 100 1 10 12 1 10 12 1 1 10 12 1 100 1 8 1 10 12 1 10 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 8 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/reflect/Member 1 1 37 100 1 10 12 1 1 100 1 100 1 1 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/lang/reflect/Constructor
+instanceKlass java/lang/reflect/Method
+ciInstanceKlass java/lang/reflect/Executable 1 1 587 10 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 11 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 8 1 10 10 12 1 1 10 12 1 1 10 100 12 1 1 1 18 12 1 1 11 100 12 1 1 1 8 1 8 1 8 1 10 100 12 1 1 1 11 12 1 1 100 1 8 1 8 1 10 12 1 100 1 8 1 10 12 1 8 1 11 100 12 1 1 1 100 1 11 100 12 1 1 1 11 12 1 8 1 18 8 1 10 12 1 10 12 1 1 18 8 1 10 12 1 100 1 10 12 1 10 12 1 11 12 1 10 12 1 1 8 1 8 1 10 12 1 1 10 12 1 1 10 10 12 1 9 12 1 1 9 100 12 1 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 10 7 12 1 1 10 12 1 10 12 1 10 12 1 10 7 12 1 1 100 1 10 100 12 1 1 1 10 12 1 1 10 7 12 1 1 10 12 1 10 12 1 1 9 7 12 1 1 1 10 100 10 12 1 8 1 10 12 1 10 12 1 3 100 1 8 1 10 12 1 10 12 1 10 10 12 1 10 12 1 1 8 1 8 1 8 1 9 12 1 1 9 12 1 10 12 1 100 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 10 12 1 7 1 10 12 1 10 12 1 1 100 1 10 100 12 1 1 1 7 1 10 7 12 1 1 1 10 12 1 1 11 7 12 1 1 10 12 1 10 100 12 1 1 1 10 12 1 1 9 12 1 10 12 1 1 10 12 1 10 12 1 1 9 7 12 1 1 1 10 7 12 1 1 1 10 12 1 10 12 1 1 9 12 1 10 10 10 10 100 12 1 1 1 10 12 1 9 12 1 10 12 1 1 9 12 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 16 15 16 1 16 1 15 10 12 16 15 10 100 12 1 1 1 1 100 1 1 1 100 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/reflect/Constructor 1 1 437 10 7 12 1 1 1 10 7 12 1 1 9 7 12 1 1 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 1 9 12 1 100 1 8 1 10 12 1 10 12 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 7 1 100 1 8 1 10 10 12 1 10 12 1 10 12 1 1 9 100 12 1 1 1 10 7 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 100 12 1 1 10 12 1 1 10 12 1 10 100 12 1 1 1 8 1 10 10 12 1 100 1 8 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 8 1 9 12 1 1 10 7 12 1 1 1 10 7 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 9 100 12 1 1 10 12 1 10 12 1 10 12 1 100 1 8 1 10 10 12 1 1 10 12 1 10 10 12 1 1 10 12 1 1 10 100 12 1 1 1 11 100 12 1 1 1 10 12 1 1 9 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1
+ciInstanceKlass java/lang/reflect/Field 1 1 454 9 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 9 12 1 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 9 12 1 1 9 12 1 1 9 12 1 9 12 1 1 100 1 8 1 10 12 1 10 12 1 9 12 1 1 9 12 1 10 7 12 1 1 10 12 1 1 10 12 1 1 10 12 1 9 12 1 1 10 12 1 1 9 100 12 1 1 1 10 7 12 1 1 1 7 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 7 1 10 7 12 1 1 100 1 10 8 1 10 12 1 1 10 12 1 1 8 1 10 12 10 12 1 8 1 8 1 10 11 100 1 9 12 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 10 12 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 10 12 1 10 100 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 7 12 1 1 10 12 1 1 11 7 1 10 12 1 7 1 10 100 12 1 1 1 10 7 12 1 1 1 9 12 1 10 7 12 1 1 1 11 7 12 1 1 1 10 12 1 1 10 12 1 1 9 7 12 1 1 10 7 12 1 1 1 10 12 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 100 1 1 100 1 1
+ciInstanceKlass java/lang/reflect/Parameter 1 1 256 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 100 1 10 10 12 1 1 11 100 12 1 1 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 8 1 8 1 10 100 12 1 1 1 10 12 1 10 12 9 100 12 1 1 1 9 100 12 1 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 8 1 10 12 1 9 12 1 1 10 12 1 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 10 12 1 10 100 12 1 1 1 10 12 1 1 11 100 12 1 1 10 100 12 1 1 100 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 9 12 1 100 1 10 11 12 1 11 12 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 100 1 1
+ciInstanceKlass java/lang/reflect/RecordComponent 0 0 196 10 100 12 1 1 1 9 100 12 1 1 1 9 12 1 1 9 12 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 100 12 1 1 10 100 12 1 1 9 12 1 1 10 100 12 1 1 1 11 100 12 1 1 1 10 9 100 12 1 1 1 10 100 12 1 1 1 9 12 1 1 10 100 12 1 1 1 10 12 1 1 11 100 12 1 1 10 100 12 1 1 100 1 9 12 1 9 12 1 1 9 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 100 1 10 10 12 1 10 12 1 1 8 1 10 12 1 10 12 1 9 12 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 100 1 1
+ciInstanceKlass java/lang/StringBuffer 1 1 487 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 1 9 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 10 10 100 12 1 1 1 10 10 12 1 1 9 12 1 1 10 100 12 1 1 10 100 1 8 10 100 12 1 1 1 8 10 12 1 8 1 10 12 1 10 12 1 10 100 12 1 1 1 10 100 12 1 1 1 7 1 10 12 100 1 8 1 10 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 12 10 12 1 10 12 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 7 1 10 12 1 9 7 12 1 1 1 9 7 1 9 12 1 1 100 1 100 1 100 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/StringBuffer serialPersistentFields [Ljava/io/ObjectStreamField; 3 [Ljava/io/ObjectStreamField;
+instanceKlass java/lang/StringBuilder
+instanceKlass java/lang/StringBuffer
+ciInstanceKlass java/lang/AbstractStringBuilder 1 1 662 7 1 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 100 1 3 3 10 12 1 10 12 1 1 10 12 1 1 11 7 1 100 1 100 1 10 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 9 12 1 10 12 1 9 12 1 1 10 7 12 1 1 1 10 10 12 1 10 12 1 10 12 1 1 9 12 1 100 1 8 1 10 12 1 10 12 1 1 8 1 10 7 12 1 1 1 10 12 1 1 8 1 10 7 12 1 1 1 100 1 8 1 10 100 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 100 1 10 10 7 12 1 1 1 9 12 1 1 9 12 1 10 12 1 1 10 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 10 10 12 1 10 12 1 1 10 8 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 100 1 9 12 1 1 9 12 1 10 12 1 1 100 1 9 12 1 9 12 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 10 12 1 1 18 12 1 1 100 1 10 100 12 1 1 1 18 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 11 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 5 0 10 100 1 8 1 10 10 12 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 100 1 10 12 100 1 10 100 1 10 10 7 12 1 1 100 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 100 1 1 1 1 1 1 100 1 1 16 1 15 10 12 16 15 10 12 15 10 100 12 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/AbstractStringBuilder EMPTYVALUE [B 0
+staticfield java/lang/AbstractStringBuilder $assertionsDisabled Z 1
+ciInstanceKlass java/lang/StringBuilder 1 1 425 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 10 12 1 1 10 12 1 10 12 1 10 12 1 1 8 1 10 12 1 10 100 12 1 1 1 9 12 1 1 10 12 1 10 12 1 10 12 1 1 9 12 1 1 10 100 12 1 1 1 10 100 1 10 12 1 1 10 100 12 1 1 10 12 1 10 12 1 1 100 1 100 1 8 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 10 12 10 12 1 10 12 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 10 10 12 1 100 1 100 1 100 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/security/CodeSource 1 1 396 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 9 12 1 1 10 100 12 1 1 10 100 10 100 12 1 1 1 10 12 1 1 10 12 1 1 100 1 10 10 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 100 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 10 100 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 8 1 10 12 1 1 10 100 1 10 10 12 1 1 8 1 10 12 1 10 12 1 10 12 1 8 1 8 1 9 12 1 1 100 1 8 1 10 12 1 10 12 1 1 8 1 10 12 1 8 1 8 1 8 1 10 100 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 100 1 100 1 10 12 1 10 12 10 12 1 1 10 100 12 1 1 10 12 1 100 1 10 12 10 100 12 1 1 1 10 8 1 10 12 1 10 12 1 1 100 1 10 12 1 1 100 1 100 1 8 1 8 1 10 10 12 1 1 10 100 12 1 1 1 100 1 10 12 10 12 1 1 11 100 12 1 1 10 10 12 1 11 10 12 1 8 1 100 1 10 12 1 10 12 1 1 10 12 1 11 12 1 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1
+ciInstanceKlass java/security/ProtectionDomain 1 1 141 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 7 1 9 12 1 9 12 1 1 7 1 9 12 1 1 9 12 1 10 100 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 8 1 100 1 8 1 10 12 1 10 11 12 1 1 10 100 12 1 1 1 10 12 1 1 8 1 11 8 1 10 12 1 8 1 8 1 8 1 10 12 1 8 1 8 1 1 1 1 1 1 1 1 100 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1
+instanceKlass jdk/internal/loader/Loader
+instanceKlass java/net/URLClassLoader
+instanceKlass jdk/internal/loader/BuiltinClassLoader
+ciInstanceKlass java/security/SecureClassLoader 1 1 99 10 7 12 1 1 1 7 1 10 12 1 9 7 12 1 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 7 1 10 7 1 10 12 1 7 1 10 12 1 11 7 12 1 1 1 7 1 11 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/net/URL 1 1 736 10 7 12 1 1 1 10 12 1 10 7 12 1 1 9 12 1 1 9 12 1 10 12 1 1 9 12 1 1 10 7 12 1 1 1 8 1 10 12 1 1 100 1 10 10 12 1 1 8 1 10 12 1 1 9 12 1 100 1 8 1 10 12 1 10 12 1 8 1 9 12 1 10 12 1 1 9 12 1 10 12 1 10 12 1 9 12 1 9 12 1 8 1 9 12 1 10 12 1 1 8 1 9 12 1 1 10 12 1 1 10 7 12 1 1 1 8 1 10 12 1 7 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 8 1 10 12 1 1 10 12 1 8 1 9 12 1 8 1 10 12 1 10 7 12 1 1 1 100 1 10 12 1 10 12 1 1 10 7 12 1 1 1 100 1 8 1 10 10 12 1 8 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 8 1 10 10 100 1 10 10 12 1 8 1 10 7 12 1 1 1 10 12 1 9 12 1 1 10 12 1 10 100 12 1 1 1 100 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 10 12 1 8 1 100 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 8 1 9 100 12 1 1 1 10 100 12 1 1 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 9 12 1 1 9 12 1 1 100 1 8 1 10 9 12 1 1 10 7 12 1 1 8 1 10 7 12 1 1 8 1 10 12 1 1 10 12 1 8 1 8 1 10 7 12 1 1 1 100 1 10 7 12 1 1 1 10 12 1 10 12 1 9 7 12 1 1 1 10 7 12 1 1 10 12 1 1 10 12 1 8 1 7 1 10 7 12 1 1 1 10 12 1 1 11 7 12 1 1 11 12 1 10 12 1 10 12 1 8 9 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 11 7 1 10 12 1 10 12 1 9 12 1 10 12 1 1 10 100 12 1 1 10 100 12 1 1 1 8 10 100 12 1 1 100 1 10 8 8 10 12 1 8 8 8 100 1 10 12 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 10 12 1 1 10 12 1 1 10 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 10 12 1 100 1 8 1 10 10 10 12 1 1 10 12 1 10 12 1 1 8 1 7 1 10 10 7 1 10 12 1 9 7 12 1 1 1 9 12 1 1 7 1 10 10 7 12 1 1 1 100 1 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/net/URL defaultFactory Ljava/net/URLStreamHandlerFactory; java/net/URL$DefaultFactory
+staticfield java/net/URL handlers Ljava/util/Hashtable; java/util/Hashtable
+staticfield java/net/URL streamHandlerLock Ljava/lang/Object; java/lang/Object
+staticfield java/net/URL serialPersistentFields [Ljava/io/ObjectStreamField; 7 [Ljava/io/ObjectStreamField;
+ciInstanceKlass java/util/jar/Manifest 1 1 320 10 7 12 1 1 1 7 1 10 9 7 12 1 1 1 7 1 10 9 12 1 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 11 7 1 11 12 1 1 10 12 1 1 10 100 12 1 1 1 100 1 100 1 10 8 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 11 100 1 10 12 1 10 12 1 1 11 12 1 1 10 12 1 11 12 1 1 11 100 12 1 1 1 11 100 12 1 1 11 12 1 1 100 1 10 12 1 8 1 11 12 1 7 1 10 12 1 1 11 12 1 10 12 1 10 12 1 10 9 7 12 1 1 1 10 12 1 1 10 100 12 1 10 12 1 10 12 1 9 100 12 1 1 1 8 1 10 12 1 8 1 8 1 7 1 10 12 1 10 12 1 10 12 1 1 100 1 8 1 10 12 1 1 8 1 10 10 12 1 1 8 1 10 12 1 1 10 100 12 1 1 1 10 12 1 10 11 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 11 10 12 1 11 10 12 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/io/ByteArrayInputStream 1 1 135 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 10 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 100 12 1 1 1 10 12 1 1 10 100 12 1 1 1 100 1 100 1 100 1 3 10 100 1 10 100 12 1 1 1 9 12 1 1 100 1 10 10 7 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/io/ByteArrayInputStream $assertionsDisabled Z 1
+instanceKlass java/nio/IntBuffer
+instanceKlass java/nio/CharBuffer
+instanceKlass java/nio/LongBuffer
+instanceKlass java/nio/ByteBuffer
+ciInstanceKlass java/nio/Buffer 1 1 259 100 1 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 100 1 100 1 10 8 1 10 12 1 1 10 12 1 8 1 8 1 10 12 1 1 10 12 1 8 1 9 12 1 1 100 1 8 1 10 12 1 8 1 8 1 9 12 10 12 1 8 1 8 1 8 1 10 12 1 8 1 8 1 8 1 100 1 10 100 1 10 100 1 10 9 12 1 1 10 7 12 1 1 1 100 1 10 12 1 1 10 12 1 10 100 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 9 12 1 1 7 1 10 10 12 1 1 7 1 10 10 7 12 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 1
+staticfield java/nio/Buffer UNSAFE Ljdk/internal/misc/Unsafe; jdk/internal/misc/Unsafe
+staticfield java/nio/Buffer SCOPED_MEMORY_ACCESS Ljdk/internal/misc/ScopedMemoryAccess; jdk/internal/misc/ScopedMemoryAccess
+staticfield java/nio/Buffer IOOBE_FORMATTER Ljava/util/function/BiFunction; jdk/internal/util/Preconditions$4
+staticfield java/nio/Buffer $assertionsDisabled Z 1
+ciInstanceKlass java/lang/AssertionStatusDirectives 0 0 24 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass com/sun/tools/javac/tree/JCTree$JCBlock$PatternMatchingCatch
+instanceKlass com/sun/tools/javac/code/TypeMetadata$Annotations
+instanceKlass com/sun/tools/javac/code/TypeMetadata$ConstantValue
+instanceKlass jdk/internal/classfile/impl/AbstractInstruction$SwitchCaseImpl
+instanceKlass com/sun/tools/javac/code/Symbol$ClassSymbol$PermittedClassWithPos
+instanceKlass com/sun/tools/javac/comp/Lower$TypePairs
+instanceKlass com/sun/tools/javac/jvm/Gen$PatternMatchingCatchConfiguration
+instanceKlass java/util/Formatter$FixedString
+instanceKlass jdk/internal/misc/ThreadTracker$ThreadRef
+instanceKlass java/lang/reflect/Executable$ParameterData
+instanceKlass jdk/internal/classfile/impl/StackCounter$Target
+instanceKlass jdk/internal/classfile/impl/StackMapDecoder$StackMapFrameImpl
+instanceKlass jdk/internal/classfile/impl/StackMapDecoder$ObjectVerificationTypeInfoImpl
+instanceKlass java/lang/reflect/Proxy$ProxyBuilder$ProxyClassContext
+instanceKlass java/lang/ClassValue$Version
+instanceKlass sun/util/locale/LanguageTag
+instanceKlass java/util/stream/Collectors$CollectorImpl
+instanceKlass java/lang/invoke/InvokerBytecodeGenerator$ClassData
+instanceKlass java/security/SecureClassLoader$CodeSourceKey
+instanceKlass java/util/zip/ZipFile$EntryPos
+instanceKlass sun/nio/fs/WindowsPathParser$Result
+instanceKlass java/lang/invoke/MethodHandles$Lookup$ClassDefiner
+instanceKlass jdk/internal/classfile/impl/ClassHierarchyImpl$ClassHierarchyInfoImpl
+instanceKlass java/lang/classfile/ClassHierarchyResolver$1Factory
+instanceKlass jdk/internal/classfile/impl/RawBytecodeHelper$CodeRange
+instanceKlass jdk/internal/classfile/impl/StackMapGenerator$Type
+instanceKlass jdk/internal/classfile/impl/DirectCodeBuilder$DeferredLabel
+instanceKlass jdk/internal/classfile/impl/Util$1WithCodeMethodHandler
+instanceKlass jdk/internal/classfile/impl/AnnotationImpl
+instanceKlass jdk/internal/reflect/ReflectionFactory$Config
+instanceKlass jdk/internal/foreign/abi/UpcallLinker$CallRegs
+instanceKlass jdk/internal/foreign/abi/VMStorage
+ciInstanceKlass java/lang/Record 1 1 22 10 7 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/util/concurrent/ConcurrentHashMap 1 1 1219 100 1 7 1 10 7 12 1 1 1 10 12 1 1 9 12 1 1 3 10 7 12 1 1 1 3 7 1 10 7 12 1 1 1 100 1 10 100 12 1 1 1 100 1 11 12 1 1 11 12 1 11 12 1 1 9 12 1 1 9 12 1 9 12 1 1 10 7 12 1 1 1 7 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 4 10 12 1 11 7 12 1 1 10 12 1 10 12 1 1 100 1 10 5 0 10 12 1 9 12 1 10 12 1 1 5 0 10 12 1 10 12 1 9 12 1 1 10 12 1 1 9 12 1 9 12 1 1 10 12 1 1 9 12 1 10 12 1 1 9 12 1 1 10 12 1 1 100 1 10 7 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 7 1 10 12 1 1 7 1 100 1 8 1 10 12 1 10 12 1 1 10 12 1 1 10 10 12 1 11 12 1 1 11 7 12 1 1 1 11 7 12 1 1 1 11 12 1 7 1 11 12 1 11 12 1 10 12 1 1 10 12 1 1 9 12 1 1 10 7 12 1 1 1 9 10 12 1 1 9 12 1 10 12 1 1 5 0 9 12 1 1 7 1 10 12 1 9 12 1 1 7 1 10 12 1 9 12 1 7 1 10 100 1 10 10 12 1 1 8 1 10 12 1 10 12 1 1 11 100 1 10 12 1 10 100 12 1 1 1 8 1 10 100 12 1 1 1 8 1 10 12 1 8 1 10 12 1 10 12 1 1 10 100 12 1 1 10 12 1 10 12 1 10 12 1 9 12 1 9 10 12 1 9 12 1 11 7 12 1 1 1 11 7 12 1 1 1 100 1 10 12 11 100 12 1 1 10 11 7 12 1 10 12 1 100 1 10 12 1 100 1 10 10 9 7 12 1 1 1 3 10 100 12 1 1 9 12 1 10 12 1 1 9 12 1 1 9 12 1 10 12 1 1 10 100 12 1 1 9 12 1 9 7 12 1 1 10 12 1 1 10 12 1 3 9 12 1 9 12 1 10 12 1 1 7 1 9 3 100 1 10 12 1 9 12 1 10 12 1 9 12 1 10 12 1 9 12 1 10 100 12 1 1 1 100 10 12 1 100 1 5 0 10 100 12 1 1 100 1 10 12 1 1 10 12 1 10 12 1 100 1 10 12 1 10 100 1 100 1 10 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 1 100 1 10 12 1 10 10 12 1 100 1 10 12 1 10 10 12 1 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 10 100 1 10 10 100 1 10 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 10 100 1 10 10 100 1 10 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 10 12 1 10 12 1 7 1 7 1 10 12 1 9 12 1 1 9 12 1 1 10 12 1 1 8 10 12 1 1 8 8 8 8 7 10 12 1 1 10 12 1 1 100 1 8 1 10 7 1 100 1 100 1 1 1 5 0 1 1 3 1 3 1 1 1 1 3 1 3 1 3 1 1 1 1 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/util/concurrent/ConcurrentHashMap serialPersistentFields [Ljava/io/ObjectStreamField; 3 [Ljava/io/ObjectStreamField;
+staticfield java/util/concurrent/ConcurrentHashMap U Ljdk/internal/misc/Unsafe; jdk/internal/misc/Unsafe
+staticfield java/util/concurrent/ConcurrentHashMap SIZECTL J 44
+staticfield java/util/concurrent/ConcurrentHashMap TRANSFERINDEX J 56
+staticfield java/util/concurrent/ConcurrentHashMap BASECOUNT J 48
+staticfield java/util/concurrent/ConcurrentHashMap CELLSBUSY J 60
+staticfield java/util/concurrent/ConcurrentHashMap CELLVALUE J 144
+staticfield java/util/concurrent/ConcurrentHashMap ABASE J 16
+staticfield java/util/concurrent/ConcurrentHashMap ASHIFT I 2
+instanceKlass org/apache/maven/project/DefaultProjectBuilder$1
+instanceKlass java/util/Collections$SingletonMap
+instanceKlass org/eclipse/sisu/wire/EntryMapAdapter
+instanceKlass com/google/common/collect/Maps$ViewCachingAbstractMap
+instanceKlass com/google/common/collect/MapMakerInternalMap
+instanceKlass org/eclipse/sisu/wire/MergedProperties
+instanceKlass com/google/common/cache/LocalCache
+instanceKlass java/util/EnumMap
+instanceKlass java/util/TreeMap
+instanceKlass java/util/IdentityHashMap
+instanceKlass java/util/WeakHashMap
+instanceKlass java/util/Collections$EmptyMap
+instanceKlass sun/util/PreHashedMap
+instanceKlass java/util/HashMap
+instanceKlass java/util/ImmutableCollections$AbstractImmutableMap
+instanceKlass java/util/concurrent/ConcurrentHashMap
+ciInstanceKlass java/util/AbstractMap 1 1 198 10 7 12 1 1 1 10 7 12 1 1 1 11 7 12 1 1 1 10 11 12 1 1 11 7 12 1 1 1 11 12 1 1 7 1 11 12 1 10 12 1 1 11 12 1 100 1 10 11 12 1 11 7 1 10 12 1 1 11 12 1 9 12 1 1 7 1 10 12 1 9 12 1 1 7 1 10 11 11 12 1 1 11 12 1 100 1 100 1 11 12 1 8 1 100 1 10 10 12 1 1 8 1 10 12 1 10 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 100 1 100 1 1 1 1 1 1 1 1
+ciInstanceKlass java/util/concurrent/ConcurrentMap 1 1 201 11 100 12 1 1 1 10 100 12 1 1 11 12 1 1 11 100 12 1 1 1 11 100 12 1 1 1 11 12 1 1 100 1 11 12 1 11 12 1 100 1 11 100 12 1 1 1 18 12 1 11 12 1 1 11 100 12 1 1 11 12 1 1 11 100 12 1 11 12 1 1 11 12 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 11 12 15 10 100 12 1 1 1 1 1 100 1 100 1 1 1 100 1 8 1 1 12 10 1 8 1 1 1 8 1 8 1 1 8 1 1 1 8 1 1 1 8 1 1 8 1 8 1 1 1 8 1 1 8 1 1 1 8 1
+ciInstanceKlass java/util/Collection 1 1 115 11 100 12 1 1 1 100 1 11 7 12 1 1 1 10 100 12 1 1 1 11 12 1 1 11 100 12 1 1 1 11 12 1 1 11 100 12 1 1 1 11 12 1 1 10 7 12 1 1 1 11 12 1 10 7 12 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass jdk/internal/loader/ClassLoaders$BootClassLoader
+instanceKlass jdk/internal/loader/ClassLoaders$PlatformClassLoader
+instanceKlass jdk/internal/loader/ClassLoaders$AppClassLoader
+ciInstanceKlass jdk/internal/loader/BuiltinClassLoader 1 1 652 9 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 1 7 1 10 12 1 9 12 1 10 12 1 9 12 1 10 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 11 7 12 1 1 1 100 1 100 1 10 10 12 1 1 8 1 10 12 1 10 12 7 1 10 12 1 10 12 1 1 11 7 12 1 1 1 11 7 12 1 1 1 11 12 1 1 7 1 8 1 8 1 10 9 12 1 1 10 7 12 1 1 11 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 10 7 12 1 1 100 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 10 12 1 100 1 8 1 10 12 1 1 10 8 1 10 12 1 1 10 12 1 1 10 12 1 1 11 7 12 1 1 11 12 1 7 1 10 11 12 1 1 11 10 12 1 1 7 1 10 12 1 10 7 12 1 10 12 1 11 12 1 1 11 7 1 11 12 1 7 1 10 12 1 1 100 1 100 1 11 12 1 1 10 12 1 10 12 10 12 1 10 7 12 1 1 1 7 1 10 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 9 12 1 1 100 1 10 10 12 1 1 10 12 1 1 10 12 1 10 12 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 7 1 10 12 10 7 12 1 1 1 10 12 1 11 12 1 7 1 10 12 1 7 1 100 1 10 12 1 10 12 1 11 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 1 10 7 12 1 1 10 12 1 100 1 8 1 8 1 10 10 12 1 8 1 8 1 10 7 12 1 1 1 11 7 12 1 1 1 9 7 12 1 1 1 10 7 12 1 1 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 10 7 12 1 1 1 8 1 10 12 1 7 1 10 11 12 1 1 10 12 10 12 1 10 12 1 100 1 10 12 1 10 12 1 11 11 12 1 10 7 12 1 1 10 7 12 1 1 8 1 10 7 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 100 1 1 1 1 1
+staticfield jdk/internal/loader/BuiltinClassLoader packageToModule Ljava/util/Map; java/util/concurrent/ConcurrentHashMap
+staticfield jdk/internal/loader/BuiltinClassLoader $assertionsDisabled Z 1
+ciInstanceKlass jdk/internal/loader/ClassLoaders$AppClassLoader 1 1 57 8 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 100 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1
+ciInstanceKlass jdk/internal/loader/ClassLoaders$PlatformClassLoader 1 1 42 8 1 10 7 12 1 1 1 10 7 12 1 1 1 100 1 10 12 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 100 1 1
+ciInstanceKlass java/lang/ArithmeticException 1 1 26 10 100 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+instanceKlass lombok/javac/JavacResolution$TypeNotConvertibleException
+instanceKlass lombok/javac/handlers/HandleDelegate$CantMakeDelegates
+instanceKlass com/sun/tools/javac/parser/ReferenceParser$ParseException
+instanceKlass com/sun/tools/javac/jvm/JNIWriter$TypeSignature$SignatureException
+instanceKlass com/sun/tools/javac/jvm/ModuleNameReader$BadClassFile
+instanceKlass com/sun/tools/javac/util/ByteBuffer$UnderflowException
+instanceKlass com/sun/tools/javac/util/InvalidUtfException
+instanceKlass com/sun/tools/javac/platform/PlatformProvider$PlatformNotSupported
+instanceKlass sun/nio/fs/WindowsException
+instanceKlass jdk/javadoc/internal/doclint/DocLint$BadArgs
+instanceKlass com/sun/tools/javac/main/Option$InvalidValueException
+instanceKlass org/codehaus/plexus/util/cli/CommandLineException
+instanceKlass org/codehaus/plexus/compiler/util/scan/InclusionScanException
+instanceKlass org/codehaus/plexus/compiler/CompilerException
+instanceKlass org/codehaus/plexus/compiler/manager/NoSuchCompilerException
+instanceKlass org/apache/maven/shared/filtering/MavenFilteringException
+instanceKlass org/apache/maven/artifact/DependencyResolutionRequiredException
+instanceKlass org/codehaus/plexus/util/introspection/MethodMap$AmbiguousException
+instanceKlass org/apache/maven/reporting/MavenReportException
+instanceKlass java/net/URISyntaxException
+instanceKlass javax/xml/transform/TransformerException
+instanceKlass bsh/EvalError
+instanceKlass org/apache/maven/enforcer/rule/api/EnforcerRuleException
+instanceKlass com/github/packageurl/MalformedPackageURLException
+instanceKlass org/xml/sax/SAXException
+instanceKlass javax/xml/parsers/ParserConfigurationException
+instanceKlass org/codehaus/plexus/interpolation/reflection/MethodMap$AmbiguousException
+instanceKlass org/apache/maven/model/resolution/UnresolvableModelException
+instanceKlass org/apache/maven/model/resolution/InvalidRepositoryException
+instanceKlass org/apache/maven/cli/internal/ExtensionResolutionException
+instanceKlass org/apache/maven/toolchain/building/ToolchainsBuildingException
+instanceKlass org/apache/maven/execution/MavenExecutionRequestPopulationException
+instanceKlass org/apache/maven/repository/legacy/resolver/conflict/ConflictResolverNotFoundException
+instanceKlass org/apache/maven/configuration/BeanConfigurationException
+instanceKlass org/apache/maven/plugin/version/PluginVersionNotFoundException
+instanceKlass org/apache/maven/plugin/InvalidPluginException
+instanceKlass org/sonatype/plexus/components/sec/dispatcher/SecDispatcherException
+instanceKlass org/sonatype/plexus/components/cipher/PlexusCipherException
+instanceKlass org/apache/maven/model/building/ModelBuildingException
+instanceKlass org/apache/maven/lifecycle/internal/builder/BuilderNotFoundException
+instanceKlass org/apache/maven/lifecycle/NoGoalSpecifiedException
+instanceKlass org/apache/maven/lifecycle/MissingProjectException
+instanceKlass org/apache/maven/artifact/repository/metadata/RepositoryMetadataReadException
+instanceKlass org/apache/maven/artifact/repository/metadata/RepositoryMetadataStoreException
+instanceKlass org/codehaus/plexus/personality/plexus/lifecycle/phase/InitializationException
+instanceKlass org/apache/maven/project/interpolation/ModelInterpolationException
+instanceKlass org/apache/maven/project/DependencyResolutionException
+instanceKlass org/apache/maven/repository/ArtifactDoesNotExistException
+instanceKlass org/apache/maven/repository/ArtifactTransferFailedException
+instanceKlass org/apache/maven/BuildFailureException
+instanceKlass org/codehaus/plexus/util/dag/CycleDetectedException
+instanceKlass org/apache/maven/MavenExecutionException
+instanceKlass org/apache/maven/project/DuplicateProjectException
+instanceKlass java/security/GeneralSecurityException
+instanceKlass org/apache/maven/lifecycle/LifecycleNotFoundException
+instanceKlass org/apache/maven/lifecycle/LifecyclePhaseNotFoundException
+instanceKlass org/apache/http/HttpException
+instanceKlass org/apache/maven/wagon/WagonException
+instanceKlass org/apache/maven/artifact/repository/metadata/RepositoryMetadataResolutionException
+instanceKlass org/apache/maven/repository/legacy/metadata/ArtifactMetadataRetrievalException
+instanceKlass org/apache/maven/toolchain/MisconfiguredToolchainException
+instanceKlass org/apache/maven/settings/building/SettingsBuildingException
+instanceKlass org/apache/maven/plugin/version/PluginVersionResolutionException
+instanceKlass org/codehaus/plexus/component/repository/exception/ComponentLifecycleException
+instanceKlass org/apache/maven/plugin/PluginManagerException
+instanceKlass org/codehaus/plexus/component/composition/CycleDetectedInComponentGraphException
+instanceKlass org/apache/maven/plugin/PluginConfigurationException
+instanceKlass org/codehaus/plexus/component/configurator/ComponentConfigurationException
+instanceKlass org/codehaus/plexus/component/configurator/expression/ExpressionEvaluationException
+instanceKlass org/codehaus/plexus/configuration/PlexusConfigurationException
+instanceKlass org/apache/maven/repository/metadata/MetadataGraphTransformationException
+instanceKlass org/apache/maven/artifact/installer/ArtifactInstallationException
+instanceKlass org/apache/maven/plugin/MojoNotFoundException
+instanceKlass org/apache/maven/project/ProjectBuildingException
+instanceKlass org/apache/maven/artifact/deployer/ArtifactDeploymentException
+instanceKlass org/eclipse/aether/RepositoryException
+instanceKlass org/apache/maven/lifecycle/LifecycleExecutionException
+instanceKlass org/apache/maven/artifact/versioning/InvalidVersionSpecificationException
+instanceKlass org/apache/maven/artifact/InvalidRepositoryException
+instanceKlass org/apache/maven/plugin/prefix/NoPluginFoundForPrefixException
+instanceKlass org/apache/maven/artifact/resolver/AbstractArtifactResolutionException
+instanceKlass org/apache/maven/plugin/InvalidPluginDescriptorException
+instanceKlass org/apache/maven/plugin/PluginResolutionException
+instanceKlass org/apache/maven/plugin/PluginDescriptorParsingException
+instanceKlass org/apache/maven/repository/metadata/GraphConflictResolutionException
+instanceKlass org/apache/maven/repository/metadata/MetadataResolutionException
+instanceKlass org/apache/maven/plugin/AbstractMojoExecutionException
+instanceKlass java/util/concurrent/TimeoutException
+instanceKlass com/google/common/collect/RegularImmutableMap$BucketOverflowException
+instanceKlass java/util/concurrent/ExecutionException
+instanceKlass java/lang/InterruptedException
+instanceKlass com/google/inject/internal/ErrorsException
+instanceKlass com/google/inject/internal/InternalProvisionException
+instanceKlass org/codehaus/plexus/context/ContextException
+instanceKlass java/text/ParseException
+instanceKlass org/codehaus/plexus/PlexusContainerException
+instanceKlass org/codehaus/plexus/component/repository/exception/ComponentLookupException
+instanceKlass org/codehaus/plexus/util/xml/pull/XmlPullParserException
+instanceKlass java/lang/CloneNotSupportedException
+instanceKlass org/apache/commons/cli/ParseException
+instanceKlass org/codehaus/plexus/interpolation/InterpolationException
+instanceKlass org/apache/maven/cli/MavenCli$ExitException
+instanceKlass org/codehaus/plexus/classworlds/launcher/ConfigurationException
+instanceKlass java/io/IOException
+instanceKlass org/codehaus/plexus/classworlds/ClassWorldException
+instanceKlass java/lang/ReflectiveOperationException
+instanceKlass java/lang/RuntimeException
+ciInstanceKlass java/lang/Exception 1 1 40 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass lombok/core/AnnotationValues$AnnotationValueDecodeFail
+instanceKlass java/lang/LayerInstantiationException
+instanceKlass javax/lang/model/UnknownEntityException
+instanceKlass com/sun/tools/javac/jvm/Gen$CodeSizeOverflow
+instanceKlass com/sun/tools/javac/code/Types$AdaptFailure
+instanceKlass com/sun/tools/javac/comp/Attr$BreakAttr
+instanceKlass com/sun/tools/javac/util/CompilerInternalException
+instanceKlass com/sun/tools/javac/jvm/ClassWriter$StringOverflow
+instanceKlass com/sun/tools/javac/jvm/ClassWriter$PoolOverflow
+instanceKlass com/sun/tools/javac/code/Symbol$CompletionFailure
+instanceKlass java/nio/file/FileSystemAlreadyExistsException
+instanceKlass java/util/MissingResourceException
+instanceKlass java/nio/file/FileSystemNotFoundException
+instanceKlass java/nio/file/ProviderNotFoundException
+instanceKlass com/sun/tools/javac/util/ClientCodeException
+instanceKlass com/sun/tools/javac/util/PropagatedException
+instanceKlass org/apache/maven/project/DuplicateArtifactAttachmentException
+instanceKlass java/time/DateTimeException
+instanceKlass org/apache/maven/plugins/enforcer/internal/EnforcerRuleManagerException
+instanceKlass org/sonatype/central/publisher/plugin/exceptions/DeploymentPublishTimedOutException
+instanceKlass org/sonatype/central/publisher/plugin/exceptions/DeploymentPublishFailedException
+instanceKlass org/eclipse/aether/named/support/LockUpgradeNotSupportedException
+instanceKlass java/util/ConcurrentModificationException
+instanceKlass com/google/inject/internal/aop/GlueException
+instanceKlass java/io/UncheckedIOException
+instanceKlass org/apache/maven/artifact/InvalidArtifactRTException
+instanceKlass com/google/inject/OutOfScopeException
+instanceKlass java/lang/annotation/IncompleteAnnotationException
+instanceKlass java/lang/reflect/UndeclaredThrowableException
+instanceKlass com/google/common/util/concurrent/UncheckedExecutionException
+instanceKlass com/google/common/cache/CacheLoader$InvalidCacheLoadException
+instanceKlass java/util/NoSuchElementException
+instanceKlass com/google/inject/CreationException
+instanceKlass com/google/inject/ConfigurationException
+instanceKlass com/google/inject/ProvisionException
+instanceKlass java/lang/TypeNotPresentException
+instanceKlass java/lang/UnsupportedOperationException
+instanceKlass java/lang/SecurityException
+instanceKlass java/lang/IllegalStateException
+instanceKlass java/lang/IllegalArgumentException
+instanceKlass java/lang/IndexOutOfBoundsException
+instanceKlass java/lang/ArithmeticException
+instanceKlass java/lang/NullPointerException
+instanceKlass java/lang/IllegalCallerException
+instanceKlass java/lang/IllegalMonitorStateException
+instanceKlass java/lang/ArrayStoreException
+instanceKlass java/lang/ClassCastException
+ciInstanceKlass java/lang/RuntimeException 1 1 40 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/ArrayIndexOutOfBoundsException 1 1 45 10 100 12 1 1 1 10 12 1 100 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/ArrayStoreException 1 1 26 10 100 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/ClassCastException 1 1 26 10 100 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/ClassNotFoundException 1 1 96 7 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 100 12 1 1 1 8 1 10 100 12 1 1 1 10 7 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 7 1 10 12 1 9 12 1 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/ClassNotFoundException serialPersistentFields [Ljava/io/ObjectStreamField; 1 [Ljava/io/ObjectStreamField;
+instanceKlass java/lang/InstantiationException
+instanceKlass java/lang/IllegalAccessException
+instanceKlass java/lang/reflect/InvocationTargetException
+instanceKlass java/lang/NoSuchFieldException
+instanceKlass java/lang/NoSuchMethodException
+instanceKlass java/lang/ClassNotFoundException
+ciInstanceKlass java/lang/ReflectiveOperationException 1 1 34 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/IllegalCallerException 0 0 35 10 100 12 1 1 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/IllegalMonitorStateException 1 1 26 10 100 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/BootstrapMethodError 0 0 45 10 100 12 1 1 1 10 12 1 10 12 1 10 100 12 1 1 1 10 100 12 1 1 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1
+instanceKlass com/sun/tools/javac/file/PathFileObject$CannotCreateUriError
+instanceKlass com/sun/tools/javac/util/Abort
+instanceKlass com/sun/tools/javac/processing/AnnotationProcessingError
+instanceKlass com/sun/tools/javac/util/FatalError
+instanceKlass java/util/ServiceConfigurationError
+instanceKlass javax/xml/transform/TransformerFactoryConfigurationError
+instanceKlass com/google/common/util/concurrent/ExecutionError
+instanceKlass java/lang/AssertionError
+instanceKlass java/io/IOError
+instanceKlass org/apache/maven/BuildAbort
+instanceKlass java/lang/VirtualMachineError
+instanceKlass java/lang/LinkageError
+ciInstanceKlass java/lang/Error 1 1 58 10 7 12 1 1 1 9 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1
+instanceKlass java/lang/ClassFormatError
+instanceKlass java/lang/ExceptionInInitializerError
+instanceKlass java/lang/UnsatisfiedLinkError
+instanceKlass java/lang/IncompatibleClassChangeError
+instanceKlass java/lang/BootstrapMethodError
+instanceKlass java/lang/NoClassDefFoundError
+ciInstanceKlass java/lang/LinkageError 1 1 31 10 7 12 1 1 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/NullPointerException 1 1 52 10 7 12 1 1 1 10 12 1 9 7 12 1 1 1 10 12 1 1 9 12 1 1 10 12 1 1 10 12 1 1 1 1 5 0 1 1 1 1 1 1 1 1 100 1 100 1 100 1 1 1
+ciInstanceKlass java/lang/InternalError 1 1 34 10 100 12 1 1 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/lang/StackOverflowError
+instanceKlass java/lang/OutOfMemoryError
+instanceKlass java/lang/InternalError
+ciInstanceKlass java/lang/VirtualMachineError 1 1 34 10 100 12 1 1 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/NoClassDefFoundError 1 1 26 10 7 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/OutOfMemoryError 1 1 26 10 100 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/StackOverflowError 1 1 26 10 100 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/StackTraceElement 1 1 235 10 7 12 1 1 1 10 7 12 1 1 9 12 1 1 9 12 1 1 9 12 1 9 12 1 8 1 10 100 12 1 1 1 7 1 9 12 1 8 1 9 12 1 9 12 1 9 12 1 1 10 12 1 1 10 12 1 8 1 10 7 12 1 1 1 7 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 10 12 1 8 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 7 1 10 12 1 1 10 7 12 1 1 10 7 12 1 1 1 10 7 12 1 1 10 7 12 1 1 10 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 100 1 1 1 1 1 1 1 3 1 3 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1
+instanceKlass java/util/concurrent/locks/AbstractQueuedLongSynchronizer
+instanceKlass java/util/concurrent/locks/AbstractQueuedSynchronizer
+ciInstanceKlass java/util/concurrent/locks/AbstractOwnableSynchronizer 1 1 32 10 7 12 1 1 1 9 7 12 1 1 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/vm/Continuation 1 1 551 9 7 12 1 1 1 9 12 1 9 12 1 9 12 1 100 1 100 1 10 12 1 1 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 9 7 12 1 1 1 11 100 12 1 1 1 10 100 1 9 12 1 1 9 12 1 1 10 8 1 10 12 1 9 12 1 1 10 11 12 1 1 100 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 11 12 1 1 9 12 1 1 10 12 1 1 18 12 1 1 10 100 12 1 1 1 100 1 10 12 1 11 100 12 1 1 1 10 12 1 9 12 1 10 12 1 1 100 1 8 1 10 12 1 10 12 1 1 9 12 1 1 11 12 1 1 9 12 1 1 8 1 10 11 12 1 1 11 12 1 1 10 12 1 1 10 12 1 1 9 12 1 10 12 1 10 10 12 1 8 1 10 12 1 8 1 8 1 10 7 12 1 1 1 10 100 12 1 1 1 10 12 1 9 12 1 11 12 1 100 1 10 12 1 10 12 1 1 9 12 1 1 100 1 10 12 1 1 9 12 1 1 10 12 1 10 12 1 11 100 12 1 1 10 7 1 10 12 1 8 1 10 12 1 1 9 12 1 1 10 7 12 1 1 8 1 8 1 8 1 8 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 8 1 9 12 1 10 12 1 1 9 12 1 1 10 12 1 1 9 12 1 8 1 10 100 12 1 1 1 10 12 1 8 1 100 1 8 1 10 9 12 1 1 8 1 10 100 12 1 1 10 100 12 1 1 8 1 8 1 10 12 10 12 1 1 10 100 1 10 100 12 1 1 1 18 11 100 12 1 1 1 18 12 1 11 12 1 1 100 1 10 7 12 1 1 10 12 1 1 8 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 10 12 1 8 1 10 12 1 100 1 100 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 16 1 15 10 12 16 15 11 100 12 1 1 1 16 1 16 1 15 10 12 16 15 10 100 12 1 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield jdk/internal/vm/Continuation U Ljdk/internal/misc/Unsafe; jdk/internal/misc/Unsafe
+staticfield jdk/internal/vm/Continuation MOUNTED_OFFSET J 13
+staticfield jdk/internal/vm/Continuation PRESERVE_SCOPED_VALUE_CACHE Z 1
+staticfield jdk/internal/vm/Continuation JLA Ljdk/internal/access/JavaLangAccess; java/lang/System$1
+staticfield jdk/internal/vm/Continuation $assertionsDisabled Z 1
+ciInstanceKlass jdk/internal/misc/UnsafeConstants 1 1 34 10 100 12 1 1 1 9 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 1 1 1 1 1 1 1
+staticfield jdk/internal/misc/UnsafeConstants ADDRESS_SIZE0 I 8
+staticfield jdk/internal/misc/UnsafeConstants PAGE_SIZE I 4096
+staticfield jdk/internal/misc/UnsafeConstants BIG_ENDIAN Z 0
+staticfield jdk/internal/misc/UnsafeConstants UNALIGNED_ACCESS Z 1
+staticfield jdk/internal/misc/UnsafeConstants DATA_CACHE_LINE_FLUSH_SIZE I 0
+ciInstanceKlass java/lang/invoke/MethodHandleImpl 1 1 1424 10 7 12 1 1 1 7 1 10 7 12 1 1 1 10 7 12 1 1 1 100 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 9 100 12 1 1 1 10 100 12 1 1 1 100 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 9 7 12 1 1 1 10 7 12 1 1 1 100 1 10 9 12 1 1 9 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 8 1 8 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 7 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 11 7 12 1 1 11 12 1 1 7 1 11 12 1 10 12 1 1 10 12 1 1 11 12 1 10 7 12 1 1 10 12 1 1 10 7 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 9 7 12 1 1 1 10 10 12 1 1 10 12 1 1 10 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 8 1 100 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 7 1 10 12 1 100 1 8 1 10 12 1 10 100 12 1 1 1 8 1 10 12 1 10 100 12 1 1 1 100 1 9 100 1 10 12 1 1 10 12 1 1 9 12 1 10 12 1 1 10 100 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 7 1 10 12 1 1 9 12 1 1 10 12 1 9 100 12 1 1 1 11 100 12 1 1 7 1 9 12 1 100 1 10 12 1 10 12 1 1 100 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 7 1 9 100 12 1 1 1 10 12 1 10 12 1 9 100 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 100 12 1 1 10 100 12 1 1 1 9 12 1 10 12 1 9 12 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 100 12 1 1 10 12 1 10 100 12 1 1 8 1 10 8 1 100 1 10 9 12 1 100 1 10 12 1 8 1 10 10 12 1 10 10 12 1 1 10 12 1 1 10 12 1 10 12 1 100 1 8 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 100 1 10 12 1 10 12 1 10 12 1 1 7 1 10 12 1 10 7 12 1 1 10 12 1 9 12 1 10 12 1 1 10 12 1 1 100 1 10 10 12 1 8 1 8 1 9 12 1 8 1 8 1 8 1 9 12 1 10 12 1 1 9 12 1 1 10 12 1 8 1 9 7 1 10 12 1 1 10 12 1 8 1 8 1 8 1 100 1 100 1 8 8 1 8 1 100 1 8 1 100 1 10 12 1 7 1 10 10 7 12 1 1 1 10 12 1 10 12 10 12 1 10 12 1 11 100 12 1 1 1 18 12 1 11 100 12 1 1 1 18 18 12 1 11 12 1 1 10 12 1 1 10 12 1 10 12 1 11 12 1 9 12 1 9 12 10 10 12 1 1 9 12 1 1 11 12 1 1 18 12 1 1 11 12 1 1 11 12 1 1 10 12 1 11 100 1 10 12 1 10 12 1 10 12 1 9 12 1 9 12 10 12 1 10 100 12 1 1 1 10 12 1 10 12 1 1 10 12 1 10 12 9 12 1 1 10 12 1 10 12 1 1 9 12 1 9 12 1 10 12 1 10 12 1 1 10 12 1 100 1 10 12 1 9 12 1 1 11 100 1 9 12 1 9 12 11 12 1 9 12 1 10 12 10 12 1 1 10 12 1 1 9 7 12 1 1 10 12 1 10 12 1 10 12 1 1 100 1 10 12 1 10 12 1 1 100 1 10 12 1 1 10 12 1 1 100 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 9 12 1 10 12 1 10 12 1 1 9 7 12 1 1 1 8 10 12 1 1 8 1 10 12 1 8 1 8 1 8 1 8 1 8 1 8 1 100 1 8 1 8 1 10 12 1 9 12 1 10 12 1 1 1 1 1 3 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 1 16 15 10 12 16 15 16 16 1 15 10 12 16 16 15 10 12 16 15 10 100 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/invoke/MethodHandleImpl ARRAYS [Ljava/lang/invoke/MethodHandle; 256 [Ljava/lang/invoke/MethodHandle;
+staticfield java/lang/invoke/MethodHandleImpl NFS [Ljava/lang/invoke/LambdaForm$NamedFunction; 7 [Ljava/lang/invoke/LambdaForm$NamedFunction;
+staticfield java/lang/invoke/MethodHandleImpl HANDLES [Ljava/lang/invoke/MethodHandle; 9 [Ljava/lang/invoke/MethodHandle;
+staticfield java/lang/invoke/MethodHandleImpl $assertionsDisabled Z 1
+instanceKlass java/lang/invoke/DelegatingMethodHandle
+instanceKlass java/lang/invoke/BoundMethodHandle
+instanceKlass java/lang/invoke/DirectMethodHandle
+ciInstanceKlass java/lang/invoke/MethodHandle 1 1 734 100 1 9 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 7 1 7 1 10 12 1 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 11 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 100 1 100 1 10 8 1 10 12 1 1 10 12 1 8 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 10 7 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 8 1 10 7 12 1 1 1 8 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 8 1 10 12 1 1 8 1 10 12 1 8 1 10 100 12 1 1 1 9 12 1 1 100 1 10 9 100 12 1 1 1 9 100 1 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 8 1 10 12 1 1 8 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 9 100 12 1 1 1 10 12 1 1 11 12 1 10 12 1 10 12 1 1 10 100 12 1 1 100 1 11 12 1 10 100 1 11 12 1 100 1 10 12 1 11 12 1 9 100 12 1 1 1 11 12 1 1 11 100 12 1 1 1 10 12 1 1 9 12 1 11 12 1 9 12 1 9 12 1 9 12 1 11 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 8 1 10 12 1 10 12 1 8 1 10 12 1 10 12 1 10 12 1 1 10 10 10 7 12 1 1 10 12 1 1 100 1 100 1 8 1 8 1 10 10 12 1 1 10 12 1 10 12 1 100 1 10 100 12 1 1 1 10 9 7 12 1 1 1 10 12 1 1 10 12 1 1 8 1 8 1 10 100 12 1 1 9 12 1 9 12 1 1 9 12 1 1 10 12 1 7 1 10 12 1 10 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 11 7 12 1 1 9 12 1 10 12 1 1 9 12 1 10 12 1 8 10 12 1 1 8 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 100 1 100 1 100 1 1 100 1 1 100 1 1 1 1
+staticfield java/lang/invoke/MethodHandle FORM_OFFSET J 20
+staticfield java/lang/invoke/MethodHandle UPDATE_OFFSET J 13
+staticfield java/lang/invoke/MethodHandle $assertionsDisabled Z 1
+ciInstanceKlass java/lang/invoke/MethodType 1 1 724 7 1 10 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 9 7 12 1 1 8 1 10 100 12 1 1 1 9 7 1 9 7 1 10 12 1 1 100 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 100 1 8 1 10 12 1 100 1 10 10 12 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 9 12 1 11 12 1 1 7 10 12 1 1 10 12 1 1 7 1 7 1 10 7 12 1 1 1 10 12 1 10 12 1 9 12 1 1 10 7 12 1 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 8 1 8 1 10 12 1 1 9 12 1 1 100 1 10 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 9 12 1 10 12 1 10 10 12 1 1 10 12 1 9 12 1 1 10 12 1 1 11 12 1 1 10 12 1 1 10 12 1 10 12 1 100 1 8 1 8 1 8 1 10 12 1 10 12 1 10 12 1 1 10 10 12 1 11 12 1 1 11 12 1 10 100 12 1 1 1 9 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 9 12 1 1 7 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 8 1 10 7 12 1 1 1 11 12 1 1 9 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 100 12 1 1 10 12 1 10 12 100 1 11 100 12 1 1 10 12 1 11 12 1 10 100 12 1 1 10 12 1 1 10 12 1 1 9 12 1 1 9 100 12 1 1 1 10 100 12 1 1 1 9 12 1 10 100 12 1 1 10 12 1 100 10 12 1 10 12 1 1 10 12 1 7 1 10 10 12 1 1 7 1 7 1 9 12 1 1 100 1 100 1 100 1 1 1 5 0 1 1 1 1 1 1 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 100 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 100 1 1
+staticfield java/lang/invoke/MethodType internTable Ljdk/internal/util/ReferencedKeySet; jdk/internal/util/ReferencedKeySet
+staticfield java/lang/invoke/MethodType NO_PTYPES [Ljava/lang/Class; 0 [Ljava/lang/Class;
+staticfield java/lang/invoke/MethodType objectOnlyTypes [Ljava/lang/invoke/MethodType; 20 [Ljava/lang/invoke/MethodType;
+staticfield java/lang/invoke/MethodType METHOD_HANDLE_ARRAY [Ljava/lang/Class; 1 [Ljava/lang/Class;
+staticfield java/lang/invoke/MethodType serialPersistentFields [Ljava/io/ObjectStreamField; 0 [Ljava/io/ObjectStreamField;
+staticfield java/lang/invoke/MethodType $assertionsDisabled Z 1
+ciInstanceKlass java/lang/invoke/TypeDescriptor$OfMethod 1 0 43 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1
+instanceKlass lombok/EqualsAndHashCode$CacheStrategy
+instanceKlass lombok/core/handlers/HandlerUtil$JavadocTag
+instanceKlass lombok/javac/handlers/JavacHandlerUtil$CopyJavadoc
+instanceKlass lombok/core/handlers/HandlerUtil$FieldAccess
+instanceKlass java/lang/invoke/MethodHandleImpl$ArrayAccess
+instanceKlass com/sun/source/tree/ModuleTree$ModuleKind
+instanceKlass com/sun/source/tree/CaseTree$CaseKind
+instanceKlass lombok/javac/handlers/JavacHandlerUtil$MemberExistsResult
+instanceKlass lombok/javac/handlers/HandleConstructor$SkipIfConstructorExists
+instanceKlass lombok/AccessLevel
+instanceKlass lombok/delombok/LombokOptionsFactory$LombokOptionCompilerVersion
+instanceKlass com/sun/tools/javac/tree/JCTree$JCMemberReference$OverloadKind
+instanceKlass com/sun/tools/javac/tree/JCTree$JCMemberReference$ReferenceKind
+instanceKlass com/sun/source/tree/LambdaExpressionTree$BodyKind
+instanceKlass lombok/core/AST$Kind
+instanceKlass com/sun/tools/javac/util/Log$PrefixKind
+instanceKlass javax/lang/model/element/ModuleElement$DirectiveKind
+instanceKlass lombok/core/configuration/JacksonVersion
+instanceKlass lombok/core/configuration/CapitalizationStrategy
+instanceKlass lombok/core/configuration/NullCheckExceptionType
+instanceKlass lombok/core/configuration/CallSuperType
+instanceKlass lombok/core/configuration/FlagUsageType
+instanceKlass javax/lang/model/util/Elements$DocCommentKind
+instanceKlass com/sun/source/tree/Tree$Kind
+instanceKlass com/sun/tools/javac/code/TypeAnnotations$AnnotationType
+instanceKlass com/sun/tools/javac/comp/Resolve$InterfaceLookupPhase
+instanceKlass com/sun/tools/javac/code/TypeAnnotationPosition$TypePathEntryKind
+instanceKlass com/sun/tools/javac/code/TargetType
+instanceKlass com/sun/tools/javac/code/Attribute$RetentionPolicy
+instanceKlass javax/lang/model/element/NestingKind
+instanceKlass javax/lang/model/element/ElementKind
+instanceKlass com/sun/tools/javac/comp/DeferredAttr$AttributionMode
+instanceKlass com/sun/tools/javac/code/Scope$LookupKind
+instanceKlass java/nio/file/FileVisitResult
+instanceKlass com/sun/tools/javac/code/Directive$ExportsFlag
+instanceKlass com/sun/tools/javac/parser/JavacParser$LambdaParameterKind
+instanceKlass com/sun/tools/javac/tree/JCTree$JCLambda$ParameterKind
+instanceKlass com/sun/tools/javac/parser/JavacParser$ParensResult
+instanceKlass com/sun/tools/javac/tree/JCTree$JCPolyExpression$PolyKind
+instanceKlass com/sun/source/tree/MemberReferenceTree$ReferenceMode
+instanceKlass com/sun/tools/javac/parser/Tokens$Comment$CommentStyle
+instanceKlass com/sun/tools/javac/code/BoundKind
+instanceKlass com/sun/tools/javac/parser/UnicodeReader$UnicodeEscapeResult
+instanceKlass javax/lang/model/type/TypeKind
+instanceKlass com/sun/tools/javac/util/RichDiagnosticFormatter$RichConfiguration$RichFormatterFeature
+instanceKlass com/sun/tools/javac/comp/CompileStates$CompileState
+instanceKlass com/sun/tools/javac/main/JavaCompiler$ImplicitSourcePolicy
+instanceKlass com/sun/tools/javac/comp/ThisEscapeAnalyzer$Indirection
+instanceKlass com/sun/tools/javac/parser/Tokens$Token$Tag
+instanceKlass com/sun/tools/javac/parser/Tokens$TokenKind
+instanceKlass com/sun/tools/javac/jvm/ClassFile$Version
+instanceKlass com/sun/tools/javac/comp/Attr$CheckMode
+instanceKlass com/sun/tools/javac/comp/Analyzer$AnalyzerMode
+instanceKlass com/sun/tools/javac/jvm/Code$StackMapFormat
+instanceKlass com/sun/tools/javac/comp/Operators$OperatorType
+instanceKlass com/sun/tools/javac/tree/JCTree$Tag
+instanceKlass com/sun/tools/javac/jvm/Profile
+instanceKlass com/sun/tools/javac/comp/Resolve$VerboseResolutionMode
+instanceKlass com/sun/tools/javac/comp/DeferredAttr$AttrMode
+instanceKlass com/sun/tools/javac/main/Option$PkgInfo
+instanceKlass com/sun/tools/javac/util/Dependencies$CompletionCause
+instanceKlass com/sun/tools/javac/comp/Resolve$ReferenceLookupResult$StaticKind
+instanceKlass com/sun/tools/javac/comp/Resolve$MethodResolutionPhase
+instanceKlass com/sun/tools/javac/code/Directive$RequiresFlag
+instanceKlass com/sun/tools/javac/util/Convert$Validation
+instanceKlass com/sun/tools/javac/code/Symbol$ModuleResolutionFlags
+instanceKlass com/sun/tools/javac/code/Symbol$ModuleFlags
+instanceKlass com/sun/tools/javac/code/Kinds$KindName
+instanceKlass com/sun/tools/javac/code/Kinds$Kind$Category
+instanceKlass com/sun/tools/javac/code/Kinds$Kind
+instanceKlass com/sun/tools/javac/code/TypeTag
+instanceKlass com/sun/tools/javac/jvm/ClassReader$AttributeKind
+instanceKlass com/sun/tools/javac/main/JavaCompiler$CompilePolicy
+instanceKlass com/sun/tools/javac/main/Main$Result
+instanceKlass com/sun/tools/javac/util/BasicDiagnosticFormatter$BasicConfiguration$SourcePosition
+instanceKlass jdk/nio/zipfs/ZipFileSystem$ZipAccessMode
+instanceKlass com/sun/tools/javac/code/Source$Feature$DiagKind
+instanceKlass com/sun/tools/javac/code/Source$Feature
+instanceKlass com/sun/tools/javac/util/JCDiagnostic$DiagnosticType
+instanceKlass jdk/javadoc/internal/tool/AccessLevel
+instanceKlass jdk/javadoc/internal/doclint/Messages$Group
+instanceKlass com/sun/tools/javac/main/Arguments$ErrorMode
+instanceKlass com/sun/tools/javac/jvm/Target
+instanceKlass com/sun/tools/javac/util/BasicDiagnosticFormatter$BasicConfiguration$BasicFormatKind
+instanceKlass com/sun/tools/javac/api/DiagnosticFormatter$Configuration$MultilineLimit
+instanceKlass com/sun/tools/javac/api/DiagnosticFormatter$Configuration$DiagnosticPart
+instanceKlass com/sun/tools/javac/util/JCDiagnostic$DiagnosticFlag
+instanceKlass com/sun/tools/javac/util/Log$WriterKind
+instanceKlass javax/tools/StandardLocation
+instanceKlass javax/tools/JavaFileObject$Kind
+instanceKlass com/sun/tools/javac/code/Source
+instanceKlass com/sun/tools/javac/code/Lint$LintCategory
+instanceKlass com/sun/tools/javac/main/Option$ChoiceKind
+instanceKlass com/sun/tools/javac/main/Option$ArgKind
+instanceKlass com/sun/tools/javac/main/Option$OptionGroup
+instanceKlass com/sun/tools/javac/main/Option$OptionKind
+instanceKlass com/sun/tools/javac/main/Option
+instanceKlass javax/tools/Diagnostic$Kind
+instanceKlass org/codehaus/plexus/compiler/javac/JavacCompiler$JavaVersion
+instanceKlass org/apache/maven/shared/utils/io/ScanConductor$ScanAction
+instanceKlass org/fusesource/jansi/Ansi$Attribute
+instanceKlass org/fusesource/jansi/Ansi$Color
+instanceKlass org/apache/maven/shared/utils/logging/Style
+instanceKlass java/nio/file/FileTreeWalker$EventType
+instanceKlass java/nio/file/FileVisitOption
+instanceKlass java/util/Comparators$NaturalOrderComparator
+instanceKlass org/codehaus/plexus/compiler/CompilerConfiguration$CompilerReuseStrategy
+instanceKlass javax/lang/model/SourceVersion
+instanceKlass org/codehaus/plexus/compiler/CompilerMessage$Kind
+instanceKlass java/nio/file/attribute/PosixFilePermission
+instanceKlass org/apache/maven/shared/filtering/ChangeDetection
+instanceKlass org/apache/commons/lang3/JavaVersion
+instanceKlass java/time/zone/ZoneOffsetTransitionRule$TimeDefinition
+instanceKlass java/time/DayOfWeek
+instanceKlass java/time/Month
+instanceKlass java/time/format/TextStyle
+instanceKlass java/time/format/DateTimeFormatterBuilder$SettingsParser
+instanceKlass java/time/format/ResolverStyle
+instanceKlass java/time/format/SignStyle
+instanceKlass java/time/temporal/JulianFields$Field
+instanceKlass java/time/temporal/IsoFields$Unit
+instanceKlass java/time/temporal/IsoFields$Field
+instanceKlass java/time/temporal/ChronoField
+instanceKlass org/apache/maven/enforcer/rules/checksum/NormalizeLineSeparatorReader$LineSeparator
+instanceKlass org/apache/maven/enforcer/rule/api/EnforcerLevel
+instanceKlass org/apache/maven/plugin/MojoExecution$Source
+instanceKlass com/google/inject/internal/ErrorId
+instanceKlass org/sonatype/central/publisher/client/model/PublishingType
+instanceKlass org/sonatype/central/publisher/plugin/model/WaitUntilRequest
+instanceKlass org/sonatype/central/publisher/plugin/model/ChecksumRequest
+instanceKlass org/eclipse/sisu/space/GlobberStrategy
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictResolver$Verbosity
+instanceKlass java/nio/file/AccessMode
+instanceKlass org/eclipse/aether/RepositoryEvent$EventType
+instanceKlass org/eclipse/aether/named/support/ReadWriteLockNamedLock$Step
+instanceKlass java/time/temporal/ChronoUnit
+instanceKlass org/apache/maven/project/ProjectBuildingRequest$RepositoryMerging
+instanceKlass java/security/DrbgParameters$Capability
+instanceKlass sun/security/util/KnownOIDs
+instanceKlass java/security/Security$SecPropLoader$LoadingMode
+instanceKlass org/eclipse/sisu/inject/QualifyingStrategy
+instanceKlass com/google/inject/internal/InjectorImpl$JitLimitation
+instanceKlass org/eclipse/sisu/bean/DeclaredMembers$View
+instanceKlass com/google/inject/internal/Initializer$InjectableReferenceState
+instanceKlass java/lang/invoke/MethodHandles$Lookup$ClassOption
+instanceKlass sun/misc/Unsafe$MemoryAccessOption
+instanceKlass com/google/common/collect/MapMakerInternalMap$Strength
+instanceKlass org/apache/maven/settings/building/SettingsProblem$Severity
+instanceKlass org/eclipse/aether/metadata/Metadata$Nature
+instanceKlass org/apache/maven/model/building/ModelProblem$Version
+instanceKlass org/apache/maven/building/Problem$Severity
+instanceKlass org/apache/maven/plugin/internal/DefaultPluginValidationManager$ValidationReportLevel
+instanceKlass org/apache/maven/plugin/PluginValidationManager$IssueLocality
+instanceKlass org/apache/maven/classrealm/ClassRealmRequest$RealmType
+instanceKlass org/apache/maven/execution/ExecutionEvent$Type
+instanceKlass org/apache/maven/model/building/ModelProblem$Severity
+instanceKlass org/apache/maven/artifact/ArtifactScopeEnum
+instanceKlass com/google/inject/spi/InjectionPoint$Position
+instanceKlass com/google/common/util/concurrent/AbstractFutureState$VarHandleAtomicHelperMaker
+instanceKlass java/lang/annotation/ElementType
+instanceKlass java/lang/classfile/attribute/StackMapFrameInfo$SimpleVerificationTypeInfo
+instanceKlass java/lang/reflect/ProxyGenerator$PrimitiveTypeInfo
+instanceKlass java/lang/classfile/ClassFile$StackMapsOption
+instanceKlass java/lang/reflect/AccessFlag$Location
+instanceKlass java/lang/reflect/AccessFlag
+instanceKlass java/lang/module/ModuleDescriptor$Modifier
+instanceKlass java/lang/annotation/RetentionPolicy
+instanceKlass com/google/inject/internal/InternalFlags$ColorizeOption
+instanceKlass com/google/inject/internal/InternalFlags$BytecodeGenOption
+instanceKlass com/google/inject/internal/InternalFlags$NullableProvidesOption
+instanceKlass com/google/inject/internal/InternalFlags$CustomClassLoadingOption
+instanceKlass com/google/inject/internal/InternalFlags$IncludeStackTraceOption
+instanceKlass com/google/inject/Key$NullAnnotationStrategy
+instanceKlass sun/reflect/annotation/TypeAnnotation$TypeAnnotationTarget
+instanceKlass com/google/common/cache/LocalCache$EntryFactory
+instanceKlass com/google/common/cache/CacheBuilder$NullListener
+instanceKlass com/google/common/cache/CacheBuilder$OneWeigher
+instanceKlass com/google/common/cache/LocalCache$Strength
+instanceKlass jdk/internal/logger/BootstrapLogger$LoggingBackend
+instanceKlass java/util/stream/MatchOps$MatchKind
+instanceKlass com/google/inject/Stage
+instanceKlass org/eclipse/sisu/space/BeanScanning
+instanceKlass java/math/RoundingMode
+instanceKlass sun/util/locale/provider/LocaleProviderAdapter$Type
+instanceKlass java/util/stream/StreamShape
+instanceKlass java/util/stream/Collector$Characteristics
+instanceKlass java/util/stream/StreamOpFlag$Type
+instanceKlass java/util/stream/StreamOpFlag
+instanceKlass java/util/Locale$Category
+instanceKlass org/apache/maven/cli/logging/Slf4jConfiguration$Level
+instanceKlass org/slf4j/impl/OutputChoice$OutputChoiceType
+instanceKlass jdk/internal/util/OperatingSystem
+instanceKlass org/fusesource/jansi/AnsiColors
+instanceKlass org/fusesource/jansi/AnsiMode
+instanceKlass org/fusesource/jansi/AnsiType
+instanceKlass java/util/regex/Pattern$Qtype
+instanceKlass java/util/concurrent/TimeUnit
+instanceKlass java/nio/file/LinkOption
+instanceKlass sun/nio/fs/WindowsPathType
+instanceKlass java/nio/file/StandardOpenOption
+instanceKlass jdk/internal/vm/Continuation$Pinned
+instanceKlass java/lang/invoke/VarHandle$AccessType
+instanceKlass java/lang/invoke/VarHandle$AccessMode
+instanceKlass java/lang/classfile/Opcode$Kind
+instanceKlass java/lang/classfile/Opcode
+instanceKlass java/lang/invoke/MethodHandleImpl$Intrinsic
+instanceKlass java/lang/classfile/AttributeMapper$AttributeStability
+instanceKlass jdk/internal/classfile/impl/AbstractPoolEntry$Utf8EntryImpl$State
+instanceKlass java/lang/classfile/TypeKind
+instanceKlass java/lang/invoke/LambdaForm$BasicType
+instanceKlass java/lang/invoke/LambdaForm$Kind
+instanceKlass java/lang/constant/DirectMethodHandleDesc$Kind
+instanceKlass sun/invoke/util/Wrapper
+instanceKlass java/io/File$PathStatus
+instanceKlass jdk/internal/module/ModuleBootstrap$IllegalNativeAccess
+instanceKlass java/lang/reflect/ClassFileFormatVersion
+instanceKlass java/lang/Thread$State
+instanceKlass java/lang/module/ModuleDescriptor$Requires$Modifier
+ciInstanceKlass java/lang/Enum 1 1 204 9 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 9 12 1 10 7 12 1 1 1 100 1 10 10 12 1 1 10 12 1 100 1 10 10 7 12 1 1 10 12 1 1 18 12 1 1 10 100 12 1 1 1 10 12 1 1 11 7 12 1 1 1 100 1 8 1 10 12 1 7 1 7 1 10 8 1 10 12 1 1 10 12 1 1 8 1 10 12 1 10 100 1 8 1 10 10 12 1 1 10 100 12 1 1 1 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 100 1 100 1 1 100 1 1 1 1 1 1 1 1 1 1 1 16 15 10 12 16 15 10 100 12 1 1 1 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/invoke/LambdaForm 1 1 1030 7 1 100 1 10 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 10 7 12 1 1 9 12 1 10 12 1 1 100 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 9 12 1 9 12 1 10 12 1 1 9 7 12 1 1 1 9 7 12 1 1 9 12 1 1 10 12 1 9 12 1 10 100 12 1 1 1 10 12 1 1 100 1 10 12 1 1 9 7 12 1 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 7 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 8 1 10 12 1 10 12 1 10 10 12 1 8 1 8 1 9 12 1 9 12 1 1 10 12 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 7 1 10 12 1 10 100 12 1 1 1 9 12 1 10 12 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 10 12 1 9 12 1 7 1 10 12 1 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 10 12 1 1 10 12 1 1 7 1 8 1 10 12 1 1 10 12 1 10 12 1 1 10 8 1 10 12 1 1 8 1 8 1 8 1 10 12 1 10 12 1 10 12 1 1 10 100 12 1 1 1 10 7 12 1 1 1 10 12 1 1 9 12 1 1 8 1 10 100 12 1 1 1 10 7 12 1 1 10 12 1 10 12 1 1 10 12 1 1 9 12 1 8 10 12 1 1 100 1 10 12 1 1 10 12 1 9 7 12 1 1 9 100 12 1 1 1 8 1 10 100 12 1 1 10 12 1 1 100 1 100 1 10 10 12 1 1 10 12 1 1 8 1 8 1 100 1 8 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 1 9 100 12 1 1 10 12 1 8 1 8 1 10 12 1 10 12 1 1 8 1 8 1 8 1 100 1 8 1 100 1 8 1 100 1 8 1 10 12 1 8 1 9 10 100 12 1 1 1 10 12 1 9 12 1 1 10 12 1 10 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 8 1 100 10 12 1 10 12 1 9 12 1 1 10 7 12 1 1 8 1 8 1 100 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 8 1 8 1 8 1 10 12 1 8 1 10 12 1 8 1 8 1 8 1 8 1 8 1 10 12 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 9 12 1 1 8 1 10 12 1 1 9 12 1 9 12 1 1 10 12 1 1 9 12 1 1 9 12 1 10 12 1 1 9 12 1 1 7 1 10 7 12 1 1 1 9 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 9 12 1 10 12 1 9 12 1 10 12 1 10 12 1 8 1 10 12 1 9 12 1 1 7 1 10 7 12 1 1 1 100 1 10 12 1 9 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 9 7 12 1 1 10 12 1 1 10 12 1 10 12 1 9 12 1 9 9 12 1 7 9 12 1 1 10 12 1 1 9 12 1 10 12 1 10 7 1 9 1 1 1 1 3 1 3 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 100 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/invoke/LambdaForm DEFAULT_CUSTOMIZED Ljava/lang/invoke/MethodHandle; 
+staticfield java/lang/invoke/LambdaForm DEFAULT_KIND Ljava/lang/invoke/LambdaForm$Kind; java/lang/invoke/LambdaForm$Kind
+staticfield java/lang/invoke/LambdaForm COMPILE_THRESHOLD I 0
+staticfield java/lang/invoke/LambdaForm INTERNED_ARGUMENTS [[Ljava/lang/invoke/LambdaForm$Name; 5 [[Ljava/lang/invoke/LambdaForm$Name;
+staticfield java/lang/invoke/LambdaForm IMPL_NAMES Ljava/lang/invoke/MemberName$Factory; java/lang/invoke/MemberName$Factory
+staticfield java/lang/invoke/LambdaForm LF_identity [Ljava/lang/invoke/LambdaForm; 6 [Ljava/lang/invoke/LambdaForm;
+staticfield java/lang/invoke/LambdaForm NF_identity [Ljava/lang/invoke/LambdaForm$NamedFunction; 6 [Ljava/lang/invoke/LambdaForm$NamedFunction;
+staticfield java/lang/invoke/LambdaForm LF_constant [Ljava/lang/invoke/LambdaForm; 5 [Ljava/lang/invoke/LambdaForm;
+staticfield java/lang/invoke/LambdaForm createIdentityFormLock Ljava/lang/Object; java/lang/Object
+staticfield java/lang/invoke/LambdaForm DEBUG_NAME_COUNTERS Ljava/util/HashMap; 
+staticfield java/lang/invoke/LambdaForm DEBUG_NAMES Ljava/util/HashMap; 
+staticfield java/lang/invoke/LambdaForm TRACE_INTERPRETER Z 0
+staticfield java/lang/invoke/LambdaForm $assertionsDisabled Z 1
+instanceKlass jdk/internal/reflect/DirectMethodHandleAccessor
+ciInstanceKlass jdk/internal/reflect/MethodAccessorImpl 1 1 38 10 7 12 1 1 1 10 100 12 1 1 1 100 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/reflect/MethodAccessor 1 0 17 100 1 100 1 1 1 1 100 1 100 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/reflect/CallerSensitive 0 0 17 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/reflect/DirectConstructorHandleAccessor$NativeAccessor 1 1 44 10 7 12 1 1 1 9 7 12 1 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 100 1 1 1
+ciInstanceKlass jdk/internal/reflect/ConstructorAccessor 1 0 16 100 1 100 1 1 1 1 100 1 100 1 100 1 1 1
+instanceKlass jdk/internal/reflect/DirectConstructorHandleAccessor
+instanceKlass jdk/internal/reflect/DirectConstructorHandleAccessor$NativeAccessor
+ciInstanceKlass jdk/internal/reflect/ConstructorAccessorImpl 1 1 27 10 7 12 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 1 1
+ciInstanceKlass jdk/internal/reflect/ConstantPool 1 1 142 10 100 12 1 1 1 9 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 100 12 1 1 1 8 11 7 12 1 1 1 10 7 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/lang/invoke/VolatileCallSite
+instanceKlass java/lang/invoke/MutableCallSite
+instanceKlass java/lang/invoke/ConstantCallSite
+ciInstanceKlass java/lang/invoke/CallSite 1 1 297 10 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 100 1 10 12 1 1 10 12 1 1 9 100 12 1 1 1 10 100 12 1 1 10 12 1 1 100 1 100 1 10 10 100 12 1 1 1 10 12 1 1 8 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 10 100 12 1 1 10 12 1 1 9 12 1 9 100 12 1 1 1 8 1 10 7 12 1 1 1 10 12 1 1 100 1 10 12 1 1 9 12 1 8 1 100 1 10 12 1 10 12 1 100 1 8 1 10 10 12 1 10 12 1 1 100 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 9 12 1 1 8 10 12 1 1 9 12 1 1 100 1 10 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 7 12 1 1 1 100 1 8 1 10 10 12 10 12 1 1 100 1 100 1 100 1 8 1 10 12 1 10 7 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1
+staticfield java/lang/invoke/CallSite $assertionsDisabled Z 1
+ciInstanceKlass java/lang/invoke/ConstantCallSite 1 1 65 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 100 1 10 12 9 12 1 1 100 1 10 10 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1
+staticfield java/lang/invoke/ConstantCallSite UNSAFE Ljdk/internal/misc/Unsafe; jdk/internal/misc/Unsafe
+instanceKlass java/lang/invoke/DirectMethodHandle$StaticAccessor
+instanceKlass java/lang/invoke/DirectMethodHandle$Special
+instanceKlass java/lang/invoke/DirectMethodHandle$Interface
+instanceKlass java/lang/invoke/DirectMethodHandle$Accessor
+instanceKlass java/lang/invoke/DirectMethodHandle$Constructor
+ciInstanceKlass java/lang/invoke/DirectMethodHandle 1 1 929 7 1 100 1 7 1 7 1 10 7 12 1 1 1 10 7 12 1 1 1 100 1 10 12 1 10 12 1 1 10 7 12 1 1 10 12 1 1 10 12 1 10 12 1 7 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 9 7 12 1 1 1 100 1 10 9 12 1 1 9 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 10 12 1 1 8 1 10 12 1 1 7 1 10 12 1 7 1 10 10 12 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 1 7 1 10 12 1 10 12 1 7 1 10 12 1 10 12 1 1 10 12 1 1 10 12 8 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 9 7 12 1 1 1 7 1 10 12 1 10 7 12 1 1 1 10 12 1 10 12 1 1 9 12 1 1 7 1 10 8 1 10 12 1 1 10 12 1 1 8 1 10 12 1 10 12 1 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 10 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 8 1 9 7 12 1 1 1 8 1 9 12 1 9 12 1 8 1 9 12 1 9 12 1 8 1 9 12 1 9 12 1 8 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 1 9 12 1 1 7 1 10 12 1 1 100 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 7 1 10 12 1 1 10 12 1 10 12 1 1 7 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 9 12 1 1 10 7 1 9 12 1 10 12 1 7 1 7 1 7 1 10 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 10 7 12 1 1 10 12 10 12 1 7 1 10 12 1 10 12 1 1 8 1 9 12 1 9 12 1 10 12 1 1 9 12 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 9 12 1 9 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 9 12 1 1 10 12 1 1 9 7 12 1 1 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 100 1 10 12 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 10 12 1 10 12 1 8 1 8 1 8 1 9 12 1 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 1 9 7 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 8 1 8 1 8 1 8 1 10 12 1 1 9 12 1 1 10 12 1 10 100 12 1 1 1 8 9 12 1 1 10 12 1 1 8 1 8 8 9 12 1 8 1 8 8 8 8 8 1 8 10 12 1 7 1 10 12 1 8 1 8 1 10 12 1 10 12 1 10 12 1 9 12 1 10 12 1 1 7 1 1 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 3 1 3 1 3 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/invoke/DirectMethodHandle IMPL_NAMES Ljava/lang/invoke/MemberName$Factory; java/lang/invoke/MemberName$Factory
+staticfield java/lang/invoke/DirectMethodHandle FT_UNCHECKED_REF I 8
+staticfield java/lang/invoke/DirectMethodHandle FT_CHECKED_REF I 9
+staticfield java/lang/invoke/DirectMethodHandle ACCESSOR_FORMS [Ljava/lang/invoke/LambdaForm; 120 [Ljava/lang/invoke/LambdaForm;
+staticfield java/lang/invoke/DirectMethodHandle ALL_WRAPPERS [Lsun/invoke/util/Wrapper; 10 [Lsun/invoke/util/Wrapper;
+staticfield java/lang/invoke/DirectMethodHandle NFS [Ljava/lang/invoke/LambdaForm$NamedFunction; 12 [Ljava/lang/invoke/LambdaForm$NamedFunction;
+staticfield java/lang/invoke/DirectMethodHandle OBJ_OBJ_TYPE Ljava/lang/invoke/MethodType; java/lang/invoke/MethodType
+staticfield java/lang/invoke/DirectMethodHandle LONG_OBJ_TYPE Ljava/lang/invoke/MethodType; java/lang/invoke/MethodType
+staticfield java/lang/invoke/DirectMethodHandle $assertionsDisabled Z 1
+ciInstanceKlass java/lang/invoke/MutableCallSite 0 0 61 10 100 12 1 1 1 10 12 1 9 100 12 1 1 1 10 12 1 10 12 1 1 9 100 12 1 1 1 10 100 12 1 1 1 10 100 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1
+ciInstanceKlass java/lang/invoke/VolatileCallSite 0 0 37 10 100 12 1 1 1 10 12 1 10 100 12 1 1 1 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/lang/invoke/VarHandleInts$FieldInstanceReadOnly
+instanceKlass java/lang/invoke/VarHandleBooleans$FieldInstanceReadOnly
+instanceKlass java/lang/invoke/VarHandleReferences$Array
+instanceKlass java/lang/invoke/VarHandleReferences$FieldInstanceReadOnly
+instanceKlass java/lang/invoke/VarHandleByteArrayAsDoubles$ByteArrayViewVarHandle
+instanceKlass java/lang/invoke/VarHandleByteArrayAsLongs$ByteArrayViewVarHandle
+instanceKlass java/lang/invoke/VarHandleByteArrayAsFloats$ByteArrayViewVarHandle
+instanceKlass java/lang/invoke/VarHandleByteArrayAsInts$ByteArrayViewVarHandle
+instanceKlass java/lang/invoke/VarHandleByteArrayAsChars$ByteArrayViewVarHandle
+instanceKlass java/lang/invoke/VarHandleByteArrayAsShorts$ByteArrayViewVarHandle
+ciInstanceKlass java/lang/invoke/VarHandle 1 1 474 10 7 12 1 1 1 10 7 12 1 1 9 12 1 1 9 12 1 1 10 12 1 1 8 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 100 12 1 1 1 9 100 12 1 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 9 12 1 10 12 1 9 12 1 1 10 100 12 1 1 10 12 1 9 100 12 1 1 1 9 12 1 1 10 12 1 1 100 1 100 1 10 8 1 10 12 1 1 10 12 1 8 1 10 12 1 10 12 1 9 12 1 1 9 12 1 10 12 1 10 12 1 1 10 12 1 10 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 10 100 12 1 1 1 9 12 1 1 9 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 100 12 1 1 1 9 12 1 1 10 12 1 1 9 12 1 10 12 1 10 12 1 10 100 12 1 1 100 1 10 9 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 8 10 12 1 1 7 1 10 12 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 1 1 1 1 1 100 1 1 1 100 1 1 100 1 100 1 100 1 100 1 100 1 100 1 1 1 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1
+staticfield java/lang/invoke/VarHandle VFORM_OFFSET J 16
+staticfield java/lang/invoke/VarHandle $assertionsDisabled Z 1
+ciInstanceKlass java/lang/invoke/MemberName 1 1 730 7 1 7 1 100 1 9 12 1 1 10 7 12 1 1 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 9 7 12 1 1 10 12 1 100 1 100 1 10 12 1 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 9 12 1 1 8 1 10 100 12 1 1 1 7 1 10 10 12 1 1 100 1 100 1 10 12 1 9 12 1 1 100 1 8 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 8 1 8 1 10 12 1 8 1 9 12 1 1 3 10 12 1 10 12 1 10 12 1 10 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 7 1 8 10 12 1 1 10 12 1 1 8 1 9 100 1 8 9 100 1 10 12 1 1 10 12 1 10 12 1 8 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 100 1 10 12 1 1 10 12 1 8 1 10 12 1 10 12 1 8 1 10 12 1 1 10 12 1 1 100 1 10 12 1 1 10 12 8 1 8 1 100 1 10 12 1 10 100 12 1 1 1 100 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 10 10 12 1 10 12 1 10 12 1 3 10 12 1 3 10 12 1 3 3 3 3 3 3 10 12 1 3 9 12 1 10 12 1 1 3 10 12 1 10 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 10 10 12 1 10 12 1 1 10 12 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 100 1 10 10 10 12 100 1 10 10 10 12 1 1 10 12 1 1 10 10 12 1 8 10 7 1 10 12 1 10 7 1 10 12 1 10 12 1 10 12 1 10 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 100 1 10 12 1 1 100 1 8 1 10 7 1 10 12 1 10 12 10 12 1 1 10 12 1 10 12 1 8 1 8 1 8 1 8 1 10 12 1 10 12 1 10 7 12 1 1 1 8 1 8 1 10 12 1 8 1 10 10 10 12 1 10 12 1 8 1 8 1 10 10 12 1 8 1 10 100 12 1 1 1 8 1 100 1 10 12 1 10 12 1 1 10 12 1 8 1 8 1 8 1 8 1 100 1 10 8 1 8 1 8 1 8 1 10 12 1 100 1 100 1 100 1 10 100 1 10 100 1 10 100 12 1 1 1 9 7 12 1 1 1 100 1 100 1 1 1 1 1 1 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/invoke/MemberName $assertionsDisabled Z 1
+ciInstanceKlass java/lang/invoke/ResolvedMethodName 1 1 25 10 100 12 1 1 1 9 100 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/invoke/MethodHandleNatives 1 1 689 100 1 10 7 12 1 1 1 9 7 12 1 1 1 10 12 1 1 100 1 10 10 12 1 1 10 12 1 10 12 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 10 12 1 1 7 1 10 7 12 1 1 1 10 100 12 1 1 1 7 1 10 10 12 1 1 8 1 10 12 1 8 1 10 12 1 1 8 1 10 12 1 1 9 100 12 1 1 1 8 1 10 100 12 1 1 1 100 1 10 12 100 1 100 1 8 1 7 1 10 10 12 1 7 1 9 7 12 1 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 9 12 1 8 1 10 12 1 1 10 12 1 8 1 10 12 1 1 7 1 10 12 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 1 8 1 10 12 1 1 8 1 10 12 1 8 1 8 1 8 1 100 1 10 12 1 8 1 10 100 12 1 1 1 10 12 1 1 10 100 12 1 1 10 10 12 1 1 10 12 1 10 100 12 1 1 1 100 1 8 1 10 100 12 1 1 1 7 1 8 1 10 12 1 8 1 8 1 8 1 8 1 8 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 7 1 10 12 1 100 1 100 1 10 12 1 10 12 1 8 1 8 1 10 10 12 1 1 10 12 1 1 8 1 10 100 12 1 1 8 1 8 1 10 12 1 1 10 7 12 1 1 1 100 1 10 12 1 1 7 1 9 12 1 1 10 7 12 1 1 1 10 10 12 1 9 12 1 10 12 1 9 12 1 9 12 1 10 12 1 1 10 12 1 10 12 1 1 7 1 7 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 100 1 8 1 10 9 7 12 1 1 1 10 12 1 1 10 12 1 1 100 1 10 12 1 1 10 12 1 1 100 1 100 1 10 10 100 1 100 1 10 100 1 10 10 12 1 1 10 100 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 8 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 10 7 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1
+staticfield java/lang/invoke/MethodHandleNatives $assertionsDisabled Z 1
+ciInstanceKlass jdk/internal/foreign/abi/NativeEntryPoint 0 0 223 10 100 12 1 1 1 9 100 12 1 1 1 9 12 1 1 100 1 8 1 10 12 1 10 12 1 1 100 1 10 100 12 1 1 1 10 12 1 9 12 1 1 18 12 1 1 10 100 12 1 1 1 9 100 12 1 1 1 8 1 10 12 1 1 8 1 8 1 8 1 8 1 10 100 12 1 1 1 100 1 10 10 12 1 1 8 1 10 12 1 8 1 10 12 1 10 12 1 1 10 12 1 1 100 1 8 1 10 12 1 10 12 1 1 100 1 8 1 10 10 12 1 9 12 1 1 18 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 100 12 1 1 1 10 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 1 15 10 12 16 1 16 15 10 12 15 10 100 12 1 1 1 1 1 100 1 1 100 1 100 1 1
+ciInstanceKlass jdk/internal/foreign/abi/ABIDescriptor 0 0 55 10 100 12 1 1 1 9 100 12 1 1 1 9 12 1 1 9 12 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/foreign/abi/VMStorage 0 0 111 10 100 12 1 1 1 9 100 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 1 100 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 100 1 10 100 12 1 1 1 10 100 12 1 1 10 100 12 1 1 10 100 12 1 1 1 18 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 8 1 15 15 15 15 15 10 100 12 1 1 1 1 100 1 100 1 1
+ciInstanceKlass jdk/internal/foreign/abi/UpcallLinker$CallRegs 0 0 66 10 100 12 1 1 1 9 100 12 1 1 1 9 12 1 18 12 1 1 18 12 1 1 18 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 8 1 15 15 15 10 100 12 1 1 1 1 1 100 1 100 1 1
+instanceKlass java/lang/StackFrameInfo
+ciInstanceKlass java/lang/ClassFrameInfo 0 0 126 10 100 12 1 1 1 9 100 12 1 1 1 100 1 3 9 12 1 1 9 12 1 1 100 1 9 12 1 1 3 11 100 12 1 1 1 11 12 1 10 12 1 1 10 12 1 1 10 12 1 100 1 10 10 12 1 1 8 1 8 1 10 12 100 1 10 10 12 1 1 8 1 10 12 1 8 1 10 12 8 1 10 12 1 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1
+ciInstanceKlass java/lang/StackWalker$StackFrame 0 0 41 100 1 10 12 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1
+ciInstanceKlass java/lang/StackWalker 0 0 236 9 100 12 1 1 1 10 100 12 1 1 1 100 1 10 100 12 1 1 1 10 12 1 1 11 100 12 1 1 1 10 12 1 1 10 12 1 1 100 1 8 1 10 12 1 10 12 1 10 12 1 10 100 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 10 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 10 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 18 12 1 1 100 1 8 1 10 8 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 11 12 1 1 9 100 12 1 1 11 100 12 1 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 16 15 10 12 16 1 15 10 100 12 1 1 1 1 1 1 1 1 1 100 1 100 1 1
+instanceKlass java/lang/LiveStackFrameInfo
+ciInstanceKlass java/lang/StackFrameInfo 0 0 150 10 100 12 1 1 1 9 100 12 1 1 1 9 12 1 1 11 100 12 1 1 1 10 12 1 1 10 100 12 1 1 1 9 12 1 1 10 12 1 1 9 12 1 1 100 1 10 12 10 12 1 9 12 1 100 1 100 1 10 12 1 1 11 12 1 1 10 12 1 10 12 1 10 12 1 1 9 12 1 1 10 12 1 1 10 100 12 1 1 10 12 1 1 9 12 1 10 100 12 1 1 1 9 12 1 1 10 100 1 10 12 1 9 12 1 1 10 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/LiveStackFrameInfo 0 0 97 10 100 12 1 1 1 9 100 12 1 1 1 9 12 1 9 12 1 9 12 1 9 12 1 1 100 1 10 12 1 1 10 12 1 8 1 10 12 1 1 8 1 8 1 8 1 10 100 1 10 12 1 100 1 10 12 1 100 1 100 1 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1
+ciInstanceKlass java/lang/LiveStackFrame 0 0 112 100 1 10 100 12 1 1 1 11 100 12 1 1 1 11 12 1 9 100 12 1 1 1 10 100 12 1 1 1 10 100 12 1 1 1 11 12 1 10 12 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 100 1 8 1 1 12 10 1 1 1 8 1 1 1 8 1 1 1 8 1 1 1 8 1 1 8 1 1 1 8 1 1 8 1
+ciInstanceKlass java/lang/StackStreamFactory$AbstractStackWalker 1 0 364 100 1 100 1 3 10 100 12 1 1 1 10 100 12 1 1 10 100 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 9 12 1 10 100 12 1 1 1 10 12 1 1 10 100 12 1 1 9 12 1 1 9 12 1 1 10 12 1 1 9 12 1 1 10 100 12 1 1 1 10 12 1 1 9 12 1 1 9 100 12 1 1 1 100 1 10 8 1 10 12 1 1 10 12 1 8 1 10 12 1 1 10 100 12 1 1 1 100 1 8 1 10 12 1 8 1 10 12 10 100 12 1 1 9 12 1 1 8 1 5 0 8 1 8 1 9 12 1 1 10 12 1 1 18 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 9 100 12 1 1 1 10 12 1 1 9 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 8 1 10 12 1 10 12 1 10 12 1 10 12 1 1 8 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 9 12 1 8 1 10 12 1 8 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 8 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 100 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 15 10 100 12 1 1 1 1 1 1 1 1 100 1 100 1 1
+ciInstanceKlass jdk/internal/module/Modules 1 1 481 10 100 12 1 1 1 9 7 12 1 1 1 11 7 12 1 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 11 12 1 11 12 1 11 12 1 11 12 1 11 12 1 1 10 100 12 1 1 1 10 12 1 1 10 100 12 1 1 10 100 12 1 1 1 10 100 12 1 1 10 12 1 1 11 12 1 9 12 1 1 11 100 12 1 1 1 10 12 1 1 10 10 12 1 10 100 1 9 12 1 1 10 100 12 1 1 10 12 1 1 10 100 12 1 1 1 100 1 11 100 12 1 1 1 10 100 12 1 1 1 11 100 12 1 1 10 12 1 1 10 100 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 11 12 1 1 18 12 1 1 11 100 12 1 1 10 100 12 1 1 1 11 100 12 1 1 1 100 1 11 12 1 1 11 100 12 1 1 1 11 12 1 1 10 12 1 1 10 100 12 1 1 18 12 1 1 11 12 1 1 18 12 1 1 11 12 1 1 10 12 1 18 18 10 12 1 1 9 12 1 1 11 100 12 1 1 1 100 1 10 11 12 1 11 12 1 1 10 100 1 10 12 1 1 10 100 12 1 1 10 12 1 1 11 12 10 12 1 1 100 1 10 18 12 1 10 12 1 1 100 1 8 1 10 12 1 10 100 12 1 1 18 12 1 11 11 12 10 12 1 10 10 100 1 18 12 1 10 10 10 7 12 1 1 10 7 12 1 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 10 12 1 16 1 16 1 15 10 12 1 16 1 16 1 15 10 12 16 1 15 10 16 1 15 10 12 16 1 16 15 10 12 16 15 10 12 16 15 10 12 15 10 100 12 1 1 1 1 1 1 100 1 100 1 1
+staticfield jdk/internal/module/Modules JLA Ljdk/internal/access/JavaLangAccess; java/lang/System$1
+staticfield jdk/internal/module/Modules JLMA Ljdk/internal/access/JavaLangModuleAccess; java/lang/module/ModuleDescriptor$1
+staticfield jdk/internal/module/Modules $assertionsDisabled Z 1
+ciInstanceKlass jdk/internal/loader/ClassLoaders 1 1 185 10 100 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 100 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 1 7 1 11 100 12 1 1 1 100 1 11 12 1 1 11 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 100 1 100 1 10 7 12 1 1 1 9 12 1 1 8 1 10 7 12 1 1 1 10 12 1 1 7 1 10 12 1 10 12 1 1 7 1 10 12 1 1 10 12 1 1 10 12 1 7 1 10 12 10 12 1 8 1 10 7 12 1 1 8 1 8 1 10 12 1 7 1 10 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield jdk/internal/loader/ClassLoaders JLA Ljdk/internal/access/JavaLangAccess; java/lang/System$1
+staticfield jdk/internal/loader/ClassLoaders BOOT_LOADER Ljdk/internal/loader/ClassLoaders$BootClassLoader; jdk/internal/loader/ClassLoaders$BootClassLoader
+staticfield jdk/internal/loader/ClassLoaders PLATFORM_LOADER Ljdk/internal/loader/ClassLoaders$PlatformClassLoader; jdk/internal/loader/ClassLoaders$PlatformClassLoader
+staticfield jdk/internal/loader/ClassLoaders APP_LOADER Ljdk/internal/loader/ClassLoaders$AppClassLoader; jdk/internal/loader/ClassLoaders$AppClassLoader
+instanceKlass org/apache/maven/artifact/versioning/ComparableVersion$ListItem
+instanceKlass org/eclipse/sisu/bean/BeanScheduler$Pending
+ciInstanceKlass java/util/ArrayList 1 1 514 10 7 12 1 1 1 7 1 9 7 12 1 1 1 9 12 1 100 1 100 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 9 12 1 11 7 12 1 1 1 9 12 1 1 11 12 1 1 7 10 7 12 1 1 1 9 12 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 100 1 100 1 10 12 1 10 10 7 12 1 1 1 10 7 12 1 1 10 12 1 100 1 10 10 12 10 12 1 1 10 12 1 1 10 12 1 10 12 10 12 1 1 7 1 10 12 1 1 10 12 1 1 10 12 1 100 1 10 11 12 1 1 11 7 12 1 1 1 11 12 1 10 12 1 10 12 1 10 12 1 1 100 1 10 12 1 1 10 10 12 1 1 10 12 1 8 1 8 1 8 1 8 1 10 12 1 1 10 12 1 1 11 12 1 100 1 10 100 12 1 1 10 12 1 10 12 1 1 10 100 12 1 1 10 12 1 10 100 12 1 1 1 11 100 12 1 1 1 10 12 1 100 1 8 1 10 7 1 10 12 1 7 1 10 12 1 10 12 1 1 7 1 10 12 1 10 12 1 1 11 7 12 1 1 7 1 10 12 1 10 12 1 1 11 7 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 11 100 12 1 1 10 12 1 1 10 12 1 1 100 1 100 1 100 1 1 1 1 5 0 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1
+staticfield java/util/ArrayList EMPTY_ELEMENTDATA [Ljava/lang/Object; 0 [Ljava/lang/Object;
+staticfield java/util/ArrayList DEFAULTCAPACITY_EMPTY_ELEMENTDATA [Ljava/lang/Object; 0 [Ljava/lang/Object;
+ciInstanceKlass java/util/List 1 1 251 10 100 12 1 1 1 11 100 12 1 1 1 11 100 12 1 1 1 11 12 1 1 11 100 12 1 1 11 12 1 1 11 12 1 1 10 100 12 1 1 1 7 1 7 1 10 12 1 1 100 1 10 7 12 1 1 1 11 12 1 1 11 12 1 11 12 1 100 1 10 12 1 11 12 1 1 11 12 1 1 11 12 1 10 100 12 1 1 1 9 7 12 1 1 1 7 1 10 12 10 12 1 7 1 10 12 1 1 10 12 1 10 12 1 1 11 12 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 100 1 1 1
+ciInstanceKlass java/util/SequencedCollection 1 1 104 100 1 10 12 1 1 11 100 12 1 1 1 11 100 12 1 1 1 11 12 1 1 11 12 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 8 1 12 10 1 1 8 1 1 1 8 1 1 8 1 1 1 8 1 1 8 1 1 1 8 1 1 8 1 8 1 1 8 1 1 1 8 1 1 8 1 1 8 1
+ciInstanceKlass java/lang/Iterable 1 1 62 10 7 12 1 1 1 11 7 12 1 1 1 11 7 12 1 1 1 11 12 1 1 11 7 12 1 1 1 10 7 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/util/RandomAccess 1 0 7 100 1 100 1 1 1
+instanceKlass com/sun/tools/javac/util/List
+instanceKlass java/util/concurrent/ConcurrentLinkedDeque
+instanceKlass java/util/AbstractMap$2
+instanceKlass org/eclipse/sisu/inject/MildElements
+instanceKlass org/eclipse/sisu/inject/MildValues$1
+instanceKlass com/google/common/collect/AbstractMapBasedMultimap$WrappedCollection
+instanceKlass com/google/common/collect/Maps$Values
+instanceKlass com/google/common/collect/AbstractMultimap$Values
+instanceKlass java/util/TreeMap$Values
+instanceKlass com/google/common/collect/ImmutableCollection
+instanceKlass java/util/IdentityHashMap$Values
+instanceKlass java/util/HashMap$Values
+instanceKlass java/util/AbstractQueue
+instanceKlass java/util/LinkedHashMap$LinkedValues
+instanceKlass java/util/ArrayDeque
+instanceKlass java/util/AbstractSet
+instanceKlass java/util/ImmutableCollections$AbstractImmutableCollection
+instanceKlass java/util/AbstractList
+ciInstanceKlass java/util/AbstractCollection 1 1 160 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 11 7 12 1 1 1 11 12 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 10 7 12 1 1 1 7 1 10 100 12 1 1 1 10 100 12 1 1 1 100 1 10 11 12 1 11 7 1 10 12 1 10 12 1 10 7 12 1 1 1 11 8 1 7 1 10 10 12 1 1 8 1 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass org/apache/maven/project/MavenProject$LoggingList
+instanceKlass org/eclipse/aether/util/graph/visitor/Stack
+instanceKlass org/apache/maven/model/merge/ModelMerger$MergingList
+instanceKlass sun/security/jca/ProviderList$2
+instanceKlass com/google/common/collect/Lists$TransformingRandomAccessList
+instanceKlass java/util/Collections$SingletonList
+instanceKlass java/util/Vector
+instanceKlass java/util/Arrays$ArrayList
+instanceKlass java/util/AbstractSequentialList
+instanceKlass java/util/ArrayList$SubList
+instanceKlass java/util/Collections$EmptyList
+instanceKlass java/util/ArrayList
+ciInstanceKlass java/util/AbstractList 1 1 218 10 7 12 1 1 1 9 7 12 1 1 1 10 12 1 1 10 12 1 1 100 1 10 10 12 1 1 11 7 12 1 1 1 11 12 1 1 11 12 1 10 7 12 1 1 1 10 12 1 11 12 1 11 12 1 11 12 1 10 12 1 1 10 12 1 1 11 100 12 1 1 1 11 7 1 11 7 1 10 12 1 7 1 10 12 1 10 12 1 1 100 1 100 1 10 12 1 100 1 10 100 1 100 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 8 1 100 1 8 1 8 1 8 1 10 7 1 11 10 10 12 1 11 12 1 10 12 1 1 8 1 8 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/annotation/Annotation 1 0 17 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/classfile/impl/RawBytecodeHelper 1 1 579 7 1 7 1 10 12 1 1 10 7 12 1 1 9 12 1 1 9 12 1 1 10 12 1 1 9 12 1 1 10 7 12 1 1 1 9 12 1 9 12 1 3 9 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 9 12 1 1 10 7 12 1 1 1 9 12 1 1 9 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 9 12 1 10 12 1 1 10 12 1 5 0 5 0 5 0 7 1 10 10 12 1 1 10 12 1 1 1 1 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield jdk/internal/classfile/impl/RawBytecodeHelper IAE_FORMATTER Ljava/util/function/BiFunction; jdk/internal/util/Preconditions$4
+staticfield jdk/internal/classfile/impl/RawBytecodeHelper LENGTHS [B 256
+staticfield jdk/internal/classfile/impl/RawBytecodeHelper UNSAFE Ljdk/internal/misc/Unsafe; jdk/internal/misc/Unsafe
+ciInstanceKlass jdk/internal/classfile/impl/StackMapGenerator 1 1 942 7 1 100 1 7 1 7 1 10 7 12 1 1 1 11 7 12 1 1 1 9 7 12 1 1 1 11 7 12 1 1 1 11 7 12 1 1 1 11 12 1 1 11 12 1 1 9 12 1 1 10 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 10 12 1 1 10 7 12 1 1 9 12 1 1 9 12 1 9 12 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 9 12 1 1 9 7 1 11 7 12 1 1 10 12 1 9 12 1 7 1 10 7 12 1 1 1 10 12 1 9 12 1 1 10 12 1 1 9 12 10 12 1 9 12 1 7 1 10 12 1 9 12 1 1 10 12 1 9 12 1 9 12 1 9 12 1 10 12 1 1 10 12 1 1 9 12 1 10 7 12 1 1 9 12 1 9 12 1 11 12 1 10 12 1 10 12 1 10 12 1 10 12 1 9 12 1 9 12 1 9 12 1 10 12 1 1 11 12 1 1 100 1 10 12 1 1 11 100 12 1 1 1 10 12 1 10 12 1 10 12 1 1 100 1 10 100 12 1 1 10 12 1 11 12 1 10 12 1 1 9 12 1 10 12 1 11 12 1 1 8 1 10 12 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 11 12 1 1 11 100 12 1 1 11 12 1 11 12 1 11 12 1 11 12 1 1 10 12 1 11 12 1 1 11 12 100 1 10 100 12 1 1 1 10 12 1 11 7 12 1 1 1 10 12 1 1 9 12 1 10 12 1 1 10 12 10 12 1 8 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 10 12 1 9 12 1 9 12 1 9 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 8 1 8 1 10 100 12 1 1 1 10 100 12 1 1 1 11 12 1 1 11 100 1 11 9 12 9 12 1 9 12 1 9 12 10 12 1 1 9 12 10 7 12 1 1 11 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 100 1 10 11 12 1 10 12 1 8 1 10 12 1 1 10 12 1 10 12 1 8 1 8 1 8 1 8 1 7 1 11 12 1 10 7 12 1 1 1 10 12 1 1 100 1 8 1 10 12 100 1 11 12 1 1 11 11 7 1 10 12 1 10 12 1 1 11 12 1 8 11 12 1 1 9 12 1 10 12 1 1 9 12 9 12 10 12 1 8 1 11 7 12 1 1 8 1 9 12 1 1 10 12 1 100 1 8 1 11 12 1 1 11 12 1 1 18 12 1 1 11 100 12 1 1 1 8 1 10 100 12 1 1 1 11 12 1 1 10 12 1 10 12 1 10 100 12 1 1 1 18 12 1 1 10 12 1 1 100 1 10 12 1 10 10 12 1 8 1 10 12 8 1 9 12 1 1 10 100 12 1 1 1 10 12 1 1 100 10 100 12 1 1 1 10 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 1 1 1 3 1 3 1 3 1 3 1 3 1 1 3 1 3 1 1 3 1 3 1 3 1 3 1 3 1 1 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 11 12 1 16 1 16 15 10 12 1 1 16 15 10 100 12 1 1 1 1 1 1 1 100 1 1 1 100 1 100 1 1
+staticfield jdk/internal/classfile/impl/StackMapGenerator EMPTY_FRAME_ARRAY [Ljdk/internal/classfile/impl/StackMapGenerator$Frame; 0 [Ljdk/internal/classfile/impl/StackMapGenerator$Frame;
+staticfield jdk/internal/classfile/impl/StackMapGenerator ARRAY_FROM_BASIC_TYPE [Ljdk/internal/classfile/impl/StackMapGenerator$Type; 12 [Ljdk/internal/classfile/impl/StackMapGenerator$Type;
+ciInstanceKlass jdk/internal/classfile/impl/StackMapGenerator$Type 1 1 326 7 1 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 10 12 1 10 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 11 7 12 1 1 1 11 12 1 9 12 1 10 12 1 9 12 1 10 12 1 10 12 1 1 11 10 12 1 9 7 12 1 1 10 100 12 1 1 1 10 9 12 1 9 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 11 12 1 1 11 12 1 11 12 1 11 12 1 1 10 100 12 1 1 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 11 100 12 1 1 1 11 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 18 12 1 1 18 12 1 1 10 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 8 1 10 7 12 1 1 1 8 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 8 1 15 15 15 15 10 100 12 1 1 1 1 1 100 1 100 1 1
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type TOP_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type NULL_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type INTEGER_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type FLOAT_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type LONG_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type LONG2_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type DOUBLE_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type BOOLEAN_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type BYTE_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type CHAR_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type SHORT_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type DOUBLE2_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type UNITIALIZED_THIS_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type OBJECT_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type THROWABLE_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type INT_ARRAY_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type BOOLEAN_ARRAY_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type BYTE_ARRAY_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type CHAR_ARRAY_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type SHORT_ARRAY_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type LONG_ARRAY_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type DOUBLE_ARRAY_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type FLOAT_ARRAY_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type STRING_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type CLASS_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type METHOD_HANDLE_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type METHOD_TYPE Ljdk/internal/classfile/impl/StackMapGenerator$Type; jdk/internal/classfile/impl/StackMapGenerator$Type
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type CD_Cloneable Ljava/lang/constant/ClassDesc; jdk/internal/constant/ClassOrInterfaceDescImpl
+staticfield jdk/internal/classfile/impl/StackMapGenerator$Type CD_Serializable Ljava/lang/constant/ClassDesc; jdk/internal/constant/ClassOrInterfaceDescImpl
+ciInstanceKlass jdk/internal/classfile/impl/StackMapGenerator$Frame 1 1 353 7 1 10 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 10 7 12 1 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 100 1 10 8 1 8 1 10 12 1 1 10 12 1 8 1 8 1 10 7 12 1 1 1 11 100 12 1 1 1 10 12 1 8 1 10 12 1 1 9 7 12 1 1 1 9 7 12 1 1 1 9 12 1 10 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 11 7 12 1 1 1 9 12 1 9 12 1 9 12 1 10 12 1 1 10 12 1 10 12 1 1 8 1 10 12 1 1 10 12 1 1 9 12 1 9 12 1 10 12 1 1 10 12 1 1 100 10 12 1 10 12 1 1 10 7 12 1 1 1 8 10 7 1 9 12 1 9 12 1 11 11 7 12 1 1 1 11 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 8 1 8 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 100 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciMethod jdk/internal/classfile/impl/StackMapGenerator processBlock (Ljdk/internal/classfile/impl/RawBytecodeHelper;)Z 516 0 10507 0 -1
+ciMethodData jdk/internal/classfile/impl/StackMapGenerator processBlock (Ljdk/internal/classfile/impl/RawBytecodeHelper;)Z 0 0 orig 80 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 2032 0x10005 0xb2 0x1522a53f1e8 0x2757 0x0 0x0 0xe0005 0xb2 0x1522a53f1e8 0x2757 0x0 0x0 0x140002 0x2809 0x170007 0x24fd 0x90 0x30c 0x200007 0x30c 0x70 0x0 0x290007 0x0 0x50 0x0 0x310005 0x0 0x0 0x0 0x0 0x0 0x8000000600380008 0x196 0x0 0x3a70 0x0 0xcc0 0x5 0xcf0 0x0 0xd38 0x3e 0xd38 0x3e 0xd38 0x7 0xd38 0x5 0xd38 0x5 0xd38 0x5 0xd38 0x0 0xd80 0x0 0xd80 0x0 0xdc8 0x0 0xdc8 0x0 0xdc8 0x0 0xe10 0x0 0xe10 0x6 0xd38 0x0 0xd38 0xce 0xe58 0x0 0xed0 0x0 0xed0 0x15 0xf48 0x7 0x1068 0x0 0x1188 0x0 0x12a8 0x1fd 0x13c8 0x0 0xff0 0x1f 0xff0 0x1f 0xff0 0x1a 0xff0 0x0 0x1110 0x0 0x1110 0x2 0x1110 0x4 0x1110 0x0 0x1230 0x0 0x1230 0x0 0x1230 0x3 0x1230 0x0 0x1350 0x0 0x1350 0x0 0x1350 0x3 0x1350 0x6ae 0x1470 0x2cd 0x1470 0x12f 0x1470 0xcf 0x1470 0x0 0x14e8 0x0 0x1560 0x0 0x15d8 0x0 0x1650 0x10 0x16c8 0x0 0x14e8 0x0 0x14e8 0x0 0x14e8 0xd 0x17d8 0x6 0x18f8 0x0 0x1a18 0x0 0x1b38 0x16f 0x1c58 0x0 0x1880 0x0 0x1880 0x2 0x1880 0x1 0x1880 0x0 0x19a0 0x0 0x19a0 0x0 0x19a0 0x0 0x19a0 0x0 0x1ac0 0x0 0x1ac0 0x0 0x1ac0 0x0 0x1ac0 0x0 0x1be0 0x0 0x1be0 0x0 0x1be0 0x0 0x1be0 0xe2 0x1d00 0x0 0x1d00 0x3f 0x1d00 0x67 0x1d00 0x0 0x1dc0 0x0 0x1d78 0x0 0x1dc0 0x0 0x1d78 0x5 0x1dc0 0x0 0x1dc0 0x0 0x1dc0 0x0 0x1dc0 0x0 0x1e08 0x0 0x1e50 0x9b 0x1e98 0x0 0x1f40 0x0 0x2048 0x0 0x21b0 0x0 0x22e8 0x0 0x2480 0x0 0x2678 0x0 0x2750 0x0 0x2840 0x0 0x29a8 0x0 0x2a98 0x0 0x2750 0x0 0x2840 0x0 0x29a8 0x0 0x2a98 0x0 0x2750 0x0 0x2840 0x0 0x29a8 0x0 0x2a98 0x0 0x2750 0x0 0x2840 0x0 0x29a8 0x0 0x2a98 0x0 0x2750 0x0 0x2840 0x0 0x29a8 0x0 0x2a98 0x0 0x27c8 0x0 0x28b8 0x0 0x2a20 0x0 0x2b10 0x0 0x2750 0x0 0x2930 0x0 0x2750 0x0 0x2930 0x0 0x2750 0x0 0x2930 0x0 0x2750 0x0 0x2840 0x0 0x2750 0x0 0x2840 0x0 0x2750 0x0 0x2840 0x0 0x2b88 0x0 0x2c00 0x0 0x2cf0 0x0 0x2d68 0x0 0x2c78 0x0 0x2de0 0x0 0x2e58 0x0 0x2ed0 0x0 0x2f48 0x0 0x2fc0 0x0 0x3218 0x0 0x3038 0x0 0x30b0 0x0 0x3128 0x0 0x3128 0x0 0x3128 0x0 0x31a0 0x0 0x3218 0x0 0x3218 0x0 0x31a0 0x0 0x31a0 0x0 0x3338 0x0 0x3338 0x0 0x3338 0x0 0x3338 0x0 0x3338 0x0 0x3338 0x0 0x3290 0x0 0x3290 0x0 0x3290 0x0 0x3290 0x0 0x3290 0x0 0x3290 0x0 0x3290 0x0 0x3290 0x0 0x33e0 0x0 0x3a40 0x0 0x3a40 0x0 0x34d0 0x0 0x34d0 0x72 0x3560 0x9 0x3518 0x0 0x3560 0x0 0x3518 0x189 0x3560 0x2cc 0xcd8 0x4b 0x35a8 0xe9 0x35a8 0x2d4 0x35a8 0x16e 0x35a8 0x209 0x35f0 0x1bb 0x35f0 0x206 0x35f0 0x84 0x35f0 0x0 0x35f0 0x12 0x3690 0x0 0x36e8 0x3 0x37c0 0x0 0x27c8 0x0 0x3560 0x443 0x3838 0x0 0x27c8 0x0 0x1e08 0x0 0x1e08 0x0 0x3a70 0x0 0x38f0 0x0 0x3338 0x0 0x3338 0x0 0x3458 0x0 0x3a40 0x3700003 0x0 0x2e30 0x3750003 0x2cc 0x2e18 0x37f0005 0x0 0x1522a5432c0 0x5 0x0 0x0 0x3830003 0x5 0x2dd0 0x38d0005 0x0 0x1522a5432c0 0x98 0x0 0x0 0x3910003 0x98 0x2d88 0x39e0005 0x0 0x0 0x0 0x0 0x0 0x3a20003 0x0 0x2d40 0x3ac0005 0x0 0x0 0x0 0x0 0x0 0x3b00003 0x0 0x2cf8 0x3bd0005 0x0 0x0 0x0 0x0 0x0 0x3c10003 0x0 0x2cb0 0x3c60005 0x3 0x1522a53f1e8 0xcb 0x0 0x0 0x3c90005 0xce 0x0 0x0 0x0 0x0 0x3cc0003 0xce 0x2c38 0x3d10005 0x0 0x0 0x0 0x0 0x0 0x3d40005 0x0 0x0 0x0 0x0 0x0 0x3d70003 0x0 0x2bc0 0x3df0005 0x1 0x1522a53f1e8 0x14 0x0 0x0 0x3e20005 0x1 0x1522a5432c0 0x14 0x0 0x0 0x3e80005 0x1 0x1522a5432c0 0x14 0x0 0x0 0x3ec0003 0x15 0x2b18 0x3f70005 0x2 0x1522a5432c0 0x56 0x0 0x0 0x3fd0005 0x2 0x1522a5432c0 0x56 0x0 0x0 0x4010003 0x58 0x2aa0 0x4090005 0x0 0x1522a53f1e8 0x7 0x0 0x0 0x40e0005 0x0 0x1522a5432c0 0x7 0x0 0x0 0x4170005 0x0 0x1522a5432c0 0x7 0x0 0x0 0x41b0003 0x7 0x29f8 0x4280005 0x0 0x1522a5432c0 0x6 0x0 0x0 0x4310005 0x0 0x1522a5432c0 0x6 0x0 0x0 0x4350003 0x6 0x2980 0x43d0005 0x0 0x0 0x0 0x0 0x0 0x4400005 0x0 0x0 0x0 0x0 0x0 0x4460005 0x0 0x0 0x0 0x0 0x0 0x44a0003 0x0 0x28d8 0x4550005 0x0 0x1522a5432c0 0x3 0x0 0x0 0x45b0005 0x0 0x1522a5432c0 0x3 0x0 0x0 0x45f0003 0x3 0x2860 0x4670005 0x0 0x0 0x0 0x0 0x0 0x46c0005 0x0 0x0 0x0 0x0 0x0 0x4750005 0x0 0x0 0x0 0x0 0x0 0x4790003 0x0 0x27b8 0x4860005 0x0 0x1522a5432c0 0x3 0x0 0x0 0x48f0005 0x0 0x1522a5432c0 0x3 0x0 0x0 0x4930003 0x3 0x2740 0x49f0005 0x2 0x1522a53f1e8 0x1fb 0x0 0x0 0x4a20005 0x2 0x1522a5432c0 0x1fb 0x0 0x0 0x4a50005 0x2 0x1522a5432c0 0x1fb 0x0 0x0 0x4a90003 0x1fd 0x2698 0x4b80005 0x38 0x1522a5432c0 0xb41 0x0 0x0 0x4bb0005 0x38 0x1522a5432c0 0xb41 0x0 0x0 0x4bf0003 0xb79 0x2620 0x4c70005 0x0 0x0 0x0 0x0 0x0 0x4cd0005 0x0 0x0 0x0 0x0 0x0 0x4d10003 0x0 0x25a8 0x4d90005 0x0 0x0 0x0 0x0 0x0 0x4e20005 0x0 0x0 0x0 0x0 0x0 0x4e60003 0x0 0x2530 0x4ee0005 0x0 0x0 0x0 0x0 0x0 0x4f40005 0x0 0x0 0x0 0x0 0x0 0x4f80003 0x0 0x24b8 0x5000005 0x0 0x0 0x0 0x0 0x0 0x5090005 0x0 0x0 0x0 0x0 0x0 0x50d0003 0x0 0x2440 0x5190005 0x0 0x1522a5432c0 0x10 0x0 0x0 0x51c0005 0x0 0x1522a5432c0 0x10 0x0 0x0 0x5250007 0x10 0x38 0x0 0x52b0003 0x0 0x48 0x5300005 0x0 0x1522a543368 0x10 0x0 0x0 0x5330005 0x0 0x1522a5432c0 0x10 0x0 0x0 0x5370003 0x10 0x2330 0x53f0005 0x1 0x1522a5432c0 0xc 0x0 0x0 0x5430005 0x1 0x1522a53f1e8 0xc 0x0 0x0 0x5490005 0x1 0x1522a5432c0 0xc 0x0 0x0 0x54c0003 0xd 0x2288 0x5540005 0x1 0x1522a5432c0 0x2 0x0 0x0 0x55e0005 0x1 0x1522a5432c0 0x2 0x0 0x0 0x5610003 0x3 0x2210 0x5690005 0x0 0x1522a5432c0 0x6 0x0 0x0 0x56d0005 0x0 0x1522a53f1e8 0x6 0x0 0x0 0x5760005 0x0 0x1522a5432c0 0x6 0x0 0x0 0x5790003 0x6 0x2168 0x5810005 0x0 0x0 0x0 0x0 0x0 0x58e0005 0x0 0x0 0x0 0x0 0x0 0x5910003 0x0 0x20f0 0x5990005 0x0 0x0 0x0 0x0 0x0 0x59d0005 0x0 0x0 0x0 0x0 0x0 0x5a30005 0x0 0x0 0x0 0x0 0x0 0x5a60003 0x0 0x2048 0x5ae0005 0x0 0x0 0x0 0x0 0x0 0x5b80005 0x0 0x0 0x0 0x0 0x0 0x5bb0003 0x0 0x1fd0 0x5c30005 0x0 0x0 0x0 0x0 0x0 0x5c70005 0x0 0x0 0x0 0x0 0x0 0x5d00005 0x0 0x0 0x0 0x0 0x0 0x5d30003 0x0 0x1f28 0x5db0005 0x0 0x0 0x0 0x0 0x0 0x5e80005 0x0 0x0 0x0 0x0 0x0 0x5eb0003 0x0 0x1eb0 0x5f30005 0x2 0x1522a53f1e8 0x16d 0x0 0x0 0x5fa0005 0x2 0x1522a5432c0 0x16d 0x0 0x0 0x5fd0005 0x2 0x1522a5432c0 0x16d 0x0 0x0 0x6000003 0x16f 0x1e08 0x60f0005 0x2 0x1522a5432c0 0x186 0x0 0x0 0x6120005 0x2 0x1522a5432c0 0x186 0x0 0x0 0x6150003 0x188 0x1d90 0x61d0005 0x0 0x0 0x0 0x0 0x0 0x6210003 0x0 0x1d48 0x6290005 0x0 0x1522a5432c0 0x5 0x0 0x0 0x62d0003 0x5 0x1d00 0x6350005 0x0 0x0 0x0 0x0 0x0 0x6390003 0x0 0x1cb8 0x6410005 0x0 0x0 0x0 0x0 0x0 0x6450003 0x0 0x1c70 0x6500005 0x0 0x1522a5432c0 0x9b 0x0 0x0 0x6560005 0x0 0x1522a5432c0 0x9b 0x0 0x0 0x65b0005 0x0 0x1522a5432c0 0x9b 0x0 0x0 0x65f0003 0x9b 0x1bc8 0x6660005 0x0 0x0 0x0 0x0 0x0 0x66f0005 0x0 0x0 0x0 0x0 0x0 0x67a0005 0x0 0x0 0x0 0x0 0x0 0x67f0005 0x0 0x0 0x0 0x0 0x0 0x6840005 0x0 0x0 0x0 0x0 0x0 0x6880003 0x0 0x1ac0 0x68f0005 0x0 0x0 0x0 0x0 0x0 0x6980005 0x0 0x0 0x0 0x0 0x0 0x6a10005 0x0 0x0 0x0 0x0 0x0 0x6ac0005 0x0 0x0 0x0 0x0 0x0 0x6b10005 0x0 0x0 0x0 0x0 0x0 0x6b60005 0x0 0x0 0x0 0x0 0x0 0x6bb0005 0x0 0x0 0x0 0x0 0x0 0x6bf0003 0x0 0x1958 0x6c60005 0x0 0x0 0x0 0x0 0x0 0x6cf0005 0x0 0x0 0x0 0x0 0x0 0x6da0005 0x0 0x0 0x0 0x0 0x0 0x6df0005 0x0 0x0 0x0 0x0 0x0 0x6e40005 0x0 0x0 0x0 0x0 0x0 0x6e90005 0x0 0x0 0x0 0x0 0x0 0x6ed0003 0x0 0x1820 0x6f40005 0x0 0x0 0x0 0x0 0x0 0x6fd0005 0x0 0x0 0x0 0x0 0x0 0x7060005 0x0 0x0 0x0 0x0 0x0 0x7110005 0x0 0x0 0x0 0x0 0x0 0x7160005 0x0 0x0 0x0 0x0 0x0 0x71b0005 0x0 0x0 0x0 0x0 0x0 0x7200005 0x0 0x0 0x0 0x0 0x0 0x7250005 0x0 0x0 0x0 0x0 0x0 0x7290003 0x0 0x1688 0x7300005 0x0 0x0 0x0 0x0 0x0 0x7390005 0x0 0x0 0x0 0x0 0x0 0x7420005 0x0 0x0 0x0 0x0 0x0 0x74b0005 0x0 0x0 0x0 0x0 0x0 0x7560005 0x0 0x0 0x0 0x0 0x0 0x75b0005 0x0 0x0 0x0 0x0 0x0 0x7600005 0x0 0x0 0x0 0x0 0x0 0x7650005 0x0 0x0 0x0 0x0 0x0 0x76a0005 0x0 0x0 0x0 0x0 0x0 0x76f0005 0x0 0x0 0x0 0x0 0x0 0x7730003 0x0 0x1490 0x77a0005 0x0 0x0 0x0 0x0 0x0 0x7830005 0x0 0x0 0x0 0x0 0x0 0x78e0005 0x0 0x0 0x0 0x0 0x0 0x7980005 0x0 0x0 0x0 0x0 0x0 0x79c0003 0x0 0x13b8 0x7a40005 0x0 0x0 0x0 0x0 0x0 0x7aa0005 0x0 0x0 0x0 0x0 0x0 0x7ae0003 0x0 0x1340 0x7b60005 0x0 0x0 0x0 0x0 0x0 0x7bc0005 0x0 0x0 0x0 0x0 0x0 0x7c00003 0x0 0x12c8 0x7c80005 0x0 0x0 0x0 0x0 0x0 0x7d10005 0x0 0x0 0x0 0x0 0x0 0x7d50003 0x0 0x1250 0x7dd0005 0x0 0x0 0x0 0x0 0x0 0x7e60005 0x0 0x0 0x0 0x0 0x0 0x7ea0003 0x0 0x11d8 0x7f20005 0x0 0x0 0x0 0x0 0x0 0x7fb0005 0x0 0x0 0x0 0x0 0x0 0x7ff0003 0x0 0x1160 0x8070005 0x0 0x0 0x0 0x0 0x0 0x80d0005 0x0 0x0 0x0 0x0 0x0 0x8110003 0x0 0x10e8 0x8190005 0x0 0x0 0x0 0x0 0x0 0x81f0005 0x0 0x0 0x0 0x0 0x0 0x8230003 0x0 0x1070 0x82b0005 0x0 0x0 0x0 0x0 0x0 0x8340005 0x0 0x0 0x0 0x0 0x0 0x8380003 0x0 0xff8 0x8400005 0x0 0x0 0x0 0x0 0x0 0x8490005 0x0 0x0 0x0 0x0 0x0 0x84d0003 0x0 0xf80 0x8550005 0x0 0x0 0x0 0x0 0x0 0x8580005 0x0 0x0 0x0 0x0 0x0 0x85c0003 0x0 0xf08 0x8640005 0x0 0x0 0x0 0x0 0x0 0x86d0005 0x0 0x0 0x0 0x0 0x0 0x8710003 0x0 0xe90 0x8790005 0x0 0x0 0x0 0x0 0x0 0x87f0005 0x0 0x0 0x0 0x0 0x0 0x8830003 0x0 0xe18 0x88b0005 0x0 0x0 0x0 0x0 0x0 0x8910005 0x0 0x0 0x0 0x0 0x0 0x8950003 0x0 0xda0 0x89d0005 0x0 0x0 0x0 0x0 0x0 0x8a60005 0x0 0x0 0x0 0x0 0x0 0x8aa0003 0x0 0xd28 0x8b20005 0x0 0x0 0x0 0x0 0x0 0x8b80005 0x0 0x0 0x0 0x0 0x0 0x8bc0003 0x0 0xcb0 0x8c40005 0x0 0x0 0x0 0x0 0x0 0x8cd0005 0x0 0x0 0x0 0x0 0x0 0x8d10003 0x0 0xc38 0x8d90005 0x0 0x0 0x0 0x0 0x0 0x8df0005 0x0 0x0 0x0 0x0 0x0 0x8e30003 0x0 0xbc0 0x8eb0005 0x0 0x0 0x0 0x0 0x0 0x8f40005 0x0 0x0 0x0 0x0 0x0 0x8f80003 0x0 0xb48 0x9000005 0x0 0x0 0x0 0x0 0x0 0x9090005 0x0 0x0 0x0 0x0 0x0 0x90d0003 0x0 0xad0 0x9150005 0x0 0x0 0x0 0x0 0x0 0x91e0005 0x0 0x8 0x0 0x0 0x0 0x9220003 0x0 0xa58 0x92a0005 0x0 0x0 0x0 0x0 0x0 0x9300005 0x0 0x0 0x0 0x0 0x0 0x9340003 0x0 0x9e0 0x93c0005 0x0 0x0 0x0 0x0 0x0 0x9420005 0x0 0x0 0x0 0x0 0x0 0x9460003 0x0 0x968 0x94e0005 0x0 0x0 0x0 0x0 0x0 0x9540005 0x0 0x0 0x0 0x0 0x0 0x9580003 0x0 0x8f0 0x9600005 0x0 0x0 0x0 0x0 0x0 0x9660005 0x0 0x0 0x0 0x0 0x0 0x96a0003 0x0 0x878 0x9730005 0x0 0x0 0x0 0x0 0x0 0x9770005 0x0 0x0 0x0 0x0 0x0 0x97a0005 0x0 0x0 0x0 0x0 0x0 0x97d0003 0x0 0x7d0 0x9860005 0x0 0x0 0x0 0x0 0x0 0x98a0005 0x0 0x0 0x0 0x0 0x0 0x98d0005 0x0 0x0 0x0 0x0 0x0 0x9900003 0x0 0x728 0x9990005 0x0 0x0 0x0 0x0 0x0 0x99c0005 0x0 0x0 0x0 0x0 0x0 0x9a10003 0x0 0x6b0 0x9aa0005 0x0 0x0 0x0 0x0 0x0 0x9ad0005 0x0 0x0 0x0 0x0 0x0 0x9b20003 0x0 0x638 0x9b70005 0x0 0x0 0x0 0x0 0x0 0x9bc0003 0x0 0x5f0 0x9c40005 0x0 0x8c36c990 0x9 0x0 0x0 0x9ca0003 0x9 0x5a8 0x9d20005 0xe 0x8c36c990 0x1ed 0x0 0x0 0x9d80003 0x1fb 0x560 0x9dd0005 0x576 0x0 0x0 0x0 0x0 0x9e00003 0x576 0x518 0x9eb0007 0x64e 0x58 0x0 0x9f40007 0x0 0x38 0x0 0x9f80003 0x0 0x18 0x9fe0005 0x64e 0x0 0x0 0x0 0x0 0xa030003 0x64e 0x478 0xa0c0002 0x12 0xa0f0005 0x0 0x8c36c990 0x12 0x0 0x0 0xa130003 0x12 0x420 0xa1b0005 0x0 0x0 0x0 0x0 0x0 0xa200005 0x0 0x0 0x0 0x0 0x0 0xa230005 0x0 0x0 0x0 0x0 0x0 0xa260005 0x0 0x0 0x0 0x0 0x0 0xa2a0003 0x0 0x348 0xa2f0005 0x0 0x8c362bf8 0x3 0x0 0x0 0xa320005 0x3 0x0 0x0 0x0 0x0 0xa350003 0x3 0x2d0 0xa3d0005 0xd 0x8c36c990 0x436 0x0 0x0 0xa410005 0xd 0x8c362bf8 0x436 0x0 0x0 0xa480002 0x443 0xa4b0005 0xd 0x8c36c990 0x436 0x0 0x0 0xa4f0003 0x443 0x218 0xa530005 0x0 0x0 0x0 0x0 0x0 0xa5a0002 0x0 0xa610005 0x0 0x0 0x0 0x0 0x0 0xa660005 0x0 0x0 0x0 0x0 0x0 0xa720007 0x0 0x68 0x0 0xa790005 0x0 0x0 0x0 0x0 0x0 0xa800003 0x0 0xffffffffffffffb0 0xa890005 0x0 0x0 0x0 0x0 0x0 0xa8d0003 0x0 0xc8 0xa940005 0x0 0x0 0x0 0x0 0x0 0xaa30002 0x0 0xaa60004 0x0 0x0 0x0 0x0 0x0 0xaa70002 0x0 0xaaa0005 0x0 0x0 0x0 0x0 0x0 0xab00007 0x0 0x90 0x280a 0xab90007 0x280a 0x70 0x0 0xac20007 0x0 0x50 0x0 0xaca0005 0x0 0x0 0x0 0x0 0x0 0x7ffb9cfce3a0 0x7ffb9cfd2658 0x1522a543078 0xffffffffffffffff 0x100000001 0x0 0x20800000067 0x15200000040 0x10000000001 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x4000 0x0 0x0 0x900000009 0x1520000000f 0x1522a542f28 0x1522a542fc8 0x1522a542dd8 0x7ffb9cfcef40 0x15235732310 0x1522a542d10 0x0 0x0 0x152339de8f0 0x7ffb9d05ece8 0x1522a543100 0x1522a543898 0x100000001 0x400000001 0x14800000068 0x40 0xffffff0000000000 0x1522a543108 0x7ffb9d00f7e0 0x1522a543198 0x1522a543878 0x400000002 0x400000002 0x1a00000069 0x15200000080 0x15200044300 0x1522a543158 0xbf800000358637bd 0x1522a543190 0x1522a5431b8 0x1522a5431c8 0x1522a543178 0x7ffb9cfbf298 0x1521f81a5d8 0x1520000001f 0x7ffb9cfcb520 0x152262a6cc8 0x1522a5431d0 0x0 0x0 0x7ffb9cfd1cc8 0x15200000003 0x7ffb9cfcfcd0 0x7ffb9d00b888 0x1522a543238 0x1522a543270 0x400000002 0x400000001 0x20000006a 0x15200000000 0x30000 0x1522a543218 0x1522a543230 0x1522a543258 0x1522a543260 0x7ffb9cfcfcd0 0x0 0x152371719f8 0x0 0x0 0x7ffb9cfce3a0 0x7ffb9cfcbbe8 0x15200000000 0x1522a543108 0x15235732760 0x152310d85f0 0x0 0x7ffb9d05ece8 0x1522a5432d0 0x1522a5436a0 0x100000001 0x400000001 0x1480000006b oops 53 2 jdk/internal/classfile/impl/RawBytecodeHelper 8 jdk/internal/classfile/impl/RawBytecodeHelper 448 jdk/internal/classfile/impl/StackMapGenerator$Frame 457 jdk/internal/classfile/impl/StackMapGenerator$Frame 493 jdk/internal/classfile/impl/RawBytecodeHelper 523 jdk/internal/classfile/impl/RawBytecodeHelper 529 jdk/internal/classfile/impl/StackMapGenerator$Frame 535 jdk/internal/classfile/impl/StackMapGenerator$Frame 544 jdk/internal/classfile/impl/StackMapGenerator$Frame 550 jdk/internal/classfile/impl/StackMapGenerator$Frame 559 jdk/internal/classfile/impl/RawBytecodeHelper 565 jdk/internal/classfile/impl/StackMapGenerator$Frame 571 jdk/internal/classfile/impl/StackMapGenerator$Frame 580 jdk/internal/classfile/impl/StackMapGenerator$Frame 586 jdk/internal/classfile/impl/StackMapGenerator$Frame 616 jdk/internal/classfile/impl/StackMapGenerator$Frame 622 jdk/internal/classfile/impl/StackMapGenerator$Frame 652 jdk/internal/classfile/impl/StackMapGenerator$Frame 658 jdk/internal/classfile/impl/StackMapGenerator$Frame 667 jdk/internal/classfile/impl/RawBytecodeHelper 673 jdk/internal/classfile/impl/StackMapGenerator$Frame 679 jdk/internal/classfile/impl/StackMapGenerator$Frame 688 jdk/internal/classfile/impl/StackMapGenerator$Frame 694 jdk/internal/classfile/impl/StackMapGenerator$Frame 763 jdk/internal/classfile/impl/StackMapGenerator$Frame 769 jdk/internal/classfile/impl/StackMapGenerator$Frame 782 jdk/internal/classfile/impl/StackMapGenerator$Type 788 jdk/internal/classfile/impl/StackMapGenerator$Frame 797 jdk/internal/classfile/impl/StackMapGenerator$Frame 803 jdk/internal/classfile/impl/RawBytecodeHelper 809 jdk/internal/classfile/impl/StackMapGenerator$Frame 818 jdk/internal/classfile/impl/StackMapGenerator$Frame 824 jdk/internal/classfile/impl/StackMapGenerator$Frame 833 jdk/internal/classfile/impl/StackMapGenerator$Frame 839 jdk/internal/classfile/impl/RawBytecodeHelper 845 jdk/internal/classfile/impl/StackMapGenerator$Frame 941 jdk/internal/classfile/impl/RawBytecodeHelper 947 jdk/internal/classfile/impl/StackMapGenerator$Frame 953 jdk/internal/classfile/impl/StackMapGenerator$Frame 962 jdk/internal/classfile/impl/StackMapGenerator$Frame 968 jdk/internal/classfile/impl/StackMapGenerator$Frame 986 jdk/internal/classfile/impl/StackMapGenerator$Frame 1013 jdk/internal/classfile/impl/StackMapGenerator$Frame 1019 jdk/internal/classfile/impl/StackMapGenerator$Frame 1025 jdk/internal/classfile/impl/StackMapGenerator$Frame

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/AssertionEvidenceReporter.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/AssertionEvidenceReporter.java
@@ -58,6 +58,32 @@ public final class AssertionEvidenceReporter {
         }
     }
 
+    /**
+     * Renders a domain-consistent evidence card for an accessibility (aria snapshot) validation.
+     *
+     * <p>Accessibility validations report their outcome as a pass/fail boolean, which
+     * {@link #renderCard} deliberately skips because a "true vs false" flag carries no comparable
+     * content. This overload instead takes the expected/actual aria-snapshot YAML so the card can
+     * show the same bounded, redacted line diff assertion cards use — a summary line plus a deep
+     * attachment, rather than a full YAML dump in the step name (issue #3532 E).
+     *
+     * @param passed       true when the aria snapshot matched its baseline
+     * @param expectedYaml the baseline aria-snapshot YAML (may be null/blank on first capture)
+     * @param actualYaml   the captured aria-snapshot YAML
+     * @return a complete self-contained HTML document string, or "" when there is nothing
+     * meaningful to show (both sides are null/blank)
+     */
+    public static String renderAccessibilityCard(boolean passed, Object expectedYaml, Object actualYaml) {
+        if (isBlank(expectedYaml) && isBlank(actualYaml)) {
+            return "";
+        }
+        try {
+            return render("Accessibility", passed, expectedYaml, actualYaml);
+        } catch (RuntimeException e) {
+            return renderFallback("Accessibility", passed, expectedYaml, actualYaml);
+        }
+    }
+
     private static String render(String categoryLabel, boolean passed, Object expected, Object actual) {
         Capped expectedText = cap(safeRedact(rawValue(expected)));
         Capped actualText = cap(safeRedact(rawValue(actual)));

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java
@@ -757,6 +757,10 @@ public class ValidationsHelper {
         AtomicBoolean actual = new AtomicBoolean(false);
         AtomicBoolean validationState = new AtomicBoolean(false);
         AtomicReference<List<List<Object>>> attachmentsRef = new AtomicReference<>(new ArrayList<>());
+        // Hoisted out of the fluentWait lambda so the reporting block can render a domain-consistent
+        // accessibility evidence card from the aria YAML (issue #3532 E).
+        AtomicReference<String> baselineYamlRef = new AtomicReference<>("");
+        AtomicReference<String> actualYamlRef = new AtomicReference<>("");
         String baselinePath = resolveAriaSnapshotPath(snapshotFileName);
 
         try {
@@ -785,6 +789,8 @@ public class ValidationsHelper {
                 }
                 attachments.add(List.of("Expected Aria Snapshot", snapshotFileName + ".yaml", baselineYaml));
                 attachments.add(List.of("Actual Aria Snapshot", snapshotFileName + "_actual.yaml", actualYaml));
+                baselineYamlRef.set(baselineYaml);
+                actualYamlRef.set(actualYaml);
                 attachmentsRef.set(attachments);
 
                 expected.set(validationType.getValue());
@@ -803,7 +809,15 @@ public class ValidationsHelper {
         parameters.put("Should match", String.valueOf(expected.get()));
         parameters.put("Actual value", String.valueOf(actual.get()));
         updateAllureParameters(parameters);
-        reportValidationState(validationState.get(), expected, actual, driver, locator, attachmentsRef.get());
+        // Prepend a domain-consistent accessibility evidence card (summary + aria-YAML diff) so the
+        // aria-snapshot outcome reads like an assertion card instead of a raw YAML dump (#3532 E).
+        List<List<Object>> ariaAttachments = attachmentsRef.get();
+        String accessibilityCard = AssertionEvidenceReporter.renderAccessibilityCard(
+                validationState.get(), baselineYamlRef.get(), actualYamlRef.get());
+        if (!accessibilityCard.isBlank()) {
+            ariaAttachments.add(0, Arrays.asList("Accessibility evidence", "accessibility-evidence.html", accessibilityCard));
+        }
+        reportValidationState(validationState.get(), expected, actual, driver, locator, ariaAttachments);
     }
 
     private static String resolveAriaSnapshotPath(String snapshotFileName) {

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/AssertionEvidenceReporterTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/AssertionEvidenceReporterTest.java
@@ -133,6 +133,54 @@ public class AssertionEvidenceReporterTest {
         Assert.assertNotNull(AssertionEvidenceReporter.renderCard("Assert", true, new Object(), new Object()));
     }
 
+    @Test(description = "Accessibility card renders a domain-labelled aria-YAML diff even though the outcome is a boolean (#3532 E)")
+    public void accessibilityCardRendersAriaYamlDiff() {
+        String baselineYaml = "- textbox \"Email\"\n- button \"Submit\"";
+        String actualYaml = "- textbox \"Email\"\n- button \"Send\"";
+
+        String html = AssertionEvidenceReporter.renderAccessibilityCard(false, baselineYaml, actualYaml);
+
+        // Domain-consistent header, real FAILED status, and a rendered line diff — not a raw dump.
+        Assert.assertTrue(html.contains("Accessibility"), html);
+        Assert.assertTrue(html.contains("FAILED"), html);
+        Assert.assertTrue(html.contains(">Text<"), html);
+        Assert.assertTrue(html.contains("aer-diff"), html);
+        Assert.assertTrue(html.contains("Submit"), html);
+        Assert.assertTrue(html.contains("Send"), html);
+        Assert.assertTrue(html.contains("<!doctype html>"), html);
+    }
+
+    @Test(description = "Accessibility card still redacts secrets and skips rendering when there is no aria YAML (#3532 E)")
+    public void accessibilityCardRedactsAndSkipsBlank() {
+        // Secrets embedded in an aria label must be redacted like any other card content.
+        String withSecret = AssertionEvidenceReporter.renderAccessibilityCard(false,
+                "- textbox \"password=hunter2\"", "- textbox \"password=different\"");
+        Assert.assertFalse(withSecret.contains("hunter2"), withSecret);
+        Assert.assertTrue(withSecret.contains("********"), withSecret);
+
+        // Nothing to diff -> no card (mirrors renderCard's blank contract).
+        Assert.assertEquals(AssertionEvidenceReporter.renderAccessibilityCard(true, null, ""), "");
+        Assert.assertEquals(AssertionEvidenceReporter.renderAccessibilityCard(true, "  ", null), "");
+    }
+
+    @Test(description = "Writes a sample accessibility aria-diff card to the scratch directory for manual visual review (#3532 E)")
+    public void writeSampleAccessibilityCardForManualReview() throws Exception {
+        String baselineYaml = "- heading \"Checkout\" [level=1]\n- textbox \"Email\"\n- textbox \"Card number\"\n- button \"Pay now\"";
+        String actualYaml = "- heading \"Checkout\" [level=2]\n- textbox \"Email\"\n- button \"Pay now\"";
+
+        String html = AssertionEvidenceReporter.renderAccessibilityCard(false, baselineYaml, actualYaml);
+
+        Path outputFile = Path.of(System.getProperty("shaft.accessibilityEvidence.sampleOutput",
+                "C:\\Users\\Mohab\\AppData\\Local\\Temp\\claude\\C--Users-Mohab-IdeaProjects-SHAFT-ENGINE\\a0966654-661a-46d0-8c81-75ecf6570c15\\scratchpad\\accessibility-card-sample.html"));
+        Files.createDirectories(outputFile.getParent());
+        Files.writeString(outputFile, html, StandardCharsets.UTF_8);
+
+        Assert.assertTrue(Files.exists(outputFile));
+        Assert.assertTrue(html.contains("Accessibility"), html);
+        Assert.assertTrue(html.contains("FAILED"), html);
+        Assert.assertTrue(html.contains("aer-diff"), html);
+    }
+
     @Test(description = "Writes a sample failed-JSON-diff card to the scratch directory for manual visual review")
     public void writeSampleFailedJsonDiffCardForManualReview() throws Exception {
         String expectedJson = "{\n  \"orderId\": 1042,\n  \"status\": \"CONFIRMED\",\n  \"items\": [\"sku-1\", \"sku-2\"],\n  \"customer\": {\n    \"name\": \"Ann Example\",\n    \"token\": \"abcdef123456\"\n  }\n}";


### PR DESCRIPTION
## What & why

Accessibility (aria snapshot) validations report their outcome as a **pass/fail boolean**, which `AssertionEvidenceReporter.renderCard` deliberately skips (a "true vs false" flag carries no comparable content). So the aria outcome had **no domain-consistent evidence card** — only raw YAML attachments and a boolean in the step. This is the accessibility half of **#3532 (E)**.

## Change

- **`AssertionEvidenceReporter.renderAccessibilityCard(passed, expectedYaml, actualYaml)`** — a new overload that bypasses the boolean-flag skip and renders the expected/actual aria-snapshot YAML through the **existing bounded, redacted, styled line-diff card**, under an "Accessibility" domain header.
- **`ValidationsHelper.validateElementAriaSnapshot`** — the baseline/actual YAML (previously local to the `fluentWait` lambda) are hoisted into refs so the reporting block **prepends the card as an "Accessibility evidence" deep-attachment** — a summary + diff instead of a full YAML dump in the step name.

Reuses the proven assertion-card CSS/layout — **no new visual system**.

## Verification

- `mvn -pl shaft-engine test -Dtest=AssertionEvidenceReporterTest` — pass, incl. **3 new tests** (aria-YAML diff renders "Accessibility"/FAILED/Text/diff; secret redaction; blank-skip contract).
- `mvn -pl shaft-engine test -Dtest=WebDriverElementValidationsBuilderAriaSnapshotUnitTest,AriaSnapshotHelperUnitTest` — **0 failures/errors** (the reporting path I touched stays green).
- Rendered a self-contained sample card (`accessibility-card-sample.html`); structural inspection confirms the "Accessibility" header, FAILED status chip, Text shape badge, and added/removed diff lines. _(Headless-Chrome PNG capture didn't write files in this sandbox; the card reuses the already-reviewed assertion-card styling, and the HTML sample is directly openable.)_

## Scope

Advances #3532 (E). The **visual image-diff card** half of (E) — image baseline/actual/diff reference metadata rather than a text diff — remains for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)