### PR TITLE
feat: domain-consistent visual evidence card (#3532 E)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/AssertionEvidenceReporter.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/AssertionEvidenceReporter.java
@@ -84,6 +84,60 @@ public final class AssertionEvidenceReporter {
         }
     }
 
+    /**
+     * Renders a domain-consistent evidence card for a visual (screenshot) validation.
+     *
+     * <p>Visual validations also report their outcome as a pass/fail boolean, so {@link #renderCard}
+     * skips them; the pixel diff is attached separately as a native Allure image-diff viewer. This
+     * overload surfaces the numeric comparison metadata — diff pixels and diff ratio against their
+     * budgets — as a compact summary card, so the report answers "how far off was it?" in text
+     * without a full dump, and points at the attached image diff (issue #3532 E).
+     *
+     * @param passed        true when the screenshot matched its baseline within budget
+     * @param diffPixels    number of differing pixels reported by the comparison
+     * @param maxDiffPixels the pixel-count budget, or {@code null} when none was configured
+     * @param diffRatio     the differing-pixel ratio reported by the comparison
+     * @param maxDiffRatio  the ratio budget, or {@code null} when none was configured
+     * @return a complete self-contained HTML document string
+     */
+    public static String renderVisualCard(boolean passed, long diffPixels, Integer maxDiffPixels,
+                                          double diffRatio, Double maxDiffRatio) {
+        try {
+            return document("Visual", passed, "Image",
+                    visualMetadataSection(diffPixels, maxDiffPixels, diffRatio, maxDiffRatio));
+        } catch (RuntimeException e) {
+            return "";
+        }
+    }
+
+    private static String visualMetadataSection(long diffPixels, Integer maxDiffPixels, double diffRatio,
+                                                Double maxDiffRatio) {
+        String pixels = diffPixels + (maxDiffPixels == null ? "" : " (budget " + maxDiffPixels + ")");
+        String ratio = formatRatio(diffRatio) + (maxDiffRatio == null ? "" : " (budget " + formatRatio(maxDiffRatio) + ")");
+        return "<div class=\"aer-scalar\">"
+                + "<div class=\"aer-scalar-row\"><span class=\"aer-scalar-label\">Diff pixels</span>"
+                + "<span class=\"aer-scalar-value\">" + escapeHtml(pixels) + "</span></div>"
+                + "<div class=\"aer-scalar-row\"><span class=\"aer-scalar-label\">Diff ratio</span>"
+                + "<span class=\"aer-scalar-value\">" + escapeHtml(ratio) + "</span></div>"
+                + "</div>"
+                + "<p class=\"aer-visual-note\">The full pixel-level image diff is attached separately as the image-diff viewer.</p>";
+    }
+
+    /**
+     * Formats a diff ratio compactly: up to six significant digits, trailing zeros trimmed, so a
+     * ratio like {@code 0.0125000} reads as {@code 0.0125} and an exact match reads as {@code 0}.
+     */
+    private static String formatRatio(double ratio) {
+        if (ratio == 0d) {
+            return "0";
+        }
+        String formatted = String.format("%.6f", ratio);
+        if (formatted.contains(".")) {
+            formatted = formatted.replaceAll("0+$", "").replaceAll("\\.$", "");
+        }
+        return formatted;
+    }
+
     private static String render(String categoryLabel, boolean passed, Object expected, Object actual) {
         Capped expectedText = cap(safeRedact(rawValue(expected)));
         Capped actualText = cap(safeRedact(rawValue(actual)));

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java
@@ -46,6 +46,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchema;
@@ -671,6 +672,10 @@ public class ValidationsHelper {
         AtomicBoolean validationState = new AtomicBoolean(false);
         List<List<Object>> attachments = new ArrayList<>();
         AtomicBoolean visualComparisonAttached = new AtomicBoolean(false);
+        // Hoisted out of the fluentWait lambda so the reporting block can render a domain-consistent
+        // visual evidence card from the numeric diff metadata (issue #3532 E).
+        AtomicLong diffPixelsRef = new AtomicLong(0);
+        AtomicReference<Double> diffRatioRef = new AtomicReference<>(0.0);
         String pageBaselineKey = pageLevel ? "page_" + ReportManagerHelper.getCallingMethodFullName() : null;
 
         try {
@@ -710,6 +715,8 @@ public class ValidationsHelper {
                 if (baselineImage != null) {
                     visualComparisonAttached.set(attachVisualComparison(baselineImage, actualScreenshot, comparisonResult.diffImage()));
                 }
+                diffPixelsRef.set(comparisonResult.diffPixels());
+                diffRatioRef.set(comparisonResult.diffRatio());
 
                 expected.set(validationType.getValue());
                 actual.set(comparisonResult.matched());
@@ -726,6 +733,15 @@ public class ValidationsHelper {
         parameters.put("Should match", String.valueOf(expected.get()));
         parameters.put("Actual value", String.valueOf(actual.get()));
         updateAllureParameters(parameters);
+        // Prepend a domain-consistent visual evidence card (diff pixels/ratio vs budget + pointer to
+        // the attached image diff) whenever an actual baseline comparison happened (#3532 E).
+        if (visualComparisonAttached.get()) {
+            String visualCard = AssertionEvidenceReporter.renderVisualCard(validationState.get(),
+                    diffPixelsRef.get(), maxDiffPixels, diffRatioRef.get(), maxDiffPixelRatio);
+            if (!visualCard.isBlank()) {
+                attachments.add(0, Arrays.asList("Visual evidence", "visual-evidence.html", visualCard));
+            }
+        }
         // force take page screenshot, (rather than element highlighted screenshot)
         reportValidationState(validationState.get(), expected, actual, driver, pageLevel ? null : locator, attachments, visualComparisonAttached.get());
     }

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/AssertionEvidenceReporterTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/AssertionEvidenceReporterTest.java
@@ -181,6 +181,46 @@ public class AssertionEvidenceReporterTest {
         Assert.assertTrue(html.contains("aer-diff"), html);
     }
 
+    @Test(description = "Visual card surfaces diff pixels/ratio against their budgets as a summary (#3532 E)")
+    public void visualCardRendersDiffMetadata() {
+        String html = AssertionEvidenceReporter.renderVisualCard(false, 1234L, 100, 0.0125d, 0.01d);
+
+        Assert.assertTrue(html.contains("Visual"), html);
+        Assert.assertTrue(html.contains("FAILED"), html);
+        Assert.assertTrue(html.contains(">Image<"), html);
+        Assert.assertTrue(html.contains("Diff pixels"), html);
+        Assert.assertTrue(html.contains("1234"), html);
+        Assert.assertTrue(html.contains("budget 100"), html);
+        Assert.assertTrue(html.contains("Diff ratio"), html);
+        Assert.assertTrue(html.contains("0.0125"), html);
+        Assert.assertTrue(html.contains("image diff is attached"), html);
+        Assert.assertTrue(html.contains("<!doctype html>"), html);
+    }
+
+    @Test(description = "Visual card omits budget text and shows PASSED when no budgets are configured (#3532 E)")
+    public void visualCardHandlesNullBudgetsAndPass() {
+        String html = AssertionEvidenceReporter.renderVisualCard(true, 0L, null, 0.0d, null);
+
+        Assert.assertTrue(html.contains("PASSED"), html);
+        // No budgets configured -> no "budget" annotation, and an exact match reads as 0.
+        Assert.assertFalse(html.contains("budget"), html);
+        Assert.assertTrue(html.contains(">0<") || html.contains(">0 <") || html.contains("\">0</span>"), html);
+    }
+
+    @Test(description = "Writes a sample visual diff-metadata card to the scratch directory for manual review (#3532 E)")
+    public void writeSampleVisualCardForManualReview() throws Exception {
+        String html = AssertionEvidenceReporter.renderVisualCard(false, 4821L, 500, 0.0231d, 0.01d);
+
+        Path outputFile = Path.of(System.getProperty("shaft.visualEvidence.sampleOutput",
+                "C:\\Users\\Mohab\\AppData\\Local\\Temp\\claude\\C--Users-Mohab-IdeaProjects-SHAFT-ENGINE\\a0966654-661a-46d0-8c81-75ecf6570c15\\scratchpad\\visual-card-sample.html"));
+        Files.createDirectories(outputFile.getParent());
+        Files.writeString(outputFile, html, StandardCharsets.UTF_8);
+
+        Assert.assertTrue(Files.exists(outputFile));
+        Assert.assertTrue(html.contains("Visual"), html);
+        Assert.assertTrue(html.contains("4821"), html);
+    }
+
     @Test(description = "Writes a sample failed-JSON-diff card to the scratch directory for manual visual review")
     public void writeSampleFailedJsonDiffCardForManualReview() throws Exception {
         String expectedJson = "{\n  \"orderId\": 1042,\n  \"status\": \"CONFIRMED\",\n  \"items\": [\"sku-1\", \"sku-2\"],\n  \"customer\": {\n    \"name\": \"Ann Example\",\n    \"token\": \"abcdef123456\"\n  }\n}";


### PR DESCRIPTION
## What & why

Visual (screenshot) validations report a pass/fail boolean, so `AssertionEvidenceReporter.renderCard` skips them; the pixel diff is attached only as the native Allure image-diff viewer, and the numeric "**how far off was it?**" metadata never surfaced as text. This completes the **visual half of #3532 (E)** (the accessibility half landed in #3563).

## Change

- **`AssertionEvidenceReporter.renderVisualCard(passed, diffPixels, maxDiffPixels, diffRatio, maxDiffRatio)`** — a compact summary card showing diff pixels and diff ratio **against their configured budgets**, reusing the shared card layout, with a pointer to the separately-attached image diff. Null budgets render without a budget annotation; an exact match reads as `0`.
- **`ValidationsHelper.validateMatchesScreenshot`** — the comparison's `diffPixels`/`diffRatio` (previously local to the `fluentWait` lambda) are hoisted into refs so the reporting block **prepends a "Visual evidence" deep-attachment** whenever an actual baseline comparison happened (`visualComparisonAttached`).

Reuses the proven card CSS/layout — no new visual system.

## Verification

- `mvn -pl shaft-engine test -Dtest=AssertionEvidenceReporterTest` — **20/20 pass** (3 new: metadata rendering, null-budget handling, sample writer).
- `mvn -pl shaft-engine test -Dtest=VisualValidationsBuilderUnitTest` — **5/5 pass** (the touched path stays green).
- Rendered sample card verified structurally: "Visual" header, FAILED chip, "Image" shape, `Diff pixels: 4821 (budget 500)`, `Diff ratio: 0.0231`, and the image-diff pointer.

## Scope

Completes #3532 (E) visual + accessibility evidence cards. Remaining under E: the vague "API-body-specific card affordances on top of the existing JSON branch" — the JSON diff branch already renders API response bodies; I'll assess whether that's a real gap or already-covered next.

_(Ran locally with `-Dallure.automaticallyOpen=false` so the report generates for debugging but doesn't auto-open.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)