### PR TITLE
feat: XML API-body evidence cards (#3532 E)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/AssertionEvidenceReporter.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/AssertionEvidenceReporter.java
@@ -6,10 +6,21 @@ import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.SerializationFeature;
 import tools.jackson.databind.json.JsonMapper;
 
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.ByteArrayInputStream;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import org.w3c.dom.Document;
 
 /**
  * Renders a self-contained HTML "assertion evidence" card for a single {@code Assert}/{@code Verify}
@@ -152,6 +163,15 @@ public final class AssertionEvidenceReporter {
             shape = "JSON";
             String prettyExpected = prettyPrint(expectedJson, expectedText.text());
             String prettyActual = prettyPrint(actualJson, actualText.text());
+            body = diffSection(prettyExpected, prettyActual) + rawSection(expectedText, actualText);
+        } else if (bothParseAsXml(expectedText.text(), actualText.text())) {
+            // API response bodies are just as commonly XML (SOAP / XML REST) as JSON; when both
+            // sides are well-formed XML, pretty-print and diff them structurally rather than letting
+            // them fall through to the flat text branch, so the card gives API-body-specific
+            // affordances on top of the JSON branch (issue #3532 E).
+            shape = "XML";
+            String prettyExpected = prettyPrintXml(expectedText.text());
+            String prettyActual = prettyPrintXml(actualText.text());
             body = diffSection(prettyExpected, prettyActual) + rawSection(expectedText, actualText);
         } else if (isTextShape(expectedText.text(), actualText.text())) {
             shape = "Text";
@@ -351,6 +371,67 @@ public final class AssertionEvidenceReporter {
             return JSON_MAPPER.writeValueAsString(node);
         } catch (RuntimeException e) {
             return fallback;
+        }
+    }
+
+    /**
+     * True only when both sides are well-formed XML documents (not JSON — JSON is checked first).
+     * A leading {@code <} gate keeps the common non-XML case from paying for a parser attempt.
+     */
+    private static boolean bothParseAsXml(String expected, String actual) {
+        return parseXml(expected) != null && parseXml(actual) != null;
+    }
+
+    /**
+     * Parses a string into an XML {@link Document} with a hardened, non-validating parser (DTDs and
+     * external entities disabled to prevent XXE / entity-expansion against untrusted API bodies),
+     * or {@code null} when the value is blank or not well-formed XML.
+     */
+    private static Document parseXml(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        if (trimmed.isEmpty() || trimmed.charAt(0) != '<') {
+            return null;
+        }
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setExpandEntityReferences(false);
+            factory.setNamespaceAware(true);
+            return factory.newDocumentBuilder()
+                    .parse(new ByteArrayInputStream(trimmed.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Pretty-prints XML with a hardened transformer; falls back to the original text on any failure
+     * so evidence rendering can never break because of an awkward document.
+     */
+    private static String prettyPrintXml(String value) {
+        Document document = parseXml(value);
+        if (document == null) {
+            return value;
+        }
+        try {
+            document.normalizeDocument();
+            TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+            Transformer transformer = transformerFactory.newTransformer();
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+            transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+            StringWriter writer = new StringWriter();
+            transformer.transform(new DOMSource(document), new StreamResult(writer));
+            return writer.toString().trim();
+        } catch (Exception e) {
+            return value;
         }
     }
 

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/AssertionEvidenceReporterTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/AssertionEvidenceReporterTest.java
@@ -44,6 +44,36 @@ public class AssertionEvidenceReporterTest {
         Assert.assertTrue(html.contains("Bob"), html);
     }
 
+    @Test(description = "Both sides parsing as XML should surface an XML data-shape badge, pretty-printed content, and a diff region (#3532 E)")
+    public void xmlBothSidesShouldShowXmlShapeAndDiff() {
+        String expectedXml = "<user><id>1</id><name>Ann</name></user>";
+        String actualXml = "<user><id>1</id><name>Bob</name></user>";
+
+        String html = AssertionEvidenceReporter.renderCard("Assert", false, expectedXml, actualXml);
+
+        Assert.assertTrue(html.contains(">XML<"), html);
+        // Transformer indents each element onto its own line, so the diff can isolate the changed leaf.
+        Assert.assertTrue(html.contains("aer-diff"), html);
+        Assert.assertTrue(html.contains("Ann"), html);
+        Assert.assertTrue(html.contains("Bob"), html);
+        // The unchanged <id> element must survive as a same-line, proving structural (not scalar) rendering.
+        Assert.assertTrue(html.contains("&lt;id&gt;1&lt;/id&gt;"), html);
+    }
+
+    @Test(description = "XML bodies with a DOCTYPE/external entity must never expand the entity (XXE hardening) (#3532 E)")
+    public void xmlWithDoctypeMustNotExpandEntities() {
+        String malicious = "<!DOCTYPE foo [<!ENTITY xxe \"SECRET_EXPANDED\">]><foo>&xxe;</foo>";
+
+        String html = AssertionEvidenceReporter.renderCard("Assert", false, malicious, "<foo>bar</foo>");
+
+        // disallow-doctype-decl makes the DOCTYPE side fail to parse, so it degrades to text — never XML.
+        Assert.assertFalse(html.contains(">XML<"), html);
+        // The entity reference must survive as a literal, unexpanded token — never resolved into
+        // the <foo> element's content. Seeing the escaped "&xxe;" (not an expanded value) proves it.
+        Assert.assertTrue(html.contains("&amp;xxe;"), html);
+        Assert.assertFalse(html.contains("<foo>SECRET_EXPANDED</foo>"), html);
+    }
+
     @Test(description = "Multi-line text values should surface a Text data-shape badge and a diff region")
     public void multiLineTextShouldShowTextShapeAndDiff() {
         String expectedText = "line one\nline two\nline three";


### PR DESCRIPTION
## What

Completes the final checkbox of issue #3532 workstream E: **API-body-specific card affordances on top of the existing JSON branch.**

The assertion-evidence card already pretty-prints and structurally diffs JSON expected/actual pairs. API validations, however, just as commonly compare **XML** response bodies (SOAP / XML REST), which previously fell through to the flat text diff — no structural pretty-print, harder to spot the changed leaf.

This adds an **XML** data-shape branch to `AssertionEvidenceReporter.render(...)`: when both sides parse as well-formed XML, they are pretty-printed and diffed under an `XML` badge, mirroring the JSON branch exactly.

## Safety

API bodies can be untrusted, so XML parsing is hardened against XXE / entity-expansion:
- `disallow-doctype-decl` = true (DOCTYPE-bearing payloads are rejected → degrade to text)
- `FEATURE_SECURE_PROCESSING` = true, `setExpandEntityReferences(false)`
- Transformer: no external DTD / stylesheet access
- Any parse/transform failure degrades safely to the existing text branch — evidence rendering can never break test execution.

No new dependencies — JDK `javax.xml` only.

## Tests

`AssertionEvidenceReporterTest` (22 total, all green, JDK 25 headless):
- `xmlBothSidesShouldShowXmlShapeAndDiff` — XML badge, pretty-printed structural diff, changed leaf isolated.
- `xmlWithDoctypeMustNotExpandEntities` — a DOCTYPE/ENTITY payload never renders as XML and the `&xxe;` reference is never expanded into element content.

Closes #3532.

🤖 Generated with [Claude Code](https://claude.com/claude-code)