### PR TITLE
feat: HEAD/OPTIONS support across SHAFT.API + capture codegen (#3530 A3)

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiTestRenderer.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiTestRenderer.java
@@ -480,6 +480,8 @@ public final class ApiTestRenderer {
             case "PUT" -> "put";
             case "PATCH" -> "patch";
             case "DELETE" -> "delete";
+            case "HEAD" -> "head";
+            case "OPTIONS" -> "options";
             default -> null;
         };
     }

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/api/ApiTestRendererTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/api/ApiTestRendererTest.java
@@ -121,15 +121,34 @@ class ApiTestRendererTest {
 
     @Test
     void unsupportedHttpMethodIsSkippedNotRenderedAsABrokenCall() throws Exception {
-        ApiTransaction headRequest = transaction("tx-1", "HEAD", "https://api.example.test/probe",
+        // TRACE has no SHAFT.API builder, so it must be skipped rather than rendered as a broken call.
+        ApiTransaction traceRequest = transaction("tx-1", "TRACE", "https://api.example.test/probe",
                 Map.of(), "", 200, Map.of(), "");
 
         RenderedApiTest rendered = ApiTestRenderer.render(
-                "tests.generated", "RecordedApiTest_Unsupported", List.of(headRequest),
+                "tests.generated", "RecordedApiTest_Unsupported", List.of(traceRequest),
                 ApiCodegenStyle.SCENARIO, ApiValidationDepth.STATUS);
 
         assertCompiles(rendered.source(), "RecordedApiTest_Unsupported");
         assertEquals(List.of("tx-1"), rendered.skippedTransactionIds());
+    }
+
+    @Test
+    void headAndOptionsMethodsRenderCompilingBuilderCallsNotSkips() throws Exception {
+        ApiTransaction headRequest = transaction("tx-1", "HEAD", "https://api.example.test/probe",
+                Map.of(), "", 200, Map.of(), "");
+        ApiTransaction optionsRequest = transaction("tx-2", "OPTIONS", "https://api.example.test/orders",
+                Map.of(), "", 204, Map.of("Allow", "GET,POST"), "");
+
+        RenderedApiTest rendered = ApiTestRenderer.render(
+                "tests.generated", "RecordedApiTest_HeadOptions", List.of(headRequest, optionsRequest),
+                ApiCodegenStyle.SCENARIO, ApiValidationDepth.STATUS);
+
+        assertCompiles(rendered.source(), "RecordedApiTest_HeadOptions");
+        // Both verbs now map to real SHAFT.API builders, so nothing is skipped.
+        assertTrue(rendered.skippedTransactionIds().isEmpty(), rendered.skippedTransactionIds().toString());
+        assertTrue(rendered.source().contains(".head(\"/probe\")"), rendered.source());
+        assertTrue(rendered.source().contains(".options(\"/orders\")"), rendered.source());
     }
 
     @Test

--- a/shaft-engine/src/main/java/com/shaft/api/RestActions.java
+++ b/shaft-engine/src/main/java/com/shaft/api/RestActions.java
@@ -1548,6 +1548,12 @@ public class RestActions {
             case DELETE -> {
                 return given().filter(allureFilter).spec(specs).when().delete(request).andReturn();
             }
+            case HEAD -> {
+                return given().filter(allureFilter).spec(specs).when().head(request).andReturn();
+            }
+            case OPTIONS -> {
+                return given().filter(allureFilter).spec(specs).when().options(request).andReturn();
+            }
             default -> {
             }
         }
@@ -1750,7 +1756,7 @@ public class RestActions {
 
     /** HTTP methods supported for building API requests. */
     public enum RequestType {
-        POST, GET, PATCH, DELETE, PUT
+        POST, GET, PATCH, DELETE, PUT, HEAD, OPTIONS
     }
 
     /**

--- a/shaft-engine/src/main/java/com/shaft/driver/SHAFT.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/SHAFT.java
@@ -882,6 +882,29 @@ public class SHAFT {
         }
 
         /**
+         * Builds a HEAD request for the specified service endpoint. HEAD returns
+         * the same headers/status as GET without a response body, so it is useful
+         * for existence, cache, and header assertions.
+         *
+         * @param serviceName the endpoint path (appended to the base URI)
+         * @return a {@link RequestBuilder} for further request configuration
+         */
+        public RequestBuilder head(String serviceName) {
+            return session.buildNewRequest(serviceName, RestActions.RequestType.HEAD);
+        }
+
+        /**
+         * Builds an OPTIONS request for the specified service endpoint, typically
+         * used to inspect the allowed methods (CORS/preflight) an endpoint exposes.
+         *
+         * @param serviceName the endpoint path (appended to the base URI)
+         * @return a {@link RequestBuilder} for further request configuration
+         */
+        public RequestBuilder options(String serviceName) {
+            return session.buildNewRequest(serviceName, RestActions.RequestType.OPTIONS);
+        }
+
+        /**
          * Builds a GraphQL POST request with a JSON body containing only the
          * supplied query.
          *


### PR DESCRIPTION
## What

Advances issue #3530 workstream **A3 — RestAssured / SHAFT.API fidelity**, first checkbox: *"Extra HTTP verbs beyond GET/POST/PUT/PATCH/DELETE (currently skipped with a comment)."*

The API recorder previously skipped any captured transaction whose HTTP verb wasn't one of the five builders, emitting a `// SHAFT.API has no builder for this HTTP method` comment instead of code. This adds first-class **HEAD** and **OPTIONS** support end to end:

- **`RestActions.RequestType`** gains `HEAD`, `OPTIONS`; `sendRequest(...)` dispatches them to RestAssured's `when().head()` / `when().options()`.
- **`SHAFT.API`** facade gains `head(serviceName)` / `options(serviceName)` convenience builders, mirroring the existing verb methods (additive — no public API breakage).
- **`ApiTestRenderer.requestMethodFor`** maps `HEAD`→`head`, `OPTIONS`→`options`, so the recorder now generates compiling builder calls for those transactions instead of skipping them.

HEAD is the natural verb for existence/cache/header checks; OPTIONS for CORS/preflight `Allow`-header inspection — the two standard "extra" REST verbs. TRACE/CONNECT remain unsupported (no clean RestAssured builder), and still degrade to the existing skip comment.

## Tests

`ApiTestRendererTest` — **14/14 green** (JDK 25 headless; compiles generated source against the real SHAFT.API facade):
- `unsupportedHttpMethodIsSkippedNotRenderedAsABrokenCall` — retargeted to `TRACE` (still genuinely unsupported → skipped).
- `headAndOptionsMethodsRenderCompilingBuilderCallsNotSkips` — new; proves HEAD/OPTIONS render compiling `.head("/probe")` / `.options("/orders")` calls and are no longer in `skippedTransactionIds`.

## Docs

`api.head(...)` / `api.options(...)` added to the Request Builder reference — companion docs PR on `shafthq.github.io`.

Part of #3530 (does not close it — A2, A3's remaining body/auth items, and negative-case templates remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)