### PR TITLE
feat: negative-case error-shape assertion templates (#3530)

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiTestRenderer.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiTestRenderer.java
@@ -401,12 +401,19 @@ public final class ApiTestRenderer {
             case STATUS_HEADERS -> renderHeaderAssertions(source, apiField, transaction);
             case SCHEMA -> renderSchemaAssertion(source, artifacts, className, apiField, transaction);
             case FULL_BODY -> renderFullBodyAssertion(source, artifacts, className, apiField, transaction, leaves);
-            case BUSINESS -> renderBusinessAssertions(source, apiField, leaves);
+            case BUSINESS -> renderBusinessAssertions(source, apiField, transaction, leaves);
             default -> throw new IllegalArgumentException("Unsupported validation depth: " + depth);
         }
     }
 
-    private static void renderBusinessAssertions(StringBuilder source, String apiField, List<ResponseLeaf> leaves) {
+    private static void renderBusinessAssertions(
+            StringBuilder source, String apiField, ApiTransaction transaction, List<ResponseLeaf> leaves) {
+        // A 4xx/5xx response is a negative case: render a dedicated error-shape template that pins
+        // the error code and message fields first, rather than the happy-path stable-field pinning.
+        if (transaction.statusCode() >= 400) {
+            renderErrorShapeAssertions(source, apiField, transaction, leaves);
+            return;
+        }
         for (ResponseLeaf leaf : leaves) {
             // Pin only business-meaningful fields: stable values a human would check. Volatile,
             // correlated (chained), and sensitive leaves are deliberately skipped so the assertion
@@ -414,12 +421,74 @@ public final class ApiTestRenderer {
             if (leaf.classification() != LeafClassification.STABLE || leaf.value().isBlank()) {
                 continue;
             }
-            line(source, "        SHAFT.Validations.assertThat()");
-            line(source, "                .object(" + apiField + ".getResponseJSONValue(\""
-                    + escape(leaf.jsonPath()) + "\"))");
-            line(source, "                .isEqualTo(\"" + escape(leaf.value()) + "\")");
-            line(source, "                .perform();");
+            pinStableLeaf(source, apiField, leaf);
         }
+    }
+
+    /**
+     * JSON property names that typically carry a machine-readable error code in a 4xx/5xx body
+     * (e.g. {@code {"code":"NOT_FOUND"}}, {@code {"error":"invalid_grant"}}).
+     */
+    private static final Set<String> ERROR_CODE_KEYS = Set.of(
+            "code", "error", "errorcode", "error_code", "status", "type", "reason");
+
+    /**
+     * JSON property names that typically carry a human-readable error message in a 4xx/5xx body
+     * (e.g. {@code {"message":"Order not found"}}, {@code {"error_description":"..."}}).
+     */
+    private static final Set<String> ERROR_MESSAGE_KEYS = Set.of(
+            "message", "detail", "details", "description", "error_description", "error_message", "title");
+
+    /**
+     * Renders a negative-case (4xx/5xx) error-shape assertion template: the HTTP status is already
+     * asserted via {@code setTargetStatusCode(...)}, so this pins the stable error <em>code</em> and
+     * <em>message</em> fields (recognized by well-known property names) first, then any remaining
+     * stable fields. Volatile/correlated/sensitive leaves are skipped exactly as in the happy path,
+     * so timestamps and trace IDs never flake the assertion (issue #3530 negative-case templates).
+     */
+    private static void renderErrorShapeAssertions(
+            StringBuilder source, String apiField, ApiTransaction transaction, List<ResponseLeaf> leaves) {
+        line(source, "        // Negative-case error shape (HTTP " + transaction.statusCode()
+                + "): the status code is asserted above; pin the stable error code and message");
+        line(source, "        // fields, skipping volatile diagnostics (timestamps, trace IDs) so the test documents the error contract.");
+        List<ResponseLeaf> codeLeaves = new ArrayList<>();
+        List<ResponseLeaf> messageLeaves = new ArrayList<>();
+        List<ResponseLeaf> otherStable = new ArrayList<>();
+        for (ResponseLeaf leaf : leaves) {
+            if (leaf.classification() != LeafClassification.STABLE || leaf.value().isBlank()) {
+                continue;
+            }
+            String key = leaf.key().toLowerCase(Locale.ROOT);
+            if (ERROR_CODE_KEYS.contains(key)) {
+                codeLeaves.add(leaf);
+            } else if (ERROR_MESSAGE_KEYS.contains(key)) {
+                messageLeaves.add(leaf);
+            } else {
+                otherStable.add(leaf);
+            }
+        }
+        // Contract-relevant fields first (code, then message), then any other stable field.
+        for (ResponseLeaf leaf : codeLeaves) {
+            pinStableLeaf(source, apiField, leaf);
+        }
+        for (ResponseLeaf leaf : messageLeaves) {
+            pinStableLeaf(source, apiField, leaf);
+        }
+        for (ResponseLeaf leaf : otherStable) {
+            pinStableLeaf(source, apiField, leaf);
+        }
+        if (codeLeaves.isEmpty() && messageLeaves.isEmpty() && otherStable.isEmpty()) {
+            line(source, "        // No stable error fields were recorded; the HTTP "
+                    + transaction.statusCode() + " status assertion above stands alone.");
+        }
+    }
+
+    private static void pinStableLeaf(StringBuilder source, String apiField, ResponseLeaf leaf) {
+        line(source, "        SHAFT.Validations.assertThat()");
+        line(source, "                .object(" + apiField + ".getResponseJSONValue(\""
+                + escape(leaf.jsonPath()) + "\"))");
+        line(source, "                .isEqualTo(\"" + escape(leaf.value()) + "\")");
+        line(source, "                .perform();");
     }
 
     private static void renderHeaderAssertions(StringBuilder source, String apiField, ApiTransaction transaction) {

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiTestRenderer.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiTestRenderer.java
@@ -38,6 +38,20 @@ public final class ApiTestRenderer {
     private static final String VOLATILE_PLACEHOLDER = "[NORMALIZED]";
 
     /**
+     * JSON property names that typically carry a machine-readable error code in a 4xx/5xx body
+     * (e.g. {@code {"code":"NOT_FOUND"}}, {@code {"error":"invalid_grant"}}).
+     */
+    private static final Set<String> ERROR_CODE_KEYS = Set.of(
+            "code", "error", "errorcode", "error_code", "status", "type", "reason");
+
+    /**
+     * JSON property names that typically carry a human-readable error message in a 4xx/5xx body
+     * (e.g. {@code {"message":"Order not found"}}, {@code {"error_description":"..."}}).
+     */
+    private static final Set<String> ERROR_MESSAGE_KEYS = Set.of(
+            "message", "detail", "details", "description", "error_description", "error_message", "title");
+
+    /**
      * Request headers that are mechanical/transport-level and never meaningfully replayed:
      * content negotiation and framing are already handled by {@code setContentType}/
      * {@code setRequestBody}, and connection/host/user-agent/cookie headers describe the
@@ -426,20 +440,6 @@ public final class ApiTestRenderer {
     }
 
     /**
-     * JSON property names that typically carry a machine-readable error code in a 4xx/5xx body
-     * (e.g. {@code {"code":"NOT_FOUND"}}, {@code {"error":"invalid_grant"}}).
-     */
-    private static final Set<String> ERROR_CODE_KEYS = Set.of(
-            "code", "error", "errorcode", "error_code", "status", "type", "reason");
-
-    /**
-     * JSON property names that typically carry a human-readable error message in a 4xx/5xx body
-     * (e.g. {@code {"message":"Order not found"}}, {@code {"error_description":"..."}}).
-     */
-    private static final Set<String> ERROR_MESSAGE_KEYS = Set.of(
-            "message", "detail", "details", "description", "error_description", "error_message", "title");
-
-    /**
      * Renders a negative-case (4xx/5xx) error-shape assertion template: the HTTP status is already
      * asserted via {@code setTargetStatusCode(...)}, so this pins the stable error <em>code</em> and
      * <em>message</em> fields (recognized by well-known property names) first, then any remaining
@@ -451,6 +451,22 @@ public final class ApiTestRenderer {
         line(source, "        // Negative-case error shape (HTTP " + transaction.statusCode()
                 + "): the status code is asserted above; pin the stable error code and message");
         line(source, "        // fields, skipping volatile diagnostics (timestamps, trace IDs) so the test documents the error contract.");
+        List<ResponseLeaf> ordered = orderedErrorLeaves(leaves);
+        for (ResponseLeaf leaf : ordered) {
+            pinStableLeaf(source, apiField, leaf);
+        }
+        if (ordered.isEmpty()) {
+            line(source, "        // No stable error fields were recorded; the HTTP "
+                    + transaction.statusCode() + " status assertion above stands alone.");
+        }
+    }
+
+    /**
+     * Orders an error response's stable leaves so the contract-relevant fields lead: recognized
+     * error <em>code</em> fields first, then <em>message</em> fields, then any remaining stable
+     * field. Volatile/correlated/sensitive and blank leaves are dropped.
+     */
+    private static List<ResponseLeaf> orderedErrorLeaves(List<ResponseLeaf> leaves) {
         List<ResponseLeaf> codeLeaves = new ArrayList<>();
         List<ResponseLeaf> messageLeaves = new ArrayList<>();
         List<ResponseLeaf> otherStable = new ArrayList<>();
@@ -467,20 +483,10 @@ public final class ApiTestRenderer {
                 otherStable.add(leaf);
             }
         }
-        // Contract-relevant fields first (code, then message), then any other stable field.
-        for (ResponseLeaf leaf : codeLeaves) {
-            pinStableLeaf(source, apiField, leaf);
-        }
-        for (ResponseLeaf leaf : messageLeaves) {
-            pinStableLeaf(source, apiField, leaf);
-        }
-        for (ResponseLeaf leaf : otherStable) {
-            pinStableLeaf(source, apiField, leaf);
-        }
-        if (codeLeaves.isEmpty() && messageLeaves.isEmpty() && otherStable.isEmpty()) {
-            line(source, "        // No stable error fields were recorded; the HTTP "
-                    + transaction.statusCode() + " status assertion above stands alone.");
-        }
+        List<ResponseLeaf> ordered = new ArrayList<>(codeLeaves);
+        ordered.addAll(messageLeaves);
+        ordered.addAll(otherStable);
+        return ordered;
     }
 
     private static void pinStableLeaf(StringBuilder source, String apiField, ResponseLeaf leaf) {

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/api/ApiTestRendererTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/api/ApiTestRendererTest.java
@@ -249,6 +249,53 @@ class ApiTestRendererTest {
                 "BUSINESS depth should not need test-data artifacts");
     }
 
+    @Test
+    void businessDepthErrorResponseRendersErrorShapeTemplatePinningCodeThenMessage() throws Exception {
+        // A 4xx negative case: code + message are the stable error contract; traceId is volatile.
+        ApiTransaction notFound = transaction("tx-1", "GET", "https://api.example.test/orders/42",
+                Map.of(), "", 404, Map.of(),
+                "{\"message\":\"Order not found\",\"code\":\"NOT_FOUND\",\"traceId\":\"" + CREATED_ID + "\"}");
+
+        RenderedApiTest rendered = ApiTestRenderer.render(
+                "tests.generated", "RecordedApiTest_Error", List.of(notFound),
+                ApiCodegenStyle.SCENARIO, ApiValidationDepth.BUSINESS);
+        String source = rendered.source();
+
+        assertCompiles(source, "RecordedApiTest_Error");
+        // Negative-case template is labelled and reports the HTTP status.
+        assertTrue(source.contains("Negative-case error shape (HTTP 404)"), source);
+        // Both the error code and message are pinned by JSON path.
+        assertTrue(source.contains(".object(api.getResponseJSONValue(\"$.code\"))"), source);
+        assertTrue(source.contains(".isEqualTo(\"NOT_FOUND\")"), source);
+        assertTrue(source.contains(".object(api.getResponseJSONValue(\"$.message\"))"), source);
+        assertTrue(source.contains(".isEqualTo(\"Order not found\")"), source);
+        // Contract-relevant fields lead: the code assertion is rendered before the message one,
+        // regardless of their order in the recorded body.
+        assertTrue(source.indexOf("$.code") < source.indexOf("$.message"),
+                "Error code must be pinned before the message, got:\n" + source);
+        // The volatile traceId is never pinned as a business value.
+        assertTrue(!source.contains(CREATED_ID),
+                "The volatile traceId must not be pinned, got:\n" + source);
+    }
+
+    @Test
+    void businessDepthErrorResponseWithOnlyVolatileFieldsFallsBackToStatusOnlyComment() throws Exception {
+        // A 5xx whose body carries no stable field -- the status assertion must stand alone.
+        ApiTransaction serverError = transaction("tx-1", "GET", "https://api.example.test/orders/42",
+                Map.of(), "", 500, Map.of(), "{\"traceId\":\"" + CREATED_ID + "\"}");
+
+        RenderedApiTest rendered = ApiTestRenderer.render(
+                "tests.generated", "RecordedApiTest_ServerError", List.of(serverError),
+                ApiCodegenStyle.SCENARIO, ApiValidationDepth.BUSINESS);
+        String source = rendered.source();
+
+        assertCompiles(source, "RecordedApiTest_ServerError");
+        assertTrue(source.contains("Negative-case error shape (HTTP 500)"), source);
+        assertTrue(source.contains("status assertion above stands alone"), source);
+        assertTrue(!source.contains(CREATED_ID),
+                "The volatile traceId must not be pinned, got:\n" + source);
+    }
+
     private void assertCompiles(String source, String className) throws Exception {
         Path moduleDir = Files.createDirectories(tempDir.resolve(className));
         Path sourceFile = moduleDir.resolve(className + ".java");


### PR DESCRIPTION
## What

Advances issue #3530 **Negative-case assertions**, first checkbox: *"4xx/5xx error-shape assertion templates (pinned error code + message fields) alongside the happy-path BUSINESS depth."*

The recorder's `BUSINESS` validation depth pinned the same stable-field set for every response, happy-path or error. For a **4xx/5xx** transaction it now renders a dedicated **error-shape template**:

- The HTTP status is already asserted via `setTargetStatusCode(...)`.
- The stable error **code** and **message** fields are pinned *first*, recognized by well-known JSON property names (`code`/`error`/`errorCode`/`status`/`type`/`reason` for the code; `message`/`detail`/`description`/`error_description`/`title` for the message), then any remaining stable fields.
- Volatile/correlated/sensitive leaves are skipped exactly as on the happy path, so error `timestamp`/`traceId` diagnostics never flake the assertion.
- When an error body carries no stable field, a comment records that the status assertion stands alone (rather than emitting nothing).

The happy-path (2xx) BUSINESS rendering is unchanged; the shared per-leaf pinning was extracted into `pinStableLeaf(...)`.

## Tests

`ApiTestRendererTest` — **16/16 green** (JDK 25 headless; generated source compiled against the real facade):
- `businessDepthErrorResponseRendersErrorShapeTemplatePinningCodeThenMessage` — 404 with `code`+`message`+volatile `traceId`: asserts the labelled template, **code-before-message** ordering (independent of recorded order), and that the volatile id is never pinned.
- `businessDepthErrorResponseWithOnlyVolatileFieldsFallsBackToStatusOnlyComment` — 500 with only a volatile field: asserts the status-only fallback comment.

Part of #3530 (does not close it — A2 pure-API capture, A3's remaining body/auth items, and the volatile-field registry / "pin this path" panel control remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)