### PR TITLE
feat: content-type-aware request body rendering (#3530 A3)

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiTestRenderer.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiTestRenderer.java
@@ -6,6 +6,8 @@ import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.ObjectNode;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -392,12 +394,140 @@ public final class ApiTestRenderer {
         }
     }
 
+    /**
+     * Renders the request body with content-type fidelity (issue #3530 A3). The recorder captures
+     * the {@code Content-Type} request header but drops it from the generated {@code addHeader}
+     * calls (it is a mechanical/transport header), which previously made every replay default to
+     * JSON. This detects the captured content type and renders each family faithfully:
+     * <ul>
+     *   <li>{@code application/x-www-form-urlencoded} &rarr; parsed into a {@code setParameters(...,
+     *       FORM)} map (unless a correlated value flows through the body, in which case the raw
+     *       interpolated body is preserved so chaining still works);</li>
+     *   <li>{@code multipart/form-data} &rarr; content type preserved plus a note to wire file
+     *       parts, since binary parts cannot be reconstructed from a captured string;</li>
+     *   <li>GraphQL (a {@code graphql} content type, or a JSON body with a top-level {@code query})
+     *       &rarr; a pointer to {@code sendGraphQlRequest} plus the working JSON body;</li>
+     *   <li>any other non-JSON content type &rarr; preserved via {@code setContentType} before the
+     *       body;</li>
+     *   <li>JSON / no content type &rarr; the existing {@code setRequestBody} default.</li>
+     * </ul>
+     */
     private static void renderRequestBody(
             StringBuilder source, ApiTransaction transaction, Map<String, String> valueToVariable) {
-        if (transaction.requestBody().isBlank()) {
+        String body = transaction.requestBody();
+        if (body.isBlank()) {
             return;
         }
-        line(source, "                .setRequestBody(" + interpolate(transaction.requestBody(), valueToVariable) + ")");
+        String rawContentType = requestHeaderValue(transaction, "content-type");
+        String contentType = rawContentType == null ? "" : rawContentType.toLowerCase(Locale.ROOT);
+
+        if (contentType.contains("x-www-form-urlencoded") && !bodyCarriesCorrelation(body, valueToVariable)) {
+            Map<String, String> formParameters = parseFormUrlEncoded(body);
+            if (!formParameters.isEmpty()) {
+                renderFormParameters(source, formParameters);
+                return;
+            }
+        }
+        if (contentType.contains("multipart/form-data")) {
+            line(source, "                // Multipart body captured as raw text; add file parts with"
+                    + " setParameters(..., RestActions.ParametersType.MULTIPART) if this endpoint uploads files.");
+        } else if (isGraphQlRequest(contentType, body)) {
+            line(source, "                // GraphQL request; SHAFT.API.sendGraphQlRequest(service, query[, variables])"
+                    + " is the idiomatic alternative to this raw body.");
+        }
+        if (shouldPreserveContentType(contentType)) {
+            line(source, "                .setContentType(\"" + escape(rawContentType) + "\")");
+        }
+        line(source, "                .setRequestBody(" + interpolate(body, valueToVariable) + ")");
+    }
+
+    /**
+     * Returns the raw value of the first request header matching {@code name} (case-insensitive),
+     * or {@code null} when absent.
+     */
+    private static String requestHeaderValue(ApiTransaction transaction, String name) {
+        for (Map.Entry<String, String> header : transaction.requestHeaders().entrySet()) {
+            if (header.getKey().equalsIgnoreCase(name)) {
+                return header.getValue();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * True when a correlated value flows through this body, so switching to {@code setParameters}
+     * (which cannot interpolate) would drop the chaining -- the raw interpolated body is kept instead.
+     */
+    private static boolean bodyCarriesCorrelation(String body, Map<String, String> valueToVariable) {
+        for (String capturedValue : valueToVariable.keySet()) {
+            if (!capturedValue.isEmpty() && body.contains(capturedValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * A content type worth pinning on the generated request: present and not JSON (SHAFT already
+     * defaults an unset content type to JSON, so re-stating it would be noise).
+     */
+    private static boolean shouldPreserveContentType(String contentType) {
+        return !contentType.isBlank() && !contentType.contains("application/json");
+    }
+
+    private static boolean isGraphQlRequest(String contentType, String body) {
+        if (contentType.contains("graphql")) {
+            return true;
+        }
+        String trimmed = body.trim();
+        return contentType.contains("json") && trimmed.startsWith("{") && trimmed.contains("\"query\"");
+    }
+
+    /**
+     * Parses an {@code a=1&b=2} form body into an ordered, URL-decoded key/value map. Malformed
+     * pairs (empty key) are skipped; a value-less key maps to the empty string.
+     */
+    private static Map<String, String> parseFormUrlEncoded(String body) {
+        Map<String, String> parameters = new LinkedHashMap<>();
+        for (String pair : body.split("&")) {
+            if (pair.isEmpty()) {
+                continue;
+            }
+            int equals = pair.indexOf('=');
+            String rawKey = equals < 0 ? pair : pair.substring(0, equals);
+            String rawValue = equals < 0 ? "" : pair.substring(equals + 1);
+            String key = urlDecode(rawKey);
+            if (key.isEmpty()) {
+                continue;
+            }
+            parameters.put(key, urlDecode(rawValue));
+        }
+        return parameters;
+    }
+
+    private static String urlDecode(String value) {
+        try {
+            return URLDecoder.decode(value, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            // A malformed percent-escape is left as-is rather than dropping the value.
+            return value;
+        }
+    }
+
+    private static void renderFormParameters(StringBuilder source, Map<String, String> parameters) {
+        line(source, "                .setContentType(\"application/x-www-form-urlencoded\")");
+        StringBuilder entries = new StringBuilder();
+        boolean first = true;
+        for (Map.Entry<String, String> parameter : parameters.entrySet()) {
+            if (!first) {
+                entries.append(", ");
+            }
+            entries.append("java.util.Map.entry(\"").append(escape(parameter.getKey()))
+                    .append("\", \"").append(escape(parameter.getValue())).append("\")");
+            first = false;
+        }
+        line(source, "                .setParameters(java.util.Map.<String, Object>ofEntries(" + entries
+                + "), com.shaft.api.RestActions.ParametersType.FORM)");
     }
 
     private static void renderValidation(

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/api/ApiTestRendererTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/api/ApiTestRendererTest.java
@@ -296,6 +296,101 @@ class ApiTestRendererTest {
                 "The volatile traceId must not be pinned, got:\n" + source);
     }
 
+    @Test
+    void formUrlEncodedBodyRendersSetParametersFormNotRawBody() throws Exception {
+        ApiTransaction login = transaction("tx-1", "POST", "https://api.example.test/login",
+                Map.of("Content-Type", "application/x-www-form-urlencoded"),
+                "username=john&password=secret%21", 200, Map.of(), "{\"status\":\"ok\"}");
+
+        RenderedApiTest rendered = ApiTestRenderer.render(
+                "tests.generated", "RecordedApiTest_Form", List.of(login),
+                ApiCodegenStyle.SCENARIO, ApiValidationDepth.STATUS);
+        String source = rendered.source();
+
+        assertCompiles(source, "RecordedApiTest_Form");
+        assertTrue(source.contains(".setContentType(\"application/x-www-form-urlencoded\")"), source);
+        assertTrue(source.contains("com.shaft.api.RestActions.ParametersType.FORM"), source);
+        assertTrue(source.contains("java.util.Map.entry(\"username\", \"john\")"), source);
+        // The %21 escape is URL-decoded to '!' before being pinned as a parameter value.
+        assertTrue(source.contains("java.util.Map.entry(\"password\", \"secret!\")"), source);
+        // A form body must not be replayed as an opaque JSON-defaulted request body.
+        assertTrue(!source.contains(".setRequestBody(\"username=john"), source);
+    }
+
+    @Test
+    void formUrlEncodedBodyWithCorrelationKeepsInterpolatedRawBody() throws Exception {
+        // A correlated value flows into the form body, so setParameters (which cannot interpolate)
+        // must be skipped in favour of the interpolated raw body -- with the content type preserved.
+        ApiTransaction createOrder = transaction("tx-1", "POST", "https://api.example.test/orders",
+                Map.of(), "{\"item\":\"widget\"}", 201, Map.of(), "{\"id\":\"" + CREATED_ID + "\"}");
+        ApiTransaction confirm = transaction("tx-2", "POST", "https://api.example.test/orders/confirm",
+                Map.of("Content-Type", "application/x-www-form-urlencoded"),
+                "orderId=" + CREATED_ID + "&note=ok", 200, Map.of(), "{\"status\":\"confirmed\"}");
+
+        RenderedApiTest rendered = ApiTestRenderer.render(
+                "tests.generated", "RecordedApiTest_FormCorrelated", List.of(createOrder, confirm),
+                ApiCodegenStyle.SCENARIO, ApiValidationDepth.STATUS);
+        String source = rendered.source();
+
+        assertCompiles(source, "RecordedApiTest_FormCorrelated");
+        assertTrue(source.contains(".setContentType(\"application/x-www-form-urlencoded\")"), source);
+        assertTrue(source.contains(".setRequestBody("), source);
+        // The correlated id is chained through a variable, never emitted as a literal or a form param.
+        assertTrue(!source.contains("ParametersType.FORM"), source);
+        assertTrue(!source.contains(CREATED_ID), source);
+    }
+
+    @Test
+    void multipartBodyPreservesContentTypeAndFlagsFileParts() throws Exception {
+        ApiTransaction upload = transaction("tx-1", "POST", "https://api.example.test/upload",
+                Map.of("Content-Type", "multipart/form-data; boundary=X"),
+                "--X\r\nContent-Disposition: form-data; name=\"f\"\r\n\r\nhi\r\n--X--", 201, Map.of(), "{\"id\":\"1\"}");
+
+        RenderedApiTest rendered = ApiTestRenderer.render(
+                "tests.generated", "RecordedApiTest_Multipart", List.of(upload),
+                ApiCodegenStyle.SCENARIO, ApiValidationDepth.STATUS);
+        String source = rendered.source();
+
+        assertCompiles(source, "RecordedApiTest_Multipart");
+        assertTrue(source.contains("Multipart body captured as raw text"), source);
+        assertTrue(source.contains(".setContentType(\"multipart/form-data; boundary=X\")"), source);
+        assertTrue(source.contains(".setRequestBody("), source);
+    }
+
+    @Test
+    void graphQlJsonBodyIsFlaggedAndTheWorkingBodyPreserved() throws Exception {
+        ApiTransaction query = transaction("tx-1", "POST", "https://api.example.test/graphql",
+                Map.of("Content-Type", "application/json"),
+                "{\"query\":\"{ user { id } }\"}", 200, Map.of(), "{\"data\":{\"user\":{\"id\":\"1\"}}}");
+
+        RenderedApiTest rendered = ApiTestRenderer.render(
+                "tests.generated", "RecordedApiTest_GraphQl", List.of(query),
+                ApiCodegenStyle.SCENARIO, ApiValidationDepth.STATUS);
+        String source = rendered.source();
+
+        assertCompiles(source, "RecordedApiTest_GraphQl");
+        assertTrue(source.contains("sendGraphQlRequest"), source);
+        assertTrue(source.contains(".setRequestBody("), source);
+        // JSON is SHAFT's default, so the content type is not re-stated for a GraphQL JSON body.
+        assertTrue(!source.contains(".setContentType(\"application/json\")"), source);
+    }
+
+    @Test
+    void nonJsonBodyPreservesTheRecordedContentType() throws Exception {
+        ApiTransaction xml = transaction("tx-1", "POST", "https://api.example.test/soap",
+                Map.of("Content-Type", "application/xml"),
+                "<user><id>1</id></user>", 200, Map.of(), "<ok/>");
+
+        RenderedApiTest rendered = ApiTestRenderer.render(
+                "tests.generated", "RecordedApiTest_Xml", List.of(xml),
+                ApiCodegenStyle.SCENARIO, ApiValidationDepth.STATUS);
+        String source = rendered.source();
+
+        assertCompiles(source, "RecordedApiTest_Xml");
+        assertTrue(source.contains(".setContentType(\"application/xml\")"), source);
+        assertTrue(source.contains(".setRequestBody("), source);
+    }
+
     private void assertCompiles(String source, String className) throws Exception {
         Path moduleDir = Files.createDirectories(tempDir.resolve(className));
         Path sourceFile = moduleDir.resolve(className + ".java");


### PR DESCRIPTION
## What

Advances issue #3530 **A3 — RestAssured / SHAFT.API fidelity**: *"multipart / form-urlencoded / GraphQL request-body detection and rendering."*

The recorder captured each request's `Content-Type` but dropped it from the generated code (it's a mechanical/transport header, skipped from `addHeader`), so **every replay defaulted to JSON** and non-JSON bodies lost fidelity. `renderRequestBody` now detects the captured content type and renders each family faithfully:

| Captured body | Rendering |
|---|---|
| `application/x-www-form-urlencoded` | parsed (URL-decoded) into `setParameters(Map.of(...), RestActions.ParametersType.FORM)` — unless a **correlated** value flows through the body, in which case the interpolated raw body is kept so chaining still works, with the content type preserved |
| `multipart/form-data` | content type preserved + a note to wire file parts (binary parts can't be reconstructed from a captured string) |
| GraphQL (a `graphql` content type, or a JSON body with a top-level `query`) | a pointer to `sendGraphQlRequest` + the working JSON body |
| any other non-JSON (`application/xml`, …) | preserved via `setContentType` |
| JSON / no content type | the existing `setRequestBody` default (**unchanged**) |

Uses existing public SHAFT.API builders only (`setContentType`, `setParameters`); no new public API, so no docs change.

## Tests

`ApiTestRendererTest` — **21/21 green** (JDK 25 headless; every case compiles the generated source):
- `formUrlEncodedBodyRendersSetParametersFormNotRawBody` — form → `setParameters(FORM)`, `%21`→`!` decoded, not an opaque body.
- `formUrlEncodedBodyWithCorrelationKeepsInterpolatedRawBody` — correlated id in a form body → falls back to interpolated `setRequestBody` (no `FORM`, no literal id), content type preserved.
- `multipartBodyPreservesContentTypeAndFlagsFileParts` — content type + file-parts note.
- `graphQlJsonBodyIsFlaggedAndTheWorkingBodyPreserved` — `sendGraphQlRequest` pointer, body preserved, JSON content type not re-stated.
- `nonJsonBodyPreservesTheRecordedContentType` — XML content type preserved.

Part of #3530 (does not close it — A2 pure-API capture, A3's auth/redirect fidelity, and the volatile-field registry / panel control remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)