### PR TITLE
feat: replay recorded session cookie as an auth bootstrap (#3530 A3)

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiTestRenderer.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiTestRenderer.java
@@ -56,12 +56,14 @@ public final class ApiTestRenderer {
     /**
      * Request headers that are mechanical/transport-level and never meaningfully replayed:
      * content negotiation and framing are already handled by {@code setContentType}/
-     * {@code setRequestBody}, and connection/host/user-agent/cookie headers describe the
-     * recording browser session, not the API contract.
+     * {@code setRequestBody}, and connection/host/user-agent headers describe the recording
+     * browser session, not the API contract. The {@code Cookie} header is handled separately as an
+     * auth bootstrap (see {@link #renderRequestHeaders}), not skipped, so recorded session auth is
+     * preserved rather than silently dropped.
      */
     private static final Set<String> SKIPPED_REQUEST_HEADERS = Set.of(
             "content-length", "content-type", "host", "connection", "accept-encoding",
-            "user-agent", "cookie", "origin", "referer");
+            "user-agent", "origin", "referer");
 
     private ApiTestRenderer() {
     }
@@ -386,12 +388,34 @@ public final class ApiTestRenderer {
             StringBuilder source, ApiTransaction transaction, Map<String, String> valueToVariable) {
         for (Map.Entry<String, String> header : transaction.requestHeaders().entrySet()) {
             String name = header.getKey().toLowerCase(Locale.ROOT);
+            if (name.equals("cookie")) {
+                renderAuthCookie(source, header.getValue(), valueToVariable);
+                continue;
+            }
             if (SKIPPED_REQUEST_HEADERS.contains(name)) {
                 continue;
             }
             line(source, "                .addHeader(\"" + escape(header.getKey()) + "\", "
                     + headerOrInterpolatedValueExpression(header.getValue(), valueToVariable) + ")");
         }
+    }
+
+    /**
+     * Renders the recorded session {@code Cookie} header as an auth bootstrap (issue #3530 A3),
+     * rather than dropping it (which left the replay unauthenticated). A sensitive cookie is
+     * captured as a {@code secret-ref} token, so it is replayed from the environment via
+     * {@code requiredEnvironment(...)} and never written to source as a literal; a non-sensitive
+     * cookie is emitted directly (with correlation applied). Blank cookies carry nothing to
+     * bootstrap and are skipped.
+     */
+    private static void renderAuthCookie(
+            StringBuilder source, String cookieValue, Map<String, String> valueToVariable) {
+        if (cookieValue == null || cookieValue.isBlank()) {
+            return;
+        }
+        line(source, "                // Auth bootstrap: replay the recorded session cookie so the request is authenticated.");
+        line(source, "                .addHeader(\"Cookie\", "
+                + headerOrInterpolatedValueExpression(cookieValue, valueToVariable) + ")");
     }
 
     /**
@@ -832,7 +856,9 @@ public final class ApiTestRenderer {
         }
         for (Map.Entry<String, String> candidate : transactions.get(0).requestHeaders().entrySet()) {
             String name = candidate.getKey().toLowerCase(Locale.ROOT);
-            if (SKIPPED_REQUEST_HEADERS.contains(name)) {
+            if (SKIPPED_REQUEST_HEADERS.contains(name) || name.equals("cookie")) {
+                // The Cookie header is rendered per request as an auth bootstrap (renderAuthCookie),
+                // which owns its blank-skip and secret-ref handling, so it is never hoisted here.
                 continue;
             }
             boolean sharedByAll = transactions.stream()

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/api/ApiTestRendererTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/api/ApiTestRendererTest.java
@@ -104,6 +104,44 @@ class ApiTestRendererTest {
     }
 
     @Test
+    void recordedSessionCookieIsReplayedAsAnAuthBootstrapNeverDropped() throws Exception {
+        // Capture tokenizes the Cookie header as a secret-ref, so it must replay from the
+        // environment (auth bootstrap) rather than being silently dropped (#3530 A3).
+        ApiTransaction authenticated = transaction("tx-1", "GET", "https://api.example.test/me",
+                Map.of("Cookie", "secret-ref:COOKIE_ABC_DEF"), "", 200, Map.of(), "{\"name\":\"Ada\"}");
+
+        RenderedApiTest rendered = ApiTestRenderer.render(
+                "tests.generated", "RecordedApiTest_Cookie", List.of(authenticated),
+                ApiCodegenStyle.SCENARIO, ApiValidationDepth.STATUS);
+        String source = rendered.source();
+
+        assertCompiles(source, "RecordedApiTest_Cookie");
+        assertTrue(source.contains("Auth bootstrap"), source);
+        assertTrue(source.contains(".addHeader(\"Cookie\", requiredEnvironment(\"COOKIE_ABC_DEF\"))"), source);
+        // The raw secret-ref token must never appear literally.
+        assertTrue(!source.contains("secret-ref:"), source);
+        // The cookie is rendered once (per request), not also hoisted into the session setup.
+        assertEquals(1, source.split("\\.addHeader\\(\"Cookie\"", -1).length - 1, source);
+        String setup = source.substring(source.indexOf("setupApiSessions"), source.indexOf("recordedApiScenario"));
+        assertTrue(!setup.contains("Cookie"), setup);
+    }
+
+    @Test
+    void blankCookieHeaderCarriesNoAuthAndIsSkipped() throws Exception {
+        ApiTransaction noCookie = transaction("tx-1", "GET", "https://api.example.test/public",
+                Map.of("Cookie", ""), "", 200, Map.of(), "{\"ok\":true}");
+
+        RenderedApiTest rendered = ApiTestRenderer.render(
+                "tests.generated", "RecordedApiTest_BlankCookie", List.of(noCookie),
+                ApiCodegenStyle.SCENARIO, ApiValidationDepth.STATUS);
+        String source = rendered.source();
+
+        assertCompiles(source, "RecordedApiTest_BlankCookie");
+        assertTrue(!source.contains(".addHeader(\"Cookie\""), source);
+        assertTrue(!source.contains("Auth bootstrap"), source);
+    }
+
+    @Test
     void commonHeaderAcrossAllTransactionsIsHoistedToBeforeClass() throws Exception {
         Map<String, String> sharedHeader = Map.of("X-Api-Version", "2026-07");
         ApiTransaction first = transaction("tx-1", "GET", "https://api.example.test/a", sharedHeader, "", 200, Map.of(), "{}");


### PR DESCRIPTION
## What

Advances issue #3530 **A3 — RestAssured / SHAFT.API fidelity**: *"Cookie / auth bootstrap handling."*

The recorder dropped the captured `Cookie` request header (it was lumped into the skipped transport-header set), so a generated test replayed **unauthenticated** even though the recording carried a session cookie. The capture layer already tokenizes the `Cookie` value as a `secret-ref` (see `SecretHeaderReplacer`, which treats `Cookie`/`Set-Cookie`/`Authorization` as sensitive), so it can be replayed safely from the environment.

`renderRequestHeaders` now renders the `Cookie` header as an **auth bootstrap**:
- secret-ref cookie → `.addHeader("Cookie", requiredEnvironment("<ENV>"))` — replayed from the environment, never written as a literal;
- non-sensitive cookie → the correlated/literal value (same expression path as other headers);
- blank cookie → skipped (nothing to bootstrap).

Cookies are excluded from `@BeforeClass` common-header hoisting, so `renderAuthCookie` is the single owner of cookie rendering — no setup/per-request duplication, one blank-skip.

Uses the existing public `addHeader(...)` builder + the existing `requiredEnvironment` seam; no new public API, so no docs change.

## Tests

`ApiTestRendererTest` — **23/23 green** (JDK 25 headless; generated source compiles):
- `recordedSessionCookieIsReplayedAsAnAuthBootstrapNeverDropped` — secret-ref cookie → `requiredEnvironment` bootstrap, no literal secret, rendered exactly once and **not** hoisted into setup.
- `blankCookieHeaderCarriesNoAuthAndIsSkipped` — blank cookie → nothing emitted.
- Pre-existing sensitive-header and common-header-hoisting tests still pass.

Part of #3530 (does not close it — A2 pure-API capture, A3's redirect/base-path fidelity, and the volatile-field registry / panel control remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)