### PR TITLE
feat: redirect fidelity for SHAFT.API + capture codegen (#3530 A3)

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiTestRenderer.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiTestRenderer.java
@@ -319,6 +319,7 @@ public final class ApiTestRenderer {
                     + " (" + transaction.statusCode() + ")");
             String pathExpression = interpolate(relativePath(transaction), valueToVariable);
             line(source, "        " + apiField + "." + requestMethod + "(" + pathExpression + ")");
+            renderRedirectControl(source, transaction);
             renderRequestHeaders(source, transaction, valueToVariable);
             renderRequestBody(source, transaction, valueToVariable);
             line(source, "                .setTargetStatusCode(" + transaction.statusCode() + ")");
@@ -372,6 +373,7 @@ public final class ApiTestRenderer {
         Map<String, String> noCorrelation = Map.of();
         line(source, "        " + apiField + "." + requestMethod + "("
                 + interpolate(relativePath(transaction), noCorrelation) + ")");
+        renderRedirectControl(source, transaction);
         renderRequestHeaders(source, transaction, noCorrelation);
         renderRequestBody(source, transaction, noCorrelation);
         line(source, "                .setTargetStatusCode(" + transaction.statusCode() + ")");
@@ -397,6 +399,20 @@ public final class ApiTestRenderer {
             }
             line(source, "                .addHeader(\"" + escape(header.getKey()) + "\", "
                     + headerOrInterpolatedValueExpression(header.getValue(), valueToVariable) + ")");
+        }
+    }
+
+    /**
+     * Emits {@code setFollowRedirects(false)} for a recorded 3xx transaction so the generated test
+     * observes the redirect itself (issue #3530 A3 redirect fidelity). REST-Assured follows
+     * redirects by default, which would turn a recorded 302 into the final 200 and fail the status
+     * assertion; a non-redirect status leaves the default follow behaviour untouched.
+     */
+    private static void renderRedirectControl(StringBuilder source, ApiTransaction transaction) {
+        int status = transaction.statusCode();
+        if (status >= 300 && status < 400) {
+            line(source, "                // Recorded status is a redirect; do not follow it so the 3xx status can be asserted.");
+            line(source, "                .setFollowRedirects(false)");
         }
     }
 

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/api/ApiTestRendererTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/api/ApiTestRendererTest.java
@@ -429,6 +429,36 @@ class ApiTestRendererTest {
         assertTrue(source.contains(".setRequestBody("), source);
     }
 
+    @Test
+    void redirectTransactionDisablesRedirectFollowingSoTheStatusCanBeAsserted() throws Exception {
+        ApiTransaction redirect = transaction("tx-1", "GET", "https://api.example.test/old",
+                Map.of(), "", 302, Map.of("Location", "/new"), "");
+
+        RenderedApiTest rendered = ApiTestRenderer.render(
+                "tests.generated", "RecordedApiTest_Redirect", List.of(redirect),
+                ApiCodegenStyle.SCENARIO, ApiValidationDepth.STATUS);
+        String source = rendered.source();
+
+        assertCompiles(source, "RecordedApiTest_Redirect");
+        // The redirect must not be followed, so the recorded 302 status assertion holds.
+        assertTrue(source.contains(".setFollowRedirects(false)"), source);
+        assertTrue(source.contains(".setTargetStatusCode(302)"), source);
+    }
+
+    @Test
+    void nonRedirectTransactionKeepsDefaultRedirectFollowing() throws Exception {
+        ApiTransaction ok = transaction("tx-1", "GET", "https://api.example.test/ok",
+                Map.of(), "", 200, Map.of(), "{\"ok\":true}");
+
+        RenderedApiTest rendered = ApiTestRenderer.render(
+                "tests.generated", "RecordedApiTest_NoRedirect", List.of(ok),
+                ApiCodegenStyle.SCENARIO, ApiValidationDepth.STATUS);
+
+        assertCompiles(rendered.source(), "RecordedApiTest_NoRedirect");
+        // A 2xx must not touch the default follow behaviour.
+        assertTrue(!rendered.source().contains("setFollowRedirects"), rendered.source());
+    }
+
     private void assertCompiles(String source, String className) throws Exception {
         Path moduleDir = Files.createDirectories(tempDir.resolve(className));
         Path sourceFile = moduleDir.resolve(className + ".java");

--- a/shaft-engine/src/main/java/com/shaft/api/RequestBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/api/RequestBuilder.java
@@ -5,6 +5,7 @@ import com.shaft.cli.FileActions;
 import com.shaft.driver.SHAFT;
 import com.shaft.tools.io.ReportManager;
 import io.qameta.allure.Step;
+import io.restassured.config.RedirectConfig;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.config.SSLConfig;
 import io.restassured.http.ContentType;
@@ -298,6 +299,22 @@ public class RequestBuilder {
      */
     public RequestBuilder addCookies(Map<String, String> cookies) {
         this.sessionCookies.putAll(cookies);
+        return this;
+    }
+
+    /**
+     * Controls whether this request automatically follows HTTP redirects (3xx). By default
+     * REST-Assured follows them, so a request to a redirecting endpoint returns the final response.
+     * Pass {@code false} to receive the redirect response itself — required when asserting a 3xx
+     * status code or inspecting the {@code Location} header of the redirect.
+     *
+     * @param followRedirects {@code true} to follow redirects (the default), {@code false} to
+     *                        return the redirect response without following it
+     * @return a self-reference to be used to continue building your API request
+     */
+    public RequestBuilder setFollowRedirects(boolean followRedirects) {
+        this.sessionConfig = this.sessionConfig.redirect(
+                RedirectConfig.redirectConfig().followRedirects(followRedirects));
         return this;
     }
 

--- a/shaft-engine/src/test/java/com/shaft/api/RequestBuilderTests.java
+++ b/shaft-engine/src/test/java/com/shaft/api/RequestBuilderTests.java
@@ -74,6 +74,21 @@ public class RequestBuilderTests {
     }
 
     @Test
+    public void setFollowRedirectsShouldUpdateTheRedirectConfigAndReturnSelf() {
+        RequestBuilder builder = new RequestBuilder(createSessionMock(), "old", RestActions.RequestType.GET);
+
+        RequestBuilder returned = builder.setFollowRedirects(false);
+
+        Assert.assertSame(returned, builder, "setFollowRedirects should return the same builder for chaining");
+        Assert.assertFalse(builder.getSessionConfig().getRedirectConfig().followsRedirects(),
+                "Redirect following should be disabled after setFollowRedirects(false)");
+
+        builder.setFollowRedirects(true);
+        Assert.assertTrue(builder.getSessionConfig().getRedirectConfig().followsRedirects(),
+                "Redirect following should be re-enabled after setFollowRedirects(true)");
+    }
+
+    @Test
     public void setPathParametersShouldReplaceMapAndOrderedPlaceholders() {
         RequestBuilder fromMap = new RequestBuilder(createSessionMock(), "users/{id}/orders/{orderId}", RestActions.RequestType.GET)
                 .setPathParameters(Map.of("id", 7, "orderId", "A1"));


### PR DESCRIPTION
## What

Advances issue #3530 **A3 — RestAssured / SHAFT.API fidelity**: *redirect / base-path fidelity.*

SHAFT.API had **no way to stop following HTTP redirects** — RestAssured follows them by default, so a request to a 3xx endpoint always returned the *final* response. A recorded `302` could never be asserted, and the API recorder generated `setTargetStatusCode(302)` assertions that auto-following would break (the response would be the followed `200`).

- **`RequestBuilder.setFollowRedirects(boolean)`** applies a `RedirectConfig` to the session config (additive public API; default follow behaviour unchanged when unused). Independently useful for any hand-written test asserting a 3xx status or inspecting a `Location` header.
- **`ApiTestRenderer`** emits `.setFollowRedirects(false)` for a recorded **3xx** transaction (both `SCENARIO` and `PER_REQUEST` styles) so the status assertion holds; non-redirect transactions are untouched.

## Tests

- `RequestBuilderTests.setFollowRedirectsShouldUpdateTheRedirectConfigAndReturnSelf` — toggles the config both ways + asserts the fluent return. **shaft-engine 19/19**.
- `ApiTestRendererTest` — a 302 emits `setFollowRedirects(false)` + `setTargetStatusCode(302)`; a 200 emits neither. **25/25** (generated source compiles against the real `RequestBuilder`).

## Docs

`setFollowRedirects(...)` documented in the Request Builder reference — companion docs PR on `shafthq.github.io`.

Part of #3530 (does not close it — A2 pure-API capture and the volatile-field registry / panel control remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)