### PR TITLE
feat: per-test attribution in the checkpoint browser details (#3534)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/tools/internal/support/HTMLHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/internal/support/HTMLHelper.java
@@ -81,7 +81,7 @@ public enum HTMLHelper {
                     <div class="table-wrap" id="shaft-checkpoints">
                       <table>
                         <thead>
-                          <tr><th>ID</th><th>Type</th><th>Message</th><th>Status</th></tr>
+                          <tr><th>ID</th><th>Test</th><th>Type</th><th>Message</th><th>Status</th></tr>
                         </thead>
                         <tbody>${CHECKPOINTS_DETAILS}</tbody>
                       </table>
@@ -91,7 +91,7 @@ public enum HTMLHelper {
               </div>
             </body>
             </html>"""),
-    CHECKPOINT_DETAILS_FORMAT("<tr class=\"checkpoint-row\" data-status=\"%s\"><td>%d</td><td>%s</td><td>%s</td><td><span class=\"status-chip %s\">%s</span></td></tr>"),
+    CHECKPOINT_DETAILS_FORMAT("<tr class=\"checkpoint-row\" data-status=\"%s\" data-test=\"%s\"><td>%d</td><td class=\"checkpoint-test\">%s</td><td>%s</td><td>%s</td><td><span class=\"status-chip %s\">%s</span></td></tr>"),
 
     EXECUTION_SUMMARY("""
             <!DOCTYPE html>

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointCounter.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointCounter.java
@@ -121,17 +121,7 @@ public class CheckpointCounter {
         if (checkpoints.isEmpty()) {
             return;
         }
-        StringBuilder detailsBuilder = new StringBuilder();
-        for (CheckpointEntry entry : checkpoints) {
-            detailsBuilder.append(String.format(
-                    HTMLHelper.CHECKPOINT_DETAILS_FORMAT.getValue(),
-                    entry.status(),
-                    entry.id(),
-                    ReportHtmlTheme.escapeHtml(entry.type()),
-                    ReportHtmlTheme.escapeHtml(entry.message()),
-                    ReportHtmlTheme.statusClass(entry.status()),
-                    entry.status()));
-        }
+        String checkpointsDetails = checkpointDetailsHtml();
 
         long assertionsPassed = typeStatusCount(ASSERTION, PASS);
         long assertionsFailed = typeStatusCount(ASSERTION, FAIL);
@@ -153,9 +143,38 @@ public class CheckpointCounter {
                         .replace("${VERIFICATIONS_PASSED}", String.valueOf(verificationsPassed))
                         .replace("${VERIFICATIONS_FAILED}", String.valueOf(verificationsFailed))
                         .replace("${VERIFICATIONS_TOTAL}", String.valueOf(verificationsPassed + verificationsFailed))
-                        .replace("${CHECKPOINTS_DETAILS}", detailsBuilder));
+                        .replace("${CHECKPOINTS_DETAILS}", checkpointsDetails));
 
         attachCheckpointsJson();
+    }
+
+    /**
+     * Builds the {@code <tr>} rows for the checkpoint-browser details table, one per checkpoint.
+     * Each row carries its stable id and the owning test's {@code class#method} identity (a
+     * {@code data-test} attribute plus a visible "Test" cell), so the report attributes every
+     * checkpoint to its test and can later filter or "jump to test" by it; a checkpoint with no
+     * captured identity (suite-level) shows "(suite)". Package-visible so it can be unit-tested
+     * without publishing an Allure attachment (issue #3534 checkpoint browser).
+     *
+     * @return the concatenated table-row HTML
+     */
+    static String checkpointDetailsHtml() {
+        StringBuilder detailsBuilder = new StringBuilder();
+        for (CheckpointEntry entry : checkpoints) {
+            String testId = entry.testId();
+            String testDisplay = testId.isEmpty() ? "(suite)" : testId;
+            detailsBuilder.append(String.format(
+                    HTMLHelper.CHECKPOINT_DETAILS_FORMAT.getValue(),
+                    entry.status(),
+                    ReportHtmlTheme.escapeHtml(testId),
+                    entry.id(),
+                    ReportHtmlTheme.escapeHtml(testDisplay),
+                    ReportHtmlTheme.escapeHtml(entry.type()),
+                    ReportHtmlTheme.escapeHtml(entry.message()),
+                    ReportHtmlTheme.statusClass(entry.status()),
+                    entry.status()));
+        }
+        return detailsBuilder.toString();
     }
 
     private static final String ASSERTION = CheckpointType.ASSERTION.toString();

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/CheckpointCounterJsonUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/CheckpointCounterJsonUnitTest.java
@@ -109,6 +109,31 @@ public class CheckpointCounterJsonUnitTest {
         Assert.assertTrue(secondId > firstId, "ids must strictly increase: " + firstId + " -> " + secondId);
     }
 
+    @Test(description = "checkpoint-browser details HTML surfaces the owning test id per row (#3534 checkpoint browser)")
+    public void checkpointDetailsHtmlSurfacesOwningTestPerRow() {
+        String marker = "browser-attribution-marker";
+        String className = "com.example.CheckoutTest";
+        String methodName = "appliesDiscount";
+        ReportContext.start(new TestExecutionInfo(
+                className + "#" + methodName, className, methodName, methodName, null, null, null, false));
+        try {
+            CheckpointCounter.increment(CheckpointType.ASSERTION, marker, CheckpointStatus.PASS);
+        } finally {
+            ReportContext.clear();
+        }
+        // A suite-level checkpoint (no test identity) captured after clearing the context.
+        CheckpointCounter.increment(CheckpointType.VERIFICATION, "browser-suite-level-marker", CheckpointStatus.PASS);
+
+        String html = CheckpointCounter.checkpointDetailsHtml();
+
+        // The attributed checkpoint carries its test both as a filterable data-test attribute and a visible cell.
+        Assert.assertTrue(html.contains("data-test=\"" + className + "#" + methodName + "\""), html);
+        Assert.assertTrue(html.contains(">" + className + "#" + methodName + "<"), html);
+        // A checkpoint with no captured identity renders the suite-level placeholder, never a blank test.
+        Assert.assertTrue(html.contains("data-test=\"\""), html);
+        Assert.assertTrue(html.contains(">(suite)<"), html);
+    }
+
     @Test(description = "checkpoints are attributed to the owning test (class/method/testId) (#3532 D / #3534 P3)")
     public void checkpointsAttributeToOwningTest() {
         String marker = "attribution-marker";

--- a/shaft-engine/src/test/java/testPackage/unitTests/HTMLHelperUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/HTMLHelperUnitTest.java
@@ -54,11 +54,14 @@ public class HTMLHelperUnitTest {
         Assert.assertTrue(value.contains("fail-only"), "expected the fail-only CSS/class hook");
     }
 
-    @Test(description = "CHECKPOINT_DETAILS_FORMAT should carry a filterable data-status (#3523)")
+    @Test(description = "CHECKPOINT_DETAILS_FORMAT should carry a filterable data-status (#3523) and per-test data-test (#3534)")
     public void checkpointDetailsFormatShouldCarryDataStatus() {
         String value = HTMLHelper.CHECKPOINT_DETAILS_FORMAT.getValue();
         Assert.assertTrue(value.contains("data-status=\"%s\""), "expected a filterable data-status attribute");
         Assert.assertTrue(value.contains("checkpoint-row"), "expected the checkpoint-row class hook");
+        // Per-test attribution for the checkpoint browser: a filterable data-test attribute plus a Test cell.
+        Assert.assertTrue(value.contains("data-test=\"%s\""), "expected a filterable data-test attribute");
+        Assert.assertTrue(value.contains("checkpoint-test"), "expected the checkpoint-test cell hook");
     }
 
     @Test(description = "CHECKPOINT_DETAILS_FORMAT should have non-null, non-empty value")


### PR DESCRIPTION
## What

First slice of the **in-report checkpoint browser with "jump to test"** (#3534 P2/P3).

The per-test checkpoint attribution + stable IDs landed in #3562 — checkpoints now carry `testClass`/`testMethod`/`testId` — but the **SHAFT Overview** details table still listed them flatly, with no indication of which test each checkpoint belongs to. This surfaces that attribution:

- **`CHECKPOINT_DETAILS_FORMAT`** gains a filterable `data-test` attribute and a visible **Test** cell (`checkpoint-test`); the details table header gains a **Test** column.
- **`CheckpointCounter.checkpointDetailsHtml()`** is extracted from `attach()` (now package-visible and unit-testable) and renders each row with the owning test's `class#method`, or `(suite)` when a checkpoint has no captured identity.

This gives every checkpoint a **visible, filterable test attribution** — the data foundation a "jump to test" browser needs. Grouping, per-test filtering, and jump links follow in subsequent slices.

## Tests

- `CheckpointCounterJsonUnitTest.checkpointDetailsHtmlSurfacesOwningTestPerRow` — asserts the details HTML carries the owning test id as both a `data-test` attribute and a visible cell, and renders `(suite)` for an unattributed checkpoint.
- `HTMLHelperUnitTest` — now asserts the `data-test`/`checkpoint-test` hooks alongside the existing `data-status` filter.
- **29/29** across HTMLHelperUnitTest + CheckpointCounterJsonUnitTest + CheckpointAndReportingTest (JDK 25 headless).

Part of #3534 (does not close it — the Awesome npm widget, in-report trace launcher, single-data-model convergence, and the cross-module speedboard theme convergence remain; see the issue's status comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)