### PR TITLE
feat: filter-by-test control in the checkpoint browser (#3534)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/tools/internal/support/HTMLHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/internal/support/HTMLHelper.java
@@ -21,9 +21,11 @@ public enum HTMLHelper {
                   background: conic-gradient(var(--shaft-pass) ${CHECKPOINTS_PASSED_DEGREES}deg, var(--shaft-fail) 0);
                   box-shadow: inset 0 0 0 28px var(--shaft-surface);
                 }
-                .filter-bar { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; font-size: 0.9em; }
+                .filter-bar { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; font-size: 0.9em; flex-wrap: wrap; }
                 .filter-bar input { accent-color: var(--shaft-fail); }
+                .filter-bar select { font: inherit; padding: 2px 6px; border: 1px solid var(--shaft-border); border-radius: 4px; background: var(--shaft-surface); color: var(--shaft-text); max-width: 60ch; }
                 .table-wrap.fail-only tr.checkpoint-row[data-status="PASS"] { display: none; }
+                tr.checkpoint-row.test-hidden { display: none; }
               </style>
             </head>
             <body>
@@ -74,10 +76,18 @@ public enum HTMLHelper {
                   </section>
                   <section class="panel">
                     <h2>Details</h2>
-                    <label class="filter-bar">
-                      <input type="checkbox" id="shaft-fail-only" onchange="document.getElementById('shaft-checkpoints').classList.toggle('fail-only', this.checked)">
-                      Show failures only
-                    </label>
+                    <div class="filter-bar">
+                      <label>
+                        <input type="checkbox" id="shaft-fail-only" onchange="document.getElementById('shaft-checkpoints').classList.toggle('fail-only', this.checked)">
+                        Show failures only
+                      </label>
+                      <label>
+                        Filter by test:
+                        <select id="shaft-test-filter" onchange="shaftFilterCheckpointsByTest(this.value)">
+                          <option value="">All tests</option>${CHECKPOINTS_TEST_OPTIONS}
+                        </select>
+                      </label>
+                    </div>
                     <div class="table-wrap" id="shaft-checkpoints">
                       <table>
                         <thead>
@@ -86,6 +96,13 @@ public enum HTMLHelper {
                         <tbody>${CHECKPOINTS_DETAILS}</tbody>
                       </table>
                     </div>
+                    <script>
+                      function shaftFilterCheckpointsByTest(selectedTest) {
+                        document.querySelectorAll('#shaft-checkpoints tr.checkpoint-row').forEach(function (row) {
+                          row.classList.toggle('test-hidden', selectedTest !== '' && row.getAttribute('data-test') !== selectedTest);
+                        });
+                      }
+                    </script>
                   </section>
                 </main>
               </div>

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointCounter.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointCounter.java
@@ -143,6 +143,7 @@ public class CheckpointCounter {
                         .replace("${VERIFICATIONS_PASSED}", String.valueOf(verificationsPassed))
                         .replace("${VERIFICATIONS_FAILED}", String.valueOf(verificationsFailed))
                         .replace("${VERIFICATIONS_TOTAL}", String.valueOf(verificationsPassed + verificationsFailed))
+                        .replace("${CHECKPOINTS_TEST_OPTIONS}", checkpointTestFilterOptions())
                         .replace("${CHECKPOINTS_DETAILS}", checkpointsDetails));
 
         attachCheckpointsJson();
@@ -175,6 +176,30 @@ public class CheckpointCounter {
                     entry.status()));
         }
         return detailsBuilder.toString();
+    }
+
+    /**
+     * Builds the {@code <option>} list for the checkpoint-browser "filter by test" control: one
+     * option per distinct owning test id, in first-seen order, so a reader can narrow the details
+     * table to a single test. Suite-level checkpoints (no captured identity) have no option and are
+     * shown only under "All tests". Package-visible for unit testing (issue #3534 checkpoint browser).
+     *
+     * @return the concatenated {@code <option>} HTML (empty when no checkpoint carries a test id)
+     */
+    static String checkpointTestFilterOptions() {
+        java.util.LinkedHashSet<String> testIds = new java.util.LinkedHashSet<>();
+        for (CheckpointEntry entry : checkpoints) {
+            String testId = entry.testId();
+            if (!testId.isEmpty()) {
+                testIds.add(testId);
+            }
+        }
+        StringBuilder options = new StringBuilder();
+        for (String testId : testIds) {
+            String escaped = ReportHtmlTheme.escapeHtml(testId);
+            options.append("<option value=\"").append(escaped).append("\">").append(escaped).append("</option>");
+        }
+        return options.toString();
     }
 
     private static final String ASSERTION = CheckpointType.ASSERTION.toString();

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/CheckpointCounterJsonUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/CheckpointCounterJsonUnitTest.java
@@ -134,6 +134,44 @@ public class CheckpointCounterJsonUnitTest {
         Assert.assertTrue(html.contains(">(suite)<"), html);
     }
 
+    @Test(description = "checkpoint-browser test filter lists one distinct option per owning test, none for suite-level (#3534)")
+    public void checkpointTestFilterOptionsListDistinctTests() {
+        String classA = "com.example.AlphaTest";
+        String classB = "com.example.BetaTest";
+        // Two checkpoints for AlphaTest (must dedupe to a single option) and one for BetaTest.
+        ReportContext.start(new TestExecutionInfo(classA + "#one", classA, "one", "one", null, null, null, false));
+        try {
+            CheckpointCounter.increment(CheckpointType.ASSERTION, "opt-a1", CheckpointStatus.PASS);
+            CheckpointCounter.increment(CheckpointType.ASSERTION, "opt-a2", CheckpointStatus.PASS);
+        } finally {
+            ReportContext.clear();
+        }
+        ReportContext.start(new TestExecutionInfo(classB + "#two", classB, "two", "two", null, null, null, false));
+        try {
+            CheckpointCounter.increment(CheckpointType.VERIFICATION, "opt-b1", CheckpointStatus.FAIL);
+        } finally {
+            ReportContext.clear();
+        }
+        // A suite-level checkpoint must not produce an option.
+        CheckpointCounter.increment(CheckpointType.ASSERTION, "opt-suite", CheckpointStatus.PASS);
+
+        String options = CheckpointCounter.checkpointTestFilterOptions();
+
+        Assert.assertEquals(countOccurrences(options, "<option value=\"" + classA + "#one\">"), 1,
+                "AlphaTest must appear exactly once despite two checkpoints: " + options);
+        Assert.assertTrue(options.contains("<option value=\"" + classB + "#two\">"), options);
+        // Suite-level checkpoints have no test id, so no empty-value option is emitted here.
+        Assert.assertFalse(options.contains("value=\"\""), options);
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length())) {
+            count++;
+        }
+        return count;
+    }
+
     @Test(description = "checkpoints are attributed to the owning test (class/method/testId) (#3532 D / #3534 P3)")
     public void checkpointsAttributeToOwningTest() {
         String marker = "attribution-marker";

--- a/shaft-engine/src/test/java/testPackage/unitTests/HTMLHelperUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/HTMLHelperUnitTest.java
@@ -52,6 +52,12 @@ public class HTMLHelperUnitTest {
                 "expected per-type breakdown placeholders");
         Assert.assertTrue(value.contains("Show failures only"), "expected a fail-only filter control");
         Assert.assertTrue(value.contains("fail-only"), "expected the fail-only CSS/class hook");
+        // Checkpoint-browser per-test filter (#3534): a test dropdown, its options placeholder,
+        // the composable test-hidden CSS hook, and the filter function.
+        Assert.assertTrue(value.contains("Filter by test"), "expected a per-test filter control");
+        Assert.assertTrue(value.contains("${CHECKPOINTS_TEST_OPTIONS}"), "expected the test-options placeholder");
+        Assert.assertTrue(value.contains("test-hidden"), "expected the test-hidden CSS hook");
+        Assert.assertTrue(value.contains("shaftFilterCheckpointsByTest"), "expected the test-filter function");
     }
 
     @Test(description = "CHECKPOINT_DETAILS_FORMAT should carry a filterable data-status (#3523) and per-test data-test (#3534)")


### PR DESCRIPTION
## What

Second slice of the **in-report checkpoint browser** (#3534), building on the per-test attribution added in #3573.

The **SHAFT Overview** details table now has a **"Filter by test"** dropdown alongside the existing "Show failures only" toggle:

- **`CheckpointCounter.checkpointTestFilterOptions()`** emits one `<option>` per distinct owning test id (first-seen order, deduped); suite-level checkpoints produce no option and appear only under "All tests".
- The template renders the dropdown + a small `shaftFilterCheckpointsByTest()` function that toggles a **composable** `test-hidden` class on non-matching rows, so the test filter and the fail-only filter **stack** — a row is shown only when it passes both.

## Tests

- `CheckpointCounterJsonUnitTest.checkpointTestFilterOptionsListDistinctTests` — asserts one deduped option per test (two checkpoints for the same test → one option) and no option for suite-level checkpoints. **6/6**.
- `HTMLHelperUnitTest` — now asserts the dropdown, the `${CHECKPOINTS_TEST_OPTIONS}` placeholder, the `test-hidden` CSS hook, and the filter function. **16/16**.

Part of #3534. Next slices: jump-to-test links and per-test grouping. Remaining larger items (Awesome npm widget, in-report trace launcher, single-data-model convergence, cross-module speedboard theme) tracked on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)