### PR TITLE
feat: jump-to-test control in the checkpoint browser (#3534)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/tools/internal/support/HTMLHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/internal/support/HTMLHelper.java
@@ -26,6 +26,8 @@ public enum HTMLHelper {
                 .filter-bar select { font: inherit; padding: 2px 6px; border: 1px solid var(--shaft-border); border-radius: 4px; background: var(--shaft-surface); color: var(--shaft-text); max-width: 60ch; }
                 .table-wrap.fail-only tr.checkpoint-row[data-status="PASS"] { display: none; }
                 tr.checkpoint-row.test-hidden { display: none; }
+                .checkpoint-test-link { font: inherit; color: var(--shaft-primary); background: none; border: none; padding: 0; cursor: pointer; text-decoration: underline; text-underline-offset: 2px; }
+                .checkpoint-test-link:hover { text-decoration: none; }
               </style>
             </head>
             <body>
@@ -101,6 +103,14 @@ public enum HTMLHelper {
                         document.querySelectorAll('#shaft-checkpoints tr.checkpoint-row').forEach(function (row) {
                           row.classList.toggle('test-hidden', selectedTest !== '' && row.getAttribute('data-test') !== selectedTest);
                         });
+                      }
+                      function shaftFocusTestFromCell(cell) {
+                        var row = cell.closest('tr.checkpoint-row');
+                        if (!row) { return; }
+                        var testId = row.getAttribute('data-test');
+                        var selector = document.getElementById('shaft-test-filter');
+                        if (selector) { selector.value = testId; }
+                        shaftFilterCheckpointsByTest(testId);
                       }
                     </script>
                   </section>

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointCounter.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointCounter.java
@@ -163,19 +163,36 @@ public class CheckpointCounter {
         StringBuilder detailsBuilder = new StringBuilder();
         for (CheckpointEntry entry : checkpoints) {
             String testId = entry.testId();
-            String testDisplay = testId.isEmpty() ? "(suite)" : testId;
             detailsBuilder.append(String.format(
                     HTMLHelper.CHECKPOINT_DETAILS_FORMAT.getValue(),
                     entry.status(),
                     ReportHtmlTheme.escapeHtml(testId),
                     entry.id(),
-                    ReportHtmlTheme.escapeHtml(testDisplay),
+                    testCellHtml(testId),
                     ReportHtmlTheme.escapeHtml(entry.type()),
                     ReportHtmlTheme.escapeHtml(entry.message()),
                     ReportHtmlTheme.statusClass(entry.status()),
                     entry.status()));
         }
         return detailsBuilder.toString();
+    }
+
+    /**
+     * Builds the inner HTML for a checkpoint row's "Test" cell. A checkpoint with an owning test
+     * renders a "jump to test" control: a link-styled button that, on click, focuses the details
+     * table on that test (it reads the row's {@code data-test} in the browser, so no identifier is
+     * embedded in JavaScript and nothing needs script-escaping). A suite-level checkpoint (no
+     * captured identity) renders plain "(suite)" text (issue #3534 checkpoint browser).
+     *
+     * @param testId the owning test's {@code class#method} id, or {@code ""} for suite-level
+     * @return the escaped inner HTML for the Test cell
+     */
+    private static String testCellHtml(String testId) {
+        if (testId.isEmpty()) {
+            return "(suite)";
+        }
+        return "<button type=\"button\" class=\"checkpoint-test-link\" onclick=\"shaftFocusTestFromCell(this)\">"
+                + ReportHtmlTheme.escapeHtml(testId) + "</button>";
     }
 
     /**

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/CheckpointCounterJsonUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/CheckpointCounterJsonUnitTest.java
@@ -129,7 +129,9 @@ public class CheckpointCounterJsonUnitTest {
         // The attributed checkpoint carries its test both as a filterable data-test attribute and a visible cell.
         Assert.assertTrue(html.contains("data-test=\"" + className + "#" + methodName + "\""), html);
         Assert.assertTrue(html.contains(">" + className + "#" + methodName + "<"), html);
-        // A checkpoint with no captured identity renders the suite-level placeholder, never a blank test.
+        // The Test cell is a "jump to test" control (link-styled button that focuses the table on that test).
+        Assert.assertTrue(html.contains("class=\"checkpoint-test-link\" onclick=\"shaftFocusTestFromCell(this)\""), html);
+        // A checkpoint with no captured identity renders the suite-level placeholder, never a blank test or a jump link.
         Assert.assertTrue(html.contains("data-test=\"\""), html);
         Assert.assertTrue(html.contains(">(suite)<"), html);
     }

--- a/shaft-engine/src/test/java/testPackage/unitTests/HTMLHelperUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/HTMLHelperUnitTest.java
@@ -58,6 +58,9 @@ public class HTMLHelperUnitTest {
         Assert.assertTrue(value.contains("${CHECKPOINTS_TEST_OPTIONS}"), "expected the test-options placeholder");
         Assert.assertTrue(value.contains("test-hidden"), "expected the test-hidden CSS hook");
         Assert.assertTrue(value.contains("shaftFilterCheckpointsByTest"), "expected the test-filter function");
+        // Jump-to-test: clicking a Test cell focuses the table on that test.
+        Assert.assertTrue(value.contains("shaftFocusTestFromCell"), "expected the jump-to-test function");
+        Assert.assertTrue(value.contains("checkpoint-test-link"), "expected the jump-to-test link styling");
     }
 
     @Test(description = "CHECKPOINT_DETAILS_FORMAT should carry a filterable data-status (#3523) and per-test data-test (#3534)")


### PR DESCRIPTION
## What

Third slice of the **in-report checkpoint browser**, completing the **"jump to test"** affordance on top of the per-test attribution (#3573) and filter-by-test control (#3574).

Each checkpoint's **Test** cell is now a link-styled button; clicking it **focuses the details table on that test** (sets the filter dropdown + applies the test filter). The handler reads the row's `data-test` attribute in the browser, so **no test identifier is embedded in JavaScript** and nothing needs script-escaping — robust even for parameterized/data-driven test names. Suite-level checkpoints (no captured identity) stay plain `(suite)` text with no jump control.

**Honest scope note:** an Allure attachment has no access to a test's Allure-result UUID, so it cannot deep-link to the test's own Allure page. "Jump to test" is therefore realized as focusing the checkpoint list on the clicked test — the meaningful navigation available from within the report.

## Tests

- `CheckpointCounterJsonUnitTest` — asserts the Test cell renders the `checkpoint-test-link` jump button for an attributed checkpoint and plain `(suite)` otherwise. **6/6**.
- `HTMLHelperUnitTest` — asserts the `shaftFocusTestFromCell` function and the `checkpoint-test-link` styling. **16/16**.

This completes the core checkpoint-browser experience (attribution → filter → jump). Remaining #3534 items (Awesome npm widget, in-report trace launcher, single-data-model convergence, cross-module speedboard theme) are tracked on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)