### PR TITLE
feat: one-click in-report trace launcher (#3534)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureTraceReporter.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureTraceReporter.java
@@ -74,6 +74,12 @@ public final class FailureTraceReporter {
             String html = renderTraceHtml(json, omitted);
             byte[] zip = renderTraceZip(json, html, CURRENT_NETWORK_JSON.get(), screenshots);
             persistTraceArtifacts(info, zip, screenshots, attempt, omitted);
+            // In-report trace launcher (issue #3534 P2): the viewer HTML is fully self-contained --
+            // it embeds the trace JSON (with base64 screenshots and inline DOM snapshots) and reads
+            // everything from that embedded data, referencing no sibling files -- so attach it
+            // directly for a one-click, in-report open, alongside the zip kept for full-fidelity
+            // offline download.
+            attach("html", "shaft-trace.html", html.getBytes(StandardCharsets.UTF_8), traceViewerLabel(info, attempt));
             attach("zip", "shaft-trace.zip", zip, traceAttachmentLabel(info, attempt));
         } catch (RuntimeException e) {
             ReportManagerHelper.logDiscrete("Could not attach SHAFT trace report: " + e.getMessage(), Level.WARN);
@@ -226,7 +232,19 @@ public final class FailureTraceReporter {
     }
 
     private static String traceAttachmentLabel(TestExecutionInfo info, int attempt) {
-        String label = "SHAFT Trace Report - " + safeTestId(info);
+        return traceLabel("SHAFT Trace Report", info, attempt);
+    }
+
+    /**
+     * Label for the one-click, in-report trace viewer HTML attachment (issue #3534 P2), distinct
+     * from the "SHAFT Trace Report" zip label so the two are unambiguous in the report.
+     */
+    private static String traceViewerLabel(TestExecutionInfo info, int attempt) {
+        return traceLabel("SHAFT Trace Viewer", info, attempt);
+    }
+
+    private static String traceLabel(String prefix, TestExecutionInfo info, int attempt) {
+        String label = prefix + " - " + safeTestId(info);
         return attempt > 1 || (info != null && info.retried()) ? label + " (attempt " + attempt + ")" : label;
     }
 

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/FailureTraceReporterTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/FailureTraceReporterTest.java
@@ -63,12 +63,16 @@ public class FailureTraceReporterTest {
             FailureTraceReporter.attachOnFailure(failingInfo, "token=raw-secret", List.of());
 
             List<Attachment> added = attachments().subList(beforePassing, attachments().size());
-            Assert.assertEquals(added.size(), 1, "Only the self-contained trace archive should be attached.");
-            Assert.assertEquals(added.getFirst().getName(), "SHAFT Trace Report - id-failingScenario",
-                    "Attachment label carries the test id (and attempt suffix once retried) for retry-aware trace attribution.");
-            Assert.assertEquals(added.getFirst().getType(), "application/zip");
-            Assert.assertFalse(added.stream().anyMatch(attachment -> "text/html".equals(attachment.getType())),
-                    "No dangling HTML attachment outside the archive.");
+            // In-report trace launcher (#3534 P2): the one-click self-contained viewer HTML plus the
+            // full-fidelity zip download. Both carry the test id (and attempt suffix once retried).
+            Assert.assertEquals(added.size(), 2, "The trace viewer HTML and the trace archive should both be attached.");
+            Assert.assertTrue(added.stream().anyMatch(attachment -> "text/html".equals(attachment.getType())
+                            && "SHAFT Trace Viewer - id-failingScenario".equals(attachment.getName())),
+                    "Expected a one-click, in-report trace viewer HTML attachment.");
+            Assert.assertTrue(added.stream().anyMatch(attachment -> "application/zip".equals(attachment.getType())
+                            && "SHAFT Trace Report - id-failingScenario".equals(attachment.getName())),
+                    "Expected the full-fidelity trace archive attachment for offline download.");
+            // The JSON is embedded in the viewer HTML and the zip, never dangled as its own attachment.
             Assert.assertFalse(added.stream().anyMatch(attachment -> "application/json".equals(attachment.getType())));
             Assert.assertFalse(Files.exists(traceDirectory.resolve("SHAFT Trace Report.html")));
             Assert.assertFalse(Files.exists(traceDirectory.resolve("shaft-trace.json")));


### PR DESCRIPTION
## What

Advances #3534 **P2 — in-report trace launcher.**

The failure trace **viewer HTML** was only ever bundled *inside* `shaft-trace.zip`, so viewing a trace from the report meant downloading and extracting the archive first — exactly the gap the issue named: *"the viewer HTML lives inside each `shaft-trace.zip` … a working in-report launch needs on-demand extraction or a link to the zip."*

The viewer turns out to be **fully self-contained**: it embeds the trace JSON — with **base64 screenshots** and **inline DOM snapshots** — in a hidden `<pre id="trace-data">` and renders everything from that embedded data via `data:` URIs and iframe `srcdoc`, referencing no sibling files. So it can simply be **attached directly**.

`attachOnFailure` now attaches the viewer HTML (**"SHAFT Trace Viewer - &lt;id&gt;"**, `text/html`) for a **one-click, in-report open**, alongside the existing `shaft-trace.zip` (**"SHAFT Trace Report - &lt;id&gt;"**) kept for full-fidelity offline download.

**Design note:** this intentionally reverses the prior zip-only choice (and the test asserting "no dangling HTML attachment outside the archive"), which predated the launcher requirement. The zip and all persisted disk artifacts are unchanged; this only *adds* the viewer as a directly-openable attachment. Attachment size stays bounded by the existing screenshot-omission logic (large screenshots are already omitted from the inline JSON and kept in the zip).

## Tests

`FailureTraceReporterTest` (**27/27**, JDK 25 headless): the failure-mode case now asserts **both** attachments — the `text/html` viewer and the `application/zip` archive — each with its retry-aware label, and still no dangling JSON attachment.

Part of #3534 (remaining: Awesome npm widget, single-data-model convergence, cross-module speedboard theme).

🤖 Generated with [Claude Code](https://claude.com/claude-code)