### PR TITLE
feat: converge Doctor speedboard onto the shared SHAFT report theme (#3534)

### DIFF
--- a/shaft-doctor/src/main/java/com/shaft/doctor/shard/ShardMerger.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/shard/ShardMerger.java
@@ -1,6 +1,7 @@
 package com.shaft.doctor.shard;
 
 import com.shaft.doctor.model.ExecutionIntelligence;
+import com.shaft.tools.internal.support.ReportHtmlTheme;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
@@ -207,9 +208,16 @@ public final class ShardMerger {
         StringBuilder html = new StringBuilder();
         html.append("<!doctype html>\n<html lang=\"en\"><head><meta charset=\"utf-8\">")
                 .append("<title>SHAFT Merged Report Speedboard</title>")
-                .append("<style>body{font-family:sans-serif;margin:24px}table{border-collapse:collapse;width:100%}")
-                .append("th,td{border:1px solid #ccc;padding:6px 10px;text-align:left}th{background:#f4f4f4}")
-                .append(".flaky{background:#fff3cd}.failed{color:#a33}.passed{color:#292}</style></head><body>")
+                // Converge the Doctor speedboard onto the shared SHAFT report theme (issue #3534):
+                // ReportHtmlTheme.style() supplies the canonical, theme-aware palette, and the
+                // speedboard-specific layout below draws its colors from that palette (border,
+                // surface, pass/fail/warn) instead of the former hardcoded off-palette hexes.
+                .append("<style>").append(ReportHtmlTheme.style())
+                .append("body{margin:24px}table{border-collapse:collapse;width:100%;margin:12px 0}")
+                .append("th,td{border:1px solid var(--shaft-border);padding:6px 10px;text-align:left}")
+                .append("th{background:var(--shaft-surface)}")
+                .append("tr.flaky{background:color-mix(in srgb, var(--shaft-warn) 20%, transparent)}")
+                .append(".failed{color:var(--shaft-fail)}.passed{color:var(--shaft-pass)}</style></head><body>")
                 .append("<h1>SHAFT Merged Report Speedboard</h1>")
                 .append("<p>Shards merged: ").append(shardCount)
                 .append(" &middot; Total results: ").append(results.size())

--- a/shaft-doctor/src/test/java/com/shaft/doctor/shard/ShardMergerTest.java
+++ b/shaft-doctor/src/test/java/com/shaft/doctor/shard/ShardMergerTest.java
@@ -1,5 +1,6 @@
 package com.shaft.doctor.shard;
 
+import com.shaft.tools.internal.support.ReportHtmlTheme;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -62,6 +63,30 @@ class ShardMergerTest {
         int fastIndex = html.indexOf("com.example.Fast.test");
         assertTrue(slowIndex >= 0 && fastIndex >= 0 && slowIndex < fastIndex,
                 "The slower test must be listed before the faster one, got:\n" + html);
+    }
+
+    @Test
+    void speedboardUsesTheSharedShaftReportThemeNotOffPaletteHardcodedColors() throws Exception {
+        Path shard = writeShard("shard-1",
+                result("t1", "com.example.Flaky.test", "passed", 0, 100));
+        Path shard2 = writeShard("shard-2",
+                result("t2", "com.example.Flaky.test", "failed", 0, 120));
+
+        MergedReport report = ShardMerger.merge(List.of(shard, shard2), tempDir.resolve("merged"));
+        String html = Files.readString(report.speedboardHtmlPath(), StandardCharsets.UTF_8);
+
+        // Convergence (#3534 "cheap first convergence step"): the speedboard embeds the canonical,
+        // theme-aware SHAFT report stylesheet and draws its colors from the shared palette.
+        assertTrue(html.contains(ReportHtmlTheme.style()),
+                "Speedboard must embed the shared ReportHtmlTheme stylesheet.");
+        assertTrue(html.contains("var(--shaft-fail)") && html.contains("var(--shaft-pass)")
+                        && html.contains("var(--shaft-border)"),
+                "Speedboard colors must reference the shared palette variables.");
+        // Drift guard: the former off-palette hardcoded colors must not creep back in.
+        for (String offPalette : List.of("#fff3cd", "#a33", "#292", "#f4f4f4", "#ccc", "font-family:sans-serif")) {
+            assertFalse(html.contains(offPalette),
+                    "Off-palette token \"" + offPalette + "\" must not appear in the themed speedboard:\n" + html);
+        }
     }
 
     @Test


### PR DESCRIPTION
## What

The **"cheap first convergence step"** from #3534 P3 (standalone convergence).

`ShardMerger.writeSpeedboard()` rendered its HTML with hardcoded, **off-palette** CSS (`font-family:sans-serif`, `#ccc` borders, `#f4f4f4` headers, `#fff3cd`/`#a33`/`#292` status colors). It now embeds **`ReportHtmlTheme.style()`** — the canonical, theme-aware SHAFT report stylesheet — and draws the speedboard-specific layout colors from the shared palette (`--shaft-border`/`--shaft-surface`/`--shaft-warn`/`--shaft-fail`/`--shaft-pass`). The merged-report speedboard now matches the rest of the SHAFT reports and picks up light/dark theming for free.

## The "module boundary" was a myth

This item was previously assumed blocked by a module boundary (shaft-doctor mustn't depend on shaft-engine). In fact **shaft-doctor already depends on shaft-engine transitively** — `shaft-doctor → shaft-pilot-core → shaft-engine`, all compile scope, and `ShardMerger`'s neighbours already `import com.shaft.driver.SHAFT`. So `ReportHtmlTheme` (a self-contained `public` class) is directly usable — **no class move and no new dependency required.**

## Tests

A new `ShardMergerTest` drift-guard, `speedboardUsesTheSharedShaftReportThemeNotOffPaletteHardcodedColors`, asserts the speedboard embeds `ReportHtmlTheme.style()`, references the shared palette variables, and contains **none** of the former off-palette hexes (`#fff3cd`/`#a33`/`#292`/`#f4f4f4`/`#ccc`/`font-family:sans-serif`). **ShardMergerTest 10/10** (JDK 25 headless).

Part of #3534 (remaining: Awesome npm widget, single-data-model → Allure widget convergence, docs/screenshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)