### PR TITLE
chore: dedup CLAUDE.md — drop redundant Memory section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,3 @@
   minimal working change (YAGNI; user-level `ponytail` when installed).
 - Keep plans and final responses proportional to the task and stop when the
   requested behavior is verified.
-
-<!-- memory:start -->
-## Memory
-
-- Use `AGENTS.md` as the canonical Memory guidance for this repo.
-- CLI fallback: `memory load "<task>"`; save durable changes with `memory remember --stdin`.
-<!-- memory:end -->


### PR DESCRIPTION
## What

Removes the redundant `## Memory` block from `CLAUDE.md`. Its content is fully covered by the `AGENTS.md` that `CLAUDE.md` already `@imports`:

- *"Use AGENTS.md as the canonical Memory guidance"* — duplicates both the adapter's own first rule (*"Treat imported AGENTS.md as canonical; do not restate it"*) and AGENTS.md's **Memory & Learning Loop** section.
- The `memory load` / `memory remember` CLI fallback — already stated in AGENTS.md.

## Why

- **Removes a self-contradiction**: the adapter says *"do not restate AGENTS.md"*, then restated it.
- **Aligns the two host adapters**: the sibling Copilot adapter (`.github/copilot-instructions.md`) already carries **no** Memory section — CLAUDE.md was the outlier.
- **Drops orphan sentinels**: the `<!-- memory:start -->` / `<!-- memory:end -->` markers were added speculatively in #2923; no repo tooling or the guidance validator reads them, and no automated sync manages the block (verified via `git log -S` — every touch is a hand-authored guidance PR).

## Scope

This was the only wholly-removable duplicate in the guidance surface. `AGENTS.md`, `.github/copilot-instructions.md`, and the two `.github/instructions/*.instructions.md` files are per-host pointer/scope files with no ≥180-char cross-file duplication — the machine `duplicate_paragraph` check in `validate_agent_setup.py` is green, so gross duplication is already prevented by design. `AGENTS.md` sits at 6494/6528 B by design and was intentionally left untouched.

## Verification

`py -3 scripts/ci/validate_agent_setup.py` → **Agent setup is valid: 64887 guidance bytes, 56.74% reduction (floor 55%), 118 memory objects.**
`CLAUDE.md` now 640 B / 15 lines (caps: 1536 B / 40 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)