### PR TITLE
fix(test): correct CheckpointCounter reflection cast in Playwright E2E base (#3578 item 1)

### DIFF
--- a/shaft-engine/src/test/java/testPackage/playwright/PlaywrightActionsE2ETestBase.java
+++ b/shaft-engine/src/test/java/testPackage/playwright/PlaywrightActionsE2ETestBase.java
@@ -15,7 +15,6 @@ import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
 @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
@@ -132,7 +131,7 @@ public abstract class PlaywrightActionsE2ETestBase {
     }
 
     private int checkpointsSize() throws IllegalAccessException {
-        return ((ConcurrentHashMap<?, ?>) CHECKPOINTS_FIELD.get(null)).size();
+        return ((List<?>) CHECKPOINTS_FIELD.get(null)).size();
     }
 
     private long screenshotAttachments() throws IOException {


### PR DESCRIPTION
## What

`PlaywrightActionsE2ETestBase.checkpointsSize()` reflected the private `CheckpointCounter.checkpoints` field and cast it to `ConcurrentHashMap<?,?>`. That field is (and long has been) a `CopyOnWriteArrayList`, so the cast would throw `ClassCastException` the moment the line is reached under the Playwright E2E profile.

- Cast to `List<?>` instead — `CopyOnWriteArrayList` satisfies it and exposes `.size()`.
- Removed the now-unused `java.util.concurrent.ConcurrentHashMap` import.

## Why

Fixes **item 1** of #3578 (a fully-specified, pre-existing, E2E-gated bug). Item 2 of that issue (forked-JVM crash triage) is intermittent and non-blocking, so it remains tracked there — this PR does not close #3578.

## Verification

- `mvn -q -pl shaft-engine test-compile -DheadlessExecution=true -Dallure.automaticallyOpen=false` → `EXIT=0`, `PlaywrightActionsE2ETestBase.class` regenerated. Test-source-only change; scoped compile is the minimal correct check (running the forked E2E suite is gated behind the Playwright profile and is exactly the surface item 2 is about).

🤖 Generated with [Claude Code](https://claude.com/claude-code)