### PR TITLE
feat(mcp): expose pinnedJsonPaths on capture_api_generate (#3530)

### DIFF
--- a/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
@@ -413,6 +413,10 @@ public class CaptureService {
      * @param excludedTransactionIds recorded transaction IDs to omit from generation entirely
      *                               (drives a recorder transaction-table include/exclude selection);
      *                               empty includes every renderable transaction
+     * @param pinnedJsonPaths response JSON paths (e.g. {@code $.status}) to force-assert as business
+     *                        assertions at {@code BUSINESS} validation depth even when the leaf is
+     *                        classified volatile or correlated; a sensitive or blank-value leaf is
+     *                        never asserted regardless of pinning; empty pins nothing (the default)
      * @return generated artifacts, compile/replay result, and copy-paste code blocks
      */
     @Tool(name = "capture_api_generate",
@@ -427,7 +431,8 @@ public class CaptureService {
             boolean overwrite,
             boolean replay,
             String openApiSpecPath,
-            List<String> excludedTransactionIds) {
+            List<String> excludedTransactionIds,
+            List<String> pinnedJsonPaths) {
         Path output = outputDirectory == null || outputDirectory.isBlank()
                 ? workspacePolicy.output("generated-tests", "Capture generation output directory")
                 : workspacePolicy.output(outputDirectory, "Capture generation output directory");
@@ -449,7 +454,8 @@ public class CaptureService {
                 null,
                 false,
                 null,
-                excludedTransactionIds));
+                excludedTransactionIds,
+                pinnedJsonPaths == null ? List.of() : pinnedJsonPaths));
         boolean successful = result.report().status() == CaptureGenerationReport.Status.SUCCESS;
         List<McpCodeBlock> blocks = successful && result.sourcePath() != null
                 ? codeBlocks.fromGeneratedSource(result.sourcePath(), "api", result.report())

--- a/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceApiToolsTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceApiToolsTest.java
@@ -204,7 +204,7 @@ class CaptureServiceApiToolsTest {
 
             McpCaptureReplayResult result = service.generateApi(
                     "recordings/session-mcp.json", "generated", "tests.generated", "",
-                    "SCENARIO", "STATUS", true, false, "openapi.json", List.of());
+                    "SCENARIO", "STATUS", true, false, "openapi.json", List.of(), List.of());
 
             assertTrue(result.successful(), "Generation report: " + result.report());
             assertNotNull(result.report().openApiCoverage());
@@ -227,7 +227,7 @@ class CaptureServiceApiToolsTest {
 
             McpCaptureReplayResult result = service.generateApi(
                     "recordings/session-mcp.json", "generated", "tests.generated", "",
-                    "SCENARIO", "STATUS", true, false, "", List.of());
+                    "SCENARIO", "STATUS", true, false, "", List.of(), List.of());
 
             assertTrue(result.successful(), "Generation report: " + result.report());
             assertFalse(result.report().openApiCoverage().loadable());
@@ -249,12 +249,38 @@ class CaptureServiceApiToolsTest {
 
             McpCaptureReplayResult result = service.generateApi(
                     "recordings/session-mcp-two.json", "generated-excluded", "tests.generated", "",
-                    "SCENARIO", "STATUS", true, false, "", List.of("tx-2"));
+                    "SCENARIO", "STATUS", true, false, "", List.of("tx-2"), List.of());
 
             assertTrue(result.successful(), "Generation report: " + result.report());
             String source = Files.readString(result.sourcePath());
             assertTrue(source.contains("/orders"), "Included transaction missing from generated source: " + source);
             assertFalse(source.contains("/admin"), "Excluded transaction leaked into generated source: " + source);
+        } finally {
+            service.close();
+        }
+    }
+
+    @Test
+    void generateApiThreadsPinnedJsonPathsIntoBusinessDepthGenerationWithoutError() throws Exception {
+        // Issue #3530 negative-case: capture_api_generate now accepts pinnedJsonPaths so an agent can
+        // force-assert an otherwise-skipped response leaf at BUSINESS depth. The pin *semantics*
+        // (volatile/correlated pinned -> asserted; sensitive/blank never) are unit-tested in
+        // shaft-capture ApiTestRendererTest; here we prove the MCP tool threads the param end to end
+        // into real generation without error.
+        CaptureService service = new CaptureService(
+                new CaptureManager(),
+                McpWorkspacePolicy.of(temp),
+                new McpCaptureCodeBlockService());
+        try {
+            writeRecordedSessionWithTwoTransactions();
+
+            McpCaptureReplayResult result = service.generateApi(
+                    "recordings/session-mcp-two.json", "generated-pinned", "tests.generated", "",
+                    "SCENARIO", "BUSINESS", true, false, "", List.of(), List.of("$.id"));
+
+            assertTrue(result.successful(), "Generation report: " + result.report());
+            String source = Files.readString(result.sourcePath());
+            assertTrue(source.contains("/orders"), "Generated source missing recorded transaction: " + source);
         } finally {
             service.close();
         }


### PR DESCRIPTION
## What

Threads a **`pinnedJsonPaths`** parameter through the `capture_api_generate` MCP tool into `ApiCaptureGenerationRequest`, so agents/backend teams can force-assert an otherwise-skipped response leaf at `BUSINESS` validation depth.

Builds directly on the render-gate that landed in #3583: a `VOLATILE`/`CORRELATED` leaf is asserted only when its JSON path is pinned, while `SENSITIVE` and blank-value leaves are never asserted (no secret embedded in generated source).

## Why

#3583 shipped the pin render-gate but it was only reachable programmatically via the `ApiCaptureGenerationRequest` record. This makes #3530's pin capability **usable end to end by MCP agents**.

The `ApiRecordingSessionPanel` "pin this path" UI control + the volatile-field registry remain the productization follow-ups, so **#3530 stays open**.

## Notes
- Adding only a **parameter** leaves the tool name/description/count unchanged, so the generated catalog (`shaft-mcp-tools.md`, 165 tools) and manifest fixture need no edit — `ShaftMcpApplicationTests`' registered-tool-set assertion still passes, and `generate_shaft_skills_tool_catalog.py --check` is up to date.

## Verification (scoped `-pl shaft-mcp`, against #3583's shaft-capture)
- `test-compile` → EXIT 0.
- `CaptureServiceApiToolsTest` → **19/19** (1 new: pins a path through real BUSINESS-depth generation without error); `ShaftMcpApplicationTests` → **5/5**. 0 failures / 0 errors (surefire XML).

🤖 Generated with [Claude Code](https://claude.com/claude-code)